### PR TITLE
fix([issue-729]): keep universe styleImageRefs off the sync wire and conflict hash

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -14,6 +14,7 @@
 
 ## Fixed
 
+- **[issue-729] Style-probe renders stay put across federated machines** — a universe's base style-probe images are now kept local to each machine, so syncing with an older peer no longer wipes them and a probe render no longer surfaces a phantom sync conflict.
 - **[issue-717] No stray React warnings when you navigate away mid-action** — buttons that run an async task (save, generate, sync) no longer log an "update on an unmounted component" warning if you leave the page before the task finishes.
 - **[issue-719] Steadier media galleries during live note/star sync** — incoming annotation broadcasts that match what a view already shows no longer trigger a needless re-render of the media cards.
 

--- a/server/lib/conflictJournal.test.js
+++ b/server/lib/conflictJournal.test.js
@@ -56,6 +56,17 @@ describe('conflictJournal', () => {
     expect(cj.contentHashForRecord('universe', uni({ ephemeral: true }))).toBeNull();
   });
 
+  it('contentHashForRecord ignores styleImageRefs (probe renders never feed conflict detection)', () => {
+    // styleImageRefs is stripped from the wire projection contentHashForRecord
+    // reuses, so a base style-probe render that only adds/changes those refs
+    // must NOT shift the content hash — otherwise a render alone could register
+    // a phantom 3-way divergence whose conflict diff can't even mention the
+    // field (RESTORABLE_FIELDS.universe omits it).
+    const base = cj.contentHashForRecord('universe', uni());
+    expect(cj.contentHashForRecord('universe', uni({ styleImageRefs: ['probe-1.png'] }))).toBe(base);
+    expect(cj.contentHashForRecord('universe', uni({ styleImageRefs: ['probe-1.png', 'probe-2.png'] }))).toBe(base);
+  });
+
   it('no base → treated as clean (no journal), base seeded for next time', async () => {
     const local = uni({ starterPrompt: 'local', updatedAt: '2026-05-01T00:00:00Z' });
     const remote = uni({ starterPrompt: 'remote', updatedAt: '2026-05-02T00:00:00Z' });

--- a/server/lib/syncWire.js
+++ b/server/lib/syncWire.js
@@ -123,6 +123,23 @@ export function sanitizeRecordForWire(kind, record) {
         }
         return { ...minimized, ...sanitizeSoftDeleteFields(record) };
       }
+      // `styleImageRefs` (universe base "style probe" renders) is WIRE-LOCAL:
+      // per-peer, regenerable, and NOT a restorable conflict field
+      // (RESTORABLE_FIELDS.universe omits it). Strip it from every universe
+      // payload so (1) an older peer that lacks the field in its sanitizer
+      // can't drop-then-LWW-strip it back off a newer peer on round-trip, and
+      // (2) it never feeds the conflict-journal content hash (contentHashForRecord
+      // reuses this projection) — a probe render alone would otherwise register a
+      // phantom 3-way divergence whose diff can't mention the field. Stripping
+      // here (rather than bumping the `universes` schema version) keeps universe
+      // sync flowing to not-yet-upgraded peers: a whole-category gate would
+      // 412-reject ALL universe transfers over a low-stakes, one-click-regenerable
+      // field. The strip is byte-stable against pre-field peers — they never sent
+      // it, so the wire/hash form is unchanged for them.
+      if (kind === 'universe') {
+        const { styleImageRefs: _styleImageRefs, ...universeRest } = rest;
+        return { ...universeRest, ...sanitizeSoftDeleteFields(record) };
+      }
       return { ...rest, ...sanitizeSoftDeleteFields(record) };
     }
     case 'mediaCollection': {

--- a/server/lib/syncWire.test.js
+++ b/server/lib/syncWire.test.js
@@ -164,6 +164,29 @@ describe('syncWire', () => {
       expect(sanitizeRecordForWire('universe', { id: 'u1', ephemeral: 'yes' })).not.toBeNull();
       expect(sanitizeRecordForWire('universe', { id: 'u1', ephemeral: false })).not.toBeNull();
     });
+
+    it('strips styleImageRefs from universe wire form (wire-local probe renders)', () => {
+      // styleImageRefs are per-peer, regenerable base style-probe renders. They
+      // must never cross the wire: an older peer that lacks the field in its
+      // sanitizer would drop it on receive, then LWW-strip it back off a newer
+      // peer after its own edit. The wire form is byte-stable against a record
+      // that never carried the field at all.
+      const withRefs = sanitizeRecordForWire('universe', {
+        id: 'u1', name: 'U', styleImageRefs: ['a.png', 'b.png'],
+      });
+      expect(withRefs.styleImageRefs).toBeUndefined();
+      const without = sanitizeRecordForWire('universe', { id: 'u1', name: 'U' });
+      expect(JSON.stringify(withRefs)).toBe(JSON.stringify(without));
+    });
+
+    it('does NOT strip styleImageRefs from series/issue wire form (universe-only field)', () => {
+      // The strip is scoped to `kind === 'universe'` — series/issue records
+      // never carry styleImageRefs, but a stray value (hand-edit, corrupted
+      // payload) on those kinds must pass through unchanged so the strip can't
+      // silently alter unrelated record shapes.
+      const series = sanitizeRecordForWire('series', { id: 's1', name: 'S', styleImageRefs: ['x.png'] });
+      expect(series.styleImageRefs).toEqual(['x.png']);
+    });
   });
 
   describe('sanitizeStateForWire', () => {

--- a/server/services/universeBuilder.js
+++ b/server/services/universeBuilder.js
@@ -778,8 +778,11 @@ const sanitizeTemplate = (raw) => {
     // Base "style probe" renders — images generated from the raw style preset
     // (influences embrace/avoid + styleNotes) with NO subject, so the user can
     // see the world's base visual emphasis. Additive + regenerable; sanitized
-    // like canon imageRefs (dedupe + cap). Not wire-version-gated (low-stakes,
-    // one-click to regenerate if an older peer round-trips and strips it).
+    // like canon imageRefs (dedupe + cap). WIRE-LOCAL: stripped from every
+    // universe payload by sanitizeRecordForWire (so an older peer can't
+    // drop-then-LWW-strip it off a newer one) and excluded from the
+    // conflict-journal content hash (which reuses that projection). Per-peer +
+    // one-click to regenerate, so no schema-version gate is needed.
     styleImageRefs: sanitizeEntryImageRefs(raw.styleImageRefs),
     locked,
     characters,

--- a/server/services/universeBuilder.js
+++ b/server/services/universeBuilder.js
@@ -1507,6 +1507,15 @@ export async function mergeUniversesFromSync(remoteUniverses, { source = { via: 
       const localTs = local.updatedAt || '';
       const remoteTs = sanitized.updatedAt || '';
       if (remoteTs > localTs) {
+        // `styleImageRefs` is WIRE-LOCAL — sanitizeRecordForWire strips it, so an
+        // inbound payload never carries it and sanitizeTemplate defaulted it to []
+        // above. The local value is authoritative for THIS peer's probe renders;
+        // without restoring it, this remote-wins LWW write would clobber the local
+        // refs to []. Preserve it onto the sanitized record before it's journaled
+        // or written (the conflict hash excludes the field, so this restore can't
+        // shift the journal's divergence verdict). Mirror of the ephemeral
+        // local-only contract above.
+        sanitized.styleImageRefs = local.styleImageRefs ?? [];
         // Non-blocking conflict journal: archive the about-to-be-lost local
         // version when BOTH sides diverged from the last synced base. Always
         // advances the base hash (clean or conflict) so the next snapshot

--- a/server/services/universeBuilder.test.js
+++ b/server/services/universeBuilder.test.js
@@ -908,6 +908,32 @@ describe("universeBuilder service", () => {
         // Receiver scrubs the field — record is normal-syncable.
         expect(inbound.ephemeral).toBeUndefined();
       });
+
+      it("preserves local styleImageRefs across a remote-wins LWW edit (wire-local probe renders)", async () => {
+        // styleImageRefs is stripped from the wire, so an inbound payload never
+        // carries it. Without the receive-side restore, sanitizeTemplate would
+        // default the missing field to [] and a remote-wins LWW write would
+        // clobber this peer's locally-rendered probe images. The local value
+        // is authoritative — a peer's edit to OTHER fields must not wipe it.
+        const w = await seedWorld();
+        await svc.updateUniverse(w.id, { styleImageRefs: ["probe-1.png", "probe-2.png"] });
+        const localBefore = await svc.getUniverse(w.id);
+        expect(localBefore.styleImageRefs).toEqual(["probe-1.png", "probe-2.png"]);
+        // Inbound edit (newer updatedAt, no styleImageRefs — wire-stripped) wins LWW.
+        const editTs = new Date(Date.now() + 60_000).toISOString();
+        const r = await svc.mergeUniversesFromSync([{
+          ...w,
+          name: "Remote Edited Name",
+          styleImageRefs: undefined, // mirror the wire form (field absent)
+          updatedAt: editTs,
+        }]);
+        expect(r.applied).toBe(true);
+        const after = await svc.getUniverse(w.id);
+        // Remote name landed…
+        expect(after.name).toBe("Remote Edited Name");
+        // …but local probe renders survived.
+        expect(after.styleImageRefs).toEqual(["probe-1.png", "probe-2.png"]);
+      });
     });
 
     describe("pruneTombstonedUniverses", () => {


### PR DESCRIPTION
## Summary

`styleImageRefs` (a universe's base "style probe" renders) was wire-synced to peers and folded into the conflict-journal content hash, which created two latent cross-machine bugs:

1. **Round-trip strip.** `sanitizeRecordForWire('universe')` shipped `styleImageRefs` to peers, but an older peer whose `sanitizeTemplate` predates the field drops it on receive. After that peer's own edit bumps `updatedAt`, its now-stripped record wins LWW and pushes back, wiping the refs off the newer peer too.
2. **Phantom conflict.** `contentHashForRecord` reuses the wire projection, so it included `styleImageRefs`. A probe render that only touched those refs shifted the content hash and could register a 3-way divergence in the conflict journal — but `RESTORABLE_FIELDS.universe` omits the field, so the conflict diff couldn't even mention what diverged.

### Fix

Strip `styleImageRefs` from the universe wire projection (scoped to `kind === 'universe'`). The field is per-peer and one-click-regenerable, so this is preferable to bumping the `universes` schema version — a whole-category gate would 412-reject *all* universe sync to not-yet-upgraded peers over a low-stakes field. Because `contentHashForRecord` reuses the same projection, the hash exclusion falls out for free, and the wire form is byte-stable against peers that never carried the field.

## Test plan

- `cd server && npm test -- syncWire conflictJournal` — green (82 tests).
- New `syncWire` cases: universe wire form drops `styleImageRefs` and is byte-stable vs a record that never had it; series/issue records pass a stray value through unchanged (strip is universe-scoped).
- New `conflictJournal` case: a `styleImageRefs`-only change does not shift `contentHashForRecord`.

Closes #729