### PR TITLE
Stop Chief of Staff avatar panel clipping its stats grid on tall viewports

### DIFF
--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -674,7 +674,7 @@ export default function ChiefOfStaff() {
           {/* Collapsible Content */}
           <div
             id="cos-agent-panel"
-            className={`${agentPanelCollapsed ? 'hidden' : 'flex'} lg:flex min-w-0 relative overflow-hidden ${hasCanvasAvatar ? 'flex-none min-h-[180px] sm:min-h-[190px] md:min-h-[190px] lg:h-[min(460px,calc(100vh-1rem))] xl:h-[min(620px,calc(100vh-1rem))]' : 'flex-1'}`}
+            className={`${agentPanelCollapsed ? 'hidden' : 'flex'} lg:flex min-w-0 relative overflow-hidden ${hasCanvasAvatar ? 'flex-none min-h-[180px] sm:min-h-[190px] md:min-h-[190px] lg:min-h-[min(460px,calc(100vh-1rem))] xl:min-h-[min(620px,calc(100vh-1rem))]' : 'flex-1'}`}
           >
             {/* Background Effects */}
             <div
@@ -694,7 +694,7 @@ export default function ChiefOfStaff() {
             )}
 
             {/* Avatar UI overlays the full-width canvas stage for 3D styles. */}
-            <div className={`${hasCanvasAvatar ? 'absolute inset-y-0 left-0 w-[46%] lg:relative lg:inset-auto lg:w-full lg:flex-none lg:h-full p-2 sm:p-3 lg:px-4 lg:py-6' : 'relative flex-1 min-w-0 lg:flex-none lg:h-full p-2 lg:px-4 lg:py-6'} min-w-0 flex flex-col items-center z-10`}>
+            <div className={`${hasCanvasAvatar ? 'absolute inset-y-0 left-0 w-[46%] lg:relative lg:inset-auto lg:w-full lg:flex-none lg:min-h-full p-2 sm:p-3 lg:px-4 lg:py-6' : 'relative flex-1 min-w-0 lg:flex-none lg:min-h-full p-2 lg:px-4 lg:py-6'} min-w-0 flex flex-col items-center z-10`}>
               <div className="hidden lg:block text-sm font-semibold tracking-widest uppercase text-slate-400 mb-1 font-mono">
                 Digital Assistant
               </div>


### PR DESCRIPTION
## Summary

The Chief of Staff info pane (canvas-avatar layout) was getting cut off at the bottom even when there was plenty of vertical space — the lower stat-grid rows (Done / Issues / Learning / Start) and the status bubble were clipped below the fold, leaving only the top `Active` / `Pending` row visible.

The cause is in `client/src/pages/ChiefOfStaff.jsx`: the canvas-avatar panel was given a **fixed** height (`lg:h-[min(460px,calc(100vh-1rem))]`, `xl:h-[min(620px,…)]`) together with `overflow-hidden`, and its inner avatar/UI overlay was pinned to `lg:h-full`. On a tall viewport the `min()` still resolved to 460px, so the panel never grew to fit its content and `overflow-hidden` clipped everything past 460px.

The fix swaps the fixed heights for minimums:
- Panel: `lg:h-[min(460px,…)]` → `lg:min-h-[min(460px,…)]` (and the `xl` variant).
- Avatar/UI overlay: `lg:h-full` → `lg:min-h-full` (both branches).

Now the panel grows to fit its content while keeping 460px/620px as a floor (and still shrinking on short viewports via the `calc(100vh-1rem)` term). `overflow-hidden` is retained so the decorative, translated canvas avatar still clips to the panel bounds, and the parent column already scrolls via `lg:overflow-y-auto`. `EventLog` is unaffected — it keeps its own `max-h-[32rem] overflow-y-auto`.

## Test plan

- [ ] On a desktop (`lg`/`xl`) viewport with a canvas avatar style (cyber / sigil / esoteric / nexus / muse), open Chief of Staff and confirm the full stat grid (Active, Pending, Done, Issues, Learning, Start/Stop) and the status bubble are all visible — no bottom clipping.
- [ ] Confirm the canvas avatar still renders without bleeding outside the panel into neighboring content.
- [ ] On a short viewport, confirm the panel still shrinks (floor honors `calc(100vh-1rem)`).
- [ ] Start the agent and confirm the Event Log appears and scrolls within its own bounds.