### PR TITLE
fix: address unresolved Copilot review from PR #76

### DIFF
--- a/server/lib/fetchWithTimeout.js
+++ b/server/lib/fetchWithTimeout.js
@@ -19,14 +19,19 @@ export async function fetchWithTimeout(url, options = {}, timeoutMs = 15000) {
       // Fallback: propagate caller abort to our controller
       abortHandler = () => controller.abort();
       options.signal.addEventListener('abort', abortHandler, { once: true });
+      if (options.signal.aborted) {
+        controller.abort();
+      }
     }
   }
 
-  return fetch(url, { ...options, signal })
-    .finally(() => {
-      clearTimeout(timeoutId);
-      if (options.signal && abortHandler) {
-        options.signal.removeEventListener('abort', abortHandler);
-      }
-    });
+  try {
+    const response = await fetch(url, { ...options, signal });
+    return response;
+  } finally {
+    clearTimeout(timeoutId);
+    if (options.signal && abortHandler) {
+      options.signal.removeEventListener('abort', abortHandler);
+    }
+  }
 }

--- a/server/lib/fetchWithTimeout.test.js
+++ b/server/lib/fetchWithTimeout.test.js
@@ -64,9 +64,9 @@ describe('fetchWithTimeout', () => {
   });
 
   it('aborts immediately when caller signal is already aborted (fallback path)', async () => {
-    // Force fallback path by making AbortSignal.any non-function
-    const origAny = AbortSignal.any;
-    Object.defineProperty(AbortSignal, 'any', { value: undefined, configurable: true });
+    // Force fallback path by temporarily removing AbortSignal.any
+    const origDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'any');
+    Object.defineProperty(AbortSignal, 'any', { value: undefined, writable: true, configurable: true });
 
     try {
       vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) =>
@@ -83,7 +83,11 @@ describe('fetchWithTimeout', () => {
       await expect(fetchWithTimeout('http://example.com', { signal: callerController.signal }, 60000))
         .rejects.toThrow('aborted');
     } finally {
-      Object.defineProperty(AbortSignal, 'any', { value: origAny, configurable: true });
+      if (origDescriptor) {
+        Object.defineProperty(AbortSignal, 'any', origDescriptor);
+      } else {
+        delete AbortSignal.any;
+      }
     }
   });
 });

--- a/server/lib/fetchWithTimeout.test.js
+++ b/server/lib/fetchWithTimeout.test.js
@@ -4,6 +4,7 @@ import { fetchWithTimeout } from './fetchWithTimeout.js';
 describe('fetchWithTimeout', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it('passes through successful fetch', async () => {
@@ -17,17 +18,20 @@ describe('fetchWithTimeout', () => {
 
   it('aborts after timeout', async () => {
     vi.useFakeTimers();
-    vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) =>
-      new Promise((_resolve, reject) => {
-        opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
-      })
-    ));
+    try {
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) =>
+        new Promise((_resolve, reject) => {
+          opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+        })
+      ));
 
-    const promise = fetchWithTimeout('http://example.com', {}, 100);
-    vi.advanceTimersByTime(100);
+      const promise = fetchWithTimeout('http://example.com', {}, 100);
+      vi.advanceTimersByTime(100);
 
-    await expect(promise).rejects.toThrow('aborted');
-    vi.useRealTimers();
+      await expect(promise).rejects.toThrow('aborted');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('clears timeout on success', async () => {

--- a/server/lib/fetchWithTimeout.test.js
+++ b/server/lib/fetchWithTimeout.test.js
@@ -62,4 +62,28 @@ describe('fetchWithTimeout', () => {
 
     await expect(promise).rejects.toThrow('aborted');
   });
+
+  it('aborts immediately when caller signal is already aborted (fallback path)', async () => {
+    // Force fallback path by making AbortSignal.any non-function
+    const origAny = AbortSignal.any;
+    Object.defineProperty(AbortSignal, 'any', { value: undefined, configurable: true });
+
+    try {
+      vi.stubGlobal('fetch', vi.fn().mockImplementation((_url, opts) =>
+        new Promise((_resolve, reject) => {
+          // Handle already-aborted signal (event won't fire if already aborted)
+          if (opts.signal.aborted) return reject(new DOMException('aborted', 'AbortError'));
+          opts.signal.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+        })
+      ));
+
+      const callerController = new AbortController();
+      callerController.abort(); // Pre-abort before calling fetchWithTimeout
+
+      await expect(fetchWithTimeout('http://example.com', { signal: callerController.signal }, 60000))
+        .rejects.toThrow('aborted');
+    } finally {
+      Object.defineProperty(AbortSignal, 'any', { value: origAny, configurable: true });
+    }
+  });
 });

--- a/server/services/cosRunnerClient.js
+++ b/server/services/cosRunnerClient.js
@@ -128,11 +128,7 @@ export async function spawnAgentViaRunner(options) {
     claudePath
   } = options;
 
-  // Create abort controller for timeout (60 seconds for agent spawn)
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 60000);
-
-  const response = await fetch(`${COS_RUNNER_URL}/spawn`, {
+  const response = await fetchWithTimeout(`${COS_RUNNER_URL}/spawn`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -146,8 +142,7 @@ export async function spawnAgentViaRunner(options) {
       cliArgs,
       claudePath
     }),
-    signal: controller.signal
-  }).finally(() => clearTimeout(timeoutId));
+  }, 60000);
 
   if (!response.ok) {
     const error = await response.json();
@@ -250,10 +245,7 @@ export async function executeCliRunViaRunner(options) {
     timeout
   } = options;
 
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 60000);
-
-  const response = await fetch(`${COS_RUNNER_URL}/run`, {
+  const response = await fetchWithTimeout(`${COS_RUNNER_URL}/run`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
@@ -265,8 +257,7 @@ export async function executeCliRunViaRunner(options) {
       envVars,
       timeout
     }),
-    signal: controller.signal
-  }).finally(() => clearTimeout(timeoutId));
+  }, 60000);
 
   if (!response.ok) {
     const error = await response.json();


### PR DESCRIPTION
## Summary

Addresses 2 unresolved Copilot review threads from PR #76 that was merged before the review loop completed, plus test hardening from the same review round.

- **fetchWithTimeout**: handle pre-aborted caller signals in the `AbortSignal.any` fallback path; use `try/finally` instead of `.finally()` so cleanup runs even on synchronous `fetch()` throws
- **cosRunnerClient**: consolidate `spawnAgentViaRunner` and `executeCliRunViaRunner` to use `fetchWithTimeout` instead of manual AbortController+setTimeout patterns
- **fetchWithTimeout.test.js**: add `vi.unstubAllGlobals()` in `beforeEach` to prevent stub leaks; wrap fake timer test in `try/finally`

## Test plan

- [x] All 1657 server tests pass
- [ ] Verify agent spawn/CLI run still works via CoS runner

Resolves unresolved threads from #76:
- `PRRT_kwDOQx8jQ85ye90v` — pre-aborted signal handling
- `PRRT_kwDOQx8jQ85ye904` — bare fetch in cosRunnerClient