### PR TITLE
fix(media): broadcast annotation updates so notes/stars sync across views

### DIFF
--- a/client/src/hooks/useMediaAnnotations.js
+++ b/client/src/hooks/useMediaAnnotations.js
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { listMediaAnnotations, setMediaAnnotation } from '../services/api';
+import socket from '../services/socket';
 import toast from '../components/ui/Toast';
 
 // Loads the full media-annotation map once and exposes optimistic-update
@@ -21,6 +22,23 @@ export function useMediaAnnotations() {
       () => { /* fallback to empty map — non-fatal */ },
     );
     return () => { cancelled = true; };
+  }, []);
+
+  // Mirror server broadcasts so a note/star toggle in one view (or browser tab)
+  // shows up in every other open consumer. Originator also receives this; the
+  // server entry is authoritative and overrides the optimistic merge.
+  useEffect(() => {
+    const onUpdate = ({ key, entry }) => {
+      if (!key) return;
+      setAnnotations((prev) => {
+        const next = { ...prev };
+        if (entry) next[key] = entry;
+        else delete next[key];
+        return next;
+      });
+    };
+    socket.on('media:annotation:updated', onUpdate);
+    return () => socket.off('media:annotation:updated', onUpdate);
   }, []);
 
   const updateAnnotation = useCallback(async (key, patch) => {

--- a/server/routes/mediaAnnotations.js
+++ b/server/routes/mediaAnnotations.js
@@ -40,6 +40,10 @@ router.patch('/:key', asyncHandler(async (req, res) => {
   // Express decodes the path param, but the key still has to round-trip through
   // svc validation so a hand-rolled curl can't sneak past.
   const updated = await svc.setAnnotation(req.params.key, body).catch((err) => { throw mapServiceError(err); });
+  // Broadcast so every other open view (History, Collections, Pipeline, other
+  // browser tabs) reflects the change without a manual refresh. `entry` is null
+  // when the annotation was pruned (both starred=false and note='').
+  req.app.get('io')?.emit('media:annotation:updated', { key: req.params.key, entry: updated });
   res.json({ key: req.params.key, entry: updated });
 }));
 


### PR DESCRIPTION
## Summary

Follow-up to #251. The note/star auto-save persisted to disk but didn't notify other open consumers, so a note added in **Image History** didn't appear when the same image was opened from **Collections** or **Pipeline**, and didn't propagate to other browser tabs/devices until a manual page refresh.

Root cause: `PATCH /api/media/annotations/:key` wrote to the file and returned, but never emitted a socket event. `useMediaAnnotations` loaded the full annotation map once on mount and had no live subscription — every page held its own stale snapshot.

## Changes

**Server** — `server/routes/mediaAnnotations.js`
- After `svc.setAnnotation` returns, emit `media:annotation:updated` with `{ key, entry }`. `entry` is `null` when the annotation was pruned (both `starred=false` and empty `note`). Matches the existing `calendar:changed` / `apps:changed` broadcast pattern in this repo.

**Client** — `client/src/hooks/useMediaAnnotations.js`
- Subscribe to `media:annotation:updated` in a second `useEffect` and merge the server entry into the shared annotation map (set on present, delete on null). The originator also receives the broadcast — the server entry simply overrides the optimistic merge with the authoritative `updatedAt`, which keeps every consumer (`MediaHistory`, `ImageGen`, `VideoGen`, `MediaCollectionDetail`) converged without per-page refetches.

## Test plan

- [ ] Open the same image in two browser tabs (e.g. Image History and Collections). Add a note in tab A → appears in tab B's notes textarea within a render.
- [ ] Toggle the star in one view → star reflects in every other view that lists the same image.
- [ ] Clear an annotation (delete note + unstar) → the row is dropped from every consumer's map (server returns `entry: null`).
- [ ] Existing 13 tests in `server/services/mediaAnnotations.test.js` still pass.