### PR TITLE
feat(pipeline): per-issue cover-concept LLM button on Comic stage

### DIFF
--- a/client/src/components/pipeline/ArcCanvas.jsx
+++ b/client/src/components/pipeline/ArcCanvas.jsx
@@ -1092,7 +1092,7 @@ function VolumeCoversPanel({ series, season, seasons, onSeriesUpdate }) {
       commit: true,
       providerOverride: series.llm?.provider || undefined,
       modelOverride: series.llm?.model || undefined,
-    }).catch((err) => {
+    }, { silent: true }).catch((err) => {
       toast.error(err.message || 'Failed to generate cover concepts');
       return null;
     });

--- a/client/src/components/pipeline/stages/ComicScriptStage.jsx
+++ b/client/src/components/pipeline/stages/ComicScriptStage.jsx
@@ -318,26 +318,34 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
     const tooltip = filled
       ? `Clear the ${noun} concept first — the LLM only seeds blank concepts to avoid clobbering your edits.`
       : `Have the LLM propose a ${noun} concept for this issue`;
+    const hintId = `concept-hint-${issue.id}-${target}`;
     // Use `aria-disabled` (not the DOM `disabled` attribute) so the
     // button stays in the keyboard tab order and the `title` tooltip is
     // discoverable on focus as well as hover. `disabled` removes the
     // element from tab order entirely and most browsers suppress hover
     // events on it, hiding the "clear first" guidance from keyboard +
     // screen-reader users. Click handler is gated on the same flag.
+    //
+    // `aria-describedby` (not `aria-label`) preserves the visible label
+    // ("Generate concept (LLM)") as the accessible name — WCAG 2.5.3
+    // "Label in Name" — and adds the tooltip as supplementary context.
     return (
-      <button
-        type="button"
-        onClick={disabled ? undefined : () => handleGenerateConcept(target)}
-        aria-disabled={disabled || undefined}
-        title={tooltip}
-        aria-label={tooltip}
-        className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-port-accent hover:text-white border border-port-border bg-port-bg hover:border-port-accent/40 ${
-          disabled ? 'opacity-40 cursor-not-allowed' : ''
-        }`}
-      >
-        {generating ? <Loader2 size={12} className="animate-spin" /> : <Wand2 size={12} />}
-        Generate concept (LLM)
-      </button>
+      <>
+        <button
+          type="button"
+          onClick={disabled ? undefined : () => handleGenerateConcept(target)}
+          aria-disabled={disabled || undefined}
+          aria-describedby={hintId}
+          title={tooltip}
+          className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-port-accent hover:text-white border border-port-border bg-port-bg hover:border-port-accent/40 ${
+            disabled ? 'opacity-40 cursor-not-allowed' : ''
+          }`}
+        >
+          {generating ? <Loader2 size={12} className="animate-spin" /> : <Wand2 size={12} />}
+          Generate concept (LLM)
+        </button>
+        <span id={hintId} className="sr-only">{tooltip}</span>
+      </>
     );
   };
 

--- a/client/src/components/pipeline/stages/ComicScriptStage.jsx
+++ b/client/src/components/pipeline/stages/ComicScriptStage.jsx
@@ -290,6 +290,7 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
   const [generatingConcept, setGeneratingConcept] = useState({ cover: false, backCover: false });
 
   const handleGenerateConcept = async (target) => {
+    const label = target === 'backCover' ? 'Back cover' : 'Cover';
     setGeneratingConcept((g) => ({ ...g, [target]: true }));
     const result = await generatePipelineComicCoverConcepts(issue.id, {
       target,
@@ -297,13 +298,12 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
       providerOverride: series?.llm?.provider || undefined,
       modelOverride: series?.llm?.model || undefined,
     }, { silent: true }).catch((err) => {
-      toast.error(err.message || 'Failed to generate cover concept');
+      toast.error(err.message || `Failed to generate ${label.toLowerCase()} concept`);
       return null;
     });
     setGeneratingConcept((g) => ({ ...g, [target]: false }));
     if (!result) return;
     if (result.stage) onStageUpdate?.('comicPages', result.stage, result.issue);
-    const label = target === 'backCover' ? 'Back cover' : 'Cover';
     const seededThis = target === 'backCover' ? result.seeded?.backCover : result.seeded?.cover;
     toast.success(seededThis
       ? `${label} concept seeded`
@@ -313,26 +313,31 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
   const renderConceptButton = (target, script) => {
     const generating = generatingConcept[target];
     const filled = !!(script || '').trim();
+    const disabled = generating || filled;
     const noun = target === 'backCover' ? 'back-cover' : 'cover';
     const tooltip = filled
       ? `Clear the ${noun} concept first — the LLM only seeds blank concepts to avoid clobbering your edits.`
       : `Have the LLM propose a ${noun} concept for this issue`;
-    // Tooltip on the wrapper, not the button: most browsers skip hover
-    // events on disabled controls so a `title` on `<button disabled>` is
-    // invisible. Mirrors the ScheduleTab.jsx pattern.
+    // Use `aria-disabled` (not the DOM `disabled` attribute) so the
+    // button stays in the keyboard tab order and the `title` tooltip is
+    // discoverable on focus as well as hover. `disabled` removes the
+    // element from tab order entirely and most browsers suppress hover
+    // events on it, hiding the "clear first" guidance from keyboard +
+    // screen-reader users. Click handler is gated on the same flag.
     return (
-      <span title={tooltip} className="inline-block">
-        <button
-          type="button"
-          onClick={() => handleGenerateConcept(target)}
-          disabled={generating || filled}
-          aria-disabled={generating || filled || undefined}
-          className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-port-accent hover:text-white border border-port-border bg-port-bg hover:border-port-accent/40 disabled:opacity-40 disabled:cursor-not-allowed"
-        >
-          {generating ? <Loader2 size={12} className="animate-spin" /> : <Wand2 size={12} />}
-          Generate concept (LLM)
-        </button>
-      </span>
+      <button
+        type="button"
+        onClick={disabled ? undefined : () => handleGenerateConcept(target)}
+        aria-disabled={disabled || undefined}
+        title={tooltip}
+        aria-label={tooltip}
+        className={`inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-port-accent hover:text-white border border-port-border bg-port-bg hover:border-port-accent/40 ${
+          disabled ? 'opacity-40 cursor-not-allowed' : ''
+        }`}
+      >
+        {generating ? <Loader2 size={12} className="animate-spin" /> : <Wand2 size={12} />}
+        Generate concept (LLM)
+      </button>
     );
   };
 

--- a/client/src/components/pipeline/stages/ComicScriptStage.jsx
+++ b/client/src/components/pipeline/stages/ComicScriptStage.jsx
@@ -9,7 +9,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { Loader2, Sparkles, ImageIcon, Save, Trash2, ChevronDown, ChevronRight, Settings as SettingsIcon, FileDown, Layers } from 'lucide-react';
+import { Loader2, Sparkles, ImageIcon, Save, Trash2, ChevronDown, ChevronRight, Settings as SettingsIcon, FileDown, Layers, Wand2 } from 'lucide-react';
 import toast from '../../ui/Toast';
 import {
   generatePipelineStage,
@@ -17,6 +17,7 @@ import {
   generatePipelineComicPage,
   generatePipelineComicCover,
   generatePipelineComicBackCover,
+  generatePipelineComicCoverConcepts,
   updatePipelineComicPage,
   updatePipelineIssue,
   updateIssueStageVisualStyle,
@@ -286,6 +287,49 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
   const [useProofForCoverFinal, setUseProofForCoverFinal] = useState(true);
   const [useProofForBackFinal, setUseProofForBackFinal] = useState(true);
 
+  const [generatingConcept, setGeneratingConcept] = useState({ cover: false, backCover: false });
+
+  const handleGenerateConcept = async (target) => {
+    setGeneratingConcept((g) => ({ ...g, [target]: true }));
+    const result = await generatePipelineComicCoverConcepts(issue.id, {
+      target,
+      commit: true,
+      providerOverride: series?.llm?.provider || undefined,
+      modelOverride: series?.llm?.model || undefined,
+    }).catch((err) => {
+      toast.error(err.message || 'Failed to generate cover concept');
+      return null;
+    });
+    setGeneratingConcept((g) => ({ ...g, [target]: false }));
+    if (!result) return;
+    if (result.stage) onStageUpdate?.('comicPages', result.stage, result.issue);
+    const label = target === 'backCover' ? 'Back cover' : 'Cover';
+    const seededThis = target === 'backCover' ? result.seeded?.backCover : result.seeded?.cover;
+    toast.success(seededThis
+      ? `${label} concept seeded`
+      : `${label} concept generated (existing edit preserved)`);
+  };
+
+  const renderConceptButton = (target, script) => {
+    const generating = generatingConcept[target];
+    const filled = !!(script || '').trim();
+    const noun = target === 'backCover' ? 'back-cover' : 'cover';
+    return (
+      <button
+        type="button"
+        onClick={() => handleGenerateConcept(target)}
+        disabled={generating || filled}
+        title={filled
+          ? `Clear the ${noun} concept first — the LLM only seeds blank concepts to avoid clobbering your edits.`
+          : `Have the LLM propose a ${noun} concept for this issue`}
+        className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-port-accent hover:text-white border border-port-border bg-port-bg hover:border-port-accent/40 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {generating ? <Loader2 size={12} className="animate-spin" /> : <Wand2 size={12} />}
+        Generate concept (LLM)
+      </button>
+    );
+  };
+
   const i2iSupported = imageCfg.mode !== 'codex';
   const i2iDisabledReason = i2iSupported
     ? null
@@ -464,6 +508,7 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
         <div className="flex items-center justify-between gap-2 flex-wrap">
           <span className="text-xs uppercase tracking-wider text-gray-500">Cover</span>
           <div className="flex items-center gap-2 flex-wrap">
+            {renderConceptButton('cover', cover.script)}
             <button
               type="button"
               onClick={() => handleRenderCoverField('cover', 'proof')}
@@ -547,6 +592,7 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
         <div className="flex items-center justify-between gap-2 flex-wrap">
           <span className="text-xs uppercase tracking-wider text-gray-500">Back cover</span>
           <div className="flex items-center gap-2 flex-wrap">
+            {renderConceptButton('backCover', backCover.script)}
             <button
               type="button"
               onClick={() => handleRenderCoverField('backCover', 'proof')}

--- a/client/src/components/pipeline/stages/ComicScriptStage.jsx
+++ b/client/src/components/pipeline/stages/ComicScriptStage.jsx
@@ -314,19 +314,25 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
     const generating = generatingConcept[target];
     const filled = !!(script || '').trim();
     const noun = target === 'backCover' ? 'back-cover' : 'cover';
+    const tooltip = filled
+      ? `Clear the ${noun} concept first — the LLM only seeds blank concepts to avoid clobbering your edits.`
+      : `Have the LLM propose a ${noun} concept for this issue`;
+    // Tooltip on the wrapper, not the button: most browsers skip hover
+    // events on disabled controls so a `title` on `<button disabled>` is
+    // invisible. Mirrors the ScheduleTab.jsx pattern.
     return (
-      <button
-        type="button"
-        onClick={() => handleGenerateConcept(target)}
-        disabled={generating || filled}
-        title={filled
-          ? `Clear the ${noun} concept first — the LLM only seeds blank concepts to avoid clobbering your edits.`
-          : `Have the LLM propose a ${noun} concept for this issue`}
-        className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-port-accent hover:text-white border border-port-border bg-port-bg hover:border-port-accent/40 disabled:opacity-40 disabled:cursor-not-allowed"
-      >
-        {generating ? <Loader2 size={12} className="animate-spin" /> : <Wand2 size={12} />}
-        Generate concept (LLM)
-      </button>
+      <span title={tooltip} className="inline-block">
+        <button
+          type="button"
+          onClick={() => handleGenerateConcept(target)}
+          disabled={generating || filled}
+          aria-disabled={generating || filled || undefined}
+          className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-port-accent hover:text-white border border-port-border bg-port-bg hover:border-port-accent/40 disabled:opacity-40 disabled:cursor-not-allowed"
+        >
+          {generating ? <Loader2 size={12} className="animate-spin" /> : <Wand2 size={12} />}
+          Generate concept (LLM)
+        </button>
+      </span>
     );
   };
 

--- a/client/src/components/pipeline/stages/ComicScriptStage.jsx
+++ b/client/src/components/pipeline/stages/ComicScriptStage.jsx
@@ -296,7 +296,7 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
       commit: true,
       providerOverride: series?.llm?.provider || undefined,
       modelOverride: series?.llm?.model || undefined,
-    }).catch((err) => {
+    }, { silent: true }).catch((err) => {
       toast.error(err.message || 'Failed to generate cover concept');
       return null;
     });

--- a/client/src/services/apiPipeline.js
+++ b/client/src/services/apiPipeline.js
@@ -183,10 +183,11 @@ export const generatePipelineComicBackCover = (issueId, opts = {}, options = {})
 // its own target so the user can regenerate one card's concept without
 // touching the other. Seeds only blank scripts; never clobbers a user edit.
 // Returns the proposed text plus the updated issue + comicPages stage.
-export const generatePipelineComicCoverConcepts = (issueId, opts = {}) =>
+export const generatePipelineComicCoverConcepts = (issueId, opts = {}, options = {}) =>
   request(`/pipeline/issues/${encodeURIComponent(issueId)}/cover-concepts/generate`, {
     method: 'POST',
     body: JSON.stringify(opts),
+    ...options,
   });
 
 // Volume (season) cover render. Persists in-flight slot on
@@ -212,10 +213,11 @@ export const generatePipelineVolumeBackCover = (seriesId, seasonId, opts = {}, o
 // `season.backCover.script` when those slots are currently blank (the
 // server never clobbers a user edit). Returns the proposed text plus the
 // updated season + series records.
-export const generatePipelineVolumeCoverConcepts = (seriesId, seasonId, opts = {}) =>
+export const generatePipelineVolumeCoverConcepts = (seriesId, seasonId, opts = {}, options = {}) =>
   request(`/pipeline/series/${encodeURIComponent(seriesId)}/seasons/${encodeURIComponent(seasonId)}/cover-concepts/generate`, {
     method: 'POST',
     body: JSON.stringify(opts),
+    ...options,
   });
 
 // Build the trade-paperback PDF download URL for one volume. Used as an

--- a/client/src/services/apiPipeline.js
+++ b/client/src/services/apiPipeline.js
@@ -177,6 +177,18 @@ export const generatePipelineComicBackCover = (issueId, opts = {}, options = {})
     ...options,
   });
 
+// Ask the LLM to propose front + back cover concepts for one comic issue.
+// `opts.target` ('cover' | 'backCover' | 'both', default 'both') gates which
+// slot(s) get seeded when `commit: true` — the UI button on each card sends
+// its own target so the user can regenerate one card's concept without
+// touching the other. Seeds only blank scripts; never clobbers a user edit.
+// Returns the proposed text plus the updated issue + comicPages stage.
+export const generatePipelineComicCoverConcepts = (issueId, opts = {}) =>
+  request(`/pipeline/issues/${encodeURIComponent(issueId)}/cover-concepts/generate`, {
+    method: 'POST',
+    body: JSON.stringify(opts),
+  });
+
 // Volume (season) cover render. Persists in-flight slot on
 // series.seasons[].cover via the season write tail.
 // Returns { jobId, mode, prompt, coverScript, season, series, variant, fromProof }.

--- a/client/src/services/apiPipeline.js
+++ b/client/src/services/apiPipeline.js
@@ -182,7 +182,9 @@ export const generatePipelineComicBackCover = (issueId, opts = {}, options = {})
 // slot(s) get seeded when `commit: true` — the UI button on each card sends
 // its own target so the user can regenerate one card's concept without
 // touching the other. Seeds only blank scripts; never clobbers a user edit.
-// Returns the proposed text plus the updated issue + comicPages stage.
+// Returns { coverConcept, backCoverConcept, target, seeded, … }; the
+// `issue` and `stage` fields are only populated when `commit: true` (the
+// preview-only path returns them as null).
 export const generatePipelineComicCoverConcepts = (issueId, opts = {}, options = {}) =>
   request(`/pipeline/issues/${encodeURIComponent(issueId)}/cover-concepts/generate`, {
     method: 'POST',

--- a/data.sample/prompts/stage-config.json
+++ b/data.sample/prompts/stage-config.json
@@ -251,14 +251,14 @@
     },
     "pipeline-volume-cover-concepts": {
       "name": "Pipeline — Volume Cover Concepts",
-      "description": "Generate FRONT and BACK cover-art concepts for one volume (season) of a comic series. Returns a {coverConcept, backCoverConcept} JSON pair — pure scene descriptions for the image-gen renderer (no masthead, logo, or typography). Lightweight per-season call; seeds blank cover scripts only and never clobbers a user edit.",
+      "description": "Generate FRONT and BACK cover-art concepts for one volume (season) of a comic series. Returns a {coverConcept, backCoverConcept} JSON pair — pure scene descriptions for the image-gen renderer (no masthead, logo, or typography). Lightweight per-season call; may seed the cover and/or backCover script slots when they're blank, and never clobbers a user edit.",
       "model": "default",
       "returnsJson": true,
       "variables": []
     },
     "pipeline-comic-cover-concepts": {
       "name": "Pipeline — Comic Issue Cover Concepts",
-      "description": "Generate FRONT and BACK cover-art concepts for a single comic issue. Returns a {coverConcept, backCoverConcept} JSON pair — pure scene descriptions for the image-gen renderer (no masthead, issue-number tag, or typography). Lightweight per-issue call; seeds blank cover scripts only and never clobbers a user edit.",
+      "description": "Generate FRONT and BACK cover-art concepts for a single comic issue. Returns a {coverConcept, backCoverConcept} JSON pair — pure scene descriptions for the image-gen renderer (no masthead, issue-number tag, or typography). Lightweight per-issue call; may seed the cover and/or backCover script slots (gated by the request `target`) when they're blank, and never clobbers a user edit.",
       "model": "default",
       "returnsJson": true,
       "variables": []

--- a/data.sample/prompts/stage-config.json
+++ b/data.sample/prompts/stage-config.json
@@ -256,6 +256,13 @@
       "returnsJson": true,
       "variables": []
     },
+    "pipeline-comic-cover-concepts": {
+      "name": "Pipeline — Comic Issue Cover Concepts",
+      "description": "Generate FRONT and BACK cover-art concepts for a single comic issue. Returns a {coverConcept, backCoverConcept} JSON pair — pure scene descriptions for the image-gen renderer (no masthead, issue-number tag, or typography). Lightweight per-issue call; seeds blank cover scripts only and never clobbers a user edit.",
+      "model": "default",
+      "returnsJson": true,
+      "variables": []
+    },
     "pipeline-comic-panel-image-prompt": {
       "name": "Pipeline — Comic Panel Image Prompt",
       "description": "Refine a single comic panel's description into a richer image-gen-ready prompt. Uses caption / dialogue / sfx context + neighboring-panel continuity to elaborate without re-imagining the scene.",

--- a/data.sample/prompts/stages/pipeline-comic-cover-concepts.md
+++ b/data.sample/prompts/stages/pipeline-comic-cover-concepts.md
@@ -1,0 +1,36 @@
+# Pipeline — Comic issue cover concepts
+
+You are an art director for a single comic-book issue. Produce a FRONT cover concept and a BACK cover concept for the issue below. Both are pure scene descriptions for an image-gen model — the comic's masthead, issue-number tag, and any title typography are added by the renderer, so do NOT describe text, logos, or typography in either concept.
+
+## Series
+
+- **Title:** {{series.name}}
+- **Logline:** {{series.logline}}
+- **Style / tonal notes:** {{series.styleNotes}}
+
+## This issue
+
+- **Number:** {{issue.number}}
+- **Title:** {{issue.title}}
+- **Logline / synopsis:** {{issue.synopsis}}
+- **Beats:** {{issue.beats}}
+- **Prose excerpt:** {{issue.proseExcerpt}}
+
+## Output format
+
+Return ONLY a JSON object with this exact shape — no preamble, no commentary, no code fences:
+
+```
+{
+  "coverConcept": "2-4 sentence FRONT cover concept",
+  "backCoverConcept": "2-4 sentence BACK cover concept"
+}
+```
+
+## Rules
+
+- **Front cover** = the iconic image for this issue. Focus on the protagonist, the central confrontation, or the issue's signature image; an antagonist or location can anchor it if the issue's beats demand it. Specify subject, framing (wide / medium / close), lighting, mood, and one striking visual detail.
+- **Back cover** = a quiet companion image that COMPLEMENTS (not duplicates) the front. Often a counterpoint: a single object, a silhouette at distance, an environmental detail, an aftermath beat. NO text, NO masthead, NO logo, NO panel borders — the renderer's prompt will forbid typography. Focus on subject, framing, mood, and one striking visual detail.
+- **Don't repeat the front cover on the back.** The two are read as a pair; a back cover that mirrors the front wastes the second page.
+- Stay visually concrete. Describe what the camera sees, not how characters feel.
+- 2-4 sentences each. Don't pad. Don't add scene-level direction beyond what a single image needs.

--- a/scripts/migrations/020-comic-cover-concepts-stage.js
+++ b/scripts/migrations/020-comic-cover-concepts-stage.js
@@ -1,0 +1,72 @@
+/**
+ * Seed the `pipeline-comic-cover-concepts` stage into existing installs.
+ *
+ * Mirrors `017-volume-cover-concepts-stage.js`: copies the `.md` template
+ * from `data.sample/prompts/stages/` and merges the stage-config entry
+ * into `data/prompts/stage-config.json` so upgrades that skip re-running
+ * `setup-data.js` still get the new per-issue cover-concept LLM step.
+ */
+
+import { access, copyFile, mkdir, readFile, writeFile, constants } from 'fs/promises';
+import { dirname, join } from 'path';
+
+const FILENAME = 'pipeline-comic-cover-concepts.md';
+const STAGE_KEY = 'pipeline-comic-cover-concepts';
+
+export default {
+  async up({ rootDir }) {
+    const stagesDir = join(rootDir, 'data', 'prompts', 'stages');
+    await mkdir(stagesDir, { recursive: true });
+
+    const dataPath = join(stagesDir, FILENAME);
+    const samplePath = join(rootDir, 'data.sample', 'prompts', 'stages', FILENAME);
+
+    const exists = await access(dataPath, constants.F_OK).then(() => true, () => false);
+    if (exists) {
+      console.log(`📝 comic-cover-concepts prompt: already present`);
+    } else {
+      const sampleExists = await access(samplePath, constants.F_OK).then(() => true, () => false);
+      if (!sampleExists) {
+        console.warn(`⚠️  comic-cover-concepts: sample missing for ${FILENAME} — skipping copy`);
+      } else {
+        try {
+          await copyFile(samplePath, dataPath);
+          console.log(`✅ seeded ${FILENAME}`);
+        } catch (err) {
+          console.warn(`⚠️  comic-cover-concepts: copy failed for ${FILENAME}: ${err.message}`);
+        }
+      }
+    }
+
+    const installedConfigPath = join(rootDir, 'data', 'prompts', 'stage-config.json');
+    const sampleConfigPath = join(rootDir, 'data.sample', 'prompts', 'stage-config.json');
+    const sampleConfigExists = await access(sampleConfigPath, constants.F_OK).then(() => true, () => false);
+    if (!sampleConfigExists) {
+      console.warn('⚠️  comic-cover-concepts: data.sample stage-config.json missing — cannot resolve entry; skipping config write');
+      return;
+    }
+    try {
+      const sample = JSON.parse(await readFile(sampleConfigPath, 'utf8'));
+      const installedExists = await access(installedConfigPath, constants.F_OK).then(() => true, () => false);
+      const installed = installedExists
+        ? JSON.parse(await readFile(installedConfigPath, 'utf8'))
+        : { stages: {} };
+      installed.stages = installed.stages || {};
+      if (installed.stages[STAGE_KEY]) {
+        console.log(`📝 comic-cover-concepts stage-config: already present`);
+        return;
+      }
+      if (!sample?.stages?.[STAGE_KEY]) {
+        console.warn(`⚠️  comic-cover-concepts: sample stage-config missing ${STAGE_KEY} — skipping`);
+        return;
+      }
+      installed.stages[STAGE_KEY] = sample.stages[STAGE_KEY];
+      await mkdir(dirname(installedConfigPath), { recursive: true });
+      await writeFile(installedConfigPath, JSON.stringify(installed, null, 2) + '\n', 'utf8');
+      const action = installedExists ? 'merged' : 'created';
+      console.log(`📝 comic-cover-concepts stage-config (${action}): 1 added`);
+    } catch (err) {
+      console.warn(`⚠️  comic-cover-concepts: stage-config merge failed: ${err.message}`);
+    }
+  },
+};

--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -376,6 +376,13 @@ const volumeCoverConceptsSchema = z.object({
   modelOverride: z.string().trim().max(200).optional(),
 });
 
+const comicCoverConceptsSchema = z.object({
+  target: z.enum(['cover', 'backCover', 'both']).optional().default('both'),
+  commit: z.boolean().optional().default(false),
+  providerOverride: z.string().trim().max(80).optional(),
+  modelOverride: z.string().trim().max(200).optional(),
+});
+
 // Full-comic-page render: same knobs as panel render minus `description` /
 // `slugline` (the prompt is built server-side from the page's panels[] so it
 // stays in sync with whatever the script-extractor produced).
@@ -1378,6 +1385,19 @@ router.patch('/issues/:id/stages/comicPages/pages/:pageIndex', asyncHandler(asyn
     },
   ).catch((err) => { throw mapServiceError(err); });
   res.json({ issue: updatedIssue, stage, page: stage.pages[pageIndex] });
+}));
+
+// Generate front + back cover-art concepts for one comic issue via the LLM.
+// Per-issue sibling of /series/:id/seasons/:seasonId/cover-concepts/generate.
+// `target` ('cover' | 'backCover' | 'both') gates which slots can be seeded
+// when `commit: true` — the UI button on each card sends its own target so
+// the user can regenerate one without touching the other. Seeds only blank
+// scripts; never clobbers a user edit.
+router.post('/issues/:id/cover-concepts/generate', asyncHandler(async (req, res) => {
+  const body = validateRequest(comicCoverConceptsSchema, req.body ?? {});
+  const result = await arcPlanner.generateComicCoverConcepts(req.params.id, body)
+    .catch((err) => { throw mapServiceError(err); });
+  res.json(result);
 }));
 
 // Render the comic-issue front cover. Builds a cover-art prompt (series

--- a/server/services/pipeline/arcPlanner.js
+++ b/server/services/pipeline/arcPlanner.js
@@ -462,11 +462,13 @@ export async function generateVolumeCoverConcepts(seriesId, seasonId, options = 
     // race against a concurrent user blur-save).
     updatedSeries = await updateSeasonOnSeries(seriesId, seasonId, (cur) => {
       const patch = {};
-      if (coverConcept && !(cur.cover?.script || '')) {
+      // Trim before the blank-check so whitespace-only scripts count as
+      // blank — matches the client `.trim()` gate on the per-card buttons.
+      if (coverConcept && !(cur.cover?.script || '').trim()) {
         patch.cover = { ...(cur.cover || {}), script: coverConcept };
         seeded.cover = true;
       }
-      if (backCoverConcept && !(cur.backCover?.script || '')) {
+      if (backCoverConcept && !(cur.backCover?.script || '').trim()) {
         patch.backCover = { ...(cur.backCover || {}), script: backCoverConcept };
         seeded.backCover = true;
       }
@@ -546,11 +548,15 @@ export async function generateComicCoverConcepts(issueId, options = {}) {
     // same "only seed when blank" pattern as the volume variant.
     const result = await updateStageWithLatest(issueId, 'comicPages', (cur) => {
       const patch = {};
-      if (wantCover && coverConcept && !(cur?.cover?.script || '')) {
+      // Trim before the blank-check so the server's notion of "occupied"
+      // matches the client's `.trim()`-based button gate — otherwise a
+      // whitespace-only script enables the button but the server refuses
+      // to seed, producing a misleading "preserved" toast.
+      if (wantCover && coverConcept && !(cur?.cover?.script || '').trim()) {
         patch.cover = { ...(cur?.cover || {}), script: coverConcept };
         seeded.cover = true;
       }
-      if (wantBack && backCoverConcept && !(cur?.backCover?.script || '')) {
+      if (wantBack && backCoverConcept && !(cur?.backCover?.script || '').trim()) {
         patch.backCover = { ...(cur?.backCover || {}), script: backCoverConcept };
         seeded.backCover = true;
       }

--- a/server/services/pipeline/arcPlanner.js
+++ b/server/services/pipeline/arcPlanner.js
@@ -22,7 +22,7 @@
 import { runStagedLLM } from '../../lib/stageRunner.js';
 import { ServerError } from '../../lib/errorHandler.js';
 import { getSeries, updateSeries, updateSeasonOnSeries } from './series.js';
-import { listIssues, updateIssue, recomputeIssueNumbersForSeries } from './issues.js';
+import { listIssues, updateIssue, recomputeIssueNumbersForSeries, getIssue, updateStageWithLatest } from './issues.js';
 import { emitRecordUpdated, withReexportSuppressed } from '../sharing/recordEvents.js';
 import { getSeason } from './seasons.js';
 import {
@@ -476,6 +476,93 @@ export async function generateVolumeCoverConcepts(seriesId, seasonId, options = 
   return {
     season: updatedSeries ? (updatedSeries.seasons || []).find((s) => s.id === seasonId) : season,
     series: updatedSeries,
+    coverConcept,
+    backCoverConcept,
+    seeded,
+    raw: content,
+    runId,
+    providerId,
+    model,
+  };
+}
+
+/**
+ * Generate FRONT + BACK cover-art concepts for one comic issue. Per-issue
+ * sibling of `generateVolumeCoverConcepts`: returns the proposed text and,
+ * when `commit: true`, seeds blank `stages.comicPages.cover.script` /
+ * `stages.comicPages.backCover.script` slots without clobbering user edits.
+ *
+ * `options.target` ('cover' | 'backCover' | 'both', default 'both') gates
+ * which slots can be seeded — the UI buttons live per-card so the user can
+ * regenerate one without touching the other, even though the LLM returns
+ * the pair so the back can complement the front.
+ */
+export async function generateComicCoverConcepts(issueId, options = {}) {
+  const target = options.target || 'both';
+  if (target !== 'cover' && target !== 'backCover' && target !== 'both') {
+    throw makeErr(`Invalid target: ${target}`, ERR_VALIDATION);
+  }
+  const issue = await getIssue(issueId);
+  const series = await getSeries(issue.seriesId);
+  const proseFull = (issue.stages?.prose?.output || '').trim();
+  // Cap prose at a generous excerpt so very long drafts don't blow the
+  // prompt budget — the LLM only needs enough scene material to anchor a
+  // cover image, not the full text.
+  const proseExcerpt = proseFull.length > 4000 ? `${proseFull.slice(0, 4000)}…` : proseFull;
+  const ctx = {
+    series: {
+      name: series.name,
+      logline: series.logline,
+      styleNotes: series.styleNotes,
+    },
+    issue: {
+      number: issue.number,
+      title: issue.title,
+      synopsis: (issue.stages?.idea?.input || '').trim(),
+      beats: (issue.stages?.idea?.output || '').trim(),
+      proseExcerpt,
+    },
+  };
+  const { content, runId, providerId, model } = await runStagedLLM(
+    'pipeline-comic-cover-concepts',
+    ctx,
+    {
+      providerOverride: options.providerOverride,
+      modelOverride: options.modelOverride,
+      returnsJson: true,
+      source: 'pipeline-comic-cover-concepts',
+    },
+  );
+  const coverConcept = (typeof content?.coverConcept === 'string' ? content.coverConcept : '').trim();
+  const backCoverConcept = (typeof content?.backCoverConcept === 'string' ? content.backCoverConcept : '').trim();
+  const wantCover = target === 'cover' || target === 'both';
+  const wantBack = target === 'backCover' || target === 'both';
+  let updatedIssue = null;
+  let updatedStage = null;
+  const seeded = { cover: false, backCover: false };
+  if (options.commit) {
+    // Read the freshest persisted stage inside the queue so a concurrent
+    // blur-save on either cover script can't be silently overwritten —
+    // same "only seed when blank" pattern as the volume variant.
+    const result = await updateStageWithLatest(issueId, 'comicPages', (cur) => {
+      const patch = {};
+      if (wantCover && coverConcept && !(cur?.cover?.script || '')) {
+        patch.cover = { ...(cur?.cover || {}), script: coverConcept };
+        seeded.cover = true;
+      }
+      if (wantBack && backCoverConcept && !(cur?.backCover?.script || '')) {
+        patch.backCover = { ...(cur?.backCover || {}), script: backCoverConcept };
+        seeded.backCover = true;
+      }
+      return patch;
+    });
+    updatedIssue = result.issue;
+    updatedStage = result.stage;
+  }
+  return {
+    issue: updatedIssue,
+    stage: updatedStage,
+    target,
     coverConcept,
     backCoverConcept,
     seeded,

--- a/server/services/pipeline/arcPlanner.js
+++ b/server/services/pipeline/arcPlanner.js
@@ -500,7 +500,9 @@ export async function generateVolumeCoverConcepts(seriesId, seasonId, options = 
  * the pair so the back can complement the front.
  */
 export async function generateComicCoverConcepts(issueId, options = {}) {
-  const target = options.target || 'both';
+  // `??` (not `||`) so an empty-string target falls through to the
+  // invalid-target guard below instead of silently defaulting to 'both'.
+  const target = options.target ?? 'both';
   if (target !== 'cover' && target !== 'backCover' && target !== 'both') {
     throw makeErr(`Invalid target: ${target}`, ERR_VALIDATION);
   }

--- a/server/services/pipeline/arcPlanner.test.js
+++ b/server/services/pipeline/arcPlanner.test.js
@@ -1003,6 +1003,14 @@ describe('arcPlanner — generateComicCoverConcepts', () => {
     expect(stageRunnerSpy).toBeUndefined();
   });
 
+  it('rejects an empty-string target (does not silently fall back to "both")', async () => {
+    const { issue } = await setupIssue();
+    await expect(
+      planner.generateComicCoverConcepts(issue.id, { target: '' }),
+    ).rejects.toMatchObject({ message: expect.stringContaining('Invalid target') });
+    expect(stageRunnerSpy).toBeUndefined();
+  });
+
   it('treats a whitespace-only existing script as blank and seeds it (client/server parity)', async () => {
     // The client gate uses `.trim()` — the server must agree so a
     // " \n " script doesn't enable the button but skip seeding.

--- a/server/services/pipeline/arcPlanner.test.js
+++ b/server/services/pipeline/arcPlanner.test.js
@@ -831,3 +831,175 @@ describe('arcPlanner — buildSeasonRemap', () => {
     expect(remap.get('old2')).toBeNull();
   });
 });
+
+describe('arcPlanner — generateComicCoverConcepts', () => {
+  beforeEach(() => {
+    fileStore.clear();
+    uuidCounter = 0;
+    stageRunnerSpy = undefined;
+  });
+
+  async function setupIssue(stageOverrides = {}) {
+    const s = await setupSeries();
+    const issue = await issuesSvc.createIssue({
+      seriesId: s.id,
+      title: 'The Pilot',
+      stages: {
+        idea: { status: 'ready', input: 'A silent foundry mystery.', output: '- beat 1\n- beat 2' },
+        prose: { status: 'ready', output: 'The bell tower lay quiet over the brackish quay…' },
+        ...stageOverrides,
+      },
+    });
+    return { series: s, issue };
+  }
+
+  it('feeds series + issue context (name, logline, styleNotes, idea.input/output, prose excerpt) into the prompt', async () => {
+    const { issue } = await setupIssue();
+    stageRunnerSpy = vi.fn(async () => ({
+      content: { coverConcept: 'front concept', backCoverConcept: 'back concept' },
+      runId: 'run-cv-1', providerId: 'claude', model: 'opus-4',
+    }));
+
+    const out = await planner.generateComicCoverConcepts(issue.id);
+
+    expect(stageRunnerSpy).toHaveBeenCalledTimes(1);
+    expect(stageRunnerSpy).toHaveBeenCalledWith(
+      'pipeline-comic-cover-concepts',
+      expect.objectContaining({
+        series: expect.objectContaining({
+          name: 'Salt Run',
+          logline: 'A foundry city goes silent.',
+          styleNotes: 'moebius linework',
+        }),
+        issue: expect.objectContaining({
+          title: 'The Pilot',
+          synopsis: 'A silent foundry mystery.',
+          beats: '- beat 1\n- beat 2',
+          proseExcerpt: 'The bell tower lay quiet over the brackish quay…',
+        }),
+      }),
+      expect.objectContaining({ returnsJson: true, source: 'pipeline-comic-cover-concepts' }),
+    );
+    expect(out.coverConcept).toBe('front concept');
+    expect(out.backCoverConcept).toBe('back concept');
+    expect(out.target).toBe('both');
+    // No commit ⇒ no seeding.
+    expect(out.seeded).toEqual({ cover: false, backCover: false });
+    expect(out.issue).toBeNull();
+    expect(out.runId).toBe('run-cv-1');
+  });
+
+  it('caps very long prose at a 4000-char excerpt so the prompt budget stays bounded', async () => {
+    const longProse = 'x'.repeat(5000);
+    const { issue } = await setupIssue({
+      prose: { status: 'ready', output: longProse },
+    });
+    stageRunnerSpy = vi.fn(async () => ({
+      content: { coverConcept: 'c', backCoverConcept: 'b' },
+      runId: 'r', providerId: 'p', model: 'm',
+    }));
+
+    await planner.generateComicCoverConcepts(issue.id);
+
+    const ctx = stageRunnerSpy.mock.calls[0][1];
+    // 4000 chars of x + ellipsis truncation marker.
+    expect(ctx.issue.proseExcerpt).toBe(`${'x'.repeat(4000)}…`);
+    expect(ctx.issue.proseExcerpt.length).toBe(4001);
+  });
+
+  it('commit:true seeds BOTH cover + backCover scripts when slots are blank (target=both)', async () => {
+    const { issue } = await setupIssue();
+    stageRunnerSpy = vi.fn(async () => ({
+      content: { coverConcept: 'front-seed', backCoverConcept: 'back-seed' },
+      runId: 'r', providerId: 'p', model: 'm',
+    }));
+
+    const out = await planner.generateComicCoverConcepts(issue.id, { commit: true });
+
+    expect(out.seeded).toEqual({ cover: true, backCover: true });
+    const stored = await issuesSvc.getIssue(issue.id);
+    expect(stored.stages.comicPages.cover.script).toBe('front-seed');
+    expect(stored.stages.comicPages.backCover.script).toBe('back-seed');
+  });
+
+  it('commit:true with target="cover" ONLY seeds the cover slot, even when LLM returns both', async () => {
+    const { issue } = await setupIssue();
+    stageRunnerSpy = vi.fn(async () => ({
+      content: { coverConcept: 'front-seed', backCoverConcept: 'back-seed' },
+      runId: 'r', providerId: 'p', model: 'm',
+    }));
+
+    const out = await planner.generateComicCoverConcepts(issue.id, { commit: true, target: 'cover' });
+
+    expect(out.seeded).toEqual({ cover: true, backCover: false });
+    // Return shape still surfaces both concepts to the caller even though
+    // only the targeted slot was seeded.
+    expect(out.coverConcept).toBe('front-seed');
+    expect(out.backCoverConcept).toBe('back-seed');
+    const stored = await issuesSvc.getIssue(issue.id);
+    expect(stored.stages.comicPages.cover.script).toBe('front-seed');
+    expect(stored.stages.comicPages.backCover?.script || '').toBe('');
+  });
+
+  it('commit:true with target="backCover" ONLY seeds the backCover slot', async () => {
+    const { issue } = await setupIssue();
+    stageRunnerSpy = vi.fn(async () => ({
+      content: { coverConcept: 'front-seed', backCoverConcept: 'back-seed' },
+      runId: 'r', providerId: 'p', model: 'm',
+    }));
+
+    const out = await planner.generateComicCoverConcepts(issue.id, { commit: true, target: 'backCover' });
+
+    expect(out.seeded).toEqual({ cover: false, backCover: true });
+    const stored = await issuesSvc.getIssue(issue.id);
+    expect(stored.stages.comicPages.cover?.script || '').toBe('');
+    expect(stored.stages.comicPages.backCover.script).toBe('back-seed');
+  });
+
+  it('commit:true does NOT overwrite non-empty cover.script (preserves user edits, even with target=both)', async () => {
+    const { issue } = await setupIssue();
+    // User-edited cover script in place before the LLM runs.
+    await issuesSvc.updateStage(issue.id, 'comicPages', {
+      cover: { script: 'USER WROTE THIS' },
+    });
+    stageRunnerSpy = vi.fn(async () => ({
+      content: { coverConcept: 'LLM front', backCoverConcept: 'LLM back' },
+      runId: 'r', providerId: 'p', model: 'm',
+    }));
+
+    const out = await planner.generateComicCoverConcepts(issue.id, { commit: true });
+
+    // cover was occupied ⇒ skipped; backCover was blank ⇒ seeded.
+    expect(out.seeded).toEqual({ cover: false, backCover: true });
+    const stored = await issuesSvc.getIssue(issue.id);
+    expect(stored.stages.comicPages.cover.script).toBe('USER WROTE THIS');
+    expect(stored.stages.comicPages.backCover.script).toBe('LLM back');
+  });
+
+  it('commit:true does NOT overwrite non-empty backCover.script (preserves user edits)', async () => {
+    const { issue } = await setupIssue();
+    await issuesSvc.updateStage(issue.id, 'comicPages', {
+      backCover: { script: 'USER BACK COVER' },
+    });
+    stageRunnerSpy = vi.fn(async () => ({
+      content: { coverConcept: 'LLM front', backCoverConcept: 'LLM back' },
+      runId: 'r', providerId: 'p', model: 'm',
+    }));
+
+    const out = await planner.generateComicCoverConcepts(issue.id, { commit: true });
+
+    expect(out.seeded).toEqual({ cover: true, backCover: false });
+    const stored = await issuesSvc.getIssue(issue.id);
+    expect(stored.stages.comicPages.cover.script).toBe('LLM front');
+    expect(stored.stages.comicPages.backCover.script).toBe('USER BACK COVER');
+  });
+
+  it('rejects an invalid target value', async () => {
+    const { issue } = await setupIssue();
+    await expect(
+      planner.generateComicCoverConcepts(issue.id, { target: 'sideCover' }),
+    ).rejects.toMatchObject({ message: expect.stringContaining('Invalid target') });
+    // LLM should never have been called for a validation failure.
+    expect(stageRunnerSpy).toBeUndefined();
+  });
+});

--- a/server/services/pipeline/arcPlanner.test.js
+++ b/server/services/pipeline/arcPlanner.test.js
@@ -1002,4 +1002,25 @@ describe('arcPlanner — generateComicCoverConcepts', () => {
     // LLM should never have been called for a validation failure.
     expect(stageRunnerSpy).toBeUndefined();
   });
+
+  it('treats a whitespace-only existing script as blank and seeds it (client/server parity)', async () => {
+    // The client gate uses `.trim()` — the server must agree so a
+    // " \n " script doesn't enable the button but skip seeding.
+    const { issue } = await setupIssue();
+    await issuesSvc.updateStage(issue.id, 'comicPages', {
+      cover: { script: '   \n  ' },
+      backCover: { script: '\t' },
+    });
+    stageRunnerSpy = vi.fn(async () => ({
+      content: { coverConcept: 'LLM front', backCoverConcept: 'LLM back' },
+      runId: 'r', providerId: 'p', model: 'm',
+    }));
+
+    const out = await planner.generateComicCoverConcepts(issue.id, { commit: true });
+
+    expect(out.seeded).toEqual({ cover: true, backCover: true });
+    const stored = await issuesSvc.getIssue(issue.id);
+    expect(stored.stages.comicPages.cover.script).toBe('LLM front');
+    expect(stored.stages.comicPages.backCover.script).toBe('LLM back');
+  });
 });


### PR DESCRIPTION
## Summary

Adds a **"Generate concept (LLM)"** button to the Cover and Back Cover cards on the Comic Pipeline stage — mirrors the existing volume-level "Generate cover concepts (LLM)" button on the Volume card.

- Each card has its own button targeting only its own concept, so the user can regenerate one without touching the other.
- Server's "only seed when blank" guard preserves user edits (matches the volume sibling's behavior).
- The button is disabled when the script already has content, with a tooltip explaining how to clear it for a fresh proposal.

## What landed

**Prompt + stage:**
- `data.sample/prompts/stages/pipeline-comic-cover-concepts.md` — per-issue cover-concept prompt (parallel to the volume one)
- `data.sample/prompts/stage-config.json` — registers the stage
- `scripts/migrations/020-comic-cover-concepts-stage.js` — seeds existing installs (mirrors `017-volume-cover-concepts-stage.js`)

**Server:**
- `server/services/pipeline/arcPlanner.js` — `generateComicCoverConcepts(issueId, { target, commit, providerOverride, modelOverride })`. `target` is `'cover' | 'backCover' | 'both'`; the LLM always returns the pair (so back can complement front) and the seeded slot is gated by `target`. Race-safe seeding via `updateStageWithLatest`.
- `server/routes/pipeline.js` — `POST /api/pipeline/issues/:id/cover-concepts/generate` + Zod schema.

**Client:**
- `client/src/services/apiPipeline.js` — `generatePipelineComicCoverConcepts(issueId, opts, options)`.
- `client/src/components/pipeline/stages/ComicScriptStage.jsx` — `renderConceptButton(target, script)` helper dedups the two card buttons; single indexed busy map (`{ cover, backCover }`) instead of two parallel booleans.

## Drive-by fix

The pre-existing `generatePipelineVolumeCoverConcepts` caller had the same double-toast bug (custom `.catch` toast + `request` helper's default toast). Both call sites now pass `{ silent: true }` per the CLAUDE.md "Custom catch ⇒ silent: true" rule.

## Test plan

- [x] Server tests: `cd server && npm test` — 5151/5151 pass
- [x] Client build: `cd client && npm run build` — clean
- [ ] Manual: open a Comic stage on any issue, click **Generate concept (LLM)** on the Cover card → script field populates, button disables (filled state), tooltip explains how to clear
- [ ] Manual: same for Back Cover card
- [ ] Manual: clear cover script, click Generate again → repopulates without affecting back cover
- [ ] Manual: verify the volume cover-concepts button on the series Volumes panel still works after the silent-toast fix