### PR TITLE
Lock plan-task worktree/PR toggles — task owns its own claim/<slug> worktree

### DIFF
--- a/client/src/components/apps/tabs/AutomationTab.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.jsx
@@ -211,14 +211,21 @@ export default function AutomationTab({ appId, appName }) {
                     {AGENT_OPTIONS.map(({ field, shortLabel, label }) => {
                       const effective = override.taskMetadata?.[field] ?? globalConfig.taskMetadata?.[field] ?? false;
                       const hasOverride = override.taskMetadata?.[field] !== undefined;
+                      const managed = globalConfig.managedAgentOptions?.includes(field);
+                      const titleText = managed
+                        ? `${label}: managed internally by ${taskType}`
+                        : `${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`;
                       return (
                         <button
                           key={field}
                           onClick={() => handleMetaToggle(taskType, field, globalConfig.taskMetadata)}
+                          disabled={managed}
                           aria-pressed={effective}
-                          aria-label={`${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`}
-                          className={`text-xs px-1.5 py-0.5 rounded transition-colors border ${agentOptionButtonClass(effective, hasOverride)}`}
-                          title={`${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`}
+                          aria-label={managed
+                            ? `${label}: managed by task`
+                            : `${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`}
+                          className={`text-xs px-1.5 py-0.5 rounded transition-colors border ${agentOptionButtonClass(effective, hasOverride)} ${managed ? 'opacity-50 cursor-not-allowed' : ''}`}
+                          title={titleText}
                         >
                           {shortLabel}
                         </button>

--- a/client/src/components/cos/tabs/ScheduleTab.jsx
+++ b/client/src/components/cos/tabs/ScheduleTab.jsx
@@ -466,26 +466,31 @@ function GlobalConfigControls({ taskType, config, onUpdate, onTrigger, onReset, 
         <div className="space-y-2">
           {AGENT_OPTIONS.map(({ field, label, description }) => {
             const enabled = config.taskMetadata?.[field] ?? false;
-            const handleToggle = () => {
-              if (!updating) onUpdate(taskType, { taskMetadata: toggleMetadataField(config.taskMetadata, field) });
-            };
+            const managed = config.managedAgentOptions?.includes(field);
+            const lockedHint = `${label} is managed internally by this task — the agent's prompt handles it.`;
             return (
               <button
                 key={field}
                 type="button"
-                disabled={updating}
+                disabled={updating || managed}
                 aria-pressed={enabled}
-                aria-label={`${enabled ? 'Disable' : 'Enable'} ${label.toLowerCase()}`}
-                className={`w-full flex items-center justify-between gap-3 min-h-[44px] rounded px-2 -mx-2 text-left ${updating ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:bg-port-card/30 active:bg-port-card/50'}`}
-                onClick={handleToggle}
+                aria-label={managed
+                  ? `${label} (managed by task)`
+                  : `${enabled ? 'Disable' : 'Enable'} ${label.toLowerCase()}`}
+                title={managed ? lockedHint : undefined}
+                className={`w-full flex items-center justify-between gap-3 min-h-[44px] rounded px-2 -mx-2 text-left ${updating || managed ? 'opacity-60 cursor-not-allowed' : 'cursor-pointer hover:bg-port-card/30 active:bg-port-card/50'}`}
+                onClick={() => onUpdate(taskType, { taskMetadata: toggleMetadataField(config.taskMetadata, field) })}
               >
                 <div className="min-w-0 flex-1">
-                  <span className="text-sm text-white">{label}</span>
-                  <p className="text-xs text-gray-500">{description}</p>
+                  <span className="text-sm text-white flex items-center gap-2">
+                    {label}
+                    {managed && <span className="text-[10px] px-1 py-0.5 bg-gray-600/30 text-gray-400 rounded">managed</span>}
+                  </span>
+                  <p className="text-xs text-gray-500">{managed ? lockedHint : description}</p>
                 </div>
                 <ToggleSwitch
                   enabled={enabled}
-                  disabled={updating}
+                  disabled={updating || managed}
                   decorative
                 />
               </button>
@@ -599,7 +604,7 @@ function GlobalConfigControls({ taskType, config, onUpdate, onTrigger, onReset, 
   );
 }
 
-const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalIntervalType, globalTaskMetadata, override, onUpdate }) {
+const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalIntervalType, globalTaskMetadata, managedAgentOptions, override, onUpdate }) {
   const [updating, setUpdating] = useState(false);
   const [cronEditing, setCronEditing] = useState(false);
   const isEnabled = override?.enabled === true;
@@ -691,15 +696,21 @@ const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalInter
           {AGENT_OPTIONS.map(({ field, label, shortLabel }) => {
             const effective = override?.taskMetadata?.[field] ?? globalTaskMetadata?.[field] ?? false;
             const hasOverride = override?.taskMetadata?.[field] !== undefined;
+            const managed = managedAgentOptions?.includes(field);
+            const titleText = managed
+              ? `${label}: managed internally by ${taskType}`
+              : `${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`;
             return (
               <button
                 key={field}
                 onClick={() => handleMetaToggle(field)}
-                disabled={updating}
+                disabled={updating || managed}
                 aria-pressed={effective}
-                aria-label={`${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`}
-                className={`text-xs px-2 py-1.5 rounded transition-colors shrink-0 min-h-[40px] min-w-[40px] border ${agentOptionButtonClass(effective, hasOverride)}`}
-                title={`${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`}
+                aria-label={managed
+                  ? `${label}: managed by task`
+                  : `${label}: ${effective ? 'on' : 'off'}${hasOverride ? ' (app override)' : ' (inherited)'}`}
+                className={`text-xs px-2 py-1.5 rounded transition-colors shrink-0 min-h-[40px] min-w-[40px] border ${agentOptionButtonClass(effective, hasOverride)} ${managed ? 'opacity-50 cursor-not-allowed' : ''}`}
+                title={titleText}
               >
                 {shortLabel}
               </button>
@@ -766,6 +777,7 @@ function PerAppOverrideList({ taskType, config, apps, onUpdateOverride, onBulkTo
             taskType={taskType}
             globalIntervalType={config.type}
             globalTaskMetadata={config.taskMetadata}
+            managedAgentOptions={config.managedAgentOptions}
             override={appOverrides[app.id]}
             onUpdate={onUpdateOverride}
           />

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -1757,6 +1757,36 @@ const DEFAULT_TASK_INTERVALS = {
   'reference-watch':     { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { readOnly: true } }
 };
 
+// Agent-options that a task manages internally — UI locks the toggle, and
+// loadSchedule/updateTaskInterval enforce the default value regardless of
+// what's persisted or POSTed. The reasoning lives next to each task above
+// (e.g., plan-task's prompt creates its own claim/<slug> worktree, so a
+// CoS-managed worktree would clobber it).
+export const MANAGED_AGENT_OPTIONS = {
+  'plan-task': ['useWorktree', 'openPR']
+};
+
+function enforceManagedAgentOptions(taskType, config) {
+  const managed = MANAGED_AGENT_OPTIONS[taskType];
+  if (!managed || !config) return false;
+  const defaults = DEFAULT_TASK_INTERVALS[taskType]?.taskMetadata || {};
+  let changed = false;
+  // If the stored config explicitly cleared taskMetadata (or never had it),
+  // we still need the managed fields present — otherwise upstream resolvers
+  // (e.g., cos.js applyAppWorktreeDefault) can flip them on via app defaults.
+  if (!config.taskMetadata || typeof config.taskMetadata !== 'object') {
+    config.taskMetadata = {};
+    changed = true;
+  }
+  for (const field of managed) {
+    if (config.taskMetadata[field] !== defaults[field]) {
+      config.taskMetadata[field] = defaults[field];
+      changed = true;
+    }
+  }
+  return changed;
+}
+
 /**
  * Default schedule data structure (v2 - unified)
  */
@@ -1920,6 +1950,7 @@ export async function loadSchedule() {
   // Populate prompts from defaults if missing, and auto-upgrade stale defaults
   let needsSave = false;
   for (const [taskType, config] of Object.entries(schedule.tasks)) {
+    if (enforceManagedAgentOptions(taskType, config)) needsSave = true;
     if (!config.prompt && DEFAULT_TASK_PROMPTS[taskType]) {
       // No prompt set — initialize with current default and version
       config.prompt = DEFAULT_TASK_PROMPTS[taskType];
@@ -2004,6 +2035,11 @@ export async function updateTaskInterval(taskType, settings) {
     ...schedule.tasks[taskType],
     ...settings
   };
+
+  // Re-assert agent-managed taskMetadata fields after the merge so a PUT that
+  // tries to flip them (UI bypass, hand-edited TASKS.md, direct API call)
+  // gets the locked value back in its response.
+  enforceManagedAgentOptions(taskType, schedule.tasks[taskType]);
 
   await saveSchedule(schedule);
   emitLog('info', `Updated task interval for ${taskType}`, { taskType, settings }, '📅 TaskSchedule');
@@ -2526,6 +2562,11 @@ export async function getScheduleStatus() {
       taskStatus.stagePrompts = interval.taskMetadata.pipeline.stages.map(stage =>
         DEFAULT_TASK_PROMPTS[stage.promptKey] || null
       );
+    }
+
+    // Surface agent-managed flags so the UI can lock the corresponding toggles
+    if (MANAGED_AGENT_OPTIONS[taskType]) {
+      taskStatus.managedAgentOptions = MANAGED_AGENT_OPTIONS[taskType];
     }
 
     status.tasks[taskType] = taskStatus;

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -265,6 +265,66 @@ describe('taskSchedule', () => {
     })
   })
 
+  describe('managed agent options', () => {
+    it('forces plan-task useWorktree/openPR back to false when stored true (loadSchedule)', async () => {
+      mockSchedule({
+        tasks: {
+          'plan-task': {
+            type: 'cron',
+            enabled: true,
+            providerId: null,
+            model: null,
+            prompt: null,
+            taskMetadata: { useWorktree: true, openPR: true, simplify: true }
+          }
+        }
+      })
+
+      const schedule = await loadSchedule()
+      expect(schedule.tasks['plan-task'].taskMetadata.useWorktree).toBe(false)
+      expect(schedule.tasks['plan-task'].taskMetadata.openPR).toBe(false)
+      // Non-managed flags pass through untouched
+      expect(schedule.tasks['plan-task'].taskMetadata.simplify).toBe(true)
+    })
+
+    it('exposes managedAgentOptions in getScheduleStatus for plan-task', async () => {
+      mockSchedule()
+      const status = await getScheduleStatus()
+      expect(status.tasks['plan-task'].managedAgentOptions).toEqual(['useWorktree', 'openPR'])
+      // Other tasks should not carry the field
+      expect(status.tasks['security'].managedAgentOptions).toBeUndefined()
+    })
+
+    it('rejects PUT attempts to flip a managed flag — response echoes the locked value', async () => {
+      mockSchedule()
+      const result = await updateTaskInterval('plan-task', {
+        taskMetadata: { useWorktree: true, openPR: true, simplify: true }
+      })
+      expect(result.taskMetadata.useWorktree).toBe(false)
+      expect(result.taskMetadata.openPR).toBe(false)
+      expect(result.taskMetadata.simplify).toBe(true)
+    })
+
+    it('repopulates managed flags when stored taskMetadata was cleared to null', async () => {
+      mockSchedule({
+        tasks: {
+          'plan-task': {
+            type: 'cron',
+            enabled: true,
+            providerId: null,
+            model: null,
+            prompt: null,
+            taskMetadata: null
+          }
+        }
+      })
+
+      const schedule = await loadSchedule()
+      expect(schedule.tasks['plan-task'].taskMetadata.useWorktree).toBe(false)
+      expect(schedule.tasks['plan-task'].taskMetadata.openPR).toBe(false)
+    })
+  })
+
   describe('recordExecution', () => {
     it('should record global execution', async () => {
       mockSchedule()


### PR DESCRIPTION
## Summary

The `plan-task` scheduled task's prompt creates its own `claim/<slug>` worktree (Phase 2 of the prompt) — a CoS-managed worktree on top of that hides the slug from the in-flight branch scan AND triggers `cleanupAgentWorktree`'s auto-merge into the source repo HEAD (clobbering a TUI user's in-flight claim branch). The defaults in `DEFAULT_TASK_INTERVALS` already set `useWorktree: false, openPR: false` for plan-task, but stored schedules from before that flip kept the wrong values, and the UI let users toggle them back on.

This PR introduces a generic "managed agent options" concept: a task can declare flags whose value the *agent's prompt itself* manages, and PortOS locks the toggle, enforces the default on every read/write, and surfaces the lock to the UI.

- `MANAGED_AGENT_OPTIONS = { 'plan-task': ['useWorktree', 'openPR'] }` in `taskSchedule.js`
- `enforceManagedAgentOptions(taskType, config)` runs inside `loadSchedule` (heals existing stored schedules in place) and `updateTaskInterval` (rejects PUT attempts to flip a managed flag — response echoes the locked value, so the UI gets immediate feedback even if it ever bypasses the disabled state)
- `getScheduleStatus` exposes `managedAgentOptions` per task so the client can lock the matching toggles
- `ScheduleTab.jsx` global Agent Options buttons + per-app `AppOverrideRow` toggle buttons + `AutomationTab.jsx` per-app overrides all read `config.managedAgentOptions` and render the locked toggle as `disabled + "managed" pill + tooltip "<Label> is managed internally by this task — the agent's prompt handles it."`
- Belt-and-suspenders: server-side enforcement means a hand-edited TASKS.md row or direct API call can't bypass the UI lock either

## Test plan

- [x] `npm test` — all 5759 server tests pass (4 new tests for managed-option enforcement)
- [x] `/simplify` — three review agents flagged AutomationTab's missed AGENT_OPTIONS site, redundant `!managed` onClick guards, and badge style inconsistency; all addressed in this diff
- [ ] On a stored schedule with `plan-task.taskMetadata.useWorktree: true` (the pre-existing bad state), boot the server and verify `data/cos/task-schedule.json` is healed to `false` on first load
- [ ] Open CoS → Schedule → plan-task — confirm Worktree and Open PR toggles render as disabled with a "managed" pill and tooltip explainer, and that the labels stay accurate
- [ ] Open Apps → Automation tab on any app — confirm the per-app override buttons for the same two flags on plan-task are also locked