### PR TITLE
show active AI provider at the top of the providers list

### DIFF
--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -388,9 +388,9 @@ export default function AIProviders() {
       {/* Provider List */}
       <div className="grid gap-4">
         {(() => {
-          const active = providers.find(p => p.id === activeProviderId);
-          const rest = providers.filter(p => p.id !== activeProviderId);
-          return active ? [active, ...rest] : providers;
+          const idx = providers.findIndex(p => p.id === activeProviderId);
+          if (idx <= 0) return providers;
+          return [providers[idx], ...providers.slice(0, idx), ...providers.slice(idx + 1)];
         })().map(provider => (
           <div
             key={provider.id}

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -387,7 +387,11 @@ export default function AIProviders() {
 
       {/* Provider List */}
       <div className="grid gap-4">
-        {providers.map(provider => (
+        {(() => {
+          const active = providers.find(p => p.id === activeProviderId);
+          const rest = providers.filter(p => p.id !== activeProviderId);
+          return active ? [active, ...rest] : providers;
+        })().map(provider => (
           <div
             key={provider.id}
             className={`bg-port-card border rounded-xl p-4 ${


### PR DESCRIPTION
## Summary

- On the AI Providers settings page, the provider marked `DEFAULT` (the active provider) now renders first in the list. Other providers keep their existing order beneath it.
- Implementation is a partition + spread in the render path — no state or sort key changes.

## Test plan

- [ ] Visit Settings → AI Providers with multiple providers configured.
- [ ] Confirm the provider tagged `DEFAULT` appears at the top of the list.
- [ ] Click "Set Default" on a different provider; confirm the list re-orders so the newly-active one moves to the top without a refresh.
- [ ] With no active provider set (`activeProviderId` null), confirm the list renders in the original order without crashing.