### PR TITLE
a11y: form labels via useId + ImageGenTab number-input clamp fix

### DIFF
--- a/client/src/components/BackupWidget.jsx
+++ b/client/src/components/BackupWidget.jsx
@@ -1,4 +1,4 @@
-import { useState, memo, useCallback } from 'react';
+import { useState, memo, useCallback, useId } from 'react';
 import { Link } from 'react-router-dom';
 import {HardDrive,
   ChevronDown,
@@ -72,6 +72,7 @@ const HEALTH_STYLES = {
 // ---------------------------------------------------------------------------
 
 function RestorePanel({ snapshot, onClose }) {
+  const filterId = useId();
   const [filter, setFilter] = useState('');
   const [preview, setPreview] = useState(null);
   const [previewing, setPreviewing] = useState(false);
@@ -125,10 +126,11 @@ function RestorePanel({ snapshot, onClose }) {
 
       {/* Subdirectory filter */}
       <div>
-        <label className="block text-xs text-gray-500 mb-1">
+        <label htmlFor={filterId} className="block text-xs text-gray-500 mb-1">
           Selective restore (optional)
         </label>
         <input
+          id={filterId}
           type="text"
           value={filter}
           onChange={e => setFilter(e.target.value)}

--- a/client/src/components/IconPicker.jsx
+++ b/client/src/components/IconPicker.jsx
@@ -6,9 +6,10 @@ export default function IconPicker({ value, onChange }) {
 
   return (
     <div className="relative">
-      <label className="block text-sm text-gray-400 mb-1">Icon</label>
+      <span className="block text-sm text-gray-400 mb-1">Icon</span>
       <button
         type="button"
+        aria-label="Icon picker"
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center gap-3 w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white hover:border-port-accent/50 focus:border-port-accent focus:outline-hidden transition-colors"
       >

--- a/client/src/components/ProviderModelSelector.jsx
+++ b/client/src/components/ProviderModelSelector.jsx
@@ -11,6 +11,8 @@
  * @param {boolean} [props.disabled] - Disable both selectors
  * @param {boolean} [props.compact] - Hide labels for inline/toolbar use
  */
+import { useId } from 'react';
+
 export default function ProviderModelSelector({
   providers,
   selectedProviderId,
@@ -22,11 +24,14 @@ export default function ProviderModelSelector({
   disabled = false,
   compact = false
 }) {
+  const providerSelectId = useId();
+  const modelSelectId = useId();
   return (
     <div className="flex items-center gap-2">
       <div className="flex-1 min-w-0">
-        {!compact && <label className="block text-xs text-gray-500 mb-1">{label}</label>}
+        {!compact && <label htmlFor={providerSelectId} className="block text-xs text-gray-500 mb-1">{label}</label>}
         <select
+          id={providerSelectId}
           value={selectedProviderId}
           onChange={(e) => onProviderChange(e.target.value)}
           disabled={disabled}
@@ -40,8 +45,9 @@ export default function ProviderModelSelector({
       </div>
       {availableModels.length > 0 && (
         <div className="flex-1 min-w-0">
-          {!compact && <label className="block text-xs text-gray-500 mb-1">Model</label>}
+          {!compact && <label htmlFor={modelSelectId} className="block text-xs text-gray-500 mb-1">Model</label>}
           <select
+            id={modelSelectId}
             value={selectedModel}
             onChange={(e) => onModelChange(e.target.value)}
             disabled={disabled}

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -341,7 +341,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
                     <button
                       onClick={(e) => deleteTemplate(template.id, e)}
                       className="flex md:hidden md:group-hover:flex absolute -top-1 -right-1 w-4 h-4 bg-port-error rounded-full items-center justify-center"
-                      title="Delete template"
+                      aria-label="Delete template"
                     >
                       <X size={10} />
                     </button>

--- a/client/src/components/settings/BackupTab.jsx
+++ b/client/src/components/settings/BackupTab.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useId } from 'react';
 import { Save, Plus, X, Play, ShieldOff } from 'lucide-react';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
@@ -35,6 +35,9 @@ const shadowsDefault = (customPath, defaultPath) => {
 };
 
 export function BackupTab() {
+  const destPathId = useId();
+  const cronId = useId();
+  const additionalExcludeId = useId();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [destPath, setDestPath] = useState('');
@@ -147,9 +150,10 @@ export function BackupTab() {
   return (
     <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6 space-y-5">
       <div className="space-y-1">
-        <label className="block text-sm text-gray-400">Destination Path</label>
+        <label htmlFor={destPathId} className="block text-sm text-gray-400">Destination Path</label>
         <div className="flex gap-2 items-stretch">
           <input
+            id={destPathId}
             type="text"
             value={destPath}
             onChange={e => setDestPath(e.target.value)}
@@ -171,8 +175,9 @@ export function BackupTab() {
       </div>
 
       <div className="space-y-1">
-        <label className="block text-sm text-gray-400">Schedule (cron)</label>
+        <label htmlFor={cronId} className="block text-sm text-gray-400">Schedule (cron)</label>
         <input
+          id={cronId}
           type="text"
           value={cronExpression}
           onChange={e => setCronExpression(e.target.value)}
@@ -229,10 +234,11 @@ export function BackupTab() {
       )}
 
       <div className="space-y-2">
-        <label className="block text-sm text-gray-400">Additional Exclude Paths</label>
+        <label htmlFor={additionalExcludeId} className="block text-sm text-gray-400">Additional Exclude Paths</label>
         <p className="text-xs text-gray-500">Custom directories/patterns to skip during backup (relative to data/)</p>
         <div className="flex gap-2">
           <input
+            id={additionalExcludeId}
             type="text"
             value={newExclude}
             onChange={e => setNewExclude(e.target.value)}

--- a/client/src/components/settings/ImageGenTab.jsx
+++ b/client/src/components/settings/ImageGenTab.jsx
@@ -6,7 +6,7 @@
  * lives in the always-visible Codex CLI Imagegen section.
  */
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useId } from 'react';
 import {
   Save, Image as ImageIcon, Zap, Wrench, Cloud, Cpu, Globe, AlertTriangle,
   Sparkles, Terminal, Key, Check, Trash2
@@ -47,10 +47,18 @@ export function ImageGenTab() {
   const [codexPath, setCodexPath] = useState('');
   const [codexModel, setCodexModel] = useState('');
   const [codexParallelLimit, setCodexParallelLimit] = useState(1);
+  // Raw string held while the user is typing in the parallel-limit input.
+  // Clamping is deferred to onBlur so multi-digit entry isn't blocked.
+  const [parallelLimitDraft, setParallelLimitDraft] = useState('1');
   // Server-authoritative bounds for the parallel-limit input. Populated from
   // /api/settings's `imageGen.codex.parallelLimitBounds`; falls back to local
   // constants until the first fetch resolves.
   const [parallelBounds, setParallelBounds] = useState(PARALLEL_FALLBACK);
+
+  // Stable ids for label/input associations
+  const codexPathId = useId();
+  const codexModelId = useId();
+  const codexParallelId = useId();
 
   // Snapshot of saved values so we can show the "dirty" state
   const [saved, setSaved] = useState({
@@ -136,6 +144,7 @@ export function ImageGenTab() {
         setCodexPath(cxPath);
         setCodexModel(cxModel);
         setCodexParallelLimit(cxParallel);
+        setParallelLimitDraft(String(cxParallel));
         setSaved({
           mode: m, sdapiUrl: url, pythonPath: py, exposeA1111: expose,
           codexEnabled: cxEnabled, codexPath: cxPath, codexModel: cxModel,
@@ -194,7 +203,10 @@ export function ImageGenTab() {
         codexEnabled, codexPath: cxPath || '', codexModel: cxModel || '',
         codexParallelLimit: cxParallel,
       });
-      if (cxParallel !== codexParallelLimit) setCodexParallelLimit(cxParallel);
+      if (cxParallel !== codexParallelLimit) {
+        setCodexParallelLimit(cxParallel);
+        setParallelLimitDraft(String(cxParallel));
+      }
       // Reflect the normalization back into the inputs so what the user
       // sees matches what was saved.
       if (cxPath !== codexPath) setCodexPath(cxPath || '');
@@ -447,8 +459,9 @@ export function ImageGenTab() {
         {codexEnabled && (
           <div className="space-y-3 pl-6 border-l-2 border-port-border">
             <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">Codex binary path (optional)</label>
+              <label htmlFor={codexPathId} className="block text-xs font-medium text-gray-400 mb-1">Codex binary path (optional)</label>
               <input
+                id={codexPathId}
                 type="text"
                 value={codexPath}
                 onChange={(e) => setCodexPath(e.target.value)}
@@ -458,8 +471,9 @@ export function ImageGenTab() {
               <p className="text-xs text-gray-500 mt-1">Leave empty to invoke <code>codex</code> from $PATH.</p>
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">Model override (optional)</label>
+              <label htmlFor={codexModelId} className="block text-xs font-medium text-gray-400 mb-1">Model override (optional)</label>
               <input
+                id={codexModelId}
                 type="text"
                 value={codexModel}
                 onChange={(e) => setCodexModel(e.target.value)}
@@ -469,14 +483,20 @@ export function ImageGenTab() {
               <p className="text-xs text-gray-500 mt-1">Passed as <code>codex exec -m &lt;model&gt;</code>. Leave empty to use Codex's default.</p>
             </div>
             <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">Parallel render limit</label>
+              <label htmlFor={codexParallelId} className="block text-xs font-medium text-gray-400 mb-1">Parallel render limit</label>
               <input
+                id={codexParallelId}
                 type="number"
                 min={parallelBounds.min}
                 max={parallelBounds.max}
                 step={1}
-                value={codexParallelLimit}
-                onChange={(e) => setCodexParallelLimit(clampParallel(e.target.value, parallelBounds))}
+                value={parallelLimitDraft}
+                onChange={(e) => setParallelLimitDraft(e.target.value)}
+                onBlur={() => {
+                  const clamped = clampParallel(parallelLimitDraft, parallelBounds);
+                  setCodexParallelLimit(clamped);
+                  setParallelLimitDraft(String(clamped));
+                }}
                 className="w-24 bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent"
               />
               <p className="text-xs text-gray-500 mt-1">

--- a/client/src/components/settings/MortalLoomTab.jsx
+++ b/client/src/components/settings/MortalLoomTab.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useId } from 'react';
 import { Save, Download, ExternalLink, CheckCircle2, AlertCircle } from 'lucide-react';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
@@ -11,6 +11,7 @@ import {
 import { formatBytes } from '../../utils/formatters';
 
 export function MortalLoomTab() {
+  const icloudPathId = useId();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [importing, setImporting] = useState(false);
@@ -115,8 +116,9 @@ export function MortalLoomTab() {
         </div>
 
         <div className="space-y-1">
-          <label className="block text-sm text-gray-400">iCloud file path</label>
+          <label htmlFor={icloudPathId} className="block text-sm text-gray-400">iCloud file path</label>
           <input
+            id={icloudPathId}
             type="text"
             value={path}
             onChange={e => setPath(e.target.value)}

--- a/client/src/components/settings/VoiceTab.jsx
+++ b/client/src/components/settings/VoiceTab.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useId, Children, cloneElement, isValidElement } from 'react';
 import { Save, Mic, Play, Zap } from 'lucide-react';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
@@ -77,13 +77,22 @@ const ServiceBadge = ({ label, probe }) => {
   );
 };
 
-const Field = ({ label, hint, children, className = '' }) => (
-  <div className={`space-y-1 ${className}`}>
-    <label className="block text-sm text-gray-400">{label}</label>
-    {hint && <p className="text-xs text-gray-500">{hint}</p>}
-    {children}
-  </div>
-);
+const Field = ({ label, hint, children, className = '' }) => {
+  const id = useId();
+  // Inject `id` into the first child element so the label's htmlFor resolves.
+  const augmented = Children.map(children, (child, i) =>
+    i === 0 && isValidElement(child) && !child.props.id
+      ? cloneElement(child, { id })
+      : child
+  );
+  return (
+    <div className={`space-y-1 ${className}`}>
+      <label htmlFor={id} className="block text-sm text-gray-400">{label}</label>
+      {hint && <p className="text-xs text-gray-500">{hint}</p>}
+      {augmented}
+    </div>
+  );
+};
 
 const inputCls = 'w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent';
 


### PR DESCRIPTION
## Summary

Phase 6 of the **Better Audit — 2026-05-19**. Accessibility regressions + one UX bug:

- **`VoiceTab.Field`** — the reusable Field component now generates a stable `id` via `useId()` and injects it into its first child + matching `htmlFor` on the label. Fixes 10+ form rows in one place.
- **`ProviderModelSelector`** — `useId` for both Provider and Model label/select pairs.
- **`BackupTab`, `MortalLoomTab`, `ImageGenTab`, `BackupWidget`** — `useId` pairing on loose label+input siblings.
- **`IconPicker`** — dangling `<label>` (pointing at a `<button>` so `htmlFor` doesn't work) → sibling `<span>` + `aria-label` on the button.
- **`TaskAddForm`** — icon-only delete button uses `aria-label` instead of `title` (screen readers ignore `title` on interactive elements).
- **`ImageGenTab` parallel-render-limit number input** — no longer snaps to default on every keystroke. Local string draft state, clamp on blur. Restores ability to type "10" instead of being reset to "1" after each digit.

## Files Modified
- 8 client components under `client/src/components/{,cos,settings}/`.

## Merge Order
Independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)