### PR TITLE
fix(lightbox): add playsInline + fail-safe close for mobile fullscreen

### DIFF
--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -233,7 +233,7 @@ export default function MediaLightbox({
             <img src={item.previewUrl} alt={item.prompt} className={`${imgMax} object-contain`} />
           )}
           {/* Fail-safe close — the SettingsPane's X is hidden in fullscreen
-              and unreachable if iOS Safari mis-lays-out the page. */}
+              and unreachable if iOS Safari mis-lays out the page. */}
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onClose(); }}

--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -225,9 +225,9 @@ export default function MediaLightbox({
           onTouchEnd={onTouchEnd}
         >
           {isVideo ? (
-            // playsInline keeps iOS Safari from auto-promoting autoplay video
-            // to a native fullscreen player — exiting that leaves the modal
-            // laid out as a tiny strip with no reachable close button.
+            /* playsInline keeps iOS Safari from auto-promoting autoplay video
+               to a native fullscreen player — exiting that leaves the modal
+               laid out as a tiny strip with no reachable close button. */
             <video src={item.downloadUrl} controls autoPlay loop playsInline className={imgMax} />
           ) : (
             <img src={item.previewUrl} alt={item.prompt} className={`${imgMax} object-contain`} />

--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -237,7 +237,7 @@ export default function MediaLightbox({
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onClose(); }}
-            className="absolute top-2 left-2 z-30 p-2 rounded-full bg-white text-black hover:bg-white/85 shadow-lg"
+            className="absolute top-2 left-2 z-30 p-2 rounded-full bg-white text-black hover:bg-white/85 shadow-lg focus:outline-none focus:ring-2 focus:ring-port-accent"
             aria-label="Close"
             title="Close (Esc)"
           >
@@ -247,7 +247,7 @@ export default function MediaLightbox({
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); setFullScreen((v) => !v); }}
-            className="absolute top-2 right-2 z-30 p-2 rounded-full bg-white text-black hover:bg-white/85 shadow-lg"
+            className="absolute top-2 right-2 z-30 p-2 rounded-full bg-white text-black hover:bg-white/85 shadow-lg focus:outline-none focus:ring-2 focus:ring-port-accent"
             aria-label={fullScreen ? 'Exit full screen' : 'Full screen'}
             title={fullScreen ? 'Exit full screen (Esc, F)' : 'Full screen (F)'}
           >

--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -225,10 +225,24 @@ export default function MediaLightbox({
           onTouchEnd={onTouchEnd}
         >
           {isVideo ? (
-            <video src={item.downloadUrl} controls autoPlay loop className={imgMax} />
+            // playsInline keeps iOS Safari from auto-promoting autoplay video
+            // to a native fullscreen player — exiting that leaves the modal
+            // laid out as a tiny strip with no reachable close button.
+            <video src={item.downloadUrl} controls autoPlay loop playsInline className={imgMax} />
           ) : (
             <img src={item.previewUrl} alt={item.prompt} className={`${imgMax} object-contain`} />
           )}
+          {/* Fail-safe close — the SettingsPane's X is hidden in fullscreen
+              and unreachable if iOS Safari mis-lays-out the page. */}
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onClose(); }}
+            className="absolute top-2 left-2 z-30 p-2 rounded-full bg-white text-black hover:bg-white/85 shadow-lg"
+            aria-label="Close"
+            title="Close (Esc)"
+          >
+            <X className="w-4 h-4" />
+          </button>
           {/* Solid white pill keeps it readable against black letterbox bars. */}
           <button
             type="button"

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -1251,7 +1251,7 @@ export default function VideoGen() {
           </div>
           <div className="aspect-video max-w-[420px] mx-auto bg-port-bg border border-port-border rounded-lg overflow-hidden flex items-center justify-center relative">
             {result ? (
-              <video src={result.path || `/data/videos/${result.filename}`} controls autoPlay loop preload="metadata" className="w-full h-full" />
+              <video src={result.path || `/data/videos/${result.filename}`} controls autoPlay loop playsInline preload="metadata" className="w-full h-full" />
             ) : generating ? (
               <div className="text-gray-500 text-xs flex flex-col items-center gap-1.5">
                 <BrailleSpinner />


### PR DESCRIPTION
## Summary

Mobile users were getting trapped in the MediaLightbox after fullscreening a video or image: the media would render as a tiny strip on the right edge of a black screen with no reachable close button, forcing them to kill the browser tab.

## Root cause

Two compounding issues, both visible in the user's screenshot:

1. **Missing `playsInline` on `<video>`** — on iOS Safari, an autoplay video without `playsInline` is automatically promoted to the OS-native fullscreen player. Exiting that native player can leave the page laid out in a broken state.
2. **No fail-safe close button** — the X close lives only inside `SettingsPane`, which is hidden when `fullScreen=true` and is also unreachable when iOS Safari has the layout broken.

## Changes

- `client/src/components/media/MediaLightbox.jsx`: add `playsInline` to the lightbox `<video>` and add an always-visible X close button on the media area itself (top-left, mirrors the maximize toggle on the top-right).
- `client/src/pages/VideoGen.jsx`: add `playsInline` to the inline preview video (same iOS autoplay class of bug).

## Test plan

- [ ] Open an image in the lightbox on iOS Safari → tap fullscreen → tap minimize → image renders normally and close button is reachable.
- [ ] Open a video in the lightbox on iOS Safari → video plays inline (no native fullscreen takeover) → fullscreen/minimize cycle leaves layout intact.
- [ ] Open a video in the lightbox on desktop → fullscreen toggle still works, Esc closes, F toggles fullscreen.
- [ ] Generate a video on the VideoGen page → preview plays inline, no auto fullscreen.