### PR TITLE
fix(cos): skip investigation task creation for API access errors

### DIFF
--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -972,6 +972,21 @@ Review the error, fix the configuration or code issue, and retry the original ta
   return investigationTask;
 }
 
+// Error categories where the LLM API itself is unavailable — spawning an
+// investigation agent would fail for the same reason, so skip it.
+const API_ACCESS_ERROR_CATEGORIES = new Set([
+  'auth-error',
+  'forbidden',
+  'usage-limit',
+]);
+
+async function maybeCreateInvestigationTask(agentId, task, analysis) {
+  if (API_ACCESS_ERROR_CATEGORIES.has(analysis?.category)) return;
+  await createInvestigationTask(agentId, task, analysis).catch(err => {
+    emitLog('warn', `Failed to create investigation task: ${err.message}`, { agentId });
+  });
+}
+
 /**
  * Handle task status update after agent failure.
  * Tracks retry count and blocks the task after MAX_TASK_RETRIES,
@@ -985,9 +1000,7 @@ async function resolveFailedTaskUpdate(task, errorAnalysis, agentId) {
     emitLog('warn', `🚫 Task ${task.id} blocked: ${errorAnalysis.message} (${errorAnalysis.category})`, {
       taskId: task.id, category: errorAnalysis.category
     });
-    await createInvestigationTask(agentId, task, errorAnalysis).catch(err => {
-      emitLog('warn', `Failed to create investigation task: ${err.message}`, { agentId });
-    });
+    await maybeCreateInvestigationTask(agentId, task, errorAnalysis);
     return {
       status: 'blocked',
       metadata: {
@@ -1013,9 +1026,7 @@ async function resolveFailedTaskUpdate(task, errorAnalysis, agentId) {
       suggestedFix: `Task has failed ${failureCount} consecutive times with ${lastErrorCategory} errors. ${errorAnalysis?.suggestedFix || 'Investigate agent output logs.'}`,
       category: lastErrorCategory
     };
-    await createInvestigationTask(agentId, task, blockedAnalysis).catch(err => {
-      emitLog('warn', `Failed to create investigation task: ${err.message}`, { agentId });
-    });
+    await maybeCreateInvestigationTask(agentId, task, blockedAnalysis);
     return {
       status: 'blocked',
       metadata: {

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -972,7 +972,7 @@ Review the error, fix the configuration or code issue, and retry the original ta
   return investigationTask;
 }
 
-// Error categories where the LLM API itself is unavailable — spawning an
+// Error categories where LLM API access is blocked or denied — spawning an
 // investigation agent would fail for the same reason, so skip it.
 const API_ACCESS_ERROR_CATEGORIES = new Set([
   'auth-error',
@@ -981,7 +981,10 @@ const API_ACCESS_ERROR_CATEGORIES = new Set([
 ]);
 
 async function maybeCreateInvestigationTask(agentId, task, analysis) {
-  if (API_ACCESS_ERROR_CATEGORIES.has(analysis?.category)) return;
+  if (API_ACCESS_ERROR_CATEGORIES.has(analysis?.category)) {
+    emitLog('debug', `⏭️ Skipping investigation task for ${task.id}: API access error (${analysis.category})`, { agentId, taskId: task.id, category: analysis.category });
+    return;
+  }
   await createInvestigationTask(agentId, task, analysis).catch(err => {
     emitLog('warn', `Failed to create investigation task: ${err.message}`, { agentId });
   });

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -986,7 +986,7 @@ async function maybeCreateInvestigationTask(agentId, task, analysis) {
     return;
   }
   await createInvestigationTask(agentId, task, analysis).catch(err => {
-    emitLog('warn', `Failed to create investigation task: ${err.message}`, { agentId });
+    emitLog('warn', `Failed to create investigation task: ${err.message}`, { agentId, taskId: task.id, category: analysis?.category });
   });
 }
 
@@ -998,7 +998,7 @@ async function maybeCreateInvestigationTask(agentId, task, analysis) {
  * Returns { status, metadata } to apply to the task.
  */
 async function resolveFailedTaskUpdate(task, errorAnalysis, agentId) {
-  // Actionable errors get blocked immediately with investigation
+  // Actionable errors get blocked immediately (investigation task created unless API access is denied)
   if (errorAnalysis?.actionable) {
     emitLog('warn', `🚫 Task ${task.id} blocked: ${errorAnalysis.message} (${errorAnalysis.category})`, {
       taskId: task.id, category: errorAnalysis.category

--- a/server/services/subAgentSpawner.test.js
+++ b/server/services/subAgentSpawner.test.js
@@ -654,4 +654,49 @@ describe('Task Failure Retry Logic', () => {
       expect(result.status).toBe('blocked');
     });
   });
+
+  describe('API access error categories skip investigation', () => {
+    const API_ACCESS_ERROR_CATEGORIES = new Set([
+      'auth-error',
+      'forbidden',
+      'usage-limit',
+    ]);
+
+    function shouldSkipInvestigation(analysis) {
+      return API_ACCESS_ERROR_CATEGORIES.has(analysis?.category);
+    }
+
+    it('should skip investigation for auth-error category', () => {
+      const analysis = { actionable: true, category: 'auth-error', message: 'Auth failed' };
+      expect(shouldSkipInvestigation(analysis)).toBe(true);
+    });
+
+    it('should skip investigation for forbidden category', () => {
+      const analysis = { actionable: true, category: 'forbidden', message: 'Forbidden' };
+      expect(shouldSkipInvestigation(analysis)).toBe(true);
+    });
+
+    it('should skip investigation for usage-limit category', () => {
+      const analysis = { actionable: true, category: 'usage-limit', message: 'Limit reached' };
+      expect(shouldSkipInvestigation(analysis)).toBe(true);
+    });
+
+    it('should NOT skip investigation for other actionable categories', () => {
+      const analysis = { actionable: true, category: 'model-not-found', message: 'Model not found' };
+      expect(shouldSkipInvestigation(analysis)).toBe(false);
+    });
+
+    it('should NOT skip investigation for non-actionable categories', () => {
+      const analysis = { actionable: false, category: 'rate-limit', message: 'Rate limited' };
+      expect(shouldSkipInvestigation(analysis)).toBe(false);
+    });
+
+    it('should NOT skip investigation for null analysis', () => {
+      expect(shouldSkipInvestigation(null)).toBe(false);
+    });
+
+    it('should NOT skip investigation for analysis without category', () => {
+      expect(shouldSkipInvestigation({ actionable: true })).toBe(false);
+    });
+  });
 });

--- a/server/services/subAgentSpawner.test.js
+++ b/server/services/subAgentSpawner.test.js
@@ -477,12 +477,18 @@ describe('Spawn Arguments Building', () => {
 describe('Task Failure Retry Logic', () => {
   const MAX_TASK_RETRIES = 3;
 
+  const API_ACCESS_ERROR_CATEGORIES = new Set([
+    'auth-error',
+    'forbidden',
+    'usage-limit',
+  ]);
+
   /**
    * Inline copy of resolveFailedTaskUpdate decision logic (sans async I/O).
    * Returns { status, metadata, shouldCreateInvestigation }
    */
   function resolveFailedTaskStatus(task, errorAnalysis) {
-    // Actionable errors get blocked immediately
+    // Actionable errors get blocked immediately (skip investigation for API access errors)
     if (errorAnalysis?.actionable) {
       return {
         status: 'blocked',
@@ -492,7 +498,7 @@ describe('Task Failure Retry Logic', () => {
           blockedCategory: errorAnalysis.category,
           blockedAt: 'test-timestamp'
         },
-        shouldCreateInvestigation: true
+        shouldCreateInvestigation: !API_ACCESS_ERROR_CATEGORIES.has(errorAnalysis.category)
       };
     }
 
@@ -531,13 +537,23 @@ describe('Task Failure Retry Logic', () => {
   describe('Actionable errors', () => {
     it('should block immediately on actionable error (first failure)', () => {
       const task = { id: 'task-1', description: 'test', metadata: {} };
-      const errorAnalysis = { actionable: true, category: 'auth-error', message: 'Auth failed' };
+      const errorAnalysis = { actionable: true, category: 'model-not-found', message: 'Model not found' };
 
       const result = resolveFailedTaskStatus(task, errorAnalysis);
 
       expect(result.status).toBe('blocked');
-      expect(result.metadata.blockedCategory).toBe('auth-error');
+      expect(result.metadata.blockedCategory).toBe('model-not-found');
       expect(result.shouldCreateInvestigation).toBe(true);
+    });
+
+    it('should skip investigation for API access error categories', () => {
+      const task = { id: 'task-1', description: 'test', metadata: {} };
+
+      for (const category of ['auth-error', 'forbidden', 'usage-limit']) {
+        const result = resolveFailedTaskStatus(task, { actionable: true, category, message: `${category} error` });
+        expect(result.status).toBe('blocked');
+        expect(result.shouldCreateInvestigation).toBe(false);
+      }
     });
 
     it('should block immediately regardless of failure count', () => {
@@ -655,48 +671,4 @@ describe('Task Failure Retry Logic', () => {
     });
   });
 
-  describe('API access error categories skip investigation', () => {
-    const API_ACCESS_ERROR_CATEGORIES = new Set([
-      'auth-error',
-      'forbidden',
-      'usage-limit',
-    ]);
-
-    function shouldSkipInvestigation(analysis) {
-      return API_ACCESS_ERROR_CATEGORIES.has(analysis?.category);
-    }
-
-    it('should skip investigation for auth-error category', () => {
-      const analysis = { actionable: true, category: 'auth-error', message: 'Auth failed' };
-      expect(shouldSkipInvestigation(analysis)).toBe(true);
-    });
-
-    it('should skip investigation for forbidden category', () => {
-      const analysis = { actionable: true, category: 'forbidden', message: 'Forbidden' };
-      expect(shouldSkipInvestigation(analysis)).toBe(true);
-    });
-
-    it('should skip investigation for usage-limit category', () => {
-      const analysis = { actionable: true, category: 'usage-limit', message: 'Limit reached' };
-      expect(shouldSkipInvestigation(analysis)).toBe(true);
-    });
-
-    it('should NOT skip investigation for other actionable categories', () => {
-      const analysis = { actionable: true, category: 'model-not-found', message: 'Model not found' };
-      expect(shouldSkipInvestigation(analysis)).toBe(false);
-    });
-
-    it('should NOT skip investigation for non-actionable categories', () => {
-      const analysis = { actionable: false, category: 'rate-limit', message: 'Rate limited' };
-      expect(shouldSkipInvestigation(analysis)).toBe(false);
-    });
-
-    it('should NOT skip investigation for null analysis', () => {
-      expect(shouldSkipInvestigation(null)).toBe(false);
-    });
-
-    it('should NOT skip investigation for analysis without category', () => {
-      expect(shouldSkipInvestigation({ actionable: true })).toBe(false);
-    });
-  });
 });


### PR DESCRIPTION
When an agent fails due to auth-error, forbidden, or usage-limit, the task is moved to blocked without creating an investigation agent task that would also fail for the same reason.