### PR TITLE
fix: adopt imported universe share subscriptions

### DIFF
--- a/server/services/sharing/importer.js
+++ b/server/services/sharing/importer.js
@@ -31,6 +31,7 @@ import { insertSeriesWithId, updateSeries, getSeries } from '../pipeline/series.
 import { insertIssueWithId, updateIssue, getIssue } from '../pipeline/issues.js';
 import { insertUniverseWithId, updateUniverse, getUniverse } from '../universeBuilder.js';
 import { findOrCreateCollectionByName, addItem as addCollectionItem, ERR_DUPLICATE as COLLECTION_ERR_DUPLICATE } from '../mediaCollections.js';
+import { adoptImportedSubscription, withReexportSuppressed } from './subscriptions.js';
 
 const isStr = (v) => typeof v === 'string';
 
@@ -215,6 +216,14 @@ async function readReferencedRecords(bucketPath, manifest) {
 async function applyAutoMerge(bucket, manifest, records, { availableAssetKeys = null } = {}) {
   let applied = 0;
   const overridden = [];
+  const inboundSub = manifest.subscription?.recordKind && manifest.subscription?.recordId
+    ? { bucketId: bucket.id, recordKind: manifest.subscription.recordKind, recordId: manifest.subscription.recordId }
+    : null;
+  const inboundRecordsForKind = (recordKind) => {
+    if (recordKind === 'series') return records.series;
+    if (recordKind === 'universe') return records.universes;
+    return [];
+  };
 
   const mergeOne = async ({ kind, record, getFn, insertFn, updateFn, label }) => {
     const existing = await getFn(record.id).catch(() => null);
@@ -228,7 +237,9 @@ async function applyAutoMerge(bucket, manifest, records, { availableAssetKeys = 
       return;
     }
     if (remoteWins(existing.updatedAt, record.updatedAt)) {
-      await updateFn(existing.id, record);
+      const suppressKind = kind === 'issue' ? 'series' : kind;
+      const suppressId = kind === 'issue' ? record.seriesId : record.id;
+      await withReexportSuppressed(suppressKind, suppressId, () => updateFn(existing.id, record));
       overridden.push({ kind, id: record.id, label });
       applied++;
     }
@@ -260,13 +271,33 @@ async function applyAutoMerge(bucket, manifest, records, { availableAssetKeys = 
   let itemsAdded = 0;
   let itemsDeferred = 0;
   if (manifest.collection) {
-    const r = await mergeCollectionPayload(manifest.collection, availableAssetKeys);
+    const r = await withReexportSuppressed('universe', manifest.collection.universeId, () =>
+      mergeCollectionPayload(manifest.collection, availableAssetKeys));
     itemsAdded = r.itemsAdded;
     itemsDeferred = r.itemsDeferred || 0;
     if (itemsAdded > 0) applied += itemsAdded;
   }
 
-  return { applied, overridden, collectionItemsAdded: itemsAdded, collectionItemsDeferred: itemsDeferred };
+  let adoptedSubscription = null;
+  if (inboundSub && inboundRecordsForKind(inboundSub.recordKind).some((record) => record.id === inboundSub.recordId)) {
+    adoptedSubscription = await adoptImportedSubscription({
+      ...inboundSub,
+      lastManifestId: manifest.id,
+    }).catch((err) => {
+      console.log(`⚠️ sharing.importer: adopt subscription failed for ${inboundSub.recordKind}/${inboundSub.recordId}: ${err.message}`);
+      return null;
+    });
+  }
+
+  return {
+    applied,
+    overridden,
+    collectionItemsAdded: itemsAdded,
+    collectionItemsDeferred: itemsDeferred,
+    adoptedSubscription: adoptedSubscription
+      ? { id: adoptedSubscription.id, bucketId: adoptedSubscription.bucketId, recordKind: adoptedSubscription.recordKind, recordId: adoptedSubscription.recordId }
+      : null,
+  };
 }
 
 const INBOX_MAX = 1000;

--- a/server/services/sharing/integration.test.js
+++ b/server/services/sharing/integration.test.js
@@ -356,6 +356,43 @@ describe('sharing round-trip', () => {
     expect(stillThere.id).toBe(u.id);
   });
 
+  it('adopts an imported universe subscription so the source bucket is selected for sharing', async () => {
+    const { listSubscriptions, subscriptionFilename, __resetForTests } = await import('./subscriptions.js');
+    __resetForTests();
+    const bucket = await buckets.createBucket({ name: 'CollabBucket', path: tempBucket, mode: 'auto-merge' });
+    const universeBuilder = await import('../universeBuilder.js');
+    const u = await universeBuilder.createUniverse({ name: 'Shared Universe' });
+
+    const exp = await exporter.exportUniverse(u.id, bucket.id, {
+      subscription: { recordKind: 'universe', recordId: u.id },
+    });
+    expect(exp.filename).toBe(subscriptionFilename({ recordKind: 'universe', recordId: u.id }));
+
+    await universeBuilder.deleteUniverse(u.id);
+    expect(await listSubscriptions({ recordKind: 'universe', recordId: u.id })).toEqual([]);
+
+    const result = await importer.processManifest(bucket.id, exp.filename);
+    expect(result.processed).toBe(true);
+    expect(result.outcome.adoptedSubscription).toMatchObject({
+      bucketId: bucket.id,
+      recordKind: 'universe',
+      recordId: u.id,
+    });
+
+    const restored = await universeBuilder.getUniverse(u.id);
+    expect(restored.id).toBe(u.id);
+    const subs = await listSubscriptions({ recordKind: 'universe', recordId: u.id });
+    expect(subs).toHaveLength(1);
+    expect(subs[0]).toMatchObject({
+      bucketId: bucket.id,
+      recordKind: 'universe',
+      recordId: u.id,
+      adoptedFromImport: true,
+      lastManifestId: exp.manifestId,
+    });
+    expect(subs[0].lastExportedAt).toBe(null);
+  });
+
   it('refuses a manifest with a sharingSchemaVersion newer than local + emits incompatible event', async () => {
     const { SHARING_SCHEMA_VERSION } = await import('./version.js');
     const { sharingEvents } = await import('./importer.js');

--- a/server/services/sharing/subscriptions.js
+++ b/server/services/sharing/subscriptions.js
@@ -76,6 +76,43 @@ export async function findSubscription(bucketId, recordKind, recordId) {
 }
 
 /**
+ * Adopt an inbound subscription as a local outgoing subscription without
+ * immediately exporting back into the bucket. Importing a subscribed record
+ * means the local user has joined that collaboration, so ShareToButton should
+ * show the source bucket as checked and future local edits should re-export.
+ */
+export async function adoptImportedSubscription({ bucketId, recordKind, recordId, lastManifestId = null }) {
+  if (!SUBSCRIBABLE_KINDS.includes(recordKind)) return null;
+  if (!isStr(bucketId) || !isStr(recordId)) return null;
+  await getBucket(bucketId);
+
+  const state = await readState();
+  const id = subId({ bucketId, recordKind, recordId });
+  const now = new Date().toISOString();
+  let sub = state.subscriptions.find((s) => s.id === id);
+  if (!sub) {
+    sub = {
+      id,
+      bucketId,
+      recordKind,
+      recordId,
+      createdAt: now,
+      updatedAt: now,
+      lastManifestId,
+      lastExportedAt: null,
+      adoptedFromImport: true,
+    };
+    state.subscriptions.push(sub);
+  } else {
+    sub.updatedAt = now;
+    sub.lastManifestId = lastManifestId || sub.lastManifestId || null;
+    sub.adoptedFromImport = sub.adoptedFromImport ?? true;
+  }
+  await writeState(state);
+  return sub;
+}
+
+/**
  * Create a subscription and trigger the first export. If a subscription
  * already exists for the same (bucket, kind, id), idempotently re-export
  * rather than throwing — clicking "subscribe" on an already-subscribed
@@ -181,6 +218,24 @@ export async function unsubscribeAllForRecord(recordKind, recordId) {
  */
 const DEBOUNCE_MS = 3000;
 const pendingTimers = new Map(); // subId → Timeout
+const suppressedReexports = new Map(); // `${kind}:${id}` → count
+
+function suppressionKey(recordKind, recordId) {
+  return `${recordKind}:${recordId}`;
+}
+
+export async function withReexportSuppressed(recordKind, recordId, fn) {
+  if (!recordKind || !recordId || typeof fn !== 'function') return fn?.();
+  const key = suppressionKey(recordKind, recordId);
+  suppressedReexports.set(key, (suppressedReexports.get(key) || 0) + 1);
+  try {
+    return await fn();
+  } finally {
+    const next = (suppressedReexports.get(key) || 1) - 1;
+    if (next <= 0) suppressedReexports.delete(key);
+    else suppressedReexports.set(key, next);
+  }
+}
 
 async function reexportNow(sub) {
   const exp = await runExport(sub).catch((err) => {
@@ -198,6 +253,7 @@ async function reexportNow(sub) {
 }
 
 export async function reexportSubscribedRecord(recordKind, recordId) {
+  if (suppressedReexports.has(suppressionKey(recordKind, recordId))) return;
   const subs = await listSubscriptions({ recordKind, recordId });
   for (const sub of subs) {
     const existing = pendingTimers.get(sub.id);
@@ -239,6 +295,7 @@ export function installSubscriptionListener() {
 export function __resetForTests() {
   for (const t of pendingTimers.values()) clearTimeout(t);
   pendingTimers.clear();
+  suppressedReexports.clear();
   if (onUpdated) recordEvents.off('updated', onUpdated);
   if (onDeleted) recordEvents.off('deleted', onDeleted);
   onUpdated = null;


### PR DESCRIPTION
## Summary
- Adopt inbound subscribed universe/series manifests as local share subscriptions so imported shared universes show their source bucket as selected
- Suppress import-triggered re-export events to avoid echoing remote updates back into the same bucket
- Add integration coverage for imported universe subscription adoption

## Review
- Local review completed after diffing against `upstream/main`
- Fixed a review finding where issue imports needed to suppress the owning series update rather than an issue update

## Tests
- `npm test --prefix server -- services/sharing/integration.test.js services/sharing/subscriptions.test.js`