### PR TITLE
fix([issue-766]): validate episodeVideo modelId against the live video-model registry

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -16,5 +16,6 @@
 
 - **[issue-717] No stray React warnings when you navigate away mid-action** — buttons that run an async task (save, generate, sync) no longer log an "update on an unmounted component" warning if you leave the page before the task finishes.
 - **[issue-719] Steadier media galleries during live note/star sync** — incoming annotation broadcasts that match what a view already shows no longer trigger a needless re-render of the media cards.
+- **[issue-766] Episode Video renders cleanly when a remembered model is gone** — if the video model you previously pinned for an episode has since been removed, the render now quietly falls back to your default model instead of failing partway through.
 
 ## Removed

--- a/server/services/pipeline/episodeVideo.js
+++ b/server/services/pipeline/episodeVideo.js
@@ -19,7 +19,7 @@ import { getSeries } from './series.js';
 import { getSeriesCanon } from './seriesCanon.js';
 import { createProject as createCDProject, setTreatment as setCDTreatment } from '../creativeDirector/local.js';
 import { startCreativeDirectorProject } from '../creativeDirector/completionHook.js';
-import { getDefaultVideoModelId } from '../../lib/mediaModels.js';
+import { getDefaultVideoModelId, getVideoModels } from '../../lib/mediaModels.js';
 import { buildPlaceByKey } from '../../lib/scenePrompt.js';
 import { getSettings } from '../settings.js';
 
@@ -165,7 +165,24 @@ export async function startEpisodeVideoForIssue(issueId, options = {}) {
   // user setting (videoGen.defaultModelId), so we persist the *choice* — not
   // the resolved id — and keep "Default" following the setting across reloads.
   // The CD project's renderer still needs a concrete model, so resolve one here.
-  const requestedModelId = options.modelId || null;
+  // Validate an explicit picker choice against the live video-model registry.
+  // A persisted `modelId` can go stale if the model is later renamed/pruned —
+  // on restart it would flow into createCDProject and fail asynchronously on
+  // the CD project's failureReason. Drop a now-unknown id to the resolved
+  // default so the render degrades cleanly instead.
+  //
+  // Sentinel rule: only drop when the registry has a NON-EMPTY list to validate
+  // against. An empty list means "can't validate on this platform" (e.g. every
+  // video model flagged broken) — NOT "this id is unknown" — so we pass the id
+  // through rather than silently swapping a possibly-valid choice for a default
+  // that's equally unresolvable. This mirrors getDefaultVideoModelId, which
+  // returns the configured id unchanged when there's nothing to fall back to.
+  let requestedModelId = options.modelId || null;
+  const knownModels = getVideoModels();
+  if (requestedModelId && knownModels.length && !knownModels.some((m) => m.id === requestedModelId)) {
+    console.log(`⚠️ Pipeline episode video — unknown modelId "${requestedModelId}" not in registry; dropping to default`);
+    requestedModelId = null;
+  }
   const modelId = requestedModelId || settings?.videoGen?.defaultModelId || getDefaultVideoModelId();
 
   const project = await createCDProject({

--- a/server/services/pipeline/episodeVideo.js
+++ b/server/services/pipeline/episodeVideo.js
@@ -179,11 +179,24 @@ export async function startEpisodeVideoForIssue(issueId, options = {}) {
   // returns the configured id unchanged when there's nothing to fall back to.
   let requestedModelId = options.modelId || null;
   const knownModels = getVideoModels();
-  if (requestedModelId && knownModels.length && !knownModels.some((m) => m.id === requestedModelId)) {
+  // `null` when the registry can't be validated (empty list) — in that case
+  // isKnown() is never consulted and every candidate id passes through.
+  const isKnown = knownModels.length ? (id) => knownModels.some((m) => m.id === id) : null;
+  if (requestedModelId && isKnown && !isKnown(requestedModelId)) {
     console.log(`⚠️ Pipeline episode video — unknown modelId "${requestedModelId}" not in registry; dropping to default`);
     requestedModelId = null;
   }
-  const modelId = requestedModelId || settings?.videoGen?.defaultModelId || getDefaultVideoModelId();
+  // Resolve the concrete model the CD renderer needs. The saved videoGen
+  // default can be just as stale as the explicit pick, so validate it the same
+  // way before trusting it — otherwise a broken settings default would still
+  // reach createCDProject and defeat the drop-to-default contract.
+  // getDefaultVideoModelId() is the final fallback and self-validates against
+  // the platform's available list.
+  const settingsDefault = settings?.videoGen?.defaultModelId || null;
+  const resolvedDefault = (settingsDefault && (!isKnown || isKnown(settingsDefault)))
+    ? settingsDefault
+    : getDefaultVideoModelId();
+  const modelId = requestedModelId || resolvedDefault;
 
   const project = await createCDProject({
     name: `Pipeline: ${(series?.name || 'Series').slice(0, 60)} — ${(issue.title || issueId).slice(0, 60)}`,

--- a/server/services/pipeline/episodeVideo.test.js
+++ b/server/services/pipeline/episodeVideo.test.js
@@ -38,8 +38,13 @@ vi.mock('../creativeDirector/completionHook.js', () => ({
   startCreativeDirectorProject: vi.fn(async () => undefined),
 }));
 
+let mockVideoModels = [
+  { id: 'ltx23_distilled_q4' },
+  { id: 'ltx2_unified' },
+];
 vi.mock('../../lib/mediaModels.js', () => ({
   getDefaultVideoModelId: () => 'ltx23_distilled_q4',
+  getVideoModels: () => mockVideoModels,
 }));
 
 vi.mock('../settings.js', () => ({
@@ -76,6 +81,10 @@ describe('pipeline episodeVideo helper', () => {
     cdCreated.length = 0;
     cdTreatments.length = 0;
     uuidCounter = 0;
+    mockVideoModels = [
+      { id: 'ltx23_distilled_q4' },
+      { id: 'ltx2_unified' },
+    ];
     vi.clearAllMocks();
   });
 
@@ -303,6 +312,35 @@ describe('pipeline episodeVideo helper', () => {
     // instead of pinning to the first-resolved id.
     const refreshed = await issuesSvc.getIssue(issue.id);
     expect(refreshed.stages.episodeVideo.modelId).toBeNull();
+  });
+
+  it('startEpisodeVideoForIssue drops a stale modelId (absent from the registry) to the default', async () => {
+    const { issue } = await seedSeriesAndIssue({
+      scenes: [{ description: 'foo' }],
+    });
+    // 'pruned_model' was a valid pick once but has since been renamed/removed
+    // from the registry — it should degrade to the resolved default rather than
+    // flow into the CD project and fail asynchronously.
+    await svc.startEpisodeVideoForIssue(issue.id, { modelId: 'pruned_model' });
+    expect(cdCreated[0].modelId).toBe('ltx23_distilled_q4');
+    // The stale choice is cleared on the stage too (null = Default), so a reload
+    // doesn't keep re-submitting the dead id.
+    const refreshed = await issuesSvc.getIssue(issue.id);
+    expect(refreshed.stages.episodeVideo.modelId).toBeNull();
+  });
+
+  it('startEpisodeVideoForIssue passes an explicit modelId through when the registry is empty (cannot validate)', async () => {
+    // An empty registry means "no models to validate against on this platform",
+    // NOT "this id is unknown" — so a possibly-valid id must not be silently
+    // swapped for an equally-unresolvable default.
+    mockVideoModels = [];
+    const { issue } = await seedSeriesAndIssue({
+      scenes: [{ description: 'foo' }],
+    });
+    await svc.startEpisodeVideoForIssue(issue.id, { modelId: 'some_byov_model' });
+    expect(cdCreated[0].modelId).toBe('some_byov_model');
+    const refreshed = await issuesSvc.getIssue(issue.id);
+    expect(refreshed.stages.episodeVideo.modelId).toBe('some_byov_model');
   });
 
   it('startEpisodeVideoForIssue reuses an existing cdProjectId by default', async () => {

--- a/server/services/pipeline/episodeVideo.test.js
+++ b/server/services/pipeline/episodeVideo.test.js
@@ -54,6 +54,7 @@ vi.mock('../settings.js', () => ({
 const svc = await import('./episodeVideo.js');
 const issuesSvc = await import('./issues.js');
 const seriesSvc = await import('./series.js');
+const settingsMod = await import('../settings.js');
 
 async function seedSeriesAndIssue({ scenes = [] } = {}) {
   const series = await seriesSvc.createSeries({
@@ -325,6 +326,23 @@ describe('pipeline episodeVideo helper', () => {
     expect(cdCreated[0].modelId).toBe('ltx23_distilled_q4');
     // The stale choice is cleared on the stage too (null = Default), so a reload
     // doesn't keep re-submitting the dead id.
+    const refreshed = await issuesSvc.getIssue(issue.id);
+    expect(refreshed.stages.episodeVideo.modelId).toBeNull();
+  });
+
+  it('startEpisodeVideoForIssue resolves a stale settings default through the registry too', async () => {
+    // The Default choice (no explicit pick) resolves the concrete model from
+    // videoGen.defaultModelId — but that saved default can be just as stale as
+    // an explicit pick. A broken settings default must not reach the CD project;
+    // it falls through to getDefaultVideoModelId() (which self-validates).
+    settingsMod.getSettings.mockResolvedValueOnce({ videoGen: { defaultModelId: 'pruned_default' } });
+    const { issue } = await seedSeriesAndIssue({
+      scenes: [{ description: 'foo' }],
+    });
+    await svc.startEpisodeVideoForIssue(issue.id);
+    expect(cdCreated[0].modelId).toBe('ltx23_distilled_q4');
+    // The recorded choice is still Default (null) — the stale *setting* is the
+    // user's to fix; we only resolve a working model for this render.
     const refreshed = await issuesSvc.getIssue(issue.id);
     expect(refreshed.stages.episodeVideo.modelId).toBeNull();
   });


### PR DESCRIPTION
## Summary

The pipeline's Episode Video stage persists a chosen video `modelId` on the issue stage and forwards it to the Creative Director project. The route schema validated it only as a bounded string — nothing checked the id was a *known* model. A previously-persisted explicit `modelId` could go stale if that model was later renamed or pruned from the registry; on restart it flowed into `createCDProject` and failed asynchronously on the CD project's `failureReason` instead of degrading cleanly.

This validates the explicit picker choice against the live video-model registry (`getVideoModels()`) in `startEpisodeVideoForIssue`. When the requested id is absent from the registry, it drops to the resolved default (the "drop-to-default" variant the issue proposed, rather than the route layer's 400 reject — this is a fire-and-forget service path, not a request handler). Because the requested id is reset to `null`, the stale choice is also cleared on the stage, so a reload stops re-submitting the dead id.

Per the CLAUDE.md "sentinel + validate" rule, a *can't-validate* case is kept distinct from an *unknown-id* case: the drop only happens when the registry returns a **non-empty** list. An empty list (e.g. every video model flagged broken on this platform) means we can't validate, so a possibly-valid pick is passed through rather than silently swapped for an equally-unresolvable default — mirroring `getDefaultVideoModelId`'s own fallback behavior.

## Test plan

- `cd server && npm test -- episodeVideo` — 16/16 pass, including two new cases:
  - stale `modelId` absent from a populated registry drops to the default and clears the persisted choice (`null`)
  - explicit `modelId` passes through unchanged when the registry is empty (can't validate)
- Updated the mediaModels test mock to provide `getVideoModels`.

Closes #766