### PR TITLE
show full shell session labels instead of truncating to 140px

### DIFF
--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -781,7 +781,7 @@ export default function Shell() {
                 title={`${s.label || s.cwd || shortId(s.sessionId)} — ${formatAge(s.createdAt)} old`}
               >
                 <TerminalIcon size={12} className="shrink-0" />
-                <span>{label}</span>
+                <span className="min-w-0 break-all">{label}</span>
                 <span className="text-[10px] opacity-60 shrink-0">{formatAge(s.createdAt)}</span>
                 <button
                   onClick={(e) => { e.stopPropagation(); killOtherSession(s.sessionId); }}

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -765,7 +765,7 @@ export default function Shell() {
 
       {/* Session tabs */}
       {sessions.length > 0 && (
-        <div className="flex items-center gap-1.5 mb-3 overflow-x-auto pb-1">
+        <div className="flex flex-wrap items-center gap-1.5 mb-3 pb-1">
           {sessions.map((s) => {
             const isActive = s.sessionId === activeSessionId;
             const label = s.label || s.cwd?.split('/').pop() || shortId(s.sessionId);
@@ -781,7 +781,7 @@ export default function Shell() {
                 title={`${s.label || s.cwd || shortId(s.sessionId)} — ${formatAge(s.createdAt)} old`}
               >
                 <TerminalIcon size={12} className="shrink-0" />
-                <span className="truncate max-w-[140px]">{label}</span>
+                <span>{label}</span>
                 <span className="text-[10px] opacity-60 shrink-0">{formatAge(s.createdAt)}</span>
                 <button
                   onClick={(e) => { e.stopPropagation(); killOtherSession(s.sessionId); }}


### PR DESCRIPTION
## Summary

The Shell page truncated session names with an ellipsis (`truncate max-w-[140px]`), which hid the agent id portion of labels like `Claude Code TUI agent-ec11f870` — so the user couldn't tell sessions apart at a glance. Drop the width cap and switch the tab strip from horizontal scroll (`overflow-x-auto`) to `flex-wrap` so longer labels can flow onto multiple lines.

## Test plan

- [ ] Open the Shell page with multiple sessions (including agent TUI sessions whose labels include `<provider name> <agent id>`)
- [ ] Confirm full labels render without ellipsis
- [ ] Open with 4–5 sessions so the strip overflows the viewport width; confirm tabs wrap to a second row instead of clipping or horizontally scrolling
- [ ] On mobile width, confirm tabs wrap cleanly and remain tappable