### PR TITLE
fix: make context windows model-aware

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -2,6 +2,7 @@
 
 ## Fixed
 
+- AI provider context-window planning is now model-aware: known Claude model windows are used after explicit provider overrides and before local `num_ctx`, and the provider settings UI shows/edits the planning window so mixed-model providers no longer collapse to one blunt 128K budget.
 - **AI fixers can no longer take down the whole server with `pm2 kill`.** PortOS runs every managed app under one shared pm2 daemon, so `pm2 kill` / `pm2 delete all` stops *everything* — including PortOS itself. A "Fix with AI" / autofixer agent (which runs its CLI fully unrestricted) could be talked into running one while trying to "restart the app." Three layers now block this: (1) the shell-command allowlist (`validateCommand`) rejects `pm2 kill`/`startup`/`unstartup` and any `pm2 <verb> all` for the manual command runner and autonomous jobs; (2) spawned AI agents (CoS tasks, the autofixer app) get a guarded `pm2` shim prepended to their PATH that intercepts those same destructive subcommands before they reach the real pm2 — a hard guard that holds even under `--dangerously-skip-permissions`; (3) every agent prompt now states the shared-daemon rule and to only `pm2 restart <its-own-process>`. Scoped commands (`pm2 restart my-app`, `pm2 logs my-app`, `pm2 list`) still work.
 
 ## Changed

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -2,11 +2,12 @@ import { useState, useEffect, useCallback } from 'react';
 import toast from '../components/ui/Toast';
 import * as api from '../services/api';
 import socket from '../services/socket';
-import { filterSelectableModels, filterGenerationModels, isEmbeddingModel, mergeModelLists, localBackendForProvider, modelOptionLabel, providerTypeClass, isTuiProvider, isApiProvider, isProcessProvider, isClaudeCodePlanCli } from '../utils/providers';
+import { filterSelectableModels, filterGenerationModels, isEmbeddingModel, mergeModelLists, localBackendForProvider, modelOptionLabel, providerTypeClass, isTuiProvider, isApiProvider, isProcessProvider, isClaudeCodePlanCli, effectiveModelContextWindow } from '../utils/providers';
 import useLocalModels from '../hooks/useLocalModels';
 import EmptyState from '../components/EmptyState';
 import {
   formatDurationMs,
+  formatContextLength,
   parseTimeoutMs,
   TIMEOUT_INPUT_MIN_MS,
   TIMEOUT_INPUT_MAX_MS,
@@ -498,6 +499,15 @@ export default function AIProviders() {
                   {provider.defaultModel && (
                     <p className="break-words">Default: <code className="text-gray-300 break-all">{provider.defaultModel}</code></p>
                   )}
+                  {(() => {
+                    const windowLabel = formatContextLength(effectiveModelContextWindow(provider, provider.defaultModel));
+                    return windowLabel ? (
+                      <p className="text-xs">
+                        Context: <span className="text-gray-300">{windowLabel}</span>
+                        {provider.contextWindow ? <span className="text-gray-500"> override</span> : null}
+                      </p>
+                    ) : null;
+                  })()}
                   {(provider.lightModel || provider.mediumModel || provider.heavyModel) && (
                     <p className="text-xs">
                       Tiers:
@@ -685,6 +695,8 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [] }) {
     heavyModel: provider?.heavyModel || '',
     fallbackProvider: provider?.fallbackProvider || '',
     fallbackModel: provider?.fallbackModel || '',
+    numCtx: provider?.numCtx ?? '',
+    contextWindow: provider?.contextWindow ?? '',
     timeout: provider?.timeout || 300000,
     enabled: provider?.enabled !== false,
     envVars: provider?.envVars || {},
@@ -723,6 +735,14 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [] }) {
   const fallbackModelOptions = filterGenerationModels(
     mergeModelLists(selectedFallbackProvider?.models, liveModelsFor(selectedFallbackProvider)),
   );
+  const plannedContextLabel = formatContextLength(
+    effectiveModelContextWindow(formData, formData.defaultModel)
+  );
+  const parseOptionalIntField = (value) => {
+    const input = String(value ?? '').trim();
+    if (!input) return null;
+    return /^\d+$/.test(input) ? Number(input) : value;
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -744,6 +764,8 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [] }) {
       ...formData,
       args: formData.args ? formData.args.split(' ').filter(Boolean) : [],
       headlessArgs: formData.headlessArgs ? formData.headlessArgs.split(' ').filter(Boolean) : [],
+      contextWindow: parseOptionalIntField(formData.contextWindow),
+      numCtx: formData.type === 'api' ? parseOptionalIntField(formData.numCtx) : null,
     };
     // The generation/fallback pickers filter out embedding-only models, so a
     // stored embedding (from an older config) would be hidden in the UI yet
@@ -1082,6 +1104,47 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [] }) {
                   : `Per-call cap. Server max: ${TIMEOUT_INPUT_MAX_MS.toLocaleString()} ms (${formatDurationMs(TIMEOUT_INPUT_MAX_MS)}).`;
               })()}
             </p>
+          </div>
+
+          <div className="border-t border-port-border pt-4 mt-4">
+            <h4 className="text-sm font-medium text-gray-300 mb-3">Context Window</h4>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm text-gray-400 mb-1">Planning Window</label>
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  min="512"
+                  max="2097152"
+                  value={formData.contextWindow}
+                  onChange={(e) => setFormData(prev => ({ ...prev, contextWindow: e.target.value }))}
+                  placeholder="Auto from model"
+                  className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+                />
+                <p className="text-xs text-gray-500 mt-1">
+                  {plannedContextLabel ? `Budgeter uses ${plannedContextLabel}` : 'Leave blank to use model/provider defaults'}
+                </p>
+              </div>
+
+              {formData.type === 'api' && (
+                <div>
+                  <label className="block text-sm text-gray-400 mb-1">Local num_ctx</label>
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    min="512"
+                    max="1048576"
+                    value={formData.numCtx}
+                    onChange={(e) => setFormData(prev => ({ ...prev, numCtx: e.target.value }))}
+                    placeholder="Ollama request size"
+                    className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    Sent to compatible local backends; used for planning when no model window is known.
+                  </p>
+                </div>
+              )}
+            </div>
           </div>
 
           {/* Fallback Provider */}

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -8,6 +8,23 @@ import { formatContextLength } from './formatters.js';
 export const CODEX_CONFIGURED_DEFAULT = 'codex-configured-default';
 export const ANTIGRAVITY_CONFIGURED_DEFAULT = 'antigravity-configured-default';
 
+export const DEFAULT_LARGE_CONTEXT_WINDOW = 128_000;
+
+// Keep in sync with server/lib/stageRunner.js. Only Opus 4.8 is special-cased
+// at 1M; unknown Opus 4 variants intentionally keep the conservative provider
+// fallback until their windows are explicitly known.
+const KNOWN_MODEL_CONTEXT_WINDOWS = Object.freeze([
+  [/claude[-_.:/]?opus[-_.:/]?4[-_.:/]?8/i, 1_000_000],
+  [/claude[-_.:/]?sonnet[-_.:/]?4(?:[-_.:/]|\b)/i, 200_000],
+  [/claude[-_.:/]?haiku[-_.:/]?4(?:[-_.:/]|\b)/i, 200_000],
+]);
+
+export const knownModelContextWindow = (model) => {
+  if (typeof model !== 'string' || !model.trim()) return null;
+  const found = KNOWN_MODEL_CONTEXT_WINDOWS.find(([pattern]) => pattern.test(model));
+  return found ? found[1] : null;
+};
+
 /**
  * Provider-type enum mirrored from server/lib/aiToolkit/constants.js#PROVIDER_TYPES.
  * The aiToolkit directory is kept self-contained (no imports out to other PortOS
@@ -97,6 +114,25 @@ export const localBackendForProvider = (provider) => {
   return null;
 };
 
+const LOCAL_ENDPOINT_RE = /^(https?:\/\/)?(localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?)(:|\/|$)/i;
+const isLocalEndpoint = (endpoint) =>
+  typeof endpoint === 'string' && LOCAL_ENDPOINT_RE.test(endpoint.trim());
+
+export const isLikelyLargeContextProvider = (provider) => {
+  if (isProcessProvider(provider)) return true;
+  return isApiProvider(provider) && !isLocalEndpoint(provider.endpoint);
+};
+
+export const effectiveModelContextWindow = (provider, model) => {
+  const explicit = Number(provider?.contextWindow);
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  const known = knownModelContextWindow(model);
+  if (known) return known;
+  const numCtx = Number(provider?.numCtx);
+  if (Number.isFinite(numCtx) && numCtx > 0) return numCtx;
+  return isLikelyLargeContextProvider(provider) ? DEFAULT_LARGE_CONTEXT_WINDOW : null;
+};
+
 /**
  * Union of one or more model-id lists, de-duplicated, order-preserving, falsy
  * values dropped. Used to merge a provider's stored `models` with the live
@@ -125,7 +161,7 @@ export const mergeModelLists = (...lists) => {
  * @returns {string}
  */
 export const modelOptionLabel = (id, ctxById) => {
-  const ctx = ctxById?.[id];
+  const ctx = ctxById?.[id] || knownModelContextWindow(id);
   const label = formatContextLength(ctx);
   return label ? `${id} (${label})` : id;
 };

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -9,6 +9,7 @@ import {
   isVisionModel,
   visionLocalModelFilter,
   localBackendForProvider,
+  effectiveModelContextWindow,
   mergeModelLists,
   modelOptionLabel,
   isTuiProvider,
@@ -233,6 +234,24 @@ describe('localBackendForProvider', () => {
     expect(localBackendForProvider({ endpoint: 'https://api.openai.com/v1', name: 'OpenAI' })).toBeNull();
     expect(localBackendForProvider({})).toBeNull();
     expect(localBackendForProvider(null)).toBeNull();
+  });
+});
+
+describe('effectiveModelContextWindow', () => {
+  it('matches known model windows before provider defaults', () => {
+    expect(effectiveModelContextWindow({ type: 'tui' }, 'claude-opus-4-8')).toBe(1_000_000);
+    expect(effectiveModelContextWindow({ type: 'api', endpoint: 'https://api.example.test/v1' }, 'claude-sonnet-4-6')).toBe(200_000);
+  });
+
+  it('matches the server planner for local and cloud api defaults', () => {
+    expect(effectiveModelContextWindow({ type: 'api', endpoint: 'http://localhost:8000/v1' }, 'unknown')).toBeNull();
+    expect(effectiveModelContextWindow({ type: 'api', endpoint: 'http://127.0.0.1:8000/v1' }, 'unknown')).toBeNull();
+    expect(effectiveModelContextWindow({ type: 'api', endpoint: 'https://api.example.test/v1' }, 'unknown')).toBe(128_000);
+  });
+
+  it('uses explicit contextWindow and numCtx with server precedence', () => {
+    expect(effectiveModelContextWindow({ type: 'api', endpoint: 'http://localhost:11434/v1', contextWindow: 64_000, numCtx: 32_768 }, 'unknown')).toBe(64_000);
+    expect(effectiveModelContextWindow({ type: 'api', endpoint: 'http://localhost:11434/v1', numCtx: 32_768 }, 'unknown')).toBe(32_768);
   });
 });
 

--- a/server/lib/stageRunner.js
+++ b/server/lib/stageRunner.js
@@ -91,6 +91,21 @@ export function resolveModel(provider, modelHint) {
 // large manuscripts can set an explicit `contextWindow` to lift it further.
 export const DEFAULT_LARGE_CONTEXT_WINDOW = 128_000;
 
+// Keep in sync with client/src/utils/providers.js. Only Opus 4.8 is
+// special-cased at 1M; unknown Opus 4 variants intentionally keep the
+// conservative provider fallback until their windows are explicitly known.
+const KNOWN_MODEL_CONTEXT_WINDOWS = Object.freeze([
+  [/claude[-_.:/]?opus[-_.:/]?4[-_.:/]?8/i, 1_000_000],
+  [/claude[-_.:/]?sonnet[-_.:/]?4(?:[-_.:/]|\b)/i, 200_000],
+  [/claude[-_.:/]?haiku[-_.:/]?4(?:[-_.:/]|\b)/i, 200_000],
+]);
+
+export function knownModelContextWindow(model) {
+  if (typeof model !== 'string' || !model.trim()) return null;
+  const found = KNOWN_MODEL_CONTEXT_WINDOWS.find(([pattern]) => pattern.test(model));
+  return found ? found[1] : null;
+}
+
 const LOCAL_ENDPOINT_RE = /^(https?:\/\/)?(localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?)(:|\/|$)/i;
 const isLocalEndpoint = (endpoint) =>
   typeof endpoint === 'string' && LOCAL_ENDPOINT_RE.test(endpoint.trim());
@@ -104,12 +119,15 @@ const isLikelyLargeContextProvider = (provider) => {
   return false;
 };
 
-// Planning-time context window for a provider: an explicit `contextWindow`
-// wins, else the Ollama per-request `numCtx`, else a large default for frontier
-// providers, else null (the budgeter applies a conservative floor for unknown
-// local backends). Model-level windows can be layered in later.
-export function effectiveContextWindow(provider) {
+// Planning-time context window for a provider/model: an explicit
+// `contextWindow` wins, else a known model window for the resolved model, else
+// the Ollama per-request `numCtx`, else a large default for frontier providers,
+// else null (the budgeter applies a conservative floor for unknown local
+// backends).
+export function effectiveContextWindow(provider, model) {
   if (Number(provider?.contextWindow) > 0) return Number(provider.contextWindow);
+  const modelWindow = knownModelContextWindow(model);
+  if (modelWindow) return modelWindow;
   if (Number(provider?.numCtx) > 0) return Number(provider.numCtx);
   if (isLikelyLargeContextProvider(provider)) return DEFAULT_LARGE_CONTEXT_WINDOW;
   return null;
@@ -126,8 +144,9 @@ export function effectiveContextWindow(provider) {
 export async function resolveStageContext(stageName, options = {}) {
   const stage = getStage(stageName);
   const provider = await resolveProviderForStage(stage, options);
-  const model = resolveModel(provider, options.modelOverride || stage?.model);
-  return { provider, model, contextWindow: effectiveContextWindow(provider) };
+  const requestedModel = resolveModel(provider, options.modelOverride || stage?.model);
+  const model = resolveEffectiveModel(provider, requestedModel);
+  return { provider, model, contextWindow: effectiveContextWindow(provider, model) };
 }
 
 // Stage config can pin a specific provider via `stage.provider`. If set we

--- a/server/lib/stageRunner.test.js
+++ b/server/lib/stageRunner.test.js
@@ -14,6 +14,7 @@ vi.mock('../services/runner.js', () => ({
   createRun: vi.fn(async () => ({ runId: 'run-abc12345' })),
   executeApiRun: vi.fn(),
   executeCliRun: vi.fn(),
+  extractBakedModel: vi.fn(() => null),
   hasModelFlag: vi.fn(() => false),
   patchRunMetadata: vi.fn(async () => undefined),
 }));
@@ -21,7 +22,16 @@ vi.mock('../services/runner.js', () => ({
 const providers = await import('../services/providers.js');
 const prompts = await import('../services/promptService.js');
 const runner = await import('../services/runner.js');
-const { runStagedLLM, runInlineLLM, resolveModel, extractJson } = await import('./stageRunner.js');
+const {
+  runStagedLLM,
+  runInlineLLM,
+  resolveModel,
+  extractJson,
+  DEFAULT_LARGE_CONTEXT_WINDOW,
+  effectiveContextWindow,
+  knownModelContextWindow,
+  resolveStageContext,
+} = await import('./stageRunner.js');
 
 const apiProvider = (extra = {}) => ({
   id: 'mock-api', name: 'Mock', type: 'api', enabled: true, defaultModel: 'm-default', ...extra,
@@ -32,6 +42,8 @@ const cliProvider = (extra = {}) => ({
 
 beforeEach(() => {
   vi.clearAllMocks();
+  runner.extractBakedModel.mockReturnValue(null);
+  runner.hasModelFlag.mockReturnValue(false);
 });
 
 describe('stageRunner — resolveModel', () => {
@@ -66,6 +78,58 @@ describe('stageRunner — resolveModel', () => {
     expect(resolveModel({}, null)).toBeNull();
     expect(resolveModel({ models: [] }, null)).toBeNull();
     expect(resolveModel({}, 'heavy')).toBeNull();
+  });
+});
+
+describe('stageRunner — context windows', () => {
+  it('resolves known model windows from the selected model id', () => {
+    expect(knownModelContextWindow('claude-opus-4-8')).toBe(1_000_000);
+    expect(knownModelContextWindow('claude-sonnet-4-6')).toBe(200_000);
+    expect(knownModelContextWindow('us.anthropic.claude-sonnet-4-5-20250929-v1:0')).toBe(200_000);
+    expect(knownModelContextWindow('unknown-model')).toBeNull();
+  });
+
+  it('keeps an explicit provider contextWindow above model defaults', () => {
+    expect(effectiveContextWindow(
+      { type: 'tui', contextWindow: 64_000 },
+      'claude-opus-4-8'
+    )).toBe(64_000);
+  });
+
+  it('uses model windows before provider numCtx', () => {
+    expect(effectiveContextWindow(
+      { type: 'api', endpoint: 'http://localhost:11434/v1', numCtx: 32_768 },
+      'claude-sonnet-4-6'
+    )).toBe(200_000);
+  });
+
+  it('falls back to numCtx, large-provider default, or null', () => {
+    expect(effectiveContextWindow(
+      { type: 'api', endpoint: 'http://localhost:11434/v1', numCtx: 32_768 },
+      'unknown-local-model'
+    )).toBe(32_768);
+    expect(effectiveContextWindow(
+      { type: 'cli' },
+      'unknown-cli-model'
+    )).toBe(DEFAULT_LARGE_CONTEXT_WINDOW);
+    expect(effectiveContextWindow(
+      { type: 'api', endpoint: 'http://localhost:1234/v1' },
+      'unknown-local-model'
+    )).toBeNull();
+  });
+
+  it('budgets with the effective model when a CLI provider has a baked model flag', async () => {
+    prompts.getStage.mockReturnValue(null);
+    providers.getActiveProvider.mockResolvedValue(cliProvider({
+      args: ['--model', 'claude-opus-4-8'],
+      defaultModel: 'claude-sonnet-4-6',
+    }));
+    runner.hasModelFlag.mockReturnValue(true);
+    runner.extractBakedModel.mockReturnValue('claude-opus-4-8');
+
+    const context = await resolveStageContext('any-stage');
+    expect(context.model).toBe('claude-opus-4-8');
+    expect(context.contextWindow).toBe(1_000_000);
   });
 });
 


### PR DESCRIPTION
## Summary
- resolve planning context windows from the selected model before falling back to provider numCtx/defaults
- show the effective planning window in provider settings and make contextWindow/numCtx editable
- cover the new precedence rules in stageRunner tests

## Test plan
- npm test --prefix server -- stageRunner.test.js contextBudget.test.js
- npm run build --prefix client

Closes #1507