### PR TITLE
fix: add stage-prompt migration for cd-treatment.md #1808 cast section (#2042)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased Changes
+
+## Internal
+
+- Migration 155 heals `data/prompts/stages/cd-treatment.md` installs that #1808's anchor-based migration 148 left stranded (#2042). Installs seeded before the `imageStrength` scene knob (older pre-#1808 template) got the `## Cast & ingredients` list but missed the per-scene `"cast": [{ "ingredientId": … }]` field, so the Creative Director cast-threading regression test stayed red on the runtime template and migration 148 (already applied) never re-ran. The new hash-driven prompt-replace upgrades those copies (and both pristine pre-#1808 shipped versions) to the current shipped reference, leaving hand-customized copies untouched. Also folds `cd-treatment.md` into `buildPromptDriftTables` so setup-data.js's drift warning classifies a stranded copy correctly.

--- a/scripts/migrations/155-heal-cd-treatment-cast-strand.js
+++ b/scripts/migrations/155-heal-cd-treatment-cast-strand.js
@@ -1,0 +1,68 @@
+/**
+ * Heal cd-treatment.md installs that #1808's migration 148 left stranded (#2042).
+ *
+ * Migration 148 backfilled the catalog-cast surfacing into
+ * `data/prompts/stages/cd-treatment.md` with two ANCHOR-based surgical inserts:
+ *   1. the `## Cast & ingredients` list section (anchored on the style-spec →
+ *      user-story bracket), and
+ *   2. the per-scene `"cast": [{ "ingredientId": … }]` JSON field (anchored on
+ *      the scene example's `"imageStrength": null` line).
+ *
+ * An install seeded BEFORE the `imageStrength` scene knob shipped (the older
+ * pre-#1808 template, md5 `2ffa482e…`) carries a scene example that lacks that
+ * anchor, so 148 applied insertion 1 (the file gained the cast list) but silently
+ * skipped insertion 2 — leaving the file at md5 `95b76856…`: it has the Cast
+ * section but is missing the per-scene `cast` field that
+ * `data.reference/prompts/stages/cd-treatment.md` ships. Because 148 is already
+ * recorded in `data/migrations.applied.json` on those installs, it never re-runs,
+ * so the `creativeDirectorPrompts.test.js` cast-threading regression stays red on
+ * the runtime template forever.
+ *
+ * This migration finishes the job with the canonical hash-driven prompt-replace
+ * (`./_lib.js`): when the installed copy still matches a KNOWN machine-produced
+ * shape (either pristine pre-#1808 shipped version, or the 148-partial strand) it
+ * is replaced wholesale with the current shipped reference. A hand-customized
+ * copy (hash matches neither old nor new) is left untouched with a warning — same
+ * safety contract as every other prompt-replace migration. Idempotent.
+ *
+ * Exporting ACCEPTED_OLD_MD5 / NEW_SHIPPED_MD5 also folds cd-treatment.md into
+ * `buildPromptDriftTables`, so setup-data.js's drift warning classifies a
+ * stranded copy as auto-updatable (was previously invisible to the sweep because
+ * 148 tracked the file via anchors, not hashes).
+ */
+
+import { makePromptReplaceMigration } from './_lib.js';
+
+export const ACCEPTED_OLD_MD5 = {
+  'cd-treatment.md': [
+    '2ffa482e7bfb6fe8b7224505fedbf712', // pre-#1808 shipped, pre-imageStrength-knob (447d2b5e3 / 22a0aced0)
+    '16d0ef6a7fd2533719a846019122ebee', // pre-#1808 shipped, post-imageStrength-knob (c68f38d09 / f04e3955c)
+    '95b7685690ecfee4f682b0293b790277', // migration-148 partial: cast list inserted, per-scene cast field missed (the #2042 strand)
+  ],
+};
+
+export const NEW_SHIPPED_MD5 = {
+  'cd-treatment.md': 'd940eadfb406ce584f0e244032f33382', // #1808 shipped reference (cast list + per-scene cast field)
+};
+
+const { applyMigration, up } = makePromptReplaceMigration({
+  accepted: ACCEPTED_OLD_MD5,
+  current: NEW_SHIPPED_MD5,
+  label: 'cd-treatment catalog-cast strand',
+  customizedHint: (filename) =>
+    `   To apply the per-scene cast field manually, diff:\n` +
+    `     data.reference/prompts/stages/${filename}\n` +
+    `   against your current:\n` +
+    `     data/prompts/stages/${filename}\n` +
+    `   and add the gated "cast": [{ "ingredientId": … }] field after the\n` +
+    `   scene example's "imageStrength" line.`,
+  skipFooter: (count) =>
+    `⚠️  ${count} cd-treatment prompt(s) could not be auto-updated because\n` +
+    `   they were customized. Creative Director treatments still generate, but\n` +
+    `   per-scene cast threading may stay underspecified until you merge the\n` +
+    `   prompt change manually.\n` +
+    `   See data.reference/prompts/stages/cd-treatment.md.`,
+});
+
+export { applyMigration };
+export default { up };

--- a/scripts/migrations/155-heal-cd-treatment-cast-strand.test.js
+++ b/scripts/migrations/155-heal-cd-treatment-cast-strand.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+
+import { runPromptMigrationTests } from './_testHelpers.js';
+import migration, { applyMigration, ACCEPTED_OLD_MD5, NEW_SHIPPED_MD5 } from './155-heal-cd-treatment-cast-strand.js';
+
+describe('migration 155 - heal cd-treatment catalog-cast strand', () => {
+  runPromptMigrationTests({
+    migration,
+    applyMigration,
+    ACCEPTED_OLD_MD5,
+    NEW_SHIPPED_MD5,
+    prefix: 'migration-155-',
+  });
+
+  it('tracks the exact #2042 strand hash (148-partial) as auto-updatable', () => {
+    // md5 `95b76856…` is the deterministic output of migration 148 applied to
+    // the older pre-#1808 shipped template (`2ffa482e…`, pre-imageStrength-knob):
+    // insertion 1 lands the Cast list, insertion 2's scene anchor misses. That
+    // stranded shape must be in the accepted-old set or the fix is a no-op.
+    expect(ACCEPTED_OLD_MD5['cd-treatment.md']).toContain('95b7685690ecfee4f682b0293b790277');
+    // Both pristine pre-#1808 shipped versions upgrade too.
+    expect(ACCEPTED_OLD_MD5['cd-treatment.md']).toContain('2ffa482e7bfb6fe8b7224505fedbf712');
+    expect(ACCEPTED_OLD_MD5['cd-treatment.md']).toContain('16d0ef6a7fd2533719a846019122ebee');
+    // Current shipped hash must never appear in its own accepted-old set.
+    expect(ACCEPTED_OLD_MD5['cd-treatment.md']).not.toContain(NEW_SHIPPED_MD5['cd-treatment.md']);
+  });
+});

--- a/scripts/setup-data-drift.test.js
+++ b/scripts/setup-data-drift.test.js
@@ -46,6 +46,7 @@ const EXPECTED_STAGE_OLD = {
   'pipeline-editorial-chekhov.md': ['bfacbf343ba2b9a3f6037bb45b94e1bb'],
   'pipeline-editorial-on-the-nose.md': ['48182b49149e6b5829fbed71b3ffc242'],
   'pipeline-tv-script.md': ['3f6fecc25573ed054b47db392250034a'],
+  'cd-treatment.md': ['2ffa482e7bfb6fe8b7224505fedbf712', '16d0ef6a7fd2533719a846019122ebee', '95b7685690ecfee4f682b0293b790277'],
 };
 const EXPECTED_STAGE_NEW = {
   'pipeline-idea-expansion.md': 'd6fa86a435f978336661dcabca67258f',
@@ -70,6 +71,7 @@ const EXPECTED_STAGE_NEW = {
   'pipeline-editorial-chekhov.md': '1f8a1696b5e4f476051dc5b2e5737db9',
   'pipeline-editorial-on-the-nose.md': 'e5786fb019e5bf19c7aa6ed0c8b35cda',
   'pipeline-tv-script.md': '376f779f4687b598f1c92ca4e770fd5a',
+  'cd-treatment.md': 'd940eadfb406ce584f0e244032f33382',
 };
 const EXPECTED_PARTIAL_OLD = {
   'bible-deference.md': ['218f0e85643609ed85a12b1ccc7b5a8d'],


### PR DESCRIPTION
Closes #2042

## Summary

#1808's migration 148 backfilled `data/prompts/stages/cd-treatment.md` using two ANCHOR-based surgical inserts (the `## Cast & ingredients` list section, and the per-scene `"cast": [{ "ingredientId": … }]` JSON field). Installs seeded **before** the `imageStrength` scene knob shipped carry an older scene example that lacks the insertion-2 anchor, so 148 applied insertion 1 (file gained the Cast list) but silently skipped insertion 2 — leaving the runtime template at md5 `95b76856…`, missing the per-scene cast field the shipped reference ships. Because 148 is already recorded in `data/migrations.applied.json` on those installs it never re-runs, so `creativeDirectorPrompts.test.js`'s cast-threading regression stays red on the runtime template forever.

New **migration 155** finishes the job with the canonical hash-driven prompt-replace (`_lib.js` `makePromptReplaceMigration`): when the installed copy still matches a known machine-produced shape it is replaced wholesale with the current shipped reference; a hand-customized copy is left untouched with a warning.

Accepted-old hashes (all verified against git history + a deterministic replay of migration 148):
- `2ffa482e…` — pristine pre-#1808 shipped, pre-imageStrength-knob (447d2b5e3 / 22a0aced0)
- `16d0ef6a…` — pristine pre-#1808 shipped, post-imageStrength-knob (c68f38d09 / f04e3955c)
- `95b76856…` — the migration-148 partial strand (the exact hash reported in #2042)
- → `d940eadf…` (current shipped reference)

**Cross-sync:** migration 148 tracks the file via anchors (not `ACCEPTED_OLD_MD5`/`NEW_SHIPPED_MD5`), so it exports nothing for the drift sweep to resync — 155 is the first hash-tracked migration for this file. Exporting the constants folds `cd-treatment.md` into `buildPromptDriftTables`, so `scripts/setup-data-drift.test.js`'s `EXPECTED_STAGE_OLD`/`EXPECTED_STAGE_NEW` baselines are updated to match, and `scripts/setup-data.js`'s drift warning now classifies a stranded copy as auto-updatable (it sweeps the same function — no hardcoded list to touch).

## Test plan

- `npx vitest run scripts/migrations/155-heal-cd-treatment-cast-strand.test.js scripts/setup-data-drift.test.js scripts/migrations/148-cd-treatment-catalog-cast.test.js` — 14 passed. Covers the six standard prompt-replace cases (idempotent, drift-catch that pins NEW_SHIPPED_MD5 to the live reference, accepted-old upgrade, customized-file no-clobber) plus a bespoke assertion that the exact `95b76856…` strand hash is in the accepted-old set.
- `npx vitest run scripts/ lib/creativeDirectorPrompts.test.js` — 128 files / 807 tests passed (no regressions in the migration suite or CD prompt tests).
- Hashes independently reproduced: replaying migration 148 against the older pre-#1808 template (`2ffa482e…`) yields exactly `95b76856…` (Cast list, no per-scene cast); against the newer template (`16d0ef6a…`) yields the current shipped `d940eadf…`.