### PR TITLE
feat(brain/notes): add folder picker to Obsidian vault manager

### DIFF
--- a/client/src/components/brain/tabs/NotesTab.jsx
+++ b/client/src/components/brain/tabs/NotesTab.jsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react';
 import BrailleSpinner from '../../BrailleSpinner';
 import toast from '../../ui/Toast';
+import FolderPicker from '../../FolderPicker';
 import { timeAgo, formatBytes } from '../../../utils/formatters';
 
 export default function NotesTab({ onRefresh }) {
@@ -731,8 +732,9 @@ function VaultSetup({ detectedVaults, vaults, customPath, setCustomPath, adding,
             value={customPath}
             onChange={e => setCustomPath(e.target.value)}
             placeholder="/path/to/obsidian/vault"
-            className="flex-1 bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-white placeholder-gray-500"
+            className="flex-1 min-w-0 bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-white placeholder-gray-500"
           />
+          <FolderPicker value={customPath} onChange={setCustomPath} />
           <button
             onClick={() => {
               if (customPath.trim()) {


### PR DESCRIPTION
## Summary
- The Obsidian Vault Manager's "Add Custom Path" form previously required users to type the full filesystem path to a vault. Adds the shared \`FolderPicker\` next to the text input so users can browse to and select a vault directory directly, matching the pattern already used in \`BackupTab.jsx\`, \`Templates.jsx\`, \`Sharing.jsx\`, and \`CreateApp.jsx\`.
- Wires the picker to the existing \`customPath\`/\`setCustomPath\` state — no new state, no new API calls.
- Adds \`min-w-0\` to the path input so the flex-1 input shrinks correctly alongside the picker button (same fix used in BackupTab).

## Test plan
- [ ] Open Brain → Notes with no vaults connected (or click the Settings gear with at least one vault) to reach the Vault Manager.
- [ ] Scroll to "Add Custom Path"; confirm a folder-browse button is visible to the right of the path input.
- [ ] Click the folder button → modal opens; navigate to a directory and click "Select This Folder" → the path appears in the input.
- [ ] Verify the "Add" button activates and successfully adds the vault.
- [ ] Verify typing into the text input still works (manual paths remain supported).