### PR TITLE
refactor([issue-722]): parallelize applyPromptReplaceMigration per-file scan

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -6,6 +6,8 @@
 
 ## Changed
 
+- **[issue-722]** Prompt-template migrations now scan their files concurrently, so future multi-file updates apply faster.
+
 ## Fixed
 
 ## Removed

--- a/scripts/migrations/_lib.js
+++ b/scripts/migrations/_lib.js
@@ -279,14 +279,22 @@ export async function applyPromptReplaceMigration({
 }) {
   const stagesDir = join(rootDir, 'data', 'prompts', 'stages');
   const sampleDir = join(rootDir, 'data.reference', 'prompts', 'stages');
+  const filenames = Object.keys(accepted);
 
-  // Per-file scan runs in parallel — each file's read/compare/write is
-  // independent (no cross-file shared state), so the only cost of the old
-  // serial loop was wall-clock time on a multi-file migration. Each task
-  // returns the name of the single counter it bumped (or null for a no-op);
-  // we sum them post-flight, so counter accumulation never races (it happens
-  // after every task settles, not from inside the async work).
-  const outcomes = await Promise.all(Object.keys(accepted).map(async (filename) => {
+  // Two phases so parallelism never changes the migration's failure semantics:
+  //
+  //   1. PLAN (parallel) — every file's reads + hash compares run concurrently
+  //      (that's the dominant cost, and they share no state). Each yields a
+  //      side-effect-free descriptor: which write/unlink to perform, which
+  //      counter to bump, and any deferred log line. A read rejection here
+  //      rejects the whole migration BEFORE any file has been mutated — so a
+  //      fail-stop on a missing/unreadable file leaves data/ untouched (a
+  //      stricter guarantee than the old serial loop, which could leave an
+  //      already-processed prefix mutated).
+  //   2. APPLY (ordered) — perform the planned writes/unlinks in Object.keys
+  //      order so log output and the on-disk result are deterministic, exactly
+  //      as the serial loop produced them.
+  const plans = await Promise.all(filenames.map(async (filename) => {
     const dataPath = join(stagesDir, filename);
     const samplePath = join(sampleDir, filename);
 
@@ -299,13 +307,10 @@ export async function applyPromptReplaceMigration({
       if (createIfMissing) {
         const sampleContent = await readFile(samplePath, 'utf-8').catch(() => null);
         if (sampleContent != null) {
-          await writeFile(dataPath, sampleContent);
-          console.log(`📄 created ${label}: ${filename}`);
-          return 'created';
+          return { write: { path: dataPath, content: sampleContent }, counter: 'created', log: `📄 created ${label}: ${filename}` };
         }
       }
-      console.log(`📄 ${label} ${filename}: not present in data/, will be created by setup-data.js`);
-      return null;
+      return { log: `📄 ${label} ${filename}: not present in data/, will be created by setup-data.js` };
     }
 
     const existingMd5 = md5(existing);
@@ -325,39 +330,41 @@ export async function applyPromptReplaceMigration({
       });
       if (!sampleExists) {
         if (matchesAcceptedOld || matchesCurrent) {
-          await unlink(dataPath);
-          console.log(`🗑️  ${label} ${filename} was renamed/retired upstream — removed unmodified copy from data/`);
-          return 'retired';
+          return { unlink: dataPath, counter: 'retired', log: `🗑️  ${label} ${filename} was renamed/retired upstream — removed unmodified copy from data/` };
         }
-        console.warn(
-          `⚠️  ${label} ${filename} was renamed/retired upstream but your local copy has been customized.\n` +
-          `   Check data.reference/prompts/stages/ for the replacement file and merge any custom edits manually.`,
-        );
-        return 'skipped';
+        return {
+          counter: 'skipped',
+          warn: `⚠️  ${label} ${filename} was renamed/retired upstream but your local copy has been customized.\n` +
+            `   Check data.reference/prompts/stages/ for the replacement file and merge any custom edits manually.`,
+        };
       }
     }
 
     if (matchesCurrent) {
-      return 'alreadyCurrent';
+      return { counter: 'alreadyCurrent' };
     }
 
     if (!matchesAcceptedOld) {
-      console.warn(
-        `⚠️  ${label} ${filename} has been customized — skipping auto-update.\n` +
-        customizedHint(filename),
-      );
-      return 'skipped';
+      return {
+        counter: 'skipped',
+        warn: `⚠️  ${label} ${filename} has been customized — skipping auto-update.\n` + customizedHint(filename),
+      };
     }
 
+    // Sample read stays in the plan phase: a missing sample for an accepted-old
+    // file is the migration-author error the old loop surfaced by throwing, so
+    // it must still abort before any write lands.
     const sampleContent = await readFile(samplePath, 'utf-8');
-    await writeFile(dataPath, sampleContent);
-    console.log(`✅ updated ${label}: ${filename}`);
-    return 'updated';
+    return { write: { path: dataPath, content: sampleContent }, counter: 'updated', log: `✅ updated ${label}: ${filename}` };
   }));
 
   const counts = { updated: 0, alreadyCurrent: 0, skipped: 0, created: 0, retired: 0 };
-  for (const outcome of outcomes) {
-    if (outcome) counts[outcome]++;
+  for (const plan of plans) {
+    if (plan.unlink) await unlink(plan.unlink);
+    if (plan.write) await writeFile(plan.write.path, plan.write.content);
+    if (plan.warn) console.warn(plan.warn);
+    if (plan.log) console.log(plan.log);
+    if (plan.counter) counts[plan.counter]++;
   }
 
   return counts;

--- a/scripts/migrations/_lib.js
+++ b/scripts/migrations/_lib.js
@@ -280,13 +280,13 @@ export async function applyPromptReplaceMigration({
   const stagesDir = join(rootDir, 'data', 'prompts', 'stages');
   const sampleDir = join(rootDir, 'data.reference', 'prompts', 'stages');
 
-  let updated = 0;
-  let alreadyCurrent = 0;
-  let skipped = 0;
-  let created = 0;
-  let retired = 0;
-
-  for (const filename of Object.keys(accepted)) {
+  // Per-file scan runs in parallel — each file's read/compare/write is
+  // independent (no cross-file shared state), so the only cost of the old
+  // serial loop was wall-clock time on a multi-file migration. Each task
+  // returns the name of the single counter it bumped (or null for a no-op);
+  // we sum them post-flight, so counter accumulation never races (it happens
+  // after every task settles, not from inside the async work).
+  const outcomes = await Promise.all(Object.keys(accepted).map(async (filename) => {
     const dataPath = join(stagesDir, filename);
     const samplePath = join(sampleDir, filename);
 
@@ -301,12 +301,11 @@ export async function applyPromptReplaceMigration({
         if (sampleContent != null) {
           await writeFile(dataPath, sampleContent);
           console.log(`📄 created ${label}: ${filename}`);
-          created++;
-          continue;
+          return 'created';
         }
       }
       console.log(`📄 ${label} ${filename}: not present in data/, will be created by setup-data.js`);
-      continue;
+      return null;
     }
 
     const existingMd5 = md5(existing);
@@ -328,21 +327,18 @@ export async function applyPromptReplaceMigration({
         if (matchesAcceptedOld || matchesCurrent) {
           await unlink(dataPath);
           console.log(`🗑️  ${label} ${filename} was renamed/retired upstream — removed unmodified copy from data/`);
-          retired++;
-        } else {
-          console.warn(
-            `⚠️  ${label} ${filename} was renamed/retired upstream but your local copy has been customized.\n` +
-            `   Check data.reference/prompts/stages/ for the replacement file and merge any custom edits manually.`,
-          );
-          skipped++;
+          return 'retired';
         }
-        continue;
+        console.warn(
+          `⚠️  ${label} ${filename} was renamed/retired upstream but your local copy has been customized.\n` +
+          `   Check data.reference/prompts/stages/ for the replacement file and merge any custom edits manually.`,
+        );
+        return 'skipped';
       }
     }
 
     if (matchesCurrent) {
-      alreadyCurrent++;
-      continue;
+      return 'alreadyCurrent';
     }
 
     if (!matchesAcceptedOld) {
@@ -350,17 +346,21 @@ export async function applyPromptReplaceMigration({
         `⚠️  ${label} ${filename} has been customized — skipping auto-update.\n` +
         customizedHint(filename),
       );
-      skipped++;
-      continue;
+      return 'skipped';
     }
 
     const sampleContent = await readFile(samplePath, 'utf-8');
     await writeFile(dataPath, sampleContent);
     console.log(`✅ updated ${label}: ${filename}`);
-    updated++;
+    return 'updated';
+  }));
+
+  const counts = { updated: 0, alreadyCurrent: 0, skipped: 0, created: 0, retired: 0 };
+  for (const outcome of outcomes) {
+    if (outcome) counts[outcome]++;
   }
 
-  return { updated, alreadyCurrent, skipped, created, retired };
+  return counts;
 }
 
 /**

--- a/scripts/migrations/_lib.test.js
+++ b/scripts/migrations/_lib.test.js
@@ -146,6 +146,27 @@ describe('applyPromptReplaceMigration opt-ins', () => {
         expect(readFileSync(join(stagesDir, name), 'utf-8')).toBe(BODY_NEW);
       }
     });
+
+    it('fail-stops before any write when one file has a missing sample', async () => {
+      // Regression for the parallel-scan failure semantics: the plan phase
+      // reads every file concurrently, but a single rejection (here, an
+      // accepted-old file whose sample is gone → ENOENT) must abort the whole
+      // migration BEFORE the apply phase mutates ANY file — so the other
+      // updatable file is left untouched, not nondeterministically written.
+      writeFileSync(join(stagesDir, 'pipeline-a.md'), BODY_OLD);
+      writeFileSync(join(sampleDir, 'pipeline-a.md'), BODY_NEW); // would update
+      writeFileSync(join(stagesDir, 'pipeline-b.md'), BODY_OLD); // sample missing → throws
+      writeFileSync(join(stagesDir, 'pipeline-c.md'), BODY_OLD);
+      writeFileSync(join(sampleDir, 'pipeline-c.md'), BODY_NEW); // would update
+
+      await expect(
+        applyPromptReplaceMigration({ rootDir, ...multiOpts }),
+      ).rejects.toThrow(/ENOENT/);
+
+      // No write landed — every data file still holds its pre-migration body.
+      expect(readFileSync(join(stagesDir, 'pipeline-a.md'), 'utf-8')).toBe(BODY_OLD);
+      expect(readFileSync(join(stagesDir, 'pipeline-c.md'), 'utf-8')).toBe(BODY_OLD);
+    });
   });
 });
 

--- a/scripts/migrations/_lib.test.js
+++ b/scripts/migrations/_lib.test.js
@@ -107,6 +107,46 @@ describe('applyPromptReplaceMigration opt-ins', () => {
       ).rejects.toThrow(/ENOENT/);
     });
   });
+
+  describe('multi-file scan', () => {
+    // The per-file scan runs in parallel (Promise.all). These assert the
+    // post-flight counter accumulation stays correct across files that land in
+    // different branches — distinct outcomes must each be counted exactly once.
+    const NAMES = ['pipeline-a.md', 'pipeline-b.md', 'pipeline-c.md'];
+    const multiOpts = {
+      accepted: Object.fromEntries(NAMES.map((n) => [n, [md5(BODY_OLD)]])),
+      current: Object.fromEntries(NAMES.map((n) => [n, md5(BODY_NEW)])),
+      label: 'multi',
+      customizedHint: () => '',
+    };
+
+    it('accumulates each file into its own counter across distinct outcomes', async () => {
+      // a → old hash + sample present → updated
+      writeFileSync(join(stagesDir, 'pipeline-a.md'), BODY_OLD);
+      writeFileSync(join(sampleDir, 'pipeline-a.md'), BODY_NEW);
+      // b → already at current hash → alreadyCurrent
+      writeFileSync(join(stagesDir, 'pipeline-b.md'), BODY_NEW);
+      // c → customized (matches neither) → skipped
+      writeFileSync(join(stagesDir, 'pipeline-c.md'), BODY_CUSTOM);
+
+      const result = await applyPromptReplaceMigration({ rootDir, ...multiOpts });
+      expect(result).toEqual({ updated: 1, alreadyCurrent: 1, skipped: 1, created: 0, retired: 0 });
+      expect(readFileSync(join(stagesDir, 'pipeline-a.md'), 'utf-8')).toBe(BODY_NEW);
+      expect(readFileSync(join(stagesDir, 'pipeline-c.md'), 'utf-8')).toBe(BODY_CUSTOM);
+    });
+
+    it('updates every file when all are at the accepted-old hash', async () => {
+      for (const name of NAMES) {
+        writeFileSync(join(stagesDir, name), BODY_OLD);
+        writeFileSync(join(sampleDir, name), BODY_NEW);
+      }
+      const result = await applyPromptReplaceMigration({ rootDir, ...multiOpts });
+      expect(result).toEqual({ updated: 3, alreadyCurrent: 0, skipped: 0, created: 0, retired: 0 });
+      for (const name of NAMES) {
+        expect(readFileSync(join(stagesDir, name), 'utf-8')).toBe(BODY_NEW);
+      }
+    });
+  });
 });
 
 describe('readLayoutsDoc / writeLayoutsDoc', () => {


### PR DESCRIPTION
## Summary

Folds the serial per-file `for (await readFile…)` loop in `applyPromptReplaceMigration` (`scripts/migrations/_lib.js`) into `Promise.all(Object.keys(accepted).map(async …))`, so a multi-file prompt-replace migration scans its files concurrently instead of one at a time. Each per-file task returns the name of the single counter it bumped (`updated` / `alreadyCurrent` / `skipped` / `created` / `retired`), and the counts are summed post-flight — so the accumulation can't race even though the file I/O now runs in parallel.

Every prompt-replace migration today covers exactly one file, so this is a no-op for current migrations; it pays off the first time a migration touches several files at once. Behavior, ordering of the applied-state semantics, and all per-file branch logic are unchanged.

Closes #722

## Test plan

- Added a `multi-file scan` describe block in `scripts/migrations/_lib.test.js` asserting per-counter accumulation across files that land in different branches (updated / alreadyCurrent / skipped) and an all-update case.
- `npx vitest run ../scripts/migrations/` — 41 files / 306 tests pass (all real migrations flow through this helper).