### PR TITLE
fix(cos): preserve manual Worktree/PR toggles across data polling

### DIFF
--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -59,15 +59,22 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   );
   const appHasJira = selectedApp?.jira?.enabled;
 
-  // Auto-toggle JIRA, worktree, and PR checkboxes when app selection changes
+  // Gate on a content signature of the selected app's defaults (not the
+  // `apps` array reference) so periodic re-fetches in the parent don't
+  // stomp manual checkbox toggles between renders.
+  const appDefaultsSig = useMemo(() => selectedApp
+    ? `${selectedApp.id}|${!!selectedApp.defaultOpenPR}|${!!selectedApp.defaultUseWorktree}|${!!selectedApp.jira?.enabled}`
+    : `none:${newTask.app || ''}`,
+    [selectedApp, newTask.app]
+  );
   useEffect(() => {
-    const app = apps?.find(a => a.id === newTask.app);
-    const defaultOpenPR = !!app?.defaultOpenPR;
-    const defaultUseWorktree = !!app?.defaultUseWorktree || defaultOpenPR;
-    setCreateJiraTicket(!!app?.jira?.enabled);
+    const defaultOpenPR = !!selectedApp?.defaultOpenPR;
+    const defaultUseWorktree = !!selectedApp?.defaultUseWorktree || defaultOpenPR;
+    setCreateJiraTicket(!!selectedApp?.jira?.enabled);
     setUseWorktree(defaultUseWorktree);
     setOpenPR(defaultOpenPR);
-  }, [newTask.app, apps]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [appDefaultsSig]);
 
   // Get models for selected provider
   const selectedProvider = providers?.find(p => p.id === newTask.provider);

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -73,7 +73,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
     setCreateJiraTicket(!!selectedApp?.jira?.enabled);
     setUseWorktree(defaultUseWorktree);
     setOpenPR(defaultOpenPR);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- selectedApp intentionally omitted; appDefaultsSig encodes every field the effect reads, so depending on the object reference would re-fire on identical-content polling refreshes and stomp manual toggles
   }, [appDefaultsSig]);
 
   // Get models for selected provider


### PR DESCRIPTION
## Summary

When adding a task in the CoS form, the **Worktree** and **Open PR** (and **JIRA**) checkboxes would silently reset to the selected app's defaults while the user was still filling things out. Reproduces every ~30 seconds, or whenever a CoS socket event fires.

## Root cause

`TaskAddForm.jsx` has a `useEffect` that applies the selected app's defaults (`defaultUseWorktree` / `defaultOpenPR` / `jira.enabled`) to the checkbox state. Its dependency list was `[newTask.app, apps]`. The parent `ChiefOfStaff.jsx` polls `fetchData` every 30 s and on socket events (`cos:agent:spawned`, `cos:agent:completed`, `apps:changed`, etc.), producing a **new `apps` array reference** each time even when the underlying content is identical. That re-fires the effect and stomps any manual toggles.

## Fix

Gate the effect on a memoized **content signature** derived from the selected app's `id` + relevant default fields. The effect now depends on the primitive signature string, so React's natural dep equality dedupes across reference-only changes.

- Reuses the existing `selectedApp` `useMemo` (no duplicate `apps?.find()`).
- No new state — pure derivation.
- Initial-load corner case still works: if `apps` populates after first render, the signature flips from `none:<appId>` to the full string and defaults apply once.
- Explicit app change still resets correctly (new `id` ⇒ new signature ⇒ effect fires).

## Test plan

- [ ] Open the CoS Tasks tab, start filling in a new task.
- [ ] Toggle **Worktree** off; wait > 30 s; confirm it stays off.
- [ ] Toggle **Open PR** on (with Worktree on); wait > 30 s; confirm it stays on.
- [ ] Trigger a socket event (e.g. let an agent finish); confirm checkboxes unchanged.
- [ ] Switch to a different app in the picker; confirm checkboxes reset to that app's defaults.
- [ ] Verify the JIRA checkbox behaves the same way on a JIRA-enabled app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)