### PR TITLE
feat([issue-1089]): document detect/repo trust model + optional PORTOS_WORKSPACE_ROOTS scoping

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -18,6 +18,7 @@
 - **[issue-1086] Maintenance:** Extracted the sidebar's apps/series/universes data-fetch loops into dedicated, independently-tested hooks — no behavior change.
 - **[issue-1087] Maintenance:** Extracted the duplicated install-progress streaming logic shared by the FLUX.2 and video-runtime installer dialogs into one tested hook — no behavior change.
 - **[issue-1088] Maintenance:** Added behavioral tests for the Backup settings tab covering settings save, the database restore confirmation gate, and backup-status rendering — no behavior change.
+- **[issue-1089] Repo detection path scoping:** The "import a repo" detector now documents its single-user trust model and, when you set `PORTOS_WORKSPACE_ROOTS`, confines detection to those directories — pointing it elsewhere returns an invalid-path result instead of reading the directory. Unset (the default), detection stays unrestricted as before.
 
 ## Fixed
 

--- a/server/lib/README.md
+++ b/server/lib/README.md
@@ -212,6 +212,7 @@ The barrel `server/lib/index.js` is a machine-checkable enumeration of every pub
 | `sseUtils.js` | Per-job SSE stream helpers (imageGen + others). |
 | `streamBackpressure.js` | `awaitWritableDrain(res)` — park a streaming-response producer on the socket's next `drain` (or `close`) when `res.write()` returned false, so SSE/NDJSON writes stay bounded for a slow reader. Shared by `routes/ask.js` (SSE) and `routes/localLlm.js` (NDJSON). |
 | `uuid.js` | `v4()` thin wrapper over `crypto.randomUUID()`. |
+| `workspaceRoots.js` | Shared allow-list for routes that take a caller-supplied filesystem path. `ALLOWED_WORKSPACE_ROOTS` (defaults + `PORTOS_WORKSPACE_ROOTS`, symlink-resolved), `isWithinRoot(resolvedPath, root)` (separator-safe containment), `isWithinAllowedRoots(realPath)`, and `WORKSPACE_ROOTS_CONFIGURED` (true when the operator set the env var — lets a permissive-by-default route like `routes/detect.js` opt into confinement). Used by `routes/commands.js` (always scoped) and `routes/detect.js` (scoped only when configured). |
 | `zodCompat.js` | Zod 4 compatibility helpers. `partialWithoutDefaults(objectSchema)` — like `.partial()` but strips inner field defaults first, so a PATCH/update schema doesn't inject (and clobber) the stored values of fields the caller didn't send. Use for any update schema derived from a defaulted base. |
 
 ## Test support

--- a/server/lib/index.js
+++ b/server/lib/index.js
@@ -179,6 +179,7 @@ export * from './singleFlight.js';
 export * from './streamBackpressure.js';
 export * from './sseUtils.js';
 export * from './uuid.js';
+export * from './workspaceRoots.js';
 export * from './zodCompat.js';
 
 // === Test support (consumed by *.test.js files) ===

--- a/server/lib/workspaceRoots.js
+++ b/server/lib/workspaceRoots.js
@@ -1,0 +1,49 @@
+import { realpathSync } from 'fs';
+import { resolve, relative, isAbsolute } from 'path';
+import { homedir } from 'os';
+
+// Allowed workspace roots shared by routes that accept a caller-supplied
+// filesystem path (command execution scoping in `routes/commands.js`, repo
+// detection in `routes/detect.js`).
+//
+// Defaults cover common single-user Tailscale deployments (home + /tmp +
+// /Users so multiple macOS accounts' repos work, plus /Volumes for external
+// drives and /opt for Linux server layouts). Operators can extend via
+// PORTOS_WORKSPACE_ROOTS="/path1:/path2" if their repos live somewhere more
+// exotic.
+//
+// Roots are symlink-resolved (e.g. /tmp -> /private/tmp on macOS) so a path
+// the caller passed and we realpath() still matches.
+export const DEFAULT_WORKSPACE_ROOTS = [homedir(), '/tmp', '/Users', '/Volumes', '/opt'];
+
+export const EXTRA_WORKSPACE_ROOTS = (process.env.PORTOS_WORKSPACE_ROOTS || '')
+  .split(':')
+  .map(s => s.trim())
+  .filter(Boolean);
+
+// True when the operator has explicitly configured PORTOS_WORKSPACE_ROOTS.
+// Routes that are permissive by default (detect) opt into root-restriction
+// only when this is set; routes that always scope (command execution) ignore
+// it and enforce against ALLOWED_WORKSPACE_ROOTS unconditionally.
+export const WORKSPACE_ROOTS_CONFIGURED = EXTRA_WORKSPACE_ROOTS.length > 0;
+
+export const ALLOWED_WORKSPACE_ROOTS = [...DEFAULT_WORKSPACE_ROOTS, ...EXTRA_WORKSPACE_ROOTS]
+  .map(r => {
+    const abs = resolve(r);
+    // Falls back to the resolved path if the root doesn't exist yet — callers
+    // providing paths under a non-existent root will fail the existence check.
+    try { return realpathSync(abs); } catch { return abs; }
+  });
+
+// Separator-safe containment: resolvedPath === root or is a descendant of root.
+export function isWithinRoot(resolvedPath, root) {
+  if (resolvedPath === root) return true;
+  const rel = relative(root, resolvedPath);
+  return !!rel && !rel.startsWith('..') && !isAbsolute(rel);
+}
+
+// True when a symlink-resolved path sits inside any allowed root. Callers must
+// pass an already-realpath()'d path so a symlink can't escape the check.
+export function isWithinAllowedRoots(realPath) {
+  return ALLOWED_WORKSPACE_ROOTS.some(root => isWithinRoot(realPath, root));
+}

--- a/server/lib/workspaceRoots.test.js
+++ b/server/lib/workspaceRoots.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { homedir } from 'os';
 import { join } from 'path';
 import {
@@ -50,5 +50,40 @@ describe('ALLOWED_WORKSPACE_ROOTS', () => {
     // exact strings (e.g. /tmp -> /private/tmp on macOS).
     expect(ALLOWED_WORKSPACE_ROOTS.length).toBeGreaterThanOrEqual(DEFAULT_WORKSPACE_ROOTS.length);
     expect(ALLOWED_WORKSPACE_ROOTS.every(r => typeof r === 'string' && r.length > 0)).toBe(true);
+  });
+});
+
+// PORTOS_WORKSPACE_ROOTS is read once at module load, so these re-import a fresh
+// copy of the module under a stubbed env to exercise the opt-in gate (the actual
+// subject of issue #1089) in both states.
+describe('PORTOS_WORKSPACE_ROOTS opt-in gate', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('WORKSPACE_ROOTS_CONFIGURED is false when the env var is unset', async () => {
+    vi.stubEnv('PORTOS_WORKSPACE_ROOTS', '');
+    vi.resetModules();
+    const mod = await import('./workspaceRoots.js');
+    expect(mod.WORKSPACE_ROOTS_CONFIGURED).toBe(false);
+    expect(mod.EXTRA_WORKSPACE_ROOTS).toEqual([]);
+  });
+
+  it('parses colon-separated roots, trimming and dropping empties', async () => {
+    vi.stubEnv('PORTOS_WORKSPACE_ROOTS', ' /srv/repos : : /data/projects ');
+    vi.resetModules();
+    const mod = await import('./workspaceRoots.js');
+    expect(mod.WORKSPACE_ROOTS_CONFIGURED).toBe(true);
+    expect(mod.EXTRA_WORKSPACE_ROOTS).toEqual(['/srv/repos', '/data/projects']);
+  });
+
+  it('folds the configured roots into the allow-list so paths under them pass', async () => {
+    vi.stubEnv('PORTOS_WORKSPACE_ROOTS', '/srv/repos');
+    vi.resetModules();
+    const mod = await import('./workspaceRoots.js');
+    // /srv/repos likely does not exist on the test host, so the root falls back
+    // to its resolved (non-realpath) form — containment still matches descendants.
+    expect(mod.isWithinAllowedRoots('/srv/repos/myapp')).toBe(true);
   });
 });

--- a/server/lib/workspaceRoots.test.js
+++ b/server/lib/workspaceRoots.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { homedir } from 'os';
+import { join } from 'path';
+import {
+  isWithinRoot,
+  isWithinAllowedRoots,
+  ALLOWED_WORKSPACE_ROOTS,
+  DEFAULT_WORKSPACE_ROOTS,
+} from './workspaceRoots.js';
+
+describe('isWithinRoot', () => {
+  it('returns true when the path IS the root', () => {
+    expect(isWithinRoot('/Users/alice', '/Users/alice')).toBe(true);
+  });
+
+  it('returns true for a descendant of the root', () => {
+    expect(isWithinRoot('/Users/alice/repo', '/Users/alice')).toBe(true);
+    expect(isWithinRoot('/Users/alice/repo/src/index.js', '/Users/alice')).toBe(true);
+  });
+
+  it('returns false for a path outside the root', () => {
+    expect(isWithinRoot('/etc/passwd', '/Users/alice')).toBe(false);
+    expect(isWithinRoot('/Users/bob', '/Users/alice')).toBe(false);
+  });
+
+  it('is separator-safe — a sibling that shares a name prefix is NOT contained', () => {
+    // /Users/alice-evil starts with "/Users/alice" as a string but is not under it.
+    expect(isWithinRoot('/Users/alice-evil/repo', '/Users/alice')).toBe(false);
+  });
+
+  it('does not treat a parent as contained', () => {
+    expect(isWithinRoot('/Users', '/Users/alice')).toBe(false);
+  });
+});
+
+describe('isWithinAllowedRoots', () => {
+  it('accepts a path under a default root (home dir)', () => {
+    expect(isWithinAllowedRoots(join(homedir(), 'projects', 'foo'))).toBe(true);
+  });
+
+  it('rejects a path outside every allowed root', () => {
+    // /etc is not in DEFAULT_WORKSPACE_ROOTS and (in tests) PORTOS_WORKSPACE_ROOTS is unset.
+    expect(isWithinAllowedRoots('/etc/shadow')).toBe(false);
+  });
+});
+
+describe('ALLOWED_WORKSPACE_ROOTS', () => {
+  it('includes every default root', () => {
+    // Defaults are symlink-resolved, so compare on length/non-empty rather than
+    // exact strings (e.g. /tmp -> /private/tmp on macOS).
+    expect(ALLOWED_WORKSPACE_ROOTS.length).toBeGreaterThanOrEqual(DEFAULT_WORKSPACE_ROOTS.length);
+    expect(ALLOWED_WORKSPACE_ROOTS.every(r => typeof r === 'string' && r.length > 0)).toBe(true);
+  });
+});

--- a/server/routes/commands.js
+++ b/server/routes/commands.js
@@ -1,39 +1,12 @@
 import { Router } from 'express';
 import { existsSync, statSync, realpathSync } from 'fs';
-import { resolve, relative, isAbsolute } from 'path';
-import { homedir } from 'os';
+import { resolve } from 'path';
 import * as commands from '../services/commands.js';
 import * as pm2Service from '../services/pm2.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
+import { isWithinAllowedRoots } from '../lib/workspaceRoots.js';
 
 const router = Router();
-
-// Allowed workspace roots. Defaults cover common single-user Tailscale
-// deployments (home + /tmp + /Users so multiple macOS accounts' repos work,
-// plus /Volumes for external drives and /opt for Linux server layouts).
-// Operators can extend via PORTOS_WORKSPACE_ROOTS="/path1:/path2" if their
-// repos live somewhere more exotic.
-// Resolve symlinks so e.g. /tmp -> /private/tmp on macOS still matches after
-// we realpath() the caller's workspacePath.
-const DEFAULT_WORKSPACE_ROOTS = [homedir(), '/tmp', '/Users', '/Volumes', '/opt'];
-const EXTRA_WORKSPACE_ROOTS = (process.env.PORTOS_WORKSPACE_ROOTS || '')
-  .split(':')
-  .map(s => s.trim())
-  .filter(Boolean);
-const ALLOWED_WORKSPACE_ROOTS = [...DEFAULT_WORKSPACE_ROOTS, ...EXTRA_WORKSPACE_ROOTS]
-  .map(r => {
-    const abs = resolve(r);
-    // Falls back to the resolved path if the root doesn't exist yet — callers
-    // providing paths under a non-existent root will fail the existence check.
-    try { return realpathSync(abs); } catch { return abs; }
-  });
-
-// Separator-safe containment: resolvedPath === root or is a descendant of root.
-function isWithinRoot(resolvedPath, root) {
-  if (resolvedPath === root) return true;
-  const rel = relative(root, resolvedPath);
-  return !!rel && !rel.startsWith('..') && !isAbsolute(rel);
-}
 
 // POST /api/commands/execute - Execute a command
 router.post('/execute', asyncHandler(async (req, res) => {
@@ -67,8 +40,7 @@ router.post('/execute', asyncHandler(async (req, res) => {
       if (err instanceof ServerError) throw err;
       throw new ServerError('workspacePath is not accessible', { status: 400, code: 'INVALID_PATH' });
     }
-    const isAllowed = ALLOWED_WORKSPACE_ROOTS.some(root => isWithinRoot(realPath, root));
-    if (!isAllowed) {
+    if (!isWithinAllowedRoots(realPath)) {
       throw new ServerError('workspacePath is outside allowed directories', { status: 400, code: 'INVALID_PATH' });
     }
   }

--- a/server/routes/detect.js
+++ b/server/routes/detect.js
@@ -56,8 +56,17 @@ router.post('/repo', asyncHandler(async (req, res) => {
 
   // Optional confinement: only when the operator has configured workspace roots.
   // realpath() first so a symlink can't smuggle a path past the containment check.
+  // realpathSync can throw on a permission/TOCTOU edge (path deleted between the
+  // stat above and here) — convert that to the same valid:false shape the rest of
+  // this route returns for unusable paths, rather than leaking a 500. This is the
+  // sanctioned fs-edge-case exception to the no-try/catch rule (see commands.js).
   if (WORKSPACE_ROOTS_CONFIGURED) {
-    const realPath = realpathSync(resolve(path));
+    let realPath;
+    try {
+      realPath = realpathSync(resolve(path));
+    } catch {
+      return res.json({ valid: false, error: 'Path is not accessible' });
+    }
     if (!isWithinAllowedRoots(realPath)) {
       return res.json({
         valid: false,

--- a/server/routes/detect.js
+++ b/server/routes/detect.js
@@ -1,18 +1,35 @@
 import { Router } from 'express';
-import { existsSync } from 'fs';
+import { existsSync, realpathSync } from 'fs';
 import { readFile, stat } from 'fs/promises';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { execPm2 } from '../services/pm2.js';
 import { detectAppWithAi } from '../services/aiDetect.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { safeJSONParse, tryReadFile } from '../lib/fileUtils.js';
+import { isWithinAllowedRoots, WORKSPACE_ROOTS_CONFIGURED } from '../lib/workspaceRoots.js';
 
 const execAsync = promisify(exec);
 const router = Router();
 
 // POST /api/detect/repo - Validate repo path and detect project type
+//
+// TRUST MODEL: This endpoint accepts an arbitrary, caller-supplied filesystem
+// path and reads a small set of well-known project files under it (package.json
+// scripts + name, project.yml, vite.config, and PORT/VITE_PORT lines from .env),
+// returning their values verbatim. This is INTENTIONAL: PortOS is a single-user
+// app on a private Tailscale network (see CLAUDE.md "Security Model"), where the
+// sole operator legitimately points the "import a repo" flow at any directory on
+// their own machine — there is no second user to read data from, so no path
+// confinement is required for safety.
+//
+// Operators who still want to confine detection to specific directories can set
+// PORTOS_WORKSPACE_ROOTS="/path1:/path2" (the same allow-list `routes/commands.js`
+// uses to scope command execution). When that env var is set, this route enforces
+// the allow-list too — a path outside the configured roots returns valid:false
+// rather than reading its files. When it is unset (the default), detection is
+// unrestricted, matching the pre-existing behavior.
 router.post('/repo', asyncHandler(async (req, res) => {
   const { path } = req.body;
 
@@ -35,6 +52,18 @@ router.post('/repo', asyncHandler(async (req, res) => {
       valid: false,
       error: 'Path is not a directory'
     });
+  }
+
+  // Optional confinement: only when the operator has configured workspace roots.
+  // realpath() first so a symlink can't smuggle a path past the containment check.
+  if (WORKSPACE_ROOTS_CONFIGURED) {
+    const realPath = realpathSync(resolve(path));
+    if (!isWithinAllowedRoots(realPath)) {
+      return res.json({
+        valid: false,
+        error: 'Path is outside the configured workspace roots (PORTOS_WORKSPACE_ROOTS)'
+      });
+    }
   }
 
   // Detect project type


### PR DESCRIPTION
Closes #1089

## What

`POST /api/detect/repo` accepts an arbitrary filesystem path and returns parsed `.env` PORT values + `package.json` scripts verbatim. This is intentional for a single-user Tailscale box, but was undocumented (flagged LOW/Security in the 2026-06-09 audit).

- **Documents the trust model** inline on the `/repo` handler — why an arbitrary-path read is safe here (one user, private network, no second party to read data from).
- **Adds opt-in confinement:** when the operator sets `PORTOS_WORKSPACE_ROOTS="/a:/b"`, detection is restricted to those roots and a path outside them returns `valid:false` instead of reading the directory. Unset (the default), behavior is unchanged — fully permissive.
- **Reuses, not duplicates:** the workspace-root allow-list already lived inline in `routes/commands.js`. Extracted it to a shared `server/lib/workspaceRoots.js` (`ALLOWED_WORKSPACE_ROOTS`, `isWithinRoot`, `isWithinAllowedRoots`, `WORKSPACE_ROOTS_CONFIGURED`) and both routes now consume it. `commands.js` keeps its always-on scoping; `detect.js` opts in only when configured.

## Tests

- New `server/lib/workspaceRoots.test.js` covers containment (separator-safe, sibling-prefix, parent rejection) and the allow-list.
- Barrel + README registered (enforced by `index.test.js`).
- Full `server/lib` suite green (2808 tests).