### PR TITLE
feat([issue-1104]): minimap waterfront overlay + UsagePage formatCompactCount dedup

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -17,3 +17,5 @@
 - **[issue-1094] Federation "Make mutual" sync behavior clarified** — documented and locked in how toggling a sync category toward a peer stays mirrored on both machines. No change to how syncing behaves.
 
 - **[issue-1114] Hardened backup-settings test coverage** — added tests pinning the "Run Backup Now" button's saved-state gating and the already-running skip path, so a regression can't silently break them.
+
+- **[issue-1104] CyberCity mini-map now shows the waterfront** — the HUD mini-map draws the bay and a Data Harbor marker, so the top-down map matches the city's real geography instead of plotting only the buildings.

--- a/client/src/components/city/CityMiniMap.jsx
+++ b/client/src/components/city/CityMiniMap.jsx
@@ -26,7 +26,7 @@ export default function CityMiniMap({ apps, onSelectApp }) {
   const { getBuildingColor } = useCityPalette();
   const view = useMemo(() => {
     const positions = computeCityLayout(Array.isArray(apps) ? apps : []);
-    return computeMiniMap(apps, positions);
+    return computeMiniMap(apps, positions, { geography: true });
   }, [apps]);
 
   if (view.empty) return null;
@@ -43,6 +43,27 @@ export default function CityMiniMap({ apps, onSelectApp }) {
           className="relative rounded-sm border border-cyan-500/20 bg-cyan-500/[0.03] overflow-hidden"
           style={{ width: MAP_SIZE, height: MAP_SIZE }}
         >
+          {/* The bay: everything above the shoreline reads as water, matching the city's
+              real geography (the bay sits north / -Z, projected to the top of the map). */}
+          {view.geography && (
+            <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+              <div
+                className="absolute left-0 right-0 top-0 bg-cyan-400/10 border-b border-cyan-400/25"
+                style={{ height: `${(view.geography.shorelineY * 100).toFixed(2)}%` }}
+              />
+              {/* Data Harbor pier marker. */}
+              <div
+                className="absolute w-1 h-1 rounded-[1px] bg-cyan-300/70 -translate-x-1/2 -translate-y-1/2 rotate-45"
+                style={{
+                  left: `${(view.geography.harbor.nx * 100).toFixed(2)}%`,
+                  top: `${(view.geography.harbor.ny * 100).toFixed(2)}%`,
+                  boxShadow: '0 0 3px rgba(103, 232, 249, 0.8)',
+                }}
+                title={view.geography.harbor.label}
+              />
+            </div>
+          )}
+
           {/* Faint grid lines for orientation */}
           <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
             <div className="absolute top-1/2 left-0 right-0 h-px bg-cyan-500/10" />

--- a/client/src/pages/UsagePage.jsx
+++ b/client/src/pages/UsagePage.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { RefreshCw } from 'lucide-react';
 import * as api from '../services/api';
 import BrailleSpinner from '../components/BrailleSpinner';
+import { formatCompactCount } from '../utils/formatters';
 
 export function UsagePage() {
   const [usage, setUsage] = useState(null);
@@ -18,12 +19,8 @@ export function UsagePage() {
     setLoading(false);
   };
 
-  const formatNumber = (num) => {
-    if (num == null) return '—';
-    if (num >= 1000000) return `${(num / 1000000).toFixed(1)}M`;
-    if (num >= 1000) return `${(num / 1000).toFixed(1)}K`;
-    return String(num);
-  };
+  // Preserve the em-dash empty-state; delegate K/M abbreviation to the shared helper.
+  const formatNumber = (num) => (num == null ? '—' : formatCompactCount(num));
 
   if (loading) {
     return <div className="text-center py-8"><BrailleSpinner text="Loading usage data" /></div>;

--- a/client/src/utils/README.md
+++ b/client/src/utils/README.md
@@ -81,7 +81,7 @@ its tunable constants and placement helpers.
 | `cityHealthTower` | Health-metric tower segments from the latest health entry (`computeHealthTower`). |
 | `cityJiraDistrict` | Jira ticket district: ticket state, sprint structures, placement (`computeJiraDistrict`). |
 | `cityMemoryDistrict` | Brain-graph memory district: category clustering, bridges, placement (`computeMemoryDistrict`). |
-| `cityMiniMap` | Mini-map projection of building positions into 2D bounds (`computeMiniMap`, `projectPoint`). |
+| `cityMiniMap` | Mini-map projection of building positions into 2D bounds, plus opt-in waterfront geography (bay/shoreline/harbor) read from `cityPlan` (`computeMiniMap`, `projectPoint`, `geographyWorldPoints`, `projectGeography`). |
 | `cityPhotoMode` | Photo-mode camera presets, the demand-loop fly stepper, postcard stats, and screenshot filename (`getPreset`, `cyclePreset`, `stepFly`). |
 | `cityPlan` | Master town plan: district parcels, shoreline/bay, plaza, transit loop, street network (`PARCELS`, `WORLD`, `computeStreets`, `computeStreetProps`, `isInWater`). |
 | `cityPlayerRig` | Exploration player-rig math: third-person follow camera, boom collision, damping, facing, avatar state (`thirdPersonCamera`, `resolveBoom`, `dampAngle`, `moveFacing`, `avatarState`). |

--- a/client/src/utils/cityMiniMap.js
+++ b/client/src/utils/cityMiniMap.js
@@ -5,6 +5,14 @@
 // projection math — world (x, z) ground coordinates → normalized 0..1 map coordinates for a
 // fixed-size map box — plus bounds and empty/degenerate handling. No React / three.js
 // imports so the topology stays unit-testable (mirrors cityTaskQueue.js).
+//
+// Geography awareness: the bay, shoreline, and Data Harbor are read from the SAME master
+// town plan (`cityPlan.js`) the 3D scene uses, so the map's waterfront can't drift from the
+// real city either. `geographyWorldPoints()` feeds those anchors into the map bounds so the
+// bay is visible, and `projectGeography()` returns normalized shoreline/harbor coordinates
+// for the overlay to draw.
+
+import { WORLD, PARCELS } from './cityPlan';
 
 // Padding (as a fraction of the box) so dots never sit exactly on the frame edge.
 export const MINI_MAP_PADDING = 0.08;
@@ -53,14 +61,53 @@ function clamp01(v) {
   return v;
 }
 
+// World-space anchor points for the city's waterfront, read from the master town plan. These
+// are folded into the map bounds (when geography is enabled) so the bay north of the shoreline
+// and the Data Harbor's piers are actually inside the visible box — building positions alone
+// only span the land, so the water would otherwise sit off-frame.
+export function geographyWorldPoints() {
+  const harbor = PARCELS.dataHarbor;
+  const [hx, , hz] = harbor.anchor;
+  const halfW = harbor.w / 2;
+  const halfD = harbor.d / 2;
+  return [
+    // Shoreline span across the paved land width, at the waterline.
+    { x: -WORLD.landHalf, z: WORLD.shorelineZ },
+    { x: WORLD.landHalf, z: WORLD.shorelineZ },
+    // Data Harbor footprint (out over the bay, z < shoreline).
+    { x: hx - halfW, z: hz - halfD },
+    { x: hx + halfW, z: hz + halfD },
+  ];
+}
+
+// Normalized (0..1) projection of the waterfront for the overlay to draw, given the SAME
+// bounds the dots use. `shorelineY` is the vertical position of the waterline (water is above
+// it on the map — smaller z projects to smaller ny); `harbor` is the harbor marker's point.
+// Returns null when bounds are null (empty city) so the overlay skips the water layer.
+export function projectGeography(bounds, padding = MINI_MAP_PADDING) {
+  if (!bounds) return null;
+  const harbor = PARCELS.dataHarbor;
+  const { ny: shorelineY } = projectPoint({ x: 0, z: WORLD.shorelineZ }, bounds, padding);
+  const harborPoint = projectPoint({ x: harbor.anchor[0], z: harbor.anchor[2] }, bounds, padding);
+  return {
+    shorelineY,
+    harbor: { nx: harborPoint.nx, ny: harborPoint.ny, label: harbor.label },
+  };
+}
+
 // Full derived view-model for the mini-map component. Takes the layout `positions` Map (the
 // return value of `computeCityLayout(apps)`, keyed by app id) plus the `apps` array (for
 // status/name/archived metadata), and produces a flat list of plotted dots with normalized
 // coordinates, the world bounds, and a count. Apps missing a layout position are skipped
 // (defensive — every active/archived app should have one). Handles empty/non-array inputs by
 // returning an empty, bounds-null view.
+//
+// `opts.geography` (default false) folds the bay/shoreline/harbor anchors into the bounds and
+// returns a `geography` view-model (shoreline + harbor in normalized coords). It's opt-in so
+// the pure projection tests keep building-only bounds; the live overlay passes `true`.
 export function computeMiniMap(apps, positions, opts = {}) {
   const padding = opts.padding ?? MINI_MAP_PADDING;
+  const includeGeography = opts.geography === true;
   const appList = Array.isArray(apps) ? apps : [];
   const posMap = positions instanceof Map ? positions : new Map();
 
@@ -71,7 +118,10 @@ export function computeMiniMap(apps, positions, opts = {}) {
     placed.push({ app, pos });
   }
 
-  const bounds = computeBounds(placed.map(({ pos }) => pos));
+  // Geography anchors expand the box so the waterfront is on-frame, but never become dots.
+  const boundsPoints = placed.map(({ pos }) => pos);
+  if (includeGeography && boundsPoints.length > 0) boundsPoints.push(...geographyWorldPoints());
+  const bounds = computeBounds(boundsPoints);
 
   const dots = placed.map(({ app, pos }) => {
     const { nx, ny } = projectPoint(pos, bounds, padding);
@@ -91,5 +141,6 @@ export function computeMiniMap(apps, positions, opts = {}) {
     bounds,
     count: dots.length,
     empty: dots.length === 0,
+    geography: includeGeography ? projectGeography(bounds, padding) : null,
   };
 }

--- a/client/src/utils/cityMiniMap.test.js
+++ b/client/src/utils/cityMiniMap.test.js
@@ -4,7 +4,10 @@ import {
   computeBounds,
   projectPoint,
   computeMiniMap,
+  geographyWorldPoints,
+  projectGeography,
 } from './cityMiniMap';
+import { WORLD, PARCELS } from './cityPlan';
 
 const pos = (x, z, district = 'downtown') => ({ x, z, district });
 
@@ -150,5 +153,76 @@ describe('computeMiniMap', () => {
     const vm = computeMiniMap(apps, positions([['a', 0, 0]]));
     expect(vm.count).toBe(1);
     expect(vm.dots.map(d => d.id)).toEqual(['a']);
+  });
+
+  it('omits geography by default (pure building bounds)', () => {
+    const apps = [{ id: 'a', overallStatus: 'online' }];
+    const vm = computeMiniMap(apps, positions([['a', 0, 0]]));
+    expect(vm.geography).toBeNull();
+  });
+
+  it('keeps geography null for an empty city even when requested', () => {
+    const vm = computeMiniMap([], new Map(), { geography: true });
+    expect(vm.geography).toBeNull();
+    expect(vm.empty).toBe(true);
+  });
+
+  it('folds the waterfront into the bounds when geography is enabled', () => {
+    const apps = [{ id: 'a', overallStatus: 'online' }];
+    const land = computeMiniMap(apps, positions([['a', 0, 0]]));
+    const sea = computeMiniMap(apps, positions([['a', 0, 0]]), { geography: true });
+    // The bay (z < shorelineZ, well north of a single downtown building) must push the
+    // box's minZ above the shoreline so the water is on-frame.
+    expect(sea.bounds.minZ).toBeLessThanOrEqual(WORLD.shorelineZ);
+    expect(sea.bounds.minZ).toBeLessThan(land.bounds.minZ);
+    expect(sea.geography).not.toBeNull();
+    expect(sea.geography.harbor.label).toBe(PARCELS.dataHarbor.label);
+  });
+
+  it('projects the shoreline above the harbor marker (water reads north / top)', () => {
+    const apps = [
+      { id: 'a', overallStatus: 'online' },
+      { id: 'b', overallStatus: 'online' },
+    ];
+    const vm = computeMiniMap(apps, positions([['a', -20, 20], ['b', 20, 40]]), { geography: true });
+    const { shorelineY, harbor } = vm.geography;
+    // Shoreline (z = -56) is north of the harbor anchor's projected dot... actually the
+    // harbor sits OUT in the bay (z = -64, beyond the shoreline), so it projects ABOVE the
+    // shoreline line — i.e. a smaller ny.
+    expect(harbor.ny).toBeLessThan(shorelineY);
+    for (const v of [shorelineY, harbor.nx, harbor.ny]) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe('geographyWorldPoints', () => {
+  it('returns shoreline + harbor anchors from the master plan', () => {
+    const pts = geographyWorldPoints();
+    expect(pts).toHaveLength(4);
+    // Shoreline endpoints span the paved land width at the waterline.
+    expect(pts[0]).toEqual({ x: -WORLD.landHalf, z: WORLD.shorelineZ });
+    expect(pts[1]).toEqual({ x: WORLD.landHalf, z: WORLD.shorelineZ });
+    // Harbor footprint corners straddle the parcel anchor out over the bay.
+    const harbor = PARCELS.dataHarbor;
+    expect(pts[2].z).toBeLessThan(WORLD.shorelineZ);
+    expect(pts[3].x).toBeCloseTo(harbor.anchor[0] + harbor.w / 2);
+  });
+});
+
+describe('projectGeography', () => {
+  it('returns null when bounds are null', () => {
+    expect(projectGeography(null)).toBeNull();
+  });
+
+  it('projects shoreline + harbor into normalized coordinates', () => {
+    const bounds = { minX: -60, maxX: 60, minZ: -70, maxZ: 60 };
+    const geo = projectGeography(bounds);
+    expect(geo.shorelineY).toBeGreaterThanOrEqual(0);
+    expect(geo.shorelineY).toBeLessThanOrEqual(1);
+    expect(geo.harbor.label).toBe(PARCELS.dataHarbor.label);
+    // Harbor anchor (z=-64) is north of the shoreline (z=-56) → projects higher (smaller ny).
+    expect(geo.harbor.ny).toBeLessThan(geo.shorelineY);
   });
 });

--- a/client/src/utils/cityMiniMap.test.js
+++ b/client/src/utils/cityMiniMap.test.js
@@ -186,9 +186,8 @@ describe('computeMiniMap', () => {
     ];
     const vm = computeMiniMap(apps, positions([['a', -20, 20], ['b', 20, 40]]), { geography: true });
     const { shorelineY, harbor } = vm.geography;
-    // Shoreline (z = -56) is north of the harbor anchor's projected dot... actually the
-    // harbor sits OUT in the bay (z = -64, beyond the shoreline), so it projects ABOVE the
-    // shoreline line — i.e. a smaller ny.
+    // The harbor sits out in the bay (z = -64, beyond the shoreline at z = -56), so it
+    // projects above the shoreline line — a smaller ny (north reads as the top of the map).
     expect(harbor.ny).toBeLessThan(shorelineY);
     for (const v of [shorelineY, harbor.nx, harbor.ny]) {
       expect(v).toBeGreaterThanOrEqual(0);


### PR DESCRIPTION
Closes #1104

City-redesign follow-ups from the master-town-plan PR. Two of the four listed items are actionable now; the other two are conditional and intentionally deferred (see below).

## Done
- **Mini-map water/harbor awareness** — `CityMiniMap` now reads the bay, shoreline, and Data Harbor from `cityPlan.js` (the same master town plan the 3D scene uses), so the top-down HUD map shows the waterfront instead of plotting only buildings. `computeMiniMap` gains an opt-in `{ geography: true }` that folds the waterfront anchors into the map bounds (so the bay is on-frame) and returns normalized shoreline + harbor coordinates; new pure helpers `geographyWorldPoints()` / `projectGeography()` are unit-tested. The overlay draws a cyan water band above the shoreline and a diamond harbor marker.
- **UsagePage compact-count dedup** — `UsagePage.formatNumber` now delegates K/M abbreviation to the shared `formatCompactCount` in `utils/formatters.js`, dropping the hand-rolled copy while preserving the em-dash empty state for null counts.

## Deferred (conditional — per the issue's triage note)
These two only fire if their trigger conditions are met; forcing them now would be speculative:
- **Instanced rooftop fallback** — only worth doing if profiling on a 100+ building install shows draw-call pain. No profiling trigger hit.
- **`CityTubeLine` closed-curve support** — only worth extracting if a second closed-loop consumer appears. Still a single consumer (`CityTransitLoop`).

## Tests
- `client/src/utils/cityMiniMap.test.js` — added geography-bounds folding, shoreline/harbor projection, and default-off coverage (geography omitted unless requested; null for empty city). All `cityMiniMap` + `cityPlan` suites pass; client build + lint clean.