### PR TITLE
feat([issue-739]): bump LTX2_PIN to v0.14.8 with dual-pin pipeline adaptation

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -29,6 +29,7 @@
 - **[issue-939] Internal: integration test locking pinned single nav rows** — Added a sidebar-level test that pinning a top-level page (Dashboard, Review Hub, City, Goals) renders it in the Pinned section, so a future refactor of the nav indexing can't silently drop pinned top-level pages. No user-facing change.
 - **[issue-895] Internal: pinned the goal-organization apex round-trip with a test** — Confirmed "create a new apex from AI suggestions" already works end-to-end and added regression coverage so it can't silently break. No user-facing change.
 - **Internal: restored a green lint build** — Added the standard DOM element globals the client lint config was missing, so the build's lint check passes again. No user-facing change.
+- **[issue-739] LTX-2 video runtime updated to v0.14.8** — Bumped the bundled LTX-2 (Apple Silicon) video generator to a newer upstream release with better memory behavior on HD and long renders and a fix that stops character LoRAs from silently dropping on Extend and high-quality modes. All five render modes (text, image, keyframe, extend, audio-to-video) keep working across the upgrade, and the previous version stays supported until an install re-runs its image/video setup.
 
 ## Fixed
 

--- a/scripts/generate_ltx2.py
+++ b/scripts/generate_ltx2.py
@@ -17,12 +17,20 @@ Why a wrapper at all (vs. spawning `ltx-2-mlx <subcommand>` directly):
     the Node side simple — one helper, four subcommands, identical contract
     to the existing `python -m mlx_video.generate_av` invocation.
 
-Modes:
-  text   → TextToVideoPipeline.generate_and_save
-  image  → ImageToVideoPipeline.generate_and_save (--image)
+Modes (class names shown new→old; we resolve whichever the installed pin has):
+  text   → TI2VidOneStagePipeline / TextToVideoPipeline .generate_and_save
+  image  → TI2VidOneStagePipeline / ImageToVideoPipeline .generate_and_save (--image)
   fflf   → KeyframeInterpolationPipeline.generate_and_save (--image start, --last-image end)
-  extend → ExtendPipeline.extend_from_video (--extend-from-video, --extend-frames, --direction)
-  a2v    → AudioToVideoPipeline.generate_and_save (--audio, optional --image)
+  extend → RetakePipeline / ExtendPipeline .extend_from_video (--extend-from-video, --extend-frames, --direction)
+  a2v    → A2VidPipelineTwoStage / AudioToVideoPipeline .generate_and_save (--audio, optional --image)
+
+Pin compatibility — class renames + frame_rate:
+  The v0.14.x line of ltx-2-mlx renamed every public pipeline class and
+  switched the output-rate keyword from `fps` to `frame_rate`. PortOS pins a
+  specific commit (see scripts/setup-image-video.sh LTX2_PIN), but installs
+  upgrade on their own schedule, so this bridge resolves both the pipeline
+  class (_resolve_pipeline / _resolve_pipeline_with_method) and the rate
+  keyword (_rate_kwargs) from the live API — old and new pins both work.
 
 Output: writes the rendered .mp4 to --output. Emits a final JSON line on
 stdout ({"video_path": "<output>"}) so the Node parent can read the result
@@ -39,6 +47,7 @@ from __future__ import annotations
 
 import argparse
 import importlib
+import inspect
 import json
 import os
 import sys
@@ -70,6 +79,87 @@ def emit_download(msg: str) -> None:
     print(f"DOWNLOAD:{msg}", file=sys.stderr, flush=True)
 
 
+def _resolve_pipeline(*names: str, method: str | None = None):
+    """Return the first available pipeline class from ltx_pipelines_mlx.
+
+    LTX-2 renamed every public pipeline class in the v0.14.x line
+    (TextToVideoPipeline → TI2VidOneStagePipeline, TwoStagePipeline →
+    TI2VidTwoStagesPipeline, AudioToVideoPipeline → A2VidPipelineTwoStage, …).
+    We try the names in preference order — new name first, legacy name as
+    fallback — so this bridge works against both the v0.14.x pins new installs
+    get AND the pre-rename pins an existing install may still have checked out
+    until it re-runs setup-image-video.sh.
+
+    `method`, when given, additionally requires the class to define it — used by
+    the extend path, where pre-rename pins expose ExtendPipeline.extend_from_video
+    and v0.14.x folds that into RetakePipeline.extend_from_video (deleting the
+    `extend` module). Preferring whichever class actually defines the method
+    avoids selecting a same-named class that happens to lack it.
+
+    Raises a clear SystemExit instead of surfacing an opaque ImportError deep
+    inside a runner.
+    """
+    pkg = importlib.import_module("ltx_pipelines_mlx")
+    for name in names:
+        cls = getattr(pkg, name, None)
+        if cls is not None and (method is None or hasattr(cls, method)):
+            return cls
+    want = f"pipeline with .{method}()" if method else "expected pipelines"
+    raise SystemExit(
+        f"ltx-2-mlx exposes no {want} among {names!r} — the installed pin may "
+        "be too old or too new for this bridge."
+    )
+
+
+def _first_module_with_attr(attr: str, *modnames: str):
+    """Return the first importable module exposing `attr`, or None.
+
+    Best-effort sibling to _resolve_pipeline for module-level symbols: the
+    extend denoise loop lives in `extend` on pre-rename pins and in `retake` on
+    v0.14.x. Unlike _resolve_pipeline this returns None instead of raising —
+    callers treat a miss as "feature unavailable at this pin" and degrade.
+    """
+    for modname in modnames:
+        try:
+            mod = importlib.import_module(modname)
+        except ImportError:
+            continue
+        if hasattr(mod, attr):
+            return mod
+    return None
+
+
+def _rate_kwarg_name(func) -> str | None:
+    """Which output frame-rate keyword `func` accepts: 'frame_rate', 'fps', or None.
+
+    v0.14.x renamed the output-rate parameter from `fps` to `frame_rate` across
+    generate_and_save / _decode_and_save_video. Inspecting the live signature
+    lets one call site feed either API. Only an *explicit* parameter counts — a
+    bare **kwargs is not treated as accepting the rate, so we never smuggle an
+    unknown keyword through.
+    """
+    try:
+        params = inspect.signature(func).parameters
+    except (TypeError, ValueError):
+        return None
+    if "frame_rate" in params:
+        return "frame_rate"
+    if "fps" in params:
+        return "fps"
+    return None
+
+
+def _rate_kwargs(func, fps: float) -> dict:
+    """Return {<rate-keyword>: fps} for `func`, or {} if it takes neither.
+
+    New pins require `frame_rate` on generate_and_save (keyword-only, no
+    default), so passing it is mandatory there; old pins where the rate is
+    bound via bind_output_fps instead return {} and rely on that wrapper.
+    """
+    name = _rate_kwarg_name(func)
+    return {name: fps} if name else {}
+
+
 _EXTEND_TC_CONFIG: dict | None = None
 _A2V_TC_CONFIG: dict | None = None
 _EXTEND_TC_PATCH_OK = False
@@ -77,24 +167,37 @@ _A2V_TC_PATCH_OK = False
 
 
 def _install_guided_denoise_teacache_patches() -> None:
-    """Wire TeaCache into Extend and A2V Stage-1 denoise loops.
+    """Wire TeaCache into the Extend and A2V Stage-1 denoise loops.
 
-    `ExtendPipeline` (ltx_pipelines_mlx.extend) and `AudioToVideoPipeline`
-    (ltx_pipelines_mlx.a2vid_two_stage) each `from ...samplers import
-    guided_denoise_loop` into their OWN module namespace and call it without a
-    `teacache=` argument. We must patch the symbol on *those two modules*
-    specifically — patching any other module (e.g. `retake`) leaves the real
-    call site untouched and silently no-ops. We then activate the controller
-    only while the matching runner has a per-call config set.
+    The extend pipeline and `A2VidPipelineTwoStage` (ltx_pipelines_mlx.
+    a2vid_two_stage) each `from ...samplers import guided_denoise_loop` into
+    their OWN module namespace and call it without a `teacache=` argument. We
+    must patch the symbol on *those exact modules* — patching any other module
+    leaves the real call site untouched and silently no-ops. We then activate
+    the controller only while the matching runner has a per-call config set.
+
+    The extend denoise loop lives in different modules across pins: pre-rename
+    pins call it from `ltx_pipelines_mlx.extend`; v0.14.x deletes that module
+    and the extend path runs through `ltx_pipelines_mlx.retake`. We resolve
+    whichever module actually exposes `guided_denoise_loop` (preferring `extend`
+    so pre-rename behavior is unchanged), matching how run_extend resolves
+    ExtendPipeline before RetakePipeline.
     """
     global _EXTEND_TC_PATCH_OK, _A2V_TC_PATCH_OK
     try:
         import ltx_pipelines_mlx.a2vid_two_stage as a2v_mod
-        import ltx_pipelines_mlx.extend as extend_mod
         from ltx_pipelines_mlx.ti2vid_two_stages import (
             _build_teacache_controller as build_stage1_teacache,
         )
     except Exception:
+        return
+
+    extend_mod = _first_module_with_attr(
+        "guided_denoise_loop",
+        "ltx_pipelines_mlx.extend",
+        "ltx_pipelines_mlx.retake",
+    )
+    if extend_mod is None:
         return
 
     original_extend_guided_denoise_loop = extend_mod.guided_denoise_loop
@@ -242,24 +345,49 @@ def parse_args() -> argparse.Namespace:
 
 
 def bind_output_fps(pipe, fps: float) -> None:
-    """Make pipeline generate_and_save() calls decode at the requested FPS."""
-    decode_and_save = pipe._decode_and_save_video
+    """Make pipeline _decode_and_save_video() calls decode at the requested rate.
 
-    def decode_with_fps(video_latent, audio_latent, output_path, fps=fps):
-        return decode_and_save(video_latent, audio_latent, output_path, fps=fps)
+    The output-rate keyword is `frame_rate` on v0.14.x pins and `fps` on
+    pre-rename pins; we bind whichever the live method accepts. We inject the
+    rate only when the caller hasn't already supplied it, so a generate_and_save
+    that threads `frame_rate=` through to the decoder internally isn't
+    double-set.
+    """
+    decode_and_save = pipe._decode_and_save_video
+    rate_name = _rate_kwarg_name(decode_and_save)
+
+    def decode_with_fps(video_latent, audio_latent, output_path, **kwargs):
+        if rate_name and rate_name not in kwargs:
+            kwargs[rate_name] = fps
+        return decode_and_save(video_latent, audio_latent, output_path, **kwargs)
 
     pipe._decode_and_save_video = decode_with_fps
 
 
 def configure_image_strength(image_strength: float | None) -> None:
-    """Thread PortOS' I2V strength into ltx-2-mlx conditioning constructors."""
+    """Thread PortOS' I2V strength into ltx-2-mlx conditioning constructors.
+
+    Pre-rename pins drive first-frame conditioning through a module-level
+    `VideoConditionByLatentIndex` symbol on ti2vid_one_stage that we subclass to
+    inject the requested strength. v0.14.x reworked image conditioning and no
+    longer exposes that hook, so on those pins we surface a clear notice and
+    leave strength at the pipeline default rather than silently pretending the
+    value applied (distinguish "applied" from "couldn't apply").
+    """
     if image_strength is None:
         return
     if image_strength < 0.0 or image_strength > 1.0:
         raise SystemExit("--image-strength must be between 0.0 and 1.0")
 
-    from ltx_core_mlx.conditioning.types.latent_cond import VideoConditionByLatentIndex as BaseCondition
     from ltx_pipelines_mlx import ti2vid_one_stage
+    if not hasattr(ti2vid_one_stage, "VideoConditionByLatentIndex"):
+        emit_status(
+            "--image-strength not supported at this ltx-2-mlx pin "
+            "(reworked image conditioning) — using pipeline default"
+        )
+        return
+
+    from ltx_core_mlx.conditioning.types.latent_cond import VideoConditionByLatentIndex as BaseCondition
 
     class PortOSVideoCondition(BaseCondition):
         def __init__(self, frame_indices, clean_latent, strength=1.0):
@@ -268,15 +396,37 @@ def configure_image_strength(image_strength: float | None) -> None:
     ti2vid_one_stage.VideoConditionByLatentIndex = PortOSVideoCondition
     try:
         from ltx_pipelines_mlx import ti2vid_two_stages
-        ti2vid_two_stages.VideoConditionByLatentIndex = PortOSVideoCondition
+        if hasattr(ti2vid_two_stages, "VideoConditionByLatentIndex"):
+            ti2vid_two_stages.VideoConditionByLatentIndex = PortOSVideoCondition
     except ImportError:
         pass
     emit_status(f"Using image strength {image_strength:g}")
 
 
+def _one_stage_kwargs(args: argparse.Namespace, **extra) -> dict:
+    """Shared generate_and_save kwargs for the one-stage text/image runners.
+
+    Omits num_steps when --steps is unset so each pin applies its own default —
+    the new TI2VidOneStagePipeline types num_steps as a non-optional int and
+    would choke on an explicit None.
+    """
+    kwargs: dict = dict(
+        prompt=args.prompt,
+        output_path=args.output,
+        height=args.height,
+        width=args.width,
+        num_frames=args.num_frames,
+        seed=args.seed,
+        **extra,
+    )
+    if args.steps is not None:
+        kwargs["num_steps"] = args.steps
+    return kwargs
+
+
 def run_two_stage(args: argparse.Namespace, image: str | None = None) -> str:
     """T2V/I2V path that honors CFG via the dgrauet two-stage pipeline."""
-    from ltx_pipelines_mlx import TwoStagePipeline
+    TwoStagePipeline = _resolve_pipeline("TI2VidTwoStagesPipeline", "TwoStagePipeline")
     emit_status(f"Loading two-stage pipeline ({args.model})…")
     emit_stage(1, 0, 1, "Loading model")
     pipe = TwoStagePipeline(
@@ -300,27 +450,23 @@ def run_two_stage(args: argparse.Namespace, image: str | None = None) -> str:
         stage1_steps=args.steps if args.steps is not None else 30,
         stage2_steps=args.stage2_steps,
         cfg_scale=args.cfg_scale if args.cfg_scale is not None else 3.0,
+        **_rate_kwargs(pipe.generate_and_save, args.fps),
     )
 
 
 def run_text(args: argparse.Namespace) -> str:
     if args.cfg_scale is not None:
         return run_two_stage(args)
-    from ltx_pipelines_mlx import TextToVideoPipeline
+    OneStagePipeline = _resolve_pipeline("TI2VidOneStagePipeline", "TextToVideoPipeline")
     emit_status(f"Loading T2V pipeline ({args.model})…")
     emit_stage(1, 0, 1, "Loading model")
-    pipe = TextToVideoPipeline(model_dir=args.model, gemma_model_id=args.gemma)
+    pipe = OneStagePipeline(model_dir=args.model, gemma_model_id=args.gemma)
     bind_output_fps(pipe, args.fps)
     emit_stage(1, 1, 1, "Loaded")
     emit_status("Generating T2V…")
     return pipe.generate_and_save(
-        prompt=args.prompt,
-        output_path=args.output,
-        height=args.height,
-        width=args.width,
-        num_frames=args.num_frames,
-        seed=args.seed,
-        num_steps=args.steps,
+        **_one_stage_kwargs(args),
+        **_rate_kwargs(pipe.generate_and_save, args.fps),
     )
 
 
@@ -330,24 +476,18 @@ def run_image(args: argparse.Namespace) -> str:
         if not args.image:
             raise SystemExit("--image is required for image mode")
         return run_two_stage(args, image=args.image)
-    from ltx_pipelines_mlx import ImageToVideoPipeline
     if not args.image:
         raise SystemExit("--image is required for image mode")
+    OneStagePipeline = _resolve_pipeline("TI2VidOneStagePipeline", "ImageToVideoPipeline")
     emit_status(f"Loading I2V pipeline ({args.model})…")
     emit_stage(1, 0, 1, "Loading model")
-    pipe = ImageToVideoPipeline(model_dir=args.model, gemma_model_id=args.gemma)
+    pipe = OneStagePipeline(model_dir=args.model, gemma_model_id=args.gemma)
     bind_output_fps(pipe, args.fps)
     emit_stage(1, 1, 1, "Loaded")
     emit_status("Generating I2V…")
     return pipe.generate_and_save(
-        prompt=args.prompt,
-        output_path=args.output,
-        image=args.image,
-        height=args.height,
-        width=args.width,
-        num_frames=args.num_frames,
-        seed=args.seed,
-        num_steps=args.steps,
+        **_one_stage_kwargs(args, image=args.image),
+        **_rate_kwargs(pipe.generate_and_save, args.fps),
     )
 
 
@@ -408,7 +548,7 @@ def run_fflf(args: argparse.Namespace) -> str:
         uses this for character continuity, cross-shot anchoring, and
         compositional control.
     """
-    from ltx_pipelines_mlx import KeyframeInterpolationPipeline
+    KeyframeInterpolationPipeline = _resolve_pipeline("KeyframeInterpolationPipeline")
     keyframe_images, keyframe_indices = _resolve_keyframes(args)
     # Keyframe interpolation needs the dev (non-distilled) transformer +
     # the distilled LoRA fused on top for stage 2. Defaults match the file
@@ -436,11 +576,11 @@ def run_fflf(args: argparse.Namespace) -> str:
         height=args.height,
         width=args.width,
         num_frames=args.num_frames,
-        fps=args.fps,
         seed=args.seed,
         stage1_steps=args.steps,
         stage2_steps=args.stage2_steps,
         cfg_scale=args.cfg_scale if args.cfg_scale is not None else 3.0,
+        **_rate_kwargs(pipe.generate_and_save, args.fps),
     )
 
 
@@ -451,8 +591,12 @@ def run_extend(args: argparse.Namespace) -> str:
     free DiT + text encoder before decode (otherwise OOMs at the VAE pass).
     """
     global _EXTEND_TC_CONFIG
-    from ltx_pipelines_mlx import ExtendPipeline
     from ltx_core_mlx.utils.memory import aggressive_cleanup
+    # Pre-rename pins: ExtendPipeline.extend_from_video; v0.14.x folds extend
+    # into RetakePipeline.extend_from_video (and deletes the extend module).
+    ExtendPipeline = _resolve_pipeline(
+        "ExtendPipeline", "RetakePipeline", method="extend_from_video"
+    )
     if not args.extend_from_video:
         raise SystemExit("--extend-from-video is required for extend mode")
     emit_status(f"Loading Extend pipeline ({args.model})…")
@@ -505,7 +649,7 @@ def run_a2v(args: argparse.Namespace) -> str:
     way ImageToVideoPipeline does, so motion + audio sync to a chosen still.
     """
     global _A2V_TC_CONFIG
-    from ltx_pipelines_mlx import AudioToVideoPipeline
+    AudioToVideoPipeline = _resolve_pipeline("A2VidPipelineTwoStage", "AudioToVideoPipeline")
     if not args.audio:
         raise SystemExit("--audio is required for a2v mode")
     emit_status(f"Loading A2V pipeline ({args.model})…")
@@ -527,12 +671,12 @@ def run_a2v(args: argparse.Namespace) -> str:
             height=args.height,
             width=args.width,
             num_frames=args.num_frames,
-            fps=args.fps,
             seed=args.seed,
             stage1_steps=stage1_steps,
             stage2_steps=args.stage2_steps,
             cfg_scale=args.cfg_scale if args.cfg_scale is not None else 3.0,
             audio_start_time=args.audio_start,
+            **_rate_kwargs(pipe.generate_and_save, args.fps),
         )
     finally:
         _A2V_TC_CONFIG = None

--- a/scripts/generate_ltx2.py
+++ b/scripts/generate_ltx2.py
@@ -29,8 +29,8 @@ Pin compatibility — class renames + frame_rate:
   switched the output-rate keyword from `fps` to `frame_rate`. PortOS pins a
   specific commit (see scripts/setup-image-video.sh LTX2_PIN), but installs
   upgrade on their own schedule, so this bridge resolves both the pipeline
-  class (_resolve_pipeline / _resolve_pipeline_with_method) and the rate
-  keyword (_rate_kwargs) from the live API — old and new pins both work.
+  class (_resolve_pipeline) and the rate keyword (_rate_kwargs) from the live
+  API — old and new pins both work.
 
 Output: writes the rendered .mp4 to --output. Emits a final JSON line on
 stdout ({"video_path": "<output>"}) so the Node parent can read the result
@@ -158,6 +158,20 @@ def _rate_kwargs(func, fps: float) -> dict:
     """
     name = _rate_kwarg_name(func)
     return {name: fps} if name else {}
+
+
+def _import_image_conditioning_input():
+    """v0.14.x ImageConditioningInput (per-image strength field), or None on old pins.
+
+    Pre-rename pins have no ltx_pipelines_mlx.utils.args module; image strength
+    there is injected via the legacy VideoConditionByLatentIndex monkey-patch
+    instead (see _image_conditioning_kwargs / _apply_legacy_image_strength).
+    """
+    try:
+        from ltx_pipelines_mlx.utils.args import ImageConditioningInput
+    except ImportError:
+        return None
+    return ImageConditioningInput
 
 
 _EXTEND_TC_CONFIG: dict | None = None
@@ -364,28 +378,19 @@ def bind_output_fps(pipe, fps: float) -> None:
     pipe._decode_and_save_video = decode_with_fps
 
 
-def configure_image_strength(image_strength: float | None) -> None:
-    """Thread PortOS' I2V strength into ltx-2-mlx conditioning constructors.
+def _apply_legacy_image_strength(image_strength: float) -> bool:
+    """Inject I2V strength on pre-rename pins; return True if the hook applied.
 
     Pre-rename pins drive first-frame conditioning through a module-level
-    `VideoConditionByLatentIndex` symbol on ti2vid_one_stage that we subclass to
-    inject the requested strength. v0.14.x reworked image conditioning and no
-    longer exposes that hook, so on those pins we surface a clear notice and
-    leave strength at the pipeline default rather than silently pretending the
-    value applied (distinguish "applied" from "couldn't apply").
+    `VideoConditionByLatentIndex` symbol on ti2vid_one_stage (and ti2vid_two_stages)
+    that we subclass to bake in the strength — replaced wholesale, not appended.
+    v0.14.x reworked image conditioning and no longer exposes that hook (strength
+    is carried by ImageConditioningInput instead — see _image_conditioning_kwargs),
+    so this returns False there and the caller surfaces a clear notice.
     """
-    if image_strength is None:
-        return
-    if image_strength < 0.0 or image_strength > 1.0:
-        raise SystemExit("--image-strength must be between 0.0 and 1.0")
-
     from ltx_pipelines_mlx import ti2vid_one_stage
     if not hasattr(ti2vid_one_stage, "VideoConditionByLatentIndex"):
-        emit_status(
-            "--image-strength not supported at this ltx-2-mlx pin "
-            "(reworked image conditioning) — using pipeline default"
-        )
-        return
+        return False
 
     from ltx_core_mlx.conditioning.types.latent_cond import VideoConditionByLatentIndex as BaseCondition
 
@@ -400,7 +405,52 @@ def configure_image_strength(image_strength: float | None) -> None:
             ti2vid_two_stages.VideoConditionByLatentIndex = PortOSVideoCondition
     except ImportError:
         pass
-    emit_status(f"Using image strength {image_strength:g}")
+    return True
+
+
+def _image_conditioning_kwargs(generate_and_save, image: str | None,
+                               image_strength: float | None) -> dict:
+    """I2V image kwarg(s) for generate_and_save, honoring --image-strength on both pins.
+
+    Returns {} when there's no source image. With no strength override we pass a
+    bare `image=` on every pin — unchanged behavior. With a strength override:
+
+      - v0.14.x carries per-image strength as a first-class field on
+        ImageConditioningInput passed through `images=[...]` (passing
+        `images=[ImageConditioningInput(path, 0, 1.0)]` is exactly what the
+        pipeline builds from a bare `image=` internally, so this only changes
+        the strength); and
+      - pre-rename pins take a bare `image=` and get strength from the legacy
+        VideoConditionByLatentIndex monkey-patch, applied here just before
+        generate reads it. If even that hook is absent we surface a notice and
+        fall back to the pipeline default rather than silently dropping it.
+
+    Pin selection is by the live API: the new path needs both an `images`
+    parameter on generate_and_save AND an importable ImageConditioningInput.
+    """
+    if not image:
+        return {}
+    if image_strength is None:
+        return {"image": image}
+    if image_strength < 0.0 or image_strength > 1.0:
+        raise SystemExit("--image-strength must be between 0.0 and 1.0")
+
+    ImageConditioningInput = _import_image_conditioning_input()
+    if ImageConditioningInput is not None and \
+            "images" in inspect.signature(generate_and_save).parameters:
+        emit_status(f"Using image strength {image_strength:g}")
+        return {"images": [ImageConditioningInput(
+            path=image, frame_idx=0, strength=image_strength,
+        )]}
+
+    if _apply_legacy_image_strength(image_strength):
+        emit_status(f"Using image strength {image_strength:g}")
+    else:
+        emit_status(
+            "--image-strength not supported at this ltx-2-mlx pin "
+            "(reworked image conditioning) — using pipeline default"
+        )
+    return {"image": image}
 
 
 def _one_stage_kwargs(args: argparse.Namespace, **extra) -> dict:
@@ -442,7 +492,6 @@ def run_two_stage(args: argparse.Namespace, image: str | None = None) -> str:
     return pipe.generate_and_save(
         prompt=args.prompt,
         output_path=args.output,
-        image=image,
         height=args.height,
         width=args.width,
         num_frames=args.num_frames,
@@ -450,6 +499,7 @@ def run_two_stage(args: argparse.Namespace, image: str | None = None) -> str:
         stage1_steps=args.steps if args.steps is not None else 30,
         stage2_steps=args.stage2_steps,
         cfg_scale=args.cfg_scale if args.cfg_scale is not None else 3.0,
+        **_image_conditioning_kwargs(pipe.generate_and_save, image, args.image_strength),
         **_rate_kwargs(pipe.generate_and_save, args.fps),
     )
 
@@ -471,13 +521,13 @@ def run_text(args: argparse.Namespace) -> str:
 
 
 def run_image(args: argparse.Namespace) -> str:
-    configure_image_strength(args.image_strength)
-    if args.cfg_scale is not None:
-        if not args.image:
-            raise SystemExit("--image is required for image mode")
-        return run_two_stage(args, image=args.image)
     if not args.image:
         raise SystemExit("--image is required for image mode")
+    # --image-strength is threaded into generate_and_save via
+    # _image_conditioning_kwargs (per-pipe, since the new/old pins carry it
+    # differently); both the two-stage and one-stage paths below pick it up.
+    if args.cfg_scale is not None:
+        return run_two_stage(args, image=args.image)
     OneStagePipeline = _resolve_pipeline("TI2VidOneStagePipeline", "ImageToVideoPipeline")
     emit_status(f"Loading I2V pipeline ({args.model})…")
     emit_stage(1, 0, 1, "Loading model")
@@ -485,8 +535,11 @@ def run_image(args: argparse.Namespace) -> str:
     bind_output_fps(pipe, args.fps)
     emit_stage(1, 1, 1, "Loaded")
     emit_status("Generating I2V…")
+    image_kwargs = _image_conditioning_kwargs(
+        pipe.generate_and_save, args.image, args.image_strength
+    )
     return pipe.generate_and_save(
-        **_one_stage_kwargs(args, image=args.image),
+        **_one_stage_kwargs(args, **image_kwargs),
         **_rate_kwargs(pipe.generate_and_save, args.fps),
     )
 
@@ -592,10 +645,11 @@ def run_extend(args: argparse.Namespace) -> str:
     """
     global _EXTEND_TC_CONFIG
     from ltx_core_mlx.utils.memory import aggressive_cleanup
-    # Pre-rename pins: ExtendPipeline.extend_from_video; v0.14.x folds extend
-    # into RetakePipeline.extend_from_video (and deletes the extend module).
+    # v0.14.x: RetakePipeline.extend_from_video; pre-rename pins: ExtendPipeline.
+    # New name first (the resolver contract) — and on the old pin RetakePipeline
+    # lacks extend_from_video, so method-presence still selects ExtendPipeline.
     ExtendPipeline = _resolve_pipeline(
-        "ExtendPipeline", "RetakePipeline", method="extend_from_video"
+        "RetakePipeline", "ExtendPipeline", method="extend_from_video"
     )
     if not args.extend_from_video:
         raise SystemExit("--extend-from-video is required for extend mode")

--- a/scripts/generate_ltx2_teacache_test.py
+++ b/scripts/generate_ltx2_teacache_test.py
@@ -85,6 +85,156 @@ class GenerateLtx2TeaCacheTest(unittest.TestCase):
             "guided_denoise_loop_with_a2v_teacache",
         )
 
+    def test_resolve_pipeline_prefers_new_name_then_falls_back(self):
+        root = sys.modules["ltx_pipelines_mlx"]
+
+        class NewCls:
+            pass
+
+        class LegacyCls:
+            pass
+
+        root.NewCls = NewCls
+        root.LegacyCls = LegacyCls
+        # New name present → wins over the legacy fallback.
+        self.assertIs(self.helper._resolve_pipeline("NewCls", "LegacyCls"), NewCls)
+        # New name absent → fall back to the legacy name (pre-rename pin).
+        self.assertIs(self.helper._resolve_pipeline("MissingNew", "LegacyCls"), LegacyCls)
+
+    def test_resolve_pipeline_method_presence_skips_class_without_method(self):
+        root = sys.modules["ltx_pipelines_mlx"]
+
+        class NoMethod:
+            pass
+
+        class WithMethod:
+            def extend_from_video(self):
+                pass
+
+        # Both names resolve, but only the second defines the method — the
+        # extend path must pick it (mirrors ExtendPipeline-without-method on a
+        # pin where the method moved to RetakePipeline).
+        root.NoMethod = NoMethod
+        root.WithMethod = WithMethod
+        chosen = self.helper._resolve_pipeline(
+            "NoMethod", "WithMethod", method="extend_from_video"
+        )
+        self.assertIs(chosen, WithMethod)
+
+    def test_resolve_pipeline_raises_when_no_name_resolves(self):
+        with self.assertRaises(SystemExit):
+            self.helper._resolve_pipeline("Nope1", "Nope2")
+
+    def test_rate_kwarg_name_prefers_frame_rate_over_fps(self):
+        def both(a, frame_rate=1, fps=2):
+            pass
+
+        def fps_only(a, fps=2):
+            pass
+
+        def kwargs_only(a, **kwargs):
+            pass
+
+        self.assertEqual(self.helper._rate_kwarg_name(both), "frame_rate")
+        self.assertEqual(self.helper._rate_kwarg_name(fps_only), "fps")
+        # A bare **kwargs must NOT be treated as accepting the rate.
+        self.assertIsNone(self.helper._rate_kwarg_name(kwargs_only))
+        self.assertEqual(self.helper._rate_kwargs(kwargs_only, 24.0), {})
+        self.assertEqual(self.helper._rate_kwargs(fps_only, 24.0), {"fps": 24.0})
+
+    def test_one_stage_kwargs_omits_num_steps_when_steps_unset(self):
+        args = SimpleNamespace(
+            prompt="p", output="o.mp4", height=480, width=704,
+            num_frames=97, seed=42, steps=None,
+        )
+        kwargs = self.helper._one_stage_kwargs(args)
+        self.assertNotIn("num_steps", kwargs)
+        self.assertEqual(kwargs["output_path"], "o.mp4")
+
+        args.steps = 20
+        kwargs = self.helper._one_stage_kwargs(args, image="i.png")
+        self.assertEqual(kwargs["num_steps"], 20)
+        self.assertEqual(kwargs["image"], "i.png")
+
+    def test_image_conditioning_empty_without_image(self):
+        def gen(image=None, images=None):
+            pass
+
+        self.assertEqual(self.helper._image_conditioning_kwargs(gen, None, None), {})
+
+    def test_image_conditioning_bare_image_when_no_strength(self):
+        # No strength override → plain image= on every pin (unchanged behavior).
+        def gen(image=None, images=None):
+            pass
+
+        self.assertEqual(
+            self.helper._image_conditioning_kwargs(gen, "i.png", None),
+            {"image": "i.png"},
+        )
+
+    def test_image_conditioning_validates_strength_range(self):
+        def gen(image=None, images=None):
+            pass
+
+        with self.assertRaises(SystemExit):
+            self.helper._image_conditioning_kwargs(gen, "i.png", 1.5)
+
+    def test_image_conditioning_uses_images_with_strength_on_new_pin(self):
+        # New pin: generate_and_save accepts images= AND ImageConditioningInput
+        # is importable → per-image strength is carried as a field.
+        args_mod = types.ModuleType("ltx_pipelines_mlx.utils.args")
+
+        class FakeImageConditioningInput(tuple):
+            def __new__(cls, path, frame_idx, strength, crf=33):
+                obj = super().__new__(cls, (path, frame_idx, strength, crf))
+                obj.path, obj.frame_idx, obj.strength = path, frame_idx, strength
+                return obj
+
+        args_mod.ImageConditioningInput = FakeImageConditioningInput
+        utils_mod = types.ModuleType("ltx_pipelines_mlx.utils")
+        saved = {
+            name: sys.modules.get(name)
+            for name in ("ltx_pipelines_mlx.utils", "ltx_pipelines_mlx.utils.args")
+        }
+        sys.modules["ltx_pipelines_mlx.utils"] = utils_mod
+        sys.modules["ltx_pipelines_mlx.utils.args"] = args_mod
+        try:
+            def gen(prompt=None, image=None, images=None, frame_rate=None):
+                pass
+
+            out = self.helper._image_conditioning_kwargs(gen, "i.png", 0.4)
+            self.assertIn("images", out)
+            self.assertNotIn("image", out)
+            self.assertEqual(len(out["images"]), 1)
+            ici = out["images"][0]
+            self.assertEqual((ici.path, ici.frame_idx, ici.strength), ("i.png", 0, 0.4))
+        finally:
+            for name, module in saved.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
+
+    def test_image_conditioning_degrades_when_no_images_param_and_no_hook(self):
+        # No images= param AND no legacy VideoConditionByLatentIndex hook →
+        # graceful fallback to bare image= (neither pin's strength mechanism is
+        # available, so we use the default rather than dropping it silently).
+        one_stage = types.ModuleType("ltx_pipelines_mlx.ti2vid_one_stage")
+        saved = sys.modules.get("ltx_pipelines_mlx.ti2vid_one_stage")
+        sys.modules["ltx_pipelines_mlx.ti2vid_one_stage"] = one_stage
+        sys.modules["ltx_pipelines_mlx"].ti2vid_one_stage = one_stage
+        try:
+            def gen(image=None):
+                pass
+
+            out = self.helper._image_conditioning_kwargs(gen, "i.png", 0.4)
+            self.assertEqual(out, {"image": "i.png"})
+        finally:
+            if saved is None:
+                sys.modules.pop("ltx_pipelines_mlx.ti2vid_one_stage", None)
+            else:
+                sys.modules["ltx_pipelines_mlx.ti2vid_one_stage"] = saved
+
     def test_extend_patch_builds_stage1_teacache_from_sigmas(self):
         self.helper._EXTEND_TC_CONFIG = self.helper._teacache_config(True, True, 30)
 
@@ -173,6 +323,81 @@ class GenerateLtx2TeaCacheTest(unittest.TestCase):
                     sys.modules.pop(name, None)
                 else:
                     sys.modules[name] = module
+
+
+class GenerateLtx2NewPinTeaCacheTest(unittest.TestCase):
+    """v0.14.x deletes the `extend` module and runs extend through `retake`.
+
+    The TeaCache patch must follow the guided_denoise_loop call site to the
+    retake module via _first_module_with_attr — otherwise TeaCache silently
+    no-ops on the new pin. This fakes the new-pin module shape (no `extend`,
+    `retake` carries the loop) and asserts the patch lands on retake.
+    """
+
+    def setUp(self):
+        self.module_name = "generate_ltx2_newpin_under_test"
+        self.original_modules = {
+            name: sys.modules.get(name)
+            for name in [
+                self.module_name,
+                "ltx_pipelines_mlx",
+                "ltx_pipelines_mlx.extend",
+                "ltx_pipelines_mlx.retake",
+                "ltx_pipelines_mlx.a2vid_two_stage",
+                "ltx_pipelines_mlx.ti2vid_two_stages",
+            ]
+        }
+        for name in self.original_modules:
+            sys.modules.pop(name, None)
+
+        root = types.ModuleType("ltx_pipelines_mlx")
+        root.__path__ = []
+        retake = types.ModuleType("ltx_pipelines_mlx.retake")
+        a2v = types.ModuleType("ltx_pipelines_mlx.a2vid_two_stage")
+        two_stages = types.ModuleType("ltx_pipelines_mlx.ti2vid_two_stages")
+
+        def retake_loop(*args, teacache=None, **kwargs):
+            return {"caller": "retake", "teacache": teacache, "kwargs": kwargs}
+
+        def a2v_loop(*args, teacache=None, **kwargs):
+            return {"caller": "a2v", "teacache": teacache, "kwargs": kwargs}
+
+        retake.guided_denoise_loop = retake_loop
+        a2v.guided_denoise_loop = a2v_loop
+        two_stages._build_teacache_controller = lambda num_steps, thresh: {
+            "num_steps": num_steps, "thresh": thresh,
+        }
+
+        sys.modules["ltx_pipelines_mlx"] = root
+        # No ltx_pipelines_mlx.extend — exactly as v0.14.x ships.
+        sys.modules["ltx_pipelines_mlx.retake"] = retake
+        sys.modules["ltx_pipelines_mlx.a2vid_two_stage"] = a2v
+        sys.modules["ltx_pipelines_mlx.ti2vid_two_stages"] = two_stages
+        self.retake = retake
+        self.a2v = a2v
+
+        spec = importlib.util.spec_from_file_location(self.module_name, HELPER_PATH)
+        self.helper = importlib.util.module_from_spec(spec)
+        sys.modules[self.module_name] = self.helper
+        spec.loader.exec_module(self.helper)
+
+    def tearDown(self):
+        for name, module in self.original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+    def test_patch_follows_extend_loop_to_retake_when_extend_module_gone(self):
+        self.assertTrue(self.helper._EXTEND_TC_PATCH_OK)
+        self.assertEqual(
+            self.retake.guided_denoise_loop.__name__,
+            "guided_denoise_loop_with_extend_teacache",
+        )
+        self.assertEqual(
+            self.a2v.guided_denoise_loop.__name__,
+            "guided_denoise_loop_with_a2v_teacache",
+        )
 
 
 if __name__ == "__main__":

--- a/scripts/setup-image-video.sh
+++ b/scripts/setup-image-video.sh
@@ -150,10 +150,15 @@ if [[ "$INSTALL_LTX2" == "1" ]]; then
     echo "❌ INSTALL_LTX2=1 requires git." >&2
     exit 1
   fi
-  # Pinned to a known-good commit (2026-05-05). To upgrade: bump this SHA
-  # and verify with PortOS's video gen smoke tests. Set LTX2_PIN=main to
-  # bypass the pin and track upstream HEAD for development.
-  LTX2_PIN="${LTX2_PIN:-f8f20c83ab7e2e929f3196f07ec5232ad1660bab}"
+  # Pinned to v0.14.8 (2026-05-22). To upgrade: bump this SHA and verify with
+  # PortOS's video gen smoke tests (text/image/fflf/extend/a2v). Set
+  # LTX2_PIN=main to bypass the pin and track upstream HEAD for development.
+  # NOTE: v0.14.x renamed every public pipeline class (TextToVideoPipeline →
+  # TI2VidOneStagePipeline, ExtendPipeline → RetakePipeline, etc.) and switched
+  # the output-rate kwarg from `fps` to `frame_rate`. generate_ltx2.py resolves
+  # pipeline classes and the rate kwarg defensively so it works against this pin
+  # AND older pre-rename pins an install may still have checked out.
+  LTX2_PIN="${LTX2_PIN:-d2ad8e9948157c14a063aca54e510d3d80c2c463}"
   LTX2_DIR="${HOME}/.portos/ltx-2-mlx"
   LTX2_PY="${LTX2_DIR}/.venv/bin/python3"
   mkdir -p "${HOME}/.portos"


### PR DESCRIPTION
## Summary

Bumps the bundled LTX-2 (Apple Silicon) video runtime pin from `f8f20c83` to **v0.14.8** (`d2ad8e99`) and adapts the `scripts/generate_ltx2.py` bridge to v0.14.x's renamed pipeline classes and `fps`→`frame_rate` kwarg change. The adaptation is **defensive on both pins** so it keeps working against the pre-rename pin an install may still have checked out until it re-runs `setup-image-video.sh` (per the distribution model — installs upgrade on their own schedule).

What changed upstream in v0.14.x (verified against the tagged source, not just the issue text):
- Every public pipeline class was renamed: `TextToVideoPipeline`/`ImageToVideoPipeline` → `TI2VidOneStagePipeline`, `TwoStagePipeline` → `TI2VidTwoStagesPipeline`, `ExtendPipeline` → `RetakePipeline`, `AudioToVideoPipeline` → `A2VidPipelineTwoStage` (`KeyframeInterpolationPipeline` kept its name).
- The `extend` module was deleted; `extend_from_video` now lives on `RetakePipeline`.
- The output-rate keyword changed from `fps` to `frame_rate` across `generate_and_save` / `_decode_and_save_video`, and one-stage `generate_and_save` made `frame_rate` a required keyword-only arg.
- Image conditioning was reworked: the `VideoConditionByLatentIndex` hook the bridge monkey-patched for `--image-strength` is gone, but per-image strength is now a first-class field on `ImageConditioningInput` passed via `images=[...]`.

How the bridge adapts:
- `_resolve_pipeline(*names, method=None)` — picks the first available class, new name preferred, legacy name as fallback (and optionally requires a method, for the extend path).
- `_rate_kwargs()` — inspects the live signature and passes `frame_rate=` or `fps=` accordingly; `bind_output_fps` does the same at the decoder level and only injects when absent (no double-set).
- `_first_module_with_attr()` — follows the TeaCache `guided_denoise_loop` patch from the deleted `extend` module to `retake`, so TeaCache on extend/a2v doesn't silently no-op on the new pin.
- `_image_conditioning_kwargs()` — keeps `--image-strength` working on **both** pins: `images=[ImageConditioningInput(path, 0, strength)]` on v0.14.x, the legacy `VideoConditionByLatentIndex` monkey-patch on pre-rename pins. With no `--image-strength` override both pins pass a bare `image=` (unchanged behavior).
- One-stage runners omit `num_steps` when `--steps` is unset (new pin types it non-optional).

## Review

`/simplify` + a `claude` sub-agent review + a `codex` CLI review all ran. Codex caught that `--image-strength` would silently no-op on the new pin; rather than degrade it (and defer to a follow-up), this PR restores it via the new `ImageConditioningInput` field — so the follow-up I'd filed (#948) is superseded and closed. The extend resolver was flipped to new-name-first for contract consistency (behavior-identical on the old pin). Stale docstring/comment references fixed.

## Test plan

- [x] `py_compile` of `generate_ltx2.py` + test file (venv Python 3.11) and `bash -n` of `setup-image-video.sh`.
- [x] **Unit suite (18 tests)**: TeaCache patch wiring on both the legacy `extend` module and the new-pin `retake` fallback; resolver new-name/legacy-fallback + method-presence; rate-kwarg detection (frame_rate/fps/none-for-bare-kwargs); one-stage num_steps omission; image-conditioning (new-pin `images=` with strength, old-pin bare `image=`, range validation, graceful degradation).
- [x] **Backward-compat import test against the currently-installed old pin** (`f8f20c83`): module imports, every runner's `_resolve_pipeline(...)` falls back to the legacy class, `_first_module_with_attr` resolves to the `extend` module, the rate kwarg is detected as `fps`, both TeaCache patches activate, and `--image-strength` applies the legacy patch + passes `image=`.
- [ ] **Five-mode GPU smoke test on Apple Silicon after re-pinning** (`INSTALL_LTX2=1 bash scripts/setup-image-video.sh`): text, image, keyframe (fflf), extend, and audio-to-video — plus an I2V render at a non-default `--image-strength` to confirm the new `images=` path visibly affects conditioning. This requires the GPU box + models and could not run in CI/headless. Note the one-stage text/image path now uses the dev transformer (`transformer-dev.safetensors`, already shipped by the dgrauet q4/q8 repos).

Closes #739.