### PR TITLE
fix([feeds-ssrf-ipv6-bracket-hostname-gap]): reject bracketed IPv6 hostnames in feed-fetch SSRF guard

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -9,4 +9,6 @@
 
 ## Fixed
 
+- **[feeds-ssrf-ipv6-bracket-hostname-gap] RSS feed subscriptions now reliably reject IPv6 loopback, link-local, and unique-local addresses** — previously the loopback `http://[::1]/feed` case was blocked only incidentally by DNS errors; subscribing to feeds at literal private IPv6 addresses is now refused outright, including IPv4-mapped variants like `[::ffff:192.168.1.1]`.
+
 ## Removed

--- a/PLAN.md
+++ b/PLAN.md
@@ -14,7 +14,7 @@ _Nothing currently parked — pick the next item from the Backlog._
 
 ### Better-audit residue
 
-- [ ] [feeds-ssrf-ipv6-bracket-hostname-gap] **[MED][SECURITY]** `server/services/feeds.js#isHostSafe` doesn't reliably reject IPv6 literal hostnames like `http://[::1]/feed`. `new URL(...).hostname` returns `'[::1]'` (with brackets), so `net.isIP('[::1]')` returns 0 (brackets aren't valid IP syntax) and execution falls through to `dns.resolve4('[::1]')`. Production DNS typically errors → empty addresses → `return false`, so the loopback is protected _incidentally_, but the protection is fragile (any caching resolver or unusual hosts file could subvert it). Fix: strip surrounding `[…]` brackets before `net.isIP`, add an explicit `if (net.isIP(stripped) === 6) return !isPrivateIP(stripped)` branch, and extend `isPrivateIP` to cover ULA (`fc00::/7`) and link-local (`fe80::/10`) ranges. `isPrivateIP` already handles `::1`/`::`. Surfaced 2026-05-19 while adding feeds.js test coverage; deferred to keep that PR scoped to tests.
+- [ ] [feeds-ssrf-aaaa-record-blindness] **[LOW][SECURITY]** `server/services/feeds.js#isHostSafe` only calls `dns.resolve4`, so a hostname with a public A record + private AAAA record passes the guard but Node's fetch (happy-eyeballs) may prefer the AAAA and reach a private IPv6. Fix: `Promise.all([dns.resolve4, dns.resolve6])`, treat empty-both as fail, require *every* address across both families to pass `isPrivateIP`. Update the test mock to also intercept `resolve6`. Same fix unlocks AAAA-only feeds (currently rejected as "no A records") as a side effect. Skipped from `[feeds-ssrf-ipv6-bracket-hostname-gap]` to keep that PR scoped to the bracket-stripping bug.
 
 ### Pipeline — deferred
 

--- a/server/services/feeds.js
+++ b/server/services/feeds.js
@@ -386,13 +386,37 @@ export async function getFeedStats() {
 
 // ─── Internal Helpers ───────────────────────────────────────────────────────
 
-// Check if an IP address is private/loopback/link-local
+// Check if an IP address is private/loopback/link-local (IPv4 or IPv6).
 function isPrivateIP(ip) {
   if (!ip) return true;
-  // IPv6 loopback
-  if (ip === '::1' || ip === '::') return true;
+  const lower = ip.toLowerCase();
+  // IPv6
+  if (lower.includes(':')) {
+    if (lower === '::1' || lower === '::') return true;
+    // IPv4-mapped IPv6 — accept both ::ffff:a.b.c.d (raw form from dns.resolve)
+    // and ::ffff:wxyz:wxyz (the hex form Node's URL parser normalizes to).
+    const mappedDotted = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mappedDotted) return isPrivateIP(mappedDotted[1]);
+    const mappedHex = lower.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+    if (mappedHex) {
+      const high = parseInt(mappedHex[1], 16);
+      const low = parseInt(mappedHex[2], 16);
+      return isPrivateIP(`${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`);
+    }
+    const firstGroup = lower.split(':')[0];
+    if (firstGroup) {
+      const firstWord = parseInt(firstGroup, 16);
+      if (Number.isFinite(firstWord)) {
+        // ULA fc00::/7 (top 7 bits = 1111110)
+        if ((firstWord & 0xfe00) === 0xfc00) return true;
+        // Link-local fe80::/10 (top 10 bits = 1111111010)
+        if ((firstWord & 0xffc0) === 0xfe80) return true;
+      }
+    }
+    return false;
+  }
   // IPv4
-  const parts = ip.split('.').map(Number);
+  const parts = lower.split('.').map(Number);
   if (parts.length === 4 && parts.every(p => !isNaN(p) && p >= 0 && p <= 255)) {
     if (parts[0] === 10) return true;
     if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
@@ -406,10 +430,14 @@ function isPrivateIP(ip) {
 
 // Resolve hostname and verify it doesn't point to a private IP
 async function isHostSafe(hostname) {
-  // Numeric IPs: check directly
-  if (net.isIP(hostname)) return !isPrivateIP(hostname);
+  // URL.hostname preserves the [::1] bracketed form for IPv6 literals; strip
+  // brackets so net.isIP recognizes the address before falling through to DNS.
+  const stripped = hostname.startsWith('[') && hostname.endsWith(']')
+    ? hostname.slice(1, -1)
+    : hostname;
+  if (net.isIP(stripped)) return !isPrivateIP(stripped);
   // DNS resolution: check all resolved addresses
-  const addresses = await dns.resolve4(hostname).catch(() => []);
+  const addresses = await dns.resolve4(stripped).catch(() => []);
   if (addresses.length === 0) return false;
   return addresses.every(addr => !isPrivateIP(addr));
 }

--- a/server/services/feeds.test.js
+++ b/server/services/feeds.test.js
@@ -166,6 +166,31 @@ describe('addFeed', () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ['IPv6 loopback', '[::1]'],
+    ['IPv6 unspecified', '[::]'],
+    ['IPv6 ULA fc00::/7 (fc..)', '[fc00::1]'],
+    ['IPv6 ULA fc00::/7 (fd..)', '[fd12:3456:789a::1]'],
+    ['IPv6 link-local fe80::/10', '[fe80::1]'],
+    ['IPv4-mapped loopback', '[::ffff:127.0.0.1]'],
+    ['IPv4-mapped RFC1918', '[::ffff:192.168.1.1]'],
+  ])('rejects literal private IPv6 %s without DNS lookup', async (_label, host) => {
+    const result = await feeds.addFeed(`http://${host}/feed`);
+    expect(result).toEqual({ error: FETCH_ERROR });
+    expect(dnsResolveMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts a public IPv6 literal (covers stripped-brackets path)', async () => {
+    fetchMock.mockResolvedValue(makeResponse({ body: RSS_FIXTURE }));
+    const result = await feeds.addFeed('http://[2606:4700:4700::1111]/rss');
+    expect(result.error).toBeUndefined();
+    expect(dnsResolveMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // Bracketed form must survive into the outbound fetch URL — stripping happened only inside isHostSafe
+    expect(fetchMock.mock.calls[0][0]).toContain('[2606:4700:4700::1111]');
+  });
+
   it('rejects hostnames that resolve to a private IP (DNS rebinding guard)', async () => {
     dnsResolveMock.mockResolvedValue(['10.0.0.42']);
     const result = await feeds.addFeed('https://evil.example.com/rss');


### PR DESCRIPTION
## Summary

`server/services/feeds.js#isHostSafe` didn't reliably reject IPv6 literal hostnames like `http://[::1]/feed`. `new URL(url).hostname` preserves the bracketed form (`'[::1]'`), so `net.isIP('[::1]')` returned 0 and execution fell through to `dns.resolve4('[::1]')`. Production DNS errors on that string and returns no addresses, so loopback was rejected *incidentally* — fragile against caching resolvers or unusual hosts files.

Fix:

- Strip surrounding `[…]` brackets before `net.isIP` so literal IPv6 addresses are recognized.
- Extend `isPrivateIP` to cover IPv6 ULA (`fc00::/7`), link-local (`fe80::/10`), and IPv4-mapped IPv6 in both dotted-quad (`::ffff:a.b.c.d`) and hex (`::ffff:wxyz:wxyz`) forms. Node's URL parser normalizes the dotted form to hex (e.g. `[::ffff:127.0.0.1]` → `[::ffff:7f00:1]`), so both branches are needed.
- Pin the new behavior with `it.each` tests covering loopback, unspecified, ULA `fc..`/`fd..`, link-local, both IPv4-mapped forms, and a positive case for a public IPv6 literal.

A follow-up item is added to PLAN.md (`[feeds-ssrf-aaaa-record-blindness]`) for closing the related AAAA-record blindness — out of scope for this PR.

## Test plan

- [x] `cd server && npx vitest run services/feeds.test.js` — 43/43 pass
- [x] Full server suite — 6191 tests pass
- [x] Manual verification that Node URL normalizes `[::ffff:127.0.0.1]` → `[::ffff:7f00:1]` so the hex branch is the one exercised in production