### PR TITLE
feat(shell): trim quick-command buttons, rename antigravity→agy, add grok

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Changes
+
+- **Shell page quick-command buttons trimmed to the interactive tools.** Dropped the four shell one-liner shortcuts (`git status`, `git pull`, `npm test`, `npm run dev`) that duplicated things you'd just type, renamed the `antigravity` button to its actual command `agy`, and added a `grok` button alongside the other coding-agent launchers.
+
 ## Fixes
 
 - **HuggingFace model downloads (Flux and every other image/video/music pull) now log to the server console.** Triggering a base-model download showed a progress bar in the UI but left no trace in the server log — the entire download path emitted progress *only* over the SSE stream to the browser, and PortOS has no HTTP access logger, so a headless/PM2 log had no record the multi-GB fetch ever ran. The shared SSE driver (`server/lib/sseDownload.js#startHfDownloadStream`, the single chokepoint behind the image, video, and music download endpoints) now writes single-line, emoji-prefixed log lines for the start of each repo pull (`⬇️`, with a forced-re-fetch marker), each file as it streams, a cache hit that skips the download (`📦`), the outcome (`✅` complete with byte count / `❌` failed with the error message), and client-disconnect cancellation (`🛑`) — while cancelled results are deliberately not logged as failures.

--- a/client/src/pages/Shell.jsx
+++ b/client/src/pages/Shell.jsx
@@ -19,12 +19,9 @@ const MAX_SESSIONS = 20;
 const QUICK_COMMANDS = [
   { label: 'claude', command: 'claude --dangerously-skip-permissions' },
   { label: 'codex', command: 'codex --dangerously-bypass-approvals-and-sandbox' },
-  { label: 'antigravity', command: 'agy' },
+  { label: 'agy', command: 'agy' },
+  { label: 'grok', command: 'grok' },
   { label: 'openclaw', command: 'openclaw tui' },
-  { label: 'git status', command: 'git status' },
-  { label: 'git pull', command: 'git pull --rebase --autostash' },
-  { label: 'npm test', command: 'npm test' },
-  { label: 'npm run dev', command: 'npm run dev' },
   // Claude Code slash-command shortcuts — typed + submitted into an interactive
   // `claude` session. The flags are double-dash (`--`); keep them verbatim.
   { label: '/do:next', command: '/do:next --issues --self --review-with=claude,codex --merge' },


### PR DESCRIPTION
## Summary
Tidies the Shell page's inline quick-command toolbar (`QUICK_COMMANDS` in `client/src/pages/Shell.jsx`):

- **Removed** the four shell one-liner shortcuts — `git status`, `git pull`, `npm test`, `npm run dev` — that just duplicated things you'd type directly.
- **Renamed** the `antigravity` button to `agy`, its actual command, so the label matches what runs.
- **Added** a `grok` launcher alongside the other coding-agent buttons (`claude`, `codex`, `agy`, `openclaw`).

`grok` is already a recognized provider command elsewhere (`client/src/utils/providers.js`, `AIProviders.jsx`), so the new button is consistent with the existing launchers.

## Testing
- The `QUICK_COMMANDS` array renders generically (`.map(({ label, command }) => …)`, `key={label}`); nothing indexes it by position, and the removed labels are not referenced anywhere else in `client/src`. No test asserts on the array contents.
- Local claude review pass: clean, no findings.

https://claude.ai/code/session_01CYY9QFrZKKFDBvjp6Sij3G