### PR TITLE
refactor(death-clock): extract reusable multi-color countdown component

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Next Release
 
+## Changed
+
+- **Death Clock now multi-color in every surface (DRY)** — extracted the colored 7-unit countdown from `CompactCountdown` in MeatSpace's Overview tab into a shared `DeathClockCountdown` component used by the Dashboard widget, the Ambient/fullscreen view, and MeatSpace itself. The values are now colored consistently (years/months/weeks/days/hours/minutes/seconds → blue/purple/teal/green/yellow/orange/red) with a `size` prop ('sm' for the dashboard widget, 'md' for the MeatSpace hero, 'lg' for Ambient) so each surface picks its own type scale without duplicating the unit/color list. Adds weeks to the Dashboard widget and Ambient view (was 6 units, now 7) to match the MeatSpace layout. Files: `client/src/components/DeathClockCountdown.jsx` (new), `client/src/components/DeathClockWidget.jsx` (use shared), `client/src/pages/Ambient.jsx` (use shared), `client/src/components/meatspace/tabs/OverviewTab.jsx` (use shared).
+
 ## Fixed
 
 - **Codex 5.5 review round 1: navigation + lint + bundle** — addressed the four "Next 1-2 Days" items from `CODEX5.5_REVIEW.md`.

--- a/client/src/components/DeathClockCountdown.jsx
+++ b/client/src/components/DeathClockCountdown.jsx
@@ -1,0 +1,43 @@
+import { useDeathClock } from '../hooks/useDeathClock';
+
+const UNITS = [
+  { key: 'years',   label: 'y',  color: 'text-port-accent' },
+  { key: 'months',  label: 'mo', color: 'text-purple-400' },
+  { key: 'weeks',   label: 'w',  color: 'text-teal-400' },
+  { key: 'days',    label: 'd',  color: 'text-port-success' },
+  { key: 'hours',   label: 'h',  color: 'text-port-warning' },
+  { key: 'minutes', label: 'm',  color: 'text-orange-400' },
+  { key: 'seconds', label: 's',  color: 'text-port-error' },
+];
+
+const SIZE_PRESETS = {
+  sm: { value: 'text-base sm:text-lg',     label: 'text-[10px]',     sep: 'mx-0' },
+  md: { value: 'text-2xl',                 label: 'text-xs',         sep: 'mx-0.5' },
+  lg: { value: 'text-3xl sm:text-4xl',     label: 'text-xs sm:text-sm', sep: 'mx-0.5 sm:mx-1' },
+};
+
+export default function DeathClockCountdown({ deathDate, size = 'md', align = 'start', className = '' }) {
+  const countdown = useDeathClock(deathDate);
+
+  if (!countdown) return null;
+  if (countdown.expired) {
+    return <p className={`text-port-error font-bold ${className}`}>Time expired. You&apos;re on borrowed time.</p>;
+  }
+
+  const preset = SIZE_PRESETS[size] ?? SIZE_PRESETS.md;
+  const justify = align === 'center' ? 'justify-center' : align === 'end' ? 'justify-end' : 'justify-start';
+
+  return (
+    <div className={`flex items-baseline gap-1 flex-wrap ${justify} ${className}`}>
+      {UNITS.map((u, i) => (
+        <span key={u.key} className="whitespace-nowrap">
+          <span className={`${preset.value} font-mono font-bold tabular-nums ${u.color}`}>
+            {String(countdown[u.key] ?? 0).padStart(2, '0')}
+          </span>
+          <span className={`${preset.label} text-gray-500 ml-0.5`}>{u.label}</span>
+          {i < UNITS.length - 1 && <span className={`text-gray-600 ${preset.sep}`}>:</span>}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/client/src/components/DeathClockWidget.jsx
+++ b/client/src/components/DeathClockWidget.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { Skull } from 'lucide-react';
 import * as api from '../services/api';
-import { useDeathClock } from '../hooks/useDeathClock';
+import DeathClockCountdown from './DeathClockCountdown';
 
 export default function DeathClockWidget() {
   const [deathData, setDeathData] = useState(null);
@@ -18,8 +18,6 @@ export default function DeathClockWidget() {
     fetchData();
   }, [fetchData]);
 
-  const countdown = useDeathClock(deathData?.deathDate);
-
   if (!loaded || deathData?.error || !deathData?.deathDate) return null;
 
   return (
@@ -31,29 +29,11 @@ export default function DeathClockWidget() {
         <Skull size={16} className="text-gray-500" />
         <h3 className="text-sm font-semibold text-white">Death Clock</h3>
       </div>
-      {countdown && (
-        <div className="flex gap-2 text-center">
-          <TimeUnit value={countdown.years} label="yr" />
-          <TimeUnit value={countdown.months} label="mo" />
-          <TimeUnit value={countdown.days} label="d" />
-          <TimeUnit value={countdown.hours} label="h" />
-          <TimeUnit value={countdown.minutes} label="m" />
-          <TimeUnit value={countdown.seconds} label="s" />
-        </div>
-      )}
+      <DeathClockCountdown deathDate={deathData.deathDate} size="sm" />
       <div className="mt-2 flex justify-between text-xs">
         <span className="text-gray-600">LE: {deathData.lifeExpectancy?.total}y</span>
         <span className="text-gray-600">{deathData.percentComplete}% complete</span>
       </div>
     </Link>
-  );
-}
-
-function TimeUnit({ value, label }) {
-  return (
-    <div className="flex-1">
-      <div className="text-lg font-mono font-bold text-gray-300">{value}</div>
-      <div className="text-xs text-gray-600">{label}</div>
-    </div>
   );
 }

--- a/client/src/components/meatspace/tabs/OverviewTab.jsx
+++ b/client/src/components/meatspace/tabs/OverviewTab.jsx
@@ -2,8 +2,8 @@ import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Beer, Scale, HeartPulse, Dna, Eye, Dumbbell, Database, Rocket, Calendar } from 'lucide-react';
 import * as api from '../../../services/api';
-import { useDeathClock } from '../../../hooks/useDeathClock';
 import BrailleSpinner from '../../BrailleSpinner';
+import DeathClockCountdown from '../../DeathClockCountdown';
 
 function HealthTile({ icon: Icon, iconColor, label, metrics, onClick }) {
   return (
@@ -30,48 +30,20 @@ function HealthTile({ icon: Icon, iconColor, label, metrics, onClick }) {
 }
 
 function CompactCountdown({ deathDate, lifeExpectancy, percentComplete, lev }) {
-  const countdown = useDeathClock(deathDate);
-
-  if (!countdown) {
+  if (!deathDate) {
     return <p className="text-gray-500 text-sm">Death clock unavailable. Set birth date in Digital Twin &gt; Goals.</p>;
   }
-
-  if (countdown.expired) {
-    return <p className="text-port-error font-bold">Time expired. You&apos;re on borrowed time.</p>;
-  }
-
-  const units = [
-    { value: countdown.years, label: 'y', color: 'text-port-accent' },
-    { value: countdown.months, label: 'mo', color: 'text-purple-400' },
-    { value: countdown.weeks, label: 'w', color: 'text-teal-400' },
-    { value: countdown.days, label: 'd', color: 'text-port-success' },
-    { value: countdown.hours, label: 'h', color: 'text-port-warning' },
-    { value: countdown.minutes, label: 'm', color: 'text-orange-400' },
-    { value: countdown.seconds, label: 's', color: 'text-port-error' },
-  ];
 
   return (
     <div>
       <div className="flex items-baseline gap-2 mb-2">
         <h3 className="text-xs font-medium text-gray-400 uppercase tracking-wider">Time Remaining</h3>
-        {deathDate && (
-          <span className="text-xs text-gray-500">
-            ({new Date(deathDate).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })})
-            {lev?.onTrack && <span className="text-port-success font-medium"> +LEV</span>}
-          </span>
-        )}
+        <span className="text-xs text-gray-500">
+          ({new Date(deathDate).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' })})
+          {lev?.onTrack && <span className="text-port-success font-medium"> +LEV</span>}
+        </span>
       </div>
-      <div className="flex items-baseline gap-1 flex-wrap mb-3">
-        {units.map((u, i) => (
-          <span key={i} className="whitespace-nowrap">
-            <span className={`text-2xl font-mono font-bold tabular-nums ${u.color}`}>
-              {String(u.value).padStart(2, '0')}
-            </span>
-            <span className="text-xs text-gray-500">{u.label}</span>
-            {i < units.length - 1 && <span className="text-gray-600 mx-0.5">:</span>}
-          </span>
-        ))}
-      </div>
+      <DeathClockCountdown deathDate={deathDate} size="md" className="mb-3" />
 
       {lifeExpectancy && (
         <p className="text-xs text-gray-400 mb-3">

--- a/client/src/pages/Ambient.jsx
+++ b/client/src/pages/Ambient.jsx
@@ -1,22 +1,13 @@
-import { useState, useEffect, useMemo, useRef, Fragment } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ArrowLeft, Maximize, Minimize } from 'lucide-react';
 import * as api from '../services/api';
-import { useDeathClock } from '../hooks/useDeathClock';
 import { useAutoRefetch } from '../hooks/useAutoRefetch';
 import { formatClockTime, formatDateFull, formatTimeOfDay } from '../utils/formatters';
+import DeathClockCountdown from '../components/DeathClockCountdown';
 
 const REFRESH_INTERVAL = 30000;
 const IDLE_DELAY = 3000;
-
-const COUNTDOWN_UNITS = [
-  { key: 'years', label: 'yr' },
-  { key: 'months', label: 'mo' },
-  { key: 'days', label: 'd' },
-  { key: 'hours', label: 'h' },
-  { key: 'minutes', label: 'm' },
-  { key: 'seconds', label: 's' },
-];
 
 const goalColor = (rate) =>
   rate >= 80 ? '#22c55e' : rate >= 50 ? '#f59e0b' : '#ef4444';
@@ -91,8 +82,6 @@ export default function Ambient() {
     return () => document.removeEventListener('fullscreenchange', handleChange);
   }, []);
 
-  const countdown = useDeathClock(data?.deathClock?.deathDate);
-
   const cosSummary = data?.cosSummary;
   const today = useMemo(() => cosSummary?.today || {}, [cosSummary]);
   const streak = useMemo(() => cosSummary?.streak || {}, [cosSummary]);
@@ -141,19 +130,18 @@ export default function Ambient() {
           </div>
         </div>
 
-        {countdown && !countdown.expired && deathData && (
+        {deathData?.deathDate && (
           <div className="text-center">
-            <div className="flex items-center justify-center gap-3 sm:gap-4 text-gray-500">
-              {COUNTDOWN_UNITS.map((unit, i) => (
-                <Fragment key={unit.key}>
-                  {i > 0 && <span className="text-gray-700 text-xl font-light self-start mt-1">:</span>}
-                  <CountdownUnit value={countdown[unit.key]} label={unit.label} />
-                </Fragment>
-              ))}
-            </div>
-            <div className="text-xs text-gray-700 mt-1">
-              {deathData.percentComplete}% of life elapsed
-            </div>
+            <DeathClockCountdown
+              deathDate={deathData.deathDate}
+              size="lg"
+              align="center"
+            />
+            {deathData.percentComplete != null && (
+              <div className="text-xs text-gray-700 mt-1">
+                {deathData.percentComplete}% of life elapsed
+              </div>
+            )}
           </div>
         )}
 
@@ -238,17 +226,6 @@ export default function Ambient() {
           {data?.health ? 'System Online' : 'Connecting...'}
         </span>
       </div>
-    </div>
-  );
-}
-
-function CountdownUnit({ value, label }) {
-  return (
-    <div className="text-center">
-      <div className="text-2xl sm:text-3xl font-mono tabular-nums text-gray-400">
-        {String(value).padStart(2, '0')}
-      </div>
-      <div className="text-[10px] text-gray-700 uppercase tracking-wider">{label}</div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The colored 7-unit Death Clock layout from MeatSpace's Overview tab is now a shared `DeathClockCountdown` component used by the Dashboard widget, the Ambient/fullscreen view, and MeatSpace itself.

- New `client/src/components/DeathClockCountdown.jsx` — single source of truth for the years/months/weeks/days/hours/minutes/seconds layout with per-unit colors.
- Sizes (`sm` / `md` / `lg`) control type scale per surface so no caller duplicates the unit/color map.
- `DeathClockWidget` (Dashboard), `Ambient.jsx`, and MeatSpace `OverviewTab` now render via the shared component — net -24 lines after factoring in the new file.

## Test plan

- [ ] Dashboard widget shows the multi-color countdown at the small/medium scale
- [ ] Ambient/fullscreen view shows the multi-color countdown at the large scale
- [ ] MeatSpace Overview tab still renders the same hero countdown as before
- [ ] Expired state ("Time expired. You're on borrowed time.") still displays in all three surfaces