### PR TITLE
fix: store Flux-dev transformer as fp8 to fit the 3090's VRAM

### DIFF
--- a/scripts/imagine_win.py
+++ b/scripts/imagine_win.py
@@ -116,7 +116,8 @@ def build_pipeline(flux_key, hf_cache, dtype):
     # the desktop/browser baseline (~5GB) plus activations are accounted for, so
     # the driver spills to shared system RAM and each diffusion step takes
     # minutes — long enough to trip the media-job idle watchdog (300s). Layerwise
-    # casting keeps the weights stored as fp8 (~12GB) and upcasts each layer to
+    # casting keeps the weights stored as fp8 (~15GB resident — fp8 weight bytes
+    # plus the norm/embedding modules that stay bf16) and upcasts each layer to
     # bf16 only during its forward pass, so the model fits in VRAM while compute
     # stays bf16. (Ampere/3090 has no fp8 tensor cores, so we must NOT compute in
     # fp8 — storage-only casting is the correct strategy here.) Set

--- a/scripts/imagine_win.py
+++ b/scripts/imagine_win.py
@@ -110,7 +110,23 @@ def build_pipeline(flux_key, hf_cache, dtype):
     log(f'STATUS:Loading Flux transformer ({flux_key})...')
     transformer = FluxTransformer2DModel.from_single_file(
         FLUX_FILES[flux_key], torch_dtype=dtype
-    ).to('cuda')
+    )
+    # The flux1-*-fp8 checkpoints are fp8 on disk, but from_single_file upcasts
+    # them to the bf16 compute dtype (~23GB). On a 24GB card that overflows once
+    # the desktop/browser baseline (~5GB) plus activations are accounted for, so
+    # the driver spills to shared system RAM and each diffusion step takes
+    # minutes — long enough to trip the media-job idle watchdog (300s). Layerwise
+    # casting keeps the weights stored as fp8 (~12GB) and upcasts each layer to
+    # bf16 only during its forward pass, so the model fits in VRAM while compute
+    # stays bf16. (Ampere/3090 has no fp8 tensor cores, so we must NOT compute in
+    # fp8 — storage-only casting is the correct strategy here.) Set
+    # IMAGINE_WIN_FP8=0 (or false/never) to fall back to the old full-bf16 load.
+    if os.environ.get('IMAGINE_WIN_FP8', '1').strip().lower() not in ('0', 'false', 'never'):
+        transformer.enable_layerwise_casting(
+            storage_dtype=torch.float8_e4m3fn, compute_dtype=dtype
+        )
+        log('STATUS:Transformer weights stored as fp8 (bf16 compute)...')
+    transformer = transformer.to('cuda')
 
     log('STATUS:Assembling pipeline...')
     pipe = FluxPipeline(


### PR DESCRIPTION
## Problem

Local Flux-dev/schnell image generation (the legacy Windows `imagine_win.py` runner) was getting killed mid-render:

```
⏱️ media-job [94237fcc] watchdog fired after 321750ms idle (limit 300000ms) — marking failed
❌ Image generation failed [94237fcc]: Killed by signal SIGTERM
```

**Root cause:** `imagine_win.py` loaded the `flux1-*-fp8.safetensors` checkpoint with `torch_dtype=bfloat16`, **upcasting the fp8 weights to ~23 GB**. On the 24 GB RTX 3090 — with ~5 GB already consumed by the Windows desktop/browsers — that overflows VRAM, the driver silently spills to shared system RAM, and each diffusion step balloons from ~1.6 s to **322 s**. The media-job idle watchdog (300 s, `server/services/mediaJobQueue/index.js`) then correctly SIGTERMs the job as hung. The watchdog was the messenger, not the bug.

## Fix

Keep the transformer **stored as fp8** and upcast per-layer to bf16 during the forward pass via `transformer.enable_layerwise_casting(storage_dtype=float8_e4m3fn, compute_dtype=bf16)`.

Ampere (3090, sm_86) has **no fp8 tensor cores** (those start at Ada sm_89), so we store in fp8 but *compute* in bf16 — the correct strategy here, and a better fit than the `enable_model_cpu_offload()` the sibling runners use (which would page the model in/out and run slower). Opt out with `IMAGINE_WIN_FP8=0` (or `false`/`never`).

## Verification

Ran real generations through the configured interpreter (`miniconda3` python, torch 2.7.1+cu118):

| Metric | Before (bf16) | After (fp8 storage) |
|---|---|---|
| Resident transformer | ~23 GB | **15.2 GB** (measured) |
| Per diffusion step | **322 s** (spilled) | **1.6 s** |
| Outcome | watchdog SIGTERM | completes, valid 1024×1024 PNG |

All silent load gaps stay ≤71 s and every step emits a progress line, so the idle watchdog can no longer fire. Image quality is unaffected (fp8-storage / bf16-compute is the established ComfyUI-default technique).

> Note: at 15 GB resident + ~5 GB desktop baseline, 1024×1024 dev is still *borderline* — step time can vary 1.6 s–34 s under activation pressure, but it always completes now. Closing Chrome/Edge frees the headroom for consistently fast renders.

## Scope

One self-contained legacy script (`scripts/imagine_win.py`). `/simplify` confirmed reuse/altitude are correctly scoped (no shared fp8 helper exists; fp8-storage is the right technique vs the siblings' cpu-offload) and aligned the env-flag parsing with the codebase convention (`_runner_common.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)