### PR TITLE
Day-of-week + time picker for CoS scheduled-task cron entry

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -18,6 +18,8 @@
 
 ## Changed
 
+- **CoS scheduled tasks get a day-of-week + time-of-day picker — no more typing crontab syntax for weekly schedules.** Every CoS cron surface (Schedule tab overrides and global config, the Workflow/Timeline schedule editor's pinned-time mode, CoS system jobs, and per-app custom tasks) now leads with a row of day pills (S M T W T F S) plus a time input: click the days it should run and set the time, and the cron expression is built for you (no days selected = every day). The raw crontab field and presets are still there behind an "Advanced" toggle for interval/stepped schedules the picker can't represent, and it round-trips — an existing `0 9 * * 1,3` lights up Mon/Wed at 09:00. Built on a shared `WeekdayTimePicker` component and `parseSimpleCron`/`buildWeeklyCron` helpers so all surfaces stay consistent.
+
 - **Creative Director is now a top-level page under Create, not a Media Gen tab.** It moved out of the Media Gen tab strip to its own `/creative-director` route with a Create sidebar link, so it's reachable directly (⌘K, voice nav, and the sidebar) without first opening Media Gen. Legacy `/media/creative-director` links and deep-links (including `:id/:tab`) redirect to the new route, preserving query string and hash.
 
 ## Added

--- a/client/src/components/CronInput.jsx
+++ b/client/src/components/CronInput.jsx
@@ -1,13 +1,22 @@
 import { useState } from 'react';
-import { CRON_PRESETS, describeCron } from '../utils/cronHelpers';
+import { CRON_PRESETS, DEFAULT_CRON, describeCron, parseSimpleCron } from '../utils/cronHelpers';
+import WeekdayTimePicker from './WeekdayTimePicker';
 
 /**
- * Inline cron expression editor with presets dropdown.
- * Shows a text input + presets select + human-readable description.
- * Calls onSave with the validated expression, onCancel to dismiss.
+ * Inline cron expression editor with a day-of-week + time-of-day picker.
+ *
+ * The picker is the easy path: toggle the days it should run and set the time,
+ * no crontab syntax required (no days selected = every day). A collapsible
+ * "advanced" row keeps the raw expression + presets for interval/stepped crons
+ * the picker can't represent. Calls onSave with the validated expression,
+ * onCancel to dismiss.
  */
 export default function CronInput({ value, onSave, onCancel, className = '' }) {
-  const [expr, setExpr] = useState(value || '0 7 * * *');
+  const [expr, setExpr] = useState(value || DEFAULT_CRON);
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
+  const parsed = parseSimpleCron(expr);
+  const isDaily = parsed && parsed.days.length === 0;
 
   const handleSave = () => {
     const trimmed = expr.trim();
@@ -16,45 +25,65 @@ export default function CronInput({ value, onSave, onCancel, className = '' }) {
   };
 
   return (
-    <div className={`flex flex-wrap items-center gap-1 ${className}`}>
-      <input
-        type="text"
-        value={expr}
-        onChange={e => setExpr(e.target.value)}
-        onKeyDown={e => {
-          if (e.key === 'Enter') handleSave();
-          if (e.key === 'Escape') onCancel?.();
-        }}
-        className="w-28 sm:w-32 px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white font-mono focus:border-port-accent focus:outline-hidden"
-        placeholder="0 7 * * *"
-        autoFocus
-      />
-      <select
-        value=""
-        onChange={e => { if (e.target.value) setExpr(e.target.value); }}
-        className="px-1 py-1 bg-port-bg border border-port-border rounded text-gray-400 text-xs"
-      >
-        <option value="">Presets</option>
-        {CRON_PRESETS.map(p => (
-          <option key={p.value} value={p.value}>{p.label}</option>
-        ))}
-      </select>
-      <button
-        onClick={handleSave}
-        className="px-1.5 py-1 bg-port-accent/20 text-port-accent rounded text-xs hover:bg-port-accent/30"
-      >
-        OK
-      </button>
-      {onCancel && (
+    <div className={`flex flex-col gap-2 ${className}`}>
+      <div className="flex flex-wrap items-center gap-1.5">
+        <WeekdayTimePicker value={expr} onChange={setExpr} />
         <button
-          onClick={onCancel}
-          className="px-1.5 py-1 text-gray-500 hover:text-gray-300 rounded text-xs"
+          type="button"
+          onClick={handleSave}
+          className="px-1.5 py-1 bg-port-accent/20 text-port-accent rounded text-xs hover:bg-port-accent/30"
         >
-          X
+          OK
         </button>
-      )}
-      {expr && (
-        <span className="text-xs text-gray-500 truncate hidden sm:inline">{describeCron(expr)}</span>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="px-1.5 py-1 text-gray-500 hover:text-gray-300 rounded text-xs"
+          >
+            X
+          </button>
+        )}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="text-xs text-gray-500">
+          {isDaily ? 'Every day ' : ''}{expr && describeCron(expr)}
+        </span>
+        <button
+          type="button"
+          onClick={() => setShowAdvanced(v => !v)}
+          className="text-xs text-gray-500 hover:text-gray-300 underline decoration-dotted"
+        >
+          {showAdvanced ? 'Hide advanced' : 'Advanced'}
+        </button>
+      </div>
+
+      {showAdvanced && (
+        <div className="flex flex-wrap items-center gap-1">
+          <input
+            type="text"
+            value={expr}
+            onChange={e => setExpr(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter') handleSave();
+              if (e.key === 'Escape') onCancel?.();
+            }}
+            className="w-28 sm:w-32 px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white font-mono focus:border-port-accent focus:outline-hidden"
+            placeholder="0 7 * * *"
+          />
+          <select
+            value=""
+            onChange={e => { if (e.target.value) setExpr(e.target.value); }}
+            className="px-1 py-1 bg-port-bg border border-port-border rounded text-gray-400 text-xs"
+            aria-label="Cron presets"
+          >
+            <option value="">Presets</option>
+            {CRON_PRESETS.map(p => (
+              <option key={p.value} value={p.value}>{p.label}</option>
+            ))}
+          </select>
+        </div>
       )}
     </div>
   );

--- a/client/src/components/WeekdayTimePicker.jsx
+++ b/client/src/components/WeekdayTimePicker.jsx
@@ -1,0 +1,63 @@
+import { WEEKDAYS, DEFAULT_TIME, parseSimpleCron, buildWeeklyCron } from '../utils/cronHelpers';
+
+/**
+ * Day-of-week + time-of-day picker that reads/writes a cron expression.
+ *
+ * Toggle the days it should run and set the time — no crontab syntax. No days
+ * selected means every day (a daily schedule). `value` is a cron string;
+ * `onChange` receives the rebuilt cron string. When `value` is an
+ * interval/stepped cron the picker can't represent, the pills show unselected
+ * and the first interaction converts it into a simple day+time cron.
+ */
+export default function WeekdayTimePicker({ value, onChange, className = '' }) {
+  const parsed = parseSimpleCron(value);
+  const days = parsed?.days ?? [];
+  const time = parsed?.time ?? '';
+
+  const apply = (nextDays, nextTime) => {
+    const built = buildWeeklyCron(nextDays, nextTime);
+    if (built) onChange(built);
+  };
+
+  const toggleDay = (day) => {
+    const nextDays = days.includes(day) ? days.filter(d => d !== day) : [...days, day];
+    apply(nextDays, time || DEFAULT_TIME);
+  };
+
+  const handleTimeChange = (nextTime) => apply(days, nextTime);
+
+  return (
+    <div className={`flex flex-wrap items-center gap-1.5 ${className}`}>
+      <div className="flex items-center gap-0.5" role="group" aria-label="Days of week">
+        {WEEKDAYS.map(wd => {
+          const active = !!parsed && days.includes(wd.value);
+          return (
+            <button
+              key={wd.value}
+              type="button"
+              onClick={() => toggleDay(wd.value)}
+              aria-pressed={active}
+              title={wd.label}
+              className={`w-6 h-6 rounded text-xs font-medium ${
+                active
+                  ? 'bg-port-accent text-white'
+                  : 'bg-port-bg border border-port-border text-gray-400 hover:border-port-accent'
+              }`}
+            >
+              {wd.short}
+            </button>
+          );
+        })}
+      </div>
+      <label className="flex items-center gap-1 text-xs text-gray-400">
+        <span className="sr-only">Time of day</span>
+        <input
+          type="time"
+          value={time}
+          onChange={e => handleTimeChange(e.target.value)}
+          className="px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white focus:border-port-accent focus:outline-hidden"
+        />
+      </label>
+    </div>
+  );
+}

--- a/client/src/components/WeekdayTimePicker.jsx
+++ b/client/src/components/WeekdayTimePicker.jsx
@@ -37,6 +37,7 @@ export default function WeekdayTimePicker({ value, onChange, className = '' }) {
               type="button"
               onClick={() => toggleDay(wd.value)}
               aria-pressed={active}
+              aria-label={wd.label}
               title={wd.label}
               className={`w-6 h-6 rounded text-xs font-medium ${
                 active

--- a/client/src/components/WeekdayTimePicker.test.jsx
+++ b/client/src/components/WeekdayTimePicker.test.jsx
@@ -34,6 +34,12 @@ describe('WeekdayTimePicker', () => {
   it('shows no days selected for an interval cron the picker cannot represent', () => {
     render(<WeekdayTimePicker value="*/15 * * * *" onChange={vi.fn()} />);
     expect(screen.getByTitle('Mon')).toHaveAttribute('aria-pressed', 'false');
-    // First interaction converts it into a simple day+time cron at the default time.
+  });
+
+  it('converts an unrepresentable interval cron into a day+time cron at the default time on first toggle', () => {
+    const onChange = vi.fn();
+    render(<WeekdayTimePicker value="*/15 * * * *" onChange={onChange} />);
+    fireEvent.click(screen.getByTitle('Mon'));
+    expect(onChange).toHaveBeenCalledWith('0 7 * * 1');
   });
 });

--- a/client/src/components/WeekdayTimePicker.test.jsx
+++ b/client/src/components/WeekdayTimePicker.test.jsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import WeekdayTimePicker from './WeekdayTimePicker';
+
+describe('WeekdayTimePicker', () => {
+  it('marks the days present in the cron as pressed', () => {
+    render(<WeekdayTimePicker value="0 9 * * 1,3" onChange={vi.fn()} />);
+    expect(screen.getByTitle('Mon')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTitle('Wed')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByTitle('Tue')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('adds a day to the cron when its pill is clicked', () => {
+    const onChange = vi.fn();
+    render(<WeekdayTimePicker value="0 9 * * 1" onChange={onChange} />);
+    fireEvent.click(screen.getByTitle('Fri'));
+    expect(onChange).toHaveBeenCalledWith('0 9 * * 1,5');
+  });
+
+  it('removes a day when an active pill is clicked', () => {
+    const onChange = vi.fn();
+    render(<WeekdayTimePicker value="0 9 * * 1,5" onChange={onChange} />);
+    fireEvent.click(screen.getByTitle('Mon'));
+    expect(onChange).toHaveBeenCalledWith('0 9 * * 5');
+  });
+
+  it('rebuilds the cron when the time changes', () => {
+    const onChange = vi.fn();
+    render(<WeekdayTimePicker value="0 9 * * 1" onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('Time of day'), { target: { value: '14:30' } });
+    expect(onChange).toHaveBeenCalledWith('30 14 * * 1');
+  });
+
+  it('shows no days selected for an interval cron the picker cannot represent', () => {
+    render(<WeekdayTimePicker value="*/15 * * * *" onChange={vi.fn()} />);
+    expect(screen.getByTitle('Mon')).toHaveAttribute('aria-pressed', 'false');
+    // First interaction converts it into a simple day+time cron at the default time.
+  });
+});

--- a/client/src/components/apps/tabs/CustomTasksSection.jsx
+++ b/client/src/components/apps/tabs/CustomTasksSection.jsx
@@ -6,7 +6,8 @@ import ConfirmButtonPair from '../../ui/ConfirmButtonPair';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
 import * as api from '../../../services/api';
 import { timeAgo } from '../../../utils/formatters';
-import { CRON_PRESETS, describeCron } from '../../../utils/cronHelpers';
+import { CRON_PRESETS, DEFAULT_CRON, describeCron } from '../../../utils/cronHelpers';
+import WeekdayTimePicker from '../../WeekdayTimePicker';
 import { AGENT_OPTIONS, agentOptionButtonClass } from '../../cos/constants';
 
 const INTERVAL_OPTIONS = [
@@ -145,23 +146,27 @@ function TaskForm({ form, setForm, onSave, onCancel, saveLabel }) {
           ))}
         </div>
         {form.scheduleMode === 'cron' ? (
-          <div className="flex gap-2 items-center flex-wrap">
-            <input
-              type="text"
-              value={form.cronExpression || ''}
-              onChange={e => update('cronExpression', e.target.value)}
-              className="flex-1 min-w-[10rem] px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono"
-              placeholder="0 7 * * *"
-              title="Cron expression: minute hour dayOfMonth month dayOfWeek"
-            />
-            <select
-              value=""
-              onChange={e => { if (e.target.value) update('cronExpression', e.target.value); }}
-              className="px-2 py-2 bg-port-bg border border-port-border rounded-lg text-gray-400 text-xs"
-            >
-              <option value="">Presets</option>
-              {CRON_PRESETS.map(p => <option key={p.value} value={p.value}>{p.label}</option>)}
-            </select>
+          <div className="space-y-2">
+            <WeekdayTimePicker value={form.cronExpression || DEFAULT_CRON} onChange={value => update('cronExpression', value)} />
+            <div className="flex gap-2 items-center flex-wrap">
+              <input
+                type="text"
+                value={form.cronExpression || ''}
+                onChange={e => update('cronExpression', e.target.value)}
+                className="flex-1 min-w-[10rem] px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono"
+                placeholder="0 7 * * *"
+                title="Cron expression: minute hour dayOfMonth month dayOfWeek"
+              />
+              <select
+                value=""
+                onChange={e => { if (e.target.value) update('cronExpression', e.target.value); }}
+                className="px-2 py-2 bg-port-bg border border-port-border rounded-lg text-gray-400 text-xs"
+                aria-label="Cron presets"
+              >
+                <option value="">Presets</option>
+                {CRON_PRESETS.map(p => <option key={p.value} value={p.value}>{p.label}</option>)}
+              </select>
+            </div>
             {form.cronExpression && <span className="text-xs text-gray-500">{describeCron(form.cronExpression)}</span>}
           </div>
         ) : (

--- a/client/src/components/apps/tabs/CustomTasksSection.jsx
+++ b/client/src/components/apps/tabs/CustomTasksSection.jsx
@@ -94,6 +94,11 @@ function scheduleSummary(job) {
 
 function TaskForm({ form, setForm, onSave, onCancel, saveLabel }) {
   const update = (key, val) => setForm(f => ({ ...f, [key]: val }));
+  // Switching to cron seeds the expression with the default the picker displays
+  // (07:00 daily) so an untouched picker is actually saveable — otherwise the
+  // form shows a schedule while cronExpression stays empty and Save is blocked.
+  const setScheduleMode = (mode) =>
+    setForm(f => ({ ...f, scheduleMode: mode, cronExpression: mode === 'cron' && !f.cronExpression ? DEFAULT_CRON : f.cronExpression }));
   // Toggle a git-workflow flag while preserving the system-wide invariant that
   // openPR implies useWorktree (matches toggleAppMetadataOverride used elsewhere):
   // turning openPR on forces useWorktree on; turning useWorktree off forces openPR off.
@@ -136,7 +141,7 @@ function TaskForm({ form, setForm, onSave, onCancel, saveLabel }) {
             <button
               key={mode}
               type="button"
-              onClick={() => update('scheduleMode', mode)}
+              onClick={() => setScheduleMode(mode)}
               className={`px-2 py-1 text-xs rounded transition-colors ${
                 form.scheduleMode === mode ? 'bg-port-accent/20 text-port-accent' : 'bg-port-bg text-gray-500 hover:text-gray-300'
               }`}

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -181,7 +181,12 @@ function ScheduleFields({ data, onChange }) {
           <button
             key={opt.value}
             type="button"
-            onClick={() => onChange('scheduleMode', opt.value)}
+            onClick={() => {
+              onChange('scheduleMode', opt.value);
+              // Seed the expression with the picker's displayed default (07:00
+              // daily) so an untouched Cron picker is actually saveable.
+              if (opt.value === 'cron' && !data.cronExpression) onChange('cronExpression', DEFAULT_CRON);
+            }}
             className={`px-2 py-1 text-xs rounded transition-colors ${
               data.scheduleMode === opt.value
                 ? 'bg-port-accent/20 text-port-accent'

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -3,7 +3,8 @@ import { Plus, RefreshCw, Play, Trash2, ChevronDown, ChevronUp, Clock, ToggleLef
 import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
 import { timeAgo, formatDateTime } from '../../../utils/formatters';
-import { CRON_PRESETS, describeCron } from '../../../utils/cronHelpers';
+import { CRON_PRESETS, DEFAULT_CRON, describeCron } from '../../../utils/cronHelpers';
+import WeekdayTimePicker from '../../WeekdayTimePicker';
 import { filterSelectableModels } from '../../../utils/providers';
 import ProviderModelSelector from '../../ProviderModelSelector';
 import InlineConfirmRow from '../../ui/InlineConfirmRow';
@@ -192,25 +193,29 @@ function ScheduleFields({ data, onChange }) {
         ))}
       </div>
       {data.scheduleMode === 'cron' ? (
-        <div className="flex gap-2 items-center">
-          <input
-            type="text"
-            value={data.cronExpression || ''}
-            onChange={e => onChange('cronExpression', e.target.value)}
-            className="flex-1 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono"
-            placeholder="0 7 * * *"
-            title="Cron expression: minute hour dayOfMonth month dayOfWeek"
-          />
-          <select
-            value=""
-            onChange={e => { if (e.target.value) onChange('cronExpression', e.target.value); }}
-            className="px-2 py-2 bg-port-bg border border-port-border rounded-lg text-gray-400 text-xs"
-          >
-            <option value="">Presets</option>
-            {CRON_PRESETS.map(p => (
-              <option key={p.value} value={p.value}>{p.label}</option>
-            ))}
-          </select>
+        <div className="space-y-2">
+          <WeekdayTimePicker value={data.cronExpression || DEFAULT_CRON} onChange={value => onChange('cronExpression', value)} />
+          <div className="flex gap-2 items-center">
+            <input
+              type="text"
+              value={data.cronExpression || ''}
+              onChange={e => onChange('cronExpression', e.target.value)}
+              className="flex-1 px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm font-mono"
+              placeholder="0 7 * * *"
+              title="Cron expression: minute hour dayOfMonth month dayOfWeek"
+            />
+            <select
+              value=""
+              onChange={e => { if (e.target.value) onChange('cronExpression', e.target.value); }}
+              className="px-2 py-2 bg-port-bg border border-port-border rounded-lg text-gray-400 text-xs"
+              aria-label="Cron presets"
+            >
+              <option value="">Presets</option>
+              {CRON_PRESETS.map(p => (
+                <option key={p.value} value={p.value}>{p.label}</option>
+              ))}
+            </select>
+          </div>
           {data.cronExpression && (
             <span className="text-xs text-gray-500">{describeCron(data.cronExpression)}</span>
           )}

--- a/client/src/components/cos/tabs/workflow/ScheduleEditor.jsx
+++ b/client/src/components/cos/tabs/workflow/ScheduleEditor.jsx
@@ -71,6 +71,14 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
 
   const Icon = node.kind === 'job' ? Bot : GitBranch;
   const set = (key, value) => setForm(current => ({ ...current, [key]: value }));
+  // Switching to cron seeds the expression with the picker's displayed default
+  // (07:00 daily) so the visible schedule is actually saveable instead of
+  // failing validation on an empty cronExpression.
+  const setMode = (mode) => setForm(current => ({
+    ...current,
+    mode,
+    cronExpression: mode === 'cron' && !current.cronExpression ? DEFAULT_CRON : current.cronExpression
+  }));
   const validateCron = (value) => String(value || '').trim().split(/\s+/).length === 5;
 
   const handleSave = async () => {
@@ -160,7 +168,7 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
         {node.kind === 'task' ? (
           <label className="block text-xs text-gray-400">
             Scheduling behavior
-            <select value={form.mode} onChange={event => set('mode', event.target.value)} className="mt-1.5 w-full rounded border border-port-border bg-port-bg px-3 py-2 text-sm text-white">
+            <select value={form.mode} onChange={event => setMode(event.target.value)} className="mt-1.5 w-full rounded border border-port-border bg-port-bg px-3 py-2 text-sm text-white">
               {TASK_MODES.map(([value, label]) => <option key={value} value={value}>{label}</option>)}
             </select>
           </label>
@@ -169,7 +177,7 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
             <span className="block text-xs text-gray-400">Scheduling behavior</span>
             <div className="mt-1.5 grid grid-cols-2 rounded border border-port-border bg-port-bg p-1">
               {['cron', 'interval'].map(mode => (
-                <button key={mode} type="button" onClick={() => set('mode', mode)} className={`rounded px-2 py-1.5 text-xs capitalize ${form.mode === mode ? 'bg-port-accent/20 text-port-accent' : 'text-gray-500 hover:text-gray-300'}`}>
+                <button key={mode} type="button" onClick={() => setMode(mode)} className={`rounded px-2 py-1.5 text-xs capitalize ${form.mode === mode ? 'bg-port-accent/20 text-port-accent' : 'text-gray-500 hover:text-gray-300'}`}>
                   {mode === 'cron' ? 'Pinned time' : 'Interval'}
                 </button>
               ))}
@@ -200,7 +208,7 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
             <input
               type="time"
               value={parseSimpleCron(form.recheckCron)?.time ?? ''}
-              onChange={event => set('recheckCron', buildWeeklyCron([], event.target.value))}
+              onChange={event => set('recheckCron', buildWeeklyCron(parseSimpleCron(form.recheckCron)?.days ?? [], event.target.value))}
               className="w-full rounded border border-port-border bg-port-bg px-3 py-2 text-sm text-white"
             />
             <input value={form.recheckCron} onChange={event => set('recheckCron', event.target.value)} placeholder="0 9 * * *" className="w-full rounded border border-port-border bg-port-bg px-3 py-2 font-mono text-xs text-gray-300" aria-label="Perpetual recheck cron" />

--- a/client/src/components/cos/tabs/workflow/ScheduleEditor.jsx
+++ b/client/src/components/cos/tabs/workflow/ScheduleEditor.jsx
@@ -2,7 +2,8 @@ import { useEffect, useMemo, useState } from 'react';
 import { Bot, GitBranch, Loader2, Plus, Save, X } from 'lucide-react';
 import toast from '../../../ui/Toast';
 import * as api from '../../../../services/api';
-import { describeCron } from '../../../../utils/cronHelpers';
+import { describeCron, parseSimpleCron, buildWeeklyCron, DEFAULT_CRON } from '../../../../utils/cronHelpers';
+import WeekdayTimePicker from '../../../WeekdayTimePicker';
 
 const TASK_MODES = [
   ['cron', 'Pinned time (cron)'],
@@ -25,18 +26,6 @@ const JOB_INTERVALS = [
   ['biweekly', 'Every 2 weeks'],
   ['monthly', 'Monthly']
 ];
-
-function dailyTimeFromCron(expression) {
-  const match = String(expression || '').match(/^(\d{1,2})\s+(\d{1,2})\s+\*\s+\*\s+\*$/);
-  if (!match) return '';
-  return `${String(Number(match[2])).padStart(2, '0')}:${String(Number(match[1])).padStart(2, '0')}`;
-}
-
-function cronFromDailyTime(value) {
-  if (!value) return '';
-  const [hour, minute] = value.split(':');
-  return `${Number(minute)} ${Number(hour)} * * *`;
-}
 
 export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSaved }) {
   const [form, setForm] = useState(null);
@@ -190,15 +179,11 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
 
         {form.mode === 'cron' && (
           <div className="space-y-2">
-            <label className="block text-xs text-gray-400">
-              Daily time
-              <input
-                type="time"
-                value={dailyTimeFromCron(form.cronExpression)}
-                onChange={event => set('cronExpression', cronFromDailyTime(event.target.value))}
-                className="mt-1.5 w-full rounded border border-port-border bg-port-bg px-3 py-2 text-sm text-white"
-              />
-            </label>
+            <div>
+              <span className="block text-xs text-gray-400">Run on</span>
+              <WeekdayTimePicker value={form.cronExpression || DEFAULT_CRON} onChange={value => set('cronExpression', value)} className="mt-1.5" />
+              <p className="mt-1 text-[11px] text-gray-600">No days selected runs every day.</p>
+            </div>
             <label className="block text-xs text-gray-400">
               Advanced cron
               <input value={form.cronExpression} onChange={event => set('cronExpression', event.target.value)} placeholder="0 9 * * *" className="mt-1.5 w-full rounded border border-port-border bg-port-bg px-3 py-2 font-mono text-sm text-white" />
@@ -214,8 +199,8 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
             </p>
             <input
               type="time"
-              value={dailyTimeFromCron(form.recheckCron)}
-              onChange={event => set('recheckCron', cronFromDailyTime(event.target.value))}
+              value={parseSimpleCron(form.recheckCron)?.time ?? ''}
+              onChange={event => set('recheckCron', buildWeeklyCron([], event.target.value))}
               className="w-full rounded border border-port-border bg-port-bg px-3 py-2 text-sm text-white"
             />
             <input value={form.recheckCron} onChange={event => set('recheckCron', event.target.value)} placeholder="0 9 * * *" className="w-full rounded border border-port-border bg-port-bg px-3 py-2 font-mono text-xs text-gray-300" aria-label="Perpetual recheck cron" />

--- a/client/src/utils/cronHelpers.js
+++ b/client/src/utils/cronHelpers.js
@@ -17,14 +17,84 @@ export function isCronExpression(val) {
 
 const DOW_MAP = { '0': 'Sun', '1': 'Mon', '2': 'Tue', '3': 'Wed', '4': 'Thu', '5': 'Fri', '6': 'Sat', '7': 'Sun' };
 
+// Default schedule the pickers seed with (07:00 daily) — kept in one place so
+// the time picker's fallback and every call site's seed cron stay in lockstep.
+export const DEFAULT_TIME = '07:00';
+export const DEFAULT_CRON = '0 7 * * *';
+
+// Sunday-first, matching cron's day-of-week numbering (0 = Sunday).
+export const WEEKDAYS = [
+  { value: 0, short: 'S', label: 'Sun' },
+  { value: 1, short: 'M', label: 'Mon' },
+  { value: 2, short: 'T', label: 'Tue' },
+  { value: 3, short: 'W', label: 'Wed' },
+  { value: 4, short: 'T', label: 'Thu' },
+  { value: 5, short: 'F', label: 'Fri' },
+  { value: 6, short: 'S', label: 'Sat' }
+];
+
+// Expand a cron day-of-week field into sorted, unique day numbers (0-6, Sun=0).
+// Returns [] for '*' (every day). Returns null for anything this simple parser
+// can't represent (steps like `*/2`, out-of-range values, malformed ranges).
+function parseDowField(dow) {
+  if (dow === '*') return [];
+  const out = new Set();
+  for (const token of dow.split(',')) {
+    if (/^\d+$/.test(token)) {
+      const value = Number(token);
+      if (value > 7) return null;
+      out.add(value % 7); // cron accepts 7 as Sunday; normalize to 0
+      continue;
+    }
+    const range = token.match(/^(\d+)-(\d+)$/);
+    if (!range) return null;
+    const start = Number(range[1]);
+    const end = Number(range[2]);
+    if (start > 7 || end > 7 || start > end) return null;
+    for (let day = start; day <= end; day++) out.add(day % 7);
+  }
+  return [...out].sort((a, b) => a - b);
+}
+
+// Parse a "simple" cron (fixed minute + hour, any day-of-month/month, an
+// enumerable day-of-week set) into { days: number[], time: 'HH:MM' }.
+// `days` is empty for an every-day (daily) schedule. Returns null when the
+// expression is an interval/stepped/complex cron the day+time picker can't
+// round-trip — callers fall back to the raw text field in that case.
+export function parseSimpleCron(expr) {
+  if (!expr) return null;
+  const parts = String(expr).trim().split(/\s+/);
+  if (parts.length !== 5) return null;
+  const [min, hour, dom, mon, dow] = parts;
+  if (dom !== '*' || mon !== '*') return null;
+  if (!/^\d{1,2}$/.test(min) || !/^\d{1,2}$/.test(hour)) return null;
+  const minute = Number(min);
+  const hr = Number(hour);
+  if (minute > 59 || hr > 23) return null;
+  const days = parseDowField(dow);
+  if (!days) return null;
+  return { days, time: `${String(hr).padStart(2, '0')}:${String(minute).padStart(2, '0')}` };
+}
+
+// Build a cron expression from a day-of-week set + a 'HH:MM' time.
+// No days selected → every day (daily at that time). Returns '' for an
+// unparseable time so callers can treat it as "not yet set".
+export function buildWeeklyCron(days, time) {
+  const [hr, minute] = String(time || '').split(':').map(Number);
+  if (!Number.isInteger(hr) || !Number.isInteger(minute)) return '';
+  const dow = !days || days.length === 0 ? '*' : [...days].sort((a, b) => a - b).join(',');
+  return `${minute} ${hr} * * ${dow}`;
+}
+
 export function describeCron(expr) {
   if (!expr) return '';
   const parts = expr.trim().split(/\s+/);
   if (parts.length !== 5) return expr;
   const [min, hour, dom, mon, dow] = parts;
   const segments = [];
-  if (min === '0' && hour !== '*') {
+  if (/^\d{1,2}$/.test(min) && /^\d{1,2}$/.test(hour)) {
     if (dow === '1-5') segments.push('Weekdays');
+    else if (dow === '0,6' || dow === '6,0') segments.push('Weekends');
     else if (dow !== '*') segments.push(dow.split(',').map(d => DOW_MAP[d] || d).join(', '));
     if (dom !== '*') segments.push(`day ${dom}`);
     if (mon !== '*') segments.push(`month ${mon}`);

--- a/client/src/utils/cronHelpers.test.js
+++ b/client/src/utils/cronHelpers.test.js
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { parseSimpleCron, buildWeeklyCron, describeCron, WEEKDAYS } from './cronHelpers.js';
+
+describe('parseSimpleCron', () => {
+  it('parses a daily cron as every-day (no days)', () => {
+    expect(parseSimpleCron('0 7 * * *')).toEqual({ days: [], time: '07:00' });
+  });
+
+  it('parses a single weekday with a non-zero minute', () => {
+    expect(parseSimpleCron('30 9 * * 1')).toEqual({ days: [1], time: '09:30' });
+  });
+
+  it('parses a comma list of days, sorted and unique', () => {
+    expect(parseSimpleCron('0 8 * * 5,1,1')).toEqual({ days: [1, 5], time: '08:00' });
+  });
+
+  it('expands a day range', () => {
+    expect(parseSimpleCron('0 6 * * 1-5')).toEqual({ days: [1, 2, 3, 4, 5], time: '06:00' });
+  });
+
+  it('normalizes cron Sunday 7 to 0', () => {
+    expect(parseSimpleCron('0 6 * * 7')).toEqual({ days: [0], time: '06:00' });
+  });
+
+  it('rejects interval/stepped crons the picker cannot represent', () => {
+    expect(parseSimpleCron('*/15 * * * *')).toBeNull();
+    expect(parseSimpleCron('0 */4 * * *')).toBeNull();
+  });
+
+  it('rejects day-of-month / month constraints', () => {
+    expect(parseSimpleCron('0 0 1 * *')).toBeNull();
+    expect(parseSimpleCron('0 0 * 6 *')).toBeNull();
+  });
+
+  it('rejects out-of-range and malformed values', () => {
+    expect(parseSimpleCron('99 9 * * 1')).toBeNull();
+    expect(parseSimpleCron('0 25 * * 1')).toBeNull();
+    expect(parseSimpleCron('0 9 * * 8')).toBeNull();
+    expect(parseSimpleCron('not a cron')).toBeNull();
+    expect(parseSimpleCron('')).toBeNull();
+  });
+});
+
+describe('buildWeeklyCron', () => {
+  it('builds an every-day cron when no days are selected', () => {
+    expect(buildWeeklyCron([], '07:00')).toBe('0 7 * * *');
+  });
+
+  it('builds a single-day cron', () => {
+    expect(buildWeeklyCron([1], '09:30')).toBe('30 9 * * 1');
+  });
+
+  it('sorts multiple days', () => {
+    expect(buildWeeklyCron([5, 1, 3], '08:00')).toBe('0 8 * * 1,3,5');
+  });
+
+  it('returns empty string for an unparseable time', () => {
+    expect(buildWeeklyCron([1], '')).toBe('');
+    expect(buildWeeklyCron([1], 'nope')).toBe('');
+  });
+
+  it('round-trips through parseSimpleCron', () => {
+    const cron = buildWeeklyCron([2, 4], '14:15');
+    expect(parseSimpleCron(cron)).toEqual({ days: [2, 4], time: '14:15' });
+  });
+});
+
+describe('describeCron weekly cases', () => {
+  it('describes a single weekday with a non-zero minute', () => {
+    expect(describeCron('30 9 * * 1')).toBe('Mon at 09:30');
+  });
+
+  it('labels weekdays and weekends', () => {
+    expect(describeCron('0 7 * * 1-5')).toBe('Weekdays at 07:00');
+    expect(describeCron('0 10 * * 0,6')).toBe('Weekends at 10:00');
+  });
+});
+
+describe('WEEKDAYS', () => {
+  it('is Sunday-first with cron-aligned values', () => {
+    expect(WEEKDAYS.map(w => w.value)).toEqual([0, 1, 2, 3, 4, 5, 6]);
+    expect(WEEKDAYS[0].label).toBe('Sun');
+  });
+});


### PR DESCRIPTION
## Summary

Weekly (and any day-of-week) CoS schedules previously required hand-typing a crontab expression. This adds a shared **WeekdayTimePicker** — a row of day pills (S M T W T F S) plus a time input — and leads every CoS cron surface with it: click the days it should run and set the time, and the cron expression is built for you (no days selected = every day).

The raw crontab field + presets stay available behind an **Advanced** toggle for the interval/stepped schedules the picker can't represent, and the picker round-trips existing crons (an existing `0 9 * * 1,3` lights up Mon/Wed at 09:00).

### Surfaces updated
- **Schedule tab** overrides + global config (via the shared `CronInput`)
- **Workflow** schedule editor's pinned-time mode (`ScheduleEditor`)
- **CoS system jobs** (`JobsTab`)
- **Per-app custom tasks** (`CustomTasksSection`)

### Implementation
- `client/src/utils/cronHelpers.js` — new `parseSimpleCron` / `buildWeeklyCron` / `WEEKDAYS` / `DEFAULT_CRON`, plus `describeCron` now renders any fixed `HH:MM` weekly schedule (including non-zero minutes and weekend sets) instead of falling back to the raw string.
- `client/src/components/WeekdayTimePicker.jsx` — shared presentational picker (reads/writes a cron string via `value`/`onChange`).
- Switching a task/job to Cron seeds the expression with the picker's displayed 07:00-daily default so an untouched picker is actually saveable.

## Test plan
- `client/src/utils/cronHelpers.test.js` — parse/build round-trip, 7→0 Sunday normalization, out-of-range + stepped-cron rejection, weekday/weekend describe cases.
- `client/src/components/WeekdayTimePicker.test.jsx` — pill pressed-state, add/remove day, time-change rebuild, interval-cron → day+time conversion on first toggle.
- `cd client && npm test` green; `npm run build` clean; eslint clean.
- Reviewed by claude + codex (both converged clean; found and fixed: day-pill `aria-label`, a test that didn't pin its named contract, and a default-cron-not-persisted-on-mode-switch bug across all three surfaces).