### PR TITLE
chore: post-release nit cleanup

### DIFF
--- a/client/src/pages/MediaHistory.jsx
+++ b/client/src/pages/MediaHistory.jsx
@@ -182,7 +182,7 @@ export default function MediaHistory() {
               <MediaCard
                 key={it.key}
                 item={it}
-                onPreview={setPreview}
+                onPreview={(media) => setPreview(media)}
                 onClick={inStitch ? () => toggleSelect(it.id) : undefined}
                 onRemix={!stitchMode ? handleRemix : undefined}
                 onSendToVideo={!stitchMode ? handleSendToVideo : undefined}

--- a/server/services/chatgptImport.test.js
+++ b/server/services/chatgptImport.test.js
@@ -3,22 +3,11 @@ import { mkdtemp, rm, readdir, readFile } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-// Redirect PATHS.brain to a temp dir BEFORE importing the service so that
-// IMPORT_ROOT (computed at module load) lands inside the temp tree.
+// Each test gets its own temp dir; the actual mocks are installed via
+// vi.doMock + vi.resetModules in beforeEach so PATHS.brain points at a
+// fresh per-test TMP before chatgptImport.js is (re-)loaded.
 let TMP;
 let createMemoryEntryMock;
-
-vi.mock('../lib/fileUtils.js', async () => {
-  const actual = await vi.importActual('../lib/fileUtils.js');
-  return {
-    ...actual,
-    PATHS: { ...actual.PATHS, brain: TMP }
-  };
-});
-
-vi.mock('./brainStorage.js', () => ({
-  createMemoryEntry: vi.fn(async (data) => ({ id: `mem-${Math.random().toString(36).slice(2, 8)}`, ...data }))
-}));
 
 let parseExport;
 let importConversations;


### PR DESCRIPTION
## Summary

Two cosmetic findings from the v1.45.0 release review that weren't worth holding the release for:

- **`MediaHistory.jsx`** passed `setPreview` directly as `MediaCard`'s `onPreview` prop. Wrap it in `(media) => setPreview(media)` so the call site reads consistently with the other arrow-wrapped handlers in the same component.
- **`chatgptImport.test.js`** had a top-level `vi.mock('../lib/fileUtils.js')` factory that closed over `let TMP` *before* `TMP` was assigned, making the factory effectively dead code. The real per-test mock is set up via `vi.doMock` + `vi.resetModules` in `beforeEach` (which is correct since `TMP` changes per test). Drop the dead top-level mock and clarify the comment.

## Test plan

- [x] `npm test --prefix server` → 2611 passing
- [x] `npm run build --prefix client` → clean
- [x] `npm test --prefix server -- chatgptImport` → all 12 chatgptImport tests still pass after dropping the dead mock