### PR TITLE
clamp collapsed-sidebar flyout into viewport so bottom sections aren't clipped

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -349,12 +349,12 @@ export default function Layout() {
     setFlyoutPos({ top: rect.top, left: rect.right + 4 });
     setFlyoutSection(label);
   }, []);
-  // After the flyout renders, shift it up if it would overflow the bottom of
-  // the viewport so the full menu of options stays visible (sections near the
-  // bottom of a collapsed sidebar otherwise clip off-screen). useLayoutEffect
-  // measures the actual rendered height and adjusts before paint (no flicker).
-  useLayoutEffect(() => {
-    if (!flyoutSection || !flyoutRef.current) return;
+  // Shift the flyout up if it would overflow the bottom of the viewport so the
+  // full menu of options stays visible (sections near the bottom of a collapsed
+  // sidebar otherwise clip off-screen). Measures the actual rendered height and
+  // adjusts before paint (no flicker, hence useLayoutEffect on open).
+  const clampFlyout = useCallback(() => {
+    if (!flyoutRef.current) return;
     const MARGIN = 8;
     const height = flyoutRef.current.offsetHeight;
     const maxTop = window.innerHeight - height - MARGIN;
@@ -362,7 +362,14 @@ export default function Layout() {
       const clampedTop = Math.max(MARGIN, Math.min(prev.top, maxTop));
       return clampedTop === prev.top ? prev : { ...prev, top: clampedTop };
     });
-  }, [flyoutSection]);
+  }, []);
+  useLayoutEffect(() => {
+    if (!flyoutSection) return;
+    clampFlyout();
+    // Re-clamp on resize so a shorter viewport doesn't strand the open flyout.
+    window.addEventListener('resize', clampFlyout);
+    return () => window.removeEventListener('resize', clampFlyout);
+  }, [flyoutSection, clampFlyout]);
   const scheduleCloseFlyout = useCallback(() => {
     clearTimeout(flyoutCloseTimer.current);
     flyoutCloseTimer.current = setTimeout(() => setFlyoutSection(null), 180);

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
+import { useState, useEffect, useLayoutEffect, useMemo, useRef, useCallback } from 'react';
 import { Outlet, NavLink, useLocation, useNavigate } from 'react-router-dom';
 import {
   Home,
@@ -341,6 +341,7 @@ export default function Layout() {
   // the whole sidebar. Tracks which section is open and the icon's screen rect.
   const [flyoutSection, setFlyoutSection] = useState(null);
   const [flyoutPos, setFlyoutPos] = useState({ top: 0, left: 0 });
+  const flyoutRef = useRef(null);
   const flyoutCloseTimer = useRef(null);
   const openFlyout = useCallback((event, label) => {
     clearTimeout(flyoutCloseTimer.current);
@@ -348,6 +349,20 @@ export default function Layout() {
     setFlyoutPos({ top: rect.top, left: rect.right + 4 });
     setFlyoutSection(label);
   }, []);
+  // After the flyout renders, shift it up if it would overflow the bottom of
+  // the viewport so the full menu of options stays visible (sections near the
+  // bottom of a collapsed sidebar otherwise clip off-screen). useLayoutEffect
+  // measures the actual rendered height and adjusts before paint (no flicker).
+  useLayoutEffect(() => {
+    if (!flyoutSection || !flyoutRef.current) return;
+    const MARGIN = 8;
+    const height = flyoutRef.current.offsetHeight;
+    const maxTop = window.innerHeight - height - MARGIN;
+    setFlyoutPos((prev) => {
+      const clampedTop = Math.max(MARGIN, Math.min(prev.top, maxTop));
+      return clampedTop === prev.top ? prev : { ...prev, top: clampedTop };
+    });
+  }, [flyoutSection]);
   const scheduleCloseFlyout = useCallback(() => {
     clearTimeout(flyoutCloseTimer.current);
     flyoutCloseTimer.current = setTimeout(() => setFlyoutSection(null), 180);
@@ -917,14 +932,15 @@ export default function Layout() {
         if (!item || !item.children || item.children.length === 0) return null;
         return (
           <div
+            ref={flyoutRef}
             role="menu"
             aria-label={`${item.label} pages`}
             onMouseEnter={cancelCloseFlyout}
             onMouseLeave={scheduleCloseFlyout}
             onFocus={cancelCloseFlyout}
             onBlur={scheduleCloseFlyout}
-            style={{ top: flyoutPos.top, left: flyoutPos.left, position: 'fixed' }}
-            className="hidden lg:block z-[60] min-w-[200px] bg-port-card border border-port-border rounded-lg shadow-2xl py-1"
+            style={{ top: flyoutPos.top, left: flyoutPos.left, position: 'fixed', maxHeight: 'calc(100vh - 16px)' }}
+            className="hidden lg:block z-[60] min-w-[200px] overflow-y-auto bg-port-card border border-port-border rounded-lg shadow-2xl py-1"
           >
             <div className="px-3 py-1.5 text-[10px] uppercase text-gray-500 tracking-wider border-b border-port-border mb-1">
               {item.label}


### PR DESCRIPTION
## Summary

When the sidebar is collapsed, hovering a section icon opens a fixed-position flyout listing that section's child pages. The flyout was anchored at the icon's `top` and grew downward, so sections near the bottom of the screen (e.g. **System**) had their lower options clipped off the bottom of the viewport.

This shifts the flyout up when it would overflow:
- A `useLayoutEffect` measures the rendered flyout height and clamps `top` to `min(anchorTop, viewportHeight - height - 8px)` (floored at 8px), so the full menu stays on screen. Running in `useLayoutEffect` adjusts the position before paint — no flicker.
- Adds `maxHeight: calc(100vh - 16px)` + `overflow-y-auto` as a fallback so a menu taller than the viewport scrolls internally instead of clipping (and keeps the clamp math non-negative).

## Test plan

- Collapse the sidebar; hover the **System** section icon near the bottom of the screen → the flyout shifts up and all options (Capabilities … Uploads) are visible.
- Hover a section near the top → flyout stays anchored at the icon top (unchanged behavior).
- Resize the window very short so a section's menu exceeds the viewport → flyout fills the height and scrolls internally.