### PR TITLE
test([issue-1198]): de-flake SeriesLlmPicker provider/model change tests

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -35,6 +35,8 @@
 
 ## Changed
 
+- **[issue-1198] Stabilized a flaky pipeline test** — the Series AI-provider picker test no longer races the async option list, so CI stops failing intermittently on it. No behavior change.
+
 - **[issue-1172] Added route-level tests for the Digital Twin and Agent Tools APIs** — pins request validation and error/status handling so a regression in those endpoints surfaces in CI. No behavior change.
 
 - **[issue-1167] Trimmed two dependencies' footprint** — the Moltworld real-time connection now uses the runtime's built-in WebSocket instead of a third-party library, and the Claude Code changelog feed parses with a small built-in extractor. No behavior change.

--- a/client/src/components/pipeline/SeriesLlmPicker.test.jsx
+++ b/client/src/components/pipeline/SeriesLlmPicker.test.jsx
@@ -47,6 +47,9 @@ describe('SeriesLlmPicker', () => {
     const onSeriesUpdate = vi.fn();
     renderPicker({ id: 's1', llm: undefined }, onSeriesUpdate);
     await waitFor(() => expect(getProviders).toHaveBeenCalled());
+    // Wait for the provider option to render before selecting it (its options
+    // come from the async getProviders result — same populate race as above).
+    await screen.findByRole('option', { name: 'Provider One' });
     fireEvent.change(screen.getAllByRole('combobox')[0], { target: { value: 'p1' } });
     await waitFor(() => expect(updatePipelineSeries).toHaveBeenCalledWith('s1', { llm: { provider: 'p1', model: null } }));
     await waitFor(() => expect(onSeriesUpdate).toHaveBeenCalledWith({ id: 's1', llm: { provider: 'p1', model: null } }));
@@ -69,6 +72,11 @@ describe('SeriesLlmPicker', () => {
   it('preserves the chosen provider when only the model changes', async () => {
     renderPicker({ id: 's1', llm: { provider: 'p1', model: '' } });
     await waitFor(() => expect(getProviders).toHaveBeenCalled());
+    // The model <select>'s options are populated from the async getProviders
+    // result. Wait for the target option to actually exist before changing the
+    // value — firing the change before the provider's models render leaves the
+    // picker mid-populate and saves the wrong (empty) provider (flaky in CI).
+    await screen.findByRole('option', { name: 'm2' });
     fireEvent.change(screen.getAllByRole('combobox')[1], { target: { value: 'm2' } });
     await waitFor(() => expect(updatePipelineSeries).toHaveBeenCalledWith('s1', { llm: { provider: 'p1', model: 'm2' } }));
   });


### PR DESCRIPTION
## Summary

Closes #1198.

`SeriesLlmPicker.test.jsx` failed intermittently in CI (observed on PR #1197's run; passes locally in isolation). The provider/model `<select>` options are populated from the async `getProviders()` result, but the two tests that fire a `change` event waited only on `getProviders` having been *called*, then immediately changed the value. Under CI scheduling load the change landed before the option (and the picker's resolved-provider state) had rendered, so `updatePipelineSeries` was called with the wrong/empty provider — the assertion saw `[ Array(1) ]` / a missing arg.

Fix: before firing the change, `await screen.findByRole('option', { name })` so the target option actually exists. Applied to both the "preserves the chosen provider when only the model changes" case (the one that failed in CI) and the sibling "saves … on provider change" case (same populate race).

## Test plan

- Ran the suite 5× locally: 6/6 every time (was the intermittent failure source).
- No production code touched — test-only timing fix.