### PR TITLE
feat: next-step CTA when all editorial findings are cleared (#1612)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+## Editorial checks
+
+- **[issue-1612] Cleared findings now point you at the next step instead of a blank list.** When every editorial finding on a series had been accepted or dismissed (or before any check has run), the triage view either showed a screen of collapsed "0 open" groups or a bare "run the checks" line — with no hint at what to do next. The empty/cleared state now surfaces a contextual next-steps block: **Re-run checks** (kicks off all enabled checks without leaving the page), **Refresh reverse outline**, and **Continue in the pipeline** (where Series Autopilot and the visual stages live). The "all cleared" banner renders above the resolved groups so you can still review or undo, and it's suppressed while a filter or muted check is narrowing the view (that case keeps its own "no matches" messaging). (`client/src/components/pipeline/editorial/EditorialFindingsTriage.jsx`, `client/src/pages/PipelineEditorialChecks.jsx`)

--- a/client/src/components/pipeline/editorial/EditorialFindingsTriage.jsx
+++ b/client/src/components/pipeline/editorial/EditorialFindingsTriage.jsx
@@ -15,7 +15,7 @@
  * bulk-dismisses the selection — each result reactively updates local state.
  */
 import { Link, useSearchParams } from 'react-router-dom';
-import { ChevronDown, ChevronRight, ExternalLink, History, Check, X, Loader2, GitCompareArrows, Search, Ban, Undo2, Info } from 'lucide-react';
+import { ChevronDown, ChevronRight, ExternalLink, History, Check, X, Loader2, GitCompareArrows, Search, Ban, Undo2, Info, Play, ArrowRight, CheckCircle2, RefreshCw } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import CheckKindBadge from './CheckKindBadge';
 import {
@@ -622,7 +622,63 @@ function FindingsToolbar({ facets, filters, sort, setParam, toggleInParam, onCle
   );
 }
 
-export default function EditorialFindingsTriage({ seriesId, comments = [], checksById = {}, onCommentChange, onToggleCheckEnabled }) {
+// Contextual next-steps shown when there are no open findings left to triage
+// (#1612): either no check has surfaced anything yet, or every finding has been
+// accepted/dismissed. Without this the user is left on a screen of collapsed
+// "0 open" groups (or a bare "run the checks" line) with no hint at the natural
+// continuations — re-run the checks, refresh the reverse outline, or head back to
+// the series pipeline to push on to visuals/autopilot. `onRunChecks` is optional
+// so the component still renders standalone (tests, embeds without a runner).
+function NextStepsCTA({ seriesId, allCleared, onRunChecks, runDisabled = false }) {
+  return (
+    <div className="space-y-3 rounded-lg border border-port-border bg-port-card p-4 text-center">
+      <div className="space-y-1">
+        {allCleared ? (
+          <p className="flex items-center justify-center gap-1.5 text-sm font-medium text-port-success">
+            <CheckCircle2 size={16} /> All findings cleared
+          </p>
+        ) : (
+          <p className="text-sm font-medium text-gray-200">No editorial-check findings yet.</p>
+        )}
+        <p className="text-xs text-gray-500">
+          {allCleared
+            ? 'Every check finding has been accepted or dismissed. Pick a next step:'
+            : 'Run the enabled checks to populate this list, or continue in the pipeline:'}
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {onRunChecks ? (
+          <button
+            type="button"
+            onClick={onRunChecks}
+            disabled={runDisabled}
+            className="inline-flex items-center gap-1.5 rounded bg-port-accent px-3 py-1.5 text-xs text-white hover:bg-port-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Play size={13} /> {allCleared ? 'Re-run checks' : 'Run checks'}
+          </button>
+        ) : null}
+        {seriesId ? (
+          <>
+            <Link
+              to={`/pipeline/series/${seriesId}/reverse-outline`}
+              className="inline-flex items-center gap-1.5 rounded border border-port-border px-3 py-1.5 text-xs text-gray-300 hover:border-port-accent/40 hover:text-white"
+            >
+              <RefreshCw size={13} /> Refresh reverse outline
+            </Link>
+            <Link
+              to={`/pipeline/series/${seriesId}`}
+              className="inline-flex items-center gap-1.5 rounded border border-port-border px-3 py-1.5 text-xs text-gray-300 hover:border-port-accent/40 hover:text-white"
+            >
+              Continue in the pipeline <ArrowRight size={13} />
+            </Link>
+          </>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export default function EditorialFindingsTriage({ seriesId, comments = [], checksById = {}, onCommentChange, onToggleCheckEnabled, onRunChecks, runDisabled = false }) {
   const groups = useMemo(() => groupFindingsByCheck(comments, checksById), [comments, checksById]);
   const [selectedIds, setSelectedIds] = useState(() => new Set());
 
@@ -759,14 +815,16 @@ export default function EditorialFindingsTriage({ seriesId, comments = [], check
   );
 
   if (!groups.length) {
-    return (
-      <p className="rounded-lg border border-dashed border-port-border p-4 text-center text-xs text-gray-500">
-        No editorial-check findings yet. Run the enabled checks to populate this list.
-      </p>
-    );
+    return <NextStepsCTA seriesId={seriesId} allCleared={false} onRunChecks={onRunChecks} runDisabled={runDisabled} />;
   }
   const totalOpen = openFindingsTotal(groups);
   const shownOpen = openFindingsTotal(visibleView);
+  // Findings exist but none are open — everything's been triaged. Surface the
+  // next-steps CTA (#1612) above the resolved groups (still listed below so the
+  // user can review or undo) instead of leaving a screen of collapsed "0 open"
+  // groups with no guidance. Suppressed while a filter/mute is narrowing the view,
+  // since that has its own "no matches" messaging.
+  const allCleared = totalOpen === 0 && activeFilterCount === 0 && hiddenCheckIds.size === 0;
   return (
     <div id={FINDINGS_TRIAGE_ANCHOR_ID} className="scroll-mt-4 space-y-2">
       <FindingsToolbar
@@ -792,6 +850,9 @@ export default function EditorialFindingsTriage({ seriesId, comments = [], check
             : `${totalOpen} open finding${totalOpen === 1 ? '' : 's'} across ${groups.length} check${groups.length === 1 ? '' : 's'}`}
         </p>
       )}
+      {allCleared ? (
+        <NextStepsCTA seriesId={seriesId} allCleared onRunChecks={onRunChecks} runDisabled={runDisabled} />
+      ) : null}
       {visibleView.length === 0 ? (
         <p className="rounded-lg border border-dashed border-port-border p-4 text-center text-xs text-gray-500">
           {activeFilterCount > 0 ? (

--- a/client/src/components/pipeline/editorial/EditorialFindingsTriage.test.jsx
+++ b/client/src/components/pipeline/editorial/EditorialFindingsTriage.test.jsx
@@ -42,6 +42,40 @@ describe('EditorialFindingsTriage', () => {
     expect(screen.getByText(/No editorial-check findings yet/i)).toBeTruthy();
   });
 
+  it('offers next-step CTAs in the no-findings empty state (#1612)', () => {
+    const onRunChecks = vi.fn();
+    renderTriage({ comments: [], onRunChecks });
+    fireEvent.click(screen.getByRole('button', { name: /Run checks/i }));
+    expect(onRunChecks).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('link', { name: /Refresh reverse outline/i }).getAttribute('href'))
+      .toBe('/pipeline/series/ser-1/reverse-outline');
+    expect(screen.getByRole('link', { name: /Continue in the pipeline/i }).getAttribute('href'))
+      .toBe('/pipeline/series/ser-1');
+  });
+
+  it('shows an "all cleared" CTA when findings exist but none are open (#1612)', () => {
+    const onRunChecks = vi.fn();
+    const comments = [
+      { id: 'c1', checkId: 'naming.dissimilar-names', status: 'accepted', severity: 'high', problem: 'Confusable names' },
+      { id: 'c2', checkId: 'naming.dissimilar-names', status: 'dismissed', severity: 'low', problem: 'Old finding' },
+    ];
+    renderTriage({ comments, onRunChecks });
+    expect(screen.getByText(/All findings cleared/i)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Re-run checks/i }));
+    expect(onRunChecks).toHaveBeenCalledTimes(1);
+    // The resolved groups still render below the CTA so the user can review/undo.
+    expect(screen.getByText('Character name dissimilarity')).toBeTruthy();
+  });
+
+  it('does not show the "all cleared" CTA while any finding is still open (#1612)', () => {
+    const comments = [
+      { id: 'c1', checkId: 'naming.dissimilar-names', status: 'open', severity: 'high', problem: 'Still open' },
+      { id: 'c2', checkId: 'naming.dissimilar-names', status: 'accepted', severity: 'low', problem: 'Done' },
+    ];
+    renderTriage({ comments, onRunChecks: vi.fn() });
+    expect(screen.queryByText(/All findings cleared/i)).toBeNull();
+  });
+
   it('groups findings by check with an open/total header and deep-links each finding', () => {
     const comments = [
       { id: 'c1', checkId: 'naming.dissimilar-names', status: 'open', severity: 'high', issueNumber: 5, problem: 'Confusable names: Alice / Adam' },

--- a/client/src/pages/PipelineEditorialChecks.jsx
+++ b/client/src/pages/PipelineEditorialChecks.jsx
@@ -631,7 +631,7 @@ export default function PipelineEditorialChecks() {
                 {loadingFindings ? (
                   <p className="flex items-center gap-2 text-sm text-gray-400"><Loader2 size={16} className="animate-spin" /> Loading findings…</p>
                 ) : (
-                  <EditorialFindingsTriage seriesId={seriesId} comments={comments} checksById={checksById} onCommentChange={handleCommentChange} onToggleCheckEnabled={handleToggle} />
+                  <EditorialFindingsTriage seriesId={seriesId} comments={comments} checksById={checksById} onCommentChange={handleCommentChange} onToggleCheckEnabled={handleToggle} onRunChecks={() => runChecks(null)} runDisabled={runDisabled || enabledCount === 0} />
                 )}
               </>
             )}


### PR DESCRIPTION
## Summary

When every editorial finding on a series has been accepted/dismissed (or before any check has run), the triage view (`EditorialFindingsTriage`) left the user on a screen of collapsed "0 open" groups — or a bare "run the checks" line — with no guidance on what to do next.

This adds a contextual **next-steps CTA** to both empty states:

- **Re-run checks** — kicks off all enabled checks via the parent's `runChecks(null)` without leaving the page (gated on the same `runDisabled`/`enabledCount` predicates as the header button).
- **Refresh reverse outline** — links to `/pipeline/series/:id/reverse-outline`.
- **Continue in the pipeline** — links to `/pipeline/series/:id`, where Series Autopilot and the visual stages live.

Details:
- The "all cleared" banner renders **above** the resolved groups, which still list below so the user can review or undo a finding.
- It's suppressed while a filter or a session-muted check is narrowing the view — that case keeps its existing "no findings match the current filters" messaging.
- `onRunChecks` / `runDisabled` are optional props, so the component still renders standalone (tests, embeds without a runner) — the button simply hides when no runner is wired.

Closes #1612

## Test plan

- `client/src/components/pipeline/editorial/EditorialFindingsTriage.test.jsx` — 4 new cases: next-step CTAs in the no-findings state (button calls `onRunChecks`, links resolve to the right routes), an "all cleared" CTA when findings exist but none are open (re-run wired, resolved groups still render), and no "all cleared" CTA while any finding is still open. Full file: 34 passing.
- `PipelineEditorialChecks.responsive.test.jsx` — still green.
- `eslint` clean on both changed source files.