### PR TITLE
fix(cos): accept multi-image task attachments and surface them to the agent

### DIFF
--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -86,6 +86,17 @@ export function buildReviewWithArgs(reviewers, stopMode = DEFAULT_REVIEW_STOP_MO
   return parts.join(' ');
 }
 
+// A generic file attachment uploaded via POST /api/attachments and referenced
+// by the returned metadata — matches the fileInfo shape TaskAddForm.jsx sends
+// (client/src/utils/fileUpload.js uploadAttachmentFile).
+const cosTaskAttachmentSchema = z.object({
+  filename: z.string(),
+  originalName: z.string().optional(),
+  path: z.string(),
+  size: z.number().optional(),
+  mimeType: z.string().optional(),
+});
+
 export const createCosTaskSchema = z.object({
   description: z.string().min(1),
   priority: z.string().optional(),
@@ -96,7 +107,7 @@ export const createCosTaskSchema = z.object({
   type: z.string().optional().default('user'),
   approvalRequired: z.boolean().optional(),
   screenshots: z.array(z.string()).optional(),
-  attachments: z.array(z.string()).optional(),
+  attachments: z.array(cosTaskAttachmentSchema).optional(),
   position: z.enum(['top', 'bottom']).optional().default('bottom'),
   createJiraTicket: z.preprocess(
     v => v === 'true' ? true : v === 'false' ? false : v,

--- a/server/lib/taskParser.js
+++ b/server/lib/taskParser.js
@@ -301,9 +301,12 @@ export function generateTasksMarkdown(tasks, includeApprovalFlags = false) {
         : '';
       lines.push(`- ${checkbox} #${task.id} | ${task.priority}${approvalFlag} | ${task.description}`);
 
-      // Add metadata (escape newlines in values for single-line storage)
+      // Add metadata (escape newlines in values for single-line storage).
+      // Pass the raw value — escapeNewlines JSON-encodes arrays/objects itself;
+      // pre-stringifying here would flatten them to "a,b" or "[object Object]"
+      // before it ever sees the array/object shape.
       for (const [key, value] of Object.entries(task.metadata)) {
-        const escapedValue = escapeNewlines(String(value));
+        const escapedValue = escapeNewlines(value);
         lines.push(`  - ${key}: ${escapedValue}`);
       }
     }

--- a/server/lib/taskParser.test.js
+++ b/server/lib/taskParser.test.js
@@ -352,6 +352,33 @@ describe('Task Parser', () => {
       expect(parsed[0].metadata.context).toBe(multiLineContext);
     });
 
+    it('should round-trip array and object metadata values (screenshots, attachments, reviewers)', () => {
+      const tasks = [
+        {
+          id: 'task-001', status: 'pending', priority: 'MEDIUM', priorityValue: 2, description: 'Test',
+          metadata: {
+            screenshots: ['/data/screenshots/a.png', '/data/screenshots/b.png'],
+            attachments: [{ filename: 'a.png', originalName: 'photo.png', path: '/data/cos/attachments/a.png' }],
+            reviewers: ['codex', 'claude'],
+          }
+        }
+      ];
+
+      const markdown = generateTasksMarkdown(tasks);
+      // Pre-stringifying before escapeNewlines would flatten the array to a
+      // bare comma-joined string ("a.png,b.png") or "[object Object]" — assert
+      // the JSON sentinel is present so a regression here fails loudly.
+      expect(markdown).toMatch(/- screenshots: __json__:\[/);
+      expect(markdown).toMatch(/- attachments: __json__:\[/);
+
+      const parsed = parseTasksMarkdown(markdown);
+      expect(parsed[0].metadata.screenshots).toEqual(['/data/screenshots/a.png', '/data/screenshots/b.png']);
+      expect(parsed[0].metadata.attachments).toEqual([
+        { filename: 'a.png', originalName: 'photo.png', path: '/data/cos/attachments/a.png' }
+      ]);
+      expect(parsed[0].metadata.reviewers).toEqual(['codex', 'claude']);
+    });
+
     it('should sort tasks by priority within sections', () => {
       const tasks = [
         { id: 'task-001', status: 'pending', priority: 'LOW', priorityValue: 1, description: 'Low', metadata: {} },

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -746,6 +746,25 @@ describe('validation.js', () => {
       expect(createCosTaskSchema.safeParse({ description: 'x', reviewStopMode: 'nope' }).success).toBe(false);
     });
 
+    it('accepts multiple image screenshots and attachment objects', () => {
+      const parsed = createCosTaskSchema.safeParse({
+        description: 'do a thing',
+        screenshots: ['/data/screenshots/a.png', '/data/screenshots/b.png'],
+        attachments: [
+          { filename: 'a-123.png', originalName: 'photo-one.png', path: '/data/cos/attachments/a-123.png', size: 100, mimeType: 'image/png' },
+          { filename: 'b-456.png', originalName: 'photo-two.png', path: '/data/cos/attachments/b-456.png', size: 200, mimeType: 'image/png' },
+        ],
+      });
+      expect(parsed.success).toBe(true);
+      expect(parsed.data.screenshots).toHaveLength(2);
+      expect(parsed.data.attachments).toHaveLength(2);
+      expect(parsed.data.attachments[1].originalName).toBe('photo-two.png');
+    });
+
+    it('rejects a legacy attachments-as-strings shape', () => {
+      expect(createCosTaskSchema.safeParse({ description: 'x', attachments: ['a.png'] }).success).toBe(false);
+    });
+
     it('should reject prototype pollution keys', () => {
       expect(sanitizeTaskMetadata({ __proto__: { malicious: true } })).toBeNull();
       expect(sanitizeTaskMetadata({ constructor: true })).toBeNull();

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -318,6 +318,31 @@ describe('CoS Routes', () => {
 
       expect(response.status).toBe(400);
     });
+
+    it('should accept multiple screenshots and attachment objects', async () => {
+      const taskData = {
+        description: 'Test task with images',
+        screenshots: ['/data/screenshots/a.png', '/data/screenshots/b.png'],
+        attachments: [
+          { filename: 'a-123.png', originalName: 'photo-one.png', path: '/data/cos/attachments/a-123.png', size: 100, mimeType: 'image/png' },
+          { filename: 'b-456.png', originalName: 'photo-two.png', path: '/data/cos/attachments/b-456.png', size: 200, mimeType: 'image/png' },
+        ]
+      };
+      cos.addTask.mockResolvedValue({ id: 'task-002', ...taskData, status: 'pending' });
+
+      const response = await request(app)
+        .post('/api/cos/tasks')
+        .send(taskData);
+
+      expect(response.status).toBe(200);
+      expect(cos.addTask).toHaveBeenCalledWith(
+        expect.objectContaining({
+          screenshots: taskData.screenshots,
+          attachments: taskData.attachments,
+        }),
+        'user'
+      );
+    });
   });
 
   describe('POST /api/cos/tasks/reorder', () => {

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -171,35 +171,60 @@ const LIGHT_CONTEXT_PROVIDER_TYPES = new Set([PROVIDER_TYPES.TUI, PROVIDER_TYPES
 const SIMPLIFY_INLINE_REVIEW = 'review your changed code for reuse, quality, and efficiency (DRY, dead code, naming, simpler equivalents, missed edge cases)';
 
 /**
- * Build the shared task block — the description plus optional `**Target App**`
- * and `**Screenshots**` fields. Used by BOTH the light and full prompt paths
- * so a new task-metadata field gets surfaced in both without drift.
+ * Render a file-list task field (screenshots, attachments, …) either as a
+ * `### Header` + bulleted-path list (light path) or a single inline
+ * `**Header**: a, b` line (full path). Shared by every file-list field in
+ * `buildTaskBlock` so a wording tweak or a new field can't drift between them.
  *
- * Returns three pre-rendered slots (`description`, `targetApp`, `screenshots`).
- * Absent fields come back as empty strings so the full path's template literal
- * can interpolate them in fixed positions and preserve byte-identical line
- * spacing. The light path filters out the empty strings and joins what remains.
+ * @param {string} header - Section heading / inline label (e.g. "Screenshots").
+ * @param {Array} items - Task-metadata array; anything else renders as ''.
+ * @param {(item: any) => string} formatItem - Renders one item for the bulleted list.
+ * @param {(item: any) => string} formatInline - Renders one item for the inline join.
+ * @param {boolean} asList - Bulleted-list style vs. inline style.
+ * @returns {string}
+ */
+function renderFileListField(header, items, formatItem, formatInline, asList) {
+  if (!Array.isArray(items) || items.length === 0) return '';
+  return asList
+    ? `### ${header}\nUse your filesystem tools to inspect each path:\n` +
+      items.map(i => `- ${formatItem(i)}`).join('\n')
+    : `**${header}**: ${items.map(formatInline).join(', ')}`;
+}
+
+/**
+ * Build the shared task block — the description plus optional `**Target App**`,
+ * `**Screenshots**`, and `**Attachments**` fields. Used by BOTH the light and
+ * full prompt paths so a new task-metadata field gets surfaced in both without
+ * drift.
+ *
+ * Returns pre-rendered slots (`description`, `targetApp`, `screenshots`,
+ * `attachments`). Absent fields come back as empty strings so the full path's
+ * template literal can interpolate them in fixed positions and preserve
+ * byte-identical line spacing. The light path filters out the empty strings
+ * and joins what remains.
  *
  * @param {Object} task
  * @param {Object} [opts]
  * @param {boolean} [opts.screenshotsAsList=false] - When true, render screenshots
- *   as a `### Screenshots` header followed by a bulleted list of paths (light
- *   path style). When false, render as a single inline `**Screenshots**: a, b`
+ *   and attachments as a header followed by a bulleted list of paths (light
+ *   path style). When false, render as a single inline `**Field**: a, b`
  *   line (full path style).
- * @returns {{ description: string, targetApp: string, screenshots: string }}
+ * @returns {{ description: string, targetApp: string, screenshots: string, attachments: string }}
  */
 export function buildTaskBlock(task, { screenshotsAsList = false } = {}) {
   const description = task.description;
   const targetApp = task.metadata?.app ? `**Target App**: ${task.metadata.app}` : '';
-  const shots = task.metadata?.screenshots;
-  let screenshots = '';
-  if (Array.isArray(shots) && shots.length > 0) {
-    screenshots = screenshotsAsList
-      ? '### Screenshots\nUse your filesystem tools to inspect each path:\n' +
-        shots.map(s => `- \`${s}\``).join('\n')
-      : `**Screenshots**: ${shots.join(', ')}`;
-  }
-  return { description, targetApp, screenshots };
+  const screenshots = renderFileListField(
+    'Screenshots', task.metadata?.screenshots,
+    (s) => `\`${s}\``, (s) => s, screenshotsAsList
+  );
+  const label = (f) => (f?.originalName || f?.filename || f?.path || '').toString();
+  const path = (f) => (f?.path || '').toString();
+  const attachments = renderFileListField(
+    'Attachments', task.metadata?.attachments,
+    (f) => `\`${path(f)}\` (${label(f)})`, (f) => `${label(f)} (${path(f)})`, screenshotsAsList
+  );
+  return { description, targetApp, screenshots, attachments };
 }
 
 /**
@@ -651,6 +676,7 @@ ${taskBlock.description}
 ${task.metadata?.context ? (task.metadata.context.includes('\n') ? `\n### Task Context\n\n${task.metadata.context.trimEnd()}\n` : `\n### Task Context\n\n${task.metadata.context}\n`) : ''}
 ${taskBlock.targetApp}
 ${taskBlock.screenshots}
+${taskBlock.attachments}
 ${worktreeSection}
 ${pipelineSection}
 ${jiraSection}
@@ -713,7 +739,7 @@ Begin working on the task now.`;
  * The agent already has direct access to the project, so we don't paste in:
  *   memory dumps, CLAUDE.md contents, digital twin, tools summary,
  *   `.planning/` snippets, auto-matched skill templates, or compaction
- *   warnings. We just hand it the task, any user-attached context/screenshots,
+ *   warnings. We just hand it the task, any user-attached context/screenshots/attachments,
  *   and the PortOS-specific contract bits it can't infer (worktree branch,
  *   JIRA ticket, pipeline predecessors, completion-sentinel protocol,
  *   review-loop follow-up procedure).
@@ -762,6 +788,7 @@ export function buildLightContextPrompt(task, workspaceDir, worktreeInfo, isTrut
   }
 
   if (taskBlock.screenshots) sections.push(taskBlock.screenshots);
+  if (taskBlock.attachments) sections.push(taskBlock.attachments);
 
   // --- Worktree ----------------------------------------------------------
   if (worktreeInfo) {

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -136,6 +136,18 @@ describe('buildLightContextPrompt', () => {
       expect(prompt).toMatch(/`\/tmp\/b\.png`/);
     });
 
+    it('lists multiple attached files (including images) so the agent can read them via its own tools', () => {
+      const prompt = buildLightContextPrompt(
+        makeTask({ metadata: { attachments: [
+          { filename: 'a-123.png', originalName: 'photo-one.png', path: '/tmp/attachments/a-123.png' },
+          { filename: 'b-456.png', originalName: 'photo-two.png', path: '/tmp/attachments/b-456.png' },
+        ] } }),
+        '/r', null, isTruthyMeta);
+      expect(prompt).toMatch(/### Attachments/);
+      expect(prompt).toMatch(/`\/tmp\/attachments\/a-123\.png` \(photo-one\.png\)/);
+      expect(prompt).toMatch(/`\/tmp\/attachments\/b-456\.png` \(photo-two\.png\)/);
+    });
+
     it('renders the worktree block with branch + path when worktreeInfo is present', () => {
       const wt = {
         branchName: 'cos/test-1',


### PR DESCRIPTION
## Summary
- The CoS task form's "Attach" button already let users select multiple images (`accept=image/*`, `multiple`), but `createCosTaskSchema` declared `attachments` as `string[]` while the client always POSTs attachment objects (`{filename, originalName, path, size, mimeType}`) — so any task with an attachment failed validation with a 400. Fixed the schema to match the real payload shape.
- Wired `task.metadata.attachments` into `buildTaskBlock` (mirroring the existing `screenshots` rendering) so attached files actually reach the spawned agent's prompt instead of being stored and never read.
- Found and fixed a deeper related bug via local review (codex): `generateTasksMarkdown` pre-stringified every metadata value with `String(value)` before handing it to `escapeNewlines`, which defeated `escapeNewlines`'s own array/object JSON-encoding branch — an array became a bare comma-joined string and an object became the literal `"[object Object]"`. Since every real task spawn re-reads `TASKS.md` from disk, this silently dropped `screenshots`/`attachments`/`reviewers` metadata on any task that went through a normal dequeue cycle. Fixed by passing the raw value through.

## Test plan
- [x] `server/lib/validation.test.js`, `server/routes/cos.test.js`, `server/services/agentPromptBuilder.test.js`, `server/lib/taskParser.test.js` — new regression tests for the schema fix, prompt surfacing, and the TASKS.md round-trip
- [x] Full server test suite (excluding pre-existing Postgres-test-DB-dependent failures unrelated to this change)
- [x] Local review passes: claude (clean), codex (found + fixed the taskParser bug, confirmed clean on re-review), ollama/gemma4:26b (clean, 7/7 files)