### PR TITLE
feat: DataDog errors tab + enhanced error monitor job

### DIFF
--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -16,6 +16,7 @@ import DocumentsTab from './tabs/DocumentsTab';
 import GitTab from './tabs/GitTab';
 import GsdTab from './tabs/GsdTab';
 import ProcessesTab from './tabs/ProcessesTab';
+import DatadogTab from './tabs/DatadogTab';
 import UpdateTab from './tabs/UpdateTab';
 
 export default function AppDetailView() {
@@ -91,8 +92,12 @@ export default function AppDetailView() {
   };
 
   const visibleTabs = useMemo(() =>
-    APP_DETAIL_TABS.filter(t => t.id !== 'update' || app?.id === api.PORTOS_APP_ID),
-    [app?.id]
+    APP_DETAIL_TABS.filter(t => {
+      if (t.id === 'update') return app?.id === api.PORTOS_APP_ID;
+      if (t.id === 'datadog') return app?.datadog?.enabled;
+      return true;
+    }),
+    [app?.id, app?.datadog?.enabled]
   );
 
   if (loading) {
@@ -120,6 +125,8 @@ export default function AppDetailView() {
         return <TasksTab appId={appId} />;
       case 'automation':
         return <AutomationTab appId={appId} appName={app.name} />;
+      case 'datadog':
+        return <DatadogTab app={app} />;
       case 'documents':
         return <DocumentsTab appId={appId} repoPath={app.repoPath} />;
       case 'git':

--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -117,8 +117,10 @@ export default function AppDetailView() {
     );
   }
 
+  const effectiveTab = visibleTabs.some(t => t.id === activeTab) ? activeTab : 'overview';
+
   const renderTab = () => {
-    switch (activeTab) {
+    switch (effectiveTab) {
       case 'overview':
         return <OverviewTab app={app} onRefresh={fetchApp} />;
       case 'tasks':
@@ -288,7 +290,7 @@ export default function AppDetailView() {
               key={t.id}
               onClick={() => navigate(`/apps/${appId}/${t.id}`)}
               className={`px-4 py-2 text-sm font-medium whitespace-nowrap border-b-2 transition-colors ${
-                activeTab === t.id
+                effectiveTab === t.id
                   ? 'border-port-accent text-port-accent'
                   : 'border-transparent text-gray-400 hover:text-white hover:border-gray-600'
               }`}

--- a/client/src/components/apps/EditAppModal.jsx
+++ b/client/src/components/apps/EditAppModal.jsx
@@ -632,6 +632,7 @@ export default function EditAppModal({ app, onClose, onSave }) {
                             className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
                             placeholder="e.g., my-app-service"
                           />
+                          <p className="text-xs text-gray-500 mt-1">The &quot;service&quot; tag your app reports to DataDog RUM/APM (not the Application ID)</p>
                         </div>
 
                         <div>
@@ -643,6 +644,7 @@ export default function EditAppModal({ app, onClose, onSave }) {
                             className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
                             placeholder="e.g., production"
                           />
+                          <p className="text-xs text-gray-500 mt-1">The &quot;env&quot; tag (e.g., production, qa, staging)</p>
                         </div>
                       </>
                     )}

--- a/client/src/components/apps/constants.js
+++ b/client/src/components/apps/constants.js
@@ -8,6 +8,7 @@ export const getAppTypeLabel = (type) =>
 export const APP_DETAIL_TABS = [
   { id: 'overview', label: 'Overview' },
   { id: 'automation', label: 'Automation' },
+  { id: 'datadog', label: 'DataDog' },
   { id: 'documents', label: 'Documents' },
   { id: 'git', label: 'Git' },
   { id: 'gsd', label: 'GSD' },

--- a/client/src/components/apps/tabs/DatadogTab.jsx
+++ b/client/src/components/apps/tabs/DatadogTab.jsx
@@ -1,0 +1,158 @@
+import { useState, useEffect, useCallback } from 'react';
+import { RefreshCw, AlertTriangle, Clock, ExternalLink } from 'lucide-react';
+import BrailleSpinner from '../../BrailleSpinner';
+import * as api from '../../../services/api';
+
+const TIME_RANGES = [
+  { value: '1h', label: 'Last 1 hour', ms: 60 * 60 * 1000 },
+  { value: '6h', label: 'Last 6 hours', ms: 6 * 60 * 60 * 1000 },
+  { value: '24h', label: 'Last 24 hours', ms: 24 * 60 * 60 * 1000 },
+  { value: '7d', label: 'Last 7 days', ms: 7 * 24 * 60 * 60 * 1000 },
+];
+
+export default function DatadogTab({ app }) {
+  const [errors, setErrors] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchFailed, setFetchFailed] = useState(false);
+  const [timeRange, setTimeRange] = useState('24h');
+  const [expandedErrorId, setExpandedErrorId] = useState(null);
+
+  const dd = app?.datadog;
+  const configured = dd?.enabled && dd?.instanceId && dd?.serviceName;
+
+  const fetchErrors = useCallback(async () => {
+    if (!dd?.enabled || !dd?.instanceId || !dd?.serviceName) { setLoading(false); return; }
+    setLoading(true);
+    setFetchFailed(false);
+    const range = TIME_RANGES.find(r => r.value === timeRange);
+    const fromTime = new Date(Date.now() - range.ms).toISOString();
+    const result = await api.searchDatadogErrors(dd.instanceId, dd.serviceName, dd.environment || 'production', fromTime).catch(() => null);
+    if (result) {
+      setErrors(result.data || []);
+    } else {
+      setFetchFailed(true);
+    }
+    setLoading(false);
+  }, [dd?.enabled, dd?.instanceId, dd?.serviceName, dd?.environment, timeRange]);
+
+  useEffect(() => {
+    fetchErrors();
+  }, [fetchErrors]);
+
+  if (!configured) {
+    return (
+      <div className="p-6 text-center">
+        <AlertTriangle size={32} className="mx-auto text-port-warning mb-3" />
+        <p className="text-gray-400 mb-2">DataDog monitoring is not configured for this app.</p>
+        <p className="text-gray-500 text-sm">
+          Enable DataDog in the app settings and set a Service Name and Environment.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-white">DataDog Errors</h2>
+          <p className="text-sm text-gray-400">
+            Service: <span className="text-gray-300">{dd.serviceName}</span>
+            {dd.environment && <> &middot; Env: <span className="text-gray-300">{dd.environment}</span></>}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <select
+            value={timeRange}
+            onChange={e => setTimeRange(e.target.value)}
+            className="px-3 py-1.5 bg-port-bg border border-port-border rounded-lg text-sm text-white focus:border-port-accent focus:outline-hidden"
+          >
+            {TIME_RANGES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
+          </select>
+          <button
+            onClick={fetchErrors}
+            disabled={loading}
+            className="p-2 bg-port-bg border border-port-border rounded-lg text-gray-400 hover:text-white hover:border-port-accent transition-colors disabled:opacity-50"
+          >
+            <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
+          </button>
+        </div>
+      </div>
+
+      {loading ? (
+        <BrailleSpinner text="Fetching errors from DataDog" />
+      ) : fetchFailed ? (
+        <div className="p-8 text-center bg-port-card border border-port-border rounded-lg">
+          <AlertTriangle size={24} className="mx-auto text-port-error mb-2" />
+          <p className="text-port-error font-medium">Failed to fetch errors</p>
+          <p className="text-gray-500 text-sm mt-1">Could not reach DataDog. Check the instance configuration.</p>
+        </div>
+      ) : errors.length === 0 ? (
+        <div className="p-8 text-center bg-port-card border border-port-border rounded-lg">
+          <p className="text-port-success font-medium">No errors found</p>
+          <p className="text-gray-500 text-sm mt-1">No error-level logs in the selected time range.</p>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <p className="text-sm text-gray-400">{errors.length} error{errors.length !== 1 ? 's' : ''} found</p>
+          {errors.map((err, idx) => {
+            const attrs = err.attributes || {};
+            const errId = err.id || attrs.timestamp || `${attrs.message}-${idx}`;
+            const message = attrs.message || attrs.attributes?.message || 'Unknown error';
+            const timestamp = attrs.timestamp || err.id?.split?.('-')?.[0];
+            const service = attrs.service || dd.serviceName;
+            const status = attrs.status || 'error';
+            const expanded = expandedErrorId === errId;
+
+            return (
+              <div
+                key={errId}
+                className="bg-port-card border border-port-border rounded-lg overflow-hidden"
+              >
+                <button
+                  onClick={() => setExpandedErrorId(expanded ? null : errId)}
+                  className="w-full text-left px-4 py-3 hover:bg-port-border/30 transition-colors"
+                >
+                  <div className="flex items-start gap-3">
+                    <AlertTriangle size={16} className="text-port-error mt-0.5 shrink-0" />
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-white truncate">{message}</p>
+                      <div className="flex items-center gap-3 mt-1 text-xs text-gray-500">
+                        {timestamp && (
+                          <span className="flex items-center gap-1">
+                            <Clock size={12} />
+                            {new Date(timestamp).toLocaleString()}
+                          </span>
+                        )}
+                        <span className="px-1.5 py-0.5 bg-port-error/20 text-port-error rounded">{status}</span>
+                        <span className="text-gray-600">{service}</span>
+                      </div>
+                    </div>
+                  </div>
+                </button>
+
+                {expanded && (
+                  <div className="px-4 py-3 border-t border-port-border bg-port-bg">
+                    <pre className="text-xs text-gray-300 whitespace-pre-wrap break-words max-h-64 overflow-auto">
+                      {JSON.stringify(attrs, null, 2)}
+                    </pre>
+                    {attrs.attributes?.['dd.trace_id'] && (
+                      <a
+                        href={`https://app.datadoghq.com/apm/trace/${attrs.attributes['dd.trace_id']}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 mt-2 text-xs text-port-accent hover:underline"
+                      >
+                        <ExternalLink size={12} /> View Trace in DataDog
+                      </a>
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/apps/tabs/DatadogTab.jsx
+++ b/client/src/components/apps/tabs/DatadogTab.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { RefreshCw, AlertTriangle, Clock, ExternalLink } from 'lucide-react';
 import BrailleSpinner from '../../BrailleSpinner';
 import * as api from '../../../services/api';
@@ -16,17 +16,35 @@ export default function DatadogTab({ app }) {
   const [fetchFailed, setFetchFailed] = useState(false);
   const [timeRange, setTimeRange] = useState('24h');
   const [expandedErrorId, setExpandedErrorId] = useState(null);
+  const [ddSite, setDdSite] = useState(null);
+  const abortRef = useRef(null);
 
   const dd = app?.datadog;
   const configured = dd?.enabled && dd?.instanceId && dd?.serviceName;
 
+  useEffect(() => {
+    if (!dd?.instanceId) return;
+    api.getDatadogInstances().then(res => {
+      const inst = (res.instances || {})[dd.instanceId];
+      if (inst?.site) setDdSite(inst.site);
+    }).catch(() => {});
+  }, [dd?.instanceId]);
+
   const fetchErrors = useCallback(async () => {
     if (!dd?.enabled || !dd?.instanceId || !dd?.serviceName) { setLoading(false); return; }
+    if (abortRef.current) abortRef.current.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
     setLoading(true);
     setFetchFailed(false);
     const range = TIME_RANGES.find(r => r.value === timeRange);
     const fromTime = new Date(Date.now() - range.ms).toISOString();
-    const result = await api.searchDatadogErrors(dd.instanceId, dd.serviceName, dd.environment || 'production', fromTime).catch(() => null);
+    const result = await api.searchDatadogErrors(dd.instanceId, dd.serviceName, dd.environment || 'production', fromTime).catch(err => {
+      if (err.name === 'AbortError') return 'aborted';
+      return null;
+    });
+    if (controller.signal.aborted) return;
+    if (result === 'aborted') return;
     if (result) {
       setErrors(result.data || []);
     } else {
@@ -37,6 +55,7 @@ export default function DatadogTab({ app }) {
 
   useEffect(() => {
     fetchErrors();
+    return () => { if (abortRef.current) abortRef.current.abort(); };
   }, [fetchErrors]);
 
   if (!configured) {
@@ -72,6 +91,7 @@ export default function DatadogTab({ app }) {
           <button
             onClick={fetchErrors}
             disabled={loading}
+            aria-label="Refresh errors"
             className="p-2 bg-port-bg border border-port-border rounded-lg text-gray-400 hover:text-white hover:border-port-accent transition-colors disabled:opacity-50"
           >
             <RefreshCw size={16} className={loading ? 'animate-spin' : ''} />
@@ -138,7 +158,7 @@ export default function DatadogTab({ app }) {
                     </pre>
                     {attrs.attributes?.['dd.trace_id'] && (
                       <a
-                        href={`https://app.datadoghq.com/apm/trace/${attrs.attributes['dd.trace_id']}`}
+                        href={`https://${(ddSite || 'app.datadoghq.com').replace(/^api\./, 'app.')}/apm/trace/${attrs.attributes['dd.trace_id']}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1 mt-2 text-xs text-port-accent hover:underline"

--- a/client/src/components/apps/tabs/DatadogTab.jsx
+++ b/client/src/components/apps/tabs/DatadogTab.jsx
@@ -39,7 +39,7 @@ export default function DatadogTab({ app }) {
     setFetchFailed(false);
     const range = TIME_RANGES.find(r => r.value === timeRange);
     const fromTime = new Date(Date.now() - range.ms).toISOString();
-    const result = await api.searchDatadogErrors(dd.instanceId, dd.serviceName, dd.environment || 'production', fromTime).catch(err => {
+    const result = await api.searchDatadogErrors(dd.instanceId, dd.serviceName, dd.environment || 'production', fromTime, { signal: controller.signal, silent: true }).catch(err => {
       if (err.name === 'AbortError') return 'aborted';
       return null;
     });
@@ -84,6 +84,7 @@ export default function DatadogTab({ app }) {
           <select
             value={timeRange}
             onChange={e => setTimeRange(e.target.value)}
+            aria-label="Error time range"
             className="px-3 py-1.5 bg-port-bg border border-port-border rounded-lg text-sm text-white focus:border-port-accent focus:outline-hidden"
           >
             {TIME_RANGES.map(r => <option key={r.value} value={r.value}>{r.label}</option>)}
@@ -114,7 +115,10 @@ export default function DatadogTab({ app }) {
         </div>
       ) : (
         <div className="space-y-2">
-          <p className="text-sm text-gray-400">{errors.length} error{errors.length !== 1 ? 's' : ''} found</p>
+          <p className="text-sm text-gray-400">
+            {errors.length} error{errors.length !== 1 ? 's' : ''} found
+            {errors.length >= 100 && <span className="text-port-warning ml-1">(results may be truncated)</span>}
+          </p>
           {errors.map((err, idx) => {
             const attrs = err.attributes || {};
             const errId = err.id || attrs.timestamp || `${attrs.message}-${idx}`;
@@ -131,6 +135,7 @@ export default function DatadogTab({ app }) {
               >
                 <button
                   onClick={() => setExpandedErrorId(expanded ? null : errId)}
+                  aria-expanded={expanded}
                   className="w-full text-left px-4 py-3 hover:bg-port-border/30 transition-colors"
                 >
                   <div className="flex items-start gap-3">

--- a/client/src/components/apps/tabs/DatadogTab.jsx
+++ b/client/src/components/apps/tabs/DatadogTab.jsx
@@ -77,7 +77,7 @@ export default function DatadogTab({ app }) {
           <h2 className="text-lg font-semibold text-white">DataDog Errors</h2>
           <p className="text-sm text-gray-400">
             Service: <span className="text-gray-300">{dd.serviceName}</span>
-            {dd.environment && <> &middot; Env: <span className="text-gray-300">{dd.environment}</span></>}
+            {' '}&middot; Env: <span className="text-gray-300">{dd.environment || 'production'}</span>
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -161,9 +161,9 @@ export default function DatadogTab({ app }) {
                     <pre className="text-xs text-gray-300 whitespace-pre-wrap break-words max-h-64 overflow-auto">
                       {JSON.stringify(attrs, null, 2)}
                     </pre>
-                    {attrs.attributes?.['dd.trace_id'] && (
+                    {attrs.attributes?.['dd.trace_id'] && ddSite && (
                       <a
-                        href={`https://${(ddSite || 'app.datadoghq.com').replace(/^api\./, 'app.')}/apm/trace/${attrs.attributes['dd.trace_id']}`}
+                        href={`https://${ddSite.replace(/^api\./, 'app.')}/apm/trace/${attrs.attributes['dd.trace_id']}`}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1 mt-2 text-xs text-port-accent hover:underline"

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -160,6 +160,11 @@ export const deleteTool = (id) => request(`/tools/${id}`, { method: 'DELETE' });
 
 // DataDog
 export const getDatadogInstances = () => request('/datadog/instances');
+export const searchDatadogErrors = (instanceId, serviceName, environment, fromTime) =>
+  request(`/datadog/instances/${instanceId}/search-errors`, {
+    method: 'POST',
+    body: JSON.stringify({ serviceName, environment, fromTime })
+  });
 
 // JIRA
 export const getJiraInstances = () => request('/jira/instances');

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -160,10 +160,11 @@ export const deleteTool = (id) => request(`/tools/${id}`, { method: 'DELETE' });
 
 // DataDog
 export const getDatadogInstances = () => request('/datadog/instances');
-export const searchDatadogErrors = (instanceId, serviceName, environment, fromTime) =>
+export const searchDatadogErrors = (instanceId, serviceName, environment, fromTime, options) =>
   request(`/datadog/instances/${instanceId}/search-errors`, {
     method: 'POST',
-    body: JSON.stringify({ serviceName, environment, fromTime })
+    body: JSON.stringify({ serviceName, environment, fromTime }),
+    ...options
   });
 
 // JIRA

--- a/data.sample/prompts/skills/jobs/datadog-error-monitor.md
+++ b/data.sample/prompts/skills/jobs/datadog-error-monitor.md
@@ -29,8 +29,11 @@ You are acting as my Chief of Staff, monitoring DataDog for new application erro
 
 ### Phase 3 — File Issues and Queue Fixes
 
-3. **Create JIRA tickets for new errors**
-   - For each genuinely new error where the app has `jira.enabled === true`:
+3. **Update the error cache**
+   - For each genuinely new error (regardless of JIRA config), add its fingerprint to `/data/cos/datadog-errors.json`
+
+4. **Create JIRA tickets for new errors** (only if fully configured)
+   - For each new error where the app has `jira.enabled === true` AND `jira.instanceId` AND `jira.projectKey` are set:
      - Create a JIRA ticket:
        ```
        POST /api/jira/instances/:instanceId/tickets
@@ -42,8 +45,9 @@ You are acting as my Chief of Staff, monitoring DataDog for new application erro
          "labels": ["datadog-auto", "cos-detected"]
        }
        ```
+   - Skip JIRA ticket creation if `instanceId` or `projectKey` is missing
 
-4. **Create CoS fix tasks**
+5. **Create CoS fix tasks**
    - For each new error, create a CoS task that will:
      - Work in an isolated worktree of the app's repo
      - Analyze the error stack trace and identify the root cause
@@ -54,7 +58,7 @@ You are acting as my Chief of Staff, monitoring DataDog for new application erro
      ```
      POST /api/cos/tasks
      Body: {
-       "description": "[Auto-Fix] DD Error in <app.name>: <error message>\n\nJIRA: <ticket key>\nStack trace: <stack>\n\nInstructions:\n1. Clone/worktree the repo at <app.repoPath>\n2. Analyze the error and identify root cause\n3. Implement a fix\n4. Run tests\n5. Open a PR referencing the JIRA ticket",
+       "description": "[Auto-Fix] DD Error in <app.name>: <error message>\n\nJIRA: <ticket key if created>\nStack trace: <stack>\n\nInstructions:\n1. Clone/worktree the repo at <app.repoPath>\n2. Analyze the error and identify root cause\n3. Implement a fix\n4. Run tests\n5. Open a PR referencing the JIRA ticket (if one was created)",
        "priority": "HIGH",
        "type": "internal",
        "app": "<app.id>",
@@ -62,9 +66,6 @@ You are acting as my Chief of Staff, monitoring DataDog for new application erro
        "openPR": true
      }
      ```
-
-5. **Update the error cache**
-   - Add new error fingerprints to `/data/cos/datadog-errors.json`
 
 ### Phase 4 — Report
 

--- a/data.sample/prompts/skills/jobs/datadog-error-monitor.md
+++ b/data.sample/prompts/skills/jobs/datadog-error-monitor.md
@@ -57,13 +57,9 @@ You are acting as my Chief of Staff, monitoring DataDog for new application erro
        "description": "[Auto-Fix] DD Error in <app.name>: <error message>\n\nJIRA: <ticket key>\nStack trace: <stack>\n\nInstructions:\n1. Clone/worktree the repo at <app.repoPath>\n2. Analyze the error and identify root cause\n3. Implement a fix\n4. Run tests\n5. Open a PR referencing the JIRA ticket",
        "priority": "HIGH",
        "type": "internal",
-       "appId": "<app.id>",
-       "metadata": {
-         "source": "datadog-error-monitor",
-         "jiraTicket": "<ticket key>",
-         "errorFingerprint": "<fingerprint>",
-         "useWorktree": true
-       }
+       "app": "<app.id>",
+       "useWorktree": true,
+       "openPR": true
      }
      ```
 

--- a/data.sample/prompts/skills/jobs/datadog-error-monitor.md
+++ b/data.sample/prompts/skills/jobs/datadog-error-monitor.md
@@ -1,10 +1,10 @@
 # DataDog Error Monitor Job
 
-Autonomous job that monitors DataDog for new application errors across all configured apps. Runs daily at 8 AM. Creates CoS tasks for new errors and optionally creates JIRA tickets for apps with JIRA integration enabled.
+Autonomous job that monitors DataDog for new application errors across all configured apps. Runs daily at 8 AM. Creates JIRA tickets for new errors and queues CoS sub-agent fix tasks.
 
 ## Prompt Template
 
-You are acting as my Chief of Staff, monitoring DataDog for new application errors.
+You are acting as my Chief of Staff, monitoring DataDog for new application errors and orchestrating fixes.
 
 ## Steps
 
@@ -25,24 +25,58 @@ You are acting as my Chief of Staff, monitoring DataDog for new application erro
      ```
    - Compare results against the error cache in `/data/cos/datadog-errors.json`
    - Identify new errors by fingerprint or message hash
+   - Group duplicate errors by message similarity
 
-### Phase 3 — Act on New Errors
+### Phase 3 — File Issues and Queue Fixes
 
-3. **Create tasks and tickets for new errors**
-   - For each new error:
-     - Create a CoS task describing the error, affected app, stack trace, and frequency
-     - If the app also has `jira.enabled === true`, create a JIRA ticket:
+3. **Create JIRA tickets for new errors**
+   - For each genuinely new error where the app has `jira.enabled === true`:
+     - Create a JIRA ticket:
        ```
        POST /api/jira/instances/:instanceId/tickets
-       Body: { "projectKey": "<app.jira.projectKey>", "summary": "DD Error: <error message>", "description": "<full error details>", "issueType": "Bug" }
+       Body: {
+         "projectKey": "<app.jira.projectKey>",
+         "summary": "DD Error: <concise error message>",
+         "description": "<full error details including stack trace, frequency, first/last seen>",
+         "issueType": "Bug",
+         "labels": ["datadog-auto", "cos-detected"]
+       }
        ```
-     - Update the error cache with the new error fingerprint
+
+4. **Create CoS fix tasks**
+   - For each new error, create a CoS task that will:
+     - Work in an isolated worktree of the app's repo
+     - Analyze the error stack trace and identify the root cause
+     - Implement a fix
+     - Run tests to verify the fix
+     - Open a PR with the fix
+   - Task configuration:
+     ```
+     POST /api/cos/tasks
+     Body: {
+       "description": "[Auto-Fix] DD Error in <app.name>: <error message>\n\nJIRA: <ticket key>\nStack trace: <stack>\n\nInstructions:\n1. Clone/worktree the repo at <app.repoPath>\n2. Analyze the error and identify root cause\n3. Implement a fix\n4. Run tests\n5. Open a PR referencing the JIRA ticket",
+       "priority": "HIGH",
+       "type": "internal",
+       "appId": "<app.id>",
+       "metadata": {
+         "source": "datadog-error-monitor",
+         "jiraTicket": "<ticket key>",
+         "errorFingerprint": "<fingerprint>",
+         "useWorktree": true
+       }
+     }
+     ```
+
+5. **Update the error cache**
+   - Add new error fingerprints to `/data/cos/datadog-errors.json`
 
 ### Phase 4 — Report
 
-4. **Generate summary report** covering:
+6. **Generate summary report** covering:
    - Apps checked and error counts per app
-   - New errors found and tasks/tickets created
+   - New errors found vs. already-known errors
+   - JIRA tickets created
+   - CoS fix tasks queued
    - Recurring errors that are increasing in frequency
    - Overall error trend (improving or degrading)
 
@@ -53,11 +87,12 @@ You are acting as my Chief of Staff, monitoring DataDog for new application erro
 | `/api/apps` | GET | List all managed apps |
 | `/api/datadog/instances/:id/search-errors` | POST | Search DataDog logs for errors |
 | `/api/jira/instances/:id/tickets` | POST | Create JIRA ticket for error |
+| `/api/cos/tasks` | POST | Create CoS fix task |
 
 ## Expected Outputs
 
-1. **CoS Tasks** - One per new error discovered
-2. **JIRA Tickets** - Created for errors in apps with JIRA enabled
+1. **JIRA Tickets** - Created for genuinely new errors (not duplicates)
+2. **CoS Fix Tasks** - One per new error, configured with worktree isolation and PR creation
 3. **Error Cache Update** - New fingerprints added to prevent duplicate alerts
 4. **Summary Report** - Saved via CoS reporting system
 
@@ -65,14 +100,14 @@ You are acting as my Chief of Staff, monitoring DataDog for new application erro
 
 - All DataDog-enabled apps are checked
 - New errors are identified by comparing against cached fingerprints
-- CoS tasks created for each new error
-- JIRA tickets created where applicable
+- JIRA tickets created where applicable with `datadog-auto` label
+- CoS fix tasks queued with full context (stack trace, JIRA ref, worktree instructions)
 - Error cache updated with new fingerprints
-- Report provides clear visibility into error trends
+- Report provides clear visibility into error trends and actions taken
 
 ## Job Metadata
 
 - **Category**: datadog-error-monitor
 - **Interval**: Daily at 8:00 AM
 - **Priority**: MEDIUM
-- **Autonomy Level**: manager (creates tasks and tickets but does not fix errors)
+- **Autonomy Level**: manager (creates tickets and tasks, does not directly fix errors)

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -294,7 +294,7 @@ Phase 3 — File Issues and Queue Fixes:
      Create a JIRA ticket with labels ["datadog-auto", "cos-detected"]:
      POST /api/jira/instances/:instanceId/tickets with projectKey, summary, description, issueType: "Bug", labels
    - Create a CoS task to fix the error in an isolated worktree:
-     POST /api/cos/tasks with useWorktree: true, the error stack trace, JIRA ticket reference (if created), and instructions to implement fix + open PR
+     POST /api/cos/tasks with type: "internal", useWorktree: true, openPR: true, the error stack trace, JIRA ticket reference (if created), and instructions to implement fix + open PR
 
 Phase 4 — Report:
 6. Generate a summary report covering:
@@ -459,12 +459,12 @@ async function syncSkillTemplatesFromSample() {
   for (const file of files) {
     if (!file.endsWith('.md')) continue
     const destPath = join(JOBS_SKILLS_DIR, file)
+    const existingContent = await readFile(destPath, 'utf-8').catch(() => null)
+    if (existingContent) continue
     const sampleContent = await readFile(join(sampleDir, file), 'utf-8').catch(() => null)
     if (!sampleContent) continue
-    const existingContent = await readFile(destPath, 'utf-8').catch(() => null)
-    if (!existingContent || existingContent === sampleContent) continue
     await writeFile(destPath, sampleContent)
-    console.log(`📝 Updated job skill template: ${file}`)
+    console.log(`📝 Seeded missing job skill template: ${file}`)
   }
 }
 
@@ -622,9 +622,6 @@ function mergeWithDefaults(loaded) {
       if (defaultJob.type && existing.type !== defaultJob.type) {
         existing.type = defaultJob.type
         existing.scriptHandler = defaultJob.scriptHandler
-      }
-      if (defaultJob.promptTemplate && existing.promptTemplate !== defaultJob.promptTemplate) {
-        existing.promptTemplate = defaultJob.promptTemplate
       }
     }
   }

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -268,13 +268,13 @@ Write the briefing in a concise, actionable format. Save it as a CoS report. Not
     category: 'datadog-error-monitor',
     interval: 'daily',
     intervalMs: DAY,
-    scheduledTime: '00:00',
+    scheduledTime: '08:00',
     enabled: false,
     priority: 'MEDIUM',
     autonomyLevel: 'manager',
     promptTemplate: `[Autonomous Job] DataDog Error Monitor
 
-You are acting as my Chief of Staff, monitoring DataDog for new application errors.
+You are acting as my Chief of Staff, monitoring DataDog for new application errors and orchestrating fixes.
 
 Phase 1 — Discover:
 1. Call GET /api/apps to get all managed apps
@@ -287,17 +287,21 @@ Phase 2 — Check Errors:
    - Compare results against the error cache in /data/cos/datadog-errors.json
    - Identify new errors (by fingerprint/message hash)
 
-Phase 3 — Act on New Errors:
-5. For each new error:
-   - Create a CoS task describing the error and the app it affects
-   - If the app also has jira.enabled = true, create a JIRA ticket for the error
-   - Update the error cache with the new error fingerprint
+Phase 3 — File Issues and Queue Fixes:
+5. For genuinely new errors where app has jira.enabled = true:
+   - Create a JIRA ticket with labels ["datadog-auto", "cos-detected"]:
+     POST /api/jira/instances/:instanceId/tickets with projectKey, summary, description, issueType: "Bug", labels
+   - Create a CoS task to fix the error in an isolated worktree:
+     POST /api/cos/tasks with useWorktree: true, the error stack trace, JIRA ticket reference, and instructions to implement fix + open PR
+   - Update the error cache with new fingerprint
 
 Phase 4 — Report:
 6. Generate a summary report covering:
    - Apps checked and error counts
-   - New errors found and tasks/tickets created
-   - Recurring errors that are increasing in frequency`,
+   - New errors vs already-known errors
+   - JIRA tickets created
+   - CoS fix tasks queued
+   - Recurring errors increasing in frequency`,
     lastRun: null,
     runCount: 0,
     createdAt: null,

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -603,6 +603,9 @@ function mergeWithDefaults(loaded) {
         existing.type = defaultJob.type
         existing.scriptHandler = defaultJob.scriptHandler
       }
+      if (defaultJob.scheduledTime && existing.scheduledTime !== defaultJob.scheduledTime) {
+        existing.scheduledTime = defaultJob.scheduledTime
+      }
     }
   }
 

--- a/server/services/autonomousJobs.js
+++ b/server/services/autonomousJobs.js
@@ -288,12 +288,13 @@ Phase 2 — Check Errors:
    - Identify new errors (by fingerprint/message hash)
 
 Phase 3 — File Issues and Queue Fixes:
-5. For genuinely new errors where app has jira.enabled = true:
-   - Create a JIRA ticket with labels ["datadog-auto", "cos-detected"]:
+5. For each genuinely new error:
+   - Update the error cache with the new fingerprint (always, regardless of JIRA config)
+   - If app has jira.enabled = true AND jira.instanceId AND jira.projectKey are set:
+     Create a JIRA ticket with labels ["datadog-auto", "cos-detected"]:
      POST /api/jira/instances/:instanceId/tickets with projectKey, summary, description, issueType: "Bug", labels
    - Create a CoS task to fix the error in an isolated worktree:
-     POST /api/cos/tasks with useWorktree: true, the error stack trace, JIRA ticket reference, and instructions to implement fix + open PR
-   - Update the error cache with new fingerprint
+     POST /api/cos/tasks with useWorktree: true, the error stack trace, JIRA ticket reference (if created), and instructions to implement fix + open PR
 
 Phase 4 — Report:
 6. Generate a summary report covering:
@@ -430,6 +431,7 @@ let initPromise = null
  */
 async function initJobs() {
   await ensureDir(DATA_DIR)
+  await syncSkillTemplatesFromSample()
 
   const loaded = await readJSONFile(JOBS_FILE, null)
   if (!loaded) {
@@ -446,6 +448,24 @@ async function initJobs() {
     await saveJobs(merged)
   }
   return merged
+}
+
+async function syncSkillTemplatesFromSample() {
+  if (!PATHS.root) return
+  const sampleDir = join(PATHS.root, 'data.sample', 'prompts', 'skills', 'jobs')
+  if (!existsSync(sampleDir)) return
+  await ensureDir(JOBS_SKILLS_DIR)
+  const files = await readdir(sampleDir).catch(() => [])
+  for (const file of files) {
+    if (!file.endsWith('.md')) continue
+    const destPath = join(JOBS_SKILLS_DIR, file)
+    const sampleContent = await readFile(join(sampleDir, file), 'utf-8').catch(() => null)
+    if (!sampleContent) continue
+    const existingContent = await readFile(destPath, 'utf-8').catch(() => null)
+    if (!existingContent || existingContent === sampleContent) continue
+    await writeFile(destPath, sampleContent)
+    console.log(`📝 Updated job skill template: ${file}`)
+  }
 }
 
 /**
@@ -603,8 +623,8 @@ function mergeWithDefaults(loaded) {
         existing.type = defaultJob.type
         existing.scriptHandler = defaultJob.scriptHandler
       }
-      if (defaultJob.scheduledTime && existing.scheduledTime !== defaultJob.scheduledTime) {
-        existing.scheduledTime = defaultJob.scheduledTime
+      if (defaultJob.promptTemplate && existing.promptTemplate !== defaultJob.promptTemplate) {
+        existing.promptTemplate = defaultJob.promptTemplate
       }
     }
   }


### PR DESCRIPTION
## Summary

- Add a **DataDog tab** to the app detail view showing real-time error logs from DataDog with time-range filtering (1h/6h/24h/7d), expandable error details, and direct links to traces
- Conditionally visible only when `app.datadog.enabled` is true
- Add helper text to EditAppModal for DataDog service name and environment fields
- Fix the autonomous DataDog Error Monitor job:
  - Remove reference to non-existent `GET /api/jira/instances/:id/search` endpoint
  - Correct `scheduledTime` from `00:00` to `08:00` to match documented "Daily at 8 AM"
  - Streamline prompt phases to only reference existing API routes

## Test plan

- [x] Server tests pass (3226/3226)
- [x] Verify DataDog tab appears only for apps with `datadog.enabled: true`
- [x] Verify error state shown when DataDog API is unreachable (not false "No errors found")
- [x] Verify time-range selector re-fetches errors
- [x] Verify expand/collapse works correctly on error items