### PR TITLE
Don't re-request an HF token for MuScriptor gating when one already exists

### DIFF
--- a/client/src/components/install/MidiGatedModal.jsx
+++ b/client/src/components/install/MidiGatedModal.jsx
@@ -1,19 +1,65 @@
 /**
  * Gated-repo gate for MuScriptor (audio → MIDI) transcription. MuScriptor's
  * model weights live in a gated HuggingFace repo (MuScriptor/muscriptor-*), so
- * a first transcribe with no accepted license / token 403s. useMidiTranscription
- * opens this when the job streams a `gated_repo` error frame — the user accepts
- * the license and pastes a read token (reusing HfTokenBanner, the same
- * paste-and-save flow the gated image models use), then `onSaved` re-runs the
- * captured transcription.
+ * a first transcribe 403s until the user has BOTH accepted the model license
+ * AND provided a HuggingFace token. useMidiTranscription opens this when the job
+ * streams a `gated_repo` error frame, then `onSaved` re-runs the captured
+ * transcription.
+ *
+ * Two distinct causes reach this modal, so we branch on whether a token is
+ * already configured (GET /image-gen/setup/hf-token-status):
+ *   - No token → the user still needs to create + paste one (reuse HfTokenBanner,
+ *     the same paste-and-save flow the gated image models use).
+ *   - Token present → the token is fine; the 403 means the model license hasn't
+ *     been accepted yet. Don't nag for a second token — just deep-link the
+ *     license page and offer a Retry (with an escape hatch to replace the token
+ *     in case the stored one is stale).
  */
 
-import { KeyRound } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { KeyRound, Loader2, RotateCw } from 'lucide-react';
 import Modal from '../ui/Modal';
 import HfTokenBanner from '../imageGen/HfTokenBanner';
+import { getHfTokenStatus } from '../../services/api';
+
+const SOURCE_LABEL = {
+  stored: 'stored in settings',
+  env: 'from the HF_TOKEN environment variable',
+  cli: 'from `hf auth login`',
+};
 
 export default function MidiGatedModal({ open, repo, onSaved, onClose }) {
   const licenseUrl = repo ? `https://huggingface.co/${repo}` : 'https://huggingface.co';
+  const licenseLinkText = licenseUrl.replace(/^https?:\/\//, '');
+
+  // null = still checking; then { hfTokenPresent, source }. Re-checked each time
+  // the modal opens so a token saved on a prior pass is reflected.
+  const [tokenStatus, setTokenStatus] = useState(null);
+  // Escape hatch: when a token IS present but the license-accept + retry still
+  // 403s, the stored token may be invalid — let the user drop to the paste form.
+  const [forceTokenEntry, setForceTokenEntry] = useState(false);
+
+  useEffect(() => {
+    if (!open) {
+      setTokenStatus(null);
+      setForceTokenEntry(false);
+      return;
+    }
+    let cancelled = false;
+    getHfTokenStatus()
+      .then((s) => { if (!cancelled) setTokenStatus({ hfTokenPresent: !!s?.hfTokenPresent, source: s?.source || 'none' }); })
+      .catch(() => { if (!cancelled) setTokenStatus({ hfTokenPresent: false, source: 'none' }); });
+    return () => { cancelled = true; };
+  }, [open]);
+
+  const checking = tokenStatus === null;
+  const hasToken = !!tokenStatus?.hfTokenPresent;
+  // Show the license-only view when a token is already configured and the user
+  // hasn't explicitly asked to replace it.
+  const licenseOnly = hasToken && !forceTokenEntry;
+
+  const title = licenseOnly ? 'Accept the model license' : 'HuggingFace access required';
+
   return (
     <Modal
       open={open}
@@ -28,15 +74,51 @@ export default function MidiGatedModal({ open, repo, onSaved, onClose }) {
       <div className="flex items-center gap-2.5 px-5 py-4 border-b border-port-border">
         <KeyRound size={18} className="text-port-warning" />
         <h2 id="midi-gated-title" className="text-sm font-semibold text-white">
-          HuggingFace access required
+          {title}
         </h2>
       </div>
       <div className="px-5 py-4">
-        <HfTokenBanner
-          modelLabel={repo || 'MuScriptor'}
-          licenseUrl={licenseUrl}
-          onSaved={onSaved}
-        />
+        {checking ? (
+          <div className="flex items-center gap-2 text-xs text-gray-400">
+            <Loader2 size={14} className="animate-spin" />
+            Checking HuggingFace access…
+          </div>
+        ) : licenseOnly ? (
+          <div className="rounded-lg border border-port-warning/40 bg-port-warning/10 px-3 py-3 text-xs text-port-warning space-y-3">
+            <div>
+              Your HuggingFace token is already configured
+              {SOURCE_LABEL[tokenStatus.source] ? ` (${SOURCE_LABEL[tokenStatus.source]})` : ''} — but you
+              haven&apos;t accepted the license for{' '}
+              <a href={licenseUrl} target="_blank" rel="noreferrer" className="underline text-white">
+                {licenseLinkText}
+              </a>{' '}
+              yet. Open that page, agree to share your info with the model owner, then retry.
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={onSaved}
+                className="inline-flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-accent text-white text-xs font-medium hover:bg-port-accent/80"
+              >
+                <RotateCw size={14} />
+                Retry transcription
+              </button>
+              <button
+                type="button"
+                onClick={() => setForceTokenEntry(true)}
+                className="text-xs underline text-gray-400 hover:text-white"
+              >
+                Use a different token
+              </button>
+            </div>
+          </div>
+        ) : (
+          <HfTokenBanner
+            modelLabel={repo || 'MuScriptor'}
+            licenseUrl={licenseUrl}
+            onSaved={onSaved}
+          />
+        )}
       </div>
     </Modal>
   );

--- a/client/src/components/install/MidiGatedModal.test.jsx
+++ b/client/src/components/install/MidiGatedModal.test.jsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+vi.mock('../../services/api', () => ({
+  getHfTokenStatus: vi.fn(),
+}));
+vi.mock('../ui/Toast', () => ({
+  default: Object.assign(vi.fn(), {
+    success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn(),
+  }),
+}));
+
+import { getHfTokenStatus } from '../../services/api';
+import MidiGatedModal from './MidiGatedModal';
+
+const REPO = 'MuScriptor/muscriptor-medium';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('MidiGatedModal token-aware branching', () => {
+  it('shows the license-only view (no token entry) when a token is already configured', async () => {
+    getHfTokenStatus.mockResolvedValue({ hfTokenPresent: true, source: 'stored' });
+    const onSaved = vi.fn();
+    render(<MidiGatedModal open repo={REPO} onSaved={onSaved} onClose={vi.fn()} />);
+
+    // Resolves to the license-accept branch.
+    await waitFor(() => expect(screen.getByText('Accept the model license')).toBeTruthy());
+    // Explains the token is already present and does NOT nag for a new one.
+    expect(screen.getByText(/token is already configured/i)).toBeTruthy();
+    expect(screen.queryByPlaceholderText('hf_…')).toBeNull();
+
+    // Retry re-fires the captured transcription.
+    fireEvent.click(screen.getByText('Retry transcription'));
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it('lets the user drop to token entry when the stored token might be stale', async () => {
+    getHfTokenStatus.mockResolvedValue({ hfTokenPresent: true, source: 'env' });
+    render(<MidiGatedModal open repo={REPO} onSaved={vi.fn()} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('Accept the model license')).toBeTruthy());
+    fireEvent.click(screen.getByText('Use a different token'));
+    // Now the paste form (HfTokenBanner) is visible.
+    expect(screen.getByPlaceholderText('hf_…')).toBeTruthy();
+  });
+
+  it('shows the token-entry banner when no token is configured', async () => {
+    getHfTokenStatus.mockResolvedValue({ hfTokenPresent: false, source: 'none' });
+    render(<MidiGatedModal open repo={REPO} onSaved={vi.fn()} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('HuggingFace access required')).toBeTruthy());
+    expect(screen.getByPlaceholderText('hf_…')).toBeTruthy();
+  });
+
+  it('falls back to the token-entry banner if the status check fails', async () => {
+    getHfTokenStatus.mockRejectedValue(new Error('offline'));
+    render(<MidiGatedModal open repo={REPO} onSaved={vi.fn()} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText('HuggingFace access required')).toBeTruthy());
+    expect(screen.getByPlaceholderText('hf_…')).toBeTruthy();
+  });
+});

--- a/client/src/components/install/MidiGatedModal.test.jsx
+++ b/client/src/components/install/MidiGatedModal.test.jsx
@@ -61,4 +61,24 @@ describe('MidiGatedModal token-aware branching', () => {
     await waitFor(() => expect(screen.getByText('HuggingFace access required')).toBeTruthy());
     expect(screen.getByPlaceholderText('hf_…')).toBeTruthy();
   });
+
+  it('re-checks token status on each reopen so a token saved on a prior pass flips the view', async () => {
+    // First open: no token → token-entry banner.
+    getHfTokenStatus.mockResolvedValueOnce({ hfTokenPresent: false, source: 'none' });
+    const { rerender } = render(
+      <MidiGatedModal open repo={REPO} onSaved={vi.fn()} onClose={vi.fn()} />,
+    );
+    await waitFor(() => expect(screen.getByPlaceholderText('hf_…')).toBeTruthy());
+
+    // Modal closes (e.g. token saved, transcription re-fires), then the license
+    // 403 reopens it — the status must be re-fetched, not reused from pass one.
+    rerender(<MidiGatedModal open={false} repo={REPO} onSaved={vi.fn()} onClose={vi.fn()} />);
+    getHfTokenStatus.mockResolvedValueOnce({ hfTokenPresent: true, source: 'stored' });
+    rerender(<MidiGatedModal open repo={REPO} onSaved={vi.fn()} onClose={vi.fn()} />);
+
+    // View flips to the license-accept branch — no stale "token missing" nag.
+    await waitFor(() => expect(screen.getByText('Accept the model license')).toBeTruthy());
+    expect(screen.queryByPlaceholderText('hf_…')).toBeNull();
+    expect(getHfTokenStatus).toHaveBeenCalledTimes(2);
+  });
 });


### PR DESCRIPTION
## Summary

When extracting MIDI from an audio file on the Music Videos page, the gated-repo modal always told the user to *create and paste a new HuggingFace token* — even when a valid token was already configured. MuScriptor's weights live in a gated HF repo, so a first transcribe 403s until **both** the model license is accepted **and** a token is present. When a token already exists, the real missing step is accepting the license (agreeing to share your info with the model owner), not adding another token.

`MidiGatedModal` now checks `GET /image-gen/setup/hf-token-status` when it opens:

- **Token already configured** → shows an "Accept the model license" view that names where the token came from (settings / `HF_TOKEN` env / `hf auth login`), deep-links the license page, and offers **Retry transcription**. A "Use a different token" link is an escape hatch if the stored token is stale.
- **No token, or the status check fails** → falls back to the existing token-entry banner (`HfTokenBanner`), unchanged.

The status is re-fetched on every reopen, so a token saved on a prior pass flips the view without a stale "token missing" nag. Public props are unchanged, so the existing `ReferenceAnalysis.jsx` usage is unaffected.

## Test plan

- `client/src/components/install/MidiGatedModal.test.jsx` (new) covers all branches: token present → license view (no token input, Retry fires `onSaved`), the "use a different token" escape hatch, no token → banner, status-check failure → banner, and a close→reopen transition asserting the status is re-fetched and the view flips.
- `cd client && npx vitest run src/components/install/MidiGatedModal.test.jsx` → 5 passing.