### PR TITLE
fix(shell): make the quick-command button run /do:next, not /do:pr

### DIFF
--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -28,7 +28,7 @@ const QUICK_COMMANDS = [
   { label: 'npm run dev', command: 'npm run dev' },
   // Claude Code slash-command shortcuts — typed + submitted into an interactive
   // `claude` session. The flags are double-dash (`--`); keep them verbatim.
-  { label: '/do:pr', command: '/do:pr --issues --review-with=claude,codex --merge' },
+  { label: '/do:next', command: '/do:next --issues --review-with=claude,codex --merge' },
   { label: '/remote-control', command: '/remote-control' },
 ];
 


### PR DESCRIPTION
## Summary
Corrects the Shell quick-command shortcut added in the previous change: the button should fire `/do:next` (claim the next item and ship a PR), not `/do:pr`. The flags are unchanged (`--issues --review-with=claude,codex --merge`), which `/do:next` accepts and forwards to its internal `/do:pr` step.

Single-line change to the `QUICK_COMMANDS` array in `client/src/pages/Shell.jsx`.

## Test plan
- No tests reference the quick-command label/command strings (verified via grep), so none needed.
- Local review gate + claude/codex/ollama reviewers: all clean.