### PR TITLE
fix: clean up socket event handlers on disconnect

### DIFF
--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -434,6 +434,8 @@ export function initSocket(io) {
       if (detached > 0) {
         console.log(`🐚 Detached ${detached} shell session(s) (still running)`);
       }
+      // Remove all event handlers registered on this socket to prevent leaks
+      socket.removeAllListeners();
     });
   });
 


### PR DESCRIPTION
## Summary
- Add `socket.removeAllListeners()` in the disconnect handler in `server/services/socket.js`
- Prevents handler leaks when clients disconnect or drop unexpectedly
- Previously, event handlers (detect:start, logs:subscribe, shell:input, etc.) remained attached to disconnected socket objects

## Better Audit Item Addressed
- [MEDIUM] `server/services/socket.js` - Socket event handlers not cleaned up for dropped clients

## Test plan
- [x] All 1393 tests pass
- [ ] Verify socket connections clean up properly on client disconnect
- [ ] Monitor memory usage under repeated connect/disconnect cycles