### PR TITLE
fix: null-safe access, fetch cleanup, and test improvements

### DIFF
--- a/server/routes/apps.test.js
+++ b/server/routes/apps.test.js
@@ -32,6 +32,22 @@ vi.mock('../services/streamingDetect.js', () => ({
   parseEcosystemFromPath: vi.fn()
 }));
 
+vi.mock('../services/appUpdater.js', () => ({
+  updateApp: vi.fn()
+}));
+
+vi.mock('../services/cos.js', () => ({
+  getAgents: vi.fn().mockResolvedValue([]),
+  getAgentDates: vi.fn().mockResolvedValue([]),
+  getAgentsByDate: vi.fn().mockResolvedValue([])
+}));
+
+vi.mock('../services/git.js', () => ({
+  stageFiles: vi.fn(),
+  getStatus: vi.fn(),
+  commit: vi.fn()
+}));
+
 // Import mocked modules
 import * as appsService from '../services/apps.js';
 import * as pm2Service from '../services/pm2.js';

--- a/server/services/agentActionExecutor.js
+++ b/server/services/agentActionExecutor.js
@@ -134,7 +134,7 @@ async function executeComment(client, agent, params) {
     console.log(`🤖 AI generating comment for "${agent.name}" on post ${postId}`);
     const post = await client.getPost(postId);
     const commentsResponse = await client.getComments(postId);
-    const comments = Array.isArray(commentsResponse.comments) ? commentsResponse.comments : Array.isArray(commentsResponse) ? commentsResponse : [];
+    const comments = Array.isArray(commentsResponse?.comments) ? commentsResponse.comments : Array.isArray(commentsResponse) ? commentsResponse : [];
     const contentConfig = agent.aiConfig?.content || agent.aiConfig;
 
     if (parentId) {
@@ -330,7 +330,7 @@ async function executeMonitor(client, agent, schedule, params) {
     });
     if (suspended) break;
 
-    const allComments = Array.isArray(commentsResponse.comments) ? commentsResponse.comments : Array.isArray(commentsResponse) ? commentsResponse : [];
+    const allComments = Array.isArray(commentsResponse?.comments) ? commentsResponse.comments : Array.isArray(commentsResponse) ? commentsResponse : [];
     totalComments += allComments.length;
 
     const otherComments = allComments.filter(c => {

--- a/server/services/meatspacePostTraining.test.js
+++ b/server/services/meatspacePostTraining.test.js
@@ -96,10 +96,8 @@ describe('getTrainingStats', () => {
   });
 
   it('computes streak for consecutive days', async () => {
-    const today = new Date();
     const dates = [0, 1, 2].map(d => {
-      const dt = new Date(today);
-      dt.setDate(dt.getDate() - d);
+      const dt = new Date(Date.now() - d * 86400000);
       return dt.toISOString().split('T')[0];
     });
 


### PR DESCRIPTION
## Summary
- Add null-safe comment access and handle pre-aborted signals
- Use try/finally for fetch cleanup instead of manual abort
- Consolidate runner timeouts to use fetchWithTimeout
- Guard fake timers and unstub globals properly in tests

## Test plan
- [ ] Verify cosRunnerClient fetch calls use consolidated timeouts
- [ ] Verify tests pass with proper timer cleanup