### PR TITLE
fix(cos): detect remote default branch instead of assuming main

### DIFF
--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -151,7 +151,8 @@ router.post('/branch-comparison', asyncHandler(async (req, res) => {
     throw new ServerError('path is required', { status: 400, code: 'VALIDATION_ERROR' });
   }
 
-  const result = await git.getBranchComparison(path, base || 'main', head || 'dev');
+  const baseBranch = base || await git.getDefaultBranch(path).catch(() => null) || 'main';
+  const result = await git.getBranchComparison(path, baseBranch, head || 'dev');
   res.json(result);
 }));
 

--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -151,7 +151,7 @@ router.post('/branch-comparison', asyncHandler(async (req, res) => {
     throw new ServerError('path is required', { status: 400, code: 'VALIDATION_ERROR' });
   }
 
-  const baseBranch = base || await git.getDefaultBranch(path).catch(() => null) || 'main';
+  const baseBranch = base || await git.getDefaultBranch(path, { allowRemote: false }).catch(() => null) || 'main';
   const result = await git.getBranchComparison(path, baseBranch, head || 'dev');
   res.json(result);
 }));

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -1156,7 +1156,7 @@ export async function cleanupAgentWorktree(agentId, success, { openPR = false, r
     if (pushResult) {
       const targetBranch = branchInfo.baseBranch || 'main';
       const taskDesc = description || 'CoS automated task';
-      const prTitle = taskDesc.replace(/[\r\n]+/g, ' ').trim().substring(0, 100);
+      const prTitle = taskDesc.split(/[\r\n]/)[0].trim().substring(0, 100);
 
       const prBody = await git.generatePRDescription(worktreePath, targetBranch, worktreeBranch, agentOutput);
 
@@ -1265,15 +1265,16 @@ export async function spawnMergeRecoveryTask(cleanupWarnings, agentId, task, app
   const appId = task?.metadata?.app;
 
   if (isMergeFail) {
+    const defaultBr = await git.getDefaultBranch(sourceWorkspace).catch(() => null) || 'main';
     addTask({
       description: `${RECOVERY_TASK_PREFIX} Resolve merge conflict and clean up stale branch ${staleBranch} in ${appName}`,
       priority: 'HIGH',
       app: appId,
       isRecovery: true,
-      context: `An agent failed to auto-merge branch "${staleBranch}" back to main in ${sourceWorkspace}. `
-        + `Resolve this by: (1) checking if the branch's changes are already on main (superseded by other commits), `
+      context: `An agent failed to auto-merge branch "${staleBranch}" back to ${defaultBr} in ${sourceWorkspace}. `
+        + `Resolve this by: (1) checking if the branch's changes are already on ${defaultBr} (superseded by other commits), `
         + `and if so, delete the branch with "git branch -D ${staleBranch}"; `
-        + `(2) if the changes are NOT on main, attempt "git merge ${staleBranch} --no-edit" from main, resolve any conflicts, and commit; `
+        + `(2) if the changes are NOT on ${defaultBr}, attempt "git merge ${staleBranch} --no-edit" from ${defaultBr}, resolve any conflicts, and commit; `
         + `(3) after merging or determining the branch is stale, delete it with "git branch -D ${staleBranch}". `
         + `Original agent: ${agentId}, original task: ${task?.description || 'unknown'}.`,
       useWorktree: false,
@@ -1285,15 +1286,19 @@ export async function spawnMergeRecoveryTask(cleanupWarnings, agentId, task, app
     // PR/MR creation failed — spawn an agent to investigate and retry. Pick gh vs
     // glab based on the repo's forge so the recovery agent gets commands that
     // actually work against this remote.
-    const { cli } = await git.resolveForgeForRepo(sourceWorkspace).catch(() => ({ cli: 'gh' }));
+    const [{ cli }, detectedBase] = await Promise.all([
+      git.resolveForgeForRepo(sourceWorkspace).catch(() => ({ cli: 'gh' })),
+      git.getDefaultBranch(sourceWorkspace).catch(() => null)
+    ]);
+    const targetBase = detectedBase || 'main';
     const isGitLab = cli === 'glab';
     const reqWord = isGitLab ? 'MR' : 'PR';
     const listCmd = isGitLab
       ? `glab mr list --source-branch ${staleBranch}`
       : `gh pr list --head ${staleBranch}`;
     const createCmd = isGitLab
-      ? `glab mr create --source-branch ${staleBranch} --target-branch main --title '...' --description '...'`
-      : `gh pr create --head ${staleBranch} --base main --title '...' --body '...'`;
+      ? `glab mr create --source-branch ${staleBranch} --target-branch ${targetBase} --title '...' --description '...'`
+      : `gh pr create --head ${staleBranch} --base ${targetBase} --title '...' --body '...'`;
 
     addTask({
       description: `${RECOVERY_TASK_PREFIX} Investigate and retry failed ${reqWord} for branch ${staleBranch} in ${appName}`,

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -1156,7 +1156,8 @@ export async function cleanupAgentWorktree(agentId, success, { openPR = false, r
     if (pushResult) {
       const targetBranch = branchInfo.baseBranch || 'main';
       const taskDesc = description || 'CoS automated task';
-      const prTitle = taskDesc.split(/[\r\n]/)[0].trim().substring(0, 100);
+      const firstLine = taskDesc.split(/[\r\n]/).find(l => l.trim()) || taskDesc;
+      const prTitle = firstLine.trim().substring(0, 100) || 'CoS automated task';
 
       const prBody = await git.generatePRDescription(worktreePath, targetBranch, worktreeBranch, agentOutput);
 

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -1154,7 +1154,10 @@ export async function cleanupAgentWorktree(agentId, success, { openPR = false, r
     ]);
 
     if (pushResult) {
-      const targetBranch = branchInfo.baseBranch || 'main';
+      let targetBranch = branchInfo.baseBranch;
+      if (!targetBranch) {
+        targetBranch = await git.getDefaultBranch(sourceWorkspace, { allowRemote: false }).catch(() => null) || 'main';
+      }
       const taskDesc = description || 'CoS automated task';
       const firstLine = taskDesc.split(/[\r\n]/).find(l => l.trim()) || taskDesc;
       const prTitle = firstLine.trim().substring(0, 100) || 'CoS automated task';

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -1308,7 +1308,7 @@ export async function spawnMergeRecoveryTask(cleanupWarnings, agentId, task, app
       context: `An agent pushed branch "${staleBranch}" to ${sourceWorkspace} but automated ${reqWord} creation failed. `
         + `Investigate by: (1) checking if a ${reqWord} already exists for this branch: "${listCmd}"; `
         + `(2) if no ${reqWord} exists, review the branch changes and create one: "${createCmd}"; `
-        + `(3) if the branch is stale or changes are already on main, delete the remote branch: "git push origin --delete ${staleBranch}". `
+        + `(3) if the branch is stale or changes are already on ${targetBase}, delete the remote branch: "git push origin --delete ${staleBranch}". `
         + `Original agent: ${agentId}, original task: ${task?.description || 'unknown'}.`,
       useWorktree: false,
     }, 'user').catch(err => {

--- a/server/services/cleanupAgentWorktree.test.js
+++ b/server/services/cleanupAgentWorktree.test.js
@@ -156,6 +156,7 @@ vi.mock('./jira.js', () => ({
 vi.mock('./git.js', () => ({
   push: vi.fn(),
   getRepoBranches: vi.fn(),
+  getDefaultBranch: vi.fn().mockResolvedValue('main'),
   createPR: vi.fn(),
   generatePRDescription: vi.fn(),
   deleteBranch: vi.fn().mockResolvedValue(undefined),
@@ -334,6 +335,18 @@ describe('cleanupAgentWorktree - openPR path', () => {
 
     expect(git.createPR).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
       title: 'A'.repeat(100)
+    }));
+  });
+
+  it('should use only first line of multiline description for PR title', async () => {
+    const multilineDesc = '[Improvement: grace] Error Handling\n\nAnalyze the codebase:\n\nRepository: /Users/foo/grace';
+    git.push.mockResolvedValue(undefined);
+    git.createPR.mockResolvedValue({ success: true, url: 'https://github.com/test/repo/pull/7' });
+
+    await cleanupAgentWorktree('agent-1', true, { openPR: true, description: multilineDesc });
+
+    expect(git.createPR).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({
+      title: '[Improvement: grace] Error Handling'
     }));
   });
 

--- a/server/services/getDefaultBranch.test.js
+++ b/server/services/getDefaultBranch.test.js
@@ -24,6 +24,9 @@ describe('getDefaultBranch', () => {
       if (args[0] === 'symbolic-ref' && args.includes('refs/remotes/origin/HEAD')) {
         return Promise.resolve({ stdout: 'origin/main', stderr: '', exitCode: 0 });
       }
+      if (args[0] === 'rev-parse' && args.includes('--verify')) {
+        return Promise.resolve({ stdout: 'abc123', stderr: '', exitCode: 0 });
+      }
       return Promise.reject(new Error('unexpected'));
     });
 
@@ -35,6 +38,9 @@ describe('getDefaultBranch', () => {
     execGit.mockImplementation((args) => {
       if (args[0] === 'symbolic-ref') {
         return Promise.resolve({ stdout: 'origin/develop', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'rev-parse' && args.includes('--verify')) {
+        return Promise.resolve({ stdout: 'abc123', stderr: '', exitCode: 0 });
       }
       return Promise.reject(new Error('unexpected'));
     });

--- a/server/services/getDefaultBranch.test.js
+++ b/server/services/getDefaultBranch.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../lib/execGit.js', () => ({
+  execGit: vi.fn()
+}));
+
+describe('getDefaultBranch', () => {
+  let getDefaultBranch;
+  let execGit;
+
+  beforeEach(async () => {
+    const execGitModule = await import('../lib/execGit.js');
+    execGit = execGitModule.execGit;
+    const gitModule = await import('./git.js');
+    getDefaultBranch = gitModule.getDefaultBranch;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns branch from origin/HEAD when available', async () => {
+    execGit.mockImplementation((args) => {
+      if (args[0] === 'symbolic-ref' && args.includes('refs/remotes/origin/HEAD')) {
+        return Promise.resolve({ stdout: 'origin/main', stderr: '', exitCode: 0 });
+      }
+      return Promise.reject(new Error('unexpected'));
+    });
+
+    const result = await getDefaultBranch('/fake/dir');
+    expect(result).toBe('main');
+  });
+
+  it('strips origin/ prefix from various branch names', async () => {
+    execGit.mockImplementation((args) => {
+      if (args[0] === 'symbolic-ref') {
+        return Promise.resolve({ stdout: 'origin/develop', stderr: '', exitCode: 0 });
+      }
+      return Promise.reject(new Error('unexpected'));
+    });
+
+    const result = await getDefaultBranch('/fake/dir');
+    expect(result).toBe('develop');
+  });
+
+  it('skips remote detection when allowRemote=false', async () => {
+    const calls = [];
+    execGit.mockImplementation((args) => {
+      calls.push(args.join(' '));
+      if (args[0] === 'symbolic-ref') {
+        return Promise.reject(new Error('not set'));
+      }
+      if (args[0] === 'branch') {
+        return Promise.resolve({ stdout: '  main\n  dev\n', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'rev-parse') {
+        return Promise.resolve({ stdout: 'main', stderr: '', exitCode: 0 });
+      }
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+    });
+
+    const result = await getDefaultBranch('/fake/dir', { allowRemote: false });
+    expect(result).toBe('main');
+    expect(calls.some(c => c.includes('set-head'))).toBe(false);
+  });
+
+  it('attempts remote set-head when allowRemote=true and origin/HEAD unset', async () => {
+    const calls = [];
+    execGit.mockImplementation((args) => {
+      calls.push(args.join(' '));
+      if (args[0] === 'symbolic-ref') {
+        // First call fails, second succeeds after set-head
+        if (calls.filter(c => c.startsWith('symbolic-ref')).length === 1) {
+          return Promise.reject(new Error('not set'));
+        }
+        return Promise.resolve({ stdout: 'origin/main', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'remote' && args.includes('set-head')) {
+        return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+      }
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+    });
+
+    const result = await getDefaultBranch('/fake/dir', { allowRemote: true });
+    expect(result).toBe('main');
+    expect(calls.some(c => c.includes('set-head'))).toBe(true);
+  });
+
+  it('falls back to master when main not in branch list', async () => {
+    execGit.mockImplementation((args) => {
+      if (args[0] === 'symbolic-ref') {
+        return Promise.reject(new Error('not set'));
+      }
+      if (args[0] === 'branch') {
+        return Promise.resolve({ stdout: '  master\n  feature/x\n', stderr: '', exitCode: 0 });
+      }
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+    });
+
+    const result = await getDefaultBranch('/fake/dir', { allowRemote: false });
+    expect(result).toBe('master');
+  });
+
+  it('falls back to current HEAD when no standard branches exist', async () => {
+    execGit.mockImplementation((args) => {
+      if (args[0] === 'symbolic-ref') {
+        return Promise.reject(new Error('not set'));
+      }
+      if (args[0] === 'branch') {
+        return Promise.resolve({ stdout: '  develop\n  feature/x\n', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'rev-parse' && args.includes('--abbrev-ref')) {
+        return Promise.resolve({ stdout: 'develop', stderr: '', exitCode: 0 });
+      }
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+    });
+
+    const result = await getDefaultBranch('/fake/dir', { allowRemote: false });
+    expect(result).toBe('develop');
+  });
+
+  it('returns null when all detection methods fail', async () => {
+    execGit.mockImplementation((args) => {
+      if (args[0] === 'symbolic-ref') {
+        return Promise.reject(new Error('not set'));
+      }
+      if (args[0] === 'branch') {
+        return Promise.resolve({ stdout: '  feature/x\n  feature/y\n', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'rev-parse') {
+        return Promise.resolve({ stdout: 'HEAD', stderr: '', exitCode: 0 });
+      }
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+    });
+
+    const result = await getDefaultBranch('/fake/dir', { allowRemote: false });
+    expect(result).toBeNull();
+  });
+});

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -722,11 +722,19 @@ export async function getDefaultBranch(dir, { allowRemote = true } = {}) {
 export async function getRepoBranches(dir) {
   // Check origin/HEAD first (fast, local-only)
   const symRef = await execGitSafe(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], dir);
-  let baseBranch = symRef.stdout?.trim() ? symRef.stdout.trim().replace(/^origin\//, '') : null;
+  let baseBranch = null;
+  if (symRef.stdout?.trim()) {
+    const candidate = symRef.stdout.trim().replace(/^origin\//, '');
+    // Verify the ref actually exists (origin/HEAD could be stale)
+    const verify = await execGitSafe(['rev-parse', '--verify', `refs/remotes/origin/${candidate}`], dir);
+    if (verify.exitCode === 0 || verify.stdout?.trim()) {
+      baseBranch = candidate;
+    }
+  }
 
   // Get local branches once — reused for both base fallback and dev detection
-  const result = await execGit(['branch', '--list'], dir, { ignoreExitCode: true });
-  const branches = result.stdout.trim().split('\n').map(b => b.replace(/^\*?\s+/, ''));
+  const result = await execGitSafe(['branch', '--list'], dir);
+  const branches = (result.stdout || '').trim().split('\n').map(b => b.replace(/^\*?\s+/, '')).filter(Boolean);
 
   if (!baseBranch) {
     if (branches.includes('main')) baseBranch = 'main';

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -681,7 +681,10 @@ export function extractAgentSummary(output) {
 export async function getDefaultBranch(dir, { allowRemote = true } = {}) {
   const symRef = await execGitSafe(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], dir);
   if (symRef.stdout?.trim()) {
-    return symRef.stdout.trim().replace(/^origin\//, '');
+    const branch = symRef.stdout.trim().replace(/^origin\//, '');
+    // Verify the ref actually exists (origin/HEAD could be stale)
+    const verify = await execGitSafe(['rev-parse', '--verify', `refs/remotes/origin/${branch}`], dir);
+    if (verify.exitCode === 0 || verify.stdout?.trim()) return branch;
   }
 
   // origin/HEAD not set locally — ask the remote (best-effort, short timeout)
@@ -689,7 +692,9 @@ export async function getDefaultBranch(dir, { allowRemote = true } = {}) {
     await execGitSafe(['remote', 'set-head', 'origin', '--auto'], dir, { timeout: 5000 });
     const symRef2 = await execGitSafe(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], dir);
     if (symRef2.stdout?.trim()) {
-      return symRef2.stdout.trim().replace(/^origin\//, '');
+      const branch2 = symRef2.stdout.trim().replace(/^origin\//, '');
+      const verify2 = await execGitSafe(['rev-parse', '--verify', `refs/remotes/origin/${branch2}`], dir);
+      if (verify2.exitCode === 0 || verify2.stdout?.trim()) return branch2;
     }
   }
 

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -678,15 +678,37 @@ export function extractAgentSummary(output) {
   return summary;
 }
 
+export async function getDefaultBranch(dir) {
+  const symRef = await execGitSafe(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], dir);
+  if (symRef.stdout?.trim()) {
+    return symRef.stdout.trim().replace(/^origin\//, '');
+  }
+
+  // origin/HEAD not set locally — ask the remote
+  await execGitSafe(['remote', 'set-head', 'origin', '--auto'], dir);
+  const symRef2 = await execGitSafe(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], dir);
+  if (symRef2.stdout?.trim()) {
+    return symRef2.stdout.trim().replace(/^origin\//, '');
+  }
+
+  const result = await execGit(['branch', '--list'], dir, { ignoreExitCode: true });
+  const branches = result.stdout.trim().split('\n').map(b => b.replace(/^\*?\s+/, ''));
+  if (branches.includes('main')) return 'main';
+  if (branches.includes('master')) return 'master';
+
+  return null;
+}
+
 /**
  * Detect base and dev branches from local branch list
  * @returns {{ baseBranch: string|null, devBranch: string|null }}
  */
 export async function getRepoBranches(dir) {
+  const baseBranch = await getDefaultBranch(dir);
   const result = await execGit(['branch', '--list'], dir, { ignoreExitCode: true });
   const branches = result.stdout.trim().split('\n').map(b => b.replace(/^\*?\s+/, ''));
   return {
-    baseBranch: branches.includes('main') ? 'main' : branches.includes('master') ? 'master' : null,
+    baseBranch,
     devBranch: branches.includes('dev') ? 'dev' : branches.includes('develop') ? 'develop' : null
   };
 }

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -711,12 +711,23 @@ export async function getDefaultBranch(dir, { allowRemote = true } = {}) {
 /**
  * Detect base and dev branches from local refs (origin/HEAD, local branch list).
  * Does not contact the remote — safe for latency-sensitive request paths.
+ * Computes the branch list once and reuses it for both base and dev detection.
  * @returns {{ baseBranch: string|null, devBranch: string|null }}
  */
 export async function getRepoBranches(dir) {
-  const baseBranch = await getDefaultBranch(dir, { allowRemote: false });
+  // Check origin/HEAD first (fast, local-only)
+  const symRef = await execGitSafe(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], dir);
+  let baseBranch = symRef.stdout?.trim() ? symRef.stdout.trim().replace(/^origin\//, '') : null;
+
+  // Get local branches once — reused for both base fallback and dev detection
   const result = await execGit(['branch', '--list'], dir, { ignoreExitCode: true });
   const branches = result.stdout.trim().split('\n').map(b => b.replace(/^\*?\s+/, ''));
+
+  if (!baseBranch) {
+    if (branches.includes('main')) baseBranch = 'main';
+    else if (branches.includes('master')) baseBranch = 'master';
+  }
+
   return {
     baseBranch,
     devBranch: branches.includes('dev') ? 'dev' : branches.includes('develop') ? 'develop' : null

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -709,12 +709,12 @@ export async function getDefaultBranch(dir, { allowRemote = true } = {}) {
 }
 
 /**
- * Detect base and dev branches via origin/HEAD (with remote auto-detection fallback)
- * and local branch list. May contact the remote if origin/HEAD is unset.
+ * Detect base and dev branches from local refs (origin/HEAD, local branch list).
+ * Does not contact the remote — safe for latency-sensitive request paths.
  * @returns {{ baseBranch: string|null, devBranch: string|null }}
  */
 export async function getRepoBranches(dir) {
-  const baseBranch = await getDefaultBranch(dir);
+  const baseBranch = await getDefaultBranch(dir, { allowRemote: false });
   const result = await execGit(['branch', '--list'], dir, { ignoreExitCode: true });
   const branches = result.stdout.trim().split('\n').map(b => b.replace(/^\*?\s+/, ''));
   return {

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -694,8 +694,8 @@ export async function getDefaultBranch(dir, { allowRemote = true } = {}) {
   }
 
   // Fall back to local branch detection
-  const result = await execGit(['branch', '--list'], dir, { ignoreExitCode: true });
-  const branches = result.stdout.trim().split('\n').map(b => b.replace(/^\*?\s+/, ''));
+  const result = await execGitSafe(['branch', '--list'], dir);
+  const branches = (result.stdout || '').trim().split('\n').map(b => b.replace(/^\*?\s+/, '')).filter(Boolean);
   if (branches.includes('main')) return 'main';
   if (branches.includes('master')) return 'master';
 

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -678,29 +678,39 @@ export function extractAgentSummary(output) {
   return summary;
 }
 
-export async function getDefaultBranch(dir) {
+export async function getDefaultBranch(dir, { allowRemote = true } = {}) {
   const symRef = await execGitSafe(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], dir);
   if (symRef.stdout?.trim()) {
     return symRef.stdout.trim().replace(/^origin\//, '');
   }
 
-  // origin/HEAD not set locally — ask the remote
-  await execGitSafe(['remote', 'set-head', 'origin', '--auto'], dir);
-  const symRef2 = await execGitSafe(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], dir);
-  if (symRef2.stdout?.trim()) {
-    return symRef2.stdout.trim().replace(/^origin\//, '');
+  // origin/HEAD not set locally — ask the remote (best-effort, short timeout)
+  if (allowRemote) {
+    await execGitSafe(['remote', 'set-head', 'origin', '--auto'], dir, { timeout: 5000 });
+    const symRef2 = await execGitSafe(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], dir);
+    if (symRef2.stdout?.trim()) {
+      return symRef2.stdout.trim().replace(/^origin\//, '');
+    }
   }
 
+  // Fall back to local branch detection
   const result = await execGit(['branch', '--list'], dir, { ignoreExitCode: true });
   const branches = result.stdout.trim().split('\n').map(b => b.replace(/^\*?\s+/, ''));
   if (branches.includes('main')) return 'main';
   if (branches.includes('master')) return 'master';
 
+  // Last resort: use the currently checked-out branch
+  const head = await execGitSafe(['rev-parse', '--abbrev-ref', 'HEAD'], dir);
+  if (head.stdout?.trim() && head.stdout.trim() !== 'HEAD') {
+    return head.stdout.trim();
+  }
+
   return null;
 }
 
 /**
- * Detect base and dev branches from local branch list
+ * Detect base and dev branches via origin/HEAD (with remote auto-detection fallback)
+ * and local branch list. May contact the remote if origin/HEAD is unset.
  * @returns {{ baseBranch: string|null, devBranch: string|null }}
  */
 export async function getRepoBranches(dir) {

--- a/server/services/git.test.js
+++ b/server/services/git.test.js
@@ -233,3 +233,4 @@ describe('extractAgentSummary', () => {
     expect(summary).not.toContain('🔧');
   });
 });
+

--- a/server/services/worktreeManager.js
+++ b/server/services/worktreeManager.js
@@ -243,6 +243,9 @@ export async function createPersistentWorktree(featureAgentId, sourceWorkspace, 
         const localOk = (await execGit(['branch', '--list', detected], sourceWorkspace, { ignoreExitCode: true })).stdout.trim();
         if (localOk) return detected;
       }
+      // All detection failed — use HEAD and update baseBranch to reflect reality
+      const headBranch = (await execGit(['rev-parse', '--abbrev-ref', 'HEAD'], sourceWorkspace, { ignoreExitCode: true })).stdout.trim();
+      baseBranch = headBranch && headBranch !== 'HEAD' ? headBranch : baseBranch;
       return 'HEAD';
     });
 

--- a/server/services/worktreeManager.js
+++ b/server/services/worktreeManager.js
@@ -44,15 +44,18 @@ export async function createWorktree(agentId, sourceWorkspace, taskId, options =
   const worktreePath = join(WORKTREES_DIR, agentId);
 
   // Fetch latest from origin so we base off up-to-date refs
-  await execGit(['fetch', 'origin'], sourceWorkspace).catch(err => {
-    console.log(`⚠️ Worktree fetch failed (will use local refs): ${err.message}`);
-  });
+  const fetchSucceeded = await execGit(['fetch', 'origin'], sourceWorkspace)
+    .then(() => true)
+    .catch(err => {
+      console.log(`⚠️ Worktree fetch failed (will use local refs): ${err.message}`);
+      return false;
+    });
 
   // Determine the base: explicit option > remote default branch > current HEAD
   let baseBranch = options.baseBranch;
   if (!baseBranch) {
     const { getDefaultBranch } = await import('./git.js');
-    baseBranch = await getDefaultBranch(sourceWorkspace).catch(() => null);
+    baseBranch = await getDefaultBranch(sourceWorkspace, { allowRemote: fetchSucceeded }).catch(() => null);
     if (!baseBranch) {
       baseBranch = (await execGit(['rev-parse', '--abbrev-ref', 'HEAD'], sourceWorkspace)).stdout.trim();
     }
@@ -211,13 +214,16 @@ export async function createPersistentWorktree(featureAgentId, sourceWorkspace, 
 
   await ensureDir(join(WORKTREES_DIR, '..', 'feature-agents', featureAgentId));
 
-  await execGit(['fetch', 'origin'], sourceWorkspace).catch(err => {
-    console.log(`⚠️ Persistent worktree fetch failed: ${err.message}`);
-  });
+  const fetchOk = await execGit(['fetch', 'origin'], sourceWorkspace)
+    .then(() => true)
+    .catch(err => {
+      console.log(`⚠️ Persistent worktree fetch failed: ${err.message}`);
+      return false;
+    });
 
   if (!baseBranch) {
     const { getDefaultBranch } = await import('./git.js');
-    baseBranch = await getDefaultBranch(sourceWorkspace).catch(() => null) || 'main';
+    baseBranch = await getDefaultBranch(sourceWorkspace, { allowRemote: fetchOk }).catch(() => null) || 'main';
   }
 
   // Verify the base branch exists locally or on the remote; fall back to HEAD if not

--- a/server/services/worktreeManager.js
+++ b/server/services/worktreeManager.js
@@ -48,14 +48,14 @@ export async function createWorktree(agentId, sourceWorkspace, taskId, options =
     console.log(`⚠️ Worktree fetch failed (will use local refs): ${err.message}`);
   });
 
-  // Determine the base: explicit option > detected default branch > current HEAD
+  // Determine the base: explicit option > remote default branch > current HEAD
   let baseBranch = options.baseBranch;
   if (!baseBranch) {
-    const mainExists = (await execGit(['branch', '--list', 'main'], sourceWorkspace)).stdout.trim();
-    const masterExists = (await execGit(['branch', '--list', 'master'], sourceWorkspace)).stdout.trim();
-    if (mainExists) baseBranch = 'main';
-    else if (masterExists) baseBranch = 'master';
-    else baseBranch = (await execGit(['rev-parse', '--abbrev-ref', 'HEAD'], sourceWorkspace)).stdout.trim();
+    const { getDefaultBranch } = await import('./git.js');
+    baseBranch = await getDefaultBranch(sourceWorkspace);
+    if (!baseBranch) {
+      baseBranch = (await execGit(['rev-parse', '--abbrev-ref', 'HEAD'], sourceWorkspace)).stdout.trim();
+    }
   }
 
   // Prefer the remote ref (freshest state) if available
@@ -206,7 +206,7 @@ export async function removeWorktree(agentId, sourceWorkspace, branchName, optio
  * Create a persistent worktree for a feature agent.
  * Unlike regular worktrees, these persist across runs.
  */
-export async function createPersistentWorktree(featureAgentId, sourceWorkspace, branchName, baseBranch = 'main') {
+export async function createPersistentWorktree(featureAgentId, sourceWorkspace, branchName, baseBranch) {
   const FA_WORKTREES = join(WORKTREES_DIR, '..', 'feature-agents', featureAgentId, 'worktree');
 
   await ensureDir(join(WORKTREES_DIR, '..', 'feature-agents', featureAgentId));
@@ -214,6 +214,11 @@ export async function createPersistentWorktree(featureAgentId, sourceWorkspace, 
   await execGit(['fetch', 'origin'], sourceWorkspace).catch(err => {
     console.log(`⚠️ Persistent worktree fetch failed: ${err.message}`);
   });
+
+  if (!baseBranch) {
+    const { getDefaultBranch } = await import('./git.js');
+    baseBranch = await getDefaultBranch(sourceWorkspace) || 'main';
+  }
 
   const baseRef = await execGit(['rev-parse', `origin/${baseBranch}`], sourceWorkspace)
     .then(() => `origin/${baseBranch}`)
@@ -267,13 +272,18 @@ export async function removePersistentWorktree(featureAgentId, sourceWorkspace, 
 /**
  * Merge base branch into a persistent feature agent worktree before a run
  */
-export async function mergeBaseIntoFeatureWorktree(featureAgentId, baseBranch = 'main') {
+export async function mergeBaseIntoFeatureWorktree(featureAgentId, baseBranch) {
   const worktreePath = join(WORKTREES_DIR, '..', 'feature-agents', featureAgentId, 'worktree');
   if (!existsSync(worktreePath)) return { merged: false, reason: 'worktree-missing' };
 
   await execGit(['fetch', 'origin'], worktreePath).catch(err => {
     console.log(`⚠️ Fetch failed for feature agent ${featureAgentId}: ${err.message}`);
   });
+
+  if (!baseBranch) {
+    const { getDefaultBranch } = await import('./git.js');
+    baseBranch = await getDefaultBranch(worktreePath) || 'main';
+  }
   const result = await execGit(['merge', `origin/${baseBranch}`, '--no-edit'], worktreePath)
     .then(() => ({ merged: true }))
     .catch(async (err) => {

--- a/server/services/worktreeManager.js
+++ b/server/services/worktreeManager.js
@@ -52,7 +52,7 @@ export async function createWorktree(agentId, sourceWorkspace, taskId, options =
   let baseBranch = options.baseBranch;
   if (!baseBranch) {
     const { getDefaultBranch } = await import('./git.js');
-    baseBranch = await getDefaultBranch(sourceWorkspace);
+    baseBranch = await getDefaultBranch(sourceWorkspace).catch(() => null);
     if (!baseBranch) {
       baseBranch = (await execGit(['rev-parse', '--abbrev-ref', 'HEAD'], sourceWorkspace)).stdout.trim();
     }
@@ -217,7 +217,7 @@ export async function createPersistentWorktree(featureAgentId, sourceWorkspace, 
 
   if (!baseBranch) {
     const { getDefaultBranch } = await import('./git.js');
-    baseBranch = await getDefaultBranch(sourceWorkspace) || 'main';
+    baseBranch = await getDefaultBranch(sourceWorkspace).catch(() => null) || 'main';
   }
 
   // Verify the base branch exists locally or on the remote; fall back to HEAD if not
@@ -287,7 +287,7 @@ export async function mergeBaseIntoFeatureWorktree(featureAgentId, baseBranch) {
 
   if (!baseBranch) {
     const { getDefaultBranch } = await import('./git.js');
-    baseBranch = await getDefaultBranch(worktreePath) || 'main';
+    baseBranch = await getDefaultBranch(worktreePath).catch(() => null) || 'main';
   }
   // Verify origin/<baseBranch> exists before attempting merge
   const remoteBranchValid = await execGit(['rev-parse', `origin/${baseBranch}`], worktreePath, { ignoreExitCode: true })

--- a/server/services/worktreeManager.js
+++ b/server/services/worktreeManager.js
@@ -226,12 +226,23 @@ export async function createPersistentWorktree(featureAgentId, sourceWorkspace, 
     baseBranch = await getDefaultBranch(sourceWorkspace, { allowRemote: fetchOk }).catch(() => null) || 'main';
   }
 
-  // Verify the base branch exists locally or on the remote; fall back to HEAD if not
+  // Verify the base branch exists locally or on the remote; re-detect if stale
   const baseRef = await execGit(['rev-parse', `origin/${baseBranch}`], sourceWorkspace)
     .then(() => `origin/${baseBranch}`)
     .catch(async () => {
       const localExists = (await execGit(['branch', '--list', baseBranch], sourceWorkspace, { ignoreExitCode: true })).stdout.trim();
       if (localExists) return baseBranch;
+      // Provided baseBranch doesn't exist — re-detect the actual default
+      const { getDefaultBranch } = await import('./git.js');
+      const detected = await getDefaultBranch(sourceWorkspace, { allowRemote: false }).catch(() => null);
+      if (detected && detected !== baseBranch) {
+        baseBranch = detected;
+        const remoteOk = await execGit(['rev-parse', `origin/${detected}`], sourceWorkspace, { ignoreExitCode: true })
+          .then(r => r.exitCode === 0).catch(() => false);
+        if (remoteOk) return `origin/${detected}`;
+        const localOk = (await execGit(['branch', '--list', detected], sourceWorkspace, { ignoreExitCode: true })).stdout.trim();
+        if (localOk) return detected;
+      }
       return 'HEAD';
     });
 
@@ -295,12 +306,23 @@ export async function mergeBaseIntoFeatureWorktree(featureAgentId, baseBranch) {
     const { getDefaultBranch } = await import('./git.js');
     baseBranch = await getDefaultBranch(worktreePath).catch(() => null) || 'main';
   }
-  // Verify origin/<baseBranch> exists before attempting merge
-  const remoteBranchValid = await execGit(['rev-parse', `origin/${baseBranch}`], worktreePath, { ignoreExitCode: true })
+  // Verify origin/<baseBranch> exists; if not, re-detect before giving up
+  let remoteBranchValid = await execGit(['rev-parse', `origin/${baseBranch}`], worktreePath, { ignoreExitCode: true })
     .then(r => r.exitCode === 0)
     .catch(() => false);
   if (!remoteBranchValid) {
-    return { merged: false, reason: `origin/${baseBranch} not found` };
+    const { getDefaultBranch } = await import('./git.js');
+    const detected = await getDefaultBranch(worktreePath, { allowRemote: false }).catch(() => null);
+    if (detected && detected !== baseBranch) {
+      remoteBranchValid = await execGit(['rev-parse', `origin/${detected}`], worktreePath, { ignoreExitCode: true })
+        .then(r => r.exitCode === 0).catch(() => false);
+      if (remoteBranchValid) {
+        baseBranch = detected;
+      }
+    }
+    if (!remoteBranchValid) {
+      return { merged: false, reason: `origin/${baseBranch} not found` };
+    }
   }
   const result = await execGit(['merge', `origin/${baseBranch}`, '--no-edit'], worktreePath)
     .then(() => ({ merged: true }))

--- a/server/services/worktreeManager.js
+++ b/server/services/worktreeManager.js
@@ -291,7 +291,8 @@ export async function mergeBaseIntoFeatureWorktree(featureAgentId, baseBranch) {
   }
   // Verify origin/<baseBranch> exists before attempting merge
   const remoteBranchValid = await execGit(['rev-parse', `origin/${baseBranch}`], worktreePath, { ignoreExitCode: true })
-    .then(r => r.exitCode === 0);
+    .then(r => r.exitCode === 0)
+    .catch(() => false);
   if (!remoteBranchValid) {
     return { merged: false, reason: `origin/${baseBranch} not found` };
   }

--- a/server/services/worktreeManager.js
+++ b/server/services/worktreeManager.js
@@ -220,9 +220,14 @@ export async function createPersistentWorktree(featureAgentId, sourceWorkspace, 
     baseBranch = await getDefaultBranch(sourceWorkspace) || 'main';
   }
 
+  // Verify the base branch exists locally or on the remote; fall back to HEAD if not
   const baseRef = await execGit(['rev-parse', `origin/${baseBranch}`], sourceWorkspace)
     .then(() => `origin/${baseBranch}`)
-    .catch(() => baseBranch);
+    .catch(async () => {
+      const localExists = (await execGit(['branch', '--list', baseBranch], sourceWorkspace, { ignoreExitCode: true })).stdout.trim();
+      if (localExists) return baseBranch;
+      return 'HEAD';
+    });
 
   // Check if branch already exists (local or remote)
   const localBranchExists = (await execGit(['branch', '--list', branchName], sourceWorkspace)).stdout.trim();
@@ -283,6 +288,12 @@ export async function mergeBaseIntoFeatureWorktree(featureAgentId, baseBranch) {
   if (!baseBranch) {
     const { getDefaultBranch } = await import('./git.js');
     baseBranch = await getDefaultBranch(worktreePath) || 'main';
+  }
+  // Verify origin/<baseBranch> exists before attempting merge
+  const remoteBranchValid = await execGit(['rev-parse', `origin/${baseBranch}`], worktreePath, { ignoreExitCode: true })
+    .then(r => r.exitCode === 0);
+  if (!remoteBranchValid) {
+    return { merged: false, reason: `origin/${baseBranch} not found` };
   }
   const result = await execGit(['merge', `origin/${baseBranch}`, '--no-edit'], worktreePath)
     .then(() => ({ merged: true }))

--- a/server/services/worktreeManager.js
+++ b/server/services/worktreeManager.js
@@ -301,13 +301,16 @@ export async function mergeBaseIntoFeatureWorktree(featureAgentId, baseBranch) {
   const worktreePath = join(WORKTREES_DIR, '..', 'feature-agents', featureAgentId, 'worktree');
   if (!existsSync(worktreePath)) return { merged: false, reason: 'worktree-missing' };
 
-  await execGit(['fetch', 'origin'], worktreePath).catch(err => {
-    console.log(`⚠️ Fetch failed for feature agent ${featureAgentId}: ${err.message}`);
-  });
+  const fetchOk = await execGit(['fetch', 'origin'], worktreePath)
+    .then(() => true)
+    .catch(err => {
+      console.log(`⚠️ Fetch failed for feature agent ${featureAgentId}: ${err.message}`);
+      return false;
+    });
 
   if (!baseBranch) {
     const { getDefaultBranch } = await import('./git.js');
-    baseBranch = await getDefaultBranch(worktreePath).catch(() => null) || 'main';
+    baseBranch = await getDefaultBranch(worktreePath, { allowRemote: fetchOk }).catch(() => null) || 'main';
   }
   // Verify origin/<baseBranch> exists; if not, re-detect before giving up
   let remoteBranchValid = await execGit(['rev-parse', `origin/${baseBranch}`], worktreePath, { ignoreExitCode: true })


### PR DESCRIPTION
## Summary

- Adds `getDefaultBranch(dir)` to `server/services/git.js` that resolves the remote's actual default branch via `origin/HEAD` symbolic ref (with auto-detection fallback)
- Replaces hardcoded `'main'` fallbacks in worktree creation, PR targeting, merge recovery tasks, and branch comparison routes
- Fixes PR title generation to use only the first line of the task description (preventing "Repository: /Users/..." from leaking into titles)

## Test plan

- [x] Existing test suite passes (3403 tests)
- [x] New test: multiline description produces clean PR title
- [x] `getDefaultBranch` mock added to cleanup test's git.js mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)