### PR TITLE
claim-issue: resolve {reviewers} from Code Review Defaults, not hardcoded copilot

### DIFF
--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -22,7 +22,7 @@
 import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { sanitizeTaskMetadata, PIPELINE_BEHAVIOR_FLAGS, MAX_TOTAL_SPAWNS, normalizeReviewers } from '../lib/validation.js';
+import { sanitizeTaskMetadata, PIPELINE_BEHAVIOR_FLAGS, MAX_TOTAL_SPAWNS, normalizeReviewers, LOCAL_LLM_REVIEWERS, DEFAULT_REVIEWERS } from '../lib/validation.js';
 import { parsePlanItems, extractAllIds, findInProgressIds, pickFirstAvailable, diagnoseUnpickablePlan } from '../lib/planIds.js';
 import { loadState, saveState, withStateLock, isImprovementEnabled, isDaemonRunning } from './cosState.js';
 import { getDomainMode } from '../lib/domainAutonomy.js';
@@ -1392,7 +1392,16 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
   // user's configured reviewers. Settings I/O failures degrade to the hardcoded
   // default inside normalizeReviewers, so a read error never blocks dispatch.
   const codeReviewDefaults = await getCodeReviewDefaults().catch(() => null);
-  const reviewersCsv = normalizeReviewers(metadata, codeReviewDefaults?.reviewers).join(',');
+  // Drop local-LLM reviewers (lmstudio/ollama) from the prompt's {reviewers}
+  // token: the claim/plan prompt templates only document how to drive copilot
+  // and the CLI reviewers (claude/codex/antigravity). Unlike the system
+  // review-loop follow-up prompt (agentPromptBuilder.js), they carry no
+  // local-endpoint invocation instructions, so naming a local-LLM reviewer
+  // here would stall the agent's review step. Fall through to the hardcoded
+  // copilot default when filtering empties the list.
+  const promptReviewers = normalizeReviewers(metadata, codeReviewDefaults?.reviewers)
+    .filter((r) => !LOCAL_LLM_REVIEWERS.includes(r));
+  const reviewersCsv = (promptReviewers.length ? promptReviewers : [...DEFAULT_REVIEWERS]).join(',');
   // claim-issue: expand {issueAuthorFilter} into a concrete directive telling
   // the agent which open issues are claimable. The filter was already merged
   // (global → per-app override) and value-constrained by sanitizeTaskMetadata,

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -36,6 +36,7 @@ import { getActiveApps, getAppTaskTypeOverrides } from './apps.js';
 import { getTaskTypeConfidence } from './taskLearning.js';
 import { generateProactiveTasks as generateMissionTasks } from './missions.js';
 import { isRecoveryTask } from './recoveryTasks.js';
+import { getCodeReviewDefaults } from './codeReview.js';
 
 /**
  * Block a task that has exceeded the max spawn limit. Returns true if blocked.
@@ -1383,7 +1384,15 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
     return null;
   }
   const planConstraintBlock = buildPlanConstraintBlock(metadata.planId);
-  const reviewersCsv = normalizeReviewers(metadata).join(',');
+  // Resolve the `{reviewers}` the agent is told to run. When the task itself
+  // didn't pin reviewers, fall back to the user's PortOS Code Review Defaults
+  // (AI Providers → Code Review Defaults) rather than the hardcoded `copilot` —
+  // otherwise scheduled tasks like claim-issue, whose prompt drives the review
+  // loop directly, would always tell the agent to use Copilot regardless of the
+  // user's configured reviewers. Settings I/O failures degrade to the hardcoded
+  // default inside normalizeReviewers, so a read error never blocks dispatch.
+  const codeReviewDefaults = await getCodeReviewDefaults().catch(() => null);
+  const reviewersCsv = normalizeReviewers(metadata, codeReviewDefaults?.reviewers).join(',');
   // claim-issue: expand {issueAuthorFilter} into a concrete directive telling
   // the agent which open issues are claimable. The filter was already merged
   // (global → per-app override) and value-constrained by sanitizeTaskMetadata,

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -62,12 +62,19 @@ describe('dry-run hook wiring matches each engine execute path', () => {
 describe('{reviewers} interpolation honors Code Review Defaults', () => {
   it('resolves getCodeReviewDefaults and passes them as the normalizeReviewers fallback', () => {
     expect(GEN_SRC).toContain("import { getCodeReviewDefaults } from './codeReview.js'");
-    const start = GEN_SRC.indexOf('const reviewersCsv =');
-    expect(start, 'reviewersCsv must be assigned').toBeGreaterThan(-1);
-    const line = GEN_SRC.slice(start, GEN_SRC.indexOf('\n', start));
-    expect(line).toContain('normalizeReviewers(metadata, codeReviewDefaults?.reviewers)');
-    // The bare two-arg-less form is the bug we are guarding against.
-    expect(line).not.toMatch(/normalizeReviewers\(metadata\)/);
+    expect(GEN_SRC).toContain('normalizeReviewers(metadata, codeReviewDefaults?.reviewers)');
+    // The bare two-arg-less form (which silently reverts to hardcoded copilot)
+    // is the bug we are guarding against. `(?!,)` lets the legitimate two-arg
+    // call through while still catching a regression to `normalizeReviewers(metadata)`.
+    expect(GEN_SRC).not.toMatch(/normalizeReviewers\(metadata\)(?!,)/);
+  });
+
+  it('filters local-LLM reviewers out of the prompt token (no invocation instructions in claim/plan prompts)', () => {
+    // lmstudio/ollama defaults must not reach {reviewers}: the claim/plan
+    // prompts can't drive them, so the loop would stall. The filter falls
+    // through to the hardcoded copilot default when it empties the list.
+    expect(GEN_SRC).toContain('.filter((r) => !LOCAL_LLM_REVIEWERS.includes(r))');
+    expect(GEN_SRC).toContain('promptReviewers.length ? promptReviewers : [...DEFAULT_REVIEWERS]');
   });
 });
 

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -53,6 +53,24 @@ describe('dry-run hook wiring matches each engine execute path', () => {
   });
 });
 
+// The `{reviewers}` prompt token is what tasks like claim-issue use to tell the
+// agent which reviewers to run (the prompt drives the review loop directly, so
+// this IS the operative reviewer list, not just display). It must fall back to
+// the user's PortOS Code Review Defaults when the task didn't pin reviewers —
+// not the bare `normalizeReviewers(metadata)` call, which silently reverts to
+// hardcoded copilot. This guard pins the wiring against that regression.
+describe('{reviewers} interpolation honors Code Review Defaults', () => {
+  it('resolves getCodeReviewDefaults and passes them as the normalizeReviewers fallback', () => {
+    expect(GEN_SRC).toContain("import { getCodeReviewDefaults } from './codeReview.js'");
+    const start = GEN_SRC.indexOf('const reviewersCsv =');
+    expect(start, 'reviewersCsv must be assigned').toBeGreaterThan(-1);
+    const line = GEN_SRC.slice(start, GEN_SRC.indexOf('\n', start));
+    expect(line).toContain('normalizeReviewers(metadata, codeReviewDefaults?.reviewers)');
+    // The bare two-arg-less form is the bug we are guarding against.
+    expect(line).not.toMatch(/normalizeReviewers\(metadata\)/);
+  });
+});
+
 describe('exceedsMaxSpawns', () => {
   it('is false below the ceiling and true at/above it — no mutation', () => {
     expect(exceedsMaxSpawns(task('a', { totalSpawnCount: 0 }))).toBe(false);


### PR DESCRIPTION
## Summary

The `claim-issue` scheduled task (and other CoS managed-app tasks) interpolated its `{reviewers}` prompt token via `normalizeReviewers(metadata)` in `cosTaskGenerator.js` with **no fallback argument**. When a task didn't pin its own reviewers, `normalizeReviewers` reverted to its hardcoded `['copilot']` default — so the agent was always told to use Copilot, ignoring the user's configured PortOS **Code Review Defaults** (AI Providers → Code Review Defaults).

For `claim-issue` this is the operative reviewer list, not just display: the prompt's Phase 6 drives the review loop directly (the task runs with `openPR: false`, so it does not go through the system review-loop follow-up that *does* resolve defaults via `resolveReviewLoopOptions`).

The fix resolves the user's Code Review Defaults and passes `codeReviewDefaults?.reviewers` as the `normalizeReviewers` fallback — exactly what `normalizeReviewers`' own docstring instructs callers to do. Settings I/O failures degrade to the hardcoded default inside `normalizeReviewers`, so a read error never blocks task dispatch. The prompt template itself was already reviewer-agnostic (`{reviewers}` with per-kind handling), so no `PROMPT_VERSIONS` bump or migration is needed.

## Test plan

- Added a source-level regression guard in `cosTaskGenerator.test.js` pinning that `{reviewers}` is resolved with `getCodeReviewDefaults()` fed into `normalizeReviewers`, and that the bare `normalizeReviewers(metadata)` form does not return.
- `npx vitest run services/cosTaskGenerator.test.js services/codeReview.test.js lib/validation.test.js` → 139 passed.
- Verified `cosTaskGenerator.js` imports cleanly (no circular dependency with `codeReview.js`).