### PR TITLE
Fix lightbox Send to Video navigation

### DIFF
--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -362,6 +362,10 @@ function SettingsPane({
   const asideClasses = 'md:w-80 lg:w-96 shrink-0 flex flex-col border-t md:border-t-0 md:border-l border-port-border max-h-[40vh] md:max-h-[92vh]';
   const [cleaning, setCleaning] = useState(false);
   const starred = !!annotation?.starred;
+  const closeThenRun = (handler) => {
+    onClose?.();
+    handler?.(item);
+  };
   // Local draft state debounces saves so each keystroke doesn't PATCH.
   // onSaveRef keeps the debounce effect off the parent's render churn —
   // page components pass inline-arrow onAnnotationChange callbacks, which
@@ -563,7 +567,7 @@ function SettingsPane({
         {onRemix && (
           <button
             type="button"
-            onClick={() => { onRemix(item); onClose(); }}
+            onClick={() => closeThenRun(onRemix)}
             className="flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-port-accent text-white hover:opacity-90 rounded"
           >
             <Sparkles className="w-3.5 h-3.5" /> Remix
@@ -572,7 +576,7 @@ function SettingsPane({
         {!isVideo && onSendToVideo && (
           <button
             type="button"
-            onClick={() => { onSendToVideo(item); onClose(); }}
+            onClick={() => closeThenRun(onSendToVideo)}
             className="flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-port-success text-white hover:opacity-90 rounded"
           >
             <Film className="w-3.5 h-3.5" /> Send to Video
@@ -606,7 +610,7 @@ function SettingsPane({
         {isVideo && onContinue && (
           <button
             type="button"
-            onClick={() => { onContinue(item); onClose(); }}
+            onClick={() => closeThenRun(onContinue)}
             className="flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 text-xs bg-port-accent text-white hover:opacity-90 rounded"
           >
             <ImageIcon className="w-3.5 h-3.5" /> Continue

--- a/client/src/components/media/MediaLightbox.test.jsx
+++ b/client/src/components/media/MediaLightbox.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import MediaLightbox from './MediaLightbox';
 
 // The footer's AddToCollectionMenu and the (closed) PromptRefineModal pull the
@@ -17,6 +17,16 @@ const videoItem = {
   previewUrl: '/data/video-thumbnails/abc.jpg',
   downloadUrl: '/data/videos/abc.mp4',
   prompt: 'a cat',
+  createdAt: Date.now(),
+};
+
+const imageItem = {
+  kind: 'image',
+  key: 'image:frame.png',
+  filename: 'frame.png',
+  previewUrl: '/data/images/frame.png',
+  downloadUrl: '/data/images/frame.png',
+  prompt: 'a cat portrait',
   createdAt: Date.now(),
 };
 
@@ -74,5 +84,27 @@ describe('MediaLightbox video element (mobile playback)', () => {
     );
     const video = container.querySelector('video');
     expect(video.hasAttribute('poster')).toBe(false);
+  });
+});
+
+describe('MediaLightbox route-changing actions', () => {
+  it('closes the preview before Send to Video runs so query cleanup cannot override navigation', () => {
+    const calls = [];
+    const onClose = vi.fn(() => calls.push('close'));
+    const onSendToVideo = vi.fn(() => calls.push('send'));
+
+    render(
+      <MediaLightbox
+        item={imageItem}
+        onClose={onClose}
+        onSendToVideo={onSendToVideo}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /send to video/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onSendToVideo).toHaveBeenCalledWith(imageItem);
+    expect(calls).toEqual(['close', 'send']);
   });
 });


### PR DESCRIPTION
## Summary
- Close the media preview before running route-changing footer actions so URL cleanup cannot override navigation.
- Cover Send to Video ordering from the lightbox with a regression test.

## Tests
- npm test -- MediaLightbox.test.jsx

## Local Review
- Reviewed changed files against runtime/navigation and test-coverage checklist; no findings.