### PR TITLE
fix(imagegen): unpack ERNIE patched latents before stepwise preview decode

### DIFF
--- a/scripts/_runner_common.py
+++ b/scripts/_runner_common.py
@@ -116,6 +116,7 @@ def make_stepwise_callback(
     width: int,
     *,
     unpack_latents=None,
+    preview_decoder=None,
 ):
     """Return a `callback_on_step_end` that decodes the running latent into
     a small preview PNG. `local.js#processLatestFrame` watches this dir and
@@ -130,6 +131,11 @@ def make_stepwise_callback(
       - flux2: transformer-packed latents come back as
         `(B, num_patches, C*p*p)`. Pass a callable that takes
         `(latents, height, width)` and returns the unpacked tensor.
+      - ernie: latents stay 4-D but are 2x2 patch-packed (e.g. `(B, 128, H/2, W/2)`
+        for a 32-ch VAE) AND need pipeline-specific BN-stats unnormalization
+        before `vae.decode`, not the standard `latents/scaling + shift`.
+        Pass `preview_decoder=fn(pipe, latents) -> image_tensor` to fully
+        override the per-step decode path.
     """
     if not stepwise_dir:
         return None
@@ -173,10 +179,16 @@ def make_stepwise_callback(
                 latents = unpack_latents(latents, height, width)
             elif latents.dim() != 4:
                 return callback_kwargs
-            scaled = latents / scaling + shift
-            if vae_dtype is not None and (scaled.dtype != vae_dtype or scaled.device != vae_device):
-                scaled = scaled.to(device=vae_device, dtype=vae_dtype)
-            decoded = vae.decode(scaled, return_dict=False)[0]
+            if preview_decoder is not None:
+                aligned = latents
+                if vae_dtype is not None and (aligned.dtype != vae_dtype or aligned.device != vae_device):
+                    aligned = aligned.to(device=vae_device, dtype=vae_dtype)
+                decoded = preview_decoder(pipe, aligned)
+            else:
+                scaled = latents / scaling + shift
+                if vae_dtype is not None and (scaled.dtype != vae_dtype or scaled.device != vae_device):
+                    scaled = scaled.to(device=vae_device, dtype=vae_dtype)
+                decoded = vae.decode(scaled, return_dict=False)[0]
             decoded = (decoded.clamp(-1, 1) + 1) / 2
             arr = (decoded[0].float().cpu().permute(1, 2, 0).numpy() * 255).astype("uint8")
             img = Image.fromarray(arr)

--- a/scripts/z_image_turbo.py
+++ b/scripts/z_image_turbo.py
@@ -131,7 +131,28 @@ def main() -> None:
     seed = args.seed if args.seed is not None else int(torch.randint(0, 2**31 - 1, (1,)).item())
     generator = make_generator(device, seed)
 
-    callback = make_stepwise_callback(args.stepwise_image_output_dir, pipe, int(args.height), int(args.width))
+    # ERNIE keeps latents 2x2 patch-packed during the loop (e.g. 32→128 ch at
+    # half spatial) and decodes via vae.bn unnormalization + _unpatchify_latents
+    # before vae.decode — the generic scaling/shift path fails with a channel
+    # mismatch ([32,32,1,1] weight vs 128-ch input). When the loaded pipeline
+    # exposes both hooks, pass an ERNIE-aware preview decoder.
+    preview_decoder = None
+    pipe_vae = getattr(pipe, "vae", None)
+    if hasattr(pipe, "_unpatchify_latents") and pipe_vae is not None and hasattr(pipe_vae, "bn"):
+        def preview_decoder(p, latents):  # noqa: E306 — local closure on purpose
+            vae = p.vae
+            mean = vae.bn.running_mean.view(1, -1, 1, 1).to(device=latents.device, dtype=latents.dtype)
+            std = torch.sqrt(vae.bn.running_var.view(1, -1, 1, 1) + 1e-5).to(device=latents.device, dtype=latents.dtype)
+            unpacked = p._unpatchify_latents(latents * std + mean)
+            return vae.decode(unpacked, return_dict=False)[0]
+
+    callback = make_stepwise_callback(
+        args.stepwise_image_output_dir,
+        pipe,
+        int(args.height),
+        int(args.width),
+        preview_decoder=preview_decoder,
+    )
 
     accepted = set(inspect.signature(pipe.__call__).parameters.keys())
     pipe_kwargs = dict(


### PR DESCRIPTION
## Summary

ERNIE-Image (`ernie-image` / `ernie-image-turbo`) generations spam a per-step error in the server log and produce no live preview frames in the UI:

```
🐍 ⚠️ stepwise preview failed at step N: RuntimeError: Given groups=1,
weight of size [32, 32, 1, 1], expected input[1, 128, 52, 76]
to have 32 channels, but got 128 channels instead
```

The final image still renders — only the SSE/stepwise live preview is broken — but the noisy log makes real failures hard to spot.

## Root cause

ERNIE's denoise loop keeps latents in their **2×2 patch-packed** layout — for a 32-channel VAE that's `(B, 128, H/2, W/2)`. The real `ErnieImagePipeline.__call__` runs two pre-decode steps before `vae.decode`:

```python
latents = latents * bn_std + bn_mean          # vae.bn stats unnormalization
latents = self._unpatchify_latents(latents)   # 128 -> 32 ch, double spatial
images = self.vae.decode(latents, return_dict=False)[0]
```

(see `diffusers/pipelines/ernie_image/pipeline_ernie_image.py:378-388`)

The shared `make_stepwise_callback` in `scripts/_runner_common.py` only applied the standard FLUX-style `latents / scaling + shift` path, so it fed packed 128-channel latents straight into a VAE conv expecting 32 — hence the every-step crash. Z-Image-Turbo and Flux2 don't hit this because their latents aren't patch-packed in the loop.

## Changes

- `scripts/_runner_common.py` — add a keyword-only `preview_decoder=` hook to `make_stepwise_callback` that fully overrides the per-step decode path when a runner needs pipeline-specific pre-decode math. Default `None` preserves the current scaling/shift + `vae.decode` flow, so Flux2 (`unpack_latents=_unpack_flux2_latents`) and standard Z-Image are unaffected.
- `scripts/z_image_turbo.py` — when the loaded pipeline exposes both `_unpatchify_latents` and `vae.bn` (the ERNIE shape contract), wire an ERNIE-aware decoder that mirrors the pipeline's real BN unnormalization + unpatchify + `vae.decode` sequence.

Detection is duck-typed on the two attrs rather than `isinstance(pipe, ErnieImagePipeline)` so it survives future ERNIE subclasses and stays robust to `AutoPipelineForImage2Image.from_pipe(...)` swaps in the i2i path.

## Test plan

- [x] ERNIE-Image run: confirm the per-step error stops firing and stepwise PNGs land in `/tmp/portos-stepwise-*`
- [x] Z-Image-Turbo run: confirm stepwise preview still works (unchanged code path — `_unpatchify_latents`/`vae.bn` not present, so `preview_decoder` stays `None`)
- [x] Flux2 run: confirm packed-3D latents still decode via the existing `unpack_latents=_unpack_flux2_latents` path