### PR TITLE
fix: preserve legacy universe collection shares

### DIFF
--- a/server/services/sharing/exporter.js
+++ b/server/services/sharing/exporter.js
@@ -177,7 +177,11 @@ async function findCollectionForUniverse(universe) {
   const direct = all.find((c) => c.universeId === universe.id);
   if (direct) return direct;
   const conventional = `universe: ${(universe.name || '').toLowerCase()}`;
-  return all.find((c) => (c.name || '').toLowerCase() === conventional) || null;
+  const legacy = all.find((c) => (c.name || '').toLowerCase() === conventional);
+  // Legacy universe-builder collections were named conventionally but did not
+  // carry the explicit link. Preserve the link in the share payload so the
+  // importer can restore membership instead of leaving copied assets unsorted.
+  return legacy ? { ...legacy, universeId: universe.id } : null;
 }
 
 /**

--- a/server/services/sharing/integration.test.js
+++ b/server/services/sharing/integration.test.js
@@ -231,6 +231,38 @@ describe('sharing round-trip', () => {
     expect(fs.existsSync(join(tempData, 'images', 'second.png'))).toBe(true);
   });
 
+  it('universe export bundles a legacy convention-named collection with no universeId', async () => {
+    const bucket = await buckets.createBucket({ name: 'LegacyBucket', path: tempBucket, mode: 'auto-merge' });
+    const universeBuilder = await import('../universeBuilder.js');
+    const mediaCollections = await import('../mediaCollections.js');
+    const u = await universeBuilder.createUniverse({ name: 'Post-Epoc' });
+    const fs = await import('fs');
+    fs.writeFileSync(join(tempData, 'images', 'legacy.png'), 'PNG');
+
+    const collection = await mediaCollections.createCollection({
+      name: `Universe: ${u.name}`,
+      description: 'Legacy unlinked collection',
+    });
+    await mediaCollections.addItem(collection.id, { kind: 'image', ref: 'legacy.png' });
+
+    const exp = await exporter.exportUniverse(u.id, bucket.id);
+    const manifest = JSON.parse(fs.readFileSync(join(tempBucket, 'manifests', exp.filename), 'utf-8'));
+    expect(manifest.collection).toMatchObject({ name: 'Universe: Post-Epoc', universeId: u.id });
+    expect(manifest.collection.items).toHaveLength(1);
+
+    await mediaCollections.deleteCollection(collection.id);
+    await universeBuilder.deleteUniverse(u.id);
+
+    const r = await importer.processManifest(bucket.id, exp.filename);
+    expect(r.processed).toBe(true);
+    expect(r.outcome.collectionItemsAdded).toBe(1);
+
+    const restored = (await mediaCollections.listCollections()).find((c) => c.name === 'Universe: Post-Epoc');
+    expect(restored).toBeTruthy();
+    expect(restored.universeId).toBe(u.id);
+    expect(restored.items.map((i) => i.ref)).toEqual(['legacy.png']);
+  });
+
   it('keeps universe manifests retryable while Drive assets are still syncing', async () => {
     const bucket = await buckets.createBucket({ name: 'SlowDriveBucket', path: tempBucket, mode: 'auto-merge' });
     const universeBuilder = await import('../universeBuilder.js');


### PR DESCRIPTION
## Summary
- Treat legacy convention-named Universe collections as linked when exporting a universe share
- Add a sharing round-trip regression for a Universe: Post-Epoc collection without universeId

## Test
- npm test -- --run services/sharing/integration.test.js