### PR TITLE
feat: symmetric upload + gallery picker on both FFLF frames

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -14,7 +14,7 @@
 
 ## Changed
 
-- Video Gen FFLF mode: both the first-frame and last-frame slots now offer the same dual control — pick from your image gallery, OR upload a fresh image. Previously the first frame was upload-only and the last frame was gallery-only.
+- Video Gen FFLF mode now offers the same dual control on both the first-frame and last-frame slots — pick from your image gallery or upload a fresh image — instead of the previous upload-only first frame and gallery-only last frame.
 - Release workflow no longer silently skips creating the GitHub Release when something else pushed the version tag before the workflow ran.
 - Release-notes style guide tightened — entries should be one sentence per change in user-facing language, not code-review prose with file paths and internal symbols.
 - Chief of Staff 3D avatars (Cyber, Sigil, Esoteric, Nexus, Muse) now fill the agent panel as a full-bleed background, with the title, status, and controls overlaying the scene instead of sharing a column with it.

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -14,6 +14,7 @@
 
 ## Changed
 
+- Video Gen FFLF mode: both the first-frame and last-frame slots now offer the same dual control — pick from your image gallery, OR upload a fresh image. Previously the first frame was upload-only and the last frame was gallery-only.
 - Release workflow no longer silently skips creating the GitHub Release when something else pushed the version tag before the workflow ran.
 - Release-notes style guide tightened — entries should be one sentence per change in user-facing language, not code-review prose with file paths and internal symbols.
 - Chief of Staff 3D avatars (Cyber, Sigil, Esoteric, Nexus, Muse) now fill the agent panel as a full-bleed background, with the title, status, and controls overlaying the scene instead of sharing a column with it.

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -673,6 +673,7 @@ export default function VideoGen() {
             <select
               value=""
               onChange={(e) => onPickGallery(e.target.value || null)}
+              aria-label={`${label} — pick from gallery`}
               className="w-full bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
             >
               <option value="">Pick from gallery…</option>

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -653,7 +653,13 @@ export default function VideoGen() {
     alt,
     advisoryNote,
   }) => {
+    // Clear button shows as soon as the user picks anything (state-only).
+    // Preview gates on `uploadUrl` instead of the raw `upload` File because
+    // the object URL is generated in a useEffect — without this, the render
+    // between "user picked a file" and "useEffect ran" would mount an
+    // <img src={null}> for one frame.
     const hasSelection = !!(file || upload);
+    const canPreview = !!(file || uploadUrl);
     return (
       <div className="border border-port-border/50 rounded-lg p-2 space-y-1.5">
         <div className="flex items-center justify-between">
@@ -662,7 +668,7 @@ export default function VideoGen() {
             <button type="button" onClick={onClear} className="text-[11px] text-port-error hover:underline">Clear</button>
           )}
         </div>
-        {hasSelection ? (
+        {canPreview ? (
           <ImagePreview
             src={file ? `/data/images/${file}` : uploadUrl}
             alt={alt}

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -124,11 +124,12 @@ export default function VideoGen() {
   const [sourceImageFile, setSourceImageFile] = useState(incomingSourceImage || null);
   const [sourceImageUpload, setSourceImageUpload] = useState(null);
   const [lastImageFile, setLastImageFile] = useState(null);
+  const [lastImageUpload, setLastImageUpload] = useState(null);
   const [extendFromVideoId, setExtendFromVideoId] = useState('');
   const [extendingFrame, setExtendingFrame] = useState(false);
 
-  // Image gallery for the FFLF end-frame picker (gallery only — no upload
-  // for the second image so the multipart parser stays single-file).
+  // Image gallery — used by both the start and end frame pickers so the
+  // user can pull from any prior render in either slot.
   const [imageGallery, setImageGallery] = useState([]);
 
   // Re-sync when ImageGen pipes a new image via ?sourceImageFile=...
@@ -160,9 +161,9 @@ export default function VideoGen() {
   const [showHidden, setShowHidden] = useState(false);
   const navigate = useNavigate();
 
-  // Object URL for the currently-selected upload File so we can render a
-  // real preview before the file ever hits the server. Revoked on change /
-  // unmount so the blob is released.
+  // Object URLs for the currently-selected upload Files so we can render
+  // real previews before the files ever hit the server. Revoked on change /
+  // unmount so the blobs are released.
   const [sourceUploadUrl, setSourceUploadUrl] = useState(null);
   useEffect(() => {
     if (!(sourceImageUpload instanceof File)) { setSourceUploadUrl(null); return; }
@@ -170,6 +171,13 @@ export default function VideoGen() {
     setSourceUploadUrl(url);
     return () => URL.revokeObjectURL(url);
   }, [sourceImageUpload]);
+  const [lastUploadUrl, setLastUploadUrl] = useState(null);
+  useEffect(() => {
+    if (!(lastImageUpload instanceof File)) { setLastUploadUrl(null); return; }
+    const url = URL.createObjectURL(lastImageUpload);
+    setLastUploadUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [lastImageUpload]);
 
   const refreshHistory = useCallback(() => {
     listVideoHistory().then((items) => setHistory(Array.isArray(items) ? items : [])).catch(() => {});
@@ -290,7 +298,10 @@ export default function VideoGen() {
       setSearchParams(next, { replace: true });
     }
   };
-  const clearLastImage = () => setLastImageFile(null);
+  const clearLastImage = () => {
+    setLastImageFile(null);
+    setLastImageUpload(null);
+  };
 
   // Switching mode resets the now-irrelevant fields so a stale choice from
   // a prior mode can't sneak into the next generation. (Prompt/seed/etc.
@@ -299,15 +310,15 @@ export default function VideoGen() {
     setMode(next);
     if (next === 'text') {
       clearSourceImage();
-      setLastImageFile(null);
+      clearLastImage();
       setExtendFromVideoId('');
     } else if (next === 'image') {
-      setLastImageFile(null);
+      clearLastImage();
       setExtendFromVideoId('');
     } else if (next === 'fflf') {
       setExtendFromVideoId('');
     } else if (next === 'extend') {
-      setLastImageFile(null);
+      clearLastImage();
       // Drop any source image carried over from a prior mode — extend will
       // populate sourceImageFile fresh from the picked video's last frame
       // via handleExtendPick. Without this, switching from image/fflf into
@@ -400,6 +411,7 @@ export default function VideoGen() {
         ? (sourceImageFile || '') : '',
       sourceImage: (mode === 'image' || mode === 'fflf') ? (sourceImageUpload || '') : '',
       lastImageFile: mode === 'fflf' ? (lastImageFile || '') : '',
+      lastImage: mode === 'fflf' ? (lastImageUpload || '') : '',
       extendFromVideoId: (mode === 'extend' && currentModel?.runtime === 'ltx2')
         ? (extendFromVideoId || '') : '',
       chunks: chunks > 1 ? chunks : '',
@@ -525,15 +537,18 @@ export default function VideoGen() {
   const handleEnqueue = () => {
     if (!prompt.trim() || (status && status.connected === false) || extendModeBlocked) return;
     const payload = buildGeneratePayload();
-    // Strip the File blob for snapshot — re-using a File across multiple
-    // queued submissions is fine, but we need a stable JSON-ish summary
-    // for the queue UI display. Hold the File in `_blob` separately.
-    const { sourceImage, ...summary } = payload;
+    // Strip File blobs for snapshot — re-using a File across multiple queued
+    // submissions is fine, but we need a stable JSON-ish summary for the
+    // queue UI display. Hold the Files in `_blobs` separately.
+    const { sourceImage, lastImage, ...summary } = payload;
     setQueue((q) => [...q, {
       id: newQueueId(),
       status: 'pending',
       params: summary,
-      _blob: sourceImage instanceof File ? sourceImage : null,
+      _blobs: {
+        sourceImage: sourceImage instanceof File ? sourceImage : null,
+        lastImage: lastImage instanceof File ? lastImage : null,
+      },
       enqueuedAt: Date.now(),
     }]);
     toast.success('Added to queue');
@@ -564,7 +579,8 @@ export default function VideoGen() {
     setRunningQueueId(next.id);
     setQueue((q) => q.map((item) => item.id === next.id ? { ...item, status: 'running', startedAt: Date.now() } : item));
     const payload = { ...next.params };
-    if (next._blob) payload.sourceImage = next._blob;
+    if (next._blobs?.sourceImage) payload.sourceImage = next._blobs.sourceImage;
+    if (next._blobs?.lastImage) payload.lastImage = next._blobs.lastImage;
     let busyRetry = false;
     let busyRetryTimer = null;
     runGeneration(payload).then((res) => {
@@ -619,6 +635,71 @@ export default function VideoGen() {
 
   const notConnected = status && status.connected === false;
   const canEnqueue = prompt.trim() && !notConnected && !extendModeBlocked;
+
+  // Symmetric frame picker for the FFLF + image modes. Each slot accepts
+  // EITHER a gallery filename OR a fresh upload; the preview renders
+  // whichever is currently set, and clearing either one snaps the slot back
+  // to the dual upload+gallery picker. Defined inline because it closes
+  // over imageGallery and the per-slot state — extracting it as a real
+  // component would mean prop-drilling 6+ values for no real reuse.
+  const renderFramePanel = ({
+    label,
+    file,
+    upload,
+    uploadUrl,
+    onPickGallery,
+    onUpload,
+    onClear,
+    alt,
+    advisoryNote,
+  }) => {
+    const hasSelection = !!(file || upload);
+    return (
+      <div className="border border-port-border/50 rounded-lg p-2 space-y-1.5">
+        <div className="flex items-center justify-between">
+          <span className="text-[11px] font-medium text-gray-400">{label}</span>
+          {hasSelection && (
+            <button type="button" onClick={onClear} className="text-[11px] text-port-error hover:underline">Clear</button>
+          )}
+        </div>
+        {hasSelection ? (
+          <ImagePreview
+            src={file ? `/data/images/${file}` : uploadUrl}
+            alt={alt}
+            label={file || upload?.name}
+          />
+        ) : (
+          <div className="space-y-1.5">
+            <select
+              value=""
+              onChange={(e) => onPickGallery(e.target.value || null)}
+              className="w-full bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
+            >
+              <option value="">Pick from gallery…</option>
+              {imageGallery.filter((img) => !img.hidden).slice(0, 50).map((img) => (
+                <option key={img.filename} value={img.filename}>{img.filename}</option>
+              ))}
+            </select>
+            <label className="flex items-center gap-2 text-[11px] text-gray-400 cursor-pointer hover:text-white">
+              <Upload className="w-3.5 h-3.5" />
+              <span className="truncate">Upload an image</span>
+              <input
+                type="file"
+                accept="image/*"
+                onChange={(e) => onUpload(e.target.files?.[0] || null)}
+                className="hidden"
+              />
+            </label>
+          </div>
+        )}
+        {advisoryNote && (
+          <p className="text-[10px] text-gray-500 leading-snug" title={advisoryNote.title}>
+            {advisoryNote.text}
+          </p>
+        )}
+      </div>
+    );
+  };
 
   return (
     <div className="space-y-3">
@@ -722,70 +803,54 @@ export default function VideoGen() {
 
           {(mode === 'image' || mode === 'fflf') && (
             <div className={`grid gap-2 ${mode === 'fflf' ? 'grid-cols-1 sm:grid-cols-2' : 'grid-cols-1'}`}>
-              <div className="border border-port-border/50 rounded-lg p-2 space-y-1.5">
-                <div className="flex items-center justify-between">
-                  <span className="text-[11px] font-medium text-gray-400">
-                    {mode === 'fflf' ? 'First frame' : 'Source image'}
-                  </span>
-                  {(sourceImageFile || sourceImageUpload) && (
-                    <button type="button" onClick={clearSourceImage} className="text-[11px] text-port-error hover:underline">Clear</button>
-                  )}
-                </div>
-                {(sourceImageFile || sourceUploadUrl) ? (
-                  <ImagePreview
-                    src={sourceImageFile ? `/data/images/${sourceImageFile}` : sourceUploadUrl}
-                    alt="Source"
-                    label={sourceImageFile || sourceImageUpload?.name}
-                  />
-                ) : (
-                  <label className="flex items-center gap-2 text-[11px] text-gray-400 cursor-pointer hover:text-white">
-                    <Upload className="w-3.5 h-3.5" />
-                    <span className="truncate">Upload an image</span>
-                    <input
-                      type="file"
-                      accept="image/*"
-                      onChange={(e) => {
-                        const file = e.target.files?.[0] || null;
-                        // Clear any gallery pick + URL param when an upload is
-                        // chosen — otherwise the preview keeps rendering the
-                        // old gallery image (src prefers sourceImageFile) while
-                        // the POST sends `req.file` from the upload, which
-                        // looks like the wrong image was used.
-                        if (file && (sourceImageFile || incomingSourceImage)) clearSourceImage();
-                        setSourceImageUpload(file);
-                      }}
-                      className="hidden"
-                    />
-                  </label>
-                )}
-              </div>
-              {mode === 'fflf' && (
-                <div className="border border-port-border/50 rounded-lg p-2 space-y-1.5">
-                  <div className="flex items-center justify-between">
-                    <span className="text-[11px] font-medium text-gray-400">Last frame</span>
-                    {lastImageFile && (
-                      <button type="button" onClick={clearLastImage} className="text-[11px] text-port-error hover:underline">Clear</button>
-                    )}
-                  </div>
-                  {lastImageFile ? (
-                    <ImagePreview src={`/data/images/${lastImageFile}`} alt="End frame" label={lastImageFile} />
-                  ) : (
-                    <select
-                      value=""
-                      onChange={(e) => setLastImageFile(e.target.value || null)}
-                      className="w-full bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
-                    >
-                      <option value="">Pick from gallery…</option>
-                      {imageGallery.filter((img) => !img.hidden).slice(0, 50).map((img) => (
-                        <option key={img.filename} value={img.filename}>{img.filename}</option>
-                      ))}
-                    </select>
-                  )}
-                  <p className="text-[10px] text-gray-500 leading-snug" title="FFLF backend support is experimental — LTX/mlx_video uses the start frame and treats the last frame as advisory.">
-                    Experimental — last frame is advisory.
-                  </p>
-                </div>
-              )}
+              {renderFramePanel({
+                label: mode === 'fflf' ? 'First frame' : 'Source image',
+                file: sourceImageFile,
+                upload: sourceImageUpload,
+                uploadUrl: sourceUploadUrl,
+                onPickGallery: (filename) => {
+                  // Switching to a gallery pick must drop any pending upload
+                  // and the deep-link URL param; otherwise the next render
+                  // would still POST the stale upload (req.files wins) while
+                  // the preview shows the gallery image.
+                  setSourceImageUpload(null);
+                  if (incomingSourceImage) {
+                    const next = new URLSearchParams(searchParams);
+                    next.delete('sourceImageFile');
+                    setSearchParams(next, { replace: true });
+                  }
+                  setSourceImageFile(filename);
+                },
+                onUpload: (file) => {
+                  // Clear any gallery pick + URL param when an upload is
+                  // chosen — otherwise the preview keeps rendering the old
+                  // gallery image while the POST sends the upload.
+                  if (file && (sourceImageFile || incomingSourceImage)) clearSourceImage();
+                  setSourceImageUpload(file);
+                },
+                onClear: clearSourceImage,
+                alt: 'Source',
+              })}
+              {mode === 'fflf' && renderFramePanel({
+                label: 'Last frame',
+                file: lastImageFile,
+                upload: lastImageUpload,
+                uploadUrl: lastUploadUrl,
+                onPickGallery: (filename) => {
+                  setLastImageUpload(null);
+                  setLastImageFile(filename);
+                },
+                onUpload: (file) => {
+                  if (file && lastImageFile) setLastImageFile(null);
+                  setLastImageUpload(file);
+                },
+                onClear: clearLastImage,
+                alt: 'End frame',
+                advisoryNote: {
+                  text: 'Experimental — last frame is advisory.',
+                  title: 'FFLF backend support is experimental — LTX/mlx_video uses the start frame and treats the last frame as advisory.',
+                },
+              })}
             </div>
           )}
 

--- a/server/lib/multipart.js
+++ b/server/lib/multipart.js
@@ -103,6 +103,12 @@ function streamMultipart(req, boundary, acceptedNames, maxSize, fileFilter, next
   let endSeen = false;        // 'end' event fired but we may still be flushing
   let textCharCount = 0;
   const TEXT_FIELD_TOTAL_CAP = 1024 * 1024; // 1MB cap on aggregate text fields
+  // Cap the bytes we'll silently consume from non-matching file parts. Without
+  // this, a client could keep the connection busy by streaming a huge file
+  // under an unaccepted field name (we just discard the bytes, but the parser
+  // would happily read forever). 50MB matches the typical accepted-file cap.
+  let droppedFileBytes = 0;
+  const DROPPED_FILE_TOTAL_CAP = 50 * 1024 * 1024;
 
   // Per-part state
   let currentName = null;
@@ -249,8 +255,18 @@ function streamMultipart(req, boundary, acceptedNames, maxSize, fileFilter, next
           req.pause();
           writeStream.once('drain', () => req.resume());
         }
+      } else {
+        // Non-matching file: drop bytes, but cap the total so a client
+        // can't tie up the connection by sending an unbounded payload
+        // under an unaccepted field name.
+        droppedFileBytes += chunk.length;
+        if (droppedFileBytes > DROPPED_FILE_TOTAL_CAP) {
+          const err = new Error(`Unaccepted file part too large (max ${DROPPED_FILE_TOTAL_CAP} bytes)`);
+          err.status = 413; err.code = 'PAYLOAD_TOO_LARGE';
+          fail(err);
+          return false;
+        }
       }
-      // Non-matching file: drop bytes silently.
     } else {
       textCharCount += chunk.length;
       if (textCharCount > TEXT_FIELD_TOTAL_CAP) {
@@ -278,6 +294,11 @@ function streamMultipart(req, boundary, acceptedNames, maxSize, fileFilter, next
         writePath = null;
         pendingFlush += 1;
         ws.end(() => {
+          // Defensive: a malformed/malicious request can include the same
+          // field name twice. Drop the prior temp file before overwriting
+          // so it doesn't leak in os.tmpdir().
+          const prior = fileResults[fieldName];
+          if (prior?.path) unlink(prior.path).catch(() => {});
           fileResults[fieldName] = { path, originalname: filename, mimetype, size };
           pendingFlush -= 1;
           cb();

--- a/server/lib/multipart.js
+++ b/server/lib/multipart.js
@@ -103,12 +103,16 @@ function streamMultipart(req, boundary, acceptedNames, maxSize, fileFilter, next
   let endSeen = false;        // 'end' event fired but we may still be flushing
   let textCharCount = 0;
   const TEXT_FIELD_TOTAL_CAP = 1024 * 1024; // 1MB cap on aggregate text fields
-  // Cap the bytes we'll silently consume from non-matching file parts. Without
-  // this, a client could keep the connection busy by streaming a huge file
-  // under an unaccepted field name (we just discard the bytes, but the parser
-  // would happily read forever). 50MB matches the typical accepted-file cap.
+  // Cap the bytes we'll silently consume from non-matching file parts.
+  // Without this, a client could keep the connection busy by streaming a huge
+  // file under an unaccepted field name (we just discard the bytes, but the
+  // parser would happily read forever). Tie the cap to the endpoint's own
+  // per-file `maxSize` so an endpoint configured for 1MB uploads doesn't
+  // accept ~50MB of dropped bytes before 413-ing — the effective DoS surface
+  // matches the declared upload limit. Endpoints with no limit (Infinity)
+  // get a safety default so the dropped-bytes path isn't itself unbounded.
   let droppedFileBytes = 0;
-  const DROPPED_FILE_TOTAL_CAP = 50 * 1024 * 1024;
+  const DROPPED_FILE_TOTAL_CAP = Number.isFinite(maxSize) ? maxSize : 50 * 1024 * 1024;
 
   // Per-part state
   let currentName = null;

--- a/server/lib/multipart.js
+++ b/server/lib/multipart.js
@@ -8,9 +8,12 @@
  *
  * Returns an Express middleware. Populates:
  *   - req.body[name]  — for text parts (Content-Disposition has no filename)
- *   - req.file = { path, originalname, mimetype, size } — for the matching
- *     file part (Content-Disposition has filename and name === fieldName).
- *     Other file parts (different field names) are silently skipped.
+ *   - req.file        — uploadSingle: { path, originalname, mimetype, size }
+ *                       for the matching file part. Other file parts (different
+ *                       field names) are silently skipped.
+ *   - req.files       — uploadFields: { [fieldName]: { path, ... } } for each
+ *                       accepted file field. Field names not in the accepted
+ *                       set are silently skipped.
  */
 
 import { createWriteStream } from 'fs';
@@ -19,26 +22,54 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { randomUUID } from 'crypto';
 
+const parseBoundary = (req) => {
+  const ct = req.headers['content-type'] || '';
+  // Media type is case-insensitive (RFC 2045), but the boundary value is
+  // case-sensitive — match the type prefix on a lowercased copy and parse
+  // the boundary off the original.
+  if (!ct.toLowerCase().startsWith('multipart/form-data')) {
+    const err = new Error('Expected multipart/form-data');
+    err.status = 400; err.code = 'INVALID_CONTENT_TYPE';
+    return { err };
+  }
+  const bm = ct.match(/boundary=([^\s;]+)/i);
+  if (!bm) {
+    const err = new Error('Missing multipart boundary');
+    err.status = 400; err.code = 'INVALID_CONTENT_TYPE';
+    return { err };
+  }
+  return { boundary: bm[1] };
+};
+
 export function uploadSingle(fieldName, { limits = {}, fileFilter } = {}) {
   const maxSize = limits.fileSize ?? Infinity;
+  const accepted = new Set([fieldName]);
 
   return (req, res, next) => {
-    const ct = req.headers['content-type'] || '';
-    // Media type is case-insensitive (RFC 2045), but the boundary value is
-    // case-sensitive — match the type prefix on a lowercased copy and parse
-    // the boundary off the original.
-    if (!ct.toLowerCase().startsWith('multipart/form-data')) {
-      const err = new Error('Expected multipart/form-data');
-      err.status = 400; err.code = 'INVALID_CONTENT_TYPE';
-      return next(err);
-    }
-    const bm = ct.match(/boundary=([^\s;]+)/i);
-    if (!bm) {
-      const err = new Error('Missing multipart boundary');
-      err.status = 400; err.code = 'INVALID_CONTENT_TYPE';
-      return next(err);
-    }
-    streamMultipart(req, bm[1], fieldName, maxSize, fileFilter, next);
+    const { err, boundary } = parseBoundary(req);
+    if (err) return next(err);
+    streamMultipart(req, boundary, accepted, maxSize, fileFilter, (innerErr) => {
+      if (innerErr) return next(innerErr);
+      // Back-compat: surface the matched file as req.file for callers that
+      // predate the multi-file `req.files` shape.
+      if (req.files?.[fieldName]) req.file = req.files[fieldName];
+      next();
+    });
+  };
+}
+
+// Multi-file variant — accepts a list of allowed file field names and
+// populates req.files = { [fieldName]: { path, originalname, mimetype, size } }
+// for each one that arrives. Same semantics as uploadSingle for everything
+// else (text fields → req.body, unknown file fields silently dropped).
+export function uploadFields(fieldNames, { limits = {}, fileFilter } = {}) {
+  const maxSize = limits.fileSize ?? Infinity;
+  const accepted = new Set(fieldNames);
+
+  return (req, res, next) => {
+    const { err, boundary } = parseBoundary(req);
+    if (err) return next(err);
+    streamMultipart(req, boundary, accepted, maxSize, fileFilter, next);
   };
 }
 
@@ -54,7 +85,7 @@ export function optionalUpload(fieldName, opts) {
   };
 }
 
-function streamMultipart(req, boundary, fileFieldName, maxSize, fileFilter, next) {
+function streamMultipart(req, boundary, acceptedNames, maxSize, fileFilter, next) {
   const PART_DELIM = Buffer.from('\r\n--' + boundary);
   const FIRST_DELIM = Buffer.from('--' + boundary);
   const HEADER_END = Buffer.from('\r\n\r\n');
@@ -76,14 +107,17 @@ function streamMultipart(req, boundary, fileFieldName, maxSize, fileFilter, next
   // Per-part state
   let currentName = null;
   let currentFilename = null;
-  let isMatchingFile = false;     // true when current part is the file we want
+  let isMatchingFile = false;     // true when current part is one of acceptedNames
   let writeStream = null;
   let writePath = null;
   let bytesWritten = 0;
   let textBuf = null;             // Buffer when current part is a text field
 
   const body = {};
-  let fileResult = null;
+  // Map of finalized files keyed by field name. Truncated-request cleanup
+  // walks this to unlink everything that was already flushed before the
+  // request died mid-stream.
+  const fileResults = {};
 
   const fail = (err) => {
     if (done) return;
@@ -93,6 +127,11 @@ function streamMultipart(req, boundary, fileFieldName, maxSize, fileFilter, next
       writeStream.destroy();
       // Best-effort cleanup of the partially-written file.
       if (writePath) unlink(writePath).catch(() => {});
+    }
+    // Also drop any already-finalized files — a fail mid-request must not
+    // leak completed uploads to the OS temp dir.
+    for (const f of Object.values(fileResults)) {
+      if (f?.path) unlink(f.path).catch(() => {});
     }
     req.removeAllListeners('data');
     next(err);
@@ -108,9 +147,10 @@ function streamMultipart(req, boundary, fileFieldName, maxSize, fileFilter, next
       // Clean up any partially-written file before failing.
       if (writeStream) writeStream.destroy();
       if (writePath) unlink(writePath).catch(() => {});
-      // Also drop the in-progress fileResult if endPart already finalized
-      // a file from a part that was followed by truncated data.
-      if (fileResult?.path) unlink(fileResult.path).catch(() => {});
+      // Also drop any files already finalized before the truncation.
+      for (const f of Object.values(fileResults)) {
+        if (f?.path) unlink(f.path).catch(() => {});
+      }
       done = true;
       const err = new Error('Truncated multipart request — never reached terminal boundary');
       err.code = 'INVALID_MULTIPART';
@@ -120,7 +160,7 @@ function streamMultipart(req, boundary, fileFieldName, maxSize, fileFilter, next
     }
     done = true;
     req.body = body;
-    if (fileResult) req.file = fileResult;
+    if (Object.keys(fileResults).length) req.files = fileResults;
     next();
   };
 
@@ -142,7 +182,7 @@ function streamMultipart(req, boundary, fileFieldName, maxSize, fileFilter, next
     currentFilename = filenameMatch?.[1];
 
     if (currentFilename != null && currentFilename !== '') {
-      isMatchingFile = currentName === fileFieldName;
+      isMatchingFile = acceptedNames.has(currentName);
       const mimeMatch = headerStr.match(/Content-Type:\s*([^\r\n]+)/i);
       currentFileMimetype = mimeMatch ? mimeMatch[1].trim() : 'application/octet-stream';
       if (isMatchingFile) {
@@ -233,11 +273,12 @@ function streamMultipart(req, boundary, fileFieldName, maxSize, fileFilter, next
         const size = bytesWritten;
         const filename = currentFilename;
         const mimetype = currentFileMimetype || 'application/octet-stream';
+        const fieldName = currentName;
         writeStream = null;
         writePath = null;
         pendingFlush += 1;
         ws.end(() => {
-          fileResult = { path, originalname: filename, mimetype, size };
+          fileResults[fieldName] = { path, originalname: filename, mimetype, size };
           pendingFlush -= 1;
           cb();
           // If 'end' arrived while we were still flushing, finalize now.

--- a/server/lib/multipart.test.js
+++ b/server/lib/multipart.test.js
@@ -58,7 +58,7 @@ const runMiddleware = (req) => new Promise((resolve, reject) => {
   mw(req, {}, (err) => err ? reject(err) : resolve());
 });
 
-describe('uploadSingle multipart parser', () => {
+describe('multipart parser', () => {
   it('parses text fields into req.body when no file is present', async () => {
     const req = makeMultipartReq([
       { name: 'prompt', body: 'a cat' },

--- a/server/lib/multipart.test.js
+++ b/server/lib/multipart.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { Readable } from 'stream';
-import { uploadSingle } from './multipart.js';
+import { uploadSingle, uploadFields } from './multipart.js';
 
 vi.mock('fs', () => ({
   createWriteStream: () => {
@@ -137,6 +137,38 @@ describe('uploadSingle multipart parser', () => {
     expect(req.file?.originalname).toBe('a.png');
     expect(req.body.prompt).toBe('after-file');
     vi.doUnmock('fs');
+  });
+
+  it('uploadFields collects two file parts into req.files keyed by field name', async () => {
+    const req = makeMultipartReq([
+      { name: 'prompt', body: 'morph between two scenes' },
+      { name: 'sourceImage', filename: 'first.png', contentType: 'image/png', body: Buffer.from([0x89, 0x50, 0x4e, 0x47]) },
+      { name: 'lastImage', filename: 'last.png', contentType: 'image/png', body: Buffer.from([0x89, 0x50, 0x4e, 0x47]) },
+    ]);
+    await new Promise((resolve, reject) => {
+      const mw = uploadFields(['sourceImage', 'lastImage'], { limits: { fileSize: 1024 * 1024 } });
+      mw(req, {}, (err) => err ? reject(err) : resolve());
+    });
+    expect(req.body.prompt).toBe('morph between two scenes');
+    expect(req.files).toBeDefined();
+    expect(req.files.sourceImage?.originalname).toBe('first.png');
+    expect(req.files.lastImage?.originalname).toBe('last.png');
+    // The single-file back-compat field should not appear when uploadFields is used.
+    expect(req.file).toBeUndefined();
+  });
+
+  it('uploadFields silently drops a file part whose name is not in the accepted set', async () => {
+    const req = makeMultipartReq([
+      { name: 'sourceImage', filename: 'good.png', contentType: 'image/png', body: Buffer.from([0xaa]) },
+      { name: 'unrelated',    filename: 'bad.png',  contentType: 'image/png', body: Buffer.from([0xbb]) },
+    ]);
+    await new Promise((resolve, reject) => {
+      const mw = uploadFields(['sourceImage', 'lastImage']);
+      mw(req, {}, (err) => err ? reject(err) : resolve());
+    });
+    expect(req.files?.sourceImage?.originalname).toBe('good.png');
+    expect(req.files?.unrelated).toBeUndefined();
+    expect(req.files?.lastImage).toBeUndefined();
   });
 
   it('rejects requests without the multipart Content-Type', async () => {

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -169,12 +169,23 @@ router.post('/', frameImageUpload, asyncHandler(async (req, res) => {
     }
   }
 
+  // Track every durable file we've already copied into PATHS.uploads so a
+  // *later* staging failure can roll them back. Without this, staging
+  // sourceImage successfully then failing on lastImage would leave the
+  // sourceImage durable copy orphaned (the job is never enqueued, so the
+  // worker's cleanup never runs).
+  const stagedDurablePaths = [];
+  const cleanupAllStaged = async () => {
+    for (const p of stagedDurablePaths) await unlink(p).catch(() => {});
+    await cleanupTempUploads();
+  };
+
   // Stage a multipart upload into data/uploads so the queue worker can find
   // it after a server restart — the OS temp dir gets reaped on reboot, and a
   // persisted `queued` job may replay long after the original POST. Worker
   // unlinks the durable file when the job completes or cancels. Throws
-  // ServerError on copy failure (and cleans up every staged temp upload so a
-  // mid-flight failure doesn't leak files under /tmp + data/uploads).
+  // ServerError on copy failure (and cleans up every staged file + multipart
+  // temp upload so a mid-flight failure doesn't leak under /tmp + data/uploads).
   const stageUploadDurable = async (file, kind) => {
     const ext = extname(file.originalname || file.path) || '.bin';
     const durablePath = join(PATHS.uploads, `video-${kind}-${randomUUID()}${ext}`);
@@ -182,13 +193,14 @@ router.post('/', frameImageUpload, asyncHandler(async (req, res) => {
       await copyFile(file.path, durablePath);
     } catch (err) {
       await unlink(durablePath).catch(() => {});
-      await cleanupTempUploads();
+      await cleanupAllStaged();
       throw new ServerError(
         `Failed to stage upload to durable location: ${err.message}`,
         { status: 500, code: 'VIDEO_GEN_UPLOAD_STAGE_FAILED' },
       );
     }
     await unlink(file.path).catch(() => {});
+    stagedDurablePaths.push(durablePath);
     return durablePath;
   };
 
@@ -213,7 +225,7 @@ router.post('/', frameImageUpload, asyncHandler(async (req, res) => {
     try {
       await ensureDir(PATHS.uploads);
     } catch (err) {
-      await cleanupTempUploads();
+      await cleanupAllStaged();
       throw new ServerError(
         `Failed to prepare uploads directory: ${err.message}`,
         { status: 500, code: 'VIDEO_GEN_UPLOADS_DIR_FAILED' },

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -255,7 +255,11 @@ router.post('/', frameImageUpload, asyncHandler(async (req, res) => {
     const history = await loadHistory();
     const videoEntry = history.find((h) => h.id === body.extendFromVideoId);
     if (!videoEntry) {
-      await cleanupTempUpload();
+      // cleanupAllStaged covers durable copies that may have been written
+      // before this validation point — extend mode and image uploads are
+      // mutually exclusive in the UI but the route doesn't enforce that,
+      // so be defensive.
+      await cleanupAllStaged();
       throw new ServerError(
         `extendFromVideoId not found in history: ${body.extendFromVideoId}`,
         { status: 404, code: 'EXTEND_SOURCE_NOT_FOUND' },
@@ -263,7 +267,7 @@ router.post('/', frameImageUpload, asyncHandler(async (req, res) => {
     }
     const candidate = safeUnder(PATHS.videos, videoEntry.filename);
     if (!candidate || !existsSync(candidate)) {
-      await cleanupTempUpload();
+      await cleanupAllStaged();
       throw new ServerError(
         `extendFromVideoId resolved to a missing file: ${videoEntry.filename}`,
         { status: 404, code: 'EXTEND_SOURCE_FILE_MISSING' },

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -195,28 +195,44 @@ router.post('/', frameImageUpload, asyncHandler(async (req, res) => {
   // Resolution precedence on each frame side: a fresh upload always wins over
   // a gallery filename so users can override a stale gallery pick by dropping
   // in a new file without first clearing the picker.
+  //
+  // Cleanup plumbing: `uploadedTempPath` (single, legacy) is RESERVED for the
+  // start-frame upload — that field shape is what already-persisted jobs from
+  // before this route change carry, so keeping its semantics stable means
+  // those replays still clean up correctly. Every additional upload (today:
+  // just `lastImage`) flows through `uploadedTempPaths` as an array. The
+  // worker walks both fields when unlinking on terminal events.
   let sourceImagePath = null;
   let lastImagePath = null;
-  const stagedUploads = [];
-  if (uploads.sourceImage || uploads.lastImage) await ensureDir(PATHS.uploads);
+  let uploadedTempPath = null;
+  const extraUploadedTempPaths = [];
+  if (uploads.sourceImage || uploads.lastImage) {
+    // Ensure the durable uploads dir exists before staging. Wrapped in
+    // try/catch so a permission/disk failure here still cleans up the
+    // multipart temp uploads instead of leaking them in the OS temp dir.
+    try {
+      await ensureDir(PATHS.uploads);
+    } catch (err) {
+      await cleanupTempUploads();
+      throw new ServerError(
+        `Failed to prepare uploads directory: ${err.message}`,
+        { status: 500, code: 'VIDEO_GEN_UPLOADS_DIR_FAILED' },
+      );
+    }
+  }
   if (uploads.sourceImage) {
     sourceImagePath = await stageUploadDurable(uploads.sourceImage, 'source');
-    stagedUploads.push(sourceImagePath);
+    uploadedTempPath = sourceImagePath;
   } else if (body.sourceImageFile) {
     sourceImagePath = resolveGalleryImage(body.sourceImageFile);
   }
   if (uploads.lastImage) {
     lastImagePath = await stageUploadDurable(uploads.lastImage, 'last');
-    stagedUploads.push(lastImagePath);
+    extraUploadedTempPaths.push(lastImagePath);
   } else if (body.lastImageFile) {
     // Same path-traversal guard as the start frame.
     lastImagePath = resolveGalleryImage(body.lastImageFile);
   }
-  // Worker cleans up every staged temp file on terminal events. The legacy
-  // `uploadedTempPath` field stays single (start-frame upload, if any) so
-  // already-persisted jobs from before this route change still replay
-  // cleanly; everything else flows through the array.
-  const [uploadedTempPath = null, ...extraUploadedTempPaths] = stagedUploads;
 
   // Native extend (ltx2 runtime): resolve the history id to a video file
   // path under data/videos/ and forward it as extendFromVideoPath. Reject

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -13,7 +13,7 @@ import { randomUUID } from 'crypto';
 import { join, basename, resolve as resolvePath, sep as PATH_SEP, extname } from 'path';
 import { z } from 'zod';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { uploadSingle } from '../lib/multipart.js';
+import { uploadFields } from '../lib/multipart.js';
 import { PATHS, ensureDir } from '../lib/fileUtils.js';
 import { safeUnder } from '../lib/ffmpeg.js';
 import { getSettings } from '../services/settings.js';
@@ -31,7 +31,10 @@ import { enqueueJob, attachSseClient, cancelJob, listJobs } from '../services/me
 
 const router = Router();
 
-const sourceImageUpload = uploadSingle('sourceImage', {
+// FFLF accepts up to two image uploads (start and end frame). The 50MB cap
+// applies per-file; image-only filter rejects non-image parts up-front so a
+// stray .mp4 drag-drop can't get staged as a "source image".
+const frameImageUpload = uploadFields(['sourceImage', 'lastImage'], {
   limits: { fileSize: 50 * 1024 * 1024 },
   fileFilter: (_req, file, cb) => cb(null, file.mimetype.startsWith('image/')),
 });
@@ -64,10 +67,10 @@ const generateBodySchema = z.object({
   tiling: z.enum(['auto', 'none', 'spatial', 'temporal']).optional(),
   disableAudio: z.union([z.boolean(), z.literal('true'), z.literal('false')]).optional(),
   sourceImageFile: z.string().max(512).optional(),
-  // FFLF mode end-frame target. Gallery-pick only (no upload field) so the
-  // multipart parser stays single-file. Users wanting a fresh end-frame
-  // image can generate or upload it via Image Gen first, then reference
-  // its basename here.
+  // Gallery-pick filename for the FFLF end-frame. The end-frame can also
+  // arrive as a multipart `lastImage` upload (handled below) — when both
+  // are present the upload wins, mirroring the sourceImage/sourceImageFile
+  // precedence on the start-frame side.
   lastImageFile: z.string().max(512).optional(),
   // UI mode hint — backend only uses it for logging/branching; absence
   // falls back to inferring (sourceImage→i2v, no source→t2v).
@@ -123,16 +126,19 @@ const resolveGalleryImage = (name) => {
   }
 };
 
-router.post('/', sourceImageUpload, asyncHandler(async (req, res) => {
-  // Pre-enqueue cleanup hook: every throw path below MUST drop the multipart
-  // temp upload (Multer wrote it before this handler ran). Without this a
-  // configuration/validation error leaks the upload in the OS temp dir.
-  const cleanupTempUpload = async () => {
-    if (req.file?.path) await unlink(req.file.path).catch(() => {});
+router.post('/', frameImageUpload, asyncHandler(async (req, res) => {
+  // Pre-enqueue cleanup hook: every throw path below MUST drop ALL multipart
+  // temp uploads (the parser wrote them before this handler ran). Without
+  // this a configuration/validation error leaks files in the OS temp dir.
+  const uploads = req.files || {};
+  const cleanupTempUploads = async () => {
+    for (const f of Object.values(uploads)) {
+      if (f?.path) await unlink(f.path).catch(() => {});
+    }
   };
   const parsed = generateBodySchema.safeParse(req.body);
   if (!parsed.success) {
-    await cleanupTempUpload();
+    await cleanupTempUploads();
     throw new ServerError(`Validation failed: ${parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join(', ')}`, { status: 400, code: 'VALIDATION_ERROR' });
   }
   const body = parsed.data;
@@ -143,7 +149,7 @@ router.post('/', sourceImageUpload, asyncHandler(async (req, res) => {
   // surface the failure asynchronously on SSE — which then pollutes the
   // persisted queue with a doomed entry.
   if (!pythonPath) {
-    await cleanupTempUpload();
+    await cleanupTempUploads();
     throw new ServerError(
       'Local video generation is not configured (settings.imageGen.local.pythonPath is missing).',
       { status: 400, code: 'VIDEO_GEN_NOT_CONFIGURED' },
@@ -155,7 +161,7 @@ router.post('/', sourceImageUpload, asyncHandler(async (req, res) => {
   if (body.modelId) {
     const known = listVideoModels();
     if (!known.some((m) => m.id === body.modelId)) {
-      await cleanupTempUpload();
+      await cleanupTempUploads();
       throw new ServerError(
         `Unknown modelId: ${body.modelId}`,
         { status: 400, code: 'VIDEO_GEN_UNKNOWN_MODEL' },
@@ -163,41 +169,54 @@ router.post('/', sourceImageUpload, asyncHandler(async (req, res) => {
     }
   }
 
-  let sourceImagePath = null;
-  let uploadedTempPath = null;
-  if (req.file) {
-    // Copy the multipart upload into a durable location under data/uploads
-    // before enqueueing. The Multer temp file lives in the OS temp dir —
-    // which gets reaped by macOS on reboot, and might be missing entirely
-    // when the queue replays a persisted `queued` job after a server
-    // restart. Copying here gives the worker a stable path that survives
-    // restarts; the worker unlinks it on completion or cancel.
-    await ensureDir(PATHS.uploads);
-    const ext = extname(req.file.originalname || req.file.path) || '.bin';
-    const durablePath = join(PATHS.uploads, `video-source-${randomUUID()}${ext}`);
-    // copyFile can throw on disk-full / permission errors. If it does we
-    // need to clean up: drop the multipart temp upload AND the half-written
-    // durablePath (copyFile may have created a zero-byte sentinel before
-    // bailing). Without this, a failed POST leaks files in /tmp + data/uploads.
+  // Stage a multipart upload into data/uploads so the queue worker can find
+  // it after a server restart — the OS temp dir gets reaped on reboot, and a
+  // persisted `queued` job may replay long after the original POST. Worker
+  // unlinks the durable file when the job completes or cancels. Throws
+  // ServerError on copy failure (and cleans up every staged temp upload so a
+  // mid-flight failure doesn't leak files under /tmp + data/uploads).
+  const stageUploadDurable = async (file, kind) => {
+    const ext = extname(file.originalname || file.path) || '.bin';
+    const durablePath = join(PATHS.uploads, `video-${kind}-${randomUUID()}${ext}`);
     try {
-      await copyFile(req.file.path, durablePath);
+      await copyFile(file.path, durablePath);
     } catch (err) {
       await unlink(durablePath).catch(() => {});
-      await cleanupTempUpload();
+      await cleanupTempUploads();
       throw new ServerError(
         `Failed to stage upload to durable location: ${err.message}`,
         { status: 500, code: 'VIDEO_GEN_UPLOAD_STAGE_FAILED' },
       );
     }
-    await unlink(req.file.path).catch(() => {});
-    sourceImagePath = durablePath;
-    uploadedTempPath = durablePath;
+    await unlink(file.path).catch(() => {});
+    return durablePath;
+  };
+
+  // Resolution precedence on each frame side: a fresh upload always wins over
+  // a gallery filename so users can override a stale gallery pick by dropping
+  // in a new file without first clearing the picker.
+  let sourceImagePath = null;
+  let lastImagePath = null;
+  const stagedUploads = [];
+  if (uploads.sourceImage || uploads.lastImage) await ensureDir(PATHS.uploads);
+  if (uploads.sourceImage) {
+    sourceImagePath = await stageUploadDurable(uploads.sourceImage, 'source');
+    stagedUploads.push(sourceImagePath);
   } else if (body.sourceImageFile) {
     sourceImagePath = resolveGalleryImage(body.sourceImageFile);
   }
-
-  // FFLF end-frame: gallery-pick only. Same path-traversal guard.
-  const lastImagePath = body.lastImageFile ? resolveGalleryImage(body.lastImageFile) : null;
+  if (uploads.lastImage) {
+    lastImagePath = await stageUploadDurable(uploads.lastImage, 'last');
+    stagedUploads.push(lastImagePath);
+  } else if (body.lastImageFile) {
+    // Same path-traversal guard as the start frame.
+    lastImagePath = resolveGalleryImage(body.lastImageFile);
+  }
+  // Worker cleans up every staged temp file on terminal events. The legacy
+  // `uploadedTempPath` field stays single (start-frame upload, if any) so
+  // already-persisted jobs from before this route change still replay
+  // cleanly; everything else flows through the array.
+  const [uploadedTempPath = null, ...extraUploadedTempPaths] = stagedUploads;
 
   // Native extend (ltx2 runtime): resolve the history id to a video file
   // path under data/videos/ and forward it as extendFromVideoPath. Reject
@@ -245,6 +264,7 @@ router.post('/', sourceImageUpload, asyncHandler(async (req, res) => {
       disableAudio: body.disableAudio === true || body.disableAudio === 'true',
       sourceImagePath,
       uploadedTempPath,
+      uploadedTempPaths: extraUploadedTempPaths,
       lastImagePath,
       extendFromVideoPath,
       mode: body.mode,

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -29,9 +29,9 @@ vi.mock('../services/mediaJobQueue/index.js', () => ({
 }));
 
 vi.mock('../lib/multipart.js', () => ({
-  // Bypass the multipart parser for unit tests — handler treats req.file as
-  // optional, and we exercise the no-upload path here.
-  uploadSingle: () => (_req, _res, next) => next(),
+  // Bypass the multipart parser for unit tests — the handler treats req.files
+  // as optional, and we exercise the no-upload path here.
+  uploadFields: () => (_req, _res, next) => next(),
 }));
 
 vi.mock('../lib/fileUtils.js', () => ({

--- a/server/services/mediaJobQueue/index.js
+++ b/server/services/mediaJobQueue/index.js
@@ -525,9 +525,19 @@ async function runJob(job) {
       return false;
     });
     safeParams.uploadedTempPaths = filtered;
+  } else if (typeof safeParams.uploadedTempPaths === 'string') {
+    // Persisted as a string (corrupted JSON or older shape) — normalize to a
+    // single-entry array if the path is safe so generateVideo's cleanup loop
+    // still unlinks it on completion. Drop otherwise.
+    if (isUnderUploadsRoot(safeParams.uploadedTempPaths)) {
+      safeParams.uploadedTempPaths = [safeParams.uploadedTempPaths];
+    } else {
+      console.log(`⚠️ media-job [${job.id.slice(0, 8)}] uploadedTempPaths string outside PATHS.uploads — dropped before gen invoke: ${safeParams.uploadedTempPaths}`);
+      safeParams.uploadedTempPaths = [];
+    }
   } else if (safeParams.uploadedTempPaths != null) {
-    // Persisted as a non-array (corrupted JSON) — drop it rather than feed
-    // a non-iterable into the worker's cleanup loop.
+    // Any other non-array, non-string value — drop it rather than feed a
+    // non-iterable into the worker's cleanup loop.
     safeParams.uploadedTempPaths = [];
   }
 

--- a/server/services/mediaJobQueue/index.js
+++ b/server/services/mediaJobQueue/index.js
@@ -83,11 +83,17 @@ async function safeUnlinkUpload(path) {
 // Walks both `uploadedTempPath` (single, start-frame upload) and
 // `uploadedTempPaths` (array, additional staged uploads such as the FFLF
 // lastImage) so cleanup paths stay agnostic to which fields contributed.
+// Also handles the corrupted-JSON case where `uploadedTempPaths` arrives as
+// a single string (treats it as a one-entry array) — defense-in-depth so a
+// hand-edited media-jobs.json still gets its staged file unlinked.
 async function safeUnlinkAllUploads(params) {
   if (!params) return;
   await safeUnlinkUpload(params.uploadedTempPath);
-  if (Array.isArray(params.uploadedTempPaths)) {
-    for (const p of params.uploadedTempPaths) await safeUnlinkUpload(p);
+  const paths = params.uploadedTempPaths;
+  if (Array.isArray(paths)) {
+    for (const p of paths) await safeUnlinkUpload(p);
+  } else if (typeof paths === 'string') {
+    await safeUnlinkUpload(paths);
   }
 }
 

--- a/server/services/mediaJobQueue/index.js
+++ b/server/services/mediaJobQueue/index.js
@@ -80,6 +80,17 @@ async function safeUnlinkUpload(path) {
   await unlink(path).catch(() => {});
 }
 
+// Walks both `uploadedTempPath` (single, start-frame upload) and
+// `uploadedTempPaths` (array, additional staged uploads such as the FFLF
+// lastImage) so cleanup paths stay agnostic to which fields contributed.
+async function safeUnlinkAllUploads(params) {
+  if (!params) return;
+  await safeUnlinkUpload(params.uploadedTempPath);
+  if (Array.isArray(params.uploadedTempPaths)) {
+    for (const p of params.uploadedTempPaths) await safeUnlinkUpload(p);
+  }
+}
+
 export const JOB_KINDS = Object.freeze(['video', 'image']);
 export const JOB_STATUSES = Object.freeze(['queued', 'running', 'completed', 'failed', 'canceled']);
 
@@ -222,11 +233,11 @@ export async function initMediaJobQueue() {
         archive.push(failed);
         restartedFailedIds.push(failed.id);
         // The failed job will never reach the worker's cleanup, so any
-        // multipart upload it staged into data/uploads would leak forever.
-        // safeUnlinkUpload constrains the delete to PATHS.uploads so we
+        // multipart uploads it staged into data/uploads would leak forever.
+        // safeUnlinkAllUploads constrains each delete to PATHS.uploads so we
         // never delete a file the job merely referenced (gallery image,
         // prior render, etc).
-        safeUnlinkUpload(j.params?.uploadedTempPath);
+        safeUnlinkAllUploads(j.params);
       } else if (j.status === 'queued') {
         queue.push({ ...j });
       } else {
@@ -491,15 +502,27 @@ async function runJob(job) {
     },
   };
 
-  // Thread #1: sanitize uploadedTempPath before passing params to the gen
+  // Thread #1: sanitize uploadedTempPath(s) before passing params to the gen
   // module. Even though safeUnlinkUpload guards the *delete* path, the gen
   // module receives the raw job.params spread and could itself act on a
-  // corrupted path from a hand-edited media-jobs.json. Null it out here if
-  // it doesn't resolve under PATHS.uploads so the constraint holds end-to-end.
+  // corrupted path from a hand-edited media-jobs.json. Null/strip anything
+  // that doesn't resolve under PATHS.uploads so the constraint holds end-to-end.
   const safeParams = { ...job.params };
   if (safeParams.uploadedTempPath && (typeof safeParams.uploadedTempPath !== 'string' || !isUnderUploadsRoot(safeParams.uploadedTempPath))) {
     console.log(`⚠️ media-job [${job.id.slice(0, 8)}] uploadedTempPath outside PATHS.uploads — nulled before gen invoke: ${safeParams.uploadedTempPath}`);
     safeParams.uploadedTempPath = null;
+  }
+  if (Array.isArray(safeParams.uploadedTempPaths)) {
+    const filtered = safeParams.uploadedTempPaths.filter((p) => {
+      if (typeof p === 'string' && isUnderUploadsRoot(p)) return true;
+      console.log(`⚠️ media-job [${job.id.slice(0, 8)}] uploadedTempPaths entry outside PATHS.uploads — dropped before gen invoke: ${p}`);
+      return false;
+    });
+    safeParams.uploadedTempPaths = filtered;
+  } else if (safeParams.uploadedTempPaths != null) {
+    // Persisted as a non-array (corrupted JSON) — drop it rather than feed
+    // a non-iterable into the worker's cleanup loop.
+    safeParams.uploadedTempPaths = [];
   }
 
   const emitter = job.kind === 'video' ? videoGenEvents : imageGenEvents;
@@ -565,10 +588,10 @@ async function runJob(job) {
   } catch (err) {
     // generateVideo / generateImage threw before reaching their proc.on
     // cleanup hooks (e.g. PYTHON not configured, validation fail). Clean up
-    // multipart upload temp files the route handed us so they don't leak
-    // under data/uploads. safeUnlinkUpload constrains the delete to
-    // PATHS.uploads as defense-in-depth against corrupted persisted params.
-    await safeUnlinkUpload(job.params?.uploadedTempPath);
+    // every multipart upload temp file the route handed us so they don't
+    // leak under data/uploads. safeUnlinkAllUploads constrains each delete
+    // to PATHS.uploads as defense-in-depth against corrupted persisted params.
+    await safeUnlinkAllUploads(job.params);
     handlers.failed({ error: err.message });
   }
 
@@ -615,12 +638,12 @@ export async function cancelJob(jobId) {
   const queueIdx = queue.findIndex((j) => j.id === jobId);
   if (queueIdx >= 0) {
     const [job] = queue.splice(queueIdx, 1);
-    // Multipart uploads (e.g. /api/video-gen with an image) hand us a path
-    // staged under PATHS.uploads. If we drop the job before it starts,
-    // runJob never gets a chance to delete it — clean up here so the
-    // uploads dir doesn't accumulate. safeUnlinkUpload constrains the
-    // delete to PATHS.uploads.
-    await safeUnlinkUpload(job.params?.uploadedTempPath);
+    // Multipart uploads (e.g. /api/video-gen with an image — start frame,
+    // end frame, or both) are staged under PATHS.uploads. If we drop the
+    // job before it starts, runJob never gets a chance to delete them —
+    // clean up here so the uploads dir doesn't accumulate. Each delete is
+    // constrained to PATHS.uploads.
+    await safeUnlinkAllUploads(job.params);
     job.status = 'canceled';
     // Persist the cancel reason on the job so a late SSE reconnect (after
     // the live SSE entry was cleaned up) can synthesize the same terminal

--- a/server/services/videoGen/local.js
+++ b/server/services/videoGen/local.js
@@ -237,7 +237,7 @@ const buildArgs = ({ pythonPath, modelId, model, prompt, negativePrompt, width, 
   return { bin: pythonPath, args };
 };
 
-export async function generateVideo({ pythonPath, prompt, negativePrompt = '', modelId = defaultVideoModelId(), width = 768, height = 512, numFrames = 121, fps = 24, steps, guidanceScale, seed, tiling = 'auto', disableAudio = false, sourceImagePath = null, uploadedTempPath = null, lastImagePath = null, extendFromVideoPath = null, mode = null, imageStrength = null, jobId: providedJobId = null }) {
+export async function generateVideo({ pythonPath, prompt, negativePrompt = '', modelId = defaultVideoModelId(), width = 768, height = 512, numFrames = 121, fps = 24, steps, guidanceScale, seed, tiling = 'auto', disableAudio = false, sourceImagePath = null, uploadedTempPath = null, uploadedTempPaths = [], lastImagePath = null, extendFromVideoPath = null, mode = null, imageStrength = null, jobId: providedJobId = null }) {
   if (!pythonPath) throw new ServerError('Python path not configured — set it in Settings > Image Gen', { status: 400, code: 'VIDEO_GEN_NOT_CONFIGURED' });
   if (!prompt?.trim()) throw new ServerError('Prompt is required', { status: 400, code: 'VALIDATION_ERROR' });
   // Single-flight is now enforced by the mediaJobQueue worker upstream — only
@@ -349,6 +349,7 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
     if (resizedSrcTempPath) unlink(resizedSrcTempPath).catch(() => {});
     if (resizedLastTempPath) unlink(resizedLastTempPath).catch(() => {});
     if (uploadedTempPath) unlink(uploadedTempPath).catch(() => {});
+    for (const p of uploadedTempPaths) unlink(p).catch(() => {});
     closeJobAfterDelay(jobs, jobId);
   });
 
@@ -421,6 +422,7 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
     // Cleanup the original multipart upload temp file too — without this,
     // every i2v request leaves a file in os.tmpdir() forever.
     if (uploadedTempPath) await unlink(uploadedTempPath).catch(() => {});
+    for (const p of uploadedTempPaths) await unlink(p).catch(() => {});
 
     if (code !== 0) {
       job.status = 'error';
@@ -538,6 +540,7 @@ export async function generateChainedVideo({ chunks, jobId: outerJobId, ...rest 
       // copy under data/uploads). Later chunks use a frame extracted from a
       // prior render, which lives under data/images.
       uploadedTempPath: i === 0 ? rest.uploadedTempPath : null,
+      uploadedTempPaths: i === 0 ? (rest.uploadedTempPaths || []) : [],
       mode: i === 0 ? firstMode : 'image',
       // After the first chunk, drop FFLF-style last image — chained continuation
       // is single-conditioned on the previous chunk's tail frame.


### PR DESCRIPTION
## Summary

In Video Gen FFLF mode, the **First frame** slot was upload-only and the **Last frame** slot was gallery-only. Both now offer the same dual control — pick from your image gallery, OR upload a fresh image.

## What changed

- **Multipart parser** (`server/lib/multipart.js`): refactored `streamMultipart` to accept a Set of allowed file fields; added a new `uploadFields(['a', 'b'], opts)` export that populates `req.files = { a: {…}, b: {…} }`. `uploadSingle` keeps its `req.file` back-compat so existing callers (Apple Health import, image gen) are untouched.
- **Video Gen route** (`server/routes/videoGen.js`): now uses `uploadFields(['sourceImage', 'lastImage'], …)`, factored a `stageUploadDurable` helper, and threads both staged uploads through to the worker. The legacy `uploadedTempPath` field stays single (start-frame upload, if any) so already-persisted jobs from before this change still replay cleanly; additional uploads flow through a new `uploadedTempPaths: string[]` array.
- **VideoGen page** (`client/src/pages/VideoGen.jsx`): collapsed both slots into a single inline `renderFramePanel` helper that shows a "Pick from gallery…" dropdown + an "Upload an image" file input side-by-side. Added `lastImageUpload` state + `lastUploadUrl` object URL. Queue snapshot now carries both blobs (`_blobs: { sourceImage, lastImage }`) so a queued FFLF render reuses the right files at dispatch time.
- **Cleanup plumbing**:
  - `server/services/mediaJobQueue/index.js`: new `safeUnlinkAllUploads(params)` walks both fields, with defense-in-depth path-traversal guard on the array sanitizer (out-of-`PATHS.uploads` entries are dropped before reaching the gen module).
  - `server/services/videoGen/local.js`: `generateVideo()` accepts the new `uploadedTempPaths` array and unlinks each on close/error. `generateChainedVideo()` only passes the array to the first chunk so later chunks don't double-unlink already-deleted files.

## Test plan

- [x] Server tests: `cd server && npm test` → 143 files / 3228 tests pass (+2 new `uploadFields` tests covering dual-file collection and field-name filtering)
- [x] Existing FFLF route test (`forwards lastImageFile + mode for FFLF`) still passes — schema and queue plumbing untouched
- [x] Existing media-job sanitizer tests still pass — back-compat with persisted `uploadedTempPath` (single field, including non-string corruption) verified
- [x] Client build: `cd client && npm run build` → clean
- [ ] Manual: switch Video Gen → FFLF mode, verify each slot offers both Upload + Gallery; pick one of each combination (gallery+gallery, upload+gallery, gallery+upload, upload+upload) and confirm the right files reach the worker