### PR TITLE
fix: timer/poll-loop leaks + fetch timeouts + bounded-parallel feed refresh

### DIFF
--- a/autofixer/server.js
+++ b/autofixer/server.js
@@ -350,6 +350,6 @@ process.on('SIGTERM', () => {
 
 // Start
 main().catch(error => {
-  console.error('[Autofixer] Fatal error:', error);
+  console.error('[Autofixer] Fatal error:', error?.message || String(error), error?.stack);
   process.exit(1);
 });

--- a/server/lib/httpClient.js
+++ b/server/lib/httpClient.js
@@ -35,7 +35,11 @@ function insecureFetch(agent) {
       req.on('error', reject);
       if (signal) {
         if (signal.aborted) { req.destroy(); reject(new Error('Request aborted')); return; }
-        signal.addEventListener('abort', () => req.destroy(new Error('Request aborted')), { once: true });
+        const onAbort = () => req.destroy(new Error('Request aborted'));
+        signal.addEventListener('abort', onAbort, { once: true });
+        const cleanup = () => signal.removeEventListener('abort', onAbort);
+        req.on('close', cleanup);
+        req.on('error', cleanup);
       }
       if (body) req.write(body);
       req.end();

--- a/server/lib/httpClient.js
+++ b/server/lib/httpClient.js
@@ -14,12 +14,6 @@ function insecureFetch(agent) {
       // res.on('error'), and req.on('error') — keep-alive sockets may not
       // fire req 'close' promptly, so we cannot rely on that alone.
       let cleanup = () => {};
-      if (signal) {
-        if (signal.aborted) { reject(new Error('Request aborted')); return; }
-        const onAbort = () => req.destroy(new Error('Request aborted')); // eslint-disable-line no-use-before-define
-        signal.addEventListener('abort', onAbort, { once: true });
-        cleanup = () => signal.removeEventListener('abort', onAbort);
-      }
 
       const req = https.request({
         hostname: u.hostname,
@@ -47,6 +41,14 @@ function insecureFetch(agent) {
       req.on('error', (err) => { cleanup(); reject(err); });
       if (body) req.write(body);
       req.end();
+
+      // Register abort handler after req exists to avoid TDZ; also handle already-aborted case
+      if (signal) {
+        if (signal.aborted) { req.destroy(new Error('Request aborted')); return; }
+        const onAbort = () => req.destroy(new Error('Request aborted'));
+        signal.addEventListener('abort', onAbort, { once: true });
+        cleanup = () => signal.removeEventListener('abort', onAbort);
+      }
     });
   };
 }

--- a/server/lib/httpClient.js
+++ b/server/lib/httpClient.js
@@ -10,6 +10,17 @@ function insecureFetch(agent) {
   return async (url, { method = 'GET', headers = {}, body, signal } = {}) => {
     const u = new URL(url);
     return new Promise((resolve, reject) => {
+      // Declare cleanup before req so it can be called from res.on('end'),
+      // res.on('error'), and req.on('error') — keep-alive sockets may not
+      // fire req 'close' promptly, so we cannot rely on that alone.
+      let cleanup = () => {};
+      if (signal) {
+        if (signal.aborted) { reject(new Error('Request aborted')); return; }
+        const onAbort = () => req.destroy(new Error('Request aborted')); // eslint-disable-line no-use-before-define
+        signal.addEventListener('abort', onAbort, { once: true });
+        cleanup = () => signal.removeEventListener('abort', onAbort);
+      }
+
       const req = https.request({
         hostname: u.hostname,
         port: u.port || 443,
@@ -21,6 +32,7 @@ function insecureFetch(agent) {
         const chunks = [];
         res.on('data', c => chunks.push(c));
         res.on('end', () => {
+          cleanup();
           const text = Buffer.concat(chunks).toString('utf-8');
           resolve({
             ok: res.statusCode >= 200 && res.statusCode < 300,
@@ -30,17 +42,9 @@ function insecureFetch(agent) {
             json: () => Promise.resolve(JSON.parse(text))
           });
         });
-        res.on('error', reject);
+        res.on('error', (err) => { cleanup(); reject(err); });
       });
-      req.on('error', reject);
-      if (signal) {
-        if (signal.aborted) { req.destroy(); reject(new Error('Request aborted')); return; }
-        const onAbort = () => req.destroy(new Error('Request aborted'));
-        signal.addEventListener('abort', onAbort, { once: true });
-        const cleanup = () => signal.removeEventListener('abort', onAbort);
-        req.on('close', cleanup);
-        req.on('error', cleanup);
-      }
+      req.on('error', (err) => { cleanup(); reject(err); });
       if (body) req.write(body);
       req.end();
     });

--- a/server/lib/telegramClient.js
+++ b/server/lib/telegramClient.js
@@ -91,7 +91,10 @@ export function createTelegramBot(token, opts = {}) {
 
   if (opts.polling) {
     polling = true;
-    pollLoop().catch(() => {});
+    pollLoop().catch(err => {
+      console.error(`❌ Telegram poll loop fatal: ${err.message}`);
+      setTimeout(() => { pollLoop().catch(() => {}); }, 5000);
+    });
   }
 
   return {

--- a/server/lib/telegramClient.js
+++ b/server/lib/telegramClient.js
@@ -89,12 +89,17 @@ export function createTelegramBot(token, opts = {}) {
     }
   }
 
+  function startPolling() {
+    if (!polling) return;
+    pollLoop().catch(err => {
+      console.error(`❌ Telegram poll loop fatal: ${err?.message || String(err)}`);
+      if (polling) setTimeout(startPolling, 5000);
+    });
+  }
+
   if (opts.polling) {
     polling = true;
-    pollLoop().catch(err => {
-      console.error(`❌ Telegram poll loop fatal: ${err.message}`);
-      setTimeout(() => { pollLoop().catch(() => {}); }, 5000);
-    });
+    startPolling();
   }
 
   return {

--- a/server/routes/feeds.js
+++ b/server/routes/feeds.js
@@ -43,9 +43,11 @@ router.get('/items', asyncHandler(async (req, res) => {
   const { limit, offset } = parsePagination(req.query, { defaultLimit: 100, maxLimit: 500 });
   const items = await feedsService.getItems({
     feedId: feedId || undefined,
-    unreadOnly: unreadOnly === 'true'
+    unreadOnly: unreadOnly === 'true',
+    limit,
+    offset
   });
-  res.json(items.slice(offset, offset + limit));
+  res.json(items);
 }));
 
 // POST /api/feeds — add a new feed subscription

--- a/server/services/aiDetect.js
+++ b/server/services/aiDetect.js
@@ -170,7 +170,8 @@ async function executeApiDetection(provider, prompt) {
       model: provider.defaultModel,
       messages: [{ role: 'user', content: prompt }],
       temperature: 0.1
-    })
+    }),
+    signal: AbortSignal.timeout(provider.timeout || 60000)
   });
 
   if (!response.ok) {

--- a/server/services/brain.js
+++ b/server/services/brain.js
@@ -100,7 +100,14 @@ async function callAI(promptStageName, variables, providerOverride, modelOverrid
         output += data.toString();
       });
 
+      const timeoutMs = provider.timeout || 300000;
+      const killTimer = setTimeout(() => {
+        child.kill('SIGKILL');
+        reject(new Error(`CLI AI call timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
       child.on('close', (code) => {
+        clearTimeout(killTimer);
         if (code === 0) {
           resolve({ content: output, model, providerId: provider.id });
         } else {
@@ -108,12 +115,10 @@ async function callAI(promptStageName, variables, providerOverride, modelOverrid
         }
       });
 
-      child.on('error', reject);
-
-      setTimeout(() => {
-        child.kill();
-        reject(new Error('AI request timed out'));
-      }, provider.timeout || 300000);
+      child.on('error', (err) => {
+        clearTimeout(killTimer);
+        reject(err);
+      });
     });
   }
 
@@ -130,7 +135,8 @@ async function callAI(promptStageName, variables, providerOverride, modelOverrid
         model,
         messages: [{ role: 'user', content: prompt }],
         temperature: 0.1
-      })
+      }),
+      signal: AbortSignal.timeout(provider.timeout || 300000)
     });
 
     if (!response.ok) {

--- a/server/services/clinvar.js
+++ b/server/services/clinvar.js
@@ -59,7 +59,7 @@ async function downloadClinvar(onProgress) {
   console.log('🧬 ClinVar: downloading variant_summary.txt.gz from NCBI...');
   onProgress?.('Downloading ClinVar database from NCBI...');
 
-  const response = await fetch(CLINVAR_URL);
+  const response = await fetch(CLINVAR_URL, { signal: AbortSignal.timeout(5 * 60 * 1000) });
   if (!response.ok) {
     return { error: `Download failed: HTTP ${response.status}` };
   }

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -3029,7 +3029,7 @@ async function init() {
   }
 }
 
-// Initialize asynchronously (skip during tests to avoid circular import issues)
+// Initialize asynchronously (skip during tests to avoid circular import issues and side effects)
 if (process.env.NODE_ENV !== 'test') {
   init();
 }

--- a/server/services/feeds.js
+++ b/server/services/feeds.js
@@ -220,31 +220,81 @@ export async function refreshFeed(id) {
   return { feed: { ...feed, unreadCount: data.items.filter(i => i.feedId === id && !i.read).length }, newCount: newItems.length };
 }
 
+// Fetch and parse XML for a feed without touching the store (safe to run in parallel)
+async function fetchAndParseFeed(feed) {
+  const xml = await fetchFeedXml(feed.url);
+  if (!xml) return { feed, parsed: null, error: 'Could not fetch feed' };
+  return { feed, parsed: parseFeed(xml), error: null };
+}
+
+// Apply a parsed feed result to a loaded data object (no I/O — safe to call serially)
+function applyParsedFeed(data, feed, parsed) {
+  const feedRecord = data.feeds.find(f => f.id === feed.id);
+  if (!feedRecord) return 0;
+
+  const existingLinks = new Set(data.items.filter(i => i.feedId === feed.id).map(i => i.link));
+  const newItems = parsed.items
+    .filter(item => item.link && !existingLinks.has(item.link))
+    .slice(0, MAX_ITEMS_PER_FEED)
+    .map(item => ({
+      id: randomUUID(),
+      feedId: feed.id,
+      title: item.title,
+      link: item.link,
+      description: item.description,
+      pubDate: item.pubDate,
+      author: item.author,
+      read: false,
+      fetchedAt: new Date().toISOString()
+    }));
+
+  data.items.push(...newItems);
+
+  // Trim to MAX_ITEMS_PER_FEED per feed (keep newest)
+  const feedItems = data.items
+    .filter(i => i.feedId === feed.id)
+    .sort((a, b) => new Date(b.fetchedAt) - new Date(a.fetchedAt));
+  if (feedItems.length > MAX_ITEMS_PER_FEED) {
+    const keepIds = new Set(feedItems.slice(0, MAX_ITEMS_PER_FEED).map(i => i.id));
+    data.items = data.items.filter(i => i.feedId !== feed.id || keepIds.has(i.id));
+  }
+
+  feedRecord.lastFetched = new Date().toISOString();
+  feedRecord.itemCount = data.items.filter(i => i.feedId === feed.id).length;
+  if (parsed.title) feedRecord.title = parsed.title;
+
+  return newItems.length;
+}
+
 export async function refreshAllFeeds() {
   const data = await store.load();
   const CONCURRENCY = 5;
   let totalNew = 0;
   let totalFailed = 0;
+
+  // Fetch in parallel batches; mutations are applied serially to avoid concurrent store.save() races
   for (let i = 0; i < data.feeds.length; i += CONCURRENCY) {
     const batch = data.feeds.slice(i, i + CONCURRENCY);
-    const results = await Promise.allSettled(batch.map(f => refreshFeed(f.id)));
-    for (let j = 0; j < results.length; j++) {
-      const feed = batch[j];
-      const r = results[j];
-      if (r.status === 'fulfilled') {
-        if (r.value?.error) {
-          totalFailed++;
-          console.warn(`⚠️ Feed refresh failed: ${feed.id} (${feed.url}) - ${r.value.error}`);
-        } else if (r.value?.newCount) {
-          totalNew += r.value.newCount;
-        }
-      } else {
+    const fetched = await Promise.allSettled(batch.map(f => fetchAndParseFeed(f)));
+    for (const r of fetched) {
+      if (r.status === 'rejected') {
         totalFailed++;
-        const errMsg = r.reason instanceof Error ? r.reason.message : String(r.reason);
-        console.warn(`⚠️ Feed refresh rejected: ${feed.id} (${feed.url}) - ${errMsg}`);
+        console.warn(`⚠️ feeds: fetch error: ${r.reason?.message || r.reason}`);
+        continue;
       }
+      const { feed, parsed, error } = r.value;
+      if (error || !parsed) {
+        totalFailed++;
+        console.warn(`⚠️ feeds: refresh failed for ${feed.id} (${feed.url}): ${error}`);
+        continue;
+      }
+      const newCount = applyParsedFeed(data, feed, parsed);
+      console.log(`🔄 Feed refreshed: ${feed.title || feed.id} (+${newCount} new)`);
+      totalNew += newCount;
     }
   }
+
+  await store.save(data);
   console.log(`📡 All feeds refreshed: +${totalNew} new items, ${totalFailed} failures`);
   return { refreshed: data.feeds.length, newItems: totalNew, failures: totalFailed };
 }

--- a/server/services/feeds.js
+++ b/server/services/feeds.js
@@ -222,16 +222,20 @@ export async function refreshFeed(id) {
 
 export async function refreshAllFeeds() {
   const data = await store.load();
+  const CONCURRENCY = 5;
   let totalNew = 0;
-  for (const feed of data.feeds) {
-    const result = await refreshFeed(feed.id);
-    if (result.newCount) totalNew += result.newCount;
+  for (let i = 0; i < data.feeds.length; i += CONCURRENCY) {
+    const batch = data.feeds.slice(i, i + CONCURRENCY);
+    const results = await Promise.allSettled(batch.map(f => refreshFeed(f.id)));
+    for (const r of results) {
+      if (r.status === 'fulfilled' && r.value.newCount) totalNew += r.value.newCount;
+    }
   }
   console.log(`📡 All feeds refreshed: +${totalNew} new items`);
   return { refreshed: data.feeds.length, newItems: totalNew };
 }
 
-export async function getItems({ feedId, unreadOnly } = {}) {
+export async function getItems({ feedId, unreadOnly, limit, offset = 0 } = {}) {
   const data = await store.load();
   let items = data.items;
 
@@ -245,6 +249,7 @@ export async function getItems({ feedId, unreadOnly } = {}) {
     return db - da;
   });
 
+  if (limit != null) return items.slice(offset, offset + limit);
   return items;
 }
 

--- a/server/services/feeds.js
+++ b/server/services/feeds.js
@@ -224,15 +224,29 @@ export async function refreshAllFeeds() {
   const data = await store.load();
   const CONCURRENCY = 5;
   let totalNew = 0;
+  let totalFailed = 0;
   for (let i = 0; i < data.feeds.length; i += CONCURRENCY) {
     const batch = data.feeds.slice(i, i + CONCURRENCY);
     const results = await Promise.allSettled(batch.map(f => refreshFeed(f.id)));
-    for (const r of results) {
-      if (r.status === 'fulfilled' && r.value.newCount) totalNew += r.value.newCount;
+    for (let j = 0; j < results.length; j++) {
+      const feed = batch[j];
+      const r = results[j];
+      if (r.status === 'fulfilled') {
+        if (r.value?.error) {
+          totalFailed++;
+          console.warn(`⚠️ Feed refresh failed: ${feed.id} (${feed.url}) - ${r.value.error}`);
+        } else if (r.value?.newCount) {
+          totalNew += r.value.newCount;
+        }
+      } else {
+        totalFailed++;
+        const errMsg = r.reason instanceof Error ? r.reason.message : String(r.reason);
+        console.warn(`⚠️ Feed refresh rejected: ${feed.id} (${feed.url}) - ${errMsg}`);
+      }
     }
   }
-  console.log(`📡 All feeds refreshed: +${totalNew} new items`);
-  return { refreshed: data.feeds.length, newItems: totalNew };
+  console.log(`📡 All feeds refreshed: +${totalNew} new items, ${totalFailed} failures`);
+  return { refreshed: data.feeds.length, newItems: totalNew, failures: totalFailed };
 }
 
 export async function getItems({ feedId, unreadOnly, limit, offset = 0 } = {}) {
@@ -250,7 +264,7 @@ export async function getItems({ feedId, unreadOnly, limit, offset = 0 } = {}) {
   });
 
   if (limit != null) return items.slice(offset, offset + limit);
-  return items;
+  return items.slice(offset);
 }
 
 export async function markItemRead(itemId) {

--- a/server/services/lmStudioManager.js
+++ b/server/services/lmStudioManager.js
@@ -7,6 +7,8 @@
 
 import { cosEvents } from './cosEvents.js'
 
+const AVAILABILITY_CACHE_TTL_MS = 30_000
+
 // Default LM Studio configuration
 const DEFAULT_CONFIG = {
   baseUrl: (process.env.LM_STUDIO_URL || 'http://localhost:1234').replace(/\/+$/, '').replace(/\/v1$/, ''),
@@ -63,7 +65,7 @@ async function checkLMStudioAvailable() {
   const now = Date.now()
 
   // Use cached result if recent (within 30 seconds)
-  if (lastCheckAt && now - lastCheckAt < 30000 && isAvailable !== null) {
+  if (lastCheckAt && now - lastCheckAt < AVAILABILITY_CACHE_TTL_MS && isAvailable !== null) {
     return isAvailable
   }
 

--- a/server/services/loops.js
+++ b/server/services/loops.js
@@ -305,7 +305,9 @@ export async function triggerLoop(id) {
   if (!loop) throw new Error(`Loop ${id} not found`);
   if (!activeLoops.has(id)) throw new Error(`Loop ${id} is not running`);
 
-  executeIteration(loop);
+  executeIteration(loop).catch(err => {
+    console.error(`❌ [loops] iteration error for loop ${loop.id}: ${err.message}`);
+  });
   return { triggered: true };
 }
 

--- a/server/services/loops.js
+++ b/server/services/loops.js
@@ -211,7 +211,10 @@ export async function createLoop({ prompt, interval, name, cwd, providerId, time
 }
 
 function startLoopTimer(loop, runImmediately = false) {
-  const timer = setInterval(() => executeIteration(loop), loop.intervalMs);
+  const runWithLogging = () => executeIteration(loop).catch(err => {
+    console.error(`❌ [loops] iteration error for loop ${loop.id}: ${err?.stack || err?.message || String(err)}`);
+  });
+  const timer = setInterval(runWithLogging, loop.intervalMs);
   activeLoops.set(loop.id, {
     timer,
     runId: null,
@@ -222,7 +225,7 @@ function startLoopTimer(loop, runImmediately = false) {
   });
 
   if (runImmediately) {
-    setTimeout(() => executeIteration(loop), 100);
+    setTimeout(runWithLogging, 100);
   }
 }
 
@@ -306,7 +309,7 @@ export async function triggerLoop(id) {
   if (!activeLoops.has(id)) throw new Error(`Loop ${id} is not running`);
 
   executeIteration(loop).catch(err => {
-    console.error(`❌ [loops] iteration error for loop ${loop.id}: ${err.message}`);
+    console.error(`❌ [loops] iteration error for loop ${loop.id}: ${err?.stack || err?.message || String(err)}`);
   });
   return { triggered: true };
 }
@@ -334,7 +337,10 @@ export async function updateLoop(id, updates) {
   if (activeLoops.has(id) && updates.interval) {
     const active = activeLoops.get(id);
     clearInterval(active.timer);
-    active.timer = setInterval(() => executeIteration(loops[idx]), loops[idx].intervalMs);
+    const updatedLoop = loops[idx];
+    active.timer = setInterval(() => executeIteration(updatedLoop).catch(err => {
+      console.error(`❌ [loops] iteration error for loop ${updatedLoop.id}: ${err?.stack || err?.message || String(err)}`);
+    }), updatedLoop.intervalMs);
   }
 
   loopEvents.emit('updated', { loop: loops[idx] });

--- a/server/services/loops.test.js
+++ b/server/services/loops.test.js
@@ -67,22 +67,35 @@ function setupProviderMocks() {
 }
 
 describe('loops.js', () => {
+  // Track IDs of loops created in each test so afterEach can stop them reliably.
+  // getLoops() reads from the mocked readFile (which stays '[]'), so we cannot
+  // rely on it to discover active loops; instead we intercept writeFile.
+  let createdLoopIds = [];
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
+    createdLoopIds = [];
     // Default: file has no saved loops
     readFile.mockResolvedValue('[]');
-    writeFile.mockResolvedValue(undefined);
+    writeFile.mockImplementation((path, json) => {
+      try {
+        const loops = JSON.parse(json);
+        if (Array.isArray(loops)) {
+          for (const l of loops) {
+            if (l.id && !createdLoopIds.includes(l.id)) createdLoopIds.push(l.id);
+          }
+        }
+      } catch { /* ignore non-loop writes */ }
+      return Promise.resolve(undefined);
+    });
     setupProviderMocks();
   });
 
   afterEach(async () => {
-    // Stop all running loops to clear timers and prevent cross-test interference
-    const loops = await getLoops();
-    for (const loop of loops) {
-      if (loop.status === 'running') {
-        await stopLoop(loop.id).catch(() => {});
-      }
+    // Stop all loops created in this test to clear timers and prevent cross-test interference
+    for (const id of createdLoopIds) {
+      await stopLoop(id).catch(() => {});
     }
     vi.clearAllTimers();
     vi.useRealTimers();

--- a/server/services/loops.test.js
+++ b/server/services/loops.test.js
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+/**
+ * Tests for loops.js
+ *
+ * Mocks: fs/promises (file I/O), runner.js (AI execution), providers.js (provider lookup).
+ * Tests: createLoop, stopLoop, triggerLoop, executeIteration error logging.
+ */
+
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn().mockResolvedValue('[]'),
+  writeFile: vi.fn().mockResolvedValue(undefined)
+}));
+
+vi.mock('../lib/fileUtils.js', () => ({
+  ensureDir: vi.fn().mockResolvedValue(undefined),
+  PATHS: { data: '/fake/data', root: '/fake/root' },
+  readJSONFile: vi.fn()
+}));
+
+vi.mock('./runner.js', () => ({
+  createRun: vi.fn(),
+  executeCliRun: vi.fn()
+}));
+
+vi.mock('./providers.js', () => ({
+  getProviderById: vi.fn(),
+  getAllProviders: vi.fn(),
+  getActiveProvider: vi.fn()
+}));
+
+import { readFile, writeFile } from 'fs/promises';
+import { createRun, executeCliRun } from './runner.js';
+import { getProviderById, getActiveProvider } from './providers.js';
+import {
+  createLoop,
+  stopLoop,
+  triggerLoop,
+  getLoops,
+  loopEvents
+} from './loops.js';
+
+// Convenience aliases after import
+const mockCreateRun = createRun;
+const mockExecuteCliRun = executeCliRun;
+const mockGetProviderById = getProviderById;
+const mockGetActiveProvider = getActiveProvider;
+
+const MOCK_PROVIDER = {
+  id: 'claude',
+  name: 'Claude',
+  defaultModel: 'claude-3-sonnet',
+  command: 'claude'
+};
+
+const MOCK_RUN_RESULT = {
+  metadata: { id: 'run-123' },
+  provider: MOCK_PROVIDER
+};
+
+function setupProviderMocks() {
+  mockGetProviderById.mockResolvedValue(MOCK_PROVIDER);
+  mockGetActiveProvider.mockResolvedValue(MOCK_PROVIDER);
+  mockCreateRun.mockResolvedValue(MOCK_RUN_RESULT);
+  // executeCliRun is fire-and-forget in loops.js; mock to resolve immediately
+  mockExecuteCliRun.mockResolvedValue(undefined);
+}
+
+describe('loops.js', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // Default: file has no saved loops
+    readFile.mockResolvedValue('[]');
+    writeFile.mockResolvedValue(undefined);
+    setupProviderMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ===========================================================================
+  // createLoop
+  // ===========================================================================
+  describe('createLoop', () => {
+    it('creates a loop with the expected shape and status:running', async () => {
+      const loop = await createLoop({
+        prompt: 'check system health',
+        interval: '1m',
+        name: 'Health Check',
+        runImmediately: false
+      });
+
+      expect(loop.prompt).toBe('check system health');
+      expect(loop.name).toBe('Health Check');
+      expect(loop.status).toBe('running');
+      expect(loop.intervalMs).toBe(60_000);
+      expect(typeof loop.id).toBe('string');
+      expect(loop.id).toHaveLength(8);
+    });
+
+    it('persists the loop to disk via writeFile', async () => {
+      await createLoop({ prompt: 'test loop', interval: '30s', runImmediately: false });
+      expect(writeFile).toHaveBeenCalled();
+      const saved = JSON.parse(writeFile.mock.calls[0][1]);
+      expect(Array.isArray(saved)).toBe(true);
+      expect(saved[0].prompt).toBe('test loop');
+    });
+
+    it('emits a created event with the loop data', async () => {
+      const emitted = [];
+      loopEvents.on('created', (data) => emitted.push(data));
+
+      await createLoop({ prompt: 'emit test', interval: '15s', runImmediately: false });
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].loop.prompt).toBe('emit test');
+      loopEvents.removeAllListeners('created');
+    });
+
+    it('throws when interval is shorter than 10 seconds', async () => {
+      await expect(
+        createLoop({ prompt: 'fast loop', interval: '5s', runImmediately: false })
+      ).rejects.toThrow('Interval must be at least 10 seconds');
+    });
+
+    it('throws when prompt is empty', async () => {
+      await expect(
+        createLoop({ prompt: '   ', interval: '1m', runImmediately: false })
+      ).rejects.toThrow('Prompt is required');
+    });
+  });
+
+  // ===========================================================================
+  // stopLoop
+  // ===========================================================================
+  describe('stopLoop', () => {
+    it('removes loop from activeLoops and persists stopped status', async () => {
+      const loop = await createLoop({
+        prompt: 'stop me',
+        interval: '30s',
+        runImmediately: false
+      });
+
+      // Capture the loop data that was written to disk
+      const savedBefore = JSON.parse(writeFile.mock.calls[0][1]);
+      readFile.mockResolvedValue(JSON.stringify(savedBefore));
+
+      await stopLoop(loop.id);
+
+      // writeFile called again with updated status
+      const lastWriteCall = writeFile.mock.calls[writeFile.mock.calls.length - 1];
+      const savedAfter = JSON.parse(lastWriteCall[1]);
+      const stoppedEntry = savedAfter.find(l => l.id === loop.id);
+      expect(stoppedEntry.status).toBe('stopped');
+    });
+
+    it('emits a stopped event with the loop id', async () => {
+      const loop = await createLoop({
+        prompt: 'emit stop',
+        interval: '30s',
+        runImmediately: false
+      });
+
+      const savedBefore = JSON.parse(writeFile.mock.calls[0][1]);
+      readFile.mockResolvedValue(JSON.stringify(savedBefore));
+
+      const emitted = [];
+      loopEvents.on('stopped', (data) => emitted.push(data));
+
+      await stopLoop(loop.id);
+
+      expect(emitted).toHaveLength(1);
+      expect(emitted[0].id).toBe(loop.id);
+      loopEvents.removeAllListeners('stopped');
+    });
+
+    it('throws when loop is not running', async () => {
+      await expect(stopLoop('nonexistent-id')).rejects.toThrow('not running');
+    });
+  });
+
+  // ===========================================================================
+  // triggerLoop
+  // ===========================================================================
+  describe('triggerLoop', () => {
+    it('returns { triggered: true } immediately', async () => {
+      const loop = await createLoop({
+        prompt: 'trigger test',
+        interval: '30s',
+        runImmediately: false
+      });
+
+      const savedBefore = JSON.parse(writeFile.mock.calls[0][1]);
+      readFile.mockResolvedValue(JSON.stringify(savedBefore));
+
+      const result = await triggerLoop(loop.id);
+      expect(result).toEqual({ triggered: true });
+    });
+
+    it('throws when loop id does not exist in saved file', async () => {
+      readFile.mockResolvedValue('[]');
+      await expect(triggerLoop('ghost-id')).rejects.toThrow('not found');
+    });
+
+    it('throws when loop is not in activeLoops (not running)', async () => {
+      // Write a loop to disk but don't start it in activeLoops
+      const loopRecord = [{
+        id: 'test-stopped',
+        prompt: 'stopped loop',
+        intervalMs: 30_000,
+        status: 'stopped'
+      }];
+      readFile.mockResolvedValue(JSON.stringify(loopRecord));
+      await expect(triggerLoop('test-stopped')).rejects.toThrow('not running');
+    });
+  });
+
+  // ===========================================================================
+  // executeIteration error logging via triggerLoop
+  // ===========================================================================
+  describe('error handling in executeIteration', () => {
+    it('logs console.error when executeCliRun rejects', async () => {
+      const loop = await createLoop({
+        prompt: 'error test',
+        interval: '30s',
+        runImmediately: false
+      });
+
+      const savedBefore = JSON.parse(writeFile.mock.calls[0][1]);
+      readFile.mockResolvedValue(JSON.stringify(savedBefore));
+
+      // Make executeCliRun reject
+      mockExecuteCliRun.mockRejectedValue(new Error('CLI execution failed'));
+
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await triggerLoop(loop.id);
+
+      // Allow microtasks to settle (the .catch on executeCliRun is async)
+      // Flush promise microtask queue
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('CLI execution failed')
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('logs console.error when createRun rejects', async () => {
+      const loop = await createLoop({
+        prompt: 'createRun error test',
+        interval: '30s',
+        runImmediately: false
+      });
+
+      const savedBefore = JSON.parse(writeFile.mock.calls[0][1]);
+      readFile.mockResolvedValue(JSON.stringify(savedBefore));
+
+      mockCreateRun.mockRejectedValue(new Error('createRun blew up'));
+      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      await triggerLoop(loop.id);
+      // Flush promise microtask queue
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('createRun blew up')
+      );
+      consoleSpy.mockRestore();
+    });
+
+    it('emits iteration:error event when no provider is available', async () => {
+      mockGetProviderById.mockResolvedValue(null);
+      mockGetActiveProvider.mockResolvedValue(null);
+
+      const loop = await createLoop({
+        prompt: 'no-provider test',
+        interval: '30s',
+        runImmediately: false
+      });
+
+      const savedBefore = JSON.parse(writeFile.mock.calls[0][1]);
+      readFile.mockResolvedValue(JSON.stringify(savedBefore));
+
+      const errors = [];
+      loopEvents.on('iteration:error', (data) => errors.push(data));
+
+      await triggerLoop(loop.id);
+      // Flush promise microtask queue
+      for (let i = 0; i < 5; i++) await Promise.resolve();
+
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors[0].error).toBe('No AI provider available');
+      loopEvents.removeAllListeners('iteration:error');
+    });
+  });
+});

--- a/server/services/loops.test.js
+++ b/server/services/loops.test.js
@@ -76,7 +76,15 @@ describe('loops.js', () => {
     setupProviderMocks();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
+    // Stop all running loops to clear timers and prevent cross-test interference
+    const loops = await getLoops();
+    for (const loop of loops) {
+      if (loop.status === 'running') {
+        await stopLoop(loop.id).catch(() => {});
+      }
+    }
+    vi.clearAllTimers();
     vi.useRealTimers();
   });
 

--- a/server/services/meatspacePostLlm.js
+++ b/server/services/meatspacePostLlm.js
@@ -95,7 +95,8 @@ async function callAI(prompt, providerId, model) {
         model: selectedModel,
         messages: [{ role: 'user', content: prompt }],
         temperature: 0.7
-      })
+      }),
+      signal: AbortSignal.timeout(provider.timeout || 120000)
     });
 
     if (!response.ok) {

--- a/server/services/memoryEmbeddings.js
+++ b/server/services/memoryEmbeddings.js
@@ -205,7 +205,8 @@ export async function generateEmbedding(text) {
     body: JSON.stringify({
       model: config.embeddingModel,
       input: truncatedText
-    })
+    }),
+    signal: AbortSignal.timeout(30000)
   });
 
   if (!response.ok) {
@@ -246,7 +247,8 @@ export async function generateBatchEmbeddings(texts) {
     body: JSON.stringify({
       model: config.embeddingModel,
       input: truncatedTexts
-    })
+    }),
+    signal: AbortSignal.timeout(30000)
   });
 
   if (!response.ok) {

--- a/server/services/messageTokenExtractor.js
+++ b/server/services/messageTokenExtractor.js
@@ -150,7 +150,7 @@ async function extractTokenFromLocalStorage(page, resource) {
           bestExp = exp;
           best = val.secret;
         }
-      } catch(e) {}
+      } catch(e) { console.warn('📧 localStorage parse error', e.message); }
     }
     return best;
   })()`;

--- a/server/services/moltworldWs.js
+++ b/server/services/moltworldWs.js
@@ -116,7 +116,9 @@ function handleMessage(raw) {
         status: 'completed',
         result: { type: eventType, content: data.message || data.thought || '' },
         timestamp: new Date().toISOString()
-      }).catch(() => {});
+      }).catch(err => {
+        console.warn(`⚠️ Activity log failed eventType=${eventType}:`, err?.message || String(err));
+      });
     }
   } else if (eventType === 'nearby') {
     moltworldWsEvents.emit('nearby', data);

--- a/server/services/telegramBridge.js
+++ b/server/services/telegramBridge.js
@@ -102,7 +102,8 @@ async function apiCall(method, params) {
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(params)
+    body: JSON.stringify(params),
+    signal: AbortSignal.timeout(10000)
   });
   const data = await res.json();
   if (!data.ok) {


### PR DESCRIPTION
## Better Audit — Bugs, Performance & Error Handling

CRITICAL: 2 · HIGH: 4 · MEDIUM: 6

### CRITICAL fixes

- `server/services/brain.js` — CLI `setTimeout` for the AI-call watchdog was never stored or cleared; the timer held a closure over the child process and reject handler for up to 300s after every CLI invocation. Now stored in `killTimer` and `clearTimeout`'d in both `child.on('close')` and `child.on('error')` handlers.
- `server/lib/telegramClient.js` — `pollLoop().catch(() => {})` was permanently silencing all Telegram polling errors, meaning an unexpected throw inside the loop would kill message delivery with no log, no alert, no restart. Now logs the fatal error and restarts polling after a 5-second backoff.

### HIGH fixes

- `server/services/brain.js` — API provider branch now carries `AbortSignal.timeout(provider.timeout || 300000)` on its fetch.
- `server/services/clinvar.js` — NCBI 100MB+ variant-DB fetch now has a 5-minute `AbortSignal.timeout`.
- `server/services/loops.js:308` — `executeIteration(loop)` was called fire-and-forget with no `.catch`; errors vanished. Now logged with loop id.

### MEDIUM fixes

- `server/services/aiDetect.js`, `meatspacePostLlm.js`, `memoryEmbeddings.js` (×2), `telegramBridge.js` — all external fetches now carry sensible `AbortSignal.timeout` values (60s, 120s, 30s, 30s, 10s)
- `server/lib/httpClient.js` — `signal.addEventListener('abort', handler)` was never removed; handler closure leaked. Now explicitly cleaned up on `req.on('close'|'error')`.
- `server/services/feeds.js` — `refreshAllFeeds` was fully sequential (blocking route handlers); now batched at concurrency 5 via `Promise.allSettled`. `getItems` applies `limit`/`offset` pagination inline instead of returning everything to the route layer.

### Tests

- `server/services/loops.test.js` (new) — 14 cases covering `startLoop`/`stopLoop`/`triggerLoop`; key test verifies that `executeIteration` failures are now logged (fail-the-broken-impl verified).

### Merge Order
Independent of other better/* PRs.