### PR TITLE
feat(pipeline): show Verify Arc scope as a hover tooltip

### DIFF
--- a/client/src/components/pipeline/ArcCanvas.jsx
+++ b/client/src/components/pipeline/ArcCanvas.jsx
@@ -111,6 +111,28 @@ function VerifyScopeHint({ scope }) {
   );
 }
 
+// Hover-revealed tooltip variant — anchors below a parent with the `group`
+// class. Use this when the scope hint should sit on the button itself
+// instead of taking up vertical space in the layout.
+function VerifyScopeTooltip({ scope, label = 'What this checks' }) {
+  return (
+    <div
+      role="tooltip"
+      className="absolute top-full right-0 mt-2 w-80 max-w-[calc(100vw-2rem)] bg-port-card border border-port-border rounded-lg shadow-lg p-3 z-30 opacity-0 invisible group-hover:opacity-100 group-hover:visible group-focus-within:opacity-100 group-focus-within:visible transition-opacity pointer-events-none text-left normal-case tracking-normal"
+    >
+      <p className="text-[10px] text-gray-300 font-medium mb-1 flex items-center gap-1">
+        <Info size={10} /> {label}
+      </p>
+      <p className="text-[10px] text-gray-400 italic mb-2">{scope.depth}</p>
+      <ul className="list-disc pl-4 space-y-0.5 text-[10px] text-gray-400">
+        {scope.checks.map((c) => (
+          <li key={c}>{c}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export default function ArcCanvas({ series, issues, onSeriesUpdate, onIssuesUpdate, onFlushPending }) {
   const seasons = series.seasons || [];
   // Stale seasonIds (e.g. after a verify-resolve season rewrite) bucket under
@@ -340,16 +362,18 @@ function ArcHeader({ series, onSeriesUpdate, onIssuesUpdate, onFlushPending }) {
             {generateBtnLabel}
           </button>
           {hasGeneratedArc ? (
-            <button
-              type="button"
-              onClick={runVerify}
-              disabled={!!running}
-              className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium border bg-port-bg text-gray-300 border-port-border hover:border-port-accent/40 disabled:opacity-40"
-              title="Cross-volume continuity pass at synopsis depth"
-            >
-              {running === 'verify' ? <Loader2 size={14} className="animate-spin" /> : <ShieldCheck size={14} />}
-              Verify arc
-            </button>
+            <div className="relative group">
+              <button
+                type="button"
+                onClick={runVerify}
+                disabled={!!running}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium border bg-port-bg text-gray-300 border-port-border hover:border-port-accent/40 disabled:opacity-40"
+              >
+                {running === 'verify' ? <Loader2 size={14} className="animate-spin" /> : <ShieldCheck size={14} />}
+                Verify arc
+              </button>
+              <VerifyScopeTooltip scope={VERIFY_ARC_SCOPE} />
+            </div>
           ) : null}
         </div>
       </div>
@@ -382,8 +406,6 @@ function ArcHeader({ series, onSeriesUpdate, onIssuesUpdate, onFlushPending }) {
           </div>
         </div>
       ) : null}
-
-      {hasGeneratedArc ? <VerifyScopeHint scope={VERIFY_ARC_SCOPE} /> : null}
 
       {arc ? (
         <ArcContent series={series} onSeriesUpdate={onSeriesUpdate} />

--- a/client/src/components/pipeline/ArcCanvas.jsx
+++ b/client/src/components/pipeline/ArcCanvas.jsx
@@ -113,15 +113,17 @@ function VerifyScopeHint({ scope }) {
 
 // Hover-revealed tooltip variant — anchors below a parent with the `group`
 // class. Use this when the scope hint should sit on the button itself
-// instead of taking up vertical space in the layout.
-function VerifyScopeTooltip({ scope, label = 'What this checks' }) {
+// instead of taking up vertical space in the layout. The `id` is exposed so
+// the triggering button can wire `aria-describedby` for screen readers.
+function VerifyScopeTooltip({ scope, id }) {
   return (
     <div
+      id={id}
       role="tooltip"
       className="absolute top-full right-0 mt-2 w-80 max-w-[calc(100vw-2rem)] bg-port-card border border-port-border rounded-lg shadow-lg p-3 z-30 opacity-0 invisible group-hover:opacity-100 group-hover:visible group-focus-within:opacity-100 group-focus-within:visible transition-opacity pointer-events-none text-left normal-case tracking-normal"
     >
       <p className="text-[10px] text-gray-300 font-medium mb-1 flex items-center gap-1">
-        <Info size={10} /> {label}
+        <Info size={10} /> What this checks
       </p>
       <p className="text-[10px] text-gray-400 italic mb-2">{scope.depth}</p>
       <ul className="list-disc pl-4 space-y-0.5 text-[10px] text-gray-400">
@@ -367,12 +369,13 @@ function ArcHeader({ series, onSeriesUpdate, onIssuesUpdate, onFlushPending }) {
                 type="button"
                 onClick={runVerify}
                 disabled={!!running}
+                aria-describedby="verify-arc-scope-tooltip"
                 className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium border bg-port-bg text-gray-300 border-port-border hover:border-port-accent/40 disabled:opacity-40"
               >
                 {running === 'verify' ? <Loader2 size={14} className="animate-spin" /> : <ShieldCheck size={14} />}
                 Verify arc
               </button>
-              <VerifyScopeTooltip scope={VERIFY_ARC_SCOPE} />
+              <VerifyScopeTooltip scope={VERIFY_ARC_SCOPE} id="verify-arc-scope-tooltip" />
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary

- Replaces the static \"What this checks\" disclosure rendered below the Verify arc button with a UI tooltip that surfaces on hover or keyboard focus of the button itself.
- Frees vertical space in the arc header and keeps the scope detail directly attached to the action it describes.
- Adds proper a11y wiring: tooltip has \`role=\"tooltip\"\` plus \`id\`, and the button references it via \`aria-describedby\` so screen readers pair them.

## Implementation notes

- New \`VerifyScopeTooltip\` component (sibling to the existing \`VerifyScopeHint\` used for the Validate volume affordance) — anchored to a \`relative group\` wrapper, revealed on \`group-hover\` / \`group-focus-within\`.
- \`pointer-events-none\` keeps the tooltip from intercepting clicks on the button.
- Volume-side \`VerifyScopeHint\` (\`Validate volume\` button) is unchanged — out of scope for this task.

## Test plan

- [ ] Open Pipeline → a series with a generated arc, hover \"Verify arc\" — tooltip appears below the button with the depth + checks list.
- [ ] Tab to the button — tooltip appears on focus.
- [ ] Click the button — verify still runs; tooltip doesn't block the click.
- [ ] Mobile viewport — tooltip stays within the viewport (\`max-w-[calc(100vw-2rem)]\`).