### PR TITLE
fix(theme): register --color-port-on-* so text-port-on-accent isn't a no-op

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1349,6 +1349,17 @@
 
 ## Fixed
 
+- **Black ICE Terminal: active day/night toggle no longer renders a white moon
+  on bright green.** The settings theme picker uses `bg-port-accent
+  text-port-on-accent` to flag the active mode, but `--color-port-on-accent`
+  was never registered in Tailwind's `@theme` block — so `text-port-on-accent`
+  was a no-op and the icon inherited the body's near-white `--port-text`
+  (218 255 238 in Black ICE Terminal) against the bright `#00f5a0` background,
+  ~1.5 contrast. Added `--color-port-on-{accent,success,warning,error}` so
+  every theme's defined on-* tokens map to Tailwind utilities, restoring the
+  intended dark forest text. Same gap also covered the `bg-port-accent
+  text-port-on-accent` button in `ErrorBoundary.jsx`. Touches `client/src/index.css`.
+
 - **Flaky death-clock test passes again.** `computeDeathClock` healthy-years
   test in `server/services/meatspace.test.js` derived its expected value from
   `result.yearsRemaining` (rounded to 2dp by the service) but compared

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -10,6 +10,10 @@
   --color-port-error: rgb(var(--port-error));
   --color-port-text: rgb(var(--port-text));
   --color-port-text-muted: rgb(var(--port-text-muted));
+  --color-port-on-accent: rgb(var(--port-on-accent));
+  --color-port-on-success: rgb(var(--port-on-success));
+  --color-port-on-warning: rgb(var(--port-on-warning));
+  --color-port-on-error: rgb(var(--port-on-error));
 
   --animate-scanline: scanline 5s linear infinite;
 }


### PR DESCRIPTION
## Summary

- Black ICE Terminal rendered the active day/night toggle in the settings theme picker as a **white moon on a #00f5a0 background (~1.5 contrast)**. The button class is `bg-port-accent text-port-on-accent`, but `--color-port-on-accent` was never added to Tailwind v4's `@theme` block in `client/src/index.css` — so `text-port-on-accent` was a no-op class and the SVG inherited `--port-text` (218 255 238 in this theme).
- Fix: register `--color-port-on-{accent,success,warning,error}` in `@theme` alongside the existing nine color tokens. Each maps to its runtime CSS variable, so per-theme overrides in `portosThemes.js` flow through automatically.
- Same gap silently affected `ErrorBoundary.jsx:41` (`bg-port-accent ... text-port-on-accent`); now fixed too.

## Why this slipped past the earlier WCAG contrast fix

Commit `64fe24c1` ("fix(theme): use dark text on success-green backgrounds") routed `bg-port-success text-white` → `--port-on-success` via a defensive CSS rule, but didn't touch this site because the class name `text-port-on-accent` doesn't include `text-white`. The class was simply dead, and the icon fell back to inherited text color.

## Test plan

- [x] `npx vite build` succeeds; generated CSS now contains `text-port-on-accent{color:var(--color-port-on-accent)}`
- [ ] Open Settings → Themes, click the moon button on the Black ICE Terminal card — moon icon should now render as dark forest (`rgb(0 22 14)`) on the bright-green active background instead of white
- [ ] Same check on every other theme card — active mode icon should be readable against its accent color
- [ ] Trigger an `ErrorBoundary` (e.g., throw in a component) — the "Try Again" button should render its label in the on-accent color, not white