### PR TITLE
fix([issue-1136]): allowlist OpenClaw runtime status fields and trim messages test-token response

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -35,6 +35,8 @@
 
 ## Changed
 
+- **[issue-1136] Debug and status responses no longer echo raw upstream payloads** — the OpenClaw status check and the message-account token test now return only the summary fields they're meant to (connection state, counts, errors) instead of passing through whatever the upstream service responded with.
+
 - **[issue-1094] Federation "Make mutual" sync behavior clarified** — documented and locked in how toggling a sync category toward a peer stays mirrored on both machines. No change to how syncing behaves.
 
 - **[issue-1114] Hardened backup-settings test coverage** — added tests pinning the "Run Backup Now" button's saved-state gating and the already-running skip path, so a regression can't silently break them.

--- a/server/integrations/openclaw/api.js
+++ b/server/integrations/openclaw/api.js
@@ -109,7 +109,11 @@ function normalizeStatusPayload(payload, config, reachable, errorMessage) {
     label: pickFirst(payload?.label, payload?.name, config.label, 'OpenClaw Runtime'),
     defaultSession: pickFirst(payload?.defaultSession, payload?.defaultSessionId, config.defaultSession, null) || null,
     message: errorMessage || pickFirst(payload?.message, payload?.statusMessage, null) || null,
-    runtime: payload && typeof payload === 'object' ? payload : null
+    // Allowlist runtime fields — the upstream payload may echo internal fields
+    // (or reflected tokens), so never pass the raw object through to the client.
+    runtime: payload && typeof payload === 'object'
+      ? { sessionsCount: payload.sessionsCount ?? null }
+      : null
   };
 }
 

--- a/server/integrations/openclaw/api.test.js
+++ b/server/integrations/openclaw/api.test.js
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../../lib/fileUtils.js', () => ({
+  PATHS: { data: '/tmp/portos-test-data' },
+  readJSONFile: vi.fn()
+}));
+
+vi.mock('../../lib/fetchWithTimeout.js', () => ({
+  fetchWithTimeout: vi.fn()
+}));
+
+import { readJSONFile } from '../../lib/fileUtils.js';
+import { fetchWithTimeout } from '../../lib/fetchWithTimeout.js';
+import { getRuntimeStatus } from './api.js';
+
+const OPENCLAW_ENV_KEYS = Object.keys(process.env).filter(key => key.startsWith('OPENCLAW_'));
+
+function mockUpstreamResponse(payload) {
+  fetchWithTimeout.mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify(payload)
+  });
+}
+
+describe('openclaw getRuntimeStatus', () => {
+  const savedEnv = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    for (const key of OPENCLAW_ENV_KEYS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    readJSONFile.mockResolvedValue({ baseUrl: 'http://openclaw.local', defaultSession: 'main' });
+  });
+
+  afterEach(() => {
+    for (const key of OPENCLAW_ENV_KEYS) {
+      process.env[key] = savedEnv[key];
+    }
+  });
+
+  it('exposes only the allowlisted runtime fields, never the raw upstream payload', async () => {
+    mockUpstreamResponse({
+      ok: true,
+      result: {
+        sessions: [{ id: 'main' }, { id: 'work' }],
+        internalToken: 'should-never-reach-the-client',
+        debugInfo: { host: 'internal-host' }
+      }
+    });
+
+    const status = await getRuntimeStatus();
+
+    expect(status.reachable).toBe(true);
+    expect(status.runtime).toEqual({ sessionsCount: 2 });
+    expect(JSON.stringify(status)).not.toContain('should-never-reach-the-client');
+    expect(JSON.stringify(status)).not.toContain('internal-host');
+  });
+
+  it('returns runtime: null when the runtime is unreachable', async () => {
+    fetchWithTimeout.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+    const status = await getRuntimeStatus();
+
+    expect(status.reachable).toBe(false);
+    expect(status.runtime).toBeNull();
+  });
+
+  it('returns runtime: null when OpenClaw is not configured', async () => {
+    readJSONFile.mockResolvedValue({});
+
+    const status = await getRuntimeStatus();
+
+    expect(status.configured).toBe(false);
+    expect(status.runtime).toBeNull();
+    expect(fetchWithTimeout).not.toHaveBeenCalled();
+  });
+});

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -468,7 +468,18 @@ router.post('/debug/test-token', asyncHandler(async (req, res) => {
 
   const apiResult = await testApi(provider, tokenResult.token, parseInt(req.query?.top, 10) || 5);
 
-  res.json({ token: tokenInfo, api: apiResult });
+  // Trim the raw Graph/Outlook response to a status summary — message bodies and
+  // recipient lists have no business in a token-connectivity check response.
+  res.json({
+    token: tokenInfo,
+    api: {
+      success: apiResult.success === true,
+      ...(apiResult.status !== undefined && { status: apiResult.status }),
+      ...(apiResult.error !== undefined && { error: apiResult.error }),
+      ...(apiResult.count !== undefined && { count: apiResult.count }),
+      ...(apiResult.note !== undefined && { note: apiResult.note })
+    }
+  });
 }));
 
 router.post('/debug/clear-token', asyncHandler(async (req, res) => {

--- a/server/routes/messages.test.js
+++ b/server/routes/messages.test.js
@@ -42,12 +42,20 @@ vi.mock('../services/messagePlaywrightSync.js', () => ({
   launchProvider: vi.fn()
 }));
 
+vi.mock('../services/messageTokenExtractor.js', () => ({
+  getToken: vi.fn(),
+  getTokenStatus: vi.fn(),
+  testApi: vi.fn(),
+  clearTokenCache: vi.fn()
+}));
+
 // Import mocked modules
 import * as messageAccounts from '../services/messageAccounts.js';
 import * as messageSync from '../services/messageSync.js';
 import * as messageDrafts from '../services/messageDrafts.js';
 import * as messageSender from '../services/messageSender.js';
 import * as messagePlaywrightSync from '../services/messagePlaywrightSync.js';
+import * as messageTokenExtractor from '../services/messageTokenExtractor.js';
 
 const VALID_UUID = '11111111-1111-1111-1111-111111111111';
 const VALID_UUID_2 = '22222222-2222-2222-2222-222222222222';
@@ -636,6 +644,54 @@ describe('Messages Routes', () => {
 
       expect(response.status).toBe(400);
       expect(response.body.error).toBe('Invalid provider');
+    });
+  });
+
+  describe('POST /api/messages/debug/test-token', () => {
+    it('trims the provider API result to a status summary without message payloads', async () => {
+      messageTokenExtractor.getToken.mockResolvedValue({
+        token: 'tok-abcdef',
+        fresh: true,
+        decoded: { exp: 1893456000, aud: 'https://outlook.office.com', scp: 'Mail.Read' }
+      });
+      messageTokenExtractor.testApi.mockResolvedValue({
+        success: true,
+        count: 2,
+        messages: [
+          { id: 'm1', subject: 'Private subject', bodyContent: 'private-body-content' },
+          { id: 'm2', subject: 'Another', bodyContent: 'more-private-content' }
+        ]
+      });
+
+      const response = await request(app)
+        .post('/api/messages/debug/test-token')
+        .send({ provider: 'outlook' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.api).toEqual({ success: true, count: 2 });
+      const serialized = JSON.stringify(response.body);
+      expect(serialized).not.toContain('private-body-content');
+      expect(serialized).not.toContain('Private subject');
+    });
+
+    it('passes through status and error fields when the API test fails', async () => {
+      messageTokenExtractor.getToken.mockResolvedValue({
+        token: 'tok-abcdef',
+        fresh: false,
+        decoded: {}
+      });
+      messageTokenExtractor.testApi.mockResolvedValue({
+        success: false,
+        status: 401,
+        error: 'InvalidAuthenticationToken'
+      });
+
+      const response = await request(app)
+        .post('/api/messages/debug/test-token')
+        .send({ provider: 'outlook' });
+
+      expect(response.status).toBe(200);
+      expect(response.body.api).toEqual({ success: false, status: 401, error: 'InvalidAuthenticationToken' });
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #1136.

Two response surfaces echoed raw upstream payloads to the client:

- `GET /api/openclaw/status` passed the upstream response straight through as `runtime`. It now allowlists the one field the status contract needs (`sessionsCount`), so upstream-internal fields or reflected tokens can never reach the client. The PortOS client never read `runtime` directly, so no UI change.
- `POST /api/messages/debug/test-token` returned the full Graph/Outlook API response — including message bodies and recipient lists — for what is a token-connectivity check. It now returns only `success`/`status`/`error`/`count`/`note`, mirroring the already-trimmed `calendar.js` sibling endpoint.

## Test plan

- New `server/integrations/openclaw/api.test.js` pins the `runtime` allowlist shape plus the unreachable/unconfigured null paths.
- New cases in `server/routes/messages.test.js` pin the trimmed test-token shape on success and failure, and assert message bodies are absent from the serialized response.
- Full server suite: 551 files, 10929 tests passing.