### PR TITLE
test([issue-1200]): de-flake peerSync unsubscribe race test

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -35,6 +35,8 @@
 
 ## Changed
 
+- **[issue-1200] Stabilized a flaky federation test** — the peer-sync unsubscribe race test now asserts the timing-independent invariants instead of one specific interleaving, so CI stops failing intermittently on it. No behavior change.
+
 - **[issue-1172] Added route-level tests for the Digital Twin and Agent Tools APIs** — pins request validation and error/status handling so a regression in those endpoints surfaces in CI. No behavior change.
 
 - **[issue-1167] Trimmed two dependencies' footprint** — the Moltworld real-time connection now uses the runtime's built-in WebSocket instead of a third-party library, and the Claude Code changelog feed parses with a small built-in extractor. No behavior change.

--- a/server/services/sharing/peerSync.test.js
+++ b/server/services/sharing/peerSync.test.js
@@ -434,14 +434,19 @@ describe('peerSync', () => {
       // need an honest count.
       //
       // We force the failure path by racing two `unsubscribeAllForRecord`
-      // calls in parallel. `listPeerSubscriptions` (line 401 of peerSync)
-      // is NOT inside withStateLock — so both calls take an identical
-      // snapshot containing sub1+sub2 before either's first
-      // `unsubscribePeer` runs. The first call's two `unsubscribePeer`
-      // invocations execute under the state lock and remove both subs.
-      // The second call's invocations then hit ERR_NOT_FOUND, so both
-      // ids land in its `failed` array — proving the per-sub catch
-      // honestly separates success from failure.
+      // calls in parallel. `listPeerSubscriptions` is NOT inside the state
+      // lock, so the two calls can race: each takes its own snapshot, and
+      // whichever `unsubscribePeer` lands second for a given sub hits
+      // ERR_NOT_FOUND and routes that id to `failed` instead of `removed`.
+      //
+      // The EXACT split depends on interleaving (whether the second call
+      // snapshots before or after the first call's removals land), so this
+      // asserts the INVARIANTS that must hold under every interleaving
+      // rather than a single timing-specific outcome (the latter flaked in
+      // CI — see #1200): each sub is removed exactly once total, no id is
+      // ever in both `removed` and `failed` of the SAME call, and a
+      // `failed` id always coincides with the other call having `removed`
+      // it (a failure only happens because the racing call already won).
       vi.mocked(getUniverse).mockResolvedValue({ id: 'u1' });
       vi.mocked(peerFetch).mockResolvedValue({ ok: true, json: async () => ({}) });
       const sub1 = await subscribePeer({ peerId: 'peer-a', recordKind: 'universe', recordId: 'u1' });
@@ -450,20 +455,33 @@ describe('peerSync', () => {
         unsubscribeAllForRecord('universe', 'u1'),
         unsubscribeAllForRecord('universe', 'u1'),
       ]);
-      // Exactly one call wins each sub. Across the two results, every sub
-      // must appear in exactly one `removed` (success) and exactly one
-      // `failed` (the racing duplicate).
-      const allRemoved = [...resultA.removed, ...resultB.removed].sort();
-      const allFailed = [...resultA.failed, ...resultB.failed].sort();
-      expect(allRemoved).toEqual([sub1.id, sub2.id].sort());
-      expect(allFailed).toEqual([sub1.id, sub2.id].sort());
-      // No id appears in both removed AND failed of the same call.
-      for (const result of [resultA, resultB]) {
-        for (const id of result.removed) {
-          expect(result.failed).not.toContain(id);
-        }
+
+      const removedA = new Set(resultA.removed);
+      const removedB = new Set(resultB.removed);
+      const failedA = new Set(resultA.failed);
+      const failedB = new Set(resultB.failed);
+
+      // Each sub is removed exactly once across the two calls — never zero
+      // (it must come out) and never twice (the lock serializes the actual
+      // removal, so only one call legitimately removes it).
+      for (const id of [sub1.id, sub2.id]) {
+        const removedCount = (removedA.has(id) ? 1 : 0) + (removedB.has(id) ? 1 : 0);
+        expect(removedCount, `sub ${id} removed exactly once`).toBe(1);
       }
-      // Both subs are actually gone from disk.
+
+      // The honest-accounting guard: within a single call, an id is never
+      // reported as BOTH removed and failed.
+      for (const [removed, failed] of [[removedA, failedA], [removedB, failedB]]) {
+        for (const id of removed) expect(failed.has(id)).toBe(false);
+      }
+
+      // Any `failed` id is one the OTHER call removed — a failure only
+      // arises because the racing call already won that sub (never a
+      // spurious failure for a sub nobody removed).
+      for (const id of failedA) expect(removedB.has(id)).toBe(true);
+      for (const id of failedB) expect(removedA.has(id)).toBe(true);
+
+      // Both subs are actually gone from disk regardless of who won.
       expect(await findPeerSubscription('peer-a', 'universe', 'u1')).toBeNull();
       expect(await findPeerSubscription('peer-b-inbound-only', 'universe', 'u1')).toBeNull();
     });


### PR DESCRIPTION
## Summary

Closes #1200.

`peerSync.test.js > unsubscribeAllForRecord > reports per-sub success vs failure separately` failed intermittently in CI (observed on PR #1199's run — a server-only arcPlanner refactor that doesn't touch peerSync). The test races two parallel `unsubscribeAllForRecord` calls and asserted that across the two results both sub ids appear in exactly one `failed` — but that outcome only holds for one interleaving (both calls snapshot `listPeerSubscriptions`, which isn't under the state lock, before either's removals land). Under CI scheduling load the first call can remove a sub before the second snapshots it, so that sub never enters the second call's working set and the combined `failed` has 1 entry, not 2.

Fix: assert the invariants that hold under **every** interleaving instead of one timing-specific outcome —
- each sub is removed exactly once across the two calls (never zero, never twice — the lock serializes the real removal),
- no id is ever in both `removed` and `failed` of the *same* call (the honest-accounting guard this test exists for),
- any `failed` id was `removed` by the *other* call (a failure only arises because the racing call already won that sub — no spurious failures).

Plus the existing on-disk check that both subs are gone.

## Test plan

- Ran the suite 5× locally: 176/176 every time.
- Full server suite: 562 files, 11034 passing.
- No production code touched — test-only.