### PR TITLE
Alphabetize CoS Schedule tasks by name

### DIFF
--- a/client/src/components/cos/tabs/schedule/AppTaskTypeSection.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskTypeSection.jsx
@@ -2,7 +2,7 @@ import AppTaskTypeRow from './AppTaskTypeRow';
 import { TASK_FILTERS, DEFAULT_FILTER_ID } from './scheduleConstants';
 
 export default function AppTaskTypeSection({ tasks, onUpdate, onTrigger, onReset, providers, apps, onUpdateOverride, onBulkToggleOverride, improvementDisabled, filter, onFilterChange }) {
-  const taskEntries = Object.entries(tasks || {});
+  const taskEntries = Object.entries(tasks || {}).sort(([a], [b]) => a.localeCompare(b));
   if (taskEntries.length === 0) return null;
 
   const activeFilter = TASK_FILTERS.find(f => f.id === filter) || TASK_FILTERS[0];


### PR DESCRIPTION
## Summary
The CoS Schedule page (`/cos/schedule`) listed scheduled tasks in object-insertion order. This sorts them alphabetically by task name for a stable, predictable listing.

`AppTaskTypeSection` now sorts `Object.entries(tasks || {})` with `localeCompare` on the task-type key (the displayed name). The sorted entries feed `allTaskTypes`, the filtered `visibleEntries`, and `counts`, so the whole section renders in alphabetical order consistently.

## Test plan
- Open `/cos/schedule` and confirm Improvement Tasks are listed A→Z by name.
- Verify task filters and per-task counts still work (order-independent).
- No new tests: UI ordering tweak; no test infra exists for these schedule components.