### PR TITLE
fix: filter disabled providers from provider→model pickers

### DIFF
--- a/client/src/components/ProviderModelSelector.jsx
+++ b/client/src/components/ProviderModelSelector.jsx
@@ -1,7 +1,12 @@
 /**
  * Two-step provider > model dropdown selector.
  * @param {Object} props
- * @param {Array} props.providers - Provider list from useProviderModels()
+ * @param {Array} props.providers - Provider list from useProviderModels(). Disabled
+ *   providers (`enabled === false`) are filtered out of the dropdown automatically,
+ *   except the currently-selected one (so a pinned-but-disabled provider still shows
+ *   its value). This is the single source of truth for "enabled only" pickers — a
+ *   caller that already filtered (e.g. via the hook's default `enabled` filter) is
+ *   unaffected since re-filtering enabled entries is idempotent.
  * @param {string} props.selectedProviderId - Currently selected provider ID
  * @param {string} props.selectedModel - Currently selected model
  * @param {Array} props.availableModels - Models for the selected provider. Entries
@@ -58,6 +63,14 @@ export default function ProviderModelSelector({
 }) {
   const providerSelectId = useId();
   const modelSelectId = useId();
+  // Only offer enabled providers (treat a missing `enabled` as enabled). The
+  // currently-selected provider stays visible even if disabled, so a record
+  // pinned to a now-disabled provider still renders its value instead of
+  // silently blanking the select. This is the single DRY gate for every
+  // provider→model picker; callers may also pre-filter, which is idempotent.
+  const visibleProviders = providers.filter(
+    (p) => p.enabled !== false || p.id === selectedProviderId
+  );
   const showModel = alwaysShowModel || availableModels.length > 0;
   const wrapperClass = layout === 'stacked' ? 'flex flex-col gap-1' : 'flex items-center gap-2';
   return (
@@ -74,7 +87,7 @@ export default function ProviderModelSelector({
           className={SELECT_CLASS}
         >
           {emptyProviderOption != null && <option value="">{emptyProviderOption}</option>}
-          {providers.map(p => (
+          {visibleProviders.map(p => (
             <option key={p.id} value={p.id}>{p.name}</option>
           ))}
         </select>

--- a/client/src/components/ProviderModelSelector.test.jsx
+++ b/client/src/components/ProviderModelSelector.test.jsx
@@ -86,6 +86,32 @@ describe('ProviderModelSelector', () => {
     expect(onModelChange).toHaveBeenCalledWith('m2');
   });
 
+  it('filters out disabled providers from the dropdown', () => {
+    renderSelector({
+      providers: [
+        { id: 'p1', name: 'Provider One' },
+        { id: 'p2', name: 'Provider Two', enabled: false },
+        { id: 'p3', name: 'Provider Three', enabled: true },
+      ],
+    });
+    const providerSelect = screen.getAllByRole('combobox')[0];
+    const labels = [...providerSelect.querySelectorAll('option')].map((o) => o.textContent);
+    expect(labels).toEqual(['Provider One', 'Provider Three']);
+  });
+
+  it('keeps a disabled provider visible when it is the current selection', () => {
+    renderSelector({
+      selectedProviderId: 'p2',
+      providers: [
+        { id: 'p1', name: 'Provider One' },
+        { id: 'p2', name: 'Provider Two', enabled: false },
+      ],
+    });
+    const providerSelect = screen.getAllByRole('combobox')[0];
+    const labels = [...providerSelect.querySelectorAll('option')].map((o) => o.textContent);
+    expect(labels).toEqual(['Provider One', 'Provider Two']);
+  });
+
   it('stacks the selects vertically when layout="stacked"', () => {
     const { container } = renderSelector({ layout: 'stacked' });
     expect(container.firstChild.className).toContain('flex-col');


### PR DESCRIPTION
## Problem

The universe create page's **"LLM for expansion"** picker showed *all* AI providers — including disabled ones. `UniverseBuilder` fetched the raw `/providers` response and passed it straight to the shared `ProviderModelSelector`, which rendered whatever list it received. The same gap affected every other direct consumer of the component that didn't pre-filter.

## Fix

Filter to enabled providers (`enabled !== false`) inside the shared `ProviderModelSelector` — the single DRY gate every provider→model picker routes through. This matches the server's own default (`enabled: providerData.enabled !== false` in `server/lib/aiToolkit/providers.js`).

Design decisions:
- **Treat missing `enabled` as enabled** (`!== false`), mirroring server semantics.
- **Keep the currently-selected provider visible even if disabled**, so a record pinned to a now-disabled provider still renders its value instead of silently blanking the select.
- **Idempotent** for callers already filtering via `useProviderModels` (whose default filter is `p => p.enabled`); re-filtering enabled entries is a no-op. Consumers that didn't filter (UniverseBuilder, etc.) are fixed automatically.

Note: models carry no `enabled` flag in this codebase — a provider's `models` list is already sanitized via `filterSelectableModels`, so the actionable gap was the provider list, now closed everywhere.

## Tests

Added two tests to `ProviderModelSelector.test.jsx`:
- disabled providers are filtered out of the dropdown
- a disabled-but-selected provider stays visible

Full component suite: 10/10 passing.