### PR TITLE
fix(update): stop reconcile/update UI from hanging forever on 'Reconciling...'

### DIFF
--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -77,7 +77,12 @@ export default function UpdateTab() {
     // Shared by the 'restart' step, 'portos:update:complete', and the
     // 'disconnect' fallback below — all three mean "the server is (or is
     // about to be) restarting, stop trusting the socket and start polling."
+    // Sets `updatingRef` synchronously (not just via the syncing effect,
+    // which only runs after the next commit) so a 'disconnect' arriving in
+    // the same tick right after an error/complete can't read a stale `true`
+    // and spuriously re-arm polling for an update that already ended.
     const armRestartPolling = () => {
+      updatingRef.current = false;
       setUpdating(false);
       setPolling(true);
       toast.loading('PortOS is restarting...', { id: 'portos-update-restart', duration: Infinity });
@@ -103,6 +108,7 @@ export default function UpdateTab() {
 
     const handleComplete = ({ success, newVersion, versionKnown }) => {
       if (!success) {
+        updatingRef.current = false;
         setUpdating(false);
         return;
       }
@@ -114,6 +120,7 @@ export default function UpdateTab() {
     };
 
     const handleError = ({ message }) => {
+      updatingRef.current = false;
       setUpdating(false);
       setPolling(false);
       toast.dismiss('portos-update-restart');
@@ -230,6 +237,7 @@ export default function UpdateTab() {
     setUpdateError(null);
     const result = await api.executePortosUpdate(opts).catch(err => {
       setUpdateError(err.message);
+      updatingRef.current = false;
       setUpdating(false);
       return null;
     });

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -8,6 +8,7 @@ import * as api from '../../../services/api';
 import socket from '../../../services/socket';
 import { formatDateTime } from '../../../utils/formatters';
 import { useAutoRefetch } from '../../../hooks/useAutoRefetch';
+import useMounted from '../../../hooks/useMounted';
 
 const STEP_LABELS = {
   starting: 'Starting update',
@@ -50,10 +51,8 @@ export default function UpdateTab() {
   // unmount (e.g. the user navigates away) while the timer is pending lets
   // the deferred callback still fire, pop an undismissable "PortOS is
   // restarting..." toast (duration: Infinity), and set state on an unmounted
-  // component — nothing is left running to ever dismiss it. Never reset to
-  // `true`; this only ever needs to flip once, on unmount.
-  const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  // component — nothing is left running to ever dismiss it.
+  const mountedRef = useMounted();
   // Tracks whether the health endpoint went down during a restart poll. A
   // reconcile (issue #1779) often lands the SAME version (new commits, no
   // release bump), so version-change detection alone can't confirm completion —

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -43,6 +43,9 @@ export default function UpdateTab() {
   const attemptsRef = useRef(0);
   const targetVersionRef = useRef(null);
   const preUpdateVersionRef = useRef(null);
+  // Mirrors `updating` for the socket 'disconnect' listener below, which is
+  // registered once on mount and would otherwise close over a stale `false`.
+  const updatingRef = useRef(false);
   // Tracks whether the health endpoint went down during a restart poll. A
   // reconcile (issue #1779) often lands the SAME version (new commits, no
   // release bump), so version-change detection alone can't confirm completion —
@@ -65,8 +68,21 @@ export default function UpdateTab() {
     fetchStatus();
   }, [fetchStatus]);
 
+  useEffect(() => {
+    updatingRef.current = updating;
+  }, [updating]);
+
   // Socket event listeners for update progress
   useEffect(() => {
+    // Shared by the 'restart' step, 'portos:update:complete', and the
+    // 'disconnect' fallback below — all three mean "the server is (or is
+    // about to be) restarting, stop trusting the socket and start polling."
+    const armRestartPolling = () => {
+      setUpdating(false);
+      setPolling(true);
+      toast.loading('PortOS is restarting...', { id: 'portos-update-restart', duration: Infinity });
+    };
+
     const handleStep = ({ step, status: stepStatus, message }) => {
       setSteps(prev => {
         const existing = prev.findIndex(s => s.step === step);
@@ -81,22 +97,20 @@ export default function UpdateTab() {
       // When the server signals it's restarting, begin health polling immediately.
       // The PM2 restart may kill the server before portos:update:complete fires.
       if ((step === 'restarting' || step === 'restart') && stepStatus !== 'error' && targetVersionRef.current) {
-        setUpdating(false);
-        setPolling(true);
-        toast.loading('PortOS is restarting...', { id: 'portos-update-restart', duration: Infinity });
+        armRestartPolling();
       }
     };
 
     const handleComplete = ({ success, newVersion, versionKnown }) => {
-      setUpdating(false);
-      if (success) {
-        // Use server-reported actual version when available; fall back to target
-        if (versionKnown && newVersion) {
-          targetVersionRef.current = newVersion;
-        }
-        setPolling(true);
-        toast.loading('PortOS is restarting...', { id: 'portos-update-restart', duration: Infinity });
+      if (!success) {
+        setUpdating(false);
+        return;
       }
+      // Use server-reported actual version when available; fall back to target
+      if (versionKnown && newVersion) {
+        targetVersionRef.current = newVersion;
+      }
+      armRestartPolling();
     };
 
     const handleError = ({ message }) => {
@@ -106,14 +120,30 @@ export default function UpdateTab() {
       setUpdateError(message);
     };
 
+    // `pm2 delete ecosystem.config.cjs` (the update's own "pm2-stop" step) kills
+    // this server process — and its socket — well before update.sh reaches its
+    // 'restart' step. That step event, and 'portos:update:complete', are then
+    // never emitted, and the UI hangs on "Reconciling..."/"Stopping apps"
+    // forever even though update.sh finishes fine in the background. The
+    // socket disconnecting IS the server dying, so treat it as the same
+    // signal 'restart' would have been — it's a strictly more reliable proxy
+    // for "the update just tore down this process" than waiting on a step
+    // event from the process being torn down.
+    const handleDisconnect = () => {
+      if (!updatingRef.current) return;
+      armRestartPolling();
+    };
+
     socket.on('portos:update:step', handleStep);
     socket.on('portos:update:complete', handleComplete);
     socket.on('portos:update:error', handleError);
+    socket.on('disconnect', handleDisconnect);
 
     return () => {
       socket.off('portos:update:step', handleStep);
       socket.off('portos:update:complete', handleComplete);
       socket.off('portos:update:error', handleError);
+      socket.off('disconnect', handleDisconnect);
     };
   }, []);
 

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -46,6 +46,14 @@ export default function UpdateTab() {
   // Mirrors `updating` for the socket 'disconnect' listener below, which is
   // registered once on mount and would otherwise close over a stale `false`.
   const updatingRef = useRef(false);
+  // Guards the disconnect-confirmation setTimeout below: without this, an
+  // unmount (e.g. the user navigates away) while the timer is pending lets
+  // the deferred callback still fire, pop an undismissable "PortOS is
+  // restarting..." toast (duration: Infinity), and set state on an unmounted
+  // component — nothing is left running to ever dismiss it. Never reset to
+  // `true`; this only ever needs to flip once, on unmount.
+  const mountedRef = useRef(true);
+  useEffect(() => () => { mountedRef.current = false; }, []);
   // Tracks whether the health endpoint went down during a restart poll. A
   // reconcile (issue #1779) often lands the SAME version (new commits, no
   // release bump), so version-change detection alone can't confirm completion —
@@ -143,9 +151,13 @@ export default function UpdateTab() {
     const handleDisconnect = () => {
       if (!updatingRef.current) return;
       setTimeout(async () => {
-        if (!updatingRef.current) return;
-        const ok = await api.checkHealth().catch(() => null);
-        if (!ok && updatingRef.current) armRestartPolling();
+        if (!updatingRef.current || !mountedRef.current) return;
+        // silent: true — a failed check here just means "confirmed, arm
+        // polling"; the generic "Server unreachable" toast would otherwise
+        // fire right alongside (and ahead of) the intended "restarting" toast
+        // on the exact real-disconnect case this confirmation exists for.
+        const ok = await api.checkHealth({ silent: true }).catch(() => null);
+        if (!ok && updatingRef.current && mountedRef.current) armRestartPolling();
       }, 1500);
     };
 
@@ -174,7 +186,12 @@ export default function UpdateTab() {
 
   const pollHealth = useCallback(async () => {
     attemptsRef.current += 1;
-    const ok = await api.checkHealth().catch(() => null);
+    // silent: true — the server being unreachable is the EXPECTED state for
+    // most of this restart poll (that's the down→up transition it's
+    // watching for), not an error; the generic toast would spam "Server
+    // unreachable" on every 2s tick throughout the "PortOS is restarting..."
+    // loading toast's own lifetime.
+    const ok = await api.checkHealth({ silent: true }).catch(() => null);
     const preUpdateVersion = preUpdateVersionRef.current;
     if (!ok) {
       // Server is mid-restart (PM2 stopped it) — record the dip so a same-version

--- a/client/src/components/apps/tabs/UpdateTab.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.jsx
@@ -131,14 +131,22 @@ export default function UpdateTab() {
     // this server process — and its socket — well before update.sh reaches its
     // 'restart' step. That step event, and 'portos:update:complete', are then
     // never emitted, and the UI hangs on "Reconciling..."/"Stopping apps"
-    // forever even though update.sh finishes fine in the background. The
-    // socket disconnecting IS the server dying, so treat it as the same
-    // signal 'restart' would have been — it's a strictly more reliable proxy
-    // for "the update just tore down this process" than waiting on a step
-    // event from the process being torn down.
+    // forever even though update.sh finishes fine in the background. A raw
+    // 'disconnect' isn't proof of that by itself, though — PortOS is commonly
+    // used remotely over Tailscale, and a transient network blip during the
+    // pre-pm2-stop steps (git-pull/submodules, while the server is still very
+    // much alive) would fire 'disconnect' too. Confirm the server is actually
+    // unreachable before treating this as "the update just tore the process
+    // down" — otherwise a blip prematurely arms polling, which can time out
+    // with a false "Restart timed out" error while the real update finishes
+    // fine in the background with nothing left watching it.
     const handleDisconnect = () => {
       if (!updatingRef.current) return;
-      armRestartPolling();
+      setTimeout(async () => {
+        if (!updatingRef.current) return;
+        const ok = await api.checkHealth().catch(() => null);
+        if (!ok && updatingRef.current) armRestartPolling();
+      }, 1500);
     };
 
     socket.on('portos:update:step', handleStep);

--- a/client/src/components/apps/tabs/UpdateTab.test.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.test.jsx
@@ -80,6 +80,31 @@ describe('UpdateTab reconcile flow', () => {
     // stay stuck showing "Reconciling..." forever waiting for a step event
     // that will never arrive from the now-dead process.
     await waitFor(() => expect(screen.getByRole('button', { name: 'Restarting...' })).toBeTruthy());
+    // The confirmation check must be silent — a real disconnect is the
+    // primary case this fallback exists for, and a generic "Server
+    // unreachable" toast firing right alongside the intended "restarting"
+    // toast would be a confusing double-toast on the common path.
+    expect(mockCheckHealth).toHaveBeenLastCalledWith({ silent: true });
+  });
+
+  it('does not pop an undismissable "restarting" toast if the component unmounts before the disconnect confirmation resolves', async () => {
+    const { unmount } = render(<UpdateTab />);
+
+    const button = await screen.findByRole('button', { name: 'Reconcile Now' });
+    fireEvent.click(button);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Reconciling...' })).toBeTruthy());
+
+    // The server really did go down (confirms), but the user navigated away
+    // before the 1.5s confirmation delay elapsed. Nothing is left mounted to
+    // ever dismiss a toast.loading({ duration: Infinity }) popped after this.
+    mockCheckHealth.mockResolvedValue(null);
+    vi.useFakeTimers();
+    handlers.get('disconnect')();
+    unmount();
+    await act(async () => { await vi.advanceTimersByTimeAsync(1500); });
+    vi.useRealTimers();
+
+    expect(mockToast.loading).not.toHaveBeenCalled();
   });
 
   it('ignores a disconnect caused by a transient network blip (server still reachable)', async () => {

--- a/client/src/components/apps/tabs/UpdateTab.test.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.test.jsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// ── Mock socket — capture registered handlers so the test can fire 'disconnect' ──
+const handlers = new Map();
+vi.mock('../../../services/socket', () => ({
+  default: {
+    on: (event, fn) => { handlers.set(event, fn); },
+    off: (event, fn) => { if (handlers.get(event) === fn) handlers.delete(event); },
+  },
+}));
+
+// ── Mock toast ────────────────────────────────────────────────────────────────
+const mockToast = vi.hoisted(() => Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn(), loading: vi.fn(), dismiss: vi.fn() }));
+vi.mock('../../ui/Toast', () => ({ default: mockToast }));
+
+// ── Mock API ──────────────────────────────────────────────────────────────────
+const mockGetUpdateStatus = vi.fn();
+const mockCheckHealth = vi.fn();
+const mockExecutePortosUpdate = vi.fn();
+vi.mock('../../../services/api', () => ({
+  getUpdateStatus: (...a) => mockGetUpdateStatus(...a),
+  checkHealth: (...a) => mockCheckHealth(...a),
+  executePortosUpdate: (...a) => mockExecutePortosUpdate(...a),
+  checkForUpdate: vi.fn(),
+  ignoreUpdateVersion: vi.fn(),
+  clearIgnoredVersions: vi.fn(),
+  syncPortosFork: vi.fn(),
+}));
+
+const UpdateTab = (await import('./UpdateTab')).default;
+
+const OUT_OF_SYNC_STATUS = {
+  currentVersion: '2.24.0',
+  installState: { outOfSync: true, runningStaleCode: true },
+};
+
+describe('UpdateTab reconcile flow', () => {
+  beforeEach(() => {
+    handlers.clear();
+    mockGetUpdateStatus.mockReset().mockResolvedValue(OUT_OF_SYNC_STATUS);
+    mockCheckHealth.mockReset().mockResolvedValue({ version: '2.24.0', uptime: 120 });
+    mockExecutePortosUpdate.mockReset().mockResolvedValue({ tag: 'v2.24.0' });
+    mockToast.mockClear();
+    mockToast.loading.mockClear();
+  });
+
+  it('arms the restart-polling fallback on socket disconnect, not just on the "restart" step', async () => {
+    render(<UpdateTab />);
+
+    const button = await screen.findByRole('button', { name: 'Reconcile Now' });
+    fireEvent.click(button);
+
+    // runUpdate flips to "Reconciling..." once the update starts.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Reconciling...' })).toBeTruthy());
+    expect(mockExecutePortosUpdate).toHaveBeenCalledWith({ reconcile: true });
+
+    // The server process dies mid-update (pm2-stop kills it) before it ever
+    // emits a 'restart' step or 'portos:update:complete' — only the socket
+    // disconnecting tells the client the process is gone.
+    expect(handlers.has('disconnect')).toBe(true);
+    fireEvent.click(button); // no-op safety: button should already reflect updating state
+    handlers.get('disconnect')();
+
+    // The fallback must arm from 'disconnect' alone — the UI should not stay
+    // stuck showing "Reconciling..." forever waiting for a step event that
+    // will never arrive from the now-dead process.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Restarting...' })).toBeTruthy());
+  });
+
+  it('ignores a disconnect that happens while no update is in progress', async () => {
+    render(<UpdateTab />);
+    await screen.findByRole('button', { name: 'Reconcile Now' });
+
+    expect(handlers.has('disconnect')).toBe(true);
+    handlers.get('disconnect')();
+
+    // No update was running, so disconnect must not fake-arm the restart flow.
+    expect(screen.getByRole('button', { name: 'Reconcile Now' })).toBeTruthy();
+    expect(mockToast.loading).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/apps/tabs/UpdateTab.test.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.test.jsx
@@ -1,3 +1,4 @@
+import { StrictMode } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 
@@ -124,6 +125,26 @@ describe('UpdateTab reconcile flow', () => {
 
     expect(screen.getByRole('button', { name: 'Reconciling...' })).toBeTruthy();
     expect(mockToast.loading).not.toHaveBeenCalled();
+  });
+
+  it('still confirms a real disconnect under StrictMode (mountedRef survives the dev-mode phantom mount→cleanup→remount)', async () => {
+    // React 18 StrictMode (on app-wide in main.jsx) double-invokes effects on
+    // mount: mount → cleanup → remount. A mountedRef implemented as a bare
+    // `useRef(true)` + cleanup-only effect never resets to `true` on the
+    // remount, so it reads permanently `false` for the rest of the
+    // component's real lifetime — silently killing the disconnect
+    // confirmation fallback in dev mode from the very first render. Plain
+    // `render()` doesn't reproduce this; wrap in StrictMode explicitly.
+    render(<StrictMode><UpdateTab /></StrictMode>);
+
+    const button = await screen.findByRole('button', { name: 'Reconcile Now' });
+    fireEvent.click(button);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Reconciling...' })).toBeTruthy());
+
+    mockCheckHealth.mockResolvedValue(null);
+    await fireDisconnectAndConfirm();
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Restarting...' })).toBeTruthy());
   });
 
   it('ignores a disconnect that happens while no update is in progress', async () => {

--- a/client/src/components/apps/tabs/UpdateTab.test.jsx
+++ b/client/src/components/apps/tabs/UpdateTab.test.jsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 // ── Mock socket — capture registered handlers so the test can fire 'disconnect' ──
 const handlers = new Map();
@@ -35,6 +35,15 @@ const OUT_OF_SYNC_STATUS = {
   installState: { outOfSync: true, runningStaleCode: true },
 };
 
+// Fires 'disconnect' and advances past the 1.5s unreachability-confirmation
+// delay in handleDisconnect, flushing the checkHealth() microtask through it.
+const fireDisconnectAndConfirm = async () => {
+  vi.useFakeTimers();
+  handlers.get('disconnect')();
+  await act(async () => { await vi.advanceTimersByTimeAsync(1500); });
+  vi.useRealTimers();
+};
+
 describe('UpdateTab reconcile flow', () => {
   beforeEach(() => {
     handlers.clear();
@@ -45,7 +54,11 @@ describe('UpdateTab reconcile flow', () => {
     mockToast.loading.mockClear();
   });
 
-  it('arms the restart-polling fallback on socket disconnect, not just on the "restart" step', async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('arms the restart-polling fallback once a disconnect is confirmed by an unreachable health check', async () => {
     render(<UpdateTab />);
 
     const button = await screen.findByRole('button', { name: 'Reconcile Now' });
@@ -57,15 +70,35 @@ describe('UpdateTab reconcile flow', () => {
 
     // The server process dies mid-update (pm2-stop kills it) before it ever
     // emits a 'restart' step or 'portos:update:complete' — only the socket
-    // disconnecting tells the client the process is gone.
+    // disconnecting tells the client the process is gone. Simulate the real
+    // death: the health check that follows the disconnect also fails.
     expect(handlers.has('disconnect')).toBe(true);
-    fireEvent.click(button); // no-op safety: button should already reflect updating state
-    handlers.get('disconnect')();
+    mockCheckHealth.mockResolvedValue(null);
+    await fireDisconnectAndConfirm();
 
-    // The fallback must arm from 'disconnect' alone — the UI should not stay
-    // stuck showing "Reconciling..." forever waiting for a step event that
-    // will never arrive from the now-dead process.
+    // The fallback must arm from a confirmed 'disconnect' — the UI should not
+    // stay stuck showing "Reconciling..." forever waiting for a step event
+    // that will never arrive from the now-dead process.
     await waitFor(() => expect(screen.getByRole('button', { name: 'Restarting...' })).toBeTruthy());
+  });
+
+  it('ignores a disconnect caused by a transient network blip (server still reachable)', async () => {
+    render(<UpdateTab />);
+
+    const button = await screen.findByRole('button', { name: 'Reconcile Now' });
+    fireEvent.click(button);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Reconciling...' })).toBeTruthy());
+
+    // PortOS is commonly used remotely over Tailscale — a socket 'disconnect'
+    // can fire from a mobile network blip during the pre-pm2-stop steps, well
+    // before the server actually dies. The health check right after the
+    // disconnect still succeeds (server alive, same pre-update version), so
+    // this must NOT be treated as proof of a restart.
+    expect(handlers.has('disconnect')).toBe(true);
+    await fireDisconnectAndConfirm();
+
+    expect(screen.getByRole('button', { name: 'Reconciling...' })).toBeTruthy();
+    expect(mockToast.loading).not.toHaveBeenCalled();
   });
 
   it('ignores a disconnect that happens while no update is in progress', async () => {
@@ -73,7 +106,7 @@ describe('UpdateTab reconcile flow', () => {
     await screen.findByRole('button', { name: 'Reconcile Now' });
 
     expect(handlers.has('disconnect')).toBe(true);
-    handlers.get('disconnect')();
+    await fireDisconnectAndConfirm();
 
     // No update was running, so disconnect must not fake-arm the restart flow.
     expect(screen.getByRole('button', { name: 'Reconcile Now' })).toBeTruthy();

--- a/client/src/services/apiSystem.js
+++ b/client/src/services/apiSystem.js
@@ -7,7 +7,7 @@ export const getAlertsSummary = (options) => request('/alerts/summary', options)
 export const getCharacter = (options) => request('/character', options);
 
 // Health
-export const checkHealth = () => request('/system/health');
+export const checkHealth = (options) => request('/system/health', options);
 export const getSystemHealth = (options) => request('/system/health/details', options);
 export const getNetworkExposure = (options) => request('/network-exposure/status', options);
 export const getCapabilities = (options) => request('/capabilities', options);


### PR DESCRIPTION
## Summary

The Update/Reconcile flow in `UpdateTab.jsx` could get stuck showing "Reconciling..." / "Stopping apps" forever, even though `update.sh` completed successfully and PortOS actually restarted on the new version.

## Root cause

`update.sh` itself already survives its own `pm2-stop` step fine — it's spawned `detached: true`, `unref()`'d, and traps `SIGPIPE` — and finishes the reconcile/update in the background. But the **only** signal that told the browser to stop trusting the socket and start polling for the server coming back (`setPolling(true)`) was a `portos:update:step` (`restart`) or `portos:update:complete` socket event. Both are emitted by the very Node process that `pm2 delete ecosystem.config.cjs` kills at the earlier `pm2-stop` step — long before `update.sh` ever reaches its `restart` step. Those events can never arrive, so the UI hangs indefinitely on whatever step it last received (typically "Stopping apps"), even though the update finished fine server-side.

## Fix

Use the Socket.IO `disconnect` event as an additional trigger — it fires reliably the instant the server process (and its socket) actually dies, which is the real-world event we want to detect, instead of waiting on a step emitted by the process being torn down.

Since PortOS is commonly used remotely over Tailscale, a bare `disconnect` isn't proof by itself (a transient network blip during the pre-`pm2-stop` steps would fire it too) — so it's debounced 1.5s and confirmed via an unreachable `checkHealth()` before arming the restart-polling fallback. That confirmation:
- is guarded by the existing `useMounted()` hook so it can't fire after the component unmounts and leak an undismissable toast
- passes `silent: true` (new option on `checkHealth()`) so a real disconnect doesn't also pop a confusing "Server unreachable" toast alongside the intended "PortOS is restarting..." one — applied at both the new call site and the pre-existing `pollHealth()` polling loop, which had the same defect

## Test plan
- [x] `npm test` (client) — 270 files / 2925 tests pass, including 6 new tests in `UpdateTab.test.jsx` covering: confirmed-disconnect arms polling, transient-blip disconnect is ignored, disconnect while idle is ignored, unmount-during-confirmation doesn't leak a toast, and a StrictMode-wrapped regression test (verified it fails against the naive `useRef(true)` mountedRef implementation and passes against `useMounted()`)
- [x] `npm run lint` (client) — clean
- [x] `npm run build` (client) — succeeds
- [x] Verified against the live install: the actual update that prompted this bug had already completed successfully server-side (PortOS running v2.24.0, clean `pm2` relaunch in `data/update.log`) — confirming the bug was purely in the UI's completion detection, not `update.sh` itself