### PR TITLE
feat: pipeline issues pagination + toolkit deleteRun override + nav drift

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -281,7 +281,18 @@ aiToolkit.services.runner.isRunActive = (runId) => {
   if (aiToolkit.services.runner._portosActiveRuns?.has(runId)) return true;
   return originalIsRunActive(runId);
 };
-console.log('🔧 Patched aiToolkit runner.executeCliRun + stopRun + isRunActive with PortOS CLI variants');
+// Patch deleteRun so that deleting an in-flight PortOS CLI run also kills the
+// child process before removing the on-disk directory. Without this patch,
+// deleteRun only checks the toolkit's internal `activeRuns` map (which is
+// empty for PortOS CLI runs) and silently leaves a zombie child process running.
+const originalDeleteRun = aiToolkit.services.runner.deleteRun.bind(aiToolkit.services.runner);
+aiToolkit.services.runner.deleteRun = async function (runId, ...args) {
+  if (this._portosActiveRuns?.has?.(runId)) {
+    await this.stopRun(runId);
+  }
+  return originalDeleteRun.call(this, runId, ...args);
+};
+console.log('🔧 Patched aiToolkit runner.executeCliRun + stopRun + isRunActive + deleteRun with PortOS CLI variants');
 
 // Note: prompts service is initialized automatically by createAIToolkit()
 

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -7,6 +7,7 @@ export const NAV_COMMANDS = [
   { id: 'nav.dashboard', path: '/', label: 'Dashboard', section: 'Main', aliases: ['dashboard', 'home'], keywords: ['overview', 'start'] },
   { id: 'nav.review-hub', path: '/review', label: 'Review Hub', section: 'Main', aliases: ['review', 'review-hub'] },
   { id: 'nav.cybercity', path: '/city', label: 'CyberCity', section: 'Main', aliases: ['city', 'cybercity'], keywords: ['3d', 'visualization'] },
+  { id: 'nav.cybercity.settings', path: '/city/settings', label: 'CyberCity Settings', section: 'Main', aliases: ['city settings', 'cybercity settings', 'city-settings', 'cybercity-config'], keywords: ['cybercity', 'settings', '3d', 'configure'] },
   { id: 'nav.apps', path: '/apps', label: 'Apps', section: 'Main', aliases: ['apps'] },
   { id: 'nav.reference-repos', path: '/reference-repos', label: 'Reference Repos', section: 'Main', aliases: ['reference-repos', 'references', 'reference', 'upstream', 'watch'], keywords: ['upstream', 'reference code', 'borrowed code', 'fork', 'git watch', 'commit watch', 'phosphene'] },
 
@@ -131,6 +132,7 @@ export const NAV_COMMANDS = [
   { id: 'nav.settings.telegram', path: '/settings/telegram', label: 'Telegram', section: 'Settings', aliases: ['settings-telegram', 'telegram'] },
   { id: 'nav.settings.voice', path: '/settings/voice', label: 'Voice', section: 'Settings', aliases: ['settings-voice', 'voice', 'voice-settings'], keywords: ['mic', 'microphone', 'speech', 'tts', 'whisper', 'kokoro'] },
 
+  { id: 'nav.ambient', path: '/ambient', label: 'Ambient', section: 'System', aliases: ['ambient', 'ambient-mode', 'ambient mode'], keywords: ['idle', 'background', 'display', 'screensaver', 'fullscreen'] },
   { id: 'nav.data', path: '/data', label: 'Data', section: 'System', aliases: ['data'] },
   { id: 'nav.cos.health', path: '/cos/health', label: 'Health', section: 'System', aliases: ['cos-health'] },
   { id: 'nav.instances', path: '/instances', label: 'Instances', section: 'System', aliases: ['instances'] },

--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -31,6 +31,12 @@ import {
   refineImagePixelCap,
   PIXEL_CAP_MESSAGE,
 } from '../lib/validation.js';
+
+const issuesListQuerySchema = z.object({
+  offset: z.preprocess((v) => (v === undefined ? 0 : Number(v)), z.number().int().min(0)).default(0),
+  limit: z.preprocess((v) => (v === undefined ? 1000 : Number(v)), z.number().int().min(1).max(1000)).default(1000),
+});
+
 import * as seriesSvc from '../services/pipeline/series.js';
 import * as issuesSvc from '../services/pipeline/issues.js';
 import * as seasonsSvc from '../services/pipeline/seasons.js';
@@ -874,7 +880,13 @@ router.get('/series/:id/issues', asyncHandler(async (req, res) => {
   // Validate the series exists so a typo returns 404 instead of [] (less
   // confusing for the UI).
   await seriesSvc.getSeries(req.params.id).catch((err) => { throw mapServiceError(err); });
-  res.json(await issuesSvc.listIssues({ seriesId: req.params.id }));
+  const hasPagination = req.query.offset !== undefined || req.query.limit !== undefined;
+  if (hasPagination) {
+    const { offset, limit } = validateRequest(issuesListQuerySchema, req.query);
+    res.json(await issuesSvc.listIssues({ seriesId: req.params.id, offset, limit, paginated: true }));
+  } else {
+    res.json(await issuesSvc.listIssues({ seriesId: req.params.id }));
+  }
 }));
 
 router.post('/series/:id/issues', asyncHandler(async (req, res) => {

--- a/server/routes/pipeline.js
+++ b/server/routes/pipeline.js
@@ -32,11 +32,6 @@ import {
   PIXEL_CAP_MESSAGE,
 } from '../lib/validation.js';
 
-const issuesListQuerySchema = z.object({
-  offset: z.preprocess((v) => (v === undefined ? 0 : Number(v)), z.number().int().min(0)).default(0),
-  limit: z.preprocess((v) => (v === undefined ? 1000 : Number(v)), z.number().int().min(1).max(1000)).default(1000),
-});
-
 import * as seriesSvc from '../services/pipeline/series.js';
 import * as issuesSvc from '../services/pipeline/issues.js';
 import * as seasonsSvc from '../services/pipeline/seasons.js';
@@ -90,6 +85,12 @@ import {
 } from '../lib/issueLength.js';
 import { llmSchema } from './universeBuilder.js';
 import { ARC_LIMITS, ARC_STATUSES, ARC_SHAPE_IDS, ARC_ROLES, SEASON_STATUSES } from '../lib/storyArc.js';
+
+// Inline until better/code-quality lands and exports this from validation.js
+const issuesListQuerySchema = z.object({
+  offset: z.preprocess((v) => (v === undefined ? 0 : Number(v)), z.number().int().min(0)).default(0),
+  limit: z.preprocess((v) => (v === undefined ? 1000 : Number(v)), z.number().int().min(1).max(1000)).default(1000),
+});
 
 const router = Router();
 

--- a/server/services/pipeline/issues.js
+++ b/server/services/pipeline/issues.js
@@ -331,15 +331,19 @@ async function writeState(state) {
   await atomicWrite(statePath(), state);
 }
 
-export async function listIssues({ seriesId = null } = {}) {
+export async function listIssues({ seriesId = null, offset = 0, limit = ISSUES_PER_RESPONSE_MAX, paginated = false } = {}) {
   const { issues } = await readState();
   const filtered = seriesId ? issues.filter((i) => i.seriesId === seriesId) : issues;
-  return [...filtered]
-    .sort((a, b) => {
-      if (a.seriesId !== b.seriesId) return a.seriesId.localeCompare(b.seriesId);
-      return (a.number || 0) - (b.number || 0);
-    })
-    .slice(0, ISSUES_PER_RESPONSE_MAX);
+  const sorted = [...filtered].sort((a, b) => {
+    if (a.seriesId !== b.seriesId) return a.seriesId.localeCompare(b.seriesId);
+    return (a.number || 0) - (b.number || 0);
+  });
+  const safeLimit = Math.min(Math.max(1, limit), ISSUES_PER_RESPONSE_MAX);
+  const safeOffset = Math.max(0, offset);
+  if (paginated) {
+    return { items: sorted.slice(safeOffset, safeOffset + safeLimit), total: sorted.length, offset: safeOffset, limit: safeLimit };
+  }
+  return sorted.slice(0, ISSUES_PER_RESPONSE_MAX);
 }
 
 /**

--- a/server/services/pipeline/issues.test.js
+++ b/server/services/pipeline/issues.test.js
@@ -203,6 +203,46 @@ describe('pipeline issues service', () => {
     expect(list1.every((i) => i.seriesId === 'ser-1')).toBe(true);
   });
 
+  describe('listIssues pagination', () => {
+    it('returns raw array when paginated is false (legacy default)', async () => {
+      await svc.createIssue({ seriesId: 'ser-1', title: 'A' });
+      await svc.createIssue({ seriesId: 'ser-1', title: 'B' });
+      const result = await svc.listIssues({ seriesId: 'ser-1' });
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(2);
+    });
+
+    it('returns paginated envelope when paginated:true', async () => {
+      await svc.createIssue({ seriesId: 'ser-1', title: 'A' });
+      await svc.createIssue({ seriesId: 'ser-1', title: 'B' });
+      await svc.createIssue({ seriesId: 'ser-1', title: 'C' });
+      const result = await svc.listIssues({ seriesId: 'ser-1', offset: 0, limit: 2, paginated: true });
+      expect(result.total).toBe(3);
+      expect(result.offset).toBe(0);
+      expect(result.limit).toBe(2);
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].title).toBe('A');
+      expect(result.items[1].title).toBe('B');
+    });
+
+    it('respects offset when paginated:true', async () => {
+      await svc.createIssue({ seriesId: 'ser-1', title: 'A' });
+      await svc.createIssue({ seriesId: 'ser-1', title: 'B' });
+      await svc.createIssue({ seriesId: 'ser-1', title: 'C' });
+      const result = await svc.listIssues({ seriesId: 'ser-1', offset: 2, limit: 10, paginated: true });
+      expect(result.total).toBe(3);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].title).toBe('C');
+    });
+
+    it('offset beyond total returns empty items but correct total', async () => {
+      await svc.createIssue({ seriesId: 'ser-1', title: 'A' });
+      const result = await svc.listIssues({ seriesId: 'ser-1', offset: 100, limit: 10, paginated: true });
+      expect(result.total).toBe(1);
+      expect(result.items).toHaveLength(0);
+    });
+  });
+
   describe('listRecentIssues', () => {
     it('orders descending by updatedAt across all series', async () => {
       const a = await svc.createIssue({ seriesId: 'ser-1', title: 'A' });
@@ -623,6 +663,30 @@ describe('pipeline issues service', () => {
       await seasonsSvc.updateSeason(series.id, a.id, { locked: false });
       const result = await svc.bulkReassignSeason(series.id, a.id, b.id);
       expect(result.reassigned).toBe(3);
+    });
+  });
+
+  describe('concurrent write serialization', () => {
+    it('two concurrent writes do not clobber each other — both fields survive in final state', async () => {
+      // This is the key regression test for the queueIssueWrite tail.
+      // If the write queue is bypassed or broken, both calls read the same
+      // pre-write snapshot and the last one to land wins — exactly one of
+      // the two writes is silently dropped.
+      const issue = await svc.createIssue({ seriesId: 'ser-1', title: 'Concurrency target' });
+
+      // Fire two writes concurrently without awaiting individually.
+      // updateStage writes to `idea.output`; updateIssue writes to top-level `status`.
+      // A clobbering race would lose whichever write landed second (its pre-image
+      // read captured an empty idea.output or no status change).
+      await Promise.all([
+        svc.updateStage(issue.id, 'idea', { status: 'ready', output: 'beat sheet content' }),
+        svc.updateIssue(issue.id, { status: 'needs-review' }),
+      ]);
+
+      const final = await svc.getIssue(issue.id);
+      // Both mutations must survive — if either is missing, the write tail is broken.
+      expect(final.stages.idea.output).toBe('beat sheet content');
+      expect(final.status).toBe('needs-review');
     });
   });
 });


### PR DESCRIPTION
## Summary

Phase 5 of the **Better Audit — 2026-05-19**. Three architectural fixes:

- **[MEDIUM] `listIssues` pagination.** Backward-compatible: `listIssues({ paginated: true, offset, limit })` returns `{ items, total, offset, limit }`; default call still returns the raw array. `GET /api/pipeline/series/:id/issues` accepts optional `?offset=N&limit=N`. Eliminates the silent 1000-issue cap for long-running series.
- **[MEDIUM] AI Toolkit runner `deleteRun` override.** Now calls `stopRun(runId)` first when `_portosActiveRuns` holds the entry — closes the zombie-child-process leak when a live PortOS run was deleted via the UI. `listRuns` left alone (reads disk metadata, not the live process map).
- **[MEDIUM] NAV_COMMANDS drift.** Register `/city/settings` and `/ambient` so they are reachable from `⌘K` and the voice agent's `ui_navigate` tool.

## Files Modified
- `server/services/pipeline/issues.js` (+ test additions: 4 pagination tests + 1 concurrent-write serialization test from Phase 4c)
- `server/routes/pipeline.js`
- `server/lib/navManifest.js`
- `server/index.js`

## Merge Order
**Schema dependency on `better/code-quality`.** This branch's `routes/pipeline.js` currently **inlines** the `issuesListQuerySchema` (declared in `server/lib/validation.js` in the code-quality PR). Once that branch merges, this branch's inlined schema can be replaced with a named import in a follow-up commit. Merging in this order is fine either way — both branches build and test independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)