### PR TITLE
feat(universe-builder): let starter idea be as long as the user wants

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,3 @@
+## Changed
+
+- **Universe Builder — starter idea is no longer capped at 4000 chars.** The starter idea is whatever the user wants to type, from a one-line pitch to a full treatment. The Zod-backed `STARTER_PROMPT_MAX` is raised to 200,000 chars (a sanity ceiling, not an artificial brevity constraint) and the textarea's `maxLength={4000}` attribute is removed.

--- a/client/src/pages/UniverseBuilder.jsx
+++ b/client/src/pages/UniverseBuilder.jsx
@@ -2502,7 +2502,6 @@ function BibleTab({
               placeholder="moebius and scavengers reign meets Prophet inspired sci fi universe"
               className="w-full bg-port-bg border border-port-border rounded px-3 py-2 text-white text-sm focus:outline-none focus:border-port-accent"
               rows={2}
-              maxLength={4000}
             />
           </div>
           <div>

--- a/server/routes/universeBuilder.test.js
+++ b/server/routes/universeBuilder.test.js
@@ -124,7 +124,10 @@ const universeBuilderRoutes = (await import('./universeBuilder.js')).default;
 
 const buildApp = () => {
   const app = express();
-  app.use(express.json());
+  // Mirror production's 55mb body limit (see server/index.js) so payload-size
+  // tests exercise the Zod `.max()` boundary instead of bumping into the
+  // 100kb default body-parser limit.
+  app.use(express.json({ limit: '55mb' }));
   app.use('/api/universe-builder', universeBuilderRoutes);
   app.use(errorMiddleware);
   return app;
@@ -254,6 +257,33 @@ describe('universe-builder routes', () => {
       .post('/api/universe-builder')
       .send({ starterPrompt: 'cyber forest' });
     expect(res.status).toBe(400);
+  });
+
+  // Starter-idea length: the legacy 4000-char cap was lifted in favor of a
+  // 200,000-char sanity ceiling. These tests pin the new Zod boundary so a
+  // future schema edit can't silently restore the old limit (or relax it
+  // past the documented ceiling).
+  it('POST / accepts a starterPrompt well beyond the legacy 4000-char limit', async () => {
+    const longPrompt = 'a'.repeat(50_000);
+    const res = await request(buildApp())
+      .post('/api/universe-builder')
+      .send({ name: 'Long Idea', starterPrompt: longPrompt });
+    expect(res.status).toBe(201);
+    expect(res.body.starterPrompt).toHaveLength(50_000);
+  });
+
+  it('POST /expand rejects a starterPrompt exceeding 200,000 chars', async () => {
+    const res = await request(buildApp())
+      .post('/api/universe-builder/expand')
+      .send({ starterPrompt: 'x'.repeat(200_001) });
+    expect(res.status).toBe(400);
+  });
+
+  it('POST /expand accepts a starterPrompt at exactly 200,000 chars', async () => {
+    const res = await request(buildApp())
+      .post('/api/universe-builder/expand')
+      .send({ starterPrompt: 'x'.repeat(200_000) });
+    expect(res.status).toBe(200);
   });
 
   it('PATCH /:id updates fields', async () => {

--- a/server/services/universeBuilder.js
+++ b/server/services/universeBuilder.js
@@ -75,7 +75,10 @@ export const NAME_MAX_LENGTH = 100;
 // A render can enqueue up to 5 categories × 50 variations × 20 batchPerVariation
 // = 5000 jobs. Cap at 10k to leave headroom against future bumps to those caps.
 const MAX_RUN_JOB_IDS = 10000;
-export const STARTER_PROMPT_MAX = 4000;
+// The starter idea is whatever the user wants to write — anything from a
+// one-line pitch to a multi-page treatment. Cap is a sanity ceiling against
+// runaway payloads, not an artificial brevity constraint.
+export const STARTER_PROMPT_MAX = 200_000;
 export const PROMPT_FRAGMENT_MAX = 2000;
 export const COMPOSITE_PROMPT_MAX = 4000;
 export const VARIATION_LABEL_MAX = 120;

--- a/server/services/universeBuilder.test.js
+++ b/server/services/universeBuilder.test.js
@@ -209,6 +209,29 @@ describe("universeBuilder service", () => {
     expect(w.styleNotes).toHaveLength(svc.STYLE_NOTES_MAX);
   });
 
+  // Starter idea is intentionally uncapped at the legacy 4000-char limit —
+  // the cap was raised to 200,000 (a sanity ceiling, not an artificial
+  // brevity constraint). These tests pin the new boundary so a future
+  // refactor can't silently regress to the old 4k limit.
+  it("createUniverse preserves a starterPrompt well beyond the legacy 4000-char limit", async () => {
+    const longPrompt = "a".repeat(50_000);
+    const w = await seedWorld({ starterPrompt: longPrompt });
+    expect(w.starterPrompt).toHaveLength(50_000);
+    expect(w.starterPrompt).toBe(longPrompt);
+  });
+
+  it("createUniverse trims a starterPrompt exceeding STARTER_PROMPT_MAX (200k)", async () => {
+    const w = await seedWorld({
+      starterPrompt: "b".repeat(svc.STARTER_PROMPT_MAX + 5_000),
+    });
+    expect(w.starterPrompt).toHaveLength(svc.STARTER_PROMPT_MAX);
+  });
+
+  it("STARTER_PROMPT_MAX is at least the documented 200k ceiling", async () => {
+    // Guard against accidental regression to the legacy 4k cap.
+    expect(svc.STARTER_PROMPT_MAX).toBeGreaterThanOrEqual(200_000);
+  });
+
   it("updateUniverse merges partial patches", async () => {
     const w = await seedWorld();
     const patched = await svc.updateUniverse(w.id, {


### PR DESCRIPTION
## Summary

- The Universe Builder's starter idea no longer has an artificial 4000-char cap. Users can type anything from a one-line pitch to a full multi-page treatment.
- `STARTER_PROMPT_MAX` is raised to 200,000 chars (a sanity ceiling against runaway payloads, not a brevity constraint), and the textarea's `maxLength={4000}` attribute is removed so the input no longer silently truncates keystrokes.

All 7 consumers of `STARTER_PROMPT_MAX` (4 Zod schemas in `server/routes/universeBuilder.js`, 3 `trimTo` calls in `server/services/universeBuilder.js` + `universeBuilderRefine.js`) pick up the new cap automatically via the shared export. Server-side Zod remains the authoritative validator.

## Test plan

- [x] `cd server && npm test -- universeBuilder` — 188/188 tests pass (no boundary tests asserted the 4000 limit).
- [ ] In the Universe Builder UI, paste a >4000-char starter idea and confirm it persists round-trip and feeds into Expand / Refine.