### PR TITLE
fix(recovery): restore the JSONB data.deleted, not just the denormalized column

### DIFF
--- a/scripts/recover-synced-test-fixtures.mjs
+++ b/scripts/recover-synced-test-fixtures.mjs
@@ -10,8 +10,11 @@
  * larger — so a size threshold separates them cleanly with a wide safety gap.
  *
  * This script (per machine):
- *   1. RESTORES real records that were tombstoned by test cleanup (deleted=true
- *      AND data >= threshold)  → un-tombstones them.
+ *   1. RESTORES real records that were tombstoned by test cleanup (data >=
+ *      threshold AND the JSONB `data.deleted` is true) → clears `data.deleted` +
+ *      `data.deletedAt`, bumps `data.updatedAt`, and resyncs the row columns.
+ *      The app reads deleted-state from the JSONB, NOT the row's `deleted`
+ *      column, so flipping only the column leaves records invisible in the UI.
  *   2. PURGES fixture records (data < threshold), whether live or deleted.
  *   3. PRUNES data/sharing/peer_subscriptions.json of subscriptions that point
  *      at records no longer present.
@@ -57,8 +60,20 @@ const mode = APPLY ? '🔧 APPLY' : '🔎 DRY-RUN';
 log(`${mode} — recover synced test fixtures  (uni<${UNI_THRESHOLD}B, ser<${SER_THRESHOLD}B = fixture)`);
 log(`   DB: ${HOST}:${PORT}/${DB}\n`);
 
+// The deleted state that the app actually reads lives INSIDE the `data` JSONB
+// (the row's `deleted` column is just a denormalized index). Restore must clear
+// `data.deleted` (+ `data.deletedAt`) and bump `data.updatedAt`, then resync the
+// columns — flipping only the column leaves the record invisible in the UI.
+const jsonbTombstoned = (col = 'data') => `(${col}->>'deleted')::boolean IS TRUE`;
+const restoreSql = (table, threshold) => `
+UPDATE ${table}
+SET data = jsonb_set((data - 'deletedAt'), '{deleted}', 'false'::jsonb)
+           || jsonb_build_object('updatedAt', to_char(now() AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')),
+    deleted = false, deleted_at = NULL, updated_at = now()
+WHERE ${jsonbTombstoned()} AND length(data::text) >= ${threshold};`;
+
 // ---- Universes ----
-const uniRestore = Number(psql(`SELECT count(*) FROM universes WHERE deleted=true AND length(data::text) >= ${UNI_THRESHOLD}`));
+const uniRestore = Number(psql(`SELECT count(*) FROM universes WHERE ${jsonbTombstoned()} AND length(data::text) >= ${UNI_THRESHOLD}`));
 const uniPurge = Number(psql(`SELECT count(*) FROM universes WHERE length(data::text) < ${UNI_THRESHOLD}`));
 log(`Universes:  restore ${uniRestore} tombstoned-real  |  purge ${uniPurge} fixtures`);
 log('  Real universes that will be LIVE after restore:');
@@ -67,7 +82,7 @@ log(psql(
 ) || '    (none)');
 
 // ---- Series ----
-const serRestore = Number(psql(`SELECT count(*) FROM pipeline_series WHERE deleted=true AND length(data::text) >= ${SER_THRESHOLD}`));
+const serRestore = Number(psql(`SELECT count(*) FROM pipeline_series WHERE ${jsonbTombstoned()} AND length(data::text) >= ${SER_THRESHOLD}`));
 const serPurge = Number(psql(`SELECT count(*) FROM pipeline_series WHERE length(data::text) < ${SER_THRESHOLD}`));
 log(`\nSeries:  restore ${serRestore} tombstoned-real  |  purge ${serPurge} fixtures`);
 log('  Real series that will be LIVE after restore:');
@@ -92,9 +107,9 @@ const out = execFileSync('psql', ['-h', HOST, '-p', PORT, '-d', DB, '-v', 'ON_ER
   encoding: 'utf8',
   input: `
 BEGIN;
-UPDATE universes SET deleted=false, deleted_at=NULL WHERE deleted=true AND length(data::text) >= ${UNI_THRESHOLD};
+${restoreSql('universes', UNI_THRESHOLD)}
 DELETE FROM universes WHERE length(data::text) < ${UNI_THRESHOLD};
-UPDATE pipeline_series SET deleted=false, deleted_at=NULL WHERE deleted=true AND length(data::text) >= ${SER_THRESHOLD};
+${restoreSql('pipeline_series', SER_THRESHOLD)}
 DELETE FROM pipeline_series WHERE length(data::text) < ${SER_THRESHOLD};
 COMMIT;
 `,
@@ -104,8 +119,8 @@ log(out.trim());
 // ---- Prune peer_subscriptions.json ----
 const subsPath = join(DATA_ROOT, 'sharing', 'peer_subscriptions.json');
 if (existsSync(subsPath)) {
-  const uniIds = new Set(psql('SELECT id FROM universes WHERE deleted=false').split('\n').filter(Boolean));
-  const serIds = new Set(psql('SELECT id FROM pipeline_series WHERE deleted=false').split('\n').filter(Boolean));
+  const uniIds = new Set(psql(`SELECT id FROM universes WHERE ${jsonbTombstoned()} IS NOT TRUE`).split('\n').filter(Boolean));
+  const serIds = new Set(psql(`SELECT id FROM pipeline_series WHERE ${jsonbTombstoned()} IS NOT TRUE`).split('\n').filter(Boolean));
   copyFileSync(subsPath, `${subsPath}.bak`);
   const j = JSON.parse(readFileSync(subsPath, 'utf8'));
   const before = j.subscriptions.length;
@@ -118,6 +133,6 @@ if (existsSync(subsPath)) {
   log(`peer_subscriptions.json: ${before} -> ${j.subscriptions.length} (pruned ${before - j.subscriptions.length} dead; .bak saved)`);
 }
 
-log('\n✅ Done. Universes live: ' + psql('SELECT count(*) FROM universes WHERE deleted=false') +
-    ', series live: ' + psql('SELECT count(*) FROM pipeline_series WHERE deleted=false'));
+log('\n✅ Done. Universes live: ' + psql(`SELECT count(*) FROM universes WHERE ${jsonbTombstoned()} IS NOT TRUE`) +
+    ', series live: ' + psql(`SELECT count(*) FROM pipeline_series WHERE ${jsonbTombstoned()} IS NOT TRUE`));
 log('   Clean every federated machine while sync is paused, then `pm2 start portos-server` to resume.');


### PR DESCRIPTION
## Summary

Follow-up to the test-Postgres-isolation fix. The recovery script (`scripts/recover-synced-test-fixtures.mjs`) restored tombstoned-real records by flipping only the row's `deleted` **column** — but `listUniverses`/`listSeries` read deleted-state from each record's `data` **JSONB** (`SELECT data FROM universes`), which still had `deleted: true`. Result: 'restored' universes stayed invisible in the UI, and a second `--apply` reported `restore 0` because the column no longer matched `deleted=true`.

Now restore clears `data.deleted` + `data.deletedAt`, bumps `data.updatedAt`, and resyncs the denormalized columns. Detection and the live tally key off the JSONB source of truth.

(Observed live: after the column-only restore, `universeBuilder.listUniverses()` returned 0 against an 11-row table; the JSONB fix brings all 11 back.)

## Test plan

- `node --check scripts/recover-synced-test-fixtures.mjs`
- Dry-run on a recovered install reports `restore 0 / purge 0` and lists the live universes; `node -e 'listUniverses()'` returns the full set.