### PR TITLE
Surface global pause in app automation tabs; manual Run bypasses pause

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,3 +3,4 @@
 ## Added
 
 - Editorial Checks page now has an AI provider + model selector that configures the editorial pass. Leave it on "Default provider" to use the active/stage provider, or pick a specific provider/model to override the LLM-backed checks for that run.
+- App **Automation** tabs now show a banner when scheduled automation is globally paused, with a one-click **Resume**. Manually clicking **Run** on a task now bypasses the global pause — the pause only stops scheduled/autonomous spawning, not explicit user triggers.

--- a/client/src/components/apps/tabs/AutomationTab.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { RefreshCw, Play } from 'lucide-react';
+import { RefreshCw, Play, PauseCircle } from 'lucide-react';
 import toast from '../../ui/Toast';
 import BrailleSpinner from '../../BrailleSpinner';
 import CronInput from '../../CronInput';
@@ -22,23 +22,40 @@ const INTERVAL_OPTIONS = [
 export default function AutomationTab({ appId, appName }) {
   const [overrides, setOverrides] = useState({});
   const [schedule, setSchedule] = useState(null);
+  const [paused, setPaused] = useState(false);
+  const [resuming, setResuming] = useState(false);
   const [loading, setLoading] = useState(true);
   const [triggering, setTriggering] = useState(null);
   const [cronEditing, setCronEditing] = useState({});
 
   const fetchData = useCallback(async () => {
-    const [taskTypesData, scheduleData] = await Promise.all([
+    const [taskTypesData, scheduleData, statusData] = await Promise.all([
       api.getAppTaskTypes(appId).catch(() => ({ taskTypeOverrides: {} })),
-      api.getCosSchedule().catch(() => null)
+      api.getCosSchedule().catch(() => null),
+      api.getCosStatus().catch(() => null)
     ]);
     setOverrides(taskTypesData.taskTypeOverrides || {});
     setSchedule(scheduleData);
+    setPaused(statusData?.paused === true);
     setLoading(false);
   }, [appId]);
 
   useEffect(() => {
     fetchData();
   }, [fetchData]);
+
+  const handleResume = async () => {
+    setResuming(true);
+    const result = await api.resumeCos().catch(err => {
+      toast.error(err.message);
+      return null;
+    });
+    setResuming(false);
+    if (result?.success) {
+      setPaused(false);
+      toast.success('Scheduled automation resumed');
+    }
+  };
 
   const handleToggle = async (taskType, isEnabled) => {
     const newEnabled = !isEnabled;
@@ -132,6 +149,25 @@ export default function AutomationTab({ appId, appName }) {
 
   return (
     <div className="max-w-5xl space-y-4">
+      {paused && (
+        <div className="bg-port-warning/10 border border-port-warning/40 rounded-lg p-3 flex items-start gap-3">
+          <PauseCircle size={18} className="text-port-warning shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-port-warning">Scheduled automation is globally paused</p>
+            <p className="text-xs text-gray-400 mt-0.5">
+              Scheduled and autonomous tasks won&apos;t run until resumed. You can still trigger an enabled task manually with <span className="text-gray-300">Run</span>.
+            </p>
+          </div>
+          <button
+            onClick={handleResume}
+            disabled={resuming}
+            className="px-3 py-1.5 bg-port-warning/20 text-port-warning hover:bg-port-warning/30 rounded-lg text-xs font-medium flex items-center gap-1 disabled:opacity-50 shrink-0"
+          >
+            <Play size={14} />
+            {resuming ? 'Resuming…' : 'Resume'}
+          </button>
+        </div>
+      )}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
           <div>

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -649,8 +649,11 @@ async function tryImmediateSpawn(task) {
 async function dequeueNextTask() {
   if (!isDaemonRunning()) return;
 
+  // A global pause stops scheduled/autonomous spawning, but NOT explicit user
+  // triggers: on-demand requests (Priority 0) are processed even while paused so
+  // a manual "Run" from an app's automation page still fires. The autonomous
+  // tiers (Priority 1+) are skipped below when paused.
   const paused = await isPaused();
-  if (paused) return;
 
   const state = await loadState();
   const runningAgents = Object.values(state.agents).filter(a => a.status === 'running').length;
@@ -750,6 +753,10 @@ async function dequeueNextTask() {
       }
     }
   }
+
+  // Global pause stops every autonomous/scheduled/user tier below; only the
+  // on-demand queue above (explicit user "Run") bypasses it.
+  if (paused) return;
 
   // Priority 1: User tasks
   const userTaskData = await getUserTasks();

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -684,6 +684,32 @@ describe('cos.js source — priority + capacity invariants', () => {
     expect(idleIdx, 'spawnPriority4IdleReview must run after feature agents').toBeGreaterThan(featureIdx);
   });
 
+  it('on-demand (Priority 0) bypasses the global pause in BOTH engines', () => {
+    // A global pause stops scheduled/autonomous/user spawning, but an explicit
+    // user "Run" queues an on-demand request that must still fire. So in each
+    // engine the pause gate must sit AFTER Priority 0, not at the top — moving it
+    // back to the top is the regression this pins.
+    const dequeueFn = extractFnBody(COS_SRC, COS_SRC.indexOf('async function dequeueNextTask'));
+    const evalFn    = extractFnBody(GEN_SRC, GEN_SRC.indexOf('export async function evaluateTasks'));
+
+    // dequeueNextTask: the `if (paused) return` gate appears AFTER the on-demand
+    // loop (`onDemandRequests`), and `paused` is NOT returned-on before it.
+    const dqOnDemandIdx = dequeueFn.indexOf('onDemandRequests');
+    const dqPauseGateIdx = dequeueFn.search(/if\s*\(\s*paused\s*\)\s*return/);
+    expect(dqOnDemandIdx, 'dequeueNextTask must process onDemandRequests').toBeGreaterThan(-1);
+    expect(dqPauseGateIdx, 'dequeueNextTask must keep an `if (paused) return` gate').toBeGreaterThan(-1);
+    expect(dqPauseGateIdx, 'pause gate must come AFTER the on-demand loop').toBeGreaterThan(dqOnDemandIdx);
+
+    // evaluateTasks: Priority 0 runs unconditionally; Priorities 1+ are wrapped in
+    // an `if (!paused)` block that begins after spawnPriority0OnDemand.
+    const evOnDemandIdx = evalFn.indexOf('spawnPriority0OnDemand(ctx)');
+    const evPauseGateIdx = evalFn.search(/if\s*\(\s*!\s*paused\s*\)/);
+    const evUserIdx = evalFn.indexOf('spawnPriority1UserTasks(ctx)');
+    expect(evOnDemandIdx, 'evaluateTasks must invoke spawnPriority0OnDemand').toBeGreaterThan(-1);
+    expect(evPauseGateIdx, 'evaluateTasks must gate the lower tiers on !paused').toBeGreaterThan(evOnDemandIdx);
+    expect(evUserIdx, 'user/autonomous tiers must sit inside the !paused gate').toBeGreaterThan(evPauseGateIdx);
+  });
+
   it('per-project cap defaults to global cap when unset', () => {
     // The fallback `state.config.maxConcurrentAgentsPerProject || state.config.maxConcurrentAgents`
     // is the safety net for older state.json files that pre-date the

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -98,7 +98,7 @@ function makeCapacityTracker(state, agentsByProject = {}) {
  * `evaluateTasks` mirrors this at cos.js:862 with `tasksToSpawn.length === 0`.
  * The replica enforces the same `spawned === 0` precondition.
  */
-function priorityDequeue(buckets, capacity) {
+function priorityDequeue(buckets, capacity, { paused = false } = {}) {
   const order = ['onDemand', 'user', 'autoSystem', 'mission', 'idle'];
 
   // Mission / idle only run when no pending user tasks exist, mirroring the
@@ -106,6 +106,10 @@ function priorityDequeue(buckets, capacity) {
   const hasPendingUserTasks = (buckets.user || []).length > 0;
 
   for (const bucketName of order) {
+    // Global pause: on-demand (explicit user "Run") still drains, but every
+    // autonomous/scheduled/user tier below is skipped — mirrors the
+    // `if (paused) return;` gate in dequeueNextTask after Priority 0.
+    if (paused && bucketName !== 'onDemand') break;
     if ((bucketName === 'mission' || bucketName === 'idle') && hasPendingUserTasks) continue;
     // Idle is stricter: only fires when no other bucket has spawned yet.
     if (bucketName === 'idle' && capacity.spawned.length > 0) continue;
@@ -165,6 +169,28 @@ describe('evaluateTasks — priority ordering', () => {
       'sys-auto-1',
     ]);
     expect(spawned.map(t => t._bucket)).toEqual(['onDemand', 'user', 'autoSystem']);
+  });
+
+  it('when globally paused, only the on-demand bucket drains (manual Run bypasses pause)', () => {
+    // A global pause stops scheduled/autonomous/user spawning, but an explicit
+    // user "Run" pushes an on-demand request that must still fire. Mirrors the
+    // production gate: Priority 0 (on-demand) is processed, then `if (paused) return;`.
+    const state = makeState({ maxConcurrentAgents: 5 });
+    const capacity = makeCapacityTracker(state);
+
+    const buckets = {
+      onDemand: [task('task-onDemand-1')],
+      user: [task('task-user-1')],
+      autoSystem: [task('sys-auto-1')],
+      mission: [task('sys-mission-1')],
+      idle: [task('sys-idle-1')],
+    };
+
+    const spawned = priorityDequeue(buckets, capacity, { paused: true });
+
+    // Only the on-demand request spawns; everything else stays paused.
+    expect(spawned.map(t => t.id)).toEqual(['task-onDemand-1']);
+    expect(spawned.map(t => t._bucket)).toEqual(['onDemand']);
   });
 
   it('mission + idle fire only when there are NO pending user tasks', () => {

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -621,12 +621,11 @@ export async function evaluateTasks(options) {
   const { initialStartup = false } = options || {};
   if (!isDaemonRunning()) return;
 
-  // Check if paused - skip evaluation if so
+  // A global pause stops scheduled/autonomous/user spawning, but NOT explicit
+  // user triggers: on-demand requests (Priority 0) are still drained while
+  // paused so a manual "Run" (or a force-evaluate) fires. The user/autonomous
+  // tiers below are gated on `!paused` — parity with dequeueNextTask in cos.js.
   const paused = (await loadState()).paused || false;
-  if (paused) {
-    emitLog('debug', 'CoS is paused - skipping evaluation');
-    return;
-  }
 
   // Update evaluation timestamp with lock to prevent race conditions
   const state = await withStateLock(async () => {
@@ -708,23 +707,31 @@ export async function evaluateTasks(options) {
     autonomousSlotCeiling: availableSlots
   };
 
-  // Priorities 0–1 spend against the global slot cap.
+  // Priority 0 (on-demand) spends against the global slot cap and runs even when
+  // paused — an explicit user "Run" bypasses the global pause.
   await spawnPriority0OnDemand(ctx);
-  await spawnPriority1UserTasks(ctx);
 
-  // Ceiling for AUTONOMOUS admissions this cycle (#711). On-demand + user tasks
-  // are already in `tasksToSpawn` and never count against the CoS action budget,
-  // so the autonomous sections below may add at most `autonomousActionsRemaining`
-  // more. With no action cap this equals `availableSlots`, so the default path is
-  // unchanged. The autonomous tiers use this in place of `availableSlots`.
-  ctx.autonomousSlotCeiling = Math.min(availableSlots, tasksToSpawn.length + autonomousActionsRemaining);
+  // Every tier below is scheduled/autonomous/user work that the global pause
+  // stops. When paused we skip them and let the shared spawn loop below emit just
+  // the on-demand tasks Priority 0 collected.
+  if (!paused) {
+    // Priority 1 spends against the global slot cap.
+    await spawnPriority1UserTasks(ctx);
 
-  // Priorities 2, 3, 3.6, 4 spend against the lower autonomous ceiling.
-  await spawnPriority2AutoApproved(ctx);
-  await maybeQueueImprovementTasks(ctx);
-  await spawnPriority3Missions(ctx);
-  await spawnPriority36FeatureAgents(ctx);
-  await spawnPriority4IdleReview(ctx);
+    // Ceiling for AUTONOMOUS admissions this cycle (#711). On-demand + user tasks
+    // are already in `tasksToSpawn` and never count against the CoS action budget,
+    // so the autonomous sections below may add at most `autonomousActionsRemaining`
+    // more. With no action cap this equals `availableSlots`, so the default path is
+    // unchanged. The autonomous tiers use this in place of `availableSlots`.
+    ctx.autonomousSlotCeiling = Math.min(availableSlots, tasksToSpawn.length + autonomousActionsRemaining);
+
+    // Priorities 2, 3, 3.6, 4 spend against the lower autonomous ceiling.
+    await spawnPriority2AutoApproved(ctx);
+    await maybeQueueImprovementTasks(ctx);
+    await spawnPriority3Missions(ctx);
+    await spawnPriority36FeatureAgents(ctx);
+    await spawnPriority4IdleReview(ctx);
+  }
 
   // Emit evaluation status
   const pendingUserCount = userTaskData.grouped?.pending?.length || 0;


### PR DESCRIPTION
## Summary

App **Automation** tabs (`apps/<id>/automation`) now surface when scheduled automation is **globally paused** and let the user resume it inline. Crucially, clicking **Run** on a task now **bypasses the global pause** — the pause is meant to stop scheduled/autonomous spawning, not to block an explicit user-triggered run.

## Changes

- **`server/services/cos.js`** — `dequeueNextTask()` no longer bails at the top when paused. It processes **Priority 0 (on-demand) requests even while paused**, then gates only the user/autonomous tiers (Priority 1+) behind `if (paused) return`. An explicit "Run" queues an on-demand request that now fires while paused.
- **`server/services/cosTaskGenerator.js`** — same parity fix in the sibling `evaluateTasks()` engine (the one driven by the periodic interval and `POST /api/cos/evaluate`): Priority 0 runs unconditionally; tiers 1–4 are wrapped in `if (!paused)`. This keeps the two spawn engines consistent (found by the claude review pass).
- **`client/src/components/apps/tabs/AutomationTab.jsx`** — fetches `getCosStatus()` and renders a warning banner with a one-click **Resume** when paused. The banner notes that an enabled task can still be triggered manually via Run. Shared component, so all app automation pages get it.
- **Tests** — `cos.test.js`: the priority-dequeue replica gained a `paused` case (only on-demand drains), plus a source-scan test pinning the pause-gate placement (after Priority 0) in **both** engines so a regression that moves it back to the top is caught.

## Review

Local multi-reviewer loop (series): **claude → ollama → codex**, all clean. Claude caught the `evaluateTasks` parity gap and a coverage gap (both fixed in this branch).

## Test plan

- `npx vitest run` for `cos.test.js`, `cosTaskGenerator.test.js`, `taskSchedule.test.js`, `cosScheduleRoutes.test.js` — all green.
- Client build passes.