### PR TITLE
refactor: dedup execGit overflow guard, name aiProvider timeout constants

### DIFF
--- a/server/lib/aiProvider.js
+++ b/server/lib/aiProvider.js
@@ -10,6 +10,14 @@ import { readResponseJson } from './readResponseJson.js';
 
 const isAPI = (p) => p && p.type === 'api' && p.enabled !== false;
 
+// LM Studio auto-recovery timeouts. Listing downloaded models is a quick local
+// HTTP call; loading a model into VRAM can take a while on a cold start.
+const LM_STUDIO_LIST_TIMEOUT_MS = 5000;
+const LM_STUDIO_LOAD_TIMEOUT_MS = 120000;
+// Default chat-completion timeout when a provider doesn't set its own. Generous
+// because local models on modest hardware can be slow to first token.
+const DEFAULT_PROVIDER_TIMEOUT_MS = 300000;
+
 /**
  * Resolve an API-type provider for features that can only run against an API
  * endpoint (CLI providers don't support the simple chat-completions call path).
@@ -66,7 +74,7 @@ async function ensureLMStudioModelLoaded(provider, statusOp) {
   if (!baseUrl) return null;
 
   const listCtl = new AbortController();
-  const listTimer = setTimeout(() => listCtl.abort(), 5000);
+  const listTimer = setTimeout(() => listCtl.abort(), LM_STUDIO_LIST_TIMEOUT_MS);
   const listResp = await fetch(`${baseUrl}/api/v0/models`, {
     method: 'GET',
     signal: listCtl.signal
@@ -97,7 +105,7 @@ async function ensureLMStudioModelLoaded(provider, statusOp) {
 
   const loadStart = Date.now();
   const loadCtl = new AbortController();
-  const loadTimer = setTimeout(() => loadCtl.abort(), 120000);
+  const loadTimer = setTimeout(() => loadCtl.abort(), LM_STUDIO_LOAD_TIMEOUT_MS);
   const loadResp = await fetch(`${baseUrl}/api/v1/models/load`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -187,7 +195,7 @@ export async function callProviderAISimple(provider, model, prompt, options = {}
   if (provider.type !== 'api') {
     return { error: 'This operation requires an API-based provider' };
   }
-  const opts = { temperature, max_tokens, timeout: provider.timeout || 300000 };
+  const opts = { temperature, max_tokens, timeout: provider.timeout || DEFAULT_PROVIDER_TIMEOUT_MS };
 
   // Always emit status events (server logs + UI toasts) for AI calls. Callers
   // can pass `op` to give the toast a meaningful label; otherwise it's labeled

--- a/server/lib/execGit.js
+++ b/server/lib/execGit.js
@@ -40,24 +40,25 @@ export function execGit(args, cwd, options = {}) {
       }
     }, timeout);
 
-    child.stdout.on('data', (data) => {
-      stdout += data.toString();
+    // Both streams share one overflow guard against the combined byte count so
+    // a runaway command can't blow past maxBuffer on either channel.
+    const guardOverflow = () => {
       if (stdout.length + stderr.length > maxBuffer && !killed) {
         killed = true;
         clearTimeout(timer);
         child.kill();
         reject(new Error(`git output exceeded maxBuffer (${maxBuffer} bytes)`));
       }
+    };
+
+    child.stdout.on('data', (data) => {
+      stdout += data.toString();
+      guardOverflow();
     });
 
     child.stderr.on('data', (data) => {
       stderr += data.toString();
-      if (stdout.length + stderr.length > maxBuffer && !killed) {
-        killed = true;
-        clearTimeout(timer);
-        child.kill();
-        reject(new Error(`git output exceeded maxBuffer (${maxBuffer} bytes)`));
-      }
+      guardOverflow();
     });
 
     child.on('close', (code) => {


### PR DESCRIPTION
## Summary

Code-quality pass over two `server/lib` modules. Pure refactors — no behavior change.

- **`execGit.js`** — The stdout and stderr `data` handlers carried byte-identical buffer-overflow logic (combined-length check → kill → reject). Extracted to a single `guardOverflow()` closure so the two channels can't drift. The combined-byte-count semantics and error message are unchanged.
- **`aiProvider.js`** — Replaced three inline timeout literals with named constants (`LM_STUDIO_LIST_TIMEOUT_MS = 5000`, `LM_STUDIO_LOAD_TIMEOUT_MS = 120000`, `DEFAULT_PROVIDER_TIMEOUT_MS = 300000`) with comments explaining each. The `provider.timeout || …` fallback is preserved.

## Scope notes

The two `300000ms` defaults in `aiProvider.js` and `cliProviderRun.js` were left as separate module-local constants rather than coupled to a shared export — they are independent defaults documented per-module, and a shared constant would create artificial coupling between the lightweight CLI path and the API chat path.

Client-side `console.warn` catch-handlers were intentionally left untouched: the emoji-prefix logging convention is a server rule, so reformatting them would be cosmetic churn.

## Testing

`npx vitest run lib/execGit.test.js lib/aiProvider.test.js lib/index.test.js` — 25/25 pass.