### PR TITLE
test([issue-734]): tripwire reference-watch readOnly default to its prompt version

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -7,6 +7,7 @@
 
 ## Changed
 
+- **[issue-734]** The reference-watch scheduled task now guards its read/write default against silent drift when its prompt is revised. Internal maintenance change with no behavior difference.
 - **[issue-722]** Prompt-template migrations now scan their files concurrently, so future multi-file updates apply faster.
 - **[issue-720] Shared popover positioning** — the theme switcher and collection pickers now share one placement engine, so their pop-up menus stay anchored to their button and on-screen consistently. Internal maintenance change with no behavior difference.
 - **`/claim --issues` marks issues in progress while it works them** — claiming an issue now assigns it to you (and labels it `in-progress`) before any code is written, so a `/claim --issues` running on another machine sees it as taken instead of grabbing it too; the marker is released if a claim is abandoned, and the issue is closed once its PR merges. Developer tooling only — no app-facing change.

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -1208,7 +1208,7 @@ Repository: {repoPath}
 
 // Prompt versions — bump when a default prompt changes so existing instances auto-upgrade.
 // Only non-customized prompts (promptCustomized !== true) are upgraded.
-const PROMPT_VERSIONS = {
+export const PROMPT_VERSIONS = {
   'feature-ideas': 9,  // v9: drop DONE.md reads — use `.changelog/` + `git log` (last 50) as the completed-work signal
   'plan-task': 8,      // v8: Phase-6 merge fallback prefers --merge over --squash (after --auto), matching the /do:pr + review-loop default and PortOS's merge-only policy
   'pr-reviewer': 3,    // v3: multi-stage pipeline (security scan → code review + merge)
@@ -1216,6 +1216,18 @@ const PROMPT_VERSIONS = {
   'code-reviewer-b': 1, // v1: 2-stage pipeline (codebase review → triage & implement)
   'reference-watch': 2  // v2: append slug-tagged checklist items to PLAN.md (Adopt + Maybe) instead of writing REFERENCE_REVIEW.md; security-flagged commits get no PLAN entry (mentioned only in final summary)
 };
+
+// Audit anchor for reference-watch's read/write coupling.
+// The reference-watch schedule default (`taskMetadata.readOnly` in DEFAULT_TASK_INTERVALS)
+// is derived from what the active prompt VERSION does: v2's prompt APPENDS slug-tagged
+// `[ref-watch-…]` items to PLAN.md and commits them, so the default must be `readOnly: false`.
+// A future v3 that returns to a propose-only flow would need `readOnly: true` again.
+// `REFERENCE_WATCH_AUDITED_VERSION` records the PROMPT_VERSIONS['reference-watch'] value
+// the current `readOnly` default was last audited against. A guard test in
+// taskSchedule.test.js fails when PROMPT_VERSIONS['reference-watch'] moves past this anchor —
+// forcing whoever bumps the prompt to re-confirm the default still matches the prompt's
+// behavior and then advance this anchor in the same change. See issue #734.
+export const REFERENCE_WATCH_AUDITED_VERSION = 2;
 
 // Known previous default prompts for legacy migration.
 // When a schedule has no promptVersion, we check if the stored prompt matches
@@ -2475,7 +2487,7 @@ export const SELF_IMPROVEMENT_TASK_TYPES = [
 // Shared config for code-reviewer-a and code-reviewer-b (two instances for independent provider/model configuration)
 const CODE_REVIEWER_INTERVAL = { type: INTERVAL_TYPES.WEEKLY, enabled: false, weekdaysOnly: true, providerId: null, model: null, prompt: null, taskMetadata: { useWorktree: true, openPR: true, simplify: true, pipeline: { stages: [{ name: 'Codebase Review', promptKey: 'code-reviewer-review', readOnly: true, providerId: null, model: null, precondition: { fileNotExists: 'REVIEW.md' } }, { name: 'Triage & Implement', promptKey: 'code-reviewer-implement', readOnly: false, providerId: null, model: null, precondition: { fileExists: 'REVIEW.md' } }] } } };
 
-const DEFAULT_TASK_INTERVALS = {
+export const DEFAULT_TASK_INTERVALS = {
   'security':            { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null },
   'code-quality':        { type: INTERVAL_TYPES.ROTATION, enabled: false, providerId: null, model: null, prompt: null },
   'test-coverage':       { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null },
@@ -2521,6 +2533,9 @@ const DEFAULT_TASK_INTERVALS = {
   // accidentally clobber) and the PLAN.md write is small enough that the in-place
   // commit on the source repo is simpler than a worktree round-trip. Mirrors the
   // on-commit trigger path in referenceRepos.js#triggerReferenceAnalysis.
+  // `readOnly` is coupled to PROMPT_VERSIONS['reference-watch'] — see
+  // REFERENCE_WATCH_AUDITED_VERSION above; bumping the prompt version requires
+  // re-auditing this default (a guard test in taskSchedule.test.js enforces it).
   'reference-watch':     { type: INTERVAL_TYPES.WEEKLY, enabled: false, providerId: null, model: null, prompt: null, taskMetadata: { readOnly: false } }
 };
 

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -92,7 +92,10 @@ import {
   getTaskPrompt,
   resetExecutionHistory,
   triggerOnDemandTask,
-  getScheduleStatus
+  getScheduleStatus,
+  PROMPT_VERSIONS,
+  DEFAULT_TASK_INTERVALS,
+  REFERENCE_WATCH_AUDITED_VERSION
 } from './taskSchedule.js'
 
 import { loadState } from './cosState.js'
@@ -228,6 +231,25 @@ describe('taskSchedule', () => {
       // the contract so a future "default to read-only" refactor surfaces here.
       const interval = await getTaskInterval('reference-watch')
       expect(interval.taskMetadata?.readOnly).toBe(false)
+    })
+
+    // Tripwire for issue #734: the reference-watch `readOnly` default is derived from
+    // what the prompt VERSION does. When PROMPT_VERSIONS['reference-watch'] is bumped,
+    // this test fails until someone re-audits the default and advances
+    // REFERENCE_WATCH_AUDITED_VERSION to match — so a prompt change can't silently
+    // leave the schedule default stale.
+    it('reference-watch readOnly default has been audited against the current prompt version (issue #734)', () => {
+      expect(PROMPT_VERSIONS['reference-watch']).toBe(REFERENCE_WATCH_AUDITED_VERSION)
+    })
+
+    it('reference-watch v2 prompt requires a writable default so it can append + commit PLAN.md items (issue #734)', () => {
+      // The coupling the audit anchor protects: at the audited version (v2), the prompt
+      // writes to PLAN.md, so the raw default must be writable. If a future re-audit flips
+      // REFERENCE_WATCH_AUDITED_VERSION to a propose-only version, update this expectation
+      // alongside the default and the anchor.
+      if (REFERENCE_WATCH_AUDITED_VERSION === 2) {
+        expect(DEFAULT_TASK_INTERVALS['reference-watch'].taskMetadata.readOnly).toBe(false)
+      }
     })
   })
 


### PR DESCRIPTION
## Summary

Issue #734 asked for a standing re-audit: whenever `PROMPT_VERSIONS['reference-watch']` changes, someone must re-check that the schedule's `taskMetadata.readOnly` default still matches what the prompt does. The default was flipped `true → false` for the v2 prompt (which appends `[ref-watch-…]` items to PLAN.md and commits them); a future propose-only v3 would need it flipped back. Nothing enforced that re-audit — the existing tests only pinned the current literal value, so a version bump would pass silently with a stale default.

This converts the reminder into an automated tripwire:

- Adds `REFERENCE_WATCH_AUDITED_VERSION` next to `PROMPT_VERSIONS`, recording the prompt version the current `readOnly` default was last audited against.
- Adds a guard test that fails when `PROMPT_VERSIONS['reference-watch']` moves past the anchor — forcing whoever bumps the prompt to re-confirm the default and advance the anchor in the same change.
- Adds a second test pinning the v2 → `readOnly: false` coupling, gated on the audited version so a future re-audit updates it deliberately.
- Exports `PROMPT_VERSIONS` and `DEFAULT_TASK_INTERVALS` so the coupling is testable (they were module-private).

No prompt content changed and `PROMPT_VERSIONS['reference-watch']` stays at 2, so no migration or `PREVIOUS_DEFAULT_PROMPTS` resync is needed.

## Test plan

- `cd server && npm test -- taskSchedule` — 67 passed (2 new).
- `cd server && npm test -- referenceRepos` — 40 passed.
- Verified the tripwire fires: temporarily bumping the version to 3 fails the new audit test, then reverted.

Closes #734