### PR TITLE
Share the --user-loras parser between the two video LoRA runners

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -6,6 +6,8 @@
 
 ## Changed
 
+- **Share the `--user-loras` JSON parser between the two video LoRA runners.** `parse_user_loras` (the strict `[{path, strength}]` validator that surfaces a Node-side bug before any model load) was duplicated verbatim in `scripts/generate_ltx2.py` (dgrauet `ltx2` runtime) and `scripts/generate_av_lora.py` (mlx_video runtime); it now lives once in `scripts/_runner_common.py` (stdlib-only at import, so it's safe to import from either MLX venv — verified in both) and both runners import it, so a future fix to the validation contract can't drift between them. (`scripts/_runner_common.py`, `scripts/generate_ltx2.py`, `scripts/generate_av_lora.py`)
+
 - **Retire the repo-local `/claim`, `/gitup`, and `/work` slash commands in favor of slashdo.** The custom 46 KB `.claude/commands/claim.md` procedure (and its `.agents/skills/claim/SKILL.md` adapter) is replaced by slashdo's `/do:next`, which runs the same claim-an-item-in-a-worktree-and-ship-a-PR flow; `/gitup` and `/work` are dropped in favor of `/do:push` and slashdo's worktree workflow. The slashdo submodule is bumped v3.5.0 → v3.9.0 so `/do:next` ships from the module itself (symlinked into `.claude/commands/do/next.md` like the other `/do:*` commands) instead of relying on a separate global install. The CoS `plan-task` / `claim-issue` scheduled agents are unaffected — they carry their own self-contained prompts and never loaded the deleted command file.
 
 ## Fixed

--- a/scripts/_runner_common.py
+++ b/scripts/_runner_common.py
@@ -63,6 +63,42 @@ def heartbeat(stage: str, interval: float = 20.0):
         t.join(timeout=interval + 1)
 
 
+def parse_user_loras(raw: "str | None") -> "list[tuple[str, float]]":
+    """Parse a `--user-loras` JSON string into a list of (path, strength) tuples.
+
+    Shared by the video LoRA runners (scripts/generate_ltx2.py for the dgrauet
+    ltx2 runtime, scripts/generate_av_lora.py for the mlx_video runtime) so the
+    strict-validation contract that protects against a Node-side bug lives in one
+    place. Each entry must be {path: str (existing file), strength: number}.
+    Returns [] when the arg is unset. Raises SystemExit with a precise message on
+    any malformed input so the failure surfaces before any model load / GPU work.
+    """
+    if not raw:
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise SystemExit(f"--user-loras is not valid JSON: {e}")
+    if not isinstance(data, list):
+        raise SystemExit("--user-loras must be a JSON list of {path, strength}")
+    specs: "list[tuple[str, float]]" = []
+    for i, item in enumerate(data):
+        if not isinstance(item, dict) or "path" not in item:
+            raise SystemExit(f"user-loras[{i}] must be an object with 'path'")
+        path = item["path"]
+        if not isinstance(path, str) or not path:
+            raise SystemExit(f"user-loras[{i}].path must be a non-empty string")
+        if not Path(path).exists():
+            raise SystemExit(f"user-loras[{i}].path does not exist: {path}")
+        strength = item.get("strength", 1.0)
+        try:
+            strength = float(strength)
+        except (TypeError, ValueError):
+            raise SystemExit(f"user-loras[{i}].strength must be a number")
+        specs.append((path, strength))
+    return specs
+
+
 class _ClipTruncationFilter(logging.Filter):
     _MARKER = "input was truncated because CLIP can only handle"
 

--- a/scripts/generate_av_lora.py
+++ b/scripts/generate_av_lora.py
@@ -30,47 +30,21 @@ a separate BYOV venv.
 from __future__ import annotations
 
 import argparse
-import json
 import sys
 from pathlib import Path
+
+# Sibling import: parse_user_loras is shared with generate_ltx2.py so the
+# strict --user-loras validation contract lives in one place. sys.path[0] is
+# already this dir when run as `python /abs/scripts/generate_av_lora.py`, but
+# insert defensively (mirrors generate_hunyuan.py). _runner_common is
+# stdlib-only at import time, so this is safe from the MLX venv.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _runner_common import parse_user_loras  # noqa: E402
 
 
 def emit_status(msg: str) -> None:
     """STATUS: line — routed to PortOS SSE as `status` (mirrors generate_ltx2.py)."""
     print(f"STATUS:{msg}", file=sys.stderr, flush=True)
-
-
-def _parse_user_loras(raw: str | None) -> list[tuple[str, float]]:
-    """Parse --user-loras JSON into a list of (path, strength) tuples.
-
-    Strict validation so a Node-side bug surfaces here before any model load.
-    Each entry must be {path: str (existing file), strength: number}. Returns []
-    when --user-loras is unset.
-    """
-    if not raw:
-        return []
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as e:
-        raise SystemExit(f"--user-loras is not valid JSON: {e}")
-    if not isinstance(data, list):
-        raise SystemExit("--user-loras must be a JSON list of {path, strength}")
-    specs: list[tuple[str, float]] = []
-    for i, item in enumerate(data):
-        if not isinstance(item, dict) or "path" not in item:
-            raise SystemExit(f"user-loras[{i}] must be an object with 'path'")
-        path = item["path"]
-        if not isinstance(path, str) or not path:
-            raise SystemExit(f"user-loras[{i}].path must be a non-empty string")
-        if not Path(path).exists():
-            raise SystemExit(f"user-loras[{i}].path does not exist: {path}")
-        strength = item.get("strength", 1.0)
-        try:
-            strength = float(strength)
-        except (TypeError, ValueError):
-            raise SystemExit(f"user-loras[{i}].strength must be a number")
-        specs.append((path, strength))
-    return specs
 
 
 def _fuse(weights: dict, specs: list[tuple[str, float]]) -> dict:
@@ -156,7 +130,7 @@ def main() -> None:
     parser.add_argument("--user-loras", default=None)
     ns, passthrough = parser.parse_known_args()
 
-    specs = _parse_user_loras(ns.user_loras)
+    specs = parse_user_loras(ns.user_loras)
     if not specs:
         raise SystemExit(
             "generate_av_lora.py requires --user-loras; use `python -m "

--- a/scripts/generate_ltx2.py
+++ b/scripts/generate_ltx2.py
@@ -63,6 +63,14 @@ from typing import NoReturn
 os.environ.setdefault("LTX2_DIT_EVAL_EVERY", "1")
 os.environ.setdefault("LTX2_GEMMA_EVAL_EVERY", "1")
 
+# Sibling import: parse_user_loras is shared with generate_av_lora.py (the
+# mlx_video LoRA runtime) so the strict --user-loras validation lives in one
+# place. sys.path[0] is already this dir when run as a script; insert defensively
+# (mirrors generate_hunyuan.py). _runner_common is stdlib-only at import time, so
+# this is safe from the ltx-2-mlx venv (no torch pulled in).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _runner_common import parse_user_loras  # noqa: E402
+
 
 def emit_status(msg: str) -> None:
     """STATUS: line — single status update routed to PortOS SSE as `status`."""
@@ -363,39 +371,6 @@ def parse_args() -> argparse.Namespace:
                         "skipping = faster but lower fidelity (~1.2x at 0.5, up to ~3x at 1.5). "
                         "Omit to use the pipeline default (0.5).")
     return p.parse_args()
-
-
-def _parse_user_loras(raw: str | None) -> list[tuple[str, float]]:
-    """Parse --user-loras JSON into a list of (path, strength) tuples.
-
-    Validation is strict so a Node-side bug surfaces here before any GPU work.
-    Each entry must be {path: str (existing file), strength: number}. Returns
-    [] when --user-loras is unset.
-    """
-    if not raw:
-        return []
-    try:
-        data = json.loads(raw)
-    except json.JSONDecodeError as e:
-        raise SystemExit(f"--user-loras is not valid JSON: {e}")
-    if not isinstance(data, list):
-        raise SystemExit("--user-loras must be a JSON list of {path, strength}")
-    specs: list[tuple[str, float]] = []
-    for i, item in enumerate(data):
-        if not isinstance(item, dict) or "path" not in item:
-            raise SystemExit(f"user-loras[{i}] must be an object with 'path'")
-        path = item["path"]
-        if not isinstance(path, str) or not path:
-            raise SystemExit(f"user-loras[{i}].path must be a non-empty string")
-        if not Path(path).exists():
-            raise SystemExit(f"user-loras[{i}].path does not exist: {path}")
-        strength = item.get("strength", 1.0)
-        try:
-            strength = float(strength)
-        except (TypeError, ValueError):
-            raise SystemExit(f"user-loras[{i}].strength must be a number")
-        specs.append((path, strength))
-    return specs
 
 
 def _apply_user_loras(pipe, specs: list[tuple[str, float]]) -> None:
@@ -838,7 +813,7 @@ def main() -> NoReturn:
     Path(args.output).parent.mkdir(parents=True, exist_ok=True)
     # Parse user LoRAs once up-front (strict validation surfaces bad input
     # before any model load). Each run_* sets pipe._pending_loras from this.
-    args.user_lora_specs = _parse_user_loras(args.user_loras)
+    args.user_lora_specs = parse_user_loras(args.user_loras)
     configure_negative_prompt(args.negative_prompt)
 
     runners = {


### PR DESCRIPTION
## Summary

Follow-up to #1271. `parse_user_loras` — the strict `[{path, strength}]` JSON validator that surfaces a Node-side bug before any model load — was duplicated verbatim in:

- `scripts/generate_ltx2.py` (dgrauet `ltx2` runtime)
- `scripts/generate_av_lora.py` (mlx_video runtime, added in #1271)

A fix to the validation contract in one wouldn't propagate to the other. This moves the single implementation into `scripts/_runner_common.py` (the existing shared-scripts module — stdlib-only at import time, already imported cross-venv by `generate_hunyuan.py`) and has both runners import it. The only difference between the two former copies was a docstring; logic was byte-identical.

`emit_status` (a one-line `print`) is intentionally left in each script — extracting one of `generate_ltx2.py`'s `emit_status`/`emit_stage`/`emit_download` family would scatter a cohesive local group for no real gain.

## Test plan

- `py_compile` of `_runner_common.py` + `generate_av_lora.py` (data/python venv) and `generate_ltx2.py` (~/.portos/ltx-2-mlx venv) — all pass.
- `parse_user_loras` imports and runs correctly in **both** venvs (the dgrauet runtime's ltx-2-mlx venv and the mlx_video runtime's data/python venv) — confirms the cross-venv sibling import is safe.
- `generate_av_lora.py` loads as a module (exercising the sibling import at load) and its `--user-loras` CLI validation still works via the shared helper.
- No stale `_parse_user_loras` references remain; `import json` correctly dropped from `generate_av_lora.py` (0 uses) and retained in `generate_ltx2.py` (4 uses).
- Node suites unaffected: 125 tests pass (`services/videoGen/local.test.js`, `routes/videoGen.test.js`, `lib/runners.test.js`).