### PR TITLE
fix(universe-builder): reopen Universe Name dropdown shows other universes instead of "No matches"

### DIFF
--- a/client/src/pages/UniverseBuilder.jsx
+++ b/client/src/pages/UniverseBuilder.jsx
@@ -383,7 +383,7 @@ const LIST_ID = 'universe-selector-list';
 const OPTION_ID_PREFIX = 'universe-option-';
 const CREATE_OPTION_ID = 'universe-option-create';
 
-function UniverseSelector({ universes, selectedId, value, onChange, onPick, onCreate, busy }) {
+export function UniverseSelector({ universes, selectedId, value, onChange, onPick, onCreate, busy }) {
   const wrapRef = useRef(null);
   const [open, setOpen] = useState(false);
   const [activeIdx, setActiveIdx] = useState(0);
@@ -395,14 +395,24 @@ function UniverseSelector({ universes, selectedId, value, onChange, onPick, onCr
   const trimmed = (value || '').trim();
   const lower = trimmed.toLowerCase();
 
+  // When the input still holds the currently selected universe's name, the
+  // user opened the dropdown to browse — not to search for that exact name
+  // (which, after excluding the selected universe itself, would always be
+  // empty). Treat this as an unfiltered browse so they see the other options.
+  const selectedName = useMemo(() => {
+    if (!selectedId || !Array.isArray(universes)) return '';
+    return (universes.find((u) => u.id === selectedId)?.name || '').trim().toLowerCase();
+  }, [universes, selectedId]);
+  const browsing = !!selectedName && lower === selectedName;
+
   // Exclude current — clicking it would be a navigation no-op.
   const filtered = useMemo(() => {
     if (!Array.isArray(universes) || universes.length === 0) return [];
     return universes
       .filter((u) => u.id !== selectedId)
-      .filter((u) => !lower || (u.name || '').toLowerCase().includes(lower))
+      .filter((u) => browsing || !lower || (u.name || '').toLowerCase().includes(lower))
       .slice(0, 20);
-  }, [universes, selectedId, lower]);
+  }, [universes, selectedId, lower, browsing]);
 
   // exactMatch still considers the current one so renaming-to-same doesn't
   // surface a misleading Create option.

--- a/client/src/pages/UniverseBuilder.test.jsx
+++ b/client/src/pages/UniverseBuilder.test.jsx
@@ -3,7 +3,7 @@ import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 
-import { CategoryEditor, TrunkView, OtherTab } from './UniverseBuilder';
+import { CategoryEditor, TrunkView, OtherTab, UniverseSelector } from './UniverseBuilder';
 
 // MemoryRouter wrapper — UniverseBuilder.jsx imports react-router-dom hooks at
 // module scope, so the test harness needs a router context even when the
@@ -179,5 +179,71 @@ describe('OtherTab — Auto-sort button', () => {
     // The disabled state must visibly block re-entry, not just rely on the
     // page-level autoSortingRef guard (which the user can't see).
     expect(screen.queryByRole('button', { name: /^Auto-sort with AI$/i })).toBeNull();
+  });
+});
+
+describe('UniverseSelector — open-while-selected', () => {
+  const universes = [
+    { id: 'u1', name: 'Cyberpunk 2099', starterPrompt: 'Neon rain' },
+    { id: 'u2', name: 'Salt Run', starterPrompt: 'Foundry city' },
+    { id: 'u3', name: 'Choir Awakens', starterPrompt: 'Empty cathedral' },
+  ];
+
+  it('lists the other universes when the dropdown is opened on a selected one', async () => {
+    const user = userEvent.setup();
+    renderWithRouter(
+      <UniverseSelector
+        universes={universes}
+        selectedId="u1"
+        value="Cyberpunk 2099"
+        onChange={() => {}}
+        onPick={() => {}}
+        onCreate={() => {}}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /Open universe list/i }));
+    const list = screen.getByRole('listbox');
+    expect(within(list).getByText('Salt Run')).toBeInTheDocument();
+    expect(within(list).getByText('Choir Awakens')).toBeInTheDocument();
+    expect(within(list).queryByText(/No matches/i)).toBeNull();
+    // Selected universe stays out of the list (clicking it would no-op).
+    expect(within(list).queryByText('Cyberpunk 2099')).toBeNull();
+    // Input matches an existing name exactly, so no Create row.
+    expect(within(list).queryByText(/Create/i)).toBeNull();
+  });
+
+  it('filters by the typed query as soon as the user starts typing', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { rerender } = renderWithRouter(
+      <UniverseSelector
+        universes={universes}
+        selectedId="u1"
+        value="Cyberpunk 2099"
+        onChange={onChange}
+        onPick={() => {}}
+        onCreate={() => {}}
+      />
+    );
+
+    await user.click(screen.getByRole('combobox'));
+    // Parent owns `value` — simulate the controlled-input update from onChange.
+    rerender(
+      <MemoryRouter>
+        <UniverseSelector
+          universes={universes}
+          selectedId="u1"
+          value="Salt"
+          onChange={onChange}
+          onPick={() => {}}
+          onCreate={() => {}}
+        />
+      </MemoryRouter>
+    );
+
+    const list = screen.getByRole('listbox');
+    expect(within(list).getByText('Salt Run')).toBeInTheDocument();
+    expect(within(list).queryByText('Choir Awakens')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- The Universe Builder header's autocomplete combobox seeds its input with the currently selected universe's name. Clicking the chevron to reopen the list applied that name as a substring filter and then excluded the selected universe itself — so the dropdown always showed "No matches" and there was no way to switch to another universe without first manually clearing the field.
- Fix: when the trimmed lower-case input equals the selected universe's name, treat it as a *browse* intent and skip the substring filter so the user sees every other universe. As soon as they type something different, normal filtering resumes.
- Added two `UniverseSelector` tests covering the browse-on-reopen case and the resume-filtering-on-type case.

## Test plan

- [x] `cd client && npm test -- --run` — 143/143 passing
- [ ] Manually: select a universe, click the chevron — verify other universes appear
- [ ] Manually: with a universe selected, type a partial name — verify the list filters
- [ ] Manually: with a universe selected, type the same name verbatim again — verify no spurious "Create" row appears