### PR TITLE
fix: resolve EISDIR symlink error in update.ps1 on Windows

### DIFF
--- a/update.ps1
+++ b/update.ps1
@@ -16,8 +16,9 @@ Write-Host ""
 Write-Host "Updating dependencies..." -ForegroundColor Yellow
 
 Write-Host "  Installing root dependencies..."
-# Clean stale workspace dirs that block npm symlink creation (Windows EISDIR fix)
-# Note: install-links=true is set in .npmrc for exFAT compat; the CLI flag was redundant
+# Clean stale workspace copies that block npm install (Windows EISDIR fix).
+# .npmrc sets install-links=true (exFAT compat) so npm copies workspace packages
+# as real dirs; on re-runs npm fails to overwrite them. Remove stale copies first.
 $repoNodeModules = Join-Path -Path $PSScriptRoot -ChildPath "node_modules"
 @("portos-server", "portos-client") | ForEach-Object {
     $wsPath = Join-Path -Path $repoNodeModules -ChildPath $_
@@ -26,7 +27,7 @@ $repoNodeModules = Join-Path -Path $PSScriptRoot -ChildPath "node_modules"
         Write-Host "    Cleaned stale $wsPath"
     }
 }
-npm install
+npm install --install-links
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "  Installing client dependencies..."

--- a/update.ps1
+++ b/update.ps1
@@ -17,8 +17,10 @@ Write-Host "Updating dependencies..." -ForegroundColor Yellow
 
 Write-Host "  Installing root dependencies..."
 # Clean stale workspace dirs that block npm symlink creation (Windows EISDIR fix)
+# Note: install-links=true is set in .npmrc for exFAT compat; the CLI flag was redundant
+$repoNodeModules = Join-Path -Path $PSScriptRoot -ChildPath "node_modules"
 @("portos-server", "portos-client") | ForEach-Object {
-    $wsPath = "node_modules\$_"
+    $wsPath = Join-Path -Path $repoNodeModules -ChildPath $_
     if ((Test-Path $wsPath) -and -not ((Get-Item $wsPath).Attributes -band [IO.FileAttributes]::ReparsePoint)) {
         Remove-Item $wsPath -Recurse -Force
         Write-Host "    Cleaned stale $wsPath"

--- a/update.ps1
+++ b/update.ps1
@@ -16,7 +16,15 @@ Write-Host ""
 Write-Host "Updating dependencies..." -ForegroundColor Yellow
 
 Write-Host "  Installing root dependencies..."
-npm install --install-links
+# Clean stale workspace dirs that block npm symlink creation (Windows EISDIR fix)
+@("portos-server", "portos-client") | ForEach-Object {
+    $wsPath = "node_modules\$_"
+    if ((Test-Path $wsPath) -and -not ((Get-Item $wsPath).Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+        Remove-Item $wsPath -Recurse -Force
+        Write-Host "    Cleaned stale $wsPath"
+    }
+}
+npm install
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "  Installing client dependencies..."


### PR DESCRIPTION
## Summary

- Added pre-install cleanup step to `update.ps1` that removes stale workspace directory copies (`portos-server`, `portos-client`) from `node_modules/` before running `npm install`
- The `.npmrc` config `install-links=true` (required for exFAT compat) causes npm to copy workspace packages as real directories; on subsequent runs npm fails to overwrite these directories, producing an `EISDIR` error on Windows
- The cleanup detects real directories (not symlinks/junctions) via `ReparsePoint` attribute check and removes only those, using `$PSScriptRoot`-anchored paths for safety

## Test plan

- [x] Run `.\update.ps1` on Windows with a pre-existing `node_modules/` from a prior install — should clean stale workspace copies and succeed
- [x] Run `.\update.ps1` on a fresh clone (no `node_modules/`) — should skip cleanup and install normally
- [x] Verify workspace packages are re-copied successfully after cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)