### PR TITLE
fix([issue-719]): skip re-render when media annotation socket update is unchanged

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -8,4 +8,6 @@
 
 ## Fixed
 
+- **[issue-719] Steadier media galleries during live note/star sync** — incoming annotation broadcasts that match what a view already shows no longer trigger a needless re-render of the media cards.
+
 ## Removed

--- a/client/src/hooks/useMediaAnnotations.js
+++ b/client/src/hooks/useMediaAnnotations.js
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { listMediaAnnotations, setMediaAnnotation } from '../services/api';
 import socket from '../services/socket';
 import toast from '../components/ui/Toast';
+import { sameJsonShape } from '../lib/sameJsonShape';
 
 // Per-entry: `own`/`others` from the server, plus back-compat aliases
 // (`starred`/`note`/`updatedAt` = local author) and `anyNote` for the
@@ -56,8 +57,17 @@ export function useMediaAnnotations() {
     const onUpdate = ({ key, entry }) => {
       if (!key) return;
       setAnnotations((prev) => {
-        const next = { ...prev };
         const enriched = enrich(entry);
+        // Bail out when the broadcast carries nothing new: an identical entry
+        // (the originator re-receives its own write) or a delete of a key we
+        // never held. Returning `prev` lets React skip the re-render and the
+        // downstream MediaCard churn instead of allocating a fresh map.
+        if (enriched) {
+          if (sameJsonShape(prev[key], enriched)) return prev;
+        } else if (!(key in prev)) {
+          return prev;
+        }
+        const next = { ...prev };
         if (enriched) next[key] = enriched;
         else delete next[key];
         return next;

--- a/client/src/hooks/useMediaAnnotations.test.jsx
+++ b/client/src/hooks/useMediaAnnotations.test.jsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, cleanup, waitFor } from '@testing-library/react';
+
+// Mock the socket module so the test can drive the 'media:annotation:updated'
+// handler that the hook subscribes to.
+const handlers = new Map();
+vi.mock('../services/socket', () => ({
+  default: {
+    emit: vi.fn(),
+    on: (event, fn) => { handlers.set(event, fn); },
+    off: (event, fn) => { if (handlers.get(event) === fn) handlers.delete(event); },
+  },
+}));
+
+// Mock the API so the initial fetch resolves to a known map.
+const listMediaAnnotations = vi.fn();
+const setMediaAnnotation = vi.fn();
+vi.mock('../services/api', () => ({
+  listMediaAnnotations: (...args) => listMediaAnnotations(...args),
+  setMediaAnnotation: (...args) => setMediaAnnotation(...args),
+}));
+
+vi.mock('../components/ui/Toast', () => ({ default: { error: vi.fn() } }));
+
+import { useMediaAnnotations } from './useMediaAnnotations.js';
+
+const emit = (payload) => act(() => { handlers.get('media:annotation:updated')(payload); });
+
+describe('useMediaAnnotations — socket bail-out guard', () => {
+  beforeEach(() => {
+    handlers.clear();
+    listMediaAnnotations.mockResolvedValue({ annotations: {} });
+    setMediaAnnotation.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('applies a new entry from the socket broadcast', async () => {
+    const { result } = renderHook(() => useMediaAnnotations());
+    await waitFor(() => expect(handlers.has('media:annotation:updated')).toBe(true));
+
+    emit({ key: 'a.png', entry: { own: { starred: true, note: '', updatedAt: '2026-01-01T00:00:00Z' } } });
+
+    expect(result.current.annotations['a.png']?.starred).toBe(true);
+  });
+
+  it('returns the same annotations reference when an identical entry is rebroadcast', async () => {
+    const { result } = renderHook(() => useMediaAnnotations());
+    await waitFor(() => expect(handlers.has('media:annotation:updated')).toBe(true));
+
+    const entry = { own: { starred: true, note: 'hi', updatedAt: '2026-01-01T00:00:00Z' } };
+    emit({ key: 'a.png', entry });
+    const first = result.current.annotations;
+
+    // Re-broadcast the same entry (the originator re-receives its own write).
+    emit({ key: 'a.png', entry: { own: { starred: true, note: 'hi', updatedAt: '2026-01-01T00:00:00Z' } } });
+
+    expect(result.current.annotations).toBe(first);
+  });
+
+  it('still re-renders when a field changes (e.g. a newer updatedAt)', async () => {
+    const { result } = renderHook(() => useMediaAnnotations());
+    await waitFor(() => expect(handlers.has('media:annotation:updated')).toBe(true));
+
+    emit({ key: 'a.png', entry: { own: { starred: false, note: 'first', updatedAt: '2026-01-01T00:00:00Z' } } });
+    const first = result.current.annotations;
+
+    emit({ key: 'a.png', entry: { own: { starred: false, note: 'second', updatedAt: '2026-01-02T00:00:00Z' } } });
+
+    expect(result.current.annotations).not.toBe(first);
+    expect(result.current.annotations['a.png']?.note).toBe('second');
+  });
+
+  it('returns the same reference when deleting a key that was never present', async () => {
+    const { result } = renderHook(() => useMediaAnnotations());
+    await waitFor(() => expect(handlers.has('media:annotation:updated')).toBe(true));
+
+    const before = result.current.annotations;
+    emit({ key: 'missing.png', entry: null });
+
+    expect(result.current.annotations).toBe(before);
+  });
+
+  it('removes an existing key when the broadcast clears it', async () => {
+    const { result } = renderHook(() => useMediaAnnotations());
+    await waitFor(() => expect(handlers.has('media:annotation:updated')).toBe(true));
+
+    emit({ key: 'a.png', entry: { own: { starred: true, note: '', updatedAt: '2026-01-01T00:00:00Z' } } });
+    expect(result.current.annotations['a.png']).toBeTruthy();
+
+    emit({ key: 'a.png', entry: null });
+    expect('a.png' in result.current.annotations).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

The `useMediaAnnotations` socket handler (`media:annotation:updated`) previously allocated a fresh map and reassigned the entry on every broadcast, forcing a re-render of all `MediaCard` consumers — even when the incoming entry was identical to what was already in state (the originator re-receives its own write through the broadcast) or deleted a key the client never held.

This adds a shallow bail-out guard built on the existing `sameJsonShape` helper: when an enriched broadcast entry matches the current entry, or a delete targets a key not in state, the updater returns `prev` unchanged so React skips the re-render. A real change (e.g. a newer `updatedAt`, a flipped star, or an edited note) still flows through and re-renders.

Closes #719

## Test plan

- New `client/src/hooks/useMediaAnnotations.test.jsx` covers: applying a new entry, returning the same reference on an identical rebroadcast, re-rendering on a real field change, no-op delete of an absent key, and removing an existing key on clear.
- `cd client && npx vitest run src/hooks/useMediaAnnotations.test.jsx` — 5/5 pass.