### PR TITLE
show CoS task action icons always, not only on card hover

### DIFF
--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -206,7 +206,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   };
 
   return (
-    <div className={`bg-port-card border rounded-lg p-4 group ${
+    <div className={`bg-port-card border rounded-lg p-4 ${
       awaitingApproval ? 'border-yellow-500/50' : 'border-port-border'
     }`}>
       <div className="flex items-start gap-3">
@@ -391,9 +391,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
         {/* Action buttons. Keep the delete confirmation here, next to the trash
             icon, rather than at the bottom of the card — a task with a lot of
             context would otherwise push the confirm row far below the fold. */}
-        <div className={`flex items-center gap-1 transition-opacity ${
-          isConfirming(task.id) ? '' : 'md:opacity-0 md:group-hover:opacity-100'
-        }`}>
+        <div className="flex items-center gap-1">
           {!editing && (
             isConfirming(task.id) ? (
               <ConfirmButtonPair


### PR DESCRIPTION
## Summary
On the cos/tasks page, each task card's action icons (process-now, mark-blocked, edit, delete) were hidden until the user hovered over the card — a non-standard pattern that hurt discoverability, especially on touch. This makes them always visible.

The change removes two Tailwind classes from `TaskItem.jsx`:
- `md:opacity-0 md:group-hover:opacity-100` on the action-button container (the hover-gate), replaced with a plain `flex items-center gap-1`.
- the now-unused `group` class on the card root `<div>` (it only existed to drive that `group-hover`).

The inner delete-confirmation logic (`isConfirming` → `ConfirmButtonPair`) is untouched; icons keep their existing `aria-label`s.

## Test plan
- Visit /cos (Tasks tab): the process/blocked/edit/delete icons are visible on every task card without hovering.
- Click the trash icon: the inline 'Delete?' confirm pair still appears next to it.
- No other `group-hover` effects on the card depended on the removed `group` class (verified via grep).