### PR TITLE
fix(nav): move Health page to Chief of Staff section

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -169,6 +169,7 @@ const navItems = [
       { to: '/cos/config', label: 'Config', icon: Settings },
       { to: '/cos/digest', label: 'Digest', icon: Calendar },
       { to: '/cos/gsd', label: 'GSD', icon: Compass },
+      { to: '/cos/health', label: 'Health', icon: Activity },
       { to: '/cos/learning', label: 'Learning', icon: GraduationCap },
       { to: '/cos/memory', label: 'Memory', icon: Brain },
       { to: '/cos/schedule', label: 'Schedule', icon: Clock },
@@ -294,10 +295,9 @@ const navItems = [
   {
     label: 'System',
     icon: HardDrive,
-    defaultTo: '/cos/health',
+    defaultTo: '/data',
     children: [
       { to: '/data', label: 'Data', icon: HardDrive },
-      { to: '/cos/health', label: 'Health', icon: Activity },
       { to: '/instances', label: 'Instances', icon: Network },
       { to: '/loops', label: 'Loops', icon: RefreshCw },
       { to: '/devtools/processes', label: 'Processes', icon: Activity },

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -184,20 +184,33 @@ export const resolveNavCommand = (input) => {
   if (!norm) return null;
 
   const tail = norm.split('-').filter(Boolean).pop();
+  // Each tier is { test, longest? }. `longest:true` picks the longest matching
+  // alias (so "meatspace health" prefers `meatspace-health` over the shorter
+  // `health` that also ends/contains-matches the input). Other tiers keep
+  // first-declared-wins ordering because shorter aliases there are intentional
+  // (e.g. `cos` should match before `cos-tasks` when input is bare "cos").
   const tiers = [
-    (a) => a === norm,
-    (a) => norm.startsWith(a) && a.length >= 3,
-    (a) => a.startsWith(norm),
-    (a) => norm.endsWith(`-${a}`) && a.length >= 3,
-    (a) => norm.includes(a) && a.length >= 4,
-    (a) => a.includes(norm),
-    (a) => tail && tail !== norm && a === tail,
+    { test: (a) => a === norm },
+    { test: (a) => norm.startsWith(a) && a.length >= 3 },
+    { test: (a) => a.startsWith(norm) },
+    { test: (a) => norm.endsWith(`-${a}`) && a.length >= 3, longest: true },
+    { test: (a) => norm.includes(a) && a.length >= 4, longest: true },
+    { test: (a) => a.includes(norm) },
+    { test: (a) => tail && tail !== norm && a === tail },
   ];
 
   let matched = null;
-  for (const test of tiers) {
-    matched = ALIAS_KEYS.find(test);
-    if (matched) break;
+  for (const { test, longest } of tiers) {
+    if (longest) {
+      const candidates = ALIAS_KEYS.filter(test);
+      if (candidates.length) {
+        matched = candidates.reduce((a, b) => (b.length > a.length ? b : a));
+        break;
+      }
+    } else {
+      matched = ALIAS_KEYS.find(test);
+      if (matched) break;
+    }
   }
   if (!matched) return null;
 

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -57,6 +57,7 @@ export const NAV_COMMANDS = [
   { id: 'nav.cos.config', path: '/cos/config', label: 'Config', section: 'Chief of Staff', aliases: ['cos-config'] },
   { id: 'nav.cos.digest', path: '/cos/digest', label: 'Digest', section: 'Chief of Staff', aliases: ['cos-digest'] },
   { id: 'nav.cos.gsd', path: '/cos/gsd', label: 'GSD', section: 'Chief of Staff', aliases: ['gsd', 'cos-gsd'] },
+  { id: 'nav.cos.health', path: '/cos/health', label: 'Health', section: 'Chief of Staff', aliases: ['cos-health'] },
   { id: 'nav.cos.learning', path: '/cos/learning', label: 'Learning', section: 'Chief of Staff', aliases: ['cos-learning'] },
   { id: 'nav.cos.memory', path: '/cos/memory', label: 'Memory', section: 'Chief of Staff', aliases: ['cos-memory'] },
   { id: 'nav.cos.schedule', path: '/cos/schedule', label: 'Schedule', section: 'Chief of Staff', aliases: ['schedule', 'cos-schedule'] },
@@ -133,7 +134,6 @@ export const NAV_COMMANDS = [
 
   { id: 'nav.ambient', path: '/ambient', label: 'Ambient', section: 'System', aliases: ['ambient', 'ambient-mode', 'ambient mode'], keywords: ['idle', 'background', 'display', 'screensaver', 'fullscreen'] },
   { id: 'nav.data', path: '/data', label: 'Data', section: 'System', aliases: ['data'] },
-  { id: 'nav.cos.health', path: '/cos/health', label: 'Health', section: 'System', aliases: ['cos-health'] },
   { id: 'nav.instances', path: '/instances', label: 'Instances', section: 'System', aliases: ['instances'] },
   { id: 'nav.loops', path: '/loops', label: 'Loops', section: 'System', aliases: ['loops'] },
   { id: 'nav.devtools.processes', path: '/devtools/processes', label: 'Processes', section: 'System', aliases: ['devtools-processes', 'processes'] },

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -57,7 +57,7 @@ export const NAV_COMMANDS = [
   { id: 'nav.cos.config', path: '/cos/config', label: 'Config', section: 'Chief of Staff', aliases: ['cos-config'] },
   { id: 'nav.cos.digest', path: '/cos/digest', label: 'Digest', section: 'Chief of Staff', aliases: ['cos-digest'] },
   { id: 'nav.cos.gsd', path: '/cos/gsd', label: 'GSD', section: 'Chief of Staff', aliases: ['gsd', 'cos-gsd'] },
-  { id: 'nav.cos.health', path: '/cos/health', label: 'Health', section: 'Chief of Staff', aliases: ['cos-health'] },
+  { id: 'nav.cos.health', path: '/cos/health', label: 'Health', section: 'Chief of Staff', aliases: ['cos-health', 'health'] },
   { id: 'nav.cos.learning', path: '/cos/learning', label: 'Learning', section: 'Chief of Staff', aliases: ['cos-learning'] },
   { id: 'nav.cos.memory', path: '/cos/memory', label: 'Memory', section: 'Chief of Staff', aliases: ['cos-memory'] },
   { id: 'nav.cos.schedule', path: '/cos/schedule', label: 'Schedule', section: 'Chief of Staff', aliases: ['schedule', 'cos-schedule'] },
@@ -107,7 +107,7 @@ export const NAV_COMMANDS = [
   { id: 'nav.twin.time-capsule', path: '/digital-twin/time-capsule', label: 'Time Capsule', section: 'Digital Twin', aliases: ['time-capsule', 'twin-time-capsule', 'capsule'], keywords: ['legacy', 'archive', 'snapshot'] },
 
   { id: 'nav.meatspace.overview', path: '/meatspace/overview', label: 'Overview', section: 'MeatSpace', aliases: ['meatspace'] },
-  { id: 'nav.meatspace.health', path: '/meatspace/health', label: 'Health', section: 'MeatSpace', aliases: ['meatspace-health', 'health'] },
+  { id: 'nav.meatspace.health', path: '/meatspace/health', label: 'Health', section: 'MeatSpace', aliases: ['meatspace-health'] },
   { id: 'nav.meatspace.body', path: '/meatspace/body', label: 'Body', section: 'MeatSpace', aliases: ['meatspace-body', 'body'] },
   { id: 'nav.meatspace.alcohol', path: '/meatspace/alcohol', label: 'Alcohol', section: 'MeatSpace', aliases: ['meatspace-alcohol', 'alcohol'] },
   { id: 'nav.meatspace.nicotine', path: '/meatspace/nicotine', label: 'Nicotine', section: 'MeatSpace', aliases: ['meatspace-nicotine', 'nicotine'] },

--- a/server/lib/navManifest.test.js
+++ b/server/lib/navManifest.test.js
@@ -62,6 +62,17 @@ describe('resolveNavCommand — fuzzy matching', () => {
     expect(resolveNavCommand('meatspace-health')?.path).toBe('/meatspace/health');
   });
 
+  it('prefers the longest matching alias in endsWith/includes tiers', () => {
+    // Multi-word voice phrasings like "take me to meatspace health" normalize
+    // to "take-me-to-meatspace-health" and match BOTH `-health` and
+    // `-meatspace-health` in the endsWith tier. The resolver picks the longest
+    // candidate so the user reaches the more specific page.
+    expect(resolveNavCommand('take me to meatspace health')?.path).toBe('/meatspace/health');
+    expect(resolveNavCommand('meatspace health')?.path).toBe('/meatspace/health');
+    // The bare "health" input still resolves to CoS Health (exact alias tier).
+    expect(resolveNavCommand('take me to health')?.path).toBe('/cos/health');
+  });
+
   it('resolves "pipeline" to the new Create Pipeline page (not CoS Workflow)', () => {
     // The `pipeline` alias used to belong to /cos/workflow; the new dedicated
     // Pipeline page owns it now. CoS Workflow keeps `pipeline` as a keyword.

--- a/server/lib/navManifest.test.js
+++ b/server/lib/navManifest.test.js
@@ -54,6 +54,14 @@ describe('resolveNavCommand — fuzzy matching', () => {
     expect(hit?.command?.id).toBe('nav.create.universe-builder');
   });
 
+  it('resolves bare "health" to /cos/health (CoS owns the alias; meatspace keeps meatspace-health)', () => {
+    // The CoS Health page is the canonical destination for "take me to health"
+    // per the page's move into the Chief of Staff sidebar group. MeatSpace's
+    // health tab is still reachable via the explicit `meatspace-health` alias.
+    expect(resolveNavCommand('health')?.path).toBe('/cos/health');
+    expect(resolveNavCommand('meatspace-health')?.path).toBe('/meatspace/health');
+  });
+
   it('resolves "pipeline" to the new Create Pipeline page (not CoS Workflow)', () => {
     // The `pipeline` alias used to belong to /cos/workflow; the new dedicated
     // Pipeline page owns it now. CoS Workflow keeps `pipeline` as a keyword.


### PR DESCRIPTION
## Summary

- Moves the `/cos/health` page out of the **System** sidebar group and into **Chief of Staff**, where it belongs as a CoS sub-page.
- Updates `nav.cos.health` in `server/lib/navManifest.js` so ⌘K palette + voice nav reflect the new section.
- Updates the System section's `defaultTo` from `/cos/health` to `/data` since the health page no longer lives there.

## Test plan
- [ ] Sidebar: Health appears under Chief of Staff (between GSD and Learning) and not under System.
- [ ] ⌘K palette: "Health" / "cos-health" resolves and shows under the Chief of Staff section.
- [ ] Voice nav: "take me to health" still resolves to `/cos/health`.
- [ ] Clicking the System group header lands on `/data` instead of `/cos/health`.