### PR TITLE
fix invisible ToggleSwitch off-state on day themes

### DIFF
--- a/client/src/components/ToggleSwitch.jsx
+++ b/client/src/components/ToggleSwitch.jsx
@@ -21,7 +21,7 @@ export default function ToggleSwitch({ enabled, onChange, disabled, ariaLabel, s
     }`} />
   );
   const trackClass = `relative inline-flex ${s.track} items-center rounded-full transition-colors shrink-0 ${
-    enabled ? activeColor : 'bg-gray-600'
+    enabled ? activeColor : 'port-toggle-track-off'
   } border border-port-border/60 shadow-sm ${disabled ? 'opacity-50' : ''} ${className}`;
 
   // Decorative mode renders as a <span> so it can sit inside another <button>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -508,6 +508,18 @@ html[data-port-theme-mode="day"] :is(.bg-gray-700, .bg-zinc-700, .bg-neutral-700
   background-color: var(--port-control-bg) !important;
 }
 
+/* Toggle off-state track. The global bg-gray-600 → --port-control-bg remap
+   above turns ToggleSwitch's inactive track into the same cream as the page,
+   making the toggle (and its white knob) nearly invisible on light themes
+   like Phosphor Paper. This class keeps the dark-theme gray-600 look while
+   swapping to a contrasting muted tone in day mode. */
+.port-toggle-track-off {
+  background-color: rgb(75 85 99);
+}
+html[data-port-theme-mode="day"] .port-toggle-track-off {
+  background-color: rgb(var(--port-text-muted) / 0.7) !important;
+}
+
 html[data-port-theme-mode="day"] :is(.bg-gray-500, .bg-zinc-500, .bg-neutral-500, .bg-slate-500) {
   background-color: var(--port-control-bg-hover) !important;
 }


### PR DESCRIPTION
## Summary

On Phosphor Paper (and other day-mode themes), `ToggleSwitch` was nearly
invisible in its off state. The component used `bg-gray-600` for the
inactive track, which the global day-mode remap in `index.css` rewrites
to `--port-control-bg` — the same cream as the page background. The
white knob on a cream track was indistinguishable from the surroundings.

The fix introduces a dedicated `.port-toggle-track-off` utility:

- Dark themes: solid `rgb(75 85 99)` (identical to the previous
  `bg-gray-600` look — no visual regression).
- Day themes: `rgb(var(--port-text-muted) / 0.7)` — every day theme's
  `--port-text-muted` is a dark zinc/slate tone, so the track now reads
  as a clear muted-dark shape against cream/white, and the white knob
  has high contrast.

## Test plan

- [ ] Open Settings → Backup on the Phosphor Paper theme; confirm the
      Default Exclusions toggle row tracks are clearly visible in both
      on and off states.
- [ ] Switch through Classic Noon, Lumen Glass Day, and Drafting Paper
      and re-verify.
- [ ] Switch to a dark theme (Classic Midnight, Black ICE Terminal,
      Blueprint Ops) and confirm the toggle off-state still looks
      identical to before (medium-dark gray track with a white knob).