### PR TITLE
Remove already-shipped hidream-qwen item from PLAN.md

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -7,7 +7,6 @@ For project goals, see [GOALS.md](./GOALS.md). For completed work, see [.changel
 Claimable, well-specified, no decision needed — `/claim`-able. Unordered.
 
 - [ ] [unify-llm-picker-components] **Three provider/model pickers still hand-roll their own two-select markup + provider fetch instead of the shared `ProviderModelSelector`.** `SeriesLlmPicker.jsx` (bound to `series.llm`, saves on change, shows an "Active provider (…)" empty option), `FeatureProviderPicker.jsx`, and `writers-room/StagePromptModelPicker.jsx` each re-implement the `getProviders → two <select>` shape that `client/src/components/ProviderModelSelector.jsx` + `useProviderModels` already provide (StoryBuilder's `ProviderModelPicker` was migrated onto the shared selector in `story-builder-extract-image-render-hook`). Promote them onto the shared selector too, preserving each one's persistence + activeProvider-fallback semantics. Deferred from that item to keep its diff scoped — these three have divergent save-on-change / active-provider behavior that needs per-component care.
-- [ ] [hidream-qwen-loras-runner-consumers] **Wire HIDREAM/QWEN through `client/src/pages/Loras.jsx`.** `imageGenResolutions.js` was extended on 2026-05-28 (`compatibilityKey` now returns HIDREAM/QWEN as their own keys). Still pending: `client/src/pages/Loras.jsx` `RUNNER_LABELS` / `RUNNER_BG_COLORS` / Top-LoRA section list omit HIDREAM/QWEN so the LoRA picker shows them as unlabeled / no badge color.
 
 ## Blocked / Deferred (skip for `/claim`)
 


### PR DESCRIPTION
## Summary

`[hidream-qwen-loras-runner-consumers]` shipped in commit `d6ae100e` — `client/src/pages/Loras.jsx` already has the HiDream/Qwen `RUNNER_LABEL`, `RUNNER_BADGE_CLASS`, and Top-LoRA section entries the item asked for. The PLAN.md checkbox kept resurrecting through parallel-claim merge churn (it was removed in PR #690 and again during #699's merge, but came back each time). With no claims now in flight, removing it sticks.

## Test plan

- PLAN.md-only deletion; no code paths affected. CI (lint + test) gates the merge.