### PR TITLE
add audio preview + download controls to music video projects

### DIFF
--- a/client/src/pages/MusicVideo.jsx
+++ b/client/src/pages/MusicVideo.jsx
@@ -20,7 +20,7 @@ import {
 } from '../services/apiMusicVideo.js';
 import { generateImage } from '../services/apiSystem.js';
 import { generateVideo } from '../services/apiImageVideo.js';
-import { listTracks } from '../services/apiTracks.js';
+import { listTracks, trackAudioUrl } from '../services/apiTracks.js';
 import BeatTimeline from '../components/musicVideo/BeatTimeline.jsx';
 import { autoArrangeScenes } from '../lib/beatGrid.js';
 import useSceneRenderLifecycle from '../hooks/useSceneRenderLifecycle.js';
@@ -206,6 +206,16 @@ export default function MusicVideo() {
   }, []);
 
   const trackName = useCallback((id) => tracks.find((t) => t.id === id)?.title || id || '—', [tracks]);
+
+  // The project's master audio file lives under data/music/ — either the linked
+  // track's stored audio or the project's own uploaded file. Returns the bare
+  // basename (or null when the project has no audio yet) for the preview/download
+  // controls; the bytes are served statically via trackAudioUrl().
+  const projectAudioFilename = useCallback((project) => {
+    if (!project) return null;
+    if (project.trackId) return tracks.find((t) => t.id === project.trackId)?.audioFilename || null;
+    return project.uploadedAudioFilename || null;
+  }, [tracks]);
 
   const handleCreate = (e) => {
     e.preventDefault();
@@ -658,6 +668,23 @@ export default function MusicVideo() {
                     compact
                   />
                 </div>
+                {/* Preview + download the project's master audio track. Both act on
+                    the resolved data/music/ file (linked track or uploaded audio). */}
+                {(() => {
+                  const audioFile = projectAudioFilename(selected);
+                  if (!audioFile) return null;
+                  const audioUrl = trackAudioUrl(audioFile);
+                  return (
+                    <div className="mt-2 flex flex-wrap items-center gap-2">
+                      <audio src={audioUrl} controls preload="metadata" className="h-8 max-w-full" aria-label="Preview track audio" />
+                      <a href={audioUrl} download={audioFile}
+                        title="Download the audio track"
+                        className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1 text-xs hover:bg-port-border/40">
+                        <Download size={13} /> Download audio
+                      </a>
+                    </div>
+                  );
+                })()}
                 {render && (
                   <div className="mt-2">
                     <div className="h-1.5 bg-port-bg rounded overflow-hidden">

--- a/client/src/pages/MusicVideo.test.jsx
+++ b/client/src/pages/MusicVideo.test.jsx
@@ -52,6 +52,7 @@ vi.mock('../services/apiSystem.js', () => ({ generateImage: vi.fn() }));
 vi.mock('../services/apiImageVideo.js', () => ({ generateVideo: vi.fn() }));
 vi.mock('../services/apiTracks.js', () => ({
   listTracks: vi.fn(async () => []),
+  trackAudioUrl: (filename) => `/data/music/${encodeURIComponent(filename)}`,
   importTrackFromYoutube: vi.fn(async () => ({ jobId: 'yt-job-1' })),
   trackImportEventsUrl: (jobId) => `/api/tracks/import/${jobId}/events`,
   cancelTrackImport: vi.fn(async () => ({ ok: true })),
@@ -75,7 +76,7 @@ import {
   listMusicVideoProjects, createMusicVideoProject, renderMusicVideoProject, planMusicVideoProject, updateMusicVideoProject,
   deleteMusicVideoProject,
 } from '../services/apiMusicVideo.js';
-import { importTrackFromYoutube, trackImportEventsUrl } from '../services/apiTracks.js';
+import { importTrackFromYoutube, trackImportEventsUrl, listTracks } from '../services/apiTracks.js';
 
 const PROJECT_ANALYZED = {
   ...PROJECT_NO_CLIP,
@@ -157,6 +158,32 @@ describe('MusicVideo render control (#1760)', () => {
     const link = await screen.findByText(/View rendered music video/i);
     // Media History matches video items by their `video:<id>` key via ?preview=.
     expect(link.closest('a').getAttribute('href')).toContain('preview=video%3Arh-9');
+  });
+});
+
+describe('MusicVideo audio preview + download', () => {
+  it('shows preview player + download link for a linked track', async () => {
+    listTracks.mockResolvedValue([{ id: 't1', title: 'Neon Song', audioFilename: 'neon song.mp3' }]);
+    await openProject(PROJECT_WITH_CLIP);
+    const player = await screen.findByLabelText('Preview track audio');
+    expect(player.getAttribute('src')).toBe('/data/music/neon%20song.mp3');
+    const dl = screen.getByRole('link', { name: /Download audio/i });
+    expect(dl.getAttribute('href')).toBe('/data/music/neon%20song.mp3');
+    expect(dl.getAttribute('download')).toBe('neon song.mp3');
+  });
+
+  it('falls back to the project uploaded-audio file when there is no linked track', async () => {
+    await openProject({ ...PROJECT_WITH_CLIP, trackId: null, uploadedAudioFilename: 'upload.wav' });
+    const player = await screen.findByLabelText('Preview track audio');
+    expect(player.getAttribute('src')).toBe('/data/music/upload.wav');
+  });
+
+  it('renders no audio controls when the project has no audio', async () => {
+    await openProject({ ...PROJECT_WITH_CLIP, trackId: null, uploadedAudioFilename: null });
+    // Board opened (Render button present) but no audio surface.
+    await screen.findByRole('button', { name: /^Render$/ });
+    expect(screen.queryByLabelText('Preview track audio')).toBeNull();
+    expect(screen.queryByRole('link', { name: /Download audio/i })).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a preview/play player and a download button for the master audio track on the Music Video project detail page (`/media/music-video/:projectId`).

- Reuses the existing `trackAudioUrl(filename)` helper (`/data/music/<encoded>`), which points at the statically-served music library — no new server endpoint needed.
- New `projectAudioFilename(project)` resolver mirrors the server's `resolveAudioPath`: it uses the linked track's `audioFilename` (from the already-loaded `tracks`) or falls back to `uploadedAudioFilename`, returning `null` when the project has no audio yet.
- Renders a native `<audio controls>` player (inline preview) and a **Download audio** `<a download>` link in the project detail header, shown only when audio exists.

## Test plan

- `client/src/pages/MusicVideo.test.jsx` (19/19 passing): added `trackAudioUrl` to the mock and 3 cases — linked-track preview+download URLs (incl. space encoding + `download` filename), uploaded-audio fallback, and the no-audio case rendering no controls.
- Verified the full suite runs green after rebasing onto latest `main`.