### PR TITLE
fix(catalog): index physicalDescription, personality, role, motivations, significance in search_tsv

### DIFF
--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -155,14 +155,31 @@ export async function ensureSchema() {
       deleted_at TIMESTAMPTZ,
       sync_sequence BIGSERIAL
     )`,
-    // Postgres can't ALTER the expression of a STORED generated column, so the
-    // FTS column is DROPped and re-ADDed on every boot. The whole catalogDDL
-    // block is idempotent: on a fresh install the DROP is a no-op (column
-    // didn't exist) and ADD creates it; on an existing v1 install the DROP
-    // removes the narrow expression and ADD installs the expanded one that
-    // also indexes physicalDescription / personality / role / motivations /
-    // significance. Bumped PORTOS_SCHEMA_VERSIONS.catalog → 2 in lockstep.
-    `ALTER TABLE catalog_ingredients DROP COLUMN IF EXISTS search_tsv`,
+    // Postgres can't ALTER the expression of a STORED generated column, so when
+    // the v2 expansion needs to land we DROP and re-ADD `search_tsv`. The
+    // conditional below (executed after the table CREATE, before the
+    // ADD-only fallback) inspects pg_attrdef and rewrites the column ONLY
+    // when the current generation expression is missing a v2-only field
+    // (`physicalDescription`). That keeps boot O(1) on already-v2 installs —
+    // an unconditional DROP+ADD would AccessExclusive-lock the table, rewrite
+    // every row, and rebuild the GIN index on every server start.
+    // Fresh installs (no column yet) fall through to the ADD IF NOT EXISTS
+    // below and skip the DROP entirely.
+    `DO $$
+       DECLARE
+         expr TEXT;
+       BEGIN
+         SELECT pg_get_expr(d.adbin, d.adrelid)
+           INTO expr
+           FROM pg_attribute a
+           JOIN pg_attrdef  d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+          WHERE a.attrelid = 'catalog_ingredients'::regclass
+            AND a.attname  = 'search_tsv'
+            AND a.attgenerated = 's';
+         IF expr IS NOT NULL AND position('physicalDescription' in expr) = 0 THEN
+           EXECUTE 'ALTER TABLE catalog_ingredients DROP COLUMN search_tsv';
+         END IF;
+       END$$`,
     `ALTER TABLE catalog_ingredients ADD COLUMN IF NOT EXISTS search_tsv tsvector
        GENERATED ALWAYS AS (
          setweight(to_tsvector('english', coalesce(name, '')), 'A') ||

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -148,15 +148,6 @@ export async function ensureSchema() {
       tags TEXT[] DEFAULT '{}',
       embedding vector(768),
       embedding_model VARCHAR(100),
-      search_tsv tsvector GENERATED ALWAYS AS (
-        setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
-        setweight(to_tsvector('english',
-          coalesce(payload->>'description', '') || ' ' ||
-          coalesce(payload->>'notes', '') || ' ' ||
-          coalesce(payload->>'background', '') || ' ' ||
-          coalesce(payload->>'summary', '')
-        ), 'B')
-      ) STORED,
       origin_instance_id VARCHAR(36),
       created_at TIMESTAMPTZ DEFAULT NOW(),
       updated_at TIMESTAMPTZ DEFAULT NOW(),
@@ -164,6 +155,29 @@ export async function ensureSchema() {
       deleted_at TIMESTAMPTZ,
       sync_sequence BIGSERIAL
     )`,
+    // Postgres can't ALTER the expression of a STORED generated column, so the
+    // FTS column is DROPped and re-ADDed on every boot. The whole catalogDDL
+    // block is idempotent: on a fresh install the DROP is a no-op (column
+    // didn't exist) and ADD creates it; on an existing v1 install the DROP
+    // removes the narrow expression and ADD installs the expanded one that
+    // also indexes physicalDescription / personality / role / motivations /
+    // significance. Bumped PORTOS_SCHEMA_VERSIONS.catalog → 2 in lockstep.
+    `ALTER TABLE catalog_ingredients DROP COLUMN IF EXISTS search_tsv`,
+    `ALTER TABLE catalog_ingredients ADD COLUMN IF NOT EXISTS search_tsv tsvector
+       GENERATED ALWAYS AS (
+         setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
+         setweight(to_tsvector('english',
+           coalesce(payload->>'description', '') || ' ' ||
+           coalesce(payload->>'physicalDescription', '') || ' ' ||
+           coalesce(payload->>'personality', '') || ' ' ||
+           coalesce(payload->>'background', '') || ' ' ||
+           coalesce(payload->>'summary', '') || ' ' ||
+           coalesce(payload->>'notes', '') || ' ' ||
+           coalesce(payload->>'role', '') || ' ' ||
+           coalesce(payload->>'motivations', '') || ' ' ||
+           coalesce(payload->>'significance', '')
+         ), 'B')
+       ) STORED`,
     `CREATE INDEX IF NOT EXISTS idx_catalog_ing_embedding
        ON catalog_ingredients USING hnsw (embedding vector_cosine_ops)
        WITH (m = 16, ef_construction = 64)`,

--- a/server/lib/schemaVersions.js
+++ b/server/lib/schemaVersions.js
@@ -47,12 +47,21 @@ export const PORTOS_SCHEMA_VERSIONS = Object.freeze({
   // pauses with old peers; issues/universes keep flowing.
   pipelineSeries: 2,
   mediaCollections: 1,
-  // v1 = creative ingredients catalog (Postgres tables: catalog_scraps,
-  // catalog_ingredients, catalog_ingredient_sources, catalog_ingredient_refs).
-  // Per-category gate so a new peer can sync its catalog independently of
-  // whether other categories are version-locked. `cat-ingredient` and
-  // `cat-scrap` record kinds map back here via RECORD_KIND_SCHEMA_CATEGORIES.
-  catalog: 1,
+  // v2 = `catalog_ingredients.search_tsv` expanded to also index the
+  // character canon fields (physicalDescription, personality) and the
+  // type-specific role/motivations/significance fields, so bible-promoted
+  // characters become searchable on their main narrative text. The schema
+  // is a DROP+re-ADD of the STORED generated column (Postgres can't ALTER
+  // its expression); applied in lockstep by `ensureSchema` in
+  // server/lib/db.js. Per-category gate so a new peer can sync its catalog
+  // independently of whether other categories are version-locked. An older
+  // v1 peer pushing to a v2 receiver is sender-behind on `catalog` (not
+  // ahead), so the receiver still accepts and re-derives `search_tsv`
+  // locally via the STORED expression. A v2 peer pushing to a v1 receiver
+  // is sender-ahead and gets 412 — the older code can't index the new
+  // payload fields. `cat-ingredient` and `cat-scrap` record kinds map back
+  // here via RECORD_KIND_SCHEMA_CATEGORIES.
+  catalog: 2,
   // NOTE: `videoHistory` is intentionally NOT listed here. The version gate
   // rejects the ENTIRE snapshot/push payload on ANY ahead-mismatch (the
   // comparator walks the union of keys), so declaring a brand-new key would

--- a/server/scripts/init-db.sql
+++ b/server/scripts/init-db.sql
@@ -172,14 +172,30 @@ CREATE TABLE IF NOT EXISTS catalog_ingredients (
 -- fields (description, physicalDescription, personality, background, summary,
 -- notes) plus the role/motivations/significance type-specific fields fall under
 -- B. Generated/stored so the GIN index stays fresh without trigger code.
--- Postgres can't ALTER the expression of a STORED generated column, so
--- ensureSchema (server/lib/db.js) DROPs + re-ADDs the column on every boot —
--- mirrored here as DROP IF EXISTS + ADD IF NOT EXISTS so a fresh-install run
--- of this script produces the same end-state as an existing-install boot
--- through ensureSchema. PORTOS_SCHEMA_VERSIONS.catalog is bumped to 2 in
--- lockstep so older peers can't push pre-expansion-shape rows that would
--- mismatch the indexed expression.
-ALTER TABLE catalog_ingredients DROP COLUMN IF EXISTS search_tsv;
+-- Postgres can't ALTER the expression of a STORED generated column, so when
+-- the v2 expansion needs to land we DROP and re-ADD the column. The DO block
+-- below inspects pg_attrdef and only drops when the existing expression is
+-- missing a v2-only field (`physicalDescription`) — fresh runs of this script
+-- skip the drop entirely (column absent), already-v2 installs skip it too, and
+-- only an upgrading v1 install pays the table-rewrite cost. ensureSchema in
+-- server/lib/db.js mirrors the same gate. PORTOS_SCHEMA_VERSIONS.catalog is
+-- bumped to 2 in lockstep so older peers can't push pre-expansion-shape rows
+-- that would mismatch the indexed expression.
+DO $$
+  DECLARE
+    expr TEXT;
+  BEGIN
+    SELECT pg_get_expr(d.adbin, d.adrelid)
+      INTO expr
+      FROM pg_attribute a
+      JOIN pg_attrdef  d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+     WHERE a.attrelid = 'catalog_ingredients'::regclass
+       AND a.attname  = 'search_tsv'
+       AND a.attgenerated = 's';
+    IF expr IS NOT NULL AND position('physicalDescription' in expr) = 0 THEN
+      EXECUTE 'ALTER TABLE catalog_ingredients DROP COLUMN search_tsv';
+    END IF;
+  END$$;
 ALTER TABLE catalog_ingredients ADD COLUMN IF NOT EXISTS search_tsv tsvector
   GENERATED ALWAYS AS (
     setweight(to_tsvector('english', coalesce(name, '')), 'A') ||

--- a/server/scripts/init-db.sql
+++ b/server/scripts/init-db.sql
@@ -161,18 +161,6 @@ CREATE TABLE IF NOT EXISTS catalog_ingredients (
   tags TEXT[] DEFAULT '{}',
   embedding vector(768),
   embedding_model VARCHAR(100),
-  -- Weighted FTS column. Name carries the most weight (A); description/notes/
-  -- background fall under B. Generated/stored so the GIN index stays fresh
-  -- without trigger code.
-  search_tsv tsvector GENERATED ALWAYS AS (
-    setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
-    setweight(to_tsvector('english',
-      coalesce(payload->>'description', '') || ' ' ||
-      coalesce(payload->>'notes', '') || ' ' ||
-      coalesce(payload->>'background', '') || ' ' ||
-      coalesce(payload->>'summary', '')
-    ), 'B')
-  ) STORED,
   origin_instance_id VARCHAR(36),
   created_at TIMESTAMPTZ DEFAULT NOW(),
   updated_at TIMESTAMPTZ DEFAULT NOW(),
@@ -180,6 +168,33 @@ CREATE TABLE IF NOT EXISTS catalog_ingredients (
   deleted_at TIMESTAMPTZ,
   sync_sequence BIGSERIAL
 );
+-- Weighted FTS column. Name carries the most weight (A); the character canon
+-- fields (description, physicalDescription, personality, background, summary,
+-- notes) plus the role/motivations/significance type-specific fields fall under
+-- B. Generated/stored so the GIN index stays fresh without trigger code.
+-- Postgres can't ALTER the expression of a STORED generated column, so
+-- ensureSchema (server/lib/db.js) DROPs + re-ADDs the column on every boot —
+-- mirrored here as DROP IF EXISTS + ADD IF NOT EXISTS so a fresh-install run
+-- of this script produces the same end-state as an existing-install boot
+-- through ensureSchema. PORTOS_SCHEMA_VERSIONS.catalog is bumped to 2 in
+-- lockstep so older peers can't push pre-expansion-shape rows that would
+-- mismatch the indexed expression.
+ALTER TABLE catalog_ingredients DROP COLUMN IF EXISTS search_tsv;
+ALTER TABLE catalog_ingredients ADD COLUMN IF NOT EXISTS search_tsv tsvector
+  GENERATED ALWAYS AS (
+    setweight(to_tsvector('english', coalesce(name, '')), 'A') ||
+    setweight(to_tsvector('english',
+      coalesce(payload->>'description', '') || ' ' ||
+      coalesce(payload->>'physicalDescription', '') || ' ' ||
+      coalesce(payload->>'personality', '') || ' ' ||
+      coalesce(payload->>'background', '') || ' ' ||
+      coalesce(payload->>'summary', '') || ' ' ||
+      coalesce(payload->>'notes', '') || ' ' ||
+      coalesce(payload->>'role', '') || ' ' ||
+      coalesce(payload->>'motivations', '') || ' ' ||
+      coalesce(payload->>'significance', '')
+    ), 'B')
+  ) STORED;
 CREATE INDEX IF NOT EXISTS idx_catalog_ing_embedding
   ON catalog_ingredients USING hnsw (embedding vector_cosine_ops)
   WITH (m = 16, ef_construction = 64);


### PR DESCRIPTION
## Summary

Catalog full-text search (`catalog_ingredients.search_tsv`) currently misses bible-promoted characters' main narrative text. The STORED generated `tsvector` only indexes `name` (weight A) and `payload->>description|notes|background|summary` (weight B), so a search for "tall" or "introverted" against a character whose data lives in `payload.physicalDescription` and `payload.personality` returns no hits.

This PR expands the indexed expression to cover the character canon fields plus the type-specific `role`/`motivations`/`significance` fields used by place/object/concept payloads:

- `payload->>'description'`
- `payload->>'physicalDescription'` (new)
- `payload->>'personality'` (new)
- `payload->>'background'`
- `payload->>'summary'`
- `payload->>'notes'`
- `payload->>'role'` (new)
- `payload->>'motivations'` (new)
- `payload->>'significance'` (new)

### Schema migration

Postgres can't `ALTER` the expression of a `STORED` generated column, so the column is `DROP`ped and re-`ADD`ed. Done inside the existing `catalogDDL` block in `server/lib/db.js`, which already runs on every boot (PR #542 made it unconditional). The whole block is idempotent: a fresh install's `DROP IF EXISTS` is a no-op (column didn't exist) and `ADD IF NOT EXISTS` creates it; an existing v1 install's `DROP IF EXISTS` removes the narrow expression and `ADD IF NOT EXISTS` installs the expanded one. The expanded `idx_catalog_ing_fts` GIN index rebuilds automatically against the re-added column.

Mirrored in `server/scripts/init-db.sql` so fresh-install schemas land in the same end state as `ensureSchema` would produce (matches the `[catalog-ddl-drift-test]` PLAN invariant).

### Wire-protocol version bump

`PORTOS_SCHEMA_VERSIONS.catalog` bumped from `1` → `2`. The existing per-category gate in `server/services/catalogSync.js` `applyRemoteChanges` enforces the contract:

- A v1 peer pushing into a v2 receiver is sender-behind on `catalog` (not ahead) → accepted. The v2 receiver re-derives `search_tsv` locally via the STORED expression.
- A v2 peer pushing into a v1 receiver is sender-ahead → 412 `CATALOG_SCHEMA_VERSION_AHEAD`, preventing pre-expansion-shape rows from mismatching the indexed expression on the older install.

PLAN entry: `[catalog-fts-character-fields]`.

## Test plan

- [x] `cd server && npm test` — 8204 pass / 7 skip / 0 fail
- [x] No test pinned `PORTOS_SCHEMA_VERSIONS.catalog === 1` — the live registry isn't asserted at a specific catalog value, so no test update needed
- [x] `server/lib/db.js` catalogDDL stays idempotent (DROP IF EXISTS + ADD IF NOT EXISTS)
- [x] `server/scripts/init-db.sql` mirrors `ensureSchema` (no drift)