### PR TITLE
surface provider-resolution errors when force-spawning a pending CoS task

### DIFF
--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -73,6 +73,7 @@ const RECENT_COMPLETION_GRACE_MS = 60_000;
 
 // Internal imports for functions used in this module
 import { pruneOldAgentArchives, archiveStaleAgents as _archiveStaleAgents, loadAgentIndex } from './cosAgents.js';
+import { resolveAgentProviderAndModel } from './agentProviderResolution.js';
 
 // Task generation + evaluation engine (extracted to cosTaskGenerator.js).
 // `evaluateTasks` and the generators emit `task:ready`; the spawn-side
@@ -471,6 +472,18 @@ export async function forceSpawnTask(taskId) {
   const runningAgents = Object.values(state.agents).filter(a => a.status === 'running').length;
   if (runningAgents >= state.config.maxConcurrentAgents) {
     return { error: `No available agent slots (${runningAgents}/${state.config.maxConcurrentAgents})` };
+  }
+
+  // Pre-validate provider/model resolution before emitting `task:ready`. The
+  // actual spawn runs asynchronously in a `task:ready` listener, so a
+  // resolution failure there (e.g. a task pinned to an `api`-type provider with
+  // no file-writing harness) would bail silently and leave the task `pending`
+  // — while this call had already returned `{ success: true }` and the UI
+  // toasted "Spawning". Resolving here surfaces the real, actionable error
+  // (which provider to use) synchronously instead of lying to the user.
+  const resolution = await resolveAgentProviderAndModel(task);
+  if (!resolution.ok) {
+    return { error: resolution.error };
   }
 
   cosEvents.emit('task:ready', { ...task, taskType: task.taskType || 'internal' });

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -1083,6 +1083,35 @@ describe('cos.js source — priority + capacity invariants', () => {
   });
 });
 
+describe('forceSpawnTask — pre-validate provider before task:ready', () => {
+  // The play button on a pending task calls forceSpawnTask, which emits
+  // `task:ready`; the actual spawn happens asynchronously in a listener. If
+  // provider/model resolution fails there (e.g. the task is pinned to an
+  // `api`-type provider with no file-writing harness), the spawn bails
+  // silently and the task stays `pending` — but the HTTP call had already
+  // returned `{ success: true }` and the UI toasted "Spawning". Pin that
+  // forceSpawnTask resolves the provider FIRST and returns the resolution
+  // error (so the route surfaces a truthful 400) instead of emitting
+  // `task:ready` on a doomed spawn.
+  const forceFn = extractFnBody(COS_SRC, COS_SRC.indexOf('export async function forceSpawnTask'));
+
+  it('calls resolveAgentProviderAndModel and returns its error', () => {
+    expect(forceFn, 'forceSpawnTask must pre-resolve the provider/model')
+      .toMatch(/resolveAgentProviderAndModel\(\s*task\s*\)/);
+    expect(forceFn, 'forceSpawnTask must return the resolution error on failure')
+      .toMatch(/if\s*\(\s*!\s*resolution\.ok\s*\)\s*\{\s*return\s*\{\s*error:\s*resolution\.error\s*\}/);
+  });
+
+  it('bails on a failed resolution BEFORE emitting task:ready', () => {
+    const resolveIdx = forceFn.indexOf('resolveAgentProviderAndModel');
+    const readyIdx = forceFn.indexOf("cosEvents.emit('task:ready'");
+    expect(resolveIdx, 'resolution must happen in forceSpawnTask').toBeGreaterThan(-1);
+    expect(readyIdx, 'forceSpawnTask must still emit task:ready on success').toBeGreaterThan(-1);
+    expect(resolveIdx, 'provider resolution must precede the task:ready emit')
+      .toBeLessThan(readyIdx);
+  });
+});
+
 describe('addTask — first-line dedup', () => {
   it('returns the first non-empty trimmed line', () => {
     expect(firstLine('hello\nworld')).toBe('hello');


### PR DESCRIPTION
## Summary

Clicking **play** (start) on a pending CoS agent task showed a "Spawning" success toast but left the task stuck in `pending` — with no explanation. This happened for Layered Intelligence tasks pinned to an `api`-type provider (e.g. `ollama`), which has no file-writing harness and so can't back a CoS agent.

Root cause: `forceSpawnTask` emitted `task:ready` and immediately returned `{ success: true }`. The actual spawn runs asynchronously in a `task:ready` listener, where provider/model resolution fails the harness-boundary guard and bails silently (`resolution.ok === false`) — never flipping the task off `pending`. The HTTP call had already returned success, so the UI toasted "Spawning" and nothing happened.

Fix: pre-resolve the provider/model in `forceSpawnTask` **before** emitting `task:ready`. On failure, return `{ error: resolution.error }` instead of emitting. The spawn route already maps a returned `error` to a 400, and the play button's `.catch` toasts it — so the user now sees the real, actionable message ("Provider … is an HTTP API provider with no file-writing harness — CoS agent tasks need a CLI/TUI coding provider …") instead of a false success.

This generalizes to **any** resolution failure (no active provider, unavailable-with-no-fallback, api-type harness boundary), and as a bonus stops orphan `task:ready` side effects (e.g. review-item creation) from firing for a task that never spawns.

## Test plan

- New source-level guard tests in `server/services/cos.test.js` pin that `forceSpawnTask` calls `resolveAgentProviderAndModel(task)`, returns its error on `!resolution.ok`, and resolves **before** emitting `task:ready`.
- `npx vitest run services/cos.test.js` — 49 passed.
- `npx vitest run services/agentProviderResolution.test.js services/agentLifecycle.test.js services/subAgentSpawner.test.js routes/cos.test.js` — 210 passed.
- Local reviewers (codex + claude) reviewed the diff: both clean, zero findings.