### PR TITLE
feat([issue-1180]): tile Loops, Songs, Templates, CapabilityMap index pages on desktop

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -48,6 +48,8 @@
 
 ## Changed
 
+- **[issue-1180] Loops, Songs, Templates, and Capabilities tile across the desktop** — these four list pages no longer render a narrow centered single column that wastes desktop width and pushes items below the fold. On wider screens loops, songs, app templates, and capability rows now flow into multi-column grids so far more is visible at a glance; on phones they stack into a single column as before.
+
 - **[issue-1175] Brain Digest shows Daily and Weekly side-by-side on wide screens** — the Brain → Digest tab no longer stacks the Daily Digest above the Weekly Review in a narrow centered column; on large screens they now sit in two columns so both are visible at once, while still stacking into a single column on smaller screens.
 
 - **[issue-1174] Brain Config settings use the full width on desktop** — the Brain → Config tab no longer crams its four settings cards (AI Provider, Classification, Schedule, Schedule Summary) into a narrow centered column; on wide screens they now flow into two or three columns so everything fits without scrolling, while still stacking into a single column on mobile.

--- a/client/src/pages/CapabilityMap.jsx
+++ b/client/src/pages/CapabilityMap.jsx
@@ -68,7 +68,7 @@ export default function CapabilityMap() {
   const OverallIcon = overallStyle.icon;
 
   return (
-    <div className="max-w-3xl mx-auto space-y-4">
+    <div className="space-y-4">
       <div className="flex items-center justify-between gap-3 flex-wrap">
         <h2 className="text-xl font-bold text-white flex items-center gap-2">
           <LayoutGrid size={20} />
@@ -92,7 +92,7 @@ export default function CapabilityMap() {
         <span className="flex items-center gap-1"><Circle size={12} className="text-gray-500" /> {summary.unconfigured} not set up</span>
       </div>
 
-      <div className="space-y-2">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-2">
         {caps.map((cap) => (
           <CapabilityRow key={cap.id} cap={cap} />
         ))}

--- a/client/src/pages/Loops.jsx
+++ b/client/src/pages/Loops.jsx
@@ -377,7 +377,7 @@ export default function Loops() {
   const runningCount = loops.filter(l => l.isRunning).length;
 
   return (
-    <div className="max-w-4xl mx-auto space-y-4">
+    <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-xl font-bold text-gray-100 flex items-center gap-2">
@@ -408,7 +408,7 @@ export default function Loops() {
           <p className="text-sm">No loops yet. Create one above to get started.</p>
         </div>
       ) : (
-        <div className="space-y-2">
+        <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 items-start">
           {loops.map(loop => (
             <LoopCard
               key={loop.id}

--- a/client/src/pages/Songs.jsx
+++ b/client/src/pages/Songs.jsx
@@ -74,7 +74,7 @@ export default function Songs() {
   }, [armed]);
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <div>
       <div className="flex items-center justify-between gap-3 mb-2">
         <div className="flex items-center gap-3">
           <Music className="w-6 h-6 text-port-accent" />
@@ -148,7 +148,7 @@ export default function Songs() {
       ) : songs.length === 0 ? (
         <p className="text-sm text-gray-500">No songs yet — write your first above.</p>
       ) : (
-        <ul className="space-y-2">
+        <ul className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3">
           {songs.map((song) => {
             const shape = shapeLabel(song.rhythmShapeId);
             const layerCount = song.layers?.length || 0;

--- a/client/src/pages/Templates.jsx
+++ b/client/src/pages/Templates.jsx
@@ -74,7 +74,7 @@ export default function Templates() {
   }
 
   return (
-    <div className="max-w-4xl mx-auto">
+    <div>
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-6">
         <div>
           <h1 className="text-2xl font-bold text-white">App Templates</h1>
@@ -89,7 +89,7 @@ export default function Templates() {
       </div>
 
       {createMode && selectedTemplate ? (
-        <div className="bg-port-card border border-port-border rounded-xl p-6">
+        <div className="bg-port-card border border-port-border rounded-xl p-6 max-w-2xl">
           <div className="flex items-center gap-3 mb-6">
             {(() => {
               const Icon = ICONS[selectedTemplate.icon] || Layers;
@@ -157,7 +157,7 @@ export default function Templates() {
           </form>
         </div>
       ) : (
-        <div className="grid gap-4 grid-cols-1 md:grid-cols-2">
+        <div className="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3">
           {templates.map(template => {
             const Icon = ICONS[template.icon] || Layers;
             return (


### PR DESCRIPTION
## Summary

Reflows four index pages that rendered a narrow centered single column — wasting desktop width and pushing items below the fold — into full-width responsive grids. Closes #1180.

- **Loops** (`Loops.jsx`) — dropped `max-w-4xl mx-auto`; loop cards now `grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-4 items-start`. `items-start` keeps rows top-aligned so an expanded card (inline live-output panel) doesn't stretch its row neighbours.
- **Songs** (`Songs.jsx`) — dropped `max-w-4xl mx-auto`; song list `<ul>` now `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3`. The create form above keeps its existing responsive layout.
- **Templates** (`Templates.jsx`) — dropped `max-w-4xl mx-auto`; card grid widened to `md:grid-cols-2 xl:grid-cols-3`. The per-template create form is capped at `max-w-2xl` so it doesn't stretch awkwardly across a wide viewport.
- **CapabilityMap** (`CapabilityMap.jsx`) — dropped `max-w-3xl mx-auto`; capability rows now `grid grid-cols-1 lg:grid-cols-2 gap-2`. The summary header/status legend stays full-width above the grid.

All four collapse to a single column on mobile (the `grid-cols-1` base).

### Deviation from the issue's Templates suggestion

The issue suggested "consider `grid-cols-[1fr_360px]` so the create form sits beside the list on lg+" for Templates. That side-by-side shape doesn't fit this page: the create form is **not** a persistent sidebar — selecting a template swaps the entire card grid *out* and renders the config form in its place (`createMode` toggle). There's never a list and a form on screen at the same time, so a two-column split has nothing to pair. Instead I widened the card grid and capped the form width, which achieves the issue's actual goal (use the width, don't strand a narrow column) without forcing an unnatural layout. The other three pages follow the issue's grid specs verbatim.

## Test plan

- `eslint` on all four changed pages — clean.
- `npm run build` — passes.
- `vitest run src/pages` — 115/115 pass.
- Layout routes confirmed to stay out of the `isFullWidth` list in `Layout.jsx`, so the padded+scrolling `<main>` continues to scroll these index pages correctly.
