### PR TITLE
Unify tabbed-page headers behind a shared PageHeader component

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -35,6 +35,8 @@
 
 ## Changed
 
+- **[issue-1182] Unified tabbed-page headers behind a shared `PageHeader`** — Brain, MeatSpace, Settings, Goals, Calendar, and Insights each hand-rolled their title bar with different padding and title scales (`px-3 py-2 sm:p-4` vs `px-6 pt-6 pb-4` vs `p-4` vs `px-4 sm:px-6 py-3 sm:py-4`, `text-lg` through `text-2xl`), so moving between sections jittered the header. They now share `client/src/components/PageHeader.jsx` — compact `px-3 py-2 sm:px-4 sm:py-3 border-b border-port-border` padding and a `text-lg sm:text-xl font-bold` title, with `icon`/`subtitle`/`actions` slots. The three pages that hand-rolled their own tab strips (MeatSpace, Insights, Goals) now render the shared `TabPills` instead, so all six pages share one active-tab style and gain its tablist/tab a11y roles and 44px mobile tap targets. Settings gains a gear icon to match its siblings; ChiefOfStaff keeps its bespoke gradient avatar panel (it isn't a plain title bar). (`client/src/components/PageHeader.jsx`, `client/src/pages/{Brain,MeatSpace,Settings,Goals,Calendar,Insights}.jsx`)
+
 - **[issue-1200] Stabilized a flaky federation test** — the peer-sync unsubscribe race test now asserts the timing-independent invariants instead of one specific interleaving, so CI stops failing intermittently on it. No behavior change.
 
 - **[issue-1198] Stabilized a flaky pipeline test** — the Series AI-provider picker test no longer races the async option list, so CI stops failing intermittently on it. No behavior change.

--- a/client/src/components/PageHeader.jsx
+++ b/client/src/components/PageHeader.jsx
@@ -1,0 +1,53 @@
+// Shared title bar for tabbed top-level pages (Brain, MeatSpace, Settings,
+// Goals, Calendar, Insights, …). Before this existed each page hand-rolled its
+// own header with different padding and title scales, so navigating between
+// sections produced visual jitter (issue #1182). This standardizes the bar:
+// compact `px-3 py-2 sm:px-4 sm:py-3` padding (keeps actionable content above
+// the fold), a `text-lg sm:text-xl font-bold` title, and the shared
+// `border-b border-port-border`.
+//
+// Slots:
+//   icon       — a lucide-react component (passed as the component, not an element)
+//   iconColor  — Tailwind color class for the icon (default `text-port-accent`;
+//                MeatSpace passes `text-port-error`)
+//   title      — string, the page name
+//   subtitle   — optional descriptive tagline (hidden below `sm` to save space)
+//   actions    — optional ReactNode rendered right-aligned on the title row
+//                (counts, badges, buttons, or a compact tab control)
+//   className  — merged onto the outer bar (e.g. Goals' `bg-port-card`,
+//                MeatSpace's `print:hidden`)
+//
+// PageHeader owns ONLY the title bar. Pages with a full tab strip render the
+// shared `TabPills` immediately below it (see Brain/Calendar/MeatSpace/Insights)
+// rather than nesting tabs inside the header, so every page keeps one
+// consistent border + padding regardless of how it lays out its tabs.
+export default function PageHeader({
+  icon: Icon,
+  iconColor = 'text-port-accent',
+  title,
+  subtitle,
+  actions,
+  className = '',
+}) {
+  return (
+    <div className={`shrink-0 px-3 py-2 sm:px-4 sm:py-3 border-b border-port-border ${className}`}>
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
+        <div className="flex items-center gap-2 sm:gap-3 min-w-0">
+          {Icon && <Icon className={`w-6 h-6 sm:w-7 sm:h-7 shrink-0 ${iconColor}`} aria-hidden="true" />}
+          <div className="min-w-0">
+            <h1 className="text-lg sm:text-xl font-bold text-white leading-tight">{title}</h1>
+            {subtitle && (
+              <p className="hidden sm:block text-sm text-gray-500 leading-tight">{subtitle}</p>
+            )}
+          </div>
+        </div>
+
+        {actions && (
+          <div className="flex items-center gap-x-3 gap-y-1 flex-wrap justify-end">
+            {actions}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/PageHeader.test.jsx
+++ b/client/src/components/PageHeader.test.jsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Brain } from 'lucide-react';
+import PageHeader from './PageHeader';
+
+describe('PageHeader', () => {
+  it('renders the title as an h1', () => {
+    render(<PageHeader title="Brain" />);
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1.textContent).toBe('Brain');
+  });
+
+  it('renders an icon when provided and marks it aria-hidden', () => {
+    const { container } = render(<PageHeader icon={Brain} title="Brain" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toBeTruthy();
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('renders no icon element when icon is omitted', () => {
+    const { container } = render(<PageHeader title="Settings" />);
+    expect(container.querySelector('svg')).toBeNull();
+  });
+
+  it('applies a custom icon color class', () => {
+    const { container } = render(<PageHeader icon={Brain} iconColor="text-port-error" title="MeatSpace" />);
+    expect(container.querySelector('svg').getAttribute('class')).toContain('text-port-error');
+  });
+
+  it('defaults the icon color to the accent token', () => {
+    const { container } = render(<PageHeader icon={Brain} title="Brain" />);
+    expect(container.querySelector('svg').getAttribute('class')).toContain('text-port-accent');
+  });
+
+  it('renders the subtitle when provided', () => {
+    render(<PageHeader title="Calendar" subtitle="Unified calendar and event management" />);
+    expect(screen.getByText('Unified calendar and event management')).toBeTruthy();
+  });
+
+  it('omits the subtitle paragraph when not provided', () => {
+    const { container } = render(<PageHeader title="Settings" />);
+    expect(container.querySelector('p')).toBeNull();
+  });
+
+  it('renders the actions slot', () => {
+    render(
+      <PageHeader
+        title="Brain"
+        actions={<span>12 links</span>}
+      />
+    );
+    expect(screen.getByText('12 links')).toBeTruthy();
+  });
+
+  it('keeps the standardized padding + border on the outer container', () => {
+    const { container } = render(<PageHeader title="Goals" />);
+    const cls = container.firstChild.getAttribute('class');
+    expect(cls).toContain('border-b');
+    expect(cls).toContain('border-port-border');
+    expect(cls).toContain('px-3');
+    expect(cls).toContain('sm:px-4');
+  });
+
+  it('merges a caller-supplied className onto the container', () => {
+    const { container } = render(<PageHeader title="Goals" className="bg-port-card" />);
+    expect(container.firstChild.getAttribute('class')).toContain('bg-port-card');
+  });
+});

--- a/client/src/pages/Brain.jsx
+++ b/client/src/pages/Brain.jsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from 'react-router-dom';
 import * as api from '../services/api';
 import {Brain as BrainIcon} from 'lucide-react';
 import BrailleSpinner from '../components/BrailleSpinner';
+import PageHeader from '../components/PageHeader';
 import TabPills from '../components/ui/TabPills';
 import { useAutoRefetch } from '../hooks/useAutoRefetch';
 import { sameJsonShape } from '../lib/sameJsonShape';
@@ -90,18 +91,12 @@ export default function Brain() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2 px-3 py-2 sm:p-4 border-b border-port-border">
-        <div className="flex items-center gap-2 sm:gap-3 min-w-0">
-          <BrainIcon className="w-6 h-6 sm:w-8 sm:h-8 text-port-accent shrink-0" />
-          <div className="min-w-0">
-            <h1 className="text-lg sm:text-xl font-bold text-white leading-tight">Brain</h1>
-            <p className="hidden sm:block text-sm text-gray-500">Second brain for capturing and organizing thoughts</p>
-          </div>
-        </div>
-
-        {/* Quick stats — wrap on small screens; only "needs review" stays loud */}
-        {summary && (
+      <PageHeader
+        icon={BrainIcon}
+        title="Brain"
+        subtitle="Second brain for capturing and organizing thoughts"
+        actions={summary && (
+          // Quick stats — wrap on small screens; only "needs review" stays loud
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs sm:text-sm">
             {summary.needsReview > 0 && (
               <span className="px-2 py-0.5 rounded bg-port-warning/20 text-port-warning">
@@ -124,7 +119,7 @@ export default function Brain() {
             )}
           </div>
         )}
-      </div>
+      />
 
       <TabPills
         tabs={TABS}

--- a/client/src/pages/Calendar.jsx
+++ b/client/src/pages/Calendar.jsx
@@ -3,6 +3,7 @@ import { CalendarDays, Calendar as CalendarIcon, ClipboardList, Clock, Columns, 
 import { useState, useEffect, useCallback } from 'react';
 import * as api from '../services/api';
 import BrailleSpinner from '../components/BrailleSpinner';
+import PageHeader from '../components/PageHeader';
 import TabPills from '../components/ui/TabPills';
 import { useValidTab } from '../hooks/useValidTab';
 
@@ -81,18 +82,12 @@ export default function Calendar() {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="flex items-center justify-between p-4 border-b border-port-border">
-        <div className="flex items-center gap-3">
-          <CalendarDays className="w-8 h-8 text-port-accent" />
-          <div>
-            <h1 className="text-xl font-bold text-white">Calendar</h1>
-            <p className="text-sm text-gray-500">Unified calendar and event management</p>
-          </div>
-        </div>
-        <div className="flex items-center gap-4 text-sm">
-          <span className="text-gray-500">{accounts.length} accounts</span>
-        </div>
-      </div>
+      <PageHeader
+        icon={CalendarDays}
+        title="Calendar"
+        subtitle="Unified calendar and event management"
+        actions={<span className="text-sm text-gray-500">{accounts.length} accounts</span>}
+      />
 
       <TabPills tabs={TABS} activeTab={activeTab} onChange={handleTabChange} ariaLabel="Calendar sections" />
 

--- a/client/src/pages/Goals.jsx
+++ b/client/src/pages/Goals.jsx
@@ -4,6 +4,8 @@ import {Target, TreePine, List} from 'lucide-react';
 import * as api from '../services/api';
 import GoalsListView from '../components/goals/GoalsListView';
 import MortalLoomBanner from '../components/MortalLoomBanner';
+import PageHeader from '../components/PageHeader';
+import TabPills from '../components/ui/TabPills';
 import BrailleSpinner from '../components/BrailleSpinner';
 import { useValidTab } from '../hooks/useValidTab';
 
@@ -45,40 +47,28 @@ export default function Goals() {
     <div className="h-full flex flex-col overflow-hidden">
       <MortalLoomBanner section="Goals" />
 
-      {/* Header */}
-      <div className="flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4 border-b border-port-border bg-port-card">
-        <div className="flex items-center gap-2 sm:gap-3 min-w-0">
-          <Target className="w-5 h-5 sm:w-6 sm:h-6 text-port-accent shrink-0" />
-          <h1 className="text-lg sm:text-xl font-semibold text-white">Goals</h1>
-          {data && (
-            <span className="text-xs sm:text-sm text-gray-500">
-              {data.flat?.length || 0}
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-2 sm:gap-3">
-          <div className="flex bg-port-bg rounded-lg p-0.5">
-            {TABS.map(t => {
-              const Icon = t.icon;
-              const active = tab === t.id;
-              return (
-                <button
-                  key={t.id}
-                  onClick={() => handleTabChange(t.id)}
-                  className={`flex items-center gap-1.5 px-2.5 sm:px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${
-                    active
-                      ? 'bg-port-accent text-white'
-                      : 'text-gray-400 hover:text-white'
-                  }`}
-                >
-                  <Icon className="w-4 h-4" />
-                  <span className="hidden sm:inline">{t.label}</span>
-                </button>
-              );
-            })}
-          </div>
-        </div>
-      </div>
+      <PageHeader
+        icon={Target}
+        title="Goals"
+        className="bg-port-card"
+        actions={(
+          <>
+            {data && (
+              <span className="text-xs sm:text-sm text-gray-500">
+                {data.flat?.length || 0}
+              </span>
+            )}
+            <TabPills
+              tabs={TABS}
+              activeTab={tab}
+              onChange={handleTabChange}
+              variant="pills"
+              size="sm"
+              ariaLabel="Goals views"
+            />
+          </>
+        )}
+      />
 
       {/* Content */}
       <div className="flex-1 overflow-hidden">

--- a/client/src/pages/Insights.jsx
+++ b/client/src/pages/Insights.jsx
@@ -11,6 +11,8 @@ import GenomeHealthTab from '../components/insights/GenomeHealthTab';
 import TasteIdentityTab from '../components/insights/TasteIdentityTab';
 import CrossDomainTab from '../components/insights/CrossDomainTab';
 import ConfidenceBadge from '../components/insights/ConfidenceBadge';
+import PageHeader from '../components/PageHeader';
+import TabPills from '../components/ui/TabPills';
 import { timeAgo } from '../utils/formatters';
 
 // Exported for the nav-manifest tab-coverage guard (server/lib/navManifest.test.js).
@@ -196,32 +198,18 @@ export default function Insights() {
 
   return (
     <div className="flex flex-col h-full">
-      {/* Header */}
-      <div className="shrink-0 px-6 pt-6 pb-4 border-b border-port-border">
-        <div className="flex items-center gap-3 mb-4">
-          <Lightbulb size={24} className="text-port-accent" />
-          <h1 className="text-2xl font-bold text-white">Insights</h1>
-          <span className="text-sm text-gray-500">Cross-Domain Intelligence</span>
-        </div>
+      <PageHeader
+        icon={Lightbulb}
+        title="Insights"
+        subtitle="Cross-Domain Intelligence"
+      />
 
-        {/* Tab bar */}
-        <div className="flex gap-1 overflow-x-auto">
-          {TABS.map(({ id, label, icon: Icon }) => (
-            <button
-              key={id}
-              onClick={() => navigate(`/insights/${id}`)}
-              className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
-                activeTab === id
-                  ? 'bg-port-accent/10 text-port-accent'
-                  : 'text-gray-400 hover:text-white hover:bg-port-border/50'
-              }`}
-            >
-              <Icon size={16} />
-              {label}
-            </button>
-          ))}
-        </div>
-      </div>
+      <TabPills
+        tabs={TABS}
+        activeTab={activeTab}
+        onChange={(id) => navigate(`/insights/${id}`)}
+        ariaLabel="Insights sections"
+      />
 
       {/* Tab content */}
       <div className="flex-1 overflow-auto p-6">

--- a/client/src/pages/MeatSpace.jsx
+++ b/client/src/pages/MeatSpace.jsx
@@ -3,6 +3,8 @@ import { Skull } from 'lucide-react';
 
 import { TABS } from '../components/meatspace/constants';
 import MortalLoomBanner from '../components/MortalLoomBanner';
+import PageHeader from '../components/PageHeader';
+import TabPills from '../components/ui/TabPills';
 
 import OverviewTab from '../components/meatspace/tabs/OverviewTab';
 import AgeTab from '../components/meatspace/tabs/AgeTab';
@@ -60,32 +62,21 @@ export default function MeatSpace() {
         <MortalLoomBanner section="Meatspace health data" />
       </div>
 
-      {/* Header */}
-      <div className="shrink-0 px-6 pt-6 pb-4 border-b border-port-border print:hidden">
-        <div className="flex items-center gap-3 mb-4">
-          <Skull size={24} className="text-port-error" />
-          <h1 className="text-2xl font-bold text-white">MeatSpace</h1>
-          <span className="text-sm text-gray-500">Physical Health Dashboard</span>
-        </div>
+      <PageHeader
+        icon={Skull}
+        iconColor="text-port-error"
+        title="MeatSpace"
+        subtitle="Physical Health Dashboard"
+        className="print:hidden"
+      />
 
-        {/* Tabs */}
-        <div className="flex gap-1 overflow-x-auto">
-          {TABS.map(({ id, label, icon: Icon }) => (
-            <button
-              key={id}
-              onClick={() => handleTabChange(id)}
-              className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium whitespace-nowrap transition-colors ${
-                activeTab === id
-                  ? 'bg-port-accent/10 text-port-accent'
-                  : 'text-gray-400 hover:text-white hover:bg-port-border/50'
-              }`}
-            >
-              <Icon size={16} />
-              {label}
-            </button>
-          ))}
-        </div>
-      </div>
+      <TabPills
+        tabs={TABS}
+        activeTab={activeTab}
+        onChange={handleTabChange}
+        ariaLabel="MeatSpace sections"
+        className="print:hidden"
+      />
 
       {/* Tab content */}
       <div className="flex-1 overflow-auto p-6 print:overflow-visible print:p-0">

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -1,4 +1,6 @@
 import { useParams, Navigate } from 'react-router-dom';
+import { Settings as SettingsIcon } from 'lucide-react';
+import PageHeader from '../components/PageHeader';
 import { ApiAccessTab } from '../components/settings/ApiAccessTab';
 import { AutofixerTab } from '../components/settings/AutofixerTab';
 import AiAssignmentsTab from '../components/settings/AiAssignmentsTab';
@@ -52,9 +54,7 @@ export default function Settings() {
 
   return (
     <div className="flex flex-col h-full min-w-0 overflow-hidden">
-      <div className="flex items-center gap-3 p-4 border-b border-port-border shrink-0">
-        <h1 className="text-2xl font-bold text-white">Settings</h1>
-      </div>
+      <PageHeader icon={SettingsIcon} title="Settings" />
 
       <SettingsTabsHeader activeTab={activeTab} />
 


### PR DESCRIPTION
## Summary

Closes #1182.

Brain, MeatSpace, Settings, Goals, Calendar, and Insights each hand-rolled their title bar with different padding (`px-3 py-2 sm:p-4` vs `px-6 pt-6 pb-4` vs `p-4` vs `px-4 sm:px-6 py-3 sm:py-4`) and title scales (`text-lg` through `text-2xl`), so navigating between sections jittered the header.

- New `client/src/components/PageHeader.jsx` — one standardized bar (`px-3 py-2 sm:px-4 sm:py-3 border-b border-port-border`, `text-lg sm:text-xl font-bold` title) with `icon` / `iconColor` / `subtitle` / `actions` / `className` slots. Compact padding keeps actionable content above the fold.
- Adopted in all six pages. Settings gains a gear icon to match its siblings.
- MeatSpace, Insights, and Goals were also rendering hand-rolled tab strips with three different active-tab styles; they now use the shared `TabPills` primitive (already used by Brain/Calendar/ChiefOfStaff), so every page matches and gains its `role="tablist"`/`role="tab"` semantics and 44px mobile tap targets.
- ChiefOfStaff is intentionally **excluded**: its header is a bespoke gradient avatar panel in a sidebar layout (`border-indigo-500/20`, gradient-text h1s, 3D/SVG/ASCII avatar canvas), not a plain title bar — folding it into PageHeader would pollute the API with props no other page wants.

Follow-up adoption candidates (Messages, Wiki, FeatureAgents, CreativeDirector) tracked in #1207.

## Test plan

- `client/src/components/PageHeader.test.jsx` — new unit test covering title/icon/subtitle/actions slots, default vs custom icon color, padding/border invariants, and `className` merge.
- `npm test` in `client/` — full suite green (206 files, 2190 tests).
- `npm run build` in `client/` — production build compiles.
- ESLint clean on all touched files.
