### PR TITLE
feat([issue-705]): CyberCity backup vault landmark (roadmap 2.3)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -11,6 +11,7 @@
 - **[issue-705] CyberCity agents leave motion trails** — active agents in CyberCity now orbit their building and trail a glowing comet tail that fades behind them, so a busy building reads as moving energy at a glance instead of a static marker. The trail's length follows the graphics quality dial and turns off on the lowest setting.
 - **[issue-705] CyberCity flow lines follow real activity** — the data streams between buildings now trace your live system instead of being random decoration: they only connect buildings that are running, and a link glows brighter and carries more, faster packets when either end has a working agent — so at a glance you can see where work is actually flowing.
 - **[issue-705] CyberCity federation horizon** — your sync peers now appear as distant towers on the city's horizon: each lights up brighter when it's reachable and dims when it goes offline, with a link line reaching toward the city that's solid while syncing and dashed when the connection drops. A "VOID" marker for the primary instance is always there, so the horizon stays meaningful even when you run a single machine.
+- **[issue-705] CyberCity backup vault** — a vault landmark now stands west of downtown and tells you your backup health at a glance: its seal glows green when a recent snapshot is protecting you, ambers as it ages, and turns red and reads "STALE" once a backup is overdue — pulsing blue while one is running. The label shows how long it's been since the last snapshot.
 
 ## Changed
 

--- a/client/src/components/city/CityBackupVault.jsx
+++ b/client/src/components/city/CityBackupVault.jsx
@@ -1,0 +1,67 @@
+import { useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { Text } from '@react-three/drei';
+import { PIXEL_FONT_URL } from './cityConstants';
+import { computeBackupVault } from '../../utils/cityBackupVault';
+import { timeAgo } from '../../utils/formatters';
+
+// CyberCity's backup-vault landmark (roadmap 2.3): a squat armored bunker west of
+// downtown with a glowing circular seal on its face. The seal's color tracks backup
+// health (green protected → amber aging → red stale/failed → blue while a backup
+// runs), it pulses on `backup:started/completed`, and the label shows time-since the
+// last snapshot — going red and reading "STALE" when a backup is overdue.
+export default function CityBackupVault({ backupStatus, settings }) {
+  const vault = useMemo(() => computeBackupVault(backupStatus), [backupStatus]);
+  const sealRef = useRef();
+
+  // Honor the quality dial: drop the seal pulse on the lowest preset, but keep the
+  // static glow so the vault's health is still legible.
+  const animate = (settings?.particleDensity ?? 1) >= 0.5;
+
+  useFrame(({ clock }) => {
+    if (!animate || !sealRef.current) return;
+    // Running backups pulse fast; an alerting (stale/failed) vault throbs urgently;
+    // a healthy vault breathes slowly.
+    const speed = vault.running ? 4 : vault.alerting ? 2.4 : 0.8;
+    const pulse = 0.5 + ((Math.sin(clock.getElapsedTime() * speed) + 1) / 2) * 0.7;
+    sealRef.current.material.emissiveIntensity = pulse * (vault.intensity + 0.3);
+  });
+
+  const { position, width, height, color } = vault;
+  const sublabel = vault.running
+    ? vault.statusLabel
+    : `${vault.statusLabel} · ${timeAgo(vault.lastRun)}`;
+
+  return (
+    <group position={position}>
+      {/* Armored vault body — dark slab with a faint health-tinted glow */}
+      <mesh position={[0, height / 2, 0]}>
+        <boxGeometry args={[width, height, width * 0.8]} />
+        <meshStandardMaterial
+          color="#0a0e16"
+          emissive={color}
+          emissiveIntensity={0.12 + vault.intensity * 0.18}
+          metalness={0.6}
+          roughness={0.5}
+        />
+      </mesh>
+      {/* Beveled cap so it reads as a sealed bunker, not just a box */}
+      <mesh position={[0, height + 0.25, 0]}>
+        <boxGeometry args={[width * 1.1, 0.5, width * 0.9]} />
+        <meshStandardMaterial color="#0d131f" emissive={color} emissiveIntensity={0.25} metalness={0.7} roughness={0.4} />
+      </mesh>
+      {/* Circular vault seal on the front (+Z) face — the live health indicator */}
+      <mesh ref={sealRef} position={[0, height * 0.5, width * 0.4 + 0.05]} rotation={[Math.PI / 2, 0, 0]}>
+        <cylinderGeometry args={[width * 0.28, width * 0.28, 0.12, 24]} />
+        <meshStandardMaterial color={color} emissive={color} emissiveIntensity={vault.intensity} toneMapped={false} />
+      </mesh>
+      {/* Label + status/time-since sublabel above the vault */}
+      <Text position={[0, height + 1.7, 0]} fontSize={1.3} color={color} anchorX="center" anchorY="middle" font={PIXEL_FONT_URL} maxWidth={18}>
+        VAULT
+      </Text>
+      <Text position={[0, height + 0.85, 0]} fontSize={0.85} color="#94a3b8" anchorX="center" anchorY="middle" font={PIXEL_FONT_URL} maxWidth={18}>
+        {sublabel}
+      </Text>
+    </group>
+  );
+}

--- a/client/src/components/city/CityScene.jsx
+++ b/client/src/components/city/CityScene.jsx
@@ -15,6 +15,7 @@ import CityShootingStars from './CityShootingStars';
 import CityVolumetricLights from './CityVolumetricLights';
 import CitySkyline from './CitySkyline';
 import CityFederationHorizon from './CityFederationHorizon';
+import CityBackupVault from './CityBackupVault';
 import CityDataRain from './CityDataRain';
 import CityNeonSigns from './CityNeonSigns';
 import CityEmbers from './CityEmbers';
@@ -25,7 +26,7 @@ import CitySky from './CitySky';
 import PlayerController from './PlayerController';
 import CameraTransition from './CameraTransition';
 
-export default function CityScene({ apps, agentMap, onBuildingClick, cosStatus, reviewCounts, instances, productivityData, settings, playSfx, keysRef, dimmedAppIds }) {
+export default function CityScene({ apps, agentMap, onBuildingClick, cosStatus, reviewCounts, instances, backupStatus, productivityData, settings, playSfx, keysRef, dimmedAppIds }) {
   const [positions, setPositions] = useState(null);
   const [proximityApp, setProximityApp] = useState(null);
   const [transitioning, setTransitioning] = useState(false);
@@ -74,6 +75,7 @@ export default function CityScene({ apps, agentMap, onBuildingClick, cosStatus, 
       {!explorationMode && <CityCelestial settings={settings} />}
       <CitySkyline />
       <CityFederationHorizon instances={instances} settings={settings} />
+      <CityBackupVault backupStatus={backupStatus} settings={settings} />
       <CityGround settings={settings} />
 
       <BuildingCluster

--- a/client/src/hooks/useCityData.js
+++ b/client/src/hooks/useCityData.js
@@ -18,6 +18,7 @@ export const useCityData = () => {
   const [instances, setInstances] = useState({ self: null, peers: [], syncStatus: null });
   const [systemHealth, setSystemHealth] = useState(null);
   const [notificationCounts, setNotificationCounts] = useState({ unread: 0 });
+  const [backupStatus, setBackupStatus] = useState(null);
   const [loading, setLoading] = useState(true);
   const logIdRef = useRef(0);
 
@@ -31,7 +32,7 @@ export const useCityData = () => {
     // /notifications/count returns the lightweight { count } payload — the HUD
     // and Attention pane only need unread, and notifications:count socket
     // events keep it fresh after this initial fetch.
-    const [appsData, agents, cosAgentsData, status, reviewData, instanceData, health, notif] = await Promise.all([
+    const [appsData, agents, cosAgentsData, status, reviewData, instanceData, health, notif, backup] = await Promise.all([
       api.getApps().catch(() => []),
       api.getRunningAgents().catch(() => []),
       api.getCosAgents().catch(() => []),
@@ -40,6 +41,7 @@ export const useCityData = () => {
       api.getInstances().catch(() => ({ self: null, peers: [], syncStatus: null })),
       api.getSystemHealth({ silent: true }).catch(() => null),
       api.getNotificationCount().catch(() => ({ count: 0 })),
+      api.getBackupStatus({ silent: true }).catch(() => null),
     ]);
 
     setApps(appsData);
@@ -50,7 +52,15 @@ export const useCityData = () => {
     setInstances(instanceData);
     setSystemHealth(health);
     setNotificationCounts({ unread: notif?.count ?? 0 });
+    setBackupStatus(backup);
     setLoading(false);
+  }, []);
+
+  // Pull a fresh backup snapshot status — used after backup:completed so the vault
+  // landmark reflects the new lastRun/status without a full fetchAll.
+  const fetchBackup = useCallback(async () => {
+    const backup = await api.getBackupStatus({ silent: true }).catch(() => null);
+    if (backup) setBackupStatus(backup);
   }, []);
 
   const healthInFlightRef = useRef(false);
@@ -157,6 +167,13 @@ export const useCityData = () => {
     socket.on('notifications:count', handleNotifCount);
     socket.on('notifications:cleared', handleNotifCleared);
 
+    // Backup vault landmark: mark in-flight on start (so the seal pulses blue), then
+    // refetch on completion to pick up the fresh lastRun/status and clear `running`.
+    const handleBackupStarted = () => setBackupStatus(prev => ({ ...(prev || {}), running: true }));
+    const handleBackupCompleted = () => fetchBackup();
+    socket.on('backup:started', handleBackupStarted);
+    socket.on('backup:completed', handleBackupCompleted);
+
     // Subscribe but do NOT unsubscribe on cleanup. The cos:* and notifications:*
     // namespaces are shared (useNotifications in Layout, useAgentFeedbackToast).
     // Server uses a per-socket Set, so unsubscribing here would yank the
@@ -172,8 +189,10 @@ export const useCityData = () => {
       socket.off('cos:status', handleCosStatus);
       socket.off('notifications:count', handleNotifCount);
       socket.off('notifications:cleared', handleNotifCleared);
+      socket.off('backup:started', handleBackupStarted);
+      socket.off('backup:completed', handleBackupCompleted);
     };
-  }, [fetchAll, fetchApps]);
+  }, [fetchAll, fetchApps, fetchBackup]);
 
   return {
     apps,
@@ -186,6 +205,7 @@ export const useCityData = () => {
     instances,
     systemHealth,
     notificationCounts,
+    backupStatus,
     loading,
     connected: socket.connected,
   };

--- a/client/src/hooks/useCityData.js
+++ b/client/src/hooks/useCityData.js
@@ -170,7 +170,12 @@ export const useCityData = () => {
     // Backup vault landmark: mark in-flight on start (so the seal pulses blue), then
     // refetch on completion to pick up the fresh lastRun/status and clear `running`.
     const handleBackupStarted = () => setBackupStatus(prev => ({ ...(prev || {}), running: true }));
-    const handleBackupCompleted = () => fetchBackup();
+    // Clear `running` optimistically so the seal stops pulsing blue even if the
+    // refetch fails, then pull authoritative lastRun/status from the server.
+    const handleBackupCompleted = () => {
+      setBackupStatus(prev => (prev?.running ? { ...prev, running: false } : prev));
+      fetchBackup();
+    };
     socket.on('backup:started', handleBackupStarted);
     socket.on('backup:completed', handleBackupCompleted);
 

--- a/client/src/pages/CyberCity.jsx
+++ b/client/src/pages/CyberCity.jsx
@@ -13,7 +13,7 @@ import CitySettingsPanel from '../components/city/CitySettingsPanel';
 import { computeFilterResult } from '../utils/cityFilter';
 
 function CyberCityInner() {
-  const { apps, cosAgents, cosStatus, eventLogs, agentMap, reviewCounts, instances, systemHealth, notificationCounts, loading, connected } = useCityData();
+  const { apps, cosAgents, cosStatus, eventLogs, agentMap, reviewCounts, instances, systemHealth, notificationCounts, backupStatus, loading, connected } = useCityData();
   const { settings, updateSetting } = useCitySettingsContext();
   const { playSfx } = useCityAudio(settings);
   const navigate = useNavigate();
@@ -106,6 +106,7 @@ function CyberCityInner() {
         cosStatus={cosStatus}
         reviewCounts={reviewCounts}
         instances={instances}
+        backupStatus={backupStatus}
         productivityData={productivityData}
         settings={settings}
         playSfx={playSfx}

--- a/client/src/utils/cityBackupVault.js
+++ b/client/src/utils/cityBackupVault.js
@@ -1,0 +1,84 @@
+// Pure, deterministic helpers for CyberCity's backup-vault landmark (roadmap 2.3):
+// a small monument west of downtown whose color, label, and pulse reflect backup
+// health. The vault derives "staleness" from the time since the last snapshot, so a
+// backup that hasn't run in too long glows red and reads as needing attention. No
+// three.js / React imports so the topology is unit-testable (mirrors cityFederation.js).
+
+export const VAULT = {
+  position: [-34, 0, -10], // west of the building grid, clear of downtown and the +Z archive district
+  width: 5,
+  height: 8,
+  // Staleness thresholds, in ms since the last snapshot. A fresh backup is healthy;
+  // between fresh and stale it ages to amber; past `staleMs` it goes red.
+  freshMs: 24 * 60 * 60 * 1000, // < 1 day → healthy
+  staleMs: 3 * 24 * 60 * 60 * 1000, // ≥ 3 days → stale
+};
+
+// Color per health classification — reuses the PortOS Tailwind design tokens so the
+// vault speaks the same visual language as the rest of the UI.
+const HEALTH_COLORS = {
+  ok: '#22c55e', // port-success — recent snapshot
+  aging: '#f59e0b', // port-warning — getting old
+  stale: '#ef4444', // port-error — overdue
+  error: '#ef4444', // port-error — last run failed
+  never: '#64748b', // slate — never backed up / not configured
+  running: '#3b82f6', // port-accent — a backup is in flight
+};
+
+// Map persisted backup state → a health classification. `state.status` is the stored
+// status ('never' | 'ok' | 'error'); `state.lastRun` is the ISO timestamp of the last
+// run (or null); `state.running` is set true while a backup is in flight (socket-driven).
+// `now` is injected so the staleness derivation is deterministic in tests.
+export function vaultHealth(state, now = Date.now()) {
+  if (state?.running) return 'running';
+  const status = state?.status || 'never';
+  if (status === 'error') return 'error';
+  if (status === 'never' || !state?.lastRun) return 'never';
+  const last = new Date(state.lastRun).getTime();
+  if (!Number.isFinite(last)) return 'never';
+  const age = now - last;
+  if (age >= VAULT.staleMs) return 'stale';
+  if (age >= VAULT.freshMs) return 'aging';
+  return 'ok';
+}
+
+export function vaultColor(health) {
+  return HEALTH_COLORS[health] || HEALTH_COLORS.never;
+}
+
+// Should the vault read as needing attention (urgent pulse, brighter glow)?
+export function vaultIsAlerting(health) {
+  return health === 'stale' || health === 'error';
+}
+
+// Short uppercase label rendered under the monument.
+export function vaultStatusLabel(health) {
+  switch (health) {
+    case 'running': return 'BACKING UP';
+    case 'ok': return 'PROTECTED';
+    case 'aging': return 'AGING';
+    case 'stale': return 'STALE';
+    case 'error': return 'FAILED';
+    default: return 'NO BACKUP';
+  }
+}
+
+// Full derived view-model for the component: geometry + health + color + alert flag +
+// emissive intensity (brighter while running or alerting, calm otherwise). `now` is
+// injected so the whole view-model is deterministic under test.
+export function computeBackupVault(state, now = Date.now()) {
+  const health = vaultHealth(state, now);
+  const alerting = vaultIsAlerting(health);
+  return {
+    position: VAULT.position,
+    width: VAULT.width,
+    height: VAULT.height,
+    health,
+    color: vaultColor(health),
+    alerting,
+    running: health === 'running',
+    statusLabel: vaultStatusLabel(health),
+    lastRun: state?.lastRun ?? null,
+    intensity: health === 'running' ? 1 : alerting ? 0.85 : 0.5,
+  };
+}

--- a/client/src/utils/cityBackupVault.test.js
+++ b/client/src/utils/cityBackupVault.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+  VAULT,
+  vaultHealth,
+  vaultColor,
+  vaultIsAlerting,
+  vaultStatusLabel,
+  computeBackupVault,
+} from './cityBackupVault';
+
+const NOW = new Date('2026-06-03T12:00:00Z').getTime();
+const hoursAgo = (h) => new Date(NOW - h * 60 * 60 * 1000).toISOString();
+const daysAgo = (d) => new Date(NOW - d * 24 * 60 * 60 * 1000).toISOString();
+
+describe('vaultHealth', () => {
+  it('returns "never" when there is no state, no lastRun, or status never', () => {
+    expect(vaultHealth(undefined, NOW)).toBe('never');
+    expect(vaultHealth({}, NOW)).toBe('never');
+    expect(vaultHealth({ status: 'never', lastRun: null }, NOW)).toBe('never');
+  });
+
+  it('returns "never" when lastRun is an unparseable timestamp', () => {
+    expect(vaultHealth({ status: 'ok', lastRun: 'not-a-date' }, NOW)).toBe('never');
+  });
+
+  it('returns "ok" for a snapshot inside the fresh window', () => {
+    expect(vaultHealth({ status: 'ok', lastRun: hoursAgo(2) }, NOW)).toBe('ok');
+  });
+
+  it('ages to "aging" between the fresh and stale thresholds', () => {
+    expect(vaultHealth({ status: 'ok', lastRun: daysAgo(2) }, NOW)).toBe('aging');
+  });
+
+  it('goes "stale" once past the stale threshold', () => {
+    expect(vaultHealth({ status: 'ok', lastRun: daysAgo(5) }, NOW)).toBe('stale');
+  });
+
+  it('treats the thresholds as inclusive lower bounds', () => {
+    expect(vaultHealth({ status: 'ok', lastRun: new Date(NOW - VAULT.freshMs).toISOString() }, NOW)).toBe('aging');
+    expect(vaultHealth({ status: 'ok', lastRun: new Date(NOW - VAULT.staleMs).toISOString() }, NOW)).toBe('stale');
+  });
+
+  it('reports "error" when the last run failed, regardless of age', () => {
+    expect(vaultHealth({ status: 'error', lastRun: hoursAgo(1) }, NOW)).toBe('error');
+  });
+
+  it('reports "running" when a backup is in flight, overriding everything', () => {
+    expect(vaultHealth({ status: 'error', lastRun: daysAgo(9), running: true }, NOW)).toBe('running');
+  });
+});
+
+describe('vaultColor', () => {
+  it('maps each health to a distinct token; stale and error share the error red', () => {
+    expect(vaultColor('ok')).toBe('#22c55e');
+    expect(vaultColor('aging')).toBe('#f59e0b');
+    expect(vaultColor('stale')).toBe('#ef4444');
+    expect(vaultColor('error')).toBe('#ef4444');
+    expect(vaultColor('running')).toBe('#3b82f6');
+    expect(vaultColor('never')).toBe('#64748b');
+  });
+
+  it('falls back to the never color for an unknown health', () => {
+    expect(vaultColor('bogus')).toBe(vaultColor('never'));
+  });
+});
+
+describe('vaultIsAlerting', () => {
+  it('alerts only on stale or error', () => {
+    expect(vaultIsAlerting('stale')).toBe(true);
+    expect(vaultIsAlerting('error')).toBe(true);
+    expect(vaultIsAlerting('ok')).toBe(false);
+    expect(vaultIsAlerting('aging')).toBe(false);
+    expect(vaultIsAlerting('running')).toBe(false);
+    expect(vaultIsAlerting('never')).toBe(false);
+  });
+});
+
+describe('vaultStatusLabel', () => {
+  it('gives a label for every health and a default for unknown', () => {
+    expect(vaultStatusLabel('running')).toBe('BACKING UP');
+    expect(vaultStatusLabel('ok')).toBe('PROTECTED');
+    expect(vaultStatusLabel('aging')).toBe('AGING');
+    expect(vaultStatusLabel('stale')).toBe('STALE');
+    expect(vaultStatusLabel('error')).toBe('FAILED');
+    expect(vaultStatusLabel('never')).toBe('NO BACKUP');
+    expect(vaultStatusLabel('bogus')).toBe('NO BACKUP');
+  });
+});
+
+describe('computeBackupVault', () => {
+  it('carries the fixed geometry through unchanged', () => {
+    const vm = computeBackupVault({ status: 'ok', lastRun: hoursAgo(1) }, NOW);
+    expect(vm.position).toEqual(VAULT.position);
+    expect(vm.width).toBe(VAULT.width);
+    expect(vm.height).toBe(VAULT.height);
+  });
+
+  it('a fresh backup is calm, protected, and not alerting', () => {
+    const vm = computeBackupVault({ status: 'ok', lastRun: hoursAgo(1) }, NOW);
+    expect(vm.health).toBe('ok');
+    expect(vm.alerting).toBe(false);
+    expect(vm.running).toBe(false);
+    expect(vm.statusLabel).toBe('PROTECTED');
+    expect(vm.intensity).toBe(0.5);
+  });
+
+  it('a stale backup alerts and burns brighter', () => {
+    const vm = computeBackupVault({ status: 'ok', lastRun: daysAgo(5) }, NOW);
+    expect(vm.health).toBe('stale');
+    expect(vm.alerting).toBe(true);
+    expect(vm.intensity).toBe(0.85);
+    expect(vm.color).toBe('#ef4444');
+  });
+
+  it('a running backup is the brightest and exposes running=true', () => {
+    const vm = computeBackupVault({ status: 'ok', lastRun: hoursAgo(1), running: true }, NOW);
+    expect(vm.health).toBe('running');
+    expect(vm.running).toBe(true);
+    expect(vm.intensity).toBe(1);
+  });
+
+  it('passes lastRun through for the time-since label, null when never', () => {
+    expect(computeBackupVault({ status: 'ok', lastRun: hoursAgo(3) }, NOW).lastRun).toBe(hoursAgo(3));
+    expect(computeBackupVault({ status: 'never' }, NOW).lastRun).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Ships the **backup vault landmark** slice (roadmap item 2.3) of the CyberCity v2 Phase 2+ umbrella (#705). A squat armored vault now stands west of downtown, west of the building grid and clear of the +Z archive district, with a glowing circular seal on its face that reports your backup health at a glance:

- **green** — a recent snapshot is protecting the city
- **amber** — the snapshot is aging (between 1 and 3 days old)
- **red, "STALE"** — a backup is overdue (≥ 3 days) or the last run failed
- **blue, pulsing fast** — a backup is currently running

The label under the vault shows how long it's been since the last snapshot. The seal pulses on `backup:started` / `backup:completed` socket events, and the pulse animation is gated on the graphics quality dial (off on the lowest preset, like the other city effects).

This follows the established federation-horizon slice pattern exactly: a pure, unit-tested helper (`cityBackupVault.js`, mirroring `cityFederation.js`) deriving health/color/staleness, a thin 3D component (`CityBackupVault.jsx`), and backup status wired into the shared `useCityData` hook (initial fetch + `backup:started`/`completed` handlers) rather than fetched inside the component.

Both originally-named Phase 2 drill-down items shipped earlier; this continues the broader roadmap. Remaining open items (AI Core beams 2.1, CoS task-queue silhouette 2.2, voice marker 2.4, productivity district 2.6, goal monuments 2.7, mini-map 2.8, health vitals 2.9, XP HUD 2.11, Phase 3) stay tracked on the umbrella.

Refs #705

## Test plan

- `cd client && npx vitest run src/utils/cityBackupVault.test.js` — 17 tests covering health classification (never/ok/aging/stale/error/running), threshold boundaries (inclusive lower bounds), color mapping, alert predicate, status labels, and the assembled view-model.
- `npx vitest run src/utils/cityFederation.test.js` — sibling slice still green (no regression).
- `eslint` clean on all changed files.
- Manual: open `/cybercity`, confirm the VAULT landmark renders west of downtown with a seal color matching backup state; trigger a backup and confirm the seal pulses blue then settles to green with an updated "time since" label.