### PR TITLE
refactor([unify-llm-picker-components]): render SeriesLlmPicker through shared ProviderModelSelector

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -25,6 +25,7 @@
 
 ## Changed
 
+- **[unify-llm-picker-components]** The Series AI-provider picker now renders through the same shared provider/model selector used by the other pickers, consolidating the last hand-rolled copy of that markup (no user-facing change).
 - **Comic-script prompt-migration hashes resynced.** Internal fix so the comic-script stage-prompt auto-upgrade recognizes the current shipped template across all install ages (no user-facing change).
 - **[story-builder-hash-shape-vs-derivation-tests]** Hardened the Story Builder step-locking test so it verifies the stamped staleness hash is actually derived from the step's upstream inputs, not merely a hex string — guarding against silent drift in the staleness detection (no user-facing change).
 - **[wan22-hunyuan-setup-pin-shas] Installing the Wan 2.2 and HunyuanVideo local video runtimes now pins to a tested version.** The optional installers for both community MLX ports previously cloned whatever was on the project's latest commit that day, so two machines set up days apart could end up with different (and possibly broken) code. They now check out a known-good commit (each repo's latest as of 2026-06-02) for reproducible installs; set `WAN22_PIN=main` or `HUNYUAN_PIN=main` to track upstream instead.

--- a/PLAN.md
+++ b/PLAN.md
@@ -6,7 +6,6 @@ For project goals, see [GOALS.md](./GOALS.md). For completed work, see [.changel
 
 Claimable, well-specified, no decision needed — `/claim`-able. Unordered.
 
-- [ ] [unify-llm-picker-components] **Three provider/model pickers still hand-roll their own two-select markup + provider fetch instead of the shared `ProviderModelSelector`.** `SeriesLlmPicker.jsx` (bound to `series.llm`, saves on change, shows an "Active provider (…)" empty option), `FeatureProviderPicker.jsx`, and `writers-room/StagePromptModelPicker.jsx` each re-implement the `getProviders → two <select>` shape that `client/src/components/ProviderModelSelector.jsx` + `useProviderModels` already provide (StoryBuilder's `ProviderModelPicker` was migrated onto the shared selector in `story-builder-extract-image-render-hook`). Promote them onto the shared selector too, preserving each one's persistence + activeProvider-fallback semantics. Deferred from that item to keep its diff scoped — these three have divergent save-on-change / active-provider behavior that needs per-component care.
 
 ## Blocked / Deferred (skip for `/claim`)
 

--- a/client/src/components/ProviderModelSelector.jsx
+++ b/client/src/components/ProviderModelSelector.jsx
@@ -12,6 +12,8 @@
  * @param {function} props.onModelChange - Called with model string
  * @param {string} [props.label] - Label text (default: "Provider")
  * @param {boolean} [props.disabled] - Disable both selectors
+ * @param {boolean} [props.modelDisabled] - Disable only the model selector (e.g.
+ *   when the selected provider has no models). Composes with `disabled`.
  * @param {boolean} [props.compact] - Hide labels for inline/toolbar use
  * @param {string} [props.emptyProviderOption] - When set, prepends an option with
  *   value `""` and this label, letting the caller represent a "no explicit
@@ -47,6 +49,7 @@ export default function ProviderModelSelector({
   onModelChange,
   label = 'Provider',
   disabled = false,
+  modelDisabled = false,
   compact = false,
   emptyProviderOption,
   emptyModelOption,
@@ -83,7 +86,7 @@ export default function ProviderModelSelector({
             id={modelSelectId}
             value={selectedModel}
             onChange={(e) => onModelChange(e.target.value)}
-            disabled={disabled}
+            disabled={disabled || modelDisabled}
             title={compact ? 'Model' : undefined}
             aria-label={compact ? 'Model' : undefined}
             className={SELECT_CLASS}

--- a/client/src/components/pipeline/SeriesLlmPicker.jsx
+++ b/client/src/components/pipeline/SeriesLlmPicker.jsx
@@ -52,6 +52,7 @@ export default function SeriesLlmPicker({ series, onSeriesUpdate, disabled = fal
       onModelChange={(model) => saveLlm({ ...(series.llm || {}), model: model || null })}
       label="AI provider"
       disabled={disabled}
+      modelDisabled={providerModels.length === 0}
       compact
       alwaysShowModel
       emptyProviderOption={`Active provider (${providerLabel(activeProviderId)})`}

--- a/client/src/components/pipeline/SeriesLlmPicker.jsx
+++ b/client/src/components/pipeline/SeriesLlmPicker.jsx
@@ -1,11 +1,15 @@
 import { useEffect, useMemo, useState } from 'react';
 import { getProviders, updatePipelineSeries } from '../../services/api';
+import ProviderModelSelector from '../ProviderModelSelector';
 import toast from '../ui/Toast';
 
 /**
  * Two-select provider+model picker bound to `series.llm`. Saves on change so
  * the choice applies to every subsequent LLM call on this series (arc, idea,
  * prose, scripts, auto-run). Mirrors the Universe Builder `universe.llm` picker.
+ *
+ * Renders through the shared {@link ProviderModelSelector}; the series-specific
+ * semantics (unset → "Active provider" fallback, save-on-change) live here.
  */
 export default function SeriesLlmPicker({ series, onSeriesUpdate, disabled = false }) {
   const [providers, setProviders] = useState([]);
@@ -35,37 +39,23 @@ export default function SeriesLlmPicker({ series, onSeriesUpdate, disabled = fal
     if (updated) onSeriesUpdate(updated);
   };
 
+  // Bind to `?? ''` (NOT `|| activeProviderId`) — unset must select the
+  // "Active provider" empty option, otherwise the dropdown would silently pin
+  // the active provider as if the user had chosen it.
   return (
-    <div className="flex items-center gap-2 flex-wrap">
-      {/* Bind to `?? ''` (NOT `|| activeProviderId || ''`) — unset must select
-          the "Active provider" empty option, otherwise the dropdown would
-          silently pin the active provider as if the user had chosen it. */}
-      <select
-        value={series.llm?.provider ?? ''}
-        onChange={(e) => saveLlm({ provider: e.target.value || null, model: null })}
-        disabled={disabled}
-        title="AI provider — applies to every LLM operation on this series"
-        className="bg-port-bg border border-port-border rounded px-2 py-1.5 text-white text-xs disabled:opacity-40"
-      >
-        <option value="">Active provider ({providerLabel(activeProviderId)})</option>
-        {providers.map((p) => (
-          <option key={p.id} value={p.id}>{p.name}</option>
-        ))}
-      </select>
-      <select
-        value={series.llm?.model || ''}
-        onChange={(e) => saveLlm({ ...(series.llm || {}), model: e.target.value || null })}
-        disabled={disabled || providerModels.length === 0}
-        title="Model"
-        className="bg-port-bg border border-port-border rounded px-2 py-1.5 text-white text-xs disabled:opacity-40 max-w-[180px]"
-      >
-        <option value="">Default model</option>
-        {providerModels.map((m) => {
-          const id = typeof m === 'string' ? m : m.id;
-          const label = typeof m === 'string' ? m : (m.name || m.id);
-          return <option key={id} value={id}>{label}</option>;
-        })}
-      </select>
-    </div>
+    <ProviderModelSelector
+      providers={providers}
+      selectedProviderId={series.llm?.provider ?? ''}
+      selectedModel={series.llm?.model || ''}
+      availableModels={providerModels}
+      onProviderChange={(id) => saveLlm({ provider: id || null, model: null })}
+      onModelChange={(model) => saveLlm({ ...(series.llm || {}), model: model || null })}
+      label="AI provider"
+      disabled={disabled}
+      compact
+      alwaysShowModel
+      emptyProviderOption={`Active provider (${providerLabel(activeProviderId)})`}
+      emptyModelOption="Default model"
+    />
   );
 }

--- a/client/src/components/pipeline/SeriesLlmPicker.test.jsx
+++ b/client/src/components/pipeline/SeriesLlmPicker.test.jsx
@@ -59,6 +59,13 @@ describe('SeriesLlmPicker', () => {
     await waitFor(() => expect(updatePipelineSeries).toHaveBeenCalledWith('s1', { llm: { provider: null, model: null } }));
   });
 
+  it('disables the model select when the resolved provider has no models', async () => {
+    getProviders.mockResolvedValue({ providers: [{ id: 'p3', name: 'No Models', models: [] }], activeProvider: 'p3' });
+    renderPicker();
+    await waitFor(() => expect(getProviders).toHaveBeenCalled());
+    expect(screen.getAllByRole('combobox')[1]).toBeDisabled();
+  });
+
   it('preserves the chosen provider when only the model changes', async () => {
     renderPicker({ id: 's1', llm: { provider: 'p1', model: '' } });
     await waitFor(() => expect(getProviders).toHaveBeenCalled());

--- a/client/src/components/pipeline/SeriesLlmPicker.test.jsx
+++ b/client/src/components/pipeline/SeriesLlmPicker.test.jsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+vi.mock('../../services/api', () => ({
+  getProviders: vi.fn(),
+  updatePipelineSeries: vi.fn(),
+}));
+vi.mock('../ui/Toast', () => ({ default: { error: vi.fn() } }));
+
+import { getProviders, updatePipelineSeries } from '../../services/api';
+import SeriesLlmPicker from './SeriesLlmPicker';
+
+const PROVIDERS = [
+  { id: 'p1', name: 'Provider One', models: ['m1', 'm2'] },
+  { id: 'p2', name: 'Provider Two', models: ['m3'] },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getProviders.mockResolvedValue({ providers: PROVIDERS, activeProvider: 'p2' });
+  updatePipelineSeries.mockResolvedValue({ id: 's1', llm: { provider: 'p1', model: null } });
+});
+
+const renderPicker = (series = { id: 's1', llm: undefined }, onSeriesUpdate = vi.fn()) =>
+  render(<SeriesLlmPicker series={series} onSeriesUpdate={onSeriesUpdate} />);
+
+describe('SeriesLlmPicker', () => {
+  it('shows the active-provider fallback option labeled with the active provider name', async () => {
+    renderPicker();
+    await waitFor(() => expect(getProviders).toHaveBeenCalled());
+    const providerSelect = screen.getAllByRole('combobox')[0];
+    const firstOption = providerSelect.querySelector('option');
+    expect(firstOption.value).toBe('');
+    expect(firstOption.textContent).toBe('Active provider (Provider Two)');
+    // unset series.llm.provider binds to the empty option, not the active provider
+    expect(providerSelect.value).toBe('');
+  });
+
+  it('always renders the model select with a "Default model" sentinel', async () => {
+    renderPicker();
+    await waitFor(() => expect(getProviders).toHaveBeenCalled());
+    const modelSelect = screen.getAllByRole('combobox')[1];
+    expect(modelSelect.querySelector('option').textContent).toBe('Default model');
+  });
+
+  it('saves { provider, model: null } and propagates the updated series on provider change', async () => {
+    const onSeriesUpdate = vi.fn();
+    renderPicker({ id: 's1', llm: undefined }, onSeriesUpdate);
+    await waitFor(() => expect(getProviders).toHaveBeenCalled());
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'p1' } });
+    await waitFor(() => expect(updatePipelineSeries).toHaveBeenCalledWith('s1', { llm: { provider: 'p1', model: null } }));
+    await waitFor(() => expect(onSeriesUpdate).toHaveBeenCalledWith({ id: 's1', llm: { provider: 'p1', model: null } }));
+  });
+
+  it('clears the provider (null) when the active-provider option is chosen', async () => {
+    renderPicker({ id: 's1', llm: { provider: 'p1', model: 'm1' } });
+    await waitFor(() => expect(getProviders).toHaveBeenCalled());
+    fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: '' } });
+    await waitFor(() => expect(updatePipelineSeries).toHaveBeenCalledWith('s1', { llm: { provider: null, model: null } }));
+  });
+
+  it('preserves the chosen provider when only the model changes', async () => {
+    renderPicker({ id: 's1', llm: { provider: 'p1', model: '' } });
+    await waitFor(() => expect(getProviders).toHaveBeenCalled());
+    fireEvent.change(screen.getAllByRole('combobox')[1], { target: { value: 'm2' } });
+    await waitFor(() => expect(updatePipelineSeries).toHaveBeenCalledWith('s1', { llm: { provider: 'p1', model: 'm2' } }));
+  });
+});


### PR DESCRIPTION
## Summary

`SeriesLlmPicker` was the last picker still hand-rolling the two-select provider+model markup that the shared `ProviderModelSelector` already provides (`FeatureProviderPicker` and `StagePromptModelPicker` were migrated earlier; `StoryBuilder`'s picker was migrated in `story-builder-extract-image-render-hook`). This routes it through the shared component while preserving the series-specific semantics:

- unset provider binds to the `Active provider (<name>)` fallback option (not the active provider id)
- save-on-change persists to `series.llm` via `updatePipelineSeries`
- the model select is always visible with a `Default model` sentinel, and is disabled when the resolved provider has no models

Adds an optional `modelDisabled` prop to `ProviderModelSelector` (composes with `disabled`) to preserve that last behavior, and a focused test suite for `SeriesLlmPicker` (none existed before).

The PLAN item's other two named components were already migrated — verified and noted; this completes the unification.

## Test plan

- New `SeriesLlmPicker.test.jsx` (6 cases) + existing `ProviderModelSelector.test.jsx` → 14 pass.
- eslint clean on all changed files.
- codex review: 1 LOW finding (the disabled-model nit), addressed in-PR.