### PR TITLE
fix(cos): always close task edit form after save

### DIFF
--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -176,9 +176,8 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   };
 
   const handleSave = async () => {
-    const result = await api.updateCosTask(task.id, editData).catch(err => { toast.error(err.message); return null; });
-    if (!result) return;
-    toast.success('Task updated');
+    const result = await api.updateCosTask(task.id, editData).catch(() => null);
+    if (result) toast.success('Task updated');
     setEditing(false);
     onRefresh();
   };


### PR DESCRIPTION
## Summary
- Fix task edit form not closing after tapping Save on a pending task
- The HTTP response could race with the WebSocket update, causing `.catch()` to null the result and skip `setEditing(false)`
- Removed duplicate error toast (apiCore's `request()` already shows errors)

## Test plan
- [ ] Edit a pending task and tap Save — form should close and show updated data
- [ ] Edit a task with invalid data that causes a server error — error toast shown, form closes
- [ ] Verify no duplicate toasts appear on save errors