### PR TITLE
Fix broken App Detail header: Dev-UI warning no longer squeezes the title/actions

### DIFF
--- a/client/src/components/apps/AppDetailView.jsx
+++ b/client/src/components/apps/AppDetailView.jsx
@@ -349,50 +349,51 @@ export default function AppDetailView() {
               <span className="text-xs">Edit</span>
             </button>
           </div>
-          {/* Vite Dev-UI host guard — the app's dev server would block this host. */}
-          {viteHostStatus && !viteHostStatus.hostAllowed && (
-            <div className="mt-3 w-full rounded-lg border border-port-warning/40 bg-port-warning/10 p-3">
-              <div className="flex items-start gap-2">
-                <AlertTriangle size={16} className="text-port-warning mt-0.5 shrink-0" />
-                <div className="flex-1 min-w-0">
-                  <p className="text-sm text-port-warning font-medium">
-                    Dev UI will be blocked on <span className="font-mono">{window.location.hostname}</span>
-                  </p>
-                  <p className="text-xs text-gray-400 mt-1">
-                    {viteHostStatus.hasViteConfig
-                      ? <>This app's Vite dev server ({viteHostStatus.filename}) doesn't allow this host, so opening the Dev UI shows a "Blocked request… not allowed" error.</>
-                      : <>This app exposes a Vite dev server but no <span className="font-mono">vite.config</span> was found to allow this host, so the Dev UI will be blocked.</>}
-                    {' '}It runs on a private Tailscale network — allowing all hosts is safe.
-                  </p>
-                  <div className="flex flex-wrap gap-2 mt-2">
-                    {viteHostStatus.canAutoFix && (
-                      <button
-                        onClick={() => handleFixViteHosts('allow-all')}
-                        disabled={Boolean(viteFixing)}
-                        className="px-2 py-1 bg-port-accent/20 text-port-accent enabled:hover:bg-port-accent/30 transition-colors rounded flex items-center gap-1 disabled:opacity-50 text-xs"
-                      >
-                        {viteFixing === 'allow-all' ? 'Allowing…' : 'Allow all hosts (auto)'}
-                      </button>
-                    )}
+        </div>
+
+        {/* Vite Dev-UI host guard — the app's dev server would block this host. */}
+        {viteHostStatus && !viteHostStatus.hostAllowed && (
+          <div className="mt-3 rounded-lg border border-port-warning/40 bg-port-warning/10 p-3">
+            <div className="flex items-start gap-2">
+              <AlertTriangle size={16} className="text-port-warning mt-0.5 shrink-0" />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm text-port-warning font-medium">
+                  Dev UI will be blocked on <span className="font-mono">{window.location.hostname}</span>
+                </p>
+                <p className="text-xs text-gray-400 mt-1">
+                  {viteHostStatus.hasViteConfig
+                    ? <>This app's Vite dev server ({viteHostStatus.filename}) doesn't allow this host, so opening the Dev UI shows a "Blocked request… not allowed" error.</>
+                    : <>This app exposes a Vite dev server but no <span className="font-mono">vite.config</span> was found to allow this host, so the Dev UI will be blocked.</>}
+                  {' '}It runs on a private Tailscale network — allowing all hosts is safe.
+                </p>
+                <div className="flex flex-wrap gap-2 mt-2">
+                  {viteHostStatus.canAutoFix && (
                     <button
-                      onClick={() => handleFixViteHosts('ai')}
+                      onClick={() => handleFixViteHosts('allow-all')}
                       disabled={Boolean(viteFixing)}
-                      className="px-2 py-1 bg-port-border/40 text-gray-200 enabled:hover:bg-port-border/60 transition-colors rounded flex items-center gap-1 disabled:opacity-50 text-xs"
+                      className="px-2 py-1 bg-port-accent/20 text-port-accent enabled:hover:bg-port-accent/30 transition-colors rounded flex items-center gap-1 disabled:opacity-50 text-xs"
                     >
-                      <Sparkles size={12} />
-                      {viteFixing === 'ai' ? 'Queuing…' : 'Fix with AI'}
+                      {viteFixing === 'allow-all' ? 'Allowing…' : 'Allow all hosts (auto)'}
                     </button>
-                  </div>
-                  {!viteHostStatus.canAutoFix && viteHostStatus.hasViteConfig && (
-                    <p className="text-[11px] text-gray-500 mt-1.5">
-                      Auto-fix can't safely edit this config shape — use AI remediation.
-                    </p>
                   )}
+                  <button
+                    onClick={() => handleFixViteHosts('ai')}
+                    disabled={Boolean(viteFixing)}
+                    className="px-2 py-1 bg-port-border/40 text-gray-200 enabled:hover:bg-port-border/60 transition-colors rounded flex items-center gap-1 disabled:opacity-50 text-xs"
+                  >
+                    <Sparkles size={12} />
+                    {viteFixing === 'ai' ? 'Queuing…' : 'Fix with AI'}
+                  </button>
                 </div>
+                {!viteHostStatus.canAutoFix && viteHostStatus.hasViteConfig && (
+                  <p className="text-[11px] text-gray-500 mt-1.5">
+                    Auto-fix can't safely edit this config shape — use AI remediation.
+                  </p>
+                )}
               </div>
             </div>
-          )}
-        </div>
+          </div>
+        )}
 
         {/* Tab Bar */}
         <div className="flex gap-1 mt-4 -mb-4 overflow-x-auto">


### PR DESCRIPTION
## Summary

The App Detail header looked broken when an app had the Vite Dev-UI host-guard warning showing: the app name and PM2 process-name list collapsed into a narrow wrapping column on the left, and the action buttons (Stop/Restart/Launch/Dev UI/Build/Edit) overlapped that text.

**Root cause:** the warning box was nested *inside* the header's `flex flex-col sm:flex-row sm:items-center` row, alongside the back-link, the name/status block, and the buttons block. On `sm:` and up it therefore became a **fourth flex column**, claiming a wide slice of the row and squeezing the `flex-1 min-w-0` name block down to a sliver — which forced the long process-name list to wrap vertically and the buttons to overlap it.

**Fix:** moved the warning out of the flex row to be a full-width sibling **below** the controls row (still inside the header card, above the tab bar), and dropped the now-unneeded `w-full` (it was only there to fight the flex layout it no longer lives in).

Before: name list wraps into a narrow column, buttons overlap the text.
After: title + status + buttons sit on one row; the warning spans the full width beneath them.

## Test plan

- [x] JSX transforms cleanly (esbuild).
- [x] Manually traced the flex layout: header row now holds only back-link / name block / buttons; warning is a normal block-level sibling.
- No behavior, state, or logic changed — this is a layout-only structural move. No existing tests cover this component; nothing to assert beyond the render structure.