### PR TITLE
fix([issue-1060]): stop server vitest from globbing client jsdom tests

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -8,3 +8,4 @@
 ## Changed
 
 - **[issue-1027] Songs: vocal takes remember their pitch analysis** — a recorded take now saves its tuner trace and color-match score so your accuracy isn't recomputed every time you reopen the song.
+- **[issue-1060] Cleaner test runs** — browser-dependent tests now run only under their own test environment, so the server test run no longer reports spurious failures from double-running them.

--- a/server/vitest.config.js
+++ b/server/vitest.config.js
@@ -3,16 +3,16 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     testTimeout: 10000,
-    // Pick up tests from the client tree too — a handful of client-side pure
-    // helpers (normalize.js sidecar field resolution) have unit tests that
-    // belong alongside the source, but the client itself has no test runner.
-    // The server's vitest is the project's single test entrypoint, so we
-    // include the client *.test.js files here. Also pick up migration tests
-    // from scripts/migrations/ so each one-shot migration can be verified
+    // The client owns its own test runner (`client/vitest.config.js`, jsdom,
+    // `cd client && npm test`) which already covers every `client/src/**` test
+    // — including the pure helper tests (e.g. normalize.js sidecar resolution).
+    // So this server runner covers only server, scripts/migrations, and lib
+    // tests; it intentionally does NOT glob the client tree (its default node
+    // environment has no DOM, so DOM-dependent client tests would fail here).
+    // The scripts/migrations glob lets each one-shot migration be verified
     // against synthetic fixtures.
     include: [
       '**/*.test.js',
-      '../client/src/**/*.test.js',
       '../scripts/**/*.test.js',
       '../lib/**/*.test.js',
     ],


### PR DESCRIPTION
Closes #1060

## Problem
`server/vitest.config.js` globbed `../client/src/**/*.test.js`, but the server runner uses the default node environment (no jsdom). DOM-dependent client tests (e.g. `client/src/hooks/useSingToScore.test.js`) failed under it with `ReferenceError: document is not defined`, while every other client test double-ran (once here, once under the client's own jsdom runner).

## Fix
Removed `'../client/src/**/*.test.js'` from the server config's `include` array and refreshed the stale comment (it claimed the client had no test runner — `client/vitest.config.js` now exists with jsdom and its `src/**/*.{test,spec}.{js,jsx}` include already covers every `client/src/**` test, including the pure-helper `normalize.js` sidecar tests that originally justified the glob). The server runner now covers only server + scripts/migrations + lib tests.

## Verification
- **Before:** `cd server && npx vitest run` → `1 failed | 596 passed`, `useSingToScore.test.js` failing with `document is not defined`.
- **After (server):** `cd server && npm test` → 517 files / 10425 tests pass, no `../client/src/**` entries, no `document is not defined`.
- **After (client):** `cd client && npm test` → 183 files / 1931 tests pass; confirmed the pure-helper `normalize.test.js` (the original glob justification) and `useSingToScore.test.js` both run and pass under the client's jsdom runner, so no coverage is lost.

## Review note
Trivial change (one glob entry removed + comment refresh, no new code paths). Skipped `/simplify` and external review per the claim review heuristic; local self-review gate is clean and both test runners are verified green.