### PR TITLE
fix(post): route LLM drills correctly during loading, support text answers in element flash

### DIFF
--- a/client/src/components/meatspace/post/PostDrillRunner.jsx
+++ b/client/src/components/meatspace/post/PostDrillRunner.jsx
@@ -1,12 +1,17 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { CheckCircle, XCircle } from 'lucide-react';
 
+import { MEMORY_DRILL_TYPES } from './constants';
+
 const DRILL_LABELS = {
   'doubling-chain': 'Doubling Chain',
   'serial-subtraction': 'Serial Subtraction',
   'multiplication': 'Multiplication',
   'powers': 'Powers',
-  'estimation': 'Estimation'
+  'estimation': 'Estimation',
+  'memory-fill-blank': 'Memory Fill Blank',
+  'memory-sequence': 'Memory Sequence',
+  'memory-element-flash': 'Element Flash',
 };
 
 export default function PostDrillRunner({ session }) {
@@ -87,6 +92,7 @@ export default function PostDrillRunner({ session }) {
   if (state !== 'drilling' || !currentDrill) return null;
 
   const question = currentDrill.questions[currentQuestionIndex];
+  const isTextDrill = MEMORY_DRILL_TYPES.includes(currentDrill.type);
   const timePct = timeLimitMs > 0 ? (timeLeft / timeLimitMs) * 100 : 0;
   const progressPct = totalQuestions > 0 ? ((currentQuestionIndex + 1) / totalQuestions) * 100 : 0;
 
@@ -181,6 +187,9 @@ export default function PostDrillRunner({ session }) {
 
       {/* Question */}
       <div className="text-center py-8">
+        {question?.promptLabel && (
+          <div className="text-sm text-gray-500 mb-2">{question.promptLabel}</div>
+        )}
         <div className="text-4xl font-mono font-bold text-white">
           {question?.prompt}
         </div>
@@ -190,8 +199,8 @@ export default function PostDrillRunner({ session }) {
       <form onSubmit={handleSubmit} className="flex gap-3">
         <input
           ref={inputRef}
-          type="number"
-          inputMode="numeric"
+          type={isTextDrill ? 'text' : 'number'}
+          inputMode={isTextDrill ? 'text' : 'numeric'}
           value={inputValue}
           onChange={e => setInputValue(e.target.value)}
           placeholder="Answer"

--- a/client/src/components/meatspace/post/PostDrillRunner.jsx
+++ b/client/src/components/meatspace/post/PostDrillRunner.jsx
@@ -92,7 +92,9 @@ export default function PostDrillRunner({ session }) {
   if (state !== 'drilling' || !currentDrill) return null;
 
   const question = currentDrill.questions[currentQuestionIndex];
-  const isTextDrill = MEMORY_DRILL_TYPES.includes(currentDrill.type);
+  const isTextDrill =
+    MEMORY_DRILL_TYPES.includes(currentDrill.type) &&
+    currentDrill.type !== 'memory-fill-blank';
   const timePct = timeLimitMs > 0 ? (timeLeft / timeLimitMs) * 100 : 0;
   const progressPct = totalQuestions > 0 ? ((currentQuestionIndex + 1) / totalQuestions) * 100 : 0;
 

--- a/client/src/components/meatspace/post/PostDrillRunner.jsx
+++ b/client/src/components/meatspace/post/PostDrillRunner.jsx
@@ -92,9 +92,7 @@ export default function PostDrillRunner({ session }) {
   if (state !== 'drilling' || !currentDrill) return null;
 
   const question = currentDrill.questions[currentQuestionIndex];
-  const isTextDrill =
-    MEMORY_DRILL_TYPES.includes(currentDrill.type) &&
-    currentDrill.type !== 'memory-fill-blank';
+  const isTextDrill = MEMORY_DRILL_TYPES.includes(currentDrill.type);
   const timePct = timeLimitMs > 0 ? (timeLeft / timeLimitMs) * 100 : 0;
   const progressPct = totalQuestions > 0 ? ((currentQuestionIndex + 1) / totalQuestions) * 100 : 0;
 

--- a/client/src/components/meatspace/post/constants.js
+++ b/client/src/components/meatspace/post/constants.js
@@ -1,5 +1,6 @@
 export const LLM_DRILL_TYPES = ['word-association', 'story-recall', 'verbal-fluency', 'wit-comeback', 'pun-wordplay', 'what-if', 'alternative-uses', 'story-prompt', 'invention-pitch', 'reframe'];
-export const MEMORY_DRILL_TYPES = ['memory-fill-blank', 'memory-sequence', 'memory-element-flash'];
+// memory-fill-blank excluded: uses answers[] array instead of expected, needs dedicated runner
+export const MEMORY_DRILL_TYPES = ['memory-sequence', 'memory-element-flash'];
 
 // Domain definitions for 5-minute balanced sessions
 export const DOMAINS = {
@@ -17,7 +18,7 @@ export const DOMAINS = {
     color: 'text-green-400',
     bgColor: 'bg-green-500/20',
     timeBudgetSec: 90,
-    drillTypes: ['memory-fill-blank', 'memory-sequence', 'memory-element-flash'],
+    drillTypes: ['memory-sequence', 'memory-element-flash'],
   },
   wordplay: {
     label: 'Wordplay',

--- a/client/src/components/meatspace/post/constants.js
+++ b/client/src/components/meatspace/post/constants.js
@@ -1,6 +1,9 @@
 export const LLM_DRILL_TYPES = ['word-association', 'story-recall', 'verbal-fluency', 'wit-comeback', 'pun-wordplay', 'what-if', 'alternative-uses', 'story-prompt', 'invention-pitch', 'reframe'];
-// memory-fill-blank excluded: uses answers[] array instead of expected, needs dedicated runner
 export const MEMORY_DRILL_TYPES = ['memory-sequence', 'memory-element-flash'];
+
+// Drill types valid elsewhere but not yet supported by the POST runner.
+// These use answers[] arrays instead of expected and need dedicated runners.
+export const POST_UNSUPPORTED_DRILL_TYPES = ['memory-fill-blank'];
 
 // Domain definitions for 5-minute balanced sessions
 export const DOMAINS = {

--- a/client/src/components/meatspace/tabs/PostTab.jsx
+++ b/client/src/components/meatspace/tabs/PostTab.jsx
@@ -109,7 +109,7 @@ export default function PostTab() {
         return (
           <div className="flex flex-col items-center justify-center h-64 gap-3">
             <Loader size={32} className="text-purple-400 animate-spin" />
-            <div className="text-gray-400">Generating {currentDrillConfig?.type ? currentDrillConfig.type.replace(/-/g, ' ') : 'drill'}...</div>
+            <div className="text-gray-400">Processing {currentDrillConfig?.type ? currentDrillConfig.type.replace(/-/g, ' ') : 'drill'}...</div>
           </div>
         );
       }

--- a/client/src/components/meatspace/tabs/PostTab.jsx
+++ b/client/src/components/meatspace/tabs/PostTab.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { Loader } from 'lucide-react';
 import { getPostConfig, getPostSessions } from '../../../services/api';
 import { usePostSession } from '../../../hooks/usePostSession';
 import PostSessionLauncher from '../post/PostSessionLauncher';
@@ -79,7 +80,11 @@ export default function PostTab() {
 
   // When between drills, show transition (handled in switch/case below)
 
-  const isLlmDrill = session.currentDrill && LLM_DRILL_TYPES.includes(session.currentDrill.type);
+  // Use queued drill config type (always current) rather than currentDrill (stale during loading transitions)
+  const currentDrillConfig = session.drills[session.currentDrillIndex];
+  const isLlmDrill = currentDrillConfig
+    ? LLM_DRILL_TYPES.includes(currentDrillConfig.type)
+    : session.currentDrill && LLM_DRILL_TYPES.includes(session.currentDrill.type);
 
   // Show transition between drills
   if (session.state === 'between-drills' && view === 'running') {
@@ -100,8 +105,15 @@ export default function PostTab() {
 
   switch (view) {
     case 'running':
+      if (session.state === 'loading' && isLlmDrill) {
+        return (
+          <div className="flex flex-col items-center justify-center h-64 gap-3">
+            <Loader size={32} className="text-purple-400 animate-spin" />
+            <div className="text-gray-400">Generating {currentDrillConfig?.type ? currentDrillConfig.type.replace(/-/g, ' ') : 'drill'}...</div>
+          </div>
+        );
+      }
       if (isLlmDrill) {
-        const drillConfig = session.drills[session.currentDrillIndex];
         return (
           <PostLlmDrillRunner
             drill={session.currentDrill}
@@ -110,8 +122,8 @@ export default function PostTab() {
             drillCount={session.drillCount}
             onComplete={session.completeLlmDrill}
             isTraining={session.isTraining}
-            providerId={drillConfig?.providerId}
-            model={drillConfig?.model}
+            providerId={currentDrillConfig?.providerId}
+            model={currentDrillConfig?.model}
           />
         );
       }

--- a/client/src/hooks/usePostSession.js
+++ b/client/src/hooks/usePostSession.js
@@ -137,11 +137,13 @@ export function usePostSession() {
       answered = value;
       correct = value !== null && String(value).toLowerCase().trim() === String(q.expected).toLowerCase().trim();
     } else if (currentDrill.type === 'estimation') {
-      answered = value === null ? null : Number(value);
+      const num = value === null ? null : Number(value);
+      answered = (num !== null && isNaN(num)) ? null : num;
       const tolerance = (currentDrill.config?.tolerancePct || 10) / 100;
       correct = answered !== null && Math.abs(answered - q.expected) <= Math.abs(q.expected * tolerance);
     } else {
-      answered = value === null ? null : Number(value);
+      const num = value === null ? null : Number(value);
+      answered = (num !== null && isNaN(num)) ? null : num;
       correct = answered === q.expected;
     }
 

--- a/client/src/hooks/usePostSession.js
+++ b/client/src/hooks/usePostSession.js
@@ -128,14 +128,14 @@ export function usePostSession() {
     const q = currentDrill.questions?.[currentQuestionIndex];
     if (!q) return;
     const responseMs = Date.now() - questionStartRef.current;
-    const isTextAnswer = typeof q.expected === 'string' && isNaN(Number(q.expected));
+    const isTextAnswer = typeof q.expected === 'string';
 
     // For estimation drills, check within tolerance
     let correct;
     let answered;
     if (isTextAnswer) {
       answered = value;
-      correct = value !== null && value.toLowerCase().trim() === q.expected.toLowerCase().trim();
+      correct = value !== null && String(value).toLowerCase().trim() === String(q.expected).toLowerCase().trim();
     } else if (currentDrill.type === 'estimation') {
       answered = value === null ? null : Number(value);
       const tolerance = (currentDrill.config?.tolerancePct || 10) / 100;

--- a/client/src/hooks/usePostSession.js
+++ b/client/src/hooks/usePostSession.js
@@ -128,21 +128,27 @@ export function usePostSession() {
     const q = currentDrill.questions?.[currentQuestionIndex];
     if (!q) return;
     const responseMs = Date.now() - questionStartRef.current;
-    const numValue = value === null ? null : Number(value);
+    const isTextAnswer = typeof q.expected === 'string' && isNaN(Number(q.expected));
 
     // For estimation drills, check within tolerance
     let correct;
-    if (currentDrill.type === 'estimation') {
+    let answered;
+    if (isTextAnswer) {
+      answered = value;
+      correct = value !== null && value.toLowerCase().trim() === q.expected.toLowerCase().trim();
+    } else if (currentDrill.type === 'estimation') {
+      answered = value === null ? null : Number(value);
       const tolerance = (currentDrill.config?.tolerancePct || 10) / 100;
-      correct = numValue !== null && Math.abs(numValue - q.expected) <= Math.abs(q.expected * tolerance);
+      correct = answered !== null && Math.abs(answered - q.expected) <= Math.abs(q.expected * tolerance);
     } else {
-      correct = numValue === q.expected;
+      answered = value === null ? null : Number(value);
+      correct = answered === q.expected;
     }
 
     const answer = {
       prompt: q.prompt,
       expected: q.expected,
-      answered: numValue,
+      answered,
       correct,
       responseMs
     };

--- a/server/lib/postValidation.js
+++ b/server/lib/postValidation.js
@@ -33,6 +33,8 @@ const llmResponseSchema = z.object({
 const MATH_DRILL_TYPES = ['doubling-chain', 'serial-subtraction', 'multiplication', 'powers', 'estimation'];
 const LLM_DRILL_TYPES = ['word-association', 'story-recall', 'verbal-fluency', 'wit-comeback', 'pun-wordplay', 'what-if', 'alternative-uses', 'story-prompt', 'invention-pitch', 'reframe'];
 const MEMORY_DRILL_TYPES = ['memory-fill-blank', 'memory-sequence', 'memory-element-flash'];
+// Memory drills supported by the POST runner (client-side scoring with string comparison)
+const POST_SUPPORTED_MEMORY_TYPES = ['memory-sequence', 'memory-element-flash'];
 const DRILL_TYPES = [...MATH_DRILL_TYPES, ...LLM_DRILL_TYPES, ...MEMORY_DRILL_TYPES];
 
 const drillTypeConfigSchema = z.object({
@@ -194,4 +196,4 @@ export const trainingEntrySchema = z.object({
   totalMs: z.number().min(0),
 });
 
-export { LLM_DRILL_TYPES, MATH_DRILL_TYPES, MEMORY_DRILL_TYPES };
+export { LLM_DRILL_TYPES, MATH_DRILL_TYPES, MEMORY_DRILL_TYPES, POST_SUPPORTED_MEMORY_TYPES };

--- a/server/lib/postValidation.js
+++ b/server/lib/postValidation.js
@@ -11,8 +11,8 @@ export const postTagsSchema = z.record(z.string().max(200));
 // expected and correct are optional — the server recomputes both via scoreDrill
 const questionResultSchema = z.object({
   prompt: z.string(),
-  expected: z.number().optional(),
-  answered: z.number().nullable(),
+  expected: z.union([z.number(), z.string()]).optional(),
+  answered: z.union([z.number(), z.string()]).nullable(),
   correct: z.boolean().optional(),
   responseMs: z.number().min(0)
 });

--- a/server/lib/postValidation.js
+++ b/server/lib/postValidation.js
@@ -7,8 +7,9 @@ import { z } from 'zod';
 // Tags for session conditions (sleep, caffeine, stress, etc.)
 export const postTagsSchema = z.record(z.string().max(200));
 
-// Individual question result (math drills)
-// expected and correct are optional — the server recomputes both via scoreDrill
+// Individual question result (math + memory drills)
+// Math: server recomputes expected/correct via scoreDrill (numeric values)
+// Memory: client scores with string comparison (text values)
 const questionResultSchema = z.object({
   prompt: z.string(),
   expected: z.union([z.number(), z.string()]).optional(),

--- a/server/services/meatspacePost.js
+++ b/server/services/meatspacePost.js
@@ -9,7 +9,7 @@ import { writeFile } from 'fs/promises';
 import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { PATHS, ensureDir, readJSONFile } from '../lib/fileUtils.js';
-import { LLM_DRILL_TYPES } from '../lib/postValidation.js';
+import { LLM_DRILL_TYPES, MEMORY_DRILL_TYPES } from '../lib/postValidation.js';
 
 const MEATSPACE_DIR = PATHS.meatspace;
 const SESSIONS_FILE = join(MEATSPACE_DIR, 'post-sessions.json');
@@ -104,6 +104,11 @@ export async function submitPostSession(sessionData) {
     // This is a single-user internal tool so client score trust is acceptable.
     // The evaluation field and per-response llmScore/llmFeedback contain the server-generated breakdown.
     if (LLM_DRILL_TYPES.includes(rest.type)) {
+      return { ...rest, score: t.score || 0 };
+    }
+
+    // Memory drills: client-side scoring with string comparison is authoritative
+    if (MEMORY_DRILL_TYPES.includes(rest.type)) {
       return { ...rest, score: t.score || 0 };
     }
 

--- a/server/services/meatspacePost.js
+++ b/server/services/meatspacePost.js
@@ -9,7 +9,7 @@ import { writeFile } from 'fs/promises';
 import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { PATHS, ensureDir, readJSONFile } from '../lib/fileUtils.js';
-import { LLM_DRILL_TYPES, MEMORY_DRILL_TYPES } from '../lib/postValidation.js';
+import { LLM_DRILL_TYPES, MEMORY_DRILL_TYPES, POST_SUPPORTED_MEMORY_TYPES } from '../lib/postValidation.js';
 
 const MEATSPACE_DIR = PATHS.meatspace;
 const SESSIONS_FILE = join(MEATSPACE_DIR, 'post-sessions.json');
@@ -108,7 +108,7 @@ export async function submitPostSession(sessionData) {
     }
 
     // Memory drills: trust client-side scoring only for supported types
-    if (rest.type === 'memory-sequence' || rest.type === 'memory-element-flash') {
+    if (POST_SUPPORTED_MEMORY_TYPES.includes(rest.type)) {
       return { ...rest, score: t.score || 0 };
     }
     // Unsupported memory drills (e.g. memory-fill-blank): preserve data, zero score

--- a/server/services/meatspacePost.js
+++ b/server/services/meatspacePost.js
@@ -309,8 +309,9 @@ export function scoreDrill(type, questions, timeLimitMs, config = {}) {
   // Recompute expected from the prompt server-side — never trust client-provided expected
   const recomputed = questions.map(q => {
     const expected = computeExpectedFromPrompt(q.prompt);
-    // Coerce answered to number for math drills (handles string "42" → 42)
-    const answered = q.answered != null ? Number(q.answered) : null;
+    // Coerce answered to number for math drills (handles string "42" → 42, NaN → null)
+    const rawNum = q.answered != null ? Number(q.answered) : null;
+    const answered = (rawNum !== null && isNaN(rawNum)) ? null : rawNum;
     let correct;
     if (expected == null || answered == null || isNaN(answered)) {
       correct = false;

--- a/server/services/meatspacePost.js
+++ b/server/services/meatspacePost.js
@@ -107,9 +107,13 @@ export async function submitPostSession(sessionData) {
       return { ...rest, score: t.score || 0 };
     }
 
-    // Memory drills: client-side scoring with string comparison is authoritative
-    if (MEMORY_DRILL_TYPES.includes(rest.type)) {
+    // Memory drills: trust client-side scoring only for supported types
+    if (rest.type === 'memory-sequence' || rest.type === 'memory-element-flash') {
       return { ...rest, score: t.score || 0 };
+    }
+    // Unsupported memory drills (e.g. memory-fill-blank): preserve data, zero score
+    if (MEMORY_DRILL_TYPES.includes(rest.type)) {
+      return { ...rest, score: 0 };
     }
 
     // Math drills: strip correct from individual questions and rescore
@@ -305,16 +309,18 @@ export function scoreDrill(type, questions, timeLimitMs, config = {}) {
   // Recompute expected from the prompt server-side — never trust client-provided expected
   const recomputed = questions.map(q => {
     const expected = computeExpectedFromPrompt(q.prompt);
+    // Coerce answered to number for math drills (handles string "42" → 42)
+    const answered = q.answered != null ? Number(q.answered) : null;
     let correct;
-    if (expected == null || q.answered == null) {
+    if (expected == null || answered == null || isNaN(answered)) {
       correct = false;
     } else if (type === 'estimation') {
       const tolerance = ((config.tolerancePct ?? 10) / 100);
-      correct = Math.abs(q.answered - expected) <= Math.abs(expected * tolerance);
+      correct = Math.abs(answered - expected) <= Math.abs(expected * tolerance);
     } else {
-      correct = q.answered === expected;
+      correct = answered === expected;
     }
-    return { ...q, expected, correct };
+    return { ...q, answered, expected, correct };
   });
 
   const answered = recomputed.filter(q => q.answered != null);

--- a/server/services/meatspacePost.js
+++ b/server/services/meatspacePost.js
@@ -309,9 +309,16 @@ export function scoreDrill(type, questions, timeLimitMs, config = {}) {
   // Recompute expected from the prompt server-side — never trust client-provided expected
   const recomputed = questions.map(q => {
     const expected = computeExpectedFromPrompt(q.prompt);
-    // Coerce answered to number for math drills (handles string "42" → 42, NaN → null)
-    const rawNum = q.answered != null ? Number(q.answered) : null;
-    const answered = (rawNum !== null && isNaN(rawNum)) ? null : rawNum;
+    // Coerce answered to number: empty/whitespace → null, NaN → null, "42" → 42
+    let answered = null;
+    if (q.answered != null) {
+      if (typeof q.answered === 'string' && q.answered.trim() === '') {
+        answered = null;
+      } else {
+        const rawNum = Number(q.answered);
+        answered = Number.isNaN(rawNum) ? null : rawNum;
+      }
+    }
     let correct;
     if (expected == null || answered == null || isNaN(answered)) {
       correct = false;

--- a/server/services/meatspacePost.test.js
+++ b/server/services/meatspacePost.test.js
@@ -348,4 +348,16 @@ describe('scoreDrill', () => {
     expect(recomputed[1].correct).toBe(false);
     expect(recomputed[1].answered).toBe(null);
   });
+
+  it('treats empty and whitespace string answered as unanswered', () => {
+    const questions = [
+      { prompt: '5 x 3', answered: '', responseMs: 1000 },
+      { prompt: '7 x 4', answered: '  ', responseMs: 1500 }
+    ];
+    const { questions: recomputed } = scoreDrill('multiplication', questions, 60000);
+    expect(recomputed[0].answered).toBe(null);
+    expect(recomputed[0].correct).toBe(false);
+    expect(recomputed[1].answered).toBe(null);
+    expect(recomputed[1].correct).toBe(false);
+  });
 });

--- a/server/services/meatspacePost.test.js
+++ b/server/services/meatspacePost.test.js
@@ -323,4 +323,29 @@ describe('scoreDrill', () => {
     const { questions: q5 } = scoreDrill('estimation', questions, 60000, { tolerancePct: 5 });
     expect(q5[0].correct).toBe(false);
   });
+
+  it('coerces string answered values to numbers', () => {
+    const questions = [
+      { prompt: '5 x 3', answered: '15', responseMs: 1000 },
+      { prompt: '7 x 4', answered: '28', responseMs: 1500 }
+    ];
+    const { questions: recomputed, score } = scoreDrill('multiplication', questions, 60000);
+    expect(recomputed[0].correct).toBe(true);
+    expect(recomputed[0].answered).toBe(15);
+    expect(recomputed[1].correct).toBe(true);
+    expect(recomputed[1].answered).toBe(28);
+    expect(score).toBeGreaterThanOrEqual(80);
+  });
+
+  it('treats non-numeric string answered as unanswered', () => {
+    const questions = [
+      { prompt: '5 x 3', answered: 'abc', responseMs: 1000 },
+      { prompt: '7 x 4', answered: 'xyz', responseMs: 1500 }
+    ];
+    const { questions: recomputed } = scoreDrill('multiplication', questions, 60000);
+    expect(recomputed[0].correct).toBe(false);
+    expect(recomputed[0].answered).toBe(null);
+    expect(recomputed[1].correct).toBe(false);
+    expect(recomputed[1].answered).toBe(null);
+  });
 });


### PR DESCRIPTION
## Summary
- Fix LLM drill loading hang: `isLlmDrill` was computed from stale `currentDrill.type` during transitions — now uses queued drill config type which is always current
- Fix element flash input: `PostDrillRunner` used `type="number"` input and `Number()` comparison, making text-based memory drills (element names/symbols) impossible to answer — now detects text drills and uses `type="text"` with case-insensitive string comparison
- Show `promptLabel` (e.g., "Symbol?", "Element name?") above the prompt for memory drills
- Show spinner with drill name during LLM drill generation instead of generic "Loading drill..."

## Test plan
- [ ] Start a POST session with math + wordplay drills — verify wordplay drill loads with spinner instead of hanging on "Loading drill..."
- [ ] Run element flash drill — verify text input accepts letters, answers are compared case-insensitively
- [ ] Verify promptLabel ("Symbol?" / "Element name?") appears above the element prompt
- [ ] Verify math drills still use numeric input and score correctly
- [ ] Run training mode for element flash — verify feedback shows correct/incorrect properly