### PR TITLE
Make the TUI agent shell link a prominent primary action button

### DIFF
--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -17,6 +17,7 @@ import {
   ThumbsDown,
   MessageSquare,
   ExternalLink,
+  Terminal,
   Send,
   GitBranch,
   GitPullRequest,
@@ -557,11 +558,12 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
           {!inactive && agent.metadata?.tuiSessionId && (
             <Link
               to={`/shell?session=${encodeURIComponent(agent.metadata.tuiSessionId)}`}
-              className="flex items-center gap-1 px-2 py-0.5 rounded bg-emerald-500/15 text-emerald-400 hover:bg-emerald-500/25 whitespace-nowrap"
-              title="Open TUI shell session"
+              className="flex items-center gap-1.5 px-3 py-1 rounded font-semibold bg-emerald-500 text-black hover:bg-emerald-400 shadow-sm ring-1 ring-emerald-400/50 whitespace-nowrap transition-colors"
+              title="Open the live TUI shell to inspect and interact with this agent"
             >
-              <ExternalLink size={10} aria-hidden="true" className="shrink-0" />
-              <span className="font-mono">shell {agent.metadata.tuiSessionId.slice(0, 6)}</span>
+              <Terminal size={14} aria-hidden="true" className="shrink-0" />
+              <span>Open Shell</span>
+              <span className="font-mono text-[10px] text-black/60">{agent.metadata.tuiSessionId.slice(0, 6)}</span>
             </Link>
           )}
           {!remote && (


### PR DESCRIPTION
## Summary

On active CoS agent task cards (TUI execution mode), the "shell" link was rendered as a faint translucent emerald chip (`bg-emerald-500/15`, 10px `ExternalLink` icon, `shell <id>` label) sitting in the same row as the passive PID-stats chip and the gray Prompt button. It was visually indistinguishable from those labeled, non-primary elements — so users didn't recognize it as the primary way to inspect and interact with a running agent.

This restyles it as the card's clear call-to-action: a solid filled emerald button (`bg-emerald-500 text-black`, ring + shadow, larger `Terminal` icon, bold "Open Shell" label) with the short session id demoted to a small mono suffix. No behavior changes — same route, same accessible name (now stronger via the "Open Shell" text plus existing `title`).

## Test plan

- Reviewed by codex, an in-process claude reviewer, and a local ollama model — all clean, no findings.
- Verified the newly imported `Terminal` icon exists in lucide-react and is used; the `to` route and conditional render are unchanged; the link retains an accessible name.
- Visual-only change to `client/src/components/cos/tabs/AgentCard.jsx`; no logic, state, or contract touched.