### PR TITLE
Image Cleaner: strip C2PA + denoise gpt-image-1 output

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -4,7 +4,7 @@
 
 ### Image Cleaner (Dev Tools)
 
-New `/devtools/image-clean` page strips C2PA provenance metadata and median-filters pixel-level noise from `gpt-image-1` / Codex output. Drag-and-drop or browse-to-upload PNG/JPEG/WebP images (up to 50MB), pick a cleaning level (`light` = median(1), `aggressive` = median(3) + sharpen), and download the re-encoded result. Side-by-side before/after preview with size delta, dimensions, format, and a "C2PA stripped" badge when the source PNG carried a `caBX` chunk. Backed by a new `POST /api/image-clean` route powered by `sharp`, with magic-byte format sniffing so client-supplied MIME types aren't trusted. Reachable via `⌘K` and voice (`ui_navigate`) through new `nav.devtools.image-clean` manifest entry.
+New `/devtools/image-clean` page strips C2PA provenance metadata and median-filters pixel-level noise from `gpt-image-1` / Codex output. Drag-and-drop or browse-to-upload PNG/JPEG/WebP images (up to 40MB), pick a cleaning level (`light` = median(1), `aggressive` = median(3) + sharpen), and download the re-encoded result. Side-by-side before/after preview with size delta, dimensions, format, and a "C2PA stripped" badge when the source PNG carried a `caBX` chunk. Backed by a new `POST /api/image-clean` route powered by `sharp`, with magic-byte format sniffing so client-supplied MIME types aren't trusted. Reachable via `⌘K` and voice (`ui_navigate`) through new `nav.devtools.image-clean` manifest entry.
 
 ### Writers Room — Read view + cross-linked storyboard
 

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -2,6 +2,10 @@
 
 ## Added
 
+### Image Cleaner (Dev Tools)
+
+New `/devtools/image-clean` page strips C2PA provenance metadata and median-filters pixel-level noise from `gpt-image-1` / Codex output. Drag-and-drop or browse-to-upload PNG/JPEG/WebP images (up to 50MB), pick a cleaning level (`light` = median(1), `aggressive` = median(3) + sharpen), and download the re-encoded result. Side-by-side before/after preview with size delta, dimensions, format, and a "C2PA stripped" badge when the source PNG carried a `caBX` chunk. Backed by a new `POST /api/image-clean` route powered by `sharp`, with magic-byte format sniffing so client-supplied MIME types aren't trusted. Reachable via `⌘K` and voice (`ui_navigate`) through new `nav.devtools.image-clean` manifest entry.
+
 ### Writers Room — Read view + cross-linked storyboard
 
 A new `?view=read` mode for the Writers Room editor renders prose with scene anchors, inline character/setting/object highlighting, and hover tooltips that show extracted profile details. Hovering a token in the prose rings the matching chip on its scene card and the matching row in the bible; clicking jumps the sidebar to the right tab. Hovering a scene card flashes the matching scene marker in the prose.

--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,11 @@ BTW.md
 # Browser service node_modules (code is committed)
 browser/node_modules/
 
-# Workspace sub-package lock files (root package-lock.json is canonical)
+# Sub-package lock files. Root package.json does NOT declare these as
+# workspaces; `npm run setup` runs `npm install --prefix <pkg>` for each,
+# generating their own lockfiles locally. The root package-lock.json only
+# tracks root devDependencies (pm2) — the `client`/`server` entries you may
+# see there are stale `extraneous: true` leftovers and are not authoritative.
 browser/package-lock.json
 client/package-lock.json
 server/package-lock.json

--- a/.npmrc
+++ b/.npmrc
@@ -4,4 +4,5 @@
 # Trusted packages requiring install scripts:
 #   esbuild      (client + server) — downloads platform-specific binary
 #   node-pty     (server)          — builds native PTY addon
+#   sharp        (server)          — fetches/builds libvips native binding
 ignore-scripts=true

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -39,6 +39,7 @@ const Messages = lazyWithReload(() => import('./pages/Messages'));
 const Goals = lazyWithReload(() => import('./pages/Goals'));
 const OpenClawPage = lazyWithReload(() => import('./pages/OpenClaw'));
 const Submodules = lazyWithReload(() => import('./pages/Submodules'));
+const ImageClean = lazyWithReload(() => import('./pages/ImageClean'));
 const ChiefOfStaff = lazyWithReload(() => import('./pages/ChiefOfStaff'));
 const Ask = lazyWithReload(() => import('./pages/Ask'));
 const MediaGen = lazyWithReload(() => import('./pages/MediaGen'));
@@ -128,6 +129,7 @@ export default function App() {
           <Route path="devtools/datadog" element={<DataDog />} />
           <Route path="devtools/github" element={<GitHub />} />
           <Route path="devtools/history" element={<HistoryPage />} />
+          <Route path="devtools/image-clean" element={<ImageClean />} />
           <Route path="devtools/runs" element={<RunsHistoryPage />} />
           <Route path="devtools/runner" element={<RunnerPage />} />
           <Route path="devtools/submodules" element={<Submodules />} />

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -76,6 +76,7 @@ import {
   Mic,
   Rss,
   Archive,
+  Eraser,
   Sun,
   Moon
 } from 'lucide-react';
@@ -206,6 +207,7 @@ const navItems = [
       { to: '/feature-agents', label: 'Feature Agents', icon: Wand2 },
       { to: '/devtools/github', label: 'GitHub', icon: Github },
       { to: '/devtools/history', label: 'History', icon: History },
+      { to: '/devtools/image-clean', label: 'Image Cleaner', icon: Eraser },
       { to: '/devtools/jira', label: 'JIRA', icon: Ticket },
       { to: '/devtools/jira/reports', label: 'JIRA Reports', icon: FileText },
       { to: '/shell', label: 'Shell', icon: SquareTerminal },

--- a/client/src/pages/ImageClean.jsx
+++ b/client/src/pages/ImageClean.jsx
@@ -1,0 +1,259 @@
+import { useState, useRef, useCallback } from 'react';
+import { Eraser, Upload, Download, ShieldCheck } from 'lucide-react';
+import toast from '../components/ui/Toast';
+import BrailleSpinner from '../components/BrailleSpinner';
+import * as api from '../services/api';
+import { formatBytes } from '../utils/formatters';
+import { readFileAsBase64 } from '../utils/fileUpload';
+
+const MAX_BYTES = 50 * 1024 * 1024;
+const CLEAN_LEVELS = ['light', 'aggressive'];
+
+export default function ImageClean() {
+  const [level, setLevel] = useState('light');
+  const [original, setOriginal] = useState(null); // { dataUri, base64, size, name }
+  const [result, setResult] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [dragActive, setDragActive] = useState(false);
+  const fileInputRef = useRef(null);
+  const requestIdRef = useRef(0);
+
+  const runClean = useCallback(async (base64, lvl) => {
+    const myRequestId = ++requestIdRef.current;
+    setBusy(true);
+    setResult(null);
+    const cleaned = await api.cleanImage(base64, lvl).catch((err) => {
+      toast.error(err.message || 'Failed to clean image');
+      return null;
+    });
+    // Drop responses from a stale click — newer reclean is in flight.
+    if (myRequestId !== requestIdRef.current) return;
+    setBusy(false);
+    if (cleaned) {
+      setResult(cleaned);
+      toast.success(cleaned.c2paStripped ? 'C2PA provenance stripped' : 'Image cleaned');
+    }
+  }, []);
+
+  const handleFile = async (file) => {
+    if (!file) return;
+    if (file.size > MAX_BYTES) {
+      toast.error(`File exceeds ${MAX_BYTES / 1024 / 1024}MB limit`);
+      return;
+    }
+    if (!/^image\/(png|jpe?g|webp)$/i.test(file.type)) {
+      toast.error('Only PNG, JPEG, and WebP images are supported');
+      return;
+    }
+
+    const base64 = await readFileAsBase64(file).catch(() => null);
+    if (!base64) {
+      toast.error('Failed to read file');
+      return;
+    }
+
+    setOriginal({
+      dataUri: `data:${file.type};base64,${base64}`,
+      base64,
+      size: file.size,
+      name: file.name,
+    });
+    runClean(base64, level);
+  };
+
+  const handleLevelChange = (newLevel) => {
+    setLevel(newLevel);
+    if (original?.base64) runClean(original.base64, newLevel);
+  };
+
+  const handleDrag = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.type === 'dragenter' || e.type === 'dragover') setDragActive(true);
+    else if (e.type === 'dragleave') setDragActive(false);
+  };
+
+  const handleDrop = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragActive(false);
+    const file = e.dataTransfer.files?.[0];
+    if (file) handleFile(file);
+  };
+
+  const handleReset = () => {
+    requestIdRef.current++;
+    setOriginal(null);
+    setResult(null);
+    setBusy(false);
+  };
+
+  const downloadName = (() => {
+    if (!original?.name) return 'cleaned';
+    const dot = original.name.lastIndexOf('.');
+    const stem = dot > 0 ? original.name.slice(0, dot) : original.name;
+    const ext = result?.format === 'jpeg' ? 'jpg' : result?.format || 'png';
+    return `${stem}.cleaned.${ext}`;
+  })();
+
+  const sizeDelta = result ? result.sizeAfter - result.sizeBefore : 0;
+  const sizeDeltaPct = result && result.sizeBefore > 0
+    ? ((sizeDelta / result.sizeBefore) * 100).toFixed(1)
+    : '0.0';
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 sm:gap-4">
+        <div>
+          <h2 className="text-2xl font-bold text-white flex items-center gap-2">
+            <Eraser size={24} className="text-port-accent" />
+            Image Cleaner
+          </h2>
+          <p className="text-gray-500 text-sm">
+            Strip C2PA provenance + median-filter pixel noise from gpt-image-1 / Codex output.
+          </p>
+        </div>
+      </div>
+
+      <div className="bg-port-card border border-port-border rounded-lg p-4 flex flex-col sm:flex-row sm:items-center gap-3">
+        <span className="text-sm text-gray-400">Cleaning level</span>
+        <div className="flex gap-2">
+          {CLEAN_LEVELS.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              onClick={() => handleLevelChange(opt)}
+              disabled={busy}
+              className={`px-3 py-1.5 rounded-lg text-sm transition-colors capitalize ${
+                level === opt
+                  ? 'bg-port-accent text-white'
+                  : 'bg-port-bg border border-port-border text-gray-400 hover:text-white'
+              } disabled:opacity-50`}
+            >
+              {opt}
+            </button>
+          ))}
+        </div>
+        <span className="text-xs text-gray-600 sm:ml-auto">
+          {level === 'light' ? 'median(1)' : 'median(3) + sharpen'}
+        </span>
+      </div>
+
+      {!original && (
+        <div
+          className={`relative p-12 border-2 border-dashed rounded-lg text-center transition-colors ${
+            dragActive
+              ? 'border-port-accent bg-port-accent/10'
+              : 'border-port-border hover:border-port-accent/50 bg-port-card'
+          }`}
+          onDragEnter={handleDrag}
+          onDragLeave={handleDrag}
+          onDragOver={handleDrag}
+          onDrop={handleDrop}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp"
+            onChange={(e) => handleFile(e.target.files?.[0])}
+            className="sr-only"
+            tabIndex={-1}
+            aria-hidden="true"
+          />
+          <Upload size={40} className={`mx-auto mb-4 ${dragActive ? 'text-port-accent' : 'text-gray-500'}`} />
+          <p className="text-white mb-2">
+            {dragActive ? 'Drop image here' : 'Drag and drop an image here'}
+          </p>
+          <p className="text-gray-500 text-sm mb-4">PNG, JPEG, or WebP (max 50MB)</p>
+          <button
+            onClick={() => fileInputRef.current?.click()}
+            className="px-4 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg transition-colors"
+          >
+            Browse File
+          </button>
+        </div>
+      )}
+
+      {original && (
+        <div className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="bg-port-card border border-port-border rounded-lg overflow-hidden">
+              <div className="px-4 py-2 border-b border-port-border flex items-center justify-between">
+                <span className="text-sm font-medium text-white">Before</span>
+                <span className="text-xs text-gray-500">{formatBytes(original.size)}</span>
+              </div>
+              <div className="p-4 flex items-center justify-center bg-port-bg/50 min-h-[200px]">
+                <img src={original.dataUri} alt="Original" className="max-w-full max-h-[480px] object-contain" />
+              </div>
+            </div>
+
+            <div className="bg-port-card border border-port-border rounded-lg overflow-hidden">
+              <div className="px-4 py-2 border-b border-port-border flex items-center justify-between">
+                <span className="text-sm font-medium text-white">After</span>
+                {result && <span className="text-xs text-gray-500">{formatBytes(result.sizeAfter)}</span>}
+              </div>
+              <div className="p-4 flex items-center justify-center bg-port-bg/50 min-h-[200px]">
+                {busy && <BrailleSpinner text="Cleaning" />}
+                {!busy && result && (
+                  <img
+                    src={`data:${result.mimeType};base64,${result.data}`}
+                    alt="Cleaned"
+                    className="max-w-full max-h-[480px] object-contain"
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+
+          {result && (
+            <div className="bg-port-card border border-port-border rounded-lg p-4 grid grid-cols-2 sm:grid-cols-4 gap-4">
+              <div>
+                <div className="text-xs text-gray-500 uppercase tracking-wide">Format</div>
+                <div className="text-white font-medium">{result.format}</div>
+              </div>
+              <div>
+                <div className="text-xs text-gray-500 uppercase tracking-wide">Dimensions</div>
+                <div className="text-white font-medium">
+                  {result.width && result.height ? `${result.width}×${result.height}` : '—'}
+                </div>
+              </div>
+              <div>
+                <div className="text-xs text-gray-500 uppercase tracking-wide">Size delta</div>
+                <div className="text-white font-medium">
+                  {sizeDelta >= 0 ? '+' : '−'}{formatBytes(Math.abs(sizeDelta))}{' '}
+                  <span className="text-xs text-gray-500">({sizeDeltaPct}%)</span>
+                </div>
+              </div>
+              <div>
+                <div className="text-xs text-gray-500 uppercase tracking-wide">C2PA</div>
+                <div className={`font-medium flex items-center gap-1 ${result.c2paStripped ? 'text-port-success' : 'text-gray-400'}`}>
+                  {result.c2paStripped && <ShieldCheck size={14} />}
+                  {result.c2paStripped ? 'Stripped' : 'None found'}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="flex flex-wrap gap-2">
+            {result && (
+              <a
+                href={`data:${result.mimeType};base64,${result.data}`}
+                download={downloadName}
+                className="px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg transition-colors flex items-center gap-2"
+              >
+                <Download size={16} />
+                Download
+              </a>
+            )}
+            <button
+              onClick={handleReset}
+              className="px-4 py-2 bg-port-card border border-port-border hover:border-port-accent/50 text-gray-300 rounded-lg transition-colors"
+            >
+              Choose another image
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/ImageClean.jsx
+++ b/client/src/pages/ImageClean.jsx
@@ -54,18 +54,25 @@ export default function ImageClean() {
     });
     // Drop responses from a stale click — newer reclean is in flight.
     if (myRequestId !== requestIdRef.current) return;
-    setBusy(false);
-    if (cleaned) {
-      const objectUrl = await buildResultUrl(cleaned);
-      // Bail if a newer reclean started while we were decoding.
-      if (myRequestId !== requestIdRef.current) {
-        URL.revokeObjectURL(objectUrl);
-        return;
-      }
-      resultUrlRef.current = objectUrl;
-      setResult({ ...cleaned, objectUrl });
-      toast.success(cleaned.c2paStripped ? 'C2PA provenance stripped' : 'Image cleaned');
+    if (!cleaned) {
+      setBusy(false);
+      return;
     }
+    // Keep busy=true through the decode — for large images the base64→Blob
+    // conversion is non-trivial and the spinner should stay visible.
+    const objectUrl = await buildResultUrl(cleaned).catch((err) => {
+      toast.error(err.message || 'Failed to decode cleaned image');
+      return null;
+    });
+    if (myRequestId !== requestIdRef.current) {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+      return;
+    }
+    setBusy(false);
+    if (!objectUrl) return;
+    resultUrlRef.current = objectUrl;
+    setResult({ ...cleaned, objectUrl });
+    toast.success(cleaned.c2paStripped ? 'C2PA provenance stripped' : 'Image cleaned');
   }, []);
 
   const handleFile = async (file) => {

--- a/client/src/pages/ImageClean.jsx
+++ b/client/src/pages/ImageClean.jsx
@@ -193,12 +193,11 @@ export default function ImageClean() {
               key={opt}
               type="button"
               onClick={() => handleLevelChange(opt)}
-              disabled={busy}
               className={`px-3 py-1.5 rounded-lg text-sm transition-colors capitalize ${
                 level === opt
                   ? 'bg-port-accent text-white'
                   : 'bg-port-bg border border-port-border text-gray-400 hover:text-white'
-              } disabled:opacity-50`}
+              }`}
             >
               {opt}
             </button>

--- a/client/src/pages/ImageClean.jsx
+++ b/client/src/pages/ImageClean.jsx
@@ -31,12 +31,13 @@ export default function ImageClean() {
   }, []);
 
   // Decode the cleaned-image base64 once into a blob URL so the After preview
-  // and the download link don't each carry a multi-MB data: string.
-  const buildResultUrl = (cleaned) => {
-    const bin = atob(cleaned.data);
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
-    return URL.createObjectURL(new Blob([bytes], { type: cleaned.mimeType }));
+  // and the download link don't each carry a multi-MB data: string. Use
+  // fetch().blob() so the base64 → bytes conversion happens in native browser
+  // code instead of a JS atob loop that would block the main thread for large
+  // images.
+  const buildResultUrl = async (cleaned) => {
+    const blob = await fetch(`data:${cleaned.mimeType};base64,${cleaned.data}`).then((r) => r.blob());
+    return URL.createObjectURL(blob);
   };
 
   const runClean = useCallback(async (base64, lvl) => {
@@ -55,7 +56,12 @@ export default function ImageClean() {
     if (myRequestId !== requestIdRef.current) return;
     setBusy(false);
     if (cleaned) {
-      const objectUrl = buildResultUrl(cleaned);
+      const objectUrl = await buildResultUrl(cleaned);
+      // Bail if a newer reclean started while we were decoding.
+      if (myRequestId !== requestIdRef.current) {
+        URL.revokeObjectURL(objectUrl);
+        return;
+      }
       resultUrlRef.current = objectUrl;
       setResult({ ...cleaned, objectUrl });
       toast.success(cleaned.c2paStripped ? 'C2PA provenance stripped' : 'Image cleaned');
@@ -68,11 +74,15 @@ export default function ImageClean() {
       toast.error(`File exceeds ${MAX_BYTES / 1024 / 1024}MB limit`);
       return;
     }
-    // Some drag sources leave file.type empty — fall back to extension. The
-    // server still does a magic-byte sniff and is the source of truth.
-    const typeOk = file.type ? ALLOWED_MIME.test(file.type) : true;
-    const extOk = ALLOWED_EXT.test(file.name || '');
-    if (!typeOk || !extOk) {
+    // Server-side magic-byte sniff is the source of truth. Only fail-fast in the
+    // client when BOTH MIME and extension are present and clearly not supported
+    // — missing/empty values (common on drag from the file system) fall through
+    // to the server.
+    const hasMime = !!file.type;
+    const hasExt = /\./.test(file.name || '');
+    const mimeOk = hasMime ? ALLOWED_MIME.test(file.type) : null;
+    const extOk = hasExt ? ALLOWED_EXT.test(file.name) : null;
+    if (mimeOk === false && extOk === false) {
       toast.error('Only PNG, JPEG, and WebP images are supported');
       return;
     }

--- a/client/src/pages/ImageClean.jsx
+++ b/client/src/pages/ImageClean.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { Eraser, Upload, Download, ShieldCheck } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import BrailleSpinner from '../components/BrailleSpinner';
@@ -6,17 +6,27 @@ import * as api from '../services/api';
 import { formatBytes } from '../utils/formatters';
 import { readFileAsBase64 } from '../utils/fileUpload';
 
-const MAX_BYTES = 50 * 1024 * 1024;
+// Keep aligned with MAX_INPUT_BYTES in server/routes/imageClean.js — both are
+// sized so the base64+JSON envelope fits under the 55mb body parser cap.
+const MAX_BYTES = 40 * 1024 * 1024;
 const CLEAN_LEVELS = ['light', 'aggressive'];
+const ALLOWED_EXT = /\.(png|jpe?g|webp)$/i;
+const ALLOWED_MIME = /^image\/(png|jpe?g|webp)$/i;
 
 export default function ImageClean() {
   const [level, setLevel] = useState('light');
-  const [original, setOriginal] = useState(null); // { dataUri, base64, size, name }
+  const [original, setOriginal] = useState(null); // { previewUrl, base64, size, name }
   const [result, setResult] = useState(null);
   const [busy, setBusy] = useState(false);
   const [dragActive, setDragActive] = useState(false);
   const fileInputRef = useRef(null);
   const requestIdRef = useRef(0);
+  const previewUrlRef = useRef(null);
+
+  // Revoke any outstanding blob URL on unmount so we don't leak.
+  useEffect(() => () => {
+    if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+  }, []);
 
   const runClean = useCallback(async (base64, lvl) => {
     const myRequestId = ++requestIdRef.current;
@@ -41,7 +51,11 @@ export default function ImageClean() {
       toast.error(`File exceeds ${MAX_BYTES / 1024 / 1024}MB limit`);
       return;
     }
-    if (!/^image\/(png|jpe?g|webp)$/i.test(file.type)) {
+    // Some drag sources leave file.type empty — fall back to extension. The
+    // server still does a magic-byte sniff and is the source of truth.
+    const typeOk = file.type ? ALLOWED_MIME.test(file.type) : true;
+    const extOk = ALLOWED_EXT.test(file.name || '');
+    if (!typeOk || !extOk) {
       toast.error('Only PNG, JPEG, and WebP images are supported');
       return;
     }
@@ -52,8 +66,14 @@ export default function ImageClean() {
       return;
     }
 
+    // Use a blob URL for the Before preview so we don't double the in-memory
+    // image (base64 string + data URI string). Revoke any previous URL first.
+    if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    const previewUrl = URL.createObjectURL(file);
+    previewUrlRef.current = previewUrl;
+
     setOriginal({
-      dataUri: `data:${file.type};base64,${base64}`,
+      previewUrl,
       base64,
       size: file.size,
       name: file.name,
@@ -83,6 +103,10 @@ export default function ImageClean() {
 
   const handleReset = () => {
     requestIdRef.current++;
+    if (previewUrlRef.current) {
+      URL.revokeObjectURL(previewUrlRef.current);
+      previewUrlRef.current = null;
+    }
     setOriginal(null);
     setResult(null);
     setBusy(false);
@@ -164,7 +188,7 @@ export default function ImageClean() {
           <p className="text-white mb-2">
             {dragActive ? 'Drop image here' : 'Drag and drop an image here'}
           </p>
-          <p className="text-gray-500 text-sm mb-4">PNG, JPEG, or WebP (max 50MB)</p>
+          <p className="text-gray-500 text-sm mb-4">PNG, JPEG, or WebP (max 40MB)</p>
           <button
             onClick={() => fileInputRef.current?.click()}
             className="px-4 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg transition-colors"
@@ -183,7 +207,7 @@ export default function ImageClean() {
                 <span className="text-xs text-gray-500">{formatBytes(original.size)}</span>
               </div>
               <div className="p-4 flex items-center justify-center bg-port-bg/50 min-h-[200px]">
-                <img src={original.dataUri} alt="Original" className="max-w-full max-h-[480px] object-contain" />
+                <img src={original.previewUrl} alt="Original" className="max-w-full max-h-[480px] object-contain" />
               </div>
             </div>
 

--- a/client/src/pages/ImageClean.jsx
+++ b/client/src/pages/ImageClean.jsx
@@ -22,15 +22,30 @@ export default function ImageClean() {
   const fileInputRef = useRef(null);
   const requestIdRef = useRef(0);
   const previewUrlRef = useRef(null);
+  const resultUrlRef = useRef(null);
 
   // Revoke any outstanding blob URL on unmount so we don't leak.
   useEffect(() => () => {
     if (previewUrlRef.current) URL.revokeObjectURL(previewUrlRef.current);
+    if (resultUrlRef.current) URL.revokeObjectURL(resultUrlRef.current);
   }, []);
+
+  // Decode the cleaned-image base64 once into a blob URL so the After preview
+  // and the download link don't each carry a multi-MB data: string.
+  const buildResultUrl = (cleaned) => {
+    const bin = atob(cleaned.data);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i += 1) bytes[i] = bin.charCodeAt(i);
+    return URL.createObjectURL(new Blob([bytes], { type: cleaned.mimeType }));
+  };
 
   const runClean = useCallback(async (base64, lvl) => {
     const myRequestId = ++requestIdRef.current;
     setBusy(true);
+    if (resultUrlRef.current) {
+      URL.revokeObjectURL(resultUrlRef.current);
+      resultUrlRef.current = null;
+    }
     setResult(null);
     const cleaned = await api.cleanImage(base64, lvl).catch((err) => {
       toast.error(err.message || 'Failed to clean image');
@@ -40,7 +55,9 @@ export default function ImageClean() {
     if (myRequestId !== requestIdRef.current) return;
     setBusy(false);
     if (cleaned) {
-      setResult(cleaned);
+      const objectUrl = buildResultUrl(cleaned);
+      resultUrlRef.current = objectUrl;
+      setResult({ ...cleaned, objectUrl });
       toast.success(cleaned.c2paStripped ? 'C2PA provenance stripped' : 'Image cleaned');
     }
   }, []);
@@ -106,6 +123,10 @@ export default function ImageClean() {
     if (previewUrlRef.current) {
       URL.revokeObjectURL(previewUrlRef.current);
       previewUrlRef.current = null;
+    }
+    if (resultUrlRef.current) {
+      URL.revokeObjectURL(resultUrlRef.current);
+      resultUrlRef.current = null;
     }
     setOriginal(null);
     setResult(null);
@@ -220,7 +241,7 @@ export default function ImageClean() {
                 {busy && <BrailleSpinner text="Cleaning" />}
                 {!busy && result && (
                   <img
-                    src={`data:${result.mimeType};base64,${result.data}`}
+                    src={result.objectUrl}
                     alt="Cleaned"
                     className="max-w-full max-h-[480px] object-contain"
                   />
@@ -261,7 +282,7 @@ export default function ImageClean() {
           <div className="flex flex-wrap gap-2">
             {result && (
               <a
-                href={`data:${result.mimeType};base64,${result.data}`}
+                href={result.objectUrl}
                 download={downloadName}
                 className="px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg transition-colors flex items-center gap-2"
               >

--- a/client/src/pages/ImageClean.jsx
+++ b/client/src/pages/ImageClean.jsx
@@ -23,6 +23,11 @@ export default function ImageClean() {
   const requestIdRef = useRef(0);
   const previewUrlRef = useRef(null);
   const resultUrlRef = useRef(null);
+  // Mirror `level` so handleFile can read the user's CURRENT choice after the
+  // readFileAsBase64 await — otherwise the closure captures the level at the
+  // moment the upload started and a mid-read level switch would be ignored.
+  const levelRef = useRef(level);
+  useEffect(() => { levelRef.current = level; }, [level]);
 
   // Revoke any outstanding blob URL on unmount so we don't leak.
   useEffect(() => () => {
@@ -115,7 +120,7 @@ export default function ImageClean() {
       size: file.size,
       name: file.name,
     });
-    runClean(base64, level);
+    runClean(base64, levelRef.current);
   };
 
   const handleLevelChange = (newLevel) => {

--- a/client/src/pages/ImageClean.jsx
+++ b/client/src/pages/ImageClean.jsx
@@ -71,7 +71,10 @@ export default function ImageClean() {
     setBusy(false);
     if (!objectUrl) return;
     resultUrlRef.current = objectUrl;
-    setResult({ ...cleaned, objectUrl });
+    // Drop `cleaned.data` (the full base64 payload) before storing — keeping it
+    // alongside the blob URL would double the in-memory image footprint.
+    const { data: _omit, ...meta } = cleaned;
+    setResult({ ...meta, objectUrl });
     toast.success(cleaned.c2paStripped ? 'C2PA provenance stripped' : 'Image cleaned');
   }, []);
 

--- a/client/src/pages/ImageClean.jsx
+++ b/client/src/pages/ImageClean.jsx
@@ -153,6 +153,9 @@ export default function ImageClean() {
       URL.revokeObjectURL(resultUrlRef.current);
       resultUrlRef.current = null;
     }
+    // Clear the input so picking the same file again still fires onChange
+    // (browsers suppress onChange when the value is unchanged).
+    if (fileInputRef.current) fileInputRef.current.value = '';
     setOriginal(null);
     setResult(null);
     setBusy(false);
@@ -224,7 +227,11 @@ export default function ImageClean() {
             ref={fileInputRef}
             type="file"
             accept="image/png,image/jpeg,image/webp"
-            onChange={(e) => handleFile(e.target.files?.[0])}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              e.target.value = '';
+              handleFile(file);
+            }}
             className="sr-only"
             tabIndex={-1}
             aria-hidden="true"

--- a/client/src/services/apiMedia.js
+++ b/client/src/services/apiMedia.js
@@ -25,8 +25,11 @@ export const getUploadUrl = (filename) => `/api/uploads/${encodeURIComponent(fil
 export const deleteUpload = (filename) => request(`/uploads/${encodeURIComponent(filename)}`, { method: 'DELETE' });
 export const deleteAllUploads = () => request('/uploads?confirm=true', { method: 'DELETE' });
 
-// Image Cleaner — strips C2PA provenance + median-filters AI-generated noise
+// Image Cleaner — strips C2PA provenance + median-filters AI-generated noise.
+// silent: true so the page can render its own error toast without duplicating
+// the one apiCore.request() fires by default.
 export const cleanImage = (base64Data, level = 'light') => request('/image-clean', {
   method: 'POST',
+  silent: true,
   body: JSON.stringify({ data: base64Data, level })
 });

--- a/client/src/services/apiMedia.js
+++ b/client/src/services/apiMedia.js
@@ -24,3 +24,9 @@ export const listUploads = () => request('/uploads');
 export const getUploadUrl = (filename) => `/api/uploads/${encodeURIComponent(filename)}`;
 export const deleteUpload = (filename) => request(`/uploads/${encodeURIComponent(filename)}`, { method: 'DELETE' });
 export const deleteAllUploads = () => request('/uploads?confirm=true', { method: 'DELETE' });
+
+// Image Cleaner — strips C2PA provenance + median-filters AI-generated noise
+export const cleanImage = (base64Data, level = 'light') => request('/image-clean', {
+  method: 'POST',
+  body: JSON.stringify({ data: base64Data, level })
+});

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "pm2:startup": "node ./node_modules/pm2/bin/pm2 startup",
     "install:all": "npm run setup",
     "migrations": "node scripts/run-migrations.js",
-    "setup": "git submodule update --init --recursive && npm install && npm install --prefix client && npm install --prefix server && npm install --prefix autofixer && node client/node_modules/esbuild/install.js && node server/node_modules/esbuild/install.js && npm rebuild node-pty --prefix server && node scripts/setup-data.js && node scripts/setup-db.js && node scripts/setup-browser.js",
+    "setup": "git submodule update --init --recursive && npm install && npm install --prefix client && npm install --prefix server && npm install --prefix autofixer && node client/node_modules/esbuild/install.js && node server/node_modules/esbuild/install.js && npm rebuild node-pty sharp --prefix server && node scripts/setup-data.js && node scripts/setup-db.js && node scripts/setup-browser.js",
     "setup:data": "node scripts/setup-data.js",
     "setup:db": "node scripts/setup-db.js",
     "setup:browser": "node scripts/setup-browser.js",

--- a/server/index.js
+++ b/server/index.js
@@ -25,6 +25,7 @@ import usageRoutes from './routes/usage.js';
 import screenshotsRoutes from './routes/screenshots.js';
 import attachmentsRoutes from './routes/attachments.js';
 import uploadsRoutes from './routes/uploads.js';
+import imageCleanRoutes from './routes/imageClean.js';
 import agentsRoutes from './routes/agents.js';
 import agentPersonalitiesRoutes from './routes/agentPersonalities.js';
 import platformAccountsRoutes from './routes/platformAccounts.js';
@@ -269,6 +270,7 @@ app.use('/api/attachments', attachmentsRoutes);
 app.use('/api/backup', backupRoutes);
 app.use('/api/database', databaseRoutes);
 app.use('/api/uploads', uploadsRoutes);
+app.use('/api/image-clean', imageCleanRoutes);
 // Agent Personalities feature routes (must be before /api/agents to avoid route conflicts)
 app.use('/api/agents/personalities', agentPersonalitiesRoutes);
 app.use('/api/agents/accounts', platformAccountsRoutes);

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -72,6 +72,7 @@ export const NAV_COMMANDS = [
   { id: 'nav.feature-agents', path: '/feature-agents', label: 'Feature Agents', section: 'Dev Tools', aliases: ['feature-agents'] },
   { id: 'nav.devtools.github', path: '/devtools/github', label: 'GitHub', section: 'Dev Tools', aliases: ['github', 'devtools-github'] },
   { id: 'nav.devtools.history', path: '/devtools/history', label: 'History', section: 'Dev Tools', aliases: ['devtools-history'] },
+  { id: 'nav.devtools.image-clean', path: '/devtools/image-clean', label: 'Image Cleaner', section: 'Dev Tools', aliases: ['image-clean', 'image-cleaner'], keywords: ['watermark', 'metadata', 'c2pa', 'sharp', 'denoise'] },
   { id: 'nav.devtools.jira', path: '/devtools/jira', label: 'JIRA', section: 'Dev Tools', aliases: ['jira', 'devtools-jira'] },
   { id: 'nav.devtools.jira-reports', path: '/devtools/jira/reports', label: 'JIRA Reports', section: 'Dev Tools', aliases: ['jira-reports'] },
   { id: 'nav.shell', path: '/shell', label: 'Shell', section: 'Dev Tools', aliases: ['shell', 'terminal'] },

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
     "pm2": "5.4.3",
     "portos-ai-toolkit": "0.8.3",
     "sax": "1.4.4",
-    "sharp": "^0.34.5",
+    "sharp": "0.34.5",
     "socket.io": "4.8.3",
     "socket.io-client": "4.8.3",
     "ws": "8.18.0",

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
     "pm2": "5.4.3",
     "portos-ai-toolkit": "0.8.3",
     "sax": "1.4.4",
+    "sharp": "^0.34.5",
     "socket.io": "4.8.3",
     "socket.io-client": "4.8.3",
     "ws": "8.18.0",

--- a/server/routes/imageClean.js
+++ b/server/routes/imageClean.js
@@ -9,7 +9,12 @@ import { validateRequest } from '../lib/validation.js';
 
 const router = Router();
 
-const MAX_INPUT_BYTES = 50 * 1024 * 1024;
+// 40MB decoded ⇒ ~53.3MB base64 + small JSON overhead, fits under the 55mb
+// global body parser limit in server/index.js. Keep these aligned — raising
+// the decoded cap requires raising the body parser limit too.
+const MAX_INPUT_BYTES = 40 * 1024 * 1024;
+// Reject oversized payloads before allocating the decoded Buffer.
+const MAX_BASE64_CHARS = Math.ceil((MAX_INPUT_BYTES * 4) / 3) + 4;
 
 export const CLEAN_LEVELS = ['light', 'aggressive'];
 
@@ -58,13 +63,12 @@ const MIME_TYPES = {
   webp: 'image/webp',
 };
 
-function buildPipeline(buffer, format, level) {
-  let pipeline = sharp(buffer);
-  if (level === 'light') {
-    pipeline = pipeline.median(1);
-  } else {
-    pipeline = pipeline.median(3).sharpen();
-  }
+function applyDenoise(pipeline, level) {
+  if (level === 'light') return pipeline.median(1);
+  return pipeline.median(3).sharpen();
+}
+
+function applyEncoder(pipeline, format) {
   if (format === 'png') return pipeline.png({ compressionLevel: 9 });
   if (format === 'jpeg') return pipeline.jpeg({ quality: 92, mozjpeg: true });
   return pipeline.webp({ quality: 92 });
@@ -72,6 +76,15 @@ function buildPipeline(buffer, format, level) {
 
 router.post('/', asyncHandler(async (req, res) => {
   const { data, level } = validateRequest(cleanBodySchema, req.body);
+
+  // Cap by base64 length BEFORE allocating the decoded Buffer so an oversized
+  // payload doesn't briefly balloon RSS.
+  if (data.length > MAX_BASE64_CHARS) {
+    throw new ServerError(`Image exceeds ${MAX_INPUT_BYTES / 1024 / 1024}MB limit`, {
+      status: 400,
+      code: 'FILE_TOO_LARGE',
+    });
+  }
 
   const buffer = Buffer.from(data, 'base64');
   if (buffer.length === 0) {
@@ -94,9 +107,12 @@ router.post('/', asyncHandler(async (req, res) => {
 
   const c2paStripped = format === 'png' && pngHasC2PA(buffer);
 
+  // Single sharp instance, .clone()-ed so metadata + transform share one decode
+  // instead of decoding the buffer twice.
+  const base = sharp(buffer);
   const [meta, cleaned] = await Promise.all([
-    sharp(buffer).metadata(),
-    buildPipeline(buffer, format, level).toBuffer(),
+    base.clone().metadata(),
+    applyEncoder(applyDenoise(base.clone(), level), format).toBuffer(),
   ]);
 
   console.log(`🧼 Image cleaned: ${format} ${buffer.length}B → ${cleaned.length}B (level=${level}, c2pa=${c2paStripped})`);

--- a/server/routes/imageClean.js
+++ b/server/routes/imageClean.js
@@ -109,11 +109,22 @@ router.post('/', asyncHandler(async (req, res) => {
 
   // Single sharp instance, .clone()-ed so metadata + transform share one decode
   // instead of decoding the buffer twice.
+  // Wrap sharp errors (truncated/corrupt buffer that still passed the magic-byte
+  // sniff) into a 400 so bad client input doesn't surface as a 500.
   const base = sharp(buffer);
-  const [meta, cleaned] = await Promise.all([
-    base.clone().metadata(),
-    applyEncoder(applyDenoise(base.clone(), level), format).toBuffer(),
-  ]);
+  let meta;
+  let cleaned;
+  try {
+    [meta, cleaned] = await Promise.all([
+      base.clone().metadata(),
+      applyEncoder(applyDenoise(base.clone(), level), format).toBuffer(),
+    ]);
+  } catch (err) {
+    throw new ServerError(`Failed to decode ${format} image: ${err.message}`, {
+      status: 400,
+      code: 'INVALID_IMAGE',
+    });
+  }
 
   console.log(`🧼 Image cleaned: ${format} ${buffer.length}B → ${cleaned.length}B (level=${level}, c2pa=${c2paStripped})`);
 

--- a/server/routes/imageClean.js
+++ b/server/routes/imageClean.js
@@ -133,7 +133,9 @@ router.post('/', asyncHandler(async (req, res) => {
   // sharp does not by default). resolveWithObject gives us output dimensions
   // (post-rotation), avoiding a second decode for metadata.
   // Wrap sharp errors (truncated/corrupt buffer that still passed the magic-byte
-  // sniff) into a 400 so bad client input doesn't surface as a 500.
+  // sniff) into a 400 so bad client input doesn't surface as a 500. Log the
+  // underlying libvips message server-side but return a stable, sanitized
+  // message to the client so internal details don't leak in API responses.
   const base = sharp(buffer, { limitInputPixels: MAX_PIXELS }).rotate();
   let cleaned;
   let info;
@@ -141,7 +143,8 @@ router.post('/', asyncHandler(async (req, res) => {
     ({ data: cleaned, info } = await applyEncoder(applyDenoise(base, level), format)
       .toBuffer({ resolveWithObject: true }));
   } catch (err) {
-    throw new ServerError(`Failed to decode ${format} image: ${err.message}`, {
+    console.error(`❌ image-clean decode failed (${format}): ${err.message}`);
+    throw new ServerError('Invalid or corrupt image', {
       status: 400,
       code: 'INVALID_IMAGE',
     });

--- a/server/routes/imageClean.js
+++ b/server/routes/imageClean.js
@@ -58,14 +58,22 @@ function isPngChunkType(buf, offset) {
   return true;
 }
 
+// Real PNGs have well under 50 chunks. Cap the walk so a buffer crafted with
+// the PNG signature followed by many tiny ASCII-typed zero-length chunks can't
+// force millions of iterations at the 40MiB input limit.
+const MAX_PNG_CHUNKS = 10000;
+
 // Walks PNG chunks once for the `caBX` provenance chunk emitted by gpt-image-1.
 // Sharp's default re-encode drops it; we detect it explicitly so the response
-// can flag what was stripped. Bails on invalid chunk type or truncated chunk —
-// a buffer that only matches the PNG signature but is otherwise garbage could
-// otherwise trigger millions of loop iterations (CPU/event-loop DoS).
+// can flag what was stripped. Bails on invalid chunk type, truncated chunk, or
+// chunk-count overrun — a buffer that only matches the PNG signature but is
+// otherwise garbage could otherwise trigger millions of loop iterations
+// (CPU/event-loop DoS).
 function pngHasC2PA(buf) {
   let offset = 8;
+  let count = 0;
   while (offset + 8 <= buf.length) {
+    if (++count > MAX_PNG_CHUNKS) return false;
     if (!isPngChunkType(buf, offset + 4)) return false;
     const length = buf.readUInt32BE(offset);
     if (offset + 8 + length + 4 > buf.length) return false;
@@ -133,9 +141,11 @@ router.post('/', asyncHandler(async (req, res) => {
   // sharp does not by default). resolveWithObject gives us output dimensions
   // (post-rotation), avoiding a second decode for metadata.
   // Wrap sharp errors (truncated/corrupt buffer that still passed the magic-byte
-  // sniff) into a 400 so bad client input doesn't surface as a 500. Log the
-  // underlying libvips message server-side but return a stable, sanitized
-  // message to the client so internal details don't leak in API responses.
+  // sniff) into a 400 so bad client input doesn't surface as a 500. Pass the
+  // libvips reason through context.details so asyncHandler logs it once
+  // (instead of an extra console.error duplicating its own log line) — the
+  // sanitized client-facing message stays generic so libvips internals don't
+  // leak in the API response or socket broadcast.
   const base = sharp(buffer, { limitInputPixels: MAX_PIXELS }).rotate();
   let cleaned;
   let info;
@@ -143,10 +153,10 @@ router.post('/', asyncHandler(async (req, res) => {
     ({ data: cleaned, info } = await applyEncoder(applyDenoise(base, level), format)
       .toBuffer({ resolveWithObject: true }));
   } catch (err) {
-    console.error(`❌ image-clean decode failed (${format}): ${err.message}`);
     throw new ServerError('Invalid or corrupt image', {
       status: 400,
       code: 'INVALID_IMAGE',
+      context: { details: { format, reason: err.message } },
     });
   }
 

--- a/server/routes/imageClean.js
+++ b/server/routes/imageClean.js
@@ -47,13 +47,28 @@ function detectFormat(buf) {
   return null;
 }
 
+// PNG chunk type bytes must be ASCII letters per the PNG spec (RFC 2083 §3.2).
+// Validating this lets us bail out of the walker on garbage payloads that
+// happen to start with the PNG signature, instead of looping millions of times.
+function isPngChunkType(buf, offset) {
+  for (let i = 0; i < 4; i++) {
+    const b = buf[offset + i];
+    if (!((b >= 0x41 && b <= 0x5a) || (b >= 0x61 && b <= 0x7a))) return false;
+  }
+  return true;
+}
+
 // Walks PNG chunks once for the `caBX` provenance chunk emitted by gpt-image-1.
 // Sharp's default re-encode drops it; we detect it explicitly so the response
-// can flag what was stripped.
+// can flag what was stripped. Bails on invalid chunk type or truncated chunk —
+// a buffer that only matches the PNG signature but is otherwise garbage could
+// otherwise trigger millions of loop iterations (CPU/event-loop DoS).
 function pngHasC2PA(buf) {
   let offset = 8;
   while (offset + 8 <= buf.length) {
+    if (!isPngChunkType(buf, offset + 4)) return false;
     const length = buf.readUInt32BE(offset);
+    if (offset + 8 + length + 4 > buf.length) return false;
     const type = buf.toString('ascii', offset + 4, offset + 8);
     if (type === 'caBX') return true;
     if (type === 'IEND') return false;

--- a/server/routes/imageClean.js
+++ b/server/routes/imageClean.js
@@ -9,12 +9,17 @@ import { validateRequest } from '../lib/validation.js';
 
 const router = Router();
 
-// 40MB decoded ⇒ ~53.3MB base64 + small JSON overhead, fits under the 55mb
-// global body parser limit in server/index.js. Keep these aligned — raising
-// the decoded cap requires raising the body parser limit too.
+// All sizes here are MiB (1024*1024). 40 MiB decoded → ~53.3 MiB base64 (4*ceil(n/3))
+// + small JSON envelope, which fits under the 55mb (= 55 MiB) body parser limit
+// in server/index.js. Keep these aligned — raising the decoded cap requires
+// raising the body parser limit too.
 const MAX_INPUT_BYTES = 40 * 1024 * 1024;
 // Reject oversized payloads before allocating the decoded Buffer.
 const MAX_BASE64_CHARS = Math.ceil((MAX_INPUT_BYTES * 4) / 3) + 4;
+// Cap decoded pixel count to prevent decompression-bomb images: a small payload
+// can declare gigantic dimensions and OOM the process during sharp decode. ~96MP
+// covers reasonable photos (12000×8000) without allowing pathological inputs.
+const MAX_PIXELS = 96 * 1000 * 1000;
 
 export const CLEAN_LEVELS = ['light', 'aggressive'];
 
@@ -111,7 +116,7 @@ router.post('/', asyncHandler(async (req, res) => {
   // instead of decoding the buffer twice.
   // Wrap sharp errors (truncated/corrupt buffer that still passed the magic-byte
   // sniff) into a 400 so bad client input doesn't surface as a 500.
-  const base = sharp(buffer);
+  const base = sharp(buffer, { limitInputPixels: MAX_PIXELS });
   let meta;
   let cleaned;
   try {

--- a/server/routes/imageClean.js
+++ b/server/routes/imageClean.js
@@ -112,18 +112,19 @@ router.post('/', asyncHandler(async (req, res) => {
 
   const c2paStripped = format === 'png' && pngHasC2PA(buffer);
 
-  // Single sharp instance, .clone()-ed so metadata + transform share one decode
-  // instead of decoding the buffer twice.
+  // Single decode for both EXIF auto-orient + denoise/encode. .rotate() with no
+  // args applies the EXIF Orientation tag so the cleaned pixels match what the
+  // browser showed in the Before preview (browsers honor EXIF orientation but
+  // sharp does not by default). resolveWithObject gives us output dimensions
+  // (post-rotation), avoiding a second decode for metadata.
   // Wrap sharp errors (truncated/corrupt buffer that still passed the magic-byte
   // sniff) into a 400 so bad client input doesn't surface as a 500.
-  const base = sharp(buffer, { limitInputPixels: MAX_PIXELS });
-  let meta;
+  const base = sharp(buffer, { limitInputPixels: MAX_PIXELS }).rotate();
   let cleaned;
+  let info;
   try {
-    [meta, cleaned] = await Promise.all([
-      base.clone().metadata(),
-      applyEncoder(applyDenoise(base.clone(), level), format).toBuffer(),
-    ]);
+    ({ data: cleaned, info } = await applyEncoder(applyDenoise(base, level), format)
+      .toBuffer({ resolveWithObject: true }));
   } catch (err) {
     throw new ServerError(`Failed to decode ${format} image: ${err.message}`, {
       status: 400,
@@ -140,8 +141,8 @@ router.post('/', asyncHandler(async (req, res) => {
     level,
     sizeBefore: buffer.length,
     sizeAfter: cleaned.length,
-    width: meta.width || null,
-    height: meta.height || null,
+    width: info.width || null,
+    height: info.height || null,
     c2paStripped,
   });
 }));

--- a/server/routes/imageClean.js
+++ b/server/routes/imageClean.js
@@ -1,0 +1,117 @@
+// Mirrors void-private's CodexImagegenService.cleanImage — strips C2PA
+// provenance + median-filters pixel-level noise from gpt-image-1 output.
+
+import { Router } from 'express';
+import { z } from 'zod';
+import sharp from 'sharp';
+import { asyncHandler, ServerError } from '../lib/errorHandler.js';
+import { validateRequest } from '../lib/validation.js';
+
+const router = Router();
+
+const MAX_INPUT_BYTES = 50 * 1024 * 1024;
+
+export const CLEAN_LEVELS = ['light', 'aggressive'];
+
+const cleanBodySchema = z.object({
+  data: z.string().min(1, 'data is required (base64)'),
+  level: z.enum(CLEAN_LEVELS).optional().default('light'),
+});
+
+// Magic-byte sniff so we re-encode as the source format and emit the right
+// MIME type — extension/header is supplied by the client and not trustworthy.
+function detectFormat(buf) {
+  if (buf.length >= 8 &&
+      buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47 &&
+      buf[4] === 0x0d && buf[5] === 0x0a && buf[6] === 0x1a && buf[7] === 0x0a) {
+    return 'png';
+  }
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return 'jpeg';
+  }
+  if (buf.length >= 12 &&
+      buf[0] === 0x52 && buf[1] === 0x49 && buf[2] === 0x46 && buf[3] === 0x46 &&
+      buf[8] === 0x57 && buf[9] === 0x45 && buf[10] === 0x42 && buf[11] === 0x50) {
+    return 'webp';
+  }
+  return null;
+}
+
+// Walks PNG chunks once for the `caBX` provenance chunk emitted by gpt-image-1.
+// Sharp's default re-encode drops it; we detect it explicitly so the response
+// can flag what was stripped.
+function pngHasC2PA(buf) {
+  let offset = 8;
+  while (offset + 8 <= buf.length) {
+    const length = buf.readUInt32BE(offset);
+    const type = buf.toString('ascii', offset + 4, offset + 8);
+    if (type === 'caBX') return true;
+    if (type === 'IEND') return false;
+    offset += 8 + length + 4;
+  }
+  return false;
+}
+
+const MIME_TYPES = {
+  png: 'image/png',
+  jpeg: 'image/jpeg',
+  webp: 'image/webp',
+};
+
+function buildPipeline(buffer, format, level) {
+  let pipeline = sharp(buffer);
+  if (level === 'light') {
+    pipeline = pipeline.median(1);
+  } else {
+    pipeline = pipeline.median(3).sharpen();
+  }
+  if (format === 'png') return pipeline.png({ compressionLevel: 9 });
+  if (format === 'jpeg') return pipeline.jpeg({ quality: 92, mozjpeg: true });
+  return pipeline.webp({ quality: 92 });
+}
+
+router.post('/', asyncHandler(async (req, res) => {
+  const { data, level } = validateRequest(cleanBodySchema, req.body);
+
+  const buffer = Buffer.from(data, 'base64');
+  if (buffer.length === 0) {
+    throw new ServerError('Decoded payload is empty', { status: 400, code: 'VALIDATION_ERROR' });
+  }
+  if (buffer.length > MAX_INPUT_BYTES) {
+    throw new ServerError(`Image exceeds ${MAX_INPUT_BYTES / 1024 / 1024}MB limit`, {
+      status: 400,
+      code: 'FILE_TOO_LARGE',
+    });
+  }
+
+  const format = detectFormat(buffer);
+  if (!format) {
+    throw new ServerError('Unsupported image format (expected PNG, JPEG, or WebP)', {
+      status: 400,
+      code: 'UNSUPPORTED_FORMAT',
+    });
+  }
+
+  const c2paStripped = format === 'png' && pngHasC2PA(buffer);
+
+  const [meta, cleaned] = await Promise.all([
+    sharp(buffer).metadata(),
+    buildPipeline(buffer, format, level).toBuffer(),
+  ]);
+
+  console.log(`🧼 Image cleaned: ${format} ${buffer.length}B → ${cleaned.length}B (level=${level}, c2pa=${c2paStripped})`);
+
+  res.json({
+    data: cleaned.toString('base64'),
+    mimeType: MIME_TYPES[format],
+    format,
+    level,
+    sizeBefore: buffer.length,
+    sizeAfter: cleaned.length,
+    width: meta.width || null,
+    height: meta.height || null,
+    c2paStripped,
+  });
+}));
+
+export default router;

--- a/server/routes/imageClean.test.js
+++ b/server/routes/imageClean.test.js
@@ -113,8 +113,9 @@ describe('POST /api/image-clean', () => {
   });
 
   it('rejects oversized base64 payloads with FILE_TOO_LARGE before decoding', async () => {
-    // Sized to exceed the pre-decode cap (~53.3MB) but stay under the 55mb
-    // body parser ceiling so the route handler runs (not express's 413).
+    // Sized (in MiB) to exceed the pre-decode base64 cap (~53.3 MiB, derived
+    // from MAX_INPUT_BYTES = 40 MiB) but stay under the 55 MiB body parser
+    // ceiling so the route handler runs (not express's 413).
     const tooBig = 'A'.repeat(54 * 1024 * 1024);
     const res = await request(buildApp())
       .post('/api/image-clean')

--- a/server/routes/imageClean.test.js
+++ b/server/routes/imageClean.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import express from 'express';
+import sharp from 'sharp';
+import { request } from '../lib/testHelper.js';
+import { errorMiddleware } from '../lib/errorHandler.js';
+import imageCleanRoutes from './imageClean.js';
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json({ limit: '55mb' }));
+  app.use('/api/image-clean', imageCleanRoutes);
+  app.use(errorMiddleware);
+  return app;
+};
+
+let pngFixture;
+let jpegFixture;
+let webpFixture;
+let pngWithC2PA;
+
+beforeAll(async () => {
+  // 1×1 fixtures sized just large enough to round-trip through sharp.
+  const baseInput = {
+    create: { width: 4, height: 4, channels: 3, background: { r: 200, g: 100, b: 50 } },
+  };
+  pngFixture = await sharp(baseInput).png().toBuffer();
+  jpegFixture = await sharp(baseInput).jpeg().toBuffer();
+  webpFixture = await sharp(baseInput).webp().toBuffer();
+
+  // Synthesize a PNG with a `caBX` chunk inserted AFTER the IHDR chunk so the
+  // file remains a structurally valid PNG that sharp can still decode, but
+  // pngHasC2PA's walker has something to find.
+  // PNG layout: 8-byte signature, then IHDR (length=13 ⇒ 4+4+13+4 = 25 bytes).
+  const ihdrEnd = 8 + 25;
+  const cabxType = Buffer.from('caBX', 'ascii');
+  const cabxData = Buffer.from([0x01, 0x02, 0x03, 0x04]);
+  const cabxLen = Buffer.alloc(4);
+  cabxLen.writeUInt32BE(cabxData.length, 0);
+  const cabxCrc = Buffer.alloc(4); // CRC value not validated by walker or sharp's strict mode here
+  const cabxChunk = Buffer.concat([cabxLen, cabxType, cabxData, cabxCrc]);
+  pngWithC2PA = Buffer.concat([
+    pngFixture.slice(0, ihdrEnd),
+    cabxChunk,
+    pngFixture.slice(ihdrEnd),
+  ]);
+});
+
+describe('POST /api/image-clean', () => {
+  it('cleans a PNG and returns base64 + metadata', async () => {
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: pngFixture.toString('base64'), level: 'light' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.format).toBe('png');
+    expect(res.body.mimeType).toBe('image/png');
+    expect(res.body.level).toBe('light');
+    expect(res.body.width).toBe(4);
+    expect(res.body.height).toBe(4);
+    expect(res.body.c2paStripped).toBe(false);
+    expect(typeof res.body.data).toBe('string');
+    expect(res.body.data.length).toBeGreaterThan(0);
+  });
+
+  it('cleans a JPEG and emits a JPEG response', async () => {
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: jpegFixture.toString('base64') });
+
+    expect(res.status).toBe(200);
+    expect(res.body.format).toBe('jpeg');
+    expect(res.body.mimeType).toBe('image/jpeg');
+    expect(res.body.level).toBe('light'); // default
+  });
+
+  it('cleans a WebP', async () => {
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: webpFixture.toString('base64'), level: 'aggressive' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.format).toBe('webp');
+    expect(res.body.mimeType).toBe('image/webp');
+    expect(res.body.level).toBe('aggressive');
+  });
+
+  it('flags c2paStripped=true when PNG contains a caBX chunk', async () => {
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: pngWithC2PA.toString('base64') });
+
+    expect(res.status).toBe(200);
+    expect(res.body.c2paStripped).toBe(true);
+  });
+
+  it('rejects unsupported formats with UNSUPPORTED_FORMAT', async () => {
+    const garbage = Buffer.from('not an image at all').toString('base64');
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: garbage });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('UNSUPPORTED_FORMAT');
+  });
+
+  it('rejects empty payloads with VALIDATION_ERROR', async () => {
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: '' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('VALIDATION_ERROR');
+  });
+
+  it('rejects oversized base64 payloads with FILE_TOO_LARGE before decoding', async () => {
+    // Sized to exceed the pre-decode cap (~53.3MB) but stay under the 55mb
+    // body parser ceiling so the route handler runs (not express's 413).
+    const tooBig = 'A'.repeat(54 * 1024 * 1024);
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: tooBig });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('FILE_TOO_LARGE');
+  });
+
+  it('rejects invalid level enum with VALIDATION_ERROR', async () => {
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: pngFixture.toString('base64'), level: 'nuclear' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('VALIDATION_ERROR');
+  });
+});

--- a/server/routes/imageClean.test.js
+++ b/server/routes/imageClean.test.js
@@ -112,6 +112,30 @@ describe('POST /api/image-clean', () => {
     expect(elapsed).toBeLessThan(1000);
   });
 
+  it('caps the chunk walk so a PNG-sig buffer of zero-length ASCII-typed chunks bails fast', async () => {
+    // Adversarial input: valid PNG signature + many tiny chunks with valid
+    // ASCII chunk types (so isPngChunkType passes) but length=0. Without a
+    // chunk-count cap, the walker would iterate ~3.5M times for a 40MiB
+    // payload. With MAX_PNG_CHUNKS=10000, it bails after 10000 iterations.
+    const pngSig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const oneChunk = Buffer.concat([
+      Buffer.from([0x00, 0x00, 0x00, 0x00]), // length=0
+      Buffer.from('ABCD', 'ascii'),           // valid chunk type bytes
+      Buffer.from([0x00, 0x00, 0x00, 0x00]), // CRC (unchecked)
+    ]);
+    // 20000 chunks > MAX_PNG_CHUNKS=10000 — proves the cap fires.
+    const fake = Buffer.concat([pngSig, Buffer.concat(Array(20000).fill(oneChunk))]);
+    const start = Date.now();
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: fake.toString('base64') });
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_IMAGE');
+    expect(elapsed).toBeLessThan(1500);
+  });
+
   it('rejects unsupported formats with UNSUPPORTED_FORMAT', async () => {
     const garbage = Buffer.from('not an image at all').toString('base64');
     const res = await request(buildApp())

--- a/server/routes/imageClean.test.js
+++ b/server/routes/imageClean.test.js
@@ -19,7 +19,7 @@ let webpFixture;
 let pngWithC2PA;
 
 beforeAll(async () => {
-  // 1×1 fixtures sized just large enough to round-trip through sharp.
+  // 4×4 fixtures sized just large enough to round-trip through sharp.
   const baseInput = {
     create: { width: 4, height: 4, channels: 3, background: { r: 200, g: 100, b: 50 } },
   };

--- a/server/routes/imageClean.test.js
+++ b/server/routes/imageClean.test.js
@@ -93,6 +93,25 @@ describe('POST /api/image-clean', () => {
     expect(res.body.c2paStripped).toBe(true);
   });
 
+  it('bails on PNG-signature buffers with garbage chunk data instead of looping', async () => {
+    // PNG magic bytes followed by zero-filled garbage. Without an early bailout,
+    // pngHasC2PA would walk in 12-byte steps through ~40MiB of zeros (~3.3M
+    // iterations) before sharp's decode failure surfaces. This test asserts the
+    // request resolves quickly with INVALID_IMAGE rather than timing out.
+    const pngSig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    const garbage = Buffer.alloc(1024); // zeros — chunk type bytes will be 0x00
+    const fake = Buffer.concat([pngSig, garbage]);
+    const start = Date.now();
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: fake.toString('base64') });
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe('INVALID_IMAGE');
+    expect(elapsed).toBeLessThan(1000);
+  });
+
   it('rejects unsupported formats with UNSUPPORTED_FORMAT', async () => {
     const garbage = Buffer.from('not an image at all').toString('base64');
     const res = await request(buildApp())

--- a/server/routes/imageClean.test.js
+++ b/server/routes/imageClean.test.js
@@ -133,4 +133,25 @@ describe('POST /api/image-clean', () => {
     expect(res.status).toBe(400);
     expect(res.body.code).toBe('VALIDATION_ERROR');
   });
+
+  it('auto-orients images via EXIF Orientation tag', async () => {
+    // Build a 4×8 JPEG, then re-emit with EXIF Orientation=6 (rotate 90° CW)
+    // embedded via withMetadata. After the route's auto-orient, the output
+    // should be 8×4 — i.e., width/height swapped.
+    const raw = await sharp({
+      create: { width: 4, height: 8, channels: 3, background: { r: 100, g: 150, b: 200 } },
+    }).jpeg().toBuffer();
+    const oriented = await sharp(raw)
+      .withMetadata({ orientation: 6 })
+      .jpeg()
+      .toBuffer();
+
+    const res = await request(buildApp())
+      .post('/api/image-clean')
+      .send({ data: oriented.toString('base64') });
+
+    expect(res.status).toBe(200);
+    expect(res.body.width).toBe(8);
+    expect(res.body.height).toBe(4);
+  });
 });

--- a/setup.ps1
+++ b/setup.ps1
@@ -62,12 +62,12 @@ Pop-Location
 
 # Rebuild native bindings
 Write-Host ""
-Write-Host "Rebuilding esbuild & node-pty..." -ForegroundColor Yellow
+Write-Host "Rebuilding esbuild, node-pty & sharp..." -ForegroundColor Yellow
 node client/node_modules/esbuild/install.js
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 node server/node_modules/esbuild/install.js
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-npm rebuild node-pty --prefix server
+npm rebuild node-pty sharp --prefix server
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
 # Run data setup scripts

--- a/update.ps1
+++ b/update.ps1
@@ -172,12 +172,12 @@ Safe-Install -Dir "server" -Label "server"
 Safe-Install -Dir "autofixer" -Label "autofixer"
 
 # Run trusted install scripts skipped by ignore-scripts=true in .npmrc
-Write-SafeHost "🔧 Rebuilding esbuild & node-pty..." -ForegroundColor Yellow
+Write-SafeHost "🔧 Rebuilding esbuild, node-pty & sharp..." -ForegroundColor Yellow
 Invoke-Logged node client/node_modules/esbuild/install.js
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 Invoke-Logged node server/node_modules/esbuild/install.js
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-Invoke-Logged npm rebuild node-pty --prefix server
+Invoke-Logged npm rebuild node-pty sharp --prefix server
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 Write-SafeHost ""
 

--- a/update.sh
+++ b/update.sh
@@ -112,10 +112,10 @@ safe_install server
 safe_install autofixer
 
 # Run trusted install scripts skipped by ignore-scripts=true in .npmrc
-log "🔧 Rebuilding esbuild & node-pty..."
+log "🔧 Rebuilding esbuild, node-pty & sharp..."
 run node client/node_modules/esbuild/install.js
 run node server/node_modules/esbuild/install.js
-run npm rebuild node-pty --prefix server
+run npm rebuild node-pty sharp --prefix server
 log ""
 
 # Verify critical dependencies exist


### PR DESCRIPTION
## Summary

- New **`/devtools/image-clean`** page re-encodes PNG/JPEG/WebP images through `sharp` to drop C2PA provenance chunks (`caBX` in PNG) and median-filter pixel-level noise commonly emitted by `gpt-image-1` / Codex image output.
- New **`POST /api/image-clean`** route (Zod-validated, magic-byte format sniffed, 40 MiB decoded-input cap aligned with the 55 MB body parser limit) returns the cleaned image as base64 with `c2paStripped` flag, format, dimensions, and size delta.
- Wired into `server/lib/navManifest.js` so the page is reachable from `⌘K` and the voice agent's `ui_navigate` tool — alphabetical sidebar entry under Dev Tools.

## Why

Pixels generated by `gpt-image-1` carry C2PA provenance metadata and a faint AI-detector signature. When reusing those images in private projects, both should go. This consolidates the cleanup behind a click-and-drag UI rather than ad-hoc `sharp` invocations.

## Implementation notes

- Magic-byte format sniff (`detectFormat`) — the request's MIME and filename extension are not trusted; a JPEG sent as `.png` is still re-encoded as JPEG.
- C2PA detection only walks PNG chunks (the format `gpt-image-1` emits); JPEG/WebP just get re-encoded. The walker is bounds-checked to handle truncated payloads.
- Levels: `light` = `median(1)`, `aggressive` = `median(3) + sharpen()`. PNG re-emits at compression level 9; JPEG at q92 with `mozjpeg`; WebP at q92.
- Size cap is 40 MiB decoded input (~53 MiB base64) — sized to fit under the global 55 MB express.json body limit. Server enforces both a pre-decode `MAX_BASE64_CHARS` check and a post-decode `MAX_INPUT_BYTES` check; client `MAX_BYTES` matches.
- Single sharp instance shared between metadata and transform via `.clone()` so the buffer is decoded once.
- Client uses a request-id ref to drop stale `runClean` responses if the user re-clicks a level mid-flight; before/after previews use blob URLs (revoked on reset/unmount) instead of inline base64 data URIs.
- `sharp` was already a transitive dep via `portos-ai-toolkit`; this PR promotes it to a direct dep, pinned to `0.34.5` to match the package's exact-version convention.

## Test plan

- [x] `cd server && npm test` — 152 files / 3,335 tests pass (includes new `routes/imageClean.test.js` with 8 cases)
- [x] Nav manifest shape invariants + alias resolution still pass
- [ ] Drag-drop a `gpt-image-1` PNG → confirm "C2PA: Stripped" badge
- [ ] Drag-drop a JPEG → confirm "C2PA: None found" and re-encoded output
- [ ] Switch level (light ↔ aggressive) on an already-uploaded image → confirm spinner + new result
- [ ] `⌘K` → "image" → confirm `Image Cleaner` appears in palette
- [ ] Mobile viewport (≤640px) — before/after stack vertically, action buttons wrap

🤖 Generated with [Claude Code](https://claude.com/claude-code)