### PR TITLE
a11y: keyboard-operable reference-audio waveform + dialog semantics for two hand-rolled modals

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -2,6 +2,8 @@
 
 ## Accessibility
 
+- **The reference-audio waveform is now keyboard-operable and two hand-rolled modals gained real dialog semantics.** The Songs "reference analysis" waveform scrubber was a mouse-only `<div onClick>` (`role="presentation"`) — keyboard and screen-reader users could not seek at all. It is now a proper `role="slider"` with `aria-valuemin/max/now/valuetext`, focusable, and scrubbable with the arrow keys (±1s, ±5s with Shift) plus Home/End (WCAG 2.1.1). Separately, the CyberCity photo-mode "postcard preview" overlay and the Catalog "pick from media gallery" picker were hand-rolled `fixed inset-0` backdrops with no `role="dialog"`, no `aria-modal`, no Escape-to-close, and no focus trap; both now render through the shared `Modal` (focus trap + Esc stack + labelled dialog), with the postcard preview portaled so it escapes the WebGL HUD's stacking/pointer-events context.
+
 - **Modals and drawers now trap and restore keyboard focus, and toasts are announced to screen readers.** Opening any shared `Modal` or `Drawer` (which back the great majority of the app's dialogs, config drawers, and lightboxes) now moves focus into the dialog, keeps Tab/Shift+Tab cycling inside it instead of leaking to the page behind, and returns focus to the control that opened it on close (WCAG 2.4.3 / 2.1.2) — implemented once in a reusable `useFocusTrap` hook. The toast stack is now a labelled ARIA notification region: default toasts announce politely (`role="status"`) and error toasts assertively (`role="alert"`), with the decorative status glyphs hidden from assistive tech, so screen-reader users hear notifications (including error toasts) as they arrive.
 
 ## AI Providers

--- a/client/src/components/city/CityPhotoOverlay.jsx
+++ b/client/src/components/city/CityPhotoOverlay.jsx
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import Modal from '../ui/Modal.jsx';
 import { PHOTO_PRESETS, getPreset, cyclePreset, buildPostcardStats, screenshotFilename } from '../../utils/cityPhotoMode';
 
 // Photo-mode HUD overlay (roadmap 3.3). When photo mode is active it dims the rest of the HUD,
@@ -157,30 +158,35 @@ export default function CityPhotoOverlay({ active, presetId, onPresetChange, onE
         </button>
       </div>
 
-      {/* Postcard preview modal */}
-      {postcard && (
-        <div className="absolute inset-0 z-40 flex items-center justify-center bg-black/70 pointer-events-auto" onClick={() => setPostcard(null)}>
-          <div className="max-w-[80vw] max-h-[80vh] flex flex-col items-center gap-3" onClick={(e) => e.stopPropagation()}>
-            <img src={postcard} alt="City postcard" className="max-w-full max-h-[68vh] rounded-lg border border-cyan-500/40 shadow-[0_0_30px_rgba(6,182,212,0.3)]" />
-            <div className="flex gap-3">
-              <button
-                type="button"
-                onClick={handleDownload}
-                className="font-pixel text-[11px] text-black bg-cyan-400 tracking-wider rounded px-4 py-2 hover:bg-cyan-300 transition-all"
-              >
-                ↓ SAVE POSTCARD
-              </button>
-              <button
-                type="button"
-                onClick={() => setPostcard(null)}
-                className="font-pixel text-[11px] text-cyan-400 tracking-wider border border-cyan-500/40 rounded px-4 py-2 hover:bg-cyan-500/10 transition-all"
-              >
-                CLOSE
-              </button>
-            </div>
-          </div>
+      {/* Postcard preview modal — portaled so it escapes the pointer-events-none
+          / z-indexed WebGL HUD stacking context and gets focus-trap + Esc from
+          the shared Modal. */}
+      <Modal
+        open={!!postcard}
+        onClose={() => setPostcard(null)}
+        size="none"
+        usePortal
+        ariaLabel="City postcard preview"
+        panelClassName="max-w-[80vw] max-h-[80vh] flex flex-col items-center gap-3"
+      >
+        <img src={postcard} alt="City postcard" className="max-w-full max-h-[68vh] rounded-lg border border-cyan-500/40 shadow-[0_0_30px_rgba(6,182,212,0.3)]" />
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={handleDownload}
+            className="font-pixel text-[11px] text-black bg-cyan-400 tracking-wider rounded px-4 py-2 hover:bg-cyan-300 transition-all"
+          >
+            ↓ SAVE POSTCARD
+          </button>
+          <button
+            type="button"
+            onClick={() => setPostcard(null)}
+            className="font-pixel text-[11px] text-cyan-400 tracking-wider border border-cyan-500/40 rounded px-4 py-2 hover:bg-cyan-500/10 transition-all"
+          >
+            CLOSE
+          </button>
         </div>
-      )}
+      </Modal>
     </>
   );
 }

--- a/client/src/components/songs/ReferenceAnalysis.jsx
+++ b/client/src/components/songs/ReferenceAnalysis.jsx
@@ -277,15 +277,60 @@ function Waveform({ samples, durationMs, segments, playheadMs, onSeek }) {
     }
   }, [samples, durationMs, segments]);
 
+  const interactive = durationMs > 0 && typeof onSeek === 'function';
+
   const seek = (e) => {
-    if (!durationMs || !onSeek) return;
+    if (!interactive) return;
     const rect = e.currentTarget.getBoundingClientRect();
     const ratio = Math.min(1, Math.max(0, (e.clientX - rect.left) / rect.width));
     onSeek(ratio * durationMs);
   };
 
+  // Keyboard scrubbing: arrows nudge ±1s (±5s with Shift), Home/End jump to the
+  // ends. Without this the waveform is a mouse-only control — unreachable and
+  // unusable for keyboard/screen-reader users.
+  const handleKeyDown = (e) => {
+    if (!interactive) return;
+    const cur = Math.min(durationMs, Math.max(0, playheadMs ?? 0));
+    const bigStep = e.shiftKey;
+    let next = null;
+    switch (e.key) {
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        next = cur - (bigStep ? 5000 : 1000);
+        break;
+      case 'ArrowRight':
+      case 'ArrowUp':
+        next = cur + (bigStep ? 5000 : 1000);
+        break;
+      case 'Home':
+        next = 0;
+        break;
+      case 'End':
+        next = durationMs;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    onSeek(Math.min(durationMs, Math.max(0, next)));
+  };
+
+  const nowMs = Math.min(durationMs, Math.max(0, playheadMs ?? 0));
+
   return (
-    <div className="relative w-full cursor-pointer" onClick={seek} role="presentation">
+    <div
+      className={`relative w-full rounded-lg ${interactive ? 'cursor-pointer focus:outline-none focus:ring-2 focus:ring-port-accent' : ''}`}
+      onClick={seek}
+      onKeyDown={handleKeyDown}
+      role={interactive ? 'slider' : 'presentation'}
+      tabIndex={interactive ? 0 : undefined}
+      aria-label={interactive ? 'Seek position in reference audio' : undefined}
+      aria-valuemin={interactive ? 0 : undefined}
+      aria-valuemax={interactive ? Math.round(durationMs) : undefined}
+      aria-valuenow={interactive ? Math.round(nowMs) : undefined}
+      aria-valuetext={interactive ? `${(nowMs / 1000).toFixed(1)} of ${(durationMs / 1000).toFixed(1)} seconds` : undefined}
+    >
       <canvas ref={canvasRef} width={800} height={96} className="w-full h-24 rounded-lg bg-port-bg border border-port-border" />
       {durationMs > 0 && playheadMs != null && (
         <div

--- a/client/src/pages/CatalogIngredient.jsx
+++ b/client/src/pages/CatalogIngredient.jsx
@@ -1292,14 +1292,19 @@ function GalleryPickerModal({ onClose, onPick }) {
   return (
     <Modal open onClose={onClose} size="lg" ariaLabelledBy="gallery-picker-title"
       panelClassName="bg-port-card border border-port-border rounded-lg max-h-[80vh] overflow-hidden flex flex-col">
-      <div>
-        <div className="flex items-center justify-between p-3 border-b border-port-border">
+      {/* Header + scroll area must be DIRECT flex children of the panel (a
+          fragment, not a wrapping <div>) so the panel's max-h-[80vh] flex
+          column constrains the scroll region's height — an intervening
+          content-sized <div> would leave `overflow-y-auto` unbounded and clip
+          long galleries. */}
+      <>
+        <div className="flex items-center justify-between p-3 border-b border-port-border shrink-0">
           <h3 id="gallery-picker-title" className="text-sm font-semibold text-white">Pick from media gallery</h3>
           <button type="button" onClick={onClose} className="text-gray-400 hover:text-white" aria-label="Close">
             <X size={16} />
           </button>
         </div>
-        <div className="p-3 overflow-y-auto">
+        <div className="p-3 overflow-y-auto flex-1 min-h-0">
           {items === null && <p className="text-xs text-gray-500">Loading gallery…</p>}
           {items?.length === 0 && <p className="text-xs text-gray-500">No images in the gallery yet. Generate one in Image Gen first.</p>}
           {items && items.length > 0 && (
@@ -1319,7 +1324,7 @@ function GalleryPickerModal({ onClose, onPick }) {
             </div>
           )}
         </div>
-      </div>
+      </>
     </Modal>
   );
 }

--- a/client/src/pages/CatalogIngredient.jsx
+++ b/client/src/pages/CatalogIngredient.jsx
@@ -9,6 +9,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams, Link } from 'react-router-dom';
 import { Sparkles, Save, Trash2, ArrowLeft, Loader2, ExternalLink, Plus, X, History, RotateCcw, Image as ImageIcon, Star, ChevronDown, Upload, Mic, Square } from 'lucide-react';
 import toast from '../components/ui/Toast';
+import Modal from '../components/ui/Modal.jsx';
 import {
   getCatalogIngredientDetails,
   updateCatalogIngredient,
@@ -1281,7 +1282,6 @@ function MediaTile({ m, missing, isPortrait = false, onSetPortrait, onDetach }) 
 // history" requirement. Never uploads; it only references library keys.
 function GalleryPickerModal({ onClose, onPick }) {
   const [items, setItems] = useState(null); // null = loading, [] = loaded-empty
-  const closeRef = useRef(null);
 
   useEffect(() => {
     listImageGallery()
@@ -1290,11 +1290,12 @@ function GalleryPickerModal({ onClose, onPick }) {
   }, []);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4" onClick={onClose}>
-      <div className="bg-port-card border border-port-border rounded-lg w-full max-w-2xl max-h-[80vh] overflow-hidden flex flex-col" onClick={(e) => e.stopPropagation()}>
+    <Modal open onClose={onClose} size="lg" ariaLabelledBy="gallery-picker-title"
+      panelClassName="bg-port-card border border-port-border rounded-lg max-h-[80vh] overflow-hidden flex flex-col">
+      <div>
         <div className="flex items-center justify-between p-3 border-b border-port-border">
-          <h3 className="text-sm font-semibold text-white">Pick from media gallery</h3>
-          <button ref={closeRef} type="button" onClick={onClose} className="text-gray-400 hover:text-white" aria-label="Close">
+          <h3 id="gallery-picker-title" className="text-sm font-semibold text-white">Pick from media gallery</h3>
+          <button type="button" onClick={onClose} className="text-gray-400 hover:text-white" aria-label="Close">
             <X size={16} />
           </button>
         </div>
@@ -1319,7 +1320,7 @@ function GalleryPickerModal({ onClose, onPick }) {
           )}
         </div>
       </div>
-    </div>
+    </Modal>
   );
 }
 


### PR DESCRIPTION
## Summary

Accessibility-audit pass over interactive surfaces that bypassed the app's mature a11y baseline (`clickableProps` helper, shared `Modal`/`Drawer` focus-trap chrome). Three genuine gaps, all verified fixed:

- **Reference-audio waveform is now keyboard-operable.** The Songs `ReferenceAnalysis` waveform scrubber was a mouse-only `<div onClick>` with `role="presentation"` — keyboard and screen-reader users could not seek at all. It is now a proper `role="slider"` with `aria-valuemin/max/now/valuetext`, focusable, and scrubbable via arrow keys (±1s, ±5s with Shift) plus Home/End (WCAG 2.1.1). The non-interactive (no `onSeek`/`durationMs`) case stays `role="presentation"`.
- **CyberCity photo-mode postcard preview → shared `Modal`.** Was a hand-rolled `absolute inset-0` backdrop with no `role="dialog"`, `aria-modal`, Escape-to-close, or focus trap. Now renders through `Modal` (focus trap + Esc stack + labelled dialog), portaled so it escapes the WebGL HUD's stacking / `pointer-events-none` context.
- **Catalog "pick from media gallery" picker → shared `Modal`.** Same hand-rolled-backdrop gap; now a labelled dialog (`aria-labelledby` the heading) with focus trap and Esc. Fixed a layout regression the conversion introduced (codex review): header + scroll area are direct flex children so the panel's `max-h-[80vh]` still bounds the scroll region for long galleries.

## Test plan

- `client` production build passes (`npm run build`).
- `client` songs vitest suite green (9 files / 75 tests), covering `ReferenceAnalysis`.
- Local codex review: clean (caught and confirmed-fixed the gallery-scroll regression).
- Manual reasoning: postcard preview stays within `max-h-[80vh]` (img capped at 68vh + small button row), so no scroll region is affected there.