### PR TITLE
Fix editing models for system CoS tasks

### DIFF
--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -94,6 +94,10 @@ function getSuccessRateStyle(rate) {
 }
 
 export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, providers, durations, dragHandleProps, apps, onEditingChange }) {
+  // System and approval-gated tasks are persisted in COS-TASKS.md. Every task
+  // mutation must name that source; otherwise the API's user-queue default
+  // searches TASKS.md and reports the system task as missing.
+  const taskSource = isSystem || awaitingApproval ? 'internal' : 'user';
   const [editing, setEditingInternal] = useState(false);
   const setEditing = useCallback((val) => {
     setEditingInternal(val);
@@ -184,7 +188,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   }, [durations, task.description, task.status]);
 
   const handleStatusChange = async (newStatus, blockedReasonText = '') => {
-    const updates = { status: newStatus };
+    const updates = { status: newStatus, type: taskSource };
     if (newStatus === 'blocked' && blockedReasonText) {
       updates.blockedReason = blockedReasonText;
     }
@@ -206,7 +210,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   };
 
   const handleSave = async () => {
-    const result = await api.updateCosTask(task.id, editData, { silent: true }).catch(err => {
+    const result = await api.updateCosTask(task.id, { ...editData, type: taskSource }, { silent: true }).catch(err => {
       toast.error(err.message);
       return null;
     });
@@ -217,8 +221,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   };
 
   const handleDelete = async () => {
-    const taskType = isSystem ? 'internal' : 'user';
-    const result = await api.deleteCosTask(task.id, taskType, { silent: true }).catch(err => { toast.error(err.message); return null; });
+    const result = await api.deleteCosTask(task.id, taskSource, { silent: true }).catch(err => { toast.error(err.message); return null; });
     if (!result) return;
     toast.success('Task deleted');
     onRefresh();

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const api = vi.hoisted(() => ({
+  updateCosTask: vi.fn(),
+  deleteCosTask: vi.fn(),
+  approveCosTask: vi.fn(),
+  forceSpawnTask: vi.fn(),
+}));
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+
+vi.mock('../../../services/api', () => api);
+vi.mock('../../ui/Toast', () => ({ default: toast }));
+
+const TaskItem = (await import('./TaskItem')).default;
+
+const task = {
+  id: 'sys-model-edit',
+  description: 'Reference repo review',
+  status: 'pending',
+  metadata: { provider: 'codex-tui', model: 'gpt-5.6-terra' },
+};
+const providers = [{ id: 'codex-tui', name: 'Codex TUI', enabled: true, models: ['gpt-5.6-terra'] }];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.updateCosTask.mockResolvedValue({ ...task });
+});
+
+describe('TaskItem task source', () => {
+  it('updates a system task in the internal queue when saving its model', async () => {
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(api.updateCosTask).toHaveBeenCalledWith(
+      'sys-model-edit',
+      expect.objectContaining({
+        provider: 'codex-tui',
+        model: 'gpt-5.6-terra',
+        type: 'internal',
+      }),
+      { silent: true },
+    ));
+  });
+
+  it('updates an approval-gated task in the internal queue when changing status', async () => {
+    render(<TaskItem task={task} awaitingApproval onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Status: pending/i }));
+
+    await waitFor(() => expect(api.updateCosTask).toHaveBeenCalledWith(
+      'sys-model-edit',
+      { status: 'completed', type: 'internal' },
+      { silent: true },
+    ));
+  });
+});

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -388,6 +388,21 @@ describe('CoS Routes', () => {
       expect(cos.updateTask).toHaveBeenCalledWith('task-001', expect.objectContaining({ status: 'completed' }), 'user');
     });
 
+    it('should update an internal task in the internal queue', async () => {
+      cos.updateTask.mockResolvedValue({ id: 'sys-001', model: 'gpt-5.6-terra' });
+
+      const response = await request(app)
+        .put('/api/cos/tasks/sys-001')
+        .send({ model: 'gpt-5.6-terra', type: 'internal' });
+
+      expect(response.status).toBe(200);
+      expect(cos.updateTask).toHaveBeenCalledWith(
+        'sys-001',
+        expect.objectContaining({ model: 'gpt-5.6-terra' }),
+        'internal'
+      );
+    });
+
     it('should return 404 if task not found', async () => {
       cos.updateTask.mockResolvedValue({ error: 'Task not found' });
 


### PR DESCRIPTION
## Summary
- route system and approval-gated task mutations to the internal CoS queue
- restore model edits for pending system tasks
- add client and route regression coverage

## Verification
- `npm test -- --run src/components/cos/tabs/TaskItem.test.jsx` (client)
- `npm test -- --run routes/cos.test.js` (server)
- `npm run lint -- --quiet` (client)
- `npm run build` (client)