### PR TITLE
Release v1.40.0

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -10,6 +10,7 @@
 - Pipeline artifacts (e.g., REVIEW.md) not cleaned up after final stage — automated cleanup now deletes `fileNotExists` precondition files when pipeline completes
 - Self-update failing with "exit code null" at npm-install step — PM2 watch restarted the server during `git checkout` (which changes `server/` files), breaking the stdout pipe to the update script. SIGPIPE killed the script before `|| true` could handle it, leaving the update incomplete. Added `trap '' PIPE` to ignore SIGPIPE so the script runs to completion.
 - Improved update error messages to show signal name (e.g., "killed by SIGPIPE") instead of opaque "exit code null"
+- Setup falsely reporting "Setup Complete!" when native PostgreSQL is selected but not installed — now auto-runs `db.sh setup-native` to install and configure PostgreSQL via Homebrew, and exits with error if setup fails instead of silently continuing
 
 ### Added
 

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,4 +1,11 @@
 ### Fixed
 
+- Scheduled tasks defaulting to enabled for existing apps when new task types are added — `isTaskTypeEnabledForApp` now defaults to disabled (opt-in) instead of enabled (opt-out)
+- Autonomous job scheduler using UTC instead of local timezone for scheduled times — daily briefing at 4:30 AM local was firing at 4:30 AM UTC. Now uses `nextLocalTime()` to compute exact UTC target from local scheduled time
+- Codex agent output flooding UI with full prompt/config dump from stderr — filtered to only show tool execution lines and errors
 - Self-update failing with "exit code null" at npm-install step — PM2 watch restarted the server during `git checkout` (which changes `server/` files), breaking the stdout pipe to the update script. SIGPIPE killed the script before `|| true` could handle it, leaving the update incomplete. Added `trap '' PIPE` to ignore SIGPIPE so the script runs to completion.
 - Improved update error messages to show signal name (e.g., "killed by SIGPIPE") instead of opaque "exit code null"
+
+### Added
+
+- Toggle to enable/disable all automations for an app on the Automation tab

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,6 +3,7 @@
 - Scheduled tasks defaulting to enabled for existing apps when new task types are added — `isTaskTypeEnabledForApp` now defaults to disabled (opt-in) instead of enabled (opt-out)
 - Autonomous job scheduler using UTC instead of local timezone for scheduled times — daily briefing at 4:30 AM local was firing at 4:30 AM UTC. Now uses `nextLocalTime()` to compute exact UTC target from local scheduled time
 - Codex agent output flooding UI with full prompt/config dump from stderr — filtered to only show tool execution lines and errors
+- On-demand tasks silently dropped when pipeline preconditions fail (e.g., REVIEW.md already exists) — on-demand tasks now skip precondition checks since the user explicitly requested them
 - Self-update failing with "exit code null" at npm-install step — PM2 watch restarted the server during `git checkout` (which changes `server/` files), breaking the stdout pipe to the update script. SIGPIPE killed the script before `|| true` could handle it, leaving the update incomplete. Added `trap '' PIPE` to ignore SIGPIPE so the script runs to completion.
 - Improved update error messages to show signal name (e.g., "killed by SIGPIPE") instead of opaque "exit code null"
 

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -7,6 +7,7 @@
 - Pipeline stage 2+ tasks stuck in queue forever — follow-up tasks were missing `id` and `status: 'pending'` fields when created with `raw: true`, making them invisible to the task evaluator
 - Pipeline tasks not marked completed after agent finishes — `app-improve-*` task IDs were misidentified as user tasks (expected `sys-` prefix), causing `updateTask` to look in the wrong file
 - Pipeline stage 2 tasks blocked by app cooldown — pipeline continuations now bypass the 30-minute app review cooldown
+- Pipeline artifacts (e.g., REVIEW.md) not cleaned up after final stage — automated cleanup now deletes `fileNotExists` precondition files when pipeline completes
 - Self-update failing with "exit code null" at npm-install step — PM2 watch restarted the server during `git checkout` (which changes `server/` files), breaking the stdout pipe to the update script. SIGPIPE killed the script before `|| true` could handle it, leaving the update incomplete. Added `trap '' PIPE` to ignore SIGPIPE so the script runs to completion.
 - Improved update error messages to show signal name (e.g., "killed by SIGPIPE") instead of opaque "exit code null"
 

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -5,6 +5,8 @@
 - Codex agent output flooding UI with full prompt/config dump from stderr — filtered to only show tool execution lines and errors
 - On-demand tasks silently dropped when pipeline preconditions fail (e.g., REVIEW.md already exists) — on-demand tasks now skip precondition checks since the user explicitly requested them
 - Pipeline stage 2+ tasks stuck in queue forever — follow-up tasks were missing `id` and `status: 'pending'` fields when created with `raw: true`, making them invisible to the task evaluator
+- Pipeline tasks not marked completed after agent finishes — `app-improve-*` task IDs were misidentified as user tasks (expected `sys-` prefix), causing `updateTask` to look in the wrong file
+- Pipeline stage 2 tasks blocked by app cooldown — pipeline continuations now bypass the 30-minute app review cooldown
 - Self-update failing with "exit code null" at npm-install step — PM2 watch restarted the server during `git checkout` (which changes `server/` files), breaking the stdout pipe to the update script. SIGPIPE killed the script before `|| true` could handle it, leaving the update incomplete. Added `trap '' PIPE` to ignore SIGPIPE so the script runs to completion.
 - Improved update error messages to show signal name (e.g., "killed by SIGPIPE") instead of opaque "exit code null"
 

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Self-update failing with "exit code null" at npm-install step — PM2 watch restarted the server during `git checkout` (which changes `server/` files), breaking the stdout pipe to the update script. SIGPIPE killed the script before `|| true` could handle it, leaving the update incomplete. Added `trap '' PIPE` to ignore SIGPIPE so the script runs to completion.
+- Improved update error messages to show signal name (e.g., "killed by SIGPIPE") instead of opaque "exit code null"

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -4,6 +4,7 @@
 - Autonomous job scheduler using UTC instead of local timezone for scheduled times — daily briefing at 4:30 AM local was firing at 4:30 AM UTC. Now uses `nextLocalTime()` to compute exact UTC target from local scheduled time
 - Codex agent output flooding UI with full prompt/config dump from stderr — filtered to only show tool execution lines and errors
 - On-demand tasks silently dropped when pipeline preconditions fail (e.g., REVIEW.md already exists) — on-demand tasks now skip precondition checks since the user explicitly requested them
+- Pipeline stage 2+ tasks stuck in queue forever — follow-up tasks were missing `id` and `status: 'pending'` fields when created with `raw: true`, making them invisible to the task evaluator
 - Self-update failing with "exit code null" at npm-install step — PM2 watch restarted the server during `git checkout` (which changes `server/` files), breaking the stdout pipe to the update script. SIGPIPE killed the script before `|| true` could handle it, leaving the update incomplete. Added `trap '' PIPE` to ignore SIGPIPE so the script runs to completion.
 - Improved update error messages to show signal name (e.g., "killed by SIGPIPE") instead of opaque "exit code null"
 

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -13,3 +13,4 @@
 ### Added
 
 - Toggle to enable/disable all automations for an app on the Automation tab
+- "Process Now" button on pending task cards to force-spawn a specific task, bypassing cooldowns and evaluation intervals

--- a/.changelog/v1.40.0.md
+++ b/.changelog/v1.40.0.md
@@ -1,3 +1,7 @@
+# Release v1.40.0
+
+Released: 2026-03-29
+
 ### Fixed
 
 - Scheduled tasks defaulting to enabled for existing apps when new task types are added — `isTaskTypeEnabledForApp` now defaults to disabled (opt-in) instead of enabled (opt-out)
@@ -16,3 +20,7 @@
 
 - Toggle to enable/disable all automations for an app on the Automation tab
 - "Process Now" button on pending task cards to force-spawn a specific task, bypassing cooldowns and evaluation intervals
+
+## Full Changelog
+
+**Full Diff**: https://github.com/atomantic/PortOS/compare/v1.39.0...v1.40.0

--- a/PLAN.md
+++ b/PLAN.md
@@ -10,7 +10,7 @@ For project goals, see [GOALS.md](./GOALS.md). For completed work, see [DONE.md]
 
 ## Backlog
 
-- [ ] **God file decomposition** — Split cos.js, subAgentSpawner.js, digital-twin.js, routes/scaffold.js, routes/cos.js, client/api.js into focused modules; resolve circular dependency
+- [ ] **God file decomposition** — cos.js done (→ cosState.js, cosAgents.js, cosReports.js, cosEvents.js; 31% reduction). Remaining: subAgentSpawner.js, digital-twin.js, routes/scaffold.js, routes/cos.js, client/api.js
 - [ ] **Test coverage** — Critical gaps: cos.js, cosRunnerClient.js, agentActionExecutor.js (~29% service, ~12% route coverage)
 - [ ] **M50 P9**: CoS Automation & Rules — Automated email classification, rule-based pre-filtering, email-to-task pipeline
 - [ ] **M50 P10**: Auto-Send with AI Review Gate — Per-account trust level, second LLM reviews drafts. See [Messages Security](./docs/features/messages-security.md)

--- a/autofixer/package-lock.json
+++ b/autofixer/package-lock.json
@@ -560,9 +560,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",

--- a/client/src/components/apps/tabs/AutomationTab.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.jsx
@@ -3,6 +3,7 @@ import { RefreshCw, Play } from 'lucide-react';
 import toast from 'react-hot-toast';
 import BrailleSpinner from '../../BrailleSpinner';
 import CronInput from '../../CronInput';
+import ToggleSwitch from '../../ToggleSwitch';
 import * as api from '../../../services/api';
 import { AGENT_OPTIONS, toggleAppMetadataOverride } from '../../cos/constants';
 import { isCronExpression, describeCron } from '../../../utils/cronHelpers';
@@ -114,10 +115,11 @@ export default function AutomationTab({ appId, appName }) {
 
   const handleToggleAll = async () => {
     const newEnabled = !allEnabled;
-    await api.toggleAllAppTaskTypes(appId, newEnabled).catch(err => {
+    const result = await api.toggleAllAppTaskTypes(appId, newEnabled).catch(err => {
       toast.error(err.message);
       return null;
     });
+    if (!result) return;
     setOverrides(prev => {
       const updated = { ...prev };
       for (const t of taskTypes) {
@@ -135,17 +137,7 @@ export default function AutomationTab({ appId, appName }) {
             <h3 className="text-lg font-semibold text-white">Task Type Overrides</h3>
             <p className="text-sm text-gray-500">Per-app automation preferences for CoS task scheduling</p>
           </div>
-          <button
-            onClick={handleToggleAll}
-            className={`w-10 h-5 rounded-full transition-colors relative shrink-0 ${
-              allEnabled ? 'bg-port-success' : 'bg-gray-600'
-            }`}
-            title={allEnabled ? 'Disable all automations' : 'Enable all automations'}
-          >
-            <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
-              allEnabled ? 'left-5' : 'left-0.5'
-            }`} />
-          </button>
+          <ToggleSwitch enabled={allEnabled} onChange={handleToggleAll} size="sm" activeColor="bg-port-success" ariaLabel={allEnabled ? 'Disable all automations' : 'Enable all automations'} />
         </div>
         <button
           onClick={fetchData}
@@ -175,16 +167,7 @@ export default function AutomationTab({ appId, appName }) {
               <div key={taskType} className="bg-port-card border border-port-border rounded-lg p-3 space-y-2">
                 {/* Row 1: name + toggle + run now */}
                 <div className="flex items-center gap-3">
-                  <button
-                    onClick={() => handleToggle(taskType, isEnabled)}
-                    className={`w-10 h-5 rounded-full transition-colors relative shrink-0 ${
-                      isEnabled ? 'bg-port-success' : 'bg-gray-600'
-                    }`}
-                  >
-                    <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
-                      isEnabled ? 'left-5' : 'left-0.5'
-                    }`} />
-                  </button>
+                  <ToggleSwitch enabled={isEnabled} onChange={() => handleToggle(taskType, isEnabled)} size="sm" activeColor="bg-port-success" />
                   <div className="flex-1 min-w-0">
                     <span className="text-white font-mono text-xs">{taskType}</span>
                     <div className="text-xs text-gray-500">{effectiveLabel}{intervalSuffix}</div>

--- a/client/src/components/apps/tabs/AutomationTab.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.jsx
@@ -110,13 +110,42 @@ export default function AutomationTab({ appId, appName }) {
   }
 
   const taskTypes = schedule?.tasks ? Object.keys(schedule.tasks).sort() : [];
+  const allEnabled = taskTypes.length > 0 && taskTypes.every(t => (overrides[t] || {}).enabled === true);
+
+  const handleToggleAll = async () => {
+    const newEnabled = !allEnabled;
+    await api.toggleAllAppTaskTypes(appId, newEnabled).catch(err => {
+      toast.error(err.message);
+      return null;
+    });
+    setOverrides(prev => {
+      const updated = { ...prev };
+      for (const t of taskTypes) {
+        updated[t] = { ...updated[t], enabled: newEnabled };
+      }
+      return updated;
+    });
+  };
 
   return (
     <div className="max-w-5xl space-y-4">
       <div className="flex items-center justify-between">
-        <div>
-          <h3 className="text-lg font-semibold text-white">Task Type Overrides</h3>
-          <p className="text-sm text-gray-500">Per-app automation preferences for CoS task scheduling</p>
+        <div className="flex items-center gap-4">
+          <div>
+            <h3 className="text-lg font-semibold text-white">Task Type Overrides</h3>
+            <p className="text-sm text-gray-500">Per-app automation preferences for CoS task scheduling</p>
+          </div>
+          <button
+            onClick={handleToggleAll}
+            className={`w-10 h-5 rounded-full transition-colors relative shrink-0 ${
+              allEnabled ? 'bg-port-success' : 'bg-gray-600'
+            }`}
+            title={allEnabled ? 'Disable all automations' : 'Enable all automations'}
+          >
+            <span className={`absolute top-0.5 w-4 h-4 rounded-full bg-white transition-transform ${
+              allEnabled ? 'left-5' : 'left-0.5'
+            }`} />
+          </button>
         </div>
         <button
           onClick={fetchData}
@@ -135,7 +164,7 @@ export default function AutomationTab({ appId, appName }) {
           {taskTypes.map(taskType => {
             const override = overrides[taskType] || {};
             const globalConfig = schedule.tasks[taskType] || {};
-            const isEnabled = override.enabled !== false;
+            const isEnabled = override.enabled === true;
             const overrideInterval = override.interval || null;
             const effectiveLabel = isCronExpression(overrideInterval)
               ? describeCron(overrideInterval) || 'cron'

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -209,17 +209,9 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     if (!result) return;
 
     toast.success('Task added');
-    setNewTask({ description: '', model: '', provider: '', app: defaultApp });
+    setNewTask(t => ({ ...t, description: '' }));
     setScreenshots([]);
     setAttachments([]);
-    setAddToTop(false);
-    setEnhancePrompt(false);
-    setCreateJiraTicket(false);
-    setUseWorktree(false);
-    setOpenPR(false);
-    setSimplify(true);
-    setReviewLoop(false);
-    setExpanded(false);
     setIsSubmitting(false);
     onTaskAdded?.();
   };

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -388,7 +388,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
         <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
           {!editing && (
             <>
-              {task.status === 'pending' && (
+              {task.status === 'pending' && !task.approvalRequired && (
                 <button
                   onClick={async () => {
                     const result = await api.forceSpawnTask(task.id).catch(err => { toast.error(err.message); return null; });

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -14,7 +14,8 @@ import {
   FileText,
   ExternalLink,
   AlertCircle,
-  TrendingUp
+  TrendingUp,
+  Play
 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import * as api from '../../../services/api';
@@ -384,7 +385,20 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
         <div className="flex items-center gap-1 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
           {!editing && (
             <>
-              {/* Mark as Blocked button - only show for non-blocked, non-completed tasks */}
+              {task.status === 'pending' && (
+                <button
+                  onClick={async () => {
+                    const result = await api.forceSpawnTask(task.id).catch(err => { toast.error(err.message); return null; });
+                    if (result?.success) toast.success(`Spawning ${task.id}`);
+                    if (onRefresh) onRefresh();
+                  }}
+                  className="p-1 text-gray-500 hover:text-port-success transition-colors"
+                  title="Process now"
+                  aria-label="Process task now"
+                >
+                  <Play size={14} aria-hidden="true" />
+                </button>
+              )}
               {task.status !== 'blocked' && task.status !== 'completed' && (
                 <button
                   onClick={handleMarkBlocked}

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -158,7 +158,8 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
     if (newStatus === 'blocked' && blockedReasonText) {
       updates.blockedReason = blockedReasonText;
     }
-    await api.updateCosTask(task.id, updates).catch(err => toast.error(err.message));
+    const result = await api.updateCosTask(task.id, updates).catch(err => { toast.error(err.message); return null; });
+    if (!result) return;
     toast.success(`Task marked as ${newStatus}`);
     onRefresh();
   };
@@ -175,7 +176,8 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   };
 
   const handleSave = async () => {
-    await api.updateCosTask(task.id, editData).catch(err => toast.error(err.message));
+    const result = await api.updateCosTask(task.id, editData).catch(err => { toast.error(err.message); return null; });
+    if (!result) return;
     toast.success('Task updated');
     setEditing(false);
     onRefresh();
@@ -183,7 +185,8 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
 
   const handleDelete = async () => {
     const taskType = isSystem ? 'internal' : 'user';
-    await api.deleteCosTask(task.id, taskType).catch(err => toast.error(err.message));
+    const result = await api.deleteCosTask(task.id, taskType).catch(err => { toast.error(err.message); return null; });
+    if (!result) return;
     toast.success('Task deleted');
     onRefresh();
   };

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -16,7 +16,12 @@ async function request(endpoint, options = {}) {
     ...fetchOptions
   };
 
-  const response = await fetch(url, config);
+  const response = await fetch(url, config).catch(() => null);
+  if (!response) {
+    const msg = 'Server unreachable — check your connection and try again';
+    if (!silent) toast.error(msg);
+    throw new Error(msg);
+  }
 
   if (!response.ok) {
     const error = await response.json().catch(() => ({ error: 'Request failed' }));

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -152,6 +152,10 @@ export const pullAndUpdateApp = (id) => request(`/apps/${id}/update`, { method: 
 export const buildApp = (id) => request(`/apps/${id}/build`, { method: 'POST' });
 export const getAppStatus = (id) => request(`/apps/${id}/status`);
 export const getAppTaskTypes = (id) => request(`/apps/${id}/task-types`);
+export const toggleAllAppTaskTypes = (id, enabled) => request(`/apps/${id}/task-types/all`, {
+  method: 'PUT',
+  body: JSON.stringify({ enabled })
+});
 export const updateAppTaskTypeOverride = (id, taskType, { enabled, interval, taskMetadata } = {}) => request(`/apps/${id}/task-types/${taskType}`, {
   method: 'PUT',
   body: JSON.stringify({ enabled, interval, taskMetadata })

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -680,6 +680,7 @@ export const reorderCosTasks = (taskIds) => request('/cos/tasks/reorder', {
 });
 export const approveCosTask = (id) => request(`/cos/tasks/${id}/approve`, { method: 'POST' });
 export const forceCosEvaluate = () => request('/cos/evaluate', { method: 'POST' });
+export const forceSpawnTask = (taskId) => request(`/cos/tasks/${taskId}/spawn`, { method: 'POST' });
 export const getCosHealth = () => request('/cos/health');
 export const forceHealthCheck = () => request('/cos/health/check', { method: 'POST' });
 export const getCosAgents = () => request('/cos/agents');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1179,9 +1179,9 @@
       "license": "MIT"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "portos",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "portos",
-      "version": "1.39.0",
+      "version": "1.40.0",
       "license": "MIT",
       "devDependencies": {
         "pm2": "^6.0.14"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "portos",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "private": true,
   "description": "Local dev machine App OS portal",
   "author": "Adam Eivy (@antic|@atomantic)",

--- a/scripts/portos-update.sh
+++ b/scripts/portos-update.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ignore SIGPIPE: when PM2 restarts the server mid-update (watch detects
+# git-checkout file changes), the parent Node process dies and our stdout
+# pipe breaks.  Without this trap, SIGPIPE kills the script before
+# `|| true` can fire, leaving the update incomplete.
+trap '' PIPE
+
 # PortOS Auto-Update Script
 # Usage: bash scripts/portos-update.sh <tag>
 # Outputs structured STEP markers for progress tracking:

--- a/scripts/setup-db.js
+++ b/scripts/setup-db.js
@@ -165,6 +165,33 @@ function promptStorageChoice(message, hint) {
   });
 }
 
+// Attempt full native PostgreSQL setup via db.sh setup-native
+function setupNativePostgres() {
+  const dbScript = join(rootDir, 'scripts', 'db.sh');
+  try {
+    console.log('🍺 Running native PostgreSQL setup...');
+    execFileSync('bash', [dbScript, 'setup-native'], { stdio: 'inherit', cwd: rootDir });
+    if (isNativeReady()) {
+      console.log('✅ System PostgreSQL ready on port 5432');
+      return true;
+    }
+  } catch (err) {
+    console.error(`⚠️  Native setup error: ${err.message}`);
+  }
+  return false;
+}
+
+// Exit with error when native PostgreSQL setup fails
+function exitNativeSetupFailed() {
+  if (process.platform === 'darwin') {
+    console.error('❌ Native PostgreSQL setup failed — try manually: brew install postgresql@17 && brew services start postgresql@17');
+  } else {
+    console.error('❌ Native PostgreSQL setup failed — install and start PostgreSQL');
+  }
+  console.log('   Then re-run: npm run setup');
+  process.exit(1);
+}
+
 async function handleDockerUnavailable(message, issue) {
   const hint = getDockerHints(issue);
   const choice = await promptStorageChoice(message, hint);
@@ -174,13 +201,13 @@ async function handleDockerUnavailable(message, issue) {
     setPgMode('native');
     if (isNativeReady()) {
       console.log('✅ System PostgreSQL ready on port 5432');
-    } else if (process.platform === 'darwin') {
-      console.log('⚠️  Native PostgreSQL not detected — try: brew install postgresql@17 && brew services start postgresql@17');
-      console.log('   Then re-run setup');
-    } else {
-      console.log('⚠️  Native PostgreSQL not detected — install and start PostgreSQL, then re-run setup');
+      process.exit(0);
     }
-    process.exit(0);
+    // Attempt automatic setup via db.sh setup-native (installs + configures)
+    if (setupNativePostgres()) {
+      process.exit(0);
+    }
+    exitNativeSetupFailed();
   }
 
   if (choice === 'file') {
@@ -212,21 +239,12 @@ if (mode === 'native') {
     process.exit(0);
   }
 
-  // Try to start via Homebrew
-  if (process.platform === 'darwin') {
-    try {
-      console.log('🍺 Starting PostgreSQL via Homebrew...');
-      execFileSync('brew', ['services', 'start', 'postgresql@17'], { stdio: 'pipe' });
-      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2000);
-      if (isNativeReady()) {
-        console.log('✅ System PostgreSQL ready on port 5432');
-        process.exit(0);
-      }
-    } catch { /* fall through */ }
+  // Attempt automatic setup via db.sh (installs + starts + configures)
+  if (setupNativePostgres()) {
+    process.exit(0);
   }
 
-  console.warn('⚠️  Native PostgreSQL not running — run: scripts/db.sh setup-native');
-  process.exit(0);
+  exitNativeSetupFailed();
 }
 
 // Docker mode

--- a/server/lib/fileUtils.js
+++ b/server/lib/fileUtils.js
@@ -14,6 +14,11 @@ const __lib_filename = fileURLToPath(import.meta.url);
 const __lib_dirname = dirname(__lib_filename);
 
 /**
+ * MIME types that could execute scripts when served inline — force Content-Disposition: attachment
+ */
+export const RISKY_MIME_TYPES = new Set(['text/html', 'image/svg+xml', 'application/javascript', 'text/javascript', 'application/xml']);
+
+/**
  * Base directories relative to project root
  */
 export const PATHS = {

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -203,7 +203,8 @@ router.get('/:id/icon', loadApp, asyncHandler(async (req, res) => {
   }
 
   const contentType = getIconContentType(iconPath);
-  const iconStat = await stat(iconPath);
+  const iconStat = await stat(iconPath).catch(e => e.code === 'ENOENT' ? null : Promise.reject(e));
+  if (!iconStat) return res.status(404).json({ error: 'No app icon found' });
   const etag = `W/"${iconStat.mtimeMs.toString(36)}-${iconStat.size.toString(36)}"`;
 
   res.set('Content-Type', contentType);
@@ -211,11 +212,15 @@ router.get('/:id/icon', loadApp, asyncHandler(async (req, res) => {
   res.set('ETag', etag);
 
   const ifNoneMatch = req.headers['if-none-match'];
-  if (ifNoneMatch === etag || ifNoneMatch === '*') {
-    return res.status(304).end();
+  if (ifNoneMatch) {
+    const tags = ifNoneMatch.split(',').map(v => v.trim());
+    if (tags.includes('*') || tags.includes(etag)) {
+      return res.status(304).end();
+    }
   }
 
-  const iconData = await readFile(iconPath);
+  const iconData = await readFile(iconPath).catch(e => e.code === 'ENOENT' ? null : Promise.reject(e));
+  if (!iconData) return res.status(404).json({ error: 'No app icon found' });
   res.send(iconData);
 }));
 

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -210,6 +210,11 @@ router.get('/:id/icon', loadApp, asyncHandler(async (req, res) => {
   res.set('Content-Type', contentType);
   res.set('Cache-Control', 'public, max-age=3600');
   res.set('ETag', etag);
+  res.set('X-Content-Type-Options', 'nosniff');
+  if (contentType === 'image/svg+xml') {
+    res.set('Content-Disposition', 'inline; filename="icon.svg"');
+    res.set('Content-Security-Policy', "default-src 'none'; style-src 'unsafe-inline'");
+  }
 
   const ifNoneMatch = req.headers['if-none-match'];
   if (ifNoneMatch) {

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -322,6 +322,20 @@ router.get('/:id/task-types', loadApp, asyncHandler(async (req, res) => {
   res.json({ appId: app.id, appName: app.name, taskTypeOverrides: overrides });
 }));
 
+// PUT /api/apps/:id/task-types/all - Toggle all task types for an app
+router.put('/:id/task-types/all', loadApp, asyncHandler(async (req, res) => {
+  const { enabled } = req.body;
+  if (typeof enabled !== 'boolean') {
+    throw new ServerError('enabled must be a boolean', { status: 400, code: 'VALIDATION_ERROR' });
+  }
+  const result = await appsService.toggleAllAppTaskTypes(req.params.id, enabled);
+  if (!result) {
+    throw new ServerError('App not found', { status: 404, code: 'NOT_FOUND' });
+  }
+  console.log(`📋 ${enabled ? 'Enabled' : 'Disabled'} all task types for ${result.name}`);
+  res.json({ success: true, appId: result.id, taskTypeOverrides: result.taskTypeOverrides || {} });
+}));
+
 // PUT /api/apps/:id/task-types/:taskType - Update a task type override for an app
 router.put('/:id/task-types/:taskType', asyncHandler(async (req, res) => {
   const { enabled, interval, taskMetadata } = req.body;

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { spawn } from 'child_process';
 import { existsSync } from 'fs';
-import { readFile, writeFile } from 'fs/promises';
+import { readFile, writeFile, stat } from 'fs/promises';
 import { join, resolve } from 'path';
 import * as appsService from '../services/apps.js';
 import { notifyAppsChanged, PORTOS_APP_ID } from '../services/apps.js';
@@ -203,9 +203,19 @@ router.get('/:id/icon', loadApp, asyncHandler(async (req, res) => {
   }
 
   const contentType = getIconContentType(iconPath);
-  const iconData = await readFile(iconPath);
+  const iconStat = await stat(iconPath);
+  const etag = `W/"${iconStat.mtimeMs.toString(36)}-${iconStat.size.toString(36)}"`;
+
   res.set('Content-Type', contentType);
   res.set('Cache-Control', 'public, max-age=3600');
+  res.set('ETag', etag);
+
+  const ifNoneMatch = req.headers['if-none-match'];
+  if (ifNoneMatch === etag || ifNoneMatch === '*') {
+    return res.status(304).end();
+  }
+
+  const iconData = await readFile(iconPath);
   res.send(iconData);
 }));
 
@@ -547,7 +557,7 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
       console.log(`📦 Installing ${label} dependencies for ${app.name}`);
       const INSTALL_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
       const installResult = await new Promise((resolve) => {
-        const child = spawn('npm', ['install'], { cwd: subDir, shell: true, windowsHide: true });
+        const child = spawn(resolveCmd('npm'), ['install'], { cwd: subDir, windowsHide: true });
         let stdout = '';
         let stderr = '';
         let settled = false;
@@ -570,7 +580,7 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
 
   const BUILD_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
   const result = await new Promise((resolve) => {
-    const child = spawn(cmd, args, { cwd: app.repoPath, shell: true, windowsHide: true });
+    const child = spawn(resolveCmd(cmd), args, { cwd: app.repoPath, windowsHide: true });
     let stdout = '';
     let stderr = '';
     let settled = false;
@@ -662,6 +672,10 @@ const ALLOWED_BUILD_CMDS = new Set([
   'make',       // Make
   'cargo'       // Rust
 ]);
+
+// On Windows, Node-based CLI tools resolve to .cmd shims
+const WIN_CMD_SHIMS = new Set(['npm', 'npx']);
+const resolveCmd = (cmd) => process.platform === 'win32' && WIN_CMD_SHIMS.has(cmd) ? `${cmd}.cmd` : cmd;
 
 // Allowlist of safe editor commands
 // Security: Only allow known-safe editor commands to prevent arbitrary code execution

--- a/server/routes/apps.test.js
+++ b/server/routes/apps.test.js
@@ -40,6 +40,11 @@ vi.mock('../services/appUpdater.js', () => ({
   updateApp: vi.fn()
 }));
 
+vi.mock('../services/appIconDetect.js', () => ({
+  detectAppIcon: vi.fn(),
+  getIconContentType: vi.fn()
+}));
+
 vi.mock('../services/cos.js', () => ({
   getAgents: vi.fn().mockResolvedValue([]),
   getAgentDates: vi.fn().mockResolvedValue([]),
@@ -57,6 +62,10 @@ import * as appsService from '../services/apps.js';
 import * as pm2Service from '../services/pm2.js';
 import * as history from '../services/history.js';
 import * as streamingDetect from '../services/streamingDetect.js';
+import { detectAppIcon, getIconContentType } from '../services/appIconDetect.js';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 describe('Apps Routes', () => {
   let app;
@@ -542,6 +551,43 @@ describe('Apps Routes', () => {
         .send({});
 
       expect(response.status).toBe(400);
+    });
+  });
+
+  describe('GET /api/apps/:id/icon', () => {
+    const iconDir = join(tmpdir(), 'portos-test-icon');
+    const iconPath = join(iconDir, 'icon.png');
+    const mockApp = { id: 'app-001', name: 'Test App', appIconPath: iconPath, repoPath: '/tmp/test', pm2ProcessNames: [] };
+
+    beforeEach(() => {
+      mkdirSync(iconDir, { recursive: true });
+      writeFileSync(iconPath, 'fake-png-data');
+      appsService.getAppById.mockResolvedValue(mockApp);
+      getIconContentType.mockReturnValue('image/png');
+    });
+
+    afterAll(() => {
+      rmSync(iconDir, { recursive: true, force: true });
+    });
+
+    it('should return icon with ETag header', async () => {
+      const response = await request(app).get('/api/apps/app-001/icon');
+
+      expect(response.status).toBe(200);
+      expect(response.headers['etag']).toBeDefined();
+      expect(response.headers['etag']).toMatch(/^W\//);
+      expect(response.headers['cache-control']).toBe('public, max-age=3600');
+    });
+
+    it('should return 304 when If-None-Match matches ETag', async () => {
+      const first = await request(app).get('/api/apps/app-001/icon');
+      const etag = first.headers['etag'];
+
+      const second = await request(app)
+        .get('/api/apps/app-001/icon')
+        .set('If-None-Match', etag);
+
+      expect(second.status).toBe(304);
     });
   });
 });

--- a/server/routes/apps.test.js
+++ b/server/routes/apps.test.js
@@ -13,6 +13,7 @@ vi.mock('../services/apps.js', () => ({
   archiveApp: vi.fn(),
   updateAppTaskTypeOverride: vi.fn(),
   getAppTaskTypeOverrides: vi.fn(),
+  toggleAllAppTaskTypes: vi.fn(),
   notifyAppsChanged: vi.fn(),
   PORTOS_APP_ID: 'portos-default'
 }));
@@ -588,6 +589,54 @@ describe('Apps Routes', () => {
         .set('If-None-Match', etag);
 
       expect(second.status).toBe(304);
+    });
+
+    it('should return 304 when If-None-Match contains multiple ETags including match', async () => {
+      const first = await request(app).get('/api/apps/app-001/icon');
+      const etag = first.headers['etag'];
+
+      const second = await request(app)
+        .get('/api/apps/app-001/icon')
+        .set('If-None-Match', `W/"other-etag", ${etag}, W/"another"`);
+
+      expect(second.status).toBe(304);
+    });
+  });
+
+  describe('PUT /api/apps/:id/task-types/all', () => {
+    it('should toggle all task types for an app', async () => {
+      appsService.getAppById.mockResolvedValue({ id: 'app-001', name: 'Test App' });
+      appsService.toggleAllAppTaskTypes.mockResolvedValue({ id: 'app-001', name: 'Test App', taskTypeOverrides: { security: { enabled: true } } });
+
+      const response = await request(app)
+        .put('/api/apps/app-001/task-types/all')
+        .send({ enabled: true });
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.appId).toBe('app-001');
+      expect(appsService.toggleAllAppTaskTypes).toHaveBeenCalledWith('app-001', true);
+    });
+
+    it('should return 400 when enabled is not a boolean', async () => {
+      appsService.getAppById.mockResolvedValue({ id: 'app-001', name: 'Test App' });
+
+      const response = await request(app)
+        .put('/api/apps/app-001/task-types/all')
+        .send({ enabled: 'yes' });
+
+      expect(response.status).toBe(400);
+      expect(response.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('should return 404 when app not found', async () => {
+      appsService.getAppById.mockResolvedValue(null);
+
+      const response = await request(app)
+        .put('/api/apps/app-999/task-types/all')
+        .send({ enabled: true });
+
+      expect(response.status).toBe(404);
     });
   });
 });

--- a/server/routes/attachments.js
+++ b/server/routes/attachments.js
@@ -12,6 +12,7 @@ import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { ensureDir, PATHS } from '../lib/fileUtils.js';
 
 const ATTACHMENTS_DIR = PATHS.cosAttachments;
+const RISKY_MIME_TYPES = new Set(['text/html', 'image/svg+xml', 'application/javascript', 'text/javascript', 'application/xml']);
 
 const router = Router();
 
@@ -161,6 +162,11 @@ router.get('/:filename', asyncHandler(async (req, res) => {
 
   const ext = getExtension(safeFilename);
   const mimeType = ALLOWED_EXTENSIONS[ext] || 'application/octet-stream';
+
+  res.set('X-Content-Type-Options', 'nosniff');
+  if (RISKY_MIME_TYPES.has(mimeType)) {
+    res.set('Content-Disposition', `attachment; filename="${safeFilename}"`);
+  }
 
   res.type(mimeType).sendFile(filepath);
 }));

--- a/server/routes/attachments.js
+++ b/server/routes/attachments.js
@@ -9,10 +9,9 @@ import { existsSync } from 'fs';
 import { join, basename, extname, resolve } from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { ensureDir, PATHS } from '../lib/fileUtils.js';
+import { ensureDir, PATHS, RISKY_MIME_TYPES } from '../lib/fileUtils.js';
 
 const ATTACHMENTS_DIR = PATHS.cosAttachments;
-const RISKY_MIME_TYPES = new Set(['text/html', 'image/svg+xml', 'application/javascript', 'text/javascript', 'application/xml']);
 
 const router = Router();
 

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -281,7 +281,20 @@ router.post('/evaluate', asyncHandler(async (req, res) => {
 router.post('/tasks/:id/spawn', asyncHandler(async (req, res) => {
   const result = await cos.forceSpawnTask(req.params.id);
   if (result.error) {
-    throw new ServerError(result.error, { status: 400, code: 'SPAWN_FAILED' });
+    const message = String(result.error);
+    let status = 400;
+    let code = 'SPAWN_FAILED';
+    if (/not found/i.test(message)) {
+      status = 404;
+      code = 'NOT_FOUND';
+    } else if (/not pending/i.test(message)) {
+      status = 409;
+      code = 'TASK_NOT_PENDING';
+    } else if (/no available agent slots/i.test(message)) {
+      status = 429;
+      code = 'NO_CAPACITY';
+    }
+    throw new ServerError(result.error, { status, code });
   }
   res.json(result);
 }));

--- a/server/routes/cos.js
+++ b/server/routes/cos.js
@@ -277,6 +277,15 @@ router.post('/evaluate', asyncHandler(async (req, res) => {
   res.json({ success: true, message: 'Evaluation triggered' });
 }));
 
+// POST /api/cos/tasks/:id/spawn - Force-spawn a pending task
+router.post('/tasks/:id/spawn', asyncHandler(async (req, res) => {
+  const result = await cos.forceSpawnTask(req.params.id);
+  if (result.error) {
+    throw new ServerError(result.error, { status: 400, code: 'SPAWN_FAILED' });
+  }
+  res.json(result);
+}));
+
 // GET /api/cos/health - Get health status
 router.get('/health', asyncHandler(async (req, res) => {
   const health = await cos.getHealthStatus();

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -38,7 +38,8 @@ vi.mock('../services/cos.js', () => ({
   getReport: vi.fn(),
   generateReport: vi.fn(),
   listScripts: vi.fn(),
-  getScript: vi.fn()
+  getScript: vi.fn(),
+  forceSpawnTask: vi.fn()
 }));
 
 // Mock the taskWatcher service
@@ -640,6 +641,45 @@ describe('CoS Routes', () => {
       expect(response.status).toBe(200);
       expect(response.body.success).toBe(true);
       expect(appActivity.clearAppCooldown).toHaveBeenCalledWith('app-001');
+    });
+  });
+
+  describe('POST /api/cos/tasks/:id/spawn', () => {
+    it('should force-spawn a pending task', async () => {
+      cos.forceSpawnTask.mockResolvedValue({ success: true, taskId: 'task-001' });
+
+      const response = await request(app).post('/api/cos/tasks/task-001/spawn');
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(cos.forceSpawnTask).toHaveBeenCalledWith('task-001');
+    });
+
+    it('should return 404 when task not found', async () => {
+      cos.forceSpawnTask.mockResolvedValue({ error: 'Task not found' });
+
+      const response = await request(app).post('/api/cos/tasks/bad-id/spawn');
+
+      expect(response.status).toBe(404);
+      expect(response.body.code).toBe('NOT_FOUND');
+    });
+
+    it('should return 409 when task is not pending', async () => {
+      cos.forceSpawnTask.mockResolvedValue({ error: 'Task is completed, not pending' });
+
+      const response = await request(app).post('/api/cos/tasks/task-002/spawn');
+
+      expect(response.status).toBe(409);
+      expect(response.body.code).toBe('TASK_NOT_PENDING');
+    });
+
+    it('should return 429 when no agent slots available', async () => {
+      cos.forceSpawnTask.mockResolvedValue({ error: 'No available agent slots (3/3)' });
+
+      const response = await request(app).post('/api/cos/tasks/task-003/spawn');
+
+      expect(response.status).toBe(429);
+      expect(response.body.code).toBe('NO_CAPACITY');
     });
   });
 });

--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import * as git from '../services/git.js';
 import * as appsService from '../services/apps.js';
-import { getAgents } from '../services/cos.js';
+import { getAgents } from '../services/cosAgents.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 
 /**

--- a/server/routes/uploads.js
+++ b/server/routes/uploads.js
@@ -12,6 +12,7 @@ import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { ensureDir, PATHS } from '../lib/fileUtils.js';
 
 const UPLOADS_DIR = PATHS.uploads;
+const RISKY_MIME_TYPES = new Set(['text/html', 'image/svg+xml', 'application/javascript', 'text/javascript', 'application/xml']);
 
 const router = Router();
 
@@ -218,6 +219,11 @@ router.get('/:filename', asyncHandler(async (req, res) => {
 
   const ext = getExtension(safeFilename);
   const mimeType = getMimeType(ext);
+
+  res.set('X-Content-Type-Options', 'nosniff');
+  if (RISKY_MIME_TYPES.has(mimeType)) {
+    res.set('Content-Disposition', `attachment; filename="${safeFilename}"`);
+  }
 
   res.type(mimeType).sendFile(filepath);
 }));

--- a/server/routes/uploads.js
+++ b/server/routes/uploads.js
@@ -9,10 +9,9 @@ import { existsSync } from 'fs';
 import { join, basename, extname, resolve } from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { ensureDir, PATHS } from '../lib/fileUtils.js';
+import { ensureDir, PATHS, RISKY_MIME_TYPES } from '../lib/fileUtils.js';
 
 const UPLOADS_DIR = PATHS.uploads;
-const RISKY_MIME_TYPES = new Set(['text/html', 'image/svg+xml', 'application/javascript', 'text/javascript', 'application/xml']);
 
 const router = Router();
 

--- a/server/services/apps.js
+++ b/server/services/apps.js
@@ -310,8 +310,8 @@ export async function getAppTaskTypeOverrides(id) {
  */
 export async function isTaskTypeEnabledForApp(id, taskType) {
   const overrides = await getAppTaskTypeOverrides(id);
-  // No override means inherit global (enabled); only disabled when explicitly false
-  return overrides[taskType]?.enabled !== false;
+  // No override means disabled — new task types must be explicitly enabled per app
+  return overrides[taskType]?.enabled === true;
 }
 
 /**
@@ -392,6 +392,30 @@ export async function bulkUpdateAppTaskTypeOverride(taskType, { enabled } = {}) 
   appsEvents.emit('changed', { action: 'update-task-types', timestamp: Date.now() });
 
   return { count: activeIds.length };
+}
+
+/**
+ * Toggle all task types for a single app to enabled or disabled
+ */
+export async function toggleAllAppTaskTypes(id, enabled) {
+  const data = await loadApps();
+  if (!data.apps[id]) return null;
+
+  await migrateTaskTypeOverrides(id);
+
+  const overrides = data.apps[id].taskTypeOverrides || {};
+  for (const taskType of SELF_IMPROVEMENT_TASK_TYPES) {
+    const existing = overrides[taskType] || {};
+    overrides[taskType] = { ...existing, enabled };
+  }
+
+  data.apps[id].taskTypeOverrides = overrides;
+  delete data.apps[id].disabledTaskTypes;
+  data.apps[id].updatedAt = new Date().toISOString();
+  await saveApps(data);
+  appsEvents.emit('changed', { action: 'update-task-types', timestamp: Date.now() });
+
+  return { id, ...data.apps[id] };
 }
 
 /**

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -633,7 +633,10 @@ async function getDueJobs() {
 
     if (timeSinceLastRun >= job.intervalMs) {
       if (job.scheduledTime) {
-        const [hours, minutes] = job.scheduledTime.split(':').map(Number)
+        const match = String(job.scheduledTime).match(/^([01]\d|2[0-3]):([0-5]\d)$/)
+        if (!match) continue // skip jobs with invalid scheduledTime format
+        const hours = Number(match[1])
+        const minutes = Number(match[2])
         const targetUtc = nextLocalTime(now - DAY, hours, minutes, timezone)
         if (now < targetUtc) continue
         if (lastRun >= targetUtc) continue

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -637,7 +637,10 @@ async function getDueJobs() {
         if (!match) continue // skip jobs with invalid scheduledTime format
         const hours = Number(match[1])
         const minutes = Number(match[2])
-        const targetUtc = nextLocalTime(now - DAY, hours, minutes, timezone)
+        // Compute today's scheduled UTC time from local midnight to avoid firing before scheduled time
+        const local = getLocalParts(new Date(now), timezone)
+        const midnightUtc = now - ((local.hour * 60 + local.minute) * 60_000)
+        const targetUtc = nextLocalTime(midnightUtc, hours, minutes, timezone)
         if (now < targetUtc) continue
         if (lastRun >= targetUtc) continue
       }

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -637,11 +637,18 @@ async function getDueJobs() {
         if (!match) continue // skip jobs with invalid scheduledTime format
         const hours = Number(match[1])
         const minutes = Number(match[2])
-        // Compute today's scheduled UTC time in a DST-safe way using nextLocalTime.
-        // Search from the later of (lastRun, now - 24h) to find the most recent scheduled occurrence.
+        // Compute today's scheduled UTC time in a DST-safe way.
+        // nextLocalTime finds the next occurrence AFTER the reference point.
+        // By searching from (now - 24h), we get today's occurrence if we haven't passed it yet,
+        // or yesterday's occurrence if we have. We then verify the candidate is on today's local date.
         const nowFloored = now - (now % 60_000)
-        const searchFrom = Math.max(lastRun, nowFloored - DAY)
-        const targetUtc = nextLocalTime(searchFrom, hours, minutes, timezone)
+        const localNow = getLocalParts(new Date(nowFloored), timezone)
+        let targetUtc = nextLocalTime(nowFloored - DAY, hours, minutes, timezone)
+        const targetLocal = getLocalParts(new Date(targetUtc), timezone)
+        // If the candidate landed on yesterday's date, advance to today's occurrence
+        if (targetLocal.day !== localNow.day || targetLocal.month !== localNow.month || targetLocal.year !== localNow.year) {
+          targetUtc = nextLocalTime(targetUtc + 1, hours, minutes, timezone)
+        }
         if (now < targetUtc) continue
         if (lastRun >= targetUtc) continue
       }

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -649,8 +649,15 @@ async function getDueJobs() {
     const timeSinceLastRun = now - lastRun
 
     if (timeSinceLastRun >= job.intervalMs) {
-      // If job has a scheduledTime, only mark due if we've passed that time today
-      if (!isScheduledTimeMet(job.scheduledTime, timezone)) continue
+      // If job has a scheduledTime, compute exact UTC target in user's timezone
+      if (job.scheduledTime) {
+        const [hours, minutes] = job.scheduledTime.split(':').map(Number)
+        const targetUtc = nextLocalTime(now - DAY, hours, minutes, timezone)
+        // Not due if today's scheduled time hasn't arrived yet
+        if (now < targetUtc) continue
+        // Already ran since this scheduled occurrence
+        if (lastRun >= targetUtc) continue
+      }
 
       // If job is weekdaysOnly, skip weekends
       if (job.weekdaysOnly && !isWeekday(timezone)) continue
@@ -1061,9 +1068,7 @@ async function getNextDueJob() {
 
     if (nextDue < earliestTime) {
       earliestTime = nextDue
-      const isDue = job.cronExpression
-        ? Date.now() >= nextDue
-        : Date.now() >= nextDue && isScheduledTimeMet(job.scheduledTime, timezone)
+      const isDue = Date.now() >= nextDue
       earliest = {
         jobId: job.id,
         jobName: job.name,

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -1054,9 +1054,11 @@ async function getNextDueJob() {
 
       // If job has scheduledTime, find next occurrence in user's timezone
       if (job.scheduledTime) {
-        const [hours, minutes] = job.scheduledTime.split(':').map(Number)
-        const candidate = nextLocalTime(nextDue, hours, minutes, timezone)
-        if (candidate > nextDue) nextDue = candidate
+        const match = String(job.scheduledTime).match(/^([01]\d|2[0-3]):([0-5]\d)$/)
+        if (match) {
+          const candidate = nextLocalTime(nextDue, Number(match[1]), Number(match[2]), timezone)
+          if (candidate > nextDue) nextDue = candidate
+        }
       }
     }
 

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -593,23 +593,6 @@ async function getEnabledJobs() {
 }
 
 /**
- * Check if the current time has passed a job's scheduledTime today.
- * scheduledTime is "HH:MM" in the user's configured timezone.
- * Returns true if no scheduledTime is set, or if current local time >= scheduledTime.
- * @param {string|null} scheduledTime - "HH:MM" or null/undefined
- * @param {string} timezone - IANA timezone string
- * @returns {boolean}
- */
-function isScheduledTimeMet(scheduledTime, timezone) {
-  if (!scheduledTime) return true
-  const [hours, minutes] = scheduledTime.split(':').map(Number)
-  const local = getLocalParts(new Date(), timezone)
-  const nowMinutes = local.hour * 60 + local.minute
-  const targetMinutes = hours * 60 + minutes
-  return nowMinutes >= targetMinutes
-}
-
-/**
  * Check if today is a weekday (Monday-Friday) in the user's timezone.
  * @param {string} timezone - IANA timezone string
  * @returns {boolean}
@@ -649,13 +632,10 @@ async function getDueJobs() {
     const timeSinceLastRun = now - lastRun
 
     if (timeSinceLastRun >= job.intervalMs) {
-      // If job has a scheduledTime, compute exact UTC target in user's timezone
       if (job.scheduledTime) {
         const [hours, minutes] = job.scheduledTime.split(':').map(Number)
         const targetUtc = nextLocalTime(now - DAY, hours, minutes, timezone)
-        // Not due if today's scheduled time hasn't arrived yet
         if (now < targetUtc) continue
-        // Already ran since this scheduled occurrence
         if (lastRun >= targetUtc) continue
       }
 
@@ -1317,7 +1297,6 @@ export {
   generateTaskFromJob,
   getJobStats,
   getNextDueJob,
-  isScheduledTimeMet,
   isWeekday,
   INTERVAL_OPTIONS,
   loadJobSkillTemplate,

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -637,11 +637,11 @@ async function getDueJobs() {
         if (!match) continue // skip jobs with invalid scheduledTime format
         const hours = Number(match[1])
         const minutes = Number(match[2])
-        // Compute today's scheduled UTC time from local midnight to avoid firing before scheduled time
-        const nowFloored = now - (now % 60_000) // floor to nearest minute to avoid second/millisecond drift
-        const local = getLocalParts(new Date(nowFloored), timezone)
-        const midnightUtc = nowFloored - ((local.hour * 60 + local.minute) * 60_000)
-        const targetUtc = nextLocalTime(midnightUtc, hours, minutes, timezone)
+        // Compute today's scheduled UTC time in a DST-safe way using nextLocalTime.
+        // Search from the later of (lastRun, now - 24h) to find the most recent scheduled occurrence.
+        const nowFloored = now - (now % 60_000)
+        const searchFrom = Math.max(lastRun, nowFloored - DAY)
+        const targetUtc = nextLocalTime(searchFrom, hours, minutes, timezone)
         if (now < targetUtc) continue
         if (lastRun >= targetUtc) continue
       }

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -638,8 +638,9 @@ async function getDueJobs() {
         const hours = Number(match[1])
         const minutes = Number(match[2])
         // Compute today's scheduled UTC time from local midnight to avoid firing before scheduled time
-        const local = getLocalParts(new Date(now), timezone)
-        const midnightUtc = now - ((local.hour * 60 + local.minute) * 60_000)
+        const nowFloored = now - (now % 60_000) // floor to nearest minute to avoid second/millisecond drift
+        const local = getLocalParts(new Date(nowFloored), timezone)
+        const midnightUtc = nowFloored - ((local.hour * 60 + local.minute) * 60_000)
         const targetUtc = nextLocalTime(midnightUtc, hours, minutes, timezone)
         if (now < targetUtc) continue
         if (lastRun >= targetUtc) continue

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -1092,9 +1092,10 @@ export async function evaluateTasks() {
 
       if (await blockIfExceedsMaxSpawns(task, 'internal')) continue;
 
-      // Check if task's app is on cooldown
+      // Check if task's app is on cooldown (pipeline continuations bypass cooldown)
       const appId = task.metadata?.app;
-      if (appId) {
+      const isPipelineContinuation = task.metadata?.pipeline?.currentStage > 0;
+      if (appId && !isPipelineContinuation) {
         const onCooldown = await isAppOnCooldown(appId, state.config.appReviewCooldownMs);
         if (onCooldown) {
           emitLog('debug', `Skipping system task ${task.id} - app ${appId} on cooldown`);

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -2607,8 +2607,10 @@ function computeNextJobFireTime(job, timezone) {
   let nextDue = lastRun + job.intervalMs;
 
   if (job.scheduledTime) {
-    const [hours, minutes] = job.scheduledTime.split(':').map(Number);
-    nextDue = nextLocalTime(nextDue, hours, minutes, timezone);
+    const match = String(job.scheduledTime).match(/^([01]\d|2[0-3]):([0-5]\d)$/);
+    if (match) {
+      nextDue = nextLocalTime(nextDue, Number(match[1]), Number(match[2]), timezone);
+    }
   }
 
   // If weekdaysOnly, skip to next weekday (using local day-of-week)

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -447,6 +447,7 @@ export async function forceSpawnTask(taskId) {
   const task = await getTaskById(taskId);
   if (!task) return { error: 'Task not found' };
   if (task.status !== 'pending') return { error: `Task is ${task.status}, not pending` };
+  if (task.approvalRequired) return { error: 'Task requires approval before it can be spawned' };
 
   const state = await loadState();
   const runningAgents = Object.values(state.agents).filter(a => a.status === 'running').length;

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -1041,7 +1041,7 @@ export async function evaluateTasks() {
         emitLog('info', `Processing on-demand improvement: ${request.taskType} for ${targetApp.name}`, { requestId: request.id, appId: targetApp.id });
         await markAppReviewStarted(targetApp.id, `on-demand-${Date.now()}`);
         await taskSchedule.recordExecution(`task:${request.taskType}`, targetApp.id);
-        task = await generateManagedAppImprovementTaskForType(request.taskType, targetApp, state);
+        task = await generateManagedAppImprovementTaskForType(request.taskType, targetApp, state, { skipPreconditions: true });
       } else {
         emitLog('info', `Processing on-demand improvement: ${request.taskType}`, { requestId: request.id });
         await taskSchedule.recordExecution(`task:${request.taskType}`);
@@ -2177,7 +2177,7 @@ async function generateManagedAppImprovementTask(app, state) {
  * @param {Object} state - Current CoS state
  * @returns {Object} Generated task
  */
-async function generateManagedAppImprovementTaskForType(taskType, app, state) {
+async function generateManagedAppImprovementTaskForType(taskType, app, state, { skipPreconditions = false } = {}) {
   const { updateAppActivity } = await import('./appActivity.js');
   const taskSchedule = await import('./taskSchedule.js');
 
@@ -2214,7 +2214,7 @@ async function generateManagedAppImprovementTaskForType(taskType, app, state) {
   }
 
   initializePipelineMetadata(metadata);
-  if (shouldSkipForPrecondition(metadata, app, taskType)) return null;
+  if (!skipPreconditions && shouldSkipForPrecondition(metadata, app, taskType)) return null;
 
   const promptTemplate = metadata.pipeline?.stages
     ? await taskSchedule.getStagePrompt(taskType, 0)
@@ -3587,7 +3587,7 @@ async function dequeueNextTask() {
       emitLog('info', `Processing on-demand improvement: ${request.taskType} for ${targetApp.name}`, { requestId: request.id, appId: targetApp.id });
       await markAppReviewStarted(targetApp.id, `on-demand-${Date.now()}`);
       await taskScheduleMod.recordExecution(`task:${request.taskType}`, targetApp.id);
-      task = await generateManagedAppImprovementTaskForType(request.taskType, targetApp, state);
+      task = await generateManagedAppImprovementTaskForType(request.taskType, targetApp, state, { skipPreconditions: true });
     } else {
       emitLog('info', `Processing on-demand improvement: ${request.taskType}`, { requestId: request.id });
       await taskScheduleMod.recordExecution(`task:${request.taskType}`);

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -823,6 +823,24 @@ export async function getTaskById(taskId) {
 }
 
 /**
+ * Force-spawn a pending task by ID, bypassing cooldowns and evaluation intervals.
+ */
+export async function forceSpawnTask(taskId) {
+  const task = await getTaskById(taskId);
+  if (!task) return { error: 'Task not found' };
+  if (task.status !== 'pending') return { error: `Task is ${task.status}, not pending` };
+
+  const state = await loadState();
+  const runningAgents = Object.values(state.agents).filter(a => a.status === 'running').length;
+  if (runningAgents >= state.config.maxConcurrentAgents) {
+    return { error: `No available agent slots (${runningAgents}/${state.config.maxConcurrentAgents})` };
+  }
+
+  cosEvents.emit('task:ready', { ...task, taskType: task.taskType || 'internal' });
+  return { success: true, taskId };
+}
+
+/**
  * Reset orphaned in_progress tasks back to pending
  * (tasks marked in_progress but no running agent)
  */

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -450,6 +450,7 @@ export async function forceSpawnTask(taskId) {
   if (task.approvalRequired) return { error: 'Task requires approval before it can be spawned' };
 
   const state = await loadState();
+  if (state.paused) return { error: 'CoS daemon is paused — resume before force-spawning tasks' };
   const runningAgents = Object.values(state.agents).filter(a => a.status === 'running').length;
   if (runningAgents >= state.config.maxConcurrentAgents) {
     return { error: `No available agent slots (${runningAgents}/${state.config.maxConcurrentAgents})` };

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -3,11 +3,17 @@
  *
  * Manages the autonomous agent manager that watches TASKS.md,
  * spawns sub-agents, and orchestrates task completion.
+ *
+ * Decomposed modules:
+ * - cosState.js    — shared state management (loadState, saveState, config, mutex)
+ * - cosAgents.js   — agent lifecycle (register, complete, archive, feedback)
+ * - cosReports.js  — reports, briefings, and activity tracking
+ * - cosEvents.js   — event emitter and logging
  */
 
-import { readFile, writeFile, rename, readdir, rm, stat } from 'fs/promises';
+import { readFile, writeFile, readdir, rm } from 'fs/promises';
 import { existsSync } from 'fs';
-import { join, dirname } from 'path';
+import { join } from 'path';
 import { exec, execFile } from 'child_process';
 import { execPm2 } from './pm2.js';
 import { promisify } from 'util';
@@ -18,31 +24,33 @@ import { isAppOnCooldown, getNextAppForReview, markAppReviewStarted, markIdleRev
 import { getActiveApps, getAppTaskTypeOverrides } from './apps.js';
 import { getAdaptiveCooldownMultiplier, getSkippedTaskTypes, getPerformanceSummary, checkAndRehabilitateSkippedTasks, getLearningInsights } from './taskLearning.js';
 import { schedule as scheduleEvent, cancel as cancelEvent, getStats as getSchedulerStats, parseCronToNextRun } from './eventScheduler.js';
-import { createMutex } from '../lib/asyncMutex.js';
 import { generateProactiveTasks as generateMissionTasks, getStats as getMissionStats } from './missions.js';
 import { generateTaskFromJob, recordJobExecution, recordJobGateSkip, isScriptJob, executeScriptJob, isShellJob, executeShellJob } from './autonomousJobs.js';
 import { checkJobGate, hasGate } from './jobGates.js';
-import { ensureDir, ensureDirs, formatDuration, safeJSONParse, PATHS } from '../lib/fileUtils.js';
+import { ensureDir, formatDuration, safeJSONParse, PATHS } from '../lib/fileUtils.js';
 import { sanitizeTaskMetadata, PIPELINE_BEHAVIOR_FLAGS, MAX_TOTAL_SPAWNS } from '../lib/validation.js';
 import { addNotification, NOTIFICATION_TYPES } from './notifications.js';
 import { recordDecision, DECISION_TYPES } from './decisionLog.js';
 import { getUserTimezone, getLocalParts, nextLocalTime, todayInTimezone } from '../lib/timezone.js';
-// Import and re-export cosEvents from separate module to avoid circular dependencies
-import { cosEvents as _cosEvents } from './cosEvents.js';
-export const cosEvents = _cosEvents;
-
 import { PORTOS_UI_URL } from '../lib/ports.js';
+
+// Shared state management (extracted to avoid circular deps)
+import { loadState, saveState, withStateLock, ensureDirectories, AGENTS_DIR, REPORTS_DIR, SCRIPTS_DIR, ROOT_DIR, isDaemonRunning, setDaemonRunning } from './cosState.js';
+
+// Events and logging (canonical source: cosEvents.js)
+import { cosEvents, emitLog } from './cosEvents.js';
+export { cosEvents, emitLog };
+
+// Agent lifecycle (re-export for backward compat with `import * as cos`)
+export { registerAgent, updateAgent, completeAgent, appendAgentOutput, getAgents, getAgentDates, getAgentsByDate, getAgent, terminateAgent, killAgent, sendBtwToAgent, getAgentProcessStats, cleanupZombieAgents, deleteAgent, submitAgentFeedback, getFeedbackStats, extractTaskType, archiveStaleAgents, clearCompletedAgents, pruneOldAgentArchives } from './cosAgents.js';
+
+// Reports and activity (re-export for backward compat with `import * as cos`)
+export { generateReport, getReport, getTodayReport, listReports, listBriefings, getBriefing, getLatestBriefing, getTodayActivity, getRecentTasks, formatRelativeTime } from './cosReports.js';
 
 const _execAsync = promisify(exec);
 const _execFileAsync = promisify(execFile);
 const execAsync = (cmd, opts) => _execAsync(cmd, { ...opts, windowsHide: true });
 const execFileAsync = (cmd, args, opts) => _execFileAsync(cmd, args, { ...opts, windowsHide: true });
-
-const STATE_FILE = join(PATHS.cos, 'state.json');
-const AGENTS_DIR = join(PATHS.cos, 'agents');
-const REPORTS_DIR = PATHS.reports;
-const SCRIPTS_DIR = PATHS.scripts;
-const ROOT_DIR = PATHS.root;
 
 // MAX_TOTAL_SPAWNS imported from validation.js (shared with subAgentSpawner.js)
 
@@ -62,400 +70,10 @@ async function blockIfExceedsMaxSpawns(task, taskType) {
   return true;
 }
 
-/**
- * Emit a log event for UI display
- * Exported for use by other CoS-related services
- * @param {string} level - Log level: 'info', 'warn', 'error', 'success', 'debug'
- * @param {string} message - Log message
- * @param {Object} data - Additional data to include in log entry
- * @param {string} prefix - Optional prefix for console output (e.g., 'SelfImprovement')
- */
-export function emitLog(level, message, data = {}, prefix = '') {
-  const logEntry = {
-    timestamp: new Date().toISOString(),
-    level,
-    message,
-    ...data
-  };
-  // Debug messages go to socket only (UI), not console — set COS_LOG_LEVEL=debug to include them
-  if (level !== 'debug' || process.env.COS_LOG_LEVEL === 'debug') {
-    const emoji = level === 'error' ? '❌' : level === 'warn' ? '⚠️' : level === 'success' ? '✅' : level === 'debug' ? '🔍' : 'ℹ️';
-    const prefixStr = prefix ? ` ${prefix}` : '';
-    console.log(`${emoji}${prefixStr} ${message}`);
-  }
-  cosEvents.emit('log', logEntry);
-}
-
-// In-memory daemon state
-let daemonRunning = false;
 let initialStartup = false;
 
-// Lightweight index mapping agentId → YYYY-MM-DD date bucket (~50KB vs 16MB full cache)
-// Lazy-loaded from data/cos/agents/index.json on first access
-let agentIndex = null;
-let agentIndexPromise = null;
-const INDEX_FILE = join(AGENTS_DIR, 'index.json');
-
-// Load agent index from disk (lazy init, singleton promise prevents concurrent migrations)
-async function loadAgentIndex() {
-  if (agentIndex) return agentIndex;
-  if (agentIndexPromise) return agentIndexPromise;
-
-  agentIndexPromise = (async () => {
-    if (!existsSync(AGENTS_DIR)) {
-      await ensureDir(AGENTS_DIR);
-    }
-
-    if (existsSync(INDEX_FILE)) {
-      const content = await readFile(INDEX_FILE, 'utf-8').catch(() => '{}');
-      const parsed = safeJSONParse(content, {});
-      agentIndex = new Map(Object.entries(parsed));
-      console.log(`📂 Loaded agent index: ${agentIndex.size} entries`);
-    } else {
-      // No index yet — run migration from flat dirs to date buckets
-      agentIndex = await migrateAgentsToDateBuckets();
-    }
-
-    return agentIndex;
-  })().catch(err => {
-    agentIndexPromise = null;
-    throw err;
-  });
-
-  return agentIndexPromise;
-}
-
-// Persist agent index to disk (atomic write via temp file + rename)
-async function saveAgentIndex() {
-  if (!agentIndex) return;
-  const obj = Object.fromEntries(agentIndex);
-  const tmpFile = `${INDEX_FILE}.tmp`;
-  await writeFile(tmpFile, JSON.stringify(obj)).catch(err => {
-    console.error(`❌ Failed to save agent index: ${err.message}`);
-  });
-  await rename(tmpFile, INDEX_FILE).catch(err => {
-    console.error(`❌ Failed to rename agent index: ${err.message}`);
-  });
-}
-
-// Resolve the correct directory for an agent (running = flat, completed = date bucket)
-function getAgentDir(agentId, dateString) {
-  if (dateString) return join(AGENTS_DIR, dateString, agentId);
-  // Check index for date bucket
-  const date = agentIndex?.get(agentId);
-  if (date) return join(AGENTS_DIR, date, agentId);
-  // Fallback to flat dir (running agents or pre-migration)
-  return join(AGENTS_DIR, agentId);
-}
-
-// Migrate flat agent-* directories into YYYY-MM-DD date buckets
-// Runs once when index.json doesn't exist. Idempotent — no-op if already migrated.
-async function migrateAgentsToDateBuckets() {
-  const index = new Map();
-
-  if (!existsSync(AGENTS_DIR)) {
-    await ensureDir(AGENTS_DIR);
-    await writeFile(INDEX_FILE, '{}');
-    console.log('📂 Created empty agent index (no agents to migrate)');
-    return index;
-  }
-
-  const entries = await readdir(AGENTS_DIR, { withFileTypes: true });
-
-  // Also scan existing date-bucket dirs to include them in the index
-  const dateDirPattern = /^\d{4}-\d{2}-\d{2}$/;
-  for (const entry of entries) {
-    if (!entry.isDirectory() || !dateDirPattern.test(entry.name)) continue;
-    const dateStr = entry.name;
-    const dateDir = join(AGENTS_DIR, dateStr);
-    const agentDirs = await readdir(dateDir, { withFileTypes: true }).catch(() => []);
-    for (const agentEntry of agentDirs) {
-      if (agentEntry.isDirectory() && agentEntry.name.startsWith('agent-')) {
-        index.set(agentEntry.name, dateStr);
-      }
-    }
-  }
-
-  // Find flat agent-* dirs that need migration
-  const flatAgentDirs = entries.filter(e => e.isDirectory() && e.name.startsWith('agent-'));
-
-  if (flatAgentDirs.length === 0) {
-    await writeFile(INDEX_FILE, JSON.stringify(Object.fromEntries(index)));
-    console.log(`📂 Agent index built: ${index.size} entries (no flat dirs to migrate)`);
-    return index;
-  }
-
-  console.log(`📦 Migrating ${flatAgentDirs.length} agents into date buckets...`);
-  let migrated = 0;
-  let skipped = 0;
-
-  for (const entry of flatAgentDirs) {
-    const agentId = entry.name;
-    const agentDir = join(AGENTS_DIR, agentId);
-    const metaPath = join(agentDir, 'metadata.json');
-
-    let dateStr = null;
-
-    // Try to get date from metadata
-    if (existsSync(metaPath)) {
-      const content = await readFile(metaPath, 'utf-8').catch(() => null);
-      if (content) {
-        const raw = safeJSONParse(content, null);
-        if (raw?.completedAt) {
-          dateStr = raw.completedAt.slice(0, 10); // YYYY-MM-DD
-        }
-      }
-    }
-
-    // Fallback: directory mtime
-    if (!dateStr) {
-      const dirStat = await stat(agentDir).catch(() => null);
-      if (dirStat?.mtime) {
-        dateStr = dirStat.mtime.toISOString().slice(0, 10);
-      }
-    }
-
-    if (!dateStr) {
-      console.log(`⚠️ Cannot determine date for ${agentId}, skipping`);
-      skipped++;
-      continue;
-    }
-
-    // Move into date bucket
-    const bucketDir = join(AGENTS_DIR, dateStr);
-    await ensureDir(bucketDir);
-    const targetDir = join(bucketDir, agentId);
-
-    // If target already exists (partial previous migration), skip
-    if (existsSync(targetDir)) {
-      index.set(agentId, dateStr);
-      migrated++;
-      continue;
-    }
-
-    await rename(agentDir, targetDir).catch(async (renameErr) => {
-      // rename can fail across filesystems — fall back to copy+delete
-      console.log(`⚠️ Rename failed for ${agentId}, using copy: ${renameErr.message}`);
-      try {
-        await ensureDir(targetDir);
-        const files = await readdir(agentDir);
-        for (const file of files) {
-          const content = await readFile(join(agentDir, file));
-          await writeFile(join(targetDir, file), content);
-        }
-        await rm(agentDir, { recursive: true });
-      } catch (copyErr) {
-        console.error(`❌ Copy fallback failed for ${agentId}: ${copyErr.message}`);
-        // Clean up partially-created target to avoid skipping on next startup
-        await rm(targetDir, { recursive: true, force: true }).catch(() => {});
-        throw copyErr;
-      }
-    });
-
-    index.set(agentId, dateStr);
-    migrated++;
-  }
-
-  // Persist index
-  await writeFile(INDEX_FILE, JSON.stringify(Object.fromEntries(index)));
-  const uniqueDates = new Set(index.values()).size;
-  const parts = [`📦 Migrated ${migrated} agents into date buckets (${uniqueDates} unique dates)`];
-  if (skipped > 0) parts.push(`skipped ${skipped} undatable`);
-  console.log(parts.join(', '));
-
-  return index;
-}
-
-// Prune agent archive date buckets older than retentionDays (default 90).
-// Removes directories + their index entries. Runs after migration on startup.
-async function pruneOldAgentArchives(retentionDays = 90) {
-  const idx = await loadAgentIndex();
-  if (!idx || idx.size === 0) return;
-
-  const cutoff = new Date();
-  cutoff.setDate(cutoff.getDate() - retentionDays);
-  const cutoffStr = cutoff.toISOString().slice(0, 10);
-
-  const dateDirPattern = /^\d{4}-\d{2}-\d{2}$/;
-  const entries = await readdir(AGENTS_DIR, { withFileTypes: true }).catch(() => []);
-  const oldDates = entries
-    .filter(e => e.isDirectory() && dateDirPattern.test(e.name) && e.name < cutoffStr)
-    .map(e => e.name);
-
-  if (oldDates.length === 0) return;
-
-  let pruned = 0;
-  for (const dateStr of oldDates) {
-    await rm(join(AGENTS_DIR, dateStr), { recursive: true }).catch(() => {});
-    // Remove index entries for this date
-    for (const [agentId, date] of idx.entries()) {
-      if (date === dateStr) { idx.delete(agentId); pruned++; }
-    }
-  }
-
-  await saveAgentIndex();
-  console.log(`🗑️ Pruned ${pruned} archived agents older than ${retentionDays} days (${oldDates.length} date buckets)`);
-}
-
-// Mutex lock for state operations to prevent race conditions
-const withStateLock = createMutex();
-
-/**
- * Default configuration
- */
-const DEFAULT_CONFIG = {
-  userTasksFile: 'data/TASKS.md',          // User-defined tasks
-  cosTasksFile: 'data/COS-TASKS.md',       // CoS internal/system tasks
-  goalsFile: 'GOALS.md',                    // Mission and goals file
-  evaluationIntervalMs: 60000,             // 1 minute - stay active, check frequently
-  healthCheckIntervalMs: 900000,           // 15 minutes
-  maxConcurrentAgents: 3,
-  maxConcurrentAgentsPerProject: 2,        // Per-project limit (prevents one project hogging all slots)
-  maxProcessMemoryMb: 2048,                // Alert if any process exceeds this
-  maxTotalProcesses: 50,                   // Alert if total PM2 processes exceed this
-  mcpServers: [
-    { name: 'filesystem', command: 'npx', args: ['-y', '@anthropic/mcp-server-filesystem'] },
-    { name: 'puppeteer', command: 'npx', args: ['-y', '@anthropic/mcp-puppeteer', '--isolated'] }
-  ],
-  autoStart: false,                        // Legacy: use alwaysOn instead
-  selfImprovementEnabled: true,            // Deprecated: use improvementEnabled
-  appImprovementEnabled: true,             // Deprecated: use improvementEnabled
-  improvementEnabled: true,                // Allow CoS to run improvement tasks on all apps (including PortOS)
-  avatarStyle: 'svg',                      // UI preference: 'svg' | 'ascii' | 'cyber' | 'sigil' | 'esoteric' | 'nexus'
-  dynamicAvatar: true,                     // Avatar changes based on active agent context
-  // Always-on mode settings
-  alwaysOn: true,                          // CoS starts automatically and stays active
-  appReviewCooldownMs: 1800000,            // 30 min between working on same app (was 1 hour)
-  idleReviewEnabled: true,                 // Review apps for improvements when no user tasks
-  idleReviewPriority: 'MEDIUM',            // Priority for auto-generated tasks (was LOW)
-  comprehensiveAppImprovement: true,       // Deprecated: always comprehensive now
-  immediateExecution: true,                // Execute new tasks immediately, don't wait for interval
-  proactiveMode: true,                     // Be proactive about finding work
-  autonomousJobsEnabled: true,             // Enable recurring autonomous jobs (git maintenance, brain processing, etc.)
-  autonomyLevel: 'standby',                // Default autonomy level preset (standby/assistant/manager/yolo)
-  rehabilitationGracePeriodDays: 7,        // Days before auto-retrying skipped task types (learning-based)
-  completedAgentRetentionMs: 86400000,     // 24h - auto-archive completed agents from state.json after this
-  embeddingProviderId: 'lmstudio',           // Provider for memory embeddings
-  embeddingModel: '',                         // Empty = auto-detect from provider
-  autoFixThresholds: {
-    maxLinesChanged: 50,                   // Auto-approve if <= this many lines changed
-    allowedCategories: [                   // Categories that can auto-execute
-      'formatting',
-      'dry-violations',
-      'dead-code',
-      'typo-fix',
-      'import-cleanup'
-    ]
-  }
-};
-
-/**
- * Default state
- */
-const DEFAULT_STATE = {
-  running: false,
-  paused: false,                       // Pause state for always-on mode
-  pausedAt: null,                      // Timestamp when paused
-  pauseReason: null,                   // Optional reason for pause
-  config: DEFAULT_CONFIG,
-  stats: {
-    tasksCompleted: 0,
-    totalRuntime: 0,
-    agentsSpawned: 0,
-    errors: 0,
-    lastEvaluation: null,
-    lastIdleReview: null               // Track last idle review time
-  },
-  agents: {}
-};
-
-/**
- * Ensure data directories exist
- */
-async function ensureDirectories() {
-  await ensureDirs([PATHS.data, PATHS.cos, AGENTS_DIR, REPORTS_DIR, SCRIPTS_DIR]);
-}
-
-/**
- * Validate JSON string before parsing
- */
-function isValidJSON(str) {
-  if (!str || !str.trim()) return false;
-  const trimmed = str.trim();
-  // Check for basic JSON structure
-  if (!(trimmed.startsWith('{') && trimmed.endsWith('}'))) return false;
-  // Check for common corruption patterns (concatenated JSON objects)
-  if (trimmed.includes('}{')) return false;
-  return true;
-}
-
-// In-memory state cache — avoids re-reading state.json from disk on every call.
-// All mutations go through withStateLock, so the cache stays consistent.
-let stateCache = null;
-
-/**
- * Load CoS state — returns cached copy if available, reads disk only on first call
- */
-async function loadState() {
-  if (stateCache) return stateCache;
-
-  await ensureDirectories();
-
-  if (!existsSync(STATE_FILE)) {
-    stateCache = { ...DEFAULT_STATE };
-    return stateCache;
-  }
-
-  const content = await readFile(STATE_FILE, 'utf-8');
-
-  if (!isValidJSON(content)) {
-    console.log(`⚠️ Corrupted or empty state file at ${STATE_FILE}, returning default state`);
-    const backupPath = `${STATE_FILE}.corrupted.${Date.now()}`;
-    await writeFile(backupPath, content).catch(() => {});
-    console.log(`📝 Backed up corrupted state to ${backupPath}`);
-    // Cleanup old corrupted backups (keep only 3 most recent)
-    const cosDir = dirname(STATE_FILE);
-    const files = await readdir(cosDir).catch(() => []);
-    const corrupted = files
-      .filter(f => f.startsWith('state.json.corrupted.'))
-      .sort()
-      .reverse();
-    for (const old of corrupted.slice(3)) {
-      await rm(join(cosDir, old)).catch(() => {});
-    }
-    if (corrupted.length > 3) {
-      console.log(`🗑️ Cleaned up ${corrupted.length - 3} old corrupted state backups`);
-    }
-    stateCache = { ...DEFAULT_STATE };
-    return stateCache;
-  }
-
-  const state = safeJSONParse(content, null, { logError: true, context: 'CoS state' });
-  if (!state) {
-    stateCache = { ...DEFAULT_STATE };
-    return stateCache;
-  }
-
-  // Merge with defaults to ensure all fields exist
-  stateCache = {
-    ...DEFAULT_STATE,
-    ...state,
-    config: { ...DEFAULT_CONFIG, ...state.config },
-    stats: { ...DEFAULT_STATE.stats, ...state.stats }
-  };
-  return stateCache;
-}
-
-/**
- * Save CoS state — writes to disk and updates in-memory cache
- */
-async function saveState(state) {
-  await ensureDirectories();
-  stateCache = state;
-  const tmpFile = `${STATE_FILE}.tmp`;
-  await writeFile(tmpFile, JSON.stringify(state, null, 2));
-  await rename(tmpFile, STATE_FILE);
-}
+// Internal imports for functions used in this module
+import { pruneOldAgentArchives, archiveStaleAgents as _archiveStaleAgents, loadAgentIndex } from './cosAgents.js';
 
 /**
  * Get current CoS status
@@ -475,7 +93,7 @@ export async function getStatus() {
   const tasksCompleted = Math.max(state.stats.tasksCompleted, idx.size + stateOnlyCompleted);
 
   return {
-    running: daemonRunning,
+    running: isDaemonRunning(),
     paused: state.paused || false,
     pausedAt: state.pausedAt,
     pauseReason: state.pauseReason,
@@ -512,7 +130,7 @@ export async function updateConfig(updates) {
  * Start the CoS daemon
  */
 export async function start() {
-  if (daemonRunning) {
+  if (isDaemonRunning()) {
     emitLog('warn', 'CoS already running');
     return { success: false, error: 'Already running' };
   }
@@ -526,7 +144,7 @@ export async function start() {
     return s;
   });
 
-  daemonRunning = true;
+  setDaemonRunning(true);
 
   // First clean up orphaned agents (agents marked running but no live process)
   const { cleanupOrphanedAgents } = await import('./subAgentSpawner.js');
@@ -539,7 +157,7 @@ export async function start() {
   await resetOrphanedTasks();
 
   // Archive stale completed agents from state.json on startup
-  const { archived } = await archiveStaleAgents().catch(() => ({ archived: 0 }));
+  const { archived } = await _archiveStaleAgents().catch(() => ({ archived: 0 }));
   if (archived > 0) {
     emitLog('info', `📦 Startup: archived ${archived} stale agent(s) from state`);
   }
@@ -559,7 +177,7 @@ export async function start() {
         emitLog('info', `🧹 Periodic cleanup: ${cleaned} orphaned agent(s)`);
       }
       await resetOrphanedTasks();
-      const { archived } = await archiveStaleAgents().catch(() => ({ archived: 0 }));
+      const { archived } = await _archiveStaleAgents().catch(() => ({ archived: 0 }));
       if (archived > 0) {
         emitLog('info', `📦 Auto-archived ${archived} stale agent(s) from state`);
       }
@@ -651,7 +269,7 @@ export async function start() {
   // Queue due improvement tasks shortly after startup (not during initial eval
   // to avoid overwhelming fresh installs, but soon enough to not stall)
   setTimeout(() => {
-    if (!daemonRunning) return;
+    if (!isDaemonRunning()) return;
     loadState().then(async (state) => {
       if (!state.config.idleReviewEnabled) return;
       const cosTaskData = await getCosTasks();
@@ -667,7 +285,7 @@ export async function start() {
  * Stop the CoS daemon
  */
 export async function stop() {
-  if (!daemonRunning) {
+  if (!isDaemonRunning()) {
     return { success: false, error: 'Not running' };
   }
 
@@ -685,7 +303,7 @@ export async function stop() {
     await saveState(state);
   });
 
-  daemonRunning = false;
+  setDaemonRunning(false);
   cosEvents.emit('status', { running: false });
   return { success: true };
 }
@@ -735,7 +353,7 @@ export async function resume() {
   });
 
   // Trigger immediate task dequeue on resume (outside lock to avoid holding it)
-  if (result.success && daemonRunning) {
+  if (result.success && isDaemonRunning()) {
     setTimeout(() => dequeueNextTask(), 500);
   }
 
@@ -943,7 +561,7 @@ function isWithinProjectLimit(task, agentsByProject, perProjectLimit) {
  * 3. Generate idle review task if no other work
  */
 export async function evaluateTasks() {
-  if (!daemonRunning) return;
+  if (!isDaemonRunning()) return;
 
   // Check if paused - skip evaluation if so
   const paused = await isPaused();
@@ -2275,7 +1893,7 @@ async function generateManagedAppImprovementTaskForType(taskType, app, state, { 
  * Run system health check
  */
 export async function runHealthCheck() {
-  if (!daemonRunning) return;
+  if (!isDaemonRunning()) return;
 
   const state = await loadState();
   const issues = [];
@@ -2446,957 +2064,14 @@ export async function getScript(name) {
   return { name, content, metadata };
 }
 
-/**
- * Register a spawned agent
- */
-export async function registerAgent(agentId, taskId, metadata = {}) {
-  return withStateLock(async () => {
-    const state = await loadState();
-
-    state.agents[agentId] = {
-      id: agentId,
-      taskId,
-      status: 'running',
-      startedAt: new Date().toISOString(),
-      metadata,
-      output: []
-    };
-
-    state.stats.agentsSpawned++;
-    await saveState(state);
-
-    cosEvents.emit('agent:spawned', state.agents[agentId]);
-    return state.agents[agentId];
-  });
-}
-
-/**
- * Update agent status
- */
-export async function updateAgent(agentId, updates) {
-  return withStateLock(async () => {
-    const state = await loadState();
-
-    if (!state.agents[agentId]) {
-      return null;
-    }
-
-    // Merge metadata if present in updates
-    if (updates.metadata) {
-      state.agents[agentId] = {
-        ...state.agents[agentId],
-        ...updates,
-        metadata: { ...state.agents[agentId].metadata, ...updates.metadata }
-      };
-    } else {
-      state.agents[agentId] = { ...state.agents[agentId], ...updates };
-    }
-    await saveState(state);
-
-    cosEvents.emit('agent:updated', state.agents[agentId]);
-    return state.agents[agentId];
-  });
-}
-
-/**
- * Mark agent as completed
- */
-export async function completeAgent(agentId, result = {}) {
-  return withStateLock(async () => {
-    const state = await loadState();
-
-    if (!state.agents[agentId]) {
-      return null;
-    }
-
-    state.agents[agentId] = {
-      ...state.agents[agentId],
-      status: 'completed',
-      completedAt: new Date().toISOString(),
-      result
-    };
-
-    if (result.success) {
-      state.stats.tasksCompleted++;
-    } else {
-      state.stats.errors = (state.stats.errors || 0) + 1;
-    }
-
-    await saveState(state);
-    cosEvents.emit('agent:completed', state.agents[agentId]);
-    cosEvents.emit('agent:updated', state.agents[agentId]);
-
-    // Determine date bucket from completedAt
-    const dateStr = state.agents[agentId].completedAt.slice(0, 10);
-    const bucketDir = join(AGENTS_DIR, dateStr);
-    await ensureDir(bucketDir);
-
-    // Write metadata to flat dir first (may already have output.txt/prompt.txt there)
-    const flatDir = join(AGENTS_DIR, agentId);
-    if (!existsSync(flatDir)) {
-      await ensureDir(flatDir);
-    }
-    const { output: _output, ...agentWithoutOutput } = state.agents[agentId];
-    await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2));
-
-    // Move entire agent dir into date bucket (atomic on same filesystem)
-    const targetDir = join(bucketDir, agentId);
-    if (!existsSync(targetDir)) {
-      await rename(flatDir, targetDir).catch(async () => {
-        // Fallback for cross-filesystem: copy files then remove
-        await ensureDir(targetDir);
-        const files = await readdir(flatDir);
-        for (const file of files) {
-          const content = await readFile(join(flatDir, file));
-          await writeFile(join(targetDir, file), content);
-        }
-        await rm(flatDir, { recursive: true });
-      });
-    }
-
-    // Update index
-    const idx = await loadAgentIndex();
-    idx.set(agentId, dateStr);
-    await saveAgentIndex();
-
-    return state.agents[agentId];
-  });
-}
-
-/**
- * Append output to agent
- */
-export async function appendAgentOutput(agentId, line) {
-  const result = await withStateLock(async () => {
-    const state = await loadState();
-
-    if (!state.agents[agentId]) {
-      return null;
-    }
-
-    state.agents[agentId].output.push({
-      timestamp: new Date().toISOString(),
-      line
-    });
-
-    // Trim to last 1000 lines in state
-    if (state.agents[agentId].output.length > 1000) {
-      state.agents[agentId].output = state.agents[agentId].output.slice(-1000);
-    }
-
-    await saveState(state);
-    return state.agents[agentId];
-  });
-
-  if (result) {
-    cosEvents.emit('agent:output', { agentId, line });
-  }
-
-  return result;
-}
-
-/**
- * Get running agents from state (completed agents loaded on-demand via getAgentsByDate)
- */
-export async function getAgents() {
-  const state = await loadState();
-  return Object.values(state.agents);
-}
-
-/**
- * Get available agent date buckets with counts, sorted descending
- */
-export async function getAgentDates() {
-  const idx = await loadAgentIndex();
-  const dateCounts = {};
-  for (const date of idx.values()) {
-    dateCounts[date] = (dateCounts[date] || 0) + 1;
-  }
-  return Object.entries(dateCounts)
-    .map(([date, count]) => ({ date, count }))
-    .sort((a, b) => b.date.localeCompare(a.date));
-}
-
-/**
- * Get completed agents for a specific date bucket
- */
-export async function getAgentsByDate(date) {
-  const dateDir = join(AGENTS_DIR, date);
-  if (!existsSync(dateDir)) return [];
-
-  const entries = await readdir(dateDir, { withFileTypes: true });
-  const agentDirs = entries.filter(e => e.isDirectory() && e.name.startsWith('agent-'));
-  const agents = [];
-
-  // Batch reads in chunks of 50 to avoid fd exhaustion on large date buckets
-  const BATCH_SIZE = 50;
-  for (let i = 0; i < agentDirs.length; i += BATCH_SIZE) {
-    const batch = agentDirs.slice(i, i + BATCH_SIZE);
-    const reads = batch.map(async (entry) => {
-      const metaPath = join(dateDir, entry.name, 'metadata.json');
-      const content = await readFile(metaPath, 'utf-8').catch(() => null);
-      if (!content) return;
-      const raw = safeJSONParse(content, null);
-      if (!raw) return;
-      const id = raw.id || raw.agentId || entry.name;
-      const { output, ...rest } = raw;
-      agents.push({ ...rest, id, status: raw.status || 'completed' });
-    });
-    await Promise.allSettled(reads);
-  }
-
-  return agents.sort((a, b) => new Date(b.completedAt || 0) - new Date(a.completedAt || 0));
-}
-
-/**
- * Get agent by ID with full output from file
- */
-export async function getAgent(agentId) {
-  const state = await loadState();
-  let agent = state.agents[agentId];
-
-  // Fall back to disk metadata via index if not in state
-  if (!agent) {
-    const idx = await loadAgentIndex();
-    const dateStr = idx.get(agentId);
-    if (dateStr) {
-      const metaPath = join(AGENTS_DIR, dateStr, agentId, 'metadata.json');
-      const content = await readFile(metaPath, 'utf-8').catch(() => null);
-      if (content) {
-        const raw = safeJSONParse(content, null);
-        if (raw) {
-          const { output, ...rest } = raw;
-          agent = { ...rest, id: raw.id || raw.agentId || agentId, status: raw.status || 'completed' };
-        }
-      }
-    }
-  }
-  if (!agent) return null;
-
-  // For completed agents, read full output from file
-  if (agent.status === 'completed') {
-    const dateStr = agent.completedAt?.slice(0, 10);
-    const agentDir = dateStr ? getAgentDir(agentId, dateStr) : getAgentDir(agentId);
-    const outputFile = join(agentDir, 'output.txt');
-    if (existsSync(outputFile)) {
-      const fullOutput = await readFile(outputFile, 'utf-8');
-      const lines = fullOutput.split('\n').filter(line => line.trim());
-      return {
-        ...agent,
-        output: lines.map(line => ({ line, timestamp: agent.completedAt }))
-      };
-    }
-  }
-
-  return agent;
-}
-
-/**
- * Terminate an agent (will be handled by spawner)
- */
-export async function terminateAgent(agentId) {
-  // Emit event to kill the process FIRST
-  cosEvents.emit('agent:terminate', agentId);
-  // The spawner will handle marking the agent as completed after termination
-  return { success: true, agentId };
-}
-
-/**
- * Force kill an agent with SIGKILL (immediate, no graceful shutdown)
- */
-export async function killAgent(agentId) {
-  const { killAgent: killAgentFromSpawner } = await import('./subAgentSpawner.js');
-  return killAgentFromSpawner(agentId);
-}
-
-/**
- * Send a BTW (additional context) message to a running agent.
- * Writes the message to a file in the agent's workspace and tracks it in state.
- */
-export async function sendBtwToAgent(agentId, message) {
-  // Single locked read to validate agent and extract workspacePath
-  const agentInfo = await withStateLock(async () => {
-    const state = await loadState();
-    const agent = state.agents[agentId];
-    if (!agent) return { error: 'Agent not found' };
-    if (agent.status !== 'running') return { error: 'Agent is not running' };
-    if (!agent.metadata?.workspacePath) return { error: 'Agent has no workspace path' };
-    return { workspacePath: agent.metadata.workspacePath };
-  });
-
-  if (agentInfo.error) return agentInfo;
-
-  // Send to runner to write the BTW.md file
-  const { sendBtwToAgent: sendViaRunner } = await import('./cosRunnerClient.js');
-  const result = await sendViaRunner(agentId, message);
-
-  // Track in agent state (cap at 50 messages)
-  const timestamp = new Date().toISOString();
-  await withStateLock(async () => {
-    const state = await loadState();
-    if (!state.agents[agentId]) return;
-    if (!state.agents[agentId].btwMessages) {
-      state.agents[agentId].btwMessages = [];
-    }
-    state.agents[agentId].btwMessages.push({ message, timestamp });
-    if (state.agents[agentId].btwMessages.length > 50) {
-      state.agents[agentId].btwMessages = state.agents[agentId].btwMessages.slice(-50);
-    }
-    await saveState(state);
-  });
-
-  cosEvents.emit('agent:btw', { agentId, message, timestamp });
-  return { success: true, ...result };
-}
-
-/**
- * Get process stats for an agent (CPU, memory)
- */
-export async function getAgentProcessStats(agentId) {
-  const { getAgentProcessStats: getStatsFromSpawner } = await import('./subAgentSpawner.js');
-  return getStatsFromSpawner(agentId);
-}
-
-/**
- * Check if a PID is still running
- */
-async function isPidAlive(pid) {
-  if (!pid) return false;
-  try {
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Cleanup zombie agents - agents marked as running but whose process is dead
- */
-export async function cleanupZombieAgents() {
-  // Check local tracking maps
-  const { getActiveAgentIds } = await import('./subAgentSpawner.js');
-  const activeIds = getActiveAgentIds();
-
-  // Also check with the CoS runner for agents it's actively tracking
-  const { getActiveAgentsFromRunner } = await import('./cosRunnerClient.js');
-  const runnerAgents = await getActiveAgentsFromRunner().catch(() => []);
-  const runnerAgentIds = new Set(runnerAgents.map(a => a.id));
-
-  return withStateLock(async () => {
-    const state = await loadState();
-    const runningAgents = Object.values(state.agents).filter(a => a.status === 'running');
-    const cleaned = [];
-
-    for (const agent of runningAgents) {
-      // Skip if tracked in local maps or runner
-      if (activeIds.includes(agent.id) || runnerAgentIds.has(agent.id)) {
-        continue;
-      }
-
-      // If agent has a PID, verify the process is actually dead
-      if (agent.pid) {
-        const alive = await isPidAlive(agent.pid);
-        if (alive) {
-          // Process is still running, don't mark as zombie
-          continue;
-        }
-      } else {
-        // No PID yet - agent might still be initializing
-        // Give it a 30 second grace period before marking as zombie
-        const startedAt = agent.startedAt ? new Date(agent.startedAt).getTime() : 0;
-        const ageMs = Date.now() - startedAt;
-        if (ageMs < 30000) {
-          // Agent is less than 30 seconds old and has no PID - still initializing
-          continue;
-        }
-      }
-
-      // Agent is not tracked anywhere and process is dead (or no PID after grace period) - it's a zombie
-      console.log(`🧟 Zombie agent detected: ${agent.id} (PID ${agent.pid || 'unknown'} not running)`);
-      state.agents[agent.id] = {
-        ...agent,
-        status: 'completed',
-        completedAt: new Date().toISOString(),
-        result: { success: false, error: 'Agent process terminated unexpectedly' }
-      };
-      cleaned.push(agent.id);
-    }
-
-    if (cleaned.length > 0) {
-      await saveState(state);
-
-      // Persist zombie-cleaned agents to date-bucketed dirs and update index
-      const idx = await loadAgentIndex();
-      for (const agentId of cleaned) {
-        const agent = state.agents[agentId];
-        const dateStr = agent.completedAt?.slice(0, 10);
-        if (!dateStr) continue;
-        const bucketDir = join(AGENTS_DIR, dateStr);
-        await ensureDir(bucketDir);
-
-        const flatDir = join(AGENTS_DIR, agentId);
-        const { output, ...agentWithoutOutput } = agent;
-
-        // Ensure metadata is written before move
-        if (!existsSync(flatDir)) await ensureDir(flatDir);
-        await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {});
-
-        // Move to date bucket
-        const targetDir = join(bucketDir, agentId);
-        if (!existsSync(targetDir)) {
-          await rename(flatDir, targetDir).catch(async () => {
-            await ensureDir(targetDir);
-            const files = await readdir(flatDir);
-            for (const file of files) {
-              const content = await readFile(join(flatDir, file));
-              await writeFile(join(targetDir, file), content);
-            }
-            await rm(flatDir, { recursive: true });
-          });
-        }
-
-        idx.set(agentId, dateStr);
-      }
-      await saveAgentIndex();
-
-      console.log(`🧹 Cleaned up ${cleaned.length} zombie agents: ${cleaned.join(', ')}`);
-      cosEvents.emit('agents:changed', { action: 'zombie-cleanup', cleaned });
-    }
-
-    return { cleaned, count: cleaned.length };
-  });
-}
-
-/**
- * Delete a single agent from state and disk
- */
-export async function deleteAgent(agentId) {
-  return withStateLock(async () => {
-    const state = await loadState();
-    const idx = await loadAgentIndex();
-
-    const inState = !!state.agents[agentId];
-    const inIndex = idx.has(agentId);
-    if (!inState && !inIndex) {
-      return { error: 'Agent not found' };
-    }
-
-    delete state.agents[agentId];
-    await saveState(state);
-
-    // Remove from disk (date-bucketed or flat)
-    const agentDir = getAgentDir(agentId);
-    if (existsSync(agentDir)) {
-      await rm(agentDir, { recursive: true }).catch(() => {});
-    }
-
-    // Remove from index
-    idx.delete(agentId);
-    await saveAgentIndex();
-
-    cosEvents.emit('agents:changed', { action: 'deleted', agentId });
-    return { success: true, agentId };
-  });
-}
-
-/**
- * Submit feedback for a completed agent
- * @param {string} agentId - Agent ID
- * @param {object} feedback - { rating: 'positive'|'negative'|'neutral', comment?: string }
- */
-export async function submitAgentFeedback(agentId, feedback) {
-  return withStateLock(async () => {
-    const state = await loadState();
-    const feedbackData = {
-      rating: feedback.rating,
-      comment: feedback.comment || null,
-      submittedAt: new Date().toISOString()
-    };
-
-    // Try state first (recently completed agents still in state)
-    if (state.agents[agentId]) {
-      const agent = state.agents[agentId];
-      if (agent.status !== 'completed') {
-        return { error: 'Can only submit feedback for completed agents' };
-      }
-      state.agents[agentId].feedback = feedbackData;
-      await saveState(state);
-
-      // Also update on-disk metadata
-      const agentDir = getAgentDir(agentId);
-      const metaPath = join(agentDir, 'metadata.json');
-      if (existsSync(metaPath)) {
-        const content = await readFile(metaPath, 'utf-8').catch(() => null);
-        if (content) {
-          const raw = safeJSONParse(content, null);
-          if (raw) {
-            raw.feedback = feedbackData;
-            await writeFile(metaPath, JSON.stringify(raw, null, 2)).catch(() => {});
-          }
-        }
-      }
-
-      emitLog('info', `Feedback received for agent ${agentId}: ${feedback.rating}`, { agentId, rating: feedback.rating });
-      cosEvents.emit('agent:feedback', { agentId, feedback: feedbackData });
-      return { success: true, agent: state.agents[agentId] };
-    }
-
-    // Agent not in state — look up from disk via index
-    const idx = await loadAgentIndex();
-    const dateStr = idx.get(agentId);
-    if (!dateStr) return { error: 'Agent not found' };
-
-    const metaPath = join(AGENTS_DIR, dateStr, agentId, 'metadata.json');
-    const content = await readFile(metaPath, 'utf-8').catch(() => null);
-    if (!content) return { error: 'Agent not found' };
-
-    const raw = safeJSONParse(content, null);
-    if (!raw) return { error: 'Agent not found' };
-
-    raw.feedback = feedbackData;
-    await writeFile(metaPath, JSON.stringify(raw, null, 2));
-
-    emitLog('info', `Feedback received for agent ${agentId}: ${feedback.rating}`, { agentId, rating: feedback.rating });
-    cosEvents.emit('agent:feedback', { agentId, feedback: feedbackData });
-    return { success: true, agent: { ...raw, id: agentId } };
-  });
-}
-
-/**
- * Get aggregated feedback statistics
- */
-export async function getFeedbackStats() {
-  const state = await loadState();
-  const agents = Object.values(state.agents);
-
-  const withFeedback = agents.filter(a => a.feedback);
-  const positive = withFeedback.filter(a => a.feedback.rating === 'positive').length;
-  const negative = withFeedback.filter(a => a.feedback.rating === 'negative').length;
-  const neutral = withFeedback.filter(a => a.feedback.rating === 'neutral').length;
-
-  // Group by task type
-  const byTaskType = {};
-  withFeedback.forEach(a => {
-    const taskType = extractTaskType(a.metadata?.taskDescription);
-    if (!byTaskType[taskType]) {
-      byTaskType[taskType] = { positive: 0, negative: 0, neutral: 0, total: 0 };
-    }
-    byTaskType[taskType][a.feedback.rating]++;
-    byTaskType[taskType].total++;
-  });
-
-  // Recent feedback (last 10 with comments)
-  const recentWithComments = withFeedback
-    .filter(a => a.feedback.comment)
-    .sort((a, b) => new Date(b.feedback.submittedAt) - new Date(a.feedback.submittedAt))
-    .slice(0, 10)
-    .map(a => ({
-      agentId: a.id,
-      taskDescription: a.metadata?.taskDescription,
-      rating: a.feedback.rating,
-      comment: a.feedback.comment,
-      submittedAt: a.feedback.submittedAt
-    }));
-
-  const satisfactionRate = withFeedback.length > 0
-    ? Math.round((positive / withFeedback.length) * 100)
-    : null;
-
-  return {
-    total: withFeedback.length,
-    positive,
-    negative,
-    neutral,
-    satisfactionRate,
-    byTaskType,
-    recentWithComments
-  };
-}
-
-// Helper to extract task type from description (mirrors client-side logic)
-function extractTaskType(description) {
-  if (!description) return 'general';
-  const d = description.toLowerCase();
-  if (d.includes('fix') || d.includes('bug') || d.includes('error') || d.includes('issue')) return 'bug-fix';
-  if (d.includes('refactor') || d.includes('clean up') || d.includes('improve') || d.includes('optimize')) return 'refactor';
-  if (d.includes('test')) return 'testing';
-  if (d.includes('document') || d.includes('readme') || d.includes('docs')) return 'documentation';
-  if (d.includes('review') || d.includes('audit')) return 'code-review';
-  if (d.includes('mobile') || d.includes('responsive')) return 'mobile-responsive';
-  if (d.includes('security') || d.includes('vulnerability')) return 'security';
-  if (d.includes('performance') || d.includes('speed')) return 'performance';
-  if (d.includes('ui') || d.includes('ux') || d.includes('design') || d.includes('style')) return 'ui-ux';
-  if (d.includes('api') || d.includes('endpoint') || d.includes('route')) return 'api';
-  if (d.includes('database') || d.includes('migration')) return 'database';
-  if (d.includes('deploy') || d.includes('ci') || d.includes('cd')) return 'devops';
-  if (d.includes('investigate') || d.includes('debug')) return 'investigation';
-  if (d.includes('self-improvement') || d.includes('feature idea')) return 'self-improvement';
-  return 'feature';
-}
-
-/**
- * Generate daily report
- */
-export async function generateReport(date = null) {
-  const reportDate = date || new Date().toISOString().split('T')[0];
-  const state = await loadState();
-
-  // Filter agents completed on this date
-  const completedAgents = Object.values(state.agents).filter(a => {
-    if (!a.completedAt) return false;
-    return a.completedAt.startsWith(reportDate);
-  });
-
-  const report = {
-    date: reportDate,
-    generated: new Date().toISOString(),
-    summary: {
-      tasksCompleted: completedAgents.filter(a => a.result?.success).length,
-      tasksFailed: completedAgents.filter(a => !a.result?.success).length,
-      totalAgents: completedAgents.length
-    },
-    agents: completedAgents.map(a => ({
-      id: a.id,
-      taskId: a.taskId,
-      success: a.result?.success || false,
-      duration: a.completedAt && a.startedAt
-        ? new Date(a.completedAt) - new Date(a.startedAt)
-        : 0
-    }))
-  };
-
-  // Save report
-  const reportFile = join(REPORTS_DIR, `${reportDate}.json`);
-  await writeFile(reportFile, JSON.stringify(report, null, 2));
-
-  return report;
-}
-
-/**
- * Get report for a date
- */
-export async function getReport(date) {
-  const reportFile = join(REPORTS_DIR, `${date}.json`);
-
-  if (!existsSync(reportFile)) {
-    return null;
-  }
-
-  const content = await readFile(reportFile, 'utf-8');
-  return safeJSONParse(content, null, { logError: true, context: `report ${date}` });
-}
-
-/**
- * Get today's report
- */
-export async function getTodayReport() {
-  const today = new Date().toISOString().split('T')[0];
-  return getReport(today) || generateReport(today);
-}
-
-/**
- * List all reports
- */
-export async function listReports() {
-  await ensureDirectories();
-
-  const files = await readdir(REPORTS_DIR);
-  return files
-    .filter(f => f.endsWith('.json'))
-    .map(f => f.replace('.json', ''))
-    .sort()
-    .reverse();
-}
-
-/**
- * List all briefings (markdown files in reports dir)
- */
-export async function listBriefings() {
-  await ensureDirectories();
-
-  const files = await readdir(REPORTS_DIR);
-  return files
-    .filter(f => f.endsWith('-briefing.md'))
-    .map(f => {
-      const date = f.replace('-briefing.md', '');
-      return { date, filename: f };
-    })
-    .sort((a, b) => b.date.localeCompare(a.date));
-}
-
-/**
- * Get a briefing by date
- */
-export async function getBriefing(date) {
-  const briefingFile = join(REPORTS_DIR, `${date}-briefing.md`);
-
-  if (!existsSync(briefingFile)) {
-    return null;
-  }
-
-  const content = await readFile(briefingFile, 'utf-8');
-  return { date, content };
-}
-
-/**
- * Get the latest briefing
- */
-export async function getLatestBriefing() {
-  const briefings = await listBriefings();
-  if (briefings.length === 0) return null;
-  return getBriefing(briefings[0].date);
-}
-
-/**
- * Get today's activity summary
- * Returns completed tasks, success rate, time worked, and top accomplishments
- */
-export async function getTodayActivity() {
-  const state = await loadState();
-  const today = new Date().toISOString().split('T')[0];
-
-  // Filter agents completed today
-  const todayAgents = Object.values(state.agents).filter(a => {
-    if (!a.completedAt) return false;
-    return a.completedAt.startsWith(today);
-  });
-
-  const succeeded = todayAgents.filter(a => a.result?.success);
-  const failed = todayAgents.filter(a => !a.result?.success);
-
-  // Calculate total time worked (sum of agent durations)
-  const totalDurationMs = todayAgents.reduce((sum, a) => {
-    const duration = a.result?.duration || 0;
-    return sum + duration;
-  }, 0);
-
-  // Get currently running agents
-  const runningAgents = Object.values(state.agents).filter(a => a.status === 'running');
-  const activeTimeMs = runningAgents.reduce((sum, a) => {
-    if (!a.startedAt) return sum;
-    return sum + (Date.now() - new Date(a.startedAt).getTime());
-  }, 0);
-
-  // Get top accomplishments (successful tasks with description snippets)
-  const accomplishments = succeeded
-    .map(a => ({
-      id: a.id,
-      taskId: a.taskId,
-      description: a.metadata?.taskDescription?.substring(0, 100) || a.taskId,
-      taskType: a.metadata?.analysisType || a.metadata?.taskType || 'task',
-      duration: a.result?.duration || 0,
-      completedAt: a.completedAt
-    }))
-    .sort((a, b) => new Date(b.completedAt) - new Date(a.completedAt))
-    .slice(0, 5);
-
-  // Calculate success rate
-  const successRate = todayAgents.length > 0
-    ? Math.round((succeeded.length / todayAgents.length) * 100)
-    : 0;
-
-  return {
-    date: today,
-    stats: {
-      completed: todayAgents.length,
-      succeeded: succeeded.length,
-      failed: failed.length,
-      successRate,
-      running: runningAgents.length
-    },
-    time: {
-      totalDurationMs,
-      totalDuration: formatDuration(totalDurationMs),
-      activeDurationMs: activeTimeMs,
-      activeDuration: formatDuration(activeTimeMs),
-      combinedMs: totalDurationMs + activeTimeMs,
-      combined: formatDuration(totalDurationMs + activeTimeMs)
-    },
-    accomplishments,
-    lastEvaluation: state.stats.lastEvaluation,
-    isRunning: daemonRunning,
-    isPaused: state.paused
-  };
-}
-
-/**
- * Get recent completed tasks across all days
- * @param {number} limit - Maximum number of tasks to return (default: 10)
- * @returns {Object} Recent tasks with metadata
- */
-export async function getRecentTasks(limit = 10) {
-  const state = await loadState();
-
-  // Get all completed agents, sorted by completion time (newest first)
-  const completedAgents = Object.values(state.agents)
-    .filter(a => a.status === 'completed' && a.completedAt)
-    .sort((a, b) => new Date(b.completedAt) - new Date(a.completedAt))
-    .slice(0, limit);
-
-  // Transform to compact task summaries
-  const tasks = completedAgents.map(a => ({
-    id: a.id,
-    taskId: a.taskId,
-    description: a.metadata?.taskDescription?.substring(0, 120) || a.taskId,
-    taskType: a.metadata?.analysisType || a.metadata?.taskType || 'task',
-    app: a.metadata?.app || null,
-    success: a.result?.success || false,
-    duration: a.result?.duration || 0,
-    durationFormatted: formatDuration(a.result?.duration || 0),
-    completedAt: a.completedAt,
-    // Add relative time (e.g., "2h ago", "yesterday")
-    completedRelative: formatRelativeTime(a.completedAt)
-  }));
-
-  // Calculate summary stats
-  const successCount = tasks.filter(t => t.success).length;
-  const failCount = tasks.filter(t => !t.success).length;
-
-  return {
-    tasks,
-    summary: {
-      total: tasks.length,
-      succeeded: successCount,
-      failed: failCount,
-      successRate: tasks.length > 0 ? Math.round((successCount / tasks.length) * 100) : 0
-    }
-  };
-}
-
-/**
- * Format a timestamp as relative time (e.g., "2h ago", "yesterday")
- * @param {string} timestamp - ISO timestamp
- * @returns {string} Relative time string
- */
-function formatRelativeTime(timestamp) {
-  const now = new Date();
-  const then = new Date(timestamp);
-  const diffMs = now - then;
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return 'just now';
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays === 1) return 'yesterday';
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return then.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
-
-/**
- * Archive stale completed agents from state.json.
- * Completed agents are already persisted to per-agent metadata files on disk
- * (metadata.json) by completeAgent(), so removing them from state.json only
- * reduces the size of the in-memory state and the state.json file.
- * Archived agents remain accessible via the date index (getAgentsByDate()/getAgent()),
- * which loads them from disk as needed; getAgents() returns only state.agents.
- */
-export async function archiveStaleAgents() {
-  return withStateLock(async () => {
-    const state = await loadState();
-    const retentionMs = state.config.completedAgentRetentionMs ?? 86400000;
-    const cutoff = Date.now() - retentionMs;
-
-    const staleIds = Object.keys(state.agents).filter(id => {
-      const agent = state.agents[id];
-      if (agent.status !== 'completed') return false;
-      const completedAt = agent.completedAt ? new Date(agent.completedAt).getTime() : 0;
-      return completedAt > 0 && completedAt < cutoff;
-    });
-
-    if (staleIds.length === 0) return { archived: 0 };
-
-    const idx = await loadAgentIndex();
-
-    for (const id of staleIds) {
-      // Ensure agent is persisted to date-bucketed disk before removing from state
-      if (!idx.has(id)) {
-        const agent = state.agents[id];
-        const dateStr = agent.completedAt?.slice(0, 10);
-        if (!dateStr) continue;
-        const bucketDir = join(AGENTS_DIR, dateStr);
-        await ensureDir(bucketDir);
-
-        const { output, ...agentWithoutOutput } = agent;
-        const flatDir = join(AGENTS_DIR, id);
-        const targetDir = join(bucketDir, id);
-
-        if (existsSync(flatDir) && !existsSync(targetDir)) {
-          // Write metadata then move (with cross-filesystem fallback)
-          await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {});
-          await rename(flatDir, targetDir).catch(async () => {
-            await ensureDir(targetDir);
-            const files = await readdir(flatDir).catch(() => []);
-            for (const file of files) {
-              const content = await readFile(join(flatDir, file)).catch(() => null);
-              if (content !== null) await writeFile(join(targetDir, file), content);
-            }
-            await rm(flatDir, { recursive: true }).catch(() => {});
-          });
-          if (!existsSync(targetDir)) continue; // Skip index update if move failed
-        } else if (!existsSync(targetDir)) {
-          await ensureDir(targetDir);
-          await writeFile(join(targetDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {});
-        }
-
-        idx.set(id, dateStr);
-      }
-
-      delete state.agents[id];
-    }
-
-    await saveState(state);
-    await saveAgentIndex();
-    console.log(`📦 Archived ${staleIds.length} stale agents from state.json (retained on disk)`);
-    cosEvents.emit('agents:changed', { action: 'auto-archive', archived: staleIds.length });
-    return { archived: staleIds.length };
-  });
-}
-
-/**
- * Clear completed agents from state, cache, and disk
- */
-export async function clearCompletedAgents() {
-  return withStateLock(async () => {
-    const state = await loadState();
-    const idx = await loadAgentIndex();
-
-    // Remove completed agents from state
-    const stateCompleted = Object.keys(state.agents).filter(
-      id => state.agents[id].status === 'completed'
-    );
-    for (const id of stateCompleted) {
-      delete state.agents[id];
-    }
-    await saveState(state);
-
-    // Collect all unique dates from index, then remove date bucket dirs
-    const dates = new Set(idx.values());
-    const totalCleared = idx.size + stateCompleted.filter(id => !idx.has(id)).length;
-
-    const removals = [...dates].map(date => {
-      const dateDir = join(AGENTS_DIR, date);
-      return existsSync(dateDir)
-        ? rm(dateDir, { recursive: true }).catch(() => {})
-        : Promise.resolve();
-    });
-    await Promise.all(removals);
-
-    // Clear index
-    idx.clear();
-    await saveAgentIndex();
-
-    return { cleared: totalCleared };
-  });
-}
+// Agent and report functions are now in cosAgents.js and cosReports.js
+// Re-exported above for backward compat with `import * as cos from './cos.js'`
 
 /**
  * Check if daemon is running
  */
 export function isRunning() {
-  return daemonRunning;
+  return isDaemonRunning();
 }
 
 /**
@@ -3501,7 +2176,7 @@ export async function addTask(taskData, taskType = 'user', { raw = false } = {})
  * This bypasses the evaluation interval for user-submitted tasks so they start instantly.
  */
 async function tryImmediateSpawn(task) {
-  if (!daemonRunning) return;
+  if (!isDaemonRunning()) return;
 
   const paused = await isPaused();
   if (paused) return;
@@ -3544,7 +2219,7 @@ async function tryImmediateSpawn(task) {
  * Returns silently when idle — no log noise.
  */
 async function dequeueNextTask() {
-  if (!daemonRunning) return;
+  if (!isDaemonRunning()) return;
 
   const paused = await isPaused();
   if (paused) return;
@@ -3999,7 +2674,7 @@ function clearSpawningJob(jobId) {
  * Execute a scheduled autonomous job and re-register its timer.
  */
 async function executeScheduledJob(jobId) {
-  if (!daemonRunning) return;
+  if (!isDaemonRunning()) return;
 
   const paused = await isPaused();
   if (paused) {
@@ -4140,7 +2815,7 @@ async function unregisterJobSchedules() {
  * When it fires, queues eligible improvement tasks and re-schedules.
  */
 async function scheduleNextImprovementCheck() {
-  if (!daemonRunning) return;
+  if (!isDaemonRunning()) return;
 
   const taskSchedule = await import('./taskSchedule.js');
   const upcoming = await taskSchedule.getUpcomingTasks(1);
@@ -4159,7 +2834,7 @@ async function scheduleNextImprovementCheck() {
     type: 'once',
     delayMs: Math.max(delayMs, 1000),
     handler: async () => {
-      if (!daemonRunning) return;
+      if (!isDaemonRunning()) return;
       const paused = await isPaused();
       if (paused) {
         await scheduleNextImprovementCheck();
@@ -4224,32 +2899,32 @@ async function init() {
 
   // Event-driven triggers: task/file changes → dequeueNextTask
   cosEvents.on('tasks:changed', (data) => {
-    if (daemonRunning && data?.action === 'added') setImmediate(() => dequeueNextTask());
+    if (isDaemonRunning() && data?.action === 'added') setImmediate(() => dequeueNextTask());
   });
 
   cosEvents.on('tasks:user:added', () => {
-    if (daemonRunning) setImmediate(() => dequeueNextTask());
+    if (isDaemonRunning()) setImmediate(() => dequeueNextTask());
   });
 
   cosEvents.on('tasks:cos:added', () => {
-    if (daemonRunning) setImmediate(() => dequeueNextTask());
+    if (isDaemonRunning()) setImmediate(() => dequeueNextTask());
   });
 
   cosEvents.on('task:on-demand-requested', () => {
-    if (daemonRunning) setImmediate(() => dequeueNextTask());
+    if (isDaemonRunning()) setImmediate(() => dequeueNextTask());
   });
 
   // Autonomous job lifecycle → re-register/cancel individual job timers
   cosEvents.on('jobs:toggled', async ({ id }) => {
-    if (daemonRunning) await registerSingleJobSchedule(id);
+    if (isDaemonRunning()) await registerSingleJobSchedule(id);
   });
 
   cosEvents.on('jobs:updated', async ({ id }) => {
-    if (daemonRunning) await registerSingleJobSchedule(id);
+    if (isDaemonRunning()) await registerSingleJobSchedule(id);
   });
 
   cosEvents.on('jobs:created', async ({ id }) => {
-    if (daemonRunning) await registerSingleJobSchedule(id);
+    if (isDaemonRunning()) await registerSingleJobSchedule(id);
   });
 
   cosEvents.on('jobs:deleted', async ({ id }) => {
@@ -4258,7 +2933,7 @@ async function init() {
 
   // Schedule changes → re-compute next improvement check
   cosEvents.on('schedule:changed', async () => {
-    if (daemonRunning) await scheduleNextImprovementCheck();
+    if (isDaemonRunning()) await scheduleNextImprovementCheck();
   });
 
   const state = await loadState();

--- a/server/services/cosAgents.js
+++ b/server/services/cosAgents.js
@@ -6,229 +6,229 @@
  * date-bucketed archival, zombie cleanup, feedback, and index management.
  */
 
-import { readFile, writeFile, rename, readdir, rm, stat } from 'fs/promises'
-import { existsSync } from 'fs'
-import { join } from 'path'
-import { cosEvents, emitLog } from './cosEvents.js'
-import { loadState, saveState, withStateLock, AGENTS_DIR } from './cosState.js'
-import { ensureDir, safeJSONParse } from '../lib/fileUtils.js'
+import { readFile, writeFile, rename, readdir, rm, stat } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { cosEvents, emitLog } from './cosEvents.js';
+import { loadState, saveState, withStateLock, AGENTS_DIR } from './cosState.js';
+import { ensureDir, safeJSONParse } from '../lib/fileUtils.js';
 
-const INDEX_FILE = join(AGENTS_DIR, 'index.json')
+const INDEX_FILE = join(AGENTS_DIR, 'index.json');
 
 // Lightweight index mapping agentId → YYYY-MM-DD date bucket (~50KB vs 16MB full cache)
 // Lazy-loaded from data/cos/agents/index.json on first access
-let agentIndex = null
-let agentIndexPromise = null
+let agentIndex = null;
+let agentIndexPromise = null;
 
 // Load agent index from disk (lazy init, singleton promise prevents concurrent migrations)
 export async function loadAgentIndex() {
-  if (agentIndex) return agentIndex
-  if (agentIndexPromise) return agentIndexPromise
+  if (agentIndex) return agentIndex;
+  if (agentIndexPromise) return agentIndexPromise;
 
   agentIndexPromise = (async () => {
     if (!existsSync(AGENTS_DIR)) {
-      await ensureDir(AGENTS_DIR)
+      await ensureDir(AGENTS_DIR);
     }
 
     if (existsSync(INDEX_FILE)) {
-      const content = await readFile(INDEX_FILE, 'utf-8').catch(() => '{}')
-      const parsed = safeJSONParse(content, {})
-      agentIndex = new Map(Object.entries(parsed))
-      console.log(`📂 Loaded agent index: ${agentIndex.size} entries`)
+      const content = await readFile(INDEX_FILE, 'utf-8').catch(() => '{}');
+      const parsed = safeJSONParse(content, {});
+      agentIndex = new Map(Object.entries(parsed));
+      console.log(`📂 Loaded agent index: ${agentIndex.size} entries`);
     } else {
       // No index yet — run migration from flat dirs to date buckets
-      agentIndex = await migrateAgentsToDateBuckets()
+      agentIndex = await migrateAgentsToDateBuckets();
     }
 
-    return agentIndex
+    return agentIndex;
   })().catch(err => {
-    agentIndexPromise = null
-    throw err
-  })
+    agentIndexPromise = null;
+    throw err;
+  });
 
-  return agentIndexPromise
+  return agentIndexPromise;
 }
 
 // Persist agent index to disk (atomic write via temp file + rename)
 async function saveAgentIndex() {
-  if (!agentIndex) return
-  const obj = Object.fromEntries(agentIndex)
-  const tmpFile = `${INDEX_FILE}.tmp`
+  if (!agentIndex) return;
+  const obj = Object.fromEntries(agentIndex);
+  const tmpFile = `${INDEX_FILE}.tmp`;
   const written = await writeFile(tmpFile, JSON.stringify(obj)).then(() => true).catch(err => {
-    console.error(`❌ Failed to save agent index: ${err.message}`)
-    return false
-  })
-  if (!written) return
+    console.error(`❌ Failed to save agent index: ${err.message}`);
+    return false;
+  });
+  if (!written) return;
   await rename(tmpFile, INDEX_FILE).catch(err => {
-    console.error(`❌ Failed to rename agent index: ${err.message}`)
-    rm(tmpFile, { force: true }).catch(() => {})
-  })
+    console.error(`❌ Failed to rename agent index: ${err.message}`);
+    rm(tmpFile, { force: true }).catch(() => {});
+  });
 }
 
 // Resolve the correct directory for an agent (running = flat, completed = date bucket)
 function getAgentDir(agentId, dateString) {
-  if (dateString) return join(AGENTS_DIR, dateString, agentId)
+  if (dateString) return join(AGENTS_DIR, dateString, agentId);
   // Check index for date bucket
-  const date = agentIndex?.get(agentId)
-  if (date) return join(AGENTS_DIR, date, agentId)
+  const date = agentIndex?.get(agentId);
+  if (date) return join(AGENTS_DIR, date, agentId);
   // Fallback to flat dir (running agents or pre-migration)
-  return join(AGENTS_DIR, agentId)
+  return join(AGENTS_DIR, agentId);
 }
 
 // Migrate flat agent-* directories into YYYY-MM-DD date buckets
 // Runs once when index.json doesn't exist. Idempotent — no-op if already migrated.
 async function migrateAgentsToDateBuckets() {
-  const index = new Map()
+  const index = new Map();
 
   if (!existsSync(AGENTS_DIR)) {
-    await ensureDir(AGENTS_DIR)
-    await writeFile(INDEX_FILE, '{}')
-    console.log('📂 Created empty agent index (no agents to migrate)')
-    return index
+    await ensureDir(AGENTS_DIR);
+    await writeFile(INDEX_FILE, '{}');
+    console.log('📂 Created empty agent index (no agents to migrate)');
+    return index;
   }
 
-  const entries = await readdir(AGENTS_DIR, { withFileTypes: true })
+  const entries = await readdir(AGENTS_DIR, { withFileTypes: true });
 
   // Also scan existing date-bucket dirs to include them in the index
-  const dateDirPattern = /^\d{4}-\d{2}-\d{2}$/
+  const dateDirPattern = /^\d{4}-\d{2}-\d{2}$/;
   for (const entry of entries) {
-    if (!entry.isDirectory() || !dateDirPattern.test(entry.name)) continue
-    const dateStr = entry.name
-    const dateDir = join(AGENTS_DIR, dateStr)
-    const agentDirs = await readdir(dateDir, { withFileTypes: true }).catch(() => [])
+    if (!entry.isDirectory() || !dateDirPattern.test(entry.name)) continue;
+    const dateStr = entry.name;
+    const dateDir = join(AGENTS_DIR, dateStr);
+    const agentDirs = await readdir(dateDir, { withFileTypes: true }).catch(() => []);
     for (const agentEntry of agentDirs) {
       if (agentEntry.isDirectory() && agentEntry.name.startsWith('agent-')) {
-        index.set(agentEntry.name, dateStr)
+        index.set(agentEntry.name, dateStr);
       }
     }
   }
 
   // Find flat agent-* dirs that need migration
-  const flatAgentDirs = entries.filter(e => e.isDirectory() && e.name.startsWith('agent-'))
+  const flatAgentDirs = entries.filter(e => e.isDirectory() && e.name.startsWith('agent-'));
 
   if (flatAgentDirs.length === 0) {
-    await writeFile(INDEX_FILE, JSON.stringify(Object.fromEntries(index)))
-    console.log(`📂 Agent index built: ${index.size} entries (no flat dirs to migrate)`)
-    return index
+    await writeFile(INDEX_FILE, JSON.stringify(Object.fromEntries(index)));
+    console.log(`📂 Agent index built: ${index.size} entries (no flat dirs to migrate)`);
+    return index;
   }
 
-  console.log(`📦 Migrating ${flatAgentDirs.length} agents into date buckets...`)
-  let migrated = 0
-  let skipped = 0
+  console.log(`📦 Migrating ${flatAgentDirs.length} agents into date buckets...`);
+  let migrated = 0;
+  let skipped = 0;
 
   for (const entry of flatAgentDirs) {
-    const agentId = entry.name
-    const agentDir = join(AGENTS_DIR, agentId)
-    const metaPath = join(agentDir, 'metadata.json')
+    const agentId = entry.name;
+    const agentDir = join(AGENTS_DIR, agentId);
+    const metaPath = join(agentDir, 'metadata.json');
 
-    let dateStr = null
+    let dateStr = null;
 
     // Try to get date from metadata
     if (existsSync(metaPath)) {
-      const content = await readFile(metaPath, 'utf-8').catch(() => null)
+      const content = await readFile(metaPath, 'utf-8').catch(() => null);
       if (content) {
-        const raw = safeJSONParse(content, null)
+        const raw = safeJSONParse(content, null);
         if (raw?.completedAt) {
-          dateStr = raw.completedAt.slice(0, 10) // YYYY-MM-DD
+          dateStr = raw.completedAt.slice(0, 10); // YYYY-MM-DD
         }
       }
     }
 
     // Fallback: directory mtime
     if (!dateStr) {
-      const dirStat = await stat(agentDir).catch(() => null)
+      const dirStat = await stat(agentDir).catch(() => null);
       if (dirStat?.mtime) {
-        dateStr = dirStat.mtime.toISOString().slice(0, 10)
+        dateStr = dirStat.mtime.toISOString().slice(0, 10);
       }
     }
 
     if (!dateStr) {
-      console.log(`⚠️ Cannot determine date for ${agentId}, skipping`)
-      skipped++
-      continue
+      console.log(`⚠️ Cannot determine date for ${agentId}, skipping`);
+      skipped++;
+      continue;
     }
 
     // Move into date bucket
-    const bucketDir = join(AGENTS_DIR, dateStr)
-    await ensureDir(bucketDir)
-    const targetDir = join(bucketDir, agentId)
+    const bucketDir = join(AGENTS_DIR, dateStr);
+    await ensureDir(bucketDir);
+    const targetDir = join(bucketDir, agentId);
 
     // If target already exists (partial previous migration), skip
     if (existsSync(targetDir)) {
-      index.set(agentId, dateStr)
-      migrated++
-      continue
+      index.set(agentId, dateStr);
+      migrated++;
+      continue;
     }
 
     await rename(agentDir, targetDir).catch(async (renameErr) => {
       // rename can fail across filesystems — fall back to copy+delete
-      console.log(`⚠️ Rename failed for ${agentId}, using copy: ${renameErr.message}`)
+      console.log(`⚠️ Rename failed for ${agentId}, using copy: ${renameErr.message}`);
       try {
-        await ensureDir(targetDir)
-        const files = await readdir(agentDir)
+        await ensureDir(targetDir);
+        const files = await readdir(agentDir);
         for (const file of files) {
-          const content = await readFile(join(agentDir, file))
-          await writeFile(join(targetDir, file), content)
+          const content = await readFile(join(agentDir, file));
+          await writeFile(join(targetDir, file), content);
         }
-        await rm(agentDir, { recursive: true })
+        await rm(agentDir, { recursive: true });
       } catch (copyErr) {
-        console.error(`❌ Copy fallback failed for ${agentId}: ${copyErr.message}`)
+        console.error(`❌ Copy fallback failed for ${agentId}: ${copyErr.message}`);
         // Clean up partially-created target to avoid skipping on next startup
-        await rm(targetDir, { recursive: true, force: true }).catch(() => {})
-        throw copyErr
+        await rm(targetDir, { recursive: true, force: true }).catch(() => {});
+        throw copyErr;
       }
-    })
+    });
 
-    index.set(agentId, dateStr)
-    migrated++
+    index.set(agentId, dateStr);
+    migrated++;
   }
 
   // Persist index
-  await writeFile(INDEX_FILE, JSON.stringify(Object.fromEntries(index)))
-  const uniqueDates = new Set(index.values()).size
-  const parts = [`📦 Migrated ${migrated} agents into date buckets (${uniqueDates} unique dates)`]
-  if (skipped > 0) parts.push(`skipped ${skipped} undatable`)
-  console.log(parts.join(', '))
+  await writeFile(INDEX_FILE, JSON.stringify(Object.fromEntries(index)));
+  const uniqueDates = new Set(index.values()).size;
+  const parts = [`📦 Migrated ${migrated} agents into date buckets (${uniqueDates} unique dates)`];
+  if (skipped > 0) parts.push(`skipped ${skipped} undatable`);
+  console.log(parts.join(', '));
 
-  return index
+  return index;
 }
 
 // Prune agent archive date buckets older than retentionDays (default 90).
 // Removes directories + their index entries. Runs after migration on startup.
 export async function pruneOldAgentArchives(retentionDays = 90) {
-  const idx = await loadAgentIndex()
-  if (!idx || idx.size === 0) return
+  const idx = await loadAgentIndex();
+  if (!idx || idx.size === 0) return;
 
-  const cutoff = new Date()
-  cutoff.setDate(cutoff.getDate() - retentionDays)
-  const cutoffStr = cutoff.toISOString().slice(0, 10)
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - retentionDays);
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
 
-  const dateDirPattern = /^\d{4}-\d{2}-\d{2}$/
-  const entries = await readdir(AGENTS_DIR, { withFileTypes: true }).catch(() => [])
+  const dateDirPattern = /^\d{4}-\d{2}-\d{2}$/;
+  const entries = await readdir(AGENTS_DIR, { withFileTypes: true }).catch(() => []);
   const oldDates = entries
     .filter(e => e.isDirectory() && dateDirPattern.test(e.name) && e.name < cutoffStr)
-    .map(e => e.name)
+    .map(e => e.name);
 
-  if (oldDates.length === 0) return
+  if (oldDates.length === 0) return;
 
   for (const dateStr of oldDates) {
-    await rm(join(AGENTS_DIR, dateStr), { recursive: true }).catch(() => {})
+    await rm(join(AGENTS_DIR, dateStr), { recursive: true }).catch(() => {});
   }
 
   // Remove index entries for all old dates in a single pass
-  const oldDateSet = new Set(oldDates)
-  let pruned = 0
+  const oldDateSet = new Set(oldDates);
+  let pruned = 0;
   for (const [agentId, date] of idx.entries()) {
-    if (oldDateSet.has(date)) { idx.delete(agentId); pruned++ }
+    if (oldDateSet.has(date)) { idx.delete(agentId); pruned++; }
   }
 
-  await saveAgentIndex()
-  console.log(`🗑️ Pruned ${pruned} archived agents older than ${retentionDays} days (${oldDates.length} date buckets)`)
+  await saveAgentIndex();
+  console.log(`🗑️ Pruned ${pruned} archived agents older than ${retentionDays} days (${oldDates.length} date buckets)`);
 }
 
 export async function registerAgent(agentId, taskId, metadata = {}) {
   return withStateLock(async () => {
-    const state = await loadState()
+    const state = await loadState();
 
     state.agents[agentId] = {
       id: agentId,
@@ -237,22 +237,22 @@ export async function registerAgent(agentId, taskId, metadata = {}) {
       startedAt: new Date().toISOString(),
       metadata,
       output: []
-    }
+    };
 
-    state.stats.agentsSpawned++
-    await saveState(state)
+    state.stats.agentsSpawned++;
+    await saveState(state);
 
-    cosEvents.emit('agent:spawned', state.agents[agentId])
-    return state.agents[agentId]
-  })
+    cosEvents.emit('agent:spawned', state.agents[agentId]);
+    return state.agents[agentId];
+  });
 }
 
 export async function updateAgent(agentId, updates) {
   return withStateLock(async () => {
-    const state = await loadState()
+    const state = await loadState();
 
     if (!state.agents[agentId]) {
-      return null
+      return null;
     }
 
     // Merge metadata if present in updates
@@ -261,23 +261,23 @@ export async function updateAgent(agentId, updates) {
         ...state.agents[agentId],
         ...updates,
         metadata: { ...state.agents[agentId].metadata, ...updates.metadata }
-      }
+      };
     } else {
-      state.agents[agentId] = { ...state.agents[agentId], ...updates }
+      state.agents[agentId] = { ...state.agents[agentId], ...updates };
     }
-    await saveState(state)
+    await saveState(state);
 
-    cosEvents.emit('agent:updated', state.agents[agentId])
-    return state.agents[agentId]
-  })
+    cosEvents.emit('agent:updated', state.agents[agentId]);
+    return state.agents[agentId];
+  });
 }
 
 export async function completeAgent(agentId, result = {}) {
   return withStateLock(async () => {
-    const state = await loadState()
+    const state = await loadState();
 
     if (!state.agents[agentId]) {
-      return null
+      return null;
     }
 
     state.agents[agentId] = {
@@ -285,440 +285,440 @@ export async function completeAgent(agentId, result = {}) {
       status: 'completed',
       completedAt: new Date().toISOString(),
       result
-    }
+    };
 
     if (result.success) {
-      state.stats.tasksCompleted++
+      state.stats.tasksCompleted++;
     } else {
-      state.stats.errors = (state.stats.errors || 0) + 1
+      state.stats.errors = (state.stats.errors || 0) + 1;
     }
 
-    await saveState(state)
-    cosEvents.emit('agent:completed', state.agents[agentId])
-    cosEvents.emit('agent:updated', state.agents[agentId])
+    await saveState(state);
+    cosEvents.emit('agent:completed', state.agents[agentId]);
+    cosEvents.emit('agent:updated', state.agents[agentId]);
 
     // Determine date bucket from completedAt
-    const dateStr = state.agents[agentId].completedAt.slice(0, 10)
-    const bucketDir = join(AGENTS_DIR, dateStr)
-    await ensureDir(bucketDir)
+    const dateStr = state.agents[agentId].completedAt.slice(0, 10);
+    const bucketDir = join(AGENTS_DIR, dateStr);
+    await ensureDir(bucketDir);
 
     // Write metadata to flat dir first (may already have output.txt/prompt.txt there)
-    const flatDir = join(AGENTS_DIR, agentId)
+    const flatDir = join(AGENTS_DIR, agentId);
     if (!existsSync(flatDir)) {
-      await ensureDir(flatDir)
+      await ensureDir(flatDir);
     }
-    const { output: _output, ...agentWithoutOutput } = state.agents[agentId]
-    await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2))
+    const { output: _output, ...agentWithoutOutput } = state.agents[agentId];
+    await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2));
 
     // Move entire agent dir into date bucket (atomic on same filesystem)
-    const targetDir = join(bucketDir, agentId)
+    const targetDir = join(bucketDir, agentId);
     if (!existsSync(targetDir)) {
       await rename(flatDir, targetDir).catch(async () => {
         // Fallback for cross-filesystem: copy files then remove
-        await ensureDir(targetDir)
-        const files = await readdir(flatDir)
+        await ensureDir(targetDir);
+        const files = await readdir(flatDir);
         for (const file of files) {
-          const content = await readFile(join(flatDir, file))
-          await writeFile(join(targetDir, file), content)
+          const content = await readFile(join(flatDir, file));
+          await writeFile(join(targetDir, file), content);
         }
-        await rm(flatDir, { recursive: true })
-      })
+        await rm(flatDir, { recursive: true });
+      });
     }
 
     // Update index
-    const idx = await loadAgentIndex()
-    idx.set(agentId, dateStr)
-    await saveAgentIndex()
+    const idx = await loadAgentIndex();
+    idx.set(agentId, dateStr);
+    await saveAgentIndex();
 
-    return state.agents[agentId]
-  })
+    return state.agents[agentId];
+  });
 }
 
 export async function appendAgentOutput(agentId, line) {
   const result = await withStateLock(async () => {
-    const state = await loadState()
+    const state = await loadState();
 
     if (!state.agents[agentId]) {
-      return null
+      return null;
     }
 
     state.agents[agentId].output.push({
       timestamp: new Date().toISOString(),
       line
-    })
+    });
 
     // Trim to last 1000 lines in state
     if (state.agents[agentId].output.length > 1000) {
-      state.agents[agentId].output = state.agents[agentId].output.slice(-1000)
+      state.agents[agentId].output = state.agents[agentId].output.slice(-1000);
     }
 
-    await saveState(state)
-    return state.agents[agentId]
-  })
+    await saveState(state);
+    return state.agents[agentId];
+  });
 
   if (result) {
-    cosEvents.emit('agent:output', { agentId, line })
+    cosEvents.emit('agent:output', { agentId, line });
   }
 
-  return result
+  return result;
 }
 
 // Get all agents from in-memory state (includes running and recently completed; archived agents loaded via getAgentsByDate)
 export async function getAgents() {
-  const state = await loadState()
-  return Object.values(state.agents)
+  const state = await loadState();
+  return Object.values(state.agents);
 }
 
 // Get available agent date buckets with counts, sorted descending
 export async function getAgentDates() {
-  const idx = await loadAgentIndex()
-  const dateCounts = {}
+  const idx = await loadAgentIndex();
+  const dateCounts = {};
   for (const date of idx.values()) {
-    dateCounts[date] = (dateCounts[date] || 0) + 1
+    dateCounts[date] = (dateCounts[date] || 0) + 1;
   }
   return Object.entries(dateCounts)
     .map(([date, count]) => ({ date, count }))
-    .sort((a, b) => b.date.localeCompare(a.date))
+    .sort((a, b) => b.date.localeCompare(a.date));
 }
 
 // Get completed agents for a specific date bucket
 export async function getAgentsByDate(date) {
-  const dateDir = join(AGENTS_DIR, date)
-  if (!existsSync(dateDir)) return []
+  const dateDir = join(AGENTS_DIR, date);
+  if (!existsSync(dateDir)) return [];
 
-  const entries = await readdir(dateDir, { withFileTypes: true })
-  const agentDirs = entries.filter(e => e.isDirectory() && e.name.startsWith('agent-'))
-  const agents = []
+  const entries = await readdir(dateDir, { withFileTypes: true });
+  const agentDirs = entries.filter(e => e.isDirectory() && e.name.startsWith('agent-'));
+  const agents = [];
 
   // Batch reads in chunks of 50 to avoid fd exhaustion on large date buckets
-  const BATCH_SIZE = 50
+  const BATCH_SIZE = 50;
   for (let i = 0; i < agentDirs.length; i += BATCH_SIZE) {
-    const batch = agentDirs.slice(i, i + BATCH_SIZE)
+    const batch = agentDirs.slice(i, i + BATCH_SIZE);
     const reads = batch.map(async (entry) => {
-      const metaPath = join(dateDir, entry.name, 'metadata.json')
-      const content = await readFile(metaPath, 'utf-8').catch(() => null)
-      if (!content) return
-      const raw = safeJSONParse(content, null)
-      if (!raw) return
-      const id = raw.id || raw.agentId || entry.name
-      const { output, ...rest } = raw
-      agents.push({ ...rest, id, status: raw.status || 'completed' })
-    })
-    await Promise.allSettled(reads)
+      const metaPath = join(dateDir, entry.name, 'metadata.json');
+      const content = await readFile(metaPath, 'utf-8').catch(() => null);
+      if (!content) return;
+      const raw = safeJSONParse(content, null);
+      if (!raw) return;
+      const id = raw.id || raw.agentId || entry.name;
+      const { output, ...rest } = raw;
+      agents.push({ ...rest, id, status: raw.status || 'completed' });
+    });
+    await Promise.allSettled(reads);
   }
 
-  return agents.sort((a, b) => new Date(b.completedAt || 0) - new Date(a.completedAt || 0))
+  return agents.sort((a, b) => new Date(b.completedAt || 0) - new Date(a.completedAt || 0));
 }
 
 // Get agent by ID with full output from file
 export async function getAgent(agentId) {
-  const state = await loadState()
-  let agent = state.agents[agentId]
+  const state = await loadState();
+  let agent = state.agents[agentId];
 
   // Fall back to disk metadata via index if not in state
   if (!agent) {
-    const idx = await loadAgentIndex()
-    const dateStr = idx.get(agentId)
+    const idx = await loadAgentIndex();
+    const dateStr = idx.get(agentId);
     if (dateStr) {
-      const metaPath = join(AGENTS_DIR, dateStr, agentId, 'metadata.json')
-      const content = await readFile(metaPath, 'utf-8').catch(() => null)
+      const metaPath = join(AGENTS_DIR, dateStr, agentId, 'metadata.json');
+      const content = await readFile(metaPath, 'utf-8').catch(() => null);
       if (content) {
-        const raw = safeJSONParse(content, null)
+        const raw = safeJSONParse(content, null);
         if (raw) {
-          const { output, ...rest } = raw
-          agent = { ...rest, id: raw.id || raw.agentId || agentId, status: raw.status || 'completed' }
+          const { output, ...rest } = raw;
+          agent = { ...rest, id: raw.id || raw.agentId || agentId, status: raw.status || 'completed' };
         }
       }
     }
   }
-  if (!agent) return null
+  if (!agent) return null;
 
   // For completed agents, read full output from file
   if (agent.status === 'completed') {
-    const dateStr = agent.completedAt?.slice(0, 10)
-    const agentDir = dateStr ? getAgentDir(agentId, dateStr) : getAgentDir(agentId)
-    const outputFile = join(agentDir, 'output.txt')
+    const dateStr = agent.completedAt?.slice(0, 10);
+    const agentDir = dateStr ? getAgentDir(agentId, dateStr) : getAgentDir(agentId);
+    const outputFile = join(agentDir, 'output.txt');
     if (existsSync(outputFile)) {
-      const fullOutput = await readFile(outputFile, 'utf-8')
-      const lines = fullOutput.split('\n').filter(line => line.trim())
+      const fullOutput = await readFile(outputFile, 'utf-8');
+      const lines = fullOutput.split('\n').filter(line => line.trim());
       return {
         ...agent,
         output: lines.map(line => ({ line, timestamp: agent.completedAt }))
-      }
+      };
     }
   }
 
-  return agent
+  return agent;
 }
 
 // Terminate an agent (will be handled by spawner)
 export async function terminateAgent(agentId) {
   // Emit event to kill the process FIRST
-  cosEvents.emit('agent:terminate', agentId)
+  cosEvents.emit('agent:terminate', agentId);
   // The spawner will handle marking the agent as completed after termination
-  return { success: true, agentId }
+  return { success: true, agentId };
 }
 
 // Force kill an agent with SIGKILL (immediate, no graceful shutdown)
 export async function killAgent(agentId) {
-  const { killAgent: killAgentFromSpawner } = await import('./subAgentSpawner.js')
-  return killAgentFromSpawner(agentId)
+  const { killAgent: killAgentFromSpawner } = await import('./subAgentSpawner.js');
+  return killAgentFromSpawner(agentId);
 }
 
 // Send a BTW (additional context) message to a running agent
 export async function sendBtwToAgent(agentId, message) {
   // Single locked read to validate agent and extract workspacePath
   const agentInfo = await withStateLock(async () => {
-    const state = await loadState()
-    const agent = state.agents[agentId]
-    if (!agent) return { error: 'Agent not found' }
-    if (agent.status !== 'running') return { error: 'Agent is not running' }
-    if (!agent.metadata?.workspacePath) return { error: 'Agent has no workspace path' }
-    return { workspacePath: agent.metadata.workspacePath }
-  })
+    const state = await loadState();
+    const agent = state.agents[agentId];
+    if (!agent) return { error: 'Agent not found' };
+    if (agent.status !== 'running') return { error: 'Agent is not running' };
+    if (!agent.metadata?.workspacePath) return { error: 'Agent has no workspace path' };
+    return { workspacePath: agent.metadata.workspacePath };
+  });
 
-  if (agentInfo.error) return agentInfo
+  if (agentInfo.error) return agentInfo;
 
   // Send to runner to write the BTW.md file
-  const { sendBtwToAgent: sendViaRunner } = await import('./cosRunnerClient.js')
-  const result = await sendViaRunner(agentId, message)
+  const { sendBtwToAgent: sendViaRunner } = await import('./cosRunnerClient.js');
+  const result = await sendViaRunner(agentId, message);
 
   // Track in agent state (cap at 50 messages)
-  const timestamp = new Date().toISOString()
+  const timestamp = new Date().toISOString();
   await withStateLock(async () => {
-    const state = await loadState()
-    if (!state.agents[agentId]) return
+    const state = await loadState();
+    if (!state.agents[agentId]) return;
     if (!state.agents[agentId].btwMessages) {
-      state.agents[agentId].btwMessages = []
+      state.agents[agentId].btwMessages = [];
     }
-    state.agents[agentId].btwMessages.push({ message, timestamp })
+    state.agents[agentId].btwMessages.push({ message, timestamp });
     if (state.agents[agentId].btwMessages.length > 50) {
-      state.agents[agentId].btwMessages = state.agents[agentId].btwMessages.slice(-50)
+      state.agents[agentId].btwMessages = state.agents[agentId].btwMessages.slice(-50);
     }
-    await saveState(state)
-  })
+    await saveState(state);
+  });
 
-  cosEvents.emit('agent:btw', { agentId, message, timestamp })
-  return { success: true, ...result }
+  cosEvents.emit('agent:btw', { agentId, message, timestamp });
+  return { success: true, ...result };
 }
 
 // Get process stats for an agent (CPU, memory)
 export async function getAgentProcessStats(agentId) {
-  const { getAgentProcessStats: getStatsFromSpawner } = await import('./subAgentSpawner.js')
-  return getStatsFromSpawner(agentId)
+  const { getAgentProcessStats: getStatsFromSpawner } = await import('./subAgentSpawner.js');
+  return getStatsFromSpawner(agentId);
 }
 
 // Check if a PID is still running
 async function isPidAlive(pid) {
-  if (!pid) return false
+  if (!pid) return false;
   try {
-    process.kill(pid, 0)
-    return true
+    process.kill(pid, 0);
+    return true;
   } catch {
-    return false
+    return false;
   }
 }
 
 // Cleanup zombie agents - agents marked as running but whose process is dead
 export async function cleanupZombieAgents() {
   // Check local tracking maps
-  const { getActiveAgentIds } = await import('./subAgentSpawner.js')
-  const activeIds = getActiveAgentIds()
+  const { getActiveAgentIds } = await import('./subAgentSpawner.js');
+  const activeIds = getActiveAgentIds();
 
   // Also check with the CoS runner for agents it's actively tracking
-  const { getActiveAgentsFromRunner } = await import('./cosRunnerClient.js')
-  const runnerAgents = await getActiveAgentsFromRunner().catch(() => [])
-  const runnerAgentIds = new Set(runnerAgents.map(a => a.id))
+  const { getActiveAgentsFromRunner } = await import('./cosRunnerClient.js');
+  const runnerAgents = await getActiveAgentsFromRunner().catch(() => []);
+  const runnerAgentIds = new Set(runnerAgents.map(a => a.id));
 
   return withStateLock(async () => {
-    const state = await loadState()
-    const runningAgents = Object.values(state.agents).filter(a => a.status === 'running')
-    const cleaned = []
+    const state = await loadState();
+    const runningAgents = Object.values(state.agents).filter(a => a.status === 'running');
+    const cleaned = [];
 
     for (const agent of runningAgents) {
       // Skip if tracked in local maps or runner
       if (activeIds.includes(agent.id) || runnerAgentIds.has(agent.id)) {
-        continue
+        continue;
       }
 
       // If agent has a PID, verify the process is actually dead
       if (agent.pid) {
-        const alive = await isPidAlive(agent.pid)
-        if (alive) continue
+        const alive = await isPidAlive(agent.pid);
+        if (alive) continue;
       } else {
         // No PID yet - agent might still be initializing
         // Give it a 30 second grace period before marking as zombie
-        const startedAt = agent.startedAt ? new Date(agent.startedAt).getTime() : 0
-        const ageMs = Date.now() - startedAt
-        if (ageMs < 30000) continue
+        const startedAt = agent.startedAt ? new Date(agent.startedAt).getTime() : 0;
+        const ageMs = Date.now() - startedAt;
+        if (ageMs < 30000) continue;
       }
 
       // Agent is not tracked anywhere and process is dead — it's a zombie
-      console.log(`🧟 Zombie agent detected: ${agent.id} (PID ${agent.pid || 'unknown'} not running)`)
+      console.log(`🧟 Zombie agent detected: ${agent.id} (PID ${agent.pid || 'unknown'} not running)`);
       state.agents[agent.id] = {
         ...agent,
         status: 'completed',
         completedAt: new Date().toISOString(),
         result: { success: false, error: 'Agent process terminated unexpectedly' }
-      }
-      cleaned.push(agent.id)
+      };
+      cleaned.push(agent.id);
     }
 
     if (cleaned.length > 0) {
-      await saveState(state)
+      await saveState(state);
 
       // Persist zombie-cleaned agents to date-bucketed dirs and update index
-      const idx = await loadAgentIndex()
+      const idx = await loadAgentIndex();
       for (const agentId of cleaned) {
-        const agent = state.agents[agentId]
-        const dateStr = agent.completedAt?.slice(0, 10)
-        if (!dateStr) continue
-        const bucketDir = join(AGENTS_DIR, dateStr)
-        await ensureDir(bucketDir)
+        const agent = state.agents[agentId];
+        const dateStr = agent.completedAt?.slice(0, 10);
+        if (!dateStr) continue;
+        const bucketDir = join(AGENTS_DIR, dateStr);
+        await ensureDir(bucketDir);
 
-        const flatDir = join(AGENTS_DIR, agentId)
-        const { output, ...agentWithoutOutput } = agent
+        const flatDir = join(AGENTS_DIR, agentId);
+        const { output, ...agentWithoutOutput } = agent;
 
         // Ensure metadata is written before move
-        if (!existsSync(flatDir)) await ensureDir(flatDir)
-        await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {})
+        if (!existsSync(flatDir)) await ensureDir(flatDir);
+        await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {});
 
         // Move to date bucket
-        const targetDir = join(bucketDir, agentId)
+        const targetDir = join(bucketDir, agentId);
         if (!existsSync(targetDir)) {
           await rename(flatDir, targetDir).catch(async () => {
-            await ensureDir(targetDir)
-            const files = await readdir(flatDir)
+            await ensureDir(targetDir);
+            const files = await readdir(flatDir);
             for (const file of files) {
-              const content = await readFile(join(flatDir, file))
-              await writeFile(join(targetDir, file), content)
+              const content = await readFile(join(flatDir, file));
+              await writeFile(join(targetDir, file), content);
             }
-            await rm(flatDir, { recursive: true })
-          })
+            await rm(flatDir, { recursive: true });
+          });
         }
 
-        idx.set(agentId, dateStr)
+        idx.set(agentId, dateStr);
       }
-      await saveAgentIndex()
+      await saveAgentIndex();
 
-      console.log(`🧹 Cleaned up ${cleaned.length} zombie agents: ${cleaned.join(', ')}`)
-      cosEvents.emit('agents:changed', { action: 'zombie-cleanup', cleaned })
+      console.log(`🧹 Cleaned up ${cleaned.length} zombie agents: ${cleaned.join(', ')}`);
+      cosEvents.emit('agents:changed', { action: 'zombie-cleanup', cleaned });
     }
 
-    return { cleaned, count: cleaned.length }
-  })
+    return { cleaned, count: cleaned.length };
+  });
 }
 
 // Delete a single agent from state and disk
 export async function deleteAgent(agentId) {
   return withStateLock(async () => {
-    const state = await loadState()
-    const idx = await loadAgentIndex()
+    const state = await loadState();
+    const idx = await loadAgentIndex();
 
-    const inState = !!state.agents[agentId]
-    const inIndex = idx.has(agentId)
+    const inState = !!state.agents[agentId];
+    const inIndex = idx.has(agentId);
     if (!inState && !inIndex) {
-      return { error: 'Agent not found' }
+      return { error: 'Agent not found' };
     }
 
-    delete state.agents[agentId]
-    await saveState(state)
+    delete state.agents[agentId];
+    await saveState(state);
 
     // Remove from disk (date-bucketed or flat)
-    const agentDir = getAgentDir(agentId)
+    const agentDir = getAgentDir(agentId);
     if (existsSync(agentDir)) {
-      await rm(agentDir, { recursive: true }).catch(() => {})
+      await rm(agentDir, { recursive: true }).catch(() => {});
     }
 
     // Remove from index
-    idx.delete(agentId)
-    await saveAgentIndex()
+    idx.delete(agentId);
+    await saveAgentIndex();
 
-    cosEvents.emit('agents:changed', { action: 'deleted', agentId })
-    return { success: true, agentId }
-  })
+    cosEvents.emit('agents:changed', { action: 'deleted', agentId });
+    return { success: true, agentId };
+  });
 }
 
 // Submit feedback for a completed agent
 export async function submitAgentFeedback(agentId, feedback) {
   return withStateLock(async () => {
-    const state = await loadState()
+    const state = await loadState();
     const feedbackData = {
       rating: feedback.rating,
       comment: feedback.comment || null,
       submittedAt: new Date().toISOString()
-    }
+    };
 
     // Try state first (recently completed agents still in state)
     if (state.agents[agentId]) {
-      const agent = state.agents[agentId]
+      const agent = state.agents[agentId];
       if (agent.status !== 'completed') {
-        return { error: 'Can only submit feedback for completed agents' }
+        return { error: 'Can only submit feedback for completed agents' };
       }
-      state.agents[agentId].feedback = feedbackData
-      await saveState(state)
+      state.agents[agentId].feedback = feedbackData;
+      await saveState(state);
 
       // Also update on-disk metadata (derive date bucket from completedAt if archived)
-      const dateBucket = agent.completedAt ? agent.completedAt.slice(0, 10) : null
-      const agentDir = getAgentDir(agentId, dateBucket)
-      const metaPath = join(agentDir, 'metadata.json')
+      const dateBucket = agent.completedAt ? agent.completedAt.slice(0, 10) : null;
+      const agentDir = getAgentDir(agentId, dateBucket);
+      const metaPath = join(agentDir, 'metadata.json');
       if (existsSync(metaPath)) {
-        const content = await readFile(metaPath, 'utf-8').catch(() => null)
+        const content = await readFile(metaPath, 'utf-8').catch(() => null);
         if (content) {
-          const raw = safeJSONParse(content, null)
+          const raw = safeJSONParse(content, null);
           if (raw) {
-            raw.feedback = feedbackData
-            await writeFile(metaPath, JSON.stringify(raw, null, 2)).catch(() => {})
+            raw.feedback = feedbackData;
+            await writeFile(metaPath, JSON.stringify(raw, null, 2)).catch(() => {});
           }
         }
       }
 
-      emitLog('info', `Feedback received for agent ${agentId}: ${feedback.rating}`, { agentId, rating: feedback.rating })
-      cosEvents.emit('agent:feedback', { agentId, feedback: feedbackData })
-      return { success: true, agent: state.agents[agentId] }
+      emitLog('info', `Feedback received for agent ${agentId}: ${feedback.rating}`, { agentId, rating: feedback.rating });
+      cosEvents.emit('agent:feedback', { agentId, feedback: feedbackData });
+      return { success: true, agent: state.agents[agentId] };
     }
 
     // Agent not in state — look up from disk via index
-    const idx = await loadAgentIndex()
-    const dateStr = idx.get(agentId)
-    if (!dateStr) return { error: 'Agent not found' }
+    const idx = await loadAgentIndex();
+    const dateStr = idx.get(agentId);
+    if (!dateStr) return { error: 'Agent not found' };
 
-    const metaPath = join(AGENTS_DIR, dateStr, agentId, 'metadata.json')
-    const content = await readFile(metaPath, 'utf-8').catch(() => null)
-    if (!content) return { error: 'Agent not found' }
+    const metaPath = join(AGENTS_DIR, dateStr, agentId, 'metadata.json');
+    const content = await readFile(metaPath, 'utf-8').catch(() => null);
+    if (!content) return { error: 'Agent not found' };
 
-    const raw = safeJSONParse(content, null)
-    if (!raw) return { error: 'Agent not found' }
+    const raw = safeJSONParse(content, null);
+    if (!raw) return { error: 'Agent not found' };
 
-    raw.feedback = feedbackData
-    await writeFile(metaPath, JSON.stringify(raw, null, 2))
+    raw.feedback = feedbackData;
+    await writeFile(metaPath, JSON.stringify(raw, null, 2));
 
-    emitLog('info', `Feedback received for agent ${agentId}: ${feedback.rating}`, { agentId, rating: feedback.rating })
-    cosEvents.emit('agent:feedback', { agentId, feedback: feedbackData })
-    return { success: true, agent: { ...raw, id: agentId } }
-  })
+    emitLog('info', `Feedback received for agent ${agentId}: ${feedback.rating}`, { agentId, rating: feedback.rating });
+    cosEvents.emit('agent:feedback', { agentId, feedback: feedbackData });
+    return { success: true, agent: { ...raw, id: agentId } };
+  });
 }
 
 // Get aggregated feedback statistics
 export async function getFeedbackStats() {
-  const state = await loadState()
-  const agents = Object.values(state.agents)
+  const state = await loadState();
+  const agents = Object.values(state.agents);
 
-  const withFeedback = agents.filter(a => a.feedback)
-  const positive = withFeedback.filter(a => a.feedback.rating === 'positive').length
-  const negative = withFeedback.filter(a => a.feedback.rating === 'negative').length
-  const neutral = withFeedback.filter(a => a.feedback.rating === 'neutral').length
+  const withFeedback = agents.filter(a => a.feedback);
+  const positive = withFeedback.filter(a => a.feedback.rating === 'positive').length;
+  const negative = withFeedback.filter(a => a.feedback.rating === 'negative').length;
+  const neutral = withFeedback.filter(a => a.feedback.rating === 'neutral').length;
 
   // Group by task type
-  const byTaskType = {}
+  const byTaskType = {};
   withFeedback.forEach(a => {
-    const taskType = extractTaskType(a.metadata?.taskDescription)
+    const taskType = extractTaskType(a.metadata?.taskDescription);
     if (!byTaskType[taskType]) {
-      byTaskType[taskType] = { positive: 0, negative: 0, neutral: 0, total: 0 }
+      byTaskType[taskType] = { positive: 0, negative: 0, neutral: 0, total: 0 };
     }
-    byTaskType[taskType][a.feedback.rating]++
-    byTaskType[taskType].total++
-  })
+    byTaskType[taskType][a.feedback.rating]++;
+    byTaskType[taskType].total++;
+  });
 
   // Recent feedback (last 10 with comments)
   const recentWithComments = withFeedback
@@ -731,11 +731,11 @@ export async function getFeedbackStats() {
       rating: a.feedback.rating,
       comment: a.feedback.comment,
       submittedAt: a.feedback.submittedAt
-    }))
+    }));
 
   const satisfactionRate = withFeedback.length > 0
     ? Math.round((positive / withFeedback.length) * 100)
-    : null
+    : null;
 
   return {
     total: withFeedback.length,
@@ -745,28 +745,28 @@ export async function getFeedbackStats() {
     satisfactionRate,
     byTaskType,
     recentWithComments
-  }
+  };
 }
 
 // Helper to extract task type from description (mirrors client-side logic)
 export function extractTaskType(description) {
-  if (!description) return 'general'
-  const d = description.toLowerCase()
-  if (d.includes('fix') || d.includes('bug') || d.includes('error') || d.includes('issue')) return 'bug-fix'
-  if (d.includes('refactor') || d.includes('clean up') || d.includes('improve') || d.includes('optimize')) return 'refactor'
-  if (d.includes('test')) return 'testing'
-  if (d.includes('document') || d.includes('readme') || d.includes('docs')) return 'documentation'
-  if (d.includes('review') || d.includes('audit')) return 'code-review'
-  if (d.includes('mobile') || d.includes('responsive')) return 'mobile-responsive'
-  if (d.includes('security') || d.includes('vulnerability')) return 'security'
-  if (d.includes('performance') || d.includes('speed')) return 'performance'
-  if (d.includes('ui') || d.includes('ux') || d.includes('design') || d.includes('style')) return 'ui-ux'
-  if (d.includes('api') || d.includes('endpoint') || d.includes('route')) return 'api'
-  if (d.includes('database') || d.includes('migration')) return 'database'
-  if (d.includes('deploy') || d.includes('ci') || d.includes('cd')) return 'devops'
-  if (d.includes('investigate') || d.includes('debug')) return 'investigation'
-  if (d.includes('self-improvement') || d.includes('feature idea')) return 'self-improvement'
-  return 'feature'
+  if (!description) return 'general';
+  const d = description.toLowerCase();
+  if (d.includes('fix') || d.includes('bug') || d.includes('error') || d.includes('issue')) return 'bug-fix';
+  if (d.includes('refactor') || d.includes('clean up') || d.includes('improve') || d.includes('optimize')) return 'refactor';
+  if (d.includes('test')) return 'testing';
+  if (d.includes('document') || d.includes('readme') || d.includes('docs')) return 'documentation';
+  if (d.includes('review') || d.includes('audit')) return 'code-review';
+  if (d.includes('mobile') || d.includes('responsive')) return 'mobile-responsive';
+  if (d.includes('security') || d.includes('vulnerability')) return 'security';
+  if (d.includes('performance') || d.includes('speed')) return 'performance';
+  if (d.includes('ui') || d.includes('ux') || d.includes('design') || d.includes('style')) return 'ui-ux';
+  if (d.includes('api') || d.includes('endpoint') || d.includes('route')) return 'api';
+  if (d.includes('database') || d.includes('migration')) return 'database';
+  if (d.includes('deploy') || d.includes('ci') || d.includes('cd')) return 'devops';
+  if (d.includes('investigate') || d.includes('debug')) return 'investigation';
+  if (d.includes('self-improvement') || d.includes('feature idea')) return 'self-improvement';
+  return 'feature';
 }
 
 // Archive stale completed agents from state.json.
@@ -775,97 +775,97 @@ export function extractTaskType(description) {
 // reduces the size of the in-memory state and the state.json file.
 export async function archiveStaleAgents() {
   return withStateLock(async () => {
-    const state = await loadState()
-    const retentionMs = state.config.completedAgentRetentionMs ?? 86400000
-    const cutoff = Date.now() - retentionMs
+    const state = await loadState();
+    const retentionMs = state.config.completedAgentRetentionMs ?? 86400000;
+    const cutoff = Date.now() - retentionMs;
 
     const staleIds = Object.keys(state.agents).filter(id => {
-      const agent = state.agents[id]
-      if (agent.status !== 'completed') return false
-      const completedAt = agent.completedAt ? new Date(agent.completedAt).getTime() : 0
-      return completedAt > 0 && completedAt < cutoff
-    })
+      const agent = state.agents[id];
+      if (agent.status !== 'completed') return false;
+      const completedAt = agent.completedAt ? new Date(agent.completedAt).getTime() : 0;
+      return completedAt > 0 && completedAt < cutoff;
+    });
 
-    if (staleIds.length === 0) return { archived: 0 }
+    if (staleIds.length === 0) return { archived: 0 };
 
-    const idx = await loadAgentIndex()
+    const idx = await loadAgentIndex();
 
     for (const id of staleIds) {
       // Ensure agent is persisted to date-bucketed disk before removing from state
       if (!idx.has(id)) {
-        const agent = state.agents[id]
-        const dateStr = agent.completedAt?.slice(0, 10)
-        if (!dateStr) continue
-        const bucketDir = join(AGENTS_DIR, dateStr)
-        await ensureDir(bucketDir)
+        const agent = state.agents[id];
+        const dateStr = agent.completedAt?.slice(0, 10);
+        if (!dateStr) continue;
+        const bucketDir = join(AGENTS_DIR, dateStr);
+        await ensureDir(bucketDir);
 
-        const { output, ...agentWithoutOutput } = agent
-        const flatDir = join(AGENTS_DIR, id)
-        const targetDir = join(bucketDir, id)
+        const { output, ...agentWithoutOutput } = agent;
+        const flatDir = join(AGENTS_DIR, id);
+        const targetDir = join(bucketDir, id);
 
         if (existsSync(flatDir) && !existsSync(targetDir)) {
           // Write metadata then move (with cross-filesystem fallback)
-          await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {})
+          await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {});
           await rename(flatDir, targetDir).catch(async () => {
-            await ensureDir(targetDir)
-            const files = await readdir(flatDir).catch(() => [])
+            await ensureDir(targetDir);
+            const files = await readdir(flatDir).catch(() => []);
             for (const file of files) {
-              const content = await readFile(join(flatDir, file)).catch(() => null)
-              if (content !== null) await writeFile(join(targetDir, file), content)
+              const content = await readFile(join(flatDir, file)).catch(() => null);
+              if (content !== null) await writeFile(join(targetDir, file), content);
             }
-            await rm(flatDir, { recursive: true }).catch(() => {})
-          })
-          if (!existsSync(targetDir)) continue // Skip index update if move failed
+            await rm(flatDir, { recursive: true }).catch(() => {});
+          });
+          if (!existsSync(targetDir)) continue; // Skip index update if move failed
         } else if (!existsSync(targetDir)) {
-          await ensureDir(targetDir)
-          await writeFile(join(targetDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {})
+          await ensureDir(targetDir);
+          await writeFile(join(targetDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {});
         }
 
-        idx.set(id, dateStr)
+        idx.set(id, dateStr);
       }
 
-      delete state.agents[id]
+      delete state.agents[id];
     }
 
-    await saveState(state)
-    await saveAgentIndex()
-    console.log(`📦 Archived ${staleIds.length} stale agents from state.json (retained on disk)`)
-    cosEvents.emit('agents:changed', { action: 'auto-archive', archived: staleIds.length })
-    return { archived: staleIds.length }
-  })
+    await saveState(state);
+    await saveAgentIndex();
+    console.log(`📦 Archived ${staleIds.length} stale agents from state.json (retained on disk)`);
+    cosEvents.emit('agents:changed', { action: 'auto-archive', archived: staleIds.length });
+    return { archived: staleIds.length };
+  });
 }
 
 // Clear completed agents from state, cache, and disk
 export async function clearCompletedAgents() {
   return withStateLock(async () => {
-    const state = await loadState()
-    const idx = await loadAgentIndex()
+    const state = await loadState();
+    const idx = await loadAgentIndex();
 
     // Remove completed agents from state
     const stateCompleted = Object.keys(state.agents).filter(
       id => state.agents[id].status === 'completed'
-    )
+    );
     for (const id of stateCompleted) {
-      delete state.agents[id]
+      delete state.agents[id];
     }
-    await saveState(state)
+    await saveState(state);
 
     // Collect all unique dates from index, then remove date bucket dirs
-    const dates = new Set(idx.values())
-    const totalCleared = idx.size + stateCompleted.filter(id => !idx.has(id)).length
+    const dates = new Set(idx.values());
+    const totalCleared = idx.size + stateCompleted.filter(id => !idx.has(id)).length;
 
     const removals = [...dates].map(date => {
-      const dateDir = join(AGENTS_DIR, date)
+      const dateDir = join(AGENTS_DIR, date);
       return existsSync(dateDir)
         ? rm(dateDir, { recursive: true }).catch(() => {})
-        : Promise.resolve()
-    })
-    await Promise.all(removals)
+        : Promise.resolve();
+    });
+    await Promise.all(removals);
 
     // Clear index
-    idx.clear()
-    await saveAgentIndex()
+    idx.clear();
+    await saveAgentIndex();
 
-    return { cleared: totalCleared }
-  })
+    return { cleared: totalCleared };
+  });
 }

--- a/server/services/cosAgents.js
+++ b/server/services/cosAgents.js
@@ -1,0 +1,871 @@
+/**
+ * CoS Agents Module
+ *
+ * Agent lifecycle management extracted from cos.js.
+ * Handles agent registration, state tracking, output capture,
+ * date-bucketed archival, zombie cleanup, feedback, and index management.
+ */
+
+import { readFile, writeFile, rename, readdir, rm, stat } from 'fs/promises'
+import { existsSync } from 'fs'
+import { join } from 'path'
+import { cosEvents, emitLog } from './cosEvents.js'
+import { loadState, saveState, withStateLock, AGENTS_DIR } from './cosState.js'
+import { ensureDir, safeJSONParse } from '../lib/fileUtils.js'
+
+const INDEX_FILE = join(AGENTS_DIR, 'index.json')
+
+// Lightweight index mapping agentId → YYYY-MM-DD date bucket (~50KB vs 16MB full cache)
+// Lazy-loaded from data/cos/agents/index.json on first access
+let agentIndex = null
+let agentIndexPromise = null
+
+// Load agent index from disk (lazy init, singleton promise prevents concurrent migrations)
+export async function loadAgentIndex() {
+  if (agentIndex) return agentIndex
+  if (agentIndexPromise) return agentIndexPromise
+
+  agentIndexPromise = (async () => {
+    if (!existsSync(AGENTS_DIR)) {
+      await ensureDir(AGENTS_DIR)
+    }
+
+    if (existsSync(INDEX_FILE)) {
+      const content = await readFile(INDEX_FILE, 'utf-8').catch(() => '{}')
+      const parsed = safeJSONParse(content, {})
+      agentIndex = new Map(Object.entries(parsed))
+      console.log(`📂 Loaded agent index: ${agentIndex.size} entries`)
+    } else {
+      // No index yet — run migration from flat dirs to date buckets
+      agentIndex = await migrateAgentsToDateBuckets()
+    }
+
+    return agentIndex
+  })().catch(err => {
+    agentIndexPromise = null
+    throw err
+  })
+
+  return agentIndexPromise
+}
+
+// Persist agent index to disk (atomic write via temp file + rename)
+async function saveAgentIndex() {
+  if (!agentIndex) return
+  const obj = Object.fromEntries(agentIndex)
+  const tmpFile = `${INDEX_FILE}.tmp`
+  const written = await writeFile(tmpFile, JSON.stringify(obj)).then(() => true).catch(err => {
+    console.error(`❌ Failed to save agent index: ${err.message}`)
+    return false
+  })
+  if (!written) return
+  await rename(tmpFile, INDEX_FILE).catch(err => {
+    console.error(`❌ Failed to rename agent index: ${err.message}`)
+    rm(tmpFile, { force: true }).catch(() => {})
+  })
+}
+
+// Resolve the correct directory for an agent (running = flat, completed = date bucket)
+function getAgentDir(agentId, dateString) {
+  if (dateString) return join(AGENTS_DIR, dateString, agentId)
+  // Check index for date bucket
+  const date = agentIndex?.get(agentId)
+  if (date) return join(AGENTS_DIR, date, agentId)
+  // Fallback to flat dir (running agents or pre-migration)
+  return join(AGENTS_DIR, agentId)
+}
+
+// Migrate flat agent-* directories into YYYY-MM-DD date buckets
+// Runs once when index.json doesn't exist. Idempotent — no-op if already migrated.
+async function migrateAgentsToDateBuckets() {
+  const index = new Map()
+
+  if (!existsSync(AGENTS_DIR)) {
+    await ensureDir(AGENTS_DIR)
+    await writeFile(INDEX_FILE, '{}')
+    console.log('📂 Created empty agent index (no agents to migrate)')
+    return index
+  }
+
+  const entries = await readdir(AGENTS_DIR, { withFileTypes: true })
+
+  // Also scan existing date-bucket dirs to include them in the index
+  const dateDirPattern = /^\d{4}-\d{2}-\d{2}$/
+  for (const entry of entries) {
+    if (!entry.isDirectory() || !dateDirPattern.test(entry.name)) continue
+    const dateStr = entry.name
+    const dateDir = join(AGENTS_DIR, dateStr)
+    const agentDirs = await readdir(dateDir, { withFileTypes: true }).catch(() => [])
+    for (const agentEntry of agentDirs) {
+      if (agentEntry.isDirectory() && agentEntry.name.startsWith('agent-')) {
+        index.set(agentEntry.name, dateStr)
+      }
+    }
+  }
+
+  // Find flat agent-* dirs that need migration
+  const flatAgentDirs = entries.filter(e => e.isDirectory() && e.name.startsWith('agent-'))
+
+  if (flatAgentDirs.length === 0) {
+    await writeFile(INDEX_FILE, JSON.stringify(Object.fromEntries(index)))
+    console.log(`📂 Agent index built: ${index.size} entries (no flat dirs to migrate)`)
+    return index
+  }
+
+  console.log(`📦 Migrating ${flatAgentDirs.length} agents into date buckets...`)
+  let migrated = 0
+  let skipped = 0
+
+  for (const entry of flatAgentDirs) {
+    const agentId = entry.name
+    const agentDir = join(AGENTS_DIR, agentId)
+    const metaPath = join(agentDir, 'metadata.json')
+
+    let dateStr = null
+
+    // Try to get date from metadata
+    if (existsSync(metaPath)) {
+      const content = await readFile(metaPath, 'utf-8').catch(() => null)
+      if (content) {
+        const raw = safeJSONParse(content, null)
+        if (raw?.completedAt) {
+          dateStr = raw.completedAt.slice(0, 10) // YYYY-MM-DD
+        }
+      }
+    }
+
+    // Fallback: directory mtime
+    if (!dateStr) {
+      const dirStat = await stat(agentDir).catch(() => null)
+      if (dirStat?.mtime) {
+        dateStr = dirStat.mtime.toISOString().slice(0, 10)
+      }
+    }
+
+    if (!dateStr) {
+      console.log(`⚠️ Cannot determine date for ${agentId}, skipping`)
+      skipped++
+      continue
+    }
+
+    // Move into date bucket
+    const bucketDir = join(AGENTS_DIR, dateStr)
+    await ensureDir(bucketDir)
+    const targetDir = join(bucketDir, agentId)
+
+    // If target already exists (partial previous migration), skip
+    if (existsSync(targetDir)) {
+      index.set(agentId, dateStr)
+      migrated++
+      continue
+    }
+
+    await rename(agentDir, targetDir).catch(async (renameErr) => {
+      // rename can fail across filesystems — fall back to copy+delete
+      console.log(`⚠️ Rename failed for ${agentId}, using copy: ${renameErr.message}`)
+      try {
+        await ensureDir(targetDir)
+        const files = await readdir(agentDir)
+        for (const file of files) {
+          const content = await readFile(join(agentDir, file))
+          await writeFile(join(targetDir, file), content)
+        }
+        await rm(agentDir, { recursive: true })
+      } catch (copyErr) {
+        console.error(`❌ Copy fallback failed for ${agentId}: ${copyErr.message}`)
+        // Clean up partially-created target to avoid skipping on next startup
+        await rm(targetDir, { recursive: true, force: true }).catch(() => {})
+        throw copyErr
+      }
+    })
+
+    index.set(agentId, dateStr)
+    migrated++
+  }
+
+  // Persist index
+  await writeFile(INDEX_FILE, JSON.stringify(Object.fromEntries(index)))
+  const uniqueDates = new Set(index.values()).size
+  const parts = [`📦 Migrated ${migrated} agents into date buckets (${uniqueDates} unique dates)`]
+  if (skipped > 0) parts.push(`skipped ${skipped} undatable`)
+  console.log(parts.join(', '))
+
+  return index
+}
+
+// Prune agent archive date buckets older than retentionDays (default 90).
+// Removes directories + their index entries. Runs after migration on startup.
+export async function pruneOldAgentArchives(retentionDays = 90) {
+  const idx = await loadAgentIndex()
+  if (!idx || idx.size === 0) return
+
+  const cutoff = new Date()
+  cutoff.setDate(cutoff.getDate() - retentionDays)
+  const cutoffStr = cutoff.toISOString().slice(0, 10)
+
+  const dateDirPattern = /^\d{4}-\d{2}-\d{2}$/
+  const entries = await readdir(AGENTS_DIR, { withFileTypes: true }).catch(() => [])
+  const oldDates = entries
+    .filter(e => e.isDirectory() && dateDirPattern.test(e.name) && e.name < cutoffStr)
+    .map(e => e.name)
+
+  if (oldDates.length === 0) return
+
+  for (const dateStr of oldDates) {
+    await rm(join(AGENTS_DIR, dateStr), { recursive: true }).catch(() => {})
+  }
+
+  // Remove index entries for all old dates in a single pass
+  const oldDateSet = new Set(oldDates)
+  let pruned = 0
+  for (const [agentId, date] of idx.entries()) {
+    if (oldDateSet.has(date)) { idx.delete(agentId); pruned++ }
+  }
+
+  await saveAgentIndex()
+  console.log(`🗑️ Pruned ${pruned} archived agents older than ${retentionDays} days (${oldDates.length} date buckets)`)
+}
+
+export async function registerAgent(agentId, taskId, metadata = {}) {
+  return withStateLock(async () => {
+    const state = await loadState()
+
+    state.agents[agentId] = {
+      id: agentId,
+      taskId,
+      status: 'running',
+      startedAt: new Date().toISOString(),
+      metadata,
+      output: []
+    }
+
+    state.stats.agentsSpawned++
+    await saveState(state)
+
+    cosEvents.emit('agent:spawned', state.agents[agentId])
+    return state.agents[agentId]
+  })
+}
+
+export async function updateAgent(agentId, updates) {
+  return withStateLock(async () => {
+    const state = await loadState()
+
+    if (!state.agents[agentId]) {
+      return null
+    }
+
+    // Merge metadata if present in updates
+    if (updates.metadata) {
+      state.agents[agentId] = {
+        ...state.agents[agentId],
+        ...updates,
+        metadata: { ...state.agents[agentId].metadata, ...updates.metadata }
+      }
+    } else {
+      state.agents[agentId] = { ...state.agents[agentId], ...updates }
+    }
+    await saveState(state)
+
+    cosEvents.emit('agent:updated', state.agents[agentId])
+    return state.agents[agentId]
+  })
+}
+
+export async function completeAgent(agentId, result = {}) {
+  return withStateLock(async () => {
+    const state = await loadState()
+
+    if (!state.agents[agentId]) {
+      return null
+    }
+
+    state.agents[agentId] = {
+      ...state.agents[agentId],
+      status: 'completed',
+      completedAt: new Date().toISOString(),
+      result
+    }
+
+    if (result.success) {
+      state.stats.tasksCompleted++
+    } else {
+      state.stats.errors = (state.stats.errors || 0) + 1
+    }
+
+    await saveState(state)
+    cosEvents.emit('agent:completed', state.agents[agentId])
+    cosEvents.emit('agent:updated', state.agents[agentId])
+
+    // Determine date bucket from completedAt
+    const dateStr = state.agents[agentId].completedAt.slice(0, 10)
+    const bucketDir = join(AGENTS_DIR, dateStr)
+    await ensureDir(bucketDir)
+
+    // Write metadata to flat dir first (may already have output.txt/prompt.txt there)
+    const flatDir = join(AGENTS_DIR, agentId)
+    if (!existsSync(flatDir)) {
+      await ensureDir(flatDir)
+    }
+    const { output: _output, ...agentWithoutOutput } = state.agents[agentId]
+    await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2))
+
+    // Move entire agent dir into date bucket (atomic on same filesystem)
+    const targetDir = join(bucketDir, agentId)
+    if (!existsSync(targetDir)) {
+      await rename(flatDir, targetDir).catch(async () => {
+        // Fallback for cross-filesystem: copy files then remove
+        await ensureDir(targetDir)
+        const files = await readdir(flatDir)
+        for (const file of files) {
+          const content = await readFile(join(flatDir, file))
+          await writeFile(join(targetDir, file), content)
+        }
+        await rm(flatDir, { recursive: true })
+      })
+    }
+
+    // Update index
+    const idx = await loadAgentIndex()
+    idx.set(agentId, dateStr)
+    await saveAgentIndex()
+
+    return state.agents[agentId]
+  })
+}
+
+export async function appendAgentOutput(agentId, line) {
+  const result = await withStateLock(async () => {
+    const state = await loadState()
+
+    if (!state.agents[agentId]) {
+      return null
+    }
+
+    state.agents[agentId].output.push({
+      timestamp: new Date().toISOString(),
+      line
+    })
+
+    // Trim to last 1000 lines in state
+    if (state.agents[agentId].output.length > 1000) {
+      state.agents[agentId].output = state.agents[agentId].output.slice(-1000)
+    }
+
+    await saveState(state)
+    return state.agents[agentId]
+  })
+
+  if (result) {
+    cosEvents.emit('agent:output', { agentId, line })
+  }
+
+  return result
+}
+
+// Get all agents from in-memory state (includes running and recently completed; archived agents loaded via getAgentsByDate)
+export async function getAgents() {
+  const state = await loadState()
+  return Object.values(state.agents)
+}
+
+// Get available agent date buckets with counts, sorted descending
+export async function getAgentDates() {
+  const idx = await loadAgentIndex()
+  const dateCounts = {}
+  for (const date of idx.values()) {
+    dateCounts[date] = (dateCounts[date] || 0) + 1
+  }
+  return Object.entries(dateCounts)
+    .map(([date, count]) => ({ date, count }))
+    .sort((a, b) => b.date.localeCompare(a.date))
+}
+
+// Get completed agents for a specific date bucket
+export async function getAgentsByDate(date) {
+  const dateDir = join(AGENTS_DIR, date)
+  if (!existsSync(dateDir)) return []
+
+  const entries = await readdir(dateDir, { withFileTypes: true })
+  const agentDirs = entries.filter(e => e.isDirectory() && e.name.startsWith('agent-'))
+  const agents = []
+
+  // Batch reads in chunks of 50 to avoid fd exhaustion on large date buckets
+  const BATCH_SIZE = 50
+  for (let i = 0; i < agentDirs.length; i += BATCH_SIZE) {
+    const batch = agentDirs.slice(i, i + BATCH_SIZE)
+    const reads = batch.map(async (entry) => {
+      const metaPath = join(dateDir, entry.name, 'metadata.json')
+      const content = await readFile(metaPath, 'utf-8').catch(() => null)
+      if (!content) return
+      const raw = safeJSONParse(content, null)
+      if (!raw) return
+      const id = raw.id || raw.agentId || entry.name
+      const { output, ...rest } = raw
+      agents.push({ ...rest, id, status: raw.status || 'completed' })
+    })
+    await Promise.allSettled(reads)
+  }
+
+  return agents.sort((a, b) => new Date(b.completedAt || 0) - new Date(a.completedAt || 0))
+}
+
+// Get agent by ID with full output from file
+export async function getAgent(agentId) {
+  const state = await loadState()
+  let agent = state.agents[agentId]
+
+  // Fall back to disk metadata via index if not in state
+  if (!agent) {
+    const idx = await loadAgentIndex()
+    const dateStr = idx.get(agentId)
+    if (dateStr) {
+      const metaPath = join(AGENTS_DIR, dateStr, agentId, 'metadata.json')
+      const content = await readFile(metaPath, 'utf-8').catch(() => null)
+      if (content) {
+        const raw = safeJSONParse(content, null)
+        if (raw) {
+          const { output, ...rest } = raw
+          agent = { ...rest, id: raw.id || raw.agentId || agentId, status: raw.status || 'completed' }
+        }
+      }
+    }
+  }
+  if (!agent) return null
+
+  // For completed agents, read full output from file
+  if (agent.status === 'completed') {
+    const dateStr = agent.completedAt?.slice(0, 10)
+    const agentDir = dateStr ? getAgentDir(agentId, dateStr) : getAgentDir(agentId)
+    const outputFile = join(agentDir, 'output.txt')
+    if (existsSync(outputFile)) {
+      const fullOutput = await readFile(outputFile, 'utf-8')
+      const lines = fullOutput.split('\n').filter(line => line.trim())
+      return {
+        ...agent,
+        output: lines.map(line => ({ line, timestamp: agent.completedAt }))
+      }
+    }
+  }
+
+  return agent
+}
+
+// Terminate an agent (will be handled by spawner)
+export async function terminateAgent(agentId) {
+  // Emit event to kill the process FIRST
+  cosEvents.emit('agent:terminate', agentId)
+  // The spawner will handle marking the agent as completed after termination
+  return { success: true, agentId }
+}
+
+// Force kill an agent with SIGKILL (immediate, no graceful shutdown)
+export async function killAgent(agentId) {
+  const { killAgent: killAgentFromSpawner } = await import('./subAgentSpawner.js')
+  return killAgentFromSpawner(agentId)
+}
+
+// Send a BTW (additional context) message to a running agent
+export async function sendBtwToAgent(agentId, message) {
+  // Single locked read to validate agent and extract workspacePath
+  const agentInfo = await withStateLock(async () => {
+    const state = await loadState()
+    const agent = state.agents[agentId]
+    if (!agent) return { error: 'Agent not found' }
+    if (agent.status !== 'running') return { error: 'Agent is not running' }
+    if (!agent.metadata?.workspacePath) return { error: 'Agent has no workspace path' }
+    return { workspacePath: agent.metadata.workspacePath }
+  })
+
+  if (agentInfo.error) return agentInfo
+
+  // Send to runner to write the BTW.md file
+  const { sendBtwToAgent: sendViaRunner } = await import('./cosRunnerClient.js')
+  const result = await sendViaRunner(agentId, message)
+
+  // Track in agent state (cap at 50 messages)
+  const timestamp = new Date().toISOString()
+  await withStateLock(async () => {
+    const state = await loadState()
+    if (!state.agents[agentId]) return
+    if (!state.agents[agentId].btwMessages) {
+      state.agents[agentId].btwMessages = []
+    }
+    state.agents[agentId].btwMessages.push({ message, timestamp })
+    if (state.agents[agentId].btwMessages.length > 50) {
+      state.agents[agentId].btwMessages = state.agents[agentId].btwMessages.slice(-50)
+    }
+    await saveState(state)
+  })
+
+  cosEvents.emit('agent:btw', { agentId, message, timestamp })
+  return { success: true, ...result }
+}
+
+// Get process stats for an agent (CPU, memory)
+export async function getAgentProcessStats(agentId) {
+  const { getAgentProcessStats: getStatsFromSpawner } = await import('./subAgentSpawner.js')
+  return getStatsFromSpawner(agentId)
+}
+
+// Check if a PID is still running
+async function isPidAlive(pid) {
+  if (!pid) return false
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Cleanup zombie agents - agents marked as running but whose process is dead
+export async function cleanupZombieAgents() {
+  // Check local tracking maps
+  const { getActiveAgentIds } = await import('./subAgentSpawner.js')
+  const activeIds = getActiveAgentIds()
+
+  // Also check with the CoS runner for agents it's actively tracking
+  const { getActiveAgentsFromRunner } = await import('./cosRunnerClient.js')
+  const runnerAgents = await getActiveAgentsFromRunner().catch(() => [])
+  const runnerAgentIds = new Set(runnerAgents.map(a => a.id))
+
+  return withStateLock(async () => {
+    const state = await loadState()
+    const runningAgents = Object.values(state.agents).filter(a => a.status === 'running')
+    const cleaned = []
+
+    for (const agent of runningAgents) {
+      // Skip if tracked in local maps or runner
+      if (activeIds.includes(agent.id) || runnerAgentIds.has(agent.id)) {
+        continue
+      }
+
+      // If agent has a PID, verify the process is actually dead
+      if (agent.pid) {
+        const alive = await isPidAlive(agent.pid)
+        if (alive) continue
+      } else {
+        // No PID yet - agent might still be initializing
+        // Give it a 30 second grace period before marking as zombie
+        const startedAt = agent.startedAt ? new Date(agent.startedAt).getTime() : 0
+        const ageMs = Date.now() - startedAt
+        if (ageMs < 30000) continue
+      }
+
+      // Agent is not tracked anywhere and process is dead — it's a zombie
+      console.log(`🧟 Zombie agent detected: ${agent.id} (PID ${agent.pid || 'unknown'} not running)`)
+      state.agents[agent.id] = {
+        ...agent,
+        status: 'completed',
+        completedAt: new Date().toISOString(),
+        result: { success: false, error: 'Agent process terminated unexpectedly' }
+      }
+      cleaned.push(agent.id)
+    }
+
+    if (cleaned.length > 0) {
+      await saveState(state)
+
+      // Persist zombie-cleaned agents to date-bucketed dirs and update index
+      const idx = await loadAgentIndex()
+      for (const agentId of cleaned) {
+        const agent = state.agents[agentId]
+        const dateStr = agent.completedAt?.slice(0, 10)
+        if (!dateStr) continue
+        const bucketDir = join(AGENTS_DIR, dateStr)
+        await ensureDir(bucketDir)
+
+        const flatDir = join(AGENTS_DIR, agentId)
+        const { output, ...agentWithoutOutput } = agent
+
+        // Ensure metadata is written before move
+        if (!existsSync(flatDir)) await ensureDir(flatDir)
+        await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {})
+
+        // Move to date bucket
+        const targetDir = join(bucketDir, agentId)
+        if (!existsSync(targetDir)) {
+          await rename(flatDir, targetDir).catch(async () => {
+            await ensureDir(targetDir)
+            const files = await readdir(flatDir)
+            for (const file of files) {
+              const content = await readFile(join(flatDir, file))
+              await writeFile(join(targetDir, file), content)
+            }
+            await rm(flatDir, { recursive: true })
+          })
+        }
+
+        idx.set(agentId, dateStr)
+      }
+      await saveAgentIndex()
+
+      console.log(`🧹 Cleaned up ${cleaned.length} zombie agents: ${cleaned.join(', ')}`)
+      cosEvents.emit('agents:changed', { action: 'zombie-cleanup', cleaned })
+    }
+
+    return { cleaned, count: cleaned.length }
+  })
+}
+
+// Delete a single agent from state and disk
+export async function deleteAgent(agentId) {
+  return withStateLock(async () => {
+    const state = await loadState()
+    const idx = await loadAgentIndex()
+
+    const inState = !!state.agents[agentId]
+    const inIndex = idx.has(agentId)
+    if (!inState && !inIndex) {
+      return { error: 'Agent not found' }
+    }
+
+    delete state.agents[agentId]
+    await saveState(state)
+
+    // Remove from disk (date-bucketed or flat)
+    const agentDir = getAgentDir(agentId)
+    if (existsSync(agentDir)) {
+      await rm(agentDir, { recursive: true }).catch(() => {})
+    }
+
+    // Remove from index
+    idx.delete(agentId)
+    await saveAgentIndex()
+
+    cosEvents.emit('agents:changed', { action: 'deleted', agentId })
+    return { success: true, agentId }
+  })
+}
+
+// Submit feedback for a completed agent
+export async function submitAgentFeedback(agentId, feedback) {
+  return withStateLock(async () => {
+    const state = await loadState()
+    const feedbackData = {
+      rating: feedback.rating,
+      comment: feedback.comment || null,
+      submittedAt: new Date().toISOString()
+    }
+
+    // Try state first (recently completed agents still in state)
+    if (state.agents[agentId]) {
+      const agent = state.agents[agentId]
+      if (agent.status !== 'completed') {
+        return { error: 'Can only submit feedback for completed agents' }
+      }
+      state.agents[agentId].feedback = feedbackData
+      await saveState(state)
+
+      // Also update on-disk metadata (derive date bucket from completedAt if archived)
+      const dateBucket = agent.completedAt ? agent.completedAt.slice(0, 10) : null
+      const agentDir = getAgentDir(agentId, dateBucket)
+      const metaPath = join(agentDir, 'metadata.json')
+      if (existsSync(metaPath)) {
+        const content = await readFile(metaPath, 'utf-8').catch(() => null)
+        if (content) {
+          const raw = safeJSONParse(content, null)
+          if (raw) {
+            raw.feedback = feedbackData
+            await writeFile(metaPath, JSON.stringify(raw, null, 2)).catch(() => {})
+          }
+        }
+      }
+
+      emitLog('info', `Feedback received for agent ${agentId}: ${feedback.rating}`, { agentId, rating: feedback.rating })
+      cosEvents.emit('agent:feedback', { agentId, feedback: feedbackData })
+      return { success: true, agent: state.agents[agentId] }
+    }
+
+    // Agent not in state — look up from disk via index
+    const idx = await loadAgentIndex()
+    const dateStr = idx.get(agentId)
+    if (!dateStr) return { error: 'Agent not found' }
+
+    const metaPath = join(AGENTS_DIR, dateStr, agentId, 'metadata.json')
+    const content = await readFile(metaPath, 'utf-8').catch(() => null)
+    if (!content) return { error: 'Agent not found' }
+
+    const raw = safeJSONParse(content, null)
+    if (!raw) return { error: 'Agent not found' }
+
+    raw.feedback = feedbackData
+    await writeFile(metaPath, JSON.stringify(raw, null, 2))
+
+    emitLog('info', `Feedback received for agent ${agentId}: ${feedback.rating}`, { agentId, rating: feedback.rating })
+    cosEvents.emit('agent:feedback', { agentId, feedback: feedbackData })
+    return { success: true, agent: { ...raw, id: agentId } }
+  })
+}
+
+// Get aggregated feedback statistics
+export async function getFeedbackStats() {
+  const state = await loadState()
+  const agents = Object.values(state.agents)
+
+  const withFeedback = agents.filter(a => a.feedback)
+  const positive = withFeedback.filter(a => a.feedback.rating === 'positive').length
+  const negative = withFeedback.filter(a => a.feedback.rating === 'negative').length
+  const neutral = withFeedback.filter(a => a.feedback.rating === 'neutral').length
+
+  // Group by task type
+  const byTaskType = {}
+  withFeedback.forEach(a => {
+    const taskType = extractTaskType(a.metadata?.taskDescription)
+    if (!byTaskType[taskType]) {
+      byTaskType[taskType] = { positive: 0, negative: 0, neutral: 0, total: 0 }
+    }
+    byTaskType[taskType][a.feedback.rating]++
+    byTaskType[taskType].total++
+  })
+
+  // Recent feedback (last 10 with comments)
+  const recentWithComments = withFeedback
+    .filter(a => a.feedback.comment)
+    .sort((a, b) => new Date(b.feedback.submittedAt) - new Date(a.feedback.submittedAt))
+    .slice(0, 10)
+    .map(a => ({
+      agentId: a.id,
+      taskDescription: a.metadata?.taskDescription,
+      rating: a.feedback.rating,
+      comment: a.feedback.comment,
+      submittedAt: a.feedback.submittedAt
+    }))
+
+  const satisfactionRate = withFeedback.length > 0
+    ? Math.round((positive / withFeedback.length) * 100)
+    : null
+
+  return {
+    total: withFeedback.length,
+    positive,
+    negative,
+    neutral,
+    satisfactionRate,
+    byTaskType,
+    recentWithComments
+  }
+}
+
+// Helper to extract task type from description (mirrors client-side logic)
+export function extractTaskType(description) {
+  if (!description) return 'general'
+  const d = description.toLowerCase()
+  if (d.includes('fix') || d.includes('bug') || d.includes('error') || d.includes('issue')) return 'bug-fix'
+  if (d.includes('refactor') || d.includes('clean up') || d.includes('improve') || d.includes('optimize')) return 'refactor'
+  if (d.includes('test')) return 'testing'
+  if (d.includes('document') || d.includes('readme') || d.includes('docs')) return 'documentation'
+  if (d.includes('review') || d.includes('audit')) return 'code-review'
+  if (d.includes('mobile') || d.includes('responsive')) return 'mobile-responsive'
+  if (d.includes('security') || d.includes('vulnerability')) return 'security'
+  if (d.includes('performance') || d.includes('speed')) return 'performance'
+  if (d.includes('ui') || d.includes('ux') || d.includes('design') || d.includes('style')) return 'ui-ux'
+  if (d.includes('api') || d.includes('endpoint') || d.includes('route')) return 'api'
+  if (d.includes('database') || d.includes('migration')) return 'database'
+  if (d.includes('deploy') || d.includes('ci') || d.includes('cd')) return 'devops'
+  if (d.includes('investigate') || d.includes('debug')) return 'investigation'
+  if (d.includes('self-improvement') || d.includes('feature idea')) return 'self-improvement'
+  return 'feature'
+}
+
+// Archive stale completed agents from state.json.
+// Completed agents are already persisted to per-agent metadata files on disk
+// (metadata.json) by completeAgent(), so removing them from state.json only
+// reduces the size of the in-memory state and the state.json file.
+export async function archiveStaleAgents() {
+  return withStateLock(async () => {
+    const state = await loadState()
+    const retentionMs = state.config.completedAgentRetentionMs ?? 86400000
+    const cutoff = Date.now() - retentionMs
+
+    const staleIds = Object.keys(state.agents).filter(id => {
+      const agent = state.agents[id]
+      if (agent.status !== 'completed') return false
+      const completedAt = agent.completedAt ? new Date(agent.completedAt).getTime() : 0
+      return completedAt > 0 && completedAt < cutoff
+    })
+
+    if (staleIds.length === 0) return { archived: 0 }
+
+    const idx = await loadAgentIndex()
+
+    for (const id of staleIds) {
+      // Ensure agent is persisted to date-bucketed disk before removing from state
+      if (!idx.has(id)) {
+        const agent = state.agents[id]
+        const dateStr = agent.completedAt?.slice(0, 10)
+        if (!dateStr) continue
+        const bucketDir = join(AGENTS_DIR, dateStr)
+        await ensureDir(bucketDir)
+
+        const { output, ...agentWithoutOutput } = agent
+        const flatDir = join(AGENTS_DIR, id)
+        const targetDir = join(bucketDir, id)
+
+        if (existsSync(flatDir) && !existsSync(targetDir)) {
+          // Write metadata then move (with cross-filesystem fallback)
+          await writeFile(join(flatDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {})
+          await rename(flatDir, targetDir).catch(async () => {
+            await ensureDir(targetDir)
+            const files = await readdir(flatDir).catch(() => [])
+            for (const file of files) {
+              const content = await readFile(join(flatDir, file)).catch(() => null)
+              if (content !== null) await writeFile(join(targetDir, file), content)
+            }
+            await rm(flatDir, { recursive: true }).catch(() => {})
+          })
+          if (!existsSync(targetDir)) continue // Skip index update if move failed
+        } else if (!existsSync(targetDir)) {
+          await ensureDir(targetDir)
+          await writeFile(join(targetDir, 'metadata.json'), JSON.stringify(agentWithoutOutput, null, 2)).catch(() => {})
+        }
+
+        idx.set(id, dateStr)
+      }
+
+      delete state.agents[id]
+    }
+
+    await saveState(state)
+    await saveAgentIndex()
+    console.log(`📦 Archived ${staleIds.length} stale agents from state.json (retained on disk)`)
+    cosEvents.emit('agents:changed', { action: 'auto-archive', archived: staleIds.length })
+    return { archived: staleIds.length }
+  })
+}
+
+// Clear completed agents from state, cache, and disk
+export async function clearCompletedAgents() {
+  return withStateLock(async () => {
+    const state = await loadState()
+    const idx = await loadAgentIndex()
+
+    // Remove completed agents from state
+    const stateCompleted = Object.keys(state.agents).filter(
+      id => state.agents[id].status === 'completed'
+    )
+    for (const id of stateCompleted) {
+      delete state.agents[id]
+    }
+    await saveState(state)
+
+    // Collect all unique dates from index, then remove date bucket dirs
+    const dates = new Set(idx.values())
+    const totalCleared = idx.size + stateCompleted.filter(id => !idx.has(id)).length
+
+    const removals = [...dates].map(date => {
+      const dateDir = join(AGENTS_DIR, date)
+      return existsSync(dateDir)
+        ? rm(dateDir, { recursive: true }).catch(() => {})
+        : Promise.resolve()
+    })
+    await Promise.all(removals)
+
+    // Clear index
+    idx.clear()
+    await saveAgentIndex()
+
+    return { cleared: totalCleared }
+  })
+}

--- a/server/services/cosEvents.js
+++ b/server/services/cosEvents.js
@@ -5,10 +5,10 @@
  * Separated to avoid circular dependencies between cos.js and other modules.
  */
 
-import { EventEmitter } from 'events'
+import { EventEmitter } from 'events';
 
 // Event emitter for CoS events
-export const cosEvents = new EventEmitter()
+export const cosEvents = new EventEmitter();
 
 /**
  * Emit a log event for UI display
@@ -23,20 +23,12 @@ export function emitLog(level, message, data = {}, prefix = '') {
     level,
     message,
     ...data
+  };
+  // Debug messages go to socket only (UI), not console — set COS_LOG_LEVEL=debug to include them
+  if (level !== 'debug' || process.env.COS_LOG_LEVEL === 'debug') {
+    const emoji = level === 'error' ? '❌' : level === 'warn' ? '⚠️' : level === 'success' ? '✅' : level === 'debug' ? '🔍' : 'ℹ️';
+    const prefixStr = prefix ? ` ${prefix}` : '';
+    console.log(`${emoji}${prefixStr} ${message}`);
   }
-
-  // Emit for UI
-  cosEvents.emit('log', logEntry)
-
-  // Also log to console with appropriate emoji
-  const levelEmojis = {
-    info: 'i',
-    warn: '!',
-    error: 'x',
-    success: '+',
-    debug: '.'
-  }
-  const emoji = levelEmojis[level] || 'i'
-  const prefixStr = prefix ? `${prefix}: ` : ''
-  console.log(`[${logEntry.timestamp}] ${emoji} ${prefixStr}${message}`)
+  cosEvents.emit('log', logEntry);
 }

--- a/server/services/cosReports.js
+++ b/server/services/cosReports.js
@@ -116,10 +116,11 @@ export async function getTodayActivity() {
   const succeeded = todayAgents.filter(a => a.result?.success);
   const failed = todayAgents.filter(a => !a.result?.success);
 
-  // Calculate total time worked (sum of agent durations)
+  // Calculate total time worked (sum of agent durations, fallback to completedAt - startedAt)
   const totalDurationMs = todayAgents.reduce((sum, a) => {
-    const duration = a.result?.duration || 0;
-    return sum + duration;
+    const duration = a.result?.duration
+      || (a.completedAt && a.startedAt ? new Date(a.completedAt).getTime() - new Date(a.startedAt).getTime() : 0);
+    return sum + (duration > 0 ? duration : 0);
   }, 0);
 
   // Get currently running agents
@@ -136,7 +137,8 @@ export async function getTodayActivity() {
       taskId: a.taskId,
       description: a.metadata?.taskDescription?.substring(0, 100) || a.taskId,
       taskType: a.metadata?.analysisType || a.metadata?.taskType || 'task',
-      duration: a.result?.duration || 0,
+      duration: a.result?.duration
+        || (a.completedAt && a.startedAt ? new Date(a.completedAt).getTime() - new Date(a.startedAt).getTime() : 0),
       completedAt: a.completedAt
     }))
     .sort((a, b) => new Date(b.completedAt) - new Date(a.completedAt))

--- a/server/services/cosReports.js
+++ b/server/services/cosReports.js
@@ -1,0 +1,228 @@
+/**
+ * CoS Reports Module
+ *
+ * Reports, briefings, and activity tracking extracted from cos.js.
+ * Handles daily reports, briefings, activity summaries, and recent tasks.
+ */
+
+import { readFile, writeFile, readdir } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { loadState, ensureDirectories, REPORTS_DIR, isDaemonRunning } from './cosState.js';
+import { formatDuration, safeJSONParse } from '../lib/fileUtils.js';
+
+export async function generateReport(date = null) {
+  const reportDate = date || new Date().toISOString().split('T')[0];
+  const state = await loadState();
+
+  // Filter agents completed on this date
+  const completedAgents = Object.values(state.agents).filter(a => {
+    if (!a.completedAt) return false;
+    return a.completedAt.startsWith(reportDate);
+  });
+
+  const report = {
+    date: reportDate,
+    generated: new Date().toISOString(),
+    summary: {
+      tasksCompleted: completedAgents.filter(a => a.result?.success).length,
+      tasksFailed: completedAgents.filter(a => !a.result?.success).length,
+      totalAgents: completedAgents.length
+    },
+    agents: completedAgents.map(a => ({
+      id: a.id,
+      taskId: a.taskId,
+      success: a.result?.success || false,
+      duration: a.completedAt && a.startedAt
+        ? new Date(a.completedAt) - new Date(a.startedAt)
+        : 0
+    }))
+  };
+
+  // Save report
+  const reportFile = join(REPORTS_DIR, `${reportDate}.json`);
+  await writeFile(reportFile, JSON.stringify(report, null, 2));
+
+  return report;
+}
+
+export async function getReport(date) {
+  const reportFile = join(REPORTS_DIR, `${date}.json`);
+
+  if (!existsSync(reportFile)) {
+    return null;
+  }
+
+  const content = await readFile(reportFile, 'utf-8');
+  return safeJSONParse(content, null, { logError: true, context: `report ${date}` });
+}
+
+export async function getTodayReport() {
+  const today = new Date().toISOString().split('T')[0];
+  return (await getReport(today)) ?? generateReport(today);
+}
+
+export async function listReports() {
+  await ensureDirectories();
+
+  const files = await readdir(REPORTS_DIR);
+  return files
+    .filter(f => f.endsWith('.json'))
+    .map(f => f.replace('.json', ''))
+    .sort()
+    .reverse();
+}
+
+export async function listBriefings() {
+  await ensureDirectories();
+
+  const files = await readdir(REPORTS_DIR);
+  return files
+    .filter(f => f.endsWith('-briefing.md'))
+    .map(f => {
+      const date = f.replace('-briefing.md', '');
+      return { date, filename: f };
+    })
+    .sort((a, b) => b.date.localeCompare(a.date));
+}
+
+export async function getBriefing(date) {
+  const briefingFile = join(REPORTS_DIR, `${date}-briefing.md`);
+
+  if (!existsSync(briefingFile)) {
+    return null;
+  }
+
+  const content = await readFile(briefingFile, 'utf-8');
+  return { date, content };
+}
+
+export async function getLatestBriefing() {
+  const briefings = await listBriefings();
+  if (briefings.length === 0) return null;
+  return getBriefing(briefings[0].date);
+}
+
+export async function getTodayActivity() {
+  const state = await loadState();
+  const today = new Date().toISOString().split('T')[0];
+
+  // Filter agents completed today
+  const todayAgents = Object.values(state.agents).filter(a => {
+    if (!a.completedAt) return false;
+    return a.completedAt.startsWith(today);
+  });
+
+  const succeeded = todayAgents.filter(a => a.result?.success);
+  const failed = todayAgents.filter(a => !a.result?.success);
+
+  // Calculate total time worked (sum of agent durations)
+  const totalDurationMs = todayAgents.reduce((sum, a) => {
+    const duration = a.result?.duration || 0;
+    return sum + duration;
+  }, 0);
+
+  // Get currently running agents
+  const runningAgents = Object.values(state.agents).filter(a => a.status === 'running');
+  const activeTimeMs = runningAgents.reduce((sum, a) => {
+    if (!a.startedAt) return sum;
+    return sum + (Date.now() - new Date(a.startedAt).getTime());
+  }, 0);
+
+  // Get top accomplishments (successful tasks with description snippets)
+  const accomplishments = succeeded
+    .map(a => ({
+      id: a.id,
+      taskId: a.taskId,
+      description: a.metadata?.taskDescription?.substring(0, 100) || a.taskId,
+      taskType: a.metadata?.analysisType || a.metadata?.taskType || 'task',
+      duration: a.result?.duration || 0,
+      completedAt: a.completedAt
+    }))
+    .sort((a, b) => new Date(b.completedAt) - new Date(a.completedAt))
+    .slice(0, 5);
+
+  // Calculate success rate
+  const successRate = todayAgents.length > 0
+    ? Math.round((succeeded.length / todayAgents.length) * 100)
+    : 0;
+
+  return {
+    date: today,
+    stats: {
+      completed: todayAgents.length,
+      succeeded: succeeded.length,
+      failed: failed.length,
+      successRate,
+      running: runningAgents.length
+    },
+    time: {
+      totalDurationMs,
+      totalDuration: formatDuration(totalDurationMs),
+      activeDurationMs: activeTimeMs,
+      activeDuration: formatDuration(activeTimeMs),
+      combinedMs: totalDurationMs + activeTimeMs,
+      combined: formatDuration(totalDurationMs + activeTimeMs)
+    },
+    accomplishments,
+    lastEvaluation: state.stats.lastEvaluation,
+    isRunning: isDaemonRunning(),
+    isPaused: state.paused
+  };
+}
+
+// Returns recently completed tasks from in-memory state only.
+// Agents older than the retention window are archived to date-bucketed dirs
+// and are not included here — use getAgentsByDate() for historical lookups.
+export async function getRecentTasks(limit = 10) {
+  const state = await loadState();
+
+  const completedAgents = Object.values(state.agents)
+    .filter(a => a.status === 'completed' && a.completedAt)
+    .sort((a, b) => new Date(b.completedAt) - new Date(a.completedAt))
+    .slice(0, limit);
+
+  // Transform to compact task summaries
+  const tasks = completedAgents.map(a => ({
+    id: a.id,
+    taskId: a.taskId,
+    description: a.metadata?.taskDescription?.substring(0, 120) || a.taskId,
+    taskType: a.metadata?.analysisType || a.metadata?.taskType || 'task',
+    app: a.metadata?.app || null,
+    success: a.result?.success || false,
+    duration: a.result?.duration || 0,
+    durationFormatted: formatDuration(a.result?.duration || 0),
+    completedAt: a.completedAt,
+    completedRelative: formatRelativeTime(a.completedAt)
+  }));
+
+  // Calculate summary stats
+  const successCount = tasks.filter(t => t.success).length;
+  const failCount = tasks.filter(t => !t.success).length;
+
+  return {
+    tasks,
+    summary: {
+      total: tasks.length,
+      succeeded: successCount,
+      failed: failCount,
+      successRate: tasks.length > 0 ? Math.round((successCount / tasks.length) * 100) : 0
+    }
+  };
+}
+
+export function formatRelativeTime(timestamp) {
+  const now = new Date();
+  const then = new Date(timestamp);
+  const diffMs = now - then;
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 1) return 'just now';
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays === 1) return 'yesterday';
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return then.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}

--- a/server/services/cosState.js
+++ b/server/services/cosState.js
@@ -1,0 +1,169 @@
+/**
+ * CoS State Module
+ *
+ * Shared state management for Chief of Staff services.
+ */
+
+import { readFile, writeFile, rename, readdir, rm } from 'fs/promises';
+import { existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { createMutex } from '../lib/asyncMutex.js';
+import { ensureDirs, safeJSONParse, PATHS } from '../lib/fileUtils.js';
+
+export const STATE_FILE = join(PATHS.cos, 'state.json');
+export const AGENTS_DIR = join(PATHS.cos, 'agents');
+export const REPORTS_DIR = PATHS.reports;
+export const SCRIPTS_DIR = PATHS.scripts;
+export const ROOT_DIR = PATHS.root;
+
+// Mutex lock for state operations to prevent race conditions
+export const withStateLock = createMutex();
+
+export const DEFAULT_CONFIG = {
+  userTasksFile: 'data/TASKS.md',
+  cosTasksFile: 'data/COS-TASKS.md',
+  goalsFile: 'GOALS.md',
+  evaluationIntervalMs: 60000,
+  healthCheckIntervalMs: 900000,
+  maxConcurrentAgents: 3,
+  maxConcurrentAgentsPerProject: 2,
+  maxProcessMemoryMb: 2048,
+  maxTotalProcesses: 50,
+  mcpServers: [
+    { name: 'filesystem', command: 'npx', args: ['-y', '@anthropic/mcp-server-filesystem'] },
+    { name: 'puppeteer', command: 'npx', args: ['-y', '@anthropic/mcp-puppeteer', '--isolated'] }
+  ],
+  autoStart: false,
+  selfImprovementEnabled: true,
+  appImprovementEnabled: true,
+  improvementEnabled: true,
+  avatarStyle: 'svg',
+  dynamicAvatar: true,
+  alwaysOn: true,
+  appReviewCooldownMs: 1800000,
+  idleReviewEnabled: true,
+  idleReviewPriority: 'MEDIUM',
+  comprehensiveAppImprovement: true,
+  immediateExecution: true,
+  proactiveMode: true,
+  autonomousJobsEnabled: true,
+  autonomyLevel: 'standby',
+  rehabilitationGracePeriodDays: 7,
+  completedAgentRetentionMs: 86400000,
+  embeddingProviderId: 'lmstudio',
+  embeddingModel: '',
+  autoFixThresholds: {
+    maxLinesChanged: 50,
+    allowedCategories: [
+      'formatting',
+      'dry-violations',
+      'dead-code',
+      'typo-fix',
+      'import-cleanup'
+    ]
+  }
+};
+
+export const DEFAULT_STATE = {
+  running: false,
+  paused: false,
+  pausedAt: null,
+  pauseReason: null,
+  config: DEFAULT_CONFIG,
+  stats: {
+    tasksCompleted: 0,
+    totalRuntime: 0,
+    agentsSpawned: 0,
+    errors: 0,
+    lastEvaluation: null,
+    lastIdleReview: null
+  },
+  agents: {}
+};
+
+export async function ensureDirectories() {
+  await ensureDirs([PATHS.data, PATHS.cos, AGENTS_DIR, REPORTS_DIR, SCRIPTS_DIR]);
+}
+
+function isValidJSON(str) {
+  if (!str || !str.trim()) return false;
+  const trimmed = str.trim();
+  if (!(trimmed.startsWith('{') && trimmed.endsWith('}'))) return false;
+  if (trimmed.includes('}{')) return false;
+  return true;
+}
+
+// In-memory state cache — avoids re-reading state.json from disk on every call.
+// All mutations go through withStateLock, so the cache stays consistent.
+let stateCache = null;
+
+export async function loadState() {
+  if (stateCache) return stateCache;
+
+  await ensureDirectories();
+
+  if (!existsSync(STATE_FILE)) {
+    stateCache = structuredClone(DEFAULT_STATE);
+    return stateCache;
+  }
+
+  const content = await readFile(STATE_FILE, 'utf-8');
+
+  if (!isValidJSON(content)) {
+    console.log(`⚠️ Corrupted or empty state file at ${STATE_FILE}, returning default state`);
+    const backupPath = `${STATE_FILE}.corrupted.${Date.now()}`;
+    await writeFile(backupPath, content).catch(() => {});
+    console.log(`📝 Backed up corrupted state to ${backupPath}`);
+    // Cleanup old corrupted backups (keep only 3 most recent)
+    const cosDir = dirname(STATE_FILE);
+    const files = await readdir(cosDir).catch(() => []);
+    const corrupted = files
+      .filter(f => f.startsWith('state.json.corrupted.'))
+      .sort()
+      .reverse();
+    for (const old of corrupted.slice(3)) {
+      await rm(join(cosDir, old)).catch(() => {});
+    }
+    if (corrupted.length > 3) {
+      console.log(`🗑️ Cleaned up ${corrupted.length - 3} old corrupted state backups`);
+    }
+    stateCache = structuredClone(DEFAULT_STATE);
+    return stateCache;
+  }
+
+  const state = safeJSONParse(content, null, { logError: true, context: 'CoS state' });
+  if (!state) {
+    stateCache = structuredClone(DEFAULT_STATE);
+    return stateCache;
+  }
+
+  // Merge with defaults to ensure all fields exist
+  stateCache = {
+    ...DEFAULT_STATE,
+    ...state,
+    config: { ...DEFAULT_CONFIG, ...state.config },
+    stats: { ...DEFAULT_STATE.stats, ...state.stats },
+    agents: state.agents ?? {}
+  };
+  return stateCache;
+}
+
+export async function saveState(state) {
+  await ensureDirectories();
+  stateCache = state;
+  const tmpFile = `${STATE_FILE}.tmp`;
+  await writeFile(tmpFile, JSON.stringify(state, null, 2));
+  await rename(tmpFile, STATE_FILE);
+}
+
+// Daemon state accessors — used by modules that need to check daemon status
+// without importing cos.js (which would create circular deps)
+let _daemonRunning = false;
+
+export function isDaemonRunning() {
+  return _daemonRunning;
+}
+
+export function setDaemonRunning(value) {
+  _daemonRunning = value;
+}

--- a/server/services/pm2.js
+++ b/server/services/pm2.js
@@ -8,6 +8,12 @@ import { extractJSONArray, safeJSONParse } from '../lib/fileUtils.js';
 
 const IS_WIN = process.platform === 'win32';
 
+// TTL cache for jlist results to reduce CLI churn during rapid UI refreshes
+const JLIST_TTL_MS = 400;
+const jlistCache = new Map();
+const jlistInflight = new Map();
+const cacheKey = (pm2Home) => pm2Home || '_default';
+
 // Resolve PM2 CLI binary path from our local dependency using require.resolve
 // to handle hoisted node_modules correctly.
 const require = createRequire(import.meta.url);
@@ -225,7 +231,41 @@ export async function deleteApp(name, pm2Home = null) {
  * @param {string} pm2Home Optional custom PM2_HOME path
  */
 export async function getAppStatus(name, pm2Home = null) {
-  return new Promise((resolve) => {
+  const processes = await fetchJlist(pm2Home);
+  if (!processes) return { name, status: 'error', pm2_env: null };
+  const proc = processes.find(p => p.name === name);
+
+  if (!proc) {
+    return { name, status: 'not_found', pm2_env: null };
+  }
+
+  return {
+    name: proc.name,
+    status: proc.pm2_env?.status || 'unknown',
+    pid: proc.pid,
+    pm_id: proc.pm_id,
+    cpu: proc.monit?.cpu || 0,
+    memory: proc.monit?.memory || 0,
+    uptime: proc.pm2_env?.pm_uptime ? Date.now() - proc.pm2_env.pm_uptime : null,
+    restarts: proc.pm2_env?.restart_time || 0,
+    createdAt: proc.pm2_env?.created_at || null
+  };
+}
+
+/**
+ * Fetch raw PM2 jlist output with TTL caching to reduce CLI churn.
+ * @param {string} pm2Home Optional custom PM2_HOME path
+ * @returns {Promise<Array|null>} Raw process list from PM2, or null on error
+ */
+function fetchJlist(pm2Home = null) {
+  const key = cacheKey(pm2Home);
+  const cached = jlistCache.get(key);
+  if (cached && Date.now() - cached.ts < JLIST_TTL_MS) return Promise.resolve(cached.data);
+
+  const inflight = jlistInflight.get(key);
+  if (inflight) return inflight;
+
+  const promise = new Promise((resolve) => {
     const child = spawnPm2(['jlist'], {
       env: buildEnv(pm2Home)
     });
@@ -235,35 +275,25 @@ export async function getAppStatus(name, pm2Home = null) {
       stdout += data.toString();
     });
 
-    child.on('close', () => {
-      const processes = safeJSONParse(extractJSONArray(stdout), []);
-      const proc = processes.find(p => p.name === name);
-
-      if (!proc) {
-        return resolve({
-          name,
-          status: 'not_found',
-          pm2_env: null
-        });
+    child.on('close', (code) => {
+      jlistInflight.delete(key);
+      if (code !== 0) {
+        resolve(null);
+        return;
       }
-
-      resolve({
-        name: proc.name,
-        status: proc.pm2_env?.status || 'unknown',
-        pid: proc.pid,
-        pm_id: proc.pm_id,
-        cpu: proc.monit?.cpu || 0,
-        memory: proc.monit?.memory || 0,
-        uptime: proc.pm2_env?.pm_uptime ? Date.now() - proc.pm2_env.pm_uptime : null,
-        restarts: proc.pm2_env?.restart_time || 0,
-        createdAt: proc.pm2_env?.created_at || null
-      });
+      const list = safeJSONParse(extractJSONArray(stdout), []);
+      jlistCache.set(key, { data: list, ts: Date.now() });
+      resolve(list);
     });
 
     child.on('error', () => {
-      resolve({ name, status: 'error', pm2_env: null });
+      jlistInflight.delete(key);
+      resolve(null);
     });
   });
+
+  jlistInflight.set(key, promise);
+  return promise;
 }
 
 /**
@@ -271,35 +301,18 @@ export async function getAppStatus(name, pm2Home = null) {
  * @param {string} pm2Home Optional custom PM2_HOME path
  */
 export async function listProcesses(pm2Home = null) {
-  return new Promise((resolve) => {
-    const child = spawnPm2(['jlist'], {
-      env: buildEnv(pm2Home)
-    });
-    let stdout = '';
-
-    child.stdout.on('data', (data) => {
-      stdout += data.toString();
-    });
-
-    child.on('close', () => {
-      const list = safeJSONParse(extractJSONArray(stdout), []);
-      const processes = list.map(proc => ({
-        name: proc.name,
-        status: proc.pm2_env?.status || 'unknown',
-        pid: proc.pid,
-        pm_id: proc.pm_id,
-        cpu: proc.monit?.cpu || 0,
-        memory: proc.monit?.memory || 0,
-        uptime: proc.pm2_env?.pm_uptime ? Date.now() - proc.pm2_env.pm_uptime : null,
-        restarts: proc.pm2_env?.restart_time || 0
-      }));
-      resolve(processes);
-    });
-
-    child.on('error', () => {
-      resolve([]);
-    });
-  });
+  const list = await fetchJlist(pm2Home);
+  if (!list) return [];
+  return list.map(proc => ({
+    name: proc.name,
+    status: proc.pm2_env?.status || 'unknown',
+    pid: proc.pid,
+    pm_id: proc.pm_id,
+    cpu: proc.monit?.cpu || 0,
+    memory: proc.monit?.memory || 0,
+    uptime: proc.pm2_env?.pm_uptime ? Date.now() - proc.pm2_env.pm_uptime : null,
+    restarts: proc.pm2_env?.restart_time || 0
+  }));
 }
 
 /**

--- a/server/services/productivity.js
+++ b/server/services/productivity.js
@@ -7,7 +7,8 @@
 
 import { writeFile } from 'fs/promises';
 import { join } from 'path';
-import { cosEvents, getAgents } from './cos.js';
+import { cosEvents } from './cosEvents.js';
+import { getAgents } from './cosAgents.js';
 import { ensureDir, getDateString, PATHS, readJSONFile } from '../lib/fileUtils.js';
 
 const DATA_DIR = PATHS.cos;

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -7,7 +7,7 @@
  */
 
 import { spawn, execSync } from 'child_process';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { writeFile, mkdir, readFile, readdir, rm, stat, unlink } from 'fs/promises'; // mkdir kept for non-recursive use
 import { existsSync } from 'fs';
 import { homedir } from 'os';
@@ -1882,10 +1882,13 @@ async function handlePipelineProgression(task, agentId, success) {
     }, task.taskType);
     // Clean up pipeline artifacts (e.g., REVIEW.md left by stage 1)
     if (task.metadata.repoPath) {
+      const repoRoot = resolve(task.metadata.repoPath);
       for (const stage of stages) {
         const file = stage.precondition?.fileNotExists;
         if (file) {
-          const filePath = join(task.metadata.repoPath, file);
+          const filePath = resolve(repoRoot, file);
+          // Only delete files within the repo directory (prevent path traversal)
+          if (!filePath.startsWith(repoRoot + '/')) continue;
           await unlink(filePath).catch(() => {});
         }
       }

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -8,7 +8,7 @@
 
 import { spawn, execSync } from 'child_process';
 import { join } from 'path';
-import { writeFile, mkdir, readFile, readdir, rm, stat } from 'fs/promises'; // mkdir kept for non-recursive use
+import { writeFile, mkdir, readFile, readdir, rm, stat, unlink } from 'fs/promises'; // mkdir kept for non-recursive use
 import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { v4 as uuidv4 } from 'uuid';
@@ -1877,6 +1877,16 @@ async function handlePipelineProgression(task, agentId, success) {
     await updateTask(task.id, {
       metadata: { ...task.metadata, pipeline: { ...pipeline, status: 'completed', stageResults: updatedResults } }
     }, task.taskType);
+    // Clean up pipeline artifacts (e.g., REVIEW.md left by stage 1)
+    if (task.metadata.repoPath) {
+      for (const stage of stages) {
+        const file = stage.precondition?.fileNotExists;
+        if (file) {
+          const filePath = join(task.metadata.repoPath, file);
+          await unlink(filePath).catch(() => {});
+        }
+      }
+    }
     emitLog('info', `✅ Pipeline ${pipeline.id} completed all ${stages.length} stages`, { pipelineId: pipeline.id });
     return;
   }

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -1986,7 +1986,8 @@ async function handleAgentCompletion(agentId, exitCode, success, duration) {
 
   // Ensure taskType is set — recovered agents may lack it, causing updateTask to search the wrong file
   if (task && !task.taskType) {
-    task.taskType = task.id?.startsWith('sys-') ? 'internal' : 'user';
+    const id = task.id || '';
+    task.taskType = (id.startsWith('sys-') || id.startsWith('app-improve-')) ? 'internal' : 'user';
   }
 
   // Release execution lane

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -2407,16 +2407,13 @@ async function spawnDirectly(agentId, task, prompt, workspacePath, model, provid
 
   claudeProcess.stderr.on('data', async (data) => {
     const text = data.toString();
-    // Codex dumps its entire prompt/config to stderr — filter to only useful lines
+    // Codex dumps its entire prompt/config to stderr — filter to useful lines only
     if (provider.id === 'codex') {
-      const lines = text.split('\n');
-      for (const line of lines) {
+      for (const line of text.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed) continue;
-        // Skip initialization noise (prompt dump, config, session info)
         if (trimmed.startsWith('Reading prompt from stdin')) continue;
         if (trimmed.startsWith('OpenAI Codex v')) continue;
-        // Keep exec lines (tool calls) and everything else (errors, progress)
         outputBuffer += `[stderr] ${trimmed}\n`;
         await appendAgentOutput(agentId, `[stderr] ${trimmed}`);
       }

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -7,7 +7,7 @@
  */
 
 import { spawn, execSync } from 'child_process';
-import { join, relative, resolve } from 'path';
+import { join, relative, resolve, sep } from 'path';
 import { writeFile, mkdir, readFile, readdir, rm, stat, unlink } from 'fs/promises'; // mkdir kept for non-recursive use
 import { existsSync } from 'fs';
 import { homedir } from 'os';
@@ -1889,7 +1889,7 @@ async function handlePipelineProgression(task, agentId, success) {
           const filePath = resolve(repoRoot, file);
           // Only delete files within the repo directory (prevent path traversal)
           const rel = relative(repoRoot, filePath);
-          if (!rel || rel.startsWith('..') || resolve(rel) === rel) continue;
+          if (!rel || rel === '..' || rel.startsWith('..' + sep) || resolve(rel) === rel) continue;
           await unlink(filePath).catch(() => {});
         }
       }

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -2407,6 +2407,22 @@ async function spawnDirectly(agentId, task, prompt, workspacePath, model, provid
 
   claudeProcess.stderr.on('data', async (data) => {
     const text = data.toString();
+    // Codex dumps its entire prompt/config to stderr — filter to only useful lines
+    if (provider.id === 'codex') {
+      const lines = text.split('\n');
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        // Skip initialization noise (prompt dump, config, session info)
+        if (trimmed.startsWith('Reading prompt from stdin')) continue;
+        if (trimmed.startsWith('OpenAI Codex v')) continue;
+        // Keep exec lines (tool calls) and everything else (errors, progress)
+        outputBuffer += `[stderr] ${trimmed}\n`;
+        await appendAgentOutput(agentId, `[stderr] ${trimmed}`);
+      }
+      await writeFile(outputFile, outputBuffer).catch(() => {});
+      return;
+    }
     outputBuffer += `[stderr] ${text}`;
     await writeFile(outputFile, outputBuffer).catch(() => {});
     await appendAgentOutput(agentId, `[stderr] ${text}`);

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -7,7 +7,7 @@
  */
 
 import { spawn, execSync } from 'child_process';
-import { join, resolve } from 'path';
+import { join, relative, resolve } from 'path';
 import { writeFile, mkdir, readFile, readdir, rm, stat, unlink } from 'fs/promises'; // mkdir kept for non-recursive use
 import { existsSync } from 'fs';
 import { homedir } from 'os';
@@ -1888,7 +1888,8 @@ async function handlePipelineProgression(task, agentId, success) {
         if (file) {
           const filePath = resolve(repoRoot, file);
           // Only delete files within the repo directory (prevent path traversal)
-          if (!filePath.startsWith(repoRoot + '/')) continue;
+          const rel = relative(repoRoot, filePath);
+          if (!rel || rel.startsWith('..') || resolve(rel) === rel) continue;
           await unlink(filePath).catch(() => {});
         }
       }
@@ -1918,7 +1919,7 @@ async function handlePipelineProgression(task, agentId, success) {
   if (task.metadata.app) prompt = prompt.replace(/\{appId\}/g, task.metadata.app);
 
   const nextTask = {
-    id: `${task.id || 'sys'}-stage${nextStageIndex}-${Date.now().toString(36)}`,
+    id: `${task.id || 'sys-pipeline'}-stage${nextStageIndex}-${Date.now().toString(36)}`,
     status: 'pending',
     description: prompt,
     priority: task.priority || 'MEDIUM',

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -12,7 +12,9 @@ import { writeFile, mkdir, readFile, readdir, rm, stat, unlink } from 'fs/promis
 import { existsSync } from 'fs';
 import { homedir } from 'os';
 import { v4 as uuidv4 } from 'uuid';
-import { cosEvents, registerAgent, updateAgent, completeAgent, appendAgentOutput, getConfig, updateTask, addTask, emitLog, getTaskById, checkStagePrecondition } from './cos.js';
+import { cosEvents, emitLog } from './cosEvents.js';
+import { registerAgent, updateAgent, completeAgent, appendAgentOutput } from './cosAgents.js';
+import { getConfig, updateTask, addTask, getTaskById, checkStagePrecondition } from './cos.js';
 import { startAppCooldown, markAppReviewCompleted } from './appActivity.js';
 import { isRunnerAvailable, spawnAgentViaRunner, terminateAgentViaRunner, killAgentViaRunner, getAgentStatsFromRunner, initCosRunnerConnection, onCosRunnerEvent, getActiveAgentsFromRunner, getRunnerHealth } from './cosRunnerClient.js';
 import { getActiveProvider, getProviderById, getAllProviders } from './providers.js';

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -2407,15 +2407,27 @@ async function spawnDirectly(agentId, task, prompt, workspacePath, model, provid
 
   claudeProcess.stderr.on('data', async (data) => {
     const text = data.toString();
-    // Codex dumps its entire prompt/config to stderr — filter to useful lines only
+    // Codex stderr: show thinking + tool names, skip config dump and command output
     if (provider.id === 'codex') {
       for (const line of text.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed) continue;
         if (trimmed.startsWith('Reading prompt from stdin')) continue;
         if (trimmed.startsWith('OpenAI Codex v')) continue;
-        outputBuffer += `[stderr] ${trimmed}\n`;
-        await appendAgentOutput(agentId, `[stderr] ${trimmed}`);
+        if (trimmed.startsWith('succeeded in')) continue;
+        // Tool calls: show just the command, strip output after "succeeded"
+        if (trimmed.startsWith('exec ')) {
+          const match = trimmed.match(/^exec\s+\S+\s+-lc\s+(['"])(.*?)\1/);
+          const cmd = match ? match[2] : trimmed.split(' in /')[0];
+          const display = `🔧 ${cmd}`;
+          outputBuffer += display + '\n';
+          await appendAgentOutput(agentId, display);
+          continue;
+        }
+        // Skip long lines (command output like file contents, directory listings)
+        if (trimmed.length > 300) continue;
+        outputBuffer += trimmed + '\n';
+        await appendAgentOutput(agentId, trimmed);
       }
       await writeFile(outputFile, outputBuffer).catch(() => {});
       return;

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -1294,7 +1294,7 @@ export async function spawnAgentForTask(task) {
     const laneResult = await waitForLane(laneName, agentId, { timeoutMs: 30000, metadata: { taskId: task.id } });
     if (!laneResult.success) {
       spawningTasks.delete(task.id);
-      emitLog('warning', `Lane ${laneName} unavailable for task ${task.id}, deferring`, { taskId: task.id, lane: laneName });
+      emitLog('warn', `Lane ${laneName} unavailable for task ${task.id}, deferring`, { taskId: task.id, lane: laneName });
       cosEvents.emit('agent:deferred', { taskId: task.id, reason: 'lane-capacity', lane: laneName });
       return null;
     }
@@ -1302,7 +1302,7 @@ export async function spawnAgentForTask(task) {
     const laneResult = acquire(laneName, agentId, { taskId: task.id });
     if (!laneResult.success) {
       spawningTasks.delete(task.id);
-      emitLog('warning', `Failed to acquire lane ${laneName}: ${laneResult.error}`, { taskId: task.id });
+      emitLog('warn', `Failed to acquire lane ${laneName}: ${laneResult.error}`, { taskId: task.id });
       return null;
     }
   }
@@ -1337,7 +1337,7 @@ export async function spawnAgentForTask(task) {
   const providerAvailable = isProviderAvailable(provider.id);
   if (!providerAvailable) {
     const status = getProviderStatus(provider.id);
-    emitLog('warning', `Provider ${provider.id} unavailable: ${status.message}`, {
+    emitLog('warn', `Provider ${provider.id} unavailable: ${status.message}`, {
       taskId: task.id,
       providerId: provider.id,
       reason: status.reason
@@ -1379,7 +1379,7 @@ export async function spawnAgentForTask(task) {
       emitLog('info', `Using user-specified provider: ${userProviderId}`, { taskId: task.id });
       provider = userProvider;
     } else {
-      emitLog('warning', `User-specified provider "${userProviderId}" not found, using active provider`, { taskId: task.id });
+      emitLog('warn', `User-specified provider "${userProviderId}" not found, using active provider`, { taskId: task.id });
     }
   }
 
@@ -1391,7 +1391,7 @@ export async function spawnAgentForTask(task) {
   if (selectedModel && provider.models && provider.models.length > 0) {
     const modelIsValid = provider.models.includes(selectedModel);
     if (!modelIsValid) {
-      emitLog('warning', `Model "${selectedModel}" not valid for provider "${provider.id}", falling back to provider default`, {
+      emitLog('warn', `Model "${selectedModel}" not valid for provider "${provider.id}", falling back to provider default`, {
         taskId: task.id,
         requestedModel: selectedModel,
         providerId: provider.id,
@@ -1438,7 +1438,7 @@ export async function spawnAgentForTask(task) {
   if (!isReadOnly) {
   // Pull latest from git before starting work (scripted — no LLM needed)
   const pullResult = await git.ensureLatest(workspacePath).catch(err => {
-    emitLog('warning', `⚠️ Pre-task git pull failed for ${workspacePath}: ${err.message}`, { taskId: task.id, workspace: workspacePath });
+    emitLog('warn', `⚠️ Pre-task git pull failed for ${workspacePath}: ${err.message}`, { taskId: task.id, workspace: workspacePath });
     return { success: false, error: err.message };
   });
 
@@ -1447,7 +1447,7 @@ export async function spawnAgentForTask(task) {
   } else if (pullResult.conflict) {
     // Git conflict detected — create a high-priority task for an agent to resolve it,
     // then defer the original task so it retries after the conflict is fixed.
-    emitLog('warning', `🔀 Git conflict in ${workspacePath} (branch: ${pullResult.branch}): ${pullResult.error}`, {
+    emitLog('warn', `🔀 Git conflict in ${workspacePath} (branch: ${pullResult.branch}): ${pullResult.error}`, {
       taskId: task.id, workspace: workspacePath, branch: pullResult.branch
     });
 
@@ -1464,7 +1464,7 @@ export async function spawnAgentForTask(task) {
         + `Resolve the conflict, commit, and push so the blocked task can proceed.`,
       position: 'top'
     }, 'internal').catch(err => {
-      emitLog('warning', `Failed to create conflict resolution task: ${err.message}`, { taskId: task.id });
+      emitLog('warn', `Failed to create conflict resolution task: ${err.message}`, { taskId: task.id });
     });
 
     // Return the original task to pending so it retries after the conflict is resolved
@@ -1478,7 +1478,7 @@ export async function spawnAgentForTask(task) {
     });
   } else if (!pullResult.success) {
     // Non-conflict failure (network error, etc.) — log warning but proceed
-    emitLog('warning', `⚠️ Pre-task git pull error: ${pullResult.error}`, { taskId: task.id, workspace: workspacePath });
+    emitLog('warn', `⚠️ Pre-task git pull error: ${pullResult.error}`, { taskId: task.id, workspace: workspacePath });
   }
 
   // JIRA integration: create ticket + feature branch if app has JIRA enabled and task opted in
@@ -1735,7 +1735,7 @@ async function waitForRunnerStability() {
     await new Promise(resolve => setTimeout(resolve, checkIntervalMs));
   }
 
-  emitLog('warning', 'Runner stability check timed out, proceeding anyway', {});
+  emitLog('warn', 'Runner stability check timed out, proceeding anyway', {});
   return false;
 }
 
@@ -1757,7 +1757,8 @@ async function spawnViaRunner(agentId, task, prompt, workspacePath, model, provi
     startedAt: Date.now(),
     initializationTimeout: null,
     executionId,
-    laneName
+    laneName,
+    workspacePath
   };
   runnerAgents.set(agentId, agentInfo);
 

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -1902,6 +1902,8 @@ async function handlePipelineProgression(task, agentId, success) {
   if (task.metadata.app) prompt = prompt.replace(/\{appId\}/g, task.metadata.app);
 
   const nextTask = {
+    id: `${task.id || 'sys'}-stage${nextStageIndex}-${Date.now().toString(36)}`,
+    status: 'pending',
     description: prompt,
     priority: task.priority || 'MEDIUM',
     metadata: {

--- a/server/services/taskLearning.js
+++ b/server/services/taskLearning.js
@@ -9,7 +9,7 @@
 import { writeFile, readFile, rename } from 'fs/promises';
 import { existsSync, readdirSync } from 'fs';
 import { join } from 'path';
-import { cosEvents, emitLog } from './cos.js';
+import { cosEvents, emitLog } from './cosEvents.js';
 import { ensureDir, readJSONFile, PATHS } from '../lib/fileUtils.js';
 import { createMutex } from '../lib/asyncMutex.js';
 

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -16,7 +16,7 @@
 import { writeFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { cosEvents, emitLog } from './cos.js';
+import { cosEvents, emitLog } from './cosEvents.js';
 import { DAY, ensureDir, HOUR, loadSlashdoFile, readJSONFile, PATHS, safeDate } from '../lib/fileUtils.js';
 import { getAdaptiveCooldownMultiplier } from './taskLearning.js';
 import { isTaskTypeEnabledForApp, getAppTaskTypeInterval, getActiveApps, getAppTaskTypeOverrides } from './apps.js';

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -63,22 +63,23 @@ export async function executeUpdate(tag, emit) {
       child.stderr.on('data', makeLineHandler());
     }
 
-    child.on('close', async (code) => {
+    child.on('close', async (code, signal) => {
       const success = code === 0;
+      const exitDetail = signal ? `killed by ${signal}` : `exit code ${code}`;
       await recordUpdateResult({
         version: tag.replace(/^v/, ''),
         success,
         completedAt: new Date().toISOString(),
-        log: success ? '' : `Process exited with code ${code}`
+        log: success ? '' : `Process ${exitDetail}`
       }).catch(e => console.error(`❌ Failed to record update result: ${e.message}`));
       if (success) {
         emit('complete', 'done', `Update to ${tag} complete`);
       } else {
-        emit(lastStep, 'error', `Update failed at step "${lastStep}" (exit code ${code})`);
+        emit(lastStep, 'error', `Update failed at step "${lastStep}" (${exitDetail})`);
       }
       resolve(success
         ? { success: true }
-        : { success: false, failedStep: lastStep, errorMessage: `Update failed at step "${lastStep}" (exit code ${code})` }
+        : { success: false, failedStep: lastStep, errorMessage: `Update failed at step "${lastStep}" (${exitDetail})` }
       );
     });
 

--- a/server/services/weeklyDigest.js
+++ b/server/services/weeklyDigest.js
@@ -9,7 +9,8 @@
 import { writeFile, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { cosEvents, emitLog, getAgents, getAgentDates, getAgentsByDate } from './cos.js';
+import { cosEvents, emitLog } from './cosEvents.js';
+import { getAgents, getAgentDates, getAgentsByDate } from './cosAgents.js';
 import { ensureDir, readJSONFile, formatDuration, PATHS } from '../lib/fileUtils.js';
 
 const DIGESTS_DIR = PATHS.digests;

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,16 @@ npm install
 
 echo ""
 echo "Setting up data directory..."
-npm run setup
+if ! npm run setup; then
+    echo ""
+    echo "==================================="
+    echo "  Setup incomplete"
+    echo "==================================="
+    echo ""
+    echo "Fix the issue above, then re-run: ./setup.sh"
+    echo ""
+    exit 1
+fi
 
 echo ""
 


### PR DESCRIPTION
# Release v1.40.0

Released: 2026-03-29

### Fixed

- Scheduled tasks defaulting to enabled for existing apps when new task types are added — `isTaskTypeEnabledForApp` now defaults to disabled (opt-in) instead of enabled (opt-out)
- Autonomous job scheduler using UTC instead of local timezone for scheduled times — daily briefing at 4:30 AM local was firing at 4:30 AM UTC. Now uses `nextLocalTime()` to compute exact UTC target from local scheduled time
- Codex agent output flooding UI with full prompt/config dump from stderr — filtered to only show tool execution lines and errors
- On-demand tasks silently dropped when pipeline preconditions fail (e.g., REVIEW.md already exists) — on-demand tasks now skip precondition checks since the user explicitly requested them
- Pipeline stage 2+ tasks stuck in queue forever — follow-up tasks were missing `id` and `status: 'pending'` fields when created with `raw: true`, making them invisible to the task evaluator
- Pipeline tasks not marked completed after agent finishes — `app-improve-*` task IDs were misidentified as user tasks (expected `sys-` prefix), causing `updateTask` to look in the wrong file
- Pipeline stage 2 tasks blocked by app cooldown — pipeline continuations now bypass the 30-minute app review cooldown
- Pipeline artifacts (e.g., REVIEW.md) not cleaned up after final stage — automated cleanup now deletes `fileNotExists` precondition files when pipeline completes
- Self-update failing with "exit code null" at npm-install step — PM2 watch restarted the server during `git checkout` (which changes `server/` files), breaking the stdout pipe to the update script. SIGPIPE killed the script before `|| true` could handle it, leaving the update incomplete. Added `trap '' PIPE` to ignore SIGPIPE so the script runs to completion.
- Improved update error messages to show signal name (e.g., "killed by SIGPIPE") instead of opaque "exit code null"
- Setup falsely reporting "Setup Complete!" when native PostgreSQL is selected but not installed — now auto-runs `db.sh setup-native` to install and configure PostgreSQL via Homebrew, and exits with error if setup fails instead of silently continuing
- Release review: `emitLog('warning', ...)` log level corrected to `'warn'` at 10 call sites (was falling through to info emoji)
- Release review: runner agent `workspacePath` not stored in tracking map, causing post-completion commit validation to always check ROOT_DIR
- Release review: task action handlers (status change, save, delete) showed success toast even on API failure

### Added

- Toggle to enable/disable all automations for an app on the Automation tab
- "Process Now" button on pending task cards to force-spawn a specific task, bypassing cooldowns and evaluation intervals

## Full Changelog

**Full Diff**: https://github.com/atomantic/PortOS/compare/v1.39.0...v1.40.0