### PR TITLE
refactor([issue-1085]): convert runner executors to options objects

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -13,6 +13,7 @@
 - **[issue-1082] Maintenance:** Decomposed the Chief-of-Staff task-evaluation engine's monolithic spawn loop into one named function per priority tier — no behavior change, making each tier independently testable.
 - **[issue-1083] Maintenance:** Split the 2,600-line task-prompt module into a pure data leaf (the default-prompt catalog) and a thin getter layer, removing a circular import between the prompt and schedule services — no behavior change.
 - **[issue-1084] Maintenance:** AI provider/run/prompt API errors now report the same structured shape (with an error code and timestamp) as the rest of PortOS, so error-handling UI behaves consistently across every API.
+- **[issue-1085] Maintenance:** The AI run executors now take a single named-options argument instead of long positional parameter lists, making their call sites less order-fragile — no behavior change.
 
 ## Fixed
 

--- a/server/lib/aiToolkit/routes/runs.js
+++ b/server/lib/aiToolkit/routes/runs.js
@@ -70,35 +70,35 @@ export function createRunsRoutes(runnerService, options = {}) {
       : provider;
 
     if (provider.type === 'cli') {
-      runnerService.executeCliRun(
+      runnerService.executeCliRun({
         runId,
-        cliProvider,
+        provider: cliProvider,
         prompt,
         workspacePath,
-        (data) => {
+        onData: (data) => {
           io?.emit(`run:${runId}:data`, data);
         },
-        (finalMetadata) => {
+        onComplete: (finalMetadata) => {
           console.log(`✅ Run complete: ${runId}, success: ${finalMetadata.success}`);
           io?.emit(`run:${runId}:complete`, finalMetadata);
         },
-        effectiveTimeout
-      );
+        timeout: effectiveTimeout,
+      });
     } else if (provider.type === 'api') {
-      runnerService.executeApiRun(
+      runnerService.executeApiRun({
         runId,
         provider,
-        runModel,
+        model: runModel,
         prompt,
         workspacePath,
         screenshots,
-        (data) => {
+        onData: (data) => {
           io?.emit(`run:${runId}:data`, data);
         },
-        (finalMetadata) => {
+        onComplete: (finalMetadata) => {
           io?.emit(`run:${runId}:complete`, finalMetadata);
-        }
-      );
+        },
+      });
     } else if (provider.type === 'tui' && typeof runnerService.executeTuiRun === 'function') {
       // Honor the user-picked model from the Runs UI — `executeTuiRun` reads
       // `provider.defaultModel` for its `--model` injection, so without the
@@ -109,20 +109,20 @@ export function createRunsRoutes(runnerService, options = {}) {
       const effectiveProvider = runModel
         ? { ...provider, defaultModel: runModel }
         : provider;
-      runnerService.executeTuiRun(
+      runnerService.executeTuiRun({
         runId,
-        effectiveProvider,
+        provider: effectiveProvider,
         prompt,
         workspacePath,
-        (data) => {
+        onData: (data) => {
           io?.emit(`run:${runId}:data`, data);
         },
-        (finalMetadata) => {
+        onComplete: (finalMetadata) => {
           console.log(`✅ Run complete: ${runId}, success: ${finalMetadata.success}`);
           io?.emit(`run:${runId}:complete`, finalMetadata);
         },
-        effectiveTimeout
-      );
+        timeout: effectiveTimeout,
+      });
     } else {
       throw new ServerError(`Unsupported provider type: ${provider.type}`, {
         status: 400,

--- a/server/lib/aiToolkit/routes/runs.test.js
+++ b/server/lib/aiToolkit/routes/runs.test.js
@@ -61,8 +61,8 @@ describe('POST /api/runs — fallback-model execution', () => {
       const res = await post(app);
       expect(res.status).toBe(202);
       expect(runnerService.executeApiRun).toHaveBeenCalledTimes(1);
-      // executeApiRun(runId, provider, runModel, prompt, ...)
-      expect(runnerService.executeApiRun.mock.calls[0][2]).toBe(REQUEST_MODEL);
+      // executeApiRun({ runId, provider, model: runModel, prompt, ... })
+      expect(runnerService.executeApiRun.mock.calls[0][0].model).toBe(REQUEST_MODEL);
     });
 
     it('TUI: clones the provider with the request model as defaultModel', async () => {
@@ -72,8 +72,8 @@ describe('POST /api/runs — fallback-model execution', () => {
       const res = await post(app);
       expect(res.status).toBe(202);
       expect(runnerService.executeTuiRun).toHaveBeenCalledTimes(1);
-      // executeTuiRun(runId, effectiveProvider, prompt, ...)
-      expect(runnerService.executeTuiRun.mock.calls[0][1].defaultModel).toBe(REQUEST_MODEL);
+      // executeTuiRun({ runId, provider: effectiveProvider, prompt, ... })
+      expect(runnerService.executeTuiRun.mock.calls[0][0].provider.defaultModel).toBe(REQUEST_MODEL);
     });
 
     it('CLI: leaves the provider untouched (request model is never threaded into CLI runs)', async () => {
@@ -82,8 +82,8 @@ describe('POST /api/runs — fallback-model execution', () => {
       const res = await post(app);
       expect(res.status).toBe(202);
       expect(runnerService.executeCliRun).toHaveBeenCalledTimes(1);
-      // executeCliRun(runId, cliProvider, prompt, ...): no clone, keeps provider's own default
-      const cliProvider = runnerService.executeCliRun.mock.calls[0][1];
+      // executeCliRun({ runId, provider: cliProvider, prompt, ... }): no clone, keeps provider's own default
+      const cliProvider = runnerService.executeCliRun.mock.calls[0][0].provider;
       expect(cliProvider).toBe(provider.provider);
       expect(cliProvider.defaultModel).toBe('provider-default');
     });
@@ -97,7 +97,7 @@ describe('POST /api/runs — fallback-model execution', () => {
         runData({ providerType: 'api', defaultModel: 'fallback-default', usedFallback: true, fallbackModel: PINNED })
       );
       await post(app);
-      expect(runnerService.executeApiRun.mock.calls[0][2]).toBe(PINNED);
+      expect(runnerService.executeApiRun.mock.calls[0][0].model).toBe(PINNED);
     });
 
     it('TUI: clones the fallback provider with the pinned model as defaultModel', async () => {
@@ -105,14 +105,14 @@ describe('POST /api/runs — fallback-model execution', () => {
         runData({ providerType: 'tui', defaultModel: 'fallback-default', usedFallback: true, fallbackModel: PINNED })
       );
       await post(app);
-      expect(runnerService.executeTuiRun.mock.calls[0][1].defaultModel).toBe(PINNED);
+      expect(runnerService.executeTuiRun.mock.calls[0][0].provider.defaultModel).toBe(PINNED);
     });
 
     it('CLI: clones the fallback provider with the pinned model as defaultModel', async () => {
       const run = runData({ providerType: 'cli', defaultModel: 'fallback-default', usedFallback: true, fallbackModel: PINNED });
       const { app, runnerService } = makeApp(run);
       await post(app);
-      const cliProvider = runnerService.executeCliRun.mock.calls[0][1];
+      const cliProvider = runnerService.executeCliRun.mock.calls[0][0].provider;
       expect(cliProvider.defaultModel).toBe(PINNED);
       // runModel !== provider.defaultModel, so the route must hand a *clone* to the
       // CLI runner — never mutate the shared fallback provider record.
@@ -128,8 +128,8 @@ describe('POST /api/runs — fallback-model execution', () => {
         runData({ providerType: 'api', defaultModel: FALLBACK_DEFAULT, usedFallback: true, fallbackModel: null })
       );
       await post(app);
-      expect(runnerService.executeApiRun.mock.calls[0][2]).toBe(FALLBACK_DEFAULT);
-      expect(runnerService.executeApiRun.mock.calls[0][2]).not.toBe(REQUEST_MODEL);
+      expect(runnerService.executeApiRun.mock.calls[0][0].model).toBe(FALLBACK_DEFAULT);
+      expect(runnerService.executeApiRun.mock.calls[0][0].model).not.toBe(REQUEST_MODEL);
     });
 
     it('TUI: clones the fallback provider with its own default, never the request model', async () => {
@@ -137,7 +137,7 @@ describe('POST /api/runs — fallback-model execution', () => {
         runData({ providerType: 'tui', defaultModel: FALLBACK_DEFAULT, usedFallback: true, fallbackModel: null })
       );
       await post(app);
-      const tuiProvider = runnerService.executeTuiRun.mock.calls[0][1];
+      const tuiProvider = runnerService.executeTuiRun.mock.calls[0][0].provider;
       expect(tuiProvider.defaultModel).toBe(FALLBACK_DEFAULT);
       expect(tuiProvider.defaultModel).not.toBe(REQUEST_MODEL);
     });
@@ -148,7 +148,7 @@ describe('POST /api/runs — fallback-model execution', () => {
       await post(app);
       // runModel === provider.defaultModel here, so the route skips the clone and
       // passes the fallback provider as-is — its default is already correct.
-      const cliProvider = runnerService.executeCliRun.mock.calls[0][1];
+      const cliProvider = runnerService.executeCliRun.mock.calls[0][0].provider;
       expect(cliProvider.defaultModel).toBe(FALLBACK_DEFAULT);
       expect(cliProvider.defaultModel).not.toBe(REQUEST_MODEL);
       // No pin and runModel === provider.defaultModel, so the route skips the clone

--- a/server/lib/aiToolkit/runner.js
+++ b/server/lib/aiToolkit/runner.js
@@ -194,7 +194,7 @@ export function createRunnerService(config = {}) {
       return { runId, runDir, provider, metadata, timeout: effectiveTimeout, usedFallback, fallbackModel: fallbackModelHint };
     },
 
-    async executeCliRun(runId, provider, prompt, workspacePath, onData, onComplete, timeout) {
+    async executeCliRun({ runId, provider, prompt, workspacePath, onData, onComplete, timeout }) {
       const runDir = join(RUNS_PATH, runId);
       const outputPath = join(runDir, 'output.txt');
       const metadataPath = join(runDir, 'metadata.json');
@@ -281,7 +281,7 @@ export function createRunnerService(config = {}) {
       return runId;
     },
 
-    async executeApiRun(runId, provider, model, prompt, workspacePath, screenshots, onData, onComplete) {
+    async executeApiRun({ runId, provider, model, prompt, workspacePath, screenshots, onData, onComplete }) {
       const runDir = join(RUNS_PATH, runId);
       const outputPath = join(runDir, 'output.txt');
       const metadataPath = join(runDir, 'metadata.json');

--- a/server/lib/aiToolkit/runner.test.js
+++ b/server/lib/aiToolkit/runner.test.js
@@ -38,16 +38,16 @@ describe('AI Toolkit runner service', () => {
       }
     });
 
-    await runner.executeApiRun(
-      'run-ready-hook',
+    await runner.executeApiRun({
+      runId: 'run-ready-hook',
       provider,
-      null,
-      'hello',
-      process.cwd(),
-      [],
-      undefined,
+      model: null,
+      prompt: 'hello',
+      workspacePath: process.cwd(),
+      screenshots: [],
+      onData: undefined,
       onComplete
-    );
+    });
 
     expect(ensureProviderReady).toHaveBeenCalledWith(provider);
     expect(fetch).not.toHaveBeenCalled();
@@ -101,7 +101,7 @@ describe('AI Toolkit runner service', () => {
     });
     let done;
     const completed = new Promise((resolve) => { done = resolve; });
-    await runner.executeApiRun('run-numctx', runReady({ numCtx: 32768 }), null, 'hi', process.cwd(), [], undefined, () => done());
+    await runner.executeApiRun({ runId: 'run-numctx', provider: runReady({ numCtx: 32768 }), model: null, prompt: 'hi', workspacePath: process.cwd(), screenshots: [], onData: undefined, onComplete: () => done() });
     await completed;
 
     expect(fetch).toHaveBeenCalledTimes(1);
@@ -119,7 +119,7 @@ describe('AI Toolkit runner service', () => {
     });
     let done;
     const completed = new Promise((resolve) => { done = resolve; });
-    await runner.executeApiRun('run-no-numctx', runReady(), null, 'hi', process.cwd(), [], undefined, () => done());
+    await runner.executeApiRun({ runId: 'run-no-numctx', provider: runReady(), model: null, prompt: 'hi', workspacePath: process.cwd(), screenshots: [], onData: undefined, onComplete: () => done() });
     await completed;
 
     expect(fetch).toHaveBeenCalledTimes(1);

--- a/server/lib/promptRunner.js
+++ b/server/lib/promptRunner.js
@@ -608,7 +608,7 @@ async function executeProviderRunOnce({ provider, prompt, source, model, runId: 
       : effectiveProvider;
 
     if (effectiveProvider.type === PROVIDER_TYPES.CLI) {
-      executeCliRun(runId, providerForRun, prompt, effectiveCwd, onData, onComplete, effectiveTimeout).catch(safeReject);
+      executeCliRun({ runId, provider: providerForRun, prompt, workspacePath: effectiveCwd, onData, onComplete, timeout: effectiveTimeout }).catch(safeReject);
     } else if (effectiveProvider.type === PROVIDER_TYPES.API) {
       // API runs take model as a first-class arg — no clone needed. The
       // toolkit's executeApiRun uses AbortController without a timer, so
@@ -622,9 +622,9 @@ async function executeProviderRunOnce({ provider, prompt, source, model, runId: 
         stopRun(runId).catch(() => { /* best-effort cancel */ });
         safeReject(new Error(`API execution timed out after ${effectiveTimeout}ms`));
       }, effectiveTimeout);
-      executeApiRun(runId, effectiveProvider, effectiveModel, prompt, effectiveCwd, [], onData, onComplete).catch(safeReject);
+      executeApiRun({ runId, provider: effectiveProvider, model: effectiveModel, prompt, workspacePath: effectiveCwd, screenshots: [], onData, onComplete }).catch(safeReject);
     } else if (effectiveProvider.type === PROVIDER_TYPES.TUI) {
-      executeTuiRun(runId, providerForRun, prompt, effectiveCwd, onData, onComplete, effectiveTimeout).catch(safeReject);
+      executeTuiRun({ runId, provider: providerForRun, prompt, workspacePath: effectiveCwd, onData, onComplete, timeout: effectiveTimeout }).catch(safeReject);
     } else {
       safeReject(new Error(`Unsupported provider type: ${effectiveProvider.type}`));
     }

--- a/server/lib/promptRunner.test.js
+++ b/server/lib/promptRunner.test.js
@@ -90,7 +90,7 @@ beforeEach(() => {
 
 describe('promptRunner — happy paths', () => {
   it('routes CLI providers through executeCliRun, accumulates text, resolves { text, runId, model }', async () => {
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('hello ');
       onData('world');
       onComplete({ success: true });
@@ -108,7 +108,7 @@ describe('promptRunner — happy paths', () => {
   });
 
   it('routes API providers through executeApiRun, accumulates text, resolves { text, runId, model }', async () => {
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('foo');
       onData({ text: 'bar' }); // API streams sometimes ship {text} chunks
       onComplete({ success: true });
@@ -140,7 +140,7 @@ describe('promptRunner — happy paths', () => {
       fallbackModel: 'pinned-fb',
     });
     let ranModel;
-    runner.executeApiRun.mockImplementation(async (id, _p, model, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ model, onData, onComplete }) => {
       ranModel = model;
       onData('ok');
       onComplete({ success: true });
@@ -159,7 +159,7 @@ describe('promptRunner — happy paths', () => {
   });
 
   it('forwards the provider id + model + source to createRun', async () => {
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('ok');
       onComplete({ success: true });
     });
@@ -183,8 +183,8 @@ describe('promptRunner — happy paths', () => {
   });
 
   it('forwards a per-call cwd through to createRun as workspacePath', async () => {
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, cwd, onData, onComplete, _t) => {
-      onData(cwd); // echo back the cwd so the assertion below can check it
+    runner.executeCliRun.mockImplementation(async ({ workspacePath, onData, onComplete }) => {
+      onData(workspacePath); // echo back the cwd so the assertion below can check it
       onComplete({ success: true });
     });
 
@@ -202,7 +202,7 @@ describe('promptRunner — happy paths', () => {
   });
 
   it('reuses a caller-supplied runId (no createRun round-trip)', async () => {
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('ok');
       onComplete({ success: true });
     });
@@ -219,7 +219,7 @@ describe('promptRunner — happy paths', () => {
   });
 
   it('passes a CLI provider clone with overridden defaultModel for codex (which honors --model)', async () => {
-    runner.executeCliRun.mockImplementation(async (id, providerArg, _p, _cwd, onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ provider: providerArg, onData, onComplete }) => {
       onData(`ran with model=${providerArg.defaultModel}`);
       onComplete({ success: true });
     });
@@ -240,7 +240,7 @@ describe('promptRunner — happy paths', () => {
     // baked a model flag into provider.args. So the clone is safe and
     // the run record correctly reflects the user's selection.
     runner.hasModelFlag.mockReturnValue(false);
-    runner.executeCliRun.mockImplementation(async (id, providerArg, _p, _cwd, onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ provider: providerArg, onData, onComplete }) => {
       onData(`ran with defaultModel=${providerArg.defaultModel}`);
       onComplete({ success: true });
     });
@@ -261,7 +261,7 @@ describe('promptRunner — happy paths', () => {
     // silently dropped and the args-baked model wins — keep the run
     // record honest by not pretending the override applied.
     runner.hasModelFlag.mockReturnValue(true);
-    runner.executeCliRun.mockImplementation(async (id, providerArg, _p, _cwd, onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ provider: providerArg, onData, onComplete }) => {
       onData(`ran with defaultModel=${providerArg.defaultModel}`);
       onComplete({ success: true });
     });
@@ -283,7 +283,7 @@ describe('promptRunner — happy paths', () => {
     // the args-pinned id directly.
     runner.hasModelFlag.mockReturnValue(true);
     runner.extractBakedModel.mockReturnValue('baked-in');
-    runner.executeCliRun.mockImplementation(async (id, providerArg, _p, _cwd, onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ provider: providerArg, onData, onComplete }) => {
       onData(`ran with defaultModel=${providerArg.defaultModel}`);
       onComplete({ success: true });
     });
@@ -315,7 +315,7 @@ describe('promptRunner — happy paths', () => {
 
 describe('promptRunner — strictest-discriminator rejection', () => {
   it('rejects when CLI onComplete reports success: false (even with no error string)', async () => {
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false });
     });
 
@@ -327,7 +327,7 @@ describe('promptRunner — strictest-discriminator rejection', () => {
   });
 
   it('rejects when CLI onComplete reports a non-zero error', async () => {
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ error: 'codex timeout' });
     });
 
@@ -342,7 +342,7 @@ describe('promptRunner — strictest-discriminator rejection', () => {
     // Before the unification, API sites only checked `error` and would
     // resolve with empty text on success: false — silently swallowing
     // soft failures. The unified runner rejects on success: false too.
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, _onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false });
     });
 
@@ -354,7 +354,7 @@ describe('promptRunner — strictest-discriminator rejection', () => {
   });
 
   it('rejects when API onComplete reports a non-zero error', async () => {
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, _onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ error: 'upstream 500' });
     });
 
@@ -421,7 +421,7 @@ describe('promptRunner — strictest-discriminator rejection', () => {
 
 describe('promptRunner — multi-chunk text accumulation', () => {
   it('accumulates many CLI string chunks in order', async () => {
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onData, onComplete }) => {
       for (const c of ['a', 'b', 'c', 'd', 'e']) onData(c);
       onComplete({ success: true });
     });
@@ -434,7 +434,7 @@ describe('promptRunner — multi-chunk text accumulation', () => {
   });
 
   it('accumulates mixed string + {text} API chunks in order', async () => {
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('A');
       onData({ text: 'B' });
       onData({ text: 'C' });
@@ -450,7 +450,7 @@ describe('promptRunner — multi-chunk text accumulation', () => {
   });
 
   it('ignores non-string non-{text} chunks (e.g. heartbeat events)', async () => {
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('hello');
       onData({ heartbeat: true }); // chunk with no text — ignored
       onData(null);                  // ignored
@@ -474,7 +474,7 @@ describe('promptRunner — multi-chunk text accumulation', () => {
 
 describe('promptRunner — TUI provider routing', () => {
   it('routes TUI providers through executeTuiRun and resolves with result.text', async () => {
-    tuiRunner.executeTuiRun.mockImplementation(async (id, _p, _pr, _cwd, onData, onComplete, _t) => {
+    tuiRunner.executeTuiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('chrome chunk ');
       onData('more chrome');
       onComplete({ success: true, exitCode: 0, text: 'once upon a time' });
@@ -493,7 +493,7 @@ describe('promptRunner — TUI provider routing', () => {
   });
 
   it('passes cwd + timeout overrides through to executeTuiRun', async () => {
-    tuiRunner.executeTuiRun.mockImplementation(async (id, _p, _pr, _cwd, onData, onComplete, _t) => {
+    tuiRunner.executeTuiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('ok');
       onComplete({ success: true });
     });
@@ -505,13 +505,13 @@ describe('promptRunner — TUI provider routing', () => {
       timeout: 60000,
     });
 
-    const args = tuiRunner.executeTuiRun.mock.calls[0];
-    expect(args[3]).toBe('/tmp/some-other-repo'); // cwd positional arg
-    expect(args[6]).toBe(60000);                   // timeout positional arg
+    const opts = tuiRunner.executeTuiRun.mock.calls[0][0];
+    expect(opts.workspacePath).toBe('/tmp/some-other-repo'); // workspacePath option
+    expect(opts.timeout).toBe(60000);                         // timeout option
   });
 
   it('returns result.text from executeTuiRun (which owns its own response cleanup)', async () => {
-    tuiRunner.executeTuiRun.mockImplementation(async (id, _p, _pr, _cwd, onData, onComplete, _t) => {
+    tuiRunner.executeTuiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('raw with chrome');
       onComplete({ success: true, text: 'cleaned response from file' });
     });
@@ -525,7 +525,7 @@ describe('promptRunner — TUI provider routing', () => {
   });
 
   it('falls back to empty string when executeTuiRun omits result.text', async () => {
-    tuiRunner.executeTuiRun.mockImplementation(async (id, _p, _pr, _cwd, onData, onComplete, _t) => {
+    tuiRunner.executeTuiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('streamed chrome');
       onComplete({ success: true });
     });
@@ -539,7 +539,7 @@ describe('promptRunner — TUI provider routing', () => {
   });
 
   it('rejects with TUI-labeled error when executeTuiRun fires onComplete with success: false', async () => {
-    tuiRunner.executeTuiRun.mockImplementation(async (id, _p, _pr, _cwd, _od, onComplete, _t) => {
+    tuiRunner.executeTuiRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, exitCode: 124 });
     });
 
@@ -591,7 +591,7 @@ describe('promptRunner — API timeout enforcement', () => {
 
   it('does not call stopRun when API completes within the timeout', async () => {
     vi.useFakeTimers();
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('quick');
       onComplete({ success: true });
     });
@@ -652,10 +652,10 @@ describe('promptRunner — retry-with-fallback', () => {
     const status = mockToolkitWithFallback();
 
     // First call: primary CLI fails. Second call: fallback API succeeds.
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'Process exited with code 1' });
     });
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('fallback content');
       onComplete({ success: true });
     });
@@ -702,11 +702,11 @@ describe('promptRunner — retry-with-fallback', () => {
       model: 'pinned-fb-model',
     });
 
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'Process exited with code 1' });
     });
     let ranModel;
-    runner.executeApiRun.mockImplementation(async (id, _p, model, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ model, onData, onComplete }) => {
       ranModel = model;
       onData('fallback content');
       onComplete({ success: true });
@@ -730,7 +730,7 @@ describe('promptRunner — retry-with-fallback', () => {
     mockToolkitWithFallback();
 
     let calls = 0;
-    runner.executeApiRun.mockImplementation(async (id, providerArg, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ provider: providerArg, onData, onComplete }) => {
       calls += 1;
       if (providerArg.id === 'primary-api') {
         onComplete({ success: false, error: 'upstream 500' });
@@ -761,14 +761,14 @@ describe('promptRunner — retry-with-fallback', () => {
       waitTime: 12345,
     };
 
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({
         success: false,
         error: 'plain wrapper error',
         errorAnalysis: runnerErrorAnalysis,
       });
     });
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('recovered');
       onComplete({ success: true });
     });
@@ -789,10 +789,10 @@ describe('promptRunner — retry-with-fallback', () => {
   it('does NOT suppress the investigation task when the fallback ALSO fails (both errors must surface)', async () => {
     mockToolkitWithFallback();
 
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'primary boom' });
     });
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, _onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'fallback also boom' });
     });
 
@@ -813,7 +813,7 @@ describe('promptRunner — retry-with-fallback', () => {
   it('rethrows the original error when no fallback is available', async () => {
     mockToolkitWithFallback(null);
 
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'no recovery path' });
     });
 
@@ -829,7 +829,7 @@ describe('promptRunner — retry-with-fallback', () => {
 
   it('rethrows when toolkit/providerStatus is not initialized (no retry path possible)', async () => {
     // Default mock returns null toolkit — no retry attempted.
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'init not ready' });
     });
 
@@ -846,7 +846,7 @@ describe('promptRunner — retry-with-fallback', () => {
     // No fallback → original error rethrown. The annotation fields are
     // implementation-detail-only and should never leak to callers.
     mockToolkitWithFallback(null);
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'plain failure' });
     });
 
@@ -870,7 +870,7 @@ describe('promptRunner — retry-with-fallback', () => {
     // before onComplete fired — providerStatus.isAvailable now returns false.
     status.isAvailable.mockReturnValue(false);
 
-    runner.executeApiRun.mockImplementation(async (id, providerArg, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ provider: providerArg, onData, onComplete }) => {
       if (providerArg.id === 'primary-api') {
         onComplete({ success: false, error: 'rate limit hit' });
       } else {
@@ -912,11 +912,11 @@ describe('promptRunner — retry-with-fallback', () => {
       provider: intermediate,
     });
 
-    runner.executeCliRun.mockImplementation(async (id, providerArg, _p, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ provider: providerArg, onComplete }) => {
       // Intermediate fails on first attempt.
       onComplete({ success: false, error: `intermediate boom (${providerArg.id})` });
     });
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('recovered via final');
       onComplete({ success: true });
     });
@@ -968,10 +968,10 @@ describe('promptRunner — retry-with-fallback', () => {
     // test pins the call-site contract that the primary stays in the map.
     const status = mockToolkitWithFallback();
 
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'primary boom' });
     });
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('recovered');
       onComplete({ success: true });
     });
@@ -994,10 +994,10 @@ describe('promptRunner — retry-with-fallback', () => {
       throw new Error('autoFixer is offline');
     });
 
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'primary boom' });
     });
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('still works');
       onComplete({ success: true });
     });
@@ -1016,10 +1016,10 @@ describe('promptRunner — retry-with-fallback', () => {
 
   it('routes USAGE_LIMIT failures through markUsageLimit (parses wait time)', async () => {
     const status = mockToolkitWithFallback();
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: "You've hit your usage limit. Try again in 5 hours" });
     });
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('recovered');
       onComplete({ success: true });
     });
@@ -1058,10 +1058,10 @@ describe('promptRunner — retry-with-fallback', () => {
       getAllGate.then(() => ({ activeProvider: null, providers: [primaryCli, primaryApi, fallbackApi] }))
     );
 
-    runner.executeCliRun.mockImplementation(async (id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'storm boom' });
     });
-    runner.executeApiRun.mockImplementation(async (id, _p, _m, _pr, _cwd, _ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('fallback content');
       onComplete({ success: true });
     });

--- a/server/lib/stageRunner.test.js
+++ b/server/lib/stageRunner.test.js
@@ -135,7 +135,7 @@ describe('stageRunner — runStagedLLM provider resolution', () => {
   it('uses the active provider when stage and overrides leave it unspecified', async () => {
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(apiProvider());
-    runner.executeApiRun.mockImplementation(async (_id, _p, _m, _pr, _cwd, _shots, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('hello');
       onComplete({ success: true });
     });
@@ -151,7 +151,7 @@ describe('stageRunner — runStagedLLM provider resolution', () => {
     providers.getProviderById.mockImplementation(async (id) => (
       id === 'override-id' ? apiProvider({ id: 'override-id' }) : null
     ));
-    runner.executeApiRun.mockImplementation(async (_id, _p, _m, _pr, _cwd, _shots, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('override-content');
       onComplete({ success: true });
     });
@@ -165,7 +165,7 @@ describe('stageRunner — runStagedLLM provider resolution', () => {
     providers.getProviderById.mockImplementation(async (id) => (
       id === 'stage-pinned' ? apiProvider({ id: 'stage-pinned' }) : null
     ));
-    runner.executeApiRun.mockImplementation(async (_id, _p, _m, _pr, _cwd, _shots, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('pinned');
       onComplete({ success: true });
     });
@@ -196,7 +196,7 @@ describe('stageRunner — runStagedLLM dispatch', () => {
   it('routes CLI providers through executeCliRun', async () => {
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(cliProvider());
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('cli-output');
       onComplete({ success: true });
     });
@@ -209,7 +209,7 @@ describe('stageRunner — runStagedLLM dispatch', () => {
   it('rejects when executeApiRun reports an error', async () => {
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(apiProvider());
-    runner.executeApiRun.mockImplementation(async (_id, _p, _m, _pr, _cwd, _shots, _onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ error: 'simulated 500' });
     });
     await expect(runStagedLLM('s', {})).rejects.toThrow(/simulated 500/);
@@ -218,7 +218,7 @@ describe('stageRunner — runStagedLLM dispatch', () => {
   it('rejects when executeCliRun reports success: false', async () => {
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(cliProvider());
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: false, error: 'cli failed' });
     });
     await expect(runStagedLLM('s', {})).rejects.toThrow(/cli failed/);
@@ -227,7 +227,7 @@ describe('stageRunner — runStagedLLM dispatch', () => {
   it('parses JSON when returnsJson is true', async () => {
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(apiProvider());
-    runner.executeApiRun.mockImplementation(async (_id, _p, _m, _pr, _cwd, _shots, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('```json\n{"x":1}\n```');
       onComplete({ success: true });
     });
@@ -238,7 +238,7 @@ describe('stageRunner — runStagedLLM dispatch', () => {
   it('forwards source to createRun for transcript filtering', async () => {
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(apiProvider());
-    runner.executeApiRun.mockImplementation(async (_id, _p, _m, _pr, _cwd, _shots, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(async ({ onData, onComplete }) => {
       onData('out');
       onComplete({ success: true });
     });
@@ -249,32 +249,32 @@ describe('stageRunner — runStagedLLM dispatch', () => {
   it('passes stage.timeout to executeCliRun when set', async () => {
     prompts.getStage.mockReturnValue({ timeout: 900000 });
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {});
-    // executeCliRun(runId, provider, prompt, cwd, onData, onComplete, timeout)
-    expect(runner.executeCliRun.mock.calls[0][6]).toBe(900000);
+    // executeCliRun({ runId, provider, prompt, workspacePath, onData, onComplete, timeout })
+    expect(runner.executeCliRun.mock.calls[0][0].timeout).toBe(900000);
   });
 
   it('falls back to provider.timeout when stage.timeout is missing', async () => {
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {});
-    expect(runner.executeCliRun.mock.calls[0][6]).toBe(5000);
+    expect(runner.executeCliRun.mock.calls[0][0].timeout).toBe(5000);
   });
 
   it('coerces a legacy digit-only stringified stage.timeout to a number', async () => {
     prompts.getStage.mockReturnValue({ timeout: '900000' });
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {});
-    expect(runner.executeCliRun.mock.calls[0][6]).toBe(900000);
+    expect(runner.executeCliRun.mock.calls[0][0].timeout).toBe(900000);
   });
 
   it('rejects exponent/hex/float string forms (matches parseTimeoutMs)', async () => {
@@ -283,31 +283,31 @@ describe('stageRunner — runStagedLLM dispatch', () => {
     // the route validator and client parser.
     prompts.getStage.mockReturnValue({ timeout: '1e3' });
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {});
-    expect(runner.executeCliRun.mock.calls[0][6]).toBe(5000);
+    expect(runner.executeCliRun.mock.calls[0][0].timeout).toBe(5000);
   });
 
   it('rejects zero/negative stage.timeout instead of cancelling instantly', async () => {
     prompts.getStage.mockReturnValue({ timeout: 0 });
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {});
-    expect(runner.executeCliRun.mock.calls[0][6]).toBe(5000);
+    expect(runner.executeCliRun.mock.calls[0][0].timeout).toBe(5000);
   });
 
   it('honors timeoutOverride beating both stage.timeout and provider.timeout', async () => {
     prompts.getStage.mockReturnValue({ timeout: 900000 });
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {}, { timeoutOverride: 1234 });
-    expect(runner.executeCliRun.mock.calls[0][6]).toBe(1234);
+    expect(runner.executeCliRun.mock.calls[0][0].timeout).toBe(1234);
   });
 
   it('rejects a non-integer stage.timeout (no silent truncation)', async () => {
@@ -316,11 +316,11 @@ describe('stageRunner — runStagedLLM dispatch', () => {
     // runner mirrors that. Falls back to provider default.
     prompts.getStage.mockReturnValue({ timeout: 1000.9 });
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {});
-    expect(runner.executeCliRun.mock.calls[0][6]).toBe(5000);
+    expect(runner.executeCliRun.mock.calls[0][0].timeout).toBe(5000);
   });
 
   it('rejects a non-positive timeoutOverride instead of running unbounded', async () => {
@@ -329,11 +329,11 @@ describe('stageRunner — runStagedLLM dispatch', () => {
     // when neither is set).
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {}, { timeoutOverride: 0 });
-    expect(runner.executeCliRun.mock.calls[0][6]).toBe(5000);
+    expect(runner.executeCliRun.mock.calls[0][0].timeout).toBe(5000);
   });
 
   it('rejects a too-large timeoutOverride (above 30-min cap) and falls back', async () => {
@@ -341,11 +341,11 @@ describe('stageRunner — runStagedLLM dispatch', () => {
     // not silently clamped. Falls through to provider.timeout.
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {}, { timeoutOverride: 9_999_999_999 });
-    expect(runner.executeCliRun.mock.calls[0][6]).toBe(5000);
+    expect(runner.executeCliRun.mock.calls[0][0].timeout).toBe(5000);
   });
 
   it('rejects a timeoutOverride below the 1s floor', async () => {
@@ -354,17 +354,17 @@ describe('stageRunner — runStagedLLM dispatch', () => {
     // override would otherwise become a near-instant cancel.
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {}, { timeoutOverride: 999 });
-    expect(runner.executeCliRun.mock.calls[0][6]).toBe(5000);
+    expect(runner.executeCliRun.mock.calls[0][0].timeout).toBe(5000);
   });
 
   it('passes effectiveTimeout into createRun so /runs metadata matches execution', async () => {
     prompts.getStage.mockReturnValue({ timeout: 900000 });
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {});
@@ -374,7 +374,7 @@ describe('stageRunner — runStagedLLM dispatch', () => {
   it('falls back to provider.timeout in createRun call when no override is set', async () => {
     prompts.getStage.mockReturnValue(null);
     providers.getActiveProvider.mockResolvedValue(cliProvider({ timeout: 5000 }));
-    runner.executeCliRun.mockImplementation(async (_id, _p, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ onComplete }) => {
       onComplete({ success: true });
     });
     await runStagedLLM('s', {});
@@ -391,7 +391,7 @@ describe('stageRunner — runStagedLLM dispatch', () => {
     const fallback = cliProvider({ id: 'fallback-cli', defaultModel: 'fallback-model', timeout: 7000 });
     providers.getActiveProvider.mockResolvedValue(original);
     runner.createRun.mockResolvedValueOnce({ runId: 'run-abc12345', provider: fallback });
-    runner.executeCliRun.mockImplementation(async (_id, providerArg, _pr, _cwd, _onData, onComplete, _t) => {
+    runner.executeCliRun.mockImplementation(async ({ provider: providerArg, onComplete }) => {
       // Critical: execution must run against the fallback (the one createRun
       // returned), NOT the original requested provider.
       expect(providerArg.id).toBe('fallback-cli');

--- a/server/lib/tuiPromptRunner.js
+++ b/server/lib/tuiPromptRunner.js
@@ -65,7 +65,7 @@ const PTY_ROWS = 50;
 /**
  * Run a single prompt through a TUI provider. Mirrors the signature of
  * `executeCliRun` / `executeApiRun` so the central handler treats all three
- * branches uniformly (positional, NOT an options object).
+ * branches uniformly (a single options object).
  *
  * Caller (typically `runPromptThroughProvider`) owns the run record:
  *   - `createRun` (toolkit) writes the initial metadata.json + prompt.txt
@@ -73,24 +73,25 @@ const PTY_ROWS = 50;
  *     via `runner.js#finalizeRunRecord`, so /runs shows TUI runs with the
  *     same success/exitCode/duration shape as CLI runs.
  *
- * @param {string} runId — pre-created run id (from createRun).
- * @param {object} provider — { id, type: 'tui', command, args, envVars,
+ * @param {object} options
+ * @param {string} options.runId — pre-created run id (from createRun).
+ * @param {object} options.provider — { id, type: 'tui', command, args, envVars,
  *   tuiPromptDelayMs?, tuiOneShotIdleMs?, timeout?, defaultModel? }. The
  *   model passed to `--model` is taken from `provider.defaultModel`; per-
  *   call overrides are applied by the central handler via a provider clone
  *   before this function is reached.
- * @param {string} prompt — full text to paste into the TUI.
- * @param {string} cwd — working directory for the spawned TUI.
- * @param {(chunk: string) => void} [onData] — incremental ANSI-stripped
+ * @param {string} options.prompt — full text to paste into the TUI.
+ * @param {string} options.workspacePath — working directory for the spawned TUI.
+ * @param {(chunk: string) => void} [options.onData] — incremental ANSI-stripped
  *   output stream.
- * @param {(meta: object) => void} [onComplete] — fired after exit with
+ * @param {(meta: object) => void} [options.onComplete] — fired after exit with
  *   `{ exitCode, duration, success, error?, model? }`. Promise resolves
  *   AFTER this fires.
- * @param {number} [timeout] — hard cap on a single run (ms). Falls back to
+ * @param {number} [options.timeout] — hard cap on a single run (ms). Falls back to
  *   `provider.timeout`, then `DEFAULT_TIMEOUT_MS`.
  * @returns {Promise<void>}
  */
-export async function executeTuiRun(runId, provider, prompt, cwd, onData, onComplete, timeout) {
+export async function executeTuiRun({ runId, provider, prompt, workspacePath, onData, onComplete, timeout }) {
   if (!provider || typeof provider !== 'object') {
     throw new Error('executeTuiRun: provider is required');
   }
@@ -102,7 +103,7 @@ export async function executeTuiRun(runId, provider, prompt, cwd, onData, onComp
   const promptDelayMs = provider.tuiPromptDelayMs ?? DEFAULT_TUI_PROMPT_DELAY_MS;
   const idleThresholdMs = provider.tuiOneShotIdleMs ?? DEFAULT_ONE_SHOT_IDLE_MS;
   const totalTimeoutMs = timeout ?? provider.timeout ?? DEFAULT_TIMEOUT_MS;
-  const workingDir = (typeof cwd === 'string' && cwd) ? cwd : PATHS.root;
+  const workingDir = (typeof workspacePath === 'string' && workspacePath) ? workspacePath : PATHS.root;
 
   // Mirror runner.js#executeCliRun's runs-path resolution so TUI runs land
   // under the runner-config dataDir (not always PATHS.runs) — otherwise a

--- a/server/lib/tuiPromptRunner.test.js
+++ b/server/lib/tuiPromptRunner.test.js
@@ -264,21 +264,21 @@ describe('executeTuiRun', () => {
 
   describe('input validation', () => {
     it('throws when provider is missing', async () => {
-      await expect(executeTuiRun('run-x', null, 'prompt', '/tmp'))
+      await expect(executeTuiRun({ runId: 'run-x', provider: null, prompt: 'prompt', workspacePath: '/tmp' }))
         .rejects.toThrow(/provider is required/);
       expect(ptySpawnMock).not.toHaveBeenCalled();
     });
 
     it('throws when prompt is empty', async () => {
       const provider = { id: 'claude', type: 'tui', command: 'echo' };
-      await expect(executeTuiRun('run-x', provider, '', '/tmp'))
+      await expect(executeTuiRun({ runId: 'run-x', provider, prompt: '', workspacePath: '/tmp' }))
         .rejects.toThrow(/non-empty string/);
       expect(ptySpawnMock).not.toHaveBeenCalled();
     });
 
     it('throws when prompt is non-string', async () => {
       const provider = { id: 'claude', type: 'tui', command: 'echo' };
-      await expect(executeTuiRun('run-x', provider, 12345, '/tmp'))
+      await expect(executeTuiRun({ runId: 'run-x', provider, prompt: 12345, workspacePath: '/tmp' }))
         .rejects.toThrow(/non-empty string/);
     });
   });
@@ -287,7 +287,7 @@ describe('executeTuiRun', () => {
     it('wraps node-pty spawn errors with the offending command name', async () => {
       ptySpawnMock.mockImplementation(() => { throw new Error('ENOENT'); });
       const provider = { id: 'codex', type: 'tui', command: 'nonexistent-cli' };
-      await expect(executeTuiRun('run-x', provider, 'do thing', '/tmp'))
+      await expect(executeTuiRun({ runId: 'run-x', provider, prompt: 'do thing', workspacePath: '/tmp' }))
         .rejects.toThrow(/Failed to spawn TUI 'nonexistent-cli': ENOENT/);
     });
   });
@@ -297,7 +297,7 @@ describe('executeTuiRun', () => {
       const provider = {
         id: 'claude', type: 'tui', command: 'echo', defaultModel: 'claude-3.5',
       };
-      const promise = executeTuiRun('run-A', provider, 'do thing big enough', '/cwd', undefined, undefined, 60000);
+      const promise = executeTuiRun({ runId: 'run-A', provider, prompt: 'do thing big enough', workspacePath: '/cwd', onData: undefined, onComplete: undefined, timeout: 60000 });
       await flushAsync();
 
       expect(ptySpawnMock).toHaveBeenCalledTimes(1);
@@ -327,7 +327,7 @@ describe('executeTuiRun', () => {
           id: 'claude', type: 'tui', command: 'echo',
           envVars: { CUSTOM_PROVIDER_VAR: 'on' },
         };
-        const promise = executeTuiRun('run-B', provider, 'p large enough to clear the guard', '/cwd', undefined, undefined, 60000);
+        const promise = executeTuiRun({ runId: 'run-B', provider, prompt: 'p large enough to clear the guard', workspacePath: '/cwd', onData: undefined, onComplete: undefined, timeout: 60000 });
         await flushAsync();
 
         const env = ptySpawnMock.mock.calls[0][2].env;
@@ -355,7 +355,7 @@ describe('executeTuiRun', () => {
         tuiPromptDelayMs: 50, tuiOneShotIdleMs: 500,
       };
       const onComplete = vi.fn();
-      const promise = executeTuiRun('run-idle', provider, 'do thing big enough to clear the prompt guard', '/cwd', undefined, onComplete, 60000);
+      const promise = executeTuiRun({ runId: 'run-idle', provider, prompt: 'do thing big enough to clear the prompt guard', workspacePath: '/cwd', onData: undefined, onComplete, timeout: 60000 });
       await flushAsync();
 
       const pty = ptyInstances[0];
@@ -395,7 +395,7 @@ describe('executeTuiRun', () => {
         toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'],
       });
       const provider = { id: 'claude', type: 'tui', command: 'echo' };
-      const promise = executeTuiRun('run-timeout', provider, 'a prompt long enough to clear the guard', '/cwd', undefined, undefined, 500);
+      const promise = executeTuiRun({ runId: 'run-timeout', provider, prompt: 'a prompt long enough to clear the guard', workspacePath: '/cwd', onData: undefined, onComplete: undefined, timeout: 500 });
       await flushAsync();
 
       // No data emitted → no firstOutputAt → ready-watch never triggers paste
@@ -417,7 +417,7 @@ describe('executeTuiRun', () => {
 
     it('early-fails with reason "command-not-found" and exitCode 127 when "command not found" appears pre-paste', async () => {
       const provider = { id: 'codex', type: 'tui', command: 'no-such-tui' };
-      const promise = executeTuiRun('run-missing', provider, 'a prompt long enough', '/cwd', undefined, undefined, 60000);
+      const promise = executeTuiRun({ runId: 'run-missing', provider, prompt: 'a prompt long enough', workspacePath: '/cwd', onData: undefined, onComplete: undefined, timeout: 60000 });
       await flushAsync();
 
       // Shell banner echoing the missing-command error before paste.
@@ -436,7 +436,7 @@ describe('executeTuiRun', () => {
     it('early-fails with reason "fallback-signal" when Claude switches to extra usage', async () => {
       const provider = { id: 'claude', type: 'tui', command: 'claude' };
       const onComplete = vi.fn();
-      const promise = executeTuiRun('run-extra-usage', provider, 'a prompt long enough', '/cwd', undefined, onComplete, 60000);
+      const promise = executeTuiRun({ runId: 'run-extra-usage', provider, prompt: 'a prompt long enough', workspacePath: '/cwd', onData: undefined, onComplete, timeout: 60000 });
       await flushAsync();
 
       ptyInstances[0].emitData('Now using extra ');
@@ -461,7 +461,7 @@ describe('executeTuiRun', () => {
 
     it('finishes with reason "exit" + exitCode 0 when the PTY closes cleanly', async () => {
       const provider = { id: 'claude', type: 'tui', command: 'echo' };
-      const promise = executeTuiRun('run-exit', provider, 'a prompt long enough', '/cwd', undefined, undefined, 60000);
+      const promise = executeTuiRun({ runId: 'run-exit', provider, prompt: 'a prompt long enough', workspacePath: '/cwd', onData: undefined, onComplete: undefined, timeout: 60000 });
       await flushAsync();
 
       ptyInstances[0].emitExit({ exitCode: 0 });
@@ -478,7 +478,7 @@ describe('executeTuiRun', () => {
 
     it('finishes with reason "killed" and surfaces the signal in the error when the PTY is terminated', async () => {
       const provider = { id: 'claude', type: 'tui', command: 'echo' };
-      const promise = executeTuiRun('run-killed', provider, 'a prompt long enough', '/cwd', undefined, undefined, 60000);
+      const promise = executeTuiRun({ runId: 'run-killed', provider, prompt: 'a prompt long enough', workspacePath: '/cwd', onData: undefined, onComplete: undefined, timeout: 60000 });
       await flushAsync();
 
       ptyInstances[0].emitData('some screen output');
@@ -496,7 +496,7 @@ describe('executeTuiRun', () => {
 
     it('finishes with a tail-bearing error message when the PTY exits non-zero with prior output', async () => {
       const provider = { id: 'claude', type: 'tui', command: 'echo' };
-      const promise = executeTuiRun('run-nonzero', provider, 'a prompt long enough', '/cwd', undefined, undefined, 60000);
+      const promise = executeTuiRun({ runId: 'run-nonzero', provider, prompt: 'a prompt long enough', workspacePath: '/cwd', onData: undefined, onComplete: undefined, timeout: 60000 });
       await flushAsync();
 
       ptyInstances[0].emitData('fatal: provider config malformed at line 42');

--- a/server/services/mediaPromptRefiner.test.js
+++ b/server/services/mediaPromptRefiner.test.js
@@ -29,12 +29,10 @@ beforeEach(() => {
   runner.createRun.mockResolvedValue({ runId: 'test-run' });
 });
 
-// executeCliRun and executeApiRun have different signatures — onData/onComplete
-// sit at different positions. Find the two trailing function args dynamically.
+// executeCliRun and executeApiRun both take a single options object with
+// onData/onComplete callbacks — drive them from the options.
 function mockRunnerSuccess(target, payload) {
-  target.mockImplementation((...args) => {
-    const fns = args.filter((a) => typeof a === 'function');
-    const [onData, onComplete] = fns;
+  target.mockImplementation(({ onData, onComplete }) => {
     onData(payload);
     onComplete({ success: true });
     return Promise.resolve();
@@ -345,7 +343,7 @@ ${JSON.stringify({ prompt: 'painted owl portrait', negativePrompt: 'blurry', rat
     providers.getProviderById.mockResolvedValue({
       id: 'openai', type: 'api', enabled: true, defaultModel: 'gpt-test',
     });
-    runner.executeApiRun.mockImplementation((runId, provider, model, prompt, cwd, ctx, onData, onComplete) => {
+    runner.executeApiRun.mockImplementation(({ onComplete }) => {
       onComplete({ error: 'upstream down' });
       return Promise.resolve();
     });

--- a/server/services/pipeline/textStages.test.js
+++ b/server/services/pipeline/textStages.test.js
@@ -41,7 +41,7 @@ vi.mock('../runner.js', () => ({
   // onComplete with success. Mirrors what universeBuilderExpand.test.js doesn't
   // need to do (it mocks the upstream expander), but we test the lower-level
   // text-stage runner here.
-  executeApiRun: vi.fn(async (runId, provider, model, prompt, _cwd, _shots, onData, onComplete) => {
+  executeApiRun: vi.fn(async ({ runId, provider, model, prompt, onData, onComplete }) => {
     llmCalls.push({ runId, provider: provider.id, model, prompt });
     onData('## Beat sheet\n1. Setup ...\n');
     onComplete({ success: true });
@@ -120,7 +120,7 @@ describe('pipeline text stage generator', () => {
   it('marks stage as error and rethrows when LLM rejects', async () => {
     const { issue } = await seed();
     const runner = await import('../runner.js');
-    runner.executeApiRun.mockImplementationOnce(async (runId, _p, _m, _prompt, _cwd, _shots, _onData, onComplete) => {
+    runner.executeApiRun.mockImplementationOnce(async ({ onComplete }) => {
       onComplete({ error: 'simulated provider 500' });
     });
     await expect(textStages.generateStage(issue.id, 'idea')).rejects.toThrow(/simulated provider 500/);

--- a/server/services/runner.js
+++ b/server/services/runner.js
@@ -143,7 +143,7 @@ export async function patchRunMetadata(runId, patch) {
  * Override executeCliRun to fix shell security issue
  * This removes 'shell: true' which causes DEP0190 warning and potential security issues
  */
-export async function executeCliRun(runId, provider, prompt, workspacePath, onData, onComplete, timeout) {
+export async function executeCliRun({ runId, provider, prompt, workspacePath, onData, onComplete, timeout }) {
   const toolkit = requireToolkit();
 
   const runsPath = join(runnerConfig.dataDir, 'runs');
@@ -275,8 +275,8 @@ export async function executeCliRun(runId, provider, prompt, workspacePath, onDa
   return runId;
 }
 
-export async function executeApiRun(runId, provider, model, prompt, workspacePath, screenshots, onData, onComplete) {
-  return requireToolkit().services.runner.executeApiRun(runId, provider, model, prompt, workspacePath, screenshots, onData, onComplete);
+export async function executeApiRun(options) {
+  return requireToolkit().services.runner.executeApiRun(options);
 }
 
 /**

--- a/server/services/runner.test.js
+++ b/server/services/runner.test.js
@@ -64,7 +64,7 @@ describe('executeCliRun — Codex sentinel suppression', () => {
       child.emit('close', 0);
     });
 
-    await executeCliRun('run-1', provider, 'test prompt', '/workspace');
+    await executeCliRun({ runId: 'run-1', provider, prompt: 'test prompt', workspacePath: '/workspace' });
 
     const [, capturedArgs] = spawn.mock.calls.at(-1);
     expect(capturedArgs).not.toContain('--model');
@@ -91,7 +91,7 @@ describe('executeCliRun — Codex sentinel suppression', () => {
       child.emit('close', 0);
     });
 
-    await executeCliRun('run-2', provider, 'test prompt', '/workspace');
+    await executeCliRun({ runId: 'run-2', provider, prompt: 'test prompt', workspacePath: '/workspace' });
 
     const [, capturedArgs] = spawn.mock.calls.at(-1);
     const modelIdx = capturedArgs.indexOf('--model');
@@ -114,7 +114,7 @@ describe('executeCliRun — Codex sentinel suppression', () => {
     };
 
     const completed = new Promise((resolve) => {
-      executeCliRun('run-extra-usage', provider, 'test prompt', '/workspace', undefined, resolve, 60000);
+      executeCliRun({ runId: 'run-extra-usage', provider, prompt: 'test prompt', workspacePath: '/workspace', onData: undefined, onComplete: resolve, timeout: 60000 });
     });
 
     await Promise.resolve();
@@ -146,7 +146,7 @@ describe('executeCliRun — Codex sentinel suppression', () => {
     };
 
     const completed = new Promise((resolve) => {
-      executeCliRun('run-fallback-exit0', provider, 'test prompt', '/workspace', undefined, resolve, 60000);
+      executeCliRun({ runId: 'run-fallback-exit0', provider, prompt: 'test prompt', workspacePath: '/workspace', onData: undefined, onComplete: resolve, timeout: 60000 });
     });
 
     await Promise.resolve();


### PR DESCRIPTION
Closes #1085

## What

`executeCliRun` (7 positional params) and `executeApiRun` (8) had order-fragile call sites. Both now take a single named-options argument. `executeTuiRun` is converted too — it's dispatched in the *same* if/else chains as its siblings (in `runs.js` and `promptRunner.js`), so leaving it positional would have made those exact call sites *more* inconsistent, not less.

## Scope (changed in one pass per the issue's caution note)

- **Toolkit methods** — `executeCliRun`/`executeApiRun` in `server/lib/aiToolkit/runner.js`
- **PortOS overrides** — `executeCliRun` (full body) + `executeApiRun` (now a verbatim pass-through shim) in `server/services/runner.js`; `executeTuiRun` in `server/lib/tuiPromptRunner.js` (`cwd` → `workspacePath` for cross-function consistency)
- **Override patch surface** — `server/index.js` only reassigns references, no signature dependency (verified)
- **Call sites** — runs router (`server/lib/aiToolkit/routes/runs.js`) and `server/lib/promptRunner.js`
- **Tests** — all mocking/assertion sites updated to the options shape (`runner.test.js`, `routes/runs.test.js`, `services/runner.test.js`, `promptRunner.test.js`, `stageRunner.test.js`, `tuiPromptRunner.test.js`, `mediaPromptRefiner.test.js`, `textStages.test.js`)

Option field names mirror each function's existing internal variable names, so the function bodies are unchanged — this is a pure signature refactor with **no behavior change**.

## Tests

Full server suite green: 531 files, 10,636 passed, 2 skipped.