### PR TITLE
feat: add prune-merged-branches button to Local Branches panel

### DIFF
--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -571,9 +571,10 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
                         <button
                           onClick={handleCleanupMerged}
                           disabled={cleaningUp}
+                          title="Deletes merged branches both locally and on the remote"
                           className={`px-2 py-1 ${touchBtnCls} text-xs bg-port-error/20 text-port-error rounded hover:bg-port-error/30 disabled:opacity-50`}
                         >
-                          {cleaningUp ? 'Deleting...' : `Delete ${localMergedCount} merged`}
+                          {cleaningUp ? 'Deleting...' : 'Delete all merged (local + remote)'}
                         </button>
                         <button
                           onClick={() => setCleanupConfirm(false)}
@@ -721,9 +722,10 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
                     <button
                       onClick={handleCleanupMerged}
                       disabled={cleaningUp}
+                      title="Deletes merged branches both locally and on the remote"
                       className={`px-2 py-1 ${touchBtnCls} text-xs bg-port-error/20 text-port-error rounded hover:bg-port-error/30 disabled:opacity-50`}
                     >
-                      {cleaningUp ? 'Deleting...' : `Delete ${mergedBranchCount} merged`}
+                      {cleaningUp ? 'Deleting...' : 'Delete all merged (local + remote)'}
                     </button>
                     <button
                       onClick={() => setCleanupConfirm(false)}

--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -328,6 +328,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
   };
 
   const mergedBranchCount = remoteBranches.filter(rb => rb.merged && !rb.isDefault).length;
+  const localMergedCount = branches.filter(b => b.merged).length;
 
   const handleCleanupMerged = async () => {
     if (!repoPath || cleaningUp) return;
@@ -552,7 +553,38 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
 
               {/* Local Branches */}
               <div className="bg-port-card border border-port-border rounded-xl p-4">
-                <h3 className="text-sm font-medium text-gray-400 mb-3">Local Branches</h3>
+                <div className="flex flex-wrap items-center justify-between gap-2 mb-3">
+                  <h3 className="text-sm font-medium text-gray-400">Local Branches</h3>
+                  <div className="flex flex-wrap items-center gap-2">
+                    {localMergedCount > 0 && !cleanupConfirm && (
+                      <button
+                        onClick={() => setCleanupConfirm('local')}
+                        disabled={cleaningUp}
+                        className={`flex items-center gap-1 text-xs ${touchBtnCls} text-port-warning hover:text-port-error disabled:opacity-50`}
+                      >
+                        <Trash2 size={12} />
+                        {cleaningUp ? 'Cleaning...' : `Clean ${localMergedCount} merged`}
+                      </button>
+                    )}
+                    {cleanupConfirm === 'local' && (
+                      <div className="flex flex-wrap items-center gap-1">
+                        <button
+                          onClick={handleCleanupMerged}
+                          disabled={cleaningUp}
+                          className={`px-2 py-1 ${touchBtnCls} text-xs bg-port-error/20 text-port-error rounded hover:bg-port-error/30 disabled:opacity-50`}
+                        >
+                          {cleaningUp ? 'Deleting...' : `Delete ${localMergedCount} merged`}
+                        </button>
+                        <button
+                          onClick={() => setCleanupConfirm(false)}
+                          className={`px-2 py-1 ${touchBtnCls} text-xs text-gray-400 hover:text-white`}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                </div>
                 <div className="space-y-2 max-h-64 overflow-auto">
                   {branches.map((branch) => (
                     <div
@@ -568,6 +600,12 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
                         <span className={`text-sm truncate ${branch.current ? 'text-port-accent font-medium' : 'text-gray-300'}`}>
                           {branch.name}
                         </span>
+                        {branch.merged && (
+                          <span className="flex items-center gap-1 text-xs text-port-success px-1.5 py-0.5 bg-port-success/10 rounded shrink-0">
+                            <GitMerge size={10} />
+                            merged
+                          </span>
+                        )}
                         {branch.tracking && (
                           <span className="text-xs text-gray-500 shrink-0">
                             {branch.ahead > 0 && <span className="text-port-success">+{branch.ahead}</span>}
@@ -670,7 +708,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
               <div className="flex flex-wrap items-center gap-2">
                 {mergedBranchCount > 0 && !cleanupConfirm && (
                   <button
-                    onClick={() => setCleanupConfirm(true)}
+                    onClick={() => setCleanupConfirm('remote')}
                     disabled={cleaningUp}
                     className={`flex items-center gap-1 text-xs ${touchBtnCls} text-port-warning hover:text-port-error disabled:opacity-50`}
                   >
@@ -678,7 +716,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
                     {cleaningUp ? 'Cleaning...' : `Clean ${mergedBranchCount} merged`}
                   </button>
                 )}
-                {cleanupConfirm && (
+                {cleanupConfirm === 'remote' && (
                   <div className="flex flex-wrap items-center gap-1">
                     <button
                       onClick={handleCleanupMerged}

--- a/client/src/components/apps/tabs/GitTab.test.jsx
+++ b/client/src/components/apps/tabs/GitTab.test.jsx
@@ -8,6 +8,7 @@ vi.mock('../../../services/api', () => ({
   getBranchComparison: vi.fn(),
   getRemoteBranches: vi.fn(),
   getGitDiff: vi.fn(),
+  cleanupMergedBranches: vi.fn(),
 }));
 
 import * as api from '../../../services/api';
@@ -34,6 +35,7 @@ beforeEach(() => {
   api.getBranchComparison.mockResolvedValue(COMPARISON);
   api.getRemoteBranches.mockResolvedValue({ branches: [], defaultBranch: 'main' });
   api.getGitDiff.mockResolvedValue({ diff: '@@ -1 +1 @@\n-old\n+new' });
+  api.cleanupMergedBranches.mockResolvedValue({ deleted: [], skipped: [] });
 });
 
 afterEach(() => {
@@ -80,5 +82,39 @@ describe('GitTab modal accessibility (issue #1090)', () => {
     expect(document.getElementById('git-release-modal-title')).toHaveTextContent('Create Release PR for App');
     expect(dialog.parentElement).toHaveAttribute('role', 'presentation');
     expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+  });
+});
+
+describe('GitTab merged-branch cleanup scoping', () => {
+  beforeEach(() => {
+    api.getBranches.mockResolvedValue({
+      branches: [
+        { name: 'main', current: true, tracking: 'origin/main', ahead: 0, behind: 0, isDefault: true, merged: false },
+        { name: 'feature/done', current: false, tracking: 'origin/feature/done', ahead: 0, behind: 0, isDefault: false, merged: true },
+      ],
+    });
+    api.getRemoteBranches.mockResolvedValue({
+      branches: [
+        { name: 'main', fullRef: 'origin/main', merged: false, hasLocal: true, isDefault: true },
+        { name: 'old/one', fullRef: 'origin/old/one', merged: true, hasLocal: false, isDefault: false },
+        { name: 'old/two', fullRef: 'origin/old/two', merged: true, hasLocal: false, isDefault: false },
+      ],
+      defaultBranch: 'main',
+    });
+  });
+
+  it('shows only the local confirm block when the Local panel button is clicked, and discloses full local+remote scope', async () => {
+    render(<GitTab appId="x" appName="App" repoPath="/repo" />);
+
+    const localCleanBtn = await screen.findByText('Clean 1 merged');
+    fireEvent.click(localCleanBtn);
+
+    const confirmButtons = await screen.findAllByText('Delete all merged (local + remote)');
+    expect(confirmButtons).toHaveLength(1);
+    expect(confirmButtons[0]).toHaveAttribute('title', 'Deletes merged branches both locally and on the remote');
+
+    // The Remote panel's own trigger is hidden while the Local panel's confirm is active,
+    // and it must not render its own confirm block at the same time.
+    expect(screen.queryByText('Clean 2 merged')).toBeNull();
   });
 });

--- a/server/services/getBranches.test.js
+++ b/server/services/getBranches.test.js
@@ -92,4 +92,44 @@ describe('getBranches', () => {
 
     expect(dev.merged).toBe(false);
   });
+
+  it('falls back to the remote-tracking ref when there is no local branch matching the default (single-branch clone / feature-only worktree)', async () => {
+    execGit.mockImplementation((args) => {
+      if (args[0] === 'branch' && args.includes('-vv')) {
+        return Promise.resolve({
+          stdout: ['*|feature-a||', ' |feature-b||'].join('\n'),
+          stderr: '',
+          exitCode: 0
+        });
+      }
+      if (args[0] === 'symbolic-ref') {
+        // origin/HEAD resolves to main, but there is no local `main` branch
+        return Promise.resolve({ stdout: 'origin/main', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'rev-parse' && args.includes('--verify')) {
+        return Promise.resolve({ stdout: 'abc123', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'branch' && args.includes('--list')) {
+        return Promise.resolve({ stdout: '  feature-a\n  feature-b\n', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'branch' && args.includes('--merged')) {
+        if (args[2] === 'main') {
+          // No local `main` ref exists — git errors out
+          return Promise.resolve({ stdout: '', stderr: 'fatal: malformed object name main', exitCode: 128 });
+        }
+        if (args[2] === 'origin/main') {
+          return Promise.resolve({ stdout: 'feature-b\n', stderr: '', exitCode: 0 });
+        }
+      }
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+    });
+
+    const branches = await getBranches('/fake/dir');
+    const featureA = branches.find(b => b.name === 'feature-a');
+    const featureB = branches.find(b => b.name === 'feature-b');
+
+    expect(featureA.current).toBe(true);
+    expect(featureA.merged).toBe(false);
+    expect(featureB.merged).toBe(true);
+  });
 });

--- a/server/services/getBranches.test.js
+++ b/server/services/getBranches.test.js
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../lib/execGit.js', () => ({
+  execGit: vi.fn()
+}));
+
+describe('getBranches', () => {
+  let getBranches;
+  let execGit;
+
+  beforeEach(async () => {
+    const execGitModule = await import('../lib/execGit.js');
+    execGit = execGitModule.execGit;
+    const gitModule = await import('./git.js');
+    getBranches = gitModule.getBranches;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('flags a non-current, non-protected branch merged into the default branch, and excludes the current/default branch', async () => {
+    execGit.mockImplementation((args) => {
+      if (args[0] === 'branch' && args.includes('-vv')) {
+        return Promise.resolve({
+          stdout: [
+            '*|main||',
+            ' |feature/done|origin/feature/done|',
+            ' |feature/wip|origin/feature/wip|[ahead 1]'
+          ].join('\n'),
+          stderr: '',
+          exitCode: 0
+        });
+      }
+      if (args[0] === 'symbolic-ref') {
+        return Promise.resolve({ stdout: 'origin/main', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'rev-parse' && args.includes('--verify')) {
+        return Promise.resolve({ stdout: 'abc123', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'branch' && args.includes('--list')) {
+        return Promise.resolve({ stdout: '  main\n  feature/done\n  feature/wip\n', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'branch' && args.includes('--merged')) {
+        return Promise.resolve({ stdout: 'main\nfeature/done\n', stderr: '', exitCode: 0 });
+      }
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+    });
+
+    const branches = await getBranches('/fake/dir');
+
+    const main = branches.find(b => b.name === 'main');
+    const done = branches.find(b => b.name === 'feature/done');
+    const wip = branches.find(b => b.name === 'feature/wip');
+
+    expect(main.current).toBe(true);
+    expect(main.isDefault).toBe(true);
+    expect(main.merged).toBe(false);
+
+    expect(done.isDefault).toBe(false);
+    expect(done.merged).toBe(true);
+
+    expect(wip.merged).toBe(false);
+  });
+
+  it('never flags a protected branch (e.g. dev) as merged even when it appears in the --merged output', async () => {
+    execGit.mockImplementation((args) => {
+      if (args[0] === 'branch' && args.includes('-vv')) {
+        return Promise.resolve({
+          stdout: ['*|main||', ' |dev||'].join('\n'),
+          stderr: '',
+          exitCode: 0
+        });
+      }
+      if (args[0] === 'symbolic-ref') {
+        return Promise.resolve({ stdout: 'origin/main', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'rev-parse' && args.includes('--verify')) {
+        return Promise.resolve({ stdout: 'abc123', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'branch' && args.includes('--list')) {
+        return Promise.resolve({ stdout: '  main\n  dev\n', stderr: '', exitCode: 0 });
+      }
+      if (args[0] === 'branch' && args.includes('--merged')) {
+        return Promise.resolve({ stdout: 'main\ndev\n', stderr: '', exitCode: 0 });
+      }
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+    });
+
+    const branches = await getBranches('/fake/dir');
+    const dev = branches.find(b => b.name === 'dev');
+
+    expect(dev.merged).toBe(false);
+  });
+});

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -595,15 +595,33 @@ export async function getRepoBranches(dir) {
  */
 export async function getBranches(dir) {
   // Get branches with verbose info (includes tracking)
-  const result = await execGit(
-    ['branch', '-vv', '--format=%(HEAD)|%(refname:short)|%(upstream:short)|%(upstream:track)'],
+  const [result, { baseBranch }] = await Promise.all([
+    execGit(
+      ['branch', '-vv', '--format=%(HEAD)|%(refname:short)|%(upstream:short)|%(upstream:track)'],
+      dir,
+      { ignoreExitCode: true }
+    ),
+    getRepoBranches(dir)
+  ]);
+
+  const defaultBranch = baseBranch || 'main';
+  const protectedSet = new Set(PROTECTED_BRANCHES);
+  protectedSet.add(defaultBranch);
+
+  const mergedResult = await execGit(
+    ['branch', '--merged', defaultBranch, '--format=%(refname:short)'],
     dir,
     { ignoreExitCode: true }
   );
+  const mergedSet = new Set(mergedResult.stdout.trim().split('\n').filter(Boolean));
 
-  const branches = result.stdout.trim().split('\n').filter(Boolean).map(parseBranchVerboseLine);
-
-  return branches;
+  return result.stdout.trim().split('\n').filter(Boolean)
+    .map(parseBranchVerboseLine)
+    .map(b => ({
+      ...b,
+      isDefault: b.name === defaultBranch,
+      merged: !b.current && !protectedSet.has(b.name) && mergedSet.has(b.name)
+    }));
 }
 
 /**

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -590,6 +590,32 @@ export async function getRepoBranches(dir) {
 }
 
 /**
+ * Get the set of local branch names merged into the default branch.
+ * Prefers the local default-branch ref, but falls back to the remote-tracking
+ * ref when there's no local branch by that name (single-branch clones,
+ * feature-only worktrees) — otherwise `git branch --merged <defaultBranch>`
+ * fails and every branch silently reports unmerged.
+ * @param {string} dir - Working directory
+ * @param {string} defaultBranch - Default branch name (e.g. "main")
+ * @returns {Promise<Set<string>>}
+ */
+async function getLocalMergedBranchNames(dir, defaultBranch) {
+  let result = await execGit(
+    ['branch', '--merged', defaultBranch, '--format=%(refname:short)'],
+    dir,
+    { ignoreExitCode: true }
+  );
+  if (result.exitCode !== 0) {
+    result = await execGit(
+      ['branch', '--merged', `origin/${defaultBranch}`, '--format=%(refname:short)'],
+      dir,
+      { ignoreExitCode: true }
+    );
+  }
+  return new Set(result.stdout.trim().split('\n').filter(Boolean));
+}
+
+/**
  * Get all local branches with tracking info
  * @returns {Promise<Array<{name: string, current: boolean, tracking: string|null, ahead: number, behind: number, isDefault: boolean, merged: boolean}>>}
  */
@@ -608,23 +634,7 @@ export async function getBranches(dir) {
   const protectedSet = new Set(PROTECTED_BRANCHES);
   protectedSet.add(defaultBranch);
 
-  // Prefer the local default-branch ref, but fall back to the remote-tracking
-  // ref when there's no local branch by that name (single-branch clones,
-  // feature-only worktrees) — otherwise `git branch --merged <defaultBranch>`
-  // fails and every branch silently reports unmerged.
-  let mergedResult = await execGit(
-    ['branch', '--merged', defaultBranch, '--format=%(refname:short)'],
-    dir,
-    { ignoreExitCode: true }
-  );
-  if (mergedResult.exitCode !== 0) {
-    mergedResult = await execGit(
-      ['branch', '--merged', `origin/${defaultBranch}`, '--format=%(refname:short)'],
-      dir,
-      { ignoreExitCode: true }
-    );
-  }
-  const mergedSet = new Set(mergedResult.stdout.trim().split('\n').filter(Boolean));
+  const mergedSet = await getLocalMergedBranchNames(dir, defaultBranch);
 
   return result.stdout.trim().split('\n').filter(Boolean)
     .map(parseBranchVerboseLine)
@@ -1016,12 +1026,12 @@ export async function deleteMergedBranches(dir, { excludeBranches } = {}) {
 
   await execGitSafe(['fetch', 'origin', '--prune'], dir, { ignoreExitCode: true });
 
-  const [localMerged, remoteMerged] = await Promise.all([
-    execGit(['branch', '--merged', defaultBranch, '--format=%(refname:short)'], dir, { ignoreExitCode: true }),
+  const [localMergedNames, remoteMerged] = await Promise.all([
+    getLocalMergedBranchNames(dir, defaultBranch),
     execGit(['branch', '-r', '--merged', `origin/${defaultBranch}`, '--format=%(refname:short)'], dir, { ignoreExitCode: true })
   ]);
 
-  const mergedLocalNames = localMerged.stdout.trim().split('\n').filter(Boolean)
+  const mergedLocalNames = [...localMergedNames]
     .filter(name => !protectedSet.has(name) && !localOnlyProtected.has(name) && name !== currentBranch);
 
   const mergedRemoteNames = remoteMerged.stdout.trim().split('\n').filter(Boolean)

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -591,7 +591,7 @@ export async function getRepoBranches(dir) {
 
 /**
  * Get all local branches with tracking info
- * @returns {Promise<Array<{name: string, current: boolean, tracking: string|null, ahead: number, behind: number}>>}
+ * @returns {Promise<Array<{name: string, current: boolean, tracking: string|null, ahead: number, behind: number, isDefault: boolean, merged: boolean}>>}
  */
 export async function getBranches(dir) {
   // Get branches with verbose info (includes tracking)

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -608,11 +608,22 @@ export async function getBranches(dir) {
   const protectedSet = new Set(PROTECTED_BRANCHES);
   protectedSet.add(defaultBranch);
 
-  const mergedResult = await execGit(
+  // Prefer the local default-branch ref, but fall back to the remote-tracking
+  // ref when there's no local branch by that name (single-branch clones,
+  // feature-only worktrees) — otherwise `git branch --merged <defaultBranch>`
+  // fails and every branch silently reports unmerged.
+  let mergedResult = await execGit(
     ['branch', '--merged', defaultBranch, '--format=%(refname:short)'],
     dir,
     { ignoreExitCode: true }
   );
+  if (mergedResult.exitCode !== 0) {
+    mergedResult = await execGit(
+      ['branch', '--merged', `origin/${defaultBranch}`, '--format=%(refname:short)'],
+      dir,
+      { ignoreExitCode: true }
+    );
+  }
   const mergedSet = new Set(mergedResult.stdout.trim().split('\n').filter(Boolean));
 
   return result.stdout.trim().split('\n').filter(Boolean)


### PR DESCRIPTION
## Summary

- The app Git tab's "Clean N merged" prune button only appeared in the Remote Branches panel, even though the underlying action already prunes both local and remote merged branches in one call. Add the same button to the Local Branches panel, with local branch merge detection (`merged`/`isDefault`) added server-side in `getBranches()`.
- Add a "merged" badge to local branch rows, matching the existing remote-branch badge.
- Fixed during local review: the delete-confirmation button now discloses its true scope ("Delete all merged (local + remote)") instead of implying a per-panel-only action; merge detection now falls back to the remote-tracking ref when no local branch matches the default (single-branch clones / feature-only worktrees), and that fallback is shared between the display logic and the actual cleanup deletion path so they never disagree.

## Test plan
- [x] `npm test --prefix server` (16427 passed)
- [x] `npm test --prefix client` (3364 passed)
- [x] `npm run build`
- [x] Local review passes (claude, codex) — clean