### PR TITLE
Add manuscript editor provider selector, editorial review button, and series link

### DIFF
--- a/client/src/pages/PipelineManuscriptEditor.jsx
+++ b/client/src/pages/PipelineManuscriptEditor.jsx
@@ -20,15 +20,17 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import {
-  ArrowLeft, Loader2, Sparkles, Check, X, CornerDownRight, FileText, ChevronDown, ChevronRight, Star, History, RotateCcw,
+  ArrowLeft, Loader2, Sparkles, Check, X, CornerDownRight, FileText, ChevronDown, ChevronRight, Star, History, RotateCcw, ClipboardCheck,
 } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import { useAsyncAction } from '../hooks/useAsyncAction';
+import useProviderModels from '../hooks/useProviderModels';
 import { timeAgo } from '../utils/formatters';
 import {
   getPipelineSeries, updatePipelineSeries, getPipelineManuscript, getPipelineManuscriptReview,
   patchPipelineManuscriptComment, savePipelineManuscriptSection, restorePipelineStageVersion,
   generatePipelineManuscriptFix, acceptPipelineManuscriptFix,
+  analyzePipelineManuscriptCompleteness,
 } from '../services/api';
 
 const STAGE_LABEL = { comicScript: 'comic script', teleplay: 'teleplay', prose: 'prose', idea: 'outline' };
@@ -71,6 +73,16 @@ export default function PipelineManuscriptEditor() {
   const [loading, setLoading] = useState(true);
   const [switching, setSwitching] = useState(false);
   const [pinning, setPinning] = useState(false);
+  // AI provider override for Generate-fix + Editorial-review actions.
+  // selectedProviderId === '' means "System default" (no override sent to server).
+  const {
+    providers,
+    selectedProviderId: overrideProviderId,
+    selectedModel: overrideModel,
+    availableModels: overrideModels,
+    setSelectedProviderId: setOverrideProviderId,
+    setSelectedModel: setOverrideModel,
+  } = useProviderModels(); // enabled providers only; we prepend "System default" in the select
   // Per-issue free-text save state: 'saving' | 'saved' | undefined.
   const [saveState, setSaveState] = useState({});
   // textarea elements keyed by issue number, for jump-to-anchor.
@@ -112,6 +124,23 @@ export default function PipelineManuscriptEditor() {
       .finally(() => { if (!canceled) setLoading(false); });
     return () => { canceled = true; };
   }, [seriesId, navigate]);
+
+  // undefined (not '') so the server treats it as "no override" → system default.
+  const providerOverride = overrideProviderId || undefined;
+  const modelOverride = overrideModel || undefined;
+
+  // Re-run the editorial completeness pass over the manuscript with the chosen
+  // provider. The route persists findings as the review comment set, so we just
+  // swap in the returned comments.
+  const [runEditorialReview, reviewing] = useAsyncAction(
+    async () => {
+      const result = await analyzePipelineManuscriptCompleteness(seriesId, { providerOverride, modelOverride });
+      const next = Array.isArray(result?.review?.comments) ? result.review.comments : [];
+      setComments(next);
+      toast.success(`Editorial review complete — ${next.filter((c) => c.status === 'open').length} open notes`);
+    },
+    { errorMessage: 'Failed to run editorial review' },
+  );
 
   // Switch which format the editor spans. Refetches that format's full-story
   // sections (every issue, empty where undrafted).
@@ -310,6 +339,50 @@ export default function PipelineManuscriptEditor() {
 
         {/* Comments sidebar */}
         <aside className="border-t lg:border-t-0 lg:border-l border-port-border bg-port-card/40 lg:overflow-y-auto p-3 space-y-3">
+          {/* AI provider override + editorial-review trigger. The chosen provider
+              feeds both the per-comment "Generate fix" and the review re-run. */}
+          <div className="border border-port-border rounded-lg bg-port-bg/40 p-2.5 space-y-2">
+            <label htmlFor="ms-provider-override" className="block text-[10px] uppercase tracking-wider text-gray-500">
+              AI provider — Generate fix &amp; Editorial review
+            </label>
+            <div className="flex items-center gap-2">
+              <select
+                id="ms-provider-override"
+                value={overrideProviderId}
+                onChange={(e) => setOverrideProviderId(e.target.value)}
+                className="flex-1 min-w-0 px-2 py-1.5 bg-port-bg border border-port-border rounded text-sm text-white"
+              >
+                <option value="">System default</option>
+                {providers.map((p) => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </select>
+              {overrideProviderId && overrideModels.length > 0 ? (
+                <select
+                  id="ms-model-override"
+                  aria-label="Model"
+                  value={overrideModel}
+                  onChange={(e) => setOverrideModel(e.target.value)}
+                  className="flex-1 min-w-0 px-2 py-1.5 bg-port-bg border border-port-border rounded text-sm text-white"
+                >
+                  {overrideModels.map((m) => <option key={m} value={m}>{m}</option>)}
+                </select>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              onClick={runEditorialReview}
+              disabled={reviewing || sections.length === 0}
+              title={sections.length === 0
+                ? 'Draft at least one issue before running an editorial review'
+                : 'Re-run the editorial feedback pass over the manuscript with the selected provider'}
+              className="w-full inline-flex items-center justify-center gap-1.5 px-2.5 py-1.5 rounded text-[12px] font-medium border bg-port-bg text-port-accent border-port-border hover:border-port-accent/40 disabled:opacity-40"
+            >
+              {reviewing ? <Loader2 size={12} className="animate-spin" /> : <ClipboardCheck size={12} />}
+              {reviewing ? 'Running editorial review…' : 'Run editorial review'}
+            </button>
+          </div>
+
           <h2 className="text-xs uppercase tracking-wider text-gray-500 flex items-center justify-between">
             <span>Editorial comments</span>
             <span className="text-gray-600">{grouped.open.length} open</span>
@@ -326,6 +399,8 @@ export default function PipelineManuscriptEditor() {
               key={comment.id}
               comment={comment}
               seriesId={seriesId}
+              providerOverride={providerOverride}
+              modelOverride={modelOverride}
               onJump={jumpToComment}
               onCommentChange={updateCommentLocal}
               onAccepted={applyAccepted}
@@ -426,12 +501,12 @@ function Badge({ comment }) {
   );
 }
 
-function CommentCard({ comment, seriesId, onJump, onCommentChange, onAccepted }) {
+function CommentCard({ comment, seriesId, providerOverride, modelOverride, onJump, onCommentChange, onAccepted }) {
   const [replaceText, setReplaceText] = useState(comment.fix?.replace || '');
   const hasFix = !!comment.fix;
 
   const [runGenerate, generating] = useAsyncAction(
-    () => generatePipelineManuscriptFix(seriesId, comment.id),
+    () => generatePipelineManuscriptFix(seriesId, comment.id, { providerOverride, modelOverride }),
     { errorMessage: 'Failed to generate fix' },
   );
   const [runAccept, accepting] = useAsyncAction(

--- a/client/src/pages/PipelineManuscriptEditor.jsx
+++ b/client/src/pages/PipelineManuscriptEditor.jsx
@@ -24,13 +24,13 @@ import {
 } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import { useAsyncAction } from '../hooks/useAsyncAction';
-import useProviderModels from '../hooks/useProviderModels';
 import { timeAgo } from '../utils/formatters';
+import { filterSelectableModels } from '../utils/providers';
 import {
   getPipelineSeries, updatePipelineSeries, getPipelineManuscript, getPipelineManuscriptReview,
   patchPipelineManuscriptComment, savePipelineManuscriptSection, restorePipelineStageVersion,
   generatePipelineManuscriptFix, acceptPipelineManuscriptFix,
-  analyzePipelineManuscriptCompleteness,
+  analyzePipelineManuscriptCompleteness, getProviders,
 } from '../services/api';
 
 const STAGE_LABEL = { comicScript: 'comic script', teleplay: 'teleplay', prose: 'prose', idea: 'outline' };
@@ -74,15 +74,12 @@ export default function PipelineManuscriptEditor() {
   const [switching, setSwitching] = useState(false);
   const [pinning, setPinning] = useState(false);
   // AI provider override for Generate-fix + Editorial-review actions.
-  // selectedProviderId === '' means "System default" (no override sent to server).
-  const {
-    providers,
-    selectedProviderId: overrideProviderId,
-    selectedModel: overrideModel,
-    availableModels: overrideModels,
-    setSelectedProviderId: setOverrideProviderId,
-    setSelectedModel: setOverrideModel,
-  } = useProviderModels(); // enabled providers only; we prepend "System default" in the select
+  // '' means "System default" (no override sent to server). Intentionally NOT
+  // auto-selected — useProviderModels always picks the first provider, but here
+  // "no selection" is the correct default so we manage this state directly.
+  const [providers, setProviders] = useState([]);
+  const [overrideProviderId, setOverrideProviderId] = useState('');
+  const [overrideModel, setOverrideModel] = useState('');
   // Per-issue free-text save state: 'saving' | 'saved' | undefined.
   const [saveState, setSaveState] = useState({});
   // textarea elements keyed by issue number, for jump-to-anchor.
@@ -125,9 +122,26 @@ export default function PipelineManuscriptEditor() {
     return () => { canceled = true; };
   }, [seriesId, navigate]);
 
+  // Load the enabled provider list once for the override selector.
+  useEffect(() => {
+    let canceled = false;
+    getProviders()
+      .then((data) => { if (!canceled) setProviders((data?.providers || []).filter((p) => p.enabled)); })
+      .catch(() => {});
+    return () => { canceled = true; };
+  }, []);
+
+  const overrideProvider = providers.find((p) => p.id === overrideProviderId) || null;
+  const overrideModels = filterSelectableModels(overrideProvider?.models || [overrideProvider?.defaultModel]);
   // undefined (not '') so the server treats it as "no override" → system default.
   const providerOverride = overrideProviderId || undefined;
   const modelOverride = overrideModel || undefined;
+
+  const changeOverrideProvider = (id) => {
+    setOverrideProviderId(id);
+    const p = providers.find((pr) => pr.id === id);
+    setOverrideModel(p?.defaultModel || '');
+  };
 
   // Re-run the editorial completeness pass over the manuscript with the chosen
   // provider. The route persists findings as the review comment set, so we just
@@ -349,7 +363,7 @@ export default function PipelineManuscriptEditor() {
               <select
                 id="ms-provider-override"
                 value={overrideProviderId}
-                onChange={(e) => setOverrideProviderId(e.target.value)}
+                onChange={(e) => changeOverrideProvider(e.target.value)}
                 className="flex-1 min-w-0 px-2 py-1.5 bg-port-bg border border-port-border rounded text-sm text-white"
               >
                 <option value="">System default</option>

--- a/client/src/pages/PipelineManuscriptEditor.test.jsx
+++ b/client/src/pages/PipelineManuscriptEditor.test.jsx
@@ -12,6 +12,8 @@ const api = vi.hoisted(() => ({
   patchPipelineManuscriptComment: vi.fn(),
   generatePipelineManuscriptFix: vi.fn(),
   acceptPipelineManuscriptFix: vi.fn(),
+  analyzePipelineManuscriptCompleteness: vi.fn(),
+  getProviders: vi.fn(),
 }));
 vi.mock('../services/api', () => api);
 vi.mock('../components/ui/Toast', () => ({ default: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }) }));
@@ -45,6 +47,11 @@ beforeEach(() => {
     availableTypes: ['prose'],
   });
   api.getPipelineManuscriptReview.mockResolvedValue({ schemaVersion: 1, comments: [comment] });
+  api.getProviders.mockResolvedValue({ providers: [
+    { id: 'anthropic', name: 'Anthropic', enabled: true, defaultModel: 'claude-opus', models: ['claude-opus', 'claude-haiku'] },
+    { id: 'openai', name: 'OpenAI', enabled: true, defaultModel: 'gpt-5', models: ['gpt-5'] },
+    { id: 'off', name: 'Disabled', enabled: false, defaultModel: 'x', models: ['x'] },
+  ] });
 });
 
 describe('PipelineManuscriptEditor', () => {
@@ -71,7 +78,7 @@ describe('PipelineManuscriptEditor', () => {
 
     // The editable replacement appears.
     expect(await screen.findByDisplayValue('She left, but paused.')).toBeInTheDocument();
-    expect(api.generatePipelineManuscriptFix).toHaveBeenCalledWith('ser-1', 'mrc-1');
+    expect(api.generatePipelineManuscriptFix).toHaveBeenCalledWith('ser-1', 'mrc-1', expect.any(Object));
 
     fireEvent.click(screen.getByText('Accept'));
 
@@ -121,5 +128,44 @@ describe('PipelineManuscriptEditor', () => {
     ));
     // Version history surfaces after the save.
     expect(await screen.findByTitle('Show prior saved versions')).toBeInTheDocument();
+  });
+
+  it('routes Generate fix through the selected provider/model override', async () => {
+    api.generatePipelineManuscriptFix.mockResolvedValue({
+      fix: { find: 'She left.', replace: 'She left, but paused.' },
+      comment: { ...comment, fix: { find: 'She left.', replace: 'She left, but paused.' } },
+    });
+    renderEditor();
+    await screen.findByText('My Series');
+
+    // Only enabled providers populate the selector.
+    const providerSelect = screen.getByLabelText(/AI provider/i);
+    expect(screen.queryByRole('option', { name: 'Disabled' })).not.toBeInTheDocument();
+    fireEvent.change(providerSelect, { target: { value: 'anthropic' } });
+    // Model defaults to the provider's defaultModel; switch it explicitly.
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'claude-haiku' } });
+
+    fireEvent.click(screen.getByText('Generate fix'));
+    await waitFor(() => expect(api.generatePipelineManuscriptFix).toHaveBeenCalledWith(
+      'ser-1', 'mrc-1', { providerOverride: 'anthropic', modelOverride: 'claude-haiku' },
+    ));
+  });
+
+  it('re-runs the editorial review with the override and swaps in the returned comments', async () => {
+    const fresh = { ...comment, id: 'mrc-2', problem: 'New pacing note' };
+    api.analyzePipelineManuscriptCompleteness.mockResolvedValue({
+      review: { schemaVersion: 1, comments: [comment, fresh] },
+    });
+    renderEditor();
+    await screen.findByText('My Series');
+
+    fireEvent.change(screen.getByLabelText(/AI provider/i), { target: { value: 'openai' } });
+    fireEvent.click(screen.getByText('Run editorial review'));
+
+    expect(await screen.findByText('New pacing note')).toBeInTheDocument();
+    expect(api.analyzePipelineManuscriptCompleteness).toHaveBeenCalledWith(
+      'ser-1', { providerOverride: 'openai', modelOverride: 'gpt-5' },
+    );
+    await waitFor(() => expect(screen.getByText(/2 open/)).toBeInTheDocument());
   });
 });

--- a/client/src/pages/PipelineSeries.jsx
+++ b/client/src/pages/PipelineSeries.jsx
@@ -14,7 +14,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
 import {
   ArrowLeft, Save, Loader2, Workflow as WorkflowIcon, Globe, NotebookPen,
-  PanelLeftClose, PanelLeftOpen, Sparkles,
+  PanelLeftClose, PanelLeftOpen, Sparkles, BookOpen,
 } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import ArcCanvas from '../components/pipeline/ArcCanvas';
@@ -207,6 +207,13 @@ export default function PipelineSeries() {
                 <NotebookPen size={12} /> Writers Room
               </Link>
             ) : null}
+            <Link
+              to={`/pipeline/series/${series.id}/manuscript`}
+              className="ml-2 inline-flex items-center gap-1 px-2 py-1 rounded text-xs text-gray-400 hover:text-white border border-port-border bg-port-card"
+              title="Open the full manuscript editor"
+            >
+              <BookOpen size={12} /> Manuscript
+            </Link>
             <button
               type="button"
               onClick={handleSave}

--- a/server/services/sharing/peerSync.test.js
+++ b/server/services/sharing/peerSync.test.js
@@ -197,11 +197,14 @@ afterEach(async () => {
   // delay between them — pushes scheduled by an earlier drain (e.g.
   // ackDeletesUpTo from a settled push) only enqueue on the next tick, so
   // we need more than one pass to fully quiesce the writeTail chains.
+  // __drainForTests double-awaits writeTail (one tick apart) so the
+  // persistPushSuccess that enqueues after peerFetch resolves is captured.
   for (let i = 0; i < 3; i++) {
-    await __resetForTests();
+    await __drainForTests();
     await __drainCursors();
     await new Promise((r) => setTimeout(r, 5));
   }
+  await __resetForTests();
   await rm(tmp, { recursive: true, force: true });
   PATHS.data = originalDataPath;
   PATHS.images = originalImagesPath;


### PR DESCRIPTION
## Summary

- **Series page header**: adds a `Manuscript` link (BookOpen icon) alongside the existing Writers Room pill so the full manuscript editor is discoverable without opening the bible sidebar
- **Manuscript editor sidebar**: adds an AI provider/model override panel above the Editorial comments section. The selected provider/model flows into every "Generate fix" call and the new "Run editorial review" button. Defaults to "System default" (no override = PortOS's active provider); switching exposes the model dropdown for the chosen provider
- **Run editorial review button**: re-triggers `POST .../manuscript/completeness` with the chosen provider override and swaps in the returned comment set immediately — no reload required. Disabled until at least one section is drafted

## Implementation notes

- Provider state managed by `useProviderModels` (no hand-rolled fetch/state)
- Editorial review action uses `useAsyncAction` (no hand-rolled running-state + toast-on-error)
- Both `generatePipelineManuscriptFix` and `analyzePipelineManuscriptCompleteness` already accepted `providerOverride`/`modelOverride` server-side — this is purely client wiring
- 2 new test cases: provider/model flows through to generate-fix call; editorial review re-runs and swaps comments

## Test plan

- [ ] Open a series page — confirm "Manuscript" link appears in header next to (or instead of, when no Writers Room) the title
- [ ] Open the manuscript editor — confirm provider selector appears at top of sidebar with "System default" pre-selected
- [ ] Select a provider — confirm model dropdown appears with that provider's models
- [ ] Click "Generate fix" — confirm the fix is generated using the selected provider
- [ ] Click "Run editorial review" — confirm the completeness pass fires and new comments appear
- [ ] Verify "Run editorial review" is disabled when no sections are drafted
- [ ] `cd client && npm test` — 6/6 tests pass