### PR TITLE
fix([issue-1090]): GitTab modal dialog roles + close affordance

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -22,4 +22,6 @@
 
 ## Fixed
 
+- **[issue-1090] Git tab dialogs are now screen-reader friendly** — the diff and release-confirmation pop-ups announce themselves as dialogs, their close buttons are labeled, and pressing Escape (or clicking outside) dismisses them.
+
 ## Removed

--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { GitBranch, Plus, Minus, FileText, RefreshCw, Download, Rocket, Upload, ArrowUpDown, Check, Trash2, GitMerge, Globe } from 'lucide-react';
 import toast from '../../ui/Toast';
+import Modal from '../../ui/Modal';
 import BrailleSpinner from '../../BrailleSpinner';
 import * as api from '../../../services/api';
 
@@ -801,71 +802,77 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
       )}
 
       {/* Diff Modal */}
-      {showDiff && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setShowDiff(false)}>
-          <div className="bg-port-card border border-port-border rounded-xl w-3/4 max-h-[80vh] overflow-hidden" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center justify-between p-4 border-b border-port-border">
-              <h3 className="font-medium text-white">Git Diff</h3>
-              <button onClick={() => setShowDiff(false)} className="text-gray-400 hover:text-white">×</button>
-            </div>
-            <pre className="p-4 overflow-auto max-h-[70vh] text-sm font-mono">
-              {diff.split('\n').map((line, i) => {
-                let color = 'text-gray-300';
-                if (line.startsWith('+') && !line.startsWith('+++')) color = 'text-port-success';
-                if (line.startsWith('-') && !line.startsWith('---')) color = 'text-port-error';
-                if (line.startsWith('@@')) color = 'text-port-accent';
-                return <div key={i} className={color}>{line}</div>;
-              })}
-              {!diff && <span className="text-gray-500">No changes to display</span>}
-            </pre>
-          </div>
+      <Modal
+        open={showDiff}
+        onClose={() => setShowDiff(false)}
+        size="none"
+        backdropClassName="bg-black/50"
+        panelClassName="bg-port-card border border-port-border rounded-xl w-3/4 max-h-[80vh] overflow-hidden"
+        ariaLabelledBy="git-diff-modal-title"
+      >
+        <div className="flex items-center justify-between p-4 border-b border-port-border">
+          <h3 id="git-diff-modal-title" className="font-medium text-white">Git Diff</h3>
+          <button onClick={() => setShowDiff(false)} aria-label="Close" className="text-gray-400 hover:text-white">×</button>
         </div>
-      )}
+        <pre className="p-4 overflow-auto max-h-[70vh] text-sm font-mono">
+          {diff.split('\n').map((line, i) => {
+            let color = 'text-gray-300';
+            if (line.startsWith('+') && !line.startsWith('+++')) color = 'text-port-success';
+            if (line.startsWith('-') && !line.startsWith('---')) color = 'text-port-error';
+            if (line.startsWith('@@')) color = 'text-port-accent';
+            return <div key={i} className={color}>{line}</div>;
+          })}
+          {!diff && <span className="text-gray-500">No changes to display</span>}
+        </pre>
+      </Modal>
 
       {/* Release Confirmation Dialog */}
-      {showReleaseConfirm && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setShowReleaseConfirm(false)}>
-          <div className="bg-port-card border border-port-border rounded-xl w-full max-w-lg overflow-hidden" onClick={e => e.stopPropagation()}>
-            <div className="flex items-center justify-between p-4 border-b border-port-border">
-              <h3 className="font-medium text-white flex items-center gap-2">
-                <Rocket size={18} className="text-port-accent" />
-                Create Release PR for {appName}
-              </h3>
-              <button onClick={() => setShowReleaseConfirm(false)} className="text-gray-400 hover:text-white">×</button>
-            </div>
-            <div className="p-4 space-y-3">
-              <p className="text-sm text-gray-300">
-                This will create a CoS agent task to automate the full release workflow:
-              </p>
-              <ul className="text-sm text-gray-400 space-y-1.5 ml-4 list-disc">
-                <li>Push local commits to origin/{gitInfo?.devBranch || 'dev'}</li>
-                {gitInfo?.hasChangelog && <li>Check and update the changelog</li>}
-                <li>Create PR from {gitInfo?.devBranch || 'dev'} to {gitInfo?.baseBranch || 'main'}</li>
-                <li>Wait for Copilot review and address feedback</li>
-                <li>Merge when approved and CI passes</li>
-              </ul>
-              <p className="text-xs text-gray-500">
-                {branchComparison?.ahead || 0} commits will be included in this release.
-              </p>
-            </div>
-            <div className="flex justify-end gap-3 p-4 border-t border-port-border">
-              <button
-                onClick={() => setShowReleaseConfirm(false)}
-                className="px-4 py-2 text-sm text-gray-400 hover:text-white"
-              >
-                Cancel
-              </button>
-              <button
-                onClick={handleReleasePR}
-                className="flex items-center gap-2 px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg text-sm"
-              >
-                <Rocket size={16} />
-                Start Release
-              </button>
-            </div>
-          </div>
+      <Modal
+        open={showReleaseConfirm}
+        onClose={() => setShowReleaseConfirm(false)}
+        size="md"
+        backdropClassName="bg-black/50"
+        panelClassName="bg-port-card border border-port-border rounded-xl overflow-hidden"
+        ariaLabelledBy="git-release-modal-title"
+      >
+        <div className="flex items-center justify-between p-4 border-b border-port-border">
+          <h3 id="git-release-modal-title" className="font-medium text-white flex items-center gap-2">
+            <Rocket size={18} className="text-port-accent" />
+            Create Release PR for {appName}
+          </h3>
+          <button onClick={() => setShowReleaseConfirm(false)} aria-label="Close" className="text-gray-400 hover:text-white">×</button>
         </div>
-      )}
+        <div className="p-4 space-y-3">
+          <p className="text-sm text-gray-300">
+            This will create a CoS agent task to automate the full release workflow:
+          </p>
+          <ul className="text-sm text-gray-400 space-y-1.5 ml-4 list-disc">
+            <li>Push local commits to origin/{gitInfo?.devBranch || 'dev'}</li>
+            {gitInfo?.hasChangelog && <li>Check and update the changelog</li>}
+            <li>Create PR from {gitInfo?.devBranch || 'dev'} to {gitInfo?.baseBranch || 'main'}</li>
+            <li>Wait for Copilot review and address feedback</li>
+            <li>Merge when approved and CI passes</li>
+          </ul>
+          <p className="text-xs text-gray-500">
+            {branchComparison?.ahead || 0} commits will be included in this release.
+          </p>
+        </div>
+        <div className="flex justify-end gap-3 p-4 border-t border-port-border">
+          <button
+            onClick={() => setShowReleaseConfirm(false)}
+            className="px-4 py-2 text-sm text-gray-400 hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleReleasePR}
+            className="flex items-center gap-2 px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg text-sm"
+          >
+            <Rocket size={16} />
+            Start Release
+          </button>
+        </div>
+      </Modal>
     </div>
   );
 }

--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -806,6 +806,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
         open={showDiff}
         onClose={() => setShowDiff(false)}
         size="none"
+        align="none"
         backdropClassName="bg-black/50"
         panelClassName="bg-port-card border border-port-border rounded-xl w-3/4 max-h-[80vh] overflow-hidden"
         ariaLabelledBy="git-diff-modal-title"
@@ -831,6 +832,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
         open={showReleaseConfirm}
         onClose={() => setShowReleaseConfirm(false)}
         size="md"
+        align="none"
         backdropClassName="bg-black/50"
         panelClassName="bg-port-card border border-port-border rounded-xl overflow-hidden"
         ariaLabelledBy="git-release-modal-title"

--- a/client/src/components/apps/tabs/GitTab.test.jsx
+++ b/client/src/components/apps/tabs/GitTab.test.jsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+
+// Mock the API surface GitTab calls on mount + when opening the diff modal.
+vi.mock('../../../services/api', () => ({
+  getGitInfo: vi.fn(),
+  getBranches: vi.fn(),
+  getBranchComparison: vi.fn(),
+  getRemoteBranches: vi.fn(),
+  getGitDiff: vi.fn(),
+}));
+
+import * as api from '../../../services/api';
+import GitTab from './GitTab';
+
+const GIT_INFO = {
+  isRepo: true,
+  branch: 'dev',
+  baseBranch: 'main',
+  devBranch: 'dev',
+  diffStats: { files: 1 },
+  status: { files: [{ path: 'a.js', status: 'M', staged: false }] },
+};
+
+const COMPARISON = {
+  ahead: 2,
+  stats: { insertions: 10, deletions: 3, files: 1 },
+  commits: [{ hash: 'abc1234', message: 'do a thing' }],
+};
+
+beforeEach(() => {
+  api.getGitInfo.mockResolvedValue(GIT_INFO);
+  api.getBranches.mockResolvedValue({ branches: [] });
+  api.getBranchComparison.mockResolvedValue(COMPARISON);
+  api.getRemoteBranches.mockResolvedValue({ branches: [], defaultBranch: 'main' });
+  api.getGitDiff.mockResolvedValue({ diff: '@@ -1 +1 @@\n-old\n+new' });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe('GitTab modal accessibility (issue #1090)', () => {
+  it('opens the diff as a labeled dialog with a labeled close button', async () => {
+    render(<GitTab appId="x" appName="App" repoPath="/repo" />);
+
+    const viewDiff = await screen.findByText('View Diff');
+    fireEvent.click(viewDiff);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'git-diff-modal-title');
+    // The labelling target is rendered inside the dialog.
+    expect(document.getElementById('git-diff-modal-title')).toHaveTextContent('Git Diff');
+    // Backdrop is presentation-only.
+    expect(dialog.parentElement).toHaveAttribute('role', 'presentation');
+    // Close affordance carries an accessible name.
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+
+  it('closes the diff dialog on Escape', async () => {
+    render(<GitTab appId="x" appName="App" repoPath="/repo" />);
+    fireEvent.click(await screen.findByText('View Diff'));
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull());
+  });
+
+  it('opens the release confirmation as a labeled dialog', async () => {
+    render(<GitTab appId="x" appName="App" repoPath="/repo" />);
+
+    const releaseBtn = await screen.findByText('Create Release PR');
+    fireEvent.click(releaseBtn);
+
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'git-release-modal-title');
+    expect(document.getElementById('git-release-modal-title')).toHaveTextContent('Create Release PR for App');
+    expect(dialog.parentElement).toHaveAttribute('role', 'presentation');
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+});

--- a/client/src/components/ui/Modal.test.jsx
+++ b/client/src/components/ui/Modal.test.jsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+import Modal from './Modal';
+
+afterEach(cleanup);
+
+describe('Modal accessibility', () => {
+  it('renders the panel as an accessible dialog over a presentation backdrop', () => {
+    render(
+      <Modal open onClose={() => {}} ariaLabel="Test dialog">
+        <p>body</p>
+      </Modal>
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-label', 'Test dialog');
+    // Backdrop is the dialog's parent and must be presentation-only so it
+    // isn't announced as interactive content.
+    expect(dialog.parentElement).toHaveAttribute('role', 'presentation');
+  });
+
+  it('labels the dialog via ariaLabelledBy (no redundant aria-label)', () => {
+    render(
+      <Modal open onClose={() => {}} ariaLabelledBy="title-id">
+        <h3 id="title-id">My Title</h3>
+      </Modal>
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-labelledby', 'title-id');
+    expect(dialog).not.toHaveAttribute('aria-label');
+  });
+
+  it('closes on Escape by default', () => {
+    const onClose = vi.fn();
+    render(<Modal open onClose={onClose} ariaLabel="x"><p>body</p></Modal>);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on backdrop click but not on panel click', () => {
+    const onClose = vi.fn();
+    render(<Modal open onClose={onClose} ariaLabel="x"><p>body</p></Modal>);
+    const dialog = screen.getByRole('dialog');
+    fireEvent.click(screen.getByText('body'));
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(dialog.parentElement);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing while closed', () => {
+    render(<Modal open={false} onClose={() => {}} ariaLabel="x"><p>body</p></Modal>);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #1090

## What
The Git tab's **Diff** and **Release Confirmation** modals were bare `onClick` backdrop divs with no dialog semantics. This converts both to the shared `ui/Modal` component, which supplies:

- `role="dialog"` + `aria-modal="true"` on the panel
- `role="presentation"` on the backdrop
- Escape-to-close (the issue's "bonus") and click-outside dismiss

It also adds `aria-label="Close"` to the `×` close buttons and `aria-labelledby` wiring to each modal's title.

## Why this approach
`ui/Modal` exists precisely to replace hand-rolled `fixed inset-0` overlays with accessible chrome — so this is a reuse/DRY win, not new abstraction. Original visuals are preserved exactly: `bg-black/50` backdrop (Modal defaults to `/70`, overridden via `backdropClassName`), `w-3/4 max-h-[80vh]` diff panel (`size="none"` + `panelClassName`), and `max-w-lg` release panel (`size="md"`).

## Tests
Adds `client/src/components/ui/Modal.test.jsx` (5 tests) pinning the dialog role, `aria-modal`, presentation backdrop, `aria-labelledby` labelling, Escape-to-close, and backdrop-vs-panel click behavior — the exact a11y guarantees #1090 asks for. The shared `Modal` had no prior test coverage.