### PR TITLE
feat(dashboard): direct-generate from Quick Image widget

### DIFF
--- a/client/src/components/QuickImagePrompt.jsx
+++ b/client/src/components/QuickImagePrompt.jsx
@@ -1,6 +1,9 @@
 import { useState, useRef } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Sparkles } from 'lucide-react';
+import { Sparkles, Pencil } from 'lucide-react';
+import { generateImage } from '../services/api';
+import { DEFAULT_NEGATIVE_PROMPT } from '../lib/imageGenDefaults';
+import toast from './ui/Toast';
 
 export default function QuickImagePrompt() {
   const [prompt, setPrompt] = useState('');
@@ -8,7 +11,7 @@ export default function QuickImagePrompt() {
   const submittingRef = useRef(false);
   const navigate = useNavigate();
 
-  const handleSubmit = (e) => {
+  const handleGenerate = async (e) => {
     e?.preventDefault();
     const text = prompt.trim();
     if (!text || submittingRef.current) return;
@@ -17,10 +20,30 @@ export default function QuickImagePrompt() {
     setIsSubmitting(true);
     setPrompt('');
 
-    // ImageGen page's remix-param effect reads ?prompt=… on mount and
-    // strips it from the URL, so the widget can hand off a one-shot
-    // prompt without us coupling to its internal form state.
-    navigate(`/media/image?prompt=${encodeURIComponent(text)}`);
+    // Omit `mode` so the server falls back to the user's saved
+    // `settings.imageGen.mode` default. Async backends (local/codex) respond
+    // with { jobId, status, position } — sync external responds with the
+    // generation result. Toast wording covers both cases without inspecting
+    // backend internals.
+    const result = await generateImage({
+      prompt: text,
+      negativePrompt: DEFAULT_NEGATIVE_PROMPT,
+    }).catch(() => null);
+
+    submittingRef.current = false;
+    setIsSubmitting(false);
+    if (result) {
+      toast.success(result.status === 'queued' || result.status === 'running' ? 'Image queued' : 'Image generated');
+    }
+  };
+
+  const handleOpenInEditor = (e) => {
+    e?.preventDefault();
+    const text = prompt.trim();
+    // ImageGen page's remix-param effect reads ?prompt=… on mount and strips
+    // it from the URL, so the widget can hand off a one-shot prompt without
+    // coupling to the form's internal state.
+    navigate(`/media/image${text ? `?prompt=${encodeURIComponent(text)}` : ''}`);
   };
 
   return (
@@ -31,7 +54,7 @@ export default function QuickImagePrompt() {
           Image Gen &rarr;
         </Link>
       </div>
-      <form onSubmit={handleSubmit} className="flex flex-col gap-2 flex-1 min-h-0">
+      <form onSubmit={handleGenerate} className="flex flex-col gap-2 flex-1 min-h-0">
         <label htmlFor="quick-image-prompt" className="sr-only">Image prompt</label>
         <textarea
           id="quick-image-prompt"
@@ -39,19 +62,32 @@ export default function QuickImagePrompt() {
           value={prompt}
           onChange={(e) => setPrompt(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSubmit(e);
+            if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleGenerate(e);
           }}
           rows={3}
           className="flex-1 min-h-0 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm resize-none"
         />
-        <button
-          type="submit"
-          disabled={!prompt.trim() || isSubmitting}
-          className="flex items-center justify-center gap-2 px-3 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg text-sm transition-colors disabled:opacity-50 min-h-[40px]"
-        >
-          <Sparkles size={14} />
-          Generate
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            type="submit"
+            disabled={!prompt.trim() || isSubmitting}
+            className="flex-1 flex items-center justify-center gap-2 px-3 py-2 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded-lg text-sm transition-colors disabled:opacity-50 min-h-[40px]"
+            title="Generate with default settings"
+          >
+            <Sparkles size={14} />
+            {isSubmitting ? 'Submitting…' : 'Generate'}
+          </button>
+          <button
+            type="button"
+            onClick={handleOpenInEditor}
+            disabled={isSubmitting}
+            className="flex items-center justify-center gap-2 px-3 py-2 border border-port-border text-gray-300 hover:text-white hover:bg-port-border/50 rounded-lg text-sm transition-colors disabled:opacity-50 min-h-[40px]"
+            title="Open in editor with this prompt"
+          >
+            <Pencil size={14} />
+            Edit
+          </button>
+        </div>
       </form>
     </div>
   );

--- a/client/src/components/QuickImagePrompt.jsx
+++ b/client/src/components/QuickImagePrompt.jsx
@@ -33,7 +33,10 @@ export default function QuickImagePrompt() {
     submittingRef.current = false;
     setIsSubmitting(false);
     if (result) {
-      setPrompt('');
+      // Only clear if the textarea still holds the submitted text — the user
+      // can keep typing while the request is in flight and we don't want to
+      // wipe out new input on resolve.
+      setPrompt((current) => (current === text ? '' : current));
       toast.success(result.status === 'queued' || result.status === 'running' ? 'Image queued' : 'Image generated');
     }
   };

--- a/client/src/components/QuickImagePrompt.jsx
+++ b/client/src/components/QuickImagePrompt.jsx
@@ -18,13 +18,13 @@ export default function QuickImagePrompt() {
 
     submittingRef.current = true;
     setIsSubmitting(true);
-    setPrompt('');
 
     // Omit `mode` so the server falls back to the user's saved
     // `settings.imageGen.mode` default. Async backends (local/codex) respond
     // with { jobId, status, position } — sync external responds with the
     // generation result. Toast wording covers both cases without inspecting
-    // backend internals.
+    // backend internals. Preserve the input on failure so the user doesn't
+    // have to retype after a server error (the API helper toasts on its own).
     const result = await generateImage({
       prompt: text,
       negativePrompt: DEFAULT_NEGATIVE_PROMPT,
@@ -33,6 +33,7 @@ export default function QuickImagePrompt() {
     submittingRef.current = false;
     setIsSubmitting(false);
     if (result) {
+      setPrompt('');
       toast.success(result.status === 'queued' || result.status === 'running' ? 'Image queued' : 'Image generated');
     }
   };

--- a/client/src/lib/README.md
+++ b/client/src/lib/README.md
@@ -42,6 +42,7 @@ grep -i "what you want to do" client/src/lib/README.md
 | `pipelineImageDefaults.js` | Pipeline comic-page image-gen defaults + settings reader. |
 | `wrImageDefaults.js` | Writers Room per-scene image-gen defaults + style discriminators. |
 | `imageGenBackends.js` | `IMAGE_GEN_MODE` enum (local / codex / external) + metadata. |
+| `imageGenDefaults.js` | Shared `DEFAULT_NEGATIVE_PROMPT` used by the Image Gen form and quick-submit entry points. Mirrors server-side default. |
 | `imageGenResolutions.js` | Shared resolution presets for image generation. |
 | `videoGenResolutions.js` | Shared resolution presets for video generation (companion to image side; LTX-2 latent-friendly sizes). |
 | `videoTilingOptions.js` | `VIDEO_TILING_OPTIONS` (the `<select>` rows) + `VIDEO_TILING_ENUM_SET` (the value-only Set). Single source consumed by `VideoGen.jsx` and the Remix URL builder in `useMediaPreviewActions`. Mirrors the server's `z.enum` in `server/routes/videoGen.js`. |

--- a/client/src/lib/imageGenDefaults.js
+++ b/client/src/lib/imageGenDefaults.js
@@ -1,0 +1,8 @@
+// Image-gen defaults shared between the full Image Gen form and quick-submit
+// entry points (e.g. the Dashboard Quick Image widget).
+//
+// The server mirrors DEFAULT_NEGATIVE_PROMPT in
+// `server/services/imageGen/index.js` and `server/services/imageGen/external.js`
+// — when changing this string, update both server copies too.
+
+export const DEFAULT_NEGATIVE_PROMPT = 'blurry, low quality, distorted, deformed, ugly, watermark, text, signature';

--- a/client/src/lib/index.js
+++ b/client/src/lib/index.js
@@ -15,6 +15,7 @@ export * from './universeStylePreset.js';
 export * from './bibleLimits.js';
 export * from './imageCleaners.js';
 export * from './imageGenBackends.js';
+export * from './imageGenDefaults.js';
 export * from './imageGenResolutions.js';
 export * from './issueLength.js';
 export * from './pipelineImageDefaults.js';

--- a/client/src/pages/ImageGen.jsx
+++ b/client/src/pages/ImageGen.jsx
@@ -34,6 +34,7 @@ import {
 } from 'lucide-react';
 import { composeStyledPrompt } from '../lib/composeStyledPrompt';
 import { deriveAvailableBackends, IMAGE_GEN_MODE } from '../lib/imageGenBackends';
+import { DEFAULT_NEGATIVE_PROMPT } from '../lib/imageGenDefaults';
 import { resolveCleanersFromConfig } from '../lib/imageCleaners';
 import toast from '../components/ui/Toast';
 import BrailleSpinner from '../components/BrailleSpinner';
@@ -44,8 +45,6 @@ import {
   buildFormData, listMediaJobs,
 } from '../services/api';
 import { safeParseJSON } from '../lib/genUtils';
-
-const DEFAULT_NEGATIVE = 'blurry, low quality, distorted, deformed, ugly, watermark, text, signature';
 
 // Multi-reference editing (FLUX.2 only) — 4 fixed slots, each carrying an
 // uploaded File + a 0..1 strength weight. Slots are positional so the
@@ -132,7 +131,7 @@ export default function ImageGen() {
   const [availableBackends, setAvailableBackends] = useState([]);
 
   const [prompt, setPrompt] = useState('');
-  const [negativePrompt, setNegativePrompt] = useState(DEFAULT_NEGATIVE);
+  const [negativePrompt, setNegativePrompt] = useState(DEFAULT_NEGATIVE_PROMPT);
   const [stylePreset, setStylePreset] = useState(null);
   const [modelId, setModelId] = useState('');
   const [width, setWidth] = useState(1024);


### PR DESCRIPTION
## Summary

The Quick Image widget on the dashboard previously only navigated to the Image Gen page with the prompt pre-filled. This adds a direct **Generate** button that submits to the user's default image-gen backend (with the shared default negative prompt) without leaving the dashboard. The existing handoff stays available as an **Edit** button.

- **Generate** — fires `POST /api/image-gen/generate` with `{ prompt, negativePrompt: DEFAULT_NEGATIVE_PROMPT }`. No `mode` is sent, so the server falls back to `settings.imageGen.mode`. Toasts `Image queued` for async backends (local/codex) or `Image generated` for sync (external).
- **Edit** — original behavior: navigate to `/media/image?prompt=…` so the user lands in the full editor with their prompt pre-filled.

`DEFAULT_NEGATIVE_PROMPT` was extracted from `ImageGen.jsx` into `client/src/lib/imageGenDefaults.js` so the widget and the form share one constant (mirrors the server-side default in `server/services/imageGen/{index,external}.js`).

## Notes
- ⌘/Ctrl+Enter inside the textarea still triggers Generate.
- On submit failure, the prompt is preserved so the user doesn't have to retype.
- The shared lib was added to `client/src/lib/index.js` + `README.md` per the barrel/README maintenance rule (enforced by `src/lib/index.test.js`).

## Test plan
- [ ] On the dashboard with the Quick Image widget enabled, type a prompt and click **Generate** — toast confirms queued/generated; navigating to `/media/image` shows the new image in the gallery
- [ ] Click **Edit** with prompt text — lands on `/media/image` with the prompt pre-filled
- [ ] Click **Edit** with empty prompt — lands on `/media/image` with a blank prompt (no stray `?prompt=` in URL)
- [ ] Submit while server-side image gen is misconfigured — error toast fires once (no double toast) and the prompt text is preserved
- [ ] ⌘+Enter inside the textarea triggers Generate
- [ ] `cd client && npx vitest run` — all 385 tests pass