### PR TITLE
fix: migrate two-click-arm delete confirms to InlineConfirmRow (#2024)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased Changes
+
+## Delete confirmations
+
+- **Destructive actions now show a clear "Delete? / Cancel" prompt instead of a hidden second click.** Deleting a round, universe, series, share bucket, issue/episode, or a Writers Room work/folder — and removing an Ask conversation or deleting a world in the Universe Builder — used to silently re-arm the same button on the first click, with nothing on screen telling you a second click was needed. Each of these now pops an explicit inline confirm/cancel affordance right where you clicked, so it's obvious what will happen and easy to back out. The pipeline's "replace existing scenes / pages / audio lines" extract buttons got the same treatment (an inline "Replace? / Cancel" row) instead of arming via a fleeting toast. Delete/confirm controls in the Writers Room library were also enlarged to a comfortable 44px touch target for mobile.

--- a/client/src/components/pipeline/ArcCanvas.jsx
+++ b/client/src/components/pipeline/ArcCanvas.jsx
@@ -33,8 +33,8 @@ import {
   Clock,
 } from 'lucide-react';
 import toast from '../ui/Toast';
+import ConfirmButtonPair from '../ui/ConfirmButtonPair';
 import { timeAgo } from '../../utils/formatters';
-import { useArmedAction } from '../../hooks/useArmedAction';
 import { useLockToggle } from '../../hooks/useLockToggle';
 import MediaImage from '../MediaImage';
 import {
@@ -2693,21 +2693,17 @@ function SeasonActions({
 
 function IssueRow({ issue, seasons, onIssuesUpdate }) {
   const [reassigning, setReassigning] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
   const cover = issueCoverRecord(issue);
 
   const runDelete = async () => {
+    setConfirmingDelete(false);
     const ok = await deletePipelineIssue(issue.id).catch((err) => {
       toast.error(err.message || 'Delete failed');
       return null;
     });
     if (ok == null) return;
     onIssuesUpdate((prev) => prev.filter((i) => i.id !== issue.id));
-  };
-  const [armDelete, armedDelete] = useArmedAction(runDelete);
-  const handleDelete = (e) => {
-    e.preventDefault();
-    e.stopPropagation();
-    armedDelete();
   };
 
   const handleReassign = async (newSeasonId) => {
@@ -2751,29 +2747,41 @@ function IssueRow({ issue, seasons, onIssuesUpdate }) {
           <p className="text-[10px] text-gray-600">updated {timeAgo(issue.updatedAt)}</p>
         </div>
       </Link>
-      <div className="px-2 pb-2 flex items-center gap-1.5">
-        <select
-          value={issue.seasonId || ''}
-          onChange={(e) => handleReassign(e.target.value)}
-          disabled={reassigning}
-          title="Move to a different season"
-          className="min-w-0 flex-1 text-[10px] bg-port-card border border-port-border rounded text-gray-300 opacity-70 group-hover:opacity-100 focus:opacity-100"
-        >
-          <option value="">— ungrouped —</option>
-          {seasons.map((s) => (
-            <option key={s.id} value={s.id}>V{s.number}: {s.title}</option>
-          ))}
-        </select>
-        <button
-          type="button"
-          onClick={handleDelete}
-          className={`p-1 rounded border border-port-border bg-port-card ${armDelete ? 'text-port-error opacity-100' : 'text-gray-500 hover:text-port-error opacity-70 group-hover:opacity-100 focus:opacity-100'}`}
-          aria-label={armDelete ? `Confirm delete ${issue.title}` : `Delete ${issue.title}`}
-          title={armDelete ? 'Click again to confirm' : 'Delete issue / episode'}
-        >
-          <Trash2 size={12} />
-        </button>
-      </div>
+      {confirmingDelete ? (
+        <div className="px-2 pb-2">
+          <ConfirmButtonPair
+            prompt="Delete?"
+            className="justify-end"
+            ariaLabel={`Confirm delete ${issue.title}`}
+            onConfirm={runDelete}
+            onCancel={() => setConfirmingDelete(false)}
+          />
+        </div>
+      ) : (
+        <div className="px-2 pb-2 flex items-center gap-1.5">
+          <select
+            value={issue.seasonId || ''}
+            onChange={(e) => handleReassign(e.target.value)}
+            disabled={reassigning}
+            title="Move to a different season"
+            className="min-w-0 flex-1 text-[10px] bg-port-card border border-port-border rounded text-gray-300 opacity-70 group-hover:opacity-100 focus:opacity-100"
+          >
+            <option value="">— ungrouped —</option>
+            {seasons.map((s) => (
+              <option key={s.id} value={s.id}>V{s.number}: {s.title}</option>
+            ))}
+          </select>
+          <button
+            type="button"
+            onClick={() => setConfirmingDelete(true)}
+            className="p-1 rounded border border-port-border bg-port-card text-gray-500 hover:text-port-error opacity-70 group-hover:opacity-100 focus:opacity-100"
+            aria-label={`Delete ${issue.title}`}
+            title="Delete issue / episode"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
+      )}
     </li>
   );
 }

--- a/client/src/components/pipeline/stages/AudioStage.jsx
+++ b/client/src/components/pipeline/stages/AudioStage.jsx
@@ -14,6 +14,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, Sparkles, Wand2, Mic, Music, Upload, Trash2, ListMusic } from 'lucide-react';
 import toast from '../../ui/Toast';
+import InlineConfirmRow from '../../ui/InlineConfirmRow';
 import VoicePicker from '../../voice/VoicePicker';
 import {
   extractPipelineAudioLines,
@@ -72,14 +73,9 @@ export default function AudioStage({ issue, onStageUpdate }) {
   // outstanding at the moment of call.
   const pendingSavesRef = useRef(new Map());
 
-  // Two-click arm pattern (no window.confirm) for the destructive
-  // re-extract path. First click flips the label; second click within 5s
-  // commits the replace.
-  const [extractArmed, setExtractArmed] = useState(false);
-  const armTimerRef = useRef(null);
-  useEffect(() => () => {
-    if (armTimerRef.current) clearTimeout(armTimerRef.current);
-  }, []);
+  // Inline confirm (no window.confirm, no two-click-arm) for the destructive
+  // re-extract path — an explicit Replace/Cancel row renders near the button.
+  const [confirmingExtract, setConfirmingExtract] = useState(false);
 
   const [musicLibrary, setMusicLibrary] = useState(null);
   const [musicLibraryLoading, setMusicLibraryLoading] = useState(false);
@@ -490,24 +486,21 @@ export default function AudioStage({ issue, onStageUpdate }) {
   const storyboardSceneCount = (issue.stages?.storyboards?.scenes || []).length;
   const canExtract = storyboardSceneCount > 0;
 
-  const handleExtract = async () => {
+  const handleExtract = () => {
     if (!canExtract) {
       toast.error('Generate Storyboards first — audio lines come from the dialogue extracted there.');
       return;
     }
-    const needsConfirm = lines.length > 0;
-    if (needsConfirm && !extractArmed) {
-      setExtractArmed(true);
-      toast.warning(`This will replace ${lines.length} existing line${lines.length === 1 ? '' : 's'} (rendered audio is preserved for unchanged lines). Click again to confirm.`);
-      if (armTimerRef.current) clearTimeout(armTimerRef.current);
-      armTimerRef.current = setTimeout(() => {
-        armTimerRef.current = null;
-        setExtractArmed(false);
-      }, 5000);
+    if (lines.length > 0) {
+      setConfirmingExtract(true);
       return;
     }
-    if (armTimerRef.current) { clearTimeout(armTimerRef.current); armTimerRef.current = null; }
-    setExtractArmed(false);
+    void runExtract();
+  };
+
+  const runExtract = async () => {
+    const needsConfirm = lines.length > 0;
+    setConfirmingExtract(false);
     setExtracting(true);
     const result = await extractPipelineAudioLines(issue.id, { force: needsConfirm }).catch((err) => {
       toast.error(err.message || 'Extract failed');
@@ -645,12 +638,20 @@ export default function AudioStage({ issue, onStageUpdate }) {
             className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-port-card border border-port-border text-white text-sm hover:border-port-accent/50 disabled:opacity-40"
           >
             {extracting ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
-            {extractArmed
-              ? 'Click again to replace'
-              : (lines.length > 0 ? 'Re-extract from storyboards' : 'Extract lines from storyboards')}
+            {lines.length > 0 ? 'Re-extract from storyboards' : 'Extract lines from storyboards'}
           </button>
         </div>
       </header>
+
+      {confirmingExtract && (
+        <InlineConfirmRow
+          tone="warning"
+          question={`Replace ${lines.length} existing line${lines.length === 1 ? '' : 's'} with a fresh extract? Rendered audio is preserved for unchanged lines.`}
+          confirmText="Replace"
+          onConfirm={() => void runExtract()}
+          onCancel={() => setConfirmingExtract(false)}
+        />
+      )}
 
       {/* Whole-episode audio mode (#863) — drives the episode's non-dialogue
           audio at stitch time. */}

--- a/client/src/components/pipeline/stages/ComicPagesStage.jsx
+++ b/client/src/components/pipeline/stages/ComicPagesStage.jsx
@@ -1,7 +1,7 @@
 import { useRef, useState } from 'react';
 import { Plus, Trash2, Sparkles, Loader2, Wand2, WandSparkles, ImagePlus, Layers } from 'lucide-react';
 import toast from '../../ui/Toast';
-import { useArmedAction } from '../../../hooks/useArmedAction';
+import InlineConfirmRow from '../../ui/InlineConfirmRow';
 import {
   generatePipelineVisualImage,
   generatePipelineComicPage,
@@ -114,18 +114,19 @@ export default function ComicPagesStage({ issue, onStageUpdate, actionsGated = f
     onStageUpdate?.('comicPages', result.stage, result.issue);
     toast.success(`Extracted ${result.pageCount} page${result.pageCount === 1 ? '' : 's'} / ${result.panelCount} panel${result.panelCount === 1 ? '' : 's'}`);
   };
-  const [extractArmed, fireExtract] = useArmedAction(runExtract);
+  const [confirmingExtract, setConfirmingExtract] = useState(false);
   const onExtractClick = () => {
-    // Nothing to clobber on a fresh stage — extract immediately. The two-click
-    // arm exists only to guard a destructive replace of existing pages.
+    // Nothing to clobber on a fresh stage — extract immediately. The inline
+    // confirm only guards a destructive replace of existing pages.
     if (pages.length === 0) {
       runExtract();
       return;
     }
-    if (!extractArmed) {
-      toast.warning(`This will replace ${pages.length} existing page${pages.length === 1 ? '' : 's'}. Click again to confirm.`);
-    }
-    fireExtract();
+    setConfirmingExtract(true);
+  };
+  const confirmExtract = () => {
+    setConfirmingExtract(false);
+    runExtract();
   };
 
   const handleGeneratePage = async (pi) => {
@@ -276,7 +277,7 @@ export default function ComicPagesStage({ issue, onStageUpdate, actionsGated = f
             className="inline-flex items-center gap-2 px-3 py-2 rounded-lg bg-port-card border border-port-border text-white text-sm hover:border-port-accent/50 disabled:opacity-40 disabled:cursor-not-allowed"
           >
             {extracting ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
-            {extractArmed ? 'Click again to replace' : 'From comic script'}
+            From comic script
           </button>
           <PromptCountInput id="comic-prompt-count" value={promptCount} onChange={setPromptCount} />
           <button
@@ -288,6 +289,16 @@ export default function ComicPagesStage({ issue, onStageUpdate, actionsGated = f
           </button>
         </div>
       </div>
+
+      {confirmingExtract && (
+        <InlineConfirmRow
+          tone="warning"
+          question={`Replace ${pages.length} existing page${pages.length === 1 ? '' : 's'} with a fresh extract from the comic script?`}
+          confirmText="Replace"
+          onConfirm={confirmExtract}
+          onCancel={() => setConfirmingExtract(false)}
+        />
+      )}
 
       {pages.length === 0 ? (
         <p className="text-xs text-gray-600 italic">No pages yet. Start with one and add panels.</p>

--- a/client/src/components/pipeline/stages/StoryboardsStage.jsx
+++ b/client/src/components/pipeline/stages/StoryboardsStage.jsx
@@ -16,9 +16,10 @@
  * extractor against the corresponding text stage and replace the list.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { Plus, Trash2, Sparkles, Loader2, Wand2, Film, WandSparkles, Shirt, Layers } from 'lucide-react';
 import toast from '../../ui/Toast';
+import InlineConfirmRow from '../../ui/InlineConfirmRow';
 import { SHOT_TYPES, SCREEN_DIRECTIONS, SHOT_TYPE_LABELS, SCREEN_DIRECTION_LABELS } from '../../../lib/shotGrammar';
 import { sceneShotWarnings } from '../../../lib/shotContinuity';
 import {
@@ -61,13 +62,10 @@ export default function StoryboardsStage({ issue, series, onStageUpdate, actions
   // would race when the user starts a second render before the first settles.
   const [renderingShots, setRenderingShots] = useState(() => new Set());
   const [extractingFrom, setExtractingFrom] = useState(null);
-  // Holds the active arm-timer id so an unmount or a fresh arm clears the
-  // pending disarm — otherwise the 5s callback fires setExtractingFrom on
-  // an unmounted component (React warning + small leak).
-  const armTimerRef = useRef(null);
-  useEffect(() => () => {
-    if (armTimerRef.current) clearTimeout(armTimerRef.current);
-  }, []);
+  // Which source ('teleplay' | 'prose') has a pending replace-confirm showing.
+  // Separate from `extractingFrom` (which is purely the in-flight source) so the
+  // inline confirm never gets conflated with an in-progress extract.
+  const [confirmingFrom, setConfirmingFrom] = useState(null);
 
   // Canon characters (with wardrobes) live on the linked universe — load it
   // and derive the pickable set so each scene can offer a per-character
@@ -80,10 +78,10 @@ export default function StoryboardsStage({ issue, series, onStageUpdate, actions
 
   const teleplayReady = !!(issue.stages?.teleplay?.output || '').trim();
   const proseReady = !!(issue.stages?.prose?.output || '').trim();
-  // Any non-null, non-arm value means an extract POST is in flight — both
-  // buttons must lock out concurrent submits so racing requests can't
-  // overwrite each other's results (last-write-wins).
-  const extractInFlight = !!extractingFrom && !extractingFrom.startsWith('arm:');
+  // A non-null value means an extract POST is in flight — both buttons must lock
+  // out concurrent submits so racing requests can't overwrite each other's
+  // results (last-write-wins).
+  const extractInFlight = !!extractingFrom;
 
   const persist = async (nextScenes) => {
     setScenes(nextScenes);
@@ -220,31 +218,19 @@ export default function StoryboardsStage({ issue, series, onStageUpdate, actions
     toast.success(`Queued shot ${shotIdx + 1} render (${result.jobId.slice(0, 8)})`);
   };
 
-  // Replace-existing confirm uses a two-click arm pattern (no window.confirm
-  // per CLAUDE.md, no shared confirm-modal primitive in the pipeline yet).
-  // First click on a button when scenes is non-empty arms it (label flips to
-  // "Click again to replace"). Second click within 5s fires the extract.
-  const onExtractClick = async (from) => {
-    const armKey = `arm:${from}`;
-    const needsConfirm = scenes.length > 0;
-
-    if (needsConfirm && extractingFrom !== armKey) {
-      setExtractingFrom(armKey);
-      toast.warning(`This will replace ${scenes.length} existing scene${scenes.length === 1 ? '' : 's'}. Click again to confirm.`);
-      if (armTimerRef.current) clearTimeout(armTimerRef.current);
-      armTimerRef.current = setTimeout(() => {
-        armTimerRef.current = null;
-        setExtractingFrom((cur) => (cur === armKey ? null : cur));
-      }, 5000);
+  // Replacing existing scenes shows an inline confirm near the buttons (no
+  // window.confirm per CLAUDE.md, no two-click-arm — the user disliked it). A
+  // fresh stage (no scenes yet) extracts immediately.
+  const onExtractClick = (from) => {
+    if (scenes.length > 0) {
+      setConfirmingFrom(from);
       return;
     }
-    // Second click landed within the arm window — cancel the pending disarm
-    // so the post-await `setExtractingFrom(null)` is the only state flip.
-    if (armTimerRef.current) {
-      clearTimeout(armTimerRef.current);
-      armTimerRef.current = null;
-    }
+    runExtract(from);
+  };
 
+  const runExtract = async (from) => {
+    setConfirmingFrom(null);
     setExtractingFrom(from);
     const result = await extractPipelineStoryboardScenes(issue.id, {
       from,
@@ -419,7 +405,7 @@ export default function StoryboardsStage({ issue, series, onStageUpdate, actions
             {extractingFrom === 'teleplay'
               ? <Loader2 size={14} className="animate-spin" />
               : <Wand2 size={14} />}
-            {extractingFrom === 'arm:teleplay' ? 'Click again to replace' : 'From Teleplay'}
+            From Teleplay
           </button>
           <button
             type="button"
@@ -431,7 +417,7 @@ export default function StoryboardsStage({ issue, series, onStageUpdate, actions
             {extractingFrom === 'prose'
               ? <Loader2 size={14} className="animate-spin" />
               : <Wand2 size={14} />}
-            {extractingFrom === 'arm:prose' ? 'Click again to replace' : 'From prose'}
+            From prose
           </button>
           <PromptCountInput id="storyboard-prompt-count" value={promptCount} onChange={setPromptCount} />
           <button
@@ -443,6 +429,16 @@ export default function StoryboardsStage({ issue, series, onStageUpdate, actions
           </button>
         </div>
       </div>
+
+      {confirmingFrom && (
+        <InlineConfirmRow
+          tone="warning"
+          question={`Replace ${scenes.length} existing scene${scenes.length === 1 ? '' : 's'} with a fresh extract from the ${confirmingFrom === 'teleplay' ? 'Teleplay' : 'prose'}?`}
+          confirmText="Replace"
+          onConfirm={() => runExtract(confirmingFrom)}
+          onCancel={() => setConfirmingFrom(null)}
+        />
+      )}
 
       {scenes.length === 0 ? (
         <p className="text-xs text-gray-600 italic">No scenes yet.</p>

--- a/client/src/components/writers-room/LibraryPane.jsx
+++ b/client/src/components/writers-room/LibraryPane.jsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Folder, FolderPlus, FilePlus, FileText, ChevronDown, ChevronRight, Trash2, GripVertical, PanelLeftClose } from 'lucide-react';
 import { DndContext, DragOverlay, PointerSensor, useDraggable, useDroppable, useSensor, useSensors } from '@dnd-kit/core';
 import toast from '../ui/Toast';
+import ConfirmButtonPair from '../ui/ConfirmButtonPair';
 import {
   createWritersRoomFolder,
   deleteWritersRoomFolder,
@@ -9,6 +10,7 @@ import {
   deleteWritersRoomWork,
   updateWritersRoomWork,
 } from '../../services/apiWritersRoom';
+import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import { KIND_LABELS } from './labels';
 
 const UNFILED_DROP_ID = 'wr-unfiled';
@@ -20,11 +22,9 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
   const [creatingWork, setCreatingWork] = useState(null); // folderId or 'unfiled'
   const [workTitle, setWorkTitle] = useState('');
   const [workKind, setWorkKind] = useState('short-story');
-  // Two-click confirm: first click arms the button, second deletes.
-  // Cleared automatically after 4s to avoid leaving a pending arm.
-  const [armedDelete, setArmedDelete] = useState(null);
-  const armTimerRef = useRef(null);
-  useEffect(() => () => clearTimeout(armTimerRef.current), []);
+  // Inline delete confirm (no two-click-arm, no toast re-arm) — one row armed at
+  // a time, keyed by `work:<id>` / `folder:<id>`.
+  const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
 
   const grouped = useMemo(() => {
     const byFolder = new Map();
@@ -72,37 +72,16 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
     onSelectWork?.(work.id);
   };
 
-  const armDelete = (key) => {
-    setArmedDelete(key);
-    clearTimeout(armTimerRef.current);
-    armTimerRef.current = setTimeout(
-      () => setArmedDelete((current) => (current === key ? null : current)),
-      4000,
-    );
-  };
-
-  const handleDeleteFolder = async (id, name) => {
-    if (armedDelete !== `folder:${id}`) {
-      armDelete(`folder:${id}`);
-      toast(`Click again to delete folder "${name}"`);
-      return;
-    }
-    setArmedDelete(null);
+  const handleDeleteFolder = (id) => confirmDelete(async () => {
     await deleteWritersRoomFolder(id).catch((err) => toast.error(`Delete failed: ${err.message}`));
     onRefresh?.();
-  };
+  });
 
-  const handleDeleteWork = async (id, title) => {
-    if (armedDelete !== `work:${id}`) {
-      armDelete(`work:${id}`);
-      toast(`Click again to delete "${title}"`);
-      return;
-    }
-    setArmedDelete(null);
+  const handleDeleteWork = (id) => confirmDelete(async () => {
     await deleteWritersRoomWork(id).catch((err) => toast.error(`Delete failed: ${err.message}`));
     if (activeWorkId === id) onSelectWork?.(null);
     onRefresh?.();
-  };
+  });
 
   // PointerSensor with a small activation distance so a quick click still
   // selects the work — only an actual drag gesture starts a DnD operation.
@@ -137,9 +116,11 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
       key={work.id}
       work={work}
       isActive={work.id === activeWorkId}
-      armedDelete={armedDelete === `work:${work.id}`}
+      confirming={isConfirming(`work:${work.id}`)}
       onSelect={() => onSelectWork?.(work.id)}
-      onDelete={() => handleDeleteWork(work.id, work.title)}
+      onRequestDelete={() => requestDelete(`work:${work.id}`)}
+      onConfirmDelete={() => handleDeleteWork(work.id)}
+      onCancelDelete={cancelDelete}
     />
   );
 
@@ -239,10 +220,12 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
               works={grouped.get(folder.id) || []}
               isOpen={!!openFolders[folder.id]}
               isDragging={!!draggingWork}
-              armedDelete={armedDelete === `folder:${folder.id}`}
+              confirming={isConfirming(`folder:${folder.id}`)}
               onToggle={() => toggleFolder(folder.id)}
               onCreateWork={() => { setCreatingWork(folder.id); setCreatingFolder(false); }}
-              onDelete={() => handleDeleteFolder(folder.id, folder.name)}
+              onRequestDelete={() => requestDelete(`folder:${folder.id}`)}
+              onConfirmDelete={() => handleDeleteFolder(folder.id)}
+              onCancelDelete={cancelDelete}
               renderWorkRow={renderWorkRow}
             />
           ))}
@@ -263,7 +246,7 @@ export default function LibraryPane({ folders, works, activeWorkId, onSelectWork
 
 // ---------- DnD-aware subcomponents ----------
 
-function WorkRow({ work, isActive, armedDelete, onSelect, onDelete }) {
+function WorkRow({ work, isActive, confirming, onSelect, onRequestDelete, onConfirmDelete, onCancelDelete }) {
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: `work:${work.id}`,
     data: { work },
@@ -292,18 +275,25 @@ function WorkRow({ work, isActive, armedDelete, onSelect, onDelete }) {
           <span className="text-[10px] text-gray-500 uppercase">{work.wordCount} w</span>
         </button>
       </div>
-      <button
-        onClick={onDelete}
-        className={`absolute right-1 top-1.5 p-0.5 transition-opacity ${
-          armedDelete
-            ? 'opacity-100 text-port-error'
-            : 'opacity-40 sm:opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-500 hover:text-port-error'
-        }`}
-        aria-label={`Delete ${work.title}`}
-        title={armedDelete ? 'Click again to confirm' : 'Delete'}
-      >
-        <Trash2 size={12} />
-      </button>
+      {confirming ? (
+        <div className="absolute inset-0 flex items-center justify-end gap-2 pr-1 bg-port-bg/95 rounded">
+          <ConfirmButtonPair
+            prompt="Delete?"
+            ariaLabel={`Confirm delete ${work.title}`}
+            onConfirm={onConfirmDelete}
+            onCancel={onCancelDelete}
+          />
+        </div>
+      ) : (
+        <button
+          onClick={onRequestDelete}
+          className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center justify-center min-w-[44px] min-h-[44px] transition-opacity opacity-40 sm:opacity-0 group-hover:opacity-100 focus:opacity-100 text-gray-500 hover:text-port-error"
+          aria-label={`Delete ${work.title}`}
+          title="Delete"
+        >
+          <Trash2 size={14} />
+        </button>
+      )}
     </li>
   );
 }
@@ -331,7 +321,7 @@ function UnfiledZone({ works, renderWorkRow, showHeader, isDragging }) {
   );
 }
 
-function FolderRow({ folder, works, isOpen, isDragging, armedDelete, onToggle, onCreateWork, onDelete, renderWorkRow }) {
+function FolderRow({ folder, works, isOpen, isDragging, confirming, onToggle, onCreateWork, onRequestDelete, onConfirmDelete, onCancelDelete, renderWorkRow }) {
   const { setNodeRef, isOver } = useDroppable({ id: `folder:${folder.id}`, data: { folderId: folder.id } });
   return (
     <li className="group/folder">
@@ -350,26 +340,34 @@ function FolderRow({ folder, works, isOpen, isDragging, armedDelete, onToggle, o
           <span className="flex-1 text-left truncate">{folder.name}</span>
           <span className="text-[10px] text-gray-500">{works.length}</span>
         </button>
-        <button
-          onClick={onCreateWork}
-          className="p-1 text-gray-500 hover:text-port-accent transition-opacity opacity-40 sm:opacity-0 group-hover/folder:opacity-100 focus:opacity-100"
-          aria-label="Add work to folder"
-          title="New work in folder"
-        >
-          <FilePlus size={12} />
-        </button>
-        <button
-          onClick={onDelete}
-          className={`p-1 transition-opacity ${
-            armedDelete
-              ? 'opacity-100 text-port-error'
-              : 'opacity-40 sm:opacity-0 group-hover/folder:opacity-100 focus:opacity-100 text-gray-500 hover:text-port-error'
-          }`}
-          aria-label={`Delete folder ${folder.name}`}
-          title={armedDelete ? 'Click again to confirm' : 'Delete folder'}
-        >
-          <Trash2 size={12} />
-        </button>
+        {confirming ? (
+          <ConfirmButtonPair
+            prompt="Delete?"
+            className="shrink-0 pr-1"
+            ariaLabel={`Confirm delete folder ${folder.name}`}
+            onConfirm={onConfirmDelete}
+            onCancel={onCancelDelete}
+          />
+        ) : (
+          <>
+            <button
+              onClick={onCreateWork}
+              className="flex items-center justify-center min-w-[44px] min-h-[44px] text-gray-500 hover:text-port-accent transition-opacity opacity-40 sm:opacity-0 group-hover/folder:opacity-100 focus:opacity-100"
+              aria-label="Add work to folder"
+              title="New work in folder"
+            >
+              <FilePlus size={14} />
+            </button>
+            <button
+              onClick={onRequestDelete}
+              className="flex items-center justify-center min-w-[44px] min-h-[44px] transition-opacity opacity-40 sm:opacity-0 group-hover/folder:opacity-100 focus:opacity-100 text-gray-500 hover:text-port-error"
+              aria-label={`Delete folder ${folder.name}`}
+              title="Delete folder"
+            >
+              <Trash2 size={14} />
+            </button>
+          </>
+        )}
       </div>
       {isOpen && (
         <ul className="space-y-0.5 pl-5 relative">

--- a/client/src/pages/Ask.jsx
+++ b/client/src/pages/Ask.jsx
@@ -428,6 +428,11 @@ export default function Ask() {
     requestDelete(id);
   }, [activeConv?.id, requestDelete, streaming]);
   const handleDelete = useCallback((id) => confirmDelete(async () => {
+    // Re-check the streaming guard at confirm time too: the row could have been
+    // armed while idle and then a stream started on this same conversation
+    // before the user clicked confirm — deleting the active stream mid-flight
+    // would race the assistant turn into a deleted record.
+    if (streaming && id === activeConv?.id) return;
     // Only mutate local state if the server confirms the delete — otherwise
     // a transient failure would hide a row that's still on disk and would
     // pop back on the next list refresh.
@@ -438,7 +443,7 @@ export default function Ask() {
     if (!ok) return;
     setConversations((prev) => prev.filter((c) => c.id !== id));
     if (id === conversationId) navigate('/ask');
-  }), [conversationId, confirmDelete, navigate]);
+  }), [activeConv?.id, conversationId, confirmDelete, navigate, streaming]);
 
   const handlePromote = useCallback(async () => {
     if (!activeConv) return;

--- a/client/src/pages/Ask.jsx
+++ b/client/src/pages/Ask.jsx
@@ -3,6 +3,8 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { Send, Loader2, MessageCircle, Trash2, Pin, Brain, Calendar, Target, BookOpen, FileText, ExternalLink, ListTodo, CheckCircle2 } from 'lucide-react';
 import * as api from '../services/api';
 import toast from '../components/ui/Toast';
+import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
+import { useConfirmDelete } from '../hooks/useConfirmDelete';
 
 // Mirrors the server-side ID_RE in askConversations.js (9-char base36 ms +
 // 8-char hex suffix) so this regex stays in lockstep with the production
@@ -47,7 +49,7 @@ function SourceChip({ source, index }) {
   );
 }
 
-function Sidebar({ conversations, activeId, onPick, onNew, onDelete, loading, streaming }) {
+function Sidebar({ conversations, activeId, onPick, onNew, isConfirmingDelete, onRequestDelete, onConfirmDelete, onCancelDelete, loading, streaming }) {
   return (
     <aside className="w-full md:w-64 md:shrink-0 border-r border-port-border bg-port-card md:h-full md:overflow-y-auto">
       <div className="p-3 border-b border-port-border flex items-center gap-2">
@@ -90,15 +92,27 @@ function Sidebar({ conversations, activeId, onPick, onNew, onDelete, loading, st
                   {c.promoted && <Pin size={10} className="text-amber-400" />}
                 </div>
               </button>
-              <button
-                type="button"
-                onClick={() => onDelete(c.id)}
-                className="absolute right-2 top-1/2 -translate-y-1/2 opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 text-gray-500 hover:text-port-error transition-opacity"
-                aria-label={`Delete conversation: ${c.title}`}
-                title="Delete conversation"
-              >
-                <Trash2 size={14} />
-              </button>
+              {isConfirmingDelete(c.id) ? (
+                <div className="absolute inset-y-0 right-0 flex items-center pr-2 bg-port-card/95 rounded">
+                  <ConfirmButtonPair
+                    prompt="Delete?"
+                    ariaLabel={`Confirm delete conversation: ${c.title}`}
+                    onConfirm={() => onConfirmDelete(c.id)}
+                    onCancel={onCancelDelete}
+                  />
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  disabled={streaming && c.id === activeId}
+                  onClick={() => onRequestDelete(c.id)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 text-gray-500 hover:text-port-error transition-opacity disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:text-gray-500"
+                  aria-label={`Delete conversation: ${c.title}`}
+                  title="Delete conversation"
+                >
+                  <Trash2 size={14} />
+                </button>
+              )}
             </div>
           );
         })}
@@ -406,18 +420,14 @@ export default function Ask() {
     setQuestion('');
   }, [navigate, streaming]);
 
-  // Two-step delete: first click arms the row (toast confirms), second click
-  // (within 4s) actually deletes. Per CLAUDE.md "no window.confirm".
-  const pendingDeleteRef = useRef({ id: null, expiresAt: 0 });
-  const handleDelete = useCallback(async (id) => {
+  // Inline delete confirm (no window.confirm, no two-click-arm) — the trash
+  // button arms the row and an explicit Delete?/Cancel row fires it.
+  const { isConfirming: isConfirmingDelete, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
+  const handleRequestDelete = useCallback((id) => {
     if (streaming && id === activeConv?.id) return;
-    const pending = pendingDeleteRef.current;
-    if (pending.id !== id || Date.now() > pending.expiresAt) {
-      pendingDeleteRef.current = { id, expiresAt: Date.now() + 4000 };
-      toast('Click delete again to confirm', { icon: '⚠️' });
-      return;
-    }
-    pendingDeleteRef.current = { id: null, expiresAt: 0 };
+    requestDelete(id);
+  }, [activeConv?.id, requestDelete, streaming]);
+  const handleDelete = useCallback((id) => confirmDelete(async () => {
     // Only mutate local state if the server confirms the delete — otherwise
     // a transient failure would hide a row that's still on disk and would
     // pop back on the next list refresh.
@@ -428,7 +438,7 @@ export default function Ask() {
     if (!ok) return;
     setConversations((prev) => prev.filter((c) => c.id !== id));
     if (id === conversationId) navigate('/ask');
-  }, [activeConv?.id, conversationId, navigate, streaming]);
+  }), [conversationId, confirmDelete, navigate]);
 
   const handlePromote = useCallback(async () => {
     if (!activeConv) return;
@@ -619,7 +629,10 @@ export default function Ask() {
         activeId={conversationId}
         onPick={(id) => navigate(`/ask/${id}`)}
         onNew={startNew}
-        onDelete={handleDelete}
+        isConfirmingDelete={isConfirmingDelete}
+        onRequestDelete={handleRequestDelete}
+        onConfirmDelete={handleDelete}
+        onCancelDelete={cancelDelete}
         loading={loadingList}
         streaming={streaming}
       />

--- a/client/src/pages/Pipeline.jsx
+++ b/client/src/pages/Pipeline.jsx
@@ -12,6 +12,7 @@ import { useConfirmDelete } from '../hooks/useConfirmDelete';
 import { Link, useNavigate } from 'react-router-dom';
 import { Plus, Workflow as WorkflowIcon, Trash2, Loader2, Globe2, FileInput, Sparkles, BookOpen } from 'lucide-react';
 import toast from '../components/ui/Toast';
+import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import ImageThumb from '../components/ui/ImageThumb';
 import ShareToButton from '../components/sharing/ShareToButton';
 import SyncToPeerButton from '../components/sharing/SyncToPeerButton';
@@ -200,24 +201,18 @@ export default function Pipeline() {
     [form.universeId, form.name],
   );
 
-  // Two-click delete: first click "arms" the row, second click fires. Avoids
-  // window.confirm (banned per CLAUDE.md) without pulling in a modal for the
-  // skeleton. Only one row is armed at once.
-  const { isConfirming, requestDelete, confirmDelete } = useConfirmDelete();
-  const handleDelete = async (s) => {
-    if (!isConfirming(s.id)) {
-      requestDelete(s.id);
-      return;
-    }
-    await confirmDelete(() => {
-      const prior = series;
-      setSeries((prev) => prev.filter((x) => x.id !== s.id));
-      return deletePipelineSeries(s.id).catch((err) => {
-        toast.error(err.message || 'Delete failed');
-        setSeries(prior);
-      });
+  // Inline delete confirm: the trash button arms the row (one at a time) and an
+  // explicit Delete?/Cancel row fires it. Avoids window.confirm (banned per
+  // CLAUDE.md) and the non-discoverable two-click-arm pattern.
+  const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
+  const handleDelete = (s) => confirmDelete(() => {
+    const prior = series;
+    setSeries((prev) => prev.filter((x) => x.id !== s.id));
+    return deletePipelineSeries(s.id).catch((err) => {
+      toast.error(err.message || 'Delete failed');
+      setSeries(prior);
     });
-  };
+  });
 
   return (
     <div>
@@ -472,15 +467,24 @@ export default function Pipeline() {
               />
               <ShareToButton kind="series" ids={[s.id]} compact />
               <SyncToPeerButton recordKind="series" recordId={s.id} compact />
-              <button
-                type="button"
-                onClick={() => handleDelete(s)}
-                className={`p-2 ${isConfirming(s.id) ? 'text-port-error' : 'text-gray-500 hover:text-port-error'}`}
-                aria-label={isConfirming(s.id) ? `Confirm delete series ${s.name}` : `Delete series ${s.name}`}
-                title={isConfirming(s.id) ? 'Click again to confirm delete' : 'Delete series'}
-              >
-                <Trash2 size={16} />
-              </button>
+              {isConfirming(s.id) ? (
+                <ConfirmButtonPair
+                  prompt="Delete?"
+                  ariaLabel={`Confirm delete series ${s.name}`}
+                  onConfirm={() => handleDelete(s)}
+                  onCancel={cancelDelete}
+                />
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => requestDelete(s.id)}
+                  className="p-2 text-gray-500 hover:text-port-error"
+                  aria-label={`Delete series ${s.name}`}
+                  title="Delete series"
+                >
+                  <Trash2 size={16} />
+                </button>
+              )}
             </li>
             );
           })}

--- a/client/src/pages/Rounds.jsx
+++ b/client/src/pages/Rounds.jsx
@@ -12,8 +12,10 @@ import { useEffect, useState, useCallback } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { Music, Plus, Trash2, BookOpen, CheckCircle2, Circle, Wand2 } from 'lucide-react';
 import toast from '../components/ui/Toast';
+import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import { timeAgo } from '../utils/formatters';
 import { useAsyncAction } from '../hooks/useAsyncAction';
+import { useConfirmDelete } from '../hooks/useConfirmDelete';
 import { listRounds, createRound, deleteRound, generateRound } from '../services/api';
 import { RHYTHM_SHAPES } from '../lib/songCraft';
 
@@ -25,8 +27,9 @@ export default function Rounds() {
   const [loading, setLoading] = useState(true);
   const [title, setTitle] = useState('');
   const [artist, setArtist] = useState('');
-  // Two-step delete confirm (no window.confirm) — the armed round id.
-  const [armed, setArmed] = useState(null);
+  // Inline delete confirm (no window.confirm, no two-click-arm) — one row armed
+  // at a time via useConfirmDelete + <ConfirmButtonPair>.
+  const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
 
   useEffect(() => {
     listRounds({ silent: true })
@@ -67,13 +70,11 @@ export default function Rounds() {
     return round;
   }, { errorMessage: 'Failed to generate round' });
 
-  const onDelete = useCallback(async (round) => {
-    if (armed !== round.id) { setArmed(round.id); return; }
-    setArmed(null);
-    await deleteRound(round.id, { silent: true })
+  const onDelete = useCallback((round) => confirmDelete(() =>
+    deleteRound(round.id, { silent: true })
       .then(() => setRounds((prev) => prev.filter((s) => s.id !== round.id)))
-      .catch((err) => toast.error(err?.message || 'Failed to delete round'));
-  }, [armed]);
+      .catch((err) => toast.error(err?.message || 'Failed to delete round')),
+  ), [confirmDelete]);
 
   return (
     <div>
@@ -180,16 +181,25 @@ export default function Rounds() {
                     {round.updatedAt && <span>Edited {timeAgo(round.updatedAt)}</span>}
                   </div>
                 </Link>
-                <button
-                  type="button"
-                  onClick={() => onDelete(round)}
-                  onBlur={() => setArmed((cur) => (cur === round.id ? null : cur))}
-                  className={`p-2 shrink-0 ${armed === round.id ? 'text-port-error' : 'text-gray-500 hover:text-port-error'}`}
-                  aria-label={armed === round.id ? `Confirm delete ${round.title}` : `Delete ${round.title}`}
-                  title={armed === round.id ? 'Click again to confirm delete' : 'Delete round'}
-                >
-                  <Trash2 size={16} />
-                </button>
+                {isConfirming(round.id) ? (
+                  <ConfirmButtonPair
+                    prompt="Delete?"
+                    className="shrink-0"
+                    ariaLabel={`Confirm delete ${round.title}`}
+                    onConfirm={() => onDelete(round)}
+                    onCancel={cancelDelete}
+                  />
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => requestDelete(round.id)}
+                    className="p-2 shrink-0 text-gray-500 hover:text-port-error"
+                    aria-label={`Delete ${round.title}`}
+                    title="Delete round"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                )}
               </li>
             );
           })}

--- a/client/src/pages/Sharing.jsx
+++ b/client/src/pages/Sharing.jsx
@@ -13,6 +13,7 @@ import {
   Share2, Plus, Trash2, Folder, Inbox, History, Save, Loader2, Check, X, Users, AlertCircle, RefreshCw, Copy, GitMerge,
 } from 'lucide-react';
 import toast from '../components/ui/Toast';
+import InlineConfirmRow from '../components/ui/InlineConfirmRow';
 import { formatDateTime } from '../utils/formatters';
 import { useConfirmDelete } from '../hooks/useConfirmDelete';
 import FolderPicker from '../components/FolderPicker';
@@ -108,7 +109,7 @@ function SharingBuckets() {
   const [inboxByBucket, setInboxByBucket] = useState({}); // bucketId → items[]
   const [activityByBucket, setActivityByBucket] = useState({});
 
-  const { isConfirming: isRemoveArmed, requestDelete: armRemove, confirmDelete: confirmRemove } = useConfirmDelete();
+  const { isConfirming: isRemoveArmed, requestDelete: armRemove, cancelDelete: cancelRemove, confirmDelete: confirmRemove } = useConfirmDelete();
 
   // Load buckets + settings on mount.
   useEffect(() => {
@@ -198,21 +199,15 @@ function SharingBuckets() {
     toast.success(`Registered bucket "${result.bucket.name}"`);
   };
 
-  const handleDelete = async (bucket) => {
-    if (!isRemoveArmed(bucket.id)) {
-      armRemove(bucket.id);
-      return;
-    }
-    await confirmRemove(() => {
-      const prior = buckets;
-      setBuckets((prev) => prev.filter((b) => b.id !== bucket.id));
-      if (selectedId === bucket.id) setSelectedId(prior[0]?.id !== bucket.id ? prior[0]?.id : (prior[1]?.id || null));
-      return deleteShareBucket(bucket.id).catch((err) => {
-        toast.error(err.message || 'Failed to remove bucket');
-        setBuckets(prior);
-      });
+  const handleDelete = (bucket) => confirmRemove(() => {
+    const prior = buckets;
+    setBuckets((prev) => prev.filter((b) => b.id !== bucket.id));
+    if (selectedId === bucket.id) setSelectedId(prior[0]?.id !== bucket.id ? prior[0]?.id : (prior[1]?.id || null));
+    return deleteShareBucket(bucket.id).catch((err) => {
+      toast.error(err.message || 'Failed to remove bucket');
+      setBuckets(prior);
     });
-  };
+  });
 
   const handleModeToggle = async (bucket) => {
     const nextMode = bucket.mode === 'auto-merge' ? 'inbox' : 'auto-merge';
@@ -501,7 +496,9 @@ function SharingBuckets() {
                 <SettingsPanel
                   bucket={selected}
                   onToggleMode={() => handleModeToggle(selected)}
-                  onDelete={() => handleDelete(selected)}
+                  onRequestDelete={() => armRemove(selected.id)}
+                  onConfirmDelete={() => handleDelete(selected)}
+                  onCancelDelete={cancelRemove}
                   armed={isRemoveArmed(selected.id)}
                 />
               )}
@@ -633,7 +630,7 @@ function ActivityList({ manifests }) {
   );
 }
 
-function SettingsPanel({ bucket, onToggleMode, onDelete, armed }) {
+function SettingsPanel({ bucket, onToggleMode, onRequestDelete, onConfirmDelete, onCancelDelete, armed }) {
   return (
     <div className="space-y-4">
       <div className="p-4 bg-port-card border border-port-border rounded-lg">
@@ -666,14 +663,23 @@ function SettingsPanel({ bucket, onToggleMode, onDelete, armed }) {
         <p className="text-[11px] text-gray-500 mb-3">
           Stops watching the folder for new shares and drops the bucket from PortOS. Files inside the folder are not deleted — your cloud-sync app keeps the data.
         </p>
-        <button
-          type="button"
-          onClick={onDelete}
-          className={`inline-flex items-center gap-2 px-3 py-2 rounded text-xs ${armed ? 'bg-port-error text-white' : 'bg-port-bg text-port-error border border-port-error/40 hover:bg-port-error/10'}`}
-        >
-          <Trash2 size={12} />
-          {armed ? 'Click again to confirm' : 'Remove bucket'}
-        </button>
+        {armed ? (
+          <InlineConfirmRow
+            question="Remove this bucket?"
+            confirmText="Remove"
+            onConfirm={onConfirmDelete}
+            onCancel={onCancelDelete}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={onRequestDelete}
+            className="inline-flex items-center gap-2 px-3 py-2 rounded text-xs bg-port-bg text-port-error border border-port-error/40 hover:bg-port-error/10"
+          >
+            <Trash2 size={12} />
+            Remove bucket
+          </button>
+        )}
       </div>
     </div>
   );

--- a/client/src/pages/UniverseBuilder.jsx
+++ b/client/src/pages/UniverseBuilder.jsx
@@ -16,6 +16,7 @@ import {
   BookOpen, Users, MapPin, Package, Layers, ImagePlus, FolderTree, Images,
 } from 'lucide-react';
 import toast from '../components/ui/Toast';
+import InlineConfirmRow from '../components/ui/InlineConfirmRow';
 import { formatDateTime } from '../utils/formatters';
 import {
   listUniverses, getUniverse, createUniverse, updateUniverse, deleteUniverse, expandUniverse,
@@ -883,11 +884,6 @@ export default function UniverseBuilder() {
 
   const handleDelete = async () => {
     if (!selectedId) return;
-    if (pendingDeleteId !== selectedId) {
-      setPendingDeleteId(selectedId);
-      toast(`Click delete again to confirm — "${draft.name}" will be removed`, { icon: '⚠️' });
-      return;
-    }
     const id = selectedId;
     // Only update local UI + show success toast when the server confirmed the
     // delete. Otherwise the user would see both a red "Delete failed" toast
@@ -1691,17 +1687,21 @@ export default function UniverseBuilder() {
               <ShareToButton kind="universe" ids={[selectedId]} label="Share" />
               <SyncToPeerButton recordKind="universe" recordId={selectedId} label="Sync" />
               {draft.origin ? <OriginBadge origin={draft.origin} /> : null}
-              <button
-                onClick={handleDelete}
-                className={`px-3 py-2 rounded flex items-center gap-2 min-h-[40px] ${
-                  pendingDeleteId === selectedId
-                    ? 'bg-port-error hover:bg-port-error/80 text-white'
-                    : 'bg-port-error/30 hover:bg-port-error/50 text-port-error'
-                }`}
-                title="Delete world"
-              >
-                <Trash2 size={16} /> {pendingDeleteId === selectedId ? 'Confirm delete' : 'Delete'}
-              </button>
+              {pendingDeleteId === selectedId ? (
+                <InlineConfirmRow
+                  question={`Delete "${draft.name || 'this world'}"?`}
+                  onConfirm={handleDelete}
+                  onCancel={() => setPendingDeleteId(null)}
+                />
+              ) : (
+                <button
+                  onClick={() => setPendingDeleteId(selectedId)}
+                  className="px-3 py-2 rounded flex items-center gap-2 min-h-[40px] bg-port-error/30 hover:bg-port-error/50 text-port-error"
+                  title="Delete world"
+                >
+                  <Trash2 size={16} /> Delete
+                </button>
+              )}
             </>
           )}
         </header>

--- a/client/src/pages/Universes.jsx
+++ b/client/src/pages/Universes.jsx
@@ -12,6 +12,7 @@ import { useEffect, useMemo, useState, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Plus, Globe, Trash2, Users, Workflow as WorkflowIcon, Copy } from 'lucide-react';
 import toast from '../components/ui/Toast';
+import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import ImageThumb from '../components/ui/ImageThumb';
 import ShareToButton from '../components/sharing/ShareToButton';
 import SyncToPeerButton from '../components/sharing/SyncToPeerButton';
@@ -23,6 +24,7 @@ import { timeAgo } from '../utils/formatters';
 import { listUniverses, deleteUniverse, listPipelineSeries, listMediaCollections, listUniverseDuplicates } from '../services/api';
 import { useSyncIntegrity, syncBadgeStatus } from '../hooks/useSyncIntegrity';
 import { useRecordMerge } from '../hooks/useRecordMerge';
+import { useConfirmDelete } from '../hooks/useConfirmDelete';
 
 // Named canon entities across all trunks — the "Canon" column reflects the
 // characters/places/objects the user has registered, not the looser variation
@@ -74,17 +76,28 @@ function UniverseThumb({ imageRef }) {
   return <ImageThumb imageRef={imageRef} FallbackIcon={Globe} />;
 }
 
-// Shared between the desktop table row and the mobile card so the armed-state
-// styling + a11y labels stay in one place.
-function DeleteButton({ universe, armed, onDelete }) {
+// Shared between the desktop table row and the mobile card so the inline-confirm
+// affordance + a11y labels stay in one place. An explicit Delete?/Cancel row
+// replaces the two-click-arm button once the row is armed.
+function DeleteButton({ universe, confirming, onRequest, onConfirm, onCancel }) {
   const name = universe.name || '(untitled universe)';
+  if (confirming) {
+    return (
+      <ConfirmButtonPair
+        prompt="Delete?"
+        ariaLabel={`Confirm delete universe ${name}`}
+        onConfirm={() => onConfirm(universe)}
+        onCancel={onCancel}
+      />
+    );
+  }
   return (
     <button
       type="button"
-      onClick={() => onDelete(universe)}
-      className={`p-2 ${armed ? 'text-port-error' : 'text-gray-500 hover:text-port-error'}`}
-      aria-label={armed ? `Confirm delete universe ${name}` : `Delete universe ${name}`}
-      title={armed ? 'Click again to confirm delete' : 'Delete universe'}
+      onClick={() => onRequest(universe.id)}
+      className="p-2 text-gray-500 hover:text-port-error"
+      aria-label={`Delete universe ${name}`}
+      title="Delete universe"
     >
       <Trash2 size={16} />
     </button>
@@ -189,16 +202,11 @@ export default function Universes() {
     return m;
   }, [series]);
 
-  // Two-click delete: first click "arms" the row, second click fires. Avoids
-  // window.confirm (banned per CLAUDE.md) without pulling in a modal. armedId
-  // resets after the action or when a different row is armed.
-  const [armedId, setArmedId] = useState(null);
-  const handleDelete = async (u) => {
-    if (armedId !== u.id) {
-      setArmedId(u.id);
-      return;
-    }
-    setArmedId(null);
+  // Inline delete confirm: the trash button arms the row (one at a time) and an
+  // explicit Delete?/Cancel row fires it. Avoids window.confirm (banned per
+  // CLAUDE.md) and the non-discoverable two-click-arm pattern.
+  const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
+  const handleDelete = (u) => confirmDelete(async () => {
     setUniverses((prev) => prev.filter((x) => x.id !== u.id));
     // silent: the custom catch below owns the error toast (CLAUDE.md).
     await deleteUniverse(u.id, { silent: true }).catch((err) => {
@@ -213,7 +221,7 @@ export default function Universes() {
           : [...prev, u].sort((a, b) => (b.createdAt || '').localeCompare(a.createdAt || '')),
       );
     });
-  };
+  });
 
   return (
     <div>
@@ -305,7 +313,7 @@ export default function Universes() {
                       <div className="flex items-center justify-end gap-1">
                         <ShareToButton kind="universe" ids={[u.id]} compact />
                         <SyncToPeerButton recordKind="universe" recordId={u.id} compact />
-                        <DeleteButton universe={u} armed={armedId === u.id} onDelete={handleDelete} />
+                        <DeleteButton universe={u} confirming={isConfirming(u.id)} onRequest={requestDelete} onConfirm={handleDelete} onCancel={cancelDelete} />
                       </div>
                     </td>
                   </tr>
@@ -336,7 +344,7 @@ export default function Universes() {
                       </div>
                     </div>
                   </Link>
-                  <DeleteButton universe={u} armed={armedId === u.id} onDelete={handleDelete} />
+                  <DeleteButton universe={u} confirming={isConfirming(u.id)} onRequest={requestDelete} onConfirm={handleDelete} onCancel={cancelDelete} />
                 </div>
                 <div className="flex items-center gap-1 mt-2">
                   <ShareToButton kind="universe" ids={[u.id]} compact />


### PR DESCRIPTION
Closes #2024

## Summary
Finishes the migration away from the non-discoverable same-button "two-click-arm" delete/replace pattern to explicit inline confirm/cancel affordances, using the existing `InlineConfirmRow` / `ConfirmButtonPair` primitives and the `useConfirmDelete` hook.

Migrated delete sites (now show an explicit Delete?/Cancel row):
- `pages/Rounds.jsx` — delete round
- `pages/Universes.jsx` (`DeleteButton`) — delete universe (desktop table + mobile card)
- `pages/Pipeline.jsx` — delete series
- `pages/Sharing.jsx` — remove bucket (`InlineConfirmRow` in the settings panel)
- `components/pipeline/ArcCanvas.jsx` — delete issue/episode
- `components/writers-room/LibraryPane.jsx` — delete work + delete folder (also enlarged the delete/add hit targets to >=44px for touch; dropped the toast re-arm + 4s timer)
- `pages/Ask.jsx` — delete conversation (converted the ref-based toast arm to `useConfirmDelete` + inline `ConfirmButtonPair`)
- `pages/UniverseBuilder.jsx` — delete world (toast-armed → `InlineConfirmRow`)

Migrated toast-armed "replace" extract buttons (now an inline "Replace?/Cancel" row near the trigger, `tone="warning"`):
- `components/pipeline/stages/AudioStage.jsx` — re-extract audio lines
- `components/pipeline/stages/StoryboardsStage.jsx` — extract from Teleplay / prose
- `components/pipeline/stages/ComicPagesStage.jsx` — extract from comic script

Notes:
- `AudioStage` `pendingLibraryDelete` and `confirmRederive`, and `ArcCanvas` volume/season delete were already explicit inline confirms — left as-is.
- `StoryBuilder.jsx` and `VoiceWidget.jsx` "click again" strings are a partial-failure retry prompt and a push-to-talk hint respectively (not arm/confirm) — out of scope.
- `useArmedAction` now has zero component consumers but is kept as a documented (discouraged) primitive to avoid barrel/README/test churn.

## Test plan
- `cd client && npm test` → 285 files, 3076 tests pass.
- `npx eslint` on all changed files → clean.
- Verified no `again to confirm` / two-click-arm delete interactions remain (grep sweep), and no now-unused imports (`useRef` in Ask, `useEffect` in AudioStage/StoryboardsStage still used or removed).

https://claude.ai/code/session_01GmWqYTkinJmpC94zkpMQ8b