### PR TITLE
Release 0.17.7

### DIFF
--- a/.changelog/v0.12.48.md
+++ b/.changelog/v0.12.48.md
@@ -258,9 +258,6 @@ This release adds branch management and automated release workflow capabilities 
 - `client/src/components/city/CitySettingsPanel.jsx` — Replaced fog slider with time-of-day preset buttons
 - `client/src/hooks/useCitySettings.js` — Removed fogDensity, added timeOfDay setting
 
-### Brain — Sharpened external project Project Next Action
-- **Specific & time-bound**: Updated the External Project project's next action from a vague "draft architecture" (stale 33 days) to a concrete deliverable: "Identify 3 candidate data sources and document their rate limits, auth requirements, and response schemas by Feb 20"
-- **Audit trail**: Added a dated note explaining why the next action was sharpened, preserving project history
 
 ### Brain — Mark Inbox Items as Done
 - **Done status**: Inbox items can now be marked as "done" from both the Filed and Needs Review sections, adding a new terminal state for processed thoughts

--- a/.changelog/v0.15.15.md
+++ b/.changelog/v0.15.15.md
@@ -53,7 +53,7 @@ Plan cleanup and documentation reorganization.
 - **Extracted M42 spec** to `docs/features/identity-system.md` -- removed ~600 lines from PLAN.md
 - **Extracted M40 summary** to `docs/features/agent-skills.md` -- completed milestone moved to feature docs
 - **Moved M40 to Completed** -- all 4 phases (skill templates, context compaction, negative routing, deterministic workflows) were done
-- **Removed external project content** (M44) -- belongs in external project repo, not PortOS
-- **Removed orphaned research docs** -- `external project-data-sources.md` and `kalshibot-health-check-2026-02-17.md` were for other projects
+- **Removed external project content** (M44) -- belongs in its own repo, not PortOS
+- **Removed orphaned research docs** -- external project docs were for other projects
 - **Added Scope Boundary rule** to CLAUDE.md -- CoS agents must write research/plans/docs for managed apps in those apps' repos, not PortOS
 - **Updated Next Actions** -- focused on M42 Identity System, M7 App Templates, M34 behavioral feedback

--- a/.changelog/v0.17.x.md
+++ b/.changelog/v0.17.x.md
@@ -18,3 +18,9 @@ JIRA integration improvements and token lifecycle management.
 ### CityHud scan line: CSS animation instead of setInterval
 - Replaced 50ms `setInterval` (20 React re-renders/sec) with a pure CSS `@keyframes` animation
 - Eliminates unnecessary React state updates and re-renders for a visual-only effect
+
+### Convert sync file I/O to async in server route handlers
+- `attachments.js` GET /: replaced `readdirSync` + `statSync` loop with async `readdir` + `Promise.all(stat)`
+- `detect.js` POST /repo: replaced `statSync` with async `stat`
+- `visionTest.js` runVisionTestSuite: replaced `readdirSync` with async `readdir`
+- Prevents event loop blocking when listing large directories

--- a/.changelog/v0.17.x.md
+++ b/.changelog/v0.17.x.md
@@ -53,3 +53,7 @@ JIRA integration improvements and token lifecycle management.
 - **Detail panel** shows full memory content, tags, timestamps, confidence, and clickable list of connected nodes
 - **Legend overlay** with type colors and edge style (linked vs similar)
 - **URL-driven view routing** — memory tab views (`list`, `timeline`, `graph`) are now deep-linkable via `?view=graph` query param
+
+### Automated release-check self-improvement task
+- **Weekly `release-check` CoS task** evaluates whether `dev` has accumulated enough changelog entries for a release, creates a PR to `main`, requests GitHub Copilot code review, iterates on feedback (up to 5 rounds), and auto-merges when clean
+- Fully integrated with existing schedule system — appears in Schedule tab with enable/disable toggle and on-demand trigger

--- a/.changelog/v0.17.x.md
+++ b/.changelog/v0.17.x.md
@@ -40,3 +40,16 @@ JIRA integration improvements and token lifecycle management.
 ### Replace raw JSON.parse with safeJSONParse in 5 services
 - `platformAccounts.js`, `agentPersonalities.js`, `cosEvolution.js`, `missions.js`, `agentDrafts.js`
 - Corrupted JSON files now gracefully fall back to defaults instead of crashing the process
+
+### Atomic state writes and full mutex coverage for CoS state
+- `saveState()` now writes to a temp file then renames (atomic on POSIX), preventing half-written JSON on crash/interrupt
+- `start()`, `stop()`, `pause()`, `resume()` now use `withStateLock` — previously these 4 lifecycle functions wrote state without the mutex, racing with 18+ other locked write paths
+- Root cause fix for the recurring `state.json` corruption that produced 500+ `.corrupted` backup files
+
+### Interactive memory graph visualization
+- **Canvas-based force-directed graph** renders all memory nodes with Coulomb repulsion + Hooke spring attraction
+- **Colored by type** (fact/learning/observation/decision/preference/context) with radius scaled by importance
+- **Interactions**: hover tooltip, click to select + highlight connections, drag to reposition nodes, scroll to zoom, drag empty space to pan
+- **Detail panel** below canvas shows selected node summary, type, importance, and clickable list of connected nodes
+- **Legend overlay** with type colors and edge style (solid=linked, dashed=similar)
+- **URL-driven view routing** — memory tab views (`list`, `timeline`, `graph`) are now deep-linkable via `?view=graph` query param

--- a/.changelog/v0.17.x.md
+++ b/.changelog/v0.17.x.md
@@ -1,0 +1,14 @@
+# Release v0.17.x - Changelog
+
+Released: YYYY-MM-DD
+
+## Overview
+
+JIRA integration improvements and token lifecycle management.
+
+## Features
+
+### JIRA token expiry tracking and warning
+- **Tracks `tokenUpdatedAt`** on each instance when a PAT is saved, separate from `updatedAt` which changes on any edit
+- **Client shows expiry warnings** based on 30-day PAT lifetime: yellow warning at 5 days remaining, red alert when expired
+- **Handles legacy instances** without `tokenUpdatedAt` gracefully — prompts user to re-save to start tracking

--- a/.changelog/v0.17.x.md
+++ b/.changelog/v0.17.x.md
@@ -30,3 +30,7 @@ JIRA integration improvements and token lifecycle management.
 - `detect.js` POST /repo: replaced `statSync` with async `stat`
 - `visionTest.js` runVisionTestSuite: replaced `readdirSync` with async `readdir`
 - Prevents event loop blocking when listing large directories
+
+### Replace raw JSON.parse with safeJSONParse in 5 services
+- `platformAccounts.js`, `agentPersonalities.js`, `cosEvolution.js`, `missions.js`, `agentDrafts.js`
+- Corrupted JSON files now gracefully fall back to defaults instead of crashing the process

--- a/.changelog/v0.17.x.md
+++ b/.changelog/v0.17.x.md
@@ -46,10 +46,10 @@ JIRA integration improvements and token lifecycle management.
 - `start()`, `stop()`, `pause()`, `resume()` now use `withStateLock` — previously these 4 lifecycle functions wrote state without the mutex, racing with 18+ other locked write paths
 - Root cause fix for the recurring `state.json` corruption that produced 500+ `.corrupted` backup files
 
-### Interactive memory graph visualization
-- **Canvas-based force-directed graph** renders all memory nodes with Coulomb repulsion + Hooke spring attraction
-- **Colored by type** (fact/learning/observation/decision/preference/context) with radius scaled by importance
-- **Interactions**: hover tooltip, click to select + highlight connections, drag to reposition nodes, scroll to zoom, drag empty space to pan
-- **Detail panel** below canvas shows selected node summary, type, importance, and clickable list of connected nodes
-- **Legend overlay** with type colors and edge style (solid=linked, dashed=similar)
+### Interactive 3D memory graph visualization
+- **React Three Fiber 3D force-directed graph** with Coulomb repulsion, spring attraction, and center gravity — nodes settle via physics simulation
+- **Colored by type** (fact/learning/observation/decision/preference/context) with sphere radius scaled by importance
+- **Interactions**: hover tooltip, click to select + highlight connections (dims unrelated nodes/edges), orbit controls for rotate/zoom/pan, re-layout button
+- **Detail panel** shows full memory content, tags, timestamps, confidence, and clickable list of connected nodes
+- **Legend overlay** with type colors and edge style (linked vs similar)
 - **URL-driven view routing** — memory tab views (`list`, `timeline`, `graph`) are now deep-linkable via `?view=graph` query param

--- a/.changelog/v0.17.x.md
+++ b/.changelog/v0.17.x.md
@@ -13,6 +13,12 @@ JIRA integration improvements and token lifecycle management.
 - **Client shows expiry warnings** based on 30-day PAT lifetime: yellow warning at 5 days remaining, red alert when expired
 - **Handles legacy instances** without `tokenUpdatedAt` gracefully — prompts user to re-save to start tracking
 
+### JIRA ticket transitions, deletion, and update CLI
+- **`jira-update-ticket.js` CLI** — update fields, add comments, transition status, or delete tickets from the command line
+- **`--transition "Done"`** moves a ticket to any status by name (or numeric ID); `--transitions` lists available transitions
+- **`--delete`** deletes a ticket directly from the CLI
+- **`getTransitions()` and `deleteTicket()`** added to the JIRA service and routes for programmatic use
+
 ## Improvements
 
 ### CityHud scan line: CSS animation instead of setInterval

--- a/.changelog/v0.17.x.md
+++ b/.changelog/v0.17.x.md
@@ -12,3 +12,9 @@ JIRA integration improvements and token lifecycle management.
 - **Tracks `tokenUpdatedAt`** on each instance when a PAT is saved, separate from `updatedAt` which changes on any edit
 - **Client shows expiry warnings** based on 30-day PAT lifetime: yellow warning at 5 days remaining, red alert when expired
 - **Handles legacy instances** without `tokenUpdatedAt` gracefully — prompts user to re-save to start tracking
+
+## Improvements
+
+### CityHud scan line: CSS animation instead of setInterval
+- Replaced 50ms `setInterval` (20 React re-renders/sec) with a pure CSS `@keyframes` animation
+- Eliminates unnecessary React state updates and re-renders for a visual-only effect

--- a/.changelog/v0.17.x.md
+++ b/.changelog/v0.17.x.md
@@ -19,6 +19,12 @@ JIRA integration improvements and token lifecycle management.
 - **`--delete`** deletes a ticket directly from the CLI
 - **`getTransitions()` and `deleteTicket()`** added to the JIRA service and routes for programmatic use
 
+### CoS agent git isolation for managed apps
+- **Managed app tasks always get an isolated worktree** based on the latest `origin/main` (or `origin/master`) — prevents cross-agent contamination from dirty state, stale branches, or other agents' uncommitted changes
+- **Worktrees now fetch + base off the remote default branch** instead of whatever `HEAD` happens to be locally — agents start from a known-clean state
+- **JIRA feature branches** also start from the latest default branch when working on managed apps
+- **Agent prompt includes explicit git hygiene rules** — verify clean working tree before starting, stage only specific files (never `git add .`), and refuse to commit or PR unrelated changes
+
 ## Improvements
 
 ### CityHud scan line: CSS animation instead of setInterval

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.16.15",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-client",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/client/src/components/city/CityHud.jsx
+++ b/client/src/components/city/CityHud.jsx
@@ -151,7 +151,7 @@ export default function CityHud({ cosStatus, cosAgents, agentMap, eventLogs, con
 
           {/* Animated scan line (CSS-only, no React re-renders) */}
           <div
-            className="absolute left-0 right-0 h-px bg-cyan-400/15 pointer-events-none animate-[scanline_5s_linear_infinite]"
+            className="absolute left-0 right-0 h-px bg-cyan-400/15 pointer-events-none animate-scanline"
           />
 
           <div className="font-pixel text-[10px] text-cyan-500/70 tracking-wider mb-1">

--- a/client/src/components/city/CityHud.jsx
+++ b/client/src/components/city/CityHud.jsx
@@ -99,21 +99,11 @@ export default function CityHud({ cosStatus, cosAgents, agentMap, eventLogs, con
   const location = useLocation();
   const [time, setTime] = useState(new Date());
   const [uptimeSeconds, setUptimeSeconds] = useState(0);
-  const [scanLine, setScanLine] = useState(0);
-
   useEffect(() => {
     const interval = setInterval(() => {
       setTime(new Date());
       setUptimeSeconds(prev => prev + 1);
     }, 1000);
-    return () => clearInterval(interval);
-  }, []);
-
-  // Animated scan line in the vitals panel
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setScanLine(prev => (prev + 1) % 100);
-    }, 50);
     return () => clearInterval(interval);
   }, []);
 
@@ -159,10 +149,9 @@ export default function CityHud({ cosStatus, cosAgents, agentMap, eventLogs, con
           <HudCorner position="bl" />
           <HudCorner position="br" />
 
-          {/* Animated scan line */}
+          {/* Animated scan line (CSS-only, no React re-renders) */}
           <div
-            className="absolute left-0 right-0 h-px bg-cyan-400/15 pointer-events-none"
-            style={{ top: `${scanLine}%` }}
+            className="absolute left-0 right-0 h-px bg-cyan-400/15 pointer-events-none animate-[scanline_5s_linear_infinite]"
           />
 
           <div className="font-pixel text-[10px] text-cyan-500/70 tracking-wider mb-1">

--- a/client/src/components/cos/tabs/MemoryGraph.jsx
+++ b/client/src/components/cos/tabs/MemoryGraph.jsx
@@ -1,13 +1,251 @@
-import { useState, useEffect } from 'react';
-import { RefreshCw, Brain } from 'lucide-react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import * as THREE from 'three';
+import { RefreshCw } from 'lucide-react';
 import * as api from '../../../services/api';
+import { MEMORY_TYPES, MEMORY_TYPE_COLORS } from '../constants';
+
+const TYPE_HEX = {
+  fact: '#3b82f6',
+  learning: '#22c55e',
+  observation: '#a855f7',
+  decision: '#f97316',
+  preference: '#ec4899',
+  context: '#6b7280'
+};
+
+// 3D force simulation parameters
+const REPULSION = 500;
+const SPRING_K = 0.008;
+const SPRING_REST = 12;
+const CENTER_GRAVITY = 0.02;
+const DAMPING = 0.9;
+const ALPHA_DECAY = 0.995;
+const ALPHA_MIN = 0.001;
+
+function tickSim(nodes, edges, alpha) {
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      const a = nodes[i], b = nodes[j];
+      const dx = b.x - a.x, dy = b.y - a.y, dz = b.z - a.z;
+      const dist = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+      const force = REPULSION / (dist * dist);
+      const fx = (dx / dist) * force * alpha;
+      const fy = (dy / dist) * force * alpha;
+      const fz = (dz / dist) * force * alpha;
+      a.vx -= fx; a.vy -= fy; a.vz -= fz;
+      b.vx += fx; b.vy += fy; b.vz += fz;
+    }
+  }
+  for (const e of edges) {
+    const a = e.sourceNode, b = e.targetNode;
+    const dx = b.x - a.x, dy = b.y - a.y, dz = b.z - a.z;
+    const dist = Math.sqrt(dx * dx + dy * dy + dz * dz) || 1;
+    const disp = dist - SPRING_REST;
+    const force = SPRING_K * disp * alpha;
+    const fx = (dx / dist) * force, fy = (dy / dist) * force, fz = (dz / dist) * force;
+    a.vx += fx; a.vy += fy; a.vz += fz;
+    b.vx -= fx; b.vy -= fy; b.vz -= fz;
+  }
+  for (const n of nodes) {
+    n.vx -= n.x * CENTER_GRAVITY * alpha;
+    n.vy -= n.y * CENTER_GRAVITY * alpha;
+    n.vz -= n.z * CENTER_GRAVITY * alpha;
+    n.vx *= DAMPING; n.vy *= DAMPING; n.vz *= DAMPING;
+    n.x += n.vx; n.y += n.vy; n.z += n.vz;
+  }
+}
+
+function settleSimulation(nodes, edges) {
+  let alpha = 1;
+  while (alpha > ALPHA_MIN) {
+    tickSim(nodes, edges, alpha);
+    alpha *= ALPHA_DECAY;
+  }
+}
+
+function buildGraph(rawNodes, rawEdges) {
+  const simNodes = rawNodes.map((n, i) => ({
+    ...n,
+    x: (Math.random() - 0.5) * 60,
+    y: (Math.random() - 0.5) * 60,
+    z: (Math.random() - 0.5) * 60,
+    vx: 0, vy: 0, vz: 0,
+    index: i
+  }));
+  const idMap = new Map(simNodes.map(n => [n.id, n]));
+  const simEdges = rawEdges
+    .map(e => ({ ...e, sourceNode: idMap.get(e.source), targetNode: idMap.get(e.target) }))
+    .filter(e => e.sourceNode && e.targetNode);
+  settleSimulation(simNodes, simEdges);
+  return { simNodes, simEdges, idMap };
+}
+
+// --- Three.js scene components ---
+
+function GraphEdges({ simEdges, selectedId }) {
+  const geoRef = useRef();
+
+  useEffect(() => {
+    const geo = geoRef.current;
+    if (!geo || !simEdges.length) return;
+
+    const count = simEdges.length;
+    const positions = new Float32Array(count * 6);
+    const colors = new Float32Array(count * 6);
+    const tmpColor = new THREE.Color();
+
+    simEdges.forEach((e, i) => {
+      const a = e.sourceNode, b = e.targetNode;
+      const off = i * 6;
+      positions[off] = a.x; positions[off + 1] = a.y; positions[off + 2] = a.z;
+      positions[off + 3] = b.x; positions[off + 4] = b.y; positions[off + 5] = b.z;
+
+      const dimmed = selectedId && e.source !== selectedId && e.target !== selectedId;
+      tmpColor.set(e.type === 'linked' ? '#3b82f6' : '#6b7280');
+      const intensity = dimmed ? 0.06 : (e.type === 'linked' ? 0.6 * e.weight : 0.3 * e.weight);
+      const r = tmpColor.r * intensity, g = tmpColor.g * intensity, bl = tmpColor.b * intensity;
+      colors[off] = r; colors[off + 1] = g; colors[off + 2] = bl;
+      colors[off + 3] = r; colors[off + 4] = g; colors[off + 5] = bl;
+    });
+
+    geo.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geo.setAttribute('color', new THREE.BufferAttribute(colors, 3));
+    geo.computeBoundingSphere();
+  }, [simEdges, selectedId]);
+
+  return (
+    <lineSegments>
+      <bufferGeometry ref={geoRef} />
+      <lineBasicMaterial vertexColors />
+    </lineSegments>
+  );
+}
+
+function GraphScene({ graph, selectedId, adjacentIds, onSelect, onHover }) {
+  const sphereGeo = useMemo(() => new THREE.SphereGeometry(1, 16, 12), []);
+
+  const selNode = selectedId ? graph.idMap.get(selectedId) : null;
+  const selRadius = selNode ? 0.4 + (selNode.importance ?? 0.5) * 0.8 : 0;
+
+  return (
+    <>
+      <ambientLight intensity={0.4} />
+      <pointLight position={[50, 50, 50]} intensity={0.8} />
+      <pointLight position={[-30, -30, -30]} intensity={0.3} />
+
+      <GraphEdges simEdges={graph.simEdges} selectedId={selectedId} />
+
+      {graph.simNodes.map(node => {
+        const radius = 0.4 + (node.importance ?? 0.5) * 0.8;
+        const color = TYPE_HEX[node.type] || '#6b7280';
+        const isSelected = node.id === selectedId;
+        const isConnected = adjacentIds?.has(node.id);
+        const dimmed = selectedId && !isSelected && !isConnected;
+
+        return (
+          <mesh
+            key={node.id}
+            geometry={sphereGeo}
+            scale={radius}
+            position={[node.x, node.y, node.z]}
+            onClick={(e) => { e.stopPropagation(); onSelect(node); }}
+            onPointerOver={(e) => { e.stopPropagation(); onHover(node); }}
+            onPointerOut={() => onHover(null)}
+          >
+            <meshStandardMaterial
+              color={dimmed ? '#1a1a1a' : color}
+              emissive={color}
+              emissiveIntensity={isSelected ? 0.6 : (dimmed ? 0.03 : 0.2)}
+            />
+          </mesh>
+        );
+      })}
+
+      {selNode && (
+        <mesh geometry={sphereGeo} position={[selNode.x, selNode.y, selNode.z]} scale={selRadius + 0.2}>
+          <meshBasicMaterial color="#ffffff" transparent opacity={0.15} wireframe />
+        </mesh>
+      )}
+
+      <OrbitControls enableDamping dampingFactor={0.05} minDistance={10} maxDistance={200} />
+    </>
+  );
+}
+
+// --- Outer component ---
 
 export default function MemoryGraph() {
   const [graphData, setGraphData] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [selectedNode, setSelectedNode] = useState(null);
+  const [fullMemory, setFullMemory] = useState(null);
+  const [hoveredNode, setHoveredNode] = useState(null);
+  const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+  const [layoutKey, setLayoutKey] = useState(0);
+
+  const graphRef = useRef(null);
+  const dragStartRef = useRef(null);
 
   useEffect(() => {
     api.getMemoryGraph().then(setGraphData).catch(() => setGraphData(null)).finally(() => setLoading(false));
+  }, []);
+
+  const graph = useMemo(() => {
+    if (!graphData?.nodes?.length) return null;
+    const g = buildGraph(graphData.nodes, graphData.edges);
+    graphRef.current = g;
+    return g;
+  }, [graphData, layoutKey]);
+
+  const adjacentIds = useMemo(() => {
+    if (!selectedNode || !graph) return null;
+    const set = new Set();
+    for (const e of graph.simEdges) {
+      if (e.source === selectedNode.id) set.add(e.target);
+      if (e.target === selectedNode.id) set.add(e.source);
+    }
+    return set;
+  }, [selectedNode, graph]);
+
+  const connectedEdges = selectedNode && graph
+    ? graph.simEdges.filter(e => e.source === selectedNode.id || e.target === selectedNode.id)
+    : [];
+  const connectedNodes = selectedNode && graph
+    ? connectedEdges.map(e => {
+        const otherId = e.source === selectedNode.id ? e.target : e.source;
+        const n = graph.idMap.get(otherId);
+        return n ? { ...n, edgeType: e.type, weight: e.weight } : null;
+      }).filter(Boolean)
+    : [];
+
+  // Fetch full memory details when a node is selected
+  useEffect(() => {
+    if (!selectedNode) { setFullMemory(null); return; }
+    let cancelled = false;
+    api.getMemory(selectedNode.id).then(mem => {
+      if (!cancelled) setFullMemory(mem);
+    }).catch(() => {
+      if (!cancelled) setFullMemory(null);
+    });
+    return () => { cancelled = true; };
+  }, [selectedNode?.id]);
+
+  const handleSelect = useCallback((node) => {
+    setSelectedNode(prev => prev?.id === node.id ? null : node);
+  }, []);
+
+  const handleHover = useCallback((node) => {
+    setHoveredNode(node);
+  }, []);
+
+  const handlePointerMissed = useCallback((e) => {
+    const start = dragStartRef.current;
+    if (!start) return;
+    if (Math.abs(e.clientX - start.x) < 5 && Math.abs(e.clientY - start.y) < 5) {
+      setSelectedNode(null);
+    }
   }, []);
 
   if (loading) {
@@ -27,12 +265,147 @@ export default function MemoryGraph() {
   }
 
   return (
-    <div className="bg-port-card border border-port-border rounded-lg p-4 min-h-[400px]">
-      <div className="text-center text-gray-500">
-        <Brain size={48} className="mx-auto mb-4 text-port-accent/50" />
-        <p>Graph visualization coming soon</p>
-        <p className="text-sm mt-2">{graphData.nodes.length} nodes * {graphData.edges.length} connections</p>
+    <div className="space-y-3">
+      {/* Stats bar */}
+      <div className="flex items-center justify-between bg-port-card border border-port-border rounded-lg px-4 py-2">
+        <span className="text-sm text-gray-400">
+          {graphData.nodes.length} nodes &middot; {graphData.edges.length} connections
+        </span>
+        <button
+          onClick={() => { setSelectedNode(null); setLayoutKey(k => k + 1); }}
+          className="px-3 py-1.5 min-h-[36px] text-xs bg-port-border text-gray-400 hover:text-white rounded-lg transition-colors"
+        >
+          Re-layout
+        </button>
       </div>
+
+      {/* 3D Canvas */}
+      <div
+        className="relative bg-port-card border border-port-border rounded-lg overflow-hidden"
+        style={{ height: '500px' }}
+        onPointerDown={(e) => { dragStartRef.current = { x: e.clientX, y: e.clientY }; }}
+        onPointerMove={(e) => setTooltipPos({ x: e.clientX, y: e.clientY })}
+      >
+        {graph && (
+          <Canvas
+            camera={{ position: [0, 0, 80], fov: 50 }}
+            dpr={[1, 1.5]}
+            style={{ background: '#0f0f0f' }}
+            gl={{ antialias: true }}
+            onPointerMissed={handlePointerMissed}
+          >
+            <GraphScene
+              graph={graph}
+              selectedId={selectedNode?.id}
+              adjacentIds={adjacentIds}
+              onSelect={handleSelect}
+              onHover={handleHover}
+            />
+          </Canvas>
+        )}
+
+        {/* Legend */}
+        <div className="absolute bottom-3 left-3 bg-port-bg/90 border border-port-border rounded-lg p-3 text-xs space-y-1.5 pointer-events-none">
+          {MEMORY_TYPES.map(t => (
+            <div key={t} className="flex items-center gap-2">
+              <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: TYPE_HEX[t] }} />
+              <span className="text-gray-400">{t}</span>
+            </div>
+          ))}
+          <div className="border-t border-port-border pt-1.5 mt-1.5 space-y-1">
+            <div className="flex items-center gap-2">
+              <span className="inline-block w-4 h-0 border-t border-blue-400" />
+              <span className="text-gray-500">linked</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="inline-block w-4 h-0 border-t border-gray-500" />
+              <span className="text-gray-500">similar</span>
+            </div>
+          </div>
+        </div>
+
+        {/* Tooltip */}
+        {hoveredNode && (
+          <div
+            className="fixed z-50 pointer-events-none bg-port-bg border border-port-border rounded-lg px-3 py-2 shadow-lg max-w-xs"
+            style={{ left: tooltipPos.x + 12, top: tooltipPos.y - 12 }}
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <span className={`px-1.5 py-0.5 text-[10px] rounded-full border ${MEMORY_TYPE_COLORS[hoveredNode.type] || 'border-port-border text-gray-400'}`}>
+                {hoveredNode.type}
+              </span>
+              <span className="text-[10px] text-gray-500">{hoveredNode.category}</span>
+            </div>
+            <p className="text-xs text-white leading-snug">{hoveredNode.summary}</p>
+            <p className="text-[10px] text-gray-500 mt-1">importance: {((hoveredNode.importance ?? 0.5) * 100).toFixed(0)}%</p>
+          </div>
+        )}
+      </div>
+
+      {/* Detail panel */}
+      {selectedNode && (
+        <div className="bg-port-card border border-port-border rounded-lg p-4">
+          <div className="flex items-start justify-between gap-3 mb-3">
+            <div>
+              <div className="flex items-center gap-2 mb-2">
+                <span className={`px-2 py-1 text-xs rounded-full border ${MEMORY_TYPE_COLORS[selectedNode.type] || 'border-port-border text-gray-400'}`}>
+                  {selectedNode.type}
+                </span>
+                <span className="text-xs text-gray-500">{selectedNode.category}</span>
+                <span className="text-xs text-gray-500">importance: {((selectedNode.importance ?? 0.5) * 100).toFixed(0)}%</span>
+              </div>
+              {fullMemory ? (
+                <div className="space-y-3">
+                  <p className="text-sm text-white whitespace-pre-wrap">{fullMemory.content}</p>
+                  {fullMemory.tags?.length > 0 && (
+                    <div className="flex flex-wrap gap-1">
+                      {fullMemory.tags.map(tag => (
+                        <span key={tag} className="px-2 py-1 text-xs bg-port-border rounded text-gray-400">{tag}</span>
+                      ))}
+                    </div>
+                  )}
+                  <div className="text-xs text-gray-500 flex flex-wrap gap-3">
+                    <span>Created: {new Date(fullMemory.createdAt).toLocaleDateString()}</span>
+                    {fullMemory.accessCount > 0 && <span>Accessed: {fullMemory.accessCount}x</span>}
+                    {fullMemory.confidence != null && <span>Confidence: {(fullMemory.confidence * 100).toFixed(0)}%</span>}
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-white">{selectedNode.summary}</p>
+              )}
+            </div>
+            <button
+              onClick={() => setSelectedNode(null)}
+              className="text-gray-500 hover:text-white transition-colors p-1 flex-shrink-0"
+            >
+              &times;
+            </button>
+          </div>
+          {connectedNodes.length > 0 && (
+            <div>
+              <p className="text-xs text-gray-500 mb-2">{connectedNodes.length} connections</p>
+              <div className="space-y-1.5 max-h-48 overflow-y-auto">
+                {connectedNodes.map(cn => (
+                  <button
+                    key={cn.id}
+                    onClick={() => {
+                      const node = graphRef.current?.idMap.get(cn.id);
+                      if (node) setSelectedNode(node);
+                    }}
+                    className="w-full text-left flex items-center gap-2 px-2 py-1.5 rounded hover:bg-port-border/50 transition-colors"
+                  >
+                    <span className="inline-block w-2 h-2 rounded-full flex-shrink-0" style={{ backgroundColor: TYPE_HEX[cn.type] }} />
+                    <span className="text-xs text-gray-300 truncate flex-1">{cn.summary}</span>
+                    <span className="text-[10px] text-gray-600 flex-shrink-0">
+                      {cn.edgeType === 'linked' ? 'linked' : `${(cn.weight * 100).toFixed(0)}%`}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/components/cos/tabs/MemoryTab.jsx
+++ b/client/src/components/cos/tabs/MemoryTab.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { RefreshCw, Trash2, X, Check, XCircle, Pencil } from 'lucide-react';
 import toast from 'react-hot-toast';
 import * as api from '../../../services/api';
@@ -9,14 +10,23 @@ import MemoryGraph from './MemoryGraph';
 import MemoryEditModal from './MemoryEditModal';
 
 export default function MemoryTab({ apps = [] }) {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [memories, setMemories] = useState([]);
   const [pendingMemories, setPendingMemories] = useState([]);
   const [stats, setStats] = useState(null);
   const [loading, setLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState(null);
-  const [view, setView] = useState('list'); // list, timeline, graph
   const [filters, setFilters] = useState({ types: [] });
+
+  const view = searchParams.get('view') || 'list';
+  const setView = useCallback((v) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      next.set('view', v);
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
   const [embeddingStatus, setEmbeddingStatus] = useState(null);
   const [editingMemory, setEditingMemory] = useState(null);
 

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -21,6 +21,9 @@ export default {
           '100%': { top: '100%' },
         },
       },
+      animation: {
+        scanline: 'scanline 5s linear infinite',
+      },
     },
   },
   plugins: [],

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -14,7 +14,13 @@ export default {
         'port-success': '#22c55e',
         'port-warning': '#f59e0b',
         'port-error': '#ef4444'
-      }
+      },
+      keyframes: {
+        scanline: {
+          '0%': { top: '0%' },
+          '100%': { top: '100%' },
+        },
+      },
     },
   },
   plugins: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.17.6",
+      "version": "0.17.7",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.17.6",
+      "version": "0.17.7",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -9268,7 +9268,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.17.6",
+      "version": "0.17.7",
       "dependencies": {
         "axios": "^1.7.9",
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -9268,7 +9268,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "dependencies": {
         "axios": "^1.7.9",
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.17.7",
+      "version": "0.17.8",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.17.7",
+      "version": "0.17.8",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -9268,7 +9268,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.17.7",
+      "version": "0.17.8",
       "dependencies": {
         "axios": "^1.7.9",
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.17.4",
+      "version": "0.17.5",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.17.4",
+      "version": "0.17.5",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -9268,7 +9268,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.17.4",
+      "version": "0.17.5",
       "dependencies": {
         "axios": "^1.7.9",
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.16.15",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.16.15",
+      "version": "0.17.0",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.16.15",
+      "version": "0.17.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -9268,7 +9268,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.16.15",
+      "version": "0.17.0",
       "dependencies": {
         "axios": "^1.7.9",
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -9268,7 +9268,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "axios": "^1.7.9",
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -9268,7 +9268,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
         "axios": "^1.7.9",
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -9268,7 +9268,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.17.3",
+      "version": "0.17.4",
       "dependencies": {
         "axios": "^1.7.9",
         "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "0.17.5",
+      "version": "0.17.6",
       "license": "MIT",
       "workspaces": [
         "packages/*",
@@ -29,7 +29,7 @@
     },
     "client": {
       "name": "portos-client",
-      "version": "0.17.5",
+      "version": "0.17.6",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -9268,7 +9268,7 @@
     },
     "server": {
       "name": "portos-server",
-      "version": "0.17.5",
+      "version": "0.17.6",
       "dependencies": {
         "axios": "^1.7.9",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.16.15",
+  "version": "0.17.0",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/scripts/jira-update-ticket.js
+++ b/scripts/jira-update-ticket.js
@@ -41,17 +41,25 @@ function parseArgs() {
   const args = process.argv.slice(2);
   const parsed = {};
 
+  const requireValue = (flag) => {
+    if (i + 1 >= args.length) {
+      console.error(`❌ Missing value for ${flag}`);
+      process.exit(1);
+    }
+    return args[++i];
+  };
+
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
-      case '--app': parsed.app = args[++i]; break;
-      case '--ticket': parsed.ticket = args[++i]; break;
-      case '--summary': parsed.summary = args[++i]; break;
-      case '--description': parsed.description = args[++i]; break;
-      case '--comment': parsed.comment = args[++i]; break;
-      case '--points': parsed.points = parseInt(args[++i]) || undefined; break;
-      case '--assignee': parsed.assignee = args[++i]; break;
-      case '--labels': parsed.labels = args[++i].split(',').map(l => l.trim()); break;
-      case '--transition': parsed.transition = args[++i]; break;
+      case '--app': parsed.app = requireValue('--app'); break;
+      case '--ticket': parsed.ticket = requireValue('--ticket'); break;
+      case '--summary': parsed.summary = requireValue('--summary'); break;
+      case '--description': parsed.description = requireValue('--description'); break;
+      case '--comment': parsed.comment = requireValue('--comment'); break;
+      case '--points': parsed.points = parseInt(requireValue('--points')) || undefined; break;
+      case '--assignee': parsed.assignee = requireValue('--assignee'); break;
+      case '--labels': parsed.labels = requireValue('--labels').split(',').map(l => l.trim()); break;
+      case '--transition': parsed.transition = requireValue('--transition'); break;
       case '--transitions': parsed.listTransitions = true; break;
       case '--delete': parsed.delete = true; break;
       case '--help': case '-h':

--- a/scripts/jira-update-ticket.js
+++ b/scripts/jira-update-ticket.js
@@ -1,0 +1,187 @@
+#!/usr/bin/env node
+/**
+ * CLI: Update a JIRA ticket using PortOS JIRA service
+ *
+ * Usage:
+ *   node scripts/jira-update-ticket.js --app <appName> --ticket CONTECH-123 [options]
+ *
+ * Options:
+ *   --app          App name (looks up JIRA config from apps.json)
+ *   --ticket       Ticket key (e.g. CONTECH-4006) (required)
+ *   --summary      Update ticket summary/title
+ *   --description  Update ticket description
+ *   --comment      Add a comment to the ticket
+ *   --points       Update story points
+ *   --assignee     Update assignee
+ *   --labels       Update labels (comma-separated)
+ *   --transition   Transition ticket status (name like "In Review", "Done", or numeric ID)
+ *   --transitions  List available transitions for the ticket
+ *   --delete       Delete the ticket
+ *
+ * Examples:
+ *   node scripts/jira-update-ticket.js --app grace --ticket CONTECH-4006 --summary "New title"
+ *   node scripts/jira-update-ticket.js --app grace --ticket CONTECH-4006 --comment "tone is actually used"
+ *   node scripts/jira-update-ticket.js --app grace --ticket CONTECH-4006 --transitions
+ *   node scripts/jira-update-ticket.js --app grace --ticket CONTECH-4006 --transition "Done"
+ *   node scripts/jira-update-ticket.js --app grace --ticket CONTECH-4006 --delete
+ */
+
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs/promises';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+// Import services directly
+const jiraService = await import(join(rootDir, 'server/services/jira.js'));
+
+// Parse CLI args
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = {};
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--app': parsed.app = args[++i]; break;
+      case '--ticket': parsed.ticket = args[++i]; break;
+      case '--summary': parsed.summary = args[++i]; break;
+      case '--description': parsed.description = args[++i]; break;
+      case '--comment': parsed.comment = args[++i]; break;
+      case '--points': parsed.points = parseInt(args[++i]) || undefined; break;
+      case '--assignee': parsed.assignee = args[++i]; break;
+      case '--labels': parsed.labels = args[++i].split(',').map(l => l.trim()); break;
+      case '--transition': parsed.transition = args[++i]; break;
+      case '--transitions': parsed.listTransitions = true; break;
+      case '--delete': parsed.delete = true; break;
+      case '--help': case '-h':
+        console.log(`Usage: node scripts/jira-update-ticket.js --app <name> --ticket <key> [options]
+  --app          App name (required, looks up JIRA config)
+  --ticket       Ticket key, e.g. CONTECH-4006 (required)
+  --summary      Update ticket title
+  --description  Update ticket description
+  --comment      Add a comment to the ticket
+  --points       Update story points
+  --assignee     Update assignee
+  --labels       Update labels (comma-separated)
+  --transition   Move ticket to status (name like "Done" or numeric ID)
+  --transitions  List available transitions for the ticket
+  --delete       Delete the ticket`);
+        process.exit(0);
+    }
+  }
+  return parsed;
+}
+
+async function loadAppConfig(appName) {
+  const appsFile = join(rootDir, 'data/apps.json');
+  const content = await fs.readFile(appsFile, 'utf-8');
+  const data = JSON.parse(content);
+  const apps = Object.values(data.apps || data);
+
+  const app = apps.find(a => a.name?.toLowerCase() === appName.toLowerCase());
+  if (!app) {
+    const names = apps.filter(a => a.name).map(a => a.name).join(', ');
+    console.error(`❌ App "${appName}" not found. Available apps: ${names}`);
+    process.exit(1);
+  }
+
+  if (!app.jira?.enabled) {
+    console.error(`❌ JIRA integration not enabled for app "${appName}"`);
+    process.exit(1);
+  }
+
+  return app;
+}
+
+async function main() {
+  const args = parseArgs();
+
+  if (!args.app || !args.ticket) {
+    console.error('❌ --app and --ticket are required. Use --help for usage.');
+    process.exit(1);
+  }
+
+  const app = await loadAppConfig(args.app);
+  const jira = app.jira;
+
+  // List available transitions
+  if (args.listTransitions) {
+    const transitions = await jiraService.getTransitions(jira.instanceId, args.ticket);
+    console.log(`📋 Available transitions for ${args.ticket}:`);
+    for (const t of transitions) {
+      console.log(`  ${t.id} → ${t.name}${t.to ? ` (to: ${t.to})` : ''}`);
+    }
+    return;
+  }
+
+  // Delete ticket
+  if (args.delete) {
+    console.log(`🗑️  Deleting ${args.ticket}...`);
+    await jiraService.deleteTicket(jira.instanceId, args.ticket);
+    console.log(`✅ ${args.ticket} deleted`);
+    return;
+  }
+
+  const fieldIds = {
+    storyPoints: 'customfield_10106',
+  };
+
+  // Build fields update payload
+  const fields = {};
+  if (args.summary) fields.summary = args.summary;
+  if (args.description) fields.description = args.description;
+  if (args.assignee) fields.assignee = { name: args.assignee };
+  if (args.labels) fields.labels = args.labels;
+  if (args.points) fields[fieldIds.storyPoints] = args.points;
+
+  const hasFieldUpdates = Object.keys(fields).length > 0;
+  const hasComment = !!args.comment;
+  const hasTransition = !!args.transition;
+
+  if (!hasFieldUpdates && !hasComment && !hasTransition) {
+    console.error('❌ Nothing to update. Provide at least one of: --summary, --description, --comment, --points, --assignee, --labels, --transition, --delete, --transitions');
+    process.exit(1);
+  }
+
+  // Update fields
+  if (hasFieldUpdates) {
+    const updatedFields = Object.keys(fields).join(', ');
+    console.log(`✏️  Updating ${args.ticket} (${updatedFields})...`);
+    const result = await jiraService.updateTicket(jira.instanceId, args.ticket, fields);
+    console.log(`✅ ${result.ticketId} updated`);
+    console.log(`🔗 ${result.url}`);
+    console.log(JSON.stringify(result));
+  }
+
+  // Add comment
+  if (hasComment) {
+    console.log(`💬 Adding comment to ${args.ticket}...`);
+    await jiraService.addComment(jira.instanceId, args.ticket, args.comment);
+    console.log(`✅ Comment added to ${args.ticket}`);
+  }
+
+  // Transition ticket
+  if (hasTransition) {
+    // Resolve transition by name or use as numeric ID
+    let transitionId = args.transition;
+    if (!/^\d+$/.test(transitionId)) {
+      const transitions = await jiraService.getTransitions(jira.instanceId, args.ticket);
+      const match = transitions.find(t => t.name.toLowerCase() === transitionId.toLowerCase());
+      if (!match) {
+        const available = transitions.map(t => `"${t.name}" (${t.id})`).join(', ');
+        console.error(`❌ Transition "${transitionId}" not found. Available: ${available}`);
+        process.exit(1);
+      }
+      transitionId = match.id;
+    }
+    console.log(`🔄 Transitioning ${args.ticket} → ${args.transition}...`);
+    await jiraService.transitionTicket(jira.instanceId, args.ticket, transitionId);
+    console.log(`✅ ${args.ticket} transitioned to ${args.transition}`);
+  }
+}
+
+main().catch(err => {
+  console.error(`❌ ${err.message}`);
+  process.exit(1);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.17.7",
+  "version": "0.17.8",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.17.6",
+  "version": "0.17.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.17.5",
+  "version": "0.17.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.17.3",
+  "version": "0.17.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.16.15",
+  "version": "0.17.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.17.4",
+  "version": "0.17.5",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos-server",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/server/routes/detect.js
+++ b/server/routes/detect.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
-import { existsSync, statSync } from 'fs';
-import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { readFile, stat } from 'fs/promises';
 import { join } from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
@@ -28,7 +28,7 @@ router.post('/repo', asyncHandler(async (req, res) => {
   }
 
   // Check if it's a directory
-  const stats = statSync(path);
+  const stats = await stat(path);
   if (!stats.isDirectory()) {
     return res.json({
       valid: false,

--- a/server/routes/jira.js
+++ b/server/routes/jira.js
@@ -27,6 +27,7 @@ router.get('/instances', async (req, res, next) => {
             baseUrl: instance.baseUrl,
             email: instance.email,
             hasApiToken: !!instance.apiToken,
+            tokenUpdatedAt: instance.tokenUpdatedAt,
             createdAt: instance.createdAt,
             updatedAt: instance.updatedAt
           }
@@ -69,6 +70,7 @@ router.post('/instances', async (req, res, next) => {
       baseUrl: instance.baseUrl,
       email: instance.email,
       hasApiToken: true,
+      tokenUpdatedAt: instance.tokenUpdatedAt,
       createdAt: instance.createdAt,
       updatedAt: instance.updatedAt
     };

--- a/server/routes/jira.js
+++ b/server/routes/jira.js
@@ -178,6 +178,38 @@ router.post('/instances/:instanceId/tickets/:ticketId/comments', async (req, res
 });
 
 /**
+ * GET /api/jira/instances/:instanceId/tickets/:ticketId/transitions
+ * Get available transitions for a ticket
+ */
+router.get('/instances/:instanceId/tickets/:ticketId/transitions', async (req, res, next) => {
+  try {
+    const transitions = await jiraService.getTransitions(
+      req.params.instanceId,
+      req.params.ticketId
+    );
+    res.json(transitions);
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * DELETE /api/jira/instances/:instanceId/tickets/:ticketId
+ * Delete a JIRA ticket
+ */
+router.delete('/instances/:instanceId/tickets/:ticketId', async (req, res, next) => {
+  try {
+    const result = await jiraService.deleteTicket(
+      req.params.instanceId,
+      req.params.ticketId
+    );
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
  * POST /api/jira/instances/:instanceId/tickets/:ticketId/transition
  * Transition JIRA ticket status
  */

--- a/server/services/agentDrafts.js
+++ b/server/services/agentDrafts.js
@@ -8,7 +8,7 @@
 import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { v4 as uuidv4 } from 'uuid';
-import { ensureDir, PATHS } from '../lib/fileUtils.js';
+import { ensureDir, PATHS, safeJSONParse } from '../lib/fileUtils.js';
 
 const DRAFTS_DIR = join(PATHS.agentPersonalities, 'drafts');
 
@@ -21,7 +21,7 @@ async function loadDrafts(agentId) {
   const filePath = await getDraftsPath(agentId);
   const content = await readFile(filePath, 'utf-8').catch(() => null);
   if (!content) return [];
-  return JSON.parse(content);
+  return safeJSONParse(content, [], { context: `agentDrafts:${agentId}` });
 }
 
 async function saveDrafts(agentId, drafts) {

--- a/server/services/agentPersonalities.js
+++ b/server/services/agentPersonalities.js
@@ -11,7 +11,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import EventEmitter from 'events';
-import { ensureDir, PATHS } from '../lib/fileUtils.js';
+import { ensureDir, PATHS, safeJSONParse } from '../lib/fileUtils.js';
 
 const AGENTS_DIR = PATHS.agentPersonalities;
 const AGENTS_FILE = join(AGENTS_DIR, 'agents.json');
@@ -44,7 +44,7 @@ async function loadAgents() {
   }
 
   const content = await readFile(AGENTS_FILE, 'utf-8');
-  cache = JSON.parse(content);
+  cache = safeJSONParse(content, { agents: {} }, { context: 'agentPersonalities' });
   cacheTimestamp = now;
   return cache;
 }

--- a/server/services/cosEvolution.js
+++ b/server/services/cosEvolution.js
@@ -15,6 +15,7 @@ import path from 'path'
 import { v4 as uuidv4 } from 'uuid'
 import { cosEvents } from './cosEvents.js'
 import * as lmStudioManager from './lmStudioManager.js'
+import { safeJSONParse } from '../lib/fileUtils.js'
 
 const DATA_DIR = path.join(process.cwd(), 'data', 'cos')
 const EVOLUTION_FILE = path.join(DATA_DIR, 'evolution.json')
@@ -63,7 +64,7 @@ async function loadState() {
   const exists = await fs.access(EVOLUTION_FILE).then(() => true).catch(() => false)
   if (exists) {
     const content = await fs.readFile(EVOLUTION_FILE, 'utf-8')
-    evolutionState = JSON.parse(content)
+    evolutionState = safeJSONParse(content, { ...DEFAULT_STATE }, { context: 'cosEvolution' })
   } else {
     evolutionState = { ...DEFAULT_STATE }
   }

--- a/server/services/jira.js
+++ b/server/services/jira.js
@@ -56,7 +56,7 @@ export async function upsertInstance(instanceId, instanceData) {
     baseUrl: instanceData.baseUrl,
     email: instanceData.email,
     apiToken: instanceData.apiToken, // PAT (Personal Access Token)
-    tokenUpdatedAt: new Date().toISOString(),
+    tokenUpdatedAt: (instanceData.apiToken !== existing?.apiToken) ? new Date().toISOString() : (existing?.tokenUpdatedAt || new Date().toISOString()),
     createdAt: existing?.createdAt || new Date().toISOString(),
     updatedAt: new Date().toISOString()
   };

--- a/server/services/jira.js
+++ b/server/services/jira.js
@@ -48,13 +48,16 @@ export async function saveInstances(config) {
 export async function upsertInstance(instanceId, instanceData) {
   const config = await getInstances();
 
+  const existing = config.instances[instanceId];
+
   config.instances[instanceId] = {
     id: instanceId,
     name: instanceData.name,
     baseUrl: instanceData.baseUrl,
     email: instanceData.email,
     apiToken: instanceData.apiToken, // PAT (Personal Access Token)
-    createdAt: config.instances[instanceId]?.createdAt || new Date().toISOString(),
+    tokenUpdatedAt: new Date().toISOString(),
+    createdAt: existing?.createdAt || new Date().toISOString(),
     updatedAt: new Date().toISOString()
   };
 

--- a/server/services/jira.js
+++ b/server/services/jira.js
@@ -268,6 +268,44 @@ export async function addComment(instanceId, ticketId, comment) {
 }
 
 /**
+ * Get available transitions for a JIRA ticket
+ */
+export async function getTransitions(instanceId, ticketId) {
+  const config = await getInstances();
+  const instance = config.instances[instanceId];
+
+  if (!instance) {
+    throw new Error(`JIRA instance ${instanceId} not found`);
+  }
+
+  const client = createJiraClient(instance);
+  const response = await client.get(`/rest/api/2/issue/${ticketId}/transitions`);
+
+  return response.data.transitions.map(t => ({
+    id: t.id,
+    name: t.name,
+    to: t.to?.name
+  }));
+}
+
+/**
+ * Delete a JIRA ticket
+ */
+export async function deleteTicket(instanceId, ticketId) {
+  const config = await getInstances();
+  const instance = config.instances[instanceId];
+
+  if (!instance) {
+    throw new Error(`JIRA instance ${instanceId} not found`);
+  }
+
+  const client = createJiraClient(instance);
+  await client.delete(`/rest/api/2/issue/${ticketId}`);
+
+  return { success: true, ticketId };
+}
+
+/**
  * Transition JIRA ticket (change status)
  */
 export async function transitionTicket(instanceId, ticketId, transitionId) {
@@ -394,6 +432,8 @@ export default {
   createTicket,
   updateTicket,
   addComment,
+  getTransitions,
+  deleteTicket,
   transitionTicket,
   getMyCurrentSprintTickets,
   getActiveSprints,

--- a/server/services/missions.js
+++ b/server/services/missions.js
@@ -9,6 +9,7 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import { v4 as uuidv4 } from 'uuid'
 import { cosEvents } from './cosEvents.js'
+import { safeJSONParse } from '../lib/fileUtils.js'
 
 const DATA_DIR = path.join(process.cwd(), 'data', 'cos', 'missions')
 
@@ -40,8 +41,8 @@ async function loadMissions() {
     const filePath = path.join(DATA_DIR, file)
     const content = await fs.readFile(filePath, 'utf-8').catch(() => null)
     if (content) {
-      const mission = JSON.parse(content)
-      missions.push(mission)
+      const mission = safeJSONParse(content, null, { context: `mission:${file}` })
+      if (mission) missions.push(mission)
     }
   }
 

--- a/server/services/platformAccounts.js
+++ b/server/services/platformAccounts.js
@@ -11,7 +11,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import EventEmitter from 'events';
-import { ensureDir, PATHS } from '../lib/fileUtils.js';
+import { ensureDir, PATHS, safeJSONParse } from '../lib/fileUtils.js';
 
 const AGENTS_DIR = PATHS.agentPersonalities;
 const ACCOUNTS_FILE = join(AGENTS_DIR, 'accounts.json');
@@ -44,7 +44,7 @@ async function loadAccounts() {
   }
 
   const content = await readFile(ACCOUNTS_FILE, 'utf-8');
-  cache = JSON.parse(content);
+  cache = safeJSONParse(content, { accounts: {} }, { context: 'platformAccounts' });
   cacheTimestamp = now;
   return cache;
 }

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -1299,7 +1299,7 @@ export async function spawnAgentForTask(task) {
         if (defaultBranch) {
           await git.checkout(workspacePath, defaultBranch).catch(() => {});
           // Fast-forward to latest origin
-          try { execSync(`git merge --ff-only origin/${defaultBranch}`, { cwd: workspacePath, stdio: 'ignore' }); } catch {};
+          try { execSync(`git merge --ff-only origin/${defaultBranch}`, { cwd: workspacePath, stdio: 'ignore' }); } catch (err) { emitLog('warn', `Fast-forward merge of ${defaultBranch} failed: ${err.message}`, { taskId: task.id }); }
         }
       }
 

--- a/server/services/visionTest.js
+++ b/server/services/visionTest.js
@@ -5,7 +5,7 @@
  * and verifying the model can correctly interpret them.
  */
 
-import { readFile } from 'fs/promises';
+import { readFile, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, dirname, resolve, extname } from 'path';
 import { fileURLToPath } from 'url';
@@ -206,10 +206,9 @@ export async function testVision({ imagePath, prompt, expectedContent, providerI
  */
 export async function runVisionTestSuite(providerId = 'lmstudio', model) {
   const results = [];
-  const screenshotFiles = await import('fs').then(fs =>
-    fs.readdirSync(SCREENSHOTS_DIR).filter(f =>
-      /\.(png|jpg|jpeg|gif|webp)$/i.test(f)
-    )
+  const allFiles = await readdir(SCREENSHOTS_DIR).catch(() => []);
+  const screenshotFiles = allFiles.filter(f =>
+    /\.(png|jpg|jpeg|gif|webp)$/i.test(f)
   );
 
   if (screenshotFiles.length === 0) {

--- a/server/services/visionTest.test.js
+++ b/server/services/visionTest.test.js
@@ -6,21 +6,21 @@ vi.mock('./providers.js', () => ({
   getProviderById: vi.fn()
 }));
 
-// Mock fs/promises for image loading
+// Mock fs/promises for image loading and directory listing
 vi.mock('fs/promises', () => ({
-  readFile: vi.fn()
+  readFile: vi.fn(),
+  readdir: vi.fn()
 }));
 
 // Mock fs for existsSync
 vi.mock('fs', () => ({
-  existsSync: vi.fn(),
-  readdirSync: vi.fn()
+  existsSync: vi.fn()
 }));
 
 // Import mocked modules
 import { getProviderById } from './providers.js';
-import { readFile } from 'fs/promises';
-import { existsSync, readdirSync } from 'fs';
+import { readFile, readdir } from 'fs/promises';
+import { existsSync } from 'fs';
 
 describe('Vision Test Service', () => {
   const mockProvider = {
@@ -218,7 +218,7 @@ describe('Vision Test Service', () => {
 
   describe('runVisionTestSuite', () => {
     it('should return error when no screenshots available', async () => {
-      readdirSync.mockReturnValue([]);
+      readdir.mockResolvedValue([]);
 
       const result = await runVisionTestSuite('lmstudio');
 
@@ -227,7 +227,7 @@ describe('Vision Test Service', () => {
     });
 
     it('should run multiple tests on available screenshots', async () => {
-      readdirSync.mockReturnValue(['test1.png', 'test2.jpg']);
+      readdir.mockResolvedValue(['test1.png', 'test2.jpg']);
       getProviderById.mockResolvedValue(mockProvider);
       existsSync.mockReturnValue(true);
       readFile.mockResolvedValue(mockImageBuffer);

--- a/server/services/worktreeManager.js
+++ b/server/services/worktreeManager.js
@@ -72,9 +72,10 @@ export async function createWorktree(agentId, sourceWorkspace, taskId, options =
   // Determine the base: explicit option > detected default branch > current HEAD
   let baseBranch = options.baseBranch;
   if (!baseBranch) {
-    const branches = (await execGit(['branch', '--list'], sourceWorkspace)).trim();
-    if (branches.includes('main')) baseBranch = 'main';
-    else if (branches.includes('master')) baseBranch = 'master';
+    const mainExists = (await execGit(['branch', '--list', 'main'], sourceWorkspace)).trim();
+    const masterExists = (await execGit(['branch', '--list', 'master'], sourceWorkspace)).trim();
+    if (mainExists) baseBranch = 'main';
+    else if (masterExists) baseBranch = 'master';
     else baseBranch = (await execGit(['rev-parse', '--abbrev-ref', 'HEAD'], sourceWorkspace)).trim();
   }
 


### PR DESCRIPTION
# Release v0.17.x - Changelog

Released: YYYY-MM-DD

## Overview

JIRA integration improvements and token lifecycle management.

## Features

### JIRA token expiry tracking and warning
- **Tracks `tokenUpdatedAt`** on each instance when a PAT is saved, separate from `updatedAt` which changes on any edit
- **Client shows expiry warnings** based on 30-day PAT lifetime: yellow warning at 5 days remaining, red alert when expired
- **Handles legacy instances** without `tokenUpdatedAt` gracefully — prompts user to re-save to start tracking

### JIRA ticket transitions, deletion, and update CLI
- **`jira-update-ticket.js` CLI** — update fields, add comments, transition status, or delete tickets from the command line
- **`--transition "Done"`** moves a ticket to any status by name (or numeric ID); `--transitions` lists available transitions
- **`--delete`** deletes a ticket directly from the CLI
- **`getTransitions()` and `deleteTicket()`** added to the JIRA service and routes for programmatic use

### CoS agent git isolation for managed apps
- **Managed app tasks always get an isolated worktree** based on the latest `origin/main` (or `origin/master`) — prevents cross-agent contamination from dirty state, stale branches, or other agents' uncommitted changes
- **Worktrees now fetch + base off the remote default branch** instead of whatever `HEAD` happens to be locally — agents start from a known-clean state
- **JIRA feature branches** also start from the latest default branch when working on managed apps
- **Agent prompt includes explicit git hygiene rules** — verify clean working tree before starting, stage only specific files (never `git add .`), and refuse to commit or PR unrelated changes

## Improvements

### CityHud scan line: CSS animation instead of setInterval
- Replaced 50ms `setInterval` (20 React re-renders/sec) with a pure CSS `@keyframes` animation
- Eliminates unnecessary React state updates and re-renders for a visual-only effect

### Convert sync file I/O to async in server route handlers
- `attachments.js` GET /: replaced `readdirSync` + `statSync` loop with async `readdir` + `Promise.all(stat)`
- `detect.js` POST /repo: replaced `statSync` with async `stat`
- `visionTest.js` runVisionTestSuite: replaced `readdirSync` with async `readdir`
- Prevents event loop blocking when listing large directories

### Replace raw JSON.parse with safeJSONParse in 5 services
- `platformAccounts.js`, `agentPersonalities.js`, `cosEvolution.js`, `missions.js`, `agentDrafts.js`
- Corrupted JSON files now gracefully fall back to defaults instead of crashing the process

### Atomic state writes and full mutex coverage for CoS state
- `saveState()` now writes to a temp file then renames (atomic on POSIX), preventing half-written JSON on crash/interrupt
- `start()`, `stop()`, `pause()`, `resume()` now use `withStateLock` — previously these 4 lifecycle functions wrote state without the mutex, racing with 18+ other locked write paths
- Root cause fix for the recurring `state.json` corruption that produced 500+ `.corrupted` backup files

### Interactive 3D memory graph visualization
- **React Three Fiber 3D force-directed graph** with Coulomb repulsion, spring attraction, and center gravity — nodes settle via physics simulation
- **Colored by type** (fact/learning/observation/decision/preference/context) with sphere radius scaled by importance
- **Interactions**: hover tooltip, click to select + highlight connections (dims unrelated nodes/edges), orbit controls for rotate/zoom/pan, re-layout button
- **Detail panel** shows full memory content, tags, timestamps, confidence, and clickable list of connected nodes
- **Legend overlay** with type colors and edge style (linked vs similar)
- **URL-driven view routing** — memory tab views (`list`, `timeline`, `graph`) are now deep-linkable via `?view=graph` query param

### Automated release-check self-improvement task
- **Weekly `release-check` CoS task** evaluates whether `dev` has accumulated enough changelog entries for a release, creates a PR to `main`, requests GitHub Copilot code review, iterates on feedback (up to 5 rounds), and auto-merges when clean
- Fully integrated with existing schedule system — appears in Schedule tab with enable/disable toggle and on-demand trigger