### PR TITLE
refactor(browser): consolidate CDP helpers in browserService.js

### DIFF
--- a/server/services/browserService.js
+++ b/server/services/browserService.js
@@ -18,6 +18,11 @@ const PM2_SETTLE_MS = 1500;
 const HEALTH_TIMEOUT_MS = 3000;
 const NAVIGATE_TIMEOUT_MS = 10000;
 const LOGS_TIMEOUT_MS = 5000;
+const CDP_DEFAULT_TIMEOUT_MS = 10000;
+const CDP_EVALUATE_TIMEOUT_MS = 60000;
+
+// Auth/login redirect detection across providers (Microsoft, Okta, generic)
+const AUTH_PATTERNS = ['login.microsoftonline.com', 'okta.com', 'login.live.com', 'Sign in'];
 
 const CONFIG_FILE = join(PATHS.data, 'browser-config.json');
 const ECOSYSTEM_FILE = join(PATHS.root, 'ecosystem.config.cjs');
@@ -166,13 +171,82 @@ export async function getRecentLogs(lines = 50) {
   return { stdout: stdout || '', stderr: stderr || '' };
 }
 
+// ---------- CDP shared helpers ----------
+
+// Bind-all addresses (0.0.0.0, ::) are not connectable — fall back to IPv4 loopback
+async function getCdpConnectHost() {
+  const config = await loadConfig();
+  const host = (config.cdpHost === '0.0.0.0' || config.cdpHost === '::') ? '127.0.0.1' : config.cdpHost;
+  return { host, port: config.cdpPort };
+}
+
+export async function cdpRequest(path, options = {}) {
+  const { host, port } = await getCdpConnectHost();
+  const url = `http://${host}:${port}${path}`;
+  const { timeout, ...rest } = options;
+  return fetchWithTimeout(url, rest, timeout || CDP_DEFAULT_TIMEOUT_MS);
+}
+
+// Returns raw CDP page objects (includes webSocketDebuggerUrl, unlike getOpenPages)
+export async function listCdpPages() {
+  const response = await cdpRequest('/json/list', { timeout: HEALTH_TIMEOUT_MS }).catch(() => null);
+  if (!response || !response.ok) return [];
+  return response.json();
+}
+
+export async function findOrOpenPage(targetUrl) {
+  const pages = await listCdpPages();
+  const existing = pages.find(p => p.url?.includes(new URL(targetUrl).hostname));
+  if (existing) return existing;
+  const response = await cdpRequest(`/json/new?${encodeURIComponent(targetUrl)}`, { method: 'PUT' });
+  if (!response.ok) return null;
+  return response.json();
+}
+
+export function isAuthPage(page) {
+  const url = page?.url || '';
+  const title = page?.title || '';
+  return AUTH_PATTERNS.some(p => url.includes(p) || title.includes(p));
+}
+
+export async function evaluateOnPage(page, expression, { timeout = CDP_EVALUATE_TIMEOUT_MS } = {}) {
+  const wsUrl = page?.webSocketDebuggerUrl;
+  if (!wsUrl) return null;
+
+  const { default: WebSocket } = await import('ws');
+
+  return new Promise((resolve) => {
+    const ws = new WebSocket(wsUrl);
+    const timer = setTimeout(() => { ws.close(); resolve(null); }, timeout);
+
+    ws.on('open', () => {
+      ws.send(JSON.stringify({
+        id: 1,
+        method: 'Runtime.evaluate',
+        params: { expression, returnByValue: true, awaitPromise: true }
+      }));
+    });
+
+    ws.on('message', (data) => {
+      const msg = safeJSONParse(data.toString(), null, { context: 'cdp-ws' });
+      if (!msg || msg.id !== 1) return;
+      clearTimeout(timer);
+      ws.close();
+      if (msg.error || msg.result?.exceptionDetails) return resolve(null);
+      resolve(msg.result?.result?.value ?? null);
+    });
+
+    ws.on('error', () => { clearTimeout(timer); ws.close(); resolve(null); });
+  });
+}
+
 // ---------- CDP navigation ----------
 
 export async function navigateToUrl(url) {
-  const config = await loadConfig();
-  const newTabUrl = `http://${config.cdpHost}:${config.cdpPort}/json/new?${encodeURIComponent(url)}`;
-
-  const response = await fetchWithTimeout(newTabUrl, { method: 'PUT' }, NAVIGATE_TIMEOUT_MS);
+  const response = await cdpRequest(`/json/new?${encodeURIComponent(url)}`, {
+    method: 'PUT',
+    timeout: NAVIGATE_TIMEOUT_MS
+  });
 
   if (!response.ok) {
     const text = await response.text().catch(() => '');
@@ -184,19 +258,10 @@ export async function navigateToUrl(url) {
   return { id: page.id, title: page.title || '(loading)', url: page.url, type: page.type };
 }
 
-// ---------- CDP page listing (connects to the debug endpoint) ----------
+// ---------- CDP page listing (UI-shaped subset) ----------
 
 export async function getOpenPages() {
-  const config = await loadConfig();
-  const listUrl = `http://${config.cdpHost}:${config.cdpPort}/json/list`;
-
-  const response = await fetchWithTimeout(listUrl, {}, HEALTH_TIMEOUT_MS).catch(() => null);
-
-  if (!response || !response.ok) {
-    return [];
-  }
-
-  const pages = await response.json();
+  const pages = await listCdpPages();
   return pages.map(p => ({
     id: p.id,
     title: p.title || '(untitled)',
@@ -208,11 +273,7 @@ export async function getOpenPages() {
 // ---------- CDP version info ----------
 
 export async function getCdpVersion() {
-  const config = await loadConfig();
-  const versionUrl = `http://${config.cdpHost}:${config.cdpPort}/json/version`;
-
-  const response = await fetchWithTimeout(versionUrl, {}, HEALTH_TIMEOUT_MS).catch(() => null);
-
+  const response = await cdpRequest('/json/version', { timeout: HEALTH_TIMEOUT_MS }).catch(() => null);
   if (!response || !response.ok) return null;
   return response.json();
 }

--- a/server/services/messagePlaywrightSync.js
+++ b/server/services/messagePlaywrightSync.js
@@ -3,18 +3,16 @@ import { join } from 'path';
 import crypto from 'crypto';
 import { v4 as uuidv4 } from '../lib/uuid.js';
 import { ensureDir, PATHS, safeJSONParse } from '../lib/fileUtils.js';
-import { fetchWithTimeout } from '../lib/fetchWithTimeout.js';
-import { loadConfig } from './browserService.js';
+import { findOrOpenPage, listCdpPages, isAuthPage, evaluateOnPage } from './browserService.js';
 
-const DEFAULT_CDP_TIMEOUT_MS = 10000;
+// Compat re-exports — older consumers and test mocks import these from here
+export { findOrOpenPage, isAuthPage, evaluateOnPage };
+export const getPages = listCdpPages;
 
 const SELECTORS_FILE = join(PATHS.messages, 'selectors.json');
 
 const OUTLOOK_URL = 'https://outlook.office.com/mail/';
 const TEAMS_URL = 'https://teams.microsoft.com/';
-
-// Auth detection patterns in page titles/URLs
-const AUTH_PATTERNS = ['login.microsoftonline.com', 'okta.com', 'login.live.com', 'Sign in'];
 
 function makeExternalId(date, sender, subject) {
   const hash = crypto.createHash('md5')
@@ -22,75 +20,6 @@ function makeExternalId(date, sender, subject) {
     .digest('hex')
     .slice(0, 12);
   return `pw-${hash}`;
-}
-
-// TODO: Extract shared CDP helpers (getCdpConnectHost, cdpFetch, getPages, findOrOpenPage)
-// into browserService.js to avoid duplication with existing CDP logic there
-async function getCdpConnectHost() {
-  const config = await loadConfig();
-  const host = (config.cdpHost === '0.0.0.0' || config.cdpHost === '::') ? '127.0.0.1' : config.cdpHost;
-  return { host, port: config.cdpPort };
-}
-
-async function cdpFetch(path, options = {}) {
-  const { host, port } = await getCdpConnectHost();
-  const url = `http://${host}:${port}${path}`;
-  const { timeout, ...rest } = options;
-  return fetchWithTimeout(url, rest, timeout || DEFAULT_CDP_TIMEOUT_MS);
-}
-
-export async function getPages() {
-  const response = await cdpFetch('/json/list');
-  if (!response.ok) return [];
-  return response.json();
-}
-
-export async function findOrOpenPage(targetUrl) {
-  const pages = await getPages();
-  // Find existing tab matching the target
-  const existing = pages.find(p => p.url?.includes(new URL(targetUrl).hostname));
-  if (existing) return existing;
-  // Open new tab
-  const response = await cdpFetch(`/json/new?${encodeURIComponent(targetUrl)}`, { method: 'PUT' });
-  if (!response.ok) return null;
-  return response.json();
-}
-
-export function isAuthPage(page) {
-  const url = page.url || '';
-  const title = page.title || '';
-  return AUTH_PATTERNS.some(p => url.includes(p) || title.includes(p));
-}
-
-export async function evaluateOnPage(page, expression) {
-  const wsUrl = page.webSocketDebuggerUrl;
-  if (!wsUrl) return null;
-
-  const { default: WebSocket } = await import('ws');
-
-  return new Promise((resolve) => {
-    const ws = new WebSocket(wsUrl);
-    const timer = setTimeout(() => { ws.close(); resolve(null); }, 60000);
-
-    ws.on('open', () => {
-      ws.send(JSON.stringify({
-        id: 1,
-        method: 'Runtime.evaluate',
-        params: { expression, returnByValue: true, awaitPromise: true }
-      }));
-    });
-
-    ws.on('message', (data) => {
-      const msg = safeJSONParse(data.toString(), null, { context: 'cdp-ws' });
-      if (!msg || msg.id !== 1) return;
-      clearTimeout(timer);
-      ws.close();
-      if (msg.error || msg.result?.exceptionDetails) return resolve(null);
-      resolve(msg.result?.result?.value ?? null);
-    });
-
-    ws.on('error', () => { clearTimeout(timer); ws.close(); resolve(null); });
-  });
 }
 
 export async function getSelectors() {

--- a/server/services/messageTokenExtractor.js
+++ b/server/services/messageTokenExtractor.js
@@ -97,38 +97,14 @@ async function extractTokenFromNetwork(page, networkPatterns, timeoutMs = 20000)
   });
 }
 
+const TRIGGER_TIMEOUT_MS = 5000;
+
 /**
  * Trigger network activity on a tab so the web app makes an API call we can intercept.
+ * The result is ignored — we only care that the script ran.
  */
 async function triggerPageRequest(page, script) {
-  const wsUrl = page.webSocketDebuggerUrl;
-  if (!wsUrl) return;
-
-  const { default: WebSocket } = await import('ws');
-
-  return new Promise((resolve) => {
-    const ws = new WebSocket(wsUrl);
-    const timer = setTimeout(() => { ws.close(); resolve(); }, 5000);
-
-    ws.on('open', () => {
-      ws.send(JSON.stringify({
-        id: 1,
-        method: 'Runtime.evaluate',
-        params: { expression: script, returnByValue: true, awaitPromise: true }
-      }));
-    });
-
-    ws.on('message', (data) => {
-      const msg = safeJSONParse(data.toString(), null, { context: 'cdp-trigger-ws' });
-      if (msg?.id === 1) {
-        clearTimeout(timer);
-        ws.close();
-        resolve();
-      }
-    });
-
-    ws.on('error', () => { clearTimeout(timer); ws.close(); resolve(); });
-  });
+  await evaluateOnPage(page, script, { timeout: TRIGGER_TIMEOUT_MS });
 }
 
 /**


### PR DESCRIPTION
## Summary

Resolves the TODO in `messagePlaywrightSync.js` asking to extract shared CDP helpers to avoid duplication. Centralizes `cdpRequest`, `listCdpPages`, `findOrOpenPage`, `isAuthPage`, and `evaluateOnPage` in `browserService.js` so `messagePlaywrightSync`, `messageActions`, `messageTokenExtractor`, and `googleOAuthAutoConfig` share one implementation.

- Adds optional timeout to `evaluateOnPage` and uses it to replace `triggerPageRequest` in `messageTokenExtractor` (was a near-verbatim copy).
- Existing browserService functions (`navigateToUrl`, `getOpenPages`, `getCdpVersion`) now build on `cdpRequest` instead of inlining fetch+host logic.
- `messagePlaywrightSync` re-exports the helpers as a compat shim so existing consumers and test mocks keep working unchanged.
- Adds named constants for the 10s default and 60s evaluate timeouts.

Net **-34 lines** across the three files.

## Test plan

- [x] All 2749 server tests pass (per agent commit notes)
- [ ] Manual: verify Outlook/Teams token extraction still functions
- [ ] Manual: verify `navigateToUrl` / `getOpenPages` / `getCdpVersion` UI works

---
*Recovery PR: created from agent task `task-moi7jsvt` (original agent: `agent-6dfa266c`). Automated PR creation failed at push time; recovered manually.*