### PR TITLE
fix(issue-728): don't mark unfilled import steps Ready

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -16,5 +16,6 @@
 
 - **[issue-717] No stray React warnings when you navigate away mid-action** — buttons that run an async task (save, generate, sync) no longer log an "update on an unmounted component" warning if you leave the page before the task finishes.
 - **[issue-719] Steadier media galleries during live note/star sync** — incoming annotation broadcasts that match what a view already shows no longer trigger a needless re-render of the media cards.
+- **[issue-728] Imported stories no longer fake a "Ready" aesthetic or reader map** — when you start a Story Builder session from an import, only the steps the importer actually fills (idea, plot arc, characters, issues) open as "Ready" to review. The Universe Aesthetic and Reader Map steps now start "pending" instead of showing an empty step under a misleading "Ready" badge, so you generate them like you would in a from-scratch build.
 
 ## Removed

--- a/server/services/storyBuilder.js
+++ b/server/services/storyBuilder.js
@@ -67,6 +67,16 @@ export const TITLE_MAX = 200;
 export const SEED_MAX = 4000;
 export const INTAKE_MODES = Object.freeze(['seed', 'import']);
 
+// Steps the importer actually pre-fills, so they open "ready" for review on an
+// import-mode session. `idea` (universe + series exist), `plotArc` (arc +
+// seasons), `characters` (extracted canon), and `issues` (the issue split) are
+// populated by `analyzeImport` → `commitImport`. Steps NOT listed here —
+// `universeAesthetic` (logline/premise/styleNotes/influences are never written
+// on import), `readerMap` (no reader-map extraction pass), and `production`
+// (the downstream render step) — fall through to the default "pending" status
+// so they don't show an empty step under a misleading "Ready" badge (#728).
+export const IMPORT_READY_STEPS = Object.freeze(['idea', 'plotArc', 'characters', 'issues']);
+
 // The universe aesthetic step freezes these universe lock keys.
 export const AESTHETIC_LOCK_FIELDS = Object.freeze([
   'logline', 'premise', 'styleNotes', 'influencesEmbrace', 'influencesAvoid',
@@ -214,9 +224,19 @@ export async function createStorySession(input = {}) {
     llm: input.llm || null,
     createdAt: now,
     updatedAt: now,
-    // Import mode pre-fills content before review — mark every step "ready" so
-    // the user walks through reviewing + locking each, rather than generating.
-    ...(intakeMode === 'import' ? { steps: Object.fromEntries(STEP_IDS.map((id) => [id, { status: 'ready' }])) } : {}),
+    // Import mode pre-fills SOME content before review — mark only the steps the
+    // importer actually populates "ready" so the user reviews + locks those. The
+    // importer (`analyzeImport` → `commitImport`) fills: the idea (universe +
+    // series exist), the plot arc + seasons, the cast (canon characters), and the
+    // issue split. It does NOT extract a universe aesthetic
+    // (logline/premise/styleNotes/influences are never written) nor a reader map,
+    // and production is the downstream render step. Those start "pending" so the
+    // user generates them — leaving them "ready" showed an empty step under a
+    // misleading "Ready" badge (issue #728). The default-pending fall-through in
+    // sanitizeSteps covers every step omitted here.
+    ...(intakeMode === 'import'
+      ? { steps: Object.fromEntries(IMPORT_READY_STEPS.map((id) => [id, { status: 'ready' }])) }
+      : {}),
   });
   await store().saveOne(created.id, created);
   return created;

--- a/server/services/storyBuilder.test.js
+++ b/server/services/storyBuilder.test.js
@@ -57,7 +57,7 @@ describe('storyBuilder — CRUD', () => {
     expect(series.premise).toBe('a foundry city goes silent');
   });
 
-  it('import mode does not mint shells and marks all steps ready', async () => {
+  it('import mode does not mint shells and marks only importer-filled steps ready', async () => {
     const universe = await universeSvc.createUniverse({ name: 'U' });
     const series = await seriesSvc.createSeries({ name: 'S', universeId: universe.id });
     const s = await sb.createStorySession({
@@ -65,8 +65,17 @@ describe('storyBuilder — CRUD', () => {
     });
     expect(s.universeId).toBe(universe.id);
     expect(s.seriesId).toBe(series.id);
-    expect(s.steps.idea.status).toBe('ready');
-    expect(s.steps.readerMap.status).toBe('ready');
+    // Steps the importer populates open "ready" for review.
+    for (const id of sb.IMPORT_READY_STEPS) {
+      expect(s.steps[id].status).toBe('ready');
+    }
+    expect(sb.IMPORT_READY_STEPS).toEqual(['idea', 'plotArc', 'characters', 'issues']);
+    // The importer never extracts an aesthetic or a reader map, and production
+    // is the downstream render step — they must stay pending, not show empty
+    // content under a misleading "Ready" badge (#728).
+    expect(s.steps.universeAesthetic.status).toBe('pending');
+    expect(s.steps.readerMap.status).toBe('pending');
+    expect(s.steps.production.status).toBe('pending');
   });
 
   it('rejects a blank title', async () => {


### PR DESCRIPTION
Summary
- Imported Story Builder sessions now leave the Universe Aesthetic and Reader Map steps pending instead of Ready. analyzeImport creates the universe with only a name (no logline/premise/styleNotes/influences) and never extracts a reader map, so those steps were showing empty content under a misleading Ready badge.
- Only the steps the importer actually populates open Ready for review: idea, plotArc, characters, issues. universeAesthetic, readerMap, and production fall through to the default pending status.

Test plan
- cd server && npm test -- storyBuilder (69 passed)

Closes #728