### PR TITLE
refactor([issue-1064]): recolor CyberCity in place, drop themeId remount

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -12,3 +12,4 @@
 - **[issue-1060] Cleaner test runs** — browser-dependent tests now run only under their own test environment, so the server test run no longer reports spurious failures from double-running them.
 - **[issue-1050] More reliable database exports** — manual database exports now pick a PostgreSQL dump tool that matches the database being exported, so an export no longer fails on machines with several Postgres versions installed.
 - **[issue-909] CyberCity theme colors** — internal refactor of how the 3D city picks up your theme accent, replacing a fragile shared-state mechanism with a cleaner one; no change to how the city looks.
+- **[issue-1064] Smoother CyberCity theme switching** — changing your theme now recolors the 3D city in place instead of rebuilding the whole scene, so the switch is seamless with no rebuild flash or blank frame.

--- a/client/src/components/city/CityBillboards.jsx
+++ b/client/src/components/city/CityBillboards.jsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo } from 'react';
+import { useRef, useMemo, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { Text } from '@react-three/drei';
 import * as THREE from 'three';
@@ -51,6 +51,14 @@ function Billboard({ position, rotation, messages, color, width = 3.5, height = 
   const displayLabel = useRef(messages[0]?.label || '');
 
   const colorVec = useMemo(() => new THREE.Color(color), [color]);
+
+  // The scan-overlay shader material persists across a theme switch (no more full-scene
+  // remount), so push the new accent into its uColor uniform imperatively — the inline
+  // `uniforms` object isn't re-uploaded to an already-built material on re-render. The
+  // other billboard surfaces use declarative `color={color}` props, which R3F reconciles.
+  useEffect(() => {
+    if (scanRef.current) scanRef.current.uniforms.uColor.value.copy(colorVec);
+  }, [colorVec]);
 
   useFrame(({ clock }) => {
     if (!groupRef.current) return;

--- a/client/src/components/city/CityVolumetricLights.jsx
+++ b/client/src/components/city/CityVolumetricLights.jsx
@@ -1,4 +1,4 @@
-import { useRef, useMemo } from 'react';
+import { useRef, useMemo, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { cityDayMix } from './cityConstants';
@@ -52,6 +52,16 @@ function LightBeam({ position, color, height = 15, radius = 2, intensity = 1, ph
   });
 
   const colorVec = useMemo(() => new THREE.Color(color), [color]);
+
+  // The shader material persists across a theme switch (no more full-scene remount),
+  // so push the new accent/intensity into its uniforms imperatively — re-rendering
+  // with a new `uniforms` object does not re-upload them to an already-built material.
+  useEffect(() => {
+    const mat = matRef.current;
+    if (!mat) return;
+    mat.uniforms.uColor.value.copy(colorVec);
+    mat.uniforms.uIntensity.value = intensity;
+  }, [colorVec, intensity]);
 
   return (
     <group position={position}>

--- a/client/src/pages/CyberCity.jsx
+++ b/client/src/pages/CyberCity.jsx
@@ -321,14 +321,15 @@ function CyberCityInner() {
     <CityPaletteProvider palette={cityPalette}>
     <div className="relative w-full h-full cybercity-themed" style={{ background: sceneBackground, isolation: 'isolate' }}>
       <CityScene
-        // Remount the whole scene subtree on a theme switch so the ~8 components that
-        // cache themed neon colors in useMemo / GPU uniforms (CityGround, CitySky,
-        // CityBillboards, CityVolumetricLights, CityTraffic, CityLandscape, …) pick up
-        // the new palette. The during-render singleton mutation is gone; the remount
-        // remains as the (rare, user-initiated) refresh path. Threading the palette
-        // into every cached dep array + imperative uniform update is the separable,
-        // riskier half — tracked as a follow-up issue.
-        key={cityPalette.themeId}
+        // A theme switch recolors the live scene in place — NO full-scene remount.
+        // Every themed surface either reads the palette fresh each render (declarative
+        // `color=` props, palette helper fns) or carries the palette value in its
+        // useMemo deps so it rebuilds on a new palette object (CityGround, CityLandscape,
+        // CityTraffic, CityNeonSigns, …). The two persistent GPU shader materials whose
+        // uniforms are set once at construction (CityBillboards scan overlay,
+        // CityVolumetricLights cones) push the new accent into their uColor uniform
+        // imperatively, mirroring CitySky's per-frame uniform updates. Dropping the old
+        // `key={cityPalette.themeId}` avoids the jarring full-scene rebuild flash.
         palette={cityPalette}
         background={sceneBackground}
         apps={v('apps', apps)}


### PR DESCRIPTION
Closes #1064.

Follow-up to #909 (CityPalette context refactor). #909 removed the during-render `CITY_COLORS` singleton mutation but **retained** the `key={cityPalette.themeId}` full-scene remount on `<CityScene>` as the theme-switch refresh path. This PR removes that remount so a theme switch recolors the live scene in place — no rebuild flash.

## What changed
- **CyberCity.jsx** — dropped `key={cityPalette.themeId}` from `<CityScene>`; rewrote the comment to document the live-recolor contract.
- **CityVolumetricLights.jsx** — the cone `ShaderMaterial` persists across a theme switch, so a `useEffect` imperatively syncs `uColor` (and `uIntensity`, which also fixes a latent day/night staleness) when they change. Re-rendering with a new inline `uniforms` object does not re-upload to an already-built material.
- **CityBillboards.jsx** — same imperative `uColor` sync for the scan-overlay shader.

## Why only these two
Every other themed surface already recolors live (verified by independent review): declarative `color={...}` props that R3F reconciles, palette helper closures (`tintStructure`, `getBuildingColor`) rebound to the new accent each switch, or `useMemo` deps that already carry `accent`/`neonAccents` (done in #909). The only stale survivors were the two persistent shader materials whose `uColor` was set once at construction — fixed here by mirroring CitySky's imperative-uniform pattern.

## Testing
- `cd client && npx vitest run src/components/city/` → 39 passed
- `npm run build` → clean
- The recolor itself is GPU/visual (untestable by unit tests — the reason it was split out of #909). Verified the logic via an independent review pass: `uColor.value.copy()` is a uniform *value* mutation that re-uploads without `needsUpdate`; no child relies on the remount for non-color reasons.