### PR TITLE
fix(lint): add missing HTML element globals to client eslint config

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -28,6 +28,7 @@
 - **[issue-919] Internal: shared-helper catalog for the client utility modules** — Added a discovery index and a drift-guard test so the client's pure helper modules stay easy to find and can't silently fall out of the catalog. No user-facing change.
 - **[issue-939] Internal: integration test locking pinned single nav rows** — Added a sidebar-level test that pinning a top-level page (Dashboard, Review Hub, City, Goals) renders it in the Pinned section, so a future refactor of the nav indexing can't silently drop pinned top-level pages. No user-facing change.
 - **[issue-895] Internal: pinned the goal-organization apex round-trip with a test** — Confirmed "create a new apex from AI suggestions" already works end-to-end and added regression coverage so it can't silently break. No user-facing change.
+- **Internal: restored a green lint build** — Added the standard DOM element globals the client lint config was missing, so the build's lint check passes again. No user-facing change.
 
 ## Fixed
 

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -24,6 +24,7 @@ const browserGlobals = {
   HTMLElement: 'readonly', HTMLInputElement: 'readonly', HTMLCanvasElement: 'readonly',
   HTMLVideoElement: 'readonly', HTMLTextAreaElement: 'readonly',
   HTMLMediaElement: 'readonly', HTMLAudioElement: 'readonly',
+  HTMLButtonElement: 'readonly', HTMLDivElement: 'readonly', HTMLSelectElement: 'readonly',
   Element: 'readonly', Node: 'readonly', NodeList: 'readonly', Text: 'readonly',
   MutationObserver: 'readonly', IntersectionObserver: 'readonly',
   ResizeObserver: 'readonly',


### PR DESCRIPTION
## Problem

CI's `lint` job has been failing across the last several merges to `main`. The client eslint config's `browserGlobals` allowlist lists most `HTML*Element` globals (`HTMLElement`, `HTMLInputElement`, `HTMLCanvasElement`, …) but was **missing `HTMLButtonElement` and `HTMLDivElement`**. Two bare references in `client/src/components/ui/ProvenanceChip.test.jsx` (lines 82, 90) tripped `no-undef` as **errors**, so `eslint src` exited non-zero and failed the build.

```
82:14  error  'HTMLButtonElement' is not defined  no-undef
90:14  error  'HTMLDivElement' is not defined     no-undef
```

## Fix

Added the missing standard DOM element globals to the allowlist, next to their siblings. Included `HTMLSelectElement` as well (also absent and the same standard-DOM-global class — currently only used via `window.HTMLSelectElement` so it doesn't error today, but a future bare reference would hit the identical bug).

`npm run lint --prefix client` now exits 0 (0 errors; the pre-existing 44 warnings are unchanged and don't fail CI).

## Scope

Lint-only. There is a separate, unrelated client **test** failure (`SeriesLlmPicker.test.jsx > preserves the chosen provider when only the model changes`) that keeps the `test` job red — not addressed here; this PR restores the green **lint** build.