### PR TITLE
test: de-flake peerSync reciprocal-sync test (fixed-timeout race) (#1860)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -33,6 +33,8 @@
 
 ## Internal
 
+- **[issue-1860] De-flaked the `peerSync` reciprocal-sync tests** — the positive `reciprocates a full-sync peer on peer:online` test waited for an async event handler with a hard `setTimeout(r, 30)` before asserting `enqueueReciprocalSync` was called, so a loaded CI runner whose handler chain exceeded 30ms produced a spurious failure (surfaced during the v2.24.0 release CI-flake gate). It now polls with `vi.waitFor`. The sibling negative test (`does NOT reciprocate a non-full-sync peer`) replaced its fixed-sleep + `not.toHaveBeenCalled()` — which could false-pass if the absent call were merely slow — with a deterministic full-sync "barrier" peer emitted after the subject: once the barrier's reciprocal call lands, the subject's handler has provably reached and skipped its own fullSync check. Test-only. (#1860)
+
 - Updated the bundled slashdo submodule to v3.20.0, pulling the latest `/do:*` slash commands and shared libraries.
 
 - **[issue-1836] Moved socket-handler orchestration into services** — the `standardize:start` and `app:deploy` Socket.IO handlers (`server/services/socket.js`) implemented their multi-step flows inline in the socket layer, where they couldn't be unit-tested or reused from an HTTP route. The PM2 standardization flow (analyze → git backup → apply) is now `pm2Standardizer.runStandardizeFlow()` and the deploy flow (resolve app → check deploy script → run) is now `appDeployer.runDeployFlow()`; each takes progress callbacks and returns a terminal outcome, so the socket handler is a thin adapter. Both are covered by new unit tests. Behavior-preserving. (#1836)

--- a/server/services/sharing/peerSync.test.js
+++ b/server/services/sharing/peerSync.test.js
@@ -1062,8 +1062,11 @@ describe('peerSync', () => {
         fullSync: true,
         syncCategories: {},
       });
-      await new Promise((r) => setTimeout(r, 30));
-      expect(vi.mocked(enqueueReciprocalSync)).toHaveBeenCalledWith('local-1');
+      // Poll until the async handler resolves peer identity and enqueues the
+      // mirror — a fixed sleep raced the call on a loaded CI runner (#1860).
+      await vi.waitFor(() =>
+        expect(vi.mocked(enqueueReciprocalSync)).toHaveBeenCalledWith('local-1')
+      );
     });
 
     it('does NOT reciprocate a non-full-sync peer on peer:online (preserves prior behavior)', async () => {
@@ -1073,6 +1076,13 @@ describe('peerSync', () => {
       vi.mocked(enqueueReciprocalSync).mockClear();
       installPeerSyncListener();
       vi.mocked(listUniverses).mockResolvedValue([]);
+      // Emit the non-full-sync subject first, then a full-sync *barrier* peer.
+      // Both run the same async handler pipeline (backfill → retryPending →
+      // fullSync check), and the barrier — emitted second and doing equal-or-
+      // more work — only calls enqueueReciprocalSync as its final step. So once
+      // the barrier's reciprocal call lands, the subject's handler has provably
+      // reached and *skipped* its own fullSync check. This replaces a fixed
+      // sleep that could false-pass merely because the absent call was slow.
       instanceEvents.emit('peer:online', {
         id: 'local-2',
         instanceId: 'peer-b',
@@ -1082,8 +1092,20 @@ describe('peerSync', () => {
         directions: ['outbound'],
         syncCategories: { universe: true },
       });
-      await new Promise((r) => setTimeout(r, 30));
-      expect(vi.mocked(enqueueReciprocalSync)).not.toHaveBeenCalled();
+      instanceEvents.emit('peer:online', {
+        id: 'local-barrier',
+        instanceId: 'peer-barrier',
+        name: 'Barrier',
+        enabled: true,
+        syncEnabled: true,
+        directions: ['outbound'],
+        fullSync: true,
+        syncCategories: {},
+      });
+      await vi.waitFor(() =>
+        expect(vi.mocked(enqueueReciprocalSync)).toHaveBeenCalledWith('local-barrier')
+      );
+      expect(vi.mocked(enqueueReciprocalSync)).not.toHaveBeenCalledWith('local-2');
     });
   });
 


### PR DESCRIPTION
## Summary

`services/sharing/peerSync.test.js` intermittently failed in CI on `reciprocates a full-sync peer on peer:online` (confirmed flaky during the v2.24.0 release, PR #1857: failed on one `test (20.x)` run, passed on the duplicate run of the same SHA). The `peer:online` listener is async — it resolves peer identity and awaits work before calling `enqueueReciprocalSync` — and the test gave that chain a hard `setTimeout(r, 30)` budget, so a loaded CI runner could assert before the call landed.

This replaces the fixed sleep with a poll-until-condition:

- **Positive test** (`reciprocates a full-sync peer`): `await vi.waitFor(() => expect(...enqueueReciprocalSync).toHaveBeenCalledWith('local-1'))` polls until the signal lands instead of guessing a duration.
- **Negative test** (`does NOT reciprocate a non-full-sync peer`): the old `not.toHaveBeenCalled()` after a fixed sleep could false-pass if the absent call were merely slow. It now emits a full-sync **barrier** peer *after* the non-full-sync subject; both run the same async handler pipeline (backfill → retryPending → fullSync check) and the barrier — emitted second, doing equal-or-more work — only calls `enqueueReciprocalSync` as its final step. Once the barrier's reciprocal call lands (awaited via `vi.waitFor`), the subject's handler has provably reached and skipped its own fullSync check, so `not.toHaveBeenCalledWith('local-2')` is deterministic rather than time-bounded.

Test-only change. `vi.waitFor` is already used widely in the suite (vitest 4.1.9).

## Test plan

- `cd server && npx vitest run services/sharing/peerSync.test.js -t "reciprocate"` — both tests pass across 5 consecutive runs (2 passed | 218 skipped each).
- Full file run: the 2 reciprocate tests pass on every run; the 5 unrelated `getFullSyncCoverageForPeer` failures are pre-existing real-Postgres reads (CI-green, untouched by this diff).

Closes #1860