### PR TITLE
fix([issue-2105]): correct Hey Ho Nobody Home melody to D-minor, fix quodlibet tritone

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,6 +3,7 @@
 ## Rounds
 
 - **[issue-2104] Fixed: 500 Miles' reference TikTok videos now show up on older installs.** The built-in "500 Miles" round shipped with three TikTok reference performances, but any install that already had its data saved from before those were added never picked them up — the Reference material section stayed empty. A one-time backfill now restores the three references for those installs, without touching anything you may have added of your own.
+- **[issue-2105] Fixed: "Hey Ho Nobody Home" now sings in D minor and stacks cleanly with its partner rounds.** The built-in round shipped with a mis-transcribed melody — centered on G with a major third — that contradicted its own key label and sounded a harsh clash when stacked with Ah Poor Bird and Rose Rose Rose Red in the Round Stack view. The melody is now the correct D-centered, all-natural minor tune (same shape, just the right key), so the three-round quodlibet is consonant. Older installs get the corrected melody automatically; a score you customized yourself is left untouched (use "Refresh from template" to pull the fix).
 
 ## Media
 

--- a/scripts/migrations/158-fix-hey-ho-melody.js
+++ b/scripts/migrations/158-fix-hey-ho-melody.js
@@ -1,0 +1,124 @@
+/**
+ * Fix the built-in "Hey Ho Nobody Home" melody for installs that seeded it with
+ * the old mis-transcription (issue #2105).
+ *
+ * Background:
+ *   The shipped `seed-hey-ho-nobody-home` score was accidentally centered on G
+ *   with a major third (phrase 2 climbed to B-natural over a G tonic), which
+ *   contradicted its own metadata ("D Dorian") and — because the round anchors
+ *   the D-minor quodlibet with Ah Poor Bird and Rose Rose Rose Red — sounded a
+ *   B-against-F tritone when the three were stacked in RoundStack. The seed now
+ *   ships the correct D-centered, all-naturals melody (`HEY_HO_MELODY`), and its
+ *   canon voices rebuild from it via `canonVoice()`.
+ *
+ *   Fresh installs seed the corrected melody directly. An install whose
+ *   `data/rounds.json` already holds the old `seed-hey-ho-nobody-home` record
+ *   keeps the wrong score/scoreParts on disk. This migration replaces them with
+ *   the shipped versions ONLY when the stored `score` still exactly matches the
+ *   old shipped string — a user who customized their score is never clobbered
+ *   (they can pull the shipped version any time via "Refresh from template").
+ *   The `notation` text is corrected independently, gated on its own old-string
+ *   match, so a customized score with the stock notation still gets the truthful
+ *   description.
+ *
+ *   Fresh installs (no file) are a clean no-op. Re-runs detect the corrected
+ *   score/notation and skip.
+ *
+ *   Runs after migration 120's Songs→Rounds rename, so it targets the CURRENT
+ *   `data/rounds.json` / `rounds` key.
+ */
+
+import { readFile, writeFile, stat } from 'fs/promises';
+import { join } from 'path';
+import { SEED_ROUNDS } from '../../server/services/rounds.js';
+
+const ROUND_ID = 'seed-hey-ho-nobody-home';
+
+// The NEW shipped content — read from the single source of truth in rounds.js
+// (identity, not a copy) so this migration and the seed can never drift. The
+// migration test asserts these come from SEED_ROUNDS.
+const NEW_SEED = SEED_ROUNDS.find((r) => r.id === ROUND_ID);
+export const NEW_HEY_HO_SCORE = NEW_SEED.score;
+export const NEW_HEY_HO_SCORE_PARTS = NEW_SEED.scoreParts;
+export const NEW_HEY_HO_NOTATION = NEW_SEED.notation;
+
+// The OLD shipped melody — frozen exactly as SEED_ROUNDS shipped it BEFORE issue
+// #2105 (G-centered, B-natural major third). Hard-coded on purpose: this is the
+// fingerprint that tells "still the untouched shipped score" apart from a user
+// customization. Do NOT regenerate it from rounds.js — that would defeat the
+// point (it must NOT track the corrected melody).
+export const OLD_HEY_HO_SCORE = [
+  'clef: treble',
+  'key: C',
+  'time: 4/4',
+  'tempo: 76',
+  '',
+  '| G4h(Hey) D4h(ho) | G4q(no-) G4e(bo-) G4e(dy) D4h(home) |',
+  '| G4q(Meat) G4q(nor) A4q(drink) A4q(nor) | B4e(mon-) B4e(ey) B4e(have) B4e(I) A4h(none) |',
+  '| D5q(Still) C5q(I) D5q(will) C5q(be) | B4h(mer-) A4h(ry) |',
+].join('\n');
+
+// The OLD shipped notation — frozen exactly as it read before #2105 (the false
+// "B natural" + unverified Campin attribution). Gates the notation correction.
+export const OLD_HEY_HO_NOTATION =
+  'A round in up to six voices (Ravenscroft\'s Pammelia, 1609). New voices enter one two-bar phrase behind the last. Scored in D with no key signature — D Dorian, B natural. Melody after Jack Campin\'s D-minor round transcription.';
+
+const fileExists = (path) => stat(path).then(() => true, (err) => {
+  if (err.code === 'ENOENT') return false;
+  throw err;
+});
+
+export default {
+  async up({ rootDir }) {
+    const path = join(rootDir, 'data', 'rounds.json');
+    if (!(await fileExists(path))) {
+      console.log('📦 migration 158: no data/rounds.json — fresh install seeds the corrected melody directly.');
+      return { updated: 0, reason: 'no-file' };
+    }
+
+    const raw = await readFile(path, 'utf-8');
+    let doc;
+    try { doc = JSON.parse(raw); } catch (err) {
+      console.warn(`⚠️ migration 158: data/rounds.json is unparseable (${err.message}); skipping.`);
+      return { updated: 0, reason: 'unreadable' };
+    }
+    if (!doc || !Array.isArray(doc.rounds)) {
+      return { updated: 0, reason: 'unexpected-shape' };
+    }
+
+    const round = doc.rounds.find((r) => r && r.id === ROUND_ID);
+    if (!round) {
+      console.log('📦 migration 158: built-in Hey Ho Nobody Home not present; nothing to fix.');
+      return { updated: 0, reason: 'round-absent' };
+    }
+
+    let fixedScore = false;
+    let fixedNotation = false;
+
+    // Replace score + scoreParts only when the stored score is still the exact
+    // old shipped string. Deep-clone the scoreParts so the persisted record can't
+    // share array/object identity with the in-memory seed.
+    if (round.score === OLD_HEY_HO_SCORE) {
+      round.score = NEW_HEY_HO_SCORE;
+      round.scoreParts = NEW_HEY_HO_SCORE_PARTS.map((p) => ({ ...p }));
+      fixedScore = true;
+    }
+
+    // Correct the notation independently — a customized score with the stock
+    // notation still deserves the truthful text.
+    if (round.notation === OLD_HEY_HO_NOTATION) {
+      round.notation = NEW_HEY_HO_NOTATION;
+      fixedNotation = true;
+    }
+
+    if (!fixedScore && !fixedNotation) {
+      console.log('📦 migration 158: Hey Ho score/notation already corrected or customized; leaving it untouched.');
+      return { updated: 0, reason: 'already-applied' };
+    }
+
+    round.updatedAt = new Date().toISOString();
+    await writeFile(path, JSON.stringify(doc, null, 2) + '\n');
+    console.log(`📦 migration 158: fixed Hey Ho Nobody Home (score: ${fixedScore}, notation: ${fixedNotation}).`);
+    return { updated: 1, fixedScore, fixedNotation };
+  },
+};

--- a/scripts/migrations/158-fix-hey-ho-melody.test.js
+++ b/scripts/migrations/158-fix-hey-ho-melody.test.js
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import migration, {
+  OLD_HEY_HO_SCORE,
+  OLD_HEY_HO_NOTATION,
+  NEW_HEY_HO_SCORE,
+  NEW_HEY_HO_SCORE_PARTS,
+  NEW_HEY_HO_NOTATION,
+} from './158-fix-hey-ho-melody.js';
+import { SEED_ROUNDS } from '../../server/services/rounds.js';
+
+const ROUND_ID = 'seed-hey-ho-nobody-home';
+const writeJson = (path, value) => writeFileSync(path, JSON.stringify(value, null, 2) + '\n');
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf-8'));
+const findRound = (path, id) => readJson(path).rounds.find((r) => r.id === id);
+
+describe('migration 158 — fix Hey Ho Nobody Home melody', () => {
+  let rootDir;
+  let roundsPath;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'migration-158-'));
+    mkdirSync(join(rootDir, 'data'), { recursive: true });
+    roundsPath = join(rootDir, 'data', 'rounds.json');
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  // Drift guard (b): the migration's NEW constants ARE the current seed (identity,
+  // not copies) — so the migration can never restore a stale melody.
+  it('new constants are the current seed (single source, no drift)', () => {
+    const seed = SEED_ROUNDS.find((r) => r.id === ROUND_ID);
+    expect(NEW_HEY_HO_SCORE).toBe(seed.score);
+    expect(NEW_HEY_HO_SCORE_PARTS).toBe(seed.scoreParts);
+    expect(NEW_HEY_HO_NOTATION).toBe(seed.notation);
+  });
+
+  // Drift guard (a): the frozen OLD constants are the pre-#2105 shipped strings —
+  // recognizably the wrong transcription, and DIFFERENT from the corrected seed.
+  it('old constants are the frozen pre-fix shipped strings, distinct from the new seed', () => {
+    expect(OLD_HEY_HO_SCORE).not.toBe(NEW_HEY_HO_SCORE);
+    // The old melody was G-centered with a B-natural major third.
+    expect(OLD_HEY_HO_SCORE).toContain('G4h(Hey)');
+    expect(OLD_HEY_HO_SCORE).toContain('B4e(mon-)');
+    // The corrected melody is D-centered with all naturals and no B.
+    expect(NEW_HEY_HO_SCORE).toContain('D4h(Hey)');
+    expect(NEW_HEY_HO_SCORE).not.toContain('B4');
+    expect(OLD_HEY_HO_NOTATION).not.toBe(NEW_HEY_HO_NOTATION);
+    expect(OLD_HEY_HO_NOTATION).toContain('B natural');
+    expect(NEW_HEY_HO_NOTATION).not.toContain('B natural');
+  });
+
+  it('no-ops when data/rounds.json is missing (fresh install seeds the fix directly)', async () => {
+    const result = await migration.up({ rootDir });
+    expect(result).toEqual({ updated: 0, reason: 'no-file' });
+    expect(existsSync(roundsPath)).toBe(false);
+  });
+
+  it('replaces score + scoreParts + notation on an untouched old record', async () => {
+    writeJson(roundsPath, {
+      rounds: [{ id: ROUND_ID, title: 'Hey Ho Nobody Home', score: OLD_HEY_HO_SCORE, scoreParts: [{ id: 'stale' }], notation: OLD_HEY_HO_NOTATION }],
+    });
+    const result = await migration.up({ rootDir });
+    expect(result).toEqual({ updated: 1, fixedScore: true, fixedNotation: true });
+    const round = findRound(roundsPath, ROUND_ID);
+    expect(round.score).toBe(NEW_HEY_HO_SCORE);
+    expect(round.scoreParts).toEqual(NEW_HEY_HO_SCORE_PARTS);
+    expect(round.notation).toBe(NEW_HEY_HO_NOTATION);
+  });
+
+  it('deep-clones the scoreParts (persisted record does not share identity with the seed)', async () => {
+    writeJson(roundsPath, { rounds: [{ id: ROUND_ID, score: OLD_HEY_HO_SCORE }] });
+    await migration.up({ rootDir });
+    const round = findRound(roundsPath, ROUND_ID);
+    // Value-equal but written to disk and re-read — proves it serialized cleanly.
+    expect(round.scoreParts).toEqual(NEW_HEY_HO_SCORE_PARTS);
+  });
+
+  it('corrects notation on a record whose score was customized (score left alone)', async () => {
+    const custom = 'clef: treble\nkey: C\ntime: 4/4\n\n| C4w(my) |';
+    writeJson(roundsPath, { rounds: [{ id: ROUND_ID, score: custom, notation: OLD_HEY_HO_NOTATION }] });
+    const result = await migration.up({ rootDir });
+    expect(result).toEqual({ updated: 1, fixedScore: false, fixedNotation: true });
+    const round = findRound(roundsPath, ROUND_ID);
+    expect(round.score).toBe(custom);
+    expect(round.notation).toBe(NEW_HEY_HO_NOTATION);
+  });
+
+  it('never clobbers a customized score with stock-but-already-fixed notation', async () => {
+    const custom = 'clef: treble\nkey: C\ntime: 4/4\n\n| C4w(my) |';
+    writeJson(roundsPath, { rounds: [{ id: ROUND_ID, score: custom, notation: NEW_HEY_HO_NOTATION }] });
+    const result = await migration.up({ rootDir });
+    expect(result).toEqual({ updated: 0, reason: 'already-applied' });
+    expect(findRound(roundsPath, ROUND_ID).score).toBe(custom);
+  });
+
+  it('is idempotent across re-runs', async () => {
+    writeJson(roundsPath, { rounds: [{ id: ROUND_ID, score: OLD_HEY_HO_SCORE, notation: OLD_HEY_HO_NOTATION }] });
+    await migration.up({ rootDir });
+    const second = await migration.up({ rootDir });
+    expect(second).toEqual({ updated: 0, reason: 'already-applied' });
+  });
+
+  it('no-ops when Hey Ho is absent (user deleted it)', async () => {
+    writeJson(roundsPath, { rounds: [{ id: 'round-custom' }] });
+    const result = await migration.up({ rootDir });
+    expect(result).toEqual({ updated: 0, reason: 'round-absent' });
+  });
+
+  it('skips an unparseable rounds.json instead of throwing', async () => {
+    writeFileSync(roundsPath, '{ not json');
+    const result = await migration.up({ rootDir });
+    expect(result).toEqual({ updated: 0, reason: 'unreadable' });
+  });
+});

--- a/server/services/rounds.js
+++ b/server/services/rounds.js
@@ -476,18 +476,25 @@ const canonVoice = (melody, { delayBars, id, label, role }) => {
 
 // Hey Ho Nobody Home — six bars, three 2-bar phrases. The classic 3-voice round:
 // voices enter one phrase (2 bars) apart, and the three phrases stack into the
-// full minor chord.
-const HEY_HO_MELODY = [
+// full D-minor chord. Centered on D with all naturals (score header `key: C` =
+// no key signature), so it stacks cleanly with Ah Poor Bird and Rose Rose Rose
+// Red in the D-minor quodlibet: phrase 1 (D/A) + phrase 2 (D–E–F) + phrase 3
+// (A–G–F–E) outline a D-minor triad, with no B-natural to sound a tritone
+// against the partners' F. Contour matches the Wikibooks Songbook (E-minor) and
+// Kodály teaching (D natural-minor) transcriptions, transposed to D
+// (1-1-2-2-♭3-♭3-♭3-♭3-2 in phrase 2). Exported so migration 158 can restore it
+// onto installs that still hold the old G-centered, major-third transcription.
+export const HEY_HO_MELODY = [
   'clef: treble',
   'key: C',
   'time: 4/4',
   'tempo: 76',
   '',
-  '| G4h(Hey) D4h(ho) | G4q(no-) G4e(bo-) G4e(dy) D4h(home) |',
-  '| G4q(Meat) G4q(nor) A4q(drink) A4q(nor) | B4e(mon-) B4e(ey) B4e(have) B4e(I) A4h(none) |',
-  '| D5q(Still) C5q(I) D5q(will) C5q(be) | B4h(mer-) A4h(ry) |',
+  '| D4h(Hey) A3h(ho) | D4q(no-) D4e(bo-) D4e(dy) A3h(home) |',
+  '| D4q(Meat) D4q(nor) E4q(drink) E4q(nor) | F4e(mon-) F4e(ey) F4e(have) F4e(I) E4h(none) |',
+  '| A4q(Still) G4q(I) A4q(will) G4q(be) | F4h(mer-) E4h(ry) |',
 ].join('\n');
-const HEY_HO_SCORE_PARTS = [
+export const HEY_HO_SCORE_PARTS = [
   canonVoice(HEY_HO_MELODY, { delayBars: 2, id: 'part-heyho-v2', label: 'Voice 2', role: 'voice-2' }),
   canonVoice(HEY_HO_MELODY, { delayBars: 4, id: 'part-heyho-v3', label: 'Voice 3', role: 'voice-3' }),
 ];
@@ -673,7 +680,7 @@ export const SEED_ROUNDS = [
     key: 'D minor (Dorian)',
     tempo: 76,
     rhythmShapeId: 'slow-4-4',
-    notation: 'A round in up to six voices (Ravenscroft\'s Pammelia, 1609). New voices enter one two-bar phrase behind the last. Scored in D with no key signature — D Dorian, B natural. Melody after Jack Campin\'s D-minor round transcription.',
+    notation: 'A round in up to six voices (Ravenscroft\'s Pammelia, 1609). New voices enter one two-bar phrase behind the last. Centered on D with no key signature — all naturals (D Dorian / natural minor), no B. Melody after the Wikibooks Songbook and Kodály teaching transcriptions, transposed to a D tonal center.',
     score: HEY_HO_MELODY,
     // Canonic voice stack: the melody entering one phrase (2 bars) late per voice
     // — the round sung against itself. Derived from HEY_HO_MELODY so it can't

--- a/server/services/rounds.test.js
+++ b/server/services/rounds.test.js
@@ -466,6 +466,60 @@ describe('rounds service', () => {
     }
   });
 
+  it('the corrected Hey Ho melody is D-centered with all naturals (no B, issue #2105)', async () => {
+    const songs = await svc.listRounds();
+    const heyHo = songs.find((s) => s.id === 'seed-hey-ho-nobody-home');
+    const parsed = parseScore(heyHo.score);
+    expect(parsed.errors).toEqual([]);
+    const letters = parsed.measures.flatMap((m) => m.notes.filter((n) => !n.rest).map((n) => n.pitch.letter));
+    // The old mis-transcription centered on G and climbed to a B-natural major
+    // third; the fix removes every B and re-centers on D.
+    expect(letters).not.toContain('B');
+    expect(letters[0]).toBe('D');
+    // The pitch content is the D natural-minor pentachord D–E–F–G–A only.
+    expect([...new Set(letters)].sort()).toEqual(['A', 'D', 'E', 'F', 'G']);
+  });
+
+  it('the D-minor quodlibet trio has no {B,F} tritone at any aligned beat (issue #2105)', async () => {
+    const songs = await svc.listRounds();
+    const trio = ['seed-hey-ho-nobody-home', 'seed-ah-poor-bird', 'seed-rose-rose-rose-red']
+      .map((id) => songs.find((s) => s.id === id));
+    trio.forEach((s, i) => expect(s, `missing quodlibet round ${i}`).toBeTruthy());
+
+    // Expand a score into an eighth-note grid of sounding pitch letters (one entry
+    // per 0.5-beat slot; null for a rest). Asserts a clean parse and full 4/4 bars
+    // along the way, so the trio's mechanical validity rides on this check too.
+    const GRID = 0.5;
+    const toGrid = (round) => {
+      const parsed = parseScore(round.score);
+      expect(parsed.errors, `${round.title}: ${parsed.errors.join('; ')}`).toEqual([]);
+      const grid = [];
+      for (const [i, m] of parsed.measures.entries()) {
+        expect(Math.abs(m.beats - 4) < 1e-9, `${round.title} bar ${i + 1} = ${m.beats} beats`).toBe(true);
+        for (const n of m.notes) {
+          const slots = Math.round(n.duration.beats / GRID);
+          for (let k = 0; k < slots; k += 1) grid.push(n.rest ? null : n.pitch.letter);
+        }
+      }
+      return grid;
+    };
+
+    const grids = trio.map(toGrid);
+    // Align the three looping rounds over the least common multiple of their
+    // lengths and assert no beat ever sounds a B and an F together (the tritone
+    // that the old G-centered Hey Ho produced against the partners' F naturals).
+    const gcd = (a, b) => (b === 0 ? a : gcd(b, a % b));
+    const lcmLen = grids.reduce((acc, g) => (acc * g.length) / gcd(acc, g.length), 1);
+    for (let i = 0; i < lcmLen; i += 1) {
+      const sounding = new Set();
+      for (const g of grids) { const p = g[i % g.length]; if (p) sounding.add(p); }
+      expect(
+        sounding.has('B') && sounding.has('F'),
+        `B-against-F tritone at slot ${i}: {${[...sounding].sort().join(',')}}`,
+      ).toBe(false);
+    }
+  });
+
   it('sanitizes partnerRoundIds — drops blanks, dedupes, and drops self-references', () => {
     const song = svc.sanitizeRound({
       id: 'seed-rose-rose-rose-red',


### PR DESCRIPTION
## Summary

Fixes the built-in **Hey Ho Nobody Home** round, whose seeded melody was mis-transcribed — centered on **G** with a **major third** (B-natural over a G tonic). That contradicted its own `key`/`notation` metadata ("D Dorian") and, because the round anchors the D-minor quodlibet with Ah Poor Bird and Rose Rose Rose Red, sounded a **B-against-F tritone** when the three stacked in the Round Stack view.

## Changes

- **`server/services/rounds.js`** — replace `HEY_HO_MELODY` with the correct D-centered, all-naturals tune (same contour, transposed down a fourth, minor third restored). Phrase 1 `D/A`, phrase 2 `D-D-E-E / F-F-F-F-E`, phrase 3 `A-G-A-G / F-E` — a clean D-minor triad against both partners, no B. `HEY_HO_SCORE_PARTS` rebuilds automatically via `canonVoice()`. Export both so the migration can restore them. Fix the `notation` text (no false "B natural", cite the Wikibooks Songbook / Kodály teaching transcriptions instead of the unverified Campin attribution).
- **`scripts/migrations/158-fix-hey-ho-melody.js` (+ test)** — restore the corrected `score`/`scoreParts`/`notation` onto installs still holding the exact old shipped strings; a customized score is left untouched. Mirrors the migration-073 drift-test pattern: frozen old constant (hard-coded), new constants imported from `rounds.js` (identity, not copies).
- **`server/services/rounds.test.js`** — assert the corrected melody has no B and is D-centered (pitch set `D–E–F–G–A`), and that the quodlibet trio has **no {B,F} tritone at any aligned beat** over the LCM of the three rounds' lengths (plus clean parse + full 4/4 bars).

## Testing

- `cd server && npm test` — 792 files, 15835 passed (DB suites skipped as designed).
- `cd client && npm test` — 293 files, 3144 passed.
- New: migration 158 (11 cases inc. drift guards) + 2 musical-correctness tests, all green.

Closes #2105