### PR TITLE
Add 'Visit' button to HuggingFace model search cards

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -716,18 +716,32 @@ export function LocalLlmTab() {
                         })}
                       </div>
                     </div>
-                    {m.installed ? (
-                      <span className="text-xs px-2 py-1 text-port-success shrink-0">Installed</span>
-                    ) : (
-                      <button
-                        onClick={() => install(m.id)}
-                        disabled={busy}
-                        className="px-2.5 py-1 text-xs bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded disabled:opacity-50 flex items-center gap-1 shrink-0"
-                      >
-                        {actionInProgress === `install-${m.id}` ? <BrailleSpinner /> : <Download size={12} />}
-                        Install
-                      </button>
-                    )}
+                    <div className="flex flex-col items-end gap-1 shrink-0">
+                      {m.installed ? (
+                        <span className="text-xs px-2 py-1 text-port-success">Installed</span>
+                      ) : (
+                        <button
+                          onClick={() => install(m.id)}
+                          disabled={busy}
+                          className="px-2.5 py-1 text-xs bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded disabled:opacity-50 flex items-center gap-1"
+                        >
+                          {actionInProgress === `install-${m.id}` ? <BrailleSpinner /> : <Download size={12} />}
+                          Install
+                        </button>
+                      )}
+                      {isHf && m.repository && (
+                        <a
+                          href={`https://huggingface.co/${m.repository}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title="Open the model page on Hugging Face"
+                          className="px-2.5 py-1 text-xs bg-port-border/60 hover:bg-port-border text-gray-300 rounded flex items-center gap-1"
+                        >
+                          <ExternalLink size={12} />
+                          Visit
+                        </a>
+                      )}
+                    </div>
                   </div>
                   );
                 })}


### PR DESCRIPTION
## Summary
When searching local LLMs on Hugging Face, the result cards displayed the model URL/id but offered no way to open the model's page. This adds a **Visit** link button to each HuggingFace search-result card that opens `https://huggingface.co/<repository>` in a new tab.

## Changes
- `client/src/components/settings/LocalLlmTab.jsx`: wrapped the right-side card actions (Install / Installed) in a `flex-col` column and added an external-link "Visit" button for HuggingFace-source models. Reuses the file's existing `ExternalLink` icon and `target="_blank" rel="noopener noreferrer"` anchor convention. Gated on `isHf && m.repository` so non-HF catalog entries (which lack a repo path) don't render a broken link.

## Review
- Local code review gate: clean
- Reviewers: claude (clean), codex (clean)