### PR TITLE
feat(cos): filter scheduled tasks by All | Enabled

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -2,6 +2,13 @@
 
 ## Added
 
+- **CoS scheduled-task filter (All / Enabled).** The CoS Schedule tab header
+  gains an All/Enabled filter persisted in the URL (`?filter=enabled`) so the
+  selection is bookmarkable. Counts render once per pass, and each filter
+  carries its own empty-state copy so a future filter can't fall back to an
+  awkward auto-generated message. Touches
+  `client/src/components/cos/tabs/ScheduleTab.jsx`.
+
 - **Character canon: wardrobes (Cluster A).** Every entry under
   `universe.characters[]` gains an optional `wardrobes[]` array — each entry
   is an `{ id, name, description, createdAt, updatedAt }` outfit/styling
@@ -932,6 +939,15 @@
 
 ## Changed
 
+- **CI test output is now quiet + fail-fast.** New `server/package.json`
+  `test:ci` script (`vitest run --bail=1 --silent=passed-only
+  --reporter=default --reporter=github-actions`) used by `.github/workflows/ci.yml`.
+  Suppresses `console.log/error` output from passing tests (so the 1000s of
+  emoji-prefixed logs that previously flooded CI only appear when the owning
+  test fails), bails after the first failing test, and emits GitHub Actions
+  annotations on failure lines so the PR view links straight to the
+  offending assertion. Local `npm test` is unchanged.
+
 - **TUI agents now write a markdown task summary into `.agent-done` and
   PortOS ingests it as the agent's `outputBuffer`.** With per-line PTY
   capture off, the agent card's "Show output" panel only showed
@@ -1263,6 +1279,15 @@
   to scrub stray references from sibling unlocked composites' prompts.
 
 ## Fixed
+
+- **Flaky death-clock test passes again.** `computeDeathClock` healthy-years
+  test in `server/services/meatspace.test.js` derived its expected value from
+  `result.yearsRemaining` (rounded to 2dp by the service) but compared
+  against `result.healthyYearsRemaining` (derived from the full-precision
+  value). On some calendar dates the two rounding paths differed by 0.1 and
+  the assertion failed in CI. Now uses `toBeCloseTo(..., 0)` so the test
+  asserts the 85% ratio with tolerance instead of re-deriving from a
+  pre-rounded number.
 
 - **Theme contrast: white text on light-green success backgrounds now uses
   dark text.** `--port-on-success` defaulted to white (255 255 255), which

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm install --prefix client
 
       - name: Run server tests
-        run: npm test --prefix server
+        run: npm run test:ci --prefix server
 
       - name: Build client
         run: npm run build --prefix client

--- a/client/src/components/cos/tabs/ScheduleTab.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.jsx
@@ -882,9 +882,10 @@ function AppTaskTypeRow({ taskType, config, onUpdate, onTrigger, onReset, provid
 }
 
 const TASK_FILTERS = [
-  { id: 'all', label: 'All', match: () => true },
-  { id: 'enabled', label: 'Enabled', match: ([, config]) => config.enabled },
+  { id: 'all', label: 'All', emptyMessage: 'No tasks configured.', match: () => true },
+  { id: 'enabled', label: 'Enabled', emptyMessage: 'No enabled tasks.', match: ([, config]) => config.enabled },
 ];
+const DEFAULT_FILTER_ID = TASK_FILTERS[0].id;
 
 function AppTaskTypeSection({ tasks, onUpdate, onTrigger, onReset, providers, apps, onUpdateOverride, onBulkToggleOverride, improvementDisabled, filter, onFilterChange }) {
   const taskEntries = Object.entries(tasks || {});
@@ -893,6 +894,7 @@ function AppTaskTypeSection({ tasks, onUpdate, onTrigger, onReset, providers, ap
   const activeFilter = TASK_FILTERS.find(f => f.id === filter) || TASK_FILTERS[0];
   const allTaskTypes = taskEntries.map(([taskType]) => taskType);
   const visibleEntries = taskEntries.filter(activeFilter.match);
+  const counts = Object.fromEntries(TASK_FILTERS.map(f => [f.id, taskEntries.filter(f.match).length]));
 
   return (
     <div className="space-y-3">
@@ -901,7 +903,6 @@ function AppTaskTypeSection({ tasks, onUpdate, onTrigger, onReset, providers, ap
         <div className="flex items-center gap-1 ml-auto">
           {TASK_FILTERS.map(f => {
             const active = activeFilter.id === f.id;
-            const count = f.id === 'all' ? taskEntries.length : taskEntries.filter(f.match).length;
             return (
               <button
                 key={f.id}
@@ -913,7 +914,7 @@ function AppTaskTypeSection({ tasks, onUpdate, onTrigger, onReset, providers, ap
                     : 'text-gray-400 hover:text-white hover:bg-port-border/50'
                 }`}
               >
-                {f.label} ({count})
+                {f.label} ({counts[f.id]})
               </button>
             );
           })}
@@ -924,9 +925,9 @@ function AppTaskTypeSection({ tasks, onUpdate, onTrigger, onReset, providers, ap
       </p>
       {visibleEntries.length === 0 ? (
         <div className="text-center py-8 text-gray-500 border border-dashed border-port-border rounded-lg">
-          No {activeFilter.id === 'all' ? '' : `${activeFilter.label.toLowerCase()} `}tasks.{' '}
-          {activeFilter.id !== 'all' && (
-            <button onClick={() => onFilterChange('all')} className="text-port-accent hover:underline">Show all</button>
+          {activeFilter.emptyMessage}{' '}
+          {activeFilter.id !== DEFAULT_FILTER_ID && (
+            <button onClick={() => onFilterChange(DEFAULT_FILTER_ID)} className="text-port-accent hover:underline">Show all</button>
           )}
         </div>
       ) : (
@@ -960,10 +961,10 @@ export default function ScheduleTab({ apps }) {
   const [loading, setLoading] = useState(true);
 
   const filterParam = searchParams.get('filter');
-  const filter = TASK_FILTERS.some(f => f.id === filterParam) ? filterParam : 'all';
+  const filter = TASK_FILTERS.some(f => f.id === filterParam) ? filterParam : DEFAULT_FILTER_ID;
   const setFilter = useCallback((next) => {
     const params = new URLSearchParams(searchParams);
-    if (next === 'all') params.delete('filter');
+    if (next === DEFAULT_FILTER_ID) params.delete('filter');
     else params.set('filter', next);
     setSearchParams(params, { replace: true });
   }, [searchParams, setSearchParams]);

--- a/client/src/components/cos/tabs/ScheduleTab.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef, memo } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { Play, RotateCcw, ChevronDown, ChevronRight, AlertCircle, RefreshCw, Package, Info, GitMerge } from 'lucide-react';
 import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
@@ -880,53 +881,92 @@ function AppTaskTypeRow({ taskType, config, onUpdate, onTrigger, onReset, provid
   );
 }
 
-function AppTaskTypeSection({ tasks, onUpdate, onTrigger, onReset, providers, apps, onUpdateOverride, onBulkToggleOverride, improvementDisabled }) {
+const TASK_FILTERS = [
+  { id: 'all', label: 'All', match: () => true },
+  { id: 'enabled', label: 'Enabled', match: ([, config]) => config.enabled },
+];
+
+function AppTaskTypeSection({ tasks, onUpdate, onTrigger, onReset, providers, apps, onUpdateOverride, onBulkToggleOverride, improvementDisabled, filter, onFilterChange }) {
   const taskEntries = Object.entries(tasks || {});
   if (taskEntries.length === 0) return null;
 
-  const enabledCount = taskEntries.filter(([, config]) => config.enabled).length;
+  const activeFilter = TASK_FILTERS.find(f => f.id === filter) || TASK_FILTERS[0];
   const allTaskTypes = taskEntries.map(([taskType]) => taskType);
+  const visibleEntries = taskEntries.filter(activeFilter.match);
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-wrap">
         <h3 className="text-lg font-semibold text-white">Improvement Tasks</h3>
-        <span className="text-xs text-gray-500">
-          {enabledCount} enabled
-        </span>
+        <div className="flex items-center gap-1 ml-auto">
+          {TASK_FILTERS.map(f => {
+            const active = activeFilter.id === f.id;
+            const count = f.id === 'all' ? taskEntries.length : taskEntries.filter(f.match).length;
+            return (
+              <button
+                key={f.id}
+                onClick={() => onFilterChange(f.id)}
+                aria-pressed={active}
+                className={`px-3 py-1.5 text-sm rounded-lg transition-colors font-medium min-h-[40px] ${
+                  active
+                    ? 'bg-port-accent/10 text-port-accent'
+                    : 'text-gray-400 hover:text-white hover:bg-port-border/50'
+                }`}
+              >
+                {f.label} ({count})
+              </button>
+            );
+          })}
+        </div>
       </div>
       <p className="text-sm text-gray-400">
         Tasks that analyze and improve PortOS and managed apps. Expand a task to configure per-app overrides.
       </p>
-      <div className="space-y-2">
-        {taskEntries.map(([taskType, config]) => (
-          <AppTaskTypeRow
-            key={taskType}
-            taskType={taskType}
-            config={config}
-            onUpdate={onUpdate}
-            onTrigger={onTrigger}
-            onReset={onReset}
-            providers={providers}
-            apps={apps}
-            onUpdateOverride={onUpdateOverride}
-            onBulkToggleOverride={onBulkToggleOverride}
-            allTaskTypes={allTaskTypes}
-            improvementDisabled={improvementDisabled}
-          />
-        ))}
-      </div>
+      {visibleEntries.length === 0 ? (
+        <div className="text-center py-8 text-gray-500 border border-dashed border-port-border rounded-lg">
+          No {activeFilter.id === 'all' ? '' : `${activeFilter.label.toLowerCase()} `}tasks.{' '}
+          {activeFilter.id !== 'all' && (
+            <button onClick={() => onFilterChange('all')} className="text-port-accent hover:underline">Show all</button>
+          )}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {visibleEntries.map(([taskType, config]) => (
+            <AppTaskTypeRow
+              key={taskType}
+              taskType={taskType}
+              config={config}
+              onUpdate={onUpdate}
+              onTrigger={onTrigger}
+              onReset={onReset}
+              providers={providers}
+              apps={apps}
+              onUpdateOverride={onUpdateOverride}
+              onBulkToggleOverride={onBulkToggleOverride}
+              allTaskTypes={allTaskTypes}
+              improvementDisabled={improvementDisabled}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
 
 export default function ScheduleTab({ apps }) {
-  // searchParams no longer used — unified task list
+  const [searchParams, setSearchParams] = useSearchParams();
   const [schedule, setSchedule] = useState(null);
   const [providers, setProviders] = useState(null);
   const [loading, setLoading] = useState(true);
 
-  // View state removed — unified task list replaces segmented self/app views
+  const filterParam = searchParams.get('filter');
+  const filter = TASK_FILTERS.some(f => f.id === filterParam) ? filterParam : 'all';
+  const setFilter = useCallback((next) => {
+    const params = new URLSearchParams(searchParams);
+    if (next === 'all') params.delete('filter');
+    else params.set('filter', next);
+    setSearchParams(params, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   const fetchSchedule = useCallback(async () => {
     const data = await api.getCosSchedule().catch(() => null);
@@ -1076,6 +1116,8 @@ export default function ScheduleTab({ apps }) {
         onUpdateOverride={handleUpdateAppOverride}
         onBulkToggleOverride={handleBulkToggleOverride}
         improvementDisabled={improvementDisabled}
+        filter={filter}
+        onFilterChange={setFilter}
       />
 
       {schedule.lastUpdated && (

--- a/server/package.json
+++ b/server/package.json
@@ -8,6 +8,7 @@
     "start": "node index.js",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:ci": "vitest run --bail=1 --silent=passed-only --reporter=default --reporter=github-actions",
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {

--- a/server/services/meatspace.test.js
+++ b/server/services/meatspace.test.js
@@ -207,8 +207,10 @@ describe('computeDeathClock', () => {
 
   it('computes healthy years as 85% of remaining', () => {
     const result = computeDeathClock('1979-07-31', 78.5, 0);
-    const expectedHealthy = Math.round(result.yearsRemaining * 0.85 * 10) / 10;
-    expect(result.healthyYearsRemaining).toBe(expectedHealthy);
+    // Service derives healthyYearsRemaining from full-precision yearsRemaining,
+    // but result.yearsRemaining is rounded to 2dp — use a tolerance instead of
+    // re-deriving, or the assertion flakes by 0.1 on certain dates.
+    expect(result.healthyYearsRemaining).toBeCloseTo(result.yearsRemaining * 0.85, 0);
   });
 });
 


### PR DESCRIPTION
## Summary

- **CoS scheduled-task filter (All / Enabled).** Header chip on the CoS Schedule tab filters the task list by enabled status; selection persists in the URL (`?filter=enabled`) so it's bookmarkable. Counts render in a single pass, and each filter carries its own empty-state copy.
- **Fix flaky `computeDeathClock` test.** The "healthy years is 85% of remaining" assertion re-derived its expected value from `result.yearsRemaining` (rounded to 2dp by the service) and compared against `result.healthyYearsRemaining` (derived from full-precision input) — off by 0.1 on certain dates. Now uses `toBeCloseTo(..., 0)`.
- **Quieter, fail-fast CI.** New `server/package.json` `test:ci` script (`vitest run --bail=1 --silent=passed-only --reporter=default --reporter=github-actions`) used by `.github/workflows/ci.yml`. Suppresses `console.log/error` from passing tests, bails after the first failure, and emits GitHub Actions annotations so PR view links straight to the failing assertion. Local `npm test` is unchanged.

## Test plan

- [x] `npx vitest run services/meatspace.test.js` — all 15 tests pass after the flaky-test fix
- [x] `npm run test:ci --prefix server` — 4875/4880 pass (5 skipped), output ~250 lines vs ~5500 before
- [ ] Visit `/cos` → Schedule tab: toggle All ↔ Enabled, confirm URL updates, count badges match, empty-state copy is correct per filter
- [ ] Refresh on `/cos?filter=enabled` — filter selection restored
- [ ] Watch this PR's CI run: confirm bail-on-first-failure and minimal log output

🤖 Generated with [Claude Code](https://claude.com/claude-code)