### PR TITLE
feat: keyboard shortcuts help modal

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -4,6 +4,12 @@ Archive of completed work. For active roadmap, see [PLAN.md](./PLAN.md). For pro
 
 ---
 
+## 2026-03-20
+
+- **Keyboard Shortcuts Help Modal** — Press `?` to show all keyboard shortcuts; global overlay with section grouping, accessible dialog
+
+---
+
 ## 2026-03-18
 
 - Fixed PromptManager.jsx fetch calls — response.ok checks now present on all endpoints

--- a/PLAN.md
+++ b/PLAN.md
@@ -12,7 +12,6 @@ For project goals, see [GOALS.md](./GOALS.md). For completed work, see [DONE.md]
 
 ## Backlog
 
-- [x] **Keyboard Shortcuts Help Modal** — Press `?` to show all keyboard shortcuts; global overlay with section grouping, accessible dialog
 - [ ] **God file decomposition** — Split cos.js, subAgentSpawner.js, digital-twin.js, routes/scaffold.js, routes/cos.js, client/api.js into focused modules; resolve circular dependency
 - [ ] **Test coverage** — Critical gaps: cos.js, cosRunnerClient.js, agentActionExecutor.js (~29% service, ~12% route coverage)
 - [ ] **M50 P9**: CoS Automation & Rules — Automated email classification, rule-based pre-filtering, email-to-task pipeline

--- a/PLAN.md
+++ b/PLAN.md
@@ -12,6 +12,7 @@ For project goals, see [GOALS.md](./GOALS.md). For completed work, see [DONE.md]
 
 ## Backlog
 
+- [x] **Keyboard Shortcuts Help Modal** — Press `?` to show all keyboard shortcuts; global overlay with section grouping, accessible dialog
 - [ ] **God file decomposition** — Split cos.js, subAgentSpawner.js, digital-twin.js, routes/scaffold.js, routes/cos.js, client/api.js into focused modules; resolve circular dependency
 - [ ] **Test coverage** — Critical gaps: cos.js, cosRunnerClient.js, agentActionExecutor.js (~29% service, ~12% route coverage)
 - [ ] **M50 P9**: CoS Automation & Rules — Automated email classification, rule-based pre-filtering, email-to-task pipeline

--- a/client/src/components/CmdKSearch.jsx
+++ b/client/src/components/CmdKSearch.jsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useNavigate } from 'react-router-dom';
 import { Brain, Cpu, Package, History, HeartPulse, Search, Loader2 } from 'lucide-react';
 import { useCmdKSearch } from '../hooks/useCmdKSearch';
+import { useScrollLock } from '../hooks/useScrollLock';
 import { search } from '../services/api';
 
 const ICON_MAP = { Brain, Cpu, Package, History, HeartPulse };
@@ -40,10 +41,7 @@ export default function CmdKSearch() {
   }, [open]);
 
   // Lock body scroll when open
-  useEffect(() => {
-    document.body.style.overflow = open ? 'hidden' : '';
-    return () => { document.body.style.overflow = ''; };
-  }, [open]);
+  useScrollLock(open);
 
   // Clear state when overlay closes
   useEffect(() => {

--- a/client/src/components/CmdKSearch.jsx
+++ b/client/src/components/CmdKSearch.jsx
@@ -5,6 +5,7 @@ import { Brain, Cpu, Package, History, HeartPulse, Search, Loader2 } from 'lucid
 import { useCmdKSearch } from '../hooks/useCmdKSearch';
 import { useScrollLock } from '../hooks/useScrollLock';
 import { search } from '../services/api';
+import { modKey } from '../utils/platform';
 
 const ICON_MAP = { Brain, Cpu, Package, History, HeartPulse };
 
@@ -144,7 +145,7 @@ export default function CmdKSearch() {
             aria-label="Search PortOS"
           />
           <span className="text-xs text-gray-500 border border-port-border rounded px-1.5 py-0.5 shrink-0">
-            {navigator.platform?.includes('Mac') ? '⌘K' : 'Ctrl+K'}
+            {`${modKey}+K`}
           </span>
         </div>
 

--- a/client/src/components/KeyboardHelp.jsx
+++ b/client/src/components/KeyboardHelp.jsx
@@ -1,0 +1,117 @@
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { Keyboard, X } from 'lucide-react';
+import { useKeyboardHelp } from '../hooks/useKeyboardHelp';
+
+const isMac = typeof navigator !== 'undefined' && navigator.platform?.includes('Mac');
+const mod = isMac ? '\u2318' : 'Ctrl';
+
+const SHORTCUT_SECTIONS = [
+  {
+    title: 'Global',
+    shortcuts: [
+      { keys: [`${mod}+K`], description: 'Open search' },
+      { keys: ['?'], description: 'Show keyboard shortcuts' },
+      { keys: ['Esc'], description: 'Close overlays' },
+    ],
+  },
+  {
+    title: 'Search (when open)',
+    shortcuts: [
+      { keys: ['\u2191', '\u2193'], description: 'Navigate results' },
+      { keys: ['Enter'], description: 'Go to selected result' },
+      { keys: ['Esc'], description: 'Close search' },
+    ],
+  },
+  {
+    title: 'CyberCity',
+    shortcuts: [
+      { keys: ['W', 'A', 'S', 'D'], description: 'Move around' },
+      { keys: ['Tab'], description: 'Toggle mode' },
+      { keys: ['E'], description: 'Interact with building' },
+    ],
+  },
+];
+
+function Kbd({ children }) {
+  return (
+    <kbd className="inline-flex items-center justify-center min-w-[24px] h-6 px-1.5 text-xs font-mono font-medium text-gray-300 bg-port-bg border border-port-border rounded shadow-sm">
+      {children}
+    </kbd>
+  );
+}
+
+export default function KeyboardHelp() {
+  const { open, setOpen } = useKeyboardHelp();
+
+  const close = () => setOpen(false);
+
+  // Lock body scroll when open
+  useEffect(() => {
+    document.body.style.overflow = open ? 'hidden' : '';
+    return () => { document.body.style.overflow = ''; };
+  }, [open]);
+
+  if (!open) return null;
+
+  const overlay = (
+    <div className="fixed inset-0 z-[9999] flex items-start justify-center pt-[10vh]">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/60"
+        onClick={close}
+        aria-hidden="true"
+      />
+
+      {/* Modal */}
+      <div role="dialog" aria-modal="true" aria-label="Keyboard shortcuts" className="relative w-full max-w-lg mx-4 bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden">
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4 border-b border-port-border">
+          <div className="flex items-center gap-2.5">
+            <Keyboard size={18} className="text-port-accent" />
+            <h2 className="text-sm font-semibold text-white">Keyboard Shortcuts</h2>
+          </div>
+          <button
+            onClick={close}
+            className="p-1 text-gray-500 hover:text-white transition-colors rounded"
+            aria-label="Close keyboard shortcuts"
+          >
+            <X size={16} />
+          </button>
+        </div>
+
+        {/* Sections */}
+        <div className="max-h-[60vh] overflow-y-auto p-5 space-y-5">
+          {SHORTCUT_SECTIONS.map(section => (
+            <div key={section.title}>
+              <h3 className="text-xs font-medium text-gray-400 uppercase tracking-wide mb-2.5">
+                {section.title}
+              </h3>
+              <div className="space-y-2">
+                {section.shortcuts.map((shortcut, i) => (
+                  <div key={i} className="flex items-center justify-between">
+                    <span className="text-sm text-gray-300">{shortcut.description}</span>
+                    <div className="flex items-center gap-1">
+                      {shortcut.keys.map((key, j) => (
+                        <Kbd key={j}>{key}</Kbd>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="px-5 py-3 border-t border-port-border">
+          <p className="text-xs text-gray-500 text-center">
+            Press <Kbd>?</Kbd> to toggle this dialog
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+
+  return createPortal(overlay, document.body);
+}

--- a/client/src/components/KeyboardHelp.jsx
+++ b/client/src/components/KeyboardHelp.jsx
@@ -3,15 +3,13 @@ import { createPortal } from 'react-dom';
 import { Keyboard, X } from 'lucide-react';
 import { useKeyboardHelp } from '../hooks/useKeyboardHelp';
 import { useScrollLock } from '../hooks/useScrollLock';
-
-const isMac = typeof navigator !== 'undefined' && navigator.platform?.includes('Mac');
-const mod = isMac ? '\u2318' : 'Ctrl';
+import { modKey } from '../utils/platform';
 
 const SHORTCUT_SECTIONS = [
   {
     title: 'Global',
     shortcuts: [
-      { keys: [`${mod}+K`], description: 'Open search' },
+      { keys: [`${modKey}+K`], description: 'Open search' },
       { keys: ['?'], description: 'Show keyboard shortcuts' },
       { keys: ['Esc'], description: 'Close overlays' },
     ],

--- a/client/src/components/KeyboardHelp.jsx
+++ b/client/src/components/KeyboardHelp.jsx
@@ -1,7 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { createPortal } from 'react-dom';
 import { Keyboard, X } from 'lucide-react';
 import { useKeyboardHelp } from '../hooks/useKeyboardHelp';
+import { useScrollLock } from '../hooks/useScrollLock';
 
 const isMac = typeof navigator !== 'undefined' && navigator.platform?.includes('Mac');
 const mod = isMac ? '\u2318' : 'Ctrl';
@@ -43,14 +44,44 @@ function Kbd({ children }) {
 
 export default function KeyboardHelp() {
   const { open, setOpen } = useKeyboardHelp();
+  const dialogRef = useRef(null);
+  const closeButtonRef = useRef(null);
+  const previousFocusRef = useRef(null);
 
-  const close = () => setOpen(false);
+  const close = useCallback(() => setOpen(false), [setOpen]);
 
   // Lock body scroll when open
+  useScrollLock(open);
+
+  // Focus management: capture previous focus, focus close button on open, restore on close
   useEffect(() => {
-    document.body.style.overflow = open ? 'hidden' : '';
-    return () => { document.body.style.overflow = ''; };
+    if (open) {
+      previousFocusRef.current = document.activeElement;
+      // Defer focus to after portal render
+      requestAnimationFrame(() => closeButtonRef.current?.focus());
+    } else if (previousFocusRef.current) {
+      previousFocusRef.current.focus();
+      previousFocusRef.current = null;
+    }
   }, [open]);
+
+  // Focus trap: keep Tab/Shift+Tab within the dialog
+  const handleKeyDown = useCallback((e) => {
+    if (e.key !== 'Tab') return;
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    const focusable = dialog.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    if (focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }, []);
 
   if (!open) return null;
 
@@ -64,14 +95,22 @@ export default function KeyboardHelp() {
       />
 
       {/* Modal */}
-      <div role="dialog" aria-modal="true" aria-label="Keyboard shortcuts" className="relative w-full max-w-lg mx-4 bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden">
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="keyboard-help-title"
+        className="relative w-full max-w-lg mx-4 bg-port-card rounded-xl border border-port-border shadow-2xl overflow-hidden"
+        onKeyDown={handleKeyDown}
+      >
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-port-border">
           <div className="flex items-center gap-2.5">
             <Keyboard size={18} className="text-port-accent" />
-            <h2 className="text-sm font-semibold text-white">Keyboard Shortcuts</h2>
+            <h2 id="keyboard-help-title" className="text-sm font-semibold text-white">Keyboard Shortcuts</h2>
           </div>
           <button
+            ref={closeButtonRef}
             onClick={close}
             className="p-1 text-gray-500 hover:text-white transition-colors rounded"
             aria-label="Close keyboard shortcuts"

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -75,6 +75,7 @@ import { useUpdateChecker } from '../hooks/useUpdateChecker';
 import NotificationDropdown from './NotificationDropdown';
 import ThemeSwitcher from './ThemeSwitcher';
 import CmdKSearch from './CmdKSearch';
+import KeyboardHelp from './KeyboardHelp';
 import * as api from '../services/api';
 import socket from '../services/socket';
 
@@ -676,6 +677,8 @@ export default function Layout() {
       </div>
       {/* Cmd+K search overlay — mounted in layout so it's available on every page */}
       <CmdKSearch />
+      {/* Keyboard shortcuts help — press ? to toggle */}
+      <KeyboardHelp />
     </div>
   );
 }

--- a/client/src/hooks/useKeyboardHelp.js
+++ b/client/src/hooks/useKeyboardHelp.js
@@ -5,7 +5,13 @@ export function useKeyboardHelp() {
 
   useEffect(() => {
     const handler = (e) => {
-      // Don't trigger when typing in inputs/textareas/contenteditable
+      // Escape always closes, even from inputs/textareas
+      if (e.key === 'Escape') {
+        setOpen(false);
+        return;
+      }
+
+      // Don't trigger shortcuts when typing in inputs/textareas/contenteditable
       const tag = e.target.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
       // Don't trigger with modifier keys
@@ -14,8 +20,6 @@ export function useKeyboardHelp() {
       if (e.key === '?' && !e.repeat) {
         e.preventDefault();
         setOpen(prev => !prev);
-      } else if (e.key === 'Escape') {
-        setOpen(false);
       }
     };
     document.addEventListener('keydown', handler);

--- a/client/src/hooks/useKeyboardHelp.js
+++ b/client/src/hooks/useKeyboardHelp.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+
+export function useKeyboardHelp() {
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handler = (e) => {
+      // Don't trigger when typing in inputs/textareas/contenteditable
+      const tag = e.target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
+      // Don't trigger with modifier keys
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      if (e.key === '?' && !e.repeat) {
+        e.preventDefault();
+        setOpen(prev => !prev);
+      } else if (e.key === 'Escape') {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, []);
+
+  return { open, setOpen };
+}

--- a/client/src/hooks/useKeyboardHelp.js
+++ b/client/src/hooks/useKeyboardHelp.js
@@ -11,13 +11,10 @@ export function useKeyboardHelp() {
         return;
       }
 
-      // Don't trigger shortcuts when typing in inputs/textareas/contenteditable
-      const tag = e.target.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
-      // Don't trigger with modifier keys
-      if (e.metaKey || e.ctrlKey || e.altKey) return;
-
+      // ? toggle — check key before modifiers so AltGr layouts (ctrlKey+altKey) still work
       if (e.key === '?' && !e.repeat) {
+        const tag = e.target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
         e.preventDefault();
         setOpen(prev => !prev);
       }

--- a/client/src/hooks/useScrollLock.js
+++ b/client/src/hooks/useScrollLock.js
@@ -1,15 +1,17 @@
 import { useEffect } from 'react';
 
 let lockCount = 0;
+let savedOverflow = '';
 
 export function useScrollLock(active) {
   useEffect(() => {
     if (!active) return;
+    if (lockCount === 0) savedOverflow = document.body.style.overflow;
     lockCount++;
     document.body.style.overflow = 'hidden';
     return () => {
       lockCount--;
-      if (lockCount === 0) document.body.style.overflow = '';
+      if (lockCount === 0) document.body.style.overflow = savedOverflow;
     };
   }, [active]);
 }

--- a/client/src/hooks/useScrollLock.js
+++ b/client/src/hooks/useScrollLock.js
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+
+let lockCount = 0;
+
+export function useScrollLock(active) {
+  useEffect(() => {
+    if (!active) return;
+    lockCount++;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      lockCount--;
+      if (lockCount === 0) document.body.style.overflow = '';
+    };
+  }, [active]);
+}

--- a/client/src/utils/platform.js
+++ b/client/src/utils/platform.js
@@ -1,3 +1,4 @@
+/** Platform detection — provides isMac flag and modifier key label for keyboard shortcuts */
 export const isMac = typeof navigator !== 'undefined' &&
   (/Mac|iPhone|iPad|iPod/.test(navigator.userAgentData?.platform ?? navigator.platform ?? ''));
 

--- a/client/src/utils/platform.js
+++ b/client/src/utils/platform.js
@@ -1,0 +1,4 @@
+export const isMac = typeof navigator !== 'undefined' &&
+  (/Mac|iPhone|iPad|iPod/.test(navigator.userAgentData?.platform ?? navigator.platform ?? ''));
+
+export const modKey = isMac ? '⌘' : 'Ctrl';


### PR DESCRIPTION
## Summary
- Adds a global keyboard shortcuts help overlay triggered by pressing `?` from any page
- Shows all available shortcuts grouped by context (Global, Search, CyberCity) with styled `<kbd>` elements
- Platform-aware modifier key display (⌘ on Mac, Ctrl elsewhere) via shared `platform.js` utility
- Follows existing overlay patterns (CmdKSearch) with portal rendering, backdrop click-to-close, and Escape key dismiss
- Accessible: `role="dialog"`, `aria-modal`, `aria-labelledby` attributes, focus trap, and focus restoration
- Shared `useScrollLock` hook prevents scroll-lock conflicts between overlays

## Test plan
- [ ] Press `?` on any page — help modal should appear
- [ ] Press `?` again or `Escape` — modal should close
- [ ] Click backdrop — modal should close
- [ ] Type `?` in an input field or textarea — modal should NOT appear
- [ ] Verify modifier key shows ⌘ on Mac, Ctrl on other platforms
- [ ] Verify modal is scrollable if content overflows
- [ ] Verify mobile responsiveness
- [ ] Verify focus moves to close button when modal opens
- [ ] Verify Tab/Shift+Tab stays within the modal