### PR TITLE
Pin validated mlx 0.31.2 trio for LoRA training (#1329)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Local model stack
+
+- **[issue-1329] Pinned a validated mlx/mlx-metal trio for LoRA training so the GPU-watchdog stack can't silently drift back to the known-bad build.** The three M5 Max kernel panics during FLUX.2 LoRA training all happened on mlx/mlx-metal 0.30.6, but `setup-image-video.sh` installed `mflux>=0.17` as a *floor* and let pip resolve mlx under mflux's `mlx<0.32` cap — so a reinstall could land back on a panicking build. The setup script now pins the bisect-validated trio **mflux 0.17.5 · mlx 0.31.2 · mlx-metal 0.31.2**, proven by run `d36562a0` completing a full LoRA training to adapter extraction (flux2-klein-4b, bf16, 768px, segmentation on) on the panicking M5 Max with no panic or reboot. The runtime-fingerprint half shipped earlier (#1406). The pure segmentation-OFF 9B verdict and the upstream mflux/MLX issue filing stay deferred — both need a destructive sustained-GPU repro that risks a hard reboot. (`scripts/setup-image-video.sh`, `docs/research/2026-06-13-mflux-training-watchdog-panic.md`)
+
 ## Mood boards
 
 - **Fix: Pinterest sync pulled 0 pins from boards that actually had images.** Two bugs compounded. (1) Linking a board *section* URL (`/user/board/section/`) stored a `/user/board/section.rss` feed, but Pinterest serves no per-section RSS — that path returns its HTML page with a 200, which parsed to zero pins. Section URLs now collapse to the parent board's feed (the best available, since Pinterest has no section feed), keeping the section URL for display; already-linked section boards self-heal on the next sync. (2) Pinterest entity-escapes each pin's description HTML (`&lt;img src=…&gt;`) rather than wrapping it in CDATA, so the `<img>` fallback never matched the live feed and every pin was skipped; the parser now decodes the description before probing for the image. (`server/lib/pinterestFeed.js`, `server/services/moodBoard/pinterest.js`)

--- a/docs/plans/2026-06-14-lora-watchdog-phosphene-review.md
+++ b/docs/plans/2026-06-14-lora-watchdog-phosphene-review.md
@@ -125,7 +125,7 @@ Phosphene's experience **confirms the architecture** rather than replacing it.
 | 1 | Record the eval-cadence negative result | this doc + incident doc | done |
 | 2 | ~~Inject per-block `mx.eval` into training~~ | — | **dropped** (not viable; see above) |
 | 3 | Phase-aware soft-hang stall watchdog (SIGKILL + auto-resume) | Node `loraTraining` + `mediaJobQueue` | PLAN item (defensive-only; needs careful phase budgets) |
-| 4 | Version bisect on the M5 → pin validated trio + runtime fingerprint + upstream issue | `setup-image-video.sh`, `train_mflux_lora.py` | PLAN item (blocked on M5 + a full run) |
+| 4 | Version bisect on the M5 → pin validated trio + runtime fingerprint + upstream issue | `setup-image-video.sh`, `train_mflux_lora.py` | **done (#1329, 2026-06-27)** — fingerprint shipped #1406; trio **mflux 0.17.5 · mlx 0.31.2 · mlx-metal 0.31.2** pinned after run `d36562a0` completed a full seg-ON LoRA on it (no panic). Pure seg-OFF 9B verdict + upstream filing deferred (destructive repro) |
 | 5 | Z-Image / FLUX.2-edit LoRA training; face+voice LoRA | future | separate proposals |
 
 Items 3–5 are captured as slug-tagged entries in `PLAN.md` → "Next Up".

--- a/docs/research/2026-06-13-mflux-training-watchdog-panic.md
+++ b/docs/research/2026-06-13-mflux-training-watchdog-panic.md
@@ -244,7 +244,28 @@ doesn't lose which version was under test.
 | When | mflux | mlx | mlx-metal | Result | powermetrics verdict |
 |---|---|---|---|---|---|
 | (baseline, not run) | 0.17.5 | 0.30.6 | 0.30.6 | known-bad (3 panics 06-13/14) | none captured (sudo was off) |
-| 2026-06-14 candidate #1 | 0.17.5 | **0.31.2** | **0.31.2** | ⏳ IN FLIGHT — survived to step ~11/600 @ 13:45 (box up, no panic) | telemetry capturing (`_bisect-mlx0312/powermetrics.log`) |
+| 2026-06-14 candidate #1 | 0.17.5 | **0.31.2** | **0.31.2** | ✅ **VALIDATED (seg-ON)** — full LoRA run `d36562a0` completed to adapter extraction (4B bf16, 768px, 4×150-step segs); box up, no panic. Pinned 2026-06-27 (#1329). | telemetry captured; GPU/power normal through the run |
+
+**Verdict & pin (2026-06-27, #1329).** The candidate #1 "IN FLIGHT" row above was
+the *seg-OFF scratch* run, which was **manually stopped clean at step ~11** (never
+reached the 150–300-step panic window) and superseded — it did NOT panic. The
+real validation is run **`d36562a0`** (`flux2-klein-4b`, bf16, 768px, segmentation
+ON: 4 × 150-step segments), which **COMPLETED to adapter extraction** on
+mflux 0.17.5 · mlx 0.31.2 · mlx-metal 0.31.2 with no panic and no reboot
+(`STATUS.txt`: "VERDICT: COMPLETED — adapter extracted"). That trio is now pinned
+in `scripts/setup-image-video.sh` (replacing the `mflux>=0.17` floor that let mlx
+drift), per phosphene's "every pin is a paid lesson."
+
+This validates the **production config** (segmentation ON — the shipped
+mitigation). The **pure seg-OFF sustained 9B-bf16 verdict on 0.31.2 remains
+untested** — a seg-OFF run reproduces the original panic condition and risks a
+session-killing hard reboot (~3.5–7 h to clear the panic window at ~1.3–1.6
+min/step). Run it on the throwaway dataset if a definitive "the driver hang
+itself is fixed" answer is wanted; until then the pin rests on a completed
+real-world run plus segmentation as the standing mitigation. The upstream
+mflux/MLX issue draft (`docs/research/2026-06-14-upstream-issue-draft-m5-watchdog.md`)
+stays unfiled pending a telemetry-captured seg-OFF repro that disambiguates
+thermal vs driver.
 
 **Speed finding (2026-06-14 ~14:10) — 9B bf16 is pathologically slow on this box; 4B is ~25× faster.**
 The first Freydis run (`flux2-klein-9b`, bf16, 768px, 600 steps) ran **14 minutes
@@ -289,9 +310,9 @@ Candidate #1 rationale: bump only the MLX/Metal backend (highest-probability
 driver-hang fix); mflux held at 0.17.5 to isolate the variable. mflux caps
 `mlx<0.32` and its `dev` extra pins `mlx==0.31.0`, so 0.31.2 is in-range and
 closer to what mflux develops against than the installed 0.30.6.
-**If this entry still says IN FLIGHT after a reboot: candidate #1 PANICKED** —
-read the scratch `powermetrics.log` (highest timestamp) for thermal-vs-driver,
-then fall back to 0.30.6 or try mflux 0.18.0.
+**Resolved 2026-06-27 (#1329):** candidate #1 did NOT panic — the seg-OFF scratch
+was manually stopped clean and superseded by the completed seg-ON run `d36562a0`.
+The 0.31.2 trio is now pinned (see "Verdict & pin" under the bisect table above).
 
 ## If it recurs — investigation checklist
 

--- a/scripts/setup-image-video.sh
+++ b/scripts/setup-image-video.sh
@@ -87,11 +87,26 @@ if [[ "$INSTALL_MFLUX" == "1" ]]; then
   # trainer dies with a bare "exited with code 2" — see train_mflux_lora.py.
   #
   echo "📦 Installing image generation packages (mflux + deps)..."
+  # VALIDATED TRIO (issue #1329) — pin the MLX/Metal backend, do NOT leave it a
+  # floor. The original three M5 Max GPU-watchdog kernel panics
+  # (docs/research/2026-06-13-mflux-training-watchdog-panic.md) happened on
+  # mlx/mlx-metal 0.30.6. A `>=` floor lets pip resolve mlx silently under
+  # mflux's `mlx<0.32` cap, so the stack can drift back onto a known-bad build.
+  # The surviving trio is mflux 0.17.5 · mlx 0.31.2 · mlx-metal 0.31.2:
+  # run d36562a0 (flux2-klein-4b, bf16, 768px) completed a full LoRA training to
+  # adapter extraction on this stack on the panicking M5 Max (Mac17,7/T6050,
+  # macOS 26.5.1) with no panic — see the bisect log in the incident doc.
+  # (mflux's `dev` extra itself pins mlx==0.31.0, so 0.31.2 is in-range and
+  # closer to what mflux develops against than the old 0.30.6.) Bump these only
+  # after re-validating with another full run on the M5; record the proving run.
+  MFLUX_PIN='mflux==0.17.5'
+  MLX_PIN='mlx==0.31.2'
+  MLX_METAL_PIN='mlx-metal==0.31.2'
   # Step 1: force-reinstall mflux's OWN files with --no-deps to flush a stale
   # file layout left by a partial reinstall (we hit this on 0.12.1, where
   # `mflux/models/flux/cli/` went missing, breaking the entry-point shim)
   # WITHOUT re-downloading the heavy torch/mlx tree.
-  "$PYTHON_BIN" -m pip install --upgrade --user --force-reinstall --no-deps 'mflux>=0.17'
+  "$PYTHON_BIN" -m pip install --upgrade --user --force-reinstall --no-deps "$MFLUX_PIN"
   # Step 2: let pip install mflux's DECLARED runtime deps — pip is the source
   # of truth, not a hand-kept list. mflux 0.17 imports packages the 0.12.x set
   # omitted (pillow, matplotlib, platformdirs, sentencepiece, piexif, …) and
@@ -100,7 +115,9 @@ if [[ "$INSTALL_MFLUX" == "1" ]]; then
   # No --no-deps (so missing deps ARE pulled) and no --upgrade (so an
   # already-satisfied heavyweight like torch isn't re-resolved/re-downloaded on
   # repeat runs); a dep that violates mflux's constraints is still corrected.
-  "$PYTHON_BIN" -m pip install --user 'mflux>=0.17'
+  # The explicit mlx/mlx-metal pins ride alongside mflux so pip resolves the
+  # proven backend rather than the latest in-range build.
+  "$PYTHON_BIN" -m pip install --user "$MFLUX_PIN" "$MLX_PIN" "$MLX_METAL_PIN"
 fi
 
 if [[ "$INSTALL_VIDEO" == "1" ]]; then


### PR DESCRIPTION
## Summary

Closes out the actionable half of #1329 — the **bisect + pin** of a validated mlx/mlx-metal trio for FLUX.2 LoRA training. (The runtime-fingerprint half shipped earlier in #1406.)

The three M5 Max GPU-watchdog kernel panics during LoRA training all hit on **mlx/mlx-metal 0.30.6**, but `scripts/setup-image-video.sh` installed `mflux>=0.17` as a *floor* and let pip resolve mlx silently under mflux's `mlx<0.32` cap — so a reinstall could drift right back onto a known-bad build. This pins the bisect-validated trio:

- **mflux 0.17.5 · mlx 0.31.2 · mlx-metal 0.31.2**

proven by run `d36562a0` completing a **full LoRA training to adapter extraction** (flux2-klein-4b, bf16, 768px, segmentation ON) on the panicking M5 Max (`Mac17,7`/`T6050`, macOS 26.5.1) with no panic and no reboot (its `STATUS.txt`: "VERDICT: COMPLETED — adapter extracted"). mflux's `dev` extra itself pins `mlx==0.31.0`, so 0.31.2 is in-range and closer to what mflux develops against than the old 0.30.6.

### Deferred (availability-gated, not blocking)

- **Pure segmentation-OFF 9B verdict.** This validates the *production config* (segmentation ON — the shipped mitigation). A pure seg-OFF sustained 9B-bf16 run would prove the driver hang *itself* is fixed rather than just mitigated, but it reproduces the original panic condition and risks a session-killing hard reboot (~3.5–7 h to clear the panic window). Documented in the incident doc to run on the throwaway dataset if a definitive answer is wanted.
- **Upstream mflux/MLX issue filing.** Draft stays in `docs/research/2026-06-14-upstream-issue-draft-m5-watchdog.md`, unfiled pending a telemetry-captured seg-OFF repro that disambiguates thermal vs driver.

## Test plan

- `bash -n scripts/setup-image-video.sh` passes.
- No JS changed (the `mflux`/`mlx` references in `server/lib/pythonSetup.js` are import-probe lists, not version specs — nothing to mirror).
- Bisect log + verdict recorded in `docs/research/2026-06-13-mflux-training-watchdog-panic.md`; status table updated in `docs/plans/2026-06-14-lora-watchdog-phosphene-review.md`.

Refs #1329
