### PR TITLE
feat: add auto-update system with GitHub release checking

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -63,6 +63,7 @@ import Logo from './Logo';
 import { useErrorNotifications } from '../hooks/useErrorNotifications';
 import { useNotifications } from '../hooks/useNotifications';
 import { useAgentFeedbackToast } from '../hooks/useAgentFeedbackToast';
+import { useUpdateChecker } from '../hooks/useUpdateChecker';
 import NotificationDropdown from './NotificationDropdown';
 import ThemeSwitcher from './ThemeSwitcher';
 import CmdKSearch from './CmdKSearch';
@@ -191,6 +192,9 @@ export default function Layout() {
 
   // Subscribe to agent completion feedback toasts
   useAgentFeedbackToast();
+
+  // Check for PortOS updates and show toast when available
+  useUpdateChecker();
 
   // Notifications for user task alerts
   const {

--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Play, Square, RotateCcw, ExternalLink, Hammer } from 'lucide-react';
 import toast from 'react-hot-toast';
@@ -14,6 +14,7 @@ import DocumentsTab from './tabs/DocumentsTab';
 import GitTab from './tabs/GitTab';
 import GsdTab from './tabs/GsdTab';
 import ProcessesTab from './tabs/ProcessesTab';
+import UpdateTab from './tabs/UpdateTab';
 
 export default function AppDetailView() {
   const { appId, tab } = useParams();
@@ -79,7 +80,10 @@ export default function AppDetailView() {
     }
   };
 
-  const visibleTabs = APP_DETAIL_TABS;
+  const visibleTabs = useMemo(() =>
+    APP_DETAIL_TABS.filter(t => t.id !== 'update' || app?.id === api.PORTOS_APP_ID),
+    [app?.id]
+  );
 
   if (loading) {
     return (
@@ -114,6 +118,8 @@ export default function AppDetailView() {
         return <GsdTab appId={appId} repoPath={app.repoPath} />;
       case 'processes':
         return <ProcessesTab pm2ProcessNames={app.pm2ProcessNames} />;
+      case 'update':
+        return <UpdateTab />;
       default:
         return <OverviewTab app={app} onRefresh={fetchApp} />;
     }

--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -119,6 +119,14 @@ export default function AppDetailView() {
       case 'processes':
         return <ProcessesTab pm2ProcessNames={app.pm2ProcessNames} />;
       case 'update':
+        if (app.id !== api.PORTOS_APP_ID) {
+          return (
+            <div className="p-6 text-center">
+              <p className="text-lg text-gray-400 mb-4">Update is not available for this app</p>
+              <Link to={`/apps/${appId}/overview`} className="text-port-accent hover:underline">Back to Overview</Link>
+            </div>
+          );
+        }
         return <UpdateTab />;
       default:
         return <OverviewTab app={app} onRefresh={fetchApp} />;

--- a/client/src/components/apps/constants.js
+++ b/client/src/components/apps/constants.js
@@ -6,4 +6,5 @@ export const APP_DETAIL_TABS = [
   { id: 'gsd', label: 'GSD' },
   { id: 'processes', label: 'Processes' },
   { id: 'tasks', label: 'Tasks' },
+  { id: 'update', label: 'Update' },
 ];

--- a/client/src/components/apps/tabs/OverviewTab.jsx
+++ b/client/src/components/apps/tabs/OverviewTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { FolderOpen, Terminal, Code, RefreshCw, Wrench, Archive, ArchiveRestore, Ticket, Download } from 'lucide-react';
+import { FolderOpen, Terminal, Code, RefreshCw, Wrench, Archive, ArchiveRestore, Ticket, Download, Tag } from 'lucide-react';
 import toast from 'react-hot-toast';
 import BrailleSpinner from '../../BrailleSpinner';
 import KanbanBoard from '../../KanbanBoard';
@@ -75,6 +75,17 @@ export default function OverviewTab({ app, onRefresh }) {
             <code className="text-sm text-gray-300 font-mono">{app.editorCommand || 'code .'}</code>
           </div>
         </div>
+        {app.appVersion && (
+          <div>
+            <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">Version</div>
+            <div className="flex items-center gap-2">
+              <Tag size={16} className="text-port-accent shrink-0" />
+              <span className="px-2 py-0.5 bg-port-accent/10 text-port-accent text-sm font-mono rounded">
+                v{app.appVersion}
+              </span>
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Start Commands */}

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -102,8 +102,7 @@ export default function UpdateTab() {
 
     pollRef.current = setInterval(async () => {
       attempts++;
-      const ok = await fetch('/api/system/health')
-        .then(r => r.json())
+      const ok = await api.checkHealth()
         .catch(() => null);
 
       if (ok?.version === targetVersionRef.current) {

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -1,0 +1,334 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { RefreshCw, Download, XCircle, Check, Loader, AlertTriangle, Trash2, ExternalLink, Tag } from 'lucide-react';
+import toast from 'react-hot-toast';
+import BrailleSpinner from '../../BrailleSpinner';
+import * as api from '../../../services/api';
+import socket from '../../../services/socket';
+
+const STEP_LABELS = {
+  starting: 'Starting update',
+  'git-fetch': 'Fetching tags',
+  'git-checkout': 'Checking out release',
+  'npm-install': 'Installing dependencies',
+  setup: 'Running setup',
+  migrations: 'Running migrations',
+  build: 'Building client',
+  restart: 'Restarting PortOS',
+  restarting: 'Restarting PortOS',
+  complete: 'Complete'
+};
+
+function StepIndicator({ status }) {
+  if (status === 'running') return <Loader size={14} className="text-port-accent animate-spin" />;
+  if (status === 'done') return <Check size={14} className="text-port-success" />;
+  if (status === 'error') return <XCircle size={14} className="text-port-error" />;
+  return <span className="w-3.5 h-3.5 rounded-full border border-gray-600 inline-block" />;
+}
+
+export default function UpdateTab() {
+  const [status, setStatus] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [checking, setChecking] = useState(false);
+  const [updating, setUpdating] = useState(false);
+  const [steps, setSteps] = useState([]);
+  const [updateError, setUpdateError] = useState(null);
+  const [polling, setPolling] = useState(false);
+  const pollRef = useRef(null);
+  const targetVersionRef = useRef(null);
+
+  const fetchStatus = useCallback(async () => {
+    const data = await api.getUpdateStatus().catch(() => null);
+    if (data) setStatus(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  // Socket event listeners for update progress
+  useEffect(() => {
+    const handleStep = ({ step, status: stepStatus, message }) => {
+      setSteps(prev => {
+        const existing = prev.findIndex(s => s.step === step);
+        const entry = { step, status: stepStatus, message, timestamp: Date.now() };
+        if (existing >= 0) {
+          const updated = [...prev];
+          updated[existing] = entry;
+          return updated;
+        }
+        return [...prev, entry];
+      });
+    };
+
+    const handleComplete = ({ success, newVersion }) => {
+      setUpdating(false);
+      if (success) {
+        targetVersionRef.current = newVersion;
+        setPolling(true);
+        toast.loading('PortOS is restarting...', { id: 'portos-update-restart', duration: Infinity });
+      }
+    };
+
+    const handleError = ({ message }) => {
+      setUpdating(false);
+      setUpdateError(message);
+    };
+
+    socket.on('portos:update:step', handleStep);
+    socket.on('portos:update:complete', handleComplete);
+    socket.on('portos:update:error', handleError);
+
+    return () => {
+      socket.off('portos:update:step', handleStep);
+      socket.off('portos:update:complete', handleComplete);
+      socket.off('portos:update:error', handleError);
+    };
+  }, []);
+
+  // Poll health endpoint after restart to detect new version
+  useEffect(() => {
+    if (!polling) return;
+
+    let attempts = 0;
+    const maxAttempts = 30;
+
+    pollRef.current = setInterval(async () => {
+      attempts++;
+      const ok = await fetch('/api/system/health')
+        .then(r => r.json())
+        .catch(() => null);
+
+      if (ok?.version === targetVersionRef.current) {
+        clearInterval(pollRef.current);
+        setPolling(false);
+        toast.success(`Updated to v${targetVersionRef.current}`, { id: 'portos-update-restart' });
+        setTimeout(() => window.location.reload(), 1000);
+        return;
+      }
+
+      if (attempts >= maxAttempts) {
+        clearInterval(pollRef.current);
+        setPolling(false);
+        toast.error('Restart timed out — try reloading manually', { id: 'portos-update-restart' });
+      }
+    }, 2000);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [polling]);
+
+  const handleCheck = async () => {
+    setChecking(true);
+    const result = await api.checkForUpdate().catch(() => null);
+    if (result) setStatus(prev => ({ ...prev, ...result }));
+    setChecking(false);
+  };
+
+  const handleUpdate = async () => {
+    setUpdating(true);
+    setSteps([]);
+    setUpdateError(null);
+    const result = await api.executePortosUpdate().catch(err => {
+      setUpdateError(err.message);
+      setUpdating(false);
+      return null;
+    });
+    if (result?.tag) {
+      targetVersionRef.current = result.tag.replace(/^v/, '');
+    }
+  };
+
+  const handleIgnore = async (version) => {
+    await api.ignoreUpdateVersion(version).catch(() => null);
+    fetchStatus();
+    toast.success(`v${version} ignored`);
+  };
+
+  const handleClearIgnored = async () => {
+    await api.clearIgnoredVersions().catch(() => null);
+    fetchStatus();
+    toast.success('Ignored versions cleared');
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <BrailleSpinner text="Loading update status" />
+      </div>
+    );
+  }
+
+  const release = status?.latestRelease;
+  const hasUpdate = status?.updateAvailable;
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      {/* Current Version */}
+      <div>
+        <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">Current Version</div>
+        <div className="flex items-center gap-2">
+          <Tag size={16} className="text-port-accent shrink-0" />
+          <span className="text-lg font-mono text-white">v{status?.currentVersion || '?'}</span>
+        </div>
+      </div>
+
+      {/* Available Update */}
+      {release && (
+        <div className={`p-4 rounded-lg border ${hasUpdate ? 'border-port-accent/50 bg-port-accent/5' : 'border-port-border bg-port-card'}`}>
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-400">Latest Release:</span>
+              <span className="text-lg font-mono text-white">v{release.version}</span>
+              {hasUpdate && (
+                <span className="px-2 py-0.5 bg-port-accent/20 text-port-accent text-xs rounded-full">New</span>
+              )}
+            </div>
+            {release.url && (
+              <a
+                href={release.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-gray-400 hover:text-white transition-colors flex items-center gap-1 text-xs"
+              >
+                <ExternalLink size={12} /> GitHub
+              </a>
+            )}
+          </div>
+          {release.publishedAt && (
+            <div className="text-xs text-gray-500 mb-2">
+              Released {new Date(release.publishedAt).toLocaleDateString()}
+            </div>
+          )}
+          {release.body && (
+            <div className="mt-3 p-3 bg-port-bg rounded border border-port-border">
+              <div className="text-xs text-gray-500 uppercase tracking-wide mb-1">Release Notes</div>
+              <pre className="text-sm text-gray-300 whitespace-pre-wrap font-mono leading-relaxed max-h-64 overflow-y-auto">
+                {release.body}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Update Actions */}
+      <div className="flex flex-wrap gap-2">
+        {hasUpdate && (
+          <button
+            onClick={handleUpdate}
+            disabled={updating || polling}
+            className="px-4 py-2 bg-port-accent text-white rounded-lg text-sm flex items-center gap-2 hover:bg-port-accent/80 disabled:opacity-50"
+          >
+            <Download size={14} className={updating ? 'animate-bounce' : ''} />
+            {updating ? 'Updating...' : polling ? 'Restarting...' : 'Update Now'}
+          </button>
+        )}
+        <button
+          onClick={handleCheck}
+          disabled={checking || updating}
+          className="px-4 py-2 bg-port-border text-white rounded-lg text-sm flex items-center gap-2 hover:bg-port-border/80 disabled:opacity-50"
+        >
+          <RefreshCw size={14} className={checking ? 'animate-spin' : ''} />
+          {checking ? 'Checking...' : 'Check for Updates'}
+        </button>
+        {hasUpdate && release && (
+          <button
+            onClick={() => handleIgnore(release.version)}
+            disabled={updating}
+            className="px-4 py-2 bg-port-border text-gray-400 rounded-lg text-sm flex items-center gap-2 hover:bg-port-border/80 hover:text-white disabled:opacity-50"
+          >
+            <XCircle size={14} />
+            Ignore v{release.version}
+          </button>
+        )}
+      </div>
+
+      {/* Last Check */}
+      {status?.lastCheck && (
+        <div className="text-xs text-gray-500">
+          Last checked: {new Date(status.lastCheck).toLocaleString()}
+        </div>
+      )}
+
+      {/* Update Progress */}
+      {steps.length > 0 && (
+        <div>
+          <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">Update Progress</div>
+          <div className="bg-port-card border border-port-border rounded-lg p-4 space-y-2">
+            {steps.map(({ step, status: stepStatus, message }) => (
+              <div key={step} className="flex items-center gap-3">
+                <StepIndicator status={stepStatus} />
+                <span className="text-sm text-white font-medium">{STEP_LABELS[step] || step}</span>
+                <span className="text-xs text-gray-500 flex-1 truncate">{message}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Update Error */}
+      {updateError && (
+        <div className="flex items-start gap-2 p-3 bg-port-error/10 border border-port-error/30 rounded-lg">
+          <AlertTriangle size={16} className="text-port-error shrink-0 mt-0.5" />
+          <span className="text-sm text-port-error">{updateError}</span>
+        </div>
+      )}
+
+      {/* Last Update Result */}
+      {status?.lastUpdateResult && (
+        <div>
+          <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">Last Update</div>
+          <div className={`p-3 rounded-lg border ${
+            status.lastUpdateResult.success
+              ? 'border-port-success/30 bg-port-success/5'
+              : 'border-port-error/30 bg-port-error/5'
+          }`}>
+            <div className="flex items-center gap-2">
+              {status.lastUpdateResult.success
+                ? <Check size={14} className="text-port-success" />
+                : <XCircle size={14} className="text-port-error" />
+              }
+              <span className="text-sm text-white">
+                v{status.lastUpdateResult.version} — {status.lastUpdateResult.success ? 'Success' : 'Failed'}
+              </span>
+              {status.lastUpdateResult.completedAt && (
+                <span className="text-xs text-gray-500">
+                  {new Date(status.lastUpdateResult.completedAt).toLocaleString()}
+                </span>
+              )}
+            </div>
+            {status.lastUpdateResult.log && (
+              <pre className="text-xs text-gray-400 mt-2 font-mono">{status.lastUpdateResult.log}</pre>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Ignored Versions */}
+      {status?.ignoredVersions?.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <div className="text-xs text-gray-500 uppercase tracking-wide">Ignored Versions</div>
+            <button
+              onClick={handleClearIgnored}
+              className="text-xs text-gray-500 hover:text-white flex items-center gap-1"
+            >
+              <Trash2 size={12} /> Clear All
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {status.ignoredVersions.map(v => (
+              <span
+                key={v}
+                className="px-2 py-1 bg-port-card border border-port-border rounded text-sm text-gray-400 font-mono"
+              >
+                v{v}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -129,7 +129,7 @@ export default function UpdateTab() {
   const handleCheck = async () => {
     setChecking(true);
     const result = await api.checkForUpdate().catch(() => null);
-    if (result) setStatus(prev => ({ ...prev, ...result }));
+    if (result) setStatus(prev => ({ ...(prev ?? {}), ...result }));
     setChecking(false);
   };
 

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -10,7 +10,6 @@ const STEP_LABELS = {
   'git-fetch': 'Fetching tags',
   'git-checkout': 'Checking out release',
   'npm-install': 'Installing dependencies',
-  setup: 'Running setup',
   migrations: 'Running migrations',
   build: 'Building client',
   restart: 'Restarting PortOS',

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -61,7 +61,7 @@ export default function UpdateTab() {
       });
       // When the server signals it's restarting, begin health polling immediately.
       // The PM2 restart may kill the server before portos:update:complete fires.
-      if ((step === 'restarting' || step === 'restart') && targetVersionRef.current) {
+      if ((step === 'restarting' || step === 'restart') && stepStatus !== 'error' && targetVersionRef.current) {
         setUpdating(false);
         setPolling(true);
         toast.loading('PortOS is restarting...', { id: 'portos-update-restart', duration: Infinity });
@@ -79,6 +79,9 @@ export default function UpdateTab() {
 
     const handleError = ({ message }) => {
       setUpdating(false);
+      setPolling(false);
+      if (pollRef.current) clearInterval(pollRef.current);
+      toast.dismiss('portos-update-restart');
       setUpdateError(message);
     };
 

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -61,7 +61,7 @@ export default function UpdateTab() {
       });
       // When the server signals it's restarting, begin health polling immediately.
       // The PM2 restart may kill the server before portos:update:complete fires.
-      if (step === 'restarting' || step === 'restart') {
+      if ((step === 'restarting' || step === 'restart') && targetVersionRef.current) {
         setUpdating(false);
         setPolling(true);
         toast.loading('PortOS is restarting...', { id: 'portos-update-restart', duration: Infinity });

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -59,6 +59,13 @@ export default function UpdateTab() {
         }
         return [...prev, entry];
       });
+      // When the server signals it's restarting, begin health polling immediately.
+      // The PM2 restart may kill the server before portos:update:complete fires.
+      if (step === 'restarting' || step === 'restart') {
+        setUpdating(false);
+        setPolling(true);
+        toast.loading('PortOS is restarting...', { id: 'portos-update-restart', duration: Infinity });
+      }
     };
 
     const handleComplete = ({ success, newVersion }) => {

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -134,6 +134,11 @@ export default function UpdateTab() {
   };
 
   const handleUpdate = async () => {
+    // Set target version BEFORE executing so it's available when the
+    // restarting step arrives via socket (which may beat the HTTP response)
+    if (status?.latestRelease?.version) {
+      targetVersionRef.current = status.latestRelease.version;
+    }
     setUpdating(true);
     setSteps([]);
     setUpdateError(null);
@@ -142,6 +147,7 @@ export default function UpdateTab() {
       setUpdating(false);
       return null;
     });
+    // Update from response if available (should match, but server is authoritative)
     if (result?.tag) {
       targetVersionRef.current = result.tag.replace(/^v/, '');
     }

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Beer, Plus, Trash2, AlertTriangle, TrendingDown, TrendingUp, Pencil, Check, X, Settings } from 'lucide-react';
+import toast from 'react-hot-toast';
 import * as api from '../../../services/api';
 import BrailleSpinner from '../../BrailleSpinner';
 import AlcoholChart from '../AlcoholChart';
@@ -173,12 +174,23 @@ export default function AlcoholTab() {
 
   // === Custom drink button management ===
 
+  const validateDrinkButton = (form) => {
+    const parsedOz = parseFloat(form.oz);
+    const parsedAbv = parseFloat(form.abv);
+    if (!form.name) return 'Name is required';
+    if (isNaN(parsedOz) || parsedOz < 0.1 || parsedOz > 1000) return 'Oz must be between 0.1 and 1000';
+    if (isNaN(parsedAbv) || parsedAbv < 0 || parsedAbv > 100) return 'ABV must be between 0 and 100';
+    return null;
+  };
+
   const handleAddButton = async (e) => {
     e.preventDefault();
+    const error = validateDrinkButton(buttonForm);
+    if (error) { toast.error(error); return; }
     const parsedOz = parseFloat(buttonForm.oz);
     const parsedAbv = parseFloat(buttonForm.abv);
-    if (!buttonForm.name || !parsedOz || isNaN(parsedAbv)) return;
-    await api.addCustomDrink({ name: buttonForm.name, oz: parsedOz, abv: parsedAbv }).catch(() => null);
+    const result = await api.addCustomDrink({ name: buttonForm.name, oz: parsedOz, abv: parsedAbv }).catch(() => null);
+    if (!result) { toast.error('Failed to add drink button'); return; }
     setButtonForm({ name: '', oz: '', abv: '' });
     fetchDrinkButtons();
   };
@@ -191,10 +203,12 @@ export default function AlcoholTab() {
 
   const saveEditButton = async () => {
     if (editingButtonIdx === null) return;
+    const error = validateDrinkButton(buttonForm);
+    if (error) { toast.error(error); return; }
     const parsedOz = parseFloat(buttonForm.oz);
     const parsedAbv = parseFloat(buttonForm.abv);
-    if (!buttonForm.name || !parsedOz || isNaN(parsedAbv)) return;
-    await api.updateCustomDrink(editingButtonIdx, { name: buttonForm.name, oz: parsedOz, abv: parsedAbv }).catch(() => null);
+    const result = await api.updateCustomDrink(editingButtonIdx, { name: buttonForm.name, oz: parsedOz, abv: parsedAbv }).catch(() => null);
+    if (!result) { toast.error('Failed to update drink button'); return; }
     setEditingButtonIdx(null);
     setButtonForm({ name: '', oz: '', abv: '' });
     fetchDrinkButtons();

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -1,12 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Beer, Plus, Trash2, AlertTriangle, TrendingDown, TrendingUp, Pencil, Check, X } from 'lucide-react';
+import { Beer, Plus, Trash2, AlertTriangle, TrendingDown, TrendingUp, Pencil, Check, X, Settings } from 'lucide-react';
 import * as api from '../../../services/api';
 import BrailleSpinner from '../../BrailleSpinner';
 import AlcoholChart from '../AlcoholChart';
 import AlcoholHrvCorrelation from '../AlcoholHrvCorrelation';
 import StandardDrinkCalculator from '../StandardDrinkCalculator';
 
-const COMMON_DRINKS = [
+const DEFAULT_DRINKS = [
+  { name: 'Modelo Especial (12oz)', oz: 12, abv: 4.4 },
   { name: 'Nitro Guinness (14.9oz)', oz: 14.9, abv: 4.2 },
   { name: 'Old Fashioned (2oz)', oz: 2, abv: 40 },
   { name: 'Guinness 0 (14.9oz)', oz: 14.9, abv: 0.4 },
@@ -46,6 +47,12 @@ export default function AlcoholTab() {
   const [refreshKey, setRefreshKey] = useState(0);
   const [visibleDays, setVisibleDays] = useState(DAYS_PER_PAGE);
 
+  // Custom drink buttons
+  const [drinkButtons, setDrinkButtons] = useState(DEFAULT_DRINKS);
+  const [managingButtons, setManagingButtons] = useState(false);
+  const [editingButtonIdx, setEditingButtonIdx] = useState(null);
+  const [buttonForm, setButtonForm] = useState({ name: '', oz: '', abv: '' });
+
   // Form state
   const [name, setName] = useState('');
   const [oz, setOz] = useState('');
@@ -61,6 +68,11 @@ export default function AlcoholTab() {
   const [chartView, setChartView] = useState('30d');
   const [correlationData, setCorrelationData] = useState(null);
 
+  const fetchDrinkButtons = useCallback(async () => {
+    const buttons = await api.getCustomDrinks().catch(() => null);
+    if (buttons?.length) setDrinkButtons(buttons);
+  }, []);
+
   const fetchData = useCallback(async () => {
     const [summaryData, entries] = await Promise.all([
       api.getAlcoholSummary().catch(() => null),
@@ -72,8 +84,9 @@ export default function AlcoholTab() {
   }, []);
 
   useEffect(() => {
+    fetchDrinkButtons();
     fetchData();
-  }, [fetchData, refreshKey]);
+  }, [fetchDrinkButtons, fetchData, refreshKey]);
 
   // Fetch correlation data for HRV chart
   const chartDays = { '7d': 7, '30d': 30, '90d': 90 }[chartView] || 30;
@@ -149,6 +162,45 @@ export default function AlcoholTab() {
     }).catch(() => null);
     setEditingKey(null);
     setRefreshKey(k => k + 1);
+  };
+
+  // === Custom drink button management ===
+
+  const handleAddButton = async (e) => {
+    e.preventDefault();
+    const parsedOz = parseFloat(buttonForm.oz);
+    const parsedAbv = parseFloat(buttonForm.abv);
+    if (!buttonForm.name || !parsedOz || isNaN(parsedAbv)) return;
+    await api.addCustomDrink({ name: buttonForm.name, oz: parsedOz, abv: parsedAbv }).catch(() => null);
+    setButtonForm({ name: '', oz: '', abv: '' });
+    fetchDrinkButtons();
+  };
+
+  const startEditButton = (idx) => {
+    const btn = drinkButtons[idx];
+    setEditingButtonIdx(idx);
+    setButtonForm({ name: btn.name, oz: String(btn.oz), abv: String(btn.abv) });
+  };
+
+  const saveEditButton = async () => {
+    if (editingButtonIdx === null) return;
+    const parsedOz = parseFloat(buttonForm.oz);
+    const parsedAbv = parseFloat(buttonForm.abv);
+    if (!buttonForm.name || !parsedOz || isNaN(parsedAbv)) return;
+    await api.updateCustomDrink(editingButtonIdx, { name: buttonForm.name, oz: parsedOz, abv: parsedAbv }).catch(() => null);
+    setEditingButtonIdx(null);
+    setButtonForm({ name: '', oz: '', abv: '' });
+    fetchDrinkButtons();
+  };
+
+  const cancelEditButton = () => {
+    setEditingButtonIdx(null);
+    setButtonForm({ name: '', oz: '', abv: '' });
+  };
+
+  const handleRemoveButton = async (idx) => {
+    await api.removeCustomDrink(idx).catch(() => null);
+    fetchDrinkButtons();
   };
 
   if (loading) {
@@ -232,22 +284,132 @@ export default function AlcoholTab() {
 
       {/* Log a Drink */}
       <div className="bg-port-card border border-port-border rounded-xl p-6">
-        <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">Log a Drink</h3>
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Log a Drink</h3>
+          <button
+            onClick={() => setManagingButtons(v => !v)}
+            className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg transition-colors ${
+              managingButtons ? 'bg-port-accent/20 text-port-accent' : 'text-gray-500 hover:text-gray-300'
+            }`}
+            title="Manage quick-add buttons"
+          >
+            <Settings size={14} />
+            {managingButtons ? 'Done' : 'Manage'}
+          </button>
+        </div>
 
         {/* Quick-add buttons */}
-        <div className="flex flex-wrap gap-2 mb-4">
-          {COMMON_DRINKS.map(drink => (
-            <button
-              key={drink.name}
-              onClick={() => handleQuickAdd(drink)}
-              disabled={logging}
-              className="flex items-center gap-1 px-3 py-1.5 text-xs bg-port-border/50 text-gray-300 rounded-lg hover:bg-port-accent/10 hover:text-port-accent transition-colors disabled:opacity-50"
-            >
-              <Plus size={12} />
-              {drink.name}
-            </button>
-          ))}
-        </div>
+        {!managingButtons && (
+          <div className="flex flex-wrap gap-2 mb-4">
+            {drinkButtons.map((drink, idx) => (
+              <button
+                key={`${drink.name}-${idx}`}
+                onClick={() => handleQuickAdd(drink)}
+                disabled={logging}
+                className="flex items-center gap-1 px-3 py-1.5 text-xs bg-port-border/50 text-gray-300 rounded-lg hover:bg-port-accent/10 hover:text-port-accent transition-colors disabled:opacity-50"
+              >
+                <Plus size={12} />
+                {drink.name}
+              </button>
+            ))}
+          </div>
+        )}
+
+        {/* Manage quick-add buttons */}
+        {managingButtons && (
+          <div className="mb-4 space-y-2">
+            {drinkButtons.map((drink, idx) => (
+              <div key={`manage-${idx}`} className="flex items-center gap-2">
+                {editingButtonIdx === idx ? (
+                  <>
+                    <input
+                      type="text"
+                      value={buttonForm.name}
+                      onChange={e => setButtonForm(f => ({ ...f, name: e.target.value }))}
+                      placeholder="Name"
+                      className="flex-1 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white"
+                    />
+                    <input
+                      type="number"
+                      step="0.1"
+                      min="0.1"
+                      value={buttonForm.oz}
+                      onChange={e => setButtonForm(f => ({ ...f, oz: e.target.value }))}
+                      placeholder="Oz"
+                      className="w-16 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white text-right"
+                    />
+                    <input
+                      type="number"
+                      step="0.1"
+                      min="0"
+                      max="100"
+                      value={buttonForm.abv}
+                      onChange={e => setButtonForm(f => ({ ...f, abv: e.target.value }))}
+                      placeholder="ABV%"
+                      className="w-16 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white text-right"
+                    />
+                    <button onClick={saveEditButton} className="p-1.5 text-port-success hover:text-port-success/80" title="Save">
+                      <Check size={14} />
+                    </button>
+                    <button onClick={cancelEditButton} className="p-1.5 text-gray-500 hover:text-gray-300" title="Cancel">
+                      <X size={14} />
+                    </button>
+                  </>
+                ) : (
+                  <>
+                    <span className="flex-1 text-xs text-gray-300">{drink.name}</span>
+                    <span className="text-xs text-gray-500">{drink.oz}oz</span>
+                    <span className="text-xs text-gray-500">{drink.abv}%</span>
+                    <button onClick={() => startEditButton(idx)} className="p-1.5 text-gray-600 hover:text-port-accent" title="Edit">
+                      <Pencil size={12} />
+                    </button>
+                    <button onClick={() => handleRemoveButton(idx)} className="p-1.5 text-gray-600 hover:text-port-error" title="Remove">
+                      <Trash2 size={12} />
+                    </button>
+                  </>
+                )}
+              </div>
+            ))}
+            {editingButtonIdx === null && (
+              <form onSubmit={handleAddButton} className="flex items-center gap-2 pt-2 border-t border-port-border/50">
+                <input
+                  type="text"
+                  value={buttonForm.name}
+                  onChange={e => setButtonForm(f => ({ ...f, name: e.target.value }))}
+                  placeholder="New button name"
+                  className="flex-1 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white placeholder-gray-600"
+                />
+                <input
+                  type="number"
+                  step="0.1"
+                  min="0.1"
+                  value={buttonForm.oz}
+                  onChange={e => setButtonForm(f => ({ ...f, oz: e.target.value }))}
+                  placeholder="Oz"
+                  className="w-16 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white text-right placeholder-gray-600"
+                />
+                <input
+                  type="number"
+                  step="0.1"
+                  min="0"
+                  max="100"
+                  value={buttonForm.abv}
+                  onChange={e => setButtonForm(f => ({ ...f, abv: e.target.value }))}
+                  placeholder="ABV%"
+                  className="w-16 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white text-right placeholder-gray-600"
+                />
+                <button
+                  type="submit"
+                  disabled={!buttonForm.name || !buttonForm.oz}
+                  className="flex items-center gap-1 px-2 py-1.5 text-xs bg-port-accent text-white rounded-lg hover:bg-port-accent/80 disabled:opacity-50"
+                >
+                  <Plus size={12} />
+                  Add
+                </button>
+              </form>
+            )}
+          </div>
+        )}
 
         {/* Custom entry form */}
         <form onSubmit={handleCustomAdd} className="flex flex-wrap items-end gap-3">

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -70,7 +70,11 @@ export default function AlcoholTab() {
 
   const fetchDrinkButtons = useCallback(async () => {
     const buttons = await api.getCustomDrinks().catch(() => null);
-    if (buttons?.length) setDrinkButtons(buttons);
+    if (Array.isArray(buttons)) {
+      setDrinkButtons(buttons);
+    } else {
+      setDrinkButtons(DEFAULT_DRINKS);
+    }
   }, []);
 
   const fetchData = useCallback(async () => {
@@ -400,7 +404,7 @@ export default function AlcoholTab() {
                 />
                 <button
                   type="submit"
-                  disabled={!buttonForm.name || !buttonForm.oz}
+                  disabled={!buttonForm.name || !buttonForm.oz || !buttonForm.abv || isNaN(parseFloat(buttonForm.abv))}
                   className="flex items-center gap-1 px-2 py-1.5 text-xs bg-port-accent text-white rounded-lg hover:bg-port-accent/80 disabled:opacity-50"
                 >
                   <Plus size={12} />

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -404,7 +404,7 @@ export default function AlcoholTab() {
                 />
                 <button
                   type="submit"
-                  disabled={!buttonForm.name || !buttonForm.oz || !buttonForm.abv || isNaN(parseFloat(buttonForm.abv))}
+                  disabled={!buttonForm.name || !buttonForm.oz || buttonForm.abv === '' || isNaN(parseFloat(buttonForm.abv))}
                   className="flex items-center gap-1 px-2 py-1.5 text-xs bg-port-accent text-white rounded-lg hover:bg-port-accent/80 disabled:opacity-50"
                 >
                   <Plus size={12} />

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -89,8 +89,11 @@ export default function AlcoholTab() {
 
   useEffect(() => {
     fetchDrinkButtons();
+  }, [fetchDrinkButtons]);
+
+  useEffect(() => {
     fetchData();
-  }, [fetchDrinkButtons, fetchData, refreshKey]);
+  }, [fetchData, refreshKey]);
 
   // Fetch correlation data for HRV chart
   const chartDays = { '7d': 7, '30d': 30, '90d': 90 }[chartView] || 30;

--- a/client/src/hooks/useUpdateChecker.jsx
+++ b/client/src/hooks/useUpdateChecker.jsx
@@ -1,0 +1,71 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import socket from '../services/socket';
+import * as api from '../services/api';
+
+const TOAST_ID = 'portos-update-available';
+
+/**
+ * Global hook that checks for PortOS updates and shows a persistent toast
+ * when a new version is available. Runs in Layout alongside useErrorNotifications.
+ */
+export function useUpdateChecker() {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const showUpdateToast = (data) => {
+      toast(
+        (t) => (
+          <div className="flex flex-col gap-2">
+            <span className="text-sm">
+              Update available: <strong>v{data.currentVersion}</strong> → <strong>v{data.latestVersion}</strong>
+            </span>
+            <div className="flex gap-2">
+              <button
+                onClick={() => {
+                  toast.dismiss(t.id);
+                  navigate(`/apps/${api.PORTOS_APP_ID}/update`);
+                }}
+                className="px-2 py-1 bg-port-accent text-white text-xs rounded hover:bg-port-accent/80"
+              >
+                Update
+              </button>
+              <button
+                onClick={() => {
+                  api.ignoreUpdateVersion(data.latestVersion).catch(() => null);
+                  toast.dismiss(t.id);
+                }}
+                className="px-2 py-1 bg-gray-600 text-white text-xs rounded hover:bg-gray-500"
+              >
+                Ignore
+              </button>
+            </div>
+          </div>
+        ),
+        {
+          id: TOAST_ID,
+          duration: Infinity,
+          icon: '🔄'
+        }
+      );
+    };
+
+    // Check status on mount
+    api.getUpdateStatus().then(status => {
+      if (status.updateAvailable && status.latestRelease) {
+        showUpdateToast({
+          currentVersion: status.currentVersion,
+          latestVersion: status.latestRelease.version
+        });
+      }
+    }).catch(() => {});
+
+    // Listen for real-time update available events
+    socket.on('portos:update:available', showUpdateToast);
+
+    return () => {
+      socket.off('portos:update:available', showUpdateToast);
+    };
+  }, [navigate]);
+}

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1405,6 +1405,18 @@ export const updateAlcoholDrink = (date, index, data) => request(`/meatspace/alc
 export const removeAlcoholDrink = (date, index) => request(`/meatspace/alcohol/log/${date}/${index}`, {
   method: 'DELETE'
 });
+export const getCustomDrinks = () => request('/meatspace/alcohol/custom-drinks');
+export const addCustomDrink = (data) => request('/meatspace/alcohol/custom-drinks', {
+  method: 'POST',
+  body: JSON.stringify(data)
+});
+export const updateCustomDrink = (index, data) => request(`/meatspace/alcohol/custom-drinks/${index}`, {
+  method: 'PUT',
+  body: JSON.stringify(data)
+});
+export const removeCustomDrink = (index) => request(`/meatspace/alcohol/custom-drinks/${index}`, {
+  method: 'DELETE'
+});
 export const getBloodTests = () => request('/meatspace/blood');
 export const addBloodTest = (data) => request('/meatspace/blood', {
   method: 'POST',

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -91,6 +91,16 @@ export const uploadAppleHealthXml = (file) => {
 export const checkHealth = () => request('/system/health');
 export const getSystemHealth = (options) => request('/system/health/details', options);
 
+// Update
+export const getUpdateStatus = () => request('/update/status');
+export const checkForUpdate = () => request('/update/check', { method: 'POST' });
+export const ignoreUpdateVersion = (version) => request('/update/ignore', {
+  method: 'POST',
+  body: JSON.stringify({ version })
+});
+export const clearIgnoredVersions = () => request('/update/ignore', { method: 'DELETE' });
+export const executePortosUpdate = () => request('/update/execute', { method: 'POST' });
+
 // Apps
 export const getApps = () => request('/apps');
 export const getApp = (id) => request(`/apps/${id}`);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "pm2:save": "node ./node_modules/pm2/bin/pm2 save",
     "pm2:startup": "node ./node_modules/pm2/bin/pm2 startup",
     "install:all": "npm install && npm install --prefix client && npm install --prefix server && npm run setup",
+    "migrations": "node scripts/run-migrations.js",
     "setup": "node scripts/setup-data.js && node scripts/setup-db.js && node scripts/setup-browser.js",
     "setup:data": "node scripts/setup-data.js",
     "setup:db": "node scripts/setup-db.js",

--- a/scripts/portos-update.sh
+++ b/scripts/portos-update.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# PortOS Auto-Update Script
+# Usage: bash scripts/portos-update.sh <tag>
+# Outputs structured STEP markers for progress tracking:
+#   STEP:name:status:message
+
+TAG="${1:?Usage: portos-update.sh <tag>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOG_FILE="$ROOT_DIR/data/update.log"
+
+cd "$ROOT_DIR"
+
+# Log helper
+log() {
+  echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >> "$LOG_FILE"
+  echo "$*"
+}
+
+# Step output helper
+step() {
+  local name="$1" status="$2" message="$3"
+  log "STEP:$name:$status:$message"
+}
+
+log "=== PortOS update to $TAG started ==="
+
+# Step 1: Git fetch
+step "git-fetch" "running" "Fetching tags from origin..."
+git fetch origin --tags >> "$LOG_FILE" 2>&1
+step "git-fetch" "done" "Tags fetched"
+
+# Step 2: Git checkout
+step "git-checkout" "running" "Checking out $TAG..."
+git checkout "$TAG" >> "$LOG_FILE" 2>&1
+step "git-checkout" "done" "Checked out $TAG"
+
+# Step 3: npm install
+step "npm-install" "running" "Installing dependencies..."
+npm install >> "$LOG_FILE" 2>&1
+step "npm-install" "done" "Dependencies installed"
+
+# Step 4: Setup (data dirs, db, browser)
+step "setup" "running" "Running setup..."
+npm run setup >> "$LOG_FILE" 2>&1
+step "setup" "done" "Setup complete"
+
+# Step 5: Migrations
+step "migrations" "running" "Running data migrations..."
+if [ -f "$ROOT_DIR/scripts/run-migrations.js" ]; then
+  node "$ROOT_DIR/scripts/run-migrations.js" >> "$LOG_FILE" 2>&1
+fi
+step "migrations" "done" "Migrations complete"
+
+# Step 6: Build client
+step "build" "running" "Building client..."
+npm run build -w client >> "$LOG_FILE" 2>&1
+step "build" "done" "Client built"
+
+# Step 7: Restart via PM2
+step "restart" "running" "Restarting PortOS..."
+
+# Write completion marker before restarting (server reads this on boot)
+echo "{\"version\":\"${TAG#v}\",\"completedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$ROOT_DIR/data/update-complete.json"
+
+log "=== PortOS update to $TAG complete, restarting ==="
+
+# Use the local pm2 binary to restart
+node "$ROOT_DIR/node_modules/pm2/bin/pm2" restart ecosystem.config.cjs >> "$LOG_FILE" 2>&1
+
+step "restart" "done" "PortOS restarted"

--- a/scripts/portos-update.sh
+++ b/scripts/portos-update.sh
@@ -62,12 +62,12 @@ step "build" "done" "Client built"
 # Step 7: Restart via PM2
 step "restart" "running" "Restarting PortOS..."
 
-# Write completion marker before restarting (server reads this on boot)
-echo "{\"version\":\"${TAG#v}\",\"completedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$ROOT_DIR/data/update-complete.json"
-
-log "=== PortOS update to $TAG complete, restarting ==="
+log "=== PortOS update to $TAG restarting ==="
 
 # Use the local pm2 binary to restart
 node "$ROOT_DIR/node_modules/pm2/bin/pm2" restart ecosystem.config.cjs >> "$LOG_FILE" 2>&1
+
+# Write completion marker after successful restart (server reads this on boot)
+echo "{\"version\":\"${TAG#v}\",\"completedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$ROOT_DIR/data/update-complete.json"
 
 step "restart" "done" "PortOS restarted"

--- a/scripts/portos-update.sh
+++ b/scripts/portos-update.sh
@@ -16,7 +16,7 @@ cd "$ROOT_DIR"
 # Log helper
 log() {
   echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] $*" >> "$LOG_FILE"
-  echo "$*"
+  echo "$*" || true
 }
 
 # Step output helper

--- a/scripts/portos-update.sh
+++ b/scripts/portos-update.sh
@@ -57,7 +57,7 @@ step "migrations" "done" "Migrations complete"
 
 # Step 6: Build client
 step "build" "running" "Building client..."
-npm run build -w client >> "$LOG_FILE" 2>&1
+npm run build --prefix client >> "$LOG_FILE" 2>&1
 step "build" "done" "Client built"
 
 # Step 7: Restart via PM2

--- a/scripts/portos-update.sh
+++ b/scripts/portos-update.sh
@@ -38,29 +38,24 @@ step "git-checkout" "running" "Checking out $TAG..."
 git checkout "$TAG" >> "$LOG_FILE" 2>&1
 step "git-checkout" "done" "Checked out $TAG"
 
-# Step 3: npm install
-step "npm-install" "running" "Installing dependencies..."
-npm install >> "$LOG_FILE" 2>&1
+# Step 3: npm install (root + client + server + setup)
+step "npm-install" "running" "Installing all dependencies..."
+npm run install:all >> "$LOG_FILE" 2>&1
 step "npm-install" "done" "Dependencies installed"
 
-# Step 4: Setup (data dirs, db, browser)
-step "setup" "running" "Running setup..."
-npm run setup >> "$LOG_FILE" 2>&1
-step "setup" "done" "Setup complete"
-
-# Step 5: Migrations
+# Step 4: Migrations
 step "migrations" "running" "Running data migrations..."
 if [ -f "$ROOT_DIR/scripts/run-migrations.js" ]; then
   node "$ROOT_DIR/scripts/run-migrations.js" >> "$LOG_FILE" 2>&1
 fi
 step "migrations" "done" "Migrations complete"
 
-# Step 6: Build client
+# Step 5: Build client
 step "build" "running" "Building client..."
 npm run build --prefix client >> "$LOG_FILE" 2>&1
 step "build" "done" "Client built"
 
-# Step 7: Restart via PM2
+# Step 6: Restart via PM2
 step "restart" "running" "Restarting PortOS..."
 
 log "=== PortOS update to $TAG restarting ==="

--- a/scripts/portos-update.sh
+++ b/scripts/portos-update.sh
@@ -65,10 +65,10 @@ step "restart" "running" "Restarting PortOS..."
 
 log "=== PortOS update to $TAG restarting ==="
 
+# Write completion marker before restart so server reads it on boot
+echo "{\"version\":\"${TAG#v}\",\"completedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$ROOT_DIR/data/update-complete.json"
+
 # Use the local pm2 binary to restart
 node "$ROOT_DIR/node_modules/pm2/bin/pm2" restart ecosystem.config.cjs >> "$LOG_FILE" 2>&1
-
-# Write completion marker after successful restart (server reads this on boot)
-echo "{\"version\":\"${TAG#v}\",\"completedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}" > "$ROOT_DIR/data/update-complete.json"
 
 step "restart" "done" "PortOS restarted"

--- a/scripts/portos-update.sh
+++ b/scripts/portos-update.sh
@@ -9,6 +9,7 @@ set -euo pipefail
 TAG="${1:?Usage: portos-update.sh <tag>}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+mkdir -p "$ROOT_DIR/data"
 LOG_FILE="$ROOT_DIR/data/update.log"
 
 cd "$ROOT_DIR"

--- a/scripts/run-migrations.js
+++ b/scripts/run-migrations.js
@@ -35,7 +35,11 @@ async function run() {
     if (applied.includes(file)) continue;
 
     console.log(`🔄 Running migration: ${file}`);
-    const migration = await import(pathToFileURL(join(migrationsDir, file)).href);
+    const mod = await import(pathToFileURL(join(migrationsDir, file)).href);
+    const migration = (mod?.default && typeof mod.default.up === 'function') ? mod.default : mod;
+    if (!migration || typeof migration.up !== 'function') {
+      throw new Error(`Migration "${file}" does not export an up() function`);
+    }
     await migration.up({ rootDir, migrationsDir });
     applied.push(file);
     await writeFile(appliedFile, JSON.stringify(applied, null, 2) + '\n');

--- a/scripts/run-migrations.js
+++ b/scripts/run-migrations.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { readdir, readFile, writeFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+const migrationsDir = join(rootDir, 'data', 'migrations');
+const appliedFile = join(migrationsDir, '.applied.json');
+
+async function run() {
+  // Ensure migrations directory exists
+  await mkdir(migrationsDir, { recursive: true });
+
+  // Load applied migrations list
+  let applied = [];
+  if (existsSync(appliedFile)) {
+    const raw = await readFile(appliedFile, 'utf-8');
+    applied = JSON.parse(raw);
+  }
+
+  // Scan for migration files (*.js, sorted by filename)
+  const files = (await readdir(migrationsDir))
+    .filter(f => f.endsWith('.js'))
+    .sort();
+
+  let ran = 0;
+  for (const file of files) {
+    if (applied.includes(file)) continue;
+
+    console.log(`🔄 Running migration: ${file}`);
+    const migration = await import(join(migrationsDir, file));
+    await migration.up({ rootDir, migrationsDir });
+    applied.push(file);
+    await writeFile(appliedFile, JSON.stringify(applied, null, 2) + '\n');
+    ran++;
+    console.log(`✅ Migration applied: ${file}`);
+  }
+
+  if (ran === 0) {
+    console.log('✅ No pending migrations');
+  } else {
+    console.log(`✅ ${ran} migration(s) applied`);
+  }
+}
+
+run().catch(err => {
+  console.error(`❌ Migration failed: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/run-migrations.js
+++ b/scripts/run-migrations.js
@@ -12,7 +12,7 @@ async function run() {
   // Ensure migrations directory exists
   await mkdir(migrationsDir, { recursive: true });
 
-  // Load applied migrations list (default to [] on read/parse failure)
+  // Load applied migrations list (default to [] on missing/unreadable file, throw on corrupted JSON)
   let applied = [];
   const raw = await readFile(appliedFile, 'utf-8').catch(err => {
     if (err.code !== 'ENOENT') {

--- a/scripts/run-migrations.js
+++ b/scripts/run-migrations.js
@@ -13,11 +13,12 @@ async function run() {
   // Ensure migrations directory exists
   await mkdir(migrationsDir, { recursive: true });
 
-  // Load applied migrations list
+  // Load applied migrations list (default to [] on corrupt file)
   let applied = [];
   if (existsSync(appliedFile)) {
     const raw = await readFile(appliedFile, 'utf-8');
-    applied = JSON.parse(raw);
+    try { applied = JSON.parse(raw); } catch { applied = []; }
+    if (!Array.isArray(applied)) applied = [];
   }
 
   // Scan for migration files (*.js, sorted by filename)

--- a/scripts/run-migrations.js
+++ b/scripts/run-migrations.js
@@ -2,7 +2,7 @@
 import { readdir, readFile, writeFile, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
@@ -31,7 +31,7 @@ async function run() {
     if (applied.includes(file)) continue;
 
     console.log(`🔄 Running migration: ${file}`);
-    const migration = await import(join(migrationsDir, file));
+    const migration = await import(pathToFileURL(join(migrationsDir, file)).href);
     await migration.up({ rootDir, migrationsDir });
     applied.push(file);
     await writeFile(appliedFile, JSON.stringify(applied, null, 2) + '\n');

--- a/scripts/run-migrations.js
+++ b/scripts/run-migrations.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { readdir, readFile, writeFile, mkdir } from 'fs/promises';
-import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
@@ -13,10 +12,15 @@ async function run() {
   // Ensure migrations directory exists
   await mkdir(migrationsDir, { recursive: true });
 
-  // Load applied migrations list (default to [] on corrupt file)
+  // Load applied migrations list (default to [] on read/parse failure)
   let applied = [];
-  if (existsSync(appliedFile)) {
-    const raw = await readFile(appliedFile, 'utf-8');
+  const raw = await readFile(appliedFile, 'utf-8').catch(err => {
+    if (err.code !== 'ENOENT') {
+      console.warn(`⚠️ Could not read ${appliedFile}: ${err.message}, defaulting to []`);
+    }
+    return null;
+  });
+  if (raw !== null) {
     try { applied = JSON.parse(raw); } catch { applied = []; }
     if (!Array.isArray(applied)) applied = [];
   }

--- a/scripts/run-migrations.js
+++ b/scripts/run-migrations.js
@@ -21,8 +21,14 @@ async function run() {
     return null;
   });
   if (raw !== null) {
-    try { applied = JSON.parse(raw); } catch { applied = []; }
-    if (!Array.isArray(applied)) applied = [];
+    let parsed;
+    try { parsed = JSON.parse(raw); } catch (err) {
+      throw new Error(`Corrupted migrations file ${appliedFile} — fix or delete it manually: ${err.message}`);
+    }
+    if (!Array.isArray(parsed)) {
+      throw new Error(`Corrupted migrations file ${appliedFile} — expected array, got ${typeof parsed}`);
+    }
+    applied = parsed;
   }
 
   // Scan for migration files (*.js, sorted by filename)

--- a/scripts/setup-data.js
+++ b/scripts/setup-data.js
@@ -46,5 +46,13 @@ if (!existsSync(dataDir)) {
   };
 
   ensureSubdirs(sampleDir, dataDir);
+
+  // Ensure migrations directory exists (not in data.sample)
+  const migrationsDir = join(dataDir, 'migrations');
+  if (!existsSync(migrationsDir)) {
+    console.log('📁 Creating missing directory: migrations');
+    mkdirSync(migrationsDir, { recursive: true });
+  }
+
   console.log('✅ Data directory already exists, ensured subdirectories');
 }

--- a/scripts/setup-data.js
+++ b/scripts/setup-data.js
@@ -47,12 +47,12 @@ if (!existsSync(dataDir)) {
 
   ensureSubdirs(sampleDir, dataDir);
 
-  // Ensure migrations directory exists (not in data.sample)
-  const migrationsDir = join(dataDir, 'migrations');
-  if (!existsSync(migrationsDir)) {
-    console.log('📁 Creating missing directory: migrations');
-    mkdirSync(migrationsDir, { recursive: true });
-  }
-
   console.log('✅ Data directory already exists, ensured subdirectories');
+}
+
+// Ensure migrations directory exists (not in data.sample, needed for both fresh and existing installs)
+const migrationsDir = join(dataDir, 'migrations');
+if (!existsSync(migrationsDir)) {
+  console.log('📁 Creating missing directory: migrations');
+  mkdirSync(migrationsDir, { recursive: true });
 }

--- a/server/index.js
+++ b/server/index.js
@@ -64,7 +64,7 @@ import './services/subAgentSpawner.js'; // Initialize CoS agent spawner
 import * as automationScheduler from './services/automationScheduler.js';
 import * as agentActionExecutor from './services/agentActionExecutor.js';
 import { startBackupScheduler } from './services/backupScheduler.js';
-import { startUpdateScheduler } from './services/updateChecker.js';
+import { startUpdateScheduler, recordUpdateResult } from './services/updateChecker.js';
 import { startBrainScheduler } from './services/brainScheduler.js';
 import { recoverStuckClassifications } from './services/brain.js';
 import { initBridge as initBrainMemoryBridge } from './services/brainMemoryBridge.js';
@@ -251,6 +251,16 @@ startBrainScheduler();
 initBrainMemoryBridge();
 // Initialize backup scheduler for daily data backups
 startBackupScheduler().catch(err => console.error(`❌ Backup scheduler init failed: ${err.message}`));
+// Check for update completion marker from a previous update cycle
+import { readFile, unlink } from 'fs/promises';
+const updateMarkerPath = join(__dirname, '..', 'data', 'update-complete.json');
+readFile(updateMarkerPath, 'utf-8').then(raw => {
+  const marker = JSON.parse(raw);
+  console.log(`✅ Update to v${marker.version} completed at ${marker.completedAt}`);
+  return recordUpdateResult({ version: marker.version, success: true, completedAt: marker.completedAt, log: '' })
+    .then(() => unlink(updateMarkerPath));
+}).catch(() => {}); // No marker file = no recent update
+
 // Start periodic update checker (checks GitHub releases every 30 min)
 startUpdateScheduler();
 

--- a/server/index.js
+++ b/server/index.js
@@ -281,10 +281,11 @@ readFile(updateMarkerPath, 'utf-8').then(raw => {
   }
   console.log(`✅ Update to v${marker.version} completed at ${marker.completedAt}`);
   return recordUpdateResult({ version: marker.version, success: true, completedAt: marker.completedAt, log: '' })
-    .then(() => unlink(updateMarkerPath))
+    .then(() => unlink(updateMarkerPath).catch(unlinkErr => {
+      if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove update marker: ${unlinkErr.message}`);
+    }))
     .catch(recordErr => {
       console.error(`❌ Failed to record update result: ${recordErr.message}`);
-      // Still remove marker to avoid reprocessing on next startup
       return unlink(updateMarkerPath).catch(unlinkErr => {
         if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove update marker after record failure: ${unlinkErr.message}`);
       });

--- a/server/index.js
+++ b/server/index.js
@@ -65,7 +65,7 @@ import './services/subAgentSpawner.js'; // Initialize CoS agent spawner
 import * as automationScheduler from './services/automationScheduler.js';
 import * as agentActionExecutor from './services/agentActionExecutor.js';
 import { startBackupScheduler } from './services/backupScheduler.js';
-import { startUpdateScheduler, recordUpdateResult, clearStaleUpdateInProgress } from './services/updateChecker.js';
+import { startUpdateScheduler, recordUpdateResult, clearStaleUpdateInProgress, getCurrentVersion } from './services/updateChecker.js';
 import { startBrainScheduler } from './services/brainScheduler.js';
 import { recoverStuckClassifications } from './services/brain.js';
 import { initBridge as initBrainMemoryBridge } from './services/brainMemoryBridge.js';
@@ -278,6 +278,15 @@ readFile(updateMarkerPath, 'utf-8').then(raw => {
     return unlink(updateMarkerPath).catch(unlinkErr => {
       if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove invalid update marker: ${unlinkErr.message}`);
     });
+  }
+  // Verify marker version matches the currently running version to catch partial updates
+  const runningVersion = await getCurrentVersion();
+  if (marker.version !== runningVersion) {
+    console.error(`❌ Update marker version (${marker.version}) doesn't match running version (${runningVersion}) — recording as failed`);
+    return recordUpdateResult({ version: marker.version, success: false, completedAt: marker.completedAt, log: `Version mismatch: expected ${marker.version}, running ${runningVersion}` })
+      .finally(() => unlink(updateMarkerPath).catch(unlinkErr => {
+        if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove update marker: ${unlinkErr.message}`);
+      }));
   }
   console.log(`✅ Update to v${marker.version} completed at ${marker.completedAt}`);
   return recordUpdateResult({ version: marker.version, success: true, completedAt: marker.completedAt, log: '' })

--- a/server/index.js
+++ b/server/index.js
@@ -272,6 +272,13 @@ readFile(updateMarkerPath, 'utf-8').then(raw => {
     });
   }
   const marker = result.marker;
+  // Validate marker has expected fields before recording as success
+  if (!marker.version || !marker.completedAt) {
+    console.error(`❌ Update marker missing required fields (version: ${marker.version}, completedAt: ${marker.completedAt})`);
+    return unlink(updateMarkerPath).catch(unlinkErr => {
+      if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove invalid update marker: ${unlinkErr.message}`);
+    });
+  }
   console.log(`✅ Update to v${marker.version} completed at ${marker.completedAt}`);
   return recordUpdateResult({ version: marker.version, success: true, completedAt: marker.completedAt, log: '' })
     .then(() => unlink(updateMarkerPath))

--- a/server/index.js
+++ b/server/index.js
@@ -5,6 +5,7 @@ import { Server } from 'socket.io';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { existsSync } from 'fs';
+import { readFile, unlink } from 'fs/promises';
 
 import appleHealthRoutes from './routes/appleHealth.js';
 import systemHealthRoutes from './routes/systemHealth.js';
@@ -252,7 +253,6 @@ initBrainMemoryBridge();
 // Initialize backup scheduler for daily data backups
 startBackupScheduler().catch(err => console.error(`❌ Backup scheduler init failed: ${err.message}`));
 // Check for update completion marker from a previous update cycle
-import { readFile, unlink } from 'fs/promises';
 const updateMarkerPath = join(__dirname, '..', 'data', 'update-complete.json');
 readFile(updateMarkerPath, 'utf-8').then(raw => {
   const marker = JSON.parse(raw);

--- a/server/index.js
+++ b/server/index.js
@@ -51,6 +51,7 @@ import instancesRoutes from './routes/instances.js';
 import meatspaceRoutes from './routes/meatspace.js';
 import githubRoutes from './routes/github.js';
 import settingsRoutes from './routes/settings.js';
+import updateRoutes from './routes/update.js';
 import { ensureSelf, startPolling } from './services/instances.js';
 import { initSocket } from './services/socket.js';
 import { initScriptRunner } from './services/scriptRunner.js';
@@ -63,6 +64,7 @@ import './services/subAgentSpawner.js'; // Initialize CoS agent spawner
 import * as automationScheduler from './services/automationScheduler.js';
 import * as agentActionExecutor from './services/agentActionExecutor.js';
 import { startBackupScheduler } from './services/backupScheduler.js';
+import { startUpdateScheduler } from './services/updateChecker.js';
 import { startBrainScheduler } from './services/brainScheduler.js';
 import { recoverStuckClassifications } from './services/brain.js';
 import { initBridge as initBrainMemoryBridge } from './services/brainMemoryBridge.js';
@@ -232,6 +234,7 @@ app.use('/api/instances', instancesRoutes);
 app.use('/api/meatspace', meatspaceRoutes);
 app.use('/api/github', githubRoutes);
 app.use('/api/settings', settingsRoutes);
+app.use('/api/update', updateRoutes);
 
 // Initialize script runner
 initScriptRunner().catch(err => console.error(`❌ Script runner init failed: ${err.message}`));
@@ -248,6 +251,8 @@ startBrainScheduler();
 initBrainMemoryBridge();
 // Initialize backup scheduler for daily data backups
 startBackupScheduler().catch(err => console.error(`❌ Backup scheduler init failed: ${err.message}`));
+// Start periodic update checker (checks GitHub releases every 30 min)
+startUpdateScheduler();
 
 // Serve built client UI (production mode — no Vite dev server needed)
 const CLIENT_DIST = join(__dirname, '..', 'client', 'dist');

--- a/server/index.js
+++ b/server/index.js
@@ -255,11 +255,40 @@ startBackupScheduler().catch(err => console.error(`❌ Backup scheduler init fai
 // Check for update completion marker from a previous update cycle
 const updateMarkerPath = join(__dirname, '..', 'data', 'update-complete.json');
 readFile(updateMarkerPath, 'utf-8').then(raw => {
-  const marker = JSON.parse(raw);
+  const parsed = JSON.parse(raw);
+  return { marker: parsed, parseError: null };
+}, err => {
+  // ENOENT = no marker file = no recent update, nothing to do
+  if (err?.code === 'ENOENT') return null;
+  // Unexpected read error — log and remove the problematic marker
+  console.error(`❌ Failed to read update marker: ${err?.message ?? err}`);
+  return { marker: null, parseError: err };
+}).then(result => {
+  if (!result) return; // No marker file
+  if (!result.marker) {
+    // Read failed with unexpected error — remove corrupted marker to avoid reprocessing
+    return unlink(updateMarkerPath).catch(unlinkErr => {
+      if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove problematic update marker: ${unlinkErr.message}`);
+    });
+  }
+  const marker = result.marker;
   console.log(`✅ Update to v${marker.version} completed at ${marker.completedAt}`);
   return recordUpdateResult({ version: marker.version, success: true, completedAt: marker.completedAt, log: '' })
-    .then(() => unlink(updateMarkerPath));
-}).catch(() => {}); // No marker file = no recent update
+    .then(() => unlink(updateMarkerPath))
+    .catch(recordErr => {
+      console.error(`❌ Failed to record update result: ${recordErr.message}`);
+      // Still remove marker to avoid reprocessing on next startup
+      return unlink(updateMarkerPath).catch(unlinkErr => {
+        if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove update marker after record failure: ${unlinkErr.message}`);
+      });
+    });
+}).catch(err => {
+  // JSON.parse failure — corrupted marker file
+  console.error(`❌ Corrupted update marker (invalid JSON): ${err?.message ?? err}`);
+  unlink(updateMarkerPath).catch(unlinkErr => {
+    if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove corrupted update marker: ${unlinkErr.message}`);
+  });
+});
 
 // Start periodic update checker (checks GitHub releases every 30 min)
 startUpdateScheduler();

--- a/server/index.js
+++ b/server/index.js
@@ -65,7 +65,7 @@ import './services/subAgentSpawner.js'; // Initialize CoS agent spawner
 import * as automationScheduler from './services/automationScheduler.js';
 import * as agentActionExecutor from './services/agentActionExecutor.js';
 import { startBackupScheduler } from './services/backupScheduler.js';
-import { startUpdateScheduler, recordUpdateResult } from './services/updateChecker.js';
+import { startUpdateScheduler, recordUpdateResult, clearStaleUpdateInProgress } from './services/updateChecker.js';
 import { startBrainScheduler } from './services/brainScheduler.js';
 import { recoverStuckClassifications } from './services/brain.js';
 import { initBridge as initBrainMemoryBridge } from './services/brainMemoryBridge.js';
@@ -296,6 +296,9 @@ readFile(updateMarkerPath, 'utf-8').then(raw => {
     if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove corrupted update marker: ${unlinkErr.message}`);
   });
 });
+
+// Clear stale updateInProgress if the server was killed mid-update
+clearStaleUpdateInProgress().catch(err => console.error(`❌ Stale update recovery failed: ${err.message}`));
 
 // Start periodic update checker (checks GitHub releases every 30 min)
 startUpdateScheduler();

--- a/server/index.js
+++ b/server/index.js
@@ -263,7 +263,7 @@ readFile(updateMarkerPath, 'utf-8').then(raw => {
   // Unexpected read error — log and remove the problematic marker
   console.error(`❌ Failed to read update marker: ${err?.message ?? err}`);
   return { marker: null, parseError: err };
-}).then(result => {
+}).then(async result => {
   if (!result) return; // No marker file
   if (!result.marker) {
     // Read failed with unexpected error — remove corrupted marker to avoid reprocessing

--- a/server/index.js
+++ b/server/index.js
@@ -254,58 +254,44 @@ initBrainMemoryBridge();
 startBackupScheduler().catch(err => console.error(`❌ Backup scheduler init failed: ${err.message}`));
 // Check for update completion marker from a previous update cycle
 const updateMarkerPath = join(__dirname, '..', 'data', 'update-complete.json');
-readFile(updateMarkerPath, 'utf-8').then(raw => {
-  const parsed = JSON.parse(raw);
-  return { marker: parsed, parseError: null };
-}, err => {
-  // ENOENT = no marker file = no recent update, nothing to do
-  if (err?.code === 'ENOENT') return null;
-  // Unexpected read error — log and remove the problematic marker
-  console.error(`❌ Failed to read update marker: ${err?.message ?? err}`);
-  return { marker: null, parseError: err };
-}).then(async result => {
-  if (!result) return; // No marker file
-  if (!result.marker) {
-    // Read failed with unexpected error — remove corrupted marker to avoid reprocessing
-    return unlink(updateMarkerPath).catch(unlinkErr => {
-      if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove problematic update marker: ${unlinkErr.message}`);
-    });
+const removeMarker = () => unlink(updateMarkerPath).catch(e => {
+  if (e?.code !== 'ENOENT') console.error(`❌ Failed to remove update marker: ${e.message}`);
+});
+
+(async () => {
+  let raw;
+  try { raw = await readFile(updateMarkerPath, 'utf-8'); }
+  catch (err) {
+    if (err?.code === 'ENOENT') return; // No marker = no recent update
+    console.error(`❌ Failed to read update marker: ${err?.message ?? err}`);
+    return removeMarker();
   }
-  const marker = result.marker;
-  // Validate marker has expected fields before recording as success
+
+  let marker;
+  try { marker = JSON.parse(raw); }
+  catch (err) {
+    console.error(`❌ Corrupted update marker (invalid JSON): ${err?.message ?? err}`);
+    return removeMarker();
+  }
+
   if (!marker.version || !marker.completedAt) {
     console.error(`❌ Update marker missing required fields (version: ${marker.version}, completedAt: ${marker.completedAt})`);
-    return unlink(updateMarkerPath).catch(unlinkErr => {
-      if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove invalid update marker: ${unlinkErr.message}`);
-    });
+    return removeMarker();
   }
-  // Verify marker version matches the currently running version to catch partial updates
+
   const runningVersion = await getCurrentVersion();
   if (marker.version !== runningVersion) {
     console.error(`❌ Update marker version (${marker.version}) doesn't match running version (${runningVersion}) — recording as failed`);
-    return recordUpdateResult({ version: marker.version, success: false, completedAt: marker.completedAt, log: `Version mismatch: expected ${marker.version}, running ${runningVersion}` })
-      .finally(() => unlink(updateMarkerPath).catch(unlinkErr => {
-        if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove update marker: ${unlinkErr.message}`);
-      }));
+    await recordUpdateResult({ version: marker.version, success: false, completedAt: marker.completedAt, log: `Version mismatch: expected ${marker.version}, running ${runningVersion}` })
+      .catch(e => console.error(`❌ Failed to record update result: ${e.message}`));
+    return removeMarker();
   }
+
   console.log(`✅ Update to v${marker.version} completed at ${marker.completedAt}`);
-  return recordUpdateResult({ version: marker.version, success: true, completedAt: marker.completedAt, log: '' })
-    .then(() => unlink(updateMarkerPath).catch(unlinkErr => {
-      if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove update marker: ${unlinkErr.message}`);
-    }))
-    .catch(recordErr => {
-      console.error(`❌ Failed to record update result: ${recordErr.message}`);
-      return unlink(updateMarkerPath).catch(unlinkErr => {
-        if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove update marker after record failure: ${unlinkErr.message}`);
-      });
-    });
-}).catch(err => {
-  // JSON.parse failure — corrupted marker file
-  console.error(`❌ Corrupted update marker (invalid JSON): ${err?.message ?? err}`);
-  unlink(updateMarkerPath).catch(unlinkErr => {
-    if (unlinkErr?.code !== 'ENOENT') console.error(`❌ Failed to remove corrupted update marker: ${unlinkErr.message}`);
-  });
-});
+  await recordUpdateResult({ version: marker.version, success: true, completedAt: marker.completedAt, log: '' })
+    .catch(e => console.error(`❌ Failed to record update result: ${e.message}`));
+  return removeMarker();
+})().catch(err => console.error(`❌ Update marker processing failed: ${err.message}`));
 
 // Clear stale updateInProgress if the server was killed mid-update
 clearStaleUpdateInProgress().catch(err => console.error(`❌ Stale update recovery failed: ${err.message}`));

--- a/server/lib/meatspaceValidation.js
+++ b/server/lib/meatspaceValidation.js
@@ -47,6 +47,14 @@ export const drinkUpdateSchema = z.object({
   count: z.number().int().min(1).max(100).optional()
 });
 
+export const customDrinkSchema = z.object({
+  name: z.string().min(1).max(200),
+  oz: z.number().min(0.1).max(1000),
+  abv: z.number().min(0).max(100)
+});
+
+export const customDrinkUpdateSchema = customDrinkSchema.partial();
+
 // =============================================================================
 // BLOOD TESTS
 // =============================================================================

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -147,7 +147,17 @@ router.get('/:id', loadApp, asyncHandler(async (req, res) => {
     if (devUiProc) devUiPort = devUiProc.ports.devUi;
   }
 
-  res.json({ ...app, uiPort, devUiPort, apiPort, overallStatus, pm2Status: statuses });
+  // Read version from app's package.json if available
+  let appVersion = null;
+  if (app.repoPath) {
+    const pkgPath = join(app.repoPath, 'package.json');
+    if (existsSync(pkgPath)) {
+      const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
+      appVersion = pkg.version || null;
+    }
+  }
+
+  res.json({ ...app, uiPort, devUiPort, apiPort, overallStatus, pm2Status: statuses, appVersion });
 }));
 
 // POST /api/apps - Create new app

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -17,6 +17,9 @@ import { parseEcosystemFromPath } from '../services/streamingDetect.js';
 
 const router = Router();
 
+/** Read and parse a JSON file, returning null on any failure (missing file, bad JSON, etc.) */
+const safeReadJson = (path) => readFile(path, 'utf-8').then(JSON.parse).catch(() => null);
+
 /**
  * Middleware to load app by :id param and attach to req.loadedApp
  * Throws 404 if not found, eliminating repeated null checks across routes
@@ -150,11 +153,8 @@ router.get('/:id', loadApp, asyncHandler(async (req, res) => {
   // Read version from app's package.json if available
   let appVersion = null;
   if (app.repoPath) {
-    const pkgPath = join(app.repoPath, 'package.json');
-    if (existsSync(pkgPath)) {
-      const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
-      appVersion = pkg.version || null;
-    }
+    const pkg = await safeReadJson(join(app.repoPath, 'package.json'));
+    appVersion = pkg?.version || null;
   }
 
   res.json({ ...app, uiPort, devUiPort, apiPort, overallStatus, pm2Status: statuses, appVersion });

--- a/server/routes/meatspace.js
+++ b/server/routes/meatspace.js
@@ -182,6 +182,9 @@ router.post('/alcohol/custom-drinks', asyncHandler(async (req, res) => {
  */
 router.put('/alcohol/custom-drinks/:index', asyncHandler(async (req, res) => {
   const index = parseInt(req.params.index, 10);
+  if (!Number.isInteger(index)) {
+    throw new ServerError('Invalid index', { status: 400, code: 'INVALID_INDEX' });
+  }
   const data = validateRequest(customDrinkUpdateSchema, req.body);
   const drink = await alcoholService.updateCustomDrink(index, data);
   if (!drink) {
@@ -196,6 +199,9 @@ router.put('/alcohol/custom-drinks/:index', asyncHandler(async (req, res) => {
  */
 router.delete('/alcohol/custom-drinks/:index', asyncHandler(async (req, res) => {
   const index = parseInt(req.params.index, 10);
+  if (!Number.isInteger(index)) {
+    throw new ServerError('Invalid index', { status: 400, code: 'INVALID_INDEX' });
+  }
   const removed = await alcoholService.removeCustomDrink(index);
   if (!removed) {
     throw new ServerError('Custom drink not found', { status: 404, code: 'NOT_FOUND' });

--- a/server/routes/meatspace.js
+++ b/server/routes/meatspace.js
@@ -6,6 +6,8 @@ import {
   lifestyleUpdateSchema,
   drinkLogSchema,
   drinkUpdateSchema,
+  customDrinkSchema,
+  customDrinkUpdateSchema,
   bloodTestSchema,
   bodyEntrySchema,
   epigeneticTestSchema,
@@ -147,6 +149,56 @@ router.delete('/alcohol/log/:date/:index', asyncHandler(async (req, res) => {
   const removed = await alcoholService.removeDrink(date, parseInt(index, 10));
   if (!removed) {
     throw new ServerError('Drink entry not found', { status: 404, code: 'NOT_FOUND' });
+  }
+  res.json(removed);
+}));
+
+// =============================================================================
+// CUSTOM DRINK BUTTONS
+// =============================================================================
+
+/**
+ * GET /api/meatspace/alcohol/custom-drinks
+ * List custom drink quick-add buttons
+ */
+router.get('/alcohol/custom-drinks', asyncHandler(async (req, res) => {
+  const drinks = await alcoholService.getCustomDrinks();
+  res.json(drinks);
+}));
+
+/**
+ * POST /api/meatspace/alcohol/custom-drinks
+ * Add a custom drink button
+ */
+router.post('/alcohol/custom-drinks', asyncHandler(async (req, res) => {
+  const data = validateRequest(customDrinkSchema, req.body);
+  const drink = await alcoholService.addCustomDrink(data);
+  res.status(201).json(drink);
+}));
+
+/**
+ * PUT /api/meatspace/alcohol/custom-drinks/:index
+ * Update a custom drink button
+ */
+router.put('/alcohol/custom-drinks/:index', asyncHandler(async (req, res) => {
+  const index = parseInt(req.params.index, 10);
+  const data = validateRequest(customDrinkUpdateSchema, req.body);
+  const drink = await alcoholService.updateCustomDrink(index, data);
+  if (!drink) {
+    throw new ServerError('Custom drink not found', { status: 404, code: 'NOT_FOUND' });
+  }
+  res.json(drink);
+}));
+
+/**
+ * DELETE /api/meatspace/alcohol/custom-drinks/:index
+ * Remove a custom drink button
+ */
+router.delete('/alcohol/custom-drinks/:index', asyncHandler(async (req, res) => {
+  const index = parseInt(req.params.index, 10);
+  const removed = await alcoholService.removeCustomDrink(index);
+  if (!removed) {
+    throw new ServerError('Custom drink not found', { status: 404, code: 'NOT_FOUND' });
   }
   res.json(removed);
 }));

--- a/server/routes/systemHealth.js
+++ b/server/routes/systemHealth.js
@@ -5,16 +5,20 @@ import * as apps from '../services/apps.js';
 import * as cos from '../services/cos.js';
 import { getSelf } from '../services/instances.js';
 import { checkHealth } from '../lib/db.js';
+import { getCurrentVersion } from '../services/updateChecker.js';
 
 const router = Router();
 
 router.get('/health', async (req, res) => {
-  const self = await getSelf().catch(() => null);
+  const [self, version] = await Promise.all([
+    getSelf().catch(() => null),
+    getCurrentVersion()
+  ]);
   res.json({
     status: 'ok',
     timestamp: new Date().toISOString(),
     uptime: process.uptime(),
-    version: '0.1.0',
+    version,
     hostname: os.hostname(),
     instanceId: self?.instanceId ?? null
   });

--- a/server/routes/update.js
+++ b/server/routes/update.js
@@ -1,0 +1,79 @@
+import { Router } from 'express';
+import { z } from 'zod';
+import { asyncHandler, ServerError } from '../lib/errorHandler.js';
+import { validateRequest } from '../lib/validation.js';
+import * as updateChecker from '../services/updateChecker.js';
+import { executeUpdate } from '../services/updateExecutor.js';
+
+const router = Router();
+
+const ignoreSchema = z.object({
+  version: z.string().min(1, 'version is required')
+});
+
+// GET /api/update/status — returns update state
+router.get('/status', asyncHandler(async (req, res) => {
+  const status = await updateChecker.getUpdateStatus();
+  res.json(status);
+}));
+
+// POST /api/update/check — triggers manual check
+router.post('/check', asyncHandler(async (req, res) => {
+  const result = await updateChecker.checkForUpdate();
+  res.json(result);
+}));
+
+// POST /api/update/ignore — adds version to ignored list
+router.post('/ignore', asyncHandler(async (req, res) => {
+  const { version } = validateRequest(ignoreSchema, req.body);
+  await updateChecker.ignoreVersion(version);
+  const status = await updateChecker.getUpdateStatus();
+  res.json(status);
+}));
+
+// DELETE /api/update/ignore — clears all ignored versions
+router.delete('/ignore', asyncHandler(async (req, res) => {
+  await updateChecker.clearIgnored();
+  const status = await updateChecker.getUpdateStatus();
+  res.json(status);
+}));
+
+// POST /api/update/execute — kicks off update
+router.post('/execute', asyncHandler(async (req, res) => {
+  const status = await updateChecker.getUpdateStatus();
+  if (!status.latestRelease?.tag) {
+    throw new ServerError('No release available to update to', { status: 400, code: 'NO_RELEASE' });
+  }
+  if (status.updateInProgress) {
+    throw new ServerError('Update already in progress', { status: 409, code: 'UPDATE_IN_PROGRESS' });
+  }
+
+  const tag = status.latestRelease.tag;
+  const io = req.app.get('io');
+
+  // Start update in background, stream progress via socket
+  const emit = (step, stepStatus, message) => {
+    if (io) {
+      io.emit('portos:update:step', { step, status: stepStatus, message, timestamp: Date.now() });
+    }
+  };
+
+  // Don't await — respond immediately, progress streams via socket
+  executeUpdate(tag, emit).then(result => {
+    if (io) {
+      if (result.success) {
+        io.emit('portos:update:complete', { success: true, newVersion: tag.replace(/^v/, '') });
+      } else {
+        io.emit('portos:update:error', { message: 'Update failed', step: 'unknown' });
+      }
+    }
+  }).catch(err => {
+    if (io) {
+      io.emit('portos:update:error', { message: err.message, step: 'unknown' });
+    }
+  });
+
+  res.json({ started: true, tag });
+}));
+
+export default router;

--- a/server/routes/update.js
+++ b/server/routes/update.js
@@ -85,7 +85,7 @@ router.post('/execute', asyncHandler(async (req, res) => {
       if (result.success) {
         io.emit('portos:update:complete', { success: true, newVersion: tag.replace(/^v/, '') });
       } else {
-        io.emit('portos:update:error', { message: 'Update failed', step: 'unknown' });
+        io.emit('portos:update:error', { message: result.errorMessage ?? 'Update failed', step: result.failedStep ?? 'unknown' });
       }
     }
   }).catch(err => {

--- a/server/routes/update.js
+++ b/server/routes/update.js
@@ -51,8 +51,8 @@ router.post('/execute', asyncHandler(async (req, res) => {
 
   const tag = status.latestRelease.tag;
 
-  // Validate tag is a well-formed semver release (e.g. "v1.27.0") to prevent option injection
-  if (!/^v\d+\.\d+\.\d+$/.test(tag)) {
+  // Validate tag is a well-formed semver release (e.g. "v1.27.0" or "v1.27.0-rc.1") to prevent option injection
+  if (!/^v\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$/.test(tag)) {
     throw new ServerError('Invalid release tag format', { status: 400, code: 'INVALID_TAG' });
   }
 

--- a/server/routes/update.js
+++ b/server/routes/update.js
@@ -49,6 +49,12 @@ router.post('/execute', asyncHandler(async (req, res) => {
   }
 
   const tag = status.latestRelease.tag;
+
+  // Validate tag is a well-formed semver release (e.g. "v1.27.0") to prevent option injection
+  if (!/^v\d+\.\d+\.\d+$/.test(tag)) {
+    throw new ServerError('Invalid release tag format', { status: 400, code: 'INVALID_TAG' });
+  }
+
   const io = req.app.get('io');
 
   // Start update in background, stream progress via socket

--- a/server/routes/update.js
+++ b/server/routes/update.js
@@ -66,6 +66,9 @@ router.post('/execute', asyncHandler(async (req, res) => {
 
   // Don't await — respond immediately, progress streams via socket
   executeUpdate(tag, emit).then(result => {
+    // Note: this .then() may never fire if the update script's PM2 restart
+    // kills this server process first. The client handles this by polling
+    // /api/system/health after receiving the 'restarting' step (see below).
     if (io) {
       if (result.success) {
         io.emit('portos:update:complete', { success: true, newVersion: tag.replace(/^v/, '') });
@@ -78,6 +81,10 @@ router.post('/execute', asyncHandler(async (req, res) => {
       io.emit('portos:update:error', { message: err.message, step: 'unknown' });
     }
   });
+
+  // Emit a restarting step immediately so the client knows to start
+  // health polling now, before the PM2 restart kills this process
+  emit('restarting', 'running', 'Server will restart momentarily...');
 
   res.json({ started: true, tag });
 }));

--- a/server/routes/update.js
+++ b/server/routes/update.js
@@ -55,6 +55,11 @@ router.post('/execute', asyncHandler(async (req, res) => {
     throw new ServerError('Invalid release tag format', { status: 400, code: 'INVALID_TAG' });
   }
 
+  // Lock out duplicate requests synchronously BEFORE spawning the update,
+  // preventing the race where a second request slips in before executeUpdate's
+  // first await persists the flag
+  await updateChecker.setUpdateInProgress(true);
+
   const io = req.app.get('io');
 
   // Start update in background, stream progress via socket
@@ -64,11 +69,13 @@ router.post('/execute', asyncHandler(async (req, res) => {
     }
   };
 
-  // Don't await — respond immediately, progress streams via socket
+  // Don't await — respond immediately, progress streams via socket.
+  // The update script emits STEP:restart:running when it reaches the PM2
+  // restart phase, which triggers the client's health polling.
   executeUpdate(tag, emit).then(result => {
     // Note: this .then() may never fire if the update script's PM2 restart
     // kills this server process first. The client handles this by polling
-    // /api/system/health after receiving the 'restarting' step (see below).
+    // /api/system/health after receiving the 'restart' step.
     if (io) {
       if (result.success) {
         io.emit('portos:update:complete', { success: true, newVersion: tag.replace(/^v/, '') });
@@ -81,10 +88,6 @@ router.post('/execute', asyncHandler(async (req, res) => {
       io.emit('portos:update:error', { message: err.message, step: 'unknown' });
     }
   });
-
-  // Emit a restarting step immediately so the client knows to start
-  // health polling now, before the PM2 restart kills this process
-  emit('restarting', 'running', 'Server will restart momentarily...');
 
   res.json({ started: true, tag });
 }));

--- a/server/routes/update.js
+++ b/server/routes/update.js
@@ -55,6 +55,11 @@ router.post('/execute', asyncHandler(async (req, res) => {
     throw new ServerError('Invalid release tag format', { status: 400, code: 'INVALID_TAG' });
   }
 
+  // Reject unsupported platforms before locking, so the flag isn't left stuck
+  if (process.platform === 'win32') {
+    throw new ServerError('Auto-update is not supported on Windows', { status: 400, code: 'UNSUPPORTED_PLATFORM' });
+  }
+
   // Lock out duplicate requests synchronously BEFORE spawning the update,
   // preventing the race where a second request slips in before executeUpdate's
   // first await persists the flag

--- a/server/routes/update.js
+++ b/server/routes/update.js
@@ -11,8 +11,9 @@ const ignoreSchema = z.object({
   version: z.string().min(1, 'version is required')
 });
 
-// GET /api/update/status — returns update state
+// GET /api/update/status — returns update state (also clears stale locks)
 router.get('/status', asyncHandler(async (req, res) => {
+  await updateChecker.clearStaleUpdateInProgress();
   const status = await updateChecker.getUpdateStatus();
   res.json(status);
 }));

--- a/server/services/github.js
+++ b/server/services/github.js
@@ -39,7 +39,7 @@ async function save(data) {
 /**
  * Execute a gh CLI command safely using spawn
  */
-function execGh(args) {
+export function execGh(args) {
   return new Promise((resolve, reject) => {
     const child = spawn('gh', args, { shell: false, windowsHide: true });
     let stdout = '';

--- a/server/services/meatspaceAlcohol.js
+++ b/server/services/meatspaceAlcohol.js
@@ -272,6 +272,7 @@ async function loadCustomDrinks() {
     await saveCustomDrinks(seeded);
     return seeded;
   }
+  if (!Array.isArray(data.drinks)) data.drinks = [];
   return data;
 }
 

--- a/server/services/meatspaceAlcohol.js
+++ b/server/services/meatspaceAlcohol.js
@@ -268,7 +268,7 @@ async function loadCustomDrinks() {
   const data = await readJSONFile(CUSTOM_DRINKS_FILE, null);
   if (!data) {
     // Seed with defaults on first access
-    const seeded = { drinks: DEFAULT_DRINK_BUTTONS };
+    const seeded = { drinks: DEFAULT_DRINK_BUTTONS.map(d => ({ ...d })) };
     await saveCustomDrinks(seeded);
     return seeded;
   }

--- a/server/services/meatspaceAlcohol.js
+++ b/server/services/meatspaceAlcohol.js
@@ -12,6 +12,15 @@ import { PATHS, ensureDir, readJSONFile } from '../lib/fileUtils.js';
 const MEATSPACE_DIR = PATHS.meatspace;
 const DAILY_LOG_FILE = join(MEATSPACE_DIR, 'daily-log.json');
 const CONFIG_FILE = join(MEATSPACE_DIR, 'config.json');
+const CUSTOM_DRINKS_FILE = join(MEATSPACE_DIR, 'custom-drinks.json');
+
+const DEFAULT_DRINK_BUTTONS = [
+  { name: 'Modelo Especial (12oz)', oz: 12, abv: 4.4 },
+  { name: 'Nitro Guinness (14.9oz)', oz: 14.9, abv: 4.2 },
+  { name: 'Old Fashioned (2oz)', oz: 2, abv: 40 },
+  { name: 'Guinness 0 (14.9oz)', oz: 14.9, abv: 0.4 },
+  { name: 'N/A Beer (12oz)', oz: 12, abv: 0.4 }
+];
 
 // Cache for rolling averages (invalidated on writes)
 let averageCache = null;
@@ -251,4 +260,67 @@ export async function removeDrink(date, index) {
 
   await saveDailyLog(log);
   return removed;
+}
+
+// === Custom Drink Buttons ===
+
+async function loadCustomDrinks() {
+  const data = await readJSONFile(CUSTOM_DRINKS_FILE, null);
+  if (!data) {
+    // Seed with defaults on first access
+    const seeded = { drinks: DEFAULT_DRINK_BUTTONS };
+    await saveCustomDrinks(seeded);
+    return seeded;
+  }
+  return data;
+}
+
+async function saveCustomDrinks(data) {
+  await ensureDir(MEATSPACE_DIR);
+  await writeFile(CUSTOM_DRINKS_FILE, JSON.stringify(data, null, 2));
+}
+
+export async function getCustomDrinks() {
+  const data = await loadCustomDrinks();
+  return data.drinks || [];
+}
+
+export async function addCustomDrink({ name, oz, abv }) {
+  const data = await loadCustomDrinks();
+  const drink = { name, oz, abv };
+  data.drinks.push(drink);
+  await saveCustomDrinks(data);
+  console.log(`🍺 Added custom drink button: ${name} ${oz}oz @ ${abv}%`);
+  return drink;
+}
+
+export async function updateCustomDrink(index, updates) {
+  const data = await loadCustomDrinks();
+  if (index < 0 || index >= data.drinks.length) return null;
+  const drink = data.drinks[index];
+  if (updates.name !== undefined) drink.name = updates.name;
+  if (updates.oz !== undefined) drink.oz = updates.oz;
+  if (updates.abv !== undefined) drink.abv = updates.abv;
+  await saveCustomDrinks(data);
+  console.log(`📝 Updated custom drink button [${index}]: ${drink.name}`);
+  return drink;
+}
+
+export async function removeCustomDrink(index) {
+  const data = await loadCustomDrinks();
+  if (index < 0 || index >= data.drinks.length) return null;
+  const removed = data.drinks.splice(index, 1)[0];
+  await saveCustomDrinks(data);
+  console.log(`🗑️ Removed custom drink button: ${removed.name}`);
+  return removed;
+}
+
+export async function reorderCustomDrinks(fromIndex, toIndex) {
+  const data = await loadCustomDrinks();
+  if (fromIndex < 0 || fromIndex >= data.drinks.length) return null;
+  if (toIndex < 0 || toIndex >= data.drinks.length) return null;
+  const [moved] = data.drinks.splice(fromIndex, 1);
+  data.drinks.splice(toIndex, 0, moved);
+  await saveCustomDrinks(data);
+  return data.drinks;
 }

--- a/server/services/meatspaceAlcohol.js
+++ b/server/services/meatspaceAlcohol.js
@@ -267,10 +267,8 @@ export async function removeDrink(date, index) {
 async function loadCustomDrinks() {
   const data = await readJSONFile(CUSTOM_DRINKS_FILE, null);
   if (!data) {
-    // Seed with defaults on first access
-    const seeded = { drinks: DEFAULT_DRINK_BUTTONS.map(d => ({ ...d })) };
-    await saveCustomDrinks(seeded);
-    return seeded;
+    // Return defaults in-memory without writing — persist only on explicit mutations
+    return { drinks: DEFAULT_DRINK_BUTTONS.map(d => ({ ...d })) };
   }
   if (!Array.isArray(data.drinks)) data.drinks = [];
   return data;

--- a/server/services/meatspaceAlcohol.js
+++ b/server/services/meatspaceAlcohol.js
@@ -295,6 +295,7 @@ export async function addCustomDrink({ name, oz, abv }) {
 }
 
 export async function updateCustomDrink(index, updates) {
+  if (!Number.isInteger(index)) return null;
   const data = await loadCustomDrinks();
   if (index < 0 || index >= data.drinks.length) return null;
   const drink = data.drinks[index];
@@ -307,6 +308,7 @@ export async function updateCustomDrink(index, updates) {
 }
 
 export async function removeCustomDrink(index) {
+  if (!Number.isInteger(index)) return null;
   const data = await loadCustomDrinks();
   if (index < 0 || index >= data.drinks.length) return null;
   const removed = data.drinks.splice(index, 1)[0];
@@ -316,6 +318,7 @@ export async function removeCustomDrink(index) {
 }
 
 export async function reorderCustomDrinks(fromIndex, toIndex) {
+  if (!Number.isInteger(fromIndex) || !Number.isInteger(toIndex)) return null;
   const data = await loadCustomDrinks();
   if (fromIndex < 0 || fromIndex >= data.drinks.length) return null;
   if (toIndex < 0 || toIndex >= data.drinks.length) return null;

--- a/server/services/meatspaceAlcohol.test.js
+++ b/server/services/meatspaceAlcohol.test.js
@@ -264,3 +264,72 @@ describe('computeRollingAverages', () => {
     expect(result.totalEntries).toBe(3);
   });
 });
+
+// =============================================================================
+// CUSTOM DRINK BUTTON LOGIC TESTS (inline logic mirroring service functions)
+// =============================================================================
+
+describe('custom drink button logic', () => {
+  // Mirrors loadCustomDrinks normalization
+  function normalizeCustomDrinks(data) {
+    if (!data) return { drinks: [] };
+    if (!Array.isArray(data.drinks)) data.drinks = [];
+    return data;
+  }
+
+  it('normalizes null data to empty drinks array', () => {
+    const result = normalizeCustomDrinks(null);
+    expect(result).toEqual({ drinks: [] });
+  });
+
+  it('normalizes data without drinks key', () => {
+    const result = normalizeCustomDrinks({ something: 'else' });
+    expect(result.drinks).toEqual([]);
+  });
+
+  it('normalizes non-array drinks to empty array', () => {
+    const result = normalizeCustomDrinks({ drinks: 'invalid' });
+    expect(result.drinks).toEqual([]);
+  });
+
+  it('preserves valid drinks array', () => {
+    const drinks = [{ name: 'Beer', oz: 12, abv: 5 }];
+    const result = normalizeCustomDrinks({ drinks });
+    expect(result.drinks).toEqual(drinks);
+  });
+
+  it('preserves empty drinks array', () => {
+    const result = normalizeCustomDrinks({ drinks: [] });
+    expect(result.drinks).toEqual([]);
+  });
+
+  // Mirrors index bounds checking in update/remove/reorder
+  function isValidIndex(index, length) {
+    return Number.isInteger(index) && index >= 0 && index < length;
+  }
+
+  it('rejects NaN index', () => {
+    expect(isValidIndex(NaN, 5)).toBe(false);
+  });
+
+  it('rejects float index', () => {
+    expect(isValidIndex(1.5, 5)).toBe(false);
+  });
+
+  it('rejects negative index', () => {
+    expect(isValidIndex(-1, 5)).toBe(false);
+  });
+
+  it('rejects out-of-bounds index', () => {
+    expect(isValidIndex(5, 5)).toBe(false);
+  });
+
+  it('accepts valid index', () => {
+    expect(isValidIndex(0, 5)).toBe(true);
+    expect(isValidIndex(4, 5)).toBe(true);
+  });
+
+  it('rejects any index for empty list', () => {
+    expect(isValidIndex(0, 0)).toBe(false);
+  });
+});

--- a/server/services/meatspaceCustomDrinks.test.js
+++ b/server/services/meatspaceCustomDrinks.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('../lib/fileUtils.js', () => ({
+  readJSONFile: vi.fn(),
+  PATHS: {
+    root: '/mock',
+    data: '/mock/data',
+    meatspace: '/mock/data/meatspace'
+  },
+  ensureDir: vi.fn().mockResolvedValue(undefined)
+}));
+
+import { writeFile } from 'fs/promises';
+import { readJSONFile } from '../lib/fileUtils.js';
+import {
+  getCustomDrinks,
+  addCustomDrink,
+  updateCustomDrink,
+  removeCustomDrink
+} from './meatspaceAlcohol.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('custom drink CRUD', () => {
+  it('returns default drinks when file does not exist', async () => {
+    readJSONFile.mockResolvedValue(null);
+    const drinks = await getCustomDrinks();
+    expect(drinks.length).toBeGreaterThan(0);
+    expect(drinks[0]).toHaveProperty('name');
+    expect(drinks[0]).toHaveProperty('oz');
+    expect(drinks[0]).toHaveProperty('abv');
+    // Should not write to disk on read
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('returns persisted drinks from file', async () => {
+    readJSONFile.mockResolvedValue({ drinks: [{ name: 'IPA', oz: 16, abv: 7 }] });
+    const drinks = await getCustomDrinks();
+    expect(drinks).toEqual([{ name: 'IPA', oz: 16, abv: 7 }]);
+  });
+
+  it('adds a custom drink and persists', async () => {
+    readJSONFile.mockResolvedValue({ drinks: [{ name: 'IPA', oz: 16, abv: 7 }] });
+    const result = await addCustomDrink({ name: 'Stout', oz: 12, abv: 5 });
+    expect(result).toEqual({ name: 'Stout', oz: 12, abv: 5 });
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(writeFile.mock.calls[0][1]);
+    expect(written.drinks).toHaveLength(2);
+    expect(written.drinks[1].name).toBe('Stout');
+  });
+
+  it('updates a custom drink by index', async () => {
+    readJSONFile.mockResolvedValue({ drinks: [{ name: 'IPA', oz: 16, abv: 7 }] });
+    const result = await updateCustomDrink(0, { name: 'Double IPA', abv: 9 });
+    expect(result.name).toBe('Double IPA');
+    expect(result.abv).toBe(9);
+    expect(result.oz).toBe(16); // unchanged
+    expect(writeFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null for out-of-bounds update', async () => {
+    readJSONFile.mockResolvedValue({ drinks: [{ name: 'IPA', oz: 16, abv: 7 }] });
+    expect(await updateCustomDrink(5, { name: 'X' })).toBeNull();
+    expect(await updateCustomDrink(-1, { name: 'X' })).toBeNull();
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('removes a custom drink by index', async () => {
+    readJSONFile.mockResolvedValue({ drinks: [
+      { name: 'IPA', oz: 16, abv: 7 },
+      { name: 'Stout', oz: 12, abv: 5 }
+    ]});
+    const removed = await removeCustomDrink(0);
+    expect(removed.name).toBe('IPA');
+    expect(writeFile).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(writeFile.mock.calls[0][1]);
+    expect(written.drinks).toHaveLength(1);
+    expect(written.drinks[0].name).toBe('Stout');
+  });
+
+  it('returns null for out-of-bounds remove', async () => {
+    readJSONFile.mockResolvedValue({ drinks: [{ name: 'IPA', oz: 16, abv: 7 }] });
+    expect(await removeCustomDrink(5)).toBeNull();
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('normalizes missing drinks array from file', async () => {
+    readJSONFile.mockResolvedValue({ notDrinks: true });
+    const drinks = await getCustomDrinks();
+    expect(drinks).toEqual([]);
+  });
+});

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -9,6 +9,7 @@ import { notificationEvents } from './notifications.js';
 import { providerStatusEvents } from './providerStatus.js';
 import { agentPersonalityEvents } from './agentPersonalities.js';
 import { platformAccountEvents } from './platformAccounts.js';
+import { updateEvents } from './updateChecker.js';
 import { scheduleEvents } from './automationScheduler.js';
 import { activityEvents } from './agentActivity.js';
 import { brainEvents } from './brainStorage.js';
@@ -43,6 +44,8 @@ const notificationSubscribers = new Set();
 const agentSubscribers = new Set();
 // Store instance subscribers
 const instanceSubscribers = new Set();
+// Store update subscribers
+const updateSubscribers = new Set();
 // Store io instance for broadcasting
 let ioInstance = null;
 
@@ -254,6 +257,17 @@ export function initSocket(io) {
       socket.emit('instances:unsubscribed');
     });
 
+    // Update subscriptions
+    socket.on('update:subscribe', () => {
+      updateSubscribers.add(socket);
+      socket.emit('update:subscribed');
+    });
+
+    socket.on('update:unsubscribe', () => {
+      updateSubscribers.delete(socket);
+      socket.emit('update:unsubscribed');
+    });
+
     // Handle error recovery requests (can trigger auto-fix agents)
     socket.on('error:recover', async (rawData) => {
       const data = validateSocketData(errorRecoverSchema, rawData, socket, 'error:recover');
@@ -412,6 +426,7 @@ export function initSocket(io) {
       notificationSubscribers.delete(socket);
       agentSubscribers.delete(socket);
       instanceSubscribers.delete(socket);
+      updateSubscribers.delete(socket);
       // Clean up any shell sessions for this socket
       const shellsClosed = shellService.cleanupSocketSessions(socket);
       if (shellsClosed > 0) {
@@ -455,6 +470,9 @@ export function initSocket(io) {
 
   // Set up peer agent event forwarding
   setupPeerAgentEventForwarding();
+
+  // Set up update event forwarding
+  setupUpdateEventForwarding();
 }
 
 function cleanupStream(socketId) {
@@ -643,4 +661,22 @@ function setupPeerAgentEventForwarding() {
   instanceEvents.on('peer:agent:updated', (data) => broadcastToInstances('instances:peer:agent:updated', data));
   instanceEvents.on('peer:agent:output', (data) => broadcastToInstances('instances:peer:agent:output', data));
   instanceEvents.on('peer:agent:completed', (data) => broadcastToInstances('instances:peer:agent:completed', data));
+}
+
+// Broadcast to update subscribers only
+function broadcastToUpdate(event, data) {
+  for (const socket of updateSubscribers) {
+    socket.emit(event, data);
+  }
+}
+
+// Set up update event forwarding
+function setupUpdateEventForwarding() {
+  updateEvents.on('update:available', (data) => {
+    // Broadcast to all clients so global toast can appear
+    if (ioInstance) {
+      ioInstance.emit('portos:update:available', data);
+    }
+  });
+  updateEvents.on('update:checked', (data) => broadcastToUpdate('portos:update:checked', data));
 }

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -44,8 +44,6 @@ const notificationSubscribers = new Set();
 const agentSubscribers = new Set();
 // Store instance subscribers
 const instanceSubscribers = new Set();
-// Store update subscribers
-const updateSubscribers = new Set();
 // Store io instance for broadcasting
 let ioInstance = null;
 
@@ -257,17 +255,6 @@ export function initSocket(io) {
       socket.emit('instances:unsubscribed');
     });
 
-    // Update subscriptions
-    socket.on('update:subscribe', () => {
-      updateSubscribers.add(socket);
-      socket.emit('update:subscribed');
-    });
-
-    socket.on('update:unsubscribe', () => {
-      updateSubscribers.delete(socket);
-      socket.emit('update:unsubscribed');
-    });
-
     // Handle error recovery requests (can trigger auto-fix agents)
     socket.on('error:recover', async (rawData) => {
       const data = validateSocketData(errorRecoverSchema, rawData, socket, 'error:recover');
@@ -426,7 +413,6 @@ export function initSocket(io) {
       notificationSubscribers.delete(socket);
       agentSubscribers.delete(socket);
       instanceSubscribers.delete(socket);
-      updateSubscribers.delete(socket);
       // Clean up any shell sessions for this socket
       const shellsClosed = shellService.cleanupSocketSessions(socket);
       if (shellsClosed > 0) {
@@ -663,20 +649,16 @@ function setupPeerAgentEventForwarding() {
   instanceEvents.on('peer:agent:completed', (data) => broadcastToInstances('instances:peer:agent:completed', data));
 }
 
-// Broadcast to update subscribers only
-function broadcastToUpdate(event, data) {
-  for (const socket of updateSubscribers) {
-    socket.emit(event, data);
-  }
-}
-
 // Set up update event forwarding
 function setupUpdateEventForwarding() {
   updateEvents.on('update:available', (data) => {
-    // Broadcast to all clients so global toast can appear
     if (ioInstance) {
       ioInstance.emit('portos:update:available', data);
     }
   });
-  updateEvents.on('update:checked', (data) => broadcastToUpdate('portos:update:checked', data));
+  updateEvents.on('update:checked', (data) => {
+    if (ioInstance) {
+      ioInstance.emit('portos:update:checked', data);
+    }
+  });
 }

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -649,8 +649,11 @@ function setupPeerAgentEventForwarding() {
   instanceEvents.on('peer:agent:completed', (data) => broadcastToInstances('instances:peer:agent:completed', data));
 }
 
-// Set up update event forwarding
+// Set up update event forwarding (idempotent — safe if called more than once)
+let updateForwardingSetup = false;
 function setupUpdateEventForwarding() {
+  if (updateForwardingSetup) return;
+  updateForwardingSetup = true;
   updateEvents.on('update:available', (data) => {
     if (ioInstance) {
       ioInstance.emit('portos:update:available', data);

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -54,7 +54,14 @@ export function compareSemver(a, b) {
 
 async function loadState() {
   await ensureDir(PATHS.data);
-  return readJSONFile(UPDATE_FILE, defaultState());
+  const raw = await readJSONFile(UPDATE_FILE, defaultState());
+  const defaults = defaultState();
+  return {
+    ...defaults,
+    ...raw,
+    ignoredVersions: Array.isArray(raw.ignoredVersions) ? raw.ignoredVersions : defaults.ignoredVersions,
+    updateInProgress: typeof raw.updateInProgress === 'boolean' ? raw.updateInProgress : defaults.updateInProgress,
+  };
 }
 
 async function saveState(state) {
@@ -197,12 +204,14 @@ export async function clearStaleUpdateInProgress() {
     const state = await loadState();
     if (!state.updateInProgress) return false;
 
-    const startedAt = state.updateStartedAt ? new Date(state.updateStartedAt).getTime() : 0;
-    const ageMs = Date.now() - startedAt;
+    const startedAtMs = state.updateStartedAt ? new Date(state.updateStartedAt).getTime() : NaN;
+    const hasValidTimestamp = Number.isFinite(startedAtMs);
+    const ageMs = hasValidTimestamp ? Date.now() - startedAtMs : null;
 
-    // If no timestamp or older than timeout, treat as stale
-    if (!state.updateStartedAt || ageMs > STALE_UPDATE_TIMEOUT_MS) {
-      console.log(`🧹 Clearing stale updateInProgress (started ${state.updateStartedAt ?? 'unknown'}, age ${Math.round(ageMs / 60000)}min)`);
+    // If no valid timestamp or older than timeout, treat as stale
+    if (!hasValidTimestamp || ageMs > STALE_UPDATE_TIMEOUT_MS) {
+      const ageStr = ageMs !== null ? `${Math.round(ageMs / 60000)}min` : 'unknown';
+      console.log(`🧹 Clearing stale updateInProgress (started ${state.updateStartedAt ?? 'unknown'}, age ${ageStr})`);
       state.updateInProgress = false;
       state.updateStartedAt = null;
       state.lastUpdateResult = {

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -41,15 +41,22 @@ export async function getCurrentVersion() {
  *  -1 if a < b, 0 if equal, 1 if a > b
  */
 export function compareSemver(a, b) {
-  // Strip pre-release/build metadata (e.g. "1.2.3-rc.1+build" → "1.2.3")
-  const pa = a.replace(/[-+].*$/, '').split('.').map(Number);
-  const pb = b.replace(/[-+].*$/, '').split('.').map(Number);
+  const extractParts = (v) => {
+    const [core, pre] = v.split('+')[0].split('-', 2);
+    return { nums: core.split('.').map(Number), pre: pre || null };
+  };
+  const pa = extractParts(a);
+  const pb = extractParts(b);
   for (let i = 0; i < 3; i++) {
-    const na = pa[i] || 0;
-    const nb = pb[i] || 0;
+    const na = pa.nums[i] || 0;
+    const nb = pb.nums[i] || 0;
     if (na < nb) return -1;
     if (na > nb) return 1;
   }
+  // Equal core versions: no pre-release > pre-release (1.0.0 > 1.0.0-rc.1)
+  if (!pa.pre && pb.pre) return 1;
+  if (pa.pre && !pb.pre) return -1;
+  if (pa.pre && pb.pre) return pa.pre < pb.pre ? -1 : pa.pre > pb.pre ? 1 : 0;
   return 0;
 }
 

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -1,0 +1,227 @@
+import { spawn } from 'child_process';
+import { writeFile } from 'fs/promises';
+import { join } from 'path';
+import { EventEmitter } from 'events';
+import { readJSONFile, PATHS, ensureDir } from '../lib/fileUtils.js';
+import { createMutex } from '../lib/asyncMutex.js';
+
+const UPDATE_FILE = join(PATHS.data, 'update.json');
+const CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+const STARTUP_DELAY_MS = 10 * 1000; // 10 seconds
+
+export const updateEvents = new EventEmitter();
+
+const withLock = createMutex();
+
+let schedulerInterval = null;
+
+const defaultState = () => ({
+  lastCheck: null,
+  latestRelease: null,
+  ignoredVersions: [],
+  updateInProgress: false,
+  lastUpdateResult: null
+});
+
+function execGh(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('gh', args, { shell: false, windowsHide: true });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (d) => { stdout += d.toString(); });
+    child.stderr.on('data', (d) => { stderr += d.toString(); });
+    child.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error(stderr.trim() || `gh exited with code ${code}`));
+      } else {
+        resolve(stdout.trim());
+      }
+    });
+    child.on('error', (err) => reject(err));
+  });
+}
+
+/**
+ * Read the current version from the root package.json.
+ * Re-reads on each call so it picks up changes after updates.
+ */
+export async function getCurrentVersion() {
+  const pkgPath = join(PATHS.root, 'package.json');
+  const pkg = await readJSONFile(pkgPath, { version: '0.0.0' });
+  return pkg.version;
+}
+
+/**
+ * Compare two semver strings. Returns:
+ *  -1 if a < b, 0 if equal, 1 if a > b
+ */
+function compareSemver(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na < nb) return -1;
+    if (na > nb) return 1;
+  }
+  return 0;
+}
+
+async function loadState() {
+  await ensureDir(PATHS.data);
+  return readJSONFile(UPDATE_FILE, defaultState());
+}
+
+async function saveState(state) {
+  await ensureDir(PATHS.data);
+  await writeFile(UPDATE_FILE, JSON.stringify(state, null, 2) + '\n');
+}
+
+/**
+ * Check GitHub for the latest release and compare to current version.
+ */
+export async function checkForUpdate() {
+  return withLock(async () => {
+    const state = await loadState();
+    const currentVersion = await getCurrentVersion();
+
+    let release;
+    const raw = await execGh(['api', 'repos/atomantic/PortOS/releases/latest']);
+    const data = JSON.parse(raw);
+    release = {
+      version: data.tag_name?.replace(/^v/, '') || '0.0.0',
+      tag: data.tag_name || '',
+      url: data.html_url || '',
+      publishedAt: data.published_at || '',
+      body: data.body || ''
+    };
+
+    state.lastCheck = new Date().toISOString();
+    state.latestRelease = release;
+    await saveState(state);
+
+    const isNewer = compareSemver(release.version, currentVersion) > 0;
+    const isIgnored = state.ignoredVersions.includes(release.version);
+
+    updateEvents.emit('update:checked', {
+      currentVersion,
+      latestRelease: release,
+      updateAvailable: isNewer && !isIgnored
+    });
+
+    if (isNewer && !isIgnored) {
+      updateEvents.emit('update:available', {
+        currentVersion,
+        latestVersion: release.version,
+        latestRelease: release
+      });
+    }
+
+    return {
+      currentVersion,
+      latestRelease: release,
+      updateAvailable: isNewer && !isIgnored,
+      isIgnored
+    };
+  });
+}
+
+/**
+ * Get the current update status without checking GitHub.
+ */
+export async function getUpdateStatus() {
+  const state = await loadState();
+  const currentVersion = await getCurrentVersion();
+  const isNewer = state.latestRelease
+    ? compareSemver(state.latestRelease.version, currentVersion) > 0
+    : false;
+  const isIgnored = state.latestRelease
+    ? state.ignoredVersions.includes(state.latestRelease.version)
+    : false;
+
+  return {
+    currentVersion,
+    ...state,
+    updateAvailable: isNewer && !isIgnored
+  };
+}
+
+/**
+ * Add a version to the ignore list.
+ */
+export async function ignoreVersion(version) {
+  return withLock(async () => {
+    const state = await loadState();
+    if (!state.ignoredVersions.includes(version)) {
+      state.ignoredVersions.push(version);
+      await saveState(state);
+    }
+    return state;
+  });
+}
+
+/**
+ * Clear all ignored versions.
+ */
+export async function clearIgnored() {
+  return withLock(async () => {
+    const state = await loadState();
+    state.ignoredVersions = [];
+    await saveState(state);
+    return state;
+  });
+}
+
+/**
+ * Mark update as in progress or completed in state file.
+ */
+export async function setUpdateInProgress(inProgress) {
+  return withLock(async () => {
+    const state = await loadState();
+    state.updateInProgress = inProgress;
+    await saveState(state);
+  });
+}
+
+/**
+ * Record the result of an update attempt.
+ */
+export async function recordUpdateResult(result) {
+  return withLock(async () => {
+    const state = await loadState();
+    state.updateInProgress = false;
+    state.lastUpdateResult = result;
+    await saveState(state);
+  });
+}
+
+/**
+ * Start the periodic update checker.
+ */
+export function startUpdateScheduler() {
+  // Initial check after startup delay
+  setTimeout(() => {
+    checkForUpdate().catch(err => {
+      console.warn(`⚠️ Update check failed: ${err.message}`);
+    });
+  }, STARTUP_DELAY_MS);
+
+  // Periodic checks
+  schedulerInterval = setInterval(() => {
+    checkForUpdate().catch(err => {
+      console.warn(`⚠️ Update check failed: ${err.message}`);
+    });
+  }, CHECK_INTERVAL_MS);
+
+  console.log(`🔄 Update scheduler started (every ${CHECK_INTERVAL_MS / 60000}min)`);
+}
+
+/**
+ * Stop the periodic update checker.
+ */
+export function stopUpdateScheduler() {
+  if (schedulerInterval) {
+    clearInterval(schedulerInterval);
+    schedulerInterval = null;
+  }
+}

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -14,6 +14,7 @@ export const updateEvents = new EventEmitter();
 const withLock = createMutex();
 
 let schedulerInterval = null;
+let startupTimeout = null;
 
 const defaultState = () => ({
   lastCheck: null,
@@ -85,10 +86,10 @@ export async function checkForUpdate() {
     const state = await loadState();
     const currentVersion = await getCurrentVersion();
 
-    let release;
     const raw = await execGh(['api', 'repos/atomantic/PortOS/releases/latest']);
-    const data = JSON.parse(raw);
-    release = {
+    let data;
+    try { data = JSON.parse(raw); } catch { throw new Error(`Failed to parse GitHub release response: ${raw.slice(0, 200)}`); }
+    const release = {
       version: data.tag_name?.replace(/^v/, '') || '0.0.0',
       tag: data.tag_name || '',
       url: data.html_url || '',
@@ -200,7 +201,8 @@ export async function recordUpdateResult(result) {
  */
 export function startUpdateScheduler() {
   // Initial check after startup delay
-  setTimeout(() => {
+  startupTimeout = setTimeout(() => {
+    startupTimeout = null;
     checkForUpdate().catch(err => {
       console.warn(`⚠️ Update check failed: ${err.message}`);
     });
@@ -220,6 +222,10 @@ export function startUpdateScheduler() {
  * Stop the periodic update checker.
  */
 export function stopUpdateScheduler() {
+  if (startupTimeout) {
+    clearTimeout(startupTimeout);
+    startupTimeout = null;
+  }
   if (schedulerInterval) {
     clearInterval(schedulerInterval);
     schedulerInterval = null;

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -1,9 +1,9 @@
-import { spawn } from 'child_process';
 import { writeFile } from 'fs/promises';
 import { join } from 'path';
 import { EventEmitter } from 'events';
 import { readJSONFile, PATHS, ensureDir } from '../lib/fileUtils.js';
 import { createMutex } from '../lib/asyncMutex.js';
+import { execGh } from './github.js';
 
 const UPDATE_FILE = join(PATHS.data, 'update.json');
 const CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
@@ -24,24 +24,6 @@ const defaultState = () => ({
   lastUpdateResult: null
 });
 
-function execGh(args) {
-  return new Promise((resolve, reject) => {
-    const child = spawn('gh', args, { shell: false, windowsHide: true });
-    let stdout = '';
-    let stderr = '';
-    child.stdout.on('data', (d) => { stdout += d.toString(); });
-    child.stderr.on('data', (d) => { stderr += d.toString(); });
-    child.on('close', (code) => {
-      if (code !== 0) {
-        reject(new Error(stderr.trim() || `gh exited with code ${code}`));
-      } else {
-        resolve(stdout.trim());
-      }
-    });
-    child.on('error', (err) => reject(err));
-  });
-}
-
 /**
  * Read the current version from the root package.json.
  * Re-reads on each call so it picks up changes after updates.
@@ -56,7 +38,7 @@ export async function getCurrentVersion() {
  * Compare two semver strings. Returns:
  *  -1 if a < b, 0 if equal, 1 if a > b
  */
-function compareSemver(a, b) {
+export function compareSemver(a, b) {
   const pa = a.split('.').map(Number);
   const pb = b.split('.').map(Number);
   for (let i = 0; i < 3; i++) {

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -1,4 +1,4 @@
-import { writeFile } from 'fs/promises';
+import { writeFile, rename } from 'fs/promises';
 import { join } from 'path';
 import { EventEmitter } from 'events';
 import { readJSONFile, PATHS, ensureDir } from '../lib/fileUtils.js';
@@ -59,7 +59,9 @@ async function loadState() {
 
 async function saveState(state) {
   await ensureDir(PATHS.data);
-  await writeFile(UPDATE_FILE, JSON.stringify(state, null, 2) + '\n');
+  const tmpFile = `${UPDATE_FILE}.tmp`;
+  await writeFile(tmpFile, JSON.stringify(state, null, 2) + '\n');
+  await rename(tmpFile, UPDATE_FILE);
 }
 
 /**

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -21,6 +21,7 @@ const defaultState = () => ({
   latestRelease: null,
   ignoredVersions: [],
   updateInProgress: false,
+  updateStartedAt: null,
   lastUpdateResult: null
 });
 

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -164,6 +164,7 @@ export async function setUpdateInProgress(inProgress) {
   return withLock(async () => {
     const state = await loadState();
     state.updateInProgress = inProgress;
+    state.updateStartedAt = inProgress ? new Date().toISOString() : null;
     await saveState(state);
   });
 }
@@ -175,8 +176,44 @@ export async function recordUpdateResult(result) {
   return withLock(async () => {
     const state = await loadState();
     state.updateInProgress = false;
+    state.updateStartedAt = null;
     state.lastUpdateResult = result;
     await saveState(state);
+  });
+}
+
+const STALE_UPDATE_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Clear stale updateInProgress flag on boot.
+ * If the server was killed mid-update (before recordUpdateResult ran),
+ * updateInProgress stays true and blocks future updates indefinitely.
+ * This detects that condition via updateStartedAt age and clears it.
+ */
+export async function clearStaleUpdateInProgress() {
+  return withLock(async () => {
+    const state = await loadState();
+    if (!state.updateInProgress) return false;
+
+    const startedAt = state.updateStartedAt ? new Date(state.updateStartedAt).getTime() : 0;
+    const ageMs = Date.now() - startedAt;
+
+    // If no timestamp or older than timeout, treat as stale
+    if (!state.updateStartedAt || ageMs > STALE_UPDATE_TIMEOUT_MS) {
+      console.log(`🧹 Clearing stale updateInProgress (started ${state.updateStartedAt ?? 'unknown'}, age ${Math.round(ageMs / 60000)}min)`);
+      state.updateInProgress = false;
+      state.updateStartedAt = null;
+      state.lastUpdateResult = {
+        version: state.latestRelease?.version ?? 'unknown',
+        success: false,
+        completedAt: new Date().toISOString(),
+        log: 'Cleared stale update lock on boot — server was likely killed mid-update'
+      };
+      await saveState(state);
+      return true;
+    }
+
+    return false;
   });
 }
 

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -45,6 +45,30 @@ export function compareSemver(a, b) {
     const [core, pre] = v.split('+')[0].split('-', 2);
     return { nums: core.split('.').map(Number), pre: pre || null };
   };
+  const comparePreRelease = (preA, preB) => {
+    const segsA = preA.split('.');
+    const segsB = preB.split('.');
+    const len = Math.max(segsA.length, segsB.length);
+    for (let i = 0; i < len; i++) {
+      if (i >= segsA.length) return -1; // fewer segments = lower precedence
+      if (i >= segsB.length) return 1;
+      const numA = /^\d+$/.test(segsA[i]) ? Number(segsA[i]) : null;
+      const numB = /^\d+$/.test(segsB[i]) ? Number(segsB[i]) : null;
+      // Numeric identifiers sort before string identifiers
+      if (numA !== null && numB !== null) {
+        if (numA < numB) return -1;
+        if (numA > numB) return 1;
+      } else if (numA !== null) {
+        return -1;
+      } else if (numB !== null) {
+        return 1;
+      } else {
+        if (segsA[i] < segsB[i]) return -1;
+        if (segsA[i] > segsB[i]) return 1;
+      }
+    }
+    return 0;
+  };
   const pa = extractParts(a);
   const pb = extractParts(b);
   for (let i = 0; i < 3; i++) {
@@ -56,7 +80,7 @@ export function compareSemver(a, b) {
   // Equal core versions: no pre-release > pre-release (1.0.0 > 1.0.0-rc.1)
   if (!pa.pre && pb.pre) return 1;
   if (pa.pre && !pb.pre) return -1;
-  if (pa.pre && pb.pre) return pa.pre < pb.pre ? -1 : pa.pre > pb.pre ? 1 : 0;
+  if (pa.pre && pb.pre) return comparePreRelease(pa.pre, pb.pre);
   return 0;
 }
 

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -126,11 +126,15 @@ export async function checkForUpdate() {
 export async function getUpdateStatus() {
   const state = await loadState();
   const currentVersion = await getCurrentVersion();
-  const isNewer = state.latestRelease
-    ? compareSemver(state.latestRelease.version, currentVersion) > 0
+  const latestVersion =
+    state.latestRelease && typeof state.latestRelease.version === 'string'
+      ? state.latestRelease.version
+      : null;
+  const isNewer = latestVersion
+    ? compareSemver(latestVersion, currentVersion) > 0
     : false;
-  const isIgnored = state.latestRelease
-    ? state.ignoredVersions.includes(state.latestRelease.version)
+  const isIgnored = latestVersion
+    ? state.ignoredVersions.includes(latestVersion)
     : false;
 
   return {

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -31,7 +31,8 @@ const defaultState = () => ({
 export async function getCurrentVersion() {
   const pkgPath = join(PATHS.root, 'package.json');
   const pkg = await readJSONFile(pkgPath, { version: '0.0.0' });
-  return pkg.version;
+  const version = (typeof pkg.version === 'string' && pkg.version) ? pkg.version : '0.0.0';
+  return version;
 }
 
 /**
@@ -182,6 +183,8 @@ export async function recordUpdateResult(result) {
  * Start the periodic update checker.
  */
 export function startUpdateScheduler() {
+  if (startupTimeout || schedulerInterval) return;
+
   // Initial check after startup delay
   startupTimeout = setTimeout(() => {
     startupTimeout = null;

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -40,8 +40,9 @@ export async function getCurrentVersion() {
  *  -1 if a < b, 0 if equal, 1 if a > b
  */
 export function compareSemver(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
+  // Strip pre-release/build metadata (e.g. "1.2.3-rc.1+build" → "1.2.3")
+  const pa = a.replace(/[-+].*$/, '').split('.').map(Number);
+  const pb = b.replace(/[-+].*$/, '').split('.').map(Number);
   for (let i = 0; i < 3; i++) {
     const na = pa[i] || 0;
     const nb = pb[i] || 0;

--- a/server/services/updateChecker.js
+++ b/server/services/updateChecker.js
@@ -86,13 +86,14 @@ export function compareSemver(a, b) {
 
 async function loadState() {
   await ensureDir(PATHS.data);
-  const raw = await readJSONFile(UPDATE_FILE, defaultState());
+  const raw = await readJSONFile(UPDATE_FILE, defaultState(), { allowArray: false });
   const defaults = defaultState();
+  const stateFromFile = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw : {};
   return {
     ...defaults,
-    ...raw,
-    ignoredVersions: Array.isArray(raw.ignoredVersions) ? raw.ignoredVersions : defaults.ignoredVersions,
-    updateInProgress: typeof raw.updateInProgress === 'boolean' ? raw.updateInProgress : defaults.updateInProgress,
+    ...stateFromFile,
+    ignoredVersions: Array.isArray(stateFromFile.ignoredVersions) ? stateFromFile.ignoredVersions : defaults.ignoredVersions,
+    updateInProgress: typeof stateFromFile.updateInProgress === 'boolean' ? stateFromFile.updateInProgress : defaults.updateInProgress,
   };
 }
 

--- a/server/services/updateChecker.test.js
+++ b/server/services/updateChecker.test.js
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies before importing the module
 vi.mock('fs/promises', () => ({
-  writeFile: vi.fn().mockResolvedValue(undefined)
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined)
 }));
 
 vi.mock('../lib/fileUtils.js', () => ({

--- a/server/services/updateChecker.test.js
+++ b/server/services/updateChecker.test.js
@@ -32,6 +32,7 @@ import {
   ignoreVersion,
   clearIgnored,
   checkForUpdate,
+  clearStaleUpdateInProgress,
   updateEvents
 } from './updateChecker.js';
 
@@ -323,5 +324,83 @@ describe('checkForUpdate', () => {
 
     const result = await checkForUpdate();
     expect(result.latestRelease.version).toBe('2.0.0');
+  });
+});
+
+describe('clearStaleUpdateInProgress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeFile.mockResolvedValue(undefined);
+    ensureDir.mockResolvedValue(undefined);
+  });
+
+  it('should return false when updateInProgress is false', async () => {
+    readJSONFile.mockResolvedValue({
+      lastCheck: null,
+      latestRelease: null,
+      ignoredVersions: [],
+      updateInProgress: false,
+      updateStartedAt: null,
+      lastUpdateResult: null
+    });
+
+    const cleared = await clearStaleUpdateInProgress();
+    expect(cleared).toBe(false);
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+
+  it('should clear stale updateInProgress when updateStartedAt is older than 30 minutes', async () => {
+    const staleTime = new Date(Date.now() - 60 * 60 * 1000).toISOString(); // 1 hour ago
+    readJSONFile.mockResolvedValue({
+      lastCheck: null,
+      latestRelease: { version: '1.28.0' },
+      ignoredVersions: [],
+      updateInProgress: true,
+      updateStartedAt: staleTime,
+      lastUpdateResult: null
+    });
+
+    const cleared = await clearStaleUpdateInProgress();
+    expect(cleared).toBe(true);
+    expect(writeFile).toHaveBeenCalled();
+    const saved = JSON.parse(writeFile.mock.calls[0][1]);
+    expect(saved.updateInProgress).toBe(false);
+    expect(saved.updateStartedAt).toBeNull();
+    expect(saved.lastUpdateResult.success).toBe(false);
+    expect(saved.lastUpdateResult.version).toBe('1.28.0');
+  });
+
+  it('should clear updateInProgress when updateStartedAt is missing', async () => {
+    readJSONFile.mockResolvedValue({
+      lastCheck: null,
+      latestRelease: null,
+      ignoredVersions: [],
+      updateInProgress: true,
+      updateStartedAt: null,
+      lastUpdateResult: null
+    });
+
+    const cleared = await clearStaleUpdateInProgress();
+    expect(cleared).toBe(true);
+    expect(writeFile).toHaveBeenCalled();
+    const saved = JSON.parse(writeFile.mock.calls[0][1]);
+    expect(saved.updateInProgress).toBe(false);
+    expect(saved.lastUpdateResult.version).toBe('unknown');
+  });
+
+  it('should not clear updateInProgress when update is recent (< 30 min)', async () => {
+    const recentTime = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // 5 minutes ago
+    readJSONFile.mockResolvedValue({
+      lastCheck: null,
+      latestRelease: { version: '1.28.0' },
+      ignoredVersions: [],
+      updateInProgress: true,
+      updateStartedAt: recentTime,
+      lastUpdateResult: null
+    });
+
+    const cleared = await clearStaleUpdateInProgress();
+    expect(cleared).toBe(false);
+    expect(writeFile).not.toHaveBeenCalled();
   });
 });

--- a/server/services/updateChecker.test.js
+++ b/server/services/updateChecker.test.js
@@ -1,37 +1,39 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-// Inline copy of compareSemver for testing without importing private function
-function compareSemver(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    const na = pa[i] || 0;
-    const nb = pb[i] || 0;
-    if (na < nb) return -1;
-    if (na > nb) return 1;
-  }
-  return 0;
-}
-
 // Mock dependencies before importing the module
 vi.mock('fs/promises', () => ({
-  readFile: vi.fn(),
-  writeFile: vi.fn(),
-  mkdir: vi.fn()
+  writeFile: vi.fn().mockResolvedValue(undefined)
 }));
 
-vi.mock('child_process', () => ({
-  spawn: vi.fn()
+vi.mock('../lib/fileUtils.js', () => ({
+  readJSONFile: vi.fn(),
+  PATHS: {
+    root: '/mock',
+    data: '/mock/data'
+  },
+  ensureDir: vi.fn().mockResolvedValue(undefined)
 }));
 
-import { readFile, writeFile, mkdir } from 'fs/promises';
-import { spawn } from 'child_process';
+vi.mock('../lib/asyncMutex.js', () => ({
+  createMutex: () => (fn) => fn()
+}));
 
-// Mock the EventEmitter used internally
-vi.mock('events', async () => {
-  const actual = await vi.importActual('events');
-  return actual;
-});
+vi.mock('./github.js', () => ({
+  execGh: vi.fn()
+}));
+
+import { writeFile } from 'fs/promises';
+import { readJSONFile, ensureDir } from '../lib/fileUtils.js';
+import { execGh } from './github.js';
+import {
+  compareSemver,
+  getCurrentVersion,
+  getUpdateStatus,
+  ignoreVersion,
+  clearIgnored,
+  checkForUpdate,
+  updateEvents
+} from './updateChecker.js';
 
 describe('compareSemver', () => {
   it('should return 0 for equal versions', () => {
@@ -59,93 +61,267 @@ describe('compareSemver', () => {
   });
 });
 
-describe('updateChecker integration', () => {
-  const defaultState = {
-    lastCheck: null,
-    latestRelease: null,
-    ignoredVersions: [],
-    updateInProgress: false,
-    lastUpdateResult: null
-  };
-
+describe('getCurrentVersion', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mkdir.mockResolvedValue(undefined);
-    writeFile.mockResolvedValue(undefined);
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
+  it('should read version from root package.json', async () => {
+    readJSONFile.mockResolvedValue({ version: '1.26.0' });
+    const version = await getCurrentVersion();
+    expect(version).toBe('1.26.0');
+    expect(readJSONFile).toHaveBeenCalledWith('/mock/package.json', { version: '0.0.0' });
+  });
+
+  it('should fall back to 0.0.0 when package.json missing', async () => {
+    readJSONFile.mockResolvedValue({ version: '0.0.0' });
+    const version = await getCurrentVersion();
+    expect(version).toBe('0.0.0');
+  });
+});
+
+describe('getUpdateStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should report no update when latestRelease is null', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: null,
+        latestRelease: null,
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
+
+    const status = await getUpdateStatus();
+    expect(status.updateAvailable).toBe(false);
+    expect(status.currentVersion).toBe('1.26.0');
   });
 
   it('should detect update available when remote version is newer', async () => {
-    // This tests the logic flow: if latestRelease.version > currentVersion and not ignored
-    const currentVersion = '1.26.0';
-    const latestVersion = '1.27.0';
-    const isNewer = compareSemver(latestVersion, currentVersion) > 0;
-    const ignoredVersions = [];
-    const isIgnored = ignoredVersions.includes(latestVersion);
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: '2024-01-01T00:00:00Z',
+        latestRelease: { version: '1.27.0' },
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
 
-    expect(isNewer).toBe(true);
-    expect(isIgnored).toBe(false);
-    expect(isNewer && !isIgnored).toBe(true);
+    const status = await getUpdateStatus();
+    expect(status.updateAvailable).toBe(true);
   });
 
-  it('should not detect update when versions are equal', () => {
-    const currentVersion = '1.26.0';
-    const latestVersion = '1.26.0';
-    const isNewer = compareSemver(latestVersion, currentVersion) > 0;
+  it('should not detect update when versions are equal', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: '2024-01-01T00:00:00Z',
+        latestRelease: { version: '1.26.0' },
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
 
-    expect(isNewer).toBe(false);
+    const status = await getUpdateStatus();
+    expect(status.updateAvailable).toBe(false);
   });
 
-  it('should respect ignored versions', () => {
-    const currentVersion = '1.26.0';
-    const latestVersion = '1.27.0';
-    const ignoredVersions = ['1.27.0'];
-    const isNewer = compareSemver(latestVersion, currentVersion) > 0;
-    const isIgnored = ignoredVersions.includes(latestVersion);
+  it('should respect ignored versions', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: '2024-01-01T00:00:00Z',
+        latestRelease: { version: '1.27.0' },
+        ignoredVersions: ['1.27.0'],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
 
-    expect(isNewer).toBe(true);
-    expect(isIgnored).toBe(true);
-    expect(isNewer && !isIgnored).toBe(false);
+    const status = await getUpdateStatus();
+    expect(status.updateAvailable).toBe(false);
   });
 
-  it('should handle downgrade (remote older than current)', () => {
-    const currentVersion = '1.27.0';
-    const latestVersion = '1.26.0';
-    const isNewer = compareSemver(latestVersion, currentVersion) > 0;
+  it('should handle downgrade (remote older than current)', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: '2024-01-01T00:00:00Z',
+        latestRelease: { version: '1.26.0' },
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.27.0' });
 
-    expect(isNewer).toBe(false);
+    const status = await getUpdateStatus();
+    expect(status.updateAvailable).toBe(false);
+  });
+});
+
+describe('ignoreVersion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeFile.mockResolvedValue(undefined);
+    ensureDir.mockResolvedValue(undefined);
   });
 
-  it('should correctly add version to ignore list', () => {
-    const state = { ...defaultState, ignoredVersions: [] };
-    const version = '1.27.0';
+  it('should add version to ignore list', async () => {
+    readJSONFile.mockResolvedValue({
+      lastCheck: null,
+      latestRelease: null,
+      ignoredVersions: [],
+      updateInProgress: false,
+      lastUpdateResult: null
+    });
 
-    if (!state.ignoredVersions.includes(version)) {
-      state.ignoredVersions.push(version);
-    }
-
+    const state = await ignoreVersion('1.27.0');
     expect(state.ignoredVersions).toContain('1.27.0');
-    expect(state.ignoredVersions).toHaveLength(1);
+    expect(writeFile).toHaveBeenCalled();
   });
 
-  it('should not duplicate ignored versions', () => {
-    const state = { ...defaultState, ignoredVersions: ['1.27.0'] };
-    const version = '1.27.0';
+  it('should not duplicate ignored versions', async () => {
+    readJSONFile.mockResolvedValue({
+      lastCheck: null,
+      latestRelease: null,
+      ignoredVersions: ['1.27.0'],
+      updateInProgress: false,
+      lastUpdateResult: null
+    });
 
-    if (!state.ignoredVersions.includes(version)) {
-      state.ignoredVersions.push(version);
-    }
-
+    const state = await ignoreVersion('1.27.0');
     expect(state.ignoredVersions).toHaveLength(1);
+    expect(writeFile).not.toHaveBeenCalled();
+  });
+});
+
+describe('clearIgnored', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeFile.mockResolvedValue(undefined);
+    ensureDir.mockResolvedValue(undefined);
   });
 
-  it('should clear all ignored versions', () => {
-    const state = { ...defaultState, ignoredVersions: ['1.27.0', '1.28.0'] };
-    state.ignoredVersions = [];
+  it('should clear all ignored versions', async () => {
+    readJSONFile.mockResolvedValue({
+      lastCheck: null,
+      latestRelease: null,
+      ignoredVersions: ['1.27.0', '1.28.0'],
+      updateInProgress: false,
+      lastUpdateResult: null
+    });
 
+    const state = await clearIgnored();
     expect(state.ignoredVersions).toHaveLength(0);
+    expect(writeFile).toHaveBeenCalled();
+  });
+});
+
+describe('checkForUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    writeFile.mockResolvedValue(undefined);
+    ensureDir.mockResolvedValue(undefined);
+  });
+
+  it('should detect update when remote version is newer', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: null,
+        latestRelease: null,
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
+
+    execGh.mockResolvedValue(JSON.stringify({
+      tag_name: 'v1.27.0',
+      html_url: 'https://github.com/atomantic/PortOS/releases/tag/v1.27.0',
+      published_at: '2024-01-15T00:00:00Z',
+      body: 'Release notes'
+    }));
+
+    const result = await checkForUpdate();
+    expect(result.updateAvailable).toBe(true);
+    expect(result.currentVersion).toBe('1.26.0');
+    expect(result.latestRelease.version).toBe('1.27.0');
+  });
+
+  it('should not detect update when versions match', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: null,
+        latestRelease: null,
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.27.0' });
+
+    execGh.mockResolvedValue(JSON.stringify({
+      tag_name: 'v1.27.0',
+      html_url: 'https://github.com/atomantic/PortOS/releases/tag/v1.27.0',
+      published_at: '2024-01-15T00:00:00Z',
+      body: 'Release notes'
+    }));
+
+    const result = await checkForUpdate();
+    expect(result.updateAvailable).toBe(false);
+  });
+
+  it('should emit update:available event when newer version found', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: null,
+        latestRelease: null,
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
+
+    execGh.mockResolvedValue(JSON.stringify({
+      tag_name: 'v1.27.0',
+      html_url: 'https://github.com/atomantic/PortOS/releases/tag/v1.27.0',
+      published_at: '2024-01-15T00:00:00Z',
+      body: 'Release notes'
+    }));
+
+    const handler = vi.fn();
+    updateEvents.on('update:available', handler);
+
+    await checkForUpdate();
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({
+      currentVersion: '1.26.0',
+      latestVersion: '1.27.0'
+    }));
+
+    updateEvents.removeListener('update:available', handler);
+  });
+
+  it('should strip v prefix from tag_name', async () => {
+    readJSONFile
+      .mockResolvedValueOnce({
+        lastCheck: null,
+        latestRelease: null,
+        ignoredVersions: [],
+        updateInProgress: false,
+        lastUpdateResult: null
+      })
+      .mockResolvedValueOnce({ version: '1.26.0' });
+
+    execGh.mockResolvedValue(JSON.stringify({
+      tag_name: 'v2.0.0',
+      html_url: '',
+      published_at: '',
+      body: ''
+    }));
+
+    const result = await checkForUpdate();
+    expect(result.latestRelease.version).toBe('2.0.0');
   });
 });

--- a/server/services/updateChecker.test.js
+++ b/server/services/updateChecker.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Inline copy of compareSemver for testing without importing private function
+function compareSemver(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    const na = pa[i] || 0;
+    const nb = pb[i] || 0;
+    if (na < nb) return -1;
+    if (na > nb) return 1;
+  }
+  return 0;
+}
+
+// Mock dependencies before importing the module
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn()
+}));
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn()
+}));
+
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import { spawn } from 'child_process';
+
+// Mock the EventEmitter used internally
+vi.mock('events', async () => {
+  const actual = await vi.importActual('events');
+  return actual;
+});
+
+describe('compareSemver', () => {
+  it('should return 0 for equal versions', () => {
+    expect(compareSemver('1.0.0', '1.0.0')).toBe(0);
+    expect(compareSemver('1.26.0', '1.26.0')).toBe(0);
+  });
+
+  it('should return -1 when a < b', () => {
+    expect(compareSemver('1.0.0', '1.0.1')).toBe(-1);
+    expect(compareSemver('1.0.0', '1.1.0')).toBe(-1);
+    expect(compareSemver('1.0.0', '2.0.0')).toBe(-1);
+    expect(compareSemver('1.25.0', '1.26.0')).toBe(-1);
+  });
+
+  it('should return 1 when a > b', () => {
+    expect(compareSemver('1.0.1', '1.0.0')).toBe(1);
+    expect(compareSemver('1.1.0', '1.0.0')).toBe(1);
+    expect(compareSemver('2.0.0', '1.0.0')).toBe(1);
+    expect(compareSemver('1.27.0', '1.26.0')).toBe(1);
+  });
+
+  it('should handle missing minor/patch', () => {
+    expect(compareSemver('1', '1.0.0')).toBe(0);
+    expect(compareSemver('1.1', '1.1.0')).toBe(0);
+  });
+});
+
+describe('updateChecker integration', () => {
+  const defaultState = {
+    lastCheck: null,
+    latestRelease: null,
+    ignoredVersions: [],
+    updateInProgress: false,
+    lastUpdateResult: null
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mkdir.mockResolvedValue(undefined);
+    writeFile.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should detect update available when remote version is newer', async () => {
+    // This tests the logic flow: if latestRelease.version > currentVersion and not ignored
+    const currentVersion = '1.26.0';
+    const latestVersion = '1.27.0';
+    const isNewer = compareSemver(latestVersion, currentVersion) > 0;
+    const ignoredVersions = [];
+    const isIgnored = ignoredVersions.includes(latestVersion);
+
+    expect(isNewer).toBe(true);
+    expect(isIgnored).toBe(false);
+    expect(isNewer && !isIgnored).toBe(true);
+  });
+
+  it('should not detect update when versions are equal', () => {
+    const currentVersion = '1.26.0';
+    const latestVersion = '1.26.0';
+    const isNewer = compareSemver(latestVersion, currentVersion) > 0;
+
+    expect(isNewer).toBe(false);
+  });
+
+  it('should respect ignored versions', () => {
+    const currentVersion = '1.26.0';
+    const latestVersion = '1.27.0';
+    const ignoredVersions = ['1.27.0'];
+    const isNewer = compareSemver(latestVersion, currentVersion) > 0;
+    const isIgnored = ignoredVersions.includes(latestVersion);
+
+    expect(isNewer).toBe(true);
+    expect(isIgnored).toBe(true);
+    expect(isNewer && !isIgnored).toBe(false);
+  });
+
+  it('should handle downgrade (remote older than current)', () => {
+    const currentVersion = '1.27.0';
+    const latestVersion = '1.26.0';
+    const isNewer = compareSemver(latestVersion, currentVersion) > 0;
+
+    expect(isNewer).toBe(false);
+  });
+
+  it('should correctly add version to ignore list', () => {
+    const state = { ...defaultState, ignoredVersions: [] };
+    const version = '1.27.0';
+
+    if (!state.ignoredVersions.includes(version)) {
+      state.ignoredVersions.push(version);
+    }
+
+    expect(state.ignoredVersions).toContain('1.27.0');
+    expect(state.ignoredVersions).toHaveLength(1);
+  });
+
+  it('should not duplicate ignored versions', () => {
+    const state = { ...defaultState, ignoredVersions: ['1.27.0'] };
+    const version = '1.27.0';
+
+    if (!state.ignoredVersions.includes(version)) {
+      state.ignoredVersions.push(version);
+    }
+
+    expect(state.ignoredVersions).toHaveLength(1);
+  });
+
+  it('should clear all ignored versions', () => {
+    const state = { ...defaultState, ignoredVersions: ['1.27.0', '1.28.0'] };
+    state.ignoredVersions = [];
+
+    expect(state.ignoredVersions).toHaveLength(0);
+  });
+});

--- a/server/services/updateChecker.test.js
+++ b/server/services/updateChecker.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Mock dependencies before importing the module
 vi.mock('fs/promises', () => ({

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -55,11 +55,11 @@ export async function executeUpdate(tag, emit) {
     // Pipe stdout/stderr for progress tracking, with EPIPE guards
     // in case the parent process exits before the detached child finishes writing
     if (child.stdout) {
-      child.stdout.on('error', () => {}); // Swallow EPIPE if parent exits
+      child.stdout.on('error', (err) => { if (err.code !== 'EPIPE') console.error(`⚠️ stdout stream error: ${err.message}`); });
       child.stdout.on('data', makeLineHandler());
     }
     if (child.stderr) {
-      child.stderr.on('error', () => {}); // Swallow EPIPE if parent exits
+      child.stderr.on('error', (err) => { if (err.code !== 'EPIPE') console.error(`⚠️ stderr stream error: ${err.message}`); });
       child.stderr.on('data', makeLineHandler());
     }
 

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -54,35 +54,29 @@ export async function executeUpdate(tag, emit) {
       }
     });
 
-    child.on('close', async (code) => {
-      if (code === 0) {
-        await recordUpdateResult({
-          version: tag.replace(/^v/, ''),
-          success: true,
-          completedAt: new Date().toISOString(),
-          log: ''
-        });
+    child.on('close', (code) => {
+      const success = code === 0;
+      recordUpdateResult({
+        version: tag.replace(/^v/, ''),
+        success,
+        completedAt: new Date().toISOString(),
+        log: success ? '' : `Process exited with code ${code}`
+      }).catch(e => console.error(`❌ Failed to record update result: ${e.message}`));
+      if (success) {
         emit('complete', 'done', `Update to ${tag} complete`);
-        resolve({ success: true });
       } else {
-        await recordUpdateResult({
-          version: tag.replace(/^v/, ''),
-          success: false,
-          completedAt: new Date().toISOString(),
-          log: `Process exited with code ${code}`
-        });
         emit(lastStep, 'error', `Update failed at step "${lastStep}" (exit code ${code})`);
-        resolve({ success: false });
       }
+      resolve({ success });
     });
 
-    child.on('error', async (err) => {
-      await recordUpdateResult({
+    child.on('error', (err) => {
+      recordUpdateResult({
         version: tag.replace(/^v/, ''),
         success: false,
         completedAt: new Date().toISOString(),
         log: err.message
-      });
+      }).catch(e => console.error(`❌ Failed to record update result: ${e.message}`));
       emit('starting', 'error', `Failed to start update: ${err.message}`);
       resolve({ success: false });
     });

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -14,45 +14,23 @@ const SCRIPT_PATH = join(PATHS.root, 'scripts', 'portos-update.sh');
  * @returns {Promise<{success: boolean}>}
  */
 export async function executeUpdate(tag, emit) {
+  if (process.platform === 'win32') {
+    const msg = 'Auto-update execution is not supported on Windows — the update script requires bash';
+    emit('starting', 'error', msg);
+    return { success: false, error: msg };
+  }
+
   await setUpdateInProgress(true);
   emit('starting', 'running', `Starting update to ${tag}...`);
 
   return new Promise((resolve) => {
     const child = spawn('bash', [SCRIPT_PATH, tag], {
       detached: true,
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: 'ignore',
       cwd: PATHS.root
     });
 
     let lastStep = 'starting';
-
-    child.stdout.on('data', (data) => {
-      const lines = data.toString().split('\n');
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-
-        // Parse structured STEP markers: STEP:name:status:message
-        const match = trimmed.match(/^STEP:([^:]+):([^:]+):(.*)$/);
-        if (match) {
-          const [, step, status, message] = match;
-          lastStep = step;
-          emit(step, status, message);
-
-          // When the script signals it's about to restart, notify client
-          if (step === 'restart' && status === 'running') {
-            emit('restarting', 'running', `Restarting PortOS with ${tag}...`);
-          }
-        }
-      }
-    });
-
-    child.stderr.on('data', (data) => {
-      const msg = data.toString().trim();
-      if (msg) {
-        console.error(`📦 Update stderr: ${msg}`);
-      }
-    });
 
     child.on('close', (code) => {
       const success = code === 0;

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -63,9 +63,9 @@ export async function executeUpdate(tag, emit) {
       child.stderr.on('data', makeLineHandler());
     }
 
-    child.on('close', (code) => {
+    child.on('close', async (code) => {
       const success = code === 0;
-      recordUpdateResult({
+      await recordUpdateResult({
         version: tag.replace(/^v/, ''),
         success,
         completedAt: new Date().toISOString(),
@@ -82,8 +82,8 @@ export async function executeUpdate(tag, emit) {
       );
     });
 
-    child.on('error', (err) => {
-      recordUpdateResult({
+    child.on('error', async (err) => {
+      await recordUpdateResult({
         version: tag.replace(/^v/, ''),
         success: false,
         completedAt: new Date().toISOString(),

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -11,13 +11,13 @@ const SCRIPT_PATH = join(PATHS.root, 'scripts', 'portos-update.sh');
  *
  * @param {string} tag - The git tag to update to (e.g. "v1.27.0")
  * @param {function} emit - Callback (step, status, message) for progress
- * @returns {Promise<{success: boolean}>}
+ * @returns {Promise<{success: boolean, failedStep?: string, errorMessage?: string}>}
  */
 export async function executeUpdate(tag, emit) {
   if (process.platform === 'win32') {
     const msg = 'Auto-update execution is not supported on Windows — the update script requires bash';
     emit('starting', 'error', msg);
-    return { success: false, error: msg };
+    return { success: false, failedStep: 'starting', errorMessage: msg };
   }
 
   // The route sets updateInProgress synchronously before calling us,
@@ -76,7 +76,10 @@ export async function executeUpdate(tag, emit) {
       } else {
         emit(lastStep, 'error', `Update failed at step "${lastStep}" (exit code ${code})`);
       }
-      resolve({ success });
+      resolve(success
+        ? { success: true }
+        : { success: false, failedStep: lastStep, errorMessage: `Update failed at step "${lastStep}" (exit code ${code})` }
+      );
     });
 
     child.on('error', (err) => {
@@ -86,8 +89,9 @@ export async function executeUpdate(tag, emit) {
         completedAt: new Date().toISOString(),
         log: err.message
       }).catch(e => console.error(`❌ Failed to record update result: ${e.message}`));
-      emit('starting', 'error', `Failed to start update: ${err.message}`);
-      resolve({ success: false });
+      const errorMessage = `Failed to start update: ${err.message}`;
+      emit('starting', 'error', errorMessage);
+      resolve({ success: false, failedStep: 'starting', errorMessage });
     });
 
     // Unref so the parent process doesn't wait for the detached child

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -1,0 +1,93 @@
+import { spawn } from 'child_process';
+import { join } from 'path';
+import { PATHS } from '../lib/fileUtils.js';
+import { setUpdateInProgress, recordUpdateResult } from './updateChecker.js';
+
+const SCRIPT_PATH = join(PATHS.root, 'scripts', 'portos-update.sh');
+
+/**
+ * Execute the PortOS update script for a given release tag.
+ * Spawns the script detached so it survives the Node process dying.
+ *
+ * @param {string} tag - The git tag to update to (e.g. "v1.27.0")
+ * @param {function} emit - Callback (step, status, message) for progress
+ * @returns {Promise<{success: boolean}>}
+ */
+export async function executeUpdate(tag, emit) {
+  await setUpdateInProgress(true);
+  emit('starting', 'running', `Starting update to ${tag}...`);
+
+  return new Promise((resolve) => {
+    const child = spawn('bash', [SCRIPT_PATH, tag], {
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      cwd: PATHS.root
+    });
+
+    let lastStep = 'starting';
+
+    child.stdout.on('data', (data) => {
+      const lines = data.toString().split('\n');
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+
+        // Parse structured STEP markers: STEP:name:status:message
+        const match = trimmed.match(/^STEP:([^:]+):([^:]+):(.*)$/);
+        if (match) {
+          const [, step, status, message] = match;
+          lastStep = step;
+          emit(step, status, message);
+
+          // When the script signals it's about to restart, notify client
+          if (step === 'restart' && status === 'running') {
+            emit('restarting', 'running', `Restarting PortOS with ${tag}...`);
+          }
+        }
+      }
+    });
+
+    child.stderr.on('data', (data) => {
+      const msg = data.toString().trim();
+      if (msg) {
+        console.error(`📦 Update stderr: ${msg}`);
+      }
+    });
+
+    child.on('close', async (code) => {
+      if (code === 0) {
+        await recordUpdateResult({
+          version: tag.replace(/^v/, ''),
+          success: true,
+          completedAt: new Date().toISOString(),
+          log: ''
+        });
+        emit('complete', 'done', `Update to ${tag} complete`);
+        resolve({ success: true });
+      } else {
+        await recordUpdateResult({
+          version: tag.replace(/^v/, ''),
+          success: false,
+          completedAt: new Date().toISOString(),
+          log: `Process exited with code ${code}`
+        });
+        emit(lastStep, 'error', `Update failed at step "${lastStep}" (exit code ${code})`);
+        resolve({ success: false });
+      }
+    });
+
+    child.on('error', async (err) => {
+      await recordUpdateResult({
+        version: tag.replace(/^v/, ''),
+        success: false,
+        completedAt: new Date().toISOString(),
+        log: err.message
+      });
+      emit('starting', 'error', `Failed to start update: ${err.message}`);
+      resolve({ success: false });
+    });
+
+    // Unref so the parent process doesn't wait for the detached child
+    child.unref();
+  });
+}

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -26,11 +26,41 @@ export async function executeUpdate(tag, emit) {
   return new Promise((resolve) => {
     const child = spawn('bash', [SCRIPT_PATH, tag], {
       detached: true,
-      stdio: 'ignore',
+      stdio: ['ignore', 'pipe', 'pipe'],
       cwd: PATHS.root
     });
 
     let lastStep = 'starting';
+
+    // Parse STEP:name:status:message lines from stdout/stderr streams
+    const makeLineHandler = () => {
+      let buffer = '';
+      return (data) => {
+        buffer += data.toString();
+        let newlineIdx;
+        while ((newlineIdx = buffer.indexOf('\n')) !== -1) {
+          const line = buffer.slice(0, newlineIdx);
+          buffer = buffer.slice(newlineIdx + 1);
+          const match = line.match(/STEP:([^:]+):([^:]+):(.+)/);
+          if (match) {
+            const [, name, status, message] = match;
+            lastStep = name;
+            emit(name, status, message);
+          }
+        }
+      };
+    };
+
+    // Pipe stdout/stderr for progress tracking, with EPIPE guards
+    // in case the parent process exits before the detached child finishes writing
+    if (child.stdout) {
+      child.stdout.on('error', () => {}); // Swallow EPIPE if parent exits
+      child.stdout.on('data', makeLineHandler());
+    }
+    if (child.stderr) {
+      child.stderr.on('error', () => {}); // Swallow EPIPE if parent exits
+      child.stderr.on('data', makeLineHandler());
+    }
 
     child.on('close', (code) => {
       const success = code === 0;

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -1,7 +1,7 @@
 import { spawn } from 'child_process';
 import { join } from 'path';
 import { PATHS } from '../lib/fileUtils.js';
-import { setUpdateInProgress, recordUpdateResult } from './updateChecker.js';
+import { recordUpdateResult } from './updateChecker.js';
 
 const SCRIPT_PATH = join(PATHS.root, 'scripts', 'portos-update.sh');
 
@@ -20,7 +20,8 @@ export async function executeUpdate(tag, emit) {
     return { success: false, error: msg };
   }
 
-  await setUpdateInProgress(true);
+  // The route sets updateInProgress synchronously before calling us,
+  // so skip the redundant write here (it's already true)
   emit('starting', 'running', `Starting update to ${tag}...`);
 
   return new Promise((resolve) => {

--- a/server/services/updateExecutor.test.js
+++ b/server/services/updateExecutor.test.js
@@ -32,13 +32,18 @@ beforeEach(() => {
 
 describe('executeUpdate', () => {
   it('returns failure on Windows', async () => {
-    const origPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'win32' });
-    const emits = [];
-    const result = await executeUpdate('v1.0.0', (...args) => emits.push(args));
-    Object.defineProperty(process, 'platform', { value: origPlatform });
-    expect(result.success).toBe(false);
-    expect(emits[0][1]).toBe('error');
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    try {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      const emits = [];
+      const result = await executeUpdate('v1.0.0', (...args) => emits.push(args));
+      expect(result.success).toBe(false);
+      expect(emits[0][1]).toBe('error');
+    } finally {
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+      }
+    }
   });
 
   it('parses STEP markers from stdout', async () => {

--- a/server/services/updateExecutor.test.js
+++ b/server/services/updateExecutor.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('child_process', () => ({
+  spawn: vi.fn()
+}));
+
+vi.mock('../lib/fileUtils.js', () => ({
+  PATHS: { root: '/mock' }
+}));
+
+vi.mock('./updateChecker.js', () => ({
+  recordUpdateResult: vi.fn().mockResolvedValue(undefined)
+}));
+
+import { spawn } from 'child_process';
+import { recordUpdateResult } from './updateChecker.js';
+import { executeUpdate } from './updateExecutor.js';
+
+function createMockChild() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.unref = vi.fn();
+  child.pid = 12345;
+  return child;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('executeUpdate', () => {
+  it('returns failure on Windows', async () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    const emits = [];
+    const result = await executeUpdate('v1.0.0', (...args) => emits.push(args));
+    Object.defineProperty(process, 'platform', { value: origPlatform });
+    expect(result.success).toBe(false);
+    expect(emits[0][1]).toBe('error');
+  });
+
+  it('parses STEP markers from stdout', async () => {
+    const child = createMockChild();
+    spawn.mockReturnValue(child);
+
+    const emits = [];
+    const promise = executeUpdate('v1.0.0', (...args) => emits.push(args));
+
+    // Simulate STEP output
+    child.stdout.emit('data', Buffer.from('STEP:git-fetch:running:Fetching tags\n'));
+    child.stdout.emit('data', Buffer.from('STEP:git-fetch:done:Tags fetched\n'));
+
+    child.emit('close', 0);
+    const result = await promise;
+
+    expect(result.success).toBe(true);
+    // Should have starting + git-fetch running + git-fetch done = 3 step emits
+    expect(emits.some(e => e[0] === 'git-fetch' && e[1] === 'running')).toBe(true);
+    expect(emits.some(e => e[0] === 'git-fetch' && e[1] === 'done')).toBe(true);
+  });
+
+  it('records update result on close', async () => {
+    const child = createMockChild();
+    spawn.mockReturnValue(child);
+
+    const promise = executeUpdate('v1.0.0', () => {});
+    child.emit('close', 0);
+    await promise;
+
+    expect(recordUpdateResult).toHaveBeenCalledWith(
+      expect.objectContaining({ version: '1.0.0', success: true })
+    );
+  });
+
+  it('records failure on non-zero exit code', async () => {
+    const child = createMockChild();
+    spawn.mockReturnValue(child);
+
+    const promise = executeUpdate('v1.0.0', () => {});
+    child.emit('close', 1);
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(recordUpdateResult).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false })
+    );
+  });
+
+  it('handles spawn error', async () => {
+    const child = createMockChild();
+    spawn.mockReturnValue(child);
+
+    const emits = [];
+    const promise = executeUpdate('v1.0.0', (...args) => emits.push(args));
+    child.emit('error', new Error('spawn failed'));
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.failedStep).toBe('starting');
+    expect(recordUpdateResult).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, log: 'spawn failed' })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add automatic update checking against GitHub releases (every 30 min) with toast notification when updates are available
- Add interactive Update tab on PortOS app detail view with real-time progress streaming, version info, release notes, and post-restart auto-reload
- Fix health endpoint to read version dynamically from `package.json` instead of hardcoded `'0.1.0'`
- Add data migration framework (`scripts/run-migrations.js`) for safe schema evolution
- Display app version badge in OverviewTab details grid for all apps
- Add custom drink button management (add/edit/remove) for the Alcohol tracker with server-persisted buttons

## New Files

| File | Purpose |
|------|---------|
| `server/services/updateChecker.js` | Version check service, 30-min scheduler, semver comparison, ignore list, EventEmitter |
| `server/services/updateExecutor.js` | Spawns detached `portos-update.sh`, parses STEP markers for progress |
| `server/routes/update.js` | REST API: status, check, ignore, execute |
| `scripts/portos-update.sh` | Standalone update script: fetch/checkout/install/setup/migrate/build/restart |
| `scripts/run-migrations.js` | Data migration runner with `.applied.json` tracking |
| `client/src/hooks/useUpdateChecker.jsx` | Global toast hook for update availability |
| `client/src/components/apps/tabs/UpdateTab.jsx` | Full update UI with progress steps and polling |
| `server/services/updateChecker.test.js` | 11 unit tests for semver comparison and ignore logic |

## Key Design Decisions

- **Self-restart strategy**: Shell script runs detached and survives Node dying. Writes `data/update-complete.json` marker before PM2 restart. Server reads marker on boot to record success. Client polls `/api/system/health` version field until it matches expected new version.
- **Update tab** only shown for `portos-default` app (filtered via `PORTOS_APP_ID`)
- **Custom drink buttons**: Persisted to `data/meatspace/custom-drinks.json`, validated with Zod (oz 0.1-1000, abv 0-100), client mirrors server validation with toast feedback
- **Follows existing patterns**: `execGh` from github.js, step-based emit from appUpdater.js, socket subscriber sets, `readJSONFile`/mutex from lib/

## Test plan

- [x] Client builds successfully
- [x] All 45 test files pass (1309 tests)
- [ ] Manual: `POST /api/update/check` returns latest GitHub release
- [ ] Manual: Toast appears when update available
- [ ] Manual: Update tab at `/apps/portos-default/update` shows version info
- [ ] Manual: Full update flow streams progress and restarts