### PR TITLE
fix: correct socket.off() cleanup and stale closure in React components

### DIFF
--- a/client/src/hooks/useCityData.js
+++ b/client/src/hooks/useCityData.js
@@ -64,28 +64,33 @@ export const useCityData = () => {
     socket.on('apps:changed', handleAppsChanged);
 
     // CoS agent events
-    socket.on('cos:agent:spawned', (data) => {
+    const handleAgentSpawned = (data) => {
       setCosAgents(prev => [...prev, data]);
       fetchAll();
-    });
+    };
+    socket.on('cos:agent:spawned', handleAgentSpawned);
 
-    socket.on('cos:agent:updated', (updatedAgent) => {
+    const handleAgentUpdated = (updatedAgent) => {
       setCosAgents(prev => prev.map(a => a.agentId === updatedAgent.agentId ? updatedAgent : a));
-    });
+    };
+    socket.on('cos:agent:updated', handleAgentUpdated);
 
-    socket.on('cos:agent:completed', () => {
+    const handleAgentCompleted = () => {
       fetchAll();
-    });
+    };
+    socket.on('cos:agent:completed', handleAgentCompleted);
 
     // CoS log events
-    socket.on('cos:log', (data) => {
+    const handleCosLog = (data) => {
       setEventLogs(prev => [...prev, { ...data, timestamp: data.timestamp || Date.now() }].slice(-50));
-    });
+    };
+    socket.on('cos:log', handleCosLog);
 
     // CoS status
-    socket.on('cos:status', (data) => {
+    const handleCosStatus = (data) => {
       setCosStatus(prev => ({ ...prev, running: data.running }));
-    });
+    };
+    socket.on('cos:status', handleCosStatus);
 
     // Poll running agents (no socket events for system agents)
     pollRef.current = setInterval(async () => {
@@ -97,11 +102,11 @@ export const useCityData = () => {
       socket.emit('cos:unsubscribe');
       socket.off('connect', subscribe);
       socket.off('apps:changed', handleAppsChanged);
-      socket.off('cos:agent:spawned');
-      socket.off('cos:agent:updated');
-      socket.off('cos:agent:completed');
-      socket.off('cos:log');
-      socket.off('cos:status');
+      socket.off('cos:agent:spawned', handleAgentSpawned);
+      socket.off('cos:agent:updated', handleAgentUpdated);
+      socket.off('cos:agent:completed', handleAgentCompleted);
+      socket.off('cos:log', handleCosLog);
+      socket.off('cos:status', handleCosStatus);
       clearInterval(pollRef.current);
     };
   }, [fetchAll, fetchApps]);

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import toast from 'react-hot-toast';
 import * as api from '../services/api';
 import socket from '../services/socket';
@@ -46,7 +46,7 @@ export default function AIProviders() {
       socket.off(`run:${activeRun}:data`, handleData);
       socket.off(`run:${activeRun}:complete`, handleComplete);
     };
-  }, [activeRun]);
+  }, [activeRun, loadRuns]);
 
   const loadData = async () => {
     setLoading(true);
@@ -62,10 +62,10 @@ export default function AIProviders() {
     setLoading(false);
   };
 
-  const loadRuns = async () => {
+  const loadRuns = useCallback(async () => {
     const runsData = await api.getRuns(20).catch(() => ({ runs: [] }));
     setRuns(runsData.runs || []);
-  };
+  }, []);
 
   const handleSetActive = async (id) => {
     if (!id) return;

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -162,20 +162,22 @@ export default function ChiefOfStaff() {
       socket.on('connect', subscribe);
     }
 
-    socket.on('cos:status', (data) => {
+    const handleCosStatus = (data) => {
       setStatus(prev => ({ ...prev, running: data.running }));
       if (!data.running) {
         setAgentState('sleeping');
         setStatusMessage("Stopped - daemon not running");
         setActiveAgentMeta(null);
       }
-    });
+    };
+    socket.on('cos:status', handleCosStatus);
 
-    socket.on('cos:tasks:user:changed', (data) => {
+    const handleTasksUserChanged = (data) => {
       setTasks(prev => ({ ...prev, user: data }));
-    });
+    };
+    socket.on('cos:tasks:user:changed', handleTasksUserChanged);
 
-    socket.on('cos:agent:spawned', (data) => {
+    const handleAgentSpawned = (data) => {
       setAgentState('coding');
       // Show actual task description if available
       const taskDesc = data?.metadata?.taskDescription;
@@ -190,16 +192,18 @@ export default function ChiefOfStaff() {
         setLiveOutputs(prev => ({ ...prev, [data.agentId || data.id]: [] }));
       }
       fetchData();
-    });
+    };
+    socket.on('cos:agent:spawned', handleAgentSpawned);
 
-    socket.on('cos:agent:updated', (updatedAgent) => {
+    const handleAgentUpdated = (updatedAgent) => {
       // Update the specific agent in the agents list without fetching all data
       setAgents(prev => prev.map(agent =>
         agent.id === updatedAgent.id ? updatedAgent : agent
       ));
-    });
+    };
+    socket.on('cos:agent:updated', handleAgentUpdated);
 
-    socket.on('cos:agent:output', (data) => {
+    const handleAgentOutput = (data) => {
       if (data?.agentId && data?.line) {
         setLiveOutputs(prev => {
           const existing = prev[data.agentId] || [];
@@ -207,9 +211,10 @@ export default function ChiefOfStaff() {
           return { ...prev, [data.agentId]: updated.length > 500 ? updated.slice(-500) : updated };
         });
       }
-    });
+    };
+    socket.on('cos:agent:output', handleAgentOutput);
 
-    socket.on('cos:agent:completed', (data) => {
+    const handleAgentCompleted = (data) => {
       setAgentState('reviewing');
       const success = data?.result?.success;
       setStatusMessage(success ? "Task completed successfully" : "Task failed - checking errors...");
@@ -225,9 +230,10 @@ export default function ChiefOfStaff() {
         });
       }
       fetchData();
-    });
+    };
+    socket.on('cos:agent:completed', handleAgentCompleted);
 
-    socket.on('cos:health:check', (data) => {
+    const handleHealthCheck = (data) => {
       setHealth({ lastCheck: data.metrics?.timestamp, issues: data.issues });
       if (data.issues?.length > 0) {
         setAgentState('investigating');
@@ -235,10 +241,11 @@ export default function ChiefOfStaff() {
         setSpeaking(true);
         setTimeout(() => setSpeaking(false), 2000);
       }
-    });
+    };
+    socket.on('cos:health:check', handleHealthCheck);
 
     // Listen for detailed log events
-    socket.on('cos:log', (data) => {
+    const handleCosLog = (data) => {
       setEventLogs(prev => {
         const newLogs = [...prev, data].slice(-20); // Keep last 20 logs
         return newLogs;
@@ -251,25 +258,27 @@ export default function ChiefOfStaff() {
           setTimeout(() => setSpeaking(false), 1500);
         }
       }
-    });
+    };
+    socket.on('cos:log', handleCosLog);
 
     // Listen for apps changes (start/stop/restart)
-    socket.on('apps:changed', () => {
+    const handleAppsChanged = () => {
       fetchData();
-    });
+    };
+    socket.on('apps:changed', handleAppsChanged);
 
     return () => {
       socket.emit('cos:unsubscribe');
       socket.off('connect', subscribe);
-      socket.off('cos:status');
-      socket.off('cos:tasks:user:changed');
-      socket.off('cos:agent:spawned');
-      socket.off('cos:agent:updated');
-      socket.off('cos:agent:output');
-      socket.off('cos:agent:completed');
-      socket.off('cos:health:check');
-      socket.off('cos:log');
-      socket.off('apps:changed');
+      socket.off('cos:status', handleCosStatus);
+      socket.off('cos:tasks:user:changed', handleTasksUserChanged);
+      socket.off('cos:agent:spawned', handleAgentSpawned);
+      socket.off('cos:agent:updated', handleAgentUpdated);
+      socket.off('cos:agent:output', handleAgentOutput);
+      socket.off('cos:agent:completed', handleAgentCompleted);
+      socket.off('cos:health:check', handleHealthCheck);
+      socket.off('cos:log', handleCosLog);
+      socket.off('apps:changed', handleAppsChanged);
     };
   }, [socket, fetchData]);
 

--- a/client/src/pages/Instances.jsx
+++ b/client/src/pages/Instances.jsx
@@ -471,13 +471,14 @@ export default function Instances() {
     fetchData();
 
     socket.emit('instances:subscribe');
-    socket.on('instances:peers:updated', (updatedPeers) => {
+    const handlePeersUpdated = (updatedPeers) => {
       setPeers(updatedPeers);
-    });
+    };
+    socket.on('instances:peers:updated', handlePeersUpdated);
 
     return () => {
       socket.emit('instances:unsubscribe');
-      socket.off('instances:peers:updated');
+      socket.off('instances:peers:updated', handlePeersUpdated);
     };
   }, [fetchData]);
 

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -742,6 +742,7 @@ export const listCosWeeklyDigests = () => request('/cos/digest/list');
 export const getCosWeekProgress = () => request('/cos/digest/progress');
 export const getCosDigestText = async () => {
   const response = await fetch('/api/cos/digest/text');
+  if (!response.ok) throw new Error(`HTTP ${response.status}`);
   return response.text();
 };
 export const generateCosDigest = (weekId = null) => request('/cos/digest/generate', {


### PR DESCRIPTION
## Better Audit — Stack-Specific (Node/React)

### Summary
5 findings addressed across 5 files.

### Changes
- **[HIGH]** Pass handler refs to `socket.off()` in useCityData, ChiefOfStaff, Instances (was removing ALL listeners)
- **[HIGH]** Fix stale closure in AIProviders by wrapping `loadRuns` in `useCallback`
- **[MEDIUM]** Add `response.ok` check in `getCosDigestText` API call

### Files Modified
- `client/src/hooks/useCityData.js`
- `client/src/pages/ChiefOfStaff.jsx`
- `client/src/pages/Instances.jsx`
- `client/src/pages/AIProviders.jsx`
- `client/src/services/api.js`

### Merge Order
Independent — can be merged in any order