### PR TITLE
refactor: sweep remaining config forms onto shared FormField (#2051)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -33,6 +33,7 @@
 ## Accessibility
 
 - **Config form labels now focus their field when clicked and read correctly to screen readers.** Many settings/config forms (AI Providers, DataDog, feature-agent config, message & calendar account setup, scheduled-task provider/model pickers, the agent world/schedule tabs, MeatSpace nicotine + POST drills, and more) rendered the label as a plain sibling of its input with no association, so clicking the label did nothing and assistive tech couldn't announce the pairing. These fields now flow through a shared `FormField` wrapper that generates a stable id and wires `htmlFor`/`id` automatically, keeping the exact same styling (#2027). Remaining forms are tracked for a follow-up sweep (#2051).
+- **The follow-up sweep wired the remaining config-form labels to their controls.** Continuing #2027, ~130 more sibling `<label>`+input pairs across ~40 files — agents (overview/list/published), digital-twin tabs, image-gen controls, media/prompt tools, MeatSpace panels, brain, CoS memory/resume, writers-room, and pages (PromptManager, VideoGen, Jira, Sharing, Loras, Security, ImageGen, Templates, Loops, Browser, and more) — now flow through the shared `FormField` wrapper so clicking a label focuses its field and screen readers announce the pairing. Accessibility only: existing Tailwind classes are preserved verbatim, wrapping `<label><input/></label>` and radio/toggle group labels are left untouched, and controls whose custom component doesn't forward `id` to a DOM input were deliberately skipped (#2051).
 
 ## Layout
 

--- a/client/src/components/agents/AgentList.jsx
+++ b/client/src/components/agents/AgentList.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { Sparkles } from 'lucide-react';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
+import { FormField } from '../ui/FormField';
 import * as api from '../../services/api';
 import { PERSONALITY_STYLES, DEFAULT_PERSONALITY, DEFAULT_AVATAR } from './constants';
 import { filterSelectableModels } from '../../utils/providers';
@@ -216,8 +217,7 @@ export default function AgentList() {
                 <span className="text-sm font-medium text-white">Generate with AI</span>
               </div>
               <div className="flex items-end gap-3">
-                <div className="flex-1">
-                  <label className="block text-xs text-gray-400 mb-1">Provider</label>
+                <FormField label="Provider" className="flex-1" labelClassName="block text-xs text-gray-400 mb-1">
                   <select
                     value={selectedProviderId}
                     onChange={(e) => { setSelectedProviderId(e.target.value); setSelectedModel(''); }}
@@ -229,9 +229,8 @@ export default function AgentList() {
                       <option key={p.id} value={p.id}>{p.name}</option>
                     ))}
                   </select>
-                </div>
-                <div className="flex-1">
-                  <label className="block text-xs text-gray-400 mb-1">Model</label>
+                </FormField>
+                <FormField label="Model" className="flex-1" labelClassName="block text-xs text-gray-400 mb-1">
                   <select
                     value={selectedModel}
                     onChange={(e) => setSelectedModel(e.target.value)}
@@ -243,7 +242,7 @@ export default function AgentList() {
                       <option key={m} value={m}>{m}</option>
                     ))}
                   </select>
-                </div>
+                </FormField>
                 <button
                   type="button"
                   onClick={handleGenerate}
@@ -263,8 +262,7 @@ export default function AgentList() {
             </div>
 
             <div className="grid grid-cols-2 gap-4 mb-4">
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Name</label>
+              <FormField label="Name">
                 <input
                   type="text"
                   value={formData.name}
@@ -272,9 +270,8 @@ export default function AgentList() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
                   required
                 />
-              </div>
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Style</label>
+              </FormField>
+              <FormField label="Style">
                 <select
                   value={formData.personality.style}
                   onChange={(e) => updatePersonality('style', e.target.value)}
@@ -284,21 +281,19 @@ export default function AgentList() {
                     <option key={style.value} value={style.value}>{style.label}</option>
                   ))}
                 </select>
-              </div>
+              </FormField>
             </div>
 
-            <div className="mb-4">
-              <label className="block text-sm text-gray-400 mb-1">Description</label>
+            <FormField label="Description" className="mb-4">
               <textarea
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white h-20"
                 placeholder="Brief description of this agent's purpose..."
               />
-            </div>
+            </FormField>
 
-            <div className="mb-4">
-              <label className="block text-sm text-gray-400 mb-1">Tone</label>
+            <FormField label="Tone" className="mb-4">
               <input
                 type="text"
                 value={formData.personality.tone}
@@ -306,10 +301,9 @@ export default function AgentList() {
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
                 placeholder="e.g., friendly but informative"
               />
-            </div>
+            </FormField>
 
-            <div className="mb-4">
-              <label className="block text-sm text-gray-400 mb-1">Topics (comma-separated)</label>
+            <FormField label="Topics (comma-separated)" className="mb-4">
               <input
                 type="text"
                 value={topicsText}
@@ -318,10 +312,9 @@ export default function AgentList() {
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
                 placeholder="e.g., technology, AI, philosophy"
               />
-            </div>
+            </FormField>
 
-            <div className="mb-4">
-              <label className="block text-sm text-gray-400 mb-1">Quirks (comma-separated)</label>
+            <FormField label="Quirks (comma-separated)" className="mb-4">
               <input
                 type="text"
                 value={quirksText}
@@ -330,17 +323,16 @@ export default function AgentList() {
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
                 placeholder="e.g., uses metaphors, asks follow-up questions"
               />
-            </div>
+            </FormField>
 
-            <div className="mb-4">
-              <label className="block text-sm text-gray-400 mb-1">Prompt Prefix</label>
+            <FormField label="Prompt Prefix" className="mb-4">
               <textarea
                 value={formData.personality.promptPrefix}
                 onChange={(e) => updatePersonality('promptPrefix', e.target.value)}
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white h-24 font-mono text-sm"
                 placeholder="Custom instructions injected into AI prompts..."
               />
-            </div>
+            </FormField>
 
             <div className="flex items-center gap-4 mb-4">
               <label className="block text-sm text-gray-400">Avatar Emoji</label>

--- a/client/src/components/agents/tabs/OverviewTab.jsx
+++ b/client/src/components/agents/tabs/OverviewTab.jsx
@@ -5,6 +5,7 @@ import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
 import { filterSelectableModels } from '../../../utils/providers';
 import BrailleSpinner from '../../BrailleSpinner';
+import { FormField } from '../../ui/FormField';
 import { PERSONALITY_STYLES, DEFAULT_PERSONALITY, DEFAULT_AVATAR, PLATFORM_TYPES, ACCOUNT_STATUSES } from '../constants';
 import { useCooldownTick } from '../../../hooks/useCooldownTick';
 import { formatCooldown, formatDateTime } from '../../../utils/formatters';
@@ -309,8 +310,7 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
             <form onSubmit={handleSave}>
               {/* Name + Style */}
               <div className="grid grid-cols-2 gap-4 mb-4">
-                <div>
-                  <label className="block text-sm text-gray-400 mb-1">Name</label>
+                <FormField label="Name">
                   <input
                     type="text"
                     value={formData.name}
@@ -318,9 +318,8 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
                     className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
                     required
                   />
-                </div>
-                <div>
-                  <label className="block text-sm text-gray-400 mb-1">Style</label>
+                </FormField>
+                <FormField label="Style">
                   <select
                     value={formData.personality.style}
                     onChange={(e) => updatePersonality('style', e.target.value)}
@@ -330,24 +329,22 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
                       <option key={style.value} value={style.value}>{style.label}</option>
                     ))}
                   </select>
-                </div>
+                </FormField>
               </div>
 
               {/* Description */}
-              <div className="mb-4">
-                <label className="block text-sm text-gray-400 mb-1">Description</label>
+              <FormField label="Description" className="mb-4">
                 <textarea
                   value={formData.description}
                   onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white h-20"
                   placeholder="Brief description of this agent's purpose..."
                 />
-              </div>
+              </FormField>
 
               {/* Tone + Avatar (emoji + color) */}
               <div className="flex items-end gap-4 mb-4">
-                <div className="flex-1">
-                  <label className="block text-sm text-gray-400 mb-1">Tone</label>
+                <FormField label="Tone" className="flex-1">
                   <input
                     type="text"
                     value={formData.personality.tone}
@@ -355,9 +352,8 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
                     className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
                     placeholder="e.g., friendly but informative"
                   />
-                </div>
-                <div className="flex items-center gap-2">
-                  <label className="text-sm text-gray-400">Emoji</label>
+                </FormField>
+                <FormField label="Emoji" className="flex items-center gap-2" labelClassName="text-sm text-gray-400">
                   <input
                     type="text"
                     value={formData.avatar.emoji || ''}
@@ -365,22 +361,20 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
                     className="w-14 px-2 py-2 bg-port-bg border border-port-border rounded text-white text-center"
                     maxLength={2}
                   />
-                </div>
-                <div className="flex items-center gap-2">
-                  <label className="text-sm text-gray-400">Color</label>
+                </FormField>
+                <FormField label="Color" className="flex items-center gap-2" labelClassName="text-sm text-gray-400">
                   <input
                     type="color"
                     value={formData.avatar.color || '#3b82f6'}
                     onChange={(e) => setFormData({ ...formData, avatar: { ...formData.avatar, color: e.target.value } })}
                     className="w-12 h-9 border border-port-border rounded cursor-pointer"
                   />
-                </div>
+                </FormField>
               </div>
 
               {/* Topics + Quirks */}
               <div className="grid grid-cols-2 gap-4 mb-4">
-                <div>
-                  <label className="block text-sm text-gray-400 mb-1">Topics (comma-separated)</label>
+                <FormField label="Topics (comma-separated)">
                   <input
                     type="text"
                     value={topicsText}
@@ -389,9 +383,8 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
                     className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
                     placeholder="e.g., technology, AI"
                   />
-                </div>
-                <div>
-                  <label className="block text-sm text-gray-400 mb-1">Quirks (comma-separated)</label>
+                </FormField>
+                <FormField label="Quirks (comma-separated)">
                   <input
                     type="text"
                     value={quirksText}
@@ -400,19 +393,18 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
                     className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
                     placeholder="e.g., uses metaphors"
                   />
-                </div>
+                </FormField>
               </div>
 
               {/* Prompt Prefix */}
-              <div className="mb-4">
-                <label className="block text-sm text-gray-400 mb-1">Prompt Prefix</label>
+              <FormField label="Prompt Prefix" className="mb-4">
                 <textarea
                   value={formData.personality.promptPrefix}
                   onChange={(e) => updatePersonality('promptPrefix', e.target.value)}
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white h-24 font-mono text-sm"
                   placeholder="Custom instructions injected into AI prompts..."
                 />
-              </div>
+              </FormField>
 
               <button
                 type="submit"
@@ -435,8 +427,7 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
             ) : (
               <>
                 {activeAccounts.length > 1 && (
-                  <div className="mb-3">
-                    <label className="block text-xs text-gray-400 mb-1">Account</label>
+                  <FormField label="Account" className="mb-3" labelClassName="block text-xs text-gray-400 mb-1">
                     <select
                       value={quickAccountId}
                       onChange={(e) => setQuickAccountId(e.target.value)}
@@ -446,7 +437,7 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
                         <option key={a.id} value={a.id}>{a.credentials.username}</option>
                       ))}
                     </select>
-                  </div>
+                  </FormField>
                 )}
 
                 {rateLimits && (
@@ -614,8 +605,7 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
             {showAccountForm && (
               <form onSubmit={handleAccountSubmit} className="mb-4 p-3 bg-port-bg border border-port-border rounded-lg">
                 <div className="grid grid-cols-2 gap-4 mb-3">
-                  <div>
-                    <label className="block text-sm text-gray-400 mb-1">Platform</label>
+                  <FormField label="Platform">
                     <select
                       value={accountForm.platform}
                       onChange={(e) => setAccountForm({ ...accountForm, platform: e.target.value })}
@@ -627,9 +617,8 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
                         </option>
                       ))}
                     </select>
-                  </div>
-                  <div>
-                    <label className="block text-sm text-gray-400 mb-1">Account Name</label>
+                  </FormField>
+                  <FormField label="Account Name">
                     <input
                       type="text"
                       value={accountForm.name}
@@ -638,17 +627,16 @@ export default function OverviewTab({ agentId, agent, onAgentUpdate }) {
                       placeholder="Display name on platform"
                       required
                     />
-                  </div>
+                  </FormField>
                 </div>
-                <div className="mb-3">
-                  <label className="block text-sm text-gray-400 mb-1">Bio/Description</label>
+                <FormField label="Bio/Description" className="mb-3">
                   <textarea
                     value={accountForm.description}
                     onChange={(e) => setAccountForm({ ...accountForm, description: e.target.value })}
                     className="w-full px-3 py-2 bg-port-card border border-port-border rounded text-white h-16"
                     placeholder="Brief bio for the platform profile..."
                   />
-                </div>
+                </FormField>
                 <div className="flex gap-2">
                   <button type="submit" className="px-3 py-1.5 text-sm bg-port-success text-white rounded hover:bg-port-success/80">
                     Register Account

--- a/client/src/components/agents/tabs/PublishedTab.jsx
+++ b/client/src/components/agents/tabs/PublishedTab.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import * as api from '../../../services/api';
 import BrailleSpinner from '../../BrailleSpinner';
+import { FormField } from '../../ui/FormField';
 import { timeAgo, formatDateTime } from '../../../utils/formatters';
 
 export default function PublishedTab({ agentId }) {
@@ -49,8 +50,7 @@ export default function PublishedTab({ agentId }) {
     <div className="p-4">
       {/* Header */}
       <div className="flex flex-wrap items-end gap-4 mb-6 p-4 bg-port-card border border-port-border rounded-lg">
-        <div>
-          <label className="block text-sm text-gray-400 mb-1">Account</label>
+        <FormField label="Account">
           <select
             value={selectedAccountId}
             onChange={(e) => setSelectedAccountId(e.target.value)}
@@ -63,7 +63,7 @@ export default function PublishedTab({ agentId }) {
               </option>
             ))}
           </select>
-        </div>
+        </FormField>
         <div className="flex items-center gap-2 ml-auto">
           <select
             value={publishedDays}

--- a/client/src/components/apps/tabs/ProcessesTab.jsx
+++ b/client/src/components/apps/tabs/ProcessesTab.jsx
@@ -4,6 +4,7 @@ import * as api from '../../../services/api';
 import { executeCommand } from '../../../services/api';
 import socket from '../../../services/socket';
 import BrailleSpinner from '../../BrailleSpinner';
+import { FormField } from '../../ui/FormField';
 import { useAutoRefetch } from '../../../hooks/useAutoRefetch';
 import { formatBytes, formatDurationMs } from '../../../utils/formatters';
 
@@ -209,8 +210,7 @@ export default function ProcessesTab({ pm2ProcessNames, filterFn }) {
                               )}
                             </div>
                             <div className="flex items-center gap-3">
-                              <div className="flex items-center gap-2">
-                                <label className="text-xs text-gray-500">Tail lines:</label>
+                              <FormField className="flex items-center gap-2" label="Tail lines:" labelClassName="text-xs text-gray-500">
                                 <select
                                   value={tailLines}
                                   onChange={(e) => {
@@ -225,7 +225,7 @@ export default function ProcessesTab({ pm2ProcessNames, filterFn }) {
                                   <option value={1000}>1000</option>
                                   <option value={2000}>2000</option>
                                 </select>
-                              </div>
+                              </FormField>
                               <span className="text-xs text-gray-600">{logs.length} lines</span>
                               <button
                                 onClick={() => setLogs([])}
@@ -294,8 +294,7 @@ export default function ProcessesTab({ pm2ProcessNames, filterFn }) {
               )}
             </div>
             <div className="flex items-center gap-4">
-              <div className="flex items-center gap-2">
-                <label className="text-sm text-gray-500">Tail lines:</label>
+              <FormField className="flex items-center gap-2" label="Tail lines:" labelClassName="text-sm text-gray-500">
                 <select
                   value={tailLines}
                   onChange={(e) => {
@@ -310,7 +309,7 @@ export default function ProcessesTab({ pm2ProcessNames, filterFn }) {
                   <option value={1000}>1000</option>
                   <option value={2000}>2000</option>
                 </select>
-              </div>
+              </FormField>
               <span className="text-sm text-gray-600">{logs.length} lines</span>
               <button
                 onClick={() => setLogs([])}

--- a/client/src/components/brain/tabs/DailyLogTab.jsx
+++ b/client/src/components/brain/tabs/DailyLogTab.jsx
@@ -5,6 +5,7 @@ import * as api from '../../../services/api';
 import { getNotesVaults } from '../../../services/apiNotes';
 import toast from '../../ui/Toast';
 import InlineConfirmRow from '../../ui/InlineConfirmRow';
+import { FormField } from '../../ui/FormField';
 import { onVoiceEvent, sendText, setDictation as setVoiceDictation } from '../../../services/voiceClient';
 import BrailleSpinner from '../../BrailleSpinner';
 
@@ -377,8 +378,7 @@ export default function DailyLogTab() {
 
         {showSettings && (
           <div className="p-3 border-b border-port-border space-y-3">
-            <div>
-              <label className="block text-xs text-gray-400 mb-1">Obsidian vault (mirror logs)</label>
+            <FormField label="Obsidian vault (mirror logs)" labelClassName="block text-xs text-gray-400 mb-1">
               <select
                 value={settings?.obsidianVaultId || ''}
                 onChange={(e) => saveSettings({ obsidianVaultId: e.target.value || null })}
@@ -389,9 +389,8 @@ export default function DailyLogTab() {
                   <option key={v.id} value={v.id}>{v.name}</option>
                 ))}
               </select>
-            </div>
-            <div>
-              <label className="block text-xs text-gray-400 mb-1">Folder inside vault</label>
+            </FormField>
+            <FormField label="Folder inside vault" labelClassName="block text-xs text-gray-400 mb-1">
               <input
                 type="text"
                 value={settings?.obsidianFolder || ''}
@@ -400,7 +399,7 @@ export default function DailyLogTab() {
                 className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm text-white"
                 placeholder="Daily Log"
               />
-            </div>
+            </FormField>
             <label className="flex items-center gap-2 text-xs text-gray-400">
               <input
                 type="checkbox"

--- a/client/src/components/brain/tabs/TrustTab.jsx
+++ b/client/src/components/brain/tabs/TrustTab.jsx
@@ -9,6 +9,7 @@ import {
 } from 'lucide-react';
 import BrailleSpinner from '../../BrailleSpinner';
 import toast from '../../ui/Toast';
+import { FormField } from '../../ui/FormField';
 
 import {
   DESTINATIONS,
@@ -118,8 +119,7 @@ export default function TrustTab({ onRefresh }) {
         {editingSettings ? (
           <div className="space-y-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Confidence Threshold</label>
+              <FormField label="Confidence Threshold">
                 <input
                   type="number"
                   min="0"
@@ -132,20 +132,18 @@ export default function TrustTab({ onRefresh }) {
                 <p className="text-xs text-gray-500 mt-1">
                   Items below this threshold go to "needs review" (0-1)
                 </p>
-              </div>
+              </FormField>
 
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Daily Digest Time</label>
+              <FormField label="Daily Digest Time">
                 <input
                   type="time"
                   value={settingsForm.dailyDigestTime || '09:00'}
                   onChange={(e) => setSettingsForm({ ...settingsForm, dailyDigestTime: e.target.value })}
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
                 />
-              </div>
+              </FormField>
 
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Weekly Review Day</label>
+              <FormField label="Weekly Review Day">
                 <select
                   value={settingsForm.weeklyReviewDay || 'sunday'}
                   onChange={(e) => setSettingsForm({ ...settingsForm, weeklyReviewDay: e.target.value })}
@@ -159,17 +157,16 @@ export default function TrustTab({ onRefresh }) {
                   <option value="friday">Friday</option>
                   <option value="saturday">Saturday</option>
                 </select>
-              </div>
+              </FormField>
 
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Weekly Review Time</label>
+              <FormField label="Weekly Review Time">
                 <input
                   type="time"
                   value={settingsForm.weeklyReviewTime || '16:00'}
                   onChange={(e) => setSettingsForm({ ...settingsForm, weeklyReviewTime: e.target.value })}
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
                 />
-              </div>
+              </FormField>
             </div>
 
             <div className="flex items-center gap-2">

--- a/client/src/components/cos/tabs/MemoryEditModal.jsx
+++ b/client/src/components/cos/tabs/MemoryEditModal.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { X, Save, Plus, Trash2 } from 'lucide-react';
 import toast from '../../ui/Toast';
 import Modal from '../../ui/Modal';
+import { FormField } from '../../ui/FormField';
 import * as api from '../../../services/api';
 import { MEMORY_TYPES, MEMORY_TYPE_COLORS } from '../constants';
 import { getAppName } from '../../../utils/formatters';
@@ -140,10 +141,10 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
           </div>
 
           {/* Content */}
-          <div>
-            <label className="block text-sm text-gray-400 mb-2">
-              Content <span className="text-port-accent">*</span>
-            </label>
+          <FormField
+            label={<>Content <span className="text-port-accent">*</span></>}
+            labelClassName="block text-sm text-gray-400 mb-2"
+          >
             <textarea
               value={formData.content}
               onChange={e => setFormData({ ...formData, content: e.target.value })}
@@ -155,11 +156,10 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
             <p className="text-xs text-gray-500 mt-1">
               Editing content will regenerate the embedding for semantic search.
             </p>
-          </div>
+          </FormField>
 
           {/* Summary */}
-          <div>
-            <label className="block text-sm text-gray-400 mb-2">Summary (optional)</label>
+          <FormField label="Summary (optional)" labelClassName="block text-sm text-gray-400 mb-2">
             <input
               type="text"
               value={formData.summary}
@@ -167,12 +167,11 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
               placeholder="Brief summary..."
               className="w-full px-3 py-3 min-h-[44px] bg-port-bg border border-port-border rounded-lg text-white text-sm focus:border-port-accent focus:outline-hidden"
             />
-          </div>
+          </FormField>
 
           {/* Category and App */}
           <div className="flex flex-col sm:flex-row gap-3">
-            <div className="flex-1">
-              <label className="block text-sm text-gray-400 mb-2">Category</label>
+            <FormField label="Category" className="flex-1" labelClassName="block text-sm text-gray-400 mb-2">
               <select
                 value={formData.category}
                 onChange={e => setFormData({ ...formData, category: e.target.value })}
@@ -189,9 +188,8 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
                 <option value="system">System</option>
                 <option value="project">Project</option>
               </select>
-            </div>
-            <div className="flex-1">
-              <label className="block text-sm text-gray-400 mb-2">Associated App</label>
+            </FormField>
+            <FormField label="Associated App" className="flex-1" labelClassName="block text-sm text-gray-400 mb-2">
               <select
                 value={formData.sourceAppId}
                 onChange={e => setFormData({ ...formData, sourceAppId: e.target.value })}
@@ -202,7 +200,7 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
                   <option key={app.id} value={app.id}>{app.name}</option>
                 ))}
               </select>
-            </div>
+            </FormField>
           </div>
 
           {/* Tags */}
@@ -247,10 +245,11 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
 
           {/* Importance and Confidence */}
           <div className="flex flex-col sm:flex-row gap-4">
-            <div className="flex-1">
-              <label className="block text-sm text-gray-400 mb-2">
-                Importance: {(formData.importance * 100).toFixed(0)}%
-              </label>
+            <FormField
+              label={<>Importance: {(formData.importance * 100).toFixed(0)}%</>}
+              className="flex-1"
+              labelClassName="block text-sm text-gray-400 mb-2"
+            >
               <input
                 type="range"
                 min="0"
@@ -260,11 +259,12 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
                 onChange={e => setFormData({ ...formData, importance: parseFloat(e.target.value) })}
                 className="w-full h-8 accent-port-accent"
               />
-            </div>
-            <div className="flex-1">
-              <label className="block text-sm text-gray-400 mb-2">
-                Confidence: {(formData.confidence * 100).toFixed(0)}%
-              </label>
+            </FormField>
+            <FormField
+              label={<>Confidence: {(formData.confidence * 100).toFixed(0)}%</>}
+              className="flex-1"
+              labelClassName="block text-sm text-gray-400 mb-2"
+            >
               <input
                 type="range"
                 min="0"
@@ -274,7 +274,7 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
                 onChange={e => setFormData({ ...formData, confidence: parseFloat(e.target.value) })}
                 className="w-full h-8 accent-port-accent"
               />
-            </div>
+            </FormField>
           </div>
 
           {/* Source Info (read-only) */}

--- a/client/src/components/cos/tabs/ResumeAgentModal.jsx
+++ b/client/src/components/cos/tabs/ResumeAgentModal.jsx
@@ -3,6 +3,7 @@ import { X, CheckCircle, AlertCircle, RotateCcw, Image, Loader2 } from 'lucide-r
 import { processScreenshotUploads } from '../../../utils/fileUpload';
 import toast from '../../ui/Toast';
 import Modal from '../../ui/Modal';
+import { FormField } from '../../ui/FormField';
 import { filterSelectableModels } from '../../../utils/providers';
 
 export default function ResumeAgentModal({ agent, taskType = 'user', providers, apps, onSubmit, onClose }) {
@@ -133,10 +134,7 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* Refined Instructions */}
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">
-              Additional Instructions (optional)
-            </label>
+          <FormField label="Additional Instructions (optional)">
             <textarea
               value={formData.refinedInstructions}
               onChange={e => setFormData({ ...formData, refinedInstructions: e.target.value })}
@@ -145,7 +143,7 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:border-port-accent focus:outline-hidden resize-none"
               autoFocus
             />
-          </div>
+          </FormField>
 
           {/* Screenshot Upload */}
           <div>
@@ -196,8 +194,7 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
           </div>
 
           {/* App Selection */}
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">Target App</label>
+          <FormField label="Target App">
             <select
               value={formData.app}
               onChange={e => setFormData({ ...formData, app: e.target.value })}
@@ -208,12 +205,11 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
                 <option key={app.id} value={app.id}>{app.name}</option>
               ))}
             </select>
-          </div>
+          </FormField>
 
           {/* Provider and Model */}
           <div className="flex gap-3">
-            <div className="flex-1">
-              <label className="block text-sm text-gray-400 mb-1">Provider</label>
+            <FormField label="Provider" className="flex-1">
               <select
                 value={formData.provider}
                 onChange={e => setFormData({ ...formData, provider: e.target.value, model: '' })}
@@ -224,9 +220,8 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
                   <option key={p.id} value={p.id}>{p.name}</option>
                 ))}
               </select>
-            </div>
-            <div className="flex-1">
-              <label className="block text-sm text-gray-400 mb-1">Model</label>
+            </FormField>
+            <FormField label="Model" className="flex-1">
               <select
                 value={formData.model}
                 onChange={e => setFormData({ ...formData, model: e.target.value })}
@@ -238,7 +233,7 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
                   <option key={m} value={m}>{m.replace('claude-', '').replace(/-\d+$/, '')}</option>
                 ))}
               </select>
-            </div>
+            </FormField>
           </div>
 
           {/* Context Preview (collapsed) */}

--- a/client/src/components/digital-twin/ListEnrichment.jsx
+++ b/client/src/components/digital-twin/ListEnrichment.jsx
@@ -12,6 +12,7 @@ import {ArrowLeft,
 import * as api from '../../services/api';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
+import { FormField } from '../ui/FormField';
 
 import { ENRICHMENT_CATEGORIES } from './constants';
 
@@ -199,10 +200,10 @@ export default function ListEnrichment({
               )}
 
               <div className="space-y-3">
-                <div>
-                  <label className="text-xs text-gray-500 uppercase tracking-wider mb-1 block">
-                    {config?.itemLabel} {index + 1}
-                  </label>
+                <FormField
+                  label={<>{config?.itemLabel} {index + 1}</>}
+                  labelClassName="text-xs text-gray-500 uppercase tracking-wider mb-1 block"
+                >
                   <input
                     type="text"
                     value={item.title}
@@ -210,12 +211,12 @@ export default function ListEnrichment({
                     placeholder={config?.itemPlaceholder}
                     className="w-full px-3 py-2.5 bg-port-card border border-port-border rounded-lg text-white focus:outline-hidden focus:border-port-accent"
                   />
-                </div>
+                </FormField>
 
-                <div>
-                  <label className="text-xs text-gray-500 uppercase tracking-wider mb-1 block">
-                    Notes (optional)
-                  </label>
+                <FormField
+                  label="Notes (optional)"
+                  labelClassName="text-xs text-gray-500 uppercase tracking-wider mb-1 block"
+                >
                   <textarea
                     value={item.note}
                     onChange={(e) => updateItem(index, 'note', e.target.value)}
@@ -223,7 +224,7 @@ export default function ListEnrichment({
                     rows={2}
                     className="w-full px-3 py-2.5 bg-port-card border border-port-border rounded-lg text-white resize-none focus:outline-hidden focus:border-port-accent"
                   />
-                </div>
+                </FormField>
               </div>
             </div>
           ))}
@@ -241,10 +242,11 @@ export default function ListEnrichment({
       {/* Provider Selection & Analyze Button */}
       <div className="bg-port-card rounded-lg border border-port-border p-4 sm:p-6 mb-6">
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-4">
-          <div className="flex-1">
-            <label className="text-xs text-gray-500 uppercase tracking-wider mb-2 block">
-              Analyze with
-            </label>
+          <FormField
+            label="Analyze with"
+            className="flex-1"
+            labelClassName="text-xs text-gray-500 uppercase tracking-wider mb-2 block"
+          >
             <select
               value={selectedProvider ? `${selectedProvider.providerId}:${selectedProvider.model}` : ''}
               onChange={(e) => {
@@ -261,7 +263,7 @@ export default function ListEnrichment({
                 ))
               ))}
             </select>
-          </div>
+          </FormField>
 
           <button
             onClick={analyzeList}

--- a/client/src/components/digital-twin/SoulWizard.jsx
+++ b/client/src/components/digital-twin/SoulWizard.jsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import * as api from '../../services/api';
 import toast from '../ui/Toast';
+import { FormField } from '../ui/FormField';
 
 const WIZARD_STEPS = [
   {
@@ -202,8 +203,7 @@ ${boundaries.irritant ? `- **Pet Peeve**: ${boundaries.irritant}` : ''}
       {/* Fields */}
       <div className="space-y-4 mb-6">
         {step.fields.map(field => (
-          <div key={field.id}>
-            <label className="block text-sm text-gray-400 mb-1">{field.label}</label>
+          <FormField key={field.id} label={field.label}>
             <input
               type={field.type}
               value={formData[step.id]?.[field.id] || ''}
@@ -211,7 +211,7 @@ ${boundaries.irritant ? `- **Pet Peeve**: ${boundaries.irritant}` : ''}
               placeholder={field.placeholder}
               className="w-full px-4 py-3 min-h-[44px] bg-port-bg border border-port-border rounded-lg text-white placeholder-gray-500 focus:outline-hidden focus:border-port-accent"
             />
-          </div>
+          </FormField>
         ))}
       </div>
 

--- a/client/src/components/digital-twin/tabs/AccountsTab.jsx
+++ b/client/src/components/digital-twin/tabs/AccountsTab.jsx
@@ -24,6 +24,7 @@ import {
 } from 'lucide-react';
 import BrailleSpinner from '../../BrailleSpinner';
 import InlineConfirmRow from '../../ui/InlineConfirmRow';
+import { FormField } from '../../ui/FormField';
 import * as api from '../../../services/api';
 import toast from '../../ui/Toast';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
@@ -306,10 +307,7 @@ export default function AccountsTab() {
 
           {/* Username and Display Name */}
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs text-gray-500 mb-1">
-                Username / Handle *
-              </label>
+            <FormField label="Username / Handle *" labelClassName="block text-xs text-gray-500 mb-1">
               <input
                 type="text"
                 value={form.username}
@@ -317,9 +315,8 @@ export default function AccountsTab() {
                 placeholder={selectedPlatformDef ? `Your ${selectedPlatformDef.label} username` : 'username'}
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:outline-hidden focus:border-port-accent min-h-[40px]"
               />
-            </div>
-            <div>
-              <label className="block text-xs text-gray-500 mb-1">Display Name</label>
+            </FormField>
+            <FormField label="Display Name" labelClassName="block text-xs text-gray-500 mb-1">
               <input
                 type="text"
                 value={form.displayName}
@@ -327,12 +324,11 @@ export default function AccountsTab() {
                 placeholder="Optional display name"
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:outline-hidden focus:border-port-accent min-h-[40px]"
               />
-            </div>
+            </FormField>
           </div>
 
           {/* URL */}
-          <div>
-            <label className="block text-xs text-gray-500 mb-1">Profile URL</label>
+          <FormField label="Profile URL" labelClassName="block text-xs text-gray-500 mb-1">
             <input
               type="url"
               value={form.url}
@@ -340,11 +336,10 @@ export default function AccountsTab() {
               placeholder={selectedPlatformDef?.urlTemplate?.replace('{username}', form.username || 'username') || 'https://...'}
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:outline-hidden focus:border-port-accent min-h-[40px]"
             />
-          </div>
+          </FormField>
 
           {/* Bio */}
-          <div>
-            <label className="block text-xs text-gray-500 mb-1">Bio / Description</label>
+          <FormField label="Bio / Description" labelClassName="block text-xs text-gray-500 mb-1">
             <textarea
               value={form.bio}
               onChange={e => setForm(prev => ({ ...prev, bio: e.target.value }))}
@@ -352,11 +347,10 @@ export default function AccountsTab() {
               rows={2}
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:outline-hidden focus:border-port-accent resize-y"
             />
-          </div>
+          </FormField>
 
           {/* Notes */}
-          <div>
-            <label className="block text-xs text-gray-500 mb-1">Notes</label>
+          <FormField label="Notes" labelClassName="block text-xs text-gray-500 mb-1">
             <textarea
               value={form.notes}
               onChange={e => setForm(prev => ({ ...prev, notes: e.target.value }))}
@@ -364,7 +358,7 @@ export default function AccountsTab() {
               rows={2}
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:outline-hidden focus:border-port-accent resize-y"
             />
-          </div>
+          </FormField>
 
           {/* Ingestion toggle */}
           <div className="flex items-center gap-3">

--- a/client/src/components/digital-twin/tabs/DocumentsTab.jsx
+++ b/client/src/components/digital-twin/tabs/DocumentsTab.jsx
@@ -14,6 +14,7 @@ import {
 import * as api from '../../../services/api';
 import toast from '../../ui/Toast';
 import Modal from '../../ui/Modal';
+import { FormField } from '../../ui/FormField';
 
 import { DOCUMENT_CATEGORIES } from '../constants';
 import { timeAgo } from '../../../utils/formatters';
@@ -324,8 +325,7 @@ export default function DocumentsTab({ onRefresh }) {
         <h2 className="text-lg font-semibold text-white mb-4">Create Soul Document</h2>
 
         <div className="space-y-4">
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">Filename</label>
+          <FormField label="Filename">
             <input
               type="text"
               value={newDoc.filename}
@@ -333,10 +333,9 @@ export default function DocumentsTab({ onRefresh }) {
               placeholder="DOCUMENT_NAME.md"
               className="w-full px-3 py-3 min-h-[44px] bg-port-bg border border-port-border rounded-lg text-white"
             />
-          </div>
+          </FormField>
 
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">Title</label>
+          <FormField label="Title">
             <input
               type="text"
               value={newDoc.title}
@@ -344,10 +343,9 @@ export default function DocumentsTab({ onRefresh }) {
               placeholder="Document title"
               className="w-full px-3 py-3 min-h-[44px] bg-port-bg border border-port-border rounded-lg text-white"
             />
-          </div>
+          </FormField>
 
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">Category</label>
+          <FormField label="Category">
             <select
               value={newDoc.category}
               onChange={(e) => setNewDoc({ ...newDoc, category: e.target.value })}
@@ -357,10 +355,9 @@ export default function DocumentsTab({ onRefresh }) {
                 <option key={key} value={key}>{config.label}</option>
               ))}
             </select>
-          </div>
+          </FormField>
 
-          <div>
-            <label className="block text-sm text-gray-400 mb-1">Content</label>
+          <FormField label="Content">
             <textarea
               value={newDoc.content}
               onChange={(e) => setNewDoc({ ...newDoc, content: e.target.value })}
@@ -368,7 +365,7 @@ export default function DocumentsTab({ onRefresh }) {
               rows={8}
               className="w-full px-3 py-3 bg-port-bg border border-port-border rounded-lg text-white font-mono text-sm"
             />
-          </div>
+          </FormField>
         </div>
 
         <div className="flex flex-col-reverse sm:flex-row justify-end gap-3 mt-6">

--- a/client/src/components/digital-twin/tabs/EnrichTab.jsx
+++ b/client/src/components/digital-twin/tabs/EnrichTab.jsx
@@ -13,6 +13,7 @@ import {Sparkles,
 import BrailleSpinner from '../../BrailleSpinner';
 import * as api from '../../../services/api';
 import toast from '../../ui/Toast';
+import { FormField } from '../../ui/FormField';
 
 import { ENRICHMENT_CATEGORIES } from '../constants';
 import ListEnrichment from '../ListEnrichment';
@@ -542,8 +543,7 @@ export default function EnrichTab({ onRefresh }) {
             </p>
 
             {/* Provider Selection */}
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4">
-              <label className="text-sm text-gray-400">Analyze with:</label>
+            <FormField className="flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4" labelClassName="text-sm text-gray-400" label="Analyze with:">
               <select
                 value={selectedProvider ? `${selectedProvider.providerId}:${selectedProvider.model}` : ''}
                 onChange={(e) => {
@@ -560,7 +560,7 @@ export default function EnrichTab({ onRefresh }) {
                   ))
                 ))}
               </select>
-            </div>
+            </FormField>
 
             {/* Writing Samples */}
             <div className="space-y-3">

--- a/client/src/components/digital-twin/tabs/GoalsTab.jsx
+++ b/client/src/components/digital-twin/tabs/GoalsTab.jsx
@@ -4,6 +4,7 @@ import {Target, Plus, Trash2, Check, ChevronDown, ChevronUp,
   Clock, AlertTriangle, Activity, Milestone} from 'lucide-react';
 import BrailleSpinner from '../../BrailleSpinner';
 import InlineConfirmRow from '../../ui/InlineConfirmRow';
+import { FormField } from '../../ui/FormField';
 import * as api from '../../../services/api';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
 
@@ -283,8 +284,7 @@ export default function GoalsTab({ onRefresh }) {
               className="w-full bg-port-card border border-port-border rounded px-3 py-2 text-sm text-white placeholder-gray-500 resize-none"
             />
             <div className="flex gap-3">
-              <div className="flex-1">
-                <label className="block text-xs text-gray-500 mb-1">Horizon</label>
+              <FormField className="flex-1" label="Horizon" labelClassName="block text-xs text-gray-500 mb-1">
                 <select
                   value={newGoal.horizon}
                   onChange={e => setNewGoal({ ...newGoal, horizon: e.target.value })}
@@ -294,9 +294,8 @@ export default function GoalsTab({ onRefresh }) {
                     <option key={h.value} value={h.value}>{h.label}</option>
                   ))}
                 </select>
-              </div>
-              <div className="flex-1">
-                <label className="block text-xs text-gray-500 mb-1">Category</label>
+              </FormField>
+              <FormField className="flex-1" label="Category" labelClassName="block text-xs text-gray-500 mb-1">
                 <select
                   value={newGoal.category}
                   onChange={e => setNewGoal({ ...newGoal, category: e.target.value })}
@@ -306,7 +305,7 @@ export default function GoalsTab({ onRefresh }) {
                     <option key={key} value={key}>{cfg.label}</option>
                   ))}
                 </select>
-              </div>
+              </FormField>
             </div>
             <div className="flex gap-2">
               <button

--- a/client/src/components/digital-twin/tabs/ImportTab.jsx
+++ b/client/src/components/digital-twin/tabs/ImportTab.jsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import * as api from '../../../services/api';
 import toast from '../../ui/Toast';
+import { FormField } from '../../ui/FormField';
 import { formatBytes } from '../../../utils/formatters';
 
 const SOURCE_ICONS = {
@@ -235,10 +236,7 @@ export default function ImportTab() {
           </div>
 
           {/* Provider Selection */}
-          <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-400 mb-2">
-              Analysis Provider
-            </label>
+          <FormField className="mb-6" label="Analysis Provider" labelClassName="block text-sm font-medium text-gray-400 mb-2">
             <select
               value={selectedProvider ? `${selectedProvider.providerId}:${selectedProvider.model}` : ''}
               onChange={(e) => {
@@ -255,7 +253,7 @@ export default function ImportTab() {
                 ))
               ))}
             </select>
-          </div>
+          </FormField>
 
           {/* Analyze Button */}
           <button

--- a/client/src/components/digital-twin/tabs/OverviewTab.jsx
+++ b/client/src/components/digital-twin/tabs/OverviewTab.jsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react';
 import * as api from '../../../services/api';
 import toast from '../../ui/Toast';
+import { FormField } from '../../ui/FormField';
 
 import {
   DOCUMENT_CATEGORIES,
@@ -267,15 +268,14 @@ export default function OverviewTab({ status, settings, onRefresh }) {
                 />
                 <span className="text-white">Auto-inject soul context into CoS agents</span>
               </label>
-              <div>
-                <label className="block text-sm text-gray-400 mb-2">Max context tokens</label>
+              <FormField labelClassName="block text-sm text-gray-400 mb-2" label="Max context tokens">
                 <input
                   type="number"
                   value={settingsForm.maxContextTokens || 4000}
                   onChange={(e) => setSettingsForm({ ...settingsForm, maxContextTokens: parseInt(e.target.value, 10) })}
                   className="w-32 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white"
                 />
-              </div>
+              </FormField>
               <button
                 onClick={handleSaveSettings}
                 disabled={saving}

--- a/client/src/components/goals/GoalEditForm.jsx
+++ b/client/src/components/goals/GoalEditForm.jsx
@@ -1,5 +1,6 @@
 import { X } from 'lucide-react';
 import Pill from '../ui/Pill';
+import { FormField } from '../ui/FormField';
 import { CATEGORY_CONFIG, HORIZON_OPTIONS, GOAL_TYPE_OPTIONS, MAX_TAGS } from './goalConstants';
 
 export default function GoalEditForm({
@@ -20,8 +21,7 @@ export default function GoalEditForm({
         rows={3}
         className="w-full bg-port-bg border border-port-border rounded px-3 py-1.5 text-sm text-white resize-none"
       />
-      <div>
-        <label className="text-xs text-gray-500">Horizon</label>
+      <FormField label="Horizon" labelClassName="text-xs text-gray-500">
         <select
           value={form.horizon}
           onChange={e => setForm({ ...form, horizon: e.target.value })}
@@ -29,9 +29,8 @@ export default function GoalEditForm({
         >
           {HORIZON_OPTIONS.map(h => <option key={h.value} value={h.value}>{h.label}</option>)}
         </select>
-      </div>
-      <div>
-        <label className="text-xs text-gray-500">Category</label>
+      </FormField>
+      <FormField label="Category" labelClassName="text-xs text-gray-500">
         <select
           value={form.category}
           onChange={e => setForm({ ...form, category: e.target.value })}
@@ -41,9 +40,8 @@ export default function GoalEditForm({
             <option key={k} value={k}>{v.label}</option>
           ))}
         </select>
-      </div>
-      <div>
-        <label className="text-xs text-gray-500">Goal Type</label>
+      </FormField>
+      <FormField label="Goal Type" labelClassName="text-xs text-gray-500">
         <select
           value={form.goalType || 'standard'}
           onChange={e => setForm({ ...form, goalType: e.target.value })}
@@ -51,9 +49,8 @@ export default function GoalEditForm({
         >
           {GOAL_TYPE_OPTIONS.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
         </select>
-      </div>
-      <div>
-        <label className="text-xs text-gray-500">Parent Goal</label>
+      </FormField>
+      <FormField label="Parent Goal" labelClassName="text-xs text-gray-500">
         <select
           value={form.parentId}
           onChange={e => setForm({ ...form, parentId: e.target.value })}
@@ -64,16 +61,15 @@ export default function GoalEditForm({
             <option key={g.id} value={g.id}>{g.title}</option>
           ))}
         </select>
-      </div>
-      <div>
-        <label className="text-xs text-gray-500">Target Date</label>
+      </FormField>
+      <FormField label="Target Date" labelClassName="text-xs text-gray-500">
         <input
           type="date"
           value={form.targetDate || ''}
           onChange={e => setForm({ ...form, targetDate: e.target.value })}
           className="w-full bg-port-bg border border-port-border rounded px-3 py-1.5 text-sm text-white mt-1"
         />
-      </div>
+      </FormField>
       <div>
         <label className="text-xs text-gray-500">Time Block Config</label>
         <div className="mt-1 space-y-2">

--- a/client/src/components/imageGen/ImageGenControls.jsx
+++ b/client/src/components/imageGen/ImageGenControls.jsx
@@ -14,6 +14,7 @@ import { randomSeed } from '../../lib/genUtils';
 import { RUNNER_FAMILIES } from '../../lib/runnerFamilies';
 import { IMAGE_GEN_MODE } from '../../lib/imageGenBackends';
 import ModelDownloadBadge, { deriveSizeEstimate } from '../media/ModelDownloadBadge';
+import { FormField } from '../ui/FormField';
 
 const QUANTIZE_OPTIONS = [
   { value: '3', label: '3-bit' },
@@ -70,8 +71,7 @@ export default function ImageGenControls({
   return (
     <div className={className}>
       {showModel && isLocal && models.length > 0 && (
-        <div>
-          <label className="block text-xs font-medium text-gray-400 mb-1">Model</label>
+        <FormField label="Model" labelClassName="block text-xs font-medium text-gray-400 mb-1">
           <select
             value={modelId || ''}
             onChange={(e) => onModelChange?.(e.target.value)}
@@ -88,11 +88,10 @@ export default function ImageGenControls({
               estimateLabel={deriveSizeEstimate(currentModel?.name)}
             />
           )}
-        </div>
+        </FormField>
       )}
 
-      <div>
-        <label className="block text-xs font-medium text-gray-400 mb-1">Resolution</label>
+      <FormField label="Resolution" labelClassName="block text-xs font-medium text-gray-400 mb-1">
         <select
           value={resolutionLabel}
           onChange={handleResolution}
@@ -102,7 +101,7 @@ export default function ImageGenControls({
           {availableResolutions.map((r) => <option key={r.label} value={r.label}>{r.label}</option>)}
           {!matched && resolutionLabel && <option value={resolutionLabel}>{resolutionLabel} (custom)</option>}
         </select>
-      </div>
+      </FormField>
 
       {/* Codex's image_gen tool ignores seed/steps/guidance — only resolution
           is honored, so the rest of the knobs are hidden in that mode. */}
@@ -132,10 +131,10 @@ export default function ImageGenControls({
       )}
 
       {!isCodex && (
-        <div>
-          <label className="block text-xs font-medium text-gray-400 mb-1">
-            Steps {currentModel?.steps && `(default: ${currentModel.steps})`}
-          </label>
+        <FormField
+          label={<>Steps {currentModel?.steps && `(default: ${currentModel.steps})`}</>}
+          labelClassName="block text-xs font-medium text-gray-400 mb-1"
+        >
           <input
             type="number" min={1} max={150}
             value={steps ?? ''}
@@ -144,7 +143,7 @@ export default function ImageGenControls({
             disabled={disabled}
             className={inputCls}
           />
-        </div>
+        </FormField>
       )}
 
       {/* Step-wise distilled models (Flux Schnell, FLUX.2 Klein, Z-Image-Turbo)
@@ -152,10 +151,10 @@ export default function ImageGenControls({
           any guidance scale we pass and prints a warning. Hide the input for
           those models so the user doesn't waste a knob-turn on a no-op. */}
       {!isCodex && isLocal && !currentModel?.cfgDisabled && (
-        <div>
-          <label className="block text-xs font-medium text-gray-400 mb-1">
-            Guidance {currentModel?.guidance != null && `(default: ${currentModel.guidance})`}
-          </label>
+        <FormField
+          label={<>Guidance {currentModel?.guidance != null && `(default: ${currentModel.guidance})`}</>}
+          labelClassName="block text-xs font-medium text-gray-400 mb-1"
+        >
           <input
             type="number" min={0} max={20} step={0.5}
             value={guidance ?? ''}
@@ -164,12 +163,11 @@ export default function ImageGenControls({
             disabled={disabled}
             className={inputCls}
           />
-        </div>
+        </FormField>
       )}
 
       {!isCodex && isLocal && showQuantize && !isFlux2 && (
-        <div>
-          <label className="block text-xs font-medium text-gray-400 mb-1">Quantize (bits)</label>
+        <FormField label="Quantize (bits)" labelClassName="block text-xs font-medium text-gray-400 mb-1">
           <select
             value={quantize ?? '8'}
             onChange={(e) => onQuantizeChange?.(e.target.value)}
@@ -178,12 +176,14 @@ export default function ImageGenControls({
           >
             {QUANTIZE_OPTIONS.map((q) => <option key={q.value} value={q.value}>{q.label}</option>)}
           </select>
-        </div>
+        </FormField>
       )}
 
       {!isCodex && !isLocal && onCfgScaleChange && (
-        <div>
-          <label className="block text-xs font-medium text-gray-400 mb-1">CFG Scale ({cfgScale})</label>
+        <FormField
+          label={<>CFG Scale ({cfgScale})</>}
+          labelClassName="block text-xs font-medium text-gray-400 mb-1"
+        >
           <input
             type="range" min={1} max={20} step={0.5}
             value={cfgScale ?? 7}
@@ -191,7 +191,7 @@ export default function ImageGenControls({
             onChange={(e) => onCfgScaleChange?.(Number(e.target.value))}
             className="w-full accent-port-accent"
           />
-        </div>
+        </FormField>
       )}
     </div>
   );

--- a/client/src/components/meatspace/GenomeCategoryCard.jsx
+++ b/client/src/components/meatspace/GenomeCategoryCard.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import InlineConfirmRow from '../ui/InlineConfirmRow';
+import { FormField } from '../ui/FormField';
 import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 
 const STATUS_DOT = {
@@ -170,8 +171,7 @@ export default function GenomeCategoryCard({ category: _category, label, emoji, 
                       </div>
 
                       {/* Notes */}
-                      <div>
-                        <label className="text-[10px] font-medium text-gray-500 uppercase tracking-wide">Your Notes</label>
+                      <FormField labelClassName="text-[10px] font-medium text-gray-500 uppercase tracking-wide" label="Your Notes">
                         <textarea
                           value={marker.notes || ''}
                           onChange={(e) => onEditNotes(marker.id, e.target.value)}
@@ -179,7 +179,7 @@ export default function GenomeCategoryCard({ category: _category, label, emoji, 
                           rows={2}
                           className="w-full mt-1 p-2 bg-port-card border border-port-border rounded text-sm text-gray-300 placeholder-gray-600 resize-none focus:outline-hidden focus:border-port-accent"
                         />
-                      </div>
+                      </FormField>
 
                       {/* References */}
                       {marker.references?.length > 0 && (

--- a/client/src/components/meatspace/StandardDrinkCalculator.jsx
+++ b/client/src/components/meatspace/StandardDrinkCalculator.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Calculator } from 'lucide-react';
+import { FormField } from '../ui/FormField';
 
 export default function StandardDrinkCalculator() {
   const [oz, setOz] = useState('');
@@ -17,8 +18,7 @@ export default function StandardDrinkCalculator() {
         </h4>
       </div>
       <div className="flex items-end gap-3">
-        <div className="flex-1">
-          <label className="text-xs text-gray-500 block mb-1">Oz</label>
+        <FormField className="flex-1" label="Oz" labelClassName="text-xs text-gray-500 block mb-1">
           <input
             type="number"
             step="0.1"
@@ -28,10 +28,9 @@ export default function StandardDrinkCalculator() {
             placeholder="12"
             className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-sm text-white placeholder-gray-600"
           />
-        </div>
+        </FormField>
         <span className="text-gray-500 pb-1.5">@</span>
-        <div className="flex-1">
-          <label className="text-xs text-gray-500 block mb-1">ABV %</label>
+        <FormField className="flex-1" label="ABV %" labelClassName="text-xs text-gray-500 block mb-1">
           <input
             type="number"
             step="0.1"
@@ -42,7 +41,7 @@ export default function StandardDrinkCalculator() {
             placeholder="5"
             className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-sm text-white placeholder-gray-600"
           />
-        </div>
+        </FormField>
         <span className="text-gray-500 pb-1.5">=</span>
         <div className="text-center pb-1">
           <span className="text-xs text-gray-500 block">Std drinks</span>

--- a/client/src/components/meatspace/post/MemoryBuilder.jsx
+++ b/client/src/components/meatspace/post/MemoryBuilder.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Brain, ChevronLeft, Plus, Trash2, BookOpen, Zap, FlaskConical, Eye, X, Save, CalendarClock } from 'lucide-react';
 import { getMemoryItems, createMemoryItem, deleteMemoryItem } from '../../../services/api';
 import ConfirmButtonPair from '../../ui/ConfirmButtonPair';
+import { FormField } from '../../ui/FormField';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
 import MemoryPractice from './MemoryPractice';
 import ElementsSong from './ElementsSong';
@@ -202,8 +203,7 @@ export default function MemoryBuilder({ onBack, onNavigateElements }) {
             </button>
           </div>
 
-          <div>
-            <label className="block text-gray-400 text-xs mb-1.5">Title</label>
+          <FormField label="Title" labelClassName="block text-gray-400 text-xs mb-1.5">
             <input
               type="text"
               value={newTitle}
@@ -212,7 +212,7 @@ export default function MemoryBuilder({ onBack, onNavigateElements }) {
               maxLength={200}
               className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-white text-sm placeholder-gray-600 focus:border-port-accent focus:outline-none"
             />
-          </div>
+          </FormField>
 
           <div>
             <label className="block text-gray-400 text-xs mb-1.5">Type</label>
@@ -233,10 +233,10 @@ export default function MemoryBuilder({ onBack, onNavigateElements }) {
             </div>
           </div>
 
-          <div>
-            <label className="block text-gray-400 text-xs mb-1.5">
-              Content <span className="text-gray-600">(one line per row; blank lines create chunk boundaries)</span>
-            </label>
+          <FormField
+            label={<>Content <span className="text-gray-600">(one line per row; blank lines create chunk boundaries)</span></>}
+            labelClassName="block text-gray-400 text-xs mb-1.5"
+          >
             <textarea
               value={newContent}
               onChange={e => setNewContent(e.target.value)}
@@ -247,7 +247,7 @@ export default function MemoryBuilder({ onBack, onNavigateElements }) {
             {newContent.trim() && (
               <ContentPreview content={newContent} />
             )}
-          </div>
+          </FormField>
 
           <div className="flex justify-end gap-3">
             <button

--- a/client/src/components/meatspace/post/PostSessionLauncher.jsx
+++ b/client/src/components/meatspace/post/PostSessionLauncher.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Zap, History, Settings, Play, Brain, BookOpen, Dumbbell, Timer, Radio, Target, TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import { getProviders } from '../../../services/api';
+import { FormField } from '../../ui/FormField';
 import { isApiProvider } from '../../../utils/providers';
 import { DOMAINS, DRILL_TO_DOMAIN, DRILL_LABELS, computeDomainAverages } from './constants';
 
@@ -400,8 +401,7 @@ export default function PostSessionLauncher({ config, recentSessions, stats, sta
             <h3 className="text-sm font-medium text-gray-400 mb-3">Conditions (optional)</h3>
             <div className="grid grid-cols-3 gap-3">
               {Object.entries(tags).map(([key, value]) => (
-                <div key={key}>
-                  <label className="text-xs text-gray-500 mb-1 block capitalize">{key}</label>
+                <FormField key={key} labelClassName="text-xs text-gray-500 mb-1 block capitalize" label={key}>
                   <input
                     type="text"
                     value={value}
@@ -409,7 +409,7 @@ export default function PostSessionLauncher({ config, recentSessions, stats, sta
                     placeholder={key === 'sleep' ? 'good/poor' : key === 'caffeine' ? '1 cup' : 'low/high'}
                     className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm text-white placeholder-gray-600 focus:border-port-accent focus:outline-none"
                   />
-                </div>
+                </FormField>
               ))}
             </div>
           </div>}

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -4,6 +4,7 @@ import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
 import BrailleSpinner from '../../BrailleSpinner';
 import ConfirmButtonPair from '../../ui/ConfirmButtonPair';
+import { FormField } from '../../ui/FormField';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
 import AlcoholChart from '../AlcoholChart';
 import AlcoholHrvCorrelation from '../AlcoholHrvCorrelation';
@@ -462,8 +463,7 @@ export default function AlcoholTab() {
 
         {/* Custom entry form */}
         <form onSubmit={handleCustomAdd} className="grid grid-cols-2 sm:grid-cols-[1fr_5rem_5rem_4rem_9rem_auto] items-end gap-3">
-          <div className="col-span-2 sm:col-span-1">
-            <label className="text-xs text-gray-500 block mb-1">Name (optional)</label>
+          <FormField className="col-span-2 sm:col-span-1" label="Name (optional)" labelClassName="text-xs text-gray-500 block mb-1">
             <input
               type="text"
               value={name}
@@ -471,7 +471,7 @@ export default function AlcoholTab() {
               placeholder="e.g., Hazy IPA"
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-sm text-white placeholder-gray-600"
             />
-          </div>
+          </FormField>
           <div>
             <div className="flex items-center gap-1.5 mb-1">
               <label className="text-xs text-gray-500">Volume</label>
@@ -494,8 +494,7 @@ export default function AlcoholTab() {
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-sm text-white placeholder-gray-600"
             />
           </div>
-          <div>
-            <label className="text-xs text-gray-500 block mb-1">ABV %</label>
+          <FormField label="ABV %" labelClassName="text-xs text-gray-500 block mb-1">
             <input
               type="number"
               step="0.1"
@@ -507,9 +506,8 @@ export default function AlcoholTab() {
               placeholder="5"
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-sm text-white placeholder-gray-600"
             />
-          </div>
-          <div>
-            <label className="text-xs text-gray-500 block mb-1">Count</label>
+          </FormField>
+          <FormField label="Count" labelClassName="text-xs text-gray-500 block mb-1">
             <input
               type="number"
               min="1"
@@ -518,16 +516,15 @@ export default function AlcoholTab() {
               onChange={e => setCount(parseInt(e.target.value) || 1)}
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-sm text-white"
             />
-          </div>
-          <div>
-            <label className="text-xs text-gray-500 block mb-1">Date</label>
+          </FormField>
+          <FormField label="Date" labelClassName="text-xs text-gray-500 block mb-1">
             <input
               type="date"
               value={date}
               onChange={e => setDate(e.target.value)}
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-sm text-white"
             />
-          </div>
+          </FormField>
           <button
             type="submit"
             disabled={logging || !oz || !abv}

--- a/client/src/components/meatspace/tabs/calendar/AddActivityForm.jsx
+++ b/client/src/components/meatspace/tabs/calendar/AddActivityForm.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { Plus } from 'lucide-react';
 import { ICON_MAP, IconForName } from './icons';
+import { FormField } from '../../../ui/FormField';
 
 export default function AddActivityForm({ onAdd }) {
   const [open, setOpen] = useState(false);
@@ -36,8 +37,7 @@ export default function AddActivityForm({ onAdd }) {
   return (
     <form onSubmit={handleSubmit} className="bg-port-card border border-port-border rounded-lg p-4 space-y-3">
       <div className="grid grid-cols-2 gap-3">
-        <div>
-          <label className="text-xs text-gray-400 mb-1 block">Name</label>
+        <FormField label="Name" labelClassName="text-xs text-gray-400 mb-1 block">
           <input
             type="text"
             value={name}
@@ -46,7 +46,7 @@ export default function AddActivityForm({ onAdd }) {
             className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-sm text-white focus:border-port-accent focus:outline-hidden"
             autoFocus
           />
-        </div>
+        </FormField>
         <div>
           <label className="text-xs text-gray-400 mb-1 block">Icon</label>
           <div className="flex gap-1 flex-wrap">
@@ -64,8 +64,7 @@ export default function AddActivityForm({ onAdd }) {
         </div>
       </div>
       <div className="grid grid-cols-2 gap-3">
-        <div>
-          <label className="text-xs text-gray-400 mb-1 block">Frequency</label>
+        <FormField label="Frequency" labelClassName="text-xs text-gray-400 mb-1 block">
           <input
             type="number"
             value={frequency}
@@ -74,9 +73,8 @@ export default function AddActivityForm({ onAdd }) {
             step="0.5"
             className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-sm text-white focus:border-port-accent focus:outline-hidden"
           />
-        </div>
-        <div>
-          <label className="text-xs text-gray-400 mb-1 block">Cadence</label>
+        </FormField>
+        <FormField label="Cadence" labelClassName="text-xs text-gray-400 mb-1 block">
           <select
             value={cadence}
             onChange={(e) => setCadence(e.target.value)}
@@ -87,7 +85,7 @@ export default function AddActivityForm({ onAdd }) {
             <option value="month">Per Month</option>
             <option value="year">Per Year</option>
           </select>
-        </div>
+        </FormField>
       </div>
       <div className="flex gap-2">
         <button type="submit" className="px-3 py-1.5 bg-port-accent text-white text-sm rounded hover:bg-port-accent/80 transition-colors">

--- a/client/src/components/meatspace/tabs/calendar/LifeEventsPanel.jsx
+++ b/client/src/components/meatspace/tabs/calendar/LifeEventsPanel.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { Calendar, Plus, Trash2, Eye, EyeOff, ChevronDown } from 'lucide-react';
+import { FormField } from '../../../ui/FormField';
 import { EVENT_TYPE_STYLES, EVENT_TYPES, MONTH_NAMES_FULL } from './lifeGridMath';
 
 export default function LifeEventsPanel({ events, onAdd, onToggle, onRemove }) {
@@ -96,8 +97,7 @@ export default function LifeEventsPanel({ events, onAdd, onToggle, onRemove }) {
           {adding ? (
             <form onSubmit={handleSubmit} className="bg-port-bg border border-port-border rounded-lg p-3 space-y-3">
               <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="text-xs text-gray-400 mb-1 block">Name</label>
+                <FormField label="Name" labelClassName="text-xs text-gray-400 mb-1 block">
                   <input
                     type="text"
                     value={name}
@@ -106,9 +106,8 @@ export default function LifeEventsPanel({ events, onAdd, onToggle, onRemove }) {
                     className="w-full px-2 py-1.5 bg-port-card border border-port-border rounded text-sm text-white focus:border-port-accent focus:outline-hidden"
                     autoFocus
                   />
-                </div>
-                <div>
-                  <label className="text-xs text-gray-400 mb-1 block">Type</label>
+                </FormField>
+                <FormField label="Type" labelClassName="text-xs text-gray-400 mb-1 block">
                   <select
                     value={type}
                     onChange={e => setType(e.target.value)}
@@ -118,11 +117,10 @@ export default function LifeEventsPanel({ events, onAdd, onToggle, onRemove }) {
                       <option key={t.id} value={t.id}>{t.label}</option>
                     ))}
                   </select>
-                </div>
+                </FormField>
               </div>
               <div className="grid grid-cols-2 gap-3">
-                <div>
-                  <label className="text-xs text-gray-400 mb-1 block">Recurrence</label>
+                <FormField label="Recurrence" labelClassName="text-xs text-gray-400 mb-1 block">
                   <select
                     value={recurrence}
                     onChange={e => setRecurrence(e.target.value)}
@@ -131,11 +129,10 @@ export default function LifeEventsPanel({ events, onAdd, onToggle, onRemove }) {
                     <option value="yearly">Yearly</option>
                     <option value="once">One-time</option>
                   </select>
-                </div>
+                </FormField>
                 {recurrence === 'yearly' ? (
                   <div className="flex gap-2">
-                    <div className="flex-1">
-                      <label className="text-xs text-gray-400 mb-1 block">Month</label>
+                    <FormField className="flex-1" label="Month" labelClassName="text-xs text-gray-400 mb-1 block">
                       <select
                         value={month}
                         onChange={e => setMonth(parseInt(e.target.value))}
@@ -145,9 +142,8 @@ export default function LifeEventsPanel({ events, onAdd, onToggle, onRemove }) {
                           <option key={i} value={i}>{m}</option>
                         ))}
                       </select>
-                    </div>
-                    <div className="w-16">
-                      <label className="text-xs text-gray-400 mb-1 block">Day</label>
+                    </FormField>
+                    <FormField className="w-16" label="Day" labelClassName="text-xs text-gray-400 mb-1 block">
                       <input
                         type="number"
                         value={day}
@@ -156,18 +152,17 @@ export default function LifeEventsPanel({ events, onAdd, onToggle, onRemove }) {
                         max="31"
                         className="w-full px-2 py-1.5 bg-port-card border border-port-border rounded text-sm text-white focus:border-port-accent focus:outline-hidden"
                       />
-                    </div>
+                    </FormField>
                   </div>
                 ) : (
-                  <div>
-                    <label className="text-xs text-gray-400 mb-1 block">Date</label>
+                  <FormField label="Date" labelClassName="text-xs text-gray-400 mb-1 block">
                     <input
                       type="date"
                       value={date}
                       onChange={e => setDate(e.target.value)}
                       className="w-full px-2 py-1.5 bg-port-card border border-port-border rounded text-sm text-white focus:border-port-accent focus:outline-hidden"
                     />
-                  </div>
+                  </FormField>
                 )}
               </div>
               <div className="flex gap-2">

--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useCallback, useEffect, useRef } from 'react';
 import { ListOrdered, Image as ImageIcon, Film, Cpu, X, RefreshCw, ChevronDown, ChevronRight, Trash2, RotateCw, Zap, Pencil } from 'lucide-react';
 import toast from '../ui/Toast';
 import ConfirmButtonPair from '../ui/ConfirmButtonPair';
+import { FormField } from '../ui/FormField';
 import { listMediaJobs, cancelMediaJob, cancelQueuedMediaJobs, deleteMediaJob, retryMediaJob, runMediaJobNow } from '../../services/apiMediaJobs.js';
 import { listLoraTrainingCheckpoints } from '../../services/apiLoraTraining.js';
 import { IMAGE_GEN_MODE } from '../../lib/imageGenBackends';
@@ -470,25 +471,26 @@ function EditRetryForm({ job, onSubmit, onCancel }) {
 
   return (
     <form onSubmit={submit} className="mt-3 pt-3 border-t border-port-border space-y-2">
-      <label className="block text-[10px] uppercase tracking-wide text-port-text-muted">Prompt</label>
-      <textarea
-        value={prompt}
-        onChange={(e) => setPrompt(e.target.value)}
-        rows={3}
-        className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-xs"
-        maxLength={8000}
-      />
-      <label className="block text-[10px] uppercase tracking-wide text-port-text-muted">Negative prompt</label>
-      <textarea
-        value={negativePrompt}
-        onChange={(e) => setNegativePrompt(e.target.value)}
-        rows={2}
-        className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-xs"
-        maxLength={8000}
-      />
+      <FormField label="Prompt" labelClassName="block text-[10px] uppercase tracking-wide text-port-text-muted">
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          rows={3}
+          className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-xs"
+          maxLength={8000}
+        />
+      </FormField>
+      <FormField label="Negative prompt" labelClassName="block text-[10px] uppercase tracking-wide text-port-text-muted">
+        <textarea
+          value={negativePrompt}
+          onChange={(e) => setNegativePrompt(e.target.value)}
+          rows={2}
+          className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-xs"
+          maxLength={8000}
+        />
+      </FormField>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-        <div className="col-span-2">
-          <label className="block text-[10px] uppercase tracking-wide text-port-text-muted">{isCodex ? 'Codex model' : 'Model id'}</label>
+        <FormField className="col-span-2" label={isCodex ? 'Codex model' : 'Model id'} labelClassName="block text-[10px] uppercase tracking-wide text-port-text-muted">
           <input
             type="text"
             value={isCodex ? model : modelId}
@@ -497,34 +499,31 @@ function EditRetryForm({ job, onSubmit, onCancel }) {
             className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-white text-xs"
             maxLength={200}
           />
-        </div>
-        <div>
-          <label className="block text-[10px] uppercase tracking-wide text-port-text-muted">Width</label>
+        </FormField>
+        <FormField label="Width" labelClassName="block text-[10px] uppercase tracking-wide text-port-text-muted">
           <input
             type="number" min={64} max={4096} step={8}
             value={width}
             onChange={(e) => setWidth(e.target.value)}
             className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-white text-xs"
           />
-        </div>
-        <div>
-          <label className="block text-[10px] uppercase tracking-wide text-port-text-muted">Height</label>
+        </FormField>
+        <FormField label="Height" labelClassName="block text-[10px] uppercase tracking-wide text-port-text-muted">
           <input
             type="number" min={64} max={4096} step={8}
             value={height}
             onChange={(e) => setHeight(e.target.value)}
             className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-white text-xs"
           />
-        </div>
-        <div>
-          <label className="block text-[10px] uppercase tracking-wide text-port-text-muted">Steps</label>
+        </FormField>
+        <FormField label="Steps" labelClassName="block text-[10px] uppercase tracking-wide text-port-text-muted">
           <input
             type="number" min={1} max={200} step={1}
             value={steps}
             onChange={(e) => setSteps(e.target.value)}
             className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-white text-xs"
           />
-        </div>
+        </FormField>
       </div>
       <div className="flex items-center justify-end gap-2 pt-1">
         <button

--- a/client/src/components/media/PromptRefineModal.jsx
+++ b/client/src/components/media/PromptRefineModal.jsx
@@ -3,6 +3,7 @@ import { ListPlus, Sparkles, Wand2, X } from 'lucide-react';
 import ProviderModelSelector from '../ProviderModelSelector';
 import toast from '../ui/Toast';
 import Modal from '../ui/Modal';
+import { FormField } from '../ui/FormField';
 import useProviderModels from '../../hooks/useProviderModels';
 import { generateImage, generateVideo, refineMediaPrompt } from '../../services/api';
 import { getRenderConfigForItem } from './normalize';
@@ -184,25 +185,23 @@ export default function PromptRefineModal({ item, open, onClose }) {
                 </p>
               )}
 
-              <div>
-                <label className="block text-[11px] uppercase tracking-wide text-gray-500 mb-1">New prompt</label>
+              <FormField label="New prompt" labelClassName="block text-[11px] uppercase tracking-wide text-gray-500 mb-1">
                 <textarea
                   value={refinedPrompt}
                   onChange={(e) => setRefinedPrompt(e.target.value)}
                   rows={6}
                   className="w-full bg-port-bg border border-port-border rounded-lg p-3 text-sm text-white focus:outline-none focus:border-port-accent resize-y"
                 />
-              </div>
+              </FormField>
 
-              <div>
-                <label className="block text-[11px] uppercase tracking-wide text-gray-500 mb-1">New negative prompt</label>
+              <FormField label="New negative prompt" labelClassName="block text-[11px] uppercase tracking-wide text-gray-500 mb-1">
                 <textarea
                   value={refinedNegative}
                   onChange={(e) => setRefinedNegative(e.target.value)}
                   rows={3}
                   className="w-full bg-port-bg border border-port-border rounded-lg p-3 text-sm text-white focus:outline-none focus:border-port-accent resize-y"
                 />
-              </div>
+              </FormField>
             </div>
           )}
         </div>

--- a/client/src/components/messages/SyncTab.jsx
+++ b/client/src/components/messages/SyncTab.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { RefreshCw, AlertCircle, Settings, Globe, Mail, MailOpen } from 'lucide-react';
 import toast from '../ui/Toast';
+import { FormField } from '../ui/FormField';
 import { formatDateTime } from '../../utils/formatters';
 import * as api from '../../services/api';
 import socket from '../../services/socket';
@@ -187,15 +188,14 @@ export default function SyncTab({ accounts, onRefresh }) {
             {editingSelector === provider ? (
               <div className="space-y-2">
                 {Object.entries(selectorForm).map(([key, val]) => (
-                  <div key={key} className="flex items-center gap-2">
-                    <label className="text-xs text-gray-500 w-32 shrink-0">{key}</label>
+                  <FormField key={key} className="flex items-center gap-2" labelClassName="text-xs text-gray-500 w-32 shrink-0" label={key}>
                     <input
                       type="text"
                       value={val}
                       onChange={(e) => setSelectorForm(f => ({ ...f, [key]: e.target.value }))}
                       className="flex-1 px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white font-mono focus:outline-none focus:border-port-accent"
                     />
-                  </div>
+                  </FormField>
                 ))}
                 <div className="flex gap-2 mt-2">
                   <button

--- a/client/src/components/writers-room/ExercisePanel.jsx
+++ b/client/src/components/writers-room/ExercisePanel.jsx
@@ -8,6 +8,7 @@ import {
   discardWritersRoomExercise,
 } from '../../services/apiWritersRoom';
 import { countWords, formatCountdown } from '../../utils/formatters';
+import { FormField } from '../ui/FormField';
 
 const DURATION_PRESETS = [
   { label: '5 min', seconds: 300 },
@@ -145,10 +146,10 @@ export default function ExercisePanel({ activeWork, onClose }) {
             </div>
           </div>
 
-          <div>
-            <label className="block text-[10px] uppercase tracking-wider text-gray-500 mb-1">
-              Prompt {activeWork && <span className="text-gray-600">(or leave blank to free-write {activeWork.title})</span>}
-            </label>
+          <FormField
+            labelClassName="block text-[10px] uppercase tracking-wider text-gray-500 mb-1"
+            label={<>Prompt {activeWork && <span className="text-gray-600">(or leave blank to free-write {activeWork.title})</span>}</>}
+          >
             <textarea
               value={prompt}
               onChange={(e) => setPrompt(e.target.value)}
@@ -156,7 +157,7 @@ export default function ExercisePanel({ activeWork, onClose }) {
               rows={2}
               className="w-full bg-port-bg border border-port-border rounded px-2 py-1 text-xs"
             />
-          </div>
+          </FormField>
 
           <button
             onClick={start}

--- a/client/src/components/writers-room/StagePromptModelPicker.jsx
+++ b/client/src/components/writers-room/StagePromptModelPicker.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import toast from '../ui/Toast';
 import ProviderModelSelector from '../ProviderModelSelector';
+import { FormField } from '../ui/FormField';
 import useFieldDraft from '../../hooks/useFieldDraft';
 import { filterSelectableModels, getProviderTimeout } from '../../utils/providers';
 import {
@@ -202,10 +203,11 @@ function StageTimeoutInput({ value, providerFallback, onCommit }) {
   }
 
   return (
-    <div className="space-y-0.5">
-      <label className="block text-[9px] uppercase tracking-wider text-gray-500">
-        Timeout override (ms)
-      </label>
+    <FormField
+      className="space-y-0.5"
+      labelClassName="block text-[9px] uppercase tracking-wider text-gray-500"
+      label="Timeout override (ms)"
+    >
       <input
         type="number"
         inputMode="numeric"
@@ -220,6 +222,6 @@ function StageTimeoutInput({ value, providerFallback, onCommit }) {
         className="w-full bg-port-bg border border-port-border rounded px-2 py-1 text-[11px] text-gray-200"
       />
       <div className="text-[10px] text-gray-500">{hint}</div>
-    </div>
+    </FormField>
   );
 }

--- a/client/src/pages/Browser.jsx
+++ b/client/src/pages/Browser.jsx
@@ -13,6 +13,7 @@ import {
   browserDownloadUrl, deleteBrowserDownload
 } from '../services/api';
 import toast from '../components/ui/Toast';
+import { FormField } from '../components/ui/FormField';
 import { formatBytes, formatDateTime } from '../utils/formatters';
 
 const POLL_INTERVAL = 5000;
@@ -193,33 +194,30 @@ export default function BrowserPage() {
         <div className="mb-6 p-4 bg-port-card border border-port-border rounded-xl">
           <h3 className="text-lg font-semibold text-white mb-4">Browser Configuration</h3>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-            <div>
-              <label className="block text-sm text-gray-400 mb-1">CDP Port</label>
+            <FormField label="CDP Port">
               <input
                 type="number"
                 value={configDraft.cdpPort}
                 onChange={e => setConfigDraft(d => ({ ...d, cdpPort: parseInt(e.target.value, 10) || 5556 }))}
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:outline-hidden focus:border-port-accent"
               />
-            </div>
-            <div>
-              <label className="block text-sm text-gray-400 mb-1">CDP Host</label>
+            </FormField>
+            <FormField label="CDP Host">
               <input
                 type="text"
                 value={configDraft.cdpHost}
                 onChange={e => setConfigDraft(d => ({ ...d, cdpHost: e.target.value }))}
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:outline-hidden focus:border-port-accent"
               />
-            </div>
-            <div>
-              <label className="block text-sm text-gray-400 mb-1">Health Port</label>
+            </FormField>
+            <FormField label="Health Port">
               <input
                 type="number"
                 value={configDraft.healthPort}
                 onChange={e => setConfigDraft(d => ({ ...d, healthPort: parseInt(e.target.value, 10) || 5557 }))}
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm focus:outline-hidden focus:border-port-accent"
               />
-            </div>
+            </FormField>
             <div className="flex items-center gap-2">
               <input
                 type="checkbox"

--- a/client/src/pages/ImageGen.jsx
+++ b/client/src/pages/ImageGen.jsx
@@ -27,6 +27,7 @@ import GalleryImagePicker from '../components/imageGen/GalleryImagePicker';
 import LoraPicker from '../components/imageGen/LoraPicker';
 import ReferenceImagePicker from '../components/imageGen/ReferenceImagePicker';
 import MediaJobsQueue from '../components/media/MediaJobsQueue';
+import { FormField } from '../components/ui/FormField';
 import { useMediaCompletionRefresh } from '../hooks/useMediaCompletionRefresh';
 import { useMediaAnnotations } from '../hooks/useMediaAnnotations';
 import { useAutoRefetch } from '../hooks/useAutoRefetch';
@@ -1105,8 +1106,7 @@ export default function ImageGen() {
             disabled={statusLoading}
           />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">Prompt</label>
+            <FormField label="Prompt" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <textarea
                 value={prompt}
                 onChange={(e) => setPrompt(e.target.value)}
@@ -1115,9 +1115,8 @@ export default function ImageGen() {
                 className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y"
                 placeholder="Describe the image you want to generate..."
               />
-            </div>
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">Negative Prompt</label>
+            </FormField>
+            <FormField label="Negative Prompt" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <textarea
                 value={negativePrompt}
                 onChange={(e) => setNegativePrompt(e.target.value)}
@@ -1126,7 +1125,7 @@ export default function ImageGen() {
                 className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y"
                 placeholder="What to avoid..."
               />
-            </div>
+            </FormField>
           </div>
 
           {flux2Issue === 'venv' && (

--- a/client/src/pages/Jira.jsx
+++ b/client/src/pages/Jira.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import toast from '../components/ui/Toast';
 import PageSkeleton from '../components/ui/PageSkeleton';
+import { FormField } from '../components/ui/FormField';
 import api from '../services/api';
 
 const TOKEN_LIFETIME_DAYS = 30;
@@ -243,10 +244,7 @@ export default function Jira() {
             )}
 
             <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">
-                  Instance ID
-                </label>
+              <FormField label="Instance ID" labelClassName="block text-sm font-medium text-gray-300 mb-1">
                 <input
                   type="text"
                   name="id"
@@ -259,12 +257,9 @@ export default function Jira() {
                 <p className="text-xs text-gray-400 mt-1">
                   Unique identifier (cannot be changed after creation)
                 </p>
-              </div>
+              </FormField>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">
-                  Display Name
-                </label>
+              <FormField label="Display Name" labelClassName="block text-sm font-medium text-gray-300 mb-1">
                 <input
                   type="text"
                   name="name"
@@ -273,12 +268,9 @@ export default function Jira() {
                   className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white"
                   placeholder="e.g., Company JIRA"
                 />
-              </div>
+              </FormField>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">
-                  Base URL
-                </label>
+              <FormField label="Base URL" labelClassName="block text-sm font-medium text-gray-300 mb-1">
                 <input
                   type="url"
                   name="baseUrl"
@@ -287,12 +279,9 @@ export default function Jira() {
                   className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white"
                   placeholder="https://jira.example.com"
                 />
-              </div>
+              </FormField>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">
-                  Email
-                </label>
+              <FormField label="Email" labelClassName="block text-sm font-medium text-gray-300 mb-1">
                 <input
                   type="email"
                   name="email"
@@ -301,12 +290,9 @@ export default function Jira() {
                   className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white"
                   placeholder="your.email@example.com"
                 />
-              </div>
+              </FormField>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">
-                  API Token (Personal Access Token)
-                </label>
+              <FormField label="API Token (Personal Access Token)" labelClassName="block text-sm font-medium text-gray-300 mb-1">
                 <input
                   type="password"
                   name="apiToken"
@@ -318,7 +304,7 @@ export default function Jira() {
                 <p className="text-xs text-gray-400 mt-1">
                   Generate this from your JIRA profile → Personal Access Tokens
                 </p>
-              </div>
+              </FormField>
 
               <div className="flex flex-col sm:flex-row gap-2">
                 <button

--- a/client/src/pages/Loops.jsx
+++ b/client/src/pages/Loops.jsx
@@ -6,6 +6,7 @@ import {
 import * as api from '../services/api';
 import socket from '../services/socket';
 import toast from '../components/ui/Toast';
+import { FormField } from '../components/ui/FormField';
 import { timeAgo } from '../components/feature-agents/constants';
 import { formatDurationMs } from '../utils/formatters';
 import BrailleSpinner from '../components/BrailleSpinner';
@@ -114,8 +115,7 @@ function CreateLoopForm({ providers, onCreated }) {
           </div>
         </div>
 
-        <div className="flex-1 min-w-[150px]">
-          <label className="block text-xs text-gray-400 mb-1">AI Provider</label>
+        <FormField className="flex-1 min-w-[150px]" label="AI Provider" labelClassName="block text-xs text-gray-400 mb-1">
           <select
             value={providerId}
             onChange={e => setProviderId(e.target.value)}
@@ -128,7 +128,7 @@ function CreateLoopForm({ providers, onCreated }) {
               </option>
             ))}
           </select>
-        </div>
+        </FormField>
 
         <button
           type="button"
@@ -141,8 +141,7 @@ function CreateLoopForm({ providers, onCreated }) {
 
       {expanded && (
         <div className="flex flex-wrap gap-3">
-          <div className="flex-1 min-w-[200px]">
-            <label className="block text-xs text-gray-400 mb-1">Name (optional)</label>
+          <FormField className="flex-1 min-w-[200px]" label="Name (optional)" labelClassName="block text-xs text-gray-400 mb-1">
             <input
               type="text"
               value={name}
@@ -150,9 +149,8 @@ function CreateLoopForm({ providers, onCreated }) {
               placeholder="Loop name for display"
               className="w-full bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-gray-200 placeholder-gray-600"
             />
-          </div>
-          <div className="flex-1 min-w-[200px]">
-            <label className="block text-xs text-gray-400 mb-1">Working Directory (optional)</label>
+          </FormField>
+          <FormField className="flex-1 min-w-[200px]" label="Working Directory (optional)" labelClassName="block text-xs text-gray-400 mb-1">
             <input
               type="text"
               value={cwd}
@@ -160,7 +158,7 @@ function CreateLoopForm({ providers, onCreated }) {
               placeholder="/path/to/project"
               className="w-full bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-gray-200 placeholder-gray-600"
             />
-          </div>
+          </FormField>
         </div>
       )}
 

--- a/client/src/pages/Loras.jsx
+++ b/client/src/pages/Loras.jsx
@@ -13,6 +13,7 @@ import { Trash2, Download, ExternalLink, Sparkles, AlertTriangle, KeyRound, Chec
 import toast from '../components/ui/Toast';
 import Modal from '../components/ui/Modal';
 import Banner from '../components/ui/Banner';
+import { FormField } from '../components/ui/FormField';
 import { formatBytes } from '../utils/formatters';
 import { RUNNER_FAMILIES, VIDEO_LORA_FAMILIES, isVideoLoraFamily } from '../lib/runnerFamilies';
 import {
@@ -917,16 +918,17 @@ function CivitaiAuthModal({ pendingUrl, message, auth, onClose, onSaved, onRetry
       </p>
 
       <form onSubmit={handleSave} className="space-y-2">
-        <label className="block text-xs font-medium text-gray-400">API key</label>
-        <input
-          type="password"
-          value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          placeholder={auth?.hasKey ? '•••• key already set — paste a new one to replace' : 'paste your Civitai API key'}
-          className="w-full bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-gray-200 placeholder:text-gray-600 font-mono"
-          disabled={saving}
-          autoFocus
-        />
+        <FormField label="API key" labelClassName="block text-xs font-medium text-gray-400" className="space-y-2">
+          <input
+            type="password"
+            value={apiKey}
+            onChange={(e) => setApiKey(e.target.value)}
+            placeholder={auth?.hasKey ? '•••• key already set — paste a new one to replace' : 'paste your Civitai API key'}
+            className="w-full bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-gray-200 placeholder:text-gray-600 font-mono"
+            disabled={saving}
+            autoFocus
+          />
+        </FormField>
         <div className="flex items-center gap-2 pt-1">
           <button
             type="submit"

--- a/client/src/pages/PromptManager.jsx
+++ b/client/src/pages/PromptManager.jsx
@@ -14,6 +14,7 @@ import {
 } from '../utils/formatters';
 import useFieldDraft from '../hooks/useFieldDraft';
 import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
+import { FormField } from '../components/ui/FormField';
 
 const VALID_PROMPT_TABS = ['stages', 'variables', 'job-skills'];
 
@@ -510,8 +511,7 @@ export default function PromptManager() {
                     </div>
                   </div>
 
-                  <div>
-                    <label className="block text-sm text-gray-400 mb-1">Template</label>
+                  <FormField label="Template">
                     <textarea
                       value={stageTemplate}
                       onChange={(e) => setStageTemplate(e.target.value)}
@@ -520,7 +520,7 @@ export default function PromptManager() {
                     <p className="text-xs text-gray-500 mt-1">
                       Use {'{{variable}}'} for substitution, {'{{#array}}...{{/array}}'} for iteration
                     </p>
-                  </div>
+                  </FormField>
                 </div>
 
                 {/* Preview Panel */}
@@ -611,8 +611,7 @@ export default function PromptManager() {
 
               <div className="space-y-4">
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm text-gray-400 mb-1">Key *</label>
+                  <FormField label="Key *">
                     <input
                       type="text"
                       value={varForm.key}
@@ -621,9 +620,8 @@ export default function PromptManager() {
                       placeholder="variableKey"
                       className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden disabled:opacity-50"
                     />
-                  </div>
-                  <div>
-                    <label className="block text-sm text-gray-400 mb-1">Name</label>
+                  </FormField>
+                  <FormField label="Name">
                     <input
                       type="text"
                       value={varForm.name}
@@ -631,11 +629,10 @@ export default function PromptManager() {
                       placeholder="Human Readable Name"
                       className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
                     />
-                  </div>
+                  </FormField>
                 </div>
 
-                <div>
-                  <label className="block text-sm text-gray-400 mb-1">Category</label>
+                <FormField label="Category">
                   <select
                     value={varForm.category}
                     onChange={(e) => setVarForm({ ...varForm, category: e.target.value })}
@@ -647,17 +644,16 @@ export default function PromptManager() {
                     <option value="rules">Rules</option>
                     <option value="system">System</option>
                   </select>
-                </div>
+                </FormField>
 
-                <div>
-                  <label className="block text-sm text-gray-400 mb-1">Content *</label>
+                <FormField label="Content *">
                   <textarea
                     value={varForm.content}
                     onChange={(e) => setVarForm({ ...varForm, content: e.target.value })}
                     className="w-full h-48 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white font-mono text-sm focus:border-port-accent focus:outline-hidden"
                     placeholder="Variable content..."
                   />
-                </div>
+                </FormField>
               </div>
             </div>
             )}
@@ -733,8 +729,7 @@ export default function PromptManager() {
                     </div>
                   </div>
 
-                  <div>
-                    <label className="block text-sm text-gray-400 mb-1">Skill Template (Markdown)</label>
+                  <FormField label="Skill Template (Markdown)">
                     <textarea
                       value={jobSkillContent}
                       onChange={(e) => setJobSkillContent(e.target.value)}
@@ -743,7 +738,7 @@ export default function PromptManager() {
                     <p className="text-xs text-gray-500 mt-1">
                       Sections: ## Prompt Template, ## Steps, ## Expected Outputs, ## Success Criteria
                     </p>
-                  </div>
+                  </FormField>
                 </div>
 
                 {/* Preview Panel */}
@@ -782,8 +777,7 @@ export default function PromptManager() {
 
             <div className="space-y-4">
               <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm text-gray-400 mb-1">Stage Key *</label>
+                <FormField label="Stage Key *">
                   <input
                     type="text"
                     value={newStageForm.stageName}
@@ -792,9 +786,8 @@ export default function PromptManager() {
                     className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
                   />
                   <p className="text-xs text-gray-500 mt-1">Lowercase, hyphens only</p>
-                </div>
-                <div>
-                  <label className="block text-sm text-gray-400 mb-1">Display Name *</label>
+                </FormField>
+                <FormField label="Display Name *">
                   <input
                     type="text"
                     value={newStageForm.name}
@@ -802,11 +795,10 @@ export default function PromptManager() {
                     placeholder="My Stage"
                     className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
                   />
-                </div>
+                </FormField>
               </div>
 
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Description</label>
+              <FormField label="Description">
                 <input
                   type="text"
                   value={newStageForm.description}
@@ -814,7 +806,7 @@ export default function PromptManager() {
                   placeholder="What this stage does"
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
                 />
-              </div>
+              </FormField>
 
               <div className="space-y-4">
                 <div>
@@ -880,15 +872,14 @@ export default function PromptManager() {
                 </div>
               </div>
 
-              <div>
-                <label className="block text-sm text-gray-400 mb-1">Template</label>
+              <FormField label="Template">
                 <textarea
                   value={newStageForm.template}
                   onChange={(e) => setNewStageForm({ ...newStageForm, template: e.target.value })}
                   className="w-full h-64 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white font-mono text-sm focus:border-port-accent focus:outline-hidden"
                   placeholder="Enter your prompt template here..."
                 />
-              </div>
+              </FormField>
 
               <div className="flex gap-2 justify-end">
                 <button
@@ -969,8 +960,7 @@ function StageTimeoutField({ timeout, providerFallback, onCommit }) {
     if (ms != null) onCommit(ms);
   });
   return (
-    <div>
-      <label className="block text-sm text-gray-400 mb-1">Timeout override (ms)</label>
+    <FormField label="Timeout override (ms)">
       <input
         type="number"
         inputMode="numeric"
@@ -989,6 +979,6 @@ function StageTimeoutField({ timeout, providerFallback, onCommit }) {
           ? `≈ ${formatDurationMs(timeout)} per run`
           : 'Leave blank to use the provider default'}
       </p>
-    </div>
+    </FormField>
   );
 }

--- a/client/src/pages/Security.jsx
+++ b/client/src/pages/Security.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { Camera, Mic, MicOff, Video, VideoOff, RefreshCw, Settings, Volume2 } from 'lucide-react';
 import api from '../services/api';
 import Banner from '../components/ui/Banner';
+import { FormField } from '../components/ui/FormField';
 
 const MEDIA_CONSTRAINTS_KEY = 'portos-media-constraints';
 
@@ -302,11 +303,10 @@ export default function Security() {
           <h3 className="text-lg font-semibold text-white mb-4">Device Settings</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             {/* Video device selector */}
-            <div>
-              <label className="block text-sm text-gray-400 mb-2">
-                <Camera size={14} className="inline mr-2" />
-                Camera
-              </label>
+            <FormField
+              labelClassName="block text-sm text-gray-400 mb-2"
+              label={<><Camera size={14} className="inline mr-2" />Camera</>}
+            >
               <select
                 value={selectedVideo}
                 onChange={(e) => handleDeviceChange('video', e.target.value)}
@@ -322,14 +322,13 @@ export default function Security() {
                   ))
                 )}
               </select>
-            </div>
+            </FormField>
 
             {/* Audio device selector */}
-            <div>
-              <label className="block text-sm text-gray-400 mb-2">
-                <Mic size={14} className="inline mr-2" />
-                Microphone
-              </label>
+            <FormField
+              labelClassName="block text-sm text-gray-400 mb-2"
+              label={<><Mic size={14} className="inline mr-2" />Microphone</>}
+            >
               <select
                 value={selectedAudio}
                 onChange={(e) => handleDeviceChange('audio', e.target.value)}
@@ -345,7 +344,7 @@ export default function Security() {
                   ))
                 )}
               </select>
-            </div>
+            </FormField>
           </div>
         </div>
       )}

--- a/client/src/pages/Sharing.jsx
+++ b/client/src/pages/Sharing.jsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import InlineConfirmRow from '../components/ui/InlineConfirmRow';
+import { FormField } from '../components/ui/FormField';
 import { formatDateTime } from '../utils/formatters';
 import { useConfirmDelete } from '../hooks/useConfirmDelete';
 import FolderPicker from '../components/FolderPicker';
@@ -335,8 +336,7 @@ function SharingBuckets({ selectedId }) {
       {showAdd && (
         <form onSubmit={handleCreate} className="mb-6 p-4 bg-port-card border border-port-border rounded-lg space-y-3">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs uppercase tracking-wider text-gray-500 mb-1">Bucket name</label>
+            <FormField label="Bucket name" labelClassName="block text-xs uppercase tracking-wider text-gray-500 mb-1">
               <input
                 type="text"
                 value={form.name}
@@ -346,9 +346,8 @@ function SharingBuckets({ selectedId }) {
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 autoFocus
               />
-            </div>
-            <div>
-              <label className="block text-xs uppercase tracking-wider text-gray-500 mb-1">Import mode</label>
+            </FormField>
+            <FormField label="Import mode" labelClassName="block text-xs uppercase tracking-wider text-gray-500 mb-1">
               <select
                 value={form.mode}
                 onChange={(e) => setForm((f) => ({ ...f, mode: e.target.value }))}
@@ -357,7 +356,7 @@ function SharingBuckets({ selectedId }) {
                 <option value="inbox">Inbox — review before importing</option>
                 <option value="auto-merge">Auto-merge — apply immediately (trusted)</option>
               </select>
-            </div>
+            </FormField>
           </div>
           <div>
             <label className="block text-xs uppercase tracking-wider text-gray-500 mb-1">
@@ -381,8 +380,7 @@ function SharingBuckets({ selectedId }) {
             </p>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs uppercase tracking-wider text-gray-500 mb-1">Display name override (optional)</label>
+            <FormField label="Display name override (optional)" labelClassName="block text-xs uppercase tracking-wider text-gray-500 mb-1">
               <input
                 type="text"
                 value={form.displayNameOverride}
@@ -391,9 +389,8 @@ function SharingBuckets({ selectedId }) {
                 maxLength={120}
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
               />
-            </div>
-            <div>
-              <label className="block text-xs uppercase tracking-wider text-gray-500 mb-1">Bio override (optional)</label>
+            </FormField>
+            <FormField label="Bio override (optional)" labelClassName="block text-xs uppercase tracking-wider text-gray-500 mb-1">
               <input
                 type="text"
                 value={form.bioOverride}
@@ -402,7 +399,7 @@ function SharingBuckets({ selectedId }) {
                 maxLength={2000}
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
               />
-            </div>
+            </FormField>
           </div>
           <div className="flex gap-2">
             <button

--- a/client/src/pages/Templates.jsx
+++ b/client/src/pages/Templates.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Layers, Code, Server, Globe, Smartphone, MonitorSmartphone, Plus } from 'lucide-react';
 import * as api from '../services/api';
 import FolderPicker from '../components/FolderPicker';
+import { FormField } from '../components/ui/FormField';
 
 const ICONS = {
   layers: Layers,
@@ -102,8 +103,7 @@ export default function Templates() {
           </div>
 
           <form onSubmit={handleCreate} className="space-y-4">
-            <div>
-              <label className="block text-sm text-gray-400 mb-1">App Name *</label>
+            <FormField label="App Name *">
               <input
                 type="text"
                 value={appName}
@@ -112,7 +112,7 @@ export default function Templates() {
                 required
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
               />
-            </div>
+            </FormField>
 
             <div>
               <label className="block text-sm text-gray-400 mb-1">Target Directory *</label>

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -49,6 +49,7 @@ import BatchQueuePanel from '../components/media/BatchQueuePanel';
 import MediaJobsQueue from '../components/media/MediaJobsQueue';
 import FavoritesFilterChip from '../components/media/FavoritesFilterChip';
 import ModelSelect from '../components/ModelSelect';
+import { FormField } from '../components/ui/FormField';
 import ModelDownloadBadge, { deriveSizeEstimate } from '../components/media/ModelDownloadBadge';
 import { useModelDownloadStatus, TEXT_ENCODER_DOWNLOAD_ID } from '../hooks/useModelDownloadStatus';
 import { useMediaJobSse } from '../hooks/useMediaJobSse';
@@ -1526,8 +1527,7 @@ export default function VideoGen() {
             disabled={generating}
           />
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">Prompt</label>
+            <FormField label="Prompt" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <textarea
                 value={prompt}
                 onChange={(e) => setPrompt(e.target.value)}
@@ -1535,9 +1535,8 @@ export default function VideoGen() {
                 className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y"
                 placeholder="Describe the video you want to generate..."
               />
-            </div>
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">Negative Prompt</label>
+            </FormField>
+            <FormField label="Negative Prompt" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <textarea
                 value={negativePrompt}
                 onChange={(e) => setNegativePrompt(e.target.value)}
@@ -1545,7 +1544,7 @@ export default function VideoGen() {
                 className="w-full bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 resize-y"
                 placeholder="What to avoid..."
               />
-            </div>
+            </FormField>
           </div>
 
           {mode === 'fflf' && keyframesSupported && (
@@ -1647,8 +1646,7 @@ export default function VideoGen() {
 
           <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
             {models.length > 0 && (
-              <div className="col-span-2 sm:col-span-3">
-                <label className="block text-xs font-medium text-gray-400 mb-1">Model</label>
+              <FormField className="col-span-2 sm:col-span-3" label="Model" labelClassName="block text-xs font-medium text-gray-400 mb-1">
                 <ModelSelect
                   models={visibleModels}
                   value={modelId}
@@ -1672,7 +1670,7 @@ export default function VideoGen() {
                     />
                   </div>
                 )}
-              </div>
+              </FormField>
             )}
 
             {/* Video LoRAs — only on ltx2-runtime models (loraFamily non-null)
@@ -1704,8 +1702,7 @@ export default function VideoGen() {
               </div>
             )}
 
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">Resolution</label>
+            <FormField label="Resolution" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <select
                 value={resolutionLabel}
                 onChange={handleResolutionChange}
@@ -1716,10 +1713,9 @@ export default function VideoGen() {
                 )}
                 {VIDEO_RESOLUTIONS.map((r) => <option key={r.label} value={r.label}>{r.label}</option>)}
               </select>
-            </div>
+            </FormField>
 
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">Frames</label>
+            <FormField label="Frames" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <select
                 value={numFrames}
                 onChange={(e) => setNumFrames(Number(e.target.value))}
@@ -1732,7 +1728,7 @@ export default function VideoGen() {
                   Past 241 frames a single-pass render may swap or OOM at 48 GB. For reliable longer clips, render up to ~10s and then use <strong>Extend</strong> on the result — it conditions on the source's full latent rather than a single last frame.
                 </p>
               )}
-            </div>
+            </FormField>
 
             {mode !== 'a2v' && (
               <div>
@@ -1756,8 +1752,7 @@ export default function VideoGen() {
               </div>
             )}
 
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">FPS</label>
+            <FormField label="FPS" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <select
                 value={fps}
                 onChange={(e) => setFps(Number(e.target.value))}
@@ -1765,7 +1760,7 @@ export default function VideoGen() {
               >
                 {FPS_OPTIONS.map((f) => <option key={f} value={f}>{f}</option>)}
               </select>
-            </div>
+            </FormField>
 
             <div>
               <label className="block text-xs font-medium text-gray-400 mb-1">Seed</label>
@@ -1788,10 +1783,10 @@ export default function VideoGen() {
               </div>
             </div>
 
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">
-                Steps {currentModel?.steps && `(default: ${currentModel.steps})`}
-              </label>
+            <FormField
+              label={<>Steps {currentModel?.steps && `(default: ${currentModel.steps})`}</>}
+              labelClassName="block text-xs font-medium text-gray-400 mb-1"
+            >
               <input
                 type="number" min={1} max={150}
                 value={steps}
@@ -1799,12 +1794,12 @@ export default function VideoGen() {
                 placeholder={String(currentModel?.steps || 25)}
                 className="w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
               />
-            </div>
+            </FormField>
 
-            <div>
-              <label className="block text-xs font-medium text-gray-400 mb-1">
-                CFG Scale {currentModel?.guidance != null && `(default: ${currentModel.guidance})`}
-              </label>
+            <FormField
+              label={<>CFG Scale {currentModel?.guidance != null && `(default: ${currentModel.guidance})`}</>}
+              labelClassName="block text-xs font-medium text-gray-400 mb-1"
+            >
               <input
                 type="number" min={0} max={20} step={0.5}
                 value={guidanceScale}
@@ -1812,7 +1807,7 @@ export default function VideoGen() {
                 placeholder={String(currentModel?.guidance ?? 3.0)}
                 className="w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
               />
-            </div>
+            </FormField>
 
             {(mode === 'image' || (mode === 'extend' && currentModel?.runtime !== 'ltx2')) && (
               <div className="col-span-2 sm:col-span-3">
@@ -1830,8 +1825,7 @@ export default function VideoGen() {
               </div>
             )}
 
-            <div className="col-span-2 sm:col-span-3">
-              <label className="block text-xs font-medium text-gray-400 mb-1">Tiling</label>
+            <FormField className="col-span-2 sm:col-span-3" label="Tiling" labelClassName="block text-xs font-medium text-gray-400 mb-1">
               <select
                 value={tiling}
                 onChange={(e) => setTiling(e.target.value)}
@@ -1839,7 +1833,7 @@ export default function VideoGen() {
               >
                 {VIDEO_TILING_OPTIONS.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
               </select>
-            </div>
+            </FormField>
 
             {mode !== 'a2v' && (
               <label className="col-span-2 sm:col-span-3 flex items-center gap-2 text-xs text-gray-400 cursor-pointer">


### PR DESCRIPTION
## Summary

Follow-up to #2027, completing the repo-wide sweep of sibling config-form labels onto the shared `FormField` accessibility wrapper (`client/src/components/ui/FormField.jsx`), which wires `<label htmlFor>` ↔ control `id` via `useId()`.

**~130 fields migrated across ~40 files.** Each converted field's label now focuses its control on click and is announced correctly by screen readers.

### Areas migrated
- **Agents:** OverviewTab (13), AgentList (9), MemoryEditModal (6), ImageGenControls (6), PublishedTab, ResumeAgentModal, TrustTab
- **Digital Twin:** AccountsTab, DocumentsTab, GoalsTab, ImportTab, OverviewTab, EnrichTab, SoulWizard, ListEnrichment
- **Pages:** PromptManager (11), VideoGen (9), Jira (5), Sharing (4), Loras, Security, ImageGen, Templates, Loops, Browser
- **Media / pipeline / writers-room / MeatSpace / brain / cos / music / messages:** MediaJobsQueue (6), LifeEventsPanel (6), GoalEditForm (5), AlcoholTab, AddActivityForm, PromptRefineModal, StandardDrinkCalculator, ExercisePanel, StagePromptModelPicker, DailyLogTab, ProcessesTab, MemoryBuilder, PostSessionLauncher, GenomeCategoryCard, SyncTab, and more

### Deliberately skipped (per #2027 rules)
- **Wrapping labels** (`<label><input/></label>`) — valid implicit associations left untouched (e.g. Tribe, CreativeDirector, MusicGenPanel, StoryboardConfigTab, the local `Field` components in Authors/PipelineSeries/AlbumsManager/TracksManager).
- **Group labels** heading radio/toggle/button groups (no single bindable control) — e.g. Platform pickers, Type/Tags groups, MergeModal survivor/fold radios, icon pickers, seed input+randomize rows.
- **Custom-component controls that don't forward `id`** to a real DOM input — `ToggleSwitch`, `CronInput`, `InfluenceChipsInput`, `FolderPicker`-wrapped rows, etc. (`ModelSelect` was migrated because it *does* forward `id` to its `<select>`).
- Labels that already had `htmlFor` (LocalLlmPlayground, many in Importer/StoryBuilder/PipelineSeries/UniverseBuilder).

## Test plan
- Client Vitest suite green: **291 files, 3127 tests passing**.
- ESLint clean on all 40 changed files.
- Diff self-scan confirms no migrated `FormField` has a non-DOM (`<div>`) first child, so every label binds to a real control.
- Accessibility only: zero restyle — Tailwind classes moved verbatim to `className` / `labelClassName`.

Closes #2051

https://claude.ai/code/session_01KSyAbxEjURcLPhugG8MZCw