### PR TITLE
refactor: remove redundant ensureDataDir wrappers and duplicate formatFileSize

### DIFF
--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -2,7 +2,8 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { Plus, Image, X, ChevronDown, ChevronRight, Sparkles, Loader2, Paperclip, FileText, Zap, Bookmark, Ticket, GitBranch } from 'lucide-react';
 import toast from 'react-hot-toast';
 import * as api from '../../services/api';
-import { processScreenshotUploads, processAttachmentUploads, formatFileSize } from '../../utils/fileUpload';
+import { processScreenshotUploads, processAttachmentUploads } from '../../utils/fileUpload';
+import { formatBytes } from '../../utils/formatters';
 
 export default function TaskAddForm({ providers, apps, onTaskAdded, compact = false, defaultApp = '' }) {
   const [newTask, setNewTask] = useState({ description: '', context: '', model: '', provider: '', app: defaultApp });
@@ -525,7 +526,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
                   <span className="text-xs text-white truncate max-w-[120px]" title={a.originalName}>
                     {a.originalName}
                   </span>
-                  <span className="text-xs text-gray-500">{formatFileSize(a.size)}</span>
+                  <span className="text-xs text-gray-500">{formatBytes(a.size)}</span>
                 </div>
                 <button
                   type="button"

--- a/client/src/utils/fileUpload.js
+++ b/client/src/utils/fileUpload.js
@@ -240,12 +240,3 @@ export async function uploadAttachmentFile(file, options = {}) {
     reader.readAsDataURL(file);
   });
 }
-
-/**
- * Format file size for display
- */
-export function formatFileSize(bytes) {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}

--- a/server/services/appActivity.js
+++ b/server/services/appActivity.js
@@ -21,17 +21,10 @@ const DEFAULT_ACTIVITY = {
 };
 
 /**
- * Ensure the data directory exists
- */
-async function ensureDataDir() {
-  await ensureDir(DATA_DIR);
-}
-
-/**
  * Load app activity data
  */
 export async function loadAppActivity() {
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
 
   const loaded = await readJSONFile(ACTIVITY_FILE, null);
   return loaded ? { ...DEFAULT_ACTIVITY, ...loaded } : { ...DEFAULT_ACTIVITY };
@@ -41,7 +34,7 @@ export async function loadAppActivity() {
  * Save app activity data
  */
 export async function saveAppActivity(activity) {
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
   await writeFile(ACTIVITY_FILE, JSON.stringify(activity, null, 2));
 }
 

--- a/server/services/apps.js
+++ b/server/services/apps.js
@@ -60,13 +60,6 @@ let cacheTimestamp = 0;
 const CACHE_TTL_MS = 2000; // Cache for 2 seconds to reduce file reads during rapid polling
 
 /**
- * Ensure data directory exists
- */
-async function ensureDataDir() {
-  await ensureDir(DATA_DIR);
-}
-
-/**
  * Load apps registry from disk (with caching).
  * Ensures the PortOS baseline app always exists.
  */
@@ -78,7 +71,7 @@ async function loadApps() {
     return appsCache;
   }
 
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
 
   const data = await readJSONFile(APPS_FILE, { apps: {} });
 
@@ -125,7 +118,7 @@ async function loadApps() {
  * Save apps registry to disk (and invalidate cache)
  */
 async function saveApps(data) {
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
   await writeFile(APPS_FILE, JSON.stringify(data, null, 2));
   // Update cache with saved data
   appsCache = data;

--- a/server/services/autobiography.js
+++ b/server/services/autobiography.js
@@ -166,27 +166,23 @@ const DEFAULT_DATA = {
   usedPrompts: []
 };
 
-async function ensureDataDir() {
-  await ensureDir(DATA_DIR);
-}
-
 async function loadStories() {
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
   return readJSONFile(STORIES_FILE, DEFAULT_DATA);
 }
 
 async function saveStories(data) {
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
   await writeFile(STORIES_FILE, JSON.stringify(data, null, 2));
 }
 
 async function loadConfig() {
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
   return readJSONFile(CONFIG_FILE, DEFAULT_CONFIG);
 }
 
 async function saveConfig(config) {
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
   await writeFile(CONFIG_FILE, JSON.stringify(config, null, 2));
 }
 

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -284,18 +284,11 @@ Phase 3 — Report:
 ]
 
 /**
- * Ensure data directory exists
- */
-async function ensureDataDir() {
-  await ensureDir(DATA_DIR)
-}
-
-/**
  * Load jobs from disk
  * @returns {Promise<Object>} Jobs data
  */
 async function loadJobs() {
-  await ensureDataDir()
+  await ensureDir(DATA_DIR)
 
   const loaded = await readJSONFile(JOBS_FILE, null)
   if (!loaded) {
@@ -356,7 +349,7 @@ function mergeWithDefaults(loaded) {
  * Save jobs to disk
  */
 async function saveJobs(data) {
-  await ensureDataDir()
+  await ensureDir(DATA_DIR)
   data.lastUpdated = new Date().toISOString()
   const tmp = JOBS_FILE + '.tmp'
   await writeFile(tmp, JSON.stringify(data, null, 2))

--- a/server/services/cosEvolution.js
+++ b/server/services/cosEvolution.js
@@ -15,7 +15,7 @@ import path from 'path'
 import { v4 as uuidv4 } from 'uuid'
 import { cosEvents } from './cosEvents.js'
 import * as lmStudioManager from './lmStudioManager.js'
-import { safeJSONParse } from '../lib/fileUtils.js'
+import { safeJSONParse, ensureDir } from '../lib/fileUtils.js'
 
 const DATA_DIR = path.join(process.cwd(), 'data', 'cos')
 const EVOLUTION_FILE = path.join(DATA_DIR, 'evolution.json')
@@ -46,20 +46,13 @@ const DEFAULT_STATE = {
 let evolutionState = null
 
 /**
- * Ensure data directory exists
- */
-async function ensureDataDir() {
-  await fs.mkdir(DATA_DIR, { recursive: true })
-}
-
-/**
  * Load evolution state
  * @returns {Promise<Object>} - Evolution state
  */
 async function loadState() {
   if (evolutionState) return evolutionState
 
-  await ensureDataDir()
+  await ensureDir(DATA_DIR)
 
   const exists = await fs.access(EVOLUTION_FILE).then(() => true).catch(() => false)
   if (exists) {
@@ -76,7 +69,7 @@ async function loadState() {
  * Save evolution state
  */
 async function saveState() {
-  await ensureDataDir()
+  await ensureDir(DATA_DIR)
   await fs.writeFile(EVOLUTION_FILE, JSON.stringify(evolutionState, null, 2))
 }
 

--- a/server/services/history.js
+++ b/server/services/history.js
@@ -12,10 +12,6 @@ let historyCache = null;
 let cacheTimestamp = 0;
 const CACHE_TTL_MS = 2000; // 2 second cache TTL
 
-async function ensureDataDir() {
-  await ensureDir(DATA_DIR);
-}
-
 async function loadHistory() {
   // Return cached data if still valid
   const now = Date.now();
@@ -23,7 +19,7 @@ async function loadHistory() {
     return historyCache;
   }
 
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
 
   historyCache = await readJSONFile(HISTORY_FILE, { entries: [] });
   cacheTimestamp = now;
@@ -31,7 +27,7 @@ async function loadHistory() {
 }
 
 async function saveHistory(data) {
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
   // Trim to max entries
   if (data.entries.length > MAX_ENTRIES) {
     data.entries = data.entries.slice(-MAX_ENTRIES);

--- a/server/services/memoryBM25.js
+++ b/server/services/memoryBM25.js
@@ -17,6 +17,7 @@ import {
   deserializeIndex,
   getIndexStats
 } from '../lib/bm25.js'
+import { ensureDir } from '../lib/fileUtils.js'
 
 const DATA_DIR = path.join(process.cwd(), 'data', 'cos', 'memory')
 const INDEX_FILE = path.join(DATA_DIR, 'bm25-index.json')
@@ -26,20 +27,13 @@ let indexCache = null
 let isDirty = false
 
 /**
- * Ensure the data directory exists
- */
-async function ensureDataDir() {
-  await fs.mkdir(DATA_DIR, { recursive: true })
-}
-
-/**
  * Load the BM25 index from disk
  * @returns {Promise<Object>} - The BM25 index
  */
 async function loadIndex() {
   if (indexCache) return indexCache
 
-  await ensureDataDir()
+  await ensureDir(DATA_DIR)
 
   const exists = await fs.access(INDEX_FILE).then(() => true).catch(() => false)
 
@@ -81,7 +75,7 @@ async function loadIndex() {
 async function saveIndex() {
   if (!indexCache || !isDirty) return
 
-  await ensureDataDir()
+  await ensureDir(DATA_DIR)
   const serialized = serializeIndex(indexCache)
   await fs.writeFile(INDEX_FILE, JSON.stringify(serialized, null, 2))
   isDirty = false
@@ -95,7 +89,7 @@ async function saveIndex() {
  * @returns {Promise<Object>} - Index statistics
  */
 async function rebuildIndex(memories) {
-  await ensureDataDir()
+  await ensureDir(DATA_DIR)
 
   // Convert memories to documents for indexing
   const documents = memories.map(m => ({

--- a/server/services/missions.js
+++ b/server/services/missions.js
@@ -9,19 +9,12 @@ import { promises as fs } from 'fs'
 import path from 'path'
 import { v4 as uuidv4 } from 'uuid'
 import { cosEvents } from './cosEvents.js'
-import { safeJSONParse } from '../lib/fileUtils.js'
+import { safeJSONParse, ensureDir } from '../lib/fileUtils.js'
 
 const DATA_DIR = path.join(process.cwd(), 'data', 'cos', 'missions')
 
 // In-memory cache
 let missionsCache = null
-
-/**
- * Ensure data directory exists
- */
-async function ensureDataDir() {
-  await fs.mkdir(DATA_DIR, { recursive: true })
-}
 
 /**
  * Load all missions
@@ -30,7 +23,7 @@ async function ensureDataDir() {
 async function loadMissions() {
   if (missionsCache) return missionsCache
 
-  await ensureDataDir()
+  await ensureDir(DATA_DIR)
 
   const files = await fs.readdir(DATA_DIR).catch(() => [])
   const missions = []
@@ -55,7 +48,7 @@ async function loadMissions() {
  * @param {Object} mission - Mission object
  */
 async function saveMission(mission) {
-  await ensureDataDir()
+  await ensureDir(DATA_DIR)
   const filePath = path.join(DATA_DIR, `${mission.id}.json`)
   await fs.writeFile(filePath, JSON.stringify(mission, null, 2))
 

--- a/server/services/productivity.js
+++ b/server/services/productivity.js
@@ -41,17 +41,10 @@ const DEFAULT_PRODUCTIVITY = {
 };
 
 /**
- * Ensure data directory exists
- */
-async function ensureDataDir() {
-  await ensureDir(DATA_DIR);
-}
-
-/**
  * Load productivity data
  */
 export async function loadProductivity() {
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
   const data = await readJSONFile(PRODUCTIVITY_FILE, DEFAULT_PRODUCTIVITY);
   // Merge with defaults to ensure all fields exist
   return {
@@ -65,7 +58,7 @@ export async function loadProductivity() {
  * Save productivity data
  */
 async function saveProductivity(data) {
-  await ensureDataDir();
+  await ensureDir(DATA_DIR);
   data.lastUpdated = new Date().toISOString();
   await writeFile(PRODUCTIVITY_FILE, JSON.stringify(data, null, 2));
   return data;


### PR DESCRIPTION
## Better Audit — DRY & YAGNI

### Summary
2 patterns addressed across 11 files.

### Changes
- **[HIGH]** Remove 9 redundant `ensureDataDir()` thin wrappers — call `ensureDir(DATA_DIR)` directly
- **[MEDIUM]** Remove duplicate `formatFileSize` from fileUpload.js — use `formatBytes` from formatters.js

### Files Modified
- `client/src/utils/fileUpload.js`
- `client/src/components/cos/TaskAddForm.jsx`
- `server/services/cosEvolution.js`
- `server/services/apps.js`
- `server/services/missions.js`
- `server/services/appActivity.js`
- `server/services/productivity.js`
- `server/services/autonomousJobs.js`
- `server/services/history.js`
- `server/services/memoryBM25.js`
- `server/services/autobiography.js`

### Merge Order
Independent — can be merged in any order