### PR TITLE
fix non-converging catalog user-type sync: strict-newer LWW instead of >=

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -10,6 +10,8 @@
 
 ## Fixed
 
+- **Catalog user-type sync now converges instead of re-applying every cycle** — federated catalog *user-defined types* used an at-or-newer (`>=`) last-write-wins comparison, so a peer re-sending a type you already held at the same timestamp was re-adopted, re-written, and re-counted as a change on every sync cycle. The logs showed a constant non-zero count (e.g. `Synced with <peer>: 3 catalog changes`) once a minute forever, and the slice was rewritten needlessly each pass. The merge now uses strict-newer (`>`), matching the SQL LWW guard every other catalog kind already uses (`EXCLUDED.updated_at > …updated_at`): an equal-clock echo is a skip, so the merge is idempotent and the cycle settles to zero changes. (`server/services/catalogSync.js`)
+
 - **[issue-1080] Notes synced from other machines become searchable promptly** — a Brain note, daily-log entry, person, project, or idea created or edited on one of your machines is now re-indexed into semantic memory on the others as soon as it syncs, instead of waiting for a full manual re-sync. Edits and deletes that arrive from a peer also refresh or retire the matching memory entry, so search no longer surfaces stale copies of records that changed elsewhere. A new **Refresh embeddings** button on the Brain graph re-indexes everything in one pass to heal anything that drifted before this fix.
 
 ## Changed

--- a/server/services/catalogSync.js
+++ b/server/services/catalogSync.js
@@ -346,8 +346,14 @@ export async function applyUserTypesFromPeer(incoming = []) {
     // system types always win and are never represented in this slice.
     if (!id || INGREDIENT_TYPE_IDS.includes(id)) { skipped++; continue; }
     const existing = byId.get(id);
-    // LWW: adopt when no local copy, or the peer's clock is at-or-newer.
-    if (!existing || clockOf(peer) >= clockOf(existing)) {
+    // LWW: adopt when no local copy, or the peer's clock is STRICTLY newer.
+    // Must be `>`, not `>=` — an equal clock means the peer is echoing a type
+    // we already hold, so re-adopting it re-writes the slice and re-counts it
+    // as an applied change every cycle, and the merge never converges (the peer
+    // keeps re-sending it on the next envelope). Strict `>` mirrors the SQL LWW
+    // guard every other catalog kind uses (`EXCLUDED.updated_at > … .updated_at`
+    // in upsertScrapFromPeer / upsertTagFromPeer): equal clock = no-op = skip.
+    if (!existing || clockOf(peer) > clockOf(existing)) {
       byId.set(id, { ...peer, id });
       applied++;
     } else {

--- a/server/services/catalogSync.js
+++ b/server/services/catalogSync.js
@@ -299,7 +299,8 @@ export async function applyRemoteChanges(envelope = {}) {
 
   // User-defined type definitions (catalog v8). LWW-merge the incoming
   // definitions into the local settings slice: a peer's type whose `updatedAt`
-  // is newer than (or equal to, for a first-seen) the local copy wins; a type
+  // is strictly newer than the local copy wins (or the local copy is absent —
+  // first-seen); an equal clock is a no-op skip so the merge converges; a type
   // colliding with a built-in system id is skipped. The merge writes the
   // settings slice ONCE (not per-row) and refreshes the in-process registry so
   // the synced types resolve immediately. Wrapped so a settings write failure

--- a/server/services/catalogSync.userTypes.test.js
+++ b/server/services/catalogSync.userTypes.test.js
@@ -80,6 +80,21 @@ describe('applyRemoteChanges — catalogTypes LWW merge', () => {
     expect(store.catalogUserTypes[0].label).toBe('New');
   });
 
+  it('LWW: an equal-clock echo of a held type is a no-op (sync converges)', async () => {
+    // Regression: the merge used `>=`, so a peer re-sending a type we already
+    // hold at the SAME updatedAt was re-adopted, re-written, and re-counted as
+    // an applied change every cycle — the "Synced: N catalog changes" log never
+    // dropped to 0. Strict `>` makes an equal clock a skip, so it converges.
+    store = { catalogUserTypes: [{ id: 'faction', label: 'Faction', primaryContentKey: 'creed', fields: [], updatedAt: '2026-01-01' }] };
+    const echo = { id: 'faction', label: 'Faction', primaryContentKey: 'creed', fields: [], updatedAt: '2026-01-01' };
+    for (let cycle = 0; cycle < 3; cycle++) {
+      const stats = await applyRemoteChanges({ portosMeta: meta, catalogTypes: [echo] });
+      expect(stats.catalogTypes.applied).toBe(0);
+      expect(stats.catalogTypes.skipped).toBe(1);
+    }
+    expect(store.catalogUserTypes).toHaveLength(1);
+  });
+
   it('skips a peer type colliding with a built-in system id', async () => {
     const stats = await applyRemoteChanges({ portosMeta: meta, catalogTypes: [{ id: 'character', label: 'Hijack', primaryContentKey: 'x', fields: [], updatedAt: '2027-01-01' }] });
     expect(stats.catalogTypes.applied).toBe(0);


### PR DESCRIPTION
## Summary

Federated catalog **user-defined types** never converged: the per-cycle sync log showed a constant non-zero count (e.g. `Synced with void: 3 catalog changes`) once a minute, forever, even when nothing had actually changed.

Root cause is in `applyUserTypesFromPeer` (`server/services/catalogSync.js`). The LWW merge compared the peer's clock against the local clock with `>=` (at-or-newer):

```js
if (!existing || clockOf(peer) >= clockOf(existing)) {
```

When a peer re-sends a type you already hold at the **same** `updatedAt` — which it does on every envelope, since user types "ride every envelope" — the equal clock satisfied `>=`, so the type was re-adopted, the whole slice was re-written to disk, and it was re-counted as an `applied` change. The merge could never settle to zero.

Every other catalog kind already uses the correct guard — strict `>` — in its SQL upsert (`EXCLUDED.updated_at > catalog_*.updated_at` in `upsertScrapFromPeer` / `upsertTagFromPeer`). This one function was the lone outlier, and its own doc comment said "newer than" (strict). The fix switches it to `>` so an equal clock is a skip: idempotent, convergent, and consistent with the rest of the file.

Behavior preserved:
- First-seen types are still adopted.
- Strictly-newer peer edits still win; strictly-older are skipped.
- Deletion tombstones (clock = later of `updatedAt`/`deletedAt`) are still strictly greater, so they still win and don't resurrect.
- Equal-clock-but-different-data now leaves the local copy in place (stable) instead of ping-ponging — matching the SQL convention used by every other kind.

## Test plan

- Added a regression test that runs an equal-clock echo of a held type through 3 sync cycles, asserting `applied: 0` and `skipped: 1` each pass and that the slice stays length 1 (`catalogSync.userTypes.test.js`).
- `cd server && npx vitest run services/catalogSync.userTypes.test.js services/catalogSync.test.js` → 36/36 pass, including the existing deletion-tombstone and older-edit cases.
- After deploying to both peers, the per-cycle log should change from a steady `N catalog changes` to `0 changes applied` whenever nothing genuinely changed.
