### PR TITLE
Record seg-OFF AGX-fix validation PANIC + mlx #3267 data point (#1329)

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -317,6 +317,16 @@ display asleep / lid closed under `caffeinate -s &`, or drive the box headless o
 SSH from another machine. With no WindowServer compositing the watchdog has nothing
 to protect and largely stops firing.
 
+> **Validated on M5 Max (2026-06-27): the env var alone is NOT enough for heavy
+> runs.** A 9B-bf16 segmentation-OFF run *with `AGX_RELAX_CDM_CTXSTORE_TIMEOUT=1`
+> set but the display active* still hard-rebooted within minutes. Telemetry showed
+> Nominal thermal pressure (so it's a GPU **driver hang**, not heat) and the
+> paniclog had `WindowServer` as the top-CPU thread (active-display contention).
+> For a **9B / heavy bf16 run you must also keep the display off** (lid closed /
+> asleep / SSH headless) — and prefer **segmentation ON** (the shipped default),
+> which on this box completed a full 4B run cleanly. `caffeinate -s` alone does
+> *not* turn the display off; it only prevents system sleep.
+
 **Mitigations already in place**:
 - `AGX_RELAX_CDM_CTXSTORE_TIMEOUT=1` is set automatically by the trainer (the
   maintainer-confirmed workaround for mlx #3267); the run log shows

--- a/docs/research/2026-06-13-mflux-training-watchdog-panic.md
+++ b/docs/research/2026-06-13-mflux-training-watchdog-panic.md
@@ -32,9 +32,12 @@ open ones that together explain this incident**, so we did NOT file a duplicate:
 **Our signature differs from both** (`watchdog timeout: no checkins from watchdogd`
 vs #3267's process-kill exception and #3186's `completeMemory` panic), but it is
 the same family: a system-level GPU/Metal driver stall under sustained ML load on
-new Apple Silicon, escalating to a `watchdogd` reboot on M5. So our exact panic
-string may be a third manifestation — worth adding as a data-point comment on
-#3186 (the panic tracker) when convenient, rather than a fresh issue.
+new Apple Silicon, escalating to a `watchdogd` reboot on M5. Our exact panic
+string is a harsher manifestation of #3267's watchdog mechanism (process kill →
+full reboot), so we **posted it as a data-point comment on #3267**
+(https://github.com/ml-explore/mlx/issues/3267#issuecomment-4819498999, 2026-06-27)
+rather than filing a duplicate, cross-referencing #3186 as the related panic
+tracker.
 
 **Action taken (#1329):** PortOS now sets `AGX_RELAX_CDM_CTXSTORE_TIMEOUT=1`
 automatically in `scripts/train_mflux_lora.py` (mirrors the `generate_ltx2.py`
@@ -286,6 +289,7 @@ doesn't lose which version was under test.
 |---|---|---|---|---|---|
 | (baseline, not run) | 0.17.5 | 0.30.6 | 0.30.6 | known-bad (3 panics 06-13/14) | none captured (sudo was off) |
 | 2026-06-14 candidate #1 | 0.17.5 | **0.31.2** | **0.31.2** | ✅ **VALIDATED (seg-ON)** — full LoRA run `d36562a0` completed to adapter extraction (4B bf16, 768px, 4×150-step segs); box up, no panic. Pinned 2026-06-27 (#1329). | telemetry captured; GPU/power normal through the run |
+| 2026-06-27 AGX fix (seg-OFF) | 0.17.5 | 0.31.2 | 0.31.2 | ⏳ **IN FLIGHT** — `flux2-klein-9b` bf16, 768px, **segmentation OFF**, `AGX_RELAX_CDM_CTXSTORE_TIMEOUT=1` set, under `caffeinate -s`. Scratch run `data/training-runs/_validate-agx-segoff/` (run.log + powermetrics.log). The real seg-OFF test of the env-var fix on the exact panic config. **If still IN FLIGHT after a reboot → the AGX fix did NOT prevent the panic on 9B seg-OFF** (read scratch powermetrics.log). | telemetry capturing |
 
 **Verdict & pin (2026-06-27, #1329).** The candidate #1 "IN FLIGHT" row above was
 the *seg-OFF scratch* run, which was **manually stopped clean at step ~11** (never

--- a/docs/research/2026-06-13-mflux-training-watchdog-panic.md
+++ b/docs/research/2026-06-13-mflux-training-watchdog-panic.md
@@ -43,11 +43,25 @@ tracker.
 automatically in `scripts/train_mflux_lora.py` (mirrors the `generate_ltx2.py`
 env-knob pattern; propagates to the `mflux-train` child Popen). The trainer logs
 `STATUS:watchdog mitigation · AGX_RELAX_CDM_CTXSTORE_TIMEOUT=…` so a paniclog
-records whether it was active. The pinned 0.31.2 trio (this same PR's predecessor
-#1746) stands. The destructive seg-OFF version-bisect is now **lower priority** —
-the env-var fix attacks the actual cause and is far cheaper to validate than a
-version sweep; validate by running a sustained (seg-OFF) job with the display
-asleep and the env var set, before concluding anything about versions.
+records whether it was active. The pinned 0.31.2 trio (#1746) stands.
+
+**Validation result (2026-06-27) — the env var is necessary but NOT sufficient on
+this box.** A seg-OFF 9B-bf16 run with the env var set, under `caffeinate -s` *but
+with the display active*, **still hard-rebooted** ~11 min in at STEP:0 (bisect-log
+row above). The first-ever telemetry capture settled the mechanism: **driver hang,
+not thermal** — `Current pressure level: Nominal` with the GPU pegged, then
+powermetrics goes silent ~3 min before the watchdog fires. The paniclog shows
+`WindowServer` as the top-CPU thread, confirming mlx #3267's **active-display GPU
+contention** as the trigger. So on M5-class silicon a heavy (9B bf16) sustained
+run defeats the env var when the display is compositing. The empirically-known
+survivors on this box are: **(a) segmentation ON** (run `d36562a0`, 4B, completed)
+and **(b) the #3267 thread's display-off levers** (lid closed / display asleep /
+SSH headless) — these were NOT both in effect for the failed run (display was on).
+The next validation worth a destructive session is **9B seg-OFF with the display
+genuinely asleep / lid closed** (or SSH headless), to isolate whether display-off
+alone clears it; until then the safe production combo is **segmentation ON +
+display off for heavy runs**, which is what PortOS ships by default (segmentation
+on). The version bisect is moot — 0.31.2 is not the variable; the display is.
 
 ## Summary
 
@@ -289,7 +303,7 @@ doesn't lose which version was under test.
 |---|---|---|---|---|---|
 | (baseline, not run) | 0.17.5 | 0.30.6 | 0.30.6 | known-bad (3 panics 06-13/14) | none captured (sudo was off) |
 | 2026-06-14 candidate #1 | 0.17.5 | **0.31.2** | **0.31.2** | ✅ **VALIDATED (seg-ON)** — full LoRA run `d36562a0` completed to adapter extraction (4B bf16, 768px, 4×150-step segs); box up, no panic. Pinned 2026-06-27 (#1329). | telemetry captured; GPU/power normal through the run |
-| 2026-06-27 AGX fix (seg-OFF) | 0.17.5 | 0.31.2 | 0.31.2 | ⏳ **IN FLIGHT** — `flux2-klein-9b` bf16, 768px, **segmentation OFF**, `AGX_RELAX_CDM_CTXSTORE_TIMEOUT=1` set, under `caffeinate -s`. Scratch run `data/training-runs/_validate-agx-segoff/` (run.log + powermetrics.log). The real seg-OFF test of the env-var fix on the exact panic config. **If still IN FLIGHT after a reboot → the AGX fix did NOT prevent the panic on 9B seg-OFF** (read scratch powermetrics.log). | telemetry capturing |
+| 2026-06-27 AGX fix (seg-OFF) | 0.17.5 | 0.31.2 | 0.31.2 | ❌ **PANICKED** — `flux2-klein-9b` bf16, 768px, **segmentation OFF**, `AGX_RELAX_CDM_CTXSTORE_TIMEOUT=1` set, under `caffeinate -s` **but the display was active**. Hard-rebooted ~11 min in, at **STEP:0** (sustained training GPU load just beginning), same `watchdog timeout: no checkins from watchdogd in 93 seconds` signature (`AppleARMWatchdogTimer`/`AppleInterruptControllerV3`), paniclog `panic-full-2026-06-27-101518`. **The AGX env var alone does NOT prevent the panic on heavy (9B bf16) seg-OFF with the display active.** | ✅ **first telemetry-captured panic** — `Current pressure level: Nominal` throughout, GPU pegged (1592 MHz, 97% active, 24.4 W), then powermetrics **stops at 10:12:19** while the watchdog fires at 10:15:18 → **driver hang, NOT thermal/swap** (compressor 13% OK). Paniclog: `WindowServer` was the top-CPU thread = active-display contention (mlx #3267). |
 
 **Verdict & pin (2026-06-27, #1329).** The candidate #1 "IN FLIGHT" row above was
 the *seg-OFF scratch* run, which was **manually stopped clean at step ~11** (never

--- a/docs/research/2026-06-14-upstream-issue-draft-m5-watchdog.md
+++ b/docs/research/2026-06-14-upstream-issue-draft-m5-watchdog.md
@@ -1,15 +1,16 @@
 # Draft upstream issue — M5 Max GPU watchdog kernel panic under sustained MLX LoRA training
 
-> **DO NOT FILE AS A NEW ISSUE (updated 2026-06-27, #1329).** A tracker search found
-> existing open MLX issues that cover this — **[mlx #3267](https://github.com/ml-explore/mlx/issues/3267)**
-> (watchdog kills LoRA training when the display is active; confirmed workaround
-> `AGX_RELAX_CDM_CTXSTORE_TIMEOUT=1`) and **[mlx #3186](https://github.com/ml-explore/mlx/issues/3186)**
-> (IOGPU `completeMemory()` kernel panic, filed with Apple as FB22091885). mflux
-> itself has no relevant issue. Our `watchdogd`-timeout signature differs slightly
-> from both, so the right contribution is a **data-point comment on #3186** (the
-> kernel-panic tracker), not a fresh issue. Keep the environment/symptom material
-> below as the body of that comment if/when posting. See the "Upstream root cause
-> + fix" section of the incident doc.
+> **DO NOT FILE AS A NEW ISSUE — already contributed (updated 2026-06-27, #1329).**
+> A tracker search found existing open MLX issues that cover this:
+> **[mlx #3267](https://github.com/ml-explore/mlx/issues/3267)** (watchdog kills
+> LoRA training; confirmed workaround `AGX_RELAX_CDM_CTXSTORE_TIMEOUT=1`) and
+> **[mlx #3186](https://github.com/ml-explore/mlx/issues/3186)** (IOGPU
+> `completeMemory()` kernel panic, filed with Apple as FB22091885). mflux itself
+> has no relevant issue. Our `watchdogd`-timeout reboot is a harsher manifestation
+> of #3267's watchdog mechanism, so we **posted a data-point comment on #3267**
+> ([issuecomment-4819498999](https://github.com/ml-explore/mlx/issues/3267#issuecomment-4819498999))
+> cross-referencing #3186 — NOT a fresh issue. The material below was the basis for
+> that comment; retained for reference.
 
 ---
 


### PR DESCRIPTION
## Summary

Records the result of the seg-OFF validation bench from #1747, plus the upstream data-point comment. **The validation failed** — which is itself a valuable, now-documented finding.

- **Seg-OFF 9B-bf16 validation PANICKED.** With `AGX_RELAX_CDM_CTXSTORE_TIMEOUT=1` set and under `caffeinate -s` *but with the display active*, the M5 Max hard-rebooted ~11 min in at STEP:0, same `watchdogd` 93s signature. **First telemetry-captured panic**: thermal pressure Nominal with the GPU pegged, then powermetrics goes silent ~3 min before the watchdog fires → **driver hang, not thermal/swap**. The paniclog had `WindowServer` as the top-CPU thread → confirms mlx #3267 active-display contention.
- **Conclusion:** the env var is necessary but **not sufficient** for heavy (9B bf16) seg-OFF runs with the display on. Known survivors on this box: segmentation ON (4B run `d36562a0` completed) + the #3267 display-off levers. The version bisect is moot — 0.31.2 isn't the variable, the display is.
- **Posted our data point to [mlx #3267](https://github.com/ml-explore/mlx/issues/3267#issuecomment-4819498999)** (cross-referencing #3186) rather than filing a duplicate.

Updates the bisect log, incident analysis, and `TROUBLESHOOTING.md`.

## Test plan

Docs only.

Refs #1329