### PR TITLE
feat([issue-907]): upgrade client to Vite 8

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -31,6 +31,7 @@
 - **Internal: restored a green lint build** — Added the standard DOM element globals the client lint config was missing, so the build's lint check passes again. No user-facing change.
 - **[issue-739] LTX-2 video runtime updated to v0.14.8** — Bumped the bundled LTX-2 (Apple Silicon) video generator to a newer upstream release with better memory behavior on HD and long renders and a fix that stops character LoRAs from silently dropping on Extend and high-quality modes. All five render modes (text, image, keyframe, extend, audio-to-video) keep working across the upgrade, and the previous version stays supported until an install re-runs its image/video setup.
 - **[issue-907] Internal: upgraded the server validation library to Zod 4** — Migrated the server's request-validation layer to the Zod 4 major release, preserving the exact accept/reject behavior of every existing rule (including a fix so partial-update saves no longer risk silently resetting fields you didn't touch). No user-facing change.
+- **[issue-907] Internal: upgraded the web build tooling to Vite 8** — Moved the client to the Vite 8 major release (and its new Rust-based bundler) for faster builds. The app builds, runs, and tests identically. No user-facing change.
 
 ## Fixed
 

--- a/client/package.json
+++ b/client/package.json
@@ -35,14 +35,14 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "16.3.2",
     "@testing-library/user-event": "14.6.1",
-    "@vitejs/plugin-react": "5.1.4",
+    "@vitejs/plugin-react": "6.0.2",
     "eslint": "9.23.0",
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "5.2.0",
     "jsdom": "25.0.1",
     "rollup-plugin-visualizer": "6.0.11",
     "tailwindcss": "4.2.1",
-    "vite": "7.3.2",
+    "vite": "8.0.16",
     "vitest": "4.1.8"
   },
   "overrides": {

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -75,15 +75,29 @@ export default defineConfig(({ mode }) => {
     build: {
       rollupOptions: {
         output: {
-          manualChunks: {
+          // Vite 8's rolldown bundler requires manualChunks to be a function;
+          // the object-map form Rollup accepted is no longer supported. Match
+          // each module id against the vendor package's node_modules path to
+          // produce the same vendor chunks as before.
+          manualChunks(id) {
+            if (!id.includes('node_modules')) return undefined;
             // Core React dependencies
-            'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+            if (/[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom)[\\/]/.test(id)) {
+              return 'vendor-react';
+            }
             // Socket dependencies
-            'vendor-realtime': ['socket.io-client'],
+            if (/[\\/]node_modules[\\/]socket\.io-client[\\/]/.test(id)) {
+              return 'vendor-realtime';
+            }
             // Drag and drop library (only used in CoS)
-            'vendor-dnd': ['@dnd-kit/core', '@dnd-kit/sortable', '@dnd-kit/utilities'],
+            if (/[\\/]node_modules[\\/]@dnd-kit[\\/]/.test(id)) {
+              return 'vendor-dnd';
+            }
             // Icon library (largest dependency)
-            'vendor-icons': ['lucide-react']
+            if (/[\\/]node_modules[\\/]lucide-react[\\/]/.test(id)) {
+              return 'vendor-icons';
+            }
+            return undefined;
           }
         }
       },


### PR DESCRIPTION
Part 2 of 2 for #907 (Zod 4 + Vite 8 major bumps, split per the issue's "each major bump wants its own focused PR"). Part 1 (Zod 4, server) shipped in #947; this PR does **Vite 7 → 8** on the client.

Closes #907.

## What changed
Bumps `client` `vite` `7.3.2` → `8.0.16` and `@vitejs/plugin-react` `5.1.4` → `6.0.2` (the plugin's peer requirement for Vite 8).

**One breaking change touched our config.** Vite 8 ships the Rust-based **rolldown** bundler, which requires `build.rollupOptions.output.manualChunks` to be a **function** — the object-map form (`{ 'vendor-react': ['react', ...] }`) Rollup accepted is no longer supported and fails the build with `manualChunks is not a function`. Rewrote it as an id-matching function that maps each `node_modules` package to the same vendor chunk as before (`vendor-react`, `vendor-realtime`, `vendor-dnd`, `vendor-icons`). No other config change was needed — the proxy, `strictPort`, `define`, and plugin setup are untouched.

## Testing
- **Production build** (`npm run build`) succeeds with the identical four vendor chunks.
- **Dev server** boots (~75ms) and serves the app with React Fast Refresh wired correctly (HTTP 200, HTML with `/@react-refresh`).
- **`ANALYZE=true` build** — the `rollup-plugin-visualizer` plugin still runs under rolldown and emits `dist/bundle-report.html`.
- **Lint** is clean (0 errors; pre-existing warnings unchanged).
- **All 1,580 client tests pass** (vitest 4.1.8 already supports Vite 8 — no vitest bump needed).
- `strictPort` still fails loudly on a taken port (verified — the existing dev server on 5554 correctly blocked a second bind).

Note: `client/package-lock.json` is gitignored in this repo (only `client/package.json` is tracked), so versions are pinned exactly in `package.json` per the repo convention.

With this merged, both major bumps deferred in #907 (Zod 4 + Vite 8) are done.