### PR TITLE
Close AI provider edit dialog on backdrop click via shared Modal

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -28,6 +28,10 @@
 
 - **Messages moved out of Brain into its own top-level "Comms" section.** The four Messages pages (Inbox, Drafts, Sync, Config) were buried as loose children inside the Brain group, mixed in with notes/feeds/links. They now live under a dedicated **Comms** sidebar section (between Chief of Staff and Create, alphabetically), with clean labels — so messaging is a first-class destination rather than a Brain sub-item. The page routes are unchanged (`/messages/*`), so existing links, ⌘K, and voice ("messages" / "comms") still resolve; only the sidebar grouping and the nav-manifest section moved. (`client/src/components/Layout.jsx`, `server/lib/navManifest.js`)
 
+## Settings
+
+- **The AI Provider add/edit dialog now closes when you click outside it (or press Esc).** The provider form on the AI Providers page was a hand-rolled `fixed inset-0` backdrop with no dismiss-on-backdrop and no Esc handling — the only way out was the Cancel/✕ button. It now uses the shared `ui/Modal` component (the app-wide DRY standard for modal chrome), so a backdrop click or Esc dismisses it like every other migrated dialog. (`client/src/pages/AIProviders.jsx`)
+
 ## Mobile
 
 - **Fix: the Apps page action buttons now meet the 40px touch-target minimum on mobile.** A mobile-responsiveness audit of the app (375px viewport) found the codebase already well-covered — tables wrap in `overflow-x-auto`, drawers/modals use `w-full sm:w-[...]`, and grids carry responsive bases — with one outlier: every control button on `/apps` (Start/Stop/Restart, Launch/Dev UI, Manage/Delete/Archive, and the expanded-panel quick actions like Update/Build/Refresh Config) used `py-1.5` + `text-xs`, rendering ~30px tall — below the codebase's own 40px tap-target convention and the WCAG 44px guideline. Each now gets `min-h-[40px] sm:min-h-0`, so the primary app-management controls are comfortably tappable on a phone while desktop keeps its compact density. (`client/src/pages/Apps.jsx`)

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -15,6 +15,7 @@ import {
 } from '../utils/formatters';
 import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
 import CodeReviewDefaultsPanel from '../components/providers/CodeReviewDefaultsPanel';
+import Modal from '../components/ui/Modal';
 
 export default function AIProviders() {
   const [providers, setProviders] = useState([]);
@@ -807,11 +808,17 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [] }) {
   };
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-port-card border border-port-border rounded-xl p-4 sm:p-6 w-full max-w-lg max-h-[90vh] overflow-y-auto">
-        <h2 className="text-xl font-bold text-white mb-4">
-          {provider ? 'Edit Provider' : 'Add Provider'}
-        </h2>
+    <Modal
+      open
+      onClose={onClose}
+      size="md"
+      backdropClassName="bg-black/50"
+      panelClassName="bg-port-card border border-port-border rounded-xl p-4 sm:p-6 max-h-[90vh] overflow-y-auto"
+      ariaLabelledBy="provider-form-title"
+    >
+      <h2 id="provider-form-title" className="text-xl font-bold text-white mb-4">
+        {provider ? 'Edit Provider' : 'Add Provider'}
+      </h2>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
@@ -1333,7 +1340,6 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [] }) {
             </button>
           </div>
         </form>
-      </div>
-    </div>
+    </Modal>
   );
 }


### PR DESCRIPTION
## Summary

The AI Provider add/edit dialog (`ProviderForm` on the AI Providers page) was a hand-rolled `fixed inset-0` backdrop with no click-outside and no Esc handling — the only way to dismiss it was the Cancel / ✕ button. This migrates it to the shared `ui/Modal` component (the app-wide DRY standard for modal chrome), so clicking the backdrop or pressing Esc now closes it like every other migrated dialog.

The DRY standard already existed (`client/src/components/ui/Modal.jsx`, used by ~30 other dialogs); this change just adopts it here. Width (`max-w-lg` via `size="md"`), backdrop styling (`bg-black/50`), centered alignment + padding, and the `max-h-[90vh] overflow-y-auto` scroll behavior are all preserved 1:1. The dialog title gets an `id` wired to the modal's `ariaLabelledBy` for accessibility.

## Test plan

- `vite build` passes (JSX balances after collapsing the two wrapper divs into `<Modal>`).
- Open AI Providers → Add/Edit Provider:
  - Clicking the dark backdrop closes the dialog.
  - Pressing Esc closes the dialog.
  - Cancel / ✕ / submit still work unchanged.
  - Panel width and scroll behavior unchanged from before.