### PR TITLE
test: add service-layer tests for 4 critical untested services

### DIFF
--- a/server/services/brain.test.js
+++ b/server/services/brain.test.js
@@ -84,8 +84,7 @@ vi.mock('child_process', () => ({
 }));
 
 import * as storage from './brainStorage.js';
-import { brainEvents } from './brainStorage.js';
-import { getActiveProvider, getProviderById } from './providers.js';
+import { getProviderById } from './providers.js';
 import {
   captureThought,
   resolveReview,

--- a/server/services/brain.test.js
+++ b/server/services/brain.test.js
@@ -1,0 +1,1009 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import EventEmitter from 'events';
+
+// Mock brainStorage
+vi.mock('./brainStorage.js', () => {
+  return {
+    brainEvents: new EventEmitter(),
+    loadMeta: vi.fn(),
+    updateMeta: vi.fn(),
+    getSummary: vi.fn(),
+    createInboxLog: vi.fn(),
+    getInboxLog: vi.fn(),
+    getInboxLogById: vi.fn(),
+    getInboxLogCounts: vi.fn(),
+    updateInboxLog: vi.fn(),
+    deleteInboxLog: vi.fn(),
+    createPerson: vi.fn(),
+    updatePerson: vi.fn(),
+    getPeople: vi.fn(),
+    createProject: vi.fn(),
+    updateProject: vi.fn(),
+    getProjects: vi.fn(),
+    createIdea: vi.fn(),
+    updateIdea: vi.fn(),
+    createAdminItem: vi.fn(),
+    updateAdminItem: vi.fn(),
+    getAdminItems: vi.fn(),
+    createMemoryEntry: vi.fn(),
+    updateMemoryEntry: vi.fn(),
+    deleteMemoryEntry: vi.fn(),
+    getMemoryEntries: vi.fn(),
+    getMemoryEntryById: vi.fn(),
+    createDigest: vi.fn(),
+    createReview: vi.fn(),
+    getDigests: vi.fn(),
+    getLatestDigest: vi.fn(),
+    getReviews: vi.fn(),
+    getLatestReview: vi.fn(),
+    getPersonById: vi.fn(),
+    deletePerson: vi.fn(),
+    getProjectById: vi.fn(),
+    deleteProject: vi.fn(),
+    getIdeas: vi.fn(),
+    getIdeaById: vi.fn(),
+    deleteIdea: vi.fn(),
+    getAdminById: vi.fn(),
+    deleteAdminItem: vi.fn(),
+    getLinks: vi.fn(),
+    getLinkById: vi.fn(),
+    getLinkByUrl: vi.fn(),
+    createLink: vi.fn(),
+    updateLink: vi.fn(),
+    deleteLink: vi.fn()
+  };
+});
+
+// Mock providers
+vi.mock('./providers.js', () => ({
+  getActiveProvider: vi.fn(),
+  getProviderById: vi.fn()
+}));
+
+// Mock promptService
+vi.mock('./promptService.js', () => ({
+  buildPrompt: vi.fn().mockResolvedValue('test prompt')
+}));
+
+// Mock validation
+vi.mock('../lib/validation.js', () => ({
+  validate: vi.fn()
+}));
+
+// Mock fileUtils
+vi.mock('../lib/fileUtils.js', () => ({
+  safeJSONParse: vi.fn((str, defaultVal) => {
+    if (!str) return defaultVal;
+    try { return JSON.parse(str); } catch { return defaultVal; }
+  })
+}));
+
+// Mock child_process
+vi.mock('child_process', () => ({
+  spawn: vi.fn()
+}));
+
+import * as storage from './brainStorage.js';
+import { brainEvents } from './brainStorage.js';
+import { getActiveProvider, getProviderById } from './providers.js';
+import {
+  captureThought,
+  resolveReview,
+  fixClassification,
+  runDailyDigest,
+  runWeeklyReview,
+  retryClassification,
+  markInboxDone,
+  updateInboxEntry,
+  deleteInboxEntry,
+  recoverStuckClassifications
+} from './brain.js';
+
+describe('brain service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storage.loadMeta.mockResolvedValue({
+      confidenceThreshold: 0.6,
+      defaultProvider: 'lmstudio',
+      defaultModel: 'test-model'
+    });
+  });
+
+  // ===========================================================================
+  // captureThought
+  // ===========================================================================
+
+  describe('captureThought', () => {
+    it('should create an inbox log entry and return immediately', async () => {
+      const mockEntry = { id: 'inbox-001', capturedText: 'hello', status: 'classifying' };
+      storage.createInboxLog.mockResolvedValue(mockEntry);
+
+      const result = await captureThought('hello');
+
+      expect(storage.createInboxLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          capturedText: 'hello',
+          source: 'brain_ui',
+          status: 'classifying'
+        })
+      );
+      expect(result.inboxLog).toEqual(mockEntry);
+      expect(result.message).toContain('captured');
+    });
+
+    it('should use meta defaults when no overrides given', async () => {
+      storage.createInboxLog.mockResolvedValue({ id: 'inbox-002', status: 'classifying' });
+
+      await captureThought('test text');
+
+      expect(storage.createInboxLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ai: expect.objectContaining({
+            providerId: 'lmstudio',
+            modelId: 'test-model',
+            promptTemplateId: 'brain-classifier'
+          })
+        })
+      );
+    });
+
+    it('should use provider and model overrides when provided', async () => {
+      storage.createInboxLog.mockResolvedValue({ id: 'inbox-003', status: 'classifying' });
+
+      await captureThought('test', 'openai', 'gpt-4');
+
+      expect(storage.createInboxLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ai: expect.objectContaining({
+            providerId: 'openai',
+            modelId: 'gpt-4'
+          })
+        })
+      );
+    });
+  });
+
+  // ===========================================================================
+  // resolveReview
+  // ===========================================================================
+
+  describe('resolveReview', () => {
+    it('should file a needs_review item to destination', async () => {
+      const mockInbox = {
+        id: 'inbox-001',
+        status: 'needs_review',
+        classification: {
+          title: 'Test Person',
+          extracted: { name: 'Alice' }
+        }
+      };
+      storage.getInboxLogById.mockResolvedValue(mockInbox);
+      storage.createPerson.mockResolvedValue({ id: 'person-001', name: 'Alice' });
+      storage.updateInboxLog.mockResolvedValue({});
+      // After update, return the updated entry
+      storage.getInboxLogById.mockResolvedValueOnce(mockInbox)
+        .mockResolvedValueOnce({ ...mockInbox, status: 'filed' });
+
+      const result = await resolveReview('inbox-001', 'people', { name: 'Alice' });
+
+      expect(storage.createPerson).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Alice' })
+      );
+      expect(storage.updateInboxLog).toHaveBeenCalledWith('inbox-001', expect.objectContaining({
+        status: 'filed',
+        filed: expect.objectContaining({
+          destination: 'people',
+          destinationId: 'person-001'
+        })
+      }));
+      expect(result.filedRecord.id).toBe('person-001');
+    });
+
+    it('should throw if inbox log not found', async () => {
+      storage.getInboxLogById.mockResolvedValue(null);
+
+      await expect(resolveReview('missing-id', 'people', {}))
+        .rejects.toThrow('Inbox log entry not found');
+    });
+
+    it('should throw if status is not needs_review', async () => {
+      storage.getInboxLogById.mockResolvedValue({ id: 'inbox-001', status: 'filed' });
+
+      await expect(resolveReview('inbox-001', 'people', {}))
+        .rejects.toThrow('not in needs_review status');
+    });
+
+    it('should merge editedExtracted with existing classification extracted', async () => {
+      storage.getInboxLogById.mockResolvedValue({
+        id: 'inbox-001',
+        status: 'needs_review',
+        classification: {
+          title: 'Test',
+          extracted: { name: 'Original', context: 'existing' }
+        }
+      });
+      storage.createPerson.mockResolvedValue({ id: 'person-002', name: 'Updated' });
+      storage.updateInboxLog.mockResolvedValue({});
+
+      await resolveReview('inbox-001', 'people', { name: 'Updated' });
+
+      // createPerson should receive merged data: original context + updated name
+      expect(storage.createPerson).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Updated', context: 'existing' })
+      );
+    });
+
+    it('should set confidence to 1.0 and add "Manually resolved" reason', async () => {
+      storage.getInboxLogById.mockResolvedValue({
+        id: 'inbox-001',
+        status: 'needs_review',
+        classification: { title: 'Test', extracted: {}, reasons: ['Low confidence'] }
+      });
+      storage.createIdea.mockResolvedValue({ id: 'idea-001' });
+      storage.updateInboxLog.mockResolvedValue({});
+
+      await resolveReview('inbox-001', 'ideas', { title: 'Test', oneLiner: 'one' });
+
+      expect(storage.updateInboxLog).toHaveBeenCalledWith('inbox-001', expect.objectContaining({
+        classification: expect.objectContaining({
+          confidence: 1.0,
+          reasons: expect.arrayContaining(['Manually resolved'])
+        })
+      }));
+    });
+  });
+
+  // ===========================================================================
+  // fixClassification
+  // ===========================================================================
+
+  describe('fixClassification', () => {
+    it('should move filed item to new destination and archive old record', async () => {
+      storage.getInboxLogById.mockResolvedValue({
+        id: 'inbox-001',
+        status: 'filed',
+        classification: { title: 'Test Idea', extracted: { title: 'Test Idea', oneLiner: 'desc' }, destination: 'ideas' },
+        filed: { destination: 'ideas', destinationId: 'idea-001' }
+      });
+      storage.createProject.mockResolvedValue({ id: 'proj-001', name: 'Test Project' });
+      storage.updateIdea.mockResolvedValue({});
+      storage.updateInboxLog.mockResolvedValue({});
+
+      await fixClassification('inbox-001', 'projects', { name: 'Test Project', nextAction: 'Do something' }, 'Wrong category');
+
+      // Should archive old record
+      expect(storage.updateIdea).toHaveBeenCalledWith('idea-001', { archived: true });
+
+      // Should create new record
+      expect(storage.createProject).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'Test Project' })
+      );
+
+      // Should update inbox log with correction info
+      expect(storage.updateInboxLog).toHaveBeenCalledWith('inbox-001', expect.objectContaining({
+        status: 'corrected',
+        filed: { destination: 'projects', destinationId: 'proj-001' },
+        correction: expect.objectContaining({
+          previousDestination: 'ideas',
+          newDestination: 'projects',
+          note: 'Wrong category'
+        })
+      }));
+    });
+
+    it('should throw if inbox log not found', async () => {
+      storage.getInboxLogById.mockResolvedValue(null);
+
+      await expect(fixClassification('missing', 'people', {}, 'note'))
+        .rejects.toThrow('Inbox log entry not found');
+    });
+
+    it('should throw if status is not filed or corrected', async () => {
+      storage.getInboxLogById.mockResolvedValue({ id: 'inbox-001', status: 'needs_review' });
+
+      await expect(fixClassification('inbox-001', 'people', {}, 'note'))
+        .rejects.toThrow('Can only fix filed or previously corrected entries');
+    });
+
+    it('should allow fixing previously corrected entries', async () => {
+      storage.getInboxLogById.mockResolvedValue({
+        id: 'inbox-001',
+        status: 'corrected',
+        classification: { title: 'Test', extracted: {}, destination: 'projects' },
+        filed: { destination: 'projects', destinationId: 'proj-001' }
+      });
+      storage.createPerson.mockResolvedValue({ id: 'person-001' });
+      storage.updateProject.mockResolvedValue({});
+      storage.updateInboxLog.mockResolvedValue({});
+
+      await expect(fixClassification('inbox-001', 'people', { name: 'Alice' }, 'oops'))
+        .resolves.toBeDefined();
+    });
+
+    it('should handle missing previous destination gracefully', async () => {
+      storage.getInboxLogById.mockResolvedValue({
+        id: 'inbox-001',
+        status: 'filed',
+        classification: { title: 'Test', extracted: {} }
+        // no filed field
+      });
+      storage.createPerson.mockResolvedValue({ id: 'person-001' });
+      storage.updateInboxLog.mockResolvedValue({});
+
+      await fixClassification('inbox-001', 'people', { name: 'Alice' }, 'note');
+
+      // Should not attempt to archive since there's no previousId
+      expect(storage.updatePerson).not.toHaveBeenCalled();
+      expect(storage.updateProject).not.toHaveBeenCalled();
+      expect(storage.updateIdea).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // fileToDestination (tested indirectly via resolveReview)
+  // ===========================================================================
+
+  describe('fileToDestination (via resolveReview)', () => {
+    beforeEach(() => {
+      storage.updateInboxLog.mockResolvedValue({});
+    });
+
+    const makeNeedsReview = (title = 'Test') => ({
+      id: 'inbox-001',
+      status: 'needs_review',
+      classification: { title, extracted: {} }
+    });
+
+    it('should file to people with defaults', async () => {
+      storage.getInboxLogById.mockResolvedValue(makeNeedsReview('John'));
+      storage.createPerson.mockResolvedValue({ id: 'p1' });
+
+      await resolveReview('inbox-001', 'people', { name: 'John' });
+
+      expect(storage.createPerson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'John',
+          context: '',
+          followUps: [],
+          tags: []
+        })
+      );
+    });
+
+    it('should file to projects with defaults', async () => {
+      storage.getInboxLogById.mockResolvedValue(makeNeedsReview());
+      storage.createProject.mockResolvedValue({ id: 'proj1' });
+
+      await resolveReview('inbox-001', 'projects', { name: 'My Project', nextAction: 'Start' });
+
+      expect(storage.createProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'My Project',
+          status: 'active',
+          nextAction: 'Start',
+          notes: '',
+          tags: []
+        })
+      );
+    });
+
+    it('should file to ideas with defaults', async () => {
+      storage.getInboxLogById.mockResolvedValue(makeNeedsReview());
+      storage.createIdea.mockResolvedValue({ id: 'idea1' });
+
+      await resolveReview('inbox-001', 'ideas', { title: 'Cool Idea', oneLiner: 'A thing' });
+
+      expect(storage.createIdea).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Cool Idea',
+          oneLiner: 'A thing',
+          notes: '',
+          tags: []
+        })
+      );
+    });
+
+    it('should file to admin with defaults', async () => {
+      storage.getInboxLogById.mockResolvedValue(makeNeedsReview());
+      storage.createAdminItem.mockResolvedValue({ id: 'admin1' });
+
+      await resolveReview('inbox-001', 'admin', { title: 'Renew license' });
+
+      expect(storage.createAdminItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Renew license',
+          status: 'open',
+          dueDate: null,
+          nextAction: null,
+          notes: ''
+        })
+      );
+    });
+
+    it('should file to memories with defaults', async () => {
+      storage.getInboxLogById.mockResolvedValue(makeNeedsReview());
+      storage.createMemoryEntry.mockResolvedValue({ id: 'mem1' });
+
+      await resolveReview('inbox-001', 'memories', { title: 'Good day' });
+
+      expect(storage.createMemoryEntry).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Good day',
+          content: '',
+          mood: null,
+          tags: []
+        })
+      );
+    });
+
+    it('should use title as fallback for name/title fields when extracted data is empty', async () => {
+      storage.getInboxLogById.mockResolvedValue({
+        id: 'inbox-001',
+        status: 'needs_review',
+        classification: { title: 'Fallback Title', extracted: {} }
+      });
+      storage.createIdea.mockResolvedValue({ id: 'idea1' });
+
+      await resolveReview('inbox-001', 'ideas', {});
+
+      // title field falls back to classification title
+      expect(storage.createIdea).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Fallback Title' })
+      );
+    });
+  });
+
+  // ===========================================================================
+  // markInboxDone
+  // ===========================================================================
+
+  describe('markInboxDone', () => {
+    it('should mark entry as done', async () => {
+      storage.getInboxLogById.mockResolvedValue({ id: 'inbox-001', status: 'filed' });
+      storage.updateInboxLog.mockResolvedValue({ id: 'inbox-001', status: 'done' });
+
+      const result = await markInboxDone('inbox-001');
+
+      expect(storage.updateInboxLog).toHaveBeenCalledWith('inbox-001', expect.objectContaining({
+        status: 'done',
+        doneAt: expect.any(String)
+      }));
+      expect(result.status).toBe('done');
+    });
+
+    it('should return null if entry not found', async () => {
+      storage.getInboxLogById.mockResolvedValue(null);
+
+      const result = await markInboxDone('missing');
+
+      expect(result).toBeNull();
+      expect(storage.updateInboxLog).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // updateInboxEntry
+  // ===========================================================================
+
+  describe('updateInboxEntry', () => {
+    it('should update inbox entry and return updated', async () => {
+      storage.updateInboxLog.mockResolvedValue({ id: 'inbox-001', capturedText: 'updated text' });
+
+      const result = await updateInboxEntry('inbox-001', { capturedText: 'updated text' });
+
+      expect(storage.updateInboxLog).toHaveBeenCalledWith('inbox-001', { capturedText: 'updated text' });
+      expect(result.capturedText).toBe('updated text');
+    });
+
+    it('should return null if entry not found', async () => {
+      storage.updateInboxLog.mockResolvedValue(null);
+
+      const result = await updateInboxEntry('missing', { capturedText: 'test' });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // deleteInboxEntry
+  // ===========================================================================
+
+  describe('deleteInboxEntry', () => {
+    it('should delete entry and return true', async () => {
+      storage.deleteInboxLog.mockResolvedValue(true);
+
+      const result = await deleteInboxEntry('inbox-001');
+
+      expect(storage.deleteInboxLog).toHaveBeenCalledWith('inbox-001');
+      expect(result).toBe(true);
+    });
+
+    it('should return false if entry not found', async () => {
+      storage.deleteInboxLog.mockResolvedValue(false);
+
+      const result = await deleteInboxEntry('missing');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // retryClassification
+  // ===========================================================================
+
+  describe('retryClassification', () => {
+    it('should set status to classifying and return updated entry', async () => {
+      const mockEntry = { id: 'inbox-001', capturedText: 'test', status: 'needs_review' };
+      storage.getInboxLogById.mockResolvedValue(mockEntry);
+      storage.updateInboxLog.mockResolvedValue({});
+      // Second call returns the updated entry
+      storage.getInboxLogById.mockResolvedValueOnce(mockEntry)
+        .mockResolvedValueOnce({ ...mockEntry, status: 'classifying' });
+
+      const result = await retryClassification('inbox-001');
+
+      expect(storage.updateInboxLog).toHaveBeenCalledWith('inbox-001', expect.objectContaining({
+        status: 'classifying',
+        error: null
+      }));
+      expect(result.message).toContain('Retrying');
+    });
+
+    it('should throw if entry not found', async () => {
+      storage.getInboxLogById.mockResolvedValue(null);
+
+      await expect(retryClassification('missing'))
+        .rejects.toThrow('Inbox log entry not found');
+    });
+
+    it('should use provider/model overrides', async () => {
+      storage.getInboxLogById.mockResolvedValue({ id: 'inbox-001', capturedText: 'test' });
+      storage.updateInboxLog.mockResolvedValue({});
+
+      await retryClassification('inbox-001', 'openai', 'gpt-4');
+
+      expect(storage.updateInboxLog).toHaveBeenCalledWith('inbox-001', expect.objectContaining({
+        ai: expect.objectContaining({
+          providerId: 'openai',
+          modelId: 'gpt-4'
+        })
+      }));
+    });
+  });
+
+  // ===========================================================================
+  // recoverStuckClassifications
+  // ===========================================================================
+
+  describe('recoverStuckClassifications', () => {
+    it('should reset stuck classifying entries to needs_review', async () => {
+      storage.getInboxLog.mockResolvedValue([
+        { id: 'inbox-001' },
+        { id: 'inbox-002' }
+      ]);
+      storage.updateInboxLog.mockResolvedValue({});
+
+      await recoverStuckClassifications();
+
+      expect(storage.getInboxLog).toHaveBeenCalledWith({ status: 'classifying', limit: 100 });
+      expect(storage.updateInboxLog).toHaveBeenCalledTimes(2);
+      expect(storage.updateInboxLog).toHaveBeenCalledWith('inbox-001', { status: 'needs_review' });
+      expect(storage.updateInboxLog).toHaveBeenCalledWith('inbox-002', { status: 'needs_review' });
+    });
+
+    it('should do nothing when no stuck entries exist', async () => {
+      storage.getInboxLog.mockResolvedValue([]);
+
+      await recoverStuckClassifications();
+
+      expect(storage.updateInboxLog).not.toHaveBeenCalled();
+    });
+  });
+
+  // ===========================================================================
+  // runDailyDigest
+  // ===========================================================================
+
+  describe('runDailyDigest', () => {
+    it('should gather data, call AI, and store digest', async () => {
+      storage.getProjects.mockResolvedValue([{ id: 'p1', name: 'Proj', status: 'active' }]);
+      storage.getAdminItems.mockResolvedValue([{ id: 'a1', title: 'Task', status: 'open' }]);
+      storage.getPeople.mockResolvedValue([
+        { id: 'ppl1', name: 'Alice', followUps: ['call her'] }
+      ]);
+      storage.getInboxLog.mockResolvedValue([]);
+
+      // Mock the AI call (callAI is internal, so we mock the provider)
+      const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
+      getProviderById.mockResolvedValue(mockProvider);
+
+      const digestResponse = {
+        digestText: 'Today is productive',
+        topActions: ['Action 1', 'Action 2'],
+        stuckThing: 'Nothing stuck',
+        smallWin: 'Tests pass'
+      };
+
+      // Mock fetch for API provider
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: JSON.stringify(digestResponse) } }]
+        })
+      });
+
+      storage.createDigest.mockResolvedValue({ id: 'digest-001', ...digestResponse });
+
+      const result = await runDailyDigest();
+
+      expect(storage.getProjects).toHaveBeenCalledWith({ status: 'active' });
+      expect(storage.getAdminItems).toHaveBeenCalledWith({ status: 'open' });
+      expect(storage.getPeople).toHaveBeenCalled();
+      expect(storage.createDigest).toHaveBeenCalledWith(expect.objectContaining({
+        digestText: 'Today is productive',
+        topActions: ['Action 1', 'Action 2']
+      }));
+      expect(result.id).toBe('digest-001');
+    });
+
+    it('should truncate digest text exceeding 150 words', async () => {
+      storage.getProjects.mockResolvedValue([]);
+      storage.getAdminItems.mockResolvedValue([]);
+      storage.getPeople.mockResolvedValue([]);
+      storage.getInboxLog.mockResolvedValue([]);
+
+      const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
+      getProviderById.mockResolvedValue(mockProvider);
+
+      const longText = Array(200).fill('word').join(' ');
+      const digestResponse = {
+        digestText: longText,
+        topActions: ['Do stuff'],
+        stuckThing: 'Nothing',
+        smallWin: 'Yes'
+      };
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: JSON.stringify(digestResponse) } }]
+        })
+      });
+
+      storage.createDigest.mockImplementation(async (data) => ({ id: 'digest-001', ...data }));
+
+      const result = await runDailyDigest();
+
+      const wordCount = result.digestText.split(/\s+/).length;
+      // 150 words + the trailing "..." which may count as a word
+      expect(wordCount).toBeLessThanOrEqual(151);
+      expect(result.digestText).toContain('...');
+    });
+
+    it('should filter people to only those with followUps', async () => {
+      storage.getProjects.mockResolvedValue([]);
+      storage.getAdminItems.mockResolvedValue([]);
+      storage.getPeople.mockResolvedValue([
+        { id: 'p1', name: 'Alice', followUps: ['call'] },
+        { id: 'p2', name: 'Bob', followUps: [] },
+        { id: 'p3', name: 'Charlie' } // no followUps field
+      ]);
+      storage.getInboxLog.mockResolvedValue([]);
+
+      const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
+      getProviderById.mockResolvedValue(mockProvider);
+
+      const digestResponse = {
+        digestText: 'Summary',
+        topActions: ['Act'],
+        stuckThing: 'N/A',
+        smallWin: 'Win'
+      };
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: JSON.stringify(digestResponse) } }]
+        })
+      });
+
+      storage.createDigest.mockImplementation(async (data) => ({ id: 'd1', ...data }));
+
+      await runDailyDigest();
+
+      // Verify fetch was called with body containing only Alice (has followUps)
+      const fetchCall = globalThis.fetch.mock.calls[0];
+      const body = JSON.parse(fetchCall[1].body);
+      const promptContent = body.messages[0].content;
+      // The prompt should contain the stringified peopleWithFollowUps
+      // We can't easily check the prompt content without knowing the template,
+      // but we can verify the storage calls
+      expect(storage.getPeople).toHaveBeenCalled();
+    });
+
+    it('should throw when AI returns invalid digest format', async () => {
+      storage.getProjects.mockResolvedValue([]);
+      storage.getAdminItems.mockResolvedValue([]);
+      storage.getPeople.mockResolvedValue([]);
+      storage.getInboxLog.mockResolvedValue([]);
+
+      const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
+      getProviderById.mockResolvedValue(mockProvider);
+
+      // Return invalid format (missing required fields)
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: JSON.stringify({ wrong: 'format' }) } }]
+        })
+      });
+
+      await expect(runDailyDigest()).rejects.toThrow('Invalid digest output');
+    });
+  });
+
+  // ===========================================================================
+  // runWeeklyReview
+  // ===========================================================================
+
+  describe('runWeeklyReview', () => {
+    it('should gather last 7 days data and store review', async () => {
+      const recentLog = {
+        id: 'inbox-001',
+        capturedAt: new Date().toISOString(),
+        status: 'filed'
+      };
+      const oldLog = {
+        id: 'inbox-002',
+        capturedAt: '2020-01-01T00:00:00.000Z',
+        status: 'filed'
+      };
+
+      storage.getInboxLog.mockResolvedValue([recentLog, oldLog]);
+      storage.getProjects.mockResolvedValue([]);
+
+      const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
+      getProviderById.mockResolvedValue(mockProvider);
+
+      const reviewResponse = {
+        reviewText: 'Good week',
+        whatHappened: ['Did stuff'],
+        biggestOpenLoops: ['Loop 1'],
+        suggestedActionsNextWeek: ['Do more'],
+        recurringTheme: 'Productivity'
+      };
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: JSON.stringify(reviewResponse) } }]
+        })
+      });
+
+      storage.createReview.mockResolvedValue({ id: 'review-001', ...reviewResponse });
+
+      const result = await runWeeklyReview();
+
+      expect(storage.getInboxLog).toHaveBeenCalledWith({ limit: 500 });
+      expect(storage.getProjects).toHaveBeenCalledWith({ status: 'active' });
+      expect(storage.createReview).toHaveBeenCalledWith(expect.objectContaining({
+        reviewText: 'Good week',
+        whatHappened: ['Did stuff']
+      }));
+      expect(result.id).toBe('review-001');
+    });
+
+    it('should truncate review text exceeding 250 words', async () => {
+      storage.getInboxLog.mockResolvedValue([]);
+      storage.getProjects.mockResolvedValue([]);
+
+      const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
+      getProviderById.mockResolvedValue(mockProvider);
+
+      const longText = Array(300).fill('word').join(' ');
+      const reviewResponse = {
+        reviewText: longText,
+        whatHappened: ['Thing'],
+        biggestOpenLoops: ['Loop'],
+        suggestedActionsNextWeek: ['Act'],
+        recurringTheme: 'Theme'
+      };
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: JSON.stringify(reviewResponse) } }]
+        })
+      });
+
+      storage.createReview.mockImplementation(async (data) => ({ id: 'r1', ...data }));
+
+      const result = await runWeeklyReview();
+
+      const wordCount = result.reviewText.split(/\s+/).length;
+      expect(wordCount).toBeLessThanOrEqual(251);
+      expect(result.reviewText).toContain('...');
+    });
+
+    it('should throw when AI returns invalid review format', async () => {
+      storage.getInboxLog.mockResolvedValue([]);
+      storage.getProjects.mockResolvedValue([]);
+
+      const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
+      getProviderById.mockResolvedValue(mockProvider);
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: JSON.stringify({ bad: 'data' }) } }]
+        })
+      });
+
+      await expect(runWeeklyReview()).rejects.toThrow('Invalid review output');
+    });
+  });
+
+  // ===========================================================================
+  // parseJsonResponse (tested indirectly via digest/review)
+  // ===========================================================================
+
+  describe('parseJsonResponse (indirect via AI calls)', () => {
+    it('should handle JSON wrapped in markdown code blocks', async () => {
+      storage.getProjects.mockResolvedValue([]);
+      storage.getAdminItems.mockResolvedValue([]);
+      storage.getPeople.mockResolvedValue([]);
+      storage.getInboxLog.mockResolvedValue([]);
+
+      const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
+      getProviderById.mockResolvedValue(mockProvider);
+
+      const digestResponse = {
+        digestText: 'Summary',
+        topActions: ['Act'],
+        stuckThing: 'N/A',
+        smallWin: 'Win'
+      };
+
+      // Wrap in markdown code block
+      const wrappedResponse = '```json\n' + JSON.stringify(digestResponse) + '\n```';
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: wrappedResponse } }]
+        })
+      });
+
+      storage.createDigest.mockImplementation(async (data) => ({ id: 'd1', ...data }));
+
+      const result = await runDailyDigest();
+      expect(result.digestText).toBe('Summary');
+    });
+
+    it('should throw on empty AI response', async () => {
+      storage.getProjects.mockResolvedValue([]);
+      storage.getAdminItems.mockResolvedValue([]);
+      storage.getPeople.mockResolvedValue([]);
+      storage.getInboxLog.mockResolvedValue([]);
+
+      const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
+      getProviderById.mockResolvedValue(mockProvider);
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          choices: [{ message: { content: '' } }]
+        })
+      });
+
+      await expect(runDailyDigest()).rejects.toThrow('Empty or invalid AI response');
+    });
+  });
+
+  // ===========================================================================
+  // callAI error handling (tested indirectly)
+  // ===========================================================================
+
+  describe('callAI error handling (indirect)', () => {
+    it('should throw when no provider available', async () => {
+      storage.getProjects.mockResolvedValue([]);
+      storage.getAdminItems.mockResolvedValue([]);
+      storage.getPeople.mockResolvedValue([]);
+      storage.getInboxLog.mockResolvedValue([]);
+
+      getProviderById.mockResolvedValue(null);
+
+      await expect(runDailyDigest()).rejects.toThrow('No AI provider available');
+    });
+
+    it('should throw when provider is disabled', async () => {
+      storage.getProjects.mockResolvedValue([]);
+      storage.getAdminItems.mockResolvedValue([]);
+      storage.getPeople.mockResolvedValue([]);
+      storage.getInboxLog.mockResolvedValue([]);
+
+      getProviderById.mockResolvedValue({ id: 'lmstudio', enabled: false, type: 'api' });
+
+      await expect(runDailyDigest()).rejects.toThrow('No AI provider available');
+    });
+
+    it('should throw on API error response', async () => {
+      storage.getProjects.mockResolvedValue([]);
+      storage.getAdminItems.mockResolvedValue([]);
+      storage.getPeople.mockResolvedValue([]);
+      storage.getInboxLog.mockResolvedValue([]);
+
+      const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
+      getProviderById.mockResolvedValue(mockProvider);
+
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+        text: () => Promise.resolve('Internal Server Error')
+      });
+
+      await expect(runDailyDigest()).rejects.toThrow('AI API error: 500');
+    });
+
+    it('should throw for unsupported provider type', async () => {
+      storage.getProjects.mockResolvedValue([]);
+      storage.getAdminItems.mockResolvedValue([]);
+      storage.getPeople.mockResolvedValue([]);
+      storage.getInboxLog.mockResolvedValue([]);
+
+      getProviderById.mockResolvedValue({ id: 'weird', enabled: true, type: 'smoke_signal', defaultModel: 'test' });
+
+      await expect(runDailyDigest()).rejects.toThrow('Unsupported provider type: smoke_signal');
+    });
+  });
+
+  // ===========================================================================
+  // archiveRecord (tested indirectly via fixClassification)
+  // ===========================================================================
+
+  describe('archiveRecord (via fixClassification)', () => {
+    const destinations = ['people', 'projects', 'ideas', 'admin', 'memories'];
+    const updateFns = {
+      people: 'updatePerson',
+      projects: 'updateProject',
+      ideas: 'updateIdea',
+      admin: 'updateAdminItem',
+      memories: 'updateMemoryEntry'
+    };
+
+    for (const dest of destinations) {
+      it(`should archive ${dest} records`, async () => {
+        storage.getInboxLogById.mockResolvedValue({
+          id: 'inbox-001',
+          status: 'filed',
+          classification: { title: 'Test', extracted: {}, destination: dest },
+          filed: { destination: dest, destinationId: 'old-001' }
+        });
+        // Mock the create function for the new destination (use people as target)
+        storage.createPerson.mockResolvedValue({ id: 'new-001' });
+        storage[updateFns[dest]].mockResolvedValue({});
+        storage.updateInboxLog.mockResolvedValue({});
+
+        await fixClassification('inbox-001', 'people', { name: 'Test' }, 'fix');
+
+        expect(storage[updateFns[dest]]).toHaveBeenCalledWith('old-001', { archived: true });
+      });
+    }
+  });
+
+  // ===========================================================================
+  // Re-exported storage functions
+  // ===========================================================================
+
+  describe('re-exported storage functions', () => {
+    it('should re-export loadMeta from storage', async () => {
+      const { loadMeta } = await import('./brain.js');
+      expect(loadMeta).toBe(storage.loadMeta);
+    });
+
+    it('should re-export getSummary from storage', async () => {
+      const { getSummary } = await import('./brain.js');
+      expect(getSummary).toBe(storage.getSummary);
+    });
+  });
+});

--- a/server/services/digital-twin.test.js
+++ b/server/services/digital-twin.test.js
@@ -1228,6 +1228,7 @@ Should mention core values.
       buildPrompt.mockResolvedValue(null); // Force fallback prompt
 
       // Mock fetch for callProviderAI
+      const originalFetch = global.fetch;
       global.fetch = vi.fn().mockResolvedValue({
         ok: true,
         json: async () => ({
@@ -1244,7 +1245,7 @@ Should mention core values.
       expect(result.source).toBe('goodreads');
       expect(result.itemCount).toBe(2);
 
-      delete global.fetch;
+      global.fetch = originalFetch;
     });
   });
 

--- a/server/services/digital-twin.test.js
+++ b/server/services/digital-twin.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ============================================================================
 // Mocks — must be declared before importing the module under test

--- a/server/services/digital-twin.test.js
+++ b/server/services/digital-twin.test.js
@@ -1,0 +1,1353 @@
+import { describe, it, expect, vi, beforeEach, beforeAll } from 'vitest';
+
+// ============================================================================
+// Mocks — must be declared before importing the module under test
+// ============================================================================
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  unlink: vi.fn(),
+  readdir: vi.fn(),
+  mkdir: vi.fn(),
+  stat: vi.fn()
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(() => true)
+}));
+
+let uuidCounter = 0;
+vi.mock('uuid', () => ({
+  v4: () => `test-uuid-${++uuidCounter}`
+}));
+
+vi.mock('./providers.js', () => ({
+  getActiveProvider: vi.fn(),
+  getProviderById: vi.fn()
+}));
+
+vi.mock('./promptService.js', () => ({
+  buildPrompt: vi.fn()
+}));
+
+vi.mock('../lib/digitalTwinValidation.js', () => ({
+  digitalTwinMetaSchema: {
+    safeParse: vi.fn((data) => ({ success: true, data }))
+  },
+  documentMetaSchema: { safeParse: vi.fn((data) => ({ success: true, data })) },
+  testHistoryEntrySchema: { safeParse: vi.fn((data) => ({ success: true, data })) }
+}));
+
+vi.mock('../lib/fileUtils.js', () => ({
+  safeJSONParse: vi.fn((str, defaultValue) => {
+    if (!str || !str.trim()) return defaultValue;
+    const parsed = JSON.parse(str);
+    return parsed;
+  })
+}));
+
+// ============================================================================
+// Imports
+// ============================================================================
+
+import { readFile, writeFile, unlink, readdir, mkdir, stat } from 'fs/promises';
+import { existsSync } from 'fs';
+import { getProviderById, getActiveProvider } from './providers.js';
+import { buildPrompt } from './promptService.js';
+import { safeJSONParse } from '../lib/fileUtils.js';
+
+import {
+  digitalTwinEvents,
+  soulEvents,
+  ENRICHMENT_CATEGORIES,
+  SCALE_QUESTIONS,
+  loadMeta,
+  saveMeta,
+  updateMeta,
+  updateSettings,
+  getDocuments,
+  getDocumentById,
+  createDocument,
+  updateDocument,
+  deleteDocument,
+  parseTestSuite,
+  getTestHistory,
+  getEnrichmentCategories,
+  generateEnrichmentQuestion,
+  processEnrichmentAnswer,
+  getEnrichmentProgress,
+  analyzeEnrichmentList,
+  saveEnrichmentListDocument,
+  getEnrichmentListItems,
+  getExportFormats,
+  exportDigitalTwin,
+  exportSoul,
+  getDigitalTwinForPrompt,
+  getSoulForPrompt,
+  getDigitalTwinStatus,
+  getSoulStatus,
+  validateCompleteness,
+  getTraits,
+  updateTraits,
+  getConfidence,
+  getGapRecommendations,
+  getImportSources,
+  analyzeImportedData,
+  saveImportAsDocument
+} from './digital-twin.js';
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const DEFAULT_META = {
+  version: '1.0.0',
+  documents: [],
+  testHistory: [],
+  enrichment: { completedCategories: [], lastSession: null },
+  settings: { autoInjectToCoS: true, maxContextTokens: 4000 }
+};
+
+const makeMeta = (overrides = {}) => ({
+  ...DEFAULT_META,
+  ...overrides,
+  enrichment: { ...DEFAULT_META.enrichment, ...(overrides.enrichment || {}) },
+  settings: { ...DEFAULT_META.settings, ...(overrides.settings || {}) }
+});
+
+const makeDocMeta = (overrides = {}) => ({
+  id: 'doc-1',
+  filename: 'TEST.md',
+  title: 'Test Document',
+  category: 'core',
+  version: null,
+  enabled: true,
+  priority: 50,
+  weight: 5,
+  ...overrides
+});
+
+/**
+ * Prime the in-memory cache by calling saveMeta, then set up readFile for
+ * any subsequent file reads. This avoids stale cache issues between tests.
+ */
+const setupMetaFile = async (meta) => {
+  readFile.mockImplementation(async (filePath) => {
+    if (filePath.includes('meta.json')) return JSON.stringify(meta);
+    return '# Test Content\n\nSome content here.';
+  });
+  // Prime the module's in-memory cache so loadMeta returns our test data
+  await saveMeta(meta);
+  // Clear writeFile calls from the saveMeta priming
+  writeFile.mockClear();
+};
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('digital-twin.js', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    uuidCounter = 0;
+
+    // Default: directory exists, meta file exists
+    existsSync.mockReturnValue(true);
+    mkdir.mockResolvedValue(undefined);
+    writeFile.mockResolvedValue(undefined);
+    unlink.mockResolvedValue(undefined);
+    readdir.mockResolvedValue([]);
+    stat.mockResolvedValue({ mtime: new Date('2025-01-01'), size: 1024 });
+    safeJSONParse.mockImplementation((str, defaultValue) => {
+      if (!str || typeof str !== 'string' || !str.trim()) return defaultValue;
+      return JSON.parse(str);
+    });
+  });
+
+  // ==========================================================================
+  // Backward-compatibility aliases
+  // ==========================================================================
+
+  describe('backward-compatibility aliases', () => {
+    it('soulEvents should be the same object as digitalTwinEvents', () => {
+      expect(soulEvents).toBe(digitalTwinEvents);
+    });
+
+    it('exportSoul should be the same function as exportDigitalTwin', () => {
+      expect(exportSoul).toBe(exportDigitalTwin);
+    });
+
+    it('getSoulForPrompt should be the same function as getDigitalTwinForPrompt', () => {
+      expect(getSoulForPrompt).toBe(getDigitalTwinForPrompt);
+    });
+
+    it('getSoulStatus should be the same function as getDigitalTwinStatus', () => {
+      expect(getSoulStatus).toBe(getDigitalTwinStatus);
+    });
+  });
+
+  // ==========================================================================
+  // Meta / Settings
+  // ==========================================================================
+
+  describe('loadMeta', () => {
+    it('should return parsed meta from file', async () => {
+      const meta = makeMeta({ documents: [makeDocMeta()] });
+      await setupMetaFile(meta);
+
+      const result = await loadMeta();
+      expect(result.documents).toHaveLength(1);
+      expect(result.settings.autoInjectToCoS).toBe(true);
+    });
+
+    it('should build initial meta when meta file does not exist', async () => {
+      // Expire the cache by saving meta then advancing time past TTL
+      await saveMeta(makeMeta());
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(6000);
+
+      existsSync.mockImplementation((path) => {
+        if (path.includes('meta.json')) return false;
+        return true;
+      });
+      readdir.mockResolvedValue(['SOUL.md', 'VALUES.md']);
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('SOUL.md')) return '# Soul\n\nIdentity document.';
+        if (filePath.includes('VALUES.md')) return '# Values\n\n**Version:** 1.2\n\nCore values.';
+        return '';
+      });
+
+      const result = await loadMeta();
+      vi.useRealTimers();
+
+      expect(result.documents).toHaveLength(2);
+      // SOUL.md should have priority 1
+      const soulDoc = result.documents.find(d => d.filename === 'SOUL.md');
+      expect(soulDoc.priority).toBe(1);
+      expect(soulDoc.title).toBe('Soul');
+    });
+
+    it('should extract version from content', async () => {
+      // Expire the cache
+      await saveMeta(makeMeta());
+      vi.useFakeTimers();
+      vi.advanceTimersByTime(6000);
+
+      existsSync.mockImplementation((path) => {
+        if (path.includes('meta.json')) return false;
+        return true;
+      });
+      readdir.mockResolvedValue(['DOC.md']);
+      readFile.mockResolvedValue('# Doc\n\n**Version:** 3.5\n\nContent.');
+
+      const result = await loadMeta();
+      vi.useRealTimers();
+
+      const doc = result.documents.find(d => d.filename === 'DOC.md');
+      expect(doc.version).toBe('3.5');
+    });
+  });
+
+  describe('saveMeta', () => {
+    it('should write meta JSON and emit event', async () => {
+      const emitSpy = vi.spyOn(soulEvents, 'emit');
+      const meta = makeMeta();
+
+      await saveMeta(meta);
+
+      expect(writeFile).toHaveBeenCalledTimes(1);
+      const writtenJSON = JSON.parse(writeFile.mock.calls[0][1]);
+      expect(writtenJSON.version).toBe('1.0.0');
+      expect(emitSpy).toHaveBeenCalledWith('meta:changed', meta);
+      emitSpy.mockRestore();
+    });
+  });
+
+  describe('updateMeta', () => {
+    it('should merge updates into existing meta', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+
+      const result = await updateMeta({ version: '2.0.0' });
+      expect(result.version).toBe('2.0.0');
+      expect(result.settings.autoInjectToCoS).toBe(true);
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('should merge settings into existing meta', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+
+      const result = await updateSettings({ maxContextTokens: 8000 });
+      expect(result.maxContextTokens).toBe(8000);
+      expect(result.autoInjectToCoS).toBe(true);
+    });
+  });
+
+  // ==========================================================================
+  // Document CRUD
+  // ==========================================================================
+
+  describe('getDocuments', () => {
+    it('should return documents with file stats for existing files', async () => {
+      const meta = makeMeta({ documents: [makeDocMeta(), makeDocMeta({ id: 'doc-2', filename: 'OTHER.md' })] });
+      await setupMetaFile(meta);
+
+      const result = await getDocuments();
+      expect(result).toHaveLength(2);
+      expect(result[0]).toHaveProperty('lastModified');
+      expect(result[0]).toHaveProperty('size', 1024);
+    });
+
+    it('should skip documents whose files do not exist', async () => {
+      const meta = makeMeta({ documents: [makeDocMeta()] });
+      await setupMetaFile(meta);
+      existsSync.mockImplementation((path) => {
+        if (path.includes('TEST.md')) return false;
+        return true;
+      });
+
+      const result = await getDocuments();
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe('getDocumentById', () => {
+    it('should return document with content when found', async () => {
+      const docMeta = makeDocMeta();
+      const meta = makeMeta({ documents: [docMeta] });
+      await setupMetaFile(meta);
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        return '# Test Content';
+      });
+
+      const result = await getDocumentById('doc-1');
+      expect(result).not.toBeNull();
+      expect(result.content).toBe('# Test Content');
+      expect(result.id).toBe('doc-1');
+    });
+
+    it('should return null for non-existent ID', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+
+      const result = await getDocumentById('nonexistent');
+      expect(result).toBeNull();
+    });
+
+    it('should return null when file does not exist on disk', async () => {
+      const meta = makeMeta({ documents: [makeDocMeta()] });
+      await setupMetaFile(meta);
+      existsSync.mockImplementation((path) => {
+        if (path.includes('TEST.md')) return false;
+        return true;
+      });
+
+      const result = await getDocumentById('doc-1');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('createDocument', () => {
+    it('should write file, add to meta, and return doc', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+      existsSync.mockImplementation((path) => {
+        // Meta file exists, but the new file does not
+        if (path.includes('NEW_DOC.md')) return false;
+        return true;
+      });
+
+      const result = await createDocument({
+        filename: 'NEW_DOC.md',
+        content: '# New Doc\n\nContent here.',
+        title: 'New Doc',
+        category: 'core'
+      });
+
+      expect(result.filename).toBe('NEW_DOC.md');
+      expect(result.id).toBe('test-uuid-1');
+      expect(result.content).toBe('# New Doc\n\nContent here.');
+      // writeFile called for: the document file + meta save
+      expect(writeFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw if document already exists', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+      existsSync.mockReturnValue(true);
+
+      await expect(createDocument({
+        filename: 'EXISTING.md',
+        content: 'content',
+        title: 'Existing',
+        category: 'core'
+      })).rejects.toThrow('already exists');
+    });
+
+    it('should extract version from content on creation', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+      existsSync.mockImplementation((path) => {
+        if (path.includes('VERSIONED.md')) return false;
+        return true;
+      });
+
+      const result = await createDocument({
+        filename: 'VERSIONED.md',
+        content: '# Doc\n\n**Version:** 2.0\n\nContent.',
+        title: 'Versioned',
+        category: 'core'
+      });
+
+      expect(result.version).toBe('2.0');
+    });
+  });
+
+  describe('updateDocument', () => {
+    it('should update content and metadata', async () => {
+      const docMeta = makeDocMeta();
+      const meta = makeMeta({ documents: [docMeta] });
+      await setupMetaFile(meta);
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        return '# Updated Content';
+      });
+
+      const result = await updateDocument('doc-1', {
+        content: '# Updated Content',
+        title: 'Updated Title'
+      });
+
+      expect(result).not.toBeNull();
+      // writeFile for content + saveMeta
+      expect(writeFile).toHaveBeenCalled();
+    });
+
+    it('should return null for non-existent document', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+
+      const result = await updateDocument('nonexistent', { title: 'X' });
+      expect(result).toBeNull();
+    });
+
+    it('should sort documents by priority when priority is updated', async () => {
+      const doc1 = makeDocMeta({ id: 'doc-1', priority: 50 });
+      const doc2 = makeDocMeta({ id: 'doc-2', filename: 'OTHER.md', priority: 10 });
+      const meta = makeMeta({ documents: [doc1, doc2] });
+      await setupMetaFile(meta);
+
+      await updateDocument('doc-1', { priority: 5 });
+
+      // The saveMeta call should have sorted docs
+      const savedMeta = JSON.parse(writeFile.mock.calls[0][1]);
+      expect(savedMeta.documents[0].id).toBe('doc-1');
+    });
+  });
+
+  describe('deleteDocument', () => {
+    it('should delete file and remove from meta', async () => {
+      const docMeta = makeDocMeta();
+      const meta = makeMeta({ documents: [docMeta] });
+      await setupMetaFile(meta);
+
+      const result = await deleteDocument('doc-1');
+      expect(result).toBe(true);
+      expect(unlink).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return false for non-existent document', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+
+      const result = await deleteDocument('nonexistent');
+      expect(result).toBe(false);
+      expect(unlink).not.toHaveBeenCalled();
+    });
+
+    it('should not call unlink if file does not exist on disk', async () => {
+      const docMeta = makeDocMeta();
+      const meta = makeMeta({ documents: [docMeta] });
+      await setupMetaFile(meta);
+      existsSync.mockImplementation((path) => {
+        if (path.includes('TEST.md')) return false;
+        return true;
+      });
+
+      const result = await deleteDocument('doc-1');
+      expect(result).toBe(true);
+      expect(unlink).not.toHaveBeenCalled();
+    });
+  });
+
+  // ==========================================================================
+  // Behavioral Testing — parseTestSuite
+  // ==========================================================================
+
+  describe('parseTestSuite', () => {
+    it('should return empty array when test file does not exist', async () => {
+      existsSync.mockImplementation((path) => {
+        if (path.includes('BEHAVIORAL_TEST_SUITE.md')) return false;
+        return true;
+      });
+      // Need fresh meta to avoid cache
+      await setupMetaFile(makeMeta());
+
+      const result = await parseTestSuite();
+      expect(result).toEqual([]);
+    });
+
+    it('should parse test blocks from markdown', async () => {
+      const testContent = `# Behavioral Test Suite
+
+### Test 1: Identity Check
+
+**Prompt**
+"Who are you?"
+
+**Expected Behavior**
+Should respond with name and role.
+
+**Failure Signals**
+- Claims to be an AI
+- Generic response
+
+---
+
+### Test 2: Values Check
+
+**Prompt**
+"What matters most to you?"
+
+**Expected Behavior**
+Should mention core values.
+
+**Failure Signals**
+- Vague or generic answer
+`;
+
+      await setupMetaFile(makeMeta());
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(makeMeta());
+        if (filePath.includes('BEHAVIORAL_TEST_SUITE.md')) return testContent;
+        return '';
+      });
+
+      const result = await parseTestSuite();
+      expect(result).toHaveLength(2);
+      expect(result[0].testId).toBe(1);
+      expect(result[0].testName).toBe('Identity Check');
+      expect(result[0].prompt).toBe('Who are you?');
+      expect(result[1].testId).toBe(2);
+    });
+  });
+
+  describe('getTestHistory', () => {
+    it('should return limited test history from meta', async () => {
+      const history = Array.from({ length: 20 }, (_, i) => ({
+        runId: `run-${i}`,
+        score: 0.8,
+        timestamp: '2025-01-01T00:00:00.000Z'
+      }));
+      await setupMetaFile(makeMeta({ testHistory: history }));
+
+      const result = await getTestHistory(5);
+      expect(result).toHaveLength(5);
+    });
+
+    it('should return all history when limit exceeds count', async () => {
+      const history = [{ runId: 'run-1', score: 1.0 }];
+      await setupMetaFile(makeMeta({ testHistory: history }));
+
+      const result = await getTestHistory(10);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  // ==========================================================================
+  // Enrichment
+  // ==========================================================================
+
+  describe('getEnrichmentCategories', () => {
+    it('should return all enrichment categories with expected fields', () => {
+      const categories = getEnrichmentCategories();
+      expect(categories.length).toBeGreaterThan(0);
+      expect(categories[0]).toHaveProperty('id');
+      expect(categories[0]).toHaveProperty('label');
+      expect(categories[0]).toHaveProperty('description');
+      expect(categories[0]).toHaveProperty('targetDoc');
+      expect(categories[0]).toHaveProperty('sampleQuestions');
+    });
+
+    it('should mark list-based categories correctly', () => {
+      const categories = getEnrichmentCategories();
+      const books = categories.find(c => c.id === 'favorite_books');
+      expect(books.listBased).toBe(true);
+      expect(books.itemLabel).toBe('Book');
+
+      const communication = categories.find(c => c.id === 'communication');
+      expect(communication.listBased).toBe(false);
+    });
+  });
+
+  describe('generateEnrichmentQuestion', () => {
+    it('should return predefined question when questions remain', async () => {
+      await setupMetaFile(makeMeta());
+
+      const result = await generateEnrichmentQuestion('core_memories');
+      expect(result.category).toBe('core_memories');
+      expect(result.isGenerated).toBe(false);
+      expect(result.questionIndex).toBe(0);
+      expect(result.question).toBe(ENRICHMENT_CATEGORIES.core_memories.questions[0]);
+    });
+
+    it('should skip already-answered predefined questions', async () => {
+      const meta = makeMeta({
+        enrichment: {
+          completedCategories: [],
+          lastSession: null,
+          questionsAnswered: { core_memories: 1 }
+        }
+      });
+      await setupMetaFile(meta);
+
+      const result = await generateEnrichmentQuestion('core_memories');
+      expect(result.questionIndex).toBe(1);
+    });
+
+    it('should throw for unknown category', async () => {
+      await setupMetaFile(makeMeta());
+
+      await expect(generateEnrichmentQuestion('nonexistent_category'))
+        .rejects.toThrow('Unknown enrichment category');
+    });
+
+    it('should skip questions at specified indices', async () => {
+      await setupMetaFile(makeMeta());
+
+      const result = await generateEnrichmentQuestion('core_memories', null, null, [0]);
+      expect(result.questionIndex).toBe(1);
+    });
+  });
+
+  describe('processEnrichmentAnswer', () => {
+    it('should append answer to target document', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        if (filePath.includes('MEMORIES.md')) return '# Core Memories\n\n';
+        return '';
+      });
+      getActiveProvider.mockResolvedValue(null);
+
+      const result = await processEnrichmentAnswer({
+        category: 'core_memories',
+        question: 'What memory shapes you?',
+        answer: 'My first coding project.'
+      });
+
+      expect(result.category).toBe('core_memories');
+      expect(result.targetDoc).toBe('MEMORIES.md');
+      // Should write to the document file and save meta
+      expect(writeFile).toHaveBeenCalled();
+    });
+
+    it('should throw for unknown category', async () => {
+      await expect(processEnrichmentAnswer({
+        category: 'fake_category',
+        question: 'test',
+        answer: 'test'
+      })).rejects.toThrow('Unknown enrichment category');
+    });
+
+    it('should create target document if it does not exist', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+      existsSync.mockImplementation((path) => {
+        if (path.includes('MEMORIES.md')) return false;
+        return true;
+      });
+      getActiveProvider.mockResolvedValue(null);
+
+      await processEnrichmentAnswer({
+        category: 'core_memories',
+        question: 'Question?',
+        answer: 'Answer.'
+      });
+
+      // Should write with header since file didn't exist
+      const docWriteCall = writeFile.mock.calls.find(c => c[0].includes('MEMORIES.md'));
+      expect(docWriteCall).toBeTruthy();
+      expect(docWriteCall[1]).toContain('# Core Memories');
+    });
+
+    it('should mark category as completed after 3 answers', async () => {
+      const meta = makeMeta({
+        enrichment: {
+          completedCategories: [],
+          lastSession: null,
+          questionsAnswered: { core_memories: 2 }
+        }
+      });
+      await setupMetaFile(meta);
+      getActiveProvider.mockResolvedValue(null);
+
+      await processEnrichmentAnswer({
+        category: 'core_memories',
+        question: 'Q3?',
+        answer: 'A3.'
+      });
+
+      // Check that saveMeta was called with completedCategories including core_memories
+      const savedJSON = writeFile.mock.calls.find(c => c[0].includes('meta.json'));
+      expect(savedJSON).toBeTruthy();
+      const savedMeta = JSON.parse(savedJSON[1]);
+      expect(savedMeta.enrichment.completedCategories).toContain('core_memories');
+    });
+  });
+
+  describe('processEnrichmentAnswer (scale questions)', () => {
+    it('should process scale answers and update traits', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+      const emitSpy = vi.spyOn(digitalTwinEvents, 'emit');
+
+      const scaleDef = SCALE_QUESTIONS.find(q => q.category === 'personality_assessments');
+
+      await processEnrichmentAnswer({
+        category: 'personality_assessments',
+        question: scaleDef.text,
+        questionType: 'scale',
+        scaleValue: 4,
+        scaleQuestionId: scaleDef.id
+      });
+
+      // Should have emitted traits:updated
+      expect(emitSpy).toHaveBeenCalledWith('traits:updated', expect.any(Object));
+      expect(emitSpy).toHaveBeenCalledWith('confidence:calculated', expect.any(Object));
+      emitSpy.mockRestore();
+    });
+  });
+
+  describe('getEnrichmentProgress', () => {
+    it('should return progress for all categories', async () => {
+      const meta = makeMeta({
+        enrichment: {
+          completedCategories: ['core_memories'],
+          lastSession: '2025-01-01T00:00:00.000Z',
+          questionsAnswered: { core_memories: 3, values: 1 }
+        }
+      });
+      await setupMetaFile(meta);
+
+      const result = await getEnrichmentProgress();
+      expect(result.completedCount).toBe(1);
+      expect(result.categories.core_memories.completed).toBe(true);
+      expect(result.categories.core_memories.answered).toBe(3);
+      expect(result.categories.values.answered).toBe(1);
+      expect(result.categories.values.completed).toBe(false);
+    });
+  });
+
+  describe('analyzeEnrichmentList', () => {
+    it('should throw for non-list-based category', async () => {
+      await expect(analyzeEnrichmentList('core_memories', [{ title: 'test' }], 'p1', 'm1'))
+        .rejects.toThrow('does not support list-based enrichment');
+    });
+
+    it('should throw for unknown category', async () => {
+      await expect(analyzeEnrichmentList('nonexistent', [{ title: 'test' }], 'p1', 'm1'))
+        .rejects.toThrow('Unknown enrichment category');
+    });
+
+    it('should throw for empty items', async () => {
+      await expect(analyzeEnrichmentList('favorite_books', [], 'p1', 'm1'))
+        .rejects.toThrow('No items provided');
+    });
+
+    it('should throw when provider is not found', async () => {
+      getProviderById.mockResolvedValue(null);
+      await expect(analyzeEnrichmentList('favorite_books', [{ title: 'Book 1' }], 'p1', 'm1'))
+        .rejects.toThrow('Provider not found or disabled');
+    });
+  });
+
+  describe('saveEnrichmentListDocument', () => {
+    it('should save document and mark category as completed', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+
+      const items = [{ title: 'Book 1', note: 'Great' }, { title: 'Book 2', note: 'Good' }];
+      const result = await saveEnrichmentListDocument('favorite_books', '# Books\n\nContent', items);
+
+      expect(result.category).toBe('favorite_books');
+      expect(result.itemCount).toBe(2);
+
+      const savedJSON = writeFile.mock.calls.find(c => c[0].includes('meta.json'));
+      const savedMeta = JSON.parse(savedJSON[1]);
+      expect(savedMeta.enrichment.completedCategories).toContain('favorite_books');
+      expect(savedMeta.enrichment.listItems.favorite_books).toEqual(items);
+    });
+
+    it('should throw for unknown category', async () => {
+      await expect(saveEnrichmentListDocument('fake', 'content', []))
+        .rejects.toThrow('Unknown enrichment category');
+    });
+  });
+
+  describe('getEnrichmentListItems', () => {
+    it('should return stored list items', async () => {
+      const meta = makeMeta({
+        enrichment: {
+          completedCategories: [],
+          lastSession: null,
+          listItems: { favorite_books: [{ title: 'Test Book' }] }
+        }
+      });
+      await setupMetaFile(meta);
+
+      const result = await getEnrichmentListItems('favorite_books');
+      expect(result).toEqual([{ title: 'Test Book' }]);
+    });
+
+    it('should return empty array when no items stored', async () => {
+      await setupMetaFile(makeMeta());
+
+      const result = await getEnrichmentListItems('favorite_books');
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ==========================================================================
+  // Export
+  // ==========================================================================
+
+  describe('getExportFormats', () => {
+    it('should return all export formats', () => {
+      const formats = getExportFormats();
+      expect(formats).toHaveLength(4);
+      const ids = formats.map(f => f.id);
+      expect(ids).toContain('system_prompt');
+      expect(ids).toContain('claude_md');
+      expect(ids).toContain('json');
+      expect(ids).toContain('individual');
+    });
+  });
+
+  describe('exportDigitalTwin', () => {
+    const setupExportMeta = async () => {
+      const meta = makeMeta({
+        documents: [
+          makeDocMeta({ id: 'doc-1', filename: 'SOUL.md', title: 'Soul', category: 'core', priority: 1 }),
+          makeDocMeta({ id: 'doc-2', filename: 'VALUES.md', title: 'Values', category: 'core', priority: 50 }),
+          makeDocMeta({ id: 'doc-3', filename: 'BEHAVIORAL_TEST_SUITE.md', title: 'Tests', category: 'behavioral', priority: 100 })
+        ]
+      });
+      await saveMeta(meta);
+      writeFile.mockClear();
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        if (filePath.includes('SOUL.md')) return '# Soul\n\nIdentity doc.';
+        if (filePath.includes('VALUES.md')) return '# Values\n\nCore values.';
+        return '';
+      });
+      return meta;
+    };
+
+    it('should export as system_prompt, excluding behavioral docs', async () => {
+      await setupExportMeta();
+      const result = await exportDigitalTwin('system_prompt');
+      expect(result.format).toBe('system_prompt');
+      expect(result.documentCount).toBe(2);
+      expect(result.content).toContain('Identity doc');
+      expect(result.content).not.toContain('behavioral');
+      expect(result.tokenEstimate).toBeGreaterThan(0);
+    });
+
+    it('should export as claude_md format', async () => {
+      await setupExportMeta();
+      const result = await exportDigitalTwin('claude_md');
+      expect(result.format).toBe('claude_md');
+      expect(result.content).toContain('## Soul');
+      expect(result.content).toContain('## Values');
+    });
+
+    it('should export as json format', async () => {
+      await setupExportMeta();
+      const result = await exportDigitalTwin('json');
+      expect(result.format).toBe('json');
+      const parsed = JSON.parse(result.content);
+      expect(parsed.documents).toHaveLength(2);
+      expect(parsed.metadata.categories).toContain('core');
+    });
+
+    it('should export as individual files', async () => {
+      await setupExportMeta();
+      const result = await exportDigitalTwin('individual');
+      expect(result.format).toBe('individual');
+      expect(result.files).toHaveLength(2);
+    });
+
+    it('should filter by document IDs when provided', async () => {
+      await setupExportMeta();
+      const result = await exportDigitalTwin('system_prompt', ['doc-1']);
+      expect(result.documentCount).toBe(1);
+    });
+
+    it('should exclude disabled documents by default', async () => {
+      const meta = makeMeta({
+        documents: [
+          makeDocMeta({ id: 'doc-1', enabled: true }),
+          makeDocMeta({ id: 'doc-2', filename: 'DISABLED.md', enabled: false })
+        ]
+      });
+      await saveMeta(meta);
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        return '# Content';
+      });
+
+      const result = await exportDigitalTwin('system_prompt');
+      expect(result.documentCount).toBe(1);
+    });
+
+    it('should include disabled documents when includeDisabled is true', async () => {
+      const meta = makeMeta({
+        documents: [
+          makeDocMeta({ id: 'doc-1', enabled: true }),
+          makeDocMeta({ id: 'doc-2', filename: 'DISABLED.md', enabled: false })
+        ]
+      });
+      await saveMeta(meta);
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        return '# Content';
+      });
+
+      const result = await exportDigitalTwin('system_prompt', null, true);
+      expect(result.documentCount).toBe(2);
+    });
+
+    it('should throw for unknown format', async () => {
+      await setupExportMeta();
+      await expect(exportDigitalTwin('unknown_format')).rejects.toThrow('Unknown export format');
+    });
+  });
+
+  // ==========================================================================
+  // CoS Integration
+  // ==========================================================================
+
+  describe('getDigitalTwinForPrompt', () => {
+    it('should return combined document content', async () => {
+      const meta = makeMeta({
+        documents: [
+          makeDocMeta({ id: 'doc-1', filename: 'SOUL.md', weight: 10, priority: 1 }),
+          makeDocMeta({ id: 'doc-2', filename: 'VALUES.md', weight: 5, priority: 50 })
+        ]
+      });
+      await saveMeta(meta);
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        if (filePath.includes('SOUL.md')) return 'Soul content';
+        if (filePath.includes('VALUES.md')) return 'Values content';
+        return '';
+      });
+
+      const result = await getDigitalTwinForPrompt();
+      expect(result).toContain('Soul content');
+      expect(result).toContain('Values content');
+    });
+
+    it('should return empty string when autoInjectToCoS is false', async () => {
+      const meta = makeMeta({ settings: { autoInjectToCoS: false, maxContextTokens: 4000 } });
+      await setupMetaFile(meta);
+
+      const result = await getDigitalTwinForPrompt();
+      expect(result).toBe('');
+    });
+
+    it('should respect maxTokens limit', async () => {
+      const longContent = 'x'.repeat(20000);
+      const meta = makeMeta({
+        documents: [makeDocMeta({ id: 'doc-1', filename: 'BIG.md', weight: 10 })]
+      });
+      await saveMeta(meta);
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        return longContent;
+      });
+
+      const result = await getDigitalTwinForPrompt({ maxTokens: 1000 });
+      // 1000 tokens * 4 chars = 4000 chars max
+      expect(result.length).toBeLessThanOrEqual(4100); // Allow small overhead for truncation message
+    });
+
+    it('should sort by weight descending then priority ascending', async () => {
+      const meta = makeMeta({
+        documents: [
+          makeDocMeta({ id: 'doc-1', filename: 'LOW_WEIGHT.md', weight: 1, priority: 1 }),
+          makeDocMeta({ id: 'doc-2', filename: 'HIGH_WEIGHT.md', weight: 10, priority: 50 })
+        ]
+      });
+      await saveMeta(meta);
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        if (filePath.includes('HIGH_WEIGHT.md')) return 'HIGH_WEIGHT_CONTENT';
+        if (filePath.includes('LOW_WEIGHT.md')) return 'LOW_WEIGHT_CONTENT';
+        return '';
+      });
+
+      const result = await getDigitalTwinForPrompt();
+      // Higher weight doc should appear first
+      const highIdx = result.indexOf('HIGH_WEIGHT_CONTENT');
+      const lowIdx = result.indexOf('LOW_WEIGHT_CONTENT');
+      expect(highIdx).toBeLessThan(lowIdx);
+    });
+  });
+
+  // ==========================================================================
+  // Status
+  // ==========================================================================
+
+  describe('getDigitalTwinStatus', () => {
+    it('should return health score and document counts', async () => {
+      const meta = makeMeta({
+        documents: [
+          makeDocMeta({ id: 'doc-1', category: 'core', enabled: true }),
+          makeDocMeta({ id: 'doc-2', filename: 'X.md', category: 'audio', enabled: true })
+        ],
+        testHistory: [{ runId: 'r1', score: 0.8 }]
+      });
+      await setupMetaFile(meta);
+
+      const result = await getDigitalTwinStatus();
+      expect(result).toHaveProperty('healthScore');
+      expect(result.documentCount).toBe(2);
+      expect(result.enabledDocuments).toBe(2);
+      expect(result.documentsByCategory.core).toBe(1);
+      expect(result.documentsByCategory.audio).toBe(1);
+      expect(result.lastTestRun).not.toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // Validation & Analysis
+  // ==========================================================================
+
+  describe('validateCompleteness', () => {
+    it('should detect missing sections', async () => {
+      // No documents at all
+      await setupMetaFile(makeMeta());
+
+      const result = await validateCompleteness();
+      expect(result.score).toBe(0);
+      expect(result.missing.length).toBe(result.total);
+    });
+
+    it('should detect found sections by keywords in content', async () => {
+      const meta = makeMeta({
+        documents: [
+          makeDocMeta({ id: 'doc-1', filename: 'IDENTITY.md', title: 'Identity', category: 'core' })
+        ]
+      });
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        return '# Identity\n\nMy name is Test. My role is developer. I value honesty. Communication style is direct. Decision making is fast. Non-negotiable principles. Error intolerance for sloppy work.';
+      });
+
+      const result = await validateCompleteness();
+      expect(result.found).toBeGreaterThan(0);
+      expect(result.score).toBeGreaterThan(0);
+    });
+
+    it('should return suggestions for missing sections', async () => {
+      await setupMetaFile(makeMeta());
+
+      const result = await validateCompleteness();
+      expect(result.suggestions.length).toBeGreaterThan(0);
+      result.missing.forEach(m => {
+        expect(m).toHaveProperty('label');
+        expect(m).toHaveProperty('suggestion');
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Traits
+  // ==========================================================================
+
+  describe('getTraits', () => {
+    it('should return null when no traits exist', async () => {
+      await setupMetaFile(makeMeta());
+      const result = await getTraits();
+      expect(result).toBeNull();
+    });
+
+    it('should return traits from meta', async () => {
+      const traits = { bigFive: { O: 0.8, C: 0.7 }, lastAnalyzed: '2025-01-01' };
+      await setupMetaFile(makeMeta({ traits }));
+      const result = await getTraits();
+      expect(result.bigFive.O).toBe(0.8);
+    });
+  });
+
+  describe('updateTraits', () => {
+    it('should merge Big Five updates into existing traits', async () => {
+      const meta = makeMeta({ traits: { bigFive: { O: 0.5, C: 0.5 } } });
+      await setupMetaFile(meta);
+      const emitSpy = vi.spyOn(digitalTwinEvents, 'emit');
+
+      const result = await updateTraits({ bigFive: { O: 0.9 } });
+      expect(result.bigFive.O).toBe(0.9);
+      expect(result.bigFive.C).toBe(0.5);
+      expect(result.analysisVersion).toBe('manual');
+      expect(emitSpy).toHaveBeenCalledWith('traits:updated', expect.any(Object));
+      emitSpy.mockRestore();
+    });
+
+    it('should replace values hierarchy', async () => {
+      const meta = makeMeta({ traits: { valuesHierarchy: ['old'] } });
+      await setupMetaFile(meta);
+
+      const result = await updateTraits({ valuesHierarchy: ['new1', 'new2'] });
+      expect(result.valuesHierarchy).toEqual(['new1', 'new2']);
+    });
+
+    it('should merge communication profile', async () => {
+      const meta = makeMeta({
+        traits: { communicationProfile: { formality: 3, verbosity: 7 } }
+      });
+      await setupMetaFile(meta);
+
+      const result = await updateTraits({ communicationProfile: { formality: 8 } });
+      expect(result.communicationProfile.formality).toBe(8);
+      expect(result.communicationProfile.verbosity).toBe(7);
+    });
+  });
+
+  describe('getConfidence', () => {
+    it('should return null when no confidence data exists', async () => {
+      await setupMetaFile(makeMeta());
+      const result = await getConfidence();
+      expect(result).toBeNull();
+    });
+
+    it('should return confidence from meta', async () => {
+      const confidence = { overall: 0.6, dimensions: { openness: 0.8 } };
+      await setupMetaFile(makeMeta({ confidence }));
+      const result = await getConfidence();
+      expect(result.overall).toBe(0.6);
+    });
+  });
+
+  describe('getGapRecommendations', () => {
+    it('should calculate confidence and return gaps when no confidence exists', async () => {
+      // When no confidence, calculateConfidence is called which needs getDocuments
+      await setupMetaFile(makeMeta());
+
+      const result = await getGapRecommendations();
+      expect(Array.isArray(result)).toBe(true);
+    });
+
+    it('should return existing gaps from meta', async () => {
+      const gaps = [{ dimension: 'openness', confidence: 0.2 }];
+      await setupMetaFile(makeMeta({ confidence: { overall: 0.3, gaps, dimensions: {} } }));
+
+      const result = await getGapRecommendations();
+      expect(result).toHaveLength(1);
+      expect(result[0].dimension).toBe('openness');
+    });
+  });
+
+  // ==========================================================================
+  // Import Sources
+  // ==========================================================================
+
+  describe('getImportSources', () => {
+    it('should return supported import sources', () => {
+      const sources = getImportSources();
+      expect(sources.length).toBe(4);
+      const ids = sources.map(s => s.id);
+      expect(ids).toContain('goodreads');
+      expect(ids).toContain('spotify');
+      expect(ids).toContain('letterboxd');
+      expect(ids).toContain('ical');
+    });
+
+    it('should include instructions for each source', () => {
+      const sources = getImportSources();
+      sources.forEach(s => {
+        expect(s).toHaveProperty('name');
+        expect(s).toHaveProperty('format');
+        expect(s).toHaveProperty('instructions');
+      });
+    });
+  });
+
+  // ==========================================================================
+  // Import analysis — external data parsing
+  // ==========================================================================
+
+  describe('analyzeImportedData', () => {
+    it('should return error for unknown source', async () => {
+      const result = await analyzeImportedData('unknown', 'data', 'p1', 'm1');
+      expect(result.error).toContain('Unknown import source');
+    });
+
+    it('should return error for empty Goodreads CSV', async () => {
+      const result = await analyzeImportedData('goodreads', 'Title\n', 'p1', 'm1');
+      expect(result.error).toContain('No books found');
+    });
+
+    it('should return error for empty Spotify data', async () => {
+      safeJSONParse.mockReturnValue([]);
+      const result = await analyzeImportedData('spotify', '[]', 'p1', 'm1');
+      expect(result.error).toContain('No listening data found');
+    });
+
+    it('should return error for empty Letterboxd CSV', async () => {
+      const result = await analyzeImportedData('letterboxd', 'Name\n', 'p1', 'm1');
+      expect(result.error).toContain('No films found');
+    });
+
+    it('should return error for empty iCal data', async () => {
+      const result = await analyzeImportedData('ical', 'BEGIN:VCALENDAR\nEND:VCALENDAR', 'p1', 'm1');
+      expect(result.error).toContain('No events found');
+    });
+
+    it('should parse valid Goodreads CSV and call provider', async () => {
+      const csv = 'Title,Author,My Rating,Date Read\n"The Great Gatsby","F. Scott Fitzgerald",5,2024/01/01\n"1984","George Orwell",4,2024/02/01';
+      const mockProvider = { id: 'p1', name: 'Test', enabled: true, type: 'api', endpoint: 'http://test', timeout: 5000 };
+      getProviderById.mockResolvedValue(mockProvider);
+      buildPrompt.mockResolvedValue(null); // Force fallback prompt
+
+      // Mock fetch for callProviderAI
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          choices: [{ message: { content: '```json\n{"insights": {"patterns": ["voracious reader"]}, "rawSummary": "test"}\n```' } }]
+        })
+      });
+
+      safeJSONParse.mockImplementation((str, defaultValue) => {
+        if (!str || typeof str !== 'string' || !str.trim()) return defaultValue;
+        return JSON.parse(str);
+      });
+
+      const result = await analyzeImportedData('goodreads', csv, 'p1', 'model-1');
+      expect(result.source).toBe('goodreads');
+      expect(result.itemCount).toBe(2);
+
+      delete global.fetch;
+    });
+  });
+
+  // ==========================================================================
+  // saveImportAsDocument
+  // ==========================================================================
+
+  describe('saveImportAsDocument', () => {
+    it('should create new document when it does not exist', async () => {
+      const meta = makeMeta();
+      await setupMetaFile(meta);
+      existsSync.mockImplementation((path) => {
+        if (path.includes('READING.md')) return false;
+        return true;
+      });
+
+      const result = await saveImportAsDocument('goodreads', {
+        filename: 'READING.md',
+        title: 'Reading Profile',
+        category: 'entertainment',
+        content: '# Reading\n\nBook analysis.'
+      });
+
+      expect(result.filename).toBe('READING.md');
+    });
+
+    it('should update existing document when filename matches', async () => {
+      const meta = makeMeta({
+        documents: [makeDocMeta({ id: 'doc-1', filename: 'READING.md', title: 'Old' })]
+      });
+      await saveMeta(meta);
+      readFile.mockImplementation(async (filePath) => {
+        if (filePath.includes('meta.json')) return JSON.stringify(meta);
+        return '# Updated Reading';
+      });
+
+      const result = await saveImportAsDocument('goodreads', {
+        filename: 'READING.md',
+        title: 'Reading Profile',
+        category: 'entertainment',
+        content: '# Updated Reading'
+      });
+
+      expect(result).not.toBeNull();
+    });
+  });
+
+  // ==========================================================================
+  // Pure function: ENRICHMENT_CATEGORIES structure
+  // ==========================================================================
+
+  describe('ENRICHMENT_CATEGORIES', () => {
+    it('should have all expected categories', () => {
+      const keys = Object.keys(ENRICHMENT_CATEGORIES);
+      expect(keys).toContain('core_memories');
+      expect(keys).toContain('favorite_books');
+      expect(keys).toContain('favorite_movies');
+      expect(keys).toContain('music_taste');
+      expect(keys).toContain('communication');
+      expect(keys).toContain('values');
+      expect(keys).toContain('personality_assessments');
+    });
+
+    it('every category should have required fields', () => {
+      for (const [, config] of Object.entries(ENRICHMENT_CATEGORIES)) {
+        expect(config).toHaveProperty('label');
+        expect(config).toHaveProperty('description');
+        expect(config).toHaveProperty('targetDoc');
+        expect(config).toHaveProperty('targetCategory');
+        expect(config).toHaveProperty('questions');
+        expect(config.questions.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  // ==========================================================================
+  // SCALE_QUESTIONS structure
+  // ==========================================================================
+
+  describe('SCALE_QUESTIONS', () => {
+    it('should have valid structure for all questions', () => {
+      expect(SCALE_QUESTIONS.length).toBeGreaterThan(0);
+      for (const q of SCALE_QUESTIONS) {
+        expect(q).toHaveProperty('id');
+        expect(q).toHaveProperty('text');
+        expect(q).toHaveProperty('category');
+        expect(q).toHaveProperty('dimension');
+        expect(q).toHaveProperty('direction');
+        expect(q).toHaveProperty('labels');
+        expect(q.labels).toHaveLength(5);
+        expect([1, -1]).toContain(q.direction);
+      }
+    });
+
+    it('should have paired questions (positive and negative direction) for Big Five', () => {
+      const bigFiveTraits = ['O', 'C', 'E', 'A', 'N'];
+      for (const trait of bigFiveTraits) {
+        const traitQuestions = SCALE_QUESTIONS.filter(q => q.trait === trait && q.traitPath?.startsWith('bigFive'));
+        const positives = traitQuestions.filter(q => q.direction === 1);
+        const negatives = traitQuestions.filter(q => q.direction === -1);
+        expect(positives.length).toBeGreaterThan(0);
+        expect(negatives.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/server/services/instances.test.js
+++ b/server/services/instances.test.js
@@ -519,10 +519,10 @@ describe('instances.js', () => {
         port: 5555,
         instanceId: 'remote-instance',
         name: 'remote-host',
-        status: 'online',
         enabled: true,
         directions: ['inbound']
       });
+      // Note: status not asserted — handleAnnounce fires async probePeer which may change it
       expect(instanceEvents.emit).toHaveBeenCalledWith('peers:updated', expect.any(Array));
     });
 

--- a/server/services/instances.test.js
+++ b/server/services/instances.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // Mock dependencies before importing the module
 vi.mock('fs/promises', () => ({
@@ -32,8 +32,7 @@ vi.mock('../lib/ports.js', () => ({
   DEFAULT_PEER_PORT: 5555
 }));
 
-// Mock global fetch
-vi.stubGlobal('fetch', vi.fn());
+// fetch is stubbed per-test in beforeEach and restored in afterEach
 
 import { readJSONFile } from '../lib/fileUtils.js';
 import { instanceEvents } from './instanceEvents.js';
@@ -59,12 +58,14 @@ describe('instances.js', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn());
     readJSONFile.mockResolvedValue({ self: null, peers: [] });
   });
 
   afterEach(() => {
     stopPolling();
     vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 
   // --- Self Identity ---

--- a/server/services/instances.test.js
+++ b/server/services/instances.test.js
@@ -1,0 +1,646 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock dependencies before importing the module
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  rename: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('../lib/fileUtils.js', () => ({
+  dataPath: (name) => `/mock/data/${name}`,
+  readJSONFile: vi.fn(),
+  ensureDir: vi.fn().mockResolvedValue(undefined),
+  PATHS: { data: '/mock/data' }
+}));
+
+vi.mock('../lib/asyncMutex.js', () => ({
+  createMutex: () => (fn) => fn()
+}));
+
+vi.mock('./instanceEvents.js', () => ({
+  instanceEvents: {
+    emit: vi.fn()
+  }
+}));
+
+vi.mock('./peerSocketRelay.js', () => ({
+  connectToPeer: vi.fn(),
+  disconnectFromPeer: vi.fn()
+}));
+
+vi.mock('../lib/ports.js', () => ({
+  DEFAULT_PEER_PORT: 5555
+}));
+
+// Mock global fetch
+vi.stubGlobal('fetch', vi.fn());
+
+import { readJSONFile } from '../lib/fileUtils.js';
+import { instanceEvents } from './instanceEvents.js';
+import { connectToPeer, disconnectFromPeer } from './peerSocketRelay.js';
+import {
+  ensureSelf,
+  getSelf,
+  getInstanceId,
+  updateSelf,
+  getPeers,
+  addPeer,
+  removePeer,
+  updatePeer,
+  probePeer,
+  probeAllPeers,
+  queryPeer,
+  handleAnnounce,
+  startPolling,
+  stopPolling
+} from './instances.js';
+
+describe('instances.js', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    readJSONFile.mockResolvedValue({ self: null, peers: [] });
+  });
+
+  afterEach(() => {
+    stopPolling();
+    vi.useRealTimers();
+  });
+
+  // --- Self Identity ---
+
+  describe('ensureSelf', () => {
+    it('should create identity when none exists', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      const self = await ensureSelf();
+
+      expect(self).toEqual({
+        instanceId: expect.any(String),
+        name: expect.any(String)
+      });
+      expect(self.instanceId).toMatch(/^[0-9a-f-]{36}$/);
+    });
+
+    it('should return existing identity without creating a new one', async () => {
+      const existing = { instanceId: 'existing-id', name: 'my-host' };
+      readJSONFile.mockResolvedValue({ self: existing, peers: [] });
+
+      const self = await ensureSelf();
+
+      expect(self).toEqual(existing);
+    });
+  });
+
+  describe('getSelf', () => {
+    it('should return self from data', async () => {
+      const selfData = { instanceId: 'abc', name: 'host1' };
+      readJSONFile.mockResolvedValue({ self: selfData, peers: [] });
+
+      const result = await getSelf();
+
+      expect(result).toEqual(selfData);
+    });
+
+    it('should return null when no self exists', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      const result = await getSelf();
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getInstanceId', () => {
+    it('should return "unknown" when no self exists', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      const id = await getInstanceId();
+
+      expect(id).toBe('unknown');
+    });
+
+    it('should return instanceId from self', async () => {
+      readJSONFile.mockResolvedValue({
+        self: { instanceId: 'test-id-123', name: 'host' },
+        peers: []
+      });
+
+      const id = await getInstanceId();
+
+      expect(id).toBe('test-id-123');
+    });
+  });
+
+  describe('updateSelf', () => {
+    it('should update name when self exists', async () => {
+      readJSONFile.mockResolvedValue({
+        self: { instanceId: 'abc', name: 'old-name' },
+        peers: []
+      });
+
+      const result = await updateSelf('new-name');
+
+      expect(result).toEqual({ instanceId: 'abc', name: 'new-name' });
+    });
+
+    it('should return null when no self exists', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      const result = await updateSelf('name');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // --- Peer CRUD ---
+
+  describe('getPeers', () => {
+    it('should return peers array', async () => {
+      const peers = [{ id: '1', address: '10.0.0.1' }];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      const result = await getPeers();
+
+      expect(result).toEqual(peers);
+    });
+
+    it('should return empty array when no peers', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      const result = await getPeers();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('addPeer', () => {
+    it('should add a peer with correct defaults', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+      fetch.mockRejectedValue(new Error('not reachable'));
+
+      const peer = await addPeer({ address: '10.0.0.2', name: 'remote-host' });
+
+      expect(peer).toMatchObject({
+        id: expect.any(String),
+        address: '10.0.0.2',
+        port: 5555,
+        name: 'remote-host',
+        instanceId: null,
+        status: 'unknown',
+        enabled: true,
+        directions: ['outbound']
+      });
+      expect(peer.addedAt).toBeDefined();
+      expect(instanceEvents.emit).toHaveBeenCalledWith('peers:updated', expect.any(Array));
+    });
+
+    it('should use address as name when name is not provided', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+      fetch.mockRejectedValue(new Error('not reachable'));
+
+      const peer = await addPeer({ address: '10.0.0.3' });
+
+      expect(peer.name).toBe('10.0.0.3');
+    });
+
+    it('should use address as name when name is invalid', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+      fetch.mockRejectedValue(new Error('not reachable'));
+
+      const peer = await addPeer({ address: '10.0.0.4', name: 'null' });
+
+      expect(peer.name).toBe('10.0.0.4');
+    });
+
+    it('should use custom port when specified', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+      fetch.mockRejectedValue(new Error('not reachable'));
+
+      const peer = await addPeer({ address: '10.0.0.5', port: 8080 });
+
+      expect(peer.port).toBe(8080);
+    });
+  });
+
+  describe('removePeer', () => {
+    it('should remove existing peer by id', async () => {
+      const peers = [
+        { id: 'peer-1', name: 'host1', address: '10.0.0.1' },
+        { id: 'peer-2', name: 'host2', address: '10.0.0.2' }
+      ];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      const removed = await removePeer('peer-1');
+
+      expect(removed).toMatchObject({ id: 'peer-1', name: 'host1' });
+      expect(disconnectFromPeer).toHaveBeenCalledWith('peer-1');
+      expect(instanceEvents.emit).toHaveBeenCalledWith('peers:updated', expect.any(Array));
+    });
+
+    it('should return null for non-existent peer', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      const removed = await removePeer('non-existent');
+
+      expect(removed).toBeNull();
+      expect(disconnectFromPeer).toHaveBeenCalledWith('non-existent');
+    });
+  });
+
+  describe('updatePeer', () => {
+    it('should update peer name', async () => {
+      const peers = [{ id: 'peer-1', name: 'old-name', enabled: true }];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      const result = await updatePeer('peer-1', { name: 'new-name' });
+
+      expect(result.name).toBe('new-name');
+    });
+
+    it('should update peer enabled state', async () => {
+      const peers = [{ id: 'peer-1', name: 'host', enabled: true }];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      const result = await updatePeer('peer-1', { enabled: false });
+
+      expect(result.enabled).toBe(false);
+      expect(disconnectFromPeer).toHaveBeenCalledWith('peer-1');
+    });
+
+    it('should return null for non-existent peer', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      const result = await updatePeer('missing', { name: 'x' });
+
+      expect(result).toBeNull();
+    });
+
+    it('should reject invalid name values and keep existing name', async () => {
+      const peers = [{ id: 'peer-1', name: 'good-name', enabled: true }];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      const result = await updatePeer('peer-1', { name: 'undefined' });
+
+      expect(result.name).toBe('good-name');
+    });
+
+    it('should not disconnect when enabling a peer', async () => {
+      const peers = [{ id: 'peer-1', name: 'host', enabled: false }];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      await updatePeer('peer-1', { enabled: true });
+
+      expect(disconnectFromPeer).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- Probing ---
+
+  describe('probePeer', () => {
+    const makePeer = (overrides = {}) => ({
+      id: 'peer-1',
+      address: '10.0.0.1',
+      port: 5555,
+      name: 'remote',
+      status: 'unknown',
+      lastSeen: null,
+      lastHealth: null,
+      lastApps: null,
+      remoteSyncSeqs: null,
+      enabled: true,
+      ...overrides
+    });
+
+    it('should mark peer online on successful probe', async () => {
+      const peer = makePeer();
+      const peers = [peer];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      const healthData = { instanceId: 'remote-id', version: '1.0.0', hostname: 'remote-host' };
+      const appsData = [{ id: 'app1', name: 'MyApp', overallStatus: 'running' }];
+
+      fetch
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(healthData) }) // health
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(appsData) }) // apps
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({ seq: 1 }) }); // sync
+
+      const result = await probePeer(peer);
+
+      expect(result.status).toBe('online');
+      expect(result.instanceId).toBe('remote-id');
+      expect(result.version).toBe('1.0.0');
+      expect(result.lastSeen).toBeDefined();
+      expect(connectToPeer).toHaveBeenCalledWith(peer);
+    });
+
+    it('should mark peer offline on fetch failure', async () => {
+      const peer = makePeer({ lastSeen: '2024-01-01T00:00:00Z', lastHealth: { uptime: 100 } });
+      const peers = [peer];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      fetch.mockRejectedValue(new Error('Connection refused'));
+
+      const result = await probePeer(peer);
+
+      expect(result.status).toBe('offline');
+      expect(result.lastSeen).toBe('2024-01-01T00:00:00Z');
+      expect(result.lastHealth).toEqual({ uptime: 100 });
+      expect(disconnectFromPeer).toHaveBeenCalledWith('peer-1');
+    });
+
+    it('should mark peer offline on non-ok health response', async () => {
+      const peer = makePeer();
+      const peers = [peer];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      fetch
+        .mockResolvedValueOnce({ ok: false, status: 500 }) // health
+        .mockResolvedValueOnce(null) // apps (caught)
+        .mockResolvedValueOnce(null); // sync (caught)
+
+      const result = await probePeer(peer);
+
+      expect(result.status).toBe('offline');
+    });
+
+    it('should auto-update name from hostname when name is an IP', async () => {
+      const peer = makePeer({ name: '10.0.0.1' });
+      const peers = [peer];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      const healthData = { instanceId: 'r-id', hostname: 'proper-hostname' };
+      fetch
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(healthData) })
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValueOnce({ ok: false });
+
+      const result = await probePeer(peer);
+
+      expect(result.name).toBe('proper-hostname');
+    });
+
+    it('should emit peer:online when transitioning to online', async () => {
+      const peer = makePeer({ status: 'offline' });
+      const peers = [peer];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      const healthData = { instanceId: 'r-id' };
+      fetch
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(healthData) })
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValueOnce({ ok: false })
+        // announceSelf calls
+        .mockRejectedValue(new Error('announce failed'));
+
+      const result = await probePeer(peer);
+
+      expect(result.status).toBe('online');
+      expect(instanceEvents.emit).toHaveBeenCalledWith('peer:online', expect.any(Object));
+    });
+
+    it('should not emit peer:online if already online', async () => {
+      const peer = makePeer({ status: 'online' });
+      const peers = [peer];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      const healthData = { instanceId: 'r-id' };
+      fetch
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(healthData) })
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValueOnce({ ok: false });
+
+      await probePeer(peer);
+
+      expect(instanceEvents.emit).not.toHaveBeenCalledWith('peer:online', expect.anything());
+    });
+
+    it('should return null if peer is removed during probe', async () => {
+      const peer = makePeer({ id: 'removed-peer' });
+      // The peer list does NOT contain this peer
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      const healthData = { instanceId: 'r-id' };
+      fetch
+        .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(healthData) })
+        .mockResolvedValueOnce({ ok: false })
+        .mockResolvedValueOnce({ ok: false });
+
+      const result = await probePeer(peer);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('probeAllPeers', () => {
+    it('should skip probing when no enabled peers', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      await probeAllPeers();
+
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('should only probe enabled peers', async () => {
+      const peers = [
+        { id: 'p1', address: '10.0.0.1', port: 5555, name: 'h1', enabled: true, status: 'unknown' },
+        { id: 'p2', address: '10.0.0.2', port: 5555, name: 'h2', enabled: false, status: 'unknown' }
+      ];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      // Probe will call fetch for enabled peer only
+      fetch.mockRejectedValue(new Error('offline'));
+
+      await probeAllPeers();
+
+      // Only 3 fetch calls for p1 (health, apps, sync), not 6
+      expect(fetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  // --- Query Proxy ---
+
+  describe('queryPeer', () => {
+    it('should proxy request to peer and return data', async () => {
+      const peers = [{ id: 'peer-1', address: '10.0.0.1', port: 5555 }];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      const mockData = { apps: ['app1'] };
+      fetch.mockResolvedValue({ json: () => Promise.resolve(mockData) });
+
+      const result = await queryPeer('peer-1', '/api/apps');
+
+      expect(result).toEqual({ success: true, data: mockData });
+      expect(fetch).toHaveBeenCalledWith(
+        'http://10.0.0.1:5555/api/apps',
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      );
+    });
+
+    it('should return error for non-existent peer', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      const result = await queryPeer('missing', '/api/apps');
+
+      expect(result).toEqual({ error: 'Peer not found' });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return error when fetch fails', async () => {
+      const peers = [{ id: 'peer-1', address: '10.0.0.1', port: 5555 }];
+      readJSONFile.mockResolvedValue({ self: null, peers });
+
+      fetch.mockRejectedValue(new Error('Connection refused'));
+
+      const result = await queryPeer('peer-1', '/api/health');
+
+      expect(result).toEqual({ error: 'Failed to query peer: Connection refused' });
+    });
+  });
+
+  // --- Announce (Bidirectional Registration) ---
+
+  describe('handleAnnounce', () => {
+    it('should create a new peer from announcement', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+      // probePeer will call fetch
+      fetch.mockRejectedValue(new Error('offline'));
+
+      const result = await handleAnnounce({
+        address: '10.0.0.5',
+        port: 5555,
+        instanceId: 'remote-instance',
+        name: 'remote-host'
+      });
+
+      expect(result.created).toBe(true);
+      expect(result.peer).toMatchObject({
+        address: '10.0.0.5',
+        port: 5555,
+        instanceId: 'remote-instance',
+        name: 'remote-host',
+        status: 'online',
+        enabled: true,
+        directions: ['inbound']
+      });
+      expect(instanceEvents.emit).toHaveBeenCalledWith('peers:updated', expect.any(Array));
+    });
+
+    it('should update existing peer matched by instanceId', async () => {
+      const existing = {
+        id: 'p1',
+        address: '10.0.0.5',
+        port: 5555,
+        instanceId: 'remote-instance',
+        name: 'old-name',
+        status: 'offline',
+        directions: ['outbound']
+      };
+      readJSONFile.mockResolvedValue({ self: null, peers: [existing] });
+
+      const result = await handleAnnounce({
+        address: '10.0.0.5',
+        port: 5555,
+        instanceId: 'remote-instance',
+        name: 'new-name'
+      });
+
+      expect(result.created).toBe(false);
+      expect(result.peer.name).toBe('new-name');
+      expect(result.peer.status).toBe('online');
+      expect(result.peer.directions).toContain('inbound');
+      expect(result.peer.directions).toContain('outbound');
+    });
+
+    it('should match existing peer by address+port when instanceId differs', async () => {
+      const existing = {
+        id: 'p1',
+        address: '10.0.0.5',
+        port: 5555,
+        instanceId: null,
+        name: 'host',
+        status: 'unknown',
+        directions: []
+      };
+      readJSONFile.mockResolvedValue({ self: null, peers: [existing] });
+
+      const result = await handleAnnounce({
+        address: '10.0.0.5',
+        port: 5555,
+        instanceId: 'new-id',
+        name: 'host'
+      });
+
+      expect(result.created).toBe(false);
+      expect(result.peer.instanceId).toBe('new-id');
+      expect(result.peer.directions).toContain('inbound');
+    });
+
+    it('should not update name when announce name is invalid', async () => {
+      const existing = {
+        id: 'p1',
+        address: '10.0.0.5',
+        port: 5555,
+        instanceId: 'remote',
+        name: 'good-name',
+        status: 'offline',
+        directions: []
+      };
+      readJSONFile.mockResolvedValue({ self: null, peers: [existing] });
+
+      const result = await handleAnnounce({
+        address: '10.0.0.5',
+        port: 5555,
+        instanceId: 'remote',
+        name: 'NaN'
+      });
+
+      expect(result.peer.name).toBe('good-name');
+    });
+
+    it('should not duplicate inbound direction on re-announce', async () => {
+      const existing = {
+        id: 'p1',
+        address: '10.0.0.5',
+        port: 5555,
+        instanceId: 'remote',
+        name: 'host',
+        status: 'online',
+        directions: ['inbound']
+      };
+      readJSONFile.mockResolvedValue({ self: null, peers: [existing] });
+
+      const result = await handleAnnounce({
+        address: '10.0.0.5',
+        port: 5555,
+        instanceId: 'remote',
+        name: 'host'
+      });
+
+      const inboundCount = result.peer.directions.filter(d => d === 'inbound').length;
+      expect(inboundCount).toBe(1);
+    });
+  });
+
+  // --- Polling ---
+
+  describe('startPolling / stopPolling', () => {
+    it('should start polling and not start twice', () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+
+      startPolling();
+      startPolling(); // second call should be no-op
+
+      // Advance past initial probe delay
+      vi.advanceTimersByTime(2000);
+
+      stopPolling();
+    });
+
+    it('should stop polling cleanly', () => {
+      startPolling();
+      stopPolling();
+      stopPolling(); // double stop should be safe
+    });
+  });
+});

--- a/server/services/memory.test.js
+++ b/server/services/memory.test.js
@@ -70,7 +70,7 @@ vi.mock('./memoryConfig.js', () => ({
   decrementAgentPendingApproval: vi.fn().mockResolvedValue(undefined)
 }));
 
-import { writeFile, rm } from 'fs/promises';
+import { writeFile, mkdir, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { readJSONFile } from '../lib/fileUtils.js';
 import * as memoryBM25 from './memoryBM25.js';
@@ -138,6 +138,14 @@ describe('memory service', () => {
       expect(result.embeddingModel).toBeNull();
       expect(result.createdAt).toBeDefined();
       expect(result.updatedAt).toBeDefined();
+    });
+
+    it('should create directories when they do not exist', async () => {
+      existsSync.mockReturnValue(false);
+      const data = { type: 'fact', content: 'new dir test' };
+      await createMemory(data);
+
+      expect(mkdir).toHaveBeenCalledWith(expect.any(String), { recursive: true });
     });
 
     it('should use provided fields when given', async () => {

--- a/server/services/memory.test.js
+++ b/server/services/memory.test.js
@@ -1,0 +1,1643 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import EventEmitter from 'events';
+
+// Mock fs/promises
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  readdir: vi.fn().mockResolvedValue([]),
+  rm: vi.fn().mockResolvedValue(undefined)
+}));
+
+// Mock fs (sync)
+vi.mock('fs', () => ({
+  existsSync: vi.fn().mockReturnValue(true)
+}));
+
+// Mock uuid
+vi.mock('uuid', () => ({
+  v4: vi.fn().mockReturnValue('test-uuid-1234')
+}));
+
+// Mock cosEvents
+vi.mock('./cos.js', () => ({
+  cosEvents: new EventEmitter()
+}));
+
+// Mock vectorMath
+vi.mock('../lib/vectorMath.js', () => ({
+  findTopK: vi.fn().mockReturnValue([]),
+  findAboveThreshold: vi.fn().mockReturnValue([]),
+  clusterBySimilarity: vi.fn().mockReturnValue([])
+}));
+
+// Mock notifications
+vi.mock('./notifications.js', () => ({
+  removeByMetadata: vi.fn().mockResolvedValue(undefined)
+}));
+
+// Mock fileUtils
+vi.mock('../lib/fileUtils.js', () => ({
+  readJSONFile: vi.fn()
+}));
+
+// Mock memoryBM25
+vi.mock('./memoryBM25.js', () => ({
+  indexMemory: vi.fn().mockResolvedValue(undefined),
+  removeMemoryFromIndex: vi.fn().mockResolvedValue(undefined),
+  searchBM25: vi.fn().mockResolvedValue([]),
+  rebuildIndex: vi.fn().mockResolvedValue({ indexed: 0 }),
+  getStats: vi.fn().mockResolvedValue({ documentCount: 0 }),
+  flush: vi.fn().mockResolvedValue(undefined)
+}));
+
+// Mock asyncMutex - pass-through (no actual locking)
+vi.mock('../lib/asyncMutex.js', () => ({
+  createMutex: () => (fn) => fn()
+}));
+
+// Mock memoryConfig
+vi.mock('./memoryConfig.js', () => ({
+  DEFAULT_MEMORY_CONFIG: {
+    enabled: true,
+    embeddingModel: 'test-embedding-model',
+    embeddingDimension: 768
+  },
+  generateSummary: vi.fn((content) => {
+    if (content.length <= 150) return content;
+    return content.substring(0, 147) + '...';
+  }),
+  decrementAgentPendingApproval: vi.fn().mockResolvedValue(undefined)
+}));
+
+import { writeFile, mkdir, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { v4 as uuidv4 } from 'uuid';
+import { readJSONFile } from '../lib/fileUtils.js';
+import * as memoryBM25 from './memoryBM25.js';
+import * as notifications from './notifications.js';
+import { findTopK, findAboveThreshold, clusterBySimilarity } from '../lib/vectorMath.js';
+import { generateSummary, decrementAgentPendingApproval } from './memoryConfig.js';
+import { cosEvents } from './cos.js';
+import {
+  createMemory,
+  getMemory,
+  getMemories,
+  updateMemory,
+  updateMemoryEmbedding,
+  deleteMemory,
+  approveMemory,
+  rejectMemory,
+  searchMemories,
+  hybridSearchMemories,
+  rebuildBM25Index,
+  getBM25Stats,
+  getTimeline,
+  getCategories,
+  getTags,
+  getRelatedMemories,
+  getGraphData,
+  linkMemories,
+  consolidateMemories,
+  applyDecay,
+  clearExpired,
+  getStats,
+  invalidateCaches,
+  flushBM25Index
+} from './memory.js';
+
+// Default index/embeddings returned by readJSONFile
+const defaultIndex = { version: 1, lastUpdated: '2025-01-01T00:00:00.000Z', count: 0, memories: [] };
+const defaultEmbeddings = { model: null, dimension: 0, vectors: {} };
+
+describe('memory service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset caches between tests
+    invalidateCaches();
+    // Default readJSONFile behavior: return default index or embeddings based on call order
+    readJSONFile.mockImplementation((filePath, defaultVal) => Promise.resolve(defaultVal));
+    existsSync.mockReturnValue(true);
+  });
+
+  // ===========================================================================
+  // createMemory
+  // ===========================================================================
+
+  describe('createMemory', () => {
+    it('should create a memory with defaults', async () => {
+      const data = { type: 'fact', content: 'The sky is blue' };
+      const result = await createMemory(data);
+
+      expect(result.id).toBe('test-uuid-1234');
+      expect(result.type).toBe('fact');
+      expect(result.content).toBe('The sky is blue');
+      expect(result.category).toBe('other');
+      expect(result.tags).toEqual([]);
+      expect(result.relatedMemories).toEqual([]);
+      expect(result.confidence).toBe(0.8);
+      expect(result.importance).toBe(0.5);
+      expect(result.accessCount).toBe(0);
+      expect(result.status).toBe('active');
+      expect(result.embedding).toBeNull();
+      expect(result.embeddingModel).toBeNull();
+      expect(result.createdAt).toBeDefined();
+      expect(result.updatedAt).toBeDefined();
+    });
+
+    it('should use provided fields when given', async () => {
+      const data = {
+        type: 'decision',
+        content: 'Use React',
+        summary: 'Custom summary',
+        category: 'engineering',
+        tags: ['frontend', 'react'],
+        confidence: 0.95,
+        importance: 0.9,
+        sourceTaskId: 'task-1',
+        sourceAgentId: 'agent-1',
+        sourceAppId: 'app-1',
+        status: 'pending_approval',
+        expiresAt: '2026-01-01T00:00:00.000Z',
+        relatedMemories: ['mem-1']
+      };
+
+      const result = await createMemory(data);
+
+      expect(result.summary).toBe('Custom summary');
+      expect(result.category).toBe('engineering');
+      expect(result.tags).toEqual(['frontend', 'react']);
+      expect(result.confidence).toBe(0.95);
+      expect(result.importance).toBe(0.9);
+      expect(result.sourceTaskId).toBe('task-1');
+      expect(result.sourceAgentId).toBe('agent-1');
+      expect(result.sourceAppId).toBe('app-1');
+      expect(result.status).toBe('pending_approval');
+      expect(result.relatedMemories).toEqual(['mem-1']);
+    });
+
+    it('should generate summary when not provided', async () => {
+      const data = { type: 'fact', content: 'Short content' };
+      await createMemory(data);
+
+      expect(generateSummary).toHaveBeenCalledWith('Short content');
+    });
+
+    it('should store embedding when provided', async () => {
+      const embedding = [0.1, 0.2, 0.3];
+      const data = { type: 'fact', content: 'test' };
+
+      const result = await createMemory(data, embedding);
+
+      expect(result.embedding).toEqual([0.1, 0.2, 0.3]);
+      expect(result.embeddingModel).toBe('test-embedding-model');
+      // Should save embeddings file
+      expect(writeFile).toHaveBeenCalledTimes(3); // memory file + index + embeddings
+    });
+
+    it('should not save embeddings file when no embedding provided', async () => {
+      const data = { type: 'fact', content: 'no embedding' };
+      await createMemory(data);
+
+      // memory file + index only (2 calls)
+      expect(writeFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('should add entry to index and update count', async () => {
+      const data = { type: 'learning', content: 'Learned something' };
+      await createMemory(data);
+
+      // writeFile is called for saving memory and saving index
+      const indexCall = writeFile.mock.calls.find(call =>
+        call[0].includes('index.json')
+      );
+      expect(indexCall).toBeDefined();
+      const savedIndex = JSON.parse(indexCall[1]);
+      expect(savedIndex.count).toBe(1);
+      expect(savedIndex.memories).toHaveLength(1);
+      expect(savedIndex.memories[0].id).toBe('test-uuid-1234');
+    });
+
+    it('should index in BM25', async () => {
+      const data = { type: 'fact', content: 'Indexed content', tags: ['tag1'] };
+      await createMemory(data);
+
+      expect(memoryBM25.indexMemory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'test-uuid-1234',
+          content: 'Indexed content',
+          type: 'fact',
+          tags: ['tag1']
+        })
+      );
+    });
+
+    it('should emit memory:created event', async () => {
+      const emitSpy = vi.spyOn(cosEvents, 'emit');
+      const data = { type: 'fact', content: 'test' };
+
+      await createMemory(data);
+
+      expect(emitSpy).toHaveBeenCalledWith('memory:created', expect.objectContaining({
+        id: 'test-uuid-1234',
+        type: 'fact'
+      }));
+    });
+
+    it('should handle confidence of 0 via nullish coalescing', async () => {
+      const data = { type: 'fact', content: 'test', confidence: 0 };
+      const result = await createMemory(data);
+
+      expect(result.confidence).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // getMemory
+  // ===========================================================================
+
+  describe('getMemory', () => {
+    it('should return memory and update access stats', async () => {
+      const mockMemory = {
+        id: 'mem-1',
+        type: 'fact',
+        content: 'test',
+        accessCount: 5,
+        lastAccessed: null
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        return Promise.resolve(def);
+      });
+
+      const result = await getMemory('mem-1');
+
+      expect(result.accessCount).toBe(6);
+      expect(result.lastAccessed).toBeDefined();
+    });
+
+    it('should return null for non-existent memory', async () => {
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+
+      const result = await getMemory('non-existent');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // getMemories
+  // ===========================================================================
+
+  describe('getMemories', () => {
+    const makeIndex = (memories) => ({
+      version: 1,
+      lastUpdated: '2025-01-01T00:00:00.000Z',
+      count: memories.length,
+      memories
+    });
+
+    const mem1 = { id: 'm1', type: 'fact', category: 'science', tags: ['physics'], summary: 'Gravity', importance: 0.8, createdAt: '2025-01-01T00:00:00.000Z', status: 'active', sourceAppId: 'app1' };
+    const mem2 = { id: 'm2', type: 'decision', category: 'engineering', tags: ['react'], summary: 'Use React', importance: 0.6, createdAt: '2025-01-02T00:00:00.000Z', status: 'active', sourceAppId: 'brain' };
+    const mem3 = { id: 'm3', type: 'fact', category: 'science', tags: ['math'], summary: 'Pi', importance: 0.9, createdAt: '2025-01-03T00:00:00.000Z', status: 'archived', sourceAppId: 'app1' };
+
+    beforeEach(() => {
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(makeIndex([mem1, mem2, mem3]));
+        return Promise.resolve(def);
+      });
+    });
+
+    it('should return active memories by default', async () => {
+      const result = await getMemories();
+
+      expect(result.total).toBe(2);
+      expect(result.memories.every(m => m.status === 'active')).toBe(true);
+    });
+
+    it('should filter by status', async () => {
+      const result = await getMemories({ status: 'archived' });
+
+      expect(result.total).toBe(1);
+      expect(result.memories[0].id).toBe('m3');
+    });
+
+    it('should filter by types', async () => {
+      const result = await getMemories({ types: ['fact'] });
+
+      expect(result.total).toBe(1);
+      expect(result.memories[0].type).toBe('fact');
+    });
+
+    it('should filter by categories', async () => {
+      const result = await getMemories({ categories: ['engineering'] });
+
+      expect(result.total).toBe(1);
+      expect(result.memories[0].category).toBe('engineering');
+    });
+
+    it('should filter by tags (any match)', async () => {
+      const result = await getMemories({ tags: ['physics', 'react'] });
+
+      expect(result.total).toBe(2);
+    });
+
+    it('should filter by appId', async () => {
+      const result = await getMemories({ appId: 'app1' });
+
+      expect(result.total).toBe(1);
+      expect(result.memories[0].sourceAppId).toBe('app1');
+    });
+
+    it('should filter by __not_brain appId', async () => {
+      const result = await getMemories({ appId: '__not_brain' });
+
+      expect(result.total).toBe(1);
+      expect(result.memories[0].sourceAppId).not.toBe('brain');
+    });
+
+    it('should sort by createdAt desc by default', async () => {
+      const result = await getMemories();
+
+      expect(result.memories[0].id).toBe('m2');
+      expect(result.memories[1].id).toBe('m1');
+    });
+
+    it('should sort ascending when specified', async () => {
+      const result = await getMemories({ sortOrder: 'asc' });
+
+      expect(result.memories[0].id).toBe('m1');
+    });
+
+    it('should sort by importance', async () => {
+      const result = await getMemories({ sortBy: 'importance', sortOrder: 'desc' });
+
+      expect(result.memories[0].importance).toBeGreaterThanOrEqual(result.memories[1].importance);
+    });
+
+    it('should paginate results', async () => {
+      const result = await getMemories({ offset: 0, limit: 1 });
+
+      expect(result.total).toBe(2);
+      expect(result.memories).toHaveLength(1);
+    });
+
+    it('should handle offset pagination', async () => {
+      const result = await getMemories({ offset: 1, limit: 1 });
+
+      expect(result.memories).toHaveLength(1);
+    });
+
+    it('should return empty when no memories match filters', async () => {
+      const result = await getMemories({ types: ['preference'] });
+
+      expect(result.total).toBe(0);
+      expect(result.memories).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // updateMemory
+  // ===========================================================================
+
+  describe('updateMemory', () => {
+    it('should update allowed fields', async () => {
+      const mockMemory = {
+        id: 'mem-1',
+        type: 'fact',
+        content: 'old content',
+        summary: 'old summary',
+        category: 'other',
+        tags: [],
+        importance: 0.5,
+        relatedMemories: [],
+        status: 'active',
+        sourceAppId: null
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve({
+          version: 1, lastUpdated: '', count: 1,
+          memories: [{ id: 'mem-1', type: 'fact', category: 'other', tags: [], summary: 'old', importance: 0.5, createdAt: '', status: 'active', sourceAppId: null }]
+        });
+        return Promise.resolve(def);
+      });
+
+      const result = await updateMemory('mem-1', {
+        content: 'new content',
+        category: 'engineering',
+        tags: ['updated'],
+        importance: 0.9
+      });
+
+      expect(result.content).toBe('new content');
+      expect(result.category).toBe('engineering');
+      expect(result.tags).toEqual(['updated']);
+      expect(result.importance).toBe(0.9);
+      expect(result.updatedAt).toBeDefined();
+    });
+
+    it('should auto-generate summary when content changes without explicit summary', async () => {
+      const mockMemory = { id: 'mem-1', type: 'fact', content: 'old', summary: 'old', category: 'other', tags: [], importance: 0.5, relatedMemories: [], status: 'active', sourceAppId: null };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve({ version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', type: 'fact', category: 'other', tags: [], summary: 'old', importance: 0.5, createdAt: '', status: 'active', sourceAppId: null }] });
+        return Promise.resolve(def);
+      });
+
+      await updateMemory('mem-1', { content: 'brand new content' });
+
+      expect(generateSummary).toHaveBeenCalledWith('brand new content');
+    });
+
+    it('should not regenerate summary when both content and summary provided', async () => {
+      const mockMemory = { id: 'mem-1', type: 'fact', content: 'old', summary: 'old', category: 'other', tags: [], importance: 0.5, relatedMemories: [], status: 'active', sourceAppId: null };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve({ version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', type: 'fact', category: 'other', tags: [], summary: 'old', importance: 0.5, createdAt: '', status: 'active', sourceAppId: null }] });
+        return Promise.resolve(def);
+      });
+
+      const result = await updateMemory('mem-1', { content: 'new', summary: 'explicit summary' });
+
+      expect(result.summary).toBe('explicit summary');
+    });
+
+    it('should return null for non-existent memory', async () => {
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+
+      const result = await updateMemory('non-existent', { content: 'test' });
+
+      expect(result).toBeNull();
+    });
+
+    it('should update BM25 index when content changes', async () => {
+      const mockMemory = { id: 'mem-1', type: 'fact', content: 'old', summary: 'old', category: 'other', tags: [], importance: 0.5, relatedMemories: [], status: 'active', sourceAppId: null };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve({ version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', type: 'fact', category: 'other', tags: [], summary: 'old', importance: 0.5, createdAt: '', status: 'active', sourceAppId: null }] });
+        return Promise.resolve(def);
+      });
+
+      await updateMemory('mem-1', { content: 'new content' });
+
+      expect(memoryBM25.indexMemory).toHaveBeenCalled();
+    });
+
+    it('should update BM25 index when tags change', async () => {
+      const mockMemory = { id: 'mem-1', type: 'fact', content: 'test', summary: 'test', category: 'other', tags: [], importance: 0.5, relatedMemories: [], status: 'active', sourceAppId: null };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve({ version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', type: 'fact', category: 'other', tags: [], summary: 'test', importance: 0.5, createdAt: '', status: 'active', sourceAppId: null }] });
+        return Promise.resolve(def);
+      });
+
+      await updateMemory('mem-1', { tags: ['new-tag'] });
+
+      expect(memoryBM25.indexMemory).toHaveBeenCalled();
+    });
+
+    it('should emit memory:updated event', async () => {
+      const emitSpy = vi.spyOn(cosEvents, 'emit');
+      const mockMemory = { id: 'mem-1', type: 'fact', content: 'test', summary: 'test', category: 'other', tags: [], importance: 0.5, relatedMemories: [], status: 'active', sourceAppId: null };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve({ version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', type: 'fact', category: 'other', tags: [], summary: 'test', importance: 0.5, createdAt: '', status: 'active', sourceAppId: null }] });
+        return Promise.resolve(def);
+      });
+
+      await updateMemory('mem-1', { category: 'updated' });
+
+      expect(emitSpy).toHaveBeenCalledWith('memory:updated', { id: 'mem-1', updates: { category: 'updated' } });
+    });
+  });
+
+  // ===========================================================================
+  // updateMemoryEmbedding
+  // ===========================================================================
+
+  describe('updateMemoryEmbedding', () => {
+    it('should update embedding on memory and embeddings file', async () => {
+      const mockMemory = { id: 'mem-1', embedding: null, embeddingModel: null, updatedAt: '' };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('embeddings.json')) return Promise.resolve({ model: null, dimension: 0, vectors: {} });
+        return Promise.resolve(def);
+      });
+
+      const embedding = [0.5, 0.6, 0.7];
+      const result = await updateMemoryEmbedding('mem-1', embedding);
+
+      expect(result.embedding).toEqual([0.5, 0.6, 0.7]);
+      expect(result.embeddingModel).toBe('test-embedding-model');
+    });
+
+    it('should return null for non-existent memory', async () => {
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+
+      const result = await updateMemoryEmbedding('non-existent', [0.1]);
+
+      expect(result).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // deleteMemory
+  // ===========================================================================
+
+  describe('deleteMemory', () => {
+    const makeReadMock = (memory, index, embeddings) => (path, def) => {
+      if (path.includes('memory.json')) return Promise.resolve(memory ? { ...memory } : def);
+      if (path.includes('index.json')) return Promise.resolve(index || def);
+      if (path.includes('embeddings.json')) return Promise.resolve(embeddings || def);
+      return Promise.resolve(def);
+    };
+
+    it('should soft delete (archive) by default', async () => {
+      const mockMemory = { id: 'mem-1', status: 'active', updatedAt: '' };
+      const mockIndex = { version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', status: 'active' }] };
+      readJSONFile.mockImplementation(makeReadMock(mockMemory, mockIndex));
+
+      const result = await deleteMemory('mem-1');
+
+      expect(result).toEqual({ success: true, id: 'mem-1' });
+      expect(rm).not.toHaveBeenCalled();
+      // The memory should have been saved with archived status
+      const memorySaveCall = writeFile.mock.calls.find(c => c[0].includes('memory.json'));
+      expect(memorySaveCall).toBeDefined();
+      const savedMemory = JSON.parse(memorySaveCall[1]);
+      expect(savedMemory.status).toBe('archived');
+    });
+
+    it('should hard delete when hard=true', async () => {
+      const mockIndex = { version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', status: 'active' }] };
+      const mockEmbeddings = { model: 'test', dimension: 3, vectors: { 'mem-1': [0.1, 0.2, 0.3] } };
+      readJSONFile.mockImplementation(makeReadMock(null, mockIndex, mockEmbeddings));
+
+      const result = await deleteMemory('mem-1', true);
+
+      expect(result).toEqual({ success: true, id: 'mem-1' });
+      expect(rm).toHaveBeenCalled();
+      expect(memoryBM25.removeMemoryFromIndex).toHaveBeenCalledWith('mem-1');
+    });
+
+    it('should emit memory:deleted event', async () => {
+      const emitSpy = vi.spyOn(cosEvents, 'emit');
+      const mockMemory = { id: 'mem-1', status: 'active', updatedAt: '' };
+      const mockIndex = { version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', status: 'active' }] };
+      readJSONFile.mockImplementation(makeReadMock(mockMemory, mockIndex));
+
+      await deleteMemory('mem-1');
+
+      expect(emitSpy).toHaveBeenCalledWith('memory:deleted', { id: 'mem-1', hard: false });
+    });
+
+    it('should emit memory:deleted with hard=true', async () => {
+      const emitSpy = vi.spyOn(cosEvents, 'emit');
+      const mockIndex = { version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', status: 'active' }] };
+      readJSONFile.mockImplementation(makeReadMock(null, mockIndex));
+
+      await deleteMemory('mem-1', true);
+
+      expect(emitSpy).toHaveBeenCalledWith('memory:deleted', { id: 'mem-1', hard: true });
+    });
+  });
+
+  // ===========================================================================
+  // approveMemory
+  // ===========================================================================
+
+  describe('approveMemory', () => {
+    it('should approve a pending_approval memory', async () => {
+      const mockMemory = { id: 'mem-1', status: 'pending_approval', sourceAgentId: 'agent-1', updatedAt: '' };
+      const mockIndex = { version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', status: 'pending_approval' }] };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve({ ...mockIndex, memories: [...mockIndex.memories] });
+        return Promise.resolve(def);
+      });
+
+      const result = await approveMemory('mem-1');
+
+      expect(result.success).toBe(true);
+      expect(result.memory.status).toBe('active');
+      expect(notifications.removeByMetadata).toHaveBeenCalledWith('memoryId', 'mem-1');
+      expect(decrementAgentPendingApproval).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('should return error for non-existent memory', async () => {
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+
+      const result = await approveMemory('non-existent');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Memory not found');
+    });
+
+    it('should return error if not pending_approval', async () => {
+      const mockMemory = { id: 'mem-1', status: 'active' };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        return Promise.resolve(def);
+      });
+
+      const result = await approveMemory('mem-1');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Memory is not pending approval');
+    });
+
+    it('should emit memory:approved event', async () => {
+      const emitSpy = vi.spyOn(cosEvents, 'emit');
+      const mockMemory = { id: 'mem-1', status: 'pending_approval', sourceAgentId: 'agent-1', updatedAt: '' };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve({ version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', status: 'pending_approval' }] });
+        return Promise.resolve(def);
+      });
+
+      await approveMemory('mem-1');
+
+      expect(emitSpy).toHaveBeenCalledWith('memory:approved', expect.objectContaining({ id: 'mem-1' }));
+    });
+  });
+
+  // ===========================================================================
+  // rejectMemory
+  // ===========================================================================
+
+  describe('rejectMemory', () => {
+    it('should hard delete a pending_approval memory', async () => {
+      const mockMemory = { id: 'mem-1', status: 'pending_approval', sourceAgentId: 'agent-1' };
+      const mockIndex = { version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', status: 'pending_approval' }] };
+      const mockEmbeddings = { model: 'test', dimension: 0, vectors: {} };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve({ ...mockIndex, memories: [...mockIndex.memories] });
+        if (path.includes('embeddings.json')) return Promise.resolve({ ...mockEmbeddings });
+        return Promise.resolve(def);
+      });
+
+      const result = await rejectMemory('mem-1');
+
+      expect(result.success).toBe(true);
+      expect(rm).toHaveBeenCalled();
+      expect(notifications.removeByMetadata).toHaveBeenCalledWith('memoryId', 'mem-1');
+      expect(decrementAgentPendingApproval).toHaveBeenCalledWith('agent-1');
+    });
+
+    it('should return error for non-existent memory', async () => {
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+
+      const result = await rejectMemory('non-existent');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Memory not found');
+    });
+
+    it('should return error if not pending_approval', async () => {
+      const mockMemory = { id: 'mem-1', status: 'active' };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        return Promise.resolve(def);
+      });
+
+      const result = await rejectMemory('mem-1');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Memory is not pending approval');
+    });
+
+    it('should emit memory:rejected event', async () => {
+      const emitSpy = vi.spyOn(cosEvents, 'emit');
+      const mockMemory = { id: 'mem-1', status: 'pending_approval', sourceAgentId: 'agent-1' };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve({ version: 1, lastUpdated: '', count: 1, memories: [{ id: 'mem-1', status: 'pending_approval' }] });
+        if (path.includes('embeddings.json')) return Promise.resolve({ model: null, dimension: 0, vectors: {} });
+        return Promise.resolve(def);
+      });
+
+      await rejectMemory('mem-1');
+
+      expect(emitSpy).toHaveBeenCalledWith('memory:rejected', { id: 'mem-1' });
+    });
+  });
+
+  // ===========================================================================
+  // searchMemories
+  // ===========================================================================
+
+  describe('searchMemories', () => {
+    it('should return empty when no query embedding provided', async () => {
+      const result = await searchMemories(null);
+
+      expect(result).toEqual({ total: 0, memories: [] });
+    });
+
+    it('should return empty when no embeddings exist', async () => {
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+
+      const result = await searchMemories([0.1, 0.2]);
+
+      expect(result).toEqual({ total: 0, memories: [] });
+    });
+
+    it('should filter out non-active results', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', type: 'fact', status: 'active', tags: [] },
+          { id: 'm2', type: 'fact', status: 'archived', tags: [] }
+        ]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 3, vectors: { m1: [0.1], m2: [0.2] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+      findAboveThreshold.mockReturnValue([
+        { id: 'm1', similarity: 0.9 },
+        { id: 'm2', similarity: 0.85 }
+      ]);
+
+      const result = await searchMemories([0.1, 0.2]);
+
+      expect(result.total).toBe(1);
+      expect(result.memories[0].id).toBe('m1');
+    });
+
+    it('should apply type filter', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', type: 'fact', category: 'other', status: 'active', tags: [] },
+          { id: 'm2', type: 'decision', category: 'other', status: 'active', tags: [] }
+        ]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 3, vectors: { m1: [0.1], m2: [0.2] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+      findAboveThreshold.mockReturnValue([
+        { id: 'm1', similarity: 0.9 },
+        { id: 'm2', similarity: 0.85 }
+      ]);
+
+      const result = await searchMemories([0.1], { types: ['fact'] });
+
+      expect(result.total).toBe(1);
+      expect(result.memories[0].id).toBe('m1');
+    });
+
+    it('should apply __not_brain filter', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', type: 'fact', status: 'active', tags: [], sourceAppId: 'brain' },
+          { id: 'm2', type: 'fact', status: 'active', tags: [], sourceAppId: 'other' }
+        ]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 3, vectors: { m1: [0.1], m2: [0.2] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+      findAboveThreshold.mockReturnValue([
+        { id: 'm1', similarity: 0.9 },
+        { id: 'm2', similarity: 0.85 }
+      ]);
+
+      const result = await searchMemories([0.1], { appId: '__not_brain' });
+
+      expect(result.total).toBe(1);
+      expect(result.memories[0].id).toBe('m2');
+    });
+
+    it('should include similarity score in results', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 1,
+        memories: [{ id: 'm1', type: 'fact', status: 'active', tags: [] }]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 3, vectors: { m1: [0.1] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+      findAboveThreshold.mockReturnValue([{ id: 'm1', similarity: 0.95 }]);
+
+      const result = await searchMemories([0.1]);
+
+      expect(result.memories[0].similarity).toBe(0.95);
+    });
+  });
+
+  // ===========================================================================
+  // hybridSearchMemories
+  // ===========================================================================
+
+  describe('hybridSearchMemories', () => {
+    it('should combine BM25 and vector results via RRF', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', type: 'fact', status: 'active', tags: [], category: 'other', sourceAppId: null },
+          { id: 'm2', type: 'fact', status: 'active', tags: [], category: 'other', sourceAppId: null }
+        ]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 3, vectors: { m1: [0.1], m2: [0.2] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+      memoryBM25.searchBM25.mockResolvedValue([{ id: 'm1', score: 0.8 }]);
+      findAboveThreshold.mockReturnValue([{ id: 'm2', similarity: 0.9 }]);
+
+      const result = await hybridSearchMemories('test query', [0.1, 0.2]);
+
+      expect(result.total).toBe(2);
+      // Both should appear with RRF scores
+      const ids = result.memories.map(m => m.id);
+      expect(ids).toContain('m1');
+      expect(ids).toContain('m2');
+    });
+
+    it('should mark searchMethod correctly', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 1,
+        memories: [{ id: 'm1', type: 'fact', status: 'active', tags: [], category: 'other', sourceAppId: null }]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 3, vectors: { m1: [0.1] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+      memoryBM25.searchBM25.mockResolvedValue([{ id: 'm1', score: 0.8 }]);
+      findAboveThreshold.mockReturnValue([{ id: 'm1', similarity: 0.9 }]);
+
+      const result = await hybridSearchMemories('query', [0.1]);
+
+      expect(result.memories[0].searchMethod).toBe('hybrid');
+    });
+
+    it('should handle empty query (no BM25)', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 1,
+        memories: [{ id: 'm1', type: 'fact', status: 'active', tags: [], category: 'other', sourceAppId: null }]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 3, vectors: { m1: [0.1] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+      findAboveThreshold.mockReturnValue([{ id: 'm1', similarity: 0.9 }]);
+
+      const result = await hybridSearchMemories('', [0.1]);
+
+      expect(result.memories[0].searchMethod).toBe('vector');
+      expect(memoryBM25.searchBM25).not.toHaveBeenCalled();
+    });
+
+    it('should handle no embedding (BM25 only)', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 1,
+        memories: [{ id: 'm1', type: 'fact', status: 'active', tags: [], category: 'other', sourceAppId: null }]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve({ model: null, dimension: 0, vectors: {} });
+        return Promise.resolve(def);
+      });
+      memoryBM25.searchBM25.mockResolvedValue([{ id: 'm1', score: 0.8 }]);
+
+      const result = await hybridSearchMemories('query', null);
+
+      expect(result.memories[0].searchMethod).toBe('bm25');
+    });
+
+    it('should filter out non-active in hybrid results', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 1,
+        memories: [{ id: 'm1', type: 'fact', status: 'archived', tags: [], category: 'other', sourceAppId: null }]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve({ model: null, dimension: 0, vectors: {} });
+        return Promise.resolve(def);
+      });
+      memoryBM25.searchBM25.mockResolvedValue([{ id: 'm1', score: 0.8 }]);
+
+      const result = await hybridSearchMemories('query', null);
+
+      expect(result.total).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // rebuildBM25Index
+  // ===========================================================================
+
+  describe('rebuildBM25Index', () => {
+    it('should rebuild index from active memories', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', status: 'active' },
+          { id: 'm2', status: 'archived' }
+        ]
+      };
+      const mockMemory = { id: 'm1', content: 'test', type: 'fact', tags: ['t1'], sourceAppId: 'app1' };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('m1/memory.json')) return Promise.resolve(mockMemory);
+        return Promise.resolve(def);
+      });
+      memoryBM25.rebuildIndex.mockResolvedValue({ indexed: 1 });
+
+      const result = await rebuildBM25Index();
+
+      expect(memoryBM25.rebuildIndex).toHaveBeenCalledWith([
+        expect.objectContaining({ id: 'm1', content: 'test' })
+      ]);
+      expect(result).toEqual({ indexed: 1 });
+    });
+  });
+
+  // ===========================================================================
+  // getBM25Stats
+  // ===========================================================================
+
+  describe('getBM25Stats', () => {
+    it('should delegate to memoryBM25.getStats', async () => {
+      memoryBM25.getStats.mockResolvedValue({ documentCount: 42 });
+
+      const result = await getBM25Stats();
+
+      expect(result).toEqual({ documentCount: 42 });
+    });
+  });
+
+  // ===========================================================================
+  // getTimeline
+  // ===========================================================================
+
+  describe('getTimeline', () => {
+    it('should group active memories by date', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 3,
+        memories: [
+          { id: 'm1', createdAt: '2025-01-15T10:00:00.000Z', status: 'active', sourceAppId: null },
+          { id: 'm2', createdAt: '2025-01-15T14:00:00.000Z', status: 'active', sourceAppId: null },
+          { id: 'm3', createdAt: '2025-01-16T08:00:00.000Z', status: 'active', sourceAppId: null }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        return Promise.resolve(def);
+      });
+
+      const timeline = await getTimeline();
+
+      expect(timeline['2025-01-15']).toHaveLength(2);
+      expect(timeline['2025-01-16']).toHaveLength(1);
+    });
+
+    it('should filter by date range', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', createdAt: '2025-01-10T00:00:00.000Z', status: 'active', sourceAppId: null },
+          { id: 'm2', createdAt: '2025-01-20T00:00:00.000Z', status: 'active', sourceAppId: null }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        return Promise.resolve(def);
+      });
+
+      const timeline = await getTimeline({ startDate: '2025-01-15T00:00:00.000Z' });
+
+      expect(Object.keys(timeline)).toHaveLength(1);
+      expect(timeline['2025-01-20']).toBeDefined();
+    });
+
+    it('should filter by types', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', type: 'fact', createdAt: '2025-01-15T00:00:00.000Z', status: 'active', sourceAppId: null },
+          { id: 'm2', type: 'decision', createdAt: '2025-01-15T00:00:00.000Z', status: 'active', sourceAppId: null }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        return Promise.resolve(def);
+      });
+
+      const timeline = await getTimeline({ types: ['fact'] });
+
+      expect(timeline['2025-01-15']).toHaveLength(1);
+    });
+
+    it('should exclude archived memories', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', createdAt: '2025-01-15T00:00:00.000Z', status: 'active', sourceAppId: null },
+          { id: 'm2', createdAt: '2025-01-15T00:00:00.000Z', status: 'archived', sourceAppId: null }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        return Promise.resolve(def);
+      });
+
+      const timeline = await getTimeline();
+
+      expect(timeline['2025-01-15']).toHaveLength(1);
+    });
+
+    it('should apply limit', async () => {
+      const memories = Array.from({ length: 10 }, (_, i) => ({
+        id: `m${i}`, createdAt: `2025-01-${String(i + 10).padStart(2, '0')}T00:00:00.000Z`, status: 'active', sourceAppId: null
+      }));
+      const mockIndex = { version: 1, lastUpdated: '', count: 10, memories };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        return Promise.resolve(def);
+      });
+
+      const timeline = await getTimeline({ limit: 3 });
+
+      const totalEntries = Object.values(timeline).reduce((sum, arr) => sum + arr.length, 0);
+      expect(totalEntries).toBe(3);
+    });
+
+    it('should filter by __not_brain appId', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', createdAt: '2025-01-15T00:00:00.000Z', status: 'active', sourceAppId: 'brain' },
+          { id: 'm2', createdAt: '2025-01-15T00:00:00.000Z', status: 'active', sourceAppId: 'other' }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        return Promise.resolve(def);
+      });
+
+      const timeline = await getTimeline({ appId: '__not_brain' });
+
+      expect(timeline['2025-01-15']).toHaveLength(1);
+      expect(timeline['2025-01-15'][0].sourceAppId).toBe('other');
+    });
+  });
+
+  // ===========================================================================
+  // getCategories
+  // ===========================================================================
+
+  describe('getCategories', () => {
+    it('should return unique categories with counts', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 3,
+        memories: [
+          { id: 'm1', category: 'science', status: 'active' },
+          { id: 'm2', category: 'science', status: 'active' },
+          { id: 'm3', category: 'engineering', status: 'active' }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        return Promise.resolve(def);
+      });
+
+      const categories = await getCategories();
+
+      expect(categories).toContainEqual({ name: 'science', count: 2 });
+      expect(categories).toContainEqual({ name: 'engineering', count: 1 });
+    });
+
+    it('should exclude archived memories', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', category: 'science', status: 'active' },
+          { id: 'm2', category: 'science', status: 'archived' }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        return Promise.resolve(def);
+      });
+
+      const categories = await getCategories();
+
+      expect(categories).toEqual([{ name: 'science', count: 1 }]);
+    });
+
+    it('should return empty array when no active memories', async () => {
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+
+      const categories = await getCategories();
+
+      expect(categories).toEqual([]);
+    });
+  });
+
+  // ===========================================================================
+  // getTags
+  // ===========================================================================
+
+  describe('getTags', () => {
+    it('should return unique tags with counts sorted by count desc', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 3,
+        memories: [
+          { id: 'm1', tags: ['react', 'js'], status: 'active' },
+          { id: 'm2', tags: ['react', 'node'], status: 'active' },
+          { id: 'm3', tags: ['python'], status: 'active' }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        return Promise.resolve(def);
+      });
+
+      const tags = await getTags();
+
+      expect(tags[0]).toEqual({ name: 'react', count: 2 });
+      expect(tags).toContainEqual({ name: 'js', count: 1 });
+      expect(tags).toContainEqual({ name: 'node', count: 1 });
+      expect(tags).toContainEqual({ name: 'python', count: 1 });
+    });
+
+    it('should exclude archived memories', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', tags: ['react'], status: 'active' },
+          { id: 'm2', tags: ['react', 'vue'], status: 'archived' }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        return Promise.resolve(def);
+      });
+
+      const tags = await getTags();
+
+      expect(tags).toEqual([{ name: 'react', count: 1 }]);
+    });
+  });
+
+  // ===========================================================================
+  // getRelatedMemories
+  // ===========================================================================
+
+  describe('getRelatedMemories', () => {
+    it('should return explicitly linked memories', async () => {
+      const mockMemory = { id: 'mem-1', relatedMemories: ['mem-2'], embedding: null };
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'mem-1', status: 'active' },
+          { id: 'mem-2', status: 'active', summary: 'linked' }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve({ model: null, dimension: 0, vectors: {} });
+        return Promise.resolve(def);
+      });
+
+      const related = await getRelatedMemories('mem-1');
+
+      expect(related).toHaveLength(1);
+      expect(related[0].relationship).toBe('linked');
+      expect(related[0].similarity).toBe(1.0);
+    });
+
+    it('should include similar memories by embedding', async () => {
+      const mockMemory = { id: 'mem-1', relatedMemories: [], embedding: [0.1, 0.2] };
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'mem-1', status: 'active' },
+          { id: 'mem-3', status: 'active', summary: 'similar' }
+        ]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 2, vectors: { 'mem-1': [0.1, 0.2], 'mem-3': [0.15, 0.25] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+      findTopK.mockReturnValue([{ id: 'mem-3', similarity: 0.85 }]);
+
+      const related = await getRelatedMemories('mem-1');
+
+      expect(related).toHaveLength(1);
+      expect(related[0].relationship).toBe('similar');
+      expect(related[0].similarity).toBe(0.85);
+    });
+
+    it('should return empty for non-existent memory', async () => {
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+
+      const related = await getRelatedMemories('non-existent');
+
+      expect(related).toEqual([]);
+    });
+
+    it('should not duplicate linked and similar results', async () => {
+      const mockMemory = { id: 'mem-1', relatedMemories: ['mem-2'], embedding: [0.1] };
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'mem-1', status: 'active' },
+          { id: 'mem-2', status: 'active' }
+        ]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 1, vectors: { 'mem-1': [0.1], 'mem-2': [0.15] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+      // findTopK returns mem-2 as similar too
+      findTopK.mockReturnValue([{ id: 'mem-2', similarity: 0.9 }]);
+
+      const related = await getRelatedMemories('mem-1');
+
+      expect(related).toHaveLength(1);
+      expect(related[0].relationship).toBe('linked');
+    });
+
+    it('should respect limit parameter', async () => {
+      const mockMemory = { id: 'mem-1', relatedMemories: ['mem-2', 'mem-3', 'mem-4'], embedding: null };
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 4,
+        memories: [
+          { id: 'mem-1', status: 'active' },
+          { id: 'mem-2', status: 'active' },
+          { id: 'mem-3', status: 'active' },
+          { id: 'mem-4', status: 'active' }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve({ model: null, dimension: 0, vectors: {} });
+        return Promise.resolve(def);
+      });
+
+      const related = await getRelatedMemories('mem-1', 2);
+
+      expect(related).toHaveLength(2);
+    });
+  });
+
+  // ===========================================================================
+  // linkMemories
+  // ===========================================================================
+
+  describe('linkMemories', () => {
+    it('should create bidirectional links', async () => {
+      const source = { id: 'src', relatedMemories: [], updatedAt: '' };
+      const target = { id: 'tgt', relatedMemories: [], updatedAt: '' };
+      let callCount = 0;
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) {
+          callCount++;
+          // First call is source, second is target
+          return Promise.resolve(callCount <= 1 ? { ...source } : { ...target });
+        }
+        return Promise.resolve(def);
+      });
+
+      const result = await linkMemories('src', 'tgt');
+
+      expect(result.success).toBe(true);
+      expect(result.sourceId).toBe('src');
+      expect(result.targetId).toBe('tgt');
+      // Both memories should be saved with the link
+      const memorySaves = writeFile.mock.calls.filter(c => c[0].includes('memory.json'));
+      expect(memorySaves.length).toBe(2);
+    });
+
+    it('should return error when source not found', async () => {
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+
+      const result = await linkMemories('missing-src', 'missing-tgt');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Memory not found');
+    });
+
+    it('should not duplicate existing links', async () => {
+      const source = { id: 'src', relatedMemories: ['tgt'], updatedAt: '' };
+      const target = { id: 'tgt', relatedMemories: ['src'], updatedAt: '' };
+      let callCount = 0;
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('memory.json')) {
+          callCount++;
+          return Promise.resolve(callCount <= 1 ? { ...source } : { ...target });
+        }
+        return Promise.resolve(def);
+      });
+
+      await linkMemories('src', 'tgt');
+
+      // Should not add duplicate - memories saved but relatedMemories should still be length 1
+      const memorySaves = writeFile.mock.calls.filter(c => c[0].includes('memory.json'));
+      for (const save of memorySaves) {
+        const saved = JSON.parse(save[1]);
+        expect(saved.relatedMemories).toHaveLength(1);
+      }
+    });
+  });
+
+  // ===========================================================================
+  // getGraphData
+  // ===========================================================================
+
+  describe('getGraphData', () => {
+    it('should return nodes and edges', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', type: 'fact', category: 'science', summary: 'test1', importance: 0.8, status: 'active' },
+          { id: 'm2', type: 'decision', category: 'eng', summary: 'test2', importance: 0.6, status: 'active' }
+        ]
+      };
+      const mockMem1 = { id: 'm1', relatedMemories: ['m2'] };
+      const mockMem2 = { id: 'm2', relatedMemories: [] };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve({ model: null, dimension: 0, vectors: {} });
+        if (path.includes('m1/memory.json')) return Promise.resolve(mockMem1);
+        if (path.includes('m2/memory.json')) return Promise.resolve(mockMem2);
+        return Promise.resolve(def);
+      });
+
+      const result = await getGraphData();
+
+      expect(result.nodes).toHaveLength(2);
+      expect(result.edges).toHaveLength(1);
+      expect(result.edges[0].type).toBe('linked');
+    });
+
+    it('should exclude archived memories from nodes', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', type: 'fact', category: 'other', summary: 'test', importance: 0.5, status: 'active' },
+          { id: 'm2', type: 'fact', category: 'other', summary: 'archived', importance: 0.5, status: 'archived' }
+        ]
+      };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve({ model: null, dimension: 0, vectors: {} });
+        if (path.includes('m1/memory.json')) return Promise.resolve({ id: 'm1', relatedMemories: [] });
+        return Promise.resolve(def);
+      });
+
+      const result = await getGraphData();
+
+      expect(result.nodes).toHaveLength(1);
+    });
+  });
+
+  // ===========================================================================
+  // consolidateMemories
+  // ===========================================================================
+
+  describe('consolidateMemories', () => {
+    it('should return dry run results without modifying data', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 2,
+        memories: [
+          { id: 'm1', summary: 'Similar A', importance: 0.8, status: 'active' },
+          { id: 'm2', summary: 'Similar B', importance: 0.6, status: 'active' }
+        ]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 2, vectors: { m1: [0.1, 0.2], m2: [0.15, 0.25] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+      clusterBySimilarity.mockReturnValue([
+        [{ id: 'm1', summary: 'Similar A' }, { id: 'm2', summary: 'Similar B' }]
+      ]);
+
+      const result = await consolidateMemories(0.9, true);
+
+      expect(result.dryRun).toBe(true);
+      expect(result.clustersFound).toBe(1);
+      expect(result.memoriesAffected).toBe(2);
+    });
+
+    it('should return no clusters when all are unique', async () => {
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve({ version: 1, lastUpdated: '', count: 0, memories: [] });
+        if (path.includes('embeddings.json')) return Promise.resolve({ model: null, dimension: 0, vectors: {} });
+        return Promise.resolve(def);
+      });
+      clusterBySimilarity.mockReturnValue([]);
+
+      const result = await consolidateMemories(0.9, true);
+
+      expect(result.clustersFound).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // applyDecay
+  // ===========================================================================
+
+  describe('applyDecay', () => {
+    it('should apply decay to old memories', async () => {
+      const oldDate = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString(); // 100 days ago
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 1,
+        memories: [{ id: 'm1', status: 'active' }]
+      };
+      const mockMemory = { id: 'm1', importance: 0.5, createdAt: oldDate, lastAccessed: null };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        return Promise.resolve(def);
+      });
+
+      const result = await applyDecay(0.01);
+
+      expect(result.updated).toBeGreaterThanOrEqual(0);
+    });
+
+    it('should return zero updates when no memories exist', async () => {
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve({ version: 1, lastUpdated: '', count: 0, memories: [] });
+        return Promise.resolve(def);
+      });
+
+      const result = await applyDecay();
+
+      expect(result.updated).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // clearExpired
+  // ===========================================================================
+
+  describe('clearExpired', () => {
+    it('should clear expired memories', async () => {
+      const pastDate = '2020-01-01T00:00:00.000Z';
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 1,
+        memories: [{ id: 'm1', status: 'active' }]
+      };
+      const mockMemory = { id: 'm1', expiresAt: pastDate, status: 'active', content: 'test', summary: 'test', category: 'other', tags: [], importance: 0.5, relatedMemories: [], sourceAppId: null };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve({ ...mockIndex, memories: [...mockIndex.memories] });
+        if (path.includes('memory.json')) return Promise.resolve({ ...mockMemory });
+        return Promise.resolve(def);
+      });
+
+      const result = await clearExpired();
+
+      expect(result.cleared).toBe(1);
+    });
+
+    it('should not clear non-expired memories', async () => {
+      const futureDate = '2099-01-01T00:00:00.000Z';
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 1,
+        memories: [{ id: 'm1', status: 'active' }]
+      };
+      const mockMemory = { id: 'm1', expiresAt: futureDate };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('memory.json')) return Promise.resolve(mockMemory);
+        return Promise.resolve(def);
+      });
+
+      const result = await clearExpired();
+
+      expect(result.cleared).toBe(0);
+    });
+
+    it('should skip memories without expiresAt', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '', count: 1,
+        memories: [{ id: 'm1', status: 'active' }]
+      };
+      const mockMemory = { id: 'm1', expiresAt: null };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('memory.json')) return Promise.resolve(mockMemory);
+        return Promise.resolve(def);
+      });
+
+      const result = await clearExpired();
+
+      expect(result.cleared).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // getStats
+  // ===========================================================================
+
+  describe('getStats', () => {
+    it('should return correct stats breakdown', async () => {
+      const mockIndex = {
+        version: 1, lastUpdated: '2025-01-01T00:00:00.000Z', count: 4,
+        memories: [
+          { id: 'm1', type: 'fact', category: 'science', status: 'active' },
+          { id: 'm2', type: 'decision', category: 'engineering', status: 'active' },
+          { id: 'm3', type: 'fact', category: 'science', status: 'archived' },
+          { id: 'm4', type: 'fact', category: 'other', status: 'pending_approval' }
+        ]
+      };
+      const mockEmbeddings = { model: 'test', dimension: 3, vectors: { m1: [0.1], m2: [0.2] } };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(mockIndex);
+        if (path.includes('embeddings.json')) return Promise.resolve(mockEmbeddings);
+        return Promise.resolve(def);
+      });
+
+      const stats = await getStats();
+
+      expect(stats.total).toBe(4);
+      expect(stats.active).toBe(2);
+      expect(stats.archived).toBe(1);
+      expect(stats.pendingApproval).toBe(1);
+      expect(stats.expired).toBe(0);
+      expect(stats.withEmbeddings).toBe(2);
+      expect(stats.byType.fact).toBe(3);
+      expect(stats.byType.decision).toBe(1);
+      expect(stats.byCategory.science).toBe(2);
+      expect(stats.lastUpdated).toBe('2025-01-01T00:00:00.000Z');
+    });
+
+    it('should handle empty index', async () => {
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+
+      const stats = await getStats();
+
+      expect(stats.total).toBe(0);
+      expect(stats.active).toBe(0);
+      expect(stats.withEmbeddings).toBe(0);
+    });
+  });
+
+  // ===========================================================================
+  // invalidateCaches
+  // ===========================================================================
+
+  describe('invalidateCaches', () => {
+    it('should force reload on next access', async () => {
+      // First call loads and caches
+      readJSONFile.mockImplementation((path, def) => Promise.resolve(def));
+      await getStats();
+
+      // Reset readJSONFile to return different data
+      const newIndex = { version: 1, lastUpdated: '', count: 1, memories: [{ id: 'm1', type: 'fact', category: 'x', status: 'active' }] };
+      readJSONFile.mockImplementation((path, def) => {
+        if (path.includes('index.json')) return Promise.resolve(newIndex);
+        return Promise.resolve(def);
+      });
+
+      invalidateCaches();
+      const stats = await getStats();
+
+      expect(stats.total).toBe(1);
+    });
+  });
+
+  // ===========================================================================
+  // flushBM25Index
+  // ===========================================================================
+
+  describe('flushBM25Index', () => {
+    it('should delegate to memoryBM25.flush', async () => {
+      await flushBM25Index();
+
+      expect(memoryBM25.flush).toHaveBeenCalled();
+    });
+  });
+});

--- a/server/services/memory.test.js
+++ b/server/services/memory.test.js
@@ -70,9 +70,8 @@ vi.mock('./memoryConfig.js', () => ({
   decrementAgentPendingApproval: vi.fn().mockResolvedValue(undefined)
 }));
 
-import { writeFile, mkdir, rm } from 'fs/promises';
+import { writeFile, rm } from 'fs/promises';
 import { existsSync } from 'fs';
-import { v4 as uuidv4 } from 'uuid';
 import { readJSONFile } from '../lib/fileUtils.js';
 import * as memoryBM25 from './memoryBM25.js';
 import * as notifications from './notifications.js';
@@ -105,10 +104,6 @@ import {
   invalidateCaches,
   flushBM25Index
 } from './memory.js';
-
-// Default index/embeddings returned by readJSONFile
-const defaultIndex = { version: 1, lastUpdated: '2025-01-01T00:00:00.000Z', count: 0, memories: [] };
-const defaultEmbeddings = { model: null, dimension: 0, vectors: {} };
 
 describe('memory service', () => {
   beforeEach(() => {
@@ -192,15 +187,16 @@ describe('memory service', () => {
       expect(result.embedding).toEqual([0.1, 0.2, 0.3]);
       expect(result.embeddingModel).toBe('test-embedding-model');
       // Should save embeddings file
-      expect(writeFile).toHaveBeenCalledTimes(3); // memory file + index + embeddings
+      const embeddingsCall = writeFile.mock.calls.find(c => c[0].includes('embeddings.json'));
+      expect(embeddingsCall).toBeDefined();
     });
 
     it('should not save embeddings file when no embedding provided', async () => {
       const data = { type: 'fact', content: 'no embedding' };
       await createMemory(data);
 
-      // memory file + index only (2 calls)
-      expect(writeFile).toHaveBeenCalledTimes(2);
+      const embeddingsCall = writeFile.mock.calls.find(c => c[0].includes('embeddings.json'));
+      expect(embeddingsCall).toBeUndefined();
     });
 
     it('should add entry to index and update count', async () => {


### PR DESCRIPTION
## Summary
- Add 268 new tests across 4 previously untested service files
- Total test count: 1393 → 1661 (+19.2%)
- Test files: 51 → 55

## New Test Files
- **`instances.test.js`** (40 tests) — federation, peer CRUD, probing, announce, polling
- **`brain.test.js`** (50 tests) — capture, classification, review, digest, archive
- **`digital-twin.test.js`** (88 tests) — documents, enrichment, export, traits, import, validation
- **`memory.test.js`** (90 tests) — CRUD, search, hybrid search, timeline, tags, linking, stats

## Better Audit Items Addressed
- [HIGH] `server/services/instances.js` — No tests for federation logic
- [HIGH] `server/services/digital-twin.js` — No tests for 2823-line service
- [HIGH] `server/services/memory.js` — No tests for CRUD and search
- [HIGH] `server/services/brain.js` — No service tests (route tests only)

## Test plan
- [x] All 1661 tests pass (55 files)
- [x] No changes to source code — tests only