### PR TITLE
Make Creative Director treatment and planning models independently assignable

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -2,6 +2,8 @@
 
 ## AI Providers
 
+- **Creative Director LLM stages are now independently configurable.** AI Assignments has separate provider/model rows for treatment generation, production planning, and scene evaluation. Point **Scene evaluation vision model** at a local Ollama or LM Studio vision model to judge rendered scenes without using the system-default agent; treatment and planning can likewise be pinned to any agent-capable CLI/TUI provider.
+
 - **[issue-2336] xAI Grok is now a built-in AI provider — API, Grok Build CLI, and Grok Build TUI.** Three new providers ship ready to enable under AI Providers: **xAI Grok** (the OpenAI-compatible chat API at `https://api.x.ai/v1` — paste your xAI key and pick a model), **Grok Build CLI** (headless, for one-shot generations and file-writing CoS agents), and **Grok Build TUI** (the interactive `grok` coding agent driven over a PTY like Claude Code / Codex). All three arrive disabled by default (nothing calls Grok until you turn one on) and reach existing installs on upgrade. The CLI/TUI use the local `grok` binary; run `grok login` (or set your xAI credentials) to authenticate it.
 
 ## Layered Intelligence

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -457,11 +457,15 @@ export const featureProviderConfigSchema = z.object({
   model: z.preprocess(emptyToUndefined, z.string().optional()),
 });
 
-// Creative Director settings slice. `evaluation` pins the vision provider/model
-// used to judge each rendered scene server-side (blank = auto-pick a local
-// vision model, else fall back to the coding agent). Reuses the shared
-// feature-provider shape so an empty-string picker value normalizes to unset.
+// Creative Director settings slice. Each LLM-backed stage can pin its own
+// provider/model instead of inheriting the system default. `evaluation` is a
+// direct vision API call (blank = auto-pick a local vision model, else fall
+// back to the coding agent); treatment and plan run as CoS agent tasks.
+// Reuses the shared feature-provider shape so an empty-string picker value
+// normalizes to unset.
 export const creativeDirectorSettingsSchema = z.object({
+  treatment: featureProviderConfigSchema.partial().optional(),
+  plan: featureProviderConfigSchema.partial().optional(),
   evaluation: featureProviderConfigSchema.partial().optional(),
 });
 

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -133,8 +133,9 @@ router.put('/', asyncHandler(async (req, res) => {
   if (req.body?.codeReview !== undefined) {
     validateRequest(codeReviewSettingsSchema.partial(), req.body.codeReview);
   }
-  // Creative Director scene-evaluation provider/model pin — validate the slice
-  // when present so a malformed picker save can't write a bad provider config.
+  // Creative Director's treatment, plan, and scene-evaluation provider/model
+  // pins — validate the slice when present so a malformed picker save can't
+  // write a bad provider config.
   if (req.body?.creativeDirector !== undefined) {
     validateRequest(creativeDirectorSettingsSchema.partial(), req.body.creativeDirector);
   }

--- a/server/services/aiAssignments.js
+++ b/server/services/aiAssignments.js
@@ -158,14 +158,38 @@ const addSettingsEntries = async (entries) => {
   }
 
   entries.push(makeEntry({
+    id: 'settings.creativeDirector.treatment',
+    area: 'Creative Director',
+    label: 'Treatment generation model',
+    source: 'settings.creativeDirector.treatment',
+    providerId: settings.creativeDirector?.treatment?.providerId || null,
+    model: settings.creativeDirector?.treatment?.model || null,
+    providerTypes: cliProviderTypes,
+    notes: 'Agent model that turns a project brief into a treatment and scene plan. Blank = system default provider and model.',
+    link: '/creative-director',
+  }));
+
+  entries.push(makeEntry({
+    id: 'settings.creativeDirector.plan',
+    area: 'Creative Director',
+    label: 'Production planning model',
+    source: 'settings.creativeDirector.plan',
+    providerId: settings.creativeDirector?.plan?.providerId || null,
+    model: settings.creativeDirector?.plan?.model || null,
+    providerTypes: cliProviderTypes,
+    notes: 'Agent model that converts a production directive into an executable plan. Blank = system default provider and model.',
+    link: '/creative-director',
+  }));
+
+  entries.push(makeEntry({
     id: 'settings.creativeDirector.evaluation',
     area: 'Creative Director',
-    label: 'Scene evaluation model',
+    label: 'Scene evaluation vision model',
     source: 'settings.creativeDirector.evaluation',
     providerId: settings.creativeDirector?.evaluation?.providerId || null,
     model: settings.creativeDirector?.evaluation?.model || null,
     providerTypes: apiProviderTypes,
-    notes: 'Vision model that judges each rendered scene. Blank = auto-pick an installed local (Ollama / LM Studio) vision model; if none is available it falls back to the coding agent (Opus).',
+    notes: 'Vision model that judges each rendered scene. Use a local Ollama or LM Studio VLM here. Blank = auto-pick an installed local vision model; if none is available it falls back to the coding agent.',
     link: '/creative-director',
   }));
 
@@ -488,8 +512,12 @@ export async function updateAiAssignment(id, { providerId, model } = {}) {
     return getAiAssignments();
   }
 
-  if (id === 'settings.creativeDirector.evaluation') {
-    await patchSettingsPath('creativeDirector.evaluation', { providerId: nextProviderId, model: nextModel });
+  if (id.startsWith('settings.creativeDirector.')) {
+    const stage = id.slice('settings.creativeDirector.'.length);
+    if (!['treatment', 'plan', 'evaluation'].includes(stage)) {
+      throw new ServerError(`Unknown Creative Director assignment: ${id}`, { status: 400, code: 'VALIDATION_ERROR' });
+    }
+    await patchSettingsPath(`creativeDirector.${stage}`, { providerId: nextProviderId, model: nextModel });
     return getAiAssignments();
   }
 

--- a/server/services/aiAssignments.test.js
+++ b/server/services/aiAssignments.test.js
@@ -142,6 +142,12 @@ describe('updateAiAssignment routing', () => {
     expect(mocks.updateSettings).toHaveBeenCalledWith({ creativeDirector: { [stage]: { providerId: 'claude', model: 'sonnet' } } });
   });
 
+  it('settings.creativeDirector.<unknown> rejects with a 400 instead of writing a bogus stage', async () => {
+    await expect(updateAiAssignment('settings.creativeDirector.bogus', { providerId: 'claude', model: 'sonnet' }))
+      .rejects.toMatchObject({ status: 400, code: 'VALIDATION_ERROR' });
+    expect(mocks.updateSettings).not.toHaveBeenCalled();
+  });
+
   it('cos.task.<existing> updates the schedule interval', async () => {
     await updateAiAssignment('cos.task.morning-brief', { providerId: 'claude', model: 'opus' });
     expect(mocks.updateTaskInterval).toHaveBeenCalledWith('morning-brief', { providerId: 'claude', model: 'opus' });

--- a/server/services/aiAssignments.test.js
+++ b/server/services/aiAssignments.test.js
@@ -109,6 +109,8 @@ describe('getAiAssignments', () => {
     expect(ids).toContain('provider.active');
     expect(ids).toContain('settings.embeddings');
     expect(ids).toContain('settings.voice.vision');
+    expect(ids).toContain('settings.creativeDirector.treatment');
+    expect(ids).toContain('settings.creativeDirector.plan');
     expect(ids).toContain('settings.creativeDirector.evaluation');
     expect(ids).toContain('cos.task.morning-brief');
   });
@@ -133,6 +135,11 @@ describe('updateAiAssignment routing', () => {
   it('settings.creativeDirector.evaluation writes the vision provider/model under creativeDirector', async () => {
     await updateAiAssignment('settings.creativeDirector.evaluation', { providerId: 'ollama', model: 'qwen2.5-vl' });
     expect(mocks.updateSettings).toHaveBeenCalledWith({ creativeDirector: { evaluation: { providerId: 'ollama', model: 'qwen2.5-vl' } } });
+  });
+
+  it.each(['treatment', 'plan'])('settings.creativeDirector.%s writes that agent stage provider/model', async (stage) => {
+    await updateAiAssignment(`settings.creativeDirector.${stage}`, { providerId: 'claude', model: 'sonnet' });
+    expect(mocks.updateSettings).toHaveBeenCalledWith({ creativeDirector: { [stage]: { providerId: 'claude', model: 'sonnet' } } });
   });
 
   it('cos.task.<existing> updates the schedule interval', async () => {

--- a/server/services/creativeDirector/agentBridge.js
+++ b/server/services/creativeDirector/agentBridge.js
@@ -26,6 +26,13 @@ import { recordRun } from './local.js';
 // choices accordingly; this helper only adds a pin when one was explicitly
 // saved, preserving the system-default behavior for existing installations.
 async function getStageAssignment(kind) {
+  // Scene evaluation is a direct vision API call (apiProviderTypes) resolved
+  // separately, NOT a CoS agent pin — injecting its api-type provider into the
+  // agent task metadata would trip the harness-boundary guard. Never pin it
+  // here. (This also documents that `kind === 'evaluate'` intentionally has no
+  // `creativeDirector.evaluate` settings key; the eval pin lives under
+  // `creativeDirector.evaluation`.)
+  if (kind === 'evaluate') return {};
   const settings = await getSettings().catch(() => ({}));
   const assignment = settings?.creativeDirector?.[kind];
   if (!assignment?.providerId && !assignment?.model) return {};

--- a/server/services/creativeDirector/agentBridge.js
+++ b/server/services/creativeDirector/agentBridge.js
@@ -18,11 +18,27 @@ import { randomUUID } from 'crypto';
 import { addTask, cosEvents } from '../cos.js';
 import { buildTreatmentPrompt, buildEvaluatePrompt, buildPlanPrompt } from '../../lib/creativeDirectorPrompts.js';
 import { getToolSpecs } from '../creative/toolRegistry.js';
+import { getSettings } from '../settings.js';
 import { recordRun } from './local.js';
 
-function buildTaskRecord(project, kind, scene, context) {
+// Treatment and production planning are CoS tasks, so unlike scene evaluation
+// they need a CLI/TUI provider with an agent harness. The assignment UI limits
+// choices accordingly; this helper only adds a pin when one was explicitly
+// saved, preserving the system-default behavior for existing installations.
+async function getStageAssignment(kind) {
+  const settings = await getSettings().catch(() => ({}));
+  const assignment = settings?.creativeDirector?.[kind];
+  if (!assignment?.providerId && !assignment?.model) return {};
+  return {
+    ...(assignment.providerId ? { provider: assignment.providerId, providerId: assignment.providerId } : {}),
+    ...(assignment.model ? { model: assignment.model } : {}),
+  };
+}
+
+async function buildTaskRecord(project, kind, scene, context) {
   const taskId = `cd-${project.id}-${kind}-${Date.now().toString(36)}`;
   const runId = randomUUID();
+  const assignment = await getStageAssignment(kind);
   return {
     id: taskId,
     runId,
@@ -40,6 +56,7 @@ function buildTaskRecord(project, kind, scene, context) {
           runId,
         },
         context,
+        ...assignment,
         useWorktree: false,
         readOnly: false,
       },
@@ -83,7 +100,7 @@ async function persistAndEmit({ id, runId, record }, project, kind, sceneId) {
 
 export async function enqueueTreatmentTask(project) {
   const context = await buildTreatmentPrompt(project);
-  const built = buildTaskRecord(project, 'treatment', null, context);
+  const built = await buildTaskRecord(project, 'treatment', null, context);
   return persistAndEmit(built, project, 'treatment', null);
 }
 
@@ -95,13 +112,13 @@ export async function enqueueTreatmentTask(project) {
 // treatment stage — the agent reads the 4xx error body and re-PATCHes.
 export async function enqueuePlanTask(project) {
   const context = await buildPlanPrompt(project, { toolSpecs: getToolSpecs() });
-  const built = buildTaskRecord(project, 'plan', null, context);
+  const built = await buildTaskRecord(project, 'plan', null, context);
   return persistAndEmit(built, project, 'plan', null);
 }
 
 export async function enqueueEvaluateTask(project, scene) {
   if (!scene) throw new Error('enqueueEvaluateTask: scene is required');
   const context = await buildEvaluatePrompt(project, scene);
-  const built = buildTaskRecord(project, 'evaluate', scene, context);
+  const built = await buildTaskRecord(project, 'evaluate', scene, context);
   return persistAndEmit(built, project, 'evaluate', scene.sceneId);
 }

--- a/server/services/creativeDirector/agentBridge.test.js
+++ b/server/services/creativeDirector/agentBridge.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  addTask: vi.fn(),
+  emit: vi.fn(),
+  buildTreatmentPrompt: vi.fn(),
+  buildEvaluatePrompt: vi.fn(),
+  buildPlanPrompt: vi.fn(),
+  getToolSpecs: vi.fn(),
+  getSettings: vi.fn(),
+  recordRun: vi.fn(),
+}));
+
+vi.mock('../cos.js', () => ({
+  addTask: mocks.addTask,
+  cosEvents: { emit: mocks.emit },
+}));
+vi.mock('../../lib/creativeDirectorPrompts.js', () => ({
+  buildTreatmentPrompt: mocks.buildTreatmentPrompt,
+  buildEvaluatePrompt: mocks.buildEvaluatePrompt,
+  buildPlanPrompt: mocks.buildPlanPrompt,
+}));
+vi.mock('../creative/toolRegistry.js', () => ({ getToolSpecs: mocks.getToolSpecs }));
+vi.mock('../settings.js', () => ({ getSettings: mocks.getSettings }));
+vi.mock('./local.js', () => ({ recordRun: mocks.recordRun }));
+
+const { enqueueTreatmentTask, enqueuePlanTask } = await import('./agentBridge.js');
+
+const project = { id: 'cd-1', name: 'Test project', treatment: { scenes: [] } };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.buildTreatmentPrompt.mockResolvedValue('treatment context');
+  mocks.buildPlanPrompt.mockResolvedValue('plan context');
+  mocks.getToolSpecs.mockReturnValue([]);
+  mocks.recordRun.mockResolvedValue();
+  mocks.addTask.mockResolvedValue();
+  mocks.getSettings.mockResolvedValue({});
+});
+
+describe('Creative Director agent bridge model assignments', () => {
+  it('pins the configured treatment provider and model on its CoS task', async () => {
+    mocks.getSettings.mockResolvedValue({
+      creativeDirector: { treatment: { providerId: 'local-agent', model: 'qwen3' } },
+    });
+
+    await enqueueTreatmentTask(project);
+
+    const [task] = mocks.addTask.mock.calls[0];
+    expect(task.metadata).toMatchObject({
+      provider: 'local-agent',
+      providerId: 'local-agent',
+      model: 'qwen3',
+      context: 'treatment context',
+    });
+  });
+
+  it('leaves planning on the system default when no assignment is saved', async () => {
+    await enqueuePlanTask(project);
+
+    const [task] = mocks.addTask.mock.calls[0];
+    expect(task.metadata).not.toHaveProperty('provider');
+    expect(task.metadata).not.toHaveProperty('model');
+  });
+});


### PR DESCRIPTION
## Summary

Creative Director's per-stage LLM work can now be pinned independently in **AI Assignments**. Previously only scene evaluation had a provider/model row; this adds two more:

- **Treatment generation model** — the agent that turns a project brief into a treatment + scene plan
- **Production planning model** — the agent that converts a production directive into an executable plan
- (existing) **Scene evaluation vision model** — the vision VLM that judges each rendered scene

Each stage's saved pin flows onto its CoS agent task via `metadata.provider` / `metadata.providerId` / `metadata.model`, which are consumed by `agentProviderResolution.js` and `agentModelSelection.js`. Stages left unset keep the system-default provider/model, so existing installs are unaffected and no migration is needed (the settings slice is additive and optional).

Treatment and planning require an agent-capable CLI/TUI provider (`cliProviderTypes`); scene evaluation remains a **direct vision API call** (`apiProviderTypes`) resolved separately — so its pin is intentionally never injected into a CoS agent task, which an api-type provider would otherwise reject at the harness boundary. An explicit guard in `getStageAssignment` makes that invariant load-bearing rather than incidental.

### Changes
- `server/lib/validation.js` — extend `creativeDirectorSettingsSchema` with optional `treatment` / `plan` slices (reusing the shared feature-provider shape).
- `server/routes/settings.js` — the existing `.partial()` validation now covers the new keys on `PUT /api/settings`.
- `server/services/aiAssignments.js` — two new assignment rows; the update router now handles all three CD stages behind an allowlist that 400s on an unknown stage.
- `server/services/creativeDirector/agentBridge.js` — new `getStageAssignment` helper injects the pin (only when explicitly saved); `buildTaskRecord` is now async to read it.

## Test plan
- `server/services/aiAssignments.test.js` — asserts the two new assignment ids appear, that `treatment`/`plan` route their provider/model under `creativeDirector`, and that an unknown CD stage is rejected with a 400 `VALIDATION_ERROR`.
- `server/services/creativeDirector/agentBridge.test.js` (new) — a saved treatment pin lands on the CoS task metadata; an unset planning stage stays on the system default (no `provider`/`model` keys).
- `cd server && npx vitest run services/aiAssignments.test.js services/creativeDirector/agentBridge.test.js` → 17 passing.