### PR TITLE
fix(sharing): retry sharing imports while record JSON syncs

### DIFF
--- a/server/services/sharing/importer.js
+++ b/server/services/sharing/importer.js
@@ -186,28 +186,44 @@ async function mergeMediaJobRecords(bucketPath, recordIds) {
   }
 }
 
-/** Read the records referenced by a manifest. */
+/**
+ * Read the records referenced by a manifest. `missing` lists recordIds whose
+ * JSON file hasn't synced into the bucket yet — the caller defers
+ * markProcessed until that list is empty, otherwise a manifest delivered
+ * ahead of its records would be silently dropped forever.
+ */
 async function readReferencedRecords(bucketPath, manifest) {
   const records = { series: [], issues: [], universes: [], media: [] };
-  for (const id of manifest.recordIds || []) {
+  const missing = [];
+  const resolveOne = async (id) => {
     if (id.startsWith('ser-')) {
       const r = await readJSONFile(join(bucketPath, 'records', 'series', `${id}.json`), null, { logError: false });
-      if (r) records.series.push(r);
-    } else if (id.startsWith('iss-')) {
-      const r = await readJSONFile(join(bucketPath, 'records', 'issues', `${id}.json`), null, { logError: false });
-      if (r) records.issues.push(r);
-    } else if (id.startsWith('chr-') || id.startsWith('set-') || id.startsWith('obj-')) {
-      // Bible entries — never standalone, just skip.
-      continue;
-    } else {
-      // Could be a universe (uuid only) or media job (uuid only). Try both.
-      const uni = await readJSONFile(join(bucketPath, 'records', 'universes', `${id}.json`), null, { logError: false });
-      if (uni) { records.universes.push(uni); continue; }
-      const med = await readJSONFile(join(bucketPath, 'records', 'media', `${id}.json`), null, { logError: false });
-      if (med) records.media.push(med);
+      return r ? { kind: 'series', record: r } : { kind: 'missing', id };
     }
+    if (id.startsWith('iss-')) {
+      const r = await readJSONFile(join(bucketPath, 'records', 'issues', `${id}.json`), null, { logError: false });
+      return r ? { kind: 'issues', record: r } : { kind: 'missing', id };
+    }
+    if (id.startsWith('chr-') || id.startsWith('set-') || id.startsWith('obj-')) {
+      // Bible entries — never standalone, just skip.
+      return { kind: 'skip' };
+    }
+    // UUID-only — could be a universe or a media job. Try both.
+    const uni = await readJSONFile(join(bucketPath, 'records', 'universes', `${id}.json`), null, { logError: false });
+    if (uni) return { kind: 'universes', record: uni };
+    const med = await readJSONFile(join(bucketPath, 'records', 'media', `${id}.json`), null, { logError: false });
+    if (med) return { kind: 'media', record: med };
+    return { kind: 'missing', id };
+  };
+  const resolved = await Promise.all((manifest.recordIds || []).map(resolveOne));
+  for (const r of resolved) {
+    if (r.kind === 'missing') missing.push(r.id);
+    else if (r.kind === 'series') records.series.push(r.record);
+    else if (r.kind === 'issues') records.issues.push(r.record);
+    else if (r.kind === 'universes') records.universes.push(r.record);
+    else if (r.kind === 'media') records.media.push(r.record);
   }
-  return records;
+  return { records, missing };
 }
 
 /**
@@ -407,7 +423,7 @@ export async function processManifest(bucketId, manifestFilename) {
     console.log(`⚠️ sharing: bucket=${bucket.name} manifest=${manifest.id} schemaVersion=${remoteVersion} > local=${SHARING_SCHEMA_VERSION} — refusing import (peer producedBy=${manifest.producedByVersion || 'unknown'})`);
     return { skipped: true, reason: 'incompatible-version', remoteVersion, localVersion: SHARING_SCHEMA_VERSION };
   }
-  const records = await readReferencedRecords(bucket.path, manifest);
+  const { records, missing: missingRecords } = await readReferencedRecords(bucket.path, manifest);
 
   // Always copy assets + media-job records ahead of the merge so canon and
   // pipeline records that reference them point at present files. Asset sync can
@@ -423,10 +439,11 @@ export async function processManifest(bucketId, manifestFilename) {
   } else {
     outcome = { mode: 'inbox', ...(await applyInbox(bucket, manifest, manifestFilename, records)) };
   }
-  if (assetCopy.missing.length > 0) {
-    outcome.pendingAssets = assetCopy.missing;
+  if (assetCopy.missing.length > 0 || missingRecords.length > 0) {
+    if (assetCopy.missing.length > 0) outcome.pendingAssets = assetCopy.missing;
+    if (missingRecords.length > 0) outcome.pendingRecords = missingRecords;
     sharingEvents.emit('manifest-processed', { bucketId, manifestId: manifest.id, manifestFilename, outcome });
-    console.log(`⏳ sharing: bucket=${bucket.name} manifest=${manifest.id} kind=${manifest.kind} mode=${bucket.mode} waitingForAssets=${assetCopy.missing.length}`);
+    console.log(`⏳ sharing: bucket=${bucket.name} manifest=${manifest.id} kind=${manifest.kind} mode=${bucket.mode} waitingForAssets=${assetCopy.missing.length} waitingForRecords=${missingRecords.length}`);
     return { processed: true, pending: true, manifest, outcome };
   }
   await markProcessed(bucketId, manifestFilename, manifest.id);
@@ -512,7 +529,13 @@ export async function promoteInboxItem(bucketId, manifestId) {
   const bucket = await getBucket(bucketId);
   const manifest = await readManifest(bucket.path, item.manifestFilename);
   if (!manifest) throw new Error(`Manifest no longer exists in bucket: ${item.manifestFilename}`);
-  const records = await readReferencedRecords(bucket.path, manifest);
+  const { records, missing: missingRecords } = await readReferencedRecords(bucket.path, manifest);
+  if (missingRecords.length > 0) {
+    throw Object.assign(new Error(`Manifest records are still syncing (${missingRecords.length} missing)`), {
+      code: 'SHARING_RECORDS_PENDING',
+      missingRecords,
+    });
+  }
   const assetCopy = await copyAssetsLocally(bucket.path, manifestAssetRefs(manifest));
   if (assetCopy.missing.length > 0) {
     throw Object.assign(new Error(`Manifest assets are still syncing (${assetCopy.missing.length} missing)`), {

--- a/server/services/sharing/integration.test.js
+++ b/server/services/sharing/integration.test.js
@@ -326,6 +326,38 @@ describe('sharing round-trip', () => {
     expect(hasBeenProcessed(cursor, exp.filename, exp.manifestId)).toBe(true);
   });
 
+  it('keeps universe manifests retryable while the record JSON itself is still syncing', async () => {
+    const bucket = await buckets.createBucket({ name: 'SlowRecordBucket', path: tempBucket, mode: 'auto-merge' });
+    const universeBuilder = await import('../universeBuilder.js');
+    const { readCursor, hasBeenProcessed } = await import('./manifest.js');
+    const u = await universeBuilder.createUniverse({ name: 'Late Record Universe' });
+
+    const exp = await exporter.exportUniverse(u.id, bucket.id);
+    simulateRemoteSender(tempBucket, exp.filename);
+    // Simulate Drive delivering the manifest before the record JSON syncs.
+    const fs = await import('fs');
+    const recordPath = join(tempBucket, 'records', 'universes', `${u.id}.json`);
+    const recordSnapshot = fs.readFileSync(recordPath);
+    fs.rmSync(recordPath, { force: true });
+    await universeBuilder.deleteUniverse(u.id);
+
+    const first = await importer.processManifest(bucket.id, exp.filename);
+    expect(first.pending).toBe(true);
+    expect(first.outcome.pendingRecords).toEqual([u.id]);
+    let cursor = await readCursor(bucket.id);
+    expect(hasBeenProcessed(cursor, exp.filename, exp.manifestId)).toBe(false);
+    await expect(universeBuilder.getUniverse(u.id)).rejects.toThrow();
+
+    // Record JSON finally syncs — retry should insert + mark processed.
+    fs.writeFileSync(recordPath, recordSnapshot);
+    const retry = await importer.processBacklog(bucket.id);
+    expect(retry.processed).toBe(1);
+    const restored = await universeBuilder.getUniverse(u.id);
+    expect(restored.name).toBe('Late Record Universe');
+    cursor = await readCursor(bucket.id);
+    expect(hasBeenProcessed(cursor, exp.filename, exp.manifestId)).toBe(true);
+  });
+
   it('subscription round-trip: subscribe → mutate → re-export onto same filename → unsubscribe → unshared event', async () => {
     const { subscribe, unsubscribe, subscriptionFilename, __resetForTests } = await import('./subscriptions.js');
     const { sharingEvents } = await import('./importer.js');


### PR DESCRIPTION
## Summary

Cloud-sync (Drive, Dropbox, etc.) can deliver a manifest into a share bucket **before** the record JSON files it references finish syncing. The current importer marks such a manifest as processed regardless — its `readReferencedRecords` returns an empty `records.universes` (or `series`, etc.) array, `applyAutoMerge` reports `applied=0`, but `markProcessed` still runs. The cursor entry then suppresses every future replay, so the record is silently lost until the user re-shares.

This mirrors and extends the existing missing-assets retry path added in fix \`b300dc6c\` ("fix: retry sharing imports while assets sync"). The asset path was covered; the record-file path was not.

### Real-world hit

A peer shared three universes at roughly the same time. For the third one, the manifest synced into the bucket faster than the record JSON. The importer logged \`📥 sharing: …manifest=18b1f41e… kind=universe mode=auto-merge applied=0\` and advanced the cursor. The universe never appeared locally, and every server restart since then was a no-op because the cursor said "done".

## What changed

- \`readReferencedRecords\` now returns \`{ records, missing }\`. The \`missing\` list contains every \`recordId\` whose JSON file isn't yet in the bucket. UUID-only ids (universe / media-job) only count as missing when neither candidate path resolves. Bible-entry prefixes (\`chr-\`/\`set-\`/\`obj-\`) are still skipped — they're never standalone records.
- \`processManifest\` defers \`markProcessed\` when either \`assetCopy.missing\` or \`missingRecords\` is non-empty, and surfaces both via \`outcome.pendingAssets\` / \`outcome.pendingRecords\`. The pending log line now reports both counts.
- \`promoteInboxItem\` throws \`SHARING_RECORDS_PENDING\` (sibling of the existing \`SHARING_ASSETS_PENDING\`) when records haven't synced yet, so the UI can reuse the same "still syncing" treatment.
- Drive-by: parallelize the per-record \`readJSONFile\` calls with \`Promise.all\` to match \`copyAssetsLocally\`'s precedent in the same file.

## Test plan

- [x] New regression test in \`integration.test.js\`: export a universe → delete the record JSON from the bucket → process the manifest → expect \`pending: true\`, \`pendingRecords: [u.id]\`, cursor not advanced, no local insert. Then restore the record JSON and run \`processBacklog\` → expect insertion and cursor advance.
- [x] Existing 18 sharing integration tests pass.
- [x] Full server suite: 4917 tests pass / 5 skipped.

## Out of scope

The latent \`subscriptions.json\` row also stays absent in the originally-broken case (because \`adoptImportedSubscription\` only fires after the record resolves). This PR only fixes the *manifest retry* side — once the record JSON syncs and the backlog replays, both the record and the subscription adoption land in the same pass.