### PR TITLE
Release v1.36.0

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,2 @@
+### Added
+- Character Sheet page: D&D-style character tracking with XP, HP, leveling, dice-based damage, short/long rests, custom event logging, and JIRA/CoS task sync for XP

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,6 +1,8 @@
 ### Fixed
 - Job scheduling now uses user's configured timezone instead of UTC — daily briefing and all scheduled jobs fire at the correct local time
 - Briefing notification date uses user timezone instead of UTC date
+- Throttle LLM drill cache startup: serialize type replenishment and add 2s delay between LLM calls to prevent API spam on server restart
+- Throttle JIRA sync: add 500ms delay between project ticket fetches to prevent 429 rate limit errors
 
 ### Added
 - Character Sheet page: D&D-style character tracking with XP, HP, leveling, dice-based damage, short/long rests, custom event logging, and JIRA/CoS task sync for XP

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,4 +1,5 @@
 ### Fixed
+- New instances no longer trigger LLM calls on startup — seed drill cache in data.sample and skip brain digest/review when no data exists
 - Job scheduling now uses user's configured timezone instead of UTC — daily briefing and all scheduled jobs fire at the correct local time
 - Briefing notification date uses user timezone instead of UTC date
 - Throttle LLM drill cache startup: serialize type replenishment and add 2s delay between LLM calls to prevent API spam on server restart

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,2 +1,18 @@
+### Fixed
+- Job scheduling now uses user's configured timezone instead of UTC — daily briefing and all scheduled jobs fire at the correct local time
+- Briefing notification date uses user timezone instead of UTC date
+
 ### Added
 - Character Sheet page: D&D-style character tracking with XP, HP, leveling, dice-based damage, short/long rests, custom event logging, and JIRA/CoS task sync for XP
+- Timezone setting in Settings > General — auto-detects from browser, configurable per user
+- Cron expression support across all scheduling systems — full 5-field crontab syntax (minute hour dayOfMonth month dayOfWeek)
+- Cron support in System Tasks (Jobs), per-app Task Type Overrides, and global CoS Schedule
+- Shared CronInput component with presets dropdown and human-readable descriptions
+- Schedule mode toggle (Interval vs Cron) in job create/edit forms
+- Timezone-aware cron matching in event scheduler and task schedule evaluator
+- Shared cron utilities (cronHelpers.js) — DRY across all scheduling UIs
+- Timezone utility module with cached Intl.DateTimeFormat and comprehensive test coverage
+
+### Changed
+- Task Type Overrides switched from table to card layout for mobile responsiveness
+- Task type subtitle shows effective schedule (cron/override) instead of always showing global type

--- a/.changelog/v1.36.0.md
+++ b/.changelog/v1.36.0.md
@@ -1,3 +1,7 @@
+# Release v1.36.0
+
+Released: 2026-03-24
+
 ### Fixed
 - New instances no longer trigger LLM calls on startup — seed drill cache in data.sample and skip brain digest/review when no data exists
 - Job scheduling now uses user's configured timezone instead of UTC — daily briefing and all scheduled jobs fire at the correct local time
@@ -19,3 +23,6 @@
 ### Changed
 - Task Type Overrides switched from table to card layout for mobile responsiveness
 - Task type subtitle shows effective schedule (cron/override) instead of always showing global type
+
+## Full Changelog
+**Full Diff**: https://github.com/atomantic/PortOS/compare/v1.35.0...v1.36.0

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -24,6 +24,7 @@ import MeatSpace from './pages/MeatSpace';
 import Post from './pages/Post';
 import Review from './pages/Review';
 import Loops from './pages/Loops';
+import CharacterSheet from './pages/CharacterSheet';
 
 // Auto-reload on stale chunk errors (e.g., after a rebuild changes chunk hashes)
 // Uses sessionStorage to prevent infinite reload loops (max 1 reload per session)
@@ -133,6 +134,7 @@ export default function App() {
           <Route path="devtools/jira" element={<Jira />} />
           <Route path="city" element={<CyberCity />} />
           <Route path="city/settings" element={<CyberCity />} />
+          <Route path="character" element={<CharacterSheet />} />
           <Route path="agents" element={<Agents />} />
           <Route path="agents/:agentId" element={<Agents />} />
           <Route path="agents/:agentId/:tab" element={<Agents />} />

--- a/client/src/components/CronInput.jsx
+++ b/client/src/components/CronInput.jsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { CRON_PRESETS, describeCron } from '../utils/cronHelpers';
+
+/**
+ * Inline cron expression editor with presets dropdown.
+ * Shows a text input + presets select + human-readable description.
+ * Calls onSave with the validated expression, onCancel to dismiss.
+ */
+export default function CronInput({ value, onSave, onCancel, className = '' }) {
+  const [expr, setExpr] = useState(value || '0 7 * * *');
+
+  const handleSave = () => {
+    const trimmed = expr.trim();
+    if (trimmed.split(/\s+/).length !== 5) return;
+    onSave(trimmed);
+  };
+
+  return (
+    <div className={`flex flex-wrap items-center gap-1 ${className}`}>
+      <input
+        type="text"
+        value={expr}
+        onChange={e => setExpr(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === 'Enter') handleSave();
+          if (e.key === 'Escape') onCancel?.();
+        }}
+        className="w-28 sm:w-32 px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white font-mono focus:border-port-accent focus:outline-hidden"
+        placeholder="0 7 * * *"
+        autoFocus
+      />
+      <select
+        value=""
+        onChange={e => { if (e.target.value) setExpr(e.target.value); }}
+        className="px-1 py-1 bg-port-bg border border-port-border rounded text-gray-400 text-xs"
+      >
+        <option value="">Presets</option>
+        {CRON_PRESETS.map(p => (
+          <option key={p.value} value={p.value}>{p.label}</option>
+        ))}
+      </select>
+      <button
+        onClick={handleSave}
+        className="px-1.5 py-1 bg-port-accent/20 text-port-accent rounded text-xs hover:bg-port-accent/30"
+      >
+        OK
+      </button>
+      {onCancel && (
+        <button
+          onClick={onCancel}
+          className="px-1.5 py-1 text-gray-500 hover:text-gray-300 rounded text-xs"
+        >
+          X
+        </button>
+      )}
+      {expr && (
+        <span className="text-xs text-gray-500 truncate hidden sm:inline">{describeCron(expr)}</span>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -65,7 +65,8 @@ import {
   RefreshCw,
   Dog,
   FilePen,
-  MessageCircle
+  MessageCircle,
+  Swords
 } from 'lucide-react';
 /* global __APP_VERSION__ */
 import Logo from './Logo';
@@ -113,6 +114,7 @@ const navItems = [
       { to: '/calendar/week', label: 'Week', icon: CalendarDays }
     ]
   },
+  { to: '/character', label: 'Character', icon: Swords, single: true },
   {
     label: 'Chief of Staff',
     icon: Crown,
@@ -671,7 +673,8 @@ export default function Layout() {
 
         {/* Main content */}
         {(() => {
-          const isFullWidth = location.pathname.startsWith('/calendar') ||
+          const isFullWidth = location.pathname === '/character' ||
+            location.pathname.startsWith('/calendar') ||
             location.pathname.startsWith('/cos') ||
             location.pathname.startsWith('/brain') ||
             location.pathname.startsWith('/digital-twin') ||

--- a/client/src/components/agents/constants.js
+++ b/client/src/components/agents/constants.js
@@ -67,16 +67,8 @@ export const DEFAULT_AVATAR = {
   color: '#3b82f6'
 };
 
-// Cron presets for easy scheduling
-export const CRON_PRESETS = [
-  { value: '0 * * * *', label: 'Every hour' },
-  { value: '0 */2 * * *', label: 'Every 2 hours' },
-  { value: '0 */4 * * *', label: 'Every 4 hours' },
-  { value: '0 */6 * * *', label: 'Every 6 hours' },
-  { value: '0 9,12,15,18 * * *', label: 'Peak hours (9am, 12pm, 3pm, 6pm)' },
-  { value: '0 9 * * *', label: 'Daily at 9am' },
-  { value: '0 12 * * *', label: 'Daily at noon' }
-];
+// Re-export shared cron presets for agent scheduling
+export { CRON_PRESETS } from '../../utils/cronHelpers';
 
 // Interval presets (in milliseconds)
 export const INTERVAL_PRESETS = [

--- a/client/src/components/apps/tabs/AutomationTab.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.jsx
@@ -2,8 +2,10 @@ import { useState, useEffect, useCallback } from 'react';
 import { RefreshCw, Play } from 'lucide-react';
 import toast from 'react-hot-toast';
 import BrailleSpinner from '../../BrailleSpinner';
+import CronInput from '../../CronInput';
 import * as api from '../../../services/api';
 import { AGENT_OPTIONS, toggleAppMetadataOverride } from '../../cos/constants';
+import { isCronExpression, describeCron } from '../../../utils/cronHelpers';
 
 const INTERVAL_OPTIONS = [
   { value: null, label: 'Inherit Global' },
@@ -11,7 +13,8 @@ const INTERVAL_OPTIONS = [
   { value: 'daily', label: 'Daily' },
   { value: 'weekly', label: 'Weekly' },
   { value: 'once', label: 'Once' },
-  { value: 'on-demand', label: 'On-demand' }
+  { value: 'on-demand', label: 'On-demand' },
+  { value: 'cron', label: 'Cron' }
 ];
 
 export default function AutomationTab({ appId, appName }) {
@@ -19,6 +22,7 @@ export default function AutomationTab({ appId, appName }) {
   const [schedule, setSchedule] = useState(null);
   const [loading, setLoading] = useState(true);
   const [triggering, setTriggering] = useState(null);
+  const [cronEditing, setCronEditing] = useState({});
 
   const fetchData = useCallback(async () => {
     const [taskTypesData, scheduleData] = await Promise.all([
@@ -47,6 +51,13 @@ export default function AutomationTab({ appId, appName }) {
   };
 
   const handleIntervalChange = async (taskType, interval) => {
+    if (interval === 'cron') {
+      // Open cron editor — don't save until user enters expression
+      const existing = overrides[taskType]?.interval;
+      setCronEditing(prev => ({ ...prev, [taskType]: isCronExpression(existing) ? existing : '0 7 * * *' }));
+      return;
+    }
+    setCronEditing(prev => { const n = { ...prev }; delete n[taskType]; return n; });
     const value = interval === 'null' ? null : interval;
     await api.updateAppTaskTypeOverride(appId, taskType, { interval: value }).catch(err => {
       toast.error(err.message);
@@ -56,6 +67,18 @@ export default function AutomationTab({ appId, appName }) {
       ...prev,
       [taskType]: { ...prev[taskType], interval: value }
     }));
+  };
+
+  const handleCronSave = async (taskType, expr) => {
+    await api.updateAppTaskTypeOverride(appId, taskType, { interval: expr }).catch(err => {
+      toast.error(err.message);
+      return null;
+    });
+    setOverrides(prev => ({
+      ...prev,
+      [taskType]: { ...prev[taskType], interval: expr }
+    }));
+    setCronEditing(prev => { const n = { ...prev }; delete n[taskType]; return n; });
   };
 
   const handleMetaToggle = async (taskType, field, globalTaskMetadata) => {
@@ -108,96 +131,96 @@ export default function AutomationTab({ appId, appName }) {
           No task types configured in the schedule
         </div>
       ) : (
-        <div className="bg-port-card border border-port-border rounded-lg overflow-hidden">
-          <div className="overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b border-port-border">
-                  <th className="text-left px-4 py-3 text-xs text-gray-500 uppercase tracking-wide font-medium">Task Type</th>
-                  <th className="text-center px-4 py-3 text-xs text-gray-500 uppercase tracking-wide font-medium">Enabled</th>
-                  <th className="text-left px-4 py-3 text-xs text-gray-500 uppercase tracking-wide font-medium">Interval</th>
-                  <th className="text-center px-4 py-3 text-xs text-gray-500 uppercase tracking-wide font-medium cursor-help" title="Bright = app override on, Dim = inherited from global, Gray = app override off">Agent Options</th>
-                  <th className="text-right px-4 py-3 text-xs text-gray-500 uppercase tracking-wide font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {taskTypes.map(taskType => {
-                  const override = overrides[taskType] || {};
-                  const globalConfig = schedule.tasks[taskType] || {};
-                  const isEnabled = override.enabled !== false;
-                  const overrideInterval = override.interval || null;
+        <div className="space-y-2">
+          {taskTypes.map(taskType => {
+            const override = overrides[taskType] || {};
+            const globalConfig = schedule.tasks[taskType] || {};
+            const isEnabled = override.enabled !== false;
+            const overrideInterval = override.interval || null;
+            const effectiveLabel = isCronExpression(overrideInterval)
+              ? describeCron(overrideInterval) || 'cron'
+              : overrideInterval || (globalConfig.type || 'rotation');
+            const intervalSuffix = !overrideInterval && globalConfig.intervalMs ? ` (${Math.round(globalConfig.intervalMs / 3600000)}h)` : '';
 
-                  return (
-                    <tr key={taskType} className="border-b border-port-border/50 hover:bg-white/5">
-                      <td className="px-4 py-3">
-                        <div>
-                          <span className="text-white font-mono text-xs">{taskType}</span>
-                          <div className="text-xs text-gray-500">{globalConfig.type || 'rotation'}{globalConfig.intervalMs ? ` (${Math.round(globalConfig.intervalMs / 3600000)}h)` : ''}</div>
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-center">
+            return (
+              <div key={taskType} className="bg-port-card border border-port-border rounded-lg p-3 space-y-2">
+                {/* Row 1: name + toggle + run now */}
+                <div className="flex items-center gap-3">
+                  <button
+                    onClick={() => handleToggle(taskType, isEnabled)}
+                    className={`w-10 h-5 rounded-full transition-colors relative shrink-0 ${
+                      isEnabled ? 'bg-port-success' : 'bg-gray-600'
+                    }`}
+                  >
+                    <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+                      isEnabled ? 'left-5' : 'left-0.5'
+                    }`} />
+                  </button>
+                  <div className="flex-1 min-w-0">
+                    <span className="text-white font-mono text-xs">{taskType}</span>
+                    <div className="text-xs text-gray-500">{effectiveLabel}{intervalSuffix}</div>
+                  </div>
+                  <button
+                    onClick={() => handleTrigger(taskType)}
+                    disabled={triggering === taskType || !isEnabled}
+                    className="px-2 py-1 bg-port-accent/20 text-port-accent hover:bg-port-accent/30 rounded text-xs disabled:opacity-50 inline-flex items-center gap-1 shrink-0"
+                  >
+                    <Play size={12} />
+                    {triggering === taskType ? '...' : 'Run'}
+                  </button>
+                </div>
+                {/* Row 2: interval + cron + agent options */}
+                <div className="flex flex-wrap items-center gap-2">
+                  <select
+                    value={cronEditing[taskType] !== undefined || isCronExpression(overrideInterval) ? 'cron' : (overrideInterval ?? 'null')}
+                    onChange={e => handleIntervalChange(taskType, e.target.value)}
+                    className="px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white focus:border-port-accent focus:outline-hidden"
+                  >
+                    {INTERVAL_OPTIONS.map(opt => (
+                      <option key={String(opt.value)} value={String(opt.value)}>{opt.label}</option>
+                    ))}
+                  </select>
+                  {cronEditing[taskType] !== undefined ? (
+                    <CronInput
+                      value={cronEditing[taskType]}
+                      onSave={expr => handleCronSave(taskType, expr)}
+                      onCancel={() => setCronEditing(prev => { const n = { ...prev }; delete n[taskType]; return n; })}
+                    />
+                  ) : isCronExpression(overrideInterval) ? (
+                    <button
+                      onClick={() => setCronEditing(prev => ({ ...prev, [taskType]: overrideInterval }))}
+                      className="px-2 py-1 text-xs text-gray-400 font-mono bg-port-bg border border-port-border rounded hover:border-port-accent cursor-pointer"
+                      title={describeCron(overrideInterval)}
+                    >
+                      {overrideInterval}
+                    </button>
+                  ) : null}
+                  <div className="flex items-center gap-1 ml-auto">
+                    {AGENT_OPTIONS.map(({ field, shortLabel, label }) => {
+                      const effective = override.taskMetadata?.[field] ?? globalConfig.taskMetadata?.[field] ?? false;
+                      const hasOverride = override.taskMetadata?.[field] !== undefined;
+                      return (
                         <button
-                          onClick={() => handleToggle(taskType, isEnabled)}
-                          className={`w-10 h-5 rounded-full transition-colors relative ${
-                            isEnabled ? 'bg-port-success' : 'bg-gray-600'
+                          key={field}
+                          onClick={() => handleMetaToggle(taskType, field, globalConfig.taskMetadata)}
+                          aria-pressed={effective}
+                          aria-label={`${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`}
+                          className={`text-xs px-1.5 py-0.5 rounded transition-colors ${
+                            effective
+                              ? hasOverride ? 'bg-port-accent/30 text-port-accent' : 'bg-port-accent/15 text-port-accent/60'
+                              : hasOverride ? 'bg-gray-600/50 text-gray-400' : 'bg-gray-600/25 text-gray-500'
                           }`}
+                          title={`${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`}
                         >
-                          <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
-                            isEnabled ? 'left-5' : 'left-0.5'
-                          }`} />
+                          {shortLabel}
                         </button>
-                      </td>
-                      <td className="px-4 py-3">
-                        <select
-                          value={overrideInterval ?? 'null'}
-                          onChange={e => handleIntervalChange(taskType, e.target.value)}
-                          className="px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white focus:border-port-accent focus:outline-hidden"
-                        >
-                          {INTERVAL_OPTIONS.map(opt => (
-                            <option key={String(opt.value)} value={String(opt.value)}>{opt.label}</option>
-                          ))}
-                        </select>
-                      </td>
-                      <td className="px-4 py-3">
-                        <div className="flex items-center justify-center gap-1">
-                          {AGENT_OPTIONS.map(({ field, shortLabel, label }) => {
-                            const effective = override.taskMetadata?.[field] ?? globalConfig.taskMetadata?.[field] ?? false;
-                            const hasOverride = override.taskMetadata?.[field] !== undefined;
-                            return (
-                              <button
-                                key={field}
-                                onClick={() => handleMetaToggle(taskType, field, globalConfig.taskMetadata)}
-                                aria-pressed={effective}
-                                aria-label={`${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`}
-                                className={`text-xs px-1.5 py-0.5 rounded transition-colors ${
-                                  effective
-                                    ? hasOverride ? 'bg-port-accent/30 text-port-accent' : 'bg-port-accent/15 text-port-accent/60'
-                                    : hasOverride ? 'bg-gray-600/50 text-gray-400' : 'bg-gray-600/25 text-gray-500'
-                                }`}
-                                title={`${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`}
-                              >
-                                {shortLabel}
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-right">
-                        <button
-                          onClick={() => handleTrigger(taskType)}
-                          disabled={triggering === taskType || !isEnabled}
-                          className="px-2 py-1 bg-port-accent/20 text-port-accent hover:bg-port-accent/30 rounded text-xs disabled:opacity-50 inline-flex items-center gap-1"
-                        >
-                          <Play size={12} />
-                          {triggering === taskType ? '...' : 'Run Now'}
-                        </button>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
         </div>
       )}
     </div>

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -189,10 +189,11 @@ function JobCard({ job, onToggle, onTrigger, onDelete, onUpdate }) {
 
   const handleSave = async () => {
     const payload = normalizeJobPayload(editData);
-    await api.updateCosJob(job.id, payload).catch(err => {
+    const result = await api.updateCosJob(job.id, payload).catch(err => {
       toast.error(err.message);
       return null;
     });
+    if (!result) return;
     toast.success('Job updated');
     setEditing(false);
     onUpdate();
@@ -544,10 +545,11 @@ export default function JobsTab() {
   };
 
   const handleDelete = async (jobId) => {
-    await api.deleteCosJob(jobId).catch(err => {
+    const result = await api.deleteCosJob(jobId).catch(err => {
       toast.error(err.message);
       return null;
     });
+    if (!result) return;
     toast.success('Job deleted');
     fetchJobs();
   };

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -489,6 +489,10 @@ export default function JobsTab() {
       toast.error('Prompt template is required for AI jobs');
       return;
     }
+    if (newJob.scheduleMode === 'cron' && (!newJob.cronExpression?.trim() || newJob.cronExpression.trim().split(/\s+/).length !== 5)) {
+      toast.error('A valid 5-field cron expression is required for cron scheduling');
+      return;
+    }
 
     const created = await api.createCosJob(normalizeJobPayload(newJob)).catch(err => {
       toast.error(err.message);

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -3,6 +3,7 @@ import { Plus, RefreshCw, Play, Trash2, ChevronDown, ChevronUp, Clock, ToggleLef
 import toast from 'react-hot-toast';
 import * as api from '../../../services/api';
 import { timeAgo } from '../../../utils/formatters';
+import { CRON_PRESETS, describeCron } from '../../../utils/cronHelpers';
 
 const INTERVAL_OPTIONS = [
   { value: 'hourly', label: 'Every Hour' },
@@ -13,6 +14,11 @@ const INTERVAL_OPTIONS = [
   { value: 'weekly', label: 'Weekly' },
   { value: 'biweekly', label: 'Every 2 Weeks' },
   { value: 'monthly', label: 'Monthly' }
+];
+
+const SCHEDULE_MODE_OPTIONS = [
+  { value: 'interval', label: 'Interval' },
+  { value: 'cron', label: 'Cron' }
 ];
 
 const PRIORITY_OPTIONS = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
@@ -39,7 +45,95 @@ const JOB_TYPE_OPTIONS = [
   { value: 'shell', label: 'Shell Command' }
 ];
 
-function formatNextDue(lastRun, intervalMs, scheduledTime) {
+function normalizeJobPayload(formData) {
+  const payload = { ...formData };
+  if (payload.type !== 'shell' && payload.type !== 'script') {
+    payload.command = null;
+    payload.triggerAction = null;
+  }
+  if (payload.scheduleMode === 'cron') {
+    payload.cronExpression = payload.cronExpression?.trim() || null;
+    payload.scheduledTime = null;
+  } else {
+    payload.cronExpression = null;
+  }
+  delete payload.scheduleMode;
+  return payload;
+}
+
+function ScheduleFields({ data, onChange }) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-gray-400">Schedule:</span>
+        {SCHEDULE_MODE_OPTIONS.map(opt => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange('scheduleMode', opt.value)}
+            className={`px-2 py-1 text-xs rounded transition-colors ${
+              data.scheduleMode === opt.value
+                ? 'bg-port-accent/20 text-port-accent'
+                : 'bg-port-bg text-gray-500 hover:text-gray-300'
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+      {data.scheduleMode === 'cron' ? (
+        <div className="flex gap-2 items-center">
+          <input
+            type="text"
+            value={data.cronExpression || ''}
+            onChange={e => onChange('cronExpression', e.target.value)}
+            className="flex-1 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono"
+            placeholder="0 7 * * *"
+            title="Cron expression: minute hour dayOfMonth month dayOfWeek"
+          />
+          <select
+            value=""
+            onChange={e => { if (e.target.value) onChange('cronExpression', e.target.value); }}
+            className="px-2 py-2 bg-port-bg border border-port-border rounded-lg text-gray-400 text-xs"
+          >
+            <option value="">Presets</option>
+            {CRON_PRESETS.map(p => (
+              <option key={p.value} value={p.value}>{p.label}</option>
+            ))}
+          </select>
+          {data.cronExpression && (
+            <span className="text-xs text-gray-500">{describeCron(data.cronExpression)}</span>
+          )}
+        </div>
+      ) : (
+        <div className="flex gap-3">
+          <select
+            value={data.interval}
+            onChange={e => onChange('interval', e.target.value)}
+            className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+          >
+            {INTERVAL_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+          <input
+            type="time"
+            value={data.scheduledTime || ''}
+            onChange={e => onChange('scheduledTime', e.target.value || null)}
+            className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+            title="Run at specific time (leave empty for any time)"
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatNextDue(job) {
+  // Cron jobs: show human-readable schedule (server computes exact next fire time)
+  if (job.cronExpression) return describeCron(job.cronExpression);
+
+  const { lastRun, intervalMs, scheduledTime } = job;
   if (!lastRun) return scheduledTime ? `at ${scheduledTime}` : 'Immediately';
   let nextDue = new Date(lastRun).getTime() + intervalMs;
   if (scheduledTime) {
@@ -50,10 +144,10 @@ function formatNextDue(lastRun, intervalMs, scheduledTime) {
   }
   const diff = nextDue - Date.now();
   if (diff <= 0) return 'Now';
-  const hours = Math.floor(diff / 3600000);
-  const days = Math.floor(hours / 24);
+  const hrs = Math.floor(diff / 3600000);
+  const days = Math.floor(hrs / 24);
   if (days > 0) return `in ${days}d`;
-  if (hours > 0) return `in ${hours}h`;
+  if (hrs > 0) return `in ${hrs}h`;
   const mins = Math.floor(diff / 60000);
   return `in ${mins}m`;
 }
@@ -77,8 +171,10 @@ function JobCard({ job, onToggle, onTrigger, onDelete, onUpdate }) {
       name: job.name,
       description: job.description,
       type: job.type || 'agent',
+      scheduleMode: job.cronExpression ? 'cron' : 'interval',
       interval: job.interval,
       scheduledTime: job.scheduledTime || '',
+      cronExpression: job.cronExpression || '',
       priority: job.priority,
       autonomyLevel: job.autonomyLevel,
       promptTemplate: job.promptTemplate || ''
@@ -92,11 +188,7 @@ function JobCard({ job, onToggle, onTrigger, onDelete, onUpdate }) {
   };
 
   const handleSave = async () => {
-    const payload = { ...editData };
-    if (payload.type !== 'shell' && payload.type !== 'script') {
-      payload.command = null;
-      payload.triggerAction = null;
-    }
+    const payload = normalizeJobPayload(editData);
     await api.updateCosJob(job.id, payload).catch(err => {
       toast.error(err.message);
       return null;
@@ -149,13 +241,18 @@ function JobCard({ job, onToggle, onTrigger, onDelete, onUpdate }) {
           <div className="flex items-center gap-3 text-xs text-gray-500 mt-1">
             <span className="flex items-center gap-1">
               <Clock size={10} />
-              {INTERVAL_OPTIONS.find(i => i.value === job.interval)?.label || job.interval}
-              {job.scheduledTime && ` at ${job.scheduledTime}`}
+              {job.cronExpression
+                ? <span title={job.cronExpression}>{describeCron(job.cronExpression)}</span>
+                : <>
+                    {INTERVAL_OPTIONS.find(i => i.value === job.interval)?.label || job.interval}
+                    {job.scheduledTime && ` at ${job.scheduledTime}`}
+                  </>
+              }
             </span>
             <span>Last: {timeAgo(job.lastRun, 'Never')}</span>
             {job.enabled && (
               <span className={isDue ? 'text-port-warning' : 'text-gray-500'}>
-                Next: {formatNextDue(job.lastRun, job.intervalMs, job.scheduledTime)}
+                Next: {formatNextDue(job)}
               </span>
             )}
             <span>Runs: {job.runCount || 0}</span>
@@ -224,22 +321,6 @@ function JobCard({ job, onToggle, onTrigger, onDelete, onUpdate }) {
                   {isScript && <option value="script">Script Handler</option>}
                 </select>
                 <select
-                  value={editData.interval}
-                  onChange={e => setEditData(d => ({ ...d, interval: e.target.value }))}
-                  className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
-                >
-                  {INTERVAL_OPTIONS.map(opt => (
-                    <option key={opt.value} value={opt.value}>{opt.label}</option>
-                  ))}
-                </select>
-                <input
-                  type="time"
-                  value={editData.scheduledTime || ''}
-                  onChange={e => setEditData(d => ({ ...d, scheduledTime: e.target.value || null }))}
-                  className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
-                  title="Run at specific time (leave empty for any time)"
-                />
-                <select
                   value={editData.priority}
                   onChange={e => setEditData(d => ({ ...d, priority: e.target.value }))}
                   className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
@@ -260,6 +341,7 @@ function JobCard({ job, onToggle, onTrigger, onDelete, onUpdate }) {
                   </select>
                 )}
               </div>
+              <ScheduleFields data={editData} onChange={(key, val) => setEditData(d => ({ ...d, [key]: val }))} />
               {editData.type === 'shell' ? (
                 <>
                   <textarea
@@ -367,8 +449,10 @@ export default function JobsTab() {
     description: '',
     category: 'custom',
     type: 'agent',
+    scheduleMode: 'interval',
     interval: 'daily',
     scheduledTime: '',
+    cronExpression: '',
     priority: 'MEDIUM',
     autonomyLevel: 'manager',
     promptTemplate: '',
@@ -405,7 +489,7 @@ export default function JobsTab() {
       return;
     }
 
-    const created = await api.createCosJob(newJob).catch(err => {
+    const created = await api.createCosJob(normalizeJobPayload(newJob)).catch(err => {
       toast.error(err.message);
       return null;
     });
@@ -416,8 +500,10 @@ export default function JobsTab() {
       description: '',
       category: 'custom',
       type: 'agent',
+      scheduleMode: 'interval',
       interval: 'daily',
       scheduledTime: '',
+      cronExpression: '',
       priority: 'MEDIUM',
       autonomyLevel: 'manager',
       promptTemplate: '',
@@ -552,22 +638,6 @@ export default function JobsTab() {
             />
             <div className="flex gap-3">
               <select
-                value={newJob.interval}
-                onChange={e => setNewJob(j => ({ ...j, interval: e.target.value }))}
-                className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
-              >
-                {INTERVAL_OPTIONS.map(opt => (
-                  <option key={opt.value} value={opt.value}>{opt.label}</option>
-                ))}
-              </select>
-              <input
-                type="time"
-                value={newJob.scheduledTime || ''}
-                onChange={e => setNewJob(j => ({ ...j, scheduledTime: e.target.value || null }))}
-                className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
-                title="Run at specific time (leave empty for any time)"
-              />
-              <select
                 value={newJob.priority}
                 onChange={e => setNewJob(j => ({ ...j, priority: e.target.value }))}
                 className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
@@ -588,6 +658,7 @@ export default function JobsTab() {
                 </select>
               )}
             </div>
+            <ScheduleFields data={newJob} onChange={(key, val) => setNewJob(j => ({ ...j, [key]: val }))} />
             {newJob.type === 'shell' ? (
               <>
                 <textarea

--- a/client/src/components/cos/tabs/ScheduleTab.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.jsx
@@ -643,7 +643,7 @@ function AppTaskTypeRow({ taskType, config, onUpdate, onTrigger, onReset, provid
               {enabledCount}/{totalCount} apps
             </span>
           )}
-          <IntervalBadge type={config.type} />
+          <IntervalBadge type={config.type} cronExpression={config.cronExpression} />
         </div>
       </div>
 

--- a/client/src/components/cos/tabs/ScheduleTab.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.jsx
@@ -3,7 +3,9 @@ import { Play, RotateCcw, ChevronDown, ChevronRight, AlertCircle, RefreshCw, Pac
 import toast from 'react-hot-toast';
 import * as api from '../../../services/api';
 import AppIcon from '../../AppIcon';
+import CronInput from '../../CronInput';
 import { AGENT_OPTIONS, toggleAppMetadataOverride } from '../constants';
+import { isCronExpression, describeCron } from '../../../utils/cronHelpers';
 
 const INTERVAL_LABELS = {
   rotation: 'Rotation',
@@ -11,7 +13,8 @@ const INTERVAL_LABELS = {
   weekly: 'Weekly',
   once: 'Once',
   'on-demand': 'On Demand',
-  custom: 'Custom'
+  custom: 'Custom',
+  cron: 'Cron'
 };
 
 const INTERVAL_DESCRIPTIONS = {
@@ -20,7 +23,8 @@ const INTERVAL_DESCRIPTIONS = {
   weekly: 'Runs once per week',
   once: 'Runs once then stops',
   'on-demand': 'Only runs when manually triggered',
-  custom: 'Custom interval'
+  custom: 'Custom interval',
+  cron: 'Cron expression schedule'
 };
 
 // Toggle a global taskMetadata field, enforcing the openPR→useWorktree invariant.
@@ -41,16 +45,20 @@ function toggleMetadataField(metadata, field) {
 }
 
 
-function IntervalBadge({ type }) {
+function IntervalBadge({ type, cronExpression }) {
+  const label = type === 'cron' && cronExpression
+    ? describeCron(cronExpression) || cronExpression
+    : INTERVAL_LABELS[type] || type;
   return (
     <span className={`text-xs px-2 py-0.5 rounded ${
       type === 'daily' ? 'bg-port-accent/20 text-port-accent' :
       type === 'weekly' ? 'bg-purple-500/20 text-purple-400' :
       type === 'once' ? 'bg-port-warning/20 text-port-warning' :
       type === 'on-demand' ? 'bg-gray-500/20 text-gray-400' :
+      type === 'cron' ? 'bg-cyan-500/20 text-cyan-400' :
       'bg-port-success/20 text-port-success'
-    }`}>
-      {INTERVAL_LABELS[type]}
+    }`} title={type === 'cron' && cronExpression ? cronExpression : undefined}>
+      {label}
     </span>
   );
 }
@@ -87,12 +95,29 @@ function GlobalConfigControls({ taskType, config, onUpdate, onTrigger, onReset, 
 
   const activeApps = apps?.filter(app => !app.archived) || [];
 
+  const [cronEditing, setCronEditing] = useState(false);
+
   const handleTypeChange = async (newType) => {
+    if (newType === 'cron') {
+      setCronEditing(true);
+      setSelectedType('cron');
+      return;
+    }
+    setCronEditing(false);
     setUpdating(true);
     setSelectedType(newType);
-    await onUpdate(taskType, { type: newType }).catch(() => {
+    await onUpdate(taskType, { type: newType, cronExpression: null }).catch(() => {
       setSelectedType(config.type);
     });
+    setUpdating(false);
+  };
+
+  const handleCronSave = async (expr) => {
+    setUpdating(true);
+    await onUpdate(taskType, { type: 'cron', cronExpression: expr }).catch(() => {
+      setSelectedType(config.type);
+    });
+    setCronEditing(false);
     setUpdating(false);
   };
 
@@ -169,8 +194,18 @@ function GlobalConfigControls({ taskType, config, onUpdate, onTrigger, onReset, 
           <option value="weekly">Weekly (once per week)</option>
           <option value="once">Once (run once then stop)</option>
           <option value="on-demand">On Demand (manual trigger only)</option>
+          <option value="cron">Cron (custom schedule)</option>
         </select>
-        <p className="text-xs text-gray-500 mt-1">{INTERVAL_DESCRIPTIONS[selectedType]}</p>
+        {(selectedType === 'cron' && (cronEditing || config.type === 'cron')) ? (
+          <CronInput
+            value={config.cronExpression || '0 7 * * *'}
+            onSave={handleCronSave}
+            onCancel={() => { setCronEditing(false); setSelectedType(config.type); }}
+            className="mt-2"
+          />
+        ) : (
+          <p className="text-xs text-gray-500 mt-1">{INTERVAL_DESCRIPTIONS[selectedType]}</p>
+        )}
       </div>
 
       <div>
@@ -387,8 +422,10 @@ function GlobalConfigControls({ taskType, config, onUpdate, onTrigger, onReset, 
 
 function AppOverrideRow({ app, taskType, globalIntervalType, globalTaskMetadata, override, onUpdate }) {
   const [updating, setUpdating] = useState(false);
+  const [cronEditing, setCronEditing] = useState(false);
   const isEnabled = override?.enabled === true;
   const currentInterval = override?.interval || null;
+  const hasCron = isCronExpression(currentInterval);
 
   const handleToggle = async () => {
     setUpdating(true);
@@ -397,9 +434,21 @@ function AppOverrideRow({ app, taskType, globalIntervalType, globalTaskMetadata,
   };
 
   const handleIntervalChange = async (newInterval) => {
+    if (newInterval === 'cron') {
+      setCronEditing(true);
+      return;
+    }
+    setCronEditing(false);
     setUpdating(true);
     const interval = newInterval === '' ? null : newInterval;
     await onUpdate(app.id, taskType, { enabled: isEnabled, interval }).catch(() => {});
+    setUpdating(false);
+  };
+
+  const handleCronSave = async (expr) => {
+    setUpdating(true);
+    await onUpdate(app.id, taskType, { enabled: isEnabled, interval: expr }).catch(() => {});
+    setCronEditing(false);
     setUpdating(false);
   };
 
@@ -417,19 +466,37 @@ function AppOverrideRow({ app, taskType, globalIntervalType, globalTaskMetadata,
         <span className="text-sm text-white truncate">{app.name}</span>
       </div>
 
-      <select
-        value={currentInterval || ''}
-        onChange={(e) => handleIntervalChange(e.target.value)}
-        disabled={updating}
-        className="bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white min-w-[140px]"
-      >
-        <option value="">Inherit ({INTERVAL_LABELS[globalIntervalType]})</option>
-        <option value="rotation">Rotation</option>
-        <option value="daily">Daily</option>
-        <option value="weekly">Weekly</option>
-        <option value="once">Once</option>
-        <option value="on-demand">On Demand</option>
-      </select>
+      <div className="flex items-center gap-1">
+        <select
+          value={cronEditing || hasCron ? 'cron' : (currentInterval || '')}
+          onChange={(e) => handleIntervalChange(e.target.value)}
+          disabled={updating}
+          className="bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white min-w-[120px]"
+        >
+          <option value="">Inherit ({INTERVAL_LABELS[globalIntervalType] || globalIntervalType})</option>
+          <option value="rotation">Rotation</option>
+          <option value="daily">Daily</option>
+          <option value="weekly">Weekly</option>
+          <option value="once">Once</option>
+          <option value="on-demand">On Demand</option>
+          <option value="cron">Cron</option>
+        </select>
+        {cronEditing ? (
+          <CronInput
+            value={hasCron ? currentInterval : '0 7 * * *'}
+            onSave={handleCronSave}
+            onCancel={() => setCronEditing(false)}
+          />
+        ) : hasCron ? (
+          <button
+            onClick={() => setCronEditing(true)}
+            className="px-2 py-1 text-xs text-gray-400 font-mono bg-port-bg border border-port-border rounded hover:border-port-accent cursor-pointer"
+            title={describeCron(currentInterval)}
+          >
+            {currentInterval}
+          </button>
+        ) : null}
+      </div>
 
       {AGENT_OPTIONS.map(({ field, label, shortLabel }) => {
         const effective = override?.taskMetadata?.[field] ?? globalTaskMetadata?.[field] ?? false;

--- a/client/src/pages/CharacterSheet.jsx
+++ b/client/src/pages/CharacterSheet.jsx
@@ -71,7 +71,8 @@ export default function CharacterSheet() {
   const [evtDice, setEvtDice] = useState('');
 
   const load = useCallback(async () => {
-    const data = await get();
+    const data = await get().catch(() => null);
+    if (!data || data.error) return setLoading(false);
     setChar(data);
     setNameVal(data.name || '');
     setClassVal(data.class || '');

--- a/client/src/pages/CharacterSheet.jsx
+++ b/client/src/pages/CharacterSheet.jsx
@@ -1,0 +1,541 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  Sword, Star, Moon, ScrollText, Shield, Heart,
+  Sparkles, RefreshCw, Dices, X, ChevronDown, Zap
+} from 'lucide-react';
+
+const API = '/api/character';
+const fetchJson = (url, opts) => fetch(url, opts).then(r => r.json());
+const get = () => fetchJson(API);
+const post = (path, body) =>
+  fetchJson(`${API}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+const put = (body) =>
+  fetchJson(API, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+
+// D&D 5e XP thresholds (must match server)
+const XP_THRESHOLDS = [
+  0, 300, 900, 2700, 6500, 14000, 23000, 34000, 48000, 64000,
+  85000, 100000, 120000, 140000, 165000, 195000, 225000, 265000, 305000, 355000
+];
+function xpForNextLevel(level) {
+  return level >= 20 ? XP_THRESHOLDS[19] : XP_THRESHOLDS[level];
+}
+function xpForCurrentLevel(level) {
+  return level <= 1 ? 0 : XP_THRESHOLDS[level - 1];
+}
+
+const EVENT_ICONS = {
+  damage: Sword,
+  xp: Star,
+  rest: Moon,
+  level_up: Sparkles,
+  custom: ScrollText,
+  sync: RefreshCw
+};
+
+const EVENT_COLORS = {
+  damage: 'text-port-error',
+  xp: 'text-port-warning',
+  rest: 'text-port-accent',
+  level_up: 'text-purple-400',
+  custom: 'text-gray-400',
+  sync: 'text-port-accent'
+};
+
+function relativeTime(ts) {
+  const diff = Date.now() - new Date(ts).getTime();
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 24) return `${hrs}h ago`;
+  const days = Math.floor(hrs / 24);
+  if (days < 30) return `${days}d ago`;
+  return `${Math.floor(days / 30)}mo ago`;
+}
+
+function hpColor(pct) {
+  if (pct > 50) return 'bg-port-success';
+  if (pct > 25) return 'bg-port-warning';
+  return 'bg-port-error';
+}
+
+export default function CharacterSheet() {
+  const [char, setChar] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [activeAction, setActiveAction] = useState(null);
+  const [editingName, setEditingName] = useState(false);
+  const [editingClass, setEditingClass] = useState(false);
+  const [nameVal, setNameVal] = useState('');
+  const [classVal, setClassVal] = useState('');
+  const [syncing, setSyncing] = useState(null);
+
+  // Form states
+  const [dmgDice, setDmgDice] = useState('1d6');
+  const [dmgDesc, setDmgDesc] = useState('');
+  const [xpAmount, setXpAmount] = useState('');
+  const [xpDesc, setXpDesc] = useState('');
+  const [evtDesc, setEvtDesc] = useState('');
+  const [evtXp, setEvtXp] = useState('');
+  const [evtDice, setEvtDice] = useState('');
+
+  const load = useCallback(async () => {
+    const data = await get();
+    setChar(data);
+    setNameVal(data.name || '');
+    setClassVal(data.class || '');
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  const toggleAction = (action) => {
+    setActiveAction(prev => prev === action ? null : action);
+  };
+
+  const handleDamage = async () => {
+    const result = await post('/damage', { diceNotation: dmgDice, description: dmgDesc || undefined });
+    setChar(result.character);
+    setActiveAction(null);
+    setDmgDice('1d6');
+    setDmgDesc('');
+  };
+
+  const handleShortRest = async () => {
+    const result = await post('/rest', { type: 'short' });
+    setChar(result.character);
+  };
+
+  const handleLongRest = async () => {
+    const result = await post('/rest', { type: 'long' });
+    setChar(result.character);
+  };
+
+  const handleAddXp = async () => {
+    if (!xpAmount) return;
+    const result = await post('/xp', { amount: Number(xpAmount), source: 'manual', description: xpDesc || undefined });
+    setChar(result.character);
+    setActiveAction(null);
+    setXpAmount('');
+    setXpDesc('');
+  };
+
+  const handleLogEvent = async () => {
+    if (!evtDesc) return;
+    const body = { description: evtDesc };
+    if (evtXp) body.xp = Number(evtXp);
+    if (evtDice) body.diceNotation = evtDice;
+    const result = await post('/event', body);
+    setChar(result.character);
+    setActiveAction(null);
+    setEvtDesc('');
+    setEvtXp('');
+    setEvtDice('');
+  };
+
+  const handleSync = async (type) => {
+    setSyncing(type);
+    const result = await post(`/sync/${type}`, {});
+    setChar(result.character);
+    setSyncing(null);
+  };
+
+  const handleNameSave = async () => {
+    if (nameVal.trim() && nameVal !== char.name) {
+      const data = await put({ name: nameVal.trim() });
+      setChar(data);
+    }
+    setEditingName(false);
+  };
+
+  const handleClassSave = async () => {
+    if (classVal.trim() && classVal !== char.class) {
+      const data = await put({ class: classVal.trim() });
+      setChar(data);
+    }
+    setEditingClass(false);
+  };
+
+  if (loading || !char) {
+    return (
+      <div className="h-full flex items-center justify-center text-gray-400">
+        <RefreshCw className="w-6 h-6 animate-spin mr-2" /> Loading character...
+      </div>
+    );
+  }
+
+  const hpPct = Math.max(0, Math.min(100, (char.hp / char.maxHp) * 100));
+  const nextLevelXP = xpForNextLevel(char.level);
+  const currentLevelXP = xpForCurrentLevel(char.level);
+  const levelRange = nextLevelXP - currentLevelXP;
+  const xpPct = char.level >= 20 ? 100 : Math.max(0, Math.min(100, ((char.xp - currentLevelXP) / levelRange) * 100));
+
+  return (
+    <div className="h-full flex flex-col overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-6 py-4 border-b border-port-border bg-port-card">
+        <div className="flex items-center gap-3">
+          <Shield className="w-6 h-6 text-port-accent" />
+          <h1 className="text-xl font-semibold text-white">Character Sheet</h1>
+        </div>
+        <button
+          onClick={() => { setLoading(true); load(); }}
+          className="p-2 rounded-lg text-gray-400 hover:text-white hover:bg-port-border/50"
+          title="Refresh"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto p-4 md:p-6 space-y-4">
+        {/* Character Identity & Stats */}
+        <div className="bg-port-card border border-port-border rounded-xl p-4 md:p-6">
+          <div className="flex flex-col md:flex-row md:items-start gap-4">
+            {/* Name, Class, Level */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-3 mb-1">
+                {editingName ? (
+                  <input
+                    autoFocus
+                    value={nameVal}
+                    onChange={e => setNameVal(e.target.value)}
+                    onBlur={handleNameSave}
+                    onKeyDown={e => e.key === 'Enter' && handleNameSave()}
+                    className="bg-port-bg border border-port-border rounded px-2 py-1 text-2xl font-bold text-white w-full max-w-xs"
+                  />
+                ) : (
+                  <h2
+                    onClick={() => setEditingName(true)}
+                    className="text-2xl font-bold text-white cursor-pointer hover:text-port-accent transition-colors truncate"
+                    title="Click to edit name"
+                  >
+                    {char.name || 'Unnamed Hero'}
+                  </h2>
+                )}
+              </div>
+              <div className="flex items-center gap-2">
+                {editingClass ? (
+                  <input
+                    autoFocus
+                    value={classVal}
+                    onChange={e => setClassVal(e.target.value)}
+                    onBlur={handleClassSave}
+                    onKeyDown={e => e.key === 'Enter' && handleClassSave()}
+                    className="bg-port-bg border border-port-border rounded px-2 py-1 text-sm text-gray-300 w-full max-w-xs"
+                  />
+                ) : (
+                  <span
+                    onClick={() => setEditingClass(true)}
+                    className="text-sm text-gray-400 cursor-pointer hover:text-port-accent transition-colors"
+                    title="Click to edit class"
+                  >
+                    {char.class || 'Adventurer'}
+                  </span>
+                )}
+              </div>
+            </div>
+
+            {/* Level Badge */}
+            <div className="flex-shrink-0 flex items-center gap-3">
+              <div className="relative w-20 h-20 flex items-center justify-center rounded-full border-2 border-port-accent bg-port-bg">
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-port-accent">{char.level}</div>
+                  <div className="text-[10px] uppercase tracking-wider text-gray-500">Level</div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* HP Bar */}
+          <div className="mt-4">
+            <div className="flex items-center justify-between mb-1">
+              <div className="flex items-center gap-1.5 text-sm font-medium text-gray-300">
+                <Heart className="w-4 h-4 text-port-error" />
+                HP
+              </div>
+              <span className="text-sm text-gray-400">
+                {char.hp} / {char.maxHp}
+              </span>
+            </div>
+            <div className="h-5 bg-port-bg rounded-full overflow-hidden border border-port-border">
+              <div
+                className={`h-full rounded-full transition-all duration-500 ease-out ${hpColor(hpPct)}`}
+                style={{ width: `${hpPct}%` }}
+              />
+            </div>
+          </div>
+
+          {/* XP Bar */}
+          <div className="mt-3">
+            <div className="flex items-center justify-between mb-1">
+              <div className="flex items-center gap-1.5 text-sm font-medium text-gray-300">
+                <Sparkles className="w-4 h-4 text-port-warning" />
+                XP
+              </div>
+              <span className="text-sm text-gray-400">
+                {char.xp} / {nextLevelXP}
+              </span>
+            </div>
+            <div className="h-3 bg-port-bg rounded-full overflow-hidden border border-port-border">
+              <div
+                className="h-full rounded-full transition-all duration-500 ease-out bg-port-warning"
+                style={{ width: `${xpPct}%` }}
+              />
+            </div>
+          </div>
+        </div>
+
+        {/* Quick Actions */}
+        <div className="bg-port-card border border-port-border rounded-xl p-4">
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => toggleAction('damage')}
+              className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                activeAction === 'damage'
+                  ? 'bg-port-error text-white'
+                  : 'bg-port-error/20 text-port-error hover:bg-port-error/30'
+              }`}
+            >
+              <Sword className="w-4 h-4" /> Take Damage
+              <ChevronDown className={`w-3 h-3 transition-transform ${activeAction === 'damage' ? 'rotate-180' : ''}`} />
+            </button>
+
+            <button
+              onClick={handleShortRest}
+              className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-port-accent/20 text-port-accent hover:bg-port-accent/30 transition-colors"
+            >
+              <Moon className="w-4 h-4" /> Short Rest
+            </button>
+
+            <button
+              onClick={handleLongRest}
+              className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-port-success/20 text-port-success hover:bg-port-success/30 transition-colors"
+            >
+              <Zap className="w-4 h-4" /> Long Rest
+            </button>
+
+            <button
+              onClick={() => toggleAction('xp')}
+              className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                activeAction === 'xp'
+                  ? 'bg-port-warning text-black'
+                  : 'bg-port-warning/20 text-port-warning hover:bg-port-warning/30'
+              }`}
+            >
+              <Star className="w-4 h-4" /> Add XP
+              <ChevronDown className={`w-3 h-3 transition-transform ${activeAction === 'xp' ? 'rotate-180' : ''}`} />
+            </button>
+
+            <button
+              onClick={() => toggleAction('event')}
+              className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                activeAction === 'event'
+                  ? 'bg-purple-500 text-white'
+                  : 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
+              }`}
+            >
+              <ScrollText className="w-4 h-4" /> Log Event
+              <ChevronDown className={`w-3 h-3 transition-transform ${activeAction === 'event' ? 'rotate-180' : ''}`} />
+            </button>
+
+            <button
+              onClick={() => handleSync('jira')}
+              disabled={syncing === 'jira'}
+              className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-port-border/50 text-gray-300 hover:bg-port-border hover:text-white transition-colors disabled:opacity-50"
+            >
+              <RefreshCw className={`w-4 h-4 ${syncing === 'jira' ? 'animate-spin' : ''}`} /> Sync JIRA
+            </button>
+
+            <button
+              onClick={() => handleSync('tasks')}
+              disabled={syncing === 'tasks'}
+              className="flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium bg-port-border/50 text-gray-300 hover:bg-port-border hover:text-white transition-colors disabled:opacity-50"
+            >
+              <RefreshCw className={`w-4 h-4 ${syncing === 'tasks' ? 'animate-spin' : ''}`} /> Sync Tasks
+            </button>
+          </div>
+
+          {/* Inline Action Forms */}
+          {activeAction === 'damage' && (
+            <div className="mt-3 p-3 bg-port-bg rounded-lg border border-port-error/30 space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-port-error">Roll Damage</span>
+                <button onClick={() => setActiveAction(null)} className="text-gray-500 hover:text-white">
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <div className="flex items-center gap-2">
+                  <Dices className="w-4 h-4 text-gray-400" />
+                  <input
+                    value={dmgDice}
+                    onChange={e => setDmgDice(e.target.value)}
+                    placeholder="1d8"
+                    className="bg-port-card border border-port-border rounded px-2 py-1.5 text-sm text-white w-24"
+                  />
+                </div>
+                <input
+                  value={dmgDesc}
+                  onChange={e => setDmgDesc(e.target.value)}
+                  placeholder="Description (optional)"
+                  className="bg-port-card border border-port-border rounded px-2 py-1.5 text-sm text-white flex-1"
+                />
+                <button
+                  onClick={handleDamage}
+                  className="px-4 py-1.5 bg-port-error text-white rounded text-sm font-medium hover:bg-port-error/80 transition-colors"
+                >
+                  Roll
+                </button>
+              </div>
+            </div>
+          )}
+
+          {activeAction === 'xp' && (
+            <div className="mt-3 p-3 bg-port-bg rounded-lg border border-port-warning/30 space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-port-warning">Add Experience</span>
+                <button onClick={() => setActiveAction(null)} className="text-gray-500 hover:text-white">
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+              <div className="flex flex-col sm:flex-row gap-2">
+                <input
+                  type="number"
+                  value={xpAmount}
+                  onChange={e => setXpAmount(e.target.value)}
+                  placeholder="XP amount"
+                  className="bg-port-card border border-port-border rounded px-2 py-1.5 text-sm text-white w-28"
+                />
+                <input
+                  value={xpDesc}
+                  onChange={e => setXpDesc(e.target.value)}
+                  placeholder="Description (optional)"
+                  className="bg-port-card border border-port-border rounded px-2 py-1.5 text-sm text-white flex-1"
+                />
+                <button
+                  onClick={handleAddXp}
+                  className="px-4 py-1.5 bg-port-warning text-black rounded text-sm font-medium hover:bg-port-warning/80 transition-colors"
+                >
+                  Add
+                </button>
+              </div>
+            </div>
+          )}
+
+          {activeAction === 'event' && (
+            <div className="mt-3 p-3 bg-port-bg rounded-lg border border-purple-500/30 space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-purple-400">Log Event</span>
+                <button onClick={() => setActiveAction(null)} className="text-gray-500 hover:text-white">
+                  <X className="w-4 h-4" />
+                </button>
+              </div>
+              <div className="flex flex-col gap-2">
+                <input
+                  value={evtDesc}
+                  onChange={e => setEvtDesc(e.target.value)}
+                  placeholder="What happened?"
+                  className="bg-port-card border border-port-border rounded px-2 py-1.5 text-sm text-white"
+                />
+                <div className="flex flex-col sm:flex-row gap-2">
+                  <input
+                    type="number"
+                    value={evtXp}
+                    onChange={e => setEvtXp(e.target.value)}
+                    placeholder="XP (optional)"
+                    className="bg-port-card border border-port-border rounded px-2 py-1.5 text-sm text-white w-28"
+                  />
+                  <div className="flex items-center gap-2">
+                    <Dices className="w-4 h-4 text-gray-400" />
+                    <input
+                      value={evtDice}
+                      onChange={e => setEvtDice(e.target.value)}
+                      placeholder="Dice (e.g. 2d6)"
+                      className="bg-port-card border border-port-border rounded px-2 py-1.5 text-sm text-white w-32"
+                    />
+                  </div>
+                  <button
+                    onClick={handleLogEvent}
+                    className="px-4 py-1.5 bg-purple-500 text-white rounded text-sm font-medium hover:bg-purple-500/80 transition-colors"
+                  >
+                    Log
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Event Log */}
+        <div className="bg-port-card border border-port-border rounded-xl flex flex-col min-h-0">
+          <div className="flex items-center gap-2 px-4 py-3 border-b border-port-border">
+            <ScrollText className="w-4 h-4 text-gray-400" />
+            <h3 className="text-sm font-medium text-gray-300">Event Log</h3>
+            <span className="text-xs text-gray-500">({char.events?.length || 0} entries)</span>
+          </div>
+          <div className="overflow-y-auto max-h-[400px] divide-y divide-port-border/50">
+            {(!char.events || char.events.length === 0) ? (
+              <div className="px-4 py-8 text-center text-gray-500 text-sm">
+                No events yet. Take an action to begin your adventure.
+              </div>
+            ) : (
+              [...char.events].reverse().map((evt, i) => {
+                const Icon = EVENT_ICONS[evt.type] || ScrollText;
+                const color = EVENT_COLORS[evt.type] || 'text-gray-400';
+                return (
+                  <div key={evt.id || i} className="px-4 py-3 flex items-start gap-3 hover:bg-port-bg/50 transition-colors">
+                    <div className={`mt-0.5 ${color}`}>
+                      <Icon className="w-4 h-4" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-baseline gap-2 flex-wrap">
+                        <span className="text-sm text-white">{evt.description}</span>
+                        {evt.xp > 0 && (
+                          <span className="text-xs font-medium text-port-success">
+                            +{evt.xp} XP
+                          </span>
+                        )}
+                        {evt.damage > 0 && (
+                          <span className="text-xs font-medium text-port-error">
+                            -{evt.damage} HP
+                          </span>
+                        )}
+                        {evt.hpRecovered > 0 && (
+                          <span className="text-xs font-medium text-port-success">
+                            +{evt.hpRecovered} HP
+                          </span>
+                        )}
+                      </div>
+                      {evt.diceNotation && (
+                        <div className="flex items-center gap-1.5 mt-1">
+                          <Dices className="w-3 h-3 text-gray-500" />
+                          <span className="text-xs text-gray-500">
+                            {evt.diceNotation}
+                            {evt.diceRolls && evt.diceRolls.length > 0 && (
+                              <> = [{evt.diceRolls.join(', ')}] = {evt.damage}</>
+                            )}
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                    <span className="text-xs text-gray-600 whitespace-nowrap mt-0.5">
+                      {relativeTime(evt.timestamp)}
+                    </span>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/CharacterSheet.jsx
+++ b/client/src/pages/CharacterSheet.jsx
@@ -3,6 +3,7 @@ import {
   Sword, Star, Moon, ScrollText, Shield, Heart,
   Sparkles, RefreshCw, Dices, X, ChevronDown, Zap
 } from 'lucide-react';
+import toast from 'react-hot-toast';
 import { timeAgo } from '../utils/formatters';
 
 const request = async (endpoint, options = {}) => {
@@ -64,6 +65,7 @@ function hpColor(pct) {
 export default function CharacterSheet() {
   const [char, setChar] = useState(null);
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
   const [activeAction, setActiveAction] = useState(null);
   const [editingName, setEditingName] = useState(false);
   const [editingClass, setEditingClass] = useState(false);
@@ -81,12 +83,21 @@ export default function CharacterSheet() {
   const [evtDice, setEvtDice] = useState('');
 
   const load = useCallback(async () => {
-    const data = await get().catch(() => null);
-    if (!data || data.error) return setLoading(false);
-    setChar(data);
-    setNameVal(data.name || '');
-    setClassVal(data.class || '');
-    setLoading(false);
+    setLoadError(null);
+    try {
+      const data = await get();
+      if (!data || data.error) {
+        setLoadError('Failed to load character data');
+        return;
+      }
+      setChar(data);
+      setNameVal(data.name || '');
+      setClassVal(data.class || '');
+    } catch (err) {
+      setLoadError(err.message || 'Failed to load character data');
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => { load(); }, [load]);
@@ -96,72 +107,102 @@ export default function CharacterSheet() {
   };
 
   const handleDamage = async () => {
-    const result = await post('/damage', { diceNotation: dmgDice, description: dmgDesc || undefined });
-    setChar(result.character);
-    setActiveAction(null);
-    setDmgDice('1d6');
-    setDmgDesc('');
+    try {
+      const result = await post('/damage', { diceNotation: dmgDice, description: dmgDesc || undefined });
+      setChar(result.character);
+      setActiveAction(null);
+      setDmgDice('1d6');
+      setDmgDesc('');
+    } catch (err) { toast.error(err.message || 'Failed to apply damage'); }
   };
 
   const handleShortRest = async () => {
-    const result = await post('/rest', { type: 'short' });
-    setChar(result.character);
+    try {
+      const result = await post('/rest', { type: 'short' });
+      setChar(result.character);
+    } catch (err) { toast.error(err.message || 'Failed to take short rest'); }
   };
 
   const handleLongRest = async () => {
-    const result = await post('/rest', { type: 'long' });
-    setChar(result.character);
+    try {
+      const result = await post('/rest', { type: 'long' });
+      setChar(result.character);
+    } catch (err) { toast.error(err.message || 'Failed to take long rest'); }
   };
 
   const handleAddXp = async () => {
     if (!xpAmount) return;
-    const result = await post('/xp', { amount: Number(xpAmount), source: 'manual', description: xpDesc || undefined });
-    setChar(result.character);
-    setActiveAction(null);
-    setXpAmount('');
-    setXpDesc('');
+    try {
+      const result = await post('/xp', { amount: Number(xpAmount), source: 'manual', description: xpDesc || undefined });
+      setChar(result.character);
+      setActiveAction(null);
+      setXpAmount('');
+      setXpDesc('');
+    } catch (err) { toast.error(err.message || 'Failed to add XP'); }
   };
 
   const handleLogEvent = async () => {
     if (!evtDesc) return;
-    const body = { description: evtDesc };
-    if (evtXp) body.xp = Number(evtXp);
-    if (evtDice) body.diceNotation = evtDice;
-    const result = await post('/event', body);
-    setChar(result.character);
-    setActiveAction(null);
-    setEvtDesc('');
-    setEvtXp('');
-    setEvtDice('');
+    try {
+      const body = { description: evtDesc };
+      if (evtXp) body.xp = Number(evtXp);
+      if (evtDice) body.diceNotation = evtDice;
+      const result = await post('/event', body);
+      setChar(result.character);
+      setActiveAction(null);
+      setEvtDesc('');
+      setEvtXp('');
+      setEvtDice('');
+    } catch (err) { toast.error(err.message || 'Failed to log event'); }
   };
 
   const handleSync = async (type) => {
     setSyncing(type);
-    const result = await post(`/sync/${type}`, {});
-    setChar(result.character);
-    setSyncing(null);
+    try {
+      const result = await post(`/sync/${type}`, {});
+      setChar(result.character);
+    } catch (err) {
+      toast.error(err.message || `Failed to sync ${type}`);
+    } finally {
+      setSyncing(null);
+    }
   };
 
   const handleNameSave = async () => {
-    if (nameVal.trim() && nameVal !== char.name) {
-      const data = await put({ name: nameVal.trim() });
-      setChar(data);
-    }
+    try {
+      if (nameVal.trim() && nameVal !== char.name) {
+        const data = await put({ name: nameVal.trim() });
+        setChar(data);
+      }
+    } catch (err) { toast.error(err.message || 'Failed to save name'); }
     setEditingName(false);
   };
 
   const handleClassSave = async () => {
-    if (classVal.trim() && classVal !== char.class) {
-      const data = await put({ class: classVal.trim() });
-      setChar(data);
-    }
+    try {
+      if (classVal.trim() && classVal !== char.class) {
+        const data = await put({ class: classVal.trim() });
+        setChar(data);
+      }
+    } catch (err) { toast.error(err.message || 'Failed to save class'); }
     setEditingClass(false);
   };
 
-  if (loading || !char) {
+  if (loading) {
     return (
       <div className="h-full flex items-center justify-center text-gray-400">
         <RefreshCw className="w-6 h-6 animate-spin mr-2" /> Loading character...
+      </div>
+    );
+  }
+
+  if (loadError || !char) {
+    return (
+      <div className="h-full flex flex-col items-center justify-center text-gray-400 gap-4">
+        <p className="text-port-error">{loadError || 'Failed to load character data'}</p>
+        <button onClick={load} className="px-4 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg text-sm transition-colors">
+          Retry
+        </button>
       </div>
     );
   }

--- a/client/src/pages/CharacterSheet.jsx
+++ b/client/src/pages/CharacterSheet.jsx
@@ -5,11 +5,21 @@ import {
 } from 'lucide-react';
 import { timeAgo } from '../utils/formatters';
 
-const request = (endpoint, options = {}) =>
-  fetch(`/api/character${endpoint}`, {
+const request = async (endpoint, options = {}) => {
+  const response = await fetch(`/api/character${endpoint}`, {
     headers: { 'Content-Type': 'application/json', ...options.headers },
     ...options
-  }).then(r => r.json());
+  });
+  let data = null;
+  try { data = await response.json(); } catch { /* non-JSON body */ }
+  if (!response.ok) {
+    const message = data?.message || `Request failed with status ${response.status}`;
+    const error = new Error(message);
+    error.status = response.status;
+    throw error;
+  }
+  return data;
+};
 
 const get = () => request('');
 const post = (path, body) => request(path, { method: 'POST', body: JSON.stringify(body) });

--- a/client/src/pages/CharacterSheet.jsx
+++ b/client/src/pages/CharacterSheet.jsx
@@ -3,22 +3,17 @@ import {
   Sword, Star, Moon, ScrollText, Shield, Heart,
   Sparkles, RefreshCw, Dices, X, ChevronDown, Zap
 } from 'lucide-react';
+import { timeAgo } from '../utils/formatters';
 
-const API = '/api/character';
-const fetchJson = (url, opts) => fetch(url, opts).then(r => r.json());
-const get = () => fetchJson(API);
-const post = (path, body) =>
-  fetchJson(`${API}${path}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body)
-  });
-const put = (body) =>
-  fetchJson(API, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body)
-  });
+const request = (endpoint, options = {}) =>
+  fetch(`/api/character${endpoint}`, {
+    headers: { 'Content-Type': 'application/json', ...options.headers },
+    ...options
+  }).then(r => r.json());
+
+const get = () => request('');
+const post = (path, body) => request(path, { method: 'POST', body: JSON.stringify(body) });
+const put = (body) => request('', { method: 'PUT', body: JSON.stringify(body) });
 
 // D&D 5e XP thresholds (must match server)
 const XP_THRESHOLDS = [
@@ -49,18 +44,6 @@ const EVENT_COLORS = {
   custom: 'text-gray-400',
   sync: 'text-port-accent'
 };
-
-function relativeTime(ts) {
-  const diff = Date.now() - new Date(ts).getTime();
-  const mins = Math.floor(diff / 60000);
-  if (mins < 1) return 'just now';
-  if (mins < 60) return `${mins}m ago`;
-  const hrs = Math.floor(mins / 60);
-  if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  if (days < 30) return `${days}d ago`;
-  return `${Math.floor(days / 30)}mo ago`;
-}
 
 function hpColor(pct) {
   if (pct > 50) return 'bg-port-success';
@@ -527,7 +510,7 @@ export default function CharacterSheet() {
                       )}
                     </div>
                     <span className="text-xs text-gray-600 whitespace-nowrap mt-0.5">
-                      {relativeTime(evt.timestamp)}
+                      {timeAgo(evt.timestamp)}
                     </span>
                   </div>
                 );

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Save, Plus, X, Eye, EyeOff, Trash2, Send, Container, HardDrive, Download, ArrowRightLeft, Wrench, RefreshCw, Square, RotateCw, Play } from 'lucide-react';
 import toast from 'react-hot-toast';
@@ -771,7 +771,84 @@ function TelegramTab() {
   );
 }
 
+function GeneralTab() {
+  const [loading, setLoading] = useState(true);
+  const [timezone, setTimezone] = useState('');
+  const [saving, setSaving] = useState(false);
+  const detectedTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const allTimezones = useMemo(() => Intl.supportedValuesOf?.('timeZone') ?? [], []);
+
+  useEffect(() => {
+    getSettings()
+      .then(settings => setTimezone(settings?.timezone || ''))
+      .catch(() => toast.error('Failed to load settings'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const handleSave = async (tz) => {
+    setSaving(true);
+    await updateSettings({ timezone: tz })
+      .then(() => {
+        setTimezone(tz);
+        toast.success(`Timezone set to ${tz}`);
+      })
+      .catch(() => toast.error('Failed to save timezone'))
+      .finally(() => setSaving(false));
+  };
+
+  if (loading) return <BrailleSpinner />;
+
+  return (
+    <div className="space-y-6">
+      <div className="bg-port-card border border-port-border rounded-lg p-6">
+        <h3 className="text-lg font-semibold text-white mb-4">Timezone</h3>
+        <p className="text-sm text-gray-400 mb-4">
+          Used for job scheduling (cron expressions & scheduled times) and briefing dates.
+        </p>
+        <div className="flex items-center gap-3">
+          <input
+            type="text"
+            value={timezone}
+            onChange={e => setTimezone(e.target.value)}
+            placeholder={detectedTz}
+            className="flex-1 max-w-xs px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm"
+            list="tz-list"
+          />
+          <button
+            onClick={() => handleSave(timezone || detectedTz)}
+            disabled={saving}
+            className="px-4 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg text-sm transition-colors disabled:opacity-50"
+          >
+            <Save size={14} className="inline mr-1" />
+            {saving ? 'Saving...' : 'Save'}
+          </button>
+          {!timezone && (
+            <button
+              onClick={() => handleSave(detectedTz)}
+              disabled={saving}
+              className="px-3 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+            >
+              Use detected: {detectedTz}
+            </button>
+          )}
+        </div>
+        {timezone && timezone !== detectedTz && (
+          <p className="text-xs text-gray-500 mt-2">
+            Browser detected: {detectedTz}
+          </p>
+        )}
+        <datalist id="tz-list">
+          {allTimezones.map(tz => (
+            <option key={tz} value={tz} />
+          ))}
+        </datalist>
+      </div>
+    </div>
+  );
+}
+
 const TABS = [
+  { id: 'general', label: 'General' },
   { id: 'backup', label: 'Backup' },
   { id: 'database', label: 'Database' },
   { id: 'telegram', label: 'Telegram' }
@@ -780,7 +857,7 @@ const TABS = [
 export default function Settings() {
   const { tab } = useParams();
   const navigate = useNavigate();
-  const activeTab = tab || 'backup';
+  const activeTab = tab || 'general';
 
   const handleTabChange = (tabId) => {
     navigate(`/settings/${tabId}`);
@@ -788,10 +865,11 @@ export default function Settings() {
 
   const renderTabContent = () => {
     switch (activeTab) {
+      case 'general': return <GeneralTab />;
       case 'backup': return <BackupTab />;
       case 'database': return <DatabaseTab />;
       case 'telegram': return <TelegramTab />;
-      default: return <BackupTab />;
+      default: return <GeneralTab />;
     }
   };
 

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -786,11 +786,32 @@ function GeneralTab() {
   }, []);
 
   const handleSave = async (tz) => {
+    const tzToSave = tz || detectedTz;
+    if (!tzToSave) {
+      toast.error('Timezone is required.');
+      return;
+    }
+
+    // Validate timezone string
+    let isValid = false;
+    if (allTimezones.length > 0) {
+      isValid = allTimezones.includes(tzToSave);
+    } else {
+      try {
+        new Intl.DateTimeFormat('en-US', { timeZone: tzToSave });
+        isValid = true;
+      } catch { isValid = false; }
+    }
+    if (!isValid) {
+      toast.error('Invalid timezone. Please select a valid IANA timezone.');
+      return;
+    }
+
     setSaving(true);
-    await updateSettings({ timezone: tz })
+    await updateSettings({ timezone: tzToSave })
       .then(() => {
-        setTimezone(tz);
-        toast.success(`Timezone set to ${tz}`);
+        setTimezone(tzToSave);
+        toast.success(`Timezone set to ${tzToSave}`);
       })
       .catch(() => toast.error('Failed to save timezone'))
       .finally(() => setSaving(false));
@@ -815,7 +836,7 @@ function GeneralTab() {
             list="tz-list"
           />
           <button
-            onClick={() => handleSave(timezone || detectedTz)}
+            onClick={() => handleSave(timezone)}
             disabled={saving}
             className="px-4 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg text-sm transition-colors disabled:opacity-50"
           >

--- a/client/src/utils/cronHelpers.js
+++ b/client/src/utils/cronHelpers.js
@@ -1,0 +1,40 @@
+export const CRON_PRESETS = [
+  { value: '*/15 * * * *', label: 'Every 15 min' },
+  { value: '0 * * * *', label: 'Every hour' },
+  { value: '0 */2 * * *', label: 'Every 2 hours' },
+  { value: '0 */4 * * *', label: 'Every 4 hours' },
+  { value: '0 */6 * * *', label: 'Every 6 hours' },
+  { value: '0 7 * * *', label: 'Daily at 7 AM' },
+  { value: '0 7 * * 1-5', label: 'Weekdays at 7 AM' },
+  { value: '0 9,12,15,18 * * *', label: 'Peak hours (9, 12, 3, 6)' },
+  { value: '0 0 * * 0', label: 'Weekly Sun midnight' },
+  { value: '0 0 1 * *', label: 'Monthly 1st at midnight' }
+];
+
+export function isCronExpression(val) {
+  return typeof val === 'string' && val.trim().split(/\s+/).length === 5;
+}
+
+const DOW_MAP = { '0': 'Sun', '1': 'Mon', '2': 'Tue', '3': 'Wed', '4': 'Thu', '5': 'Fri', '6': 'Sat', '7': 'Sun' };
+
+export function describeCron(expr) {
+  if (!expr) return '';
+  const parts = expr.trim().split(/\s+/);
+  if (parts.length !== 5) return expr;
+  const [min, hour, dom, mon, dow] = parts;
+  const segments = [];
+  if (min === '0' && hour !== '*') {
+    if (dow === '1-5') segments.push('Weekdays');
+    else if (dow !== '*') segments.push(dow.split(',').map(d => DOW_MAP[d] || d).join(', '));
+    if (dom !== '*') segments.push(`day ${dom}`);
+    if (mon !== '*') segments.push(`month ${mon}`);
+    segments.push(`at ${hour.padStart(2, '0')}:${min.padStart(2, '0')}`);
+  } else if (min.startsWith('*/')) {
+    segments.push(`every ${min.slice(2)} min`);
+  } else if (hour.startsWith('*/')) {
+    segments.push(`every ${hour.slice(2)} hours at :${min.padStart(2, '0')}`);
+  } else {
+    return expr;
+  }
+  return segments.join(' ');
+}

--- a/data.sample/brain/meta.json
+++ b/data.sample/brain/meta.json
@@ -5,7 +5,7 @@
   "weeklyReviewTime": "16:00",
   "weeklyReviewDay": "sunday",
   "defaultProvider": "lmstudio",
-  "defaultModel": "gptoss-20b",
+  "defaultModel": "",
   "lastDailyDigest": null,
   "lastWeeklyReview": null
 }

--- a/data.sample/meatspace/post-drill-cache.json
+++ b/data.sample/meatspace/post-drill-cache.json
@@ -1,0 +1,1913 @@
+{
+  "compound-chain": [
+    {
+      "type": "compound-chain",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "rootWord": "fire",
+          "position": "both",
+          "examples": [
+            "firehouse",
+            "firewall",
+            "campfire",
+            "wildfire",
+            "backfire"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "cross",
+          "position": "both",
+          "examples": [
+            "crossword",
+            "crossbow",
+            "crossroads",
+            "double-cross",
+            "crisscross"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "hand",
+          "position": "both",
+          "examples": [
+            "handshake",
+            "handbook",
+            "backhand",
+            "shorthand",
+            "firsthand"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "break",
+          "position": "both",
+          "examples": [
+            "breakfast",
+            "breakdown",
+            "heartbreak",
+            "daybreak",
+            "jawbreaker"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "light",
+          "position": "both",
+          "examples": [
+            "lighthouse",
+            "spotlight",
+            "moonlight",
+            "flashlight",
+            "lightweight"
+          ],
+          "minExpected": 12
+        }
+      ]
+    },
+    {
+      "type": "compound-chain",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "rootWord": "light",
+          "position": "both",
+          "examples": [
+            "lighthouse",
+            "lightweight",
+            "flashlight",
+            "moonlight",
+            "spotlight"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "cross",
+          "position": "prefix",
+          "examples": [
+            "crossword",
+            "crossroads",
+            "crossfire",
+            "crossbow",
+            "crosswalk"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "break",
+          "position": "both",
+          "examples": [
+            "breakfast",
+            "breakthrough",
+            "daybreak",
+            "heartbreak",
+            "outbreak"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "head",
+          "position": "both",
+          "examples": [
+            "headline",
+            "headphones",
+            "forehead",
+            "overhead",
+            "figurehead"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "ground",
+          "position": "both",
+          "examples": [
+            "groundwork",
+            "underground",
+            "playground",
+            "background",
+            "groundwater"
+          ],
+          "minExpected": 10
+        }
+      ]
+    },
+    {
+      "type": "compound-chain",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "rootWord": "fire",
+          "position": "both",
+          "examples": [
+            "firehouse",
+            "firewall",
+            "firework",
+            "campfire",
+            "crossfire"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "back",
+          "position": "both",
+          "examples": [
+            "backbone",
+            "backpack",
+            "backstage",
+            "feedback",
+            "flashback"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "cross",
+          "position": "prefix",
+          "examples": [
+            "crossword",
+            "crossbow",
+            "crossroad",
+            "crossover",
+            "crosswalk"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "break",
+          "position": "both",
+          "examples": [
+            "breakfast",
+            "breakthrough",
+            "breakwater",
+            "daybreak",
+            "jailbreak"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "light",
+          "position": "both",
+          "examples": [
+            "lighthouse",
+            "lightweight",
+            "moonlight",
+            "spotlight",
+            "twilight"
+          ],
+          "minExpected": 12
+        }
+      ]
+    },
+    {
+      "type": "compound-chain",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "rootWord": "fire",
+          "position": "both",
+          "examples": [
+            "firehouse",
+            "firework",
+            "firefly",
+            "campfire",
+            "crossfire"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "cross",
+          "position": "both",
+          "examples": [
+            "crossword",
+            "crossbow",
+            "crossroads",
+            "crisscross",
+            "double-cross"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "light",
+          "position": "both",
+          "examples": [
+            "lighthouse",
+            "lightweight",
+            "flashlight",
+            "moonlight",
+            "spotlight"
+          ],
+          "minExpected": 14
+        },
+        {
+          "rootWord": "break",
+          "position": "both",
+          "examples": [
+            "breakfast",
+            "breakthrough",
+            "heartbreak",
+            "outbreak",
+            "jawbreaker"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "hand",
+          "position": "both",
+          "examples": [
+            "handshake",
+            "handbook",
+            "handwriting",
+            "backhand",
+            "shorthand"
+          ],
+          "minExpected": 10
+        }
+      ]
+    },
+    {
+      "type": "compound-chain",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "rootWord": "light",
+          "position": "both",
+          "examples": [
+            "lighthouse",
+            "lightweight",
+            "flashlight",
+            "moonlight",
+            "spotlight"
+          ],
+          "minExpected": 15
+        },
+        {
+          "rootWord": "hand",
+          "position": "both",
+          "examples": [
+            "handshake",
+            "handbook",
+            "handmade",
+            "backhand",
+            "shorthand"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "cross",
+          "position": "both",
+          "examples": [
+            "crossword",
+            "crossbow",
+            "crosswalk",
+            "crisscross",
+            "double-cross"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "break",
+          "position": "both",
+          "examples": [
+            "breakfast",
+            "breakthrough",
+            "daybreak",
+            "heartbreak",
+            "jailbreak"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "stone",
+          "position": "both",
+          "examples": [
+            "stonewall",
+            "limestone",
+            "milestone",
+            "cornerstone",
+            "keystone"
+          ],
+          "minExpected": 12
+        }
+      ]
+    },
+    {
+      "type": "compound-chain",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "rootWord": "fire",
+          "position": "both",
+          "examples": [
+            "firehouse",
+            "firework",
+            "fireplace",
+            "campfire",
+            "crossfire"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "back",
+          "position": "both",
+          "examples": [
+            "backbone",
+            "backyard",
+            "setback",
+            "feedback",
+            "quarterback"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "cross",
+          "position": "both",
+          "examples": [
+            "crossword",
+            "crossroads",
+            "crisscross",
+            "double-cross",
+            "crossbow"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "break",
+          "position": "both",
+          "examples": [
+            "breakfast",
+            "breakdown",
+            "daybreak",
+            "outbreak",
+            "breakthrough"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "light",
+          "position": "both",
+          "examples": [
+            "lighthouse",
+            "lightweight",
+            "moonlight",
+            "spotlight",
+            "flashlight"
+          ],
+          "minExpected": 12
+        }
+      ]
+    },
+    {
+      "type": "compound-chain",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "rootWord": "fire",
+          "position": "both",
+          "examples": [
+            "firehouse",
+            "firewall",
+            "campfire",
+            "crossfire",
+            "firework"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "back",
+          "position": "both",
+          "examples": [
+            "backbone",
+            "backpack",
+            "feedback",
+            "setback",
+            "throwback"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "cross",
+          "position": "prefix",
+          "examples": [
+            "crossroads",
+            "crossbow",
+            "crosswalk",
+            "crossword",
+            "crossover"
+          ],
+          "minExpected": 10
+        },
+        {
+          "rootWord": "light",
+          "position": "both",
+          "examples": [
+            "lighthouse",
+            "spotlight",
+            "daylight",
+            "headlight",
+            "lighthearted"
+          ],
+          "minExpected": 12
+        },
+        {
+          "rootWord": "break",
+          "position": "both",
+          "examples": [
+            "breakfast",
+            "breakthrough",
+            "daybreak",
+            "heartbreak",
+            "breakwater"
+          ],
+          "minExpected": 10
+        }
+      ]
+    }
+  ],
+  "bridge-word": [
+    {
+      "type": "bridge-word",
+      "config": {
+        "count": 5
+      },
+      "puzzles": [
+        {
+          "clues": [
+            "camp___",
+            "___work",
+            "___place",
+            "___truck"
+          ],
+          "answer": "fire",
+          "difficulty": "easy",
+          "hint": "It keeps you warm"
+        },
+        {
+          "clues": [
+            "rain___",
+            "___fall",
+            "___proof",
+            "___mark"
+          ],
+          "answer": "water",
+          "difficulty": "easy",
+          "hint": "You drink it every day"
+        },
+        {
+          "clues": [
+            "card___",
+            "___room",
+            "___walk",
+            "skate___"
+          ],
+          "answer": "board",
+          "difficulty": "medium",
+          "hint": "A flat rigid surface"
+        },
+        {
+          "clues": [
+            "figure___",
+            "___line",
+            "___band",
+            "over___"
+          ],
+          "answer": "head",
+          "difficulty": "medium",
+          "hint": "It sits on your shoulders"
+        },
+        {
+          "clues": [
+            "off___",
+            "___board",
+            "___time",
+            "hand___"
+          ],
+          "answer": "spring",
+          "difficulty": "hard",
+          "hint": "A season or a coil"
+        }
+      ]
+    },
+    {
+      "type": "bridge-word",
+      "config": {
+        "count": 5
+      },
+      "puzzles": [
+        {
+          "clues": [
+            "camp___",
+            "___place",
+            "___work",
+            "___fly"
+          ],
+          "answer": "fire",
+          "difficulty": "easy",
+          "hint": "It keeps you warm"
+        },
+        {
+          "clues": [
+            "note___",
+            "___worm",
+            "___mark",
+            "text___"
+          ],
+          "answer": "book",
+          "difficulty": "easy",
+          "hint": "Found in a library"
+        },
+        {
+          "clues": [
+            "day___",
+            "___house",
+            "spot___",
+            "___bulb"
+          ],
+          "answer": "light",
+          "difficulty": "medium",
+          "hint": "Flip a switch for this"
+        },
+        {
+          "clues": [
+            "___berry",
+            "___board",
+            "___smith",
+            "___out"
+          ],
+          "answer": "black",
+          "difficulty": "medium",
+          "hint": "The darkest color"
+        },
+        {
+          "clues": [
+            "back___",
+            "___work",
+            "play___",
+            "___breaking"
+          ],
+          "answer": "ground",
+          "difficulty": "hard",
+          "hint": "Beneath your feet"
+        }
+      ]
+    },
+    {
+      "type": "bridge-word",
+      "config": {
+        "count": 5
+      },
+      "puzzles": [
+        {
+          "clues": [
+            "flash___",
+            "___house",
+            "day___",
+            "spot___"
+          ],
+          "answer": "light",
+          "difficulty": "easy",
+          "hint": "Opposite of dark"
+        },
+        {
+          "clues": [
+            "camp___",
+            "___work",
+            "___place",
+            "___fly"
+          ],
+          "answer": "fire",
+          "difficulty": "easy",
+          "hint": "It burns"
+        },
+        {
+          "clues": [
+            "card___",
+            "___room",
+            "skate___",
+            "___walk"
+          ],
+          "answer": "board",
+          "difficulty": "medium",
+          "hint": "A flat piece of material"
+        },
+        {
+          "clues": [
+            "dead___",
+            "___up",
+            "out___",
+            "side___"
+          ],
+          "answer": "line",
+          "difficulty": "medium",
+          "hint": "Draw one with a ruler"
+        },
+        {
+          "clues": [
+            "book___",
+            "___et",
+            "land___",
+            "trade___"
+          ],
+          "answer": "mark",
+          "difficulty": "hard",
+          "hint": "Leave one on paper"
+        }
+      ]
+    },
+    {
+      "type": "bridge-word",
+      "config": {
+        "count": 5
+      },
+      "puzzles": [
+        {
+          "clues": [
+            "camp___",
+            "___work",
+            "___place",
+            "___fly"
+          ],
+          "answer": "fire",
+          "difficulty": "easy",
+          "hint": "It provides warmth and light"
+        },
+        {
+          "clues": [
+            "___ball",
+            "___flake",
+            "___board",
+            "___man"
+          ],
+          "answer": "snow",
+          "difficulty": "easy",
+          "hint": "Falls from winter skies"
+        },
+        {
+          "clues": [
+            "bare___",
+            "___print",
+            "___note",
+            "___hold"
+          ],
+          "answer": "foot",
+          "difficulty": "medium",
+          "hint": "You stand on two of these"
+        },
+        {
+          "clues": [
+            "black___",
+            "___room",
+            "card___",
+            "___walk"
+          ],
+          "answer": "board",
+          "difficulty": "medium",
+          "hint": "A flat rigid surface"
+        },
+        {
+          "clues": [
+            "pad___",
+            "___smith",
+            "grid___",
+            "___down"
+          ],
+          "answer": "lock",
+          "difficulty": "hard",
+          "hint": "Secures a door"
+        }
+      ]
+    },
+    {
+      "type": "bridge-word",
+      "config": {
+        "count": 5
+      },
+      "puzzles": [
+        {
+          "clues": [
+            "note___",
+            "___mark",
+            "___worm",
+            "text___"
+          ],
+          "answer": "book",
+          "difficulty": "easy",
+          "hint": "You might find one in a library"
+        },
+        {
+          "clues": [
+            "camp___",
+            "___work",
+            "___fly",
+            "___place"
+          ],
+          "answer": "fire",
+          "difficulty": "easy",
+          "hint": "It's hot and bright"
+        },
+        {
+          "clues": [
+            "lime___",
+            "___wall",
+            "key___",
+            "___cold"
+          ],
+          "answer": "stone",
+          "difficulty": "medium",
+          "hint": "A piece of rock"
+        },
+        {
+          "clues": [
+            "water___",
+            "___out",
+            "down___",
+            "___back"
+          ],
+          "answer": "fall",
+          "difficulty": "medium",
+          "hint": "What leaves do in autumn"
+        },
+        {
+          "clues": [
+            "pad___",
+            "___smith",
+            "grid___",
+            "___down"
+          ],
+          "answer": "lock",
+          "difficulty": "hard",
+          "hint": "Keeps things secure"
+        }
+      ]
+    },
+    {
+      "type": "bridge-word",
+      "config": {
+        "count": 5
+      },
+      "puzzles": [
+        {
+          "clues": [
+            "camp___",
+            "___place",
+            "___work",
+            "___fly"
+          ],
+          "answer": "fire",
+          "difficulty": "easy",
+          "hint": "It keeps you warm outdoors"
+        },
+        {
+          "clues": [
+            "note___",
+            "___mark",
+            "___worm",
+            "text___"
+          ],
+          "answer": "book",
+          "difficulty": "easy",
+          "hint": "Found on a library shelf"
+        },
+        {
+          "clues": [
+            "___shake",
+            "back___",
+            "second___",
+            "___writing"
+          ],
+          "answer": "hand",
+          "difficulty": "medium",
+          "hint": "You have two of them"
+        },
+        {
+          "clues": [
+            "card___",
+            "___room",
+            "___walk",
+            "skate___"
+          ],
+          "answer": "board",
+          "difficulty": "medium",
+          "hint": "A flat surface"
+        },
+        {
+          "clues": [
+            "mile___",
+            "key___",
+            "___wall",
+            "___cold"
+          ],
+          "answer": "stone",
+          "difficulty": "hard",
+          "hint": "A natural building material"
+        }
+      ]
+    },
+    {
+      "type": "bridge-word",
+      "config": {
+        "count": 5
+      },
+      "puzzles": [
+        {
+          "clues": [
+            "___burn",
+            "___rise",
+            "___flower",
+            "___screen"
+          ],
+          "answer": "sun",
+          "difficulty": "easy",
+          "hint": "It comes up every morning"
+        },
+        {
+          "clues": [
+            "note___",
+            "___mark",
+            "text___",
+            "___worm"
+          ],
+          "answer": "book",
+          "difficulty": "easy",
+          "hint": "You might find one in a library"
+        },
+        {
+          "clues": [
+            "out___",
+            "___step",
+            "___bell",
+            "trap___"
+          ],
+          "answer": "door",
+          "difficulty": "medium",
+          "hint": "You walk through one every day"
+        },
+        {
+          "clues": [
+            "over___",
+            "___band",
+            "figure___",
+            "___line"
+          ],
+          "answer": "head",
+          "difficulty": "medium",
+          "hint": "It sits on top of your shoulders"
+        },
+        {
+          "clues": [
+            "first___",
+            "___shake",
+            "short___",
+            "___made"
+          ],
+          "answer": "hand",
+          "difficulty": "hard",
+          "hint": "You have two of them"
+        }
+      ]
+    },
+    {
+      "type": "bridge-word",
+      "config": {
+        "count": 5
+      },
+      "puzzles": [
+        {
+          "clues": [
+            "___flower",
+            "___burn",
+            "___rise",
+            "___screen"
+          ],
+          "answer": "sun",
+          "difficulty": "easy",
+          "hint": "It rises every morning"
+        },
+        {
+          "clues": [
+            "camp___",
+            "___work",
+            "___place",
+            "___fly"
+          ],
+          "answer": "fire",
+          "difficulty": "easy",
+          "hint": "It's hot and bright"
+        },
+        {
+          "clues": [
+            "note___",
+            "___mark",
+            "text___",
+            "___worm"
+          ],
+          "answer": "book",
+          "difficulty": "medium",
+          "hint": "Found in a library"
+        },
+        {
+          "clues": [
+            "day___",
+            "___through",
+            "___down",
+            "out___"
+          ],
+          "answer": "break",
+          "difficulty": "medium",
+          "hint": "A pause or fracture"
+        },
+        {
+          "clues": [
+            "lime___",
+            "key___",
+            "mile___",
+            "___wall"
+          ],
+          "answer": "stone",
+          "difficulty": "hard",
+          "hint": "A type of rock"
+        }
+      ]
+    }
+  ],
+  "double-meaning": [
+    {
+      "type": "double-meaning",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "word": "crane",
+          "meanings": [
+            "a tall wading bird",
+            "a machine used to lift heavy objects"
+          ],
+          "example": "The crane on the riverbank watched the crane on the construction site lift steel beams all morning.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "spring",
+          "meanings": [
+            "the season after winter",
+            "a coiled piece of metal",
+            "a natural water source"
+          ],
+          "example": "Every spring, the mattress spring pokes through just as the mountain spring thaws.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "pitch",
+          "meanings": [
+            "to throw a ball",
+            "a sticky dark substance",
+            "the highness or lowness of a sound"
+          ],
+          "example": "He tried to pitch the idea at a higher pitch, but his voice got stuck like pitch.",
+          "difficulty": "hard"
+        },
+        {
+          "word": "sentence",
+          "meanings": [
+            "a grammatical unit of words",
+            "a punishment assigned by a judge"
+          ],
+          "example": "The judge struggled to sentence the grammarian, who kept correcting every sentence in the verdict.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "jam",
+          "meanings": [
+            "a fruit preserve spread on bread",
+            "a situation where things are stuck or crowded",
+            "an informal music session"
+          ],
+          "example": "Stuck in a jam on the freeway, the band ate jam on toast and decided to jam acoustically in the back seat.",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "double-meaning",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "word": "pitch",
+          "meanings": [
+            "throw a ball",
+            "dark sticky substance",
+            "musical tone",
+            "sales presentation"
+          ],
+          "example": "His pitch went so high during the pitch meeting that it sounded like a musical pitch covered in pitch.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "crane",
+          "meanings": [
+            "large bird",
+            "construction machine",
+            "to stretch one's neck"
+          ],
+          "example": "I had to crane my neck to watch the crane lift the injured crane back to its nest.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "bank",
+          "meanings": [
+            "financial institution",
+            "side of a river",
+            "to tilt an aircraft"
+          ],
+          "example": "The pilot had to bank sharply to avoid the bank of the river near the bank where we keep our savings.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "hamper",
+          "meanings": [
+            "a large basket",
+            "to hinder or obstruct"
+          ],
+          "example": "The overflowing laundry hamper in the hallway continued to hamper everyone trying to reach the door.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "mole",
+          "meanings": [
+            "burrowing mammal",
+            "unit of measurement in chemistry",
+            "spy within an organization",
+            "dark spot on skin"
+          ],
+          "example": "The mole in our lab reported that exactly one mole of the compound would remove a mole from your skin, but the garden mole ate the sample.",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "double-meaning",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "word": "pitcher",
+          "meanings": [
+            "a container for pouring liquids",
+            "a baseball player who throws the ball"
+          ],
+          "example": "The pitcher on the mound asked the dugout for a pitcher of water.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "sentence",
+          "meanings": [
+            "a grammatical unit of words",
+            "a punishment given by a judge"
+          ],
+          "example": "The judge read his sentence aloud, making sure every sentence was clear.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "club",
+          "meanings": [
+            "a social organization or venue",
+            "a heavy stick used as a weapon"
+          ],
+          "example": "He was kicked out of the club after swinging a club at the bouncer.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "draft",
+          "meanings": [
+            "a preliminary version of a document",
+            "a current of cool air"
+          ],
+          "example": "A cold draft blew through the window and scattered the pages of her draft.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "match",
+          "meanings": [
+            "a small stick used to start a fire",
+            "a contest or competition between opponents"
+          ],
+          "example": "He struck a match to celebrate winning the match.",
+          "difficulty": "easy"
+        }
+      ]
+    },
+    {
+      "type": "double-meaning",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "word": "bat",
+          "meanings": [
+            "a flying nocturnal mammal",
+            "a club used to hit a ball in baseball or cricket"
+          ],
+          "example": "The bat flew so close to home plate that the batter nearly swatted it with his bat.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "crane",
+          "meanings": [
+            "a large wading bird with long legs",
+            "a heavy machine used for lifting and moving objects"
+          ],
+          "example": "The crane on the riverbank watched curiously as the construction crane hoisted steel beams overhead.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "pitcher",
+          "meanings": [
+            "a container for pouring liquids",
+            "the player who throws the ball in baseball"
+          ],
+          "example": "The pitcher poured himself a glass from the pitcher before taking the mound.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "court",
+          "meanings": [
+            "a place where legal trials are held",
+            "to pursue romantically"
+          ],
+          "example": "He tried to court her with love letters, but she said she'd see him in court instead.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "mole",
+          "meanings": [
+            "a small burrowing mammal",
+            "a unit of measurement in chemistry equal to 6.022×10²³ particles"
+          ],
+          "example": "The chemistry student calculated a mole of dirt particles while a mole tunneled beneath the lab.",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "double-meaning",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "word": "pitcher",
+          "meanings": [
+            "a container for pouring liquids",
+            "a baseball player who throws the ball"
+          ],
+          "example": "The pitcher poured water from the pitcher between innings.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "jam",
+          "meanings": [
+            "a fruit preserve spread on bread",
+            "a difficult situation or traffic congestion"
+          ],
+          "example": "I was stuck in a jam on the highway because a truck spilled jam across three lanes.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "bank",
+          "meanings": [
+            "a financial institution",
+            "the sloping land beside a river"
+          ],
+          "example": "The bank on the river bank flooded, and now my savings are literally underwater.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "crane",
+          "meanings": [
+            "a large wading bird",
+            "a heavy machine used for lifting"
+          ],
+          "example": "The crane watched curiously as the crane hoisted steel beams over the marsh.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "suit",
+          "meanings": [
+            "a set of formal clothing",
+            "a legal action or lawsuit"
+          ],
+          "example": "He wore his finest suit to file the suit against his tailor.",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "double-meaning",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "word": "bat",
+          "meanings": [
+            "a flying nocturnal mammal",
+            "a wooden club used in baseball"
+          ],
+          "example": "The bat flew so close to home plate that the batter nearly swung his bat at it.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "crane",
+          "meanings": [
+            "a large wading bird",
+            "a heavy construction machine for lifting"
+          ],
+          "example": "The crane on the riverbank watched curiously as the crane on the construction site hoisted a steel beam.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "pitch",
+          "meanings": [
+            "a throw in baseball",
+            "the highness or lowness of a musical sound"
+          ],
+          "example": "The pitcher's wild pitch made the stadium organist hit a sour pitch in surprise.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "draft",
+          "meanings": [
+            "a preliminary version of a document",
+            "a current of cool air"
+          ],
+          "example": "A cold draft from the window scattered the pages of her rough draft across the floor.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "mole",
+          "meanings": [
+            "a small burrowing mammal",
+            "a unit of measurement in chemistry"
+          ],
+          "example": "The chemistry student calculated one mole of dirt displaced by an actual mole tunneling through the quad.",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "double-meaning",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "word": "pitcher",
+          "meanings": [
+            "a container for pouring liquids",
+            "a baseball player who throws the ball"
+          ],
+          "example": "The pitcher filled the pitcher with ice water between innings.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "bank",
+          "meanings": [
+            "a financial institution",
+            "the side of a river"
+          ],
+          "example": "I sat on the bank and watched my savings flow away like the river beside me.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "crane",
+          "meanings": [
+            "a large wading bird",
+            "a machine used to lift heavy objects"
+          ],
+          "example": "The crane watched curiously as the crane hoisted steel beams over the marsh.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "match",
+          "meanings": [
+            "a small stick used to start fire",
+            "a competitive contest between opponents"
+          ],
+          "example": "She struck a match to celebrate winning the match.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "grave",
+          "meanings": [
+            "a burial site",
+            "serious or solemn in manner"
+          ],
+          "example": "The priest spoke in a grave tone as they lowered the casket into the grave.",
+          "difficulty": "medium"
+        }
+      ]
+    },
+    {
+      "type": "double-meaning",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "word": "pitcher",
+          "meanings": [
+            "a container for pouring liquids",
+            "a baseball player who throws the ball"
+          ],
+          "example": "The pitcher poured water from the pitcher between innings.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "bass",
+          "meanings": [
+            "a low-pitched musical tone",
+            "a type of freshwater fish"
+          ],
+          "example": "The bass guitarist reeled in a massive bass while humming a bass line.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "draft",
+          "meanings": [
+            "a preliminary version of a document",
+            "a current of cool air",
+            "selecting players for a team"
+          ],
+          "example": "A cold draft blew the draft of his draft picks off the desk.",
+          "difficulty": "hard"
+        },
+        {
+          "word": "crane",
+          "meanings": [
+            "a large wading bird",
+            "a heavy machinery used for lifting",
+            "to stretch one's neck"
+          ],
+          "example": "She had to crane her neck to watch the crane lift a statue of a crane.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "match",
+          "meanings": [
+            "a thin stick used to start fire",
+            "a contest or game between opponents",
+            "something that corresponds or pairs well"
+          ],
+          "example": "The tennis match was a perfect match of rivals, each with a fire lit as if by a match.",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "double-meaning",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "word": "pitcher",
+          "meanings": [
+            "a container for pouring liquids",
+            "a baseball player who throws the ball"
+          ],
+          "example": "The pitcher filled the pitcher with ice water between innings.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "bat",
+          "meanings": [
+            "a nocturnal flying mammal",
+            "a wooden club used to hit a ball"
+          ],
+          "example": "A bat swooped so close to home plate the batter nearly swung his bat at it.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "crane",
+          "meanings": [
+            "a large wading bird",
+            "a heavy machine used for lifting"
+          ],
+          "example": "The crane on the riverbank watched the crane on the construction site lift steel beams.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "match",
+          "meanings": [
+            "a thin stick used to start fire",
+            "a contest or competition between opponents"
+          ],
+          "example": "She struck a match to light the victory bonfire after winning the championship match.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "draft",
+          "meanings": [
+            "a preliminary version of a document",
+            "a current of cool air",
+            "selecting players for a sports team"
+          ],
+          "example": "A cold draft blew the draft of his speech off the table right before the NFL draft began.",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "double-meaning",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "word": "pitcher",
+          "meanings": [
+            "a container for pouring liquids",
+            "a baseball player who throws the ball"
+          ],
+          "example": "The pitcher poured water from the pitcher between innings.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "bat",
+          "meanings": [
+            "a nocturnal flying mammal",
+            "a wooden club used to hit a ball"
+          ],
+          "example": "A bat swooped down and knocked the bat right out of his hands.",
+          "difficulty": "easy"
+        },
+        {
+          "word": "crane",
+          "meanings": [
+            "a large wading bird with long legs",
+            "a heavy machine used to lift and move objects"
+          ],
+          "example": "The crane watched curiously as the crane hoisted steel beams over the marsh.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "match",
+          "meanings": [
+            "a small stick used to start a fire",
+            "a contest or competition between opponents"
+          ],
+          "example": "She struck a match to celebrate winning the match.",
+          "difficulty": "medium"
+        },
+        {
+          "word": "volume",
+          "meanings": [
+            "the loudness of a sound",
+            "a single book in a series"
+          ],
+          "example": "He turned down the volume so he could focus on the final volume of the trilogy.",
+          "difficulty": "hard"
+        }
+      ]
+    }
+  ],
+  "idiom-twist": [
+    {
+      "type": "idiom-twist",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "idiom": "A penny for your thoughts",
+          "domain": "Artificial Intelligence",
+          "example": "A prompt for your thoughts",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Don't cry over spilled milk",
+          "domain": "Chemistry",
+          "example": "Don't cry over spilled reagents",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "When life gives you lemons, make lemonade",
+          "domain": "Music production",
+          "example": "When life gives you loops, make a remix",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "You can't judge a book by its cover",
+          "domain": "Cybersecurity",
+          "example": "You can't judge a packet by its header",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "Burning the candle at both ends",
+          "domain": "Astrophysics",
+          "example": "Burning the star at both poles",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "idiom-twist",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "idiom": "A penny for your thoughts",
+          "domain": "Artificial Intelligence",
+          "example": "A token for your thoughts",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "You can't have your cake and eat it too",
+          "domain": "Dieting",
+          "example": "You can't have your carbs and eat them too",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "When it rains, it pours",
+          "domain": "Cybersecurity",
+          "example": "When it breaches, it dumps",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "Burning the candle at both ends",
+          "domain": "Cryptocurrency",
+          "example": "Burning the token at both ends",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "The squeaky wheel gets the grease",
+          "domain": "Open Source Software",
+          "example": "The squeaky issue gets the merge",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "idiom-twist",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "idiom": "A penny for your thoughts",
+          "domain": "Artificial Intelligence",
+          "example": "A prompt for your thoughts",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Don't cry over spilled milk",
+          "domain": "Cybersecurity",
+          "example": "Don't cry over leaked data",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "When life gives you lemons, make lemonade",
+          "domain": "Music production",
+          "example": "When life gives you samples, make a remix",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "You can't judge a book by its cover",
+          "domain": "Cooking",
+          "example": "You can't judge a dish by its plating",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "Burning the candle at both ends",
+          "domain": "Space exploration",
+          "example": "Burning the rocket at both stages",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "idiom-twist",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "idiom": "A penny for your thoughts",
+          "domain": "Artificial Intelligence",
+          "example": "A prompt for your thoughts",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Don't cry over spilled milk",
+          "domain": "Chemistry",
+          "example": "Don't cry over spilled reagents",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Kill two birds with one stone",
+          "domain": "Music Production",
+          "example": "Mix two tracks with one session",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "Burning the candle at both ends",
+          "domain": "Cryptocurrency",
+          "example": "Burning the token at both ends",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "The pen is mightier than the sword",
+          "domain": "Competitive Gaming",
+          "example": "The ping is mightier than the score",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "idiom-twist",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "idiom": "A penny for your thoughts",
+          "domain": "Artificial Intelligence",
+          "example": "A prompt for your thoughts",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Don't cry over spilled milk",
+          "domain": "Chemistry",
+          "example": "Don't cry over spilled reagents",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "When life gives you lemons, make lemonade",
+          "domain": "Music production",
+          "example": "When life gives you demos, make remixes",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "You can't judge a book by its cover",
+          "domain": "Cybersecurity",
+          "example": "You can't judge a hack by its header",
+          "difficulty": "hard"
+        },
+        {
+          "idiom": "The pen is mightier than the sword",
+          "domain": "Baking",
+          "example": "The whisk is mightier than the fork",
+          "difficulty": "medium"
+        }
+      ]
+    },
+    {
+      "type": "idiom-twist",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "idiom": "A penny for your thoughts",
+          "domain": "Artificial Intelligence",
+          "example": "A prompt for your thoughts",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Don't cry over spilled milk",
+          "domain": "Chemistry",
+          "example": "Don't cry over spilled reagents",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "When life gives you lemons, make lemonade",
+          "domain": "Music production",
+          "example": "When life gives you samples, make a remix",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "You can't judge a book by its cover",
+          "domain": "Cybersecurity",
+          "example": "You can't judge a packet by its header",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "Burning the candle at both ends",
+          "domain": "Space exploration",
+          "example": "Burning the booster at both stages",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "idiom-twist",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "idiom": "A penny for your thoughts",
+          "domain": "Artificial Intelligence",
+          "example": "A token for your thoughts",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Don't cry over spilled milk",
+          "domain": "Databases",
+          "example": "Don't cry over dropped tables",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Kill two birds with one stone",
+          "domain": "Cooking",
+          "example": "Grill two steaks with one flame",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "Burning the candle at both ends",
+          "domain": "Cryptocurrency",
+          "example": "Burning the wallet at both chains",
+          "difficulty": "hard"
+        },
+        {
+          "idiom": "The grass is always greener on the other side",
+          "domain": "Space exploration",
+          "example": "The atmosphere is always breezier on the other planet",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "idiom-twist",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "idiom": "A stitch in time saves nine",
+          "domain": "Cybersecurity",
+          "example": "A patch in time saves nine breaches",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Don't cry over spilled milk",
+          "domain": "Databases",
+          "example": "Don't cry over dropped tables",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "When it rains, it pours",
+          "domain": "Customer support",
+          "example": "When it rings, it roars",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "You can't have your cake and eat it too",
+          "domain": "Cloud computing",
+          "example": "You can't have your cache and free tier too",
+          "difficulty": "hard"
+        },
+        {
+          "idiom": "Burning the candle at both ends",
+          "domain": "Space exploration",
+          "example": "Burning the boosters at both stages",
+          "difficulty": "hard"
+        }
+      ]
+    },
+    {
+      "type": "idiom-twist",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "idiom": "A penny for your thoughts",
+          "domain": "Artificial Intelligence",
+          "example": "A prompt for your thoughts",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Burning the candle at both ends",
+          "domain": "Cryptocurrency",
+          "example": "Burning the token at both ends",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Don't cry over spilled milk",
+          "domain": "Databases",
+          "example": "Don't cry over dropped tables",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "The grass is always greener on the other side",
+          "domain": "Space exploration",
+          "example": "The atmosphere is always greener on the other planet",
+          "difficulty": "hard"
+        },
+        {
+          "idiom": "You can lead a horse to water but you can't make it drink",
+          "domain": "Online education",
+          "example": "You can lead a student to the course but you can't make them click",
+          "difficulty": "medium"
+        }
+      ]
+    },
+    {
+      "type": "idiom-twist",
+      "config": {
+        "count": 5
+      },
+      "challenges": [
+        {
+          "idiom": "A penny for your thoughts",
+          "domain": "Artificial Intelligence",
+          "example": "A prompt for your thoughts",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "Don't cry over spilled milk",
+          "domain": "Chemistry",
+          "example": "Don't cry over spilled reagents",
+          "difficulty": "easy"
+        },
+        {
+          "idiom": "When life gives you lemons, make lemonade",
+          "domain": "Music production",
+          "example": "When life gives you demos, make remixes",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "You can't teach an old dog new tricks",
+          "domain": "Web development",
+          "example": "You can't teach an old site new frameworks",
+          "difficulty": "medium"
+        },
+        {
+          "idiom": "The pen is mightier than the sword",
+          "domain": "Cybersecurity",
+          "example": "The patch is mightier than the firewall",
+          "difficulty": "hard"
+        }
+      ]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.35.0",
+      "version": "1.36.0",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.35.0",
+  "version": "1.36.0",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/server/index.js
+++ b/server/index.js
@@ -61,6 +61,7 @@ import settingsRoutes from './routes/settings.js';
 import telegramRoutes from './routes/telegram.js';
 import updateRoutes from './routes/update.js';
 import loopsRoutes from './routes/loops.js';
+import characterRoutes from './routes/character.js';
 import { ensureSelf, startPolling } from './services/instances.js';
 import { initSyncLog } from './services/brainSyncLog.js';
 import { backfillOriginInstanceId } from './services/brainStorage.js';
@@ -258,6 +259,7 @@ app.use('/api/settings', settingsRoutes);
 app.use('/api/telegram', telegramRoutes);
 app.use('/api/update', updateRoutes);
 app.use('/api/loops', loopsRoutes);
+app.use('/api/character', characterRoutes);
 
 // Initialize agent automation scheduler and action executor
 automationScheduler.init().catch(err => console.error(`❌ Agent scheduler init failed: ${err.message}`));

--- a/server/lib/timezone.js
+++ b/server/lib/timezone.js
@@ -38,7 +38,17 @@ function getFormatter(timezone) {
  */
 export async function getUserTimezone() {
   const settings = await getSettings()
-  return settings.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
+  const tz = settings.timezone
+  if (tz) {
+    // Validate the configured timezone; fall back to system timezone if invalid
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone: tz })
+      return tz
+    } catch {
+      console.error(`❌ Invalid configured timezone "${tz}", falling back to system default`)
+    }
+  }
+  return Intl.DateTimeFormat().resolvedOptions().timeZone
 }
 
 /**

--- a/server/lib/timezone.js
+++ b/server/lib/timezone.js
@@ -1,0 +1,117 @@
+/**
+ * Timezone utilities for scheduling
+ *
+ * All scheduling runs in the user's configured timezone.
+ * The server process uses TZ=UTC, so all Date operations are UTC internally.
+ * These helpers convert between UTC and the user's local timezone.
+ */
+
+import { getSettings } from '../services/settings.js'
+
+const WEEKDAY_MAP = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 }
+
+// Cache Intl.DateTimeFormat instances per timezone — these are expensive to construct
+// but safe to reuse since they're stateless formatters.
+const formatterCache = new Map()
+
+function getFormatter(timezone) {
+  let fmt = formatterCache.get(timezone)
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: timezone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      weekday: 'short',
+      hour12: false
+    })
+    formatterCache.set(timezone, fmt)
+  }
+  return fmt
+}
+
+/**
+ * Get the user's configured timezone, falling back to system timezone.
+ * @returns {Promise<string>} IANA timezone string (e.g., 'America/Los_Angeles')
+ */
+export async function getUserTimezone() {
+  const settings = await getSettings()
+  return settings.timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
+}
+
+/**
+ * Get local date/time parts for a UTC Date in the given timezone.
+ * @param {Date} utcDate - Date object (interpreted as UTC since TZ=UTC)
+ * @param {string} timezone - IANA timezone string
+ * @returns {{ year: number, month: number, day: number, hour: number, minute: number, dayOfWeek: number }}
+ */
+export function getLocalParts(utcDate, timezone) {
+  const parts = {}
+  for (const { type, value } of getFormatter(timezone).formatToParts(utcDate)) {
+    parts[type] = value
+  }
+  return {
+    year: parseInt(parts.year),
+    month: parseInt(parts.month),
+    day: parseInt(parts.day),
+    hour: parts.hour === '24' ? 0 : parseInt(parts.hour),
+    minute: parseInt(parts.minute),
+    dayOfWeek: WEEKDAY_MAP[parts.weekday] ?? 0
+  }
+}
+
+/**
+ * Get the UTC offset (in ms) for a timezone at a given UTC time.
+ * Positive = ahead of UTC (e.g., +9h for Tokyo), negative = behind (e.g., -7h for PDT).
+ * @param {Date} utcDate - Reference UTC date
+ * @param {string} timezone - IANA timezone string
+ * @returns {number} Offset in milliseconds
+ */
+export function getUtcOffsetMs(utcDate, timezone) {
+  const utcStr = utcDate.toLocaleString('en-US', { timeZone: 'UTC' })
+  const localStr = utcDate.toLocaleString('en-US', { timeZone: timezone })
+  return new Date(localStr).getTime() - new Date(utcStr).getTime()
+}
+
+/**
+ * Find the next UTC timestamp where the local time in `timezone` matches HH:MM.
+ * @param {number} afterMs - UTC timestamp to search after
+ * @param {number} hours - Target hour (0-23) in local timezone
+ * @param {number} minutes - Target minute (0-59) in local timezone
+ * @param {string} timezone - IANA timezone string
+ * @returns {number} UTC timestamp
+ */
+export function nextLocalTime(afterMs, hours, minutes, timezone) {
+  // Start from the after point, find what the current local time is
+  const ref = new Date(afterMs)
+  const local = getLocalParts(ref, timezone)
+
+  // Compute desired vs current in minutes-since-midnight
+  const desiredMin = hours * 60 + minutes
+  const currentMin = local.hour * 60 + local.minute
+
+  // How many minutes until the target time?
+  let deltaMin = desiredMin - currentMin
+  if (deltaMin <= 0) deltaMin += 1440 // wrap to next day
+
+  const candidate = afterMs + deltaMin * 60_000
+  // DST transitions can shift the result by up to ±60 min — verify and nudge if needed.
+  const check = getLocalParts(new Date(candidate), timezone)
+  const checkMin = check.hour * 60 + check.minute
+  if (checkMin !== desiredMin) {
+    return candidate + (desiredMin - checkMin) * 60_000
+  }
+  return candidate
+}
+
+/**
+ * Get today's date string (YYYY-MM-DD) in the user's timezone.
+ * @param {string} timezone - IANA timezone string
+ * @returns {string}
+ */
+export function todayInTimezone(timezone) {
+  const parts = getLocalParts(new Date(), timezone)
+  return `${parts.year}-${String(parts.month).padStart(2, '0')}-${String(parts.day).padStart(2, '0')}`
+}

--- a/server/lib/timezone.test.js
+++ b/server/lib/timezone.test.js
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from 'vitest'
+import { getLocalParts, getUtcOffsetMs, nextLocalTime, todayInTimezone } from './timezone.js'
+
+describe('timezone', () => {
+  describe('getLocalParts', () => {
+    it('returns UTC parts when timezone is UTC', () => {
+      const date = new Date('2026-03-24T14:30:00Z')
+      const parts = getLocalParts(date, 'UTC')
+      expect(parts.year).toBe(2026)
+      expect(parts.month).toBe(3)
+      expect(parts.day).toBe(24)
+      expect(parts.hour).toBe(14)
+      expect(parts.minute).toBe(30)
+      expect(parts.dayOfWeek).toBe(2) // Tuesday
+    })
+
+    it('converts UTC to Pacific time', () => {
+      // March 24, 2026 14:00 UTC = March 24, 2026 07:00 PDT (UTC-7)
+      const date = new Date('2026-03-24T14:00:00Z')
+      const parts = getLocalParts(date, 'America/Los_Angeles')
+      expect(parts.hour).toBe(7)
+      expect(parts.day).toBe(24)
+    })
+
+    it('handles date boundary crossing', () => {
+      // March 24, 2026 03:00 UTC = March 23, 2026 20:00 PDT (UTC-7)
+      const date = new Date('2026-03-24T03:00:00Z')
+      const parts = getLocalParts(date, 'America/Los_Angeles')
+      expect(parts.hour).toBe(20)
+      expect(parts.day).toBe(23)
+    })
+
+    it('handles hour 24 normalization', () => {
+      // Intl can sometimes return hour 24 for midnight
+      // Test with a known midnight time
+      const date = new Date('2026-03-25T00:00:00Z')
+      const parts = getLocalParts(date, 'UTC')
+      expect(parts.hour).toBe(0)
+    })
+  })
+
+  describe('getUtcOffsetMs', () => {
+    it('returns 0 for UTC', () => {
+      const date = new Date('2026-03-24T12:00:00Z')
+      expect(getUtcOffsetMs(date, 'UTC')).toBe(0)
+    })
+
+    it('returns negative offset for US Pacific', () => {
+      // PDT is UTC-7 in March
+      const date = new Date('2026-03-24T12:00:00Z')
+      const offset = getUtcOffsetMs(date, 'America/Los_Angeles')
+      expect(offset).toBe(-7 * 60 * 60 * 1000) // -7 hours in ms
+    })
+
+    it('returns positive offset for Tokyo', () => {
+      // JST is UTC+9 always
+      const date = new Date('2026-03-24T12:00:00Z')
+      const offset = getUtcOffsetMs(date, 'Asia/Tokyo')
+      expect(offset).toBe(9 * 60 * 60 * 1000) // +9 hours in ms
+    })
+  })
+
+  describe('nextLocalTime', () => {
+    it('finds the next occurrence of a local time in UTC timezone', () => {
+      const after = new Date('2026-03-24T10:00:00Z').getTime()
+      const result = nextLocalTime(after, 14, 0, 'UTC')
+      // Should be 14:00 UTC same day
+      const resultDate = new Date(result)
+      expect(resultDate.getUTCHours()).toBe(14)
+      expect(resultDate.getUTCMinutes()).toBe(0)
+      expect(resultDate.getUTCDate()).toBe(24)
+    })
+
+    it('wraps to next day if time has passed', () => {
+      const after = new Date('2026-03-24T15:00:00Z').getTime()
+      const result = nextLocalTime(after, 14, 0, 'UTC')
+      // 14:00 has passed, should find 14:00 tomorrow
+      const resultDate = new Date(result)
+      expect(resultDate.getUTCHours()).toBe(14)
+      expect(resultDate.getUTCDate()).toBe(25)
+    })
+
+    it('handles timezone offset correctly', () => {
+      // At 2026-03-24 08:00 UTC, it's 01:00 PDT
+      // Next 07:00 PDT = 14:00 UTC same day
+      const after = new Date('2026-03-24T08:00:00Z').getTime()
+      const result = nextLocalTime(after, 7, 0, 'America/Los_Angeles')
+      const resultDate = new Date(result)
+      const parts = getLocalParts(resultDate, 'America/Los_Angeles')
+      expect(parts.hour).toBe(7)
+      expect(parts.minute).toBe(0)
+    })
+  })
+
+  describe('todayInTimezone', () => {
+    it('returns date string in YYYY-MM-DD format', () => {
+      const result = todayInTimezone('UTC')
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+    })
+
+    it('may differ from UTC date in offset timezones', () => {
+      // At 2026-03-24 03:00 UTC, it's still March 23 in Pacific time
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-03-24T03:00:00Z'))
+
+      const utcDate = todayInTimezone('UTC')
+      const pdtDate = todayInTimezone('America/Los_Angeles')
+      expect(utcDate).toBe('2026-03-24')
+      expect(pdtDate).toBe('2026-03-23')
+
+      vi.useRealTimers()
+    })
+  })
+})

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -357,10 +357,9 @@ router.put('/:id/task-types/:taskType', asyncHandler(async (req, res) => {
         throw new ServerError('interval must be one of rotation|daily|weekly|once|on-demand, a cron expression, or null', { status: 400, code: 'VALIDATION_ERROR' });
       }
       if (isCron) {
-        const nextRun = parseCronToNextRun(interval, new Date(), 'UTC');
-        if (!nextRun) {
-          throw new ServerError('Invalid cron expression: unable to compute next run time', { status: 400, code: 'VALIDATION_ERROR' });
-        }
+        // Validate syntax and field ranges (parseCronToNextRun throws on invalid expressions)
+        // Note: null return means no match within search window (e.g. leap day) -- not invalid
+        parseCronToNextRun(interval, new Date(), 'UTC');
       }
     } else if (interval !== null) {
       throw new ServerError('interval must be a string or null', { status: 400, code: 'VALIDATION_ERROR' });

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -12,6 +12,7 @@ import { logAction } from '../services/history.js';
 import { z } from 'zod';
 import { validateRequest, appSchema, appUpdateSchema, sanitizeTaskMetadata } from '../lib/validation.js';
 import * as git from '../services/git.js';
+import { parseCronToNextRun } from '../services/eventScheduler.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { safeJSONParse } from '../lib/fileUtils.js';
 import { parseEcosystemFromPath, usesPm2 } from '../services/streamingDetect.js';
@@ -354,6 +355,12 @@ router.put('/:id/task-types/:taskType', asyncHandler(async (req, res) => {
       const isCron = interval.trim().split(/\s+/).length === 5;
       if (!isCron && !allowedIntervals.includes(interval)) {
         throw new ServerError('interval must be one of rotation|daily|weekly|once|on-demand, a cron expression, or null', { status: 400, code: 'VALIDATION_ERROR' });
+      }
+      if (isCron) {
+        const nextRun = parseCronToNextRun(interval, new Date(), 'UTC');
+        if (!nextRun) {
+          throw new ServerError('Invalid cron expression: unable to compute next run time', { status: 400, code: 'VALIDATION_ERROR' });
+        }
       }
     } else if (interval !== null) {
       throw new ServerError('interval must be a string or null', { status: 400, code: 'VALIDATION_ERROR' });

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -347,11 +347,16 @@ router.put('/:id/task-types/:taskType', asyncHandler(async (req, res) => {
     }
   }
 
-  // Validate interval against allowed values
+  // Validate interval against allowed values (also accepts 5-field cron expressions)
   if (interval !== undefined) {
     const allowedIntervals = ['rotation', 'daily', 'weekly', 'once', 'on-demand'];
-    if (interval !== null && (typeof interval !== 'string' || !allowedIntervals.includes(interval))) {
-      throw new ServerError('interval must be one of rotation|daily|weekly|once|on-demand or null', { status: 400, code: 'VALIDATION_ERROR' });
+    if (interval !== null && typeof interval === 'string') {
+      const isCron = interval.trim().split(/\s+/).length === 5;
+      if (!isCron && !allowedIntervals.includes(interval)) {
+        throw new ServerError('interval must be one of rotation|daily|weekly|once|on-demand, a cron expression, or null', { status: 400, code: 'VALIDATION_ERROR' });
+      }
+    } else if (interval !== null) {
+      throw new ServerError('interval must be a string or null', { status: 400, code: 'VALIDATION_ERROR' });
     }
   }
 

--- a/server/routes/character.js
+++ b/server/routes/character.js
@@ -1,0 +1,109 @@
+/**
+ * Character Sheet Routes
+ * D&D-style character sheet with XP, HP, damage, rests, and event tracking.
+ */
+
+import { Router } from 'express';
+import { z } from 'zod';
+import { asyncHandler } from '../lib/errorHandler.js';
+import { validateRequest } from '../lib/validation.js';
+import * as characterService from '../services/character.js';
+
+const router = Router();
+
+// Zod schemas for request validation
+const updateCharacterSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  class: z.string().min(1).max(100).optional()
+});
+
+const addXPSchema = z.object({
+  amount: z.number().int().min(1),
+  source: z.string().min(1).max(200),
+  description: z.string().max(500).optional()
+});
+
+const takeDamageSchema = z.object({
+  diceNotation: z.string().regex(/^\d+d\d+([+-]\d+)?$/, 'Invalid dice notation (e.g. "1d8", "2d6+3")'),
+  description: z.string().max(500).optional()
+});
+
+const takeRestSchema = z.object({
+  type: z.enum(['short', 'long'])
+});
+
+const addEventSchema = z.object({
+  description: z.string().min(1).max(500),
+  xp: z.number().int().min(0).optional(),
+  diceNotation: z.string().regex(/^\d+d\d+([+-]\d+)?$/).optional(),
+  damageType: z.string().max(100).optional()
+});
+
+// GET /api/character - Get character sheet
+router.get('/', asyncHandler(async (req, res) => {
+  const character = await characterService.getCharacter();
+  res.json(character);
+}));
+
+// PUT /api/character - Update character name/class
+router.put('/', asyncHandler(async (req, res) => {
+  const data = validateRequest(updateCharacterSchema, req.body);
+  const character = await characterService.getCharacter();
+  if (data.name) character.name = data.name;
+  if (data.class) character.class = data.class;
+  const updated = await characterService.saveCharacter(character);
+  res.json(updated);
+}));
+
+// POST /api/character/xp - Add XP manually
+router.post('/xp', asyncHandler(async (req, res) => {
+  const { amount, source, description } = validateRequest(addXPSchema, req.body);
+  const result = await characterService.addXP(amount, source, description);
+  res.json(result);
+}));
+
+// POST /api/character/damage - Take damage
+router.post('/damage', asyncHandler(async (req, res) => {
+  const { diceNotation, description } = validateRequest(takeDamageSchema, req.body);
+  const result = await characterService.takeDamage(diceNotation, description);
+  res.json(result);
+}));
+
+// POST /api/character/rest - Take a rest
+router.post('/rest', asyncHandler(async (req, res) => {
+  const { type } = validateRequest(takeRestSchema, req.body);
+  const result = await characterService.takeRest(type);
+  res.json(result);
+}));
+
+// POST /api/character/event - Log custom event
+router.post('/event', asyncHandler(async (req, res) => {
+  const data = validateRequest(addEventSchema, req.body);
+  const result = await characterService.addEvent(data);
+  res.json(result);
+}));
+
+// POST /api/character/sync/jira - Sync JIRA tickets for XP
+router.post('/sync/jira', asyncHandler(async (req, res) => {
+  const result = await characterService.syncJiraXP();
+  res.json(result);
+}));
+
+// POST /api/character/sync/tasks - Sync CoS tasks for XP
+router.post('/sync/tasks', asyncHandler(async (req, res) => {
+  const result = await characterService.syncTaskXP();
+  res.json(result);
+}));
+
+// POST /api/character/reset - Reset character (fresh start)
+router.post('/reset', asyncHandler(async (req, res) => {
+  const character = await characterService.saveCharacter(
+    Object.assign(
+      { name: 'Adventurer', class: 'Developer', xp: 0, hp: 15, maxHp: 15, level: 1, events: [], syncedJiraTickets: [], syncedTaskIds: [] },
+      { createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() }
+    )
+  );
+  res.json(character);
+}));
+
+export default router;

--- a/server/routes/character.js
+++ b/server/routes/character.js
@@ -35,8 +35,7 @@ const takeRestSchema = z.object({
 const addEventSchema = z.object({
   description: z.string().min(1).max(500),
   xp: z.number().int().min(0).optional(),
-  diceNotation: z.string().regex(/^\d+d\d+([+-]\d+)?$/).optional(),
-  damageType: z.string().max(100).optional()
+  diceNotation: z.string().regex(/^\d+d\d+([+-]\d+)?$/).optional()
 });
 
 // GET /api/character - Get character sheet

--- a/server/routes/character.js
+++ b/server/routes/character.js
@@ -97,12 +97,7 @@ router.post('/sync/tasks', asyncHandler(async (req, res) => {
 
 // POST /api/character/reset - Reset character (fresh start)
 router.post('/reset', asyncHandler(async (req, res) => {
-  const character = await characterService.saveCharacter(
-    Object.assign(
-      { name: 'Adventurer', class: 'Developer', xp: 0, hp: 15, maxHp: 15, level: 1, events: [], syncedJiraTickets: [], syncedTaskIds: [] },
-      { createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() }
-    )
-  );
+  const character = await characterService.saveCharacter(characterService.createDefaultCharacter());
   res.json(character);
 }));
 

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -966,9 +966,10 @@ router.post('/jobs', asyncHandler(async (req, res) => {
     if (parts.length !== 5) {
       throw new ServerError('cronExpression must be a 5-field cron expression (minute hour dayOfMonth month dayOfWeek)', { status: 400, code: 'VALIDATION_ERROR' });
     }
-    const nextRun = parseCronToNextRun(cronExpression);
+    // Validate by computing next run within a 90-day window to avoid expensive searches
+    const nextRun = parseCronToNextRun(cronExpression, new Date(), 'UTC');
     if (!nextRun) {
-      throw new ServerError('Invalid cronExpression: unable to parse next run time', { status: 400, code: 'VALIDATION_ERROR' });
+      throw new ServerError('Invalid cronExpression: unable to compute next run time', { status: 400, code: 'VALIDATION_ERROR' });
     }
   }
 
@@ -988,9 +989,9 @@ router.put('/jobs/:id', asyncHandler(async (req, res) => {
     if (parts.length !== 5) {
       throw new ServerError('cronExpression must be a 5-field cron expression', { status: 400, code: 'VALIDATION_ERROR' });
     }
-    const nextRun = parseCronToNextRun(cronExpression);
+    const nextRun = parseCronToNextRun(cronExpression, new Date(), 'UTC');
     if (!nextRun) {
-      throw new ServerError('Invalid cronExpression: unable to parse next run time', { status: 400, code: 'VALIDATION_ERROR' });
+      throw new ServerError('Invalid cronExpression: unable to compute next run time', { status: 400, code: 'VALIDATION_ERROR' });
     }
   }
   const job = await autonomousJobs.updateJob(req.params.id, {

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -966,11 +966,9 @@ router.post('/jobs', asyncHandler(async (req, res) => {
     if (parts.length !== 5) {
       throw new ServerError('cronExpression must be a 5-field cron expression (minute hour dayOfMonth month dayOfWeek)', { status: 400, code: 'VALIDATION_ERROR' });
     }
-    // Validate by attempting to compute the next run time
-    const nextRun = parseCronToNextRun(cronExpression, new Date(), 'UTC');
-    if (!nextRun) {
-      throw new ServerError('Invalid cronExpression: unable to compute next run time', { status: 400, code: 'VALIDATION_ERROR' });
-    }
+    // Validate syntax and field ranges (parseCronToNextRun throws on invalid expressions)
+    // Note: null return means no match within search window (e.g. leap day) -- not invalid
+    parseCronToNextRun(cronExpression, new Date(), 'UTC');
   }
 
   const job = await autonomousJobs.createJob({
@@ -989,10 +987,8 @@ router.put('/jobs/:id', asyncHandler(async (req, res) => {
     if (parts.length !== 5) {
       throw new ServerError('cronExpression must be a 5-field cron expression', { status: 400, code: 'VALIDATION_ERROR' });
     }
-    const nextRun = parseCronToNextRun(cronExpression, new Date(), 'UTC');
-    if (!nextRun) {
-      throw new ServerError('Invalid cronExpression: unable to compute next run time', { status: 400, code: 'VALIDATION_ERROR' });
-    }
+    // Validate syntax and field ranges (parseCronToNextRun throws on invalid expressions)
+    parseCronToNextRun(cronExpression, new Date(), 'UTC');
   }
   const job = await autonomousJobs.updateJob(req.params.id, {
     name, description, category, type, interval, intervalMs, scheduledTime, cronExpression,

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -966,7 +966,7 @@ router.post('/jobs', asyncHandler(async (req, res) => {
     if (parts.length !== 5) {
       throw new ServerError('cronExpression must be a 5-field cron expression (minute hour dayOfMonth month dayOfWeek)', { status: 400, code: 'VALIDATION_ERROR' });
     }
-    // Validate by computing next run within a 90-day window to avoid expensive searches
+    // Validate by attempting to compute the next run time
     const nextRun = parseCronToNextRun(cronExpression, new Date(), 'UTC');
     if (!nextRun) {
       throw new ServerError('Invalid cronExpression: unable to compute next run time', { status: 400, code: 'VALIDATION_ERROR' });

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -18,6 +18,7 @@ import * as goalProgress from '../services/goalProgress.js';
 import * as decisionLog from '../services/decisionLog.js';
 import { reinitialize as reinitializeEmbeddings } from '../services/memoryEmbeddings.js';
 import * as claudeChangelog from '../services/claudeChangelog.js';
+import { parseCronToNextRun } from '../services/eventScheduler.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { validateRequest, sanitizeTaskMetadata } from '../lib/validation.js';
 import { z } from 'zod';
@@ -965,6 +966,10 @@ router.post('/jobs', asyncHandler(async (req, res) => {
     if (parts.length !== 5) {
       throw new ServerError('cronExpression must be a 5-field cron expression (minute hour dayOfMonth month dayOfWeek)', { status: 400, code: 'VALIDATION_ERROR' });
     }
+    const nextRun = parseCronToNextRun(cronExpression);
+    if (!nextRun) {
+      throw new ServerError('Invalid cronExpression: unable to parse next run time', { status: 400, code: 'VALIDATION_ERROR' });
+    }
   }
 
   const job = await autonomousJobs.createJob({
@@ -978,6 +983,16 @@ router.post('/jobs', asyncHandler(async (req, res) => {
 router.put('/jobs/:id', asyncHandler(async (req, res) => {
   const { name, description, category, type, interval, intervalMs, scheduledTime, cronExpression,
     enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, weekdaysOnly } = req.body;
+  if (cronExpression) {
+    const parts = cronExpression.trim().split(/\s+/);
+    if (parts.length !== 5) {
+      throw new ServerError('cronExpression must be a 5-field cron expression', { status: 400, code: 'VALIDATION_ERROR' });
+    }
+    const nextRun = parseCronToNextRun(cronExpression);
+    if (!nextRun) {
+      throw new ServerError('Invalid cronExpression: unable to parse next run time', { status: 400, code: 'VALIDATION_ERROR' });
+    }
+  }
   const job = await autonomousJobs.updateJob(req.params.id, {
     name, description, category, type, interval, intervalMs, scheduledTime, cronExpression,
     enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, weekdaysOnly

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -64,7 +64,7 @@ const cosConfigSchema = z.object({
   }).optional()
 }).strict();
 
-const SCHEDULE_FIELDS = ['type', 'enabled', 'intervalMs', 'providerId', 'model', 'prompt', 'taskMetadata', 'runAfter'];
+const SCHEDULE_FIELDS = ['type', 'enabled', 'intervalMs', 'cronExpression', 'providerId', 'model', 'prompt', 'taskMetadata', 'runAfter'];
 
 /**
  * Pick only defined values from body for schedule settings updates
@@ -875,7 +875,8 @@ router.get('/schedule/interval-types', (req, res) => {
       weekly: 'Runs once per week',
       once: 'Runs once per app or globally, then stops',
       'on-demand': 'Only runs when manually triggered',
-      custom: 'Custom interval in milliseconds'
+      custom: 'Custom interval in milliseconds',
+      cron: 'Cron expression schedule (minute hour dayOfMonth month dayOfWeek)'
     }
   });
 });
@@ -942,7 +943,7 @@ router.get('/jobs/:id', asyncHandler(async (req, res) => {
 
 // POST /api/cos/jobs - Create a new autonomous job
 router.post('/jobs', asyncHandler(async (req, res) => {
-  const { name, description, category, type, interval, intervalMs, scheduledTime, enabled, priority, autonomyLevel, promptTemplate, command, triggerAction } = req.body;
+  const { name, description, category, type, interval, intervalMs, scheduledTime, cronExpression, enabled, priority, autonomyLevel, promptTemplate, command, triggerAction } = req.body;
 
   const VALID_JOB_TYPES = ['agent', 'shell', 'script'];
   if (!name) {
@@ -959,9 +960,15 @@ router.post('/jobs', asyncHandler(async (req, res) => {
       throw new ServerError('promptTemplate is required for agent jobs', { status: 400, code: 'VALIDATION_ERROR' });
     }
   }
+  if (cronExpression) {
+    const parts = cronExpression.trim().split(/\s+/);
+    if (parts.length !== 5) {
+      throw new ServerError('cronExpression must be a 5-field cron expression (minute hour dayOfMonth month dayOfWeek)', { status: 400, code: 'VALIDATION_ERROR' });
+    }
+  }
 
   const job = await autonomousJobs.createJob({
-    name, description, category, type, interval, intervalMs, scheduledTime,
+    name, description, category, type, interval, intervalMs, scheduledTime, cronExpression,
     enabled, priority, autonomyLevel, promptTemplate, command, triggerAction
   });
   res.json({ success: true, job });
@@ -969,10 +976,10 @@ router.post('/jobs', asyncHandler(async (req, res) => {
 
 // PUT /api/cos/jobs/:id - Update a job
 router.put('/jobs/:id', asyncHandler(async (req, res) => {
-  const { name, description, category, type, interval, intervalMs, scheduledTime,
+  const { name, description, category, type, interval, intervalMs, scheduledTime, cronExpression,
     enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, weekdaysOnly } = req.body;
   const job = await autonomousJobs.updateJob(req.params.id, {
-    name, description, category, type, interval, intervalMs, scheduledTime,
+    name, description, category, type, interval, intervalMs, scheduledTime, cronExpression,
     enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, weekdaysOnly
   });
   if (!job) {

--- a/server/services/automationScheduler.js
+++ b/server/services/automationScheduler.js
@@ -11,6 +11,7 @@ import EventEmitter from 'events';
 import { PATHS, createCachedStore } from '../lib/fileUtils.js';
 import * as eventScheduler from './eventScheduler.js';
 import * as agentActivity from './agentActivity.js';
+import { getUserTimezone } from '../lib/timezone.js';
 
 const SCHEDULES_FILE = join(PATHS.agentPersonalities, 'schedules.json');
 const store = createCachedStore(SCHEDULES_FILE, { schedules: {} }, { context: 'automation schedules' });
@@ -209,6 +210,7 @@ async function activateSchedule(id, schedule) {
   if (schedule.schedule.type === 'cron') {
     eventConfig.type = 'cron';
     eventConfig.cron = schedule.schedule.cron;
+    eventConfig.timezone = await getUserTimezone();
   } else if (schedule.schedule.type === 'interval') {
     eventConfig.type = 'interval';
     eventConfig.intervalMs = schedule.schedule.intervalMs;

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -632,7 +632,7 @@ async function getDueJobs() {
   for (const job of enabledJobs) {
     // Cron-mode jobs: compute next run from cron expression
     if (job.cronExpression) {
-      const from = job.lastRun ? new Date(job.lastRun) : new Date(0)
+      const from = job.lastRun ? new Date(job.lastRun) : new Date(now)
       const next = parseCronToNextRun(job.cronExpression, from, timezone)
       if (!next || next.getTime() > now) continue
 
@@ -1042,7 +1042,7 @@ async function getNextDueJob() {
 
     if (job.cronExpression) {
       // Cron-mode: derive next due from cron expression
-      const from = job.lastRun ? new Date(job.lastRun) : new Date(0)
+      const from = job.lastRun ? new Date(job.lastRun) : new Date()
       const next = parseCronToNextRun(job.cronExpression, from, timezone)
       if (!next) continue
       nextDue = next.getTime()

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -26,6 +26,7 @@ import { createMutex } from '../lib/asyncMutex.js'
 import { checkAndPrompt as autobiographyCheckAndPrompt } from './autobiography.js'
 import { runGoalCheckIn } from './goalCheckIn.js'
 import { validateCommand, redactOutput, ALLOWED_COMMANDS_SORTED } from '../lib/commandSecurity.js'
+import { getUserTimezone, getLocalParts, nextLocalTime } from '../lib/timezone.js'
 
 /**
  * Run the moltworld-explore.mjs script as a child process (no AI agent needed).
@@ -592,27 +593,29 @@ async function getEnabledJobs() {
 
 /**
  * Check if the current time has passed a job's scheduledTime today.
- * scheduledTime is "HH:MM" in local time (e.g., "05:00").
+ * scheduledTime is "HH:MM" in the user's configured timezone.
  * Returns true if no scheduledTime is set, or if current local time >= scheduledTime.
  * @param {string|null} scheduledTime - "HH:MM" or null/undefined
+ * @param {string} timezone - IANA timezone string
  * @returns {boolean}
  */
-function isScheduledTimeMet(scheduledTime) {
+function isScheduledTimeMet(scheduledTime, timezone) {
   if (!scheduledTime) return true
   const [hours, minutes] = scheduledTime.split(':').map(Number)
-  const now = new Date()
-  const nowMinutes = now.getHours() * 60 + now.getMinutes()
+  const local = getLocalParts(new Date(), timezone)
+  const nowMinutes = local.hour * 60 + local.minute
   const targetMinutes = hours * 60 + minutes
   return nowMinutes >= targetMinutes
 }
 
 /**
- * Check if today is a weekday (Monday-Friday).
+ * Check if today is a weekday (Monday-Friday) in the user's timezone.
+ * @param {string} timezone - IANA timezone string
  * @returns {boolean}
  */
-function isWeekday() {
-  const day = new Date().getDay()
-  return day >= 1 && day <= 5
+function isWeekday(timezone) {
+  const local = getLocalParts(new Date(), timezone)
+  return local.dayOfWeek >= 1 && local.dayOfWeek <= 5
 }
 
 /**
@@ -622,6 +625,7 @@ function isWeekday() {
 async function getDueJobs() {
   const enabledJobs = await getEnabledJobs()
   const now = Date.now()
+  const timezone = await getUserTimezone()
   const due = []
 
   for (const job of enabledJobs) {
@@ -630,10 +634,10 @@ async function getDueJobs() {
 
     if (timeSinceLastRun >= job.intervalMs) {
       // If job has a scheduledTime, only mark due if we've passed that time today
-      if (!isScheduledTimeMet(job.scheduledTime)) continue
+      if (!isScheduledTimeMet(job.scheduledTime, timezone)) continue
 
       // If job is weekdaysOnly, skip weekends
-      if (job.weekdaysOnly && !isWeekday()) continue
+      if (job.weekdaysOnly && !isWeekday(timezone)) continue
 
       due.push({
         ...job,
@@ -687,6 +691,7 @@ async function createJob(jobData) {
       name: jobData.name,
       description: jobData.description || '',
       category: jobData.category || 'custom',
+      cronExpression: jobData.cronExpression || null,
       type: jobType,
       interval: jobData.interval || 'weekly',
       intervalMs: resolveIntervalMs(jobData.interval || 'weekly', jobData.intervalMs),
@@ -739,7 +744,7 @@ async function updateJob(jobId, updates) {
 
     const updatableFields = [
       'name', 'description', 'category', 'type', 'interval', 'intervalMs',
-      'scheduledTime', 'weekdaysOnly', 'enabled', 'priority', 'autonomyLevel', 'promptTemplate',
+      'scheduledTime', 'cronExpression', 'weekdaysOnly', 'enabled', 'priority', 'autonomyLevel', 'promptTemplate',
       'command', 'triggerAction'
     ]
 
@@ -1012,6 +1017,7 @@ async function getNextDueJob() {
   const enabledJobs = await getEnabledJobs()
   if (enabledJobs.length === 0) return null
 
+  const timezone = await getUserTimezone()
   let earliest = null
   let earliestTime = Infinity
 
@@ -1019,21 +1025,16 @@ async function getNextDueJob() {
     const lastRun = job.lastRun ? new Date(job.lastRun).getTime() : 0
     let nextDue = lastRun + job.intervalMs
 
-    // If job has scheduledTime, adjust nextDue to that time of day
+    // If job has scheduledTime, find next occurrence in user's timezone
     if (job.scheduledTime) {
       const [hours, minutes] = job.scheduledTime.split(':').map(Number)
-      const nextDueDate = new Date(nextDue)
-      nextDueDate.setHours(hours, minutes, 0, 0)
-      // If the scheduled time already passed on the interval-due date, it's fine
-      // If not, the job waits until that time
-      if (nextDueDate.getTime() > nextDue) {
-        nextDue = nextDueDate.getTime()
-      }
+      const candidate = nextLocalTime(nextDue, hours, minutes, timezone)
+      if (candidate > nextDue) nextDue = candidate
     }
 
     if (nextDue < earliestTime) {
       earliestTime = nextDue
-      const isDue = Date.now() >= nextDue && isScheduledTimeMet(job.scheduledTime)
+      const isDue = Date.now() >= nextDue && isScheduledTimeMet(job.scheduledTime, timezone)
       earliest = {
         jobId: job.id,
         jobName: job.name,

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -27,6 +27,7 @@ import { checkAndPrompt as autobiographyCheckAndPrompt } from './autobiography.j
 import { runGoalCheckIn } from './goalCheckIn.js'
 import { validateCommand, redactOutput, ALLOWED_COMMANDS_SORTED } from '../lib/commandSecurity.js'
 import { getUserTimezone, getLocalParts, nextLocalTime } from '../lib/timezone.js'
+import { parseCronToNextRun } from './eventScheduler.js'
 
 /**
  * Run the moltworld-explore.mjs script as a child process (no AI agent needed).
@@ -629,6 +630,21 @@ async function getDueJobs() {
   const due = []
 
   for (const job of enabledJobs) {
+    // Cron-mode jobs: compute next run from cron expression
+    if (job.cronExpression) {
+      const from = job.lastRun ? new Date(job.lastRun) : new Date(0)
+      const next = parseCronToNextRun(job.cronExpression, from, timezone)
+      if (!next || next.getTime() > now) continue
+
+      due.push({
+        ...job,
+        reason: job.lastRun ? 'cron-due' : 'never-run',
+        overdueBy: now - next.getTime()
+      })
+      continue
+    }
+
+    // Interval-mode jobs
     const lastRun = job.lastRun ? new Date(job.lastRun).getTime() : 0
     const timeSinceLastRun = now - lastRun
 
@@ -1022,19 +1038,32 @@ async function getNextDueJob() {
   let earliestTime = Infinity
 
   for (const job of enabledJobs) {
-    const lastRun = job.lastRun ? new Date(job.lastRun).getTime() : 0
-    let nextDue = lastRun + job.intervalMs
+    let nextDue
 
-    // If job has scheduledTime, find next occurrence in user's timezone
-    if (job.scheduledTime) {
-      const [hours, minutes] = job.scheduledTime.split(':').map(Number)
-      const candidate = nextLocalTime(nextDue, hours, minutes, timezone)
-      if (candidate > nextDue) nextDue = candidate
+    if (job.cronExpression) {
+      // Cron-mode: derive next due from cron expression
+      const from = job.lastRun ? new Date(job.lastRun) : new Date(0)
+      const next = parseCronToNextRun(job.cronExpression, from, timezone)
+      if (!next) continue
+      nextDue = next.getTime()
+    } else {
+      // Interval-mode
+      const lastRun = job.lastRun ? new Date(job.lastRun).getTime() : 0
+      nextDue = lastRun + job.intervalMs
+
+      // If job has scheduledTime, find next occurrence in user's timezone
+      if (job.scheduledTime) {
+        const [hours, minutes] = job.scheduledTime.split(':').map(Number)
+        const candidate = nextLocalTime(nextDue, hours, minutes, timezone)
+        if (candidate > nextDue) nextDue = candidate
+      }
     }
 
     if (nextDue < earliestTime) {
       earliestTime = nextDue
-      const isDue = Date.now() >= nextDue && isScheduledTimeMet(job.scheduledTime, timezone)
+      const isDue = job.cronExpression
+        ? Date.now() >= nextDue
+        : Date.now() >= nextDue && isScheduledTimeMet(job.scheduledTime, timezone)
       earliest = {
         jobId: job.id,
         jobName: job.name,

--- a/server/services/autonomousJobs.test.js
+++ b/server/services/autonomousJobs.test.js
@@ -8,6 +8,7 @@ vi.mock('./cosEvents.js', () => ({
 vi.mock('../lib/fileUtils.js', () => ({
   readJSONFile: vi.fn(),
   ensureDir: vi.fn().mockResolvedValue(),
+  safeJSONParse: (raw, fallback) => { try { return JSON.parse(raw) } catch { return fallback } },
   PATHS: { cos: '/mock/data/cos', digitalTwin: '/mock/data/digital-twin', data: '/mock/data' },
   HOUR: 60 * 60 * 1000,
   DAY: 24 * 60 * 60 * 1000

--- a/server/services/backupScheduler.js
+++ b/server/services/backupScheduler.js
@@ -8,6 +8,7 @@
 import { schedule, cancel } from './eventScheduler.js';
 import { getSettings } from './settings.js';
 import { runBackup } from './backup.js';
+import { getUserTimezone } from '../lib/timezone.js';
 
 /**
  * Start the backup scheduler.
@@ -30,11 +31,13 @@ export async function startBackupScheduler() {
   const cronExpression = settings.backup?.cronExpression || '0 0 * * *';
   const destPath = settings.backup.destPath;
   const excludePaths = settings.backup?.excludePaths || [];
+  const timezone = await getUserTimezone();
 
   schedule({
     id: 'backup-daily',
     type: 'cron',
     cron: cronExpression,
+    timezone,
     handler: async () => {
       console.log('💾 Backup scheduler: running scheduled backup');
       await runBackup(destPath, null, { excludePaths });

--- a/server/services/brain.js
+++ b/server/services/brain.js
@@ -489,6 +489,13 @@ export async function runDailyDigest(providerOverride, modelOverride) {
   // Filter people with follow-ups
   const peopleWithFollowUps = allPeople.filter(p => p.followUps && p.followUps.length > 0);
 
+  // Skip AI call when brain has no data (fresh instance)
+  if (!activeProjects.length && !openAdmin.length && !peopleWithFollowUps.length && !needsReviewLogs.length) {
+    console.log('🧠 Skipping daily digest: no brain data yet');
+    await storage.updateMeta({ lastDailyDigest: new Date().toISOString() });
+    return null;
+  }
+
   const aiResponse = await callAI(
     'brain-daily-digest',
     {
@@ -544,6 +551,13 @@ export async function runWeeklyReview(providerOverride, modelOverride) {
 
   // Get active projects
   const activeProjects = await storage.getProjects({ status: 'active' });
+
+  // Skip AI call when brain has no data (fresh instance)
+  if (!recentInboxLogs.length && !activeProjects.length) {
+    console.log('🧠 Skipping weekly review: no brain data yet');
+    await storage.updateMeta({ lastWeeklyReview: new Date().toISOString() });
+    return null;
+  }
 
   const aiResponse = await callAI(
     'brain-weekly-review',

--- a/server/services/brain.test.js
+++ b/server/services/brain.test.js
@@ -647,7 +647,7 @@ describe('brain service', () => {
 
     it('should truncate digest text exceeding 150 words', async () => {
       storage.getProjects.mockResolvedValue([]);
-      storage.getAdminItems.mockResolvedValue([]);
+      storage.getAdminItems.mockResolvedValue([{ id: 'a1', title: 'Task', status: 'open' }]);
       storage.getPeople.mockResolvedValue([]);
       storage.getInboxLog.mockResolvedValue([]);
 
@@ -721,7 +721,7 @@ describe('brain service', () => {
     });
 
     it('should throw when AI returns invalid digest format', async () => {
-      storage.getProjects.mockResolvedValue([]);
+      storage.getProjects.mockResolvedValue([{ id: 'p1', name: 'Proj', status: 'active' }]);
       storage.getAdminItems.mockResolvedValue([]);
       storage.getPeople.mockResolvedValue([]);
       storage.getInboxLog.mockResolvedValue([]);
@@ -793,7 +793,7 @@ describe('brain service', () => {
     });
 
     it('should truncate review text exceeding 250 words', async () => {
-      storage.getInboxLog.mockResolvedValue([]);
+      storage.getInboxLog.mockResolvedValue([{ id: 'inbox-001', capturedAt: new Date().toISOString(), status: 'filed' }]);
       storage.getProjects.mockResolvedValue([]);
 
       const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
@@ -825,7 +825,7 @@ describe('brain service', () => {
     });
 
     it('should throw when AI returns invalid review format', async () => {
-      storage.getInboxLog.mockResolvedValue([]);
+      storage.getInboxLog.mockResolvedValue([{ id: 'inbox-001', capturedAt: new Date().toISOString(), status: 'filed' }]);
       storage.getProjects.mockResolvedValue([]);
 
       const mockProvider = { id: 'lmstudio', enabled: true, type: 'api', endpoint: 'http://localhost:1234/v1', defaultModel: 'test' };
@@ -848,7 +848,7 @@ describe('brain service', () => {
 
   describe('parseJsonResponse (indirect via AI calls)', () => {
     it('should handle JSON wrapped in markdown code blocks', async () => {
-      storage.getProjects.mockResolvedValue([]);
+      storage.getProjects.mockResolvedValue([{ id: 'p1', name: 'Proj', status: 'active' }]);
       storage.getAdminItems.mockResolvedValue([]);
       storage.getPeople.mockResolvedValue([]);
       storage.getInboxLog.mockResolvedValue([]);
@@ -880,7 +880,7 @@ describe('brain service', () => {
     });
 
     it('should throw on empty AI response', async () => {
-      storage.getProjects.mockResolvedValue([]);
+      storage.getProjects.mockResolvedValue([{ id: 'p1', name: 'Proj', status: 'active' }]);
       storage.getAdminItems.mockResolvedValue([]);
       storage.getPeople.mockResolvedValue([]);
       storage.getInboxLog.mockResolvedValue([]);
@@ -905,7 +905,7 @@ describe('brain service', () => {
 
   describe('callAI error handling (indirect)', () => {
     it('should throw when no provider available', async () => {
-      storage.getProjects.mockResolvedValue([]);
+      storage.getProjects.mockResolvedValue([{ id: 'p1', name: 'Proj', status: 'active' }]);
       storage.getAdminItems.mockResolvedValue([]);
       storage.getPeople.mockResolvedValue([]);
       storage.getInboxLog.mockResolvedValue([]);
@@ -916,7 +916,7 @@ describe('brain service', () => {
     });
 
     it('should throw when provider is disabled', async () => {
-      storage.getProjects.mockResolvedValue([]);
+      storage.getProjects.mockResolvedValue([{ id: 'p1', name: 'Proj', status: 'active' }]);
       storage.getAdminItems.mockResolvedValue([]);
       storage.getPeople.mockResolvedValue([]);
       storage.getInboxLog.mockResolvedValue([]);
@@ -927,7 +927,7 @@ describe('brain service', () => {
     });
 
     it('should throw on API error response', async () => {
-      storage.getProjects.mockResolvedValue([]);
+      storage.getProjects.mockResolvedValue([{ id: 'p1', name: 'Proj', status: 'active' }]);
       storage.getAdminItems.mockResolvedValue([]);
       storage.getPeople.mockResolvedValue([]);
       storage.getInboxLog.mockResolvedValue([]);
@@ -945,7 +945,7 @@ describe('brain service', () => {
     });
 
     it('should throw for unsupported provider type', async () => {
-      storage.getProjects.mockResolvedValue([]);
+      storage.getProjects.mockResolvedValue([{ id: 'p1', name: 'Proj', status: 'active' }]);
       storage.getAdminItems.mockResolvedValue([]);
       storage.getPeople.mockResolvedValue([]);
       storage.getInboxLog.mockResolvedValue([]);

--- a/server/services/character.js
+++ b/server/services/character.js
@@ -179,6 +179,8 @@ export async function addEvent(event) {
   return { character, event: logEntry, leveledUp };
 }
 
+const delay = ms => new Promise(r => setTimeout(r, ms));
+
 export async function syncJiraXP() {
   const character = await getCharacter();
   const config = await jiraService.getInstances();
@@ -195,7 +197,9 @@ export async function syncJiraXP() {
       continue;
     }
 
-    for (const project of projects) {
+    for (let i = 0; i < projects.length; i++) {
+      if (i > 0) await delay(500); // Rate-limit JIRA API calls
+      const project = projects[i];
       let tickets;
       try {
         tickets = await jiraService.getMyCurrentSprintTickets(instanceId, project.key);

--- a/server/services/character.js
+++ b/server/services/character.js
@@ -1,0 +1,395 @@
+/**
+ * Character Sheet Service
+ * D&D-style character sheet tracking XP, HP, level, damage, rests, and events.
+ */
+
+import crypto from 'crypto';
+import path from 'path';
+import { readFile, writeFile } from 'fs/promises';
+import { existsSync } from 'fs';
+import { ensureDir, PATHS } from '../lib/fileUtils.js';
+import * as jiraService from './jira.js';
+import * as cosService from './cos.js';
+
+const CHARACTER_FILE = path.join(PATHS.data, 'character.json');
+
+// D&D 5e XP thresholds per level
+const XP_THRESHOLDS = [
+  0,       // Level 1
+  300,     // Level 2
+  900,     // Level 3
+  2700,    // Level 4
+  6500,    // Level 5
+  14000,   // Level 6
+  23000,   // Level 7
+  34000,   // Level 8
+  48000,   // Level 9
+  64000,   // Level 10
+  85000,   // Level 11
+  100000,  // Level 12
+  120000,  // Level 13
+  140000,  // Level 14
+  165000,  // Level 15
+  195000,  // Level 16
+  225000,  // Level 17
+  265000,  // Level 18
+  305000,  // Level 19
+  355000   // Level 20
+];
+
+/**
+ * Calculate level from XP using D&D 5e thresholds
+ */
+function getLevelFromXP(xp) {
+  for (let i = XP_THRESHOLDS.length - 1; i >= 0; i--) {
+    if (xp >= XP_THRESHOLDS[i]) return i + 1;
+  }
+  return 1;
+}
+
+/**
+ * Calculate max HP: base 10 + (level * 5)
+ */
+function getMaxHP(level) {
+  return 10 + (level * 5);
+}
+
+/**
+ * Create default character data
+ */
+function createDefaultCharacter() {
+  const now = new Date().toISOString();
+  return {
+    name: 'Adventurer',
+    class: 'Developer',
+    xp: 0,
+    hp: 15,
+    maxHp: 15,
+    level: 1,
+    events: [],
+    syncedJiraTickets: [],
+    syncedTaskIds: [],
+    createdAt: now,
+    updatedAt: now
+  };
+}
+
+/**
+ * Load character data, creating defaults if file doesn't exist
+ */
+export async function getCharacter() {
+  await ensureDir(PATHS.data);
+  if (!existsSync(CHARACTER_FILE)) {
+    const character = createDefaultCharacter();
+    await saveCharacter(character);
+    return character;
+  }
+  const content = await readFile(CHARACTER_FILE, 'utf-8');
+  return JSON.parse(content);
+}
+
+/**
+ * Save character data to disk
+ */
+export async function saveCharacter(data) {
+  await ensureDir(PATHS.data);
+  data.updatedAt = new Date().toISOString();
+  await writeFile(CHARACTER_FILE, JSON.stringify(data, null, 2));
+  return data;
+}
+
+/**
+ * Parse dice notation like "1d8", "2d6+3", "1d20-1"
+ * Returns { rolls, modifier, total }
+ */
+export function rollDice(notation) {
+  const match = notation.match(/^(\d+)d(\d+)([+-]\d+)?$/);
+  if (!match) {
+    throw new Error(`Invalid dice notation: ${notation}`);
+  }
+
+  const count = parseInt(match[1], 10);
+  const sides = parseInt(match[2], 10);
+  const modifier = match[3] ? parseInt(match[3], 10) : 0;
+
+  const rolls = [];
+  for (let i = 0; i < count; i++) {
+    rolls.push(Math.floor(Math.random() * sides) + 1);
+  }
+
+  const total = rolls.reduce((sum, r) => sum + r, 0) + modifier;
+
+  return { rolls, modifier, total: Math.max(0, total) };
+}
+
+/**
+ * Add XP and check for level up
+ * Returns { character, leveledUp, newLevel }
+ */
+export async function addXP(amount, source, description) {
+  const character = await getCharacter();
+  const oldLevel = character.level;
+
+  character.xp += amount;
+  character.level = getLevelFromXP(character.xp);
+  character.maxHp = getMaxHP(character.level);
+
+  // If leveled up, heal to new max HP
+  const leveledUp = character.level > oldLevel;
+  if (leveledUp) {
+    character.hp = character.maxHp;
+    console.log(`🎉 Level up! ${oldLevel} -> ${character.level}`);
+  }
+
+  const event = {
+    id: crypto.randomUUID(),
+    type: 'xp',
+    description: description || `Gained ${amount} XP from ${source}`,
+    xp: amount,
+    damage: 0,
+    diceNotation: null,
+    diceRolls: [],
+    hpRecovered: 0,
+    timestamp: new Date().toISOString()
+  };
+
+  character.events.push(event);
+  await saveCharacter(character);
+
+  console.log(`✨ +${amount} XP (${source}) — total ${character.xp} XP, level ${character.level}`);
+  return { character, leveledUp, newLevel: character.level };
+}
+
+/**
+ * Roll dice and apply damage
+ * Returns { character, roll, totalDamage }
+ */
+export async function takeDamage(diceNotation, description) {
+  const character = await getCharacter();
+  const roll = rollDice(diceNotation);
+
+  character.hp = Math.max(0, character.hp - roll.total);
+
+  const event = {
+    id: crypto.randomUUID(),
+    type: 'damage',
+    description: description || `Took ${roll.total} damage (${diceNotation})`,
+    xp: 0,
+    damage: roll.total,
+    diceNotation,
+    diceRolls: roll.rolls,
+    hpRecovered: 0,
+    timestamp: new Date().toISOString()
+  };
+
+  character.events.push(event);
+  await saveCharacter(character);
+
+  console.log(`💥 ${roll.total} damage (${diceNotation}: [${roll.rolls}]+${roll.modifier}) — ${character.hp}/${character.maxHp} HP`);
+  return { character, roll, totalDamage: roll.total };
+}
+
+/**
+ * Take a short or long rest
+ * Returns { character, hpRecovered }
+ */
+export async function takeRest(type) {
+  const character = await getCharacter();
+  const oldHp = character.hp;
+
+  if (type === 'long') {
+    character.hp = character.maxHp;
+  } else {
+    const recovery = Math.floor(character.maxHp * 0.25);
+    character.hp = Math.min(character.maxHp, character.hp + recovery);
+  }
+
+  const hpRecovered = character.hp - oldHp;
+
+  const event = {
+    id: crypto.randomUUID(),
+    type: 'rest',
+    description: `${type === 'long' ? 'Long' : 'Short'} rest — recovered ${hpRecovered} HP`,
+    xp: 0,
+    damage: 0,
+    diceNotation: null,
+    diceRolls: [],
+    hpRecovered,
+    timestamp: new Date().toISOString()
+  };
+
+  character.events.push(event);
+  await saveCharacter(character);
+
+  console.log(`🛏️ ${type} rest — recovered ${hpRecovered} HP (${character.hp}/${character.maxHp})`);
+  return { character, hpRecovered };
+}
+
+/**
+ * Log a custom event with optional XP and/or damage
+ */
+export async function addEvent(event) {
+  const character = await getCharacter();
+  const oldLevel = character.level;
+  let roll = null;
+  let leveledUp = false;
+
+  if (event.xp) {
+    character.xp += event.xp;
+    character.level = getLevelFromXP(character.xp);
+    character.maxHp = getMaxHP(character.level);
+    leveledUp = character.level > oldLevel;
+    if (leveledUp) {
+      character.hp = character.maxHp;
+    }
+  }
+
+  if (event.diceNotation) {
+    roll = rollDice(event.diceNotation);
+    character.hp = Math.max(0, character.hp - roll.total);
+  }
+
+  const logEntry = {
+    id: crypto.randomUUID(),
+    type: 'custom',
+    description: event.description,
+    xp: event.xp || 0,
+    damage: roll ? roll.total : 0,
+    diceNotation: event.diceNotation || null,
+    diceRolls: roll ? roll.rolls : [],
+    hpRecovered: 0,
+    timestamp: new Date().toISOString()
+  };
+
+  character.events.push(logEntry);
+  await saveCharacter(character);
+
+  console.log(`📝 Custom event: ${event.description}`);
+  return { character, event: logEntry, leveledUp };
+}
+
+/**
+ * Sync JIRA tickets for XP — awards XP for Done tickets not already tracked
+ */
+export async function syncJiraXP() {
+  const character = await getCharacter();
+  const config = await jiraService.getInstances();
+  const instances = config.instances || {};
+  let totalXP = 0;
+  let ticketCount = 0;
+
+  for (const [instanceId, instance] of Object.entries(instances)) {
+    // Get projects for this instance
+    let projects;
+    try {
+      projects = await jiraService.getProjects(instanceId);
+    } catch {
+      console.log(`⚠️ Could not fetch projects for JIRA instance ${instanceId}`);
+      continue;
+    }
+
+    for (const project of projects) {
+      let tickets;
+      try {
+        tickets = await jiraService.getMyCurrentSprintTickets(instanceId, project.key);
+      } catch {
+        console.log(`⚠️ Could not fetch tickets for ${project.key}`);
+        continue;
+      }
+      const doneTickets = tickets.filter(t =>
+        t.statusCategory === 'Done' || t.status === 'Done'
+      );
+
+      for (const ticket of doneTickets) {
+        if (character.syncedJiraTickets.includes(ticket.key)) continue;
+
+        const xp = (ticket.storyPoints || 1) * 50;
+        character.xp += xp;
+        totalXP += xp;
+        ticketCount++;
+
+        character.syncedJiraTickets.push(ticket.key);
+
+        character.events.push({
+          id: crypto.randomUUID(),
+          type: 'xp',
+          description: `JIRA ${ticket.key}: ${ticket.summary} (${ticket.storyPoints || 0} pts)`,
+          xp,
+          damage: 0,
+          diceNotation: null,
+          diceRolls: [],
+          hpRecovered: 0,
+          timestamp: new Date().toISOString()
+        });
+      }
+    }
+  }
+
+  // Recalculate level after all XP added
+  const oldLevel = character.level;
+  character.level = getLevelFromXP(character.xp);
+  character.maxHp = getMaxHP(character.level);
+  const leveledUp = character.level > oldLevel;
+  if (leveledUp) {
+    character.hp = character.maxHp;
+  }
+
+  await saveCharacter(character);
+
+  console.log(`🎫 Synced ${ticketCount} JIRA tickets for ${totalXP} XP`);
+  return { character, ticketCount, totalXP, leveledUp };
+}
+
+/**
+ * Sync CoS tasks for XP — awards 25 XP for completed tasks not already tracked
+ */
+export async function syncTaskXP() {
+  const character = await getCharacter();
+  const { user: userTasks, cos: cosTasks } = await cosService.getAllTasks();
+  let totalXP = 0;
+  let taskCount = 0;
+
+  const allTasks = [
+    ...(userTasks.tasks || []),
+    ...(cosTasks.tasks || [])
+  ];
+
+  const completedTasks = allTasks.filter(t => t.status === 'completed');
+
+  for (const task of completedTasks) {
+    if (character.syncedTaskIds.includes(task.id)) continue;
+
+    const xp = 25;
+    character.xp += xp;
+    totalXP += xp;
+    taskCount++;
+
+    character.syncedTaskIds.push(task.id);
+
+    character.events.push({
+      id: crypto.randomUUID(),
+      type: 'xp',
+      description: `Task: ${task.title || task.description || task.id}`,
+      xp,
+      damage: 0,
+      diceNotation: null,
+      diceRolls: [],
+      hpRecovered: 0,
+      timestamp: new Date().toISOString()
+    });
+  }
+
+  // Recalculate level after all XP added
+  const oldLevel = character.level;
+  character.level = getLevelFromXP(character.xp);
+  character.maxHp = getMaxHP(character.level);
+  const leveledUp = character.level > oldLevel;
+  if (leveledUp) {
+    character.hp = character.maxHp;
+  }
+
+  await saveCharacter(character);
+
+  console.log(`✅ Synced ${taskCount} tasks for ${totalXP} XP`);
+  return { character, taskCount, totalXP, leveledUp };
+}

--- a/server/services/character.js
+++ b/server/services/character.js
@@ -1,45 +1,22 @@
 /**
  * Character Sheet Service
- * D&D-style character sheet tracking XP, HP, level, damage, rests, and events.
+ * D&D 5e-style character tracking XP, HP, level, damage, rests, and events.
  */
 
 import crypto from 'crypto';
 import path from 'path';
-import { readFile, writeFile } from 'fs/promises';
-import { existsSync } from 'fs';
-import { ensureDir, PATHS } from '../lib/fileUtils.js';
+import { writeFile } from 'fs/promises';
+import { ensureDir, readJSONFile, PATHS } from '../lib/fileUtils.js';
 import * as jiraService from './jira.js';
 import * as cosService from './cos.js';
 
 const CHARACTER_FILE = path.join(PATHS.data, 'character.json');
 
-// D&D 5e XP thresholds per level
 const XP_THRESHOLDS = [
-  0,       // Level 1
-  300,     // Level 2
-  900,     // Level 3
-  2700,    // Level 4
-  6500,    // Level 5
-  14000,   // Level 6
-  23000,   // Level 7
-  34000,   // Level 8
-  48000,   // Level 9
-  64000,   // Level 10
-  85000,   // Level 11
-  100000,  // Level 12
-  120000,  // Level 13
-  140000,  // Level 14
-  165000,  // Level 15
-  195000,  // Level 16
-  225000,  // Level 17
-  265000,  // Level 18
-  305000,  // Level 19
-  355000   // Level 20
+  0, 300, 900, 2700, 6500, 14000, 23000, 34000, 48000, 64000,
+  85000, 100000, 120000, 140000, 165000, 195000, 225000, 265000, 305000, 355000
 ];
 
-/**
- * Calculate level from XP using D&D 5e thresholds
- */
 function getLevelFromXP(xp) {
   for (let i = XP_THRESHOLDS.length - 1; i >= 0; i--) {
     if (xp >= XP_THRESHOLDS[i]) return i + 1;
@@ -47,17 +24,38 @@ function getLevelFromXP(xp) {
   return 1;
 }
 
-/**
- * Calculate max HP: base 10 + (level * 5)
- */
 function getMaxHP(level) {
   return 10 + (level * 5);
 }
 
-/**
- * Create default character data
- */
-function createDefaultCharacter() {
+function createEvent(type, description, overrides = {}) {
+  return {
+    id: crypto.randomUUID(),
+    type,
+    description,
+    xp: 0,
+    damage: 0,
+    diceNotation: null,
+    diceRolls: [],
+    hpRecovered: 0,
+    ...overrides,
+    timestamp: new Date().toISOString()
+  };
+}
+
+function recalcLevel(character) {
+  const oldLevel = character.level;
+  character.level = getLevelFromXP(character.xp);
+  character.maxHp = getMaxHP(character.level);
+  const leveledUp = character.level > oldLevel;
+  if (leveledUp) {
+    character.hp = character.maxHp;
+    console.log(`🎉 Level up! ${oldLevel} -> ${character.level}`);
+  }
+  return leveledUp;
+}
+
+export function createDefaultCharacter() {
   const now = new Date().toISOString();
   return {
     name: 'Adventurer',
@@ -74,23 +72,14 @@ function createDefaultCharacter() {
   };
 }
 
-/**
- * Load character data, creating defaults if file doesn't exist
- */
 export async function getCharacter() {
-  await ensureDir(PATHS.data);
-  if (!existsSync(CHARACTER_FILE)) {
-    const character = createDefaultCharacter();
-    await saveCharacter(character);
-    return character;
-  }
-  const content = await readFile(CHARACTER_FILE, 'utf-8');
-  return JSON.parse(content);
+  const data = await readJSONFile(CHARACTER_FILE, null);
+  if (data) return data;
+  const character = createDefaultCharacter();
+  await saveCharacter(character);
+  return character;
 }
 
-/**
- * Save character data to disk
- */
 export async function saveCharacter(data) {
   await ensureDir(PATHS.data);
   data.updatedAt = new Date().toISOString();
@@ -98,15 +87,9 @@ export async function saveCharacter(data) {
   return data;
 }
 
-/**
- * Parse dice notation like "1d8", "2d6+3", "1d20-1"
- * Returns { rolls, modifier, total }
- */
 export function rollDice(notation) {
   const match = notation.match(/^(\d+)d(\d+)([+-]\d+)?$/);
-  if (!match) {
-    throw new Error(`Invalid dice notation: ${notation}`);
-  }
+  if (!match) throw new Error(`Invalid dice notation: ${notation}`);
 
   const count = parseInt(match[1], 10);
   const sides = parseInt(match[2], 10);
@@ -118,81 +101,36 @@ export function rollDice(notation) {
   }
 
   const total = rolls.reduce((sum, r) => sum + r, 0) + modifier;
-
   return { rolls, modifier, total: Math.max(0, total) };
 }
 
-/**
- * Add XP and check for level up
- * Returns { character, leveledUp, newLevel }
- */
 export async function addXP(amount, source, description) {
   const character = await getCharacter();
-  const oldLevel = character.level;
-
   character.xp += amount;
-  character.level = getLevelFromXP(character.xp);
-  character.maxHp = getMaxHP(character.level);
+  const leveledUp = recalcLevel(character);
 
-  // If leveled up, heal to new max HP
-  const leveledUp = character.level > oldLevel;
-  if (leveledUp) {
-    character.hp = character.maxHp;
-    console.log(`🎉 Level up! ${oldLevel} -> ${character.level}`);
-  }
-
-  const event = {
-    id: crypto.randomUUID(),
-    type: 'xp',
-    description: description || `Gained ${amount} XP from ${source}`,
-    xp: amount,
-    damage: 0,
-    diceNotation: null,
-    diceRolls: [],
-    hpRecovered: 0,
-    timestamp: new Date().toISOString()
-  };
-
-  character.events.push(event);
+  character.events.push(createEvent('xp', description || `Gained ${amount} XP from ${source}`, { xp: amount }));
   await saveCharacter(character);
 
   console.log(`✨ +${amount} XP (${source}) — total ${character.xp} XP, level ${character.level}`);
   return { character, leveledUp, newLevel: character.level };
 }
 
-/**
- * Roll dice and apply damage
- * Returns { character, roll, totalDamage }
- */
 export async function takeDamage(diceNotation, description) {
   const character = await getCharacter();
   const roll = rollDice(diceNotation);
 
   character.hp = Math.max(0, character.hp - roll.total);
 
-  const event = {
-    id: crypto.randomUUID(),
-    type: 'damage',
-    description: description || `Took ${roll.total} damage (${diceNotation})`,
-    xp: 0,
-    damage: roll.total,
-    diceNotation,
-    diceRolls: roll.rolls,
-    hpRecovered: 0,
-    timestamp: new Date().toISOString()
-  };
-
-  character.events.push(event);
+  character.events.push(createEvent('damage', description || `Took ${roll.total} damage (${diceNotation})`, {
+    damage: roll.total, diceNotation, diceRolls: roll.rolls
+  }));
   await saveCharacter(character);
 
   console.log(`💥 ${roll.total} damage (${diceNotation}: [${roll.rolls}]+${roll.modifier}) — ${character.hp}/${character.maxHp} HP`);
   return { character, roll, totalDamage: roll.total };
 }
 
-/**
- * Take a short or long rest
- * Returns { character, hpRecovered }
- */
 export async function takeRest(type) {
   const character = await getCharacter();
   const oldHp = character.hp;
@@ -200,48 +138,24 @@ export async function takeRest(type) {
   if (type === 'long') {
     character.hp = character.maxHp;
   } else {
-    const recovery = Math.floor(character.maxHp * 0.25);
-    character.hp = Math.min(character.maxHp, character.hp + recovery);
+    character.hp = Math.min(character.maxHp, character.hp + Math.floor(character.maxHp * 0.25));
   }
 
   const hpRecovered = character.hp - oldHp;
 
-  const event = {
-    id: crypto.randomUUID(),
-    type: 'rest',
-    description: `${type === 'long' ? 'Long' : 'Short'} rest — recovered ${hpRecovered} HP`,
-    xp: 0,
-    damage: 0,
-    diceNotation: null,
-    diceRolls: [],
-    hpRecovered,
-    timestamp: new Date().toISOString()
-  };
-
-  character.events.push(event);
+  character.events.push(createEvent('rest', `${type === 'long' ? 'Long' : 'Short'} rest — recovered ${hpRecovered} HP`, { hpRecovered }));
   await saveCharacter(character);
 
   console.log(`🛏️ ${type} rest — recovered ${hpRecovered} HP (${character.hp}/${character.maxHp})`);
   return { character, hpRecovered };
 }
 
-/**
- * Log a custom event with optional XP and/or damage
- */
 export async function addEvent(event) {
   const character = await getCharacter();
-  const oldLevel = character.level;
   let roll = null;
-  let leveledUp = false;
 
   if (event.xp) {
     character.xp += event.xp;
-    character.level = getLevelFromXP(character.xp);
-    character.maxHp = getMaxHP(character.level);
-    leveledUp = character.level > oldLevel;
-    if (leveledUp) {
-      character.hp = character.maxHp;
-    }
   }
 
   if (event.diceNotation) {
@@ -249,17 +163,14 @@ export async function addEvent(event) {
     character.hp = Math.max(0, character.hp - roll.total);
   }
 
-  const logEntry = {
-    id: crypto.randomUUID(),
-    type: 'custom',
-    description: event.description,
+  const leveledUp = recalcLevel(character);
+
+  const logEntry = createEvent('custom', event.description, {
     xp: event.xp || 0,
     damage: roll ? roll.total : 0,
     diceNotation: event.diceNotation || null,
-    diceRolls: roll ? roll.rolls : [],
-    hpRecovered: 0,
-    timestamp: new Date().toISOString()
-  };
+    diceRolls: roll ? roll.rolls : []
+  });
 
   character.events.push(logEntry);
   await saveCharacter(character);
@@ -268,9 +179,6 @@ export async function addEvent(event) {
   return { character, event: logEntry, leveledUp };
 }
 
-/**
- * Sync JIRA tickets for XP — awards XP for Done tickets not already tracked
- */
 export async function syncJiraXP() {
   const character = await getCharacter();
   const config = await jiraService.getInstances();
@@ -278,8 +186,7 @@ export async function syncJiraXP() {
   let totalXP = 0;
   let ticketCount = 0;
 
-  for (const [instanceId, instance] of Object.entries(instances)) {
-    // Get projects for this instance
+  for (const [instanceId] of Object.entries(instances)) {
     let projects;
     try {
       projects = await jiraService.getProjects(instanceId);
@@ -296,98 +203,47 @@ export async function syncJiraXP() {
         console.log(`⚠️ Could not fetch tickets for ${project.key}`);
         continue;
       }
-      const doneTickets = tickets.filter(t =>
-        t.statusCategory === 'Done' || t.status === 'Done'
-      );
 
-      for (const ticket of doneTickets) {
+      for (const ticket of tickets.filter(t => t.statusCategory === 'Done' || t.status === 'Done')) {
         if (character.syncedJiraTickets.includes(ticket.key)) continue;
 
         const xp = (ticket.storyPoints || 1) * 50;
         character.xp += xp;
         totalXP += xp;
         ticketCount++;
-
         character.syncedJiraTickets.push(ticket.key);
-
-        character.events.push({
-          id: crypto.randomUUID(),
-          type: 'xp',
-          description: `JIRA ${ticket.key}: ${ticket.summary} (${ticket.storyPoints || 0} pts)`,
-          xp,
-          damage: 0,
-          diceNotation: null,
-          diceRolls: [],
-          hpRecovered: 0,
-          timestamp: new Date().toISOString()
-        });
+        character.events.push(createEvent('xp', `JIRA ${ticket.key}: ${ticket.summary} (${ticket.storyPoints || 0} pts)`, { xp }));
       }
     }
   }
 
-  // Recalculate level after all XP added
-  const oldLevel = character.level;
-  character.level = getLevelFromXP(character.xp);
-  character.maxHp = getMaxHP(character.level);
-  const leveledUp = character.level > oldLevel;
-  if (leveledUp) {
-    character.hp = character.maxHp;
-  }
-
+  const leveledUp = recalcLevel(character);
   await saveCharacter(character);
 
   console.log(`🎫 Synced ${ticketCount} JIRA tickets for ${totalXP} XP`);
   return { character, ticketCount, totalXP, leveledUp };
 }
 
-/**
- * Sync CoS tasks for XP — awards 25 XP for completed tasks not already tracked
- */
 export async function syncTaskXP() {
   const character = await getCharacter();
   const { user: userTasks, cos: cosTasks } = await cosService.getAllTasks();
   let totalXP = 0;
   let taskCount = 0;
 
-  const allTasks = [
-    ...(userTasks.tasks || []),
-    ...(cosTasks.tasks || [])
-  ];
+  const allTasks = [...(userTasks.tasks || []), ...(cosTasks.tasks || [])];
 
-  const completedTasks = allTasks.filter(t => t.status === 'completed');
-
-  for (const task of completedTasks) {
+  for (const task of allTasks.filter(t => t.status === 'completed')) {
     if (character.syncedTaskIds.includes(task.id)) continue;
 
     const xp = 25;
     character.xp += xp;
     totalXP += xp;
     taskCount++;
-
     character.syncedTaskIds.push(task.id);
-
-    character.events.push({
-      id: crypto.randomUUID(),
-      type: 'xp',
-      description: `Task: ${task.title || task.description || task.id}`,
-      xp,
-      damage: 0,
-      diceNotation: null,
-      diceRolls: [],
-      hpRecovered: 0,
-      timestamp: new Date().toISOString()
-    });
+    character.events.push(createEvent('xp', `Task: ${task.title || task.description || task.id}`, { xp }));
   }
 
-  // Recalculate level after all XP added
-  const oldLevel = character.level;
-  character.level = getLevelFromXP(character.xp);
-  character.maxHp = getMaxHP(character.level);
-  const leveledUp = character.level > oldLevel;
-  if (leveledUp) {
-    character.hp = character.maxHp;
-  }
-
+  const leveledUp = recalcLevel(character);
   await saveCharacter(character);
 
   console.log(`✅ Synced ${taskCount} tasks for ${totalXP} XP`);

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -26,7 +26,7 @@ import { ensureDir, ensureDirs, formatDuration, safeJSONParse, PATHS } from '../
 import { sanitizeTaskMetadata } from '../lib/validation.js';
 import { addNotification, NOTIFICATION_TYPES } from './notifications.js';
 import { recordDecision, DECISION_TYPES } from './decisionLog.js';
-import { getUserTimezone, nextLocalTime, todayInTimezone } from '../lib/timezone.js';
+import { getUserTimezone, getLocalParts, nextLocalTime, todayInTimezone } from '../lib/timezone.js';
 // Import and re-export cosEvents from separate module to avoid circular dependencies
 import { cosEvents as _cosEvents } from './cosEvents.js';
 export const cosEvents = _cosEvents;
@@ -3768,12 +3768,11 @@ function computeNextJobFireTime(job, timezone) {
     nextDue = nextLocalTime(nextDue, hours, minutes, timezone);
   }
 
-  // If weekdaysOnly, skip to next weekday
+  // If weekdaysOnly, skip to next weekday (using local day-of-week)
   if (job.weekdaysOnly) {
-    const nextDate = new Date(nextDue);
-    const day = nextDate.getDay();
-    if (day === 0) nextDue += 24 * 60 * 60 * 1000; // Sunday → Monday
-    if (day === 6) nextDue += 2 * 24 * 60 * 60 * 1000; // Saturday → Monday
+    const { dayOfWeek } = getLocalParts(new Date(nextDue), timezone);
+    if (dayOfWeek === 0) nextDue += 24 * 60 * 60 * 1000; // Sunday → Monday
+    if (dayOfWeek === 6) nextDue += 2 * 24 * 60 * 60 * 1000; // Saturday → Monday
   }
 
   return nextDue;

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -4025,21 +4025,24 @@ async function init() {
   await ensureDirectories();
 
   // When an agent completes, immediately try to dequeue the next pending task
-  cosEvents.on('agent:completed', async (agent) => {
+  cosEvents.on('agent:completed', (agent) => {
     setImmediate(() => dequeueNextTask());
 
     // Create notification when a daily briefing completes
     if (agent?.metadata?.jobId === 'job-daily-briefing' && agent?.result?.success) {
-      const tz = await getUserTimezone();
-      const today = todayInTimezone(tz);
-      addNotification({
-        type: NOTIFICATION_TYPES.BRIEFING_READY,
-        title: 'Daily Briefing Ready',
-        description: `Your daily briefing for ${today} is ready for review.`,
-        priority: 'low',
-        link: '/cos/briefing',
-        metadata: { date: today, agentId: agent.id }
-      }).catch(err => console.error(`❌ Failed to create briefing notification: ${err.message}`));
+      getUserTimezone()
+        .then(tz => {
+          const today = todayInTimezone(tz);
+          return addNotification({
+            type: NOTIFICATION_TYPES.BRIEFING_READY,
+            title: 'Daily Briefing Ready',
+            description: `Your daily briefing for ${today} is ready for review.`,
+            priority: 'low',
+            link: '/cos/briefing',
+            metadata: { date: today, agentId: agent.id }
+          });
+        })
+        .catch(err => console.error(`❌ Failed to create briefing notification: ${err.message}`));
     }
   });
 

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -3757,7 +3757,14 @@ function computeNextJobFireTime(job, timezone) {
   if (job.cronExpression) {
     const from = job.lastRun ? new Date(job.lastRun) : new Date();
     const next = parseCronToNextRun(job.cronExpression, from, timezone);
-    return next ? next.getTime() : Date.now() + 60_000;
+    if (!next) {
+      throw new Error(
+        `Invalid cron expression for autonomous job` +
+        (job.id ? ` "${job.id}"` : '') +
+        `: ${job.cronExpression}`
+      );
+    }
+    return next.getTime();
   }
 
   const lastRun = job.lastRun ? new Date(job.lastRun).getTime() : 0;

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -4106,5 +4106,7 @@ async function init() {
   }
 }
 
-// Initialize asynchronously
-init();
+// Initialize asynchronously (skip during tests to avoid circular import issues)
+if (process.env.NODE_ENV !== 'test') {
+  init();
+}

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -17,7 +17,7 @@ import { parseTasksMarkdown, groupTasksByStatus, getNextTask, getAutoApprovedTas
 import { isAppOnCooldown, getNextAppForReview, markAppReviewStarted, markIdleReviewStarted } from './appActivity.js';
 import { getActiveApps, getAppTaskTypeOverrides } from './apps.js';
 import { getAdaptiveCooldownMultiplier, getSkippedTaskTypes, getPerformanceSummary, checkAndRehabilitateSkippedTasks, getLearningInsights } from './taskLearning.js';
-import { schedule as scheduleEvent, cancel as cancelEvent, getStats as getSchedulerStats } from './eventScheduler.js';
+import { schedule as scheduleEvent, cancel as cancelEvent, getStats as getSchedulerStats, parseCronToNextRun } from './eventScheduler.js';
 import { createMutex } from '../lib/asyncMutex.js';
 import { generateProactiveTasks as generateMissionTasks, getStats as getMissionStats } from './missions.js';
 import { generateTaskFromJob, recordJobExecution, recordJobGateSkip, isScriptJob, executeScriptJob, isShellJob, executeShellJob } from './autonomousJobs.js';
@@ -26,6 +26,7 @@ import { ensureDir, ensureDirs, formatDuration, safeJSONParse, PATHS } from '../
 import { sanitizeTaskMetadata } from '../lib/validation.js';
 import { addNotification, NOTIFICATION_TYPES } from './notifications.js';
 import { recordDecision, DECISION_TYPES } from './decisionLog.js';
+import { getUserTimezone, nextLocalTime, todayInTimezone } from '../lib/timezone.js';
 // Import and re-export cosEvents from separate module to avoid circular dependencies
 import { cosEvents as _cosEvents } from './cosEvents.js';
 export const cosEvents = _cosEvents;
@@ -3743,22 +3744,28 @@ export async function approveTask(taskId) {
 }
 
 /**
- * Compute the next fire time for an autonomous job
- * @param {Object} job - The job object with intervalMs, lastRun, scheduledTime, weekdaysOnly
+ * Compute the next fire time for an autonomous job.
+ * Supports two scheduling modes:
+ * 1. Cron mode: job.cronExpression defines the full schedule
+ * 2. Interval mode: job.intervalMs + optional job.scheduledTime (HH:MM in user timezone)
+ *
+ * @param {Object} job - The job object
+ * @param {string} timezone - IANA timezone string for interpreting scheduledTime/cron
  * @returns {number} Timestamp (ms) of next fire time
  */
-function computeNextJobFireTime(job) {
+function computeNextJobFireTime(job, timezone) {
+  if (job.cronExpression) {
+    const from = job.lastRun ? new Date(job.lastRun) : new Date();
+    const next = parseCronToNextRun(job.cronExpression, from, timezone);
+    return next ? next.getTime() : Date.now() + 60_000;
+  }
+
   const lastRun = job.lastRun ? new Date(job.lastRun).getTime() : 0;
   let nextDue = lastRun + job.intervalMs;
 
-  // If job has scheduledTime, adjust to that time of day
   if (job.scheduledTime) {
     const [hours, minutes] = job.scheduledTime.split(':').map(Number);
-    const nextDueDate = new Date(nextDue);
-    nextDueDate.setHours(hours, minutes, 0, 0);
-    if (nextDueDate.getTime() > nextDue) {
-      nextDue = nextDueDate.getTime();
-    }
+    nextDue = nextLocalTime(nextDue, hours, minutes, timezone);
   }
 
   // If weekdaysOnly, skip to next weekday
@@ -3784,7 +3791,8 @@ async function registerSingleJobSchedule(jobId) {
     return;
   }
 
-  const nextFire = computeNextJobFireTime(job);
+  const timezone = await getUserTimezone();
+  const nextFire = computeNextJobFireTime(job, timezone);
   const delayMs = Math.max(nextFire - Date.now(), 1000);
 
   scheduleEvent({
@@ -4011,12 +4019,13 @@ async function init() {
   await ensureDirectories();
 
   // When an agent completes, immediately try to dequeue the next pending task
-  cosEvents.on('agent:completed', (agent) => {
+  cosEvents.on('agent:completed', async (agent) => {
     setImmediate(() => dequeueNextTask());
 
     // Create notification when a daily briefing completes
     if (agent?.metadata?.jobId === 'job-daily-briefing' && agent?.result?.success) {
-      const today = new Date().toISOString().split('T')[0];
+      const tz = await getUserTimezone();
+      const today = todayInTimezone(tz);
       addNotification({
         type: NOTIFICATION_TYPES.BRIEFING_READY,
         title: 'Daily Briefing Ready',

--- a/server/services/eventScheduler.js
+++ b/server/services/eventScheduler.js
@@ -50,8 +50,8 @@ function validateCronFieldRange(expr, min, max) {
   return true
 }
 
-// Maximum iterations for cron search loop (1 year in minutes)
-const MAX_CRON_ITERATIONS = 525960
+// Maximum iterations for cron search loop (2 years in minutes, matches maxDate window)
+const MAX_CRON_ITERATIONS = 1051920
 
 /**
  * Parse cron expression to next execution time

--- a/server/services/eventScheduler.js
+++ b/server/services/eventScheduler.js
@@ -117,9 +117,14 @@ function parseCronToNextRun(cronExpr, from = new Date(), timezone = 'UTC') {
       hour = next.getHours(); minute = next.getMinutes()
     }
 
+    // Normalize DOW: cron allows 7 for Sunday, but JS getDay() returns 0
+    // Match both 0 and 7 representations for Sunday
+    const dowMatches = matchesCronField(dow, dayOfWeekExpr, 0) ||
+      (dow === 0 && matchesCronField(7, dayOfWeekExpr, 0))
+
     if (matchesCronField(month, monthExpr, 1) &&
         matchesCronField(day, dayOfMonthExpr, 1) &&
-        matchesCronField(dow, dayOfWeekExpr, 0) &&
+        dowMatches &&
         matchesCronField(hour, hourExpr, 0) &&
         matchesCronField(minute, minuteExpr, 0)) {
       return next

--- a/server/services/eventScheduler.js
+++ b/server/services/eventScheduler.js
@@ -144,18 +144,28 @@ function matchesCronField(value, expr) {
     return expr.split(',').some(part => matchesCronField(value, part.trim()))
   }
 
+  // Handle step values first (e.g., */5, 0/10, 1-5/2)
+  if (expr.includes('/')) {
+    const [rangeExpr, step] = expr.split('/')
+    const stepNum = Number(step)
+    let startNum = 0
+    let endNum = Infinity
+    if (rangeExpr === '*') {
+      startNum = 0
+    } else if (rangeExpr.includes('-')) {
+      const [s, e] = rangeExpr.split('-').map(Number)
+      startNum = s
+      endNum = e
+    } else {
+      startNum = Number(rangeExpr)
+    }
+    return value >= startNum && value <= endNum && (value - startNum) % stepNum === 0
+  }
+
   // Handle ranges (e.g., 1-5)
   if (expr.includes('-')) {
     const [start, end] = expr.split('-').map(Number)
     return value >= start && value <= end
-  }
-
-  // Handle step values (e.g., */5 or 0/10)
-  if (expr.includes('/')) {
-    const [start, step] = expr.split('/')
-    const startNum = start === '*' ? 0 : Number(start)
-    const stepNum = Number(step)
-    return (value - startNum) % stepNum === 0 && value >= startNum
   }
 
   // Direct value match
@@ -514,7 +524,7 @@ function getStats() {
 function cancelAll() {
   const count = scheduledEvents.size
 
-  for (const id of scheduledEvents.keys()) {
+  for (const id of [...scheduledEvents.keys()]) {
     cancel(id)
   }
 

--- a/server/services/eventScheduler.js
+++ b/server/services/eventScheduler.js
@@ -117,11 +117,11 @@ function parseCronToNextRun(cronExpr, from = new Date(), timezone = 'UTC') {
       hour = next.getHours(); minute = next.getMinutes()
     }
 
-    if (matchesCronField(month, monthExpr) &&
-        matchesCronField(day, dayOfMonthExpr) &&
-        matchesCronField(dow, dayOfWeekExpr) &&
-        matchesCronField(hour, hourExpr) &&
-        matchesCronField(minute, minuteExpr)) {
+    if (matchesCronField(month, monthExpr, 1) &&
+        matchesCronField(day, dayOfMonthExpr, 1) &&
+        matchesCronField(dow, dayOfWeekExpr, 0) &&
+        matchesCronField(hour, hourExpr, 0) &&
+        matchesCronField(minute, minuteExpr, 0)) {
       return next
     }
     next.setMinutes(next.getMinutes() + 1)
@@ -136,22 +136,22 @@ function parseCronToNextRun(cronExpr, from = new Date(), timezone = 'UTC') {
  * @param {string} expr - Cron field expression
  * @returns {boolean} - True if matches
  */
-function matchesCronField(value, expr) {
+function matchesCronField(value, expr, fieldMin = 0) {
   if (expr === '*') return true
 
   // Handle comma-separated values
   if (expr.includes(',')) {
-    return expr.split(',').some(part => matchesCronField(value, part.trim()))
+    return expr.split(',').some(part => matchesCronField(value, part.trim(), fieldMin))
   }
 
   // Handle step values first (e.g., */5, 0/10, 1-5/2)
   if (expr.includes('/')) {
     const [rangeExpr, step] = expr.split('/')
     const stepNum = Number(step)
-    let startNum = 0
+    let startNum = fieldMin
     let endNum = Infinity
     if (rangeExpr === '*') {
-      startNum = 0
+      startNum = fieldMin
     } else if (rangeExpr.includes('-')) {
       const [s, e] = rangeExpr.split('-').map(Number)
       startNum = s

--- a/server/services/eventScheduler.js
+++ b/server/services/eventScheduler.js
@@ -6,6 +6,7 @@
  */
 
 import { cosEvents } from './cosEvents.js'
+import { getLocalParts } from '../lib/timezone.js'
 
 // Maximum safe setTimeout value (2^31 - 1 ms, ~24.8 days)
 const MAX_TIMEOUT = 2147483647
@@ -63,9 +64,10 @@ const MAX_CRON_ITERATIONS = 525960
  *
  * @param {string} cronExpr - Cron expression
  * @param {Date} from - Starting point (default: now)
- * @returns {Date|null} - Next execution time, or null if invalid/no match
+ * @param {string} timezone - IANA timezone for matching (default: 'UTC')
+ * @returns {Date|null} - Next execution time (UTC), or null if invalid/no match
  */
-function parseCronToNextRun(cronExpr, from = new Date()) {
+function parseCronToNextRun(cronExpr, from = new Date(), timezone = 'UTC') {
   const parts = cronExpr.trim().split(/\s+/)
   if (parts.length !== 5) {
     throw new Error(`Invalid cron expression: ${cronExpr}`)
@@ -97,17 +99,29 @@ function parseCronToNextRun(cronExpr, from = new Date()) {
   const maxDate = new Date(from)
   maxDate.setFullYear(maxDate.getFullYear() + 2)
 
+  const useLocal = timezone !== 'UTC'
+
   let iterations = 0
   while (next < maxDate) {
     if (++iterations > MAX_CRON_ITERATIONS) {
       console.error(`❌ Cron search exceeded ${MAX_CRON_ITERATIONS} iterations for: ${cronExpr}`)
       return null
     }
-    if (matchesCronField(next.getMonth() + 1, monthExpr) &&
-        matchesCronField(next.getDate(), dayOfMonthExpr) &&
-        matchesCronField(next.getDay(), dayOfWeekExpr) &&
-        matchesCronField(next.getHours(), hourExpr) &&
-        matchesCronField(next.getMinutes(), minuteExpr)) {
+
+    let month, day, dow, hour, minute
+    if (useLocal) {
+      const lp = getLocalParts(next, timezone)
+      month = lp.month; day = lp.day; dow = lp.dayOfWeek; hour = lp.hour; minute = lp.minute
+    } else {
+      month = next.getMonth() + 1; day = next.getDate(); dow = next.getDay()
+      hour = next.getHours(); minute = next.getMinutes()
+    }
+
+    if (matchesCronField(month, monthExpr) &&
+        matchesCronField(day, dayOfMonthExpr) &&
+        matchesCronField(dow, dayOfWeekExpr) &&
+        matchesCronField(hour, hourExpr) &&
+        matchesCronField(minute, minuteExpr)) {
       return next
     }
     next.setMinutes(next.getMinutes() + 1)
@@ -195,7 +209,7 @@ function createSafeTimer(callback, delayMs, eventId) {
  * @returns {Object} - Scheduled event
  */
 function schedule(config) {
-  const { id, type, cron, intervalMs, delayMs, handler, metadata = {} } = config
+  const { id, type, cron, timezone, intervalMs, delayMs, handler, metadata = {} } = config
 
   if (!id || !type || !handler) {
     throw new Error('Event requires id, type, and handler')
@@ -210,6 +224,7 @@ function schedule(config) {
     id,
     type,
     cron,
+    timezone: timezone || 'UTC',
     intervalMs,
     delayMs,
     handler,
@@ -225,7 +240,7 @@ function schedule(config) {
   switch (type) {
     case 'cron':
       if (!cron) throw new Error('Cron type requires cron expression')
-      event.nextRunAt = parseCronToNextRun(cron)?.getTime() || null
+      event.nextRunAt = parseCronToNextRun(cron, new Date(), event.timezone)?.getTime() || null
       break
 
     case 'interval':
@@ -334,7 +349,7 @@ async function runEvent(event) {
 function updateNextRunTime(event) {
   switch (event.type) {
     case 'cron':
-      const nextDate = parseCronToNextRun(event.cron, new Date())
+      const nextDate = parseCronToNextRun(event.cron, new Date(), event.timezone || 'UTC')
       event.nextRunAt = nextDate?.getTime() || null
       break
 

--- a/server/services/meatspacePostDrillCache.js
+++ b/server/services/meatspacePostDrillCache.js
@@ -136,6 +136,6 @@ export async function initDrillCache(providerId, model) {
       for (const type of lowTypes) {
         await replenishType(type, providerId, model);
       }
-    })();
+    })().catch(err => console.error(`❌ POST drill cache startup fill failed: ${err.message}`));
   }
 }

--- a/server/services/meatspacePostDrillCache.js
+++ b/server/services/meatspacePostDrillCache.js
@@ -57,6 +57,8 @@ function replenishType(type, providerId, model) {
     let consecutiveFailures = 0;
     try {
       for (let i = 0; i < needed; i++) {
+        // Pause between LLM calls to avoid rate limiting
+        if (i > 0) await new Promise(r => setTimeout(r, 2000));
         const drill = await generateLlmDrill(type, { count: 5 }, providerId, model).catch(err => {
           console.log(`⚠️ POST cache: failed to generate ${type}: ${err.message}`);
           return null;
@@ -117,16 +119,25 @@ export function getCacheStats() {
 }
 
 /**
- * Initialize cache: load from disk, start background fill for empty types.
+ * Initialize cache: load from disk, start sequential background fill for low types.
  */
 export async function initDrillCache(providerId, model) {
   await loadCache();
   const stats = CACHEABLE_TYPES.map(t => `${t}:${cache[t]?.length || 0}`).join(' ');
   console.log(`📦 POST drill cache loaded: ${stats}`);
 
-  for (const type of CACHEABLE_TYPES) {
-    if ((cache[type]?.length || 0) < MIN_PER_TYPE) {
-      replenishType(type, providerId, model);
-    }
+  // Fill types sequentially (not in parallel) to avoid LLM API spam on startup
+  const lowTypes = CACHEABLE_TYPES.filter(t => (cache[t]?.length || 0) < MIN_PER_TYPE);
+  if (lowTypes.length > 0) {
+    console.log(`📦 POST cache: queuing startup fill for ${lowTypes.length} types`);
+    (async () => {
+      for (const type of lowTypes) {
+        replenishType(type, providerId, model);
+        // Wait for this type to finish before starting the next
+        while (replenishing.has(type)) {
+          await new Promise(r => setTimeout(r, 1000));
+        }
+      }
+    })();
   }
 }

--- a/server/services/meatspacePostDrillCache.js
+++ b/server/services/meatspacePostDrillCache.js
@@ -19,8 +19,10 @@ const CACHEABLE_TYPES = [
   'compound-chain', 'bridge-word', 'double-meaning', 'idiom-twist',
 ];
 
+const delay = ms => new Promise(r => setTimeout(r, ms));
+
 let cache = {}; // { type: [drill, drill, ...] }
-let replenishing = new Set(); // types currently being refilled
+let replenishing = new Map(); // type -> Promise (in-flight replenishment)
 let saveQueued = false;
 
 async function loadCache() {
@@ -46,19 +48,17 @@ function debouncedSave() {
 }
 
 function replenishType(type, providerId, model) {
-  if (replenishing.has(type)) return;
-  if ((cache[type]?.length || 0) >= MIN_PER_TYPE) return;
+  if (replenishing.has(type)) return replenishing.get(type);
+  if ((cache[type]?.length || 0) >= MIN_PER_TYPE) return Promise.resolve();
 
-  replenishing.add(type);
   const needed = MAX_PER_TYPE - (cache[type]?.length || 0);
 
-  (async () => {
+  const promise = (async () => {
     let generated = 0;
     let consecutiveFailures = 0;
     try {
       for (let i = 0; i < needed; i++) {
-        // Pause between LLM calls to avoid rate limiting
-        if (i > 0) await new Promise(r => setTimeout(r, 2000));
+        if (i > 0) await delay(2000); // avoid LLM rate limits
         const drill = await generateLlmDrill(type, { count: 5 }, providerId, model).catch(err => {
           console.log(`⚠️ POST cache: failed to generate ${type}: ${err.message}`);
           return null;
@@ -69,7 +69,6 @@ function replenishType(type, providerId, model) {
           consecutiveFailures = 0;
         } else {
           consecutiveFailures++;
-          // Bail early if provider appears unavailable (2+ consecutive failures)
           if (consecutiveFailures >= 2) {
             console.log(`⚠️ POST cache: bailing on ${type} after ${consecutiveFailures} consecutive failures`);
             break;
@@ -84,6 +83,9 @@ function replenishType(type, providerId, model) {
       replenishing.delete(type);
     }
   })();
+
+  replenishing.set(type, promise);
+  return promise;
 }
 
 /**
@@ -132,11 +134,7 @@ export async function initDrillCache(providerId, model) {
     console.log(`📦 POST cache: queuing startup fill for ${lowTypes.length} types`);
     (async () => {
       for (const type of lowTypes) {
-        replenishType(type, providerId, model);
-        // Wait for this type to finish before starting the next
-        while (replenishing.has(type)) {
-          await new Promise(r => setTimeout(r, 1000));
-        }
+        await replenishType(type, providerId, model);
       }
     })();
   }

--- a/server/services/portosChangelog.js
+++ b/server/services/portosChangelog.js
@@ -1,0 +1,77 @@
+/**
+ * PortOS Changelog Service
+ *
+ * Extracts recent PortOS feature commits from git history.
+ * Used by the daily briefing to highlight new features for the user.
+ */
+
+import { execFileSync } from 'child_process';
+import { writeFile } from 'fs/promises';
+import { join } from 'path';
+import { readJSONFile, PATHS, DAY } from '../lib/fileUtils.js';
+
+const STATE_FILE = join(PATHS.data, 'portos-changelog.json');
+const NUL = '\x00';
+
+const DEFAULT_STATE = { lastBriefedAt: null, lastBriefedCommit: null };
+
+function parseConventionalCommit(message) {
+  const match = message.match(/^(feat|fix|refactor|perf|docs|chore|style|test)(?:\(([^)]+)\))?:\s*(.+)/);
+  if (!match) return null;
+  return { type: match[1], scope: match[2] || null, description: match[3] };
+}
+
+/**
+ * @param {string} [since] - ISO date string. Defaults to last briefed time or 24h ago.
+ * @returns {{ features: Array, fixes: Array, other: Array, since: string }}
+ */
+export async function getRecentChanges(since) {
+  let sinceDate = since;
+  if (!sinceDate) {
+    const state = await readJSONFile(STATE_FILE, DEFAULT_STATE);
+    sinceDate = state.lastBriefedAt || new Date(Date.now() - DAY).toISOString();
+  }
+
+  // NUL delimiter avoids breakage from | in commit messages
+  const raw = execFileSync('git', [
+    'log', `--since=${sinceDate}`, '--no-merges', `--format=%H${NUL}%s${NUL}%ai`
+  ], { cwd: process.cwd(), encoding: 'utf-8', windowsHide: true }).trim();
+
+  if (!raw) {
+    return { features: [], fixes: [], other: [], since: sinceDate };
+  }
+
+  const features = [];
+  const fixes = [];
+  const other = [];
+
+  for (const line of raw.split('\n')) {
+    const [hash, message, date] = line.split(NUL);
+    const parsed = parseConventionalCommit(message);
+    const commit = { hash: hash?.slice(0, 8), message, date, parsed };
+    if (parsed?.type === 'feat') features.push(commit);
+    else if (parsed?.type === 'fix') fixes.push(commit);
+    else if (parsed) other.push(commit);
+  }
+
+  return { features, fixes, other, since: sinceDate };
+}
+
+export async function markBriefed() {
+  const headCommit = execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+    cwd: process.cwd(), encoding: 'utf-8', windowsHide: true
+  }).trim();
+
+  const state = {
+    lastBriefedAt: new Date().toISOString(),
+    lastBriefedCommit: headCommit
+  };
+
+  await writeFile(STATE_FILE, JSON.stringify(state, null, 2));
+  console.log(`📋 PortOS changelog briefed at ${headCommit}`);
+  return state;
+}
+
+export async function getState() {
+  return readJSONFile(STATE_FILE, DEFAULT_STATE);
+}

--- a/server/services/portosChangelog.js
+++ b/server/services/portosChangelog.js
@@ -7,8 +7,8 @@
 
 import { execFileSync } from 'child_process';
 import { writeFile } from 'fs/promises';
-import { join } from 'path';
-import { readJSONFile, PATHS, DAY } from '../lib/fileUtils.js';
+import { join, dirname } from 'path';
+import { readJSONFile, ensureDir, PATHS, DAY } from '../lib/fileUtils.js';
 
 const STATE_FILE = join(PATHS.data, 'portos-changelog.json');
 const NUL = '\x00';
@@ -32,10 +32,16 @@ export async function getRecentChanges(since) {
     sinceDate = state.lastBriefedAt || new Date(Date.now() - DAY).toISOString();
   }
 
-  // NUL delimiter avoids breakage from | in commit messages
-  const raw = execFileSync('git', [
-    'log', `--since=${sinceDate}`, '--no-merges', `--format=%H${NUL}%s${NUL}%ai`
-  ], { cwd: process.cwd(), encoding: 'utf-8', windowsHide: true }).trim();
+  let raw;
+  try {
+    // NUL delimiter avoids breakage from | in commit messages
+    raw = execFileSync('git', [
+      'log', `--since=${sinceDate}`, '--no-merges', `--format=%H${NUL}%s${NUL}%ai`
+    ], { cwd: process.cwd(), encoding: 'utf-8', windowsHide: true }).trim();
+  } catch {
+    console.log('📋 PortOS changelog: git not available, skipping');
+    return { features: [], fixes: [], other: [], since: sinceDate };
+  }
 
   if (!raw) {
     return { features: [], fixes: [], other: [], since: sinceDate };
@@ -58,15 +64,22 @@ export async function getRecentChanges(since) {
 }
 
 export async function markBriefed() {
-  const headCommit = execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
-    cwd: process.cwd(), encoding: 'utf-8', windowsHide: true
-  }).trim();
+  let headCommit;
+  try {
+    headCommit = execFileSync('git', ['rev-parse', '--short', 'HEAD'], {
+      cwd: process.cwd(), encoding: 'utf-8', windowsHide: true
+    }).trim();
+  } catch {
+    console.log('📋 PortOS changelog: git not available, skipping markBriefed');
+    return DEFAULT_STATE;
+  }
 
   const state = {
     lastBriefedAt: new Date().toISOString(),
     lastBriefedCommit: headCommit
   };
 
+  await ensureDir(dirname(STATE_FILE));
   await writeFile(STATE_FILE, JSON.stringify(state, null, 2));
   console.log(`📋 PortOS changelog briefed at ${headCommit}`);
   return state;

--- a/server/services/portosChangelog.test.js
+++ b/server/services/portosChangelog.test.js
@@ -12,6 +12,7 @@ vi.mock('fs/promises', () => ({
 
 vi.mock('../lib/fileUtils.js', () => ({
   readJSONFile: vi.fn(),
+  ensureDir: vi.fn().mockResolvedValue(undefined),
   PATHS: { data: '/mock/data' },
   DAY: 86400000
 }));

--- a/server/services/portosChangelog.test.js
+++ b/server/services/portosChangelog.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const NUL = '\x00';
+
+vi.mock('child_process', () => ({
+  execFileSync: vi.fn()
+}));
+
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('../lib/fileUtils.js', () => ({
+  readJSONFile: vi.fn(),
+  PATHS: { data: '/mock/data' },
+  DAY: 86400000
+}));
+
+import { execFileSync } from 'child_process';
+import { writeFile } from 'fs/promises';
+import { readJSONFile } from '../lib/fileUtils.js';
+import { getRecentChanges, markBriefed, getState } from './portosChangelog.js';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  readJSONFile.mockResolvedValue({ lastBriefedAt: null, lastBriefedCommit: null });
+});
+
+describe('getRecentChanges', () => {
+  it('returns empty arrays when no commits found', async () => {
+    execFileSync.mockReturnValue('');
+    const result = await getRecentChanges();
+    expect(result.features).toEqual([]);
+    expect(result.fixes).toEqual([]);
+    expect(result.other).toEqual([]);
+  });
+
+  it('parses feature commits correctly', async () => {
+    execFileSync.mockReturnValue(
+      `abc12345${NUL}feat(cos): add new briefing section${NUL}2026-03-23 10:00:00 -0700\n` +
+      `def67890${NUL}feat(ui): add dark mode toggle${NUL}2026-03-23 09:00:00 -0700`
+    );
+    const result = await getRecentChanges();
+    expect(result.features).toHaveLength(2);
+    expect(result.features[0].parsed.type).toBe('feat');
+    expect(result.features[0].parsed.scope).toBe('cos');
+    expect(result.features[0].parsed.description).toBe('add new briefing section');
+    expect(result.features[0].hash).toBe('abc12345');
+  });
+
+  it('separates features from fixes', async () => {
+    execFileSync.mockReturnValue(
+      `abc12345${NUL}feat(cos): add feature${NUL}2026-03-23 10:00:00 -0700\n` +
+      `def67890${NUL}fix(ui): broken button${NUL}2026-03-23 09:00:00 -0700`
+    );
+    const result = await getRecentChanges();
+    expect(result.features).toHaveLength(1);
+    expect(result.fixes).toHaveLength(1);
+    expect(result.fixes[0].parsed.type).toBe('fix');
+  });
+
+  it('categorizes refactor/chore/docs as other', async () => {
+    execFileSync.mockReturnValue(
+      `abc12345${NUL}refactor(api): clean up routes${NUL}2026-03-23 10:00:00 -0700\n` +
+      `def67890${NUL}chore: update deps${NUL}2026-03-23 09:00:00 -0700`
+    );
+    const result = await getRecentChanges();
+    expect(result.features).toHaveLength(0);
+    expect(result.fixes).toHaveLength(0);
+    expect(result.other).toHaveLength(2);
+  });
+
+  it('uses lastBriefedAt from state when no since param provided', async () => {
+    readJSONFile.mockResolvedValue({ lastBriefedAt: '2026-03-22T00:00:00Z', lastBriefedCommit: 'aaa' });
+    execFileSync.mockReturnValue('');
+    const result = await getRecentChanges();
+    expect(result.since).toBe('2026-03-22T00:00:00Z');
+    expect(execFileSync).toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining(['--since=2026-03-22T00:00:00Z']),
+      expect.any(Object)
+    );
+  });
+
+  it('skips state file read when since param is provided', async () => {
+    execFileSync.mockReturnValue('');
+    const result = await getRecentChanges('2026-03-20T00:00:00Z');
+    expect(result.since).toBe('2026-03-20T00:00:00Z');
+    expect(readJSONFile).not.toHaveBeenCalled();
+  });
+
+  it('handles commits without conventional format', async () => {
+    execFileSync.mockReturnValue(
+      `abc12345${NUL}feat(cos): add feature${NUL}2026-03-23 10:00:00 -0700\n` +
+      `bbb22222${NUL}Merge branch main${NUL}2026-03-23 08:00:00 -0700`
+    );
+    const result = await getRecentChanges();
+    expect(result.features).toHaveLength(1);
+    expect(result.fixes).toHaveLength(0);
+    expect(result.other).toHaveLength(0);
+  });
+
+  it('handles feat commits without scope', async () => {
+    execFileSync.mockReturnValue(`abc12345${NUL}feat: global feature${NUL}2026-03-23 10:00:00 -0700`);
+    const result = await getRecentChanges();
+    expect(result.features).toHaveLength(1);
+    expect(result.features[0].parsed.scope).toBeNull();
+    expect(result.features[0].parsed.description).toBe('global feature');
+  });
+});
+
+describe('markBriefed', () => {
+  it('writes state file with current commit hash', async () => {
+    execFileSync.mockReturnValue('abc1234\n');
+    const result = await markBriefed();
+    expect(result.lastBriefedCommit).toBe('abc1234');
+    expect(result.lastBriefedAt).toBeDefined();
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining('portos-changelog.json'),
+      expect.any(String)
+    );
+  });
+});
+
+describe('getState', () => {
+  it('returns default state when no file exists', async () => {
+    readJSONFile.mockResolvedValue({ lastBriefedAt: null, lastBriefedCommit: null });
+    const state = await getState();
+    expect(state.lastBriefedAt).toBeNull();
+    expect(state.lastBriefedCommit).toBeNull();
+  });
+});

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -1350,7 +1350,8 @@ export async function shouldRunTask(taskType, appId = null) {
         result = { shouldRun: false, reason: 'invalid-cron' };
         break;
       }
-      const fromDate = lastRun ? new Date(lastRun) : new Date(now);
+      // For never-run tasks, use 1 minute ago so the first scheduled occurrence can match
+      const fromDate = lastRun ? new Date(lastRun) : new Date(now - 60_000);
       const nextRun = parseCronToNextRun(cronExpr, fromDate, timezone);
       if (!nextRun) {
         result = { shouldRun: false, reason: 'invalid-cron', cronExpression: cronExpr };

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -1233,9 +1233,11 @@ export async function shouldRunTask(taskType, appId = null) {
     return { shouldRun: false, reason: 'disabled' };
   }
 
+  // Fetch timezone once for reuse across weekday and cron checks
+  const timezone = await getUserTimezone();
+
   // Weekday-only tasks skip weekends (timezone-aware)
   if (interval.weekdaysOnly) {
-    const timezone = await getUserTimezone();
     const { dayOfWeek } = getLocalParts(new Date(), timezone);
     if (dayOfWeek === 0 || dayOfWeek === 6) {
       return { shouldRun: false, reason: 'weekday-only' };
@@ -1348,8 +1350,7 @@ export async function shouldRunTask(taskType, appId = null) {
         result = { shouldRun: false, reason: 'invalid-cron' };
         break;
       }
-      const timezone = await getUserTimezone();
-      const fromDate = lastRun ? new Date(lastRun) : new Date(now - DAY);
+      const fromDate = lastRun ? new Date(lastRun) : new Date(now);
       const nextRun = parseCronToNextRun(cronExpr, fromDate, timezone);
       if (!nextRun) {
         result = { shouldRun: false, reason: 'invalid-cron', cronExpression: cronExpr };

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -1351,11 +1351,15 @@ export async function shouldRunTask(taskType, appId = null) {
       const timezone = await getUserTimezone();
       const fromDate = lastRun ? new Date(lastRun) : new Date(now - DAY);
       const nextRun = parseCronToNextRun(cronExpr, fromDate, timezone);
-      if (nextRun && now >= nextRun.getTime()) {
+      if (!nextRun) {
+        result = { shouldRun: false, reason: 'invalid-cron', cronExpression: cronExpr };
+        break;
+      }
+      if (now >= nextRun.getTime()) {
         result = { shouldRun: true, reason: 'cron-due', cronExpression: cronExpr, nextRunAt: nextRun.toISOString() };
       } else {
         result = { shouldRun: false, reason: 'cron-cooldown', cronExpression: cronExpr,
-          nextRunAt: nextRun?.toISOString() || null };
+          nextRunAt: nextRun.toISOString() };
       }
       break;
     }

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -21,6 +21,8 @@ import { DAY, ensureDir, HOUR, readJSONFile, PATHS, safeDate } from '../lib/file
 import { getAdaptiveCooldownMultiplier } from './taskLearning.js';
 import { isTaskTypeEnabledForApp, getAppTaskTypeInterval, getActiveApps, getAppTaskTypeOverrides } from './apps.js';
 import { PORTOS_UI_URL } from '../lib/ports.js';
+import { getUserTimezone } from '../lib/timezone.js';
+import { parseCronToNextRun } from './eventScheduler.js';
 
 const DATA_DIR = PATHS.cos;
 const SCHEDULE_FILE = join(DATA_DIR, 'task-schedule.json');
@@ -32,7 +34,8 @@ export const INTERVAL_TYPES = {
   WEEKLY: 'weekly',          // Runs once per week
   ONCE: 'once',              // Runs once per app or globally
   ON_DEMAND: 'on-demand',    // Only runs when manually triggered
-  CUSTOM: 'custom'           // Custom interval in milliseconds
+  CUSTOM: 'custom',          // Custom interval in milliseconds
+  CRON: 'cron'               // Cron expression schedule
 };
 
 const WEEK = 7 * DAY;
@@ -1247,7 +1250,9 @@ export async function shouldRunTask(taskType, appId = null) {
 
   // Determine effective interval type: per-app override takes precedence
   const perAppInterval = appId ? await getAppTaskTypeInterval(appId, taskType) : null;
-  const effectiveType = perAppInterval || interval.type;
+  // Cron expressions (contain spaces) are stored directly as the interval value
+  const isCronOverride = perAppInterval && perAppInterval.includes(' ');
+  const effectiveType = isCronOverride ? INTERVAL_TYPES.CRON : (perAppInterval || interval.type);
 
   const key = `task:${taskType}`;
   const execution = schedule.executions[key] || { lastRun: null, count: 0, perApp: {} };
@@ -1331,6 +1336,25 @@ export async function shouldRunTask(taskType, appId = null) {
           nextRunAt: new Date(lastRun + adjustedInterval).toISOString(),
           baseIntervalMs: baseInterval, adjustedIntervalMs: adjustedInterval
         });
+      }
+      break;
+    }
+
+    case INTERVAL_TYPES.CRON: {
+      // Cron expression: per-app override (stored as the interval string) or global config
+      const cronExpr = isCronOverride ? perAppInterval : interval.cronExpression;
+      if (!cronExpr || typeof cronExpr !== 'string' || cronExpr.trim().split(/\s+/).length !== 5) {
+        result = { shouldRun: false, reason: 'invalid-cron' };
+        break;
+      }
+      const timezone = await getUserTimezone();
+      const fromDate = lastRun ? new Date(lastRun) : new Date(now - DAY);
+      const nextRun = parseCronToNextRun(cronExpr, fromDate, timezone);
+      if (nextRun && now >= nextRun.getTime()) {
+        result = { shouldRun: true, reason: 'cron-due', cronExpression: cronExpr, nextRunAt: nextRun.toISOString() };
+      } else {
+        result = { shouldRun: false, reason: 'cron-cooldown', cronExpression: cronExpr,
+          nextRunAt: nextRun?.toISOString() || null };
       }
       break;
     }

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -21,7 +21,7 @@ import { DAY, ensureDir, HOUR, readJSONFile, PATHS, safeDate } from '../lib/file
 import { getAdaptiveCooldownMultiplier } from './taskLearning.js';
 import { isTaskTypeEnabledForApp, getAppTaskTypeInterval, getActiveApps, getAppTaskTypeOverrides } from './apps.js';
 import { PORTOS_UI_URL } from '../lib/ports.js';
-import { getUserTimezone } from '../lib/timezone.js';
+import { getUserTimezone, getLocalParts } from '../lib/timezone.js';
 import { parseCronToNextRun } from './eventScheduler.js';
 
 const DATA_DIR = PATHS.cos;
@@ -1233,10 +1233,11 @@ export async function shouldRunTask(taskType, appId = null) {
     return { shouldRun: false, reason: 'disabled' };
   }
 
-  // Weekday-only tasks skip weekends
+  // Weekday-only tasks skip weekends (timezone-aware)
   if (interval.weekdaysOnly) {
-    const day = new Date().getDay();
-    if (day === 0 || day === 6) {
+    const timezone = await getUserTimezone();
+    const { dayOfWeek } = getLocalParts(new Date(), timezone);
+    if (dayOfWeek === 0 || dayOfWeek === 6) {
       return { shouldRun: false, reason: 'weekday-only' };
     }
   }


### PR DESCRIPTION
# Release v1.36.0

Released: 2026-03-24

### Fixed
- New instances no longer trigger LLM calls on startup — seed drill cache in data.sample and skip brain digest/review when no data exists
- Job scheduling now uses user's configured timezone instead of UTC — daily briefing and all scheduled jobs fire at the correct local time
- Briefing notification date uses user timezone instead of UTC date
- Throttle LLM drill cache startup: serialize type replenishment and add 2s delay between LLM calls to prevent API spam on server restart
- Throttle JIRA sync: add 500ms delay between project ticket fetches to prevent 429 rate limit errors
- Fix matchesCronField: handle range-with-step cron expressions (1-5/2) correctly
- Fix cancelAll: snapshot Map keys before iterating to avoid mutation during deletion
- Fix weekdaysOnly: use timezone-aware local day instead of UTC getDay()
- Fix JobsTab: guard success toasts behind API result check
- Fix CharacterSheet: add error handling to load() for network failures

### Added
- Character Sheet page: D&D-style character tracking with XP, HP, leveling, dice-based damage, short/long rests, custom event logging, and JIRA/CoS task sync for XP
- Timezone setting in Settings > General — auto-detects from browser, configurable per user
- Cron expression support across all scheduling systems — full 5-field crontab syntax (minute hour dayOfMonth month dayOfWeek)
- Cron support in System Tasks (Jobs), per-app Task Type Overrides, and global CoS Schedule
- Shared CronInput component with presets dropdown and human-readable descriptions
- Schedule mode toggle (Interval vs Cron) in job create/edit forms
- Timezone-aware cron matching in event scheduler and task schedule evaluator
- Shared cron utilities (cronHelpers.js) — DRY across all scheduling UIs
- Timezone utility module with cached Intl.DateTimeFormat and comprehensive test coverage

### Changed
- Task Type Overrides switched from table to card layout for mobile responsiveness
- Task type subtitle shows effective schedule (cron/override) instead of always showing global type

**Full Diff**: https://github.com/atomantic/PortOS/compare/v1.35.0...v1.36.0