### PR TITLE
fix([issue-1183]): tile Review Hub, de-pad System Health, unclip SongEditor TikTok embed

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -18,6 +18,8 @@
 
 ## Fixed
 
+- **[issue-1183] Review Hub, System Health, and song video embeds lay out better** — the Review Hub now spreads its alert/CoS/todo/briefing sections across two columns on wide screens instead of one tall stack; the System Health page no longer carries an extra band of padding on larger screens; and a TikTok reference video in the song editor now scales to fit instead of getting clipped on shorter windows.
+
 - **[issue-1176] Brain Notes uses the full screen instead of a tall scroll** — the Notes tab now lays the vault/folder list and the note content out side-by-side and fills the available height, so browsing and reading a note no longer means scrolling past a stack of panels. On phones the list and the open note swap places — tapping a note shows it full-width with a back arrow to return to the list — instead of squeezing both into a narrow column.
 
 - **Multi-reference FLUX.2 renders no longer crash on `guidance_scale`** — generating with reference images on a FLUX.2-klein model loads the guidance-distilled `Flux2KleinKVPipeline`, whose `__call__()` doesn't accept `guidance_scale`. The runner passed it unconditionally in the base kwargs (only the optional kwargs were signature-filtered), so every multi-reference render died with `TypeError: …got an unexpected keyword argument 'guidance_scale'`. `guidance_scale` is now gated on the live pipeline signature like `negative_prompt`/`strength`/`image`. The same run also silently dropped its LoRA — `set_adapters` raised `'tuple' / int` because `zip(*loaded)` hands diffusers tuples where it does arithmetic over the weights; the adapter names/scales are now passed as lists. (`scripts/flux2_macos.py`, `scripts/lora_utils.py`)

--- a/client/src/pages/Review.jsx
+++ b/client/src/pages/Review.jsx
@@ -270,7 +270,7 @@ export default function Review() {
 
   return (
     <div className="h-full overflow-auto p-4 md:p-6">
-      <div className="max-w-6xl mx-auto space-y-3">
+      <div className="space-y-3">
         {/* Header */}
         <div className="flex flex-col lg:flex-row lg:items-center justify-between gap-3">
           <h2 className="text-xl font-bold text-white flex items-center gap-2">
@@ -440,7 +440,9 @@ export default function Review() {
           </section>
         )}
 
-        {/* Detailed sections */}
+        {/* Detailed sections — tiled two-up on wide screens so the per-type
+            queues use the full width instead of stacking in one column. */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-3 items-start">
         {['alert', 'cos', 'todo', 'briefing'].map(type => {
           const typeItems = grouped[type];
           if (!typeItems?.length) return null;
@@ -474,6 +476,7 @@ export default function Review() {
             </section>
           );
         })}
+        </div>
 
         {items.length === 0 && (
           <div className="text-center py-12 text-gray-500">

--- a/client/src/pages/SongEditor.jsx
+++ b/client/src/pages/SongEditor.jsx
@@ -1117,11 +1117,11 @@ function ReferenceCard({ reference }) {
   const safeHref = isHttpUrl(reference.url);
   if (ttId) {
     return (
-      <div className="w-full sm:w-80 lg:w-96 space-y-2">
+      <div className="w-full sm:w-80 lg:w-96 max-w-[45vh] space-y-2">
         <iframe
           title={title}
           src={tiktokEmbedSrc(ttId)}
-          className="w-full aspect-[9/16] max-h-[80vh] rounded-lg border border-port-border bg-port-card"
+          className="w-full aspect-[9/16] rounded-lg border border-port-border bg-port-card"
           loading="lazy"
           allow="encrypted-media; fullscreen"
           referrerPolicy="strict-origin-when-cross-origin"

--- a/client/src/pages/SongEditor.jsx
+++ b/client/src/pages/SongEditor.jsx
@@ -1117,11 +1117,11 @@ function ReferenceCard({ reference }) {
   const safeHref = isHttpUrl(reference.url);
   if (ttId) {
     return (
-      <div className="w-full sm:w-[325px] space-y-2">
+      <div className="w-full sm:w-80 lg:w-96 space-y-2">
         <iframe
           title={title}
           src={tiktokEmbedSrc(ttId)}
-          className="w-full h-[575px] rounded-lg border border-port-border bg-port-card"
+          className="w-full aspect-[9/16] max-h-[80vh] rounded-lg border border-port-border bg-port-card"
           loading="lazy"
           allow="encrypted-media; fullscreen"
           referrerPolicy="strict-origin-when-cross-origin"
@@ -1144,7 +1144,7 @@ function ReferenceCard({ reference }) {
   return (
     <Wrapper
       {...wrapperProps}
-      className={`w-full sm:w-[325px] bg-port-card border border-port-border rounded-lg p-4 ${safeHref ? 'hover:border-port-accent/50 transition-colors' : ''}`}
+      className={`w-full sm:w-80 lg:w-96 bg-port-card border border-port-border rounded-lg p-4 ${safeHref ? 'hover:border-port-accent/50 transition-colors' : ''}`}
     >
       <div className="flex items-center gap-2 text-white">
         <ExternalLink size={15} className="text-port-accent shrink-0" />

--- a/client/src/pages/SystemHealthPage.jsx
+++ b/client/src/pages/SystemHealthPage.jsx
@@ -91,8 +91,7 @@ export default function SystemHealthPage() {
       draft.diskCritical !== t.diskCritical);
 
   return (
-    <div className="h-full overflow-auto p-4 md:p-6">
-      <div className="max-w-5xl mx-auto space-y-4">
+    <div className="max-w-5xl mx-auto space-y-4">
         <div className="flex items-center justify-between gap-3">
           <h2 className="text-xl font-bold text-white flex items-center gap-2">
             <ServerCog size={20} />
@@ -205,7 +204,6 @@ export default function SystemHealthPage() {
             </button>
           </div>
         </section>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Ships **3 of the 6** "Misc layout fixes" from the #1183 umbrella. Two need a design decision (split to a follow-up issue), one was already fixed.

Refs #1183 (partial — leaving the umbrella open for the two deferred items).

### Shipped here

- **Review Hub** (`Review.jsx:272`) — dropped `max-w-6xl` and tiled the per-type detail sections (alert / CoS / todo / briefing) into `grid grid-cols-1 lg:grid-cols-2 gap-3 items-start` instead of one tall stack. The page is in `isFullWidth` and already owns a single `overflow-auto` scroller, so the "single scroll owner" ask was already satisfied — kept it.
- **System Health** (`SystemHealthPage.jsx:94`) — the page is **not** in Layout's `isFullWidth` list, yet it added its own `h-full overflow-auto p-4 md:p-6` wrapper → doubled padding on `md+`. Removed the page wrapper so the Layout `<main>` scrolls and pads it once.
- **SongEditor TikTok embed** (`SongEditor.jsx:1120`) — a fixed `sm:w-[325px]` + `h-[575px]` iframe clipped on short viewports. Switched to `sm:w-80 lg:w-96` width and `aspect-[9/16] max-h-[80vh]` so the portrait video scales to fit instead of being cut off; matched the sibling link-card's width for consistency.

### Already fixed (no change needed)

- **DataManager** (`DataManager.jsx:230`) — the `min-w-[480px]` backup-archives table is **already** wrapped in `overflow-x-auto` (line 229), so mobile already scrolls it horizontally. Nothing to do.

### Deferred to #1221 (need design, not a CSS reflow)

- **CreateApp** (`CreateApp.jsx:245`) — the suggested "template preview in the rail" doesn't map: CreateApp is the import *wizard* (path → detect → config), not a template page (templates live on `/templates`), so there's no preview to rail. Needs a layout decision for a linear form.
- **Brain ImportTab** (`ImportTab.jsx:198`) — `StepPreview` and `StepConfigure` are **separate `Stepper` steps** shown one at a time; "show both at once" means merging two wizard steps (a flow/behavior change), not a grid wrapper.

Both are written up with full context in #1221.

## Test plan

- `eslint` on the three changed files — clean.
- `npm run build` — passes.
- `vitest run src/pages` — 115/115 pass.
- The Review.jsx grid wrapper opens/closes around the existing `.map()` (verified balanced); SystemHealthPage drops exactly one wrapper `<div>` and its matching close.
