### PR TITLE
Self-heal Layered Intelligence when a stale API-only provider is pinned per-app

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -10,3 +10,7 @@
 ## Changed
 
 - **Elements Song study mode drops a redundant result field.** The Flash Cards study results tracked both `element` and `symbol` on each record even though they hold identical values; the review UI now reads the single `element` field, removing the duplicate.
+
+## Fixed
+
+- **Layered Intelligence no longer wedges on a stale API-only provider.** Any install that ran the Layered Intelligence loop on an api provider (ollama/lmstudio/kimi) before it became agent-backed (#2322) had that provider carried into the per-app override by migration 184 — where it now outranks the global Schedule pin at spawn. The agent-backed loop needs a file-writing CLI/TUI harness, so those runs skipped with "the selected provider is an API-only model with no coding harness," and picking a CLI/TUI provider on the global Schedule page silently missed (it only sets the fallback pin). The loop now self-heals: an api-only per-app provider falls back to a CLI/TUI schedule pin (adopting its matched model), so the Schedule-page selection finally takes effect. It still skips with the actionable message only when no CLI/TUI provider is configured anywhere.

--- a/server/services/autonomousJobs/layeredIntelligenceHooks.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHooks.js
@@ -180,28 +180,67 @@ export async function buildTaskInput({ app } = {}) {
   // The reasoning agent needs a file-writing CLI/TUI harness to emit its
   // `.agent-done` sentinel — an HTTP `api` provider (ollama / lmstudio / kimi)
   // has none, so an agent-backed run pinned to one fails provider resolution and
-  // the task sits pending forever (pre-#2322 LI called the API path directly, so
-  // installs routinely carried an api provider through migration 184). Preflight
-  // the EFFECTIVE agent provider — the per-app override (config.providerId, the
-  // documented home for LI's provider) OR, when unset, the global schedule pin the
-  // generator applies (interval.providerId) — and skip with an actionable reason
-  // instead of generating a doomed task the lifecycle path would only block. A
-  // null/absent effective provider inherits the default coding agent and is fine;
-  // a spawn-time api resolution (e.g. an api ACTIVE provider) still falls to the
-  // lifecycle block. A pinned api provider is skipped even if it's momentarily
-  // unavailable with a CLI fallback — guiding the user to a real CLI/TUI provider
-  // beats silently running LI on a provider they didn't choose.
-  let effectiveProviderId = config.providerId || null
-  if (!effectiveProviderId) {
-    const { loadSchedule } = await import('../taskSchedule.js')
-    const schedule = await loadSchedule().catch(() => null)
-    effectiveProviderId = schedule?.tasks?.['layered-intelligence']?.providerId || null
+  // the task sits pending forever. Pre-#2322 LI called the API path directly, so
+  // an api provider was a perfectly valid LI provider then; migration 184
+  // faithfully carried whatever `layeredIntelligence.providerId` held — INCLUDING
+  // ollama/lmstudio/kimi — into the per-app override, which now outranks
+  // everything at spawn (cosTaskGenerator applies the hook's providerId LAST). So
+  // any install that ran LI on an api provider before #2322 is wedged, and the
+  // user's natural fix — picking a CLI/TUI provider on the global Schedule page —
+  // silently misses, because that only sets the schedule pin (the FALLBACK) while
+  // the stale per-app override still wins.
+  //
+  // SELF-HEAL that residue: resolve the EFFECTIVE agent provider (per-app override,
+  // else the global schedule pin), and when the per-app override is api-only but
+  // the schedule pin IS a real CLI/TUI provider, adopt the pin (provider + its
+  // matched model) instead of wedging — this makes the global Schedule page's
+  // selection finally take effect for an install carrying the stale override. Only
+  // when NO CLI/TUI provider is configured anywhere the user chose (per-app api
+  // with no usable pin, or an api pin) do we skip with the actionable reason —
+  // guiding them to pick a real CLI/TUI provider beats silently substituting one
+  // they never chose. A null/absent effective provider inherits the default coding
+  // agent and is fine; a spawn-time api resolution still falls to the lifecycle
+  // block.
+  const { getProviderById } = await import('../providers.js')
+  const providerTypeOf = async (id) => {
+    if (!id) return null
+    const provider = await getProviderById(id).catch(() => null)
+    return provider?.type ?? null
   }
-  if (effectiveProviderId) {
-    const { getProviderById } = await import('../providers.js')
-    const provider = await getProviderById(effectiveProviderId).catch(() => null)
-    if (provider?.type === 'api') return skip('skipped', 'provider-not-agent-capable')
+  // The global schedule pin is LI's provider FALLBACK; read it via the canonical
+  // getTaskInterval (returns a defaulted { providerId: null, ... } when absent).
+  const readPinTask = async () => {
+    const { getTaskInterval } = await import('../taskSchedule.js')
+    return getTaskInterval('layered-intelligence')
   }
+
+  // Only `effectiveType` gates the decision below; the healed provider/model flow
+  // out via config.providerId/config.model (re-read by this hook's return).
+  let effectiveType = await providerTypeOf(config.providerId || null)
+
+  if (effectiveType === 'api') {
+    const pinTask = await readPinTask()
+    const pinId = pinTask?.providerId || null
+    const pinType = await providerTypeOf(pinId)
+    if (pinId && pinType !== 'api') {
+      console.warn(`⚠️ Layered Intelligence: ${app.name} per-app provider '${config.providerId}' is API-only (no coding harness) — using the schedule provider '${pinId}' instead`)
+      // Persist the healed provider/model onto config so the returned prompt input
+      // (and the spawn's hookOverride) pins the AGENT to the pin, not the stale api
+      // id. Adopt the pin's model too — provider+model are a matched pair the user
+      // set together on the Schedule page (an api-provider model name may not be
+      // valid for the CLI/TUI provider).
+      config.providerId = pinId
+      config.model = pinTask?.model ?? null
+      effectiveType = pinType
+    }
+  } else if (!config.providerId) {
+    // No per-app override → the generator applies the global schedule pin
+    // (interval.providerId) at spawn; check its type here so an api pin still skips.
+    const pinTask = await readPinTask()
+    effectiveType = await providerTypeOf(pinTask?.providerId || null)
+  }
+
+  if (effectiveType === 'api') return skip('skipped', 'provider-not-agent-capable')
 
   // A jira-tracked app with no usable instance/project can't file — skip before
   // burning an agent on a result we couldn't land.

--- a/server/services/autonomousJobs/layeredIntelligenceHooks.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHooks.js
@@ -222,7 +222,11 @@ export async function buildTaskInput({ app } = {}) {
     const pinTask = await readPinTask()
     const pinId = pinTask?.providerId || null
     const pinType = await providerTypeOf(pinId)
-    if (pinId && pinType !== 'api') {
+    // Adopt the pin only when it RESOLVES to a real non-api provider. `pinType`
+    // is null for an unresolvable id (deleted/renamed/typo'd pin) — treating that
+    // as "not api" and adopting it would re-wedge the task on a doomed provider
+    // with a misleading "healed" warning, so require a positively-known type.
+    if (pinId && pinType && pinType !== 'api') {
       console.warn(`⚠️ Layered Intelligence: ${app.name} per-app provider '${config.providerId}' is API-only (no coding harness) — using the schedule provider '${pinId}' instead`)
       // Persist the healed provider/model onto config so the returned prompt input
       // (and the spawn's hookOverride) pins the AGENT to the pin, not the stale api

--- a/server/services/autonomousJobs/layeredIntelligenceHooks.test.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHooks.test.js
@@ -24,9 +24,10 @@ vi.mock('../providers.js', () => ({
 }));
 
 // When no per-app provider is pinned, the guard falls back to the global LI
-// schedule provider. Default to no global pin so the no-provider path stays inert.
+// schedule provider via getTaskInterval. Default to no global pin so the
+// no-provider path stays inert.
 vi.mock('../taskSchedule.js', () => ({
-  loadSchedule: vi.fn(async () => ({ tasks: { 'layered-intelligence': {} } }))
+  getTaskInterval: vi.fn(async () => ({ providerId: null, model: null }))
 }));
 
 vi.mock('../layeredIntelligence.js', () => ({
@@ -72,7 +73,7 @@ import * as apps from '../apps.js';
 import { resolveAppWorkTracker } from '../../lib/workTracker.js';
 import { tryReadFile } from '../../lib/fileUtils.js';
 import { getProviderById } from '../providers.js';
-import { loadSchedule } from '../taskSchedule.js';
+import { getTaskInterval } from '../taskSchedule.js';
 
 const APP = { id: 'app-1', name: 'App One', repoPath: '/repo', taskTypeOverrides: {} };
 
@@ -80,7 +81,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   resolveAppWorkTracker.mockResolvedValue({ resolved: 'github', forge: 'gh' });
   getProviderById.mockImplementation(async (id) => ({ id, type: 'cli' }));
-  loadSchedule.mockResolvedValue({ tasks: { 'layered-intelligence': {} } });
+  getTaskInterval.mockResolvedValue({ providerId: null, model: null });
   li.getEffectiveConfig.mockReturnValue({ providerId: 'ollama', model: 'qwen', allowedScopes: ['app-improvement'], sources: {} });
   li.filerForTracker.mockImplementation((r) => (r === 'github' || r === 'gitlab') ? 'forge' : (r === 'jira' ? 'jira' : 'plan'));
   li.trackerSupportsPause.mockImplementation((r) => r !== 'plan');
@@ -127,11 +128,35 @@ describe('buildTaskInput', () => {
 
   it('skips on an api-only GLOBAL schedule provider when no per-app provider is pinned', async () => {
     li.getEffectiveConfig.mockReturnValue({ providerId: null, model: null, allowedScopes: ['app-improvement'], sources: {} });
-    loadSchedule.mockResolvedValue({ tasks: { 'layered-intelligence': { providerId: 'ollama' } } });
+    getTaskInterval.mockResolvedValue({ providerId: 'ollama', model: null });
     getProviderById.mockResolvedValue({ id: 'ollama', type: 'api' });
     const res = await buildTaskInput({ app: APP });
     expect(res).toEqual({ skip: { reason: 'provider-not-agent-capable' } });
     expect(getProviderById).toHaveBeenCalledWith('ollama');
+  });
+
+  it('self-heals a stale api per-app provider by adopting a CLI/TUI schedule pin (migration-184 residue)', async () => {
+    // Per-app override carries an api provider (what migration 184 copied from the
+    // pre-#2322 layeredIntelligence.providerId); the global Schedule page pins a
+    // real CLI/TUI provider + its matched model. LI must run on the pin, not wedge.
+    li.getEffectiveConfig.mockReturnValue({ providerId: 'ollama', model: 'qwen', allowedScopes: ['app-improvement'], sources: {} });
+    getTaskInterval.mockResolvedValue({ providerId: 'claude-ollama-tui', model: 'qwen3:35b' });
+    getProviderById.mockImplementation(async (id) => ({ id, type: id === 'claude-ollama-tui' ? 'tui' : 'api' }));
+    const res = await buildTaskInput({ app: APP });
+    expect(res.skip).toBeUndefined();
+    expect(res.prompt).toContain('REASONING PROMPT');
+    // Healed to the pin's provider + its matched model (not the stale api pair).
+    expect(res.providerId).toBe('claude-ollama-tui');
+    expect(res.model).toBe('qwen3:35b');
+  });
+
+  it('still skips when the per-app AND the schedule pin are both api-only (no CLI/TUI anywhere)', async () => {
+    li.getEffectiveConfig.mockReturnValue({ providerId: 'ollama', model: 'qwen', allowedScopes: ['app-improvement'], sources: {} });
+    getTaskInterval.mockResolvedValue({ providerId: 'lmstudio', model: null });
+    getProviderById.mockResolvedValue({ id: 'any', type: 'api' });
+    const res = await buildTaskInput({ app: APP });
+    expect(res).toEqual({ skip: { reason: 'provider-not-agent-capable' } });
+    expect(li.gatherSources).not.toHaveBeenCalled();
   });
 
   it('skips a jira-tracked app with no usable jira config', async () => {

--- a/server/services/autonomousJobs/layeredIntelligenceHooks.test.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHooks.test.js
@@ -150,6 +150,18 @@ describe('buildTaskInput', () => {
     expect(res.model).toBe('qwen3:35b');
   });
 
+  it('skips (does not adopt) when the schedule pin references an unresolvable provider id', async () => {
+    // Stale api per-app override + a schedule pin pointing at a provider that no
+    // longer resolves (deleted/renamed). providerTypeOf(pin) → null; adopting it
+    // would re-wedge on a doomed id, so the heal must fall through to the skip.
+    li.getEffectiveConfig.mockReturnValue({ providerId: 'ollama', model: 'qwen', allowedScopes: ['app-improvement'], sources: {} });
+    getTaskInterval.mockResolvedValue({ providerId: 'ghost-provider', model: null });
+    getProviderById.mockImplementation(async (id) => (id === 'ghost-provider' ? null : { id, type: 'api' }));
+    const res = await buildTaskInput({ app: APP });
+    expect(res).toEqual({ skip: { reason: 'provider-not-agent-capable' } });
+    expect(li.gatherSources).not.toHaveBeenCalled();
+  });
+
   it('still skips when the per-app AND the schedule pin are both api-only (no CLI/TUI anywhere)', async () => {
     li.getEffectiveConfig.mockReturnValue({ providerId: 'ollama', model: 'qwen', allowedScopes: ['app-improvement'], sources: {} });
     getTaskInterval.mockResolvedValue({ providerId: 'lmstudio', model: null });


### PR DESCRIPTION
## Summary

The Layered Intelligence (LI) loop resolves its reasoning-agent provider from the **per-app override** (`taskTypeOverrides['layered-intelligence']`), which outranks the global Schedule pin at spawn (`cosTaskGenerator` applies the hook's `providerId` last). Pre-#2322, LI called the API path directly, so an `api` provider (ollama/lmstudio/kimi) was a valid choice — and migration 184 faithfully carried whatever `layeredIntelligence.providerId` held into that per-app override.

The agent-backed loop (#2322) needs a file-writing CLI/TUI harness to emit its `.agent-done` sentinel, so any install carrying that stale `api` override now **wedges**: runs skip with `provider-not-agent-capable`, and the user's natural fix — picking a CLI/TUI provider on the global **Schedule** page — silently misses, because that only sets the fallback pin while the per-app override still wins.

`buildTaskInput` now **self-heals**: an `api`-only per-app provider falls back to the global schedule pin when that pin resolves to a real CLI/TUI provider (adopting its matched model), so the Schedule-page selection finally takes effect. It still skips with the actionable message only when no CLI/TUI provider is configured anywhere — including when the pin id no longer resolves (deleted/renamed provider), which would otherwise re-wedge the task.

Resolution order (in the preflight gate, mirrored by the spawn path):
1. per-app override provider, if CLI/TUI
2. else the global schedule pin, if it resolves to a CLI/TUI provider (heal)
3. else skip with `provider-not-agent-capable` (per-app api + api/unresolvable pin), or inherit the default coding agent (no provider pinned anywhere)

Reuse/cleanup from `/simplify`: the schedule pin is read via the canonical `getTaskInterval('layered-intelligence')` instead of inlining `loadSchedule`, and the redundant local `effectiveProviderId` was dropped (only the resolved type gates the decision; the healed value flows out via `config.providerId`/`config.model`).

## Test plan

- `server/services/autonomousJobs/layeredIntelligenceHooks.test.js` — added coverage for: healing a stale api per-app provider to a CLI/TUI pin (adopting its matched model), still skipping when both per-app and pin are api-only, and skipping (not adopting) when the pin references an unresolvable provider id. All existing skip/proceed cases unchanged. 23 pass.
- `cd server && npx vitest run services/autonomousJobs/` — green.

## Follow-up (out of scope)

LI's agent-provider resolution is spread across three fragments (`resolveLiContext` overlay → `buildTaskInput` preflight → `cosTaskGenerator` interval/hookOverride) whose consistency rests on an unstated invariant; a single `resolveLiAgentProvider` used by both the preflight and the spawn path would collapse the double schedule read and remove the config-mutation side channel. Filing separately.