### PR TITLE
feat: peer-to-peer brain + CoS memory sync

### DIFF
--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { GitBranch, Plus, Minus, FileText, RefreshCw, Download, Rocket, Upload, ArrowUpDown, Check } from 'lucide-react';
+import { GitBranch, Plus, Minus, FileText, RefreshCw, Download, Rocket, Upload, ArrowUpDown, Check, Trash2, GitMerge, Globe } from 'lucide-react';
 import toast from 'react-hot-toast';
 import BrailleSpinner from '../../BrailleSpinner';
 import * as api from '../../../services/api';
@@ -92,6 +92,11 @@ export default function GitTab({ appId, appName, repoPath }) {
   const [pushing, setPushing] = useState(null);
   const [syncing, setSyncing] = useState(null);
   const [pushingAll, setPushingAll] = useState(false);
+  const [remoteBranches, setRemoteBranches] = useState([]);
+  const [defaultBranch, setDefaultBranch] = useState('main');
+  const [loadingRemote, setLoadingRemote] = useState(false);
+  const [deleting, setDeleting] = useState(null);
+  const [deleteConfirm, setDeleteConfirm] = useState(null);
 
   const loadGitInfo = useCallback(async () => {
     if (!repoPath) return;
@@ -110,9 +115,21 @@ export default function GitTab({ appId, appName, repoPath }) {
     setLoading(false);
   }, [repoPath]);
 
+  const loadRemoteBranches = useCallback(async () => {
+    if (!repoPath) return;
+    setLoadingRemote(true);
+    const result = await api.getRemoteBranches(repoPath).catch(() => null);
+    if (result) {
+      setRemoteBranches(result.branches || []);
+      setDefaultBranch(result.defaultBranch || 'main');
+    }
+    setLoadingRemote(false);
+  }, [repoPath]);
+
   useEffect(() => {
     loadGitInfo();
-  }, [loadGitInfo]);
+    loadRemoteBranches();
+  }, [loadGitInfo, loadRemoteBranches]);
 
   const loadDiff = async () => {
     if (!repoPath) return;
@@ -232,6 +249,22 @@ export default function GitTab({ appId, appName, repoPath }) {
       toast.error(`Push failed for: ${failedNames.join(', ')}`);
     }
     await loadGitInfo();
+  };
+
+  const handleDeleteBranch = async (branchName, { local, remote }) => {
+    if (!repoPath || deleting) return;
+    setDeleting(branchName);
+    setDeleteConfirm(null);
+    const result = await api.deleteBranch(repoPath, branchName, { local, remote }).catch((err) => {
+      toast.error(`Delete failed: ${err.message}`);
+      return null;
+    });
+    setDeleting(null);
+    if (result) {
+      const parts = Object.entries(result.results || {}).map(([k, v]) => `${k}: ${v}`);
+      toast.success(`Branch ${branchName} — ${parts.join(', ')}`);
+      await Promise.all([loadGitInfo(), loadRemoteBranches()]);
+    }
   };
 
   const getStatusIcon = (file) => {
@@ -507,6 +540,102 @@ export default function GitTab({ appId, appName, repoPath }) {
                 </div>
               </div>
             </div>
+          </div>
+
+          {/* Remote Branches */}
+          <div className="bg-port-card border border-port-border rounded-xl p-4">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <Globe size={16} className="text-gray-400" />
+                <h3 className="text-sm font-medium text-gray-400">Remote Branches</h3>
+                {remoteBranches.length > 0 && (
+                  <span className="text-xs text-gray-500">({remoteBranches.length})</span>
+                )}
+              </div>
+              <button
+                onClick={loadRemoteBranches}
+                disabled={loadingRemote}
+                className="text-xs text-port-accent hover:underline disabled:opacity-50"
+              >
+                {loadingRemote ? 'Refreshing...' : 'Refresh'}
+              </button>
+            </div>
+            {loadingRemote && remoteBranches.length === 0 ? (
+              <div className="text-center py-4"><BrailleSpinner text="Loading remote branches" /></div>
+            ) : (
+              <div className="space-y-1.5 max-h-80 overflow-auto">
+                {remoteBranches.map((rb) => (
+                  <div
+                    key={rb.fullRef}
+                    className={`flex items-center justify-between py-2 px-2 rounded-lg hover:bg-port-bg ${rb.isDefault ? 'bg-port-accent/5' : ''}`}
+                  >
+                    <div className="flex items-center gap-2 min-w-0 flex-1">
+                      <GitBranch size={14} className={rb.isDefault ? 'text-port-accent shrink-0' : 'text-gray-500 shrink-0'} />
+                      <span className={`text-sm truncate ${rb.isDefault ? 'text-port-accent font-medium' : 'text-gray-300'}`}>
+                        {rb.name}
+                      </span>
+                      {rb.merged && !rb.isDefault && (
+                        <span className="flex items-center gap-1 text-xs text-port-success px-1.5 py-0.5 bg-port-success/10 rounded shrink-0">
+                          <GitMerge size={10} />
+                          merged
+                        </span>
+                      )}
+                      {rb.hasLocal && (
+                        <span className="text-xs text-gray-500 shrink-0">local</span>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2 shrink-0">
+                      {rb.lastCommitDate && (
+                        <span className="text-xs text-gray-500">
+                          {new Date(rb.lastCommitDate).toLocaleDateString()}
+                        </span>
+                      )}
+                      {!rb.isDefault && (
+                        <>
+                          {deleteConfirm === rb.name ? (
+                            <div className="flex items-center gap-1">
+                              <button
+                                onClick={() => handleDeleteBranch(rb.name, { local: rb.hasLocal, remote: true })}
+                                disabled={deleting === rb.name}
+                                className="px-2 py-1 text-xs bg-port-error/20 text-port-error rounded hover:bg-port-error/30 disabled:opacity-50"
+                              >
+                                {deleting === rb.name ? 'Deleting...' : rb.hasLocal ? 'Delete both' : 'Delete remote'}
+                              </button>
+                              {rb.hasLocal && (
+                                <button
+                                  onClick={() => handleDeleteBranch(rb.name, { local: false, remote: true })}
+                                  disabled={deleting === rb.name}
+                                  className="px-2 py-1 text-xs bg-port-warning/20 text-port-warning rounded hover:bg-port-warning/30 disabled:opacity-50"
+                                >
+                                  Remote only
+                                </button>
+                              )}
+                              <button
+                                onClick={() => setDeleteConfirm(null)}
+                                className="px-2 py-1 text-xs text-gray-400 hover:text-white"
+                              >
+                                Cancel
+                              </button>
+                            </div>
+                          ) : (
+                            <button
+                              onClick={() => setDeleteConfirm(rb.name)}
+                              className="p-1.5 text-gray-500 hover:text-port-error hover:bg-port-bg rounded"
+                              title="Delete branch"
+                            >
+                              <Trash2 size={14} />
+                            </button>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  </div>
+                ))}
+                {remoteBranches.length === 0 && !loadingRemote && (
+                  <div className="text-gray-500 text-sm">No remote branches found</div>
+                )}
+              </div>
+            )}
           </div>
         </div>
       ) : (

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -342,22 +342,6 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     return (
       <>
         <div className="flex items-center gap-6 flex-wrap">
-          <div className="flex items-center gap-3">
-            <label htmlFor="add-position" className="text-sm text-gray-400">Queue Position:</label>
-            <button
-              id="add-position"
-              type="button"
-              onClick={() => setAddToTop(!addToTop)}
-              className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm transition-colors ${
-                addToTop
-                  ? 'bg-port-accent/20 text-port-accent border border-port-accent/50'
-                  : 'bg-port-bg text-gray-400 border border-port-border'
-              }`}
-              aria-pressed={addToTop}
-            >
-              {addToTop ? 'Top of Queue' : 'Bottom of Queue'}
-            </button>
-          </div>
           <label className="flex items-center gap-2 cursor-pointer select-none">
             <input
               type="checkbox"
@@ -582,7 +566,23 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
           </div>
         )}
         {!compact && (
-          <div className="flex justify-end gap-2">
+          <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 mr-auto">
+              <label htmlFor="add-position" className="text-sm text-gray-400">Queue:</label>
+              <button
+                id="add-position"
+                type="button"
+                onClick={() => setAddToTop(!addToTop)}
+                className={`flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm transition-colors ${
+                  addToTop
+                    ? 'bg-port-accent/20 text-port-accent border border-port-accent/50'
+                    : 'bg-port-bg text-gray-400 border border-port-border'
+                }`}
+                aria-pressed={addToTop}
+              >
+                {addToTop ? 'Top of Queue' : 'Bottom of Queue'}
+              </button>
+            </div>
             <button
               onClick={saveAsTemplate}
               type="button"

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -1059,8 +1059,8 @@ export const openBrainLinkFolder = (id) => request(`/brain/links/${id}/open-fold
 // Brain - Graph
 export const getBrainGraph = () => request('/brain/graph');
 
-// Brain - Sync
-export const syncBrainData = () => request('/brain/sync', { method: 'POST' });
+// Brain - Bridge Sync (brain data to CoS memory system)
+export const syncBrainData = () => request('/brain/bridge-sync', { method: 'POST' });
 
 // Media - Server media devices
 export const getMediaDevices = () => request('/media/devices');

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -349,6 +349,15 @@ export const syncBranch = (path, branch) => request('/git/sync', {
   method: 'POST',
   body: JSON.stringify({ path, branch })
 });
+export const getRemoteBranches = (path) => request('/git/remote-branches', {
+  method: 'POST',
+  body: JSON.stringify({ path })
+});
+export const deleteBranch = (path, branch, { local = false, remote = false } = {}) =>
+  request('/git/delete-branch', {
+    method: 'POST',
+    body: JSON.stringify({ path, branch, local, remote })
+  });
 
 // Usage
 export const getUsage = () => request('/usage');

--- a/server/index.js
+++ b/server/index.js
@@ -55,6 +55,9 @@ import githubRoutes from './routes/github.js';
 import settingsRoutes from './routes/settings.js';
 import updateRoutes from './routes/update.js';
 import { ensureSelf, startPolling } from './services/instances.js';
+import { initSyncLog } from './services/brainSyncLog.js';
+import { backfillOriginInstanceId } from './services/brainStorage.js';
+import { initSyncOrchestrator } from './services/syncOrchestrator.js';
 import { initSocket } from './services/socket.js';
 import { initScriptRunner } from './services/scriptRunner.js';
 import { errorMiddleware, setupProcessErrorHandlers, asyncHandler } from './lib/errorHandler.js';
@@ -335,6 +338,13 @@ httpServer.listen(PORT, HOST, () => {
   // Set up process error handlers with io instance
   setupProcessErrorHandlers(io);
 
-  // Initialize instance identity and start peer polling
-  ensureSelf().then(() => startPolling()).catch(err => console.error(`❌ Instance init failed: ${err.message}`));
+  // Initialize instance identity, sync log, backfill origin tags, start peer polling + sync
+  ensureSelf()
+    .then(() => initSyncLog())
+    .then(() => backfillOriginInstanceId())
+    .then(() => {
+      startPolling();
+      initSyncOrchestrator();
+    })
+    .catch(err => console.error(`❌ Instance init failed: ${err.message}`));
 });

--- a/server/lib/brainValidation.js
+++ b/server/lib/brainValidation.js
@@ -373,3 +373,29 @@ export const linksQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(100).optional().default(50),
   offset: z.coerce.number().int().min(0).optional().default(0)
 });
+
+// =============================================================================
+// SYNC SCHEMAS
+// =============================================================================
+
+// Brain sync query schema (GET /api/brain/sync?since=N&limit=100)
+export const brainSyncQuerySchema = z.object({
+  since: z.coerce.number().int().min(0).default(0),
+  limit: z.coerce.number().int().min(1).max(1000).optional().default(100)
+});
+
+// Brain sync change object schema
+const brainSyncChangeSchema = z.object({
+  seq: z.number().int(),
+  op: z.enum(['create', 'update', 'delete']),
+  type: z.string(),
+  id: z.string(),
+  record: z.record(z.unknown()).nullable().optional(),
+  originInstanceId: z.string().optional(),
+  ts: z.string()
+});
+
+// Brain sync push schema (POST /api/brain/sync body)
+export const brainSyncPushSchema = z.object({
+  changes: z.array(brainSyncChangeSchema).min(1).max(1000)
+});

--- a/server/lib/brainValidation.test.js
+++ b/server/lib/brainValidation.test.js
@@ -26,7 +26,9 @@ import {
   inboxQuerySchema,
   linkRecordSchema,
   linkInputSchema,
-  linksQuerySchema
+  linksQuerySchema,
+  brainSyncQuerySchema,
+  brainSyncPushSchema
 } from './brainValidation.js';
 
 describe('brainValidation.js', () => {
@@ -517,6 +519,79 @@ describe('brainValidation.js', () => {
       const result = linksQuerySchema.safeParse({ linkType: 'documentation' });
       expect(result.success).toBe(true);
       expect(result.data.linkType).toBe('documentation');
+    });
+  });
+
+  describe('brainSyncQuerySchema', () => {
+    it('should accept valid query with defaults', () => {
+      const result = brainSyncQuerySchema.safeParse({});
+      expect(result.success).toBe(true);
+      expect(result.data.since).toBe(0);
+      expect(result.data.limit).toBe(100);
+    });
+
+    it('should coerce string since to number', () => {
+      const result = brainSyncQuerySchema.safeParse({ since: '5', limit: '50' });
+      expect(result.success).toBe(true);
+      expect(result.data.since).toBe(5);
+      expect(result.data.limit).toBe(50);
+    });
+
+    it('should reject negative since', () => {
+      const result = brainSyncQuerySchema.safeParse({ since: -1 });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject limit exceeding 1000', () => {
+      const result = brainSyncQuerySchema.safeParse({ limit: 1001 });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject limit of 0', () => {
+      const result = brainSyncQuerySchema.safeParse({ limit: 0 });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('brainSyncPushSchema', () => {
+    const validChange = {
+      seq: 1,
+      op: 'create',
+      type: 'people',
+      id: 'abc-123',
+      record: { name: 'Test' },
+      originInstanceId: 'inst-1',
+      ts: '2026-01-01T00:00:00Z'
+    };
+
+    it('should accept valid push with one change', () => {
+      const result = brainSyncPushSchema.safeParse({ changes: [validChange] });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject empty changes array', () => {
+      const result = brainSyncPushSchema.safeParse({ changes: [] });
+      expect(result.success).toBe(false);
+    });
+
+    it('should reject invalid op values', () => {
+      const result = brainSyncPushSchema.safeParse({
+        changes: [{ ...validChange, op: 'upsert' }]
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('should accept delete with null record', () => {
+      const result = brainSyncPushSchema.safeParse({
+        changes: [{ ...validChange, op: 'delete', record: null }]
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should accept change without optional fields', () => {
+      const { originInstanceId, record, ...minimal } = validChange;
+      const result = brainSyncPushSchema.safeParse({ changes: [minimal] });
+      expect(result.success).toBe(true);
     });
   });
 });

--- a/server/lib/memoryValidation.js
+++ b/server/lib/memoryValidation.js
@@ -132,6 +132,7 @@ const syncMemoryItemSchema = z.object({
   expiresAt: z.string().datetime().nullable().optional(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+  originInstanceId: z.string().max(36).nullable().optional(),
   syncSequence: z.string().regex(/^\d+$/).optional()
 });
 

--- a/server/lib/postValidation.js
+++ b/server/lib/postValidation.js
@@ -57,6 +57,14 @@ const taskResultSchema = z.object({
   responses: z.array(llmResponseSchema).optional().default([]),
   drillData: z.any().optional(),
   score: z.number().min(0).max(100).optional(),
+  evaluation: z.object({
+    score: z.number().min(0).max(100).optional(),
+    breakdown: z.array(z.object({
+      question: z.string().optional(),
+      score: z.number().min(0).max(100).optional(),
+      feedback: z.string().optional()
+    })).optional()
+  }).optional(),
   totalMs: z.number().min(0)
 });
 

--- a/server/routes/brain.js
+++ b/server/routes/brain.js
@@ -29,11 +29,15 @@ import {
   settingsUpdateInputSchema,
   linkInputSchema,
   linkUpdateInputSchema,
-  linksQuerySchema
+  linksQuerySchema,
+  brainSyncQuerySchema,
+  brainSyncPushSchema
 } from '../lib/brainValidation.js';
 import * as githubCloner from '../services/githubCloner.js';
 import { getBrainGraphData } from '../services/brainGraph.js';
 import { syncAllBrainData } from '../services/brainMemoryBridge.js';
+import * as brainSyncLog from '../services/brainSyncLog.js';
+import * as brainSync from '../services/brainSync.js';
 
 const router = Router();
 
@@ -729,17 +733,38 @@ router.get('/graph', asyncHandler(async (req, res) => {
 }));
 
 // =============================================================================
-// SYNC
+// SYNC (Federation)
 // =============================================================================
 
 /**
- * POST /api/brain/sync
+ * POST /api/brain/bridge-sync
  * Sync all brain data to CoS memory system (generates embeddings)
+ * (Renamed from /sync to avoid conflict with federation sync)
+ */
+router.post('/bridge-sync', asyncHandler(async (req, res) => {
+  const stats = await syncAllBrainData();
+  console.log(`🧠🔗 Brain bridge sync complete: ${stats.synced} synced, ${stats.skipped} skipped, ${stats.errors} errors`);
+  res.json(stats);
+}));
+
+/**
+ * GET /api/brain/sync?since={seq}&limit=100
+ * Get brain changes since a given sequence number (for peers to pull)
+ */
+router.get('/sync', asyncHandler(async (req, res) => {
+  const { since, limit } = validateRequest(brainSyncQuerySchema, req.query);
+  const result = await brainSyncLog.getChangesSince(since, limit);
+  res.json(result);
+}));
+
+/**
+ * POST /api/brain/sync
+ * Receive remote brain changes from a peer
  */
 router.post('/sync', asyncHandler(async (req, res) => {
-  const stats = await syncAllBrainData();
-  console.log(`🧠🔗 Brain sync complete: ${stats.synced} synced, ${stats.skipped} skipped, ${stats.errors} errors`);
-  res.json(stats);
+  const { changes } = validateRequest(brainSyncPushSchema, req.body);
+  const result = await brainSync.applyRemoteChanges(changes);
+  res.json(result);
 }));
 
 export default router;

--- a/server/routes/brain.test.js
+++ b/server/routes/brain.test.js
@@ -66,10 +66,22 @@ vi.mock('../services/brainMemoryBridge.js', () => ({
   syncAllBrainData: vi.fn()
 }));
 
+// Mock the brain sync log service
+vi.mock('../services/brainSyncLog.js', () => ({
+  getChangesSince: vi.fn()
+}));
+
+// Mock the brain sync service
+vi.mock('../services/brainSync.js', () => ({
+  applyRemoteChanges: vi.fn()
+}));
+
 // Import mocked modules
 import * as brainService from '../services/brain.js';
 import { getBrainGraphData } from '../services/brainGraph.js';
 import { syncAllBrainData } from '../services/brainMemoryBridge.js';
+import { getChangesSince } from '../services/brainSyncLog.js';
+import { applyRemoteChanges } from '../services/brainSync.js';
 
 describe('Brain Routes', () => {
   let app;
@@ -905,15 +917,15 @@ describe('Brain Routes', () => {
   });
 
   // ===========================================================================
-  // SYNC
+  // BRIDGE SYNC (renamed from /sync)
   // ===========================================================================
 
-  describe('POST /api/brain/sync', () => {
+  describe('POST /api/brain/bridge-sync', () => {
     it('should return sync stats', async () => {
       const mockStats = { synced: 5, skipped: 2, errors: 0 };
       syncAllBrainData.mockResolvedValue(mockStats);
 
-      const response = await request(app).post('/api/brain/sync');
+      const response = await request(app).post('/api/brain/bridge-sync');
       expect(response.status).toBe(200);
       expect(response.body.synced).toBe(5);
       expect(response.body.skipped).toBe(2);
@@ -923,8 +935,85 @@ describe('Brain Routes', () => {
     it('should return 500 when sync fails', async () => {
       syncAllBrainData.mockRejectedValue(new Error('Sync failed'));
 
-      const response = await request(app).post('/api/brain/sync');
+      const response = await request(app).post('/api/brain/bridge-sync');
       expect(response.status).toBe(500);
+    });
+  });
+
+  // ===========================================================================
+  // FEDERATION SYNC (peer-to-peer)
+  // ===========================================================================
+
+  describe('GET /api/brain/sync', () => {
+    it('should return changes since a given seq', async () => {
+      const mockResult = {
+        changes: [{ seq: 2, op: 'create', type: 'people', id: 'p1', record: { name: 'A' }, ts: '2026-01-01T00:00:00.000Z' }],
+        maxSeq: 2,
+        hasMore: false
+      };
+      getChangesSince.mockResolvedValue(mockResult);
+
+      const response = await request(app).get('/api/brain/sync?since=1');
+
+      expect(response.status).toBe(200);
+      expect(response.body.changes).toHaveLength(1);
+      expect(response.body.maxSeq).toBe(2);
+      expect(response.body.hasMore).toBe(false);
+      expect(getChangesSince).toHaveBeenCalledWith(1, 100);
+    });
+
+    it('should default since to 0', async () => {
+      getChangesSince.mockResolvedValue({ changes: [], maxSeq: 0, hasMore: false });
+
+      const response = await request(app).get('/api/brain/sync');
+
+      expect(response.status).toBe(200);
+      expect(getChangesSince).toHaveBeenCalledWith(0, 100);
+    });
+
+    it('should pass custom limit', async () => {
+      getChangesSince.mockResolvedValue({ changes: [], maxSeq: 0, hasMore: false });
+
+      await request(app).get('/api/brain/sync?since=0&limit=50');
+
+      expect(getChangesSince).toHaveBeenCalledWith(0, 50);
+    });
+  });
+
+  describe('POST /api/brain/sync', () => {
+    it('should apply remote changes and return stats', async () => {
+      const mockResult = { inserted: 2, updated: 1, deleted: 0, skipped: 1 };
+      applyRemoteChanges.mockResolvedValue(mockResult);
+
+      const response = await request(app)
+        .post('/api/brain/sync')
+        .send({
+          changes: [
+            { seq: 1, op: 'create', type: 'people', id: 'p1', record: { name: 'A' }, ts: '2026-01-01T00:00:00.000Z' },
+            { seq: 2, op: 'update', type: 'ideas', id: 'i1', record: { title: 'B' }, ts: '2026-01-01T00:00:00.000Z' }
+          ]
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.inserted).toBe(2);
+      expect(response.body.updated).toBe(1);
+      expect(applyRemoteChanges).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return 400 when changes array is empty', async () => {
+      const response = await request(app)
+        .post('/api/brain/sync')
+        .send({ changes: [] });
+
+      expect(response.status).toBe(400);
+    });
+
+    it('should return 400 when changes is missing', async () => {
+      const response = await request(app)
+        .post('/api/brain/sync')
+        .send({});
+
+      expect(response.status).toBe(400);
     });
   });
 });

--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -199,4 +199,32 @@ router.post('/sync', asyncHandler(async (req, res) => {
   res.json(result);
 }));
 
+// POST /api/git/remote-branches - Get remote branches with merge status
+router.post('/remote-branches', asyncHandler(async (req, res) => {
+  const { path } = req.body;
+
+  if (!path) {
+    throw new ServerError('path is required', { status: 400, code: 'VALIDATION_ERROR' });
+  }
+
+  const result = await git.getRemoteBranches(path);
+  res.json(result);
+}));
+
+// POST /api/git/delete-branch - Delete a branch locally and/or remotely
+router.post('/delete-branch', asyncHandler(async (req, res) => {
+  const { path, branch, local, remote } = req.body;
+
+  if (!path || !branch) {
+    throw new ServerError('path and branch are required', { status: 400, code: 'VALIDATION_ERROR' });
+  }
+
+  if (!local && !remote) {
+    throw new ServerError('at least one of local or remote must be true', { status: 400, code: 'VALIDATION_ERROR' });
+  }
+
+  const result = await git.deleteBranch(path, branch, { local, remote });
+  res.json(result);
+}));
+
 export default router;

--- a/server/scripts/init-db.sql
+++ b/server/scripts/init-db.sql
@@ -32,6 +32,10 @@ CREATE TABLE IF NOT EXISTS memories (
 -- Schema upgrades: add columns that may not exist on older installs
 ALTER TABLE memories ADD COLUMN IF NOT EXISTS sync_sequence BIGSERIAL;
 
+-- Origin instance tracking for federation
+ALTER TABLE memories ADD COLUMN IF NOT EXISTS origin_instance_id VARCHAR(36);
+CREATE INDEX IF NOT EXISTS idx_memories_origin_instance ON memories (origin_instance_id);
+
 -- HNSW index for fast vector similarity search (O(log n) instead of O(n))
 CREATE INDEX IF NOT EXISTS idx_memories_embedding
   ON memories USING hnsw (embedding vector_cosine_ops)

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -611,18 +611,20 @@ export async function applyRemoteRecord(type, id, record, op) {
  * Apply a remote JSONL record (digests/reviews) — dedup by ID
  */
 export async function applyRemoteJsonl(type, record) {
-  const records = await loadJsonlStore(type);
-  if (records.some(r => r.id === record.id)) {
-    return { applied: false, reason: 'duplicate' };
-  }
+  return withRemoteLock(async () => {
+    const records = await loadJsonlStore(type);
+    if (records.some(r => r.id === record.id)) {
+      return { applied: false, reason: 'duplicate' };
+    }
 
-  await ensureBrainDir();
-  const line = JSON.stringify(record) + '\n';
-  await appendFile(FILES[type], line);
-  caches[type].data = null;
-  caches[type].timestamp = 0;
+    await ensureBrainDir();
+    const line = JSON.stringify(record) + '\n';
+    await appendFile(FILES[type], line);
+    caches[type].data = null;
+    caches[type].timestamp = 0;
 
-  return { applied: true };
+    return { applied: true };
+  });
 }
 
 /**

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -15,20 +15,10 @@ import { v4 as uuidv4 } from 'uuid';
 import EventEmitter from 'events';
 import { readJSONFile, safeJSONParse } from '../lib/fileUtils.js';
 import { createMutex } from '../lib/asyncMutex.js';
-import { getSelf } from './instances.js';
+import { getInstanceId } from './instances.js';
 import * as brainSyncLog from './brainSyncLog.js';
 
 const withRemoteLock = createMutex();
-let cachedInstanceId = null;
-
-async function getInstanceId() {
-  if (!cachedInstanceId) {
-    const id = (await getSelf())?.instanceId;
-    if (id) cachedInstanceId = id;
-    return id ?? 'unknown';
-  }
-  return cachedInstanceId;
-}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -590,8 +590,8 @@ export async function applyRemoteRecord(type, id, record, op) {
 
     if (op === 'delete') {
       if (!data.records[id]) return { applied: false, reason: 'not_found' };
-      // LWW: only delete if local record isn't newer than the remote delete
-      if (record?.updatedAt && data.records[id].updatedAt > record.updatedAt) {
+      // LWW: only delete if local record isn't newer than the remote delete (>= for consistency with update path)
+      if (record?.updatedAt && data.records[id].updatedAt >= record.updatedAt) {
         return { applied: false, reason: 'local_newer' };
       }
       delete data.records[id];

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -23,7 +23,9 @@ let cachedInstanceId = null;
 
 async function getInstanceId() {
   if (!cachedInstanceId) {
-    cachedInstanceId = (await getSelf())?.instanceId ?? 'unknown';
+    const id = (await getSelf())?.instanceId;
+    if (id) cachedInstanceId = id;
+    return id ?? 'unknown';
   }
   return cachedInstanceId;
 }
@@ -611,8 +613,6 @@ export async function applyRemoteRecord(type, id, record, op) {
     return { applied: true };
   });
 }
-
-
 
 /**
  * Backfill originInstanceId on records missing it (run once at startup)

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -14,8 +14,19 @@ import { fileURLToPath } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 import EventEmitter from 'events';
 import { readJSONFile, safeJSONParse } from '../lib/fileUtils.js';
+import { createMutex } from '../lib/asyncMutex.js';
 import { getSelf } from './instances.js';
 import * as brainSyncLog from './brainSyncLog.js';
+
+const withRemoteLock = createMutex();
+let cachedInstanceId = null;
+
+async function getInstanceId() {
+  if (!cachedInstanceId) {
+    cachedInstanceId = (await getSelf())?.instanceId ?? 'unknown';
+  }
+  return cachedInstanceId;
+}
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -189,7 +200,7 @@ export async function create(type, recordData) {
   const data = await loadJsonStore(type);
   const id = generateId();
   const timestamp = now();
-  const originInstanceId = (await getSelf())?.instanceId ?? 'unknown';
+  const originInstanceId = await getInstanceId();
 
   const record = {
     ...recordData,
@@ -219,6 +230,7 @@ export async function update(type, id, updates) {
   const record = {
     ...data.records[id],
     ...updates,
+    // Preserve immutable fields — originInstanceId tracks the creating instance
     originInstanceId: data.records[id].originInstanceId,
     createdAt: data.records[id].createdAt,
     updatedAt: now()
@@ -572,25 +584,27 @@ export async function getLinkByUrl(url) {
  * Apply a remote record to a JSON store (last-writer-wins by updatedAt)
  */
 export async function applyRemoteRecord(type, id, record, op) {
-  const data = await loadJsonStore(type);
+  return withRemoteLock(async () => {
+    const data = await loadJsonStore(type);
 
-  if (op === 'delete') {
-    if (!data.records[id]) return { applied: false, reason: 'not_found' };
-    delete data.records[id];
-  } else {
-    const existing = data.records[id];
-    if (existing && existing.updatedAt >= record.updatedAt) {
-      return { applied: false, reason: 'local_newer' };
+    if (op === 'delete') {
+      if (!data.records[id]) return { applied: false, reason: 'not_found' };
+      delete data.records[id];
+    } else {
+      const existing = data.records[id];
+      if (existing && existing.updatedAt >= record.updatedAt) {
+        return { applied: false, reason: 'local_newer' };
+      }
+      data.records[id] = { ...record };
     }
-    data.records[id] = { ...record };
-  }
 
-  await ensureBrainDir();
-  await writeFile(FILES[type], JSON.stringify(data, null, 2));
-  caches[type].data = data;
-  caches[type].timestamp = Date.now();
+    await ensureBrainDir();
+    await writeFile(FILES[type], JSON.stringify(data, null, 2));
+    caches[type].data = data;
+    caches[type].timestamp = Date.now();
 
-  return { applied: true };
+    return { applied: true };
+  });
 }
 
 /**
@@ -615,8 +629,7 @@ export async function applyRemoteJsonl(type, record) {
  * Backfill originInstanceId on records missing it (run once at startup)
  */
 export async function backfillOriginInstanceId() {
-  const self = await getSelf();
-  const instanceId = self?.instanceId ?? 'unknown';
+  const instanceId = await getInstanceId();
   const entityTypes = ['people', 'projects', 'ideas', 'admin', 'memories', 'links'];
   let totalBackfilled = 0;
 

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -612,25 +612,7 @@ export async function applyRemoteRecord(type, id, record, op) {
   });
 }
 
-/**
- * Apply a remote JSONL record (digests/reviews) — dedup by ID
- */
-export async function applyRemoteJsonl(type, record) {
-  return withRemoteLock(async () => {
-    const records = await loadJsonlStore(type);
-    if (records.some(r => r.id === record.id)) {
-      return { applied: false, reason: 'duplicate' };
-    }
 
-    await ensureBrainDir();
-    const line = JSON.stringify(record) + '\n';
-    await appendFile(FILES[type], line);
-    caches[type].data = null;
-    caches[type].timestamp = 0;
-
-    return { applied: true };
-  });
-}
 
 /**
  * Backfill originInstanceId on records missing it (run once at startup)

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -14,6 +14,8 @@ import { fileURLToPath } from 'url';
 import { v4 as uuidv4 } from 'uuid';
 import EventEmitter from 'events';
 import { readJSONFile, safeJSONParse } from '../lib/fileUtils.js';
+import { getSelf } from './instances.js';
+import * as brainSyncLog from './brainSyncLog.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -187,15 +189,18 @@ export async function create(type, recordData) {
   const data = await loadJsonStore(type);
   const id = generateId();
   const timestamp = now();
+  const originInstanceId = (await getSelf())?.instanceId ?? 'unknown';
 
   const record = {
     ...recordData,
+    originInstanceId,
     createdAt: timestamp,
     updatedAt: timestamp
   };
 
   data.records[id] = record;
   await saveJsonStore(type, data);
+  brainSyncLog.appendChange('create', type, id, record, originInstanceId);
 
   console.log(`🧠 Created ${type} record: ${id}`);
   return { id, ...record };
@@ -214,12 +219,14 @@ export async function update(type, id, updates) {
   const record = {
     ...data.records[id],
     ...updates,
+    originInstanceId: data.records[id].originInstanceId,
     createdAt: data.records[id].createdAt,
     updatedAt: now()
   };
 
   data.records[id] = record;
   await saveJsonStore(type, data);
+  brainSyncLog.appendChange('update', type, id, record, record.originInstanceId);
 
   console.log(`🧠 Updated ${type} record: ${id}`);
   return { id, ...record };
@@ -235,8 +242,10 @@ export async function remove(type, id) {
     return false;
   }
 
+  const originInstanceId = data.records[id]?.originInstanceId ?? 'unknown';
   delete data.records[id];
   await saveJsonStore(type, data);
+  brainSyncLog.appendChange('delete', type, id, null, originInstanceId);
 
   console.log(`🧠 Deleted ${type} record: ${id}`);
   return true;
@@ -553,6 +562,87 @@ export const deleteLink = (id) => remove('links', id);
 export async function getLinkByUrl(url) {
   const links = await getAll('links');
   return links.find(link => link.url === url) || null;
+}
+
+// =============================================================================
+// REMOTE SYNC OPERATIONS (no events, no sync log — echo prevention)
+// =============================================================================
+
+/**
+ * Apply a remote record to a JSON store (last-writer-wins by updatedAt)
+ */
+export async function applyRemoteRecord(type, id, record, op) {
+  const data = await loadJsonStore(type);
+
+  if (op === 'delete') {
+    if (!data.records[id]) return { applied: false, reason: 'not_found' };
+    delete data.records[id];
+  } else {
+    const existing = data.records[id];
+    if (existing && existing.updatedAt >= record.updatedAt) {
+      return { applied: false, reason: 'local_newer' };
+    }
+    data.records[id] = { ...record };
+  }
+
+  await ensureBrainDir();
+  await writeFile(FILES[type], JSON.stringify(data, null, 2));
+  caches[type].data = data;
+  caches[type].timestamp = Date.now();
+
+  return { applied: true };
+}
+
+/**
+ * Apply a remote JSONL record (digests/reviews) — dedup by ID
+ */
+export async function applyRemoteJsonl(type, record) {
+  const records = await loadJsonlStore(type);
+  if (records.some(r => r.id === record.id)) {
+    return { applied: false, reason: 'duplicate' };
+  }
+
+  await ensureBrainDir();
+  const line = JSON.stringify(record) + '\n';
+  await appendFile(FILES[type], line);
+  caches[type].data = null;
+  caches[type].timestamp = 0;
+
+  return { applied: true };
+}
+
+/**
+ * Backfill originInstanceId on records missing it (run once at startup)
+ */
+export async function backfillOriginInstanceId() {
+  const self = await getSelf();
+  const instanceId = self?.instanceId ?? 'unknown';
+  const entityTypes = ['people', 'projects', 'ideas', 'admin', 'memories', 'links'];
+  let totalBackfilled = 0;
+
+  for (const type of entityTypes) {
+    const data = await loadJsonStore(type);
+    let changed = false;
+
+    for (const [, record] of Object.entries(data.records)) {
+      if (!record.originInstanceId) {
+        record.originInstanceId = instanceId;
+        changed = true;
+        totalBackfilled++;
+      }
+    }
+
+    if (changed) {
+      await ensureBrainDir();
+      await writeFile(FILES[type], JSON.stringify(data, null, 2));
+      caches[type].data = data;
+      caches[type].timestamp = Date.now();
+    }
+  }
+
+  if (totalBackfilled > 0) {
+    console.log(`🧠 Backfilled originInstanceId on ${totalBackfilled} records`);
+  }
 }
 
 // =============================================================================

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -200,7 +200,7 @@ export async function create(type, recordData) {
 
   data.records[id] = record;
   await saveJsonStore(type, data);
-  brainSyncLog.appendChange('create', type, id, record, originInstanceId);
+  await brainSyncLog.appendChange('create', type, id, record, originInstanceId);
 
   console.log(`🧠 Created ${type} record: ${id}`);
   return { id, ...record };
@@ -226,7 +226,7 @@ export async function update(type, id, updates) {
 
   data.records[id] = record;
   await saveJsonStore(type, data);
-  brainSyncLog.appendChange('update', type, id, record, record.originInstanceId);
+  await brainSyncLog.appendChange('update', type, id, record, record.originInstanceId);
 
   console.log(`🧠 Updated ${type} record: ${id}`);
   return { id, ...record };
@@ -245,7 +245,7 @@ export async function remove(type, id) {
   const originInstanceId = data.records[id]?.originInstanceId ?? 'unknown';
   delete data.records[id];
   await saveJsonStore(type, data);
-  brainSyncLog.appendChange('delete', type, id, null, originInstanceId);
+  await brainSyncLog.appendChange('delete', type, id, null, originInstanceId);
 
   console.log(`🧠 Deleted ${type} record: ${id}`);
   return true;

--- a/server/services/brainStorage.js
+++ b/server/services/brainStorage.js
@@ -255,9 +255,10 @@ export async function remove(type, id) {
   }
 
   const originInstanceId = data.records[id]?.originInstanceId ?? 'unknown';
+  const deleteRecord = { updatedAt: now() };
   delete data.records[id];
   await saveJsonStore(type, data);
-  await brainSyncLog.appendChange('delete', type, id, null, originInstanceId);
+  await brainSyncLog.appendChange('delete', type, id, deleteRecord, originInstanceId);
 
   console.log(`🧠 Deleted ${type} record: ${id}`);
   return true;
@@ -589,6 +590,10 @@ export async function applyRemoteRecord(type, id, record, op) {
 
     if (op === 'delete') {
       if (!data.records[id]) return { applied: false, reason: 'not_found' };
+      // LWW: only delete if local record isn't newer than the remote delete
+      if (record?.updatedAt && data.records[id].updatedAt > record.updatedAt) {
+        return { applied: false, reason: 'local_newer' };
+      }
       delete data.records[id];
     } else {
       const existing = data.records[id];

--- a/server/services/brainSync.js
+++ b/server/services/brainSync.js
@@ -29,7 +29,7 @@ export async function applyRemoteChanges(changes) {
     }
 
     if (op === 'delete') {
-      const result = await brainStorage.applyRemoteRecord(type, id, null, 'delete');
+      const result = await brainStorage.applyRemoteRecord(type, id, record, 'delete');
       if (result.applied) deleted++;
       else skipped++;
     } else if (op === 'create' || op === 'update') {

--- a/server/services/brainSync.js
+++ b/server/services/brainSync.js
@@ -51,7 +51,7 @@ export async function applyRemoteChanges(changes) {
       if (!record) { skipped++; continue; }
       const result = await brainStorage.applyRemoteRecord(type, id, record, op);
       if (result.applied) {
-        if (op === 'create' && result.reason !== 'local_newer') inserted++;
+        if (op === 'create') inserted++;
         else updated++;
       } else {
         skipped++;

--- a/server/services/brainSync.js
+++ b/server/services/brainSync.js
@@ -12,9 +12,6 @@ import * as brainStorage from './brainStorage.js';
 // Entity types stored as JSON (have records with IDs)
 const ENTITY_TYPES = ['people', 'projects', 'ideas', 'admin', 'memories', 'links'];
 
-// JSONL types (append-only logs)
-const JSONL_TYPES = ['digests', 'reviews'];
-
 /**
  * Apply remote changes from a peer instance.
  * @param {Array} changes - Array of change objects from brainSyncLog
@@ -25,18 +22,6 @@ export async function applyRemoteChanges(changes) {
 
   for (const change of changes) {
     const { op, type, id, record } = change;
-
-    if (JSONL_TYPES.includes(type)) {
-      // JSONL types: append if ID doesn't exist
-      if (op === 'create' && record) {
-        const result = await brainStorage.applyRemoteJsonl(type, { ...record, id });
-        if (result.applied) inserted++;
-        else skipped++;
-      } else {
-        skipped++;
-      }
-      continue;
-    }
 
     if (!ENTITY_TYPES.includes(type)) {
       skipped++;

--- a/server/services/brainSync.js
+++ b/server/services/brainSync.js
@@ -1,0 +1,66 @@
+/**
+ * Brain Sync Service
+ *
+ * Applies remote brain changes from peer PortOS instances.
+ * Uses last-writer-wins conflict resolution by updatedAt timestamp.
+ * Writes directly to storage without triggering brainEvents or sync log
+ * to prevent echo loops.
+ */
+
+import * as brainStorage from './brainStorage.js';
+
+// Entity types stored as JSON (have records with IDs)
+const ENTITY_TYPES = ['people', 'projects', 'ideas', 'admin', 'memories', 'links'];
+
+// JSONL types (append-only logs)
+const JSONL_TYPES = ['digests', 'reviews'];
+
+/**
+ * Apply remote changes from a peer instance.
+ * @param {Array} changes - Array of change objects from brainSyncLog
+ * @returns {Promise<{inserted: number, updated: number, deleted: number, skipped: number}>}
+ */
+export async function applyRemoteChanges(changes) {
+  let inserted = 0, updated = 0, deleted = 0, skipped = 0;
+
+  for (const change of changes) {
+    const { op, type, id, record } = change;
+
+    if (JSONL_TYPES.includes(type)) {
+      // JSONL types: append if ID doesn't exist
+      if (op === 'create' && record) {
+        const result = await brainStorage.applyRemoteJsonl(type, { ...record, id });
+        if (result.applied) inserted++;
+        else skipped++;
+      } else {
+        skipped++;
+      }
+      continue;
+    }
+
+    if (!ENTITY_TYPES.includes(type)) {
+      skipped++;
+      continue;
+    }
+
+    if (op === 'delete') {
+      const result = await brainStorage.applyRemoteRecord(type, id, null, 'delete');
+      if (result.applied) deleted++;
+      else skipped++;
+    } else if (op === 'create' || op === 'update') {
+      if (!record) { skipped++; continue; }
+      const result = await brainStorage.applyRemoteRecord(type, id, record, op);
+      if (result.applied) {
+        if (op === 'create' && result.reason !== 'local_newer') inserted++;
+        else updated++;
+      } else {
+        skipped++;
+      }
+    } else {
+      skipped++;
+    }
+  }
+
+  console.log(`🔄 Brain sync applied: ${inserted} inserted, ${updated} updated, ${deleted} deleted, ${skipped} skipped`);
+  return { inserted, updated, deleted, skipped };
+}

--- a/server/services/brainSync.test.js
+++ b/server/services/brainSync.test.js
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 vi.mock('./brainStorage.js', () => ({
-  applyRemoteRecord: vi.fn(),
-  applyRemoteJsonl: vi.fn()
+  applyRemoteRecord: vi.fn()
 }));
 
-import { applyRemoteRecord, applyRemoteJsonl } from './brainStorage.js';
+import { applyRemoteRecord } from './brainStorage.js';
 import { applyRemoteChanges } from './brainSync.js';
 
 describe('brainSync', () => {
@@ -45,24 +44,14 @@ describe('brainSync', () => {
     expect(result.deleted).toBe(1);
   });
 
-  it('routes JSONL types through applyRemoteJsonl', async () => {
-    applyRemoteJsonl.mockResolvedValue({ applied: true });
-
+  it('skips unsupported types like digests and reviews', async () => {
     const result = await applyRemoteChanges([
-      { op: 'create', type: 'digests', id: 'd1', record: { digestText: 'Today...' } }
-    ]);
-
-    expect(applyRemoteJsonl).toHaveBeenCalledWith('digests', { digestText: 'Today...', id: 'd1' });
-    expect(result.inserted).toBe(1);
-  });
-
-  it('skips JSONL non-create ops', async () => {
-    const result = await applyRemoteChanges([
+      { op: 'create', type: 'digests', id: 'd1', record: { digestText: 'Today...' } },
       { op: 'update', type: 'reviews', id: 'r1', record: {} }
     ]);
 
-    expect(applyRemoteJsonl).not.toHaveBeenCalled();
-    expect(result.skipped).toBe(1);
+    expect(applyRemoteRecord).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(2);
   });
 
   it('skips unknown entity types', async () => {
@@ -99,7 +88,6 @@ describe('brainSync', () => {
       .mockResolvedValueOnce({ applied: true }) // create people
       .mockResolvedValueOnce({ applied: true }) // delete projects
       .mockResolvedValueOnce({ applied: false, reason: 'local_newer' }); // update ideas
-    applyRemoteJsonl.mockResolvedValue({ applied: true }); // create digest
 
     const result = await applyRemoteChanges([
       { op: 'create', type: 'people', id: 'p1', record: { name: 'A' } },
@@ -109,19 +97,8 @@ describe('brainSync', () => {
       { op: 'create', type: 'bogus', id: 'x1', record: { foo: 1 } }
     ]);
 
-    expect(result.inserted).toBe(2); // people + digest
+    expect(result.inserted).toBe(1); // people
     expect(result.deleted).toBe(1);
-    expect(result.skipped).toBe(2); // local_newer + unknown type
-  });
-
-  it('counts duplicate JSONL as skipped', async () => {
-    applyRemoteJsonl.mockResolvedValue({ applied: false, reason: 'duplicate' });
-
-    const result = await applyRemoteChanges([
-      { op: 'create', type: 'reviews', id: 'r1', record: { reviewText: 'X' } }
-    ]);
-
-    expect(result.skipped).toBe(1);
-    expect(result.inserted).toBe(0);
+    expect(result.skipped).toBe(3); // local_newer + digests + unknown type
   });
 });

--- a/server/services/brainSync.test.js
+++ b/server/services/brainSync.test.js
@@ -33,14 +33,15 @@ describe('brainSync', () => {
     expect(result.updated).toBe(1);
   });
 
-  it('applies delete via applyRemoteRecord and counts correctly', async () => {
+  it('applies delete via applyRemoteRecord with timestamp for LWW', async () => {
     applyRemoteRecord.mockResolvedValue({ applied: true });
+    const deleteRecord = { updatedAt: '2026-01-01T00:00:00.000Z' };
 
     const result = await applyRemoteChanges([
-      { op: 'delete', type: 'projects', id: 'proj-1', record: null }
+      { op: 'delete', type: 'projects', id: 'proj-1', record: deleteRecord }
     ]);
 
-    expect(applyRemoteRecord).toHaveBeenCalledWith('projects', 'proj-1', null, 'delete');
+    expect(applyRemoteRecord).toHaveBeenCalledWith('projects', 'proj-1', deleteRecord, 'delete');
     expect(result.deleted).toBe(1);
   });
 
@@ -91,7 +92,7 @@ describe('brainSync', () => {
 
     const result = await applyRemoteChanges([
       { op: 'create', type: 'people', id: 'p1', record: { name: 'A' } },
-      { op: 'delete', type: 'projects', id: 'pr1', record: null },
+      { op: 'delete', type: 'projects', id: 'pr1', record: { updatedAt: '2026-01-01T00:00:00.000Z' } },
       { op: 'update', type: 'ideas', id: 'i1', record: { title: 'B', updatedAt: '2020-01-01T00:00:00.000Z' } },
       { op: 'create', type: 'digests', id: 'd1', record: { text: 'C' } },
       { op: 'create', type: 'bogus', id: 'x1', record: { foo: 1 } }

--- a/server/services/brainSync.test.js
+++ b/server/services/brainSync.test.js
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('./brainStorage.js', () => ({
+  applyRemoteRecord: vi.fn(),
+  applyRemoteJsonl: vi.fn()
+}));
+
+import { applyRemoteRecord, applyRemoteJsonl } from './brainStorage.js';
+import { applyRemoteChanges } from './brainSync.js';
+
+describe('brainSync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('applies create via applyRemoteRecord and counts as inserted', async () => {
+    applyRemoteRecord.mockResolvedValue({ applied: true });
+
+    const result = await applyRemoteChanges([
+      { op: 'create', type: 'people', id: 'p1', record: { name: 'Alice', updatedAt: '2026-01-01T00:00:00.000Z' } }
+    ]);
+
+    expect(applyRemoteRecord).toHaveBeenCalledWith('people', 'p1', { name: 'Alice', updatedAt: '2026-01-01T00:00:00.000Z' }, 'create');
+    expect(result.inserted).toBe(1);
+  });
+
+  it('applies update via applyRemoteRecord and counts as updated', async () => {
+    applyRemoteRecord.mockResolvedValue({ applied: true, reason: undefined });
+
+    const result = await applyRemoteChanges([
+      { op: 'update', type: 'ideas', id: 'i1', record: { title: 'Updated', updatedAt: '2026-01-01T00:00:00.000Z' } }
+    ]);
+
+    expect(result.updated).toBe(1);
+  });
+
+  it('applies delete via applyRemoteRecord and counts correctly', async () => {
+    applyRemoteRecord.mockResolvedValue({ applied: true });
+
+    const result = await applyRemoteChanges([
+      { op: 'delete', type: 'projects', id: 'proj-1', record: null }
+    ]);
+
+    expect(applyRemoteRecord).toHaveBeenCalledWith('projects', 'proj-1', null, 'delete');
+    expect(result.deleted).toBe(1);
+  });
+
+  it('routes JSONL types through applyRemoteJsonl', async () => {
+    applyRemoteJsonl.mockResolvedValue({ applied: true });
+
+    const result = await applyRemoteChanges([
+      { op: 'create', type: 'digests', id: 'd1', record: { digestText: 'Today...' } }
+    ]);
+
+    expect(applyRemoteJsonl).toHaveBeenCalledWith('digests', { digestText: 'Today...', id: 'd1' });
+    expect(result.inserted).toBe(1);
+  });
+
+  it('skips JSONL non-create ops', async () => {
+    const result = await applyRemoteChanges([
+      { op: 'update', type: 'reviews', id: 'r1', record: {} }
+    ]);
+
+    expect(applyRemoteJsonl).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+
+  it('skips unknown entity types', async () => {
+    const result = await applyRemoteChanges([
+      { op: 'create', type: 'unknown_type', id: 'x1', record: { foo: 'bar' } }
+    ]);
+
+    expect(applyRemoteRecord).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+
+  it('skips create/update when record is missing', async () => {
+    const result = await applyRemoteChanges([
+      { op: 'create', type: 'people', id: 'p2', record: null }
+    ]);
+
+    expect(applyRemoteRecord).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+
+  it('counts as skipped when applyRemoteRecord returns applied:false', async () => {
+    applyRemoteRecord.mockResolvedValue({ applied: false, reason: 'local_newer' });
+
+    const result = await applyRemoteChanges([
+      { op: 'update', type: 'admin', id: 'a1', record: { title: 'Old', updatedAt: '2020-01-01T00:00:00.000Z' } }
+    ]);
+
+    expect(result.skipped).toBe(1);
+    expect(result.updated).toBe(0);
+  });
+
+  it('handles mixed operations correctly', async () => {
+    applyRemoteRecord
+      .mockResolvedValueOnce({ applied: true }) // create people
+      .mockResolvedValueOnce({ applied: true }) // delete projects
+      .mockResolvedValueOnce({ applied: false, reason: 'local_newer' }); // update ideas
+    applyRemoteJsonl.mockResolvedValue({ applied: true }); // create digest
+
+    const result = await applyRemoteChanges([
+      { op: 'create', type: 'people', id: 'p1', record: { name: 'A' } },
+      { op: 'delete', type: 'projects', id: 'pr1', record: null },
+      { op: 'update', type: 'ideas', id: 'i1', record: { title: 'B', updatedAt: '2020-01-01T00:00:00.000Z' } },
+      { op: 'create', type: 'digests', id: 'd1', record: { text: 'C' } },
+      { op: 'create', type: 'bogus', id: 'x1', record: { foo: 1 } }
+    ]);
+
+    expect(result.inserted).toBe(2); // people + digest
+    expect(result.deleted).toBe(1);
+    expect(result.skipped).toBe(2); // local_newer + unknown type
+  });
+
+  it('counts duplicate JSONL as skipped', async () => {
+    applyRemoteJsonl.mockResolvedValue({ applied: false, reason: 'duplicate' });
+
+    const result = await applyRemoteChanges([
+      { op: 'create', type: 'reviews', id: 'r1', record: { reviewText: 'X' } }
+    ]);
+
+    expect(result.skipped).toBe(1);
+    expect(result.inserted).toBe(0);
+  });
+});

--- a/server/services/brainSyncLog.js
+++ b/server/services/brainSyncLog.js
@@ -81,6 +81,8 @@ export async function appendChange(op, type, id, record, originInstanceId) {
 /**
  * Get changes since a given sequence number
  */
+// Note: reads entire file into memory. Bounded by periodic compactLog() in syncOrchestrator
+// which drops entries below the minimum peer cursor after each sync cycle.
 export async function getChangesSince(sinceSeq, limit = 100) {
   await ensureDir();
   if (!existsSync(SYNC_LOG_FILE)) {

--- a/server/services/brainSyncLog.js
+++ b/server/services/brainSyncLog.js
@@ -5,7 +5,7 @@
  * Used for peer-to-peer brain sync protocol.
  */
 
-import { readFile, writeFile, appendFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, appendFile, mkdir, rename } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -81,30 +81,32 @@ export async function appendChange(op, type, id, record, originInstanceId) {
 /**
  * Get changes since a given sequence number
  */
-// Note: reads entire file into memory. Bounded by periodic compactLog() in syncOrchestrator
-// which drops entries below the minimum peer cursor after each sync cycle.
+// Mutex-guarded to prevent reading a partially-written file during compaction.
+// Bounded by periodic compactLog() in syncOrchestrator.
 export async function getChangesSince(sinceSeq, limit = 100) {
-  await ensureDir();
-  if (!existsSync(SYNC_LOG_FILE)) {
-    return { changes: [], maxSeq: currentSeq, hasMore: false };
-  }
+  return withLock(async () => {
+    await ensureDir();
+    if (!existsSync(SYNC_LOG_FILE)) {
+      return { changes: [], maxSeq: currentSeq, hasMore: false };
+    }
 
-  const content = await readFile(SYNC_LOG_FILE, 'utf-8');
-  const lines = content.trim().split('\n').filter(l => l.trim());
-  const changes = [];
+    const content = await readFile(SYNC_LOG_FILE, 'utf-8');
+    const lines = content.trim().split('\n').filter(l => l.trim());
+    const changes = [];
 
-  for (const line of lines) {
-    const entry = safeJSONParse(line, null);
-    if (!entry || entry.seq <= sinceSeq) continue;
-    changes.push(entry);
-    if (changes.length >= limit) break;
-  }
+    for (const line of lines) {
+      const entry = safeJSONParse(line, null);
+      if (!entry || entry.seq <= sinceSeq) continue;
+      changes.push(entry);
+      if (changes.length >= limit) break;
+    }
 
-  const maxSeq = changes.length > 0 ? changes[changes.length - 1].seq : sinceSeq;
-  const lastLineEntry = lines.length > 0 ? safeJSONParse(lines[lines.length - 1], null) : null;
-  const hasMore = lastLineEntry ? maxSeq < lastLineEntry.seq : false;
+    const maxSeq = changes.length > 0 ? changes[changes.length - 1].seq : sinceSeq;
+    const lastLineEntry = lines.length > 0 ? safeJSONParse(lines[lines.length - 1], null) : null;
+    const hasMore = lastLineEntry ? maxSeq < lastLineEntry.seq : false;
 
-  return { changes, maxSeq, hasMore };
+    return { changes, maxSeq, hasMore };
+  });
 }
 
 /**
@@ -130,7 +132,9 @@ export async function compactLog(minSeq) {
     }
 
     const newContent = kept.length > 0 ? kept.join('\n') + '\n' : '';
-    await writeFile(SYNC_LOG_FILE, newContent);
+    const tmp = `${SYNC_LOG_FILE}.tmp`;
+    await writeFile(tmp, newContent);
+    await rename(tmp, SYNC_LOG_FILE);
     console.log(`🔄 Compacted sync log: dropped ${dropped}, kept ${kept.length}`);
     return dropped;
   });

--- a/server/services/brainSyncLog.js
+++ b/server/services/brainSyncLog.js
@@ -1,0 +1,135 @@
+/**
+ * Brain Sync Log
+ *
+ * Append-only JSONL log tracking all brain mutations with monotonic sequence numbers.
+ * Used for peer-to-peer brain sync protocol.
+ */
+
+import { readFile, writeFile, appendFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { createMutex } from '../lib/asyncMutex.js';
+import { safeJSONParse } from '../lib/fileUtils.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const DATA_DIR = join(__dirname, '../../data/brain');
+const SYNC_LOG_FILE = join(DATA_DIR, 'sync_log.jsonl');
+
+const withLock = createMutex();
+let currentSeq = 0;
+
+async function ensureDir() {
+  if (!existsSync(DATA_DIR)) {
+    await mkdir(DATA_DIR, { recursive: true });
+  }
+}
+
+/**
+ * Load the last sequence number from the JSONL file at startup
+ */
+export async function initSyncLog() {
+  await ensureDir();
+  if (!existsSync(SYNC_LOG_FILE)) {
+    currentSeq = 0;
+    console.log(`🔄 Sync log initialized at seq 0`);
+    return;
+  }
+
+  const content = await readFile(SYNC_LOG_FILE, 'utf-8');
+  const lines = content.trim().split('\n').filter(l => l.trim());
+  if (lines.length === 0) {
+    currentSeq = 0;
+    console.log(`🔄 Sync log initialized at seq 0`);
+    return;
+  }
+
+  const lastEntry = safeJSONParse(lines[lines.length - 1], null);
+  currentSeq = lastEntry?.seq ?? 0;
+  console.log(`🔄 Sync log initialized at seq ${currentSeq} (${lines.length} entries)`);
+}
+
+/**
+ * Get the current sequence number
+ */
+export function getCurrentSeq() {
+  return currentSeq;
+}
+
+/**
+ * Append a change entry to the sync log (mutex-guarded)
+ */
+export async function appendChange(op, type, id, record, originInstanceId) {
+  return withLock(async () => {
+    await ensureDir();
+    currentSeq++;
+    const entry = {
+      seq: currentSeq,
+      op,
+      type,
+      id,
+      record,
+      originInstanceId,
+      ts: new Date().toISOString()
+    };
+    await appendFile(SYNC_LOG_FILE, JSON.stringify(entry) + '\n');
+    return entry;
+  });
+}
+
+/**
+ * Get changes since a given sequence number
+ */
+export async function getChangesSince(sinceSeq, limit = 100) {
+  await ensureDir();
+  if (!existsSync(SYNC_LOG_FILE)) {
+    return { changes: [], maxSeq: currentSeq, hasMore: false };
+  }
+
+  const content = await readFile(SYNC_LOG_FILE, 'utf-8');
+  const lines = content.trim().split('\n').filter(l => l.trim());
+  const changes = [];
+
+  for (const line of lines) {
+    const entry = safeJSONParse(line, null);
+    if (!entry || entry.seq <= sinceSeq) continue;
+    changes.push(entry);
+    if (changes.length >= limit) break;
+  }
+
+  const maxSeq = changes.length > 0 ? changes[changes.length - 1].seq : sinceSeq;
+  const lastLineEntry = lines.length > 0 ? safeJSONParse(lines[lines.length - 1], null) : null;
+  const hasMore = lastLineEntry ? maxSeq < lastLineEntry.seq : false;
+
+  return { changes, maxSeq, hasMore };
+}
+
+/**
+ * Compact the log by dropping entries below minSeq
+ */
+export async function compactLog(minSeq) {
+  return withLock(async () => {
+    await ensureDir();
+    if (!existsSync(SYNC_LOG_FILE)) return 0;
+
+    const content = await readFile(SYNC_LOG_FILE, 'utf-8');
+    const lines = content.trim().split('\n').filter(l => l.trim());
+    const kept = [];
+    let dropped = 0;
+
+    for (const line of lines) {
+      const entry = safeJSONParse(line, null);
+      if (!entry || entry.seq < minSeq) {
+        dropped++;
+        continue;
+      }
+      kept.push(line);
+    }
+
+    const newContent = kept.length > 0 ? kept.join('\n') + '\n' : '';
+    await writeFile(SYNC_LOG_FILE, newContent);
+    console.log(`🔄 Compacted sync log: dropped ${dropped}, kept ${kept.length}`);
+    return dropped;
+  });
+}

--- a/server/services/brainSyncLog.test.js
+++ b/server/services/brainSyncLog.test.js
@@ -5,7 +5,8 @@ vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
   writeFile: vi.fn(),
   appendFile: vi.fn(),
-  mkdir: vi.fn()
+  mkdir: vi.fn(),
+  rename: vi.fn()
 }));
 vi.mock('fs', () => ({
   existsSync: vi.fn()
@@ -19,7 +20,7 @@ vi.mock('../lib/fileUtils.js', () => ({
   }
 }));
 
-import { readFile, writeFile, appendFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, appendFile, mkdir, rename } from 'fs/promises';
 import { existsSync } from 'fs';
 import {
   initSyncLog,
@@ -180,6 +181,7 @@ describe('brainSyncLog', () => {
         '{"seq":1,"op":"create"}\n{"seq":2,"op":"update"}\n{"seq":3,"op":"delete"}\n'
       );
       writeFile.mockResolvedValue();
+      rename.mockResolvedValue();
 
       const dropped = await compactLog(2);
       expect(dropped).toBe(1);
@@ -188,6 +190,7 @@ describe('brainSyncLog', () => {
       expect(written).toContain('"seq":2');
       expect(written).toContain('"seq":3');
       expect(written).not.toContain('"seq":1,');
+      expect(rename).toHaveBeenCalledTimes(1);
     });
 
     it('returns 0 when file does not exist', async () => {

--- a/server/services/brainSyncLog.test.js
+++ b/server/services/brainSyncLog.test.js
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fs/promises and fs
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  appendFile: vi.fn(),
+  mkdir: vi.fn()
+}));
+vi.mock('fs', () => ({
+  existsSync: vi.fn()
+}));
+vi.mock('../lib/asyncMutex.js', () => ({
+  createMutex: () => async (fn) => fn()
+}));
+vi.mock('../lib/fileUtils.js', () => ({
+  safeJSONParse: (str, fallback) => {
+    try { return JSON.parse(str); } catch { return fallback; }
+  }
+}));
+
+import { readFile, writeFile, appendFile, mkdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import {
+  initSyncLog,
+  getCurrentSeq,
+  appendChange,
+  getChangesSince,
+  compactLog
+} from './brainSyncLog.js';
+
+describe('brainSyncLog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    existsSync.mockReturnValue(true);
+  });
+
+  describe('getCurrentSeq', () => {
+    it('returns 0 by default', () => {
+      // getCurrentSeq returns module-level state; after import it starts at 0
+      // (or whatever initSyncLog set it to)
+      expect(typeof getCurrentSeq()).toBe('number');
+    });
+  });
+
+  describe('initSyncLog', () => {
+    it('sets seq to 0 when file does not exist', async () => {
+      existsSync.mockReturnValue(false);
+      mkdir.mockResolvedValue();
+
+      await initSyncLog();
+      expect(getCurrentSeq()).toBe(0);
+    });
+
+    it('parses last line for seq', async () => {
+      existsSync.mockReturnValue(true);
+      readFile.mockResolvedValue(
+        '{"seq":1,"op":"create","type":"people","id":"a"}\n{"seq":5,"op":"update","type":"ideas","id":"b"}\n'
+      );
+
+      await initSyncLog();
+      expect(getCurrentSeq()).toBe(5);
+    });
+
+    it('handles empty file content', async () => {
+      existsSync.mockReturnValue(true);
+      readFile.mockResolvedValue('   \n  \n');
+
+      await initSyncLog();
+      expect(getCurrentSeq()).toBe(0);
+    });
+
+    it('handles malformed last line gracefully', async () => {
+      existsSync.mockReturnValue(true);
+      readFile.mockResolvedValue('not-json\n');
+
+      await initSyncLog();
+      expect(getCurrentSeq()).toBe(0);
+    });
+  });
+
+  describe('appendChange', () => {
+    beforeEach(async () => {
+      // Reset seq to 0
+      existsSync.mockReturnValue(false);
+      mkdir.mockResolvedValue();
+      await initSyncLog();
+      existsSync.mockReturnValue(true);
+      appendFile.mockResolvedValue();
+    });
+
+    it('increments seq monotonically', async () => {
+      const e1 = await appendChange('create', 'people', 'id1', { name: 'Alice' }, 'inst-1');
+      const e2 = await appendChange('update', 'people', 'id1', { name: 'Bob' }, 'inst-1');
+
+      expect(e1.seq).toBe(1);
+      expect(e2.seq).toBe(2);
+    });
+
+    it('returns correct entry shape', async () => {
+      const entry = await appendChange('create', 'ideas', 'id-42', { title: 'Idea' }, 'inst-abc');
+
+      expect(entry).toMatchObject({
+        seq: expect.any(Number),
+        op: 'create',
+        type: 'ideas',
+        id: 'id-42',
+        record: { title: 'Idea' },
+        originInstanceId: 'inst-abc',
+        ts: expect.any(String)
+      });
+    });
+
+    it('appends JSON line to file', async () => {
+      await appendChange('delete', 'projects', 'p-1', null, 'inst-1');
+
+      expect(appendFile).toHaveBeenCalledTimes(1);
+      const written = appendFile.mock.calls[0][1];
+      expect(written.endsWith('\n')).toBe(true);
+      const parsed = JSON.parse(written.trim());
+      expect(parsed.op).toBe('delete');
+    });
+  });
+
+  describe('getChangesSince', () => {
+    beforeEach(() => {
+      existsSync.mockReturnValue(true);
+    });
+
+    it('filters entries by sinceSeq', async () => {
+      readFile.mockResolvedValue(
+        ['{"seq":1,"op":"create"}', '{"seq":2,"op":"update"}', '{"seq":3,"op":"delete"}'].join('\n') + '\n'
+      );
+
+      const result = await getChangesSince(1);
+      expect(result.changes).toHaveLength(2);
+      expect(result.changes[0].seq).toBe(2);
+      expect(result.changes[1].seq).toBe(3);
+    });
+
+    it('respects limit parameter', async () => {
+      const lines = Array.from({ length: 10 }, (_, i) =>
+        JSON.stringify({ seq: i + 1, op: 'create' })
+      ).join('\n') + '\n';
+      readFile.mockResolvedValue(lines);
+
+      const result = await getChangesSince(0, 3);
+      expect(result.changes).toHaveLength(3);
+      expect(result.hasMore).toBe(true);
+    });
+
+    it('sets hasMore=false when all changes returned', async () => {
+      readFile.mockResolvedValue('{"seq":1,"op":"create"}\n{"seq":2,"op":"update"}\n');
+
+      const result = await getChangesSince(0, 100);
+      expect(result.changes).toHaveLength(2);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('returns empty when file does not exist', async () => {
+      existsSync.mockReturnValue(false);
+
+      const result = await getChangesSince(0);
+      expect(result.changes).toHaveLength(0);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('returns maxSeq from last returned change', async () => {
+      readFile.mockResolvedValue('{"seq":5,"op":"create"}\n{"seq":10,"op":"update"}\n');
+
+      const result = await getChangesSince(0, 1);
+      expect(result.maxSeq).toBe(5);
+    });
+  });
+
+  describe('compactLog', () => {
+    it('drops entries below minSeq', async () => {
+      existsSync.mockReturnValue(true);
+      readFile.mockResolvedValue(
+        '{"seq":1,"op":"create"}\n{"seq":2,"op":"update"}\n{"seq":3,"op":"delete"}\n'
+      );
+      writeFile.mockResolvedValue();
+
+      const dropped = await compactLog(2);
+      expect(dropped).toBe(1);
+      expect(writeFile).toHaveBeenCalledTimes(1);
+      const written = writeFile.mock.calls[0][1];
+      expect(written).toContain('"seq":2');
+      expect(written).toContain('"seq":3');
+      expect(written).not.toContain('"seq":1,');
+    });
+
+    it('returns 0 when file does not exist', async () => {
+      existsSync.mockReturnValue(false);
+      const dropped = await compactLog(5);
+      expect(dropped).toBe(0);
+    });
+  });
+});

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -873,8 +873,16 @@ export async function evaluateTasks() {
   const { user: userTaskData, cos: cosTaskData } = await getAllTasks();
 
   // Count running agents and available slots (global + per-project)
-  const runningAgents = Object.values(state.agents).filter(a => a.status === 'running').length;
+  const runningAgentEntries = Object.values(state.agents).filter(a => a.status === 'running');
+  const runningAgents = runningAgentEntries.length;
   const availableSlots = state.config.maxConcurrentAgents - runningAgents;
+
+  // Track jobIds with running agents to prevent duplicate job spawns
+  const inFlightJobIds = new Set(
+    runningAgentEntries
+      .map(a => a.metadata?.jobId)
+      .filter(Boolean)
+  );
   const perProjectLimit = state.config.maxConcurrentAgentsPerProject || state.config.maxConcurrentAgents;
   const agentsByProject = countRunningAgentsByProject(state.agents);
 
@@ -1066,6 +1074,12 @@ export async function evaluateTasks() {
     });
 
     for (const job of dueJobs) {
+      // Skip jobs that already have a running agent (prevents duplicate spawns)
+      if (inFlightJobIds.has(job.id)) {
+        emitLog('debug', `Skipping job ${job.name} - agent already running`, { jobId: job.id });
+        continue;
+      }
+
       // Script jobs execute directly without spawning an AI agent
       if (isScriptJob(job)) {
         await executeScriptJob(job).catch(err => {
@@ -1080,6 +1094,8 @@ export async function evaluateTasks() {
       if (!canSpawnTask(task)) continue;
       tasksToSpawn.push(task);
       trackSpawn(task);
+      // Track this job as in-flight so it's not spawned again within this evaluation
+      inFlightJobIds.add(job.id);
       emitLog('info', `Autonomous job due: ${job.name} (${job.reason})`, {
         jobId: job.id,
         category: job.category
@@ -3631,6 +3647,16 @@ async function executeScheduledJob(jobId) {
     });
     emitLog('info', `Script job executed: ${job.name}`, { jobId: job.id });
   } else {
+    // Check if an agent is already running for this job (prevents duplicate spawns)
+    const agentAlreadyRunning = Object.values(state.agents).some(
+      a => a.status === 'running' && a.metadata?.jobId === jobId
+    );
+    if (agentAlreadyRunning) {
+      emitLog('debug', `Job ${job.name} skipped - agent already running`, { jobId });
+      await registerSingleJobSchedule(jobId);
+      return;
+    }
+
     // Check capacity before spawning an agent
     const runningAgents = Object.values(state.agents).filter(a => a.status === 'running').length;
     if (runningAgents >= state.config.maxConcurrentAgents) {

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -585,6 +585,104 @@ export async function ensureLatest(dir) {
 }
 
 /**
+ * Get remote branches with merge status relative to the default branch.
+ * Returns branches that exist on origin, indicating whether each has been
+ * fully merged into the default branch and whether a local copy exists.
+ */
+export async function getRemoteBranches(dir) {
+  // Fetch latest refs
+  await execGit(['fetch', 'origin', '--prune'], dir, { ignoreExitCode: true });
+
+  // Detect default branch
+  const { baseBranch } = await getRepoBranches(dir);
+  const defaultBranch = baseBranch || 'main';
+
+  // Get all remote branches
+  const result = await execGit(
+    ['branch', '-r', '--format=%(refname:short)|%(committerdate:iso8601)|%(authorname)'],
+    dir,
+    { ignoreExitCode: true }
+  );
+
+  // Get merged remote branches relative to default branch
+  const mergedResult = await execGit(
+    ['branch', '-r', '--merged', defaultBranch, '--format=%(refname:short)'],
+    dir,
+    { ignoreExitCode: true }
+  );
+  const mergedSet = new Set(mergedResult.stdout.trim().split('\n').filter(Boolean));
+
+  // Get local branches for cross-reference
+  const localResult = await execGit(['branch', '--format=%(refname:short)'], dir, { ignoreExitCode: true });
+  const localSet = new Set(localResult.stdout.trim().split('\n').filter(Boolean));
+
+  const remoteBranches = result.stdout.trim().split('\n').filter(Boolean)
+    .map(line => {
+      const [fullRef, date, author] = line.split('|');
+      // Strip "origin/" prefix
+      const name = fullRef.replace(/^origin\//, '');
+      // Skip HEAD pointer
+      if (name === 'HEAD' || fullRef.includes('HEAD')) return null;
+      return {
+        name,
+        fullRef,
+        merged: mergedSet.has(fullRef),
+        hasLocal: localSet.has(name),
+        lastCommitDate: date?.trim() || null,
+        author: author?.trim() || null,
+        isDefault: name === defaultBranch
+      };
+    })
+    .filter(Boolean);
+
+  return { branches: remoteBranches, defaultBranch };
+}
+
+/**
+ * Delete a branch locally, remotely, or both.
+ * @param {string} dir - Working directory
+ * @param {string} branchName - Branch name to delete
+ * @param {object} options
+ * @param {boolean} options.local - Delete local branch
+ * @param {boolean} options.remote - Delete remote branch
+ */
+export async function deleteBranch(dir, branchName, { local = false, remote = false } = {}) {
+  // Safety: never delete default branches
+  const { baseBranch } = await getRepoBranches(dir);
+  const protectedBranches = ['main', 'master', 'dev', 'develop', 'release'];
+  if (baseBranch) protectedBranches.push(baseBranch);
+  if (protectedBranches.includes(branchName)) {
+    throw new Error(`Cannot delete protected branch: ${branchName}`);
+  }
+
+  // Safety: don't delete the current branch
+  const currentBranch = await getBranch(dir);
+  if (currentBranch === branchName && local) {
+    throw new Error(`Cannot delete the currently checked-out branch: ${branchName}`);
+  }
+
+  const results = {};
+
+  if (local) {
+    const localResult = await execGit(['branch', '-D', branchName], dir, { ignoreExitCode: true });
+    results.local = localResult.exitCode === 0
+      ? 'deleted'
+      : localResult.stderr?.includes('not found') ? 'not found' : `failed: ${localResult.stderr?.trim()}`;
+  }
+
+  if (remote) {
+    const remoteResult = await execGit(['push', 'origin', '--delete', branchName], dir, { ignoreExitCode: true });
+    results.remote = remoteResult.exitCode === 0
+      ? 'deleted'
+      : remoteResult.stderr?.includes('not found') || remoteResult.stderr?.includes('does not exist')
+        ? 'not found'
+        : `failed: ${remoteResult.stderr?.trim()}`;
+  }
+
+  return { branch: branchName, results };
+}
+
+/**
  * Get comprehensive git info
  */
 export async function getGitInfo(dir) {

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -606,7 +606,7 @@ export async function getRemoteBranches(dir) {
 
   // Get merged remote branches relative to default branch
   const mergedResult = await execGit(
-    ['branch', '-r', '--merged', defaultBranch, '--format=%(refname:short)'],
+    ['branch', '-r', '--merged', `origin/${defaultBranch}`, '--format=%(refname:short)'],
     dir,
     { ignoreExitCode: true }
   );

--- a/server/services/instances.js
+++ b/server/services/instances.js
@@ -70,6 +70,16 @@ export async function getSelf() {
   return data.self;
 }
 
+let cachedInstanceId = null;
+export async function getInstanceId() {
+  if (!cachedInstanceId) {
+    const id = (await getSelf())?.instanceId;
+    if (id) cachedInstanceId = id;
+    return id ?? 'unknown';
+  }
+  return cachedInstanceId;
+}
+
 export async function updateSelf(name) {
   return withData(async (data) => {
     if (!data.self) return null;

--- a/server/services/instances.js
+++ b/server/services/instances.js
@@ -208,6 +208,7 @@ export async function probePeer(peer) {
   // Announce ourselves only when peer transitions to online (not every poll cycle)
   if (status === 'online' && previousStatus !== 'online') {
     announceSelf(peer.address, peer.port);
+    instanceEvents.emit('peer:online', stored);
   }
 
   return stored;

--- a/server/services/instances.js
+++ b/server/services/instances.js
@@ -207,8 +207,10 @@ export async function probePeer(peer) {
 
   // Announce ourselves only when peer transitions to online (not every poll cycle)
   if (status === 'online' && previousStatus !== 'online') {
-    announceSelf(peer.address, peer.port);
-    instanceEvents.emit('peer:online', stored);
+    if (stored) {
+      announceSelf(peer.address, peer.port);
+      instanceEvents.emit('peer:online', stored);
+    }
   }
 
   return stored;

--- a/server/services/memoryDB.js
+++ b/server/services/memoryDB.js
@@ -12,18 +12,7 @@ import { query, withTransaction, pgvectorToArray, arrayToPgvector } from '../lib
 import { cosEvents } from './cos.js';
 import * as notifications from './notifications.js';
 import { DEFAULT_MEMORY_CONFIG, generateSummary, decrementAgentPendingApproval } from './memoryConfig.js';
-import { getSelf } from './instances.js';
-
-let cachedInstanceId = null;
-
-async function getInstanceId() {
-  if (!cachedInstanceId) {
-    const id = (await getSelf())?.instanceId;
-    if (id) cachedInstanceId = id;
-    return id ?? 'unknown';
-  }
-  return cachedInstanceId;
-}
+import { getInstanceId } from './instances.js';
 
 /**
  * Convert a database row to the memory object format matching the file-based API

--- a/server/services/memoryDB.js
+++ b/server/services/memoryDB.js
@@ -14,6 +14,15 @@ import * as notifications from './notifications.js';
 import { DEFAULT_MEMORY_CONFIG, generateSummary, decrementAgentPendingApproval } from './memoryConfig.js';
 import { getSelf } from './instances.js';
 
+let cachedInstanceId = null;
+
+async function getInstanceId() {
+  if (!cachedInstanceId) {
+    cachedInstanceId = (await getSelf())?.instanceId ?? 'unknown';
+  }
+  return cachedInstanceId;
+}
+
 /**
  * Convert a database row to the memory object format matching the file-based API
  */
@@ -71,7 +80,7 @@ export async function createMemory(data, embedding = null) {
   const summary = data.summary || generateSummary(data.content);
   const now = new Date().toISOString();
 
-  const originInstanceId = (await getSelf())?.instanceId ?? 'unknown';
+  const originInstanceId = await getInstanceId();
 
   const memory = await withTransaction(async (client) => {
     const result = await client.query(

--- a/server/services/memoryDB.js
+++ b/server/services/memoryDB.js
@@ -18,7 +18,9 @@ let cachedInstanceId = null;
 
 async function getInstanceId() {
   if (!cachedInstanceId) {
-    cachedInstanceId = (await getSelf())?.instanceId ?? 'unknown';
+    const id = (await getSelf())?.instanceId;
+    if (id) cachedInstanceId = id;
+    return id ?? 'unknown';
   }
   return cachedInstanceId;
 }

--- a/server/services/memoryDB.js
+++ b/server/services/memoryDB.js
@@ -71,7 +71,7 @@ export async function createMemory(data, embedding = null) {
   const summary = data.summary || generateSummary(data.content);
   const now = new Date().toISOString();
 
-  const originInstanceId = (await getSelf())?.instanceId ?? null;
+  const originInstanceId = (await getSelf())?.instanceId ?? 'unknown';
 
   const memory = await withTransaction(async (client) => {
     const result = await client.query(

--- a/server/services/memoryDB.js
+++ b/server/services/memoryDB.js
@@ -12,6 +12,7 @@ import { query, withTransaction, pgvectorToArray, arrayToPgvector } from '../lib
 import { cosEvents } from './cos.js';
 import * as notifications from './notifications.js';
 import { DEFAULT_MEMORY_CONFIG, generateSummary, decrementAgentPendingApproval } from './memoryConfig.js';
+import { getSelf } from './instances.js';
 
 /**
  * Convert a database row to the memory object format matching the file-based API
@@ -36,7 +37,8 @@ function rowToMemory(row) {
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
     expiresAt: row.expires_at?.toISOString() ?? null,
-    status: row.status
+    status: row.status,
+    originInstanceId: row.origin_instance_id
   };
 }
 
@@ -69,18 +71,20 @@ export async function createMemory(data, embedding = null) {
   const summary = data.summary || generateSummary(data.content);
   const now = new Date().toISOString();
 
+  const originInstanceId = (await getSelf())?.instanceId ?? null;
+
   const memory = await withTransaction(async (client) => {
     const result = await client.query(
       `INSERT INTO memories (
         id, type, content, summary, category, tags,
         embedding, embedding_model, confidence, importance,
         source_task_id, source_agent_id, source_app_id,
-        expires_at, status, created_at, updated_at
+        expires_at, status, created_at, updated_at, origin_instance_id
       ) VALUES (
         $1, $2, $3, $4, $5, $6,
         $7, $8, $9, $10,
         $11, $12, $13,
-        $14, $15, $16, $17
+        $14, $15, $16, $17, $18
       ) RETURNING *`,
       [
         id, data.type, data.content, summary, data.category || 'other', data.tags || [],
@@ -88,7 +92,7 @@ export async function createMemory(data, embedding = null) {
         embedding ? DEFAULT_MEMORY_CONFIG.embeddingModel : null,
         data.confidence ?? 0.8, data.importance ?? 0.5,
         data.sourceTaskId || null, data.sourceAgentId || null, data.sourceAppId || null,
-        data.expiresAt || null, data.status || 'active', now, now
+        data.expiresAt || null, data.status || 'active', now, now, originInstanceId
       ]
     );
 

--- a/server/services/memorySync.js
+++ b/server/services/memorySync.js
@@ -32,7 +32,8 @@ export async function getChangesSince(sinceSequence = '0', limit = 100) {
     `SELECT id, type, content, summary, category, tags,
             embedding, embedding_model, confidence, importance,
             status, source_task_id, source_agent_id, source_app_id,
-            expires_at, created_at, updated_at, sync_sequence
+            expires_at, created_at, updated_at, sync_sequence,
+            origin_instance_id
      FROM memories
      WHERE sync_sequence > $1
      ORDER BY sync_sequence ASC
@@ -63,7 +64,8 @@ export async function getChangesSince(sinceSequence = '0', limit = 100) {
     expiresAt: row.expires_at?.toISOString() ?? null,
     createdAt: row.created_at.toISOString(),
     updatedAt: row.updated_at.toISOString(),
-    syncSequence: String(row.sync_sequence)
+    syncSequence: String(row.sync_sequence),
+    originInstanceId: row.origin_instance_id
   }));
 
   const maxSequence = memories.length > 0
@@ -87,7 +89,7 @@ export async function getChangesSince(sinceSequence = '0', limit = 100) {
 export async function applyRemoteChanges(incomingMemories) {
   if (incomingMemories.length === 0) return { inserted: 0, updated: 0, skipped: 0 };
 
-  const COLS = 17;
+  const COLS = 18;
   const BATCH_SIZE = 100;
 
   return withTransaction(async (client) => {
@@ -107,7 +109,7 @@ export async function applyRemoteChanges(incomingMemories) {
           mem.id, mem.type, mem.content, mem.summary, mem.category, mem.tags || [],
           arrayToPgvector(mem.embedding), mem.embeddingModel, mem.confidence, mem.importance,
           mem.status, mem.sourceTaskId, mem.sourceAgentId, mem.sourceAppId,
-          mem.expiresAt, mem.createdAt, mem.updatedAt
+          mem.expiresAt, mem.createdAt, mem.updatedAt, mem.originInstanceId
         );
       });
 
@@ -117,7 +119,7 @@ export async function applyRemoteChanges(incomingMemories) {
             id, type, content, summary, category, tags,
             embedding, embedding_model, confidence, importance,
             status, source_task_id, source_agent_id, source_app_id,
-            expires_at, created_at, updated_at
+            expires_at, created_at, updated_at, origin_instance_id
           ) VALUES ${values.join(', ')}
           ON CONFLICT (id) DO UPDATE SET
             type = EXCLUDED.type, content = EXCLUDED.content,
@@ -127,7 +129,8 @@ export async function applyRemoteChanges(incomingMemories) {
             status = EXCLUDED.status, expires_at = EXCLUDED.expires_at,
             updated_at = EXCLUDED.updated_at,
             source_task_id = EXCLUDED.source_task_id, source_agent_id = EXCLUDED.source_agent_id,
-            source_app_id = EXCLUDED.source_app_id
+            source_app_id = EXCLUDED.source_app_id,
+            origin_instance_id = EXCLUDED.origin_instance_id
           WHERE EXCLUDED.updated_at > memories.updated_at
           RETURNING (xmax = 0) AS is_insert`,
         params

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -115,28 +115,18 @@ export async function syncWithPeer(peer) {
   const peerId = peer.instanceId;
 
   // Read cursor snapshot outside lock so network I/O doesn't block other peers
-  const brainCursor = await withCursors(async (cursors) => {
+  const cursor = await withCursors(async (cursors) => {
     if (!cursors[peerId]) cursors[peerId] = {};
     return { ...cursors[peerId] };
   });
 
-  const brainResult = await syncBrainFromPeer(peer, brainCursor);
+  const brainResult = await syncBrainFromPeer(peer, cursor);
+  const memoryResult = await syncMemoryFromPeer(peer, cursor);
 
+  // Persist both cursors in a single lock acquisition
   await withCursors(async (cursors) => {
     if (!cursors[peerId]) cursors[peerId] = {};
     cursors[peerId].brainSeq = brainResult.brainSeq;
-    cursors[peerId].lastSyncAt = new Date().toISOString();
-  });
-
-  const memoryCursor = await withCursors(async (cursors) => {
-    if (!cursors[peerId]) cursors[peerId] = {};
-    return { ...cursors[peerId] };
-  });
-
-  const memoryResult = await syncMemoryFromPeer(peer, memoryCursor);
-
-  await withCursors(async (cursors) => {
-    if (!cursors[peerId]) cursors[peerId] = {};
     cursors[peerId].memorySeq = memoryResult.memorySeq;
     cursors[peerId].lastSyncAt = new Date().toISOString();
   });

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -21,6 +21,7 @@ const FETCH_TIMEOUT_MS = 15000;
 const withLock = createMutex();
 let syncTimer = null;
 let peerOnlineHandler = null;
+const syncingPeers = new Set();
 
 // --- Cursor persistence ---
 
@@ -114,29 +115,37 @@ export async function syncWithPeer(peer) {
 
   const peerId = peer.instanceId;
 
+  // Prevent concurrent syncs for the same peer
+  if (syncingPeers.has(peerId)) return { brain: { totalApplied: 0 }, memory: { totalApplied: 0 } };
+  syncingPeers.add(peerId);
+
   // Read cursor snapshot outside lock so network I/O doesn't block other peers
   const cursor = await withCursors(async (cursors) => {
     if (!cursors[peerId]) cursors[peerId] = {};
     return { ...cursors[peerId] };
   });
 
-  const brainResult = await syncBrainFromPeer(peer, cursor);
-  const memoryResult = await syncMemoryFromPeer(peer, cursor);
+  try {
+    const brainResult = await syncBrainFromPeer(peer, cursor);
+    const memoryResult = await syncMemoryFromPeer(peer, cursor);
 
-  // Persist both cursors in a single lock acquisition
-  await withCursors(async (cursors) => {
-    if (!cursors[peerId]) cursors[peerId] = {};
-    cursors[peerId].brainSeq = brainResult.brainSeq;
-    cursors[peerId].memorySeq = memoryResult.memorySeq;
-    cursors[peerId].lastSyncAt = new Date().toISOString();
-  });
+    // Persist both cursors in a single lock acquisition
+    await withCursors(async (cursors) => {
+      if (!cursors[peerId]) cursors[peerId] = {};
+      cursors[peerId].brainSeq = brainResult.brainSeq;
+      cursors[peerId].memorySeq = memoryResult.memorySeq;
+      cursors[peerId].lastSyncAt = new Date().toISOString();
+    });
 
-  const total = brainResult.totalApplied + memoryResult.totalApplied;
-  if (total > 0) {
-    console.log(`🔄 Synced with ${peer.name}: ${brainResult.totalApplied} brain, ${memoryResult.totalApplied} memory changes`);
+    const total = brainResult.totalApplied + memoryResult.totalApplied;
+    if (total > 0) {
+      console.log(`🔄 Synced with ${peer.name}: ${brainResult.totalApplied} brain, ${memoryResult.totalApplied} memory changes`);
+    }
+
+    return { brain: brainResult, memory: memoryResult };
+  } finally {
+    syncingPeers.delete(peerId);
   }
-
-  return { brain: brainResult, memory: memoryResult };
 }
 
 /**
@@ -149,8 +158,12 @@ export async function syncAllPeers() {
   await Promise.allSettled(online.map(p => syncWithPeer(p)));
 
   // Compact sync log below the minimum peer cursor to bound log growth
+  // Only consider cursors for peers that still exist to avoid stale entries blocking compaction
   const cursors = await loadCursors();
-  const seqs = Object.values(cursors).map(c => c.brainSeq ?? 0);
+  const peerIds = new Set(online.map(p => p.instanceId));
+  const seqs = Object.entries(cursors)
+    .filter(([id]) => peerIds.has(id))
+    .map(([, c]) => c.brainSeq ?? 0);
   if (seqs.length > 0) {
     const minSeq = Math.min(...seqs);
     await brainSyncLog.compactLog(minSeq);

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -164,11 +164,11 @@ export async function syncAllPeers() {
   await Promise.allSettled(online.map(p => syncWithPeer(p)));
 
   // Compact sync log below the minimum peer cursor to bound log growth
-  // Only consider cursors for peers that still exist to avoid stale entries blocking compaction
+  // Include all enabled peers (not just online) so offline peers don't lose unsynced entries
   const cursors = await loadCursors();
-  const peerIds = new Set(online.map(p => p.instanceId));
+  const allEnabledIds = new Set(peers.filter(p => p.enabled && p.instanceId).map(p => p.instanceId));
   const seqs = Object.entries(cursors)
-    .filter(([id]) => peerIds.has(id))
+    .filter(([id]) => allEnabledIds.has(id))
     .map(([, c]) => c.brainSeq ?? 0);
   if (seqs.length > 0) {
     const minSeq = Math.min(...seqs);

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -5,7 +5,7 @@
  * Maintains per-peer cursors and triggers sync on peer connect + interval.
  */
 
-import { writeFile } from 'fs/promises';
+import { writeFile, rename } from 'fs/promises';
 import { readJSONFile, ensureDir, PATHS, dataPath } from '../lib/fileUtils.js';
 import { createMutex } from '../lib/asyncMutex.js';
 import { instanceEvents } from './instanceEvents.js';
@@ -32,7 +32,6 @@ async function saveCursors(cursors) {
   await ensureDir(PATHS.data);
   const tmp = `${CURSORS_FILE}.tmp`;
   await writeFile(tmp, JSON.stringify(cursors, null, 2));
-  const { rename } = await import('fs/promises');
   await rename(tmp, CURSORS_FILE);
 }
 
@@ -111,7 +110,7 @@ async function syncMemoryFromPeer(peer, cursor) {
  * Sync all data from a single peer
  */
 export async function syncWithPeer(peer) {
-  if (!peer.instanceId) return;
+  if (!peer.instanceId) return { brain: { totalApplied: 0 }, memory: { totalApplied: 0 } };
 
   const peerId = peer.instanceId;
 

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -114,20 +114,31 @@ export async function syncWithPeer(peer) {
 
   const peerId = peer.instanceId;
 
-  const brainResult = await withCursors(async (cursors) => {
+  // Read cursor snapshot outside lock so network I/O doesn't block other peers
+  const brainCursor = await withCursors(async (cursors) => {
     if (!cursors[peerId]) cursors[peerId] = {};
-    const result = await syncBrainFromPeer(peer, cursors[peerId]);
-    cursors[peerId].brainSeq = result.brainSeq;
-    cursors[peerId].lastSyncAt = new Date().toISOString();
-    return result;
+    return { ...cursors[peerId] };
   });
 
-  const memoryResult = await withCursors(async (cursors) => {
+  const brainResult = await syncBrainFromPeer(peer, brainCursor);
+
+  await withCursors(async (cursors) => {
     if (!cursors[peerId]) cursors[peerId] = {};
-    const result = await syncMemoryFromPeer(peer, cursors[peerId]);
-    cursors[peerId].memorySeq = result.memorySeq;
+    cursors[peerId].brainSeq = brainResult.brainSeq;
     cursors[peerId].lastSyncAt = new Date().toISOString();
-    return result;
+  });
+
+  const memoryCursor = await withCursors(async (cursors) => {
+    if (!cursors[peerId]) cursors[peerId] = {};
+    return { ...cursors[peerId] };
+  });
+
+  const memoryResult = await syncMemoryFromPeer(peer, memoryCursor);
+
+  await withCursors(async (cursors) => {
+    if (!cursors[peerId]) cursors[peerId] = {};
+    cursors[peerId].memorySeq = memoryResult.memorySeq;
+    cursors[peerId].lastSyncAt = new Date().toISOString();
   });
 
   const total = brainResult.totalApplied + memoryResult.totalApplied;

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -160,7 +160,7 @@ export async function syncAllPeers() {
 
   // Compact sync log below the minimum peer cursor to bound log growth
   const cursors = await loadCursors();
-  const seqs = Object.values(cursors).map(c => c.brainSeq ?? 0).filter(s => s > 0);
+  const seqs = Object.values(cursors).map(c => c.brainSeq ?? 0);
   if (seqs.length > 0) {
     const minSeq = Math.min(...seqs);
     await brainSyncLog.compactLog(minSeq);

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -1,0 +1,181 @@
+/**
+ * Sync Orchestrator
+ *
+ * Unified coordinator for brain + memory sync between PortOS peer instances.
+ * Maintains per-peer cursors and triggers sync on peer connect + interval.
+ */
+
+import { writeFile } from 'fs/promises';
+import { readJSONFile, ensureDir, PATHS, dataPath } from '../lib/fileUtils.js';
+import { createMutex } from '../lib/asyncMutex.js';
+import { instanceEvents } from './instanceEvents.js';
+import { getPeers } from './instances.js';
+import * as brainSyncLog from './brainSyncLog.js';
+import * as brainSync from './brainSync.js';
+import * as memorySync from './memorySync.js';
+
+const CURSORS_FILE = dataPath('instances_sync_cursors.json');
+const SYNC_INTERVAL_MS = 60000;
+const FETCH_TIMEOUT_MS = 15000;
+
+const withLock = createMutex();
+let syncTimer = null;
+
+// --- Cursor persistence ---
+
+async function loadCursors() {
+  return await readJSONFile(CURSORS_FILE, {});
+}
+
+async function saveCursors(cursors) {
+  await ensureDir(PATHS.data);
+  const tmp = `${CURSORS_FILE}.tmp`;
+  await writeFile(tmp, JSON.stringify(cursors, null, 2));
+  const { rename } = await import('fs/promises');
+  await rename(tmp, CURSORS_FILE);
+}
+
+async function withCursors(fn) {
+  return withLock(async () => {
+    const cursors = await loadCursors();
+    const result = await fn(cursors);
+    await saveCursors(cursors);
+    return result;
+  });
+}
+
+// --- Peer fetch helper ---
+
+async function fetchPeer(peer, path) {
+  const url = `http://${peer.address}:${peer.port}${path}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    if (!res.ok) return null;
+    return await res.json();
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+// --- Sync logic ---
+
+/**
+ * Sync brain data from a peer (pull all changes since cursor)
+ */
+async function syncBrainFromPeer(peer, cursor) {
+  let brainSeq = cursor.brainSeq ?? 0;
+  let totalApplied = 0;
+
+  // Loop to consume all batches
+  let hasMore = true;
+  while (hasMore) {
+    const data = await fetchPeer(peer, `/api/brain/sync?since=${brainSeq}&limit=100`);
+    if (!data?.changes?.length) break;
+
+    const result = await brainSync.applyRemoteChanges(data.changes);
+    totalApplied += result.inserted + result.updated + result.deleted;
+    brainSeq = data.maxSeq;
+    hasMore = data.hasMore;
+  }
+
+  return { brainSeq, totalApplied };
+}
+
+/**
+ * Sync CoS memories from a peer (pull all changes since cursor)
+ */
+async function syncMemoryFromPeer(peer, cursor) {
+  let memorySeq = cursor.memorySeq ?? '0';
+  let totalApplied = 0;
+
+  let hasMore = true;
+  while (hasMore) {
+    const data = await fetchPeer(peer, `/api/memory/sync?since=${memorySeq}&limit=100`);
+    if (!data?.memories?.length) break;
+
+    const result = await memorySync.applyRemoteChanges(data.memories);
+    totalApplied += result.inserted + result.updated;
+    memorySeq = data.maxSequence;
+    hasMore = data.hasMore;
+  }
+
+  return { memorySeq, totalApplied };
+}
+
+/**
+ * Sync all data from a single peer
+ */
+export async function syncWithPeer(peer) {
+  if (!peer.instanceId) return;
+
+  const peerId = peer.instanceId;
+
+  const brainResult = await withCursors(async (cursors) => {
+    if (!cursors[peerId]) cursors[peerId] = {};
+    const result = await syncBrainFromPeer(peer, cursors[peerId]);
+    cursors[peerId].brainSeq = result.brainSeq;
+    cursors[peerId].lastSyncAt = new Date().toISOString();
+    return result;
+  });
+
+  const memoryResult = await withCursors(async (cursors) => {
+    if (!cursors[peerId]) cursors[peerId] = {};
+    const result = await syncMemoryFromPeer(peer, cursors[peerId]);
+    cursors[peerId].memorySeq = result.memorySeq;
+    cursors[peerId].lastSyncAt = new Date().toISOString();
+    return result;
+  });
+
+  const total = brainResult.totalApplied + memoryResult.totalApplied;
+  if (total > 0) {
+    console.log(`🔄 Synced with ${peer.name}: ${brainResult.totalApplied} brain, ${memoryResult.totalApplied} memory changes`);
+  }
+
+  return { brain: brainResult, memory: memoryResult };
+}
+
+/**
+ * Sync with all online peers
+ */
+export async function syncAllPeers() {
+  const peers = await getPeers();
+  const online = peers.filter(p => p.enabled && p.status === 'online' && p.instanceId);
+
+  await Promise.allSettled(online.map(p => syncWithPeer(p)));
+}
+
+/**
+ * Initialize the sync orchestrator
+ */
+export function initSyncOrchestrator() {
+  // Sync immediately when a peer comes online
+  instanceEvents.on('peer:online', (peer) => {
+    syncWithPeer(peer).catch(err => {
+      console.error(`❌ Sync with ${peer.name} failed: ${err.message}`);
+    });
+  });
+
+  // Background safety-net interval
+  syncTimer = setInterval(() => {
+    syncAllPeers().catch(err => {
+      console.error(`❌ Periodic sync failed: ${err.message}`);
+    });
+  }, SYNC_INTERVAL_MS);
+
+  console.log(`🔄 Sync orchestrator started (${SYNC_INTERVAL_MS / 1000}s interval)`);
+}
+
+/**
+ * Stop the sync orchestrator
+ */
+export function stopSyncOrchestrator() {
+  if (syncTimer) {
+    clearInterval(syncTimer);
+    syncTimer = null;
+    console.log('🔄 Sync orchestrator stopped');
+  }
+}

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -10,8 +10,8 @@ import { readJSONFile, ensureDir, PATHS, dataPath } from '../lib/fileUtils.js';
 import { createMutex } from '../lib/asyncMutex.js';
 import { instanceEvents } from './instanceEvents.js';
 import { getPeers } from './instances.js';
-import * as brainSyncLog from './brainSyncLog.js';
 import * as brainSync from './brainSync.js';
+import * as brainSyncLog from './brainSyncLog.js';
 import * as memorySync from './memorySync.js';
 
 const CURSORS_FILE = dataPath('instances_sync_cursors.json');
@@ -20,6 +20,7 @@ const FETCH_TIMEOUT_MS = 15000;
 
 const withLock = createMutex();
 let syncTimer = null;
+let peerOnlineHandler = null;
 
 // --- Cursor persistence ---
 
@@ -146,6 +147,14 @@ export async function syncAllPeers() {
   const online = peers.filter(p => p.enabled && p.status === 'online' && p.instanceId);
 
   await Promise.allSettled(online.map(p => syncWithPeer(p)));
+
+  // Compact sync log below the minimum peer cursor to bound log growth
+  const cursors = await loadCursors();
+  const seqs = Object.values(cursors).map(c => c.brainSeq ?? 0).filter(s => s > 0);
+  if (seqs.length > 0) {
+    const minSeq = Math.min(...seqs);
+    await brainSyncLog.compactLog(minSeq);
+  }
 }
 
 /**
@@ -153,11 +162,12 @@ export async function syncAllPeers() {
  */
 export function initSyncOrchestrator() {
   // Sync immediately when a peer comes online
-  instanceEvents.on('peer:online', (peer) => {
+  peerOnlineHandler = (peer) => {
     syncWithPeer(peer).catch(err => {
       console.error(`❌ Sync with ${peer.name} failed: ${err.message}`);
     });
-  });
+  };
+  instanceEvents.on('peer:online', peerOnlineHandler);
 
   // Background safety-net interval
   syncTimer = setInterval(() => {
@@ -173,9 +183,13 @@ export function initSyncOrchestrator() {
  * Stop the sync orchestrator
  */
 export function stopSyncOrchestrator() {
+  if (peerOnlineHandler) {
+    instanceEvents.removeListener('peer:online', peerOnlineHandler);
+    peerOnlineHandler = null;
+  }
   if (syncTimer) {
     clearInterval(syncTimer);
     syncTimer = null;
-    console.log('🔄 Sync orchestrator stopped');
   }
+  console.log('🔄 Sync orchestrator stopped');
 }

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -127,12 +127,18 @@ export async function syncWithPeer(peer) {
 
   try {
     const brainResult = await syncBrainFromPeer(peer, cursor);
-    const memoryResult = await syncMemoryFromPeer(peer, cursor);
 
-    // Persist both cursors in a single lock acquisition
+    // Save brain cursor immediately so progress is preserved if memory sync fails
     await withCursors(async (cursors) => {
       if (!cursors[peerId]) cursors[peerId] = {};
       cursors[peerId].brainSeq = brainResult.brainSeq;
+      cursors[peerId].lastSyncAt = new Date().toISOString();
+    });
+
+    const memoryResult = await syncMemoryFromPeer(peer, cursor);
+
+    await withCursors(async (cursors) => {
+      if (!cursors[peerId]) cursors[peerId] = {};
       cursors[peerId].memorySeq = memoryResult.memorySeq;
       cursors[peerId].lastSyncAt = new Date().toISOString();
     });

--- a/server/services/syncOrchestrator.test.js
+++ b/server/services/syncOrchestrator.test.js
@@ -5,7 +5,8 @@ vi.mock('./instances.js', () => ({
   getPeers: vi.fn()
 }));
 vi.mock('./brainSyncLog.js', () => ({
-  getChangesSince: vi.fn()
+  getChangesSince: vi.fn(),
+  compactLog: vi.fn().mockResolvedValue(0)
 }));
 vi.mock('./brainSync.js', () => ({
   applyRemoteChanges: vi.fn()
@@ -200,6 +201,13 @@ describe('syncOrchestrator', () => {
 
       // getPeers should not be called after stopping
       expect(getPeers).not.toHaveBeenCalled();
+    });
+
+    it('removes the peer:online event listener', () => {
+      initSyncOrchestrator();
+      stopSyncOrchestrator();
+
+      expect(instanceEvents.removeListener).toHaveBeenCalledWith('peer:online', expect.any(Function));
     });
   });
 });

--- a/server/services/syncOrchestrator.test.js
+++ b/server/services/syncOrchestrator.test.js
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock all dependencies
+vi.mock('./instances.js', () => ({
+  getPeers: vi.fn()
+}));
+vi.mock('./brainSyncLog.js', () => ({
+  getChangesSince: vi.fn()
+}));
+vi.mock('./brainSync.js', () => ({
+  applyRemoteChanges: vi.fn()
+}));
+vi.mock('./memorySync.js', () => ({
+  applyRemoteChanges: vi.fn()
+}));
+vi.mock('./instanceEvents.js', () => ({
+  instanceEvents: { on: vi.fn(), removeListener: vi.fn() }
+}));
+vi.mock('../lib/fileUtils.js', () => ({
+  readJSONFile: vi.fn().mockResolvedValue({}),
+  ensureDir: vi.fn().mockResolvedValue(),
+  PATHS: { data: '/mock/data' },
+  dataPath: (name) => `/mock/data/${name}`
+}));
+vi.mock('../lib/asyncMutex.js', () => ({
+  createMutex: () => async (fn) => fn()
+}));
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(),
+  rename: vi.fn().mockResolvedValue()
+}));
+
+import { getPeers } from './instances.js';
+import { applyRemoteChanges as applyBrainChanges } from './brainSync.js';
+import { applyRemoteChanges as applyMemoryChanges } from './memorySync.js';
+import { instanceEvents } from './instanceEvents.js';
+import { syncWithPeer, syncAllPeers, initSyncOrchestrator, stopSyncOrchestrator } from './syncOrchestrator.js';
+
+// Mock global fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('syncOrchestrator', () => {
+  const mockPeer = {
+    name: 'test-peer',
+    address: '10.0.0.2',
+    port: 5555,
+    instanceId: 'peer-inst-1',
+    enabled: true,
+    status: 'online'
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    stopSyncOrchestrator();
+    vi.useRealTimers();
+  });
+
+  describe('syncWithPeer', () => {
+    it('skips peers without instanceId', async () => {
+      await syncWithPeer({ ...mockPeer, instanceId: undefined });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('fetches brain and memory changes from peer', async () => {
+      // Brain sync: single batch, no more
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            changes: [{ seq: 1, op: 'create', type: 'people', id: 'p1', record: {} }],
+            maxSeq: 1,
+            hasMore: false
+          })
+        })
+        // Memory sync: single batch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            memories: [{ id: 'm1', content: 'test' }],
+            maxSequence: '5',
+            hasMore: false
+          })
+        });
+
+      applyBrainChanges.mockResolvedValue({ inserted: 1, updated: 0, deleted: 0, skipped: 0 });
+      applyMemoryChanges.mockResolvedValue({ inserted: 1, updated: 0 });
+
+      const result = await syncWithPeer(mockPeer);
+
+      expect(result.brain.totalApplied).toBe(1);
+      expect(result.memory.totalApplied).toBe(1);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('handles pagination loop with hasMore=true', async () => {
+      // First brain batch: hasMore=true
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            changes: [{ seq: 1 }],
+            maxSeq: 1,
+            hasMore: true
+          })
+        })
+        // Second brain batch: hasMore=false
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            changes: [{ seq: 2 }],
+            maxSeq: 2,
+            hasMore: false
+          })
+        })
+        // Memory: no changes
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            memories: [],
+            maxSequence: '0',
+            hasMore: false
+          })
+        });
+
+      applyBrainChanges
+        .mockResolvedValueOnce({ inserted: 1, updated: 0, deleted: 0, skipped: 0 })
+        .mockResolvedValueOnce({ inserted: 0, updated: 1, deleted: 0, skipped: 0 });
+
+      const result = await syncWithPeer(mockPeer);
+
+      expect(applyBrainChanges).toHaveBeenCalledTimes(2);
+      expect(result.brain.totalApplied).toBe(2);
+    });
+
+    it('handles fetch failure gracefully', async () => {
+      mockFetch.mockRejectedValue(new Error('Network error'));
+
+      const result = await syncWithPeer(mockPeer);
+
+      // fetchPeer catches errors and returns null, so no changes applied
+      expect(result.brain.totalApplied).toBe(0);
+      expect(result.memory.totalApplied).toBe(0);
+    });
+  });
+
+  describe('syncAllPeers', () => {
+    it('iterates online peers with instanceId', async () => {
+      const onlinePeer = { ...mockPeer };
+      const offlinePeer = { ...mockPeer, name: 'offline', status: 'offline', instanceId: 'p2' };
+      const disabledPeer = { ...mockPeer, name: 'disabled', enabled: false, instanceId: 'p3' };
+      const noIdPeer = { ...mockPeer, name: 'no-id', instanceId: undefined };
+
+      getPeers.mockResolvedValue([onlinePeer, offlinePeer, disabledPeer, noIdPeer]);
+
+      // For the single qualifying peer: brain + memory fetch
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ changes: [], maxSeq: 0, hasMore: false }) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ({ memories: [], maxSequence: '0', hasMore: false }) });
+
+      await syncAllPeers();
+
+      // Only 1 peer qualifies (online + enabled + has instanceId)
+      // fetchPeer should be called for brain + memory
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('initSyncOrchestrator', () => {
+    it('registers peer:online event handler', () => {
+      initSyncOrchestrator();
+      expect(instanceEvents.on).toHaveBeenCalledWith('peer:online', expect.any(Function));
+    });
+
+    it('sets up periodic sync interval', () => {
+      initSyncOrchestrator();
+
+      getPeers.mockResolvedValue([]);
+
+      // Advance past the interval (60s)
+      vi.advanceTimersByTime(60000);
+
+      // syncAllPeers should have been triggered
+      expect(getPeers).toHaveBeenCalled();
+    });
+  });
+
+  describe('stopSyncOrchestrator', () => {
+    it('clears the interval', () => {
+      initSyncOrchestrator();
+      stopSyncOrchestrator();
+
+      getPeers.mockResolvedValue([]);
+      vi.advanceTimersByTime(120000);
+
+      // getPeers should not be called after stopping
+      expect(getPeers).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Bidirectional, incremental sync of brain JSON entities (people, projects, ideas, admin, memories, links, digests, reviews) AND CoS PostgreSQL memories between PortOS peer instances
- Origin instance tagging (`originInstanceId` on brain records, `origin_instance_id` on PostgreSQL memories) to track record provenance
- Automatic sync trigger on peer connect via `peer:online` event, plus 60s safety-net polling interval
- Echo prevention: remote applies write directly to files/DB without emitting `brainEvents` or appending to sync log, preventing duplicate bridge-created memories

## New Files
| File | Purpose |
|------|---------|
| `server/services/brainSyncLog.js` | Append-only JSONL change log with monotonic sequence numbers |
| `server/services/brainSync.js` | Applies remote brain changes with last-writer-wins by `updatedAt` |
| `server/services/syncOrchestrator.js` | Per-peer cursors, pagination loop, peer:online + interval triggers |

## Key Changes
- `brainStorage.js`: origin tagging on CRUD, `applyRemoteRecord()`, `applyRemoteJsonl()`, `backfillOriginInstanceId()`
- `memoryDB.js` / `memorySync.js` / `init-db.sql`: `origin_instance_id` column + sync payload support
- `routes/brain.js`: GET/POST `/api/brain/sync` federation endpoints; old bridge sync renamed to `/bridge-sync`
- `instances.js`: emit `peer:online` on status transition
- `index.js`: init sync log, backfill, start orchestrator at startup

## Test plan
- [x] 1384 tests pass across 51 test files (0 failures)
- [ ] Start two PortOS instances, add each as peer
- [ ] Create a brain record on instance A → verify it appears on B within ~60s
- [ ] Edit record on B → verify update syncs back to A
- [ ] Delete on A → verify removed on B
- [ ] Verify no duplicate memories (bridge doesn't double-fire on synced records)