### PR TITLE
feat: truncate long task prompts on task cards with expand toggle

### DIFF
--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -137,6 +137,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
     if (!el) return;
     const measure = () => setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
     measure();
+    if (typeof ResizeObserver === 'undefined') return;
     const observer = new ResizeObserver(measure);
     observer.observe(el);
     return () => observer.disconnect();

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -368,6 +368,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
               </p>
               {(isOverflowing || promptExpanded) && (
                 <button
+                  type="button"
                   onClick={() => setPromptExpanded(v => !v)}
                   className="flex items-center gap-0.5 mt-0.5 text-xs text-port-accent hover:text-port-accent/80 transition-colors"
                   aria-expanded={promptExpanded}

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -15,7 +15,9 @@ import {
   ExternalLink,
   AlertCircle,
   TrendingUp,
-  Play
+  Play,
+  ChevronDown,
+  ChevronUp
 } from 'lucide-react';
 import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
@@ -108,12 +110,30 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
   const blockedInputRef = useRef(null);
 
+  // Collapse long task prompts to the first couple of lines with an expand
+  // toggle. `isOverflowing` is measured against the clamped element so the
+  // toggle only appears when the description actually spills past two lines.
+  const [promptExpanded, setPromptExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+  const descRef = useRef(null);
+
   // Focus input when modal opens
   useEffect(() => {
     if (showBlockedModal && blockedInputRef.current) {
       blockedInputRef.current.focus();
     }
   }, [showBlockedModal]);
+
+  // Measure overflow while the prompt is collapsed. Kept sticky when expanded
+  // (removing the clamp collapses scrollHeight, which would otherwise hide the
+  // toggle mid-expand); recomputed only on the collapsed path when the text
+  // changes so an edit that shortens the prompt clears a stale toggle.
+  useEffect(() => {
+    if (promptExpanded) return;
+    const el = descRef.current;
+    if (!el) return;
+    setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
+  }, [task.description, promptExpanded, editing]);
 
   // Get models for selected provider in edit mode
   const editProvider = providers?.find(p => p.id === editData.provider);
@@ -340,7 +360,25 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
             </div>
           ) : (
             <>
-              <p className="text-white">{task.description}</p>
+              <p
+                ref={descRef}
+                className={`text-white whitespace-pre-wrap ${promptExpanded ? '' : 'line-clamp-2'}`}
+              >
+                {task.description}
+              </p>
+              {(isOverflowing || promptExpanded) && (
+                <button
+                  onClick={() => setPromptExpanded(v => !v)}
+                  className="flex items-center gap-0.5 mt-0.5 text-xs text-port-accent hover:text-port-accent/80 transition-colors"
+                  aria-expanded={promptExpanded}
+                >
+                  {promptExpanded ? (
+                    <><ChevronUp size={12} aria-hidden="true" /> Show less</>
+                  ) : (
+                    <><ChevronDown size={12} aria-hidden="true" /> Show more</>
+                  )}
+                </button>
+              )}
               {task.metadata?.context && (
                 <p className="text-sm text-gray-500 mt-1">{task.metadata.context}</p>
               )}

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -370,7 +370,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
               <p
                 ref={descRef}
                 id={`task-desc-${task.id}`}
-                className={`text-white whitespace-pre-wrap ${promptExpanded ? '' : 'line-clamp-2'}`}
+                className={`text-white whitespace-pre-wrap break-words ${promptExpanded ? '' : 'line-clamp-2'}`}
               >
                 {task.description}
               </p>

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -127,12 +127,19 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   // Measure overflow while the prompt is collapsed. Kept sticky when expanded
   // (removing the clamp collapses scrollHeight, which would otherwise hide the
   // toggle mid-expand); recomputed only on the collapsed path when the text
-  // changes so an edit that shortens the prompt clears a stale toggle.
+  // changes so an edit that shortens the prompt clears a stale toggle. A
+  // ResizeObserver re-measures on width changes (sidebar collapse, rotation,
+  // window resize) so a prompt that wraps to a new line at a narrower width
+  // still surfaces the toggle instead of silently clamping with no affordance.
   useEffect(() => {
     if (promptExpanded) return;
     const el = descRef.current;
     if (!el) return;
-    setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
+    const measure = () => setIsOverflowing(el.scrollHeight > el.clientHeight + 1);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
   }, [task.description, promptExpanded, editing]);
 
   // Get models for selected provider in edit mode
@@ -362,6 +369,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
             <>
               <p
                 ref={descRef}
+                id={`task-desc-${task.id}`}
                 className={`text-white whitespace-pre-wrap ${promptExpanded ? '' : 'line-clamp-2'}`}
               >
                 {task.description}
@@ -372,6 +380,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
                   onClick={() => setPromptExpanded(v => !v)}
                   className="flex items-center gap-0.5 mt-0.5 text-xs text-port-accent hover:text-port-accent/80 transition-colors"
                   aria-expanded={promptExpanded}
+                  aria-controls={`task-desc-${task.id}`}
                 >
                   {promptExpanded ? (
                     <><ChevronUp size={12} aria-hidden="true" /> Show less</>


### PR DESCRIPTION
## Summary
On the Tasks page, pending/active/blocked (and all) task cards now collapse a long task description to the first two lines with a **Show more / Show less** toggle, so a lengthy prompt no longer blows up the card height.

## Behavior
- Description clamps to two lines by default (`line-clamp-2`).
- The toggle only renders when the description **actually** overflows two lines — measured via `scrollHeight > clientHeight` on the clamped element (no dead toggles on short prompts, no missing toggle on long ones).
- Toggle stays visible while expanded and self-heals when the text is edited shorter.
- `break-words` wraps long unbroken tokens (URLs/paths) so horizontal clipping can't hide text without an affordance.
- A `ResizeObserver` re-measures on width changes (sidebar collapse, rotation, resize) — guarded with the codebase's `typeof ResizeObserver === 'undefined'` convention for jsdom/older envs.
- Accessible toggle: `type="button"`, `aria-expanded`, and `aria-controls` linked to the description `id`.

## Review
- Local code review gate: passed.
- Multi-reviewer loop (series): **claude** → clean (ResizeObserver + aria-controls), **codex** → clean (break-words + jsdom ResizeObserver guard).
- Lint clean, client build passes, 70/70 cos component tests pass.

https://claude.ai/code/session_01BALrhifwY7BTxxhugznGXT