### PR TITLE
feat([issue-705]): CyberCity recent-action timeline overlay

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -6,6 +6,7 @@
 - **`/claim --issues`** — the claim workflow can now pull its work queue from GitHub issues instead of PLAN.md, auto-picking the oldest open issue filed by the repo owner and filing any major code-review findings as new issues. Developer tooling only — no app-facing change.
 - **Episode video model picker** — the pipeline's Episode Video stage now lets you choose which video model renders each scene, alongside the aspect-ratio and quality controls. Leave it on "Default model" to follow your video settings, or pin a specific model; the choice is remembered when you restart a render.
 - **[issue-732] Multi-reference editing on Flux 2 Klein 9B (bf16)** — the full-quality bf16 Flux 2 Klein 9B model now accepts reference images for multi-reference editing. When you supply references it loads the `FLUX.2-klein-9B-kv` repo (tuned for reference editing) instead of the base 9B; plain text and image-to-image renders stay on the base repo. Needs ~64+ GB RAM and the FLUX.2-klein license accepted on Hugging Face.
+- **[issue-705] CyberCity activity timeline** — the CyberCity intel panel gains a TIMELINE tab: a ten-minute activity-density bar over time-bucketed events (just now, last 5 minutes, last 15 minutes, earlier), so you can see at a glance when bursts of system activity happened instead of scrolling a flat log.
 
 ## Changed
 

--- a/client/src/components/city/CityIntelPane.jsx
+++ b/client/src/components/city/CityIntelPane.jsx
@@ -277,6 +277,7 @@ function TimelineView({ logs }) {
         </div>
         <div className="flex items-end gap-px h-8" title="Event density over the last 10 minutes">
           {density.map((slot, i) => {
+            // Floor non-empty bins at 12% so a single event is still visible.
             const heightPct = slot.count > 0 ? Math.max(12, (slot.count / maxCount) * 100) : 0;
             const colorClass = slot.level ? (DENSITY_BAR_COLORS[slot.level] || DENSITY_BAR_COLORS.info) : 'bg-cyan-500/10';
             return (

--- a/client/src/components/city/CityIntelPane.jsx
+++ b/client/src/components/city/CityIntelPane.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { formatClockTime } from '../../utils/formatters';
+import { computeActivityDensity, buildTimelineBuckets } from '../../utils/cityTimeline';
 
 const SEVERITY_RANK = { critical: 0, warning: 1, info: 2 };
 const SEVERITY_COLORS = {
@@ -222,6 +223,115 @@ function ActivityLogList({ logs }) {
   );
 }
 
+const DENSITY_BAR_COLORS = {
+  error: 'bg-red-400',
+  warn: 'bg-amber-400',
+  success: 'bg-emerald-400',
+  info: 'bg-cyan-400',
+  debug: 'bg-gray-600',
+};
+
+const relativeAge = (ms) => {
+  const s = Math.floor(ms / 1000);
+  if (s < 10) return 'now';
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h`;
+};
+
+// Temporal view of the event stream: a density sparkbar (when did bursts of
+// activity happen) over relative-age buckets (what happened, newest first).
+// Reads the same `eventLogs` the ACTIVITY tab does — no new data wiring.
+function TimelineView({ logs }) {
+  const navigate = useNavigate();
+  // Tick `now` every 15s so "2m" ages forward without re-fetching anything.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNow(Date.now()), 15_000);
+    return () => clearInterval(id);
+  }, []);
+
+  const density = useMemo(() => computeActivityDensity(logs, { now }), [logs, now]);
+  const buckets = useMemo(() => buildTimelineBuckets(logs, { now }), [logs, now]);
+  const maxCount = useMemo(() => Math.max(1, ...density.map(d => d.count)), [density]);
+
+  if (!logs || logs.length === 0) {
+    return (
+      <div className="flex-1 flex items-center justify-center px-3 py-6">
+        <div className="font-pixel text-[8px] text-cyan-500/30 tracking-wide">No recent activity</div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex-1 overflow-y-auto px-3 py-2 space-y-2.5"
+      style={{ scrollbarWidth: 'thin', scrollbarColor: 'rgba(6,182,212,0.2) transparent' }}
+    >
+      {/* Density sparkbar — last 10 minutes, oldest at left */}
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <span className="font-pixel text-[8px] text-cyan-500/50 tracking-wider">ACTIVITY · 10 MIN</span>
+          <span className="font-pixel text-[8px] text-cyan-500/30 tracking-wider">NOW {'>'}</span>
+        </div>
+        <div className="flex items-end gap-px h-8" title="Event density over the last 10 minutes">
+          {density.map((slot, i) => {
+            const heightPct = slot.count > 0 ? Math.max(12, (slot.count / maxCount) * 100) : 0;
+            const colorClass = slot.level ? (DENSITY_BAR_COLORS[slot.level] || DENSITY_BAR_COLORS.info) : 'bg-cyan-500/10';
+            return (
+              <div key={i} className="flex-1 flex items-end h-full">
+                <div
+                  className={`w-full rounded-sm ${colorClass} ${slot.count > 0 ? 'opacity-80' : 'opacity-100'}`}
+                  style={{ height: slot.count > 0 ? `${heightPct}%` : '2px' }}
+                />
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Time-bucketed event spine, newest first */}
+      <div className="space-y-2">
+        {buckets.map(bucket => (
+          <div key={bucket.id}>
+            <div className="font-pixel text-[8px] text-cyan-500/40 tracking-widest mb-1 border-b border-cyan-500/10 pb-0.5">
+              {bucket.label}
+            </div>
+            <div className="space-y-1 pl-1">
+              {bucket.events.map(event => {
+                const colorClass = LEVEL_COLORS[event.level] || LEVEL_COLORS.info;
+                const indicatorClass = LEVEL_INDICATORS[event.level] || LEVEL_INDICATORS.info;
+                return (
+                  <div
+                    key={event.id}
+                    className="font-pixel text-[9px] leading-tight flex items-start gap-1.5 tracking-wide group hover:bg-cyan-500/5 rounded px-1 py-0.5 -mx-1"
+                    title={event.message}
+                  >
+                    <span className={`w-1 h-1 rounded-full ${indicatorClass} shrink-0 mt-1 opacity-70`} />
+                    <span className="text-gray-500 shrink-0 w-7 text-right">{relativeAge(event.ageMs)}</span>
+                    <span className={`${colorClass} truncate group-hover:whitespace-normal group-hover:break-all`}>
+                      {event.message || '(event)'}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => navigate('/cos')}
+        className="w-full font-pixel text-[8px] text-cyan-500/40 hover:text-cyan-400 tracking-wider py-1 transition-colors"
+      >
+        OPEN CHIEF OF STAFF {'>'}
+      </button>
+    </div>
+  );
+}
+
 export default function CityIntelPane({ apps, cosAgents, reviewCounts, instances, systemHealth, notificationCounts, eventLogs }) {
   const [tab, setTab] = useState('attention');
   const [collapsed, setCollapsed] = useState(false);
@@ -258,6 +368,18 @@ export default function CityIntelPane({ apps, cosAgents, reviewCounts, instances
           </button>
           <button
             type="button"
+            onClick={() => { setTab('timeline'); setCollapsed(false); }}
+            className={`flex-1 flex items-center justify-center gap-1.5 px-2 py-2 border-l border-cyan-500/20 transition-colors ${
+              tab === 'timeline' && !collapsed
+                ? 'bg-cyan-500/10 text-cyan-400'
+                : 'text-cyan-500/50 hover:bg-cyan-500/5'
+            }`}
+            title="Recent-action timeline"
+          >
+            <span className="font-pixel text-[10px] tracking-wider font-bold">TIMELINE</span>
+          </button>
+          <button
+            type="button"
             onClick={() => { setTab('activity'); setCollapsed(false); }}
             className={`flex-1 flex items-center justify-center gap-1.5 px-2 py-2 border-l border-cyan-500/20 transition-colors ${
               tab === 'activity' && !collapsed
@@ -283,7 +405,9 @@ export default function CityIntelPane({ apps, cosAgents, reviewCounts, instances
         {!collapsed && (
           tab === 'attention'
             ? <AttentionList items={items} />
-            : <ActivityLogList logs={eventLogs} />
+            : tab === 'timeline'
+              ? <TimelineView logs={eventLogs} />
+              : <ActivityLogList logs={eventLogs} />
         )}
       </div>
     </div>

--- a/client/src/utils/cityTimeline.js
+++ b/client/src/utils/cityTimeline.js
@@ -6,17 +6,15 @@
 // and grouping them into relative-age buckets. Both transforms are pure so
 // they can be unit-tested without a DOM (mirrors cityFilter.js).
 
-// Newest-first, only events with a usable timestamp, capped so a runaway log
-// can't blow up the render. `now` is injectable for deterministic tests.
+// Default cap on events the timeline considers, so a runaway log can't blow
+// up the render. `now` is injectable into both transforms for deterministic tests.
 const MAX_TIMELINE_EVENTS = 40;
 
-const normalizeLevel = (level) => {
-  const l = (level || 'info').toLowerCase();
-  if (l === 'warning') return 'warn';
-  if (l === 'err' || l === 'fatal') return 'error';
-  if (l === 'ok' || l === 'done') return 'success';
-  return l;
-};
+// Lower-case so lookups against the lower-cased color maps in CityIntelPane
+// stay robust; the cos:log stream only emits info/warn/error/success/debug, so
+// unknown values just fall through to the maps' info default (same as the
+// sibling ACTIVITY tab).
+const normalizeLevel = (level) => (level || 'info').toLowerCase();
 
 const eventTime = (log) => {
   const t = new Date(log?.timestamp ?? NaN).getTime();

--- a/client/src/utils/cityTimeline.js
+++ b/client/src/utils/cityTimeline.js
@@ -33,16 +33,11 @@ const eventTime = (log) => {
  * @param {number} opts.now - reference "now" epoch ms (injectable for tests)
  * @param {number} [opts.windowMs] - how far back the bar spans (default 10m)
  * @param {number} [opts.bins] - number of bars (default 24)
- * @returns {Array<{count:number, level:string|null, startMs:number}>}
+ * @returns {Array<{count:number, level:string|null}>}
  */
 export function computeActivityDensity(logs, { now, windowMs = 10 * 60 * 1000, bins = 24 } = {}) {
   const slotMs = windowMs / bins;
-  const slots = Array.from({ length: bins }, (_, i) => ({
-    count: 0,
-    level: null,
-    // ms-ago at the START (older edge) of this bin; bin 0 is the oldest.
-    startMs: windowMs - i * slotMs,
-  }));
+  const slots = Array.from({ length: bins }, () => ({ count: 0, level: null }));
 
   const severityRank = { error: 3, warn: 2, success: 1, info: 0, debug: 0 };
 

--- a/client/src/utils/cityTimeline.js
+++ b/client/src/utils/cityTimeline.js
@@ -1,0 +1,111 @@
+// Pure helpers for CyberCity's recent-action timeline overlay.
+//
+// The Intel pane's ACTIVITY tab shows a flat, newest-at-bottom log; the
+// TIMELINE tab instead conveys *cadence* — when bursts of activity happened
+// versus quiet stretches — by binning recent events into a density sparkbar
+// and grouping them into relative-age buckets. Both transforms are pure so
+// they can be unit-tested without a DOM (mirrors cityFilter.js).
+
+// Newest-first, only events with a usable timestamp, capped so a runaway log
+// can't blow up the render. `now` is injectable for deterministic tests.
+const MAX_TIMELINE_EVENTS = 40;
+
+const normalizeLevel = (level) => {
+  const l = (level || 'info').toLowerCase();
+  if (l === 'warning') return 'warn';
+  if (l === 'err' || l === 'fatal') return 'error';
+  if (l === 'ok' || l === 'done') return 'success';
+  return l;
+};
+
+const eventTime = (log) => {
+  const t = new Date(log?.timestamp ?? NaN).getTime();
+  return Number.isFinite(t) ? t : null;
+};
+
+/**
+ * Bin recent events into evenly-spaced time slots for a density sparkbar.
+ * Returns one entry per bin, oldest-first, each `{ count, level }` where
+ * `level` is the highest-severity event in that bin (drives the bar color).
+ *
+ * @param {Array} logs - raw event log entries (`{ timestamp, level }`)
+ * @param {object} opts
+ * @param {number} opts.now - reference "now" epoch ms (injectable for tests)
+ * @param {number} [opts.windowMs] - how far back the bar spans (default 10m)
+ * @param {number} [opts.bins] - number of bars (default 24)
+ * @returns {Array<{count:number, level:string|null, startMs:number}>}
+ */
+export function computeActivityDensity(logs, { now, windowMs = 10 * 60 * 1000, bins = 24 } = {}) {
+  const slotMs = windowMs / bins;
+  const slots = Array.from({ length: bins }, (_, i) => ({
+    count: 0,
+    level: null,
+    // ms-ago at the START (older edge) of this bin; bin 0 is the oldest.
+    startMs: windowMs - i * slotMs,
+  }));
+
+  const severityRank = { error: 3, warn: 2, success: 1, info: 0, debug: 0 };
+
+  (logs || []).forEach(log => {
+    const t = eventTime(log);
+    if (t == null) return;
+    const ageMs = now - t;
+    if (ageMs < 0 || ageMs >= windowMs) return; // outside the visible window
+    // Oldest events land in bin 0, newest in the last bin.
+    const idx = Math.min(bins - 1, Math.floor((windowMs - ageMs) / slotMs));
+    const slot = slots[idx];
+    slot.count += 1;
+    const lvl = normalizeLevel(log.level);
+    if (slot.level == null || (severityRank[lvl] ?? 0) > (severityRank[slot.level] ?? 0)) {
+      slot.level = lvl;
+    }
+  });
+
+  return slots;
+}
+
+// Relative-age buckets, newest first. Each event falls into the first bucket
+// whose `maxAgeMs` it does not exceed; the final bucket is open-ended.
+const BUCKET_DEFS = [
+  { id: 'now', label: 'JUST NOW', maxAgeMs: 60 * 1000 },
+  { id: 'recent', label: 'LAST 5 MIN', maxAgeMs: 5 * 60 * 1000 },
+  { id: 'quarter', label: 'LAST 15 MIN', maxAgeMs: 15 * 60 * 1000 },
+  { id: 'older', label: 'EARLIER', maxAgeMs: Infinity },
+];
+
+/**
+ * Group recent events into relative-age buckets, newest event first within
+ * each bucket. Empty buckets are dropped. Each event carries its normalized
+ * level and ms-age so the renderer can show "2m ago" without re-parsing.
+ *
+ * @param {Array} logs - raw event log entries
+ * @param {object} opts
+ * @param {number} opts.now - reference "now" epoch ms (injectable for tests)
+ * @param {number} [opts.max] - cap on total events considered (default 40)
+ * @returns {Array<{id:string, label:string, events:Array}>}
+ */
+export function buildTimelineBuckets(logs, { now, max = MAX_TIMELINE_EVENTS } = {}) {
+  const dated = (logs || [])
+    .map(log => {
+      const t = eventTime(log);
+      if (t == null) return null;
+      return {
+        id: log._localId ?? `${log.timestamp}-${log.message || log.event || ''}`,
+        ageMs: now - t,
+        timestamp: t,
+        level: normalizeLevel(log.level),
+        message: log.message || log.event || '',
+      };
+    })
+    .filter(e => e && e.ageMs >= 0)
+    .sort((a, b) => b.timestamp - a.timestamp) // newest first
+    .slice(0, max);
+
+  const buckets = BUCKET_DEFS.map(def => ({ id: def.id, label: def.label, events: [] }));
+  dated.forEach(event => {
+    const idx = BUCKET_DEFS.findIndex(def => event.ageMs < def.maxAgeMs);
+    buckets[idx === -1 ? buckets.length - 1 : idx].events.push(event);
+  });
+
+  return buckets.filter(b => b.events.length > 0);
+}

--- a/client/src/utils/cityTimeline.test.js
+++ b/client/src/utils/cityTimeline.test.js
@@ -95,15 +95,15 @@ describe('buildTimelineBuckets', () => {
     expect(total).toBe(10);
   });
 
-  it('normalizes level aliases', () => {
+  it('lower-cases the level and defaults a missing one to info', () => {
     const logs = [
-      { _localId: 1, timestamp: secsAgo(1), level: 'warning', message: 'w' },
-      { _localId: 2, timestamp: secsAgo(2), level: 'OK', message: 'o' },
+      { _localId: 1, timestamp: secsAgo(1), level: 'WARN', message: 'w' },
+      { _localId: 2, timestamp: secsAgo(2), message: 'no-level' },
     ];
     const buckets = buildTimelineBuckets(logs, { now: NOW });
     const levels = buckets.flatMap(b => b.events.map(e => e.level));
     expect(levels).toContain('warn');
-    expect(levels).toContain('success');
+    expect(levels).toContain('info');
   });
 
   it('skips events with future or invalid timestamps', () => {

--- a/client/src/utils/cityTimeline.test.js
+++ b/client/src/utils/cityTimeline.test.js
@@ -7,11 +7,9 @@ const minsAgo = (m) => NOW - m * 60 * 1000;
 const secsAgo = (s) => NOW - s * 1000;
 
 describe('computeActivityDensity', () => {
-  it('returns one slot per bin, oldest first', () => {
+  it('returns one empty slot per bin', () => {
     const slots = computeActivityDensity([], { now: NOW, bins: 24 });
     expect(slots).toHaveLength(24);
-    // bin 0 is the oldest edge of the window
-    expect(slots[0].startMs).toBeGreaterThan(slots[23].startMs);
     expect(slots.every(s => s.count === 0 && s.level === null)).toBe(true);
   });
 

--- a/client/src/utils/cityTimeline.test.js
+++ b/client/src/utils/cityTimeline.test.js
@@ -1,0 +1,121 @@
+import { describe, it, expect } from 'vitest';
+import { computeActivityDensity, buildTimelineBuckets } from './cityTimeline';
+
+// Fixed reference "now" so the relative-age math is deterministic.
+const NOW = 1_700_000_000_000;
+const minsAgo = (m) => NOW - m * 60 * 1000;
+const secsAgo = (s) => NOW - s * 1000;
+
+describe('computeActivityDensity', () => {
+  it('returns one slot per bin, oldest first', () => {
+    const slots = computeActivityDensity([], { now: NOW, bins: 24 });
+    expect(slots).toHaveLength(24);
+    // bin 0 is the oldest edge of the window
+    expect(slots[0].startMs).toBeGreaterThan(slots[23].startMs);
+    expect(slots.every(s => s.count === 0 && s.level === null)).toBe(true);
+  });
+
+  it('bins recent events into the correct slot and counts them', () => {
+    const logs = [
+      { timestamp: secsAgo(5), level: 'info' },   // newest → last bin
+      { timestamp: secsAgo(6), level: 'info' },
+      { timestamp: minsAgo(9.9), level: 'info' }, // oldest → bin 0
+    ];
+    const slots = computeActivityDensity(logs, { now: NOW, windowMs: 10 * 60 * 1000, bins: 24 });
+    expect(slots[slots.length - 1].count).toBe(2);
+    expect(slots[0].count).toBe(1);
+  });
+
+  it('drops events outside the window', () => {
+    const logs = [
+      { timestamp: minsAgo(20), level: 'info' }, // older than 10m window
+      { timestamp: NOW + 5000, level: 'info' },  // future
+    ];
+    const slots = computeActivityDensity(logs, { now: NOW, windowMs: 10 * 60 * 1000, bins: 24 });
+    expect(slots.reduce((n, s) => n + s.count, 0)).toBe(0);
+  });
+
+  it('keeps the highest-severity level per bin', () => {
+    const logs = [
+      { timestamp: secsAgo(5), level: 'info' },
+      { timestamp: secsAgo(6), level: 'error' },
+      { timestamp: secsAgo(7), level: 'warn' },
+    ];
+    const slots = computeActivityDensity(logs, { now: NOW, windowMs: 60 * 1000, bins: 1 });
+    expect(slots[0].count).toBe(3);
+    expect(slots[0].level).toBe('error');
+  });
+
+  it('ignores entries with an unparseable timestamp', () => {
+    const slots = computeActivityDensity(
+      [{ timestamp: 'not-a-date', level: 'info' }, { level: 'info' }],
+      { now: NOW },
+    );
+    expect(slots.reduce((n, s) => n + s.count, 0)).toBe(0);
+  });
+});
+
+describe('buildTimelineBuckets', () => {
+  it('groups events into relative-age buckets, newest first', () => {
+    const logs = [
+      { _localId: 1, timestamp: secsAgo(10), level: 'info', message: 'now-ish' },
+      { _localId: 2, timestamp: minsAgo(3), level: 'warn', message: 'recent' },
+      { _localId: 3, timestamp: minsAgo(12), level: 'error', message: 'quarter' },
+      { _localId: 4, timestamp: minsAgo(40), level: 'info', message: 'older' },
+    ];
+    const buckets = buildTimelineBuckets(logs, { now: NOW });
+    expect(buckets.map(b => b.id)).toEqual(['now', 'recent', 'quarter', 'older']);
+    expect(buckets[0].events[0].message).toBe('now-ish');
+    expect(buckets[2].events[0].level).toBe('error');
+  });
+
+  it('drops empty buckets', () => {
+    const logs = [{ _localId: 1, timestamp: secsAgo(5), level: 'info', message: 'just happened' }];
+    const buckets = buildTimelineBuckets(logs, { now: NOW });
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].id).toBe('now');
+  });
+
+  it('orders events newest-first within a bucket', () => {
+    const logs = [
+      { _localId: 1, timestamp: minsAgo(4), level: 'info', message: 'first' },
+      { _localId: 2, timestamp: minsAgo(2), level: 'info', message: 'second' },
+    ];
+    const buckets = buildTimelineBuckets(logs, { now: NOW });
+    expect(buckets[0].events.map(e => e.message)).toEqual(['second', 'first']);
+  });
+
+  it('caps total events at `max`', () => {
+    const logs = Array.from({ length: 100 }, (_, i) => ({
+      _localId: i,
+      timestamp: secsAgo(i),
+      level: 'info',
+      message: `e${i}`,
+    }));
+    const buckets = buildTimelineBuckets(logs, { now: NOW, max: 10 });
+    const total = buckets.reduce((n, b) => n + b.events.length, 0);
+    expect(total).toBe(10);
+  });
+
+  it('normalizes level aliases', () => {
+    const logs = [
+      { _localId: 1, timestamp: secsAgo(1), level: 'warning', message: 'w' },
+      { _localId: 2, timestamp: secsAgo(2), level: 'OK', message: 'o' },
+    ];
+    const buckets = buildTimelineBuckets(logs, { now: NOW });
+    const levels = buckets.flatMap(b => b.events.map(e => e.level));
+    expect(levels).toContain('warn');
+    expect(levels).toContain('success');
+  });
+
+  it('skips events with future or invalid timestamps', () => {
+    const logs = [
+      { _localId: 1, timestamp: NOW + 60000, level: 'info', message: 'future' },
+      { _localId: 2, timestamp: 'nope', level: 'info', message: 'bad' },
+      { _localId: 3, timestamp: secsAgo(5), level: 'info', message: 'good' },
+    ];
+    const buckets = buildTimelineBuckets(logs, { now: NOW });
+    const msgs = buckets.flatMap(b => b.events.map(e => e.message));
+    expect(msgs).toEqual(['good']);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a **TIMELINE** tab to the CyberCity intel panel — one slice of the CyberCity v2 Phase 2+ roadmap (#705), which lists "recent-action timeline overlay" among its named features.

The existing ACTIVITY tab shows a flat, newest-at-bottom log. The new TIMELINE tab conveys *cadence* instead:
- a **10-minute activity-density sparkbar** (24 bins, colored by the highest-severity event in each bin) so bursts vs. quiet stretches are visible at a glance, and
- a **relative-age event spine** grouped into buckets (just now / last 5 min / last 15 min / earlier), newest first.

It reads the same `eventLogs` socket stream the ACTIVITY tab already consumes — no new endpoints, no 3D/frame-loop changes. The pure transforms live in `client/src/utils/cityTimeline.js` (mirroring the existing `cityFilter.js` pattern) and are unit-tested.

This is **one self-contained slice**; #705 remains open for the rest of Phase 2+ (per-agent spatial trail, system flow lines between buildings, and the broader Phase 2/3 roadmap). Referenced, not closed.

## Test plan

- `client && npx vitest run src/utils/cityTimeline.test.js` — 11 passing (density binning, severity-per-bin, window/future/invalid-timestamp filtering, age-bucket grouping, newest-first ordering, cap, level-alias normalization).
- `client && npm run build` — succeeds.
- `eslint` clean on changed files.
- Manual: open `/city`, switch to the TIMELINE tab, confirm the sparkbar fills as `cos:log` events arrive and ages tick forward.

Relates to #705