### PR TITLE
Fix federation probe, sanitize peer names, add version tracking

### DIFF
--- a/client/src/pages/Instances.jsx
+++ b/client/src/pages/Instances.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   Network, Plus, Trash2, RefreshCw, Edit3, Check, X,
   Wifi, WifiOff, CircleDot,
-  Cpu, HardDrive, Activity, Bot, MonitorSmartphone,
+  Cpu, HardDrive, Activity, Bot, MonitorSmartphone, Tag,
   ArrowUpRight, ArrowDownLeft, ArrowLeftRight
 } from 'lucide-react';
 import toast from 'react-hot-toast';
@@ -46,10 +46,16 @@ function timeAgo(iso) {
   return `${Math.floor(hrs / 24)}d ago`;
 }
 
-function HealthSummary({ health }) {
+function HealthSummary({ health, version }) {
   if (!health) return <span className="text-gray-500 text-xs">No data</span>;
   return (
     <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+      {version && (
+        <div className="flex items-center gap-1.5 text-gray-400 col-span-2">
+          <Tag size={12} />
+          <span>v{version}</span>
+        </div>
+      )}
       <div className="flex items-center gap-1.5 text-gray-400">
         <HardDrive size={12} />
         <span>Mem {health.system?.memory?.usagePercent ?? '?'}%</span>
@@ -347,7 +353,7 @@ function PeerCard({ peer, onRefresh }) {
         )}
       </div>
 
-      <HealthSummary health={peer.lastHealth} />
+      <HealthSummary health={peer.lastHealth} version={peer.version} />
 
       <div className="mt-2 text-xs text-gray-600">
         Last seen: {timeAgo(peer.lastSeen)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.27.0",
+      "version": "1.27.1",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/server/routes/health.test.js
+++ b/server/routes/health.test.js
@@ -1,7 +1,23 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import express from 'express';
 import request from 'supertest';
 import systemHealthRoutes from './systemHealth.js';
+
+vi.mock('../services/pm2.js', () => ({
+  listProcesses: vi.fn().mockResolvedValue([])
+}));
+
+vi.mock('../services/apps.js', () => ({
+  getAllApps: vi.fn().mockResolvedValue([])
+}));
+
+vi.mock('../services/cos.js', () => ({
+  getStatus: vi.fn().mockResolvedValue(null)
+}));
+
+vi.mock('../lib/db.js', () => ({
+  checkHealth: vi.fn().mockResolvedValue({ connected: false, hasSchema: false })
+}));
 
 describe('System Health Routes', () => {
   const app = express();

--- a/server/routes/health.test.js
+++ b/server/routes/health.test.js
@@ -14,4 +14,14 @@ describe('System Health Routes', () => {
     expect(response.body.status).toBe('ok');
     expect(response.body.version).toBeDefined();
   });
+
+  it('should return health details with version', async () => {
+    const response = await request(app).get('/api/system/health/details');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toHaveProperty('version');
+    expect(response.body).toHaveProperty('system');
+    expect(response.body).toHaveProperty('apps');
+    expect(response.body).toHaveProperty('overallHealth');
+  });
 });

--- a/server/routes/systemHealth.js
+++ b/server/routes/systemHealth.js
@@ -32,12 +32,13 @@ router.get('/health/details', async (req, res) => {
   const startTime = Date.now();
 
   // Gather data in parallel
-  const [pm2Processes, allApps, cosStatus, self, dbHealth] = await Promise.all([
+  const [pm2Processes, allApps, cosStatus, self, dbHealth, version] = await Promise.all([
     listProcesses().catch(() => []),
     apps.getAllApps({ includeArchived: false }).catch(() => []),
     cos.getStatus().catch(() => null),
     getSelf().catch(() => null),
-    checkHealth().catch(() => ({ connected: false, hasSchema: false, error: 'Health check failed' }))
+    checkHealth().catch(() => ({ connected: false, hasSchema: false, error: 'Health check failed' })),
+    getCurrentVersion().catch(() => null)
   ]);
 
   // System metrics
@@ -139,6 +140,7 @@ router.get('/health/details', async (req, res) => {
     timestamp: new Date().toISOString(),
     hostname: os.hostname(),
     instanceId: self?.instanceId ?? null,
+    version,
     overallHealth,
     warnings,
     system: {

--- a/server/services/instances.js
+++ b/server/services/instances.js
@@ -86,13 +86,20 @@ export async function getPeers() {
   return data.peers;
 }
 
+function validName(name, fallback) {
+  if (!name || typeof name !== 'string') return fallback;
+  const lower = name.trim().toLowerCase();
+  if (['undefined', 'nan', 'null', ''].includes(lower)) return fallback;
+  return name.trim();
+}
+
 export async function addPeer({ address, port = DEFAULT_PEER_PORT, name }) {
   const peer = await withData(async (data) => {
     const entry = {
       id: crypto.randomUUID(),
       address,
       port,
-      name: name || address,
+      name: validName(name, address),
       instanceId: null,
       addedAt: new Date().toISOString(),
       lastSeen: null,
@@ -138,24 +145,26 @@ export async function updatePeer(id, updates) {
 // --- Probing ---
 
 export async function probePeer(peer) {
-  const url = `http://${peer.address}:${peer.port}/api/health/system`;
+  const baseUrl = `http://${peer.address}:${peer.port}`;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
 
   const previousStatus = peer.status;
-  let status, lastHealth, lastSeen, remoteInstanceId, remoteApps;
+  let status, lastHealth, lastSeen, remoteInstanceId, remoteVersion, remoteApps;
   try {
-    const res = await fetch(url, { signal: controller.signal });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    const json = await res.json();
+    // Fetch health details and apps in parallel
+    const [healthRes, appsRes] = await Promise.all([
+      fetch(`${baseUrl}/api/system/health/details`, { signal: controller.signal }),
+      fetch(`${baseUrl}/api/apps`, { signal: controller.signal }).catch(() => null)
+    ]);
+    if (!healthRes.ok) throw new Error(`HTTP ${healthRes.status}`);
+    const json = await healthRes.json();
     status = 'online';
     lastHealth = json;
     lastSeen = new Date().toISOString();
     remoteInstanceId = json.instanceId ?? null;
+    remoteVersion = json.version ?? null;
 
-    // Fetch apps from the peer (piggybacks on probe cycle)
-    const appsUrl = `http://${peer.address}:${peer.port}/api/apps`;
-    const appsRes = await fetch(appsUrl, { signal: controller.signal }).catch(() => null);
     if (appsRes?.ok) {
       const appsJson = await appsRes.json().catch(() => null);
       const appsList = Array.isArray(appsJson) ? appsJson : appsJson?.apps;
@@ -180,6 +189,12 @@ export async function probePeer(peer) {
     entry.lastHealth = lastHealth;
     entry.lastApps = remoteApps ?? entry.lastApps ?? null;
     if (remoteInstanceId) entry.instanceId = remoteInstanceId;
+    if (remoteVersion) entry.version = remoteVersion;
+    // Auto-update name from hostname if current name is just an IP address
+    const remoteHostname = lastHealth?.hostname;
+    if (remoteHostname && /^\d+\.\d+\.\d+\.\d+$/.test(entry.name)) {
+      entry.name = remoteHostname;
+    }
     return entry;
   });
 
@@ -248,7 +263,8 @@ export async function handleAnnounce({ address, port, instanceId, name }) {
       existing.status = 'online';
       existing.instanceId = instanceId;
       existing.port = port;
-      if (name) existing.name = name;
+      const sanitized = validName(name, null);
+      if (sanitized) existing.name = sanitized;
       // Mark that this peer has announced to us (inbound connection)
       existing.directions = existing.directions || [];
       if (!existing.directions.includes('inbound')) existing.directions.push('inbound');
@@ -262,7 +278,7 @@ export async function handleAnnounce({ address, port, instanceId, name }) {
       id: crypto.randomUUID(),
       address,
       port,
-      name: name || address,
+      name: validName(name, address),
       instanceId,
       addedAt: new Date().toISOString(),
       lastSeen: new Date().toISOString(),

--- a/server/services/instances.js
+++ b/server/services/instances.js
@@ -135,7 +135,7 @@ export async function updatePeer(id, updates) {
   return withData(async (data) => {
     const peer = data.peers.find(p => p.id === id);
     if (!peer) return null;
-    if (updates.name !== undefined) peer.name = updates.name;
+    if (updates.name !== undefined) peer.name = validName(updates.name, peer.name);
     if (updates.enabled !== undefined) peer.enabled = updates.enabled;
     instanceEvents.emit('peers:updated', data.peers);
     return peer;
@@ -191,7 +191,7 @@ export async function probePeer(peer) {
     if (remoteInstanceId) entry.instanceId = remoteInstanceId;
     if (remoteVersion) entry.version = remoteVersion;
     // Auto-update name from hostname if current name is just an IP address
-    const remoteHostname = lastHealth?.hostname;
+    const remoteHostname = validName(lastHealth?.hostname, null);
     if (remoteHostname && /^\d+\.\d+\.\d+\.\d+$/.test(entry.name)) {
       entry.name = remoteHostname;
     }

--- a/server/services/instances.js
+++ b/server/services/instances.js
@@ -189,7 +189,7 @@ export async function probePeer(peer) {
     entry.lastHealth = lastHealth;
     entry.lastApps = remoteApps ?? entry.lastApps ?? null;
     if (remoteInstanceId) entry.instanceId = remoteInstanceId;
-    if (remoteVersion) entry.version = remoteVersion;
+    if (status === 'online') entry.version = remoteVersion;
     // Auto-update name from hostname if current name is just an IP address
     const remoteHostname = validName(lastHealth?.hostname, null);
     if (remoteHostname && /^\d+\.\d+\.\d+\.\d+$/.test(entry.name)) {


### PR DESCRIPTION
## Summary
- **Fix probe endpoint**: Changed from `/api/health/system` (404) to `/api/system/health/details`, which returns the system metrics (memory, CPU, uptime, apps, CoS) the UI expects. This was the root cause of peers showing as disconnected despite being online.
- **Sanitize peer names**: Added `validName()` guard that rejects string literals `"undefined"`, `"NaN"`, `"null"` — these were passing the `||` fallback because truthy strings. Applied to all name assignment paths (addPeer, handleAnnounce create/update).
- **Auto-name from hostname**: When probing succeeds and the peer's current name is just an IP address, auto-update from the health response's hostname field.
- **Version tracking**: Added `version` to `/api/system/health/details` response, extract and store it during probe, display in the Instances UI with a tag icon so outdated peers are visible.
- **Parallel fetch**: Health and apps requests now run in parallel during each probe cycle instead of sequentially.

## Test plan
- [x] All 1311 server tests pass
- [x] Client builds successfully
- [ ] Verify peers show as online with health metrics after restart
- [ ] Verify version displays on peer cards
- [ ] Verify new peers added with no name get the IP address (not "undefined")
- [ ] Verify peer name auto-updates from hostname on first successful probe