### PR TITLE
feat(city): add sky theme selector and post-bloom exposure control

### DIFF
--- a/client/src/components/city/CityCelestial.jsx
+++ b/client/src/components/city/CityCelestial.jsx
@@ -1,7 +1,7 @@
 import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { CITY_COLORS } from './cityConstants';
+import { CITY_COLORS, getTimeOfDayPreset } from './cityConstants';
 
 // Orbital ring line geometry
 function OrbitalRing({ radius, tilt, color, opacity = 0.15, nightFactorRef }) {
@@ -69,7 +69,8 @@ export default function CityCelestial({ settings }) {
   const nightFactorRef = useRef(1);
 
   const timeOfDay = settings?.timeOfDay ?? 'sunset';
-  const preset = CITY_COLORS.timeOfDay[timeOfDay] ?? CITY_COLORS.timeOfDay.sunset;
+  const skyTheme = settings?.skyTheme ?? 'cyberpunk';
+  const preset = getTimeOfDayPreset(timeOfDay, skyTheme);
   const targetDaylight = preset.daylightFactor ?? 0;
 
   useFrame(({ clock }, delta) => {

--- a/client/src/components/city/CityClouds.jsx
+++ b/client/src/components/city/CityClouds.jsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo } from 'react';
+import { useRef, useMemo, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 
@@ -74,6 +74,8 @@ function Cloud({ position, scale, speed, seed }) {
     side: THREE.DoubleSide,
     blending: THREE.NormalBlending,
   }), [seed]);
+
+  useEffect(() => () => material.dispose(), [material]);
 
   useFrame(({ clock, camera }) => {
     if (!meshRef.current) return;

--- a/client/src/components/city/CityClouds.jsx
+++ b/client/src/components/city/CityClouds.jsx
@@ -1,0 +1,138 @@
+import { useRef, useMemo } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+const CLOUD_COUNT = 18;
+const CLOUD_SPREAD_X = 200;
+const CLOUD_SPREAD_Z = 200;
+const CLOUD_MIN_Y = 60;
+const CLOUD_MAX_Y = 100;
+const WIND_SPEED = 1.5;
+
+// Soft cloud billboard shader
+const CLOUD_VERT = `
+  varying vec2 vUv;
+  void main() {
+    vUv = uv;
+    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+  }
+`;
+
+const CLOUD_FRAG = `
+  uniform float uOpacity;
+  uniform vec3 uColor;
+  uniform float uTime;
+  varying vec2 vUv;
+
+  float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+  }
+  float noise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+    f = f * f * (3.0 - 2.0 * f);
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+    return mix(mix(a, b, f.x), mix(c, d, f.x), f.y);
+  }
+
+  void main() {
+    vec2 uv = vUv;
+    // Cloud shape: soft ellipse with noise-based edges
+    vec2 centered = (uv - 0.5) * 2.0;
+    // Stretch horizontally for flatter clouds
+    centered.x *= 0.7;
+    float dist = length(centered);
+    // Noise for irregular edges
+    float n = noise(uv * 4.0 + uTime * 0.05) * 0.3;
+    n += noise(uv * 8.0 - uTime * 0.03) * 0.15;
+    float shape = smoothstep(1.0 + n, 0.3, dist);
+    // Inner brightness variation
+    float inner = noise(uv * 3.0 + uTime * 0.02) * 0.2 + 0.8;
+    vec3 color = uColor * inner;
+    float alpha = shape * uOpacity;
+    gl_FragColor = vec4(color, alpha);
+  }
+`;
+
+function Cloud({ position, scale, speed, seed }) {
+  const meshRef = useRef();
+  const initialX = position[0];
+
+  const material = useMemo(() => new THREE.ShaderMaterial({
+    vertexShader: CLOUD_VERT,
+    fragmentShader: CLOUD_FRAG,
+    uniforms: {
+      uOpacity: { value: 0.6 },
+      uColor: { value: new THREE.Color('#ffffff') },
+      uTime: { value: seed * 100 },
+    },
+    transparent: true,
+    depthWrite: false,
+    side: THREE.DoubleSide,
+    blending: THREE.NormalBlending,
+  }), [seed]);
+
+  useFrame(({ clock, camera }) => {
+    if (!meshRef.current) return;
+    const t = clock.getElapsedTime();
+    material.uniforms.uTime.value = t + seed * 100;
+
+    // Drift with wind, wrap around
+    const drift = ((t * speed * WIND_SPEED + initialX + CLOUD_SPREAD_X) % (CLOUD_SPREAD_X * 2)) - CLOUD_SPREAD_X;
+    meshRef.current.position.x = drift;
+
+    // Billboard: face camera
+    meshRef.current.quaternion.copy(camera.quaternion);
+  });
+
+  return (
+    <mesh ref={meshRef} position={position} scale={scale} material={material}>
+      <planeGeometry args={[1, 1]} />
+    </mesh>
+  );
+}
+
+export default function CityClouds({ settings }) {
+  const skyTheme = settings?.skyTheme ?? 'cyberpunk';
+  const visible = skyTheme === 'dreamworld';
+
+  const clouds = useMemo(() => {
+    const items = [];
+    for (let i = 0; i < CLOUD_COUNT; i++) {
+      const seed = i / CLOUD_COUNT;
+      const x = (Math.random() - 0.5) * CLOUD_SPREAD_X * 2;
+      const y = CLOUD_MIN_Y + Math.random() * (CLOUD_MAX_Y - CLOUD_MIN_Y);
+      const z = (Math.random() - 0.5) * CLOUD_SPREAD_Z * 2;
+      const baseScale = 15 + Math.random() * 25;
+      const scaleY = baseScale * (0.3 + Math.random() * 0.3);
+      const speed = 0.3 + Math.random() * 0.7;
+      items.push({
+        key: i,
+        position: [x, y, z],
+        scale: [baseScale, scaleY, 1],
+        speed,
+        seed,
+      });
+    }
+    return items;
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <group>
+      {clouds.map(c => (
+        <Cloud
+          key={c.key}
+          position={c.position}
+          scale={c.scale}
+          speed={c.speed}
+          seed={c.seed}
+        />
+      ))}
+    </group>
+  );
+}

--- a/client/src/components/city/CityEffects.jsx
+++ b/client/src/components/city/CityEffects.jsx
@@ -198,6 +198,7 @@ export default function CityEffects({ settings }) {
     return () => {
       composer.dispose();
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- sceneExposure intentionally omitted; updated via exposurePassRef in useFrame to avoid recreating the composer on slider drag
   }, [gl, scene, camera, size.width, size.height, bloomEnabled, bloomStrength, chromaticAberration, filmGrain, colorGrading]);
 
   useFrame(({ clock }) => {

--- a/client/src/components/city/CityEffects.jsx
+++ b/client/src/components/city/CityEffects.jsx
@@ -29,9 +29,9 @@ const ExposureShader = {
     varying vec2 vUv;
     void main() {
       vec4 color = texture2D(tDiffuse, vUv);
-      // Reverse power curve: lifts shadows/midtones, preserves highlights
+      // Reverse power curve: lifts shadows/midtones, preserves highlights; higher uExposure -> brighter
       float safeExposure = max(uExposure, 0.001);
-      color.rgb = 1.0 - pow(max(1.0 - color.rgb, 0.0), vec3(1.0 / safeExposure));
+      color.rgb = 1.0 - pow(max(1.0 - color.rgb, 0.0), vec3(safeExposure));
       gl_FragColor = color;
     }
   `,

--- a/client/src/components/city/CityGround.jsx
+++ b/client/src/components/city/CityGround.jsx
@@ -2,7 +2,7 @@ import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Grid } from '@react-three/drei';
 import * as THREE from 'three';
-import { CITY_COLORS } from './cityConstants';
+import { CITY_COLORS, getTimeOfDayPreset } from './cityConstants';
 
 // Reflective puddle/wet-ground patches
 function WetPatch({ position, size, color }) {
@@ -58,7 +58,8 @@ export default function CityGround({ settings }) {
   const groundMatRef = useRef();
 
   const timeOfDay = settings?.timeOfDay ?? 'sunset';
-  const preset = CITY_COLORS.timeOfDay[timeOfDay] ?? CITY_COLORS.timeOfDay.sunset;
+  const skyTheme = settings?.skyTheme ?? 'cyberpunk';
+  const preset = getTimeOfDayPreset(timeOfDay, skyTheme);
   const groundColorTarget = useRef(new THREE.Color(preset.groundColor ?? '#0a0a20'));
   groundColorTarget.current.set(preset.groundColor ?? '#0a0a20');
   const targetRoughness = preset.groundRoughness ?? 0.7;

--- a/client/src/components/city/CityLights.jsx
+++ b/client/src/components/city/CityLights.jsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { CITY_COLORS, getTimeOfDayPreset } from './cityConstants';
+import { getTimeOfDayPreset } from './cityConstants';
 
 // Animated accent light that slowly shifts color, with reactive brightness
 function AnimatedLight({ position, baseColor, baseIntensity, distance, shiftRange = 0.1, speed = 0.5, brightnessRef, neonScaleRef }) {

--- a/client/src/components/city/CityLights.jsx
+++ b/client/src/components/city/CityLights.jsx
@@ -1,7 +1,7 @@
 import { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { CITY_COLORS } from './cityConstants';
+import { CITY_COLORS, getTimeOfDayPreset } from './cityConstants';
 
 // Animated accent light that slowly shifts color, with reactive brightness
 function AnimatedLight({ position, baseColor, baseIntensity, distance, shiftRange = 0.1, speed = 0.5, brightnessRef, neonScaleRef }) {
@@ -84,7 +84,8 @@ export default function CityLights({ settings }) {
   brightnessRef.current = settings?.ambientBrightness ?? 1.2;
 
   const timeOfDay = settings?.timeOfDay ?? 'sunset';
-  const preset = CITY_COLORS.timeOfDay[timeOfDay] ?? CITY_COLORS.timeOfDay.sunset;
+  const skyTheme = settings?.skyTheme ?? 'cyberpunk';
+  const preset = getTimeOfDayPreset(timeOfDay, skyTheme);
 
   // Neon scale: dim neon point lights during daytime (30% at noon, 100% at night)
   const neonScaleRef = useRef(1);

--- a/client/src/components/city/CityScene.jsx
+++ b/client/src/components/city/CityScene.jsx
@@ -19,6 +19,7 @@ import CityDataRain from './CityDataRain';
 import CityNeonSigns from './CityNeonSigns';
 import CityEmbers from './CityEmbers';
 import CityEffects from './CityEffects';
+import CityClouds from './CityClouds';
 import CitySky from './CitySky';
 
 export default function CityScene({ apps, agentMap, onBuildingClick, cosStatus, productivityData, settings, playSfx }) {
@@ -42,6 +43,7 @@ export default function CityScene({ apps, agentMap, onBuildingClick, cosStatus, 
       gl={{ antialias: true }}
     >
       <CitySky settings={settings} />
+      <CityClouds settings={settings} />
       <CityLights settings={settings} />
       <CityStarfield settings={settings} />
       <CityShootingStars playSfx={playSfx} settings={settings} />

--- a/client/src/components/city/CitySettingsPanel.jsx
+++ b/client/src/components/city/CitySettingsPanel.jsx
@@ -262,7 +262,7 @@ export default function CitySettingsPanel() {
               max={2.5}
               step={0.1}
               format={(v) => `${v.toFixed(1)}x`}
-              description="Post-bloom brightness lift — brightens assets without adding bloom"
+              description="Post-bloom exposure adjustment — darkens or brightens assets without adding bloom"
             />
             <SettingSlider
               label="AMBIENT BRIGHTNESS"

--- a/client/src/components/city/CitySettingsPanel.jsx
+++ b/client/src/components/city/CitySettingsPanel.jsx
@@ -255,6 +255,16 @@ export default function CitySettingsPanel() {
           <div>
             <SectionHeader title="SCENE LIGHTING" subtitle="Brightness and time of day" />
             <SettingSlider
+              label="EXPOSURE"
+              value={settings.sceneExposure ?? 1.0}
+              onChange={(v) => updateSetting('sceneExposure', v)}
+              min={0.5}
+              max={2.5}
+              step={0.1}
+              format={(v) => `${v.toFixed(1)}x`}
+              description="Post-bloom brightness lift — brightens assets without adding bloom"
+            />
+            <SettingSlider
               label="AMBIENT BRIGHTNESS"
               value={settings.ambientBrightness}
               onChange={(v) => updateSetting('ambientBrightness', v)}

--- a/client/src/components/city/CitySettingsPanel.jsx
+++ b/client/src/components/city/CitySettingsPanel.jsx
@@ -225,6 +225,32 @@ export default function CitySettingsPanel() {
 
           <div className="border-t border-cyan-500/10" />
 
+          {/* Sky Theme */}
+          <div>
+            <SectionHeader title="SKY THEME" subtitle="Change the world atmosphere" />
+            <div className="grid grid-cols-2 gap-1.5">
+              {[
+                { key: 'cyberpunk', label: 'CYBERPUNK', desc: 'Dark neon-lit night city' },
+                { key: 'dreamworld', label: 'DREAMWORLD', desc: 'Bright open-world sky with clouds' },
+              ].map(theme => (
+                <button
+                  key={theme.key}
+                  onClick={() => updateSetting('skyTheme', theme.key)}
+                  title={theme.desc}
+                  className={`font-pixel text-[9px] py-2 rounded border transition-all tracking-wide ${
+                    settings.skyTheme === theme.key
+                      ? 'bg-cyan-500/20 border-cyan-500/50 text-cyan-400 shadow-[0_0_8px_rgba(6,182,212,0.2)]'
+                      : 'bg-gray-800/40 border-gray-700/40 text-gray-500 hover:border-gray-600 hover:text-gray-400'
+                  }`}
+                >
+                  {theme.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="border-t border-cyan-500/10" />
+
           {/* Scene Lighting */}
           <div>
             <SectionHeader title="SCENE LIGHTING" subtitle="Brightness and time of day" />

--- a/client/src/components/city/CityShootingStars.jsx
+++ b/client/src/components/city/CityShootingStars.jsx
@@ -1,7 +1,7 @@
 import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { CITY_COLORS } from './cityConstants';
+import { getTimeOfDayPreset } from './cityConstants';
 
 // Vertex shader for shooting star trail
 const TRAIL_VERT = `
@@ -193,7 +193,8 @@ function ShootingStar({ index, playSfx, daylightRef }) {
 export default function CityShootingStars({ playSfx, settings }) {
   const daylightRef = useRef(0);
   const timeOfDay = settings?.timeOfDay ?? 'sunset';
-  const preset = CITY_COLORS.timeOfDay[timeOfDay] ?? CITY_COLORS.timeOfDay.sunset;
+  const skyTheme = settings?.skyTheme ?? 'cyberpunk';
+  const preset = getTimeOfDayPreset(timeOfDay, skyTheme);
   const targetDaylight = preset.daylightFactor ?? 0;
 
   useFrame((_, delta) => {

--- a/client/src/components/city/CitySky.jsx
+++ b/client/src/components/city/CitySky.jsx
@@ -1,7 +1,7 @@
 import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { CITY_COLORS, getTimeOfDayPreset } from './cityConstants';
+import { getTimeOfDayPreset } from './cityConstants';
 
 const SUN_RADIUS = 100;
 

--- a/client/src/components/city/CitySky.jsx
+++ b/client/src/components/city/CitySky.jsx
@@ -105,7 +105,7 @@ const lerpColor = (target, a, b, t) => {
 
 // Pre-allocate parsed preset colors (keyed by "theme:timeOfDay")
 const presetColors = {};
-const getPresetColors = (name, skyTheme = 'cyberpunk') => {
+const getPresetColors = (name, skyTheme) => {
   const cacheKey = `${skyTheme}:${name}`;
   if (!presetColors[cacheKey]) {
     const p = getTimeOfDayPreset(name, skyTheme);
@@ -175,10 +175,19 @@ export default function CitySky({ settings }) {
   timeOfDayRef.current = settings?.timeOfDay ?? 'sunset';
 
   const skyThemeRef = useRef(settings?.skyTheme ?? 'cyberpunk');
-  skyThemeRef.current = settings?.skyTheme ?? 'cyberpunk';
+  const previousSkyThemeRef = useRef(skyThemeRef.current);
 
   const currentPresetRef = useRef(timeOfDayRef.current);
   const transitionRef = useRef(1.0);
+
+  const nextSkyTheme = settings?.skyTheme ?? 'cyberpunk';
+  if (previousSkyThemeRef.current !== nextSkyTheme) {
+    previousSkyThemeRef.current = nextSkyTheme;
+    skyThemeRef.current = nextSkyTheme;
+    transitionRef.current = 0;
+  } else {
+    skyThemeRef.current = nextSkyTheme;
+  }
 
   const bodyGroupRef = useRef();
   const lightRef = useRef();
@@ -186,8 +195,11 @@ export default function CitySky({ settings }) {
   const currentHourRef = useRef(18); // start at sunset
 
   const skyMaterial = useMemo(() => {
-    const preset = getPresetColors('sunset');
-    const initPos = getArcPosition(18);
+    const initialTheme = settings?.skyTheme ?? 'cyberpunk';
+    const initialTod = settings?.timeOfDay ?? 'sunset';
+    const initialHour = getTimeOfDayPreset(initialTod, initialTheme).hour ?? 18;
+    const preset = getPresetColors(initialTod, initialTheme);
+    const initPos = getArcPosition(initialHour);
     return new THREE.ShaderMaterial({
       vertexShader: SkyDomeShader.vertexShader,
       fragmentShader: SkyDomeShader.fragmentShader,

--- a/client/src/components/city/CitySky.jsx
+++ b/client/src/components/city/CitySky.jsx
@@ -192,7 +192,8 @@ export default function CitySky({ settings }) {
   const bodyGroupRef = useRef();
   const lightRef = useRef();
   const currentScaleRef = useRef(1.0);
-  const currentHourRef = useRef(18); // start at sunset
+  const initialPreset = getTimeOfDayPreset(settings?.timeOfDay ?? 'sunset', settings?.skyTheme ?? 'cyberpunk');
+  const currentHourRef = useRef(initialPreset.hour ?? 18);
 
   const skyMaterial = useMemo(() => {
     const initialTheme = settings?.skyTheme ?? 'cyberpunk';
@@ -210,7 +211,7 @@ export default function CitySky({ settings }) {
         uHorizonLow: { value: preset.horizonLow.clone() },
         uSunDirection: { value: new THREE.Vector3(...initPos).normalize() },
         uSunIntensity: { value: preset.sunIntensity },
-        uIsMoon: { value: 0.0 },
+        uIsMoon: { value: preset.isMoon ? 1.0 : 0.0 },
         uTime: { value: 0 },
       },
       side: THREE.BackSide,

--- a/client/src/components/city/CityStarfield.jsx
+++ b/client/src/components/city/CityStarfield.jsx
@@ -1,7 +1,7 @@
 import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { CITY_COLORS } from './cityConstants';
+import { getTimeOfDayPreset } from './cityConstants';
 
 const STAR_VERT = `
   attribute float size;
@@ -83,7 +83,8 @@ export default function CityStarfield({ settings }) {
   }, []);
 
   const timeOfDay = settings?.timeOfDay ?? 'sunset';
-  const preset = CITY_COLORS.timeOfDay[timeOfDay] ?? CITY_COLORS.timeOfDay.sunset;
+  const skyTheme = settings?.skyTheme ?? 'cyberpunk';
+  const preset = getTimeOfDayPreset(timeOfDay, skyTheme);
   const targetDaylight = preset.daylightFactor ?? 0;
 
   useFrame(({ clock }, delta) => {

--- a/client/src/components/city/cityConstants.js
+++ b/client/src/components/city/cityConstants.js
@@ -265,9 +265,22 @@ export const getBuildingHeight = (app) => {
 // Resolve the time-of-day preset for a given sky theme
 // Returns theme-specific overrides if available, otherwise default timeOfDay preset
 export const getTimeOfDayPreset = (timeOfDay, skyTheme) => {
-  const themeOverrides = CITY_COLORS.skyThemes[skyTheme];
-  if (themeOverrides && themeOverrides[timeOfDay]) return themeOverrides[timeOfDay];
-  return CITY_COLORS.timeOfDay[timeOfDay] ?? CITY_COLORS.timeOfDay.sunset;
+  const hasOwn = Object.prototype.hasOwnProperty;
+  const skyThemes = CITY_COLORS.skyThemes;
+  const timeOfDayPresets = CITY_COLORS.timeOfDay;
+
+  if (skyThemes && hasOwn.call(skyThemes, skyTheme)) {
+    const themeOverrides = skyThemes[skyTheme];
+    if (themeOverrides && hasOwn.call(themeOverrides, timeOfDay)) {
+      return themeOverrides[timeOfDay];
+    }
+  }
+
+  if (timeOfDayPresets && hasOwn.call(timeOfDayPresets, timeOfDay)) {
+    return timeOfDayPresets[timeOfDay];
+  }
+
+  return timeOfDayPresets.sunset;
 };
 
 // Get a deterministic neon accent color per app (for windows/decorations)

--- a/client/src/components/city/cityConstants.js
+++ b/client/src/components/city/cityConstants.js
@@ -109,6 +109,98 @@ export const CITY_COLORS = {
       ambientIntensity: 0.1,
     },
   },
+  // Sky themes: visual palette overrides for time-of-day presets
+  // 'cyberpunk' uses default timeOfDay colors above
+  // 'dreamworld' bright purple/blue open-world sky with clouds
+  skyThemes: {
+    cyberpunk: null, // uses default timeOfDay colors
+    dreamworld: {
+      sunrise: {
+        hour: 6,
+        zenith: '#4a2080',
+        midSky: '#6a3aaa',
+        horizonHigh: '#ff9070',
+        horizonLow: '#ffcc88',
+        sunCore: '#ffdd66',
+        sunGlow: '#ffaa55',
+        sunLight: '#ffeecc',
+        sunIntensity: 3.0,
+        sunScale: 1.2,
+        isMoon: false,
+        daylightFactor: 0.5,
+        groundColor: '#4a4a60',
+        groundRoughness: 0.5,
+        hemiSkyColor: '#cc88ff',
+        hemiGroundColor: '#4a3a50',
+        hemiIntensity: 0.8,
+        ambientColor: '#6644aa',
+        ambientIntensity: 0.35,
+      },
+      noon: {
+        hour: 12,
+        zenith: '#4466cc',
+        midSky: '#6688dd',
+        horizonHigh: '#88aaee',
+        horizonLow: '#aaccff',
+        sunCore: '#ffffee',
+        sunGlow: '#ffffcc',
+        sunLight: '#ffffff',
+        sunIntensity: 5.0,
+        sunScale: 0.8,
+        isMoon: false,
+        daylightFactor: 1.0,
+        groundColor: '#556680',
+        groundRoughness: 0.4,
+        hemiSkyColor: '#99bbff',
+        hemiGroundColor: '#445566',
+        hemiIntensity: 1.6,
+        ambientColor: '#7799cc',
+        ambientIntensity: 0.5,
+      },
+      sunset: {
+        hour: 18,
+        zenith: '#2a1860',
+        midSky: '#5530a0',
+        horizonHigh: '#ff6088',
+        horizonLow: '#ffaa60',
+        sunCore: '#ffcc44',
+        sunGlow: '#ff8866',
+        sunLight: '#ffddbb',
+        sunIntensity: 2.5,
+        sunScale: 1.2,
+        isMoon: false,
+        daylightFactor: 0.4,
+        groundColor: '#302848',
+        groundRoughness: 0.55,
+        hemiSkyColor: '#bb6688',
+        hemiGroundColor: '#2a2040',
+        hemiIntensity: 0.6,
+        ambientColor: '#4a2266',
+        ambientIntensity: 0.3,
+      },
+      midnight: {
+        hour: 0,
+        zenith: '#0a0830',
+        midSky: '#161248',
+        horizonHigh: '#2a2266',
+        horizonLow: '#3a3080',
+        sunCore: '#ccccff',
+        sunGlow: '#9999dd',
+        sunLight: '#556688',
+        sunIntensity: 0.3,
+        sunScale: 0.7,
+        isMoon: true,
+        daylightFactor: 0.05,
+        groundColor: '#141230',
+        groundRoughness: 0.7,
+        hemiSkyColor: '#221e55',
+        hemiGroundColor: '#0a0818',
+        hemiIntensity: 0.1,
+        ambientColor: '#1a1644',
+        ambientIntensity: 0.15,
+      },
+    },
+  },
 };
 
 export const BOROUGH_PARAMS = {
@@ -168,6 +260,14 @@ export const getBuildingHeight = (app) => {
   const hash = hashString(app.name || app.id);
   const variation = (hash % 100) / 100 * BUILDING_PARAMS.heightVariation;
   return base + processBonus + variation;
+};
+
+// Resolve the time-of-day preset for a given sky theme
+// Returns theme-specific overrides if available, otherwise default timeOfDay preset
+export const getTimeOfDayPreset = (timeOfDay, skyTheme) => {
+  const themeOverrides = CITY_COLORS.skyThemes[skyTheme];
+  if (themeOverrides && themeOverrides[timeOfDay]) return themeOverrides[timeOfDay];
+  return CITY_COLORS.timeOfDay[timeOfDay] ?? CITY_COLORS.timeOfDay.sunset;
 };
 
 // Get a deterministic neon accent color per app (for windows/decorations)

--- a/client/src/hooks/useCitySettings.js
+++ b/client/src/hooks/useCitySettings.js
@@ -47,6 +47,7 @@ const DEFAULT_SETTINGS = {
   sfxEnabled: true,
   sfxVolume: 0.5,
   qualityPreset: 'high',
+  skyTheme: 'cyberpunk',
   timeOfDay: 'sunset',
   ...QUALITY_PRESETS.high,
 };

--- a/client/src/hooks/useCitySettings.js
+++ b/client/src/hooks/useCitySettings.js
@@ -10,6 +10,7 @@ const QUALITY_PRESETS = {
     particleDensity: 0.5, scanlineOverlay: false,
     ambientBrightness: 1.0,
     neonBrightness: 1.0,
+    sceneExposure: 1.0,
     dpr: [1, 1],
   },
   medium: {
@@ -19,6 +20,7 @@ const QUALITY_PRESETS = {
     particleDensity: 0.75, scanlineOverlay: true,
     ambientBrightness: 1.0,
     neonBrightness: 1.0,
+    sceneExposure: 1.0,
     dpr: [1, 1.25],
   },
   high: {
@@ -28,6 +30,7 @@ const QUALITY_PRESETS = {
     particleDensity: 1.0, scanlineOverlay: true,
     ambientBrightness: 1.2,
     neonBrightness: 1.2,
+    sceneExposure: 1.0,
     dpr: [1, 1.5],
   },
   ultra: {
@@ -37,6 +40,7 @@ const QUALITY_PRESETS = {
     particleDensity: 1.5, scanlineOverlay: true,
     ambientBrightness: 1.5,
     neonBrightness: 1.5,
+    sceneExposure: 1.2,
     dpr: [1, 2],
   },
 };


### PR DESCRIPTION
## Summary

- **Sky theme selector**: Adds a Cyberpunk/Dreamworld toggle in CitySettingsPanel. Dreamworld mode uses bright purple/blue open-world sky palettes with procedural shader-based clouds (CityClouds.jsx). Theme-specific color presets override all time-of-day settings (sunrise, noon, sunset, midnight).
- **Post-bloom exposure slider**: Adds a scene exposure pass that runs after the bloom pipeline, using a reverse power curve to lift shadows and midtones without feeding extra luminosity into the bloom calculation. Configurable from 0.5x to 2.5x in the settings panel.
- Refactors time-of-day preset resolution into a shared `getTimeOfDayPreset()` helper that respects the active sky theme, replacing direct `CITY_COLORS.timeOfDay` lookups across all city components.

## Changes

- `cityConstants.js` — Added `skyThemes` config with dreamworld palette, `getTimeOfDayPreset()` helper
- `CityClouds.jsx` — New component: procedural GLSL clouds (billboard shader, wind drift, noise edges)
- `CityEffects.jsx` — Added ExposureShader post-processing pass
- `CitySettingsPanel.jsx` — Sky theme grid selector, exposure slider
- `CitySky.jsx`, `CityCelestial.jsx`, `CityGround.jsx`, `CityLights.jsx`, `CityStarfield.jsx`, `CityShootingStars.jsx` — Updated to use `getTimeOfDayPreset()` with sky theme support
- `useCitySettings.js` — Added `skyTheme` and `sceneExposure` to defaults and quality presets

## Test plan

- [ ] Toggle between Cyberpunk and Dreamworld themes — verify sky colors, clouds, and lighting update
- [ ] Cycle through all time-of-day presets in both themes
- [ ] Adjust exposure slider — confirm shadows lift without bloom intensity increasing
- [ ] Verify all quality presets still load correctly with new defaults