### PR TITLE
a11y: focus-trap shared modals/drawers and announce toasts to screen readers

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Accessibility
+
+- **Modals and drawers now trap and restore keyboard focus, and toasts are announced to screen readers.** Opening any shared `Modal` or `Drawer` (which back the great majority of the app's dialogs, config drawers, and lightboxes) now moves focus into the dialog, keeps Tab/Shift+Tab cycling inside it instead of leaking to the page behind, and returns focus to the control that opened it on close (WCAG 2.4.3 / 2.1.2) — implemented once in a reusable `useFocusTrap` hook. The toast stack is now a labelled ARIA notification region: default toasts announce politely (`role="status"`) and error toasts assertively (`role="alert"`), with the decorative status glyphs hidden from assistive tech, so screen-reader users hear notifications (including error toasts) as they arrive.
+
 ## AI Providers
 
 - **Creative Director LLM stages are now independently configurable.** AI Assignments has separate provider/model rows for treatment generation, production planning, and scene evaluation. Point **Scene evaluation vision model** at a local Ollama or LM Studio vision model to judge rendered scenes without using the system-default agent; treatment and planning can likewise be pinned to any agent-capable CLI/TUI provider.

--- a/client/src/components/Drawer.jsx
+++ b/client/src/components/Drawer.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { X } from 'lucide-react';
 import { useScrollLock } from '../hooks/useScrollLock';
+import useFocusTrap from '../hooks/useFocusTrap.js';
 import TabPills from './ui/TabPills';
 
 // Right-side slide-in panel for the "settings over a feature page" pattern.
@@ -54,6 +55,11 @@ export default function Drawer({
 }) {
   useScrollLock(open);
 
+  // Trap keyboard focus inside the panel while open and restore it to the
+  // trigger on close (WCAG 2.4.3 / 2.1.2).
+  const panelRef = useRef(null);
+  useFocusTrap(open, panelRef);
+
   const tabList = Array.isArray(tabs) ? tabs.filter(Boolean) : null;
   const hasTabs = !!(tabList && tabList.length);
 
@@ -83,6 +89,7 @@ export default function Drawer({
         aria-hidden="true"
       />
       <aside
+        ref={panelRef}
         role="dialog"
         aria-modal="true"
         aria-label={title}

--- a/client/src/components/ui/Modal.jsx
+++ b/client/src/components/ui/Modal.jsx
@@ -47,6 +47,7 @@
 
 import { useEffect, useId, useRef } from 'react';
 import { createPortal } from 'react-dom';
+import useFocusTrap from '../../hooks/useFocusTrap.js';
 
 const SIZE_CLASSES = {
   sm: 'max-w-md',
@@ -176,6 +177,11 @@ export default function Modal({
   ariaLabel,
 }) {
   const backdropRef = useRef(null);
+  const dialogRef = useRef(null);
+  // Trap keyboard focus inside the dialog while open, then restore it to the
+  // element that opened the modal (WCAG 2.4.3 / 2.1.2). Runs for every Modal
+  // regardless of the Esc/backdrop opt-outs.
+  useFocusTrap(open, dialogRef);
   // `useId()` is React's render-safe stable id source — survives StrictMode's
   // double-invoke without allocating extra ids the way a `modalIdSeq++`
   // module-scope counter would.
@@ -252,6 +258,7 @@ export default function Modal({
       role="presentation"
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby={ariaLabelledBy}

--- a/client/src/components/ui/Toast.jsx
+++ b/client/src/components/ui/Toast.jsx
@@ -98,14 +98,27 @@ export function Toaster({ position = 'bottom-right', toastOptions = {} }) {
   }[position] ?? 'bottom-4 right-4 items-end';
 
   return (
-    <div className={`fixed ${posClass} z-[9999] flex flex-col gap-2 pointer-events-none`}>
+    // Notification region. Each toast is its own live region (role="alert" for
+    // errors → assertive, role="status" otherwise → polite) so screen readers
+    // announce toasts as they arrive. Announcing per-toast rather than on the
+    // container avoids the whole stack being re-read when one entry changes.
+    <div
+      className={`fixed ${posClass} z-[9999] flex flex-col gap-2 pointer-events-none`}
+      role="region"
+      aria-label="Notifications"
+    >
       {items.map(t => {
         const style = { padding: '12px 16px', borderRadius: '8px', ...toastOptions.style, ...t.style };
         const iconStr = t.icon ?? (t.type !== 'default' ? TYPE_ICON[t.type] : null);
         const iconClass = t.type !== 'default' ? TYPE_CLASS[t.type] : '';
         return (
-          <div key={t.id} style={style} className="pointer-events-auto flex items-start gap-2 shadow-lg text-sm max-w-[calc(100vw-2rem)] sm:max-w-[520px] bg-port-card border border-port-border">
-            {iconStr && <span className={`shrink-0 ${iconClass}`}>{iconStr}</span>}
+          <div
+            key={t.id}
+            style={style}
+            role={t.type === 'error' ? 'alert' : 'status'}
+            aria-live={t.type === 'error' ? 'assertive' : 'polite'}
+            className="pointer-events-auto flex items-start gap-2 shadow-lg text-sm max-w-[calc(100vw-2rem)] sm:max-w-[520px] bg-port-card border border-port-border">
+            {iconStr && <span className={`shrink-0 ${iconClass}`} aria-hidden="true">{iconStr}</span>}
             <div className="flex-1 min-w-0">
               {typeof t.content === 'function' ? t.content({ id: t.id }) : <span>{t.content}</span>}
             </div>

--- a/client/src/components/ui/Toast.test.jsx
+++ b/client/src/components/ui/Toast.test.jsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup, act } from '@testing-library/react';
+
+import { toast, Toaster } from './Toast.jsx';
+
+afterEach(() => {
+  act(() => toast.dismiss());
+  cleanup();
+});
+
+describe('Toaster accessibility', () => {
+  it('exposes the toast stack as a labelled notification region', () => {
+    render(<Toaster />);
+    const region = screen.getByRole('region', { name: 'Notifications' });
+    expect(region).toBeInTheDocument();
+  });
+
+  it('announces a default toast politely (role="status")', () => {
+    render(<Toaster />);
+    act(() => { toast('Saved'); });
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('Saved');
+    expect(status).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('announces an error toast assertively (role="alert")', () => {
+    render(<Toaster />);
+    act(() => { toast.error('Boom'); });
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('Boom');
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+  });
+
+  it('hides the decorative status glyph from assistive tech', () => {
+    render(<Toaster />);
+    act(() => { toast.success('Done'); });
+    const status = screen.getByRole('status');
+    const glyph = status.querySelector('[aria-hidden="true"]');
+    expect(glyph).toHaveTextContent('✓');
+  });
+});

--- a/client/src/hooks/README.md
+++ b/client/src/hooks/README.md
@@ -87,6 +87,7 @@ grep -i "what you want to do" client/src/hooks/README.md
 | `useClickOutside` | Fire `onOutside` on mousedown outside a ref. | Popovers, menus, drawers. |
 | `useConfirmDelete` | Single-at-a-time `{ confirmingId, isConfirming, requestDelete, cancelDelete, confirmDelete }` for arming one list/card row at a time. | New destructive list action — pair with `<InlineConfirmRow>` / `<ConfirmButtonPair>` instead of deleting on the raw trash click. |
 | `useEscapeKey` | `useEscapeKey(active, handler)` — call `handler` on Escape while `active`. | Non-modal dismissables (in-context popovers/cards); Modal owns Esc for true modals. |
+| `useFocusTrap` | `useFocusTrap(active, containerRef, { initialFocusRef? })` — moves focus into the container on open, traps Tab/Shift+Tab so it can't escape to the page behind, and restores focus to the opener on close (WCAG 2.4.3 / 2.1.2). | Modal surfaces (dialogs, drawers, lightboxes). Already wired into `Modal` and `Drawer` — reach for it when hand-rolling a new overlay. |
 | `useCmdKSearch` | `⌘K` open/close state. | Anywhere that needs to toggle the palette. |
 | `useContainerWidth` | `[ref, width]` via ResizeObserver. | Layout responds to a specific container's width. |
 | `useCooldownTick` | 1-second ticker over a `{ id: epochMs }` cooldown map; fires `onAllExpired` once when every deadline passes. | Rate-limit countdown labels that need to refetch when the last cooldown clears (agents tabs pattern). |

--- a/client/src/hooks/index.js
+++ b/client/src/hooks/index.js
@@ -19,6 +19,7 @@ export { default as useColorMatch } from './useColorMatch.js';
 export { default as useContainerWidth } from './useContainerWidth.js';
 export { default as useEscapeKey } from './useEscapeKey.js';
 export { default as useFieldDraft } from './useFieldDraft.js';
+export { default as useFocusTrap } from './useFocusTrap.js';
 export { default as useImageGenQueue } from './useImageGenQueue.js';
 export { default as useImageRenderSettings } from './useImageRenderSettings.js';
 export { default as useSingleImageRender } from './useSingleImageRender.js';

--- a/client/src/hooks/useFocusTrap.js
+++ b/client/src/hooks/useFocusTrap.js
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 // Keyboard focus management for modal surfaces (dialogs, drawers, lightboxes).
 // When `active` flips true it:
@@ -36,15 +36,38 @@ function getFocusable(container) {
 }
 
 export default function useFocusTrap(active, containerRef, { initialFocusRef } = {}) {
+  // Capture the element to return focus to at the RENDER where `active` flips
+  // true — before the dialog commits to the DOM and any child `autoFocus`
+  // fires. Capturing in the effect below (which runs after commit) would grab
+  // the modal's own auto-focused input instead of the control that opened it,
+  // breaking restoration for autoFocus modals like ResumeAgentModal.
+  const restoreRef = useRef(null);
+  const wasActive = useRef(false);
+  if (active && !wasActive.current) {
+    restoreRef.current = typeof document !== 'undefined' ? document.activeElement : null;
+  }
+  wasActive.current = active;
+
   useEffect(() => {
     if (!active) return;
     const container = containerRef.current;
     if (!container) return;
 
-    const previouslyFocused = document.activeElement;
+    const previouslyFocused = restoreRef.current;
 
     const focusInitial = () => {
-      const target = initialFocusRef?.current || getFocusable(container)[0];
+      if (initialFocusRef?.current) {
+        initialFocusRef.current.focus();
+        return;
+      }
+      // Respect focus a child already claimed — React applies a child's
+      // `autoFocus` during commit, before this passive effect runs, so if
+      // focus is already inside the dialog leave it there rather than yanking
+      // it to the first focusable (which would defeat the author's autoFocus).
+      if (container.contains(document.activeElement) && document.activeElement !== container) {
+        return;
+      }
+      const target = getFocusable(container)[0];
       if (target) {
         target.focus();
       } else {
@@ -57,7 +80,7 @@ export default function useFocusTrap(active, containerRef, { initialFocusRef } =
     focusInitial();
 
     const onKeyDown = (e) => {
-      if (e.key !== 'Tab') return;
+      if (e.key !== 'Tab' || e.defaultPrevented) return;
       const focusable = getFocusable(container);
       if (focusable.length === 0) {
         e.preventDefault();
@@ -81,6 +104,11 @@ export default function useFocusTrap(active, containerRef, { initialFocusRef } =
     container.addEventListener('keydown', onKeyDown);
     return () => {
       container.removeEventListener('keydown', onKeyDown);
+      // Drop the fallback tabindex we may have added so the container doesn't
+      // linger as a programmatic focus target after close.
+      if (container.getAttribute('tabindex') === '-1') {
+        container.removeAttribute('tabindex');
+      }
       // Restore focus to the pre-open element so keyboard users return to where
       // they were. Guard: it may have been removed from the DOM while open.
       if (previouslyFocused && typeof previouslyFocused.focus === 'function') {

--- a/client/src/hooks/useFocusTrap.js
+++ b/client/src/hooks/useFocusTrap.js
@@ -1,0 +1,91 @@
+import { useEffect } from 'react';
+
+// Keyboard focus management for modal surfaces (dialogs, drawers, lightboxes).
+// When `active` flips true it:
+//   1. remembers the element that had focus (to restore on close),
+//   2. moves focus into the container — an explicit `initialFocusRef` if given,
+//      else the first focusable descendant, else the container itself,
+//   3. traps Tab / Shift+Tab so focus wraps at the edges and can't escape to
+//      the page behind the modal (WCAG 2.4.3 / 2.1.2), and
+//   4. on deactivate/unmount, returns focus to where it was before the modal
+//      opened.
+//
+// The Tab listener is bound to the container (not `document`) so nested/stacked
+// modals don't fight: an inner dialog's Tab bubbles to its own container first,
+// and the outer container's handler is a no-op while focus sits inside the
+// inner one. Modal owns the Esc stack separately (see ui/Modal.jsx); this hook
+// only concerns focus.
+
+// Visibility is intentionally NOT filtered by layout geometry
+// (offsetWidth/offsetParent) — those are always zero under jsdom, which would
+// make the trap untestable. The selector already drops disabled controls,
+// hidden inputs, and tabindex="-1"; that is sufficient for the modal surfaces
+// this hook guards.
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled]):not([type="hidden"])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function getFocusable(container) {
+  if (!container) return [];
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR));
+}
+
+export default function useFocusTrap(active, containerRef, { initialFocusRef } = {}) {
+  useEffect(() => {
+    if (!active) return;
+    const container = containerRef.current;
+    if (!container) return;
+
+    const previouslyFocused = document.activeElement;
+
+    const focusInitial = () => {
+      const target = initialFocusRef?.current || getFocusable(container)[0];
+      if (target) {
+        target.focus();
+      } else {
+        // Nothing focusable inside — make the container itself the focus target
+        // so the reader/keyboard lands in the dialog rather than on the page.
+        container.setAttribute('tabindex', '-1');
+        container.focus();
+      }
+    };
+    focusInitial();
+
+    const onKeyDown = (e) => {
+      if (e.key !== 'Tab') return;
+      const focusable = getFocusable(container);
+      if (focusable.length === 0) {
+        e.preventDefault();
+        container.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      const activeEl = document.activeElement;
+      if (e.shiftKey) {
+        if (activeEl === first || !container.contains(activeEl)) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else if (activeEl === last || !container.contains(activeEl)) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    container.addEventListener('keydown', onKeyDown);
+    return () => {
+      container.removeEventListener('keydown', onKeyDown);
+      // Restore focus to the pre-open element so keyboard users return to where
+      // they were. Guard: it may have been removed from the DOM while open.
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus();
+      }
+    };
+  }, [active, containerRef]);
+}

--- a/client/src/hooks/useFocusTrap.test.jsx
+++ b/client/src/hooks/useFocusTrap.test.jsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { useRef } from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+
+import useFocusTrap from './useFocusTrap.js';
+
+afterEach(cleanup);
+
+function Dialog({ active }) {
+  const ref = useRef(null);
+  useFocusTrap(active, ref);
+  return (
+    <div ref={ref} data-testid="dialog">
+      <button>first</button>
+      <button>middle</button>
+      <button>last</button>
+    </div>
+  );
+}
+
+function Harness({ active }) {
+  return (
+    <>
+      <button data-testid="opener">opener</button>
+      {active && <Dialog active={active} />}
+    </>
+  );
+}
+
+describe('useFocusTrap', () => {
+  it('moves focus to the first focusable element on activation', () => {
+    render(<Dialog active />);
+    expect(document.activeElement).toBe(screen.getByText('first'));
+  });
+
+  it('wraps focus from the last element to the first on Tab', () => {
+    render(<Dialog active />);
+    const last = screen.getByText('last');
+    last.focus();
+    fireEvent.keyDown(screen.getByTestId('dialog'), { key: 'Tab' });
+    expect(document.activeElement).toBe(screen.getByText('first'));
+  });
+
+  it('wraps focus from the first element to the last on Shift+Tab', () => {
+    render(<Dialog active />);
+    const first = screen.getByText('first');
+    first.focus();
+    fireEvent.keyDown(screen.getByTestId('dialog'), { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(screen.getByText('last'));
+  });
+
+  it('restores focus to the previously-focused element on deactivation', () => {
+    const opener = document.createElement('button');
+    document.body.appendChild(opener);
+    opener.focus();
+    expect(document.activeElement).toBe(opener);
+
+    const { rerender } = render(<Harness active />);
+    // Focus moved into the dialog.
+    expect(document.activeElement).toBe(screen.getByText('first'));
+
+    rerender(<Harness active={false} />);
+    // Focus returns to the opener.
+    expect(document.activeElement).toBe(opener);
+    opener.remove();
+  });
+
+  it('focuses the container itself when there is nothing focusable inside', () => {
+    function Empty() {
+      const ref = useRef(null);
+      useFocusTrap(true, ref);
+      return <div ref={ref} data-testid="empty">no controls</div>;
+    }
+    render(<Empty />);
+    const container = screen.getByTestId('empty');
+    expect(container).toHaveAttribute('tabindex', '-1');
+    expect(document.activeElement).toBe(container);
+  });
+});

--- a/client/src/hooks/useFocusTrap.test.jsx
+++ b/client/src/hooks/useFocusTrap.test.jsx
@@ -65,6 +65,54 @@ describe('useFocusTrap', () => {
     opener.remove();
   });
 
+  it('respects a child autoFocus instead of moving to the first focusable', () => {
+    function AutoFocusDialog({ active }) {
+      const ref = useRef(null);
+      useFocusTrap(active, ref);
+      return (
+        <div ref={ref} data-testid="dialog">
+          <button>close</button>
+          <input data-testid="field" autoFocus />
+        </div>
+      );
+    }
+    render(<AutoFocusDialog active />);
+    // React applies the input's autoFocus during commit; the trap must not
+    // yank focus to the leading close button.
+    expect(document.activeElement).toBe(screen.getByTestId('field'));
+  });
+
+  it('restores focus to the opener even when a child auto-focuses', () => {
+    function AutoFocusDialog() {
+      const ref = useRef(null);
+      useFocusTrap(true, ref);
+      return (
+        <div ref={ref}>
+          <input data-testid="field" autoFocus />
+        </div>
+      );
+    }
+    function AutoHarness({ active }) {
+      return (
+        <>
+          <button data-testid="opener">opener</button>
+          {active && <AutoFocusDialog />}
+        </>
+      );
+    }
+    const { rerender } = render(<AutoHarness active={false} />);
+    screen.getByTestId('opener').focus();
+    expect(document.activeElement).toBe(screen.getByTestId('opener'));
+
+    rerender(<AutoHarness active />);
+    expect(document.activeElement).toBe(screen.getByTestId('field'));
+
+    rerender(<AutoHarness active={false} />);
+    // The pre-open element was captured at render time (before the child's
+    // autoFocus fired), so focus returns to the opener, not the input.
+    expect(document.activeElement).toBe(screen.getByTestId('opener'));
+  });
+
   it('focuses the container itself when there is nothing focusable inside', () => {
     function Empty() {
       const ref = useRef(null);


### PR DESCRIPTION
## Summary

Accessibility audit of PortOS focused on the highest-leverage shared UI surfaces.

- **Keyboard focus management for modals & drawers.** The shared `Modal` and `Drawer` (which back the great majority of the app's dialogs, config drawers, and lightboxes) had correct ARIA roles and Esc handling but no focus management. Added a reusable `useFocusTrap` hook and wired it into both: on open it moves focus into the dialog, keeps Tab/Shift+Tab cycling inside it instead of leaking to the page behind, and restores focus to the control that opened it on close (WCAG 2.4.3 / 2.1.2). The restore target is captured at render time (before commit) so modals whose content uses `autoFocus` (e.g. `ResumeAgentModal`, `MemoryEditModal`) both keep their intended initial focus and restore correctly.
- **Screen-reader announcements for toasts.** The toast stack had no ARIA live region, so screen readers never announced notifications — including error toasts. It's now a labelled notification region; each toast is its own live region (`role="status"`/polite, or `role="alert"`/assertive for errors), with the decorative status glyphs hidden from assistive tech.

The audit also confirmed the codebase is already clean on image `alt` text and on icon-only-button accessible names in the sidebar/nav.

## Test plan

- New `useFocusTrap.test.jsx` — initial focus, Tab/Shift+Tab wrap, focus restoration, empty-container fallback, child-`autoFocus` respect, and render-time restore capture.
- New `Toast.test.jsx` — notification region, polite/assertive live-region roles, decorative-glyph hiding.
- Existing `Modal.test.jsx` / `Drawer.test.jsx` pass unchanged (no regression from focus moving on open).
- Full client suite: `cd client && npm test` — 317 files / 3510 tests pass.
