### PR TITLE
Show context-window size on available local-model cards

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -16,6 +16,8 @@
 
 ## Added
 
+- **Context-window size on available-model cards (Settings → Local LLM).** The model cards in the install catalog and the Hugging Face search results now show each model's native context window (e.g. "128K ctx") alongside its size and parameter count — previously this only appeared on already-installed models, so you couldn't compare context windows before deciding what to install. Live Hugging Face results read the true value from the repo's GGUF metadata (`gguf.context_length`, backfilled from the same per-repo fetch that already supplies file sizes); curated catalog entries carry it when it's a documented spec for that build.
+
 - **Music studio (Create → Music).** A new home for generating and organizing music with local OSS tools, with three tabs:
   - **Artists** — reusable musical personas (the audio analogue of Authors): name, genre, bio, musical style, plus a physical description + portrait style used to **generate an artist portrait** with your existing image-gen options, **upload** one, or pick from the gallery.
   - **Albums** — ordered track collections under an artist, with **cover art** you generate (1024×1024 via your image-gen options), upload, or pick from the gallery; add tracks and reorder them.

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -706,6 +706,7 @@ export function LocalLlmTab() {
               <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
                 {group.models.map((m) => {
                   const ram = recommendedRamGb(m?.sizeBytes, m?.size);
+                  const ctxLabel = formatContextLength(m.contextLength);
                   const isHf = m.source === 'huggingface';
                   const isAudio = m.category === 'audio';
                   const createdMs = new Date(m.createdAt).getTime();
@@ -720,6 +721,9 @@ export function LocalLlmTab() {
                       <div className="flex items-center gap-1.5 flex-wrap text-[11px] text-gray-600 mt-1">
                         <span className="text-gray-500">{categoryLabel(m.category)}</span>
                         <span>{m.size}</span>
+                        {ctxLabel && (
+                          <span title="Native context window (max tokens)">{ctxLabel}</span>
+                        )}
                         {ram && (
                           <span title="Approx RAM/VRAM to run this model — weights + ~20% overhead">
                             ~{ram} GB RAM

--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -37,10 +37,13 @@ export const LOCAL_LLM_CATEGORIES = [
 ];
 
 // Each entry: { key, name, category, params, size, family, description, capabilities,
-//               ollama?, lmstudio? }
+//               context?, ollama?, lmstudio? }
 // `ollama` / `lmstudio` are the exact pull/download ids for that backend.
 // A missing id means there is no well-known build of that model for that
 // backend (the user can still free-text install one).
+// `context` is the model's native context window in tokens — set it only when
+// it's a documented spec for that build (the install-card badge shows it; live
+// Hugging Face results read the true value from GGUF metadata instead).
 export const LOCAL_LLM_CATALOG = [
   {
     key: 'llama3.2',
@@ -115,6 +118,7 @@ export const LOCAL_LLM_CATALOG = [
     family: 'mistral',
     description: 'Top-tier open-weight prose model with a 128K context window — best local pick for long-form narrative and editorial review. Needs ~96GB+ unified memory.',
     capabilities: ['chat', 'tools'],
+    context: 131072,
     ollama: 'mistral-large:123b'
   },
   {
@@ -126,6 +130,7 @@ export const LOCAL_LLM_CATALOG = [
     family: 'command-r',
     description: 'Cohere long-context model (128K) tuned for RAG and clean character-voice dialogue — strong for whole-manuscript continuity passes. Needs ~80GB+ unified memory.',
     capabilities: ['chat', 'tools', 'multilingual'],
+    context: 131072,
     ollama: 'command-r-plus:104b'
   },
   {
@@ -137,6 +142,7 @@ export const LOCAL_LLM_CATALOG = [
     family: 'llama',
     description: "Meta's 70B instruct model with a 128K context — excellent narrative quality with memory headroom to spare for a large context window. Runs on 64GB+.",
     capabilities: ['chat', 'tools'],
+    context: 131072,
     ollama: 'llama3.3:70b',
     lmstudio: 'lmstudio-community/Llama-3.3-70B-Instruct-GGUF'
   },
@@ -149,6 +155,7 @@ export const LOCAL_LLM_CATALOG = [
     family: 'qwen',
     description: 'Fast MoE with a native 256K context — the long-context workhorse for one-shot whole-manuscript review when you want maximum context with memory to spare.',
     capabilities: ['chat', 'tools', 'multilingual'],
+    context: 262144,
     ollama: 'qwen3:30b',
     lmstudio: 'lmstudio-community/Qwen3-30B-A3B-GGUF'
   },
@@ -161,6 +168,7 @@ export const LOCAL_LLM_CATALOG = [
     family: 'gemma',
     description: "Google's dense 31B with a 256K context window and vision — a strong long-context narrative editor that fits comfortably on 64GB+. MLX build on Apple Silicon: gemma4:31b-mlx.",
     capabilities: ['chat', 'vision'],
+    context: 262144,
     ollama: 'gemma4:31b',
     lmstudio: 'lmstudio-community/gemma-4-31B-it-GGUF'
   },
@@ -173,6 +181,7 @@ export const LOCAL_LLM_CATALOG = [
     family: 'gemma',
     description: "Google's MoE (4B active) with a 256K context window and vision — a fast long-context option for one-shot whole-manuscript review. MLX build on Apple Silicon: gemma4:26b-mlx.",
     capabilities: ['chat', 'vision'],
+    context: 262144,
     ollama: 'gemma4:26b',
     lmstudio: 'lmstudio-community/gemma-4-26B-A4B-it-GGUF'
   },
@@ -451,7 +460,7 @@ const normalizeFor = (backend, id) =>
  *
  * @param {string} backend - 'ollama' | 'lmstudio'
  * @param {string[]} [installedIds] - ids currently installed on that backend
- * @returns {Array<{ id, key, name, params, size, family, description, capabilities, installed }>}
+ * @returns {Array<{ id, key, name, params, size, family, description, capabilities, contextLength, installed }>}
  */
 export function getCatalog(backend, installedIds = []) {
   if (!isBackend(backend)) return [];
@@ -468,6 +477,8 @@ export function getCatalog(backend, installedIds = []) {
       family: entry.family,
       description: entry.description,
       capabilities: entry.capabilities,
+      // Native context window (tokens), when it's a documented spec; null otherwise.
+      contextLength: Number.isFinite(entry.context) ? entry.context : null,
       installed: installedNorm.has(normalizeFor(backend, entry[backend]))
     }));
 }

--- a/server/lib/localLlmCatalog.test.js
+++ b/server/lib/localLlmCatalog.test.js
@@ -48,6 +48,16 @@ describe('localLlmCatalog', () => {
     it('returns [] for an unknown backend', () => {
       expect(getCatalog('nope')).toEqual([]);
     });
+
+    it('surfaces a documented context window as contextLength, null otherwise', () => {
+      const ollama = getCatalog('ollama');
+      // mistral-large's description documents a 128K window.
+      expect(ollama.find((m) => m.key === 'mistral-large').contextLength).toBe(131072);
+      // qwen3-30b-a3b documents a native 256K window.
+      expect(ollama.find((m) => m.key === 'qwen3-30b-a3b').contextLength).toBe(262144);
+      // Entries with no documented window expose null (never undefined).
+      expect(ollama.find((m) => m.key === 'llama3.2').contextLength).toBeNull();
+    });
   });
 
   describe('searchCatalog', () => {

--- a/server/services/huggingFaceCatalog.js
+++ b/server/services/huggingFaceCatalog.js
@@ -301,6 +301,10 @@ function toResult(model, backend, requestedCategory, installedIds, installedAudi
     downloads: Number(model?.downloads || 0),
     likes: Number(model?.likes || 0),
     sizeBytes: Number.isFinite(file?.size) ? file.size : null,
+    // Native context window (tokens). The search endpoint omits the GGUF
+    // metadata block, so this is backfilled from the per-repo `?blobs=true`
+    // record in enrichWithSizes; stays null for audio repos (no `gguf` field).
+    contextLength: null,
     createdAt: model?.createdAt || model?.created_at || null,
     updatedAt: model?.lastModified || model?.last_modified || model?.updatedAt || null,
     license: licenseOf(model),
@@ -381,18 +385,37 @@ function sumWeightBytes(model) {
   return total > 0 ? total : null
 }
 
-// Backfill real file sizes for results the search endpoint left sizeless.
+// Native context window (tokens) for a GGUF repo. HF surfaces it under
+// `gguf.context_length` on the per-repo record (the search listing omits the
+// whole `gguf` block). Returns null for non-GGUF/audio repos or when absent.
+function contextLengthOf(model) {
+  const n = Number(model?.gguf?.context_length)
+  return Number.isFinite(n) && n > 0 ? n : null
+}
+
+// Backfill real file sizes AND native context windows from the per-model
+// `?blobs=true` record (the search listing carries neither). Both are fetched
+// from the same cached repo record, so a result missing either triggers one
+// (deduped) per-repo fetch.
 async function enrichWithSizes(results) {
   await Promise.allSettled(results.map(async (result) => {
-    if (Number.isFinite(result.sizeBytes)) return
+    const needsSize = !Number.isFinite(result.sizeBytes)
+    const needsContext = result.category !== 'audio' && result.contextLength == null
+    if (!needsSize && !needsContext) return
     const model = await fetchRepoModel(result.repository)
     if (!model) return
-    const bytes = result.category === 'audio'
-      ? sumWeightBytes(model)
-      : (() => { const picked = pickGgufFile(model); return Number.isFinite(picked?.size) ? picked.size : null })()
-    if (Number.isFinite(bytes)) {
-      result.sizeBytes = bytes
-      result.size = formatBytes(bytes) || result.size
+    if (needsSize) {
+      const bytes = result.category === 'audio'
+        ? sumWeightBytes(model)
+        : (() => { const picked = pickGgufFile(model); return Number.isFinite(picked?.size) ? picked.size : null })()
+      if (Number.isFinite(bytes)) {
+        result.sizeBytes = bytes
+        result.size = formatBytes(bytes) || result.size
+      }
+    }
+    if (needsContext) {
+      const ctx = contextLengthOf(model)
+      if (ctx != null) result.contextLength = ctx
     }
   }))
   return results

--- a/server/services/huggingFaceCatalog.test.js
+++ b/server/services/huggingFaceCatalog.test.js
@@ -93,6 +93,41 @@ describe('huggingFaceCatalog', () => {
     expect(results[0].size).toMatch(/\d+(\.\d+)?\s(MB|GB)/)
   })
 
+  it('backfills the native context window from the per-model gguf metadata', async () => {
+    fetch
+      .mockResolvedValueOnce(response([
+        {
+          modelId: 'lmstudio-community/Meta-Llama-3.1-8B-Instruct-GGUF',
+          downloads: 50,
+          tags: ['gguf'],
+          // search listing omits both the size and the gguf metadata block
+          siblings: [{ rfilename: 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf' }]
+        }
+      ]))
+      .mockResolvedValueOnce(response({
+        id: 'lmstudio-community/Meta-Llama-3.1-8B-Instruct-GGUF',
+        gguf: { context_length: 131072 },
+        siblings: [{ rfilename: 'Meta-Llama-3.1-8B-Instruct-Q4_K_M.gguf', size: 4_700_000_000 }]
+      }))
+
+    const results = await searchHuggingFaceModels({ backend: 'ollama', query: 'llama' })
+
+    expect(results[0].contextLength).toBe(131072)
+    expect(results[0].sizeBytes).toBe(4_700_000_000)
+  })
+
+  it('leaves contextLength null when the repo record carries no gguf window', async () => {
+    fetch
+      .mockResolvedValueOnce(response([
+        { modelId: 'org/Useful-GGUF', downloads: 1, tags: ['gguf'], siblings: [{ rfilename: 'Useful-Q4_K_M.gguf', size: 100 }] }
+      ]))
+      .mockResolvedValueOnce(response({ id: 'org/Useful-GGUF', siblings: [{ rfilename: 'Useful-Q4_K_M.gguf', size: 100 }] }))
+
+    const results = await searchHuggingFaceModels({ backend: 'ollama', query: 'useful' })
+
+    expect(results[0].contextLength).toBeNull()
+  })
+
   it('filters out non-GGUF results even if Hugging Face returns them', async () => {
     fetch.mockResolvedValue(response([
       { modelId: 'org/Plain-Safetensors', tags: ['safetensors'], siblings: [] },


### PR DESCRIPTION
## Summary

The model cards in the install catalog and Hugging Face search results on **Settings → Local LLM** now show each model's native context window (e.g. "128K ctx") alongside its size and parameter count. Previously this only appeared on already-installed models, so you couldn't compare context windows before deciding what to install.

- **Live Hugging Face results** read the true value from the repo's GGUF metadata (`gguf.context_length`), backfilled from the same per-repo `?blobs=true` fetch that already supplies file sizes — so no extra network round-trip beyond what already happens (the per-repo record is cached and deduped per search).
- **Curated catalog entries** carry it as a documented spec (`context` field) on the 6 entries whose context window is stated in their description; getCatalog surfaces it as `contextLength`. Entries without a documented window show nothing rather than a fabricated number.
- All three card sources (installed / curated / HF) normalize to a `contextLength` field and reuse the existing `formatContextLength` formatter, so the badge renders identically everywhere.

## Test plan

- `server/lib/localLlmCatalog.test.js` — asserts documented context windows surface as `contextLength` (128K/256K) and undocumented entries expose `null`.
- `server/services/huggingFaceCatalog.test.js` — asserts the native window is backfilled from per-repo `gguf.context_length`, and stays `null` when the repo record carries no GGUF window.
- All affected server suites pass (`localLlmCatalog`, `huggingFaceCatalog`, `localLlm`, `routes/localLlm` — 67 tests).