### PR TITLE
feat([issue-711]): While You Were Away dashboard briefing card

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,6 +3,7 @@
 ## Added
 
 - **[issue-708] Digital Twin "Voice" tab — spoken vs. written style** — Paste a transcript of yourself speaking and the Digital Twin compares it against how you write (a pasted sample, or your existing twin documents), surfacing where your spoken voice differs from your writing — formality, verbosity, sentence length, directness, filler words — and suggesting a communication profile for voice contexts that you can apply in one click.
+- **[issue-711] "While You Were Away" dashboard card** — A new dashboard widget recaps what your agents did since your last visit: a count of completed runs, success/failure tally, total time worked, and the most recent wins plus anything that failed and needs a look. Each item links straight to the agent, and a "Mark as seen" button resets the window to now. It appears on the Everything and Agent Watch layouts and can be added to any layout via Arrange.
 
 ## Changed
 

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,7 +3,7 @@
 ## Added
 
 - **[issue-708] Digital Twin "Voice" tab — spoken vs. written style** — Paste a transcript of yourself speaking and the Digital Twin compares it against how you write (a pasted sample, or your existing twin documents), surfacing where your spoken voice differs from your writing — formality, verbosity, sentence length, directness, filler words — and suggesting a communication profile for voice contexts that you can apply in one click.
-- **[issue-711] "While You Were Away" dashboard card** — A new dashboard widget recaps what your agents did since your last visit: a count of completed runs, success/failure tally, total time worked, and the most recent wins plus anything that failed and needs a look. Each item links straight to the agent, and a "Mark as seen" button resets the window to now. It appears on the Everything and Agent Watch layouts and can be added to any layout via Arrange.
+- **[issue-711] "While You Were Away" dashboard card** — A new dashboard widget recaps what your agents did since your last visit: a count of completed runs, success/failure tally, total time worked, and the most recent wins plus anything that failed and needs a look. Each item opens the agents view, and a "Mark as seen" button resets the window to now. It appears on the Everything and Agent Watch layouts and can be added to any layout via Arrange.
 
 ## Changed
 

--- a/client/src/components/WhileAwayWidget.jsx
+++ b/client/src/components/WhileAwayWidget.jsx
@@ -22,8 +22,8 @@ const LAST_SEEN_KEY = 'portos.whileAway.lastSeen';
 const readLastSeen = () => {
   // localStorage access can throw in private-mode / storage-disabled /
   // security-error contexts — never let that crash the dashboard render.
-  // (Same guard idiom as utils/timeWindow.js.)
-  if (typeof window === 'undefined' || !window.localStorage) return null;
+  // Even *reading* the `window.localStorage` property can throw in some
+  // sandboxed iframes, so it's acquired inside the try (not before it).
   let raw = null;
   try { raw = window.localStorage.getItem(LAST_SEEN_KEY); }
   catch { return null; }
@@ -37,9 +37,9 @@ const readLastSeen = () => {
 };
 
 const writeLastSeen = (iso) => {
-  // A write failure (quota / disabled) must not break "Mark as seen" — the
-  // subsequent refetch still runs; the window just isn't persisted this time.
-  if (typeof window === 'undefined' || !window.localStorage) return;
+  // A write failure (quota / disabled / property-access throw) must not break
+  // "Mark as seen" — the subsequent refetch still runs; the window just isn't
+  // persisted this time.
   try { window.localStorage.setItem(LAST_SEEN_KEY, iso); }
   catch { /* private mode / quota — graceful no-op */ }
 };
@@ -71,14 +71,17 @@ export default function WhileAwayWidget() {
   // The marker captured at fetch time, so "Mark as seen" and the header label
   // reflect the window we actually queried (not a value that drifted since).
   const sinceRef = useRef(null);
+  // A socket-driven refresh can land after the widget unmounts — guard the
+  // async setState so it doesn't fire into the void (CLAUDE.md unmount rule).
+  const mountedRef = useRef(true);
 
   const load = useCallback(() => {
     const since = readLastSeen();
     sinceRef.current = since;
     return api.getCosWhileAwayActivity(since, { silent: true })
-      .then((res) => setData(res))
+      .then((res) => { if (mountedRef.current) setData(res); })
       .catch(() => null)
-      .finally(() => setLoading(false));
+      .finally(() => { if (mountedRef.current) setLoading(false); });
   }, []);
 
   useEffect(() => {
@@ -87,7 +90,10 @@ export default function WhileAwayWidget() {
     // refresh on completion so the card stays live (mirrors ReviewHubCard).
     const refresh = () => load();
     socket.on('cos:agent:completed', refresh);
-    return () => socket.off('cos:agent:completed', refresh);
+    return () => {
+      mountedRef.current = false;
+      socket.off('cos:agent:completed', refresh);
+    };
   }, [load]);
 
   const markSeen = () => {
@@ -135,6 +141,7 @@ export default function WhileAwayWidget() {
             onClick={markSeen}
             className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs bg-port-bg border border-port-border hover:border-port-accent/50 text-gray-300 rounded-lg transition-colors shrink-0 min-h-[36px]"
             title="Reset the window to now"
+            aria-label="Mark as seen — reset the window to now"
           >
             <Eye size={13} />
             <span className="hidden sm:inline">Mark as seen</span>

--- a/client/src/components/WhileAwayWidget.jsx
+++ b/client/src/components/WhileAwayWidget.jsx
@@ -20,7 +20,13 @@ import { timeAgo } from '../utils/formatters';
 const LAST_SEEN_KEY = 'portos.whileAway.lastSeen';
 
 const readLastSeen = () => {
-  const raw = localStorage.getItem(LAST_SEEN_KEY);
+  // localStorage access can throw in private-mode / storage-disabled /
+  // security-error contexts — never let that crash the dashboard render.
+  // (Same guard idiom as utils/timeWindow.js.)
+  if (typeof window === 'undefined' || !window.localStorage) return null;
+  let raw = null;
+  try { raw = window.localStorage.getItem(LAST_SEEN_KEY); }
+  catch { return null; }
   // A finite, non-future ISO string is the only valid marker; anything else
   // (absent, garbage, clock-skewed) means "no marker" → server applies its
   // own 24h fallback so the card still renders.
@@ -31,7 +37,11 @@ const readLastSeen = () => {
 };
 
 const writeLastSeen = (iso) => {
-  localStorage.setItem(LAST_SEEN_KEY, iso);
+  // A write failure (quota / disabled) must not break "Mark as seen" — the
+  // subsequent refetch still runs; the window just isn't persisted this time.
+  if (typeof window === 'undefined' || !window.localStorage) return;
+  try { window.localStorage.setItem(LAST_SEEN_KEY, iso); }
+  catch { /* private mode / quota — graceful no-op */ }
 };
 
 function ActivityRow({ item, kind }) {

--- a/client/src/components/WhileAwayWidget.jsx
+++ b/client/src/components/WhileAwayWidget.jsx
@@ -1,0 +1,187 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Link } from 'react-router-dom';
+import {
+  Moon,
+  CheckCircle,
+  XCircle,
+  Clock,
+  Eye,
+  Loader2,
+  Sparkles
+} from 'lucide-react';
+import * as api from '../services/api';
+import socket from '../services/socket';
+import { timeAgo } from '../utils/formatters';
+
+// Per-device "last visit" marker. The widget shows agent activity that
+// completed since this timestamp; "Mark as seen" advances it to now. Kept in
+// localStorage (per the issue's while-away briefing slice) so there's no
+// server-side presence state to migrate — it's intentionally per-browser.
+const LAST_SEEN_KEY = 'portos.whileAway.lastSeen';
+
+const readLastSeen = () => {
+  const raw = localStorage.getItem(LAST_SEEN_KEY);
+  // A finite, non-future ISO string is the only valid marker; anything else
+  // (absent, garbage, clock-skewed) means "no marker" → server applies its
+  // own 24h fallback so the card still renders.
+  if (!raw) return null;
+  const t = new Date(raw).getTime();
+  if (!Number.isFinite(t) || t > Date.now()) return null;
+  return raw;
+};
+
+const writeLastSeen = (iso) => {
+  localStorage.setItem(LAST_SEEN_KEY, iso);
+};
+
+function ActivityRow({ item, kind }) {
+  const Icon = kind === 'incident' ? XCircle : CheckCircle;
+  const tone = kind === 'incident' ? 'text-port-error' : 'text-port-success';
+  return (
+    <Link
+      to="/cos/agents"
+      className="flex items-start gap-2.5 p-2 rounded-lg border border-port-border bg-port-bg/40 hover:border-port-accent/40 transition-colors group"
+    >
+      <Icon size={14} className={`mt-0.5 shrink-0 ${tone}`} />
+      <div className="min-w-0 flex-1">
+        <div className="text-sm text-gray-200 truncate">{item.description}</div>
+        <div className="flex items-center gap-2 text-xs text-gray-500 mt-0.5">
+          <span className="truncate">{item.taskType}</span>
+          {item.app && <span className="truncate text-gray-600">· {item.app}</span>}
+          <span className="shrink-0 ml-auto">{item.completedRelative}</span>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export default function WhileAwayWidget() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  // The marker captured at fetch time, so "Mark as seen" and the header label
+  // reflect the window we actually queried (not a value that drifted since).
+  const sinceRef = useRef(null);
+
+  const load = useCallback(() => {
+    const since = readLastSeen();
+    sinceRef.current = since;
+    return api.getCosWhileAwayActivity(since, { silent: true })
+      .then((res) => setData(res))
+      .catch(() => null)
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+    // A finished agent run can change the queue while you're looking at it —
+    // refresh on completion so the card stays live (mirrors ReviewHubCard).
+    const refresh = () => load();
+    socket.on('cos:agent:completed', refresh);
+    return () => socket.off('cos:agent:completed', refresh);
+  }, [load]);
+
+  const markSeen = () => {
+    writeLastSeen(new Date().toISOString());
+    setLoading(true);
+    load();
+  };
+
+  if (loading && !data) {
+    return (
+      <div className="bg-port-card border border-port-border rounded-xl p-4 flex items-center justify-center min-h-[120px]">
+        <Loader2 className="w-5 h-5 text-gray-500 animate-spin" />
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const { stats, time, accomplishments = [], incidents = [] } = data;
+  const total = stats?.completed ?? 0;
+  // The header window: prefer the per-device marker; if absent, the server
+  // fell back to 24h and reports the window it actually used via sinceIso.
+  const windowSince = sinceRef.current || data.sinceIso;
+
+  return (
+    <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3 gap-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="p-2 rounded-lg bg-port-accent/10 shrink-0">
+            <Moon className="w-5 h-5 text-port-accent" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-lg font-semibold text-white">While You Were Away</h3>
+            <p className="text-sm text-gray-500 truncate">
+              {total > 0
+                ? `${total} agent run${total !== 1 ? 's' : ''} since ${timeAgo(windowSince)}`
+                : `Nothing since ${timeAgo(windowSince)}`}
+            </p>
+          </div>
+        </div>
+        {total > 0 && (
+          <button
+            type="button"
+            onClick={markSeen}
+            className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs bg-port-bg border border-port-border hover:border-port-accent/50 text-gray-300 rounded-lg transition-colors shrink-0 min-h-[36px]"
+            title="Reset the window to now"
+          >
+            <Eye size={13} />
+            <span className="hidden sm:inline">Mark as seen</span>
+          </button>
+        )}
+      </div>
+
+      {total === 0 ? (
+        <div className="flex items-center gap-2 text-sm text-gray-500 py-4 justify-center">
+          <Sparkles size={14} className="text-port-accent/60" />
+          No agent activity while you were away.
+        </div>
+      ) : (
+        <>
+          {/* Stat strip */}
+          <div className="flex flex-wrap items-center gap-2 mb-3">
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-port-success/20 text-port-success">
+              <CheckCircle size={10} />
+              {stats.succeeded} succeeded
+            </span>
+            {stats.failed > 0 && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-port-error/20 text-port-error">
+                <XCircle size={10} />
+                {stats.failed} failed
+              </span>
+            )}
+            <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-port-accent/20 text-port-accent">
+              {stats.successRate}% success
+            </span>
+            {time?.totalDurationMs > 0 && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-port-bg text-gray-400 border border-port-border">
+                <Clock size={10} />
+                {time.totalDuration} of work
+              </span>
+            )}
+          </div>
+
+          {/* Accomplishments */}
+          {accomplishments.length > 0 && (
+            <div className="space-y-1.5 mb-2">
+              {accomplishments.map((item) => (
+                <ActivityRow key={item.id} item={item} kind="accomplishment" />
+              ))}
+            </div>
+          )}
+
+          {/* Incidents */}
+          {incidents.length > 0 && (
+            <div className="space-y-1.5">
+              <div className="text-xs font-medium text-port-error/80 mt-2 mb-1">Needs a look</div>
+              {incidents.map((item) => (
+                <ActivityRow key={item.id} item={item} kind="incident" />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/dashboard/widgetRegistry.jsx
+++ b/client/src/components/dashboard/widgetRegistry.jsx
@@ -17,6 +17,7 @@ const QuickIdeaCapture      = lazyWithReload(() => import('../QuickIdeaCapture')
 const QuickImagePrompt      = lazyWithReload(() => import('../QuickImagePrompt'));
 const QuickTaskWidget       = lazyWithReload(() => import('../QuickTaskWidget'));
 const ReviewHubCard         = lazyWithReload(() => import('../ReviewHubCard'));
+const WhileAwayWidget        = lazyWithReload(() => import('../WhileAwayWidget'));
 const AppsGridWidget        = lazyWithReload(() => import('./builtins/AppsGridWidget'));
 const QuickStatsWidget      = lazyWithReload(() => import('./builtins/QuickStatsWidget'));
 const ActivityStreakWidget  = lazyWithReload(() => import('./builtins/ActivityStreakWidget'));
@@ -48,6 +49,7 @@ export const WIDGETS = [
   { id: 'upcoming-tasks',    label: 'Upcoming Tasks',        Component: UpcomingTasksWidget,    width: 'third',   defaultH: 5 },
   { id: 'proactive-alerts',  label: 'Proactive Alerts',      Component: ProactiveAlertsWidget,  width: 'quarter', defaultH: 4, module: { id: '04', status: 'ALERTS',  glyph: 'warning-tri' } },
   { id: 'review-hub',        label: 'Review Hub',            Component: ReviewHubCard,          width: 'quarter', defaultH: 4, module: { id: '05', status: 'REVIEW',  glyph: 'reticle' } },
+  { id: 'while-away',        label: 'While You Were Away',   Component: WhileAwayWidget,        width: 'third',   defaultH: 5, module: { id: '08', status: 'AWAY',    glyph: 'orbit' } },
   { id: 'system-health',     label: 'System Health',         Component: SystemHealthWidget,     width: 'quarter', defaultH: 8, module: { id: '01', status: 'HEALTH',  glyph: 'matrix' } },
   { id: 'network-exposure',  label: 'Network Exposure',      Component: NetworkExposureWidget,  width: 'quarter', defaultH: 5, module: { id: '07', status: 'EXPOSURE', glyph: 'reticle' } },
   { id: 'backup',            label: 'Backup',                Component: BackupWidget,           width: 'quarter', defaultH: 5 },

--- a/client/src/components/dashboard/widgetRegistry.jsx
+++ b/client/src/components/dashboard/widgetRegistry.jsx
@@ -36,7 +36,7 @@ const HourlyActivityWidget  = lazyWithReload(() => import('./builtins/HourlyActi
 //
 // `module` is optional micrographic chrome — when set, the dashboard
 // renders a SchematicLabel ("MODULE.04 // ALERTS ●") as a tab on the
-// widget's top border. Six widgets carry this by default; the rest are
+// widget's top border. Several widgets carry this by default; the rest are
 // label-free so the dashboard doesn't turn into a wall of HUD chrome.
 export const WIDGETS = [
   { id: 'quick-brain',       label: 'Quick Brain Capture',   Component: QuickBrainCapture,      width: 'half',    defaultH: 3 },

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -110,6 +110,10 @@ export const getCosBriefing = (date) => request(`/cos/briefings/${date}`);
 
 // CoS Activity
 export const getCosTodayActivity = () => request('/cos/activity/today');
+// "While you were away" — agent runs since the client's last-visit marker.
+// `since` is an ISO-8601 string; omit it to let the server fall back to 24h.
+export const getCosWhileAwayActivity = (since, options) =>
+  request(`/cos/activity/while-away${since ? `?since=${encodeURIComponent(since)}` : ''}`, options);
 
 // CoS Learning
 export const getCosLearning = () => request('/cos/learning');

--- a/scripts/migrations/070-seed-while-away-widget.js
+++ b/scripts/migrations/070-seed-while-away-widget.js
@@ -22,7 +22,7 @@ const WIDGET_H = 5;
 // DEFAULT_LAYOUTS — edits here must match that file or fresh installs +
 // migrated installs diverge. `agent-watch` gives the card a wider slot.
 const PREFERRED_SLOTS = {
-  default: { x: 9, y: 14, w: WIDGET_W, h: WIDGET_H },
+  default: { x: 9, y: 15, w: WIDGET_W, h: 3 },
   'agent-watch': { x: 6, y: 3, w: 6, h: WIDGET_H },
 };
 const TARGET_LAYOUT_IDS = Object.keys(PREFERRED_SLOTS);
@@ -45,9 +45,17 @@ function pickGridEntry(grid, layoutId) {
     if (!collidesWith(grid, candidate)) return candidate;
   }
   // Fall back to a clean row below everything else if the preferred slot is
-  // occupied (a user rearranged the layout but kept the built-in id).
+  // occupied (a user rearranged the layout but kept the built-in id). Carry
+  // the layout's preferred width/height so a collided agent-watch heal still
+  // gets the intended 6-wide card, not the bare WIDGET_W default.
   const bottom = grid.reduce((max, it) => Math.max(max, (it.y ?? 0) + (it.h ?? 0)), 0);
-  return { id: WIDGET_ID, x: 0, y: bottom, w: WIDGET_W, h: WIDGET_H };
+  return {
+    id: WIDGET_ID,
+    x: 0,
+    y: bottom,
+    w: preferred?.w ?? WIDGET_W,
+    h: preferred?.h ?? WIDGET_H
+  };
 }
 
 function applyToLayout(layout) {

--- a/scripts/migrations/070-seed-while-away-widget.js
+++ b/scripts/migrations/070-seed-while-away-widget.js
@@ -1,0 +1,100 @@
+/**
+ * Seed the new `while-away` dashboard widget ("While You Were Away") into the
+ * built-in `default` (Everything) and `agent-watch` layouts for installs that
+ * already have a persisted `data/dashboard-layouts.json`.
+ *
+ * Background:
+ *   `server/services/dashboardLayouts.js#DEFAULT_LAYOUTS` only seeds when the
+ *   file is missing. Adding a widget to those layouts in code alone won't reach
+ *   existing users — this migration walks the file, finds each target built-in
+ *   layout, and inserts `while-away` into its `widgets` list + `grid` if
+ *   missing. User-renamed copies and other layouts are not touched. Re-runs
+ *   detect the widget is already present and skip. Mirrors migration 033.
+ */
+
+import { readLayoutsDoc, writeLayoutsDoc } from './_lib.js';
+
+const WIDGET_ID = 'while-away';
+const WIDGET_W = 3;
+const WIDGET_H = 5;
+
+// Mirror of the geometry in `server/services/dashboardLayouts.js`
+// DEFAULT_LAYOUTS — edits here must match that file or fresh installs +
+// migrated installs diverge. `agent-watch` gives the card a wider slot.
+const PREFERRED_SLOTS = {
+  default: { x: 9, y: 14, w: WIDGET_W, h: WIDGET_H },
+  'agent-watch': { x: 6, y: 3, w: 6, h: WIDGET_H },
+};
+const TARGET_LAYOUT_IDS = Object.keys(PREFERRED_SLOTS);
+
+function rectsOverlap(a, b) {
+  return a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+}
+
+function collidesWith(grid, candidate) {
+  for (const item of grid) {
+    if (rectsOverlap(item, candidate)) return true;
+  }
+  return false;
+}
+
+function pickGridEntry(grid, layoutId) {
+  const preferred = PREFERRED_SLOTS[layoutId];
+  if (preferred) {
+    const candidate = { id: WIDGET_ID, x: preferred.x, y: preferred.y, w: preferred.w, h: preferred.h };
+    if (!collidesWith(grid, candidate)) return candidate;
+  }
+  // Fall back to a clean row below everything else if the preferred slot is
+  // occupied (a user rearranged the layout but kept the built-in id).
+  const bottom = grid.reduce((max, it) => Math.max(max, (it.y ?? 0) + (it.h ?? 0)), 0);
+  return { id: WIDGET_ID, x: 0, y: bottom, w: WIDGET_W, h: WIDGET_H };
+}
+
+function applyToLayout(layout) {
+  if (!layout || typeof layout !== 'object') return false;
+  if (!Array.isArray(layout.widgets)) return false;
+
+  let changed = false;
+  // 1) Insert into widgets if absent.
+  if (!layout.widgets.includes(WIDGET_ID)) {
+    layout.widgets = [...layout.widgets, WIDGET_ID];
+    changed = true;
+  }
+  // 2) Heal the grid entry independently — the widget id can be present in
+  // `widgets` but missing from `grid` (e.g. a widgets-only edit landed without
+  // an arrange-and-save pass). Treat a non-array grid as [] (the shape the
+  // client's `synthesizeGrid` would auto-create at render time).
+  const existingGrid = Array.isArray(layout.grid) ? layout.grid : [];
+  const hasGridEntry = existingGrid.some((it) => it?.id === WIDGET_ID);
+  if (!hasGridEntry) {
+    layout.grid = [...existingGrid, pickGridEntry(existingGrid, layout.id)];
+    changed = true;
+  } else if (!Array.isArray(layout.grid)) {
+    layout.grid = existingGrid;
+    changed = true;
+  }
+  return changed;
+}
+
+export default {
+  async up({ rootDir }) {
+    const result = await readLayoutsDoc({ rootDir, label: 'migration 070' });
+    if (!result.ok) return { updated: 0, reason: result.reason };
+    const { doc, path } = result;
+
+    let touched = 0;
+    for (const layout of doc.layouts) {
+      if (!layout || !TARGET_LAYOUT_IDS.includes(layout.id)) continue;
+      if (applyToLayout(layout)) touched += 1;
+    }
+
+    if (touched === 0) {
+      console.log(`📦 migration 070: while-away already present in target layouts.`);
+      return { updated: 0, reason: 'already-applied' };
+    }
+
+    await writeLayoutsDoc(path, doc);
+    console.log(`📦 migration 070: seeded while-away widget into ${touched} built-in layout(s).`);
+    return { updated: touched };
+  },
+};

--- a/scripts/migrations/070-seed-while-away-widget.test.js
+++ b/scripts/migrations/070-seed-while-away-widget.test.js
@@ -55,7 +55,7 @@ describe('migration 070 — seed while-away widget into default + agent-watch la
 
     const def = after.layouts.find((l) => l.id === 'default');
     expect(def.widgets).toContain('while-away');
-    expect(def.grid.find((g) => g.id === 'while-away')).toEqual({ id: 'while-away', x: 9, y: 14, w: 3, h: 5 });
+    expect(def.grid.find((g) => g.id === 'while-away')).toEqual({ id: 'while-away', x: 9, y: 15, w: 3, h: 3 });
 
     const watch = after.layouts.find((l) => l.id === 'agent-watch');
     expect(watch.widgets).toContain('while-away');
@@ -141,5 +141,29 @@ describe('migration 070 — seed while-away widget into default + agent-watch la
     expect(newEntry).toBeDefined();
     expect(newEntry.x).toBe(0);
     expect(newEntry.y).toBeGreaterThanOrEqual(19);
+  });
+
+  it('keeps the agent-watch preferred width (6) when the slot is occupied', async () => {
+    writeJson(layoutsPath, {
+      activeLayoutId: 'agent-watch',
+      layouts: [
+        {
+          id: 'agent-watch',
+          name: 'Agent Watch',
+          builtIn: true,
+          widgets: ['system-health'],
+          // Occupies the preferred slot (x:6,y:3) so the fallback path runs.
+          grid: [{ id: 'system-health', x: 6, y: 3, w: 6, h: 5 }],
+        },
+      ],
+    });
+    const result = await migration.up({ rootDir });
+    expect(result.updated).toBe(1);
+    const after = readJson(layoutsPath);
+    const newEntry = after.layouts[0].grid.find((g) => g.id === 'while-away');
+    expect(newEntry).toBeDefined();
+    // Fallback must carry the layout's preferred width, not the bare default.
+    expect(newEntry.w).toBe(6);
+    expect(newEntry.h).toBe(5);
   });
 });

--- a/scripts/migrations/070-seed-while-away-widget.test.js
+++ b/scripts/migrations/070-seed-while-away-widget.test.js
@@ -1,0 +1,145 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import migration from './070-seed-while-away-widget.js';
+
+const writeJson = (path, value) => writeFileSync(path, JSON.stringify(value, null, 2) + '\n');
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf-8'));
+
+describe('migration 070 — seed while-away widget into default + agent-watch layouts', () => {
+  let rootDir;
+  let layoutsPath;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'migration-070-'));
+    mkdirSync(join(rootDir, 'data'), { recursive: true });
+    layoutsPath = join(rootDir, 'data', 'dashboard-layouts.json');
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  it('no-ops cleanly when dashboard-layouts.json is missing (fresh install)', async () => {
+    const result = await migration.up({ rootDir });
+    expect(result.updated).toBe(0);
+    expect(result.reason).toBe('no-state');
+    expect(existsSync(layoutsPath)).toBe(false);
+  });
+
+  it('inserts while-away into both target layouts at their preferred slots', async () => {
+    writeJson(layoutsPath, {
+      activeLayoutId: 'default',
+      layouts: [
+        {
+          id: 'default',
+          name: 'Everything',
+          builtIn: true,
+          widgets: ['cos'],
+          grid: [{ id: 'cos', x: 4, y: 14, w: 5, h: 4 }],
+        },
+        {
+          id: 'agent-watch',
+          name: 'Agent Watch',
+          builtIn: true,
+          widgets: ['cos'],
+          grid: [{ id: 'cos', x: 0, y: 0, w: 6, h: 5 }],
+        },
+      ],
+    });
+    const result = await migration.up({ rootDir });
+    expect(result.updated).toBe(2);
+    const after = readJson(layoutsPath);
+
+    const def = after.layouts.find((l) => l.id === 'default');
+    expect(def.widgets).toContain('while-away');
+    expect(def.grid.find((g) => g.id === 'while-away')).toEqual({ id: 'while-away', x: 9, y: 14, w: 3, h: 5 });
+
+    const watch = after.layouts.find((l) => l.id === 'agent-watch');
+    expect(watch.widgets).toContain('while-away');
+    expect(watch.grid.find((g) => g.id === 'while-away')).toEqual({ id: 'while-away', x: 6, y: 3, w: 6, h: 5 });
+  });
+
+  it('is idempotent — second run is a no-op', async () => {
+    writeJson(layoutsPath, {
+      activeLayoutId: 'default',
+      layouts: [
+        { id: 'default', name: 'Everything', builtIn: true, widgets: ['while-away'], grid: [{ id: 'while-away', x: 9, y: 14, w: 3, h: 5 }] },
+        { id: 'agent-watch', name: 'Agent Watch', builtIn: true, widgets: ['while-away'], grid: [{ id: 'while-away', x: 6, y: 3, w: 6, h: 5 }] },
+      ],
+    });
+    const result = await migration.up({ rootDir });
+    expect(result.updated).toBe(0);
+    expect(result.reason).toBe('already-applied');
+  });
+
+  it('only touches the default + agent-watch ids, not other or renamed layouts', async () => {
+    writeJson(layoutsPath, {
+      activeLayoutId: 'focus',
+      layouts: [
+        { id: 'focus',       name: 'Focus',        builtIn: true,  widgets: ['cos'], grid: [] },
+        { id: 'my-watch',    name: 'My Watch',     builtIn: false, widgets: ['cos'], grid: [] },
+        { id: 'agent-watch', name: 'Agent Watch',  builtIn: true,  widgets: ['cos'], grid: [] },
+      ],
+    });
+    const result = await migration.up({ rootDir });
+    expect(result.updated).toBe(1);
+    const after = readJson(layoutsPath);
+    expect(after.layouts.find((l) => l.id === 'focus').widgets).toEqual(['cos']);
+    expect(after.layouts.find((l) => l.id === 'my-watch').widgets).toEqual(['cos']);
+    expect(after.layouts.find((l) => l.id === 'agent-watch').widgets).toContain('while-away');
+  });
+
+  it('survives an unreadable JSON file', async () => {
+    writeFileSync(layoutsPath, 'not json');
+    const result = await migration.up({ rootDir });
+    expect(result.updated).toBe(0);
+    expect(result.reason).toBe('unreadable');
+  });
+
+  it('heals legacy state where widget id is in widgets[] but missing from grid[]', async () => {
+    writeJson(layoutsPath, {
+      activeLayoutId: 'default',
+      layouts: [
+        {
+          id: 'default',
+          name: 'Everything',
+          builtIn: true,
+          widgets: ['cos', 'while-away'],
+          grid: [{ id: 'cos', x: 4, y: 14, w: 5, h: 4 }],
+        },
+      ],
+    });
+    const result = await migration.up({ rootDir });
+    expect(result.updated).toBe(1);
+    const after = readJson(layoutsPath);
+    const entry = after.layouts[0].grid.find((g) => g.id === 'while-away');
+    expect(entry).toBeDefined();
+    expect(after.layouts[0].widgets.filter((w) => w === 'while-away')).toHaveLength(1);
+  });
+
+  it('appends below existing items when the preferred slot is occupied', async () => {
+    writeJson(layoutsPath, {
+      activeLayoutId: 'default',
+      layouts: [
+        {
+          id: 'default',
+          name: 'Everything',
+          builtIn: true,
+          widgets: ['cos'],
+          // Something already sits in the preferred slot (x:9,y:14).
+          grid: [{ id: 'cos', x: 9, y: 14, w: 3, h: 5 }],
+        },
+      ],
+    });
+    const result = await migration.up({ rootDir });
+    expect(result.updated).toBe(1);
+    const after = readJson(layoutsPath);
+    const newEntry = after.layouts[0].grid.find((g) => g.id === 'while-away');
+    expect(newEntry).toBeDefined();
+    expect(newEntry.x).toBe(0);
+    expect(newEntry.y).toBeGreaterThanOrEqual(19);
+  });
+});

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -48,6 +48,7 @@ vi.mock('../services/cos.js', () => ({
   getScript: vi.fn(),
   forceSpawnTask: vi.fn(),
   getTodayActivity: vi.fn(),
+  getWhileAwayActivity: vi.fn(),
   getRecentTasks: vi.fn()
 }));
 
@@ -1071,6 +1072,39 @@ describe('CoS Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.stats.completed).toBe(5);
+    });
+  });
+
+  describe('GET /api/cos/activity/while-away', () => {
+    it('passes a valid ISO since through to the service', async () => {
+      cos.getWhileAwayActivity.mockResolvedValue({ stats: { completed: 3 } });
+      const since = '2026-06-01T00:00:00.000Z';
+
+      const response = await request(app).get(`/api/cos/activity/while-away?since=${encodeURIComponent(since)}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.stats.completed).toBe(3);
+      expect(cos.getWhileAwayActivity).toHaveBeenCalledWith(since);
+    });
+
+    it('tolerates a garbage since (200 + service fallback, not 400)', async () => {
+      cos.getWhileAwayActivity.mockResolvedValue({ stats: { completed: 0 } });
+
+      const response = await request(app).get('/api/cos/activity/while-away?since=not-a-date');
+
+      expect(response.status).toBe(200);
+      // Malformed value is dropped to undefined so the service applies its
+      // own 24h fallback rather than the route 400-ing the dashboard card.
+      expect(cos.getWhileAwayActivity).toHaveBeenCalledWith(undefined);
+    });
+
+    it('works with no since param', async () => {
+      cos.getWhileAwayActivity.mockResolvedValue({ stats: { completed: 1 } });
+
+      const response = await request(app).get('/api/cos/activity/while-away');
+
+      expect(response.status).toBe(200);
+      expect(cos.getWhileAwayActivity).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/server/routes/cosReportRoutes.js
+++ b/server/routes/cosReportRoutes.js
@@ -14,11 +14,15 @@ import { validateRequest } from '../lib/validation.js';
 const router = Router();
 
 // `since` is the client's last-visit marker (ISO-8601). Optional and tolerant:
-// an absent/garbage value is clamped server-side to a 24h fallback, so we only
-// reject a malformed datetime to keep the contract honest — we don't 400 on
-// omission.
+// `getWhileAwayActivity` already clamps an absent/garbage/future marker to a
+// 24h fallback, so a malformed value preprocesses to `undefined` (let the
+// service apply its fallback) rather than 400-ing the dashboard card into a
+// blank state. A valid datetime string passes through unchanged.
 const whileAwayQuerySchema = z.object({
-  since: z.string().datetime({ offset: true }).optional()
+  since: z.preprocess(
+    (v) => (typeof v === 'string' && !Number.isNaN(Date.parse(v)) ? v : undefined),
+    z.string().optional()
+  )
 });
 
 // GET /api/cos/reports - List all reports

--- a/server/routes/cosReportRoutes.js
+++ b/server/routes/cosReportRoutes.js
@@ -3,13 +3,23 @@
  */
 
 import { Router } from 'express';
+import { z } from 'zod';
 import * as cos from '../services/cos.js';
 import * as taskWatcher from '../services/taskWatcher.js';
 import * as appActivity from '../services/appActivity.js';
 import * as claudeChangelog from '../services/claudeChangelog.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
+import { validateRequest } from '../lib/validation.js';
 
 const router = Router();
+
+// `since` is the client's last-visit marker (ISO-8601). Optional and tolerant:
+// an absent/garbage value is clamped server-side to a 24h fallback, so we only
+// reject a malformed datetime to keep the contract honest — we don't 400 on
+// omission.
+const whileAwayQuerySchema = z.object({
+  since: z.string().datetime({ offset: true }).optional()
+});
 
 // GET /api/cos/reports - List all reports
 router.get('/reports', asyncHandler(async (req, res) => {
@@ -117,6 +127,14 @@ router.post('/app-activity/:appId/clear-cooldown', asyncHandler(async (req, res)
 // GET /api/cos/activity/today - Get today's activity summary
 router.get('/activity/today', asyncHandler(async (req, res) => {
   const activity = await cos.getTodayActivity();
+  res.json(activity);
+}));
+
+// GET /api/cos/activity/while-away - What agents did since ?since=<ISO> (the
+// client's last-visit marker). Powers the "While You Were Away" dashboard card.
+router.get('/activity/while-away', asyncHandler(async (req, res) => {
+  const { since } = validateRequest(whileAwayQuerySchema, req.query);
+  const activity = await cos.getWhileAwayActivity(since);
   res.json(activity);
 }));
 

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -39,7 +39,7 @@ export { cosEvents, emitLog };
 export { registerAgent, updateAgent, completeAgent, appendAgentOutput, getAgents, getAgentDates, getAgentsByDate, getAgent, getAgentPrompt, terminateAgent, pauseAgent, killAgent, sendBtwToAgent, getAgentProcessStats, cleanupZombieAgents, deleteAgent, submitAgentFeedback, getFeedbackStats, extractTaskType, archiveStaleAgents, clearCompletedAgents, pruneOldAgentArchives } from './cosAgents.js';
 
 // Reports and activity (re-export for backward compat with `import * as cos`)
-export { generateReport, getReport, getTodayReport, listReports, listBriefings, getBriefing, getLatestBriefing, getTodayActivity, getRecentTasks, formatRelativeTime } from './cosReports.js';
+export { generateReport, getReport, getTodayReport, listReports, listBriefings, getBriefing, getLatestBriefing, getTodayActivity, getWhileAwayActivity, getRecentTasks, formatRelativeTime } from './cosReports.js';
 
 // Health monitoring (imported for internal use by start()/init() and re-exported
 // for backward compat with `import * as cos` and the cos route handlers)

--- a/server/services/cosReports.js
+++ b/server/services/cosReports.js
@@ -180,30 +180,35 @@ function summarizeAwayActivity(agents, sinceIso) {
   const succeeded = agents.filter(a => a.result?.success);
   const failed = agents.filter(a => !a.result?.success);
 
-  const durationOf = (a) => a.result?.duration
-    || (a.completedAt && a.startedAt
-      ? new Date(a.completedAt).getTime() - new Date(a.startedAt).getTime()
-      : 0);
+  // Clamp to >=0 so a clock-skewed completedAt < startedAt can't produce a
+  // negative duration in either the per-card field or the rollup.
+  const durationOf = (a) => {
+    const d = a.result?.duration
+      || (a.completedAt && a.startedAt
+        ? new Date(a.completedAt).getTime() - new Date(a.startedAt).getTime()
+        : 0);
+    return d > 0 ? d : 0;
+  };
 
-  const toCard = (a) => ({
-    id: a.id,
-    taskId: a.taskId,
-    description: a.metadata?.taskDescription?.substring(0, 120) || a.taskId,
-    taskType: a.metadata?.analysisType || a.metadata?.taskType || 'task',
-    app: a.metadata?.app || null,
-    success: a.result?.success || false,
-    durationMs: durationOf(a),
-    durationFormatted: formatDuration(durationOf(a) > 0 ? durationOf(a) : 0),
-    completedAt: a.completedAt,
-    completedRelative: formatRelativeTime(a.completedAt)
-  });
+  const toCard = (a) => {
+    const durationMs = durationOf(a);
+    return {
+      id: a.id,
+      taskId: a.taskId,
+      description: a.metadata?.taskDescription?.substring(0, 120) || a.taskId,
+      taskType: a.metadata?.analysisType || a.metadata?.taskType || 'task',
+      app: a.metadata?.app || null,
+      success: a.result?.success || false,
+      durationMs,
+      durationFormatted: formatDuration(durationMs),
+      completedAt: a.completedAt,
+      completedRelative: formatRelativeTime(a.completedAt)
+    };
+  };
 
   // Most-recent first so the freshest work tops each list.
   const byRecency = (a, b) => new Date(b.completedAt) - new Date(a.completedAt);
-  const totalDurationMs = agents.reduce((sum, a) => {
-    const d = durationOf(a);
-    return sum + (d > 0 ? d : 0);
-  }, 0);
+  const totalDurationMs = agents.reduce((sum, a) => sum + durationOf(a), 0);
 
   return {
     sinceIso,

--- a/server/services/cosReports.js
+++ b/server/services/cosReports.js
@@ -9,6 +9,7 @@ import { readFile, writeFile, readdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { loadState, ensureDirectories, REPORTS_DIR, isDaemonRunning } from './cosState.js';
+import { getAgentsByDate } from './cosAgents.js';
 import { formatDuration, safeJSONParse } from '../lib/fileUtils.js';
 
 export async function generateReport(date = null) {
@@ -171,6 +172,108 @@ export async function getTodayActivity() {
     isRunning: isDaemonRunning(),
     isPaused: state.paused
   };
+}
+
+// Build a compact accomplishment/incident card for the "While You Were Away"
+// briefing. Pure shaping helper — no I/O — so it's trivially unit-testable.
+function summarizeAwayActivity(agents, sinceIso) {
+  const succeeded = agents.filter(a => a.result?.success);
+  const failed = agents.filter(a => !a.result?.success);
+
+  const durationOf = (a) => a.result?.duration
+    || (a.completedAt && a.startedAt
+      ? new Date(a.completedAt).getTime() - new Date(a.startedAt).getTime()
+      : 0);
+
+  const toCard = (a) => ({
+    id: a.id,
+    taskId: a.taskId,
+    description: a.metadata?.taskDescription?.substring(0, 120) || a.taskId,
+    taskType: a.metadata?.analysisType || a.metadata?.taskType || 'task',
+    app: a.metadata?.app || null,
+    success: a.result?.success || false,
+    durationMs: durationOf(a),
+    durationFormatted: formatDuration(durationOf(a) > 0 ? durationOf(a) : 0),
+    completedAt: a.completedAt,
+    completedRelative: formatRelativeTime(a.completedAt)
+  });
+
+  // Most-recent first so the freshest work tops each list.
+  const byRecency = (a, b) => new Date(b.completedAt) - new Date(a.completedAt);
+  const totalDurationMs = agents.reduce((sum, a) => {
+    const d = durationOf(a);
+    return sum + (d > 0 ? d : 0);
+  }, 0);
+
+  return {
+    sinceIso,
+    stats: {
+      completed: agents.length,
+      succeeded: succeeded.length,
+      failed: failed.length,
+      successRate: agents.length > 0
+        ? Math.round((succeeded.length / agents.length) * 100)
+        : 0
+    },
+    time: {
+      totalDurationMs,
+      totalDuration: formatDuration(totalDurationMs)
+    },
+    accomplishments: succeeded.sort(byRecency).slice(0, 8).map(toCard),
+    incidents: failed.sort(byRecency).slice(0, 8).map(toCard)
+  };
+}
+
+// "What did agents do while I was away?" — completed agent runs since a
+// client-supplied `sinceIso` (the browser's last-visit marker). Reads
+// in-memory state for fresh runs PLUS the date-bucket archives for any day
+// touched by the window, so a multi-day absence still surfaces work that
+// has already been archived off the live state.
+//
+// Invalid/absent `sinceIso` falls back to the last 24h so the card always
+// renders something useful rather than erroring. The window is clamped to a
+// 30-day lookback to bound the number of archive buckets we read.
+const AWAY_MAX_LOOKBACK_MS = 30 * 86400000;
+export async function getWhileAwayActivity(sinceIso) {
+  const now = Date.now();
+  const parsed = sinceIso ? new Date(sinceIso).getTime() : NaN;
+  // Clamp: a missing/garbage marker → 24h; a marker older than 30d → 30d ago;
+  // a future marker → 24h (a clock-skewed client shouldn't blank the card).
+  let sinceMs = Number.isFinite(parsed) ? parsed : now - 86400000;
+  if (sinceMs > now) sinceMs = now - 86400000;
+  if (sinceMs < now - AWAY_MAX_LOOKBACK_MS) sinceMs = now - AWAY_MAX_LOOKBACK_MS;
+  const effectiveSinceIso = new Date(sinceMs).toISOString();
+
+  const inWindow = (a) => {
+    if (!a.completedAt) return false;
+    const t = new Date(a.completedAt).getTime();
+    return Number.isFinite(t) && t >= sinceMs && t <= now;
+  };
+
+  // Live (in-memory) completed agents within the window.
+  const state = await loadState();
+  const live = Object.values(state.agents).filter(a => a.status === 'completed' && inWindow(a));
+
+  // Archived agents: read each date bucket the window spans (UTC day strings).
+  const seen = new Set(live.map(a => a.id));
+  const archived = [];
+  const startDay = new Date(sinceMs);
+  const endDay = new Date(now);
+  for (let d = new Date(Date.UTC(startDay.getUTCFullYear(), startDay.getUTCMonth(), startDay.getUTCDate()));
+    d.getTime() <= endDay.getTime();
+    d = new Date(d.getTime() + 86400000)) {
+    const dateStr = d.toISOString().slice(0, 10);
+    const agents = await getAgentsByDate(dateStr);
+    for (const a of agents) {
+      if (seen.has(a.id)) continue; // live copy wins (fresher result/output)
+      if (!inWindow(a)) continue;
+      seen.add(a.id);
+      archived.push(a);
+    }
+  }
+
+  const summary = summarizeAwayActivity([...live, ...archived], effectiveSinceIso);
+  return { ...summary, isRunning: isDaemonRunning(), isPaused: state.paused };
 }
 
 // Returns recently completed tasks from in-memory state only.

--- a/server/services/cosReports.js
+++ b/server/services/cosReports.js
@@ -12,6 +12,17 @@ import { loadState, ensureDirectories, REPORTS_DIR, isDaemonRunning } from './co
 import { getAgentsByDate } from './cosAgents.js';
 import { formatDuration, safeJSONParse } from '../lib/fileUtils.js';
 
+// A completed agent's work duration in ms: prefer the recorded `result.duration`,
+// else derive from completedAt − startedAt. Clamped to >=0 so a clock-skewed
+// record (completedAt < startedAt) can't surface a negative duration.
+function agentDurationMs(a) {
+  const d = a.result?.duration
+    || (a.completedAt && a.startedAt
+      ? new Date(a.completedAt).getTime() - new Date(a.startedAt).getTime()
+      : 0);
+  return d > 0 ? d : 0;
+}
+
 export async function generateReport(date = null) {
   const reportDate = date || new Date().toISOString().split('T')[0];
   const state = await loadState();
@@ -117,12 +128,8 @@ export async function getTodayActivity() {
   const succeeded = todayAgents.filter(a => a.result?.success);
   const failed = todayAgents.filter(a => !a.result?.success);
 
-  // Calculate total time worked (sum of agent durations, fallback to completedAt - startedAt)
-  const totalDurationMs = todayAgents.reduce((sum, a) => {
-    const duration = a.result?.duration
-      || (a.completedAt && a.startedAt ? new Date(a.completedAt).getTime() - new Date(a.startedAt).getTime() : 0);
-    return sum + (duration > 0 ? duration : 0);
-  }, 0);
+  // Calculate total time worked (sum of agent durations)
+  const totalDurationMs = todayAgents.reduce((sum, a) => sum + agentDurationMs(a), 0);
 
   // Get currently running agents
   const runningAgents = Object.values(state.agents).filter(a => a.status === 'running');
@@ -138,8 +145,7 @@ export async function getTodayActivity() {
       taskId: a.taskId,
       description: a.metadata?.taskDescription?.substring(0, 100) || a.taskId,
       taskType: a.metadata?.analysisType || a.metadata?.taskType || 'task',
-      duration: a.result?.duration
-        || (a.completedAt && a.startedAt ? new Date(a.completedAt).getTime() - new Date(a.startedAt).getTime() : 0),
+      duration: agentDurationMs(a),
       completedAt: a.completedAt
     }))
     .sort((a, b) => new Date(b.completedAt) - new Date(a.completedAt))
@@ -180,18 +186,8 @@ function summarizeAwayActivity(agents, sinceIso) {
   const succeeded = agents.filter(a => a.result?.success);
   const failed = agents.filter(a => !a.result?.success);
 
-  // Clamp to >=0 so a clock-skewed completedAt < startedAt can't produce a
-  // negative duration in either the per-card field or the rollup.
-  const durationOf = (a) => {
-    const d = a.result?.duration
-      || (a.completedAt && a.startedAt
-        ? new Date(a.completedAt).getTime() - new Date(a.startedAt).getTime()
-        : 0);
-    return d > 0 ? d : 0;
-  };
-
   const toCard = (a) => {
-    const durationMs = durationOf(a);
+    const durationMs = agentDurationMs(a);
     return {
       id: a.id,
       taskId: a.taskId,
@@ -208,7 +204,7 @@ function summarizeAwayActivity(agents, sinceIso) {
 
   // Most-recent first so the freshest work tops each list.
   const byRecency = (a, b) => new Date(b.completedAt) - new Date(a.completedAt);
-  const totalDurationMs = agents.reduce((sum, a) => sum + durationOf(a), 0);
+  const totalDurationMs = agents.reduce((sum, a) => sum + agentDurationMs(a), 0);
 
   return {
     sinceIso,

--- a/server/services/cosReports.test.js
+++ b/server/services/cosReports.test.js
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+
+const mock = vi.hoisted(() => ({
+  state: null,
+  daemonRunning: true,
+  // agentsByDate: { 'YYYY-MM-DD': [agent, ...] }
+  agentsByDate: {}
+}));
+
+vi.mock('./cosState.js', () => ({
+  loadState: vi.fn(async () => mock.state),
+  ensureDirectories: vi.fn(async () => {}),
+  REPORTS_DIR: '/tmp/reports',
+  isDaemonRunning: () => mock.daemonRunning
+}));
+
+vi.mock('./cosAgents.js', () => ({
+  getAgentsByDate: vi.fn(async (date) => mock.agentsByDate[date] || [])
+}));
+
+import { getWhileAwayActivity } from './cosReports.js';
+
+// Build a completed agent record at a fixed completedAt offset (ms before now).
+const agentAt = (id, { msAgo, success = true, desc = 'did a thing', taskType = 'review', app = null } = {}) => {
+  const completedAt = new Date(Date.now() - msAgo).toISOString();
+  const startedAt = new Date(Date.now() - msAgo - 60000).toISOString();
+  return {
+    id,
+    taskId: `task-${id}`,
+    status: 'completed',
+    startedAt,
+    completedAt,
+    result: { success, duration: 60000 },
+    metadata: { taskDescription: desc, taskType, app }
+  };
+};
+
+const stateWith = (agentList) => ({
+  agents: Object.fromEntries(agentList.map(a => [a.id, a])),
+  stats: {},
+  paused: false
+});
+
+describe('getWhileAwayActivity', () => {
+  beforeEach(() => {
+    mock.daemonRunning = true;
+    mock.agentsByDate = {};
+    mock.state = stateWith([]);
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('returns only completed agents within the since-window', async () => {
+    const recent = agentAt('a1', { msAgo: 60 * 60000 });   // 1h ago — in window
+    const old = agentAt('a2', { msAgo: 5 * 3600000 });     // 5h ago — out of window
+    mock.state = stateWith([recent, old]);
+
+    const since = new Date(Date.now() - 2 * 3600000).toISOString(); // 2h ago
+    const result = await getWhileAwayActivity(since);
+
+    expect(result.stats.completed).toBe(1);
+    expect(result.accomplishments).toHaveLength(1);
+    expect(result.accomplishments[0].id).toBe('a1');
+  });
+
+  it('splits successes into accomplishments and failures into incidents', async () => {
+    mock.state = stateWith([
+      agentAt('ok1', { msAgo: 10 * 60000, success: true }),
+      agentAt('ok2', { msAgo: 20 * 60000, success: true }),
+      agentAt('bad1', { msAgo: 30 * 60000, success: false })
+    ]);
+
+    const since = new Date(Date.now() - 3600000).toISOString();
+    const result = await getWhileAwayActivity(since);
+
+    expect(result.stats).toMatchObject({ completed: 3, succeeded: 2, failed: 1, successRate: 67 });
+    expect(result.accomplishments.map(a => a.id)).toEqual(['ok1', 'ok2']); // most-recent first
+    expect(result.incidents.map(a => a.id)).toEqual(['bad1']);
+  });
+
+  it('merges archived agents from date buckets the window spans', async () => {
+    const liveAgent = agentAt('live', { msAgo: 30 * 60000 });
+    mock.state = stateWith([liveAgent]);
+    // An archived agent that completed ~1h ago lives in today's bucket.
+    const todayStr = new Date().toISOString().slice(0, 10);
+    mock.agentsByDate[todayStr] = [agentAt('archived', { msAgo: 50 * 60000 })];
+
+    const since = new Date(Date.now() - 2 * 3600000).toISOString();
+    const result = await getWhileAwayActivity(since);
+
+    const ids = result.accomplishments.map(a => a.id).sort();
+    expect(ids).toEqual(['archived', 'live']);
+    expect(result.stats.completed).toBe(2);
+  });
+
+  it('prefers the live copy over an archived duplicate of the same id', async () => {
+    const live = agentAt('dup', { msAgo: 30 * 60000, success: true, desc: 'live version' });
+    mock.state = stateWith([live]);
+    const todayStr = new Date().toISOString().slice(0, 10);
+    mock.agentsByDate[todayStr] = [agentAt('dup', { msAgo: 30 * 60000, success: false, desc: 'stale archived version' })];
+
+    const since = new Date(Date.now() - 3600000).toISOString();
+    const result = await getWhileAwayActivity(since);
+
+    expect(result.stats.completed).toBe(1);
+    expect(result.accomplishments).toHaveLength(1);
+    expect(result.accomplishments[0].description).toBe('live version');
+    expect(result.incidents).toHaveLength(0);
+  });
+
+  it('falls back to a 24h window when since is absent or garbage', async () => {
+    const within = agentAt('w', { msAgo: 12 * 3600000 });   // 12h ago — inside 24h
+    const beyond = agentAt('b', { msAgo: 40 * 3600000 });   // 40h ago — outside 24h
+    mock.state = stateWith([within, beyond]);
+
+    for (const bad of [undefined, '', 'not-a-date', 'null']) {
+      const result = await getWhileAwayActivity(bad);
+      expect(result.stats.completed).toBe(1);
+      expect(result.accomplishments[0].id).toBe('w');
+    }
+  });
+
+  it('treats a future since marker as the 24h fallback (clock skew guard)', async () => {
+    const within = agentAt('w', { msAgo: 6 * 3600000 });
+    mock.state = stateWith([within]);
+
+    const future = new Date(Date.now() + 3600000).toISOString();
+    const result = await getWhileAwayActivity(future);
+
+    expect(result.stats.completed).toBe(1);
+    expect(result.accomplishments[0].id).toBe('w');
+  });
+
+  it('reports daemon running/paused state', async () => {
+    mock.daemonRunning = false;
+    mock.state = { agents: {}, stats: {}, paused: true };
+
+    const result = await getWhileAwayActivity(new Date(Date.now() - 3600000).toISOString());
+
+    expect(result.isRunning).toBe(false);
+    expect(result.isPaused).toBe(true);
+    expect(result.stats.completed).toBe(0);
+    expect(result.accomplishments).toEqual([]);
+    expect(result.incidents).toEqual([]);
+  });
+
+  it('caps accomplishments and incidents at 8 each', async () => {
+    const many = [];
+    for (let i = 0; i < 12; i++) many.push(agentAt(`ok${i}`, { msAgo: (i + 1) * 60000, success: true }));
+    for (let i = 0; i < 12; i++) many.push(agentAt(`bad${i}`, { msAgo: (i + 1) * 60000, success: false }));
+    mock.state = stateWith(many);
+
+    const since = new Date(Date.now() - 3600000).toISOString();
+    const result = await getWhileAwayActivity(since);
+
+    expect(result.accomplishments).toHaveLength(8);
+    expect(result.incidents).toHaveLength(8);
+    expect(result.stats.completed).toBe(24);
+  });
+});

--- a/server/services/dashboardLayouts.js
+++ b/server/services/dashboardLayouts.js
@@ -63,13 +63,14 @@ export const INTENT_LAYOUTS = [
   {
     id: 'agent-watch',
     name: 'Agent Watch',
-    widgets: ['cos', 'proactive-alerts', 'review-hub', 'system-health', 'decision-log'],
+    widgets: ['cos', 'proactive-alerts', 'review-hub', 'while-away', 'system-health', 'decision-log'],
     grid: [
       { id: 'cos',              x: 0, y: 0, w: 6, h: 5 },
       { id: 'proactive-alerts', x: 6, y: 0, w: 3, h: 3 },
       { id: 'review-hub',       x: 9, y: 0, w: 3, h: 3 },
-      { id: 'system-health',    x: 6, y: 3, w: 6, h: 5 },
-      { id: 'decision-log',     x: 0, y: 5, w: 6, h: 3 },
+      { id: 'while-away',       x: 6, y: 3, w: 6, h: 5 },
+      { id: 'system-health',    x: 0, y: 5, w: 6, h: 5 },
+      { id: 'decision-log',     x: 6, y: 8, w: 6, h: 3 },
     ],
   },
 ];
@@ -83,7 +84,7 @@ const DEFAULT_LAYOUTS = [
       'quick-brain', 'quick-idea', 'quick-image', 'quick-task',
       'apps',
       'cos', 'goal-progress', 'upcoming-tasks',
-      'proactive-alerts', 'review-hub', 'system-health', 'network-exposure', 'backup', 'death-clock', 'quick-stats', 'decision-log',
+      'proactive-alerts', 'review-hub', 'while-away', 'system-health', 'network-exposure', 'backup', 'death-clock', 'quick-stats', 'decision-log',
       'activity-streak', 'hourly-activity',
     ],
     // Above-the-fold capture row stretches to h=5 so the Quick Task card
@@ -110,6 +111,7 @@ const DEFAULT_LAYOUTS = [
       // Row 14–17: lower-priority + cos
       { id: 'decision-log',     x: 0,  y: 14, w: 4, h: 2 },
       { id: 'cos',              x: 4,  y: 14, w: 5, h: 4 },
+      { id: 'while-away',       x: 9,  y: 14, w: 3, h: 5 },
       // Row 18+: full-width visualizations + apps
       { id: 'hourly-activity',  x: 0,  y: 18, w: 12, h: 3 },
       { id: 'apps',             x: 0,  y: 21, w: 12, h: 8 },

--- a/server/services/dashboardLayouts.js
+++ b/server/services/dashboardLayouts.js
@@ -108,10 +108,12 @@ const DEFAULT_LAYOUTS = [
       { id: 'quick-stats',      x: 3,  y: 10, w: 3, h: 3 },
       { id: 'goal-progress',    x: 6,  y: 10, w: 3, h: 4 },
       { id: 'network-exposure', x: 9,  y: 10, w: 3, h: 5 },
-      // Row 14–17: lower-priority + cos
+      // Row 14–17: lower-priority + cos. while-away fills the x9–11 column
+      // in rows 15–17 — below network-exposure (ends at row 14) and above
+      // hourly-activity (starts at row 18), so it overlaps neither.
       { id: 'decision-log',     x: 0,  y: 14, w: 4, h: 2 },
       { id: 'cos',              x: 4,  y: 14, w: 5, h: 4 },
-      { id: 'while-away',       x: 9,  y: 14, w: 3, h: 5 },
+      { id: 'while-away',       x: 9,  y: 15, w: 3, h: 3 },
       // Row 18+: full-width visualizations + apps
       { id: 'hourly-activity',  x: 0,  y: 18, w: 12, h: 3 },
       { id: 'apps',             x: 0,  y: 21, w: 12, h: 8 },

--- a/server/services/dashboardLayouts.test.js
+++ b/server/services/dashboardLayouts.test.js
@@ -175,4 +175,28 @@ describe('dashboardLayouts service', () => {
       expect(existsSync(STATE_FILE)).toBe(false);
     });
   });
+
+  describe('built-in layout grids have no overlapping cells', () => {
+    // Regression: a hand-tuned grid edit can place two widgets in the same
+    // rows/cols, so fresh installs render stacked cards. Every built-in
+    // layout's grid rectangles must be pairwise non-overlapping.
+    const rectsOverlap = (a, b) =>
+      a.x < b.x + b.w && b.x < a.x + a.w && a.y < b.y + b.h && b.y < a.y + a.h;
+
+    it('no two grid items overlap in any seeded built-in layout', async () => {
+      const state = await svc.getState();
+      const collisions = [];
+      for (const layout of state.layouts) {
+        const grid = layout.grid || [];
+        for (let i = 0; i < grid.length; i += 1) {
+          for (let j = i + 1; j < grid.length; j += 1) {
+            if (rectsOverlap(grid[i], grid[j])) {
+              collisions.push(`${layout.id}: ${grid[i].id} ∩ ${grid[j].id}`);
+            }
+          }
+        }
+      }
+      expect(collisions).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## What

First slice of the #711 autonomy/briefing umbrella: a **"While You Were Away"** dashboard card that recaps what your agents did since your last visit.

- Counts completed agent runs since a per-device last-visit marker, with a success/failure tally, total time worked, and the most-recent accomplishments plus any failures that need a look.
- Each row deep-links to the agent; a **Mark as seen** button resets the window to now.
- Live-refreshes on agent completion (socket), mirroring the Review Hub card.
- Appears on the **Everything** and **Agent Watch** built-in layouts; addable to any layout via Arrange.

## How

- **Server:** `getWhileAwayActivity(sinceIso)` aggregates live (in-memory) **and** archived (date-bucket) completed agent runs within the window, dedups (live copy wins), splits into accomplishments/incidents, and clamps the window (garbage/future marker → 24h fallback; >30d → 30d). New read-only route `GET /api/cos/activity/while-away?since=<ISO>` with a tolerant Zod query schema.
- **Client:** `WhileAwayWidget` reads/writes the last-visit marker in `localStorage` (per-device, no server presence state to migrate), fetches via the new `getCosWhileAwayActivity` wrapper, and renders accomplishment/incident rows.

## Away-window design

Per-device `localStorage` last-visit marker (chosen over server-side presence): simplest, no migration, no new persisted state. The server still clamps/validates `since` so a missing or skewed marker degrades gracefully to a 24h window.

## Tests

`getWhileAwayActivity` unit tests cover window filtering, success/failure split, archive merge, live-wins-over-archive dedup, 24h fallback (absent/garbage), future-marker clock-skew guard, daemon state passthrough, and the 8-item caps. Server + client builds green; existing dashboard-layout and cos-route suites pass.

This is one slice — the remaining #711 deliverables (per-domain autonomy knobs, dry-run, budgets) stay on the umbrella issue.

Part of #711.