### PR TITLE
feat(video-gen): add 576×1024 (9:16) vertical resolution preset

### DIFF
--- a/client/src/lib/videoGenResolutions.js
+++ b/client/src/lib/videoGenResolutions.js
@@ -4,13 +4,14 @@
 //
 // Video sizes follow LTX-2's preferred latent boundaries (multiples of 32 on
 // each edge); the aspect-ratio hints in the labels surface common shapes the
-// user picks for (16:9 social, 2:3 portrait, 1:1 grid).
+// user picks for (16:9 social, 9:16 vertical, 2:3 portrait, 1:1 grid).
 export const VIDEO_RESOLUTIONS = [
   { label: '512×320 (16:10)', w: 512, h: 320 },
   { label: '640×384 (5:3)', w: 640, h: 384 },
   { label: '704×448 (16:10)', w: 704, h: 448 },
   { label: '768×512 (3:2 default)', w: 768, h: 512 },
   { label: '1024×576 (16:9)', w: 1024, h: 576 },
+  { label: '576×1024 (9:16)', w: 576, h: 1024 },
   { label: '512×768 (portrait)', w: 512, h: 768 },
   { label: '512×512 (1:1)', w: 512, h: 512 },
   { label: '768×768 (1:1)', w: 768, h: 768 },


### PR DESCRIPTION
## Summary
The LTX video generation form offered a `1024×576 (16:9)` landscape preset but no matching `9:16` vertical option. This adds `576×1024 (9:16)` so users can generate portrait/vertical clips (Reels/Shorts/TikTok shape) from the preset dropdown.

## Changes
- `client/src/lib/videoGenResolutions.js`: add `{ label: '576×1024 (9:16)', w: 576, h: 1024 }` to `VIDEO_RESOLUTIONS`, placed at the head of the portrait group; update the header comment's aspect-ratio hint to include "9:16 vertical".

## Notes
- `576` and `1024` are both multiples of 32 (LTX-2's latent-boundary requirement) and fall within the video-gen route's `64–2048` width/height bounds, so the new size validates server-side with no other changes.
- The size dropdown (`VideoGen.jsx`), `handleResolutionChange`, and `resolveResolutionLabel` are all fully data-driven off this table — adding the entry is the complete change.

## Testing
- `server` videoGen route suite: 56/56 pass.