### PR TITLE
fix(sync): relay brain changes and reset stale cursors

### DIFF
--- a/server/services/brainSync.js
+++ b/server/services/brainSync.js
@@ -15,18 +15,15 @@ import * as brainSyncLog from './brainSyncLog.js';
 // Entity types stored as JSON (have records with IDs)
 const ENTITY_TYPES = ['people', 'projects', 'ideas', 'admin', 'memories', 'links'];
 
-async function relaySyncChange(op, type, id, record, originInstanceId) {
-  await brainSyncLog.appendChange(op, type, id, record, originInstanceId)
-    .catch(err => console.error(`⚠️ Sync log append failed for relayed ${op} ${type}/${id}: ${err.message}`));
-}
-
 /**
  * Apply remote changes from a peer instance.
+ * Batches relay sync-log appends to reduce lock contention and fs calls.
  * @param {Array} changes - Array of change objects from brainSyncLog
  * @returns {Promise<{inserted: number, updated: number, deleted: number, skipped: number}>}
  */
 export async function applyRemoteChanges(changes) {
   let inserted = 0, updated = 0, deleted = 0, skipped = 0;
+  const relayBatch = [];
 
   for (const change of changes) {
     const { op, type, id, record, originInstanceId } = change;
@@ -40,7 +37,7 @@ export async function applyRemoteChanges(changes) {
       const result = await brainStorage.applyRemoteRecord(type, id, record, 'delete');
       if (result.applied) {
         deleted++;
-        await relaySyncChange(op, type, id, record, originInstanceId);
+        relayBatch.push({ op, type, id, record, originInstanceId });
       } else {
         skipped++;
       }
@@ -50,13 +47,19 @@ export async function applyRemoteChanges(changes) {
       if (result.applied) {
         if (op === 'create') inserted++;
         else updated++;
-        await relaySyncChange(op, type, id, record, originInstanceId);
+        relayBatch.push({ op, type, id, record, originInstanceId });
       } else {
         skipped++;
       }
     } else {
       skipped++;
     }
+  }
+
+  // Batch-append all applied changes to the sync log in a single lock acquisition
+  if (relayBatch.length > 0) {
+    await brainSyncLog.appendChanges(relayBatch)
+      .catch(err => console.error(`⚠️ Sync log batch append failed (${relayBatch.length} entries): ${err.message}`));
   }
 
   console.log(`🔄 Brain sync applied: ${inserted} inserted, ${updated} updated, ${deleted} deleted, ${skipped} skipped`);

--- a/server/services/brainSync.js
+++ b/server/services/brainSync.js
@@ -3,14 +3,22 @@
  *
  * Applies remote brain changes from peer PortOS instances.
  * Uses last-writer-wins conflict resolution by updatedAt timestamp.
- * Writes directly to storage without triggering brainEvents or sync log
- * to prevent echo loops.
+ * Writes directly to storage without triggering brainEvents.
+ * Logs applied changes to the local sync log so they relay to other peers
+ * and sync status counts reflect received data. Echo prevention is handled
+ * by the LWW dedup in applyRemoteRecord (same updatedAt = skip).
  */
 
 import * as brainStorage from './brainStorage.js';
+import * as brainSyncLog from './brainSyncLog.js';
 
 // Entity types stored as JSON (have records with IDs)
 const ENTITY_TYPES = ['people', 'projects', 'ideas', 'admin', 'memories', 'links'];
+
+async function relaySyncChange(op, type, id, record, originInstanceId) {
+  await brainSyncLog.appendChange(op, type, id, record, originInstanceId)
+    .catch(err => console.error(`⚠️ Sync log append failed for relayed ${op} ${type}/${id}: ${err.message}`));
+}
 
 /**
  * Apply remote changes from a peer instance.
@@ -21,7 +29,7 @@ export async function applyRemoteChanges(changes) {
   let inserted = 0, updated = 0, deleted = 0, skipped = 0;
 
   for (const change of changes) {
-    const { op, type, id, record } = change;
+    const { op, type, id, record, originInstanceId } = change;
 
     if (!ENTITY_TYPES.includes(type)) {
       skipped++;
@@ -30,14 +38,19 @@ export async function applyRemoteChanges(changes) {
 
     if (op === 'delete') {
       const result = await brainStorage.applyRemoteRecord(type, id, record, 'delete');
-      if (result.applied) deleted++;
-      else skipped++;
+      if (result.applied) {
+        deleted++;
+        await relaySyncChange(op, type, id, record, originInstanceId);
+      } else {
+        skipped++;
+      }
     } else if (op === 'create' || op === 'update') {
       if (!record) { skipped++; continue; }
       const result = await brainStorage.applyRemoteRecord(type, id, record, op);
       if (result.applied) {
         if (op === 'create') inserted++;
         else updated++;
+        await relaySyncChange(op, type, id, record, originInstanceId);
       } else {
         skipped++;
       }

--- a/server/services/brainSync.test.js
+++ b/server/services/brainSync.test.js
@@ -4,7 +4,12 @@ vi.mock('./brainStorage.js', () => ({
   applyRemoteRecord: vi.fn()
 }));
 
+vi.mock('./brainSyncLog.js', () => ({
+  appendChange: vi.fn().mockResolvedValue({})
+}));
+
 import { applyRemoteRecord } from './brainStorage.js';
+import { appendChange } from './brainSyncLog.js';
 import { applyRemoteChanges } from './brainSync.js';
 
 describe('brainSync', () => {
@@ -82,6 +87,26 @@ describe('brainSync', () => {
 
     expect(result.skipped).toBe(1);
     expect(result.updated).toBe(0);
+  });
+
+  it('logs applied changes to sync log for relay to other peers', async () => {
+    applyRemoteRecord.mockResolvedValue({ applied: true });
+
+    await applyRemoteChanges([
+      { op: 'create', type: 'people', id: 'p1', record: { name: 'A' }, originInstanceId: 'peer-1' }
+    ]);
+
+    expect(appendChange).toHaveBeenCalledWith('create', 'people', 'p1', { name: 'A' }, 'peer-1');
+  });
+
+  it('does not log skipped changes to sync log', async () => {
+    applyRemoteRecord.mockResolvedValue({ applied: false, reason: 'local_newer' });
+
+    await applyRemoteChanges([
+      { op: 'update', type: 'people', id: 'p1', record: { name: 'Old' }, originInstanceId: 'peer-1' }
+    ]);
+
+    expect(appendChange).not.toHaveBeenCalled();
   });
 
   it('handles mixed operations correctly', async () => {

--- a/server/services/brainSync.test.js
+++ b/server/services/brainSync.test.js
@@ -5,11 +5,11 @@ vi.mock('./brainStorage.js', () => ({
 }));
 
 vi.mock('./brainSyncLog.js', () => ({
-  appendChange: vi.fn().mockResolvedValue({})
+  appendChanges: vi.fn().mockResolvedValue([])
 }));
 
 import { applyRemoteRecord } from './brainStorage.js';
-import { appendChange } from './brainSyncLog.js';
+import { appendChanges } from './brainSyncLog.js';
 import { applyRemoteChanges } from './brainSync.js';
 
 describe('brainSync', () => {
@@ -96,7 +96,9 @@ describe('brainSync', () => {
       { op: 'create', type: 'people', id: 'p1', record: { name: 'A' }, originInstanceId: 'peer-1' }
     ]);
 
-    expect(appendChange).toHaveBeenCalledWith('create', 'people', 'p1', { name: 'A' }, 'peer-1');
+    expect(appendChanges).toHaveBeenCalledWith([
+      { op: 'create', type: 'people', id: 'p1', record: { name: 'A' }, originInstanceId: 'peer-1' }
+    ]);
   });
 
   it('does not log skipped changes to sync log', async () => {
@@ -106,7 +108,7 @@ describe('brainSync', () => {
       { op: 'update', type: 'people', id: 'p1', record: { name: 'Old' }, originInstanceId: 'peer-1' }
     ]);
 
-    expect(appendChange).not.toHaveBeenCalled();
+    expect(appendChanges).not.toHaveBeenCalled();
   });
 
   it('handles mixed operations correctly', async () => {

--- a/server/services/brainSyncLog.js
+++ b/server/services/brainSyncLog.js
@@ -85,15 +85,19 @@ export async function appendChanges(entries) {
   if (!entries.length) return [];
   return withLock(async () => {
     await ensureDir();
+    const startSeq = currentSeq;
     const results = [];
     const lines = [];
+    let nextSeq = startSeq;
     for (const { op, type, id, record, originInstanceId } of entries) {
-      currentSeq++;
-      const entry = { seq: currentSeq, op, type, id, record, originInstanceId, ts: new Date().toISOString() };
+      nextSeq++;
+      const entry = { seq: nextSeq, op, type, id, record, originInstanceId, ts: new Date().toISOString() };
       lines.push(JSON.stringify(entry));
       results.push(entry);
     }
     await appendFile(SYNC_LOG_FILE, lines.join('\n') + '\n');
+    // Only advance currentSeq after successful write
+    currentSeq = nextSeq;
     return results;
   });
 }

--- a/server/services/brainSyncLog.js
+++ b/server/services/brainSyncLog.js
@@ -95,9 +95,10 @@ export async function appendChanges(entries) {
       lines.push(JSON.stringify(entry));
       results.push(entry);
     }
-    await appendFile(SYNC_LOG_FILE, lines.join('\n') + '\n');
-    // Only advance currentSeq after successful write
+    // Reserve sequence numbers before write to avoid reuse on partial failure
+    // (matches appendChange semantics where currentSeq advances pre-write)
     currentSeq = nextSeq;
+    await appendFile(SYNC_LOG_FILE, lines.join('\n') + '\n');
     return results;
   });
 }

--- a/server/services/brainSyncLog.js
+++ b/server/services/brainSyncLog.js
@@ -79,6 +79,26 @@ export async function appendChange(op, type, id, record, originInstanceId) {
 }
 
 /**
+ * Append multiple change entries in a single mutex-guarded batch (reduces lock contention)
+ */
+export async function appendChanges(entries) {
+  if (!entries.length) return [];
+  return withLock(async () => {
+    await ensureDir();
+    const results = [];
+    const lines = [];
+    for (const { op, type, id, record, originInstanceId } of entries) {
+      currentSeq++;
+      const entry = { seq: currentSeq, op, type, id, record, originInstanceId, ts: new Date().toISOString() };
+      lines.push(JSON.stringify(entry));
+      results.push(entry);
+    }
+    await appendFile(SYNC_LOG_FILE, lines.join('\n') + '\n');
+    return results;
+  });
+}
+
+/**
  * Get changes since a given sequence number
  */
 // Mutex-guarded to prevent reading a partially-written file during compaction.

--- a/server/services/brainSyncLog.test.js
+++ b/server/services/brainSyncLog.test.js
@@ -26,6 +26,7 @@ import {
   initSyncLog,
   getCurrentSeq,
   appendChange,
+  appendChanges,
   getChangesSince,
   compactLog
 } from './brainSyncLog.js';
@@ -120,6 +121,76 @@ describe('brainSyncLog', () => {
       expect(written.endsWith('\n')).toBe(true);
       const parsed = JSON.parse(written.trim());
       expect(parsed.op).toBe('delete');
+    });
+  });
+
+  describe('appendChanges', () => {
+    beforeEach(async () => {
+      existsSync.mockReturnValue(false);
+      mkdir.mockResolvedValue();
+      await initSyncLog();
+      existsSync.mockReturnValue(true);
+      appendFile.mockResolvedValue();
+    });
+
+    it('increments seq across all entries in the batch', async () => {
+      const entries = await appendChanges([
+        { op: 'create', type: 'people', id: 'p1', record: { name: 'A' }, originInstanceId: 'inst-1' },
+        { op: 'update', type: 'ideas', id: 'i1', record: { title: 'B' }, originInstanceId: 'inst-1' },
+        { op: 'delete', type: 'projects', id: 'pr1', record: null, originInstanceId: 'inst-2' }
+      ]);
+
+      expect(entries).toHaveLength(3);
+      expect(entries[0].seq).toBe(1);
+      expect(entries[1].seq).toBe(2);
+      expect(entries[2].seq).toBe(3);
+      expect(getCurrentSeq()).toBe(3);
+    });
+
+    it('makes a single appendFile call for the entire batch', async () => {
+      await appendChanges([
+        { op: 'create', type: 'people', id: 'p1', record: { name: 'A' }, originInstanceId: 'inst-1' },
+        { op: 'update', type: 'people', id: 'p2', record: { name: 'B' }, originInstanceId: 'inst-1' }
+      ]);
+
+      expect(appendFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes newline-separated JSON entries ending with newline', async () => {
+      await appendChanges([
+        { op: 'create', type: 'people', id: 'p1', record: { name: 'A' }, originInstanceId: 'inst-1' },
+        { op: 'delete', type: 'ideas', id: 'i1', record: null, originInstanceId: 'inst-2' }
+      ]);
+
+      const written = appendFile.mock.calls[0][1];
+      expect(written.endsWith('\n')).toBe(true);
+      const lines = written.trim().split('\n');
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]).op).toBe('create');
+      expect(JSON.parse(lines[1]).op).toBe('delete');
+    });
+
+    it('returns empty array for empty input', async () => {
+      const entries = await appendChanges([]);
+
+      expect(entries).toEqual([]);
+      expect(appendFile).not.toHaveBeenCalled();
+    });
+
+    it('returns entries with correct shape', async () => {
+      const entries = await appendChanges([
+        { op: 'create', type: 'links', id: 'l1', record: { url: 'http://x' }, originInstanceId: 'peer-3' }
+      ]);
+
+      expect(entries[0]).toMatchObject({
+        seq: expect.any(Number),
+        op: 'create',
+        type: 'links',
+        id: 'l1',
+        record: { url: 'http://x' },
+        originInstanceId: 'peer-3',
+        ts: expect.any(String)
+      });
     });
   });
 

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -165,13 +165,21 @@ function detectCursorReset(cursor, peer) {
   }
 
   // Memory: BigInt comparison (BIGSERIAL can exceed Number.MAX_SAFE_INTEGER)
-  const cursorMemStr = corrected.memorySeq ?? '0';
-  const peerMemStr = remote.memorySeq ?? '0';
-  const cursorMem = safeBigInt(cursorMemStr);
-  const peerMem = safeBigInt(peerMemStr);
-  if (cursorMem > 0n && cursorMem > peerMem) {
-    console.log(`🔄 Memory cursor reset for ${peer.name}: cursor ${cursorMemStr} > peer max ${peerMemStr}`);
-    corrected.memorySeq = '0';
+  // Only check when peer reports a numeric memorySeq (null means non-Postgres peer)
+  const remoteMemRaw = remote.memorySeq;
+  const hasNumericRemoteMem = remoteMemRaw != null && (
+    typeof remoteMemRaw === 'bigint' ||
+    (typeof remoteMemRaw === 'number' && Number.isFinite(remoteMemRaw) && remoteMemRaw >= 0) ||
+    (typeof remoteMemRaw === 'string' && /^\d+$/.test(remoteMemRaw.trim()))
+  );
+  if (hasNumericRemoteMem) {
+    const cursorMemStr = corrected.memorySeq ?? '0';
+    const cursorMem = safeBigInt(cursorMemStr);
+    const peerMem = safeBigInt(remoteMemRaw);
+    if (cursorMem > 0n && cursorMem > peerMem) {
+      console.log(`🔄 Memory cursor reset for ${peer.name}: cursor ${cursorMemStr} > peer max ${String(remoteMemRaw)}`);
+      corrected.memorySeq = '0';
+    }
   }
 
   return corrected;

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -134,6 +134,34 @@ async function syncMemoryFromPeer(peer, cursor) {
 }
 
 /**
+ * Detect and reset stale cursors when peer's sequence has been reset
+ * (e.g. database rebuild). Returns corrected cursor.
+ */
+function detectCursorReset(cursor, peer) {
+  const corrected = { ...cursor };
+  const remote = peer.remoteSyncSeqs;
+  if (!remote) return corrected;
+
+  // Brain: integer comparison
+  const cursorBrain = corrected.brainSeq ?? 0;
+  const peerBrain = remote.brainSeq ?? 0;
+  if (cursorBrain > 0 && cursorBrain > peerBrain) {
+    console.log(`🔄 Brain cursor reset for ${peer.name}: cursor ${cursorBrain} > peer max ${peerBrain}`);
+    corrected.brainSeq = 0;
+  }
+
+  // Memory: string-as-number comparison (BIGSERIAL)
+  const cursorMem = Number(corrected.memorySeq ?? '0');
+  const peerMem = Number(remote.memorySeq ?? '0');
+  if (cursorMem > 0 && cursorMem > peerMem) {
+    console.log(`🔄 Memory cursor reset for ${peer.name}: cursor ${cursorMem} > peer max ${peerMem}`);
+    corrected.memorySeq = '0';
+  }
+
+  return corrected;
+}
+
+/**
  * Sync all data from a single peer
  */
 export async function syncWithPeer(peer) {
@@ -146,8 +174,10 @@ export async function syncWithPeer(peer) {
   syncingPeers.add(peerId);
 
   // Read cursor snapshot outside lock so network I/O doesn't block other peers
+  // Also detect and reset stale cursors (e.g. peer DB was rebuilt)
   const cursor = await readCursors((cursors) => {
-    return { ...(cursors[peerId] || {}) };
+    const raw = { ...(cursors[peerId] || {}) };
+    return detectCursorReset(raw, peer);
   });
 
   try {

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -134,6 +134,20 @@ async function syncMemoryFromPeer(peer, cursor) {
 }
 
 /**
+ * Safely parse a value to BigInt for BIGSERIAL comparison.
+ * Returns 0n for invalid/empty/negative inputs.
+ */
+function safeBigInt(value) {
+  if (typeof value === 'bigint') return value;
+  if (typeof value === 'number') return Number.isFinite(value) && value >= 0 ? BigInt(Math.trunc(value)) : 0n;
+  if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
+    const parsed = BigInt(value.trim());
+    return parsed;
+  }
+  return 0n;
+}
+
+/**
  * Detect and reset stale cursors when peer's sequence has been reset
  * (e.g. database rebuild). Returns corrected cursor.
  */
@@ -150,11 +164,13 @@ function detectCursorReset(cursor, peer) {
     corrected.brainSeq = 0;
   }
 
-  // Memory: string-as-number comparison (BIGSERIAL)
-  const cursorMem = Number(corrected.memorySeq ?? '0');
-  const peerMem = Number(remote.memorySeq ?? '0');
-  if (cursorMem > 0 && cursorMem > peerMem) {
-    console.log(`🔄 Memory cursor reset for ${peer.name}: cursor ${cursorMem} > peer max ${peerMem}`);
+  // Memory: BigInt comparison (BIGSERIAL can exceed Number.MAX_SAFE_INTEGER)
+  const cursorMemStr = corrected.memorySeq ?? '0';
+  const peerMemStr = remote.memorySeq ?? '0';
+  const cursorMem = safeBigInt(cursorMemStr);
+  const peerMem = safeBigInt(peerMemStr);
+  if (cursorMem > 0n && cursorMem > peerMem) {
+    console.log(`🔄 Memory cursor reset for ${peer.name}: cursor ${cursorMemStr} > peer max ${peerMemStr}`);
     corrected.memorySeq = '0';
   }
 

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -150,6 +150,11 @@ function safeBigInt(value) {
 /**
  * Detect and reset stale cursors when peer's sequence has been reset
  * (e.g. database rebuild). Returns corrected cursor.
+ *
+ * Uses cached remoteSyncSeqs from periodic peer probing. If null (probe hasn't
+ * run yet or failed), we skip detection — a real reset will be caught on the
+ * next probe cycle. Stale probe data may trigger a conservative full re-sync
+ * (cursor reset to 0), which is safe since sync is idempotent (LWW dedup).
  */
 function detectCursorReset(cursor, peer) {
   const corrected = { ...cursor };

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -162,11 +162,17 @@ function detectCursorReset(cursor, peer) {
   if (!remote) return corrected;
 
   // Brain: integer comparison
-  const cursorBrain = corrected.brainSeq ?? 0;
-  const peerBrain = remote.brainSeq ?? 0;
-  if (cursorBrain > 0 && cursorBrain > peerBrain) {
-    console.log(`🔄 Brain cursor reset for ${peer.name}: cursor ${cursorBrain} > peer max ${peerBrain}`);
-    corrected.brainSeq = 0;
+  // Only check when peer reports a finite non-negative brainSeq (older peers may omit it)
+  const remoteBrainRaw = remote.brainSeq;
+  const hasNumericRemoteBrain = typeof remoteBrainRaw === 'number' &&
+    Number.isFinite(remoteBrainRaw) &&
+    remoteBrainRaw >= 0;
+  if (hasNumericRemoteBrain) {
+    const cursorBrain = corrected.brainSeq ?? 0;
+    if (cursorBrain > 0 && cursorBrain > remoteBrainRaw) {
+      console.log(`🔄 Brain cursor reset for ${peer.name}: cursor ${cursorBrain} > peer max ${remoteBrainRaw}`);
+      corrected.brainSeq = 0;
+    }
   }
 
   // Memory: BigInt comparison (BIGSERIAL can exceed Number.MAX_SAFE_INTEGER)

--- a/server/services/syncOrchestrator.js
+++ b/server/services/syncOrchestrator.js
@@ -138,7 +138,7 @@ async function syncMemoryFromPeer(peer, cursor) {
  * Returns 0n for invalid/empty/negative inputs.
  */
 function safeBigInt(value) {
-  if (typeof value === 'bigint') return value;
+  if (typeof value === 'bigint') return value >= 0n ? value : 0n;
   if (typeof value === 'number') return Number.isFinite(value) && value >= 0 ? BigInt(Math.trunc(value)) : 0n;
   if (typeof value === 'string' && /^\d+$/.test(value.trim())) {
     const parsed = BigInt(value.trim());

--- a/server/services/syncOrchestrator.test.js
+++ b/server/services/syncOrchestrator.test.js
@@ -151,9 +151,13 @@ describe('syncOrchestrator', () => {
 
       // Simulate stale cursor (we previously synced to 1127 but peer reset to 2)
       const { readJSONFile } = await import('../lib/fileUtils.js');
-      readJSONFile.mockResolvedValue({
+      const cursorData = {
         [peerWithReset.instanceId]: { brainSeq: 0, memorySeq: '1127', lastSyncAt: '2026-01-01T00:00:00.000Z' }
-      });
+      };
+      // readJSONFile is called 3 times in syncWithPeer: readCursors + 2x withCursors
+      readJSONFile.mockResolvedValueOnce(cursorData)
+        .mockResolvedValueOnce(cursorData)
+        .mockResolvedValueOnce(cursorData);
 
       // Brain: no changes
       mockFetch
@@ -188,9 +192,13 @@ describe('syncOrchestrator', () => {
       };
 
       const { readJSONFile } = await import('../lib/fileUtils.js');
-      readJSONFile.mockResolvedValue({
+      const cursorData = {
         [peerWithReset.instanceId]: { brainSeq: 5, memorySeq: '10', lastSyncAt: '2026-01-01T00:00:00.000Z' }
-      });
+      };
+      // readJSONFile is called 3 times in syncWithPeer: readCursors + 2x withCursors
+      readJSONFile.mockResolvedValueOnce(cursorData)
+        .mockResolvedValueOnce(cursorData)
+        .mockResolvedValueOnce(cursorData);
 
       // Brain: returns data from seq 0 (after cursor reset)
       mockFetch

--- a/server/services/syncOrchestrator.test.js
+++ b/server/services/syncOrchestrator.test.js
@@ -143,6 +143,80 @@ describe('syncOrchestrator', () => {
       expect(result.brain.totalApplied).toBe(2);
     });
 
+    it('resets memory cursor when peer DB was rebuilt (cursor > peerMax)', async () => {
+      const peerWithReset = {
+        ...mockPeer,
+        remoteSyncSeqs: { brainSeq: 0, memorySeq: '2' }
+      };
+
+      // Simulate stale cursor (we previously synced to 1127 but peer reset to 2)
+      const { readJSONFile } = await import('../lib/fileUtils.js');
+      readJSONFile.mockResolvedValue({
+        [peerWithReset.instanceId]: { brainSeq: 0, memorySeq: '1127', lastSyncAt: '2026-01-01T00:00:00.000Z' }
+      });
+
+      // Brain: no changes
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ changes: [], maxSeq: 0, hasMore: false })
+        })
+        // Memory: returns data from seq 0 (after cursor reset)
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            memories: [{ id: 'm1', content: 'new' }],
+            maxSequence: '2',
+            hasMore: false
+          })
+        });
+
+      applyMemoryChanges.mockResolvedValue({ inserted: 1, updated: 0 });
+
+      const result = await syncWithPeer(peerWithReset);
+
+      // Memory sync should have fetched since=0 (reset), not since=1127
+      const memoryCall = mockFetch.mock.calls.find(c => c[0].includes('/api/memory/sync'));
+      expect(memoryCall[0]).toContain('since=0');
+      expect(result.memory.totalApplied).toBe(1);
+    });
+
+    it('resets brain cursor when peer sync log was rebuilt', async () => {
+      const peerWithReset = {
+        ...mockPeer,
+        remoteSyncSeqs: { brainSeq: 0, memorySeq: '10' }
+      };
+
+      const { readJSONFile } = await import('../lib/fileUtils.js');
+      readJSONFile.mockResolvedValue({
+        [peerWithReset.instanceId]: { brainSeq: 5, memorySeq: '10', lastSyncAt: '2026-01-01T00:00:00.000Z' }
+      });
+
+      // Brain: returns data from seq 0 (after cursor reset)
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            changes: [{ seq: 1, op: 'create', type: 'people', id: 'p1', record: {} }],
+            maxSeq: 1,
+            hasMore: false
+          })
+        })
+        // Memory: no changes
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ memories: [], maxSequence: '10', hasMore: false })
+        });
+
+      applyBrainChanges.mockResolvedValue({ inserted: 1, updated: 0, deleted: 0, skipped: 0 });
+
+      const result = await syncWithPeer(peerWithReset);
+
+      const brainCall = mockFetch.mock.calls.find(c => c[0].includes('/api/brain/sync'));
+      expect(brainCall[0]).toContain('since=0');
+      expect(result.brain.totalApplied).toBe(1);
+    });
+
     it('handles fetch failure gracefully', async () => {
       mockFetch.mockRejectedValue(new Error('Network error'));
 

--- a/server/services/syncOrchestrator.test.js
+++ b/server/services/syncOrchestrator.test.js
@@ -154,10 +154,7 @@ describe('syncOrchestrator', () => {
       const cursorData = {
         [peerWithReset.instanceId]: { brainSeq: 0, memorySeq: '1127', lastSyncAt: '2026-01-01T00:00:00.000Z' }
       };
-      // readJSONFile is called 3 times in syncWithPeer: readCursors + 2x withCursors
-      readJSONFile.mockResolvedValueOnce(cursorData)
-        .mockResolvedValueOnce(cursorData)
-        .mockResolvedValueOnce(cursorData);
+      readJSONFile.mockResolvedValue(cursorData);
 
       // Brain: no changes
       mockFetch
@@ -195,10 +192,7 @@ describe('syncOrchestrator', () => {
       const cursorData = {
         [peerWithReset.instanceId]: { brainSeq: 5, memorySeq: '10', lastSyncAt: '2026-01-01T00:00:00.000Z' }
       };
-      // readJSONFile is called 3 times in syncWithPeer: readCursors + 2x withCursors
-      readJSONFile.mockResolvedValueOnce(cursorData)
-        .mockResolvedValueOnce(cursorData)
-        .mockResolvedValueOnce(cursorData);
+      readJSONFile.mockResolvedValue(cursorData);
 
       // Brain: returns data from seq 0 (after cursor reset)
       mockFetch


### PR DESCRIPTION
## Summary
- Brain sync now logs applied remote changes to the local sync log, enabling relay to other peers and accurate sync status display (fixes Brain showing 0/0 when peers have received data)
- Adds stale cursor detection: when a peer's DB is rebuilt and sequences restart, cursors exceeding the peer's max are automatically reset to 0 so sync resumes instead of being permanently stuck (fixes Memory showing 1127/2 on rebuilt peer)

## Test plan
- [x] New tests for brain sync relay logging (applied changes logged, skipped changes not logged)
- [x] New tests for cursor reset detection (memory cursor > peerMax, brain cursor > peerMax)
- [x] All 1824 existing tests pass