### PR TITLE
Filter Video Gen model dropdown to ltx2 runtime in a2v mode + auto-select largest model that fits

### DIFF
--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -92,6 +92,17 @@ const videoModelMemoryGb = (model) => {
   return match ? Number(match[1]) : Number.POSITIVE_INFINITY;
 };
 
+// Mode-compatibility predicate for the Model dropdown. a2v requires the
+// ltx2 runtime (dgrauet's pipeline) — the legacy mlx_video pipeline has no
+// audio-conditioned mode, and Wan/Hunyuan don't either. Server enforces the
+// same rule in routes/videoGen.js (A2V_REQUIRES_LTX2); filtering client-side
+// keeps the dropdown honest so the user can't pick a doomed model.
+const isModelAllowedForMode = (model, mode) => {
+  if (!model) return false;
+  if (mode === 'a2v') return model.runtime === 'ltx2';
+  return true;
+};
+
 const ImagePreview = ({ src, alt, label }) => (
   <div className="space-y-1">
     <img src={src} alt={alt} className="w-full max-h-48 object-contain rounded border border-port-border bg-port-bg" />
@@ -552,27 +563,64 @@ export default function VideoGen() {
       .catch((err) => toast.error(`Failed to save: ${err.message}`));
   }, [refreshStatus]);
 
-  // Validate `modelId` once models are loaded. A Remix URL (or hand-edited
-  // link) can carry a `modelId` that no longer exists in the catalog — that
-  // leaves <ModelSelect> showing nothing and `currentModel` undefined, which
-  // then breaks resolution suggestions and submit. When we detect that, fall
-  // back to status.defaultModel (preferred) or the first available model so
-  // the form stays in a usable state.
+  // Models filtered to the current mode's compatibility. Drives the
+  // <ModelSelect> options and the auto-select fallback so the user can't
+  // land on a model the server will reject.
+  const visibleModels = useMemo(
+    () => models.filter((m) => isModelAllowedForMode(m, mode)),
+    [models, mode],
+  );
+
+  // Validate `modelId` once models are loaded. Two failure modes covered:
+  //  1. A Remix URL (or hand-edited link) carries a `modelId` that no longer
+  //     exists in the catalog — <ModelSelect> shows nothing and `currentModel`
+  //     is undefined, which then breaks resolution suggestions and submit.
+  //  2. The picked model exists but isn't compatible with the current mode
+  //     (e.g. switching into a2v while an mlx_video model is selected). The
+  //     server would 400 on submit; we proactively swap to a compatible model.
+  // a2v fallback preference: highest-memory model that fits this machine
+  // (leaving headroom for the OS + text encoder) > the largest if none fit.
+  // Other modes: status.defaultModel (if compatible) > first compatible model.
   useEffect(() => {
     if (!modelId || models.length === 0) return;
-    if (models.some((m) => m.id === modelId)) return;
-    const fallback = status?.defaultModel || models[0]?.id || '';
-    if (fallback) {
-      // Notify the user once per unique stale id so a Remix of an uninstalled
-      // model doesn't silently drop to default. staleModelToastRef prevents
-      // re-firing when the effect re-runs with the same stale modelId.
-      if (staleModelToastRef.current !== modelId) {
-        staleModelToastRef.current = modelId;
-        toast(`Original model "${modelId}" is no longer available — using default`);
+    const current = models.find((m) => m.id === modelId);
+    const currentCompatible = current && isModelAllowedForMode(current, mode);
+    if (currentCompatible) return;
+    let fallback = '';
+    if (mode === 'a2v') {
+      // Reserve ~16 GB headroom for the OS + text encoder + working set.
+      // Anything that fits within `systemMemoryGb - reserveGb` is "runnable"
+      // on this machine; among those, pick the largest (highest quality).
+      // If nothing fits (constrained box), fall back to the smallest model
+      // so the user can at least try, and the install banner / OOM surfaces
+      // the real constraint instead of a silent dropdown change.
+      const reserveGb = 16;
+      const budget = status?.systemMemoryGb
+        ? Math.max(0, status.systemMemoryGb - reserveGb)
+        : Number.POSITIVE_INFINITY;
+      const sortedDesc = [...visibleModels].sort(
+        (a, b) => videoModelMemoryGb(b) - videoModelMemoryGb(a),
+      );
+      const fits = sortedDesc.find((m) => videoModelMemoryGb(m) <= budget);
+      fallback = (fits || sortedDesc[sortedDesc.length - 1])?.id || '';
+    } else {
+      const defaultModel = models.find((m) => m.id === status?.defaultModel);
+      if (defaultModel && isModelAllowedForMode(defaultModel, mode)) {
+        fallback = defaultModel.id;
+      } else {
+        fallback = visibleModels[0]?.id || status?.defaultModel || models[0]?.id || '';
       }
-      setModelId(fallback);
     }
-  }, [modelId, models, status?.defaultModel]);
+    if (!fallback || fallback === modelId) return;
+    // Toast only for the stale-id case (model removed from catalog). The
+    // mode-incompatibility swap is expected behavior after a mode change —
+    // no need to surface it.
+    if (!current && staleModelToastRef.current !== modelId) {
+      staleModelToastRef.current = modelId;
+      toast(`Original model "${modelId}" is no longer available — using default`);
+    }
+    setModelId(fallback);
+  }, [modelId, models, status?.defaultModel, status?.systemMemoryGb, mode, visibleModels]);
 
   const currentModel = models.find((m) => m.id === modelId);
 
@@ -693,16 +741,8 @@ export default function VideoGen() {
       setDisableAudio(false);
       setNoMusic(false);
       setChunks(1);
-      // Auto-select the lowest-memory ltx2-runtime model so the user
-      // doesn't land on a blocked state. Only fires when the current model
-      // can't handle a2v — if they already have a dgrauet model selected
-      // we leave it alone.
-      if (currentModel?.runtime !== 'ltx2') {
-        const ltx2Model = models
-          .filter((m) => m.runtime === 'ltx2')
-          .sort((a, b) => videoModelMemoryGb(a) - videoModelMemoryGb(b))[0];
-        if (ltx2Model) setModelId(ltx2Model.id);
-      }
+      // Auto-select to a compatible ltx2-runtime model is handled by the
+      // modelId-validation effect, which re-runs on every mode change.
     }
   };
 
@@ -1290,9 +1330,12 @@ export default function VideoGen() {
               <p className="text-[10px] text-gray-500 leading-snug">
                 Audio length should match {`${(numFrames / fps).toFixed(1)}s`} (frames ÷ fps). Longer clips are trimmed to fit; shorter clips fail.
               </p>
-              {currentModel?.runtime !== 'ltx2' && (
+              {visibleModels.length === 0 && (
                 <p className="text-[11px] text-port-warning">
-                  a2v requires an ltx2-runtime model — switch the Model dropdown to one of the dgrauet entries.
+                  a2v requires an ltx2-runtime model, but none are installed. Add a dgrauet entry to{' '}
+                  <code>data/media-models.json</code> (or restore <code>ltx23_dgrauet_q4</code> / <code>_q8</code>{' '}
+                  from the built-in defaults), then provision the runtime via{' '}
+                  <code>INSTALL_LTX2=1 bash scripts/setup-image-video.sh</code>.
                 </p>
               )}
             </div>
@@ -1337,7 +1380,7 @@ export default function VideoGen() {
               <div className="col-span-2 sm:col-span-3">
                 <label className="block text-xs font-medium text-gray-400 mb-1">Model</label>
                 <ModelSelect
-                  models={models}
+                  models={visibleModels}
                   value={modelId}
                   onChange={(e) => { setModelId(e.target.value); setSteps(''); setGuidanceScale(''); }}
                 />

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -595,7 +595,12 @@ export default function VideoGen() {
       // so the user can at least try, and the install banner / OOM surfaces
       // the real constraint instead of a silent dropdown change.
       const reserveGb = 16;
-      const budget = status?.systemMemoryGb
+      // typeof === 'number' (not `status?.systemMemoryGb ? ...`) so a server
+      // legitimately reporting a tiny number (0 GB after rounding on a
+      // sub-GB box) flows through the `fits` check and lands on the
+      // smallest model. The truthiness shortcut would collapse 0 with
+      // "absent" and pick the LARGEST model on a tiny machine.
+      const budget = typeof status?.systemMemoryGb === 'number'
         ? Math.max(0, status.systemMemoryGb - reserveGb)
         : Number.POSITIVE_INFINITY;
       const sortedDesc = [...visibleModels].sort(
@@ -614,10 +619,13 @@ export default function VideoGen() {
     if (!fallback || fallback === modelId) return;
     // Toast only for the stale-id case (model removed from catalog). The
     // mode-incompatibility swap is expected behavior after a mode change —
-    // no need to surface it.
+    // no need to surface it. Name the destination model so users on a2v
+    // don't think they landed on `status.defaultModel` (they may not have —
+    // a2v picks the largest-fits model, which is often a dgrauet entry).
     if (!current && staleModelToastRef.current !== modelId) {
       staleModelToastRef.current = modelId;
-      toast(`Original model "${modelId}" is no longer available — using default`);
+      const fallbackName = models.find((m) => m.id === fallback)?.name || fallback;
+      toast(`Original model "${modelId}" is no longer available — switched to "${fallbackName}"`);
     }
     setModelId(fallback);
   }, [modelId, models, status?.defaultModel, status?.systemMemoryGb, mode, visibleModels]);

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -12,6 +12,7 @@ import { copyFile, unlink } from 'fs/promises';
 import { randomUUID } from 'crypto';
 import { join, extname } from 'path';
 import { spawn } from 'child_process';
+import os from 'os';
 import { z } from 'zod';
 import { asyncHandler, ServerError, failValidation } from '../lib/errorHandler.js';
 import { uploadFields } from '../lib/multipart.js';
@@ -167,6 +168,11 @@ router.get('/status', asyncHandler(async (_req, res) => {
     // Authoritative list of bring-your-own-venv runtimes — lets the client
     // gate the install-banner probe without hardcoding the same Set.
     byovRuntimes: Object.keys(BYOV_RUNTIME_INFO),
+    // Total system memory in GB — the client uses this to auto-select the
+    // highest-memory mode-compatible model that fits on this machine.
+    // Rounded to nearest GB; sub-GB precision isn't useful for the
+    // model-size comparison and reads more cleanly in the UI.
+    systemMemoryGb: Math.round(os.totalmem() / 1024 ** 3),
   });
 }));
 

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -182,6 +182,11 @@ describe('videoGen routes', () => {
       expect(r.body.pythonPath).toBe('/usr/bin/python3');
       expect(r.body.missingPackages).toEqual([]);
       expect(r.body.defaultModel).toBe('ltx2_unified');
+      // systemMemoryGb drives the client's a2v auto-select (largest model
+      // that fits in `systemMemoryGb - 16 GB` headroom). Pin the field's
+      // presence + type so a future accidental removal is caught here.
+      expect(typeof r.body.systemMemoryGb).toBe('number');
+      expect(r.body.systemMemoryGb).toBeGreaterThan(0);
     });
 
     it('reports disconnected with reason + missingPackages when packages fail to import', async () => {


### PR DESCRIPTION
## Summary

- The Audio→Video mode previously showed every video model in the dropdown and rendered a warning telling the user to "switch the Model dropdown to one of the dgrauet entries" — which on installs where the dgrauet entries had been pruned from `data/media-models.json` referred to options that weren't in the list. The server enforces `A2V_REQUIRES_LTX2` and would 400 on submit, so filtering client-side keeps the dropdown honest.
- `<ModelSelect>` for a2v now receives only `runtime === 'ltx2'` models (via a `visibleModels` memo). The model-validation `useEffect` now also checks mode-compatibility, so switching to a2v while an mlx_video model was selected auto-swaps to a compatible model on the next render. The previous bespoke auto-select inside `handleModeChange` was removed — one source of truth.
- For a2v, auto-select picks the **highest-memory** compatible model that fits within `systemMemoryGb - 16 GB` headroom (OS + text encoder + working set). On a 128 GB box this lands on `ltx23_dgrauet_q8` (~25 GB); on a 32 GB box it lands on `ltx23_dgrauet_q4` (~16 GB) — Q8 wouldn't fit the budget. If nothing fits, falls back to the smallest model so the user can still try and let the install banner / OOM surface the constraint.
- Server `/api/video-gen/status` now returns `systemMemoryGb` (rounded `os.totalmem()`) so the client can make the runnable-size decision. Additive, optional field — older clients ignore it; the new client gracefully falls back to `POSITIVE_INFINITY` budget when the field is absent.
- The inline warning under the audio uploader now only fires when `visibleModels.length === 0` — i.e. no ltx2 models are installed at all — and the copy explains how to add a dgrauet entry to `data/media-models.json` and provision the runtime with `INSTALL_LTX2=1 bash scripts/setup-image-video.sh`.

## Test plan

- [ ] Switch Video Gen mode to **Audio**. The Model dropdown only lists dgrauet (`runtime: 'ltx2'`) entries.
- [ ] Switch back to **Text** / **Image** / **FFLF** / **Extend**. Full model list reappears.
- [ ] On a machine with both `ltx23_dgrauet_q4` and `ltx23_dgrauet_q8` installed and ≥ 48 GB RAM, switching into a2v auto-selects Q8 (highest that fits).
- [ ] On a machine with both installed but < ~41 GB RAM (16 GB reserve + 25 GB model), auto-select lands on Q4.
- [ ] When `data/media-models.json` contains no `runtime: 'ltx2'` entries, switching to a2v shows the new "no a2v-compatible models installed" warning and the dropdown is empty.
- [ ] Connect a new client to an older server that doesn't return `systemMemoryGb` — auto-select still picks the largest dgrauet model (infinite budget fallback).
- [ ] `GET /api/video-gen/status` includes `systemMemoryGb: <integer>` matching `os.totalmem()` rounded to GB.