### PR TITLE
refactor([issue-751]): collapse AppleScript builders in xcodeScripts.js

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -7,6 +7,7 @@
 
 ## Changed
 
+- **[issue-751]** Collapsed the repeated AppleScript builders in `server/services/xcodeScripts.js` into a shared `xcodeScriptBuilders.js`; the emitted `take_screenshots_macos.sh` is byte-for-byte unchanged. Internal refactor with no behavior difference.
 - **[issue-748]** Extracted the pure command-arg builders and output parsers from `server/services/git.js` into focused `server/lib/git*` modules. Internal refactor with no behavior difference.
 - **[issue-718]** The duplicated optimistic canon-patch handler in the universe canon and Nouns stage editors now lives in one shared `useCanonPatch` hook. Internal refactor with no behavior difference.
 - **[issue-721]** Goal detail badges now use the shared pill component, keeping their look consistent with the rest of the app. Internal maintenance change with no behavior difference.

--- a/server/services/xcodeScriptBuilders.js
+++ b/server/services/xcodeScriptBuilders.js
@@ -1,0 +1,60 @@
+/**
+ * AppleScript fragment builders for the macOS screenshot automation script
+ * emitted by `xcodeScripts.js` (`generateMacScreenshotScript`).
+ *
+ * These produce the literal `osascript -e "…"` shell snippets that get baked
+ * into the generated `take_screenshots_macos.sh`. They are NOT executed here —
+ * the strings are written verbatim into the bash script the user runs.
+ *
+ * The macOS screenshot script drives the app through System Events
+ * accessibility scripting; every UI-automation helper repeats the same
+ * `tell application "System Events" / tell process "<target>"` wrapper and an
+ * optional leading `tell application "<target>" to activate`. Collapsing that
+ * boilerplate into one builder keeps the five helpers (setup_window,
+ * click_sidebar, click_at, go_back, capture_window) from drifting and removes
+ * the bulk of the repeated AppleScript in the file.
+ *
+ * Kept as a sibling `server/services` module (not `server/lib`) because it is
+ * specific to the Xcode script generator and not a general-purpose helper.
+ */
+
+/**
+ * Emit a single-line `osascript -e 'tell application "<target>" to activate'`
+ * snippet (single-quoted form). The trailing redirection is the caller's.
+ */
+export function activateAppLine(targetName) {
+  return `osascript -e 'tell application "${targetName}" to activate'`;
+}
+
+/**
+ * Build an `osascript -e "…"` block that runs an AppleScript body inside a
+ * `tell process "<target>"` / `tell application "System Events"` wrapper.
+ *
+ * Options:
+ *   - body:        AppleScript statements to nest inside the process tell
+ *                  block. Lines are emitted with 8-space indentation so the
+ *                  output matches the hand-written originals.
+ *   - activate:    when true, prefix the script with
+ *                  `tell application "<target>" to activate` (double-quoted,
+ *                  escaped for the outer double-quoted shell string).
+ *   - redirect:    shell redirection appended after the closing quote
+ *                  (e.g. ` 2>/dev/null` or ` 2>/dev/null || true`).
+ *
+ * The result is double-quoted (`osascript -e "…"`) so `\"` escapes are used
+ * for the inner AppleScript string literals, matching the originals exactly.
+ */
+export function osascriptSystemEvents(targetName, { body, activate = false, redirect = '' } = {}) {
+  const lines = [];
+  lines.push('    osascript -e "');
+  if (activate) {
+    lines.push(`    tell application \\"${targetName}\\" to activate`);
+  }
+  lines.push('    tell application \\"System Events\\"');
+  lines.push(`        tell process \\"${targetName}\\"`);
+  for (const bodyLine of body) {
+    lines.push(bodyLine);
+  }
+  lines.push('        end tell');
+  lines.push(`    end tell"${redirect}`);
+  return lines.join('\n');
+}

--- a/server/services/xcodeScriptBuilders.test.js
+++ b/server/services/xcodeScriptBuilders.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { activateAppLine, osascriptSystemEvents } from './xcodeScriptBuilders.js';
+
+describe('xcodeScriptBuilders', () => {
+  describe('activateAppLine', () => {
+    it('emits a single-quoted osascript activate line', () => {
+      expect(activateAppLine('MyApp')).toBe(
+        `osascript -e 'tell application "MyApp" to activate'`
+      );
+    });
+
+    it('interpolates the target name verbatim (no sanitizing)', () => {
+      expect(activateAppLine('My_App')).toBe(
+        `osascript -e 'tell application "My_App" to activate'`
+      );
+    });
+  });
+
+  describe('osascriptSystemEvents', () => {
+    it('wraps the body in a System Events / process tell block (escaped, double-quoted)', () => {
+      const out = osascriptSystemEvents('MyApp', {
+        redirect: ' 2>/dev/null',
+        body: ['            select row 1']
+      });
+      expect(out).toBe(
+        '    osascript -e "\n' +
+        '    tell application \\"System Events\\"\n' +
+        '        tell process \\"MyApp\\"\n' +
+        '            select row 1\n' +
+        '        end tell\n' +
+        '    end tell" 2>/dev/null'
+      );
+    });
+
+    it('prepends an activate tell when activate is true', () => {
+      const out = osascriptSystemEvents('MyApp', {
+        activate: true,
+        redirect: ' 2>/dev/null || true',
+        body: ['            click at {1, 2}']
+      });
+      expect(out).toBe(
+        '    osascript -e "\n' +
+        '    tell application \\"MyApp\\" to activate\n' +
+        '    tell application \\"System Events\\"\n' +
+        '        tell process \\"MyApp\\"\n' +
+        '            click at {1, 2}\n' +
+        '        end tell\n' +
+        '    end tell" 2>/dev/null || true'
+      );
+    });
+
+    it('defaults to no activate and no redirect', () => {
+      const out = osascriptSystemEvents('MyApp', { body: ['            beep'] });
+      expect(out).not.toContain('to activate');
+      expect(out.endsWith('end tell"')).toBe(true);
+    });
+
+    it('emits one line per body entry in order', () => {
+      const out = osascriptSystemEvents('MyApp', {
+        body: ['            line one', '            line two']
+      });
+      expect(out).toContain('            line one\n            line two');
+    });
+  });
+});

--- a/server/services/xcodeScripts.js
+++ b/server/services/xcodeScripts.js
@@ -3,6 +3,7 @@ import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
+import { activateAppLine, osascriptSystemEvents } from './xcodeScriptBuilders.js';
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
@@ -822,43 +823,43 @@ get_window_id() {
 
 # Position and resize window
 setup_window() {
-    osascript -e "
-    tell application \\"System Events\\"
-        tell process \\"${targetName}\\"
-            if (count of windows) > 0 then
-                set position of first window to {100, 100}
-                set size of first window to {\${WINDOW_WIDTH}, \${WINDOW_HEIGHT}}
-            end if
-        end tell
-    end tell" 2>/dev/null
+${osascriptSystemEvents(targetName, {
+    redirect: ' 2>/dev/null',
+    body: [
+      '            if (count of windows) > 0 then',
+      '                set position of first window to {100, 100}',
+      '                set size of first window to {${WINDOW_WIDTH}, ${WINDOW_HEIGHT}}',
+      '            end if'
+    ]
+  })}
 }
 
 # Click a sidebar item by row number
 click_sidebar() {
     local row="$1"
-    osascript -e "
-    tell application \\"System Events\\"
-        tell process \\"${targetName}\\"
-            tell outline 1 of scroll area 1 of group 1 of splitter group 1 of group 1 of window 1
-                select row $row
-            end tell
-        end tell
-    end tell" 2>/dev/null || true
+${osascriptSystemEvents(targetName, {
+    redirect: ' 2>/dev/null || true',
+    body: [
+      '            tell outline 1 of scroll area 1 of group 1 of splitter group 1 of group 1 of window 1',
+      '                select row $row',
+      '            end tell'
+    ]
+  })}
 }
 
 # Click at a position in the window (relative to window top-left, in points)
 click_at() {
     local x="$1" y="$2"
-    osascript -e "
-    tell application \\"${targetName}\\" to activate
-    tell application \\"System Events\\"
-        tell process \\"${targetName}\\"
-            set winPos to position of window 1
-            set absX to (item 1 of winPos) + $x
-            set absY to (item 2 of winPos) + $y
-            click at {absX, absY}
-        end tell
-    end tell" 2>/dev/null || true
+${osascriptSystemEvents(targetName, {
+    activate: true,
+    redirect: ' 2>/dev/null || true',
+    body: [
+      '            set winPos to position of window 1',
+      '            set absX to (item 1 of winPos) + $x',
+      '            set absY to (item 2 of winPos) + $y',
+      '            click at {absX, absY}'
+    ]
+  })}
 }
 
 # Go back via Cmd+[ keyboard shortcut
@@ -874,7 +875,7 @@ go_back() {
 # Take screenshot of the app window
 capture_window() {
     local output_path="$1"
-    osascript -e 'tell application "${targetName}" to activate' 2>/dev/null
+    ${activateAppLine(targetName)} 2>/dev/null
     sleep 0.5
     local wid
     wid=$(get_window_id)

--- a/server/services/xcodeScripts.test.js
+++ b/server/services/xcodeScripts.test.js
@@ -225,6 +225,70 @@ describe('xcodeScripts', () => {
       expect(script).toContain('#!/bin/bash');
       expect(script).toContain('MyApp');
     });
+
+    // The five UI-automation helpers are built from the shared AppleScript
+    // builders in xcodeScriptBuilders.js. These snapshot-style assertions pin
+    // the exact emitted osascript fragments so a builder change that alters
+    // the generated AppleScript fails loudly.
+    it('emits setup_window with the System Events tell wrapper', () => {
+      const script = generateMacScreenshotScript('MyApp', 'net.test.MyApp');
+      expect(script).toContain(
+        'setup_window() {\n' +
+        '    osascript -e "\n' +
+        '    tell application \\"System Events\\"\n' +
+        '        tell process \\"MyApp\\"\n' +
+        '            if (count of windows) > 0 then\n' +
+        '                set position of first window to {100, 100}\n' +
+        '                set size of first window to {${WINDOW_WIDTH}, ${WINDOW_HEIGHT}}\n' +
+        '            end if\n' +
+        '        end tell\n' +
+        '    end tell" 2>/dev/null\n' +
+        '}'
+      );
+    });
+
+    it('emits click_sidebar with select row and || true redirect', () => {
+      const script = generateMacScreenshotScript('MyApp', 'net.test.MyApp');
+      expect(script).toContain(
+        '    osascript -e "\n' +
+        '    tell application \\"System Events\\"\n' +
+        '        tell process \\"MyApp\\"\n' +
+        '            tell outline 1 of scroll area 1 of group 1 of splitter group 1 of group 1 of window 1\n' +
+        '                select row $row\n' +
+        '            end tell\n' +
+        '        end tell\n' +
+        '    end tell" 2>/dev/null || true'
+      );
+    });
+
+    it('emits click_at with a leading activate tell', () => {
+      const script = generateMacScreenshotScript('MyApp', 'net.test.MyApp');
+      expect(script).toContain(
+        '    osascript -e "\n' +
+        '    tell application \\"MyApp\\" to activate\n' +
+        '    tell application \\"System Events\\"\n' +
+        '        tell process \\"MyApp\\"\n' +
+        '            set winPos to position of window 1\n' +
+        '            set absX to (item 1 of winPos) + $x\n' +
+        '            set absY to (item 2 of winPos) + $y\n' +
+        '            click at {absX, absY}\n' +
+        '        end tell\n' +
+        '    end tell" 2>/dev/null || true'
+      );
+    });
+
+    it('emits the single-quoted activate line in capture_window', () => {
+      const script = generateMacScreenshotScript('MyApp', 'net.test.MyApp');
+      expect(script).toContain(
+        `    osascript -e 'tell application "MyApp" to activate' 2>/dev/null`
+      );
+    });
+
+    it('interpolates the target name into all process tells', () => {
+      const script = generateMacScreenshotScript('Cool_App', 'net.test.CoolApp');
+      expect(script).toContain('tell process \\"Cool_App\\"');
+      expect(script).not.toContain('tell process \\"MyApp\\"');
+    });
   });
 
   describe('installScripts', () => {


### PR DESCRIPTION
Summary
- Collapses the repetitive AppleScript string builders in the macOS screenshot helper (generateMacScreenshotScript) of server/services/xcodeScripts.js into a parameterized sibling module server/services/xcodeScriptBuilders.js (osascriptSystemEvents + activateAppLine).
- The emitted take_screenshots_macos.sh is verified byte-for-byte identical for representative target names; deploy.sh and the iOS screenshot script are unchanged.

Test plan
- cd server && npm test (all 440 files / 9372 tests pass)
- New xcodeScriptBuilders.test.js asserts the exact emitted osascript fragments; xcodeScripts.test.js gains snapshot-style assertions pinning the generated AppleScript.

Closes #751