### PR TITLE
Don't drop-cap-glue a wrapped "I"/"A" in the manuscript Format pass

### DIFF
--- a/client/src/lib/manuscriptFormat.js
+++ b/client/src/lib/manuscriptFormat.js
@@ -50,8 +50,12 @@ const dehyphenate = (text) => text.replace(/([A-Za-z])-\n([a-z])/g, '$1$2');
 
 // Re-attach a stylized drop-cap that landed on its own line: a line that is a
 // single uppercase letter immediately followed by a line starting lowercase.
-// "T\nhe dawn" → "The dawn". Lookahead keeps the next line's first char.
-const rejoinDropCaps = (text) => text.replace(/^([A-Z])\n(?=[a-z])/gm, '$1');
+// "T\nhe dawn" → "The dawn" (joined with NO space — it's one word). `I` and `A`
+// are excluded: they're the only single-letter English words, so a lone `I`/`A`
+// is almost always the WORD wrapped to its own line ("I\nam …"), which must
+// join WITH a space — left to reflowProse — not glue into "Iam". The rare
+// drop-cap "In"/"And" is the accepted miss.
+const rejoinDropCaps = (text) => text.replace(/^([B-HJ-Z])\n(?=[a-z])/gm, '$1');
 
 // Re-attach closing double-quotes the PDF export orphaned. Three artifacts, all
 // keyed on a `"` separated from the text it should hug. (Straight quotes only —

--- a/client/src/lib/manuscriptFormat.test.js
+++ b/client/src/lib/manuscriptFormat.test.js
@@ -7,6 +7,21 @@ describe('formatManuscript — prose reflow', () => {
     expect(out).toBe('The dawn cycle hums to life.');
   });
 
+  it('joins a wrapped "I" with a space, not as a drop-cap glue', () => {
+    // "I" is a word, not a stylized drop-cap — must become "I am", never "Iam".
+    expect(formatManuscript('I\nam absolutely, definitely here.', 'prose')).toBe(
+      'I am absolutely, definitely here.',
+    );
+  });
+
+  it('joins a wrapped "A" with a space too', () => {
+    expect(formatManuscript('A\nman walked in.', 'prose')).toBe('A man walked in.');
+  });
+
+  it('still glues a genuine drop-cap (not I/A) with no space', () => {
+    expect(formatManuscript('T\nhe dawn cycle hums.', 'prose')).toBe('The dawn cycle hums.');
+  });
+
   it('de-hyphenates a word split across a wrap', () => {
     const out = formatManuscript('something approxi-\nmating daylight.', 'prose');
     expect(out).toBe('something approximating daylight.');


### PR DESCRIPTION
## Summary

Follow-up to the manuscript Format button. Running Format turned `I\nam absolutely…` into `Iam absolutely…`.

The `rejoinDropCaps` pass treated *any* lone capital letter on its own line as a stylized drop-cap and glued it to the next line with **no space** (`T\nhe` → `The`). But `I` and `A` are the only single-letter English words, so a lone `I`/`A` is almost always the *word* wrapped to its own line — confirmed against the real stored source:

```
system log, flagged as personal
I
am absolutely, definitely, one hundred
```

**Fix:** exclude `I` and `A` from the drop-cap regex (`[A-Z]` → `[B-HJ-Z]`). They fall through to `reflowProse`, which joins them *with* a space (`I am`). Genuine drop-caps (`T`, `S`, …) are unchanged. The rare drop-cap `In`/`And` is the accepted miss.

## Test plan

- `client/src/lib/manuscriptFormat.test.js` — new tests: wrapped `I` → `I am`, wrapped `A` → `A man`, and a genuine `T` drop-cap still glues to `The`. 31 tests, all green.
- `eslint` clean.
