### PR TITLE
feat(lightbox): add Remix action for videos

### DIFF
--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -517,7 +517,7 @@ function SettingsPane({
             <Sparkles className="w-3.5 h-3.5" /> Refine Prompt
           </button>
         )}
-        {!isVideo && onRemix && (
+        {onRemix && (
           <button
             type="button"
             onClick={() => { onRemix(item); onClose(); }}

--- a/client/src/components/media/MediaPreview.jsx
+++ b/client/src/components/media/MediaPreview.jsx
@@ -7,9 +7,9 @@ import { computeImageVariantGroup } from './variants';
 // page repeated by hand: open/close, prev/next nav, and the annotation
 // lookup/patch dance. Page-specific handlers pass through as-is.
 //
-// MediaLightbox already gates Remix / SendToVideo / Clean on `isVideo` and
-// Continue on `!isVideo`, so callers should pass handlers unconditionally
-// rather than pre-filtering by `preview.kind`.
+// MediaLightbox already gates SendToVideo / Clean on `!isVideo` and
+// Continue on `isVideo`. Remix works for both kinds — callers should
+// dispatch by `item.kind` inside their handler (see useImagePreviewActions).
 //
 // Nav props win over handlers (spread order) so a stray `onPrevious`/`onNext`
 // in a caller can't accidentally shadow the wrapper's navigation contract.

--- a/client/src/components/media/MediaPreview.jsx
+++ b/client/src/components/media/MediaPreview.jsx
@@ -9,7 +9,7 @@ import { computeImageVariantGroup } from './variants';
 //
 // MediaLightbox already gates SendToVideo / Clean on `!isVideo` and
 // Continue on `isVideo`. Remix works for both kinds — callers should
-// dispatch by `item.kind` inside their handler (see useImagePreviewActions).
+// dispatch by `item.kind` inside their handler (see useMediaPreviewActions).
 //
 // Nav props win over handlers (spread order) so a stray `onPrevious`/`onNext`
 // in a caller can't accidentally shadow the wrapper's navigation contract.

--- a/client/src/hooks/README.md
+++ b/client/src/hooks/README.md
@@ -43,7 +43,7 @@ grep -i "what you want to do" client/src/hooks/README.md
 | `useMediaAnnotations` | Per-entry `own`/`others` annotations with back-compat aliases. | Showing media annotations + ownership. |
 | `useMediaCompletionRefresh` | Refetch on image/video completion socket events. | A list view that needs to refresh when new media lands. |
 | `useOpenClawAttachments` | File attachment handling (base64, size-capped). | OpenClaw attachment UI. |
-| `useImagePreviewActions` | Shared MediaPreview / MediaLightbox action handlers. | New surface that exposes the same 4 preview actions. |
+| `useMediaPreviewActions` | Shared MediaPreview / MediaLightbox action handlers (images + videos — dispatch by `item.kind`). | New surface that exposes the same 4 preview actions. |
 | `usePreviewRoute` | URL-driven `[preview, setPreview]` via `?preview=<filename>`. | Any page hosting `<MediaPreview>` — gives the preview a deep-link. |
 | `useImageGenQueue` | Work-scoped live queue of in-flight image renders. | Pages that show per-work image-gen queue state. |
 

--- a/client/src/hooks/index.js
+++ b/client/src/hooks/index.js
@@ -13,7 +13,7 @@ export { default as useClickOutside } from './useClickOutside.js';
 export { default as useContainerWidth } from './useContainerWidth.js';
 export { default as useFieldDraft } from './useFieldDraft.js';
 export { default as useImageGenQueue } from './useImageGenQueue.js';
-export { default as useImagePreviewActions } from './useImagePreviewActions.js';
+export { default as useMediaPreviewActions } from './useMediaPreviewActions.js';
 export { default as useKeyboardControls } from './useKeyboardControls.js';
 export { default as useMediaJobProgress } from './useMediaJobProgress.js';
 export { default as useMoltworldWs } from './useMoltworldWs.js';

--- a/client/src/hooks/useImagePreviewActions.js
+++ b/client/src/hooks/useImagePreviewActions.js
@@ -3,6 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import toast from '../components/ui/Toast';
 import { cleanGalleryImage, extractLastFrame } from '../services/apiImageVideo';
 
+// Video tiling enum — mirrors TILING_OPTIONS in pages/VideoGen.jsx and the
+// z.enum on the server in server/routes/videoGen.js. Hoisted to module scope
+// so it's not re-allocated on every Remix call. If a new tiling mode is added
+// to TILING_OPTIONS, also add it here (and to the server enum).
+const VIDEO_TILING_ENUM = new Set(['auto', 'none', 'spatial', 'temporal']);
+
 /**
  * Shared MediaPreview / MediaLightbox action handlers. The same four
  * callbacks (`onRemix`, `onSendToVideo`, `onContinue`, `onClean`) used to
@@ -53,12 +59,10 @@ export default function useImagePreviewActions({ onCleanComplete = null } = {}) 
       if (raw.steps != null && raw.steps !== '') params.set('steps', String(raw.steps));
       const guidance = raw.guidanceScale ?? raw.guidance_scale ?? raw.guidance;
       if (guidance != null && guidance !== '') params.set('guidanceScale', String(guidance));
-      // tiling must match the server's enum (auto|none|spatial|temporal).
-      // Legacy sidecars sometimes store a boolean here — pass through only
-      // known-good string values so the remixed POST doesn't 400 on
-      // /api/video-gen validation.
-      const TILING_ENUM = new Set(['auto', 'none', 'spatial', 'temporal']);
-      if (typeof raw.tiling === 'string' && TILING_ENUM.has(raw.tiling)) {
+      // tiling must match the server's enum. Legacy sidecars sometimes store
+      // a boolean here — pass through only known-good string values so the
+      // remixed POST doesn't 400 on /api/video-gen validation.
+      if (typeof raw.tiling === 'string' && VIDEO_TILING_ENUM.has(raw.tiling)) {
         params.set('tiling', raw.tiling);
       }
       const disableAudio = raw.disableAudio ?? raw.disable_audio;

--- a/client/src/hooks/useImagePreviewActions.js
+++ b/client/src/hooks/useImagePreviewActions.js
@@ -53,7 +53,14 @@ export default function useImagePreviewActions({ onCleanComplete = null } = {}) 
       if (raw.steps != null && raw.steps !== '') params.set('steps', String(raw.steps));
       const guidance = raw.guidanceScale ?? raw.guidance_scale ?? raw.guidance;
       if (guidance != null && guidance !== '') params.set('guidanceScale', String(guidance));
-      if (raw.tiling) params.set('tiling', String(raw.tiling));
+      // tiling must match the server's enum (auto|none|spatial|temporal).
+      // Legacy sidecars sometimes store a boolean here — pass through only
+      // known-good string values so the remixed POST doesn't 400 on
+      // /api/video-gen validation.
+      const TILING_ENUM = new Set(['auto', 'none', 'spatial', 'temporal']);
+      if (typeof raw.tiling === 'string' && TILING_ENUM.has(raw.tiling)) {
+        params.set('tiling', raw.tiling);
+      }
       const disableAudio = raw.disableAudio ?? raw.disable_audio;
       if (disableAudio === true) params.set('disableAudio', '1');
       navigate(`/media/video?${params}`);

--- a/client/src/hooks/useImagePreviewActions.js
+++ b/client/src/hooks/useImagePreviewActions.js
@@ -27,12 +27,38 @@ import { cleanGalleryImage, extractLastFrame } from '../services/apiImageVideo';
 export default function useImagePreviewActions({ onCleanComplete = null } = {}) {
   const navigate = useNavigate();
 
-  // Remix: hand the prompt + render settings to the Image Gen page so the
-  // user can iterate. `(no prompt)` is the metadata-sidecar placeholder for
-  // images that lost their prompt — skip it so the next render doesn't
+  // Remix: hand the prompt + render settings to the source-kind's gen page
+  // so the user can iterate. `(no prompt)` is the metadata-sidecar placeholder
+  // for items that lost their prompt — skip it so the next render doesn't
   // start with that literal as the user's prompt.
+  //
+  // Dispatches by item.kind: images go to /media/image (with image-shaped
+  // params), videos go to /media/video (with video-shaped params — frames,
+  // fps, tiling, etc.). Video remix lands the user in 'text' mode with all
+  // params filled; they can switch to image/extend mode and pick a source.
   const handleRemix = useCallback((item) => {
     if (!item) return;
+    if (item.kind === 'video') {
+      const params = new URLSearchParams();
+      if (item.prompt && item.prompt !== '(no prompt)') params.set('prompt', item.prompt);
+      if (item.negativePrompt) params.set('negativePrompt', item.negativePrompt);
+      if (item.modelId) params.set('modelId', item.modelId);
+      if (item.width) params.set('w', String(item.width));
+      if (item.height) params.set('h', String(item.height));
+      if (item.numFrames) params.set('numFrames', String(item.numFrames));
+      if (item.fps) params.set('fps', String(item.fps));
+      const raw = item.raw || {};
+      const seed = raw.seed;
+      if (seed != null && seed !== '') params.set('seed', String(seed));
+      if (raw.steps != null && raw.steps !== '') params.set('steps', String(raw.steps));
+      const guidance = raw.guidanceScale ?? raw.guidance_scale ?? raw.guidance;
+      if (guidance != null && guidance !== '') params.set('guidanceScale', String(guidance));
+      if (raw.tiling) params.set('tiling', String(raw.tiling));
+      const disableAudio = raw.disableAudio ?? raw.disable_audio;
+      if (disableAudio === true) params.set('disableAudio', '1');
+      navigate(`/media/video?${params}`);
+      return;
+    }
     const params = new URLSearchParams();
     if (item.prompt && item.prompt !== '(no prompt)') params.set('prompt', item.prompt);
     if (item.negativePrompt) params.set('negativePrompt', item.negativePrompt);

--- a/client/src/hooks/useMediaPreviewActions.js
+++ b/client/src/hooks/useMediaPreviewActions.js
@@ -2,12 +2,7 @@ import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toast from '../components/ui/Toast';
 import { cleanGalleryImage, extractLastFrame } from '../services/apiImageVideo';
-
-// Video tiling enum — mirrors TILING_OPTIONS in pages/VideoGen.jsx and the
-// z.enum on the server in server/routes/videoGen.js. Hoisted to module scope
-// so it's not re-allocated on every Remix call. If a new tiling mode is added
-// to TILING_OPTIONS, also add it here (and to the server enum).
-const VIDEO_TILING_ENUM = new Set(['auto', 'none', 'spatial', 'temporal']);
+import { VIDEO_TILING_ENUM_SET } from '../lib/videoTilingOptions';
 
 /**
  * Shared MediaPreview / MediaLightbox action handlers. The same four
@@ -30,7 +25,7 @@ const VIDEO_TILING_ENUM = new Set(['auto', 'none', 'spatial', 'temporal']);
  *
  * Returns the four handlers shaped for direct use as MediaPreview props.
  */
-export default function useImagePreviewActions({ onCleanComplete = null } = {}) {
+export default function useMediaPreviewActions({ onCleanComplete = null } = {}) {
   const navigate = useNavigate();
 
   // Remix: hand the prompt + render settings to the source-kind's gen page
@@ -62,7 +57,7 @@ export default function useImagePreviewActions({ onCleanComplete = null } = {}) 
       // tiling must match the server's enum. Legacy sidecars sometimes store
       // a boolean here — pass through only known-good string values so the
       // remixed POST doesn't 400 on /api/video-gen validation.
-      if (typeof raw.tiling === 'string' && VIDEO_TILING_ENUM.has(raw.tiling)) {
+      if (typeof raw.tiling === 'string' && VIDEO_TILING_ENUM_SET.has(raw.tiling)) {
         params.set('tiling', raw.tiling);
       }
       const disableAudio = raw.disableAudio ?? raw.disable_audio;

--- a/client/src/lib/README.md
+++ b/client/src/lib/README.md
@@ -44,6 +44,7 @@ grep -i "what you want to do" client/src/lib/README.md
 | `imageGenBackends.js` | `IMAGE_GEN_MODE` enum (local / codex / external) + metadata. |
 | `imageGenResolutions.js` | Shared resolution presets for image generation. |
 | `videoGenResolutions.js` | Shared resolution presets for video generation (companion to image side; LTX-2 latent-friendly sizes). |
+| `videoTilingOptions.js` | `VIDEO_TILING_OPTIONS` (the `<select>` rows) + `VIDEO_TILING_ENUM_SET` (the value-only Set). Single source consumed by `VideoGen.jsx` and the Remix URL builder in `useMediaPreviewActions`. Mirrors the server's `z.enum` in `server/routes/videoGen.js`. |
 
 ## Graph & sim
 

--- a/client/src/lib/index.js
+++ b/client/src/lib/index.js
@@ -20,6 +20,7 @@ export * from './issueLength.js';
 export * from './pipelineImageDefaults.js';
 export * from './runnerFamilies.js';
 export * from './videoGenResolutions.js';
+export * from './videoTilingOptions.js';
 export * from './wrImageDefaults.js';
 
 // === Graph & sim ===

--- a/client/src/lib/videoTilingOptions.js
+++ b/client/src/lib/videoTilingOptions.js
@@ -1,0 +1,13 @@
+// Single source of truth for video tiling modes. Consumed by:
+//   - pages/VideoGen.jsx — the <select> options + remix-prefill guard.
+//   - hooks/useMediaPreviewActions.js — the Remix URL builder.
+// The server's z.enum in server/routes/videoGen.js must match these values;
+// add a new mode here and to the server enum together.
+export const VIDEO_TILING_OPTIONS = [
+  { value: 'auto', label: 'Auto (recommended)' },
+  { value: 'none', label: 'None (fastest, more VRAM)' },
+  { value: 'spatial', label: 'Spatial only' },
+  { value: 'temporal', label: 'Temporal only' },
+];
+
+export const VIDEO_TILING_ENUM_SET = new Set(VIDEO_TILING_OPTIONS.map((o) => o.value));

--- a/client/src/pages/MediaCollectionDetail.jsx
+++ b/client/src/pages/MediaCollectionDetail.jsx
@@ -16,7 +16,7 @@ import {
   listImageGallery, listVideoHistory,
   deleteImage, deleteVideoHistoryItem,
 } from '../services/api';
-import useImagePreviewActions from '../hooks/useImagePreviewActions';
+import useMediaPreviewActions from '../hooks/useMediaPreviewActions';
 import usePreviewRoute from '../hooks/usePreviewRoute';
 
 // Hydrate a collection's "<kind>:<ref>" pointer list into the same
@@ -243,11 +243,11 @@ export default function MediaCollectionDetail() {
 
   // Remix / SendToVideo / Continue / Clean share a single implementation
   // with MediaHistory, ImageGen, and the Universe Builder lightbox via
-  // `useImagePreviewActions`. The collection-specific post-clean step (add
+  // `useMediaPreviewActions`. The collection-specific post-clean step (add
   // the cleaned image to THIS collection + seed imagesByName so hydrate()
   // renders it immediately, no refresh round-trip) is wired through
   // `onCleanComplete`.
-  const { handleRemix, handleSendToVideo, handleContinue, handleClean } = useImagePreviewActions({
+  const { handleRemix, handleSendToVideo, handleContinue, handleClean } = useMediaPreviewActions({
     onCleanComplete: async (cleaned) => {
       // The server's clean route auto-files the cleaned filename into every
       // collection that contained the source — including this one — so this

--- a/client/src/pages/MediaHistory.jsx
+++ b/client/src/pages/MediaHistory.jsx
@@ -14,7 +14,7 @@ import FavoritesFilterChip from '../components/media/FavoritesFilterChip';
 import { normalizeImage, normalizeVideo } from '../components/media/normalize';
 import { useMediaCompletionRefresh } from '../hooks/useMediaCompletionRefresh';
 import { useMediaAnnotations } from '../hooks/useMediaAnnotations';
-import useImagePreviewActions from '../hooks/useImagePreviewActions';
+import useMediaPreviewActions from '../hooks/useMediaPreviewActions';
 import usePreviewRoute from '../hooks/usePreviewRoute';
 import {
   listVideoHistory, deleteVideoHistoryItem, stitchVideos,
@@ -150,11 +150,11 @@ export default function MediaHistory() {
 
   // Remix / SendToVideo / Continue / Clean all share a single implementation
   // with MediaCollectionDetail, ImageGen, and the Universe Builder lightbox
-  // via `useImagePreviewActions`. Only the post-clean side effect (splicing
+  // via `useMediaPreviewActions`. Only the post-clean side effect (splicing
   // the cleaned image to the top of the local list) is page-specific —
   // wired through `onCleanComplete` so the cleaned record lands in `items`
   // without a full gallery refetch.
-  const { handleRemix, handleSendToVideo, handleContinue, handleClean } = useImagePreviewActions({
+  const { handleRemix, handleSendToVideo, handleContinue, handleClean } = useMediaPreviewActions({
     onCleanComplete: (cleaned) => {
       const normalized = normalizeImage(cleaned);
       setItems((prev) => [normalized, ...prev.filter((x) => x.key !== normalized.key)]);

--- a/client/src/pages/UniverseBuilder.jsx
+++ b/client/src/pages/UniverseBuilder.jsx
@@ -40,7 +40,7 @@ import EntryCard from '../components/universe/EntryCard';
 import EntryThumbSlot from '../components/universe/EntryThumbSlot';
 import useMediaJobProgress from '../hooks/useMediaJobProgress';
 import MediaPreview from '../components/media/MediaPreview';
-import useImagePreviewActions from '../hooks/useImagePreviewActions';
+import useMediaPreviewActions from '../hooks/useMediaPreviewActions';
 import usePreviewRoute from '../hooks/usePreviewRoute';
 import { useMediaAnnotations } from '../hooks/useMediaAnnotations';
 import { listImageGallery } from '../services/apiImageVideo';
@@ -753,7 +753,7 @@ export default function UniverseBuilder() {
   // as the History grid + Image Gen page. `onCleanComplete` splices the
   // cleaned image into the local gallery map so the next preview open
   // shows it immediately — no full refetch needed.
-  const previewActions = useImagePreviewActions({
+  const previewActions = useMediaPreviewActions({
     onCleanComplete: useCallback((cleaned) => {
       if (!cleaned?.filename) return;
       setGalleryByFilename((prev) => {

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -178,9 +178,18 @@ export default function VideoGen() {
   // form state once on mount, then strip the params so a hot-reload or back-
   // nav doesn't re-clobber edits the user has made since. Mirrors the
   // ImageGen remix-prefill effect.
+  //
+  // Gating: presence of any remix-only key (modelId / numFrames / fps / seed
+  // / steps / guidanceScale / tiling / disableAudio) marks the URL as a Remix
+  // bundle — the Continue and SendToVideo paths set sourceImageFile +/-
+  // prompt/w/h but never the remix-only keys, so they keep their URL state.
+  // When it IS a remix, we ALSO strip prompt/negativePrompt/w/h from the URL
+  // so back-nav / refresh doesn't re-sync those via the standalone
+  // incomingPrompt / incomingWidth effects (initial useState already captured
+  // their values on first mount, which is the one-shot we want).
   useEffect(() => {
-    const remixKeys = ['modelId', 'numFrames', 'fps', 'seed', 'steps', 'guidanceScale', 'tiling', 'disableAudio'];
-    const present = remixKeys.filter((k) => searchParams.get(k) != null);
+    const remixGateKeys = ['modelId', 'numFrames', 'fps', 'seed', 'steps', 'guidanceScale', 'tiling', 'disableAudio'];
+    const present = remixGateKeys.filter((k) => searchParams.get(k) != null);
     if (present.length === 0) return;
     const get = (k) => searchParams.get(k);
     if (get('modelId')) setModelId(get('modelId'));
@@ -190,12 +199,18 @@ export default function VideoGen() {
     if (Number.isFinite(f) && f > 0) setFps(f);
     if (get('seed') != null) setSeed(get('seed'));
     if (get('steps')) setSteps(get('steps'));
-    if (get('guidanceScale')) setGuidanceScale(get('guidanceScale'));
+    // guidanceScale=0 is a meaningful value (CFG off); test for presence,
+    // not truthiness, so "0" round-trips through Remix correctly.
+    if (get('guidanceScale') != null && get('guidanceScale') !== '') setGuidanceScale(get('guidanceScale'));
     if (get('tiling')) setTiling(get('tiling'));
-    if (get('disableAudio') === '1') setDisableAudio(true);
+    // disableAudio is a boolean; explicitly set to false when the URL says so
+    // (or omits the key, which means "default off"). Without this, the toggle
+    // sticks ON across remixes of clips that had audio.
+    setDisableAudio(get('disableAudio') === '1');
+    const stripKeys = [...remixGateKeys, 'prompt', 'negativePrompt', 'w', 'h'];
     setSearchParams((prev) => {
       const n = new URLSearchParams(prev);
-      remixKeys.forEach((k) => n.delete(k));
+      stripKeys.forEach((k) => n.delete(k));
       return n;
     }, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -323,8 +338,11 @@ export default function VideoGen() {
     const guidance = item.guidanceScale ?? item.guidance_scale ?? item.guidance;
     if (guidance != null && guidance !== '') setGuidanceScale(String(guidance));
     if (item.tiling) setTiling(item.tiling);
+    // disableAudio: always set explicitly (true/false) so the toggle reliably
+    // matches the remixed render. Skipping the false branch would leave the
+    // toggle stuck ON when the user remixes a clip that had audio enabled.
     const disableAudio = item.disableAudio ?? item.disable_audio;
-    if (disableAudio === true) setDisableAudio(true);
+    setDisableAudio(disableAudio === true);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -357,9 +357,14 @@ export default function VideoGen() {
     if (item.numFrames) setNumFrames(item.numFrames);
     if (item.fps) setFps(item.fps);
     if (item.seed != null) setSeed(String(item.seed));
-    if (item.steps != null && item.steps !== '') setSteps(String(item.steps));
+    // steps/guidanceScale: always set explicitly. Legacy entries (created
+    // before these were persisted) lack these fields — clear the form to the
+    // empty-string sentinel rather than leaving the prior render's value
+    // behind. The form treats '' as "use model default" so this is the
+    // faithful round-trip for missing fields.
+    setSteps(item.steps != null && item.steps !== '' ? String(item.steps) : '');
     const guidance = item.guidanceScale ?? item.guidance_scale ?? item.guidance;
-    if (guidance != null && guidance !== '') setGuidanceScale(String(guidance));
+    setGuidanceScale(guidance != null && guidance !== '' ? String(guidance) : '');
     // tiling must match the TILING_OPTIONS enum. Legacy sidecars sometimes
     // store a boolean here — silently ignore unknown values so the <select>
     // stays valid and the next POST doesn't 400.

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -70,6 +70,10 @@ const TILING_OPTIONS = [
   { value: 'spatial', label: 'Spatial only' },
   { value: 'temporal', label: 'Temporal only' },
 ];
+// Derive the valid-enum set from TILING_OPTIONS so adding a new option in one
+// place automatically flows through the remix-prefill / handleRemixVideo
+// guards. Keeps client and server (videoGen.js z.enum) in sync via the UI.
+const TILING_ENUM_SET = new Set(TILING_OPTIONS.map((o) => o.value));
 
 const MODES = [
   { id: 'text',   label: 'Text',   icon: Type,       desc: 'Text-to-video' },
@@ -204,12 +208,11 @@ export default function VideoGen() {
     // guidanceScale=0 is a meaningful value (CFG off); test for presence,
     // not truthiness, so "0" round-trips through Remix correctly.
     if (get('guidanceScale') != null && get('guidanceScale') !== '') setGuidanceScale(get('guidanceScale'));
-    // tiling: URL params are user-controlled; only accept known enum strings
-    // (auto|none|spatial|temporal) so a hand-edited URL or stale link can't
-    // push the <select> into an invalid state and 400 the next POST.
-    const TILING_ENUM = new Set(['auto', 'none', 'spatial', 'temporal']);
+    // tiling: URL params are user-controlled; only accept values defined in
+    // TILING_OPTIONS so a hand-edited URL or stale link can't push the <select>
+    // into an invalid state and 400 the next POST.
     const urlTiling = get('tiling');
-    if (urlTiling && TILING_ENUM.has(urlTiling)) setTiling(urlTiling);
+    if (urlTiling && TILING_ENUM_SET.has(urlTiling)) setTiling(urlTiling);
     // disableAudio is a boolean; explicitly set to false when the URL says so
     // (or omits the key, which means "default off"). Without this, the toggle
     // sticks ON across remixes of clips that had audio.
@@ -344,7 +347,11 @@ export default function VideoGen() {
     // original settings" expectation.
     const neg = item.negativePrompt || item.negative_prompt || '';
     setNegativePrompt(neg);
-    if (item.modelId && models.some((m) => m.id === item.modelId)) setModelId(item.modelId);
+    // Set modelId unconditionally when present. If models hasn't loaded yet
+    // (race on initial mount), this avoids dropping the value silently — the
+    // post-load validation effect (`Validate modelId once models are loaded`)
+    // will fall back to defaultModel if the id doesn't end up in the catalog.
+    if (item.modelId) setModelId(item.modelId);
     if (item.width) setWidth(item.width);
     if (item.height) setHeight(item.height);
     if (item.numFrames) setNumFrames(item.numFrames);
@@ -353,12 +360,10 @@ export default function VideoGen() {
     if (item.steps != null && item.steps !== '') setSteps(String(item.steps));
     const guidance = item.guidanceScale ?? item.guidance_scale ?? item.guidance;
     if (guidance != null && guidance !== '') setGuidanceScale(String(guidance));
-    // tiling must match the server enum (auto|none|spatial|temporal). Legacy
-    // sidecars sometimes store a boolean here — silently ignore unknown values
-    // so the <select> stays valid and the next POST doesn't 400. Mirrors the
-    // guard in useImagePreviewActions.handleRemix.
-    const TILING_ENUM = new Set(['auto', 'none', 'spatial', 'temporal']);
-    if (typeof item.tiling === 'string' && TILING_ENUM.has(item.tiling)) setTiling(item.tiling);
+    // tiling must match the TILING_OPTIONS enum. Legacy sidecars sometimes
+    // store a boolean here — silently ignore unknown values so the <select>
+    // stays valid and the next POST doesn't 400.
+    if (typeof item.tiling === 'string' && TILING_ENUM_SET.has(item.tiling)) setTiling(item.tiling);
     // disableAudio: always set explicitly (true/false) so the toggle reliably
     // matches the remixed render. Skipping the false branch would leave the
     // toggle stuck ON when the user remixes a clip that had audio enabled.

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -183,10 +183,12 @@ export default function VideoGen() {
   // / steps / guidanceScale / tiling / disableAudio) marks the URL as a Remix
   // bundle — the Continue and SendToVideo paths set sourceImageFile +/-
   // prompt/w/h but never the remix-only keys, so they keep their URL state.
-  // When it IS a remix, we ALSO strip prompt/negativePrompt/w/h from the URL
-  // so back-nav / refresh doesn't re-sync those via the standalone
-  // incomingPrompt / incomingWidth effects (initial useState already captured
-  // their values on first mount, which is the one-shot we want).
+  // When it IS a remix, we ALSO strip prompt/negativePrompt/w/h from the URL.
+  // Note: prompt/negativePrompt are captured by initial useState (lines above);
+  // w/h are NOT in initial state (defaults are 768×512) and are instead applied
+  // by the separate incomingWidth/incomingHeight effect on first render —
+  // which runs BEFORE this strip-pass since effects fire in declaration order.
+  // The result is the same one-shot consumption, just via two effects.
   useEffect(() => {
     const remixGateKeys = ['modelId', 'numFrames', 'fps', 'seed', 'steps', 'guidanceScale', 'tiling', 'disableAudio'];
     const present = remixGateKeys.filter((k) => searchParams.get(k) != null);
@@ -357,6 +359,19 @@ export default function VideoGen() {
     // toggle stuck ON when the user remixes a clip that had audio enabled.
     const disableAudio = item.disableAudio ?? item.disable_audio;
     setDisableAudio(disableAudio === true);
+    // Reset to text-to-video mode and clear any stale conditioning inputs from
+    // image / fflf / extend / a2v modes. Without this, clicking Remix while
+    // currently in (e.g.) image mode would carry the old source image into the
+    // next submit even though Remix is meant to faithfully reproduce the prior
+    // (text-to-video) render. Cross-page Remix already lands the user in text
+    // mode because /media/video without `sourceImageFile` defaults that way.
+    setMode('text');
+    setSourceImageFile(null);
+    setSourceImageUpload(null);
+    setLastImageFile(null);
+    setLastImageUpload(null);
+    setExtendFromVideoId('');
+    setAudioFile(null);
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
@@ -399,6 +414,19 @@ export default function VideoGen() {
     refreshStatus();
     return () => eventSourceRef.current?.close();
   }, [refreshStatus]);
+
+  // Validate `modelId` once models are loaded. A Remix URL (or hand-edited
+  // link) can carry a `modelId` that no longer exists in the catalog — that
+  // leaves <ModelSelect> showing nothing and `currentModel` undefined, which
+  // then breaks resolution suggestions and submit. When we detect that, fall
+  // back to status.defaultModel (preferred) or the first available model so
+  // the form stays in a usable state.
+  useEffect(() => {
+    if (!modelId || models.length === 0) return;
+    if (models.some((m) => m.id === modelId)) return;
+    const fallback = status?.defaultModel || models[0]?.id || '';
+    if (fallback) setModelId(fallback);
+  }, [modelId, models, status?.defaultModel]);
 
   const currentModel = models.find((m) => m.id === modelId);
   const { matched: matchedResolution, label: resolutionLabel } = resolveResolutionLabel(VIDEO_RESOLUTIONS, width, height);

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -174,6 +174,33 @@ export default function VideoGen() {
     if (Number.isFinite(h) && h > 0) setHeight(h);
   }, [incomingWidth, incomingHeight]);
 
+  // Remix payload from MediaPreview (?modelId=…&numFrames=…&seed=…). Populate
+  // form state once on mount, then strip the params so a hot-reload or back-
+  // nav doesn't re-clobber edits the user has made since. Mirrors the
+  // ImageGen remix-prefill effect.
+  useEffect(() => {
+    const remixKeys = ['modelId', 'numFrames', 'fps', 'seed', 'steps', 'guidanceScale', 'tiling', 'disableAudio'];
+    const present = remixKeys.filter((k) => searchParams.get(k) != null);
+    if (present.length === 0) return;
+    const get = (k) => searchParams.get(k);
+    if (get('modelId')) setModelId(get('modelId'));
+    const nf = Number(get('numFrames'));
+    if (Number.isFinite(nf) && nf > 0) setNumFrames(nf);
+    const f = Number(get('fps'));
+    if (Number.isFinite(f) && f > 0) setFps(f);
+    if (get('seed') != null) setSeed(get('seed'));
+    if (get('steps')) setSteps(get('steps'));
+    if (get('guidanceScale')) setGuidanceScale(get('guidanceScale'));
+    if (get('tiling')) setTiling(get('tiling'));
+    if (get('disableAudio') === '1') setDisableAudio(true);
+    setSearchParams((prev) => {
+      const n = new URLSearchParams(prev);
+      remixKeys.forEach((k) => n.delete(k));
+      return n;
+    }, { replace: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const [history, setHistory] = useState([]);
   // `preview` is URL-driven via `usePreviewRoute(previewItems)` — declared
   // after `previewItems` below so the resolver can match against it.
@@ -273,6 +300,32 @@ export default function VideoGen() {
     if (item?.width) params.set('w', String(item.width));
     if (item?.height) params.set('h', String(item.height));
     navigate(`/media/video?${params.toString()}`);
+  };
+
+  // Remix a prior render: hand all its params back into the form so the user
+  // can iterate (tweak the prompt, swap seeds, etc.) without re-typing.
+  // Mirrors ImageGen.handleRemix — in-page state set so the form jumps to
+  // the new values without a navigation. The `item` is the raw video sidecar
+  // (not the normalized MediaPreview shape).
+  const handleRemixVideo = (item) => {
+    if (!item) return;
+    setStylePreset(null);
+    if (item.prompt) setPrompt(item.prompt);
+    const neg = item.negativePrompt || item.negative_prompt;
+    if (neg) setNegativePrompt(neg);
+    if (item.modelId && models.some((m) => m.id === item.modelId)) setModelId(item.modelId);
+    if (item.width) setWidth(item.width);
+    if (item.height) setHeight(item.height);
+    if (item.numFrames) setNumFrames(item.numFrames);
+    if (item.fps) setFps(item.fps);
+    if (item.seed != null) setSeed(String(item.seed));
+    if (item.steps != null && item.steps !== '') setSteps(String(item.steps));
+    const guidance = item.guidanceScale ?? item.guidance_scale ?? item.guidance;
+    if (guidance != null && guidance !== '') setGuidanceScale(String(guidance));
+    if (item.tiling) setTiling(item.tiling);
+    const disableAudio = item.disableAudio ?? item.disable_audio;
+    if (disableAudio === true) setDisableAudio(true);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const [generating, setGenerating] = useState(false);
@@ -1362,6 +1415,7 @@ export default function VideoGen() {
         annotations={annotations}
         updateAnnotation={updateAnnotation}
         onContinue={(item) => handleContinueHistory(item.raw)}
+        onRemix={(item) => item?.raw && handleRemixVideo(item.raw)}
       />
 
       <Drawer open={settingsOpen} onClose={closeSettings} title="Media Generation Settings">

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -54,6 +54,7 @@ import {
 } from '../services/api';
 import { randomSeed, safeParseJSON } from '../lib/genUtils';
 import { VIDEO_RESOLUTIONS } from '../lib/videoGenResolutions';
+import { VIDEO_TILING_OPTIONS, VIDEO_TILING_ENUM_SET } from '../lib/videoTilingOptions';
 import { resolveResolutionLabel } from '../lib/imageGenResolutions';
 
 // Values follow LTX-2's 8k+1 latent boundary so the model doesn't silently
@@ -64,16 +65,6 @@ import { resolveResolutionLabel } from '../lib/imageGenResolutions';
 // see the hint under the Frames dropdown.
 const FRAME_OPTIONS = [25, 49, 73, 97, 121, 145, 169, 193, 217, 241, 265, 313, 361, 481];
 const FPS_OPTIONS = [16, 24, 30];
-const TILING_OPTIONS = [
-  { value: 'auto', label: 'Auto (recommended)' },
-  { value: 'none', label: 'None (fastest, more VRAM)' },
-  { value: 'spatial', label: 'Spatial only' },
-  { value: 'temporal', label: 'Temporal only' },
-];
-// Derive the valid-enum set from TILING_OPTIONS so adding a new option in one
-// place automatically flows through the remix-prefill / handleRemixVideo
-// guards. Keeps client and server (videoGen.js z.enum) in sync via the UI.
-const TILING_ENUM_SET = new Set(TILING_OPTIONS.map((o) => o.value));
 
 const MODES = [
   { id: 'text',   label: 'Text',   icon: Type,       desc: 'Text-to-video' },
@@ -209,14 +200,15 @@ export default function VideoGen() {
     // not truthiness, so "0" round-trips through Remix correctly.
     if (get('guidanceScale') != null && get('guidanceScale') !== '') setGuidanceScale(get('guidanceScale'));
     // tiling: URL params are user-controlled; only accept values defined in
-    // TILING_OPTIONS so a hand-edited URL or stale link can't push the <select>
-    // into an invalid state and 400 the next POST.
+    // VIDEO_TILING_OPTIONS so a hand-edited URL or stale link can't push the
+    // <select> into an invalid state and 400 the next POST.
     const urlTiling = get('tiling');
-    if (urlTiling && TILING_ENUM_SET.has(urlTiling)) setTiling(urlTiling);
-    // disableAudio is a boolean; explicitly set to false when the URL says so
-    // (or omits the key, which means "default off"). Without this, the toggle
-    // sticks ON across remixes of clips that had audio.
-    setDisableAudio(get('disableAudio') === '1');
+    if (urlTiling && VIDEO_TILING_ENUM_SET.has(urlTiling)) setTiling(urlTiling);
+    // disableAudio is a boolean; accept the common encodings a hand-edited URL
+    // might carry ('1' from our own Remix builder, 'true' from a manual share).
+    // Anything else (absent, '0', 'false', garbage) means "default off".
+    const audioParam = (get('disableAudio') || '').toLowerCase();
+    setDisableAudio(audioParam === '1' || audioParam === 'true');
     const stripKeys = [...remixGateKeys, 'prompt', 'negativePrompt', 'w', 'h'];
     setSearchParams((prev) => {
       const n = new URLSearchParams(prev);
@@ -338,7 +330,7 @@ export default function VideoGen() {
     // prompt: always set explicitly. Legacy entries can be missing `prompt`
     // (normalizeVideo surfaces them as '(no prompt)') — clear the form instead
     // of leaving whatever the user previously typed, matching the
-    // useImagePreviewActions.handleRemix '(no prompt)' filter.
+    // useMediaPreviewActions.handleRemix '(no prompt)' filter.
     const nextPrompt = item.prompt && item.prompt !== '(no prompt)' ? item.prompt : '';
     setPrompt(nextPrompt);
     // negativePrompt: always set explicitly so remixing a clip with no
@@ -365,10 +357,10 @@ export default function VideoGen() {
     setSteps(item.steps != null && item.steps !== '' ? String(item.steps) : '');
     const guidance = item.guidanceScale ?? item.guidance_scale ?? item.guidance;
     setGuidanceScale(guidance != null && guidance !== '' ? String(guidance) : '');
-    // tiling must match the TILING_OPTIONS enum. Legacy sidecars sometimes
+    // tiling must match the VIDEO_TILING_OPTIONS enum. Legacy sidecars sometimes
     // store a boolean here — silently ignore unknown values so the <select>
     // stays valid and the next POST doesn't 400.
-    if (typeof item.tiling === 'string' && TILING_ENUM_SET.has(item.tiling)) setTiling(item.tiling);
+    if (typeof item.tiling === 'string' && VIDEO_TILING_ENUM_SET.has(item.tiling)) setTiling(item.tiling);
     // disableAudio: always set explicitly (true/false) so the toggle reliably
     // matches the remixed render. Skipping the false branch would leave the
     // toggle stuck ON when the user remixes a clip that had audio enabled.
@@ -1289,7 +1281,7 @@ export default function VideoGen() {
                 onChange={(e) => setTiling(e.target.value)}
                 className="w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
               >
-                {TILING_OPTIONS.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+                {VIDEO_TILING_OPTIONS.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
               </select>
             </div>
 

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -202,7 +202,12 @@ export default function VideoGen() {
     // guidanceScale=0 is a meaningful value (CFG off); test for presence,
     // not truthiness, so "0" round-trips through Remix correctly.
     if (get('guidanceScale') != null && get('guidanceScale') !== '') setGuidanceScale(get('guidanceScale'));
-    if (get('tiling')) setTiling(get('tiling'));
+    // tiling: URL params are user-controlled; only accept known enum strings
+    // (auto|none|spatial|temporal) so a hand-edited URL or stale link can't
+    // push the <select> into an invalid state and 400 the next POST.
+    const TILING_ENUM = new Set(['auto', 'none', 'spatial', 'temporal']);
+    const urlTiling = get('tiling');
+    if (urlTiling && TILING_ENUM.has(urlTiling)) setTiling(urlTiling);
     // disableAudio is a boolean; explicitly set to false when the URL says so
     // (or omits the key, which means "default off"). Without this, the toggle
     // sticks ON across remixes of clips that had audio.

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -331,8 +331,12 @@ export default function VideoGen() {
     if (!item) return;
     setStylePreset(null);
     if (item.prompt) setPrompt(item.prompt);
-    const neg = item.negativePrompt || item.negative_prompt;
-    if (neg) setNegativePrompt(neg);
+    // negativePrompt: always set explicitly so remixing a clip with no
+    // negative prompt clears any value the user previously typed. Skipping the
+    // else-branch would leave stale form text and break the "round-trip
+    // original settings" expectation.
+    const neg = item.negativePrompt || item.negative_prompt || '';
+    setNegativePrompt(neg);
     if (item.modelId && models.some((m) => m.id === item.modelId)) setModelId(item.modelId);
     if (item.width) setWidth(item.width);
     if (item.height) setHeight(item.height);

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -337,7 +337,12 @@ export default function VideoGen() {
     if (item.steps != null && item.steps !== '') setSteps(String(item.steps));
     const guidance = item.guidanceScale ?? item.guidance_scale ?? item.guidance;
     if (guidance != null && guidance !== '') setGuidanceScale(String(guidance));
-    if (item.tiling) setTiling(item.tiling);
+    // tiling must match the server enum (auto|none|spatial|temporal). Legacy
+    // sidecars sometimes store a boolean here — silently ignore unknown values
+    // so the <select> stays valid and the next POST doesn't 400. Mirrors the
+    // guard in useImagePreviewActions.handleRemix.
+    const TILING_ENUM = new Set(['auto', 'none', 'spatial', 'temporal']);
+    if (typeof item.tiling === 'string' && TILING_ENUM.has(item.tiling)) setTiling(item.tiling);
     // disableAudio: always set explicitly (true/false) so the toggle reliably
     // matches the remixed render. Skipping the false branch would leave the
     // toggle stuck ON when the user remixes a clip that had audio enabled.

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -332,7 +332,12 @@ export default function VideoGen() {
   const handleRemixVideo = (item) => {
     if (!item) return;
     setStylePreset(null);
-    if (item.prompt) setPrompt(item.prompt);
+    // prompt: always set explicitly. Legacy entries can be missing `prompt`
+    // (normalizeVideo surfaces them as '(no prompt)') — clear the form instead
+    // of leaving whatever the user previously typed, matching the
+    // useImagePreviewActions.handleRemix '(no prompt)' filter.
+    const nextPrompt = item.prompt && item.prompt !== '(no prompt)' ? item.prompt : '';
+    setPrompt(nextPrompt);
     // negativePrompt: always set explicitly so remixing a clip with no
     // negative prompt clears any value the user previously typed. Skipping the
     // else-branch would leave stale form text and break the "round-trip

--- a/server/services/videoGen/local.js
+++ b/server/services/videoGen/local.js
@@ -449,6 +449,14 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
     height: h,
     numFrames: parsedNumFrames,
     fps: parsedFps,
+    // Persist the effective render settings so the lightbox Remix flow can
+    // round-trip them back into the form. Without these, Remix would only
+    // recover prompt/model/dims/frames/fps/seed and silently revert the
+    // other dials to defaults.
+    steps: actualSteps,
+    guidanceScale: actualGuidance,
+    tiling,
+    disableAudio,
     filename,
     createdAt: new Date().toISOString(),
     // History mode reflects the EFFECTIVE mode — buildLtx2Args infers fflf


### PR DESCRIPTION
## Summary

Adds a **Remix** option to videos in the media preview modal (lightbox), matching the existing behavior for images.

## Behavior

Clicking **Remix** on a video in the lightbox repopulates the Video Gen form with the original render's settings — prompt, negative prompt, model, resolution, frame count, fps, seed, steps, guidance, tiling, and audio toggle — so the user can iterate without retyping.

- Same-page (VideoGen → its own gallery → lightbox): in-page state set, smooth-scroll to top.
- Cross-page (MediaHistory / MediaCollectionDetail → lightbox): navigates to `/media/video?…` with the settings as URL params; VideoGen consumes them on mount and strips them.

## Changes

- `MediaLightbox.jsx` — drop the `!isVideo` gate on the Remix button.
- `MediaPreview.jsx` — update the action-gating comment to match.
- `useImagePreviewActions.js` — `handleRemix` now dispatches by `item.kind`; video items route to `/media/video` with video-shaped params (numFrames, fps, tiling, etc.).
- `VideoGen.jsx` — new remix-prefill `useEffect` for the incoming params + in-page `handleRemixVideo` for same-page clicks; `<MediaPreview onRemix=…>` wired.
- `server/services/videoGen/local.js` — persist `steps`, `guidanceScale`, `tiling`, `disableAudio` in the history meta so Remix can round-trip them. Without this, Remix would silently revert those dials to defaults.

## Test plan

- [x] Client tests: 385 passed (no new tests needed — handler logic is straightforward state-set/URL-param dispatch with existing patterns; covered by the existing remix-prefill pattern).
- [x] Server tests: `services/videoGen/local.test.js` + `routes/videoGen.test.js` pass (additive meta-field change, no shape break).
- [x] Client build passes.
- [ ] Manual: open a video in lightbox from VideoGen, MediaHistory, MediaCollectionDetail — verify Remix button appears and prefills correctly in each case.