### PR TITLE
fix(windows): use shell:true for spawn to fix EINVAL on .cmd shims

### DIFF
--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -675,7 +675,7 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
         child.on('error', err => { if (!settled) { settled = true; clearTimeout(timer); resolve({ success: false, exitCode: -1, output: err.message }); } });
       });
       if (!installResult.success) {
-        console.log(`❌ npm install (${label}) exit=${installResult.exitCode}: ${installResult.output.slice(0, 300)}`);
+        console.log(`❌ npm install (${label}) exit=${installResult.exitCode}: ${installResult.output.slice(-300)}`);
         await logAction('build', app.id, app.name, { buildCommand, step: `npm install (${label})` }, false);
         throw new ServerError(`npm install failed (${label}) exit=${installResult.exitCode}: ${installResult.output}`, { status: 500, code: 'INSTALL_FAILED' });
       }
@@ -692,7 +692,8 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
       if (!settled) {
         settled = true;
         killProc(child);
-        resolve({ success: false, stderr: `Build timed out after ${BUILD_TIMEOUT_MS / 1000}s`, code: -1 });
+        const tail = (stderr.trim() || stdout.trim()).slice(-512);
+        resolve({ success: false, stderr: `Build timed out after ${BUILD_TIMEOUT_MS / 1000}s`, code: -1, output: tail || 'no output captured' });
       }
     }, BUILD_TIMEOUT_MS);
     child.stdout.on('data', d => {

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -657,7 +657,7 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
       const label = sub || 'root';
       console.log(`📦 Installing ${label} dependencies for ${app.name}`);
       const installResult = await new Promise((resolve) => {
-        const child = spawn('npm', ['install'], { cwd: subDir, windowsHide: true, shell: IS_WIN32 });
+        const child = spawn('npm', ['install'], { cwd: subDir, windowsHide: true, shell: needsShell('npm') });
         let stdout = '';
         let stderr = '';
         let settled = false;
@@ -667,7 +667,7 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
         }, INSTALL_TIMEOUT_MS);
         child.stdout.on('data', d => { stdout += d; if (stdout.length > MAX) stdout = stdout.slice(-MAX); });
         child.stderr.on('data', d => { stderr += d; if (stderr.length > MAX) stderr = stderr.slice(-MAX); });
-        child.on('close', exitCode => { if (!settled) { settled = true; clearTimeout(timer); resolve({ success: exitCode === 0, exitCode, output: (stderr.trim() || stdout.trim()).slice(0, 1024) }); } });
+        child.on('close', exitCode => { if (!settled) { settled = true; clearTimeout(timer); resolve({ success: exitCode === 0, exitCode, output: (stderr.trim() || stdout.trim()).slice(-1024) }); } });
         child.on('error', err => { if (!settled) { settled = true; clearTimeout(timer); resolve({ success: false, exitCode: -1, output: err.message }); } });
       });
       if (!installResult.success) {
@@ -679,7 +679,7 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
   }
 
   const result = await new Promise((resolve) => {
-    const child = spawn(cmd, args, { cwd: app.repoPath, windowsHide: true, shell: IS_WIN32 });
+    const child = spawn(cmd, args, { cwd: app.repoPath, windowsHide: true, shell: needsShell(cmd) });
     let stdout = '';
     let stderr = '';
     let settled = false;
@@ -773,6 +773,11 @@ const ALLOWED_BUILD_CMDS = new Set([
 ]);
 
 const IS_WIN32 = process.platform === 'win32';
+// npm/npx are .cmd shims on Windows — enable shell only for these so cmd.exe
+// can resolve them, without enabling shell metacharacter interpretation for
+// native binaries (xcodebuild, swift, make, cargo).
+const WIN_CMD_SHIMS = new Set(['npm', 'npx']);
+const needsShell = (cmd) => IS_WIN32 && WIN_CMD_SHIMS.has(cmd);
 const INSTALL_TIMEOUT_MS = 3 * 60 * 1000;
 const BUILD_TIMEOUT_MS = 5 * 60 * 1000;
 

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -692,8 +692,9 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
       if (!settled) {
         settled = true;
         killProc(child);
+        const timeoutMsg = `Build timed out after ${BUILD_TIMEOUT_MS / 1000}s`;
         const tail = (stderr.trim() || stdout.trim()).slice(-512);
-        resolve({ success: false, stderr: `Build timed out after ${BUILD_TIMEOUT_MS / 1000}s`, code: -1, output: tail || 'no output captured' });
+        resolve({ success: false, stderr: timeoutMsg, code: -1, output: tail ? `${timeoutMsg} — last output: ${tail}` : timeoutMsg });
       }
     }, BUILD_TIMEOUT_MS);
     child.stdout.on('data', d => {
@@ -708,7 +709,7 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
       if (!settled) {
         settled = true;
         clearTimeout(timer);
-        const output = (stderr.trim() || stdout.trim()).slice(0, 1024);
+        const output = (stderr.trim() || stdout.trim()).slice(-1024);
         resolve({ success: code === 0, stdout: stdout.trim(), stderr: stderr.trim(), code, signal, output });
       }
     });

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -644,6 +644,10 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
     throw new ServerError(`Build command '${cmd}' is not allowed. Allowed: ${[...ALLOWED_BUILD_CMDS].join(', ')}`, { status: 400, code: 'INVALID_BUILD_COMMAND' });
   }
 
+  if (WIN_CMD_SHIMS.has(cmd) && args.some(a => SHELL_UNSAFE_RE.test(a))) {
+    throw new ServerError('Build command args contain shell-unsafe characters', { status: 400, code: 'INVALID_BUILD_COMMAND' });
+  }
+
   console.log(`🔨 Building ${app.name}: ${buildCommand}`);
 
   // Install dependencies before building (root + common subdirs) - skip for non-Node apps
@@ -663,7 +667,7 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
         let settled = false;
         const MAX = 64 * 1024;
         const timer = setTimeout(() => {
-          if (!settled) { settled = true; child.kill('SIGTERM'); resolve({ success: false, exitCode: -1, output: `npm install timed out after ${INSTALL_TIMEOUT_MS / 1000}s` }); }
+          if (!settled) { settled = true; killProc(child); resolve({ success: false, exitCode: -1, output: `npm install timed out after ${INSTALL_TIMEOUT_MS / 1000}s` }); }
         }, INSTALL_TIMEOUT_MS);
         child.stdout.on('data', d => { stdout += d; if (stdout.length > MAX) stdout = stdout.slice(-MAX); });
         child.stderr.on('data', d => { stderr += d; if (stderr.length > MAX) stderr = stderr.slice(-MAX); });
@@ -687,7 +691,7 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
     const timer = setTimeout(() => {
       if (!settled) {
         settled = true;
-        child.kill('SIGTERM');
+        killProc(child);
         resolve({ success: false, stderr: `Build timed out after ${BUILD_TIMEOUT_MS / 1000}s`, code: -1 });
       }
     }, BUILD_TIMEOUT_MS);
@@ -778,6 +782,19 @@ const IS_WIN32 = process.platform === 'win32';
 // native binaries (xcodebuild, swift, make, cargo).
 const WIN_CMD_SHIMS = new Set(['npm', 'npx']);
 const needsShell = (cmd) => IS_WIN32 && WIN_CMD_SHIMS.has(cmd);
+// Characters cmd.exe interprets as metacharacters when shell:true is active.
+// Validate args for any command that uses a shell shim (npm/npx) so malicious
+// buildCommand strings like "npm run build&whoami" are rejected at parse time.
+const SHELL_UNSAFE_RE = /[&|<>;`$\\^%!]/;
+// On Windows, SIGTERM kills cmd.exe but orphans its child (npm). Use taskkill
+// /T /F to terminate the whole process tree.
+const killProc = (child) => {
+  if (IS_WIN32 && child.pid) {
+    spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' }).unref();
+  } else {
+    child.kill('SIGTERM');
+  }
+};
 const INSTALL_TIMEOUT_MS = 3 * 60 * 1000;
 const BUILD_TIMEOUT_MS = 5 * 60 * 1000;
 

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -789,7 +789,7 @@ const SHELL_UNSAFE_RE = /[&|<>^%!()]/;
 // /T /F to terminate the whole process tree.
 const killProc = (child) => {
   if (IS_WIN32 && child.pid) {
-    spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore', windowsHide: true }).unref();
+    spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore', windowsHide: true }).on('error', () => {}).unref();
   } else {
     child.kill('SIGTERM');
   }

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -656,18 +656,17 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
     if (await pathExists(join(subDir, 'package.json'))) {
       const label = sub || 'root';
       console.log(`📦 Installing ${label} dependencies for ${app.name}`);
-      const INSTALL_TIMEOUT_MS = 3 * 60 * 1000; // 3 minutes
       const installResult = await new Promise((resolve) => {
-        const child = spawn(resolveCmd('npm'), ['install'], { cwd: subDir, windowsHide: true });
+        const child = spawn('npm', ['install'], { cwd: subDir, windowsHide: true, shell: IS_WIN32 });
         let stdout = '';
         let stderr = '';
         let settled = false;
-        const MAX = 16 * 1024;
+        const MAX = 64 * 1024;
         const timer = setTimeout(() => {
           if (!settled) { settled = true; child.kill('SIGTERM'); resolve({ success: false, exitCode: -1, output: `npm install timed out after ${INSTALL_TIMEOUT_MS / 1000}s` }); }
         }, INSTALL_TIMEOUT_MS);
-        child.stdout.on('data', d => { if (stdout.length < MAX) stdout += d; });
-        child.stderr.on('data', d => { if (stderr.length < MAX) stderr += d; });
+        child.stdout.on('data', d => { stdout += d; if (stdout.length > MAX) stdout = stdout.slice(-MAX); });
+        child.stderr.on('data', d => { stderr += d; if (stderr.length > MAX) stderr = stderr.slice(-MAX); });
         child.on('close', exitCode => { if (!settled) { settled = true; clearTimeout(timer); resolve({ success: exitCode === 0, exitCode, output: (stderr.trim() || stdout.trim()).slice(0, 1024) }); } });
         child.on('error', err => { if (!settled) { settled = true; clearTimeout(timer); resolve({ success: false, exitCode: -1, output: err.message }); } });
       });
@@ -679,9 +678,8 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
     }
   }
 
-  const BUILD_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
   const result = await new Promise((resolve) => {
-    const child = spawn(resolveCmd(cmd), args, { cwd: app.repoPath, windowsHide: true });
+    const child = spawn(cmd, args, { cwd: app.repoPath, windowsHide: true, shell: IS_WIN32 });
     let stdout = '';
     let stderr = '';
     let settled = false;
@@ -774,9 +772,9 @@ const ALLOWED_BUILD_CMDS = new Set([
   'cargo'       // Rust
 ]);
 
-// On Windows, Node-based CLI tools resolve to .cmd shims
-const WIN_CMD_SHIMS = new Set(['npm', 'npx']);
-const resolveCmd = (cmd) => process.platform === 'win32' && WIN_CMD_SHIMS.has(cmd) ? `${cmd}.cmd` : cmd;
+const IS_WIN32 = process.platform === 'win32';
+const INSTALL_TIMEOUT_MS = 3 * 60 * 1000;
+const BUILD_TIMEOUT_MS = 5 * 60 * 1000;
 
 // Allowlist of safe editor commands
 // Security: Only allow known-safe editor commands to prevent arbitrary code execution

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -644,7 +644,7 @@ router.post('/:id/build', loadApp, asyncHandler(async (req, res) => {
     throw new ServerError(`Build command '${cmd}' is not allowed. Allowed: ${[...ALLOWED_BUILD_CMDS].join(', ')}`, { status: 400, code: 'INVALID_BUILD_COMMAND' });
   }
 
-  if (WIN_CMD_SHIMS.has(cmd) && args.some(a => SHELL_UNSAFE_RE.test(a))) {
+  if (needsShell(cmd) && args.some(a => SHELL_UNSAFE_RE.test(a))) {
     throw new ServerError('Build command args contain shell-unsafe characters', { status: 400, code: 'INVALID_BUILD_COMMAND' });
   }
 
@@ -782,15 +782,14 @@ const IS_WIN32 = process.platform === 'win32';
 // native binaries (xcodebuild, swift, make, cargo).
 const WIN_CMD_SHIMS = new Set(['npm', 'npx']);
 const needsShell = (cmd) => IS_WIN32 && WIN_CMD_SHIMS.has(cmd);
-// Characters cmd.exe interprets as metacharacters when shell:true is active.
-// Validate args for any command that uses a shell shim (npm/npx) so malicious
-// buildCommand strings like "npm run build&whoami" are rejected at parse time.
-const SHELL_UNSAFE_RE = /[&|<>;`$\\^%!]/;
+// Actual cmd.exe metacharacters (& | < > ^ % ! and grouping parens).
+// Validated only when shell is active (needsShell guard at call site).
+const SHELL_UNSAFE_RE = /[&|<>^%!()]/;
 // On Windows, SIGTERM kills cmd.exe but orphans its child (npm). Use taskkill
 // /T /F to terminate the whole process tree.
 const killProc = (child) => {
   if (IS_WIN32 && child.pid) {
-    spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' }).unref();
+    spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore', windowsHide: true }).unref();
   } else {
     child.kill('SIGTERM');
   }

--- a/server/routes/apps.test.js
+++ b/server/routes/apps.test.js
@@ -404,7 +404,7 @@ describe('Apps Routes', () => {
       expect(response.status).toBe(404);
     });
 
-    it('should reject build command args containing shell-unsafe metacharacters', async () => {
+    it.skipIf(process.platform !== 'win32')('should reject build command args containing shell-unsafe metacharacters', async () => {
       const mockApp = {
         id: 'app-001',
         name: 'Test App',

--- a/server/routes/apps.test.js
+++ b/server/routes/apps.test.js
@@ -404,6 +404,22 @@ describe('Apps Routes', () => {
       expect(response.status).toBe(404);
     });
 
+    it('should reject build command args containing shell-unsafe metacharacters', async () => {
+      const mockApp = {
+        id: 'app-001',
+        name: 'Test App',
+        repoPath: process.cwd(), // real path so pathExists check passes
+        buildCommand: 'npm run build&whoami',
+        pm2ProcessNames: ['test-app']
+      };
+      appsService.getAppById.mockResolvedValue(mockApp);
+
+      const response = await request(app).post('/api/apps/app-001/build');
+
+      expect(response.status).toBe(400);
+      expect(response.body.code).toBe('INVALID_BUILD_COMMAND');
+    });
+
     it('should reject build commands not starting with npm or npx', async () => {
       const mockApp = {
         id: 'app-001',

--- a/server/services/appUpdater.js
+++ b/server/services/appUpdater.js
@@ -11,7 +11,7 @@ const CMD_TIMEOUT_MS = 5 * 60 * 1000;
 
 function runCommand(cmd, args, cwd) {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { cwd, shell: IS_WIN32, windowsHide: true });
+    const child = spawn(cmd, args, { cwd, shell: IS_WIN32 && ['npm', 'npx'].includes(cmd), windowsHide: true });
     let stdout = '';
     let stderr = '';
     let settled = false;

--- a/server/services/appUpdater.js
+++ b/server/services/appUpdater.js
@@ -16,7 +16,15 @@ function runCommand(cmd, args, cwd) {
     let stderr = '';
     let settled = false;
     const timer = setTimeout(() => {
-      if (!settled) { settled = true; child.kill('SIGTERM'); reject(new Error(`${cmd} timed out after ${CMD_TIMEOUT_MS / 1000}s`)); }
+      if (!settled) {
+        settled = true;
+        if (IS_WIN32 && child.pid) {
+          spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' }).unref();
+        } else {
+          child.kill('SIGTERM');
+        }
+        reject(new Error(`${cmd} timed out after ${CMD_TIMEOUT_MS / 1000}s`));
+      }
     }, CMD_TIMEOUT_MS);
     child.stdout.on('data', d => { stdout += d; if (stdout.length > MAX_OUTPUT_BYTES) stdout = stdout.slice(-MAX_OUTPUT_BYTES); });
     child.stderr.on('data', d => { stderr += d; if (stderr.length > MAX_OUTPUT_BYTES) stderr = stderr.slice(-MAX_OUTPUT_BYTES); });

--- a/server/services/appUpdater.js
+++ b/server/services/appUpdater.js
@@ -6,12 +6,14 @@ import * as gitService from './git.js';
 import * as pm2Service from './pm2.js';
 
 const IS_WIN32 = process.platform === 'win32';
+const WIN_CMD_SHIMS = new Set(['npm', 'npx']);
+const needsShell = (cmd) => IS_WIN32 && WIN_CMD_SHIMS.has(cmd);
 const MAX_OUTPUT_BYTES = 64 * 1024;
 const CMD_TIMEOUT_MS = 5 * 60 * 1000;
 
 function runCommand(cmd, args, cwd) {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { cwd, shell: IS_WIN32 && ['npm', 'npx'].includes(cmd), windowsHide: true });
+    const child = spawn(cmd, args, { cwd, shell: needsShell(cmd), windowsHide: true });
     let stdout = '';
     let stderr = '';
     let settled = false;

--- a/server/services/appUpdater.js
+++ b/server/services/appUpdater.js
@@ -19,7 +19,7 @@ function runCommand(cmd, args, cwd) {
       if (!settled) {
         settled = true;
         if (IS_WIN32 && child.pid) {
-          spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore', windowsHide: true }).unref();
+          spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore', windowsHide: true }).on('error', () => {}).unref();
         } else {
           child.kill('SIGTERM');
         }

--- a/server/services/appUpdater.js
+++ b/server/services/appUpdater.js
@@ -5,29 +5,27 @@ import { readFile } from 'fs/promises';
 import * as gitService from './git.js';
 import * as pm2Service from './pm2.js';
 
-/**
- * Run a command and return stdout/stderr
- */
-const MAX_OUTPUT_BYTES = 64 * 1024; // 64KB tail per stream
+const IS_WIN32 = process.platform === 'win32';
+const MAX_OUTPUT_BYTES = 64 * 1024;
+const CMD_TIMEOUT_MS = 5 * 60 * 1000;
 
 function runCommand(cmd, args, cwd) {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, { cwd, shell: false, windowsHide: true });
+    const child = spawn(cmd, args, { cwd, shell: IS_WIN32, windowsHide: true });
     let stdout = '';
     let stderr = '';
-    child.stdout.on('data', d => {
-      stdout += d;
-      if (stdout.length > MAX_OUTPUT_BYTES) stdout = stdout.slice(-MAX_OUTPUT_BYTES);
-    });
-    child.stderr.on('data', d => {
-      stderr += d;
-      if (stderr.length > MAX_OUTPUT_BYTES) stderr = stderr.slice(-MAX_OUTPUT_BYTES);
-    });
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (!settled) { settled = true; child.kill('SIGTERM'); reject(new Error(`${cmd} timed out after ${CMD_TIMEOUT_MS / 1000}s`)); }
+    }, CMD_TIMEOUT_MS);
+    child.stdout.on('data', d => { stdout += d; if (stdout.length > MAX_OUTPUT_BYTES) stdout = stdout.slice(-MAX_OUTPUT_BYTES); });
+    child.stderr.on('data', d => { stderr += d; if (stderr.length > MAX_OUTPUT_BYTES) stderr = stderr.slice(-MAX_OUTPUT_BYTES); });
     child.on('close', code => {
+      if (!settled) { settled = true; clearTimeout(timer); }
       if (code !== 0) reject(new Error(stderr.trim() || `${cmd} exited with code ${code}`));
       else resolve({ stdout, stderr });
     });
-    child.on('error', reject);
+    child.on('error', err => { if (!settled) { settled = true; clearTimeout(timer); } reject(err); });
   });
 }
 
@@ -63,14 +61,12 @@ async function _doUpdate(app, emit) {
   const dir = app.repoPath;
   const steps = [];
 
-  // Step 1: Git pull
   emit('git-pull', 'running', 'Pulling latest changes...');
   const pullResult = await gitService.pull(dir);
   const pullMsg = pullResult.output?.trim() || 'Up to date';
   emit('git-pull', 'done', pullMsg);
   steps.push({ step: 'git-pull', success: true, message: pullMsg });
 
-  // Step 2: Install deps for each subdir that has package.json
   for (const sub of ['', 'client', 'server', 'admin']) {
     const subDir = sub ? join(dir, sub) : dir;
     if (existsSync(join(subDir, 'package.json'))) {
@@ -83,7 +79,6 @@ async function _doUpdate(app, emit) {
     }
   }
 
-  // Step 3: Run setup if available
   const pkgPath = join(dir, 'package.json');
   if (existsSync(pkgPath)) {
     const pkg = JSON.parse(await readFile(pkgPath, 'utf-8'));
@@ -95,7 +90,6 @@ async function _doUpdate(app, emit) {
     }
   }
 
-  // Step 4: Restart PM2 processes
   const processNames = app.pm2ProcessNames || [];
   if (processNames.length > 0) {
     emit('restart', 'running', 'Restarting app...');

--- a/server/services/appUpdater.js
+++ b/server/services/appUpdater.js
@@ -19,7 +19,7 @@ function runCommand(cmd, args, cwd) {
       if (!settled) {
         settled = true;
         if (IS_WIN32 && child.pid) {
-          spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' }).unref();
+          spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore', windowsHide: true }).unref();
         } else {
           child.kill('SIGTERM');
         }
@@ -29,11 +29,14 @@ function runCommand(cmd, args, cwd) {
     child.stdout.on('data', d => { stdout += d; if (stdout.length > MAX_OUTPUT_BYTES) stdout = stdout.slice(-MAX_OUTPUT_BYTES); });
     child.stderr.on('data', d => { stderr += d; if (stderr.length > MAX_OUTPUT_BYTES) stderr = stderr.slice(-MAX_OUTPUT_BYTES); });
     child.on('close', code => {
-      if (!settled) { settled = true; clearTimeout(timer); }
-      if (code !== 0) reject(new Error(stderr.trim() || `${cmd} exited with code ${code}`));
-      else resolve({ stdout, stderr });
+      if (!settled) {
+        settled = true;
+        clearTimeout(timer);
+        if (code !== 0) reject(new Error(stderr.trim() || `${cmd} exited with code ${code}`));
+        else resolve({ stdout, stderr });
+      }
     });
-    child.on('error', err => { if (!settled) { settled = true; clearTimeout(timer); } reject(err); });
+    child.on('error', err => { if (!settled) { settled = true; clearTimeout(timer); reject(err); } });
   });
 }
 


### PR DESCRIPTION
## Summary

- **Bug fix**: \`spawn EINVAL\` crash when triggering Build or Update on Windows — Node cannot directly execute \`.cmd\` shim files (npm, npx) without routing through \`cmd.exe\`. Fixed by adding \`shell: true\` scoped to npm/npx shims via \`needsShell()\`.
- **Cleanup**: Removed \`resolveCmd\` (the helper that appended \`.cmd\` to npm/npx). \`WIN_CMD_SHIMS\` is retained and repurposed as the backing set for \`needsShell()\`, which gates \`shell: true\` to npm/npx only — keeping native binaries (xcodebuild, swift, make, cargo) with \`shell: false\`.
- **Safety**: Added \`SHELL_UNSAFE_RE\` validation that rejects cmd.exe metacharacters (\`& | < > ^ % ! ()\`) in npm/npx build args when shell is active on Windows. \`taskkill\` spawns include \`windowsHide: true\` and \`.on('error', () => {})\` guards.
- **Reliability**: Added 5-minute timeout to \`appUpdater.runCommand\` with process-tree kill (\`taskkill /T /F\`) on Windows to prevent indefinite hangs and avoid orphaned child processes.
- **Consistency**: Unified install buffer strategy to 64 KB rolling tail (was 16 KB head-cap). Hoisted \`IS_WIN32\`, \`INSTALL_TIMEOUT_MS\`, \`BUILD_TIMEOUT_MS\` to module scope. Fixed double-settle race in \`runCommand\` close/error handlers.

## Test plan

- [ ] Trigger **Build** from the PortOS app page on Windows — should no longer crash with \`spawn EINVAL\`
- [ ] Trigger **Update** from the PortOS Update page on Windows — npm install steps should complete
- [ ] \`routes/apps.test.js\` passes (46 tests; 4 xcode-scripts failures are pre-existing and unrelated); metacharacter rejection test is \`skipIf\` non-Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)