### PR TITLE
Per-project provider/model overrides for Creative Director stages

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -4,6 +4,8 @@
 
 - **Creative Director LLM stages are now independently configurable.** AI Assignments has separate provider/model rows for treatment generation, production planning, and scene evaluation. Point **Scene evaluation vision model** at a local Ollama or LM Studio vision model to judge rendered scenes without using the system-default agent; treatment and planning can likewise be pinned to any agent-capable CLI/TUI provider.
 
+- **Creative Director provider/model can now be overridden per project.** Each Creative Director project has a **Models** button (header of the project page, deep-linkable via `?models=1`) that opens a drawer to pin the treatment, production-plan, and scene-evaluation stages to a specific provider + model *for that project* — overriding the global AI Assignment. A stage left on **Inherit global** falls back to the global assignment (and then the system default), so the override is purely additive. The pin travels with the project record and federates to sync peers verbatim.
+
 - **[issue-2336] xAI Grok is now a built-in AI provider — API, Grok Build CLI, and Grok Build TUI.** Three new providers ship ready to enable under AI Providers: **xAI Grok** (the OpenAI-compatible chat API at `https://api.x.ai/v1` — paste your xAI key and pick a model), **Grok Build CLI** (headless, for one-shot generations and file-writing CoS agents), and **Grok Build TUI** (the interactive `grok` coding agent driven over a PTY like Claude Code / Codex). All three arrive disabled by default (nothing calls Grok until you turn one on) and reach existing installs on upgrade. The CLI/TUI use the local `grok` binary; run `grok login` (or set your xAI credentials) to authenticate it.
 
 ## Layered Intelligence

--- a/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
+++ b/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
@@ -1,0 +1,210 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Bot, Save } from 'lucide-react';
+import Drawer from '../Drawer.jsx';
+import toast from '../ui/Toast';
+import { getAiAssignments } from '../../services/api';
+import { updateCreativeDirectorProject } from '../../services/apiCreativeDirector.js';
+import { providerDisplayName, assignmentProviderOptions, assignmentModelOptions } from '../../utils/providers.js';
+
+// Per-project AI model override drawer (per-project CD provider/model pins).
+// Lets the user pin the treatment / plan / evaluation stage to a specific
+// provider + model ON THIS PROJECT, overriding the global AI Assignment. A
+// blank stage inherits the global pin (shown as the "Inherit" hint). The same
+// resolution the server does (`resolveStagePin`) is mirrored here only for the
+// inherit-hint label — the authoritative resolve happens server-side.
+
+// Each CD cognitive stage maps 1:1 to a global AI Assignment entry keyed
+// `settings.creativeDirector.<key>`, so the drawer reads that entry's
+// `providerTypes` (which providers are eligible: CLI/TUI for treatment+plan,
+// API for evaluation) and its current global provider/model (the inherit hint).
+const STAGES = [
+  { key: 'treatment', label: 'Treatment', help: 'Agent that turns the brief into a treatment + scene plan.' },
+  { key: 'plan', label: 'Production plan', help: 'Agent that converts a production directive into an executable plan.' },
+  { key: 'evaluation', label: 'Scene evaluation', help: 'Vision model that judges each rendered scene.' },
+];
+
+const assignmentIdFor = (key) => `settings.creativeDirector.${key}`;
+
+// The inherit-hint text: what this stage resolves to when left blank.
+const inheritLabel = (entry, providers) => {
+  if (!entry?.providerId) return 'system default';
+  const name = providerDisplayName(providers, entry.providerId);
+  return entry.model ? `${name} · ${entry.model}` : name;
+};
+
+const draftsFromProject = (project) => {
+  const overrides = project?.modelOverrides || {};
+  return Object.fromEntries(STAGES.map(({ key }) => {
+    const o = overrides[key] || {};
+    return [key, { providerId: o.providerId || '', model: o.model || '' }];
+  }));
+};
+
+export default function CreativeDirectorModelsDrawer({ open, onClose, project, onSaved }) {
+  const [loading, setLoading] = useState(true);
+  const [providers, setProviders] = useState([]);
+  const [assignments, setAssignments] = useState([]);
+  const [drafts, setDrafts] = useState(() => draftsFromProject(project));
+  const [saving, setSaving] = useState(false);
+
+  // Re-seed drafts from the persisted project only on the open transition or a
+  // project swap — NOT on `project` object identity, which the parent's 5s poll
+  // mints fresh every tick and would otherwise wipe in-progress edits.
+  useEffect(() => {
+    if (open) setDrafts(draftsFromProject(project));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, project?.id]);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    const next = await getAiAssignments({ silent: true }).catch((err) => {
+      toast.error(`Failed to load providers: ${err.message}`);
+      return null;
+    });
+    if (next) {
+      setProviders(next.providers || []);
+      setAssignments(next.assignments || []);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { if (open) load(); }, [open, load]);
+
+  const entryById = useMemo(
+    () => Object.fromEntries((assignments || []).map((e) => [e.id, e])),
+    [assignments],
+  );
+
+  // draftsFromProject normalizes every stage to a stable key order, so a plain
+  // JSON compare against the persisted project is a sound dirty check.
+  const dirty = useMemo(
+    () => JSON.stringify(drafts) !== JSON.stringify(draftsFromProject(project)),
+    [drafts, project],
+  );
+
+  const setStage = (key, patch) =>
+    setDrafts((prev) => ({ ...prev, [key]: { ...prev[key], ...patch } }));
+
+  const handleSave = async () => {
+    setSaving(true);
+    // Only send stages that name a provider; a blank provider means "inherit".
+    const modelOverrides = {};
+    for (const { key } of STAGES) {
+      const d = drafts[key];
+      if (d?.providerId) modelOverrides[key] = { providerId: d.providerId, ...(d.model ? { model: d.model } : {}) };
+    }
+    const updated = await updateCreativeDirectorProject(project.id, { modelOverrides }, { silent: true })
+      .catch((err) => {
+        toast.error(err.message || 'Failed to save model overrides');
+        return null;
+      });
+    setSaving(false);
+    if (!updated) return;
+    onSaved?.(updated.modelOverrides || {});
+    toast.success('Project model overrides saved');
+    onClose?.();
+  };
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      title="AI models for this project"
+      subtitle={project?.name}
+      size="md"
+    >
+      {loading ? (
+        <div className="text-sm text-gray-400">Loading providers…</div>
+      ) : (
+        <div className="space-y-5">
+          <p className="text-xs text-gray-400">
+            Pin the provider + model for each Creative Director stage on this project. Leave a
+            stage on <span className="text-gray-300">Inherit</span> to use the global{' '}
+            <Link to="/settings/ai-assignments" className="text-port-accent hover:underline">AI Assignment</Link>.
+          </p>
+
+          {STAGES.map((stage) => {
+            const entry = entryById[assignmentIdFor(stage.key)];
+            const draft = drafts[stage.key] || { providerId: '', model: '' };
+            const providerOptions = assignmentProviderOptions(entry, providers);
+            const modelOptions = assignmentModelOptions(entry, providers, draft.providerId);
+            const overriding = !!draft.providerId;
+            return (
+              <section key={stage.key} className="bg-port-bg border border-port-border rounded-lg p-3 space-y-2">
+                <div className="flex items-center gap-2">
+                  <Bot size={15} className="text-port-accent shrink-0" />
+                  <h3 className="text-sm font-medium text-white">{stage.label}</h3>
+                  {!overriding && (
+                    <span className="ml-auto text-[11px] px-1.5 py-0.5 rounded bg-port-card border border-port-border text-gray-400">
+                      Inherit: {inheritLabel(entry, providers)}
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs text-gray-500">{stage.help}</p>
+
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <label className="flex flex-col gap-1">
+                    <span className="text-[11px] uppercase tracking-wide text-gray-500">Provider</span>
+                    <select
+                      value={draft.providerId}
+                      aria-label={`${stage.label} provider`}
+                      onChange={(e) => {
+                        const providerId = e.target.value;
+                        const nextDefault = providers.find((p) => p.id === providerId)?.defaultModel || '';
+                        // Seed the provider's default model on switch; clearing the
+                        // provider (Inherit) clears the model too.
+                        setStage(stage.key, { providerId, model: providerId ? nextDefault : '' });
+                      }}
+                      className="bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white"
+                    >
+                      <option value="">Inherit global</option>
+                      {providerOptions.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
+                    </select>
+                  </label>
+
+                  <label className="flex flex-col gap-1">
+                    <span className="text-[11px] uppercase tracking-wide text-gray-500">Model</span>
+                    {!overriding ? (
+                      <div className="text-sm text-gray-600 py-2">—</div>
+                    ) : modelOptions.length > 0 ? (
+                      <select
+                        value={draft.model}
+                        aria-label={`${stage.label} model`}
+                        onChange={(e) => setStage(stage.key, { model: e.target.value })}
+                        className="bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white"
+                      >
+                        <option value="">Provider default / auto</option>
+                        {modelOptions.map((m) => <option key={m} value={m}>{m}</option>)}
+                      </select>
+                    ) : (
+                      <input
+                        value={draft.model}
+                        aria-label={`${stage.label} model`}
+                        onChange={(e) => setStage(stage.key, { model: e.target.value })}
+                        placeholder="Provider default / auto"
+                        className="bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white placeholder-gray-600"
+                      />
+                    )}
+                  </label>
+                </div>
+              </section>
+            );
+          })}
+
+          <div className="flex justify-end pt-1">
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={!dirty || saving}
+              className="inline-flex items-center gap-1.5 px-3 py-2 bg-port-accent hover:bg-port-accent/80 disabled:opacity-50 text-white rounded text-sm"
+            >
+              <Save size={14} />
+              {saving ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </div>
+      )}
+    </Drawer>
+  );
+}

--- a/client/src/components/creative-director/CreativeDirectorModelsDrawer.test.jsx
+++ b/client/src/components/creative-director/CreativeDirectorModelsDrawer.test.jsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../../services/api', () => ({ getAiAssignments: vi.fn() }));
+vi.mock('../../services/apiCreativeDirector.js', () => ({ updateCreativeDirectorProject: vi.fn() }));
+vi.mock('../ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+import CreativeDirectorModelsDrawer from './CreativeDirectorModelsDrawer.jsx';
+import { getAiAssignments } from '../../services/api';
+import { updateCreativeDirectorProject } from '../../services/apiCreativeDirector.js';
+
+const ASSIGNMENTS = {
+  providers: [
+    { id: 'agent-a', name: 'Agent A', type: 'cli', enabled: true, defaultModel: 'a-default', models: ['a-default', 'a-big'] },
+    { id: 'vlm-x', name: 'VLM X', type: 'api', enabled: true, defaultModel: 'llava', models: ['llava', 'moondream'] },
+  ],
+  assignments: [
+    { id: 'settings.creativeDirector.treatment', providerTypes: ['cli', 'tui'], providerId: '', model: '' },
+    { id: 'settings.creativeDirector.plan', providerTypes: ['cli', 'tui'], providerId: '', model: '' },
+    { id: 'settings.creativeDirector.evaluation', providerTypes: ['api'], providerId: '', model: '' },
+  ],
+};
+
+const renderDrawer = (project, props = {}) => render(
+  <MemoryRouter>
+    <CreativeDirectorModelsDrawer open onClose={vi.fn()} project={project} {...props} />
+  </MemoryRouter>,
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAiAssignments.mockResolvedValue(ASSIGNMENTS);
+});
+
+describe('CreativeDirectorModelsDrawer', () => {
+  it('seeds the model select from an existing project override', async () => {
+    renderDrawer({ id: 'cd-1', name: 'Demo', modelOverrides: { treatment: { providerId: 'agent-a', model: 'a-big' } } });
+    await waitFor(() => expect(screen.getByLabelText('Treatment provider')).toBeTruthy());
+    expect(screen.getByLabelText('Treatment provider').value).toBe('agent-a');
+    expect(screen.getByLabelText('Treatment model').value).toBe('a-big');
+  });
+
+  it('saves only stages that name a provider, omitting inherited ones', async () => {
+    updateCreativeDirectorProject.mockResolvedValue({ modelOverrides: { evaluation: { providerId: 'vlm-x', model: 'moondream' } } });
+    const onSaved = vi.fn();
+    renderDrawer({ id: 'cd-1', name: 'Demo', modelOverrides: {} }, { onSaved });
+
+    await waitFor(() => expect(screen.getByLabelText('Scene evaluation provider')).toBeTruthy());
+    // Pick a provider for evaluation only; treatment/plan stay on "Inherit global".
+    fireEvent.change(screen.getByLabelText('Scene evaluation provider'), { target: { value: 'vlm-x' } });
+    // Provider switch seeds the default model; override it explicitly.
+    fireEvent.change(screen.getByLabelText('Scene evaluation model'), { target: { value: 'moondream' } });
+    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+
+    await waitFor(() => expect(updateCreativeDirectorProject).toHaveBeenCalled());
+    const [id, patch] = updateCreativeDirectorProject.mock.calls[0];
+    expect(id).toBe('cd-1');
+    expect(patch).toEqual({ modelOverrides: { evaluation: { providerId: 'vlm-x', model: 'moondream' } } });
+    await waitFor(() => expect(onSaved).toHaveBeenCalledWith({ evaluation: { providerId: 'vlm-x', model: 'moondream' } }));
+  });
+
+  it('disables Save until a stage is edited', async () => {
+    renderDrawer({ id: 'cd-1', name: 'Demo', modelOverrides: {} });
+    await waitFor(() => expect(screen.getByRole('button', { name: /Save/i })).toBeTruthy());
+    expect(screen.getByRole('button', { name: /Save/i }).disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText('Treatment provider'), { target: { value: 'agent-a' } });
+    expect(screen.getByRole('button', { name: /Save/i }).disabled).toBe(false);
+  });
+});

--- a/client/src/components/settings/AiAssignmentsTab.jsx
+++ b/client/src/components/settings/AiAssignmentsTab.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { ArrowRight, Bot, RefreshCw, Save, Search } from 'lucide-react';
 import toast from '../ui/Toast';
 import { getAiAssignments, updateAiAssignment } from '../../services/api';
+import { providerDisplayName, assignmentProviderOptions, assignmentModelOptions } from '../../utils/providers.js';
 
 const getDraft = (entry) => ({
   providerId: entry.providerId || '',
@@ -25,24 +26,8 @@ const reconcileDrafts = (prev, assignments, savedIds) => {
   return next;
 };
 
-const providerName = (providers, id) =>
-  providers.find((p) => p.id === id)?.name || id || 'Default';
-
-const modelOptionsFor = (entry, providers, draftProviderId) => {
-  if (Array.isArray(entry.modelOptions)) return entry.modelOptions;
-  const provider = providers.find((p) => p.id === draftProviderId);
-  return provider?.models || [];
-};
-
-const providerOptionsFor = (entry, providers) => {
-  if (Array.isArray(entry.providerOptions)) return entry.providerOptions;
-  const types = Array.isArray(entry.providerTypes) && entry.providerTypes.length
-    ? new Set(entry.providerTypes)
-    : null;
-  return providers
-    .filter((p) => !types || types.has(p.type))
-    .map((p) => ({ id: p.id, name: `${p.name}${p.enabled ? '' : ' (disabled)'}` }));
-};
+// Provider label with the settings-table's "Default" fallback for an unset id.
+const providerName = (providers, id) => providerDisplayName(providers, id, 'Default');
 
 export default function AiAssignmentsTab() {
   const [loading, setLoading] = useState(true);
@@ -130,7 +115,7 @@ export default function AiAssignmentsTab() {
       entry.editable !== false &&
       entry.providerEditable !== false &&
       (drafts[entry.id]?.providerId || entry.providerId || '') === fromProvider &&
-      providerOptionsFor(entry, data.providers).some((option) => option.id === toProvider)
+      assignmentProviderOptions(entry, data.providers).some((option) => option.id === toProvider)
     ));
     if (targets.length === 0) {
       toast.error('No editable assignments match that provider');
@@ -260,8 +245,8 @@ export default function AiAssignmentsTab() {
           <tbody className="divide-y divide-port-border bg-port-bg">
             {filtered.map((entry) => {
               const draft = drafts[entry.id] || getDraft(entry);
-              const providerOptions = providerOptionsFor(entry, data.providers);
-              const modelOptions = modelOptionsFor(entry, data.providers, draft.providerId);
+              const providerOptions = assignmentProviderOptions(entry, data.providers);
+              const modelOptions = assignmentModelOptions(entry, data.providers, draft.providerId);
               const dirty = !sameDraft(entry, draft);
               return (
                 <tr key={entry.id} className="align-top">

--- a/client/src/pages/CreativeDirectorDetail.jsx
+++ b/client/src/pages/CreativeDirectorDetail.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
-import { ArrowLeft, Play, Pause, RefreshCw } from 'lucide-react';
+import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom';
+import { ArrowLeft, Play, Pause, RefreshCw, SlidersHorizontal } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import {
   getCreativeDirectorProject,
@@ -14,6 +14,7 @@ import SegmentsTab from '../components/creative-director/SegmentsTab.jsx';
 import PlanTab from '../components/creative-director/PlanTab.jsx';
 import RunsTab from '../components/creative-director/RunsTab.jsx';
 import ActiveAgentsBanner from '../components/creative-director/ActiveAgentsBanner.jsx';
+import CreativeDirectorModelsDrawer from '../components/creative-director/CreativeDirectorModelsDrawer.jsx';
 import { getCosAgents } from '../services/apiAgents.js';
 import { useAutoRefetch } from '../hooks/useAutoRefetch';
 import { useValidTab } from '../hooks/useValidTab';
@@ -32,7 +33,19 @@ const TABS = [
 export default function CreativeDirectorDetail() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
   const activeTab = useValidTab(TABS, 'overview');
+  // Deep-linkable open state for the per-project AI models drawer (URL is the
+  // source of truth for what's open, per the project convention).
+  const modelsOpen = searchParams.get('models') === '1';
+  const setModelsOpen = useCallback((next) => {
+    setSearchParams((prev) => {
+      const params = new URLSearchParams(prev);
+      if (next) params.set('models', '1');
+      else params.delete('models');
+      return params;
+    }, { replace: !next });
+  }, [setSearchParams]);
   const [project, setProject] = useState(null);
   const [loading, setLoading] = useState(true);
   const [activeAgents, setActiveAgents] = useState([]);
@@ -181,6 +194,9 @@ export default function CreativeDirectorDetail() {
             <button onClick={fetchProject} className="flex items-center gap-1 px-2 py-1 bg-port-card border border-port-border rounded text-xs">
               <RefreshCw className="w-3 h-3" /> Refresh
             </button>
+            <button onClick={() => setModelsOpen(true)} title="AI provider + model for this project's treatment, plan, and scene evaluation" className="flex items-center gap-1 px-2 py-1 bg-port-card border border-port-border rounded text-xs">
+              <SlidersHorizontal className="w-3 h-3" /> Models
+            </button>
             {(project.status === 'draft' || project.status === 'failed') && (
               <button onClick={() => handleAction('start')} className="flex items-center gap-1 px-2 py-1 bg-port-accent/30 text-port-accent rounded text-xs">
                 <Play className="w-3 h-3" /> Start
@@ -230,6 +246,13 @@ export default function CreativeDirectorDetail() {
         {activeTab === 'segments' && <SegmentsTab project={project} activeAgents={activeAgents} />}
         {activeTab === 'runs' && <RunsTab project={project} />}
       </div>
+
+      <CreativeDirectorModelsDrawer
+        open={modelsOpen}
+        onClose={() => setModelsOpen(false)}
+        project={project}
+        onSaved={(modelOverrides) => setProject((p) => (p ? { ...p, modelOverrides } : p))}
+      />
     </div>
   );
 }

--- a/client/src/services/apiCreativeDirector.js
+++ b/client/src/services/apiCreativeDirector.js
@@ -11,9 +11,10 @@ export const createCreativeDirectorProject = (data) => request('/creative-direct
   method: 'POST',
   body: JSON.stringify(data),
 });
-export const updateCreativeDirectorProject = (id, patch) => request(`/creative-director/${encodeURIComponent(id)}`, {
+export const updateCreativeDirectorProject = (id, patch, options = {}) => request(`/creative-director/${encodeURIComponent(id)}`, {
   method: 'PATCH',
   body: JSON.stringify(patch),
+  ...options,
 });
 export const deleteCreativeDirectorProject = (id) => request(`/creative-director/${encodeURIComponent(id)}`, {
   method: 'DELETE',

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -322,3 +322,42 @@ export const providerTypeClass = (type) => {
   if (type === PROVIDER_TYPES.TUI) return 'bg-emerald-500/20 text-emerald-400';
   return 'bg-purple-500/20 text-purple-400';
 };
+
+// ---------------------------------------------------------------------------
+// AI Assignments option helpers — shared by the global AI Assignments table
+// (settings/AiAssignmentsTab.jsx) and per-record override drawers (e.g. the
+// Creative Director Models drawer). All three consume the `getAiAssignments`
+// payload shape (`{ providers, assignments }`), where an assignment `entry` may
+// carry `providerTypes` (which provider kinds are eligible) and optional
+// pre-baked `providerOptions` / `modelOptions` overrides for runtime call sites.
+// ---------------------------------------------------------------------------
+
+/** Display name for a provider id, falling back to the id then `fallback`. */
+export const providerDisplayName = (providers, id, fallback = '') =>
+  providers.find((p) => p.id === id)?.name || id || fallback;
+
+/**
+ * Provider `{ id, name }` options eligible for an assignment entry — the entry's
+ * pre-baked `providerOptions` when present, else every provider whose `type` is
+ * in the entry's `providerTypes` (all providers when unfiltered), tagged with a
+ * "(disabled)" suffix on disabled providers.
+ */
+export const assignmentProviderOptions = (entry, providers) => {
+  if (Array.isArray(entry?.providerOptions)) return entry.providerOptions;
+  const types = Array.isArray(entry?.providerTypes) && entry.providerTypes.length
+    ? new Set(entry.providerTypes)
+    : null;
+  return providers
+    .filter((p) => !types || types.has(p.type))
+    .map((p) => ({ id: p.id, name: `${p.name}${p.enabled ? '' : ' (disabled)'}` }));
+};
+
+/**
+ * Model-id options for an assignment entry given the selected provider — the
+ * entry's pre-baked `modelOptions` when present, else the provider's own model
+ * list (empty when the provider is unknown or has none).
+ */
+export const assignmentModelOptions = (entry, providers, providerId) => {
+  if (Array.isArray(entry?.modelOptions)) return entry.modelOptions;
+  return providers.find((p) => p.id === providerId)?.models || [];
+};

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -2,6 +2,9 @@ import { describe, it, expect } from 'vitest';
 import {
   ANTIGRAVITY_CONFIGURED_DEFAULT,
   CODEX_CONFIGURED_DEFAULT,
+  providerDisplayName,
+  assignmentProviderOptions,
+  assignmentModelOptions,
   PROVIDER_TYPES,
   filterSelectableModels,
   filterGenerationModels,
@@ -398,5 +401,38 @@ describe('visionLocalModelFilter', () => {
 
   it('treats an unknown/undefined provider as non-local (no filtering)', () => {
     expect(visionLocalModelFilter('some-text-model', undefined)).toBe(true);
+  });
+});
+
+describe('AI Assignments option helpers', () => {
+  const providers = [
+    { id: 'agent-a', name: 'Agent A', type: 'cli', enabled: true, models: ['a-1', 'a-2'] },
+    { id: 'vlm-x', name: 'VLM X', type: 'api', enabled: false, models: ['llava'] },
+  ];
+
+  it('providerDisplayName resolves name, then id, then fallback', () => {
+    expect(providerDisplayName(providers, 'agent-a')).toBe('Agent A');
+    expect(providerDisplayName(providers, 'ghost')).toBe('ghost');
+    expect(providerDisplayName(providers, '', 'Default')).toBe('Default');
+    expect(providerDisplayName(providers, '')).toBe('');
+  });
+
+  it('assignmentProviderOptions filters by providerTypes and flags disabled', () => {
+    expect(assignmentProviderOptions({ providerTypes: ['api'] }, providers))
+      .toEqual([{ id: 'vlm-x', name: 'VLM X (disabled)' }]);
+    // No providerTypes → all providers.
+    expect(assignmentProviderOptions({}, providers).map((p) => p.id)).toEqual(['agent-a', 'vlm-x']);
+  });
+
+  it('assignmentProviderOptions honors a pre-baked providerOptions override', () => {
+    const baked = [{ id: 'x', name: 'X' }];
+    expect(assignmentProviderOptions({ providerOptions: baked }, providers)).toBe(baked);
+  });
+
+  it('assignmentModelOptions returns the selected provider models, else empty', () => {
+    expect(assignmentModelOptions({}, providers, 'agent-a')).toEqual(['a-1', 'a-2']);
+    expect(assignmentModelOptions({}, providers, 'ghost')).toEqual([]);
+    const baked = ['m'];
+    expect(assignmentModelOptions({ modelOptions: baked }, providers, 'agent-a')).toBe(baked);
   });
 });

--- a/server/lib/creativeDirectorValidation.js
+++ b/server/lib/creativeDirectorValidation.js
@@ -68,6 +68,28 @@ export const creativeDirectorDirectiveSchema = z.object({
   }).default({}),
 });
 
+// Per-project AI model override (issue: per-project CD provider/model pins).
+// Each Creative Director cognitive stage (treatment / plan / evaluation) can be
+// pinned to a specific provider + model ON THIS PROJECT, overriding the global
+// `settings.creativeDirector.<stage>` AI Assignment. A stage is only overridden
+// when it names a `providerId`; a blank/absent stage inherits the global pin
+// (which itself falls back to the system default). `model` is optional — blank
+// uses the provider's default/auto model. Kept permissive on the string values;
+// the runtime resolver (agentBridge / sceneEvaluator) validates the provider is
+// usable and of the right harness type before honoring it. Additive on the
+// project record (round-trips through the JSONB `data` column verbatim), so it
+// needs no schema-version bump for federation.
+export const creativeDirectorStagePinSchema = z.object({
+  providerId: z.string().max(120).nullable().optional(),
+  model: z.string().max(200).nullable().optional(),
+}).strict();
+
+export const creativeDirectorModelOverridesSchema = z.object({
+  treatment: creativeDirectorStagePinSchema.optional(),
+  plan: creativeDirectorStagePinSchema.optional(),
+  evaluation: creativeDirectorStagePinSchema.optional(),
+}).strict();
+
 export const creativeDirectorProjectCreateSchema = z.object({
   name: z.string().min(1).max(200),
   aspectRatio: creativeDirectorAspectRatioSchema,
@@ -99,6 +121,9 @@ export const creativeDirectorProjectCreateSchema = z.object({
   // the generalized advance loop executes through the gated creative tool
   // registry. Absent → the legacy video treatment/scene flow (unchanged).
   directive: creativeDirectorDirectiveSchema.nullable().optional(),
+  // Optional per-project provider/model pins for the treatment/plan/evaluation
+  // stages. Absent → every stage inherits the global AI Assignment.
+  modelOverrides: creativeDirectorModelOverridesSchema.optional(),
 });
 
 // Autonomous auto-cast (#1810). `types` narrows the catalog search to a set of
@@ -155,6 +180,10 @@ export const creativeDirectorProjectUpdateSchema = z.object({
   failureReason: z.string().max(500).nullable().optional(),
   // Toggleable post-creation — only affects future scene renders.
   disableAudio: z.boolean().optional(),
+  // Per-project provider/model pins (editable from the CD project's Models
+  // drawer). A stage naming a providerId overrides the global AI Assignment;
+  // a blank stage inherits it. The whole object replaces the stored one.
+  modelOverrides: creativeDirectorModelOverridesSchema.optional(),
 }).strict();
 
 // One scene in the treatment, written by the agent on the treatment task.

--- a/server/services/aiAssignments.js
+++ b/server/services/aiAssignments.js
@@ -165,7 +165,7 @@ const addSettingsEntries = async (entries) => {
     providerId: settings.creativeDirector?.treatment?.providerId || null,
     model: settings.creativeDirector?.treatment?.model || null,
     providerTypes: cliProviderTypes,
-    notes: 'Agent model that turns a project brief into a treatment and scene plan. Blank = system default provider and model.',
+    notes: 'Agent model that turns a project brief into a treatment and scene plan. Blank = system default provider and model. Each Creative Director project can override this from its Models drawer.',
     link: '/creative-director',
   }));
 
@@ -177,7 +177,7 @@ const addSettingsEntries = async (entries) => {
     providerId: settings.creativeDirector?.plan?.providerId || null,
     model: settings.creativeDirector?.plan?.model || null,
     providerTypes: cliProviderTypes,
-    notes: 'Agent model that converts a production directive into an executable plan. Blank = system default provider and model.',
+    notes: 'Agent model that converts a production directive into an executable plan. Blank = system default provider and model. Each Creative Director project can override this from its Models drawer.',
     link: '/creative-director',
   }));
 
@@ -189,7 +189,7 @@ const addSettingsEntries = async (entries) => {
     providerId: settings.creativeDirector?.evaluation?.providerId || null,
     model: settings.creativeDirector?.evaluation?.model || null,
     providerTypes: apiProviderTypes,
-    notes: 'Vision model that judges each rendered scene. Use a local Ollama or LM Studio VLM here. Blank = auto-pick an installed local vision model; if none is available it falls back to the coding agent.',
+    notes: 'Vision model that judges each rendered scene. Use a local Ollama or LM Studio VLM here. Blank = auto-pick an installed local vision model; if none is available it falls back to the coding agent. Each Creative Director project can override this from its Models drawer.',
     link: '/creative-director',
   }));
 

--- a/server/services/creativeDirector/agentBridge.js
+++ b/server/services/creativeDirector/agentBridge.js
@@ -19,13 +19,16 @@ import { addTask, cosEvents } from '../cos.js';
 import { buildTreatmentPrompt, buildEvaluatePrompt, buildPlanPrompt } from '../../lib/creativeDirectorPrompts.js';
 import { getToolSpecs } from '../creative/toolRegistry.js';
 import { getSettings } from '../settings.js';
+import { resolveStagePin } from './projectsLogic.js';
 import { recordRun } from './local.js';
 
 // Treatment and production planning are CoS tasks, so unlike scene evaluation
-// they need a CLI/TUI provider with an agent harness. The assignment UI limits
-// choices accordingly; this helper only adds a pin when one was explicitly
-// saved, preserving the system-default behavior for existing installations.
-async function getStageAssignment(kind) {
+// they need a CLI/TUI provider with an agent harness. Resolution prefers the
+// project's own `modelOverrides.<kind>` pin (per-project CD provider/model
+// pins) and falls back to the global `settings.creativeDirector.<kind>` AI
+// Assignment — only adding a pin when one is set, preserving the system-default
+// behavior for existing installations.
+async function getStageAssignment(kind, project) {
   // Scene evaluation is a direct vision API call (apiProviderTypes) resolved
   // separately, NOT a CoS agent pin — injecting its api-type provider into the
   // agent task metadata would trip the harness-boundary guard. Never pin it
@@ -34,8 +37,8 @@ async function getStageAssignment(kind) {
   // `creativeDirector.evaluation`.)
   if (kind === 'evaluate') return {};
   const settings = await getSettings().catch(() => ({}));
-  const assignment = settings?.creativeDirector?.[kind];
-  if (!assignment?.providerId && !assignment?.model) return {};
+  const assignment = resolveStagePin(kind, project, settings);
+  if (!assignment.providerId && !assignment.model) return {};
   return {
     ...(assignment.providerId ? { provider: assignment.providerId, providerId: assignment.providerId } : {}),
     ...(assignment.model ? { model: assignment.model } : {}),
@@ -45,7 +48,7 @@ async function getStageAssignment(kind) {
 async function buildTaskRecord(project, kind, scene, context) {
   const taskId = `cd-${project.id}-${kind}-${Date.now().toString(36)}`;
   const runId = randomUUID();
-  const assignment = await getStageAssignment(kind);
+  const assignment = await getStageAssignment(kind, project);
   return {
     id: taskId,
     runId,

--- a/server/services/creativeDirector/agentBridge.test.js
+++ b/server/services/creativeDirector/agentBridge.test.js
@@ -62,4 +62,38 @@ describe('Creative Director agent bridge model assignments', () => {
     expect(task.metadata).not.toHaveProperty('provider');
     expect(task.metadata).not.toHaveProperty('model');
   });
+
+  it('prefers the project-level override over the global assignment', async () => {
+    mocks.getSettings.mockResolvedValue({
+      creativeDirector: { treatment: { providerId: 'global-agent', model: 'global-model' } },
+    });
+
+    await enqueueTreatmentTask({
+      ...project,
+      modelOverrides: { treatment: { providerId: 'project-agent', model: 'project-model' } },
+    });
+
+    const [task] = mocks.addTask.mock.calls[0];
+    expect(task.metadata).toMatchObject({
+      provider: 'project-agent',
+      providerId: 'project-agent',
+      model: 'project-model',
+    });
+  });
+
+  it('inherits the global assignment when the project override omits a provider', async () => {
+    mocks.getSettings.mockResolvedValue({
+      creativeDirector: { plan: { providerId: 'global-agent', model: 'global-model' } },
+    });
+
+    // A model-only override can't resolve (no provider) → inherit the global pin.
+    await enqueuePlanTask({ ...project, modelOverrides: { plan: { model: 'stray-model' } } });
+
+    const [task] = mocks.addTask.mock.calls[0];
+    expect(task.metadata).toMatchObject({
+      provider: 'global-agent',
+      providerId: 'global-agent',
+      model: 'global-model',
+    });
+  });
 });

--- a/server/services/creativeDirector/projectsLogic.js
+++ b/server/services/creativeDirector/projectsLogic.js
@@ -20,6 +20,49 @@ import { localImageFilename } from '../../lib/localImageFilename.js';
 
 const isStr = (v) => typeof v === 'string';
 
+// Per-project AI model override (per-project CD provider/model pins). Stored on
+// the project record as `modelOverrides.{treatment,plan,evaluation}` — each an
+// optional `{ providerId, model }`. Only stages that name a `providerId` are
+// kept, so the stored object never carries empty stubs (a blank stage means
+// "inherit the global AI Assignment"). Additive: the whole record round-trips
+// through the JSONB `data` column verbatim in sanitizeProjectForSync, so this
+// needs no schema-version bump.
+export const MODEL_OVERRIDE_STAGES = ['treatment', 'plan', 'evaluation'];
+
+export function normalizeModelOverrides(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+  const out = {};
+  for (const stage of MODEL_OVERRIDE_STAGES) {
+    const v = raw[stage];
+    if (!v || typeof v !== 'object' || Array.isArray(v)) continue;
+    const providerId = isStr(v.providerId) ? v.providerId.trim() : '';
+    const model = isStr(v.model) ? v.model.trim() : '';
+    // A model without a provider can't be resolved (the runtime keys on the
+    // provider first), so drop a model-only stage — it would inherit anyway.
+    if (providerId) out[stage] = { providerId, ...(model ? { model } : {}) };
+  }
+  return out;
+}
+
+/**
+ * Resolve the effective provider/model pin for one CD cognitive stage. The
+ * per-project override wins when it names a providerId; otherwise the global
+ * `settings.creativeDirector.<stage>` assignment applies (which itself may be
+ * empty → the caller falls back to the system default / auto-resolution).
+ * Returns `{ providerId, model }` with string values ('' when unset). Shared by
+ * agentBridge (treatment/plan CoS-task pins) and sceneEvaluator (evaluation
+ * vision-call pin) so the two resolution paths can never drift.
+ */
+export function resolveStagePin(stage, project, settings) {
+  const override = project?.modelOverrides?.[stage];
+  const global = settings?.creativeDirector?.[stage];
+  const chosen = override?.providerId ? override : global;
+  return {
+    providerId: isStr(chosen?.providerId) ? chosen.providerId : '',
+    model: isStr(chosen?.model) ? chosen.model : '',
+  };
+}
+
 // TIMESTAMPTZ bind-safety helper, shared with the media asset index (#1000) and
 // any other store that mirrors a hand-editable timestamp into a typed column.
 // Re-exported here so the historical `import { mirrorTimestamp } from
@@ -87,6 +130,7 @@ export function buildProjectRecord(input, { id, now, collectionId }) {
     styleSpec = '', startingImageFile = null, userStory = null,
     disableAudio = true, autoAcceptScenes = false, sourceIssueId = null,
     cast = [], generateFirstPass = false, directive = null,
+    modelOverrides = {},
   } = input;
   return {
     id,
@@ -141,6 +185,11 @@ export function buildProjectRecord(input, { id, now, collectionId }) {
     // the whole record round-trips through the JSONB column verbatim.
     directive: directive && typeof directive === 'object' ? directive : null,
     plan: null,
+    // Per-project provider/model pins for the treatment/plan/evaluation stages
+    // (per-project CD provider/model pins). `{}` = every stage inherits the
+    // global AI Assignment. Additive — round-trips through the JSONB column
+    // verbatim, so no schema-version bump is needed for federation.
+    modelOverrides: normalizeModelOverrides(modelOverrides),
     runs: [],
     // Soft-delete / LWW tombstone trio (#1564) — projects federate across peers
     // via the per-record push pipeline (record kind `creativeDirectorProject`,
@@ -208,7 +257,11 @@ export function applyProjectPatch(project, patch) {
   if (patch.status && !PROJECT_STATUSES.includes(patch.status)) {
     throw new ServerError(`Invalid status: ${patch.status}`, { status: 400, code: 'VALIDATION_ERROR' });
   }
-  return { ...project, ...patch, updatedAt: new Date().toISOString() };
+  const next = { ...project, ...patch, updatedAt: new Date().toISOString() };
+  // Normalize the whole override object on write so stored records never carry
+  // empty/model-only stage stubs; the client sends the full object each save.
+  if ('modelOverrides' in patch) next.modelOverrides = normalizeModelOverrides(patch.modelOverrides);
+  return next;
 }
 
 /**

--- a/server/services/creativeDirector/projectsLogic.test.js
+++ b/server/services/creativeDirector/projectsLogic.test.js
@@ -21,6 +21,8 @@ import {
   sanitizeProjectForSync,
   mergeProjectRecord,
   startingImageFilename,
+  normalizeModelOverrides,
+  resolveStagePin,
 } from './projectsLogic.js';
 
 const VALID_TREATMENT = {
@@ -28,6 +30,56 @@ const VALID_TREATMENT = {
   synopsis: 'Then puts it on.',
   scenes: [{ sceneId: 'scene-1', order: 0, intent: 'Cat enters', prompt: 'A cat walks in', durationSeconds: 4 }],
 };
+
+describe('modelOverrides (per-project provider/model pins)', () => {
+  const base = { name: 'X', aspectRatio: '1:1', quality: 'draft', modelId: 'm', targetDurationSeconds: 9 };
+
+  it('defaults to an empty object on a bare project', () => {
+    const p = buildProjectRecord(base, { id: 'cd-1', now: 'now', collectionId: 'c-1' });
+    expect(p.modelOverrides).toEqual({});
+  });
+
+  it('normalizes: keeps provider-bearing stages, drops empty + model-only ones', () => {
+    const p = buildProjectRecord(
+      {
+        ...base,
+        modelOverrides: {
+          treatment: { providerId: '  agent-a  ', model: '  qwen  ' },
+          plan: { model: 'no-provider' }, // dropped — a model alone can't resolve
+          evaluation: { providerId: '' },  // dropped — blank provider
+          bogus: { providerId: 'x' },       // dropped — not a known stage
+        },
+      },
+      { id: 'cd-1', now: 'now', collectionId: 'c-1' },
+    );
+    expect(p.modelOverrides).toEqual({ treatment: { providerId: 'agent-a', model: 'qwen' } });
+  });
+
+  it('normalizeModelOverrides tolerates non-objects', () => {
+    expect(normalizeModelOverrides(null)).toEqual({});
+    expect(normalizeModelOverrides('nope')).toEqual({});
+    expect(normalizeModelOverrides([1, 2])).toEqual({});
+    expect(normalizeModelOverrides({ treatment: { providerId: 'a' } })).toEqual({ treatment: { providerId: 'a' } });
+  });
+
+  it('applyProjectPatch re-normalizes an incoming override object', () => {
+    const next = applyProjectPatch({ id: 'cd-1', modelOverrides: {} }, {
+      modelOverrides: { plan: { providerId: 'a', model: '' }, evaluation: { model: 'orphan' } },
+    });
+    expect(next.modelOverrides).toEqual({ plan: { providerId: 'a' } });
+  });
+
+  it('resolveStagePin prefers the project override, else the global assignment', () => {
+    const settings = { creativeDirector: { treatment: { providerId: 'global', model: 'gm' } } };
+    // Override wins when it names a provider.
+    expect(resolveStagePin('treatment', { modelOverrides: { treatment: { providerId: 'proj', model: 'pm' } } }, settings))
+      .toEqual({ providerId: 'proj', model: 'pm' });
+    // No override → global.
+    expect(resolveStagePin('treatment', {}, settings)).toEqual({ providerId: 'global', model: 'gm' });
+    // Neither → empty strings.
+    expect(resolveStagePin('plan', {}, settings)).toEqual({ providerId: '', model: '' });
+  });
+});
 
 describe('buildProjectRecord', () => {
   it('produces a draft project with the supplied collection id and null pointers', () => {

--- a/server/services/creativeDirector/sceneEvaluator.js
+++ b/server/services/creativeDirector/sceneEvaluator.js
@@ -36,6 +36,7 @@ import { getProviderById } from '../providers.js';
 import { listVisionModels } from '../localLlm.js';
 import { addItem } from '../mediaCollections.js';
 import { updateScene, recordRun, updateRun } from './local.js';
+import { resolveStagePin } from './projectsLogic.js';
 import { enqueueEvaluateTask } from './agentBridge.js';
 
 // Cap frames per call — the runner base64-inlines every frame into one request
@@ -97,15 +98,18 @@ export function parseVisionVerdict(text) {
  * Resolve which API provider + model should run the vision evaluation.
  *
  * Order:
- *   1. Explicit assignment — `settings.creativeDirector.evaluation.providerId`
- *      (set via AI Assignments). Honored as long as it's an enabled API
- *      provider; the assigned `model` (if any) is used verbatim.
+ *   1. Explicit assignment — the project's own `modelOverrides.evaluation` pin
+ *      (per-project CD provider/model pins) when set, else the global
+ *      `settings.creativeDirector.evaluation` pin (set via AI Assignments).
+ *      Honored as long as it's an enabled API provider; the assigned `model`
+ *      (if any) is used verbatim.
  *   2. Auto — the first installed local (Ollama/LM Studio) vision-capable model.
  *
+ * @param {object} [project] the CD project, for its per-project override.
  * @returns {Promise<{ provider: object, model: string|undefined }|null>} null
  *   when nothing suitable is configured (caller falls back to the agent).
  */
-export async function resolveVisionEvalTarget() {
+export async function resolveVisionEvalTarget(project) {
   // An API provider is usable only if it exists and is enabled — vision runs
   // through the api-only chat path, so a CLI/TUI provider can't serve it.
   const usableApiProvider = async (id) => {
@@ -114,7 +118,7 @@ export async function resolveVisionEvalTarget() {
   };
 
   const settings = await getSettings().catch(() => ({}));
-  const assigned = settings?.creativeDirector?.evaluation || {};
+  const assigned = resolveStagePin('evaluation', project, settings);
 
   if (assigned.providerId) {
     const provider = await usableApiProvider(assigned.providerId);
@@ -168,7 +172,7 @@ function collectFramePaths(scene) {
  * >}
  */
 export async function evaluateSceneWithVision(project, scene) {
-  const target = await resolveVisionEvalTarget();
+  const target = await resolveVisionEvalTarget(project);
   if (!target) {
     return { ok: false, fallbackToAgent: true, reason: 'no vision-capable API provider configured' };
   }

--- a/server/services/creativeDirector/sceneEvaluator.test.js
+++ b/server/services/creativeDirector/sceneEvaluator.test.js
@@ -127,6 +127,14 @@ describe('resolveVisionEvalTarget', () => {
     expect(mocks.listVisionModels).not.toHaveBeenCalled();
   });
 
+  it('prefers the per-project override over the global evaluation assignment', async () => {
+    mocks.getSettings.mockResolvedValue({ creativeDirector: { evaluation: { providerId: 'global-vlm', model: 'gm' } } });
+    mocks.getProviderById.mockImplementation(async (id) => (id === 'proj-vlm' ? { id: 'proj-vlm', type: 'api', enabled: true } : null));
+    const target = await resolveVisionEvalTarget({ modelOverrides: { evaluation: { providerId: 'proj-vlm', model: 'moondream' } } });
+    expect(target).toEqual({ provider: { id: 'proj-vlm', type: 'api', enabled: true }, model: 'moondream' });
+    expect(mocks.listVisionModels).not.toHaveBeenCalled();
+  });
+
   it('falls through to auto when the pinned provider is not an API provider', async () => {
     mocks.getSettings.mockResolvedValue({ creativeDirector: { evaluation: { providerId: 'claude' } } });
     mocks.getProviderById.mockImplementation(async (id) => {


### PR DESCRIPTION
## Summary

Creative Director provider/model selection was global-only (Settings → AI Assignments). This adds a **per-project override**: each project can pin the **treatment**, **production-plan**, and **scene-evaluation** stages to a specific provider + model, overriding the global assignment. A stage left blank inherits the global pin (then the system default), so the feature is purely additive.

- **Server:** new `modelOverrides` field on the CD project record (`{treatment,plan,evaluation}: {providerId, model}`), validated in `creativeDirectorValidation.js`, normalized in `projectsLogic.js`. A shared `resolveStagePin()` (project override → global → default) is used by both the CoS-task path (`agentBridge.js`, treatment/plan) and the vision path (`sceneEvaluator.js`, evaluation) so they can't drift.
- **Client:** new deep-linkable **Models** drawer on the project page (`?models=1`) with a provider + model picker per stage and an "Inherit global" default. Duplicated provider/model option helpers were extracted into `utils/providers.js` and adopted by both the drawer and the existing `AiAssignmentsTab`.
- **Federation:** the field rides the project record verbatim through the JSONB column and syncs to peers — no schema-version bump or migration needed (additive).

## Test plan

- `server`: added override coverage in `agentBridge.test.js` (project override wins; model-only override inherits global), `projectsLogic.test.js` (`normalizeModelOverrides`/`resolveStagePin`/`applyProjectPatch`), `sceneEvaluator.test.js` (per-project eval pin wins). Full CD + routes + validation suites green (140 tests).
- `client`: new `CreativeDirectorModelsDrawer.test.jsx` (seed from override, save only provider-bearing stages, dirty gating) and `providers.test.js` helper coverage. `vite build` clean.
- Reviewed by codex + an in-process claude reviewer — both clean.