### PR TITLE
fix(issue-1811): stop update.ps1 aborting on native-command stderr under ErrorActionPreference=Stop

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -2,6 +2,10 @@
 
 - Shell page now has a **Fullscreen** button that promotes the terminal to a full-viewport overlay (above the sidebar), hiding the stacked header/tabs/quick-commands toolbars so the TUI gets the whole screen — a major mobile usability win where those toolbars previously ate most of the display. Fullscreen keeps a compact, horizontally-scrollable control bar (Exit, Ctrl+C, Paste, arrow/Enter keys) so you can still drive a TUI by thumb, and the Ctrl+C/Paste labels now collapse on small screens to save width.
 
+## Windows updater
+
+- **[issue-1811] Windows update no longer aborts on a successful `git pull`** — the PowerShell updater (`update.ps1`) was treating normal git/npm progress messages (which those tools print to stderr, e.g. "From https://github.com/…") as fatal errors and stopping the update partway through. The updater now distinguishes real failures (by exit code) from routine status output, so updates run to completion on Windows. (#1811)
+
 ## Fixed
 
 - Catalog "Appears in" panel no longer renders dangling chips that deep-link to soft-deleted universe/series/creative-director targets — the detail page filters refs to live targets only (the orphan stays recoverable via the "Orphaned" album). Also fixed a stale resolver bug where soft-deleted Creative Director projects (#1564) wrongly resolved as live, and extended orphan-bucket detection so a deleted CD project's ex-cast surfaces as orphaned rather than unlinked. (#1812)

--- a/update.ps1
+++ b/update.ps1
@@ -61,9 +61,18 @@ function Step {
 function Invoke-Logged {
     param([Parameter(ValueFromRemainingArguments)]$CmdArgs)
     $cmd = $CmdArgs[0]
-    $args = @()
-    if ($CmdArgs.Count -gt 1) { $args = $CmdArgs[1..($CmdArgs.Count - 1)] }
-    & $cmd @args >> $UpdateLog 2>&1
+    # Avoid clobbering the automatic $args variable — use a distinct name.
+    $cmdArgs = @()
+    if ($CmdArgs.Count -gt 1) { $cmdArgs = $CmdArgs[1..($CmdArgs.Count - 1)] }
+    # Native commands (git, npm, node) routinely write progress/status to stderr —
+    # `git pull` prints "From https://github.com/..." there on every SUCCESSFUL run.
+    # Under the script-level $ErrorActionPreference='Stop', PowerShell promotes that
+    # redirected stderr into a terminating NativeCommandError and aborts the update on
+    # a command that actually succeeded (issue #1811). Real failures are detected via
+    # $LASTEXITCODE by every caller, so downgrade the error action to Continue for the
+    # external call only — this assignment is function-scoped and reverts on return.
+    $ErrorActionPreference = 'Continue'
+    & $cmd @cmdArgs >> $UpdateLog 2>&1
 }
 
 Write-SafeHost "===================================" -ForegroundColor Cyan
@@ -304,7 +313,13 @@ Step "migrations" "done" "Migrations complete"
 # Pipe "a" so slash-do's "multiple environments detected" prompt auto-selects
 # all detected envs instead of hanging on readline (update.ps1 has no TTY).
 Step "slash-do" "running" "Installing/updating slash-do commands..."
-"a" | & npx --yes slash-do@latest >> $UpdateLog 2>&1
+# npx writes status to stderr; scope the same Continue downgrade as Invoke-Logged
+# around this stdin-piped call so it isn't aborted by a NativeCommandError (#1811).
+# $LASTEXITCODE set inside the script block still propagates to the check below.
+& {
+    $ErrorActionPreference = 'Continue'
+    "a" | & npx --yes slash-do@latest >> $UpdateLog 2>&1
+}
 if ($LASTEXITCODE -ne 0) {
     Write-SafeHost "⚠️  slash-do install/update failed. Continuing (re-run later: npx slash-do@latest)." -ForegroundColor Yellow
     $global:LASTEXITCODE = 0

--- a/update.ps1
+++ b/update.ps1
@@ -61,9 +61,10 @@ function Step {
 function Invoke-Logged {
     param([Parameter(ValueFromRemainingArguments)]$CmdArgs)
     $cmd = $CmdArgs[0]
-    # Avoid clobbering the automatic $args variable — use a distinct name.
-    $cmdArgs = @()
-    if ($CmdArgs.Count -gt 1) { $cmdArgs = $CmdArgs[1..($CmdArgs.Count - 1)] }
+    # Name must differ from $CmdArgs by more than case — PowerShell variable names are
+    # case-insensitive, so a $cmdArgs would alias the $CmdArgs parameter and wipe it.
+    $cmdRest = @()
+    if ($CmdArgs.Count -gt 1) { $cmdRest = $CmdArgs[1..($CmdArgs.Count - 1)] }
     # Native commands (git, npm, node) routinely write progress/status to stderr —
     # `git pull` prints "From https://github.com/..." there on every SUCCESSFUL run.
     # Under the script-level $ErrorActionPreference='Stop', PowerShell promotes that
@@ -72,7 +73,7 @@ function Invoke-Logged {
     # $LASTEXITCODE by every caller, so downgrade the error action to Continue for the
     # external call only — this assignment is function-scoped and reverts on return.
     $ErrorActionPreference = 'Continue'
-    & $cmd @cmdArgs >> $UpdateLog 2>&1
+    & $cmd @cmdRest >> $UpdateLog 2>&1
 }
 
 Write-SafeHost "===================================" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary

Fixes #1811 — the Windows PowerShell updater (`update.ps1`) aborted partway through a **successful** update. With the script-level `$ErrorActionPreference = "Stop"`, native commands (git/npm/node) writing routine progress to **stderr** — e.g. `git pull` prints `From https://github.com/atomantic/PortOS` there on every run — get promoted by PowerShell into a terminating `NativeCommandError` when redirected with `2>&1`. The reporter's log shows exactly this: `FullyQualifiedErrorId : NativeCommandError` raised from the `& $cmd @args >> $UpdateLog 2>&1` line, killing the update right after the pull.

The fix scopes a `$ErrorActionPreference = 'Continue'` downgrade around the native-command invocations so routine stderr no longer terminates the script, while **real** failures keep being detected via `$LASTEXITCODE` (which every caller already checks):

- `Invoke-Logged` — the shared wrapper that routes git/npm/node output to the log. The downgrade is function-scoped, so it reverts on return and the rest of the script keeps `Stop` semantics for cmdlet errors.
- The stdin-piped `npx slash-do@latest` call — the one native invocation that bypasses `Invoke-Logged` — gets the same downgrade inside a `& { … }` block (`$LASTEXITCODE` still propagates to the failure check that follows).

`update.sh` (bash) has no equivalent issue — bash does not promote stderr to errors.

## Test plan

- No automated test: this is Windows PowerShell **runtime** error-stream behavior, not exercisable from the Node/vitest suite (no `pwsh` on CI). The fix is documented inline with the issue number.
- Verified the file retains its UTF-8 BOM (`scripts/ps1-bom.test.js` enforces it).
- Reviewed by `claude` + `codex` (clean) — the claude pass caught and fixed a case-insensitive variable-name collision in an interim version of the patch.
- Manual confirmation on Windows: run `./update.ps1` from a feature branch and on `main`; the update now runs to completion through the `git-pull` step instead of aborting with `NativeCommandError`.