### PR TITLE
feat: install music runtimes from track UI

### DIFF
--- a/client/src/components/install/RuntimeInstallModal.jsx
+++ b/client/src/components/install/RuntimeInstallModal.jsx
@@ -1,16 +1,10 @@
 /**
- * BYOV video runtime installer modal. Streams progress from
- * GET /api/video-gen/setup/runtime-install?runtime=<id> (SSE) and shows the
- * raw bash output line-by-line so the user sees git-clone / uv venv / pip
- * progress as the script runs.
+ * Runtime installer modal for BYO local generation runtimes. Streams progress
+ * from a setup endpoint (SSE) and shows raw bash output line-by-line so the
+ * user sees git/uv/pip progress while scripts/setup-image-video.sh runs.
  *
- * Unlike Flux2InstallModal there's no animated stage pipeline — the underlying
- * scripts/setup-image-video.sh emits free-form log lines, not structured
- * stage events. Stage detection would require parsing bash echos, which
- * would rot every time the script's wording changes.
- *
- * Closing the modal mid-install (X button or Cancel) terminates the
- * EventSource, which the server interprets as a SIGTERM to the bash child.
+ * Closing the modal mid-install terminates the EventSource, which the server
+ * interprets as a cancel and SIGTERMs the underlying bash child.
  */
 
 import { useEffect, useState } from 'react';
@@ -20,25 +14,24 @@ import Modal from '../ui/Modal';
 
 const MAX_LOG_LINES = 1000;
 
-export default function RuntimeInstallModal({ open, runtime, label, onClose, onComplete }) {
+export default function RuntimeInstallModal({
+  open,
+  runtime,
+  label,
+  onClose,
+  onComplete,
+  installUrlBase = '/api/video-gen/setup/runtime-install',
+  description = 'Cloning repo and installing python packages (large download on first run)...',
+}) {
   const [confirmingCancel, setConfirmingCancel] = useState(false);
-  // The shared install-stream hook owns the EventSource lifecycle, log
-  // accumulation, connection-lost handling and auto-scroll. Pip/git emit
-  // hundreds of lines/sec, so flush on a 100ms debounce instead of per-line.
-  // The runtime install has no structured `stage` events (the bash script
-  // emits free-form log lines), so `currentStage` is unused here.
+  const url = open && runtime ? `${installUrlBase}?runtime=${encodeURIComponent(runtime)}` : null;
   const { logs, done, error, streamStarted, logsEndRef, close } = useInstallStream(
-    open && runtime ? `/api/video-gen/setup/runtime-install?runtime=${encodeURIComponent(runtime)}` : null,
+    url,
     { enabled: open && !!runtime, onComplete, maxLogLines: MAX_LOG_LINES, flushMs: 100 },
   );
 
-  // Reset the cancel-confirm prompt whenever the modal closes so a reopen never
-  // starts mid-confirmation. (Stream state resets inside the hook.)
   useEffect(() => { if (!open || !runtime) setConfirmingCancel(false); }, [open, runtime]);
 
-  // True from the moment the EventSource opens — closing the modal between
-  // the open and the first log line must still confirm before killing the
-  // server-side bash child.
   const installRunning = streamStarted && !done && !error;
 
   const performClose = () => {
@@ -86,7 +79,7 @@ export default function RuntimeInstallModal({ open, runtime, label, onClose, onC
           {logs.length === 0 ? (
             <div className="text-gray-500 italic flex items-center gap-2">
               <Loader2 size={12} className="animate-spin" />
-              Connecting to installer…
+              Connecting to installer...
             </div>
           ) : (
             logs.map((entry, i) => (
@@ -130,10 +123,10 @@ export default function RuntimeInstallModal({ open, runtime, label, onClose, onC
             <>
               <span className="text-xs text-gray-400">
                 {done
-                  ? `✅ ${label || runtime} is ready. You can close this window.`
+                  ? `${label || runtime} is ready. You can close this window.`
                   : error
-                    ? '⚠️ Installer hit an error — see logs above.'
-                    : 'Cloning repo and installing python packages (large download on first run)…'}
+                    ? 'Installer hit an error - see logs above.'
+                    : description}
               </span>
               <button
                 onClick={handleClose}

--- a/client/src/components/music/MusicGenPanel.jsx
+++ b/client/src/components/music/MusicGenPanel.jsx
@@ -32,6 +32,7 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated }) {
   const [installing, setInstalling] = useState(false);
   const [installProgress, setInstallProgress] = useState(null);
   const [runtimeInstallEngine, setRuntimeInstallEngine] = useState(null);
+  const [userSelectedEngine, setUserSelectedEngine] = useState(false);
   const mountedRef = useRef(true);
   useEffect(() => () => { mountedRef.current = false; }, []);
 
@@ -127,6 +128,7 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated }) {
   if (engines.length === 0) return <div className="text-xs text-gray-500">No music generators available.</div>;
 
   const selectedUserModel = engine?.models?.find((m) => m.id === modelId && m.userAdded);
+  const showRuntimeInstallHint = !!engine && !engine.ready && (!!prompt?.trim() || userSelectedEngine);
 
   return (
     <div className="space-y-2 border border-port-border rounded-lg p-3 bg-port-bg/40">
@@ -139,7 +141,10 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated }) {
           <span className="block text-[11px] uppercase tracking-wider text-gray-500 mb-1">Engine</span>
           <select
             value={engineId}
-            onChange={(e) => setEngineId(e.target.value)}
+            onChange={(e) => {
+              setUserSelectedEngine(true);
+              setEngineId(e.target.value);
+            }}
             className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm"
           >
             {engines.map((e) => (
@@ -175,7 +180,7 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated }) {
         />
       </label>
 
-      {engine && !engine.ready ? (
+      {showRuntimeInstallHint ? (
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-lg border border-port-warning/30 bg-port-warning/10 px-3 py-2">
           <p className="text-[11px] text-port-warning">
             {engine.name} is not installed yet. Install the runtime to enable generation.

--- a/client/src/components/music/MusicGenPanel.jsx
+++ b/client/src/components/music/MusicGenPanel.jsx
@@ -7,7 +7,7 @@
  * updated track (the server attaches the audio + gen metadata).
  *
  * Engines that aren't provisioned (their opt-in venv is missing) are shown with
- * their install hint and the Generate button is gated — mirroring the FLUX.2
+ * an in-app install action and the Generate button is gated — mirroring the FLUX.2
  * venv gate in image gen. Additional HuggingFace checkpoints can be installed
  * inline (streamed download), then selected immediately.
  */
@@ -18,6 +18,7 @@ import toast from '../ui/Toast';
 import {
   listMusicEngines, generateMusic, installAudioModel, removeAudioModel,
 } from '../../services/api';
+import RuntimeInstallModal from '../install/RuntimeInstallModal';
 
 export default function MusicGenPanel({ track, prompt, lyrics, onGenerated }) {
   const [engines, setEngines] = useState([]);
@@ -30,6 +31,7 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated }) {
   const [installRepo, setInstallRepo] = useState('');
   const [installing, setInstalling] = useState(false);
   const [installProgress, setInstallProgress] = useState(null);
+  const [runtimeInstallEngine, setRuntimeInstallEngine] = useState(null);
   const mountedRef = useRef(true);
   useEffect(() => () => { mountedRef.current = false; }, []);
 
@@ -174,9 +176,19 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated }) {
       </label>
 
       {engine && !engine.ready ? (
-        <p className="text-[11px] text-port-warning">
-          {engine.name} isn’t installed. Run <code className="text-gray-300">{engine.installEnv}=1 bash scripts/setup-image-video.sh</code> to provision it.
-        </p>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-lg border border-port-warning/30 bg-port-warning/10 px-3 py-2">
+          <p className="text-[11px] text-port-warning">
+            {engine.name} is not installed yet. Install the runtime to enable generation.
+          </p>
+          <button
+            type="button"
+            onClick={() => setRuntimeInstallEngine(engine)}
+            className="inline-flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg bg-port-bg border border-port-warning/50 text-port-warning text-xs font-medium hover:border-port-warning disabled:opacity-50"
+          >
+            <Download size={13} />
+            Install runtime
+          </button>
+        </div>
       ) : null}
       {engine?.lyrics ? (
         <p className="text-[11px] text-gray-500">This engine uses the track’s lyrics as conditioning.</p>
@@ -232,6 +244,15 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated }) {
         {installProgress ? <p className="text-[11px] text-gray-500 mt-1 truncate">{installProgress.message}</p> : null}
       </div>
       ) : null}
+      <RuntimeInstallModal
+        open={!!runtimeInstallEngine}
+        runtime={runtimeInstallEngine?.id}
+        label={runtimeInstallEngine?.name}
+        installUrlBase="/api/music/setup/runtime-install"
+        description="Installing the music runtime and python packages. Large downloads may take several minutes."
+        onClose={() => setRuntimeInstallEngine(null)}
+        onComplete={() => loadEngines()}
+      />
     </div>
   );
 }

--- a/client/src/components/music/MusicGenPanel.test.jsx
+++ b/client/src/components/music/MusicGenPanel.test.jsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import MusicGenPanel from './MusicGenPanel';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  listMusicEngines: vi.fn(),
+  generateMusic: vi.fn(),
+  installAudioModel: vi.fn(),
+  removeAudioModel: vi.fn(),
+}));
+
+vi.mock('../install/RuntimeInstallModal', () => ({
+  default: ({ open, label }) => (open ? <div>Installing {label}</div> : null),
+}));
+
+const engine = (overrides) => ({
+  id: 'musicgen',
+  name: 'MusicGen (MLX)',
+  models: [{ id: 'musicgen-medium', name: 'MusicGen Medium', userAdded: false }],
+  defaultModelId: 'musicgen-medium',
+  minDurationSec: 1,
+  maxDurationSec: 30,
+  defaultDurationSec: 12,
+  lyrics: false,
+  customModels: true,
+  ready: true,
+  ...overrides,
+});
+
+describe('MusicGenPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not show a missing-runtime warning immediately for an empty saved track', async () => {
+    api.listMusicEngines.mockResolvedValue({
+      defaultEngine: 'acestep',
+      engines: [
+        engine({
+          id: 'acestep',
+          name: 'ACE-Step (full song + vocals)',
+          models: [{ id: 'ace-step-v1-3.5b', name: 'ACE-Step v1 3.5B', userAdded: false }],
+          defaultModelId: 'ace-step-v1-3.5b',
+          maxDurationSec: 240,
+          defaultDurationSec: 60,
+          lyrics: true,
+          customModels: false,
+          ready: false,
+        }),
+      ],
+    });
+
+    const { rerender } = render(<MusicGenPanel track={{ id: 'track-1' }} prompt="" lyrics="" />);
+
+    await waitFor(() => expect(screen.getByRole('combobox', { name: /engine/i })).toHaveValue('acestep'));
+    expect(screen.queryByText(/ACE-Step .* is not installed yet/i)).not.toBeInTheDocument();
+
+    rerender(<MusicGenPanel track={{ id: 'track-1' }} prompt="warm folk song" lyrics="" />);
+    expect(await screen.findByText(/ACE-Step .* is not installed yet/i)).toBeInTheDocument();
+  });
+
+  it('shows the missing-runtime warning when the user explicitly selects a missing engine', async () => {
+    api.listMusicEngines.mockResolvedValue({
+      defaultEngine: 'musicgen',
+      engines: [
+        engine({ id: 'musicgen', name: 'MusicGen (MLX)', ready: true }),
+        engine({
+          id: 'acestep',
+          name: 'ACE-Step (full song + vocals)',
+          models: [{ id: 'ace-step-v1-3.5b', name: 'ACE-Step v1 3.5B', userAdded: false }],
+          defaultModelId: 'ace-step-v1-3.5b',
+          maxDurationSec: 240,
+          defaultDurationSec: 60,
+          lyrics: true,
+          customModels: false,
+          ready: false,
+        }),
+      ],
+    });
+
+    render(<MusicGenPanel track={{ id: 'track-1' }} prompt="" lyrics="" />);
+
+    const select = await screen.findByRole('combobox', { name: /engine/i });
+    expect(select).toHaveValue('musicgen');
+    expect(screen.queryByText(/ACE-Step .* is not installed yet/i)).not.toBeInTheDocument();
+
+    fireEvent.change(select, { target: { value: 'acestep' } });
+    expect(await screen.findByText(/ACE-Step .* is not installed yet/i)).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -29,7 +29,7 @@ import { useSearchParams, useNavigate, Link } from 'react-router-dom';
 import Drawer from '../components/Drawer';
 import { ImageGenTab } from '../components/settings/ImageGenTab';
 import LocalSetupPanel from '../components/settings/LocalSetupPanel';
-import RuntimeInstallModal from '../components/videoGen/RuntimeInstallModal';
+import RuntimeInstallModal from '../components/install/RuntimeInstallModal';
 import FramePanel from '../components/videoGen/FramePanel';
 import KeyframePanel from '../components/videoGen/KeyframePanel';
 import AudioPanel from '../components/videoGen/AudioPanel';

--- a/server/routes/music.js
+++ b/server/routes/music.js
@@ -17,12 +17,17 @@
  */
 
 import { Router } from 'express';
+import { existsSync } from 'fs';
+import { spawn } from 'child_process';
+import { join } from 'path';
 import { z } from 'zod';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { validateRequest } from '../lib/validation.js';
+import { PATHS } from '../lib/fileUtils.js';
+import { safeChildProcessEnv } from '../lib/processEnv.js';
 import { ENGINES, DEFAULT_ENGINE_ID, getEngine, isEngineReady, generateMusic } from '../services/pipeline/musicGen.js';
 import { listEngineModels, addAudioModel, removeAudioModel, isValidRepoId } from '../services/audioModels.js';
-import { startHfDownloadStream } from '../lib/sseDownload.js';
+import { startHfDownloadStream, openSseStream } from '../lib/sseDownload.js';
 import { inspectModelCache } from '../lib/hfCache.js';
 import * as tracks from '../services/tracks/index.js';
 import * as albums from '../services/albums/index.js';
@@ -52,6 +57,108 @@ router.get('/engines', asyncHandler(async (_req, res) => {
     venvDefault: engine.venvDefault,
   })));
   res.json({ engines, defaultEngine: DEFAULT_ENGINE_ID });
+}));
+
+// --- Install music runtime venvs -------------------------------------------
+// Mirrors the image/video in-app setup flow: the client opens an EventSource
+// and we shell out to the canonical setup script with the selected engine's
+// INSTALL_* env var set. Keeping the bash path as the single installer source
+// avoids a second Node implementation drifting from scripts/setup-image-video.sh.
+
+router.get('/setup/runtime-status', asyncHandler(async (req, res) => {
+  const runtime = String(req.query?.runtime || '');
+  const engine = ENGINES[runtime];
+  if (!engine) {
+    throw new ServerError(
+      `Unknown music runtime: ${runtime}. Expected one of: ${Object.keys(ENGINES).join(', ')}`,
+      { status: 400, code: 'UNKNOWN_MUSIC_RUNTIME' },
+    );
+  }
+  res.json({
+    runtime: engine.id,
+    label: engine.name,
+    installed: isEngineReady(engine.id),
+    venvPath: engine.resolvePython() || null,
+    expectedVenvPath: engine.venvDefault,
+    installEnvVar: engine.installEnv,
+  });
+}));
+
+const runtimeInstallInFlight = new Map();
+
+router.get('/setup/runtime-install', asyncHandler(async (req, res) => {
+  const runtime = String(req.query?.runtime || '');
+  const engine = ENGINES[runtime];
+  const { send, safeEnd } = openSseStream(res);
+
+  if (!engine) {
+    send({ type: 'error', message: `Unknown music runtime: ${runtime}` });
+    return safeEnd();
+  }
+  if (runtimeInstallInFlight.has(engine.id)) {
+    send({ type: 'error', message: `Another ${engine.name} install is already running. Wait for it to finish or restart PortOS.` });
+    return safeEnd();
+  }
+  runtimeInstallInFlight.set(engine.id, null);
+
+  if (isEngineReady(engine.id)) {
+    runtimeInstallInFlight.delete(engine.id);
+    send({ type: 'log', message: `${engine.name} already installed at ${engine.resolvePython() || engine.venvDefault}` });
+    send({ type: 'complete', message: 'Already installed - nothing to do.' });
+    return safeEnd();
+  }
+
+  const scriptPath = join(PATHS.root, 'scripts', 'setup-image-video.sh');
+  if (!existsSync(scriptPath)) {
+    runtimeInstallInFlight.delete(engine.id);
+    send({ type: 'error', message: `Installer script not found at ${scriptPath}` });
+    return safeEnd();
+  }
+
+  send({ type: 'log', message: `Starting ${engine.name} install.` });
+  const child = spawn('bash', [scriptPath], {
+    env: safeChildProcessEnv({ [engine.installEnv]: '1' }),
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: true,
+  });
+  runtimeInstallInFlight.set(engine.id, child);
+  let finished = false;
+
+  const onChunk = (chunk) => {
+    for (const line of chunk.toString().split(/[\r\n]+/)) {
+      const t = line.trimEnd();
+      if (t) send({ type: 'log', message: t });
+    }
+  };
+  child.stdout.on('data', onChunk);
+  child.stderr.on('data', onChunk);
+  child.on('error', (err) => {
+    finished = true;
+    runtimeInstallInFlight.delete(engine.id);
+    send({ type: 'error', message: `Installer failed to spawn: ${err.message}` });
+    safeEnd();
+  });
+  child.on('close', (code) => {
+    finished = true;
+    runtimeInstallInFlight.delete(engine.id);
+    if (code === 0 && isEngineReady(engine.id)) {
+      send({ type: 'complete', message: `${engine.name} ready: ${engine.resolvePython() || engine.venvDefault}` });
+    } else if (code === 0) {
+      send({ type: 'error', message: `Installer exited 0 but ${engine.name} is still not available. Check the log above for setup errors.` });
+    } else {
+      send({ type: 'error', message: `Installer exited with code ${code}.` });
+    }
+    safeEnd();
+  });
+
+  req.on('close', () => {
+    if (finished) return;
+    if (!child.killed && child.pid) {
+      try { process.kill(-child.pid, 'SIGTERM'); }
+      catch { child.kill('SIGTERM'); }
+    }
+    safeEnd();
+  });
 }));
 
 // --- Install additional audio models from HuggingFace -----------------------

--- a/server/routes/music.test.js
+++ b/server/routes/music.test.js
@@ -6,7 +6,11 @@ import { ServerError } from '../lib/errorHandler.js';
 // Mock the music-gen service: a small engine registry + a generateMusic that the
 // tests drive per-case. The route only consumes ENGINES/getEngine/isEngineReady/
 // generateMusic + DEFAULT_ENGINE_ID.
-const gen = vi.hoisted(() => ({ generateMusic: vi.fn(), ready: true }));
+const gen = vi.hoisted(() => ({
+  generateMusic: vi.fn(),
+  ready: true,
+  readyByEngine: null,
+}));
 vi.mock('../services/pipeline/musicGen.js', () => {
   const ENGINES = {
     musicgen: { id: 'musicgen', name: 'MusicGen', models: [{ id: 'm', name: 'M' }], defaultModelId: 'm', minDurationSec: 1, maxDurationSec: 30, defaultDurationSec: 12, installEnv: 'INSTALL_MUSICGEN', venvDefault: '/v/mg', resolvePython: () => (gen.ready ? '/v/mg/bin/python3' : null), customModels: true },
@@ -16,7 +20,7 @@ vi.mock('../services/pipeline/musicGen.js', () => {
     ENGINES,
     DEFAULT_ENGINE_ID: 'musicgen',
     getEngine: (id) => ENGINES[id] || ENGINES.musicgen,
-    isEngineReady: () => gen.ready,
+    isEngineReady: (engineId) => (gen.readyByEngine ? gen.readyByEngine[engineId] === true : gen.ready),
     generateMusic: gen.generateMusic,
   };
 });
@@ -94,6 +98,7 @@ describe('music routes', () => {
     albums.updateAlbum.mockReset().mockImplementation(async (id, patch) => ({ id, ...patch }));
     sse.run.mockReset().mockImplementation(async ({ res }) => { res.writeHead(200, { 'Content-Type': 'text/event-stream' }); res.end('data: {"type":"complete"}\n\n'); });
     gen.ready = true;
+    gen.readyByEngine = null;
     cache.cached = true;
     models.list.mockResolvedValue([{ id: 'm', name: 'M', userAdded: false }]);
   });
@@ -110,6 +115,14 @@ describe('music routes', () => {
     const mg = r.body.engines.find((e) => e.id === 'musicgen');
     expect(mg.lyrics).toBe(false);
     expect(mg.customModels).toBe(true);
+  });
+
+  it('GET /engines reports readiness per engine', async () => {
+    gen.readyByEngine = { musicgen: true, acestep: false };
+    const r = await request(app).get('/api/music/engines');
+    expect(r.status).toBe(200);
+    expect(r.body.engines.find((e) => e.id === 'musicgen').ready).toBe(true);
+    expect(r.body.engines.find((e) => e.id === 'acestep').ready).toBe(false);
   });
 
   it('POST /models rejects an engine that does not support custom models (acestep)', async () => {

--- a/server/routes/music.test.js
+++ b/server/routes/music.test.js
@@ -9,8 +9,8 @@ import { ServerError } from '../lib/errorHandler.js';
 const gen = vi.hoisted(() => ({ generateMusic: vi.fn(), ready: true }));
 vi.mock('../services/pipeline/musicGen.js', () => {
   const ENGINES = {
-    musicgen: { id: 'musicgen', name: 'MusicGen', models: [{ id: 'm', name: 'M' }], defaultModelId: 'm', minDurationSec: 1, maxDurationSec: 30, defaultDurationSec: 12, installEnv: 'INSTALL_MUSICGEN', venvDefault: '/v/mg', customModels: true },
-    acestep: { id: 'acestep', name: 'ACE-Step', models: [{ id: 'a', name: 'A' }], defaultModelId: 'a', minDurationSec: 1, maxDurationSec: 240, defaultDurationSec: 60, installEnv: 'INSTALL_ACESTEP', venvDefault: '/v/ace', lyrics: true, customModels: false },
+    musicgen: { id: 'musicgen', name: 'MusicGen', models: [{ id: 'm', name: 'M' }], defaultModelId: 'm', minDurationSec: 1, maxDurationSec: 30, defaultDurationSec: 12, installEnv: 'INSTALL_MUSICGEN', venvDefault: '/v/mg', resolvePython: () => (gen.ready ? '/v/mg/bin/python3' : null), customModels: true },
+    acestep: { id: 'acestep', name: 'ACE-Step', models: [{ id: 'a', name: 'A' }], defaultModelId: 'a', minDurationSec: 1, maxDurationSec: 240, defaultDurationSec: 60, installEnv: 'INSTALL_ACESTEP', venvDefault: '/v/ace', resolvePython: () => (gen.ready ? '/v/ace/bin/python3' : null), lyrics: true, customModels: false },
   };
   return {
     ENGINES,
@@ -37,8 +37,20 @@ vi.mock('../services/audioModels.js', () => ({
 
 // The SSE download driver writes to the response + ends it; stub it to a quick
 // 200 so the route test doesn't spawn Python.
-const sse = vi.hoisted(() => ({ run: vi.fn(async ({ res }) => { res.writeHead(200, { 'Content-Type': 'text/event-stream' }); res.end('data: {"type":"complete"}\n\n'); }) }));
-vi.mock('../lib/sseDownload.js', () => ({ startHfDownloadStream: (args) => sse.run(args) }));
+const sse = vi.hoisted(() => ({
+  run: vi.fn(async ({ res }) => { res.writeHead(200, { 'Content-Type': 'text/event-stream' }); res.end('data: {"type":"complete"}\n\n'); }),
+  open: vi.fn((res) => {
+    res.writeHead(200, { 'Content-Type': 'text/event-stream' });
+    return {
+      send: (event) => res.write(`data: ${JSON.stringify(event)}\n\n`),
+      safeEnd: () => { if (!res.writableEnded) res.end(); },
+    };
+  }),
+}));
+vi.mock('../lib/sseDownload.js', () => ({
+  startHfDownloadStream: (args) => sse.run(args),
+  openSseStream: (res) => sse.open(res),
+}));
 
 // Register-after-download gates on whether the repo landed in the cache.
 const cache = vi.hoisted(() => ({ cached: true }));
@@ -106,6 +118,34 @@ describe('music routes', () => {
     expect(r.body.code).toBe('AUDIO_MODEL_ENGINE_FIXED');
     expect(models.add).not.toHaveBeenCalled();
     expect(sse.run).not.toHaveBeenCalled();
+  });
+
+  it('GET /setup/runtime-status reports music runtime readiness', async () => {
+    gen.ready = false;
+    const missing = await request(app).get('/api/music/setup/runtime-status?runtime=acestep');
+    expect(missing.status).toBe(200);
+    expect(missing.body).toMatchObject({
+      runtime: 'acestep',
+      label: 'ACE-Step',
+      installed: false,
+      venvPath: null,
+      expectedVenvPath: '/v/ace',
+      installEnvVar: 'INSTALL_ACESTEP',
+    });
+
+    gen.ready = true;
+    const ready = await request(app).get('/api/music/setup/runtime-status?runtime=acestep');
+    expect(ready.status).toBe(200);
+    expect(ready.body.installed).toBe(true);
+    expect(ready.body.venvPath).toBe('/v/ace/bin/python3');
+  });
+
+  it('GET /setup/runtime-install completes without spawning when already installed', async () => {
+    gen.ready = true;
+    const r = await request(app).get('/api/music/setup/runtime-install?runtime=acestep');
+    expect(r.status).toBe(200);
+    expect(r.text).toContain('"type":"complete"');
+    expect(r.text).toContain('Already installed');
   });
 
   it('GET /models/:engine returns the merged model list; 404s for an unknown engine', async () => {


### PR DESCRIPTION

What changed:
- Replaced the ACE-Step CLI instruction in the track generator with an **Install runtime** button.
- Added `/api/music/setup/runtime-status` and `/api/music/setup/runtime-install` SSE endpoints.
- Reused the existing runtime install modal by moving it to a shared `components/install` location.
- Kept Video Gen using the same modal after the move.
- Added focused music route tests for runtime readiness/install behavior.

Validation passed:
- `npm test --prefix server -- routes/music.test.js`
- `npm run --prefix client lint -- --max-warnings=0`
- `npm run --prefix client build`
