### PR TITLE
fix(cos): recover lost agent work from stash, improve duration tracking

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -39,6 +39,9 @@
 - Alcohol page summary compressed into a single compact stat bar row to maximize above-the-fold content
 
 ## Fixed
+- Notifications crash on missing metadata: added optional chaining in `removeByMetadata()` and `exists()`
+- Telegram memory approve/reject: wrapped in try/catch to prevent unhandled errors, clears inline keyboard buttons after action
+- ETA duration estimates skewed by failed agents: track success-only durations separately, add `recalculate-durations` endpoint for retroactive rebuild from agent archive
 - CoS orphan retry over-spawning: `resetOrphanedTasks()` was bypassing retry limits by blindly resetting in_progress tasks to pending — now routes through `handleOrphanedTask()` for consistent spawn counting, cooldown, and max-retry enforcement
 - CoS scheduled improvement tasks (feature-ideas, etc.) never spawning: event listener mismatch (`tasks:user:added`/`tasks:cos:added` vs actual `tasks:changed` event), missing dequeue trigger after improvement check timer, and no improvement queuing after daemon restart until timer fires
 - App icons in CoS schedule per-app override list rendering at natural image size instead of respecting the `size` prop

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -641,6 +641,12 @@ router.post('/learning/recalculate-model-tiers', asyncHandler(async (req, res) =
   res.json({ success: true, ...result });
 }));
 
+// POST /api/cos/learning/recalculate-durations - Rebuild success-only duration stats from agent archive
+router.post('/learning/recalculate-durations', asyncHandler(async (req, res) => {
+  const result = await taskLearning.recalculateDurationStats();
+  res.json({ success: true, ...result });
+}));
+
 // ============================================================
 // Weekly Digest Routes
 // ============================================================

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -275,6 +275,37 @@ describe('CoS Routes', () => {
 
       expect(response.status).toBe(404);
     });
+
+    it('should set blocker metadata when marking as blocked', async () => {
+      cos.updateTask.mockResolvedValue({ id: 'task-001', status: 'blocked' });
+
+      const response = await request(app)
+        .put('/api/cos/tasks/task-001')
+        .send({ status: 'blocked', blockedReason: 'Waiting for API access' });
+
+      expect(response.status).toBe(200);
+      expect(cos.updateTask).toHaveBeenCalledWith(
+        'task-001',
+        expect.objectContaining({
+          status: 'blocked',
+          metadata: { blocker: 'Waiting for API access' }
+        }),
+        'user'
+      );
+    });
+
+    it('should not send metadata when changing status to pending (service handles cleanup)', async () => {
+      cos.updateTask.mockResolvedValue({ id: 'task-001', status: 'pending' });
+
+      const response = await request(app)
+        .put('/api/cos/tasks/task-001')
+        .send({ status: 'pending' });
+
+      expect(response.status).toBe(200);
+      const callArgs = cos.updateTask.mock.calls[0][1];
+      expect(callArgs.status).toBe('pending');
+      expect(callArgs.metadata).toBeUndefined();
+    });
   });
 
   describe('DELETE /api/cos/tasks/:id', () => {

--- a/server/services/notifications.js
+++ b/server/services/notifications.js
@@ -199,7 +199,7 @@ export async function removeByMetadata(field, value) {
     const data = await loadNotifications();
     const before = data.notifications.length;
 
-    data.notifications = data.notifications.filter(n => n.metadata[field] !== value);
+    data.notifications = data.notifications.filter(n => n.metadata?.[field] !== value);
 
     const removed = before - data.notifications.length;
     if (removed > 0) {
@@ -288,7 +288,7 @@ export async function exists(type, metadataField, metadataValue) {
     return data.notifications.some(n => n.type === type);
   }
   return data.notifications.some(
-    n => n.type === type && n.metadata[metadataField] === metadataValue
+    n => n.type === type && n.metadata?.[metadataField] === metadataValue
   );
 }
 

--- a/server/services/taskLearning.js
+++ b/server/services/taskLearning.js
@@ -6,8 +6,8 @@
  * to provide smarter task prioritization and model selection.
  */
 
-import { writeFile, rename } from 'fs/promises';
-import { existsSync } from 'fs';
+import { writeFile, readFile, rename } from 'fs/promises';
+import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { cosEvents, emitLog } from './cos.js';
 import { ensureDir, readJSONFile, PATHS } from '../lib/fileUtils.js';
@@ -17,6 +17,22 @@ const withLock = createMutex();
 
 const DATA_DIR = PATHS.cos;
 const LEARNING_FILE = join(DATA_DIR, 'learning.json');
+const AGENTS_DIR = join(DATA_DIR, 'agents');
+
+/**
+ * Calculate ETA-oriented duration stats from success-only metrics with fallback.
+ * Returns { avgDurationMs, maxDurationMs, p80DurationMs }.
+ */
+function calculateDurationETA(metrics) {
+  const hasSuccessData = (metrics.successDurationMs || 0) > 0;
+  const avgBase = hasSuccessData ? metrics.successDurationMs : metrics.totalDurationMs;
+  const countBase = hasSuccessData ? metrics.succeeded : metrics.completed;
+  if (!countBase || countBase <= 0) return { avgDurationMs: 0, maxDurationMs: 0, p80DurationMs: 0 };
+  const avg = Math.round(avgBase / countBase);
+  const max = hasSuccessData ? (metrics.successMaxDurationMs || avg) : avg;
+  const p80 = Math.round(Math.min(avg * 3, avg + 0.6 * (max - avg)));
+  return { avgDurationMs: avg, maxDurationMs: max, p80DurationMs: p80 };
+}
 
 /**
  * Default learning data structure
@@ -175,6 +191,7 @@ export async function recordTaskCompletion(agent, task) {
       succeeded: 0,
       failed: 0,
       totalDurationMs: 0,
+      successDurationMs: 0,
       avgDurationMs: 0
     };
   }
@@ -184,17 +201,15 @@ export async function recordTaskCompletion(agent, task) {
   typeMetrics.completed++;
   if (success) {
     typeMetrics.succeeded++;
+    // Only include successful durations in ETA calculations — failed agents often
+    // run long in error loops and skew estimates
+    typeMetrics.successDurationMs = (typeMetrics.successDurationMs || 0) + duration;
+    typeMetrics.successMaxDurationMs = Math.max(typeMetrics.successMaxDurationMs || 0, duration);
   } else {
     typeMetrics.failed++;
   }
   typeMetrics.totalDurationMs += duration;
-  typeMetrics.avgDurationMs = Math.round(typeMetrics.totalDurationMs / typeMetrics.completed);
-  typeMetrics.maxDurationMs = Math.max(typeMetrics.maxDurationMs || 0, duration);
-  // P80 estimate: avg + 60% of the gap between avg and max
-  // This provides a realistic upper-bound for progress bars so they don't hit 100% too early
-  typeMetrics.p80DurationMs = Math.round(
-    typeMetrics.avgDurationMs + 0.6 * (typeMetrics.maxDurationMs - typeMetrics.avgDurationMs)
-  );
+  Object.assign(typeMetrics, calculateDurationETA(typeMetrics));
   typeMetrics.lastCompleted = new Date().toISOString();
   typeMetrics.successRate = Math.round((typeMetrics.succeeded / typeMetrics.completed) * 100);
 
@@ -203,11 +218,12 @@ export async function recordTaskCompletion(agent, task) {
   tierMetrics.completed++;
   if (success) {
     tierMetrics.succeeded++;
+    tierMetrics.successDurationMs = (tierMetrics.successDurationMs || 0) + duration;
   } else {
     tierMetrics.failed++;
   }
   tierMetrics.totalDurationMs += duration;
-  tierMetrics.avgDurationMs = Math.round(tierMetrics.totalDurationMs / tierMetrics.completed);
+  tierMetrics.avgDurationMs = calculateDurationETA(tierMetrics).avgDurationMs;
 
   // Track routing accuracy: taskType × modelTier cross-reference
   if (!data.routingAccuracy) data.routingAccuracy = {};
@@ -264,15 +280,13 @@ export async function recordTaskCompletion(agent, task) {
   data.totals.completed++;
   if (success) {
     data.totals.succeeded++;
+    data.totals.successDurationMs = (data.totals.successDurationMs || 0) + duration;
+    data.totals.successMaxDurationMs = Math.max(data.totals.successMaxDurationMs || 0, duration);
   } else {
     data.totals.failed++;
   }
   data.totals.totalDurationMs += duration;
-  data.totals.avgDurationMs = Math.round(data.totals.totalDurationMs / data.totals.completed);
-  data.totals.maxDurationMs = Math.max(data.totals.maxDurationMs || 0, duration);
-  data.totals.p80DurationMs = Math.round(
-    data.totals.avgDurationMs + 0.6 * ((data.totals.maxDurationMs || data.totals.avgDurationMs) - data.totals.avgDurationMs)
-  );
+  Object.assign(data.totals, calculateDurationETA(data.totals));
 
   await saveLearningData(data);
 
@@ -911,15 +925,13 @@ export async function resetTaskTypeLearning(taskType) {
   data.totals.succeeded -= metrics.succeeded;
   data.totals.failed -= metrics.failed;
   data.totals.totalDurationMs -= metrics.totalDurationMs;
-  data.totals.avgDurationMs = data.totals.completed > 0
-    ? Math.round(data.totals.totalDurationMs / data.totals.completed)
-    : 0;
+  if (data.totals.successDurationMs) {
+    data.totals.successDurationMs -= (metrics.successDurationMs || 0);
+  }
   // Recalculate max from remaining task types (we can't subtract a max)
   const remainingTypes = Object.entries(data.byTaskType).filter(([t]) => t !== taskType);
-  data.totals.maxDurationMs = remainingTypes.reduce((max, [, m]) => Math.max(max, m.maxDurationMs || 0), 0);
-  data.totals.p80DurationMs = data.totals.completed > 0
-    ? Math.round(data.totals.avgDurationMs + 0.6 * ((data.totals.maxDurationMs || data.totals.avgDurationMs) - data.totals.avgDurationMs))
-    : 0;
+  data.totals.successMaxDurationMs = remainingTypes.reduce((max, [, m]) => Math.max(max, m.successMaxDurationMs || 0), 0);
+  Object.assign(data.totals, calculateDurationETA(data.totals));
 
   // Clean up error patterns referencing this task type
   for (const [category, pattern] of Object.entries(data.errorPatterns)) {
@@ -1163,6 +1175,104 @@ export async function recalculateModelTierMetrics() {
   }
 
   return { recalculated: changes.length > 0, changes };
+  });
+}
+
+/**
+ * Rebuild success-only duration stats from the agent archive.
+ * Scans all completed agent metadata to recalculate avgDurationMs, maxDurationMs, and p80DurationMs
+ * using only successful agent durations (failed agents often run long in error loops and skew ETAs).
+ */
+export async function recalculateDurationStats() {
+  return withLock(async () => {
+  const data = await loadLearningData();
+
+  // Reset success-only duration fields
+  for (const metrics of Object.values(data.byTaskType)) {
+    metrics.successDurationMs = 0;
+    metrics.successMaxDurationMs = 0;
+  }
+  data.totals.successDurationMs = 0;
+  data.totals.successMaxDurationMs = 0;
+
+  let agentCount = 0;
+  let successCount = 0;
+
+  if (existsSync(AGENTS_DIR)) {
+    const dateDirs = readdirSync(AGENTS_DIR, { withFileTypes: true })
+      .filter(d => d.isDirectory() && /^\d{4}-\d{2}-\d{2}$/.test(d.name));
+
+    // Collect all metadata paths then read in parallel
+    const metaPaths = [];
+    for (const dateDir of dateDirs) {
+      const datePath = join(AGENTS_DIR, dateDir.name);
+      const agentDirs = readdirSync(datePath, { withFileTypes: true })
+        .filter(d => d.isDirectory());
+      for (const agentDir of agentDirs) {
+        metaPaths.push(join(datePath, agentDir.name, 'metadata.json'));
+      }
+    }
+
+    const results = await Promise.all(
+      metaPaths.map(p => readFile(p, 'utf-8').catch(() => null))
+    );
+
+    for (const raw of results) {
+      if (!raw) continue;
+      const meta = JSON.parse(raw);
+      agentCount++;
+
+      const duration = meta.result?.duration || 0;
+      if (!meta.result?.success || duration <= 0) continue;
+
+      successCount++;
+      const taskType = extractTaskType({
+        description: meta.metadata?.taskDescription,
+        metadata: meta.metadata,
+        taskType: meta.metadata?.taskType
+      });
+
+      if (data.byTaskType[taskType]) {
+        data.byTaskType[taskType].successDurationMs += duration;
+        data.byTaskType[taskType].successMaxDurationMs = Math.max(
+          data.byTaskType[taskType].successMaxDurationMs, duration
+        );
+      }
+
+      data.totals.successDurationMs += duration;
+      data.totals.successMaxDurationMs = Math.max(data.totals.successMaxDurationMs, duration);
+    }
+  }
+
+  // Recalculate avgDurationMs, maxDurationMs, and p80DurationMs using the helper
+  for (const metrics of Object.values(data.byTaskType)) {
+    if ((metrics.succeeded || 0) > 0 && metrics.successDurationMs > 0) {
+      Object.assign(metrics, calculateDurationETA(metrics));
+    }
+  }
+
+  if ((data.totals.succeeded || 0) > 0 && data.totals.successDurationMs > 0) {
+    Object.assign(data.totals, calculateDurationETA(data.totals));
+  }
+
+  await saveLearningData(data);
+
+  emitLog('info', `📚 Recalculated duration stats from ${agentCount} agents (${successCount} successful)`, {
+    agentCount, successCount,
+    newAvgMs: data.totals.avgDurationMs,
+    newP80Ms: data.totals.p80DurationMs
+  }, '[TaskLearning]');
+
+  return {
+    recalculated: true,
+    agentsScanned: agentCount,
+    successfulAgents: successCount,
+    newTotals: {
+      avgDurationMs: data.totals.avgDurationMs,
+      p80DurationMs: data.totals.p80DurationMs,
+      maxDurationMs: data.totals.maxDurationMs
+    }
+  };
   });
 }
 

--- a/server/services/telegram.js
+++ b/server/services/telegram.js
@@ -328,7 +328,13 @@ async function handleCallbackQuery(query) {
     const memoryId = data.slice(colonIdx + 1);
     const isApprove = action === CALLBACK_APPROVE;
 
-    const result = isApprove ? await approveMemory(memoryId) : await rejectMemory(memoryId);
+    let result;
+    try {
+      result = isApprove ? await approveMemory(memoryId) : await rejectMemory(memoryId);
+    } catch (err) {
+      console.error(`📱 Telegram: memory ${isApprove ? 'approve' : 'reject'} failed — ${err.message}`);
+      result = { success: false, error: err.message };
+    }
 
     const responseText = result.success
       ? (isApprove ? '✅ Memory approved' : '❌ Memory rejected')
@@ -343,7 +349,8 @@ async function handleCallbackQuery(query) {
       bot.answerCallbackQuery(query.id, { text: responseText }).catch(() => {}),
       bot.editMessageText(originalText + statusLine, {
         chat_id: query.message.chat.id,
-        message_id: query.message.message_id
+        message_id: query.message.message_id,
+        reply_markup: JSON.stringify({ inline_keyboard: [] })
       }).catch(() => {})
     ]);
   }


### PR DESCRIPTION
## Summary
- Audited all 17 git stash entries left by agents that stashed but never popped
- Recovered 4 sets of lost bug fixes and improvements from orphaned stashes
- Added `calculateDurationETA` helper to eliminate 3x duplicated duration calculation
- Parallelized metadata reads in `recalculateDurationStats` for performance

## Changes
- **notifications.js**: Optional chaining to prevent crashes on missing metadata
- **telegram.js**: Try/catch around memory approve/reject, clear inline keyboard after action
- **taskLearning.js**: Success-only duration tracking for accurate ETAs, `recalculateDurationStats` endpoint, extracted helper, parallelized I/O
- **cos.js routes**: New `recalculate-durations` endpoint
- **cos.test.js**: Blocker metadata test coverage

## Test plan
- [x] All 25 taskLearning tests pass
- [x] All 47 cos route tests pass
- [x] Pre-existing failures (meatspacePostLlm scoring) unrelated to changes