### PR TITLE
Fix update/reconcile stranding PortOS stopped: launch update.sh via double-fork so it survives pm2's tree-kill

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,3 +1,7 @@
+## Self-Update
+
+- **The in-app update/reconcile no longer strands PortOS stopped.** `updateExecutor` launched `update.sh` with a plain `spawn(..., { detached: true })`, assuming it would survive the restart phase — but PM2's TreeKill walks PPID, not the process group, so the moment the script's own `pm2-stop` step ran `pm2 delete ecosystem.config.cjs`, the script (still a PPID-child of portos-server) was killed along with the server. Every app was stopped and the only process that would have run the final `pm2 start` was dead — the "update/reconcile shuts everything down but never comes back" failure. On POSIX the script now launches through `spawnDetached()`'s double-fork (the same reparent-to-init machinery LoRA training uses to survive PM2 restarts, #1332), with `STEP:` progress streamed via the control-dir log tailer, so the update runs to completion and restarts PortOS even after the server dies mid-script. Windows keeps its prior plain-spawn behavior (PM2 there is taskkill-based; detached survival is a POSIX-only guarantee). (`server/services/updateExecutor.js`)
+
 ## CI
 
 - **CI and release workflows now run Node 24.x** (matching `.nvmrc`, which has pinned 24 while the workflows still ran 20.x). Also removed the stale v1.14-era GSD planning workspace (`.planning/`, `.plan-questions.md`) from the repo root — the milestone it tracked shipped in February and GSD is no longer in use for PortOS itself (the GSD feature for managed apps is unaffected; it simply no longer lists PortOS).

--- a/server/lib/detachedSpawn.js
+++ b/server/lib/detachedSpawn.js
@@ -437,6 +437,25 @@ export async function reattachDetached(controlDir, { pollMs = DEFAULT_POLL_MS, c
 }
 
 /**
+ * Is the control dir's job still running (live PID, no exit sentinel)? Lets a
+ * caller that REUSES a fixed control dir (e.g. the update executor) refuse to
+ * spawn while a prior detached job is alive — spawnDetached's setup truncates
+ * the pid/exit files, so the old supervisor's late `exit` write would satisfy
+ * the NEW tailer's sentinel check and prematurely close the new handle with
+ * the old job's status (the stale-late-write race reapDetached guards against).
+ *
+ * @param {string} controlDir - the job's spawnDetached control dir
+ * @returns {Promise<boolean>}
+ */
+export async function isDetachedRunning(controlDir) {
+  const pidRaw = await readFile(join(controlDir, 'pid'), 'utf8').catch(() => '');
+  const pid = Number.parseInt(pidRaw, 10);
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  const exitWritten = (await readFile(join(controlDir, 'exit'), 'utf8').catch(() => '')).length > 0;
+  return !exitWritten && isAlive(pid);
+}
+
+/**
  * Reap a detached job that outlived the server (boot recovery). Because
  * spawnDetached children reparent to init, a `pm2 restart` leaves them running
  * with no in-process handle — and the boot reconcile then marks their run/job

--- a/server/lib/detachedSpawn.test.js
+++ b/server/lib/detachedSpawn.test.js
@@ -4,7 +4,7 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { spawnDetached, reapDetached, reapAndCleanDetachedDirs, reattachDetached, isReattachable } from './detachedSpawn.js';
+import { spawnDetached, reapDetached, reapAndCleanDetachedDirs, reattachDetached, isReattachable, isDetachedRunning } from './detachedSpawn.js';
 
 const execFileAsync = promisify(execFile);
 const dirs = [];
@@ -265,6 +265,34 @@ describe('isReattachable', () => {
     // and the supervisor never got to write `exit`. PID 2^31-1 is never live.
     await writeFile(join(controlDir, 'pid'), '2147483647');
     expect(await isReattachable(controlDir)).toBe(false);
+  });
+});
+
+describe('isDetachedRunning', () => {
+  it('is true while the recorded child is still alive with no exit sentinel', async () => {
+    const controlDir = await tmpControlDir();
+    const handle = await spawnDetached('sh', ['-c', 'sleep 30'], { controlDir, pollMs: 25 });
+    expect(await isDetachedRunning(controlDir)).toBe(true);
+    handle.kill('SIGKILL');
+    await onClose(handle);
+  });
+
+  it('is false once the job recorded its exit', async () => {
+    const controlDir = await tmpControlDir();
+    const handle = await spawnDetached('sh', ['-c', 'exit 0'], { controlDir, pollMs: 25 });
+    await onClose(handle);
+    expect(await isDetachedRunning(controlDir)).toBe(false);
+  });
+
+  it('is false when no pid was ever recorded', async () => {
+    const controlDir = await tmpControlDir();
+    expect(await isDetachedRunning(controlDir)).toBe(false);
+  });
+
+  it('is false for a dead pid with no exit sentinel', async () => {
+    const controlDir = await tmpControlDir();
+    await writeFile(join(controlDir, 'pid'), '2147483647');
+    expect(await isDetachedRunning(controlDir)).toBe(false);
   });
 });
 

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -2,6 +2,7 @@ import { spawn } from 'child_process';
 import { readFile, unlink } from 'fs/promises';
 import { join } from 'path';
 import { PATHS } from '../lib/fileUtils.js';
+import { spawnDetached } from '../lib/detachedSpawn.js';
 import { recordUpdateResult } from './updateChecker.js';
 
 const UPDATE_SH = join(PATHS.root, 'update.sh');
@@ -9,8 +10,20 @@ const UPDATE_PS1 = join(PATHS.root, 'update.ps1');
 
 /**
  * Execute the PortOS update script (git pull to latest).
- * Spawns update.sh (or update.ps1 on Windows) detached so it survives
- * the Node process dying during the PM2 restart phase.
+ *
+ * On POSIX the script is launched via spawnDetached's double-fork so it
+ * reparents to init and SURVIVES pm2's TreeKill. A plain
+ * `spawn(..., { detached: true })` does NOT survive: pm2 walks PPID
+ * (`ps -e -o pid=,ppid=`), not the process group, so when update.sh reaches
+ * its `pm2-stop` step (`pm2 delete ecosystem.config.cjs`) the script itself —
+ * still a PPID-child of portos-server — was tree-killed with the server,
+ * leaving every app stopped with nothing alive to run the final `pm2 start`
+ * (the reconcile/update "shuts down but never comes back" failure). See the
+ * rationale in `server/lib/detachedSpawn.js`.
+ *
+ * Windows keeps the prior plain-spawn behavior (pm2 there is taskkill-based;
+ * detached survival is a POSIX-only guarantee — same trade-off as
+ * spawnDetached's own win32 fallback).
  *
  * The scripts pull the latest code via `git pull --rebase --autostash` and
  * write the actual resulting version to `data/update-complete.json`.
@@ -46,14 +59,27 @@ export async function executeUpdate(tag, emit, { forceCleanWorkspaces } = {}) {
     ? { ...process.env, PORTOS_FORCE_CLEAN_WORKSPACES: cleanList.join(',') }
     : process.env;
 
-  return new Promise((resolve) => {
-    const child = spawn(cmd, args, {
-      detached: true,
-      stdio: ['ignore', 'pipe', 'pipe'],
-      cwd: PATHS.root,
-      env: childEnv
-    });
+  // POSIX: double-fork via spawnDetached so the script reparents to init and
+  // survives the pm2 TreeKill its own `pm2 delete`/`pm2 start` steps trigger.
+  // The returned handle is ChildProcess-like (stdout/stderr 'data', 'close',
+  // 'error'), streamed by tailing the control dir's log files — so the STEP:
+  // progress parsing below works unchanged. The control dir is reused across
+  // updates (spawnDetached truncates stale files) and kept afterward as the
+  // post-mortem record of the launch.
+  const child = isWindows
+    ? spawn(cmd, args, {
+        detached: true,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        cwd: PATHS.root,
+        env: childEnv
+      })
+    : await spawnDetached(cmd, args, {
+        cwd: PATHS.root,
+        env: childEnv,
+        controlDir: join(PATHS.data, 'update-detached')
+      });
 
+  return new Promise((resolve) => {
     let lastStep = 'starting';
 
     // Parse STEP:name:status:message lines from stdout/stderr streams
@@ -149,7 +175,9 @@ export async function executeUpdate(tag, emit, { forceCleanWorkspaces } = {}) {
       resolve({ success: false, failedStep: 'starting', errorMessage });
     });
 
-    // Unref so the parent process doesn't wait for the detached child
-    child.unref();
+    // Unref so the parent process doesn't wait for the detached child.
+    // The spawnDetached handle has no unref (its launcher already unref'd);
+    // only the Windows plain-spawn child needs it.
+    child.unref?.();
   });
 }

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -2,7 +2,7 @@ import { spawn } from 'child_process';
 import { readFile, unlink } from 'fs/promises';
 import { join } from 'path';
 import { PATHS } from '../lib/fileUtils.js';
-import { spawnDetached } from '../lib/detachedSpawn.js';
+import { spawnDetached, isDetachedRunning } from '../lib/detachedSpawn.js';
 import { recordUpdateResult } from './updateChecker.js';
 
 const UPDATE_SH = join(PATHS.root, 'update.sh');
@@ -66,6 +66,25 @@ export async function executeUpdate(tag, emit, { forceCleanWorkspaces } = {}) {
   // progress parsing below works unchanged. The control dir is reused across
   // updates (spawnDetached truncates stale files) and kept afterward as the
   // post-mortem record of the launch.
+  const controlDir = join(PATHS.data, 'update-detached');
+
+  // Refuse to reuse the control dir while a prior update script is still
+  // running (survival path: the old script outlives the server restart it
+  // triggers, and its supervisor's late `exit` write into a truncated control
+  // dir would prematurely close the new handle with the OLD script's status).
+  // A still-running script also means a second update is wrong regardless.
+  if (!isWindows && await isDetachedRunning(controlDir)) {
+    const errorMessage = 'A previous update script is still running — wait for it to finish before starting another update';
+    await recordUpdateResult({
+      version: tag.replace(/^v/, ''),
+      success: false,
+      completedAt: new Date().toISOString(),
+      log: errorMessage
+    }).catch(e => console.error(`❌ Failed to record update result: ${e.message}`));
+    emit('starting', 'error', errorMessage);
+    return { success: false, failedStep: 'starting', errorMessage };
+  }
+
   const child = isWindows
     ? spawn(cmd, args, {
         detached: true,
@@ -76,7 +95,7 @@ export async function executeUpdate(tag, emit, { forceCleanWorkspaces } = {}) {
     : await spawnDetached(cmd, args, {
         cwd: PATHS.root,
         env: childEnv,
-        controlDir: join(PATHS.data, 'update-detached')
+        controlDir
       });
 
   return new Promise((resolve) => {

--- a/server/services/updateExecutor.test.js
+++ b/server/services/updateExecutor.test.js
@@ -11,7 +11,8 @@ tryReadFile: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('../lib/detachedSpawn.js', () => ({
-  spawnDetached: vi.fn()
+  spawnDetached: vi.fn(),
+  isDetachedRunning: vi.fn().mockResolvedValue(false)
 }));
 
 vi.mock('fs/promises', () => ({
@@ -24,16 +25,18 @@ vi.mock('./updateChecker.js', () => ({
 }));
 
 import { spawn } from 'child_process';
-import { spawnDetached } from '../lib/detachedSpawn.js';
+import { spawnDetached, isDetachedRunning } from '../lib/detachedSpawn.js';
 import { readFile } from 'fs/promises';
 import { recordUpdateResult } from './updateChecker.js';
 import { executeUpdate } from './updateExecutor.js';
 
+// The spawnDetached handle deliberately has NO unref (its launcher already
+// unref'd) — executeUpdate must use `child.unref?.()`. Only the win32
+// plain-spawn test adds a real ChildProcess-style unref to its mock.
 function createMockChild() {
   const child = new EventEmitter();
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
-  child.unref = vi.fn();
   child.pid = 12345;
   return child;
 }
@@ -55,6 +58,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   // Default: marker file not found (tests that need it override this)
   readFile.mockRejectedValue(new Error('ENOENT'));
+  // Default: no prior update script still running
+  isDetachedRunning.mockResolvedValue(false);
 });
 
 describe('executeUpdate', () => {
@@ -63,6 +68,7 @@ describe('executeUpdate', () => {
     try {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
       const child = createMockChild();
+      child.unref = vi.fn();
       spawn.mockReturnValue(child);
 
       const { promise } = await startUpdate('v1.0.0', () => {});
@@ -104,6 +110,27 @@ describe('executeUpdate', () => {
         controlDir: expect.stringContaining('update-detached')
       })
     );
+  });
+
+  // Reusing the fixed control dir while the prior update script is still
+  // alive would let the old supervisor's late `exit` write prematurely close
+  // the new handle with the old script's status — so a still-running script
+  // must refuse the new update instead of spawning over it.
+  it('refuses to spawn while a prior update script is still running', async () => {
+    isDetachedRunning.mockResolvedValue(true);
+
+    const emits = [];
+    const { promise } = await startUpdate('v1.0.0', (...args) => emits.push(args));
+    const result = await promise;
+
+    expect(result.success).toBe(false);
+    expect(result.failedStep).toBe('starting');
+    expect(spawnDetached).not.toHaveBeenCalled();
+    expect(spawn).not.toHaveBeenCalled();
+    expect(recordUpdateResult).toHaveBeenCalledWith(
+      expect.objectContaining({ success: false, log: expect.stringContaining('still running') })
+    );
+    expect(emits.some(e => e[0] === 'starting' && e[1] === 'error')).toBe(true);
   });
 
   it('parses STEP markers from stdout', async () => {

--- a/server/services/updateExecutor.test.js
+++ b/server/services/updateExecutor.test.js
@@ -10,6 +10,10 @@ tryReadFile: vi.fn().mockResolvedValue(null),
   PATHS: { root: '/mock', data: '/mock/data' }
 }));
 
+vi.mock('../lib/detachedSpawn.js', () => ({
+  spawnDetached: vi.fn()
+}));
+
 vi.mock('fs/promises', () => ({
   readFile: vi.fn(),
   unlink: vi.fn().mockResolvedValue(undefined)
@@ -20,6 +24,7 @@ vi.mock('./updateChecker.js', () => ({
 }));
 
 import { spawn } from 'child_process';
+import { spawnDetached } from '../lib/detachedSpawn.js';
 import { readFile } from 'fs/promises';
 import { recordUpdateResult } from './updateChecker.js';
 import { executeUpdate } from './updateExecutor.js';
@@ -33,6 +38,19 @@ function createMockChild() {
   return child;
 }
 
+// executeUpdate awaits spawnDetached before wiring its event listeners, so
+// tests must flush the microtask/immediate queue after calling it and before
+// emitting child events, or the emission fires into the void.
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+async function startUpdate(...args) {
+  const promise = executeUpdate(...args);
+  await flush();
+  // Wrapped in an object so `await startUpdate(...)` does not flatten the
+  // still-pending executeUpdate promise (which only settles after 'close').
+  return { promise };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   // Default: marker file not found (tests that need it override this)
@@ -40,14 +58,14 @@ beforeEach(() => {
 });
 
 describe('executeUpdate', () => {
-  it('spawns powershell on Windows', async () => {
+  it('spawns powershell on Windows (plain spawn, not spawnDetached)', async () => {
     const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
     try {
       Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
       const child = createMockChild();
       spawn.mockReturnValue(child);
 
-      const promise = executeUpdate('v1.0.0', () => {});
+      const { promise } = await startUpdate('v1.0.0', () => {});
       child.emit('close', 0);
       await promise;
 
@@ -56,6 +74,7 @@ describe('executeUpdate', () => {
         expect.arrayContaining(['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File']),
         expect.any(Object)
       );
+      expect(spawnDetached).not.toHaveBeenCalled();
     } finally {
       if (originalPlatformDescriptor) {
         Object.defineProperty(process, 'platform', originalPlatformDescriptor);
@@ -63,12 +82,36 @@ describe('executeUpdate', () => {
     }
   });
 
+  // Regression for the reconcile "shuts down but never restarts" failure: a
+  // plain spawn(detached:true) child is still a PPID-descendant of
+  // portos-server, so update.sh's own `pm2 delete` tree-killed the script
+  // before it could run the final `pm2 start`. POSIX must launch through
+  // spawnDetached's double-fork (reparent to init) instead.
+  it('launches via spawnDetached with a control dir on POSIX', async () => {
+    const child = createMockChild();
+    spawnDetached.mockResolvedValue(child);
+
+    const { promise } = await startUpdate('v1.0.0', () => {});
+    child.emit('close', 0);
+    await promise;
+
+    expect(spawn).not.toHaveBeenCalled();
+    expect(spawnDetached).toHaveBeenCalledWith(
+      'bash',
+      [expect.stringContaining('update.sh')],
+      expect.objectContaining({
+        cwd: '/mock',
+        controlDir: expect.stringContaining('update-detached')
+      })
+    );
+  });
+
   it('parses STEP markers from stdout', async () => {
     const child = createMockChild();
-    spawn.mockReturnValue(child);
+    spawnDetached.mockResolvedValue(child);
 
     const emits = [];
-    const promise = executeUpdate('v1.0.0', (...args) => emits.push(args));
+    const { promise } = await startUpdate('v1.0.0', (...args) => emits.push(args));
 
     // Simulate STEP output
     child.stdout.emit('data', Buffer.from('STEP:git-pull:running:Pulling latest changes\n'));
@@ -84,9 +127,9 @@ describe('executeUpdate', () => {
 
   it('records update result on success with tag fallback when marker missing', async () => {
     const child = createMockChild();
-    spawn.mockReturnValue(child);
+    spawnDetached.mockResolvedValue(child);
 
-    const promise = executeUpdate('v1.0.0', () => {});
+    const { promise } = await startUpdate('v1.0.0', () => {});
     child.emit('close', 0);
     const result = await promise;
 
@@ -99,9 +142,9 @@ describe('executeUpdate', () => {
 
   it('records failure on non-zero exit code', async () => {
     const child = createMockChild();
-    spawn.mockReturnValue(child);
+    spawnDetached.mockResolvedValue(child);
 
-    const promise = executeUpdate('v1.0.0', () => {});
+    const { promise } = await startUpdate('v1.0.0', () => {});
     child.emit('close', 1);
     const result = await promise;
 
@@ -113,10 +156,10 @@ describe('executeUpdate', () => {
 
   it('handles CRLF line endings from Windows PowerShell', async () => {
     const child = createMockChild();
-    spawn.mockReturnValue(child);
+    spawnDetached.mockResolvedValue(child);
 
     const emits = [];
-    const promise = executeUpdate('v1.0.0', (...args) => emits.push(args));
+    const { promise } = await startUpdate('v1.0.0', (...args) => emits.push(args));
 
     // Simulate CRLF output (Windows PowerShell)
     child.stdout.emit('data', Buffer.from('STEP:git-pull:running:Pulling latest changes\r\n'));
@@ -133,10 +176,10 @@ describe('executeUpdate', () => {
 
   it('returns actual version from completion marker and records result on success', async () => {
     const child = createMockChild();
-    spawn.mockReturnValue(child);
+    spawnDetached.mockResolvedValue(child);
     readFile.mockResolvedValue(JSON.stringify({ version: '2.0.0', completedAt: '2026-01-01T00:00:00Z' }));
 
-    const promise = executeUpdate('v1.0.0', () => {});
+    const { promise } = await startUpdate('v1.0.0', () => {});
     child.emit('close', 0);
     const result = await promise;
 
@@ -149,10 +192,10 @@ describe('executeUpdate', () => {
 
   it('handles spawn error', async () => {
     const child = createMockChild();
-    spawn.mockReturnValue(child);
+    spawnDetached.mockResolvedValue(child);
 
     const emits = [];
-    const promise = executeUpdate('v1.0.0', (...args) => emits.push(args));
+    const { promise } = await startUpdate('v1.0.0', (...args) => emits.push(args));
     child.emit('error', new Error('spawn failed'));
     const result = await promise;
 
@@ -167,41 +210,41 @@ describe('executeUpdate', () => {
   // reinstalls exactly those, regardless of the commit diff.
   it('passes allowlisted forceCleanWorkspaces as PORTOS_FORCE_CLEAN_WORKSPACES', async () => {
     const child = createMockChild();
-    spawn.mockReturnValue(child);
-    const promise = executeUpdate('v1.0.0', () => {}, { forceCleanWorkspaces: ['.', 'client'] });
+    spawnDetached.mockResolvedValue(child);
+    const { promise } = await startUpdate('v1.0.0', () => {}, { forceCleanWorkspaces: ['.', 'client'] });
     child.emit('close', 0);
     await promise;
-    const env = spawn.mock.calls[0][2].env;
+    const env = spawnDetached.mock.calls[0][2].env;
     expect(env.PORTOS_FORCE_CLEAN_WORKSPACES).toBe('.,client');
   });
 
   it('does NOT set PORTOS_FORCE_CLEAN_WORKSPACES when none are given', async () => {
     const child = createMockChild();
-    spawn.mockReturnValue(child);
-    const promise = executeUpdate('v1.0.0', () => {});
+    spawnDetached.mockResolvedValue(child);
+    const { promise } = await startUpdate('v1.0.0', () => {});
     child.emit('close', 0);
     await promise;
-    const env = spawn.mock.calls[0][2].env;
+    const env = spawnDetached.mock.calls[0][2].env;
     expect(env.PORTOS_FORCE_CLEAN_WORKSPACES).toBeUndefined();
   });
 
   it('filters out non-allowlisted workspace names (no injection)', async () => {
     const child = createMockChild();
-    spawn.mockReturnValue(child);
-    const promise = executeUpdate('v1.0.0', () => {}, { forceCleanWorkspaces: ['client', '../../etc', 'rm -rf /'] });
+    spawnDetached.mockResolvedValue(child);
+    const { promise } = await startUpdate('v1.0.0', () => {}, { forceCleanWorkspaces: ['client', '../../etc', 'rm -rf /'] });
     child.emit('close', 0);
     await promise;
-    const env = spawn.mock.calls[0][2].env;
+    const env = spawnDetached.mock.calls[0][2].env;
     expect(env.PORTOS_FORCE_CLEAN_WORKSPACES).toBe('client');
   });
 
   it('does NOT set the env when every workspace name is rejected', async () => {
     const child = createMockChild();
-    spawn.mockReturnValue(child);
-    const promise = executeUpdate('v1.0.0', () => {}, { forceCleanWorkspaces: ['bogus'] });
+    spawnDetached.mockResolvedValue(child);
+    const { promise } = await startUpdate('v1.0.0', () => {}, { forceCleanWorkspaces: ['bogus'] });
     child.emit('close', 0);
     await promise;
-    const env = spawn.mock.calls[0][2].env;
+    const env = spawnDetached.mock.calls[0][2].env;
     expect(env.PORTOS_FORCE_CLEAN_WORKSPACES).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

The in-app update/reconcile flow shut PortOS down and never brought it back. `updateExecutor` spawned `update.sh` with plain `spawn(..., { detached: true })`, assuming it would survive the restart phase — but PM2's TreeKill walks PPID (not the process group), so the moment the script's own `pm2-stop` step ran `pm2 delete ecosystem.config.cjs`, the script — still a PPID-child of portos-server — was killed along with the server. Every app was stopped and the only process that would have run the final `pm2 start` was dead. (Running `./update.sh` from a terminal was unaffected, which is why this only bit the in-app path.)

- On POSIX, launch `update.sh` through `spawnDetached()`'s double-fork (the same reparent-to-init machinery LoRA training uses to survive PM2 restarts, #1332). `STEP:` progress still streams to the UI via the control-dir log tailer, and the existing `update-complete.json` marker + boot recovery handles the server dying mid-script.
- Refuse to start a new update while a prior update script is still running (new `isDetachedRunning()` probe) — both a correctness guard and protection against the reused control dir's stale-late-write race.
- Windows keeps its prior plain-spawn behavior (PM2 there is taskkill-based; detached survival is a POSIX-only guarantee).

## Test plan

- `services/updateExecutor.test.js`: new regression test pinning the POSIX `spawnDetached` + control-dir contract, a still-running-refusal test, and the POSIX mock now omits `unref` so reverting `child.unref?.()` fails the suite; all prior behaviors (STEP parsing, CRLF, marker fallback, force-clean allowlist) re-pinned against the new spawn path.
- `lib/detachedSpawn.test.js`: four new `isDetachedRunning` cases (live pid, recorded exit, no pid, dead pid) using real spawned processes.
- Full server suite: 15,611 passed; the one failure is the pre-existing install-local prompt-drift issue tracked in #2042, unrelated to this change.
