### PR TITLE
feat([issue-1174]): flow Brain Config cards into a responsive multi-column grid

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -38,6 +38,8 @@
 
 ## Changed
 
+- **[issue-1174] Brain Config settings use the full width on desktop** — the Brain → Config tab no longer crams its four settings cards (AI Provider, Classification, Schedule, Schedule Summary) into a narrow centered column; on wide screens they now flow into two or three columns so everything fits without scrolling, while still stacking into a single column on mobile.
+
 - **[issue-1182] Unified tabbed-page headers behind a shared `PageHeader`** — Brain, MeatSpace, Settings, Goals, Calendar, and Insights each hand-rolled their title bar with different padding and title scales (`px-3 py-2 sm:p-4` vs `px-6 pt-6 pb-4` vs `p-4` vs `px-4 sm:px-6 py-3 sm:py-4`, `text-lg` through `text-2xl`), so moving between sections jittered the header. They now share `client/src/components/PageHeader.jsx` — compact `px-3 py-2 sm:px-4 sm:py-3 border-b border-port-border` padding and a `text-lg sm:text-xl font-bold` title, with `icon`/`subtitle`/`actions` slots. The three pages that hand-rolled their own tab strips (MeatSpace, Insights, Goals) now render the shared `TabPills` instead, so all six pages share one active-tab style and gain its tablist/tab a11y roles and 44px mobile tap targets. Settings gains a gear icon to match its siblings; ChiefOfStaff keeps its bespoke gradient avatar panel (it isn't a plain title bar). (`client/src/components/PageHeader.jsx`, `client/src/pages/{Brain,MeatSpace,Settings,Goals,Calendar,Insights}.jsx`)
 
 - **[issue-1200] Stabilized a flaky federation test** — the peer-sync unsubscribe race test now asserts the timing-independent invariants instead of one specific interleaving, so CI stops failing intermittently on it. No behavior change.

--- a/client/src/components/brain/tabs/ConfigTab.jsx
+++ b/client/src/components/brain/tabs/ConfigTab.jsx
@@ -113,7 +113,7 @@ export default function ConfigTab({ onRefresh }) {
   }
 
   return (
-    <div className="space-y-6 max-w-2xl mx-auto">
+    <div className="space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
@@ -141,6 +141,8 @@ export default function ConfigTab({ onRefresh }) {
         )}
       </div>
 
+      {/* Settings cards flow into columns on lg/xl, stack on mobile */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 items-start">
       {/* AI Provider & Model Section */}
       <section className="p-4 bg-port-card border border-port-border rounded-lg space-y-4">
         <div className="flex items-center gap-2 mb-4">
@@ -344,6 +346,7 @@ export default function ConfigTab({ onRefresh }) {
           </div>
         </section>
       )}
+      </div>
 
       {/* Save button at bottom for mobile */}
       {hasChanges() && (


### PR DESCRIPTION
## Summary

Brain → Config (`client/src/components/brain/tabs/ConfigTab.jsx`) wrapped its four settings cards (AI Provider, Classification, Schedule, Schedule Summary) in `max-w-2xl mx-auto` — ~672px on a 1440px+ screen, forcing scroll for content that fits one screen.

Replaced the root `max-w-2xl mx-auto` with a `grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 items-start` wrapper around the four cards. Cards flow into 2 columns on `lg` and 3 on `xl`, and stack into a single column on mobile. The header and bottom mobile save button stay full-width outside the grid. Each card's internal layout is unchanged.

Closes #1174

## Test plan

- CSS-only layout change (one wrapper div + one className swap); no logic, state, or data flow touched.
- Verified JSX structure is balanced (grid opens after the header, closes before the bottom save button).
- Visual check at 1280 / 1440 / 1920 and mobile widths: cards tile across columns on desktop, stack on mobile.