### PR TITLE
Move app Edit action to header; convert edit modal to right drawer

### DIFF
--- a/client/src/components/Drawer.jsx
+++ b/client/src/components/Drawer.jsx
@@ -1,22 +1,31 @@
 import { useEffect } from 'react';
 import { X } from 'lucide-react';
+import { useScrollLock } from '../hooks/useScrollLock';
 
 // Right-side slide-in panel for "settings over a feature page" pattern.
 // Mobile (<sm): full width. Desktop: ~520px. Backdrop click + Esc close it.
 // Caller controls open state — typically driven by a URL search param so the
 // view stays deep-linkable per the project convention.
-export default function Drawer({ open, onClose, title, children, widthClass = 'sm:w-[520px]' }) {
+// Long-lived forms (e.g. the app-edit drawer) can opt out of accidental
+// dismissal via closeOnEsc / closeOnBackdrop so an Esc keystroke mid-edit
+// doesn't discard the form.
+export default function Drawer({
+  open,
+  onClose,
+  title,
+  children,
+  widthClass = 'sm:w-[520px]',
+  closeOnEsc = true,
+  closeOnBackdrop = true
+}) {
+  useScrollLock(open);
+
   useEffect(() => {
-    if (!open) return;
+    if (!open || !closeOnEsc) return;
     const onKey = (e) => { if (e.key === 'Escape') onClose(); };
     window.addEventListener('keydown', onKey);
-    const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = 'hidden';
-    return () => {
-      window.removeEventListener('keydown', onKey);
-      document.body.style.overflow = prevOverflow;
-    };
-  }, [open, onClose]);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose, closeOnEsc]);
 
   if (!open) return null;
 
@@ -24,7 +33,7 @@ export default function Drawer({ open, onClose, title, children, widthClass = 's
     <>
       <div
         className="fixed inset-0 z-40 bg-black/60"
-        onClick={onClose}
+        onClick={closeOnBackdrop ? onClose : undefined}
         aria-hidden="true"
       />
       <aside

--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Link, useParams, useNavigate } from 'react-router-dom';
-import { ArrowLeft, Play, Square, RotateCcw, ExternalLink, Hammer, RefreshCw } from 'lucide-react';
+import { ArrowLeft, Play, Square, RotateCcw, ExternalLink, Hammer, RefreshCw, Pencil } from 'lucide-react';
 import DeployPanel from './DeployPanel';
+import EditAppDrawer from './EditAppDrawer';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
 import StatusBadge from '../StatusBadge';
@@ -30,6 +31,7 @@ export default function AppDetailView() {
   const [notFound, setNotFound] = useState(false);
   const [actionLoading, setActionLoading] = useState(null);
   const [buildLoading, setBuildLoading] = useState(false);
+  const [editing, setEditing] = useState(false);
 
   const fetchApp = useCallback(async () => {
     const data = await api.getApp(appId).catch(() => null);
@@ -295,6 +297,13 @@ export default function AppDetailView() {
             {app.hasDeployScript && (
               <DeployPanel appId={appId} appName={app.name} />
             )}
+            <button
+              onClick={() => setEditing(true)}
+              className="px-2 py-1 bg-port-accent/20 text-port-accent hover:bg-port-accent/30 transition-colors rounded-lg border border-port-border flex items-center gap-1"
+            >
+              <Pencil size={14} />
+              <span className="text-xs">Edit</span>
+            </button>
           </div>
         </div>
 
@@ -320,6 +329,14 @@ export default function AppDetailView() {
       <div className="flex-1 overflow-auto p-4 sm:p-6">
         {renderTab()}
       </div>
+
+      {editing && (
+        <EditAppDrawer
+          app={app}
+          onClose={() => setEditing(false)}
+          onSave={() => { setEditing(false); fetchApp(); }}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -48,6 +48,14 @@ export default function AppDetailView() {
     fetchApp();
   }, [fetchApp]);
 
+  // Close the edit drawer when navigating to a different app so its stale
+  // form state (initialized from the previous app) can't be saved against the
+  // newly loaded app id. Keyed on appId only — a same-app socket refresh must
+  // not interrupt an in-progress edit.
+  useEffect(() => {
+    setEditing(false);
+  }, [appId]);
+
   // Real-time updates
   useEffect(() => {
     const handleAppsChanged = () => fetchApp();

--- a/client/src/components/apps/EditAppDrawer.jsx
+++ b/client/src/components/apps/EditAppDrawer.jsx
@@ -5,7 +5,7 @@ import IconPicker from '../IconPicker';
 import * as api from '../../services/api';
 import { PORTOS_APP_ID } from '../../services/apiCore';
 import toast from '../ui/Toast';
-import Modal from '../ui/Modal';
+import Drawer from '../Drawer';
 import Banner from '../ui/Banner';
 import { copyToClipboard } from '../../lib/clipboard';
 
@@ -21,7 +21,7 @@ const WORK_TRACKER_LABELS = Object.fromEntries(
   WORK_TRACKER_OPTIONS.map(o => [o.value, o.label])
 );
 
-export default function EditAppModal({ app, onClose, onSave }) {
+export default function EditAppDrawer({ app, onClose, onSave }) {
   const [formData, setFormData] = useState({
     name: app.name,
     icon: app.icon || 'package',
@@ -183,21 +183,17 @@ export default function EditAppModal({ app, onClose, onSave }) {
   };
 
   return (
-    <Modal
+    <Drawer
       open
       onClose={onClose}
-      // App-edit historically had no backdrop dismiss / Esc — the form is
-      // long-lived and an accidental Esc while editing nested JIRA pickers
-      // would lose state. Preserve that.
-      closeOnBackdrop={false}
+      title="Edit App"
+      widthClass="sm:w-[640px]"
+      // The form is long-lived and an accidental Esc / backdrop click while
+      // editing nested JIRA pickers would lose state. Preserve the modal's
+      // no-accidental-dismiss behavior.
       closeOnEsc={false}
-      size="md"
-      backdropClassName="bg-black/50"
-      ariaLabelledBy="edit-app-title"
-      panelClassName="bg-port-card border border-port-border rounded-xl p-4 sm:p-6 max-h-[90vh] overflow-auto"
+      closeOnBackdrop={false}
     >
-      <h2 id="edit-app-title" className="text-xl font-bold text-white mb-4">Edit App</h2>
-
         {error && (
           <div className="mb-4 p-3 bg-port-error/20 border border-port-error rounded-lg text-port-error text-sm">
             {error}
@@ -726,6 +722,6 @@ export default function EditAppModal({ app, onClose, onSave }) {
             </button>
           </div>
         </form>
-    </Modal>
+    </Drawer>
   );
 }

--- a/client/src/components/apps/EditAppDrawer.test.jsx
+++ b/client/src/components/apps/EditAppDrawer.test.jsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
 
-// Mock the API surface EditAppModal touches on mount, plus the work-tracker
+// Mock the API surface EditAppDrawer touches on mount, plus the work-tracker
 // resolver and the update path used on save.
 vi.mock('../../services/api', () => ({
   getJiraInstances: vi.fn(),
@@ -18,7 +18,7 @@ vi.mock('react-router-dom', () => ({
 }));
 
 import * as api from '../../services/api';
-import EditAppModal from './EditAppModal';
+import EditAppDrawer from './EditAppDrawer';
 
 const APP = {
   id: 'app-1',
@@ -46,9 +46,9 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe('EditAppModal work tracker selector', () => {
+describe('EditAppDrawer work tracker selector', () => {
   it('renders a labeled select with the five tracker options', async () => {
-    render(<EditAppModal app={APP} onClose={() => {}} onSave={() => {}} />);
+    render(<EditAppDrawer app={APP} onClose={() => {}} onSave={() => {}} />);
 
     const select = await screen.findByLabelText('Work Tracker');
     expect(select).toBeInTheDocument();
@@ -59,7 +59,7 @@ describe('EditAppModal work tracker selector', () => {
   });
 
   it('shows the resolved auto target from the work-tracker endpoint', async () => {
-    render(<EditAppModal app={APP} onClose={() => {}} onSave={() => {}} />);
+    render(<EditAppDrawer app={APP} onClose={() => {}} onSave={() => {}} />);
 
     await screen.findByLabelText('Work Tracker');
     expect(api.getAppWorkTracker).toHaveBeenCalledWith('app-1');
@@ -69,7 +69,7 @@ describe('EditAppModal work tracker selector', () => {
   });
 
   it('updates the selection locally and includes workTracker in the save payload', async () => {
-    render(<EditAppModal app={APP} onClose={() => {}} onSave={() => {}} />);
+    render(<EditAppDrawer app={APP} onClose={() => {}} onSave={() => {}} />);
 
     const select = await screen.findByLabelText('Work Tracker');
     fireEvent.change(select, { target: { value: 'gitlab' } });

--- a/client/src/components/apps/tabs/OverviewTab.jsx
+++ b/client/src/components/apps/tabs/OverviewTab.jsx
@@ -4,7 +4,6 @@ import toast from '../../ui/Toast';
 import { NON_PM2_TYPES } from '../constants';
 import BrailleSpinner from '../../BrailleSpinner';
 import KanbanBoard from '../../KanbanBoard';
-import EditAppModal from '../EditAppModal';
 import ActivityLog from '../ActivityLog';
 import SlashDoPanel from '../SlashDoPanel';
 import Banner from '../../ui/Banner';
@@ -19,7 +18,6 @@ const SCRIPT_ICONS = {
 };
 
 export default function OverviewTab({ app, onRefresh }) {
-  const [editingApp, setEditingApp] = useState(null);
   const [refreshingConfig, setRefreshingConfig] = useState(false);
   const [archiving, setArchiving] = useState(false);
   const [jiraTickets, setJiraTickets] = useState(null);
@@ -313,12 +311,6 @@ export default function OverviewTab({ app, onRefresh }) {
             {standardizing ? 'Standardizing...' : 'Standardize PM2'}
           </button>
         )}
-        <button
-          onClick={() => setEditingApp(app)}
-          className="px-3 py-1.5 bg-port-accent/20 text-port-accent hover:bg-port-accent/30 rounded-lg text-xs flex items-center gap-1"
-        >
-          Edit
-        </button>
         {app.id !== api.PORTOS_APP_ID && (
           <button
             onClick={app.archived ? handleUnarchive : handleArchive}
@@ -337,15 +329,6 @@ export default function OverviewTab({ app, onRefresh }) {
 
       {/* Activity Log */}
       <ActivityLog steps={steps} error={error} completed={completed} />
-
-      {/* Edit Modal */}
-      {editingApp && (
-        <EditAppModal
-          app={editingApp}
-          onClose={() => setEditingApp(null)}
-          onSave={() => { setEditingApp(null); onRefresh(); }}
-        />
-      )}
     </div>
   );
 }

--- a/client/src/components/ui/Modal.jsx
+++ b/client/src/components/ui/Modal.jsx
@@ -17,7 +17,7 @@
  *   none   no width clamp (caller owns sizing via panelClassName)
  *
  * Divergent call-site behavior is opt-in via flags:
- *   closeOnBackdrop=false   EditAppModal / MemoryEditModal / ResumeAgentModal
+ *   closeOnBackdrop=false   MemoryEditModal / ResumeAgentModal
  *                           — long forms where an accidental click on the
  *                           overlay would lose typed state.
  *   closeOnEsc=false        Flux2InstallModal — never wired Esc pre-refactor.

--- a/client/src/services/apiApps.js
+++ b/client/src/services/apiApps.js
@@ -6,7 +6,7 @@ export const getApps = (options) => request('/apps', options);
 export const getApp = (id) => request(`/apps/${id}`);
 // Resolves what the app's `workTracker` field ('auto' or explicit) actually
 // points to: { configured, resolved, host, forge, source }. Read-only — the
-// caller (EditAppModal) owns its own .catch fallback, so default to silent.
+// caller (EditAppDrawer) owns its own .catch fallback, so default to silent.
 export const getAppWorkTracker = (id, options) =>
   request(`/apps/${id}/work-tracker`, { silent: true, ...options });
 export const createApp = (data) => request('/apps', {


### PR DESCRIPTION
## Summary

On the app-manager detail pages, the **Edit** button now lives in the top-right header button set (alongside Start/Stop/Restart, Launch, Build, and Deploy) instead of buried in the Overview tab's quick-actions row. The edit form opens as a **right-side slide-in drawer** rather than a centered modal.

- `EditAppModal` → renamed to `EditAppDrawer`, now built on the shared `Drawer` component instead of `Modal`.
- The shared `Drawer` gains optional `closeOnEsc` / `closeOnBackdrop` props (both default `true`, preserving behavior for its 6 existing callers). The edit drawer sets both to `false` to keep the old modal's no-accidental-dismiss guarantee for the long, nested form.
- `Drawer` now reuses the existing `useScrollLock` hook for body-scroll locking (ref-counted, composes safely with other overlays) instead of hand-rolling `document.body.style.overflow`.
- Edit state lifted from `OverviewTab` to `AppDetailView` (the route view that owns the header actions). The drawer closes automatically when navigating to a different app, so its form state can't be saved against a newly-loaded app id.

## Test plan

- `client` vitest: `EditAppDrawer.test.jsx` (work-tracker selector + save payload) and `Drawer` tests pass (6 tests).
- Local review gate + multi-reviewer loop (claude, ollama, codex) — all clean. Codex caught a stale-form-save-on-navigation regression, fixed in this PR.