### PR TITLE
fix: graceful SIGTERM shutdown + systemHealth asyncHandler + iframe listener cleanup

### DIFF
--- a/client/src/components/messages/MessageDetail.jsx
+++ b/client/src/components/messages/MessageDetail.jsx
@@ -47,7 +47,7 @@ function SafeHtmlBody({ html }) {
     };
     resize();
     // Resize again after images load
-    doc.querySelectorAll('img').forEach(img => img.addEventListener('load', resize));
+    doc.querySelectorAll('img').forEach(img => img.addEventListener('load', resize, { once: true }));
   }, [html]);
 
   useEffect(() => {

--- a/server/index.js
+++ b/server/index.js
@@ -300,7 +300,7 @@ app.use('/api/openclaw', openclawRoutes);
 
 // Initialize agent automation scheduler and action executor
 automationScheduler.init().catch(err => console.error(`❌ Agent scheduler init failed: ${err.message}`));
-agentActionExecutor.init();
+agentActionExecutor.init().catch(err => console.error(`❌ agentActionExecutor init failed: ${err.message}`));
 
 // Recover any inbox entries stuck in 'classifying' from a previous crash/restart
 recoverStuckClassifications().catch(err => console.error(`❌ Brain recovery failed: ${err.message}`));
@@ -444,3 +444,21 @@ ensureSelf()
     console.error(`❌ Instance init failed: ${err.message}`);
     process.exit(1);
   });
+
+let shuttingDown = false;
+const shutdown = async (signal) => {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`🛑 Received ${signal} - shutting down gracefully`);
+  httpServer.close(() => console.log('✅ HTTP server closed'));
+  try {
+    const { close } = await import('./lib/db.js');
+    if (typeof close === 'function') await close();
+    console.log('✅ DB pool closed');
+  } catch (err) {
+    console.error(`⚠️ Error during shutdown: ${err.message}`);
+  }
+  process.exit(0);
+};
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+process.on('SIGINT', () => shutdown('SIGINT'));

--- a/server/index.js
+++ b/server/index.js
@@ -445,19 +445,45 @@ ensureSelf()
     process.exit(1);
   });
 
+const closeServer = (server, label) => new Promise((resolve) => {
+  if (!server) return resolve();
+  server.close((err) => {
+    if (err) console.error(`⚠️ Error closing ${label}: ${err.message}`);
+    else console.log(`✅ ${label} closed`);
+    resolve();
+  });
+});
+
 let shuttingDown = false;
 const shutdown = async (signal) => {
   if (shuttingDown) return;
   shuttingDown = true;
   console.log(`🛑 Received ${signal} - shutting down gracefully`);
-  httpServer.close(() => console.log('✅ HTTP server closed'));
-  try {
-    const { close } = await import('./lib/db.js');
-    if (typeof close === 'function') await close();
+
+  const forceExitTimer = setTimeout(() => {
+    console.error('⚠️ Graceful shutdown timed out, forcing exit');
+    process.exit(1);
+  }, 10000);
+
+  await new Promise((resolve) => {
+    io.close((err) => {
+      if (err) console.error(`⚠️ Error closing Socket.IO: ${err.message}`);
+      else console.log('✅ Socket.IO server closed');
+      resolve();
+    });
+  });
+  await closeServer(httpServer, 'HTTP server');
+  await closeServer(localHttpServer, 'Local HTTP server');
+
+  const { close } = await import('./lib/db.js');
+  if (typeof close === 'function') {
+    await close();
     console.log('✅ DB pool closed');
-  } catch (err) {
-    console.error(`⚠️ Error during shutdown: ${err.message}`);
+  } else {
+    console.warn('ℹ️ DB pool close not available; skipping DB shutdown');
   }
+
+  clearTimeout(forceExitTimer);
   process.exit(0);
 };
 process.on('SIGTERM', () => shutdown('SIGTERM'));

--- a/server/routes/systemHealth.js
+++ b/server/routes/systemHealth.js
@@ -7,10 +7,11 @@ import * as cos from '../services/cos.js';
 import { getSelf } from '../services/instances.js';
 import { checkHealth } from '../lib/db.js';
 import { getCurrentVersion } from '../services/updateChecker.js';
+import { asyncHandler } from '../lib/errorHandler.js';
 
 const router = Router();
 
-router.get('/health', async (req, res) => {
+router.get('/health', asyncHandler(async (req, res) => {
   const [self, version] = await Promise.all([
     getSelf().catch(() => null),
     getCurrentVersion()
@@ -23,13 +24,13 @@ router.get('/health', async (req, res) => {
     hostname: os.hostname(),
     instanceId: self?.instanceId ?? null
   });
-});
+}));
 
 /**
  * GET /api/system/health/details - Comprehensive system health summary
  * Returns system metrics, app status, and CoS status for dashboard display
  */
-router.get('/health/details', async (req, res) => {
+router.get('/health/details', asyncHandler(async (req, res) => {
   const startTime = Date.now();
 
   // Gather data in parallel
@@ -207,6 +208,6 @@ router.get('/health/details', async (req, res) => {
     cos: cosInfo,
     database: dbHealth
   });
-});
+}));
 
 export default router;

--- a/server/services/lmStudioManager.js
+++ b/server/services/lmStudioManager.js
@@ -7,6 +7,8 @@
 
 import { cosEvents } from './cosEvents.js'
 
+const AVAILABILITY_CACHE_TTL_MS = 30_000
+
 // Default LM Studio configuration
 const DEFAULT_CONFIG = {
   baseUrl: (process.env.LM_STUDIO_URL || 'http://localhost:1234').replace(/\/+$/, '').replace(/\/v1$/, ''),
@@ -63,7 +65,7 @@ async function checkLMStudioAvailable() {
   const now = Date.now()
 
   // Use cached result if recent (within 30 seconds)
-  if (lastCheckAt && now - lastCheckAt < 30000 && isAvailable !== null) {
+  if (lastCheckAt && now - lastCheckAt < AVAILABILITY_CACHE_TTL_MS && isAvailable !== null) {
     return isAvailable
   }
 

--- a/server/services/messageTokenExtractor.js
+++ b/server/services/messageTokenExtractor.js
@@ -150,7 +150,7 @@ async function extractTokenFromLocalStorage(page, resource) {
           bestExp = exp;
           best = val.secret;
         }
-      } catch(e) {}
+      } catch(e) { console.warn('📧 localStorage parse error', e.message); }
     }
     return best;
   })()`;


### PR DESCRIPTION
## Better Audit — Stack-Specific

MEDIUM: 3

### Changes

- `server/index.js` — **graceful shutdown handler** for SIGTERM + SIGINT. Closes the HTTP server, calls `lib/db.close()` (pool.end), logs each step with emoji. Includes `shuttingDown` guard against double-fire (Ctrl+C sends SIGINT; PM2 then sends SIGTERM — both would have fired shutdown twice). Also adds `.catch(...)` guard on `agentActionExecutor.init()` to prevent an unhandled rejection at startup if init fails.

- `server/routes/systemHealth.js` — wrap the two async handlers (`GET /health`, `GET /health/details`) with `asyncHandler` to match every other route file. An unguarded throw from `os.cpus()` or `process.uptime()` in a degraded environment would previously have bypassed the project's error-emitting middleware.

- `client/src/components/messages/MessageDetail.jsx` — iframe `'load'` listeners on `<img>` elements now use `{ once: true }` so they auto-remove after firing. Previously, every re-render of the component added another layer of listeners to the same images without removing the old ones.

### Merge Order
Independent of other better/* PRs.