### PR TITLE
perf: lazy-load three.js views; a11y fixes; accurate .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,12 +19,29 @@ PGPASSWORD=portos
 # CDP browser automation host
 # CDP_HOST=127.0.0.1
 
-# Server host binding
+# Server host binding (hostname used for self-links and federation peer discovery)
+# PORTOS_HOST=my-machine.ts.net
+
+# Loopback HTTP port spawned when HTTPS is active so local curl skips the cert (default: 5553)
+# PORTOS_HTTP_PORT=5553
+
+# Override the base URLs advertised to clients (auto-derived from PORTOS_HOST/PORT if unset)
+# PORTOS_API_URL=https://my-machine.ts.net:5555
+# PORTOS_UI_URL=https://my-machine.ts.net:5555
+
+# Server host binding for Express listen (default: 0.0.0.0)
 # HOST=0.0.0.0
 
-# OpenClaw API credentials
-# OPENCLAW_API_URL=https://api.openclaw.example.com
-# OPENCLAW_API_KEY=your_openclaw_api_key_here
+# OpenClaw integration (configured via Settings UI; env overrides take precedence)
+# OPENCLAW_ENABLED=true
+# OPENCLAW_BASE_URL=https://your-openclaw-instance.example.com
+# OPENCLAW_AUTH_TOKEN=your_token_here
+# OPENCLAW_AUTH_HEADER=Authorization
+# OPENCLAW_AUTH_SCHEME=Bearer
+# OPENCLAW_LABEL=OpenClaw Runtime
+# OPENCLAW_DEFAULT_SESSION=
+# OPENCLAW_DEFAULT_AGENT_ID=main
+# OPENCLAW_TIMEOUT_MS=30000
 
 # Chief of Staff runner endpoint (used when CoS runs as a separate process)
 # COS_RUNNER_URL=http://localhost:5558
@@ -49,3 +66,41 @@ PGPASSWORD=portos
 
 # Duration (minutes) for Moltworld agent sessions
 # MOLTWORLD_DURATION_MINUTES=60
+
+# Memory backend — "file" is dev/test only; leave unset for production (PostgreSQL required)
+# MEMORY_BACKEND=file
+
+# CoS log verbosity — set to "debug" to enable verbose Chief of Staff event logs
+# COS_LOG_LEVEL=debug
+
+# Hugging Face token for authenticated model downloads (three equivalent env var names accepted)
+# HF_TOKEN=hf_...
+# HUGGINGFACE_HUB_TOKEN=hf_...
+# HUGGINGFACEHUB_API_TOKEN=hf_...
+
+# Google Gemini API key (used by the Google AI provider in Settings → AI Providers)
+# GOOGLE_API_KEY=AIza...
+
+# CivitAI API key for LoRA / model downloads from civitai.com
+# CIVITAI_API_KEY=your_civitai_api_key_here
+
+# Absolute path to the bash binary used when spawning shell sessions (auto-detected if unset)
+# PORTOS_BASH=/bin/bash
+
+# Colon-separated list of extra directory roots exposed in the workspace file browser
+# PORTOS_WORKSPACE_ROOTS=/home/user/projects:/mnt/data
+
+# PyTorch CUDA index URL suffix for Windows GPU installs (e.g. cu121); auto-detected on Linux
+# PORTOS_TORCH_CUDA_INDEX=cu121
+
+# Path to the media-models registry JSON file (defaults to data/media-models.json)
+# PORTOS_MEDIA_MODELS_FILE=/path/to/custom/media-models.json
+
+# LM Studio models directory override (default: ~/LM Studio/models)
+# LM_STUDIO_MODELS_DIR=/path/to/lm-studio/models
+
+# Ollama models directory override (default: ~/.ollama/models)
+# OLLAMA_MODELS=/path/to/ollama/models
+
+# Ollama context window size passed to new model loads (default: 32768)
+# OLLAMA_NUM_CTX=32768

--- a/client/src/components/cos/index.js
+++ b/client/src/components/cos/index.js
@@ -2,12 +2,11 @@
 export { TABS, AGENT_STATES, STATE_MESSAGES, MEMORY_TYPES, MEMORY_TYPE_COLORS } from './constants';
 
 // Avatar/Character Components
+// The five three.js *CoSAvatar variants are intentionally NOT re-exported:
+// ChiefOfStaff.jsx lazy-imports them per variant, and a static barrel
+// re-export pulls them all back into the eager chunk
+// (Rollup INEFFECTIVE_DYNAMIC_IMPORT).
 export { default as CoSCharacter } from './CoSCharacter';
-export { default as CyberCoSAvatar } from './CyberCoSAvatar';
-export { default as SigilCoSAvatar } from './SigilCoSAvatar';
-export { default as EsotericCoSAvatar } from './EsotericCoSAvatar';
-export { default as NexusCoSAvatar } from './NexusCoSAvatar';
-export { default as MuseCoSAvatar } from './MuseCoSAvatar';
 export { default as StateLabel } from './StateLabel';
 export { default as TerminalCoSPanel } from './TerminalCoSPanel';
 

--- a/client/src/components/cos/tabs/MemoryTab.jsx
+++ b/client/src/components/cos/tabs/MemoryTab.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, lazy, Suspense } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import {Trash2, X, Check, XCircle, Pencil, AlertTriangle, Brain, Bot} from 'lucide-react';
 import toast from '../../ui/Toast';
@@ -7,7 +7,8 @@ import * as api from '../../../services/api';
 import { MEMORY_TYPES, MEMORY_TYPE_COLORS } from '../constants';
 import { getAppName } from '../../../utils/formatters';
 import MemoryTimeline from './MemoryTimeline';
-import MemoryGraph from './MemoryGraph';
+// Lazy: MemoryGraph pulls the three.js stack; load it only when rendered.
+const MemoryGraph = lazy(() => import('./MemoryGraph'));
 import MemoryEditModal from './MemoryEditModal';
 import ProviderModelSelector from '../../ProviderModelSelector';
 import useProviderModels from '../../../hooks/useProviderModels';
@@ -183,6 +184,7 @@ export default function MemoryTab({ apps = [] }) {
           onChange={(e) => setSearchQuery(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
           placeholder="Search memories semantically..."
+          aria-label="Search memories"
           className="flex-1 bg-port-card border border-port-border rounded-lg px-3 py-1.5 text-sm text-white placeholder-gray-500 focus:border-port-accent outline-hidden"
         />
         <button
@@ -293,6 +295,7 @@ export default function MemoryTab({ apps = [] }) {
                     disabled={actionInFlight === memory.id}
                     className="flex-1 sm:flex-none p-3 min-h-[44px] min-w-[44px] flex items-center justify-center bg-port-accent/20 text-port-accent hover:bg-port-accent/30 active:bg-port-accent/40 rounded-lg transition-colors disabled:opacity-50"
                     title="Edit before approving"
+                    aria-label="Edit before approving"
                   >
                     <Pencil size={20} />
                   </button>
@@ -301,6 +304,7 @@ export default function MemoryTab({ apps = [] }) {
                     disabled={!!actionInFlight}
                     className="flex-1 sm:flex-none p-3 min-h-[44px] min-w-[44px] flex items-center justify-center bg-green-500/20 text-green-400 hover:bg-green-500/30 active:bg-green-500/40 rounded-lg transition-colors disabled:opacity-50"
                     title="Approve"
+                    aria-label="Approve memory"
                   >
                     {actionInFlight === memory.id ? <BrailleSpinner /> : <Check size={20} />}
                   </button>
@@ -309,6 +313,7 @@ export default function MemoryTab({ apps = [] }) {
                     disabled={!!actionInFlight}
                     className="flex-1 sm:flex-none p-3 min-h-[44px] min-w-[44px] flex items-center justify-center bg-red-500/20 text-red-400 hover:bg-red-500/30 active:bg-red-500/40 rounded-lg transition-colors disabled:opacity-50"
                     title="Reject"
+                    aria-label="Reject memory"
                   >
                     {actionInFlight === memory.id ? <BrailleSpinner /> : <XCircle size={20} />}
                   </button>
@@ -432,6 +437,7 @@ export default function MemoryTab({ apps = [] }) {
                       onClick={() => setEditingMemory(memory)}
                       className="p-3 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-500 hover:text-port-accent transition-colors"
                       title="Edit memory"
+                      aria-label="Edit memory"
                     >
                       <Pencil size={18} />
                     </button>
@@ -439,6 +445,7 @@ export default function MemoryTab({ apps = [] }) {
                       onClick={() => handleDelete(memory.id)}
                       className="p-3 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-500 hover:text-port-error transition-colors"
                       title="Archive memory"
+                      aria-label="Archive memory"
                     >
                       <Trash2 size={18} />
                     </button>
@@ -451,7 +458,9 @@ export default function MemoryTab({ apps = [] }) {
       ) : view === 'timeline' ? (
         <MemoryTimeline memories={memories} />
       ) : (
-        <MemoryGraph />
+        <Suspense fallback={<BrailleSpinner text="Loading graph" />}>
+          <MemoryGraph />
+        </Suspense>
       )}
 
       {/* Edit Modal */}

--- a/client/src/components/cos/tabs/schedule/PromptEditor.jsx
+++ b/client/src/components/cos/tabs/schedule/PromptEditor.jsx
@@ -41,9 +41,15 @@ export default function PromptEditor({ config, promptValue, setPromptValue, edit
             )}
           </div>
         ) : (
-          <div className="bg-port-bg border border-port-border rounded px-3 py-2 text-xs text-gray-400 font-mono max-h-32 overflow-y-auto cursor-pointer hover:border-port-accent/50" onClick={() => setEditingPrompt(true)} title="Click to edit prompt">
+          <button
+            type="button"
+            className="w-full bg-port-bg border border-port-border rounded px-3 py-2 text-xs text-gray-400 font-mono max-h-32 overflow-y-auto cursor-pointer hover:border-port-accent/50 text-left"
+            onClick={() => setEditingPrompt(true)}
+            title="Click to edit prompt"
+            aria-label="Edit prompt"
+          >
             <pre className="whitespace-pre-wrap">{promptValue || 'No prompt configured'}</pre>
-          </div>
+          </button>
         )}
       </div>
     );

--- a/client/src/pages/Brain.jsx
+++ b/client/src/pages/Brain.jsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, lazy, Suspense } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import * as api from '../services/api';
 import {Brain as BrainIcon} from 'lucide-react';
@@ -13,7 +13,6 @@ import { timeAgo } from '../utils/formatters';
 import InboxTab from '../components/brain/tabs/InboxTab';
 import LinksTab from '../components/brain/tabs/LinksTab';
 import MemoryTab from '../components/brain/tabs/MemoryTab';
-import BrainGraph from '../components/brain/tabs/BrainGraph';
 import DigestTab from '../components/brain/tabs/DigestTab';
 import FeedsTab from '../components/brain/tabs/FeedsTab';
 import TrustTab from '../components/brain/tabs/TrustTab';
@@ -21,6 +20,10 @@ import NotesTab from '../components/brain/tabs/NotesTab';
 import DailyLogTab from '../components/brain/tabs/DailyLogTab';
 import ConfigTab from '../components/brain/tabs/ConfigTab';
 import ImportTab from '../components/brain/tabs/ImportTab';
+
+// BrainGraph uses the three.js stack — lazy-load so it's not bundled until the
+// graph tab is actually opened.
+const BrainGraph = lazy(() => import('../components/brain/tabs/BrainGraph'));
 
 export default function Brain() {
   const { tab } = useParams();
@@ -61,7 +64,7 @@ export default function Brain() {
       case 'daily-log':
         return <DailyLogTab />;
       case 'graph':
-        return <BrainGraph />;
+        return <Suspense fallback={<div className="flex items-center justify-center h-64"><BrailleSpinner text="Loading" /></div>}><BrainGraph /></Suspense>;
       case 'digest':
         return <DigestTab onRefresh={refetch} />;
       case 'feeds':

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef, lazy, Suspense } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useSocket } from '../hooks/useSocket';
 import { useLocalStorageBool } from '../hooks/useLocalStorageBool';
@@ -15,11 +15,6 @@ import {
   TABS,
   STATE_MESSAGES,
   CoSCharacter,
-  CyberCoSAvatar,
-  SigilCoSAvatar,
-  EsotericCoSAvatar,
-  NexusCoSAvatar,
-  MuseCoSAvatar,
   StateLabel,
   TerminalCoSPanel,
   StatusIndicator,
@@ -43,6 +38,16 @@ import {
   BriefingTab
 } from '../components/cos';
 import { resolveDynamicAvatar } from '../components/cos/constants';
+
+// Three.js-based avatars lazy-loaded so the R3F stack isn't bundled unless the
+// user's chosen avatar style actually needs it.
+const LAZY_AVATARS = {
+  cyber:    lazy(() => import('../components/cos/CyberCoSAvatar')),
+  sigil:    lazy(() => import('../components/cos/SigilCoSAvatar')),
+  esoteric: lazy(() => import('../components/cos/EsotericCoSAvatar')),
+  nexus:    lazy(() => import('../components/cos/NexusCoSAvatar')),
+  muse:     lazy(() => import('../components/cos/MuseCoSAvatar')),
+};
 
 const CANVAS_AVATAR_STYLES = new Set(['cyber', 'sigil', 'esoteric', 'nexus', 'muse']);
 
@@ -504,20 +509,13 @@ export default function ChiefOfStaff() {
   );
 
   const renderAvatar = (background = false) => {
-    if (avatarStyle === 'cyber') {
-      return <CyberCoSAvatar state={agentState} speaking={speaking} background={background} />;
-    }
-    if (avatarStyle === 'sigil') {
-      return <SigilCoSAvatar state={agentState} speaking={speaking} background={background} />;
-    }
-    if (avatarStyle === 'esoteric') {
-      return <EsotericCoSAvatar state={agentState} speaking={speaking} background={background} />;
-    }
-    if (avatarStyle === 'nexus') {
-      return <NexusCoSAvatar state={agentState} speaking={speaking} background={background} />;
-    }
-    if (avatarStyle === 'muse') {
-      return <MuseCoSAvatar state={agentState} speaking={speaking} background={background} />;
+    const LazyAvatar = LAZY_AVATARS[avatarStyle];
+    if (LazyAvatar) {
+      return (
+        <Suspense fallback={<div className="flex items-center justify-center h-full"><BrailleSpinner /></div>}>
+          <LazyAvatar state={agentState} speaking={speaking} background={background} />
+        </Suspense>
+      );
     }
     return <CoSCharacter state={agentState} speaking={speaking} />;
   };

--- a/client/src/pages/Goals.jsx
+++ b/client/src/pages/Goals.jsx
@@ -1,11 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, lazy, Suspense } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {Target, TreePine, List} from 'lucide-react';
 import * as api from '../services/api';
-import GoalsTreeView from '../components/goals/GoalsTreeView';
 import GoalsListView from '../components/goals/GoalsListView';
 import MortalLoomBanner from '../components/MortalLoomBanner';
 import BrailleSpinner from '../components/BrailleSpinner';
+
+const GoalsTreeView = lazy(() => import('../components/goals/GoalsTreeView'));
 
 // Exported for the nav-manifest tab-coverage guard (server/lib/navManifest.test.js).
 export const TABS = [
@@ -88,7 +89,9 @@ export default function Goals() {
         ) : tab === 'list' ? (
           <GoalsListView data={data} onRefresh={loadData} />
         ) : (
-          <GoalsTreeView data={data} onRefresh={loadData} />
+          <Suspense fallback={<div className="flex items-center justify-center h-full"><BrailleSpinner text="Loading" /></div>}>
+            <GoalsTreeView data={data} onRefresh={loadData} />
+          </Suspense>
         )}
       </div>
     </div>

--- a/client/src/pages/PipelineSeriesRoadmap.jsx
+++ b/client/src/pages/PipelineSeriesRoadmap.jsx
@@ -124,7 +124,7 @@ function IssueRow({ entry, onAnalyze, analyzing }) {
             <div className="text-xs text-gray-500 flex items-center gap-1.5"><Loader2 size={12} className="animate-spin" /> Loading…</div>
           ) : detail?.sections?.length ? (
             <ul className="space-y-1.5">
-              {detail.sections.map((s, i) => <SectionRow key={i} section={s} index={i} />)}
+              {detail.sections.map((s, i) => <SectionRow key={s.id ?? `${s.title ?? 'section'}-${i}`} section={s} index={i} />)}
             </ul>
           ) : (
             <p className="text-xs text-gray-500 italic">No section detail available.</p>


### PR DESCRIPTION
## Better Audit 2026-06-09 — Stack-Specific (React/Node)

### Summary
11 findings addressed across 8 files.

### Changes
- **[MEDIUM]** Goals (GoalsTreeView), Brain (BrainGraph), Chief of Staff (all five avatar variants), and CoS MemoryTab (MemoryGraph) now lazy-load their three.js scenes. The cos barrel's static avatar re-exports are removed — they made the dynamic imports a no-op (Rollup INEFFECTIVE_DYNAMIC_IMPORT ×5, verified gone after the fix).
- **[MEDIUM]** MemoryTab a11y — aria-labels on the search input and all icon-only Approve/Reject/Edit/Archive buttons; PromptEditor's clickable div becomes a real `<button>`.
- **[LOW]** Stable, collision-free keys for roadmap section rows.
- **[MEDIUM]** `.env.example` — phantom `OPENCLAW_API_URL`/`OPENCLAW_API_KEY` replaced with the nine `OPENCLAW_*` vars the server actually reads; 16 missing-but-real env vars documented (each verified by grep; `CERT_DIR` deliberately excluded — the server derives it, never reads the env var).

### Merge Order
Independent — can be merged in any order.