### PR TITLE
Add Settings → Security to the sidebar nav

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -84,6 +84,7 @@
 
 ## Fixed
 
+- **Security settings reachable from the sidebar** — the Settings → Security tab now has its own entry in the sidebar's Settings group, so you can open it without typing the URL or going through ⌘K. The tab, its route, and command-palette/voice navigation already existed; only the sidebar link was missing.
 - **[issue-729] Style-probe renders stay put across federated machines** — a universe's base style-probe images are now kept local to each machine, so syncing with an older peer no longer wipes them and a probe render no longer surfaces a phantom sync conflict.
 - **[issue-717] No stray React warnings when you navigate away mid-action** — buttons that run an async task (save, generate, sync) no longer log an "update on an unmounted component" warning if you leave the page before the task finishes.
 - **[issue-719] Steadier media galleries during live note/star sync** — incoming annotation broadcasts that match what a view already shows no longer trigger a needless re-render of the media cards.

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -59,6 +59,7 @@ import {
   Link2,
   Database,
   Shield,
+  Lock,
   Wand2,
   Zap,
   Inbox,
@@ -292,6 +293,7 @@ const navItems = [
       { to: '/settings/mortalloom', label: 'MortalLoom', icon: Activity },
       { to: '/prompts', label: 'Prompts', icon: FileText },
       { to: '/ai', label: 'Providers', icon: Bot },
+      { to: '/settings/security', label: 'Security', icon: Lock },
       { to: '/settings/sharing', label: 'Sharing', icon: Share2 },
       { to: '/settings/telegram', label: 'Telegram', icon: MessageSquare },
       { to: '/settings/voice', label: 'Voice', icon: Mic }


### PR DESCRIPTION
## Summary

The **Settings → Security** tab already existed — its component (`SecurityTab`), route (`/settings/security`), settings sub-nav pill (`SettingsTabsHeader`), and command-palette/voice nav-manifest entry were all in place — but it had no link in the sidebar's **Settings** group, so it was only reachable by typing the URL or using ⌘K.

This adds that missing sidebar entry.

## Changes

- `client/src/components/Layout.jsx`: import the `Lock` icon and add a `{ to: '/settings/security', label: 'Security', icon: Lock }` child to the Settings nav group, placed alphabetically between Providers and Sharing (per the project's alphabetical-navigation convention).
- `.changelog/NEXT.md`: add a Fixed entry noting the sidebar link.

## Verification

- `server` vitest: `navManifest.test.js` + `palette.test.js` — 53 tests passing
- `client` Vite build succeeds (confirms the `Lock` import resolves)