### PR TITLE
security: add Zod validation to CoS config, warn on missing PGPASSWORD

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.29.0",
+      "version": "1.29.1",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -9,6 +9,10 @@ import pg from 'pg';
 
 const { Pool } = pg;
 
+if (!process.env.PGPASSWORD) {
+  console.warn('⚠️ PGPASSWORD not set, using default database password');
+}
+
 // Connection config from environment or defaults
 const pool = new Pool({
   host: process.env.PGHOST || 'localhost',

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -17,8 +17,50 @@ import * as goalProgress from '../services/goalProgress.js';
 import * as decisionLog from '../services/decisionLog.js';
 import { reinitialize as reinitializeEmbeddings } from '../services/memoryEmbeddings.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
+import { validateRequest } from '../lib/validation.js';
+import { z } from 'zod';
 
 const router = Router();
+
+const cosConfigSchema = z.object({
+  userTasksFile: z.string().optional(),
+  cosTasksFile: z.string().optional(),
+  goalsFile: z.string().optional(),
+  evaluationIntervalMs: z.number().int().min(1000).optional(),
+  healthCheckIntervalMs: z.number().int().min(1000).optional(),
+  maxConcurrentAgents: z.number().int().min(1).optional(),
+  maxConcurrentAgentsPerProject: z.number().int().min(1).optional(),
+  maxProcessMemoryMb: z.number().int().min(128).optional(),
+  maxTotalProcesses: z.number().int().min(1).optional(),
+  mcpServers: z.array(z.object({
+    name: z.string(),
+    command: z.string(),
+    args: z.array(z.string()).optional()
+  })).optional(),
+  autoStart: z.boolean().optional(),
+  selfImprovementEnabled: z.boolean().optional(),
+  appImprovementEnabled: z.boolean().optional(),
+  improvementEnabled: z.boolean().optional(),
+  avatarStyle: z.enum(['svg', 'ascii', 'cyber', 'sigil']).optional(),
+  dynamicAvatar: z.boolean().optional(),
+  alwaysOn: z.boolean().optional(),
+  appReviewCooldownMs: z.number().int().min(0).optional(),
+  idleReviewEnabled: z.boolean().optional(),
+  idleReviewPriority: z.enum(['LOW', 'MEDIUM', 'HIGH', 'CRITICAL']).optional(),
+  comprehensiveAppImprovement: z.boolean().optional(),
+  immediateExecution: z.boolean().optional(),
+  proactiveMode: z.boolean().optional(),
+  autonomousJobsEnabled: z.boolean().optional(),
+  autonomyLevel: z.enum(['standby', 'assistant', 'manager', 'yolo']).optional(),
+  rehabilitationGracePeriodDays: z.number().int().min(1).optional(),
+  completedAgentRetentionMs: z.number().int().min(0).optional(),
+  embeddingProviderId: z.string().optional(),
+  embeddingModel: z.string().optional(),
+  autoFixThresholds: z.object({
+    maxLinesChanged: z.number().int().min(1).optional(),
+    allowedCategories: z.array(z.string()).optional()
+  }).optional()
+}).strict();
 
 const SCHEDULE_FIELDS = ['type', 'enabled', 'intervalMs', 'providerId', 'model', 'prompt'];
 
@@ -74,8 +116,9 @@ router.get('/config', asyncHandler(async (req, res) => {
 
 // PUT /api/cos/config - Update configuration
 router.put('/config', asyncHandler(async (req, res) => {
-  const config = await cos.updateConfig(req.body);
-  if (req.body.embeddingProviderId !== undefined || req.body.embeddingModel !== undefined) {
+  const validated = validateRequest(cosConfigSchema, req.body);
+  const config = await cos.updateConfig(validated);
+  if (validated.embeddingProviderId !== undefined || validated.embeddingModel !== undefined) {
     reinitializeEmbeddings();
   }
   res.json(config);
@@ -988,7 +1031,7 @@ router.get('/actionable-insights', asyncHandler(async (req, res) => {
       priority: 'high',
       icon: 'AlertCircle',
       title: `${pendingApprovals.length} task${pendingApprovals.length > 1 ? 's' : ''} awaiting approval`,
-      description: pendingApprovals[0]?.description?.substring(0, 80) + (pendingApprovals[0]?.description?.length > 80 ? '...' : ''),
+      description: ((d) => d ? d.substring(0, 80) + (d.length > 80 ? '...' : '') : '')(pendingApprovals[0]?.description ?? ''),
       action: { label: 'Review', route: '/cos/tasks' },
       count: pendingApprovals.length
     });

--- a/server/services/backup.js
+++ b/server/services/backup.js
@@ -159,6 +159,10 @@ export async function dumpPostgres(outputPath) {
   const pgDb = process.env.PGDATABASE || 'portos';
   const pgUser = process.env.PGUSER || 'portos';
 
+  if (!process.env.PGPASSWORD) {
+    console.warn('⚠️ PGPASSWORD not set for pg_dump, using default password');
+  }
+
   return new Promise((resolve) => {
     const proc = spawn('pg_dump', [
       '-h', pgHost,


### PR DESCRIPTION
## Better Audit — Security & Secrets

### Summary
4 findings addressed across 3 files. Version bumped to 1.29.1.

### Changes
- **[HIGH]** Add strict Zod schema for PUT /api/cos/config preventing mass assignment
- **[HIGH]** Fix undefined string concatenation in insights description (line 991)
- **[MEDIUM]** Add warning logs when PGPASSWORD env var is not set (db.js, backup.js)
- **[HIGH]** multer DoS (skipped — false positive, server uses multer ^2.0.2 not affected)

### Files Modified
- `server/lib/db.js`
- `server/routes/cos.js`
- `server/services/backup.js`
- `package.json` / `package-lock.json` (version bump)

### Merge Order
Independent — can be merged in any order