### PR TITLE
Improve mobile responsive layout of the Editorial Checks page

### DIFF
--- a/client/src/components/pipeline/editorial/EditorialHealthPanel.jsx
+++ b/client/src/components/pipeline/editorial/EditorialHealthPanel.jsx
@@ -35,7 +35,7 @@ function SeverityBreakdown({ openBySeverity }) {
   const any = SEVERITY_ORDER.some((s) => (openBySeverity?.[s] || 0) > 0);
   if (!any) return <span className="text-[11px] text-port-success">No open findings</span>;
   return (
-    <span className="flex items-center gap-3">
+    <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
       {SEVERITY_ORDER.map((sev) => (
         <span key={sev} className="flex items-center gap-1 text-[11px] text-gray-400">
           <span className={`h-2 w-2 rounded-full ${SEVERITY_DOT[sev]}`} />
@@ -51,7 +51,7 @@ function Sparkline({ points }) {
   if (!poly) return <span className="text-[11px] text-gray-600">Run editorial checks to start the trend</span>;
   const last = coords[coords.length - 1];
   return (
-    <svg width={140} height={32} className="overflow-visible" role="img" aria-label="Editorial health score trend">
+    <svg viewBox="0 0 140 32" width={140} height={32} className="h-8 w-[140px] max-w-full overflow-visible" role="img" aria-label="Editorial health score trend">
       <polyline points={poly} fill="none" stroke="currentColor" strokeWidth="1.5" className="text-port-accent" />
       <circle cx={last.x} cy={last.y} r="2.5" className="fill-port-accent" />
     </svg>
@@ -137,8 +137,8 @@ export default function EditorialHealthPanel({ seriesId, refreshKey = 0 }) {
       </div>
 
       {/* Score + breakdown */}
-      <div className="flex flex-wrap items-end justify-between gap-3">
-        <div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-end sm:justify-between">
+        <div className="min-w-0">
           <div className="flex items-baseline gap-2">
             <span className={`text-3xl font-bold ${band.tone}`}>{health.score}</span>
             <span className="text-xs text-gray-500">/ 100 · {band.label}</span>
@@ -153,7 +153,7 @@ export default function EditorialHealthPanel({ seriesId, refreshKey = 0 }) {
           </div>
           <div className="mt-1.5"><SeverityBreakdown openBySeverity={health.openBySeverity} /></div>
         </div>
-        <div className="text-right">
+        <div className="sm:text-right">
           <span className="block text-[10px] uppercase tracking-wide text-gray-600">Score trend</span>
           <span className="text-port-accent"><Sparkline points={health.trend?.points} /></span>
         </div>

--- a/client/src/pages/PipelineEditorialChecks.jsx
+++ b/client/src/pages/PipelineEditorialChecks.jsx
@@ -279,13 +279,13 @@ export default function PipelineEditorialChecks() {
           <h1 className="flex items-center gap-2 text-xl font-semibold text-gray-100">
             <ListChecks size={20} className="text-port-accent" /> Editorial Checks
           </h1>
-          <div className="flex flex-wrap items-center gap-2">
+          <div className="flex w-full flex-wrap items-center gap-2 sm:w-auto">
             <label htmlFor="ec-series" className="sr-only">Series</label>
             <select
               id="ec-series"
               value={seriesId}
               onChange={(e) => onSeriesChange(e.target.value)}
-              className="rounded border border-port-border bg-port-card px-2 py-1.5 text-sm text-gray-100 focus:border-port-accent focus:outline-none"
+              className="w-full rounded border border-port-border bg-port-card px-2 py-1.5 text-sm text-gray-100 focus:border-port-accent focus:outline-none sm:w-auto"
             >
               <option value="">Select a series…</option>
               {series.map((s) => (
@@ -296,7 +296,7 @@ export default function PipelineEditorialChecks() {
               <button
                 type="button"
                 onClick={cancelRun}
-                className="inline-flex items-center gap-1.5 rounded bg-port-error/20 px-3 py-1.5 text-sm text-rose-300 hover:bg-port-error/30"
+                className="inline-flex flex-1 items-center justify-center gap-1.5 rounded bg-port-error/20 px-3 py-1.5 text-sm text-rose-300 hover:bg-port-error/30 sm:flex-none"
               >
                 <Square size={14} /> Cancel
               </button>
@@ -306,7 +306,7 @@ export default function PipelineEditorialChecks() {
                 onClick={() => runChecks(null)}
                 disabled={runDisabled || enabledCount === 0}
                 title={enabledCount === 0 ? 'No checks enabled' : undefined}
-                className="inline-flex items-center gap-1.5 rounded bg-port-accent px-3 py-1.5 text-sm text-white hover:bg-port-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex flex-1 items-center justify-center gap-1.5 rounded bg-port-accent px-3 py-1.5 text-sm text-white hover:bg-port-accent/90 disabled:cursor-not-allowed disabled:opacity-50 sm:flex-none"
               >
                 {runStarting ? <Loader2 size={14} className="animate-spin" /> : <Play size={14} />}
                 Run all enabled ({enabledCount})
@@ -317,7 +317,7 @@ export default function PipelineEditorialChecks() {
                 type="button"
                 onClick={() => runChecks([...selectedIds])}
                 disabled={runDisabled}
-                className="inline-flex items-center gap-1.5 rounded border border-port-accent px-3 py-1.5 text-sm text-port-accent hover:bg-port-accent/10 disabled:cursor-not-allowed disabled:opacity-50"
+                className="inline-flex flex-1 items-center justify-center gap-1.5 rounded border border-port-accent px-3 py-1.5 text-sm text-port-accent hover:bg-port-accent/10 disabled:cursor-not-allowed disabled:opacity-50 sm:flex-none"
               >
                 <Play size={14} /> Run selected ({selectedIds.size})
               </button>


### PR DESCRIPTION
## Summary

The Editorial Checks page (`/pipeline/editorial-checks`) had a few spots that didn't lay out well on phone-width screens. This PR tightens them up — all changes are Tailwind className adjustments, no logic changes.

- **Header controls** (`PipelineEditorialChecks.jsx`): the series `<select>` plus the run buttons sat in a single `flex-wrap` row that crowded/overflowed on narrow screens. They now collapse to a full-width column on mobile (`w-full` select, `flex-1` buttons that share a row) and restore the original inline layout at `sm:` and up.
- **Health panel score + trend** (`EditorialHealthPanel.jsx`): the score block and the trend sparkline now stack vertically on mobile and only go side-by-side at `sm:`. The score-trend block left-aligns when stacked.
- **Trend sparkline**: added a `viewBox` (matching the existing `sparklineGeometry` 140×32 coordinate space) plus `max-w-full` so the SVG shrinks to fit narrow viewports instead of overflowing. Width/height attributes are kept as intrinsic-size fallbacks.
- **Severity breakdown row**: now wraps (`flex-wrap` + `gap-x/gap-y`) instead of forcing three items onto one line.

## Test plan

- No logic changed; no existing tests assert this markup.
- Verified the diff against the local review checklist and ran a two-reviewer pass (claude + local ollama coding model) — both clean.
- Sparkline coordinate space (`viewBox="0 0 140 32"`) matches `sparklineGeometry({ width: 140, height: 32 })`, so the polyline/circle still render at the correct positions while scaling down on small screens.