### PR TITLE
docs: mark M44 P6 genome migration cleanup as complete

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -79,7 +79,7 @@ pm2 logs
 
 ### In Progress
 
-- [ ] **M44 P6**: MeatSpace - Genome/Epigenetic Migration cleanup (genome routes moved, but route comments still reference `/api/digital-twin/genome/` and IdentityTab still renders a Genome card with broken link to `/digital-twin/genome`)
+- [x] **M44 P6**: MeatSpace - Genome/Epigenetic Migration cleanup (route comments updated to `/api/meatspace/genome/`, IdentityTab genome link points to `/meatspace/genome`)
 - [x] **M53 P1**: POST (Power On Self Test) - Foundation + Mental Math (daily cognitive self-test with 5 drill types, scoring, history, config). Phase 1 complete: server service/routes/tests, client UI with drill runner, results, history charts, config editor
 - [ ] **M53 P2**: POST - LLM-Powered Wit & Memory Drills (5 AI drill types: word association, story recall, verbal fluency, wit/comeback, pun/wordplay). Per-drill provider/model config, LLM-scored responses with feedback. Server: meatspacePostLlm.js service, score-llm route. Client: PostLlmDrillRunner component, provider selector in config
 


### PR DESCRIPTION
## Summary
- Mark M44 P6 as complete in PLAN.md — all genome/epigenetic migration cleanup was already done in v1.14.4
- Route comments already reference `/api/meatspace/genome/`
- IdentityTab genome link already points to `/meatspace/genome`
- Zero stale references to `/digital-twin/genome` in source code

## Test plan
- [x] All tests pass
- [x] No code changes — documentation only