### PR TITLE
show machine instance name in browser tab title as 'PortOS: {name}'

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,7 +1,7 @@
 import { Suspense, useEffect } from 'react';
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import Layout from './components/Layout';
-import { getSettings, updateSettings } from './services/api';
+import { getSettings, updateSettings, getSelfInstance } from './services/api';
 import BrailleSpinner from './components/BrailleSpinner';
 import { CatalogTypesProvider } from './hooks/useCatalogTypes.jsx';
 import Dashboard from './pages/Dashboard';
@@ -153,8 +153,21 @@ function useTimezoneBootstrap() {
   }, []);
 }
 
+// Stamp the machine's instance name into the browser tab so multiple federated
+// installs are distinguishable at a glance — "PortOS: {name}". Falls back to the
+// static "PortOS" title (set in index.html) when the name is missing/unfetchable.
+function useDocumentTitle() {
+  useEffect(() => {
+    getSelfInstance({ silent: true }).then((self) => {
+      const name = self?.name?.trim();
+      if (name) document.title = `PortOS: ${name}`;
+    }).catch(() => null);
+  }, []);
+}
+
 export default function App() {
   useTimezoneBootstrap();
+  useDocumentTitle();
   return (
     <CatalogTypesProvider>
     <Suspense fallback={<PageLoader />}>

--- a/client/src/pages/Instances.jsx
+++ b/client/src/pages/Instances.jsx
@@ -234,6 +234,7 @@ function SelfCard({ self, onUpdate, syncStatus, tailnetInfo }) {
     if (!name.trim()) return;
     const result = await updateSelfInstance({ name: name.trim() }).catch(() => null);
     if (!result) return;
+    document.title = `PortOS: ${name.trim()}`;
     onUpdate();
     setEditing(false);
     toast.success('Instance name updated');

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -166,7 +166,7 @@ export const navigateBrowser = (url) => request('/browser/navigate', {
 
 // Instances (Federation)
 export const getInstances = (options) => request('/instances', options);
-export const getSelfInstance = () => request('/instances/self');
+export const getSelfInstance = (options) => request('/instances/self', options);
 export const updateSelfInstance = (data) => request('/instances/self', { method: 'PUT', body: JSON.stringify(data) });
 export const addPeer = (data) => request('/instances/peers', { method: 'POST', body: JSON.stringify(data) });
 export const updatePeer = (id, data) => request(`/instances/peers/${id}`, { method: 'PUT', body: JSON.stringify(data) });


### PR DESCRIPTION
## Summary

The browser tab previously showed a static `PortOS` title for every install. With several federated installs open at once, the tabs are indistinguishable. This stamps the machine's instance name into the tab so it reads `PortOS: {name}` (e.g. `PortOS: Adams-MacBook-Pro`).

- `App.jsx`: new `useDocumentTitle` bootstrap hook fetches `getSelfInstance()` on mount and sets `document.title` to `PortOS: {name}` when a name is present. Falls back to the static `PortOS` title (in `index.html`) when the name is missing or the fetch fails — the call is `{ silent: true }` so a startup failure doesn't toast.
- `apiSystem.js`: `getSelfInstance(options)` now forwards request options (mirrors sibling `getInstances`), enabling the silent fetch.
- `Instances.jsx`: renaming the instance updates `document.title` immediately, so the tab stays in sync without a reload.

## Test plan

- Load the app → tab reads `PortOS: {hostname}`.
- Rename the instance on the Instances page → tab title updates immediately.
- Simulate a failed/empty instance fetch → tab keeps the static `PortOS` title, no error toast.
- `npx eslint` passes on all three changed files.