### PR TITLE
fix(catalog): stop generating embeddings on scrap create

### DIFF
--- a/server/routes/catalog.js
+++ b/server/routes/catalog.js
@@ -19,7 +19,7 @@ import {
   catalogEmbeddingsBackfillSchema,
   catalogMigrationRerunSchema,
 } from '../lib/catalogValidation.js';
-import { embedText, embedIngredient, embedBatch, ingredientEmbedSeed } from '../services/embeddings.js';
+import { embedIngredient, embedBatch, ingredientEmbedSeed } from '../services/embeddings.js';
 import { extractIngredients } from '../services/catalogExtraction.js';
 import { migrateBibleToCatalog } from '../scripts/migrateBibleToCatalog.js';
 import { PORTOS_SCHEMA_VERSIONS } from '../lib/schemaVersions.js';
@@ -45,14 +45,15 @@ router.get('/scraps/:id', asyncHandler(async (req, res) => {
 
 router.post('/scraps', asyncHandler(async (req, res) => {
   validateRequest(catalogScrapCreateSchema, req.body);
-  const embedded = await embedText(req.body.rawText).catch(() => null);
+  // Scrap embedding was previously generated on create but never read — there is no
+  // semantic-search route or "find similar scraps" UI. Removed pending a search endpoint
+  // that justifies the LLM round-trip; the catalog_scraps.embedding column remains for
+  // future backfill (and peer sync still accepts embeddings from peers that have them).
   const scrap = await catalogDB.createScrap({
     title: req.body.title,
     rawText: req.body.rawText,
     sourceKind: req.body.sourceKind,
     metadata: req.body.metadata,
-    embedding: embedded?.success ? embedded.embedding : null,
-    embeddingModel: embedded?.success ? embedded.model : null,
   });
   res.status(201).json({ scrap });
 }));


### PR DESCRIPTION
## Summary

Resolves PLAN item `[catalog-scrap-embedding-or-search]` by **removing the LLM embedding round-trip on scrap create**, keeping the column for future use.

Every `POST /api/catalog/scraps` fired an `embedText` call and persisted a 768-dim vector to `catalog_scraps.embedding`, but **nothing reads that column** — there is no semantic-search route, no "find similar scraps" UI. Every paste paid an LLM round-trip (~6KB stored per scrap) for zero current search benefit.

## Decision: remove the round-trip, keep the column

- **DDL is unchanged.** `catalog_scraps.embedding` stays — a future `[catalog-scrap-search]` work item can backfill it on demand.
- **`createScrap()` signature is unchanged.** `embedding` / `embeddingModel` are still optional parameters with default `null`, so the peer-sync ingest path (`upsertScrapFromPeer`) keeps working — peers that *do* have embeddings can still hand them over.
- **`embedText` stays exported** from `server/services/embeddings.js` because the ingredient path (`embedIngredient`, `embedBatch`, `ingredientEmbedSeed`) still uses it. Only the import in `server/routes/catalog.js` was trimmed since `embedText` had only one caller there.
- **No schema-version bump.** This is purely a request-time behavior change; on-disk shape is unchanged.

## Test plan

- [x] `cd server && npm test` — 370 files, 8204 pass, 7 skipped, 0 fail.
- [x] No existing tests assert embed-on-create behavior (the path was minimally covered); nothing to update.