### PR TITLE
docs: replan — archive Better Audit follow-up fixes

### DIFF
--- a/DONE.md
+++ b/DONE.md
@@ -6,6 +6,7 @@ Archive of completed work. For active roadmap, see [PLAN.md](./PLAN.md). For pro
 
 ## 2026-04-28
 
+- **Better Audit follow-up — bugs/perf/test quality** — Added `AbortSignal.timeout` to remaining fetch sites (`aiDetect.js`, `meatspacePostLlm.js`, `memoryEmbeddings.js` ×3, `telegramBridge.js`); fixed `httpClient.js` abort-listener leak via cleanup + `{ once: true }`; fixed `MessageDetail.jsx` iframe `load` listener leak via `{ once: true }`; parallelized `feeds.js` refresh with `Promise.allSettled` over `fetchAndParseFeed`; replaced vacuous `usage.test.js` typeof checks with real streak-calculation assertions; `cosRunnerClient.test.js` now uses `.rejects.toThrow` for capacity/spawn/kill/terminate paths; `subAgentSpawner.test.js` imports the real `selectModelForTask` instead of re-implementing it; added `loops.test.js`.
 - **Ask Yourself — slice (b)** — Voice (`ui_ask`) + per-turn promotions ("Save as Brain note" / "Create CoS task" / "Attach to Goal…") with auto-pin to survive 30-day expiry; palette whitelist for `⌘K` → `Ask Yourself`; ask-intent classifier gates the voice tool to RAG-shaped phrasing only; barge-in cancels upstream `askService` stream via `AbortSignal`. 17 new tests; suite 2785/2785 green.
 
 ## 2026-04-24

--- a/PLAN.md
+++ b/PLAN.md
@@ -25,12 +25,9 @@ For project goals, see [GOALS.md](./GOALS.md). For completed work, see [DONE.md]
 - [ ] **[HIGH][DRY]** `server/services/socket.js:595-814` — extract `broadcastToSet` + `registerSubscriber` to collapse 6× duplicated subscriber/broadcast boilerplate (also fixes missing `shellService.unsubscribeSessionList` on disconnect).
 - [ ] **[HIGH][CODE]** `server/services/cos.js:3055` — remove `NODE_ENV !== 'test'` init guard (test-specific hack in prod).
 - [ ] **[CRITICAL][TESTS]** `server/services/cos.js` and `server/services/agentLifecycle.js` — add test files (covered in Next Up #3).
-- [ ] **[HIGH][TESTS]** Create test files for `server/services/loops.js`, `clinvar.js`, `telegramBridge.js`.
-- [ ] **[HIGH][TESTS-VACUOUS]** `server/services/usage.test.js` (asserts `typeof === 'number'`), `cosRunnerClient.test.js:68-75` (no-throw assertion), `subAgentSpawner.test.js:14-260` (re-implements `selectModelForTask` locally instead of importing).
+- [ ] **[HIGH][TESTS]** Create test files for `server/services/clinvar.js`, `telegramBridge.js`.
 - [ ] **[MEDIUM][CLIENT]** 8 client components redefine `formatBytes`/`formatTime`/`formatDuration`/`timeAgo`/`formatDate` locally; import from `client/src/utils/formatters.js`.
-- [ ] **[MEDIUM][BUGS]** Missing `AbortSignal` timeouts in `aiDetect.js:166`, `meatspacePostLlm.js:91`, `memoryEmbeddings.js:202,243`, `telegramBridge.js:102`.
-- [ ] **[MEDIUM][PERF]** `server/services/feeds.js:223-231` — sequential feed refresh; switch to concurrency-bounded `Promise.allSettled`. `feeds.js:234-248` — full-sort-then-paginate on every request.
-- [ ] **[MEDIUM][BUGS]** `server/lib/httpClient.js:38` — abort listener never removed; closure leak. `client/src/components/messages/MessageDetail.jsx:50` — iframe `'load'` listeners never removed; use `{ once: true }`.
+- [ ] **[MEDIUM][PERF]** `server/services/feeds.js:234-248` — full-sort-then-paginate on every request.
 - [ ] **[MEDIUM][CODE]** Various magic numbers in `cos.js:166,357`, `lmStudioManager.js:66`; brittle `err.message.includes`/`startsWith` checks in `visionTest.js:124` and `routes/voice.js:160`.
 
 ### Deferred Architecture (human-led planning)
@@ -38,10 +35,10 @@ For project goals, see [GOALS.md](./GOALS.md). For completed work, see [DONE.md]
 - `server/services/cos.js` (3057 lines) — split into cosTaskStore / cosTaskGenerator / cosJobScheduler / cosHealthMonitor.
 - `server/services/agentLifecycle.js` (1283 lines) — extract prepareAgentWorkspace / resolveProvider / processCompletion.
 - `server/services/identity.js` (1917 lines) — separate genomic markers + longevity + goals + todos.
-- `server/services/taskSchedule.js` (2201 lines) — extract prompt management to `taskPromptService.js`.
+- `server/services/taskSchedule.js` (2233 lines) — extract prompt management to `taskPromptService.js`.
 - `server/services/socket.js` — split into domain-specific socket modules.
 - `server/routes/apps.js` (1126 lines) — extract `npm install` orchestration to `appBuilder.js`.
-- `client/src/components/goals/GoalDetailPanel.jsx` (1141 lines) — god component.
+- `client/src/components/goals/GoalDetailPanel.jsx` (1252 lines) — god component.
 - `autofixer/ui.js` (972 lines) — inline HTML template needs extraction.
 - API contract — standardize error response shapes (`asyncHandler` + `ServerError` everywhere).
 


### PR DESCRIPTION
## Summary

Automated replan triage. Verified that the following items shipped to `main` between the last replan (eedf2095) and now, and moved them from PLAN.md → DONE.md:

- **`AbortSignal.timeout`** — added to all 4 fetch sites the prior audit flagged (`aiDetect.js`, `meatspacePostLlm.js`, `memoryEmbeddings.js` ×3, `telegramBridge.js`).
- **Listener-leak fixes** — `httpClient.js` cleans up its `abort` listener; `MessageDetail.jsx` uses `{ once: true }` on iframe `load` listeners.
- **`feeds.js` parallel refresh** — `refreshAllFeeds` now uses `Promise.allSettled` over `fetchAndParseFeed`.
- **Test-quality** — `usage.test.js` asserts real streak values; `cosRunnerClient.test.js` uses `.rejects.toThrow` on capacity/spawn/kill paths; `subAgentSpawner.test.js` imports the real `selectModelForTask`; `loops.test.js` exists.

Also refreshed two stale line-count references (`taskSchedule.js` 2201→2233, `GoalDetailPanel.jsx` 1141→1252) and dropped a redundant cross-reference.

PLAN.md goes from 64 → 61 lines.

## Test plan

- [x] PLAN.md still parses as the documented structure (Next Up / Backlog / Better Audit / Deferred Architecture / Future Ideas)
- [x] Every removed item verified done by grep against current `main` (see commit body)
- [x] No active work was archived