### PR TITLE
fix: capabilities shows AI providers as unconfigured

### DIFF
--- a/server/routes/capabilities.js
+++ b/server/routes/capabilities.js
@@ -50,7 +50,7 @@ async function resolveTelegram() {
 // GET /api/capabilities — capability map of every connected system.
 router.get('/', asyncHandler(async (req, res) => {
   const [
-    providers,
+    providersData,
     providerStatuses,
     calendarAccounts,
     messageAccounts,
@@ -62,7 +62,7 @@ router.get('/', asyncHandler(async (req, res) => {
     appSummary,
     network,
   ] = await Promise.all([
-    getAllProviders().catch(() => []),
+    getAllProviders().catch(() => ({ providers: [] })),
     Promise.resolve().then(() => getAllProviderStatuses()).catch(() => ({})),
     listCalendarAccounts().catch(() => []),
     listMessageAccounts().catch(() => []),
@@ -78,7 +78,7 @@ router.get('/', asyncHandler(async (req, res) => {
   ]);
 
   const rows = buildCapabilityRows({
-    providers,
+    providers: providersData?.providers ?? [],
     providerStatuses,
     calendarAccounts,
     messageAccounts,

--- a/server/routes/capabilities.test.js
+++ b/server/routes/capabilities.test.js
@@ -6,7 +6,7 @@ import { errorMiddleware } from '../lib/errorHandler.js';
 // Stub every integration the aggregator reads. Defaults describe a fully
 // configured, healthy install; individual tests override a single source.
 vi.mock('../services/providers.js', () => ({
-  getAllProviders: vi.fn(async () => [{ id: 'p1', enabled: true }]),
+  getAllProviders: vi.fn(async () => ({ activeProvider: 'p1', providers: [{ id: 'p1', enabled: true }] })),
   getProviderById: vi.fn(async () => ({ id: 'lmstudio', endpoint: 'http://x/v1', enabled: true })),
 }));
 vi.mock('../services/providerStatus.js', () => ({


### PR DESCRIPTION
## Summary
- `getAllProviders()` returns `{ activeProvider, providers: [...] }` but the capabilities route was assigning the whole object to a variable named `providers` and passing it directly to `buildCapabilityRows`
- This caused the AI Providers capability to always appear as "No AI Providers configured" even when providers exist
- Fixed by destructuring `.providers` from the response object

## Test plan
- [x] `capabilities.test.js` passes (mock updated to match real return shape)
- [ ] Verify System Capabilities page shows configured AI providers