### PR TITLE
Add resilient dependency installation with retry logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.27.4",
+      "version": "1.27.5",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.27.0",
+  "version": "1.27.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.27.0",
+      "version": "1.27.3",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.27.4",
+  "version": "1.27.5",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.27.2",
+  "version": "1.27.3",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "node scripts/dev-start.js",
     "dev:stop": "node ./node_modules/pm2/bin/pm2 stop ecosystem.config.cjs",
     "build": "npm run build --prefix client",
-    "start": "npm run build && node scripts/setup-db.js && (node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent || echo pm2 delete skipped) && node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs && node ./node_modules/pm2/bin/pm2 save",
+    "start": "node scripts/ensure-deps.js && npm run build && node scripts/setup-db.js && (node ./node_modules/pm2/bin/pm2 delete ecosystem.config.cjs --silent || echo pm2 delete skipped) && node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs && node ./node_modules/pm2/bin/pm2 save",
     "pm2:start": "node ./node_modules/pm2/bin/pm2 start ecosystem.config.cjs",
     "pm2:stop": "node ./node_modules/pm2/bin/pm2 stop ecosystem.config.cjs",
     "pm2:restart": "node ./node_modules/pm2/bin/pm2 restart ecosystem.config.cjs",
@@ -25,7 +25,7 @@
     "setup:db": "node scripts/setup-db.js",
     "setup:browser": "node scripts/setup-browser.js",
     "setup:ghostty": "node scripts/setup-ghostty.js",
-    "update": "npm install && npm install --prefix client && npm install --prefix server && npm run setup && npm run setup:ghostty",
+    "update": "bash update.sh",
     "test": "npm test --prefix server"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",
@@ -25,7 +25,7 @@
     "setup:db": "node scripts/setup-db.js",
     "setup:browser": "node scripts/setup-browser.js",
     "setup:ghostty": "node scripts/setup-ghostty.js",
-    "update": "bash update.sh",
+    "update": "node -e \"const{spawnSync:s}=require('child_process');const w=process.platform==='win32';const r=s(w?'powershell':'bash',w?['-File','update.ps1']:['update.sh'],{stdio:'inherit'});process.exit(r.status??1)\"",
     "test": "npm test --prefix server"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.27.3",
+  "version": "1.27.4",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.27.1",
+  "version": "1.27.2",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/scripts/dev-start.js
+++ b/scripts/dev-start.js
@@ -22,6 +22,12 @@ function pm2(...args) {
   });
 }
 
+// Ensure dependencies are installed (handles missing node_modules, ENOTEMPTY retries)
+execFileSync(process.execPath, [join(__dirname, 'ensure-deps.js')], {
+  stdio: 'inherit',
+  windowsHide: true
+});
+
 // Ensure PostgreSQL is running (gracefully skips if Docker unavailable)
 execFileSync(process.execPath, [join(__dirname, 'setup-db.js')], {
   stdio: 'inherit',

--- a/scripts/dev-start.js
+++ b/scripts/dev-start.js
@@ -12,8 +12,16 @@ import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const PM2 = join(dirname(require.resolve('pm2/package.json')), 'bin', 'pm2');
 const ECO = 'ecosystem.config.cjs';
+
+// Ensure dependencies are installed BEFORE resolving pm2 path
+// (pm2 lives in node_modules — require.resolve fails if deps are missing)
+execFileSync(process.execPath, [join(__dirname, 'ensure-deps.js')], {
+  stdio: 'inherit',
+  windowsHide: true
+});
+
+const PM2 = join(dirname(require.resolve('pm2/package.json')), 'bin', 'pm2');
 
 function pm2(...args) {
   execFileSync(process.execPath, [PM2, ...args], {
@@ -21,12 +29,6 @@ function pm2(...args) {
     windowsHide: true
   });
 }
-
-// Ensure dependencies are installed (handles missing node_modules, ENOTEMPTY retries)
-execFileSync(process.execPath, [join(__dirname, 'ensure-deps.js')], {
-  stdio: 'inherit',
-  windowsHide: true
-});
 
 // Ensure PostgreSQL is running (gracefully skips if Docker unavailable)
 execFileSync(process.execPath, [join(__dirname, 'setup-db.js')], {

--- a/scripts/ensure-deps.js
+++ b/scripts/ensure-deps.js
@@ -1,0 +1,53 @@
+/**
+ * Ensures all workspace dependencies are installed before starting.
+ * Runs npm install only for workspaces with missing node_modules.
+ * Handles ENOTEMPTY npm bug by retrying with clean node_modules.
+ */
+import { existsSync, rmSync } from 'fs';
+import { execSync } from 'child_process';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+const WORKSPACES = [
+  { dir: ROOT, label: 'root' },
+  { dir: join(ROOT, 'client'), label: 'client' },
+  { dir: join(ROOT, 'server'), label: 'server' }
+];
+
+function install(dir, label) {
+  try {
+    execSync('npm install', { cwd: dir, stdio: 'inherit' });
+    return true;
+  } catch {
+    console.log(`⚠️  npm install failed for ${label} — cleaning node_modules and retrying...`);
+    rmSync(join(dir, 'node_modules'), { recursive: true, force: true });
+    try {
+      execSync('npm install', { cwd: dir, stdio: 'inherit' });
+      return true;
+    } catch {
+      console.error(`❌ npm install failed for ${label} after retry`);
+      return false;
+    }
+  }
+}
+
+let needed = false;
+for (const { dir, label } of WORKSPACES) {
+  if (!existsSync(join(dir, 'node_modules'))) {
+    console.log(`📦 Missing node_modules for ${label} — installing...`);
+    if (!install(dir, label)) process.exit(1);
+    needed = true;
+  }
+}
+
+// Verify critical binary exists even if node_modules dirs were present
+const vitePath = join(ROOT, 'client', 'node_modules', 'vite', 'bin', 'vite.js');
+if (!existsSync(vitePath)) {
+  console.log('📦 Vite not found — reinstalling client deps...');
+  if (!install(join(ROOT, 'client'), 'client')) process.exit(1);
+  needed = true;
+}
+
+if (needed) console.log('✅ Dependencies verified');

--- a/scripts/ensure-deps.js
+++ b/scripts/ensure-deps.js
@@ -4,11 +4,12 @@
  * Handles ENOTEMPTY npm bug by retrying with clean node_modules.
  */
 import { existsSync, rmSync } from 'fs';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
 const WORKSPACES = [
   { dir: ROOT, label: 'root' },
@@ -18,13 +19,13 @@ const WORKSPACES = [
 
 function install(dir, label) {
   try {
-    execSync('npm install', { cwd: dir, stdio: 'inherit' });
+    execFileSync(NPM, ['install'], { cwd: dir, stdio: 'inherit', windowsHide: true });
     return true;
   } catch {
     console.log(`⚠️  npm install failed for ${label} — cleaning node_modules and retrying...`);
     rmSync(join(dir, 'node_modules'), { recursive: true, force: true });
     try {
-      execSync('npm install', { cwd: dir, stdio: 'inherit' });
+      execFileSync(NPM, ['install'], { cwd: dir, stdio: 'inherit', windowsHide: true });
       return true;
     } catch {
       console.error(`❌ npm install failed for ${label} after retry`);

--- a/scripts/ensure-deps.js
+++ b/scripts/ensure-deps.js
@@ -42,12 +42,19 @@ for (const { dir, label } of WORKSPACES) {
   }
 }
 
-// Verify critical binary exists even if node_modules dirs were present
-const vitePath = join(ROOT, 'client', 'node_modules', 'vite', 'bin', 'vite.js');
-if (!existsSync(vitePath)) {
-  console.log('📦 Vite not found — reinstalling client deps...');
-  if (!install(join(ROOT, 'client'), 'client')) process.exit(1);
-  needed = true;
+// Verify critical packages exist even if node_modules dirs were present
+const criticalPackages = [
+  { dir: join(ROOT, 'client'), label: 'client', pkg: 'vite/bin/vite.js' },
+  { dir: join(ROOT, 'server'), label: 'server', pkg: 'express/package.json' },
+  { dir: join(ROOT, 'server'), label: 'server', pkg: 'pg/package.json' },
+];
+
+for (const { dir, label, pkg } of criticalPackages) {
+  if (!existsSync(join(dir, 'node_modules', pkg))) {
+    console.log(`📦 Missing ${pkg.split('/')[0]} in ${label} — reinstalling deps...`);
+    if (!install(dir, label)) process.exit(1);
+    needed = true;
+  }
 }
 
 if (needed) console.log('✅ Dependencies verified');

--- a/scripts/ensure-deps.js
+++ b/scripts/ensure-deps.js
@@ -49,6 +49,7 @@ for (const { dir, label } of WORKSPACES) {
 }
 
 // Verify critical packages exist even if node_modules dirs were present
+// Grouped by workspace to avoid redundant installs
 const criticalPackages = [
   { dir: ROOT, label: 'root', pkg: 'pm2/package.json' },
   { dir: join(ROOT, 'client'), label: 'client', pkg: 'vite/bin/vite.js' },
@@ -56,11 +57,24 @@ const criticalPackages = [
   { dir: join(ROOT, 'server'), label: 'server', pkg: 'pg/package.json' },
 ];
 
+const criticalByDir = new Map();
 for (const { dir, label, pkg } of criticalPackages) {
-  if (!existsSync(join(dir, 'node_modules', pkg))) {
-    console.log(`📦 Missing ${pkg.split('/')[0]} in ${label} — reinstalling deps...`);
-    if (!install(dir, label)) process.exit(1);
-    needed = true;
+  if (!criticalByDir.has(dir)) criticalByDir.set(dir, { label, pkgs: [] });
+  criticalByDir.get(dir).pkgs.push(pkg);
+}
+
+for (const [dir, { label, pkgs }] of criticalByDir) {
+  const missing = pkgs.filter(pkg => !existsSync(join(dir, 'node_modules', pkg)));
+  if (!missing.length) continue;
+
+  console.log(`📦 Missing ${missing.map(p => p.split('/')[0]).join(', ')} in ${label} — reinstalling deps...`);
+  if (!install(dir, label)) process.exit(1);
+  needed = true;
+
+  const stillMissing = pkgs.filter(pkg => !existsSync(join(dir, 'node_modules', pkg)));
+  if (stillMissing.length) {
+    console.error(`❌ Still missing in ${label} after reinstall: ${stillMissing.map(p => p.split('/')[0]).join(', ')}`);
+    process.exit(1);
   }
 }
 

--- a/scripts/ensure-deps.js
+++ b/scripts/ensure-deps.js
@@ -23,7 +23,12 @@ function install(dir, label) {
     return true;
   } catch {
     console.log(`⚠️  npm install failed for ${label} — cleaning node_modules and retrying...`);
-    rmSync(join(dir, 'node_modules'), { recursive: true, force: true });
+    try {
+      rmSync(join(dir, 'node_modules'), { recursive: true, force: true });
+    } catch (cleanupErr) {
+      console.error(`❌ Failed to clean node_modules for ${label}: ${cleanupErr.message}`);
+      return false;
+    }
     try {
       execFileSync(NPM, ['install'], { cwd: dir, stdio: 'inherit', windowsHide: true });
       return true;
@@ -45,6 +50,7 @@ for (const { dir, label } of WORKSPACES) {
 
 // Verify critical packages exist even if node_modules dirs were present
 const criticalPackages = [
+  { dir: ROOT, label: 'root', pkg: 'pm2/package.json' },
   { dir: join(ROOT, 'client'), label: 'client', pkg: 'vite/bin/vite.js' },
   { dir: join(ROOT, 'server'), label: 'server', pkg: 'express/package.json' },
   { dir: join(ROOT, 'server'), label: 'server', pkg: 'pg/package.json' },

--- a/scripts/ensure-deps.js
+++ b/scripts/ensure-deps.js
@@ -64,14 +64,14 @@ for (const { dir, label, pkg } of criticalPackages) {
 }
 
 for (const [dir, { label, pkgs }] of criticalByDir) {
-  const missing = pkgs.filter(pkg => !existsSync(join(dir, 'node_modules', pkg)));
+  const missing = pkgs.filter(pkg => !existsSync(join(dir, 'node_modules', ...pkg.split('/'))));
   if (!missing.length) continue;
 
   console.log(`📦 Missing ${missing.map(p => p.split('/')[0]).join(', ')} in ${label} — reinstalling deps...`);
   if (!install(dir, label)) process.exit(1);
   needed = true;
 
-  const stillMissing = pkgs.filter(pkg => !existsSync(join(dir, 'node_modules', pkg)));
+  const stillMissing = pkgs.filter(pkg => !existsSync(join(dir, 'node_modules', ...pkg.split('/'))));
   if (stillMissing.length) {
     console.error(`❌ Still missing in ${label} after reinstall: ${stillMissing.map(p => p.split('/')[0]).join(', ')}`);
     process.exit(1);

--- a/update.ps1
+++ b/update.ps1
@@ -6,6 +6,29 @@ Write-Host "  PortOS Update" -ForegroundColor Cyan
 Write-Host "===================================" -ForegroundColor Cyan
 Write-Host ""
 
+# Resilient npm install — retries once after cleaning node_modules on failure
+function Safe-Install {
+    param([string]$Dir = ".", [string]$Label = "root")
+
+    Write-Host "📦 Installing deps ($Label)..." -ForegroundColor Yellow
+    Push-Location $Dir
+    npm install 2>&1
+    if ($LASTEXITCODE -eq 0) { Pop-Location; return }
+
+    Write-Host "⚠️  npm install failed for $Label — cleaning node_modules and retrying..." -ForegroundColor Yellow
+    Pop-Location
+    if (Test-Path "$Dir/node_modules") {
+        Remove-Item -Recurse -Force "$Dir/node_modules" -ErrorAction SilentlyContinue
+    }
+    Push-Location $Dir
+    npm install 2>&1
+    if ($LASTEXITCODE -eq 0) { Pop-Location; return }
+
+    Pop-Location
+    Write-Host "❌ npm install failed for $Label after retry" -ForegroundColor Red
+    exit 1
+}
+
 # Pull latest
 Write-Host "Pulling latest changes..." -ForegroundColor Yellow
 git pull --rebase --autostash
@@ -17,25 +40,19 @@ Write-Host "Stopping PortOS apps..." -ForegroundColor Yellow
 npm run pm2:stop 2>$null
 Write-Host ""
 
-# Update dependencies
+# Update dependencies with retry logic
 Write-Host "Updating dependencies..." -ForegroundColor Yellow
-
-Write-Host "  Installing root dependencies..."
-npm install
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-
-Write-Host "  Installing client dependencies..."
-Push-Location client
-npm install
-if ($LASTEXITCODE -ne 0) { Pop-Location; exit $LASTEXITCODE }
-Pop-Location
-
-Write-Host "  Installing server dependencies..."
-Push-Location server
-npm install
-if ($LASTEXITCODE -ne 0) { Pop-Location; exit $LASTEXITCODE }
-Pop-Location
+Safe-Install -Dir "." -Label "root"
+Safe-Install -Dir "client" -Label "client"
+Safe-Install -Dir "server" -Label "server"
 Write-Host ""
+
+# Verify critical dependencies exist
+if (-not (Test-Path "client/node_modules/vite/bin/vite.js")) {
+    Write-Host "❌ Critical dependency missing: client/node_modules/vite" -ForegroundColor Red
+    Write-Host "   Try running: npm run install:all"
+    exit 1
+}
 
 # Run setup (data dirs + browser deps)
 Write-Host "Ensuring data & browser setup..." -ForegroundColor Yellow
@@ -54,6 +71,6 @@ if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 Write-Host ""
 
 Write-Host "===================================" -ForegroundColor Green
-Write-Host "  Update Complete!" -ForegroundColor Green
+Write-Host "  ✅ Update Complete!" -ForegroundColor Green
 Write-Host "===================================" -ForegroundColor Green
 Write-Host ""

--- a/update.sh
+++ b/update.sh
@@ -6,6 +6,28 @@ echo "  PortOS Update"
 echo "==================================="
 echo ""
 
+# Resilient npm install — retries once after cleaning node_modules on failure
+# Handles ENOTEMPTY and other transient npm bugs
+safe_install() {
+  local dir="${1:-.}"
+  local label="${dir}"
+  [ "$dir" = "." ] && label="root"
+
+  echo "📦 Installing deps ($label)..."
+  if (cd "$dir" && npm install 2>&1); then
+    return 0
+  fi
+
+  echo "⚠️  npm install failed for $label — cleaning node_modules and retrying..."
+  rm -rf "$dir/node_modules"
+  if (cd "$dir" && npm install 2>&1); then
+    return 0
+  fi
+
+  echo "❌ npm install failed for $label after retry"
+  return 1
+}
+
 # Pull latest
 echo "Pulling latest changes..."
 git pull --rebase --autostash
@@ -16,12 +38,19 @@ echo "Stopping PortOS apps..."
 npm run pm2:stop 2>/dev/null || true
 echo ""
 
-# Update dependencies
+# Update dependencies with retry logic
 echo "Updating dependencies..."
-npm install
-(cd client && npm install)
-(cd server && npm install)
+safe_install .
+safe_install client
+safe_install server
 echo ""
+
+# Verify critical dependencies exist
+if [ ! -f "client/node_modules/vite/bin/vite.js" ]; then
+  echo "❌ Critical dependency missing: client/node_modules/vite"
+  echo "   Try running: npm run install:all"
+  exit 1
+fi
 
 # Run setup (data dirs + browser deps)
 echo "Ensuring data & browser setup..."
@@ -38,6 +67,6 @@ npm run pm2:restart
 echo ""
 
 echo "==================================="
-echo "  Update Complete!"
+echo "  ✅ Update Complete!"
 echo "==================================="
 echo ""


### PR DESCRIPTION
## Summary
- **`update.sh`**: Added `safe_install()` function that retries `npm install` after cleaning `node_modules` on failure, handling the npm ENOTEMPTY bug and other transient install failures
- **`scripts/ensure-deps.js`**: New prestart check that verifies `node_modules` dirs and the vite binary exist, installing only when missing — zero overhead on normal starts, with the same retry-on-failure logic
- **`package.json`**: `start` and `dev` flows now run `ensure-deps.js` before PM2 launch; `update` script delegates to `update.sh` instead of duplicating inline commands

## Problem
Two issues during upgrades:
1. `npm install` fails with `ENOTEMPTY: directory not empty, rename .../node_modules/debug` — a known npm bug
2. PM2 can't find `client/node_modules/vite/bin/vite.js` when client deps are missing after a failed or partial install

## Test plan
- [ ] Run `./update.sh` on a clean checkout — all deps install on first try
- [ ] Delete `client/node_modules` then run `npm start` — ensure-deps.js reinstalls before PM2 launch
- [ ] Delete `client/node_modules/vite` then run `npm run dev` — vite check triggers reinstall
- [ ] Simulate ENOTEMPTY by corrupting a node_modules dir, verify retry succeeds