### PR TITLE
Let voice assistant use any AI provider/model, not just LM Studio

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -12,6 +12,7 @@ TBD
 
 ## Changed
 
+- **Pick any AI provider for the voice assistant.** The voice Chief-of-Staff's language model was hard-wired to LM Studio. Settings → Voice now has an "LLM provider" picker listing every API provider you've configured (LM Studio, Ollama, NVIDIA, or any OpenAI-compatible endpoint) plus a model dropdown with a refresh button that re-queries the provider's available models. Local-only setups are unchanged out of the box — LM Studio stays the default and the `LM_STUDIO_URL` override still applies — but you can now point voice at a hosted model. The voice service-health badge probes whichever provider you select.
 - **Consistent inline badge styling.** The peer relationship and connection-scheme labels on the Instances page and the length-target cards in the Writers Room Guide now render through one shared badge component, so their look stays consistent as more badges are added.
 
 ## Fixed

--- a/client/src/components/settings/VoiceTab.jsx
+++ b/client/src/components/settings/VoiceTab.jsx
@@ -466,6 +466,7 @@ export function VoiceTab() {
               type="button"
               onClick={() => handleRefreshModels(llmProvider)}
               disabled={refreshingModels || providerMissing || apiProviders.length === 0}
+              aria-label="Refresh model list from the provider"
               title="Refresh model list from the provider"
               className="shrink-0 p-2 rounded-lg bg-port-border hover:bg-port-border/70 text-white disabled:opacity-50"
             >

--- a/client/src/components/settings/VoiceTab.jsx
+++ b/client/src/components/settings/VoiceTab.jsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback, useId, Children, cloneElement, isValidElement } from 'react';
-import { Save, Mic, Play, Zap } from 'lucide-react';
+import { Save, Mic, Play, Zap, RefreshCw } from 'lucide-react';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
 import {
   getVoiceStatus, getVoiceConfig, updateVoiceConfig, listVoices, testTts, fetchPiperVoice,
 } from '../../services/apiVoice';
+import { getProviders, refreshProviderModels } from '../../services/apiProviders';
 import { playWav, webSpeechSupported } from '../../services/voiceClient';
 import { readVoiceHidden, writeVoiceHidden } from '../../services/voiceVisibility';
 import { formatVoiceLabel } from '../../lib/voiceLabel';
@@ -14,7 +15,7 @@ const SERVICE_LABELS = {
   'web-speech': 'Web Speech API (STT)',
   piper: 'Piper (TTS)',
   kokoro: 'Kokoro (TTS)',
-  lmstudio: 'LM Studio (LLM)',
+  llm: 'LLM provider',
 };
 
 const STT_ENGINES = [
@@ -87,6 +88,10 @@ export function VoiceTab() {
   const [previewingVoice, setPreviewingVoice] = useState(null);
   const [downloadingVoice, setDownloadingVoice] = useState(null);
   const [widgetHidden, setWidgetHidden] = useState(readVoiceHidden);
+  // API-type providers only — voice needs low-latency streaming chat, which
+  // CLI/TUI providers can't deliver.
+  const [apiProviders, setApiProviders] = useState([]);
+  const [refreshingModels, setRefreshingModels] = useState(false);
 
   const toggleWidgetHidden = (next) => {
     writeVoiceHidden(next);
@@ -109,6 +114,11 @@ export function VoiceTab() {
       .then(([config, s]) => { setCfg(config); setStatus(s); })
       .catch(() => toast.error('Failed to load voice settings'))
       .finally(() => setLoading(false));
+    // Load the provider registry for the LLM provider picker. Voice can only
+    // stream through `api`-type providers — filter the rest out here.
+    getProviders()
+      .then((data) => setApiProviders((data?.providers || []).filter((p) => p.type === 'api')))
+      .catch(() => setApiProviders([]));
   }, []);
 
   // Refetch the voice catalog whenever the user flips TTS engine so the picker
@@ -194,12 +204,42 @@ export function VoiceTab() {
     patch('stt.modelPath', `~/.portos/voice/models/${m.file}`);
   };
 
+  // Re-query the selected provider's /models endpoint and refresh the dropdown
+  // (LM Studio / Ollama load models on demand, so the list goes stale).
+  const handleRefreshModels = async (providerId) => {
+    if (!providerId || refreshingModels) return;
+    setRefreshingModels(true);
+    try {
+      const updated = await refreshProviderModels(providerId);
+      if (updated) {
+        setApiProviders((prev) => prev.map((p) => (p.id === providerId ? { ...p, models: updated.models || [] } : p)));
+        toast.success(`Refreshed models for ${updated.name || providerId} (${updated.models?.length || 0})`);
+      } else {
+        toast.error('No models returned — is the provider running and reachable?');
+      }
+    } catch (err) {
+      toast.error(`Failed to refresh models: ${err.message}`);
+    } finally {
+      setRefreshingModels(false);
+    }
+  };
+
   if (loading || !cfg) return <BrailleSpinner text="Loading voice settings" />;
 
   const engine = cfg.tts.engine || 'kokoro';
   const sttEngine = cfg.stt.engine || 'whisper';
   const activeVoice = engine === 'kokoro' ? cfg.tts.kokoro?.voice : cfg.tts.piper?.voice;
   const voices = voiceList.voices || [];
+
+  // LLM provider/model pickers. The saved provider/model are always shown even
+  // when missing from the registry (e.g. provider deleted, or a model not in
+  // the cached list) so the select never silently drops the user's choice.
+  const llmProvider = cfg.llm.provider || 'lmstudio';
+  const llmModel = cfg.llm.model || 'auto';
+  const selectedProvider = apiProviders.find((p) => p.id === llmProvider);
+  const providerMissing = apiProviders.length > 0 && !selectedProvider;
+  const providerModels = selectedProvider?.models || [];
+  const modelMissing = llmModel !== 'auto' && !providerModels.includes(llmModel);
 
   return (
     <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6 space-y-6">
@@ -208,9 +248,10 @@ export function VoiceTab() {
         <h2 className="text-lg font-semibold">Local Voice Chief-of-Staff</h2>
       </div>
       <p className="text-xs text-gray-500 -mt-4">
-        Hands-free or push-to-talk voice. Whisper (STT) + Kokoro/Piper (TTS) + LM Studio (LLM)
-        with tool calling for real actions (brain capture, goal updates, PM2 control, feed
-        digests, time, and more). Everything runs on this machine — no external API calls.
+        Hands-free or push-to-talk voice. Whisper (STT) + Kokoro/Piper (TTS) + your chosen LLM
+        provider with tool calling for real actions (brain capture, goal updates, PM2 control, feed
+        digests, time, and more). Pick a local provider (LM Studio, Ollama) to keep everything on
+        this machine, or any OpenAI-compatible API.
       </p>
 
       <label className="flex items-start gap-3 cursor-pointer">
@@ -385,13 +426,52 @@ export function VoiceTab() {
           </>
         )}
 
-        <Field label="LLM model" hint="'auto' picks the first loaded LM Studio model">
-          <input
-            type="text"
-            value={cfg.llm.model}
-            onChange={(e) => patch('llm.model', e.target.value)}
+        <Field label="LLM provider" hint="Voice streams tokens, so only API providers (LM Studio, Ollama, OpenAI-compatible) are listed. Configure providers under Settings → Providers.">
+          <select
+            value={llmProvider}
+            onChange={(e) => {
+              // Switching provider invalidates the old model — reset to 'auto'
+              // so we don't send a model the new provider doesn't have.
+              patch('llm.provider', e.target.value);
+              patch('llm.model', 'auto');
+            }}
             className={inputCls}
-          />
+          >
+            {providerMissing && (
+              <option value={llmProvider}>{llmProvider} (not an API provider)</option>
+            )}
+            {apiProviders.map((p) => (
+              <option key={p.id} value={p.id}>
+                {p.name}{p.enabled === false ? ' (disabled)' : ''}
+              </option>
+            ))}
+            {apiProviders.length === 0 && <option value={llmProvider}>{llmProvider}</option>}
+          </select>
+        </Field>
+
+        <Field label="LLM model" hint="'auto' uses the provider's default model, or the fastest loaded model for LM Studio / Ollama.">
+          <div className="flex items-center gap-2">
+            <select
+              value={llmModel}
+              onChange={(e) => patch('llm.model', e.target.value)}
+              className={`${inputCls} flex-1`}
+            >
+              <option value="auto">auto</option>
+              {modelMissing && <option value={llmModel}>{llmModel} (current)</option>}
+              {providerModels.map((m) => (
+                <option key={m} value={m}>{m}</option>
+              ))}
+            </select>
+            <button
+              type="button"
+              onClick={() => handleRefreshModels(llmProvider)}
+              disabled={refreshingModels || providerMissing || apiProviders.length === 0}
+              title="Refresh model list from the provider"
+              className="shrink-0 p-2 rounded-lg bg-port-border hover:bg-port-border/70 text-white disabled:opacity-50"
+            >
+              {refreshingModels ? <BrailleSpinner /> : <RefreshCw size={14} />}
+            </button>
+          </div>
         </Field>
 
         <label className="flex items-start gap-3 cursor-pointer md:col-span-2">

--- a/client/src/components/settings/VoiceTab.jsx
+++ b/client/src/components/settings/VoiceTab.jsx
@@ -115,8 +115,9 @@ export function VoiceTab() {
       .catch(() => toast.error('Failed to load voice settings'))
       .finally(() => setLoading(false));
     // Load the provider registry for the LLM provider picker. Voice can only
-    // stream through `api`-type providers — filter the rest out here.
-    getProviders()
+    // stream through `api`-type providers — filter the rest out here. Silent:
+    // the empty-list fallback is the error UI, so don't also pop a toast.
+    getProviders({ silent: true })
       .then((data) => setApiProviders((data?.providers || []).filter((p) => p.type === 'api')))
       .catch(() => setApiProviders([]));
   }, []);
@@ -210,13 +211,11 @@ export function VoiceTab() {
     if (!providerId || refreshingModels) return;
     setRefreshingModels(true);
     try {
-      const updated = await refreshProviderModels(providerId);
-      if (updated) {
-        setApiProviders((prev) => prev.map((p) => (p.id === providerId ? { ...p, models: updated.models || [] } : p)));
-        toast.success(`Refreshed models for ${updated.name || providerId} (${updated.models?.length || 0})`);
-      } else {
-        toast.error('No models returned — is the provider running and reachable?');
-      }
+      // Silent: the route 404s when the provider returns no models, so the
+      // catch below owns the error toast (avoids a double toast).
+      const updated = await refreshProviderModels(providerId, { silent: true });
+      setApiProviders((prev) => prev.map((p) => (p.id === providerId ? { ...p, models: updated.models || [] } : p)));
+      toast.success(`Refreshed models for ${updated.name || providerId} (${updated.models?.length || 0})`);
     } catch (err) {
       toast.error(`Failed to refresh models: ${err.message}`);
     } finally {
@@ -449,9 +448,15 @@ export function VoiceTab() {
           </select>
         </Field>
 
-        <Field label="LLM model" hint="'auto' uses the provider's default model, or the fastest loaded model for LM Studio / Ollama.">
+        {/* Not wrapped in <Field>: the select sits beside a refresh button, so
+            the id must land on the <select> (Field injects it onto the first
+            child, which would be the flex wrapper — orphaning the label). */}
+        <div className="space-y-1">
+          <label htmlFor="voice-llm-model" className="block text-sm text-gray-400">LLM model</label>
+          <p className="text-xs text-gray-500">'auto' uses the provider's default model, or the fastest loaded model for LM Studio / Ollama.</p>
           <div className="flex items-center gap-2">
             <select
+              id="voice-llm-model"
               value={llmModel}
               onChange={(e) => patch('llm.model', e.target.value)}
               className={`${inputCls} flex-1`}
@@ -473,7 +478,7 @@ export function VoiceTab() {
               {refreshingModels ? <BrailleSpinner /> : <RefreshCw size={14} />}
             </button>
           </div>
-        </Field>
+        </div>
 
         <label className="flex items-start gap-3 cursor-pointer md:col-span-2">
           <input

--- a/client/src/services/apiProviders.js
+++ b/client/src/services/apiProviders.js
@@ -1,7 +1,9 @@
 import { request } from './apiCore.js';
 
 // Providers
-export const getProviders = () => request('/providers');
+// `options` (e.g. { silent: true }) lets callers that own their own error UI
+// suppress the helper's default error toast.
+export const getProviders = (options) => request('/providers', options);
 export const getActiveProvider = () => request('/providers/active');
 export const setActiveProvider = (id) => request('/providers/active', {
   method: 'PUT',
@@ -19,7 +21,7 @@ export const updateProvider = (id, data) => request(`/providers/${id}`, {
 export const deleteProvider = (id) => request(`/providers/${id}`, { method: 'DELETE' });
 export const getSampleProviders = () => request('/providers/samples');
 export const testProvider = (id) => request(`/providers/${id}/test`, { method: 'POST' });
-export const refreshProviderModels = (id) => request(`/providers/${id}/refresh-models`, { method: 'POST' });
+export const refreshProviderModels = (id, options) => request(`/providers/${id}/refresh-models`, { method: 'POST', ...options });
 
 // Provider status (usage limits, availability)
 export const getProviderStatuses = () => request('/providers/status');

--- a/server/routes/voice.js
+++ b/server/routes/voice.js
@@ -59,7 +59,10 @@ const voiceConfigPatchSchema = z.object({
     }).partial().optional(),
   }).partial().optional(),
   llm: z.object({
-    provider: z.string().max(32).optional(),
+    // 80 matches the provider-registry id cap (providerSchema.id in
+    // aiToolkit/validation.js) — a shorter cap here would reject a valid
+    // custom provider the voice picker happily lets the user select.
+    provider: z.string().max(80).optional(),
     model: z.string().max(128).optional(),
     systemPrompt: z.string().max(4000).optional(),
     usePersonality: z.boolean().optional(),

--- a/server/services/voice/health.js
+++ b/server/services/voice/health.js
@@ -1,4 +1,4 @@
-// Voice stack health checks — whisper.cpp + LM Studio + (when active) Piper.
+// Voice stack health checks — whisper.cpp + LLM provider + (when active) Piper.
 // Kokoro runs in-process; readiness is reported via the in-memory model flag.
 
 import { existsSync } from 'fs';
@@ -6,16 +6,17 @@ import { join } from 'path';
 import { getVoiceConfig, expandPath, voiceHome } from './config.js';
 import { readyState as kokoroReadyState } from './tts-kokoro.js';
 import { which } from './bootstrap.js';
+import { resolveLlmEndpoint, authHeaders } from './llm.js';
 import { fetchWithTimeout } from '../../lib/fetchWithTimeout.js';
 
 const PROBE_TIMEOUT_MS = 1500;
 const CACHE_TTL_MS = 3000;
 let cache = null;
 
-const probe = async (url) => {
+const probe = async (url, headers = {}) => {
   const started = Date.now();
   try {
-    const res = await fetchWithTimeout(url, { method: 'GET' }, PROBE_TIMEOUT_MS);
+    const res = await fetchWithTimeout(url, { method: 'GET', headers }, PROBE_TIMEOUT_MS);
     const latencyMs = Date.now() - started;
     if (!res.ok) return { ok: false, state: 'bad_status', status: res.status, latencyMs };
     return { ok: true, status: res.status, latencyMs };
@@ -28,12 +29,13 @@ const probe = async (url) => {
   }
 };
 
-const lmStudioBaseUrl = () => (process.env.LM_STUDIO_URL || 'http://localhost:1234').replace(/\/+$/, '').replace(/\/v1$/, '');
-
 export const checkAll = async (cfg) => {
   const voice = cfg || await getVoiceConfig();
   const sttEngine = voice.stt?.engine || 'whisper';
-  const cacheKey = `${sttEngine}|${voice.tts.engine}|${voice.stt.endpoint}`;
+  const llmProvider = voice.llm?.provider || 'lmstudio';
+  // Provider is part of the cache key so switching the voice LLM provider in
+  // Settings re-probes the new endpoint instead of serving the stale badge.
+  const cacheKey = `${sttEngine}|${voice.tts.engine}|${voice.stt.endpoint}|${llmProvider}`;
   if (cache && cache.key === cacheKey && Date.now() - cache.ts < CACHE_TTL_MS) {
     // Refresh kokoro readiness on every call — it's a cheap in-memory check
     // and flips from lazy → loading → loaded mid-cache-window after first synthesis.
@@ -44,10 +46,12 @@ export const checkAll = async (cfg) => {
     return cache.value;
   }
 
-  // STT probes: whisper.cpp needs an HTTP health check; web-speech runs in
-  // the browser so just report it as available.
-  const probes = [probe(`${lmStudioBaseUrl()}/v1/models`)];
-  const labels = ['lmstudio'];
+  // LLM probe: hit the configured provider's OpenAI-compatible /models endpoint
+  // (with apiKey when the provider needs auth) so the badge reflects whichever
+  // provider drives voice, not just LM Studio.
+  const { apiBase, apiKey } = await resolveLlmEndpoint(llmProvider);
+  const probes = [probe(`${apiBase}/models`, authHeaders(apiKey))];
+  const labels = ['llm'];
   if (sttEngine === 'whisper') {
     probes.unshift(probe(voice.stt.endpoint));
     labels.unshift('whisper');

--- a/server/services/voice/llm.js
+++ b/server/services/voice/llm.js
@@ -1,7 +1,43 @@
-// LM Studio streaming chat — SSE parser yielding token deltas via onDelta callback.
+// Provider-aware streaming chat — SSE parser yielding token deltas via onDelta
+// callback. The OpenAI-compatible endpoint is resolved from the configured
+// voice provider (Settings → Voice → LLM provider) so any `api`-type provider
+// in the toolkit registry (LM Studio, Ollama, NVIDIA, OpenAI-compatible, …) can
+// drive voice. CLI/TUI providers can't stream low-latency tokens, so they're
+// not offered. Falls back to the legacy env-based LM Studio default when the
+// provider is missing, not API-type, or the toolkit hasn't warmed yet.
 
-const LM_STUDIO_BASE = () => (process.env.LM_STUDIO_URL || 'http://localhost:1234')
-  .replace(/\/+$/, '').replace(/\/v1$/, '');
+import { getProviderById } from '../providers.js';
+
+// Legacy env-based LM Studio default. Returns the OpenAI-compatible API base
+// INCLUDING the version path, so callers append `/models` / `/chat/completions`.
+const LM_STUDIO_API_BASE = () => `${(process.env.LM_STUDIO_URL || 'http://localhost:1234')
+  .replace(/\/+$/, '').replace(/\/v1$/, '')}/v1`;
+
+/**
+ * Resolve the OpenAI-compatible endpoint for the voice text LLM.
+ * @param {string} [providerId='lmstudio']
+ * @returns {Promise<{ apiBase: string, apiKey: string, defaultModel: string|null, providerName: string }>}
+ */
+export const resolveLlmEndpoint = async (providerId = 'lmstudio') => {
+  const provider = await getProviderById(providerId || 'lmstudio').catch(() => null);
+  if (provider && provider.type === 'api' && provider.endpoint) {
+    // Back-compat: the LM_STUDIO_URL env override still wins for the built-in
+    // lmstudio provider, so installs that pointed it at another host keep
+    // working without re-saving the provider endpoint.
+    const useEnv = provider.id === 'lmstudio' && process.env.LM_STUDIO_URL;
+    return {
+      apiBase: (useEnv ? LM_STUDIO_API_BASE() : provider.endpoint).replace(/\/+$/, ''),
+      apiKey: provider.apiKey || '',
+      defaultModel: provider.defaultModel || null,
+      providerName: provider.name || providerId,
+    };
+  }
+  // No usable API provider (CLI/TUI, missing, or toolkit not warmed) — fall
+  // back to the env-based LM Studio default so voice still works out of the box.
+  return { apiBase: LM_STUDIO_API_BASE(), apiKey: '', defaultModel: null, providerName: 'LM Studio' };
+};
+
+export const authHeaders = (apiKey) => (apiKey ? { Authorization: `Bearer ${apiKey}` } : {});
 
 // Approximate parameter count from LM Studio model id so 'auto' avoids a 70B
 // when smaller, faster models are available. Returns Infinity for non-matches
@@ -95,14 +131,21 @@ const sortBySpeed = (list) => list.slice().sort((a, b) => {
   return as - bs;
 });
 
-const resolveModel = async (requested, { requireTools = false } = {}) => {
-  const res = await fetch(`${LM_STUDIO_BASE()}/v1/models`, { signal: AbortSignal.timeout(5000) }).catch(() => null);
-  if (!res || !res.ok) return requested && requested !== 'auto' ? requested : null;
-  const body = await res.json();
+const resolveModel = async (requested, { apiBase, apiKey, defaultModel = null, requireTools = false } = {}) => {
+  const isAuto = !requested || requested === 'auto';
+  const res = await fetch(`${apiBase}/models`, { headers: authHeaders(apiKey), signal: AbortSignal.timeout(5000) }).catch(() => null);
+  // Models list unreachable: honor an explicit pin, else the provider's
+  // configured default, else give up (caller throws "no model available").
+  if (!res || !res.ok) return isAuto ? defaultModel : requested;
+  const body = await res.json().catch(() => null);
   const ids = (body?.data || []).map((m) => m.id);
-  if (requested && requested !== 'auto') {
-    return ids.includes(requested) ? requested : ids[0] || null;
+  if (!isAuto) {
+    return ids.includes(requested) ? requested : ids[0] || requested;
   }
+  // 'auto' — prefer the provider's configured default when set (hosted
+  // providers expose dozens of models; the latency heuristics below are tuned
+  // for a local LM Studio model list, not a hosted catalog).
+  if (defaultModel) return defaultModel;
   // 'auto' selection priority for voice latency:
   //   1. tool-capable + non-reasoning, smallest first  (the sweet spot)
   //   2. tool-capable + reasoning, smallest first      (slow but works)
@@ -218,6 +261,7 @@ export const extractInlineToolCalls = (text) => {
  *
  * @param {Array<object>} messages
  * @param {object} opts
+ * @param {string} [opts.provider='lmstudio']  voice LLM provider id (toolkit registry)
  * @param {string} [opts.model='auto']
  * @param {AbortSignal} [opts.signal]
  * @param {(delta: string) => void} [opts.onDelta]
@@ -226,14 +270,15 @@ export const extractInlineToolCalls = (text) => {
  */
 export const streamChat = async (messages, opts = {}) => {
   const resolveStart = Date.now();
-  const model = await resolveModel(opts.model, { requireTools: !!opts.tools?.length });
+  const { apiBase, apiKey, defaultModel, providerName } = await resolveLlmEndpoint(opts.provider);
+  const model = await resolveModel(opts.model, { apiBase, apiKey, defaultModel, requireTools: !!opts.tools?.length });
   const resolveMs = Date.now() - resolveStart;
-  if (!model) throw new Error('No LM Studio model available');
-  // Surface resolution time — non-trivial when LM Studio is warming up a new
+  if (!model) throw new Error(`No model available for voice provider "${providerName}"`);
+  // Surface resolution time — non-trivial when the backend is warming up a new
   // model, and invisible otherwise because we only logged once the stream
   // finished. opts.tag lets the pipeline inject its turn id for correlation.
   const tag = opts.tag ? `[${opts.tag}] ` : '';
-  console.log(`🤖 ${tag}lmstudio.resolve requested=${opts.model || 'auto'} → ${model} in ${resolveMs}ms`);
+  console.log(`🤖 ${tag}voice.llm.resolve provider=${providerName} requested=${opts.model || 'auto'} → ${model} in ${resolveMs}ms`);
 
   const started = Date.now();
   // When the resolved model has a reasoning mode, try every known disable
@@ -271,16 +316,16 @@ export const streamChat = async (messages, opts = {}) => {
   }
 
   const reqStart = Date.now();
-  const res = await fetch(`${LM_STUDIO_BASE()}/v1/chat/completions`, {
+  const res = await fetch(`${apiBase}/chat/completions`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json', ...authHeaders(apiKey) },
     body: JSON.stringify(body),
     signal: opts.signal,
   });
-  console.log(`🤖 ${tag}lmstudio.headers ${res.status} in ${Date.now() - reqStart}ms`);
+  console.log(`🤖 ${tag}voice.llm.headers ${res.status} in ${Date.now() - reqStart}ms`);
   if (!res.ok || !res.body) {
     const errBody = await res.text().catch(() => '');
-    throw new Error(`LM Studio chat failed: ${res.status} ${errBody.slice(0, 200)}`);
+    throw new Error(`${providerName} chat failed: ${res.status} ${errBody.slice(0, 200)}`);
   }
 
   const decoder = new TextDecoder();

--- a/server/services/voice/llm.test.js
+++ b/server/services/voice/llm.test.js
@@ -1,5 +1,14 @@
-import { describe, it, expect } from 'vitest';
-import { extractInlineToolCalls, isToolCapable, isReasoningModel, TOOL_CAPABLE_PATTERNS, REASONING_PATTERNS } from './llm.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the provider registry shim so resolveLlmEndpoint can be exercised
+// without warming the AI toolkit.
+vi.mock('../providers.js', () => ({ getProviderById: vi.fn() }));
+import { getProviderById } from '../providers.js';
+
+import {
+  extractInlineToolCalls, isToolCapable, isReasoningModel,
+  TOOL_CAPABLE_PATTERNS, REASONING_PATTERNS, resolveLlmEndpoint,
+} from './llm.js';
 
 describe('extractInlineToolCalls', () => {
   it('returns empty when no tag is present', () => {
@@ -157,5 +166,71 @@ describe('isReasoningModel', () => {
 
   it('exports the pattern list for introspection', () => {
     expect(Array.isArray(REASONING_PATTERNS)).toBe(true);
+  });
+});
+
+describe('resolveLlmEndpoint', () => {
+  const ORIG_ENV = process.env.LM_STUDIO_URL;
+  beforeEach(() => {
+    getProviderById.mockReset();
+    delete process.env.LM_STUDIO_URL;
+  });
+  afterEach(() => {
+    if (ORIG_ENV === undefined) delete process.env.LM_STUDIO_URL;
+    else process.env.LM_STUDIO_URL = ORIG_ENV;
+  });
+
+  it('uses an API provider endpoint, apiKey, and default model', async () => {
+    getProviderById.mockResolvedValue({
+      id: 'nvidia-kimi', type: 'api', endpoint: 'https://integrate.api.nvidia.com/v1',
+      apiKey: 'secret', defaultModel: 'moonshotai/kimi-k2-5', name: 'NVIDIA Kimi',
+    });
+    const ep = await resolveLlmEndpoint('nvidia-kimi');
+    expect(ep.apiBase).toBe('https://integrate.api.nvidia.com/v1');
+    expect(ep.apiKey).toBe('secret');
+    expect(ep.defaultModel).toBe('moonshotai/kimi-k2-5');
+    expect(ep.providerName).toBe('NVIDIA Kimi');
+  });
+
+  it('strips trailing slashes from the provider endpoint', async () => {
+    getProviderById.mockResolvedValue({ id: 'ollama', type: 'api', endpoint: 'http://localhost:11434/v1/', apiKey: '' });
+    const ep = await resolveLlmEndpoint('ollama');
+    expect(ep.apiBase).toBe('http://localhost:11434/v1');
+  });
+
+  it('falls back to the env LM Studio default for CLI/TUI providers', async () => {
+    getProviderById.mockResolvedValue({ id: 'claude-code', type: 'cli', command: 'claude' });
+    const ep = await resolveLlmEndpoint('claude-code');
+    expect(ep.apiBase).toBe('http://localhost:1234/v1');
+    expect(ep.apiKey).toBe('');
+    expect(ep.defaultModel).toBeNull();
+  });
+
+  it('falls back when the provider is missing or the lookup throws', async () => {
+    getProviderById.mockRejectedValue(Object.assign(new Error('not ready'), { code: 'AI_TOOLKIT_NOT_INITIALIZED' }));
+    const ep = await resolveLlmEndpoint('lmstudio');
+    expect(ep.apiBase).toBe('http://localhost:1234/v1');
+  });
+
+  it('honors LM_STUDIO_URL env override for the built-in lmstudio provider', async () => {
+    process.env.LM_STUDIO_URL = 'http://10.0.0.5:1234';
+    getProviderById.mockResolvedValue({ id: 'lmstudio', type: 'api', endpoint: 'http://localhost:1234/v1', apiKey: 'lm-studio' });
+    const ep = await resolveLlmEndpoint('lmstudio');
+    // Env override wins over the registry endpoint for back-compat.
+    expect(ep.apiBase).toBe('http://10.0.0.5:1234/v1');
+  });
+
+  it('does NOT apply the env override to non-lmstudio providers', async () => {
+    process.env.LM_STUDIO_URL = 'http://10.0.0.5:1234';
+    getProviderById.mockResolvedValue({ id: 'ollama', type: 'api', endpoint: 'http://localhost:11434/v1', apiKey: '' });
+    const ep = await resolveLlmEndpoint('ollama');
+    expect(ep.apiBase).toBe('http://localhost:11434/v1');
+  });
+
+  it('defaults to lmstudio when no provider id is passed', async () => {
+    getProviderById.mockResolvedValue(null);
+    const ep = await resolveLlmEndpoint();
+    expect(getProviderById).toHaveBeenCalledWith('lmstudio');
+    expect(ep.apiBase).toBe('http://localhost:1234/v1');
   });
 });

--- a/server/services/voice/pipeline.js
+++ b/server/services/voice/pipeline.js
@@ -642,8 +642,9 @@ export const runTurn = async ({ audio, text, mimeType, source, history = [], emi
     const iterStart = Date.now();
     let firstDeltaAt = null;
     let deltaChars = 0;
-    tlog(`llm.start iter=${iter + 1}/${maxIterations} model=${cfg.llm.model} tools=${toolSpecs?.length || 0} msgs=${messages.length}`);
+    tlog(`llm.start iter=${iter + 1}/${maxIterations} provider=${cfg.llm.provider || 'lmstudio'} model=${cfg.llm.model} tools=${toolSpecs?.length || 0} msgs=${messages.length}`);
     const llm = await streamChat(messages, {
+      provider: cfg.llm.provider,
       model: cfg.llm.model,
       signal,
       tools: toolSpecs,


### PR DESCRIPTION
## Summary

The voice Chief-of-Staff's language model was hard-wired to LM Studio (`server/services/voice/llm.js` fetched a fixed `LM_STUDIO_URL`/localhost:1234 endpoint). The voice config already carried `llm.provider`/`llm.model` fields and vision already resolved by provider — only the *text* LLM ignored them. This wires the text LLM (and its health probe) through the AI-toolkit provider registry and adds provider/model pickers to **Settings → Voice**.

## What changed

- **`server/services/voice/llm.js`** — new exported `resolveLlmEndpoint(providerId)` resolves the OpenAI-compatible endpoint (`endpoint` + `apiKey` + `defaultModel`) from the toolkit provider registry. `streamChat` + `resolveModel` now use it and send `Authorization` when the provider needs auth. `'auto'` prefers the provider's `defaultModel` (sensible for hosted catalogs) and otherwise keeps the existing LM Studio latency heuristics.
- **`server/services/voice/health.js`** — the LLM service badge probes whichever provider is selected (with apiKey), and the provider id is part of the health cache key so switching re-probes.
- **`server/services/voice/pipeline.js`** — passes `cfg.llm.provider` into `streamChat`.
- **`client/src/components/settings/VoiceTab.jsx`** — replaced the free-text "LLM model" input with an **LLM provider** dropdown (API-type providers only — voice streams tokens, which CLI/TUI providers can't do) plus an **LLM model** dropdown with a refresh-models button.

## Backward compatibility

Only `api`-type providers are offered (LM Studio, Ollama, NVIDIA, any OpenAI-compatible endpoint); CLI/TUI providers can't stream low-latency tokens. Existing installs are unchanged out of the box — LM Studio stays the default, the `LM_STUDIO_URL` env override still wins for the built-in `lmstudio` provider, and the fallback path keeps voice working when the toolkit isn't warmed or the provider is missing.

## Tests

- 7 new `resolveLlmEndpoint` unit tests (api provider, slash-strip, CLI/TUI fallback, missing/throwing lookup, env-override scoping, default id).
- Full voice + voice-routes + providers-routes server suites pass (390 tests); client builds + lints clean; client voice tests pass (25).

🤖 Generated with [Claude Code](https://claude.com/claude-code)