### PR TITLE
refactor(client): extract clipboard helpers + useSwipeNav hook

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -91,7 +91,6 @@ For project goals, see [GOALS.md](./GOALS.md). For completed work, see [DONE.md]
 
 ### Code quality / dedup (from `/simplify` passes)
 
-- [ ] **Extract `useSwipeNav` hook + `lib/clipboard.js`.** `MediaLightbox` swipe nav; clipboard inlined across 8+ call sites. Clipboard can move now.
 - [ ] **Route `MediaLightbox` settings drawer through `components/Drawer.jsx`.** Reconcile `Drawer`'s flat Esc handler with the lightbox's layered Escape cascade.
 - [ ] **Extract `<ModelSelect>` component for the active+Legacy optgroup pattern.** `VideoGen.jsx` + `CreativeDirector.jsx` render identical blocks differing only in `m.name` vs `m.name || m.id`.
 - [ ] **Extract `mockPathsDataRoot()` test helper.** 6 test files open with byte-identical PATHS mocking setup.

--- a/client/src/components/apps/EditAppModal.jsx
+++ b/client/src/components/apps/EditAppModal.jsx
@@ -6,6 +6,7 @@ import * as api from '../../services/api';
 import { PORTOS_APP_ID } from '../../services/apiCore';
 import toast from '../ui/Toast';
 import Modal from '../ui/Modal';
+import { copyToClipboard } from '../../lib/clipboard';
 
 export default function EditAppModal({ app, onClose, onSave }) {
   const [formData, setFormData] = useState({
@@ -291,7 +292,7 @@ export default function EditAppModal({ app, onClose, onSave }) {
                     <pre className="bg-black/40 text-gray-200 p-2 rounded overflow-x-auto font-mono text-[11px] leading-tight">{tlsResult.snippet}</pre>
                     <button
                       type="button"
-                      onClick={() => { navigator.clipboard.writeText(tlsResult.snippet); toast.success('Snippet copied'); }}
+                      onClick={() => copyToClipboard(tlsResult.snippet, 'Snippet copied')}
                       className="absolute top-1 right-1 p-1 bg-port-border/60 hover:bg-port-border rounded"
                       aria-label="Copy snippet"
                     >

--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -27,6 +27,7 @@ import OutputBlocks from '../OutputBlocks';
 import MarkdownOutput from '../MarkdownOutput';
 import Modal from '../../ui/Modal';
 import toast from '../../ui/Toast';
+import { copyToClipboard } from '../../../lib/clipboard';
 
 // Extract task type from description (matches server-side extractTaskType)
 function extractTaskType(description) {
@@ -173,10 +174,7 @@ export default function AgentCard({ agent, onKill, onDelete, onResume, completed
   }, [agent.id, promptContent, loadingPrompt]);
 
   const copyPromptToClipboard = useCallback(() => {
-    if (!promptContent) return;
-    navigator.clipboard.writeText(promptContent)
-      .then(() => toast.success('Prompt copied to clipboard'))
-      .catch(err => toast.error(`Failed to copy: ${err.message}`));
+    copyToClipboard(promptContent, 'Prompt copied to clipboard');
   }, [promptContent]);
 
   // Send BTW message to running agent

--- a/client/src/components/digital-twin/NextActionBanner.jsx
+++ b/client/src/components/digital-twin/NextActionBanner.jsx
@@ -13,6 +13,7 @@ import {
 import * as api from '../../services/api';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
+import { writeClipboardSilently } from '../../lib/clipboard';
 import { ENRICHMENT_CATEGORIES } from './constants';
 import ScaleInput from './ScaleInput';
 
@@ -242,8 +243,8 @@ export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
                   {prompt}
                 </pre>
                 <button
-                  onClick={() => {
-                    navigator.clipboard.writeText(prompt);
+                  onClick={async () => {
+                    if (!(await writeClipboardSilently(prompt))) return;
                     setCopied(true);
                     setTimeout(() => setCopied(false), 2000);
                   }}
@@ -383,8 +384,8 @@ export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
                   {buildContinuationPrompt(activeGap.dimension, activeGap)}
                 </pre>
                 <button
-                  onClick={() => {
-                    navigator.clipboard.writeText(buildContinuationPrompt(activeGap.dimension, activeGap));
+                  onClick={async () => {
+                    if (!(await writeClipboardSilently(buildContinuationPrompt(activeGap.dimension, activeGap)))) return;
                     setCopied(true);
                     setTimeout(() => setCopied(false), 2000);
                   }}

--- a/client/src/components/digital-twin/tabs/ExportTab.jsx
+++ b/client/src/components/digital-twin/tabs/ExportTab.jsx
@@ -11,6 +11,7 @@ import {Download,
 import BrailleSpinner from '../../BrailleSpinner';
 import * as api from '../../../services/api';
 import toast from '../../ui/Toast';
+import { copyToClipboard } from '../../../lib/clipboard';
 
 import { DOCUMENT_CATEGORIES } from '../constants';
 
@@ -65,17 +66,18 @@ export default function ExportTab({ onRefresh: _onRefresh }) {
     setExporting(false);
   };
 
-  const copyToClipboard = async () => {
+  const handleCopyExport = async () => {
     if (!exportResult) return;
 
     const content = typeof exportResult.content === 'string'
       ? exportResult.content
       : JSON.stringify(exportResult.content, null, 2);
 
-    await navigator.clipboard.writeText(content);
-    setCopied(true);
-    toast.success('Copied to clipboard');
-    setTimeout(() => setCopied(false), 2000);
+    const ok = await copyToClipboard(content, 'Copied to clipboard');
+    if (ok) {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
   };
 
   const downloadFile = () => {
@@ -264,7 +266,7 @@ export default function ExportTab({ onRefresh: _onRefresh }) {
                 ~{exportResult.tokenEstimate?.toLocaleString()} tokens
               </span>
               <button
-                onClick={copyToClipboard}
+                onClick={handleCopyExport}
                 className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-400 hover:text-white transition-colors"
                 title="Copy to clipboard"
               >

--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -3,10 +3,11 @@ import {
   X, Copy, Sparkles, Film, Image as ImageIcon, Download, Eraser,
   ChevronLeft, ChevronRight, Maximize2, Minimize2, Star,
 } from 'lucide-react';
-import toast from '../ui/Toast';
 import PromptRefineModal from './PromptRefineModal';
 import AddToCollectionMenu from './AddToCollectionMenu';
 import { useScrollLock } from '../../hooks/useScrollLock';
+import { useSwipeNav } from '../../hooks/useSwipeNav';
+import { copyToClipboard } from '../../lib/clipboard';
 
 // Intentionally NOT migrated to <ui/Modal>. The prev/next buttons sit as
 // viewport-edge siblings of the card (not children of a constrained panel
@@ -32,10 +33,6 @@ const isEditableTarget = (e) => {
 // new level, drop a label here and the pill renders automatically.
 const CLEAN_LEVEL_LABELS = { light: 'Light', aggressive: 'Aggressive' };
 
-// Touch thresholds. dx > dy×1.2 keeps a diagonal scroll from being read as a
-// nav swipe but stays forgiving for a real thumb swipe.
-const SWIPE_MIN_PX = 50;
-
 // onClean(item, level) — optional. Returning a rejected promise keeps the
 // lightbox open (e.g. on error) so the user can retry.
 export default function MediaLightbox({
@@ -54,7 +51,6 @@ export default function MediaLightbox({
 }) {
   const [fullScreen, setFullScreen] = useState(false);
   const [refineOpen, setRefineOpen] = useState(false);
-  const touchStart = useRef({ x: null, y: null });
   useScrollLock(!!item);
   // Read callbacks + frequently-changing values from refs so the keydown
   // listener and the note-save debounce don't tear down on every parent
@@ -103,16 +99,13 @@ export default function MediaLightbox({
   // Reset refine modal when the previewed item changes.
   useEffect(() => { setRefineOpen(false); }, [item?.key]);
 
+  const { onTouchStart, onTouchEnd } = useSwipeNav({ onPrevious, onNext, hasPrevious, hasNext });
+
   if (!item) return null;
   const isVideo = item.kind === 'video';
 
   const copy = (text, label = 'Prompt') => {
-    if (!text) return;
-    if (!navigator.clipboard?.writeText) { toast.error('Clipboard unavailable on insecure context'); return; }
-    navigator.clipboard.writeText(text).then(
-      () => toast.success(`${label} copied`),
-      () => toast.error('Copy failed')
-    );
+    copyToClipboard(text, `${label} copied`);
   };
 
   const isCodex = item.mode === 'codex';
@@ -132,28 +125,6 @@ export default function MediaLightbox({
     ['FPS', item.fps],
     ['Created', item.createdAt && new Date(item.createdAt).toLocaleString()],
   ].filter(([, v]) => v != null && v !== '');
-
-  // Ignore touches that originate on inline buttons (max/min toggle) so a
-  // button tap isn't also read as a swipe-start on the image.
-  const isButtonTouch = (e) => !!e.target.closest('button');
-  const onTouchStart = (e) => {
-    if (isButtonTouch(e)) { touchStart.current = { x: null, y: null }; return; }
-    const t = e.touches[0];
-    touchStart.current = { x: t.clientX, y: t.clientY };
-  };
-  const onTouchEnd = (e) => {
-    const start = touchStart.current;
-    if (start.x == null) return;
-    if (isButtonTouch(e)) { touchStart.current = { x: null, y: null }; return; }
-    const end = e.changedTouches[0];
-    const dx = end.clientX - start.x;
-    const dy = end.clientY - start.y;
-    touchStart.current = { x: null, y: null };
-    if (Math.abs(dx) >= SWIPE_MIN_PX && Math.abs(dx) > Math.abs(dy) * 1.2) {
-      if (dx > 0 && hasPrevious) onPrevious?.();
-      else if (dx < 0 && hasNext) onNext?.();
-    }
-  };
 
   const cardClasses = fullScreen
     ? 'relative w-full h-full bg-black flex'

--- a/client/src/hooks/useSwipeNav.js
+++ b/client/src/hooks/useSwipeNav.js
@@ -1,0 +1,35 @@
+import { useRef, useCallback } from 'react';
+
+// Horizontal swipe ≥ 50px and dominantly horizontal (dx > dy × 1.2) — keeps
+// diagonal scrolls from registering as nav but stays forgiving for thumb swipes.
+const SWIPE_MIN_PX = 50;
+const HORIZONTAL_BIAS = 1.2;
+
+// Ignore touches that originate on inline buttons so a button tap on the
+// surface (e.g. fullscreen toggle) isn't also read as a swipe-start.
+const isButtonTouch = (e) => !!e.target.closest('button');
+
+export function useSwipeNav({ onPrevious, onNext, hasPrevious = false, hasNext = false } = {}) {
+  const touchStart = useRef({ x: null, y: null });
+
+  const onTouchStart = useCallback((e) => {
+    if (isButtonTouch(e)) { touchStart.current = { x: null, y: null }; return; }
+    const t = e.touches[0];
+    touchStart.current = { x: t.clientX, y: t.clientY };
+  }, []);
+
+  const onTouchEnd = useCallback((e) => {
+    const start = touchStart.current;
+    if (start.x == null) return;
+    if (isButtonTouch(e)) { touchStart.current = { x: null, y: null }; return; }
+    const end = e.changedTouches[0];
+    const dx = end.clientX - start.x;
+    const dy = end.clientY - start.y;
+    touchStart.current = { x: null, y: null };
+    if (Math.abs(dx) < SWIPE_MIN_PX || Math.abs(dx) <= Math.abs(dy) * HORIZONTAL_BIAS) return;
+    if (dx > 0 && hasPrevious) onPrevious?.();
+    else if (dx < 0 && hasNext) onNext?.();
+  }, [hasPrevious, hasNext, onPrevious, onNext]);
+
+  return { onTouchStart, onTouchEnd };
+}

--- a/client/src/hooks/useSwipeNav.js
+++ b/client/src/hooks/useSwipeNav.js
@@ -7,7 +7,9 @@ const HORIZONTAL_BIAS = 1.2;
 
 // Ignore touches that originate on inline buttons so a button tap on the
 // surface (e.g. fullscreen toggle) isn't also read as a swipe-start.
-const isButtonTouch = (e) => !!e.target.closest('button');
+// Optional-chain on `closest` because touch targets aren't guaranteed to be
+// Elements (e.g. Text nodes, jsdom-style envs without `closest`).
+const isButtonTouch = (e) => !!e.target?.closest?.('button');
 
 export function useSwipeNav({ onPrevious, onNext, hasPrevious = false, hasNext = false } = {}) {
   const touchStart = useRef({ x: null, y: null });
@@ -20,8 +22,10 @@ export function useSwipeNav({ onPrevious, onNext, hasPrevious = false, hasNext =
 
   const onTouchEnd = useCallback((e) => {
     const start = touchStart.current;
+    // Origin-based gate: if onTouchStart cleared the ref because the touch
+    // started on a button, we never bail on the end target — a swipe that
+    // begins on the surface and ends over an inline control is still valid.
     if (start.x == null) return;
-    if (isButtonTouch(e)) { touchStart.current = { x: null, y: null }; return; }
     const end = e.changedTouches[0];
     const dx = end.clientX - start.x;
     const dy = end.clientY - start.y;

--- a/client/src/hooks/useSwipeNav.js
+++ b/client/src/hooks/useSwipeNav.js
@@ -5,11 +5,17 @@ import { useRef, useCallback } from 'react';
 const SWIPE_MIN_PX = 50;
 const HORIZONTAL_BIAS = 1.2;
 
-// Ignore touches whose start OR end target is an inline button: a tap on the
-// surface (e.g. fullscreen toggle) shouldn't seed a swipe, and a swipe that
-// happens to release over a button shouldn't double-fire as nav + a synthetic
-// button click. Optional-chain on `closest` because touch targets aren't
-// guaranteed to be Elements (e.g. Text nodes, jsdom-style envs).
+// Ignore touches that *originate* on an inline button so a tap on the
+// surface (e.g. the fullscreen toggle) isn't seeded as a swipe-start. The
+// gate runs only on touchstart: `Touch.target` on a touchend event is the
+// element the touch *began* on (per spec), not where the finger released —
+// so a symmetrical check in onTouchEnd would just re-check the start
+// element. We don't gate on the end position either: a deliberate swipe
+// crossing SWIPE_MIN_PX won't synthesize a click on a button the finger
+// happens to release over (the browser's tap-slop is much smaller than
+// 50px), so nav-on-release-over-button is safe to allow.
+// Optional-chain on `closest` because touch targets aren't guaranteed to
+// be Elements (e.g. Text nodes, jsdom-style envs).
 const isButtonTouch = (e) => !!e.target?.closest?.('button');
 
 export function useSwipeNav({ onPrevious, onNext, hasPrevious = false, hasNext = false } = {}) {
@@ -24,7 +30,6 @@ export function useSwipeNav({ onPrevious, onNext, hasPrevious = false, hasNext =
   const onTouchEnd = useCallback((e) => {
     const start = touchStart.current;
     if (start.x == null) return;
-    if (isButtonTouch(e)) { touchStart.current = { x: null, y: null }; return; }
     const end = e.changedTouches[0];
     const dx = end.clientX - start.x;
     const dy = end.clientY - start.y;

--- a/client/src/hooks/useSwipeNav.js
+++ b/client/src/hooks/useSwipeNav.js
@@ -5,10 +5,11 @@ import { useRef, useCallback } from 'react';
 const SWIPE_MIN_PX = 50;
 const HORIZONTAL_BIAS = 1.2;
 
-// Ignore touches that originate on inline buttons so a button tap on the
-// surface (e.g. fullscreen toggle) isn't also read as a swipe-start.
-// Optional-chain on `closest` because touch targets aren't guaranteed to be
-// Elements (e.g. Text nodes, jsdom-style envs without `closest`).
+// Ignore touches whose start OR end target is an inline button: a tap on the
+// surface (e.g. fullscreen toggle) shouldn't seed a swipe, and a swipe that
+// happens to release over a button shouldn't double-fire as nav + a synthetic
+// button click. Optional-chain on `closest` because touch targets aren't
+// guaranteed to be Elements (e.g. Text nodes, jsdom-style envs).
 const isButtonTouch = (e) => !!e.target?.closest?.('button');
 
 export function useSwipeNav({ onPrevious, onNext, hasPrevious = false, hasNext = false } = {}) {
@@ -22,10 +23,8 @@ export function useSwipeNav({ onPrevious, onNext, hasPrevious = false, hasNext =
 
   const onTouchEnd = useCallback((e) => {
     const start = touchStart.current;
-    // Origin-based gate: if onTouchStart cleared the ref because the touch
-    // started on a button, we never bail on the end target — a swipe that
-    // begins on the surface and ends over an inline control is still valid.
     if (start.x == null) return;
+    if (isButtonTouch(e)) { touchStart.current = { x: null, y: null }; return; }
     const end = e.changedTouches[0];
     const dx = end.clientX - start.x;
     const dy = end.clientY - start.y;

--- a/client/src/lib/clipboard.js
+++ b/client/src/lib/clipboard.js
@@ -1,13 +1,19 @@
 import toast from '../components/ui/Toast';
 
 // `navigator.clipboard` is undefined on insecure-origin contexts (raw HTTP over
-// LAN, some embedded webviews). Each helper short-circuits cleanly so callers
-// don't have to re-check `?.writeText` / `?.readText` at every site.
+// LAN, some embedded webviews). Reading via `globalThis.navigator` also keeps
+// the helpers safe in non-browser contexts (unit tests, SSR), where a bare
+// `navigator` reference would throw a ReferenceError before optional-chaining
+// could help. Each helper short-circuits cleanly so callers don't have to
+// re-check `?.writeText` / `?.readText` at every site.
+
+const clipboard = () => globalThis.navigator?.clipboard;
 
 export async function writeClipboardSilently(text) {
-  if (!text || !navigator.clipboard?.writeText) return false;
+  const c = clipboard();
+  if (!text || !c?.writeText) return false;
   try {
-    await navigator.clipboard.writeText(text);
+    await c.writeText(text);
     return true;
   } catch {
     return false;
@@ -19,12 +25,13 @@ export async function writeClipboardSilently(text) {
 // indicator in their own UI.
 export async function copyToClipboard(text, successMessage = 'Copied') {
   if (!text) return false;
-  if (!navigator.clipboard?.writeText) {
+  const c = clipboard();
+  if (!c?.writeText) {
     toast.error('Clipboard unavailable on insecure context');
     return false;
   }
   try {
-    await navigator.clipboard.writeText(text);
+    await c.writeText(text);
     if (successMessage) toast.success(successMessage);
     return true;
   } catch {
@@ -34,9 +41,10 @@ export async function copyToClipboard(text, successMessage = 'Copied') {
 }
 
 export async function readClipboard() {
-  if (!navigator.clipboard?.readText) return null;
+  const c = clipboard();
+  if (!c?.readText) return null;
   try {
-    return await navigator.clipboard.readText();
+    return await c.readText();
   } catch {
     return null;
   }

--- a/client/src/lib/clipboard.js
+++ b/client/src/lib/clipboard.js
@@ -14,6 +14,9 @@ export async function writeClipboardSilently(text) {
   }
 }
 
+// Pass `successMessage: null` to keep the failure/insecure-context toasts but
+// suppress the success toast — for callers that own a transient "Copied"
+// indicator in their own UI.
 export async function copyToClipboard(text, successMessage = 'Copied') {
   if (!text) return false;
   if (!navigator.clipboard?.writeText) {
@@ -22,7 +25,7 @@ export async function copyToClipboard(text, successMessage = 'Copied') {
   }
   try {
     await navigator.clipboard.writeText(text);
-    toast.success(successMessage);
+    if (successMessage) toast.success(successMessage);
     return true;
   } catch {
     toast.error('Copy failed');

--- a/client/src/lib/clipboard.js
+++ b/client/src/lib/clipboard.js
@@ -27,7 +27,12 @@ export async function copyToClipboard(text, successMessage = 'Copied') {
   if (!text) return false;
   const c = clipboard();
   if (!c?.writeText) {
-    toast.error('Clipboard unavailable on insecure context');
+    // `navigator.clipboard` can be missing on insecure origins *or* on secure
+    // origins where the API is disabled (unsupported browser, Permissions
+    // Policy, etc.). Only call out the insecure-context case when we can
+    // confirm it — otherwise stay generic so the message isn't misleading.
+    const insecure = globalThis.isSecureContext === false;
+    toast.error(insecure ? 'Clipboard unavailable on insecure context' : 'Clipboard unavailable');
     return false;
   }
   try {

--- a/client/src/lib/clipboard.js
+++ b/client/src/lib/clipboard.js
@@ -1,0 +1,40 @@
+import toast from '../components/ui/Toast';
+
+// `navigator.clipboard` is undefined on insecure-origin contexts (raw HTTP over
+// LAN, some embedded webviews). Each helper short-circuits cleanly so callers
+// don't have to re-check `?.writeText` / `?.readText` at every site.
+
+export async function writeClipboardSilently(text) {
+  if (!text || !navigator.clipboard?.writeText) return false;
+  try {
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function copyToClipboard(text, successMessage = 'Copied') {
+  if (!text) return false;
+  if (!navigator.clipboard?.writeText) {
+    toast.error('Clipboard unavailable on insecure context');
+    return false;
+  }
+  try {
+    await navigator.clipboard.writeText(text);
+    toast.success(successMessage);
+    return true;
+  } catch {
+    toast.error('Copy failed');
+    return false;
+  }
+}
+
+export async function readClipboard() {
+  if (!navigator.clipboard?.readText) return null;
+  try {
+    return await navigator.clipboard.readText();
+  } catch {
+    return null;
+  }
+}

--- a/client/src/lib/clipboard.test.js
+++ b/client/src/lib/clipboard.test.js
@@ -23,6 +23,10 @@ function setClipboard(clipboard) {
   vi.stubGlobal('navigator', clipboard === undefined ? {} : { clipboard });
 }
 
+function unsetNavigator() {
+  vi.stubGlobal('navigator', undefined);
+}
+
 describe('writeClipboardSilently', () => {
   it('returns true and writes text on success', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
@@ -35,6 +39,12 @@ describe('writeClipboardSilently', () => {
 
   it('returns false when navigator.clipboard is unavailable (no toasts)', async () => {
     setClipboard(undefined);
+    expect(await writeClipboardSilently('hello')).toBe(false);
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it('returns false when navigator itself is undefined (no ReferenceError)', async () => {
+    unsetNavigator();
     expect(await writeClipboardSilently('hello')).toBe(false);
     expect(toastMock.error).not.toHaveBeenCalled();
   });
@@ -87,6 +97,12 @@ describe('copyToClipboard', () => {
     expect(toastMock.error).toHaveBeenCalledWith('Clipboard unavailable on insecure context');
   });
 
+  it('toasts the insecure-context error when navigator itself is undefined', async () => {
+    unsetNavigator();
+    expect(await copyToClipboard('hello')).toBe(false);
+    expect(toastMock.error).toHaveBeenCalledWith('Clipboard unavailable on insecure context');
+  });
+
   it('toasts the failure and returns false when writeText throws', async () => {
     setClipboard({ writeText: vi.fn().mockRejectedValue(new Error('denied')) });
     expect(await copyToClipboard('hello')).toBe(false);
@@ -110,6 +126,11 @@ describe('readClipboard', () => {
 
   it('returns null when navigator.clipboard.readText is unavailable', async () => {
     setClipboard({});
+    expect(await readClipboard()).toBeNull();
+  });
+
+  it('returns null when navigator itself is undefined (no ReferenceError)', async () => {
+    unsetNavigator();
     expect(await readClipboard()).toBeNull();
   });
 

--- a/client/src/lib/clipboard.test.js
+++ b/client/src/lib/clipboard.test.js
@@ -91,16 +91,25 @@ describe('copyToClipboard', () => {
     expect(toastMock.success).not.toHaveBeenCalled();
   });
 
-  it('toasts the insecure-context error and returns false when clipboard is unavailable', async () => {
+  it('toasts the insecure-context error when isSecureContext is false', async () => {
     setClipboard(undefined);
+    vi.stubGlobal('isSecureContext', false);
     expect(await copyToClipboard('hello')).toBe(false);
     expect(toastMock.error).toHaveBeenCalledWith('Clipboard unavailable on insecure context');
   });
 
-  it('toasts the insecure-context error when navigator itself is undefined', async () => {
-    unsetNavigator();
+  it('toasts the generic error when clipboard is missing on a secure context', async () => {
+    setClipboard(undefined);
+    vi.stubGlobal('isSecureContext', true);
     expect(await copyToClipboard('hello')).toBe(false);
-    expect(toastMock.error).toHaveBeenCalledWith('Clipboard unavailable on insecure context');
+    expect(toastMock.error).toHaveBeenCalledWith('Clipboard unavailable');
+  });
+
+  it('toasts the generic error when navigator itself is undefined and isSecureContext is unknown', async () => {
+    unsetNavigator();
+    // isSecureContext deliberately not stubbed — undefined ≠ false
+    expect(await copyToClipboard('hello')).toBe(false);
+    expect(toastMock.error).toHaveBeenCalledWith('Clipboard unavailable');
   });
 
   it('toasts the failure and returns false when writeText throws', async () => {

--- a/client/src/lib/clipboard.test.js
+++ b/client/src/lib/clipboard.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const toastMock = { success: vi.fn(), error: vi.fn() };
+
+vi.mock('../components/ui/Toast', () => ({ default: toastMock }));
+
+let writeClipboardSilently;
+let copyToClipboard;
+let readClipboard;
+
+beforeEach(async () => {
+  toastMock.success.mockReset();
+  toastMock.error.mockReset();
+  vi.resetModules();
+  ({ writeClipboardSilently, copyToClipboard, readClipboard } = await import('./clipboard.js'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function setClipboard(clipboard) {
+  vi.stubGlobal('navigator', clipboard === undefined ? {} : { clipboard });
+}
+
+describe('writeClipboardSilently', () => {
+  it('returns true and writes text on success', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    setClipboard({ writeText });
+    expect(await writeClipboardSilently('hello')).toBe(true);
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(toastMock.error).not.toHaveBeenCalled();
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+
+  it('returns false when navigator.clipboard is unavailable (no toasts)', async () => {
+    setClipboard(undefined);
+    expect(await writeClipboardSilently('hello')).toBe(false);
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it('returns false when writeText throws (no toasts)', async () => {
+    setClipboard({ writeText: vi.fn().mockRejectedValue(new Error('denied')) });
+    expect(await writeClipboardSilently('hello')).toBe(false);
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it('returns false for empty text without touching navigator', async () => {
+    const writeText = vi.fn();
+    setClipboard({ writeText });
+    expect(await writeClipboardSilently('')).toBe(false);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+});
+
+describe('copyToClipboard', () => {
+  it('toasts success and returns true on success', async () => {
+    setClipboard({ writeText: vi.fn().mockResolvedValue(undefined) });
+    expect(await copyToClipboard('hello')).toBe(true);
+    expect(toastMock.success).toHaveBeenCalledWith('Copied');
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it('uses a custom success message when provided', async () => {
+    setClipboard({ writeText: vi.fn().mockResolvedValue(undefined) });
+    expect(await copyToClipboard('hello', 'Snippet copied')).toBe(true);
+    expect(toastMock.success).toHaveBeenCalledWith('Snippet copied');
+  });
+
+  it('suppresses the success toast when successMessage is null', async () => {
+    setClipboard({ writeText: vi.fn().mockResolvedValue(undefined) });
+    expect(await copyToClipboard('hello', null)).toBe(true);
+    expect(toastMock.success).not.toHaveBeenCalled();
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it('still toasts the failure on null successMessage when writeText throws', async () => {
+    setClipboard({ writeText: vi.fn().mockRejectedValue(new Error('denied')) });
+    expect(await copyToClipboard('hello', null)).toBe(false);
+    expect(toastMock.error).toHaveBeenCalledWith('Copy failed');
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+
+  it('toasts the insecure-context error and returns false when clipboard is unavailable', async () => {
+    setClipboard(undefined);
+    expect(await copyToClipboard('hello')).toBe(false);
+    expect(toastMock.error).toHaveBeenCalledWith('Clipboard unavailable on insecure context');
+  });
+
+  it('toasts the failure and returns false when writeText throws', async () => {
+    setClipboard({ writeText: vi.fn().mockRejectedValue(new Error('denied')) });
+    expect(await copyToClipboard('hello')).toBe(false);
+    expect(toastMock.error).toHaveBeenCalledWith('Copy failed');
+    expect(toastMock.success).not.toHaveBeenCalled();
+  });
+
+  it('returns false for empty text without toasting', async () => {
+    setClipboard({ writeText: vi.fn() });
+    expect(await copyToClipboard('')).toBe(false);
+    expect(toastMock.success).not.toHaveBeenCalled();
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('readClipboard', () => {
+  it('returns the clipboard contents on success', async () => {
+    setClipboard({ readText: vi.fn().mockResolvedValue('pasted') });
+    expect(await readClipboard()).toBe('pasted');
+  });
+
+  it('returns null when navigator.clipboard.readText is unavailable', async () => {
+    setClipboard({});
+    expect(await readClipboard()).toBeNull();
+  });
+
+  it('returns null when readText throws', async () => {
+    setClipboard({ readText: vi.fn().mockRejectedValue(new Error('denied')) });
+    expect(await readClipboard()).toBeNull();
+  });
+});

--- a/client/src/pages/JiraReports.jsx
+++ b/client/src/pages/JiraReports.jsx
@@ -62,7 +62,11 @@ function ReportDetail({ report }) {
 
   const handleCopy = async () => {
     const plain = statusText.replace(/\*\*/g, '');
-    await writeClipboardSilently(plain);
+    const ok = await writeClipboardSilently(plain);
+    if (!ok) {
+      toast.error('Copy failed');
+      return;
+    }
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/client/src/pages/JiraReports.jsx
+++ b/client/src/pages/JiraReports.jsx
@@ -7,7 +7,7 @@ import {FileText,
   Check} from 'lucide-react';
 import * as api from '../services/api';
 import BrailleSpinner from '../components/BrailleSpinner';
-import { writeClipboardSilently } from '../lib/clipboard';
+import { copyToClipboard } from '../lib/clipboard';
 
 function ReportCard({ report, onClick, isSelected }) {
   return (
@@ -62,11 +62,8 @@ function ReportDetail({ report }) {
 
   const handleCopy = async () => {
     const plain = statusText.replace(/\*\*/g, '');
-    const ok = await writeClipboardSilently(plain);
-    if (!ok) {
-      toast.error('Copy failed');
-      return;
-    }
+    const ok = await copyToClipboard(plain, null);
+    if (!ok) return;
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/client/src/pages/JiraReports.jsx
+++ b/client/src/pages/JiraReports.jsx
@@ -7,6 +7,7 @@ import {FileText,
   Check} from 'lucide-react';
 import * as api from '../services/api';
 import BrailleSpinner from '../components/BrailleSpinner';
+import { writeClipboardSilently } from '../lib/clipboard';
 
 function ReportCard({ report, onClick, isSelected }) {
   return (
@@ -61,7 +62,7 @@ function ReportDetail({ report }) {
 
   const handleCopy = async () => {
     const plain = statusText.replace(/\*\*/g, '');
-    await navigator.clipboard.writeText(plain);
+    await writeClipboardSilently(plain);
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/client/src/pages/RapidReader.jsx
+++ b/client/src/pages/RapidReader.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Zap, ClipboardPaste, Eraser } from 'lucide-react';
 import RapidReader from '../components/RapidReader';
+import { readClipboard } from '../lib/clipboard';
 
 const SAMPLE = `Speed reading is a collection of techniques used to scan text quickly while still understanding what you've read. Most people read in chunks of three or four words at a time, which slows them down. Rapid serial visual presentation flashes one word at a time at a fixed location, removing the need to move your eyes. With practice, comprehension stays intact at three to five hundred words per minute, and many readers can push past six hundred for familiar material.`;
 
@@ -30,8 +31,7 @@ export default function RapidReaderPage() {
   };
 
   const pasteFromClipboard = async () => {
-    if (!navigator.clipboard?.readText) return;
-    const t = await navigator.clipboard.readText().catch(() => '');
+    const t = await readClipboard();
     if (t) setText(t);
   };
 

--- a/client/src/pages/RunsHistoryPage.jsx
+++ b/client/src/pages/RunsHistoryPage.jsx
@@ -4,6 +4,7 @@ import { Trash2, RotateCcw, MessageSquarePlus } from 'lucide-react';
 import * as api from '../services/api';
 import { formatTime, formatRuntime } from '../utils/formatters';
 import BrailleSpinner from '../components/BrailleSpinner';
+import { writeClipboardSilently } from '../lib/clipboard';
 
 export function RunsHistoryPage() {
   const navigate = useNavigate();
@@ -304,7 +305,7 @@ export function RunsHistoryPage() {
                           <button
                             onClick={(e) => {
                               e.stopPropagation();
-                              navigator.clipboard?.writeText(run.id).catch(() => {});
+                              writeClipboardSilently(run.id);
                             }}
                             className="p-1 text-gray-500 hover:text-white transition-colors"
                             title="Copy execution ID"

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -7,6 +7,7 @@ import '@xterm/xterm/css/xterm.css';
 import { useSocket } from '../hooks/useSocket';
 import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown, Plus, X, Terminal as TerminalIcon, ClipboardPaste, OctagonX } from 'lucide-react';
 import * as api from '../services/api';
+import { readClipboard } from '../lib/clipboard';
 
 // Must match MAX_TOTAL_SESSIONS in server/services/shell.js
 const MAX_SESSIONS = 5;
@@ -150,14 +151,10 @@ export default function Shell() {
 
   const sendCommand = useCallback((cmd) => emitShellInput(cmd + '\n'), [emitShellInput]);
   const sendCtrlC = useCallback(() => emitShellInput('\x03'), [emitShellInput]);
-  const handlePaste = useCallback(() => {
-    if (navigator.clipboard?.readText) {
-      navigator.clipboard.readText()
-        .then(text => { if (text) emitShellInput(text); })
-        .catch(() => setShowPasteInput(true));
-    } else {
-      setShowPasteInput(true);
-    }
+  const handlePaste = useCallback(async () => {
+    const text = await readClipboard();
+    if (text == null) { setShowPasteInput(true); return; }
+    if (text) emitShellInput(text);
   }, [emitShellInput]);
 
   const handlePasteInputEvent = useCallback((e) => {

--- a/server/lib/storyArc.js
+++ b/server/lib/storyArc.js
@@ -319,6 +319,7 @@ export function sanitizeSeasonList(rawList, opts = {}) {
  * timestamps, and the canonical defaults.
  */
 export function buildSeason(input = {}) {
+  const now = nowIso();
   return sanitizeSeason({
     id: `${SEASON_ID_PREFIX}${randomUUID()}`,
     number: input.number,
@@ -329,7 +330,7 @@ export function buildSeason(input = {}) {
     themes: input.themes,
     endingHook: input.endingHook,
     status: input.status,
-    createdAt: nowIso(),
-    updatedAt: nowIso(),
+    createdAt: now,
+    updatedAt: now,
   });
 }


### PR DESCRIPTION
## Summary

Completes the **Extract `useSwipeNav` hook + `lib/clipboard.js`** dedup item from PLAN.md's Code quality section.

- New `client/src/lib/clipboard.js` exports three helpers — `copyToClipboard(text, successMessage)` (toasts), `writeClipboardSilently(text)` (returns boolean), `readClipboard()` (returns string or null). The insecure-origin guard (`navigator.clipboard?.writeText`) and the "Copy failed" toast now live in one place instead of being copy-pasted across 10 sites.
- New `client/src/hooks/useSwipeNav.js` encapsulates `MediaLightbox`'s horizontal swipe nav (`touchStart` ref, button-touch guard, 50px / 1.2× horizontal-bias threshold).
- Migrated 10 call sites: `MediaLightbox`, `AgentCard`, `EditAppModal`, `NextActionBanner` (×2), `ExportTab`, `RunsHistoryPage`, `RapidReader`, `JiraReports`, `Shell`.
- **Pre-existing bug fix** in `NextActionBanner`: the copy-prompt buttons previously called `setCopied(true)` unconditionally — the green checkmark would lie if the write failed. Both sites now gate on the actual write result.

## Test plan

- [ ] Open `MediaLightbox` on mobile, swipe left/right to nav between images
- [ ] Copy prompt / negative / seed / codex-session from the lightbox; verify toast
- [ ] On insecure origin, verify the "Clipboard unavailable on insecure context" toast still fires
- [ ] `Shell` paste with `clipboard.readText` available, denied, and unavailable — manual paste input should appear in the last two cases
- [ ] `NextActionBanner` copy-prompt buttons: checkmark only appears after a successful write
- [ ] `ExportTab` Copy button still works (local function renamed to `handleCopyExport`)