### PR TITLE
Release v0.11.x — Autonomous Jobs, Live Agent Streaming, Quick Templates

### DIFF
--- a/.changelog/v0.10.29.md
+++ b/.changelog/v0.10.29.md
@@ -1,4 +1,4 @@
-# Release v0.10.x - Changelog Documentation System
+# Release v0.10.29 - Changelog Documentation System
 
 Released: 2026-01-XX
 
@@ -13,7 +13,7 @@ This release introduces a structured changelog documentation system for creating
 - **Comprehensive README**: Created detailed documentation for changelog format and best practices
 - **GitHub Actions Integration**: Updated release workflow to automatically use changelog files with version substitution
 - **Fallback Support**: Maintains automatic commit-based changelogs when manual changelog is not provided
-- **Automatic File Rename**: Pattern files (e.g., `v0.10.x.md`) automatically renamed to versioned files (e.g., `v0.10.5.md`) on release, preserving git history
+- **Automatic File Rename**: Pattern files (e.g., `v0.10.29.md`) automatically renamed to versioned files (e.g., `v0.10.5.md`) on release, preserving git history
 
 ### Documentation Updates
 - **CLAUDE.md Updates**: Added detailed release changelog process instructions
@@ -557,4 +557,4 @@ npm run pm2:start
 
 ## 🔗 Full Changelog
 
-**Full Diff**: https://github.com/atomantic/PortOS/compare/v0.9.9...v0.10.x
+**Full Diff**: https://github.com/atomantic/PortOS/compare/v0.9.9...v0.10.29

--- a/.changelog/v0.10.29.md
+++ b/.changelog/v0.10.29.md
@@ -316,6 +316,11 @@ This release introduces a structured changelog documentation system for creating
 
 ## 🐛 Fixes
 
+### Default App Setup on Fresh Install
+- **Removed PortOS Autofixer as separate app**: The Autofixer is part of PortOS itself, not a standalone app - removed it from the sample apps.json
+- **PortOS self-registers on fresh install**: New installs now include PortOS as a default app with correct process definitions (server, UI, CoS, autofixer, browser)
+- **Dynamic repoPath resolution**: The setup script now replaces a `__PORTOS_ROOT__` placeholder with the actual install path so the PortOS app entry points to the real directory
+
 ### Media Page Debug Logs Cleanup
 - **Removed Debug Console Logs**: Cleaned up 10 `console.log` statements from `client/src/pages/Media.jsx` that were left over from AudioContext debugging - improves production code quality
 

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -70,6 +70,11 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - `client/src/components/brain/tabs/InboxTab.jsx` - Socket.IO listener for classification results, classifying section UI
 - `client/src/components/brain/constants.js` - Added `classifying` status color
 
+### Killed Tasks No Longer Requeue
+- **DevTools Kill Integration**: Killing a CoS agent via the DevTools process manager (`DELETE /api/agents/:pid`) now delegates to the CoS `killAgent()` function, which properly blocks the task instead of letting the close handler treat it as a retryable failure
+- **Immediate Task Blocking**: Both `terminateAgent()` and `killAgent()` in direct mode now immediately update the task to `blocked` with `user-terminated` category, matching the runner mode behavior. Previously, task blocking was deferred to the close handler, creating a window where server restarts could cause requeue
+- **Orphan Handler Guard**: `handleOrphanedTask()` now skips tasks already marked as `user-terminated`, preventing any residual requeue path
+
 ### Autofixer App Replaced with PortOS Default
 - Replaced the standalone Autofixer app with PortOS default app in sample data to avoid confusion
 

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -195,6 +195,11 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **Removed noise patterns**: Eliminated pattern extractors for "no issues found", "already well-optimized", conclusion sections, and positive assessments — these were generating the bulk of low-value 0% confidence approval requests
 - **Key test**: Every candidate memory now passes the question "Would a brand-new agent benefit from knowing this even with full code access?" — if it's about code, reject; if it's about the user, keep
 
+### Orphaned Agent Completion Warnings on Restart
+- **Eliminated false "unknown agent" warnings**: On app restart, the runner's orphan cleanup would emit completion events for dead agents, but the server's in-memory tracking map was already cleared — causing noisy `⚠️ Received completion for unknown agent` warnings for every finished agent
+- **Graceful state reconciliation**: `handleAgentCompletion()` now checks cos persistent state when an agent isn't in the in-memory map. If already completed by the server's own cleanup, it logs a quiet confirmation instead of a warning. If still marked as running, it properly completes the agent and updates its task.
+- **No more duplicate work**: The two parallel orphan cleanup paths (server at 2s, runner at 3s) now cooperate — whichever runs first handles the agent, and the second silently skips it
+
 ### Task Progress Bars Use P80 Estimates Instead of Average
 - **More accurate progress**: Task progress bars now use a P80 (80th percentile approximation) estimate instead of the simple average duration, preventing progress bars from hitting 100% when only ~50% through a task
 - **Variance tracking**: The learning system now tracks `maxDurationMs` per task type and computes `p80DurationMs` (avg + 60% of the gap to max) for more realistic progress estimates

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -142,6 +142,14 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - `client/src/components/cos/index.js` — Export JobsTab component
 - `client/src/pages/ChiefOfStaff.jsx` — Render Jobs tab
 
+### Completed Agents Search
+- **Search bar**: Added a search input to the Completed Agents section on the Agents tab, allowing quick filtering by task description, model, agent ID, or error message
+- **Full results when searching**: When a search query is active, all matching agents are shown (bypasses the default 15-item limit) so you can find any completed agent
+- **Match count**: Displays "X of Y agents match" when filtering is active
+
+**Files Modified**:
+- `client/src/components/cos/tabs/AgentsTab.jsx` — Added search state, filtered list with `useMemo`, search input UI
+
 ## 🔧 Improvements
 
 ### Live Output Streaming for Claude CLI Agents

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -1,0 +1,25 @@
+# Release v0.11.x - Changelog
+
+Released: YYYY-MM-DD
+
+## Overview
+
+This release focuses on security improvements and bug fixes for the AI runner system.
+
+## 🐛 Bug Fixes
+
+### CLI Runner Security & Reliability
+- **Security Warning Fix**: Resolved Node.js DEP0190 deprecation warning in CLI runner by removing unsafe `shell: true` option from child process spawning
+- **Improved Argument Handling**: CLI commands now use direct argument passing instead of shell interpretation, preventing potential security vulnerabilities from unescaped arguments
+- **Enhanced Logging**: Added detailed logging for CLI execution showing full command and prompt preview to aid debugging
+- **Context**: The `/devtools/runner` page was generating security warnings when executing Claude CLI commands. The fix removes shell interpretation which was unnecessary and insecure, while maintaining full functionality
+
+**Technical Details**:
+- Created override in `server/services/runner.js` for `executeCliRun()` function
+- Removed `shell: true` option from `spawn()` call (recommended by Node.js security guidelines)
+- Arguments are now properly passed as array without shell metacharacter interpretation
+- Added runtime patching in `server/index.js` to inject fixed implementation into AI toolkit
+
+**Files Modified**:
+- `server/services/runner.js` - New secure CLI execution implementation
+- `server/index.js` - Runtime patching to override toolkit's runner

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -154,6 +154,21 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 **Files Modified**:
 - `client/src/components/cos/tabs/AgentsTab.jsx` — Added search state, filtered list with `useMemo`, search input UI
 
+### Quick Task Templates
+- **One-click task creation**: Added a collapsible "Quick Templates" section above the task form with 8 built-in templates for common task patterns (fix mobile, add feature, fix bug, refactor, add tests, improve UX, add API, security fix)
+- **Save as template**: New "Save Template" button lets you save the current form as a reusable template for future tasks
+- **Usage tracking**: Templates show usage counts and are sorted by popularity so your most-used templates appear first
+- **Custom templates**: Create and delete your own templates; built-in templates cannot be deleted
+- **Template presets**: Each template populates description, context, and optionally provider/model/app settings
+
+**Files Added**:
+- `server/services/taskTemplates.js` — Template management with built-in templates, usage tracking, CRUD operations
+
+**Files Modified**:
+- `server/routes/cos.js` — Added `/api/cos/templates` REST endpoints
+- `client/src/services/api.js` — Added template API functions
+- `client/src/components/cos/tabs/TasksTab.jsx` — Template UI with apply/save/delete functionality
+
 ## 🔧 Improvements
 
 ### Live Output Streaming for Claude CLI Agents

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -9,10 +9,11 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 ## 🎉 Features
 
 ### Universal Model Refresh for AI Providers
-- **Model Refresh Button**: Added "Refresh Models" button to all AI providers on the `/devtools/providers` page
+- **Model Refresh Button**: Added "Refresh Models" button to AI providers on the `/devtools/providers` page
 - **Multi-Provider Support**: Refresh now works for both API and CLI providers including:
   - API providers: OpenAI, LM Studio, Ollama (with provider-specific endpoint detection)
-  - CLI providers: Claude/Anthropic (returns latest model list), Gemini (fetches from Google AI API)
+  - CLI providers: Claude/Anthropic (returns latest model list)
+- **Smart UI**: Button is hidden for providers that don't require model specification (e.g., Gemini CLI)
 - **User Feedback**: Toast notifications show success/failure messages with descriptive error handling
 - **Loading States**: Button shows "Refreshing..." state during model fetch operations
 - **Graceful Degradation**: Providers without refresh support show appropriate error messages

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -194,3 +194,10 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **Implementation detail filter**: Both LLM classifier and pattern-based fallback now reject file paths, CSS values, port numbers, architecture descriptions, status assessments, and other trivially-discoverable code facts
 - **Removed noise patterns**: Eliminated pattern extractors for "no issues found", "already well-optimized", conclusion sections, and positive assessments — these were generating the bulk of low-value 0% confidence approval requests
 - **Key test**: Every candidate memory now passes the question "Would a brand-new agent benefit from knowing this even with full code access?" — if it's about code, reject; if it's about the user, keep
+
+### Task Progress Bars Use P80 Estimates Instead of Average
+- **More accurate progress**: Task progress bars now use a P80 (80th percentile approximation) estimate instead of the simple average duration, preventing progress bars from hitting 100% when only ~50% through a task
+- **Variance tracking**: The learning system now tracks `maxDurationMs` per task type and computes `p80DurationMs` (avg + 60% of the gap to max) for more realistic progress estimates
+- **ETAs reflect variance**: Running agent ETAs and pending task time estimates are based on the P80 value, giving users a more honest picture of when tasks will complete
+- **Learning tab shows both**: The Duration Estimates table now displays both average and estimated (P80) columns so users can see the range
+- **Backward compatible**: Existing learning data without max/P80 fields gracefully falls back to using the average

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -109,6 +109,11 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **Category exhaustion UI**: EnrichTab now shows a "all questions answered" completion view when a category has no more questions, instead of silently falling back to category selection
 - **Deduplicated near-identical questions**: `values` and `non_negotiables` categories previously had nearly identical first questions; `values` now asks a distinct question about top three guiding values
 
+### Quick Enrich Shows "Unable to Load Question" for Exhausted Categories
+- **Auto-advance to next gap**: When a category's questions are exhausted (all predefined, scale, and fallback answered) and AI generation isn't available, the NextActionBanner now automatically advances to the next gap category instead of showing "Unable to load question"
+- **Graceful exhaustion UI**: If all gap categories are exhausted, the banner shows an "Enrichment questions complete" view with links to run an interview or behavioral tests
+- **Stable gap tracking**: Uses category-based dependency tracking instead of array references to prevent unnecessary resets during parent re-renders
+
 ### Quick Enrich Skip Returns Same Question
 - **Skip now advances to a different question**: Clicking "Skip" on Quick Enrich prompts (both in the overview banner and the full EnrichTab) previously returned the exact same question, because question selection was deterministic based on `questionsAnswered` count which skip didn't increment
 - **Client tracks skipped indices**: Both NextActionBanner and EnrichTab now maintain a `skippedIndices` list for the current session, passing it to the server so it can serve the next non-skipped question

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -211,3 +211,10 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **ETAs reflect variance**: Running agent ETAs and pending task time estimates are based on the P80 value, giving users a more honest picture of when tasks will complete
 - **Learning tab shows both**: The Duration Estimates table now displays both average and estimated (P80) columns so users can see the range
 - **Backward compatible**: Existing learning data without max/P80 fields gracefully falls back to using the average
+
+### Architecture Documentation Update
+- **Updated system diagram**: Expanded the architecture diagram to include portos-browser and portos-autofixer as PM2-managed satellite services alongside Chief of Staff
+- **New data flow sections**: Added Browser Automation Flow and Autofixer Flow documenting how each service communicates with the rest of PortOS
+- **Directory structure**: Added `browser/`, `autofixer/`, `data/autofixer/`, and `data/browser-config.json` entries
+- **Key services**: Added Browser Service and Autofixer service descriptions
+- **PM2 process map**: Expanded with script paths and more descriptive purposes

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -78,6 +78,12 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 ### Autofixer App Replaced with PortOS Default
 - Replaced the standalone Autofixer app with PortOS default app in sample data to avoid confusion
 
+### Immediate Task Execution for User Tasks
+- **Instant Spawn**: User-submitted tasks now start immediately when agent slots are available, instead of waiting up to 60 seconds for the next evaluation interval
+- **Slot-Free Dequeue**: When an agent completes and frees a slot, the next pending task is immediately dequeued and spawned without waiting for the evaluation cycle
+- **Priority Preserved**: Dequeue on slot free checks user tasks first, then auto-approved system tasks, maintaining the existing priority order
+- **Evaluation Interval Preserved**: The periodic evaluation interval continues to handle system task generation, idle reviews, and mission tasks — immediate execution is specifically for dequeuing pending work
+
 ## 🔧 Improvements
 
 ### Live Output Streaming for Claude CLI Agents

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -177,3 +177,11 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **Tool Use Visibility**: Shows tool invocations (e.g., "🔧 Using Edit...") in the live output so users can see what the agent is doing
 - **Both Spawn Modes**: Works in both direct spawn mode and via the standalone CoS Runner (PM2 process)
 - **Clean Output Files**: The final output file contains the clean result text, while the raw JSON stream is preserved for error analysis
+
+### Detailed Agent Tool Activity Display
+- **Tool Input Details**: Agent output now shows what each tool is operating on — file paths for Read/Edit/Write, search patterns for Grep/Glob, commands for Bash, queries for WebSearch, and descriptions for Task spawns
+- **Input JSON Delta Parsing**: Stream parser now accumulates `input_json_delta` events and emits detailed summaries when `content_block_stop` fires, providing context like `🔧 Using Grep... → "pattern" in …/services/api.js`
+- **Rich Live Activity Feed**: Running agent cards show the last few tool actions with details instead of just the tool name, giving immediate insight into what the agent is doing
+- **Color-Coded Expanded View**: Expanded agent output now color-codes tool invocations (accent blue), input details (gray), and tool results (dim gray) for easy scanning
+- **Scrollable Output**: Expanded output view is now height-limited and scrollable to prevent page layout issues with verbose agents
+- **Tool Counter**: Shows total tool invocation count when agents use more than 3 tools

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -93,6 +93,11 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **Immediate Task Blocking**: Both `terminateAgent()` and `killAgent()` in direct mode now immediately update the task to `blocked` with `user-terminated` category, matching the runner mode behavior. Previously, task blocking was deferred to the close handler, creating a window where server restarts could cause requeue
 - **Orphan Handler Guard**: `handleOrphanedTask()` now skips tasks already marked as `user-terminated`, preventing any residual requeue path
 
+### Quick Enrich Skip Returns Same Question
+- **Skip now advances to a different question**: Clicking "Skip" on Quick Enrich prompts (both in the overview banner and the full EnrichTab) previously returned the exact same question, because question selection was deterministic based on `questionsAnswered` count which skip didn't increment
+- **Client tracks skipped indices**: Both NextActionBanner and EnrichTab now maintain a `skippedIndices` list for the current session, passing it to the server so it can serve the next non-skipped question
+- **Works for all question types**: Predefined questions skip by index, scale questions skip by negative-offset convention, and AI-generated questions already vary via temperature
+
 ### Digital Twin Personality Trait Confidence Display & Recalculation
 - **Low confidence bars now grey instead of red**: Personality trait bars with low confidence (<60%) now display as grey rather than red, avoiding the false impression of errors when data is simply unverified or sparse
 - **Confidence recalculates after trait analysis**: Running "Analyze Traits" or processing an AI interview assessment now automatically recalculates confidence scores, so the displayed confidence reflects the latest data instead of remaining stale from a previous manual calculation

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -116,6 +116,27 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **Priority Preserved**: Dequeue on slot free checks user tasks first, then auto-approved system tasks, maintaining the existing priority order
 - **Evaluation Interval Preserved**: The periodic evaluation interval continues to handle system task generation, idle reviews, and mission tasks — immediate execution is specifically for dequeuing pending work
 
+### Autonomous Jobs (M37)
+- **Recurring Proactive Jobs**: The CoS can now run scheduled recurring jobs on your behalf — maintaining repositories, processing brain ideas, generating daily briefings, and reviewing projects
+- **Digital Twin Integration**: Jobs execute using your digital twin identity, so the CoS acts with your preferences and values in mind
+- **4 Built-in Jobs**: Ships with Git Repo Maintenance (weekly), Brain Inbox Processing (daily), Daily Briefing (daily), and Brain Project Review (weekly) — all disabled by default for opt-in
+- **Jobs Tab UI**: New "Jobs" tab on the `/cos/jobs` page with toggle controls, interval configuration, manual trigger, inline editing, and prompt template visibility
+- **Custom Jobs**: Create your own recurring jobs with custom prompt templates, intervals (hourly to monthly), priority levels, and autonomy levels (standby/assistant/manager/yolo)
+- **Evaluation Integration**: Due jobs are checked during each CoS evaluation cycle at Priority 3.5 (between missions and idle review), only when no user tasks are pending
+- **Full CRUD API**: REST endpoints at `/api/cos/jobs` for listing, creating, updating, toggling, triggering, and deleting jobs
+
+**Files Added**:
+- `server/services/autonomousJobs.js` — Job management service with scheduling, execution tracking, and task generation
+- `client/src/components/cos/tabs/JobsTab.jsx` — Jobs tab UI component
+
+**Files Modified**:
+- `server/services/cos.js` — Added autonomous jobs to evaluation loop (Priority 3.5), added `autonomousJobsEnabled` config
+- `server/routes/cos.js` — Added `/api/cos/jobs` REST endpoints
+- `client/src/services/api.js` — Added autonomous jobs API functions
+- `client/src/components/cos/constants.js` — Added Jobs tab to navigation
+- `client/src/components/cos/index.js` — Export JobsTab component
+- `client/src/pages/ChiefOfStaff.jsx` — Render Jobs tab
+
 ## 🔧 Improvements
 
 ### Live Output Streaming for Claude CLI Agents

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -103,6 +103,10 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **Root cause**: PortOS mounted the toolkit's parameterized routes before its own `/status` route, so Express matched the toolkit's `/:id` first
 - **Fix**: Reordered route registration so PortOS-specific routes (including `/status`) are defined before mounting the toolkit's catch-all routes
 
+### Quick Enrich Repeats Already-Answered Questions
+- **AI fallback no longer recycles answered questions**: When all predefined and scale questions for a category are exhausted and AI question generation fails, the system now serves a generic follow-up ("What else should your digital twin know about your [category]?") instead of repeating the first predefined question
+- **Deduplicated near-identical questions**: `values` and `non_negotiables` categories previously had nearly identical first questions; `values` now asks a distinct question about top three guiding values
+
 ### Quick Enrich Skip Returns Same Question
 - **Skip now advances to a different question**: Clicking "Skip" on Quick Enrich prompts (both in the overview banner and the full EnrichTab) previously returned the exact same question, because question selection was deterministic based on `questionsAnswered` count which skip didn't increment
 - **Client tracks skipped indices**: Both NextActionBanner and EnrichTab now maintain a `skippedIndices` list for the current session, passing it to the server so it can serve the next non-skipped question

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -98,6 +98,11 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **Reduced log noise**: Empty enhancement results log a warning instead of surfacing as route errors
 - **Client unchanged**: The client already handled enhancement failures gracefully; this fix prevents unnecessary error noise server-side
 
+### AI Providers Status Unreachable on Health Page
+- **Route shadowing fix**: The `/api/providers/status` endpoint was being intercepted by the AI toolkit's `GET /:id` route (treating "status" as a provider ID), returning "Provider not found" instead of the actual status data
+- **Root cause**: PortOS mounted the toolkit's parameterized routes before its own `/status` route, so Express matched the toolkit's `/:id` first
+- **Fix**: Reordered route registration so PortOS-specific routes (including `/status`) are defined before mounting the toolkit's catch-all routes
+
 ### Quick Enrich Skip Returns Same Question
 - **Skip now advances to a different question**: Clicking "Skip" on Quick Enrich prompts (both in the overview banner and the full EnrichTab) previously returned the exact same question, because question selection was deterministic based on `questionsAnswered` count which skip didn't increment
 - **Client tracks skipped indices**: Both NextActionBanner and EnrichTab now maintain a `skippedIndices` list for the current session, passing it to the server so it can serve the next non-skipped question

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -29,6 +29,15 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - `portos-ai-toolkit/src/server/providers.js` - Universal refresh implementation
 - `client/src/pages/AIProviders.jsx` - UI updates with toast notifications
 
+### Digital Twin AI Interview Chat
+- New "Interview" tab in Digital Twin for building personality profiles via external AI conversation loops
+- Paste personality data from ChatGPT/other AIs for automated analysis and twin record updates
+- AI-powered follow-up question generation to deepen profile coverage
+- Persistent chat sessions with session management (create, rename, delete)
+- Automatically maps traits to Big Five, values, and communication dimensions
+- Creates new documents for trait categories not yet captured (Cognitive, Creative, Technical, etc.)
+- Linkable sessions via URL query params (`/digital-twin/interview?session=<uuid>`)
+
 ## 🐛 Bug Fixes
 
 ### CLI Runner Security & Reliability
@@ -46,3 +55,17 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 **Files Modified**:
 - `server/services/runner.js` - New secure CLI execution implementation
 - `server/index.js` - Runtime patching to override toolkit's runner
+
+### Brain Inbox Classification Hang on Capture
+- **Background Classification**: Brain inbox thought capture now returns immediately instead of blocking the UI while waiting for AI classification
+- **Real-time Updates**: Classification results are pushed to the client via Socket.IO events (`brain:classified`), with toast notifications showing the result
+- **New "Classifying" Status**: Added `classifying` status with animated UI indicator so users can see thoughts being processed in real time
+- **No More Hangs**: Previously, submitting a thought would hang the UI spinner indefinitely if the AI provider was slow or unresponsive. Now the thought is saved instantly and classified in the background
+
+**Files Modified**:
+- `server/services/brain.js` - Split `captureThought` into immediate return + background `classifyInBackground`
+- `server/services/socket.js` - Added brain event forwarding via `setupBrainEventForwarding`
+- `server/lib/brainValidation.js` - Added `classifying` to inbox status enum
+- `server/services/brainStorage.js` - Added `classifying` to inbox log counts
+- `client/src/components/brain/tabs/InboxTab.jsx` - Socket.IO listener for classification results, classifying section UI
+- `client/src/components/brain/constants.js` - Added `classifying` status color

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -105,6 +105,8 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 
 ### Quick Enrich Repeats Already-Answered Questions
 - **AI fallback no longer recycles answered questions**: When all predefined and scale questions for a category are exhausted and AI question generation fails, the system now serves a generic follow-up ("What else should your digital twin know about your [category]?") instead of repeating the first predefined question
+- **Fallback only asked once**: The generic fallback question is now only served once per category; after being answered, the category signals completion instead of repeating
+- **Category exhaustion UI**: EnrichTab now shows a "all questions answered" completion view when a category has no more questions, instead of silently falling back to category selection
 - **Deduplicated near-identical questions**: `values` and `non_negotiables` categories previously had nearly identical first questions; `values` now asks a distinct question about top three guiding values
 
 ### Quick Enrich Skip Returns Same Question

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -187,3 +187,10 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **Color-Coded Expanded View**: Expanded agent output now color-codes tool invocations (accent blue), input details (gray), and tool results (dim gray) for easy scanning
 - **Scrollable Output**: Expanded output view is now height-limited and scrollable to prevent page layout issues with verbose agents
 - **Tool Counter**: Shows total tool invocation count when agents use more than 3 tools
+
+### Memory System Overhaul — User-Centric Knowledge
+- **Focus on the user, not the code**: Memory extraction now prioritizes user values, preferences, work patterns, and aesthetic taste — not implementation details an agent can discover by reading files
+- **Higher quality bar**: Minimum confidence raised from 0.6 to 0.7; auto-save threshold raised from 0.8 to 0.85. Most task outputs now correctly produce zero memories instead of noisy low-value ones
+- **Implementation detail filter**: Both LLM classifier and pattern-based fallback now reject file paths, CSS values, port numbers, architecture descriptions, status assessments, and other trivially-discoverable code facts
+- **Removed noise patterns**: Eliminated pattern extractors for "no issues found", "already well-optimized", conclusion sections, and positive assessments — these were generating the bulk of low-value 0% confidence approval requests
+- **Key test**: Every candidate memory now passes the question "Would a brand-new agent benefit from knowing this even with full code access?" — if it's about code, reject; if it's about the user, keep

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -69,3 +69,15 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - `server/services/brainStorage.js` - Added `classifying` to inbox log counts
 - `client/src/components/brain/tabs/InboxTab.jsx` - Socket.IO listener for classification results, classifying section UI
 - `client/src/components/brain/constants.js` - Added `classifying` status color
+
+### Autofixer App Replaced with PortOS Default
+- Replaced the standalone Autofixer app with PortOS default app in sample data to avoid confusion
+
+## 🔧 Improvements
+
+### Live Output Streaming for Claude CLI Agents
+- **Real-time Feedback**: Claude CLI agents now stream output in real-time as they work, matching the live output experience previously only available with Codex
+- **Stream-JSON Parsing**: Uses Claude CLI's `--output-format stream-json --verbose --include-partial-messages` flags to receive incremental text deltas as they're generated
+- **Tool Use Visibility**: Shows tool invocations (e.g., "🔧 Using Edit...") in the live output so users can see what the agent is doing
+- **Both Spawn Modes**: Works in both direct spawn mode and via the standalone CoS Runner (PM2 process)
+- **Clean Output Files**: The final output file contains the clean result text, while the raw JSON stream is preserved for error analysis

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -4,7 +4,29 @@ Released: YYYY-MM-DD
 
 ## Overview
 
-This release focuses on security improvements and bug fixes for the AI runner system.
+This release focuses on security improvements, bug fixes for the AI runner system, and enhanced AI provider model management.
+
+## 🎉 Features
+
+### Universal Model Refresh for AI Providers
+- **Model Refresh Button**: Added "Refresh Models" button to all AI providers on the `/devtools/providers` page
+- **Multi-Provider Support**: Refresh now works for both API and CLI providers including:
+  - API providers: OpenAI, LM Studio, Ollama (with provider-specific endpoint detection)
+  - CLI providers: Claude/Anthropic (returns latest model list), Gemini (fetches from Google AI API)
+- **User Feedback**: Toast notifications show success/failure messages with descriptive error handling
+- **Loading States**: Button shows "Refreshing..." state during model fetch operations
+- **Graceful Degradation**: Providers without refresh support show appropriate error messages
+
+**Implementation Details**:
+- Updated `portos-ai-toolkit` to support provider-specific refresh strategies
+- Added `_refreshAPIProviderModels()` for API-based providers with multi-format support
+- Added `_refreshCLIProviderModels()` with provider detection and API integration
+- Client shows refresh button for all providers (previously API-only)
+- Enhanced error handling with user-friendly toast notifications
+
+**Files Modified**:
+- `portos-ai-toolkit/src/server/providers.js` - Universal refresh implementation
+- `client/src/pages/AIProviders.jsx` - UI updates with toast notifications
 
 ## 🐛 Bug Fixes
 

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -93,6 +93,11 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **Immediate Task Blocking**: Both `terminateAgent()` and `killAgent()` in direct mode now immediately update the task to `blocked` with `user-terminated` category, matching the runner mode behavior. Previously, task blocking was deferred to the close handler, creating a window where server restarts could cause requeue
 - **Orphan Handler Guard**: `handleOrphanedTask()` now skips tasks already marked as `user-terminated`, preventing any residual requeue path
 
+### Task Enhancement Empty Result No Longer Throws Error
+- **Graceful fallback**: When an AI provider returns an empty response during task prompt enhancement, the server now returns the original description instead of throwing a 500 error
+- **Reduced log noise**: Empty enhancement results log a warning instead of surfacing as route errors
+- **Client unchanged**: The client already handled enhancement failures gracefully; this fix prevents unnecessary error noise server-side
+
 ### Quick Enrich Skip Returns Same Question
 - **Skip now advances to a different question**: Clicking "Skip" on Quick Enrich prompts (both in the overview banner and the full EnrichTab) previously returned the exact same question, because question selection was deterministic based on `questionsAnswered` count which skip didn't increment
 - **Client tracks skipped indices**: Both NextActionBanner and EnrichTab now maintain a `skippedIndices` list for the current session, passing it to the server so it can serve the next non-skipped question

--- a/.changelog/v0.11.x.md
+++ b/.changelog/v0.11.x.md
@@ -29,14 +29,32 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - `portos-ai-toolkit/src/server/providers.js` - Universal refresh implementation
 - `client/src/pages/AIProviders.jsx` - UI updates with toast notifications
 
-### Digital Twin AI Interview Chat
-- New "Interview" tab in Digital Twin for building personality profiles via external AI conversation loops
-- Paste personality data from ChatGPT/other AIs for automated analysis and twin record updates
-- AI-powered follow-up question generation to deepen profile coverage
-- Persistent chat sessions with session management (create, rename, delete)
+### Digital Twin Interview & Enrichment Guide
+- Redesigned "Interview" tab as a single-page assessment analyzer + enrichment guide
+- Paste AI personality assessments for automated analysis and twin profile updates
+- Enrichment gap dashboard shows which areas need the most attention
+- Direct navigation from gaps to specific enrichment categories
 - Automatically maps traits to Big Five, values, and communication dimensions
-- Creates new documents for trait categories not yet captured (Cognitive, Creative, Technical, etc.)
-- Linkable sessions via URL query params (`/digital-twin/interview?session=<uuid>`)
+- Creates new documents for personality dimensions not yet captured
+- Removed session-based chat interface in favor of simpler paste-and-analyze flow
+
+### Digital Twin Enrichment UX Improvements
+- **Deep-link Enrich buttons**: All "Enrich" buttons on gap cards and completeness missing sections now navigate directly to the specific enrichment category (e.g., `/digital-twin/enrich?category=values`) instead of the generic landing page
+- **"Start Enrichment Session" targets top gap**: The main CTA button uses the most critical gap's category for immediate action
+- **"Enrich Soul" quick action uses top gap**: The overview quick action card navigates to the highest-priority gap's category when available
+- **Next Action Banner on Overview**: New contextual banner at the top of the overview tab with three modes:
+  - **No profile yet**: Suggests pasting a personality assessment via the Interview tab
+  - **Gaps exist (Q&A)**: Shows an inline question from the top gap's category with submit/skip, Ctrl+Enter shortcut, and link to full enrichment
+  - **Gaps exist (list-based)**: Shows a navigate prompt for list categories (books, movies, music)
+  - **All caught up**: Confirms the twin is well-defined and links to behavioral tests
+
+### Likert-Scale Trait Scoring for Digital Twin Enrichment
+- **Immediate Trait Feedback**: Enrichment now includes 1-5 Likert-scale questions that directly update trait scores and confidence when answered, closing the loop between enrichment answers and personality modeling
+- **18 Scale Questions**: Covers Big Five (10 items), communication style (2), daily routines (2), values (2), and decision heuristics (2) — each mapped to a specific trait dimension
+- **Weighted Moving Average**: Scale answers blend with existing scores using a 0.3 weight factor, preventing any single answer from dominating while still moving the needle
+- **Confidence Boost**: Each scale answer adds +0.15 to the relevant dimension's confidence score, so 3-4 answers can cross the 0.6 gap threshold and remove that dimension from recommendations
+- **Inline Scale UI**: New `ScaleInput` component renders 5 touch-friendly buttons with labels, working in both the full EnrichTab and the NextActionBanner's quick-enrich mode
+- **Backward Compatible**: `questionType` defaults to `text`, existing text question flow is completely unchanged, old client submissions still work
 
 ## 🐛 Bug Fixes
 
@@ -74,6 +92,10 @@ This release focuses on security improvements, bug fixes for the AI runner syste
 - **DevTools Kill Integration**: Killing a CoS agent via the DevTools process manager (`DELETE /api/agents/:pid`) now delegates to the CoS `killAgent()` function, which properly blocks the task instead of letting the close handler treat it as a retryable failure
 - **Immediate Task Blocking**: Both `terminateAgent()` and `killAgent()` in direct mode now immediately update the task to `blocked` with `user-terminated` category, matching the runner mode behavior. Previously, task blocking was deferred to the close handler, creating a window where server restarts could cause requeue
 - **Orphan Handler Guard**: `handleOrphanedTask()` now skips tasks already marked as `user-terminated`, preventing any residual requeue path
+
+### Digital Twin Personality Trait Confidence Display & Recalculation
+- **Low confidence bars now grey instead of red**: Personality trait bars with low confidence (<60%) now display as grey rather than red, avoiding the false impression of errors when data is simply unverified or sparse
+- **Confidence recalculates after trait analysis**: Running "Analyze Traits" or processing an AI interview assessment now automatically recalculates confidence scores, so the displayed confidence reflects the latest data instead of remaining stale from a previous manual calculation
 
 ### Autofixer App Replaced with PortOS Default
 - Replaced the standalone Autofixer app with PortOS default app in sample data to avoid confusion

--- a/PLAN.md
+++ b/PLAN.md
@@ -63,6 +63,7 @@ pm2 logs
 - [x] **M35**: Chief of Staff Enhancement - Proactive autonomous agent with hybrid memory, missions, LM Studio, thinking levels. See [CoS Enhancement](./docs/features/cos-enhancement.md)
 - [x] **M35.1**: CoS UI - Added Arcane Sigil (3D) avatar style option alongside Cyberpunk 3D
 - [x] **M36**: Browser Management - CDP/Playwright browser page with status, controls, config, and logs
+- [x] **M37**: Autonomous Jobs - Recurring scheduled jobs that the CoS executes proactively using digital twin identity
 
 ### Planned
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.14",
+  "version": "0.11.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.10.29",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/components/ProviderModelSelector.jsx
+++ b/client/src/components/ProviderModelSelector.jsx
@@ -1,0 +1,55 @@
+/**
+ * Two-step provider > model dropdown selector.
+ * @param {Object} props
+ * @param {Array} props.providers - Provider list from useProviderModels()
+ * @param {string} props.selectedProviderId - Currently selected provider ID
+ * @param {string} props.selectedModel - Currently selected model
+ * @param {Array} props.availableModels - Models for the selected provider
+ * @param {function} props.onProviderChange - Called with provider ID string
+ * @param {function} props.onModelChange - Called with model string
+ * @param {string} [props.label] - Label text (default: "Provider")
+ * @param {boolean} [props.disabled] - Disable both selectors
+ */
+export default function ProviderModelSelector({
+  providers,
+  selectedProviderId,
+  selectedModel,
+  availableModels,
+  onProviderChange,
+  onModelChange,
+  label = 'Provider',
+  disabled = false
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <div className="flex-1 min-w-0">
+        <label className="block text-xs text-gray-500 mb-1">{label}</label>
+        <select
+          value={selectedProviderId}
+          onChange={(e) => onProviderChange(e.target.value)}
+          disabled={disabled}
+          className="w-full px-3 py-2 min-h-[40px] bg-port-bg border border-port-border rounded-lg text-white text-sm"
+        >
+          {providers.map(p => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+      </div>
+      {availableModels.length > 0 && (
+        <div className="flex-1 min-w-0">
+          <label className="block text-xs text-gray-500 mb-1">Model</label>
+          <select
+            value={selectedModel}
+            onChange={(e) => onModelChange(e.target.value)}
+            disabled={disabled}
+            className="w-full px-3 py-2 min-h-[40px] bg-port-bg border border-port-border rounded-lg text-white text-sm"
+          >
+            {availableModels.map(m => (
+              <option key={m} value={m}>{m}</option>
+            ))}
+          </select>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/brain/constants.js
+++ b/client/src/components/brain/constants.js
@@ -49,6 +49,7 @@ export const DESTINATIONS = {
 
 // Inbox status colors
 export const STATUS_COLORS = {
+  classifying: 'bg-port-accent/20 text-port-accent border-port-accent/30',
   filed: 'bg-port-success/20 text-port-success border-port-success/30',
   needs_review: 'bg-port-warning/20 text-port-warning border-port-warning/30',
   corrected: 'bg-blue-500/20 text-blue-400 border-blue-500/30',

--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -7,12 +7,14 @@ import {
   Settings,
   Calendar,
   Clock,
-  GraduationCap
+  GraduationCap,
+  Bot
 } from 'lucide-react';
 
 export const TABS = [
   { id: 'tasks', label: 'Tasks', icon: FileText },
   { id: 'agents', label: 'Agents', icon: Cpu },
+  { id: 'jobs', label: 'Jobs', icon: Bot },
   { id: 'scripts', label: 'Scripts', icon: Terminal },
   { id: 'schedule', label: 'Schedule', icon: Clock },
   { id: 'digest', label: 'Digest', icon: Calendar },

--- a/client/src/components/cos/index.js
+++ b/client/src/components/cos/index.js
@@ -21,6 +21,7 @@ export { default as EventLog } from './EventLog';
 // Tab Components
 export { default as TasksTab } from './tabs/TasksTab';
 export { default as AgentsTab } from './tabs/AgentsTab';
+export { default as JobsTab } from './tabs/JobsTab';
 export { default as ScriptsTab } from './tabs/ScriptsTab';
 export { default as ScheduleTab } from './tabs/ScheduleTab';
 export { default as LearningTab } from './tabs/LearningTab';

--- a/client/src/components/cos/tabs/AgentsTab.jsx
+++ b/client/src/components/cos/tabs/AgentsTab.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { Trash2 } from 'lucide-react';
+import { useState, useEffect, useMemo } from 'react';
+import { Trash2, Search, X } from 'lucide-react';
 import toast from 'react-hot-toast';
 import * as api from '../../../services/api';
 import AgentCard from './AgentCard';
@@ -8,6 +8,7 @@ import ResumeAgentModal from './ResumeAgentModal';
 export default function AgentsTab({ agents, onRefresh, liveOutputs, providers, apps }) {
   const [resumingAgent, setResumingAgent] = useState(null);
   const [durations, setDurations] = useState(null);
+  const [searchQuery, setSearchQuery] = useState('');
 
   // Fetch duration estimates for progress indicators
   useEffect(() => {
@@ -57,6 +58,18 @@ export default function AgentsTab({ agents, onRefresh, liveOutputs, providers, a
   const completedAgents = agents
     .filter(a => a.status === 'completed')
     .sort((a, b) => new Date(b.completedAt || 0) - new Date(a.completedAt || 0));
+
+  const filteredCompletedAgents = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return completedAgents;
+    return completedAgents.filter(a => {
+      const description = (a.metadata?.taskDescription || '').toLowerCase();
+      const model = (a.metadata?.model || '').toLowerCase();
+      const id = (a.id || '').toLowerCase();
+      const error = (a.result?.error || '').toLowerCase();
+      return description.includes(q) || model.includes(q) || id.includes(q) || error.includes(q);
+    });
+  }, [completedAgents, searchQuery]);
 
   return (
     <div className="space-y-6">
@@ -108,13 +121,45 @@ export default function AgentsTab({ agents, onRefresh, liveOutputs, providers, a
               Clear
             </button>
           </div>
+          {/* Search */}
+          <div className="flex gap-2 mb-3">
+            <div className="relative flex-1">
+              <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" aria-hidden="true" />
+              <input
+                type="text"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                placeholder="Search completed agents..."
+                className="w-full bg-port-card border border-port-border rounded-lg pl-9 pr-4 py-2 min-h-[40px] text-white text-sm placeholder-gray-500 focus:border-port-accent outline-none"
+              />
+            </div>
+            {searchQuery && (
+              <button
+                onClick={() => setSearchQuery('')}
+                className="px-3 py-2 min-h-[40px] min-w-[40px] flex items-center justify-center bg-port-border text-gray-400 hover:text-white rounded-lg transition-colors"
+                aria-label="Clear search"
+              >
+                <X size={16} aria-hidden="true" />
+              </button>
+            )}
+          </div>
+          {searchQuery && (
+            <div className="text-xs text-gray-500 mb-2">
+              {filteredCompletedAgents.length} of {completedAgents.length} agents match
+            </div>
+          )}
           <div className="space-y-2">
-            {completedAgents.slice(0, 15).map(agent => (
+            {(searchQuery ? filteredCompletedAgents : filteredCompletedAgents.slice(0, 15)).map(agent => (
               <AgentCard key={agent.id} agent={agent} completed onDelete={handleDelete} onResume={handleResumeClick} />
             ))}
-            {completedAgents.length > 15 && (
+            {!searchQuery && completedAgents.length > 15 && (
               <div className="text-center text-sm text-gray-500 py-2">
                 + {completedAgents.length - 15} more completed agents
+              </div>
+            )}
+            {searchQuery && filteredCompletedAgents.length === 0 && (
+              <div className="bg-port-card border border-port-border rounded-lg p-6 text-center text-gray-500">
+                No completed agents match "{searchQuery}"
               </div>
             )}
           </div>

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -1,0 +1,490 @@
+import { useState, useEffect, useCallback } from 'react';
+import { Plus, RefreshCw, Play, Trash2, ChevronDown, ChevronUp, Clock, ToggleLeft, ToggleRight, Edit3, Save, X } from 'lucide-react';
+import toast from 'react-hot-toast';
+import * as api from '../../../services/api';
+
+const INTERVAL_OPTIONS = [
+  { value: 'hourly', label: 'Every Hour' },
+  { value: 'every-4-hours', label: 'Every 4 Hours' },
+  { value: 'every-8-hours', label: 'Every 8 Hours' },
+  { value: 'daily', label: 'Daily' },
+  { value: 'weekly', label: 'Weekly' },
+  { value: 'biweekly', label: 'Every 2 Weeks' },
+  { value: 'monthly', label: 'Monthly' }
+];
+
+const PRIORITY_OPTIONS = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
+const AUTONOMY_OPTIONS = [
+  { value: 'standby', label: 'Standby', desc: 'Creates tasks but waits for approval' },
+  { value: 'assistant', label: 'Assistant', desc: 'Creates tasks, notifies you' },
+  { value: 'manager', label: 'Manager', desc: 'Executes tasks autonomously' },
+  { value: 'yolo', label: 'YOLO', desc: 'Full autonomy, no guardrails' }
+];
+
+function formatTimeAgo(dateStr) {
+  if (!dateStr) return 'Never';
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `${days}d ago`;
+  if (hours > 0) return `${hours}h ago`;
+  const mins = Math.floor(diff / 60000);
+  return mins > 0 ? `${mins}m ago` : 'Just now';
+}
+
+function formatNextDue(lastRun, intervalMs) {
+  if (!lastRun) return 'Immediately';
+  const nextDue = new Date(lastRun).getTime() + intervalMs;
+  const diff = nextDue - Date.now();
+  if (diff <= 0) return 'Now';
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(hours / 24);
+  if (days > 0) return `in ${days}d`;
+  if (hours > 0) return `in ${hours}h`;
+  const mins = Math.floor(diff / 60000);
+  return `in ${mins}m`;
+}
+
+function JobCard({ job, onToggle, onTrigger, onDelete, onUpdate }) {
+  const [expanded, setExpanded] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editData, setEditData] = useState({});
+
+  const startEditing = () => {
+    setEditData({
+      name: job.name,
+      description: job.description,
+      interval: job.interval,
+      priority: job.priority,
+      autonomyLevel: job.autonomyLevel,
+      promptTemplate: job.promptTemplate
+    });
+    setEditing(true);
+    setExpanded(true);
+  };
+
+  const handleSave = async () => {
+    await api.updateCosJob(job.id, editData).catch(err => {
+      toast.error(err.message);
+      return null;
+    });
+    toast.success('Job updated');
+    setEditing(false);
+    onUpdate();
+  };
+
+  const isDue = job.enabled && (
+    !job.lastRun || (Date.now() - new Date(job.lastRun).getTime() >= job.intervalMs)
+  );
+
+  return (
+    <div className={`bg-port-card border rounded-lg transition-colors ${
+      job.enabled ? 'border-port-border' : 'border-port-border/50 opacity-60'
+    }`}>
+      <div className="flex items-center gap-3 p-4">
+        {/* Toggle */}
+        <button
+          onClick={() => onToggle(job.id)}
+          className={`flex-shrink-0 transition-colors ${
+            job.enabled ? 'text-port-success' : 'text-gray-600'
+          }`}
+          title={job.enabled ? 'Disable job' : 'Enable job'}
+        >
+          {job.enabled ? <ToggleRight size={24} /> : <ToggleLeft size={24} />}
+        </button>
+
+        {/* Info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="text-white font-medium truncate">{job.name}</span>
+            {isDue && (
+              <span className="px-1.5 py-0.5 bg-port-warning/20 text-port-warning text-xs rounded">
+                Due
+              </span>
+            )}
+            <span className="px-1.5 py-0.5 bg-port-bg text-gray-400 text-xs rounded">
+              {job.category}
+            </span>
+          </div>
+          <div className="flex items-center gap-3 text-xs text-gray-500 mt-1">
+            <span className="flex items-center gap-1">
+              <Clock size={10} />
+              {INTERVAL_OPTIONS.find(i => i.value === job.interval)?.label || job.interval}
+            </span>
+            <span>Last: {formatTimeAgo(job.lastRun)}</span>
+            {job.enabled && (
+              <span className={isDue ? 'text-port-warning' : 'text-gray-500'}>
+                Next: {formatNextDue(job.lastRun, job.intervalMs)}
+              </span>
+            )}
+            <span>Runs: {job.runCount || 0}</span>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => onTrigger(job.id)}
+            className="p-1.5 text-gray-500 hover:text-port-accent transition-colors"
+            title="Run now"
+          >
+            <Play size={14} />
+          </button>
+          <button
+            onClick={startEditing}
+            className="p-1.5 text-gray-500 hover:text-white transition-colors"
+            title="Edit"
+          >
+            <Edit3 size={14} />
+          </button>
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="p-1.5 text-gray-500 hover:text-white transition-colors"
+          >
+            {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </button>
+        </div>
+      </div>
+
+      {/* Expanded content */}
+      {expanded && (
+        <div className="border-t border-port-border p-4 space-y-3">
+          {editing ? (
+            <>
+              <input
+                type="text"
+                value={editData.name}
+                onChange={e => setEditData(d => ({ ...d, name: e.target.value }))}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+                placeholder="Job name"
+              />
+              <input
+                type="text"
+                value={editData.description}
+                onChange={e => setEditData(d => ({ ...d, description: e.target.value }))}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+                placeholder="Description"
+              />
+              <div className="flex gap-3">
+                <select
+                  value={editData.interval}
+                  onChange={e => setEditData(d => ({ ...d, interval: e.target.value }))}
+                  className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+                >
+                  {INTERVAL_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+                <select
+                  value={editData.priority}
+                  onChange={e => setEditData(d => ({ ...d, priority: e.target.value }))}
+                  className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+                >
+                  {PRIORITY_OPTIONS.map(p => (
+                    <option key={p} value={p}>{p}</option>
+                  ))}
+                </select>
+                <select
+                  value={editData.autonomyLevel}
+                  onChange={e => setEditData(d => ({ ...d, autonomyLevel: e.target.value }))}
+                  className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+                >
+                  {AUTONOMY_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>{opt.label}</option>
+                  ))}
+                </select>
+              </div>
+              <textarea
+                value={editData.promptTemplate}
+                onChange={e => setEditData(d => ({ ...d, promptTemplate: e.target.value }))}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono h-40"
+                placeholder="Prompt template for the agent"
+              />
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={() => setEditing(false)}
+                  className="flex items-center gap-1 px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+                >
+                  <X size={14} /> Cancel
+                </button>
+                <button
+                  onClick={handleSave}
+                  className="flex items-center gap-1 px-3 py-1.5 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg text-sm transition-colors"
+                >
+                  <Save size={14} /> Save
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <p className="text-sm text-gray-400">{job.description}</p>
+              <div className="flex gap-4 text-xs text-gray-500">
+                <span>Priority: <span className="text-gray-300">{job.priority}</span></span>
+                <span>Autonomy: <span className="text-gray-300">{job.autonomyLevel}</span></span>
+                <span>Created: <span className="text-gray-300">{new Date(job.createdAt).toLocaleDateString()}</span></span>
+              </div>
+              <details className="group">
+                <summary className="text-xs text-gray-500 cursor-pointer hover:text-gray-300 transition-colors">
+                  View prompt template
+                </summary>
+                <pre className="mt-2 p-3 bg-port-bg border border-port-border rounded-lg text-xs text-gray-400 font-mono whitespace-pre-wrap max-h-48 overflow-y-auto">
+                  {job.promptTemplate}
+                </pre>
+              </details>
+              <div className="flex justify-end">
+                <button
+                  onClick={() => onDelete(job.id)}
+                  className="flex items-center gap-1 px-2 py-1 text-xs text-red-400/60 hover:text-red-400 transition-colors"
+                >
+                  <Trash2 size={12} /> Delete
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function JobsTab() {
+  const [jobs, setJobs] = useState([]);
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [newJob, setNewJob] = useState({
+    name: '',
+    description: '',
+    category: 'custom',
+    interval: 'daily',
+    priority: 'MEDIUM',
+    autonomyLevel: 'manager',
+    promptTemplate: '',
+    enabled: false
+  });
+
+  const fetchJobs = useCallback(async () => {
+    const data = await api.getCosJobs().catch(err => {
+      toast.error(`Failed to load jobs: ${err.message}`);
+      return null;
+    });
+    if (data) {
+      setJobs(data.jobs || []);
+      setStats(data.stats || null);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetchJobs(); }, [fetchJobs]);
+
+  const handleCreate = async () => {
+    if (!newJob.name.trim() || !newJob.promptTemplate.trim()) {
+      toast.error('Name and prompt template are required');
+      return;
+    }
+
+    await api.createCosJob(newJob).catch(err => {
+      toast.error(err.message);
+      return null;
+    });
+    toast.success('Job created');
+    setNewJob({
+      name: '',
+      description: '',
+      category: 'custom',
+      interval: 'daily',
+      priority: 'MEDIUM',
+      autonomyLevel: 'manager',
+      promptTemplate: '',
+      enabled: false
+    });
+    setShowCreate(false);
+    fetchJobs();
+  };
+
+  const handleToggle = async (jobId) => {
+    const result = await api.toggleCosJob(jobId).catch(err => {
+      toast.error(err.message);
+      return null;
+    });
+    if (result) {
+      toast.success(result.job.enabled ? 'Job enabled' : 'Job disabled');
+      fetchJobs();
+    }
+  };
+
+  const handleTrigger = async (jobId) => {
+    toast.loading('Triggering job...', { id: 'job-trigger' });
+    const result = await api.triggerCosJob(jobId).catch(err => {
+      toast.error(err.message, { id: 'job-trigger' });
+      return null;
+    });
+    if (result) {
+      toast.success('Job triggered — task queued', { id: 'job-trigger' });
+      fetchJobs();
+    }
+  };
+
+  const handleDelete = async (jobId) => {
+    await api.deleteCosJob(jobId).catch(err => {
+      toast.error(err.message);
+      return null;
+    });
+    toast.success('Job deleted');
+    fetchJobs();
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12 text-gray-500">
+        Loading autonomous jobs...
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold text-white">Autonomous Jobs</h3>
+          <p className="text-sm text-gray-500 mt-1">
+            Recurring jobs that run on your behalf using your digital twin identity
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowCreate(!showCreate)}
+            className="flex items-center gap-1 text-sm text-port-accent hover:text-port-accent/80 transition-colors"
+          >
+            <Plus size={16} />
+            New Job
+          </button>
+          <button
+            onClick={fetchJobs}
+            className="text-gray-500 hover:text-white transition-colors"
+          >
+            <RefreshCw size={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Stats bar */}
+      {stats && (
+        <div className="flex gap-4 text-xs text-gray-500">
+          <span>{stats.enabled} enabled / {stats.total} total</span>
+          <span>{stats.totalRuns} total runs</span>
+          {stats.nextDue && (
+            <span className={stats.nextDue.isDue ? 'text-port-warning' : ''}>
+              Next: {stats.nextDue.jobName} ({stats.nextDue.isDue ? 'due now' : new Date(stats.nextDue.nextDueAt).toLocaleString()})
+            </span>
+          )}
+        </div>
+      )}
+
+      {/* Create form */}
+      {showCreate && (
+        <div className="bg-port-card border border-port-accent/50 rounded-lg p-4">
+          <div className="space-y-3">
+            <div className="flex gap-3">
+              <input
+                type="text"
+                placeholder="Job name *"
+                value={newJob.name}
+                onChange={e => setNewJob(j => ({ ...j, name: e.target.value }))}
+                className="flex-1 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+              />
+              <input
+                type="text"
+                placeholder="Category"
+                value={newJob.category}
+                onChange={e => setNewJob(j => ({ ...j, category: e.target.value }))}
+                className="w-40 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+              />
+            </div>
+            <input
+              type="text"
+              placeholder="Description"
+              value={newJob.description}
+              onChange={e => setNewJob(j => ({ ...j, description: e.target.value }))}
+              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+            />
+            <div className="flex gap-3">
+              <select
+                value={newJob.interval}
+                onChange={e => setNewJob(j => ({ ...j, interval: e.target.value }))}
+                className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+              >
+                {INTERVAL_OPTIONS.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label}</option>
+                ))}
+              </select>
+              <select
+                value={newJob.priority}
+                onChange={e => setNewJob(j => ({ ...j, priority: e.target.value }))}
+                className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+              >
+                {PRIORITY_OPTIONS.map(p => (
+                  <option key={p} value={p}>{p}</option>
+                ))}
+              </select>
+              <select
+                value={newJob.autonomyLevel}
+                onChange={e => setNewJob(j => ({ ...j, autonomyLevel: e.target.value }))}
+                className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+              >
+                {AUTONOMY_OPTIONS.map(opt => (
+                  <option key={opt.value} value={opt.value}>{opt.label} — {opt.desc}</option>
+                ))}
+              </select>
+            </div>
+            <textarea
+              placeholder="Prompt template for the agent *"
+              value={newJob.promptTemplate}
+              onChange={e => setNewJob(j => ({ ...j, promptTemplate: e.target.value }))}
+              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono h-32"
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setShowCreate(false)}
+                className="px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleCreate}
+                className="flex items-center gap-1 px-3 py-1.5 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg text-sm transition-colors"
+              >
+                <Plus size={14} />
+                Create Job
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Jobs list */}
+      {jobs.length === 0 ? (
+        <div className="bg-port-card border border-port-border rounded-lg p-8 text-center">
+          <div className="text-gray-500 mb-3">No autonomous jobs configured.</div>
+          <p className="text-xs text-gray-600 max-w-md mx-auto">
+            Autonomous jobs let the Chief of Staff act proactively on your behalf — maintaining repositories, processing brain ideas, and more.
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {jobs.map(job => (
+            <JobCard
+              key={job.id}
+              job={job}
+              onToggle={handleToggle}
+              onTrigger={handleTrigger}
+              onDelete={handleDelete}
+              onUpdate={fetchJobs}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/cos/tabs/LearningTab.jsx
+++ b/client/src/components/cos/tabs/LearningTab.jsx
@@ -399,7 +399,8 @@ export default function LearningTab() {
                     <thead className="bg-port-bg">
                       <tr>
                         <th className="text-left p-3 text-gray-500 font-medium">Task Type</th>
-                        <th className="text-right p-3 text-gray-500 font-medium">Avg Duration</th>
+                        <th className="text-right p-3 text-gray-500 font-medium">Avg</th>
+                        <th className="text-right p-3 text-gray-500 font-medium" title="P80 estimate used for progress bars">Est</th>
                         <th className="text-right p-3 text-gray-500 font-medium hidden sm:table-cell">Samples</th>
                         <th className="text-right p-3 text-gray-500 font-medium hidden sm:table-cell">Success</th>
                       </tr>
@@ -408,8 +409,11 @@ export default function LearningTab() {
                       {sortedDurations.map(([taskType, data], idx) => (
                         <tr key={idx} className="border-t border-port-border">
                           <td className="p-3 text-gray-300 truncate max-w-[200px]">{taskType}</td>
-                          <td className="p-3 text-right text-cyan-400 font-mono">
+                          <td className="p-3 text-right text-gray-500 font-mono">
                             {formatDuration(data.avgDurationMs)}
+                          </td>
+                          <td className="p-3 text-right text-cyan-400 font-mono" title="P80 estimate used for progress bars and ETAs">
+                            {formatDuration(data.p80DurationMs || data.avgDurationMs)}
                           </td>
                           <td className="p-3 text-right text-gray-500 hidden sm:table-cell">
                             {data.completed}

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -112,6 +112,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   const editModels = editProvider?.models || [];
 
   // Calculate duration estimate for pending tasks
+  // Uses P80 estimate when available for more realistic time predictions
   const durationEstimate = useMemo(() => {
     if (!durations || task.status !== 'pending') return null;
 
@@ -120,8 +121,10 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
     const overallData = durations._overall;
 
     if (typeData && typeData.avgDurationMin) {
+      const p80Min = typeData.p80DurationMs ? Math.round(typeData.p80DurationMs / 60000) : typeData.avgDurationMin;
       return {
-        estimatedMin: typeData.avgDurationMin,
+        estimatedMin: p80Min,
+        avgMin: typeData.avgDurationMin,
         basedOn: typeData.completed,
         taskType,
         successRate: typeData.successRate,
@@ -130,8 +133,10 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
     }
 
     if (overallData && overallData.avgDurationMin) {
+      const p80Min = overallData.p80DurationMs ? Math.round(overallData.p80DurationMs / 60000) : overallData.avgDurationMin;
       return {
-        estimatedMin: overallData.avgDurationMin,
+        estimatedMin: p80Min,
+        avgMin: overallData.avgDurationMin,
         basedOn: overallData.completed,
         taskType: 'all tasks',
         successRate: overallData.successRate,

--- a/client/src/components/cos/tabs/TasksTab.jsx
+++ b/client/src/components/cos/tabs/TasksTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import { Plus, Play, Image, X, ChevronDown, ChevronRight, Sparkles, Loader2, Paperclip, FileText, Zap, Bookmark, Trash2 } from 'lucide-react';
+import { Plus, Play, Image, X, ChevronDown, ChevronRight, Sparkles, Loader2, Paperclip, FileText, Zap, Bookmark } from 'lucide-react';
 import toast from 'react-hot-toast';
 import {
   DndContext,

--- a/client/src/components/cos/tabs/TasksTab.jsx
+++ b/client/src/components/cos/tabs/TasksTab.jsx
@@ -329,10 +329,13 @@ export default function TasksTab({ tasks, onRefresh, providers, apps }) {
             {showTemplates && (
               <div className="flex flex-wrap gap-2">
                 {templates.map(template => (
-                  <button
+                  <div
                     key={template.id}
+                    role="button"
+                    tabIndex={0}
                     onClick={() => applyTemplate(template)}
-                    className="group relative flex items-center gap-1.5 px-3 py-1.5 bg-port-card border border-port-border rounded-lg text-sm text-gray-300 hover:text-white hover:border-port-accent/50 transition-colors"
+                    onKeyDown={(e) => e.key === 'Enter' && applyTemplate(template)}
+                    className="group relative flex items-center gap-1.5 px-3 py-1.5 bg-port-card border border-port-border rounded-lg text-sm text-gray-300 hover:text-white hover:border-port-accent/50 transition-colors cursor-pointer"
                     title={template.description}
                   >
                     <span>{template.icon || '📝'}</span>
@@ -349,7 +352,7 @@ export default function TasksTab({ tasks, onRefresh, providers, apps }) {
                         <X size={10} />
                       </button>
                     )}
-                  </button>
+                  </div>
                 ))}
               </div>
             )}

--- a/client/src/components/cos/tabs/TasksTab.jsx
+++ b/client/src/components/cos/tabs/TasksTab.jsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef, useMemo } from 'react';
-import { Plus, Play, Image, X, ChevronDown, ChevronRight, Sparkles, Loader2, Paperclip, FileText } from 'lucide-react';
+import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
+import { Plus, Play, Image, X, ChevronDown, ChevronRight, Sparkles, Loader2, Paperclip, FileText, Zap, Bookmark, Trash2 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import {
   DndContext,
@@ -32,14 +32,82 @@ export default function TasksTab({ tasks, onRefresh, providers, apps }) {
   const [showCompletedSystemTasks, setShowCompletedSystemTasks] = useState(false);
   const [enhancePrompt, setEnhancePrompt] = useState(false);
   const [isEnhancing, setIsEnhancing] = useState(false);
+  const [templates, setTemplates] = useState([]);
+  const [showTemplates, setShowTemplates] = useState(true);
   const fileInputRef = useRef(null);
   const attachmentInputRef = useRef(null);
 
-  // Fetch task duration estimates from learning data
+  // Fetch task duration estimates and templates
   useEffect(() => {
     api.getCosLearningDurations()
       .then(setDurations)
       .catch(() => setDurations(null));
+
+    api.getCosPopularTemplates(8)
+      .then(data => setTemplates(data.templates || []))
+      .catch(() => setTemplates([]));
+  }, []);
+
+  // Apply template to form
+  const applyTemplate = useCallback(async (template) => {
+    setNewTask({
+      description: template.description,
+      context: template.context || '',
+      model: template.model || '',
+      provider: template.provider || '',
+      app: template.app || ''
+    });
+
+    // Record usage for popularity tracking
+    await api.useCosTaskTemplate(template.id).catch(() => {});
+
+    toast.success(`Template applied: ${template.name}`);
+  }, []);
+
+  // Save current form as template
+  const saveAsTemplate = useCallback(async () => {
+    if (!newTask.description.trim()) {
+      toast.error('Enter a task description first');
+      return;
+    }
+
+    const name = prompt('Template name:', newTask.description.substring(0, 40));
+    if (!name) return;
+
+    const result = await api.createCosTaskTemplate({
+      name,
+      description: newTask.description,
+      context: newTask.context,
+      provider: newTask.provider,
+      model: newTask.model,
+      app: newTask.app
+    }).catch(err => {
+      toast.error(err.message);
+      return null;
+    });
+
+    if (result?.success) {
+      toast.success('Template saved');
+      // Refresh templates
+      api.getCosPopularTemplates(8)
+        .then(data => setTemplates(data.templates || []))
+        .catch(() => {});
+    }
+  }, [newTask]);
+
+  // Delete a user template
+  const deleteTemplate = useCallback(async (templateId, e) => {
+    e.stopPropagation();
+
+    const result = await api.deleteCosTaskTemplate(templateId).catch(err => {
+      toast.error(err.message);
+      return null;
+    });
+
+    if (result?.success) {
+      toast.success('Template deleted');
+      setTemplates(prev => prev.filter(t => t.id !== templateId));
+    }
   }, []);
 
   // Memoize task arrays to prevent unnecessary re-renders
@@ -245,6 +313,49 @@ export default function TasksTab({ tasks, onRefresh, providers, apps }) {
           </button>
         </div>
 
+        {/* Quick Templates */}
+        {templates.length > 0 && (
+          <div className="mb-4">
+            <button
+              onClick={() => setShowTemplates(!showTemplates)}
+              className="flex items-center gap-2 text-sm text-gray-400 hover:text-white transition-colors mb-2"
+              aria-expanded={showTemplates}
+            >
+              {showTemplates ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+              <Zap size={14} className="text-yellow-500" />
+              Quick Templates
+              <span className="text-xs text-gray-600">({templates.length})</span>
+            </button>
+            {showTemplates && (
+              <div className="flex flex-wrap gap-2">
+                {templates.map(template => (
+                  <button
+                    key={template.id}
+                    onClick={() => applyTemplate(template)}
+                    className="group relative flex items-center gap-1.5 px-3 py-1.5 bg-port-card border border-port-border rounded-lg text-sm text-gray-300 hover:text-white hover:border-port-accent/50 transition-colors"
+                    title={template.description}
+                  >
+                    <span>{template.icon || '📝'}</span>
+                    <span className="max-w-[120px] truncate">{template.name}</span>
+                    {template.useCount > 0 && (
+                      <span className="text-xs text-gray-600">({template.useCount})</span>
+                    )}
+                    {!template.isBuiltin && (
+                      <button
+                        onClick={(e) => deleteTemplate(template.id, e)}
+                        className="hidden group-hover:flex absolute -top-1 -right-1 w-4 h-4 bg-port-error rounded-full items-center justify-center"
+                        title="Delete template"
+                      >
+                        <X size={10} />
+                      </button>
+                    )}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
         {/* Add Task Form */}
         {showAddTask && (
           <div className="bg-port-card border border-port-accent/50 rounded-lg p-4 mb-4" role="form" aria-label="Add new task">
@@ -447,7 +558,16 @@ export default function TasksTab({ tasks, onRefresh, providers, apps }) {
                   ))}
                 </div>
               )}
-              <div className="flex justify-end">
+              <div className="flex justify-end gap-2">
+                <button
+                  onClick={saveAsTemplate}
+                  type="button"
+                  className="flex items-center gap-1 px-3 py-1.5 bg-port-border hover:bg-port-border/80 text-gray-400 hover:text-white rounded-lg text-sm transition-colors min-h-[40px]"
+                  title="Save current form as a reusable template"
+                >
+                  <Bookmark size={14} aria-hidden="true" />
+                  <span className="hidden sm:inline">Save Template</span>
+                </button>
                 <button
                   onClick={handleAddTask}
                   disabled={isEnhancing}

--- a/client/src/components/digital-twin/GapRecommendations.jsx
+++ b/client/src/components/digital-twin/GapRecommendations.jsx
@@ -113,7 +113,7 @@ export default function GapRecommendations({ gaps, maxDisplay = 3 }) {
                   </div>
                 </div>
                 <button
-                  onClick={() => navigate('/digital-twin/enrich')}
+                  onClick={() => navigate(`/digital-twin/enrich?category=${gap.suggestedCategory}`)}
                   className="flex items-center gap-1 text-sm text-port-accent hover:text-white transition-colors"
                 >
                   Enrich
@@ -151,7 +151,7 @@ export default function GapRecommendations({ gaps, maxDisplay = 3 }) {
       </div>
 
       <button
-        onClick={() => navigate('/digital-twin/enrich')}
+        onClick={() => navigate(`/digital-twin/enrich?category=${gaps[0]?.suggestedCategory || ''}`)}
         className="w-full mt-4 px-4 py-3 bg-port-accent/20 border border-port-accent/50 text-port-accent rounded-lg text-sm hover:bg-port-accent/30 transition-colors flex items-center justify-center gap-2"
       >
         Start Enrichment Session

--- a/client/src/components/digital-twin/InterviewAnalysisCard.jsx
+++ b/client/src/components/digital-twin/InterviewAnalysisCard.jsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, FileText, TrendingUp, Layers, BarChart3 } from 'lucide-react';
+
+function CollapsibleSection({ title, icon: Icon, children, defaultOpen = false }) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border border-port-border rounded-lg overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-300 hover:bg-port-bg transition-colors"
+      >
+        {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        <Icon size={14} />
+        <span>{title}</span>
+      </button>
+      {open && <div className="px-3 pb-3 text-sm">{children}</div>}
+    </div>
+  );
+}
+
+export default function InterviewAnalysisCard({ analysisResult }) {
+  if (!analysisResult) return null;
+
+  const { traitsUpdated, documentsCreated, documentsUpdated, newDimensions, confidenceDelta, rawAnalysis } = analysisResult;
+
+  const traitCount = Object.keys(traitsUpdated || {}).length;
+  const docsCreatedCount = (documentsCreated || []).length;
+  const docsUpdatedCount = (documentsUpdated || []).length;
+  const dimensionCount = (newDimensions || []).length;
+
+  return (
+    <div className="mt-2 space-y-2">
+      {/* Summary badges */}
+      <div className="flex flex-wrap gap-2">
+        {traitCount > 0 && (
+          <span className="px-2 py-1 text-xs rounded-full bg-blue-500/20 text-blue-400 border border-blue-500/30">
+            {traitCount} trait categories updated
+          </span>
+        )}
+        {docsCreatedCount > 0 && (
+          <span className="px-2 py-1 text-xs rounded-full bg-green-500/20 text-green-400 border border-green-500/30">
+            {docsCreatedCount} docs created
+          </span>
+        )}
+        {docsUpdatedCount > 0 && (
+          <span className="px-2 py-1 text-xs rounded-full bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
+            {docsUpdatedCount} docs updated
+          </span>
+        )}
+        {dimensionCount > 0 && (
+          <span className="px-2 py-1 text-xs rounded-full bg-purple-500/20 text-purple-400 border border-purple-500/30">
+            {dimensionCount} new dimensions
+          </span>
+        )}
+        {confidenceDelta && confidenceDelta.after !== confidenceDelta.before && (
+          <span className="px-2 py-1 text-xs rounded-full bg-emerald-500/20 text-emerald-400 border border-emerald-500/30">
+            Confidence: {Math.round(confidenceDelta.before * 100)}% → {Math.round(confidenceDelta.after * 100)}%
+          </span>
+        )}
+      </div>
+
+      {/* Collapsible sections */}
+      <div className="space-y-1">
+        {traitCount > 0 && (
+          <CollapsibleSection title="Trait Updates" icon={BarChart3}>
+            <div className="space-y-2">
+              {traitsUpdated.bigFive && (
+                <div>
+                  <p className="text-gray-400 mb-1">Big Five:</p>
+                  <div className="grid grid-cols-5 gap-2">
+                    {Object.entries(traitsUpdated.bigFive).filter(([k]) => k !== 'notes').map(([k, v]) => (
+                      <div key={k} className="text-center">
+                        <div className="text-xs text-gray-500">{k}</div>
+                        <div className="text-white font-medium">{typeof v === 'number' ? v.toFixed(2) : v}</div>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {traitsUpdated.valuesHierarchy && (
+                <div>
+                  <p className="text-gray-400 mb-1">Values:</p>
+                  <div className="flex flex-wrap gap-1">
+                    {traitsUpdated.valuesHierarchy.map((v, i) => (
+                      <span key={i} className="px-2 py-0.5 text-xs bg-port-bg rounded text-gray-300">
+                        {v.value} ({v.priority})
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {traitsUpdated.communicationProfile && (
+                <div>
+                  <p className="text-gray-400 mb-1">Communication:</p>
+                  <div className="text-xs text-gray-300 space-y-0.5">
+                    {traitsUpdated.communicationProfile.formality !== undefined && (
+                      <div>Formality: {traitsUpdated.communicationProfile.formality}/10</div>
+                    )}
+                    {traitsUpdated.communicationProfile.verbosity !== undefined && (
+                      <div>Verbosity: {traitsUpdated.communicationProfile.verbosity}/10</div>
+                    )}
+                    {traitsUpdated.communicationProfile.preferredTone && (
+                      <div>Tone: {traitsUpdated.communicationProfile.preferredTone}</div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </CollapsibleSection>
+        )}
+
+        {dimensionCount > 0 && (
+          <CollapsibleSection title="New Dimensions" icon={Layers}>
+            <div className="space-y-2">
+              {newDimensions.map((dim, i) => (
+                <div key={i} className="bg-port-bg rounded p-2">
+                  <div className="font-medium text-purple-400 text-xs mb-1">{dim.name}</div>
+                  <div className="space-y-1">
+                    {dim.traits.map((t, j) => (
+                      <div key={j} className="text-xs text-gray-300">
+                        <span className="text-white">{t.trait}:</span> {t.expression}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </CollapsibleSection>
+        )}
+
+        {(docsCreatedCount > 0 || docsUpdatedCount > 0) && (
+          <CollapsibleSection title="Document Changes" icon={FileText}>
+            <div className="space-y-1">
+              {(documentsCreated || []).map((f, i) => (
+                <div key={`c-${i}`} className="text-xs text-green-400">+ {f}</div>
+              ))}
+              {(documentsUpdated || []).map((f, i) => (
+                <div key={`u-${i}`} className="text-xs text-yellow-400">~ {f}</div>
+              ))}
+            </div>
+          </CollapsibleSection>
+        )}
+
+        {rawAnalysis && (
+          <CollapsibleSection title="Analysis Summary" icon={TrendingUp} defaultOpen>
+            <p className="text-xs text-gray-300 whitespace-pre-wrap">{rawAnalysis}</p>
+          </CollapsibleSection>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/digital-twin/NextActionBanner.jsx
+++ b/client/src/components/digital-twin/NextActionBanner.jsx
@@ -43,7 +43,7 @@ export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
   const [skippedIndices, setSkippedIndices] = useState([]);
 
   const hasTraits = traits && Object.keys(traits).length > 0;
-  const hasEnrichment = (status?.enrichmentProgress?.completedCategories || 0) > 0;
+  const hasEnrichment = (status?.enrichmentProgress?.completedCategories?.length || 0) > 0;
   const hasGaps = gaps && gaps.length > 0;
 
   const topGap = hasGaps ? gaps[0] : null;

--- a/client/src/components/digital-twin/NextActionBanner.jsx
+++ b/client/src/components/digital-twin/NextActionBanner.jsx
@@ -131,7 +131,18 @@ export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
   const handleSkip = () => {
     if (!activeCategory || !question) return;
     const idx = question.questionType === 'scale' ? -(question.scaleIndex + 1) : question.questionIndex;
-    const nextSkipped = idx != null ? [...skippedIndices, idx] : skippedIndices;
+    // Fallback/generated questions have no index — treat skip as category exhaustion
+    if (idx == null) {
+      setCurrentGapIdx(prev => {
+        for (let i = prev + 1; i < (gaps?.length || 0); i++) {
+          if (gaps[i]?.suggestedCategory) return i;
+        }
+        return prev;
+      });
+      setQuestion(null);
+      return;
+    }
+    const nextSkipped = [...skippedIndices, idx];
     setSkippedIndices(nextSkipped);
     loadQuestion(activeCategory, nextSkipped);
   };

--- a/client/src/components/digital-twin/NextActionBanner.jsx
+++ b/client/src/components/digital-twin/NextActionBanner.jsx
@@ -1,0 +1,266 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Sparkles,
+  Send,
+  SkipForward,
+  RefreshCw,
+  ArrowRight,
+  CheckCircle,
+  MessageSquare
+} from 'lucide-react';
+import * as api from '../../services/api';
+import toast from 'react-hot-toast';
+import { ENRICHMENT_CATEGORIES } from './constants';
+import ScaleInput from './ScaleInput';
+
+const DIMENSION_LABELS = {
+  openness: 'Openness',
+  conscientiousness: 'Conscientiousness',
+  extraversion: 'Extraversion',
+  agreeableness: 'Agreeableness',
+  neuroticism: 'Neuroticism',
+  values: 'Values',
+  communication: 'Communication',
+  decision_making: 'Decision Making',
+  boundaries: 'Boundaries',
+  identity: 'Identity'
+};
+
+function getUrgencyBadge(confidence) {
+  if (confidence < 0.3) return { text: 'Critical', cls: 'text-red-400 bg-red-500/20' };
+  if (confidence < 0.5) return { text: 'Important', cls: 'text-orange-400 bg-orange-500/20' };
+  return { text: 'Suggested', cls: 'text-yellow-400 bg-yellow-500/20' };
+}
+
+export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
+  const navigate = useNavigate();
+  const [question, setQuestion] = useState(null);
+  const [answer, setAnswer] = useState('');
+  const [scaleValue, setScaleValue] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const hasTraits = traits && Object.keys(traits).length > 0;
+  const hasEnrichment = (status?.enrichmentProgress?.completedCategories || 0) > 0;
+  const hasGaps = gaps && gaps.length > 0;
+
+  const topGap = hasGaps ? gaps[0] : null;
+  const topCategory = topGap?.suggestedCategory;
+  const isListBased = topCategory && ENRICHMENT_CATEGORIES[topCategory]?.listBased;
+
+  // Load a question for the top gap's category (only for Q&A categories)
+  useEffect(() => {
+    if (topCategory && !isListBased) {
+      loadQuestion(topCategory);
+    }
+  }, [topCategory, isListBased]);
+
+  const loadQuestion = async (category) => {
+    setLoading(true);
+    const q = await api.getSoulEnrichQuestion(category).catch(() => null);
+    setQuestion(q);
+    setAnswer('');
+    setScaleValue(null);
+    setLoading(false);
+  };
+
+  const handleSubmit = async () => {
+    if (!question) return;
+    const isScale = question.questionType === 'scale';
+
+    if (isScale && scaleValue == null) return;
+    if (!isScale && !answer.trim()) return;
+
+    setSubmitting(true);
+
+    const payload = {
+      questionId: question.questionId,
+      category: topCategory,
+      question: question.question
+    };
+
+    if (isScale) {
+      payload.questionType = 'scale';
+      payload.scaleValue = scaleValue;
+      payload.scaleQuestionId = question.scaleQuestionId;
+    } else {
+      payload.questionType = 'text';
+      payload.answer = answer.trim();
+    }
+
+    await api.submitSoulEnrichAnswer(payload);
+    toast.success(isScale ? 'Rating saved' : 'Answer saved');
+    setAnswer('');
+    setScaleValue(null);
+    onRefresh?.();
+    await loadQuestion(topCategory);
+    setSubmitting(false);
+  };
+
+  const handleSkip = () => {
+    if (topCategory) loadQuestion(topCategory);
+  };
+
+  const handleKeyDown = (e) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      const isScale = question?.questionType === 'scale';
+      if (isScale ? scaleValue != null : answer.trim()) handleSubmit();
+    }
+  };
+
+  // Mode 1: No traits and no enrichment - suggest interview
+  if (!hasTraits && !hasEnrichment) {
+    return (
+      <div className="bg-gradient-to-r from-purple-500/10 to-pink-500/10 border border-purple-500/30 rounded-lg p-5">
+        <div className="flex items-start gap-3">
+          <MessageSquare className="w-5 h-5 text-purple-400 mt-0.5 flex-shrink-0" />
+          <div className="flex-1">
+            <h3 className="text-white font-medium mb-1">Get started with a personality assessment</h3>
+            <p className="text-sm text-gray-400 mb-3">
+              Paste results from a personality test (Big Five, MBTI, Enneagram) to quickly seed your digital twin profile.
+            </p>
+            <button
+              onClick={() => navigate('/digital-twin/interview')}
+              className="px-4 py-2 bg-purple-600 text-white rounded-lg text-sm hover:bg-purple-500 flex items-center gap-2"
+            >
+              Go to Interview
+              <ArrowRight size={14} />
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Mode 3: No gaps - all caught up
+  if (!hasGaps) {
+    return (
+      <div className="bg-green-500/10 border border-green-500/30 rounded-lg p-5">
+        <div className="flex items-start gap-3">
+          <CheckCircle className="w-5 h-5 text-green-400 mt-0.5 flex-shrink-0" />
+          <div className="flex-1">
+            <h3 className="text-white font-medium mb-1">Your twin is well-defined</h3>
+            <p className="text-sm text-gray-400 mb-3">
+              All personality dimensions have strong confidence. Run behavioral tests to validate accuracy.
+            </p>
+            <button
+              onClick={() => navigate('/digital-twin/test')}
+              className="px-4 py-2 bg-green-600 text-white rounded-lg text-sm hover:bg-green-500 flex items-center gap-2"
+            >
+              Run Tests
+              <ArrowRight size={14} />
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Mode 2: Gaps exist - inline question or navigate prompt
+  const urgency = getUrgencyBadge(topGap.confidence);
+  const dimensionLabel = DIMENSION_LABELS[topGap.dimension] || topGap.dimension;
+
+  // List-based category: show navigate prompt instead of inline Q&A
+  if (isListBased) {
+    const catConfig = ENRICHMENT_CATEGORIES[topCategory];
+    return (
+      <div className="bg-gradient-to-r from-yellow-500/10 to-orange-500/10 border border-yellow-500/30 rounded-lg p-5">
+        <div className="flex items-start gap-3">
+          <Sparkles className="w-5 h-5 text-yellow-400 mt-0.5 flex-shrink-0" />
+          <div className="flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <h3 className="text-white font-medium">Enrich: {dimensionLabel}</h3>
+              <span className={`text-xs px-2 py-0.5 rounded-full ${urgency.cls}`}>{urgency.text}</span>
+            </div>
+            <p className="text-sm text-gray-400 mb-3">
+              Add your {catConfig?.label?.toLowerCase() || 'items'} to strengthen this dimension.
+            </p>
+            <button
+              onClick={() => navigate(`/digital-twin/enrich?category=${topCategory}`)}
+              className="px-4 py-2 bg-yellow-600 text-white rounded-lg text-sm hover:bg-yellow-500 flex items-center gap-2"
+            >
+              Add {catConfig?.label || 'Items'}
+              <ArrowRight size={14} />
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Q&A-based category: inline question
+  return (
+    <div className="bg-gradient-to-r from-yellow-500/10 to-orange-500/10 border border-yellow-500/30 rounded-lg p-5">
+      <div className="flex items-start gap-3">
+        <Sparkles className="w-5 h-5 text-yellow-400 mt-0.5 flex-shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="text-white font-medium">Quick Enrich: {dimensionLabel}</h3>
+            <span className={`text-xs px-2 py-0.5 rounded-full ${urgency.cls}`}>{urgency.text}</span>
+          </div>
+
+          {loading ? (
+            <div className="flex items-center gap-2 text-gray-400 py-4">
+              <RefreshCw className="w-4 h-4 animate-spin" />
+              Loading question...
+            </div>
+          ) : question ? (
+            <>
+              <p className="text-sm text-gray-300 mb-3">{question.question}</p>
+              {question.questionType === 'scale' ? (
+                <div className="mb-2">
+                  <ScaleInput
+                    labels={question.labels}
+                    value={scaleValue}
+                    onChange={setScaleValue}
+                    disabled={submitting}
+                  />
+                </div>
+              ) : (
+                <textarea
+                  value={answer}
+                  onChange={(e) => setAnswer(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder="Type your answer..."
+                  rows={3}
+                  className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm resize-none focus:outline-none focus:border-port-accent mb-2"
+                />
+              )}
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={handleSubmit}
+                    disabled={submitting || (question.questionType === 'scale' ? scaleValue == null : !answer.trim())}
+                    className="px-3 py-1.5 bg-port-accent text-white rounded-lg text-sm hover:bg-port-accent/80 disabled:opacity-50 flex items-center gap-1.5"
+                  >
+                    {submitting ? <RefreshCw className="w-3.5 h-3.5 animate-spin" /> : <Send size={14} />}
+                    Submit
+                  </button>
+                  <button
+                    onClick={handleSkip}
+                    className="px-3 py-1.5 text-gray-400 hover:text-white text-sm flex items-center gap-1.5"
+                  >
+                    <SkipForward size={14} />
+                    Skip
+                  </button>
+                </div>
+                <button
+                  onClick={() => navigate(`/digital-twin/enrich?category=${topCategory}`)}
+                  className="text-xs text-port-accent hover:text-white"
+                >
+                  Full enrichment →
+                </button>
+              </div>
+              {question.questionType !== 'scale' && (
+                <div className="text-xs text-gray-600 mt-1">Ctrl+Enter to submit</div>
+              )}
+            </>
+          ) : (
+            <p className="text-sm text-gray-400">Unable to load question.</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/digital-twin/NextActionBanner.jsx
+++ b/client/src/components/digital-twin/NextActionBanner.jsx
@@ -91,7 +91,12 @@ export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
       payload.answer = answer.trim();
     }
 
-    await api.submitSoulEnrichAnswer(payload);
+    const result = await api.submitSoulEnrichAnswer(payload).catch(() => null);
+    if (!result) {
+      toast.error('Failed to save response. Please try again.');
+      setSubmitting(false);
+      return;
+    }
     toast.success(isScale ? 'Rating saved' : 'Answer saved');
     setAnswer('');
     setScaleValue(null);

--- a/client/src/components/digital-twin/PersonalityMap.jsx
+++ b/client/src/components/digital-twin/PersonalityMap.jsx
@@ -16,13 +16,13 @@ const TRAIT_ORDER = ['O', 'C', 'E', 'A', 'N'];
 function getConfidenceColor(confidence) {
   if (confidence >= 0.8) return 'text-green-400';
   if (confidence >= 0.6) return 'text-yellow-400';
-  return 'text-red-400';
+  return 'text-gray-400';
 }
 
 function getConfidenceBg(confidence) {
   if (confidence >= 0.8) return 'bg-green-500';
   if (confidence >= 0.6) return 'bg-yellow-500';
-  return 'bg-red-500';
+  return 'bg-gray-500';
 }
 
 export default function PersonalityMap({ traits, confidence, providers, onAnalyze }) {

--- a/client/src/components/digital-twin/ScaleInput.jsx
+++ b/client/src/components/digital-twin/ScaleInput.jsx
@@ -1,0 +1,30 @@
+export default function ScaleInput({ labels, value, onChange, disabled }) {
+  const defaultLabels = ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'];
+  const shortLabels = ['SD', 'D', 'N', 'A', 'SA'];
+  const displayLabels = labels || defaultLabels;
+
+  return (
+    <div className="flex gap-2 justify-center">
+      {[1, 2, 3, 4, 5].map((val) => {
+        const selected = value === val;
+        return (
+          <button
+            key={val}
+            type="button"
+            disabled={disabled}
+            onClick={() => onChange(val)}
+            className={`flex-1 min-w-[48px] min-h-[48px] flex flex-col items-center justify-center rounded-lg border transition-all ${
+              selected
+                ? 'bg-port-accent border-port-accent text-white'
+                : 'bg-port-bg border-port-border text-gray-400 hover:border-gray-500 hover:text-gray-300'
+            } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+          >
+            <span className="text-lg font-bold">{val}</span>
+            <span className="text-[10px] leading-tight mt-0.5 hidden sm:block">{displayLabels[val - 1]}</span>
+            <span className="text-[10px] leading-tight mt-0.5 sm:hidden">{shortLabels[val - 1]}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/client/src/components/digital-twin/constants.js
+++ b/client/src/components/digital-twin/constants.js
@@ -33,6 +33,7 @@ export const TABS = [
   { id: 'test', label: 'Test', icon: CheckCircle },
   { id: 'enrich', label: 'Enrich', icon: Sparkles },
   { id: 'accounts', label: 'Accounts', icon: Globe },
+  { id: 'interview', label: 'Interview', icon: MessageSquare },
   { id: 'import', label: 'Import', icon: Upload },
   { id: 'export', label: 'Export', icon: Download }
 ];
@@ -153,7 +154,8 @@ export const ENRICHMENT_CATEGORIES = {
     label: 'Communication Style',
     description: 'How you prefer to give and receive information',
     icon: MessageSquare,
-    color: 'cyan'
+    color: 'cyan',
+    hasScaleQuestions: true
   },
   decision_making: {
     id: 'decision_making',
@@ -167,7 +169,8 @@ export const ENRICHMENT_CATEGORIES = {
     label: 'Values',
     description: 'Core principles that guide your actions',
     icon: Heart,
-    color: 'pink'
+    color: 'pink',
+    hasScaleQuestions: true
   },
   aesthetics: {
     id: 'aesthetics',
@@ -181,7 +184,8 @@ export const ENRICHMENT_CATEGORIES = {
     label: 'Daily Routines',
     description: 'Habits and rhythms that structure your day',
     icon: Clock,
-    color: 'amber'
+    color: 'amber',
+    hasScaleQuestions: true
   },
   career_skills: {
     id: 'career_skills',
@@ -202,7 +206,8 @@ export const ENRICHMENT_CATEGORIES = {
     label: 'Decision Heuristics',
     description: 'Mental models and shortcuts for making choices',
     icon: GitBranch,
-    color: 'indigo'
+    color: 'indigo',
+    hasScaleQuestions: true
   },
   error_intolerance: {
     id: 'error_intolerance',
@@ -216,7 +221,8 @@ export const ENRICHMENT_CATEGORIES = {
     label: 'Personality Assessments',
     description: 'Myers-Briggs, Big Five, Enneagram, and other personality type results',
     icon: Fingerprint,
-    color: 'sky'
+    color: 'sky',
+    hasScaleQuestions: true
   }
 };
 

--- a/client/src/components/digital-twin/tabs/EnrichTab.jsx
+++ b/client/src/components/digital-twin/tabs/EnrichTab.jsx
@@ -249,6 +249,37 @@ export default function EnrichTab({ onRefresh }) {
     );
   }
 
+  // All questions exhausted for this category
+  if (activeCategory && !currentQuestion && !loadingQuestion) {
+    const categoryConfig = ENRICHMENT_CATEGORIES[activeCategory];
+    const Icon = categoryConfig?.icon || Sparkles;
+    return (
+      <div className="max-w-2xl mx-auto px-1">
+        <div className="mb-6">
+          <button
+            onClick={exitCategory}
+            className="flex items-center gap-2 text-gray-400 hover:text-white mb-4 py-2 min-h-[44px]"
+          >
+            <ArrowLeft size={18} />
+            Back to categories
+          </button>
+          <div className="flex items-center gap-3">
+            <div className={`p-2.5 rounded-lg bg-${categoryConfig?.color || 'blue'}-500/20`}>
+              <Icon className={`w-5 h-5 text-${categoryConfig?.color || 'blue'}-400`} />
+            </div>
+            <h2 className="text-xl font-semibold text-white">{categoryConfig?.label}</h2>
+          </div>
+        </div>
+        <div className="p-4 bg-green-500/10 border border-green-500/30 rounded-lg">
+          <div className="flex items-center gap-3">
+            <Check className="w-5 h-5 text-green-400" />
+            <span className="text-green-400">All questions for this category have been answered. Great job!</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   // Q&A-based enrichment session
   if (activeCategory && currentQuestion) {
     const categoryConfig = ENRICHMENT_CATEGORIES[activeCategory];

--- a/client/src/components/digital-twin/tabs/EnrichTab.jsx
+++ b/client/src/components/digital-twin/tabs/EnrichTab.jsx
@@ -196,7 +196,12 @@ export default function EnrichTab({ onRefresh }) {
       payload.answer = answer.trim();
     }
 
-    await api.submitSoulEnrichAnswer(payload);
+    const result = await api.submitSoulEnrichAnswer(payload).catch(() => null);
+    if (!result) {
+      toast.error('Failed to save response. Please try again.');
+      setSubmitting(false);
+      return;
+    }
 
     toast.success(isScale ? 'Rating saved' : 'Answer saved');
     setSkippedIndices([]);
@@ -210,7 +215,12 @@ export default function EnrichTab({ onRefresh }) {
 
   const skipQuestion = async () => {
     const idx = currentQuestion?.questionType === 'scale' ? -(currentQuestion.scaleIndex + 1) : currentQuestion?.questionIndex;
-    const nextSkipped = idx != null ? [...skippedIndices, idx] : skippedIndices;
+    // Fallback/generated questions have no index — treat skip as category-complete
+    if (idx == null) {
+      setCurrentQuestion(null);
+      return;
+    }
+    const nextSkipped = [...skippedIndices, idx];
     setSkippedIndices(nextSkipped);
     await loadQuestion(activeCategory, nextSkipped);
   };

--- a/client/src/components/digital-twin/tabs/InterviewTab.jsx
+++ b/client/src/components/digital-twin/tabs/InterviewTab.jsx
@@ -1,0 +1,262 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ClipboardPaste,
+  RefreshCw,
+  BarChart3,
+  ArrowRight,
+  AlertCircle,
+  Target,
+  Sparkles
+} from 'lucide-react';
+import * as api from '../../../services/api';
+import toast from 'react-hot-toast';
+import useProviderModels from '../../../hooks/useProviderModels';
+import ProviderModelSelector from '../../ProviderModelSelector';
+import InterviewAnalysisCard from '../InterviewAnalysisCard';
+import { ENRICHMENT_CATEGORIES } from '../constants';
+
+export default function InterviewTab({ onRefresh }) {
+  const navigate = useNavigate();
+  const {
+    providers, selectedProviderId, selectedModel, availableModels,
+    setSelectedProviderId, setSelectedModel, loading: providersLoading
+  } = useProviderModels();
+
+  const [content, setContent] = useState('');
+  const [analyzing, setAnalyzing] = useState(false);
+  const [analysisResult, setAnalysisResult] = useState(null);
+  const [gaps, setGaps] = useState([]);
+  const [enrichProgress, setEnrichProgress] = useState(null);
+
+  const loadEnrichmentData = useCallback(async () => {
+    const [gapsData, progressData] = await Promise.all([
+      api.getDigitalTwinGaps().catch(() => ({ gaps: [] })),
+      api.getDigitalTwinEnrichProgress().catch(() => null)
+    ]);
+    setGaps(gapsData.gaps || []);
+    setEnrichProgress(progressData);
+  }, []);
+
+  useEffect(() => {
+    loadEnrichmentData();
+  }, [loadEnrichmentData]);
+
+  const handleAnalyze = async () => {
+    if (!content.trim() || content.trim().length < 50) {
+      toast.error('Assessment must be at least 50 characters');
+      return;
+    }
+    if (!selectedProviderId || !selectedModel) {
+      toast.error('Select a provider and model');
+      return;
+    }
+
+    setAnalyzing(true);
+    setAnalysisResult(null);
+
+    const result = await api.analyzeAssessment(content.trim(), selectedProviderId, selectedModel)
+      .catch((err) => ({ error: err.message }));
+
+    if (result.error) {
+      toast.error(result.error);
+    } else {
+      setAnalysisResult(result.analysisResult);
+      if (result.gaps) setGaps(result.gaps);
+      toast.success('Assessment analyzed successfully');
+      onRefresh?.();
+      loadEnrichmentData();
+    }
+    setAnalyzing(false);
+  };
+
+  const navigateToEnrich = (categoryId) => {
+    navigate(`/digital-twin/enrich?category=${categoryId}`);
+  };
+
+  // Sort gaps by lowest confidence first
+  const sortedGaps = [...gaps].sort((a, b) => a.confidence - b.confidence);
+
+  // Build category progress map
+  const categoryProgress = enrichProgress?.categories || {};
+  const categoryEntries = Object.entries(ENRICHMENT_CATEGORIES);
+
+  return (
+    <div className="space-y-6 max-w-4xl mx-auto">
+      {/* Section 1: Paste & Analyze */}
+      <div className="bg-port-card rounded-lg border border-port-border p-6">
+        <div className="flex items-center gap-3 mb-4">
+          <ClipboardPaste className="w-6 h-6 text-port-accent" />
+          <div>
+            <h2 className="text-lg font-semibold text-white">Analyze Personality Assessment</h2>
+            <p className="text-sm text-gray-400">
+              Paste an AI personality assessment to automatically enrich your digital twin
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          {/* Provider/Model Selector */}
+          {!providersLoading && providers.length > 0 && (
+            <ProviderModelSelector
+              providers={providers}
+              selectedProviderId={selectedProviderId}
+              selectedModel={selectedModel}
+              availableModels={availableModels}
+              onProviderChange={setSelectedProviderId}
+              onModelChange={setSelectedModel}
+              disabled={analyzing}
+            />
+          )}
+
+          {/* Textarea */}
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Paste your personality assessment here (from ChatGPT, Claude, etc.)..."
+            rows={8}
+            className="w-full px-4 py-3 bg-port-bg border border-port-border rounded-lg text-white resize-y focus:outline-none focus:border-port-accent placeholder-gray-600"
+            disabled={analyzing}
+          />
+
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-gray-500">
+              {content.length} characters {content.length > 0 && content.length < 50 && '(need 50+)'}
+            </span>
+            <button
+              onClick={handleAnalyze}
+              disabled={analyzing || content.trim().length < 50 || !selectedProviderId}
+              className="flex items-center gap-2 px-6 py-3 min-h-[48px] bg-port-accent text-white rounded-lg font-medium hover:bg-port-accent/80 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {analyzing ? (
+                <>
+                  <RefreshCw size={18} className="animate-spin" />
+                  Analyzing...
+                </>
+              ) : (
+                <>
+                  <BarChart3 size={18} />
+                  Analyze
+                </>
+              )}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Section 2: Analysis Results */}
+      {analysisResult && (
+        <div className="bg-port-card rounded-lg border border-green-500/30 p-6">
+          <div className="flex items-center gap-3 mb-4">
+            <BarChart3 className="w-6 h-6 text-green-400" />
+            <h2 className="text-lg font-semibold text-white">Analysis Results</h2>
+          </div>
+
+          {analysisResult.summary && (
+            <p className="text-sm text-gray-300 mb-4">{analysisResult.summary}</p>
+          )}
+
+          <InterviewAnalysisCard analysisResult={analysisResult} />
+        </div>
+      )}
+
+      {/* Section 3: Enrichment Guide */}
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <Target className="w-6 h-6 text-yellow-400" />
+          <h2 className="text-lg font-semibold text-white">Areas to Enrich</h2>
+        </div>
+
+        {/* Gap Cards */}
+        {sortedGaps.length > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {sortedGaps.map((gap) => (
+              <button
+                key={gap.dimension}
+                onClick={() => gap.suggestedCategory && navigateToEnrich(gap.suggestedCategory)}
+                className="bg-port-card rounded-lg border border-port-border p-4 text-left hover:border-port-accent transition-colors"
+              >
+                <div className="flex items-center justify-between mb-2">
+                  <span className="text-sm font-medium text-white capitalize">
+                    {gap.dimension.replace(/_/g, ' ')}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-gray-400">
+                      {Math.round(gap.confidence * 100)}%
+                    </span>
+                    {gap.suggestedCategory && (
+                      <ArrowRight size={14} className="text-gray-500" />
+                    )}
+                  </div>
+                </div>
+                <div className="h-1.5 bg-port-border rounded-full overflow-hidden mb-2">
+                  <div
+                    className={`h-full rounded-full transition-all ${
+                      gap.confidence < 0.3 ? 'bg-red-500' :
+                      gap.confidence < 0.6 ? 'bg-yellow-500' : 'bg-green-500'
+                    }`}
+                    style={{ width: `${Math.round(gap.confidence * 100)}%` }}
+                  />
+                </div>
+                {gap.suggestedCategory && (
+                  <span className="text-xs text-gray-500">
+                    Enrich via: {ENRICHMENT_CATEGORIES[gap.suggestedCategory]?.label || gap.suggestedCategory}
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {sortedGaps.length === 0 && (
+          <div className="bg-port-card rounded-lg border border-port-border p-4 flex items-center gap-3">
+            <AlertCircle size={18} className="text-gray-500" />
+            <span className="text-sm text-gray-400">
+              No gap data available yet. Analyze an assessment or run confidence calculation to see gaps.
+            </span>
+          </div>
+        )}
+
+        {/* Category Completion Grid */}
+        <div>
+          <h3 className="text-sm font-medium text-gray-400 mb-3">Enrichment Categories</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+            {categoryEntries.map(([key, config]) => {
+              const progress = categoryProgress[key];
+              const isComplete = progress?.completed;
+              const percentage = progress?.percentage || 0;
+              const Icon = config.icon || Sparkles;
+
+              return (
+                <button
+                  key={key}
+                  onClick={() => navigateToEnrich(key)}
+                  className={`flex items-center gap-3 p-3 rounded-lg border transition-colors text-left hover:border-port-accent ${
+                    isComplete ? 'border-green-500/30 bg-green-500/5' : 'border-port-border bg-port-card'
+                  }`}
+                >
+                  <Icon size={16} className={isComplete ? 'text-green-400' : 'text-gray-500'} />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-white truncate">{config.label}</span>
+                      <span className={`text-xs ml-2 ${isComplete ? 'text-green-400' : 'text-gray-500'}`}>
+                        {percentage}%
+                      </span>
+                    </div>
+                    <div className="h-1 bg-port-border rounded-full mt-1 overflow-hidden">
+                      <div
+                        className={`h-full rounded-full transition-all ${isComplete ? 'bg-green-500' : 'bg-port-accent'}`}
+                        style={{ width: `${percentage}%` }}
+                      />
+                    </div>
+                  </div>
+                  <ArrowRight size={14} className="text-gray-600 flex-shrink-0" />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/digital-twin/tabs/OverviewTab.jsx
+++ b/client/src/components/digital-twin/tabs/OverviewTab.jsx
@@ -27,6 +27,7 @@ import SoulWizard from '../SoulWizard';
 import PersonalityMap from '../PersonalityMap';
 import ConfidenceGauge from '../ConfidenceGauge';
 import GapRecommendations from '../GapRecommendations';
+import NextActionBanner from '../NextActionBanner';
 
 export default function OverviewTab({ status, settings, onRefresh }) {
   const navigate = useNavigate();
@@ -170,8 +171,21 @@ export default function OverviewTab({ status, settings, onRefresh }) {
     );
   }
 
+  const handleBannerRefresh = () => {
+    loadTraitsAndConfidence();
+    onRefresh();
+  };
+
   return (
     <div className="space-y-6">
+      {/* Next Action Banner */}
+      <NextActionBanner
+        gaps={gaps}
+        status={status}
+        traits={traits}
+        onRefresh={handleBannerRefresh}
+      />
+
       {/* Health Score Card */}
       <div className="bg-port-card rounded-lg border border-port-border p-6">
         <div className="flex items-center justify-between mb-4">
@@ -356,7 +370,7 @@ export default function OverviewTab({ status, settings, onRefresh }) {
                       </div>
                       {section.enrichmentCategory && (
                         <button
-                          onClick={() => navigate('/digital-twin/enrich')}
+                          onClick={() => navigate(`/digital-twin/enrich?category=${section.enrichmentCategory}`)}
                           className="flex items-center gap-1 text-sm text-port-accent hover:text-white"
                         >
                           Add via Enrich
@@ -503,7 +517,7 @@ export default function OverviewTab({ status, settings, onRefresh }) {
         </button>
 
         <button
-          onClick={() => navigate('/digital-twin/enrich')}
+          onClick={() => navigate(gaps[0]?.suggestedCategory ? `/digital-twin/enrich?category=${gaps[0].suggestedCategory}` : '/digital-twin/enrich')}
           className="flex items-center gap-3 sm:gap-4 p-4 min-h-[72px] bg-port-card rounded-lg border border-port-border hover:border-port-accent transition-colors"
         >
           <div className="p-2.5 sm:p-3 rounded-lg bg-yellow-500/20 flex-shrink-0">

--- a/client/src/hooks/useProviderModels.js
+++ b/client/src/hooks/useProviderModels.js
@@ -1,0 +1,62 @@
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import * as api from '../services/api';
+
+/**
+ * Hook for loading AI providers and managing two-step provider > model selection.
+ * @param {Object} options
+ * @param {function} [options.filter] - Filter function for providers (default: enabled only)
+ * @returns {{ providers, selectedProviderId, selectedModel, availableModels, selectedProvider, setSelectedProviderId, setSelectedModel, loading }}
+ */
+export default function useProviderModels({ filter } = {}) {
+  const [providers, setProviders] = useState([]);
+  const [selectedProviderId, setSelectedProviderId] = useState('');
+  const [selectedModel, setSelectedModel] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const data = await api.getProviders().catch(() => ({ providers: [] }));
+    const filterFn = filter || (p => p.enabled);
+    const filtered = (data.providers || []).filter(filterFn);
+    setProviders(filtered);
+    if (filtered.length > 0 && !selectedProviderId) {
+      setSelectedProviderId(filtered[0].id);
+      setSelectedModel(filtered[0].defaultModel || '');
+    }
+    setLoading(false);
+  }, [filter]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const currentProvider = useMemo(
+    () => providers.find(p => p.id === selectedProviderId),
+    [providers, selectedProviderId]
+  );
+
+  const availableModels = useMemo(
+    () => (currentProvider?.models || [currentProvider?.defaultModel]).filter(Boolean),
+    [currentProvider]
+  );
+
+  const handleProviderChange = useCallback((id) => {
+    setSelectedProviderId(id);
+    const p = providers.find(pr => pr.id === id);
+    setSelectedModel(p?.defaultModel || '');
+  }, [providers]);
+
+  // Convenience: combined { providerId, model } for consumers
+  const selectedProvider = selectedProviderId && selectedModel
+    ? { providerId: selectedProviderId, model: selectedModel }
+    : null;
+
+  return {
+    providers,
+    selectedProviderId,
+    selectedModel,
+    availableModels,
+    selectedProvider,
+    setSelectedProviderId: handleProviderChange,
+    setSelectedModel,
+    loading
+  };
+}

--- a/client/src/hooks/useProviderModels.js
+++ b/client/src/hooks/useProviderModels.js
@@ -24,7 +24,7 @@ export default function useProviderModels({ filter } = {}) {
       setSelectedModel(filtered[0].defaultModel || '');
     }
     setLoading(false);
-  }, [filter]);
+  }, [filter, selectedProviderId]);
 
   useEffect(() => { load(); }, [load]);
 

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -84,6 +84,15 @@ export default function AIProviders() {
     loadData();
   };
 
+  const supportsModelRefresh = (provider) => {
+    // Gemini CLI doesn't require model specification
+    if (provider.type === 'cli' && provider.command === 'gemini') {
+      return false;
+    }
+    // All other providers support refresh (API and CLI)
+    return true;
+  };
+
   const handleRefreshModels = async (id) => {
     setRefreshing(prev => ({ ...prev, [id]: true }));
     try {
@@ -296,14 +305,16 @@ export default function AIProviders() {
                   {testResults[provider.id]?.testing ? 'Testing...' : 'Test'}
                 </button>
 
-                <button
-                  onClick={() => handleRefreshModels(provider.id)}
-                  disabled={refreshing[provider.id]}
-                  className="px-3 py-1.5 text-sm bg-port-border hover:bg-port-border/80 text-white rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                  title="Refresh available models"
-                >
-                  {refreshing[provider.id] ? 'Refreshing...' : 'Refresh Models'}
-                </button>
+                {supportsModelRefresh(provider) && (
+                  <button
+                    onClick={() => handleRefreshModels(provider.id)}
+                    disabled={refreshing[provider.id]}
+                    className="px-3 py-1.5 text-sm bg-port-border hover:bg-port-border/80 text-white rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                    title="Refresh available models"
+                  >
+                    {refreshing[provider.id] ? 'Refreshing...' : 'Refresh Models'}
+                  </button>
+                )}
 
                 <button
                   onClick={() => handleToggleEnabled(provider)}

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import toast from 'react-hot-toast';
 import * as api from '../services/api';
 import socket from '../services/socket';
 
@@ -9,6 +10,7 @@ export default function AIProviders() {
   const [showForm, setShowForm] = useState(false);
   const [editingProvider, setEditingProvider] = useState(null);
   const [testResults, setTestResults] = useState({});
+  const [refreshing, setRefreshing] = useState({});
   const [runs, setRuns] = useState([]);
   const [showRunPanel, setShowRunPanel] = useState(false);
   const [runPrompt, setRunPrompt] = useState('');
@@ -83,8 +85,20 @@ export default function AIProviders() {
   };
 
   const handleRefreshModels = async (id) => {
-    await api.refreshProviderModels(id);
-    loadData();
+    setRefreshing(prev => ({ ...prev, [id]: true }));
+    try {
+      const result = await api.refreshProviderModels(id);
+      if (result) {
+        toast.success(`Models refreshed for ${result.name}`);
+        loadData();
+      } else {
+        toast.error('Failed to refresh models - provider may not support this feature');
+      }
+    } catch (error) {
+      toast.error(`Error refreshing models: ${error.message}`);
+    } finally {
+      setRefreshing(prev => ({ ...prev, [id]: false }));
+    }
   };
 
   const handleExecuteRun = async () => {
@@ -282,15 +296,14 @@ export default function AIProviders() {
                   {testResults[provider.id]?.testing ? 'Testing...' : 'Test'}
                 </button>
 
-                {provider.type === 'api' && (
-                  <button
-                    onClick={() => handleRefreshModels(provider.id)}
-                    className="px-3 py-1.5 text-sm bg-port-border hover:bg-port-border/80 text-white rounded transition-colors"
-                    title="Refresh models from API"
-                  >
-                    Refresh
-                  </button>
-                )}
+                <button
+                  onClick={() => handleRefreshModels(provider.id)}
+                  disabled={refreshing[provider.id]}
+                  className="px-3 py-1.5 text-sm bg-port-border hover:bg-port-border/80 text-white rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  title="Refresh available models"
+                >
+                  {refreshing[provider.id] ? 'Refreshing...' : 'Refresh Models'}
+                </button>
 
                 <button
                   onClick={() => handleToggleEnabled(provider)}

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -22,6 +22,7 @@ import {
   EventLog,
   TasksTab,
   AgentsTab,
+  JobsTab,
   ScriptsTab,
   ScheduleTab,
   DigestTab,
@@ -542,6 +543,11 @@ export default function ChiefOfStaff() {
         {activeTab === 'agents' && (
           <div role="tabpanel" id="tabpanel-agents" aria-labelledby="tab-agents">
             <AgentsTab agents={agents} onRefresh={fetchData} liveOutputs={liveOutputs} providers={providers} apps={apps} />
+          </div>
+        )}
+        {activeTab === 'jobs' && (
+          <div role="tabpanel" id="tabpanel-jobs" aria-labelledby="tab-jobs">
+            <JobsTab />
           </div>
         )}
         {activeTab === 'scripts' && (

--- a/client/src/pages/DigitalTwin.jsx
+++ b/client/src/pages/DigitalTwin.jsx
@@ -10,6 +10,7 @@ import DocumentsTab from '../components/digital-twin/tabs/DocumentsTab';
 import TestTab from '../components/digital-twin/tabs/TestTab';
 import EnrichTab from '../components/digital-twin/tabs/EnrichTab';
 import AccountsTab from '../components/digital-twin/tabs/AccountsTab';
+import InterviewTab from '../components/digital-twin/tabs/InterviewTab';
 import ImportTab from '../components/digital-twin/tabs/ImportTab';
 import ExportTab from '../components/digital-twin/tabs/ExportTab';
 
@@ -54,6 +55,8 @@ export default function DigitalTwin() {
         return <EnrichTab onRefresh={fetchData} />;
       case 'accounts':
         return <AccountsTab />;
+      case 'interview':
+        return <InterviewTab onRefresh={fetchData} />;
       case 'import':
         return <ImportTab onRefresh={fetchData} />;
       case 'export':

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -399,6 +399,25 @@ export const getCosLearningPerformance = () => request('/cos/learning/performanc
 export const backfillCosLearning = () => request('/cos/learning/backfill', { method: 'POST' });
 export const resetCosTaskTypeLearning = (taskType) => request(`/cos/learning/reset/${encodeURIComponent(taskType)}`, { method: 'POST' });
 
+// CoS Quick Task Templates
+export const getCosTaskTemplates = () => request('/cos/templates');
+export const getCosPopularTemplates = (limit = 5) => request(`/cos/templates/popular?limit=${limit}`);
+export const getCosTemplateCategories = () => request('/cos/templates/categories');
+export const createCosTaskTemplate = (data) => request('/cos/templates', {
+  method: 'POST',
+  body: JSON.stringify(data)
+});
+export const createCosTemplateFromTask = (task, templateName) => request('/cos/templates/from-task', {
+  method: 'POST',
+  body: JSON.stringify({ task, templateName })
+});
+export const useCosTaskTemplate = (id) => request(`/cos/templates/${id}/use`, { method: 'POST' });
+export const updateCosTaskTemplate = (id, data) => request(`/cos/templates/${id}`, {
+  method: 'PUT',
+  body: JSON.stringify(data)
+});
+export const deleteCosTaskTemplate = (id) => request(`/cos/templates/${id}`, { method: 'DELETE' });
+
 // CoS Scripts
 export const getCosScripts = () => request('/cos/scripts');
 export const getCosScript = (id) => request(`/cos/scripts/${id}`);

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -461,6 +461,23 @@ export const addCosScheduleTemplate = (template) => request('/cos/schedule/templ
 });
 export const deleteCosScheduleTemplate = (templateId) => request(`/cos/schedule/templates/${templateId}`, { method: 'DELETE' });
 
+// Autonomous Jobs
+export const getCosJobs = () => request('/cos/jobs');
+export const getCosJobsDue = () => request('/cos/jobs/due');
+export const getCosJobIntervals = () => request('/cos/jobs/intervals');
+export const getCosJob = (id) => request(`/cos/jobs/${id}`);
+export const createCosJob = (data) => request('/cos/jobs', {
+  method: 'POST',
+  body: JSON.stringify(data)
+});
+export const updateCosJob = (id, data) => request(`/cos/jobs/${id}`, {
+  method: 'PUT',
+  body: JSON.stringify(data)
+});
+export const toggleCosJob = (id) => request(`/cos/jobs/${id}/toggle`, { method: 'POST' });
+export const triggerCosJob = (id) => request(`/cos/jobs/${id}/trigger`, { method: 'POST' });
+export const deleteCosJob = (id) => request(`/cos/jobs/${id}`, { method: 'DELETE' });
+
 // Memory
 export const getMemories = (options = {}) => {
   const params = new URLSearchParams();

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -739,9 +739,9 @@ export const getDigitalTwinEnrichCategories = () => request('/digital-twin/enric
 export const getSoulEnrichCategories = getDigitalTwinEnrichCategories;
 export const getDigitalTwinEnrichProgress = () => request('/digital-twin/enrich/progress');
 export const getSoulEnrichProgress = getDigitalTwinEnrichProgress;
-export const getDigitalTwinEnrichQuestion = (category, providerOverride, modelOverride) => request('/digital-twin/enrich/question', {
+export const getDigitalTwinEnrichQuestion = (category, providerOverride, modelOverride, skipIndices) => request('/digital-twin/enrich/question', {
   method: 'POST',
-  body: JSON.stringify({ category, providerOverride, modelOverride })
+  body: JSON.stringify({ category, providerOverride, modelOverride, ...(skipIndices?.length ? { skipIndices } : {}) })
 });
 export const getSoulEnrichQuestion = getDigitalTwinEnrichQuestion;
 export const submitDigitalTwinEnrichAnswer = (data) => request('/digital-twin/enrich/answer', {
@@ -824,6 +824,13 @@ export const saveDigitalTwinImport = (source, suggestedDoc) => request('/digital
   method: 'POST',
   body: JSON.stringify({ source, suggestedDoc })
 });
+
+// Digital Twin - Assessment Analyzer
+export const analyzeAssessment = (content, providerId, model) =>
+  request('/digital-twin/interview/analyze', {
+    method: 'POST',
+    body: JSON.stringify({ content, providerId, model })
+  });
 
 // Digital Twin - Social Accounts
 export const getSocialAccounts = (params = {}) => {

--- a/data.sample/apps.json
+++ b/data.sample/apps.json
@@ -1,25 +1,61 @@
 {
   "apps": {
-    "portos-autofixer": {
-      "id": "portos-autofixer",
-      "name": "PortOS Autofixer",
-      "description": "Autonomous PM2 crash detection and repair using Claude CLI",
-      "repoPath": "/path/to/PortOS",
+    "portos-default": {
+      "id": "portos-default",
+      "name": "PortOS",
+      "description": "Local App OS portal for dev machines",
+      "repoPath": "__PORTOS_ROOT__",
       "type": "express",
-      "uiPort": 5560,
-      "apiPort": null,
+      "uiPort": 5555,
+      "apiPort": 5554,
       "startCommands": [
-        "pm2 start ecosystem.config.cjs --only portos-autofixer,portos-autofixer-ui"
+        "npm run dev"
       ],
       "pm2ProcessNames": [
+        "portos-server",
+        "portos-cos",
+        "portos-ui",
         "portos-autofixer",
-        "portos-autofixer-ui"
+        "portos-autofixer-ui",
+        "portos-browser"
       ],
-      "envFile": null,
-      "icon": null,
+      "envFile": ".env",
+      "icon": "portos",
       "editorCommand": "code .",
       "createdAt": "2024-01-01T00:00:00.000Z",
-      "updatedAt": "2024-01-01T00:00:00.000Z"
+      "updatedAt": "2024-01-01T00:00:00.000Z",
+      "processes": [
+        {
+          "name": "portos-server",
+          "port": 5554,
+          "ports": { "api": 5554 }
+        },
+        {
+          "name": "portos-cos",
+          "port": 5558,
+          "ports": { "api": 5558 }
+        },
+        {
+          "name": "portos-ui",
+          "port": 5555,
+          "ports": { "ui": 5555 }
+        },
+        {
+          "name": "portos-autofixer",
+          "port": 5559,
+          "ports": { "api": 5559 }
+        },
+        {
+          "name": "portos-autofixer-ui",
+          "port": 5560,
+          "ports": { "ui": 5560 }
+        },
+        {
+          "name": "portos-browser",
+          "port": 5556,
+          "ports": { "cdp": 5556, "health": 5557 }
+        }
+      ]
     },
     "example-app-1": {
       "id": "example-app-1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.5",
+      "version": "0.11.6",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.5",
+      "version": "0.11.6",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.5",
+      "version": "0.11.6",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.11",
+      "version": "0.11.12",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.11",
+      "version": "0.11.12",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.11",
+      "version": "0.11.12",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.15",
+      "version": "0.11.16",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.15",
+      "version": "0.11.16",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.15",
+      "version": "0.11.16",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.10",
+      "version": "0.11.11",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.10",
+      "version": "0.11.11",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.10",
+      "version": "0.11.11",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.3",
+      "version": "0.11.4",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.13",
+      "version": "0.11.14",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.13",
+      "version": "0.11.14",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.13",
+      "version": "0.11.14",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.16",
+      "version": "0.11.17",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.16",
+      "version": "0.11.17",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.16",
+      "version": "0.11.17",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.8",
+      "version": "0.11.9",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.8",
+      "version": "0.11.9",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.8",
+      "version": "0.11.9",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.10.29",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.10.29",
+      "version": "0.11.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.10.29",
+      "version": "0.11.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7344,7 +7344,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.10.29",
+      "version": "0.11.0",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.14",
+  "version": "0.11.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.14",
+      "version": "0.11.15",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.14",
+      "version": "0.11.15",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.14",
+      "version": "0.11.15",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.12",
+      "version": "0.11.13",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.12",
+      "version": "0.11.13",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.12",
+      "version": "0.11.13",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "dependencies": {
         "express": "^5.2.1",
-        "portos-ai-toolkit": "github:atomantic/portos-ai-toolkit#v0.2.0"
+        "portos-ai-toolkit": "github:atomantic/portos-ai-toolkit#ac13168156f81c90dab57702c0de3f97de7970a9"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.4",
@@ -5099,8 +5099,9 @@
       }
     },
     "node_modules/portos-ai-toolkit": {
-      "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/atomantic/portos-ai-toolkit.git#54c33f88be85b1fa301c5ccb4ca099bfda4199e2",
+      "version": "0.4.0",
+      "resolved": "git+ssh://git@github.com/atomantic/portos-ai-toolkit.git#ac13168156f81c90dab57702c0de3f97de7970a9",
+      "integrity": "sha512-X4bf0poJ87XklYGeaIO5W37dqK0ODBGrKbUjGnG3Eut8WOiQyP2azWtiXQJTaHZK33pp/7rS7T+S2frNzPLoFA==",
       "license": "MIT",
       "dependencies": {
         "uuid": "^11.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.7",
+      "version": "0.11.8",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.7",
+      "version": "0.11.8",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.7",
+      "version": "0.11.8",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.6",
+      "version": "0.11.7",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.6",
+      "version": "0.11.7",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.6",
+      "version": "0.11.7",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.4",
+      "version": "0.11.5",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.2",
+      "version": "0.11.3",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.11.9",
+      "version": "0.11.10",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.11.9",
+      "version": "0.11.10",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -7345,7 +7345,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.11.9",
+      "version": "0.11.10",
       "dependencies": {
         "cors": "^2.8.5",
         "express": "^4.21.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,6 @@
   },
   "dependencies": {
     "express": "^5.2.1",
-    "portos-ai-toolkit": "github:atomantic/portos-ai-toolkit#v0.2.0"
+    "portos-ai-toolkit": "github:atomantic/portos-ai-toolkit#ac13168156f81c90dab57702c0de3f97de7970a9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.10.29",
+  "version": "0.11.0",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.14",
+  "version": "0.11.15",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/scripts/setup-data.js
+++ b/scripts/setup-data.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { existsSync, mkdirSync, cpSync, readdirSync, statSync } from 'fs';
+import { existsSync, mkdirSync, cpSync, readdirSync, statSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
@@ -14,6 +14,17 @@ if (!existsSync(dataDir)) {
   console.log('📁 Creating data directory from data.sample...');
   mkdirSync(dataDir, { recursive: true });
   cpSync(sampleDir, dataDir, { recursive: true });
+
+  // Replace __PORTOS_ROOT__ placeholder with actual install path in apps.json
+  const appsFile = join(dataDir, 'apps.json');
+  if (existsSync(appsFile)) {
+    const content = readFileSync(appsFile, 'utf8');
+    if (content.includes('__PORTOS_ROOT__')) {
+      writeFileSync(appsFile, content.replace(/__PORTOS_ROOT__/g, rootDir));
+      console.log(`📍 Set PortOS repoPath to ${rootDir}`);
+    }
+  }
+
   console.log('✅ Data directory created');
 } else {
   // Ensure all subdirectories exist without overwriting existing files

--- a/server/cos-runner/index.js
+++ b/server/cos-runner/index.js
@@ -152,12 +152,14 @@ function createStreamJsonParser() {
         if (event?.type === 'content_block_stop') {
           const idx = event.index;
           const tool = activeTools.get(idx);
-          if (tool && tool.inputJson) {
-            const input = safeParse(tool.inputJson);
-            if (input) {
-              const detail = summarizeToolInput(tool.name, input);
-              if (detail) {
-                lines.push(`  → ${detail}`);
+          if (tool) {
+            if (tool.inputJson) {
+              const input = safeParse(tool.inputJson);
+              if (input) {
+                const detail = summarizeToolInput(tool.name, input);
+                if (detail) {
+                  lines.push(`  → ${detail}`);
+                }
               }
             }
             activeTools.delete(idx);

--- a/server/index.js
+++ b/server/index.js
@@ -128,6 +128,12 @@ setProvidersToolkit(aiToolkit);
 setRunnerToolkit(aiToolkit);
 setPromptsToolkit(aiToolkit);
 
+// Patch toolkit's runner to fix shell security issue (DEP0190)
+// Override executeCliRun to remove 'shell: true' which causes security warnings
+import { executeCliRun as executeCliRunFixed } from './services/runner.js';
+aiToolkit.services.runner.executeCliRun = executeCliRunFixed;
+console.log('🔧 Patched aiToolkit runner.executeCliRun to fix shell security issue');
+
 // Note: prompts service is initialized automatically by createAIToolkit()
 
 // Initialize auto-fixer for error recovery

--- a/server/lib/brainValidation.js
+++ b/server/lib/brainValidation.js
@@ -10,7 +10,7 @@ export const projectStatusEnum = z.enum(['active', 'waiting', 'blocked', 'someda
 export const adminStatusEnum = z.enum(['open', 'waiting', 'done']);
 
 // Inbox log status enum
-export const inboxStatusEnum = z.enum(['filed', 'needs_review', 'corrected', 'error']);
+export const inboxStatusEnum = z.enum(['classifying', 'filed', 'needs_review', 'corrected', 'error']);
 
 // AI configuration schema
 export const aiConfigSchema = z.object({

--- a/server/lib/digitalTwinValidation.js
+++ b/server/lib/digitalTwinValidation.js
@@ -207,7 +207,7 @@ export const enrichmentQuestionInputSchema = z.object({
   category: enrichmentCategoryEnum,
   providerOverride: z.string().optional(),
   modelOverride: z.string().optional(),
-  skipIndices: z.array(z.number().int().min(0)).optional()
+  skipIndices: z.array(z.number().int()).optional()
 });
 
 // Enrichment answer input
@@ -225,6 +225,9 @@ export const enrichmentAnswerInputSchema = z.object({
   data => (data.questionType === 'text' && data.answer) ||
           (data.questionType === 'scale' && data.scaleValue != null),
   { message: 'Text questions require answer; scale questions require scaleValue' }
+).refine(
+  data => data.questionType !== 'scale' || data.scaleQuestionId,
+  { message: 'Scale questions require scaleQuestionId' }
 );
 
 // Export input

--- a/server/lib/digitalTwinValidation.js
+++ b/server/lib/digitalTwinValidation.js
@@ -206,7 +206,8 @@ export const runMultiTestsInputSchema = z.object({
 export const enrichmentQuestionInputSchema = z.object({
   category: enrichmentCategoryEnum,
   providerOverride: z.string().optional(),
-  modelOverride: z.string().optional()
+  modelOverride: z.string().optional(),
+  skipIndices: z.array(z.number().int().min(0)).optional()
 });
 
 // Enrichment answer input

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.15",
+  "version": "0.11.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.5",
+  "version": "0.11.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.16",
+  "version": "0.11.17",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.11",
+  "version": "0.11.12",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.10",
+  "version": "0.11.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.9",
+  "version": "0.11.10",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.10.29",
+  "version": "0.11.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.14",
+  "version": "0.11.15",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.6",
+  "version": "0.11.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.7",
+  "version": "0.11.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.13",
+  "version": "0.11.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.3",
+  "version": "0.11.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.12",
+  "version": "0.11.13",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -734,6 +734,7 @@ router.post('/jobs/:id/trigger', asyncHandler(async (req, res) => {
   }
 
   // Generate task and add to CoS internal task queue
+  // Job execution is recorded via the job:spawned event when the agent actually starts
   const task = autonomousJobs.generateTaskFromJob(job);
   const result = await cos.addTask({
     description: task.description,
@@ -741,7 +742,6 @@ router.post('/jobs/:id/trigger', asyncHandler(async (req, res) => {
     context: `Manually triggered autonomous job: ${job.name}`,
     approvalRequired: !task.autoApprove
   }, 'internal');
-  await autonomousJobs.recordJobExecution(job.id);
 
   res.json({ success: true, task: result });
 }));

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -733,14 +733,14 @@ router.post('/jobs/:id/trigger', asyncHandler(async (req, res) => {
     throw new ServerError('Job not found', { status: 404, code: 'NOT_FOUND' });
   }
 
-  // Generate task and add to CoS task queue
+  // Generate task and add to CoS internal task queue
   const task = autonomousJobs.generateTaskFromJob(job);
   const result = await cos.addTask({
     description: task.description,
     priority: task.priority,
     context: `Manually triggered autonomous job: ${job.name}`,
-    ...task.metadata
-  }, 'cos');
+    approvalRequired: !task.autoApprove
+  }, 'internal');
   await autonomousJobs.recordJobExecution(job.id);
 
   res.json({ success: true, task: result });

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -10,6 +10,7 @@ import * as taskLearning from '../services/taskLearning.js';
 import * as weeklyDigest from '../services/weeklyDigest.js';
 import * as taskSchedule from '../services/taskSchedule.js';
 import * as autonomousJobs from '../services/autonomousJobs.js';
+import * as taskTemplates from '../services/taskTemplates.js';
 import { enhanceTaskPrompt } from '../services/taskEnhancer.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 
@@ -752,6 +753,79 @@ router.delete('/jobs/:id', asyncHandler(async (req, res) => {
     throw new ServerError('Job not found', { status: 404, code: 'NOT_FOUND' });
   }
   res.json({ success: true });
+}));
+
+// ============================================================
+// Quick Task Templates Routes
+// ============================================================
+
+// GET /api/cos/templates - Get all task templates
+router.get('/templates', asyncHandler(async (req, res) => {
+  const templates = await taskTemplates.getAllTemplates();
+  res.json({ templates });
+}));
+
+// GET /api/cos/templates/popular - Get popular templates
+router.get('/templates/popular', asyncHandler(async (req, res) => {
+  const limit = parseInt(req.query.limit, 10) || 5;
+  const templates = await taskTemplates.getPopularTemplates(limit);
+  res.json({ templates });
+}));
+
+// GET /api/cos/templates/categories - Get template categories
+router.get('/templates/categories', asyncHandler(async (req, res) => {
+  const categories = await taskTemplates.getCategories();
+  res.json({ categories });
+}));
+
+// POST /api/cos/templates - Create a new template
+router.post('/templates', asyncHandler(async (req, res) => {
+  const { name, icon, description, context, category, provider, model, app } = req.body;
+
+  if (!name || !description) {
+    throw new ServerError('name and description are required', { status: 400, code: 'VALIDATION_ERROR' });
+  }
+
+  const template = await taskTemplates.createTemplate({
+    name, icon, description, context, category, provider, model, app
+  });
+  res.json({ success: true, template });
+}));
+
+// POST /api/cos/templates/from-task - Create template from task
+router.post('/templates/from-task', asyncHandler(async (req, res) => {
+  const { task, templateName } = req.body;
+
+  if (!task || !task.description) {
+    throw new ServerError('task with description is required', { status: 400, code: 'VALIDATION_ERROR' });
+  }
+
+  const template = await taskTemplates.createTemplateFromTask(task, templateName);
+  res.json({ success: true, template });
+}));
+
+// POST /api/cos/templates/:id/use - Record template usage
+router.post('/templates/:id/use', asyncHandler(async (req, res) => {
+  const useCount = await taskTemplates.recordTemplateUsage(req.params.id);
+  res.json({ success: true, useCount });
+}));
+
+// PUT /api/cos/templates/:id - Update a template
+router.put('/templates/:id', asyncHandler(async (req, res) => {
+  const result = await taskTemplates.updateTemplate(req.params.id, req.body);
+  if (result.error) {
+    throw new ServerError(result.error, { status: 400, code: 'BAD_REQUEST' });
+  }
+  res.json({ success: true, template: result });
+}));
+
+// DELETE /api/cos/templates/:id - Delete a template
+router.delete('/templates/:id', asyncHandler(async (req, res) => {
+  const result = await taskTemplates.deleteTemplate(req.params.id);
+  if (result.error) {
+    throw new ServerError(result.error, { status: 400, code: 'BAD_REQUEST' });
+  }
+  res.json(result);
 }));
 
 export default router;

--- a/server/routes/providers.js
+++ b/server/routes/providers.js
@@ -10,16 +10,40 @@ import { getAllProviderStatuses, getProviderStatus, markProviderAvailable, getTi
 export function createPortOSProviderRoutes(aiToolkit) {
   const router = Router();
 
-  // Mount all base toolkit routes
-  router.use('/', aiToolkit.routes.providers);
+  // Provider status routes MUST be defined before toolkit routes,
+  // because the toolkit has a GET /:id route that would catch /status
+  router.get('/status', asyncHandler(async (req, res) => {
+    const statuses = getAllProviderStatuses();
+    // Enrich with time until recovery
+    const enriched = { ...statuses };
+    for (const [providerId, status] of Object.entries(enriched.providers)) {
+      enriched.providers[providerId] = {
+        ...status,
+        timeUntilRecovery: getTimeUntilRecovery(providerId)
+      };
+    }
+    res.json(enriched);
+  }));
 
-  // PortOS-specific extension: Vision health check
+  router.get('/:id/status', asyncHandler(async (req, res) => {
+    const status = getProviderStatus(req.params.id);
+    res.json({
+      ...status,
+      timeUntilRecovery: getTimeUntilRecovery(req.params.id)
+    });
+  }));
+
+  router.post('/:id/status/recover', asyncHandler(async (req, res) => {
+    const status = await markProviderAvailable(req.params.id);
+    res.json({ success: true, status });
+  }));
+
+  // PortOS-specific extensions (parameterized routes before toolkit mount)
   router.get('/:id/vision-health', asyncHandler(async (req, res) => {
     const result = await checkVisionHealth(req.params.id);
     res.json(result);
   }));
 
-  // PortOS-specific extension: Test vision with specific image
   router.post('/:id/test-vision', asyncHandler(async (req, res) => {
     const { imagePath, prompt, expectedContent, model } = req.body;
 
@@ -38,41 +62,14 @@ export function createPortOSProviderRoutes(aiToolkit) {
     res.json(result);
   }));
 
-  // PortOS-specific extension: Run full vision test suite
   router.post('/:id/vision-suite', asyncHandler(async (req, res) => {
     const { model } = req.body;
     const result = await runVisionTestSuite(req.params.id, model);
     res.json(result);
   }));
 
-  // Provider status: Get all provider statuses (usage limits, availability)
-  router.get('/status', asyncHandler(async (req, res) => {
-    const statuses = getAllProviderStatuses();
-    // Enrich with time until recovery
-    const enriched = { ...statuses };
-    for (const [providerId, status] of Object.entries(enriched.providers)) {
-      enriched.providers[providerId] = {
-        ...status,
-        timeUntilRecovery: getTimeUntilRecovery(providerId)
-      };
-    }
-    res.json(enriched);
-  }));
-
-  // Provider status: Get single provider status
-  router.get('/:id/status', asyncHandler(async (req, res) => {
-    const status = getProviderStatus(req.params.id);
-    res.json({
-      ...status,
-      timeUntilRecovery: getTimeUntilRecovery(req.params.id)
-    });
-  }));
-
-  // Provider status: Manually mark provider as available (recovery)
-  router.post('/:id/status/recover', asyncHandler(async (req, res) => {
-    const status = await markProviderAvailable(req.params.id);
-    res.json({ success: true, status });
-  }));
+  // Mount base toolkit routes last (its /:id route would shadow our /status route)
+  router.use('/', aiToolkit.routes.providers);
 
   return router;
 }

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -50,8 +50,6 @@ const DEFAULT_JOBS = [
 
 You are acting as my Chief of Staff, maintaining my GitHub repositories.
 
-My GitHub username is: atomantic
-
 Tasks to perform:
 1. Check my local git repositories for uncommitted changes or stale branches
 2. Look for repositories that haven't been updated recently

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -1,0 +1,534 @@
+/**
+ * Autonomous Jobs Service
+ *
+ * Manages recurring scheduled jobs that the CoS executes proactively
+ * on behalf of the user, using their digital twin identity to make decisions.
+ *
+ * Jobs are different from tasks:
+ * - Tasks are one-shot work items (TASKS.md)
+ * - Jobs are recurring schedules that generate tasks when due
+ *
+ * Job types:
+ * - git-maintenance: Maintain user's git repositories
+ * - brain-processing: Process and act on brain ideas/inbox
+ * - Custom user-defined jobs
+ */
+
+import { promises as fs } from 'fs'
+import { existsSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { v4 as uuidv4 } from 'uuid'
+import { cosEvents } from './cosEvents.js'
+import { readJSONFile } from '../lib/fileUtils.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const DATA_DIR = path.join(__dirname, '../../data/cos')
+const JOBS_FILE = path.join(DATA_DIR, 'autonomous-jobs.json')
+
+// Time constants
+const HOUR = 60 * 60 * 1000
+const DAY = 24 * HOUR
+const WEEK = 7 * DAY
+
+/**
+ * Default job definitions
+ */
+const DEFAULT_JOBS = [
+  {
+    id: 'job-git-maintenance',
+    name: 'Git Repository Maintenance',
+    description: 'Review and maintain my open source repositories on GitHub. Check for stale issues, outdated dependencies, and merge-worthy PRs.',
+    category: 'git-maintenance',
+    interval: 'weekly',
+    intervalMs: WEEK,
+    enabled: false,
+    priority: 'MEDIUM',
+    autonomyLevel: 'manager',
+    promptTemplate: `[Autonomous Job] Git Repository Maintenance
+
+You are acting as my Chief of Staff, maintaining my GitHub repositories.
+
+My GitHub username is: atomantic
+
+Tasks to perform:
+1. Check my local git repositories for uncommitted changes or stale branches
+2. Look for repositories that haven't been updated recently
+3. Review any obvious maintenance needs (outdated README, missing license, etc.)
+4. If there are simple cleanups to make, create tasks for them
+
+Focus on practical, actionable maintenance. Don't make changes directly — create CoS tasks for anything that needs doing.
+
+Report a summary of the repository health status when done.`,
+    lastRun: null,
+    runCount: 0,
+    createdAt: null,
+    updatedAt: null
+  },
+  {
+    id: 'job-brain-processing',
+    name: 'Brain Inbox Processing',
+    description: 'Review brain inbox items that need attention, process ideas into actionable tasks, and surface patterns.',
+    category: 'brain-processing',
+    interval: 'daily',
+    intervalMs: DAY,
+    enabled: false,
+    priority: 'MEDIUM',
+    autonomyLevel: 'manager',
+    promptTemplate: `[Autonomous Job] Brain Inbox Processing
+
+You are acting as my Chief of Staff, processing my brain inbox.
+
+Tasks to perform:
+1. Call GET /api/brain/inbox?status=needs_review to find items needing review
+2. Call GET /api/brain/summary to understand the current brain state
+3. For items in needs_review status, analyze the content and suggest classifications
+4. Look for patterns across recent brain captures — recurring themes, related ideas
+5. For high-value ideas that could become projects, create CoS tasks to explore them
+6. Generate a brief summary of insights from the brain inbox
+
+Focus on surfacing actionable insights. Don't just classify — think about what these ideas mean and how they connect.`,
+    lastRun: null,
+    runCount: 0,
+    createdAt: null,
+    updatedAt: null
+  },
+  {
+    id: 'job-daily-briefing',
+    name: 'Daily Briefing',
+    description: 'Generate a morning briefing with task priorities, calendar awareness, and proactive suggestions.',
+    category: 'daily-briefing',
+    interval: 'daily',
+    intervalMs: DAY,
+    enabled: false,
+    priority: 'LOW',
+    autonomyLevel: 'assistant',
+    promptTemplate: `[Autonomous Job] Daily Briefing
+
+You are acting as my Chief of Staff, preparing a daily briefing.
+
+Tasks to perform:
+1. Review pending user tasks (GET /api/cos/tasks/user) and summarize priorities
+2. Check brain digest (GET /api/brain/digest/latest) for recent thought patterns
+3. Review CoS learning insights (GET /api/cos/learning/insights) for system health
+4. Check which agents completed work recently (GET /api/cos/agents)
+5. Suggest 2-3 focus areas for today based on open tasks and recent activity
+
+Write the briefing in a concise, actionable format. Save it as a CoS report.`,
+    lastRun: null,
+    runCount: 0,
+    createdAt: null,
+    updatedAt: null
+  },
+  {
+    id: 'job-project-review',
+    name: 'Brain Project Review',
+    description: 'Review active brain projects, check progress, suggest next actions, and identify stalled projects.',
+    category: 'project-review',
+    interval: 'weekly',
+    intervalMs: WEEK,
+    enabled: false,
+    priority: 'LOW',
+    autonomyLevel: 'assistant',
+    promptTemplate: `[Autonomous Job] Brain Project Review
+
+You are acting as my Chief of Staff, reviewing active projects from my brain.
+
+Tasks to perform:
+1. Call GET /api/brain/projects to get all active projects
+2. For each active project:
+   - Assess if the next action is still relevant
+   - Check if there are related brain captures since last review
+   - Suggest updated next actions if stale
+3. Identify projects that might be stalled (no activity in 2+ weeks)
+4. Look for connections between projects that could be leveraged
+5. For any actionable suggestions, create CoS tasks
+
+Report a project health summary when done.`,
+    lastRun: null,
+    runCount: 0,
+    createdAt: null,
+    updatedAt: null
+  }
+]
+
+/**
+ * Ensure data directory exists
+ */
+async function ensureDataDir() {
+  if (!existsSync(DATA_DIR)) {
+    await fs.mkdir(DATA_DIR, { recursive: true })
+  }
+}
+
+/**
+ * Load jobs from disk
+ * @returns {Promise<Object>} Jobs data
+ */
+async function loadJobs() {
+  await ensureDataDir()
+
+  const loaded = await readJSONFile(JOBS_FILE, null)
+  if (!loaded) {
+    const initial = createDefaultJobsData()
+    await saveJobs(initial)
+    return initial
+  }
+
+  // Merge with defaults to ensure all default jobs exist
+  const merged = mergeWithDefaults(loaded)
+  return merged
+}
+
+/**
+ * Create initial jobs data with defaults
+ */
+function createDefaultJobsData() {
+  const now = new Date().toISOString()
+  return {
+    version: 1,
+    lastUpdated: now,
+    jobs: DEFAULT_JOBS.map(j => ({
+      ...j,
+      createdAt: now,
+      updatedAt: now
+    }))
+  }
+}
+
+/**
+ * Merge loaded data with defaults (add any missing default jobs)
+ */
+function mergeWithDefaults(loaded) {
+  const existingIds = new Set(loaded.jobs.map(j => j.id))
+  const now = new Date().toISOString()
+
+  for (const defaultJob of DEFAULT_JOBS) {
+    if (!existingIds.has(defaultJob.id)) {
+      loaded.jobs.push({
+        ...defaultJob,
+        createdAt: now,
+        updatedAt: now
+      })
+    }
+  }
+
+  return loaded
+}
+
+/**
+ * Save jobs to disk
+ */
+async function saveJobs(data) {
+  await ensureDataDir()
+  data.lastUpdated = new Date().toISOString()
+  await fs.writeFile(JOBS_FILE, JSON.stringify(data, null, 2))
+}
+
+/**
+ * Get all jobs
+ * @returns {Promise<Array>} All jobs
+ */
+async function getAllJobs() {
+  const data = await loadJobs()
+  return data.jobs
+}
+
+/**
+ * Get a single job by ID
+ * @param {string} jobId
+ * @returns {Promise<Object|null>}
+ */
+async function getJob(jobId) {
+  const data = await loadJobs()
+  return data.jobs.find(j => j.id === jobId) || null
+}
+
+/**
+ * Get enabled jobs
+ * @returns {Promise<Array>} Enabled jobs
+ */
+async function getEnabledJobs() {
+  const data = await loadJobs()
+  return data.jobs.filter(j => j.enabled)
+}
+
+/**
+ * Get jobs that are due to run
+ * @returns {Promise<Array>} Due jobs with reason
+ */
+async function getDueJobs() {
+  const enabledJobs = await getEnabledJobs()
+  const now = Date.now()
+  const due = []
+
+  for (const job of enabledJobs) {
+    const lastRun = job.lastRun ? new Date(job.lastRun).getTime() : 0
+    const timeSinceLastRun = now - lastRun
+
+    if (timeSinceLastRun >= job.intervalMs) {
+      due.push({
+        ...job,
+        reason: job.lastRun ? `${job.interval}-due` : 'never-run',
+        overdueBy: timeSinceLastRun - job.intervalMs
+      })
+    }
+  }
+
+  // Sort by overdue time (most overdue first)
+  due.sort((a, b) => b.overdueBy - a.overdueBy)
+
+  return due
+}
+
+/**
+ * Create a new job
+ * @param {Object} jobData
+ * @returns {Promise<Object>} Created job
+ */
+async function createJob(jobData) {
+  const data = await loadJobs()
+  const now = new Date().toISOString()
+
+  const job = {
+    id: jobData.id || `job-${uuidv4().slice(0, 8)}`,
+    name: jobData.name,
+    description: jobData.description || '',
+    category: jobData.category || 'custom',
+    interval: jobData.interval || 'weekly',
+    intervalMs: resolveIntervalMs(jobData.interval, jobData.intervalMs),
+    enabled: jobData.enabled !== undefined ? jobData.enabled : false,
+    priority: jobData.priority || 'MEDIUM',
+    autonomyLevel: jobData.autonomyLevel || 'manager',
+    promptTemplate: jobData.promptTemplate || '',
+    lastRun: null,
+    runCount: 0,
+    createdAt: now,
+    updatedAt: now
+  }
+
+  data.jobs.push(job)
+  await saveJobs(data)
+
+  console.log(`🤖 Autonomous job created: ${job.name}`)
+  cosEvents.emit('jobs:created', { id: job.id, name: job.name })
+
+  return job
+}
+
+/**
+ * Update an existing job
+ * @param {string} jobId
+ * @param {Object} updates
+ * @returns {Promise<Object|null>} Updated job or null
+ */
+async function updateJob(jobId, updates) {
+  const data = await loadJobs()
+  const job = data.jobs.find(j => j.id === jobId)
+  if (!job) return null
+
+  const updatableFields = [
+    'name', 'description', 'category', 'interval', 'intervalMs',
+    'enabled', 'priority', 'autonomyLevel', 'promptTemplate'
+  ]
+
+  for (const field of updatableFields) {
+    if (updates[field] !== undefined) {
+      job[field] = updates[field]
+    }
+  }
+
+  // Recalculate intervalMs if interval changed
+  if (updates.interval) {
+    job.intervalMs = resolveIntervalMs(updates.interval, updates.intervalMs)
+  }
+
+  job.updatedAt = new Date().toISOString()
+  await saveJobs(data)
+
+  console.log(`🤖 Autonomous job updated: ${job.name}`)
+  cosEvents.emit('jobs:updated', { id: job.id, updates })
+
+  return job
+}
+
+/**
+ * Delete a job
+ * @param {string} jobId
+ * @returns {Promise<boolean>}
+ */
+async function deleteJob(jobId) {
+  const data = await loadJobs()
+  const idx = data.jobs.findIndex(j => j.id === jobId)
+  if (idx === -1) return false
+
+  const deleted = data.jobs.splice(idx, 1)[0]
+  await saveJobs(data)
+
+  console.log(`🗑️ Autonomous job deleted: ${deleted.name}`)
+  cosEvents.emit('jobs:deleted', { id: jobId })
+
+  return true
+}
+
+/**
+ * Record a job execution
+ * @param {string} jobId
+ * @returns {Promise<Object|null>} Updated job
+ */
+async function recordJobExecution(jobId) {
+  const data = await loadJobs()
+  const job = data.jobs.find(j => j.id === jobId)
+  if (!job) return null
+
+  job.lastRun = new Date().toISOString()
+  job.runCount = (job.runCount || 0) + 1
+  job.updatedAt = job.lastRun
+
+  await saveJobs(data)
+
+  console.log(`🤖 Job executed: ${job.name} (run #${job.runCount})`)
+  cosEvents.emit('jobs:executed', { id: jobId, runCount: job.runCount })
+
+  return job
+}
+
+/**
+ * Toggle a job's enabled state
+ * @param {string} jobId
+ * @returns {Promise<Object|null>}
+ */
+async function toggleJob(jobId) {
+  const data = await loadJobs()
+  const job = data.jobs.find(j => j.id === jobId)
+  if (!job) return null
+
+  job.enabled = !job.enabled
+  job.updatedAt = new Date().toISOString()
+
+  await saveJobs(data)
+
+  const stateLabel = job.enabled ? 'enabled' : 'disabled'
+  console.log(`🤖 Autonomous job ${stateLabel}: ${job.name}`)
+  cosEvents.emit('jobs:toggled', { id: jobId, enabled: job.enabled })
+
+  return job
+}
+
+/**
+ * Generate a CoS task from a due job
+ * @param {Object} job - The job to generate a task for
+ * @returns {Object} Task data suitable for cos.addTask()
+ */
+function generateTaskFromJob(job) {
+  return {
+    id: `${job.id}-${Date.now().toString(36)}`,
+    description: job.promptTemplate,
+    priority: job.priority,
+    metadata: {
+      autonomousJob: true,
+      jobId: job.id,
+      jobName: job.name,
+      jobCategory: job.category,
+      autonomyLevel: job.autonomyLevel
+    },
+    taskType: 'internal',
+    autoApprove: job.autonomyLevel === 'yolo'
+  }
+}
+
+/**
+ * Get job statistics
+ * @returns {Promise<Object>}
+ */
+async function getJobStats() {
+  const jobs = await getAllJobs()
+
+  return {
+    total: jobs.length,
+    enabled: jobs.filter(j => j.enabled).length,
+    disabled: jobs.filter(j => !j.enabled).length,
+    byCategory: jobs.reduce((acc, j) => {
+      acc[j.category] = (acc[j.category] || 0) + 1
+      return acc
+    }, {}),
+    totalRuns: jobs.reduce((sum, j) => sum + (j.runCount || 0), 0),
+    nextDue: await getNextDueJob()
+  }
+}
+
+/**
+ * Get the next job that will be due
+ * @returns {Promise<Object|null>}
+ */
+async function getNextDueJob() {
+  const enabledJobs = await getEnabledJobs()
+  if (enabledJobs.length === 0) return null
+
+  let earliest = null
+  let earliestTime = Infinity
+
+  for (const job of enabledJobs) {
+    const lastRun = job.lastRun ? new Date(job.lastRun).getTime() : 0
+    const nextDue = lastRun + job.intervalMs
+
+    if (nextDue < earliestTime) {
+      earliestTime = nextDue
+      earliest = {
+        jobId: job.id,
+        jobName: job.name,
+        nextDueAt: new Date(nextDue).toISOString(),
+        isDue: Date.now() >= nextDue
+      }
+    }
+  }
+
+  return earliest
+}
+
+/**
+ * Resolve interval string to milliseconds
+ */
+function resolveIntervalMs(interval, customMs) {
+  switch (interval) {
+    case 'hourly': return HOUR
+    case 'every-4-hours': return 4 * HOUR
+    case 'every-8-hours': return 8 * HOUR
+    case 'daily': return DAY
+    case 'weekly': return WEEK
+    case 'biweekly': return 2 * WEEK
+    case 'monthly': return 30 * DAY
+    case 'custom': return customMs || DAY
+    default: return DAY
+  }
+}
+
+/**
+ * Available interval options for UI
+ */
+const INTERVAL_OPTIONS = [
+  { value: 'hourly', label: 'Every Hour', ms: HOUR },
+  { value: 'every-4-hours', label: 'Every 4 Hours', ms: 4 * HOUR },
+  { value: 'every-8-hours', label: 'Every 8 Hours', ms: 8 * HOUR },
+  { value: 'daily', label: 'Daily', ms: DAY },
+  { value: 'weekly', label: 'Weekly', ms: WEEK },
+  { value: 'biweekly', label: 'Every 2 Weeks', ms: 2 * WEEK },
+  { value: 'monthly', label: 'Monthly', ms: 30 * DAY }
+]
+
+export {
+  getAllJobs,
+  getJob,
+  getEnabledJobs,
+  getDueJobs,
+  createJob,
+  updateJob,
+  deleteJob,
+  recordJobExecution,
+  toggleJob,
+  generateTaskFromJob,
+  getJobStats,
+  getNextDueJob,
+  INTERVAL_OPTIONS
+}

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -295,7 +295,7 @@ async function createJob(jobData) {
     description: jobData.description || '',
     category: jobData.category || 'custom',
     interval: jobData.interval || 'weekly',
-    intervalMs: resolveIntervalMs(jobData.interval, jobData.intervalMs),
+    intervalMs: resolveIntervalMs(jobData.interval || 'weekly', jobData.intervalMs),
     enabled: jobData.enabled !== undefined ? jobData.enabled : false,
     priority: jobData.priority || 'MEDIUM',
     autonomyLevel: jobData.autonomyLevel || 'manager',

--- a/server/services/brain.js
+++ b/server/services/brain.js
@@ -10,9 +10,11 @@
 
 import { spawn } from 'child_process';
 import * as storage from './brainStorage.js';
+import { brainEvents } from './brainStorage.js';
 import { getActiveProvider, getProviderById } from './providers.js';
 import { buildPrompt } from './promptService.js';
 import { validate } from '../lib/validation.js';
+import { safeJSONParse } from '../lib/fileUtils.js';
 import {
   classifierOutputSchema,
   digestOutputSchema,
@@ -136,7 +138,31 @@ function parseJsonResponse(content) {
 }
 
 /**
+ * Safe version of parseJsonResponse that returns null instead of throwing.
+ * Used in background classification where errors can't bubble to middleware.
+ */
+function safeParseJsonResponse(content) {
+  if (!content || typeof content !== 'string') return null;
+
+  let jsonStr = content.trim();
+
+  const jsonMatch = jsonStr.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (jsonMatch) {
+    jsonStr = jsonMatch[1].trim();
+  }
+
+  const objectMatch = jsonStr.match(/\{[\s\S]*\}/);
+  if (objectMatch) {
+    jsonStr = objectMatch[0];
+  }
+
+  return safeJSONParse(jsonStr, null, { logError: true, context: 'brain-classifier' });
+}
+
+/**
  * Capture a thought and classify it
+ * Returns immediately after creating the inbox entry.
+ * AI classification runs in the background and emits a socket event on completion.
  */
 export async function captureThought(text, providerOverride, modelOverride) {
   const meta = await storage.loadMeta();
@@ -152,10 +178,25 @@ export async function captureThought(text, providerOverride, modelOverride) {
       modelId: model,
       promptTemplateId: 'brain-classifier'
     },
-    status: 'needs_review'
+    status: 'classifying'
   });
 
-  // Attempt AI classification
+  console.log(`🧠 Thought captured, classifying in background: ${inboxEntry.id}`);
+
+  // Run AI classification in background (don't await)
+  classifyInBackground(inboxEntry.id, text, meta, providerOverride, modelOverride);
+
+  return {
+    inboxLog: inboxEntry,
+    message: 'Thought captured! AI is classifying...'
+  };
+}
+
+/**
+ * Background AI classification for a captured thought.
+ * Updates the inbox entry and emits a brain:classified event when done.
+ */
+async function classifyInBackground(entryId, text, meta, providerOverride, modelOverride) {
   let classification = null;
   let aiError = null;
 
@@ -170,21 +211,24 @@ export async function captureThought(text, providerOverride, modelOverride) {
   });
 
   if (aiResponse) {
-    const parsed = parseJsonResponse(aiResponse);
-    const validationResult = classifierOutputSchema.safeParse(parsed);
-
-    if (validationResult.success) {
-      classification = validationResult.data;
+    const parsed = safeParseJsonResponse(aiResponse);
+    if (parsed) {
+      const validationResult = classifierOutputSchema.safeParse(parsed);
+      if (validationResult.success) {
+        classification = validationResult.data;
+      } else {
+        console.error(`🧠 Classification validation failed: ${JSON.stringify(validationResult.error.errors)}`);
+        aiError = new Error('Invalid classification output from AI');
+      }
     } else {
-      console.error(`🧠 Classification validation failed: ${JSON.stringify(validationResult.error.errors)}`);
-      aiError = new Error('Invalid classification output from AI');
+      aiError = new Error('Could not parse AI response as JSON');
     }
   }
 
-  // If AI failed, return entry as needs_review
+  // If AI failed, mark as needs_review
   if (!classification) {
     const errorMessage = aiError?.message || 'AI classification failed';
-    await storage.updateInboxLog(inboxEntry.id, {
+    await storage.updateInboxLog(entryId, {
       classification: {
         destination: 'unknown',
         confidence: 0,
@@ -196,31 +240,27 @@ export async function captureThought(text, providerOverride, modelOverride) {
       error: { message: errorMessage }
     });
 
-    console.log(`🧠 Capture queued for review (AI unavailable): ${inboxEntry.id}`);
-    return {
-      inboxLog: await storage.getInboxLogById(inboxEntry.id),
-      message: `Thought captured but AI unavailable. Queued for manual review.`
-    };
+    console.log(`🧠 Classification failed for ${entryId}: ${errorMessage}`);
+    brainEvents.emit('classified', { entryId, status: 'needs_review', error: errorMessage });
+    return;
   }
 
   // Check confidence threshold
   if (classification.confidence < meta.confidenceThreshold || classification.destination === 'unknown') {
-    await storage.updateInboxLog(inboxEntry.id, {
+    await storage.updateInboxLog(entryId, {
       classification,
       status: 'needs_review'
     });
 
-    console.log(`🧠 Capture needs review (low confidence ${classification.confidence}): ${inboxEntry.id}`);
-    return {
-      inboxLog: await storage.getInboxLogById(inboxEntry.id),
-      message: `Thought captured but needs review. Confidence: ${Math.round(classification.confidence * 100)}%`
-    };
+    console.log(`🧠 Low confidence (${classification.confidence}) for ${entryId}`);
+    brainEvents.emit('classified', { entryId, status: 'needs_review', confidence: classification.confidence });
+    return;
   }
 
   // File to appropriate destination
   const filedRecord = await fileToDestination(classification.destination, classification.extracted, classification.title);
 
-  await storage.updateInboxLog(inboxEntry.id, {
+  await storage.updateInboxLog(entryId, {
     classification,
     status: 'filed',
     filed: {
@@ -229,12 +269,13 @@ export async function captureThought(text, providerOverride, modelOverride) {
     }
   });
 
-  console.log(`🧠 Captured and filed to ${classification.destination}: ${filedRecord.id}`);
-  return {
-    inboxLog: await storage.getInboxLogById(inboxEntry.id),
-    filedRecord,
-    message: `Filed to ${classification.destination}: ${classification.title}`
-  };
+  console.log(`🧠 Classified and filed to ${classification.destination}: ${filedRecord.id}`);
+  brainEvents.emit('classified', {
+    entryId,
+    status: 'filed',
+    destination: classification.destination,
+    title: classification.title
+  });
 }
 
 /**

--- a/server/services/brain.js
+++ b/server/services/brain.js
@@ -184,7 +184,8 @@ export async function captureThought(text, providerOverride, modelOverride) {
   console.log(`🧠 Thought captured, classifying in background: ${inboxEntry.id}`);
 
   // Run AI classification in background (don't await)
-  classifyInBackground(inboxEntry.id, text, meta, providerOverride, modelOverride);
+  classifyInBackground(inboxEntry.id, text, meta, providerOverride, modelOverride)
+    .catch(err => console.error(`❌ Background classification failed for ${inboxEntry.id}: ${err.message}`));
 
   return {
     inboxLog: inboxEntry,

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -402,6 +402,7 @@ export async function getInboxLogCounts() {
 
   const counts = {
     total: records.length,
+    classifying: 0,
     filed: 0,
     needs_review: 0,
     corrected: 0,

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -671,7 +671,6 @@ export async function evaluateTasks() {
       if (tasksToSpawn.length >= availableSlots) break;
       const task = generateTaskFromJob(job);
       tasksToSpawn.push(task);
-      await recordJobExecution(job.id);
       emitLog('info', `Autonomous job due: ${job.name} (${job.reason})`, {
         jobId: job.id,
         category: job.category
@@ -2843,6 +2842,13 @@ async function init() {
   // When an agent completes, immediately try to dequeue the next pending task
   cosEvents.on('agent:completed', () => {
     setImmediate(() => dequeueNextTask());
+  });
+
+  // Record autonomous job execution only after the agent actually spawns
+  cosEvents.on('job:spawned', async ({ jobId }) => {
+    await recordJobExecution(jobId).catch(err =>
+      console.error(`❌ Failed to record job execution for ${jobId}: ${err.message}`)
+    );
   });
 
   const state = await loadState();

--- a/server/services/digital-twin.js
+++ b/server/services/digital-twin.js
@@ -223,6 +223,40 @@ export const ENRICHMENT_CATEGORIES = {
   }
 };
 
+// Scale questions for Likert-based trait scoring (1-5)
+export const SCALE_QUESTIONS = [
+  // Big Five — Openness (2 items)
+  { id: 'bf-o-1', text: 'I enjoy exploring new ideas and unconventional perspectives.', category: 'personality_assessments', dimension: 'openness', trait: 'O', traitPath: 'bigFive.O', direction: 1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  { id: 'bf-o-2', text: 'I prefer familiar routines over trying something new.', category: 'personality_assessments', dimension: 'openness', trait: 'O', traitPath: 'bigFive.O', direction: -1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  // Big Five — Conscientiousness (2 items)
+  { id: 'bf-c-1', text: 'I keep a detailed plan and follow through on commitments.', category: 'personality_assessments', dimension: 'conscientiousness', trait: 'C', traitPath: 'bigFive.C', direction: 1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  { id: 'bf-c-2', text: 'I tend to leave things unfinished or improvise instead of planning.', category: 'personality_assessments', dimension: 'conscientiousness', trait: 'C', traitPath: 'bigFive.C', direction: -1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  // Big Five — Extraversion (2 items)
+  { id: 'bf-e-1', text: 'I feel energized after spending time with a group of people.', category: 'personality_assessments', dimension: 'extraversion', trait: 'E', traitPath: 'bigFive.E', direction: 1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  { id: 'bf-e-2', text: 'I prefer solitary activities over social gatherings.', category: 'personality_assessments', dimension: 'extraversion', trait: 'E', traitPath: 'bigFive.E', direction: -1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  // Big Five — Agreeableness (2 items)
+  { id: 'bf-a-1', text: 'I go out of my way to help others, even at personal cost.', category: 'personality_assessments', dimension: 'agreeableness', trait: 'A', traitPath: 'bigFive.A', direction: 1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  { id: 'bf-a-2', text: 'I prioritize my own goals over group harmony.', category: 'personality_assessments', dimension: 'agreeableness', trait: 'A', traitPath: 'bigFive.A', direction: -1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  // Big Five — Neuroticism (2 items)
+  { id: 'bf-n-1', text: 'I frequently worry about things that might go wrong.', category: 'personality_assessments', dimension: 'neuroticism', trait: 'N', traitPath: 'bigFive.N', direction: 1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  { id: 'bf-n-2', text: 'I stay calm and composed under pressure.', category: 'personality_assessments', dimension: 'neuroticism', trait: 'N', traitPath: 'bigFive.N', direction: -1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  // Communication — formality + verbosity (2 items)
+  { id: 'comm-f', text: 'I prefer formal, structured language over casual speech.', category: 'communication', dimension: 'communication', trait: 'formality', traitPath: 'communicationProfile.formality', direction: 1, labels: ['Very Casual', 'Casual', 'Balanced', 'Formal', 'Very Formal'] },
+  { id: 'comm-v', text: 'I prefer thorough, detailed explanations over brief answers.', category: 'communication', dimension: 'communication', trait: 'verbosity', traitPath: 'communicationProfile.verbosity', direction: 1, labels: ['Very Terse', 'Brief', 'Balanced', 'Detailed', 'Very Elaborate'] },
+  // Daily routines — conscientiousness proxy (2 items)
+  { id: 'rout-1', text: 'My day follows a consistent structure and set of rituals.', category: 'daily_routines', dimension: 'conscientiousness', trait: 'C', traitPath: 'bigFive.C', direction: 1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  { id: 'rout-2', text: 'I adapt my schedule spontaneously based on how I feel.', category: 'daily_routines', dimension: 'conscientiousness', trait: 'C', traitPath: 'bigFive.C', direction: -1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  // Values (2 items)
+  { id: 'val-1', text: 'I would sacrifice personal gain to uphold a principle.', category: 'values', dimension: 'values', trait: 'values', traitPath: null, direction: 1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  { id: 'val-2', text: 'Pragmatism matters more to me than idealism.', category: 'values', dimension: 'values', trait: 'values', traitPath: null, direction: -1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  // Decision heuristics (2 items)
+  { id: 'dec-1', text: 'I make decisions quickly with available information rather than waiting.', category: 'decision_heuristics', dimension: 'decision_making', trait: 'decision_making', traitPath: null, direction: 1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] },
+  { id: 'dec-2', text: 'I prefer to gather extensive data before committing to a choice.', category: 'decision_heuristics', dimension: 'decision_making', trait: 'decision_making', traitPath: null, direction: -1, labels: ['Strongly Disagree', 'Disagree', 'Neutral', 'Agree', 'Strongly Agree'] }
+];
+
+const SCALE_WEIGHT = 0.3;
+const CONFIDENCE_BOOST = 0.15;
+
 // =============================================================================
 // HELPERS
 // =============================================================================
@@ -240,6 +274,91 @@ async function ensureSoulDir() {
     await mkdir(DIGITAL_TWIN_DIR, { recursive: true });
     console.log(`🧬 Created soul data directory: ${DIGITAL_TWIN_DIR}`);
   }
+}
+
+/**
+ * Call any AI provider (API or CLI) with a prompt and return the response text.
+ */
+async function callProviderAI(provider, model, prompt, { temperature = 0.3, max_tokens = 4000 } = {}) {
+  const timeout = provider.timeout || 300000;
+
+  if (provider.type === 'api') {
+    const headers = { 'Content-Type': 'application/json' };
+    if (provider.apiKey) headers['Authorization'] = `Bearer ${provider.apiKey}`;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeout);
+
+    const response = await fetch(`${provider.endpoint}/chat/completions`, {
+      method: 'POST',
+      headers,
+      signal: controller.signal,
+      body: JSON.stringify({
+        model,
+        messages: [{ role: 'user', content: prompt }],
+        temperature,
+        max_tokens
+      })
+    }).catch((err) => {
+      clearTimeout(timer);
+      return { ok: false, _fetchError: err.name === 'AbortError' ? 'AI request timed out' : err.message };
+    });
+
+    clearTimeout(timer);
+
+    if (response._fetchError) {
+      return { error: response._fetchError };
+    }
+
+    if (!response.ok) {
+      return { error: `Provider API error: ${response.status}` };
+    }
+
+    const data = await response.json();
+    return { text: data.choices?.[0]?.message?.content || '' };
+  }
+
+  // CLI provider — pipe prompt via stdin to avoid arg length limits on large prompts
+  const { spawn } = await import('child_process');
+  return new Promise((resolve) => {
+    const args = [...(provider.args || [])];
+    let output = '';
+    let resolved = false;
+
+    const child = spawn(provider.command, args, {
+      env: { ...process.env, ...provider.envVars },
+      shell: false,
+      stdio: ['pipe', 'pipe', 'pipe']
+    });
+
+    // Pipe prompt via stdin
+    child.stdin.write(prompt);
+    child.stdin.end();
+
+    child.stdout.on('data', (data) => { output += data.toString(); });
+    child.stderr.on('data', (data) => { output += data.toString(); });
+    child.on('close', (code) => {
+      if (resolved) return;
+      resolved = true;
+      if (code === 0) {
+        resolve({ text: output });
+      } else {
+        resolve({ error: `CLI exited with code ${code}: ${output.substring(0, 500)}` });
+      }
+    });
+    child.on('error', (err) => {
+      if (resolved) return;
+      resolved = true;
+      resolve({ error: err.message });
+    });
+
+    setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      child.kill();
+      resolve({ error: 'AI request timed out' });
+    }, timeout);
+  });
 }
 
 // =============================================================================
@@ -782,6 +901,26 @@ export async function generateEnrichmentQuestion(category, providerOverride, mod
     };
   }
 
+  // Serve unanswered scale questions for this category
+  const answered = meta.enrichment.scaleQuestionsAnswered || {};
+  const categoryScaleQuestions = SCALE_QUESTIONS.filter(q => q.category === category);
+  const unanswered = categoryScaleQuestions.filter(q => !(q.id in answered));
+  if (unanswered.length > 0) {
+    const sq = unanswered[0];
+    return {
+      questionId: generateId(),
+      category,
+      question: sq.text,
+      questionType: 'scale',
+      labels: sq.labels,
+      dimension: sq.dimension,
+      scaleQuestionId: sq.id,
+      isGenerated: false,
+      questionNumber: questionsAnswered + 1,
+      totalQuestions: config.questions.length + categoryScaleQuestions.length
+    };
+  }
+
   // Generate follow-up question using AI
   const existingSoul = await getSoulForPrompt({ maxTokens: 2000 });
 
@@ -847,7 +986,123 @@ export async function generateEnrichmentQuestion(category, providerOverride, mod
   };
 }
 
+async function processScaleAnswer(data) {
+  const { category, question, scaleValue, scaleQuestionId } = data;
+  const config = ENRICHMENT_CATEGORIES[category];
+  if (!config) throw new Error(`Unknown enrichment category: ${category}`);
+
+  const scaleDef = SCALE_QUESTIONS.find(q => q.id === scaleQuestionId);
+  if (!scaleDef) throw new Error(`Unknown scale question: ${scaleQuestionId}`);
+
+  // Convert 1-5 to 0-1, apply direction
+  const rawScore = (scaleValue - 1) / 4;
+  const adjustedScore = scaleDef.direction === 1 ? rawScore : (1 - rawScore);
+
+  const meta = await loadMeta();
+  if (!meta.traits) meta.traits = {};
+
+  // Update trait score via weighted moving average
+  if (scaleDef.traitPath) {
+    const parts = scaleDef.traitPath.split('.');
+    const section = parts[0]; // e.g. 'bigFive' or 'communicationProfile'
+    const field = parts[1];   // e.g. 'O' or 'formality'
+
+    if (!meta.traits[section]) meta.traits[section] = {};
+    const existing = meta.traits[section][field];
+
+    // communicationProfile fields are integer 1-10
+    if (section === 'communicationProfile') {
+      const mapped = Math.round(adjustedScore * 9) + 1; // 1-10
+      meta.traits[section][field] = existing == null
+        ? mapped
+        : Math.round(existing * (1 - SCALE_WEIGHT) + mapped * SCALE_WEIGHT);
+    } else {
+      meta.traits[section][field] = existing == null
+        ? Math.round(adjustedScore * 100) / 100
+        : Math.round((existing * (1 - SCALE_WEIGHT) + adjustedScore * SCALE_WEIGHT) * 100) / 100;
+    }
+
+    meta.traits.lastAnalyzed = now();
+  }
+
+  // Boost confidence for the dimension
+  if (!meta.confidence) meta.confidence = { overall: 0, dimensions: {}, gaps: [], lastCalculated: now() };
+  if (!meta.confidence.dimensions) meta.confidence.dimensions = {};
+  const currentConf = meta.confidence.dimensions[scaleDef.dimension] || 0;
+  meta.confidence.dimensions[scaleDef.dimension] = Math.min(1, Math.round((currentConf + CONFIDENCE_BOOST) * 100) / 100);
+
+  // Recalculate overall confidence
+  const dimValues = Object.values(meta.confidence.dimensions);
+  meta.confidence.overall = dimValues.length > 0
+    ? Math.round((dimValues.reduce((a, b) => a + b, 0) / dimValues.length) * 100) / 100
+    : 0;
+
+  // Regenerate gap recommendations
+  meta.confidence.gaps = generateGapRecommendations(meta.confidence.dimensions);
+  meta.confidence.lastCalculated = now();
+
+  // Store readable line in target document
+  const labelText = scaleDef.labels[scaleValue - 1] || String(scaleValue);
+  const formattedContent = `### ${question}\n\nResponse: ${labelText} (${scaleValue}/5)\n\n`;
+
+  await ensureSoulDir();
+  const targetPath = join(DIGITAL_TWIN_DIR, config.targetDoc);
+  let existingContent = '';
+  if (existsSync(targetPath)) {
+    existingContent = await readFile(targetPath, 'utf-8');
+  } else {
+    existingContent = `# ${config.label}\n\n`;
+  }
+  await writeFile(targetPath, existingContent + '\n' + formattedContent);
+
+  // Record scale answer
+  if (!meta.enrichment.scaleQuestionsAnswered) meta.enrichment.scaleQuestionsAnswered = {};
+  meta.enrichment.scaleQuestionsAnswered[scaleQuestionId] = scaleValue;
+
+  // Increment questions answered for the category
+  if (!meta.enrichment.questionsAnswered) meta.enrichment.questionsAnswered = {};
+  meta.enrichment.questionsAnswered[category] = (meta.enrichment.questionsAnswered[category] || 0) + 1;
+  meta.enrichment.lastSession = now();
+
+  if (meta.enrichment.questionsAnswered[category] >= 3 &&
+      !meta.enrichment.completedCategories.includes(category)) {
+    meta.enrichment.completedCategories.push(category);
+  }
+
+  // Ensure document is in meta
+  const existingDoc = meta.documents.find(d => d.filename === config.targetDoc);
+  if (!existingDoc) {
+    meta.documents.push({
+      id: generateId(),
+      filename: config.targetDoc,
+      title: config.label,
+      category: config.targetCategory || 'enrichment',
+      enabled: true,
+      priority: 30
+    });
+  }
+
+  await saveMeta(meta);
+
+  digitalTwinEvents.emit('traits:updated', meta.traits);
+  digitalTwinEvents.emit('confidence:calculated', meta.confidence);
+
+  console.log(`📊 Scale answer processed: ${scaleQuestionId}=${scaleValue} → ${scaleDef.dimension} confidence=${meta.confidence.dimensions[scaleDef.dimension]}`);
+
+  return {
+    category,
+    targetDoc: config.targetDoc,
+    contentAdded: formattedContent,
+    traitsUpdated: true,
+    dimension: scaleDef.dimension,
+    newConfidence: meta.confidence.dimensions[scaleDef.dimension]
+  };
+}
+
 export async function processEnrichmentAnswer(data) {
+  // Branch for scale questions
+  if (data.questionType === 'scale') return processScaleAnswer(data);
+
   const { category, question, answer, providerOverride, modelOverride } = data;
   const config = ENRICHMENT_CATEGORIES[category];
 
@@ -1835,6 +2090,9 @@ export async function analyzeTraits(providerId, model, forceReanalyze = false) {
       await saveMeta(meta);
       digitalTwinEvents.emit('traits:analyzed', traits);
 
+      // Recalculate confidence with updated traits
+      await calculateConfidence();
+
       return { traits, analysisNotes: parsedTraits.analysisNotes };
     }
 
@@ -1846,16 +2104,18 @@ export async function analyzeTraits(providerId, model, forceReanalyze = false) {
 
 function parseTraitsResponse(response) {
   const jsonMatch = response.match(/```json\s*([\s\S]*?)\s*```/);
-  if (jsonMatch) {
-    const parsed = JSON.parse(jsonMatch[1]);
-    return parsed;
+  const jsonStr = jsonMatch ? jsonMatch[1] : (response.trim().startsWith('{') ? response.trim() : null);
+
+  if (!jsonStr) {
+    return { error: 'Failed to parse traits response - no JSON found', rawResponse: response };
   }
 
-  if (response.trim().startsWith('{')) {
-    return JSON.parse(response);
+  const parsed = safeJSONParse(jsonStr, null, { allowArray: false });
+  if (!parsed) {
+    return { error: 'Failed to parse traits response - invalid JSON', rawResponse: response };
   }
 
-  return { error: 'Failed to parse traits response', rawResponse: response };
+  return parsed;
 }
 
 /**
@@ -2581,6 +2841,102 @@ export async function saveImportAsDocument(source, suggestedDoc) {
     enabled: true,
     priority: 5
   });
+}
+
+// =============================================================================
+// ASSESSMENT ANALYZER
+// =============================================================================
+
+/**
+ * Analyze a pasted personality assessment without session management.
+ * Extracts traits, creates/updates documents, and returns gap recommendations.
+ */
+export async function analyzeAssessment(content, providerId, model) {
+  console.log(`🧪 [${now()}] Assessment analysis: provider=${providerId}, model=${model}, content=${content.length} chars`);
+
+  // 1. Load twin context
+  const twinContent = await getAllTwinContent();
+  const meta = await loadMeta();
+  const currentTraits = meta.traits || {};
+  const confidenceBefore = meta.confidence?.overall || 0;
+
+  // 2. Build analysis prompt
+  const analysisPrompt = await buildPrompt('twin-interview-analyze', {
+    twinContent: twinContent || 'No existing twin documents yet.',
+    currentTraits: JSON.stringify(currentTraits, null, 2) || '{}',
+    pastedContent: content
+  }).catch(() => null);
+
+  if (!analysisPrompt) {
+    return { error: 'Analysis prompt template not found' };
+  }
+
+  const provider = await getProviderById(providerId);
+  if (!provider || !provider.enabled) {
+    return { error: 'Provider not found or disabled' };
+  }
+
+  // 3. Call AI for analysis
+  console.log(`🧪 [${now()}] Calling ${provider.name} (${model}), prompt=${analysisPrompt.length} chars`);
+  const aiResponse = await callProviderAI(provider, model, analysisPrompt, { temperature: 0.3, max_tokens: 4000 });
+
+  if (aiResponse.error) {
+    return { error: aiResponse.error };
+  }
+
+  const parsed = parseTraitsResponse(aiResponse.text);
+  if (parsed.error) {
+    return { error: parsed.error };
+  }
+
+  // 4. Apply trait updates
+  const traitUpdates = {};
+  if (parsed.bigFive) traitUpdates.bigFive = parsed.bigFive;
+  if (parsed.valuesHierarchy) traitUpdates.valuesHierarchy = parsed.valuesHierarchy;
+  if (parsed.communicationProfile) traitUpdates.communicationProfile = parsed.communicationProfile;
+
+  if (Object.keys(traitUpdates).length > 0) {
+    await updateTraits(traitUpdates);
+  }
+
+  // 5. Create/update documents from suggestions
+  const docsCreated = [];
+  const docsUpdated = [];
+  for (const doc of (parsed.suggestedDocuments || [])) {
+    if (!doc.filename || !doc.content) continue;
+    const currentMeta = await loadMeta();
+    const existsBefore = currentMeta.documents.some(d => d.filename === doc.filename);
+    const result = await saveImportAsDocument('interview', {
+      filename: doc.filename,
+      title: doc.title || doc.filename.replace('.md', ''),
+      category: doc.category || 'enrichment',
+      content: doc.content
+    });
+    if (result) {
+      (existsBefore ? docsUpdated : docsCreated).push(doc.filename);
+    }
+  }
+
+  // 6. Recalculate confidence with updated content and traits
+  const confidenceResult = await calculateConfidence();
+  const confidenceAfter = confidenceResult.confidence?.overall || confidenceBefore;
+
+  // 7. Get gap recommendations
+  const gaps = await getGapRecommendations();
+
+  const analysisResult = {
+    traitsUpdated: traitUpdates,
+    documentsCreated: docsCreated,
+    documentsUpdated: docsUpdated,
+    newDimensions: parsed.newDimensions || [],
+    confidenceDelta: { before: confidenceBefore, after: confidenceAfter },
+    summary: parsed.summary || 'Analysis complete. Twin profile updated.'
+  };
+
+  digitalTwinEvents.emit('interview:analyzed', { analysisResult });
+  console.log(`🧪 [${now()}] Assessment complete: ${docsCreated.length} created, ${docsUpdated.length} updated, ${Object.keys(traitUpdates).length} trait categories`);
+
+  return { analysisResult, gaps };
 }
 
 /**

--- a/server/services/digital-twin.js
+++ b/server/services/digital-twin.js
@@ -139,7 +139,7 @@ export const ENRICHMENT_CATEGORIES = {
     targetDoc: 'VALUES.md',
     targetCategory: 'core',
     questions: [
-      'What principle would you never compromise, even at personal cost?',
+      'What are the top three values that guide your most important decisions?',
       'What value do you wish more people held?',
       'Where do you draw the line between pragmatism and principle?'
     ]
@@ -948,10 +948,10 @@ export async function generateEnrichmentQuestion(category, providerOverride, mod
     return {
       questionId: generateId(),
       category,
-      question: config.questions[0], // Fallback to first question
-      isGenerated: false,
+      question: `What else should your digital twin know about your ${config.label.toLowerCase()}?`,
+      isGenerated: true,
       questionNumber: questionsAnswered + 1,
-      totalQuestions: config.questions.length
+      totalQuestions: null
     };
   }
 
@@ -965,7 +965,7 @@ export async function generateEnrichmentQuestion(category, providerOverride, mod
 
   const model = modelOverride || provider.defaultModel;
 
-  let question = config.questions[0]; // Fallback
+  let question = `What else should your digital twin know about your ${config.label.toLowerCase()}?`; // Fallback
 
   if (provider.type === 'api') {
     const headers = { 'Content-Type': 'application/json' };

--- a/server/services/runner.js
+++ b/server/services/runner.js
@@ -84,7 +84,8 @@ export async function executeCliRun(runId, provider, prompt, workspacePath, onDa
     await writeFile(outputPath, output);
 
     const metadataStr = await readFile(metadataPath, 'utf-8').catch(() => '{}');
-    const metadata = metadataStr ? JSON.parse(metadataStr) : {};
+    let metadata = {};
+    try { metadata = JSON.parse(metadataStr); } catch { /* corrupted metadata, start fresh */ }
     metadata.endTime = new Date().toISOString();
     metadata.duration = Date.now() - startTime;
     metadata.exitCode = code;

--- a/server/services/runner.js
+++ b/server/services/runner.js
@@ -33,16 +33,18 @@ export async function executeCliRun(runId, provider, prompt, workspacePath, onDa
   const startTime = Date.now();
   let output = '';
 
-  // Build command with args - NO shell: true
-  const args = [...(provider.args || []), prompt];
-  console.log(`🚀 Executing CLI: ${provider.command} ${args.join(' ')}`);
-  console.log(`📝 Prompt length: ${prompt.length} chars, first 100: ${prompt.substring(0, 100)}`);
+  // Build command with args - prompt passed via stdin to avoid argv limits
+  const args = [...(provider.args || []), '-p', '-'];
+  console.log(`🚀 Executing CLI: ${provider.command} (${prompt.length} chars via stdin)`);
 
   const childProcess = spawn(provider.command, args, {
     cwd: workspacePath,
     env: { ...process.env, ...provider.envVars }
-    // Removed shell: true - this fixes the security warning and ensures proper argument handling
   });
+
+  // Pass prompt via stdin to avoid OS argv limits
+  childProcess.stdin.write(prompt);
+  childProcess.stdin.end();
 
   // Track active run (store on the runner service itself for stopRun to access)
   if (!aiToolkitInstance.services.runner._portosActiveRuns) {

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -11,6 +11,7 @@ import { agentPersonalityEvents } from './agentPersonalities.js';
 import { platformAccountEvents } from './platformAccounts.js';
 import { scheduleEvents } from './automationScheduler.js';
 import { activityEvents } from './agentActivity.js';
+import { brainEvents } from './brainStorage.js';
 import * as shellService from './shell.js';
 
 // Store active log streams per socket
@@ -292,6 +293,9 @@ export function initSocket(io) {
 
   // Set up agent event forwarding
   setupAgentEventForwarding();
+
+  // Set up brain event forwarding
+  setupBrainEventForwarding();
 }
 
 function cleanupStream(socketId) {
@@ -432,4 +436,13 @@ function setupAgentEventForwarding() {
   // Activity events
   activityEvents.on('activity', (data) => broadcastToAgents('agents:activity', data));
   activityEvents.on('activity:updated', (data) => broadcastToAgents('agents:activity:updated', data));
+}
+
+// Set up brain event forwarding - broadcast to all clients
+function setupBrainEventForwarding() {
+  brainEvents.on('classified', (data) => {
+    if (ioInstance) {
+      ioInstance.emit('brain:classified', data);
+    }
+  });
 }

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -1018,6 +1018,7 @@ export async function spawnAgentForTask(task) {
     // Wait for lane availability (max 30 seconds)
     const laneResult = await waitForLane(laneName, agentId, { timeoutMs: 30000, metadata: { taskId: task.id } });
     if (!laneResult.success) {
+      spawningTasks.delete(task.id);
       emitLog('warning', `Lane ${laneName} unavailable for task ${task.id}, deferring`, { taskId: task.id, lane: laneName });
       cosEvents.emit('agent:deferred', { taskId: task.id, reason: 'lane-capacity', lane: laneName });
       return null;
@@ -1025,6 +1026,7 @@ export async function spawnAgentForTask(task) {
   } else {
     const laneResult = acquire(laneName, agentId, { taskId: task.id });
     if (!laneResult.success) {
+      spawningTasks.delete(task.id);
       emitLog('warning', `Failed to acquire lane ${laneName}: ${laneResult.error}`, { taskId: task.id });
       return null;
     }

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -1638,17 +1638,63 @@ async function spawnDirectly(agentId, task, prompt, workspacePath, model, provid
 }
 
 /**
+ * Summarize tool input into a concise description for display.
+ * Extracts the most relevant parameter from each tool type.
+ */
+function summarizeToolInput(toolName, input) {
+  if (!input || typeof input !== 'object') return '';
+  const shorten = (p) => {
+    if (!p || typeof p !== 'string') return '';
+    // Strip long absolute paths to just filename or last 2 segments
+    const parts = p.split('/').filter(Boolean);
+    return parts.length > 2 ? `…/${parts.slice(-2).join('/')}` : p;
+  };
+  switch (toolName) {
+    case 'Read':
+      return shorten(input.file_path);
+    case 'Edit':
+      return shorten(input.file_path);
+    case 'Write':
+      return shorten(input.file_path);
+    case 'Glob':
+      return input.pattern || '';
+    case 'Grep':
+      return `"${(input.pattern || '').substring(0, 60)}"${input.path ? ` in ${shorten(input.path)}` : ''}`;
+    case 'Bash': {
+      const cmd = input.command || input.description || '';
+      return cmd.substring(0, 80);
+    }
+    case 'Task':
+      return input.description || '';
+    case 'WebFetch':
+      return shorten(input.url || '');
+    case 'WebSearch':
+      return `"${(input.query || '').substring(0, 60)}"`;
+    case 'TodoWrite':
+      return input.todos?.length ? `${input.todos.length} items` : '';
+    case 'NotebookEdit':
+      return shorten(input.notebook_path);
+    default:
+      return '';
+  }
+}
+
+/**
  * Create a Claude stream-json parser that extracts human-readable text from JSON stream events.
  * Returns a stateful parser with a `processChunk(data)` method that returns extracted text lines.
  * The parser handles:
  *   - content_block_delta: incremental text tokens as they stream
- *   - tool_use events: shows tool calls for visibility (e.g. "🔧 Using Edit on file.js")
+ *   - tool_use events: shows tool calls with input details (e.g. "🔧 Read …/services/api.js")
+ *   - input_json_delta: accumulates tool input JSON for detailed summaries
+ *   - content_block_stop: emits detailed tool summary when input is complete
  *   - result: final result text (used for output file)
  */
 function createStreamJsonParser() {
   let lineBuffer = '';
   let finalResult = '';
   let textBuffer = '';
+  // Track active tool blocks by index for input accumulation
+  const activeTools = new Map(); // index -> { name, inputJson }
 
   const processChunk = (rawData) => {
     const lines = [];
@@ -1682,10 +1728,35 @@ function createStreamJsonParser() {
             lines.push(tl);
           }
         }
-        // Show tool use starts for visibility
+        // Accumulate tool input JSON deltas
+        if (event?.type === 'content_block_delta' && event.delta?.type === 'input_json_delta') {
+          const idx = event.index;
+          const tool = activeTools.get(idx);
+          if (tool) {
+            tool.inputJson += event.delta.partial_json || '';
+          }
+        }
+        // Track tool use start - record name and begin accumulating input
         if (event?.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
           const toolName = event.content_block.name || 'unknown';
+          const idx = event.index;
+          activeTools.set(idx, { name: toolName, inputJson: '' });
           lines.push(`🔧 Using ${toolName}...`);
+        }
+        // When tool input is complete, emit a detailed summary line
+        if (event?.type === 'content_block_stop') {
+          const idx = event.index;
+          const tool = activeTools.get(idx);
+          if (tool && tool.inputJson) {
+            let input;
+            // Parse accumulated JSON - may be incomplete for very large inputs
+            input = JSON.parse(tool.inputJson);
+            const detail = summarizeToolInput(tool.name, input);
+            if (detail) {
+              lines.push(`  → ${detail}`);
+            }
+            activeTools.delete(idx);
+          }
         }
       }
 

--- a/server/services/taskEnhancer.js
+++ b/server/services/taskEnhancer.js
@@ -160,10 +160,16 @@ export async function enhanceTaskPrompt(description, context = '') {
 
   enhancedDescription = enhancedDescription.trim();
 
-  // Ensure we have a valid enhanced description
+  // Fall back to original description if enhancement returned empty
   if (!enhancedDescription) {
-    console.warn(`⚠️ Task enhancement returned empty result from ${provider.name}/${model}`);
-    throw new Error('AI enhancement returned empty result');
+    console.warn(`⚠️ Task enhancement returned empty result from ${provider.name}/${model}, using original`);
+    return {
+      enhancedDescription: description,
+      originalDescription: description,
+      model,
+      provider: provider.id,
+      fallback: true
+    };
   }
 
   console.log(`✅ Enhanced task prompt (${enhancedDescription.length} chars) using ${provider.name}/${model}`);

--- a/server/services/taskTemplates.js
+++ b/server/services/taskTemplates.js
@@ -106,7 +106,7 @@ const DEFAULT_STATE = {
 async function loadState() {
   const data = await readJSONFile(TEMPLATES_FILE);
   if (!data) return { ...DEFAULT_STATE };
-  return data;
+  return { ...DEFAULT_STATE, ...data, userTemplates: data.userTemplates || [], usage: data.usage || {} };
 }
 
 /**

--- a/server/services/taskTemplates.js
+++ b/server/services/taskTemplates.js
@@ -1,0 +1,281 @@
+/**
+ * Task Templates Service
+ *
+ * Quick task templates for common user task patterns.
+ * Helps users quickly create tasks for frequently needed operations.
+ */
+
+import { writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { readJSONFile } from '../lib/fileUtils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DATA_DIR = join(__dirname, '../../data/cos');
+const TEMPLATES_FILE = join(DATA_DIR, 'task-templates.json');
+
+// Built-in templates based on common task patterns
+const BUILT_IN_TEMPLATES = [
+  {
+    id: 'builtin-mobile-fix',
+    name: 'Fix Mobile Responsiveness',
+    icon: '📱',
+    description: 'Make this page mobile-friendly',
+    context: 'Check viewport sizes 375px, 768px, and 1024px. Fix Tailwind responsive classes.',
+    category: 'ui',
+    isBuiltin: true
+  },
+  {
+    id: 'builtin-add-feature',
+    name: 'Add New Feature',
+    icon: '✨',
+    description: 'Add a new feature to',
+    context: 'Follow existing patterns in the codebase. Write tests for new functionality.',
+    category: 'feature',
+    isBuiltin: true
+  },
+  {
+    id: 'builtin-fix-bug',
+    name: 'Fix Bug',
+    icon: '🐛',
+    description: 'Fix the bug where',
+    context: 'Investigate root cause, implement fix, add test to prevent regression.',
+    category: 'bugfix',
+    isBuiltin: true
+  },
+  {
+    id: 'builtin-refactor',
+    name: 'Refactor Code',
+    icon: '🔧',
+    description: 'Refactor',
+    context: 'Improve code quality while maintaining existing behavior. Ensure tests pass.',
+    category: 'refactor',
+    isBuiltin: true
+  },
+  {
+    id: 'builtin-add-test',
+    name: 'Add Tests',
+    icon: '🧪',
+    description: 'Add tests for',
+    context: 'Write unit tests with good coverage. Follow existing test patterns.',
+    category: 'testing',
+    isBuiltin: true
+  },
+  {
+    id: 'builtin-improve-ux',
+    name: 'Improve UX',
+    icon: '🎨',
+    description: 'Improve the user experience of',
+    context: 'Focus on usability, accessibility, and visual polish.',
+    category: 'ui',
+    isBuiltin: true
+  },
+  {
+    id: 'builtin-add-api',
+    name: 'Add API Endpoint',
+    icon: '🔌',
+    description: 'Add API endpoint for',
+    context: 'Add route with Zod validation, service function, and API tests.',
+    category: 'feature',
+    isBuiltin: true
+  },
+  {
+    id: 'builtin-security-fix',
+    name: 'Security Fix',
+    icon: '🔒',
+    description: 'Fix security issue in',
+    context: 'Address vulnerability with proper input validation and sanitization.',
+    category: 'security',
+    isBuiltin: true
+  }
+];
+
+// Default empty state
+const DEFAULT_STATE = {
+  version: 1,
+  lastUpdated: null,
+  userTemplates: [],
+  usage: {}
+};
+
+/**
+ * Load templates state
+ */
+async function loadState() {
+  const data = await readJSONFile(TEMPLATES_FILE);
+  if (!data) return { ...DEFAULT_STATE };
+  return data;
+}
+
+/**
+ * Save templates state
+ */
+async function saveState(state) {
+  state.lastUpdated = new Date().toISOString();
+
+  if (!existsSync(DATA_DIR)) {
+    await mkdir(DATA_DIR, { recursive: true });
+  }
+
+  await writeFile(TEMPLATES_FILE, JSON.stringify(state, null, 2));
+}
+
+/**
+ * Get all templates (built-in + user)
+ */
+export async function getAllTemplates() {
+  const state = await loadState();
+
+  // Combine built-in and user templates
+  const templates = [
+    ...BUILT_IN_TEMPLATES,
+    ...state.userTemplates
+  ];
+
+  // Add usage counts
+  return templates.map(t => ({
+    ...t,
+    useCount: state.usage[t.id] || 0
+  }));
+}
+
+/**
+ * Get templates sorted by recent usage
+ */
+export async function getPopularTemplates(limit = 5) {
+  const templates = await getAllTemplates();
+
+  return templates
+    .sort((a, b) => (b.useCount || 0) - (a.useCount || 0))
+    .slice(0, limit);
+}
+
+/**
+ * Record template usage (for popularity tracking)
+ */
+export async function recordTemplateUsage(templateId) {
+  const state = await loadState();
+
+  if (!state.usage) {
+    state.usage = {};
+  }
+
+  state.usage[templateId] = (state.usage[templateId] || 0) + 1;
+  await saveState(state);
+
+  return state.usage[templateId];
+}
+
+/**
+ * Create a new user template
+ */
+export async function createTemplate(templateData) {
+  const state = await loadState();
+
+  const newTemplate = {
+    id: `user-${Date.now().toString(36)}`,
+    name: templateData.name,
+    icon: templateData.icon || '📝',
+    description: templateData.description,
+    context: templateData.context || '',
+    category: templateData.category || 'custom',
+    provider: templateData.provider || '',
+    model: templateData.model || '',
+    app: templateData.app || '',
+    isBuiltin: false,
+    createdAt: new Date().toISOString()
+  };
+
+  state.userTemplates.push(newTemplate);
+  await saveState(state);
+
+  return newTemplate;
+}
+
+/**
+ * Update a user template
+ */
+export async function updateTemplate(templateId, updates) {
+  const state = await loadState();
+
+  const index = state.userTemplates.findIndex(t => t.id === templateId);
+  if (index === -1) {
+    return { error: 'Template not found or is a built-in template' };
+  }
+
+  state.userTemplates[index] = {
+    ...state.userTemplates[index],
+    ...updates,
+    id: templateId, // Preserve ID
+    isBuiltin: false,
+    updatedAt: new Date().toISOString()
+  };
+
+  await saveState(state);
+  return state.userTemplates[index];
+}
+
+/**
+ * Delete a user template
+ */
+export async function deleteTemplate(templateId) {
+  const state = await loadState();
+
+  // Can't delete built-in templates
+  if (templateId.startsWith('builtin-')) {
+    return { error: 'Cannot delete built-in templates' };
+  }
+
+  const index = state.userTemplates.findIndex(t => t.id === templateId);
+  if (index === -1) {
+    return { error: 'Template not found' };
+  }
+
+  const deleted = state.userTemplates.splice(index, 1)[0];
+
+  // Also clean up usage data
+  if (state.usage && state.usage[templateId]) {
+    delete state.usage[templateId];
+  }
+
+  await saveState(state);
+
+  return { success: true, deleted };
+}
+
+/**
+ * Get categories with counts
+ */
+export async function getCategories() {
+  const templates = await getAllTemplates();
+
+  const categories = {};
+  for (const t of templates) {
+    const cat = t.category || 'other';
+    if (!categories[cat]) {
+      categories[cat] = { name: cat, count: 0 };
+    }
+    categories[cat].count++;
+  }
+
+  return Object.values(categories);
+}
+
+/**
+ * Create template from a completed task
+ * Useful for saving successful task patterns
+ */
+export async function createTemplateFromTask(task, templateName) {
+  return createTemplate({
+    name: templateName || `Custom: ${task.description?.substring(0, 30)}...`,
+    icon: '⭐',
+    description: task.description,
+    context: task.context || '',
+    category: 'from-task',
+    provider: task.provider || '',
+    model: task.model || '',
+    app: task.app || ''
+  });
+}

--- a/server/services/taskTemplates.test.js
+++ b/server/services/taskTemplates.test.js
@@ -1,0 +1,234 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock dependencies before importing the module
+vi.mock('../lib/fileUtils.js', () => ({
+  readJSONFile: vi.fn()
+}));
+
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(),
+  mkdir: vi.fn().mockResolvedValue()
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true)
+}));
+
+// Import after mocking
+const { readJSONFile } = await import('../lib/fileUtils.js');
+const { writeFile, mkdir } = await import('fs/promises');
+const { existsSync } = await import('fs');
+const {
+  getAllTemplates,
+  getPopularTemplates,
+  recordTemplateUsage,
+  createTemplate,
+  deleteTemplate
+} = await import('./taskTemplates.js');
+
+describe('taskTemplates service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getAllTemplates', () => {
+    it('returns built-in templates when no user templates exist', async () => {
+      readJSONFile.mockResolvedValue(null);
+
+      const templates = await getAllTemplates();
+
+      expect(templates.length).toBeGreaterThan(0);
+      expect(templates.every(t => t.isBuiltin)).toBe(true);
+      expect(templates.every(t => t.id.startsWith('builtin-'))).toBe(true);
+      expect(templates.every(t => t.useCount === 0)).toBe(true);
+    });
+
+    it('merges built-in and user templates', async () => {
+      readJSONFile.mockResolvedValue({
+        userTemplates: [
+          {
+            id: 'user-abc123',
+            name: 'My Template',
+            description: 'Custom',
+            icon: '🔥',
+            context: 'some context',
+            isBuiltin: false
+          }
+        ],
+        usage: {},
+        lastUpdated: '2025-01-01T00:00:00.000Z'
+      });
+
+      const templates = await getAllTemplates();
+
+      const builtInCount = templates.filter(t => t.isBuiltin).length;
+      const userCount = templates.filter(t => !t.isBuiltin).length;
+
+      expect(builtInCount).toBeGreaterThan(0);
+      expect(userCount).toBe(1);
+      expect(templates.find(t => t.id === 'user-abc123')).toBeDefined();
+    });
+
+    it('includes usage counts from state', async () => {
+      readJSONFile.mockResolvedValue({
+        userTemplates: [
+          {
+            id: 'user-abc123',
+            name: 'My Template',
+            description: 'Custom',
+            icon: '🔥',
+            context: 'some context',
+            isBuiltin: false
+          }
+        ],
+        usage: {
+          'user-abc123': 5,
+          'builtin-mobile-fix': 3
+        },
+        lastUpdated: '2025-01-01T00:00:00.000Z'
+      });
+
+      const templates = await getAllTemplates();
+
+      const userTemplate = templates.find(t => t.id === 'user-abc123');
+      const builtinTemplate = templates.find(t => t.id === 'builtin-mobile-fix');
+
+      expect(userTemplate.useCount).toBe(5);
+      expect(builtinTemplate.useCount).toBe(3);
+    });
+  });
+
+  describe('createTemplate', () => {
+    it('creates with generated ID and correct fields', async () => {
+      readJSONFile.mockResolvedValue({
+        userTemplates: [],
+        usage: {},
+        lastUpdated: null
+      });
+
+      const templateData = {
+        name: 'Test Template',
+        icon: '🚀',
+        description: 'Test description',
+        context: 'Test context',
+        category: 'testing',
+        provider: 'openai',
+        model: 'gpt-4',
+        app: 'test-app'
+      };
+
+      const newTemplate = await createTemplate(templateData);
+
+      expect(newTemplate.id).toMatch(/^user-/);
+      expect(newTemplate.name).toBe('Test Template');
+      expect(newTemplate.icon).toBe('🚀');
+      expect(newTemplate.description).toBe('Test description');
+      expect(newTemplate.context).toBe('Test context');
+      expect(newTemplate.category).toBe('testing');
+      expect(newTemplate.provider).toBe('openai');
+      expect(newTemplate.model).toBe('gpt-4');
+      expect(newTemplate.app).toBe('test-app');
+      expect(newTemplate.isBuiltin).toBe(false);
+      expect(newTemplate.createdAt).toBeDefined();
+
+      expect(writeFile).toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteTemplate', () => {
+    it('returns error for built-in templates', async () => {
+      readJSONFile.mockResolvedValue({
+        userTemplates: [],
+        usage: {},
+        lastUpdated: null
+      });
+
+      const result = await deleteTemplate('builtin-mobile-fix');
+
+      expect(result.error).toBe('Cannot delete built-in templates');
+      expect(writeFile).not.toHaveBeenCalled();
+    });
+
+    it('deletes user templates', async () => {
+      readJSONFile.mockResolvedValue({
+        userTemplates: [
+          {
+            id: 'user-abc123',
+            name: 'My Template',
+            description: 'Custom',
+            icon: '🔥',
+            context: 'some context',
+            isBuiltin: false
+          }
+        ],
+        usage: {
+          'user-abc123': 5
+        },
+        lastUpdated: '2025-01-01T00:00:00.000Z'
+      });
+
+      const result = await deleteTemplate('user-abc123');
+
+      expect(result.success).toBe(true);
+      expect(result.deleted.id).toBe('user-abc123');
+      expect(writeFile).toHaveBeenCalled();
+
+      const savedState = JSON.parse(writeFile.mock.calls[0][1]);
+      expect(savedState.userTemplates.length).toBe(0);
+      expect(savedState.usage['user-abc123']).toBeUndefined();
+    });
+  });
+
+  describe('recordTemplateUsage', () => {
+    it('increments usage counter', async () => {
+      readJSONFile.mockResolvedValue({
+        userTemplates: [],
+        usage: {
+          'builtin-mobile-fix': 3
+        },
+        lastUpdated: '2025-01-01T00:00:00.000Z'
+      });
+
+      const count = await recordTemplateUsage('builtin-mobile-fix');
+
+      expect(count).toBe(4);
+      expect(writeFile).toHaveBeenCalled();
+
+      const savedState = JSON.parse(writeFile.mock.calls[0][1]);
+      expect(savedState.usage['builtin-mobile-fix']).toBe(4);
+    });
+  });
+
+  describe('getPopularTemplates', () => {
+    it('returns sorted by useCount descending', async () => {
+      readJSONFile.mockResolvedValue({
+        userTemplates: [
+          {
+            id: 'user-abc123',
+            name: 'My Template',
+            description: 'Custom',
+            icon: '🔥',
+            context: 'some context',
+            isBuiltin: false
+          }
+        ],
+        usage: {
+          'user-abc123': 10,
+          'builtin-mobile-fix': 3,
+          'builtin-add-feature': 7
+        },
+        lastUpdated: '2025-01-01T00:00:00.000Z'
+      });
+
+      const popular = await getPopularTemplates(3);
+
+      expect(popular.length).toBe(3);
+      expect(popular[0].id).toBe('user-abc123');
+      expect(popular[0].useCount).toBe(10);
+      expect(popular[1].id).toBe('builtin-add-feature');
+      expect(popular[1].useCount).toBe(7);
+      expect(popular[2].id).toBe('builtin-mobile-fix');
+      expect(popular[2].useCount).toBe(3);
+    });
+  });
+});

--- a/server/services/taskTemplates.test.js
+++ b/server/services/taskTemplates.test.js
@@ -16,8 +16,7 @@ vi.mock('fs', () => ({
 
 // Import after mocking
 const { readJSONFile } = await import('../lib/fileUtils.js');
-const { writeFile, mkdir } = await import('fs/promises');
-const { existsSync } = await import('fs');
+const { writeFile } = await import('fs/promises');
 const {
   getAllTemplates,
   getPopularTemplates,


### PR DESCRIPTION
## Summary

This release brings significant new features, UX improvements, and reliability fixes to PortOS:

- **Autonomous Jobs System (M37)**: Recurring proactive jobs (git maintenance, brain processing, daily briefings, project reviews) that execute using your digital twin identity. Full CRUD API, configurable intervals, and Jobs tab UI
- **Live Output Streaming**: Claude CLI agents now stream output in real-time with tool-use visibility, matching the Codex live output experience
- **Detailed Agent Tool Activity**: Running agent cards show what each tool is operating on — file paths, search patterns, commands — with color-coded expanded views
- **Quick Task Templates**: One-click task creation from 8 built-in templates, plus save-your-own custom templates with usage tracking
- **Interview Assessment Analyzer**: Paste AI personality assessments for automated Big Five trait analysis and digital twin profile enrichment
- **Likert-Scale Trait Scoring**: 18 inline scale questions that directly update trait scores and confidence during enrichment
- **Universal Model Refresh**: Refresh models button now works for all AI provider types (API and CLI)
- **Completed Agents Search**: Search and filter completed agents by task description, model, or error message

## Bug Fixes

- Brain inbox classification no longer hangs on capture (background classification with Socket.IO updates)
- Killed tasks no longer requeue on server restart
- Quick Enrich skip now advances to a different question
- Quick Enrich no longer repeats already-answered questions
- AI providers status route no longer shadowed by toolkit's `/:id` route
- Empty AI enhancement results return original description instead of 500 error
- CLI runner security warning resolved (removed unsafe `shell: true`)
- Immediate task execution for user-submitted tasks (no more 60s wait)
- Low confidence personality bars now grey instead of misleading red

## Test Plan

- [x] Verify autonomous jobs tab loads and toggles work at `/cos/jobs`
- [x] Confirm live output streaming works for Claude CLI agents
- [x] Test Quick Task Templates create/apply/delete flow
- [x] Validate brain inbox capture returns immediately with background classification
- [x] Check model refresh works for API and CLI providers
- [x] Confirm completed agents search filters correctly