### PR TITLE
fix: stop CoS avatar canvas from overlapping the stats grid on desktop

### DIFF
--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -688,7 +688,13 @@ export default function ChiefOfStaff() {
             />
 
             {hasCanvasAvatar && (
-              <div className="absolute inset-0 z-[1] -translate-x-16 -translate-y-1 sm:translate-x-0 sm:-translate-y-6 md:-translate-y-8 lg:-translate-y-28 xl:-translate-y-36">
+              // Cap the full-bleed avatar canvas to the panel's BASE height
+              // (the same min-h the panel starts at) and anchor it to the top.
+              // The panel itself uses min-h so it can grow to fit the stats grid
+              // + event log without clipping; without this cap the inset-0 canvas
+              // grows with the panel on desktop, dragging the framed avatar down
+              // into the stats grid below it.
+              <div className="absolute inset-0 lg:bottom-auto lg:h-[min(460px,calc(100vh-1rem))] xl:h-[min(620px,calc(100vh-1rem))] z-[1] -translate-x-16 -translate-y-1 sm:translate-x-0 sm:-translate-y-6 md:-translate-y-8 lg:-translate-y-28 xl:-translate-y-36">
                 {renderAvatar(true)}
               </div>
             )}


### PR DESCRIPTION
## Summary

On the Chief of Staff page (`/cos`), the canvas-avatar styles render the 3D avatar as a full-bleed background (`absolute inset-0`) behind the overlaid UI (headings, status bubble, stats grid, event log).

The recent tall-viewport fix (`30729c13`) switched the avatar **panel** from a fixed `h-[min(460px,…)]` to `min-h-[…]` so it grows to fit the stats grid + event log without clipping them. But the avatar **canvas** stayed at `absolute inset-0`, so on desktop it grew along with the now-taller panel — dragging the framed avatar down on top of the stats grid below it ("the Chief of Staff got bumped down and it's colliding with the status widgets").

The fix caps the avatar canvas to the panel's **base** height (the same `min(460px,…)` / `min(620px,…)` values) and anchors it to the top via `lg:bottom-auto`. The avatar now stays in its designed zone while the panel still grows downward for overflow content — keeping both the un-clip fix and the avatar's original framing.

- Desktop (`lg`/`xl`): avatar canvas pinned to top at its base height; no longer stretches into the stats grid.
- Mobile/tablet (base/`sm`/`md`): unchanged — the 46/54 side-by-side split keeps `inset-0`.

## Test plan

- [x] `npm run build` (client) passes — confirms the Tailwind arbitrary `h-[min(…)]` / `bottom-auto` utilities generate.
- [ ] On a tall desktop viewport, open `/cos` with a canvas avatar style (cyber/sigil/esoteric/nexus/muse) and a running CoS with event-log output; confirm the avatar stays anchored above the stats grid and the stats/event log are no longer overlapped or clipped.