### PR TITLE
fix tab-nav rows crushed to near-zero height inside scrolling flex columns

### DIFF
--- a/client/src/components/ui/TabPills.jsx
+++ b/client/src/components/ui/TabPills.jsx
@@ -59,7 +59,7 @@ export default function TabPills({
         <div
           ref={listRef}
           onScroll={onScroll}
-          className={`${mobileDropdown ? 'hidden sm:flex' : 'flex'} items-center gap-1 bg-port-card border border-port-border rounded p-1 overflow-x-auto touch-pan-x ${className}`}
+          className={`${mobileDropdown ? 'hidden sm:flex' : 'flex'} shrink-0 items-center gap-1 bg-port-card border border-port-border rounded p-1 overflow-x-auto touch-pan-x ${className}`}
           role="tablist"
           aria-label={ariaLabel}
         >
@@ -106,7 +106,7 @@ export default function TabPills({
     <div
       ref={listRef}
       onScroll={onScroll}
-      className={`flex border-b border-port-border ${stretch ? 'items-stretch bg-port-bg/40 shrink-0' : 'gap-1'} overflow-x-auto scrollbar-hide touch-pan-x ${className}`}
+      className={`flex shrink-0 border-b border-port-border ${stretch ? 'items-stretch bg-port-bg/40' : 'gap-1'} overflow-x-auto scrollbar-hide touch-pan-x ${className}`}
       role="tablist"
       aria-label={ariaLabel}
     >


### PR DESCRIPTION
## Summary
Universe pages' sub-nav tab bar (Bible/Cast/Places/Objects/Other/Composites/Render) was rendering crushed to ~8px tall, clipping every icon and label. Root cause: `TabPills`' tab-row container has `overflow-x-auto` (which forces `overflow-y: auto` too), and per the flexbox spec, a flex item with non-visible overflow gets an automatic minimum size of `0` instead of a content-based one. When it sits inside a `flex flex-col` ancestor whose total content exceeds the ancestor's own height-constrained box, flex-shrink squeezes this zero-min-size item down to near-zero before any content-sized sibling would shrink.

This was latent while the app-shell root used `min-h-screen` (the page always grew to fit). Pinning the root to a definite viewport height this week (`79ff9fb1c`/`ae734c043`/`5439228cc`) exposed it on Universe pages, whose content routinely exceeds one screen.

Fix: add `shrink-0` to both `TabPills` variants so the tab row can never be forced to shrink below its natural height — the ancestor's own `overflow-y-auto` handles overflow via scrolling instead, as intended. The underline variant's non-`stretch` branch was missing what its `stretch` branch already had.

## Test plan
- Verified live via CDP against the running app: toggling `shrink-0` on the broken tab bar took its rendered height from 8px → 42px and restored full icon/label rendering (before/after screenshots captured).
- `cd client && npx vitest run` — 270 test files, 2925 tests, all passing.