### PR TITLE
refactor([issue-909]): replace CITY_COLORS global mutation with CityPalette context

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -11,3 +11,4 @@
 - **[issue-1027] Songs: vocal takes remember their pitch analysis** — a recorded take now saves its tuner trace and color-match score so your accuracy isn't recomputed every time you reopen the song.
 - **[issue-1060] Cleaner test runs** — browser-dependent tests now run only under their own test environment, so the server test run no longer reports spurious failures from double-running them.
 - **[issue-1050] More reliable database exports** — manual database exports now pick a PostgreSQL dump tool that matches the database being exported, so an export no longer fails on machines with several Postgres versions installed.
+- **[issue-909] CyberCity theme colors** — internal refactor of how the 3D city picks up your theme accent, replacing a fragile shared-state mechanism with a cleaner one; no change to how the city looks.

--- a/client/src/components/city/Building.jsx
+++ b/client/src/components/city/Building.jsx
@@ -1,7 +1,8 @@
 import { useRef, useState, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { getBuildingColor, getBuildingHeight, getAccentColor, BUILDING_PARAMS, PIXEL_FONT_URL, mixHex, tintStructure, seededRand } from './cityConstants';
+import { getBuildingHeight, BUILDING_PARAMS, PIXEL_FONT_URL, mixHex, seededRand } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import HolographicPanel from './HolographicPanel';
 import BuildingHologram from './BuildingHologram';
@@ -90,8 +91,9 @@ const PIXEL_ICONS = [
   ],
 ];
 
-// Generate a pixel window texture with icon mural for a building face
-const createWindowTexture = (accentColor, width, height, seed) => {
+// Generate a pixel window texture with icon mural for a building face. `tintStructure`
+// is passed in (bound to the active palette accent) so the facade base tracks the theme.
+const createWindowTexture = (accentColor, width, height, seed, tintStructure) => {
   const canvas = document.createElement('canvas');
   const px = 8;
   const cols = 12;
@@ -363,6 +365,7 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
   const displayedColorRef = useRef(null);
   const targetColorRef = useRef(null);
 
+  const { getBuildingColor, getAccentColor, tintStructure } = useCityPalette();
   const height = getBuildingHeight(app);
   const edgeColor = getBuildingColor(app.overallStatus, app.archived);
   const accentColor = getAccentColor(app);
@@ -401,8 +404,8 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
 
   // Window texture with pixel art icon
   const windowTexture = useMemo(
-    () => createWindowTexture(accentColor, width, height, seed),
-    [accentColor, width, height, seed]
+    () => createWindowTexture(accentColor, width, height, seed, tintStructure),
+    [accentColor, width, height, seed, tintStructure]
   );
 
   // Format name for building face

--- a/client/src/components/city/CityAiCore.jsx
+++ b/client/src/components/city/CityAiCore.jsx
@@ -1,7 +1,8 @@
 import { useMemo, useRef } from 'react';
 import * as THREE from 'three';
 import { useFrame } from '@react-three/fiber';
-import { PIXEL_FONT_URL, cityDayMix, mixHex, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix, mixHex } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import { computeAiCore, computeAiCoreBeams, AI_CORE } from '../../utils/cityAiCore';
 
@@ -100,6 +101,7 @@ function SpireLightRings({ height, color, dayMix }) {
 }
 
 export default function CityAiCore({ aiActivity, positions, apps, settings }) {
+  const { tintStructure } = useCityPalette();
   const core = useMemo(
     () => computeAiCore(aiActivity?.ops, aiActivity?.lastStartTs ?? 0),
     [aiActivity],

--- a/client/src/components/city/CityArtifacts.jsx
+++ b/client/src/components/city/CityArtifacts.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import { computeArtifacts, ARTIFACTS } from '../../utils/cityArtifacts';
 
@@ -11,6 +12,7 @@ import { computeArtifacts, ARTIFACTS } from '../../utils/cityArtifacts';
 // goals. The emblems shimmer in unison via a single per-frame ref mutation, gated on the
 // quality dial. Mirrors CityGoalMonuments / CityProductivityDistrict.
 function Artifact({ artifact, dayMix = 0 }) {
+  const { tintStructure } = useCityPalette();
   const { color, intensity, label, position } = artifact;
   const { pedestalWidth: pw, pedestalHeight: ph, emblemSize } = ARTIFACTS;
   const emblemY = ph + emblemSize * 0.6;

--- a/client/src/components/city/CityBackupVault.jsx
+++ b/client/src/components/city/CityBackupVault.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import { computeBackupVault } from '../../utils/cityBackupVault';
 import { timeAgo } from '../../utils/formatters';
@@ -11,6 +12,7 @@ import { timeAgo } from '../../utils/formatters';
 // runs), it pulses on `backup:started/completed`, and the label shows time-since the
 // last snapshot — going red and reading "STALE" when a backup is overdue.
 export default function CityBackupVault({ backupStatus, settings }) {
+  const { tintStructure } = useCityPalette();
   const vault = useMemo(() => computeBackupVault(backupStatus), [backupStatus]);
   const sealRef = useRef();
 

--- a/client/src/components/city/CityBillboards.jsx
+++ b/client/src/components/city/CityBillboards.jsx
@@ -2,7 +2,8 @@ import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Text } from '@react-three/drei';
 import * as THREE from 'three';
-import { CITY_COLORS, PIXEL_FONT_URL } from './cityConstants';
+import { PIXEL_FONT_URL } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 
 // Holographic scan line shader for billboard overlay
 const SCAN_VERT = `
@@ -205,6 +206,7 @@ function Billboard({ position, rotation, messages, color, width = 3.5, height = 
 }
 
 export default function CityBillboards({ positions, apps, cosStatus, reviewCounts, instances, productivityData }) {
+  const { neonAccents } = useCityPalette();
   // Build billboard messages from real system data
   const billboardConfig = useMemo(() => {
     if (!positions || positions.size < 2) return [];
@@ -212,7 +214,7 @@ export default function CityBillboards({ positions, apps, cosStatus, reviewCount
     const onlineApps = apps.filter(a => !a.archived && a.overallStatus === 'online');
     const stoppedApps = apps.filter(a => !a.archived && a.overallStatus === 'stopped');
     const totalActive = apps.filter(a => !a.archived).length;
-    const colors = CITY_COLORS.neonAccents;
+    const colors = neonAccents;
     const pendingReview = reviewCounts?.total || 0;
     const alertCount = reviewCounts?.alert || 0;
     const peers = instances?.peers || [];
@@ -317,7 +319,7 @@ export default function CityBillboards({ positions, apps, cosStatus, reviewCount
     }
 
     return billboards;
-  }, [positions, apps, cosStatus, reviewCounts, instances, productivityData]);
+  }, [positions, apps, cosStatus, reviewCounts, instances, productivityData, neonAccents]);
 
   if (billboardConfig.length === 0) return null;
 

--- a/client/src/components/city/CityFederationHorizon.jsx
+++ b/client/src/components/city/CityFederationHorizon.jsx
@@ -1,7 +1,8 @@
 import { useMemo, useRef, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import { computeFederationHorizon, FEDERATION } from '../../utils/cityFederation';
 
@@ -48,6 +49,7 @@ function FederationBridge({ from, color, broken, intensity }) {
 
 // A distant peer (or the void marker) rendered as a neon-trimmed silhouette.
 function Monolith({ position, width, height, color, opacity, label, sublabel, online, animate, dayMix = 0 }) {
+  const { tintStructure } = useCityPalette();
   const capRef = useRef();
 
   useFrame(({ clock }) => {

--- a/client/src/components/city/CityGoalMonuments.jsx
+++ b/client/src/components/city/CityGoalMonuments.jsx
@@ -1,7 +1,8 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import CityTubeLine from './CityTubeLine';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import { computeGoalMonuments, computeGoalForest, MONUMENTS, FOREST } from '../../utils/cityGoalMonuments';
 
@@ -20,6 +21,7 @@ import { computeGoalMonuments, computeGoalForest, MONUMENTS, FOREST } from '../.
 // or the plain built/scaffold split. `shimmerRef`/`isShimmer` wires the completed-monument
 // pulse onto whichever mesh carries the topmost built portion.
 function MonumentBody({ monument, shimmerRef, isShimmer }) {
+  const { tintStructure } = useCityPalette();
   const { height, width, color, opacity, intensity, built, completeness, segments } = monument;
 
   // Milestone floors: one box per milestone, solid+emissive when done, wireframe scaffold
@@ -86,6 +88,7 @@ function MonumentBody({ monument, shimmerRef, isShimmer }) {
 }
 
 function Monument({ monument, shimmerRef, isShimmer, dayMix = 0 }) {
+  const { tintStructure } = useCityPalette();
   const { height, width, color, opacity, intensity, position, milestoneTotal, milestoneDone, isSpire } = monument;
 
   return (
@@ -170,6 +173,7 @@ function GoalForest({ forest, shimmerRef, shimmerId, dayMix = 0 }) {
 }
 
 export default function CityGoalMonuments({ goals, settings }) {
+  const { tintStructure } = useCityPalette();
   // The API returns `{ goals: [...] }`; accept either the wrapper or a bare array.
   const list = Array.isArray(goals) ? goals : goals?.goals;
   const district = useMemo(() => computeGoalMonuments(list), [list]);

--- a/client/src/components/city/CityGround.jsx
+++ b/client/src/components/city/CityGround.jsx
@@ -2,7 +2,8 @@ import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Grid } from '@react-three/drei';
 import * as THREE from 'three';
-import { CITY_COLORS, getTimeOfDayPreset, cityDayMix, mixHex, seededRand } from './cityConstants';
+import { getTimeOfDayPreset, cityDayMix, mixHex, seededRand } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 
 // Reflective puddle/wet-ground patches
 function WetPatch({ position, size, color, dayMix = 0 }) {
@@ -32,6 +33,7 @@ function WetPatch({ position, size, color, dayMix = 0 }) {
 // Rolling fog layer with animated opacity
 function RollingFog({ dayMix = 0 }) {
   const ref = useRef();
+  const { ground } = useCityPalette();
 
   useFrame(({ clock }) => {
     if (!ref.current) return;
@@ -44,7 +46,7 @@ function RollingFog({ dayMix = 0 }) {
     <mesh ref={ref} rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.5, 0]}>
       <planeGeometry args={[100, 100]} />
       <meshBasicMaterial
-        color={CITY_COLORS.ground}
+        color={ground}
         transparent
         opacity={0.012}
         blending={THREE.AdditiveBlending}
@@ -55,6 +57,7 @@ function RollingFog({ dayMix = 0 }) {
 }
 
 export default function CityGround({ settings }) {
+  const { ground, neonAccents } = useCityPalette();
   const reflectionsEnabled = settings?.reflectionsEnabled ?? true;
   const groundMatRef = useRef();
 
@@ -67,10 +70,10 @@ export default function CityGround({ settings }) {
   const targetRoughness = preset.groundRoughness ?? 0.7;
   const targetMetalness = 0.4 * (1 - dayMix) + 0.04 * dayMix;
 
-  // The neon grid + additive fog follow the themed accent (CITY_COLORS.ground is
-  // recolored per theme by applyCityBrandColors). At night they read as accent neon;
-  // by day the grid mutes to faint pavement lines and the glow fog fades out.
-  const accent = CITY_COLORS.ground;
+  // The neon grid + additive fog follow the themed accent (palette.ground tracks the
+  // theme). At night they read as accent neon; by day the grid mutes to faint pavement
+  // lines and the glow fog fades out.
+  const accent = ground;
   const gridSectionColor = mixHex(accent, '#bcc4cc', dayMix);
   const gridCellColor = mixHex(mixHex(accent, '#0a1420', 0.5), '#a7afb8', dayMix);
   const groundFogOpacity = 0.045 * (1 - dayMix);
@@ -86,7 +89,7 @@ export default function CityGround({ settings }) {
   const puddles = useMemo(() => {
     const result = [];
     const rand = seededRand(137);
-    const colors = CITY_COLORS.neonAccents;
+    const colors = neonAccents;
     const count = reflectionsEnabled ? 40 : 20;
 
     for (let i = 0; i < count; i++) {
@@ -98,7 +101,7 @@ export default function CityGround({ settings }) {
       });
     }
     return result;
-  }, [reflectionsEnabled]);
+  }, [reflectionsEnabled, neonAccents]);
 
   return (
     <group>

--- a/client/src/components/city/CityHealthTower.jsx
+++ b/client/src/components/city/CityHealthTower.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import { computeHealthTower } from '../../utils/cityHealthTower';
 
@@ -11,6 +12,7 @@ import { computeHealthTower } from '../../utils/cityHealthTower';
 // a present-but-zero value, which keeps its lit color. The heart-rate tier pulses like a
 // heartbeat, faster as the rate climbs. Mirrors CityBackupVault / CityTaskQueue.
 function Segment({ segment, baseRadius, isHeart, heartRef }) {
+  const { tintStructure } = useCityPalette();
   const { height, color, intensity } = segment;
   return (
     <mesh ref={isHeart ? heartRef : undefined} position={[0, segment.y, 0]}>
@@ -28,6 +30,7 @@ function Segment({ segment, baseRadius, isHeart, heartRef }) {
 }
 
 export default function CityHealthTower({ healthMetrics, settings }) {
+  const { tintStructure } = useCityPalette();
   const tower = useMemo(() => computeHealthTower(healthMetrics), [healthMetrics]);
   const heartRef = useRef();
 

--- a/client/src/components/city/CityJiraDistrict.jsx
+++ b/client/src/components/city/CityJiraDistrict.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import { computeJiraDistrict, JIRA_DISTRICT } from '../../utils/cityJiraDistrict';
 
@@ -13,6 +14,7 @@ import { computeJiraDistrict, JIRA_DISTRICT } from '../../utils/cityJiraDistrict
 // One ticket structure. The mesh form is chosen by workflow state so the yard reads as work
 // progressing from crates → scaffolds → finished buildings.
 function SprintStructure({ structure, pulseRef, isPulse }) {
+  const { tintStructure } = useCityPalette();
   const { position, color, height, state } = structure;
   const size = JIRA_DISTRICT.crateSize;
 

--- a/client/src/components/city/CityLandscape.jsx
+++ b/client/src/components/city/CityLandscape.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo } from 'react';
 import * as THREE from 'three';
-import { CITY_COLORS, cityDayMix, mixHex, seededRand, smoothstepRange } from './cityConstants';
+import { cityDayMix, mixHex, seededRand, smoothstepRange } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 
 const TERRAIN_SIZE = 2400;
 const MOUNTAIN_INNER_RADIUS = 560;
@@ -60,7 +61,7 @@ const TERRAIN_FRAG = `
   }
 `;
 
-function TerrainPlane({ dayMix }) {
+function TerrainPlane({ dayMix, accent }) {
   const material = useMemo(() => new THREE.ShaderMaterial({
     vertexShader: TERRAIN_VERT,
     fragmentShader: TERRAIN_FRAG,
@@ -68,12 +69,12 @@ function TerrainPlane({ dayMix }) {
       uInner: { value: new THREE.Color(mixHex('#202426', '#686d68', dayMix)) },
       uMeadow: { value: new THREE.Color(mixHex('#172719', '#6f8758', dayMix)) },
       uRidge: { value: new THREE.Color(mixHex('#111827', '#8d937f', dayMix)) },
-      uAccent: { value: new THREE.Color(CITY_COLORS.ground) },
+      uAccent: { value: new THREE.Color(accent) },
       uDayMix: { value: dayMix },
     },
     side: THREE.DoubleSide,
     depthWrite: true,
-  }), [dayMix]);
+  }), [dayMix, accent]);
 
   // R3F doesn't dispose a material handed in via the `material` prop, so free the
   // prior one when dayMix flips (Day/Night toggle) and on unmount.
@@ -135,6 +136,7 @@ function Mountain({ mountain, dayMix }) {
 }
 
 export default function CityLandscape({ settings }) {
+  const { accent } = useCityPalette();
   const dayMix = cityDayMix(settings);
 
   const mountains = useMemo(() => {
@@ -165,7 +167,7 @@ export default function CityLandscape({ settings }) {
 
   return (
     <group>
-      <TerrainPlane dayMix={dayMix} />
+      <TerrainPlane dayMix={dayMix} accent={accent} />
       <group>
         {mountains.map((mountain) => (
           <Mountain key={mountain.id} mountain={mountain} dayMix={dayMix} />

--- a/client/src/components/city/CityLights.jsx
+++ b/client/src/components/city/CityLights.jsx
@@ -1,7 +1,8 @@
 import { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { CITY_COLORS, getTimeOfDayPreset } from './cityConstants';
+import { getTimeOfDayPreset } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 
 // Animated accent light that slowly shifts color, with reactive brightness
 function AnimatedLight({ position, baseColor, baseIntensity, distance, shiftRange = 0.1, speed = 0.5, brightnessRef, neonScaleRef }) {
@@ -80,6 +81,7 @@ function ReactivePointLight({ position, baseIntensity, color, distance, brightne
 }
 
 export default function CityLights({ settings }) {
+  const { ground } = useCityPalette();
   const brightnessRef = useRef(settings?.ambientBrightness ?? 1.2);
   brightnessRef.current = settings?.ambientBrightness ?? 1.2;
 
@@ -138,7 +140,7 @@ export default function CityLights({ settings }) {
       {/* Secondary overhead fill - broad white/blue */}
       <ReactivePointLight position={[0, 20, 10]} baseIntensity={0.5} color="#4488cc" distance={90} brightnessRef={brightnessRef} neonScaleRef={neonScaleRef} />
       {/* Broad nighttime city glow — signage bounce + moonlit haze, faded in daylight */}
-      <ReactivePointLight position={[0, 16, 0]} baseIntensity={1.8 * nightGlow} color={CITY_COLORS.ground} distance={150} brightnessRef={brightnessRef} neonScaleRef={neonScaleRef} />
+      <ReactivePointLight position={[0, 16, 0]} baseIntensity={1.8 * nightGlow} color={ground} distance={150} brightnessRef={brightnessRef} neonScaleRef={neonScaleRef} />
       <ReactivePointLight position={[-28, 10, 24]} baseIntensity={1.05 * nightGlow} color="#ec4899" distance={118} brightnessRef={brightnessRef} neonScaleRef={neonScaleRef} />
       <ReactivePointLight position={[30, 12, -22]} baseIntensity={1.1 * nightGlow} color="#60a5fa" distance={120} brightnessRef={brightnessRef} neonScaleRef={neonScaleRef} />
       {/* Magenta accent from left - animated color shift */}

--- a/client/src/components/city/CityMemoryDistrict.jsx
+++ b/client/src/components/city/CityMemoryDistrict.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import CityTubeLine from './CityTubeLine';
 import { computeMemoryDistrict, MEMORY_DISTRICT } from '../../utils/cityMemoryDistrict';
@@ -70,6 +71,7 @@ function CrystalCluster({ cluster, glowRef, isGlow, dayMix = 0 }) {
 }
 
 export default function CityMemoryDistrict({ memoryGraph, inboxDepth = 0, settings }) {
+  const { tintStructure } = useCityPalette();
   const district = useMemo(() => computeMemoryDistrict(memoryGraph), [memoryGraph]);
   const glowRef = useRef();
   const wellRef = useRef();

--- a/client/src/components/city/CityMiniMap.jsx
+++ b/client/src/components/city/CityMiniMap.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { computeCityLayout } from './cityLayout';
-import { getBuildingColor } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import { computeMiniMap } from '../../utils/cityMiniMap';
 
 // CyberCity mini-map overlay (roadmap 2.8). A compact top-down map in a HUD corner showing
@@ -21,6 +21,9 @@ import { computeMiniMap } from '../../utils/cityMiniMap';
 const MAP_SIZE = 132;
 
 export default function CityMiniMap({ apps, onSelectApp }) {
+  // Status colors track the theme accent for 'online' (the rest stay semantic), so a
+  // dot matches its building exactly. Read from the palette the city page provides.
+  const { getBuildingColor } = useCityPalette();
   const view = useMemo(() => {
     const positions = computeCityLayout(Array.isArray(apps) ? apps : []);
     return computeMiniMap(apps, positions);

--- a/client/src/components/city/CityNeonSigns.jsx
+++ b/client/src/components/city/CityNeonSigns.jsx
@@ -2,7 +2,8 @@ import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Text } from '@react-three/drei';
 import * as THREE from 'three';
-import { CITY_COLORS, PIXEL_FONT_URL } from './cityConstants';
+import { PIXEL_FONT_URL } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 
 // Floating neon street-level signs with animated glow
 
@@ -105,6 +106,7 @@ function NeonBar({ position, rotation, color, height = 2 }) {
 }
 
 export default function CityNeonSigns({ positions }) {
+  const { neonAccents } = useCityPalette();
   const signs = useMemo(() => {
     if (!positions || positions.size < 2) return [];
 
@@ -123,7 +125,7 @@ export default function CityNeonSigns({ positions }) {
       maxZ = Math.max(maxZ, p.z);
     });
 
-    const colors = CITY_COLORS.neonAccents;
+    const colors = neonAccents;
     const pad = 3;
     const result = [];
 
@@ -203,7 +205,7 @@ export default function CityNeonSigns({ positions }) {
     });
 
     return result;
-  }, [positions]);
+  }, [positions, neonAccents]);
 
   const bars = useMemo(() => {
     if (!positions || positions.size < 2) return [];
@@ -223,7 +225,7 @@ export default function CityNeonSigns({ positions }) {
       maxZ = Math.max(maxZ, p.z);
     });
 
-    const colors = CITY_COLORS.neonAccents;
+    const colors = neonAccents;
     const pad = 3;
     const result = [];
 
@@ -246,7 +248,7 @@ export default function CityNeonSigns({ positions }) {
     });
 
     return result;
-  }, [positions]);
+  }, [positions, neonAccents]);
 
   if (signs.length === 0) return null;
 

--- a/client/src/components/city/CityPaletteContext.jsx
+++ b/client/src/components/city/CityPaletteContext.jsx
@@ -1,0 +1,33 @@
+import { createContext, useContext } from 'react';
+import { deriveCityPalette } from './cityConstants';
+
+// CyberCity's "brand" surfaces (ground grid, particles, online buildings, the lead
+// neon accent, the dark structural bases) track the active PortOS theme accent. The
+// palette is derived once per theme (see deriveCityPalette) and handed down through
+// this context instead of mutating a shared module-level singleton during render —
+// the old approach fired a side-effect mid-render that was fragile under React
+// StrictMode's double-invoke and concurrent rendering.
+//
+// IMPORTANT: react-three-fiber's <Canvas> runs its own reconciler, so React context
+// does NOT cross that boundary automatically (the same reason `settings` is prop-
+// threaded into every scene component). The palette is therefore provided TWICE: once
+// by CyberCityInner for the DOM-side HUD/minimap, and again inside <Canvas> by
+// CityScene for the 3D scene. Both providers share the same derived palette object.
+
+// Default to the cyan-era baseline so a consumer rendered outside a provider (or in a
+// test) still gets a valid, fully-formed palette rather than crashing on undefined.
+const DEFAULT_CITY_PALETTE = deriveCityPalette(undefined);
+
+const CityPaletteContext = createContext(DEFAULT_CITY_PALETTE);
+
+export function CityPaletteProvider({ palette, children }) {
+  return (
+    <CityPaletteContext.Provider value={palette || DEFAULT_CITY_PALETTE}>
+      {children}
+    </CityPaletteContext.Provider>
+  );
+}
+
+export function useCityPalette() {
+  return useContext(CityPaletteContext);
+}

--- a/client/src/components/city/CityParticles.jsx
+++ b/client/src/components/city/CityParticles.jsx
@@ -1,7 +1,9 @@
 import { Sparkles } from '@react-three/drei';
-import { cityDayMix, CITY_COLORS } from './cityConstants';
+import { cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 
 export default function CityParticles({ settings }) {
+  const { particles } = useCityPalette();
   const density = settings?.particleDensity ?? 1.0;
   const scale = (base) => Math.max(1, Math.round(base * density));
   // Neon atmosphere dust is a night look — fade it out in daylight.
@@ -9,15 +11,14 @@ export default function CityParticles({ settings }) {
 
   return (
     <>
-      {/* Primary ambient sparkles — follow the themed accent (CITY_COLORS.particles
-          is recolored per theme by applyCityBrandColors) */}
+      {/* Primary ambient sparkles — follow the themed accent (palette.particles). */}
       <Sparkles
         count={scale(120)}
         scale={[50, 20, 50]}
         size={1.8}
         speed={0.3}
         opacity={0.3 * dayFade}
-        color={CITY_COLORS.particles}
+        color={particles}
       />
       {/* Pink/magenta secondary sparkles */}
       <Sparkles

--- a/client/src/components/city/CityProductivityDistrict.jsx
+++ b/client/src/components/city/CityProductivityDistrict.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import { computeProductivityMonument } from '../../utils/cityProductivity';
 
@@ -11,6 +12,7 @@ import { computeProductivityMonument } from '../../utils/cityProductivity';
 // distinct from a real zero-day streak. The capstone pulses brighter the longer the streak,
 // faster while velocity is surging. Mirrors CityBackupVault / CityHealthTower.
 export default function CityProductivityDistrict({ productivityData, settings }) {
+  const { tintStructure } = useCityPalette();
   const monument = useMemo(() => computeProductivityMonument(productivityData), [productivityData]);
   const capRef = useRef();
 

--- a/client/src/components/city/CityScene.jsx
+++ b/client/src/components/city/CityScene.jsx
@@ -43,9 +43,10 @@ import CameraTransition from './CameraTransition';
 import CityPhotoCamera from './CityPhotoCamera';
 import CityDepthOfField from './CityDepthOfField';
 import { cityDayMix } from './cityConstants';
+import { CityPaletteProvider } from './CityPaletteContext';
 import ErrorBoundary from '../ErrorBoundary';
 
-export default function CityScene({ apps, agentMap, onBuildingClick, cosStatus, reviewCounts, instances, backupStatus, cosTasks, healthMetrics, voiceState, aiActivity, productivityData, activityCalendar, goals, character, chronotype, memoryGraph, inboxDepth, jiraTickets, playback = false, photoMode, photoPresetId, photoDof, onPhotoCaptureReady, settings, playSfx, keysRef, dimmedAppIds, background }) {
+export default function CityScene({ apps, agentMap, onBuildingClick, cosStatus, reviewCounts, instances, backupStatus, cosTasks, healthMetrics, voiceState, aiActivity, productivityData, activityCalendar, goals, character, chronotype, memoryGraph, inboxDepth, jiraTickets, playback = false, photoMode, photoPresetId, photoDof, onPhotoCaptureReady, settings, playSfx, keysRef, dimmedAppIds, background, palette }) {
   const [positions, setPositions] = useState(null);
   const [proximityApp, setProximityApp] = useState(null);
   const [transitioning, setTransitioning] = useState(false);
@@ -176,6 +177,10 @@ export default function CityScene({ apps, agentMap, onBuildingClick, cosStatus, 
         // dashboard, which reads as a blank white scene.
         gl={{ antialias: true, preserveDrawingBuffer: Boolean(photoMode), alpha: false, powerPreference: 'high-performance' }}
       >
+      {/* Re-provide the themed palette INSIDE the Canvas — react-three-fiber runs its
+          own reconciler, so the provider in CyberCityInner doesn't reach these scene
+          components. Plain React Context.Provider works across the r3f tree. */}
+      <CityPaletteProvider palette={palette}>
       {/* By day, the solid clear color is the scene background. At night, the galaxy
           Environment below owns scene.background (the equirectangular spheremap), so we
           must NOT also drive <color attach="background"> — both write scene.background and
@@ -288,6 +293,7 @@ export default function CityScene({ apps, agentMap, onBuildingClick, cosStatus, 
           toggle would churn render-loop ownership and could strand a blurred frozen frame on screen
           when DoF flips off mid-freeze. */}
       {photoMode && <CityDepthOfField presetId={photoPresetId} enabled={photoDof} composerRef={photoComposerRef} />}
+      </CityPaletteProvider>
       </Canvas>
     </div>
   );

--- a/client/src/components/city/CitySignalBeacons.jsx
+++ b/client/src/components/city/CitySignalBeacons.jsx
@@ -1,10 +1,12 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 
 function SignalBeacon({ position, color, label, sublabel, intensity = 1, dayMix = 0 }) {
+  const { tintStructure } = useCityPalette();
   const groupRef = useRef();
   const glowRef = useRef();
   const beamRef = useRef();

--- a/client/src/components/city/CitySky.jsx
+++ b/client/src/components/city/CitySky.jsx
@@ -1,7 +1,8 @@
 import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { getTimeOfDayPreset, tintTowardAccent, CITY_COLORS } from './cityConstants';
+import { getTimeOfDayPreset, tintTowardAccent } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 
 const SUN_RADIUS = 100;
 
@@ -112,16 +113,15 @@ const lerpColor = (target, a, b, t) => {
 // tracks the theme; horizon haze + sun colors stay physical/untinted. The accent is
 // in the cache key so a theme switch re-derives instead of serving a stale tint.
 const presetColors = {};
-const getPresetColors = (name, skyTheme) => {
-  const accent = CITY_COLORS.ground;
+const getPresetColors = (name, skyTheme, accent) => {
   const cacheKey = `${skyTheme}:${name}:${accent}`;
   if (!presetColors[cacheKey]) {
     const p = getTimeOfDayPreset(name, skyTheme);
     const isBrightDay = (p.daylightFactor ?? 0) >= 0.75;
     const belowHorizon = isBrightDay ? p.horizonLow : '#03030a';
     presetColors[cacheKey] = {
-      zenith: new THREE.Color(tintTowardAccent(p.zenith, 0.16)),
-      midSky: new THREE.Color(tintTowardAccent(p.midSky, 0.12)),
+      zenith: new THREE.Color(tintTowardAccent(p.zenith, 0.16, accent)),
+      midSky: new THREE.Color(tintTowardAccent(p.midSky, 0.12, accent)),
       horizonHigh: new THREE.Color(p.horizonHigh),
       horizonLow: new THREE.Color(p.horizonLow),
       belowHorizon: new THREE.Color(belowHorizon),
@@ -182,6 +182,12 @@ function CelestialBody({ groupRef }) {
 }
 
 export default function CitySky({ settings }) {
+  // The upper sky bands are tinted toward the theme accent. Mirror it into a ref so
+  // the useFrame loop reads the current accent without re-subscribing each frame.
+  const { accent } = useCityPalette();
+  const accentRef = useRef(accent);
+  accentRef.current = accent;
+
   const brightnessRef = useRef(settings?.ambientBrightness ?? 1.2);
   brightnessRef.current = settings?.ambientBrightness ?? 1.2;
 
@@ -213,7 +219,7 @@ export default function CitySky({ settings }) {
     const initialTheme = skyThemeRef.current;
     const initialTod = timeOfDayRef.current;
     const initialHour = getTimeOfDayPreset(initialTod, initialTheme).hour ?? 18;
-    const preset = getPresetColors(initialTod, initialTheme);
+    const preset = getPresetColors(initialTod, initialTheme, accentRef.current);
     const initPos = getArcPosition(initialHour);
     return new THREE.ShaderMaterial({
       vertexShader: SkyDomeShader.vertexShader,
@@ -250,7 +256,7 @@ export default function CitySky({ settings }) {
     transitionRef.current = Math.min(1.0, transitionRef.current + delta * 1.5);
     const lerpFactor = transitionRef.current < 1 ? delta * 3 : 1;
 
-    const preset = getPresetColors(target, skyThemeRef.current);
+    const preset = getPresetColors(target, skyThemeRef.current, accentRef.current);
 
     // Lerp hour along shortest path on the 24h clock
     let hourDiff = preset.hour - currentHourRef.current;

--- a/client/src/components/city/CityTaskQueue.jsx
+++ b/client/src/components/city/CityTaskQueue.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import { computeTaskQueue, TASK_QUEUE } from '../../utils/cityTaskQueue';
 
@@ -26,6 +27,7 @@ function Crate({ y, size, color, topGlow }) {
 }
 
 export default function CityTaskQueue({ cosTasks, settings }) {
+  const { tintStructure } = useCityPalette();
   const queue = useMemo(() => computeTaskQueue(cosTasks), [cosTasks]);
   const roofRef = useRef();
 

--- a/client/src/components/city/CityTraffic.jsx
+++ b/client/src/components/city/CityTraffic.jsx
@@ -1,6 +1,6 @@
 import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { CITY_COLORS } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 
 // A single flying hover vehicle
 function HoverVehicle({ path, color, speed, offset, altitude }) {
@@ -70,6 +70,7 @@ function HoverVehicle({ path, color, speed, offset, altitude }) {
 }
 
 export default function CityTraffic({ positions }) {
+  const { neonAccents } = useCityPalette();
   // Generate traffic lanes based on building layout
   const vehicles = useMemo(() => {
     if (!positions || positions.size < 2) return [];
@@ -91,7 +92,7 @@ export default function CityTraffic({ positions }) {
     });
 
     const pad = 3;
-    const colors = CITY_COLORS.neonAccents;
+    const colors = neonAccents;
     const result = [];
 
     // Create traffic lanes around the perimeter
@@ -145,7 +146,7 @@ export default function CityTraffic({ positions }) {
     }
 
     return result;
-  }, [positions]);
+  }, [positions, neonAccents]);
 
   if (vehicles.length === 0) return null;
 

--- a/client/src/components/city/CityVoiceMarker.jsx
+++ b/client/src/components/city/CityVoiceMarker.jsx
@@ -1,6 +1,7 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { PIXEL_FONT_URL, cityDayMix, tintStructure } from './cityConstants';
+import { PIXEL_FONT_URL, cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 import { computeVoiceMarker } from '../../utils/cityVoiceMarker';
 
@@ -10,6 +11,7 @@ import { computeVoiceMarker } from '../../utils/cityVoiceMarker';
 // while listening, green while dictating, red on error, and barely-lit when voice mode is
 // off. Keeps to a small footprint so it reads as a district marker, not a landmark.
 export default function CityVoiceMarker({ voiceState, settings }) {
+  const { tintStructure } = useCityPalette();
   const marker = useMemo(() => computeVoiceMarker(voiceState), [voiceState]);
   const orbRef = useRef();
 

--- a/client/src/components/city/CityVolumetricLights.jsx
+++ b/client/src/components/city/CityVolumetricLights.jsx
@@ -1,7 +1,8 @@
 import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { CITY_COLORS, cityDayMix } from './cityConstants';
+import { cityDayMix } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 
 // Volumetric light cone shader
 const CONE_VERT = `
@@ -130,6 +131,7 @@ function ScanBeam({ start, end, color, speed = 0.2, delay = 0, intensityScale = 
 }
 
 export default function CityVolumetricLights({ positions, settings }) {
+  const { neonAccents } = useCityPalette();
   const nightFade = 1 - cityDayMix(settings);
   const beams = useMemo(() => {
     if (!positions || positions.size < 2) return { lights: [], scans: [] };
@@ -148,7 +150,7 @@ export default function CityVolumetricLights({ positions, settings }) {
     });
 
     const pad = 5;
-    const colors = CITY_COLORS.neonAccents;
+    const colors = neonAccents;
 
     // Spotlight beams at corners and edges of the city
     const lights = [
@@ -168,7 +170,7 @@ export default function CityVolumetricLights({ positions, settings }) {
     ];
 
     return { lights, scans };
-  }, [positions]);
+  }, [positions, neonAccents]);
 
   if (nightFade <= 0.05 || beams.lights.length === 0) return null;
 

--- a/client/src/components/city/ProcessBuilding.jsx
+++ b/client/src/components/city/ProcessBuilding.jsx
@@ -1,36 +1,37 @@
 import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { CITY_COLORS, PROCESS_BUILDING_PARAMS, PIXEL_FONT_URL, mixHex } from './cityConstants';
+import { PROCESS_BUILDING_PARAMS, PIXEL_FONT_URL, mixHex } from './cityConstants';
+import { useCityPalette } from './CityPaletteContext';
 import CityLabel from './CityLabel';
 
-// Process status → color, unified with CITY_COLORS.building (read live so 'online'
-// follows the active theme accent and the semantic colors match a stopped/missing
-// *app*): 'stopped' is the same red as a stopped app (was amber), 'not_found' the
-// same purple (was indigo). PM2's hard-failure states ("errored"; some legacy
-// callers send "error") read as the same red as stopped — both mean "down".
-const getProcessColor = (status) => {
-  const b = CITY_COLORS.building;
+// Process status → color, unified with the themed building map (so 'online' follows
+// the active theme accent and the semantic colors match a stopped/missing *app*):
+// 'stopped' is the same red as a stopped app (was amber), 'not_found' the same purple
+// (was indigo). PM2's hard-failure states ("errored"; some legacy callers send "error")
+// read as the same red as stopped — both mean "down".
+const getProcessColor = (status, building) => {
   switch (status) {
-    case 'online': return b.online;
+    case 'online': return building.online;
     case 'stopped':
     case 'errored':
-    case 'error': return b.stopped;
+    case 'error': return building.stopped;
     case 'not_found':
-    default: return b.not_found;
+    default: return building.not_found;
   }
 };
 
 export default function ProcessBuilding({ process, pm2Status, position, seed, dimmed = false, dayMix = 0 }) {
+  const { building, buildingBody } = useCityPalette();
   const blinkRef = useRef();
   const glowRef = useRef();
 
   const status = pm2Status?.status || 'not_found';
-  const color = getProcessColor(status);
+  const color = getProcessColor(status, building);
   const { width, depth } = PROCESS_BUILDING_PARAMS;
   const dimMul = dimmed ? 0.25 : 1;
   // Match the main Building's daytime treatment — sheds neon, lightens to a lit solid.
-  const bodyColor = mixHex(CITY_COLORS.buildingBody, mixHex('#9aa0ac', color, 0.12), dayMix);
+  const bodyColor = mixHex(buildingBody, mixHex('#9aa0ac', color, 0.12), dayMix);
   const neonFade = 1 - dayMix;
 
   // Height based on status + seed variation

--- a/client/src/components/city/cityConstants.js
+++ b/client/src/components/city/cityConstants.js
@@ -165,9 +165,12 @@ export const DISTRICT_PARAMS = {
   gap: 4,
 };
 
-export const getBuildingColor = (status, archived) => {
-  if (archived) return CITY_COLORS.building.archived;
-  return CITY_COLORS.building[status] || CITY_COLORS.building.not_started;
+// Resolve a building's color from a status against a building-color map. The map
+// defaults to the static CITY_COLORS table; pass a themed palette's `building` map
+// (where `online` tracks the theme accent) to follow a theme switch.
+export const getBuildingColor = (status, archived, building = CITY_COLORS.building) => {
+  if (archived) return building.archived;
+  return building[status] || building.not_started;
 };
 
 export const getBuildingHeight = (app) => {
@@ -235,25 +238,24 @@ export const cityLabelColors = (neonColor, dayMix = 0) => {
   };
 };
 
-// Get a deterministic neon accent color per app (for windows/decorations)
-export const getAccentColor = (app) => {
+// Get a deterministic neon accent color per app (for windows/decorations). The accent
+// list defaults to the static palette; pass a themed palette's `neonAccents` to follow
+// a theme switch (its lead entry tracks the theme accent).
+export const getAccentColor = (app, neonAccents = CITY_COLORS.neonAccents) => {
   const hash = hashString(app.name || app.id);
-  return CITY_COLORS.neonAccents[hash % CITY_COLORS.neonAccents.length];
+  return neonAccents[hash % neonAccents.length];
 };
 
 // --- Theme integration -------------------------------------------------------
 // CyberCity's "brand" surfaces (ground grid, particles, online buildings, the
-// lead neon accent) default to cyan. When the user picks a PortOS theme we
-// recolor those surfaces to the theme accent so the 3D scene tracks the rest of
-// the UI. Status colors (stopped=red, etc.) stay semantic. Every brand surface
-// is recomputed from the theme accent (not from the previous theme), so repeated
-// switches don't compound; ORIGINAL_GROUND is only the fallback for a theme that
-// somehow has no accent.
+// lead neon accent, the dark structural bases) default to cyan. When the user picks
+// a PortOS theme, deriveCityPalette recolors those surfaces toward the theme accent
+// so the 3D scene tracks the rest of the UI; status colors (stopped=red, etc.) stay
+// semantic. The palette is a fresh immutable object per theme — every brand surface
+// is recomputed from the theme accent (never from a previous theme), so repeated
+// switches can't compound. ORIGINAL_GROUND is the fallback accent for a theme with no
+// --port-accent; the cyan-era brand defaults are captured up front to recompute from.
 const ORIGINAL_GROUND = CITY_COLORS.ground;
-// The dark building body + window-grid bases default to a cyber near-black. We
-// re-tint them toward the theme accent on a theme switch (see applyCityBrandColors
-// / tintStructure), so capture the cyan-era originals to recompute from — never
-// from the already-tinted value, or repeated switches compound.
 const ORIGINAL_BUILDING_BODY = CITY_COLORS.buildingBody;
 
 // Shared color primitives. parseHex: "#0a7a4a" -> [10, 122, 74] (null on bad input).
@@ -295,14 +297,14 @@ export const mixHex = (a, b, t) => {
   return ca && cb ? toHex(...ca.map((c, i) => c + (cb[i] - c) * t)) : a;
 };
 
-// Tint a color toward the active theme accent (the live CITY_COLORS.ground) by
-// `amount`, then rescale to the original luminance so ONLY hue/saturation shift —
-// the scene's brightness hierarchy (dark structural bases stay dark, bright sky
-// bands stay bright) is preserved while every surface picks up the theme. Reads the
-// live accent so it tracks theme switches. Pure aside from that read; null-safe.
-export const tintTowardAccent = (hex, amount = 0.2) => {
+// Tint a color toward the theme accent by `amount`, then rescale to the original
+// luminance so ONLY hue/saturation shift — the scene's brightness hierarchy (dark
+// structural bases stay dark, bright sky bands stay bright) is preserved while every
+// surface picks up the theme. The accent defaults to the static cyan brand; pass a
+// themed palette's accent to track a theme switch. Pure; null-safe.
+export const tintTowardAccent = (hex, amount = 0.2, accentHex = CITY_COLORS.ground) => {
   const base = parseHex(hex);
-  const accent = parseHex(CITY_COLORS.ground);
+  const accent = parseHex(accentHex);
   if (!base || !accent) return hex;
   const lum = (c) => 0.299 * c[0] + 0.587 * c[1] + 0.114 * c[2];
   const lb = lum(base);
@@ -314,8 +316,9 @@ export const tintTowardAccent = (hex, amount = 0.2) => {
 };
 
 // Convenience for the dark structural bases (building bodies, district plinths,
-// monument footings) — a slightly stronger tint than the default.
-export const tintStructure = (hex) => tintTowardAccent(hex, 0.22);
+// monument footings) — a slightly stronger tint than the default. The accent defaults
+// to the static brand; pass a themed accent (from useCityPalette().accent) to theme.
+export const tintStructure = (hex, accentHex = CITY_COLORS.ground) => tintTowardAccent(hex, 0.22, accentHex);
 
 // GLSL-style smoothstep with an edge remap (distinct from the plain Hermite
 // smoothstep(t) in utils/easing.js — different arity, kept local on purpose).
@@ -372,6 +375,16 @@ export const deriveCityPalette = (theme) => {
   // panels follow the light/dark theme independently (see .cybercity-themed CSS).
   const nightBackground = darkenHex(accent, 0.1);
   const dayBackground = lightenHex(accent, 0.72);
+
+  // Themed brand surfaces — recomputed from the theme accent each time, so switching
+  // back and forth never compounds. The lead neonAccents entry tracks the accent;
+  // the rest of the palette is the static decorative spread. The dark building body
+  // is re-tinted toward the accent (luminance preserved) so structures track the
+  // theme too, not just the neon surfaces. Status colors stay semantic.
+  const neonAccents = [accent, ...CITY_COLORS.neonAccents.slice(1)];
+  const building = { ...CITY_COLORS.building, online: accent };
+  const buildingBody = tintStructure(ORIGINAL_BUILDING_BODY, accent);
+
   return {
     themeId: theme?.id || 'classic-midnight',
     mode: theme?.mode || 'night',
@@ -382,22 +395,21 @@ export const deriveCityPalette = (theme) => {
     // Default surround by theme mode — used for the loading screen before settings resolve.
     background: isDay ? dayBackground : nightBackground,
     crt: deriveCrtProfile(theme?.family),
+    // Brand surfaces the 3D scene reads via useCityPalette() instead of the old
+    // mutated singleton. `ground`/`particles` are the accent; `building`/`buildingBody`/
+    // `neonAccents` carry the themed maps.
+    ground: accent,
+    particles: accent,
+    neonAccents,
+    building,
+    buildingBody,
+    // Helper functions pre-bound to this palette's accent/maps, so a consumer can call
+    // `palette.tintStructure(hex)` (no accent threading) and still track the theme. These
+    // are the themed equivalents of the bare module helpers, which default to the static
+    // cyan brand when called without a palette.
+    tintTowardAccent: (hex, amount = 0.2) => tintTowardAccent(hex, amount, accent),
+    tintStructure: (hex) => tintStructure(hex, accent),
+    getBuildingColor: (status, archived) => getBuildingColor(status, archived, building),
+    getAccentColor: (app) => getAccentColor(app, neonAccents),
   };
-};
-
-// Recolor the brand surfaces in-place from a derived palette. The city page calls
-// this when the theme changes and remounts the scene subtree (keyed on themeId)
-// so every component re-reads the singleton. Recomputes every brand surface from
-// the derived palette's accent (not from the previously-applied colors), so
-// repeated theme switches don't compound.
-export const applyCityBrandColors = (palette) => {
-  const accent = palette?.accent || ORIGINAL_GROUND;
-  CITY_COLORS.ground = accent;
-  CITY_COLORS.particles = accent;
-  CITY_COLORS.building.online = accent;
-  CITY_COLORS.neonAccents[0] = accent;
-  // Ground must be set first — tintStructure reads CITY_COLORS.ground. Re-tint the
-  // dark building body toward the accent (luminance preserved) so structures track
-  // the theme too, not just the neon brand surfaces.
-  CITY_COLORS.buildingBody = tintStructure(ORIGINAL_BUILDING_BODY);
 };

--- a/client/src/components/city/cityTheme.test.js
+++ b/client/src/components/city/cityTheme.test.js
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { deriveCityPalette, applyCityBrandColors, resolveCityTimeOfDay, cityLabelColors, tintTowardAccent, tintStructure, CITY_COLORS, getBuildingColor, seededRand, smoothstepRange, cityDayMix, getTimeOfDayPreset } from './cityConstants';
+import { describe, it, expect } from 'vitest';
+import { deriveCityPalette, resolveCityTimeOfDay, cityLabelColors, tintTowardAccent, tintStructure, CITY_COLORS, getBuildingColor, getAccentColor, seededRand, smoothstepRange, cityDayMix, getTimeOfDayPreset } from './cityConstants';
 
 const hexLum = (hex) => {
   const n = parseInt(hex.slice(1), 16);
@@ -146,15 +146,10 @@ describe('cityLabelColors', () => {
 });
 
 describe('tintTowardAccent / tintStructure', () => {
-  // These read the live CITY_COLORS.ground accent; set/restore it per test.
-  let savedGround;
-  beforeEach(() => { savedGround = CITY_COLORS.ground; });
-  afterEach(() => { CITY_COLORS.ground = savedGround; });
-
+  // These are now pure: the accent is passed in explicitly (no shared-singleton read).
   it('shifts hue toward the accent while preserving luminance', () => {
-    CITY_COLORS.ground = '#ff0000'; // pure red accent
     const base = '#0a0e16'; // a dark blue-dominant structural base
-    const out = tintStructure(base);
+    const out = tintStructure(base, '#ff0000'); // pure red accent
     // Luminance preserved within rounding — the base stays just as dark.
     expect(hexLum(out)).toBeCloseTo(hexLum(base), 0);
     // Hue pulled toward red: the red channel rises relative to the original.
@@ -162,68 +157,84 @@ describe('tintTowardAccent / tintStructure', () => {
   });
 
   it('leaves pure black untouched (no hue to tint)', () => {
-    CITY_COLORS.ground = '#22c55e';
-    expect(tintTowardAccent('#000000')).toBe('#000000');
+    expect(tintTowardAccent('#000000', 0.2, '#22c55e')).toBe('#000000');
   });
 
   it('is a no-op-ish identity when the accent equals the base hue direction', () => {
-    CITY_COLORS.ground = '#0a0e16';
     // Tinting toward itself preserves the color (luminance + channels unchanged).
-    expect(hexLum(tintStructure('#0a0e16'))).toBeCloseTo(hexLum('#0a0e16'), 0);
+    expect(hexLum(tintStructure('#0a0e16', '#0a0e16'))).toBeCloseTo(hexLum('#0a0e16'), 0);
   });
 
   it('returns the input unchanged for an unparseable color', () => {
-    CITY_COLORS.ground = '#22c55e';
-    expect(tintTowardAccent('not-a-hex')).toBe('not-a-hex');
+    expect(tintTowardAccent('not-a-hex', 0.2, '#22c55e')).toBe('not-a-hex');
+  });
+
+  it('defaults to the static cyan brand accent when none is passed', () => {
+    // The bare helper (no accent arg) tints toward the cyan brand default, so a
+    // consumer that hasn't wired the palette still gets a sensible result.
+    const out = tintStructure('#0a0e16');
+    expect(out).toMatch(/^#[0-9a-f]{6}$/);
+    expect(hexLum(out)).toBeCloseTo(hexLum('#0a0e16'), 0);
   });
 });
 
-describe('applyCityBrandColors', () => {
-  // Restore the cyan baseline after each test so mutation doesn't leak across the suite.
-  beforeEach(() => applyCityBrandColors(deriveCityPalette(undefined)));
-
-  it('recolors brand surfaces to the theme accent', () => {
-    applyCityBrandColors(deriveCityPalette(getTheme('black-ice-terminal-day')));
-    expect(CITY_COLORS.ground).toBe('#0a7a4a');
-    expect(CITY_COLORS.particles).toBe('#0a7a4a');
-    expect(CITY_COLORS.building.online).toBe('#0a7a4a');
-    expect(CITY_COLORS.neonAccents[0]).toBe('#0a7a4a');
-    // online buildings follow the recolor through the shared helper
-    expect(getBuildingColor('online')).toBe('#0a7a4a');
+describe('deriveCityPalette brand surfaces', () => {
+  it('carries themed brand surfaces derived from the accent', () => {
+    const p = deriveCityPalette(getTheme('black-ice-terminal-day'));
+    expect(p.ground).toBe('#0a7a4a');
+    expect(p.particles).toBe('#0a7a4a');
+    expect(p.building.online).toBe('#0a7a4a');
+    expect(p.neonAccents[0]).toBe('#0a7a4a');
+    // online buildings follow the recolor through the palette-bound helper
+    expect(p.getBuildingColor('online')).toBe('#0a7a4a');
   });
 
   it('leaves status colors untouched', () => {
-    applyCityBrandColors(deriveCityPalette(getTheme('black-ice-terminal-day')));
-    expect(CITY_COLORS.building.stopped).toBe('#ef4444');
-    expect(getBuildingColor('stopped')).toBe('#ef4444');
+    const p = deriveCityPalette(getTheme('black-ice-terminal-day'));
+    expect(p.building.stopped).toBe('#ef4444');
+    expect(p.getBuildingColor('stopped')).toBe('#ef4444');
     // not_found stays the canonical purple — the value ProcessBuilding now unifies to.
-    expect(CITY_COLORS.building.not_found).toBe('#8b5cf6');
+    expect(p.building.not_found).toBe('#8b5cf6');
   });
 
   it('re-tints the building body toward the accent, preserving its darkness', () => {
     const ORIGINAL_BODY = '#0c0c24';
-    applyCityBrandColors(deriveCityPalette(getTheme('black-ice-terminal-day'))); // green accent
-    const themed = CITY_COLORS.buildingBody;
-    expect(themed).not.toBe(ORIGINAL_BODY); // picked up the theme
-    expect(hexLum(themed)).toBeCloseTo(hexLum(ORIGINAL_BODY), 0); // still a dark body
+    const p = deriveCityPalette(getTheme('black-ice-terminal-day')); // green accent
+    expect(p.buildingBody).not.toBe(ORIGINAL_BODY); // picked up the theme
+    expect(hexLum(p.buildingBody)).toBeCloseTo(hexLum(ORIGINAL_BODY), 0); // still a dark body
   });
 
-  it('recomputes the building body from the original, not compounding across switches', () => {
-    applyCityBrandColors(deriveCityPalette(getTheme('black-ice-terminal-day')));
-    const greenBody = CITY_COLORS.buildingBody;
-    applyCityBrandColors(deriveCityPalette(getTheme('classic-midnight')));
-    const blueBody = CITY_COLORS.buildingBody;
-    // Switching back yields the same value — proof it recomputes from ORIGINAL_BUILDING_BODY.
-    applyCityBrandColors(deriveCityPalette(getTheme('black-ice-terminal-day')));
-    expect(CITY_COLORS.buildingBody).toBe(greenBody);
-    expect(blueBody).not.toBe(greenBody);
+  it('is pure — never mutates the shared CITY_COLORS singleton', () => {
+    deriveCityPalette(getTheme('black-ice-terminal-day'));
+    // The static table keeps its cyan baseline; only the returned palette is themed.
+    expect(CITY_COLORS.ground).toBe('#06b6d4');
+    expect(CITY_COLORS.building.online).toBe('#06b6d4');
+    expect(CITY_COLORS.neonAccents[0]).toBe('#06b6d4');
+    expect(CITY_COLORS.buildingBody).toBe('#0c0c24');
+    // The bare helper, reading no palette, still reports the static brand.
+    expect(getBuildingColor('online')).toBe('#06b6d4');
   });
 
-  it('recomputes from the cyan baseline rather than compounding across switches', () => {
-    applyCityBrandColors(deriveCityPalette(getTheme('black-ice-terminal-day')));
-    applyCityBrandColors(deriveCityPalette(getTheme('classic-midnight')));
-    // classic-midnight accent is 59 130 246 -> #3b82f6, not a blend of green+blue
-    expect(CITY_COLORS.ground).toBe('#3b82f6');
+  it('does not compound across repeated derivations — each is recomputed from the accent', () => {
+    const green = deriveCityPalette(getTheme('black-ice-terminal-day'));
+    deriveCityPalette(getTheme('classic-midnight'));
+    const greenAgain = deriveCityPalette(getTheme('black-ice-terminal-day'));
+    // classic-midnight accent is 59 130 246 -> #3b82f6, never a blend of green+blue.
+    expect(deriveCityPalette(getTheme('classic-midnight')).ground).toBe('#3b82f6');
+    // Re-deriving the green theme yields an identical body — proof it's recomputed
+    // from ORIGINAL_BUILDING_BODY, not from a previously-tinted value.
+    expect(greenAgain.buildingBody).toBe(green.buildingBody);
+  });
+
+  it('binds getAccentColor to the themed neon list', () => {
+    const p = deriveCityPalette(getTheme('black-ice-terminal-day'));
+    // The lead neon accent tracks the theme, so an app hashing to index 0 gets it.
+    expect(p.neonAccents[0]).toBe('#0a7a4a');
+    // Bound helper picks from the palette's list; the bare helper picks from the
+    // static list. Both are deterministic for a given app and stay in their list.
+    const app = { name: 'anything' };
+    expect(p.neonAccents).toContain(p.getAccentColor(app));
+    expect(CITY_COLORS.neonAccents).toContain(getAccentColor(app));
   });
 });
 

--- a/client/src/pages/CyberCity.jsx
+++ b/client/src/pages/CyberCity.jsx
@@ -17,7 +17,8 @@ import CitySettingsPanel from '../components/city/CitySettingsPanel';
 import { computeFilterResult } from '../utils/cityFilter';
 import { DEFAULT_PRESET_ID, cyclePreset } from '../utils/cityPhotoMode';
 import { computeSoundscape } from '../utils/citySoundscape';
-import { CITY_COLORS, deriveCityPalette, applyCityBrandColors, resolveCityTimeOfDay } from '../components/city/cityConstants';
+import { CITY_COLORS, deriveCityPalette, resolveCityTimeOfDay } from '../components/city/cityConstants';
+import { CityPaletteProvider } from '../components/city/CityPaletteContext';
 import { useThemeContext } from '../components/ThemeContext';
 
 function CyberCityInner() {
@@ -42,14 +43,10 @@ function CyberCityInner() {
   // `cybercity-themed` CSS scope (see index.css) and the 3D scene's brand colors
   // + surround are derived from the same theme here.
   const { theme: cityTheme } = useThemeContext();
-  const cityPalette = useMemo(() => {
-    const palette = deriveCityPalette(cityTheme);
-    // Recolor the shared CITY_COLORS singleton during render — before the scene
-    // children render — so the keyed remount below (key={cityPalette.themeId})
-    // reads fresh brand colors on a theme switch.
-    applyCityBrandColors(palette);
-    return palette;
-  }, [cityTheme]);
+  // Pure: derive the themed palette and hand it down through CityPaletteContext (and,
+  // inside <Canvas>, a second provider in CityScene since r3f's reconciler doesn't
+  // bridge context). No more during-render mutation of a shared singleton.
+  const cityPalette = useMemo(() => deriveCityPalette(cityTheme), [cityTheme]);
 
   // The city renders day or night, following the theme mode by default (see
   // resolveCityTimeOfDay). The resolved preset key is handed to the scene via a
@@ -321,9 +318,18 @@ function CyberCityInner() {
   }
 
   return (
+    <CityPaletteProvider palette={cityPalette}>
     <div className="relative w-full h-full cybercity-themed" style={{ background: sceneBackground, isolation: 'isolate' }}>
       <CityScene
+        // Remount the whole scene subtree on a theme switch so the ~8 components that
+        // cache themed neon colors in useMemo / GPU uniforms (CityGround, CitySky,
+        // CityBillboards, CityVolumetricLights, CityTraffic, CityLandscape, …) pick up
+        // the new palette. The during-render singleton mutation is gone; the remount
+        // remains as the (rare, user-initiated) refresh path. Threading the palette
+        // into every cached dep array + imperative uniform update is the separable,
+        // riskier half — tracked as a follow-up issue.
         key={cityPalette.themeId}
+        palette={cityPalette}
         background={sceneBackground}
         apps={v('apps', apps)}
         agentMap={v('agentMap', agentMap)}
@@ -410,6 +416,7 @@ function CyberCityInner() {
       <CityScanlines settings={settings} crt={cityPalette.crt} />
       {showSettings && <CitySettingsPanel />}
     </div>
+    </CityPaletteProvider>
   );
 }
 


### PR DESCRIPTION
Closes #909.

## What

CyberCity's themed brand surfaces (ground grid, particles, online buildings, lead neon accent, dark structural bases) used to track the active PortOS theme by **mutating a shared module-level `CITY_COLORS` singleton during render** (`applyCityBrandColors`), with a keyed full-scene remount to propagate. A during-render side-effect is fragile under React StrictMode's double-invoke and concurrent rendering.

This replaces that with:

- **`deriveCityPalette(theme)` is now pure** and returns an immutable palette carrying the themed brand maps (`ground`, `particles`, `neonAccents`, `building`, `buildingBody`) plus accent-bound helpers (`tintTowardAccent`, `tintStructure`, `getBuildingColor`, `getAccentColor`). The shared `CITY_COLORS` table is never mutated.
- **New `CityPaletteContext` + `useCityPalette()`** feeds every scene reader. It's provided **twice**: once in `CyberCityInner` for the DOM-side HUD/minimap, and again **inside `<Canvas>`** in `CityScene` — react-three-fiber runs its own reconciler, so React context doesn't cross that boundary (the same reason `settings` is prop-threaded today).
- The bare module helpers keep working unchanged for any non-themed caller — they default their accent argument to the static cyan brand.

## Deliberately retained + documented

The `key={palette.themeId}` full-scene remount stays. ~8 scene components cache themed neon colors in `useMemo` / GPU shader uniforms; the remount is the refresh path on a (rare, user-initiated) theme switch. **The fragility the issue cites — the during-render mutation — is gone.** Threading the palette into every cached dependency + imperative uniform updates is the separable, riskier, visually-untestable half, filed as follow-up **#1064** (`plan` + `future`).

## Tests

- `cityTheme.test.js` updated for the new immutable API (the old `applyCityBrandColors` mutation suite became a `deriveCityPalette brand surfaces` suite, incl. a "never mutates the singleton" assertion). **32/32 pass.**
- Lint clean (0 errors), client build succeeds — verifies all 27 changed files' imports resolve.