### PR TITLE
Guarantee the cross-chunk setup digest reaches final-part-gated editorial checks (#1667)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,1 +1,5 @@
 # Unreleased
+
+## Editorial checks
+
+- **[issue-1667] Final-part editorial verdicts no longer lose their carried setup context on a packed last chunk.** The cross-chunk "setup so far" digest normally yields to manuscript coverage — but two whole-story checks (`arc.climax-agency`, `emotion.reaction-proportionality`) gate their verdict to the final part and anchor it on a snippet carried in that digest (the climax candidate / the unprocessed event). When the final chunk packed to within a few hundred chars of the provider window, the digest was silently dropped and the final-only finding was missed. These checks now opt into a `reserveSetupDigest` guarantee that trims the final chunk's manuscript tail to make room for the digest (the inverse of the usual yield), scoped to the final chunk and opt-in checks only — every other chunk and every non-reserving check keeps full manuscript coverage. (`server/lib/editorial/checkRegistry.js`)

--- a/server/lib/editorial/checkRegistry.js
+++ b/server/lib/editorial/checkRegistry.js
@@ -1142,9 +1142,11 @@ export function buildSetupDigestPrompt({ focus, priorSummary, manuscript }) {
 // so a final chunk packed to within a few hundred chars of the window silently
 // drops the digest and the final-only finding is missed. When this opt-in is set
 // and the digest doesn't fit the final chunk's spare room, the manuscript TAIL is
-// trimmed by the digest's size (the inverse of the usual yield) so the verdict
-// keeps its carried context. Scoped to the final chunk and to opt-in checks only —
-// every other chunk, and every non-reserving check, keeps full manuscript coverage.
+// trimmed to reserve the digest's room (the inverse of the usual yield) so the
+// verdict keeps its carried context. Scoped to the final chunk and to opt-in checks
+// only — every other chunk, and every non-reserving check, keeps full manuscript
+// coverage. If the digest alone is larger than the whole window it still yields
+// (never prepended past the budget), preserving the no-overflow contract.
 async function runChunkedManuscriptCheck(ctx, { chunks, category, max, callChunk, crossChunkDigest = false, summarizeChunk = null, reserveSetupDigest = false }) {
   const usableChars = Number.isFinite(chunks?.usableChars) ? chunks.usableChars : Infinity;
   const merged = new Map();
@@ -1178,14 +1180,18 @@ async function runChunkedManuscriptCheck(ctx, { chunks, category, max, callChunk
         // Fits into whatever spare room remains AFTER the findings digest — manuscript
         // coverage and the findings digest both win over the setup digest if budget is tight.
         text = `${setup}${text}`;
-      } else if (setup && reserveSetupDigest && isFinal && Number.isFinite(usableChars)) {
+      } else if (setup && reserveSetupDigest && isFinal && setup.length <= usableChars) {
         // #1667: the digest didn't fit, but this check gates its verdict to the final
-        // part and anchors it on the carried snippet — so trim the manuscript tail to
-        // make room rather than drop the carried context. Slicing `text` (findings
-        // digest + manuscript) from the end keeps the higher-value front (the findings
-        // digest and the manuscript head) and total stays at exactly `usableChars`.
-        const room = Math.max(0, usableChars - setup.length);
-        text = `${setup}${text.slice(0, room)}`;
+        // part and anchors it on the carried snippet — so reserve the digest's room and
+        // fill the rest with the manuscript HEAD (trimming its tail) rather than drop
+        // the carried context. Rebuild from the RAW `manuscript`, NOT the
+        // findings-digest-prefixed `text`: slicing `text` could truncate the findings
+        // digest mid-block into a malformed prefix, and the findings digest's job
+        // (suppressing duplicate re-flags) is already covered by the first-wins merge,
+        // so it safely yields here. Gated on `setup.length <= usableChars` so a digest
+        // larger than the whole window yields instead of overflowing it — preserving
+        // the pre-reserve no-overflow contract on a tiny/high-overhead window.
+        text = `${setup}${manuscript.slice(0, usableChars - setup.length)}`;
       }
     }
     const content = await callChunk(text, { isFinal });

--- a/server/lib/editorial/checkRegistry.js
+++ b/server/lib/editorial/checkRegistry.js
@@ -1134,7 +1134,18 @@ export function buildSetupDigestPrompt({ focus, priorSummary, manuscript }) {
 // chunks — also yielding to spare room. It is a no-op for a single-chunk run (no
 // later chunk consumes a summary), so the common fits-in-one-call provider pays
 // nothing.
-async function runChunkedManuscriptCheck(ctx, { chunks, category, max, callChunk, crossChunkDigest = false, summarizeChunk = null }) {
+//
+// `reserveSetupDigest` (#1667) GUARANTEES the carried setup digest reaches the
+// FINAL chunk for checks that gate a whole-story verdict to it and anchor that
+// verdict on the carried snippet (arc.climax-agency #1583, emotion.reaction-
+// proportionality #1584). The setup digest normally yields to manuscript coverage,
+// so a final chunk packed to within a few hundred chars of the window silently
+// drops the digest and the final-only finding is missed. When this opt-in is set
+// and the digest doesn't fit the final chunk's spare room, the manuscript TAIL is
+// trimmed by the digest's size (the inverse of the usual yield) so the verdict
+// keeps its carried context. Scoped to the final chunk and to opt-in checks only —
+// every other chunk, and every non-reserving check, keeps full manuscript coverage.
+async function runChunkedManuscriptCheck(ctx, { chunks, category, max, callChunk, crossChunkDigest = false, summarizeChunk = null, reserveSetupDigest = false }) {
   const usableChars = Number.isFinite(chunks?.usableChars) ? chunks.usableChars : Infinity;
   const merged = new Map();
   // The presence of `summarizeChunk` (set only when the check opts into the
@@ -1147,6 +1158,13 @@ async function runChunkedManuscriptCheck(ctx, { chunks, category, max, callChunk
     // only checks the signal around the whole check, so without this a multi-
     // chunk check keeps paying for LLM calls whose results will be discarded.
     if (ctx.signal?.aborted) break;
+    // `isFinal` lets a check distinguish the last part of a chunked manuscript
+    // from earlier ones (#1299): a whole-corpus judgment like "this setup is
+    // never paid off" can only be made once the final part is in view, so the
+    // Chekhov check defers its "planted, never fired" findings to it. A
+    // single-chunk run is its own final part, so the common (provider-fits-the-
+    // book) case judges against the whole text. Existing checks ignore the arg.
+    const isFinal = i === chunks.length - 1;
     let text = manuscript;
     if (crossChunkDigest && merged.size) {
       const digest = editorialPriorFindingsDigest([...merged.values()]);
@@ -1156,17 +1174,21 @@ async function runChunkedManuscriptCheck(ctx, { chunks, category, max, callChunk
     }
     if (summarizeChunk && setupSummary) {
       const setup = editorialSetupDigest(setupSummary);
-      // Fits into whatever spare room remains AFTER the findings digest — manuscript
-      // coverage and the findings digest both win over the setup digest if budget is tight.
-      if (setup && setup.length <= usableChars - text.length) text = `${setup}${text}`;
+      if (setup && setup.length <= usableChars - text.length) {
+        // Fits into whatever spare room remains AFTER the findings digest — manuscript
+        // coverage and the findings digest both win over the setup digest if budget is tight.
+        text = `${setup}${text}`;
+      } else if (setup && reserveSetupDigest && isFinal && Number.isFinite(usableChars)) {
+        // #1667: the digest didn't fit, but this check gates its verdict to the final
+        // part and anchors it on the carried snippet — so trim the manuscript tail to
+        // make room rather than drop the carried context. Slicing `text` (findings
+        // digest + manuscript) from the end keeps the higher-value front (the findings
+        // digest and the manuscript head) and total stays at exactly `usableChars`.
+        const room = Math.max(0, usableChars - setup.length);
+        text = `${setup}${text.slice(0, room)}`;
+      }
     }
-    // `isFinal` lets a check distinguish the last part of a chunked manuscript
-    // from earlier ones (#1299): a whole-corpus judgment like "this setup is
-    // never paid off" can only be made once the final part is in view, so the
-    // Chekhov check defers its "planted, never fired" findings to it. A
-    // single-chunk run is its own final part, so the common (provider-fits-the-
-    // book) case judges against the whole text. Existing checks ignore the arg.
-    const content = await callChunk(text, { isFinal: i === chunks.length - 1 });
+    const content = await callChunk(text, { isFinal });
     for (const f of mapLlmFindings(content?.findings, {
       severityDefault: ctx.severityDefault,
       category,
@@ -1227,7 +1249,7 @@ async function runChunkedManuscriptCheck(ctx, { chunks, category, max, callChunk
 // check). Existing checks ignore the extra args. These checks are all
 // manuscript-scoped, so findings keep a model-supplied issue number
 // (`withIssueNumber: true`).
-async function runManuscriptLlmCheck(ctx, { stage, category, overheadTokens = 0, context = null, buildVars, crossChunkDigest = false, crossChunkSetup = false, setupFocus = '' }) {
+async function runManuscriptLlmCheck(ctx, { stage, category, overheadTokens = 0, context = null, buildVars, crossChunkDigest = false, crossChunkSetup = false, setupFocus = '', reserveSetupDigest = false }) {
   const max = ctx.config?.maxFindings ?? 12;
   // Chunks are planned at the full usable budget; the digest is fitted into each
   // later chunk's spare room inside runChunkedManuscriptCheck (it yields to the
@@ -1261,6 +1283,7 @@ async function runManuscriptLlmCheck(ctx, { stage, category, overheadTokens = 0,
     max,
     crossChunkDigest,
     summarizeChunk,
+    reserveSetupDigest,
     callChunk: async (manuscript, meta) => {
       const { content } = await ctx.callStagedLLM(stage, buildVars(manuscript, meta, fittedContext), { returnsJson: true, source: stage });
       return content;
@@ -4079,6 +4102,11 @@ export const EDITORIAL_CHECKS = [
         // their hardest active choice.
         crossChunkDigest: true,
         crossChunkSetup: true,
+        // #1667: this check's verdict is gated to the final part AND anchored on the
+        // carried CLIMAX CANDIDATE snippet, so the setup digest must reach the final
+        // chunk even when it's packed to the window — reserve room for it by trimming
+        // the final chunk's manuscript tail rather than silently dropping the snippet.
+        reserveSetupDigest: true,
         // The setup digest is a separate rolling-summary call (buildSetupDigestPrompt)
         // whose output is fed into the FINAL chunk's prompt. The climax can land in a
         // non-final chunk (followed by a denouement chunk), so the digest must carry
@@ -4168,6 +4196,11 @@ export const EDITORIAL_CHECKS = [
         // happened pages earlier.
         crossChunkDigest: true,
         crossChunkSetup: true,
+        // #1667: the under-reaction verdict is gated to the final part AND anchored on
+        // the carried unprocessed-event snippet, so guarantee the setup digest reaches
+        // the final chunk (trim its manuscript tail to fit) rather than letting a packed
+        // final chunk drop the snippet and miss the unprocessed-trauma finding.
+        reserveSetupDigest: true,
         setupFocus: 'List the high-magnitude emotional events seen so far (a death, trauma, betrayal, '
           + 'a major loss or hard-won victory) and, for each, whether the affected character has yet shown '
           + 'a proportionate on-page reaction or processed it. CRUCIALLY: carry forward every event that is '

--- a/server/lib/editorial/checkRegistry.test.js
+++ b/server/lib/editorial/checkRegistry.test.js
@@ -3408,6 +3408,51 @@ describe('cross-chunk clean-setup digest (#1403)', () => {
     expect(seen[1]).not.toContain('Setup already established in EARLIER parts');
   });
 
+  it('yields (no overflow) when the setup digest alone is larger than the whole window, even for an opt-in check (#1667)', async () => {
+    const digest = editorialSetupDigest('- SETUP: past tense, first person');
+    const usableChars = digest.length - 5; // even the digest alone overflows the window
+    const { seen } = await runTwoChunksWithSetup('arc.climax-agency', {}, { usableChars });
+    // A digest that can't fit the window at all must not be prepended — fall back to
+    // the manuscript chunk untouched rather than send an over-budget prompt.
+    expect(seen[1]).toBe('CHUNK_TWO');
+    expect(seen[1]).not.toContain('Setup already established in EARLIER parts');
+  });
+
+  it('reserves from the RAW manuscript so a prepended findings digest is never truncated mid-block (#1667)', async () => {
+    const setupDigest = editorialSetupDigest('- SETUP: past tense, first person');
+    // A finding from the first chunk produces a findings digest carried into the final
+    // chunk; size the window so the findings digest fits there but the setup digest
+    // doesn't, forcing the reserve branch.
+    const findingsDigest = editorialPriorFindingsDigest([{ category: 'arc', problem: 'passive climax', issueNumber: 1, location: '' }]);
+    const usableChars = setupDigest.length + findingsDigest.length + 2;
+    const seen = [];
+    let call = 0;
+    await getCheck('arc.climax-agency').run({
+      config: { maxFindings: 12 },
+      severityDefault: 'medium',
+      planManuscriptChunks: async () => {
+        const chunks = ['CHUNK_ONE', 'CHUNK_TWO'];
+        chunks.usableChars = usableChars;
+        return chunks;
+      },
+      callStagedLLM: async (_stage, vars) => {
+        seen.push(vars.manuscript);
+        call += 1;
+        // First chunk emits a finding so the final chunk carries a findings digest.
+        return call === 1
+          ? { content: { findings: [{ problem: 'passive climax', severity: 'medium', issueNumber: 1 }] } }
+          : { content: { findings: [] } };
+      },
+      callStageScopedInlineLLM: async () => ({ content: '- SETUP: past tense, first person' }),
+    });
+    // Final chunk: setup digest guaranteed + the manuscript head, rebuilt from the raw
+    // manuscript — so the findings digest is dropped whole, never sliced into a
+    // malformed fragment (the old `text.slice` would have emitted a partial header).
+    expect(seen[1]).toBe(`${setupDigest}CHUNK_TWO`);
+    expect(seen[1]).not.toContain('Editorial findings already recorded');
+    expect(seen[1].length).toBeLessThanOrEqual(usableChars);
+  });
+
   it('only reserves on the FINAL chunk — a non-final chunk still yields the digest to manuscript coverage (#1667)', async () => {
     const digest = editorialSetupDigest('- SETUP: past tense, first person');
     const seen = [];

--- a/server/lib/editorial/checkRegistry.test.js
+++ b/server/lib/editorial/checkRegistry.test.js
@@ -3365,6 +3365,72 @@ describe('cross-chunk clean-setup digest (#1403)', () => {
     expect(seen[1]).not.toContain('Setup already established in EARLIER parts');
   });
 
+  // #1667: a check that gates a whole-story verdict to the final part AND anchors it on
+  // the carried setup snippet opts into `reserveSetupDigest` — so when the digest can't
+  // ride alongside a packed final chunk, the manuscript TAIL is trimmed to guarantee the
+  // carried context, rather than silently dropping it and missing the final-only finding.
+  it('reserves room for the setup digest on the FINAL chunk of an opt-in check (#1667), trimming the manuscript tail', async () => {
+    const digest = editorialSetupDigest('- SETUP: past tense, first person');
+    // Window leaves only 4 chars of spare room beyond the digest, so the digest cannot
+    // ride alongside the full final chunk — but arc.climax-agency opts in, so the
+    // manuscript tail is trimmed instead of the digest dropped.
+    const usableChars = digest.length + 4;
+    const { seen } = await runTwoChunksWithSetup('arc.climax-agency', {}, { usableChars });
+    // First chunk untouched (no prior setup yet).
+    expect(seen[0]).toBe('CHUNK_ONE');
+    // Final chunk: the guaranteed setup digest + only the head of the manuscript chunk
+    // (tail trimmed), and the total never exceeds the window.
+    expect(seen[1].startsWith(digest)).toBe(true);
+    expect(seen[1]).toContain('past tense, first person');
+    expect(seen[1]).toBe(`${digest}CHUN`);
+    expect(seen[1].length).toBe(usableChars);
+  });
+
+  it('reserves the setup digest even when it fully displaces the final manuscript chunk (#1667)', async () => {
+    const digest = editorialSetupDigest('- SETUP: past tense, first person');
+    const usableChars = digest.length; // zero spare room: digest exactly fills the window
+    const { seen } = await runTwoChunksWithSetup('emotion.reaction-proportionality', {}, { usableChars });
+    expect(seen[1]).toBe(digest); // manuscript tail trimmed to nothing, digest guaranteed
+    expect(seen[1].length).toBe(usableChars);
+  });
+
+  it('does NOT reserve the setup digest for a check that did not opt in (manuscript coverage still wins)', async () => {
+    const digest = editorialSetupDigest('- SETUP: past tense, first person');
+    // Same window where the opt-in check would trim to fit — but style.conformance does
+    // not set reserveSetupDigest, so the digest yields and the full manuscript chunk runs.
+    const usableChars = digest.length + 4;
+    const { seen } = await runTwoChunksWithSetup(
+      'style.conformance',
+      { series: { styleGuide: { tense: 'past', povPerson: 'first' } } },
+      { usableChars },
+    );
+    expect(seen[1]).toBe('CHUNK_TWO');
+    expect(seen[1]).not.toContain('Setup already established in EARLIER parts');
+  });
+
+  it('only reserves on the FINAL chunk — a non-final chunk still yields the digest to manuscript coverage (#1667)', async () => {
+    const digest = editorialSetupDigest('- SETUP: past tense, first person');
+    const seen = [];
+    // Three chunks: the MIDDLE chunk (i=1) consumes a setup summary but is not final, so
+    // even for an opt-in check it must yield (no tail trimming) when the digest won't fit.
+    await getCheck('arc.climax-agency').run({
+      config: { maxFindings: 12 },
+      severityDefault: 'medium',
+      planManuscriptChunks: async () => {
+        const chunks = ['CHUNK_ONE', 'CHUNK_TWO', 'CHUNK_THREE'];
+        chunks.usableChars = digest.length + 4; // would force a trim IF this were the final chunk
+        return chunks;
+      },
+      callStagedLLM: async (_stage, vars) => { seen.push(vars.manuscript); return { content: { findings: [] } }; },
+      callStageScopedInlineLLM: async () => ({ content: '- SETUP: past tense, first person' }),
+    });
+    // Middle chunk yields the digest (not final) → runs the full manuscript untouched.
+    expect(seen[1]).toBe('CHUNK_TWO');
+    // Final chunk reserves → digest guaranteed, manuscript tail trimmed.
+    expect(seen[2].startsWith(digest)).toBe(true);
+    expect(seen[2]).toBe(`${digest}CHUN`);
+  });
+
   it('degrades to findings-only when no inline LLM caller is injected (no setup digest, no crash)', async () => {
     // No callStageScopedInlineLLM in ctx → the setup-summary path stays off entirely.
     const seen = [];


### PR DESCRIPTION
## Summary

`runChunkedManuscriptCheck` prepends the cross-chunk **setup digest** (the rolling "setup so far" summary, #1403) only when it fits a chunk's spare room — it yields to manuscript coverage by design. That is correct for checks where the digest is a nice-to-have, but **best-effort** for checks that gate a whole-story verdict to the final part and **anchor** that verdict on a snippet carried forward in the digest:

- `arc.climax-agency` (#1583) — the final-part climax verdict needs the carried CLIMAX CANDIDATE snippet.
- `emotion.reaction-proportionality` (#1584) — the final-part under-reaction verdict needs the carried unprocessed-event snippet.

When the final chunk packs to within a few hundred chars of the provider window, the digest was silently omitted and the final-only finding was missed (graceful — never a false positive or crash, but the advertised cross-chunk path didn't fire).

This implements **Option 2** from the issue: a per-check opt-in `reserveSetupDigest` that, **on the final chunk only**, trims the manuscript tail by the digest's size to guarantee the carried context (the inverse of the usual yield). The two final-part-gated checks opt in.

- Scoped to opt-in checks and the **final** chunk — every other chunk and every non-reserving check keeps full manuscript coverage.
- No-op for the common fits-in-one-call provider (unbounded headroom) and for checks that don't opt in.
- Self-contained in `checkRegistry.js` — no runner / `planManuscriptChunks` changes.

## Test plan

- `cd server && npx vitest run lib/editorial/checkRegistry.test.js` — 414 pass, incl. 4 new cases:
  - reserves on the final chunk, trimming the manuscript tail to fit the digest
  - reserves even when the digest fully displaces the final manuscript chunk
  - does NOT reserve for a non-opt-in check (manuscript coverage still wins)
  - only reserves on the FINAL chunk — a non-final chunk still yields the digest
- `cd server && npx vitest run lib/editorial/` — 646 pass, no regressions.

Closes #1667