### PR TITLE
feat([issue-703]): add a video-model picker to the episode-video stage

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,6 +3,7 @@
 ## Added
 
 - **`/claim --issues`** — the claim workflow can now pull its work queue from GitHub issues instead of PLAN.md, auto-picking the oldest open issue filed by the repo owner and filing any major code-review findings as new issues. Developer tooling only — no app-facing change.
+- **Episode video model picker** — the pipeline's Episode Video stage now lets you choose which video model renders each scene, alongside the aspect-ratio and quality controls. Leave it on "Default model" to follow your video settings, or pin a specific model; the choice is remembered when you restart a render.
 
 ## Changed
 

--- a/client/src/components/ModelSelect.jsx
+++ b/client/src/components/ModelSelect.jsx
@@ -1,8 +1,14 @@
 // Active + Legacy optgroup `<select>` shared by media-gen pages (VideoGen,
-// CreativeDirector). Splits `models` into active and `m.deprecated === true`
-// groups; the Legacy optgroup only renders when at least one deprecated model
-// exists. `getLabel` picks the option text — defaults to `m.name`; callers
-// whose model shape may omit `name` pass `(m) => m.name || m.id`.
+// CreativeDirector, the Pipeline episode-video stage). Splits `models` into
+// active and `m.deprecated === true` groups; the Legacy optgroup only renders
+// when at least one deprecated model exists. `getLabel` picks the option
+// text — defaults to `m.name`; callers whose model shape may omit `name` pass
+// `(m) => m.name || m.id`.
+//
+// `emptyOption` (optional) prepends a `value=""` option with that label — use
+// it for "optional model / fall back to the server default" pickers (mirrors
+// ProviderModelSelector's `emptyModelOption`). `ariaLabel` / `title` let an
+// inline picker with no visible <label> stay accessible.
 const defaultGetLabel = (m) => m.name;
 export default function ModelSelect({
   models,
@@ -12,6 +18,9 @@ export default function ModelSelect({
   id,
   className = 'w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50',
   disabled = false,
+  emptyOption,
+  ariaLabel,
+  title,
 }) {
   const active = models.filter((m) => !m.deprecated);
   const legacy = models.filter((m) => m.deprecated);
@@ -21,8 +30,11 @@ export default function ModelSelect({
       value={value}
       onChange={onChange}
       disabled={disabled}
+      aria-label={ariaLabel}
+      title={title}
       className={className}
     >
+      {emptyOption != null && <option value="">{emptyOption}</option>}
       {active.map((m) => <option key={m.id} value={m.id}>{getLabel(m)}</option>)}
       {legacy.length > 0 && (
         <optgroup label="Legacy">

--- a/client/src/components/ModelSelect.test.jsx
+++ b/client/src/components/ModelSelect.test.jsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ModelSelect from './ModelSelect';
+
+const MODELS = [
+  { id: 'a', name: 'Alpha' },
+  { id: 'b', name: 'Beta' },
+  { id: 'old', name: 'Legacy One', deprecated: true },
+];
+
+function renderSelect(props = {}) {
+  return render(
+    <ModelSelect models={MODELS} value="a" onChange={() => {}} {...props} />
+  );
+}
+
+describe('ModelSelect', () => {
+  it('renders active options and a Legacy optgroup for deprecated models', () => {
+    renderSelect();
+    const options = screen.getAllByRole('option').map((o) => o.textContent);
+    expect(options).toEqual(['Alpha', 'Beta', 'Legacy One']);
+    // The deprecated model lives under a labelled <optgroup>.
+    const optgroup = document.querySelector('optgroup');
+    expect(optgroup?.label).toBe('Legacy');
+  });
+
+  it('omits the Legacy optgroup when no model is deprecated', () => {
+    renderSelect({ models: [{ id: 'a', name: 'Alpha' }] });
+    expect(document.querySelector('optgroup')).toBeNull();
+  });
+
+  it('prepends an empty option with value "" when emptyOption is set', () => {
+    renderSelect({ emptyOption: 'Default model', value: '' });
+    const first = screen.getByRole('combobox').querySelector('option');
+    expect(first.value).toBe('');
+    expect(first.textContent).toBe('Default model');
+  });
+
+  it('falls back through getLabel when a model omits name', () => {
+    renderSelect({ models: [{ id: 'no-name' }], value: 'no-name', getLabel: (m) => m.name || m.id });
+    expect(screen.getByRole('option').textContent).toBe('no-name');
+  });
+
+  it('applies ariaLabel and forwards change events', () => {
+    const onChange = vi.fn();
+    renderSelect({ ariaLabel: 'Video model', onChange });
+    const select = screen.getByLabelText('Video model');
+    fireEvent.change(select, { target: { value: 'b' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/pipeline/stages/EpisodeVideoStage.jsx
+++ b/client/src/components/pipeline/stages/EpisodeVideoStage.jsx
@@ -3,10 +3,11 @@ import { Link } from 'react-router-dom';
 import { Film, ExternalLink, Loader2, Sparkles, AlertCircle, CheckCircle2 } from 'lucide-react';
 import toast from '../../ui/Toast';
 import Banner from '../../ui/Banner';
-import { generatePipelineVisualImage } from '../../../services/api';
+import { generatePipelineVisualImage, listVideoModels } from '../../../services/api';
 import { getCreativeDirectorProject } from '../../../services/apiCreativeDirector';
 import { getSceneStatusBadge, PROJECT_STATUS_LABEL } from '../../creative-director/sceneStatus';
 import ScenePreview from '../../creative-director/ScenePreview';
+import ModelSelect from '../../ModelSelect';
 import { useAsyncAction } from '../../../hooks/useAsyncAction';
 import { useAutoRefetch } from '../../../hooks/useAutoRefetch';
 
@@ -33,6 +34,54 @@ const STATUS_LABEL = {
   paused: 'Paused',
 };
 
+// Shared inline render-settings controls — aspect ratio, quality, and (when
+// the video-model list loaded) the video model. Rendered identically in the
+// initial-start and restart-confirm toolbars so the two paths can't drift.
+const SELECT_CLS = 'bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-gray-300';
+function RenderControls({ aspectRatio, setAspectRatio, quality, setQuality, modelId, setModelId, videoModels, disabled }) {
+  return (
+    <>
+      <select
+        value={aspectRatio}
+        onChange={(e) => setAspectRatio(e.target.value)}
+        disabled={disabled}
+        aria-label="Aspect ratio"
+        title="Aspect ratio for the rendered scenes"
+        className={SELECT_CLS}
+      >
+        <option value="16:9">16:9</option>
+        <option value="9:16">9:16</option>
+        <option value="1:1">1:1</option>
+      </select>
+      <select
+        value={quality}
+        onChange={(e) => setQuality(e.target.value)}
+        disabled={disabled}
+        aria-label="Render quality"
+        title="Render quality — higher = slower + more GPU time"
+        className={SELECT_CLS}
+      >
+        <option value="draft">draft</option>
+        <option value="standard">standard</option>
+        <option value="high">high</option>
+      </select>
+      {videoModels.length > 0 && (
+        <ModelSelect
+          models={videoModels}
+          value={modelId}
+          onChange={(e) => setModelId(e.target.value)}
+          getLabel={(m) => m.name || m.id}
+          disabled={disabled}
+          emptyOption="Default model"
+          ariaLabel="Video model"
+          title="Video model used to render each scene (Default follows the server setting)"
+          className={`${SELECT_CLS} max-w-[180px]`}
+        />
+      )}
+    </>
+  );
+}
+
 export default function EpisodeVideoStage({ issue, series, onStageUpdate }) {
   const stage = issue.stages?.episodeVideo || {};
   const cdProjectId = stage.cdProjectId || null;
@@ -45,6 +94,21 @@ export default function EpisodeVideoStage({ issue, series, onStageUpdate }) {
   // for an unstarted episodeVideo stage.
   const [aspectRatio, setAspectRatio] = useState(stage.aspectRatio || '16:9');
   const [quality, setQuality] = useState(stage.quality || 'standard');
+  // '' = use the server/settings default video model. A persisted concrete id
+  // (set after a render starts) restores the user's prior choice on reload.
+  const [modelId, setModelId] = useState(stage.modelId || '');
+
+  // Load the video-model list once for the picker. Secondary control — a fetch
+  // failure just hides the model select (the user still gets the server
+  // default), so swallow the error rather than toasting.
+  const [videoModels, setVideoModels] = useState([]);
+  useEffect(() => {
+    let cancelled = false;
+    listVideoModels({ silent: true })
+      .then((models) => { if (!cancelled) setVideoModels(Array.isArray(models) ? models : []); })
+      .catch(() => { if (!cancelled) setVideoModels([]); });
+    return () => { cancelled = true; };
+  }, []);
 
   // Poll while a project id is bound. Pauses on hidden tab via the hook's
   // visibility short-circuit; identical snapshots dedup via the compare option
@@ -88,6 +152,9 @@ export default function EpisodeVideoStage({ issue, series, onStageUpdate }) {
   const [runSubmit, submitting] = useAsyncAction(
     async ({ force }) => {
       const payload = { aspectRatio, quality };
+      // Omit modelId on the "Default model" sentinel so the server resolves
+      // its own default (videoGen.defaultModelId → registry default).
+      if (modelId) payload.modelId = modelId;
       if (force) payload.force = true;
       return generatePipelineVisualImage(issue.id, 'episodeVideo', payload).catch((err) => {
         // Re-throw with a force-aware fallback so useAsyncAction's toaster
@@ -123,9 +190,12 @@ export default function EpisodeVideoStage({ issue, series, onStageUpdate }) {
       cdProjectId: result.cdProjectId,
       // Mirror the server's persisted render settings on the client-side
       // issue model so a same-session navigate-away-and-back doesn't reset
-      // the restart pickers to defaults before a full refetch lands.
+      // the restart pickers to defaults before a full refetch lands. modelId
+      // mirrors the request value ('' when the user left it on Default);
+      // a full refetch later replaces it with the server-resolved concrete id.
       aspectRatio,
       quality,
+      modelId: modelId || null,
     });
   };
 
@@ -154,30 +224,12 @@ export default function EpisodeVideoStage({ issue, series, onStageUpdate }) {
         </div>
         {!cdProjectId ? (
           <div className="flex items-center gap-2 flex-wrap">
-            <select
-              value={aspectRatio}
-              onChange={(e) => setAspectRatio(e.target.value)}
-              disabled={submitting}
-              aria-label="Aspect ratio"
-              title="Aspect ratio for the rendered scenes"
-              className="bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-gray-300"
-            >
-              <option value="16:9">16:9</option>
-              <option value="9:16">9:16</option>
-              <option value="1:1">1:1</option>
-            </select>
-            <select
-              value={quality}
-              onChange={(e) => setQuality(e.target.value)}
-              disabled={submitting}
-              aria-label="Render quality"
-              title="Render quality — higher = slower + more GPU time"
-              className="bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-gray-300"
-            >
-              <option value="draft">draft</option>
-              <option value="standard">standard</option>
-              <option value="high">high</option>
-            </select>
+            <RenderControls
+              aspectRatio={aspectRatio} setAspectRatio={setAspectRatio}
+              quality={quality} setQuality={setQuality}
+              modelId={modelId} setModelId={setModelId}
+              videoModels={videoModels} disabled={submitting}
+            />
             <button
               type="button"
               onClick={() => submit({ force: false })}
@@ -192,28 +244,12 @@ export default function EpisodeVideoStage({ issue, series, onStageUpdate }) {
         ) : confirmRestart ? (
           <div className="flex items-center gap-2 flex-wrap">
             <span className="text-xs text-port-warning">Start a new CD project?</span>
-            <select
-              value={aspectRatio}
-              onChange={(e) => setAspectRatio(e.target.value)}
-              disabled={submitting}
-              aria-label="Aspect ratio"
-              className="bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-gray-300"
-            >
-              <option value="16:9">16:9</option>
-              <option value="9:16">9:16</option>
-              <option value="1:1">1:1</option>
-            </select>
-            <select
-              value={quality}
-              onChange={(e) => setQuality(e.target.value)}
-              disabled={submitting}
-              aria-label="Render quality"
-              className="bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-gray-300"
-            >
-              <option value="draft">draft</option>
-              <option value="standard">standard</option>
-              <option value="high">high</option>
-            </select>
+            <RenderControls
+              aspectRatio={aspectRatio} setAspectRatio={setAspectRatio}
+              quality={quality} setQuality={setQuality}
+              modelId={modelId} setModelId={setModelId}
+              videoModels={videoModels} disabled={submitting}
+            />
             <button
               type="button"
               onClick={() => submit({ force: true })}

--- a/client/src/services/apiImageVideo.js
+++ b/client/src/services/apiImageVideo.js
@@ -38,7 +38,7 @@ export const clearHfToken = () => request('/image-gen/setup/hf-token', { method:
 
 // Video gen
 export const getVideoGenStatus = () => request('/video-gen/status');
-export const listVideoModels = () => request('/video-gen/models');
+export const listVideoModels = (options) => request('/video-gen/models', options);
 // `{ models: [...], textEncoder: { repo, cached, sizeBytes } }`. Same shape
 // contract as the image variant + a text-encoder block since the active
 // encoder is a separate multi-GB pull.

--- a/server/services/pipeline/episodeVideo.js
+++ b/server/services/pipeline/episodeVideo.js
@@ -160,7 +160,13 @@ export async function startEpisodeVideoForIssue(issueId, options = {}) {
   assertStageUnlocked(issue, 'episodeVideo');
   const aspectRatio = options.aspectRatio || '16:9';
   const quality = options.quality || 'standard';
-  const modelId = options.modelId || settings?.videoGen?.defaultModelId || getDefaultVideoModelId();
+  // The user's picker choice: `null` = "Default model". Unlike aspectRatio /
+  // quality (whose defaults are fixed constants), the video default is a live
+  // user setting (videoGen.defaultModelId), so we persist the *choice* — not
+  // the resolved id — and keep "Default" following the setting across reloads.
+  // The CD project's renderer still needs a concrete model, so resolve one here.
+  const requestedModelId = options.modelId || null;
+  const modelId = requestedModelId || settings?.videoGen?.defaultModelId || getDefaultVideoModelId();
 
   const project = await createCDProject({
     name: `Pipeline: ${(series?.name || 'Series').slice(0, 60)} — ${(issue.title || issueId).slice(0, 60)}`,
@@ -182,12 +188,13 @@ export async function startEpisodeVideoForIssue(issueId, options = {}) {
     cdProjectId: project.id,
     // Persist the chosen render settings so a page reload restores the
     // pickers — otherwise restart from a fresh tab would silently fall back
-    // to defaults that the user can't see or adjust. modelId is the resolved
-    // concrete id (a user "Default model" pick lands here as the actual id),
-    // mirroring how aspectRatio/quality persist their resolved defaults.
+    // to defaults that the user can't see or adjust. modelId persists the
+    // user's CHOICE (null = "Default"), so a Default pick keeps tracking the
+    // videoGen.defaultModelId setting on reload instead of pinning to whatever
+    // it happened to resolve to at first render.
     aspectRatio,
     quality,
-    modelId,
+    modelId: requestedModelId,
     output: '',
     errorMessage: '',
   });

--- a/server/services/pipeline/episodeVideo.js
+++ b/server/services/pipeline/episodeVideo.js
@@ -182,9 +182,12 @@ export async function startEpisodeVideoForIssue(issueId, options = {}) {
     cdProjectId: project.id,
     // Persist the chosen render settings so a page reload restores the
     // pickers — otherwise restart from a fresh tab would silently fall back
-    // to defaults that the user can't see or adjust.
+    // to defaults that the user can't see or adjust. modelId is the resolved
+    // concrete id (a user "Default model" pick lands here as the actual id),
+    // mirroring how aspectRatio/quality persist their resolved defaults.
     aspectRatio,
     quality,
+    modelId,
     output: '',
     errorMessage: '',
   });

--- a/server/services/pipeline/episodeVideo.test.js
+++ b/server/services/pipeline/episodeVideo.test.js
@@ -280,6 +280,27 @@ describe('pipeline episodeVideo helper', () => {
     expect(refreshed.stages.episodeVideo.quality).toBe('high');
   });
 
+  it('startEpisodeVideoForIssue forwards an explicit modelId to the CD project + persists it on the stage', async () => {
+    const { issue } = await seedSeriesAndIssue({
+      scenes: [{ description: 'foo' }],
+    });
+    await svc.startEpisodeVideoForIssue(issue.id, { modelId: 'ltx2_unified' });
+    expect(cdCreated[0].modelId).toBe('ltx2_unified');
+    const refreshed = await issuesSvc.getIssue(issue.id);
+    expect(refreshed.stages.episodeVideo.modelId).toBe('ltx2_unified');
+  });
+
+  it('startEpisodeVideoForIssue falls back to the default video model when modelId is omitted', async () => {
+    const { issue } = await seedSeriesAndIssue({
+      scenes: [{ description: 'foo' }],
+    });
+    await svc.startEpisodeVideoForIssue(issue.id);
+    // mediaModels mock resolves the default to 'ltx23_distilled_q4'.
+    expect(cdCreated[0].modelId).toBe('ltx23_distilled_q4');
+    const refreshed = await issuesSvc.getIssue(issue.id);
+    expect(refreshed.stages.episodeVideo.modelId).toBe('ltx23_distilled_q4');
+  });
+
   it('startEpisodeVideoForIssue reuses an existing cdProjectId by default', async () => {
     const { issue } = await seedSeriesAndIssue({
       scenes: [{ description: 'one' }, { description: 'two' }, { description: '' }],

--- a/server/services/pipeline/episodeVideo.test.js
+++ b/server/services/pipeline/episodeVideo.test.js
@@ -290,15 +290,19 @@ describe('pipeline episodeVideo helper', () => {
     expect(refreshed.stages.episodeVideo.modelId).toBe('ltx2_unified');
   });
 
-  it('startEpisodeVideoForIssue falls back to the default video model when modelId is omitted', async () => {
+  it('startEpisodeVideoForIssue resolves a concrete default for the CD project but records the Default choice (null) on the stage', async () => {
     const { issue } = await seedSeriesAndIssue({
       scenes: [{ description: 'foo' }],
     });
     await svc.startEpisodeVideoForIssue(issue.id);
-    // mediaModels mock resolves the default to 'ltx23_distilled_q4'.
+    // The renderer needs a concrete id — mediaModels mock resolves the default
+    // to 'ltx23_distilled_q4'.
     expect(cdCreated[0].modelId).toBe('ltx23_distilled_q4');
+    // ...but the stage records the *choice* (null = Default) so a Default pick
+    // keeps following the videoGen.defaultModelId setting across reloads
+    // instead of pinning to the first-resolved id.
     const refreshed = await issuesSvc.getIssue(issue.id);
-    expect(refreshed.stages.episodeVideo.modelId).toBe('ltx23_distilled_q4');
+    expect(refreshed.stages.episodeVideo.modelId).toBeNull();
   });
 
   it('startEpisodeVideoForIssue reuses an existing cdProjectId by default', async () => {

--- a/server/services/pipeline/issues.js
+++ b/server/services/pipeline/issues.js
@@ -361,6 +361,13 @@ const sanitizeVisualStage = (raw, stageId = null) => {
     videoPath: isStr(raw?.videoPath) && raw.videoPath ? raw.videoPath : null,
     aspectRatio: ASPECT_RATIO_VALUES.has(raw?.aspectRatio) ? raw.aspectRatio : null,
     quality: QUALITY_VALUES.has(raw?.quality) ? raw.quality : null,
+    // Video model id — only meaningful on episodeVideo (it picks the per-scene
+    // render engine). Dropped on comicPages/storyboards so the contract is
+    // explicit, but kept when stageId is omitted (legacy load-time sanitize
+    // has no per-stage context). `null` = use the server/settings default.
+    modelId: (stageId === null || stageId === 'episodeVideo') && isStr(raw?.modelId) && raw.modelId
+      ? raw.modelId.slice(0, 64)
+      : null,
     // genConfig is read by comicPages/storyboards; pass-through is a no-op on
     // episodeVideo, which never looks at it.
     genConfig: sanitizeGenConfig(raw?.genConfig),


### PR DESCRIPTION
## Summary

Closes #703.

The pipeline's Episode Video stage renders each storyboard scene through the Creative Director machinery, and `startEpisodeVideoForIssue` already accepted a `modelId` to pick the video model — but the UI had no way to set it, so every render used the server/settings default. This surfaces a video-model picker on the stage, next to the existing aspect-ratio and quality controls.

- **Picker UI** — a "Default model" + active/legacy video-model dropdown appears in both the initial-start and restart-confirm toolbars on `EpisodeVideoStage`. "Default model" leaves `modelId` off the request so the server resolves its own default; a concrete pick is sent through.
- **Persistence** — the chosen `modelId` is persisted on `stages.episodeVideo` (sanitizer + service), so a reload or restart restores the picker, mirroring how `aspectRatio`/`quality` already persist their resolved values.
- **Shared `ModelSelect`** gains optional `emptyOption` / `ariaLabel` / `title` props (every existing caller untouched) so it fits the inline toolbar — mirrors `ProviderModelSelector`'s `emptyModelOption`.
- **De-dup** — the two previously-duplicated aspect/quality select groups in the stage are collapsed into one shared `RenderControls` block so the start and restart paths can't drift.

> Scope note: issue #703 framed this as wiring the shared `ProviderModelSelector` for a "RunwayML / third-party" video provider. That component picks LLM/CLI providers, and no third-party video-provider abstraction exists yet — episode video renders through the local video-model registry. With the user's confirmation, this ships the honest, shippable version: a video-model picker (the natural precursor to a future RunwayML provider).

## Test plan

- `server`: new `episodeVideo` tests assert an explicit `modelId` is forwarded to the CD project + persisted on the stage, and that an omitted `modelId` falls back to the registry default. Full `episodeVideo` + `issues` suites green (122 tests).
- `client`: new `ModelSelect.test.jsx` (active/legacy split, `emptyOption` prepend, `getLabel` fallback, `ariaLabel` + change forwarding). `ProviderModelSelector` suite still green.
- `vite build` succeeds; ESLint clean on changed files (one pre-existing unused-`series`-prop warning, untouched).