### PR TITLE
test([issue-895]): pin goal-organization __new_apex__ round-trip

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -26,6 +26,7 @@
 - **[issue-925] Pin the top-level sidebar pages too** — Dashboard, Review Hub, City, and Goals can now be pinned to the top of the sidebar, the same way pages inside the collapsible sections already could. Hover (or keyboard-focus) one of these rows to reveal its pin button; the Chief of Staff unread badge and the collapsed icon-rail look are unchanged.
 - **City keeps downtown clear of the AI Core** — downtown buildings that would otherwise grid onto the central AI Core landmark are now pushed out onto a one-cell plaza ring (dodging occupied slots so two buildings never stack), so no downtown building or label overlaps the core; a lone app sits at the front of the plaza. The warehouse district keeps its existing placement. District neon signs also gain a styled back panel with a thin accent strip so they read as finished objects when seen from behind instead of flat black cutouts.
 - **[issue-919] Internal: shared-helper catalog for the client utility modules** — Added a discovery index and a drift-guard test so the client's pure helper modules stay easy to find and can't silently fall out of the catalog. No user-facing change.
+- **[issue-895] Internal: pinned the goal-organization apex round-trip with a test** — Confirmed "create a new apex from AI suggestions" already works end-to-end and added regression coverage so it can't silently break. No user-facing change.
 
 ## Fixed
 

--- a/client/src/components/goals/applyOrganization.test.js
+++ b/client/src/components/goals/applyOrganization.test.js
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// applyOrganizationSuggestion resolves the `__new_apex__` sentinel CLIENT-SIDE:
-// it creates the new apex first, rewrites every `__new_apex__` parent ref to the
-// real id, creates sub-apex goals under it, THEN calls the server. So the server's
-// applyGoalOrganization never receives a raw sentinel — its goalMap.has() skip is
-// correct defensive behavior, not a bug. These tests pin that round-trip so a
-// future refactor of this file can't silently regress it (see issue #895).
+// For a VALID new-apex suggestion, applyOrganizationSuggestion resolves the
+// `__new_apex__` sentinel CLIENT-SIDE: it creates the new apex first, rewrites every
+// `__new_apex__` parent ref to the real id, creates sub-apex goals under it, THEN
+// calls the server — so no raw sentinel reaches applyGoalOrganization. The rewrite
+// only runs once an apex id is resolved, so a malformed/drift suggestion that carries
+// `__new_apex__` with no resolvable apex still passes the sentinel through; the
+// server's goalMap.has() skip is the defensive net for that case (correct behavior,
+// not a bug). These tests pin both paths so a future refactor of this file can't
+// silently regress the round-trip (see issue #895).
 vi.mock('../../services/api', () => ({
   createGoal: vi.fn(),
   applyGoalOrganization: vi.fn(() => Promise.resolve(true)),
@@ -94,10 +97,32 @@ describe('applyOrganizationSuggestion — __new_apex__ round-trip', () => {
 
     await applyOrganizationSuggestion(suggestion);
 
-    // First createGoal is the apex; the sub-apex create must be parented under the real apex id
+    // The apex is created first (so its id is available to parent the sub-apex)...
+    expect(api.createGoal.mock.calls[0][0]).toMatchObject({ title: 'Apex', goalType: 'apex' });
+    // ...then the sub-apex create is parented under the real apex id
     expect(api.createGoal).toHaveBeenCalledWith(
       expect.objectContaining({ title: 'Health', goalType: 'sub-apex', parentId: 'apex-real-3' })
     );
+  });
+
+  it('passes the raw sentinel through (server-side skip is the safety net) when no apex resolves', async () => {
+    // Drift case: organization carries __new_apex__ but the suggestion gives no
+    // resolvable apex (no existingId, no suggestedTitle), so the client rewrite is
+    // skipped. The sentinel reaches the server, where goalMap.has('__new_apex__') is
+    // false and the item is silently skipped — the defensive behavior issue #895 noted.
+    const suggestion = {
+      apexGoal: { existingId: null, suggestedTitle: null, suggestedDescription: null },
+      organization: [{ id: 'g-1', goalType: 'sub-apex', suggestedParentId: '__new_apex__' }],
+      suggestedSubApex: [],
+    };
+
+    const ok = await applyOrganizationSuggestion(suggestion);
+    expect(ok).toBe(true);
+    expect(api.createGoal).not.toHaveBeenCalled();
+
+    // No apex resolved → no client-side rewrite → the raw sentinel is still in the payload
+    const sentOrg = api.applyGoalOrganization.mock.calls[0][0];
+    expect(sentOrg[0].suggestedParentId).toBe('__new_apex__');
   });
 
   it('does not mutate the caller-provided organization array', async () => {

--- a/client/src/components/goals/applyOrganization.test.js
+++ b/client/src/components/goals/applyOrganization.test.js
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// applyOrganizationSuggestion resolves the `__new_apex__` sentinel CLIENT-SIDE:
+// it creates the new apex first, rewrites every `__new_apex__` parent ref to the
+// real id, creates sub-apex goals under it, THEN calls the server. So the server's
+// applyGoalOrganization never receives a raw sentinel — its goalMap.has() skip is
+// correct defensive behavior, not a bug. These tests pin that round-trip so a
+// future refactor of this file can't silently regress it (see issue #895).
+vi.mock('../../services/api', () => ({
+  createGoal: vi.fn(),
+  applyGoalOrganization: vi.fn(() => Promise.resolve(true)),
+}));
+
+import * as api from '../../services/api';
+import { applyOrganizationSuggestion } from './applyOrganization';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.applyGoalOrganization.mockResolvedValue(true);
+});
+
+describe('applyOrganizationSuggestion — __new_apex__ round-trip', () => {
+  it('creates a new apex and rewrites __new_apex__ parent refs to its real id before the server call', async () => {
+    api.createGoal.mockResolvedValue({ id: 'apex-real-1' });
+
+    const suggestion = {
+      apexGoal: { existingId: null, suggestedTitle: 'Live fully', suggestedDescription: 'North star' },
+      organization: [
+        { id: 'g-1', goalType: 'sub-apex', suggestedParentId: '__new_apex__' },
+        { id: 'g-2', goalType: 'standard', suggestedParentId: 'g-1' },
+      ],
+      suggestedSubApex: [],
+    };
+
+    const ok = await applyOrganizationSuggestion(suggestion);
+    expect(ok).toBe(true);
+
+    // Apex created from the suggestion
+    expect(api.createGoal).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Live fully', goalType: 'apex' })
+    );
+
+    // The server received the rewritten organization — no raw sentinel survives
+    const sentOrg = api.applyGoalOrganization.mock.calls[0][0];
+    expect(sentOrg.find(i => i.id === 'g-1').suggestedParentId).toBe('apex-real-1');
+    expect(sentOrg.some(i => i.suggestedParentId === '__new_apex__')).toBe(false);
+    // Unrelated parent refs are untouched
+    expect(sentOrg.find(i => i.id === 'g-2').suggestedParentId).toBe('g-1');
+  });
+
+  it('rewrites unparented sub-apex items (no parent + sub-apex type) to the apex too', async () => {
+    api.createGoal.mockResolvedValue({ id: 'apex-real-2' });
+
+    const suggestion = {
+      apexGoal: { existingId: null, suggestedTitle: 'Purpose', suggestedDescription: '' },
+      organization: [
+        { id: 'g-1', goalType: 'sub-apex', suggestedParentId: null },
+      ],
+      suggestedSubApex: [],
+    };
+
+    await applyOrganizationSuggestion(suggestion);
+    const sentOrg = api.applyGoalOrganization.mock.calls[0][0];
+    expect(sentOrg[0].suggestedParentId).toBe('apex-real-2');
+  });
+
+  it('uses an existing apex id (no apex creation) and still strips the sentinel', async () => {
+    const suggestion = {
+      apexGoal: { existingId: 'existing-apex', suggestedTitle: null, suggestedDescription: null },
+      organization: [
+        { id: 'g-1', goalType: 'sub-apex', suggestedParentId: '__new_apex__' },
+      ],
+      suggestedSubApex: [],
+    };
+
+    const ok = await applyOrganizationSuggestion(suggestion);
+    expect(ok).toBe(true);
+    expect(api.createGoal).not.toHaveBeenCalled();
+
+    const sentOrg = api.applyGoalOrganization.mock.calls[0][0];
+    expect(sentOrg[0].suggestedParentId).toBe('existing-apex');
+  });
+
+  it('creates suggestedSubApex goals parented under the resolved apex', async () => {
+    api.createGoal.mockResolvedValue({ id: 'apex-real-3' });
+
+    const suggestion = {
+      apexGoal: { existingId: null, suggestedTitle: 'Apex', suggestedDescription: '' },
+      organization: [],
+      suggestedSubApex: [
+        { title: 'Health', description: 'Stay alive', category: 'health', suggestedParentId: '__new_apex__' },
+      ],
+    };
+
+    await applyOrganizationSuggestion(suggestion);
+
+    // First createGoal is the apex; the sub-apex create must be parented under the real apex id
+    expect(api.createGoal).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Health', goalType: 'sub-apex', parentId: 'apex-real-3' })
+    );
+  });
+
+  it('does not mutate the caller-provided organization array', async () => {
+    api.createGoal.mockResolvedValue({ id: 'apex-real-4' });
+
+    const original = [{ id: 'g-1', goalType: 'sub-apex', suggestedParentId: '__new_apex__' }];
+    const suggestion = {
+      apexGoal: { existingId: null, suggestedTitle: 'Apex', suggestedDescription: '' },
+      organization: original,
+      suggestedSubApex: [],
+    };
+
+    await applyOrganizationSuggestion(suggestion);
+    // Caller's array is untouched (the function clones before rewriting)
+    expect(original[0].suggestedParentId).toBe('__new_apex__');
+  });
+
+  it('aborts (returns false) when apex creation fails', async () => {
+    api.createGoal.mockResolvedValue(null);
+
+    const suggestion = {
+      apexGoal: { existingId: null, suggestedTitle: 'Apex', suggestedDescription: '' },
+      organization: [{ id: 'g-1', goalType: 'sub-apex', suggestedParentId: '__new_apex__' }],
+      suggestedSubApex: [],
+    };
+
+    const ok = await applyOrganizationSuggestion(suggestion);
+    expect(ok).toBe(false);
+    expect(api.applyGoalOrganization).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #895.

## Verdict: already-correct

Issue #895 asked whether the `__new_apex__` apex round-trip is wired up, since the server's `applyGoalOrganization` (`server/services/identity/goals.js`) only reparents/retypes **existing** goals and silently skips any `suggestedParentId === '__new_apex__'` (the `goalMap.has()` guard).

For a **valid** new-apex suggestion it **is** handled — on the client, in `client/src/components/goals/applyOrganization.js` (`applyOrganizationSuggestion`):

1. If `apexGoal.suggestedTitle` is set with no `existingId`, create the new apex goal first and capture its real id.
2. Rewrite every `__new_apex__` parent ref (and unparented sub-apex items) in the organization array to that real id.
3. Create `suggestedSubApex` goals parented under the resolved apex.
4. **Then** call the server's `applyGoalOrganization` with the rewritten array.

So for valid suggestions the server never receives a raw sentinel. The rewrite only runs *after* an apex id is resolved, so a malformed/drift suggestion that carries `__new_apex__` with no resolvable apex (no `existingId`, no `suggestedTitle`) still passes the sentinel through — and the server's `goalMap.has()` skip is the correct defensive net for that case, not a bug. Both UI entry points (`GoalsListView`, `GoalsTreeView`) route through `applyOrganizationSuggestion`.

## What this PR ships

`applyOrganization.js` had **zero test coverage** while the server side already had integration tests — so the resolved-by-design behavior was one refactor away from silently regressing. This PR pins it with `applyOrganization.test.js` (7 cases): new-apex creation + sentinel rewrite, unparented sub-apex rewrite, existing-apex path, `suggestedSubApex` parenting (asserting apex-created-first ordering), no-mutation-of-caller-array, apex-creation-failure abort, and the unresolved-sentinel drift path (server-skip is the safety net).

No production code changed. `/simplify` skipped (test-only, no new production code paths). Reviewed by `claude` + `codex` per `--review-with` — both independently flagged that the original "no raw sentinel survives" claim was too broad; addressed by narrowing the claim and adding the drift-path test.