### PR TITLE
Add fullscreen mode to the Shell terminal for mobile usability

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,3 +1,7 @@
+## Added
+
+- Shell page now has a **Fullscreen** button that promotes the terminal to a full-viewport overlay (above the sidebar), hiding the stacked header/tabs/quick-commands toolbars so the TUI gets the whole screen — a major mobile usability win where those toolbars previously ate most of the display. Fullscreen keeps a compact, horizontally-scrollable control bar (Exit, Ctrl+C, Paste, arrow/Enter keys) so you can still drive a TUI by thumb, and the Ctrl+C/Paste labels now collapse on small screens to save width.
+
 ## Fixed
 
 - Catalog "Appears in" panel no longer renders dangling chips that deep-link to soft-deleted universe/series/creative-director targets — the detail page filters refs to live targets only (the orphan stays recoverable via the "Orphaned" album). Also fixed a stale resolver bug where soft-deleted Creative Director projects (#1564) wrongly resolved as live, and extended orphan-bucket detection so a deleted CD project's ex-cast surfaces as orphaned rather than unlinked. (#1812)

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -90,6 +90,7 @@ function TerminalHotKeys({ sendCtrlC, handlePaste, sendNavKey, showPasteInput, s
         onClick={sendCtrlC}
         className="flex items-center gap-1.5 px-3 py-1.5 bg-red-500/15 hover:bg-red-500/25 text-red-400 hover:text-red-300 rounded text-xs font-mono transition-colors border border-red-500/30 min-h-[40px] shrink-0"
         title="Send Ctrl+C interrupt"
+        aria-label="Send Ctrl+C interrupt"
       >
         <OctagonX size={14} />
         <span className="hidden sm:inline">Ctrl+C</span>
@@ -98,6 +99,7 @@ function TerminalHotKeys({ sendCtrlC, handlePaste, sendNavKey, showPasteInput, s
         onClick={handlePaste}
         className="flex items-center gap-1.5 px-3 py-1.5 bg-port-accent/15 hover:bg-port-accent/25 text-port-accent hover:text-blue-300 rounded text-xs font-mono transition-colors border border-port-accent/30 min-h-[40px] shrink-0"
         title="Paste clipboard contents"
+        aria-label="Paste clipboard contents"
       >
         <ClipboardPaste size={14} />
         <span className="hidden sm:inline">Paste</span>
@@ -898,6 +900,7 @@ export default function Shell() {
             onClick={() => setIsFullscreen(true)}
             className="flex items-center gap-1.5 px-2.5 py-2 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded-lg text-sm transition-colors border border-port-border min-h-[40px]"
             title="Fullscreen terminal"
+            aria-label="Fullscreen terminal"
           >
             <Maximize2 size={16} />
             <span className="hidden sm:inline">Fullscreen</span>
@@ -1070,6 +1073,7 @@ export default function Shell() {
             onClick={() => setIsFullscreen(false)}
             className="flex items-center gap-1.5 px-3 py-1.5 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded text-xs transition-colors border border-port-border min-h-[40px] shrink-0"
             title="Exit fullscreen"
+            aria-label="Exit fullscreen"
           >
             <Minimize2 size={14} />
             <span className="hidden sm:inline">Exit</span>

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -6,7 +6,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 import { useSocket } from '../hooks/useSocket';
 import { useThemeContext } from '../components/ThemeContext';
-import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown, Plus, X, Terminal as TerminalIcon, ClipboardPaste, OctagonX, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, CornerDownLeft, Bot } from 'lucide-react';
+import { RefreshCw, Power, PowerOff, FolderOpen, ChevronDown, Plus, X, Terminal as TerminalIcon, ClipboardPaste, OctagonX, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, CornerDownLeft, Bot, Maximize2, Minimize2 } from 'lucide-react';
 import * as api from '../services/api';
 import { readClipboard } from '../lib/clipboard';
 import { buildTerminalTheme, parseCssColorToHex } from '../lib/terminalTheme';
@@ -79,6 +79,56 @@ const formatAge = (createdAt) => {
 
 const shortId = (id) => id?.slice(0, 6) ?? '';
 
+// Touch-friendly TUI-driving controls shared by the inline quick-commands toolbar
+// and the fullscreen control bar: Ctrl+C, Paste (+ fallback paste input), and the
+// arrow / Enter hot buttons. The Ctrl+C / Paste text labels collapse below `sm` so
+// the cluster stays narrow on a phone; the icons always show.
+function TerminalHotKeys({ sendCtrlC, handlePaste, sendNavKey, showPasteInput, setShowPasteInput, pasteInputRef, handlePasteInputEvent }) {
+  return (
+    <>
+      <button
+        onClick={sendCtrlC}
+        className="flex items-center gap-1.5 px-3 py-1.5 bg-red-500/15 hover:bg-red-500/25 text-red-400 hover:text-red-300 rounded text-xs font-mono transition-colors border border-red-500/30 min-h-[40px] shrink-0"
+        title="Send Ctrl+C interrupt"
+      >
+        <OctagonX size={14} />
+        <span className="hidden sm:inline">Ctrl+C</span>
+      </button>
+      <button
+        onClick={handlePaste}
+        className="flex items-center gap-1.5 px-3 py-1.5 bg-port-accent/15 hover:bg-port-accent/25 text-port-accent hover:text-blue-300 rounded text-xs font-mono transition-colors border border-port-accent/30 min-h-[40px] shrink-0"
+        title="Paste clipboard contents"
+      >
+        <ClipboardPaste size={14} />
+        <span className="hidden sm:inline">Paste</span>
+      </button>
+      {showPasteInput && (
+        <input
+          ref={pasteInputRef}
+          type="text"
+          className="w-32 px-2 py-1.5 bg-port-card text-white text-xs font-mono rounded border border-port-accent/50 focus:outline-none focus:border-port-accent min-h-[40px] placeholder-gray-500 shrink-0"
+          placeholder="Tap & paste here"
+          onPaste={handlePasteInputEvent}
+          onBlur={() => setShowPasteInput(false)}
+        />
+      )}
+      <div className="w-px h-6 bg-port-border shrink-0" />
+      {/* Arrow / Enter hot buttons — touch-friendly TUI nav + shell history */}
+      {NAV_KEYS.map((key) => (
+        <button
+          key={key.label}
+          onClick={() => sendNavKey(key)}
+          className="flex items-center justify-center px-2.5 py-1.5 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded text-xs font-mono transition-colors border border-port-border min-h-[40px] min-w-[40px] shrink-0"
+          title={`Send ${key.label} key`}
+          aria-label={`Send ${key.label} key`}
+        >
+          <key.Icon size={14} />
+        </button>
+      ))}
+    </>
+  );
+}
+
 export default function Shell() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { sessionId: urlSessionId } = useParams();
@@ -135,6 +185,10 @@ export default function Shell() {
   const [appFolders, setAppFolders] = useState([]);
   const [folderDropdownOpen, setFolderDropdownOpen] = useState(false);
   const [showPasteInput, setShowPasteInput] = useState(false);
+  // Fullscreen promotes the terminal to a fixed overlay above the sidebar, hiding
+  // the stacked toolbars so the TUI gets the whole viewport — the key mobile win
+  // where the header/tabs/quick-commands otherwise eat most of the screen.
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const pasteInputRef = useRef(null);
   const dropdownRef = useRef(null);
   const sessionsRef = useRef([]);
@@ -282,6 +336,15 @@ export default function Shell() {
     window.addEventListener('resize', refitTerminal);
     return () => window.removeEventListener('resize', refitTerminal);
   }, [refitTerminal]);
+
+  // Entering/leaving fullscreen swaps the terminal between the in-flow flex box and
+  // the fixed overlay — a big size change. The ResizeObserver below catches it too,
+  // but refit on the next frame so the new cols/rows reach the PTY immediately
+  // instead of waiting for the observer to settle.
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => refitTerminal());
+    return () => cancelAnimationFrame(frame);
+  }, [isFullscreen, refitTerminal]);
 
   // Refit whenever the terminal *container* changes size — not just the window.
   // The toolbars (session tabs, live-run banner, quick-commands bar) mount
@@ -808,8 +871,11 @@ export default function Shell() {
   const isLiveRun = !!activeSession?.external;
 
   return (
-    <div className="h-full flex flex-col p-4 md:p-6">
-      {/* Header */}
+    <div className={isFullscreen
+      ? 'fixed inset-0 z-[70] flex flex-col bg-port-bg p-2'
+      : 'h-full flex flex-col p-4 md:p-6'}>
+      {/* Header (hidden in fullscreen — the compact bottom bar takes over) */}
+      {!isFullscreen && (
       <div className="flex flex-wrap items-center gap-2 mb-3">
         <h1 className="text-xl font-semibold text-white">Shell</h1>
         <div className={`flex items-center gap-2 px-2 py-1 rounded text-sm ${
@@ -828,6 +894,14 @@ export default function Shell() {
           </span>
         )}
         <div className="flex items-center gap-2 ml-auto">
+          <button
+            onClick={() => setIsFullscreen(true)}
+            className="flex items-center gap-1.5 px-2.5 py-2 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded-lg text-sm transition-colors border border-port-border min-h-[40px]"
+            title="Fullscreen terminal"
+          >
+            <Maximize2 size={16} />
+            <span className="hidden sm:inline">Fullscreen</span>
+          </button>
           {/* Restart (kill + new shell) is meaningless for a TUI-run view. */}
           {connected && !isLiveRun && (
             <button
@@ -859,9 +933,10 @@ export default function Shell() {
           </button>
         </div>
       </div>
+      )}
 
       {/* Session tabs */}
-      {sessions.length > 0 && (
+      {!isFullscreen && sessions.length > 0 && (
         <div className="flex flex-wrap items-center gap-1.5 mb-3 pb-1">
           {sessions.map((s) => {
             const isActive = s.sessionId === activeSessionId;
@@ -911,7 +986,7 @@ export default function Shell() {
 
       {/* Live TUI run banner — these views are interactive: type to answer or
           correct the model, or Stop to end it. It won't auto-close while open. */}
-      {connected && isLiveRun && (
+      {!isFullscreen && connected && isLiveRun && (
         <div className="flex items-center gap-2 mb-3 px-3 py-2 rounded bg-port-accent/10 border border-port-accent/30 text-port-accent text-xs">
           <Bot size={14} className="shrink-0" />
           <span>
@@ -922,47 +997,17 @@ export default function Shell() {
       )}
 
       {/* Quick commands toolbar */}
-      {connected && (
+      {!isFullscreen && connected && (
         <div className="flex items-center gap-2 mb-3 flex-wrap">
-          <button
-            onClick={sendCtrlC}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-red-500/15 hover:bg-red-500/25 text-red-400 hover:text-red-300 rounded text-xs font-mono transition-colors border border-red-500/30 min-h-[40px]"
-            title="Send Ctrl+C interrupt"
-          >
-            <OctagonX size={14} />
-            Ctrl+C
-          </button>
-          <button
-            onClick={handlePaste}
-            className="flex items-center gap-1.5 px-3 py-1.5 bg-port-accent/15 hover:bg-port-accent/25 text-port-accent hover:text-blue-300 rounded text-xs font-mono transition-colors border border-port-accent/30 min-h-[40px]"
-            title="Paste clipboard contents"
-          >
-            <ClipboardPaste size={14} />
-            Paste
-          </button>
-          {showPasteInput && (
-            <input
-              ref={pasteInputRef}
-              type="text"
-              className="w-32 px-2 py-1.5 bg-port-card text-white text-xs font-mono rounded border border-port-accent/50 focus:outline-none focus:border-port-accent min-h-[40px] placeholder-gray-500"
-              placeholder="Tap & paste here"
-              onPaste={handlePasteInputEvent}
-              onBlur={() => setShowPasteInput(false)}
-            />
-          )}
-          <div className="w-px h-6 bg-port-border" />
-          {/* Arrow / Enter hot buttons — touch-friendly TUI nav + shell history */}
-          {NAV_KEYS.map((key) => (
-            <button
-              key={key.label}
-              onClick={() => sendNavKey(key)}
-              className="flex items-center justify-center px-2.5 py-1.5 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded text-xs font-mono transition-colors border border-port-border min-h-[40px] min-w-[40px]"
-              title={`Send ${key.label} key`}
-              aria-label={`Send ${key.label} key`}
-            >
-              <key.Icon size={14} />
-            </button>
-          ))}
+          <TerminalHotKeys
+            sendCtrlC={sendCtrlC}
+            handlePaste={handlePaste}
+            sendNavKey={sendNavKey}
+            showPasteInput={showPasteInput}
+            setShowPasteInput={setShowPasteInput}
+            pasteInputRef={pasteInputRef}
+            handlePasteInputEvent={handlePasteInputEvent}
+          />
           <div className="w-px h-6 bg-port-border" />
           {QUICK_COMMANDS.map(({ label, command }) => (
             <button
@@ -1008,14 +1053,41 @@ export default function Shell() {
         </div>
       )}
 
-      {/* Terminal container */}
-      <div className="flex-1 bg-port-bg rounded-lg border border-port-border overflow-hidden">
+      {/* Terminal container — drops the rounded border in fullscreen so it sits flush */}
+      <div className={`flex-1 bg-port-bg overflow-hidden ${isFullscreen ? '' : 'rounded-lg border border-port-border'}`}>
         <div
           ref={terminalRef}
           className="w-full h-full"
           style={{ padding: '8px' }}
         />
       </div>
+
+      {/* Fullscreen control bar — compact, single-row, horizontally scrollable so
+          the TUI-driving keys stay reachable by thumb without the stacked toolbars. */}
+      {isFullscreen && (
+        <div className="flex items-center gap-1.5 mt-2 overflow-x-auto pb-1">
+          <button
+            onClick={() => setIsFullscreen(false)}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-port-card hover:bg-port-border text-gray-300 hover:text-white rounded text-xs transition-colors border border-port-border min-h-[40px] shrink-0"
+            title="Exit fullscreen"
+          >
+            <Minimize2 size={14} />
+            <span className="hidden sm:inline">Exit</span>
+          </button>
+          <div className="w-px h-6 bg-port-border shrink-0" />
+          {connected && (
+            <TerminalHotKeys
+              sendCtrlC={sendCtrlC}
+              handlePaste={handlePaste}
+              sendNavKey={sendNavKey}
+              showPasteInput={showPasteInput}
+              setShowPasteInput={setShowPasteInput}
+              pasteInputRef={pasteInputRef}
+              handlePasteInputEvent={handlePasteInputEvent}
+            />
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

The Shell page stacked a header, session tabs, a live-run banner, and a wrapping quick-commands toolbar above the `flex-1` terminal. On mobile those toolbars wrapped into many rows and squeezed the terminal into a thin, hard-to-read strip — and the cramped terminal was awkward to scroll.

This adds a **Fullscreen** button (next to New/Stop in the header) that promotes the terminal to a `fixed inset-0` overlay above the sidebar, hiding the stacked toolbars so the TUI gets the whole viewport. Fullscreen keeps a compact, horizontally-scrollable control bar at the bottom (Exit, Ctrl+C, Paste, arrow/Enter keys) so a TUI stays drivable by thumb without summoning the on-screen keyboard.

### Changes
- `client/src/pages/Shell.jsx`:
  - New `isFullscreen` state; the page root swaps to a `fixed inset-0 z-[70] flex flex-col` overlay (above the `z-50` sidebar) and hides the header/tabs/banner/quick-commands in fullscreen.
  - Extracted the shared TUI-driving controls (Ctrl+C, Paste + fallback input, arrow/Enter keys) into a `TerminalHotKeys` component reused by the main toolbar and the fullscreen bar — no duplication.
  - The terminal `div` stays mounted in both modes (only its wrapper className changes), so the xterm instance survives the toggle; a `requestAnimationFrame` refit on toggle pushes the new cols/rows to the PTY immediately.
  - Ctrl+C/Paste labels collapse below `sm` to save width on phones; added `aria-label`s to the now-icon-only Fullscreen/Exit/Ctrl+C/Paste buttons for screen readers.

## Test plan
- `npx vite build` — passes.
- `npx eslint src/pages/Shell.jsx` — clean.
- Manual: on a narrow viewport, tap **Fullscreen** → terminal fills the screen over the sidebar; the bottom bar's Ctrl+C / arrows / Enter drive a TUI; **Exit** restores the normal layout. Toggling refits the terminal (no clipped rows). Desktop layout unchanged (labels still show at `sm`+).