### PR TITLE
fix: remove npm workspaces to resolve Windows EISDIR error

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-# Copy workspace packages instead of symlinking (required for exFAT filesystems)
-install-links=true

--- a/package.json
+++ b/package.json
@@ -6,14 +6,10 @@
   "author": "Adam Eivy (@antic|@atomantic)",
   "license": "MIT",
   "type": "module",
-  "workspaces": [
-    "client",
-    "server"
-  ],
   "scripts": {
     "dev": "node scripts/dev-start.js",
     "dev:stop": "node ./node_modules/pm2/bin/pm2 stop ecosystem.config.cjs",
-    "build": "npm run build -w client",
+    "build": "npm run build --prefix client",
     "start": "npm run build && node scripts/setup-db.js && node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent; node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs && node ./node_modules/pm2/bin/pm2 save",
     "pm2:start": "node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs",
     "pm2:stop": "node ./node_modules/pm2/bin/pm2 stop ecosystem.config.cjs",
@@ -29,7 +25,7 @@
     "setup:browser": "node scripts/setup-browser.js",
     "setup:ghostty": "node scripts/setup-ghostty.js",
     "update": "npm install && npm run setup && npm run setup:ghostty",
-    "test": "npm test -w server"
+    "test": "npm test --prefix server"
   },
   "devDependencies": {
     "pm2": "^6.0.14"

--- a/setup.ps1
+++ b/setup.ps1
@@ -24,12 +24,11 @@ if ($majorVersion -lt 18) {
 Write-Host "Found Node.js v$nodeVersion" -ForegroundColor Green
 
 # Install dependencies
-# Note: Using --install-links to copy instead of symlink (required for exFAT filesystems)
 Write-Host ""
 Write-Host "Installing dependencies..." -ForegroundColor Yellow
 
 Write-Host "  Installing root dependencies..."
-npm install --install-links
+npm install
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "  Installing client dependencies..."

--- a/update.ps1
+++ b/update.ps1
@@ -16,18 +16,16 @@ Write-Host ""
 Write-Host "Updating dependencies..." -ForegroundColor Yellow
 
 Write-Host "  Installing root dependencies..."
-# Clean stale workspace copies that block npm install (Windows EISDIR fix).
-# .npmrc sets install-links=true (exFAT compat) so npm copies workspace packages
-# as real dirs; on re-runs npm fails to overwrite them. Remove stale copies first.
+# Clean stale workspace symlinks/copies left from prior workspaces config
 $repoNodeModules = Join-Path -Path $PSScriptRoot -ChildPath "node_modules"
 @("portos-server", "portos-client") | ForEach-Object {
     $wsPath = Join-Path -Path $repoNodeModules -ChildPath $_
-    if ((Test-Path $wsPath) -and -not ((Get-Item $wsPath).Attributes -band [IO.FileAttributes]::ReparsePoint)) {
+    if (Test-Path $wsPath) {
         Remove-Item $wsPath -Recurse -Force
         Write-Host "    Cleaned stale $wsPath"
     }
 }
-npm install --install-links
+npm install
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 Write-Host "  Installing client dependencies..."


### PR DESCRIPTION
## Summary

- Removed `workspaces` field from root `package.json` — npm workspaces always create symlinks which fail on Windows/exFAT with `EISDIR`. This was already fixed in v1.4.3 but workspaces were re-added at some point
- Replaced `-w client`/`-w server` workspace flags with `--prefix` equivalents for `build` and `test` scripts
- Removed `.npmrc` (`install-links=true`) and `--install-links` flags from `setup.ps1`/`update.ps1` — these were workarounds that didn't actually prevent the workspace symlink issue
- Simplified `update.ps1` cleanup to remove any stale workspace symlinks/copies unconditionally

## Test plan

- [ ] Run `.\update.ps1` on Windows — should complete without EISDIR errors
- [ ] Run `.\setup.ps1` on a fresh clone — should install all deps successfully
- [ ] Run `npm run build` from root — should build client via `--prefix`
- [ ] Run `npm test` from root — should run server tests via `--prefix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)