### PR TITLE
fix: two-column Story Builder index layout above lg breakpoint (#2030)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -8,6 +8,10 @@
 
 - **Config form labels now focus their field when clicked and read correctly to screen readers.** Many settings/config forms (AI Providers, DataDog, feature-agent config, message & calendar account setup, scheduled-task provider/model pickers, the agent world/schedule tabs, MeatSpace nicotine + POST drills, and more) rendered the label as a plain sibling of its input with no association, so clicking the label did nothing and assistive tech couldn't announce the pairing. These fields now flow through a shared `FormField` wrapper that generates a stable id and wires `htmlFor`/`id` automatically, keeping the exact same styling (#2027). Remaining forms are tracked for a follow-up sweep (#2051).
 
+## Layout
+
+- **The Story Builder index now uses the full desktop width instead of a single narrow column.** The create form and the "Continue a story" session list previously stacked in one `max-w-3xl` column, leaving most of a 1280px+ screen empty. Above the `lg` breakpoint they now sit side by side — form left, in-progress sessions in a fixed-width sidebar on the right — mirroring the POST launcher's two-column layout (#1986), so your existing stories are visible without scrolling. Below `lg` the columns stack exactly as before, so mobile is unchanged (#2030).
+
 ## Loading states
 
 - **The DataDog, Jira, and GitHub integration pages now show a layout-shaped skeleton on first paint instead of a centered "Loading…" line.** Each page previously rendered a bare full-screen text message sized with `h-screen`, which mis-sized under mobile browser chrome and jumped when the real content arrived. They now share a `PageSkeleton` that reserves the header + card-grid dimensions (matching the loaded layout, using the `port-*` design tokens like the dashboard's `WidgetSkeleton`), so there's no post-load layout jump and no full-height wrapper fighting Layout's scroll (#2029).

--- a/client/src/pages/StoryBuilder.jsx
+++ b/client/src/pages/StoryBuilder.jsx
@@ -222,7 +222,12 @@ function StoryBuilderIndex() {
   }`;
 
   return (
-    <div className="max-w-3xl mx-auto space-y-6">
+    // Wide two-column shell above lg: create form left, "Continue a story" list
+    // right (mirrors the POST launcher redesign, #1986). Below lg the grid
+    // collapses to a single stacked column so mobile is unchanged. The 22rem
+    // sidebar track is reserved even with no sessions so the form keeps a
+    // comfortable ~48rem width instead of stretching the full shell.
+    <div className="max-w-6xl mx-auto space-y-6">
       <header>
         <h1 className="text-2xl font-bold flex items-center gap-2">
           <Sparkles className="w-6 h-6 text-port-accent" /> Story Builder
@@ -233,6 +238,7 @@ function StoryBuilderIndex() {
         </p>
       </header>
 
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_22rem] gap-6 items-start">
       <section className="bg-port-card border border-port-border rounded-lg">
         <div className="flex gap-1 border-b border-port-border px-2 pt-2">
           <button onClick={() => setMode('seed')} className={tabClass('seed')}>Start from an idea</button>
@@ -294,14 +300,15 @@ function StoryBuilderIndex() {
           {sessions.map((s) => (
             <Link
               key={s.id} to={`/story-builder/${s.id}/${s.currentStep || 'idea'}`}
-              className="flex items-center justify-between bg-port-card border border-port-border rounded-lg px-4 py-3 hover:border-port-accent"
+              className="flex items-center justify-between gap-2 bg-port-card border border-port-border rounded-lg px-4 py-3 hover:border-port-accent"
             >
-              <span className="font-medium">{s.title}</span>
-              <span className="text-xs text-gray-500">at “{s.currentStep}” <ChevronRight className="w-4 h-4 inline" /></span>
+              <span className="font-medium truncate">{s.title}</span>
+              <span className="text-xs text-gray-500 whitespace-nowrap">at “{s.currentStep}” <ChevronRight className="w-4 h-4 inline" /></span>
             </Link>
           ))}
         </section>
       )}
+      </div>
     </div>
   );
 }

--- a/client/src/pages/StoryBuilder.jsx
+++ b/client/src/pages/StoryBuilder.jsx
@@ -302,7 +302,7 @@ function StoryBuilderIndex() {
               key={s.id} to={`/story-builder/${s.id}/${s.currentStep || 'idea'}`}
               className="flex items-center justify-between gap-2 bg-port-card border border-port-border rounded-lg px-4 py-3 hover:border-port-accent"
             >
-              <span className="font-medium truncate">{s.title}</span>
+              <span className="font-medium truncate min-w-0">{s.title}</span>
               <span className="text-xs text-gray-500 whitespace-nowrap">at “{s.currentStep}” <ChevronRight className="w-4 h-4 inline" /></span>
             </Link>
           ))}


### PR DESCRIPTION
Closes #2030

## Summary

The Story Builder index (`StoryBuilderIndex` in `client/src/pages/StoryBuilder.jsx`) wrapped both the create form and the "Continue a story" session list in a single `max-w-3xl mx-auto` column, wasting most of a 1280px+ desktop viewport.

This lays the index out in two columns above the `lg` breakpoint — create form left, in-progress session list in a fixed 22rem sidebar on the right — mirroring the POST launcher redesign (#1986):

- Page shell widened from `max-w-3xl` to `max-w-6xl`.
- Content wrapped in `grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_22rem] gap-6 items-start`. Below `lg` this collapses to a single stacked column, so mobile is unchanged.
- The 22rem sidebar track is reserved even when there are no sessions, so the form keeps a comfortable ~48rem width on a fresh install rather than stretching the full shell — no `max-w-3xl` constraint remains on the shell.
- Session rows gained `gap-2` + `truncate`/`whitespace-nowrap` so long story titles clip cleanly inside the narrower sidebar column.

Layout-only change; no behavior change.

## Test plan

- `cd client && npm test` — full suite green (286 files, 3086 tests), including the 27 existing `StoryBuilder.test.jsx` tests.
- Manual: at ≥1024px the form and session list render side by side with the session list visible above the fold; at 360px both columns stack in a single scroll column (mobile unchanged).