### PR TITLE
fix([issue-717]): guard useAsyncAction setRunning against post-unmount calls

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -8,4 +8,6 @@
 
 ## Fixed
 
+- **[issue-717] No stray React warnings when you navigate away mid-action** — buttons that run an async task (save, generate, sync) no longer log an "update on an unmounted component" warning if you leave the page before the task finishes.
+
 ## Removed

--- a/client/src/hooks/useAsyncAction.js
+++ b/client/src/hooks/useAsyncAction.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import toast from '../components/ui/Toast';
 
 /**
@@ -15,16 +15,25 @@ import toast from '../components/ui/Toast';
  * error is toasted and `run` resolves to `null`. The hook only models a
  * single boolean in-flight flag — keyed/indexed loading states (e.g. "which
  * row is saving") need a different abstraction.
+ *
+ * The trailing `setRunning(false)` is gated on a `mountedRef` so an action
+ * that resolves after the component unmounts (navigate-away mid-request)
+ * doesn't call `setState` on an unmounted component — React warns about
+ * that and it's a latent memory-leak signal.
  */
 export function useAsyncAction(fn, { errorMessage } = {}) {
   const [running, setRunning] = useState(false);
+  const mountedRef = useRef(true);
+  // Never reset to `true` on re-mount — this handles dev-mode double-mount
+  // cleanly (the cleanup runs once, the flag stays false for the dead tree).
+  useEffect(() => () => { mountedRef.current = false; }, []);
   const run = async (...args) => {
     setRunning(true);
     const result = await fn(...args).catch((err) => {
       toast.error(err?.message || errorMessage || 'Action failed');
       return null;
     });
-    setRunning(false);
+    if (mountedRef.current) setRunning(false);
     return result;
   };
   return [run, running];

--- a/client/src/hooks/useAsyncAction.test.jsx
+++ b/client/src/hooks/useAsyncAction.test.jsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useAsyncAction } from './useAsyncAction';
+
+const errorSpy = vi.fn();
+vi.mock('../components/ui/Toast', () => ({
+  default: { error: (...args) => errorSpy(...args) },
+}));
+
+describe('useAsyncAction', () => {
+  beforeEach(() => {
+    errorSpy.mockClear();
+  });
+
+  it('toggles running around a successful action and resolves to the fn value', async () => {
+    const { result } = renderHook(() => useAsyncAction(async (x) => x * 2));
+
+    expect(result.current[1]).toBe(false);
+
+    let resolved;
+    await act(async () => {
+      resolved = await result.current[0](21);
+    });
+
+    expect(resolved).toBe(42);
+    expect(result.current[1]).toBe(false);
+  });
+
+  it('toasts and resolves to null when the action throws', async () => {
+    const { result } = renderHook(() =>
+      useAsyncAction(async () => { throw new Error('boom'); }, { errorMessage: 'fallback' })
+    );
+
+    let resolved = 'unset';
+    await act(async () => {
+      resolved = await result.current[0]();
+    });
+
+    expect(resolved).toBeNull();
+    expect(errorSpy).toHaveBeenCalledWith('boom');
+    expect(result.current[1]).toBe(false);
+  });
+
+  it('falls back to errorMessage then a default when the error has no message', async () => {
+    const { result } = renderHook(() => useAsyncAction(async () => { throw {}; }, { errorMessage: 'fallback' }));
+    await act(async () => { await result.current[0](); });
+    expect(errorSpy).toHaveBeenCalledWith('fallback');
+
+    const { result: bare } = renderHook(() => useAsyncAction(async () => { throw {}; }));
+    await act(async () => { await bare.current[0](); });
+    expect(errorSpy).toHaveBeenCalledWith('Action failed');
+  });
+
+  it('does not call setRunning after the component unmounts mid-request', async () => {
+    const setStateSpy = vi.spyOn(console, 'error');
+    let release;
+    const pending = new Promise((resolve) => { release = resolve; });
+    const { result, unmount } = renderHook(() => useAsyncAction(async () => { await pending; return 'late'; }));
+
+    // Kick off the action so `running` flips true and the await suspends.
+    let runPromise;
+    act(() => { runPromise = result.current[0](); });
+    expect(result.current[1]).toBe(true);
+
+    // Unmount while the action is still pending, then let it resolve.
+    unmount();
+    await act(async () => {
+      release();
+      await runPromise;
+    });
+
+    // React logs an "update on an unmounted component" error if the guard is
+    // missing — the guard keeps that console.error from ever firing.
+    const sawUnmountWarning = setStateSpy.mock.calls.some((call) =>
+      String(call[0]).includes('unmounted')
+    );
+    expect(sawUnmountWarning).toBe(false);
+    setStateSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

`useAsyncAction` toggled `running` off with an unconditional `setRunning(false)` after the awaited action settled. If the component unmounted mid-request (navigate away while a save/generate/sync is in flight), that `setState` fired on an unmounted component — React logs an "update on an unmounted component" warning and it's a latent memory-leak signal.

This adds the canonical `mountedRef` guard documented in CLAUDE.md ("Deferred work must respect both staleness and unmount"): a `useRef(true)` cleared by an unmount-cleanup effect, gating the trailing `setRunning(false)`. The ref is never reset to `true`, so dev-mode double-mount is handled cleanly.

The hook now has well past the 4-consumer threshold the issue gated the work on (~15 call sites across pages/components).

Closes #717

## Test plan

- Added `client/src/hooks/useAsyncAction.test.jsx` covering: running toggles around a successful action, throw → toast + null resolve, errorMessage/default fallbacks, and the new guard (no unmount warning when the action resolves after unmount).
- `npx vitest run src/hooks/useAsyncAction.test.jsx src/hooks/index.test.js` — 8 passed.