### PR TITLE
fix([issue-1532]): import Apple Health exports containing clinical_records without crashing

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -15,6 +15,10 @@
 
 - **[issue-1527] A failed ChatGPT export import no longer leaves a stray temp file behind under heavy disk load.** When an import was aborted mid-stream (e.g. a corrupt asset-name map or an oversized member), the cleanup that removes the half-written `.part` temp file could run *before* the asset still streaming to that file finished closing — so under heavy concurrent disk I/O the write could re-create the `.part` file just after it was deleted and orphan it. Cleanup now waits for every in-flight asset write to close before removing temp files, so a rejected import reliably leaves nothing behind.
 
+## Apple Health import
+
+- **[issue-1532] Apple Health exports that include clinical records now import instead of crashing.** Importing a Health export ZIP that contained a `clinical_records/` folder (the FHIR records you get after linking a healthcare provider) failed outright — the import aborted while reading those JSON files. Such exports now import correctly, with their clinical records loaded alongside the rest of your health data; exports without clinical records are unaffected.
+
 ## Per-issue story generation
 
 - **[issue-1511] Per-issue prose and comic-script generation now sees only the characters that issue involves.** Generating an issue used to load the entire series character bible into every prose and comic-script prompt — on a large-cast series that's tens of thousands of tokens of character detail (including one-off bit players from unrelated issues) re-sent on every issue and every stage. Generation now sends full character records only for the cast named in that issue's beats, synopsis, and source material, with a compact one-line roster of everyone else kept for continuity. This sharply cuts token cost on big-cast series and, on context-bounded providers, leaves more room for the actual draft. The series' lead/recurring characters stay in context for every issue, so the core cast is never dropped — generation just stops carrying the full record of every bit player from unrelated issues.

--- a/server/lib/README.md
+++ b/server/lib/README.md
@@ -114,7 +114,7 @@ The barrel `server/lib/index.js` is a machine-checkable enumeration of every pub
 | `multipart.js` | Streaming multipart/form-data parser. |
 | `safetensors.js` | `readSafetensorsHeader(path)` reads only the JSON header of a `.safetensors` file (never the tensor payload). `detectFlux2VariantFromHeader(header)` / `detectFlux2Variant(path)` classify a LoRA as FLUX.2 Klein `'4b'` (hidden dim 3072) vs `'9b'` (4096) by transformer-block tensor shapes, so the LoRA picker can hide off-variant weights that would silently fail to load. |
 | `pdfImageEmbed.js` | PDF image embed helpers for comic / volume PDFs. |
-| `zipStream.js` | Streaming ZIP parser (`parseZip`, unzipper-style); `extractZipEntryToBuffer(path, match)` cracks one member out to a Buffer. |
+| `zipStream.js` | Streaming ZIP parser (`parseZip`, unzipper-style); `collectZipEntry(entry, maxBytes?)` buffers one `parseZip` entry into a Buffer (size-capped); `extractZipEntryToBuffer(path, match)` cracks one member out to a Buffer. |
 | `zipWriter.js` | Minimal ZIP writer — `createZip(entries)` builds a stored (uncompressed) archive Buffer that round-trips through `parseZip`; `crc32(buf)` is the dependency-free checksum it uses. |
 | `assetHash.js` | Cross-transport SHA-256 cache for `data/images/*` — persists hashes in the asset's `.metadata.json` sidecar so the share-bucket exporter and the federated peer-sync push pipeline reuse the same value. `sidecarGenParamsHash` canonically hashes a sidecar's gen-params (excludes the machine-local `sha256` cache block) for cross-machine sidecar-convergence comparisons. |
 

--- a/server/lib/zipStream.js
+++ b/server/lib/zipStream.js
@@ -201,6 +201,38 @@ export function parseZip() {
 }
 
 /**
+ * Collect a single `parseZip()` entry's decompressed bytes into one Buffer.
+ *
+ * `parseZip()` entries are NOT readable streams — they expose only `.pipe(dest)`
+ * / `.autodrain()`, so the EventEmitter idiom `entry.on('data'/'end')` throws
+ * `entry.on is not a function`. Pipe the entry into a collecting Writable and
+ * resolve with the concatenated buffer instead. When `maxBytes` is finite the
+ * collect rejects once the member exceeds it, rather than buffering an unbounded
+ * amount into memory.
+ *
+ * Call this synchronously inside the `entry` handler (entries auto-drain on the
+ * next tick if nothing attaches a pipe/drain), and gather the returned promises
+ * so the parser's `close` handler can `Promise.all` them before settling.
+ */
+export function collectZipEntry(entry, maxBytes = Infinity) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let size = 0;
+    const sink = new Writable({
+      write(chunk, _enc, cb) {
+        size += chunk.length;
+        if (size > maxBytes) { cb(new Error(`ZIP member exceeds ${maxBytes} byte limit`)); return; }
+        chunks.push(chunk);
+        cb();
+      }
+    });
+    sink.on('finish', () => resolve(Buffer.concat(chunks)));
+    sink.on('error', reject);
+    entry.pipe(sink);
+  });
+}
+
+/**
  * Extract the first entry whose path satisfies `match` (a predicate or a
  * substring) from a zip on disk, resolving to its decompressed Buffer (or null
  * if nothing matched). Convenience over parseZip() for the random-single-member

--- a/server/lib/zipStream.js
+++ b/server/lib/zipStream.js
@@ -200,21 +200,26 @@ export function parseZip() {
   return sink;
 }
 
+// Default per-member ceiling when buffering one ZIP entry into memory. Guards
+// against a pathological member exhausting RAM; consumers buffering arbitrary
+// archive members (chatgptZipImport, appleHealth clinical records) share it.
+export const MAX_ZIP_MEMBER_BYTES = 100 * 1024 * 1024;
+
 /**
  * Collect a single `parseZip()` entry's decompressed bytes into one Buffer.
  *
  * `parseZip()` entries are NOT readable streams — they expose only `.pipe(dest)`
  * / `.autodrain()`, so the EventEmitter idiom `entry.on('data'/'end')` throws
  * `entry.on is not a function`. Pipe the entry into a collecting Writable and
- * resolve with the concatenated buffer instead. When `maxBytes` is finite the
- * collect rejects once the member exceeds it, rather than buffering an unbounded
- * amount into memory.
+ * resolve with the concatenated buffer instead. The collect rejects once the
+ * member exceeds `maxBytes` (defaults to `MAX_ZIP_MEMBER_BYTES`), rather than
+ * buffering an unbounded amount into memory.
  *
  * Call this synchronously inside the `entry` handler (entries auto-drain on the
  * next tick if nothing attaches a pipe/drain), and gather the returned promises
  * so the parser's `close` handler can `Promise.all` them before settling.
  */
-export function collectZipEntry(entry, maxBytes = Infinity) {
+export function collectZipEntry(entry, maxBytes = MAX_ZIP_MEMBER_BYTES) {
   return new Promise((resolve, reject) => {
     const chunks = [];
     let size = 0;

--- a/server/lib/zipStream.test.js
+++ b/server/lib/zipStream.test.js
@@ -222,6 +222,22 @@ describe('collectZipEntry', () => {
     await expect(collected).rejects.toThrow(/exceeds 16 byte limit/);
   });
 
+  it('rejects (does not hang) when a deflated member is corrupt', async () => {
+    // method:8 declares deflate, but the payload is not a valid raw-deflate
+    // stream — the inflate pipeline must error and reject the collect, not hang.
+    const garbage = Buffer.from('not a valid deflate stream at all');
+    const zip = Buffer.concat([buildEntry('clinical_records/bad.json', garbage, { method: 8 }), buildEocd()]);
+    const collected = new Promise((resolve, reject) => {
+      const parser = parseZip();
+      let read;
+      parser.on('entry', (entry) => { read = collectZipEntry(entry); });
+      parser.on('close', () => read.then(resolve, reject));
+      parser.on('error', reject);
+      Readable.from([zip]).pipe(parser);
+    });
+    await expect(collected).rejects.toThrow();
+  });
+
   it('collects multiple JSON members alongside a drained member (appleHealth pattern)', async () => {
     // Mirrors server/routes/appleHealth.js: drain export.xml, collect every
     // clinical_records/*.json into buffers, await them all on 'close'.

--- a/server/lib/zipStream.test.js
+++ b/server/lib/zipStream.test.js
@@ -4,7 +4,7 @@ import { deflateRawSync } from 'zlib';
 import { writeFile, rm, mkdtemp } from 'fs/promises';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { parseZip, extractZipEntryToBuffer } from './zipStream.js';
+import { parseZip, extractZipEntryToBuffer, collectZipEntry } from './zipStream.js';
 
 const LOCAL_SIG = 0x04034b50;
 const CENTRAL_SIG = 0x02014b50;
@@ -173,6 +173,80 @@ describe('parseZip', () => {
     // Without the destroy→end teardown this never resolves and the test times out.
     const data = await sinkFinished;
     expect(data.length).toBe(100);
+  });
+});
+
+describe('collectZipEntry', () => {
+  it('collects a stored entry into one Buffer', async () => {
+    const data = Buffer.from('clinical record json payload');
+    const zip = Buffer.concat([buildEntry('clinical_records/a.json', data), buildEocd()]);
+    const out = await new Promise((resolve, reject) => {
+      const parser = parseZip();
+      let read;
+      parser.on('entry', (entry) => { read = collectZipEntry(entry); });
+      parser.on('close', () => read.then(resolve, reject));
+      parser.on('error', reject);
+      Readable.from([zip]).pipe(parser);
+    });
+    expect(out.toString()).toBe('clinical record json payload');
+  });
+
+  it('round-trips a deflated entry', async () => {
+    const original = Buffer.from('{"resourceType":"Observation","value":42}');
+    const zip = Buffer.concat([
+      buildEntry('clinical_records/obs.json', deflateRawSync(original), { method: 8 }),
+      buildEocd(),
+    ]);
+    const out = await new Promise((resolve, reject) => {
+      const parser = parseZip();
+      let read;
+      parser.on('entry', (entry) => { read = collectZipEntry(entry); });
+      parser.on('close', () => read.then(resolve, reject));
+      parser.on('error', reject);
+      Readable.from([zip]).pipe(parser);
+    });
+    expect(out.toString()).toBe(original.toString());
+  });
+
+  it('rejects when the member exceeds maxBytes', async () => {
+    const data = Buffer.alloc(64, 0x41);
+    const zip = Buffer.concat([buildEntry('big.json', data), buildEocd()]);
+    const collected = new Promise((resolve, reject) => {
+      const parser = parseZip();
+      let read;
+      parser.on('entry', (entry) => { read = collectZipEntry(entry, 16); });
+      parser.on('close', () => read.then(resolve, reject));
+      parser.on('error', reject);
+      Readable.from([zip]).pipe(parser);
+    });
+    await expect(collected).rejects.toThrow(/exceeds 16 byte limit/);
+  });
+
+  it('collects multiple JSON members alongside a drained member (appleHealth pattern)', async () => {
+    // Mirrors server/routes/appleHealth.js: drain export.xml, collect every
+    // clinical_records/*.json into buffers, await them all on 'close'.
+    const zip = Buffer.concat([
+      buildEntry('apple_health_export/export.xml', Buffer.from('<HealthData/>')),
+      buildEntry('clinical_records/r1.json', deflateRawSync(Buffer.from('{"id":1}')), { method: 8 }),
+      buildEntry('clinical_records/r2.json', Buffer.from('{"id":2}')),
+      buildEocd(),
+    ]);
+    const jsons = await new Promise((resolve, reject) => {
+      const reads = [];
+      const collected = [];
+      const parser = parseZip();
+      parser.on('entry', (entry) => {
+        if (entry.path.includes('clinical_records/') && entry.path.endsWith('.json')) {
+          reads.push(collectZipEntry(entry).then((buf) => collected.push(buf.toString('utf-8'))));
+        } else {
+          entry.autodrain();
+        }
+      });
+      parser.on('close', () => Promise.all(reads).then(() => resolve(collected), reject));
+      parser.on('error', reject);
+      Readable.from([zip]).pipe(parser);
+    });
+    expect(jsons.sort()).toEqual(['{"id":1}', '{"id":2}']);
   });
 });
 

--- a/server/routes/appleHealth.js
+++ b/server/routes/appleHealth.js
@@ -156,10 +156,18 @@ router.post('/import/xml', uploadXml, asyncHandler(async (req, res) => {
           // polled flag; the clinical collects are awaited as promises.
           const finalize = () => Promise.all(clinicalReads).then(settle(resolve));
           if (xmlWriteFinished) return finalize();
-          const check = setInterval(() => { if (xmlWriteFinished) { clearInterval(check); finalize(); } }, XML_WRITE_POLL_INTERVAL_MS);
-          setTimeout(() => { clearInterval(check); finalize(); }, XML_WRITE_TIMEOUT_MS);
+          const check = setInterval(() => { if (xmlWriteFinished) { clearInterval(check); clearTimeout(timer); finalize(); } }, XML_WRITE_POLL_INTERVAL_MS);
+          const timer = setTimeout(() => { clearInterval(check); finalize(); }, XML_WRITE_TIMEOUT_MS);
         })
         .on('error', settle(reject));
+    }).catch(async (err) => {
+      // A rejected parse (missing export.xml, or an oversized/corrupt clinical
+      // record member) would otherwise orphan the uploaded ZIP and any partial
+      // extracted XML on disk. Clean both up before the error bubbles to the
+      // centralized middleware (mirrors chatgptZipImport's reject cleanup).
+      await fs.unlink(filePath).catch(() => {});
+      await fs.unlink(xmlPath).catch(() => {});
+      throw err;
     });
 
     await fs.unlink(filePath);

--- a/server/routes/appleHealth.js
+++ b/server/routes/appleHealth.js
@@ -3,7 +3,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { createReadStream, createWriteStream, promises as fs } from 'fs';
 import { uploadSingle } from '../lib/multipart.js';
-import { parseZip } from '../lib/zipStream.js';
+import { parseZip, collectZipEntry } from '../lib/zipStream.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { validateRequest } from '../lib/validation.js';
 import { healthIngestSchema } from '../lib/appleHealthValidation.js';
@@ -22,6 +22,11 @@ import {
 // Polling interval and timeout for XML write-stream completion (ms)
 const XML_WRITE_POLL_INTERVAL_MS = 50;
 const XML_WRITE_TIMEOUT_MS = 5000;
+
+// Per-member cap when buffering a clinical-record JSON into memory. Real records
+// are ~1-5KB each; the generous ceiling just guards against a pathological
+// member exhausting memory (mirrors chatgptZipImport's MAX_MEMBER_BYTES).
+const MAX_CLINICAL_RECORD_BYTES = 100 * 1024 * 1024;
 
 const isZip = (file) =>
   file.mimetype === 'application/zip' ||
@@ -117,6 +122,10 @@ router.post('/import/xml', uploadXml, asyncHandler(async (req, res) => {
     const xmlPath = join(tmpdir(), `apple-health-${Date.now()}.xml`);
     let foundXml = false;
     let xmlWriteFinished = false;
+    // Each clinical-record collect is async (entries stream through an inflate
+    // pipeline), so track them and await all before resolving — otherwise
+    // 'close' can fire and drop records whose buffers haven't finished.
+    const clinicalReads = [];
 
     await new Promise((resolve, reject) => {
       let settled = false;
@@ -132,20 +141,28 @@ router.post('/import/xml', uploadXml, asyncHandler(async (req, res) => {
               .on('finish', () => { xmlWriteFinished = true; })
               .on('error', settle(reject));
           } else if (entry.path.includes('clinical_records/') && entry.path.endsWith('.json')) {
-            // Buffer clinical record JSON files (~1-5KB each)
-            const chunks = [];
-            entry.on('data', (chunk) => chunks.push(chunk));
-            entry.on('end', () => clinicalJsons.push(Buffer.concat(chunks).toString('utf-8')));
+            // Buffer clinical record JSON files (~1-5KB each). parseZip() entries
+            // aren't EventEmitters (no entry.on('data'/'end') — that throws), so
+            // pipe into a collecting Writable via the shared helper and track the
+            // read so 'close' can await it.
+            clinicalReads.push(
+              collectZipEntry(entry, MAX_CLINICAL_RECORD_BYTES)
+                .then((buf) => { clinicalJsons.push(buf.toString('utf-8')); })
+                .catch(settle(reject))
+            );
           } else {
             entry.autodrain();
           }
         })
         .on('close', () => {
           if (!foundXml) return settle(reject)(new ServerError('ZIP does not contain export.xml', { status: 400, code: 'BAD_REQUEST' }));
-          // Wait briefly for XML write stream to finish if close fires first
-          if (xmlWriteFinished) return settle(resolve)();
-          const check = setInterval(() => { if (xmlWriteFinished) { clearInterval(check); settle(resolve)(); } }, XML_WRITE_POLL_INTERVAL_MS);
-          setTimeout(() => { clearInterval(check); settle(resolve)(); }, XML_WRITE_TIMEOUT_MS);
+          // Resolve once the XML write stream has flushed AND every clinical
+          // record collect has finished. XML completion is signaled via the
+          // polled flag; the clinical collects are awaited as promises.
+          const finalize = () => Promise.all(clinicalReads).then(settle(resolve));
+          if (xmlWriteFinished) return finalize();
+          const check = setInterval(() => { if (xmlWriteFinished) { clearInterval(check); finalize(); } }, XML_WRITE_POLL_INTERVAL_MS);
+          setTimeout(() => { clearInterval(check); finalize(); }, XML_WRITE_TIMEOUT_MS);
         })
         .on('error', settle(reject));
     });

--- a/server/routes/appleHealth.js
+++ b/server/routes/appleHealth.js
@@ -122,17 +122,39 @@ router.post('/import/xml', uploadXml, asyncHandler(async (req, res) => {
     // 'close' can fire and drop records whose buffers haven't finished.
     const clinicalReads = [];
 
+    const src = createReadStream(filePath);
+    const parser = parseZip();
+    let xmlWriteStream = null;
+
     await new Promise((resolve, reject) => {
       let settled = false;
-      const settle = (fn) => (...args) => { if (!settled) { settled = true; fn(...args); } };
+      const settle = (fn) => (...args) => {
+        if (settled) return;
+        settled = true;
+        // On failure, tear down extraction immediately: stop the read stream,
+        // the ZIP parser, and any in-flight XML write so nothing keeps consuming
+        // work — and, crucially, so a buffered XML write can't re-create xmlPath
+        // right after the cleanup below unlinks it (the write-after-unlink race
+        // chatgptZipImport guards against). Destroying the write stream discards
+        // its pending writes, so the post-reject unlink is final.
+        if (fn === reject) {
+          src.destroy();
+          parser.destroy?.();
+          xmlWriteStream?.destroy();
+        }
+        fn(...args);
+      };
 
-      createReadStream(filePath)
-        .pipe(parseZip())
+      // `.pipe()` doesn't forward source errors, so handle a read failure on the
+      // upload stream explicitly (otherwise it would throw unhandled).
+      src.on('error', settle(reject));
+      src
+        .pipe(parser)
         .on('entry', (entry) => {
           if (entry.path === 'apple_health_export/export.xml' || entry.path === 'export.xml') {
             foundXml = true;
-            const ws = createWriteStream(xmlPath);
-            entry.pipe(ws)
+            xmlWriteStream = createWriteStream(xmlPath);
+            entry.pipe(xmlWriteStream)
               .on('finish', () => { xmlWriteFinished = true; })
               .on('error', settle(reject));
           } else if (entry.path.includes('clinical_records/') && entry.path.endsWith('.json')) {

--- a/server/routes/appleHealth.js
+++ b/server/routes/appleHealth.js
@@ -23,11 +23,6 @@ import {
 const XML_WRITE_POLL_INTERVAL_MS = 50;
 const XML_WRITE_TIMEOUT_MS = 5000;
 
-// Per-member cap when buffering a clinical-record JSON into memory. Real records
-// are ~1-5KB each; the generous ceiling just guards against a pathological
-// member exhausting memory (mirrors chatgptZipImport's MAX_MEMBER_BYTES).
-const MAX_CLINICAL_RECORD_BYTES = 100 * 1024 * 1024;
-
 const isZip = (file) =>
   file.mimetype === 'application/zip' ||
   file.mimetype === 'application/x-zip-compressed' ||
@@ -143,10 +138,10 @@ router.post('/import/xml', uploadXml, asyncHandler(async (req, res) => {
           } else if (entry.path.includes('clinical_records/') && entry.path.endsWith('.json')) {
             // Buffer clinical record JSON files (~1-5KB each). parseZip() entries
             // aren't EventEmitters (no entry.on('data'/'end') — that throws), so
-            // pipe into a collecting Writable via the shared helper and track the
-            // read so 'close' can await it.
+            // pipe into a collecting Writable via the shared helper (which applies
+            // MAX_ZIP_MEMBER_BYTES) and track the read so 'close' can await it.
             clinicalReads.push(
-              collectZipEntry(entry, MAX_CLINICAL_RECORD_BYTES)
+              collectZipEntry(entry)
                 .then((buf) => { clinicalJsons.push(buf.toString('utf-8')); })
                 .catch(settle(reject))
             );

--- a/server/routes/appleHealth.js
+++ b/server/routes/appleHealth.js
@@ -187,6 +187,15 @@ router.post('/import/xml', uploadXml, asyncHandler(async (req, res) => {
       // record member) would otherwise orphan the uploaded ZIP and any partial
       // extracted XML on disk. Clean both up before the error bubbles to the
       // centralized middleware (mirrors chatgptZipImport's reject cleanup).
+      //
+      // settle(reject) already destroy()'d xmlWriteStream, but createWriteStream
+      // opens its fd asynchronously and can finish creating xmlPath *after* an
+      // early destroy — so unlinking immediately can no-op and leave the temp
+      // file behind. Wait for the stream to emit 'close' (the fd is fully
+      // opened-and-closed by then) before unlinking.
+      if (xmlWriteStream && !xmlWriteStream.closed) {
+        await new Promise((res) => xmlWriteStream.once('close', res));
+      }
       await fs.unlink(filePath).catch(() => {});
       await fs.unlink(xmlPath).catch(() => {});
       throw err;

--- a/server/services/chatgptZipImport.js
+++ b/server/services/chatgptZipImport.js
@@ -33,7 +33,7 @@ import { createReadStream, createWriteStream } from 'fs';
 import { mkdir, rename, unlink } from 'fs/promises';
 import { Writable } from 'stream';
 import { PATHS, getMimeType } from '../lib/fileUtils.js';
-import { parseZip } from '../lib/zipStream.js';
+import { parseZip, collectZipEntry } from '../lib/zipStream.js';
 import { parseExport, importConversations, assetPointerId } from './chatgptImport.js';
 import { ServerError } from '../lib/errorHandler.js';
 
@@ -105,23 +105,9 @@ const IS_ASSET_NAME_MAP = (path) => /(?:^|\/)conversation_asset_file_names\.json
 const datAssetId = (path) => path.replace(/^.*\//, '').replace(/\.dat$/i, '');
 
 // `parseZip` entries aren't readable streams — they expose `.pipe(dest)` /
-// `.autodrain()`. Pipe the entry into a size-capped collecting Writable and
-// resolve with the concatenated buffer.
-const collect = (entry, max) => new Promise((resolve, reject) => {
-  const chunks = [];
-  let size = 0;
-  const sink = new Writable({
-    write(chunk, _enc, cb) {
-      size += chunk.length;
-      if (size > max) { cb(new Error(`ZIP member exceeds ${max} byte limit`)); return; }
-      chunks.push(chunk);
-      cb();
-    }
-  });
-  sink.on('finish', () => resolve(Buffer.concat(chunks)));
-  sink.on('error', reject);
-  entry.pipe(sink);
-});
+// `.autodrain()`, so buffering one into memory goes through the shared,
+// size-capped `collectZipEntry` helper (see lib/zipStream.js).
+const collect = collectZipEntry;
 
 // Stream a `.dat` entry straight to `filePath`, holding only the leading
 // `SNIFF_BYTES` so the asset's real extension can be sniffed without buffering

--- a/server/services/chatgptZipImport.js
+++ b/server/services/chatgptZipImport.js
@@ -33,7 +33,7 @@ import { createReadStream, createWriteStream } from 'fs';
 import { mkdir, rename, unlink } from 'fs/promises';
 import { Writable } from 'stream';
 import { PATHS, getMimeType } from '../lib/fileUtils.js';
-import { parseZip, collectZipEntry } from '../lib/zipStream.js';
+import { parseZip, collectZipEntry, MAX_ZIP_MEMBER_BYTES } from '../lib/zipStream.js';
 import { parseExport, importConversations, assetPointerId } from './chatgptImport.js';
 import { ServerError } from '../lib/errorHandler.js';
 
@@ -43,7 +43,7 @@ import { ServerError } from '../lib/errorHandler.js';
 // malicious zip claiming one member is enormous. Assets stream straight to disk
 // (peak RAM is one chunk), so there is no aggregate in-memory ceiling to keep —
 // a legitimately large multi-GB export imports without an arbitrary budget.
-const MAX_MEMBER_BYTES = 100 * 1024 * 1024;
+const MAX_MEMBER_BYTES = MAX_ZIP_MEMBER_BYTES;
 
 // Leading bytes captured from each streamed asset to sniff its magic-byte type
 // (the widest sniff — WAV/WebP — reads bytes 8–11). Everything past this streams
@@ -103,11 +103,6 @@ const IS_ASSET_NAME_MAP = (path) => /(?:^|\/)conversation_asset_file_names\.json
 // reference assets as `file-service://file-XXX` / `sediment://file_HASH`, both
 // of which `assetPointerId()` reduces to that same bare id.
 const datAssetId = (path) => path.replace(/^.*\//, '').replace(/\.dat$/i, '');
-
-// `parseZip` entries aren't readable streams — they expose `.pipe(dest)` /
-// `.autodrain()`, so buffering one into memory goes through the shared,
-// size-capped `collectZipEntry` helper (see lib/zipStream.js).
-const collect = collectZipEntry;
 
 // Stream a `.dat` entry straight to `filePath`, holding only the leading
 // `SNIFF_BYTES` so the asset's real extension can be sniffed without buffering
@@ -199,11 +194,11 @@ export async function extractChatgptZip(zipPath, { assetDir = PATHS.brainImportA
       .on('entry', (entry) => {
         const { path } = entry;
         if (IS_ASSET_NAME_MAP(path)) {
-          inFlight.push(collect(entry, MAX_MEMBER_BYTES)
+          inFlight.push(collectZipEntry(entry, MAX_MEMBER_BYTES)
             .then((buf) => { assetNameMap = JSON.parse(buf.toString('utf8')); })
             .catch(onErr));
         } else if (IS_CONVO_JSON(path)) {
-          inFlight.push(collect(entry, MAX_MEMBER_BYTES)
+          inFlight.push(collectZipEntry(entry, MAX_MEMBER_BYTES)
             .then((buf) => { convoBuffers.push({ path, buffer: buf }); })
             .catch(onErr));
         } else if (IS_DAT(path)) {


### PR DESCRIPTION
## Summary

Apple Health export ZIPs that contain a `clinical_records/` folder (the FHIR records you get after linking a healthcare provider) crashed the import with `TypeError: entry.on is not a function`. `parseZip()` entries are not EventEmitters — they expose only `{ path, pipe, autodrain }` — so the `clinical_records/*.json` branch in `server/routes/appleHealth.js` threw for any export that hit it. It was latent only because exports without clinical records never reach that branch.

The fix consumes each clinical entry via its streaming interface (a collecting `Writable`) instead of `entry.on('data'/'end')`, tracking each read so the parser's `close` handler awaits them all before resolving (a synchronous `on('end')` could otherwise drop records mid-flight).

### Changes
- **`lib/zipStream.js`** — extract the collect-into-Buffer pattern (previously duplicated inline in `chatgptZipImport.js`) into a shared, size-capped `collectZipEntry(entry, maxBytes)` helper, plus a single `MAX_ZIP_MEMBER_BYTES` constant both importers share.
- **`routes/appleHealth.js`** — pipe each `clinical_records/*.json` entry through `collectZipEntry`, await all collects on `close`, and on any rejection tear down the read/parser/XML-write streams and clean up temp files (awaiting the write stream's `close` first, so an async fd-open can't re-create the temp XML after the unlink).
- **`services/chatgptZipImport.js`** — use the shared helper and constant; drop the local duplicate.

### Review
- `/simplify` pass: unified the per-member byte cap into one shared constant; removed a redundant alias.
- `--review-with=claude,codex`: claude found a temp-file-cleanup leak (fixed); codex found a stream-teardown / write-after-unlink race (fixed across two iterations). A final codex note about bounding aggregate clinical-record memory for *crafted* multi-GB ZIPs was declined as out of scope under PortOS's single-user/private-network trust model (no rate-limiting/DoS defenses) — the new per-member cap is already a net improvement over the prior unbounded buffering.

## Test plan
- `cd server && npx vitest run lib/zipStream.test.js services/chatgptZipImport.test.js services/chatgptImport.test.js services/appleHealthClinical.test.js lib/index.test.js` — all green.
- New `collectZipEntry` tests cover stored, deflated round-trip, over-cap rejection, corrupt-deflate rejection (no hang), and the multi-member appleHealth pattern.

Closes #1532