### PR TITLE
Fix CyberCity canvas crash from drei <Line> fat-line geometry

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -103,6 +103,7 @@
 
 ## Fixed
 
+- **[issue-705] CyberCity no longer crashes when light connectors are on screen** — the memory district's category bridges and the goal-tree links rendered through a line primitive that depended on a fat-line geometry method (`computeLineDistances`) missing from this build's 3D stack, which crashed the whole CyberCity canvas as soon as either was visible. Those connectors now draw as native glowing tubes — no dependency on that method — so the city renders cleanly, with a bit more presence to the links as a bonus.
 - **Security settings reachable from the sidebar** — the Settings → Security tab now has its own entry in the sidebar's Settings group, so you can open it without typing the URL or going through ⌘K. The tab, its route, and command-palette/voice navigation already existed; only the sidebar link was missing.
 - **[issue-729] Style-probe renders stay put across federated machines** — a universe's base style-probe images are now kept local to each machine, so syncing with an older peer no longer wipes them and a probe render no longer surfaces a phantom sync conflict.
 - **[issue-717] No stray React warnings when you navigate away mid-action** — buttons that run an async task (save, generate, sync) no longer log an "update on an unmounted component" warning if you leave the page before the task finishes.

--- a/client/src/components/city/CityGoalMonuments.jsx
+++ b/client/src/components/city/CityGoalMonuments.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { Text, Line } from '@react-three/drei';
+import { Text } from '@react-three/drei';
+import CityTubeLine from './CityTubeLine';
 import { PIXEL_FONT_URL } from './cityConstants';
 import { computeGoalMonuments, computeGoalForest, MONUMENTS, FOREST } from '../../utils/cityGoalMonuments';
 
@@ -129,12 +130,11 @@ function GoalForest({ forest, shimmerRef, shimmerId }) {
             </group>
           ))}
           {cluster.links.map((link) => (
-            <Line
+            <CityTubeLine
               key={link.childId}
               points={[link.from, link.to]}
               color={cluster.spire.color}
-              lineWidth={1.5}
-              transparent
+              radius={0.06}
               opacity={0.4}
             />
           ))}

--- a/client/src/components/city/CityMemoryDistrict.jsx
+++ b/client/src/components/city/CityMemoryDistrict.jsx
@@ -1,7 +1,8 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { Text, Line } from '@react-three/drei';
+import { Text } from '@react-three/drei';
 import { PIXEL_FONT_URL } from './cityConstants';
+import CityTubeLine from './CityTubeLine';
 import { computeMemoryDistrict, MEMORY_DISTRICT } from '../../utils/cityMemoryDistrict';
 
 // CyberCity's memory / knowledge district (roadmap 3.2): the user's long-term memory graph
@@ -124,12 +125,11 @@ export default function CityMemoryDistrict({ memoryGraph, inboxDepth = 0, settin
         // Arc the midpoint up so bridges read as light arcs, not flat lines.
         const mid = [(from[0] + to[0]) / 2, MEMORY_DISTRICT.bridgeY + 2 + Math.min(bridge.weight, 6) * 0.3, (from[2] + to[2]) / 2];
         return (
-          <Line
+          <CityTubeLine
             key={i}
             points={[from, mid, to]}
             color="#67e8f9"
-            lineWidth={Math.min(1 + bridge.weight * 0.5, 4)}
-            transparent
+            radius={Math.min(0.05 + bridge.weight * 0.03, 0.22)}
             opacity={Math.min(0.25 + bridge.weight * 0.12, 0.8)}
           />
         );

--- a/client/src/components/city/CityTubeLine.jsx
+++ b/client/src/components/city/CityTubeLine.jsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react';
+import * as THREE from 'three';
+
+// A thin glowing connector rendered as a native-three tube along a curve through `points`.
+// Used for CyberCity's light bridges (memory district) and goal-tree links. We deliberately do
+// NOT use drei's <Line>: it builds a three-stdlib Line2 whose fat-line geometry needs
+// `computeLineDistances`, and the bundled three-stdlib instance mismatches the app's three
+// (0.182), so that method is missing on the reconciled object and the whole Canvas crashes
+// ("m.computeLineDistances is not a function"). A TubeGeometry needs none of that, gives real
+// width (native LineBasicMaterial ignores linewidth anyway), and reads better as a glow.
+export default function CityTubeLine({ points, color, radius = 0.08, opacity = 0.5, segments = 24 }) {
+  const geometry = useMemo(() => {
+    const pts = (points || []).filter(Boolean).map((p) => new THREE.Vector3(p[0], p[1], p[2]));
+    if (pts.length < 2) return null;
+    const curve = new THREE.CatmullRomCurve3(pts);
+    // Tubular segments scale with point count so a multi-point arc stays smooth.
+    return new THREE.TubeGeometry(curve, Math.max(segments, pts.length * 8), radius, 6, false);
+  }, [points, radius, segments]);
+
+  if (!geometry) return null;
+
+  return (
+    <mesh geometry={geometry}>
+      <meshBasicMaterial color={color} transparent opacity={opacity} toneMapped={false} />
+    </mesh>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes a hard crash on `/city`: `TypeError: m.computeLineDistances is not a function`, which takes down the whole CyberCity canvas (caught by the error boundary, so the page is unusable).

**Root cause:** drei's `<Line>` constructs a `Line2` from its **bundled** `three-stdlib` and calls `.computeLineDistances()` on it. That object is reconciled by r3f against the **app's** `three@0.182` — a different three instance — so the fat-line method isn't present on the reconciled object and every mounted `<Line>` throws. It surfaced now because the memory district's category **bridges** (shipped in #871) are the first drei `<Line>` to reliably mount; the only other use — goal-tree links in `CityGoalMonuments` — only renders in a rarely-hit hierarchy mode, so the same latent crash was lurking there too.

**Fix:** replace drei `<Line>` with a small native-three `CityTubeLine` (a `TubeGeometry` swept along a `CatmullRomCurve3`) in **both** call sites. No `Line2`, no `computeLineDistances`, no dual-three-instance hazard. It also gives real, controllable width (native `LineBasicMaterial` ignores `linewidth` anyway) and reads better as a glowing connector. Zero new dependencies.

Files:
- `client/src/components/city/CityTubeLine.jsx` — new shared connector component (documents *why* it avoids drei `<Line>`).
- `CityMemoryDistrict.jsx` — bridges now use `CityTubeLine` (radius scales with link weight).
- `CityGoalMonuments.jsx` — goal-tree links now use `CityTubeLine` (fixes the same latent crash).

**Follow-up (not in this PR):** bringing the react-three stack current — drei 10 / fiber 9, which require React 19 across the whole app — is tracked in #880. This fix removes the dependency on the broken `<Line>` path, so that upgrade is no longer a fire and can be done deliberately.

## Test plan

- `npx vite build` — client compiles.
- `npx vitest run src/utils/ src/components/city/` — 509 tests green.
- `npx eslint` on changed files — clean.
- Manual: `/city` renders without the `computeLineDistances` crash; memory-district bridges and (in hierarchy mode) goal-tree links draw as glowing tubes.

Refs #705