### PR TITLE
fix([issue-1080]): re-vectorize synced-in brain records into memory

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -6,6 +6,10 @@
 
 - **Public API surface with per-API auth gating (Voice/TTS + sdapi):** PortOS can now serve individual services as HTTP APIs on your tailnet. A new **Settings → API Access** tab exposes per-API toggles — *Expose on the network* (off by default) and *Require auth* (off = passwordless) — so you can keep the whole app behind your PortOS password while leaving the **Voice/TTS** and **Image Gen (sdapi)** APIs open for other machines to call. A deliberately-minimal `POST /api/voice/public/synthesize` (plus `/voices` and `/engines`) turns text into WAV audio with any engine/voice/rate; config and process-control endpoints always stay gated. A single in-tree registry (`server/lib/apiRegistry.js`) drives the auth-gate exemptions, the settings UI, and a native **OpenAPI 3.1 spec** at `GET /api/api-docs/openapi.json` (no swagger dependency — request bodies are generated from the same Zod schemas the routes validate against). The API Access tab shows each API's public base URL and a copy-paste `curl` example, and the Voice settings tab links to it. Defaults are safe: both APIs ship not-exposed and passwordless-once-exposed, with a migration seeding the key for existing installs.
 
+## Fixed
+
+- **[issue-1080] Notes synced from other machines become searchable promptly** — a Brain note, daily-log entry, person, project, or idea created or edited on one of your machines is now re-indexed into semantic memory on the others as soon as it syncs, instead of waiting for a full manual re-sync. Edits and deletes that arrive from a peer also refresh or retire the matching memory entry, so search no longer surfaces stale copies of records that changed elsewhere. A new **Refresh embeddings** button on the Brain graph re-indexes everything in one pass to heal anything that drifted before this fix.
+
 ## Changed
 
 - **[issue-1094] Federation "Make mutual" sync behavior clarified** — documented and locked in how toggling a sync category toward a peer stays mirrored on both machines. No change to how syncing behaves.

--- a/client/src/components/brain/tabs/BrainGraph.jsx
+++ b/client/src/components/brain/tabs/BrainGraph.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
-import {Search, AlertTriangle, Zap} from 'lucide-react';
+import {Search, AlertTriangle, Zap, RefreshCw} from 'lucide-react';
 import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
 import { BRAIN_TYPE_HEX, DESTINATIONS } from '../constants';
@@ -210,9 +210,12 @@ export default function BrainGraph() {
     }
   }, []);
 
-  const handleSync = async () => {
+  // refresh:true re-embeds already-mapped records — the recovery path for
+  // memory entries that diverged before synced-in records were re-vectorized
+  // automatically (issue #1080). The default sync only embeds new records.
+  const handleSync = async ({ refresh = false } = {}) => {
     setSyncing(true);
-    const stats = await api.syncBrainData().catch(err => {
+    const stats = await api.syncBrainData({ refresh }).catch(err => {
       toast.error(err.message || 'Sync failed');
       return null;
     });
@@ -256,7 +259,7 @@ export default function BrainGraph() {
             No embeddings found. Sync brain data to CoS memory to enable semantic similarity edges.
           </div>
           <button
-            onClick={handleSync}
+            onClick={() => handleSync()}
             disabled={syncing}
             className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium bg-port-warning/20 text-port-warning border border-port-warning/30 rounded-lg hover:bg-port-warning/30 transition-colors disabled:opacity-50"
           >
@@ -313,6 +316,18 @@ export default function BrainGraph() {
           className="px-3 py-1.5 min-h-[36px] text-xs bg-port-border text-gray-400 hover:text-white rounded-lg transition-colors"
         >
           Re-layout
+        </button>
+        {/* Recovery action (issue #1080): re-embed already-synced records whose
+            memory copy may be stale — e.g. a peer edited a record that this
+            machine received via sync before auto re-vectorization existed. */}
+        <button
+          onClick={() => handleSync({ refresh: true })}
+          disabled={syncing}
+          title="Re-embed all brain records, including ones synced from peers, to refresh stale memory entries"
+          className="flex items-center gap-1.5 px-3 py-1.5 min-h-[36px] text-xs bg-port-border text-gray-400 hover:text-white rounded-lg transition-colors disabled:opacity-50"
+        >
+          {syncing ? <BrailleSpinner /> : <RefreshCw size={14} />}
+          Refresh embeddings
         </button>
       </div>
 

--- a/client/src/components/brain/tabs/BrainGraph.jsx
+++ b/client/src/components/brain/tabs/BrainGraph.jsx
@@ -221,7 +221,8 @@ export default function BrainGraph() {
     });
     setSyncing(false);
     if (stats) {
-      toast.success(`Synced ${stats.synced} records (${stats.skipped} skipped)`);
+      const archivedNote = stats.archived ? `, ${stats.archived} archived` : '';
+      toast.success(`Synced ${stats.synced} records (${stats.skipped} skipped${archivedNote})`);
       // Reload graph data to pick up new embeddings
       const fresh = await api.getBrainGraph().catch(() => null);
       if (fresh) setGraphData(fresh);

--- a/client/src/components/brain/tabs/BrainGraph.jsx
+++ b/client/src/components/brain/tabs/BrainGraph.jsx
@@ -215,7 +215,9 @@ export default function BrainGraph() {
   // automatically (issue #1080). The default sync only embeds new records.
   const handleSync = async ({ refresh = false } = {}) => {
     setSyncing(true);
-    const stats = await api.syncBrainData({ refresh }).catch(err => {
+    // silent:true — this catch owns the error toast, so suppress the helper's
+    // own toast to avoid a duplicate (CLAUDE.md: custom catch ⇒ silent).
+    const stats = await api.syncBrainData({ refresh }, { silent: true }).catch(err => {
       toast.error(err.message || 'Sync failed');
       return null;
     });

--- a/client/src/services/apiBrain.js
+++ b/client/src/services/apiBrain.js
@@ -197,8 +197,11 @@ export const reorderBrainBuckets = (ids) => request('/brain/buckets/reorder', {
 // Brain - Graph
 export const getBrainGraph = () => request('/brain/graph');
 
-// Brain - Bridge Sync (brain data to CoS memory system)
-export const syncBrainData = () => request('/brain/bridge-sync', { method: 'POST' });
+// Brain - Bridge Sync (brain data to CoS memory system).
+// refresh:true re-embeds already-mapped records to heal memory entries that
+// went stale before the per-record sync signal existed (issue #1080).
+export const syncBrainData = ({ refresh = false } = {}) =>
+  request('/brain/bridge-sync', { method: 'POST', body: JSON.stringify({ refresh }) });
 
 // Brain - Daily Log
 export const listDailyLogs = (options = {}) => {

--- a/client/src/services/apiBrain.js
+++ b/client/src/services/apiBrain.js
@@ -200,8 +200,10 @@ export const getBrainGraph = () => request('/brain/graph');
 // Brain - Bridge Sync (brain data to CoS memory system).
 // refresh:true re-embeds already-mapped records to heal memory entries that
 // went stale before the per-record sync signal existed (issue #1080).
-export const syncBrainData = ({ refresh = false } = {}) =>
-  request('/brain/bridge-sync', { method: 'POST', body: JSON.stringify({ refresh }) });
+// `options` (e.g. { silent: true }) passes through to the request helper so a
+// caller with its own error toast doesn't get a duplicate from the helper.
+export const syncBrainData = ({ refresh = false } = {}, options = {}) =>
+  request('/brain/bridge-sync', { method: 'POST', body: JSON.stringify({ refresh }), ...options });
 
 // Brain - Daily Log
 export const listDailyLogs = (options = {}) => {

--- a/server/lib/brainValidation.js
+++ b/server/lib/brainValidation.js
@@ -474,6 +474,14 @@ export const brainSyncPushSchema = z.object({
   changes: z.array(brainSyncChangeSchema).min(1).max(1000)
 });
 
+// Brain bridge-sync body (POST /api/brain/bridge-sync). `refresh` forces a
+// re-embed of already-mapped records — the recovery path for memory entries
+// that diverged before the per-record sync:applied signal existed (issue
+// #1080). Optional + default-false so the existing no-body call is unchanged.
+export const brainBridgeSyncSchema = z.object({
+  refresh: z.boolean().optional().default(false)
+});
+
 // Daily log settings schema (PUT /api/brain/daily-log/settings body).
 // Only these three keys are persisted — strict() rejects unknown keys so
 // a typo or stray payload field can't corrupt the settings file.

--- a/server/routes/brain.js
+++ b/server/routes/brain.js
@@ -37,6 +37,7 @@ import {
   bucketReorderSchema,
   brainSyncQuerySchema,
   brainSyncPushSchema,
+  brainBridgeSyncSchema,
   dailyLogSettingsSchema
 } from '../lib/brainValidation.js';
 import * as githubCloner from '../services/githubCloner.js';
@@ -963,12 +964,16 @@ router.get('/graph', asyncHandler(async (req, res) => {
 
 /**
  * POST /api/brain/bridge-sync
- * Sync all brain data to CoS memory system (generates embeddings)
+ * Sync all brain data to CoS memory system (generates embeddings).
+ * Body: { refresh?: boolean } — refresh:true re-embeds already-mapped records
+ * to heal memory entries that diverged before the per-record sync:applied
+ * signal existed (issue #1080).
  * (Renamed from /sync to avoid conflict with federation sync)
  */
 router.post('/bridge-sync', asyncHandler(async (req, res) => {
-  const stats = await syncAllBrainData();
-  console.log(`🧠🔗 Brain bridge sync complete: ${stats.synced} synced, ${stats.skipped} skipped, ${stats.errors} errors`);
+  const { refresh } = validateRequest(brainBridgeSyncSchema, req.body ?? {});
+  const stats = await syncAllBrainData({ refresh });
+  console.log(`🧠🔗 Brain bridge sync complete${refresh ? ' (refresh)' : ''}: ${stats.synced} synced, ${stats.skipped} skipped, ${stats.errors} errors`);
   res.json(stats);
 }));
 

--- a/server/routes/brain.js
+++ b/server/routes/brain.js
@@ -973,7 +973,7 @@ router.get('/graph', asyncHandler(async (req, res) => {
 router.post('/bridge-sync', asyncHandler(async (req, res) => {
   const { refresh } = validateRequest(brainBridgeSyncSchema, req.body ?? {});
   const stats = await syncAllBrainData({ refresh });
-  console.log(`🧠🔗 Brain bridge sync complete${refresh ? ' (refresh)' : ''}: ${stats.synced} synced, ${stats.skipped} skipped, ${stats.errors} errors`);
+  console.log(`🧠🔗 Brain bridge sync complete${refresh ? ' (refresh)' : ''}: ${stats.synced} synced, ${stats.skipped} skipped, ${stats.archived} archived, ${stats.errors} errors`);
   res.json(stats);
 }));
 

--- a/server/routes/brain.test.js
+++ b/server/routes/brain.test.js
@@ -977,6 +977,17 @@ describe('Brain Routes', () => {
       expect(response.body.synced).toBe(5);
       expect(response.body.skipped).toBe(2);
       expect(response.body.errors).toBe(0);
+      // No body → refresh defaults false (issue #1080).
+      expect(syncAllBrainData).toHaveBeenCalledWith({ refresh: false });
+    });
+
+    it('passes refresh:true through for the recovery re-embed path (issue #1080)', async () => {
+      syncAllBrainData.mockResolvedValue({ synced: 3, skipped: 0, errors: 0, archived: 1 });
+
+      const response = await request(app).post('/api/brain/bridge-sync').send({ refresh: true });
+      expect(response.status).toBe(200);
+      expect(response.body.archived).toBe(1);
+      expect(syncAllBrainData).toHaveBeenCalledWith({ refresh: true });
     });
 
     it('should return 500 when sync fails', async () => {

--- a/server/services/brainMemoryBridge.js
+++ b/server/services/brainMemoryBridge.js
@@ -17,7 +17,7 @@ import * as brainStorage from './brainStorage.js';
 import * as memory from './memoryBackend.js';
 import * as embeddings from './memoryEmbeddings.js';
 import { ensureDir, PATHS } from '../lib/fileUtils.js';
-import { listJournals } from './brainJournal.js';
+import { listJournals, getJournal } from './brainJournal.js';
 
 const BRIDGE_MAP_PATH = join(PATHS.brain, 'memory-bridge-map.json');
 
@@ -208,9 +208,19 @@ export async function syncBrainRecord(brainType, record) {
 /**
  * Bulk sync all existing brain data into the memory system.
  * Used for initial migration and catch-up.
- * Returns { synced, skipped, errors }.
+ *
+ * @param {object}  [opts]
+ * @param {boolean} [opts.dryRun=false]  Report what would sync without writing.
+ * @param {boolean} [opts.refresh=false] Re-embed records that ALREADY have a
+ *   bridge-map entry instead of skipping them. This is the recovery path for
+ *   records that diverged before the per-record sync:applied signal existed
+ *   (issue #1080): a peer's edit/delete of an already-mapped record used to
+ *   leave the local memory copy stale and searchable forever, and a normal
+ *   bulk sync skipped it precisely because it was mapped. `refresh` forces a
+ *   re-embed of every live record so a one-time catch-up heals the staleness.
+ * @returns {Promise<{synced:number, skipped:number, errors:number}>}
  */
-export async function syncAllBrainData({ dryRun = false } = {}) {
+export async function syncAllBrainData({ dryRun = false, refresh = false } = {}) {
   const map = await loadBridgeMap();
   const stats = { synced: 0, skipped: 0, errors: 0 };
 
@@ -225,7 +235,7 @@ export async function syncAllBrainData({ dryRun = false } = {}) {
         continue;
       }
       const key = bridgeKey(type, record.id);
-      if (map[key] && !dryRun) {
+      if (map[key] && !dryRun && !refresh) {
         stats.skipped++;
         continue;
       }
@@ -243,18 +253,19 @@ export async function syncAllBrainData({ dryRun = false } = {}) {
     }
   }
 
-  // Daily log entries — one memory per day, initial/backfill import only;
-  // already-mapped records are skipped by this bulk sync. Content updates
-  // and deletions flow through the 'journals:upserted' / 'journals:deleted'
-  // event handlers instead (see initBridge).
+  // Daily log entries — one memory per day. Without `refresh`, already-mapped
+  // days are skipped (initial/backfill import only) and content updates /
+  // deletions flow through the 'journals:upserted' / 'journals:deleted' and
+  // 'sync:applied' event handlers instead (see initBridge). With `refresh`,
+  // already-mapped days are re-embedded to heal pre-#1080 staleness.
   {
     const { records: journals } = await listJournals({ limit: 10000, includeContent: true });
     for (const record of journals) {
       const key = bridgeKey('journals', record.id);
       // Already-mapped days are skipped in both real and dry-run modes so
       // dry-run stats match actual-run stats (rather than claiming to
-      // re-sync every day every time).
-      if (map[key]) {
+      // re-sync every day every time) — unless refresh is forcing a re-embed.
+      if (map[key] && !refresh) {
         stats.skipped += 1;
         continue;
       }
@@ -279,7 +290,7 @@ export async function syncAllBrainData({ dryRun = false } = {}) {
     const records = await getter(1000); // get all
     for (const record of records) {
       const key = bridgeKey(type, record.id);
-      if (map[key] && !dryRun) {
+      if (map[key] && !dryRun && !refresh) {
         stats.skipped++;
         continue;
       }
@@ -298,6 +309,86 @@ export async function syncAllBrainData({ dryRun = false } = {}) {
   }
 
   return stats;
+}
+
+// ─── Synced-in record resync (issue #1080) ──────────────────────────────────
+// Peer-synced brain writes go through brainStorage.applyRemoteRecord, which is
+// deliberately event-silent (no brainEvents) to prevent cross-peer echo loops
+// (#1077). That silence means the per-record bridge listeners below never fire
+// for synced-in records, so a record created/edited/deleted on peer A was never
+// re-vectorized into peer B's memory index — it stayed stale and searchable
+// until a full bulk resync (which itself SKIPPED already-mapped records). The
+// sync apply paths now emit a LOCAL-ONLY 'sync:applied' signal (it never feeds
+// the sync log, so no echo) carrying the {type, id} of every applied change;
+// we re-read each record's canonical state and re-embed or archive accordingly.
+
+const RESYNC_DEBOUNCE_MS = 250;
+const pendingResync = new Map(); // bridgeKey → { type, id } (dedups repeated touches)
+let resyncTimer = null;
+
+/**
+ * Re-vectorize (or archive) a single brain record from its CANONICAL stored
+ * state — used after a peer sync applies a change. Reading the store rather
+ * than trusting an event payload makes this self-healing and order-independent:
+ * whatever the final converged state is (live record, archived, or tombstoned),
+ * the memory copy is brought into line.
+ *   - record present & not archived → upsert + re-embed (syncBrainRecord)
+ *   - record absent (tombstoned) or archived → archive the mapped memory entry
+ *   - type not mirrored by the bridge (links/buckets/inbox) → no-op
+ */
+export async function resyncBrainRecord(brainType, id) {
+  if (!id || !TYPE_MAP[brainType]) return;
+  // getById returns null for tombstones (deleted records), so a synced-in
+  // delete naturally lands in the archive branch.
+  const record = brainType === 'journals'
+    ? await getJournal(id)
+    : await brainStorage.getById(brainType, id);
+  if (!record || record.archived) {
+    const map = await loadBridgeMap();
+    const memoryId = map[bridgeKey(brainType, id)];
+    if (memoryId) {
+      await memory.updateMemory(memoryId, { status: 'archived' });
+      console.log(`🧠🔗 Archived synced-in brain→memory: ${brainType}/${id} → ${memoryId}`);
+    }
+    return;
+  }
+  await syncBrainRecord(brainType, record);
+}
+
+/**
+ * Drain the pending resync queue sequentially. Sequential (not parallel) so a
+ * large catch-up sync doesn't fire hundreds of concurrent embedding calls and
+ * saturate the embedding backend. Exported for deterministic flushing in tests.
+ */
+export async function flushPendingResync() {
+  resyncTimer = null;
+  const batch = [...pendingResync.values()];
+  pendingResync.clear();
+  for (const { type, id } of batch) {
+    await resyncBrainRecord(type, id).catch((err) => {
+      console.error(`❌ Brain bridge resync failed for ${type}/${id}: ${err.message}`);
+    });
+  }
+}
+
+/**
+ * Queue applied-change records for a debounced resync. Records touching a type
+ * the bridge doesn't mirror are dropped here so they never schedule a flush.
+ */
+export function queueResync(records) {
+  if (!Array.isArray(records)) return;
+  for (const { type, id } of records) {
+    if (!id || !TYPE_MAP[type]) continue;
+    pendingResync.set(bridgeKey(type, id), { type, id });
+  }
+  if (pendingResync.size === 0 || resyncTimer) return;
+  resyncTimer = setTimeout(() => {
+    flushPendingResync().catch((err) => {
+      console.error(`❌ Brain bridge resync flush failed: ${err.message}`);
+    });
+  }, RESYNC_DEBOUNCE_MS);
+  // Don't keep the event loop alive just for a pending resync flush.
+  if (typeof resyncTimer.unref === 'function') resyncTimer.unref();
 }
 
 // ─── Event Handlers ─────────────────────────────────────────────────────────
@@ -377,6 +468,14 @@ export function initBridge() {
       console.error(`❌ Brain bridge delete sync failed for journals/${entry?.id}: ${err.message}`);
     });
   });
+
+  // Peer-synced records (issue #1080) — applyRemoteRecord is event-silent to
+  // prevent echo loops, so the per-record listeners above never fire for
+  // synced-in changes. The sync apply paths emit this local-only signal with
+  // the touched {type, id}s; we re-read each from the store and re-embed or
+  // archive. Debounced + sequential so a large catch-up doesn't saturate the
+  // embedding backend.
+  brainEvents.on('sync:applied', ({ records } = {}) => queueResync(records));
 
   console.log('🧠🔗 Brain→Memory bridge initialized');
 }

--- a/server/services/brainMemoryBridge.js
+++ b/server/services/brainMemoryBridge.js
@@ -218,11 +218,14 @@ export async function syncBrainRecord(brainType, record) {
  *   leave the local memory copy stale and searchable forever, and a normal
  *   bulk sync skipped it precisely because it was mapped. `refresh` forces a
  *   re-embed of every live record so a one-time catch-up heals the staleness.
- * @returns {Promise<{synced:number, skipped:number, errors:number}>}
+ *   In refresh mode a reconcile pass also archives memory entries whose brain
+ *   record was deleted/archived on a peer before this fix (orphaned map keys
+ *   the live-record walks can't reach) — reported as `archived`.
+ * @returns {Promise<{synced:number, skipped:number, errors:number, archived:number}>}
  */
 export async function syncAllBrainData({ dryRun = false, refresh = false } = {}) {
   const map = await loadBridgeMap();
-  const stats = { synced: 0, skipped: 0, errors: 0 };
+  const stats = { synced: 0, skipped: 0, errors: 0, archived: 0 };
 
   // Entity stores (JSON-based)
   const entityTypes = ['people', 'projects', 'ideas', 'admin', 'memories'];
@@ -308,6 +311,37 @@ export async function syncAllBrainData({ dryRun = false, refresh = false } = {})
     }
   }
 
+  // Refresh-mode reconcile (issue #1080 recovery): the live-record walks above
+  // re-embed edited records, but they iterate ONLY live records — getAll /
+  // listJournals strip tombstones and archived entities are skipped — so a
+  // record DELETED or ARCHIVED on a peer BEFORE this fix shipped leaves an
+  // orphaned bridge-map entry whose memory copy stays active and searchable.
+  // The going-forward sync:applied path archives those, but it can't reach the
+  // pre-fix backlog. Walk the bridge map and archive any mapped entry whose
+  // canonical record no longer resolves as live. Only for deletable, bridge-
+  // mirrored stores: digests/reviews are append-only (never deleted) and
+  // links/buckets/inbox aren't mirrored, so neither can orphan a memory entry.
+  if (refresh && !dryRun) {
+    const reconcilableTypes = new Set(['people', 'projects', 'ideas', 'admin', 'memories', 'journals']);
+    for (const mapKey of Object.keys(map)) {
+      const sep = mapKey.indexOf(':');
+      if (sep === -1) continue;
+      const type = mapKey.slice(0, sep);
+      const id = mapKey.slice(sep + 1);
+      if (!reconcilableTypes.has(type)) continue;
+      const record = type === 'journals'
+        ? await getJournal(id)
+        : await brainStorage.getById(type, id);
+      if (record && !record.archived) continue; // still live — already re-embedded above
+      const archived = await archiveMappedMemory(type, id).catch(err => {
+        console.error(`❌ Failed to archive stale ${type}/${id}: ${err.message}`);
+        stats.errors++;
+        return false;
+      });
+      if (archived) stats.archived++;
+    }
+  }
+
   return stats;
 }
 
@@ -325,6 +359,21 @@ export async function syncAllBrainData({ dryRun = false, refresh = false } = {})
 const RESYNC_DEBOUNCE_MS = 250;
 const pendingResync = new Map(); // bridgeKey → { type, id } (dedups repeated touches)
 let resyncTimer = null;
+let resyncFlushing = false; // single-flight guard so two flushes can't overlap
+
+/**
+ * Archive the memory entry mapped to a brain record (if any). Used when the
+ * canonical record is gone (tombstoned), archived, or otherwise should no
+ * longer be searchable.
+ */
+async function archiveMappedMemory(brainType, id) {
+  const map = await loadBridgeMap();
+  const memoryId = map[bridgeKey(brainType, id)];
+  if (!memoryId) return false;
+  await memory.updateMemory(memoryId, { status: 'archived' });
+  console.log(`🧠🔗 Archived brain→memory: ${brainType}/${id} → ${memoryId}`);
+  return true;
+}
 
 /**
  * Re-vectorize (or archive) a single brain record from its CANONICAL stored
@@ -344,36 +393,49 @@ export async function resyncBrainRecord(brainType, id) {
     ? await getJournal(id)
     : await brainStorage.getById(brainType, id);
   if (!record || record.archived) {
-    const map = await loadBridgeMap();
-    const memoryId = map[bridgeKey(brainType, id)];
-    if (memoryId) {
-      await memory.updateMemory(memoryId, { status: 'archived' });
-      console.log(`🧠🔗 Archived synced-in brain→memory: ${brainType}/${id} → ${memoryId}`);
-    }
+    await archiveMappedMemory(brainType, id);
     return;
   }
   await syncBrainRecord(brainType, record);
 }
 
 /**
- * Drain the pending resync queue sequentially. Sequential (not parallel) so a
+ * Drain the pending resync queue sequentially. Single-flight + re-draining:
+ * only one flush runs at a time (the `resyncFlushing` guard), and it loops
+ * until the queue is empty so records enqueued mid-flush are still processed —
+ * without a second flush running concurrently. Sequential (not parallel) so a
  * large catch-up sync doesn't fire hundreds of concurrent embedding calls and
- * saturate the embedding backend. Exported for deterministic flushing in tests.
+ * saturate the embedding backend; single-flight also prevents two flushes from
+ * both creating a memory for the same not-yet-mapped record (duplicate entries).
+ * Exported for deterministic flushing in tests.
  */
 export async function flushPendingResync() {
-  resyncTimer = null;
-  const batch = [...pendingResync.values()];
-  pendingResync.clear();
-  for (const { type, id } of batch) {
-    await resyncBrainRecord(type, id).catch((err) => {
-      console.error(`❌ Brain bridge resync failed for ${type}/${id}: ${err.message}`);
-    });
+  if (resyncTimer) { clearTimeout(resyncTimer); resyncTimer = null; }
+  if (resyncFlushing) return; // an in-flight flush will pick up newly-queued items
+  resyncFlushing = true;
+  try {
+    // The queue only grows during an `await` below; the loop re-checks size at
+    // the top of each pass, and the gap between the final size===0 check and
+    // clearing `resyncFlushing` contains no await — so nothing can be stranded.
+    while (pendingResync.size > 0) {
+      const batch = [...pendingResync.values()];
+      pendingResync.clear();
+      for (const { type, id } of batch) {
+        await resyncBrainRecord(type, id).catch((err) => {
+          console.error(`❌ Brain bridge resync failed for ${type}/${id}: ${err.message}`);
+        });
+      }
+    }
+  } finally {
+    resyncFlushing = false;
   }
 }
 
 /**
  * Queue applied-change records for a debounced resync. Records touching a type
  * the bridge doesn't mirror are dropped here so they never schedule a flush.
+ * No timer is armed while a flush is in flight — that flush re-drains the queue
+ * itself, so a second concurrent flush can never start.
  */
 export function queueResync(records) {
   if (!Array.isArray(records)) return;
@@ -381,7 +443,7 @@ export function queueResync(records) {
     if (!id || !TYPE_MAP[type]) continue;
     pendingResync.set(bridgeKey(type, id), { type, id });
   }
-  if (pendingResync.size === 0 || resyncTimer) return;
+  if (pendingResync.size === 0 || resyncTimer || resyncFlushing) return;
   resyncTimer = setTimeout(() => {
     flushPendingResync().catch((err) => {
       console.error(`❌ Brain bridge resync flush failed: ${err.message}`);

--- a/server/services/brainMemoryBridge.js
+++ b/server/services/brainMemoryBridge.js
@@ -188,8 +188,12 @@ export async function syncBrainRecord(brainType, record) {
   const embedding = await embeddings.generateMemoryEmbedding(memoryData).catch(() => null);
 
   if (existingMemoryId) {
-    // Update existing memory
-    const updated = await memory.updateMemory(existingMemoryId, memoryData);
+    // Update existing memory. Force status:'active' so a record that was
+    // archived for a synced-in delete/archive and later came back live
+    // (un-deleted on a peer, or un-archived) is searchable again — memory
+    // search filters out archived rows, so without this the resurrected
+    // record would stay invisible (issue #1080 review finding).
+    const updated = await memory.updateMemory(existingMemoryId, { ...memoryData, status: 'active' });
     if (updated && embedding) {
       await memory.updateMemoryEmbedding(existingMemoryId, embedding);
     }

--- a/server/services/brainMemoryBridge.test.js
+++ b/server/services/brainMemoryBridge.test.js
@@ -152,6 +152,33 @@ describe('brainMemoryBridge — queueResync debounce + dedup', () => {
     expect(getById).not.toHaveBeenCalled();
   });
 
+  it('single-flights overlapping flushes so a record is never embedded twice', async () => {
+    const bridge = await loadBridge();
+    // Slow embed for p1 — while the first flush is awaiting it, a second
+    // sync:applied for the SAME not-yet-mapped record arrives. Without the
+    // single-flight guard, a second flush would start and createMemory twice.
+    let resolveFirst;
+    const gate = new Promise((r) => { resolveFirst = r; });
+    let calls = 0;
+    getById.mockImplementation(async (_type, id) => {
+      calls += 1;
+      if (id === 'p1' && calls === 1) await gate; // hold the first resync open
+      return { id, name: id };
+    });
+
+    bridge.queueResync([{ type: 'people', id: 'p1' }]);
+    const inFlight = bridge.flushPendingResync(); // begins, awaits the gate on p1
+    // Same record re-queued mid-flush + a direct flush attempt (the re-arm path).
+    bridge.queueResync([{ type: 'people', id: 'p1' }]);
+    const second = bridge.flushPendingResync(); // must early-return (guard), not run concurrently
+    resolveFirst();
+    await Promise.all([inFlight, second]);
+
+    // p1 was mapped by the first create; the re-drain sees it mapped → update,
+    // not a second create. Exactly one memory created for p1.
+    expect(createMemory).toHaveBeenCalledTimes(1);
+  });
+
   it('re-vectorizes when brainEvents emits sync:applied (end-to-end wiring)', async () => {
     const bridge = await loadBridge();
     const { brainEvents } = await import('./brainStorage.js');
@@ -180,5 +207,36 @@ describe('brainMemoryBridge — syncAllBrainData refresh mode (issue #1080 recov
     const refreshed = await bridge.syncAllBrainData({ refresh: true });
     expect(refreshed.synced).toBeGreaterThanOrEqual(1);
     expect(updateMemory).toHaveBeenCalledWith('mem-old', expect.any(Object));
+  });
+
+  it('refresh reconcile archives a mapped entry whose record was deleted on a peer pre-fix', async () => {
+    const bridge = await loadBridge();
+    // p-gone is mapped but its canonical record no longer resolves (deleted/
+    // tombstoned on a peer before the fix) — getAll won't surface it, so only
+    // the reconcile pass can retire its stale, still-searchable memory entry.
+    getAll.mockResolvedValue([]);
+    getById.mockResolvedValue(null);
+    bridgeFileContents = JSON.stringify({ [bridge.bridgeKey('people', 'p-gone')]: 'mem-orphan' });
+
+    // Default mode does NOT reconcile (no archival).
+    await bridge.syncAllBrainData();
+    expect(updateMemory).not.toHaveBeenCalled();
+
+    const refreshed = await bridge.syncAllBrainData({ refresh: true });
+    expect(updateMemory).toHaveBeenCalledWith('mem-orphan', { status: 'archived' });
+    expect(refreshed.archived).toBe(1);
+  });
+
+  it('refresh reconcile leaves live mapped records alone (no spurious archive)', async () => {
+    const bridge = await loadBridge();
+    getAll.mockImplementation(async (type) => (type === 'people' ? [{ id: 'p1', name: 'Alice' }] : []));
+    getById.mockResolvedValue({ id: 'p1', name: 'Alice' }); // still live
+    bridgeFileContents = JSON.stringify({ [bridge.bridgeKey('people', 'p1')]: 'mem-live' });
+
+    const refreshed = await bridge.syncAllBrainData({ refresh: true });
+
+    // Re-embedded (update via syncBrainRecord), never archived.
+    expect(refreshed.archived).toBe(0);
+    expect(updateMemory).not.toHaveBeenCalledWith('mem-live', { status: 'archived' });
   });
 });

--- a/server/services/brainMemoryBridge.test.js
+++ b/server/services/brainMemoryBridge.test.js
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The bridge memoizes its parsed bridge-map in a module-level variable
+// (loadBridgeMap caches), so each test resets the module registry and
+// re-imports a fresh copy to stay isolated. Mocks are declared with
+// vi.mock (hoisted) so they apply to every fresh import; shared mock fns
+// live in module scope so assertions can reach them after re-import.
+
+let bridgeFileContents = null; // null = file absent
+
+const createMemory = vi.fn(async (data) => ({ id: `mem-${data.content?.slice(0, 6) || 'x'}` }));
+const updateMemory = vi.fn(async () => ({ id: 'updated' }));
+const updateMemoryEmbedding = vi.fn(async () => {});
+const generateMemoryEmbedding = vi.fn(async () => [0.1, 0.2, 0.3]);
+const getById = vi.fn();
+const getAll = vi.fn(async () => []);
+const getDigests = vi.fn(async () => []);
+const getReviews = vi.fn(async () => []);
+const listJournals = vi.fn(async () => ({ records: [] }));
+const getJournal = vi.fn();
+
+vi.mock('fs', () => ({ existsSync: vi.fn(() => bridgeFileContents !== null) }));
+vi.mock('fs/promises', () => ({
+  readFile: vi.fn(async () => bridgeFileContents ?? '{}'),
+  writeFile: vi.fn(async (_path, data) => { bridgeFileContents = data; }),
+}));
+vi.mock('../lib/fileUtils.js', () => ({
+  PATHS: { brain: '/tmp/test-brain' },
+  ensureDir: vi.fn(async () => {}),
+}));
+vi.mock('./memoryBackend.js', () => ({ createMemory, updateMemory, updateMemoryEmbedding }));
+vi.mock('./memoryEmbeddings.js', () => ({ generateMemoryEmbedding }));
+vi.mock('./brainStorage.js', () => {
+  const { EventEmitter } = require('events');
+  return { brainEvents: new EventEmitter(), getById, getAll, getDigests, getReviews };
+});
+vi.mock('./brainJournal.js', () => ({ listJournals, getJournal }));
+
+// Re-import a fresh bridge module (clears the cached bridge map).
+async function loadBridge() {
+  vi.resetModules();
+  return import('./brainMemoryBridge.js');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  bridgeFileContents = null;
+});
+
+describe('brainMemoryBridge — resyncBrainRecord (issue #1080)', () => {
+  it('re-embeds a present, non-archived synced-in record', async () => {
+    const bridge = await loadBridge();
+    getById.mockResolvedValue({ id: 'p1', name: 'Alice', context: 'met at conf' });
+
+    await bridge.resyncBrainRecord('people', 'p1');
+
+    expect(getById).toHaveBeenCalledWith('people', 'p1');
+    expect(createMemory).toHaveBeenCalledTimes(1); // no prior map → new vector
+  });
+
+  it('archives the mapped memory when the record is gone (tombstoned)', async () => {
+    const bridge = await loadBridge();
+    bridgeFileContents = JSON.stringify({ [bridge.bridgeKey('people', 'p2')]: 'mem-existing' });
+    getById.mockResolvedValue(null); // getById returns null for tombstones
+
+    await bridge.resyncBrainRecord('people', 'p2');
+
+    expect(updateMemory).toHaveBeenCalledWith('mem-existing', { status: 'archived' });
+    expect(createMemory).not.toHaveBeenCalled();
+  });
+
+  it('archives the mapped memory when the record is archived', async () => {
+    const bridge = await loadBridge();
+    bridgeFileContents = JSON.stringify({ [bridge.bridgeKey('projects', 'pr1')]: 'mem-proj' });
+    getById.mockResolvedValue({ id: 'pr1', name: 'X', status: 'done', archived: true });
+
+    await bridge.resyncBrainRecord('projects', 'pr1');
+
+    expect(updateMemory).toHaveBeenCalledWith('mem-proj', { status: 'archived' });
+  });
+
+  it('reads journals via getJournal, not getById', async () => {
+    const bridge = await loadBridge();
+    getJournal.mockResolvedValue({ id: '2026-06-09', date: '2026-06-09', content: 'a good day' });
+
+    await bridge.resyncBrainRecord('journals', '2026-06-09');
+
+    expect(getJournal).toHaveBeenCalledWith('2026-06-09');
+    expect(getById).not.toHaveBeenCalled();
+    expect(createMemory).toHaveBeenCalledTimes(1);
+  });
+
+  it('no-ops for a type the bridge does not mirror (links/buckets/inbox)', async () => {
+    const bridge = await loadBridge();
+
+    await bridge.resyncBrainRecord('links', 'l1');
+    await bridge.resyncBrainRecord('inbox', 'i1');
+
+    expect(getById).not.toHaveBeenCalled();
+    expect(createMemory).not.toHaveBeenCalled();
+    expect(updateMemory).not.toHaveBeenCalled();
+  });
+
+  it('no archive call when a deleted record was never mapped', async () => {
+    const bridge = await loadBridge();
+    getById.mockResolvedValue(null);
+
+    await bridge.resyncBrainRecord('people', 'never-seen');
+
+    expect(updateMemory).not.toHaveBeenCalled();
+    expect(createMemory).not.toHaveBeenCalled();
+  });
+});
+
+describe('brainMemoryBridge — queueResync debounce + dedup', () => {
+  it('dedups repeated touches of the same record and drops unmirrored types', async () => {
+    const bridge = await loadBridge();
+    getById.mockResolvedValue({ id: 'p1', name: 'Alice' });
+
+    bridge.queueResync([
+      { type: 'people', id: 'p1' },
+      { type: 'people', id: 'p1' }, // duplicate — collapses
+      { type: 'links', id: 'l1' },  // unmirrored — dropped
+    ]);
+    await bridge.flushPendingResync(); // flush deterministically
+
+    expect(getById).toHaveBeenCalledTimes(1);
+    expect(getById).toHaveBeenCalledWith('people', 'p1');
+  });
+
+  it('processes the queue sequentially across multiple records', async () => {
+    const bridge = await loadBridge();
+    getById.mockImplementation(async (_type, id) => ({ id, name: id }));
+
+    bridge.queueResync([
+      { type: 'people', id: 'a' },
+      { type: 'projects', id: 'b' },
+      { type: 'ideas', id: 'c' },
+    ]);
+    await bridge.flushPendingResync();
+
+    expect(getById).toHaveBeenCalledTimes(3);
+  });
+
+  it('ignores a non-array payload without throwing', async () => {
+    const bridge = await loadBridge();
+
+    expect(() => bridge.queueResync(undefined)).not.toThrow();
+    expect(() => bridge.queueResync(null)).not.toThrow();
+    await bridge.flushPendingResync();
+
+    expect(getById).not.toHaveBeenCalled();
+  });
+
+  it('re-vectorizes when brainEvents emits sync:applied (end-to-end wiring)', async () => {
+    const bridge = await loadBridge();
+    const { brainEvents } = await import('./brainStorage.js');
+    bridge.initBridge();
+    getById.mockResolvedValue({ id: 'p1', name: 'Alice' });
+
+    brainEvents.emit('sync:applied', { records: [{ type: 'people', id: 'p1' }] });
+    await bridge.flushPendingResync();
+
+    expect(getById).toHaveBeenCalledWith('people', 'p1');
+    expect(createMemory).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('brainMemoryBridge — syncAllBrainData refresh mode (issue #1080 recovery)', () => {
+  it('skips already-mapped records by default but re-embeds them with refresh:true', async () => {
+    const bridge = await loadBridge();
+    getAll.mockImplementation(async (type) => (type === 'people' ? [{ id: 'p1', name: 'Alice' }] : []));
+    // p1 already mapped — the pre-#1080 staleness scenario.
+    bridgeFileContents = JSON.stringify({ [bridge.bridgeKey('people', 'p1')]: 'mem-old' });
+
+    const normal = await bridge.syncAllBrainData();
+    expect(normal.skipped).toBeGreaterThanOrEqual(1);
+    expect(updateMemory).not.toHaveBeenCalled();
+
+    const refreshed = await bridge.syncAllBrainData({ refresh: true });
+    expect(refreshed.synced).toBeGreaterThanOrEqual(1);
+    expect(updateMemory).toHaveBeenCalledWith('mem-old', expect.any(Object));
+  });
+});

--- a/server/services/brainMemoryBridge.test.js
+++ b/server/services/brainMemoryBridge.test.js
@@ -110,6 +110,20 @@ describe('brainMemoryBridge — resyncBrainRecord (issue #1080)', () => {
     expect(updateMemory).not.toHaveBeenCalled();
     expect(createMemory).not.toHaveBeenCalled();
   });
+
+  it('reactivates an archived memory when its record comes back live (status:active)', async () => {
+    const bridge = await loadBridge();
+    // p1 is already mapped (memory was archived for a prior synced-in delete);
+    // now the record resolves live again. The re-embed must reset status:active
+    // or memory search (which filters status='active') keeps hiding it.
+    bridgeFileContents = JSON.stringify({ [bridge.bridgeKey('people', 'p1')]: 'mem-resurrect' });
+    getById.mockResolvedValue({ id: 'p1', name: 'Alice', context: 'back again' });
+
+    await bridge.resyncBrainRecord('people', 'p1');
+
+    expect(updateMemory).toHaveBeenCalledWith('mem-resurrect', expect.objectContaining({ status: 'active' }));
+    expect(createMemory).not.toHaveBeenCalled();
+  });
 });
 
 describe('brainMemoryBridge — queueResync debounce + dedup', () => {

--- a/server/services/brainReconcile.js
+++ b/server/services/brainReconcile.js
@@ -30,6 +30,7 @@
 
 import { createHash } from 'crypto';
 import * as brainStorage from './brainStorage.js';
+import { brainEvents } from './brainStorage.js';
 import * as brainSyncLog from './brainSyncLog.js';
 
 const { BRAIN_ENTITY_TYPES } = brainStorage;
@@ -186,6 +187,15 @@ export async function applyBrainSnapshot(snapshot) {
   if (relayBatch.length > 0) {
     await brainSyncLog.appendChanges(relayBatch)
       .catch(err => console.error(`⚠️ Brain reconcile relay append failed (${relayBatch.length} entries): ${err.message}`));
+    // Local-only signal so the memory bridge re-vectorizes reconciled records
+    // (issue #1080) — same mechanism as brainSync.applyRemoteChanges. Anti-
+    // entropy snapshot merges are exactly the case where a record can change
+    // without ever flowing through a per-record event, so the bridge would
+    // otherwise never learn of the reconciled state. Local embedding only,
+    // never re-fed to the sync log (no #1077 echo).
+    brainEvents.emit('sync:applied', {
+      records: relayBatch.map(({ type, id }) => ({ type, id })),
+    });
   }
 
   console.log(`🔄 Brain reconcile applied: ${updated} upserted, ${deleted} deleted, ${skipped} skipped`);

--- a/server/services/brainReconcile.test.js
+++ b/server/services/brainReconcile.test.js
@@ -1,11 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Hoisted so the vi.mock factory (also hoisted) can reference it without a TDZ error.
+const { brainEvents } = vi.hoisted(() => {
+  const { EventEmitter } = require('events');
+  return { brainEvents: new EventEmitter() };
+});
+
 // brainStorage is the data layer; mock it so the reconcile logic is tested in
 // isolation (matching the inline-copy / mock style used across sync tests).
 vi.mock('./brainStorage.js', () => ({
   BRAIN_ENTITY_TYPES: ['people', 'projects', 'ideas', 'admin', 'memories', 'links', 'buckets', 'journals', 'inbox'],
   getRawRecords: vi.fn(),
   applyRemoteRecord: vi.fn(),
+  brainEvents,
 }));
 vi.mock('./brainSyncLog.js', () => ({
   appendChanges: vi.fn().mockResolvedValue([]),
@@ -143,6 +150,41 @@ describe('applyBrainSnapshot', () => {
     expect(brainSyncLog.appendChanges).toHaveBeenCalledTimes(1);
     const relayed = brainSyncLog.appendChanges.mock.calls[0][0];
     expect(relayed.map(r => r.id)).toEqual(['x']);
+  });
+
+  it('emits a local-only sync:applied signal for reconciled records (issue #1080)', async () => {
+    brainStorage.applyRemoteRecord
+      .mockResolvedValueOnce({ applied: true })
+      .mockResolvedValueOnce({ applied: false, reason: 'local_newer' });
+    const seen = [];
+    const listener = (payload) => seen.push(payload);
+    brainEvents.on('sync:applied', listener);
+
+    await applyBrainSnapshot({
+      records: { links: {
+        x: { id: 'x', updatedAt: '2026-01-02T00:00:00.000Z', title: 'X' },
+        y: { id: 'y', updatedAt: '2026-01-01T00:00:00.000Z', title: 'Y' },
+      } },
+    });
+
+    brainEvents.off('sync:applied', listener);
+    expect(seen).toHaveLength(1);
+    // Only the APPLIED record is signalled (the rejected LWW op is not).
+    expect(seen[0].records).toEqual([{ type: 'links', id: 'x' }]);
+  });
+
+  it('does NOT emit sync:applied when nothing applies', async () => {
+    brainStorage.applyRemoteRecord.mockResolvedValue({ applied: false, reason: 'local_newer' });
+    const seen = [];
+    const listener = (payload) => seen.push(payload);
+    brainEvents.on('sync:applied', listener);
+
+    await applyBrainSnapshot({
+      records: { links: { y: { id: 'y', updatedAt: '2020-01-01T00:00:00.000Z', title: 'Y' } } },
+    });
+
+    brainEvents.off('sync:applied', listener);
+    expect(seen).toHaveLength(0);
   });
 
   it('skips records missing updatedAt (no LWW clock) and unknown types', async () => {

--- a/server/services/brainSync.js
+++ b/server/services/brainSync.js
@@ -10,6 +10,7 @@
  */
 
 import * as brainStorage from './brainStorage.js';
+import { brainEvents } from './brainStorage.js';
 import * as brainSyncLog from './brainSyncLog.js';
 
 const { BRAIN_ENTITY_TYPES } = brainStorage;
@@ -70,6 +71,15 @@ export async function applyRemoteChanges(changes) {
   if (relayBatch.length > 0) {
     await brainSyncLog.appendChanges(relayBatch)
       .catch(err => console.error(`⚠️ Sync log batch append failed (${relayBatch.length} entries): ${err.message}`));
+    // Local-only signal so the memory bridge re-vectorizes synced-in records
+    // (issue #1080). applyRemoteRecord is event-silent to prevent cross-peer
+    // echo (#1077); this event drives ONLY local embedding and never feeds the
+    // sync log, so it can't amplify. Carries just {type, id} — the bridge
+    // re-reads canonical state. Emitted on the relay batch (applied changes
+    // only) so a rejected LWW op doesn't trigger a needless re-embed.
+    brainEvents.emit('sync:applied', {
+      records: relayBatch.map(({ type, id }) => ({ type, id })),
+    });
   }
 
   console.log(`🔄 Brain sync applied: ${inserted} inserted, ${updated} updated, ${deleted} deleted, ${skipped} skipped`);

--- a/server/services/brainSync.test.js
+++ b/server/services/brainSync.test.js
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Hoisted so the vi.mock factory (also hoisted) can reference it without a TDZ error.
+const { brainEvents } = vi.hoisted(() => {
+  const { EventEmitter } = require('events');
+  return { brainEvents: new EventEmitter() };
+});
+
 vi.mock('./brainStorage.js', () => ({
   applyRemoteRecord: vi.fn(),
+  brainEvents,
   BRAIN_ENTITY_TYPES: ['people', 'projects', 'ideas', 'admin', 'memories', 'links', 'buckets', 'journals', 'inbox'],
 }));
 
@@ -134,6 +141,40 @@ describe('brainSync', () => {
     );
     expect(result.deleted).toBe(1);
     expect(result.inserted).toBe(0);
+  });
+
+  it('emits a local-only sync:applied signal carrying applied {type,id}s (issue #1080)', async () => {
+    applyRemoteRecord.mockResolvedValue({ applied: true });
+    const seen = [];
+    const listener = (payload) => seen.push(payload);
+    brainEvents.on('sync:applied', listener);
+
+    await applyRemoteChanges([
+      { op: 'create', type: 'people', id: 'p1', record: { name: 'A', updatedAt: '2026-01-01T00:00:00.000Z' } },
+      { op: 'update', type: 'ideas', id: 'i1', record: { title: 'B', updatedAt: '2026-01-01T00:00:00.000Z' } },
+    ]);
+
+    brainEvents.off('sync:applied', listener);
+    expect(seen).toHaveLength(1);
+    // Carries only {type,id} — the bridge re-reads canonical state itself.
+    expect(seen[0].records).toEqual([
+      { type: 'people', id: 'p1' },
+      { type: 'ideas', id: 'i1' },
+    ]);
+  });
+
+  it('does NOT emit sync:applied when every change is rejected (no relay batch)', async () => {
+    applyRemoteRecord.mockResolvedValue({ applied: false, reason: 'local_newer' });
+    const seen = [];
+    const listener = (payload) => seen.push(payload);
+    brainEvents.on('sync:applied', listener);
+
+    await applyRemoteChanges([
+      { op: 'update', type: 'people', id: 'p1', record: { name: 'Old', updatedAt: '2020-01-01T00:00:00.000Z' } },
+    ]);
+
+    brainEvents.off('sync:applied', listener);
+    expect(seen).toHaveLength(0);
   });
 
   it('handles mixed operations correctly', async () => {


### PR DESCRIPTION
Closes #1080

## Problem

Brain records that arrive via peer sync are written through `brainStorage.applyRemoteRecord`, which is **deliberately event-silent** (no `brainEvents`) to prevent cross-peer echo loops (#1077). Because the `brainMemoryBridge` listeners only fire on *local* writes, a record created/edited/deleted on peer A was **never re-vectorized** into peer B's memory index. Worse: the bulk `bridge-sync` **skips already-mapped records**, so a peer's *edit or delete* of an existing record left peer B's semantic-memory copy **stale and searchable indefinitely**.

This was pre-existing for people/projects/ideas/etc. and became newly relevant for the Daily Log (#1079), whose whole value is semantic search over journal entries.

## Fix

**Event path now owns synced-in edits/deletes (primary):**
- `brainSync.applyRemoteChanges` and `brainReconcile.applyBrainSnapshot` emit a **local-only** `sync:applied` signal after their relay batch, carrying `{type, id}` for every *applied* change (rejected LWW ops don't fire it). The signal **never feeds the sync log**, so it can't re-introduce the #1077 echo class.
- `brainMemoryBridge` subscribes, **debounces (~250ms)** and drains the queue **sequentially** (so a large catch-up sync doesn't saturate the embedding backend), then **re-reads each record's canonical state**: live → re-embed, tombstoned/archived → archive the mapped memory entry. Reading the store rather than the event payload makes it self-healing and order-independent.

**Bulk recovery for already-diverged installs (secondary):**
- `syncAllBrainData` gains a `refresh` mode (`POST /api/brain/bridge-sync { refresh: true }`) that re-embeds already-mapped records — the event path can't retroactively heal records that diverged *before* this fix shipped. Surfaced as a **Refresh embeddings** button on the Brain graph.

## Tests
- New `brainMemoryBridge.test.js` (the bridge had none): resync re-embed / archive-on-tombstone / archive-on-archived / journals-via-getJournal / unmirrored-type no-op / never-mapped no-op, queue dedup + sequential drain + non-array guard, end-to-end `sync:applied` wiring, and `refresh` re-embed-vs-skip.
- `sync:applied` emission tests added to `brainSync` and `brainReconcile` suites (fires on applied, silent when all rejected).
- Full server suite green (10,729 passing); client builds clean.

## Compatibility
- `sync:applied` is local-only and never re-fed to the sync log → no #1077 echo/amplification.
- `refresh` is optional and defaults false; the existing no-body `bridge-sync` call is unchanged.
- No on-disk format change, no schema-version bump needed (the new Zod schema only validates an optional request-body flag).