### PR TITLE
refactor([issue-741]): extract CoS health monitor from cos.js

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -14,6 +14,7 @@
 
 ## Changed
 
+- **[issue-741]** Extracted the CoS daemon health monitor (PM2/memory checks and errored-process auto-restart) out of the 3300-line `cos.js` into a dedicated `cosHealthMonitor.js` behind an unchanged public API. First slice of the `cos.js` split. Internal refactor with no behavior difference.
 - **[issue-744]** Extracted the scheduled-task prompt catalog and prompt getters out of the 3500-line `taskSchedule.js` into a dedicated `taskPromptService.js`; the prompt defaults and auto-upgrade machinery are moved verbatim and re-exported, so behavior is unchanged. Internal refactor with no behavior difference.
 - **[issue-790]** Unified the duplicated buffered-spawn and Windows kill-tree logic shared by the app build and update flows into one helper. Internal refactor with no behavior difference.
 - **[issue-751]** Collapsed the repeated AppleScript builders in `server/services/xcodeScripts.js` into a shared `xcodeScriptBuilders.js`; the emitted `take_screenshots_macos.sh` is byte-for-byte unchanged. Internal refactor with no behavior difference.

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -5,18 +5,16 @@
  * spawns sub-agents, and orchestrates task completion.
  *
  * Decomposed modules:
- * - cosState.js    — shared state management (loadState, saveState, config, mutex)
- * - cosAgents.js   — agent lifecycle (register, complete, archive, feedback)
- * - cosReports.js  — reports, briefings, and activity tracking
- * - cosEvents.js   — event emitter and logging
+ * - cosState.js          — shared state management (loadState, saveState, config, mutex)
+ * - cosAgents.js         — agent lifecycle (register, complete, archive, feedback)
+ * - cosReports.js        — reports, briefings, and activity tracking
+ * - cosEvents.js         — event emitter and logging
+ * - cosHealthMonitor.js  — daemon health checks (PM2/memory, auto-restart)
  */
 
 import { readFile, writeFile, readdir, rm } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { exec, execFile } from 'child_process';
-import { execPm2 } from './pm2.js';
-import { promisify } from 'util';
 import { v4 as uuidv4 } from '../lib/uuid.js';
 import { getActiveProvider } from './providers.js';
 import { parseTasksMarkdown, groupTasksByStatus, getNextTask, getAutoApprovedTasks, getAwaitingApprovalTasks, updateTaskStatus, generateTasksMarkdown, hasKnownPrefix, isInternalTaskId } from '../lib/taskParser.js';
@@ -43,7 +41,6 @@ import { recordDecision, DECISION_TYPES } from './decisionLog.js';
 import { isRecoveryTask } from './recoveryTasks.js';
 import { getUserTimezone, getLocalParts, nextLocalTime, todayInTimezone } from '../lib/timezone.js';
 import { PORTOS_UI_URL } from '../lib/ports.js';
-import { getMemoryStats } from '../lib/memoryStats.js';
 
 // Shared state management (extracted to avoid circular deps)
 import { loadState, saveState, withStateLock, ensureDirectories, isImprovementEnabled, AGENTS_DIR, REPORTS_DIR, SCRIPTS_DIR, ROOT_DIR, isDaemonRunning, setDaemonRunning } from './cosState.js';
@@ -57,6 +54,11 @@ export { registerAgent, updateAgent, completeAgent, appendAgentOutput, getAgents
 
 // Reports and activity (re-export for backward compat with `import * as cos`)
 export { generateReport, getReport, getTodayReport, listReports, listBriefings, getBriefing, getLatestBriefing, getTodayActivity, getRecentTasks, formatRelativeTime } from './cosReports.js';
+
+// Health monitoring (imported for internal use by start()/init() and re-exported
+// for backward compat with `import * as cos` and the cos route handlers)
+import { runHealthCheck, getHealthStatus } from './cosHealthMonitor.js';
+export { runHealthCheck, getHealthStatus };
 
 const AGENT_ARCHIVE_RETENTION_DAYS = 90;
 const RESUME_DEQUEUE_DELAY_MS = 500;
@@ -74,11 +76,6 @@ const RECENT_COMPLETION_GRACE_MS = 60_000;
 // are flattened to a single line by generateTasksMarkdown, so the comparison
 // must normalize on the first line to match multi-line inputs.
 export const firstLine = (s) => (s || '').split('\n').map(l => l.trim()).find(l => l) || '';
-
-const _execAsync = promisify(exec);
-const _execFileAsync = promisify(execFile);
-const execAsync = (cmd, opts) => _execAsync(cmd, { ...opts, windowsHide: true });
-const execFileAsync = (cmd, args, opts) => _execFileAsync(cmd, args, { ...opts, windowsHide: true });
 
 // MAX_TOTAL_SPAWNS imported from validation.js (shared with subAgentSpawner.js)
 
@@ -2173,132 +2170,6 @@ async function generateManagedAppImprovementTaskForType(taskType, app, state, { 
   };
 
   return task;
-}
-
-/**
- * Run system health check
- */
-export async function runHealthCheck() {
-  if (!isDaemonRunning()) return;
-
-  const state = await loadState();
-  const issues = [];
-  const metrics = {
-    timestamp: new Date().toISOString(),
-    pm2: null,
-    memory: null,
-    ports: null
-  };
-
-  // Check PM2 processes
-  const pm2Result = await execPm2(['jlist']).catch(() => ({ stdout: '[]' }));
-  // pm2 jlist may output ANSI codes and warnings before JSON, extract the JSON array
-  // Look for '[{' (array with objects) or '[]' (empty array) to avoid matching ANSI codes like [31m
-  const pm2Output = pm2Result.stdout || '[]';
-  let jsonStart = pm2Output.indexOf('[{');
-  if (jsonStart < 0) {
-    // Check for empty array - find '[]' that's not part of ANSI codes
-    const emptyMatch = pm2Output.match(/\[\](?![0-9])/);
-    jsonStart = emptyMatch ? pm2Output.indexOf(emptyMatch[0]) : -1;
-  }
-  const pm2Json = jsonStart >= 0 ? pm2Output.slice(jsonStart) : '[]';
-  const pm2Processes = safeJSONParse(pm2Json, [], { logError: true, context: 'pm2 process list' });
-
-  metrics.pm2 = {
-    total: pm2Processes.length,
-    online: pm2Processes.filter(p => p.pm2_env?.status === 'online').length,
-    errored: pm2Processes.filter(p => p.pm2_env?.status === 'errored').length,
-    stopped: pm2Processes.filter(p => p.pm2_env?.status === 'stopped').length
-  };
-
-  // Check for runaway processes (too many)
-  if (pm2Processes.length > state.config.maxTotalProcesses) {
-    issues.push({
-      type: 'warning',
-      category: 'processes',
-      message: `High process count: ${pm2Processes.length} PM2 processes (limit: ${state.config.maxTotalProcesses})`
-    });
-  }
-
-  // Check for errored processes and auto-restart them
-  const erroredProcesses = pm2Processes.filter(p => p.pm2_env?.status === 'errored');
-  if (erroredProcesses.length > 0) {
-    const names = erroredProcesses.map(p => p.name);
-    emitLog('warn', `🔄 ${names.length} errored PM2 process(es) detected: ${names.join(', ')} — attempting restart`);
-
-    const restartResults = await Promise.all(names.map(async (name) => {
-      const result = await execFileAsync('pm2', ['restart', name], { shell: process.platform === 'win32' }).catch(e => ({ stdout: '', stderr: e.message }));
-      const failed = result.stderr && !result.stdout;
-      if (failed) {
-        emitLog('error', `❌ Failed to restart ${name}: ${result.stderr}`);
-      } else {
-        emitLog('success', `✅ Auto-restarted errored process: ${name}`);
-      }
-      return { name, success: !failed };
-    }));
-
-    const failedRestarts = restartResults.filter(r => !r.success);
-    if (failedRestarts.length > 0) {
-      issues.push({
-        type: 'error',
-        category: 'processes',
-        message: `${failedRestarts.length} errored PM2 process(es) failed to auto-restart: ${failedRestarts.map(r => r.name).join(', ')}`
-      });
-    }
-
-    const succeededRestarts = restartResults.filter(r => r.success);
-    if (succeededRestarts.length > 0) {
-      issues.push({
-        type: 'warning',
-        category: 'processes',
-        message: `Auto-restarted ${succeededRestarts.length} errored PM2 process(es): ${succeededRestarts.map(r => r.name).join(', ')}`
-      });
-    }
-  }
-
-  // Check memory usage per process
-  const highMemoryProcesses = pm2Processes.filter(p => {
-    const memMb = (p.monit?.memory || 0) / (1024 * 1024);
-    return memMb > state.config.maxProcessMemoryMb;
-  });
-
-  if (highMemoryProcesses.length > 0) {
-    issues.push({
-      type: 'warning',
-      category: 'memory',
-      message: `High memory usage in: ${highMemoryProcesses.map(p => `${p.name} (${Math.round((p.monit?.memory || 0) / (1024 * 1024))}MB)`).join(', ')}`
-    });
-  }
-
-  metrics.memory = await getMemoryStats();
-
-  // Store health check result with lock to prevent race conditions
-  await withStateLock(async () => {
-    const freshState = await loadState();
-    freshState.stats.lastHealthCheck = metrics.timestamp;
-    freshState.stats.healthIssues = issues;
-    await saveState(freshState);
-  });
-
-  cosEvents.emit('health:check', { metrics, issues });
-
-  // If there are critical issues, emit for potential automated response
-  if (issues.filter(i => i.type === 'error').length > 0) {
-    cosEvents.emit('health:critical', issues.filter(i => i.type === 'error'));
-  }
-
-  return { metrics, issues };
-}
-
-/**
- * Get latest health status
- */
-export async function getHealthStatus() {
-  const state = await loadState();
-  return {
-    lastCheck: state.stats.lastHealthCheck,
-    issues: state.stats.healthIssues || []
-  };
 }
 
 /**

--- a/server/services/cosHealthMonitor.js
+++ b/server/services/cosHealthMonitor.js
@@ -1,0 +1,145 @@
+/**
+ * CoS Health Monitor Module
+ *
+ * Daemon health checks extracted from cos.js. Inspects PM2 process state and
+ * memory usage, auto-restarts errored processes, records the latest health
+ * snapshot to CoS state, and emits health events for downstream consumers.
+ */
+
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { execPm2 } from './pm2.js';
+import { safeJSONParse } from '../lib/fileUtils.js';
+import { getMemoryStats } from '../lib/memoryStats.js';
+import { loadState, saveState, withStateLock, isDaemonRunning } from './cosState.js';
+import { cosEvents, emitLog } from './cosEvents.js';
+
+const _execFileAsync = promisify(execFile);
+const execFileAsync = (cmd, args, opts) => _execFileAsync(cmd, args, { ...opts, windowsHide: true });
+
+/**
+ * Run a daemon health check: inspect PM2 processes and memory, auto-restart
+ * errored processes, store the result, and emit health events.
+ */
+export async function runHealthCheck() {
+  if (!isDaemonRunning()) return;
+
+  const state = await loadState();
+  const issues = [];
+  const metrics = {
+    timestamp: new Date().toISOString(),
+    pm2: null,
+    memory: null,
+    ports: null
+  };
+
+  // Check PM2 processes
+  const pm2Result = await execPm2(['jlist']).catch(() => ({ stdout: '[]' }));
+  // pm2 jlist may output ANSI codes and warnings before JSON, extract the JSON array
+  // Look for '[{' (array with objects) or '[]' (empty array) to avoid matching ANSI codes like [31m
+  const pm2Output = pm2Result.stdout || '[]';
+  let jsonStart = pm2Output.indexOf('[{');
+  if (jsonStart < 0) {
+    // Check for empty array - find '[]' that's not part of ANSI codes
+    const emptyMatch = pm2Output.match(/\[\](?![0-9])/);
+    jsonStart = emptyMatch ? pm2Output.indexOf(emptyMatch[0]) : -1;
+  }
+  const pm2Json = jsonStart >= 0 ? pm2Output.slice(jsonStart) : '[]';
+  const pm2Processes = safeJSONParse(pm2Json, [], { logError: true, context: 'pm2 process list' });
+
+  const erroredProcesses = pm2Processes.filter(p => p.pm2_env?.status === 'errored');
+  metrics.pm2 = {
+    total: pm2Processes.length,
+    online: pm2Processes.filter(p => p.pm2_env?.status === 'online').length,
+    errored: erroredProcesses.length,
+    stopped: pm2Processes.filter(p => p.pm2_env?.status === 'stopped').length
+  };
+
+  // Check for runaway processes (too many)
+  if (pm2Processes.length > state.config.maxTotalProcesses) {
+    issues.push({
+      type: 'warning',
+      category: 'processes',
+      message: `High process count: ${pm2Processes.length} PM2 processes (limit: ${state.config.maxTotalProcesses})`
+    });
+  }
+
+  // Check for errored processes and auto-restart them
+  if (erroredProcesses.length > 0) {
+    const names = erroredProcesses.map(p => p.name);
+    emitLog('warn', `🔄 ${names.length} errored PM2 process(es) detected: ${names.join(', ')} — attempting restart`);
+
+    const restartResults = await Promise.all(names.map(async (name) => {
+      const result = await execFileAsync('pm2', ['restart', name], { shell: process.platform === 'win32' }).catch(e => ({ stdout: '', stderr: e.message }));
+      const failed = result.stderr && !result.stdout;
+      if (failed) {
+        emitLog('error', `❌ Failed to restart ${name}: ${result.stderr}`);
+      } else {
+        emitLog('success', `✅ Auto-restarted errored process: ${name}`);
+      }
+      return { name, success: !failed };
+    }));
+
+    const failedRestarts = restartResults.filter(r => !r.success);
+    if (failedRestarts.length > 0) {
+      issues.push({
+        type: 'error',
+        category: 'processes',
+        message: `${failedRestarts.length} errored PM2 process(es) failed to auto-restart: ${failedRestarts.map(r => r.name).join(', ')}`
+      });
+    }
+
+    const succeededRestarts = restartResults.filter(r => r.success);
+    if (succeededRestarts.length > 0) {
+      issues.push({
+        type: 'warning',
+        category: 'processes',
+        message: `Auto-restarted ${succeededRestarts.length} errored PM2 process(es): ${succeededRestarts.map(r => r.name).join(', ')}`
+      });
+    }
+  }
+
+  // Check memory usage per process
+  const highMemoryProcesses = pm2Processes.filter(p => {
+    const memMb = (p.monit?.memory || 0) / (1024 * 1024);
+    return memMb > state.config.maxProcessMemoryMb;
+  });
+
+  if (highMemoryProcesses.length > 0) {
+    issues.push({
+      type: 'warning',
+      category: 'memory',
+      message: `High memory usage in: ${highMemoryProcesses.map(p => `${p.name} (${Math.round((p.monit?.memory || 0) / (1024 * 1024))}MB)`).join(', ')}`
+    });
+  }
+
+  metrics.memory = await getMemoryStats();
+
+  // Store health check result with lock to prevent race conditions
+  await withStateLock(async () => {
+    const freshState = await loadState();
+    freshState.stats.lastHealthCheck = metrics.timestamp;
+    freshState.stats.healthIssues = issues;
+    await saveState(freshState);
+  });
+
+  cosEvents.emit('health:check', { metrics, issues });
+
+  // If there are critical issues, emit for potential automated response
+  if (issues.filter(i => i.type === 'error').length > 0) {
+    cosEvents.emit('health:critical', issues.filter(i => i.type === 'error'));
+  }
+
+  return { metrics, issues };
+}
+
+/**
+ * Get latest health status
+ */
+export async function getHealthStatus() {
+  const state = await loadState();
+  return {
+    lastCheck: state.stats.lastHealthCheck,
+    issues: state.stats.healthIssues || []
+  };
+}

--- a/server/services/cosHealthMonitor.test.js
+++ b/server/services/cosHealthMonitor.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mock = vi.hoisted(() => ({
+  daemonRunning: true,
+  state: null,
+  savedState: null,
+  pm2Stdout: '[]',
+  restartImpl: null,
+  events: []
+}));
+
+vi.mock('./cosState.js', () => ({
+  loadState: vi.fn(async () => mock.state),
+  saveState: vi.fn(async (s) => { mock.savedState = s; }),
+  withStateLock: async (fn) => fn(),
+  isDaemonRunning: () => mock.daemonRunning
+}));
+
+vi.mock('./pm2.js', () => ({
+  execPm2: vi.fn(async () => ({ stdout: mock.pm2Stdout }))
+}));
+
+vi.mock('../lib/memoryStats.js', () => ({
+  getMemoryStats: vi.fn(async () => ({ usedMb: 100 }))
+}));
+
+vi.mock('./cosEvents.js', () => ({
+  cosEvents: { emit: (name, payload) => mock.events.push({ name, payload }) },
+  emitLog: vi.fn()
+}));
+
+vi.mock('child_process', () => ({
+  execFile: (cmd, args, opts, cb) => mock.restartImpl(cmd, args, opts, cb)
+}));
+
+import { runHealthCheck, getHealthStatus } from './cosHealthMonitor.js';
+
+const baseState = () => ({
+  config: { maxTotalProcesses: 10, maxProcessMemoryMb: 1024 },
+  stats: {}
+});
+
+describe('cosHealthMonitor.runHealthCheck', () => {
+  beforeEach(() => {
+    mock.daemonRunning = true;
+    mock.state = baseState();
+    mock.savedState = null;
+    mock.pm2Stdout = '[]';
+    mock.events = [];
+    // default execFile success
+    mock.restartImpl = (cmd, args, opts, cb) => cb(null, { stdout: 'restarted', stderr: '' });
+  });
+
+  it('short-circuits when the daemon is not running', async () => {
+    mock.daemonRunning = false;
+    const result = await runHealthCheck();
+    expect(result).toBeUndefined();
+    expect(mock.savedState).toBeNull();
+  });
+
+  it('extracts the JSON array from pm2 output prefixed with ANSI noise', async () => {
+    mock.pm2Stdout = '[31mwarning[0m[{"name":"a","pm2_env":{"status":"online"},"monit":{"memory":1000}}]';
+    const { metrics } = await runHealthCheck();
+    expect(metrics.pm2).toEqual({ total: 1, online: 1, errored: 0, stopped: 0 });
+  });
+
+  it('flags a high process count over the configured limit', async () => {
+    const procs = Array.from({ length: 12 }, (_, i) => ({ name: `p${i}`, pm2_env: { status: 'online' }, monit: { memory: 0 } }));
+    mock.pm2Stdout = JSON.stringify(procs);
+    const { issues } = await runHealthCheck();
+    expect(issues.some(i => i.category === 'processes' && /High process count/.test(i.message))).toBe(true);
+  });
+
+  it('auto-restarts errored processes and records a warning on success', async () => {
+    mock.pm2Stdout = JSON.stringify([{ name: 'boom', pm2_env: { status: 'errored' }, monit: { memory: 0 } }]);
+    const { issues } = await runHealthCheck();
+    expect(issues.some(i => i.type === 'warning' && /Auto-restarted 1/.test(i.message))).toBe(true);
+    expect(issues.some(i => i.type === 'error')).toBe(false);
+  });
+
+  it('records an error issue and emits health:critical when a restart fails', async () => {
+    mock.pm2Stdout = JSON.stringify([{ name: 'boom', pm2_env: { status: 'errored' }, monit: { memory: 0 } }]);
+    mock.restartImpl = (cmd, args, opts, cb) => cb(new Error('restart failed'), null);
+    const { issues } = await runHealthCheck();
+    expect(issues.some(i => i.type === 'error' && /failed to auto-restart/.test(i.message))).toBe(true);
+    expect(mock.events.some(e => e.name === 'health:critical')).toBe(true);
+  });
+
+  it('flags processes over the memory limit', async () => {
+    const overLimitBytes = 2048 * 1024 * 1024;
+    mock.pm2Stdout = JSON.stringify([{ name: 'hog', pm2_env: { status: 'online' }, monit: { memory: overLimitBytes } }]);
+    const { issues } = await runHealthCheck();
+    expect(issues.some(i => i.category === 'memory' && /High memory usage/.test(i.message))).toBe(true);
+  });
+
+  it('persists the latest snapshot to state and emits health:check', async () => {
+    mock.pm2Stdout = '[]';
+    const { metrics } = await runHealthCheck();
+    expect(mock.savedState.stats.lastHealthCheck).toBe(metrics.timestamp);
+    expect(mock.events.some(e => e.name === 'health:check')).toBe(true);
+  });
+});
+
+describe('cosHealthMonitor.getHealthStatus', () => {
+  it('returns the persisted last check and issues', async () => {
+    mock.state = { ...baseState(), stats: { lastHealthCheck: 'T', healthIssues: [{ type: 'warning' }] } };
+    const status = await getHealthStatus();
+    expect(status).toEqual({ lastCheck: 'T', issues: [{ type: 'warning' }] });
+  });
+
+  it('defaults issues to an empty array when none recorded', async () => {
+    mock.state = { ...baseState(), stats: {} };
+    const status = await getHealthStatus();
+    expect(status.issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

First slice of the umbrella `cos.js` split (#741, which calls for splitting the 3300-line `server/services/cos.js` into focused modules). This PR extracts the daemon **health monitor** — `runHealthCheck` (PM2 process + memory inspection, errored-process auto-restart, health-event emission) and `getHealthStatus` — into a self-contained `server/services/cosHealthMonitor.js`.

The functions move verbatim. `cos.js` imports them for its internal `start()`/`init()` calls and re-exports them, so the public `import * as cos` API and the existing `cos` route handlers (`cosInsightRoutes`, `cosAgentRoutes`) are unchanged. Now-dead imports (`execPm2`, `getMemoryStats`, `exec`/`execFile`/`promisify`, the `execAsync`/`execFileAsync` wrappers) are removed from `cos.js`.

A focused `cosHealthMonitor.test.js` pins the behaviors that make this slice worth isolating: daemon-not-running short-circuit, ANSI-prefixed PM2 JSON extraction, high-process-count and high-memory flagging, errored-process auto-restart (success → warning, failure → error + `health:critical`), snapshot persistence, and `getHealthStatus` defaults.

This is `Refs`, not `Closes` — #741 is an umbrella issue and remaining slices (task store, generator, job scheduler) stay open for follow-up PRs.

## Test plan

- `cd server && npm test -- cosHealthMonitor` — 9/9 pass
- `cd server && npm test -- cos.test cosInsightRoutes cosAgentRoutes` — 133/133 pass (re-export wiring + route consumers intact)

Refs #741