### PR TITLE
fix([issue-968]): distinguish failed PM2 read from empty process list in app status

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -2,4 +2,4 @@
 
 ## Fixed
 
-- **[issue-968] A PM2 hiccup no longer makes running apps look offline** — when PortOS briefly can't read process state, affected apps now show as "status unavailable" instead of being silently reported as stopped, and the system health page flags the degraded read rather than quietly counting those apps as never started.
+- **[issue-968] A PM2 hiccup no longer makes running apps look offline** — when PortOS briefly can't read process state, affected apps now show "status unavailable" instead of being silently reported as stopped. The Apps list and detail pages replace the (misleading) Start button with a refresh-to-retry control, the dashboard counts these separately, the system health page flags the degraded read, and CyberCity no longer rains on apps whose status simply couldn't be read.

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased Changes
+
+## Fixed
+
+- **[issue-968] A PM2 hiccup no longer makes running apps look offline** — when PortOS briefly can't read process state, affected apps now show as "status unavailable" instead of being silently reported as stopped, and the system health page flags the degraded read rather than quietly counting those apps as never started.

--- a/client/src/components/AppTile.jsx
+++ b/client/src/components/AppTile.jsx
@@ -30,6 +30,8 @@ const AppTile = memo(function AppTile({ app, onUpdate }) {
   };
 
   const isOnline = app.overallStatus === 'online';
+  // PM2 read failed — status is genuinely unknown, so don't offer Start/Stop.
+  const isDegraded = app.degraded || app.overallStatus === 'unknown';
 
   return (
     <article className={`border rounded-lg p-3 transition-colors ${
@@ -95,7 +97,18 @@ const AppTile = memo(function AppTile({ app, onUpdate }) {
           </a>
         )}
 
-        {!isOnline && (
+        {!isOnline && isDegraded && (
+          <button
+            onClick={() => onUpdate?.()}
+            className="px-2.5 py-1 text-xs rounded bg-port-warning hover:bg-port-warning/80 text-white transition-colors"
+            aria-label={`${app.name} status unavailable — refresh`}
+            title="PM2 status could not be read — refresh to retry"
+          >
+            Status unavailable
+          </button>
+        )}
+
+        {!isOnline && !isDegraded && (
           <button
             onClick={() => handleAction('start')}
             disabled={loading === 'start'}

--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Play, Square, RotateCcw, ExternalLink, Hammer } from 'lucide-react';
+import { ArrowLeft, Play, Square, RotateCcw, ExternalLink, Hammer, RefreshCw } from 'lucide-react';
 import DeployPanel from './DeployPanel';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
@@ -203,6 +203,18 @@ export default function AppDetailView() {
                     <span className="text-xs">{actionLoading === 'restart' ? 'Restarting...' : 'Restart'}</span>
                   </button>
                 </>
+              ) : (app.degraded || app.overallStatus === 'unknown') ? (
+                // PM2 read failed — don't offer a misleading Start; surface the
+                // gap and let the user re-check. Mirrors the Apps list page.
+                <button
+                  onClick={fetchApp}
+                  disabled={actionLoading}
+                  className="px-2 py-1 bg-port-warning/20 text-port-warning enabled:hover:bg-port-warning/30 transition-colors disabled:opacity-50 flex items-center gap-1"
+                  title="PM2 status could not be read — refresh to retry"
+                >
+                  <RefreshCw size={14} />
+                  <span className="text-xs">Status unavailable</span>
+                </button>
               ) : (
                 <button
                   onClick={handleStart}

--- a/client/src/components/apps/tabs/OverviewTab.jsx
+++ b/client/src/components/apps/tabs/OverviewTab.jsx
@@ -201,7 +201,8 @@ export default function OverviewTab({ app, onRefresh }) {
                 >
                   <span className={`w-2 h-2 rounded-full shrink-0 ${
                     proc.status === 'online' ? 'bg-port-success' :
-                    proc.status === 'stopped' ? 'bg-gray-500' : 'bg-port-error'
+                    proc.status === 'stopped' ? 'bg-gray-500' :
+                    proc.status === 'unknown' ? 'bg-port-warning' : 'bg-port-error'
                   }`} />
                   <span className="text-sm text-white font-mono">{proc.name}</span>
                   {processConfig?.ports && Object.keys(processConfig.ports).length > 0 && (

--- a/client/src/components/city/CityScene.jsx
+++ b/client/src/components/city/CityScene.jsx
@@ -105,7 +105,10 @@ export default function CityScene({ apps, agentMap, onBuildingClick, cosStatus, 
     setTransitioning(false);
   }, []);
 
-  const stoppedCount = apps.filter(a => !a.archived && a.overallStatus !== 'online').length;
+  // Weather reflects confirmed outages. A PM2-unavailable ('unknown') app's
+  // status is simply unknown, not down — excluded so a read blip doesn't
+  // conjure rain/lightning over apps that may well be online.
+  const stoppedCount = apps.filter(a => !a.archived && a.overallStatus !== 'online' && a.overallStatus !== 'unknown').length;
   const totalCount = apps.filter(a => !a.archived).length;
 
   // Quality presets always express dpr as a [min, max] pair. Cap it to the live

--- a/client/src/components/city/HolographicPanel.jsx
+++ b/client/src/components/city/HolographicPanel.jsx
@@ -5,6 +5,7 @@ const STATUS_ICONS = {
   stopped: '\u25A0',
   not_started: '\u25CB',
   not_found: '\u25CB',
+  unknown: '\u25CB',
 };
 
 export default function HolographicPanel({ app, agentCount, position, expanded = false }) {
@@ -13,6 +14,8 @@ export default function HolographicPanel({ app, agentCount, position, expanded =
     stopped: 'border-red-500/50 text-red-400',
     not_started: 'border-violet-500/50 text-violet-400',
     not_found: 'border-violet-500/50 text-violet-400',
+    // PM2 read failed \u2014 gray, matching the city building, distinct from violet.
+    unknown: 'border-gray-400/50 text-gray-400',
   };
 
   const statusDotColors = {
@@ -20,6 +23,7 @@ export default function HolographicPanel({ app, agentCount, position, expanded =
     stopped: 'text-red-400',
     not_started: 'text-violet-400',
     not_found: 'text-violet-400',
+    unknown: 'text-gray-400',
   };
 
   const colorClass = app.archived

--- a/client/src/components/city/cityConstants.js
+++ b/client/src/components/city/cityConstants.js
@@ -12,6 +12,9 @@ export const CITY_COLORS = {
     stopped: '#ef4444',
     not_started: '#8b5cf6',
     not_found: '#8b5cf6',
+    // PM2 read failed — status unavailable. A muted amber-gray so it reads as
+    // "unknown," distinct from the purple "never launched" buildings.
+    unknown: '#9ca3af',
     archived: '#64748b',
   },
   buildingBody: '#0c0c24',
@@ -149,6 +152,7 @@ export const BUILDING_PARAMS = {
     stopped: 2.5,
     not_started: 1.5,
     not_found: 1.5,
+    unknown: 1.5,
     archived: 2.0,
   },
   processHeightBonus: 0.8,

--- a/client/src/components/dashboard/builtins/QuickStatsWidget.jsx
+++ b/client/src/components/dashboard/builtins/QuickStatsWidget.jsx
@@ -8,6 +8,10 @@ export default function QuickStatsWidget({ dashboardState }) {
         <StatCard label="Online" value={appStats.online} icon="🟢" />
         <StatCard label="Stopped" value={appStats.stopped} icon="🟡" />
         <StatCard label="Offline" value={appStats.notStarted} icon="⚪" />
+        {/* Only when a PM2 read failed — status unavailable, not confidently offline. */}
+        {appStats.unknown > 0 && (
+          <StatCard label="Status N/A" value={appStats.unknown} icon="⚠️" />
+        )}
       </div>
     </div>
   );

--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -289,6 +289,20 @@ export default function Apps() {
                             <span className="text-xs">{actionLoading[app.id] === 'restart' ? 'Restarting...' : 'Restart'}</span>
                           </button>
                         </>
+                      ) : (app.degraded || app.overallStatus === 'unknown') ? (
+                        // PM2 read failed — status is genuinely unknown, so don't
+                        // offer a misleading Start. Surface "Status unavailable"
+                        // and let the user re-check rather than act on bad info.
+                        <button
+                          onClick={() => fetchApps()}
+                          disabled={actionLoading[app.id]}
+                          className="px-3 py-1.5 bg-port-warning/20 text-port-warning enabled:hover:bg-port-warning/30 transition-colors disabled:opacity-50 flex items-center gap-1 focus:outline-hidden focus:ring-2 focus:ring-port-warning"
+                          aria-label={`${app.name} status unavailable — refresh`}
+                          title="PM2 status could not be read — refresh to retry"
+                        >
+                          <RefreshCw size={14} aria-hidden="true" />
+                          <span className="text-xs">Status unavailable</span>
+                        </button>
                       ) : (
                         <button
                           onClick={() => handleStart(app)}

--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -447,7 +447,8 @@ export default function Apps() {
                               >
                                 <span className={`w-2 h-2 rounded-full shrink-0 ${
                                   proc.status === 'online' ? 'bg-port-success' :
-                                  proc.status === 'stopped' ? 'bg-gray-500' : 'bg-port-error'
+                                  proc.status === 'stopped' ? 'bg-gray-500' :
+                                  proc.status === 'unknown' ? 'bg-port-warning' : 'bg-port-error'
                                 }`} />
                                 <span className="text-sm text-white font-mono">{proc.name}</span>
                                 {processConfig?.ports && Object.keys(processConfig.ports).length > 0 && (

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -156,6 +156,9 @@ export default function Dashboard() {
     online: activeApps.filter((a) => a.overallStatus === 'online').length,
     stopped: activeApps.filter((a) => a.overallStatus === 'stopped').length,
     notStarted: activeApps.filter((a) => a.overallStatus === 'not_started' || a.overallStatus === 'not_found').length,
+    // PM2 read failed for these — status unavailable, NOT confidently stopped.
+    // Counted so the buckets sum to `total` instead of silently dropping them.
+    unknown: activeApps.filter((a) => a.degraded || a.overallStatus === 'unknown').length,
   }), [activeApps]);
 
   const dashboardState = useMemo(

--- a/server/lib/capabilityMap.js
+++ b/server/lib/capabilityMap.js
@@ -234,13 +234,18 @@ export function appsRow(summary = {}) {
   // setup gap this page exists to surface, so it degrades the row too. unmanaged
   // (Xcode/native projects with no runtime state) is intentionally NOT counted.
   const notStarted = Number(summary?.notStarted) || 0;
+  // unknown = PM2 home read failed — runtime status unavailable, NOT a confident
+  // "not running." Surfaced separately so a transient PM2 blip reads as
+  // "status unavailable" rather than inflating the not-started/stopped count.
+  const unknown = Number(summary?.unknown) || 0;
   return row('apps', 'Apps & Processes', '/apps', {
-    status: stopped > 0 || notStarted > 0 ? WARN : OK,
+    status: stopped > 0 || notStarted > 0 || unknown > 0 ? WARN : OK,
     configured: true,
     summary: `${total} ${plural(total, 'app')} · ${online} online`
       + (stopped > 0 ? ` · ${stopped} stopped` : '')
-      + (notStarted > 0 ? ` · ${notStarted} not started` : ''),
-    detail: { total, online, stopped, notStarted, unmanaged },
+      + (notStarted > 0 ? ` · ${notStarted} not started` : '')
+      + (unknown > 0 ? ` · ${unknown} status unavailable` : ''),
+    detail: { total, online, stopped, notStarted, unknown, degraded: unknown > 0, unmanaged },
   });
 }
 

--- a/server/lib/capabilityMap.test.js
+++ b/server/lib/capabilityMap.test.js
@@ -166,6 +166,14 @@ describe('appsRow', () => {
     expect(r.detail.notStarted).toBe(3);
   });
 
+  it('warns and reports "status unavailable" when PM2 read degraded the summary', () => {
+    const r = appsRow({ total: 3, online: 2, stopped: 0, notStarted: 0, unknown: 1, degraded: true });
+    expect(r.status).toBe(WARN);
+    expect(r.summary).toContain('1 status unavailable');
+    expect(r.detail.unknown).toBe(1);
+    expect(r.detail.degraded).toBe(true);
+  });
+
   it('reports native-only (unmanaged) apps as present, not "No apps"', () => {
     // getAppStatusSummary().total excludes unmanaged native/Xcode apps.
     const r = appsRow({ total: 0, online: 0, unmanaged: 2 });

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -67,11 +67,21 @@ router.get('/', asyncHandler(async (req, res) => {
     pm2HomeGroups.get(home).push(app);
   }
 
-  // Fetch PM2 processes for each unique PM2_HOME
+  // Fetch PM2 processes for each unique PM2_HOME.
+  // A thrown listProcesses is a failed read, not an empty list — track those
+  // homes so we report `unknown` (status unavailable) instead of `not_started`
+  // (confidently not running) for their apps. See getAppStatuses() in the
+  // service for the same absent-vs-empty distinction.
   const pm2Maps = new Map();
+  const failedHomes = new Set();
   for (const pm2Home of pm2HomeGroups.keys()) {
-    const processes = await pm2Service.listProcesses(pm2Home).catch(() => []);
-    pm2Maps.set(pm2Home, new Map(processes.map(p => [p.name, p])));
+    const processes = await pm2Service.listProcesses(pm2Home).catch(() => null);
+    if (processes === null) {
+      failedHomes.add(pm2Home);
+      pm2Maps.set(pm2Home, new Map());
+    } else {
+      pm2Maps.set(pm2Home, new Map(processes.map(p => [p.name, p])));
+    }
   }
 
   // Enrich with PM2 status and auto-populate processes if needed
@@ -83,17 +93,24 @@ router.get('/', asyncHandler(async (req, res) => {
 
     const pm2Home = app.pm2Home || null;
     const pm2Map = pm2Maps.get(pm2Home) || new Map();
+    const homeFailed = failedHomes.has(pm2Home);
 
     const statuses = {};
     for (const processName of app.pm2ProcessNames || []) {
       const pm2Proc = pm2Map.get(processName);
-      statuses[processName] = pm2Proc ?? { name: processName, status: 'not_found', pm2_env: null };
+      // A failed PM2 read leaves status genuinely unknown — don't claim
+      // `not_found` (which the UI reads as "registered but never launched").
+      statuses[processName] = pm2Proc
+        ?? { name: processName, status: homeFailed ? 'unknown' : 'not_found', pm2_env: null };
     }
 
-    // Compute overall status
+    // Compute overall status. A failed PM2 home short-circuits to `unknown`
+    // with a `degraded` flag rather than collapsing to `not_started`.
     const statusValues = Object.values(statuses);
     let overallStatus = 'unknown';
-    if (statusValues.some(s => s.status === 'online')) {
+    if (homeFailed) {
+      overallStatus = 'unknown';
+    } else if (statusValues.some(s => s.status === 'online')) {
       overallStatus = 'online';
     } else if (statusValues.some(s => s.status === 'stopped')) {
       overallStatus = 'stopped';
@@ -132,6 +149,7 @@ router.get('/', asyncHandler(async (req, res) => {
       apiPort,
       pm2Status: statuses,
       overallStatus,
+      degraded: homeFailed,
       hasDeployScript: hasDeployScript(app),
       xcodeScripts: checkScripts(app)
     };

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -68,14 +68,15 @@ router.get('/', asyncHandler(async (req, res) => {
   }
 
   // Fetch PM2 processes for each unique PM2_HOME.
-  // A thrown listProcesses is a failed read, not an empty list — track those
-  // homes so we report `unknown` (status unavailable) instead of `not_started`
-  // (confidently not running) for their apps. See getAppStatuses() in the
-  // service for the same absent-vs-empty distinction.
+  // listProcessesStrict returns `null` on a failed read (vs `[]` for a
+  // successful read with no processes) — track those homes so we report
+  // `unknown` (status unavailable) instead of `not_started` (confidently not
+  // running) for their apps. See getAppStatuses() in the service for the same
+  // absent-vs-empty distinction.
   const pm2Maps = new Map();
   const failedHomes = new Set();
   for (const pm2Home of pm2HomeGroups.keys()) {
-    const processes = await pm2Service.listProcesses(pm2Home).catch(() => null);
+    const processes = await pm2Service.listProcessesStrict(pm2Home);
     if (processes === null) {
       failedHomes.add(pm2Home);
       pm2Maps.set(pm2Home, new Map());
@@ -168,22 +169,27 @@ router.get('/:id', loadApp, asyncHandler(async (req, res) => {
 
   let degraded = false;
   if (usesPm2(app.type)) {
-    // Get PM2 status for each process (using app's custom PM2_HOME if set).
-    // A thrown getAppStatus is a failed read, not a confident "not running" —
-    // mark `degraded` so the detail UI can disable lifecycle controls rather
-    // than offer a misleading Start. Mirrors the list endpoint's `degraded`.
+    // getAppStatusStrict returns `null` when the PM2 read failed (vs a real
+    // status object). A failed read is genuinely unknown, not "not running" —
+    // mark `degraded` so the detail UI can offer refresh-to-retry rather than a
+    // misleading Start. Mirrors the list endpoint's `degraded`.
     for (const processName of app.pm2ProcessNames || []) {
-      const status = await pm2Service.getAppStatus(processName, app.pm2Home).catch(() => {
+      const status = await pm2Service.getAppStatusStrict(processName, app.pm2Home);
+      if (status === null) {
         degraded = true;
-        return { status: 'unknown' };
-      });
-      statuses[processName] = status;
+        statuses[processName] = { name: processName, status: 'unknown', pm2_env: null };
+      } else {
+        statuses[processName] = status;
+      }
     }
 
-    // Compute overall status (same logic as list endpoint)
+    // Compute overall status (same logic as list endpoint). A degraded read
+    // short-circuits to `unknown` rather than collapsing to `not_started`.
     const statusValues = Object.values(statuses);
     overallStatus = 'unknown';
-    if (statusValues.some(s => s.status === 'online')) {
+    if (degraded) {
+      overallStatus = 'unknown';
+    } else if (statusValues.some(s => s.status === 'online')) {
       overallStatus = 'online';
     } else if (statusValues.some(s => s.status === 'stopped')) {
       overallStatus = 'stopped';

--- a/server/routes/apps.js
+++ b/server/routes/apps.js
@@ -166,10 +166,17 @@ router.get('/:id', loadApp, asyncHandler(async (req, res) => {
   let statuses = {};
   let overallStatus = 'n/a';
 
+  let degraded = false;
   if (usesPm2(app.type)) {
-    // Get PM2 status for each process (using app's custom PM2_HOME if set)
+    // Get PM2 status for each process (using app's custom PM2_HOME if set).
+    // A thrown getAppStatus is a failed read, not a confident "not running" —
+    // mark `degraded` so the detail UI can disable lifecycle controls rather
+    // than offer a misleading Start. Mirrors the list endpoint's `degraded`.
     for (const processName of app.pm2ProcessNames || []) {
-      const status = await pm2Service.getAppStatus(processName, app.pm2Home).catch(() => ({ status: 'unknown' }));
+      const status = await pm2Service.getAppStatus(processName, app.pm2Home).catch(() => {
+        degraded = true;
+        return { status: 'unknown' };
+      });
       statuses[processName] = status;
     }
 
@@ -209,7 +216,7 @@ router.get('/:id', loadApp, asyncHandler(async (req, res) => {
     appVersion = pkg?.version || null;
   }
 
-  res.json({ ...app, uiPort, devUiPort, apiPort, overallStatus, pm2Status: statuses, appVersion, hasDeployScript: hasDeployScript(app), xcodeScripts: checkScripts(app) });
+  res.json({ ...app, uiPort, devUiPort, apiPort, overallStatus, degraded, pm2Status: statuses, appVersion, hasDeployScript: hasDeployScript(app), xcodeScripts: checkScripts(app) });
 }));
 
 // POST /api/apps/:id/xcode-scripts/install - Install missing management scripts

--- a/server/routes/apps.test.js
+++ b/server/routes/apps.test.js
@@ -130,6 +130,24 @@ describe('Apps Routes', () => {
       expect(response.body[0].overallStatus).toBe('not_started');
     });
 
+    it('reports unknown + degraded (not not_started) when the PM2 read fails', async () => {
+      const mockApps = [
+        { id: 'app-001', name: 'Test App', pm2ProcessNames: ['test-app'], repoPath: '/tmp/test' }
+      ];
+
+      appsService.getAllApps.mockResolvedValue(mockApps);
+      // A failed PM2 read must not collapse into a confident "not started."
+      pm2Service.listProcesses.mockRejectedValue(new Error('pm2 daemon unreachable'));
+      streamingDetect.parseEcosystemFromPath.mockResolvedValue([]);
+
+      const response = await request(app).get('/api/apps');
+
+      expect(response.status).toBe(200);
+      expect(response.body[0].overallStatus).toBe('unknown');
+      expect(response.body[0].degraded).toBe(true);
+      expect(response.body[0].pm2Status['test-app'].status).toBe('unknown');
+    });
+
     it('should return empty array when no apps exist', async () => {
       appsService.getAllApps.mockResolvedValue([]);
       pm2Service.listProcesses.mockResolvedValue([]);

--- a/server/routes/apps.test.js
+++ b/server/routes/apps.test.js
@@ -176,6 +176,24 @@ describe('Apps Routes', () => {
       expect(response.body.pm2Status).toBeDefined();
     });
 
+    it('returns degraded + unknown when the PM2 status read fails', async () => {
+      const mockApp = {
+        id: 'app-001',
+        name: 'Test App',
+        pm2ProcessNames: ['test-app']
+      };
+      appsService.getAppById.mockResolvedValue(mockApp);
+      // Detail endpoint reads per-process status; a thrown read must surface
+      // as degraded, not collapse into a confident not_started.
+      pm2Service.getAppStatus.mockRejectedValue(new Error('pm2 daemon unreachable'));
+
+      const response = await request(app).get('/api/apps/app-001');
+
+      expect(response.status).toBe(200);
+      expect(response.body.overallStatus).toBe('unknown');
+      expect(response.body.degraded).toBe(true);
+    });
+
     it('should return 404 if app not found', async () => {
       appsService.getAppById.mockResolvedValue(null);
 

--- a/server/routes/apps.test.js
+++ b/server/routes/apps.test.js
@@ -20,7 +20,9 @@ vi.mock('../services/apps.js', () => ({
 
 vi.mock('../services/pm2.js', () => ({
   listProcesses: vi.fn(),
+  listProcessesStrict: vi.fn(),
   getAppStatus: vi.fn(),
+  getAppStatusStrict: vi.fn(),
   startWithCommand: vi.fn(),
   stopApp: vi.fn(),
   restartApp: vi.fn(),
@@ -105,7 +107,7 @@ describe('Apps Routes', () => {
       ];
 
       appsService.getAllApps.mockResolvedValue(mockApps);
-      pm2Service.listProcesses.mockResolvedValue(mockPm2Processes);
+      pm2Service.listProcessesStrict.mockResolvedValue(mockPm2Processes);
       streamingDetect.parseEcosystemFromPath.mockResolvedValue([]);
 
       const response = await request(app).get('/api/apps');
@@ -121,7 +123,7 @@ describe('Apps Routes', () => {
       ];
 
       appsService.getAllApps.mockResolvedValue(mockApps);
-      pm2Service.listProcesses.mockResolvedValue([]);
+      pm2Service.listProcessesStrict.mockResolvedValue([]);
       streamingDetect.parseEcosystemFromPath.mockResolvedValue([]);
 
       const response = await request(app).get('/api/apps');
@@ -136,8 +138,9 @@ describe('Apps Routes', () => {
       ];
 
       appsService.getAllApps.mockResolvedValue(mockApps);
-      // A failed PM2 read must not collapse into a confident "not started."
-      pm2Service.listProcesses.mockRejectedValue(new Error('pm2 daemon unreachable'));
+      // Strict read returns null on a failed PM2 read — must not collapse into
+      // a confident "not started."
+      pm2Service.listProcessesStrict.mockResolvedValue(null);
       streamingDetect.parseEcosystemFromPath.mockResolvedValue([]);
 
       const response = await request(app).get('/api/apps');
@@ -150,7 +153,7 @@ describe('Apps Routes', () => {
 
     it('should return empty array when no apps exist', async () => {
       appsService.getAllApps.mockResolvedValue([]);
-      pm2Service.listProcesses.mockResolvedValue([]);
+      pm2Service.listProcessesStrict.mockResolvedValue([]);
 
       const response = await request(app).get('/api/apps');
 
@@ -167,7 +170,7 @@ describe('Apps Routes', () => {
         pm2ProcessNames: ['test-app']
       };
       appsService.getAppById.mockResolvedValue(mockApp);
-      pm2Service.getAppStatus.mockResolvedValue({ status: 'online' });
+      pm2Service.getAppStatusStrict.mockResolvedValue({ name: 'test-app', status: 'online' });
 
       const response = await request(app).get('/api/apps/app-001');
 
@@ -183,9 +186,10 @@ describe('Apps Routes', () => {
         pm2ProcessNames: ['test-app']
       };
       appsService.getAppById.mockResolvedValue(mockApp);
-      // Detail endpoint reads per-process status; a thrown read must surface
-      // as degraded, not collapse into a confident not_started.
-      pm2Service.getAppStatus.mockRejectedValue(new Error('pm2 daemon unreachable'));
+      // Detail endpoint reads per-process status via the strict variant, which
+      // returns null on a failed read — must surface as degraded, not collapse
+      // into a confident not_started.
+      pm2Service.getAppStatusStrict.mockResolvedValue(null);
 
       const response = await request(app).get('/api/apps/app-001');
 
@@ -383,7 +387,7 @@ describe('Apps Routes', () => {
         processes: [{ name: 'test-app', ports: { devUi: 5554 } }]
       }];
       appsService.getAllApps.mockResolvedValue(mockApps);
-      pm2Service.listProcesses.mockResolvedValue([]);
+      pm2Service.listProcessesStrict.mockResolvedValue([]);
 
       const response = await request(app).get('/api/apps');
 
@@ -403,7 +407,7 @@ describe('Apps Routes', () => {
         ]
       }];
       appsService.getAllApps.mockResolvedValue(mockApps);
-      pm2Service.listProcesses.mockResolvedValue([]);
+      pm2Service.listProcessesStrict.mockResolvedValue([]);
 
       const response = await request(app).get('/api/apps');
 
@@ -423,7 +427,7 @@ describe('Apps Routes', () => {
         processes: [{ name: 'test-app', ports: { devUi: 5554 } }]
       }];
       appsService.getAllApps.mockResolvedValue(mockApps);
-      pm2Service.listProcesses.mockResolvedValue([]);
+      pm2Service.listProcessesStrict.mockResolvedValue([]);
 
       const response = await request(app).get('/api/apps');
 

--- a/server/routes/systemHealth.js
+++ b/server/routes/systemHealth.js
@@ -61,7 +61,7 @@ router.get('/health/details', asyncHandler(async (req, res) => {
   // Gather data in parallel
   const [pm2Processes, appStatusSummary, cosStatus, self, dbHealth, version, diskStats, memStats, thresholds] = await Promise.all([
     listProcesses().catch(() => []),
-    apps.getAppStatusSummary().catch(() => ({ total: 0, online: 0, stopped: 0, notStarted: 0, unmanaged: 0 })),
+    apps.getAppStatusSummary().catch(() => ({ total: 0, online: 0, stopped: 0, notStarted: 0, unknown: 0, degraded: false, unmanaged: 0 })),
     cos.getStatus().catch(() => null),
     getSelf().catch(() => null),
     checkHealth().catch(() => ({ connected: false, hasSchema: false, error: 'Health check failed' })),
@@ -153,6 +153,15 @@ router.get('/health/details', asyncHandler(async (req, res) => {
       type: 'restarts',
       message: `${processStats.unstableRestarts} crash-loop restart${plural} (${crashing.join(', ')})`
     });
+  }
+
+  // A degraded app summary means PM2 couldn't be read for one or more homes, so
+  // those apps' online/stopped status is unknown — surface it rather than letting
+  // the counts silently read as "everything not started."
+  if (appStats.degraded) {
+    if (overallHealth !== 'critical') overallHealth = 'warning';
+    const unknown = appStats.unknown || 0;
+    warnings.push({ type: 'apps', message: `App status unavailable for ${unknown} app(s) — PM2 read failed` });
   }
 
   if (!dbHealth.connected) {

--- a/server/services/apps.js
+++ b/server/services/apps.js
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from '../lib/uuid.js';
 import EventEmitter from 'events';
 import { atomicWrite, ensureDir, readJSONFile, PATHS } from '../lib/fileUtils.js';
 import { NON_PM2_TYPES, usesPm2 } from './streamingDetect.js';
-import { listProcesses } from './pm2.js';
+import { listProcessesStrict } from './pm2.js';
 import { SELF_IMPROVEMENT_TASK_TYPES } from './taskSchedule.js';
 import { sanitizeTaskMetadata } from '../lib/validation.js';
 import { PORTS } from '../lib/ports.js';
@@ -193,8 +193,9 @@ export async function getActiveApps() {
  * primitive behind both `getAppStatusSummary()` (counts) and the CyberCity
  * snapshot pipeline (per-building status), so the two never drift.
  *
- * Absent-vs-empty rule (CLAUDE.md): a `listProcesses(home)` that *throws* is a
- * failed read, NOT a successful "no processes." Folding it into `[]` would
+ * Absent-vs-empty rule (CLAUDE.md): `listProcessesStrict(home)` returns `null`
+ * when the PM2 read FAILED (vs `[]` for a successful read with no processes).
+ * The generic `listProcesses` flattens a failed read into `[]`, which would
  * record every app in that home as `not_started` (status known: never launched)
  * when the truth is `unknown` (status unavailable: PM2 unreachable). We track
  * failed homes explicitly and mark their apps `overallStatus: 'unknown'` +
@@ -217,8 +218,8 @@ export async function getAppStatuses() {
   const procMaps = new Map();
   const failedHomes = new Set();
   for (const home of homeGroups.keys()) {
-    // `null` sentinel on throw distinguishes a failed read from an empty list.
-    const procs = await listProcesses(home).catch(() => null);
+    // `null` = PM2 read failed (vs `[]` = read OK, no processes).
+    const procs = await listProcessesStrict(home);
     if (procs === null) {
       failedHomes.add(home);
       procMaps.set(home, new Map());

--- a/server/services/apps.js
+++ b/server/services/apps.js
@@ -187,13 +187,21 @@ export async function getActiveApps() {
  * Resolve each active app's overall PM2 status in one pass.
  *
  * Returns one entry per active app — PM2-runnable apps carry a derived
- * `overallStatus` of `online` / `stopped` / `not_started`; native projects
- * (Xcode, iOS, macOS) report `n/a` since they have no detectable runtime.
- * Each unique PM2_HOME is queried at most once. This is the shared primitive
- * behind both `getAppStatusSummary()` (counts) and the CyberCity snapshot
- * pipeline (per-building status), so the two never drift.
+ * `overallStatus` of `online` / `stopped` / `not_started` / `unknown`; native
+ * projects (Xcode, iOS, macOS) report `n/a` since they have no detectable
+ * runtime. Each unique PM2_HOME is queried at most once. This is the shared
+ * primitive behind both `getAppStatusSummary()` (counts) and the CyberCity
+ * snapshot pipeline (per-building status), so the two never drift.
  *
- * @returns {Promise<Array<{ id, name, type, repoPath, overallStatus, managed: boolean }>>}
+ * Absent-vs-empty rule (CLAUDE.md): a `listProcesses(home)` that *throws* is a
+ * failed read, NOT a successful "no processes." Folding it into `[]` would
+ * record every app in that home as `not_started` (status known: never launched)
+ * when the truth is `unknown` (status unavailable: PM2 unreachable). We track
+ * failed homes explicitly and mark their apps `overallStatus: 'unknown'` +
+ * `degraded: true`, so a transient PM2 blip can't masquerade as "all apps
+ * offline." Homes that read fine still report accurate status alongside.
+ *
+ * @returns {Promise<Array<{ id, name, type, repoPath, overallStatus, managed: boolean, degraded?: boolean }>>}
  */
 export async function getAppStatuses() {
   const apps = await getAllApps({ includeArchived: false });
@@ -207,9 +215,16 @@ export async function getAppStatuses() {
   }
 
   const procMaps = new Map();
+  const failedHomes = new Set();
   for (const home of homeGroups.keys()) {
-    const procs = await listProcesses(home).catch(() => []);
-    procMaps.set(home, new Map(procs.map(p => [p.name, p])));
+    // `null` sentinel on throw distinguishes a failed read from an empty list.
+    const procs = await listProcesses(home).catch(() => null);
+    if (procs === null) {
+      failedHomes.add(home);
+      procMaps.set(home, new Map());
+    } else {
+      procMaps.set(home, new Map(procs.map(p => [p.name, p])));
+    }
   }
 
   return apps.map(app => {
@@ -221,7 +236,13 @@ export async function getAppStatuses() {
     if (!managed) {
       return { ...base, overallStatus: 'n/a', managed: false };
     }
-    const procMap = procMaps.get(app.pm2Home || null) || new Map();
+    const home = app.pm2Home || null;
+    if (failedHomes.has(home)) {
+      // PM2 read for this home failed — runtime status is genuinely unknown,
+      // NOT a confident `not_started`. `degraded` lets callers surface the gap.
+      return { ...base, overallStatus: 'unknown', managed: true, degraded: true };
+    }
+    const procMap = procMaps.get(home) || new Map();
     const names = app.pm2ProcessNames || [];
     let overallStatus = 'not_started';
     if (names.length > 0) {
@@ -237,12 +258,19 @@ export async function getAppStatuses() {
 export async function getAppStatusSummary() {
   const statuses = await getAppStatuses();
   const managed = statuses.filter(s => s.managed);
+  // `unknown` = PM2 home read failed (status unavailable), distinct from
+  // `notStarted` (read succeeded, app simply isn't running). `degraded` flags
+  // that at least one managed app's runtime status couldn't be determined, so
+  // consumers don't report a PM2 blip as a confident "everything offline."
+  const unknown = managed.filter(s => s.overallStatus === 'unknown').length;
 
   return {
     total: managed.length,
     online: managed.filter(s => s.overallStatus === 'online').length,
     stopped: managed.filter(s => s.overallStatus === 'stopped').length,
     notStarted: managed.filter(s => s.overallStatus === 'not_started').length,
+    unknown,
+    degraded: unknown > 0,
     unmanaged: statuses.length - managed.length
   };
 }

--- a/server/services/apps.test.js
+++ b/server/services/apps.test.js
@@ -30,7 +30,7 @@ vi.mock('./pm2.js', () => ({
 
 import { readJSONFile } from '../lib/fileUtils.js';
 import { listProcesses } from './pm2.js';
-import { getAppStatusSummary, getReservedPorts, invalidateCache, PORTOS_APP_ID } from './apps.js';
+import { getAppStatuses, getAppStatusSummary, getReservedPorts, invalidateCache, PORTOS_APP_ID } from './apps.js';
 
 describe('getReservedPorts', () => {
   beforeEach(() => {
@@ -169,6 +169,8 @@ describe('getAppStatusSummary', () => {
       online: 1,
       stopped: 1,
       notStarted: 1,
+      unknown: 0,
+      degraded: false,
       unmanaged: 2
     });
   });
@@ -191,6 +193,8 @@ describe('getAppStatusSummary', () => {
       online: 1,
       stopped: 0,
       notStarted: 0,
+      unknown: 0,
+      degraded: false,
       unmanaged: 0
     });
   });
@@ -255,5 +259,79 @@ describe('getAppStatusSummary', () => {
 
     const summary = await getAppStatusSummary();
     expect(summary.total).toBe(1);
+  });
+
+  it('marks the summary degraded (not all not-started) when a PM2 read fails', async () => {
+    readJSONFile.mockResolvedValue({
+      apps: {
+        [PORTOS_APP_ID]: { name: 'PortOS', type: 'express', pm2ProcessNames: ['portos-server'] },
+        'svc-a': { name: 'svc-a', type: 'express', pm2ProcessNames: ['svc-a'] }
+      }
+    });
+    // The default PM2 home throws — a transient read failure, NOT an empty list.
+    listProcesses.mockRejectedValue(new Error('pm2 daemon unreachable'));
+
+    const summary = await getAppStatusSummary();
+    expect(summary).toEqual({
+      total: 2,
+      online: 0,
+      stopped: 0,
+      notStarted: 0,
+      unknown: 2,
+      degraded: true,
+      unmanaged: 0
+    });
+  });
+
+  it('keeps accurate counts for healthy homes when only one home fails', async () => {
+    readJSONFile.mockResolvedValue({
+      apps: {
+        [PORTOS_APP_ID]: { name: 'PortOS', type: 'express', pm2ProcessNames: ['portos-server'] },
+        'custom-home': { name: 'c', type: 'express', pm2Home: '/tmp/other-pm2', pm2ProcessNames: ['c'] }
+      }
+    });
+    listProcesses.mockImplementation(async (home) => {
+      if (home === '/tmp/other-pm2') throw new Error('this home is down');
+      return [{ name: 'portos-server', status: 'online' }];
+    });
+
+    const summary = await getAppStatusSummary();
+    expect(summary).toMatchObject({ total: 2, online: 1, unknown: 1, degraded: true });
+  });
+});
+
+describe('getAppStatuses', () => {
+  beforeEach(() => {
+    invalidateCache();
+    vi.clearAllMocks();
+  });
+
+  it('reports unknown + degraded for apps whose PM2 home read failed', async () => {
+    readJSONFile.mockResolvedValue({
+      apps: {
+        [PORTOS_APP_ID]: { name: 'PortOS', type: 'express', pm2ProcessNames: ['portos-server'] }
+      }
+    });
+    listProcesses.mockRejectedValue(new Error('pm2 daemon unreachable'));
+
+    const statuses = await getAppStatuses();
+    const portos = statuses.find(s => s.id === PORTOS_APP_ID);
+    expect(portos.overallStatus).toBe('unknown');
+    expect(portos.degraded).toBe(true);
+  });
+
+  it('does NOT mark apps unknown when the PM2 home reads an empty list', async () => {
+    readJSONFile.mockResolvedValue({
+      apps: {
+        [PORTOS_APP_ID]: { name: 'PortOS', type: 'express', pm2ProcessNames: ['portos-server'] }
+      }
+    });
+    // Successful read, genuinely no processes → not_started, NOT unknown.
+    listProcesses.mockResolvedValue([]);
+
+    const statuses = await getAppStatuses();
+    const portos = statuses.find(s => s.id === PORTOS_APP_ID);
+    expect(portos.overallStatus).toBe('not_started');
+    expect(portos.degraded).toBeUndefined();
   });
 });

--- a/server/services/apps.test.js
+++ b/server/services/apps.test.js
@@ -25,11 +25,13 @@ vi.mock('./taskSchedule.js', () => ({
 }));
 
 vi.mock('./pm2.js', () => ({
-  listProcesses: vi.fn().mockResolvedValue([]),
+  // Strict variant: resolves an array on success (incl. []), or null on a
+  // failed PM2 read. The status getters use this, not the forgiving listProcesses.
+  listProcessesStrict: vi.fn().mockResolvedValue([]),
 }));
 
 import { readJSONFile } from '../lib/fileUtils.js';
-import { listProcesses } from './pm2.js';
+import { listProcessesStrict } from './pm2.js';
 import { getAppStatuses, getAppStatusSummary, getReservedPorts, invalidateCache, PORTOS_APP_ID } from './apps.js';
 
 describe('getReservedPorts', () => {
@@ -157,7 +159,7 @@ describe('getAppStatusSummary', () => {
         }
       }
     });
-    listProcesses.mockResolvedValue([
+    listProcessesStrict.mockResolvedValue([
       { name: 'portos-server', status: 'online' },
       { name: 'svc-a', status: 'stopped' }
       // svc-b is missing → not_found → notStarted
@@ -185,7 +187,7 @@ describe('getAppStatusSummary', () => {
         }
       }
     });
-    listProcesses.mockResolvedValue([{ name: 'portos-server', status: 'online' }]);
+    listProcessesStrict.mockResolvedValue([{ name: 'portos-server', status: 'online' }]);
 
     const summary = await getAppStatusSummary();
     expect(summary).toEqual({
@@ -225,7 +227,7 @@ describe('getAppStatusSummary', () => {
         }
       }
     });
-    listProcesses.mockImplementation(async (home) => {
+    listProcessesStrict.mockImplementation(async (home) => {
       if (home === '/tmp/other-pm2') return [{ name: 'c', status: 'online' }];
       return [
         { name: 'portos-server', status: 'online' },
@@ -235,7 +237,7 @@ describe('getAppStatusSummary', () => {
     });
 
     const summary = await getAppStatusSummary();
-    expect(listProcesses).toHaveBeenCalledTimes(2);
+    expect(listProcessesStrict).toHaveBeenCalledTimes(2);
     expect(summary).toMatchObject({ total: 4, online: 3, stopped: 1, notStarted: 0, unmanaged: 0 });
   });
 
@@ -255,7 +257,7 @@ describe('getAppStatusSummary', () => {
         }
       }
     });
-    listProcesses.mockResolvedValue([{ name: 'portos-server', status: 'online' }]);
+    listProcessesStrict.mockResolvedValue([{ name: 'portos-server', status: 'online' }]);
 
     const summary = await getAppStatusSummary();
     expect(summary.total).toBe(1);
@@ -268,8 +270,8 @@ describe('getAppStatusSummary', () => {
         'svc-a': { name: 'svc-a', type: 'express', pm2ProcessNames: ['svc-a'] }
       }
     });
-    // The default PM2 home throws — a transient read failure, NOT an empty list.
-    listProcesses.mockRejectedValue(new Error('pm2 daemon unreachable'));
+    // Strict read returns null on a transient PM2 failure (NOT an empty list).
+    listProcessesStrict.mockResolvedValue(null);
 
     const summary = await getAppStatusSummary();
     expect(summary).toEqual({
@@ -290,8 +292,8 @@ describe('getAppStatusSummary', () => {
         'custom-home': { name: 'c', type: 'express', pm2Home: '/tmp/other-pm2', pm2ProcessNames: ['c'] }
       }
     });
-    listProcesses.mockImplementation(async (home) => {
-      if (home === '/tmp/other-pm2') throw new Error('this home is down');
+    listProcessesStrict.mockImplementation(async (home) => {
+      if (home === '/tmp/other-pm2') return null; // this home's read failed
       return [{ name: 'portos-server', status: 'online' }];
     });
 
@@ -312,7 +314,7 @@ describe('getAppStatuses', () => {
         [PORTOS_APP_ID]: { name: 'PortOS', type: 'express', pm2ProcessNames: ['portos-server'] }
       }
     });
-    listProcesses.mockRejectedValue(new Error('pm2 daemon unreachable'));
+    listProcessesStrict.mockResolvedValue(null);
 
     const statuses = await getAppStatuses();
     const portos = statuses.find(s => s.id === PORTOS_APP_ID);
@@ -327,7 +329,7 @@ describe('getAppStatuses', () => {
       }
     });
     // Successful read, genuinely no processes → not_started, NOT unknown.
-    listProcesses.mockResolvedValue([]);
+    listProcessesStrict.mockResolvedValue([]);
 
     const statuses = await getAppStatuses();
     const portos = statuses.find(s => s.id === PORTOS_APP_ID);

--- a/server/services/pm2.js
+++ b/server/services/pm2.js
@@ -233,6 +233,9 @@ export async function deleteApp(name, pm2Home = null) {
  */
 export async function getAppStatus(name, pm2Home = null) {
   const processes = await fetchJlist(pm2Home);
+  // `error` here means "PM2 read failed", but it's the same forgiving shape the
+  // generic callers expect. App-status callers that must distinguish a failed
+  // read from a genuine state use getAppStatusStrict (null sentinel) instead.
   if (!processes) return { name, status: 'error', pm2_env: null };
   const proc = processes.find(p => p.name === name);
 
@@ -240,6 +243,28 @@ export async function getAppStatus(name, pm2Home = null) {
     return { name, status: 'not_found', pm2_env: null };
   }
 
+  return shapeProcStatus(proc);
+}
+
+/**
+ * Strict variant of {@link getAppStatus}: returns `null` when the PM2 read
+ * FAILED, distinct from a `{ status: 'not_found' }` for a read that succeeded
+ * but found no matching process. The detail endpoint uses this so a daemon
+ * blip surfaces as `degraded` rather than a confident `not_started`.
+ *
+ * @returns {Promise<object|null>} Process status, `{ status: 'not_found' }`, or
+ *   `null` on read failure.
+ */
+export async function getAppStatusStrict(name, pm2Home = null) {
+  const processes = await fetchJlist(pm2Home);
+  if (!processes) return null;
+  const proc = processes.find(p => p.name === name);
+  if (!proc) return { name, status: 'not_found', pm2_env: null };
+  return shapeProcStatus(proc);
+}
+
+// Shared shaping for getAppStatus / getAppStatusStrict so the two never drift.
+function shapeProcStatus(proc) {
   return {
     name: proc.name,
     status: proc.pm2_env?.status || 'unknown',
@@ -333,7 +358,32 @@ function fetchJlist(pm2Home = null) {
 export async function listProcesses(pm2Home = null) {
   const list = await fetchJlist(pm2Home);
   if (!list) return [];
-  return list.map(proc => ({
+  return list.map(mapProcess);
+}
+
+/**
+ * Strict variant of {@link listProcesses}: returns `null` when the PM2 read
+ * FAILED (daemon unreachable / non-zero exit) and the mapped array otherwise —
+ * including `[]` for a successful read with no processes.
+ *
+ * `listProcesses()` flattens a failed read into `[]`, which is the right
+ * forgiving behavior for log/command/voice callers that just want "whatever is
+ * running." But app-status getters MUST distinguish "PM2 unreachable" from
+ * "nothing running" (CLAUDE.md absent-vs-empty rule) — collapsing them records
+ * a transient blip as every app `not_started`. Those callers use this instead.
+ *
+ * @param {string} pm2Home Optional custom PM2_HOME path
+ * @returns {Promise<Array|null>} Mapped process list, or `null` on read failure.
+ */
+export async function listProcessesStrict(pm2Home = null) {
+  const list = await fetchJlist(pm2Home);
+  if (!list) return null;
+  return list.map(mapProcess);
+}
+
+// Shared shaping for listProcesses / listProcessesStrict so the two never drift.
+function mapProcess(proc) {
+  return {
     name: proc.name,
     status: proc.pm2_env?.status || 'unknown',
     pid: proc.pid,
@@ -343,7 +393,7 @@ export async function listProcesses(pm2Home = null) {
     uptime: proc.pm2_env?.pm_uptime ? Date.now() - proc.pm2_env.pm_uptime : null,
     restarts: proc.pm2_env?.restart_time || 0,
     unstableRestarts: proc.pm2_env?.unstable_restarts || 0
-  }));
+  };
 }
 
 /**

--- a/server/services/pm2.js
+++ b/server/services/pm2.js
@@ -280,6 +280,28 @@ function shapeProcStatus(proc) {
 }
 
 /**
+ * Parse the stdout of a `pm2 jlist` (custom PM2_HOME CLI path) into a raw
+ * process array, or `null` when the read effectively failed.
+ *
+ * PM2 jlist always emits a JSON array (`[]` when there are no processes), so an
+ * exit-0 with empty or garbage stdout (no array literal at all) is a FAILED read
+ * — not a successful "no processes." Returning `[]` there would reintroduce the
+ * absent-vs-empty footgun (issue #968) for custom PM2_HOME reads. `extractJSONArray`
+ * itself falls back to `'[]'` on garbage, so we must detect a real array literal
+ * before trusting it (mirroring extractJSONArray's own detection) and return null
+ * otherwise — matching the default-home path, which resolves null for a non-array.
+ *
+ * @param {string} stdout Raw `pm2 jlist` stdout (may carry ANSI noise).
+ * @returns {Array|null} The parsed process array (incl. `[]`), or `null` on failure.
+ */
+export function parseJlistStdout(stdout) {
+  const hasArrayLiteral = typeof stdout === 'string' && (stdout.includes('[{') || /\[\](?![0-9])/.test(stdout));
+  if (!hasArrayLiteral) return null;
+  const list = safeJSONParse(extractJSONArray(stdout), null);
+  return Array.isArray(list) ? list : null;
+}
+
+/**
  * Fetch PM2 process list with TTL caching.
  * Uses the PM2 Node.js API for the default PM2_HOME (no subprocess spawning — avoids
  * visible cmd windows on Windows). Falls back to CLI only for custom PM2_HOME paths.
@@ -335,7 +357,11 @@ function fetchJlist(pm2Home = null) {
           resolve(null);
           return;
         }
-        const list = safeJSONParse(extractJSONArray(stdout), []);
+        const list = parseJlistStdout(stdout);
+        if (list === null) {
+          resolve(null);
+          return;
+        }
         jlistCache.set(key, { data: list, ts: Date.now() });
         resolve(list);
       });

--- a/server/services/pm2.parseJlist.test.js
+++ b/server/services/pm2.parseJlist.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// pm2.js imports the `pm2` package at module load (no daemon connection until a
+// call is made), so importing it for a pure-helper test is safe. We still mock
+// the package to keep the import side-effect-free in CI.
+vi.mock('pm2', () => ({ default: { connect: vi.fn(), list: vi.fn(), disconnect: vi.fn() } }));
+
+import { parseJlistStdout } from './pm2.js';
+
+describe('parseJlistStdout (issue #968 — custom PM2_HOME absent-vs-empty)', () => {
+  it('parses a populated jlist array', () => {
+    const out = '[{"name":"svc-a","pm2_env":{"status":"online"}}]';
+    const list = parseJlistStdout(out);
+    expect(Array.isArray(list)).toBe(true);
+    expect(list).toHaveLength(1);
+    expect(list[0].name).toBe('svc-a');
+  });
+
+  it('parses a genuine empty array as [] (read OK, no processes)', () => {
+    // The literal '[]' is a successful "nothing running" — NOT a failure.
+    expect(parseJlistStdout('[]')).toEqual([]);
+    // Tolerates ANSI/log noise around the array literal.
+    expect(parseJlistStdout('[2K[]\n')).toEqual([]);
+  });
+
+  it('returns null for empty stdout (failed read, not "no processes")', () => {
+    // exit-0 with no output is a failed read — must NOT collapse to [].
+    expect(parseJlistStdout('')).toBeNull();
+    expect(parseJlistStdout('   \n')).toBeNull();
+  });
+
+  it('returns null for garbage / non-array stdout', () => {
+    expect(parseJlistStdout('pm2 daemon not running')).toBeNull();
+    expect(parseJlistStdout('{"not":"an array"}')).toBeNull();
+    expect(parseJlistStdout(undefined)).toBeNull();
+    expect(parseJlistStdout(null)).toBeNull();
+  });
+
+  it('does not mistake an ANSI color code like [31m for an empty array', () => {
+    // The /\[\](?![0-9])/ guard means '[]' inside '[31m' style noise without a
+    // real array still resolves to null, not a bogus empty success.
+    expect(parseJlistStdout('[31mERROR[0m no pm2')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #968

## Problem

`getAppStatuses()`, `getAppStatusSummary()`, and the `/api/apps` route enrichment all did `listProcesses(home).catch(() => [])`. A transient PM2 read failure therefore collapsed into a *successful empty process list*, so a PM2-managed app was recorded as `not_started` and the online count as `0` — the absent-vs-empty footgun CLAUDE.md warns about, but inside the app-status getter rather than the snapshot layer.

This affected every consumer of app status: `/api/system/health/details`, capabilities, the dashboard app cards, and CyberCity snapshots (a PM2 blip would record "all apps offline" in the history).

## Fix

- **Service (`getAppStatuses`)** — `listProcesses(home)` now uses a `null` sentinel on throw to distinguish a failed read from an empty list. Failed homes are tracked in a set; their apps report `overallStatus: 'unknown'` + `degraded: true`, distinct from a confident `not_started`. Homes that read fine still report accurate status alongside (a single failed home doesn't blank the others).
- **Summary (`getAppStatusSummary`)** — gains an `unknown` count and a `degraded` flag (`unknown > 0`).
- **Capability row** — surfaces "N status unavailable" and stays `WARN` when degraded, with `unknown`/`degraded` in the detail.
- **System health** — pushes an `apps`-type warning and degrades `overallHealth` to `warning` when the app summary is degraded; fallback shape updated.
- **`/api/apps` route enrichment** — same failed-vs-empty distinction; processes in a failed home report `status: 'unknown'`, the app's `overallStatus` short-circuits to `unknown`, and the payload carries `degraded`.

The client already tolerates `'unknown'` via `StatusBadge`'s fallback config, so no client change was needed (no speculative degraded-badge UI added, per YAGNI).

## Tests

Regression tests cover failed-read vs empty-read for both the service (`getAppStatuses` + `getAppStatusSummary`) and the `/api/apps` route, plus the degraded capability row. Full server suite green (532 files).

## Notes for reviewers

- The null-sentinel "track failed homes" loop now appears in two places (the service getter and the route enrichment). Left inline rather than extracted: only 2 occurrences (rule-of-three not met) and the two loops differ — the route additionally auto-populates ports/processes — so a shared helper wouldn't cleanly absorb both.