### PR TITLE
fix([issue-1529]): proper-noun guard for single-word common-name scoping

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -7,6 +7,7 @@
 ## Per-issue story generation
 
 - **[issue-1511] Per-issue prose and comic-script generation now sees only the characters that issue involves.** Generating an issue used to load the entire series character bible into every prose and comic-script prompt — on a large-cast series that's tens of thousands of tokens of character detail (including one-off bit players from unrelated issues) re-sent on every issue and every stage. Generation now sends full character records only for the cast named in that issue's beats, synopsis, and source material, with a compact one-line roster of everyone else kept for continuity. This sharply cuts token cost on big-cast series and, on context-bounded providers, leaves more room for the actual draft. The series' lead/recurring characters stay in context for every issue, so the core cast is never dropped — generation just stops carrying the full record of every bit player from unrelated issues.
+- **[issue-1529] A character whose name is a common word (Will, May, Grace) is no longer pulled into a prompt by an incidental word.** When scoping an issue's character bible, an ordinary phrase like "the team **will** regroup" could be mistaken for naming a cast member called "Will" — incidentally scoping the prompt down to that one character. A single-word character name now only counts as named when it appears capitalized as a proper noun ("Will entered"), so common-word names match the same way every other name does. Multi-word names and nicknames are unaffected.
 
 ## Fixed
 

--- a/server/services/pipeline/textStages.js
+++ b/server/services/pipeline/textStages.js
@@ -25,7 +25,6 @@ import { computeIssueTargets, assessSynopsisScope } from '../../lib/issueLength.
 import { renderEntitiesSummary } from '../../lib/universePromptRenderers.js';
 import { composeStyleNotes } from '../../lib/styleGuide.js';
 import { renderTickingClock } from '../../lib/storyArc.js';
-import { matchCharactersInText } from '../../lib/scenePrompt.js';
 
 const STAGE_TO_TEMPLATE = Object.freeze({
   idea: 'pipeline-idea-expansion',
@@ -240,6 +239,48 @@ const firstNameToken = (c) => {
   return parts.length > 1 ? parts[0] : '';
 };
 
+// Proper-noun variant of `wordInText` (#1529): the match counts only when an
+// occurrence appears with an UPPERCASE first letter — so "Will entered" / "WILL"
+// match, but mid-sentence "the team will regroup" does not. We scan all
+// word-boundary occurrences case-insensitively (the `i` flag), then accept only if
+// at least one has a capitalized initial. A sentence-initial capital ("Will the
+// team…") still matches — that's the safe over-inclusion direction.
+const properNounInText = (needle, haystack) => {
+  if (!needle) return false;
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const re = new RegExp(`(?<![\\p{L}\\p{N}_])${escaped}(?![\\p{L}\\p{N}_])`, 'giu');
+  for (const m of String(haystack || '').matchAll(re)) {
+    const ch = m[0][0];
+    // An uppercase cased letter: `ch === toUpperCase` AND `ch !== toLowerCase`
+    // (rules out digits/symbols, whose upper- and lower-case forms are equal).
+    if (ch && ch === ch.toUpperCase() && ch !== ch.toLowerCase()) return true;
+  }
+  return false;
+};
+
+// Reliable "this issue names them" signal with a proper-noun guard for single-word
+// names (#1529). `matchCharactersInText` is case-insensitive — correct for visual
+// stages and shared with `canonReadiness`, so we refine LOCALLY rather than widen it.
+// A character whose FULL NAME is a single common English word ("Will"/"May"/"Grace")
+// otherwise matches incidentally on ordinary prose ("the team will regroup"), and one
+// incidental hit can scope a prompt down to that lone character. So here a single-word
+// NAME must appear in its CAPITALIZED form to count; multi-word names and ALL aliases
+// keep the case-insensitive word-boundary match (a multi-word phrase or a nickname is
+// essentially never an incidental common-word collision).
+const matchReliableNames = (scopeText, allCharacters) => {
+  if (!scopeText || !Array.isArray(allCharacters)) return [];
+  const matched = [];
+  for (const c of allCharacters) {
+    const name = String(c?.name || '').trim();
+    const nameHit = name && !/\s/.test(name)
+      ? properNounInText(name, scopeText)   // single-word name → proper-noun guard
+      : wordInText(name, scopeText);        // multi-word name → as-is
+    const aliasHit = (c?.aliases || []).some((a) => wordInText(a, scopeText));
+    if (nameHit || aliasHit) matched.push(c);
+  }
+  return matched;
+};
+
 /**
  * Scope the full-record character bible to the cast relevant to THIS issue (#1511).
  *
@@ -265,14 +306,17 @@ const firstNameToken = (c) => {
  * let "will" scope the prompt down to "Will Stone" and drop everyone else. The
  * block is therefore never empty.
  *
- * Known precision limit: a character whose own name IS a common word (a cast
- * member literally named "Will"/"May"/"Grace") still matches incidentally via the
- * full-name matcher, which counts as reliable — so on such a cast an issue can be
- * scoped to that one character. This is bounded, not lossy: the uncapped roster
- * (`worldEntitiesSummary`) still carries every un-scoped character, so they keep a
- * continuity line — they just lose the full record, which is exactly #1511's
- * intended tradeoff for a non-featured character. A stopword/casing-aware matcher
- * could tighten this; tracked as a follow-up rather than guessed at here.
+ * Precision guard (#1529): a character whose own name IS a common word (a cast
+ * member literally named "Will"/"May"/"Grace") would otherwise match incidentally
+ * via the case-insensitive full-name matcher and count as reliable — scoping the
+ * issue down to that one character. The reliable-signal matcher (`matchReliableNames`)
+ * therefore requires a SINGLE-WORD name to appear in its capitalized form, so "the
+ * team will regroup" no longer counts as naming a character called "Will", while
+ * "Will entered" still does. Multi-word names and aliases keep the case-insensitive
+ * match. Residual: a sentence-initial capital ("Will the team…") still matches, but
+ * that's the safe over-inclusion direction (the character keeps its full record) —
+ * and even a true miss is non-lossy, since the uncapped `worldEntitiesSummary` roster
+ * still carries every un-scoped character's one-line continuity entry.
  */
 export function scopeCharactersForIssue(allCharacters, scopeText) {
   if (!Array.isArray(allCharacters) || allCharacters.length === 0) return [];
@@ -281,8 +325,10 @@ export function scopeCharactersForIssue(allCharacters, scopeText) {
   for (const c of allCharacters) {
     if (PRINCIPAL_ROLE_RE.test(c?.role || '')) byKey.set(c.id || c.name, c);
   }
-  // (b) Full-name / alias matches — a reliable "this issue names them" signal.
-  for (const c of matchCharactersInText(scopeText, allCharacters)) byKey.set(c.id || c.name, c);
+  // (b) Full-name / alias matches — a reliable "this issue names them" signal,
+  // with a proper-noun guard so a single-word common-name ("Will"/"Grace") doesn't
+  // scope on an incidental lowercase hit (#1529).
+  for (const c of matchReliableNames(scopeText, allCharacters)) byKey.set(c.id || c.name, c);
   // Principals + full-name matches are the trustworthy signal. A first-name-only
   // match is NOT, on its own, enough to suppress the whole-cast fallback below.
   const hasReliableSignal = byKey.size > 0;

--- a/server/services/pipeline/textStages.test.js
+++ b/server/services/pipeline/textStages.test.js
@@ -654,6 +654,53 @@ describe('pipeline text stage generator', () => {
       .toEqual(['Will Stone', 'Bram']);
   });
 
+  it('scopeCharactersForIssue: a single-word common-word name does NOT scope on an incidental lowercase hit (#1529)', () => {
+    // A cast member literally named "Will" + an untagged cast. The old case-insensitive
+    // full-name matcher treated lowercase "will" in "the team will regroup" as a reliable
+    // match and scoped the prompt down to just "Will". The proper-noun guard rejects the
+    // lowercase hit → no reliable signal → whole cast survives.
+    const cast = [
+      { name: 'Will', role: 'side' },
+      { name: 'Bram', role: 'clerk' },
+    ];
+    expect(textStages.__testing.scopeCharactersForIssue(cast, 'the team will regroup').map((c) => c.name))
+      .toEqual(['Will', 'Bram']);
+  });
+
+  it('scopeCharactersForIssue: an incidental lowercase common word never pulls in the literally-named character (#1529)', () => {
+    // Principal floor gives a reliable signal; the incidental "will" must NOT add the
+    // non-principal character named "Will" (lowercase ≠ proper-noun).
+    const cast = [
+      { name: 'Lena', role: 'lead protagonist' },
+      { name: 'Will', role: 'extra' },
+    ];
+    expect(textStages.__testing.scopeCharactersForIssue(cast, 'the team will regroup').map((c) => c.name))
+      .toEqual(['Lena']);
+  });
+
+  it('scopeCharactersForIssue: a capitalized single-word name IS a reliable proper-noun match (#1529)', () => {
+    const cast = [
+      { name: 'Will', role: 'side' },
+      { name: 'Bram', role: 'clerk' },
+    ];
+    // "Will entered" — proper-noun usage scopes to Will; ALL-CAPS beat-sheet form too.
+    expect(textStages.__testing.scopeCharactersForIssue(cast, 'Will entered the room').map((c) => c.name))
+      .toEqual(['Will']);
+    expect(textStages.__testing.scopeCharactersForIssue(cast, 'WILL slams the door').map((c) => c.name))
+      .toEqual(['Will']);
+  });
+
+  it('scopeCharactersForIssue: aliases stay case-insensitive — only single-word NAMES get the proper-noun guard (#1529)', () => {
+    const cast = [
+      { name: 'Lena', role: 'lead' },
+      { name: 'Grace', role: 'side', aliases: ['Gigi'] },
+    ];
+    // Lowercase alias "gigi" still matches (aliases keep the old behavior); Grace is in.
+    const got = textStages.__testing.scopeCharactersForIssue(cast, 'gigi waved from the dock').map((c) => c.name);
+    expect(got).toContain('Grace');
+    expect(got).toContain('Lena');
+  });
+
   it('scopeCharactersForIssue: matches non-ASCII names (accented) the ASCII \\b matcher would miss', () => {
     const cast = [
       { name: 'José Marín', role: 'pilot' }, // non-principal — only in via accented first-name match


### PR DESCRIPTION
Closes #1529.

## Problem

`scopeCharactersForIssue` (`server/services/pipeline/textStages.js`) decided which canon characters get full bible records in a prose/comic-script/teleplay prompt by matching canon names against the issue's source text via the shared, **case-insensitive** `matchCharactersInText`. A character whose own name is a single common English word — `Will`, `May`, `Grace`, `Hope`, `Art` — matched incidentally on ordinary text (`the team **will** regroup`). Since a single-word full-name match counted as a "reliable" signal, on an untagged cast that incidental hit could scope the prompt down to that one character.

## Fix

A **local** precision refinement in the per-issue text-stage matcher (the shared `matchCharactersInText` is intentionally untouched — `canonReadiness` also uses it):

- New `properNounInText(needle, haystack)` — like the existing local `wordInText`, but a match counts only when an occurrence appears with an **uppercase first letter**. So `Will entered` / `WILL` match, but mid-sentence `the team will regroup` does not.
- New `matchReliableNames(scopeText, allCharacters)` — the reliable name/alias signal, but a **single-word name** must appear in its capitalized proper-noun form to count. Multi-word names and **all aliases** keep the case-insensitive word-boundary match (a multi-word phrase or nickname is essentially never an incidental common-word collision).
- `scopeCharactersForIssue` step (b) now calls `matchReliableNames` instead of `matchCharactersInText`; the unused import is removed.

**Residual (documented):** a sentence-initial capital (`Will the team…`) still matches — but that's the safe over-inclusion direction (the character keeps its full record), never the lossy one. Even a true miss is non-lossy: the uncapped `worldEntitiesSummary` roster still carries every un-scoped character's one-line continuity entry.

## Tests

Four new cases in `textStages.test.js`:
- incidental lowercase `will` on an untagged cast → whole cast survives (no scope-down);
- incidental lowercase `will` with a principal present → the literally-named `Will` extra is **not** pulled in;
- capitalized `Will entered` and ALL-CAPS `WILL` → reliable proper-noun match;
- lowercase alias still matches (aliases keep the old behavior).

Full pipeline suite: 1041 passed. Reviewed by claude + codex (both clean).