### PR TITLE
drop redundant Target App line for the PortOS default app in agent prompts

### DIFF
--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -728,15 +728,8 @@ ${task.metadata.jiraBranch ? 'Commit your changes to this branch. Do NOT switch 
   // predates the {{reviewLoopFollowUpSection}} placeholder; the built-in
   // fallback is the source of truth for that section, and silently dropping
   // it would leave the agent with no instructions and the loop would not run.
-  // The template renders `### Target Application` from `task.metadata.app`. Drop
-  // the app for the PortOS default so that section stays empty — the api agent
-  // already runs in the PortOS directory, matching buildTaskBlock's behavior for
-  // the light/fallback paths. Managed-app tasks keep the scoping line.
-  const templateTask = task.metadata?.app === PORTOS_APP_ID
-    ? { ...task, metadata: { ...task.metadata, app: undefined } }
-    : task;
   const promptData = isReviewLoopFollowUp ? null : await buildPrompt('cos-agent-briefing', {
-    task: templateTask,
+    task,
     config,
     memorySection,
     claudeMdSection,

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -22,6 +22,7 @@ import { isOpencodeCommand } from '../lib/providerModels.js';
 import { shellQuote } from '../lib/shellQuote.js';
 import * as jiraService from './jira.js';
 import { emitLog } from './cosEvents.js';
+import { PORTOS_APP_ID } from './apps.js';
 
 const ROOT_DIR = PATHS.root;
 const AGENTS_DIR = PATHS.cosAgents;
@@ -213,7 +214,11 @@ function renderFileListField(header, items, formatItem, formatInline, asList) {
  */
 export function buildTaskBlock(task, { screenshotsAsList = false } = {}) {
   const description = task.description;
-  const targetApp = task.metadata?.app ? `**Target App**: ${task.metadata.app}` : '';
+  // Only surface **Target App** for MANAGED apps — it scopes cross-repo work the
+  // agent's cwd wouldn't otherwise reveal. For the PortOS default app the agent
+  // already runs in the PortOS directory, so the line is redundant noise.
+  const app = task.metadata?.app;
+  const targetApp = app && app !== PORTOS_APP_ID ? `**Target App**: ${app}` : '';
   const screenshots = renderFileListField(
     'Screenshots', task.metadata?.screenshots,
     (s) => `\`${s}\``, (s) => s, screenshotsAsList
@@ -723,8 +728,15 @@ ${task.metadata.jiraBranch ? 'Commit your changes to this branch. Do NOT switch 
   // predates the {{reviewLoopFollowUpSection}} placeholder; the built-in
   // fallback is the source of truth for that section, and silently dropping
   // it would leave the agent with no instructions and the loop would not run.
+  // The template renders `### Target Application` from `task.metadata.app`. Drop
+  // the app for the PortOS default so that section stays empty — the api agent
+  // already runs in the PortOS directory, matching buildTaskBlock's behavior for
+  // the light/fallback paths. Managed-app tasks keep the scoping line.
+  const templateTask = task.metadata?.app === PORTOS_APP_ID
+    ? { ...task, metadata: { ...task.metadata, app: undefined } }
+    : task;
   const promptData = isReviewLoopFollowUp ? null : await buildPrompt('cos-agent-briefing', {
-    task,
+    task: templateTask,
     config,
     memorySection,
     claudeMdSection,
@@ -896,8 +908,10 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
 
   // --- Task block --------------------------------------------------------
   // cwd is set by the spawner and the agent knows its own id from the
-  // runner, so the prompt skips that metadata. Target app is kept because
-  // it scopes managed-app work. Shared with the full path via buildTaskBlock.
+  // runner, so the prompt skips that metadata. Target app is kept only for
+  // MANAGED apps because it scopes cross-repo work; the PortOS default app is
+  // suppressed in buildTaskBlock since cwd already reveals it. Shared with the
+  // full path via buildTaskBlock.
   const taskBlock = buildTaskBlock(task, { screenshotsAsList: true });
   sections.push(taskBlock.description);
   if (taskBlock.targetApp) sections.push(taskBlock.targetApp);

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -56,6 +56,7 @@ tryReadFile: vi.fn().mockResolvedValue(null),
 }));
 
 import { buildLightContextPrompt, buildAgentPrompt, buildCompletionGuidelineBullet } from './agentPromptBuilder.js';
+import { buildPrompt } from './promptService.js';
 import { isTruthyMeta } from './agentState.js';
 
 function makeTask(overrides = {}) {
@@ -673,6 +674,31 @@ describe('buildAgentPrompt — provider type routing', () => {
     expect(prompt).not.toMatch(/You are an autonomous agent/);
     // Light + non-TUI uses the plain "## Completion" block.
     expect(prompt).toMatch(/^## Completion$/m);
+  });
+
+  // The api/full path renders "### Target Application" from the cos-agent-briefing
+  // template's {{#task.metadata.app}} section, so the app is suppressed by stripping
+  // it from the task handed to buildPrompt (rather than by buildTaskBlock). Assert on
+  // the mocked buildPrompt's call args since the template render itself is mocked out.
+  describe('api-path Target Application suppression', () => {
+    const apiOpts = { providerType: 'api' };
+    const wt = { branchName: 'b', worktreePath: '/tmp/wt' };
+
+    it('strips the PortOS default app from the template task so its section stays empty', async () => {
+      buildPrompt.mockClear();
+      await buildAgentPrompt(
+        makeTask({ metadata: { app: 'portos-default' } }), {}, '/r', wt, isTruthyMeta, apiOpts);
+      const briefing = buildPrompt.mock.calls.find(([name]) => name === 'cos-agent-briefing');
+      expect(briefing?.[1]?.task?.metadata?.app).toBeUndefined();
+    });
+
+    it('keeps a managed app on the template task so it scopes the work', async () => {
+      buildPrompt.mockClear();
+      await buildAgentPrompt(
+        makeTask({ metadata: { app: 'comics' } }), {}, '/r', wt, isTruthyMeta, apiOpts);
+      const briefing = buildPrompt.mock.calls.find(([name]) => name === 'cos-agent-briefing');
+      expect(briefing?.[1]?.task?.metadata?.app).toBe('comics');
+    });
   });
 
   describe('split system/user prompt (Claude providers)', () => {

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -56,7 +56,6 @@ tryReadFile: vi.fn().mockResolvedValue(null),
 }));
 
 import { buildLightContextPrompt, buildAgentPrompt, buildCompletionGuidelineBullet } from './agentPromptBuilder.js';
-import { buildPrompt } from './promptService.js';
 import { isTruthyMeta } from './agentState.js';
 
 function makeTask(overrides = {}) {
@@ -674,31 +673,6 @@ describe('buildAgentPrompt — provider type routing', () => {
     expect(prompt).not.toMatch(/You are an autonomous agent/);
     // Light + non-TUI uses the plain "## Completion" block.
     expect(prompt).toMatch(/^## Completion$/m);
-  });
-
-  // The api/full path renders "### Target Application" from the cos-agent-briefing
-  // template's {{#task.metadata.app}} section, so the app is suppressed by stripping
-  // it from the task handed to buildPrompt (rather than by buildTaskBlock). Assert on
-  // the mocked buildPrompt's call args since the template render itself is mocked out.
-  describe('api-path Target Application suppression', () => {
-    const apiOpts = { providerType: 'api' };
-    const wt = { branchName: 'b', worktreePath: '/tmp/wt' };
-
-    it('strips the PortOS default app from the template task so its section stays empty', async () => {
-      buildPrompt.mockClear();
-      await buildAgentPrompt(
-        makeTask({ metadata: { app: 'portos-default' } }), {}, '/r', wt, isTruthyMeta, apiOpts);
-      const briefing = buildPrompt.mock.calls.find(([name]) => name === 'cos-agent-briefing');
-      expect(briefing?.[1]?.task?.metadata?.app).toBeUndefined();
-    });
-
-    it('keeps a managed app on the template task so it scopes the work', async () => {
-      buildPrompt.mockClear();
-      await buildAgentPrompt(
-        makeTask({ metadata: { app: 'comics' } }), {}, '/r', wt, isTruthyMeta, apiOpts);
-      const briefing = buildPrompt.mock.calls.find(([name]) => name === 'cos-agent-briefing');
-      expect(briefing?.[1]?.task?.metadata?.app).toBe('comics');
-    });
   });
 
   describe('split system/user prompt (Claude providers)', () => {

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -110,11 +110,18 @@ describe('buildLightContextPrompt', () => {
       expect(prompt).not.toMatch(/\*\*Working Directory\*\*:/);
     });
 
-    it('shows Target App when set', () => {
+    it('shows Target App for a managed app', () => {
       const prompt = buildLightContextPrompt(
         makeTask({ metadata: { app: 'comics' } }),
         '/r', null, isTruthyMeta);
       expect(prompt).toMatch(/\*\*Target App\*\*: comics/);
+    });
+
+    it('omits Target App for the PortOS default app (cwd already scopes it)', () => {
+      const prompt = buildLightContextPrompt(
+        makeTask({ metadata: { app: 'portos-default' } }),
+        '/r', null, isTruthyMeta);
+      expect(prompt).not.toMatch(/\*\*Target App\*\*/);
     });
 
     it('renders attached context (multiline and single-line)', () => {


### PR DESCRIPTION
## Summary

Scheduled / CoS agent prompts appended `**Target App**: portos-default` to the
briefing whenever `task.metadata.app` was set. For **managed** apps that line
usefully scopes cross-repo work the agent's cwd wouldn't otherwise reveal, but
for the **PortOS default app** the agent already runs in the PortOS directory —
so the line was redundant noise (e.g. the Layered Intelligence task showed
`**Target App**: portos-default` at the end of its prompt).

`buildTaskBlock` — the shared chokepoint feeding both the light prompt path
(TUI/CLI agents) and the full-path fallback template — now emits the `Target App`
line only for non-default apps. Managed-app tasks are unchanged.

The api-prompt path renders the briefing from the editable `cos-agent-briefing`
stage template, whose `### Target Application` heading still prints for a
default-app task. Suppressing that cleanly (without changing the template's
`{{task.metadata.app}}` input semantics for customized templates) needs a
stage-template migration, deferred to #2430.

## Test plan

- `server/services/agentPromptBuilder.test.js` — new coverage: the light path
  shows `**Target App**` for a managed app (`comics`) and omits it for
  `portos-default`.
- Ran the builder suite plus the two other suites that import it
  (`taskSchedule`, `agentWorkspacePrep`) — 174 tests green. Confirmed the new
  `PORTOS_APP_ID` import introduces no circular-import or mocked-suite breakage.
- Reviewed by claude (clean), ollama (clean), and codex (flagged the api-path
  template-semantics concern, addressed by reverting the template-context hack;
  re-review clean).