### PR TITLE
Keep the shell TUI prompt visible on initial render with scrollback

### DIFF
--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -264,24 +264,50 @@ export default function Shell() {
     }
   }, [themeId, themeMode]);
 
+  // Refit the terminal to its container and tell the PTY about the new size.
+  const refitTerminal = useCallback(() => {
+    if (!fitAddonRef.current || !termInstanceRef.current) return;
+    fitAddonRef.current.fit();
+    if (socket && sessionIdRef.current) {
+      socket.emit('shell:resize', {
+        sessionId: sessionIdRef.current,
+        cols: termInstanceRef.current.cols,
+        rows: termInstanceRef.current.rows
+      });
+    }
+  }, [socket]);
+
   // Handle window resize
   useEffect(() => {
-    const handleResize = () => {
-      if (fitAddonRef.current && termInstanceRef.current) {
-        fitAddonRef.current.fit();
-        if (socket && sessionIdRef.current) {
-          socket.emit('shell:resize', {
-            sessionId: sessionIdRef.current,
-            cols: termInstanceRef.current.cols,
-            rows: termInstanceRef.current.rows
-          });
-        }
-      }
-    };
+    window.addEventListener('resize', refitTerminal);
+    return () => window.removeEventListener('resize', refitTerminal);
+  }, [refitTerminal]);
 
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [socket]);
+  // Refit whenever the terminal *container* changes size — not just the window.
+  // The toolbars (session tabs, live-run banner, quick-commands bar) mount
+  // conditionally on `connected`, which shrinks the flex-1 terminal box after the
+  // one-shot mount fit() has already run. Without re-fitting, xterm keeps its
+  // taller row count and overflows below the fold, hiding the prompt and breaking
+  // scrollback. A ResizeObserver catches every such reflow (the user's "resize the
+  // window and it appears" glitch). rAF-guarded so fit()'s own DOM mutation can't
+  // re-enter the observer in a tight loop.
+  useEffect(() => {
+    const el = terminalRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    let frame = null;
+    const observer = new ResizeObserver(() => {
+      if (frame != null) return;
+      frame = requestAnimationFrame(() => {
+        frame = null;
+        refitTerminal();
+      });
+    });
+    observer.observe(el);
+    return () => {
+      if (frame != null) cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
+  }, [refitTerminal]);
 
   // Handle terminal input
   useEffect(() => {


### PR DESCRIPTION
## Summary

The Shell page rendered too tall on initial load: the final TUI/shell prompt sat below the fold with no scrollback, and only resizing the browser window made it appear.

Root cause: xterm's `fit()` runs once on mount via `requestAnimationFrame`, but the session tabs, live-run banner, and quick-commands toolbars mount conditionally on `connected`. When `connected` flips true those bars appear and shrink the `flex-1` terminal box — after the one-shot fit has already run. xterm keeps its taller row count, so the bottom rows (including the prompt) overflow below the container, which is `overflow-hidden`, leaving no scrollback. A window resize fires the existing `handleResize → fit()`, which is why toggling the window "fixed" it.

Fix: add a `ResizeObserver` on the terminal container so any reflow refits the terminal and re-reports the PTY size. The fit + `shell:resize` emit logic is extracted into a shared `refitTerminal` callback reused by both the window-resize listener and the observer. The observer is rAF-guarded against re-entrancy, guarded for environments without `ResizeObserver` (jsdom), and torn down (disconnect + cancel pending frame) on unmount.

## Test plan

- `vite build` passes.
- On initial load of `/shell/:sessionId`, the prompt is visible within the terminal box and scrollback works — without needing to resize the window.
- Resizing the window still refits as before.