### PR TITLE
feat(image-gen): add US comic-trim resolution presets

### DIFF
--- a/client/src/lib/imageGenResolutions.js
+++ b/client/src/lib/imageGenResolutions.js
@@ -24,12 +24,19 @@ export const RESOLUTIONS = [
   { label: '1536×1536 (hi-res square)', w: 1536, h: 1536, compatible: ['codex', RUNNER_FAMILIES.FLUX2] },
   { label: '1024×1536 (hi-res portrait)', w: 1024, h: 1536, compatible: ['codex', RUNNER_FAMILIES.FLUX2] },
   { label: '1536×1024 (hi-res landscape)', w: 1536, h: 1024, compatible: ['codex', RUNNER_FAMILIES.FLUX2] },
+  // US comic-book trim presets — 6.625"×10.25" = 1.547:1 aspect, the real
+  // standard. Distinct from "portrait" because comic pages are squarer than
+  // 2:3. The draft size is small enough to also run on FLUX2/flux1 locally;
+  // hi-res variants are codex-only (impractical on local diffusers).
+  { label: '1280×1972 (comic page — draft)', w: 1280, h: 1972, compatible: ['codex', 'flux1', RUNNER_FAMILIES.FLUX2] },
+  { label: '1920×2951 (comic page — hi-res, margin)', w: 1920, h: 2951, compatible: ['codex'] },
+  { label: '1988×3056 (comic page — hi-res, full bleed)', w: 1988, h: 3056, compatible: ['codex'] },
   // gpt-image-2 final-render presets: hard ceiling is each edge ≤ 3840 and
   // total ≤ 8,294,400 pixels. All three below sit exactly at the pixel cap
   // — pick aspect by shape. Codex-only because mflux/diffusers are too slow
   // at this resolution to be practical (and the smaller models degrade).
   { label: '3840×2160 (4K landscape)', w: 3840, h: 2160, compatible: ['codex'] },
-  { label: '2160×3840 (4K portrait — comic page)', w: 2160, h: 3840, compatible: ['codex'] },
+  { label: '2160×3840 (4K portrait)', w: 2160, h: 3840, compatible: ['codex'] },
   { label: '2880×2880 (4K square)', w: 2880, h: 2880, compatible: ['codex'] },
 ];
 

--- a/client/src/lib/imageGenResolutions.js
+++ b/client/src/lib/imageGenResolutions.js
@@ -26,9 +26,10 @@ export const RESOLUTIONS = [
   { label: '1536×1024 (hi-res landscape)', w: 1536, h: 1024, compatible: ['codex', RUNNER_FAMILIES.FLUX2] },
   // US comic-book trim presets — 6.625"×10.25" = 1.547:1 aspect, the real
   // standard. Distinct from "portrait" because comic pages are squarer than
-  // 2:3. The draft size is small enough to also run on FLUX2/flux1 locally;
-  // hi-res variants are codex-only (impractical on local diffusers).
-  { label: '1280×1972 (comic page — draft)', w: 1280, h: 1972, compatible: ['codex', 'flux1', RUNNER_FAMILIES.FLUX2] },
+  // 2:3. Codex-only: every dimension here exceeds the implicit local-runner
+  // ceilings used by the entries above (flux1 ≤1216, FLUX2 ≤1536, Z-Image /
+  // ERNIE degrade past ~1280).
+  { label: '1280×1972 (comic page — draft)', w: 1280, h: 1972, compatible: ['codex'] },
   { label: '1920×2951 (comic page — hi-res, margin)', w: 1920, h: 2951, compatible: ['codex'] },
   { label: '1988×3056 (comic page — hi-res, full bleed)', w: 1988, h: 3056, compatible: ['codex'] },
   // gpt-image-2 final-render presets: hard ceiling is each edge ≤ 3840 and


### PR DESCRIPTION
## Summary

Adds three new resolution presets at the real US comic-book trim aspect (6.625"×10.25" = 1.547:1) and cleans up a misleading label on the existing 4K portrait preset.

The existing `2160×3840 (4K portrait — comic page)` preset is mislabeled — at 1.78:1 it's actually a phone-screen aspect, dramatically taller than any real printed comic page. The new presets match standard comic dimensions (and match the source files I work from: 1280×1972, 1920×2951, 1988×3056 are all 1.537–1.541:1).

### New presets (codex-only)

| Label | W×H | Pixels | Use |
|---|---|---|---|
| Comic page — draft | 1280×1972 | 2.5M | Fast draft renders |
| Comic page — hi-res, margin | 1920×2951 | 5.7M | Print-quality with white border |
| Comic page — hi-res, full bleed | 1988×3056 | 6.1M | Print-quality full bleed |

All three fit under codex's `MAX_IMAGE_EDGE=3840` / `MAX_IMAGE_PIXELS=8,294,400` caps. Marked codex-only because every dimension exceeds the implicit local-runner ceilings used by existing entries (flux1 ≤1216, FLUX2 ≤1536, Z-Image/ERNIE degrade past ~1280).

### Other change

- Renamed `2160×3840 (4K portrait — comic page)` → `2160×3840 (4K portrait)` — keeps the preset for users who want a tall portrait, drops the misleading semantic.

Bleed-vs-margin is a prompt/style concern (same canvas dimensions, different instructions to the model), so it stays in the style guide rather than as separate resolution entries.

## Test plan

- [ ] Open `/image-gen` → resolution dropdown shows the three new comic-trim entries under the hi-res block when codex is the selected backend
- [ ] Switch to local mode → comic-trim entries are filtered out (codex-only, like the 4K presets)
- [ ] Generate a comic page at 1988×3056 via codex → output is 1.537:1, fits gpt-image-2's pixel cap
- [ ] Universe Builder batch render shows the same options (shared module)