### PR TITLE
feat([issue-2141]): trusted-organizations registry + per-field holdings

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -7,6 +7,7 @@
 ## Privacy Center
 
 - **[issue-2140] Encrypted PII Vault** — PortOS can now store your identity facts (legal name, addresses, phones, emails, DOB, ID documents, financial-account stubs) in an encrypted-at-rest vault: values are AES-256-GCM encrypted with a key auto-provisioned into your `.env` on first use, the API only ever shows masked values (like `••••6789` or `j•••@example.com`) unless you explicitly reveal one, and sensitive document types can never be marked for use in the upcoming data-broker scans. This is Phase 1 of the Privacy Center (epic #2138) — the UI arrives in Phase 3.
+- **[issue-2141] Trusted Organizations registry** — the Privacy Center now has a place to track every organization that has (or had) your PII — banks, utilities, government, employers, subscriptions, medical, insurers, platforms — each with a trust stance (trusted/tolerated/unwanted) and per-org holdings linking to the exact vault records they hold. Holdings always show masked values, never plaintext, and deleting an organization or a vault record automatically cleans up its holdings. This is Phase 2 of the Privacy Center (epic #2138) — it's the data backbone for the upcoming change-of-address inventory and "who has my PII" view; the UI still arrives in Phase 3.
 
 ## Songs
 

--- a/scripts/migrations/162-privacy-orgs-tables.js
+++ b/scripts/migrations/162-privacy-orgs-tables.js
@@ -1,0 +1,27 @@
+/**
+ * Registration stub for the Privacy Center Trusted Organizations registry
+ * (issue #2141, epic #2138).
+ *
+ * The actual DDL — `CREATE TABLE IF NOT EXISTS privacy_orgs` and
+ * `privacy_org_holdings` (+ their indexes) — is idempotent and lives in
+ * `ensureSchema()` (`server/lib/db.js`) and the fresh-install seed
+ * (`server/scripts/init-db.sql`), both of which run at server boot AFTER the
+ * DB pool is up. The `scripts/migrations/` runner executes BEFORE the pool is
+ * initialized, so a DB-table create cannot live here — the same reason
+ * migrations 048–052, 108, and 160/161 are boot-time + stub-registered.
+ *
+ * This stub exists so the new-table change is *registered the standard way*:
+ * it lands in `data/migrations.applied.json` so the migration ledger and
+ * `git log` show when the trusted-organizations tables were introduced. Both
+ * tables are additive (brand-new, machine-local db-primary stores) with no
+ * data backfill — the privacyOrgs service populates them lazily as the user
+ * adds organizations and holdings.
+ *
+ * No-op + idempotent: nothing to do here.
+ */
+
+export default {
+  async up() {
+    console.log('🏢 privacy_orgs/privacy_org_holdings: tables created idempotently by ensureSchema at boot; nothing to do in the file runner');
+  },
+};

--- a/server/lib/README.md
+++ b/server/lib/README.md
@@ -42,7 +42,7 @@ The barrel `server/lib/index.js` is a machine-checkable enumeration of every pub
 | `peerSyncValidation.js` | Federated peer-sync wire/request schemas (push payload, subscribe, sync-now, pull-metadata). |
 | `pipelineValidation.js` | Creative-production pipeline schemas (Writers Room works/folders/live-mode/drafts, story-bible character/place/object, editorial checks, storyboard shots/scenes, prompt-stage config, issue-list query). |
 | `postValidation.js` | MeatSpace POST (Power On Self Test) schemas — drill config (incl. adaptive toggle), drill generation/scoring, sessions, memory builder, training log. |
-| `privacyValidation.js` | Privacy Center PII Vault schemas (issue #2140) — vault record create/update (partial PUT), list query, UUID params; the vault type/status vocabularies + the sensitive-type (`ssn`/`passport`/`drivers_license`/`financial_account`) `useForScans` hard-false rule and per-type scan defaults. |
+| `privacyValidation.js` | Privacy Center schemas — PII Vault (issue #2140): vault record create/update (partial PUT), list query, UUID params; the vault type/status vocabularies + the sensitive-type (`ssn`/`passport`/`drivers_license`/`financial_account`) `useForScans` hard-false rule and per-type scan defaults. Trusted Organizations registry (issue #2141): org create/update (partial PUT), list query, UUID params, and the replace-set holdings schema. |
 | `socketValidation.js` | Socket event payload schemas. |
 | `storyBuilderValidation.js` | Unified Story Builder session/step schemas. |
 | `telegramValidation.js` | Telegram bot config + test schemas. |

--- a/server/lib/db.js
+++ b/server/lib/db.js
@@ -1313,6 +1313,44 @@ async function ensureSchemaImpl() {
       granted_at TIMESTAMPTZ DEFAULT NOW()
     )`,
 
+    // ─── Privacy Center: Trusted Organizations registry (issue #2141, epic
+    // #2138) ──────────────────────────────────────────────────────────────
+    // Every organization that has (or had) the user's PII, with a trust
+    // stance and per-org holdings linking to the exact vault records each org
+    // holds. Data backbone for the change-of-address inventory (Phase 4) and
+    // the "who has my PII" view. Machine-local: no federation, no tombstones
+    // (same deferred scope as the vault, #2148). Mirrors the privacy blocks
+    // in init-db.sql.
+    `CREATE TABLE IF NOT EXISTS privacy_orgs (
+      id UUID PRIMARY KEY,
+      name TEXT NOT NULL,
+      category TEXT NOT NULL DEFAULT 'other',
+      website TEXT NOT NULL DEFAULT '',
+      trust TEXT NOT NULL DEFAULT 'trusted',
+      status TEXT NOT NULL DEFAULT 'active',
+      contact JSONB NOT NULL DEFAULT '{}'::jsonb,
+      social_account_id TEXT,
+      notes TEXT NOT NULL DEFAULT '',
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      updated_at TIMESTAMPTZ DEFAULT NOW()
+    )`,
+    `CREATE INDEX IF NOT EXISTS idx_privacy_orgs_trust ON privacy_orgs (trust)`,
+    `CREATE INDEX IF NOT EXISTS idx_privacy_orgs_status ON privacy_orgs (status)`,
+    // Which vault records each org holds. Composite PK (no surrogate id) — an
+    // org either holds a given vault record or it doesn't, so the pair IS the
+    // identity. Cascade both ways: deleting the org or the vault record drops
+    // its holdings rows.
+    `CREATE TABLE IF NOT EXISTS privacy_org_holdings (
+      org_id UUID NOT NULL REFERENCES privacy_orgs (id) ON DELETE CASCADE,
+      vault_record_id UUID NOT NULL REFERENCES privacy_vault_records (id) ON DELETE CASCADE,
+      status TEXT NOT NULL DEFAULT 'current',
+      noted_at TIMESTAMPTZ DEFAULT NOW(),
+      updated_at TIMESTAMPTZ DEFAULT NOW(),
+      PRIMARY KEY (org_id, vault_record_id)
+    )`,
+    // Reverse lookup: "which orgs hold vault record X" (getOrgsHoldingRecord).
+    `CREATE INDEX IF NOT EXISTS idx_privacy_org_holdings_vault_record ON privacy_org_holdings (vault_record_id)`,
+
     // ─── Deletion audit log (incident #1248-follow-up) ──────────────────────
     // Append-only forensic trail of EVERY tombstone (soft-delete), un-tombstone
     // (recovery), and hard-delete of user-authored records — written by a DB

--- a/server/lib/privacyValidation.js
+++ b/server/lib/privacyValidation.js
@@ -76,3 +76,72 @@ export const privacyVaultListQuerySchema = z.object({
 export const privacyVaultIdParamsSchema = z.object({
   id: z.string().uuid(),
 }).strict();
+
+// =============================================================================
+// TRUSTED ORGANIZATIONS REGISTRY SCHEMAS (issue #2141, epic #2138)
+// =============================================================================
+// Zod schemas for `privacy_orgs` / `privacy_org_holdings` — db-primary Postgres,
+// machine-local (same federation-deferred scope as the vault, #2148).
+
+export const PRIVACY_ORG_CATEGORIES = Object.freeze([
+  'bank', 'utility', 'government', 'employer', 'subscription',
+  'medical', 'insurance', 'platform', 'broker', 'other',
+]);
+
+export const PRIVACY_ORG_TRUST_LEVELS = Object.freeze(['trusted', 'tolerated', 'unwanted']);
+
+export const PRIVACY_ORG_STATUSES = Object.freeze(['active', 'closed', 'opted_out']);
+
+export const PRIVACY_ORG_HOLDING_STATUSES = Object.freeze([
+  'current', 'update_pending', 'updated', 'removed', 'unknown',
+]);
+
+const privacyOrgContactSchema = z.object({
+  email: z.string().max(320).optional(),
+  phone: z.string().max(64).optional(),
+  portalUrl: z.string().max(2000).optional(),
+  mailingAddress: z.string().max(2000).optional(),
+}).strict();
+
+export const privacyOrgCreateSchema = z.object({
+  name: z.string().trim().min(1).max(200),
+  category: z.enum(PRIVACY_ORG_CATEGORIES).optional(),
+  website: z.string().max(2000).optional(),
+  trust: z.enum(PRIVACY_ORG_TRUST_LEVELS).optional(),
+  status: z.enum(PRIVACY_ORG_STATUSES).optional(),
+  contact: privacyOrgContactSchema.optional(),
+  socialAccountId: z.string().max(200).nullable().optional(),
+  notes: z.string().max(5000).optional(),
+}).strict();
+
+// PUT is a partial update — every field optional, same shape otherwise.
+export const privacyOrgUpdateSchema = z.object({
+  name: z.string().trim().min(1).max(200).optional(),
+  category: z.enum(PRIVACY_ORG_CATEGORIES).optional(),
+  website: z.string().max(2000).optional(),
+  trust: z.enum(PRIVACY_ORG_TRUST_LEVELS).optional(),
+  status: z.enum(PRIVACY_ORG_STATUSES).optional(),
+  contact: privacyOrgContactSchema.optional(),
+  socialAccountId: z.string().max(200).nullable().optional(),
+  notes: z.string().max(5000).optional(),
+}).strict();
+
+export const privacyOrgListQuerySchema = z.object({
+  trust: z.enum(PRIVACY_ORG_TRUST_LEVELS).optional(),
+  status: z.enum(PRIVACY_ORG_STATUSES).optional(),
+  category: z.enum(PRIVACY_ORG_CATEGORIES).optional(),
+}).strict();
+
+export const privacyOrgIdParamsSchema = z.object({
+  id: z.string().uuid(),
+}).strict();
+
+// PUT /api/privacy/orgs/:id/holdings — replace-set semantics: body is the
+// full list of vault record ids (+ optional status) this org holds. An empty
+// array clears all holdings for the org.
+export const privacyOrgHoldingsSetSchema = z.object({
+  holdings: z.array(z.object({
+    vaultRecordId: z.string().uuid(),
+    status: z.enum(PRIVACY_ORG_HOLDING_STATUSES).optional(),
+  }).strict()).max(500),
+}).strict();

--- a/server/routes/privacy.js
+++ b/server/routes/privacy.js
@@ -1,9 +1,11 @@
 /**
- * Privacy Center Routes — encrypted PII Vault REST surface (issue #2140).
+ * Privacy Center Routes — encrypted PII Vault + Trusted Organizations
+ * registry REST surface (issues #2140, #2141).
  *
- * Mounted at /api/privacy. List/read responses carry `maskedValue` only —
- * `value_enc` and plaintext never leave the service except through the ONE
- * explicit reveal endpoint.
+ * Mounted at /api/privacy. Vault list/read responses carry `maskedValue`
+ * only — `value_enc` and plaintext never leave the service except through
+ * the ONE explicit reveal endpoint. Org holdings responses join the vault's
+ * masked fields only — never plaintext.
  */
 
 import { Router } from 'express';
@@ -14,6 +16,11 @@ import {
   privacyVaultUpdateSchema,
   privacyVaultListQuerySchema,
   privacyVaultIdParamsSchema,
+  privacyOrgCreateSchema,
+  privacyOrgUpdateSchema,
+  privacyOrgListQuerySchema,
+  privacyOrgIdParamsSchema,
+  privacyOrgHoldingsSetSchema,
 } from '../lib/privacyValidation.js';
 import {
   createVaultRecord,
@@ -24,6 +31,15 @@ import {
   revealValue,
   getVaultStatus,
 } from '../services/privacyVault.js';
+import {
+  createOrg,
+  listOrgs,
+  getOrg,
+  updateOrg,
+  deleteOrg,
+  setOrgHoldings,
+  getHoldingsForOrg,
+} from '../services/privacyOrgs.js';
 
 const router = Router();
 
@@ -62,6 +78,47 @@ router.delete('/vault/:id', asyncHandler(async (req, res) => {
 router.post('/vault/:id/reveal', asyncHandler(async (req, res) => {
   const { id } = validateRequest(privacyVaultIdParamsSchema, req.params);
   res.json(await revealValue(id));
+}));
+
+// ─── Trusted Organizations registry (issue #2141) ──────────────────────────
+
+router.get('/orgs', asyncHandler(async (req, res) => {
+  const filters = validateRequest(privacyOrgListQuerySchema, req.query);
+  res.json(await listOrgs(filters));
+}));
+
+router.post('/orgs', asyncHandler(async (req, res) => {
+  const data = validateRequest(privacyOrgCreateSchema, req.body);
+  res.status(201).json(await createOrg(data));
+}));
+
+router.get('/orgs/:id', asyncHandler(async (req, res) => {
+  const { id } = validateRequest(privacyOrgIdParamsSchema, req.params);
+  const org = await getOrg(id);
+  if (!org) throw new ServerError('Organization not found', { status: 404, code: 'NOT_FOUND' });
+  res.json(org);
+}));
+
+router.put('/orgs/:id', asyncHandler(async (req, res) => {
+  const { id } = validateRequest(privacyOrgIdParamsSchema, req.params);
+  const patch = validateRequest(privacyOrgUpdateSchema, req.body);
+  res.json(await updateOrg(id, patch));
+}));
+
+router.delete('/orgs/:id', asyncHandler(async (req, res) => {
+  const { id } = validateRequest(privacyOrgIdParamsSchema, req.params);
+  res.json(await deleteOrg(id));
+}));
+
+router.get('/orgs/:id/holdings', asyncHandler(async (req, res) => {
+  const { id } = validateRequest(privacyOrgIdParamsSchema, req.params);
+  res.json(await getHoldingsForOrg(id));
+}));
+
+router.put('/orgs/:id/holdings', asyncHandler(async (req, res) => {
+  const { id } = validateRequest(privacyOrgIdParamsSchema, req.params);
+  const { holdings } = validateRequest(privacyOrgHoldingsSetSchema, req.body);
+  res.json(await setOrgHoldings(id, holdings));
 }));
 
 export default router;

--- a/server/routes/privacy.js
+++ b/server/routes/privacy.js
@@ -112,6 +112,8 @@ router.delete('/orgs/:id', asyncHandler(async (req, res) => {
 
 router.get('/orgs/:id/holdings', asyncHandler(async (req, res) => {
   const { id } = validateRequest(privacyOrgIdParamsSchema, req.params);
+  const org = await getOrg(id);
+  if (!org) throw new ServerError('Organization not found', { status: 404, code: 'NOT_FOUND' });
   res.json(await getHoldingsForOrg(id));
 }));
 

--- a/server/routes/privacy.test.js
+++ b/server/routes/privacy.test.js
@@ -185,9 +185,16 @@ describe('DELETE /api/privacy/orgs/:id', () => {
 
 describe('GET /api/privacy/orgs/:id/holdings', () => {
   it('returns the joined masked holdings for the org', async () => {
+    orgService.getOrg.mockResolvedValueOnce({ id: VALID_UUID, name: 'Acme Bank' });
     const res = await request(makeApp()).get(`/api/privacy/orgs/${VALID_UUID}/holdings`);
     expect(res.status).toBe(200);
     expect(res.body).toEqual([{ orgId: 'o1', vaultRecordId: 'v1', vaultMaskedValue: 'a•••@b.com' }]);
+  });
+
+  it('404s a missing org before ever querying holdings', async () => {
+    const res = await request(makeApp()).get(`/api/privacy/orgs/${VALID_UUID}/holdings`);
+    expect(res.status).toBe(404);
+    expect(orgService.getHoldingsForOrg).not.toHaveBeenCalled();
   });
 });
 

--- a/server/routes/privacy.test.js
+++ b/server/routes/privacy.test.js
@@ -20,8 +20,19 @@ vi.mock('../services/privacyVault.js', () => ({
   getVaultStatus: vi.fn(async () => ({ keyConfigured: true, recordCounts: { email: 1 } })),
 }));
 
+vi.mock('../services/privacyOrgs.js', () => ({
+  createOrg: vi.fn(async (input) => ({ id: 'c0ffee00-0000-4000-8000-000000000002', name: input.name, trust: input.trust ?? 'trusted' })),
+  listOrgs: vi.fn(async () => [{ id: 'o1', name: 'Acme Bank', trust: 'trusted' }]),
+  getOrg: vi.fn(async () => null),
+  updateOrg: vi.fn(async (id, patch) => ({ id, ...patch })),
+  deleteOrg: vi.fn(async () => ({ ok: true })),
+  setOrgHoldings: vi.fn(async (id, holdings) => holdings.map((h) => ({ orgId: id, ...h }))),
+  getHoldingsForOrg: vi.fn(async () => [{ orgId: 'o1', vaultRecordId: 'v1', vaultMaskedValue: 'a•••@b.com' }]),
+}));
+
 const privacyRoutes = (await import('./privacy.js')).default;
 const service = await import('../services/privacyVault.js');
+const orgService = await import('../services/privacyOrgs.js');
 
 const VALID_UUID = 'c0ffee00-0000-4000-8000-000000000001';
 
@@ -114,5 +125,85 @@ describe('GET /api/privacy/vault/:id', () => {
   it('404s a missing record', async () => {
     const res = await request(makeApp()).get(`/api/privacy/vault/${VALID_UUID}`);
     expect(res.status).toBe(404);
+  });
+});
+
+describe('GET /api/privacy/orgs', () => {
+  it('lists orgs and accepts trust/status/category filters', async () => {
+    const res = await request(makeApp()).get('/api/privacy/orgs');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ id: 'o1', name: 'Acme Bank', trust: 'trusted' }]);
+
+    expect((await request(makeApp()).get('/api/privacy/orgs?trust=unwanted')).status).toBe(200);
+    expect(orgService.listOrgs).toHaveBeenCalledWith({ trust: 'unwanted' });
+    expect((await request(makeApp()).get('/api/privacy/orgs?trust=bogus')).status).toBe(400);
+  });
+});
+
+describe('POST /api/privacy/orgs', () => {
+  it('creates an org from a valid body', async () => {
+    const res = await request(makeApp()).post('/api/privacy/orgs').send({ name: 'Acme Bank', category: 'bank' });
+    expect(res.status).toBe(201);
+    expect(orgService.createOrg).toHaveBeenCalledWith({ name: 'Acme Bank', category: 'bank' });
+  });
+
+  it('rejects a missing name, an unknown category/trust, and unknown keys', async () => {
+    expect((await request(makeApp()).post('/api/privacy/orgs').send({})).status).toBe(400);
+    expect((await request(makeApp()).post('/api/privacy/orgs').send({ name: 'X', category: 'nope' })).status).toBe(400);
+    expect((await request(makeApp()).post('/api/privacy/orgs').send({ name: 'X', trust: 'nope' })).status).toBe(400);
+    expect((await request(makeApp()).post('/api/privacy/orgs').send({ name: 'X', extra: 1 })).status).toBe(400);
+  });
+});
+
+describe('GET /api/privacy/orgs/:id', () => {
+  it('404s a missing org', async () => {
+    const res = await request(makeApp()).get(`/api/privacy/orgs/${VALID_UUID}`);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('PUT /api/privacy/orgs/:id', () => {
+  it('applies a partial patch', async () => {
+    const res = await request(makeApp()).put(`/api/privacy/orgs/${VALID_UUID}`).send({ trust: 'unwanted' });
+    expect(res.status).toBe(200);
+    expect(orgService.updateOrg).toHaveBeenCalledWith(VALID_UUID, { trust: 'unwanted' });
+  });
+
+  it('rejects a non-uuid id and an unknown enum value', async () => {
+    expect((await request(makeApp()).put('/api/privacy/orgs/not-a-uuid').send({ name: 'x' })).status).toBe(400);
+    expect((await request(makeApp()).put(`/api/privacy/orgs/${VALID_UUID}`).send({ status: 'nope' })).status).toBe(400);
+  });
+});
+
+describe('DELETE /api/privacy/orgs/:id', () => {
+  it('deletes by id and validates the uuid', async () => {
+    expect((await request(makeApp()).delete(`/api/privacy/orgs/${VALID_UUID}`)).status).toBe(200);
+    expect(orgService.deleteOrg).toHaveBeenCalledWith(VALID_UUID);
+    expect((await request(makeApp()).delete('/api/privacy/orgs/nope')).status).toBe(400);
+  });
+});
+
+describe('GET /api/privacy/orgs/:id/holdings', () => {
+  it('returns the joined masked holdings for the org', async () => {
+    const res = await request(makeApp()).get(`/api/privacy/orgs/${VALID_UUID}/holdings`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ orgId: 'o1', vaultRecordId: 'v1', vaultMaskedValue: 'a•••@b.com' }]);
+  });
+});
+
+describe('PUT /api/privacy/orgs/:id/holdings', () => {
+  it('replace-sets holdings from a valid body', async () => {
+    const res = await request(makeApp()).put(`/api/privacy/orgs/${VALID_UUID}/holdings`)
+      .send({ holdings: [{ vaultRecordId: VALID_UUID, status: 'current' }] });
+    expect(res.status).toBe(200);
+    expect(orgService.setOrgHoldings).toHaveBeenCalledWith(
+      VALID_UUID, [{ vaultRecordId: VALID_UUID, status: 'current' }],
+    );
+  });
+
+  it('accepts an empty list (clears all holdings) and rejects an unknown status', async () => {
+    expect((await request(makeApp()).put(`/api/privacy/orgs/${VALID_UUID}/holdings`).send({ holdings: [] })).status).toBe(200);
+    expect((await request(makeApp()).put(`/api/privacy/orgs/${VALID_UUID}/holdings`)
+      .send({ holdings: [{ vaultRecordId: VALID_UUID, status: 'nope' }] })).status).toBe(400);
   });
 });

--- a/server/scripts/init-db.sql
+++ b/server/scripts/init-db.sql
@@ -1098,6 +1098,43 @@ CREATE TABLE IF NOT EXISTS privacy_consents (
   granted_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+-- Privacy Center: Trusted Organizations registry (issue #2141, epic #2138).
+-- Every organization that has (or had) the user's PII, with a trust stance
+-- and per-org holdings linking to the exact vault records each org holds.
+-- Data backbone for the change-of-address inventory (Phase 4) and the "who
+-- has my PII" view. Machine-local — no federation, no tombstones (same
+-- deferred scope as the vault, #2148). Mirrors the privacy blocks in
+-- server/lib/db.js ensureSchema().
+CREATE TABLE IF NOT EXISTS privacy_orgs (
+  id UUID PRIMARY KEY,
+  name TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'other',
+  website TEXT NOT NULL DEFAULT '',
+  trust TEXT NOT NULL DEFAULT 'trusted',
+  status TEXT NOT NULL DEFAULT 'active',
+  contact JSONB NOT NULL DEFAULT '{}'::jsonb,
+  social_account_id TEXT,
+  notes TEXT NOT NULL DEFAULT '',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_privacy_orgs_trust ON privacy_orgs (trust);
+CREATE INDEX IF NOT EXISTS idx_privacy_orgs_status ON privacy_orgs (status);
+-- Which vault records each org holds. Composite PK (no surrogate id) — an org
+-- either holds a given vault record or it doesn't, so the pair IS the
+-- identity. Cascade both ways: deleting the org or the vault record drops its
+-- holdings rows.
+CREATE TABLE IF NOT EXISTS privacy_org_holdings (
+  org_id UUID NOT NULL REFERENCES privacy_orgs (id) ON DELETE CASCADE,
+  vault_record_id UUID NOT NULL REFERENCES privacy_vault_records (id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'current',
+  noted_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (org_id, vault_record_id)
+);
+-- Reverse lookup: "which orgs hold vault record X" (getOrgsHoldingRecord).
+CREATE INDEX IF NOT EXISTS idx_privacy_org_holdings_vault_record ON privacy_org_holdings (vault_record_id);
+
 -- Deletion audit log (incident #1248-follow-up). Append-only forensic trail of
 -- every tombstone / un-tombstone / hard-delete of user-authored records, written
 -- by a DB trigger so it captures deletions from ANY source (app, a test suite's

--- a/server/services/privacyOrgs.db.test.js
+++ b/server/services/privacyOrgs.db.test.js
@@ -1,0 +1,150 @@
+/**
+ * Postgres-backed round-trip for the Trusted Organizations registry
+ * (issue #2141). Like privacyVault.db.test.js, this needs a live PostgreSQL
+ * with the schema applied. If no DB is reachable (CI, fresh checkout) it
+ * SKIPS cleanly rather than failing red. Exercises org CRUD, cascade deletes
+ * (org delete and vault-record delete both clean up holdings), the
+ * getOrgsHoldingRecord join, and the batch status flip. Runs via
+ * `npm run test:db` (→ portos_test) ONLY; the db.js guards refuse writes to
+ * a non-test DB.
+ */
+
+import { describe, it, expect, afterAll, beforeAll } from 'vitest';
+import { checkHealth, ensureSchema, query, close } from '../lib/db.js';
+
+const HEX_KEY = 'd'.repeat(64);
+const originalKey = process.env.PRIVACY_VAULT_KEY;
+process.env.PRIVACY_VAULT_KEY = HEX_KEY;
+
+let dbReady = false;
+let skipReason = '';
+{
+  const health = await checkHealth().catch((e) => ({ connected: false, error: e?.message }));
+  if (!health.connected) {
+    skipReason = `Postgres not reachable (${health.error || 'no connection'})`;
+  } else {
+    await ensureSchema().catch(() => {});
+    const probe = await query(
+      `SELECT EXISTS(SELECT 1 FROM information_schema.tables WHERE table_name = 'privacy_orgs') AS ok`,
+    ).catch(() => ({ rows: [{ ok: false }] }));
+    if (probe.rows?.[0]?.ok) dbReady = true;
+    else skipReason = 'privacy_orgs table not present';
+  }
+}
+
+if (!dbReady) console.log(`⏭️  privacyOrgs.db.test.js skipped: ${skipReason}`);
+
+describe.skipIf(!dbReady)('privacy orgs DB round-trip', () => {
+  let orgs;
+  let vault;
+  const createdOrgs = [];
+  const createdVaultRecords = [];
+
+  beforeAll(async () => {
+    orgs = await import('./privacyOrgs.js');
+    vault = await import('./privacyVault.js');
+  });
+
+  afterAll(async () => {
+    for (const id of createdOrgs) {
+      await query(`DELETE FROM privacy_orgs WHERE id = $1`, [id]).catch(() => {});
+    }
+    for (const id of createdVaultRecords) {
+      await query(`DELETE FROM privacy_vault_records WHERE id = $1`, [id]).catch(() => {});
+    }
+    await close();
+    if (originalKey === undefined) delete process.env.PRIVACY_VAULT_KEY;
+    else process.env.PRIVACY_VAULT_KEY = originalKey;
+  });
+
+  it('creates an org, attaches vault holdings, and queries both directions', async () => {
+    const record = await vault.createVaultRecord({ type: 'email', label: 'Work email', value: 'me@work.example' });
+    createdVaultRecords.push(record.id);
+
+    const org = await orgs.createOrg({ name: 'Acme Bank', category: 'bank', trust: 'trusted' });
+    createdOrgs.push(org.id);
+    expect(org.category).toBe('bank');
+
+    const holdings = await orgs.setOrgHoldings(org.id, [{ vaultRecordId: record.id, status: 'current' }]);
+    expect(holdings).toHaveLength(1);
+    expect(holdings[0]).toMatchObject({ vaultRecordId: record.id, vaultType: 'email', vaultMaskedValue: 'm•••@work.example' });
+    expect(JSON.stringify(holdings)).not.toContain('me@work.example');
+
+    const forOrg = await orgs.getHoldingsForOrg(org.id);
+    expect(forOrg).toHaveLength(1);
+
+    const holdingOrgs = await orgs.getOrgsHoldingRecord(record.id);
+    expect(holdingOrgs).toHaveLength(1);
+    expect(holdingOrgs[0]).toMatchObject({ orgId: org.id, orgName: 'Acme Bank' });
+  });
+
+  it('replace-set semantics: re-calling setOrgHoldings drops anything not listed', async () => {
+    const r1 = await vault.createVaultRecord({ type: 'phone', label: 'Cell', value: '+1 503 555 0100' });
+    const r2 = await vault.createVaultRecord({ type: 'address', label: 'Home', value: '1 Main St' });
+    createdVaultRecords.push(r1.id, r2.id);
+
+    const org = await orgs.createOrg({ name: 'Utility Co' });
+    createdOrgs.push(org.id);
+
+    await orgs.setOrgHoldings(org.id, [
+      { vaultRecordId: r1.id }, { vaultRecordId: r2.id },
+    ]);
+    expect(await orgs.getHoldingsForOrg(org.id)).toHaveLength(2);
+
+    await orgs.setOrgHoldings(org.id, [{ vaultRecordId: r1.id, status: 'update_pending' }]);
+    const after = await orgs.getHoldingsForOrg(org.id);
+    expect(after).toHaveLength(1);
+    expect(after[0]).toMatchObject({ vaultRecordId: r1.id, status: 'update_pending' });
+  });
+
+  it('cascades: deleting the org drops its holdings', async () => {
+    const record = await vault.createVaultRecord({ type: 'custom', label: 'Misc', value: 'x' });
+    createdVaultRecords.push(record.id);
+    const org = await orgs.createOrg({ name: 'Temp Org' });
+    await orgs.setOrgHoldings(org.id, [{ vaultRecordId: record.id }]);
+
+    await orgs.deleteOrg(org.id);
+    const { rows } = await query(`SELECT * FROM privacy_org_holdings WHERE org_id = $1`, [org.id]);
+    expect(rows).toHaveLength(0);
+    expect(await orgs.getOrg(org.id)).toBe(null);
+  });
+
+  it('cascades: deleting the vault record drops its holdings', async () => {
+    const record = await vault.createVaultRecord({ type: 'custom', label: 'Misc2', value: 'y' });
+    const org = await orgs.createOrg({ name: 'Another Org' });
+    createdOrgs.push(org.id);
+    await orgs.setOrgHoldings(org.id, [{ vaultRecordId: record.id }]);
+
+    await vault.deleteVaultRecord(record.id);
+    const { rows } = await query(`SELECT * FROM privacy_org_holdings WHERE vault_record_id = $1`, [record.id]);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('batch-flips holdings status across all orgs holding a record', async () => {
+    const record = await vault.createVaultRecord({ type: 'address', label: 'Old address', value: '9 Old Rd' });
+    createdVaultRecords.push(record.id);
+    const orgA = await orgs.createOrg({ name: 'Bank A' });
+    const orgB = await orgs.createOrg({ name: 'Bank B' });
+    createdOrgs.push(orgA.id, orgB.id);
+    await orgs.setOrgHoldings(orgA.id, [{ vaultRecordId: record.id, status: 'current' }]);
+    await orgs.setOrgHoldings(orgB.id, [{ vaultRecordId: record.id, status: 'current' }]);
+
+    const result = await orgs.setHoldingsStatus(record.id, 'current', 'update_pending');
+    expect(result.updated).toBe(2);
+    const holdingOrgs = await orgs.getOrgsHoldingRecord(record.id);
+    expect(holdingOrgs.every((h) => h.status === 'update_pending')).toBe(true);
+  });
+
+  it('validation rejects unknown enum values at the service boundary via the schema layer', async () => {
+    const { privacyOrgCreateSchema } = await import('../lib/privacyValidation.js');
+    expect(() => privacyOrgCreateSchema.parse({ name: 'X', trust: 'bogus' })).toThrow();
+    expect(() => privacyOrgCreateSchema.parse({ name: 'X', category: 'bogus' })).toThrow();
+    expect(() => privacyOrgCreateSchema.parse({ name: 'X', status: 'bogus' })).toThrow();
+  });
+
+  it('reports a holdings summary across orgs and vault records', async () => {
+    const summary = await orgs.getHoldingsSummary();
+    expect(Array.isArray(summary.byOrg)).toBe(true);
+    expect(Array.isArray(summary.byVaultRecord)).toBe(true);
+  });
+});

--- a/server/services/privacyOrgs.db.test.js
+++ b/server/services/privacyOrgs.db.test.js
@@ -109,6 +109,25 @@ describe.skipIf(!dbReady)('privacy orgs DB round-trip', () => {
     expect(await orgs.getOrg(org.id)).toBe(null);
   });
 
+  it('rejects a nonexistent vaultRecordId as a 400 and rolls back the whole call (transactional)', async () => {
+    const record = await vault.createVaultRecord({ type: 'custom', label: 'Real one', value: 'z' });
+    createdVaultRecords.push(record.id);
+    const org = await orgs.createOrg({ name: 'Rollback Org' });
+    createdOrgs.push(org.id);
+    // Seed one real holding so we can confirm it survives the failed call untouched.
+    await orgs.setOrgHoldings(org.id, [{ vaultRecordId: record.id }]);
+
+    await expect(orgs.setOrgHoldings(org.id, [
+      { vaultRecordId: record.id }, { vaultRecordId: '00000000-0000-4000-8000-000000000000' },
+    ])).rejects.toMatchObject({ status: 400, code: 'VAULT_RECORD_NOT_FOUND' });
+
+    // The transaction must have rolled back the DELETE-complement too — the
+    // pre-existing holding for `record.id` is still there, unchanged.
+    const holdings = await orgs.getHoldingsForOrg(org.id);
+    expect(holdings).toHaveLength(1);
+    expect(holdings[0].vaultRecordId).toBe(record.id);
+  });
+
   it('cascades: deleting the vault record drops its holdings', async () => {
     const record = await vault.createVaultRecord({ type: 'custom', label: 'Misc2', value: 'y' });
     const org = await orgs.createOrg({ name: 'Another Org' });

--- a/server/services/privacyOrgs.js
+++ b/server/services/privacyOrgs.js
@@ -164,10 +164,17 @@ export async function getOrgsHoldingRecord(vaultRecordId) {
  * a bad `vaultRecordId` partway through the upsert loop (foreign key
  * violation, see below) would leave the DELETE committed but only some of
  * the new rows written: neither the old nor the requested holdings set.
+ * `FOR UPDATE` row-locks the org for the duration of the transaction (same
+ * pattern as `updateVaultRecord` in privacyVault.js) — without it, two
+ * concurrent replace calls for the same org (e.g. a double-click, or two
+ * browser tabs saving holdings at once) can both pass the existence check,
+ * each delete against the pre-existing set, and each upsert their own rows —
+ * leaving the UNION of both requests rather than the last full replacement,
+ * silently defeating the documented replace-set semantics.
  */
 export async function setOrgHoldings(orgId, holdings) {
   await withTransaction(async (client) => {
-    const { rows: orgRows } = await client.query(`SELECT id FROM privacy_orgs WHERE id = $1`, [orgId]);
+    const { rows: orgRows } = await client.query(`SELECT id FROM privacy_orgs WHERE id = $1 FOR UPDATE`, [orgId]);
     if (!orgRows[0]) throw new ServerError('Organization not found', { status: 404, code: 'NOT_FOUND' });
 
     const ids = holdings.map((h) => h.vaultRecordId);

--- a/server/services/privacyOrgs.js
+++ b/server/services/privacyOrgs.js
@@ -10,6 +10,11 @@
  * Holdings responses join masked vault values ONLY — never plaintext. The
  * one decrypt path stays `revealValue()` in privacyVault.js; this service
  * never touches `value_enc`.
+ *
+ * Log lines never include the org `name` — a name like "my employer" or
+ * "Dr. Smith's practice" is itself privacy-adjacent (it reveals a
+ * relationship, not just an identity fact), so logs carry only id/category,
+ * mirroring the vault's plaintext-never-logged posture.
  */
 
 import { randomUUID } from 'crypto';
@@ -67,7 +72,10 @@ export async function createOrg(input) {
       input.notes ?? '',
     ],
   );
-  console.log(`🏢 Created privacy org ${id} (name=${input.name})`);
+  // Log id/category only — the org NAME (bank, employer, medical provider, …)
+  // is user-entered privacy-adjacent data and follows the same never-log
+  // posture as the vault's plaintext values (see privacyVault.js header).
+  console.log(`🏢 Created privacy org ${id} (category=${input.category ?? 'other'})`);
   return rowToOrg(rows[0]);
 }
 

--- a/server/services/privacyOrgs.js
+++ b/server/services/privacyOrgs.js
@@ -13,7 +13,7 @@
  */
 
 import { randomUUID } from 'crypto';
-import { query } from '../lib/db.js';
+import { query, withTransaction } from '../lib/db.js';
 import { ServerError } from '../lib/errorHandler.js';
 
 const ORG_COLUMNS = `id, name, category, website, trust, status, contact,
@@ -160,30 +160,44 @@ export async function getOrgsHoldingRecord(vaultRecordId) {
  * anything not listed is removed. Runs as one statement per side (delete the
  * complement, upsert the rest) rather than a delete-all + reinsert, so an
  * unrelated concurrent read never sees a momentarily-empty holdings set.
+ * The whole delete+upsert sequence runs inside ONE transaction — without it,
+ * a bad `vaultRecordId` partway through the upsert loop (foreign key
+ * violation, see below) would leave the DELETE committed but only some of
+ * the new rows written: neither the old nor the requested holdings set.
  */
 export async function setOrgHoldings(orgId, holdings) {
-  const org = await getOrg(orgId);
-  if (!org) throw new ServerError('Organization not found', { status: 404, code: 'NOT_FOUND' });
+  await withTransaction(async (client) => {
+    const { rows: orgRows } = await client.query(`SELECT id FROM privacy_orgs WHERE id = $1`, [orgId]);
+    if (!orgRows[0]) throw new ServerError('Organization not found', { status: 404, code: 'NOT_FOUND' });
 
-  const ids = holdings.map((h) => h.vaultRecordId);
-  if (ids.length === 0) {
-    await query(`DELETE FROM privacy_org_holdings WHERE org_id = $1`, [orgId]);
-  } else {
-    await query(
-      `DELETE FROM privacy_org_holdings WHERE org_id = $1 AND vault_record_id != ALL($2::uuid[])`,
-      [orgId, ids],
-    );
-    for (const h of holdings) {
-      await query(
-        `INSERT INTO privacy_org_holdings (org_id, vault_record_id, status, noted_at, updated_at)
-         VALUES ($1, $2, $3, NOW(), NOW())
-         ON CONFLICT (org_id, vault_record_id)
-         DO UPDATE SET status = EXCLUDED.status, updated_at = NOW()`,
-        [orgId, h.vaultRecordId, h.status ?? 'current'],
+    const ids = holdings.map((h) => h.vaultRecordId);
+    if (ids.length === 0) {
+      await client.query(`DELETE FROM privacy_org_holdings WHERE org_id = $1`, [orgId]);
+    } else {
+      await client.query(
+        `DELETE FROM privacy_org_holdings WHERE org_id = $1 AND vault_record_id != ALL($2::uuid[])`,
+        [orgId, ids],
       );
+      for (const h of holdings) {
+        // A vaultRecordId that doesn't exist (stale UI id, typo, raced with a
+        // deletion) trips the FK constraint — surface it as a clean 400
+        // instead of a raw Postgres constraint-violation 500.
+        await client.query(
+          `INSERT INTO privacy_org_holdings (org_id, vault_record_id, status, noted_at, updated_at)
+           VALUES ($1, $2, $3, NOW(), NOW())
+           ON CONFLICT (org_id, vault_record_id)
+           DO UPDATE SET status = EXCLUDED.status, updated_at = NOW()`,
+          [orgId, h.vaultRecordId, h.status ?? 'current'],
+        ).catch((err) => {
+          if (err?.code === '23503') {
+            throw new ServerError(`Vault record ${h.vaultRecordId} not found`, { status: 400, code: 'VAULT_RECORD_NOT_FOUND' });
+          }
+          throw err;
+        });
+      }
     }
-  }
-  console.log(`🔗 Set ${ids.length} holdings for privacy org ${orgId}`);
+    console.log(`🔗 Set ${ids.length} holdings for privacy org ${orgId}`);
+  });
   return getHoldingsForOrg(orgId);
 }
 

--- a/server/services/privacyOrgs.js
+++ b/server/services/privacyOrgs.js
@@ -1,0 +1,230 @@
+/**
+ * Trusted Organizations registry (issue #2141, epic #2138).
+ *
+ * db-primary Postgres per docs/STORAGE.md: `privacy_orgs` (one row per
+ * organization that has or had the user's PII) and `privacy_org_holdings`
+ * (which vault records each org holds, with a per-holding status). Machine-
+ * local: NO federation, NO tombstones (same deferred scope as the vault,
+ * #2148) — deletes are hard DELETEs with cascading holdings cleanup.
+ *
+ * Holdings responses join masked vault values ONLY — never plaintext. The
+ * one decrypt path stays `revealValue()` in privacyVault.js; this service
+ * never touches `value_enc`.
+ */
+
+import { randomUUID } from 'crypto';
+import { query } from '../lib/db.js';
+import { ServerError } from '../lib/errorHandler.js';
+
+const ORG_COLUMNS = `id, name, category, website, trust, status, contact,
+  social_account_id, notes, created_at, updated_at`;
+
+function rowToOrg(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    name: row.name,
+    category: row.category,
+    website: row.website,
+    trust: row.trust,
+    status: row.status,
+    contact: row.contact ?? {},
+    socialAccountId: row.social_account_id,
+    notes: row.notes,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function rowToHolding(row) {
+  return {
+    orgId: row.org_id,
+    vaultRecordId: row.vault_record_id,
+    status: row.status,
+    notedAt: row.noted_at,
+    updatedAt: row.updated_at,
+    // Present only on joined queries that select these columns.
+    ...(row.type !== undefined ? { vaultType: row.type } : {}),
+    ...(row.label !== undefined ? { vaultLabel: row.label } : {}),
+    ...(row.masked_value !== undefined ? { vaultMaskedValue: row.masked_value } : {}),
+    ...(row.org_name !== undefined ? { orgName: row.org_name } : {}),
+  };
+}
+
+export async function createOrg(input) {
+  const id = randomUUID();
+  const { rows } = await query(
+    `INSERT INTO privacy_orgs
+       (id, name, category, website, trust, status, contact, social_account_id, notes, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
+     RETURNING ${ORG_COLUMNS}`,
+    [
+      id, input.name,
+      input.category ?? 'other', input.website ?? '',
+      input.trust ?? 'trusted', input.status ?? 'active',
+      JSON.stringify(input.contact ?? {}),
+      input.socialAccountId ?? null,
+      input.notes ?? '',
+    ],
+  );
+  console.log(`🏢 Created privacy org ${id} (name=${input.name})`);
+  return rowToOrg(rows[0]);
+}
+
+export async function listOrgs({ trust, status, category } = {}) {
+  const clauses = [];
+  const params = [];
+  if (trust) { params.push(trust); clauses.push(`trust = $${params.length}`); }
+  if (status) { params.push(status); clauses.push(`status = $${params.length}`); }
+  if (category) { params.push(category); clauses.push(`category = $${params.length}`); }
+  const where = clauses.length ? `WHERE ${clauses.join(' AND ')}` : '';
+  const { rows } = await query(
+    `SELECT ${ORG_COLUMNS} FROM privacy_orgs ${where} ORDER BY name ASC`,
+    params,
+  );
+  return rows.map(rowToOrg);
+}
+
+export async function getOrg(id) {
+  const { rows } = await query(`SELECT ${ORG_COLUMNS} FROM privacy_orgs WHERE id = $1`, [id]);
+  return rowToOrg(rows[0]);
+}
+
+export async function updateOrg(id, patch) {
+  const sets = [];
+  const params = [];
+  const add = (column, value) => {
+    params.push(value);
+    sets.push(`${column} = $${params.length}`);
+  };
+  if (patch.name !== undefined) add('name', patch.name);
+  if (patch.category !== undefined) add('category', patch.category);
+  if (patch.website !== undefined) add('website', patch.website);
+  if (patch.trust !== undefined) add('trust', patch.trust);
+  if (patch.status !== undefined) add('status', patch.status);
+  if (patch.contact !== undefined) add('contact', JSON.stringify(patch.contact));
+  if (patch.socialAccountId !== undefined) add('social_account_id', patch.socialAccountId);
+  if (patch.notes !== undefined) add('notes', patch.notes);
+  params.push(id);
+  const { rows } = await query(
+    `UPDATE privacy_orgs SET ${[...sets, 'updated_at = NOW()'].join(', ')}
+     WHERE id = $${params.length} RETURNING ${ORG_COLUMNS}`,
+    params,
+  );
+  if (!rows[0]) throw new ServerError('Organization not found', { status: 404, code: 'NOT_FOUND' });
+  console.log(`🏢 Updated privacy org ${id}`);
+  return rowToOrg(rows[0]);
+}
+
+export async function deleteOrg(id) {
+  const { rows } = await query(`DELETE FROM privacy_orgs WHERE id = $1 RETURNING id`, [id]);
+  if (!rows[0]) throw new ServerError('Organization not found', { status: 404, code: 'NOT_FOUND' });
+  console.log(`🗑️ Deleted privacy org ${id} (holdings cascaded)`);
+  return { ok: true };
+}
+
+/**
+ * Which vault records does org `orgId` hold — joined with masked vault
+ * fields for display. Never selects `value_enc`.
+ */
+export async function getHoldingsForOrg(orgId) {
+  const { rows } = await query(
+    `SELECT h.org_id, h.vault_record_id, h.status, h.noted_at, h.updated_at,
+            v.type, v.label, v.masked_value
+     FROM privacy_org_holdings h
+     JOIN privacy_vault_records v ON v.id = h.vault_record_id
+     WHERE h.org_id = $1
+     ORDER BY v.type, v.label`,
+    [orgId],
+  );
+  return rows.map(rowToHolding);
+}
+
+/** Which orgs hold vault record `vaultRecordId` — powers the inventory view. */
+export async function getOrgsHoldingRecord(vaultRecordId) {
+  const { rows } = await query(
+    `SELECT h.org_id, h.vault_record_id, h.status, h.noted_at, h.updated_at,
+            o.name AS org_name
+     FROM privacy_org_holdings h
+     JOIN privacy_orgs o ON o.id = h.org_id
+     WHERE h.vault_record_id = $1
+     ORDER BY o.name`,
+    [vaultRecordId],
+  );
+  return rows.map(rowToHolding);
+}
+
+/**
+ * Replace-set the holdings for an org: the body's list of
+ * `{ vaultRecordId, status }` becomes the full holdings set for the org —
+ * anything not listed is removed. Runs as one statement per side (delete the
+ * complement, upsert the rest) rather than a delete-all + reinsert, so an
+ * unrelated concurrent read never sees a momentarily-empty holdings set.
+ */
+export async function setOrgHoldings(orgId, holdings) {
+  const org = await getOrg(orgId);
+  if (!org) throw new ServerError('Organization not found', { status: 404, code: 'NOT_FOUND' });
+
+  const ids = holdings.map((h) => h.vaultRecordId);
+  if (ids.length === 0) {
+    await query(`DELETE FROM privacy_org_holdings WHERE org_id = $1`, [orgId]);
+  } else {
+    await query(
+      `DELETE FROM privacy_org_holdings WHERE org_id = $1 AND vault_record_id != ALL($2::uuid[])`,
+      [orgId, ids],
+    );
+    for (const h of holdings) {
+      await query(
+        `INSERT INTO privacy_org_holdings (org_id, vault_record_id, status, noted_at, updated_at)
+         VALUES ($1, $2, $3, NOW(), NOW())
+         ON CONFLICT (org_id, vault_record_id)
+         DO UPDATE SET status = EXCLUDED.status, updated_at = NOW()`,
+        [orgId, h.vaultRecordId, h.status ?? 'current'],
+      );
+    }
+  }
+  console.log(`🔗 Set ${ids.length} holdings for privacy org ${orgId}`);
+  return getHoldingsForOrg(orgId);
+}
+
+/**
+ * Batch status flip across ALL orgs holding a given vault record — used by
+ * the Phase 4 change-of-address workflow ("mark every org holding my old
+ * address as update_pending"). Only rows currently in `fromStatus` flip.
+ */
+export async function setHoldingsStatus(vaultRecordId, fromStatus, toStatus) {
+  const { rows } = await query(
+    `UPDATE privacy_org_holdings SET status = $1, updated_at = NOW()
+     WHERE vault_record_id = $2 AND status = $3
+     RETURNING org_id, vault_record_id`,
+    [toStatus, vaultRecordId, fromStatus],
+  );
+  console.log(`🔁 Flipped ${rows.length} holdings for vault record ${vaultRecordId} (${fromStatus} → ${toStatus})`);
+  return { updated: rows.length };
+}
+
+/** Per-org holding counts + per-vault-record org counts — powers the inventory view. */
+export async function getHoldingsSummary() {
+  const [byOrg, byRecord] = await Promise.all([
+    query(
+      `SELECT o.id AS org_id, o.name AS org_name, COUNT(h.vault_record_id)::int AS holding_count
+       FROM privacy_orgs o
+       LEFT JOIN privacy_org_holdings h ON h.org_id = o.id
+       GROUP BY o.id, o.name
+       ORDER BY o.name`,
+    ),
+    query(
+      `SELECT v.id AS vault_record_id, v.type, v.label, COUNT(h.org_id)::int AS org_count
+       FROM privacy_vault_records v
+       LEFT JOIN privacy_org_holdings h ON h.vault_record_id = v.id
+       GROUP BY v.id, v.type, v.label
+       ORDER BY v.type, v.label`,
+    ),
+  ]);
+  return {
+    byOrg: byOrg.rows.map((r) => ({ orgId: r.org_id, orgName: r.org_name, holdingCount: r.holding_count })),
+    byVaultRecord: byRecord.rows.map((r) => ({
+      vaultRecordId: r.vault_record_id, type: r.type, label: r.label, orgCount: r.org_count,
+    })),
+  };
+}

--- a/server/services/privacyOrgs.test.js
+++ b/server/services/privacyOrgs.test.js
@@ -151,6 +151,18 @@ describe('setOrgHoldings', () => {
     expect(queryMock).not.toHaveBeenCalled(); // getHoldingsForOrg never reached
   });
 
+  it('row-locks the org with FOR UPDATE to serialize concurrent replace calls', async () => {
+    const client = mockTransaction(async (sql) => {
+      if (/FROM privacy_orgs WHERE id/.test(sql)) return { rows: [orgRow()] };
+      if (/DELETE FROM privacy_org_holdings/.test(sql)) return { rows: [] };
+      return { rows: [] };
+    });
+    queryMock.mockResolvedValue({ rows: [] });
+    await setOrgHoldings('o1', []);
+    const lockCall = client.query.mock.calls.find(([sql]) => /FROM privacy_orgs WHERE id/.test(sql));
+    expect(lockCall[0]).toMatch(/FOR UPDATE/);
+  });
+
   it('deletes the complement and upserts the given set, all inside one transaction', async () => {
     const client = mockTransaction(async (sql) => {
       if (/FROM privacy_orgs WHERE id/.test(sql)) return { rows: [orgRow()] };

--- a/server/services/privacyOrgs.test.js
+++ b/server/services/privacyOrgs.test.js
@@ -7,16 +7,29 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { queryMock } = vi.hoisted(() => ({ queryMock: vi.fn() }));
+const { queryMock, withTransactionMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+  withTransactionMock: vi.fn(),
+}));
 
-vi.mock('../lib/db.js', () => ({ query: queryMock }));
+vi.mock('../lib/db.js', () => ({ query: queryMock, withTransaction: withTransactionMock }));
 
 const {
   createOrg, listOrgs, getOrg, updateOrg, deleteOrg,
   getHoldingsForOrg, getOrgsHoldingRecord, setOrgHoldings, setHoldingsStatus, getHoldingsSummary,
 } = await import('./privacyOrgs.js');
 
-beforeEach(() => { queryMock.mockReset(); });
+beforeEach(() => {
+  queryMock.mockReset();
+  withTransactionMock.mockReset();
+});
+
+/** Fakes a transactional client whose `.query` is driven by the given handler. */
+function mockTransaction(handler) {
+  const client = { query: vi.fn(handler) };
+  withTransactionMock.mockImplementation(async (fn) => fn(client));
+  return client;
+}
 
 const orgRow = (overrides = {}) => ({
   id: 'o1', name: 'Acme Bank', category: 'bank', website: 'https://acme.example',
@@ -127,39 +140,56 @@ describe('getHoldingsForOrg / getOrgsHoldingRecord', () => {
 });
 
 describe('setOrgHoldings', () => {
-  it('404s an unknown org before writing anything', async () => {
-    queryMock.mockResolvedValueOnce({ rows: [] }); // getOrg
+  it('404s an unknown org before writing anything, inside the transaction', async () => {
+    const client = mockTransaction(async (sql) => {
+      if (/FROM privacy_orgs WHERE id/.test(sql)) return { rows: [] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
     await expect(setOrgHoldings('missing', [{ vaultRecordId: 'v1' }]))
       .rejects.toMatchObject({ status: 404 });
-    expect(queryMock).toHaveBeenCalledTimes(1);
+    expect(client.query).toHaveBeenCalledTimes(1);
+    expect(queryMock).not.toHaveBeenCalled(); // getHoldingsForOrg never reached
   });
 
-  it('deletes the complement and upserts the given set', async () => {
-    queryMock.mockImplementation(async (sql) => {
+  it('deletes the complement and upserts the given set, all inside one transaction', async () => {
+    const client = mockTransaction(async (sql) => {
       if (/FROM privacy_orgs WHERE id/.test(sql)) return { rows: [orgRow()] };
       if (/DELETE FROM privacy_org_holdings/.test(sql)) return { rows: [] };
       if (/INSERT INTO privacy_org_holdings/.test(sql)) return { rows: [] };
-      if (/SELECT h\.org_id/.test(sql)) return { rows: [] };
-      throw new Error(`unexpected query: ${sql}`);
+      throw new Error(`unexpected client query: ${sql}`);
     });
+    queryMock.mockResolvedValue({ rows: [] }); // getHoldingsForOrg after commit
     await setOrgHoldings('o1', [{ vaultRecordId: 'v1', status: 'current' }, { vaultRecordId: 'v2' }]);
-    const deleteCall = queryMock.mock.calls.find(([sql]) => /DELETE FROM privacy_org_holdings/.test(sql));
+    const deleteCall = client.query.mock.calls.find(([sql]) => /DELETE FROM privacy_org_holdings/.test(sql));
     expect(deleteCall[1]).toEqual(['o1', ['v1', 'v2']]);
-    const insertCalls = queryMock.mock.calls.filter(([sql]) => /INSERT INTO privacy_org_holdings/.test(sql));
+    const insertCalls = client.query.mock.calls.filter(([sql]) => /INSERT INTO privacy_org_holdings/.test(sql));
     expect(insertCalls).toHaveLength(2);
     expect(insertCalls[1][1]).toEqual(['o1', 'v2', 'current']); // default status applied
+    expect(withTransactionMock).toHaveBeenCalledTimes(1);
   });
 
   it('clears all holdings when given an empty list', async () => {
-    queryMock.mockImplementation(async (sql) => {
+    const client = mockTransaction(async (sql) => {
       if (/FROM privacy_orgs WHERE id/.test(sql)) return { rows: [orgRow()] };
       if (/DELETE FROM privacy_org_holdings WHERE org_id = \$1$/.test(sql)) return { rows: [] };
-      if (/SELECT h\.org_id/.test(sql)) return { rows: [] };
-      throw new Error(`unexpected query: ${sql}`);
+      throw new Error(`unexpected client query: ${sql}`);
     });
+    queryMock.mockResolvedValue({ rows: [] });
     await setOrgHoldings('o1', []);
-    const deleteCall = queryMock.mock.calls.find(([sql]) => /DELETE FROM privacy_org_holdings/.test(sql));
+    const deleteCall = client.query.mock.calls.find(([sql]) => /DELETE FROM privacy_org_holdings/.test(sql));
     expect(deleteCall[1]).toEqual(['o1']);
+  });
+
+  it('surfaces a stale/unknown vaultRecordId as a 400, not a raw FK-violation 500', async () => {
+    const fkError = Object.assign(new Error('insert or update on table violates foreign key constraint'), { code: '23503' });
+    mockTransaction(async (sql) => {
+      if (/FROM privacy_orgs WHERE id/.test(sql)) return { rows: [orgRow()] };
+      if (/DELETE FROM privacy_org_holdings/.test(sql)) return { rows: [] };
+      if (/INSERT INTO privacy_org_holdings/.test(sql)) throw fkError;
+      throw new Error(`unexpected client query: ${sql}`);
+    });
+    await expect(setOrgHoldings('o1', [{ vaultRecordId: 'missing-vault-id' }]))
+      .rejects.toMatchObject({ status: 400, code: 'VAULT_RECORD_NOT_FOUND' });
   });
 });
 

--- a/server/services/privacyOrgs.test.js
+++ b/server/services/privacyOrgs.test.js
@@ -56,6 +56,15 @@ describe('createOrg', () => {
     const [, params] = queryMock.mock.calls[0];
     expect(params[6]).toBe(JSON.stringify({ email: 'a@b.com' }));
   });
+
+  it('never logs the org name — it is privacy-adjacent data, like the vault plaintext', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    queryMock.mockResolvedValue({ rows: [orgRow({ name: 'Dr. Smith Family Medicine' })] });
+    await createOrg({ name: 'Dr. Smith Family Medicine', category: 'medical' });
+    const loggedLines = logSpy.mock.calls.map((args) => args.join(' ')).join('\n');
+    expect(loggedLines).not.toContain('Dr. Smith Family Medicine');
+    logSpy.mockRestore();
+  });
 });
 
 describe('listOrgs', () => {

--- a/server/services/privacyOrgs.test.js
+++ b/server/services/privacyOrgs.test.js
@@ -1,0 +1,187 @@
+/**
+ * Trusted Organizations registry service unit tests (issue #2141) — DB
+ * mocked; the live-DB round trip lives in privacyOrgs.db.test.js (test:db →
+ * portos_test only). Pins CRUD param shapes, the replace-set holdings
+ * semantics, the batch status-flip query, and the 404 paths.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { queryMock } = vi.hoisted(() => ({ queryMock: vi.fn() }));
+
+vi.mock('../lib/db.js', () => ({ query: queryMock }));
+
+const {
+  createOrg, listOrgs, getOrg, updateOrg, deleteOrg,
+  getHoldingsForOrg, getOrgsHoldingRecord, setOrgHoldings, setHoldingsStatus, getHoldingsSummary,
+} = await import('./privacyOrgs.js');
+
+beforeEach(() => { queryMock.mockReset(); });
+
+const orgRow = (overrides = {}) => ({
+  id: 'o1', name: 'Acme Bank', category: 'bank', website: 'https://acme.example',
+  trust: 'trusted', status: 'active', contact: {}, social_account_id: null,
+  notes: '', created_at: 'now', updated_at: 'now', ...overrides,
+});
+
+describe('createOrg', () => {
+  it('inserts with defaults for optional fields', async () => {
+    queryMock.mockResolvedValue({ rows: [orgRow()] });
+    const org = await createOrg({ name: 'Acme Bank' });
+    const [sql, params] = queryMock.mock.calls[0];
+    expect(sql).toMatch(/INSERT INTO privacy_orgs/);
+    expect(params[1]).toBe('Acme Bank');
+    expect(params[2]).toBe('other'); // category default
+    expect(params[4]).toBe('trusted'); // trust default
+    expect(params[5]).toBe('active'); // status default
+    expect(org.name).toBe('Acme Bank');
+  });
+
+  it('serializes contact as JSON', async () => {
+    queryMock.mockResolvedValue({ rows: [orgRow()] });
+    await createOrg({ name: 'Acme', contact: { email: 'a@b.com' } });
+    const [, params] = queryMock.mock.calls[0];
+    expect(params[6]).toBe(JSON.stringify({ email: 'a@b.com' }));
+  });
+});
+
+describe('listOrgs', () => {
+  it('lists with no filters', async () => {
+    queryMock.mockResolvedValue({ rows: [orgRow()] });
+    const orgs = await listOrgs();
+    expect(orgs).toHaveLength(1);
+    const [sql, params] = queryMock.mock.calls[0];
+    expect(sql).not.toMatch(/WHERE/);
+    expect(params).toEqual([]);
+  });
+
+  it('applies trust/status/category filters', async () => {
+    queryMock.mockResolvedValue({ rows: [] });
+    await listOrgs({ trust: 'unwanted', status: 'active', category: 'broker' });
+    const [sql, params] = queryMock.mock.calls[0];
+    expect(sql).toMatch(/trust = \$1/);
+    expect(sql).toMatch(/status = \$2/);
+    expect(sql).toMatch(/category = \$3/);
+    expect(params).toEqual(['unwanted', 'active', 'broker']);
+  });
+});
+
+describe('getOrg', () => {
+  it('returns null for a missing org', async () => {
+    queryMock.mockResolvedValue({ rows: [] });
+    expect(await getOrg('missing')).toBe(null);
+  });
+});
+
+describe('updateOrg', () => {
+  it('builds a partial SET clause for only the provided fields', async () => {
+    queryMock.mockResolvedValue({ rows: [orgRow({ name: 'Renamed' })] });
+    const updated = await updateOrg('o1', { name: 'Renamed' });
+    const [sql, params] = queryMock.mock.calls[0];
+    expect(sql).toMatch(/SET name = \$1, updated_at = NOW\(\)/);
+    expect(params).toEqual(['Renamed', 'o1']);
+    expect(updated.name).toBe('Renamed');
+  });
+
+  it('404s an unknown org', async () => {
+    queryMock.mockResolvedValue({ rows: [] });
+    await expect(updateOrg('missing', { name: 'x' })).rejects.toMatchObject({ status: 404, code: 'NOT_FOUND' });
+  });
+});
+
+describe('deleteOrg', () => {
+  it('404s an unknown org', async () => {
+    queryMock.mockResolvedValue({ rows: [] });
+    await expect(deleteOrg('missing')).rejects.toMatchObject({ status: 404 });
+  });
+
+  it('deletes and returns ok', async () => {
+    queryMock.mockResolvedValue({ rows: [{ id: 'o1' }] });
+    expect(await deleteOrg('o1')).toEqual({ ok: true });
+  });
+});
+
+describe('getHoldingsForOrg / getOrgsHoldingRecord', () => {
+  it('joins masked vault fields only — never value_enc', async () => {
+    queryMock.mockResolvedValue({
+      rows: [{
+        org_id: 'o1', vault_record_id: 'v1', status: 'current', noted_at: 'now', updated_at: 'now',
+        type: 'email', label: 'Main', masked_value: 'a•••@b.com',
+      }],
+    });
+    const holdings = await getHoldingsForOrg('o1');
+    expect(holdings[0]).toEqual({
+      orgId: 'o1', vaultRecordId: 'v1', status: 'current', notedAt: 'now', updatedAt: 'now',
+      vaultType: 'email', vaultLabel: 'Main', vaultMaskedValue: 'a•••@b.com',
+    });
+    expect(JSON.stringify(holdings)).not.toMatch(/value_enc/);
+  });
+
+  it('getOrgsHoldingRecord joins org name', async () => {
+    queryMock.mockResolvedValue({
+      rows: [{ org_id: 'o1', vault_record_id: 'v1', status: 'current', noted_at: 'now', updated_at: 'now', org_name: 'Acme Bank' }],
+    });
+    const orgs = await getOrgsHoldingRecord('v1');
+    expect(orgs[0]).toMatchObject({ orgId: 'o1', orgName: 'Acme Bank' });
+  });
+});
+
+describe('setOrgHoldings', () => {
+  it('404s an unknown org before writing anything', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [] }); // getOrg
+    await expect(setOrgHoldings('missing', [{ vaultRecordId: 'v1' }]))
+      .rejects.toMatchObject({ status: 404 });
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('deletes the complement and upserts the given set', async () => {
+    queryMock.mockImplementation(async (sql) => {
+      if (/FROM privacy_orgs WHERE id/.test(sql)) return { rows: [orgRow()] };
+      if (/DELETE FROM privacy_org_holdings/.test(sql)) return { rows: [] };
+      if (/INSERT INTO privacy_org_holdings/.test(sql)) return { rows: [] };
+      if (/SELECT h\.org_id/.test(sql)) return { rows: [] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    await setOrgHoldings('o1', [{ vaultRecordId: 'v1', status: 'current' }, { vaultRecordId: 'v2' }]);
+    const deleteCall = queryMock.mock.calls.find(([sql]) => /DELETE FROM privacy_org_holdings/.test(sql));
+    expect(deleteCall[1]).toEqual(['o1', ['v1', 'v2']]);
+    const insertCalls = queryMock.mock.calls.filter(([sql]) => /INSERT INTO privacy_org_holdings/.test(sql));
+    expect(insertCalls).toHaveLength(2);
+    expect(insertCalls[1][1]).toEqual(['o1', 'v2', 'current']); // default status applied
+  });
+
+  it('clears all holdings when given an empty list', async () => {
+    queryMock.mockImplementation(async (sql) => {
+      if (/FROM privacy_orgs WHERE id/.test(sql)) return { rows: [orgRow()] };
+      if (/DELETE FROM privacy_org_holdings WHERE org_id = \$1$/.test(sql)) return { rows: [] };
+      if (/SELECT h\.org_id/.test(sql)) return { rows: [] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    await setOrgHoldings('o1', []);
+    const deleteCall = queryMock.mock.calls.find(([sql]) => /DELETE FROM privacy_org_holdings/.test(sql));
+    expect(deleteCall[1]).toEqual(['o1']);
+  });
+});
+
+describe('setHoldingsStatus', () => {
+  it('flips only rows matching fromStatus and reports the count', async () => {
+    queryMock.mockResolvedValue({ rows: [{ org_id: 'o1', vault_record_id: 'v1' }, { org_id: 'o2', vault_record_id: 'v1' }] });
+    const result = await setHoldingsStatus('v1', 'current', 'update_pending');
+    expect(result).toEqual({ updated: 2 });
+    const [, params] = queryMock.mock.calls[0];
+    expect(params).toEqual(['update_pending', 'v1', 'current']);
+  });
+});
+
+describe('getHoldingsSummary', () => {
+  it('returns per-org and per-vault-record counts', async () => {
+    queryMock.mockImplementation(async (sql) => {
+      if (/FROM privacy_orgs o/.test(sql)) return { rows: [{ org_id: 'o1', org_name: 'Acme', holding_count: 2 }] };
+      if (/FROM privacy_vault_records v/.test(sql)) return { rows: [{ vault_record_id: 'v1', type: 'email', label: 'Main', org_count: 1 }] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
+    const summary = await getHoldingsSummary();
+    expect(summary.byOrg).toEqual([{ orgId: 'o1', orgName: 'Acme', holdingCount: 2 }]);
+    expect(summary.byVaultRecord).toEqual([{ vaultRecordId: 'v1', type: 'email', label: 'Main', orgCount: 1 }]);
+  });
+});

--- a/server/vitest.config.db.js
+++ b/server/vitest.config.db.js
@@ -13,6 +13,7 @@ export const DB_TEST_INCLUDE = [
   'services/catalogDB.facets.db.test.js',
   'services/humanActivity.db.test.js',
   'services/privacyVault.db.test.js',
+  'services/privacyOrgs.db.test.js',
   'services/catalogCanonProjection.test.js',
   'services/catalogRefResolver.test.js',
   'services/creativeDirector/projectsDB.test.js',


### PR DESCRIPTION
## Summary

Privacy Center Phase 2: adds the **Trusted Organizations registry** — every organization that has (or had) the user's PII (banks, utilities, government, employers, subscriptions, medical, insurers, platforms, brokers), with per-org *holdings* linking to the exact PII Vault records each org holds, and a trust stance.

- `privacy_orgs` + `privacy_org_holdings` tables (cascade deletes both directions), added via the same boot-time `ensureSchema()` / `init-db.sql` pattern as the Phase 1 vault tables (migration 162 registers the change on the ledger; migrations run before the DB pool is up, so the DDL itself lives in the boot-time schema files)
- `server/services/privacyOrgs.js`: org CRUD, replace-set holdings (`setOrgHoldings`, transactional + row-locked to serialize concurrent replace calls), batch status flip (`setHoldingsStatus`, for the future change-of-address workflow), reverse lookup (`getOrgsHoldingRecord`), and a holdings summary
- Zod schemas in `server/lib/privacyValidation.js` with POST/PUT-partial parity
- REST routes on `server/routes/privacy.js`: `GET/POST /api/privacy/orgs`, `GET/PUT/DELETE /api/privacy/orgs/:id`, `GET/PUT /api/privacy/orgs/:id/holdings`
- Holdings responses join masked vault values only — **never plaintext or ciphertext**
- Unit tests (mocked DB) + a live-Postgres round-trip suite covering CRUD, cascade deletes, replace-set semantics, the transactional rollback on a bad `vaultRecordId`, and the batch status flip

No UI in this issue (that's Phase 3, issue #2142).

Closes #2141

## Review

Ran the local multi-reviewer loop (`claude`, `codex` per saved defaults) before opening this PR — both are clean after 3 fix commits:
- **claude**: wrapped `setOrgHoldings`'s delete+upsert in one transaction (a bad `vaultRecordId` partway through no longer leaves holdings half-applied), added a clean 400 for FK violations instead of a raw Postgres error, and added a 404 check to `GET /orgs/:id/holdings` for a missing org
- **codex**: added a `FOR UPDATE` row lock (same pattern as `updateVaultRecord`) to serialize concurrent holdings-replace calls, and stopped logging user-entered organization names (privacy-adjacent data, same posture as the vault's plaintext-never-logged rule)

## Test plan

- [x] `cd server && npm test` — 810 test files / 16274 tests pass
- [x] `cd server && npm run test:db` (against `portos_test`) — 22 files / 179 tests pass, including the new cascade-delete and transactional-rollback round trips
- [x] Local review loop (claude + codex) clean after fixes