### PR TITLE
Release v1.28.0

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,0 @@
-# Unreleased Changes
-
-## Changed
-
-- Inject app version from root package.json at build time via Vite `define`, replacing stale client package.json import

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased Changes
+
+## Changed
+
+- Inject app version from root package.json at build time via Vite `define`, replacing stale client package.json import

--- a/.changelog/v1.28.0.md
+++ b/.changelog/v1.28.0.md
@@ -1,0 +1,39 @@
+# Release v1.28.0
+
+Released: 2026-03-04
+
+## Features
+
+- **CoS**: Add screenshot upload to resume task modal
+- **Git**: Add Push button to push all branches with unpushed commits
+- **Shell**: Persist sessions across page navigations with session switcher
+- **Shell**: Improve session management with always-visible controls
+- **Shell**: Add quick command buttons and app folder cd selector
+- **Dashboard**: Link app card names to individual app detail pages
+
+## Fixes
+
+- **UI**: Inject root package.json version into client build via Vite define
+- **UI**: Inline delete for history/runs instead of full page reload
+- **Agents**: Fix opus model ID for Bedrock and inject settings.json env vars
+- **Agents**: Respect user's Claude CLI provider config in buildCliSpawnConfig
+- **Agents**: Filter macOS app bundles from agent process list
+- **Shell**: Handle socket disconnect to prevent stuck session attach
+- **Shell**: Use managed apps list instead of scaffold directories for cd selector
+- **SPA**: Prevent MIME type error on stale lazy-loaded chunks
+- **CoS**: Reset orphaned system tasks, not just user tasks
+- **CoS**: Make hover-only buttons visible on mobile touch devices
+- **CoS**: Prevent duplicate task submissions from rapid taps
+- **CoS**: Prevent agent output markdown from overflowing on mobile
+- **Apps**: Make app detail button header more compact on mobile
+- **Git**: Update all tracked branches instead of hardcoded dev/main
+- **Providers**: Use provider model IDs instead of hardcoded values in thinkingLevels
+
+## Style
+
+- **Shell**: Make page header responsive on mobile
+- **Meatspace**: Make alcohol daily consumption widget mobile-friendly
+
+## Full Changelog
+
+**Full Diff**: https://github.com/atomantic/PortOS/compare/v1.27.5...v1.28.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ When CoS agents or AI tools work on managed apps outside PortOS, all research, p
 - **Command allowlist** - shell execution restricted to approved commands only
 - **No hardcoded localhost** - use `window.location.hostname` for URLs; app accessed via Tailscale remotely
 - **Alphabetical navigation** - sidebar nav items in `Layout.jsx` are alphabetically ordered after the Dashboard+CyberCity top section and separator; children within collapsible sections are also alphabetical
+- **Reactive UI updates** - after mutations (delete, create, update), update local state directly instead of refetching the entire list from the server. Use `setState(prev => prev.filter(...))` or similar patterns for immediate feedback
 - **Single-line logging** - use emoji prefixes and string interpolation, never log full JSON blobs or arrays
   ```js
   console.log(`🚀 Server started on port ${PORT}`);

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -22,11 +22,16 @@ import Instances from './pages/Instances';
 import MeatSpace from './pages/MeatSpace';
 
 // Auto-reload on stale chunk errors (e.g., after a rebuild changes chunk hashes)
+// Uses sessionStorage to prevent infinite reload loops (max 1 reload per session)
 const lazyWithReload = (importFn) => lazy(() =>
   importFn().catch(err => {
     if (err.message?.includes('MIME type') || err.message?.includes('Failed to fetch dynamically imported module')) {
-      window.location.reload();
-      return new Promise(() => {}); // hang until reload completes
+      const key = 'lazyReloadAttempted';
+      if (!sessionStorage.getItem(key)) {
+        sessionStorage.setItem(key, '1');
+        window.location.reload();
+        return new Promise(() => {}); // hang until reload completes
+      }
     }
     throw err;
   })

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -21,18 +21,29 @@ import Insights from './pages/Insights';
 import Instances from './pages/Instances';
 import MeatSpace from './pages/MeatSpace';
 
+// Auto-reload on stale chunk errors (e.g., after a rebuild changes chunk hashes)
+const lazyWithReload = (importFn) => lazy(() =>
+  importFn().catch(err => {
+    if (err.message?.includes('MIME type') || err.message?.includes('Failed to fetch dynamically imported module')) {
+      window.location.reload();
+      return new Promise(() => {}); // hang until reload completes
+    }
+    throw err;
+  })
+);
+
 // Lazy load heavier pages for code splitting
 // DevTools pages are large (~2300 lines total) so lazy load them
-const AIProviders = lazy(() => import('./pages/AIProviders'));
-const HistoryPage = lazy(() => import('./pages/DevTools').then(m => ({ default: m.HistoryPage })));
-const RunsHistoryPage = lazy(() => import('./pages/DevTools').then(m => ({ default: m.RunsHistoryPage })));
-const RunnerPage = lazy(() => import('./pages/DevTools').then(m => ({ default: m.RunnerPage })));
-const UsagePage = lazy(() => import('./pages/DevTools').then(m => ({ default: m.UsagePage })));
-const ProcessesPage = lazy(() => import('./pages/DevTools').then(m => ({ default: m.ProcessesPage })));
-const AgentsPage = lazy(() => import('./pages/DevTools').then(m => ({ default: m.AgentsPage })));
-const GitHub = lazy(() => import('./pages/GitHub'));
-const CyberCity = lazy(() => import('./pages/CyberCity'));
-const AppDetail = lazy(() => import('./pages/AppDetail'));
+const AIProviders = lazyWithReload(() => import('./pages/AIProviders'));
+const HistoryPage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.HistoryPage })));
+const RunsHistoryPage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.RunsHistoryPage })));
+const RunnerPage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.RunnerPage })));
+const UsagePage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.UsagePage })));
+const ProcessesPage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.ProcessesPage })));
+const AgentsPage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.AgentsPage })));
+const GitHub = lazyWithReload(() => import('./pages/GitHub'));
+const CyberCity = lazyWithReload(() => import('./pages/CyberCity'));
+const AppDetail = lazyWithReload(() => import('./pages/AppDetail'));
 
 // Loading fallback for lazy-loaded pages
 const PageLoader = () => (

--- a/client/src/components/AppTile.jsx
+++ b/client/src/components/AppTile.jsx
@@ -1,4 +1,5 @@
 import { useState, memo } from 'react';
+import { Link } from 'react-router-dom';
 import StatusBadge from './StatusBadge';
 import AppIcon from './AppIcon';
 import * as api from '../services/api';
@@ -56,7 +57,11 @@ const AppTile = memo(function AppTile({ app, onUpdate }) {
           </div>
           <div className="min-w-0">
             <div className="flex items-center gap-1.5">
-              <h3 id={`app-title-${app.id}`} className={`text-sm font-semibold truncate ${app.archived ? 'text-gray-500' : 'text-white'}`}>{app.name}</h3>
+              <h3 id={`app-title-${app.id}`} className={`text-sm font-semibold truncate ${app.archived ? 'text-gray-500' : 'text-white'}`}>
+                <Link to={`/apps/${app.id}`} className="hover:text-port-accent transition-colors">
+                  {app.name}
+                </Link>
+              </h3>
               {app.archived && (
                 <span className="px-1 py-0.5 bg-gray-600/30 text-gray-500 text-[10px] rounded shrink-0">Arc</span>
               )}

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -58,7 +58,7 @@ import {
   Shield,
   Zap
 } from 'lucide-react';
-import packageJson from '../../package.json';
+/* global __APP_VERSION__ */
 import Logo from './Logo';
 import { useErrorNotifications } from '../hooks/useErrorNotifications';
 import { useNotifications } from '../hooks/useNotifications';
@@ -547,7 +547,7 @@ export default function Layout() {
         <div className={`p-4 border-t border-port-border ${collapsed ? 'lg:flex lg:justify-center' : ''}`}>
           <div className={`flex items-center ${collapsed ? 'lg:justify-center' : 'justify-between'}`}>
             <span className={`text-sm text-gray-500 ${collapsed ? 'lg:hidden' : ''}`}>
-              v{packageJson.version}
+              v{__APP_VERSION__}
             </span>
             <div className="flex items-center gap-1">
               <ThemeSwitcher />

--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -152,7 +152,7 @@ export default function AppDetailView() {
               </div>
             )}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-1.5">
             {/* Start/Stop/Restart */}
             <div className="inline-flex rounded-lg overflow-hidden border border-port-border">
               {app.overallStatus === 'online' ? (
@@ -160,7 +160,7 @@ export default function AppDetailView() {
                   <button
                     onClick={handleStop}
                     disabled={actionLoading}
-                    className="px-3 py-1.5 bg-port-error/20 text-port-error hover:bg-port-error/30 transition-colors disabled:opacity-50 flex items-center gap-1"
+                    className="px-2 py-1 bg-port-error/20 text-port-error hover:bg-port-error/30 transition-colors disabled:opacity-50 flex items-center gap-1"
                   >
                     <Square size={14} />
                     <span className="text-xs">Stop</span>
@@ -168,7 +168,7 @@ export default function AppDetailView() {
                   <button
                     onClick={handleRestart}
                     disabled={actionLoading}
-                    className="px-3 py-1.5 bg-port-warning/20 text-port-warning hover:bg-port-warning/30 transition-colors disabled:opacity-50 border-l border-port-border flex items-center gap-1"
+                    className="px-2 py-1 bg-port-warning/20 text-port-warning hover:bg-port-warning/30 transition-colors disabled:opacity-50 border-l border-port-border flex items-center gap-1"
                   >
                     <RotateCcw size={14} className={actionLoading === 'restart' ? 'animate-spin' : ''} />
                     <span className="text-xs">Restart</span>
@@ -178,7 +178,7 @@ export default function AppDetailView() {
                 <button
                   onClick={handleStart}
                   disabled={actionLoading}
-                  className="px-3 py-1.5 bg-port-success/20 text-port-success hover:bg-port-success/30 transition-colors disabled:opacity-50 flex items-center gap-1"
+                  className="px-2 py-1 bg-port-success/20 text-port-success hover:bg-port-success/30 transition-colors disabled:opacity-50 flex items-center gap-1"
                 >
                   <Play size={14} />
                   <span className="text-xs">{actionLoading === 'start' ? 'Starting...' : 'Start'}</span>
@@ -189,7 +189,7 @@ export default function AppDetailView() {
             {app.uiPort && app.overallStatus === 'online' && (
               <button
                 onClick={() => window.open(`${window.location.protocol}//${window.location.hostname}:${app.uiPort}`, '_blank')}
-                className="px-3 py-1.5 bg-port-accent/20 text-port-accent hover:bg-port-accent/30 transition-colors rounded-lg border border-port-border flex items-center gap-1"
+                className="px-2 py-1 bg-port-accent/20 text-port-accent hover:bg-port-accent/30 transition-colors rounded-lg border border-port-border flex items-center gap-1"
               >
                 <ExternalLink size={14} />
                 <span className="text-xs">Launch</span>
@@ -198,17 +198,17 @@ export default function AppDetailView() {
             {app.devUiPort && app.overallStatus === 'online' && (
               <button
                 onClick={() => window.open(`${window.location.protocol}//${window.location.hostname}:${app.devUiPort}`, '_blank')}
-                className="px-3 py-1.5 bg-port-warning/20 text-port-warning hover:bg-port-warning/30 transition-colors rounded-lg border border-port-border flex items-center gap-1"
+                className="px-2 py-1 bg-port-warning/20 text-port-warning hover:bg-port-warning/30 transition-colors rounded-lg border border-port-border flex items-center gap-1"
               >
                 <ExternalLink size={14} />
-                <span className="text-xs">Launch Dev</span>
+                <span className="text-xs">Dev UI</span>
               </button>
             )}
             {app.buildCommand && (
               <button
                 onClick={handleBuild}
                 disabled={buildLoading}
-                className="px-3 py-1.5 bg-port-warning/20 text-port-warning hover:bg-port-warning/30 transition-colors rounded-lg border border-port-border flex items-center gap-1 disabled:opacity-50"
+                className="px-2 py-1 bg-port-warning/20 text-port-warning hover:bg-port-warning/30 transition-colors rounded-lg border border-port-border flex items-center gap-1 disabled:opacity-50"
                 aria-label={`Build production UI: ${app.buildCommand}`}
               >
                 <Hammer size={14} className={buildLoading ? 'animate-bounce' : ''} />

--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -91,6 +91,7 @@ export default function GitTab({ appId, appName, repoPath }) {
   const [checkingOut, setCheckingOut] = useState(null);
   const [pushing, setPushing] = useState(null);
   const [syncing, setSyncing] = useState(null);
+  const [pushingAll, setPushingAll] = useState(false);
 
   const loadGitInfo = useCallback(async () => {
     if (!repoPath) return;
@@ -217,6 +218,22 @@ export default function GitTab({ appId, appName, repoPath }) {
     }
   };
 
+  const handlePushAll = async () => {
+    if (!repoPath || pushingAll) return;
+    setPushingAll(true);
+    const result = await api.pushAllBranches(repoPath).catch(() => null);
+    setPushingAll(false);
+    if (result?.success) {
+      toast.success(`Pushed ${result.pushed} branch${result.pushed === 1 ? '' : 'es'}`);
+    } else if (result) {
+      const failedNames = Object.entries(result.results || {})
+        .filter(([, v]) => !v.success)
+        .map(([name]) => name);
+      toast.error(`Push failed for: ${failedNames.join(', ')}`);
+    }
+    await loadGitInfo();
+  };
+
   const getStatusIcon = (file) => {
     if (file.added) return <Plus size={14} className="text-port-success" />;
     if (file.deleted) return <Minus size={14} className="text-port-error" />;
@@ -235,14 +252,26 @@ export default function GitTab({ appId, appName, repoPath }) {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold text-white">Git Status</h2>
-        <button
-          onClick={handleUpdateBranches}
-          disabled={updating}
-          className="flex items-center gap-1.5 px-3 py-2 bg-port-card border border-port-border rounded-lg text-sm text-gray-300 hover:text-white hover:border-port-accent disabled:opacity-50"
-        >
-          <Download size={16} className={updating ? 'animate-bounce' : ''} />
-          {updating ? 'Updating...' : 'Update'}
-        </button>
+        <div className="flex items-center gap-2">
+          {branches.some(b => b.tracking && b.ahead > 0) && (
+            <button
+              onClick={handlePushAll}
+              disabled={pushingAll}
+              className="flex items-center gap-1.5 px-3 py-2 bg-port-card border border-port-border rounded-lg text-sm text-gray-300 hover:text-white hover:border-port-success disabled:opacity-50"
+            >
+              <Upload size={16} className={pushingAll ? 'animate-bounce' : ''} />
+              {pushingAll ? 'Pushing...' : 'Push'}
+            </button>
+          )}
+          <button
+            onClick={handleUpdateBranches}
+            disabled={updating}
+            className="flex items-center gap-1.5 px-3 py-2 bg-port-card border border-port-border rounded-lg text-sm text-gray-300 hover:text-white hover:border-port-accent disabled:opacity-50"
+          >
+            <Download size={16} className={updating ? 'animate-bounce' : ''} />
+            {updating ? 'Updating...' : 'Update'}
+          </button>
+        </div>
       </div>
 
       {loading ? (

--- a/client/src/components/cos/MarkdownOutput.jsx
+++ b/client/src/components/cos/MarkdownOutput.jsx
@@ -12,13 +12,13 @@ const components = {
     // Fenced code block (has language className like "language-js")
     if (className) {
       return (
-        <code className="block bg-port-bg rounded p-2 my-1 text-xs font-mono text-cyan-400 overflow-x-auto">
+        <code className="block bg-port-bg rounded p-2 my-1 text-xs font-mono text-cyan-400 overflow-x-auto whitespace-pre-wrap break-all">
           {children}
         </code>
       );
     }
     // Inline code
-    return <code className="bg-port-bg px-1 py-0.5 rounded text-cyan-400 font-mono text-xs">{children}</code>;
+    return <code className="bg-port-bg px-1 py-0.5 rounded text-cyan-400 font-mono text-xs break-all">{children}</code>;
   },
   pre: ({ children }) => <pre className="my-1 overflow-x-auto">{children}</pre>,
   ul: ({ children }) => <ul className="my-0.5 pl-4 space-y-0.5">{children}</ul>,
@@ -45,7 +45,7 @@ const components = {
 
 export default function MarkdownOutput({ content }) {
   return (
-    <div className="markdown-output">
+    <div className="markdown-output min-w-0 overflow-hidden break-words">
       <ReactMarkdown components={components}>{content}</ReactMarkdown>
     </div>
   );

--- a/client/src/components/cos/OutputBlocks.jsx
+++ b/client/src/components/cos/OutputBlocks.jsx
@@ -31,20 +31,20 @@ export default function OutputBlocks({ output }) {
   }, [output]);
 
   return (
-    <div className="space-y-0.5">
+    <div className="space-y-0.5 min-w-0 overflow-hidden">
       {blocks.map((block, i) => {
         if (block.type === 'tool') {
           const line = block.line;
           if (line.startsWith('🔧')) {
-            return <div key={i} className="py-0.5 text-xs font-mono text-port-accent">{line}</div>;
+            return <div key={i} className="py-0.5 text-xs font-mono text-port-accent break-all">{line}</div>;
           }
           if (line.startsWith('  →')) {
-            return <div key={i} className="py-0.5 text-xs font-mono text-gray-500 pl-4">{line.substring(4)}</div>;
+            return <div key={i} className="py-0.5 text-xs font-mono text-gray-500 pl-4 break-all">{line.substring(4)}</div>;
           }
           if (line.startsWith('  ↳')) {
-            return <div key={i} className="py-0.5 text-xs font-mono text-gray-600 pl-4">{line.substring(4)}</div>;
+            return <div key={i} className="py-0.5 text-xs font-mono text-gray-600 pl-4 break-all">{line.substring(4)}</div>;
           }
-          return <div key={i} className="py-0.5 text-xs font-mono text-yellow-500">{line}</div>;
+          return <div key={i} className="py-0.5 text-xs font-mono text-yellow-500 break-all">{line}</div>;
         }
         return <MarkdownOutput key={i} content={block.content} />;
       })}

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -195,7 +195,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       })) : undefined,
       position: addToTop ? 'top' : 'bottom'
     }).catch(err => {
-      toast.error(err.message);
+      console.warn('Failed to add COS task:', err);
       setIsSubmitting(false);
       return null;
     });

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -307,7 +307,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
                   {!template.isBuiltin && (
                     <button
                       onClick={(e) => deleteTemplate(template.id, e)}
-                      className="hidden group-hover:flex absolute -top-1 -right-1 w-4 h-4 bg-port-error rounded-full items-center justify-center"
+                      className="flex md:hidden md:group-hover:flex absolute -top-1 -right-1 w-4 h-4 bg-port-error rounded-full items-center justify-center"
                       title="Delete template"
                     >
                       <X size={10} />
@@ -514,7 +514,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
                 <button
                   type="button"
                   onClick={() => removeScreenshot(s.id)}
-                  className="absolute -top-2 -right-2 w-5 h-5 bg-port-error rounded-full flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity"
+                  className="absolute -top-2 -right-2 w-5 h-5 bg-port-error rounded-full flex items-center justify-center md:opacity-0 md:group-hover:opacity-100 transition-opacity"
                   aria-label={`Remove screenshot ${s.filename}`}
                 >
                   <X size={12} aria-hidden="true" />

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -18,6 +18,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   const [expanded, setExpanded] = useState(false);
   const [templateNameInput, setTemplateNameInput] = useState('');
   const [showTemplateSave, setShowTemplateSave] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const fileInputRef = useRef(null);
   const attachmentInputRef = useRef(null);
 
@@ -145,10 +146,13 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   };
 
   const handleAddTask = async () => {
+    if (isSubmitting) return;
     if (!newTask.description.trim()) {
       toast.error('Description is required');
       return;
     }
+
+    setIsSubmitting(true);
 
     let finalDescription = newTask.description;
 
@@ -173,7 +177,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       setIsEnhancing(false);
     }
 
-    await api.addCosTask({
+    const result = await api.addCosTask({
       description: finalDescription,
       context: newTask.context,
       model: newTask.model || undefined,
@@ -192,8 +196,11 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       position: addToTop ? 'top' : 'bottom'
     }).catch(err => {
       toast.error(err.message);
-      return;
+      setIsSubmitting(false);
+      return null;
     });
+
+    if (!result) return;
 
     toast.success('Task added');
     setNewTask({ description: '', context: '', model: '', provider: '', app: defaultApp });
@@ -204,6 +211,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     setCreateJiraTicket(false);
     setUseWorktree(false);
     setExpanded(false);
+    setIsSubmitting(false);
     onTaskAdded?.();
   };
 
@@ -219,7 +227,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
             placeholder="Task description *"
             value={newTask.description}
             onChange={e => setNewTask(t => ({ ...t, description: e.target.value }))}
-            onKeyDown={e => e.key === 'Enter' && !e.shiftKey && handleAddTask()}
+            onKeyDown={e => e.key === 'Enter' && !e.shiftKey && !isSubmitting && handleAddTask()}
             className="flex-1 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
             aria-required="true"
           />
@@ -238,11 +246,11 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
             </select>
             <button
               onClick={handleAddTask}
-              disabled={isEnhancing}
+              disabled={isSubmitting || isEnhancing}
               className="flex items-center gap-1 px-3 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg text-sm transition-colors disabled:opacity-50 min-h-[44px]"
             >
-              {isEnhancing ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
-              Add
+              {(isSubmitting || isEnhancing) ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+              {isSubmitting ? 'Adding...' : 'Add'}
             </button>
           </div>
         </div>
@@ -586,13 +594,13 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
             </button>
             <button
               onClick={handleAddTask}
-              disabled={isEnhancing}
+              disabled={isSubmitting || isEnhancing}
               className="flex items-center gap-1 px-3 py-1.5 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed min-h-[40px]"
             >
-              {isEnhancing ? (
+              {(isSubmitting || isEnhancing) ? (
                 <>
                   <Loader2 size={14} className="animate-spin" aria-hidden="true" />
-                  Enhancing...
+                  {isSubmitting ? 'Adding...' : 'Enhancing...'}
                 </>
               ) : (
                 <>

--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -542,7 +542,7 @@ export default function AgentCard({ agent, onKill, onDelete, onResume, completed
 
       {/* Expanded output view */}
       {expanded && (
-        <div className="border-t border-port-border bg-port-bg/50 p-3">
+        <div className="border-t border-port-border bg-port-bg/50 p-3 min-w-0 overflow-hidden">
           {loadingOutput ? (
             <div className="flex items-center gap-2 text-gray-500 text-sm">
               <Loader2 size={14} aria-hidden="true" className="animate-spin" />

--- a/client/src/components/cos/tabs/AgentsTab.jsx
+++ b/client/src/components/cos/tabs/AgentsTab.jsx
@@ -80,14 +80,15 @@ export default function AgentsTab({ agents, onRefresh, liveOutputs, providers, a
     setResumingAgent(agent);
   };
 
-  const handleResumeSubmit = async ({ description, context, model, provider, app, type = 'user' }) => {
+  const handleResumeSubmit = async ({ description, context, model, provider, app, type = 'user', screenshots }) => {
     await api.addCosTask({
       description,
       context,
       model: model || undefined,
       provider: provider || undefined,
       app: app || undefined,
-      type
+      type,
+      screenshots
     }).catch(err => {
       toast.error(err.message);
       return;

--- a/client/src/components/cos/tabs/ResumeAgentModal.jsx
+++ b/client/src/components/cos/tabs/ResumeAgentModal.jsx
@@ -1,5 +1,7 @@
-import { useState } from 'react';
-import { X, CheckCircle, AlertCircle, RotateCcw } from 'lucide-react';
+import { useState, useRef } from 'react';
+import { X, CheckCircle, AlertCircle, RotateCcw, Image } from 'lucide-react';
+import { processScreenshotUploads } from '../../../utils/fileUpload';
+import toast from 'react-hot-toast';
 
 export default function ResumeAgentModal({ agent, taskType = 'user', providers, apps, onSubmit, onClose }) {
   const taskDescription = agent.metadata?.taskDescription || agent.taskId || 'Resume previous task';
@@ -24,6 +26,20 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
     model: agent.metadata?.model || '',
     app: agent.metadata?.app || ''
   });
+  const [screenshots, setScreenshots] = useState([]);
+  const fileInputRef = useRef(null);
+
+  const handleFileSelect = async (e) => {
+    await processScreenshotUploads(e.target.files, {
+      onSuccess: (fileInfo) => setScreenshots(prev => [...prev, fileInfo]),
+      onError: (msg) => toast.error(msg)
+    });
+    e.target.value = '';
+  };
+
+  const removeScreenshot = (id) => {
+    setScreenshots(prev => prev.filter(s => s.id !== id));
+  };
 
   const selectedProvider = providers?.find(p => p.id === formData.provider);
   const availableModels = selectedProvider?.models || [];
@@ -40,7 +56,8 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
       model: formData.model,
       provider: formData.provider,
       app: formData.app,
-      type: taskType
+      type: taskType,
+      screenshots: screenshots.length > 0 ? screenshots.map(s => s.path) : undefined
     });
   };
 
@@ -88,6 +105,53 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:border-port-accent focus:outline-hidden resize-none"
               autoFocus
             />
+          </div>
+
+          {/* Screenshot Upload */}
+          <div>
+            <div className="flex items-center gap-3 flex-wrap">
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                className="flex items-center gap-2 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-gray-400 hover:text-white text-sm transition-colors"
+              >
+                <Image size={16} aria-hidden="true" />
+                Add Screenshot
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                multiple
+                onChange={handleFileSelect}
+                className="hidden"
+                aria-label="Upload screenshot files"
+              />
+              {screenshots.length > 0 && (
+                <span className="text-xs text-gray-500">{screenshots.length} screenshot{screenshots.length > 1 ? 's' : ''}</span>
+              )}
+            </div>
+            {screenshots.length > 0 && (
+              <div className="flex gap-2 flex-wrap mt-2">
+                {screenshots.map(s => (
+                  <div key={s.id} className="relative group">
+                    <img
+                      src={s.preview}
+                      alt={s.filename}
+                      className="w-20 h-20 object-cover rounded-lg border border-port-border"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => removeScreenshot(s.id)}
+                      className="absolute -top-2 -right-2 w-5 h-5 bg-port-error rounded-full flex items-center justify-center md:opacity-0 md:group-hover:opacity-100 transition-opacity"
+                      aria-label={`Remove screenshot ${s.filename}`}
+                    >
+                      <X size={12} aria-hidden="true" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
 
           {/* App Selection */}

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -379,7 +379,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
         </div>
 
         {/* Action buttons */}
-        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+        <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
           {!editing && (
             <>
               {/* Mark as Blocked button - only show for non-blocked, non-completed tasks */}

--- a/client/src/components/meatspace/AlcoholChart.jsx
+++ b/client/src/components/meatspace/AlcoholChart.jsx
@@ -79,8 +79,8 @@ export default function AlcoholChart({ sex = 'male', onRefreshKey, onViewChange 
   };
 
   return (
-    <div className="bg-port-card border border-port-border rounded-xl p-6">
-      <div className="flex items-center justify-between mb-4">
+    <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-4">
         <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">
           Daily Consumption
         </h3>
@@ -90,7 +90,7 @@ export default function AlcoholChart({ sex = 'male', onRefreshKey, onViewChange 
               <button
                 key={u}
                 onClick={() => setUnit(u)}
-                className={`px-2 py-1 text-xs rounded transition-colors ${
+                className={`px-2 py-1 min-h-[40px] text-xs rounded transition-colors ${
                   unit === u
                     ? 'bg-port-accent/10 text-port-accent'
                     : 'text-gray-500 hover:text-gray-300'
@@ -106,7 +106,7 @@ export default function AlcoholChart({ sex = 'male', onRefreshKey, onViewChange 
               <button
                 key={v.id}
                 onClick={() => { setView(v.id); onViewChange?.(v.id); }}
-                className={`px-2 py-1 text-xs rounded transition-colors ${
+                className={`px-2 py-1 min-h-[40px] text-xs rounded transition-colors ${
                   view === v.id
                     ? 'bg-port-accent/10 text-port-accent'
                     : 'text-gray-500 hover:text-gray-300'

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -239,15 +239,15 @@ export default function AlcoholTab() {
     <div className="space-y-6">
       {/* Rolling Averages Summary */}
       {summary && (
-        <div className="bg-port-card border border-port-border rounded-xl p-6">
-          <div className="flex items-center justify-between mb-4">
+        <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-4">
             <div className="flex items-center gap-2">
               <Beer size={18} className="text-port-accent" />
               <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">
                 Alcohol Summary
               </h3>
             </div>
-            <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border ${RISK_BG[summary.riskLevel]}`}>
+            <span className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium border self-start sm:self-auto ${RISK_BG[summary.riskLevel]}`}>
               {summary.riskLevel === 'high' && <AlertTriangle size={12} />}
               {summary.riskLevel === 'low' && <TrendingDown size={12} />}
               {summary.riskLevel === 'moderate' && <TrendingUp size={12} />}
@@ -304,7 +304,7 @@ export default function AlcoholTab() {
       </div>
 
       {/* Log a Drink */}
-      <div className="bg-port-card border border-port-border rounded-xl p-6">
+      <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider">Log a Drink</h3>
           <button
@@ -327,7 +327,7 @@ export default function AlcoholTab() {
                 key={`${drink.name}-${idx}`}
                 onClick={() => handleQuickAdd(drink)}
                 disabled={logging}
-                className="flex items-center gap-1 px-3 py-1.5 text-xs bg-port-border/50 text-gray-300 rounded-lg hover:bg-port-accent/10 hover:text-port-accent transition-colors disabled:opacity-50"
+                className="flex items-center gap-1 px-3 py-2 min-h-[40px] text-xs bg-port-border/50 text-gray-300 rounded-lg hover:bg-port-accent/10 hover:text-port-accent transition-colors disabled:opacity-50"
               >
                 <Plus size={12} />
                 {drink.name}
@@ -433,8 +433,8 @@ export default function AlcoholTab() {
         )}
 
         {/* Custom entry form */}
-        <form onSubmit={handleCustomAdd} className="flex flex-wrap items-end gap-3">
-          <div className="flex-1 min-w-[120px]">
+        <form onSubmit={handleCustomAdd} className="grid grid-cols-2 sm:grid-cols-[1fr_5rem_5rem_4rem_9rem_auto] items-end gap-3">
+          <div className="col-span-2 sm:col-span-1">
             <label className="text-xs text-gray-500 block mb-1">Name (optional)</label>
             <input
               type="text"
@@ -444,7 +444,7 @@ export default function AlcoholTab() {
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-sm text-white placeholder-gray-600"
             />
           </div>
-          <div className="w-20">
+          <div>
             <label className="text-xs text-gray-500 block mb-1">Oz</label>
             <input
               type="number"
@@ -457,7 +457,7 @@ export default function AlcoholTab() {
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-sm text-white placeholder-gray-600"
             />
           </div>
-          <div className="w-20">
+          <div>
             <label className="text-xs text-gray-500 block mb-1">ABV %</label>
             <input
               type="number"
@@ -471,7 +471,7 @@ export default function AlcoholTab() {
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-sm text-white placeholder-gray-600"
             />
           </div>
-          <div className="w-16">
+          <div>
             <label className="text-xs text-gray-500 block mb-1">Count</label>
             <input
               type="number"
@@ -482,7 +482,7 @@ export default function AlcoholTab() {
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-sm text-white"
             />
           </div>
-          <div className="w-36">
+          <div>
             <label className="text-xs text-gray-500 block mb-1">Date</label>
             <input
               type="date"
@@ -494,7 +494,7 @@ export default function AlcoholTab() {
           <button
             type="submit"
             disabled={logging || !oz || !abv}
-            className="flex items-center gap-2 px-4 py-2 bg-port-accent text-white rounded-lg hover:bg-port-accent/80 disabled:opacity-50 transition-colors"
+            className="col-span-2 sm:col-span-1 flex items-center justify-center gap-2 px-4 py-2 min-h-[40px] bg-port-accent text-white rounded-lg hover:bg-port-accent/80 disabled:opacity-50 transition-colors"
           >
             {logging ? <BrailleSpinner /> : <Plus size={16} />}
             Log
@@ -504,12 +504,12 @@ export default function AlcoholTab() {
 
       {/* All Drink Entries */}
       {allEntries?.length > 0 && (
-        <div className="bg-port-card border border-port-border rounded-xl p-6">
+        <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6">
           <h3 className="text-sm font-medium text-gray-400 uppercase tracking-wider mb-4">
             All Drink Entries ({allEntries.length} days)
           </h3>
-          <div className="max-h-[70vh] overflow-y-auto rounded-lg border border-port-border">
-            <table className="w-full text-sm">
+          <div className="max-h-[70vh] overflow-x-auto overflow-y-auto rounded-lg border border-port-border">
+            <table className="w-full text-sm min-w-[600px]">
               <thead className="sticky top-0 bg-port-card z-10">
                 <tr className="border-b border-port-border text-left text-xs text-gray-500 uppercase">
                   <th className="px-3 py-2">Date</th>

--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -299,7 +299,7 @@ export default function Apps() {
                         aria-label={`Launch ${app.name} Dev UI`}
                       >
                         <ExternalLink size={14} aria-hidden="true" />
-                        <span className="text-xs">Launch Dev</span>
+                        <span className="text-xs">Dev UI</span>
                       </button>
                     )}
 

--- a/client/src/pages/DevTools.jsx
+++ b/client/src/pages/DevTools.jsx
@@ -48,7 +48,8 @@ export function HistoryPage() {
   const handleDelete = async (id, e) => {
     e.stopPropagation();
     await api.deleteHistoryEntry(id);
-    loadData();
+    setHistory(prev => prev.filter(entry => entry.id !== id));
+    if (expandedId === id) setExpandedId(null);
   };
 
   const getActionIcon = (action) => {
@@ -342,7 +343,8 @@ export function RunsHistoryPage() {
   const handleDelete = async (id, e) => {
     e.stopPropagation();
     await api.deleteRun(id);
-    loadRuns();
+    setRuns(prev => prev.filter(run => run.id !== id));
+    if (expandedId === id) setExpandedId(null);
   };
 
   const toggleExpand = async (id) => {
@@ -438,7 +440,7 @@ export function RunsHistoryPage() {
   const handleClearFailed = async () => {
     const result = await api.deleteFailedRuns().catch(() => null);
     if (result) {
-      loadRuns();
+      setRuns(prev => prev.filter(r => r.success !== false));
     }
   };
 

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -7,6 +7,9 @@ import '@xterm/xterm/css/xterm.css';
 import { useSocket } from '../hooks/useSocket';
 import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown, Plus, X, Terminal as TerminalIcon } from 'lucide-react';
 
+// Must match MAX_TOTAL_SESSIONS in server/services/shell.js
+const MAX_SESSIONS = 5;
+
 const QUICK_COMMANDS = [
   { label: 'claude', command: 'claude --dangerously-skip-permissions' },
   { label: 'git status', command: 'git status' },
@@ -390,7 +393,7 @@ export default function Shell() {
           {connected ? 'Connected' : 'Disconnected'}
         </div>
         {sessions.length > 0 && (
-          <span className="text-xs text-gray-500 font-mono">{sessions.length}/5</span>
+          <span className="text-xs text-gray-500 font-mono">{sessions.length}/{MAX_SESSIONS}</span>
         )}
         <div className="flex items-center gap-2 ml-auto">
           {connected && (

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -499,7 +499,7 @@ export default function Shell() {
                   <button
                     key={name}
                     onClick={() => {
-                      sendCommand(`cd "${path}"`);
+                      sendCommand(`cd '${path}'`);
                       setFolderDropdownOpen(false);
                     }}
                     className="w-full text-left px-3 py-2 text-xs font-mono text-gray-300 hover:bg-port-border hover:text-white transition-colors"

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -5,7 +5,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 import { useSocket } from '../hooks/useSocket';
-import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown, Plus, X, Terminal as TerminalIcon } from 'lucide-react';
+import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown, Plus, X, Terminal as TerminalIcon, Trash2 } from 'lucide-react';
 
 const QUICK_COMMANDS = [
   { label: 'claude', command: 'claude --dangerously-skip-permissions' },
@@ -237,6 +237,15 @@ export default function Shell() {
   const killOtherSession = useCallback((sessionId) => {
     if (!socket) return;
     socket.emit('shell:stop', { sessionId });
+    // If killing the active session via tab X, clean up local state too
+    if (sessionId === sessionIdRef.current) {
+      sessionIdRef.current = null;
+      setActiveSessionId(null);
+      setConnected(false);
+      if (termInstanceRef.current) {
+        termInstanceRef.current.writeln('\r\n\x1b[33m[Session killed]\x1b[0m');
+      }
+    }
   }, [socket]);
 
   const switchToSession = useCallback((sessionId) => {
@@ -318,6 +327,14 @@ export default function Shell() {
         if (termInstanceRef.current) {
           termInstanceRef.current.writeln(`\r\n\x1b[33m[Shell exited with code ${code}]\x1b[0m`);
         }
+        // Auto-attach to next available session if any remain
+        setSessions(prev => {
+          const remaining = prev.filter(s => s.sessionId !== sid);
+          if (remaining.length > 0) {
+            setTimeout(() => attachToSession(remaining[remaining.length - 1].sessionId), 100);
+          }
+          return prev; // actual list update comes from server broadcast
+        });
       }
     };
 
@@ -364,29 +381,39 @@ export default function Shell() {
             <div className={`w-2 h-2 rounded-full ${connected ? 'bg-green-500' : 'bg-gray-500'}`} />
             {connected ? 'Connected' : 'Disconnected'}
           </div>
+          {sessions.length > 0 && (
+            <span className="text-xs text-gray-500 font-mono">{sessions.length}/5 sessions</span>
+          )}
         </div>
         <div className="flex items-center gap-2">
-          {connected ? (
-            <>
-              <button
-                onClick={stopSession}
-                className="flex items-center gap-2 px-3 py-2 bg-red-500/20 hover:bg-red-500/30 text-red-400 rounded-lg text-sm transition-colors min-h-[40px]"
-                title="Kill current session"
-              >
-                <PowerOff size={16} />
-                Kill
-              </button>
-            </>
-          ) : (
+          {connected && (
             <button
-              onClick={startSession}
-              className="flex items-center gap-2 px-3 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg text-sm transition-colors min-h-[40px]"
-              title="Start new session"
+              onClick={() => { stopSession(); setTimeout(startSession, 100); }}
+              className="flex items-center gap-2 px-3 py-2 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded-lg text-sm transition-colors border border-port-border min-h-[40px]"
+              title="Restart session (kill + new)"
             >
-              <Power size={16} />
-              New Session
+              <RefreshCw size={16} />
+              Restart
             </button>
           )}
+          {connected && (
+            <button
+              onClick={stopSession}
+              className="flex items-center gap-2 px-3 py-2 bg-red-500/20 hover:bg-red-500/30 text-red-400 rounded-lg text-sm transition-colors min-h-[40px]"
+              title="Kill current session"
+            >
+              <PowerOff size={16} />
+              Stop
+            </button>
+          )}
+          <button
+            onClick={startSession}
+            className="flex items-center gap-2 px-3 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg text-sm transition-colors min-h-[40px]"
+            title="Start new session"
+          >
+            <Power size={16} />
+            New
+          </button>
         </div>
       </div>
 
@@ -399,7 +426,7 @@ export default function Shell() {
             return (
               <div
                 key={s.sessionId}
-                className={`group flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-mono transition-colors cursor-pointer min-h-[36px] ${
+                className={`flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-mono transition-colors cursor-pointer min-h-[40px] ${
                   isActive
                     ? 'bg-port-accent/20 text-port-accent border border-port-accent/40'
                     : 'bg-port-card hover:bg-port-border text-gray-400 hover:text-white border border-port-border'
@@ -407,24 +434,24 @@ export default function Shell() {
                 onClick={() => !isActive && switchToSession(s.sessionId)}
                 title={`${s.cwd || shortId(s.sessionId)} — ${formatAge(s.createdAt)} old`}
               >
-                <TerminalIcon size={12} />
+                <TerminalIcon size={12} className="shrink-0" />
                 <span className="truncate max-w-[100px]">{label}</span>
-                <span className="text-[10px] opacity-60">{formatAge(s.createdAt)}</span>
-                {!isActive && (
-                  <button
-                    onClick={(e) => { e.stopPropagation(); killOtherSession(s.sessionId); }}
-                    className="opacity-0 group-hover:opacity-100 hover:text-red-400 transition-opacity ml-0.5"
-                    title="Kill session"
-                  >
-                    <X size={12} />
-                  </button>
-                )}
+                <span className="text-[10px] opacity-60 shrink-0">{formatAge(s.createdAt)}</span>
+                <button
+                  onClick={(e) => { e.stopPropagation(); killOtherSession(s.sessionId); }}
+                  className={`shrink-0 ml-0.5 p-0.5 rounded transition-colors ${
+                    isActive ? 'text-port-accent/60 hover:text-red-400' : 'text-gray-600 hover:text-red-400'
+                  }`}
+                  title="Kill session"
+                >
+                  <X size={14} />
+                </button>
               </div>
             );
           })}
           <button
             onClick={startSession}
-            className="flex items-center gap-1 px-2 py-1.5 text-xs text-gray-500 hover:text-white hover:bg-port-border rounded transition-colors min-h-[36px]"
+            className="flex items-center gap-1 px-2 py-1.5 text-xs text-gray-500 hover:text-white hover:bg-port-border rounded transition-colors min-h-[40px]"
             title="New session"
           >
             <Plus size={14} />

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -372,47 +372,45 @@ export default function Shell() {
   return (
     <div className="h-full flex flex-col p-4 md:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-3">
-          <h1 className="text-xl font-semibold text-white">Shell</h1>
-          <div className={`flex items-center gap-2 px-2 py-1 rounded text-sm ${
-            connected ? 'bg-green-500/20 text-green-400' : 'bg-gray-500/20 text-gray-400'
-          }`}>
-            <div className={`w-2 h-2 rounded-full ${connected ? 'bg-green-500' : 'bg-gray-500'}`} />
-            {connected ? 'Connected' : 'Disconnected'}
-          </div>
-          {sessions.length > 0 && (
-            <span className="text-xs text-gray-500 font-mono">{sessions.length}/5 sessions</span>
-          )}
+      <div className="flex flex-wrap items-center gap-2 mb-3">
+        <h1 className="text-xl font-semibold text-white">Shell</h1>
+        <div className={`flex items-center gap-2 px-2 py-1 rounded text-sm ${
+          connected ? 'bg-green-500/20 text-green-400' : 'bg-gray-500/20 text-gray-400'
+        }`}>
+          <div className={`w-2 h-2 rounded-full ${connected ? 'bg-green-500' : 'bg-gray-500'}`} />
+          {connected ? 'Connected' : 'Disconnected'}
         </div>
-        <div className="flex items-center gap-2">
+        {sessions.length > 0 && (
+          <span className="text-xs text-gray-500 font-mono">{sessions.length}/5</span>
+        )}
+        <div className="flex items-center gap-2 ml-auto">
           {connected && (
             <button
               onClick={() => { stopSession(); setTimeout(startSession, 100); }}
-              className="flex items-center gap-2 px-3 py-2 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded-lg text-sm transition-colors border border-port-border min-h-[40px]"
+              className="flex items-center gap-1.5 px-2.5 py-2 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded-lg text-sm transition-colors border border-port-border min-h-[40px]"
               title="Restart session (kill + new)"
             >
               <RefreshCw size={16} />
-              Restart
+              <span className="hidden sm:inline">Restart</span>
             </button>
           )}
           {connected && (
             <button
               onClick={stopSession}
-              className="flex items-center gap-2 px-3 py-2 bg-red-500/20 hover:bg-red-500/30 text-red-400 rounded-lg text-sm transition-colors min-h-[40px]"
+              className="flex items-center gap-1.5 px-2.5 py-2 bg-red-500/20 hover:bg-red-500/30 text-red-400 rounded-lg text-sm transition-colors min-h-[40px]"
               title="Kill current session"
             >
               <PowerOff size={16} />
-              Stop
+              <span className="hidden sm:inline">Stop</span>
             </button>
           )}
           <button
             onClick={startSession}
-            className="flex items-center gap-2 px-3 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg text-sm transition-colors min-h-[40px]"
+            className="flex items-center gap-1.5 px-2.5 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg text-sm transition-colors min-h-[40px]"
             title="Start new session"
           >
             <Power size={16} />
-            New
+            <span className="hidden sm:inline">New</span>
           </button>
         </div>
       </div>

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -398,7 +398,7 @@ export default function Shell() {
         <div className="flex items-center gap-2 ml-auto">
           {connected && (
             <button
-              onClick={() => { stopSession(); setTimeout(startSession, 100); }}
+              onClick={() => { stopSession(); setTimeout(startSession, 1000); }}
               className="flex items-center gap-1.5 px-2.5 py-2 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded-lg text-sm transition-colors border border-port-border min-h-[40px]"
               title="Restart session (kill + new)"
             >
@@ -499,7 +499,7 @@ export default function Shell() {
                   <button
                     key={name}
                     onClick={() => {
-                      sendCommand(`cd ${path}`);
+                      sendCommand(`cd "${path}"`);
                       setFolderDropdownOpen(false);
                     }}
                     className="w-full text-left px-3 py-2 text-xs font-mono text-gray-300 hover:bg-port-border hover:text-white transition-colors"

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -5,7 +5,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 import { useSocket } from '../hooks/useSocket';
-import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown, Plus, X, Terminal as TerminalIcon, Trash2 } from 'lucide-react';
+import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown, Plus, X, Terminal as TerminalIcon } from 'lucide-react';
 
 const QUICK_COMMANDS = [
   { label: 'claude', command: 'claude --dangerously-skip-permissions' },

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -5,7 +5,7 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 import { useSocket } from '../hooks/useSocket';
-import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown } from 'lucide-react';
+import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown, Plus, X, Terminal as TerminalIcon } from 'lucide-react';
 
 const QUICK_COMMANDS = [
   { label: 'claude', command: 'claude --dangerously-skip-permissions' },
@@ -24,6 +24,17 @@ const getThemeHex = (varName) => {
   return '#' + parts.map(n => n.toString(16).padStart(2, '0')).join('');
 };
 
+const formatAge = (createdAt) => {
+  const seconds = Math.floor((Date.now() - createdAt) / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h${minutes % 60}m`;
+};
+
+const shortId = (id) => id?.slice(0, 6) ?? '';
+
 export default function Shell() {
   const [searchParams, setSearchParams] = useSearchParams();
   const terminalRef = useRef(null);
@@ -31,8 +42,11 @@ export default function Shell() {
   const fitAddonRef = useRef(null);
   const sessionIdRef = useRef(null);
   const initialOptsRef = useRef(null);
+  const hasInitializedRef = useRef(false);
   const socket = useSocket();
   const [connected, setConnected] = useState(false);
+  const [sessions, setSessions] = useState([]);
+  const [activeSessionId, setActiveSessionId] = useState(null);
   const [appFolders, setAppFolders] = useState([]);
   const [folderDropdownOpen, setFolderDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);
@@ -44,7 +58,6 @@ export default function Shell() {
     const cmd = searchParams.get('cmd');
     if (cwd || cmd) {
       initialOptsRef.current = { cwd, cmd };
-      // Clear query params from URL so restart/refresh starts a plain shell
       setSearchParams({}, { replace: true });
     } else {
       initialOptsRef.current = {};
@@ -134,7 +147,6 @@ export default function Shell() {
 
     term.open(terminalRef.current);
 
-    // Defer initial fit to next frame for proper sizing
     requestAnimationFrame(() => {
       fitAddon.fit();
     });
@@ -154,7 +166,6 @@ export default function Shell() {
     const handleResize = () => {
       if (fitAddonRef.current && termInstanceRef.current) {
         fitAddonRef.current.fit();
-        // Notify server of resize if we have an active session
         if (socket && sessionIdRef.current) {
           socket.emit('shell:resize', {
             sessionId: sessionIdRef.current,
@@ -182,6 +193,12 @@ export default function Shell() {
     return () => disposable.dispose();
   }, [socket]);
 
+  const activateSession = useCallback((sessionId) => {
+    sessionIdRef.current = sessionId;
+    setActiveSessionId(sessionId);
+    setConnected(true);
+  }, []);
+
   const startSession = useCallback(() => {
     if (!socket) return;
     if (termInstanceRef.current) {
@@ -192,40 +209,76 @@ export default function Shell() {
     const startOpts = {};
     if (opts.cwd) startOpts.cwd = opts.cwd;
     if (opts.cmd) startOpts.initialCommand = opts.cmd;
-    // Only use initial opts once
     initialOptsRef.current = {};
     socket.emit('shell:start', Object.keys(startOpts).length > 0 ? startOpts : undefined);
+  }, [socket]);
+
+  const attachToSession = useCallback((sessionId) => {
+    if (!socket) return;
+    if (termInstanceRef.current) {
+      termInstanceRef.current.clear();
+      termInstanceRef.current.writeln('\x1b[36mAttaching to session...\x1b[0m');
+    }
+    socket.emit('shell:attach', { sessionId });
   }, [socket]);
 
   const stopSession = useCallback(() => {
     if (socket && sessionIdRef.current) {
       socket.emit('shell:stop', { sessionId: sessionIdRef.current });
       sessionIdRef.current = null;
+      setActiveSessionId(null);
       setConnected(false);
+      if (termInstanceRef.current) {
+        termInstanceRef.current.writeln('\r\n\x1b[33m[Session killed]\x1b[0m');
+      }
     }
   }, [socket]);
 
-  const restartSession = useCallback(() => {
-    if (sessionIdRef.current && socket) {
-      socket.emit('shell:stop', { sessionId: sessionIdRef.current });
-    }
+  const killOtherSession = useCallback((sessionId) => {
+    if (!socket) return;
+    socket.emit('shell:stop', { sessionId });
+  }, [socket]);
+
+  const switchToSession = useCallback((sessionId) => {
+    if (sessionId === sessionIdRef.current) return;
+    // Detach current display (don't kill)
     sessionIdRef.current = null;
+    setActiveSessionId(null);
     setConnected(false);
-    startSession();
-  }, [socket, startSession]);
+    attachToSession(sessionId);
+  }, [attachToSession]);
 
   // Handle socket connection and shell session events
   useEffect(() => {
     if (!socket) return;
 
     const handleConnect = () => {
-      startSession();
+      // Request session list first — decide what to do in handleSessions
+      hasInitializedRef.current = false;
+      socket.emit('shell:list');
+    };
+
+    const handleSessions = (sessionList) => {
+      setSessions(sessionList);
+      // On first load, auto-attach to existing session or create new
+      if (!hasInitializedRef.current) {
+        hasInitializedRef.current = true;
+        const opts = initialOptsRef.current || {};
+        // If we have initial opts (cwd/cmd), always create a new session
+        if (opts.cwd || opts.cmd) {
+          startSession();
+        } else if (sessionList.length > 0 && !sessionIdRef.current) {
+          // Attach to most recent existing session
+          const latest = sessionList[sessionList.length - 1];
+          attachToSession(latest.sessionId);
+        } else if (sessionList.length === 0) {
+          startSession();
+        }
+      }
     };
 
     const handleShellStarted = ({ sessionId: sid }) => {
-      sessionIdRef.current = sid;
-      setConnected(true);
-      // Send initial size
+      activateSession(sid);
       if (termInstanceRef.current) {
         socket.emit('shell:resize', {
           sessionId: sid,
@@ -235,18 +288,36 @@ export default function Shell() {
       }
     };
 
-    const handleShellOutput = ({ data }) => {
+    const handleShellAttached = ({ sessionId: sid, bufferedOutput }) => {
+      activateSession(sid);
       if (termInstanceRef.current) {
+        termInstanceRef.current.clear();
+        if (bufferedOutput) {
+          termInstanceRef.current.write(bufferedOutput);
+        }
+        socket.emit('shell:resize', {
+          sessionId: sid,
+          cols: termInstanceRef.current.cols,
+          rows: termInstanceRef.current.rows
+        });
+      }
+    };
+
+    const handleShellOutput = ({ sessionId: sid, data }) => {
+      // Only render output for the currently viewed session
+      if (sid === sessionIdRef.current && termInstanceRef.current) {
         termInstanceRef.current.write(data);
       }
     };
 
-    const handleShellExit = ({ code }) => {
-      setConnected(false);
-      sessionIdRef.current = null;
-      if (termInstanceRef.current) {
-        termInstanceRef.current.writeln(`\r\n\x1b[33m[Shell exited with code ${code}]\x1b[0m`);
-        termInstanceRef.current.writeln('\x1b[90mPress the restart button to start a new session\x1b[0m');
+    const handleShellExit = ({ sessionId: sid, code }) => {
+      if (sid === sessionIdRef.current) {
+        setConnected(false);
+        sessionIdRef.current = null;
+        setActiveSessionId(null);
+        if (termInstanceRef.current) {
+          termInstanceRef.current.writeln(`\r\n\x1b[33m[Shell exited with code ${code}]\x1b[0m`);
+        }
       }
     };
 
@@ -257,35 +328,34 @@ export default function Shell() {
     };
 
     socket.on('connect', handleConnect);
+    socket.on('shell:sessions', handleSessions);
     socket.on('shell:started', handleShellStarted);
+    socket.on('shell:attached', handleShellAttached);
     socket.on('shell:output', handleShellOutput);
     socket.on('shell:exit', handleShellExit);
     socket.on('shell:error', handleShellError);
 
-    // Start session if already connected
     if (socket.connected) {
-      startSession();
+      handleConnect();
     }
 
     return () => {
       socket.off('connect', handleConnect);
+      socket.off('shell:sessions', handleSessions);
       socket.off('shell:started', handleShellStarted);
+      socket.off('shell:attached', handleShellAttached);
       socket.off('shell:output', handleShellOutput);
       socket.off('shell:exit', handleShellExit);
       socket.off('shell:error', handleShellError);
-
-      // Stop shell session on unmount
-      if (sessionIdRef.current) {
-        socket.emit('shell:stop', { sessionId: sessionIdRef.current });
-        sessionIdRef.current = null;
-      }
+      // Don't kill session on unmount — it persists server-side
+      sessionIdRef.current = null;
     };
-  }, [socket, startSession]);
+  }, [socket, startSession, attachToSession, activateSession]);
 
   return (
     <div className="h-full flex flex-col p-4 md:p-6">
       {/* Header */}
-      <div className="flex items-center justify-between mb-4">
+      <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-3">
           <h1 className="text-xl font-semibold text-white">Shell</h1>
           <div className={`flex items-center gap-2 px-2 py-1 rounded text-sm ${
@@ -299,39 +369,72 @@ export default function Shell() {
           {connected ? (
             <>
               <button
-                onClick={restartSession}
-                className="flex items-center gap-2 px-3 py-2 bg-port-border hover:bg-port-border/80 text-white rounded-lg text-sm transition-colors min-h-[40px]"
-                title="Restart session"
-              >
-                <RefreshCw size={16} />
-                Restart
-              </button>
-              <button
                 onClick={stopSession}
                 className="flex items-center gap-2 px-3 py-2 bg-red-500/20 hover:bg-red-500/30 text-red-400 rounded-lg text-sm transition-colors min-h-[40px]"
-                title="Stop session"
+                title="Kill current session"
               >
                 <PowerOff size={16} />
-                Stop
+                Kill
               </button>
             </>
           ) : (
             <button
               onClick={startSession}
               className="flex items-center gap-2 px-3 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg text-sm transition-colors min-h-[40px]"
-              title="Start session"
+              title="Start new session"
             >
               <Power size={16} />
-              Start
+              New Session
             </button>
           )}
         </div>
       </div>
 
+      {/* Session tabs */}
+      {sessions.length > 0 && (
+        <div className="flex items-center gap-1.5 mb-3 overflow-x-auto pb-1">
+          {sessions.map((s) => {
+            const isActive = s.sessionId === activeSessionId;
+            const label = s.cwd?.split('/').pop() || shortId(s.sessionId);
+            return (
+              <div
+                key={s.sessionId}
+                className={`group flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs font-mono transition-colors cursor-pointer min-h-[36px] ${
+                  isActive
+                    ? 'bg-port-accent/20 text-port-accent border border-port-accent/40'
+                    : 'bg-port-card hover:bg-port-border text-gray-400 hover:text-white border border-port-border'
+                }`}
+                onClick={() => !isActive && switchToSession(s.sessionId)}
+                title={`${s.cwd || shortId(s.sessionId)} — ${formatAge(s.createdAt)} old`}
+              >
+                <TerminalIcon size={12} />
+                <span className="truncate max-w-[100px]">{label}</span>
+                <span className="text-[10px] opacity-60">{formatAge(s.createdAt)}</span>
+                {!isActive && (
+                  <button
+                    onClick={(e) => { e.stopPropagation(); killOtherSession(s.sessionId); }}
+                    className="opacity-0 group-hover:opacity-100 hover:text-red-400 transition-opacity ml-0.5"
+                    title="Kill session"
+                  >
+                    <X size={12} />
+                  </button>
+                )}
+              </div>
+            );
+          })}
+          <button
+            onClick={startSession}
+            className="flex items-center gap-1 px-2 py-1.5 text-xs text-gray-500 hover:text-white hover:bg-port-border rounded transition-colors min-h-[36px]"
+            title="New session"
+          >
+            <Plus size={14} />
+          </button>
+        </div>
+      )}
+
       {/* Quick commands toolbar */}
       {connected && (
         <div className="flex items-center gap-2 mb-3 flex-wrap">
-          {/* Quick command buttons */}
           {QUICK_COMMANDS.map(({ label, command }) => (
             <button
               key={label}

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -498,7 +498,7 @@ export default function Shell() {
                   <button
                     key={name}
                     onClick={() => {
-                      sendCommand(`cd '${path}'`);
+                      sendCommand(`cd '${path.replace(/'/g, "'\\''")}'`);
                       setFolderDropdownOpen(false);
                     }}
                     className="w-full text-left px-3 py-2 text-xs font-mono text-gray-300 hover:bg-port-border hover:text-white transition-colors"

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -200,7 +200,7 @@ export default function Shell() {
   }, []);
 
   const startSession = useCallback(() => {
-    if (!socket) return;
+    if (!socket?.connected) return;
     if (termInstanceRef.current) {
       termInstanceRef.current.clear();
       termInstanceRef.current.writeln('\x1b[36mStarting shell session...\x1b[0m');
@@ -214,7 +214,7 @@ export default function Shell() {
   }, [socket]);
 
   const attachToSession = useCallback((sessionId) => {
-    if (!socket) return;
+    if (!socket?.connected) return;
     if (termInstanceRef.current) {
       termInstanceRef.current.clear();
       termInstanceRef.current.writeln('\x1b[36mAttaching to session...\x1b[0m');
@@ -265,6 +265,13 @@ export default function Shell() {
       // Request session list first — decide what to do in handleSessions
       hasInitializedRef.current = false;
       socket.emit('shell:list');
+    };
+
+    const handleDisconnect = () => {
+      // Clear session state so reconnect auto-reattaches
+      sessionIdRef.current = null;
+      setActiveSessionId(null);
+      setConnected(false);
     };
 
     const handleSessions = (sessionList) => {
@@ -345,6 +352,7 @@ export default function Shell() {
     };
 
     socket.on('connect', handleConnect);
+    socket.on('disconnect', handleDisconnect);
     socket.on('shell:sessions', handleSessions);
     socket.on('shell:started', handleShellStarted);
     socket.on('shell:attached', handleShellAttached);
@@ -358,6 +366,7 @@ export default function Shell() {
 
     return () => {
       socket.off('connect', handleConnect);
+      socket.off('disconnect', handleDisconnect);
       socket.off('shell:sessions', handleSessions);
       socket.off('shell:started', handleShellStarted);
       socket.off('shell:attached', handleShellAttached);

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -5,7 +5,15 @@ import { FitAddon } from '@xterm/addon-fit';
 import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 import { useSocket } from '../hooks/useSocket';
-import { RefreshCw, Power, PowerOff } from 'lucide-react';
+import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown } from 'lucide-react';
+
+const QUICK_COMMANDS = [
+  { label: 'claude', command: 'claude --dangerously-skip-permissions' },
+  { label: 'git status', command: 'git status' },
+  { label: 'git pull', command: 'git pull --rebase --autostash' },
+  { label: 'npm test', command: 'npm test' },
+  { label: 'npm run dev', command: 'npm run dev' },
+];
 
 // Read a CSS custom property as hex (e.g., '--port-bg' → '#0f0f0f')
 const getThemeHex = (varName) => {
@@ -25,6 +33,9 @@ export default function Shell() {
   const initialOptsRef = useRef(null);
   const socket = useSocket();
   const [connected, setConnected] = useState(false);
+  const [appFolders, setAppFolders] = useState([]);
+  const [folderDropdownOpen, setFolderDropdownOpen] = useState(false);
+  const dropdownRef = useRef(null);
 
   // Read query params once on mount for initial session options
   useEffect(() => {
@@ -39,6 +50,32 @@ export default function Shell() {
       initialOptsRef.current = {};
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Fetch app folders for the cd selector
+  useEffect(() => {
+    fetch('/api/scaffold/directories')
+      .then(res => res.ok ? res.json() : Promise.reject())
+      .then(data => setAppFolders(data.directories || []))
+      .catch(() => {});
+  }, []);
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target)) {
+        setFolderDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  // Send a command string to the active shell session
+  const sendCommand = useCallback((cmd) => {
+    if (!socket || !sessionIdRef.current) return;
+    socket.emit('shell:input', { sessionId: sessionIdRef.current, data: cmd + '\n' });
+    termInstanceRef.current?.focus();
+  }, [socket]);
 
   // Initialize terminal once
   useEffect(() => {
@@ -285,6 +322,54 @@ export default function Shell() {
           )}
         </div>
       </div>
+
+      {/* Quick commands toolbar */}
+      {connected && (
+        <div className="flex items-center gap-2 mb-3 flex-wrap">
+          {/* Quick command buttons */}
+          {QUICK_COMMANDS.map(({ label, command }) => (
+            <button
+              key={label}
+              onClick={() => sendCommand(command)}
+              className="px-3 py-1.5 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded text-xs font-mono transition-colors border border-port-border min-h-[40px]"
+              title={command}
+            >
+              {label}
+            </button>
+          ))}
+
+          {/* App folder cd selector */}
+          <div className="relative ml-auto" ref={dropdownRef}>
+            <button
+              onClick={() => setFolderDropdownOpen(prev => !prev)}
+              className="flex items-center gap-2 px-3 py-1.5 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded text-xs transition-colors border border-port-border min-h-[40px]"
+            >
+              <FolderOpen size={14} />
+              cd to app
+              <ChevronDown size={12} className={`transition-transform ${folderDropdownOpen ? 'rotate-180' : ''}`} />
+            </button>
+            {folderDropdownOpen && (
+              <div className="absolute right-0 top-full mt-1 w-64 max-h-80 overflow-y-auto bg-port-card border border-port-border rounded-lg shadow-xl z-50">
+                {appFolders.map(({ name, path }) => (
+                  <button
+                    key={name}
+                    onClick={() => {
+                      sendCommand(`cd ${path}`);
+                      setFolderDropdownOpen(false);
+                    }}
+                    className="w-full text-left px-3 py-2 text-xs font-mono text-gray-300 hover:bg-port-border hover:text-white transition-colors"
+                  >
+                    {name}
+                  </button>
+                ))}
+                {appFolders.length === 0 && (
+                  <div className="px-3 py-2 text-xs text-gray-500">No folders found</div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
 
       {/* Terminal container */}
       <div className="flex-1 bg-port-bg rounded-lg border border-port-border overflow-hidden">

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -51,11 +51,16 @@ export default function Shell() {
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Fetch app folders for the cd selector
+  // Fetch app folders from the managed apps list
   useEffect(() => {
-    fetch('/api/scaffold/directories')
+    fetch('/api/apps')
       .then(res => res.ok ? res.json() : Promise.reject())
-      .then(data => setAppFolders(data.directories || []))
+      .then(apps => setAppFolders(
+        (apps || [])
+          .filter(a => a.repoPath)
+          .map(a => ({ name: a.name, path: a.repoPath }))
+          .sort((a, b) => a.name.localeCompare(b.name))
+      ))
       .catch(() => {});
   }, []);
 

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -53,6 +53,7 @@ export default function Shell() {
   const [appFolders, setAppFolders] = useState([]);
   const [folderDropdownOpen, setFolderDropdownOpen] = useState(false);
   const dropdownRef = useRef(null);
+  const sessionsRef = useRef([]);
 
   // Read query params once on mount for initial session options
   useEffect(() => {
@@ -278,6 +279,7 @@ export default function Shell() {
     };
 
     const handleSessions = (sessionList) => {
+      sessionsRef.current = sessionList;
       setSessions(sessionList);
       // On first load, auto-attach to existing session or create new
       if (!hasInitializedRef.current) {
@@ -338,13 +340,10 @@ export default function Shell() {
           termInstanceRef.current.writeln(`\r\n\x1b[33m[Shell exited with code ${code}]\x1b[0m`);
         }
         // Auto-attach to next available session if any remain
-        setSessions(prev => {
-          const remaining = prev.filter(s => s.sessionId !== sid);
-          if (remaining.length > 0) {
-            setTimeout(() => attachToSession(remaining[remaining.length - 1].sessionId), 100);
-          }
-          return prev; // actual list update comes from server broadcast
-        });
+        const remaining = sessionsRef.current.filter(s => s.sessionId !== sid);
+        if (remaining.length > 0) {
+          setTimeout(() => attachToSession(remaining[remaining.length - 1].sessionId), 100);
+        }
       }
     };
 

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -329,6 +329,10 @@ export const pushBranch = (path, branch) => request('/git/push', {
   method: 'POST',
   body: JSON.stringify({ path, branch })
 });
+export const pushAllBranches = (path) => request('/git/push-all', {
+  method: 'POST',
+  body: JSON.stringify({ path })
+});
 export const getBranches = (path) => request('/git/branches', {
   method: 'POST',
   body: JSON.stringify({ path })

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -11,45 +11,45 @@ export default defineConfig(({ mode }) => {
   const API_TARGET = `http://${API_HOST}:5555`;
 
   return {
-  define: {
-    __APP_VERSION__: JSON.stringify(rootPkg.version)
-  },
-  plugins: [react()],
-  server: {
-    host: '0.0.0.0',
-    port: 5554,
-    open: false,
-    proxy: {
-      '/api': {
-        target: API_TARGET,
-        changeOrigin: true
-      },
-      '/socket.io': {
-        target: API_TARGET,
-        changeOrigin: true,
-        ws: true
-      }
-    }
-  },
-  build: {
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          // Core React dependencies
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          // Socket and toast dependencies
-          'vendor-realtime': ['socket.io-client', 'react-hot-toast'],
-          // Drag and drop library (only used in CoS)
-          'vendor-dnd': ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
-          // Icon library (largest dependency)
-          'vendor-icons': ['lucide-react']
+    define: {
+      __APP_VERSION__: JSON.stringify(rootPkg.version)
+    },
+    plugins: [react()],
+    server: {
+      host: '0.0.0.0',
+      port: 5554,
+      open: false,
+      proxy: {
+        '/api': {
+          target: API_TARGET,
+          changeOrigin: true
+        },
+        '/socket.io': {
+          target: API_TARGET,
+          changeOrigin: true,
+          ws: true
         }
       }
     },
-    // Enable source maps for debugging in production
-    sourcemap: false,
-    // Increase chunk size warning limit (icons are large)
-    chunkSizeWarningLimit: 600
-  }
-};
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            // Core React dependencies
+            'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+            // Socket and toast dependencies
+            'vendor-realtime': ['socket.io-client', 'react-hot-toast'],
+            // Drag and drop library (only used in CoS)
+            'vendor-dnd': ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
+            // Icon library (largest dependency)
+            'vendor-icons': ['lucide-react']
+          }
+        }
+      },
+      // Enable source maps for debugging in production
+      sourcemap: false,
+      // Increase chunk size warning limit (icons are large)
+      chunkSizeWarningLimit: 600
+    }
+  };
 });

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,5 +1,9 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const rootPkg = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8'));
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), 'VITE_');
@@ -7,6 +11,9 @@ export default defineConfig(({ mode }) => {
   const API_TARGET = `http://${API_HOST}:5555`;
 
   return {
+  define: {
+    __APP_VERSION__: JSON.stringify(rootPkg.version)
+  },
   plugins: [react()],
   server: {
     host: '0.0.0.0',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.27.5",
+  "version": "1.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.27.5",
+      "version": "1.28.0",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.27.5",
+  "version": "1.28.0",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/server/index.js
+++ b/server/index.js
@@ -303,8 +303,13 @@ startUpdateScheduler();
 const CLIENT_DIST = join(__dirname, '..', 'client', 'dist');
 if (existsSync(CLIENT_DIST)) {
   app.use(express.static(CLIENT_DIST));
-  // SPA fallback: serve index.html for non-API routes
-  app.get('/{*splat}', (req, res) => {
+  // SPA fallback: serve index.html for page navigations only
+  // Skip asset requests (.js, .css, etc.) so stale chunk requests get a proper 404
+  // instead of index.html with text/html MIME type
+  app.get('/{*splat}', (req, res, next) => {
+    if (req.path.match(/\.\w+$/) && !req.path.endsWith('.html')) {
+      return next();
+    }
     res.sendFile(join(CLIENT_DIST, 'index.html'));
   });
   console.log(`📦 Serving built UI from client/dist`);

--- a/server/lib/socketValidation.js
+++ b/server/lib/socketValidation.js
@@ -40,10 +40,13 @@ export const shellResizeSchema = z.object({
   rows: z.number().int().positive().max(500)
 });
 
-// shell:stop — session ID
-export const shellStopSchema = z.object({
+// Shared session ID schema for shell operations
+export const shellSessionIdSchema = z.object({
   sessionId: z.string().min(1, 'sessionId is required')
 });
+
+// shell:stop — session ID
+export const shellStopSchema = shellSessionIdSchema;
 
 // app:update — app ID for pull/install/restart cycle
 export const appUpdateSchema = z.object({

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -141,7 +141,7 @@ router.post('/tasks', asyncHandler(async (req, res) => {
   const result = await cos.addTask(taskData, type);
 
   if (result?.duplicate) {
-    throw new ServerError(`A task with this description is already ${result.existingTask.status}`, { status: 409, code: 'DUPLICATE_TASK' });
+    throw new ServerError(`A task with this description is already ${result.status}`, { status: 409, code: 'DUPLICATE_TASK' });
   }
 
   res.json(result);

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -139,6 +139,11 @@ router.post('/tasks', asyncHandler(async (req, res) => {
 
   const taskData = { description, priority, context, model, provider, app, approvalRequired, screenshots, attachments, position, createJiraTicket, jiraTicketId, jiraTicketUrl, useWorktree };
   const result = await cos.addTask(taskData, type);
+
+  if (result?.duplicate) {
+    throw new ServerError(`A task with this description is already ${result.existingTask.status}`, { status: 409, code: 'DUPLICATE_TASK' });
+  }
+
   res.json(result);
 }));
 

--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -127,6 +127,18 @@ router.post('/push', asyncHandler(async (req, res) => {
   res.json(result);
 }));
 
+// POST /api/git/push-all - Push all branches with unpushed commits
+router.post('/push-all', asyncHandler(async (req, res) => {
+  const { path } = req.body;
+
+  if (!path) {
+    throw new ServerError('path is required', { status: 400, code: 'VALIDATION_ERROR' });
+  }
+
+  const result = await git.pushAll(path);
+  res.json(result);
+}));
+
 // POST /api/git/info - Get full git info for a path
 router.post('/info', asyncHandler(async (req, res) => {
   const { path } = req.body;

--- a/server/services/agents.js
+++ b/server/services/agents.js
@@ -137,8 +137,9 @@ async function findUnixProcesses(pattern) {
       const etime = parts[4];
       const command = parts.slice(5).join(' ');
 
-      // Skip if it's a grep or our own process
+      // Skip grep, our own process, and macOS app bundles (e.g. Cursor.app)
       if (command.includes('grep') || command.includes('ps -eo')) continue;
+      if (command.includes('.app/Contents/')) continue;
 
       // Parse elapsed time to get start time
       const runtime = parseElapsedTime(etime);

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -531,6 +531,7 @@ export async function start() {
       if (cleaned > 0) {
         emitLog('info', `🧹 Periodic cleanup: ${cleaned} orphaned agent(s)`);
       }
+      await resetOrphanedTasks();
       const { archived } = await archiveStaleAgents().catch(() => ({ archived: 0 }));
       if (archived > 0) {
         emitLog('info', `📦 Auto-archived ${archived} stale agent(s) from state`);
@@ -787,15 +788,7 @@ export async function getTaskById(taskId) {
  */
 async function resetOrphanedTasks() {
   const state = await loadState();
-  const { user: userTaskData } = await getAllTasks();
-
-  if (!userTaskData.exists) {
-    emitLog('debug', 'No user tasks file found');
-    return;
-  }
-
-  const inProgressTasks = userTaskData.grouped.in_progress || [];
-  emitLog('debug', `Checking for orphaned tasks: ${inProgressTasks.length} in_progress`);
+  const { user: userTaskData, cos: cosTaskData } = await getAllTasks();
 
   const runningAgentTaskIds = Object.values(state.agents)
     .filter(a => a.status === 'running')
@@ -803,10 +796,25 @@ async function resetOrphanedTasks() {
 
   emitLog('debug', `Running agents: ${runningAgentTaskIds.length}`, { taskIds: runningAgentTaskIds });
 
-  for (const task of inProgressTasks) {
-    if (!runningAgentTaskIds.includes(task.id)) {
-      emitLog('info', `Resetting orphaned task ${task.id} to pending`, { taskId: task.id });
-      await updateTask(task.id, { status: 'pending' }, 'user');
+  // Reset orphaned user tasks
+  if (userTaskData.exists) {
+    const inProgressUserTasks = userTaskData.grouped.in_progress || [];
+    for (const task of inProgressUserTasks) {
+      if (!runningAgentTaskIds.includes(task.id)) {
+        emitLog('info', `Resetting orphaned user task ${task.id} to pending`, { taskId: task.id });
+        await updateTask(task.id, { status: 'pending' }, 'user');
+      }
+    }
+  }
+
+  // Reset orphaned CoS internal tasks
+  if (cosTaskData.exists) {
+    const inProgressCosTasks = cosTaskData.grouped.in_progress || [];
+    for (const task of inProgressCosTasks) {
+      if (!runningAgentTaskIds.includes(task.id)) {
+        emitLog('info', `Resetting orphaned system task ${task.id} to pending`, { taskId: task.id });
+        await updateTask(task.id, { status: 'pending' }, 'internal');
+      }
     }
   }
 }

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -3086,7 +3086,7 @@ export async function addTask(taskData, taskType = 'user') {
   );
   if (duplicate) {
     console.log(`⚠️ Duplicate task rejected: "${taskData.description.substring(0, 60)}" matches ${duplicate.id}`);
-    return { duplicate: true, existingTask: duplicate };
+    return { ...duplicate, duplicate: true };
   }
 
   // Generate a unique ID if not provided

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -3070,6 +3070,17 @@ export async function addTask(taskData, taskType = 'user') {
     tasks = parseTasksMarkdown(content);
   }
 
+  // Reject duplicate: same description already pending or in_progress
+  const normalizedDesc = taskData.description.trim().toLowerCase();
+  const duplicate = tasks.find(t =>
+    (t.status === 'pending' || t.status === 'in_progress') &&
+    t.description?.trim().toLowerCase() === normalizedDesc
+  );
+  if (duplicate) {
+    console.log(`⚠️ Duplicate task rejected: "${taskData.description.substring(0, 60)}" matches ${duplicate.id}`);
+    return { duplicate: true, existingTask: duplicate };
+  }
+
   // Generate a unique ID if not provided
   const id = taskData.id || `${taskType === 'user' ? 'task' : 'sys'}-${Date.now().toString(36)}`;
 

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -227,7 +227,7 @@ export async function fetchOrigin(dir) {
 }
 
 /**
- * Update dev and main branches from origin without switching branches.
+ * Update all local branches that have remote tracking branches.
  * Uses fetch refspecs for non-current branches to avoid checkout (which
  * would swap files on disk and trigger HMR/server restarts).
  */
@@ -236,8 +236,8 @@ export async function updateBranches(dir) {
 
   const status = await getStatus(dir);
   const currentBranch = await getBranch(dir);
-  const { baseBranch, devBranch } = await getRepoBranches(dir);
-  const trackBranches = [devBranch, baseBranch].filter(Boolean);
+  const allBranches = await getBranches(dir);
+  const trackBranches = allBranches.filter(b => b.tracking).map(b => b.name);
   let stashed = false;
   let stashRestored = false;
 

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -313,6 +313,38 @@ export async function push(dir, branch = null) {
 }
 
 /**
+ * Push all local branches that are ahead of their remote tracking branch.
+ * Never uses --force. Returns per-branch results.
+ */
+export async function pushAll(dir) {
+  const allBranches = await getBranches(dir);
+  const pushable = allBranches.filter(b => b.tracking && b.ahead > 0);
+
+  if (pushable.length === 0) {
+    return { success: true, pushed: 0, results: {}, message: 'Nothing to push' };
+  }
+
+  const results = {};
+  let failed = 0;
+
+  for (const branch of pushable) {
+    const r = await execGit(['push', 'origin', branch.name], dir, { ignoreExitCode: true });
+    const output = (r.stdout || '') + (r.stderr || '');
+    const ok = !output.includes('rejected') && !output.includes('fatal') && !output.includes('error:');
+    results[branch.name] = { success: ok, output: output.trim() };
+    if (!ok) failed++;
+  }
+
+  return {
+    success: failed === 0,
+    pushed: pushable.length - failed,
+    failed,
+    total: pushable.length,
+    results
+  };
+}
+
+/**
  * Create and switch to a new branch
  */
 export async function createBranch(dir, branchName) {

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -34,7 +34,7 @@ function execGit(args, cwd, options = {}) {
       if (code !== 0 && !options.ignoreExitCode) {
         reject(new Error(stderr || `git exited with code ${code}`));
       } else {
-        resolve({ stdout, stderr });
+        resolve({ stdout, stderr, exitCode: code });
       }
     });
 
@@ -330,7 +330,7 @@ export async function pushAll(dir) {
   for (const branch of pushable) {
     const r = await execGit(['push', 'origin', branch.name], dir, { ignoreExitCode: true });
     const output = (r.stdout || '') + (r.stderr || '');
-    const ok = !output.includes('rejected') && !output.includes('fatal') && !output.includes('error:');
+    const ok = r.exitCode === 0;
     results[branch.name] = { success: ok, output: output.trim() };
     if (!ok) failed++;
   }

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -8,7 +8,7 @@ import { safeJSONParse } from '../lib/fileUtils.js';
  * @param {string[]} args - Git command arguments
  * @param {string} cwd - Working directory
  * @param {object} options - Additional options
- * @returns {Promise<{stdout: string, stderr: string}>}
+ * @returns {Promise<{stdout: string, stderr: string, exitCode: number}>}
  */
 function execGit(args, cwd, options = {}) {
   return new Promise((resolve, reject) => {

--- a/server/services/shell.js
+++ b/server/services/shell.js
@@ -2,10 +2,10 @@ import * as pty from 'node-pty';
 import os from 'os';
 import { v4 as uuidv4 } from 'uuid';
 
-// Store active shell sessions
+// Store active shell sessions (persist across socket reconnects)
 const shellSessions = new Map();
 
-const MAX_SESSIONS_PER_SOCKET = 3;
+const MAX_TOTAL_SESSIONS = 5;
 
 // Allowlist of safe environment variable prefixes to pass to PTY sessions
 // Prevents leaking secrets (API keys, tokens) to the shell
@@ -42,10 +42,9 @@ function getDefaultShell() {
  * Create a new shell session
  */
 export function createShellSession(socket, options = {}) {
-  const existing = getSessionsForSocket(socket);
-  if (existing.length >= MAX_SESSIONS_PER_SOCKET) {
-    console.warn(`🐚 Socket ${socket.id} exceeded max sessions (${MAX_SESSIONS_PER_SOCKET})`);
-    socket.emit('shell:error', { error: `Max ${MAX_SESSIONS_PER_SOCKET} shell sessions per connection` });
+  if (shellSessions.size >= MAX_TOTAL_SESSIONS) {
+    console.warn(`🐚 Max total sessions reached (${MAX_TOTAL_SESSIONS})`);
+    socket.emit('shell:error', { error: `Max ${MAX_TOTAL_SESSIONS} shell sessions. Kill an existing session first.` });
     return null;
   }
 
@@ -76,26 +75,93 @@ export function createShellSession(socket, options = {}) {
     return null;
   }
 
+  // Buffer recent output for re-attach (last 50KB)
+  const outputBuffer = [];
+  let bufferSize = 0;
+  const MAX_BUFFER = 50 * 1024;
+
   // Store session info
   shellSessions.set(sessionId, {
     pty: ptyProcess,
     socket,
-    createdAt: Date.now()
+    cwd,
+    createdAt: Date.now(),
+    outputBuffer,
+    bufferSize: () => bufferSize
   });
 
   // Handle pty output
   ptyProcess.onData((data) => {
-    socket.emit('shell:output', { sessionId, data });
+    // Buffer output for re-attach
+    outputBuffer.push(data);
+    bufferSize += data.length;
+    while (bufferSize > MAX_BUFFER && outputBuffer.length > 1) {
+      bufferSize -= outputBuffer.shift().length;
+    }
+    const session = shellSessions.get(sessionId);
+    session?.socket?.emit('shell:output', { sessionId, data });
   });
 
   // Handle pty exit
   ptyProcess.onExit(({ exitCode }) => {
     console.log(`🐚 Shell session ${sessionId.slice(0, 8)} exited (code: ${exitCode})`);
+    const session = shellSessions.get(sessionId);
     shellSessions.delete(sessionId);
-    socket.emit('shell:exit', { sessionId, code: exitCode });
+    session?.socket?.emit('shell:exit', { sessionId, code: exitCode });
+    // Notify all sockets about session list change
+    broadcastSessionList();
   });
 
+  broadcastSessionList();
   return sessionId;
+}
+
+/**
+ * Attach an existing session to a new socket
+ */
+export function attachSession(sessionId, socket) {
+  const session = shellSessions.get(sessionId);
+  if (!session) return null;
+  // Detach from old socket
+  session.socket = socket;
+  console.log(`🐚 Attached session ${sessionId.slice(0, 8)} to socket ${socket.id}`);
+  return {
+    sessionId,
+    bufferedOutput: session.outputBuffer.join('')
+  };
+}
+
+// Subscribers for session list broadcasts
+const sessionListSubscribers = new Set();
+
+export function subscribeSessionList(socket) {
+  sessionListSubscribers.add(socket);
+}
+
+export function unsubscribeSessionList(socket) {
+  sessionListSubscribers.delete(socket);
+}
+
+function broadcastSessionList() {
+  const list = listAllSessions();
+  for (const sock of sessionListSubscribers) {
+    sock.emit('shell:sessions', list);
+  }
+}
+
+/**
+ * List all active sessions with metadata
+ */
+export function listAllSessions() {
+  const sessions = [];
+  for (const [sessionId, session] of shellSessions.entries()) {
+    sessions.push({
+      sessionId,
+      cwd: session.cwd,
+      createdAt: session.createdAt
+    });
+  }
+  return sessions;
 }
 
 /**
@@ -131,33 +197,25 @@ export function killSession(sessionId) {
     console.log(`🐚 Killing shell session ${sessionId.slice(0, 8)}`);
     session.pty.kill();
     shellSessions.delete(sessionId);
+    broadcastSessionList();
     return true;
   }
   return false;
 }
 
 /**
- * Get all active sessions for a socket
+ * Detach all sessions from a socket (on disconnect) — sessions stay alive
  */
-export function getSessionsForSocket(socket) {
-  const sessions = [];
-  for (const [sessionId, session] of shellSessions.entries()) {
+export function detachSocketSessions(socket) {
+  let count = 0;
+  for (const [, session] of shellSessions.entries()) {
     if (session.socket === socket) {
-      sessions.push(sessionId);
+      session.socket = null;
+      count++;
     }
   }
-  return sessions;
-}
-
-/**
- * Clean up all sessions for a socket (on disconnect)
- */
-export function cleanupSocketSessions(socket) {
-  const sessions = getSessionsForSocket(socket);
-  for (const sessionId of sessions) {
-    killSession(sessionId);
-  }
-  return sessions.length;
+  unsubscribeSessionList(socket);
+  return count;
 }
 
 /**

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -384,6 +384,22 @@ export function initSocket(io) {
       }
     });
 
+    socket.on('shell:attach', (rawData) => {
+      const validated = validateSocketData(shellStopSchema, rawData, socket, 'shell:attach');
+      if (!validated) return;
+      const result = shellService.attachSession(validated.sessionId, socket);
+      if (result) {
+        socket.emit('shell:attached', result);
+      } else {
+        socket.emit('shell:error', { error: 'Session not found' });
+      }
+    });
+
+    socket.on('shell:list', () => {
+      shellService.subscribeSessionList(socket);
+      socket.emit('shell:sessions', shellService.listAllSessions());
+    });
+
     socket.on('shell:input', (rawData) => {
       const validated = validateSocketData(shellInputSchema, rawData, socket, 'shell:input');
       if (!validated) return;
@@ -404,7 +420,7 @@ export function initSocket(io) {
       shellService.killSession(validated.sessionId);
     });
 
-    // Cleanup on disconnect
+    // Cleanup on disconnect — detach sessions, don't kill them
     socket.on('disconnect', () => {
       console.log(`🔌 Client disconnected: ${socket.id}`);
       cleanupStream(socket.id);
@@ -413,10 +429,9 @@ export function initSocket(io) {
       notificationSubscribers.delete(socket);
       agentSubscribers.delete(socket);
       instanceSubscribers.delete(socket);
-      // Clean up any shell sessions for this socket
-      const shellsClosed = shellService.cleanupSocketSessions(socket);
-      if (shellsClosed > 0) {
-        console.log(`🐚 Cleaned up ${shellsClosed} shell session(s)`);
+      const detached = shellService.detachSocketSessions(socket);
+      if (detached > 0) {
+        console.log(`🐚 Detached ${detached} shell session(s) (still running)`);
       }
     });
   });

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -25,6 +25,7 @@ import {
   errorRecoverSchema,
   shellInputSchema,
   shellResizeSchema,
+  shellSessionIdSchema,
   shellStopSchema,
   appUpdateSchema,
   appStandardizeSchema
@@ -385,7 +386,7 @@ export function initSocket(io) {
     });
 
     socket.on('shell:attach', (rawData) => {
-      const validated = validateSocketData(shellStopSchema, rawData, socket, 'shell:attach');
+      const validated = validateSocketData(shellSessionIdSchema, rawData, socket, 'shell:attach');
       if (!validated) return;
       const result = shellService.attachSession(validated.sessionId, socket);
       if (result) {

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -2400,16 +2400,16 @@ function buildSpawnArgs(config, model) {
 }
 
 /**
- * Read env vars from ~/.claude/settings.json to inject into Claude CLI spawns
- * Ensures user's Bedrock/provider config (CLAUDE_CODE_USE_BEDROCK, AWS_PROFILE, etc.)
- * is present in spawned agent environments even if PM2 was started without them
- */
-/**
  * Check if a provider is a Claude CLI provider that needs settings.json env injection
  */
 const isClaudeCliProvider = (provider) =>
   provider?.type === 'cli' && (provider.id === 'claude-code' || provider.id === 'claude-code-bedrock');
 
+/**
+ * Read env vars from ~/.claude/settings.json to inject into Claude CLI spawns
+ * Ensures user's Bedrock/provider config (CLAUDE_CODE_USE_BEDROCK, AWS_PROFILE, etc.)
+ * is present in spawned agent environments even if PM2 was started without them
+ */
 let _claudeSettingsEnvCache = null;
 let _claudeSettingsEnvCacheTime = 0;
 const SETTINGS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -1687,7 +1687,7 @@ async function spawnViaRunner(agentId, task, prompt, workspacePath, model, provi
 
   // For Claude CLI providers, merge ~/.claude/settings.json env vars so Bedrock config
   // (CLAUDE_CODE_USE_BEDROCK, AWS_PROFILE, etc.) is present in the runner spawn env
-  const claudeSettingsEnv = provider.type === 'cli' && (provider.id === 'claude-code' || provider.id === 'claude-code-bedrock')
+  const claudeSettingsEnv = isClaudeCliProvider(provider)
     ? await getClaudeSettingsEnv()
     : {};
 
@@ -1931,7 +1931,7 @@ async function spawnDirectly(agentId, task, prompt, workspacePath, model, provid
 
   // For Claude CLI providers, inject ~/.claude/settings.json env vars so Bedrock config
   // (CLAUDE_CODE_USE_BEDROCK, AWS_PROFILE, etc.) is present even if PM2 lacks them
-  const claudeSettingsEnv = provider.type === 'cli' && (provider.id === 'claude-code' || provider.id === 'claude-code-bedrock')
+  const claudeSettingsEnv = isClaudeCliProvider(provider)
     ? await getClaudeSettingsEnv()
     : {};
 
@@ -2404,6 +2404,12 @@ function buildSpawnArgs(config, model) {
  * Ensures user's Bedrock/provider config (CLAUDE_CODE_USE_BEDROCK, AWS_PROFILE, etc.)
  * is present in spawned agent environments even if PM2 was started without them
  */
+/**
+ * Check if a provider is a Claude CLI provider that needs settings.json env injection
+ */
+const isClaudeCliProvider = (provider) =>
+  provider?.type === 'cli' && (provider.id === 'claude-code' || provider.id === 'claude-code-bedrock');
+
 let _claudeSettingsEnvCache = null;
 let _claudeSettingsEnvCacheTime = 0;
 const SETTINGS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -2342,19 +2342,21 @@ function buildCliSpawnConfig(provider, model) {
   }
 
   // Default: Claude Code CLI
+  // Use provider's configured command (respects user's Claude setup, e.g. Bedrock)
   const args = [
     '--dangerously-skip-permissions', // Unrestricted mode
     '--print',                          // Print output and exit
     '--output-format', 'stream-json',   // Stream JSON events for live output
     '--verbose',                        // Required for stream-json
     '--include-partial-messages',       // Include incremental text deltas
+    ...(provider?.args || []),          // User-configured provider args
   ];
   if (model) {
     args.push('--model', model);
   }
 
   return {
-    command: process.env.CLAUDE_PATH || 'claude',
+    command: provider?.command || process.env.CLAUDE_PATH || 'claude',
     args,
     stdinMode: 'prompt',
     streamFormat: 'stream-json'

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -1685,13 +1685,19 @@ async function spawnViaRunner(agentId, task, prompt, workspacePath, model, provi
     }
   }, 3000);
 
+  // For Claude CLI providers, merge ~/.claude/settings.json env vars so Bedrock config
+  // (CLAUDE_CODE_USE_BEDROCK, AWS_PROFILE, etc.) is present in the runner spawn env
+  const claudeSettingsEnv = provider.type === 'cli' && (provider.id === 'claude-code' || provider.id === 'claude-code-bedrock')
+    ? await getClaudeSettingsEnv()
+    : {};
+
   const result = await spawnAgentViaRunner({
     agentId,
     taskId: task.id,
     prompt,
     workspacePath,
     model,
-    envVars: provider.envVars,
+    envVars: { ...claudeSettingsEnv, ...provider.envVars },
     cliCommand: cliConfig.command,
     cliArgs: cliConfig.args
   });
@@ -1923,12 +1929,18 @@ async function spawnDirectly(agentId, task, prompt, workspacePath, model, provid
   // Ensure workspacePath is valid
   const cwd = workspacePath && typeof workspacePath === 'string' ? workspacePath : ROOT_DIR;
 
+  // For Claude CLI providers, inject ~/.claude/settings.json env vars so Bedrock config
+  // (CLAUDE_CODE_USE_BEDROCK, AWS_PROFILE, etc.) is present even if PM2 lacks them
+  const claudeSettingsEnv = provider.type === 'cli' && (provider.id === 'claude-code' || provider.id === 'claude-code-bedrock')
+    ? await getClaudeSettingsEnv()
+    : {};
+
   const claudeProcess = spawn(cliConfig.command, cliConfig.args, {
     cwd,
     shell: false,
     stdio: ['pipe', 'pipe', 'pipe'],
     windowsHide: true,
-    env: (() => { const e = { ...process.env, ...provider.envVars }; delete e.CLAUDECODE; return e; })()
+    env: (() => { const e = { ...process.env, ...claudeSettingsEnv, ...provider.envVars }; delete e.CLAUDECODE; return e; })()
   });
 
   registerSpawnedAgent(claudeProcess.pid, {
@@ -2388,6 +2400,29 @@ function buildSpawnArgs(config, model) {
 }
 
 /**
+ * Read env vars from ~/.claude/settings.json to inject into Claude CLI spawns
+ * Ensures user's Bedrock/provider config (CLAUDE_CODE_USE_BEDROCK, AWS_PROFILE, etc.)
+ * is present in spawned agent environments even if PM2 was started without them
+ */
+let _claudeSettingsEnvCache = null;
+async function getClaudeSettingsEnv() {
+  if (_claudeSettingsEnvCache !== null) return _claudeSettingsEnvCache;
+  try {
+    const settingsPath = join(homedir(), '.claude', 'settings.json');
+    if (existsSync(settingsPath)) {
+      const raw = await readFile(settingsPath, 'utf-8');
+      const settings = JSON.parse(raw);
+      _claudeSettingsEnvCache = settings.env || {};
+    } else {
+      _claudeSettingsEnvCache = {};
+    }
+  } catch (err) {
+    _claudeSettingsEnvCache = {};
+  }
+  return _claudeSettingsEnvCache;
+}
+
+/**
  * Read CLAUDE.md files for agent context
  * Reads both global (~/.claude/CLAUDE.md) and project-specific (./CLAUDE.md)
  */
@@ -2745,7 +2780,7 @@ async function createJiraTicketForTask(task, app) {
     ticketUrl: result.url
   });
 
-  return { ticketId: result.ticketId, ticketUrl: result.url };
+  return { ticketId: result.ticketId, ticketUrl: result.url, summary };
 }
 
 /**

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -2405,8 +2405,10 @@ function buildSpawnArgs(config, model) {
  * is present in spawned agent environments even if PM2 was started without them
  */
 let _claudeSettingsEnvCache = null;
+let _claudeSettingsEnvCacheTime = 0;
+const SETTINGS_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 async function getClaudeSettingsEnv() {
-  if (_claudeSettingsEnvCache !== null) return _claudeSettingsEnvCache;
+  if (_claudeSettingsEnvCache !== null && (Date.now() - _claudeSettingsEnvCacheTime) < SETTINGS_CACHE_TTL_MS) return _claudeSettingsEnvCache;
   try {
     const settingsPath = join(homedir(), '.claude', 'settings.json');
     if (existsSync(settingsPath)) {
@@ -2419,6 +2421,7 @@ async function getClaudeSettingsEnv() {
   } catch (err) {
     _claudeSettingsEnvCache = {};
   }
+  _claudeSettingsEnvCacheTime = Date.now();
   return _claudeSettingsEnvCache;
 }
 
@@ -2740,7 +2743,7 @@ async function generateJiraTitle(description) {
 /**
  * Create a JIRA ticket for a task if the app has JIRA integration enabled.
  * Non-blocking — returns null on failure.
- * @returns {Promise<{ticketId: string, ticketUrl: string}|null>}
+ * @returns {Promise<{ticketId: string, ticketUrl: string, summary: string}|null>}
  */
 async function createJiraTicketForTask(task, app) {
   const jira = app?.jira;

--- a/server/services/thinkingLevels.js
+++ b/server/services/thinkingLevels.js
@@ -48,7 +48,7 @@ const THINKING_LEVELS = {
     model: 'opus',
     maxTokens: 16384,
     localPreferred: false,
-    description: 'Maximum reasoning with Opus'
+    description: 'Maximum reasoning with provider\'s heaviest model'
   }
 }
 

--- a/server/services/thinkingLevels.js
+++ b/server/services/thinkingLevels.js
@@ -233,7 +233,7 @@ function getModelForLevel(level, provider = {}) {
     case 'provider-heavy':
       return provider.heavyModel || null
     case 'opus':
-      return 'claude-opus-4-20250514'
+      return provider.heavyModel || provider.defaultModel || null
     default:
       return modelKey
   }

--- a/server/services/thinkingLevels.test.js
+++ b/server/services/thinkingLevels.test.js
@@ -205,6 +205,16 @@ describe('Thinking Levels Service', () => {
       expect(getModelForLevel('xhigh', provider)).toBe('heavy-model');
     });
 
+    it('should fall back to defaultModel for xhigh when heavyModel is absent', () => {
+      const provider = { defaultModel: 'default-model' };
+      expect(getModelForLevel('xhigh', provider)).toBe('default-model');
+    });
+
+    it('should return null for xhigh when neither heavyModel nor defaultModel is configured', () => {
+      const provider = {};
+      expect(getModelForLevel('xhigh', provider)).toBeNull();
+    });
+
     it('should return null for invalid level', () => {
       expect(getModelForLevel('invalid')).toBeNull();
     });

--- a/server/services/thinkingLevels.test.js
+++ b/server/services/thinkingLevels.test.js
@@ -200,8 +200,9 @@ describe('Thinking Levels Service', () => {
       expect(getModelForLevel('high', provider)).toBe('heavy-model');
     });
 
-    it('should return opus for xhigh', () => {
-      expect(getModelForLevel('xhigh')).toBe('claude-opus-4-20250514');
+    it('should return provider heavy for xhigh', () => {
+      const provider = { heavyModel: 'heavy-model', defaultModel: 'default-model' };
+      expect(getModelForLevel('xhigh', provider)).toBe('heavy-model');
     });
 
     it('should return null for invalid level', () => {


### PR DESCRIPTION
# Release v1.28.0

Released: 2026-03-04

## Features

- **CoS**: Add screenshot upload to resume task modal
- **Git**: Add Push button to push all branches with unpushed commits
- **Shell**: Persist sessions across page navigations with session switcher
- **Shell**: Improve session management with always-visible controls
- **Shell**: Add quick command buttons and app folder cd selector
- **Dashboard**: Link app card names to individual app detail pages

## Fixes

- **UI**: Inject root package.json version into client build via Vite define
- **UI**: Inline delete for history/runs instead of full page reload
- **Agents**: Fix opus model ID for Bedrock and inject settings.json env vars
- **Agents**: Respect user's Claude CLI provider config in buildCliSpawnConfig
- **Agents**: Filter macOS app bundles from agent process list
- **Shell**: Handle socket disconnect to prevent stuck session attach
- **Shell**: Use managed apps list instead of scaffold directories for cd selector
- **SPA**: Prevent MIME type error on stale lazy-loaded chunks
- **CoS**: Reset orphaned system tasks, not just user tasks
- **CoS**: Make hover-only buttons visible on mobile touch devices
- **CoS**: Prevent duplicate task submissions from rapid taps
- **CoS**: Prevent agent output markdown from overflowing on mobile
- **Apps**: Make app detail button header more compact on mobile
- **Git**: Update all tracked branches instead of hardcoded dev/main
- **Providers**: Use provider model IDs instead of hardcoded values in thinkingLevels

## Style

- **Shell**: Make page header responsive on mobile
- **Meatspace**: Make alcohol daily consumption widget mobile-friendly

**Full Diff**: https://github.com/atomantic/PortOS/compare/v1.27.5...v1.28.0