### PR TITLE
Use dark themed thin scrollbars in the integration-flows doc

### DIFF
--- a/client/public/flows.html
+++ b/client/public/flows.html
@@ -6,6 +6,7 @@
 <title>PortOS Integration Flows</title>
 <style>
   :root {
+    color-scheme: dark; /* dark UA scrollbars + form controls to match the page */
     --bg: #0f0f0f;
     --card: #1a1a1a;
     --border: #2a2a2a;
@@ -17,6 +18,12 @@
     --muted: #9ca3af;
   }
   * { box-sizing: border-box; margin: 0; padding: 0; }
+  * { scrollbar-width: thin; scrollbar-color: var(--border) transparent; }
+  ::-webkit-scrollbar { width: 8px; height: 8px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 4px; }
+  ::-webkit-scrollbar-thumb:hover { background: #3f3f3f; }
+  ::-webkit-scrollbar-corner { background: transparent; }
   html, body { height: 100%; }
   /* The scroll containers below re-declare the body background because some
      browsers paint composited scroll regions white when they inherit none. */


### PR DESCRIPTION
## Summary

- The flows doc (`/flows.html`, hosted at `/devtools/flows`) never declared `color-scheme`, so browsers painted their default light, chunky scrollbars over the dark layout — one per sidebar scroll region plus the diagram's horizontal bar.
- Declares `color-scheme: dark` and styles all scroll containers with thin, border-colored thumbs on transparent tracks (standard `scrollbar-width`/`scrollbar-color` plus `::-webkit-scrollbar` for Safari).

## Test plan

- Verified via headless Chrome screenshot at a scroll-forcing viewport: scrollbars now render as thin dark slivers matching the theme; no layout regression in flow highlighting.
- CSS-only change to a standalone static file — no logic surface; existing flows integrity tests unaffected.
