### PR TITLE
fix: allowlist vision-test imagePath to screenshots-dir basenames (#1820)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,3 +1,7 @@
+## Security
+
+- **Vision-test endpoint no longer reads arbitrary files** — `POST /api/providers/:id/test-vision` took `imagePath` straight from the request body, so a `../` traversal or absolute path could have any readable file base64-encoded and forwarded to the configured external vision provider. The image loader now allowlists `imagePath` to a real image basename under `data/screenshots` (via the canonical `resolveScreenshot` path resolver), rejecting traversal and absolute-path escapes before any file is read or forwarded. (#1820)
+
 ## Added
 
 - **Creative Director auto-compose** — the Overview tab's Auto-cast control now has a `+ treatment` toggle (shown only before a treatment exists): with it on, once the director seeds the cast from the catalog it autonomously writes a first-pass treatment + scene plan grounded in that cast, instead of stopping at cast seeding. Director-first — the autonomous treatment is a starting point you keep editing on the same board, and it never clobbers an existing treatment. (#1817)

--- a/server/lib/fileUtils.js
+++ b/server/lib/fileUtils.js
@@ -1036,6 +1036,21 @@ export const resolveTemplateAsset = makePathResolver(() => PATHS.visualTemplates
 });
 
 /**
+ * Resolve a user-supplied screenshot filename to an absolute path under
+ * `PATHS.screenshots`. Used by the vision-test endpoint, whose `imagePath`
+ * comes straight from `req.body` — basenaming the input (and rejecting any
+ * non-image extension or missing file) stops `../` traversal and absolute-path
+ * escapes from reading arbitrary files off disk and forwarding their contents
+ * to an external vision provider. Returns `null` on any failure so the caller
+ * can surface a clean error. See `makePathResolver` for the defense-in-depth
+ * checks. Late-binds via a thunk so tests that mutate `PATHS.screenshots` still
+ * steer the resolver.
+ */
+export const resolveScreenshot = makePathResolver(() => PATHS.screenshots, {
+  extensions: ['png', 'jpg', 'jpeg', 'gif', 'webp'],
+});
+
+/**
  * Resolve any user-supplied image input (init image OR multi-reference image)
  * to an absolute path under one of PortOS's approved image roots — the
  * gallery (`PATHS.images`), the multi-ref upload dir (`PATHS.imageRefs`),

--- a/server/lib/fileUtils.test.js
+++ b/server/lib/fileUtils.test.js
@@ -29,6 +29,7 @@ import {
   formatDuration,
   sha256File,
   resolveImageInputPath,
+  resolveScreenshot,
   PATHS,
   sanitizeFilename,
   getFileExtension,
@@ -677,6 +678,52 @@ describe('fileUtils', () => {
       const out = resolveImageInputPath(refsAbs);
       expect(out).toContain('data/image-refs/');
       expect(out).not.toContain('data/images/');
+    });
+  });
+
+  describe('resolveScreenshot', () => {
+    const sampleTemplate = join(__dirname_test, '..', '..', 'data.reference', 'templates', 'character-reference-sheet.png');
+    const shotName = 'fileutils-test-screenshot.png';
+    const shotPath = join(PATHS.screenshots, shotName);
+
+    beforeEach(() => {
+      if (!existsSync(PATHS.screenshots)) mkdirSync(PATHS.screenshots, { recursive: true });
+      if (existsSync(sampleTemplate) && !existsSync(shotPath)) copyFileSync(sampleTemplate, shotPath);
+    });
+
+    afterAll(() => {
+      // Remove ONLY the uniquely-named fixture — never the real screenshots root.
+      if (existsSync(shotPath)) rmSync(shotPath, { force: true });
+    });
+
+    it('resolves a basename present under the screenshots root', () => {
+      const out = resolveScreenshot(shotName);
+      expect(out).toBeTruthy();
+      expect(out).toContain('data/screenshots/');
+      expect(out).toContain(shotName);
+    });
+
+    it('SECURITY: rejects parent-directory traversal that escapes the screenshots root', () => {
+      // `loadImageAsBase64` (issue #1820) fed `imagePath` straight from req.body;
+      // a `../` payload must NOT resolve to a file outside data/screenshots.
+      expect(resolveScreenshot('../../etc/passwd')).toBeNull();
+      expect(resolveScreenshot('../package.json')).toBeNull();
+    });
+
+    it('SECURITY: rejects an absolute path outside the screenshots root', () => {
+      expect(resolveScreenshot('/etc/passwd')).toBeNull();
+      expect(resolveScreenshot('/etc/hosts')).toBeNull();
+    });
+
+    it('rejects non-image extensions and missing files', () => {
+      expect(resolveScreenshot('notes.txt')).toBeNull();
+      expect(resolveScreenshot('does-not-exist.png')).toBeNull();
+    });
+
+    it('returns null for non-string / empty input', () => {
+      expect(resolveScreenshot(null)).toBeNull();
+      expect(resolveScreenshot('')).toBeNull();
+      expect(resolveScreenshot(undefined)).toBeNull();
     });
   });
 

--- a/server/services/visionTest.js
+++ b/server/services/visionTest.js
@@ -6,10 +6,9 @@
  */
 
 import { readFile, readdir } from 'fs/promises';
-import { existsSync } from 'fs';
-import { join, extname } from 'path';
+import { extname } from 'path';
 import { getProviderById } from './providers.js';
-import { PATHS } from '../lib/fileUtils.js';
+import { PATHS, resolveScreenshot } from '../lib/fileUtils.js';
 import { fetchWithTimeout } from '../lib/fetchWithTimeout.js';
 import { ensureProviderReady as ensureOllamaProviderReady } from './ollamaManager.js';
 import { describeImageViaCli } from './visionCli.js';
@@ -41,10 +40,13 @@ function getMimeType(filepath) {
  * @returns {Promise<string>} - Base64 data URL
  */
 async function loadImageAsBase64(imagePath) {
-  const fullPath = imagePath.startsWith('/') ? imagePath : join(SCREENSHOTS_DIR, imagePath);
-
-  if (!existsSync(fullPath)) {
-    throw new Error(`Image not found: ${fullPath}`);
+  // `imagePath` originates from req.body — basename-allowlist it to a real file
+  // under SCREENSHOTS_DIR. This rejects `../` traversal and absolute-path
+  // escapes so an attacker can't have an arbitrary file base64-encoded and
+  // forwarded to the external vision provider (issue #1820).
+  const fullPath = resolveScreenshot(imagePath);
+  if (!fullPath) {
+    throw new Error(`Image not found under screenshots dir: ${imagePath}`);
   }
 
   const buffer = await readFile(fullPath);

--- a/server/services/visionTest.test.js
+++ b/server/services/visionTest.test.js
@@ -18,16 +18,20 @@ vi.mock('fs/promises', () => ({
   readdir: vi.fn()
 }));
 
-// Mock fs for existsSync
-vi.mock('fs', () => ({
-  existsSync: vi.fn()
+// Mock the fileUtils path-safety layer. `resolveScreenshot` is the basename
+// allowlist that hardens `imagePath` (issue #1820) — stubbing it lets each test
+// drive the resolved-or-rejected outcome without touching the real filesystem.
+// Its own traversal/absolute-escape guarantees are covered in fileUtils.test.js.
+vi.mock('../lib/fileUtils.js', () => ({
+  PATHS: { screenshots: '/mock/screenshots' },
+  resolveScreenshot: vi.fn(),
 }));
 
 // Import mocked modules
 import { getProviderById } from './providers.js';
 import { describeImageViaCli } from './visionCli.js';
 import { readFile, readdir } from 'fs/promises';
-import { existsSync } from 'fs';
+import { resolveScreenshot } from '../lib/fileUtils.js';
 
 describe('Vision Test Service', () => {
   const mockProvider = {
@@ -103,7 +107,7 @@ describe('Vision Test Service', () => {
 
     it('should successfully test vision when API returns expected content', async () => {
       getProviderById.mockResolvedValue(mockProvider);
-      existsSync.mockReturnValue(true);
+      resolveScreenshot.mockReturnValue('/mock/screenshots/image.png');
       readFile.mockResolvedValue(mockImageBuffer);
 
       const mockResponse = {
@@ -135,7 +139,7 @@ describe('Vision Test Service', () => {
 
     it('should return success false when expected content not found', async () => {
       getProviderById.mockResolvedValue(mockProvider);
-      existsSync.mockReturnValue(true);
+      resolveScreenshot.mockReturnValue('/mock/screenshots/image.png');
       readFile.mockResolvedValue(mockImageBuffer);
 
       const mockResponse = {
@@ -164,7 +168,7 @@ describe('Vision Test Service', () => {
 
     it('should handle API errors gracefully', async () => {
       getProviderById.mockResolvedValue(mockProvider);
-      existsSync.mockReturnValue(true);
+      resolveScreenshot.mockReturnValue('/mock/screenshots/image.png');
       readFile.mockResolvedValue(mockImageBuffer);
 
       global.fetch.mockResolvedValue({
@@ -182,7 +186,7 @@ describe('Vision Test Service', () => {
 
     it('should use custom model when specified', async () => {
       getProviderById.mockResolvedValue(mockProvider);
-      existsSync.mockReturnValue(true);
+      resolveScreenshot.mockReturnValue('/mock/screenshots/image.png');
       readFile.mockResolvedValue(mockImageBuffer);
 
       const mockResponse = {
@@ -213,13 +217,31 @@ describe('Vision Test Service', () => {
 
     it('should handle image not found error', async () => {
       getProviderById.mockResolvedValue(mockProvider);
-      existsSync.mockReturnValue(false);
+      resolveScreenshot.mockReturnValue(null);
 
       await expect(testVision({
         imagePath: '/nonexistent/image.png',
         prompt: 'Describe',
         expectedContent: []
       })).rejects.toThrow('Failed to load image');
+    });
+
+    it('SECURITY: refuses a traversal/absolute imagePath without reading the file or calling the provider (#1820)', async () => {
+      getProviderById.mockResolvedValue(mockProvider);
+      // resolveScreenshot rejects anything that escapes the screenshots root.
+      resolveScreenshot.mockReturnValue(null);
+
+      await expect(testVision({
+        imagePath: '../../../../etc/passwd',
+        prompt: 'Describe',
+        expectedContent: []
+      })).rejects.toThrow('Failed to load image');
+
+      // The unsanitized path must never reach readFile or the external API —
+      // otherwise arbitrary file contents would be base64-encoded and forwarded.
+      expect(resolveScreenshot).toHaveBeenCalledWith('../../../../etc/passwd');
+      expect(readFile).not.toHaveBeenCalled();
+      expect(global.fetch).not.toHaveBeenCalled();
     });
   });
 
@@ -236,7 +258,7 @@ describe('Vision Test Service', () => {
     it('should run multiple tests on available screenshots', async () => {
       readdir.mockResolvedValue(['test1.png', 'test2.jpg']);
       getProviderById.mockResolvedValue(mockProvider);
-      existsSync.mockReturnValue(true);
+      resolveScreenshot.mockReturnValue('/mock/screenshots/image.png');
       readFile.mockResolvedValue(mockImageBuffer);
 
       const mockResponse = {


### PR DESCRIPTION
## Summary

`POST /api/providers/:id/test-vision` accepted `imagePath` from `req.body` with only a presence check. The image loader (`server/services/visionTest.js` `loadImageAsBase64`) honored absolute paths and `../` traversal directly:

```js
const fullPath = imagePath.startsWith('/') ? imagePath : join(SCREENSHOTS_DIR, imagePath);
```

So any readable file on the host could be base64-encoded and forwarded to the configured **external** vision provider, exfiltrating its contents.

### Fix

- Add a canonical `resolveScreenshot` path resolver to `server/lib/fileUtils.js`, built on the same `makePathResolver` factory as `resolveGalleryImage`/`resolveImageRef`/`resolveTemplateAsset`. It basenames the input, enforces an image extension (`png/jpg/jpeg/gif/webp`), and confirms the file exists under `data/screenshots` — `null` on any failure.
- `loadImageAsBase64` now resolves `imagePath` through `resolveScreenshot`, rejecting traversal and absolute-path escapes before any file is read or forwarded. This hardens **all** callers of `testVision` (the route, the vision suite, and any future caller), not just the route.

Legitimate callers already pass screenshot basenames (the suite reads them from `readdir(SCREENSHOTS_DIR)`; no client UI sends `imagePath`), so behavior is unchanged for them.

### Note — follow-up filed

The vendored aiToolkit runner (`server/lib/aiToolkit/runner.js` `loadImageAsBase64`, reached via `POST /api/runs` with a body `screenshots` array) has the same unsanitized pattern. It's in the self-contained toolkit (can't import PortOS's `resolveScreenshot`), so it's tracked separately as a follow-up rather than expanding this PR's scope.

## Test plan

- `server/lib/fileUtils.test.js` — new `resolveScreenshot` block: resolves a real basename under the screenshots root; **SECURITY**: rejects `../` traversal and absolute paths outside the root; rejects non-image extensions / missing files / non-string input. (real filesystem)
- `server/services/visionTest.test.js` — re-pointed the existing image-load mocks at `resolveScreenshot`; added a **SECURITY** test asserting a traversal `imagePath` is refused with no `readFile` and no external `fetch`.
- `npx vitest run services/visionTest.test.js lib/fileUtils.test.js` → 149 passed.
- `npx vitest run lib/index.test.js routes/providers.test.js services/visionTest.integration.test.js` → green (barrel + route-call-arg + integration suites unaffected).

Closes #1820