### PR TITLE
fix: Layered Intelligence loop can use any provider type (+ scheduled-task migration design)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+## Fixed
+
+- **Layered Intelligence loop now supports every provider type.** The per-app AI-provider picker previously listed only `cli` providers, while the reasoning call went through the api-only `callProviderAISimple` — so a selected CLI provider failed at runtime with "requires an API-based provider," and API/TUI providers (Ollama, LM Studio, Claude/Codex/OpenCode TUI, etc.) never appeared at all. The reasoning call now routes through the unified `runPromptThroughProvider`, which dispatches on `provider.type`, and the picker lists all enabled `cli`/`api`/`tui` providers. CLI/TUI spawns run in the app's repo (`cwd`).

--- a/client/src/components/apps/EditAppDrawer.jsx
+++ b/client/src/components/apps/EditAppDrawer.jsx
@@ -10,6 +10,7 @@ import Banner from '../ui/Banner';
 import useDrawerTab from '../../hooks/useDrawerTab';
 import { copyToClipboard } from '../../lib/clipboard';
 import LayeredIntelligenceTab, { buildLayeredIntelligenceUpdate } from './LayeredIntelligenceTab';
+import { PROVIDER_TYPES } from '../../utils/providers';
 
 const WORK_TRACKER_OPTIONS = [
   { value: 'auto', label: 'Auto (detect from git origin)' },
@@ -172,7 +173,11 @@ export default function EditAppDrawer({ app, onClose, onSave }) {
       setLiConfig(cfg);
       setLiBaseline(cfg);
       setLiIsPortos(!!li?.isPortos);
-      setLiProviders((provData?.providers || []).filter(p => p.type === 'cli' && p.enabled !== false));
+      // The loop reasons through runPromptThroughProvider, which dispatches on
+      // provider.type — so any enabled provider of a known type is selectable
+      // (Claude Code, Codex, OpenCode, Ollama/LM Studio API, TUI variants…).
+      const runnableTypes = Object.values(PROVIDER_TYPES);
+      setLiProviders((provData?.providers || []).filter(p => runnableTypes.includes(p.type) && p.enabled !== false));
       setLiError(!cfg);
       setLiLoaded(true);
     }).catch(() => {

--- a/docs/plans/2026-07-08-layered-intelligence-scheduled-task-migration.md
+++ b/docs/plans/2026-07-08-layered-intelligence-scheduled-task-migration.md
@@ -1,0 +1,138 @@
+# Layered Intelligence → per-app scheduled task (migration design)
+
+**Status:** proposed (design record; not yet implemented) — tracked in [#2322](https://github.com/atomantic/PortOS/issues/2322)
+**Date:** 2026-07-08
+**Supersedes the execution model in:** `docs/plans/2026-07-07-layered-intelligence-loop.md`
+
+## Why
+
+The Layered Intelligence (LI) loop shipped as a **single global autonomous job**
+(`job-layered-intelligence`) that sweeps *all* enabled apps on one daily fire,
+with a global on/off under CoS → System Tasks and per-app config under Edit App →
+Intelligence. This produced two concrete problems the user hit:
+
+1. **Confusing global/per-app split.** A per-app card shows "Enabled · Due now,"
+   but nothing runs, because the *global* sweep already fired earlier that day (or
+   is off). Per-app "due" is decoupled from the one global schedule.
+2. **It doesn't behave like the other self-improvement work.** Every other
+   per-app automation is a *scheduled task* (CoS → Schedule) with its own per-app
+   interval, provider, and manual "run now." LI is a bespoke third surface.
+
+**Decision (user):** migrate LI to run **per-app, one app's context at a time,
+like the other scheduled tasks.** Drop the cross-app sweep entirely.
+
+## Key finding — the scheduled-task system can't run a deterministic handler
+
+The `taskSchedule.js` / `SELF_IMPROVEMENT_TASK_TYPES` system is **hardwired to
+spawn one coding agent per fire.** `generateManagedAppImprovementTaskForType`
+(`cosTaskGenerator.js:1540`) always terminates by emitting an agent prompt
+(`taskType:'internal'`); deterministic per-type work (e.g. `branch-reconcile`,
+`reference-watch`) exists only as *pre-steps that prepare the agent prompt*, never
+as the task's terminal deliverable. There is **no `type:'script'`/handler concept**
+in the task system.
+
+LI is the opposite: the reasoning model returns JSON only (never code) and all
+side effects (dedup, scope-gate, park, file-one-issue) are deterministic. That
+deterministic-handler capability exists today **only** in the autonomous-jobs
+system (`executeScriptJob` → `SCRIPT_HANDLERS`).
+
+**So the migration's core work is adding a per-app deterministic *handler-backed*
+task type to the scheduled-task system** — a genuinely new execution primitive in
+core CoS autonomous-spawn infrastructure. This is why it's bigger than a config
+move, and why it warrants review before landing.
+
+Helpfully, the per-app logic already exists and is engine-agnostic:
+`processApp(app, deps)` (`layeredIntelligenceHandler.js:67`) processes exactly one
+app with injected deps. Only the thin `runLayeredIntelligence()` sweep wrapper
+loops apps — that is what we delete.
+
+## Proposed architecture
+
+### Execution primitive (the new, review-critical part)
+- Add a `HANDLER_BACKED_TASK_TYPES` set + a lazy handler registry to the
+  scheduled-task layer. A handler-backed type maps to an async `(app) => outcome`.
+- In `queueEligibleImprovementTasks` (`cosTaskGenerator.js:1094`), after
+  `getNextTaskType` selects a due type for an app: if the type is handler-backed,
+  **run the handler fire-and-forget guarded by a per-app in-flight `Set`** (so the
+  next scheduler tick can't double-run it), record execution via
+  `recordExecution('task:layered-intelligence', app.id)` on completion, and
+  `continue` — **never** touch the agent-spawn path. A bug here can only fail to
+  run LI; it can never spawn a runaway agent.
+- Mirror the on-demand path (`triggerOnDemandTask` drain) so per-app "Run now"
+  invokes the handler instead of generating an agent task.
+- `processApp` becomes gate-free per-app work (drop its own `enabled`/`isAppDue`
+  checks and `recordRun` — the scheduler now owns gating + cadence bookkeeping).
+
+### Config home — recommend **A** (required by the Schedule-UI goal)
+Two options were considered:
+- **A. Move scheduling into the task override (recommended).** `enabled`/interval/
+  `providerId`/`model` live in the per-app `taskTypeOverrides['layered-intelligence']`;
+  behavior (sources/scopes/rules) stays in `app.layeredIntelligence`, edited via the
+  Intelligence tab (reachable from the Schedule card). Requires a per-app data
+  migration, but it's what makes LI actually configurable *in the Schedule UI like
+  the other tasks* — the whole point.
+- **B. Keep all config in `app.layeredIntelligence`.** Rejected: the Schedule UI's
+  config drawer writes to `taskTypeOverrides`, so a handler that read scheduling from
+  `layeredIntelligence` instead would leave the Schedule card's enabled/interval/
+  provider controls inert — not "like other tasks." B only avoids a migration by
+  giving up the goal.
+
+**Migration (option A):** for each app with a `layeredIntelligence` config, set
+`taskTypeOverrides['layered-intelligence'] = { enabled: (globalJobEnabled &&
+li.enabled), type: intervalTypeFromMs(li.intervalMs), intervalMs, providerId,
+model }`; leave sources/scopes/rules in `layeredIntelligence`. Idempotent; safe when
+absent. This subsumes the job-tombstone migration below into one step.
+
+### Retire the global job (needs a migration)
+- Remove the `LI_JOB_ID` entry from `autonomousJobs/defaults.js` + its
+  `SCRIPT_HANDLERS` registration; delete `runLayeredIntelligence`.
+- **Migration** (`scripts/migrations/NNN-…`): in `data/cos/autonomous-jobs.json`,
+  find `job-layered-intelligence`; capture its `enabled`; **tombstone/remove** the
+  record. Faithful effective-state preservation: an app's LI stays enabled only if
+  `(globalJobEnabled && app.layeredIntelligence.enabled)` — because a per-app
+  enable did nothing while the global job was off. Idempotent; safe when absent.
+- No `schemaVersions.js` / peer-sync gating touches LI (confirmed), so no
+  cross-install payload changes are required.
+
+### Routes
+- `/layered-intelligence/overview`: re-point `jobEnabled`/`jobExists` off the
+  global job (gone) to the per-app task schedule; drop the "global job is off"
+  banner. Keep `/proposals` and `/:id/layered-intelligence` (behavior config).
+
+### Client
+- Surface LI in **CoS → Schedule** like other tasks (enabled/interval/provider/
+  run-now). Keep the Intelligence drawer tab as the behavior-config home
+  (sources/scopes/rules). Decide whether to **remove the dedicated
+  `/layered-intelligence` page + sidebar link + `NAV_COMMANDS` entry** (the "whole
+  other section" the user questioned) or keep it as a read-only status view — the
+  navManifest test couples nav path ↔ route, so both move together.
+
+## Touchpoint inventory (from research)
+- **Job:** `layeredIntelligence.js:61` (`LI_JOB_ID`), `autonomousJobs/defaults.js:259`,
+  `autonomousJobs/scriptHandlers.js:144`, `layeredIntelligenceHandler.js` (whole).
+  Persisted: `data/cos/autonomous-jobs.json` job record.
+- **Per-app config:** `apps.js:331/442/459`, `validation.js:118`
+  (`layeredIntelligenceConfigSchema`). Persisted: `data/apps.json` `layeredIntelligence`.
+- **Routes:** `routes/apps.js:24/597/748/782/804`; client wrappers `apiApps.js`.
+- **Client:** `pages/LayeredIntelligence.jsx`, `App.jsx:41/208`, `Layout.jsx:190`,
+  `navManifest.js:89`, `LayeredIntelligenceTab.jsx`, `EditAppDrawer.jsx` (tab wiring),
+  `AppDetailView.jsx:65` (`?edit=1&appTab=intelligence` deep-link).
+- **Tests:** `layeredIntelligenceHandler.test.js`, `layeredIntelligence.test.js`,
+  `apps.layeredIntelligence.test.js`, `routes/apps.test.js`,
+  `pages/LayeredIntelligence.test.jsx`, `LayeredIntelligenceTab.test.jsx`,
+  `EditAppDrawer.test.jsx`, `navManifest.test.js`.
+- **Cross-cutting gate reminder:** cover `queueEligibleImprovementTasks` +
+  the on-demand drain (`cos.js`) + `dequeueNextTask` when adding the handler path.
+
+## Open questions for review
+1. **Remove the dedicated `/layered-intelligence` page** (the "whole other section"),
+   or keep it as a read-only status view? Removal is cleaner per the consolidation
+   goal but moves nav + route + `NAV_COMMANDS` + page tests together.
+2. Behavior config (sources/scopes/rules) stays in the Intelligence tab under
+   option A — confirm that's the right home, reachable via a "Configure behavior"
+   link on the Schedule card, rather than folding those fields into the Schedule
+   drawer too.
+
+(Resolved: config home = **A**, so provider/interval/enabled live in the task
+override and are edited by the standard Schedule task controls — one provider home,
+no duplication.)

--- a/server/services/autonomousJobs/layeredIntelligenceHandler.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHandler.js
@@ -146,7 +146,7 @@ export async function processApp(app, deps = {}) {
 
   // ---- Layer 2: REASON ----
   const prompt = buildPrompt({ app, config, sources, openIssues, isPortos })
-  const llm = await resolveLLM(config, callLLM)
+  const llm = await resolveLLM(config, callLLM, cwd)
   if (!llm.ok) {
     await recordRun(app, config, now)
     return { app: app.id, action: 'no-op', reason: llm.reason }
@@ -283,11 +283,20 @@ async function fileProposal({ filer, forgeCli, cwd, app, proposal, jira }) {
 
 /**
  * Resolve the LLM call function. Prefers an injected `callLLM(prompt)`; otherwise
- * resolves the active/overridden provider and returns a bound
- * callProviderAISimple. Returns `{ ok: false, reason }` when no provider is
- * available (a no-op for that app, never a throw).
+ * resolves the active/overridden provider and returns a bound call through the
+ * unified `runPromptThroughProvider`. Returns `{ ok: false, reason }` when no
+ * provider is available (a no-op for that app, never a throw).
+ *
+ * Routing through runPromptThroughProvider (rather than the api-only
+ * callProviderAISimple) lets the loop reason with EVERY provider type the user
+ * can configure — `api` (Ollama, LM Studio), `cli` (Claude Code, Codex,
+ * OpenCode, Antigravity), and `tui` — not just API providers. It dispatches on
+ * `provider.type` and returns `{ text }`, throwing on failure; we convert a
+ * throw back to the `{ error }` shape processApp already branches on. `cwd` is
+ * the app's repo path so CLI/TUI spawns land in the right directory (no-op for
+ * API providers).
  */
-async function resolveLLM(config, injected) {
+async function resolveLLM(config, injected, cwd) {
   if (typeof injected === 'function') return { ok: true, call: injected }
   const { getActiveProvider, getProviderById } = await import('../providers.js')
   const provider = config.providerId
@@ -295,14 +304,16 @@ async function resolveLLM(config, injected) {
     : await getActiveProvider().catch(() => null)
   if (!provider) return { ok: false, reason: 'no-provider' }
   const model = config.model || provider.defaultModel
-  const { callProviderAISimple } = await import('../../lib/aiProvider.js')
+  const { runPromptThroughProvider } = await import('../../lib/promptRunner.js')
   return {
     ok: true,
-    call: (prompt) => callProviderAISimple(provider, model, prompt, {
-      op: `layered-intelligence:${provider.id}`,
-      opLabel: 'Layered Intelligence reasoning…',
-      max_tokens: 1500
-    })
+    call: (prompt) => runPromptThroughProvider({
+      provider,
+      model,
+      prompt,
+      source: 'layered-intelligence',
+      cwd
+    }).catch(err => ({ error: err.message }))
   }
 }
 

--- a/server/services/autonomousJobs/layeredIntelligenceHandler.test.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHandler.test.js
@@ -59,6 +59,21 @@ vi.mock('../layeredIntelligence.js', async (importOriginal) => {
   };
 });
 
+// resolveLLM lazy-imports these only when NO callLLM is injected. Mocking them
+// lets us assert the real provider-resolution path routes through the unified
+// runPromptThroughProvider (which supports cli/api/tui) rather than the old
+// api-only callProviderAISimple.
+const runPromptMock = vi.fn().mockResolvedValue({ text: '{}' });
+vi.mock('../../lib/promptRunner.js', () => ({
+  runPromptThroughProvider: (...args) => runPromptMock(...args)
+}));
+const getProviderByIdMock = vi.fn();
+const getActiveProviderMock = vi.fn();
+vi.mock('../providers.js', () => ({
+  getProviderById: (...args) => getProviderByIdMock(...args),
+  getActiveProvider: (...args) => getActiveProviderMock(...args)
+}));
+
 import { isAppDue, processApp, runLayeredIntelligence } from './layeredIntelligenceHandler.js';
 import { getActiveApps } from '../apps.js';
 
@@ -87,6 +102,12 @@ beforeEach(() => {
   forgeState.jiraBlockingApplied = [];
   forgeState.semanticResult = { available: false, duplicate: false, match: null };
   resolveTrackerMock.mockResolvedValue({ resolved: 'github', forge: 'gh' });
+  runPromptMock.mockResolvedValue({ text: '{}' });
+  // Default to resolving null (no provider) — mirrors the real async signature so
+  // resolveLLM's `.catch()` never trips over a non-promise in sweep tests that
+  // don't inject callLLM.
+  getProviderByIdMock.mockReset().mockResolvedValue(null);
+  getActiveProviderMock.mockReset().mockResolvedValue(null);
 });
 
 describe('isAppDue', () => {
@@ -297,6 +318,59 @@ describe('processApp', () => {
     expect(out.action).toBe('filed');
     expect(out.paused).toBe(false); // pause skipped for plan tracker
     expect(forgeState.blockingApplied).toHaveLength(0);
+  });
+});
+
+describe('processApp — provider resolution (no injected callLLM)', () => {
+  const app = (providerId) => ({
+    id: 'app-1', name: 'App One', repoPath: '/repo',
+    layeredIntelligence: { enabled: true, intervalMs: DAY, providerId, allowedScopes: ['app-improvement'] }
+  });
+
+  it('reasons through runPromptThroughProvider for a non-API (tui) provider', async () => {
+    getProviderByIdMock.mockResolvedValue({ id: 'claude-code-tui', type: 'tui', defaultModel: null });
+    runPromptMock.mockResolvedValue({ text: JSON.stringify({ proposal: { scope: 'app-improvement', slug: 'add-x', title: 'Add X', body: 'do it' } }) });
+    const out = await processApp(app('claude-code-tui'));
+    expect(getProviderByIdMock).toHaveBeenCalledWith('claude-code-tui');
+    expect(runPromptMock).toHaveBeenCalledWith(expect.objectContaining({
+      provider: expect.objectContaining({ id: 'claude-code-tui', type: 'tui' }),
+      source: 'layered-intelligence',
+      cwd: '/repo'
+    }));
+    expect(out.action).toBe('filed');
+  });
+
+  it('works for a cli provider too (Claude Code / Codex / OpenCode)', async () => {
+    getProviderByIdMock.mockResolvedValue({ id: 'opencode-ollama', type: 'cli', defaultModel: null });
+    runPromptMock.mockResolvedValue({ text: JSON.stringify({ proposal: { scope: 'app-improvement', slug: 'add-y', title: 'Add Y', body: 'do it' } }) });
+    const out = await processApp(app('opencode-ollama'));
+    expect(runPromptMock).toHaveBeenCalledWith(expect.objectContaining({ provider: expect.objectContaining({ type: 'cli' }) }));
+    expect(out.action).toBe('filed');
+  });
+
+  it('falls back to the active provider when no providerId is set', async () => {
+    getActiveProviderMock.mockResolvedValue({ id: 'ollama', type: 'api', defaultModel: 'llama3.2' });
+    runPromptMock.mockResolvedValue({ text: JSON.stringify({ proposal: { scope: 'app-improvement', slug: 'add-z', title: 'Add Z', body: 'do it' } }) });
+    const out = await processApp(app(null));
+    expect(getProviderByIdMock).not.toHaveBeenCalled();
+    expect(getActiveProviderMock).toHaveBeenCalled();
+    expect(out.action).toBe('filed');
+  });
+
+  it('no-ops (never throws) when the runner rejects', async () => {
+    getProviderByIdMock.mockResolvedValue({ id: 'ollama', type: 'api', defaultModel: 'llama3.2' });
+    runPromptMock.mockRejectedValue(new Error('backend down'));
+    const out = await processApp(app('ollama'));
+    expect(out.action).toBe('no-op');
+    expect(out.reason).toContain('backend down');
+  });
+
+  it('no-ops when the provider cannot be resolved', async () => {
+    getProviderByIdMock.mockResolvedValue(null);
+    const out = await processApp(app('ghost-provider'));
+    expect(out.action).toBe('no-op');
+    expect(out.reason).toBe('no-provider');
+    expect(runPromptMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes the Layered Intelligence (LI) per-app AI-provider picker, and records the design for the follow-up architecture migration (#2322).

**The bug (fixed here):** the LI provider picker listed only `cli` providers, but the reasoning call ran through the api-only `callProviderAISimple` — so any CLI provider you selected failed at runtime with *"requires an API-based provider,"* while `api`/`tui` providers (Ollama, LM Studio, Claude/Codex/OpenCode TUI) never appeared at all. Reported from the Intelligence tab showing only Claude Code CLI / Codex CLI / Bedrock / Antigravity CLI.

**The fix:**
- Route the reasoning call through the unified `runPromptThroughProvider`, which dispatches on `provider.type` (`cli`/`api`/`tui`) and returns `{ text }`. CLI/TUI spawns run in the app's repo (`cwd`). A runner throw is converted back to the `{ error }` shape `processApp` already branches on.
- Widen the picker to every enabled provider whose type is in `PROVIDER_TYPES` (reuses the client enum instead of a hardcoded list).
- Ollama auto-start is preserved (the toolkit's API run path wires `ensureProviderReady`).

**Design record (no behavior change):** `docs/plans/2026-07-08-layered-intelligence-scheduled-task-migration.md` captures the plan to migrate LI from its global sweep job to a **per-app deterministic scheduled task** — including the key finding that the scheduled-task system has no deterministic-handler path today, so the migration adds that primitive. Tracked in #2322. Not implemented here.

## Test plan

- `cd server && NODE_ENV=test npx vitest run services/autonomousJobs services/layeredIntelligence.test.js routes/apps.test.js` — 318 pass, 1 skipped. Added 5 regression tests asserting the reasoning path routes cli/api/tui through `runPromptThroughProvider`, falls back to the active provider, and no-ops (never throws) on runner rejection / unresolved provider.
- `cd client && npx vitest run src/components/apps/EditAppDrawer.test.jsx src/components/apps/LayeredIntelligenceTab.test.jsx src/pages/LayeredIntelligence.test.jsx` — 35 pass.
- eslint clean on changed client files.

## Note

I left an unrelated pre-existing working-tree edit (`ecosystem.config.cjs`: `AUTOFIXER_UI` 5560 → 5555) out of this PR — it wasn't mine and 5555 collides with the main app port, so it looks accidental. Flagging rather than committing it.