### PR TITLE
Fix red CI: sync comic-script prompt-migration hashes to migration 063

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -24,6 +24,7 @@
 
 ## Changed
 
+- **Comic-script prompt-migration hashes resynced.** Internal fix so the comic-script stage-prompt auto-upgrade recognizes the current shipped template across all install ages (no user-facing change).
 - **[wan22-hunyuan-setup-pin-shas] Installing the Wan 2.2 and HunyuanVideo local video runtimes now pins to a tested version.** The optional installers for both community MLX ports previously cloned whatever was on the project's latest commit that day, so two machines set up days apart could end up with different (and possibly broken) code. They now check out a known-good commit (each repo's latest as of 2026-06-02) for reproducible installs; set `WAN22_PIN=main` or `HUNYUAN_PIN=main` to track upstream instead.
 - **[consolidate-client-url-normalize]** Consolidated the three near-identical "add `https://` to a bare URL" routines behind Brain Links, the quick-capture bar, and Feeds into one shared, unit-tested helper, preserving each spot's existing behavior (no user-facing change).
 - **[nav-tabbed-page-coverage-guard] A few page tabs that were only reachable by clicking are now searchable from ⌘K and voice.** The Goals "Tree" view, the Insights "Genome-Health", "Taste & Identity" and "Cross-Domain Patterns" views, and the Settings "Catalog Types" tab are now jump-to destinations in the command palette and voice navigation, alongside every other tab. A new test keeps every tab of a tabbed page registered for search, so future tabs can't silently go unreachable.

--- a/scripts/migrations/003-update-pipeline-stage-prompts.js
+++ b/scripts/migrations/003-update-pipeline-stage-prompts.js
@@ -38,6 +38,7 @@ export const ACCEPTED_OLD_MD5 = {
     '1e0af305c27d0c80c4b482d2ebcb4a0d', // post-013 / pre-027
     '133d200d069c2e8173b7c129eea58f53', // post-027 / pre-054
     'e530fc76b89cedaef848ad7ec99c934c', // post-054 / pre-054-fence
+    'dea7d497d1cb38e7574f236f4ff8e644', // post-054-fence / pre-063
   ],
   'pipeline-tv-script.md':       ['3f6fecc25573ed054b47db392250034a'],
   'pipeline-season-episodes.md': [
@@ -49,7 +50,7 @@ export const ACCEPTED_OLD_MD5 = {
 export const NEW_SHIPPED_MD5 = {
   'pipeline-idea-expansion.md':  '49a208628290543ba2607a5ed48fdc8c', // post-054-fence
   'pipeline-prose.md':           '84523d531eeafa60959c65c553b2563f', // post-054-fence
-  'pipeline-comic-script.md':    'dea7d497d1cb38e7574f236f4ff8e644', // post-054-fence
+  'pipeline-comic-script.md':    'e9ee70bf18888492edada6633cd9928a', // post-063
   'pipeline-tv-script.md':       '376f779f4687b598f1c92ca4e770fd5a', // retired upstream (no data.reference)
   'pipeline-season-episodes.md': '50c68a29c3ebc275db3095d06bd87100', // post-005
 };

--- a/scripts/migrations/013-comic-script-back-cover.js
+++ b/scripts/migrations/013-comic-script-back-cover.js
@@ -20,11 +20,12 @@ export const ACCEPTED_OLD_MD5 = {
     '1e0af305c27d0c80c4b482d2ebcb4a0d', // post-013 / pre-027 — the hash this migration originally produced
     '133d200d069c2e8173b7c129eea58f53', // post-027 / pre-054
     'e530fc76b89cedaef848ad7ec99c934c', // post-054 / pre-054-fence
+    'dea7d497d1cb38e7574f236f4ff8e644', // post-054-fence / pre-063
   ],
 };
 
 export const NEW_SHIPPED_MD5 = {
-  'pipeline-comic-script.md': 'dea7d497d1cb38e7574f236f4ff8e644', // post-054-fence
+  'pipeline-comic-script.md': 'e9ee70bf18888492edada6633cd9928a', // post-063
 };
 
 const { applyMigration, up } = makePromptReplaceMigration({

--- a/scripts/migrations/027-text-stage-prompts-entities-summary.js
+++ b/scripts/migrations/027-text-stage-prompts-entities-summary.js
@@ -55,6 +55,7 @@ export const ACCEPTED_OLD_MD5 = {
     '40e5fdc1a1e68a7419b7dad936366c1a', // pre-003 (in setup-data OLD list)
     '133d200d069c2e8173b7c129eea58f53', // post-027 / pre-054
     'e530fc76b89cedaef848ad7ec99c934c', // post-054 / pre-054-fence
+    'dea7d497d1cb38e7574f236f4ff8e644', // post-054-fence / pre-063
   ],
   'universe-character-expand.md': [
     'ef109eb8e12ddb664c11c790271b5139', // pre-027 shipped
@@ -64,7 +65,7 @@ export const ACCEPTED_OLD_MD5 = {
 export const NEW_SHIPPED_MD5 = {
   'pipeline-prose.md':            '84523d531eeafa60959c65c553b2563f', // post-054-fence
   'pipeline-teleplay.md':         'afa4215330bf856429d70d7e2f856605', // post-054-fence
-  'pipeline-comic-script.md':     'dea7d497d1cb38e7574f236f4ff8e644', // post-054-fence
+  'pipeline-comic-script.md':     'e9ee70bf18888492edada6633cd9928a', // post-063
   'universe-character-expand.md': '67b6e73ed47f318451a730088b4cff14',
 };
 

--- a/scripts/migrations/054-source-agnostic-stage-prompts.js
+++ b/scripts/migrations/054-source-agnostic-stage-prompts.js
@@ -26,7 +26,7 @@ import { makePromptReplaceMigration } from './_lib.js';
 export const ACCEPTED_OLD_MD5 = {
   'pipeline-idea-expansion.md': ['1f3c5d077a5ef9a4b610335d5e3edd9c', 'b5c47c94ffc74637983c95761ab0c66c'],
   'pipeline-prose.md':          ['d1f8e3f1d214725b5aa67f309a81cd7d', 'bef1bc2767b78f585f2bd89f3d615130'],
-  'pipeline-comic-script.md':   ['133d200d069c2e8173b7c129eea58f53', 'e530fc76b89cedaef848ad7ec99c934c'],
+  'pipeline-comic-script.md':   ['133d200d069c2e8173b7c129eea58f53', 'e530fc76b89cedaef848ad7ec99c934c', 'dea7d497d1cb38e7574f236f4ff8e644'],
   'pipeline-teleplay.md':       ['1280ef6b1ad68fa44070ca7478ec2a5f', '2568e14beaa574d43f8018a5def51d04'],
 };
 
@@ -35,7 +35,7 @@ export const ACCEPTED_OLD_MD5 = {
 export const NEW_SHIPPED_MD5 = {
   'pipeline-idea-expansion.md': '49a208628290543ba2607a5ed48fdc8c',
   'pipeline-prose.md':          '84523d531eeafa60959c65c553b2563f',
-  'pipeline-comic-script.md':   'dea7d497d1cb38e7574f236f4ff8e644',
+  'pipeline-comic-script.md':   'e9ee70bf18888492edada6633cd9928a',
   'pipeline-teleplay.md':       'afa4215330bf856429d70d7e2f856605',
 };
 


### PR DESCRIPTION
## Summary

CI has been red on `main` (the `test (20.x)` job) since before this session — root cause is a single failing test, unrelated to any feature work:

```
scripts/migrations/027-text-stage-prompts-entities-summary.test.js
  > NEW_SHIPPED_MD5 matches the live data.reference bodies (drift catch)
  > skips files already at the new hash (idempotent re-run)
```

Migration 063 advanced `data.reference/prompts/stages/pipeline-comic-script.md` to hash `e9ee70bf…` and correctly declared the prior `dea7d497…` as accepted-old. But the four earlier migrations that also track this file — 003, 013, 027, 054 — were left pinned to `dea7d497…` as their `NEW_SHIPPED_MD5`. The earlier `setup-data-drift` baseline was already resynced (commit c0796889) but the migrations themselves were not. Migration 027 is the only one with a drift-catch test asserting `NEW_SHIPPED_MD5` equals the live reference body, so it alone turned CI red.

This bumps all four migrations' comic-script `NEW_SHIPPED_MD5` to `e9ee70bf…` and adds `dea7d497…` to each `ACCEPTED_OLD_MD5` list (`post-054-fence / pre-063`) — the same cross-migration sync that was applied for the 054-fence change, which 063 missed. This keeps the whole lineage consistent so any older install still auto-upgrades the prompt.

## Test plan

- `npx vitest run scripts/migrations/ scripts/setup-data-drift.test.js` → **42 files / 307 tests pass** (was 1 file / 2 tests failing).
- Verified the live `pipeline-comic-script.md` hashes to `e9ee70bf18888492edada6633cd9928a` via newline-normalized MD5 (matches migration 063 + the drift baseline).