### PR TITLE
fix(importer): use standard page layout to remove excess margin

### DIFF
--- a/client/src/pages/Importer.jsx
+++ b/client/src/pages/Importer.jsx
@@ -204,11 +204,11 @@ export default function Importer() {
   }, { errorMessage: 'Failed to commit import' });
 
   return (
-    <div className="max-w-6xl mx-auto p-4 sm:p-6 text-port-text">
-      <header className="mb-6 flex items-start gap-3">
+    <div className="space-y-6">
+      <header className="flex items-start gap-3">
         <FileInput className="w-7 h-7 text-port-accent mt-1" />
         <div>
-          <h1 className="text-2xl font-bold">Importer</h1>
+          <h1 className="text-2xl font-bold text-white">Importer</h1>
           <p className="text-sm text-port-text-muted mt-1">
             Reverse-engineer a finished story, novel, screenplay, or comic script into the pipeline.
             The LLM extracts universe canon, the story arc, and a proposed issue split; you review,


### PR DESCRIPTION
## Summary

The Importer page (`/importer`) was wrapped in `max-w-6xl mx-auto p-4 sm:p-6 text-port-text`, which constrained the content to a narrower column AND doubled the padding on top of the parent `<main>` element's `p-4 md:p-6` (provided for all non-full-width pages by `Layout.jsx:998`). The result was excessive left/right and top margins.

This change aligns the Importer with the standard non-full-width page layout used elsewhere (e.g. `HistoryPage.jsx`) and matches the MediaGen reference (the page the user pointed at as "the standard"):

- Outer wrapper: `space-y-6` (vertical spacing for direct children, no doubled padding, no width cap)
- `<h1>` gets `text-white` to match MediaGen's heading contrast
- `mb-6` removed from the header (handled uniformly by `space-y-6`)

## Test plan

- [ ] Visit `/importer` and verify the form fills the available width up to the parent's `p-4 md:p-6` padding (no extra inset, no `max-w-6xl` cap)
- [ ] Verify intake form renders correctly at mobile, tablet, and desktop widths
- [ ] Verify the review phase (post-Analyze) still renders cards and the sticky commit bar without overlap
- [ ] Compare against `/media` (MediaGen) to confirm the heading style matches