### PR TITLE
refactor: drop redundant symbol field from Elements Song study results

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased Changes
+
+## Changed
+
+- **Elements Song study mode drops a redundant result field.** The Flash Cards study results tracked both `element` and `symbol` on each record even though they hold identical values; the review UI now reads the single `element` field, removing the duplicate.

--- a/client/src/components/meatspace/post/ElementsSong.jsx
+++ b/client/src/components/meatspace/post/ElementsSong.jsx
@@ -603,7 +603,7 @@ function ElementStudyMode({ item, mastery, onBack, onComplete }) {
             <div className="grid grid-cols-2 gap-2">
               {results.filter(r => !r.correct).map((r, i) => (
                 <div key={i} className="text-xs bg-port-bg rounded p-2">
-                  <span className="text-port-warning font-mono">{r.symbol}</span>
+                  <span className="text-port-warning font-mono">{r.element}</span>
                   <span className="text-gray-500 mx-1">&rarr;</span>
                   <span className="text-gray-300">{r.name}</span>
                 </div>
@@ -632,7 +632,7 @@ function ElementStudyMode({ item, mastery, onBack, onComplete }) {
   const frontLabel = card.showSymbolFront ? 'What element?' : 'What symbol?';
 
   function rate(known) {
-    setResults(prev => [...prev, { correct: known, element: card.symbol, symbol: card.symbol, name: info.name }]);
+    setResults(prev => [...prev, { correct: known, element: card.symbol, name: info.name }]);
     setIdx(prev => prev + 1);
     setFlipped(false);
   }


### PR DESCRIPTION
## Summary

Follow-up cleanup to the Elements Song **Flash Cards study mode** (shipped in v2.29.0 via #2483). The study-mode `results` array recorded both `element` and `symbol` on every record, but both were assigned the identical value (`card.symbol`). This drops the duplicate `symbol` field and switches the one render site that read `r.symbol` to `r.element`.

This is the final refactor commit from the original #2480 work that landed after the feature PR was merged — recovered from an unmerged claim branch during a branch-cleanup pass rather than being lost.

- `rate()` now pushes `{ correct, element, name }` (was `{ correct, element, symbol, name }`).
- The incorrect-answers review UI reads `{r.element}` (was `{r.symbol}`) — byte-for-byte identical rendered value.
- The `onComplete` payload already read `element`, so no consumer needed changing there.

No behavior change — purely removes a redundant field.

## Test plan

- `client` vitest: `ElementsSong.test.jsx` passes (2/2).
- eslint clean on the changed file.
- Verified no remaining reader of `r.symbol` on the study `results` array (other `.symbol` refs are `card.symbol` / `cat.symbols`, unrelated).