### PR TITLE
fix([issue-1438]): guarantee localStorage/sessionStorage in client test env

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -95,6 +95,8 @@
 
 ## Changed
 
+- **[issue-1438] Hardened the client test suite against an environment where jsdom doesn't expose `localStorage`** — a guaranteed in-memory Web Storage shim is now installed before tests run, so suites that rely on `localStorage`/`sessionStorage` no longer fail intermittently across jsdom versions or CI environments (no user-visible app change).
+
 - **CyberCity now eases into full quality so the first second of startup doesn't drop frames.** Mounting the 3D city used to render every district at the full quality preset on frame one — reflections, full particle density, and the high-DPR pixel ratio all at once — which spiked the GPU and stuttered the opening camera move. The scene now renders a deliberately lightened first pass (reflections off, particle density capped, `dpr` pinned to `[1, 1]`) for ~1.2s, then restores your real settings once startup has settled. Photo mode is exempt (it needs full fidelity immediately). The same settle also re-runs when the app count changes, since that reshuffles building layout — another heavy frame worth easing into. (`client/src/components/city/CityScene.jsx`)
 
 - **[issue-1364] Generating a D&D character avatar now persists in one round-trip.** The character-sheet "Generate avatar" flow used to render the image and then make a *second* call to save the path onto your character. Since the avatar route already knows the character context, it now persists the rendered `avatarPath` itself when asked (`persistToCharacter`), so the client drops the follow-up `PUT /api/character` and keeps its optimistic update — same result, one fewer request. (`server/routes/imageGen.js`, `server/services/character.js`, `client/src/pages/CharacterSheet.jsx`, #1364)

--- a/client/src/test/setup.js
+++ b/client/src/test/setup.js
@@ -1,7 +1,16 @@
 import '@testing-library/jest-dom/vitest';
 import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/react';
+import { installTestStorage } from './storagePolyfill.js';
+
+// Guarantee a working localStorage/sessionStorage before any test runs, regardless
+// of how jsdom exposes Storage in this environment. See storagePolyfill.js / #1438.
+installTestStorage();
 
 afterEach(() => {
   cleanup();
+  // Reset storage between tests so a file that forgets its own `clear()` can't leak
+  // state into the next — reinforces the isolation the polyfill restores.
+  globalThis.localStorage?.clear();
+  globalThis.sessionStorage?.clear();
 });

--- a/client/src/test/storagePolyfill.js
+++ b/client/src/test/storagePolyfill.js
@@ -1,0 +1,69 @@
+// Web Storage (localStorage/sessionStorage) polyfill for the test environment.
+//
+// jsdom only exposes Storage when the document runs on a non-opaque origin — which
+// varies by jsdom version, by `environmentOptions.url`, and by whether an earlier
+// test stubbed `window` away (e.g. `vi.stubGlobal('window', undefined)` in
+// loopbackHost.test.js, later restored by `vi.unstubAllGlobals()`). When Storage is
+// absent, any test whose `beforeEach` calls `localStorage.clear()` dies with
+// "Cannot read properties of undefined (reading 'clear')". Installing a guaranteed
+// in-memory Storage removes that environmental dependency. See issue #1438.
+
+export const createMemoryStorage = () => {
+  let store = new Map();
+  return {
+    get length() {
+      return store.size;
+    },
+    key(index) {
+      return Array.from(store.keys())[index] ?? null;
+    },
+    getItem(key) {
+      return store.has(String(key)) ? store.get(String(key)) : null;
+    },
+    setItem(key, value) {
+      store.set(String(key), String(value));
+    },
+    removeItem(key) {
+      store.delete(String(key));
+    },
+    clear() {
+      store = new Map();
+    },
+  };
+};
+
+// A present-but-broken Storage is as bad as a missing one — probe round-trip before
+// trusting the environment's own implementation.
+export const storageWorks = (candidate) => {
+  if (!candidate) return false;
+  const probe = '__portos_storage_probe__';
+  // A throwing setItem (e.g. a Storage stubbed to simulate quota/private mode) means
+  // "not usable as a baseline" — fall back to the in-memory shim.
+  let ok = false;
+  try {
+    candidate.setItem(probe, '1');
+    ok = candidate.getItem(probe) === '1';
+    candidate.removeItem(probe);
+  } catch {
+    return false;
+  }
+  return ok;
+};
+
+// Ensure `globalThis[name]` (and `window[name]`, which jsdom aliases) is a working
+// Storage. Returns true when it installed a shim, false when the environment's own
+// Storage already worked. Idempotent.
+export const ensureStorage = (name, root = globalThis) => {
+  if (storageWorks(root[name])) return false;
+  const shim = createMemoryStorage();
+  Object.defineProperty(root, name, { value: shim, configurable: true, writable: true });
+  if (typeof window !== 'undefined' && window !== root) {
+    Object.defineProperty(window, name, { value: shim, configurable: true, writable: true });
+  }
+  return true;
+};
+
+export const installTestStorage = () => {
+  ensureStorage('localStorage');
+  ensureStorage('sessionStorage');
+};

--- a/client/src/test/storagePolyfill.js
+++ b/client/src/test/storagePolyfill.js
@@ -57,7 +57,11 @@ export const ensureStorage = (name, root = globalThis) => {
   if (storageWorks(root[name])) return false;
   const shim = createMemoryStorage();
   Object.defineProperty(root, name, { value: shim, configurable: true, writable: true });
-  if (typeof window !== 'undefined' && window !== root) {
+  // jsdom may expose `window` and `globalThis` as distinct objects; alias the shim
+  // onto `window` too so bare `localStorage` and `window.localStorage` resolve to the
+  // same instance. Only when installing onto the real global root — a caller passing
+  // an explicit `root` (e.g. tests) must not mutate the global `window`.
+  if (root === globalThis && typeof window !== 'undefined' && window !== globalThis) {
     Object.defineProperty(window, name, { value: shim, configurable: true, writable: true });
   }
   return true;

--- a/client/src/test/storagePolyfill.test.js
+++ b/client/src/test/storagePolyfill.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { createMemoryStorage, storageWorks, ensureStorage } from './storagePolyfill.js';
+import { createMemoryStorage, storageWorks, ensureStorage, installTestStorage } from './storagePolyfill.js';
 
 describe('storagePolyfill', () => {
   afterEach(() => {
@@ -68,6 +68,25 @@ describe('storagePolyfill', () => {
       expect(root.localStorage.getItem('k')).toBe('v');
     });
 
+    it('is name-agnostic — installs sessionStorage too', () => {
+      const root = {};
+      const installed = ensureStorage('sessionStorage', root);
+      expect(installed).toBe(true);
+      expect(storageWorks(root.sessionStorage)).toBe(true);
+      // Only the requested name is touched.
+      expect(root.localStorage).toBeUndefined();
+    });
+
+    it('does NOT mutate the global window when a caller passes an explicit root', () => {
+      // The window-aliasing branch is gated on `root === globalThis` precisely so a
+      // test passing its own root can't clobber the suite-wide window.localStorage.
+      const before = window.localStorage;
+      const root = {};
+      ensureStorage('localStorage', root);
+      expect(window.localStorage).toBe(before);
+      expect(root.localStorage).not.toBe(before);
+    });
+
     it('leaves a working Storage untouched (idempotent, no clobber)', () => {
       const existing = createMemoryStorage();
       existing.setItem('keep', 'me');
@@ -83,6 +102,18 @@ describe('storagePolyfill', () => {
       const installed = ensureStorage('localStorage', root);
       expect(installed).toBe(true);
       expect(storageWorks(root.localStorage)).toBe(true);
+    });
+  });
+
+  describe('installTestStorage (the setup.js entry point)', () => {
+    it('guarantees both local AND session storage are working (idempotent)', () => {
+      // The actual entry point setup.js calls. Asserting it directly catches a
+      // refactor that dropped the sessionStorage line — the ensureStorage cases above
+      // would still pass. It targets the live globals (already installed by setup.js),
+      // so this re-invocation must be a no-op that leaves both keys working.
+      expect(() => installTestStorage()).not.toThrow();
+      expect(storageWorks(globalThis.localStorage)).toBe(true);
+      expect(storageWorks(globalThis.sessionStorage)).toBe(true);
     });
   });
 

--- a/client/src/test/storagePolyfill.test.js
+++ b/client/src/test/storagePolyfill.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createMemoryStorage, storageWorks, ensureStorage } from './storagePolyfill.js';
+
+describe('storagePolyfill', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('createMemoryStorage', () => {
+    it('implements the Storage contract (set/get/remove/clear/length/key)', () => {
+      const s = createMemoryStorage();
+      expect(s.length).toBe(0);
+      expect(s.getItem('missing')).toBe(null);
+
+      s.setItem('a', '1');
+      s.setItem('b', '2');
+      expect(s.getItem('a')).toBe('1');
+      expect(s.length).toBe(2);
+      expect([s.key(0), s.key(1)]).toEqual(['a', 'b']);
+      expect(s.key(99)).toBe(null);
+
+      s.removeItem('a');
+      expect(s.getItem('a')).toBe(null);
+      expect(s.length).toBe(1);
+
+      s.clear();
+      expect(s.length).toBe(0);
+    });
+
+    it('coerces keys and values to strings, matching the DOM Storage spec', () => {
+      const s = createMemoryStorage();
+      s.setItem(1, 2);
+      expect(s.getItem('1')).toBe('2');
+      expect(s.getItem(1)).toBe('2');
+    });
+  });
+
+  describe('storageWorks', () => {
+    it('returns false for null/undefined', () => {
+      expect(storageWorks(null)).toBe(false);
+      expect(storageWorks(undefined)).toBe(false);
+    });
+
+    it('returns true for a functioning Storage', () => {
+      expect(storageWorks(createMemoryStorage())).toBe(true);
+    });
+
+    it('returns false for a Storage whose setItem throws (quota/private mode)', () => {
+      const broken = { setItem() { throw new Error('QuotaExceededError'); }, getItem() {}, removeItem() {} };
+      expect(storageWorks(broken)).toBe(false);
+    });
+
+    it('returns false for a Storage that drops what it stores', () => {
+      const lossy = { setItem() {}, getItem() { return null; }, removeItem() {} };
+      expect(storageWorks(lossy)).toBe(false);
+    });
+  });
+
+  describe('ensureStorage', () => {
+    it('installs a working Storage when the environment lacks one (the #1438 failure mode)', () => {
+      const root = {};
+      // Reproduces "Cannot read properties of undefined (reading clear)": no Storage present.
+      expect(root.localStorage).toBeUndefined();
+      const installed = ensureStorage('localStorage', root);
+      expect(installed).toBe(true);
+      expect(storageWorks(root.localStorage)).toBe(true);
+      root.localStorage.setItem('k', 'v');
+      expect(root.localStorage.getItem('k')).toBe('v');
+    });
+
+    it('leaves a working Storage untouched (idempotent, no clobber)', () => {
+      const existing = createMemoryStorage();
+      existing.setItem('keep', 'me');
+      const root = { localStorage: existing };
+      const installed = ensureStorage('localStorage', root);
+      expect(installed).toBe(false);
+      expect(root.localStorage).toBe(existing);
+      expect(root.localStorage.getItem('keep')).toBe('me');
+    });
+
+    it('replaces a broken Storage with a working shim', () => {
+      const root = { localStorage: { setItem() { throw new Error('boom'); }, getItem() {}, removeItem() {} } };
+      const installed = ensureStorage('localStorage', root);
+      expect(installed).toBe(true);
+      expect(storageWorks(root.localStorage)).toBe(true);
+    });
+  });
+
+  it('the active test environment has a working localStorage (setup.js installed it)', () => {
+    expect(storageWorks(globalThis.localStorage)).toBe(true);
+    expect(storageWorks(globalThis.sessionStorage)).toBe(true);
+    // And the bare global resolves to the same instance window exposes.
+    expect(localStorage).toBe(window.localStorage);
+  });
+});


### PR DESCRIPTION
Closes #1438

## Problem

`client/src/components/Layout.test.jsx`, `client/src/hooks/useNavWorkingSet.test.jsx`, and `client/src/pages/PipelineManuscriptEditor.test.jsx` could fail with `TypeError: Cannot read properties of undefined (reading 'clear')` at a `beforeEach` calling `localStorage.clear()`.

## Root cause

jsdom only exposes Web Storage (`localStorage`/`sessionStorage`) when the document runs on a **non-opaque origin**. Whether it's present is environment-dependent — it varies by jsdom version, by vitest's `environmentOptions.url` (here the default `http://localhost:3000/` happens to expose it, so the suite passes on this machine), and by whether an earlier test in the same worker stubbed `window` away (e.g. `vi.stubGlobal('window', undefined)` in `loopbackHost.test.js`, later restored). When Storage is absent, any `localStorage.clear()` in a `beforeEach` throws — exactly the reported failure, and exactly the kind of flake that bites a different node/jsdom version or CI runner without reproducing locally.

## Fix

Remove the environmental dependency entirely rather than chase a config that happens to work on one machine:

- **`client/src/test/storagePolyfill.js`** (new) — a guaranteed in-memory `Storage` shim plus `ensureStorage()` (idempotent; replaces a *present-but-broken* Storage too) and `installTestStorage()`.
- **`client/src/test/setup.js`** — installs the shim before any test runs, and resets storage in `afterEach` so a file that forgets its own `clear()` can't leak state into the next (reinforces isolation).
- **`client/src/test/storagePolyfill.test.js`** (new) — regression tests that reproduce the failure mode (missing / broken / lossy Storage) and prove the shim installs working storage, is idempotent, and doesn't clobber a working one. This is the "root-caused so it doesn't silently regress" acceptance criterion.

## Verification

- Full client suite: **232 files / 2396 tests pass** (10 new).
- The three originally-cited files pass in isolation, in the exact repro command, and in the full suite.
- Lint clean on all changed files.

Note: the bug did not reproduce on this machine (node v24 / jsdom 26.1.0 / default jsdom origin), so this is a structural hardening that makes the documented failure mode impossible across environments, with tests pinning it.