### PR TITLE
fix: drop redundant aria-live on toasts, exclude hidden panels from focus trap

### DIFF
--- a/client/src/components/ui/Toast.jsx
+++ b/client/src/components/ui/Toast.jsx
@@ -98,10 +98,13 @@ export function Toaster({ position = 'bottom-right', toastOptions = {} }) {
   }[position] ?? 'bottom-4 right-4 items-end';
 
   return (
-    // Notification region. Each toast is its own live region (role="alert" for
-    // errors → assertive, role="status" otherwise → polite) so screen readers
-    // announce toasts as they arrive. Announcing per-toast rather than on the
-    // container avoids the whole stack being re-read when one entry changes.
+    // Notification region. Each toast is its own live region: role="alert"
+    // (implicitly assertive) for errors, role="status" (implicitly polite)
+    // otherwise, so screen readers announce toasts as they arrive. The role's
+    // implicit live semantics are relied on WITHOUT a redundant aria-live —
+    // pairing both on one node double-announces in iOS VoiceOver. Announcing
+    // per-toast rather than on the container avoids the whole stack being
+    // re-read when one entry changes.
     <div
       className={`fixed ${posClass} z-[9999] flex flex-col gap-2 pointer-events-none`}
       role="region"
@@ -116,7 +119,6 @@ export function Toaster({ position = 'bottom-right', toastOptions = {} }) {
             key={t.id}
             style={style}
             role={t.type === 'error' ? 'alert' : 'status'}
-            aria-live={t.type === 'error' ? 'assertive' : 'polite'}
             className="pointer-events-auto flex items-start gap-2 shadow-lg text-sm max-w-[calc(100vw-2rem)] sm:max-w-[520px] bg-port-card border border-port-border">
             {iconStr && <span className={`shrink-0 ${iconClass}`} aria-hidden="true">{iconStr}</span>}
             <div className="flex-1 min-w-0">

--- a/client/src/components/ui/Toast.test.jsx
+++ b/client/src/components/ui/Toast.test.jsx
@@ -15,20 +15,23 @@ describe('Toaster accessibility', () => {
     expect(region).toBeInTheDocument();
   });
 
-  it('announces a default toast politely (role="status")', () => {
+  it('announces a default toast politely (role="status") without a redundant aria-live', () => {
     render(<Toaster />);
     act(() => { toast('Saved'); });
     const status = screen.getByRole('status');
     expect(status).toHaveTextContent('Saved');
-    expect(status).toHaveAttribute('aria-live', 'polite');
+    // role="status" already implies aria-live="polite"; pairing both
+    // double-announces in iOS VoiceOver, so aria-live must be absent.
+    expect(status).not.toHaveAttribute('aria-live');
   });
 
-  it('announces an error toast assertively (role="alert")', () => {
+  it('announces an error toast assertively (role="alert") without a redundant aria-live', () => {
     render(<Toaster />);
     act(() => { toast.error('Boom'); });
     const alert = screen.getByRole('alert');
     expect(alert).toHaveTextContent('Boom');
-    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    // role="alert" already implies aria-live="assertive".
+    expect(alert).not.toHaveAttribute('aria-live');
   });
 
   it('hides the decorative status glyph from assistive tech', () => {

--- a/client/src/hooks/useFocusTrap.js
+++ b/client/src/hooks/useFocusTrap.js
@@ -16,11 +16,13 @@ import { useEffect, useRef } from 'react';
 // inner one. Modal owns the Esc stack separately (see ui/Modal.jsx); this hook
 // only concerns focus.
 
-// Visibility is intentionally NOT filtered by layout geometry
-// (offsetWidth/offsetParent) — those are always zero under jsdom, which would
-// make the trap untestable. The selector already drops disabled controls,
-// hidden inputs, and tabindex="-1"; that is sufficient for the modal surfaces
-// this hook guards.
+// The selector drops disabled controls, hidden inputs, and tabindex="-1". It
+// does NOT filter by layout geometry (offsetWidth/offsetParent) — those are
+// always zero under jsdom, which would make the trap untestable — but it MUST
+// still exclude CSS-hidden subtrees: a `display:none` panel (e.g. a retained
+// but inactive tab panel in a tabbed Drawer) still matches querySelectorAll,
+// so without this filter the trap's computed last element diverges from the
+// browser's real tab order and Tab fails to wrap, letting focus escape.
 const FOCUSABLE_SELECTOR = [
   'a[href]',
   'button:not([disabled])',
@@ -30,9 +32,27 @@ const FOCUSABLE_SELECTOR = [
   '[tabindex]:not([tabindex="-1"])',
 ].join(',');
 
+// Walk from the element up to (but not including) the container, treating it as
+// untabbable if it or any ancestor along the way is removed from rendering via
+// `display:none`, `visibility:hidden/collapse`, or the `hidden` attribute. Uses
+// computed style (reflects inline styles under jsdom and stylesheet rules in the
+// browser) rather than offset geometry so it works in both. The container itself
+// is the open dialog and assumed visible, so the walk stops there.
+function isTabbable(el, container) {
+  for (let node = el; node && node !== container; node = node.parentElement) {
+    if (node.nodeType !== 1) return false;
+    if (node.hasAttribute('hidden')) return false;
+    const style = typeof getComputedStyle === 'function' ? getComputedStyle(node) : null;
+    if (style && (style.display === 'none' || style.visibility === 'hidden' || style.visibility === 'collapse')) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function getFocusable(container) {
   if (!container) return [];
-  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR));
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter((el) => isTabbable(el, container));
 }
 
 export default function useFocusTrap(active, containerRef, { initialFocusRef } = {}) {


### PR DESCRIPTION
## Summary
- Toast: role="alert"/"status" already imply assertive/polite live-region semantics; pairing an explicit aria-live with the role double-announces in iOS VoiceOver, so drop it and update the test accordingly.
- useFocusTrap: the focusable-element query didn't exclude CSS `display:none`/`visibility:hidden`/`hidden` subtrees, so a retained-but-inactive tab panel (e.g. in a tabbed Drawer) could still match, letting the computed last element diverge from the real tab order and focus escape the modal. Walk ancestors with computed style to filter those out.

This was uncommitted follow-up work left in a CoS accessibility agent's worktree (branch `cos/sys-portos-d-accessibility-mregfku4/agent-240cf118`, whose prior commits already merged) that never got committed/pushed before the agent's session ended.

## Test plan
- [x] `npx vitest run src/components/ui/Toast.test.jsx src/hooks/useFocusTrap.test.js` — 11 passed