### PR TITLE
show backend toggle in Writers Room config + default to codex when enabled

### DIFF
--- a/client/src/components/writers-room/StoryboardPanel.jsx
+++ b/client/src/components/writers-room/StoryboardPanel.jsx
@@ -112,15 +112,20 @@ export default function StoryboardPanel({
   const [stylePresets, setStylePresets] = useState([]);
   const [sysSettings, setSysSettings] = useState(null);
   const mountedRef = useMounted();
-  // External SD-API doesn't emit the SSE progress that SceneCard's socket bus
-  // consumes — restrict storyboard renders to Local + Codex.
+  // All three backends emit started/progress/completed via imageGenEvents →
+  // socket.io, so the storyboard supports Local, Codex, and External SD-API.
   const availableBackends = useMemo(
-    () => deriveAvailableBackends(sysSettings, { excludeExternal: true }),
+    () => deriveAvailableBackends(sysSettings),
     [sysSettings],
   );
 
   const imageStyle = work.imageStyle || EMPTY_IMAGE_STYLE;
   const activeDraft = (work.drafts || []).find((d) => d.id === work.activeDraftVersionId);
+
+  const applyFreshSettings = useCallback((s) => {
+    setSysSettings(s);
+    setImageCfg(readWrImageSettings(s, deriveAvailableBackends(s)));
+  }, []);
 
   // Re-runnable so the Settings drawer can refresh availableBackends/imageCfg
   // when it closes — without this, enabling Codex in the drawer wouldn't
@@ -128,9 +133,8 @@ export default function StoryboardPanel({
   const reloadSysSettings = useCallback(async () => {
     const s = await getSettings().catch(() => ({}));
     if (!mountedRef.current) return;
-    setSysSettings(s);
-    setImageCfg(readWrImageSettings(s));
-  }, [mountedRef]);
+    applyFreshSettings(s);
+  }, [mountedRef, applyFreshSettings]);
 
   useEffect(() => {
     let cancelled = false;
@@ -140,13 +144,12 @@ export default function StoryboardPanel({
       listImageStylePresets().catch(() => []),
     ]).then(([s, modelList, presets]) => {
       if (cancelled) return;
-      setSysSettings(s);
-      setImageCfg(readWrImageSettings(s));
+      applyFreshSettings(s);
       setModels(Array.isArray(modelList) ? modelList : []);
       setStylePresets(Array.isArray(presets) ? presets : []);
     });
     return () => { cancelled = true; };
-  }, []);
+  }, [applyFreshSettings]);
 
   // When the user closes the Image Gen settings drawer, settings may have
   // changed (e.g. they enabled Codex) — reload so the chip strip reflects
@@ -669,7 +672,7 @@ function ConfigTab({ imageCfg, models, availableBackends, onCfgChange, stylePres
         </div>
         {availableBackends.length === 0 && (
           <div className="text-[10px] text-port-warning bg-port-warning/10 border border-port-warning/40 rounded px-2 py-1.5">
-            No image gen backend configured. Click <span className="font-medium">Backends</span> to enable Local mflux or Codex <code className="text-gray-400">$imagegen</code>.
+            No image gen backend configured. Click <span className="font-medium">Backends</span> to enable Local mflux, Codex <code className="text-gray-400">$imagegen</code>, or an External SD-API endpoint.
           </div>
         )}
         <ImageGenSettingsRow cfg={imageCfg} models={models} availableBackends={availableBackends} onChange={onCfgChange} />
@@ -1039,17 +1042,25 @@ const RES_PRESETS = [
   { label: '1024×1024 (1:1)', width: 1024, height: 1024 },
 ];
 
+// Per-mode form layout — Codex picks model/steps/seed internally, External
+// SD-API loads its model server-side. Showing fields the active backend
+// can't act on misleads the user about what's actually controlling renders.
+const MODE_HINT = {
+  [IMAGE_GEN_MODE.LOCAL]: 'Renders locally via mflux/diffusers on this machine.',
+  [IMAGE_GEN_MODE.CODEX]: "Codex's $imagegen skill renders via your logged-in Codex session. Model, steps, and seed are picked by Codex itself.",
+  [IMAGE_GEN_MODE.EXTERNAL]: 'External SD-API renders against your configured A1111/Forge endpoint. The active model is set by the SD-API server.',
+};
+
 function ImageGenSettingsRow({ cfg, models, availableBackends = [], onChange }) {
   const presetMatch = RES_PRESETS.find((p) => p.width === cfg.width && p.height === cfg.height);
   const currentModel = models.find((m) => m.id === cfg.modelId);
   const inputCls = 'w-full mt-0.5 bg-port-bg border border-port-border rounded px-2 py-1 text-[11px] text-gray-200 focus:border-port-accent outline-none';
   const labelCls = 'text-[9px] uppercase tracking-wider text-gray-500';
-  // Codex's built-in image_gen tool picks model/steps/seed internally — hide
-  // those knobs in codex mode so the user doesn't tune values that won't apply.
+  const isLocalMode = cfg.mode === IMAGE_GEN_MODE.LOCAL;
   const isCodexMode = cfg.mode === IMAGE_GEN_MODE.CODEX;
   return (
     <div className="space-y-1.5">
-      {availableBackends.length > 1 && (
+      {availableBackends.length > 0 && (
         <div>
           <span className={labelCls}>Backend</span>
           <div className="mt-0.5">
@@ -1062,15 +1073,11 @@ function ImageGenSettingsRow({ cfg, models, availableBackends = [], onChange }) 
               titlePrefix="Render storyboard scenes via"
             />
           </div>
-          {isCodexMode && (
-            <p className="text-[9px] text-gray-500 mt-1">
-              Codex's <code className="text-gray-400">$imagegen</code> skill renders via your logged-in Codex session. Model, steps, and seed are picked by Codex itself.
-            </p>
-          )}
+          <p className="text-[9px] text-gray-500 mt-1">{MODE_HINT[cfg.mode]}</p>
         </div>
       )}
       <div className="grid grid-cols-2 gap-1.5">
-        {!isCodexMode && (
+        {isLocalMode && (
           <label className="block">
             <span className={labelCls}>Image model</span>
             <select
@@ -1107,13 +1114,13 @@ function ImageGenSettingsRow({ cfg, models, availableBackends = [], onChange }) 
         <div className="grid grid-cols-2 gap-1.5">
           <label className="block">
             <span className={labelCls}>
-              Steps {currentModel?.steps && <span className="normal-case text-gray-600">(default {currentModel.steps})</span>}
+              Steps {isLocalMode && currentModel?.steps && <span className="normal-case text-gray-600">(default {currentModel.steps})</span>}
             </span>
             <input
               type="number" min={1} max={150}
               value={cfg.steps}
               onChange={(e) => onChange({ ...cfg, steps: e.target.value })}
-              placeholder={String(currentModel?.steps || 'auto')}
+              placeholder={isLocalMode ? String(currentModel?.steps || 'auto') : 'server default'}
               className={inputCls}
             />
           </label>

--- a/client/src/lib/wrImageDefaults.js
+++ b/client/src/lib/wrImageDefaults.js
@@ -24,11 +24,24 @@ export const WR_IMAGE_DEFAULTS = Object.freeze({
   seed: '',
 });
 
-export function readWrImageSettings(settings) {
+// Resolve the per-scene render config. When the user hasn't pinned a Writers
+// Room mode, prefer Codex if enabled — cloud models render storyboard scenes
+// more reliably than local diffusion when both are available. If the stored
+// mode points at a backend that's no longer available (codex disabled, local
+// pythonPath cleared), fall back to the first available backend so the form
+// always reflects something that will actually run.
+export function readWrImageSettings(settings, availableBackends = null) {
   const stored = settings?.writersRoom?.imageGen || {};
+  const codexEnabled = settings?.imageGen?.codex?.enabled === true;
+  const defaultMode = codexEnabled ? IMAGE_GEN_MODE.CODEX : WR_IMAGE_DEFAULTS.mode;
+  let mode = stored.mode || defaultMode;
+  if (Array.isArray(availableBackends) && availableBackends.length > 0
+      && !availableBackends.some((b) => b.id === mode)) {
+    mode = availableBackends[0].id;
+  }
   return {
     modelId: stored.modelId || WR_IMAGE_DEFAULTS.modelId,
-    mode: stored.mode || WR_IMAGE_DEFAULTS.mode,
+    mode,
     width: Number.isFinite(stored.width) ? stored.width : WR_IMAGE_DEFAULTS.width,
     height: Number.isFinite(stored.height) ? stored.height : WR_IMAGE_DEFAULTS.height,
     steps: stored.steps != null && stored.steps !== '' ? String(stored.steps) : '',


### PR DESCRIPTION
## Summary

- The Writers Room → Config tab previously only surfaced the backend chip strip when more than one backend was configured. With a codex-only setup the strip stayed hidden and the form defaulted to Local mode, exposing knobs (Image model, Steps, Seed) the active backend would never act on.
- `readWrImageSettings` now prefers Codex when `imageGen.codex.enabled` is true, and validates the stored mode against the currently-available backends — if the stored mode is no longer reachable (codex disabled, local pythonPath cleared), it falls back to the first available backend so the form always reflects something that will actually run.
- `ImageGenSettingsRow` renders the backend chip strip whenever any backend is configured, and the field set is chosen per mode:
  - **Local**: Image model + Resolution + Steps + Seed
  - **Codex**: Resolution only (Codex picks model/steps/seed itself)
  - **External**: Resolution + Steps + Seed (the active model is set by the SD-API server)
  - Plus a one-line hint describing what the active backend controls.
- External SD-API is included alongside Local and Codex in the Writers Room. All three backends emit `started`/`progress`/`completed` via `imageGenEvents → socket.io`, which is what `SceneCard` already subscribes to — the old "External excluded" comment didn't match how the bus is wired.
- DRY'd the duplicated settings-load lines (`reloadSysSettings` + initial `useEffect`) into a shared `applyFreshSettings` helper.

## Test plan

- [ ] With Codex enabled and no local pythonPath configured: open Writers Room → Config tab. Backend chip strip shows Codex selected; only Resolution field is visible; hint mentions Codex.
- [ ] With Codex enabled AND local pythonPath set: chip strip shows both backends; switching to Local reveals Image model + Steps + Seed; switching back to Codex hides them.
- [ ] With External SD-API URL configured (and Codex+Local also configured): chip strip shows all three; External shows Resolution + Steps + Seed (no model dropdown); hint references the A1111/Forge endpoint.
- [ ] With no backend configured: warning banner still appears under the Image generation header (now mentions all three backend types).
- [ ] Stored mode = `local` from previous use, then user disables local: reopening Writers Room auto-selects the next available backend (no stale chip selection).
- [ ] Enable Codex from the Backends drawer while on the Writers Room: closing the drawer refreshes the available backends and chip strip without a page reload.