### PR TITLE
fix: preserve voice mic icon contrast

### DIFF
--- a/client/src/components/voice/VoiceWidget.jsx
+++ b/client/src/components/voice/VoiceWidget.jsx
@@ -560,7 +560,7 @@ export default function VoiceWidget() {
             onClick={() => { setExpanded(true); toggleCapture(); }}
             className={`p-3 rounded-full border transition-colors ${fabSurface} ${
               capturing
-                ? 'bg-port-accent-2 text-white animate-pulse'
+                ? 'bg-port-accent-2 text-port-on-accent-2 animate-pulse'
                 : 'bg-port-card text-white'
             }`}
             title="Open voice controls"
@@ -692,7 +692,7 @@ export default function VoiceWidget() {
             onClick={toggleCapture}
             className={`p-3 rounded-full transition-colors ${
               capturing
-                ? 'bg-port-accent-2 text-white animate-pulse'
+                ? 'bg-port-accent-2 text-port-on-accent-2 animate-pulse'
                 : 'bg-port-accent-2/20 hover:bg-port-accent-2/40 text-port-accent-2'
             }`}
             title={(() => {


### PR DESCRIPTION
## Summary
- use the secondary accent’s semantic foreground token for active voice microphone controls
- keep the icon legible in Phosphor Paper and themes whose foreground is not white

## Validation
- npm run lint --prefix client
- npm run build --prefix client

## Visual note
The in-app browser was unavailable in this session; the fix follows the existing theme token contract used by other solid secondary-accent controls.