### PR TITLE
fix(tests): de-flake WordplayTrainer premature-submit assertion (#2139)

### DIFF
--- a/client/src/components/meatspace/post/WordplayTrainer.test.jsx
+++ b/client/src/components/meatspace/post/WordplayTrainer.test.jsx
@@ -166,14 +166,30 @@ describe('WordplayTrainer — training-log persistence (issue #2097)', () => {
 
     await waitFor(() => expect(screen.getByText('news___')).toBeInTheDocument());
 
-    const input = screen.getByPlaceholderText(/bridge word is/i);
-    fireEvent.change(input, { target: { value: 'wrongword' } });
+    // Answer the FIRST of two puzzles.
+    fireEvent.change(screen.getByPlaceholderText(/bridge word is/i), { target: { value: 'wrongword' } });
     fireEvent.click(screen.getByText('Submit'));
 
-    // First of two puzzles — advancing shows "Next", not "See Results", and
-    // no training entry has been logged yet (only the final round does).
-    await screen.findByText('Next');
+    // Non-final question → the feedback panel's advance button reads "Next"
+    // (not "See Results"). Instead of a bare synchronous "not called yet"
+    // check at one incidental instant (which CI's variable scheduling could
+    // trip), gate the negative assertion on an explicit, settled observable
+    // transition: advancing to the SECOND puzzle. If any premature-submit
+    // regression fired a training entry mid-round, it would have happened by
+    // the time puzzle two has rendered.
+    fireEvent.click(await screen.findByText('Next'));
+    await waitFor(() => expect(screen.getByText('sun___')).toBeInTheDocument());
     expect(submitTrainingEntry).not.toHaveBeenCalled();
+
+    // Positive anchor (deterministic): only completing the FINAL puzzle logs
+    // the entry — and exactly once. This pins the round-completion boundary so
+    // the mid-round negative above can't pass vacuously.
+    fireEvent.change(screen.getByPlaceholderText(/bridge word is/i), { target: { value: 'wrongagain' } });
+    fireEvent.click(screen.getByText('Submit'));
+    const seeResults = await screen.findByText('See Results');
+    expect(submitTrainingEntry).not.toHaveBeenCalled(); // still mid-flow until clicked
+    fireEvent.click(seeResults);
+    await waitFor(() => expect(submitTrainingEntry).toHaveBeenCalledTimes(1));
   });
 
   it('persists a Bridge Word breakdown with a readable prompt built from the clue set (issue #2114)', async () => {


### PR DESCRIPTION
## Summary

De-flakes the one genuinely order/timing-sensitive client test called out in #2139:

- `client/src/components/meatspace/post/WordplayTrainer.test.jsx` › *does not submit a training entry before the round completes*

The three server suites in #2139 (peerSync / manuscriptReview / promoteToPipeline) were NOT flaky — they were a real, deterministic regression from #2136 (a static import dragging `fileUtils.PATHS` into the module graph, breaking suites that partial-mock fileUtils without PATHS), already fixed on that branch. This PR is scoped to the client test only.

## Root cause

`submitTrainingEntry` is called in exactly one place — `handleNext`, and only when `questionIndex + 1 >= totalPrompts` (the final "See Results" click). The old test asserted `expect(submitTrainingEntry).not.toHaveBeenCalled()` at a single incidental instant right after `await screen.findByText('Next')`, with no settled boundary that distinguishes "mid-round" from "round-complete." It's an inherently order/timing-sensitive negative assertion — the class of check CI's slower, variable scheduling can trip.

## Fix

Anchor the negative assertion to explicit, settled observable state transitions instead of a bare "not called yet" check:

1. Answer puzzle 1 → click the feedback panel's **Next** button → `waitFor` the SECOND puzzle to render, then assert `submitTrainingEntry` was NOT called (mid-round boundary is now a real DOM transition, not an incidental instant).
2. Answer the FINAL puzzle → **See Results** → assert `submitTrainingEntry` was called **exactly once**.

The positive anchor (called exactly once after the final round) pins the round-completion boundary so the mid-round negative can't pass vacuously. Intent is preserved and strengthened: a premature-submit regression still fails the test — now deterministically, independent of CI scheduling. No timeout bumps or retries.

## Verification

`cd client && npx vitest run src/components/meatspace/post/WordplayTrainer.test.jsx` — run 3×, all green (5/5 tests each run).

Refs #2139.

https://claude.ai/code/session_01PZkEpYs1wF8viV6yT9pzvE