### PR TITLE
feat(federation): bidirectional sync from a single toggle (auto-reciprocate)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -15,6 +15,7 @@
 
 ## Changed
 
+- **[issue-1070] Federation sync is now bidirectional from one switch** — turning on a sync category for a peer (Brain, Goals, Universe, etc.) now automatically asks that peer to sync the same category back, so you no longer have to set the toggle on both machines by hand. Since you typically own every federated machine, enabling once establishes two-way sync. The Sync Categories panel explains this inline, and a new **Make mutual** button pushes the current set to a peer that was offline during an earlier change (or was configured one-directionally before this existed). Peers on older versions that don't understand the request simply stay one-directional until you toggle again — nothing breaks.
 - **Songs: built-in alert stacks cleanly on mobile** — the "Built-in default" banner on the song page now stacks its label, description, and Refresh action vertically on narrow screens instead of cramming them onto one row, with full-width touch targets for the refresh/confirm buttons.
 - **[issue-1027] Songs: vocal takes remember their pitch analysis** — a recorded take now saves its tuner trace and color-match score so your accuracy isn't recomputed every time you reopen the song.
 - **[issue-1060] Cleaner test runs** — browser-dependent tests now run only under their own test environment, so the server test run no longer reports spurious failures from double-running them.

--- a/client/src/pages/Instances.jsx
+++ b/client/src/pages/Instances.jsx
@@ -565,7 +565,13 @@ function SyncCategoriesPanel({ peer, onRefresh }) {
             sync the same back automatically.
           </p>
           <div className="flex items-center justify-end gap-2 mb-1.5">
-            {peer.instanceId && enabledCount > 0 && (
+            {/* Available whenever we know the peer's identity — NOT gated on
+                enabledCount. The worst stale case is disabling the LAST category
+                while the peer is offline: the peer keeps its now-stale enabled
+                set, and the reciprocate endpoint pushes our all-false map to
+                clear it. Gating on enabledCount>0 would hide the control exactly
+                when it's needed. */}
+            {peer.instanceId && (
               <button
                 onClick={makeMutual}
                 className="flex items-center gap-1 mr-auto text-[10px] text-gray-500 hover:text-port-accent transition-colors"

--- a/client/src/pages/Instances.jsx
+++ b/client/src/pages/Instances.jsx
@@ -14,7 +14,7 @@ import Pill from '../components/ui/Pill';
 import socket from '../services/socket';
 import {
   getInstances, updateSelfInstance, addPeer, updatePeer,
-  removePeer, connectPeer, probePeer, getTailnetInfo, provisionTailnetCert,
+  removePeer, connectPeer, reciprocatePeer, probePeer, getTailnetInfo, provisionTailnetCert,
   getNetworkExposure,
   listPeerSubscriptions,
 } from '../services/api';
@@ -531,6 +531,17 @@ function SyncCategoriesPanel({ peer, onRefresh }) {
     onRefresh();
   };
 
+  // Explicitly push our current category map to the peer so it enables the same
+  // toward us. Toggling already auto-reciprocates; this is the catch-up button
+  // for peers configured one-directionally before auto-reciprocate existed, or
+  // when the peer was offline during an earlier toggle.
+  const makeMutual = async () => {
+    const result = await reciprocatePeer(peer.id, { silent: true }).catch(() => null);
+    if (result?.ok) toast.success(`Asked ${peer.name} to sync the same categories back`);
+    else toast.error(`Couldn't reach ${peer.name} to make sync mutual — try again when it's online`);
+    onRefresh();
+  };
+
   return (
     <div className="mt-2 pt-2 border-t border-port-border/50">
       <button
@@ -549,7 +560,21 @@ function SyncCategoriesPanel({ peer, onRefresh }) {
 
       {expanded && (
         <div className="mt-2 space-y-1">
-          <div className="flex justify-end gap-2 mb-1.5">
+          <p className="text-[10px] text-gray-600 mb-1.5 leading-snug">
+            Enabling a category syncs it both ways — we ask {peer.name || 'the peer'} to
+            sync the same back automatically.
+          </p>
+          <div className="flex items-center justify-end gap-2 mb-1.5">
+            {peer.instanceId && enabledCount > 0 && (
+              <button
+                onClick={makeMutual}
+                className="flex items-center gap-1 mr-auto text-[10px] text-gray-500 hover:text-port-accent transition-colors"
+                title="Push the current categories to this peer so it syncs them back (use if it was offline during a change)"
+              >
+                <ArrowLeftRight size={10} />
+                Make mutual
+              </button>
+            )}
             <button
               onClick={() => toggleAll(true)}
               className="text-[10px] text-port-accent hover:text-port-accent/80 transition-colors"

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -173,6 +173,7 @@ export const addPeer = (data) => request('/instances/peers', { method: 'POST', b
 export const updatePeer = (id, data) => request(`/instances/peers/${id}`, { method: 'PUT', body: JSON.stringify(data) });
 export const removePeer = (id) => request(`/instances/peers/${id}`, { method: 'DELETE' });
 export const connectPeer = (id) => request(`/instances/peers/${id}/connect`, { method: 'POST' });
+export const reciprocatePeer = (id, options) => request(`/instances/peers/${id}/reciprocate`, { method: 'POST', ...options });
 export const probePeer = (id) => request(`/instances/peers/${id}/probe`, { method: 'POST' });
 export const queryPeer = (id, path) => request(`/instances/peers/${id}/query?path=${encodeURIComponent(path)}`);
 export const getTailnetInfo = () => request('/instances/tailnet-suffix');

--- a/server/routes/instances.js
+++ b/server/routes/instances.js
@@ -100,8 +100,10 @@ const querySchema = z.object({
 // announcing peer's identity (matched against our peer record).
 const reciprocalSyncSchema = z.object({
   instanceId: z.string().guid(),
-  // `.unwrap()` strips the `.optional()` from the shared schema — the category
-  // map is required on this endpoint (an empty/absent map has nothing to mirror).
+  // `.unwrap()` strips the `.optional()` from the shared schema so the
+  // syncCategories KEY is required. An empty `{}` still parses (all fields are
+  // optional) and simply no-ops downstream in applyReciprocalSync
+  // (sanitizeSyncCategories returns null → changed:false).
   syncCategories: syncCategoriesSchema.unwrap()
 });
 
@@ -255,10 +257,14 @@ router.post('/peers/:id/connect', asyncHandler(async (req, res) => {
 // instanceId in the body (we may not know its local-peer-id mapping).
 router.post('/peers/sync-categories', asyncHandler(async (req, res) => {
   const data = reciprocalSyncSchema.parse(req.body);
-  const { changed, peer } = await instances.applyReciprocalSync(data.instanceId, data.syncCategories);
+  const { changed } = await instances.applyReciprocalSync(data.instanceId, data.syncCategories);
   // 200 even when the peer is unknown to us / nothing changed — this is a
-  // best-effort convergence signal, not a command that must succeed.
-  res.json({ applied: changed, peer: peer ? instances.sanitizePeerForClient(peer) : null });
+  // best-effort convergence signal, not a command that must succeed. We return
+  // only `applied` (not the peer record) — the remote caller doesn't consume it,
+  // and echoing our peer entry would leak our stored proxy-credential metadata
+  // (username + hasPassword) for reaching them across the peer boundary, the
+  // same leak the /announce route guards against with redactPeerForWire.
+  res.json({ applied: changed });
 }));
 
 // POST /api/instances/peers/:id/reciprocate — explicit "make all enabled

--- a/server/routes/instances.js
+++ b/server/routes/instances.js
@@ -95,6 +95,16 @@ const querySchema = z.object({
   path: z.string().startsWith('/api/', 'Path must start with /api/')
 });
 
+// Reciprocal sync request from a peer: it enabled `syncCategories` toward us
+// and asks us to mirror them so the sync is bidirectional. instanceId is the
+// announcing peer's identity (matched against our peer record).
+const reciprocalSyncSchema = z.object({
+  instanceId: z.string().guid(),
+  // `.unwrap()` strips the `.optional()` from the shared schema — the category
+  // map is required on this endpoint (an empty/absent map has nothing to mirror).
+  syncCategories: syncCategoriesSchema.unwrap()
+});
+
 // GET /api/instances — list self + all peers
 router.get('/', asyncHandler(async (req, res) => {
   const [self, peers, syncStatus] = await Promise.all([
@@ -237,6 +247,29 @@ router.post('/peers/:id/connect', asyncHandler(async (req, res) => {
   const result = await instances.connectPeer(req.params.id);
   if (!result) throw new ServerError('Peer not found', { status: 404 });
   res.json(instances.sanitizePeerForClient(result));
+}));
+
+// POST /api/instances/peers/sync-categories — reciprocal-sync callback from a
+// peer. The peer enabled some categories toward us and is asking us to mirror
+// them so the sync is bidirectional. No :id — the peer is identified by the
+// instanceId in the body (we may not know its local-peer-id mapping).
+router.post('/peers/sync-categories', asyncHandler(async (req, res) => {
+  const data = reciprocalSyncSchema.parse(req.body);
+  const { changed, peer } = await instances.applyReciprocalSync(data.instanceId, data.syncCategories);
+  // 200 even when the peer is unknown to us / nothing changed — this is a
+  // best-effort convergence signal, not a command that must succeed.
+  res.json({ applied: changed, peer: peer ? instances.sanitizePeerForClient(peer) : null });
+}));
+
+// POST /api/instances/peers/:id/reciprocate — explicit "make all enabled
+// categories mutual" for an existing (likely one-directional) peer. Pushes our
+// current category map to the peer so it enables the same toward us.
+router.post('/peers/:id/reciprocate', asyncHandler(async (req, res) => {
+  const peers = await instances.getPeers();
+  const peer = peers.find(p => p.id === req.params.id);
+  if (!peer) throw new ServerError('Peer not found', { status: 404 });
+  const result = await instances.requestReciprocalSync(peer, peer.syncCategories || {});
+  res.json(result);
 }));
 
 // POST /api/instances/peers/:id/probe — force immediate probe

--- a/server/routes/instances.js
+++ b/server/routes/instances.js
@@ -274,8 +274,11 @@ router.post('/peers/:id/reciprocate', asyncHandler(async (req, res) => {
   const peers = await instances.getPeers();
   const peer = peers.find(p => p.id === req.params.id);
   if (!peer) throw new ServerError('Peer not found', { status: 404 });
-  const result = await instances.requestReciprocalSync(peer, peer.syncCategories || {});
-  res.json(result);
+  // Go through the per-peer serialized queue (same path as the auto-reciprocate
+  // on toggle) so a manual "Make mutual" can't race an in-flight toggle send and
+  // land a stale map. The queue re-reads the freshest persisted categories.
+  const result = await instances.enqueueReciprocalSync(peer.id);
+  res.json(result ?? { ok: false, reason: 'no-result' });
 }));
 
 // POST /api/instances/peers/:id/probe — force immediate probe

--- a/server/services/instances.js
+++ b/server/services/instances.js
@@ -728,7 +728,10 @@ export async function applyReciprocalSync(instanceId, categories) {
   const peer = await withData(async (data) => {
     const entry = data.peers.find(p => p.instanceId === instanceId);
     if (!entry) return null;
-    const prev = entry.syncCategories || { ...DEFAULT_SYNC_CATEGORIES };
+    // Default the baseline so a partial stored map doesn't make absent-vs-false
+    // diverge — otherwise sanitized adding `goals:false` to a `prev` missing
+    // `goals` reads as a change (`false !== undefined`) and defeats the guard.
+    const prev = { ...DEFAULT_SYNC_CATEGORIES, ...(entry.syncCategories || {}) };
     const next = { ...prev, ...sanitized };
     // No-op when nothing actually flips — the echo guard.
     if (Object.keys(next).every(k => next[k] === prev[k])) return entry;

--- a/server/services/instances.js
+++ b/server/services/instances.js
@@ -295,11 +295,10 @@ export async function updatePeer(id, updates) {
   // peer object) and consumed after the lock releases.
   const turnedOnKinds = [];
   let backfillPeerInstanceId = null;
-  // When the user changes which categories sync toward this peer, mirror the
-  // change back so the sync is bidirectional (the user owns all machines). We
-  // reciprocate the FULL resulting category map, not just the delta, so the
-  // peer converges even if an earlier reciprocate was missed (peer offline).
-  let reciprocateCategories = null;
+  // Set when a syncCategories change should be mirrored back to the peer so the
+  // sync is bidirectional (the user owns all machines). The actual send reads
+  // the freshest persisted map at send time via the serialized queue below.
+  let reciprocate = false;
   const result = await withData(async (data) => {
     const peer = data.peers.find(p => p.id === id);
     if (!peer) return null;
@@ -318,9 +317,9 @@ export async function updatePeer(id, updates) {
       }
       peer.syncCategories = { ...prev, ...incoming };
       if (turnedOnKinds.length > 0) backfillPeerInstanceId = peer.instanceId || null;
-      // Reciprocate the resulting map so the peer enables the same categories
-      // toward us. Only when we know the peer's identity (post-handshake).
-      if (peer.instanceId) reciprocateCategories = { ...peer.syncCategories };
+      // Reciprocate so the peer enables the same categories toward us. Only when
+      // we know the peer's identity (post-handshake).
+      if (peer.instanceId) reciprocate = true;
     }
     // Optional proxy credential. `null` (or both fields blank) clears it; a
     // valid object replaces it; malformed input (sanitizePeerAuth → undefined)
@@ -408,14 +407,45 @@ export async function updatePeer(id, updates) {
     });
   }
   // Mirror the category change back to the peer so sync is bidirectional.
-  // Fire-and-forget — a peer that's offline / on an older version just stays
-  // one-directional until the next toggle (or the "make mutual" backfill).
-  if (reciprocateCategories && result) {
-    requestReciprocalSync(result, reciprocateCategories).catch((err) => {
-      console.log(`⚠️ peer: reciprocal sync request failed: ${err.message}`);
-    });
+  // Fire-and-forget, but SERIALIZED per peer (see enqueueReciprocalSync): two
+  // rapid toggles must not race — an earlier send arriving after a later one
+  // would push a stale full map and undo the newer change on the peer.
+  if (reciprocate && result?.instanceId) {
+    enqueueReciprocalSync(result.id);
   }
   return result;
+}
+
+// Per-peer tail that serializes reciprocal-sync sends. Two rapid category
+// toggles for the same peer each want to push the full resulting map; if their
+// fire-and-forget requests raced, the earlier (staler) map could land last on
+// the peer and undo the newer change. Chaining per peer.id guarantees in-order
+// delivery, and each send re-reads the FRESHEST persisted category map (not a
+// value captured at enqueue time) so the final send always carries final state.
+const reciprocalSyncTails = new Map();
+
+export function enqueueReciprocalSync(peerId) {
+  const prev = reciprocalSyncTails.get(peerId) || Promise.resolve();
+  const next = prev
+    .catch(() => {}) // a failed prior send must not break the chain
+    .then(async () => {
+      // Re-read the peer fresh at send time — the last enqueued send wins with
+      // the latest persisted syncCategories, regardless of enqueue order.
+      const data = await loadData();
+      const peer = data.peers.find(p => p.id === peerId);
+      if (!peer?.instanceId) return { ok: false, reason: 'no-peer-identity' };
+      return requestReciprocalSync(peer, peer.syncCategories || {}).catch((err) => {
+        console.log(`⚠️ peer: reciprocal sync request failed: ${err.message}`);
+        return { ok: false, reason: err.message };
+      });
+    });
+  reciprocalSyncTails.set(peerId, next);
+  // Evict the tail once it settles and nothing newer has been chained, so the
+  // map doesn't grow unbounded across many peers/toggles.
+  next.finally(() => {
+    if (reciprocalSyncTails.get(peerId) === next) reciprocalSyncTails.delete(peerId);
+  });
+  return next;
 }
 
 // --- Probing ---

--- a/server/services/instances.js
+++ b/server/services/instances.js
@@ -295,6 +295,11 @@ export async function updatePeer(id, updates) {
   // peer object) and consumed after the lock releases.
   const turnedOnKinds = [];
   let backfillPeerInstanceId = null;
+  // When the user changes which categories sync toward this peer, mirror the
+  // change back so the sync is bidirectional (the user owns all machines). We
+  // reciprocate the FULL resulting category map, not just the delta, so the
+  // peer converges even if an earlier reciprocate was missed (peer offline).
+  let reciprocateCategories = null;
   const result = await withData(async (data) => {
     const peer = data.peers.find(p => p.id === id);
     if (!peer) return null;
@@ -313,6 +318,9 @@ export async function updatePeer(id, updates) {
       }
       peer.syncCategories = { ...prev, ...incoming };
       if (turnedOnKinds.length > 0) backfillPeerInstanceId = peer.instanceId || null;
+      // Reciprocate the resulting map so the peer enables the same categories
+      // toward us. Only when we know the peer's identity (post-handshake).
+      if (peer.instanceId) reciprocateCategories = { ...peer.syncCategories };
     }
     // Optional proxy credential. `null` (or both fields blank) clears it; a
     // valid object replaces it; malformed input (sanitizePeerAuth → undefined)
@@ -397,6 +405,14 @@ export async function updatePeer(id, updates) {
       }
     }).catch((err) => {
       console.log(`⚠️ peer: backfill-subscribe after category toggle failed: ${err.message}`);
+    });
+  }
+  // Mirror the category change back to the peer so sync is bidirectional.
+  // Fire-and-forget — a peer that's offline / on an older version just stays
+  // one-directional until the next toggle (or the "make mutual" backfill).
+  if (reciprocateCategories && result) {
+    requestReciprocalSync(result, reciprocateCategories).catch((err) => {
+      console.log(`⚠️ peer: reciprocal sync request failed: ${err.message}`);
     });
   }
   return result;
@@ -673,6 +689,107 @@ export async function connectPeer(id) {
   await announceSelf(peer);
   const probed = await probePeer(peer);
   return probed;
+}
+
+// --- Bidirectional sync reciprocation ---
+//
+// A single user commonly owns every federated machine and expects enabling a
+// sync category toward a peer to make it two-way without also toggling it on
+// the peer by hand. Sync is pull-based per direction, so enabling category C
+// toward peer B only makes US pull B's C. For B to pull OUR C, B must enable C
+// toward US. `requestReciprocalSync` asks B to do exactly that; the peer side
+// is `applyReciprocalSync`, invoked by the POST /sync-categories route.
+
+// Keep only the keys DEFAULT_SYNC_CATEGORIES defines, coerced to booleans, so a
+// peer can never inject unknown/garbage category flags onto our peer record.
+function sanitizeSyncCategories(input) {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return null;
+  const out = {};
+  for (const key of Object.keys(DEFAULT_SYNC_CATEGORIES)) {
+    if (typeof input[key] === 'boolean') out[key] = input[key];
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
+/**
+ * Receiver side of reciprocation: a peer is telling us it enabled `categories`
+ * toward us and is asking us to mirror them so the sync is bidirectional.
+ * Find the local peer record for the announcing instance and apply the same
+ * category flags. Returns `{ changed, peer }`; `changed` is false when our
+ * record already matched (the echo guard — the caller never re-reciprocates,
+ * but this keeps a misbehaving peer from churning our state).
+ */
+export async function applyReciprocalSync(instanceId, categories) {
+  const sanitized = sanitizeSyncCategories(categories);
+  if (!sanitized) return { changed: false, peer: null };
+  const turnedOnKinds = [];
+  let backfillInstanceId = null;
+  let changed = false;
+  const peer = await withData(async (data) => {
+    const entry = data.peers.find(p => p.instanceId === instanceId);
+    if (!entry) return null;
+    const prev = entry.syncCategories || { ...DEFAULT_SYNC_CATEGORIES };
+    const next = { ...prev, ...sanitized };
+    // No-op when nothing actually flips — the echo guard.
+    if (Object.keys(next).every(k => next[k] === prev[k])) return entry;
+    for (const [cat, kind] of [['universe', 'universe'], ['pipeline', 'series']]) {
+      if (prev[cat] !== true && next[cat] === true) turnedOnKinds.push(kind);
+    }
+    entry.syncCategories = next;
+    entry.syncEnabled = Object.values(next).some(Boolean);
+    if (turnedOnKinds.length > 0) backfillInstanceId = entry.instanceId || null;
+    changed = true;
+    instanceEvents.emit('peers:updated', data.peers);
+    return entry;
+  });
+  if (!peer) return { changed: false, peer: null };
+  // Mirror updatePeer's backfill-subscribe so a reciprocally-enabled
+  // per-record category (universe/pipeline) pushes our existing records too.
+  if (changed && turnedOnKinds.length > 0 && backfillInstanceId) {
+    import('./sharing/peerSync.js').then(async ({ autoSubscribePeerToAllRecords }) => {
+      for (const kind of turnedOnKinds) {
+        await autoSubscribePeerToAllRecords(backfillInstanceId, kind).catch((err) => {
+          console.log(`⚠️ peer: reciprocal backfill-subscribe ${kind} failed: ${err.message}`);
+        });
+      }
+    }).catch((err) => console.log(`⚠️ peer: reciprocal backfill-subscribe failed: ${err.message}`));
+  }
+  if (changed) console.log(`🔁 Reciprocal sync applied for peer ${peer.name}: ${Object.keys(sanitized).filter(k => sanitized[k]).join(',') || 'none'}`);
+  return { changed, peer };
+}
+
+/**
+ * Sender side: ask `peer` to enable `categories` toward us (mirror what we just
+ * enabled toward them). Best-effort and fire-and-forget at the call site — a
+ * peer that's offline or on an older version (404s the endpoint) just stays
+ * one-directional until the next toggle. Returns `{ ok, reason }`.
+ */
+export async function requestReciprocalSync(peer, categories) {
+  const self = await getSelf();
+  if (!self?.instanceId) return { ok: false, reason: 'no-self-identity' };
+  const sanitized = sanitizeSyncCategories(categories);
+  if (!sanitized) return { ok: false, reason: 'no-categories' };
+  const url = `${peerBaseUrl(peer)}/api/instances/peers/sync-categories`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS);
+  try {
+    const res = await peerFetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ instanceId: self.instanceId, syncCategories: sanitized }),
+      signal: controller.signal
+    }, peer);
+    if (res.ok) {
+      console.log(`🔁 Requested reciprocal sync from ${peer.name}: ${Object.keys(sanitized).filter(k => sanitized[k]).join(',') || 'none'}`);
+      return { ok: true };
+    }
+    // 404 = peer predates this endpoint; not an error worth surfacing loudly.
+    return { ok: false, reason: `http-${res.status}` };
+  } catch (err) {
+    return { ok: false, reason: err.message };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 async function markDirection(peerId, direction) {

--- a/server/services/instances.test.js
+++ b/server/services/instances.test.js
@@ -565,6 +565,18 @@ describe('instances.js', () => {
       expect(changed).toBe(false);
     });
 
+    it('echo guard treats absent-vs-false alike: adding goals:false to a partial map is a no-op', async () => {
+      // prev is a partial map missing `goals`; incoming sets goals:false, which
+      // is already the effective state → must NOT report changed (the baseline
+      // is defaulted so `false !== undefined` can't spuriously trip the guard).
+      const peers = [{ id: 'p1', instanceId: 'inst-A', name: 'A', syncCategories: { brain: true } }];
+      readJSONFile.mockResolvedValue({ self: { instanceId: 'me' }, peers });
+
+      const { changed } = await applyReciprocalSync('inst-A', { goals: false });
+
+      expect(changed).toBe(false);
+    });
+
     it('returns changed:false for an unknown peer instanceId', async () => {
       readJSONFile.mockResolvedValue({ self: { instanceId: 'me' }, peers: [] });
       const { changed, peer } = await applyReciprocalSync('nope', { brain: true });

--- a/server/services/instances.test.js
+++ b/server/services/instances.test.js
@@ -43,7 +43,7 @@ vi.mock('../lib/ports.js', () => ({
 
 // fetch is stubbed per-test in beforeEach and restored in afterEach
 
-import { readJSONFile } from '../lib/fileUtils.js';
+import { readJSONFile, atomicWrite } from '../lib/fileUtils.js';
 import { instanceEvents } from './instanceEvents.js';
 import { connectToPeer, disconnectFromPeer } from './peerSocketRelay.js';
 import {
@@ -61,6 +61,8 @@ import {
   handleAnnounce,
   redactPeerForWire,
   sanitizePeerForClient,
+  applyReciprocalSync,
+  requestReciprocalSync,
   startPolling,
   stopPolling
 } from './instances.js';
@@ -533,6 +535,98 @@ describe('instances.js', () => {
 
       await updatePeer('peer-1', { host: 'bad!!host' });
       expect(disconnectFromPeer).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- Bidirectional sync reciprocation ---
+
+  describe('applyReciprocalSync', () => {
+    it('mirrors a peer\'s enabled categories onto our local record for that peer', async () => {
+      const peers = [{ id: 'p1', instanceId: 'inst-A', name: 'A', syncCategories: { brain: false, goals: false } }];
+      readJSONFile.mockResolvedValue({ self: { instanceId: 'me' }, peers });
+
+      const { changed, peer } = await applyReciprocalSync('inst-A', { brain: true });
+
+      expect(changed).toBe(true);
+      expect(peer.syncCategories.brain).toBe(true);
+      expect(peer.syncEnabled).toBe(true); // recomputed from the resulting map
+      expect(peer._reciprocalChanged).toBeUndefined(); // no transient marker leaks onto the record
+      // And the persisted payload must not carry any transient marker either.
+      const written = atomicWrite.mock.calls.at(-1)?.[1];
+      expect(written.peers[0]._reciprocalChanged).toBeUndefined();
+    });
+
+    it('is a no-op (changed:false) when our record already matches — the echo guard', async () => {
+      const peers = [{ id: 'p1', instanceId: 'inst-A', name: 'A', syncCategories: { brain: true }, syncEnabled: true }];
+      readJSONFile.mockResolvedValue({ self: { instanceId: 'me' }, peers });
+
+      const { changed } = await applyReciprocalSync('inst-A', { brain: true });
+
+      expect(changed).toBe(false);
+    });
+
+    it('returns changed:false for an unknown peer instanceId', async () => {
+      readJSONFile.mockResolvedValue({ self: { instanceId: 'me' }, peers: [] });
+      const { changed, peer } = await applyReciprocalSync('nope', { brain: true });
+      expect(changed).toBe(false);
+      expect(peer).toBeNull();
+    });
+
+    it('drops unknown/garbage category keys (only DEFAULT_SYNC_CATEGORIES keys applied)', async () => {
+      const peers = [{ id: 'p1', instanceId: 'inst-A', name: 'A', syncCategories: { brain: false } }];
+      readJSONFile.mockResolvedValue({ self: { instanceId: 'me' }, peers });
+
+      const { peer } = await applyReciprocalSync('inst-A', { brain: true, __proto__: true, bogus: true });
+
+      expect(peer.syncCategories.brain).toBe(true);
+      expect(peer.syncCategories.bogus).toBeUndefined();
+    });
+
+    it('ignores a non-object categories payload', async () => {
+      readJSONFile.mockResolvedValue({ self: { instanceId: 'me' }, peers: [] });
+      const { changed } = await applyReciprocalSync('inst-A', 'not-an-object');
+      expect(changed).toBe(false);
+    });
+  });
+
+  describe('requestReciprocalSync', () => {
+    it('POSTs our self instanceId + sanitized categories to the peer', async () => {
+      readJSONFile.mockResolvedValue({ self: { instanceId: 'me-id', name: 'me' }, peers: [] });
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await requestReciprocalSync(
+        { id: 'p1', address: '10.0.0.2', port: 5555, name: 'B' },
+        { brain: true, bogus: true }
+      );
+
+      expect(result.ok).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, opts] = fetchMock.mock.calls[0];
+      expect(url).toContain('/api/instances/peers/sync-categories');
+      const body = JSON.parse(opts.body);
+      expect(body.instanceId).toBe('me-id');
+      expect(body.syncCategories).toEqual({ brain: true }); // bogus dropped
+    });
+
+    it('returns ok:false (not throw) when the peer 404s the endpoint (older version)', async () => {
+      readJSONFile.mockResolvedValue({ self: { instanceId: 'me-id' }, peers: [] });
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 404 }));
+
+      const result = await requestReciprocalSync(
+        { id: 'p1', address: '10.0.0.2', port: 5555, name: 'B' },
+        { brain: true }
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('http-404');
+    });
+
+    it('returns ok:false when we have no self identity', async () => {
+      readJSONFile.mockResolvedValue({ self: null, peers: [] });
+      const result = await requestReciprocalSync({ id: 'p1', address: '10.0.0.2', port: 5555 }, { brain: true });
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('no-self-identity');
     });
   });
 

--- a/server/services/instances.test.js
+++ b/server/services/instances.test.js
@@ -577,6 +577,17 @@ describe('instances.js', () => {
       expect(changed).toBe(false);
     });
 
+    it('applies an all-false map to clear a stale enabled category (the offline-disable recovery path)', async () => {
+      const peers = [{ id: 'p1', instanceId: 'inst-A', name: 'A', syncCategories: { brain: true }, syncEnabled: true }];
+      readJSONFile.mockResolvedValue({ self: { instanceId: 'me' }, peers });
+
+      const { changed, peer } = await applyReciprocalSync('inst-A', { brain: false });
+
+      expect(changed).toBe(true);
+      expect(peer.syncCategories.brain).toBe(false);
+      expect(peer.syncEnabled).toBe(false); // nothing left enabled
+    });
+
     it('returns changed:false for an unknown peer instanceId', async () => {
       readJSONFile.mockResolvedValue({ self: { instanceId: 'me' }, peers: [] });
       const { changed, peer } = await applyReciprocalSync('nope', { brain: true });

--- a/server/services/instances.test.js
+++ b/server/services/instances.test.js
@@ -63,6 +63,7 @@ import {
   sanitizePeerForClient,
   applyReciprocalSync,
   requestReciprocalSync,
+  enqueueReciprocalSync,
   startPolling,
   stopPolling
 } from './instances.js';
@@ -650,6 +651,65 @@ describe('instances.js', () => {
       const result = await requestReciprocalSync({ id: 'p1', address: '10.0.0.2', port: 5555 }, { brain: true });
       expect(result.ok).toBe(false);
       expect(result.reason).toBe('no-self-identity');
+    });
+  });
+
+  describe('enqueueReciprocalSync', () => {
+    it('reads the FRESHEST persisted categories at send time (last enqueue wins, not enqueue-time snapshot)', async () => {
+      // readJSONFile is re-read on each send; point it at the latest map so the
+      // serialized send carries final state regardless of when it was enqueued.
+      readJSONFile.mockResolvedValue({
+        self: { instanceId: 'me-id' },
+        peers: [{ id: 'p1', instanceId: 'inst-A', name: 'A', syncCategories: { brain: true, goals: true } }]
+      });
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      vi.stubGlobal('fetch', fetchMock);
+
+      await enqueueReciprocalSync('p1');
+
+      const body = JSON.parse(fetchMock.mock.calls.at(-1)[1].body);
+      expect(body.syncCategories).toEqual({ brain: true, goals: true });
+    });
+
+    it('serializes per peer so sends leave in enqueue order (no stale-map race)', async () => {
+      // Unique peer id so the module-level per-peer tail can't chain onto another
+      // test's queue. The second send resolves immediately; the first blocks on
+      // resolveFirst. If sends raced, order would be ['second', 'first']; ordered
+      // serialization yields ['first', 'second'].
+      readJSONFile.mockResolvedValue({
+        self: { instanceId: 'me-id' },
+        peers: [{ id: 'p-serial', instanceId: 'inst-A', name: 'A', syncCategories: { brain: true } }]
+      });
+      const order = [];
+      let resolveFirst;
+      const fetchMock = vi.fn()
+        .mockImplementationOnce(() => new Promise(r => { resolveFirst = () => { order.push('first'); r({ ok: true, status: 200 }); }; }))
+        .mockImplementationOnce(async () => { order.push('second'); return { ok: true, status: 200 }; });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const p1 = enqueueReciprocalSync('p-serial');
+      const p2 = enqueueReciprocalSync('p-serial');
+      // The second send resolves immediately; the first blocks until we release
+      // it. If the two ran concurrently (unserialized), 'second' would land
+      // first. Flush microtasks until the first send reaches its (blocked)
+      // fetch, then release it — the recorded order proves serialization.
+      // (beforeEach installs fake timers, so we flush the microtask queue
+      // directly rather than waiting on a real-time setTimeout.)
+      for (let i = 0; i < 20 && !resolveFirst; i++) await Promise.resolve();
+      resolveFirst();
+      await Promise.all([p1, p2]);
+      expect(order).toEqual(['first', 'second']);
+    });
+
+    it('no-ops cleanly for a peer that lost its instanceId', async () => {
+      readJSONFile.mockResolvedValue({
+        self: { instanceId: 'me-id' },
+        peers: [{ id: 'p-noinst', name: 'A', syncCategories: { brain: true } }] // no instanceId
+      });
+      vi.stubGlobal('fetch', vi.fn());
+      const result = await enqueueReciprocalSync('p-noinst');
+      expect(result.ok).toBe(false);
+      expect(result.reason).toBe('no-peer-identity');
     });
   });
 


### PR DESCRIPTION
Closes #1070. Follow-up to the brain-sync fix (#1069).

## Problem

Federation sync categories are **pull-based per direction**: enabling category C toward peer B only makes *us* pull B's C. For B to pull *our* C, B has to enable C toward us too. So two-way sync required setting the toggle on both machines by hand. Since a single user typically owns every federated machine (void/null/NaN/undefined), enabling once should establish two-way sync.

## Approach — auto-reciprocate

- **`updatePeer`** — after a `syncCategories` change, fire-and-forget `requestReciprocalSync(peer, fullResultingMap)` asks the peer to enable the same categories toward us. It sends the **full resulting map** (not just the delta) so the peer converges even if an earlier reciprocate was missed (peer offline).
- **`applyReciprocalSync` (receiver)** + **`POST /api/instances/peers/sync-categories`** — a peer asks us to mirror its categories; we find our record for that `instanceId`, apply the flags, recompute `syncEnabled`, and backfill-subscribe the per-record kinds (universe/pipeline) — mirroring `updatePeer`. **Echo-guarded**: no-op when nothing flips. **Sanitized** to `DEFAULT_SYNC_CATEGORIES` keys only (no prototype pollution / garbage flags).
- **`requestReciprocalSync` (sender)** — reuses `peerFetch`/`peerBaseUrl` with an AbortController timeout. A 404 (peer on an older version) returns `ok:false` rather than throwing, so nothing breaks across mixed versions.
- **`POST /api/instances/peers/:id/reciprocate`** + UI **"Make mutual"** button — explicit catch-up for peers configured one-directionally before this existed, or offline during a toggle. The Sync Categories panel now explains that toggles are bidirectional.

## Backward/forward compat

Wire-only addition — no schema-version bump. A peer that 404s the new endpoint just stays one-directional until the next toggle. Categories are sanitized on both send and receive.

## Tests

8 new service tests (`applyReciprocalSync` mirror/echo-guard/unknown-peer/garbage-key/non-object; `requestReciprocalSync` POST shape/404/no-identity), including an assertion that no transient marker leaks into the persisted `instances.json`. Full server suite 10,515 passing; client 1,935 passing; client build clean.

## Not in scope

UI directional counts + realtime sync progress are tracked separately in #1072.