### PR TITLE
feat(avatar): rigged 3D avatar runtime + Stage view (WIP)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -66,6 +66,7 @@ const Goals = lazyWithReload(() => import('./pages/Goals'));
 const OpenClawPage = lazyWithReload(() => import('./pages/OpenClaw'));
 const Submodules = lazyWithReload(() => import('./pages/Submodules'));
 const ChiefOfStaff = lazyWithReload(() => import('./pages/ChiefOfStaff'));
+const CoSStagePage = lazyWithReload(() => import('./pages/CoSStagePage'));
 
 // Loading fallback for lazy-loaded pages
 const PageLoader = () => (
@@ -118,6 +119,7 @@ export default function App() {
           <Route path="ai" element={<AIProviders />} />
           <Route path="prompts" element={<PromptManager />} />
           <Route path="cos" element={<Navigate to="/cos/tasks" replace />} />
+          <Route path="cos/stage" element={<CoSStagePage />} />
           <Route path="cos/:tab" element={<ChiefOfStaff />} />
           <Route path="calendar" element={<Navigate to="/calendar/agenda" replace />} />
           <Route path="calendar/:tab" element={<CalendarPage />} />

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -73,7 +73,8 @@ import {
   MessagesSquare,
   BookOpen,
   Search,
-  Mic
+  Mic,
+  Clapperboard
 } from 'lucide-react';
 /* global __APP_VERSION__ */
 import Logo from './Logo';
@@ -141,6 +142,7 @@ const navItems = [
       { to: '/cos/memory', label: 'Memory', icon: Brain },
       { to: '/cos/schedule', label: 'Schedule', icon: Clock },
       { to: '/cos/scripts', label: 'Scripts', icon: Terminal },
+      { to: '/cos/stage', label: 'Stage', icon: Clapperboard },
       { to: '/cos/productivity', label: 'Streaks', icon: Flame },
       { to: '/cos/jobs', label: 'System Tasks', icon: Bot },
       { to: '/cos/tasks', label: 'Tasks', icon: FileText }

--- a/client/src/components/cos/Rigged3DCoSAvatar.jsx
+++ b/client/src/components/cos/Rigged3DCoSAvatar.jsx
@@ -1,0 +1,30 @@
+import { Suspense } from 'react';
+import { Canvas } from '@react-three/fiber';
+import RiggedAvatarScene from './avatar3d/RiggedAvatarScene';
+import { useAvatarModel } from './avatar3d/useAvatarModel';
+import CoSCharacter from './CoSCharacter';
+
+// Header-slot variant of the rigged 3D avatar. Matches the footprint of the
+// SVG/cyber/sigil/esoteric/nexus variants — small, fixed camera, no controls.
+//
+// If no model is configured on the server, falls back to the default SVG
+// CoSCharacter so the header is never blank.
+export default function Rigged3DCoSAvatar({ state, speaking }) {
+  const { status, url } = useAvatarModel();
+
+  if (status !== 'present') {
+    return <CoSCharacter state={state} speaking={speaking} />;
+  }
+
+  return (
+    <div className="relative w-full max-w-[8rem] lg:max-w-[12rem] aspect-[2/3] overflow-visible">
+      <Canvas camera={{ position: [0, 1.5, 2.5], fov: 30 }} dpr={[1, 2]} shadows={false}>
+        <ambientLight intensity={0.7} />
+        <directionalLight position={[2, 4, 3]} intensity={0.9} />
+        <Suspense fallback={null}>
+          <RiggedAvatarScene url={url} state={state} speaking={speaking} />
+        </Suspense>
+      </Canvas>
+    </div>
+  );
+}

--- a/client/src/components/cos/Rigged3DStage.jsx
+++ b/client/src/components/cos/Rigged3DStage.jsx
@@ -1,0 +1,59 @@
+import { Suspense, useState } from 'react';
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls, Environment, ContactShadows } from '@react-three/drei';
+import RiggedAvatarScene from './avatar3d/RiggedAvatarScene';
+
+// Full-page stage view. User-controllable camera, environmental lighting,
+// contact shadows — the rigged avatar's "showroom".
+export default function Rigged3DStage({ url, state, speaking }) {
+  const [caps, setCaps] = useState(null);
+
+  return (
+    <div className="relative w-full h-full min-h-[70vh] bg-port-bg">
+      <Canvas
+        camera={{ position: [0, 1.4, 2.6], fov: 30 }}
+        dpr={[1, 2]}
+        shadows
+      >
+        <ambientLight intensity={0.5} />
+        <directionalLight
+          position={[3, 5, 3]}
+          intensity={1.1}
+          castShadow
+          shadow-mapSize-width={1024}
+          shadow-mapSize-height={1024}
+        />
+        <Suspense fallback={null}>
+          <RiggedAvatarScene
+            url={url}
+            state={state}
+            speaking={speaking}
+            onCapabilitiesReady={setCaps}
+          />
+          <Environment preset="studio" />
+        </Suspense>
+        <ContactShadows position={[0, 0, 0]} opacity={0.5} scale={10} blur={2.4} far={4} />
+        <OrbitControls target={[0, 1.2, 0]} enablePan={false} minDistance={1.2} maxDistance={6} />
+      </Canvas>
+      {caps && <CapabilityBadge caps={caps} />}
+    </div>
+  );
+}
+
+function CapabilityBadge({ caps }) {
+  const features = [
+    caps.hasSkins && 'rigged',
+    caps.availableClips.size > 0 && `${caps.availableClips.size} clips`,
+    caps.hasVisemes && 'visemes',
+    caps.hasBlinkShapes && 'blinks',
+    caps.hasEyeLook && 'eye-tracking',
+    caps.hasBrowShapes && 'expressions',
+    caps.skeletonHint !== 'unknown' && caps.skeletonHint
+  ].filter(Boolean);
+  if (features.length === 0) return null;
+  return (
+    <div className="absolute bottom-4 left-4 px-3 py-1.5 rounded-md bg-port-card/80 backdrop-blur border border-port-border text-xs text-gray-400 font-mono">
+      {features.join(' · ')}
+    </div>
+  );
+}

--- a/client/src/components/cos/avatar3d/RiggedAvatarScene.jsx
+++ b/client/src/components/cos/avatar3d/RiggedAvatarScene.jsx
@@ -1,0 +1,30 @@
+import { useRef, useEffect } from 'react';
+import { useGLTF } from '@react-three/drei';
+import { useAvatarCapabilities } from './useAvatarCapabilities';
+import { useStateAnimation } from './useStateAnimation';
+import { useExpressionLayer } from './useExpressionLayer';
+import { useLifeLayer } from './useLifeLayer';
+import { useSpeakingLayer } from './useSpeakingLayer';
+
+// Inner scene: the rigged character primitive plus all four runtime layers.
+// Lives inside a Canvas — not a top-level component. Height/camera/lighting
+// are owned by the wrapper (Rigged3DCoSAvatar for header, Rigged3DStage for
+// the full page).
+export default function RiggedAvatarScene({ url, state, speaking, onCapabilitiesReady }) {
+  const gltf = useGLTF(url);
+  const capabilities = useAvatarCapabilities(gltf);
+  const rootRef = useRef();
+
+  useEffect(() => {
+    if (onCapabilitiesReady) onCapabilitiesReady(capabilities);
+  }, [capabilities, onCapabilitiesReady]);
+
+  useStateAnimation({ gltf, capabilities, state });
+  useExpressionLayer({ gltf, capabilities, state });
+  useLifeLayer({ gltf, capabilities, state, rootRef });
+  useSpeakingLayer({ gltf, capabilities, speaking });
+
+  return (
+    <primitive ref={rootRef} object={gltf.scene} />
+  );
+}

--- a/client/src/components/cos/avatar3d/emptyStateCopy.js
+++ b/client/src/components/cos/avatar3d/emptyStateCopy.js
@@ -1,0 +1,16 @@
+export const EMPTY_STATE = {
+  title: 'No 3D avatar configured',
+  summary:
+    'Drop a rigged GLB at ./data/avatar/model.glb on the server and refresh. The avatar style and Stage view will activate automatically.',
+  requiredClips: [
+    'base',
+    'sleeping',
+    'thinking',
+    'coding',
+    'investigating',
+    'reviewing',
+    'planning',
+    'ideating'
+  ],
+  guideLinkPath: '/docs/avatar-pipeline.md'
+};

--- a/client/src/components/cos/avatar3d/stateClipMap.js
+++ b/client/src/components/cos/avatar3d/stateClipMap.js
@@ -1,0 +1,60 @@
+// Canonical map from CoS agent state → body-clip name + facial expression targets.
+// This object is the contract with user-supplied GLBs:
+// - `clip` must match an animation track name in the exported GLB
+// - `expression` keys must match shape-key names on the mesh
+//
+// Missing clips fall back to `base`. Missing shape keys are silently skipped
+// by the expression layer — the avatar still works with a minimal rig.
+
+export const stateClipMap = {
+  base: {
+    clip: 'base',
+    expression: {}
+  },
+  sleeping: {
+    clip: 'sleeping',
+    expression: { Eye_Blink_L: 1, Eye_Blink_R: 1 }
+  },
+  thinking: {
+    clip: 'thinking',
+    expression: { Brow_Compress_L: 0.5, Brow_Compress_R: 0.5 }
+  },
+  coding: {
+    clip: 'coding',
+    expression: { Mouth_Smile_L: 0.2, Mouth_Smile_R: 0.2 }
+  },
+  investigating: {
+    clip: 'investigating',
+    expression: {
+      Brow_Raise_Outer_L: 0.6,
+      Brow_Raise_Outer_R: 0.6,
+      Eye_Wide_L: 0.4,
+      Eye_Wide_R: 0.4
+    }
+  },
+  reviewing: {
+    clip: 'reviewing',
+    expression: { Brow_Compress_L: 0.3, Brow_Compress_R: 0.3 }
+  },
+  planning: {
+    clip: 'planning',
+    expression: {}
+  },
+  ideating: {
+    clip: 'ideating',
+    expression: {
+      Brow_Raise_Inner_L: 0.6,
+      Brow_Raise_Inner_R: 0.6,
+      Mouth_Smile_L: 0.3,
+      Mouth_Smile_R: 0.3
+    }
+  }
+};
+
+export const REQUIRED_CLIPS = ['base'];
+
+// Viseme shape keys used by the speaking layer (CC3+/Reallusion convention).
+export const VISEME_KEYS = [
+  'V_Open', 'V_Explosive', 'V_Dental_Lip', 'V_Tight_O',
+  'V_Tight', 'V_Wide', 'V_Affricate', 'V_Lip_Open'
+];

--- a/client/src/components/cos/avatar3d/useAvatarCapabilities.js
+++ b/client/src/components/cos/avatar3d/useAvatarCapabilities.js
@@ -1,0 +1,97 @@
+import { useMemo } from 'react';
+import { VISEME_KEYS } from './stateClipMap';
+
+// Scan a loaded glTF scene for rig features. Downstream layers gate behavior
+// on these booleans so a minimal rig still renders — it just animates less.
+export function useAvatarCapabilities(gltf) {
+  return useMemo(() => detectCapabilities(gltf), [gltf]);
+}
+
+export function detectCapabilities(gltf) {
+  if (!gltf || !gltf.scene) {
+    return empty();
+  }
+
+  const shapeKeys = collectShapeKeys(gltf.scene);
+  const clipNames = (gltf.animations || []).map((a) => a.name);
+  const boneNames = collectBoneNames(gltf.scene);
+
+  const hasSkins = hasAnySkin(gltf.scene);
+  const availableClips = new Set(clipNames);
+
+  const hasVisemes = VISEME_KEYS.some((k) => shapeKeys.has(k));
+  const hasBlinkShapes = shapeKeys.has('Eye_Blink_L') && shapeKeys.has('Eye_Blink_R');
+  const hasEyeLook = ['Eye_L_Look_L', 'Eye_L_Look_R', 'Eye_R_Look_L', 'Eye_R_Look_R']
+    .some((k) => shapeKeys.has(k));
+  const hasBrowShapes = ['Brow_Raise_Inner_L', 'Brow_Compress_L', 'Brow_Drop_L']
+    .some((k) => shapeKeys.has(k));
+  const hasMouthShapes = ['Mouth_Smile_L', 'Mouth_Frown_L'].some((k) => shapeKeys.has(k));
+
+  let skeletonHint = 'unknown';
+  if (boneNames.some((n) => n.startsWith('cc_base_'))) skeletonHint = 'cc3';
+  else if (boneNames.some((n) => n.startsWith('mixamorig'))) skeletonHint = 'mixamo';
+
+  return {
+    hasSkins,
+    availableClips,
+    clipNames,
+    hasVisemes,
+    hasBlinkShapes,
+    hasEyeLook,
+    hasBrowShapes,
+    hasMouthShapes,
+    shapeKeys,
+    skeletonHint,
+    bonesByName: collectBonesMap(gltf.scene)
+  };
+}
+
+function empty() {
+  return {
+    hasSkins: false,
+    availableClips: new Set(),
+    clipNames: [],
+    hasVisemes: false,
+    hasBlinkShapes: false,
+    hasEyeLook: false,
+    hasBrowShapes: false,
+    hasMouthShapes: false,
+    shapeKeys: new Set(),
+    skeletonHint: 'unknown',
+    bonesByName: new Map()
+  };
+}
+
+function collectShapeKeys(root) {
+  const set = new Set();
+  root.traverse((obj) => {
+    if (obj.morphTargetDictionary) {
+      for (const name of Object.keys(obj.morphTargetDictionary)) set.add(name);
+    }
+  });
+  return set;
+}
+
+function collectBoneNames(root) {
+  const names = [];
+  root.traverse((obj) => {
+    if (obj.isBone) names.push(obj.name);
+  });
+  return names;
+}
+
+function collectBonesMap(root) {
+  const map = new Map();
+  root.traverse((obj) => {
+    if (obj.isBone) map.set(obj.name, obj);
+  });
+  return map;
+}
+
+function hasAnySkin(root) {
+  let found = false;
+  root.traverse((obj) => {
+    if (obj.isSkinnedMesh) found = true;
+  });
+  return found;
+}

--- a/client/src/components/cos/avatar3d/useAvatarModel.js
+++ b/client/src/components/cos/avatar3d/useAvatarModel.js
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react';
+import { useGLTF } from '@react-three/drei';
+
+const MODEL_URL = '/api/avatar/model.glb';
+
+// Resolve whether a user-supplied rigged avatar is configured.
+// HEAD probes the API once; the client only attempts to load the GLB when
+// the server signals 200. Missing model is a first-class state, not an error.
+export function useAvatarModel() {
+  const [status, setStatus] = useState('probing');
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch(MODEL_URL, { method: 'HEAD' })
+      .then((res) => {
+        if (cancelled) return;
+        setStatus(res.ok ? 'present' : 'missing');
+      })
+      .catch(() => {
+        if (!cancelled) setStatus('missing');
+      });
+    return () => { cancelled = true; };
+  }, []);
+
+  return { status, url: MODEL_URL };
+}
+
+// Preload hint for drei's GLTF cache — safe to call speculatively after a
+// HEAD 200 so the model starts downloading before the canvas mounts.
+export function preloadAvatarModel() {
+  useGLTF.preload(MODEL_URL);
+}

--- a/client/src/components/cos/avatar3d/useExpressionLayer.js
+++ b/client/src/components/cos/avatar3d/useExpressionLayer.js
@@ -1,0 +1,39 @@
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { stateClipMap } from './stateClipMap';
+
+const EASE_SECONDS = 0.3;
+
+// Expression layer: per-state facial shape-key targets, eased over time.
+// No-op on models without matching shape keys.
+export function useExpressionLayer({ gltf, capabilities, state }) {
+  const currentRef = useRef({}); // name -> current influence value
+
+  useFrame((_, delta) => {
+    if (!gltf || !gltf.scene) return;
+    if (!capabilities.hasBrowShapes && !capabilities.hasMouthShapes) return;
+
+    const targets = (stateClipMap[state] || stateClipMap.base).expression || {};
+    const current = currentRef.current;
+    const lerpFactor = Math.min(1, delta / EASE_SECONDS);
+
+    // Build set of targeted shape keys so we can ease unspecified ones back to 0.
+    const targetedKeys = new Set(Object.keys(targets));
+
+    gltf.scene.traverse((obj) => {
+      if (!obj.morphTargetDictionary || !obj.morphTargetInfluences) return;
+      for (const [name, index] of Object.entries(obj.morphTargetDictionary)) {
+        // Leave visemes alone — they're owned by the speaking layer.
+        if (name.startsWith('V_')) continue;
+        // Skip blink shapes if the life layer is actively blinking — but allow
+        // state-driven overrides (e.g. sleeping sets Eye_Blink to 1). Life layer
+        // will write 0 on non-blink frames so state overrides read through.
+        const desired = targetedKeys.has(name) ? targets[name] : 0;
+        const prior = current[name] ?? obj.morphTargetInfluences[index] ?? 0;
+        const next = prior + (desired - prior) * lerpFactor;
+        current[name] = next;
+        obj.morphTargetInfluences[index] = next;
+      }
+    });
+  });
+}

--- a/client/src/components/cos/avatar3d/useLifeLayer.js
+++ b/client/src/components/cos/avatar3d/useLifeLayer.js
@@ -1,0 +1,88 @@
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+
+// Always-on ambient motion independent of state:
+//   - periodic blink (if Eye_Blink_L/R exist)
+//   - occasional saccades on the eye-look shape keys (if present)
+//   - tiny breathing scale on the root so static models never feel frozen
+//
+// Sleeping state is a special case: blinking is suppressed so Eye_Blink stays
+// at 1.0 (eyes closed) as set by the expression layer.
+export function useLifeLayer({ gltf, capabilities, state, rootRef }) {
+  const blinkNextRef = useRef(randomBlinkDelay());
+  const blinkElapsedRef = useRef(0);
+  const blinkActiveRef = useRef(false);
+  const saccadeNextRef = useRef(randomSaccadeDelay());
+  const saccadeElapsedRef = useRef(0);
+  const saccadeTargetsRef = useRef(null);
+
+  useFrame((_, delta) => {
+    if (!gltf || !gltf.scene) return;
+
+    // Breathing — always-on even without shape keys.
+    if (rootRef?.current) {
+      const breath = Math.sin(performance.now() / 1000 * 1.4) * 0.005;
+      rootRef.current.scale.y = 1 + breath;
+    }
+
+    // Blinking
+    if (capabilities.hasBlinkShapes && state !== 'sleeping') {
+      blinkElapsedRef.current += delta;
+      if (!blinkActiveRef.current && blinkElapsedRef.current >= blinkNextRef.current) {
+        blinkActiveRef.current = true;
+        blinkElapsedRef.current = 0;
+      } else if (blinkActiveRef.current && blinkElapsedRef.current >= 0.12) {
+        blinkActiveRef.current = false;
+        blinkElapsedRef.current = 0;
+        blinkNextRef.current = randomBlinkDelay();
+      }
+      const blinkValue = blinkActiveRef.current ? 1 : 0;
+      writeShape(gltf.scene, 'Eye_Blink_L', blinkValue);
+      writeShape(gltf.scene, 'Eye_Blink_R', blinkValue);
+    }
+
+    // Saccades
+    if (capabilities.hasEyeLook) {
+      saccadeElapsedRef.current += delta;
+      if (saccadeElapsedRef.current >= saccadeNextRef.current) {
+        saccadeTargetsRef.current = pickSaccadeTargets();
+        saccadeElapsedRef.current = 0;
+        saccadeNextRef.current = randomSaccadeDelay();
+      }
+      // Hold the current targets for ~200ms, then zero out.
+      const holdTime = 0.2;
+      const targets = saccadeTargetsRef.current;
+      if (targets) {
+        const amplitude = saccadeElapsedRef.current < holdTime ? 0.3 : 0;
+        for (const key of targets) writeShape(gltf.scene, key, amplitude);
+      }
+    }
+  });
+}
+
+function writeShape(root, name, value) {
+  root.traverse((obj) => {
+    if (!obj.morphTargetDictionary || !obj.morphTargetInfluences) return;
+    const index = obj.morphTargetDictionary[name];
+    if (index === undefined) return;
+    obj.morphTargetInfluences[index] = value;
+  });
+}
+
+function randomBlinkDelay() {
+  return 3 + Math.random() * 2; // 3–5s
+}
+
+function randomSaccadeDelay() {
+  return 2 + Math.random() * 4; // 2–6s
+}
+
+const SACCADE_PAIRS = [
+  ['Eye_L_Look_L', 'Eye_R_Look_L'],
+  ['Eye_L_Look_R', 'Eye_R_Look_R'],
+  ['Eye_L_Look_Up', 'Eye_R_Look_Up'],
+  ['Eye_L_Look_Down', 'Eye_R_Look_Down']
+];
+function pickSaccadeTargets() {
+  return SACCADE_PAIRS[Math.floor(Math.random() * SACCADE_PAIRS.length)];
+}

--- a/client/src/components/cos/avatar3d/useSpeakingLayer.js
+++ b/client/src/components/cos/avatar3d/useSpeakingLayer.js
@@ -1,0 +1,59 @@
+import { useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+
+const SPEAKING_FREQ_HZ = 6;
+
+// Speaking layer. If the model has visemes, drive V_Open + V_Lip_Open from a
+// 6Hz sine while the `speaking` flag is true — visually reads as "talking"
+// without needing phoneme-timed TTS metadata.
+//
+// If there are no visemes, fall back to a small sinusoidal head rotation
+// using any head-like bone found in the rig.
+export function useSpeakingLayer({ gltf, capabilities, speaking }) {
+  const basisRef = useRef({ recorded: false, rotationY: 0 });
+
+  useFrame(() => {
+    if (!gltf || !gltf.scene) return;
+
+    if (capabilities.hasVisemes) {
+      const amp = speaking ? 0.5 + 0.5 * Math.sin(performance.now() / 1000 * SPEAKING_FREQ_HZ * Math.PI * 2) : 0;
+      writeShape(gltf.scene, 'V_Open', amp * 0.6);
+      writeShape(gltf.scene, 'V_Lip_Open', amp * 0.4);
+    } else {
+      const head = findHeadBone(capabilities.bonesByName);
+      if (!head) return;
+      if (!basisRef.current.recorded) {
+        basisRef.current.recorded = true;
+        basisRef.current.rotationY = head.rotation.y;
+      }
+      if (speaking) {
+        const amp = Math.sin(performance.now() / 1000 * SPEAKING_FREQ_HZ * Math.PI * 2) * 0.08;
+        head.rotation.y = basisRef.current.rotationY + amp;
+      } else {
+        head.rotation.y = basisRef.current.rotationY;
+      }
+    }
+  });
+}
+
+function writeShape(root, name, value) {
+  root.traverse((obj) => {
+    if (!obj.morphTargetDictionary || !obj.morphTargetInfluences) return;
+    const index = obj.morphTargetDictionary[name];
+    if (index === undefined) return;
+    obj.morphTargetInfluences[index] = value;
+  });
+}
+
+const HEAD_BONE_CANDIDATES = ['head', 'Head', 'mixamorig:Head', 'cc_base_head', 'cc_base_Head', 'neck_01', 'Neck'];
+function findHeadBone(bonesByName) {
+  for (const name of HEAD_BONE_CANDIDATES) {
+    const bone = bonesByName.get(name);
+    if (bone) return bone;
+  }
+  // Fallback: first bone with "head" in its name.
+  for (const [name, bone] of bonesByName.entries()) {
+    if (name.toLowerCase().includes('head')) return bone;
+  }
+  return null;
+}

--- a/client/src/components/cos/avatar3d/useStateAnimation.js
+++ b/client/src/components/cos/avatar3d/useStateAnimation.js
@@ -1,0 +1,69 @@
+import { useEffect, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { AnimationMixer, LoopRepeat } from 'three';
+import { stateClipMap } from './stateClipMap';
+
+const CROSSFADE_SECONDS = 0.3;
+
+// Body-clip layer. Picks an AnimationClip per CoS state and crossfades
+// between them via Three.js AnimationMixer. Falls back to `base` if the
+// requested clip is missing.
+export function useStateAnimation({ gltf, capabilities, state }) {
+  const mixerRef = useRef(null);
+  const currentActionRef = useRef(null);
+  const clipByNameRef = useRef(new Map());
+
+  // Build the clip lookup + mixer once per gltf.
+  useEffect(() => {
+    if (!gltf || !gltf.scene) return undefined;
+    const mixer = new AnimationMixer(gltf.scene);
+    const map = new Map();
+    for (const clip of gltf.animations || []) map.set(clip.name, clip);
+    mixerRef.current = mixer;
+    clipByNameRef.current = map;
+    currentActionRef.current = null;
+    return () => {
+      mixer.stopAllAction();
+      mixer.uncacheRoot(gltf.scene);
+      mixerRef.current = null;
+    };
+  }, [gltf]);
+
+  // Switch clip on state change.
+  useEffect(() => {
+    const mixer = mixerRef.current;
+    const map = clipByNameRef.current;
+    if (!mixer || map.size === 0) return;
+
+    const desired = resolveClipName(state, capabilities);
+    if (!desired) return;
+    const clip = map.get(desired);
+    if (!clip) return;
+
+    const next = mixer.clipAction(clip);
+    next.setLoop(LoopRepeat, Infinity);
+    next.enabled = true;
+    next.paused = false;
+
+    const prev = currentActionRef.current;
+    if (prev === next) return;
+
+    next.reset().fadeIn(CROSSFADE_SECONDS).play();
+    if (prev) prev.fadeOut(CROSSFADE_SECONDS);
+    currentActionRef.current = next;
+  }, [state, capabilities]);
+
+  useFrame((_, delta) => {
+    mixerRef.current?.update(delta);
+  });
+}
+
+function resolveClipName(state, capabilities) {
+  const entry = stateClipMap[state] || stateClipMap.base;
+  const desired = entry.clip;
+  if (capabilities.availableClips.has(desired)) return desired;
+  if (capabilities.availableClips.has('base')) return 'base';
+  // No base clip present — return the first available clip so the mesh at
+  // least moves instead of freezing in T-pose.
+  return capabilities.clipNames[0] || null;
+}

--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -214,6 +214,7 @@ export const AVATAR_STYLE_LABELS = {
   sigil: 'Arcane Sigil (3D)',
   esoteric: 'Esoteric (3D)',
   nexus: 'Neural Nexus (3D)',
+  rigged3d: 'Rigged Character (3D)',
   ascii: 'Minimalist (ASCII)'
 };
 

--- a/client/src/components/cos/index.js
+++ b/client/src/components/cos/index.js
@@ -10,6 +10,8 @@ export { default as CyberCoSAvatar } from './CyberCoSAvatar';
 export { default as SigilCoSAvatar } from './SigilCoSAvatar';
 export { default as EsotericCoSAvatar } from './EsotericCoSAvatar';
 export { default as NexusCoSAvatar } from './NexusCoSAvatar';
+export { default as Rigged3DCoSAvatar } from './Rigged3DCoSAvatar';
+export { default as Rigged3DStage } from './Rigged3DStage';
 export { default as StateLabel } from './StateLabel';
 export { default as TerminalCoSPanel } from './TerminalCoSPanel';
 

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -16,6 +16,7 @@ import {
   SigilCoSAvatar,
   EsotericCoSAvatar,
   NexusCoSAvatar,
+  Rigged3DCoSAvatar,
   StateLabel,
   TerminalCoSPanel,
   StatusIndicator,
@@ -602,6 +603,8 @@ export default function ChiefOfStaff() {
                   ? <EsotericCoSAvatar state={agentState} speaking={speaking} />
                 : avatarStyle === 'nexus'
                   ? <NexusCoSAvatar state={agentState} speaking={speaking} />
+                : avatarStyle === 'rigged3d'
+                  ? <Rigged3DCoSAvatar state={agentState} speaking={speaking} />
                 : <CoSCharacter state={agentState} speaking={speaking} />
               }
               <div className="hidden lg:block">

--- a/client/src/pages/CoSStagePage.jsx
+++ b/client/src/pages/CoSStagePage.jsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { useSocket } from '../hooks/useSocket';
+import * as api from '../services/api';
+import Rigged3DStage from '../components/cos/Rigged3DStage';
+import { useAvatarModel } from '../components/cos/avatar3d/useAvatarModel';
+import { EMPTY_STATE } from '../components/cos/avatar3d/emptyStateCopy';
+import { StateLabel } from '../components/cos';
+
+// Mirrors ChiefOfStaff's socket subscription shape so the Stage page sees the
+// same derived state transitions. We don't import the page itself to avoid a
+// circular dep; instead we listen to the same events and apply the same rules.
+function pulseSpeaking(setter) {
+  setter(true);
+  setTimeout(() => setter(false), 2000);
+}
+
+export default function CoSStagePage() {
+  const { status, url } = useAvatarModel();
+  const [agentState, setAgentState] = useState('sleeping');
+  const [speaking, setSpeaking] = useState(false);
+  const socket = useSocket();
+
+  useEffect(() => {
+    api.getCosStatus()
+      .then((data) => { if (data?.state) setAgentState(data.state); })
+      .catch(() => null);
+  }, []);
+
+  useEffect(() => {
+    if (!socket) return undefined;
+    const subscribe = () => socket.emit('cos:subscribe');
+    if (socket.connected) subscribe(); else socket.on('connect', subscribe);
+
+    const onStatus = (data) => { if (data && data.running === false) setAgentState('sleeping'); };
+    const onSpawned = () => { setAgentState('coding'); pulseSpeaking(setSpeaking); };
+    const onCompleted = () => { setAgentState('reviewing'); pulseSpeaking(setSpeaking); };
+    const onHealth = () => { setAgentState('investigating'); pulseSpeaking(setSpeaking); };
+    const onLog = () => { pulseSpeaking(setSpeaking); };
+    const onThinking = () => { setAgentState('thinking'); pulseSpeaking(setSpeaking); };
+
+    socket.on('cos:status', onStatus);
+    socket.on('cos:agent:spawned', onSpawned);
+    socket.on('cos:agent:completed', onCompleted);
+    socket.on('cos:health:check', onHealth);
+    socket.on('cos:log', onLog);
+    socket.on('cos:thinking', onThinking);
+
+    return () => {
+      socket.off('connect', subscribe);
+      socket.off('cos:status', onStatus);
+      socket.off('cos:agent:spawned', onSpawned);
+      socket.off('cos:agent:completed', onCompleted);
+      socket.off('cos:health:check', onHealth);
+      socket.off('cos:log', onLog);
+      socket.off('cos:thinking', onThinking);
+    };
+  }, [socket]);
+
+  if (status === 'probing') {
+    return (
+      <div className="flex items-center justify-center h-[70vh] text-gray-500">
+        <div className="text-sm font-mono">Probing avatar model…</div>
+      </div>
+    );
+  }
+  if (status === 'missing') return <EmptyState />;
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-3 px-4 pt-4">
+        <h1 className="text-xl font-semibold text-gray-100">Chief of Staff — Stage</h1>
+        <StateLabel state={agentState} />
+        {speaking && <span className="text-xs text-port-accent">speaking</span>}
+      </div>
+      <Rigged3DStage url={url} state={agentState} speaking={speaking} />
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-10">
+      <div className="rounded-lg border border-port-border bg-port-card p-6 space-y-4">
+        <h1 className="text-xl font-semibold text-gray-100">{EMPTY_STATE.title}</h1>
+        <p className="text-gray-400">{EMPTY_STATE.summary}</p>
+        <div>
+          <div className="text-xs uppercase text-gray-500 mb-2">Required animation clips</div>
+          <div className="flex flex-wrap gap-2">
+            {EMPTY_STATE.requiredClips.map((c) => (
+              <span
+                key={c}
+                className="px-2 py-1 rounded font-mono text-xs bg-port-bg border border-port-border text-gray-300"
+              >
+                {c}
+              </span>
+            ))}
+          </div>
+        </div>
+        <div className="text-sm text-gray-400">
+          See <code className="px-1 py-0.5 rounded bg-port-bg text-gray-300">docs/avatar-pipeline.md</code> for the full setup guide, including optional shape keys (visemes, blinks, brows) that unlock richer behavior.
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/avatar-pipeline.md
+++ b/docs/avatar-pipeline.md
@@ -1,0 +1,97 @@
+# Rigged 3D Avatar — Setup Guide
+
+PortOS's **Chief of Staff → Stage** view (and the `Rigged Character (3D)` avatar style in the CoS header) renders a user-supplied rigged-and-animated GLB file. PortOS does not ship a default model — you provide one.
+
+## TL;DR
+
+1. Put a rigged `.glb` with the required animation clips at `./data/avatar/model.glb` on the server.
+2. Restart PortOS (or just reload the browser — the server picks up new files without restart).
+3. Choose **Rigged Character (3D)** in CoS → Config → Avatar Style, and/or visit **Chief of Staff → Stage**.
+
+If `./data/avatar/model.glb` is missing, the Stage view shows a help panel and the header avatar falls back to whichever style was previously selected.
+
+---
+
+## The clip-name contract
+
+PortOS switches body animations based on the Chief-of-Staff agent state. Your GLB must include animation tracks with these exact names:
+
+| Clip name       | Plays when the CoS agent is…                     | Required |
+|-----------------|--------------------------------------------------|----------|
+| `base`          | default / fallback idle                          | **yes**  |
+| `sleeping`      | idle, no active tasks                            | optional |
+| `thinking`      | evaluating or reasoning                          | optional |
+| `coding`        | actively running an agent / writing code         | optional |
+| `investigating` | running diagnostics, looking at logs             | optional |
+| `reviewing`     | reading or reviewing output                      | optional |
+| `planning`      | planning next steps                              | optional |
+| `ideating`      | brainstorming / option analysis                  | optional |
+
+Only `base` is strictly required. Any missing clip falls back to `base`.
+
+---
+
+## Optional shape keys (unlock richer behavior)
+
+If your GLB is a CC3+/ARKit-style character with blendshapes, PortOS's runtime detects these automatically and layers extra behavior on top of the body animation:
+
+- **Visemes** — `V_Open`, `V_Lip_Open`, `V_Explosive`, `V_Dental_Lip`, `V_Tight_O`, `V_Tight`, `V_Wide`, `V_Affricate` → real mouth movement when the CoS is speaking.
+- **Blinks** — `Eye_Blink_L`, `Eye_Blink_R` → periodic blinks.
+- **Eye look** — `Eye_L_Look_L/R/Up/Down`, `Eye_R_Look_L/R/Up/Down` → subtle saccades.
+- **Brows** — `Brow_Raise_Inner_L/R`, `Brow_Raise_Outer_L/R`, `Brow_Compress_L/R`, `Brow_Drop_L/R` → per-state expressions.
+- **Mouth** — `Mouth_Smile_L/R`, `Mouth_Frown_L/R` → per-state expressions.
+
+None of these are required. A rig-only model still works — it just won't blink or change expression.
+
+---
+
+## Where to get a model
+
+You supply your own. Examples of sources:
+
+- **Reallusion ActorCore** (https://actorcore.reallusion.com) — characters + motion library. Full CC3+ facial rig included on most characters.
+- **CGTrader / Sketchfab** — search for "rigged" + "animated". Many static meshes are mis-tagged as rigged, so verify before buying.
+- **Your own Character Creator export** if you're already in the Reallusion ecosystem.
+
+**Worked example**: The free [Amber](https://www.cgtrader.com/free-3d-models/character/woman/amber-free-high-poly-3d-model) model on CGTrader is a full CC3+ character with a rigged skeleton and facial blendshapes. Download, follow the reduction steps below, and drop the resulting GLB into `./data/avatar/model.glb`.
+
+> **License disclaimer**: You are responsible for the license of any model you ship or use with PortOS. "Free to download" is not the same as "free to redistribute". PortOS never ships, commits, or redistributes any user-supplied model — your copy stays local.
+
+---
+
+## If your mesh is unrigged
+
+Start with an auto-rigger:
+
+- **AccuRIG 2** (free, desktop, Reallusion) — https://actorcore.reallusion.com/auto-rig. Produces CC3+-compatible rigs. Recommended if you plan to use CC3+ animations or already have ActorCore characters.
+- **Mesh2Motion** (free, open source, web-based) — https://mesh2motion.org/. Closest substitute for the defunct Mixamo workflow.
+- **Blender Rigify** (free, built into Blender) — most manual work but entirely offline.
+
+---
+
+## Blender reduction + export pipeline
+
+Once you have a rigged FBX/GLB with named animation tracks:
+
+1. **Open in Blender** — File → Import → FBX, or File → Open if it's a `.blend`.
+2. **Rename actions to match the clip-name contract** — Open the Action Editor (top-left dropdown in the Dope Sheet). Rename each action to `base`, `sleeping`, `thinking`, etc. Exact names, case-sensitive.
+3. **Reduce textures** (optional but recommended for web):
+   - Select every image texture → in the Image Properties, use Blender's built-in resize (N panel → Image → Resize) to drop 4k textures to 1k.
+   - For PBR-heavy characters, aim to keep the total texture budget under ~20 MB.
+4. **Export GLB**:
+   - File → Export → **glTF 2.0 (.glb/.gltf)**
+   - Format: **glTF Binary (.glb)**
+   - Include: **Animations ✓**, **Shape Keys ✓** (if the model has blendshapes)
+   - Compression: enable **Draco** for smaller mesh data
+   - Target ≤ 30 MB total. Larger files will load but delay first render.
+5. **Copy the result** to the PortOS server at `./data/avatar/model.glb`.
+
+---
+
+## Verifying
+
+After dropping the GLB in place:
+
+- Hit `HEAD /api/avatar/model.glb` — should return 200 with `Content-Type: model/gltf-binary`. Returns 404 if the file isn't present.
+- Visit `/cos/stage` — the Stage view loads the model, and a small badge in the bottom-left lists the detected capabilities (`rigged · N clips · visemes · blinks · eye-tracking · expressions · cc3`).
+- Set CoS → Config → Avatar Style to **Rigged Character (3D)** to use the rigged avatar in the header too.

--- a/docs/superpowers/specs/2026-04-20-rigged-3d-avatar-stage-design.md
+++ b/docs/superpowers/specs/2026-04-20-rigged-3d-avatar-stage-design.md
@@ -1,0 +1,204 @@
+# Rigged 3D Avatar — Stage View & Header Slot
+
+**Status**: design approved, awaiting implementation plan
+**Date**: 2026-04-20
+**Scope**: single feature, one implementation plan
+
+## Goal
+
+Add a rigged, animated 3D character as a new avatar style for the Chief of Staff. The same runtime feeds two views:
+
+- a small header slot (alongside existing `cyber`/`sigil`/`esoteric`/`nexus` variants), and
+- a full-page **Stage** route at `/cos/stage`.
+
+The character's body animation, facial expression, and speaking behavior react to CoS agent state (`sleeping`, `thinking`, `coding`, `investigating`, `reviewing`, `planning`, `ideating`) and the existing `speaking` flag — the same props every other avatar variant already consumes.
+
+## Non-goals
+
+- Shipping a bundled 3D model in the repo. The single source of the character is a user-supplied GLB at `./data/avatar/model.glb`. No binary is committed.
+- Teaching users to rig characters. `docs/avatar-pipeline.md` links to external tools (AccuRIG 2, Mesh2Motion, Rigify) for the rigging step.
+- Per-agent personas, skins, or multiple simultaneous avatars.
+- Phoneme-timed TTS lip-sync. Speaking is driven by audio amplitude or a sine fallback, not phoneme sequences. A viseme-per-phoneme engine is a later upgrade if desired.
+- LOD swap, user-uploaded clip-remap UI, or runtime model format conversion.
+
+## Architecture
+
+```
+client/src/components/cos/
+  Rigged3DCoSAvatar.jsx       # header slot component (small canvas, fixed camera)
+  Rigged3DStage.jsx           # 3D scene component (canvas + camera + lighting); used by the Stage page
+  avatar3d/
+    useAvatarModel.js         # GLB resolution + load (HEAD → GET or 404 fallback)
+    useAvatarCapabilities.js  # scans loaded GLB, returns capability descriptor
+    useStateAnimation.js      # body-clip layer: crossfades AnimationMixer clips
+    useExpressionLayer.js     # blendshape layer: per-state facial expression targets
+    useLifeLayer.js           # always-on: blink + saccades + breathing
+    useSpeakingLayer.js       # viseme or head-bob, capability-gated
+    stateClipMap.js           # canonical state → clip-name + expression targets
+    emptyStateCopy.js         # strings for the "no model configured" UX
+
+client/src/pages/
+  CoSStagePage.jsx            # route container — switches between Rigged3DStage (model present) and EmptyStateCard (missing)
+
+server/routes/
+  avatar.js                   # GET /api/avatar/model.glb, HEAD /api/avatar/model.glb
+```
+
+No new npm dependencies — `@react-three/fiber`, `@react-three/drei`, and `three` are already installed (confirmed in `client/package.json`).
+
+Avatar-style registry (`client/src/components/cos/constants.js`) gains one entry: `rigged3d: "Rigged Character (3D)"`. The option is always visible in the settings dropdown; selecting it when no model is configured shows the empty-state view and does not break existing behavior.
+
+New sidebar nav item "Stage" under Chief of Staff, alphabetically ordered (after "Schedule"). Route `/cos/stage`.
+
+## Model resolution
+
+`useAvatarModel` runs once per mount:
+
+1. `HEAD /api/avatar/model.glb`
+2. 200 → `useGLTF('/api/avatar/model.glb')`
+3. 404 or network error → returns `{ status: 'missing' }`. No bundled fallback is attempted.
+
+Server route `GET /api/avatar/model.glb`:
+- Streams `./data/avatar/model.glb` with `Content-Type: model/gltf-binary` if present.
+- Returns 404 otherwise. The missing case is normal, not an error.
+- `HEAD` supported for the probe without downloading the body.
+
+## Capability detection
+
+On successful load, `useAvatarCapabilities` scans the parsed glTF JSON once and produces:
+
+```js
+{
+  hasSkins: boolean,
+  availableClips: Set<string>,
+  hasVisemes: boolean,           // any of V_Open / V_Tight / V_Explosive etc.
+  hasBlinkShapes: boolean,       // Eye_Blink_L && Eye_Blink_R
+  hasEyeLook: boolean,           // Eye_*_Look_* shapes present
+  hasBrowShapes: boolean,        // Brow_* shapes present
+  hasMouthShapes: boolean,       // Mouth_Smile_*, Mouth_Frown_*
+  skeletonHint: 'cc3' | 'mixamo' | 'unknown',
+}
+```
+
+Every runtime layer gates behavior on this object. Missing capabilities silently degrade — the canvas never crashes because a shape key or clip is absent.
+
+## Runtime: three layers + speaking
+
+All four layers compose on the same scene graph and are independent.
+
+**Layer 1 — Body clip (`useStateAnimation`)**
+`AnimationMixer` plays one body clip per CoS state. State transitions crossfade over 300 ms via `fadeOut(0.3)` + `fadeIn(0.3).play()`. All clips loop (`LoopRepeat`). If the configured state clip is missing, falls back to `base`. If `base` is missing, the mesh stands in T-pose (capability detector flags this as a config error surfaced in the empty-state panel).
+
+**Layer 2 — Expression (`useExpressionLayer`)**
+Per-state facial targets from `stateClipMap`. Eased to targets over 300 ms using a per-frame lerp. Skipped entirely if `hasBrowShapes && hasMouthShapes` is false. Target set intentionally small (brow raise/drop/compress, mouth smile/frown, eye squint/wide) — expressive but inside the common-denominator CC3+/ARKit shape vocabulary.
+
+**Layer 3 — Life (`useLifeLayer`)**
+Always-on ambient motion, independent of state:
+- **Blink cycle**: `Eye_Blink_L` + `Eye_Blink_R` driven to 1.0 for ~120 ms every 3–5 s (randomized). Skipped if `!hasBlinkShapes`.
+- **Saccades**: every 2–6 s pick a random `Eye_*_Look_*` pair at 0.3 amplitude for 200 ms. Skipped if `!hasEyeLook`.
+- **Breathing**: small sine modulation on root scale Y (~0.5%) — works without shape keys, always on.
+
+**Layer 4 — Speaking (`useSpeakingLayer`)**
+Triggered by the existing `speaking` prop:
+- If `hasVisemes`: drive `V_Open` + `V_Lip_Open` from an audio amplitude analyzer if a speaking audio stream is available; else drive from a 6 Hz sine while `speaking === true`.
+- If `!hasVisemes`: small sinusoidal rotation on the head bone (≤5°) — works on any rigged mesh.
+
+## State → clip + expression mapping
+
+`stateClipMap.js` exports one object that's the single source of truth:
+
+```js
+export const stateClipMap = {
+  base:          { clip: 'base',          expression: {} },                     // required fallback
+  sleeping:      { clip: 'sleeping',      expression: { Eye_Blink_L: 1, Eye_Blink_R: 1 } },
+  thinking:      { clip: 'thinking',      expression: { Brow_Compress_L: 0.5, Brow_Compress_R: 0.5 } },
+  coding:        { clip: 'coding',        expression: { Mouth_Smile_L: 0.2, Mouth_Smile_R: 0.2 } },
+  investigating: { clip: 'investigating', expression: { Brow_Raise_Outer_L: 0.6, Brow_Raise_Outer_R: 0.6, Eye_Wide_L: 0.4, Eye_Wide_R: 0.4 } },
+  reviewing:     { clip: 'reviewing',     expression: { Brow_Compress_L: 0.3, Brow_Compress_R: 0.3 } },
+  planning:      { clip: 'planning',      expression: {} },
+  ideating:      { clip: 'ideating',      expression: { Brow_Raise_Inner_L: 0.6, Brow_Raise_Inner_R: 0.6, Mouth_Smile_L: 0.3, Mouth_Smile_R: 0.3 } },
+};
+```
+
+Clip names are the **contract with the user-supplied GLB**: whichever model a user drops in, they rename their animation tracks to these keys during Blender export (documented in `docs/avatar-pipeline.md`).
+
+## Empty-state UX
+
+When `useAvatarModel` returns `{ status: 'missing' }`:
+
+- **Header slot** (`Rigged3DCoSAvatar`): renders nothing itself and lets the existing fallback chain pick the previously-selected style (or `cyber` default). Header never shows a broken canvas.
+- **Stage route** (`Rigged3DStage`): renders `EmptyStateCard` — full-page panel with the feature name, a short description, the `./data/avatar/model.glb` target path, required clip-name contract, and a link to `docs/avatar-pipeline.md`. Sidebar nav entry stays visible so the feature remains discoverable.
+
+## Settings integration
+
+Avatar style dropdown (existing UI) gains `rigged3d`. When selected:
+
+- If model is present: `Rigged3DCoSAvatar` renders in the header slot.
+- If model is missing: style is accepted but the header slot falls back to the prior style. A small "⚠ no model configured — see setup guide" hint appears under the dropdown.
+
+No change to `AVATAR_STYLE_LABELS` consumers elsewhere.
+
+## Assets & docs
+
+`docs/avatar-pipeline.md` is authored as part of this feature and covers:
+
+- Where to drop the GLB (`./data/avatar/model.glb`).
+- The required clip-name contract (`base`, `sleeping`, `thinking`, `coding`, `investigating`, `reviewing`, `planning`, `ideating`).
+- Optional shape keys that unlock richer behavior (CC3+ `V_*` visemes, `Eye_Blink_*`, `Brow_*`, `Mouth_Smile_*`).
+- Worked example: using the freely-downloadable Amber CC3 character from https://www.cgtrader.com/free-3d-models/character/woman/amber-free-high-poly-3d-model, reduced via a documented Blender texture-downsample + Draco export.
+- Pointers for users starting from an unrigged mesh (AccuRIG 2, Mesh2Motion, Rigify) — not step-by-step, just links.
+- Explicit note: license compliance for the dropped-in model is the user's responsibility.
+
+## Error handling
+
+No `try`/`catch` — the codebase convention is to let errors bubble to centralized middleware. Capability-gated fallbacks replace defensive exception handling:
+
+- Missing GLB → 404 → empty-state view.
+- GLB load failure (corrupt file, network error) → error bubbles, `useGLTF` Suspense boundary shows the empty state with a distinct "model failed to load" message instead of the generic "no model configured" message.
+- Missing clip → fall back to `base` clip.
+- Missing shape keys → that layer is a no-op.
+- Missing `base` clip → capability detector sets a warning that surfaces in the empty-state panel.
+
+## Testing
+
+Server:
+- `avatar.js` route: 404 when file absent, 200 with `model/gltf-binary` when present, HEAD returns correct status without body. Uses a small fixture GLB in `server/test/fixtures/`.
+
+Client — pure-logic units (preferred pattern per `CLAUDE.md`):
+- `useAvatarCapabilities` classifier: given a parsed glTF JSON, returns the expected capability descriptor. Multiple fixtures: no-skin, Mixamo-rigged, CC3-full.
+- `stateClipMap` integrity: every state has a clip + expression; `base` exists; no typos in shape key names against the CC3+ reference.
+
+Client — integration:
+- `useStateAnimation` clip lookup falls back to `base` when the requested clip is missing.
+- Empty-state renders when the API returns 404, without mounting an R3F canvas.
+
+Visual behavior (blink timing, crossfade, saccade randomness) is not unit-tested — validated by manual Stage-view check during implementation.
+
+## Out of scope (explicitly deferred)
+
+- Per-phoneme TTS viseme timing.
+- Per-agent avatar customization.
+- User-uploaded clip-name remap UI in settings.
+- LOD swap between header and stage.
+- Inline model upload via the web UI (users drop files directly into `./data/avatar/`).
+- Shipping a default model.
+
+## Files touched
+
+Created:
+- `client/src/components/cos/Rigged3DCoSAvatar.jsx`
+- `client/src/components/cos/Rigged3DStage.jsx`
+- `client/src/components/cos/avatar3d/` (6 files listed above)
+- `client/src/pages/CoSStagePage.jsx`
+- `server/routes/avatar.js`
+- `server/test/fixtures/cos-avatar.glb` (tiny test fixture, NOT a user-facing model)
+- `server/test/avatar.test.js`
+- `client/src/components/cos/avatar3d/__tests__/*.test.js`
+- `docs/avatar-pipeline.md`
+
+Modified:
+- `client/src/components/cos/constants.js` — add `rigged3d` to `AVATAR_STYLE_LABELS`
+- `client/src/components/cos/index.js` — export new components
+- `client/src/App.jsx` — register `/cos/stage` route
+- `client/src/components/Layout.jsx` — add "Stage" sidebar entry
+- `server/server.js` — mount `avatar.js` router

--- a/server/index.js
+++ b/server/index.js
@@ -74,6 +74,7 @@ import characterRoutes from './routes/character.js';
 import toolsRoutes from './routes/tools.js';
 import imageGenRoutes from './routes/imageGen.js';
 import openclawRoutes from './routes/openclaw.js';
+import avatarRoutes from './routes/avatar.js';
 import { ensureSelf, startPolling } from './services/instances.js';
 import { initSyncLog } from './services/brainSyncLog.js';
 import { backfillOriginInstanceId } from './services/brainStorage.js';
@@ -300,6 +301,7 @@ app.use('/api/character', characterRoutes);
 app.use('/api/tools', toolsRoutes);
 app.use('/api/image-gen', imageGenRoutes);
 app.use('/api/openclaw', openclawRoutes);
+app.use('/api/avatar', avatarRoutes);
 
 // Initialize agent automation scheduler and action executor
 automationScheduler.init().catch(err => console.error(`❌ Agent scheduler init failed: ${err.message}`));

--- a/server/routes/avatar.js
+++ b/server/routes/avatar.js
@@ -1,0 +1,42 @@
+import { Router } from 'express';
+import { createReadStream, existsSync, statSync } from 'fs';
+import { join } from 'path';
+import { PATHS } from '../lib/fileUtils.js';
+
+const router = Router();
+
+const MODEL_PATH = join(PATHS.data, 'avatar', 'model.glb');
+
+// HEAD /api/avatar/model.glb — probe whether a user-supplied model is configured.
+// 200 if present, 404 otherwise. No body.
+router.head('/model.glb', (req, res) => {
+  if (!existsSync(MODEL_PATH)) {
+    console.log(`🎭 avatar HEAD ${MODEL_PATH} — 404 (no model configured)`);
+    return res.status(404).end();
+  }
+  const { size } = statSync(MODEL_PATH);
+  res.set({
+    'Content-Type': 'model/gltf-binary',
+    'Content-Length': size,
+    'Cache-Control': 'no-cache'
+  });
+  res.status(200).end();
+});
+
+// GET /api/avatar/model.glb — stream the user-supplied rigged avatar if present.
+router.get('/model.glb', (req, res) => {
+  if (!existsSync(MODEL_PATH)) {
+    console.log(`🎭 avatar GET ${MODEL_PATH} — 404 (no model configured)`);
+    return res.status(404).json({ error: 'avatar model not configured' });
+  }
+  const { size } = statSync(MODEL_PATH);
+  console.log(`🎭 avatar GET streaming ${size} bytes from ${MODEL_PATH}`);
+  res.set({
+    'Content-Type': 'model/gltf-binary',
+    'Content-Length': size,
+    'Cache-Control': 'no-cache'
+  });
+  createReadStream(MODEL_PATH).pipe(res);
+});
+
+export default router;


### PR DESCRIPTION
## Summary

Adds a new **Rigged Character (3D)** avatar style and a dedicated **`/cos/stage`** route that render a user-supplied rigged GLB. No model ships in the repo — users drop their own at `./data/avatar/model.glb`.

Full design: [docs/superpowers/specs/2026-04-20-rigged-3d-avatar-stage-design.md](../blob/main/docs/superpowers/specs/2026-04-20-rigged-3d-avatar-stage-design.md) (already on main).

## What's built

**Server**
- `GET|HEAD /api/avatar/model.glb` streams `./data/avatar/model.glb` if present, 404 otherwise.

**Client — four-layer runtime composing on a loaded glTF scene**
- Body clip: AnimationMixer 300ms crossfade between CoS agent states
- Expression: per-state shape-key targets, eased
- Life: always-on blink cycle + saccades + breathing micro-scale
- Speaking: CC3+/ARKit viseme amplitude if present, head-bob fallback

All four gated by a capability detector (`useAvatarCapabilities`) that scans for skins, shape keys, bones, and skeleton hints. Missing features silently degrade — a minimal rig still works.

**Views**
- `Rigged3DCoSAvatar` — header slot (falls back to SVG avatar on 404)
- `Rigged3DStage` — full-page scene with OrbitControls, studio env, contact shadows, capability badge
- `CoSStagePage` — route container with empty-state help panel

**Integration**
- `rigged3d` added to `AVATAR_STYLE_LABELS`
- Avatar ladder in `ChiefOfStaff.jsx` updated
- `/cos/stage` route registered ahead of `/cos/:tab`
- "Stage" sidebar entry added alphabetically in `Layout.jsx`

**Docs**
- `docs/avatar-pipeline.md` — clip-name contract, optional shape keys, model-source examples, license disclaimer, Blender export steps

## Status: draft, pausing to explore another avenue

Functional scaffolding is complete and the client build passes, but **not yet fully test-driven end-to-end**. Remaining work before undraft:
- [ ] Drop a real rigged GLB into `./data/avatar/model.glb` and visually verify all four layers on `/cos/stage`
- [ ] Confirm capability badge shows expected features (skins, clips, visemes, blinks, eye-tracking, expressions, skeleton hint)
- [ ] Verify header-slot variant when `rigged3d` is selected in config
- [ ] Verify state transitions crossfade cleanly (thinking → coding → investigating → sleeping)
- [ ] Verify speaking behavior when CoS speaks
- [ ] Add server route unit test (404 when absent, 200 + correct MIME when present)
- [ ] Add client unit tests for `useAvatarCapabilities` and `stateClipMap` integrity
- [ ] Update CHANGELOG

## Test plan

Without a model:
- [ ] `curl -skI https://localhost:5555/api/avatar/model.glb` returns 404
- [ ] Visit `/cos/stage` — shows empty-state panel with clip-name contract
- [ ] Select **Rigged Character (3D)** in CoS Config — header falls back to SVG avatar (no broken canvas)

With a model:
- [ ] Drop a rigged GLB at `./data/avatar/model.glb`
- [ ] `/cos/stage` renders the scene with OrbitControls
- [ ] Capability badge shows detected features
- [ ] State changes trigger body clip crossfade
- [ ] Blink cycle active (if Eye_Blink_L/R shape keys exist)
- [ ] Speaking flag drives visemes or head-bob