### PR TITLE
fix(settings): show sub-nav header on Providers and Prompts pages

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -8,4 +8,6 @@
 
 ## Fixed
 
+- Providers (`/ai`) and Prompts (`/prompts`) pages now render the same Settings sub-nav tabbed header as the other settings pages, so users can hop between Backup / Database / General / MortalLoom / Prompts / Providers / Sharing / Telegram / Voice without going back to the sidebar. Extracted a shared `SettingsTabsHeader` component used by `Settings.jsx`, `AIProviders.jsx`, and `PromptManager.jsx`.
+
 ## Removed

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -970,6 +970,7 @@ export default function Layout() {
         {/* Main content */}
         {(() => {
           const isFullWidth = location.pathname === '/character' ||
+            location.pathname === '/ai' ||
             location.pathname === '/ask' ||
             location.pathname.startsWith('/ask/') ||
             location.pathname.startsWith('/calendar') ||
@@ -985,6 +986,7 @@ export default function Layout() {
             location.pathname.startsWith('/pipeline/issues/') ||
             location.pathname.startsWith('/pipeline/series/') ||
             location.pathname.startsWith('/post') ||
+            location.pathname === '/prompts' ||
             location.pathname === '/review' ||
             location.pathname.startsWith('/settings') ||
             location.pathname.startsWith('/wiki') ||

--- a/client/src/components/settings/SettingsTabsHeader.jsx
+++ b/client/src/components/settings/SettingsTabsHeader.jsx
@@ -1,0 +1,40 @@
+import { useNavigate } from 'react-router-dom';
+import TabPills from '../ui/TabPills';
+
+// Shared sub-nav for every page that lives under the sidebar's "Settings"
+// group. Settings.jsx hosts the in-Settings tabs (general/backup/etc.) and
+// the two standalone pages (Providers at /ai, Prompts at /prompts) host
+// themselves — but all three need the same tabbed header so users can hop
+// between them without going back to the sidebar.
+//
+// Pass `activeTab` matching one of the TABS ids below. Internal Settings
+// pages use the `<tab>` slug; the standalone pages use `providers` / `prompts`.
+const TABS = [
+  { id: 'backup', label: 'Backup', to: '/settings/backup' },
+  { id: 'database', label: 'Database', to: '/settings/database' },
+  { id: 'general', label: 'General', to: '/settings/general' },
+  { id: 'mortalloom', label: 'MortalLoom', to: '/settings/mortalloom' },
+  { id: 'prompts', label: 'Prompts', to: '/prompts' },
+  { id: 'providers', label: 'Providers', to: '/ai' },
+  { id: 'sharing', label: 'Sharing', to: '/settings/sharing' },
+  { id: 'telegram', label: 'Telegram', to: '/settings/telegram' },
+  { id: 'voice', label: 'Voice', to: '/settings/voice' }
+];
+
+export default function SettingsTabsHeader({ activeTab }) {
+  const navigate = useNavigate();
+
+  const handleChange = (tabId) => {
+    const target = TABS.find(t => t.id === tabId);
+    if (target) navigate(target.to);
+  };
+
+  return (
+    <TabPills
+      tabs={TABS}
+      activeTab={activeTab}
+      onChange={handleChange}
+      ariaLabel="Settings sections"
+    />
+  );
+}

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -10,6 +10,7 @@ import {
   TIMEOUT_INPUT_MAX_MS,
   TIMEOUT_INPUT_STEP_MS,
 } from '../utils/formatters';
+import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
 
 export default function AIProviders() {
   const [providers, setProviders] = useState([]);
@@ -185,14 +186,27 @@ export default function AIProviders() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center h-64">
-        <div className="text-gray-400">Loading providers...</div>
+      <div className="flex flex-col h-full">
+        <div className="flex items-center gap-3 p-4 border-b border-port-border">
+          <h1 className="text-2xl font-bold text-white">Settings</h1>
+        </div>
+        <SettingsTabsHeader activeTab="providers" />
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-gray-400">Loading providers...</div>
+        </div>
       </div>
     );
   }
 
   return (
-    <div className="space-y-6">
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-3 p-4 border-b border-port-border">
+        <h1 className="text-2xl font-bold text-white">Settings</h1>
+      </div>
+
+      <SettingsTabsHeader activeTab="providers" />
+
+      <div className="flex-1 overflow-auto p-4 space-y-6">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <h1 className="text-2xl font-bold text-white">AI Providers</h1>
         <div className="flex flex-wrap gap-2">
@@ -565,6 +579,7 @@ export default function AIProviders() {
           onSave={() => { setShowForm(false); setEditingProvider(null); loadData(); }}
         />
       )}
+      </div>
     </div>
   );
 }

--- a/client/src/pages/PromptManager.jsx
+++ b/client/src/pages/PromptManager.jsx
@@ -12,6 +12,7 @@ import {
   TIMEOUT_INPUT_STEP_MS,
 } from '../utils/formatters';
 import useFieldDraft from '../hooks/useFieldDraft';
+import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
 
 export default function PromptManager() {
   const [tab, setTab] = useState('stages');
@@ -262,11 +263,28 @@ export default function PromptManager() {
   };
 
   if (loading) {
-    return <div className="flex items-center justify-center h-64"><BrailleSpinner text="Loading prompts" /></div>;
+    return (
+      <div className="flex flex-col h-full">
+        <div className="flex items-center gap-3 p-4 border-b border-port-border">
+          <h1 className="text-2xl font-bold text-white">Settings</h1>
+        </div>
+        <SettingsTabsHeader activeTab="prompts" />
+        <div className="flex-1 flex items-center justify-center">
+          <BrailleSpinner text="Loading prompts" />
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div>
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-3 p-4 border-b border-port-border">
+        <h1 className="text-2xl font-bold text-white">Settings</h1>
+      </div>
+
+      <SettingsTabsHeader activeTab="prompts" />
+
+      <div className="flex-1 overflow-auto p-4">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 mb-6">
         <div>
@@ -877,6 +895,7 @@ export default function PromptManager() {
           </div>
         </div>
       )}
+      </div>
     </div>
   );
 }

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate, Navigate } from 'react-router-dom';
+import { useParams, Navigate } from 'react-router-dom';
 import { BackupTab } from '../components/settings/BackupTab';
 import { DatabaseTab } from '../components/settings/DatabaseTab';
 import { TelegramTab } from '../components/settings/TelegramTab';
@@ -6,17 +6,7 @@ import { GeneralTab } from '../components/settings/GeneralTab';
 import { MortalLoomTab } from '../components/settings/MortalLoomTab';
 import { SharingTab } from '../components/settings/SharingTab';
 import { VoiceTab } from '../components/settings/VoiceTab';
-import TabPills from '../components/ui/TabPills';
-
-const TABS = [
-  { id: 'general', label: 'General' },
-  { id: 'backup', label: 'Backup' },
-  { id: 'database', label: 'Database' },
-  { id: 'sharing', label: 'Sharing' },
-  { id: 'voice', label: 'Voice' },
-  { id: 'telegram', label: 'Telegram' },
-  { id: 'mortalloom', label: 'MortalLoom' }
-];
+import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
 
 // Settings pages now host themselves as drawers on their feature pages where
 // it makes sense. Redirect old direct URLs to the new home so bookmarks and
@@ -27,16 +17,11 @@ const REDIRECTS = {
 
 export default function Settings() {
   const { tab } = useParams();
-  const navigate = useNavigate();
   const activeTab = tab || 'general';
 
   if (REDIRECTS[activeTab]) {
     return <Navigate to={REDIRECTS[activeTab]} replace />;
   }
-
-  const handleTabChange = (tabId) => {
-    navigate(`/settings/${tabId}`);
-  };
 
   const renderTabContent = () => {
     switch (activeTab) {
@@ -57,7 +42,7 @@ export default function Settings() {
         <h1 className="text-2xl font-bold text-white">Settings</h1>
       </div>
 
-      <TabPills tabs={TABS} activeTab={activeTab} onChange={handleTabChange} ariaLabel="Settings sections" />
+      <SettingsTabsHeader activeTab={activeTab} />
 
       <div className="flex-1 overflow-auto p-4">
         {renderTabContent()}


### PR DESCRIPTION
## Summary

The `/ai` (Providers) and `/prompts` (Prompts) pages live in the Settings sidebar group, but they rendered without the tabbed sub-nav header that every other settings page shares. Users landing on either page had no quick way to hop to a sibling settings tab — they had to go back to the sidebar.

## Changes

- New shared `SettingsTabsHeader` component (`client/src/components/settings/SettingsTabsHeader.jsx`) using the existing `TabPills` primitive. Encodes the full Settings group (alphabetical, matching the sidebar): Backup / Database / General / MortalLoom / **Prompts** / **Providers** / Sharing / Telegram / Voice. Handles routing via `react-router`'s `useNavigate` — internal Settings tabs go to `/settings/<id>`, Prompts/Providers go to `/prompts` and `/ai`.
- `Settings.jsx` switched to use the shared component; removed the now-duplicated local TABS list and tab-change handler.
- `AIProviders.jsx` and `PromptManager.jsx` adopt the same `Settings` h1 + sub-nav header used by `Settings.jsx`, including in their loading states so the nav doesn't flash in/out during initial fetches.

## Test plan

- [x] `vite build` succeeds
- [x] `npm test --run` — 385/385 client tests pass
- [ ] Manually verify `/settings/general`, `/ai`, and `/prompts` all show the same tabbed sub-nav with the correct active pill
- [ ] Click each sub-nav pill and confirm navigation lands on the correct route