### PR TITLE
Fix Morse trainer audio on mobile Safari (await AudioContext resume)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,3 +3,7 @@
 ## Media
 
 - **[issue-2036] Sketch & Annotation Canvas (phase 2): re-render an image guided by your annotations.** The annotate page (`/media/annotate/:mediaKey`) gained a "Re-render" action: draw over a generated image, then feed your markup back through local img2img so the marks reshape the render. A confirmation dialog names the exact local model it will run (no surprise AI calls) and lets you add an optional prompt and tune how much to change before it starts; the new render is queued and appears in Media History. Requires a local FLUX img2img runner — the action explains when one isn't available. Phase 3 (blank-canvas storyboard) remains open on #2036.
+
+## MeatSpace POST
+
+- **Morse trainer audio now works on mobile Safari.** iOS Safari starts the Web Audio context suspended and only unlocks it once `resume()` fully settles. The trainer fired `resume()` without awaiting it, so the first tones were scheduled against a still-suspended clock and never sounded on iPhone/iPad. It now awaits the resume before scheduling any tone (matching the app's other audio modules), so Copy, Head Copy, and Send-mode keying all produce sound on mobile Safari.

--- a/client/src/components/meatspace/post/MorseTrainer.jsx
+++ b/client/src/components/meatspace/post/MorseTrainer.jsx
@@ -252,17 +252,24 @@ function useKeyingDecoder({ unitMs, hz, ensureCtx, enabled = false }) {
   // depends on them, and re-running per keystroke would tear down the
   // just-scheduled flush timers and cut off the active tone mid-press.
   const pressingRef = useRef(false);
+  // Bumped once per beginPress so a startTone whose resume await settles after a
+  // newer press started can tell it's been superseded and bail.
+  const toneGenRef = useRef(0);
 
   const [pattern, setPattern] = useState('');
   const [decoded, setDecoded] = useState('');
   const [pressing, setPressing] = useState(false);
 
   const startTone = useCallback(async () => {
+    const gen = ++toneGenRef.current;
     const ctx = await ensureCtx();
-    // A fast tap can release (endPress → stopTone) before the first-press-only
-    // resume await settles. Bail so we don't spin up an orphan oscillator that
-    // has no matching stop and drones on.
-    if (!pressingRef.current) return;
+    // A fast tap can release (endPress → stopTone), or a newer press can start,
+    // before the first-press-only resume await settles. Bail if the key is no
+    // longer held (`!pressingRef.current`) OR a newer press superseded this one
+    // (`gen !== toneGenRef.current`) — a bare boolean can't distinguish the two,
+    // so two overlapping starts would both create an oscillator and orphan the
+    // first, leaving it droning with no matching stop.
+    if (!pressingRef.current || gen !== toneGenRef.current) return;
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
     osc.type = 'sine';

--- a/client/src/components/meatspace/post/MorseTrainer.jsx
+++ b/client/src/components/meatspace/post/MorseTrainer.jsx
@@ -803,8 +803,17 @@ function CopyDrill({ prefs, updatePrefs, ensureCtx, onExit, onSessionComplete, h
   const [done, setDone] = useState(false);
   const inputRef = useRef(null);
   const roundStartRef = useRef(0);
+  // Re-entrancy guard. On the first play of a session `ensureCtx()` awaits the
+  // iOS audio-unlock, and `prompt`/`playing` aren't set until after it — so the
+  // Start Round / New Round button stays live during that window. A second tap
+  // would otherwise start a second overlapping playPrompt, scheduling two Morse
+  // prompts over each other with the UI tracking only whichever set state last.
+  // A ref (not `playing` state) because it must gate synchronously, before the
+  // first await, where a state update wouldn't have rendered yet.
+  const playingRef = useRef(false);
 
   async function startRound() {
+    if (playingRef.current) return;
     setResults([]);
     setFeedback(null);
     setDone(false);
@@ -813,6 +822,8 @@ function CopyDrill({ prefs, updatePrefs, ensureCtx, onExit, onSessionComplete, h
   }
 
   async function playPrompt(isNew) {
+    if (playingRef.current) return;
+    playingRef.current = true;
     const ctx = await ensureCtx();
     const text = isNew ? pickKochPrompt(prefs.kochLevel) : prompt;
     if (isNew) {
@@ -823,6 +834,7 @@ function CopyDrill({ prefs, updatePrefs, ensureCtx, onExit, onSessionComplete, h
     setPlaying(true);
     await playMorse(ctx, text, prefs);
     setPlaying(false);
+    playingRef.current = false;
     setTimeout(() => inputRef.current?.focus(), 50);
   }
 

--- a/client/src/components/meatspace/post/MorseTrainer.jsx
+++ b/client/src/components/meatspace/post/MorseTrainer.jsx
@@ -215,12 +215,17 @@ function pickSendPrompt() {
 
 function useAudioContext() {
   const ctxRef = useRef(null);
-  const ensureCtx = useCallback(() => {
+  const ensureCtx = useCallback(async () => {
     if (!ctxRef.current) {
       const Ctor = window.AudioContext || window.webkitAudioContext;
       ctxRef.current = new Ctor();
     }
-    if (ctxRef.current.state === 'suspended') ctxRef.current.resume();
+    // Autoplay policy starts the context suspended until a user gesture — and on
+    // iOS Safari resume() is async, so we MUST await it before scheduling any
+    // oscillator. Firing resume() without awaiting (the old behavior) laid tones
+    // down against a still-suspended clock: silent on mobile Safari. Mirrors the
+    // await-resume idiom in metronome.js / scorePlayback.js / songPlayback.js.
+    if (ctxRef.current.state === 'suspended') await ctxRef.current.resume();
     return ctxRef.current;
   }, []);
   useEffect(() => () => {
@@ -252,8 +257,12 @@ function useKeyingDecoder({ unitMs, hz, ensureCtx, enabled = false }) {
   const [decoded, setDecoded] = useState('');
   const [pressing, setPressing] = useState(false);
 
-  const startTone = useCallback(() => {
-    const ctx = ensureCtx();
+  const startTone = useCallback(async () => {
+    const ctx = await ensureCtx();
+    // A fast tap can release (endPress → stopTone) before the first-press-only
+    // resume await settles. Bail so we don't spin up an orphan oscillator that
+    // has no matching stop and drones on.
+    if (!pressingRef.current) return;
     const osc = ctx.createOscillator();
     const gain = ctx.createGain();
     osc.type = 'sine';
@@ -272,8 +281,10 @@ function useKeyingDecoder({ unitMs, hz, ensureCtx, enabled = false }) {
     const osc = oscRef.current;
     const gain = gainRef.current;
     if (!osc || !gain) return;
-    const ctx = ensureCtx();
-    const now = ctx.currentTime;
+    // Read the clock straight off the live oscillator's context — a tone is only
+    // playing on an already-running context, so there's nothing to resume here
+    // (and stopTone stays synchronous, which endPress/clear/cleanup rely on).
+    const now = osc.context.currentTime;
     gain.gain.cancelScheduledValues(now);
     gain.gain.setValueAtTime(gain.gain.value, now);
     gain.gain.linearRampToValueAtTime(0, now + RAMP_SEC);
@@ -281,7 +292,7 @@ function useKeyingDecoder({ unitMs, hz, ensureCtx, enabled = false }) {
     osc.onended = () => { osc.disconnect(); gain.disconnect(); };
     oscRef.current = null;
     gainRef.current = null;
-  }, [ensureCtx]);
+  }, []);
 
   const flushLetter = useCallback(() => {
     const buf = patternRef.current;
@@ -795,7 +806,7 @@ function CopyDrill({ prefs, updatePrefs, ensureCtx, onExit, onSessionComplete, h
   }
 
   async function playPrompt(isNew) {
-    const ctx = ensureCtx();
+    const ctx = await ensureCtx();
     const text = isNew ? pickKochPrompt(prefs.kochLevel) : prompt;
     if (isNew) {
       setPrompt(text);

--- a/client/src/components/meatspace/post/MorseTrainer.test.jsx
+++ b/client/src/components/meatspace/post/MorseTrainer.test.jsx
@@ -197,6 +197,7 @@ describe('MorseTrainer iOS audio unlock', () => {
   // sounds. The trainer must await resume() (like metronome.js / scorePlayback.js)
   // so no oscillator is ever created while the context is still 'suspended'.
   let createdWhileSuspended;
+  let oscCount;
   class SuspendedAudioContext {
     constructor() { this.currentTime = 0; this.destination = {}; this.state = 'suspended'; }
     // Resolve on a macrotask (setTimeout), NOT a microtask. iOS resume latency
@@ -210,6 +211,7 @@ describe('MorseTrainer iOS audio unlock', () => {
     resume() { return new Promise((resolve) => { setTimeout(() => { this.state = 'running'; resolve(); }, 0); }); }
     createOscillator() {
       if (this.state === 'suspended') createdWhileSuspended = true;
+      oscCount += 1;
       return new MockOscillator();
     }
     createGain() { return new MockGainNode(); }
@@ -218,6 +220,7 @@ describe('MorseTrainer iOS audio unlock', () => {
 
   beforeEach(() => {
     createdWhileSuspended = false;
+    oscCount = 0;
     submitTrainingEntry.mockClear();
     getTrainingStats.mockClear();
     window.AudioContext = SuspendedAudioContext;
@@ -231,6 +234,22 @@ describe('MorseTrainer iOS audio unlock', () => {
     // first tone has been scheduled and played.
     await screen.findByPlaceholderText('????');
     expect(createdWhileSuspended).toBe(false);
+  });
+
+  it('ignores a second Start-Round tap during the audio-unlock window (no overlapping prompt)', async () => {
+    // While the first play awaits resume() (the iOS unlock window), prompt/playing
+    // aren't set yet, so the Start Round button is still live. A second tap in that
+    // window must be ignored — otherwise two playPrompt runs schedule two Morse
+    // prompts over each other. playMorse uses exactly one oscillator per prompt, so
+    // two overlapping prompts would create two oscillators for one round start.
+    renderMorse({ mode: 'copy', onSelectMode: vi.fn(), onExitMode: vi.fn() });
+    const startBtn = await screen.findByRole('button', { name: /Start Round/i });
+    // Two synchronous taps land inside the unlock window (resume() resolves on a
+    // later macrotask, so neither startRound has reached createOscillator yet).
+    fireEvent.click(startBtn);
+    fireEvent.click(startBtn);
+    await screen.findByPlaceholderText('????');
+    expect(oscCount).toBe(1);
   });
 });
 

--- a/client/src/components/meatspace/post/MorseTrainer.test.jsx
+++ b/client/src/components/meatspace/post/MorseTrainer.test.jsx
@@ -199,9 +199,15 @@ describe('MorseTrainer iOS audio unlock', () => {
   let createdWhileSuspended;
   class SuspendedAudioContext {
     constructor() { this.currentTime = 0; this.destination = {}; this.state = 'suspended'; }
-    // Resolve on a later microtask, mirroring the real async resume — the
-    // component must await this before touching createOscillator.
-    resume() { return Promise.resolve().then(() => { this.state = 'running'; }); }
+    // Resolve on a macrotask (setTimeout), NOT a microtask. iOS resume latency
+    // is real time, and the component must AWAIT it before touching
+    // createOscillator. A microtask-resolving mock would let the unawaited
+    // (buggy) path pass too — playPrompt's own `await ensureCtx()` yields a
+    // microtask, so a microtask state-flip always beats createOscillator
+    // regardless of the await. The macrotask makes the missing-await path
+    // schedule the oscillator while still 'suspended', so the test fails if the
+    // fix regresses.
+    resume() { return new Promise((resolve) => { setTimeout(() => { this.state = 'running'; resolve(); }, 0); }); }
     createOscillator() {
       if (this.state === 'suspended') createdWhileSuspended = true;
       return new MockOscillator();

--- a/client/src/components/meatspace/post/MorseTrainer.test.jsx
+++ b/client/src/components/meatspace/post/MorseTrainer.test.jsx
@@ -22,7 +22,9 @@ import { submitTrainingEntry, getTrainingStats } from '../../../services/api';
 // own) — mirrors that convention. `stop()` resolves playMorse's promise on
 // the next tick, matching the real oscillator's `onended` callback shape.
 class MockOscillator {
-  constructor() { this.onended = null; this.frequency = { value: 0 }; }
+  // `context` mirrors the real AudioNode.context — stopTone reads currentTime
+  // off it instead of re-resolving the AudioContext.
+  constructor(context = { currentTime: 0 }) { this.onended = null; this.frequency = { value: 0 }; this.context = context; }
   connect() { return this; }
   start() {}
   stop() { if (this.onended) setTimeout(() => this.onended(), 0); }
@@ -185,6 +187,44 @@ describe('MorseTrainer training log integration', () => {
         }));
       });
     });
+  });
+});
+
+describe('MorseTrainer iOS audio unlock', () => {
+  // Regression for "audio doesn't work on mobile Safari": iOS starts the
+  // AudioContext suspended and resume() is async. If a tone is scheduled before
+  // resume() settles, it's laid down against a still-suspended clock and never
+  // sounds. The trainer must await resume() (like metronome.js / scorePlayback.js)
+  // so no oscillator is ever created while the context is still 'suspended'.
+  let createdWhileSuspended;
+  class SuspendedAudioContext {
+    constructor() { this.currentTime = 0; this.destination = {}; this.state = 'suspended'; }
+    // Resolve on a later microtask, mirroring the real async resume — the
+    // component must await this before touching createOscillator.
+    resume() { return Promise.resolve().then(() => { this.state = 'running'; }); }
+    createOscillator() {
+      if (this.state === 'suspended') createdWhileSuspended = true;
+      return new MockOscillator();
+    }
+    createGain() { return new MockGainNode(); }
+    close() {}
+  }
+
+  beforeEach(() => {
+    createdWhileSuspended = false;
+    submitTrainingEntry.mockClear();
+    getTrainingStats.mockClear();
+    window.AudioContext = SuspendedAudioContext;
+  });
+  afterEach(() => { delete window.AudioContext; });
+
+  it('awaits resume() before scheduling any tone (no oscillator while suspended)', async () => {
+    renderMorse({ mode: 'copy', onSelectMode: vi.fn(), onExitMode: vi.fn() });
+    fireEvent.click(await screen.findByRole('button', { name: /Start Round/i }));
+    // The round input only renders once playMorse has finished, so by here the
+    // first tone has been scheduled and played.
+    await screen.findByPlaceholderText('????');
+    expect(createdWhileSuspended).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
The Morse code trainer produced no sound on mobile Safari. iOS Safari starts the Web Audio `AudioContext` **suspended** and `resume()` is asynchronous — the trainer fired `resume()` without awaiting it, so the first tones were scheduled against a still-suspended clock and never sounded. Desktop browsers resume fast enough that the 50 ms scheduling lead hid the bug.

## Root cause
`useAudioContext().ensureCtx()` called `ctx.resume()` fire-and-forget, unlike every other audio module in the app (`metronome.js`, `scorePlayback.js`, `songPlayback.js`), which all `await c.resume()` before scheduling.

## Changes
- **`ensureCtx` now `await`s `resume()`** before returning the context (Copy / Head Copy / Send all benefit).
- **`playPrompt` awaits `ensureCtx()`.**
- **Send-mode keying**: `startTone` awaits `ensureCtx()` and uses a generation token so a fast release-then-repress during the first-play unlock can't orphan a droning oscillator; `stopTone` reads the clock off the live oscillator's `context` so it stays synchronous.
- **Re-entrancy guard** on `startRound`/`playPrompt`: the earlier await widened the window where the Start Round button is still live during the iOS unlock, so a double-tap could schedule two overlapping prompts — now ignored.

## Tests
Added regression tests in `MorseTrainer.test.jsx`:
- asserts no oscillator is created while the context is `suspended` (mock resolves `resume()` on a macrotask so the test actually fails if the `await` regresses).
- asserts a double Start-Round tap in the unlock window creates only one oscillator.

All 18 MorseTrainer tests + 80 meatspace tests pass. Reviewed locally with claude + codex.

https://claude.ai/code/session_01USGJgLzYBHwis8rn38K3Pn