### PR TITLE
Add /do:pr and /remote-control quick-command buttons to the Shell page

### DIFF
--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -26,6 +26,10 @@ const QUICK_COMMANDS = [
   { label: 'git pull', command: 'git pull --rebase --autostash' },
   { label: 'npm test', command: 'npm test' },
   { label: 'npm run dev', command: 'npm run dev' },
+  // Claude Code slash-command shortcuts — typed + submitted into an interactive
+  // `claude` session. The flags are double-dash (`--`); keep them verbatim.
+  { label: '/do:pr', command: '/do:pr --issues --review-with=claude,codex --merge' },
+  { label: '/remote-control', command: '/remote-control' },
 ];
 
 // Hot buttons for arrow / Enter entry — handy on touch devices and for driving TUI


### PR DESCRIPTION
## Summary

Adds two Claude Code slash-command shortcut buttons to the Shell page's quick-command toolbar:

- `/do:pr --issues --review-with=claude,codex --merge` (flags are double-dash)
- `/remote-control`

Both are appended to the existing `QUICK_COMMANDS` array in `client/src/pages/Shell.jsx`, so they render as buttons alongside the existing shortcuts (`git status`, `npm test`, etc.) and reuse the existing `sendCommand` path — the command text is typed and submitted into the connected interactive session over the socket.

A reviewer noted `/remote-control` is not currently a shipped slash command in this repo; the button was requested explicitly and simply sends the text, so it's kept as-is for the user to back with a global/project command.

## Test plan

- No tests assert on the `QUICK_COMMANDS` shape (no `Shell.test.*` exists), so this is a data-only addition with no behavior change to the send path.
- Manual: open `/shell`, connect a session, and confirm both new buttons appear in the quick-command toolbar and send the expected text.