### PR TITLE
Filter Creative Director scene evaluation to vision models on local backends

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -24,6 +24,8 @@
 
 ## AI Providers
 
+- **Creative Director Scene evaluation pickers now list only vision-capable models on local Ollama / LM Studio.** When you pin the scene-evaluation stage (global AI Assignment or a project's Models drawer) to a local backend, text-only models drop out of the model dropdown and a text-only provider default is replaced by the first installed VLM — so you can't accidentally assign a chat model to a vision job. Cloud/API providers keep their full model lists (multimodal ids like `gpt-4o` don't encode "vision" in the name).
+
 - **Creative Director LLM stages are now independently configurable.** AI Assignments has separate provider/model rows for treatment generation, production planning, and scene evaluation. Point **Scene evaluation vision model** at a local Ollama or LM Studio vision model to judge rendered scenes without using the system-default agent; treatment and planning can likewise be pinned to any agent-capable CLI/TUI provider.
 
 - **Creative Director provider/model can now be overridden per project.** Each Creative Director project has a **Models** button (header of the project page, deep-linkable via `?models=1`) that opens a drawer to pin the treatment, production-plan, and scene-evaluation stages to a specific provider + model *for that project* — overriding the global AI Assignment. A stage left on **Inherit global** falls back to the global assignment (and then the system default), so the override is purely additive. The pin travels with the project record and federates to sync peers verbatim.

--- a/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
+++ b/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
@@ -5,7 +5,12 @@ import Drawer from '../Drawer.jsx';
 import toast from '../ui/Toast';
 import { getAiAssignments } from '../../services/api';
 import { updateCreativeDirectorProject } from '../../services/apiCreativeDirector.js';
-import { providerDisplayName, assignmentProviderOptions, assignmentModelOptions } from '../../utils/providers.js';
+import {
+  providerDisplayName,
+  assignmentProviderOptions,
+  assignmentModelOptions,
+  assignmentDefaultModel,
+} from '../../utils/providers.js';
 
 // Per-project AI model override drawer (per-project CD provider/model pins).
 // Lets the user pin the treatment / plan / evaluation stage to a specific
@@ -151,10 +156,14 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
                       aria-label={`${stage.label} provider`}
                       onChange={(e) => {
                         const providerId = e.target.value;
-                        const nextDefault = providers.find((p) => p.id === providerId)?.defaultModel || '';
+                        // Vision-filtered stages (scene evaluation) seed the first
+                        // eligible VLM when the provider's default is text-only.
+                        const nextDefault = providerId
+                          ? assignmentDefaultModel(entry, providers, providerId)
+                          : '';
                         // Seed the provider's default model on switch; clearing the
                         // provider (Inherit) clears the model too.
-                        setStage(stage.key, { providerId, model: providerId ? nextDefault : '' });
+                        setStage(stage.key, { providerId, model: nextDefault });
                       }}
                       className="bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white"
                     >

--- a/client/src/components/creative-director/CreativeDirectorModelsDrawer.test.jsx
+++ b/client/src/components/creative-director/CreativeDirectorModelsDrawer.test.jsx
@@ -14,11 +14,25 @@ const ASSIGNMENTS = {
   providers: [
     { id: 'agent-a', name: 'Agent A', type: 'cli', enabled: true, defaultModel: 'a-default', models: ['a-default', 'a-big'] },
     { id: 'vlm-x', name: 'VLM X', type: 'api', enabled: true, defaultModel: 'llava', models: ['llava', 'moondream'] },
+    {
+      id: 'ollama',
+      name: 'Ollama',
+      type: 'api',
+      enabled: true,
+      defaultModel: 'gemma4:26b',
+      models: ['qwen2.5vl:latest', 'llava:latest', 'gemma4:26b', 'llama3.2:latest'],
+    },
   ],
   assignments: [
     { id: 'settings.creativeDirector.treatment', providerTypes: ['cli', 'tui'], providerId: '', model: '' },
     { id: 'settings.creativeDirector.plan', providerTypes: ['cli', 'tui'], providerId: '', model: '' },
-    { id: 'settings.creativeDirector.evaluation', providerTypes: ['api'], providerId: '', model: '' },
+    {
+      id: 'settings.creativeDirector.evaluation',
+      providerTypes: ['api'],
+      providerId: '',
+      model: '',
+      modelFilter: 'vision',
+    },
   ],
 };
 
@@ -66,5 +80,23 @@ describe('CreativeDirectorModelsDrawer', () => {
     expect(screen.getByRole('button', { name: /Save/i }).disabled).toBe(true);
     fireEvent.change(screen.getByLabelText('Treatment provider'), { target: { value: 'agent-a' } });
     expect(screen.getByRole('button', { name: /Save/i }).disabled).toBe(false);
+  });
+
+  it('restricts Scene evaluation models to vision-capable ids for local Ollama', async () => {
+    renderDrawer({ id: 'cd-1', name: 'Demo', modelOverrides: {} });
+    await waitFor(() => expect(screen.getByLabelText('Scene evaluation provider')).toBeTruthy());
+
+    fireEvent.change(screen.getByLabelText('Scene evaluation provider'), { target: { value: 'ollama' } });
+
+    const modelSelect = screen.getByLabelText('Scene evaluation model');
+    const optionValues = Array.from(modelSelect.querySelectorAll('option')).map((o) => o.value);
+    // Empty "Provider default / auto" sentinel stays; text-only local models drop out.
+    expect(optionValues).toContain('');
+    expect(optionValues).toContain('qwen2.5vl:latest');
+    expect(optionValues).toContain('llava:latest');
+    expect(optionValues).not.toContain('gemma4:26b');
+    expect(optionValues).not.toContain('llama3.2:latest');
+    // Text-only default is replaced by the first eligible VLM.
+    expect(modelSelect.value).toBe('qwen2.5vl:latest');
   });
 });

--- a/client/src/components/settings/AiAssignmentsTab.jsx
+++ b/client/src/components/settings/AiAssignmentsTab.jsx
@@ -3,7 +3,12 @@ import { Link } from 'react-router-dom';
 import { ArrowRight, Bot, RefreshCw, Save, Search } from 'lucide-react';
 import toast from '../ui/Toast';
 import { getAiAssignments, updateAiAssignment } from '../../services/api';
-import { providerDisplayName, assignmentProviderOptions, assignmentModelOptions } from '../../utils/providers.js';
+import {
+  providerDisplayName,
+  assignmentProviderOptions,
+  assignmentModelOptions,
+  assignmentDefaultModel,
+} from '../../utils/providers.js';
 
 const getDraft = (entry) => ({
   providerId: entry.providerId || '',
@@ -124,8 +129,9 @@ export default function AiAssignmentsTab() {
     setBulkSaving(true);
     let latest = data;
     const savedIds = [];
-    const targetDefaultModel = data.providers.find((p) => p.id === toProvider)?.defaultModel || '';
     for (const entry of targets) {
+      // Vision-filtered rows seed the first eligible VLM, not a text-only default.
+      const targetDefaultModel = assignmentDefaultModel(entry, data.providers, toProvider);
       const nextModel = entry.modelEditable === false ? (drafts[entry.id]?.model || '') : targetDefaultModel;
       const next = await updateAiAssignment(entry.id, {
         providerId: toProvider,
@@ -266,7 +272,9 @@ export default function AiAssignmentsTab() {
                         value={draft.providerId}
                         onChange={(e) => {
                           const nextProviderId = e.target.value;
-                          const nextDefault = data.providers.find((p) => p.id === nextProviderId)?.defaultModel || '';
+                          // Vision-filtered rows (e.g. Scene evaluation) seed the
+                          // first eligible VLM when the provider default is text-only.
+                          const nextDefault = assignmentDefaultModel(entry, data.providers, nextProviderId);
                           setDraft(entry.id, { providerId: nextProviderId, model: entry.modelEditable === false ? draft.model : nextDefault });
                         }}
                         aria-label={`Provider for ${entry.label}`}

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -167,18 +167,28 @@ export const visionLocalModelFilter = (id, provider) =>
   localBackendForProvider(provider) ? isVisionModel(id) : true;
 
 /**
- * Classify a provider as a local-LLM backend by its endpoint/name, so callers
+ * Classify a provider as a local-LLM backend by its id/endpoint/name, so callers
  * can fold in live-installed models (Ollama/LM Studio) that aren't in the
  * provider's stored `models` list. Ollama's native + OpenAI-compat ports are
- * 11434; LM Studio defaults to 1234.
- * @param {{endpoint?:string,name?:string}} provider
+ * 11434; LM Studio defaults to 1234. The stable provider ids (`ollama` /
+ * `lmstudio`) are checked too — AI Assignments' curated provider payload
+ * omits `endpoint`, and a renamed display name would otherwise miss detection.
+ * @param {{id?:string,endpoint?:string,name?:string}} provider
  * @returns {'ollama'|'lmstudio'|null}
  */
 export const localBackendForProvider = (provider) => {
-  const endpoint = String(provider?.endpoint || '');
-  const name = String(provider?.name || '').toLowerCase();
-  if (/:11434\b/.test(endpoint) || name.includes('ollama')) return 'ollama';
-  if (/:1234\b/.test(endpoint) || name.includes('lm studio') || name.includes('lmstudio')) return 'lmstudio';
+  if (!provider) return null;
+  const id = String(provider.id || '').toLowerCase();
+  const endpoint = String(provider.endpoint || '');
+  const name = String(provider.name || '').toLowerCase();
+  if (id === 'ollama' || /:11434\b/.test(endpoint) || name.includes('ollama')) return 'ollama';
+  if (
+    id === 'lmstudio' ||
+    /:1234\b/.test(endpoint) ||
+    name.includes('lm studio') ||
+    name.includes('lmstudio') ||
+    /lm[\s-]?studio/i.test(name)
+  ) return 'lmstudio';
   return null;
 };
 
@@ -366,8 +376,41 @@ export const assignmentProviderOptions = (entry, providers) => {
  * Model-id options for an assignment entry given the selected provider — the
  * entry's pre-baked `modelOptions` when present, else the provider's own model
  * list (empty when the provider is unknown or has none).
+ *
+ * When `entry.modelFilter === 'vision'`, LOCAL backends (Ollama / LM Studio)
+ * are reduced to vision-capable models via `visionLocalModelFilter` so the
+ * Scene Evaluation (and other vision) pickers can't offer text-only ids.
+ * Cloud/API providers are left intact by that filter.
  */
 export const assignmentModelOptions = (entry, providers, providerId) => {
-  if (Array.isArray(entry?.modelOptions)) return entry.modelOptions;
-  return providers.find((p) => p.id === providerId)?.models || [];
+  const provider = providers.find((p) => p.id === providerId);
+  const raw = Array.isArray(entry?.modelOptions)
+    ? entry.modelOptions
+    : (provider?.models || []);
+  // Normalize object-shaped entries (`{ id }`) so both baked and live lists
+  // yield plain string options for the <select>.
+  const models = raw
+    .map((m) => (typeof m === 'string' ? m : m?.id))
+    .filter(Boolean);
+  if (entry?.modelFilter === 'vision') {
+    return models.filter((id) => visionLocalModelFilter(id, provider));
+  }
+  return models;
+};
+
+/**
+ * Default model to seed when the user picks a provider for an assignment.
+ * For vision-filtered entries, only returns a model that still appears in the
+ * filtered options — a local backend's text-only `defaultModel` must not be
+ * seeded into the Scene Evaluation picker.
+ */
+export const assignmentDefaultModel = (entry, providers, providerId) => {
+  if (!providerId) return '';
+  const provider = providers.find((p) => p.id === providerId);
+  if (!provider) return '';
+  const def = provider.defaultModel || '';
+  if (entry?.modelFilter !== 'vision') return def;
+  const models = assignmentModelOptions(entry, providers, providerId);
+  if (def && models.includes(def)) return def;
+  return models[0] || '';
 };

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -6,6 +6,7 @@ import {
   providerDisplayName,
   assignmentProviderOptions,
   assignmentModelOptions,
+  assignmentDefaultModel,
   PROVIDER_TYPES,
   filterSelectableModels,
   filterGenerationModels,
@@ -290,14 +291,17 @@ describe('toolUseLocalModelFilter', () => {
 });
 
 describe('localBackendForProvider', () => {
-  it('detects Ollama by endpoint or name', () => {
+  it('detects Ollama by id, endpoint, or name', () => {
+    expect(localBackendForProvider({ id: 'ollama' })).toBe('ollama');
     expect(localBackendForProvider({ endpoint: 'http://localhost:11434/v1' })).toBe('ollama');
     expect(localBackendForProvider({ name: 'Ollama' })).toBe('ollama');
   });
 
-  it('detects LM Studio by endpoint or name', () => {
+  it('detects LM Studio by id, endpoint, or name', () => {
+    expect(localBackendForProvider({ id: 'lmstudio' })).toBe('lmstudio');
     expect(localBackendForProvider({ endpoint: 'http://localhost:1234/v1' })).toBe('lmstudio');
     expect(localBackendForProvider({ name: 'LM Studio' })).toBe('lmstudio');
+    expect(localBackendForProvider({ name: 'lm-studio' })).toBe('lmstudio');
   });
 
   it('returns null for cloud providers', () => {
@@ -415,6 +419,22 @@ describe('AI Assignments option helpers', () => {
   const providers = [
     { id: 'agent-a', name: 'Agent A', type: 'cli', enabled: true, models: ['a-1', 'a-2'] },
     { id: 'vlm-x', name: 'VLM X', type: 'api', enabled: false, models: ['llava'] },
+    {
+      id: 'ollama',
+      name: 'Ollama',
+      type: 'api',
+      enabled: true,
+      defaultModel: 'gemma4:26b',
+      models: ['qwen2.5vl:latest', 'llava:latest', 'gemma4:26b', 'llama3.2:latest', 'nomic-embed-text'],
+    },
+    {
+      id: 'openai',
+      name: 'OpenAI',
+      type: 'api',
+      enabled: true,
+      defaultModel: 'gpt-4o',
+      models: ['gpt-4o', 'gpt-4.1', 'o3-mini'],
+    },
   ];
 
   it('providerDisplayName resolves name, then id, then fallback', () => {
@@ -426,9 +446,14 @@ describe('AI Assignments option helpers', () => {
 
   it('assignmentProviderOptions filters by providerTypes and flags disabled', () => {
     expect(assignmentProviderOptions({ providerTypes: ['api'] }, providers))
-      .toEqual([{ id: 'vlm-x', name: 'VLM X (disabled)' }]);
+      .toEqual([
+        { id: 'vlm-x', name: 'VLM X (disabled)' },
+        { id: 'ollama', name: 'Ollama' },
+        { id: 'openai', name: 'OpenAI' },
+      ]);
     // No providerTypes → all providers.
-    expect(assignmentProviderOptions({}, providers).map((p) => p.id)).toEqual(['agent-a', 'vlm-x']);
+    expect(assignmentProviderOptions({}, providers).map((p) => p.id))
+      .toEqual(['agent-a', 'vlm-x', 'ollama', 'openai']);
   });
 
   it('assignmentProviderOptions honors a pre-baked providerOptions override', () => {
@@ -440,6 +465,29 @@ describe('AI Assignments option helpers', () => {
     expect(assignmentModelOptions({}, providers, 'agent-a')).toEqual(['a-1', 'a-2']);
     expect(assignmentModelOptions({}, providers, 'ghost')).toEqual([]);
     const baked = ['m'];
-    expect(assignmentModelOptions({ modelOptions: baked }, providers, 'agent-a')).toBe(baked);
+    expect(assignmentModelOptions({ modelOptions: baked }, providers, 'agent-a')).toEqual(baked);
+  });
+
+  it('assignmentModelOptions with modelFilter=vision keeps only VLMs on local backends', () => {
+    expect(assignmentModelOptions({ modelFilter: 'vision' }, providers, 'ollama'))
+      .toEqual(['qwen2.5vl:latest', 'llava:latest']);
+  });
+
+  it('assignmentModelOptions with modelFilter=vision leaves cloud model lists intact', () => {
+    // gpt-4o is multimodal but its id does not encode "vision" — the local
+    // heuristic must not hide cloud multimodal models.
+    expect(assignmentModelOptions({ modelFilter: 'vision' }, providers, 'openai'))
+      .toEqual(['gpt-4o', 'gpt-4.1', 'o3-mini']);
+  });
+
+  it('assignmentDefaultModel seeds the first VLM when the local default is text-only', () => {
+    expect(assignmentDefaultModel({ modelFilter: 'vision' }, providers, 'ollama'))
+      .toBe('qwen2.5vl:latest');
+    // Cloud: default stays (and is in the unfiltered list).
+    expect(assignmentDefaultModel({ modelFilter: 'vision' }, providers, 'openai'))
+      .toBe('gpt-4o');
+    // Non-vision rows still seed the provider default.
+    expect(assignmentDefaultModel({}, providers, 'ollama')).toBe('gemma4:26b');
+    expect(assignmentDefaultModel({}, providers, '')).toBe('');
   });
 });

--- a/server/services/aiAssignments.js
+++ b/server/services/aiAssignments.js
@@ -48,6 +48,10 @@ const makeEntry = ({
   providerTypes = textProviderTypes,
   providerOptions = null,
   modelOptions = null,
+  // Optional client-side model-list filter key. `'vision'` tells the AI
+  // Assignments / Creative Director pickers to restrict LOCAL backends
+  // (Ollama / LM Studio) to vision-capable models only.
+  modelFilter = null,
   link = null,
   notes = '',
 }) => ({
@@ -64,6 +68,7 @@ const makeEntry = ({
   providerTypes,
   providerOptions,
   modelOptions,
+  modelFilter,
   link,
   notes,
 });
@@ -189,6 +194,9 @@ const addSettingsEntries = async (entries) => {
     providerId: settings.creativeDirector?.evaluation?.providerId || null,
     model: settings.creativeDirector?.evaluation?.model || null,
     providerTypes: apiProviderTypes,
+    // Scene evaluation is a vision call — restrict local Ollama/LM Studio
+    // model pickers to VLMs so a text-only default can't be selected by mistake.
+    modelFilter: 'vision',
     notes: 'Vision model that judges each rendered scene. Use a local Ollama or LM Studio VLM here. Blank = auto-pick an installed local vision model; if none is available it falls back to the coding agent. Each Creative Director project can override this from its Models drawer.',
     link: '/creative-director',
   }));

--- a/server/services/aiAssignments.test.js
+++ b/server/services/aiAssignments.test.js
@@ -113,6 +113,9 @@ describe('getAiAssignments', () => {
     expect(ids).toContain('settings.creativeDirector.plan');
     expect(ids).toContain('settings.creativeDirector.evaluation');
     expect(ids).toContain('cos.task.morning-brief');
+    // Scene evaluation is a vision call — clients filter local model lists to VLMs.
+    const evaluation = result.assignments.find((a) => a.id === 'settings.creativeDirector.evaluation');
+    expect(evaluation.modelFilter).toBe('vision');
   });
 });
 


### PR DESCRIPTION
## Summary

When Creative Director **Scene evaluation** is pinned to a local Ollama or LM Studio provider, the model picker no longer lists text-only models. Only vision-capable (VLM) ids are offered, and a text-only provider default is replaced by the first eligible vision model.

This applies in both:
- **Settings → AI Assignments** (global `settings.creativeDirector.evaluation`)
- **Creative Director project → Models drawer** (per-project evaluation override)

Cloud/API providers keep their full model lists so multimodal ids that don’t encode “vision” in the name (e.g. `gpt-4o`) are not hidden.

## Test plan

- [x] `client`: `providers.test.js` + `CreativeDirectorModelsDrawer.test.jsx`
- [x] `server`: `aiAssignments.test.js`
- [ ] Manually: AI Assignments → Scene evaluation → pick Ollama → confirm only VLMs appear and default isn’t a text model
- [ ] Manually: CD project Models drawer → Scene evaluation → same for Ollama / LM Studio
- [ ] Manually: pick a cloud API provider → full model list still available