### PR TITLE
feat: capture every *_PORT in ecosystem configs and reserve them

### DIFF
--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -144,10 +144,13 @@ export const automationScheduleUpdateSchema = automationScheduleSchema.partial()
 // EXISTING SCHEMAS
 // =============================================================================
 
-// Process definition schema (for PM2 processes with ports)
+// `ports` is an open-ended label→port map so app-specific keys derived from
+// *_PORT env vars (coinbaseIpc, geminiIpc, etc.) survive validation alongside
+// the well-known labels (api, ui, devUi, cdp, health).
 export const processSchema = z.object({
   name: z.string().min(1),
   port: z.number().int().min(1).max(65535).nullable().optional(),
+  ports: z.record(z.number().int().min(1).max(65535)).optional(),
   description: z.string().optional()
 });
 

--- a/server/services/apps.js
+++ b/server/services/apps.js
@@ -427,20 +427,38 @@ export async function toggleAllAppTaskTypes(id, enabled) {
 }
 
 /**
- * Get reserved ports from all registered apps
+ * Reserved ports across every app — top-level uiPort/devUiPort/apiPort/tlsPort
+ * plus every value in each process's `ports` map. Walking processes[] is what
+ * lets the scaffolder avoid colliding with non-public ports (engine IPC, CDP)
+ * that have no top-level field of their own.
  */
 export async function getReservedPorts() {
   const apps = await getAllApps();
   const ports = new Set();
 
+  const addPort = (p) => {
+    const n = typeof p === 'number' ? p : parseInt(p, 10);
+    if (Number.isInteger(n) && n > 0) ports.add(n);
+  };
+
   for (const app of apps) {
-    if (app.uiPort) ports.add(app.uiPort);
-    if (app.apiPort) ports.add(app.apiPort);
+    addPort(app.uiPort);
+    addPort(app.devUiPort);
+    addPort(app.apiPort);
+    addPort(app.tlsPort);
+    if (Array.isArray(app.processes)) {
+      for (const proc of app.processes) {
+        if (proc?.port) addPort(proc.port);
+        if (proc?.ports && typeof proc.ports === 'object') {
+          for (const value of Object.values(proc.ports)) addPort(value);
+        }
+      }
+    }
   }
 
   // Also reserve PortOS ports
-  ports.add(PORTS.API);
-  ports.add(PORTS.UI);
+  addPort(PORTS.API);
+  addPort(PORTS.UI);
 
   return Array.from(ports).sort((a, b) => a - b);
 }

--- a/server/services/apps.js
+++ b/server/services/apps.js
@@ -437,8 +437,11 @@ export async function getReservedPorts() {
   const ports = new Set();
 
   const addPort = (p) => {
-    const n = typeof p === 'number' ? p : parseInt(p, 10);
-    if (Number.isInteger(n) && n > 0) ports.add(n);
+    let n = null;
+    if (typeof p === 'number' && Number.isInteger(p)) n = p;
+    // Strict /^\d+$/ rather than parseInt — '5565abc' should not coerce to 5565.
+    else if (typeof p === 'string' && /^\d+$/.test(p)) n = Number(p);
+    if (n !== null && n >= 1 && n <= 65535) ports.add(n);
   };
 
   for (const app of apps) {

--- a/server/services/apps.test.js
+++ b/server/services/apps.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/fileUtils.js', () => ({
+  ensureDir: vi.fn().mockResolvedValue(undefined),
+  readJSONFile: vi.fn(),
+  PATHS: { data: '/mock/data', root: '/mock/root' },
+}));
+
+vi.mock('../../lib/tailscale-https.js', () => ({
+  hasTailscaleCert: () => false,
+}));
+
+vi.mock('../lib/ports.js', () => ({
+  PORTS: { API: 5555, API_LOCAL: 5553, UI: 5554 },
+}));
+
+vi.mock('./taskSchedule.js', () => ({
+  SELF_IMPROVEMENT_TASK_TYPES: [],
+}));
+
+import { readJSONFile } from '../lib/fileUtils.js';
+import { getReservedPorts, invalidateCache, PORTOS_APP_ID } from './apps.js';
+
+describe('getReservedPorts', () => {
+  beforeEach(() => {
+    invalidateCache();
+    vi.clearAllMocks();
+  });
+
+  it('reserves every per-process port (ports map values), not just uiPort/apiPort', async () => {
+    // Mirror critical-mass: top-level apiPort/uiPort + engine processes that
+    // expose IPC ports via the per-process `ports` map.
+    readJSONFile.mockResolvedValue({
+      apps: {
+        [PORTOS_APP_ID]: { name: 'PortOS', uiPort: 5555, apiPort: 5555, devUiPort: 5554 },
+        'critical-mass': {
+          name: 'critical-mass',
+          apiPort: 5563,
+          uiPort: 5563,
+          devUiPort: 5564,
+          processes: [
+            { name: 'critical-mass', ports: { api: 5563, coinbaseIpc: 5565, geminiIpc: 5566, cryptocomIpc: 5567 } },
+            { name: 'critical-mass-coinbase', ports: { exchangeIpc: 5565 } },
+            { name: 'critical-mass-gemini', ports: { geminiIpc: 5566 } },
+            { name: 'critical-mass-cryptocom', ports: { cryptocomIpc: 5567 } },
+            { name: 'critical-mass-ui', ports: { devUi: 5564 } },
+          ],
+        },
+      },
+    });
+
+    const reserved = await getReservedPorts();
+
+    // Includes engine IPC ports surfaced only through processes[].ports
+    expect(reserved).toContain(5565);
+    expect(reserved).toContain(5566);
+    expect(reserved).toContain(5567);
+    // Top-level port fields still reserved
+    expect(reserved).toContain(5563);
+    expect(reserved).toContain(5564);
+    // PortOS baseline ports always reserved
+    expect(reserved).toContain(5555);
+    expect(reserved).toContain(5554);
+    // De-duplicated and sorted ascending
+    expect([...reserved]).toEqual([...new Set(reserved)].sort((a, b) => a - b));
+  });
+
+  it('ignores invalid port values in processes[].ports', async () => {
+    readJSONFile.mockResolvedValue({
+      apps: {
+        [PORTOS_APP_ID]: { name: 'PortOS' },
+        'weird-app': {
+          name: 'weird',
+          processes: [
+            { name: 'a', ports: { api: 5570, broken: null, alsoBroken: 'not-a-port', zero: 0 } },
+          ],
+        },
+      },
+    });
+
+    const reserved = await getReservedPorts();
+    expect(reserved).toContain(5570);
+    expect(reserved).not.toContain(0);
+    expect(reserved.every(p => Number.isInteger(p) && p > 0)).toBe(true);
+  });
+});

--- a/server/services/apps.test.js
+++ b/server/services/apps.test.js
@@ -87,4 +87,31 @@ describe('getReservedPorts', () => {
     expect(reserved).not.toContain(0);
     expect(reserved.every(p => Number.isInteger(p) && p > 0)).toBe(true);
   });
+
+  it('rejects garbage strings (e.g. "5565abc") and out-of-range integers', async () => {
+    // parseInt-style coercion would silently accept `'5565abc'` as 5565.
+    // Strict /^\\d+$/ + range check is what keeps a hand-edited apps.json from
+    // smuggling a bogus reservation.
+    readJSONFile.mockResolvedValue({
+      apps: {
+        [PORTOS_APP_ID]: { name: 'PortOS' },
+        'sketchy': {
+          name: 'sketchy',
+          apiPort: '5565abc',     // partially-numeric string
+          uiPort: 99999,          // above 65535
+          processes: [
+            { name: 'a', ports: { api: 5571, weird: '12.5', neg: -1, big: 70000 } },
+          ],
+        },
+      },
+    });
+
+    const reserved = await getReservedPorts();
+    expect(reserved).toContain(5571);
+    expect(reserved).not.toContain(5565);
+    expect(reserved).not.toContain(99999);
+    expect(reserved).not.toContain(70000);
+    expect(reserved).not.toContain(-1);
+    expect(reserved.every(p => Number.isInteger(p) && p >= 1 && p <= 65535)).toBe(true);
+  });
 });

--- a/server/services/streamingDetect.js
+++ b/server/services/streamingDetect.js
@@ -214,41 +214,47 @@ export function parseEcosystemConfig(content) {
         return null;
       };
 
-      // Extract CDP_PORT first (Chrome DevTools Protocol port for browser processes)
-      // Word boundary ensures we don't match VITE_CDP_PORT
-      // Capture full expression (up to , or }) to handle process.env.X || fallback
-      const cdpPortMatch = appBlock.match(/(?:env|env_development|env_production)\s*:\s*\{[^}]*\bCDP_PORT\s*:\s*([^,}\n]+)/);
-      if (cdpPortMatch) {
-        const resolved = resolvePortValue(cdpPortMatch[1]);
-        if (resolved) ports.cdp = resolved;
-      }
-
-      // Extract PORT from env (handles literals, variables, and process.env.X || fallback)
-      const portMatch = appBlock.match(/(?:env|env_development|env_production)\s*:\s*\{[^}]*\bPORT\s*:\s*([^,}\n]+)/);
-      if (portMatch) {
-        const resolved = resolvePortValue(portMatch[1]);
-        if (resolved) {
-          // Smart labeling based on process name and context
-          const isUiProcess = /[-_](ui|client)$/i.test(processName);
-          const isBrowserProcess = /[-_]browser$/i.test(processName);
-          const hasCdpPort = ports.cdp !== undefined;
-
-          if (isUiProcess) {
-            ports.ui = resolved;
-          } else if (isBrowserProcess && hasCdpPort) {
-            // Browser processes with CDP_PORT use PORT for health checks
-            ports.health = resolved;
-          } else {
-            ports.api = resolved;
-          }
+      // Collect every `<NAME>_PORT` env-var first, label after — so CDP_PORT
+      // can influence the smart label chosen for PORT regardless of source order.
+      // The `_PORT` suffix requirement avoids matching identifiers like REPORT.
+      const envPorts = {};
+      const envBlockRegex = /(?:env|env_development|env_production)\s*:\s*\{([^}]*)\}/g;
+      let envBlockMatch;
+      while ((envBlockMatch = envBlockRegex.exec(appBlock)) !== null) {
+        const envContent = envBlockMatch[1];
+        const portKeyRegex = /\b(PORT|[A-Z][A-Z0-9_]*_PORT)\b\s*:\s*([^,}\n]+)/g;
+        let m;
+        while ((m = portKeyRegex.exec(envContent)) !== null) {
+          const key = m[1];
+          if (envPorts[key] !== undefined) continue;
+          const resolved = resolvePortValue(m[2]);
+          if (resolved) envPorts[key] = resolved;
         }
       }
 
-      // Extract VITE_PORT for Vite processes
-      const vitePortMatch = appBlock.match(/(?:env|env_development|env_production)\s*:\s*\{[^}]*VITE_PORT\s*:\s*([^,}\n]+)/);
-      if (vitePortMatch) {
-        const resolved = resolvePortValue(vitePortMatch[1]);
-        if (resolved) ports.ui = resolved;
+      const isUiProcess = /[-_](ui|client)$/i.test(processName);
+      const isBrowserProcess = /[-_]browser$/i.test(processName);
+
+      if (envPorts.CDP_PORT !== undefined) ports.cdp = envPorts.CDP_PORT;
+      if (envPorts.PORT !== undefined) {
+        if (isUiProcess) {
+          ports.ui = envPorts.PORT;
+        } else if (isBrowserProcess && ports.cdp !== undefined) {
+          // Browser processes pair CDP_PORT (DevTools) with PORT (health endpoint).
+          ports.health = envPorts.PORT;
+        } else {
+          ports.api = envPorts.PORT;
+        }
+      }
+      if (envPorts.VITE_PORT !== undefined) ports.ui = envPorts.VITE_PORT;
+
+      // FOO_BAR_PORT → fooBar, capturing app-specific labels (coinbaseIpc, etc.).
+      for (const [key, value] of Object.entries(envPorts)) {
+        if (key === 'PORT' || key === 'VITE_PORT' || key === 'CDP_PORT') continue;
+        const stem = key.replace(/_?PORT$/, '');
+        if (!stem) continue;
+        const label = stem.toLowerCase().replace(/_(\w)/g, (_, c) => c.toUpperCase());
+        if (ports[label] === undefined) ports[label] = value;
       }
 
       // Also check for --port in args

--- a/server/services/streamingDetect.js
+++ b/server/services/streamingDetect.js
@@ -13,6 +13,18 @@ export const NON_PM2_TYPES = new Set(['ios-native', 'macos-native', 'xcode', 'sw
 export const usesPm2 = (type) => !NON_PM2_TYPES.has(type);
 
 /**
+ * Count the run of consecutive backslashes immediately before `idx`.
+ * An odd count means the character at `idx` is escaped; even (including 0)
+ * means it isn't — `\"` is an escaped quote, but `\\"` is an escaped backslash
+ * followed by a real quote.
+ */
+function isEscaped(content, idx) {
+  let count = 0;
+  for (let i = idx - 1; i >= 0 && content[i] === '\\'; i--) count++;
+  return count % 2 === 1;
+}
+
+/**
  * Find the index of the `}` that matches the `{` at `openBraceIdx`, ignoring
  * braces inside strings (single/double/backtick) and JS comments. Returns -1
  * if no match. Backticks are treated as opaque so `${...}` interpolations
@@ -28,7 +40,6 @@ function findMatchingBrace(content, openBraceIdx) {
   for (let i = openBraceIdx; i < content.length; i++) {
     const char = content[i];
     const nextChar = i < content.length - 1 ? content[i + 1] : '';
-    const prevChar = i > 0 ? content[i - 1] : '';
 
     if (!inString && !inBlockComment && char === '/' && nextChar === '/') { inLineComment = true; continue; }
     if (inLineComment && char === '\n') { inLineComment = false; continue; }
@@ -36,7 +47,7 @@ function findMatchingBrace(content, openBraceIdx) {
     if (inBlockComment && char === '*' && nextChar === '/') { inBlockComment = false; i++; continue; }
     if (inLineComment || inBlockComment) continue;
 
-    if ((char === '"' || char === "'" || char === '`') && prevChar !== '\\') {
+    if ((char === '"' || char === "'" || char === '`') && !isEscaped(content, i)) {
       if (!inString) { inString = true; stringChar = char; }
       else if (char === stringChar) { inString = false; stringChar = null; }
     }
@@ -163,7 +174,6 @@ export function parseEcosystemConfig(content) {
     for (let i = startPos; i < content.length; i++) {
       const char = content[i];
       const nextChar = i < content.length - 1 ? content[i + 1] : '';
-      const prevChar = i > 0 ? content[i - 1] : '';
 
       // Handle line comments (// ...)
       if (!inString && !inBlockComment && char === '/' && nextChar === '/') {
@@ -189,8 +199,10 @@ export function parseEcosystemConfig(content) {
       // Skip if in any comment
       if (inLineComment || inBlockComment) continue;
 
-      // Track string boundaries
-      if ((char === '"' || char === "'") && prevChar !== '\\') {
+      // Backticks count as string delimiters so `${...}` braces don't perturb
+      // the count. Use isEscaped() so an even-length backslash run before a
+      // quote (e.g. `\\"`) correctly reads as not-escaped.
+      if ((char === '"' || char === "'" || char === '`') && !isEscaped(content, i)) {
         if (!inString) {
           inString = true;
           stringChar = char;
@@ -259,23 +271,40 @@ export function parseEcosystemConfig(content) {
       // The `_PORT` suffix requirement avoids matching identifiers like REPORT.
       // Brace-counting (not `[^}]*`) so env values with nested objects/ternaries
       // don't truncate the scan at the first inner `}`.
-      const envPorts = {};
-      const envHeaderRegex = /(?:env|env_development|env_production)\s*:\s*\{/g;
+      // Iterate env blocks in PM2 precedence order (env < env_development <
+      // env_production) and let later writes overwrite — so when a port is
+      // redefined per-environment, the production value is the one we surface.
+      const envBlockPrecedence = { env: 0, env_development: 1, env_production: 2 };
+      const envHeaderRegex = /\b(env|env_development|env_production)\s*:\s*\{/g;
+      const envBlocks = [];
       let envHeaderMatch;
       while ((envHeaderMatch = envHeaderRegex.exec(appBlock)) !== null) {
+        const envName = envHeaderMatch[1];
         const openIdx = envHeaderMatch.index + envHeaderMatch[0].length - 1;
         const closeIdx = findMatchingBrace(appBlock, openIdx);
         if (closeIdx < 0) continue;
-        const envContent = appBlock.substring(openIdx + 1, closeIdx);
-        // `['"]?` lets quoted keys like `'PORT': 3000` or `"COINBASE_IPC_PORT": 5565`
-        // match — common in JSON-style ecosystem configs. `\b` still anchors the key.
-        const portKeyRegex = /['"]?\b(PORT|[A-Z][A-Z0-9_]*_PORT)\b['"]?\s*:\s*([^,}\n]+)/g;
+        envBlocks.push({
+          envName,
+          index: envHeaderMatch.index,
+          envContent: appBlock.substring(openIdx + 1, closeIdx),
+        });
+      }
+      envBlocks.sort((a, b) => {
+        const pd = envBlockPrecedence[a.envName] - envBlockPrecedence[b.envName];
+        return pd !== 0 ? pd : a.index - b.index;
+      });
+
+      const envPorts = {};
+      // `['"]?` lets quoted keys like `'PORT': 3000` or `"COINBASE_IPC_PORT": 5565`
+      // match — common in JSON-style ecosystem configs. `\b` still anchors the key.
+      const portKeyRegex = /['"]?\b(PORT|[A-Z][A-Z0-9_]*_PORT)\b['"]?\s*:\s*([^,}\n]+)/g;
+      for (const { envContent } of envBlocks) {
+        portKeyRegex.lastIndex = 0;
         let m;
         while ((m = portKeyRegex.exec(envContent)) !== null) {
           const key = m[1];
-          if (envPorts[key] !== undefined) continue;
           const resolved = resolvePortValue(m[2]);
-          if (resolved) envPorts[key] = resolved;
+          if (resolved) envPorts[key] = resolved; // last write wins
         }
       }
 

--- a/server/services/streamingDetect.js
+++ b/server/services/streamingDetect.js
@@ -13,6 +13,44 @@ export const NON_PM2_TYPES = new Set(['ios-native', 'macos-native', 'xcode', 'sw
 export const usesPm2 = (type) => !NON_PM2_TYPES.has(type);
 
 /**
+ * Find the index of the `}` that matches the `{` at `openBraceIdx`, ignoring
+ * braces inside strings and comments. Returns -1 if no match.
+ */
+function findMatchingBrace(content, openBraceIdx) {
+  let depth = 0;
+  let inString = false;
+  let stringChar = null;
+  let inLineComment = false;
+  let inBlockComment = false;
+
+  for (let i = openBraceIdx; i < content.length; i++) {
+    const char = content[i];
+    const nextChar = i < content.length - 1 ? content[i + 1] : '';
+    const prevChar = i > 0 ? content[i - 1] : '';
+
+    if (!inString && !inBlockComment && char === '/' && nextChar === '/') { inLineComment = true; continue; }
+    if (inLineComment && char === '\n') { inLineComment = false; continue; }
+    if (!inString && !inLineComment && char === '/' && nextChar === '*') { inBlockComment = true; continue; }
+    if (inBlockComment && char === '*' && nextChar === '/') { inBlockComment = false; i++; continue; }
+    if (inLineComment || inBlockComment) continue;
+
+    if ((char === '"' || char === "'") && prevChar !== '\\') {
+      if (!inString) { inString = true; stringChar = char; }
+      else if (char === stringChar) { inString = false; stringChar = null; }
+    }
+
+    if (!inString) {
+      if (char === '{') depth++;
+      else if (char === '}') {
+        depth--;
+        if (depth === 0) return i;
+      }
+    }
+  }
+  return -1;
+}
+
+/**
  * Parse ecosystem.config.js/cjs to extract all processes with their ports
  * Uses regex parsing since we can't safely execute arbitrary JS
  * @returns {{ processes: Array, pm2Home: string|null }}
@@ -217,11 +255,16 @@ export function parseEcosystemConfig(content) {
       // Collect every `<NAME>_PORT` env-var first, label after — so CDP_PORT
       // can influence the smart label chosen for PORT regardless of source order.
       // The `_PORT` suffix requirement avoids matching identifiers like REPORT.
+      // Brace-counting (not `[^}]*`) so env values with nested objects/ternaries
+      // don't truncate the scan at the first inner `}`.
       const envPorts = {};
-      const envBlockRegex = /(?:env|env_development|env_production)\s*:\s*\{([^}]*)\}/g;
-      let envBlockMatch;
-      while ((envBlockMatch = envBlockRegex.exec(appBlock)) !== null) {
-        const envContent = envBlockMatch[1];
+      const envHeaderRegex = /(?:env|env_development|env_production)\s*:\s*\{/g;
+      let envHeaderMatch;
+      while ((envHeaderMatch = envHeaderRegex.exec(appBlock)) !== null) {
+        const openIdx = envHeaderMatch.index + envHeaderMatch[0].length - 1;
+        const closeIdx = findMatchingBrace(appBlock, openIdx);
+        if (closeIdx < 0) continue;
+        const envContent = appBlock.substring(openIdx + 1, closeIdx);
         const portKeyRegex = /\b(PORT|[A-Z][A-Z0-9_]*_PORT)\b\s*:\s*([^,}\n]+)/g;
         let m;
         while ((m = portKeyRegex.exec(envContent)) !== null) {

--- a/server/services/streamingDetect.js
+++ b/server/services/streamingDetect.js
@@ -14,7 +14,9 @@ export const usesPm2 = (type) => !NON_PM2_TYPES.has(type);
 
 /**
  * Find the index of the `}` that matches the `{` at `openBraceIdx`, ignoring
- * braces inside strings and comments. Returns -1 if no match.
+ * braces inside strings (single/double/backtick) and JS comments. Returns -1
+ * if no match. Backticks are treated as opaque so `${...}` interpolations
+ * don't perturb the depth count of the surrounding object.
  */
 function findMatchingBrace(content, openBraceIdx) {
   let depth = 0;
@@ -34,7 +36,7 @@ function findMatchingBrace(content, openBraceIdx) {
     if (inBlockComment && char === '*' && nextChar === '/') { inBlockComment = false; i++; continue; }
     if (inLineComment || inBlockComment) continue;
 
-    if ((char === '"' || char === "'") && prevChar !== '\\') {
+    if ((char === '"' || char === "'" || char === '`') && prevChar !== '\\') {
       if (!inString) { inString = true; stringChar = char; }
       else if (char === stringChar) { inString = false; stringChar = null; }
     }
@@ -265,7 +267,9 @@ export function parseEcosystemConfig(content) {
         const closeIdx = findMatchingBrace(appBlock, openIdx);
         if (closeIdx < 0) continue;
         const envContent = appBlock.substring(openIdx + 1, closeIdx);
-        const portKeyRegex = /\b(PORT|[A-Z][A-Z0-9_]*_PORT)\b\s*:\s*([^,}\n]+)/g;
+        // `['"]?` lets quoted keys like `'PORT': 3000` or `"COINBASE_IPC_PORT": 5565`
+        // match — common in JSON-style ecosystem configs. `\b` still anchors the key.
+        const portKeyRegex = /['"]?\b(PORT|[A-Z][A-Z0-9_]*_PORT)\b['"]?\s*:\s*([^,}\n]+)/g;
         let m;
         while ((m = portKeyRegex.exec(envContent)) !== null) {
           const key = m[1];

--- a/server/services/streamingDetect.test.js
+++ b/server/services/streamingDetect.test.js
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { parseEcosystemConfig } from './streamingDetect.js';
+
+describe('parseEcosystemConfig', () => {
+  it('captures arbitrary *_PORT env vars and labels them by camelCased stem', () => {
+    // Mirror the critical-mass shape: a server process that fans out IPC ports
+    // to per-exchange engine processes.
+    const content = `
+      const PORTS = {
+        API: 5563,
+        UI: 5564,
+        COINBASE_IPC: 5565,
+        GEMINI_IPC: 5566,
+        CRYPTOCOM_IPC: 5567,
+      };
+
+      module.exports = {
+        apps: [
+          {
+            name: 'critical-mass',
+            script: 'server.js',
+            env: {
+              PORT: PORTS.API,
+              COINBASE_IPC_PORT: PORTS.COINBASE_IPC,
+              GEMINI_IPC_PORT: PORTS.GEMINI_IPC,
+              CRYPTOCOM_IPC_PORT: PORTS.CRYPTOCOM_IPC,
+            },
+          },
+          {
+            name: 'critical-mass-coinbase',
+            script: 'engines/coinbase-engine.js',
+            env: {
+              EXCHANGE_IPC_PORT: PORTS.COINBASE_IPC,
+            },
+          },
+          {
+            name: 'critical-mass-gemini',
+            script: 'engines/gemini-engine.js',
+            env: {
+              GEMINI_IPC_PORT: PORTS.GEMINI_IPC,
+            },
+          },
+        ],
+      };
+    `;
+
+    const { processes } = parseEcosystemConfig(content);
+
+    const main = processes.find(p => p.name === 'critical-mass');
+    expect(main.ports).toEqual({
+      api: 5563,
+      coinbaseIpc: 5565,
+      geminiIpc: 5566,
+      cryptocomIpc: 5567,
+    });
+
+    const coinbase = processes.find(p => p.name === 'critical-mass-coinbase');
+    expect(coinbase.ports).toEqual({ exchangeIpc: 5565 });
+
+    const gemini = processes.find(p => p.name === 'critical-mass-gemini');
+    expect(gemini.ports).toEqual({ geminiIpc: 5566 });
+  });
+
+  it('preserves smart-labeling for PORT/VITE_PORT/CDP_PORT alongside generic *_PORT capture', () => {
+    const content = `
+      module.exports = {
+        apps: [
+          {
+            name: 'my-app-server',
+            env: {
+              PORT: 5570,
+              ADMIN_PORT: 5571,
+            },
+          },
+          {
+            name: 'my-app-ui',
+            env: {
+              VITE_PORT: 5572,
+            },
+          },
+          {
+            name: 'my-app-browser',
+            env: {
+              CDP_PORT: 5573,
+              PORT: 5574,
+            },
+          },
+        ],
+      };
+    `;
+
+    const { processes } = parseEcosystemConfig(content);
+
+    const server = processes.find(p => p.name === 'my-app-server');
+    expect(server.ports.api).toBe(5570);
+    expect(server.ports.admin).toBe(5571);
+
+    const ui = processes.find(p => p.name === 'my-app-ui');
+    // Post-processing relabels Vite ports from `ui` → `devUi` whenever a sibling
+    // api process exists (the prod UI is served by the API server in that shape).
+    expect(ui.ports.devUi).toBe(5572);
+    expect(ui.ports.ui).toBeUndefined();
+
+    const browser = processes.find(p => p.name === 'my-app-browser');
+    expect(browser.ports.cdp).toBe(5573);
+    // Browser process with CDP_PORT routes PORT → health (not api)
+    expect(browser.ports.health).toBe(5574);
+    expect(browser.ports.api).toBeUndefined();
+  });
+
+  it('does not treat identifiers ending in PORT (e.g., REPORT) as ports', () => {
+    const content = `
+      module.exports = {
+        apps: [
+          {
+            name: 'reporter',
+            env: {
+              PORT: 5580,
+              REPORT_LEVEL: 3,
+              MY_REPORT: 'verbose',
+            },
+          },
+        ],
+      };
+    `;
+
+    const { processes } = parseEcosystemConfig(content);
+    const proc = processes.find(p => p.name === 'reporter');
+    expect(proc.ports).toEqual({ api: 5580 });
+  });
+
+  it('still honors explicit ports: { ... } literal map (does not double-extract from env)', () => {
+    const content = `
+      module.exports = {
+        apps: [
+          {
+            name: 'explicit-app',
+            ports: { api: 5590, ui: 5591 },
+            env: {
+              PORT: 9999, // should be ignored — explicit ports map wins
+              IPC_PORT: 8888,
+            },
+          },
+        ],
+      };
+    `;
+
+    const { processes } = parseEcosystemConfig(content);
+    const proc = processes.find(p => p.name === 'explicit-app');
+    expect(proc.ports).toEqual({ api: 5590, ui: 5591 });
+  });
+});

--- a/server/services/streamingDetect.test.js
+++ b/server/services/streamingDetect.test.js
@@ -129,6 +129,31 @@ describe('parseEcosystemConfig', () => {
     expect(proc.ports).toEqual({ api: 5580 });
   });
 
+  it('captures *_PORT keys after a nested brace inside the env block', () => {
+    // Env values can contain object spreads/ternaries that introduce nested `}`.
+    // A naive `\\{[^}]*\\}` env-block regex would truncate at the inner `}` and
+    // miss any *_PORT key that follows. Brace-counting handles this correctly.
+    const content = `
+      module.exports = {
+        apps: [
+          {
+            name: 'nested-env-app',
+            env: {
+              ...(process.env.FEATURE_FLAG ? { ENABLED: 'true' } : { ENABLED: 'false' }),
+              PORT: 5600,
+              IPC_PORT: 5601,
+            },
+          },
+        ],
+      };
+    `;
+
+    const { processes } = parseEcosystemConfig(content);
+    const proc = processes.find(p => p.name === 'nested-env-app');
+    expect(proc.ports.api).toBe(5600);
+    expect(proc.ports.ipc).toBe(5601);
+  });
+
   it('still honors explicit ports: { ... } literal map (does not double-extract from env)', () => {
     const content = `
       module.exports = {

--- a/server/services/streamingDetect.test.js
+++ b/server/services/streamingDetect.test.js
@@ -202,6 +202,59 @@ describe('parseEcosystemConfig', () => {
     expect(proc.ports.ipc).toBe(5601);
   });
 
+  it('correctly handles even-length backslash runs before a closing quote', () => {
+    // Content has a string ending in `\\\\` (4 literal backslashes) then `"`.
+    // A naive `prevChar === '\\'` check would flag the closing `"` as escaped,
+    // leave inString true, and run the brace-counter past the env-block close —
+    // dropping every port that follows. isEscaped() counts the backslash run
+    // (even = not escaped) and exits the string correctly.
+    const content = `
+      module.exports = {
+        apps: [
+          {
+            name: 'escape-app',
+            env: {
+              NOTE: "ends-with-backslashes\\\\\\\\",
+              PORT: 5640,
+            },
+          },
+        ],
+      };
+    `;
+
+    const { processes } = parseEcosystemConfig(content);
+    const proc = processes.find(p => p.name === 'escape-app');
+    expect(proc.ports.api).toBe(5640);
+  });
+
+  it('env_production overrides env when the same *_PORT key appears in both blocks', () => {
+    // PM2 picks the env block based on `--env`. For port reservation/display,
+    // env_production wins so the value PortOS surfaces matches the production
+    // deploy that runs against this config.
+    const content = `
+      module.exports = {
+        apps: [
+          {
+            name: 'multi-env',
+            env: {
+              PORT: 5620,
+              IPC_PORT: 5621,
+            },
+            env_production: {
+              PORT: 5630,
+              IPC_PORT: 5631,
+            },
+          },
+        ],
+      };
+    `;
+
+    const { processes } = parseEcosystemConfig(content);
+    const proc = processes.find(p => p.name === 'multi-env');
+    expect(proc.ports.api).toBe(5630);
+    expect(proc.ports.ipc).toBe(5631);
+  });
+
   it('still honors explicit ports: { ... } literal map (does not double-extract from env)', () => {
     const content = `
       module.exports = {

--- a/server/services/streamingDetect.test.js
+++ b/server/services/streamingDetect.test.js
@@ -129,6 +129,54 @@ describe('parseEcosystemConfig', () => {
     expect(proc.ports).toEqual({ api: 5580 });
   });
 
+  it('captures *_PORT keys when surrounding code uses backtick template literals', () => {
+    // PM2 configs commonly use template literals (script paths, CLI args). The
+    // brace-counter must treat backticks as string delimiters so `${...}` braces
+    // don't perturb depth and miscount the env block close.
+    const content = `
+      module.exports = {
+        apps: [
+          {
+            name: 'tmpl-app',
+            script: \`\${__dirname}/server.js\`,
+            args: \`--port \${5602} --extra \${{x: 1}}\`,
+            env: {
+              PORT: 5602,
+              IPC_PORT: 5603,
+            },
+          },
+        ],
+      };
+    `;
+
+    const { processes } = parseEcosystemConfig(content);
+    const proc = processes.find(p => p.name === 'tmpl-app');
+    expect(proc.ports.api).toBe(5602);
+    expect(proc.ports.ipc).toBe(5603);
+  });
+
+  it('captures *_PORT keys when written with quoted key syntax', () => {
+    // JSON-style ecosystem configs quote env keys.
+    const content = `
+      module.exports = {
+        apps: [
+          {
+            name: 'json-style',
+            env: {
+              'PORT': 5610,
+              "COINBASE_IPC_PORT": 5611,
+            },
+          },
+        ],
+      };
+    `;
+
+    const { processes } = parseEcosystemConfig(content);
+    const proc = processes.find(p => p.name === 'json-style');
+    expect(proc.ports.api).toBe(5610);
+    expect(proc.ports.coinbaseIpc).toBe(5611);
+  });
+
   it('captures *_PORT keys after a nested brace inside the env block', () => {
     // Env values can contain object spreads/ternaries that introduce nested `}`.
     // A naive `\\{[^}]*\\}` env-block regex would truncate at the inner `}` and


### PR DESCRIPTION
## Summary

- **Parser** (`server/services/streamingDetect.js`): single-pass over each `env`/`env_development`/`env_production` block now captures every `<NAME>_PORT` (or plain `PORT`) env var. Known names keep smart labels (`PORT` → `api`/`ui`/`health`, `VITE_PORT` → `ui`, `CDP_PORT` → `cdp`); anything else gets a label by camelCased stem (`COINBASE_IPC_PORT` → `coinbaseIpc`). The `_PORT` suffix requirement avoids matching identifiers like `REPORT`.
- **Reservation** (`server/services/apps.js`): `getReservedPorts` now walks every app's `processes[].ports` map plus `devUiPort` / `tlsPort`, so the scaffolder picks free ports across the full footprint of every existing app — not just the public `uiPort` / `apiPort` pair.
- **Schema** (`server/lib/validation.js`): `processSchema` gains a `ports: z.record(z.number())` field so the new label map survives external API validation.

## Why

The motivating case was `critical-mass`: it declares 5 PM2 processes (`critical-mass`, `-coinbase`, `-gemini`, `-cryptocom`, `-ui`) and uses `COINBASE_IPC_PORT` / `GEMINI_IPC_PORT` / `CRYPTOCOM_IPC_PORT` / `EXCHANGE_IPC_PORT` env vars to wire IPC sockets between them. The old parser only matched `PORT` / `VITE_PORT` / `CDP_PORT`, so those engine ports were silently dropped — they didn't appear in the per-process display, and the scaffolder could re-assign them to a new app.

## Test plan

- [x] `npx vitest run services/streamingDetect.test.js services/apps.test.js lib/validation.test.js routes/apps.test.js` — 122/122 pass
- [x] `parseEcosystemConfig` returns `{ api: 5563, coinbaseIpc: 5565, geminiIpc: 5566, cryptocomIpc: 5567 }` for the critical-mass main process
- [x] `parseEcosystemConfig` still routes `PORT` to `health` (not `api`) for browser processes that also declare `CDP_PORT`
- [x] `parseEcosystemConfig` does not match `REPORT` / `MY_REPORT` env keys as ports
- [x] `getReservedPorts` includes engine IPC ports surfaced only through `processes[].ports`
- [x] `getReservedPorts` rejects null/string/zero values without throwing
- [x] After deploy, click **Refresh Config** on existing apps with non-standard `*_PORT` env vars to backfill `processes[].ports`