### PR TITLE
refactor([issue-754]): extract preset picker + uploader from ImageGen

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -14,6 +14,7 @@
 - **[issue-734]** The reference-watch scheduled task now guards its read/write default against silent drift when its prompt is revised. Internal maintenance change with no behavior difference.
 - **[issue-722]** Prompt-template migrations now scan their files concurrently, so future multi-file updates apply faster.
 - **[issue-720] Shared popover positioning** — the theme switcher and collection pickers now share one placement engine, so their pop-up menus stay anchored to their button and on-screen consistently. Internal maintenance change with no behavior difference.
+- **[issue-754]** Extracted the init-image and FLUX.2 multi-reference uploaders from `client/src/pages/ImageGen.jsx` into focused `InitImagePicker` / `ReferenceImagePicker` components. Internal refactor with no behavior difference.
 - **`/claim --issues` marks issues in progress while it works them** — claiming an issue now assigns it to you (and labels it `in-progress`) before any code is written, so a `/claim --issues` running on another machine sees it as taken instead of grabbing it too; the marker is released if a claim is abandoned, and the issue is closed once its PR merges. Developer tooling only — no app-facing change.
 - **`$claim` (Codex) and `/claim` (Claude Code) now share one procedure** — the Codex claim skill was collapsed to a thin adapter over the slash command's procedure, so Codex inherits `--issues` mode, the in-progress marker, and the multi-reviewer loop instead of running a stale copy that had drifted behind. Developer tooling only — no app-facing change.
 

--- a/client/src/components/imageGen/InitImagePicker.jsx
+++ b/client/src/components/imageGen/InitImagePicker.jsx
@@ -1,0 +1,72 @@
+// Single init / source image uploader for the Image Gen page (local mflux/Flux
+// image-to-image, plus edit-only models like Qwen-Image-Edit which require a
+// source). The caller owns the `initImage` object — `{ source, file, name,
+// previewUrl }` — and the 0..1 `strength`; this component only renders the
+// thumbnail + clear button + strength slider and a drop-target label when
+// empty. `onPick` receives the raw file-input change event so the caller can
+// run EXIF orientation normalization before storing the File.
+//
+// `editOnly` flips the label copy/styling: edit-only models need a source
+// image (shown as a required warning), regular i2i is optional.
+
+import { Image as ImageIcon, X } from 'lucide-react';
+
+export default function InitImagePicker({
+  initImage,
+  initImageStrength,
+  onStrengthChange,
+  onPick,
+  onClear,
+  editOnly = false,
+  disabled = false,
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-400 mb-1">
+        {editOnly ? 'Source image' : 'Init image'}{' '}
+        <span className={`font-normal ${editOnly ? 'text-port-warning' : 'text-gray-500'}`}>
+          {editOnly ? '(required — this model edits an existing image)' : '(image-to-image — Flux only)'}
+        </span>
+      </label>
+      {initImage.previewUrl ? (
+        <div className="flex items-start gap-3">
+          <div className="relative shrink-0">
+            <img
+              src={initImage.previewUrl}
+              alt="Init"
+              className="w-16 h-16 object-cover rounded-lg border border-port-border bg-port-bg"
+            />
+            <button
+              type="button"
+              onClick={onClear}
+              disabled={disabled}
+              className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-port-card border border-port-border text-gray-300 hover:text-white hover:bg-port-error/40 flex items-center justify-center disabled:opacity-50"
+              title="Remove init image"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </div>
+          <div className="flex-1 min-w-0 space-y-1">
+            <div className="text-xs text-gray-400 truncate" title={initImage.name}>{initImage.name}</div>
+            <label className="block text-[11px] text-gray-500">
+              Strength {initImageStrength.toFixed(2)}
+              <input
+                type="range" min={0} max={1} step={0.05}
+                value={initImageStrength}
+                disabled={disabled}
+                onChange={(e) => onStrengthChange(Number(e.target.value))}
+                className="w-full accent-port-accent mt-1"
+              />
+            </label>
+          </div>
+        </div>
+      ) : (
+        <label className="flex items-center justify-center gap-2 w-full px-3 py-2 border border-dashed border-port-border rounded-lg text-xs text-gray-400 hover:text-white hover:border-port-accent cursor-pointer transition-colors">
+          <ImageIcon className="w-4 h-4" />
+          Upload image to remix (PNG/JPG/WebP)
+          <input type="file" accept="image/png,image/jpeg,image/webp" className="hidden" onChange={onPick} disabled={disabled} />
+        </label>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/imageGen/InitImagePicker.jsx
+++ b/client/src/components/imageGen/InitImagePicker.jsx
@@ -41,6 +41,7 @@ export default function InitImagePicker({
               onClick={onClear}
               disabled={disabled}
               className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-port-card border border-port-border text-gray-300 hover:text-white hover:bg-port-error/40 flex items-center justify-center disabled:opacity-50"
+              aria-label="Remove init image"
               title="Remove init image"
             >
               <X className="w-3 h-3" />

--- a/client/src/components/imageGen/InitImagePicker.test.jsx
+++ b/client/src/components/imageGen/InitImagePicker.test.jsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import InitImagePicker from './InitImagePicker';
+
+const EMPTY = { source: null, file: null, name: null, previewUrl: null };
+const FILLED = { source: 'upload', file: null, name: 'cat.png', previewUrl: 'blob:abc' };
+
+describe('InitImagePicker', () => {
+  it('renders the upload drop-target when empty', () => {
+    render(
+      <InitImagePicker
+        initImage={EMPTY}
+        initImageStrength={0.4}
+        onStrengthChange={vi.fn()}
+        onPick={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Upload image to remix/i)).toBeTruthy();
+    expect(screen.getByText(/image-to-image — Flux only/i)).toBeTruthy();
+  });
+
+  it('shows the required-source label and warning copy when editOnly', () => {
+    render(
+      <InitImagePicker
+        initImage={EMPTY}
+        initImageStrength={0.4}
+        onStrengthChange={vi.fn()}
+        onPick={vi.fn()}
+        onClear={vi.fn()}
+        editOnly
+      />,
+    );
+    expect(screen.getByText(/Source image/i)).toBeTruthy();
+    expect(screen.getByText(/required — this model edits an existing image/i)).toBeTruthy();
+  });
+
+  it('renders the thumbnail, name, strength, and fires onClear', () => {
+    const onClear = vi.fn();
+    render(
+      <InitImagePicker
+        initImage={FILLED}
+        initImageStrength={0.55}
+        onStrengthChange={vi.fn()}
+        onPick={vi.fn()}
+        onClear={onClear}
+      />,
+    );
+    expect(screen.getByText('cat.png')).toBeTruthy();
+    expect(screen.getByText(/Strength 0.55/)).toBeTruthy();
+    expect(screen.getByAltText('Init')).toBeTruthy();
+    fireEvent.click(screen.getByTitle('Remove init image'));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onStrengthChange with a numeric value from the slider', () => {
+    const onStrengthChange = vi.fn();
+    const { container } = render(
+      <InitImagePicker
+        initImage={FILLED}
+        initImageStrength={0.4}
+        onStrengthChange={onStrengthChange}
+        onPick={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    );
+    const slider = container.querySelector('input[type="range"]');
+    fireEvent.change(slider, { target: { value: '0.7' } });
+    expect(onStrengthChange).toHaveBeenCalledWith(0.7);
+  });
+
+  it('disables the clear button and slider when disabled', () => {
+    const { container } = render(
+      <InitImagePicker
+        initImage={FILLED}
+        initImageStrength={0.4}
+        onStrengthChange={vi.fn()}
+        onPick={vi.fn()}
+        onClear={vi.fn()}
+        disabled
+      />,
+    );
+    expect(screen.getByTitle('Remove init image').disabled).toBe(true);
+    expect(container.querySelector('input[type="range"]').disabled).toBe(true);
+  });
+});

--- a/client/src/components/imageGen/ReferenceImagePicker.jsx
+++ b/client/src/components/imageGen/ReferenceImagePicker.jsx
@@ -1,0 +1,91 @@
+// FLUX.2 multi-reference uploader — up to 4 fixed, positional slots, each
+// carrying an uploaded File + a 0..1 strength weight. The caller owns the
+// `referenceImages` array (`[{ file, previewUrl, strength }]`) and the slot
+// mutations; this component only renders the grid of thumbnails / Add tiles /
+// strength sliders.
+//
+// References are conditioned via diffusers' Flux2KleinKVPipeline (K/V-cache
+// reference-token attention). First-time use prompts the user to accept the
+// FLUX.2-klein-9B-kv license on Hugging Face. Per-reference strengths are
+// honored end-to-end: scripts/flux2_macos.py patches Flux2KVLayerCache.store +
+// _flux2_kv_causal_attention so each reference's V slice is scaled by its
+// strength (1.0 = full influence, 0.0 = ignored).
+//
+// `onPick(slotIndex, event)` receives the raw file-input change event so the
+// caller can run EXIF orientation normalization before storing the File.
+
+import { Image as ImageIcon, X } from 'lucide-react';
+
+export default function ReferenceImagePicker({
+  referenceImages = [],
+  onPick,
+  onClear,
+  onStrengthChange,
+  disabled = false,
+}) {
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-400 mb-1">
+        Reference images <span className="text-gray-500 font-normal">(up to 4 images for FLUX.2 multi-reference edit)</span>
+      </label>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+        {referenceImages.map((slot, i) => {
+          const slotId = `ref-image-${i}`;
+          const strengthId = `ref-strength-${i}`;
+          return (
+            <div key={i} className="flex flex-col gap-1 p-2 rounded-lg border border-port-border bg-port-bg/30">
+              <div className="text-[10px] uppercase tracking-wide text-gray-500">Ref {i + 1}</div>
+              {slot.previewUrl ? (
+                <>
+                  <div className="relative">
+                    <img
+                      src={slot.previewUrl}
+                      alt={`Reference ${i + 1}`}
+                      className="w-full h-16 object-cover rounded border border-port-border bg-port-bg"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => onClear(i)}
+                      disabled={disabled}
+                      className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-port-card border border-port-border text-gray-300 hover:text-white hover:bg-port-error/40 flex items-center justify-center disabled:opacity-50"
+                      title={`Remove reference ${i + 1}`}
+                    >
+                      <X className="w-3 h-3" />
+                    </button>
+                  </div>
+                  <label htmlFor={strengthId} className="block text-[10px] text-gray-500">
+                    Strength {slot.strength.toFixed(2)}
+                  </label>
+                  <input
+                    id={strengthId}
+                    type="range" min={0} max={1} step={0.05}
+                    value={slot.strength}
+                    disabled={disabled}
+                    onChange={(e) => onStrengthChange(i, Number(e.target.value))}
+                    className="w-full accent-port-accent"
+                  />
+                </>
+              ) : (
+                <label
+                  htmlFor={slotId}
+                  className="flex flex-col items-center justify-center gap-1 h-[88px] border border-dashed border-port-border rounded text-[10px] text-gray-500 hover:text-white hover:border-port-accent cursor-pointer transition-colors"
+                >
+                  <ImageIcon className="w-4 h-4" />
+                  Add
+                  <input
+                    id={slotId}
+                    type="file"
+                    accept="image/png,image/jpeg,image/webp"
+                    className="hidden"
+                    onChange={(e) => onPick(i, e)}
+                    disabled={disabled}
+                  />
+                </label>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/imageGen/ReferenceImagePicker.jsx
+++ b/client/src/components/imageGen/ReferenceImagePicker.jsx
@@ -48,6 +48,7 @@ export default function ReferenceImagePicker({
                       onClick={() => onClear(i)}
                       disabled={disabled}
                       className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-port-card border border-port-border text-gray-300 hover:text-white hover:bg-port-error/40 flex items-center justify-center disabled:opacity-50"
+                      aria-label={`Remove reference ${i + 1}`}
                       title={`Remove reference ${i + 1}`}
                     >
                       <X className="w-3 h-3" />

--- a/client/src/components/imageGen/ReferenceImagePicker.test.jsx
+++ b/client/src/components/imageGen/ReferenceImagePicker.test.jsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ReferenceImagePicker from './ReferenceImagePicker';
+
+const emptySlot = () => ({ file: null, previewUrl: null, strength: 1.0 });
+const fourEmpty = () => Array.from({ length: 4 }, emptySlot);
+
+describe('ReferenceImagePicker', () => {
+  it('renders an Add tile per empty slot', () => {
+    render(<ReferenceImagePicker referenceImages={fourEmpty()} onPick={vi.fn()} onClear={vi.fn()} onStrengthChange={vi.fn()} />);
+    expect(screen.getAllByText('Add')).toHaveLength(4);
+    expect(screen.getByText('Ref 1')).toBeTruthy();
+    expect(screen.getByText('Ref 4')).toBeTruthy();
+  });
+
+  it('renders a thumbnail + strength slider for a populated slot', () => {
+    const slots = fourEmpty();
+    slots[1] = { file: null, previewUrl: 'blob:two', strength: 0.6 };
+    render(<ReferenceImagePicker referenceImages={slots} onPick={vi.fn()} onClear={vi.fn()} onStrengthChange={vi.fn()} />);
+    expect(screen.getByAltText('Reference 2')).toBeTruthy();
+    expect(screen.getByText(/Strength 0.60/)).toBeTruthy();
+    expect(screen.getAllByText('Add')).toHaveLength(3);
+  });
+
+  it('fires onClear with the slot index', () => {
+    const slots = fourEmpty();
+    slots[2] = { file: null, previewUrl: 'blob:three', strength: 1.0 };
+    const onClear = vi.fn();
+    render(<ReferenceImagePicker referenceImages={slots} onPick={vi.fn()} onClear={onClear} onStrengthChange={vi.fn()} />);
+    fireEvent.click(screen.getByTitle('Remove reference 3'));
+    expect(onClear).toHaveBeenCalledWith(2);
+  });
+
+  it('fires onStrengthChange with slot index and numeric value', () => {
+    const slots = fourEmpty();
+    slots[0] = { file: null, previewUrl: 'blob:one', strength: 0.5 };
+    const onStrengthChange = vi.fn();
+    const { container } = render(<ReferenceImagePicker referenceImages={slots} onPick={vi.fn()} onClear={vi.fn()} onStrengthChange={onStrengthChange} />);
+    fireEvent.change(container.querySelector('input[type="range"]'), { target: { value: '0.25' } });
+    expect(onStrengthChange).toHaveBeenCalledWith(0, 0.25);
+  });
+
+  it('fires onPick with slot index and event when a file is chosen on an empty slot', () => {
+    const onPick = vi.fn();
+    const { container } = render(<ReferenceImagePicker referenceImages={fourEmpty()} onPick={onPick} onClear={vi.fn()} onStrengthChange={vi.fn()} />);
+    const fileInputs = container.querySelectorAll('input[type="file"]');
+    fireEvent.change(fileInputs[3], { target: { files: [] } });
+    expect(onPick).toHaveBeenCalledWith(3, expect.anything());
+  });
+
+  it('disables clear buttons and sliders when disabled', () => {
+    const slots = fourEmpty();
+    slots[0] = { file: null, previewUrl: 'blob:one', strength: 0.5 };
+    const { container } = render(<ReferenceImagePicker referenceImages={slots} onPick={vi.fn()} onClear={vi.fn()} onStrengthChange={vi.fn()} disabled />);
+    expect(screen.getByTitle('Remove reference 1').disabled).toBe(true);
+    expect(container.querySelector('input[type="range"]').disabled).toBe(true);
+  });
+});

--- a/client/src/pages/ImageGen.jsx
+++ b/client/src/pages/ImageGen.jsx
@@ -22,7 +22,9 @@ import { RUNNER_FAMILIES } from '../lib/runnerFamilies';
 import Flux2InstallModal from '../components/imageGen/Flux2InstallModal';
 import HfTokenBanner from '../components/imageGen/HfTokenBanner';
 import ImageGenControls from '../components/imageGen/ImageGenControls';
+import InitImagePicker from '../components/imageGen/InitImagePicker';
 import LoraPicker from '../components/imageGen/LoraPicker';
+import ReferenceImagePicker from '../components/imageGen/ReferenceImagePicker';
 import MediaJobsQueue from '../components/media/MediaJobsQueue';
 import { useMediaCompletionRefresh } from '../hooks/useMediaCompletionRefresh';
 import { useMediaAnnotations } from '../hooks/useMediaAnnotations';
@@ -1011,129 +1013,25 @@ export default function ImageGen() {
           )}
 
           {isLocalMode && (
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">
-                {isEditOnlyModel ? 'Source image' : 'Init image'}{' '}
-                <span className={`font-normal ${isEditOnlyModel ? 'text-port-warning' : 'text-gray-500'}`}>
-                  {isEditOnlyModel ? '(required — this model edits an existing image)' : '(image-to-image — Flux only)'}
-                </span>
-              </label>
-              {initImage.previewUrl ? (
-                <div className="flex items-start gap-3">
-                  <div className="relative shrink-0">
-                    <img
-                      src={initImage.previewUrl}
-                      alt="Init"
-                      className="w-16 h-16 object-cover rounded-lg border border-port-border bg-port-bg"
-                    />
-                    <button
-                      type="button"
-                      onClick={handleClearInitImage}
-                      disabled={statusLoading}
-                      className="absolute -top-2 -right-2 w-5 h-5 rounded-full bg-port-card border border-port-border text-gray-300 hover:text-white hover:bg-port-error/40 flex items-center justify-center disabled:opacity-50"
-                      title="Remove init image"
-                    >
-                      <X className="w-3 h-3" />
-                    </button>
-                  </div>
-                  <div className="flex-1 min-w-0 space-y-1">
-                    <div className="text-xs text-gray-400 truncate" title={initImage.name}>{initImage.name}</div>
-                    <label className="block text-[11px] text-gray-500">
-                      Strength {initImageStrength.toFixed(2)}
-                      <input
-                        type="range" min={0} max={1} step={0.05}
-                        value={initImageStrength}
-                        disabled={statusLoading}
-                        onChange={(e) => setInitImageStrength(Number(e.target.value))}
-                        className="w-full accent-port-accent mt-1"
-                      />
-                    </label>
-                  </div>
-                </div>
-              ) : (
-                <label className="flex items-center justify-center gap-2 w-full px-3 py-2 border border-dashed border-port-border rounded-lg text-xs text-gray-400 hover:text-white hover:border-port-accent cursor-pointer transition-colors">
-                  <ImageIcon className="w-4 h-4" />
-                  Upload image to remix (PNG/JPG/WebP)
-                  <input type="file" accept="image/png,image/jpeg,image/webp" className="hidden" onChange={handlePickInitImage} disabled={statusLoading} />
-                </label>
-              )}
-            </div>
+            <InitImagePicker
+              initImage={initImage}
+              initImageStrength={initImageStrength}
+              onStrengthChange={setInitImageStrength}
+              onPick={handlePickInitImage}
+              onClear={handleClearInitImage}
+              editOnly={isEditOnlyModel}
+              disabled={statusLoading}
+            />
           )}
 
           {isLocalMode && isFlux2Model && (
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">
-                Reference images <span className="text-gray-500 font-normal">(up to 4 images for FLUX.2 multi-reference edit)</span>
-              </label>
-              {/*
-                FLUX.2 multi-reference editing — references are conditioned via
-                diffusers' Flux2KleinKVPipeline (K/V-cache reference-token
-                attention). First-time use prompts the user to accept the
-                FLUX.2-klein-9B-kv license on Hugging Face. Per-reference
-                strengths are honored end-to-end: scripts/flux2_macos.py
-                patches Flux2KVLayerCache.store + _flux2_kv_causal_attention
-                so each reference's V slice is scaled by its strength
-                (1.0 = full influence, 0.0 = ignored).
-              */}
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                {referenceImages.map((slot, i) => {
-                  const slotId = `ref-image-${i}`;
-                  const strengthId = `ref-strength-${i}`;
-                  return (
-                    <div key={i} className="flex flex-col gap-1 p-2 rounded-lg border border-port-border bg-port-bg/30">
-                      <div className="text-[10px] uppercase tracking-wide text-gray-500">Ref {i + 1}</div>
-                      {slot.previewUrl ? (
-                        <>
-                          <div className="relative">
-                            <img
-                              src={slot.previewUrl}
-                              alt={`Reference ${i + 1}`}
-                              className="w-full h-16 object-cover rounded border border-port-border bg-port-bg"
-                            />
-                            <button
-                              type="button"
-                              onClick={() => handleClearReferenceImage(i)}
-                              disabled={statusLoading}
-                              className="absolute -top-1.5 -right-1.5 w-5 h-5 rounded-full bg-port-card border border-port-border text-gray-300 hover:text-white hover:bg-port-error/40 flex items-center justify-center disabled:opacity-50"
-                              title={`Remove reference ${i + 1}`}
-                            >
-                              <X className="w-3 h-3" />
-                            </button>
-                          </div>
-                          <label htmlFor={strengthId} className="block text-[10px] text-gray-500">
-                            Strength {slot.strength.toFixed(2)}
-                          </label>
-                          <input
-                            id={strengthId}
-                            type="range" min={0} max={1} step={0.05}
-                            value={slot.strength}
-                            disabled={statusLoading}
-                            onChange={(e) => handleReferenceStrengthChange(i, Number(e.target.value))}
-                            className="w-full accent-port-accent"
-                          />
-                        </>
-                      ) : (
-                        <label
-                          htmlFor={slotId}
-                          className="flex flex-col items-center justify-center gap-1 h-[88px] border border-dashed border-port-border rounded text-[10px] text-gray-500 hover:text-white hover:border-port-accent cursor-pointer transition-colors"
-                        >
-                          <ImageIcon className="w-4 h-4" />
-                          Add
-                          <input
-                            id={slotId}
-                            type="file"
-                            accept="image/png,image/jpeg,image/webp"
-                            className="hidden"
-                            onChange={(e) => handlePickReferenceImage(i, e)}
-                            disabled={statusLoading}
-                          />
-                        </label>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
+            <ReferenceImagePicker
+              referenceImages={referenceImages}
+              onPick={handlePickReferenceImage}
+              onClear={handleClearReferenceImage}
+              onStrengthChange={handleReferenceStrengthChange}
+              disabled={statusLoading}
+            />
           )}
 
           <div className="flex items-center gap-2 pt-1 flex-wrap">


### PR DESCRIPTION
Summary
- Extracts the init-image uploader and the FLUX.2 multi-reference uploader out of client/src/pages/ImageGen.jsx (1407 LOC) into focused InitImagePicker and ReferenceImagePicker subcomponents under client/src/components/imageGen/. Behavior-preserving — JSX + props moved verbatim, state and handlers stay in the page and pass down as props. ImageGen.jsx drops to 1305 LOC.
- (The style preset picker referenced in the issue title was already a standalone component, media/StylePresetPicker, used inline; the upload UI was the remaining inline surface to extract.)

Test plan
- New vitest suites InitImagePicker.test.jsx + ReferenceImagePicker.test.jsx (11 tests).
- Full client suite green: 924 tests passed.

Closes #754