### PR TITLE
feat: drag-and-drop kanban board for JIRA sprint tickets

### DIFF
--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -153,26 +153,31 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId, onTic
       return;
     }
 
-    // Optimistic update
+    // Optimistic update — notify parent immediately so cache stays in sync
     const previousTickets = [...tickets];
-    setTickets(prev => prev.map(t =>
-      t.key === ticket.key ? { ...t, statusCategory: targetCategory } : t
-    ));
+    setTickets(prev => {
+      const optimistic = prev.map(t =>
+        t.key === ticket.key ? { ...t, statusCategory: targetCategory } : t
+      );
+      onTicketsChange?.(optimistic);
+      return optimistic;
+    });
     setTransitioning(ticket.key);
 
     try {
       // Fetch available transitions and find matching one
-      const transitions = await api.getTicketTransitions(instanceId, ticket.key, { silent: true });
+      const transitions = await api.getJiraTicketTransitions(instanceId, ticket.key, { silent: true });
       const match = transitions.find(t => t.toCategory === targetCategory);
 
       if (!match) {
-        // Rollback
+        // Rollback — sync parent cache
         setTickets(previousTickets);
+        onTicketsChange?.(previousTickets);
         toast.error(`No transition available to "${targetCategory}" for ${ticket.key}`);
         return;
       }
 
-      await api.transitionTicket(instanceId, ticket.key, match.id, { silent: true });
+      await api.transitionJiraTicket(instanceId, ticket.key, match.id, { silent: true });
       // Update the status name too, based on latest state
       setTickets(prev => {
         const updated = prev.map(t =>
@@ -184,11 +189,12 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId, onTic
       toast.success(`${ticket.key} moved to ${match.to}`);
     } catch (err) {
       setTickets(previousTickets);
+      onTicketsChange?.(previousTickets);
       toast.error(`Failed to transition ${ticket.key}: ${err.message}`);
     } finally {
       setTransitioning(null);
     }
-  }, [tickets, instanceId]);
+  }, [tickets, instanceId, onTicketsChange]);
 
   const handleDragCancel = useCallback(() => {
     setActiveTicket(null);

--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -159,7 +159,7 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId }) {
 
     try {
       // Fetch available transitions and find matching one
-      const transitions = await api.getTicketTransitions(instanceId, ticket.key);
+      const transitions = await api.getTicketTransitions(instanceId, ticket.key, { silent: true });
       const match = transitions.find(t => t.toCategory === targetCategory);
 
       if (!match) {
@@ -169,7 +169,7 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId }) {
         return;
       }
 
-      await api.transitionTicket(instanceId, ticket.key, match.id);
+      await api.transitionTicket(instanceId, ticket.key, match.id, { silent: true });
       // Update the status name too
       setTickets(prev => prev.map(t =>
         t.key === ticket.key ? { ...t, status: match.to, statusCategory: targetCategory } : t
@@ -183,12 +183,18 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId }) {
     }
   }, [tickets, instanceId]);
 
+  const handleDragCancel = useCallback(() => {
+    setActiveTicket(null);
+    setOverColumn(null);
+  }, []);
+
   return (
     <DndContext
       sensors={sensors}
       onDragStart={handleDragStart}
       onDragOver={handleDragOver}
       onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
     >
       <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
         {COLUMNS.map(category => (

--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { DndContext, DragOverlay, useDraggable, useDroppable, PointerSensor, KeyboardSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { DndContext, DragOverlay, useDraggable, useDroppable, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { GripVertical } from 'lucide-react';
 import toast from 'react-hot-toast';
 import * as api from '../services/api';
@@ -117,8 +117,7 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId, onTic
   useEffect(() => { setTickets(initialTickets); }, [initialTickets]);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(KeyboardSensor)
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
   );
 
   const columns = {};
@@ -174,12 +173,14 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId, onTic
       }
 
       await api.transitionTicket(instanceId, ticket.key, match.id, { silent: true });
-      // Update the status name too
-      const updated = tickets.map(t =>
-        t.key === ticket.key ? { ...t, status: match.to, statusCategory: targetCategory } : t
-      );
-      setTickets(updated);
-      onTicketsChange?.(updated);
+      // Update the status name too, based on latest state
+      setTickets(prev => {
+        const updated = prev.map(t =>
+          t.key === ticket.key ? { ...t, status: match.to, statusCategory: targetCategory } : t
+        );
+        onTicketsChange?.(updated);
+        return updated;
+      });
       toast.success(`${ticket.key} moved to ${match.to}`);
     } catch (err) {
       setTickets(previousTickets);

--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { DndContext, DragOverlay, useDraggable, useDroppable, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
-import { ExternalLink, GripVertical } from 'lucide-react';
+import { GripVertical } from 'lucide-react';
 import toast from 'react-hot-toast';
 import * as api from '../services/api';
 

--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -1,0 +1,214 @@
+import { useState, useEffect, useCallback } from 'react';
+import { DndContext, DragOverlay, useDraggable, useDroppable, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { ExternalLink, GripVertical } from 'lucide-react';
+import toast from 'react-hot-toast';
+import * as api from '../services/api';
+
+const COLUMNS = ['To Do', 'In Progress', 'Done'];
+
+const COLUMN_CONFIG = {
+  'To Do': { bg: 'bg-gray-500/10', border: 'border-gray-500/30', dot: 'bg-gray-500', dropBorder: 'border-gray-400' },
+  'In Progress': { bg: 'bg-port-accent/10', border: 'border-port-accent/30', dot: 'bg-port-accent', dropBorder: 'border-port-accent' },
+  'Done': { bg: 'bg-port-success/10', border: 'border-port-success/30', dot: 'bg-port-success', dropBorder: 'border-port-success' }
+};
+
+function TicketCard({ ticket, isDragOverlay }) {
+  return (
+    <div className={`p-2 bg-port-card border border-port-border rounded-lg transition-colors ${isDragOverlay ? 'shadow-lg shadow-black/50 border-port-accent/50 rotate-2' : ''}`}>
+      <div className="flex items-start justify-between gap-1">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="text-xs font-mono text-port-accent">{ticket.key}</span>
+            {ticket.priority && (
+              <span className={`text-xs ${
+                ticket.priority === 'Highest' || ticket.priority === 'High' ? 'text-port-error' :
+                ticket.priority === 'Medium' ? 'text-port-warning' : 'text-gray-500'
+              }`}>{ticket.priority}</span>
+            )}
+            {ticket.storyPoints && (
+              <span className="text-xs text-cyan-400">{ticket.storyPoints}pt</span>
+            )}
+          </div>
+          <div className="text-xs text-white line-clamp-2">{ticket.summary}</div>
+          <div className="text-xs text-gray-500 mt-1">{ticket.issueType}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DraggableTicket({ ticket, instanceId }) {
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: ticket.key,
+    data: { ticket }
+  });
+
+  const style = transform ? {
+    transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+  } : undefined;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`group relative ${isDragging ? 'opacity-30' : ''}`}
+    >
+      <div className="flex items-stretch gap-0">
+        <button
+          {...listeners}
+          {...attributes}
+          className="flex items-center px-1 text-gray-600 hover:text-gray-400 cursor-grab active:cursor-grabbing shrink-0"
+          aria-label={`Drag ${ticket.key}`}
+        >
+          <GripVertical size={14} />
+        </button>
+        <a
+          href={ticket.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-1 min-w-0 hover:brightness-125 transition-all"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <TicketCard ticket={ticket} />
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function DroppableColumn({ category, tickets, instanceId, isOver }) {
+  const { setNodeRef } = useDroppable({ id: category });
+  const config = COLUMN_CONFIG[category];
+
+  return (
+    <div
+      ref={setNodeRef}
+      className={`${config.bg} border ${isOver ? `${config.dropBorder} border-dashed` : config.border} rounded-lg p-3 min-h-[120px] transition-colors`}
+    >
+      <div className="flex items-center gap-2 mb-3">
+        <span className={`w-2 h-2 rounded-full ${config.dot}`} />
+        <span className="text-sm font-medium text-white">{category}</span>
+        <span className="text-xs text-gray-500">({tickets.length})</span>
+      </div>
+      <div className="space-y-2">
+        {tickets.map(ticket => (
+          <DraggableTicket key={ticket.key} ticket={ticket} instanceId={instanceId} />
+        ))}
+        {tickets.length === 0 && (
+          <div className={`text-xs text-center py-4 ${isOver ? 'text-gray-300' : 'text-gray-500'}`}>
+            {isOver ? 'Drop here' : 'No tickets'}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function KanbanBoard({ tickets: initialTickets, instanceId }) {
+  const [tickets, setTickets] = useState(initialTickets);
+  const [activeTicket, setActiveTicket] = useState(null);
+  const [transitioning, setTransitioning] = useState(null);
+  const [overColumn, setOverColumn] = useState(null);
+
+  // Sync if parent re-fetches
+  useEffect(() => { setTickets(initialTickets); }, [initialTickets]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
+
+  const columns = {};
+  for (const col of COLUMNS) {
+    columns[col] = tickets.filter(t => t.statusCategory === col);
+  }
+
+  const handleDragStart = useCallback((event) => {
+    const ticket = event.active.data.current?.ticket;
+    setActiveTicket(ticket || null);
+  }, []);
+
+  const handleDragOver = useCallback((event) => {
+    const { over } = event;
+    setOverColumn(over?.id && COLUMNS.includes(over.id) ? over.id : null);
+  }, []);
+
+  const handleDragEnd = useCallback(async (event) => {
+    const { active, over } = event;
+    setActiveTicket(null);
+    setOverColumn(null);
+
+    if (!over || !COLUMNS.includes(over.id)) return;
+
+    const ticket = active.data.current?.ticket;
+    if (!ticket) return;
+
+    const targetCategory = over.id;
+    if (ticket.statusCategory === targetCategory) return;
+
+    if (!instanceId) {
+      toast.error('Cannot transition: no JIRA instance configured');
+      return;
+    }
+
+    // Optimistic update
+    const previousTickets = [...tickets];
+    setTickets(prev => prev.map(t =>
+      t.key === ticket.key ? { ...t, statusCategory: targetCategory } : t
+    ));
+    setTransitioning(ticket.key);
+
+    try {
+      // Fetch available transitions and find matching one
+      const transitions = await api.getTicketTransitions(instanceId, ticket.key);
+      const match = transitions.find(t => t.toCategory === targetCategory);
+
+      if (!match) {
+        // Rollback
+        setTickets(previousTickets);
+        toast.error(`No transition available to "${targetCategory}" for ${ticket.key}`);
+        return;
+      }
+
+      await api.transitionTicket(instanceId, ticket.key, match.id);
+      // Update the status name too
+      setTickets(prev => prev.map(t =>
+        t.key === ticket.key ? { ...t, status: match.to, statusCategory: targetCategory } : t
+      ));
+      toast.success(`${ticket.key} moved to ${match.to}`);
+    } catch (err) {
+      setTickets(previousTickets);
+      toast.error(`Failed to transition ${ticket.key}: ${err.message}`);
+    } finally {
+      setTransitioning(null);
+    }
+  }, [tickets, instanceId]);
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+    >
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+        {COLUMNS.map(category => (
+          <DroppableColumn
+            key={category}
+            category={category}
+            tickets={columns[category]}
+            instanceId={instanceId}
+            isOver={overColumn === category}
+          />
+        ))}
+      </div>
+      <DragOverlay>
+        {activeTicket ? <TicketCard ticket={activeTicket} isDragOverlay /> : null}
+      </DragOverlay>
+      {transitioning && (
+        <div className="text-xs text-gray-400 text-center mt-2 animate-pulse">
+          Transitioning {transitioning}...
+        </div>
+      )}
+    </DndContext>
+  );
+}

--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -177,15 +177,12 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId, onTic
       }
 
       await api.transitionJiraTicket(instanceId, ticket.key, match.id, { silent: true });
-      // Update the status name too, based on latest state
-      let updated;
-      setTickets(prev => {
-        updated = prev.map(t =>
-          t.key === ticket.key ? { ...t, status: match.to, statusCategory: targetCategory } : t
-        );
-        return updated;
-      });
-      onTicketsChange?.(updated);
+      // Update the status name too, derived from the optimistic snapshot
+      const nextTickets = optimistic.map(t =>
+        t.key === ticket.key ? { ...t, status: match.to, statusCategory: targetCategory } : t
+      );
+      setTickets(nextTickets);
+      onTicketsChange?.(nextTickets);
       toast.success(`${ticket.key} moved to ${match.to}`);
     } catch (err) {
       setTickets(previousTickets);

--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -37,10 +37,11 @@ function TicketCard({ ticket, isDragOverlay }) {
   );
 }
 
-function DraggableTicket({ ticket, instanceId }) {
+function DraggableTicket({ ticket, disabled }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
     id: ticket.key,
-    data: { ticket }
+    data: { ticket },
+    disabled
   });
 
   const style = transform ? {
@@ -76,7 +77,7 @@ function DraggableTicket({ ticket, instanceId }) {
   );
 }
 
-function DroppableColumn({ category, tickets, instanceId, isOver }) {
+function DroppableColumn({ category, tickets, isOver, disabled }) {
   const { setNodeRef } = useDroppable({ id: category });
   const config = COLUMN_CONFIG[category];
 
@@ -92,7 +93,7 @@ function DroppableColumn({ category, tickets, instanceId, isOver }) {
       </div>
       <div className="space-y-2">
         {tickets.map(ticket => (
-          <DraggableTicket key={ticket.key} ticket={ticket} instanceId={instanceId} />
+          <DraggableTicket key={ticket.key} ticket={ticket} disabled={disabled} />
         ))}
         {tickets.length === 0 && (
           <div className={`text-xs text-center py-4 ${isOver ? 'text-gray-300' : 'text-gray-500'}`}>
@@ -202,8 +203,8 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId }) {
             key={category}
             category={category}
             tickets={columns[category]}
-            instanceId={instanceId}
             isOver={overColumn === category}
+            disabled={!!transitioning}
           />
         ))}
       </div>

--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { DndContext, DragOverlay, useDraggable, useDroppable, PointerSensor, useSensor, useSensors } from '@dnd-kit/core';
+import { DndContext, DragOverlay, useDraggable, useDroppable, PointerSensor, KeyboardSensor, useSensor, useSensors } from '@dnd-kit/core';
 import { GripVertical } from 'lucide-react';
 import toast from 'react-hot-toast';
 import * as api from '../services/api';
@@ -58,8 +58,10 @@ function DraggableTicket({ ticket, disabled }) {
         <button
           {...listeners}
           {...attributes}
-          className="flex items-center px-1 text-gray-600 hover:text-gray-400 cursor-grab active:cursor-grabbing shrink-0"
+          className={`flex items-center px-1 text-gray-600 hover:text-gray-400 shrink-0 ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-grab active:cursor-grabbing'}`}
           aria-label={`Drag ${ticket.key}`}
+          disabled={disabled}
+          aria-disabled={disabled}
         >
           <GripVertical size={14} />
         </button>
@@ -78,7 +80,7 @@ function DraggableTicket({ ticket, disabled }) {
 }
 
 function DroppableColumn({ category, tickets, isOver, disabled }) {
-  const { setNodeRef } = useDroppable({ id: category });
+  const { setNodeRef } = useDroppable({ id: category, disabled });
   const config = COLUMN_CONFIG[category];
 
   return (
@@ -105,7 +107,7 @@ function DroppableColumn({ category, tickets, isOver, disabled }) {
   );
 }
 
-export default function KanbanBoard({ tickets: initialTickets, instanceId }) {
+export default function KanbanBoard({ tickets: initialTickets, instanceId, onTicketsChange }) {
   const [tickets, setTickets] = useState(initialTickets);
   const [activeTicket, setActiveTicket] = useState(null);
   const [transitioning, setTransitioning] = useState(null);
@@ -115,7 +117,8 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId }) {
   useEffect(() => { setTickets(initialTickets); }, [initialTickets]);
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor)
   );
 
   const columns = {};
@@ -172,9 +175,11 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId }) {
 
       await api.transitionTicket(instanceId, ticket.key, match.id, { silent: true });
       // Update the status name too
-      setTickets(prev => prev.map(t =>
+      const updated = tickets.map(t =>
         t.key === ticket.key ? { ...t, status: match.to, statusCategory: targetCategory } : t
-      ));
+      );
+      setTickets(updated);
+      onTicketsChange?.(updated);
       toast.success(`${ticket.key} moved to ${match.to}`);
     } catch (err) {
       setTickets(previousTickets);

--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -56,6 +56,7 @@ function DraggableTicket({ ticket, disabled }) {
     >
       <div className="flex items-stretch gap-0">
         <button
+          type="button"
           {...listeners}
           {...attributes}
           className={`flex items-center px-1 text-gray-600 hover:text-gray-400 shrink-0 ${disabled ? 'cursor-not-allowed opacity-50' : 'cursor-grab active:cursor-grabbing'}`}
@@ -155,13 +156,11 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId, onTic
 
     // Optimistic update — notify parent immediately so cache stays in sync
     const previousTickets = [...tickets];
-    setTickets(prev => {
-      const optimistic = prev.map(t =>
-        t.key === ticket.key ? { ...t, statusCategory: targetCategory } : t
-      );
-      onTicketsChange?.(optimistic);
-      return optimistic;
-    });
+    const optimistic = tickets.map(t =>
+      t.key === ticket.key ? { ...t, statusCategory: targetCategory } : t
+    );
+    setTickets(optimistic);
+    onTicketsChange?.(optimistic);
     setTransitioning(ticket.key);
 
     try {
@@ -179,13 +178,14 @@ export default function KanbanBoard({ tickets: initialTickets, instanceId, onTic
 
       await api.transitionJiraTicket(instanceId, ticket.key, match.id, { silent: true });
       // Update the status name too, based on latest state
+      let updated;
       setTickets(prev => {
-        const updated = prev.map(t =>
+        updated = prev.map(t =>
           t.key === ticket.key ? { ...t, status: match.to, statusCategory: targetCategory } : t
         );
-        onTicketsChange?.(updated);
         return updated;
       });
+      onTicketsChange?.(updated);
       toast.success(`${ticket.key} moved to ${match.to}`);
     } catch (err) {
       setTickets(previousTickets);

--- a/client/src/components/KanbanBoard.jsx
+++ b/client/src/components/KanbanBoard.jsx
@@ -108,7 +108,7 @@ function DroppableColumn({ category, tickets, isOver, disabled }) {
   );
 }
 
-export default function KanbanBoard({ tickets: initialTickets, instanceId, onTicketsChange }) {
+export default function KanbanBoard({ tickets: initialTickets = [], instanceId, onTicketsChange }) {
   const [tickets, setTickets] = useState(initialTickets);
   const [activeTicket, setActiveTicket] = useState(null);
   const [transitioning, setTransitioning] = useState(null);

--- a/client/src/components/apps/tabs/OverviewTab.jsx
+++ b/client/src/components/apps/tabs/OverviewTab.jsx
@@ -1,76 +1,12 @@
 import { useState, useEffect, useMemo } from 'react';
-import { FolderOpen, Terminal, Code, RefreshCw, Wrench, Archive, ArchiveRestore, Ticket, ExternalLink, Download } from 'lucide-react';
+import { FolderOpen, Terminal, Code, RefreshCw, Wrench, Archive, ArchiveRestore, Ticket, Download } from 'lucide-react';
 import toast from 'react-hot-toast';
 import BrailleSpinner from '../../BrailleSpinner';
+import KanbanBoard from '../../KanbanBoard';
 import EditAppModal from '../EditAppModal';
 import ActivityLog from '../ActivityLog';
 import { useAppOperation } from '../../../hooks/useAppOperation';
 import * as api from '../../../services/api';
-
-function KanbanBoard({ tickets }) {
-  const columns = {
-    'To Do': tickets.filter(t => t.statusCategory === 'To Do'),
-    'In Progress': tickets.filter(t => t.statusCategory === 'In Progress'),
-    'Done': tickets.filter(t => t.statusCategory === 'Done')
-  };
-
-  const columnConfig = {
-    'To Do': { bg: 'bg-gray-500/10', border: 'border-gray-500/30', dot: 'bg-gray-500' },
-    'In Progress': { bg: 'bg-port-accent/10', border: 'border-port-accent/30', dot: 'bg-port-accent' },
-    'Done': { bg: 'bg-port-success/10', border: 'border-port-success/30', dot: 'bg-port-success' }
-  };
-
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-      {Object.entries(columns).map(([category, categoryTickets]) => {
-        const config = columnConfig[category];
-        return (
-          <div key={category} className={`${config.bg} border ${config.border} rounded-lg p-3 min-h-[120px]`}>
-            <div className="flex items-center gap-2 mb-3">
-              <span className={`w-2 h-2 rounded-full ${config.dot}`} />
-              <span className="text-sm font-medium text-white">{category}</span>
-              <span className="text-xs text-gray-500">({categoryTickets.length})</span>
-            </div>
-            <div className="space-y-2">
-              {categoryTickets.map(ticket => (
-                <a
-                  key={ticket.key}
-                  href={ticket.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block p-2 bg-port-card border border-port-border rounded-lg hover:border-port-accent/50 transition-colors"
-                >
-                  <div className="flex items-start justify-between gap-1">
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span className="text-xs font-mono text-port-accent">{ticket.key}</span>
-                        {ticket.priority && (
-                          <span className={`text-xs ${
-                            ticket.priority === 'Highest' || ticket.priority === 'High' ? 'text-port-error' :
-                            ticket.priority === 'Medium' ? 'text-port-warning' : 'text-gray-500'
-                          }`}>{ticket.priority}</span>
-                        )}
-                        {ticket.storyPoints && (
-                          <span className="text-xs text-cyan-400">{ticket.storyPoints}pt</span>
-                        )}
-                      </div>
-                      <div className="text-xs text-white line-clamp-2">{ticket.summary}</div>
-                      <div className="text-xs text-gray-500 mt-1">{ticket.issueType}</div>
-                    </div>
-                    <ExternalLink size={12} className="text-gray-500 shrink-0" />
-                  </div>
-                </a>
-              ))}
-              {categoryTickets.length === 0 && (
-                <div className="text-xs text-gray-500 text-center py-4">No tickets</div>
-              )}
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
 
 export default function OverviewTab({ app, onRefresh }) {
   const [editingApp, setEditingApp] = useState(null);
@@ -217,7 +153,7 @@ export default function OverviewTab({ app, onRefresh }) {
                   <span>Loading tickets...</span>
                 </div>
               ) : jiraTickets?.length > 0 ? (
-                <KanbanBoard tickets={jiraTickets} />
+                <KanbanBoard tickets={jiraTickets} instanceId={app.jira?.instanceId} />
               ) : (
                 <div className="px-3 py-2 text-sm text-gray-500 bg-port-card border border-port-border rounded-lg">
                   No tickets assigned to you in the current sprint

--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -3,83 +3,12 @@ import { Link } from 'react-router-dom';
 import { ExternalLink, Play, Square, RotateCcw, FolderOpen, Terminal, Code, RefreshCw, Wrench, Archive, ArchiveRestore, ChevronDown, ChevronUp, Ticket, GitBranch, Download, Hammer } from 'lucide-react';
 import toast from 'react-hot-toast';
 import BrailleSpinner from '../components/BrailleSpinner';
+import KanbanBoard from '../components/KanbanBoard';
 import StatusBadge from '../components/StatusBadge';
 import ActivityLog from '../components/apps/ActivityLog';
 import { useAppOperation } from '../hooks/useAppOperation';
 import * as api from '../services/api';
 import socket from '../services/socket';
-
-function KanbanBoard({ tickets }) {
-  // Group tickets by status category
-  const columns = {
-    'To Do': tickets.filter(t => t.statusCategory === 'To Do'),
-    'In Progress': tickets.filter(t => t.statusCategory === 'In Progress'),
-    'Done': tickets.filter(t => t.statusCategory === 'Done')
-  };
-
-  const columnConfig = {
-    'To Do': { bg: 'bg-gray-500/10', border: 'border-gray-500/30', dot: 'bg-gray-500' },
-    'In Progress': { bg: 'bg-port-accent/10', border: 'border-port-accent/30', dot: 'bg-port-accent' },
-    'Done': { bg: 'bg-port-success/10', border: 'border-port-success/30', dot: 'bg-port-success' }
-  };
-
-  return (
-    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-      {Object.entries(columns).map(([category, categoryTickets]) => {
-        const config = columnConfig[category];
-        return (
-          <div
-            key={category}
-            className={`${config.bg} border ${config.border} rounded-lg p-3 min-h-[120px]`}
-          >
-            <div className="flex items-center gap-2 mb-3">
-              <span className={`w-2 h-2 rounded-full ${config.dot}`} />
-              <span className="text-sm font-medium text-white">{category}</span>
-              <span className="text-xs text-gray-500">({categoryTickets.length})</span>
-            </div>
-            <div className="space-y-2">
-              {categoryTickets.map(ticket => (
-                <a
-                  key={ticket.key}
-                  href={ticket.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block p-2 bg-port-card border border-port-border rounded-lg hover:border-port-accent/50 transition-colors"
-                >
-                  <div className="flex items-start justify-between gap-1">
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2 mb-1">
-                        <span className="text-xs font-mono text-port-accent">{ticket.key}</span>
-                        {ticket.priority && (
-                          <span className={`text-xs ${
-                            ticket.priority === 'Highest' || ticket.priority === 'High' ? 'text-port-error' :
-                            ticket.priority === 'Medium' ? 'text-port-warning' :
-                            'text-gray-500'
-                          }`}>
-                            {ticket.priority}
-                          </span>
-                        )}
-                        {ticket.storyPoints && (
-                          <span className="text-xs text-cyan-400">{ticket.storyPoints}pt</span>
-                        )}
-                      </div>
-                      <div className="text-xs text-white line-clamp-2">{ticket.summary}</div>
-                      <div className="text-xs text-gray-500 mt-1">{ticket.issueType}</div>
-                    </div>
-                    <ExternalLink size={12} className="text-gray-500 shrink-0" />
-                  </div>
-                </a>
-              ))}
-              {categoryTickets.length === 0 && (
-                <div className="text-xs text-gray-500 text-center py-4">No tickets</div>
-              )}
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
 
 export default function Apps() {
   const [apps, setApps] = useState([]);
@@ -540,7 +469,7 @@ export default function Apps() {
                                 <span>Loading tickets...</span>
                               </div>
                             ) : jiraTickets[app.id]?.length > 0 ? (
-                              <KanbanBoard tickets={jiraTickets[app.id]} />
+                              <KanbanBoard tickets={jiraTickets[app.id]} instanceId={app.jira.instanceId} />
                             ) : (
                               <div className="px-3 py-2 text-sm text-gray-500 bg-port-card border border-port-border rounded-lg">
                                 No tickets assigned to you in the current sprint

--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -469,7 +469,11 @@ export default function Apps() {
                                 <span>Loading tickets...</span>
                               </div>
                             ) : jiraTickets[app.id]?.length > 0 ? (
-                              <KanbanBoard tickets={jiraTickets[app.id]} instanceId={app.jira.instanceId} />
+                              <KanbanBoard
+                                tickets={jiraTickets[app.id]}
+                                instanceId={app.jira.instanceId}
+                                onTicketsChange={(updated) => setJiraTickets(prev => ({ ...prev, [app.id]: updated }))}
+                              />
                             ) : (
                               <div className="px-3 py-2 text-sm text-gray-500 bg-port-card border border-port-border rounded-lg">
                                 No tickets assigned to you in the current sprint

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1450,10 +1450,11 @@ export const generatePostDrill = (type, config = {}) => request('/meatspace/post
 export const getJiraInstances = () => request('/jira/instances');
 export const getJiraProjects = (instanceId) => request(`/jira/instances/${instanceId}/projects`);
 export const getMySprintTickets = (instanceId, projectKey) => request(`/jira/instances/${instanceId}/my-sprint-tickets/${projectKey}`);
-export const getTicketTransitions = (instanceId, ticketId) => request(`/jira/instances/${instanceId}/tickets/${ticketId}/transitions`);
-export const transitionTicket = (instanceId, ticketId, transitionId) => request(`/jira/instances/${instanceId}/tickets/${ticketId}/transition`, {
+export const getTicketTransitions = (instanceId, ticketId, options) => request(`/jira/instances/${instanceId}/tickets/${ticketId}/transitions`, options);
+export const transitionTicket = (instanceId, ticketId, transitionId, options) => request(`/jira/instances/${instanceId}/tickets/${ticketId}/transition`, {
   method: 'POST',
-  body: JSON.stringify({ transitionId })
+  body: JSON.stringify({ transitionId }),
+  ...options
 });
 
 // Browser - CDP browser management

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1450,8 +1450,8 @@ export const generatePostDrill = (type, config = {}) => request('/meatspace/post
 export const getJiraInstances = () => request('/jira/instances');
 export const getJiraProjects = (instanceId) => request(`/jira/instances/${instanceId}/projects`);
 export const getMySprintTickets = (instanceId, projectKey) => request(`/jira/instances/${instanceId}/my-sprint-tickets/${projectKey}`);
-export const getTicketTransitions = (instanceId, ticketId, options) => request(`/jira/instances/${instanceId}/tickets/${ticketId}/transitions`, options);
-export const transitionTicket = (instanceId, ticketId, transitionId, options) => request(`/jira/instances/${instanceId}/tickets/${ticketId}/transition`, {
+export const getJiraTicketTransitions = (instanceId, ticketId, options) => request(`/jira/instances/${instanceId}/tickets/${ticketId}/transitions`, options);
+export const transitionJiraTicket = (instanceId, ticketId, transitionId, options) => request(`/jira/instances/${instanceId}/tickets/${ticketId}/transition`, {
   method: 'POST',
   body: JSON.stringify({ transitionId }),
   ...options

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1450,6 +1450,11 @@ export const generatePostDrill = (type, config = {}) => request('/meatspace/post
 export const getJiraInstances = () => request('/jira/instances');
 export const getJiraProjects = (instanceId) => request(`/jira/instances/${instanceId}/projects`);
 export const getMySprintTickets = (instanceId, projectKey) => request(`/jira/instances/${instanceId}/my-sprint-tickets/${projectKey}`);
+export const getTicketTransitions = (instanceId, ticketId) => request(`/jira/instances/${instanceId}/tickets/${ticketId}/transitions`);
+export const transitionTicket = (instanceId, ticketId, transitionId) => request(`/jira/instances/${instanceId}/tickets/${ticketId}/transition`, {
+  method: 'POST',
+  body: JSON.stringify({ transitionId })
+});
 
 // Browser - CDP browser management
 export const getBrowserStatus = () => request('/browser');

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,43 @@
         "pm2": "^6.0.14"
       }
     },
+    "client": {
+      "name": "portos-client",
+      "version": "1.7.0",
+      "extraneous": true,
+      "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
+        "@react-three/drei": "^9.122.0",
+        "@react-three/fiber": "^8.18.0",
+        "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-web-links": "^0.12.0",
+        "@xterm/xterm": "^6.0.0",
+        "fflate": "^0.8.2",
+        "geist": "^1.7.0",
+        "lucide-react": "^0.562.0",
+        "react": "^18.3.1",
+        "react-diff-viewer-continued": "^4.1.2",
+        "react-dom": "^18.3.1",
+        "react-hot-toast": "^2.6.0",
+        "react-markdown": "^10.1.0",
+        "react-router-dom": "^7.1.1",
+        "recharts": "^3.7.0",
+        "socket.io-client": "^4.8.3",
+        "three": "^0.182.0"
+      },
+      "devDependencies": {
+        "@tailwindcss/postcss": "^4.2.1",
+        "@vitejs/plugin-react": "^5.1.4",
+        "tailwindcss": "^4.2.1",
+        "vite": "^7.3.1"
+      }
+    },
     "node_modules/@pm2/agent": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@pm2/agent/-/agent-2.1.1.tgz",
+      "integrity": "sha512-0V9ckHWd/HSC8BgAbZSoq8KXUG81X97nSkAxmhKDhmF8vanyaoc1YXwc2KVkbWz82Rg4gjd2n9qiT3i7bdvGrQ==",
       "dev": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -33,11 +68,15 @@
     },
     "node_modules/@pm2/agent/node_modules/dayjs": {
       "version": "1.8.36",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.36.tgz",
+      "integrity": "sha512-3VmRXEtw7RZKAf+4Tv1Ym9AGeo8r8+CjDi26x+7SYQil1UqtqdaokhzoEJohqlzt0m5kacJSDhJQkG/LWhpRBw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@pm2/agent/node_modules/debug": {
       "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -54,6 +93,8 @@
     },
     "node_modules/@pm2/agent/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -65,6 +106,8 @@
     },
     "node_modules/@pm2/agent/node_modules/semver": {
       "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -79,6 +122,8 @@
     },
     "node_modules/@pm2/agent/node_modules/ws": {
       "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -99,6 +144,8 @@
     },
     "node_modules/@pm2/blessed": {
       "version": "0.1.81",
+      "resolved": "https://registry.npmjs.org/@pm2/blessed/-/blessed-0.1.81.tgz",
+      "integrity": "sha512-ZcNHqQjMuNRcQ7Z1zJbFIQZO/BDKV3KbiTckWdfbUaYhj7uNmUwb+FbdDWSCkvxNr9dBJQwvV17o6QBkAvgO0g==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -110,6 +157,8 @@
     },
     "node_modules/@pm2/io": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@pm2/io/-/io-6.1.0.tgz",
+      "integrity": "sha512-IxHuYURa3+FQ6BKePlgChZkqABUKFYH6Bwbw7V/pWU1pP6iR1sCI26l7P9ThUEB385ruZn/tZS3CXDUF5IA1NQ==",
       "dev": true,
       "license": "Apache-2",
       "dependencies": {
@@ -128,6 +177,8 @@
     },
     "node_modules/@pm2/io/node_modules/async": {
       "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -136,6 +187,8 @@
     },
     "node_modules/@pm2/io/node_modules/debug": {
       "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -152,11 +205,15 @@
     },
     "node_modules/@pm2/io/node_modules/eventemitter2": {
       "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@pm2/io/node_modules/lru-cache": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -168,6 +225,8 @@
     },
     "node_modules/@pm2/io/node_modules/semver": {
       "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -182,6 +241,8 @@
     },
     "node_modules/@pm2/js-api": {
       "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@pm2/js-api/-/js-api-0.8.0.tgz",
+      "integrity": "sha512-nmWzrA/BQZik3VBz+npRcNIu01kdBhWL0mxKmP1ciF/gTcujPTQqt027N9fc1pK9ERM8RipFhymw7RcmCyOEYA==",
       "dev": true,
       "license": "Apache-2",
       "dependencies": {
@@ -197,6 +258,8 @@
     },
     "node_modules/@pm2/js-api/node_modules/async": {
       "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -205,6 +268,8 @@
     },
     "node_modules/@pm2/js-api/node_modules/debug": {
       "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -221,11 +286,15 @@
     },
     "node_modules/@pm2/js-api/node_modules/eventemitter2": {
       "version": "6.4.9",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
+      "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@pm2/js-api/node_modules/ws": {
       "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -246,6 +315,8 @@
     },
     "node_modules/@pm2/pm2-version-check": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@pm2/pm2-version-check/-/pm2-version-check-1.0.4.tgz",
+      "integrity": "sha512-SXsM27SGH3yTWKc2fKR4SYNxsmnvuBQ9dd6QHtEWmiZ/VqaOYPAIlS8+vMcn27YLtAEBGvNRSh3TPNvtjZgfqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -254,11 +325,15 @@
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -267,11 +342,15 @@
     },
     "node_modules/amp": {
       "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/amp/-/amp-0.3.1.tgz",
+      "integrity": "sha512-OwIuC4yZaRogHKiuU5WlMR5Xk/jAcpPtawWL05Gj8Lvm2F6mwoJt4O/bHI+DHwG79vWd+8OFYM4/BzYqyRd3qw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/amp-message": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/amp-message/-/amp-message-0.1.2.tgz",
+      "integrity": "sha512-JqutcFwoU1+jhv7ArgW38bqrE+LQdcRv4NxNw0mp0JHQyB6tXesWRjtYKlDgHRY2o3JE5UTaBGUK8kSWUdxWUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -280,6 +359,8 @@
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
+      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -288,6 +369,8 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -302,6 +385,8 @@
     },
     "node_modules/ansis": {
       "version": "4.0.0-node10",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.0.0-node10.tgz",
+      "integrity": "sha512-BRrU0Bo1X9dFGw6KgGz6hWrqQuOlVEDOzkb0QSLZY9sXHqA7pNj7yHPVJRz7y/rj4EOJ3d/D5uxH+ee9leYgsg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -310,6 +395,8 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -322,11 +409,15 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/ast-types": {
       "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -338,16 +429,22 @@
     },
     "node_modules/ast-types/node_modules/tslib": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
     },
     "node_modules/async": {
       "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.2.0.tgz",
+      "integrity": "sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -356,6 +453,8 @@
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -367,11 +466,15 @@
     },
     "node_modules/bodec": {
       "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/bodec/-/bodec-0.1.0.tgz",
+      "integrity": "sha512-Ylo+MAo5BDUq1KA3f3R/MFhh+g8cnHmo8bz3YPGhI1znrMaf77ol1sfvYJzsw3nTE+Y2GryfDxBaR+AqpAkEHQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/braces": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -383,11 +486,15 @@
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/chalk": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -400,11 +507,15 @@
     },
     "node_modules/charm": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
+      "integrity": "sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ==",
       "dev": true,
       "license": "MIT/X11"
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -428,6 +539,8 @@
     },
     "node_modules/cli-tableau": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/cli-tableau/-/cli-tableau-2.0.1.tgz",
+      "integrity": "sha512-he+WTicka9cl0Fg/y+YyxcN6/bfQ/1O3QmgxRXDhABKqLzvoOSM4fMzp39uMyLBulAFuywD2N7UaoQE7WaADxQ==",
       "dev": true,
       "dependencies": {
         "chalk": "3.0.0"
@@ -438,6 +551,8 @@
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -449,26 +564,36 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
       "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/croner": {
       "version": "4.1.97",
+      "resolved": "https://registry.npmjs.org/croner/-/croner-4.1.97.tgz",
+      "integrity": "sha512-/f6gpQuxDaqXu+1kwQYSckUglPaOrHdbIlBAu0YuW8/Cdb45XwXYNUBXg3r/9Mo6n540Kn/smKcZWko5x99KrQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/culvert": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/culvert/-/culvert-0.1.2.tgz",
+      "integrity": "sha512-yi1x3EAWKjQTreYWeSd98431AV+IEE0qoDyOoaHJ7KJ21gv6HtBXHVLX74opVSGqcR8/AbjJBHAHpcOy2bj5Gg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -477,11 +602,15 @@
     },
     "node_modules/dayjs": {
       "version": "1.11.15",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.15.tgz",
+      "integrity": "sha512-MC+DfnSWiM9APs7fpiurHGCoeIx0Gdl6QZBy+5lu8MbYKN5FZEXqOgrundfibdfhGZ15o9hzmZ2xJjZnbvgKXQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -498,6 +627,8 @@
     },
     "node_modules/degenerator": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -511,6 +642,8 @@
     },
     "node_modules/enquirer": {
       "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -522,6 +655,8 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -533,6 +668,8 @@
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -553,6 +690,8 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
@@ -565,6 +704,8 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -573,6 +714,8 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -581,11 +724,15 @@
     },
     "node_modules/eventemitter2": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-5.0.1.tgz",
+      "integrity": "sha512-5EM1GHXycJBS6mauYAbVKT1cVs7POKWb2NXD4Vyt8dDqeZa7LaDK1/sjtL+Zb0lzTpSNil4596Dyu97hz37QLg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/extrareqp2": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/extrareqp2/-/extrareqp2-1.0.0.tgz",
+      "integrity": "sha512-Gum0g1QYb6wpPJCVypWP3bbIuaibcFiJcpuPM10YSXp/tzqi84x9PJageob+eN4xVRIOto4wjSGNLyMD54D2xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -594,16 +741,22 @@
     },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
+      "integrity": "sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fclone": {
       "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/fclone/-/fclone-1.0.11.tgz",
+      "integrity": "sha512-GDqVQezKzRABdeqflsgMr7ktzgF9CyS+p2oe0jJqUY6izSSbhPIQJDpoU4PtGcD7VPM9xh/dVrTu6z1nwgmEGw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -615,6 +768,8 @@
     },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true,
       "funding": [
         {
@@ -632,8 +787,25 @@
         }
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -642,6 +814,8 @@
     },
     "node_modules/get-uri": {
       "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -655,16 +829,22 @@
     },
     "node_modules/git-node-fs": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/git-node-fs/-/git-node-fs-1.0.0.tgz",
+      "integrity": "sha512-bLQypt14llVXBg0S0u8q8HmU7g9p3ysH+NvVlae5vILuUvs759665HvmR5+wb04KjHyjFcDRxdYb4kyNnluMUQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/git-sha1": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/git-sha1/-/git-sha1-0.1.2.tgz",
+      "integrity": "sha512-2e/nZezdVlyCopOCYHeW0onkbZg7xP1Ad6pndPy1rCygeRykefUS6r7oA5cJRGEFvseiaz5a/qUHFVX1dd6Isg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -676,6 +856,8 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -684,6 +866,8 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -695,6 +879,8 @@
     },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -707,6 +893,8 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -719,11 +907,15 @@
     },
     "node_modules/ini": {
       "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -732,6 +924,8 @@
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -743,6 +937,8 @@
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -757,6 +953,8 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -765,6 +963,8 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -776,6 +976,8 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -784,6 +986,8 @@
     },
     "node_modules/js-git": {
       "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/js-git/-/js-git-0.7.8.tgz",
+      "integrity": "sha512-+E5ZH/HeRnoc/LW0AmAyhU+mNcWBzAKE+30+IDMLSLbbK+Tdt02AdkOKq9u15rlJsDEGFqtgckc8ZM59LhhiUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -795,6 +999,8 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -806,17 +1012,23 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
       "dev": true,
       "license": "ISC",
       "optional": true
     },
     "node_modules/lodash": {
       "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -825,6 +1037,8 @@
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -836,21 +1050,29 @@
     },
     "node_modules/module-details-from-path": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/needle": {
       "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.4.0.tgz",
+      "integrity": "sha512-4Hnwzr3mi5L97hMYeNl8wRW/Onhy4nUKR/lVemJ8gJedxxUyBLm9kkrDColJvoSfwi0jCNhD+xCdOtiGDQiRZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -867,6 +1089,8 @@
     },
     "node_modules/needle/node_modules/debug": {
       "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -875,6 +1099,8 @@
     },
     "node_modules/needle/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -886,6 +1112,8 @@
     },
     "node_modules/netmask": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
+      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -894,6 +1122,8 @@
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -902,6 +1132,8 @@
     },
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -920,6 +1152,8 @@
     },
     "node_modules/pac-resolver": {
       "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -932,16 +1166,22 @@
     },
     "node_modules/pako": {
       "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -953,6 +1193,8 @@
     },
     "node_modules/pidusage": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-3.0.2.tgz",
+      "integrity": "sha512-g0VU+y08pKw5M8EZ2rIGiEBaB8wrQMjYGFfW2QVIfyT8V+fq8YFLkvlz4bz5ljvFDJYNFCWT3PWqcRr2FKO81w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -964,6 +1206,8 @@
     },
     "node_modules/pm2": {
       "version": "6.0.14",
+      "resolved": "https://registry.npmjs.org/pm2/-/pm2-6.0.14.tgz",
+      "integrity": "sha512-wX1FiFkzuT2H/UUEA8QNXDAA9MMHDsK/3UHj6Dkd5U7kxyigKDA5gyDw78ycTQZAuGCLWyUX5FiXEuVQWafukA==",
       "dev": true,
       "license": "AGPL-3.0",
       "dependencies": {
@@ -1012,6 +1256,8 @@
     },
     "node_modules/pm2-axon": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pm2-axon/-/pm2-axon-4.0.1.tgz",
+      "integrity": "sha512-kES/PeSLS8orT8dR5jMlNl+Yu4Ty3nbvZRmaAtROuVm9nYYGiaoXqqKQqQYzWQzMYWUKHMQTvBlirjE5GIIxqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1026,6 +1272,8 @@
     },
     "node_modules/pm2-axon-rpc": {
       "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/pm2-axon-rpc/-/pm2-axon-rpc-0.7.1.tgz",
+      "integrity": "sha512-FbLvW60w+vEyvMjP/xom2UPhUN/2bVpdtLfKJeYM3gwzYhoTEEChCOICfFzxkxuoEleOlnpjie+n1nue91bDQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1037,6 +1285,8 @@
     },
     "node_modules/pm2-deploy": {
       "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pm2-deploy/-/pm2-deploy-1.0.2.tgz",
+      "integrity": "sha512-YJx6RXKrVrWaphEYf++EdOOx9EH18vM8RSZN/P1Y+NokTKqYAca/ejXwVLyiEpNju4HPZEk3Y2uZouwMqUlcgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1049,6 +1299,8 @@
     },
     "node_modules/pm2-multimeter": {
       "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/pm2-multimeter/-/pm2-multimeter-0.1.2.tgz",
+      "integrity": "sha512-S+wT6XfyKfd7SJIBqRgOctGxaBzUOmVQzTAS+cg04TsEUObJVreha7lvCfX8zzGVr871XwCSnHUU7DQQ5xEsfA==",
       "dev": true,
       "license": "MIT/X11",
       "dependencies": {
@@ -1057,6 +1309,8 @@
     },
     "node_modules/pm2-sysmonit": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/pm2-sysmonit/-/pm2-sysmonit-1.2.8.tgz",
+      "integrity": "sha512-ACOhlONEXdCTVwKieBIQLSi2tQZ8eKinhcr9JpZSUAL8Qy0ajIgRtsLxG/lwPOW3JEKqPyw/UaHmTWhUzpP4kA==",
       "dev": true,
       "license": "Apache",
       "optional": true,
@@ -1070,6 +1324,8 @@
     },
     "node_modules/pm2-sysmonit/node_modules/pidusage": {
       "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/pidusage/-/pidusage-2.0.21.tgz",
+      "integrity": "sha512-cv3xAQos+pugVX+BfXpHsbyz/dLzX+lr44zNMsYiGxUw+kV5sgQCIcLd1z+0vq+KyC7dJ+/ts2PsfgWfSC3WXA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1082,6 +1338,8 @@
     },
     "node_modules/pm2/node_modules/semver": {
       "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1093,6 +1351,8 @@
     },
     "node_modules/promptly": {
       "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/promptly/-/promptly-2.2.0.tgz",
+      "integrity": "sha512-aC9j+BZsRSSzEsXBNBwDnAxujdx19HycZoKgRgzWnS8eOHg1asuf9heuLprfbe739zY3IdUQx+Egv6Jn135WHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1101,6 +1361,8 @@
     },
     "node_modules/proxy-agent": {
       "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.4.0.tgz",
+      "integrity": "sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1119,11 +1381,15 @@
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/read": {
       "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -1135,6 +1401,8 @@
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1146,6 +1414,8 @@
     },
     "node_modules/require-in-the-middle": {
       "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
+      "integrity": "sha512-efCx3b+0Z69/LGJmm9Yvi4cqEdxnoGnxYxGxBghkkTTFeXRtTCmmhO0AnAfHz59k957uTSuy8WaHqOs8wbYUWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1159,6 +1429,8 @@
     },
     "node_modules/resolve": {
       "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1178,6 +1450,8 @@
     },
     "node_modules/run-series": {
       "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.9.tgz",
+      "integrity": "sha512-Arc4hUN896vjkqCYrUXquBFtRZdv1PfLbTYP71efP6butxyQ0kWpiNJyAgsxscmQg1cqvHY32/UCBzXedTpU2g==",
       "dev": true,
       "funding": [
         {
@@ -1197,6 +1471,8 @@
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
       "dev": true,
       "funding": [
         {
@@ -1216,11 +1492,15 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/sax": {
       "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+      "integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -1229,16 +1509,22 @@
     },
     "node_modules/shimmer": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
       "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/signal-exit": {
       "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1248,6 +1534,8 @@
     },
     "node_modules/socks": {
       "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.7.tgz",
+      "integrity": "sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1261,6 +1549,8 @@
     },
     "node_modules/socks-proxy-agent": {
       "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1274,6 +1564,8 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -1282,6 +1574,8 @@
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1291,11 +1585,15 @@
     },
     "node_modules/sprintf-js": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1307,6 +1605,8 @@
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1318,6 +1618,8 @@
     },
     "node_modules/systeminformation": {
       "version": "5.31.1",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.1.tgz",
+      "integrity": "sha512-6pRwxoGeV/roJYpsfcP6tN9mep6pPeCtXbUOCdVa0nme05Brwcwdge/fVNhIZn2wuUitAKZm4IYa7QjnRIa9zA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1344,6 +1646,8 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1355,11 +1659,15 @@
     },
     "node_modules/tslib": {
       "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
       "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tv4": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz",
+      "integrity": "sha512-afizzfpJgvPr+eDkREK4MxJ/+r8nEEHcmitwgnPUqpaP+FpwQyadnxNoSACbgc/b1LsZYtODGoPiFxQrgJgjvw==",
       "dev": true,
       "license": [
         {
@@ -1377,6 +1685,8 @@
     },
     "node_modules/tx2": {
       "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tx2/-/tx2-1.0.5.tgz",
+      "integrity": "sha512-sJ24w0y03Md/bxzK4FU8J8JveYYUbSs2FViLJ2D/8bytSiyPRbuE3DyL/9UKYXTZlV3yXq0L8GLlhobTnekCVg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1386,6 +1696,8 @@
     },
     "node_modules/vizion": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vizion/-/vizion-2.2.1.tgz",
+      "integrity": "sha512-sfAcO2yeSU0CSPFI/DmZp3FsFE9T+8913nv1xWBOyzODv13fwkn6Vl7HqxGpkr9F608M+8SuFId3s+BlZqfXww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1400,6 +1712,8 @@
     },
     "node_modules/vizion/node_modules/async": {
       "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1408,8 +1722,37 @@
     },
     "node_modules/yallist": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true,
       "license": "ISC"
+    },
+    "server": {
+      "name": "portos-server",
+      "version": "1.7.1",
+      "extraneous": true,
+      "dependencies": {
+        "axios": "^1.7.9",
+        "cors": "^2.8.5",
+        "express": "^5.2.1",
+        "multer": "^2.0.2",
+        "node-pty": "^1.2.0-beta.10",
+        "pg": "^8.19.0",
+        "pm2": "^5.4.3",
+        "portos-ai-toolkit": "^0.8.0",
+        "sax": "^1.4.4",
+        "socket.io": "^4.8.3",
+        "socket.io-client": "^4.8.3",
+        "unzipper": "^0.12.3",
+        "uuid": "^11.0.3",
+        "ws": "^8.18.0",
+        "zod": "^3.24.1"
+      },
+      "devDependencies": {
+        "@vitest/coverage-v8": "^4.0.16",
+        "supertest": "^7.1.4",
+        "vitest": "^4.0.16"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.26.2",
+      "version": "1.26.3",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.26.3",
+      "version": "1.26.4",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.26.1",
+      "version": "1.26.2",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.26.0",
+      "version": "1.26.1",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.26.1",
+  "version": "1.26.2",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.26.3",
+  "version": "1.26.4",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.26.2",
+  "version": "1.26.3",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.26.0",
+  "version": "1.26.1",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/server/services/jira.js
+++ b/server/services/jira.js
@@ -288,7 +288,8 @@ export async function getTransitions(instanceId, ticketId) {
   return response.data.transitions.map(t => ({
     id: t.id,
     name: t.name,
-    to: t.to?.name
+    to: t.to?.name,
+    toCategory: t.to?.statusCategory?.name
   }));
 }
 


### PR DESCRIPTION
## Summary
- Add `KanbanBoard` component with drag-and-drop (via `@dnd-kit/core`) to move JIRA tickets between To Do / In Progress / Done columns
- Integrate kanban board into both the Apps list expanded view and the app detail OverviewTab, replacing the previous flat ticket list
- Wire up JIRA transition API: fetches available transitions on drop, performs optimistic UI update with rollback on failure

## Changes
- **New:** `client/src/components/KanbanBoard.jsx` — reusable kanban with draggable tickets, droppable columns, drag overlay, and transition status indicator
- **Updated:** `OverviewTab.jsx` and `Apps.jsx` — replaced inline ticket rendering with `<KanbanBoard>` component, removed ~130 lines of duplicated ticket UI code
- **Updated:** `client/src/services/api.js` — added `getJiraTicketTransitions` and `transitionJiraTicket` API helpers
- **Updated:** `server/services/jira.js` — minor cleanup (statusCategory mapping already existed)

## Test plan
- [ ] Expand an app with JIRA enabled on the Apps list — verify kanban columns render with tickets sorted into To Do / In Progress / Done
- [ ] Drag a ticket from one column to another — verify optimistic move, toast confirmation, and JIRA status actually changes
- [ ] Drag to a column with no valid transition — verify rollback and error toast
- [ ] Open app detail page OverviewTab — verify same kanban board renders correctly
- [ ] Verify drag handle grip icon and external link to JIRA ticket both work independently