### PR TITLE
feat: extend thinking-effort override to pipeline stages and autonomous jobs (#2502)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -10,6 +10,7 @@
 ## Added
 
 - **Scheduled tasks and the new-task form can pin a thinking-effort level.** Alongside the existing provider/model overrides, a "Thinking Effort" select appears when the pinned provider is Claude Code or Codex (Claude: low→max; Codex: minimal→ultra). The spawned agent gets `--effort <level>` (claude) or `-c model_reasoning_effort=<level>` (codex) across all three execution modes — direct CLI, runner, and TUI. Codex-only values clamp to the nearest Claude equivalent if the task later runs on a Claude provider, a user-baked `--effort` in provider args wins over the injected one, and task templates save/re-apply the effort choice.
+- **[issue-2502] Thinking-effort pins now extend to pipeline stages and autonomous jobs.** The two remaining surfaces that carried provider/model overrides gain the same "Thinking Effort" select: each pipeline stage (code-reviewer's Review/Implement, pr-reviewer's Security/Review, etc.) can pin its own effort in its stage card, and each autonomous job can pin one in the job form. The select only renders for effort-capable providers (Claude Code / Codex) and resets when the stage/job provider changes. Stage 0's effort rides into the first agent and each subsequent stage re-applies its own on hand-off; a job's effort flows into every task it generates — spawning with `--effort`/`-c model_reasoning_effort=` and a no-op for non-effort providers.
 
 ## Changed
 

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -5,7 +5,7 @@ import * as api from '../../../services/api';
 import { timeAgo, formatDateTime } from '../../../utils/formatters';
 import { CRON_PRESETS, DEFAULT_CRON, describeCron } from '../../../utils/cronHelpers';
 import WeekdayTimePicker from '../../WeekdayTimePicker';
-import { filterSelectableModels } from '../../../utils/providers';
+import { filterSelectableModels, effortLevelsForProvider } from '../../../utils/providers';
 import ProviderModelSelector from '../../ProviderModelSelector';
 import InlineConfirmRow from '../../ui/InlineConfirmRow';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
@@ -75,6 +75,7 @@ const INITIAL_JOB = {
   appId: '',
   providerId: '',
   model: '',
+  effort: '',
   enabled: false
 };
 
@@ -114,14 +115,17 @@ function BriefingConfig({ config, onChange }) {
   );
 }
 
-// Provider + model override for an agent job. Empty selection = use the active
-// provider / its default model. Only rendered for agent jobs (shell/script jobs
-// never reach the AI runner). `data` carries `providerId`/`model`; `onChange`
-// applies a partial patch back onto the form state.
+// Provider + model + effort override for an agent job. Empty selection = use the
+// active provider / its default model / default effort. Only rendered for agent
+// jobs (shell/script jobs never reach the AI runner). `data` carries
+// `providerId`/`model`/`effort`; `onChange` applies a partial patch back onto the
+// form state. Effort only renders for effort-capable providers (claude/codex) and
+// resets when the provider changes.
 function JobProviderModelFields({ data, providers, onChange }) {
   if (!providers?.length) return null;
   const selectedProvider = providers.find(p => p.id === data.providerId);
   const availableModels = filterSelectableModels(selectedProvider?.models);
+  const effortLevels = effortLevelsForProvider(selectedProvider);
   return (
     <div>
       <span className="text-xs text-gray-400 block mb-1">AI Provider &amp; Model (optional)</span>
@@ -130,13 +134,29 @@ function JobProviderModelFields({ data, providers, onChange }) {
         selectedProviderId={data.providerId || ''}
         selectedModel={data.model || ''}
         availableModels={availableModels}
-        onProviderChange={id => onChange({ providerId: id, model: '' })}
+        onProviderChange={id => onChange({ providerId: id, model: '', effort: '' })}
         onModelChange={model => onChange({ model })}
         compact
         emptyProviderOption="Default (active provider)"
         emptyModelOption="Default model"
         alwaysShowModel
       />
+      {effortLevels && (
+        <div className="mt-2">
+          <span className="text-xs text-gray-400 block mb-1">Thinking Effort (optional)</span>
+          <select
+            aria-label="Thinking Effort"
+            value={data.effort || ''}
+            onChange={e => onChange({ effort: e.target.value })}
+            className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-white text-xs"
+          >
+            <option value="">Default effort</option>
+            {effortLevels.map(level => (
+              <option key={level} value={level}>{level}</option>
+            ))}
+          </select>
+        </div>
+      )}
     </div>
   );
 }
@@ -152,10 +172,11 @@ function normalizeJobPayload(formData) {
     // appId left over from when the job was an agent type — otherwise the saved
     // job shows a misleading app badge while executing in root.
     payload.appId = null;
-    // Provider/model overrides only apply to AI-agent jobs — clear any leftover
-    // selection so a shell/script job doesn't carry a misleading AI badge.
+    // Provider/model/effort overrides only apply to AI-agent jobs — clear any
+    // leftover selection so a shell/script job doesn't carry a misleading AI badge.
     payload.providerId = null;
     payload.model = null;
+    payload.effort = null;
   }
   // Empty app picker selection ('') → null so a PUT actively un-scopes the job
   // back to global (undefined would be dropped from JSON and updateJob would
@@ -302,7 +323,8 @@ function JobCard({ job, apps, providers, onToggle, onTrigger, onDelete, onUpdate
       promptTemplate: job.promptTemplate || '',
       appId: job.appId || '',
       providerId: job.providerId || '',
-      model: job.model || ''
+      model: job.model || '',
+      effort: job.effort || ''
     };
     // Always initialize shell fields so switching type to 'shell' during editing works
     base.command = job.command || '';
@@ -561,7 +583,7 @@ function JobCard({ job, apps, providers, onToggle, onTrigger, onDelete, onUpdate
                 <span>Priority: <span className="text-gray-300">{job.priority}</span></span>
                 {!isShell && <span>Autonomy: <span className="text-gray-300">{job.autonomyLevel}</span></span>}
                 {isAgentJobType(job.type) && job.providerId && (
-                  <span>AI: <span className="text-gray-300">{providers.find(p => p.id === job.providerId)?.name || job.providerId}{job.model ? ` / ${job.model}` : ''}</span></span>
+                  <span>AI: <span className="text-gray-300">{providers.find(p => p.id === job.providerId)?.name || job.providerId}{job.model ? ` / ${job.model}` : ''}{job.effort ? ` · ${job.effort}` : ''}</span></span>
                 )}
                 {isShell && <span>Action: <span className="text-gray-300">{job.triggerAction || 'log-only'}</span></span>}
                 <span>Created: <span className="text-gray-300">{job.createdAt ? new Date(job.createdAt).toLocaleDateString() : '—'}</span></span>

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -7,6 +7,7 @@ import { CRON_PRESETS, DEFAULT_CRON, describeCron } from '../../../utils/cronHel
 import WeekdayTimePicker from '../../WeekdayTimePicker';
 import { filterSelectableModels, effortLevelsForProvider } from '../../../utils/providers';
 import ProviderModelSelector from '../../ProviderModelSelector';
+import { FormField } from '../../ui/FormField';
 import InlineConfirmRow from '../../ui/InlineConfirmRow';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
 
@@ -142,10 +143,8 @@ function JobProviderModelFields({ data, providers, onChange }) {
         alwaysShowModel
       />
       {effortLevels && (
-        <div className="mt-2">
-          <span className="text-xs text-gray-400 block mb-1">Thinking Effort (optional)</span>
+        <FormField label="Thinking Effort (optional)" className="mt-2" labelClassName="text-xs text-gray-400 block mb-1">
           <select
-            aria-label="Thinking Effort"
             value={data.effort || ''}
             onChange={e => onChange({ effort: e.target.value })}
             className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-white text-xs"
@@ -155,7 +154,7 @@ function JobProviderModelFields({ data, providers, onChange }) {
               <option key={level} value={level}>{level}</option>
             ))}
           </select>
-        </div>
+        </FormField>
       )}
     </div>
   );

--- a/client/src/components/cos/tabs/schedule/PipelineStageConfig.jsx
+++ b/client/src/components/cos/tabs/schedule/PipelineStageConfig.jsx
@@ -1,4 +1,4 @@
-import { filterSelectableModels } from '../../../../utils/providers';
+import { filterSelectableModels, effortLevelsForProvider } from '../../../../utils/providers';
 import { FormField } from '../../../ui/FormField';
 
 export default function PipelineStageConfig({ taskType, config, providers, onUpdate, updating, setUpdating }) {
@@ -14,9 +14,12 @@ export default function PipelineStageConfig({ taskType, config, providers, onUpd
       } else {
         updated[field] = value;
       }
-      // When provider changes, clear model (it may not be valid for new provider)
+      // When provider changes, clear model + effort (neither may be valid for the
+      // new provider — effort levels differ between claude/codex and non-effort
+      // providers have none).
       if (field === 'providerId') {
         delete updated.model;
+        delete updated.effort;
       }
       return updated;
     });
@@ -35,6 +38,7 @@ export default function PipelineStageConfig({ taskType, config, providers, onUpd
         {stages.map((stage, i) => {
           const stageProvider = providers?.find(p => p.id === stage.providerId);
           const stageModels = filterSelectableModels(stageProvider?.models);
+          const stageEffortLevels = effortLevelsForProvider(stageProvider);
           return (
             <div key={i} className="bg-port-card border border-port-border rounded-lg p-3">
               <div className="flex items-center gap-2 mb-3">
@@ -77,6 +81,21 @@ export default function PipelineStageConfig({ taskType, config, providers, onUpd
                     ))}
                   </select>
                 </FormField>
+                {stageEffortLevels && (
+                  <FormField label="Thinking Effort" labelClassName="text-xs text-gray-500 block mb-1">
+                    <select
+                      value={stage.effort || ''}
+                      onChange={(e) => handleStageUpdate(i, 'effort', e.target.value || null)}
+                      disabled={updating}
+                      className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-white text-xs"
+                    >
+                      <option value="">Default effort</option>
+                      {stageEffortLevels.map(level => (
+                        <option key={level} value={level}>{level}</option>
+                      ))}
+                    </select>
+                  </FormField>
+                )}
               </div>
             </div>
           );

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -455,6 +455,11 @@ export const createCosJobSchema = z.object({
   // generated task's metadata as `provider`/`model` by generateTaskFromJob.
   providerId: z.preprocess(emptyToNull, z.string().nullable().optional()),
   model: z.preprocess(emptyToNull, z.string().nullable().optional()),
+  // Optional reasoning-effort override (claude/codex). Mirrors providerId's
+  // clearable-null semantics — '' from the UI picker → null so a PUT can reset it
+  // back to the provider default. Forwarded into the generated task's metadata as
+  // `effort` by generateTaskFromJob; no-op'd at spawn for non-effort providers.
+  effort: effortUpdateSchema,
   // Optional managed-app scope. Empty string from the UI picker → null so a PUT
   // can actively un-scope a job back to global (updateJob only skips `undefined`,
   // so undefined would silently preserve the old scope). Absent key stays

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createCosTaskSchema, updateCosTaskSchema } from './cosValidation.js';
+import { createCosTaskSchema, updateCosTaskSchema, createCosJobSchema, updateCosJobSchema } from './cosValidation.js';
 import { EFFORT_LEVELS } from './providerModels.js';
 
 describe('cosValidation effort field', () => {
@@ -24,5 +24,27 @@ describe('cosValidation effort field', () => {
     expect(updateCosTaskSchema.parse({ effort: 'high' }).effort).toBe('high');
     expect(updateCosTaskSchema.parse({}).effort).toBeUndefined();
     expect(updateCosTaskSchema.safeParse({ effort: 'bogus' }).success).toBe(false);
+  });
+});
+
+describe('cosValidation autonomous-job effort field', () => {
+  it('accepts every EFFORT_LEVELS value on create and rejects unknown values', () => {
+    for (const effort of EFFORT_LEVELS) {
+      expect(createCosJobSchema.safeParse({ name: 'j', effort }).success).toBe(true);
+    }
+    expect(createCosJobSchema.safeParse({ name: 'j', effort: 'bogus' }).success).toBe(false);
+  });
+
+  it("mirrors providerId's clearable-null semantics: ''/null → null, absent → undefined", () => {
+    // A job effort pin is clearable through a PUT the same way providerId is —
+    // '' from the UI picker and an explicit null both persist as null so
+    // updateJob (which skips only `undefined`) resets the pin to the provider
+    // default; an omitted key stays undefined and preserves the existing value.
+    expect(createCosJobSchema.parse({ name: 'j', effort: '' }).effort).toBeNull();
+    expect(updateCosJobSchema.parse({ effort: '' }).effort).toBeNull();
+    expect(updateCosJobSchema.parse({ effort: null }).effort).toBeNull();
+    expect(updateCosJobSchema.parse({ effort: 'max' }).effort).toBe('max');
+    expect(updateCosJobSchema.parse({}).effort).toBeUndefined();
+    expect(updateCosJobSchema.safeParse({ effort: 'bogus' }).success).toBe(false);
   });
 });

--- a/server/routes/cosJobRoutes.js
+++ b/server/routes/cosJobRoutes.js
@@ -90,7 +90,7 @@ router.get('/jobs/:id', asyncHandler(async (req, res) => {
 router.post('/jobs', asyncHandler(async (req, res) => {
   const parsedJob = createCosJobSchema.safeParse(req.body);
   if (!parsedJob.success) failValidation(parsedJob);
-  const { name, description, category, type, interval, intervalMs, scheduledTime, cronExpression, enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, appId, taskMetadata, providerId, model } = parsedJob.data;
+  const { name, description, category, type, interval, intervalMs, scheduledTime, cronExpression, enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, appId, taskMetadata, providerId, model, effort } = parsedJob.data;
 
   if (type === 'shell' && !command?.trim()) {
     throw new ServerError('command is required for shell jobs', { status: 400, code: 'VALIDATION_ERROR' });
@@ -106,7 +106,7 @@ router.post('/jobs', asyncHandler(async (req, res) => {
 
   const job = await autonomousJobs.createJob({
     name, description, category, type, interval, intervalMs, scheduledTime, cronExpression,
-    enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, appId, taskMetadata, providerId, model
+    enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, appId, taskMetadata, providerId, model, effort
   });
   res.json({ success: true, job });
 }));
@@ -116,13 +116,13 @@ router.put('/jobs/:id', asyncHandler(async (req, res) => {
   const parsedJobUpdate = updateCosJobSchema.safeParse(req.body);
   if (!parsedJobUpdate.success) failValidation(parsedJobUpdate);
   const { name, description, category, type, interval, intervalMs, scheduledTime, cronExpression,
-    enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, weekdaysOnly, appId, taskMetadata, providerId, model } = parsedJobUpdate.data;
+    enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, weekdaysOnly, appId, taskMetadata, providerId, model, effort } = parsedJobUpdate.data;
   if (cronExpression) {
     validateCronExpression(cronExpression);
   }
   const job = await autonomousJobs.updateJob(req.params.id, {
     name, description, category, type, interval, intervalMs, scheduledTime, cronExpression,
-    enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, weekdaysOnly, appId, taskMetadata, providerId, model
+    enabled, priority, autonomyLevel, promptTemplate, command, triggerAction, weekdaysOnly, appId, taskMetadata, providerId, model, effort
   });
   if (!job) {
     throw new ServerError('Job not found', { status: 404, code: 'NOT_FOUND' });

--- a/server/routes/cosJobRoutes.test.js
+++ b/server/routes/cosJobRoutes.test.js
@@ -256,6 +256,28 @@ describe('CoS Job Routes', () => {
         expect.objectContaining({ providerId: null, model: null })
       );
     });
+
+    it('should accept effort and forward it to createJob', async () => {
+      autonomousJobs.createJob.mockResolvedValue({ id: 'j1' });
+
+      const response = await request(app)
+        .post('/api/cos/jobs')
+        .send({ name: 'Effort Task', type: 'agent', promptTemplate: 'test', providerId: 'claude-code', effort: 'xhigh' });
+
+      expect(response.status).toBe(200);
+      expect(autonomousJobs.createJob).toHaveBeenCalledWith(
+        expect.objectContaining({ effort: 'xhigh' })
+      );
+    });
+
+    it('should reject an effort value outside EFFORT_LEVELS', async () => {
+      const response = await request(app)
+        .post('/api/cos/jobs')
+        .send({ name: 'Bad Effort', type: 'agent', promptTemplate: 'test', effort: 'bogus' });
+
+      expect(response.status).toBe(400);
+      expect(autonomousJobs.createJob).not.toHaveBeenCalled();
+    });
   });
 
   describe('PUT /api/cos/jobs/:id', () => {

--- a/server/services/agentCompletionCleanup.js
+++ b/server/services/agentCompletionCleanup.js
@@ -122,6 +122,7 @@ export async function handlePipelineProgression(task, agentId, success) {
     nextTask.metadata.provider = nextStage.providerId;
     nextTask.metadata.providerId = nextStage.providerId;
   }
+  if (nextStage.effort) nextTask.metadata.effort = nextStage.effort;
   // Apply per-stage overrides for agent behavior flags
   const stageReadOnly = nextStage.readOnly ?? false;
   const taskDefaults = pipeline.taskDefaults || {};

--- a/server/services/agentCompletionCleanup.js
+++ b/server/services/agentCompletionCleanup.js
@@ -117,6 +117,10 @@ export async function handlePipelineProgression(task, agentId, success) {
     },
     autoApproved: true
   };
+  // Provider/model/effort are SET-only (never cleared) on hand-off: a stage
+  // without its own pin inherits the value carried in `...task.metadata` — either
+  // the task-level pin (interval config) or the prior stage's. Clearing an unset
+  // stage's effort here would wipe a task-level effort from stage 1+.
   if (nextStage.model) nextTask.metadata.model = nextStage.model;
   if (nextStage.providerId) {
     nextTask.metadata.provider = nextStage.providerId;

--- a/server/services/agentCompletionCleanup.test.js
+++ b/server/services/agentCompletionCleanup.test.js
@@ -90,4 +90,13 @@ describe('handlePipelineProgression', () => {
     const [nextTask] = addTask.mock.calls[0];
     expect(nextTask.metadata.effort).toBeUndefined();
   });
+
+  it('inherits a task-level effort into a stage that has no effort pin of its own', async () => {
+    // Effort is SET-only on hand-off: a task-level effort (from the interval
+    // config) must reach stage 1+ via the metadata carry-forward, not be wiped.
+    const task = { id: 't', taskType: 'user', metadata: { effort: 'high', pipeline: runningPipeline() } };
+    await handlePipelineProgression(task, 'agent-1', true);
+    const [nextTask] = addTask.mock.calls[0];
+    expect(nextTask.metadata.effort).toBe('high');
+  });
 });

--- a/server/services/agentCompletionCleanup.test.js
+++ b/server/services/agentCompletionCleanup.test.js
@@ -72,4 +72,22 @@ describe('handlePipelineProgression', () => {
     expect(nextTask.metadata.pipeline.status).toBe('running');
     expect(nextTask.metadata.pipeline.previousStageAgentId).toBe('agent-1');
   });
+
+  it('propagates the next stage provider/model/effort pins into the enqueued task', async () => {
+    const stages = [{ name: 'stage-0' }, { name: 'stage-1', providerId: 'codex', model: 'gpt-5', effort: 'xhigh' }];
+    const task = { id: 't', taskType: 'user', metadata: { pipeline: runningPipeline({ stages }) } };
+    await handlePipelineProgression(task, 'agent-1', true);
+    const [nextTask] = addTask.mock.calls[0];
+    expect(nextTask.metadata.provider).toBe('codex');
+    expect(nextTask.metadata.providerId).toBe('codex');
+    expect(nextTask.metadata.model).toBe('gpt-5');
+    expect(nextTask.metadata.effort).toBe('xhigh');
+  });
+
+  it('leaves effort unset when the next stage has no effort pin', async () => {
+    const task = { id: 't', taskType: 'user', metadata: { pipeline: runningPipeline() } };
+    await handlePipelineProgression(task, 'agent-1', true);
+    const [nextTask] = addTask.mock.calls[0];
+    expect(nextTask.metadata.effort).toBeUndefined();
+  });
 });

--- a/server/services/autonomousJobs.test.js
+++ b/server/services/autonomousJobs.test.js
@@ -231,6 +231,17 @@ describe('autonomousJobs', () => {
       expect(task.metadata.provider).toBeUndefined()
       expect(task.metadata.model).toBeUndefined()
     })
+
+    it('forwards effort into metadata.effort', async () => {
+      const job = { ...mockJobsData.jobs[0], providerId: 'claude-code', effort: 'max' }
+      const task = await generateTaskFromJob(job)
+      expect(task.metadata.effort).toBe('max')
+    })
+
+    it('omits effort when job has no override', async () => {
+      const task = await generateTaskFromJob(mockJobsData.jobs[0])
+      expect(task.metadata.effort).toBeUndefined()
+    })
   })
 
   describe('createJob with resolveIntervalMs', () => {
@@ -786,6 +797,21 @@ describe('autonomousJobs', () => {
       })
       expect(job.providerId).toBe('anthropic')
       expect(job.model).toBe('claude-opus-4-8')
+    })
+
+    it('defaults effort to null when omitted', async () => {
+      const job = await createJob({ name: 'No Effort Job', promptTemplate: 'do it' })
+      expect(job.effort).toBeNull()
+    })
+
+    it('persists effort when provided', async () => {
+      const job = await createJob({
+        name: 'Effort Job',
+        promptTemplate: 'do it',
+        providerId: 'claude-code',
+        effort: 'xhigh'
+      })
+      expect(job.effort).toBe('xhigh')
     })
   })
 

--- a/server/services/autonomousJobs/crud.js
+++ b/server/services/autonomousJobs/crud.js
@@ -103,6 +103,9 @@ async function createJob(jobData) {
       // forwards these into the task metadata the agent runner resolves.
       providerId: jobData.providerId || null,
       model: jobData.model || null,
+      // Optional reasoning-effort override (claude/codex). Null = provider
+      // default. generateTaskFromJob forwards it into task metadata as `effort`.
+      effort: jobData.effort || null,
       command: jobData.command || null,
       triggerAction,
       config: jobData.config || null,
@@ -148,7 +151,7 @@ async function updateJob(jobId, updates) {
     const updatableFields = [
       'name', 'description', 'category', 'type', 'interval', 'intervalMs',
       'scheduledTime', 'cronExpression', 'weekdaysOnly', 'enabled', 'priority', 'autonomyLevel', 'promptTemplate',
-      'command', 'triggerAction', 'config', 'appId', 'taskMetadata', 'providerId', 'model'
+      'command', 'triggerAction', 'config', 'appId', 'taskMetadata', 'providerId', 'model', 'effort'
     ]
 
     for (const field of updatableFields) {

--- a/server/services/autonomousJobs/skillTemplates.js
+++ b/server/services/autonomousJobs/skillTemplates.js
@@ -167,7 +167,11 @@ async function generateTaskFromJob(job) {
       // metadata.model as the highest-priority model choice. Absent = active
       // provider / per-task model selection (historical behavior).
       ...(job.providerId ? { provider: job.providerId } : {}),
-      ...(job.model ? { model: job.model } : {})
+      ...(job.model ? { model: job.model } : {}),
+      // Reasoning-effort override — agentLifecycle reads metadata.effort and the
+      // spawn builders emit `--effort`/`-c model_reasoning_effort=` (no-op for
+      // non-effort providers). Absent = provider default.
+      ...(job.effort ? { effort: job.effort } : {})
     },
     taskType: 'internal',
     autoApprove: job.autonomyLevel === 'yolo'

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -1419,12 +1419,13 @@ function initializePipelineMetadata(metadata) {
   if (stage0.readOnly !== undefined) {
     metadata.readOnly = stage0.readOnly;
   }
-  // Propagate stage 0's provider/model so the first agent uses per-stage config
+  // Propagate stage 0's provider/model/effort so the first agent uses per-stage config
   if (stage0.model) metadata.model = stage0.model;
   if (stage0.providerId) {
     metadata.provider = stage0.providerId;
     metadata.providerId = stage0.providerId;
   }
+  if (stage0.effort) metadata.effort = stage0.effort;
   // Save task-level defaults and apply stage 0 overrides in one pass
   // Read-only stages default flags to false to prevent worktree/PR/simplify on review-only stages
   metadata.pipeline.taskDefaults = {};


### PR DESCRIPTION
## Summary

Extends the reasoning-effort override (Claude Code `--effort`, Codex `-c model_reasoning_effort=`) to the two surfaces that were left out of the original effort work (a277f1e8): **CoS pipeline stage pins** and **autonomous jobs**. Both already carried provider/model overrides; this adds the matching `effort` control on the same pattern.

The value rides `task.metadata.effort` into the existing `buildEffortArgs` emitter in `providerModels.js`, so **no spawn-path changes were needed** — the backbone already applies `--effort`/`-c model_reasoning_effort=` across direct-CLI, runner, and TUI modes and no-ops for non-effort providers.

### Pipeline stages
- `initializePipelineMetadata` (`cosTaskGenerator.js`) propagates stage 0's `effort` into the first agent's metadata.
- `handlePipelineProgression` (`agentCompletionCleanup.js`) re-applies each subsequent stage's `effort` on hand-off.
- `PipelineStageConfig.jsx` renders a "Thinking Effort" select per stage card, gated on `effortLevelsForProvider(stageProvider)`, and clears it when the stage provider changes.

### Autonomous jobs
- `effort` added to `createCosJobSchema` (clearable-null via `effortUpdateSchema`, mirroring `providerId`).
- Persisted by `createJob`/`updateJob` (`autonomousJobs/crud.js`), forwarded through the route destructure (`cosJobRoutes.js`), mapped into task metadata by `generateTaskFromJob` (`skillTemplates.js`).
- `JobsTab.jsx` renders the effort select in the create/edit form (gated + reset-on-provider-change) and shows it in the job card AI badge.

## Acceptance criteria
- ✅ A pipeline stage pinned to codex with effort `xhigh` spawns with `-c model_reasoning_effort=xhigh` (via `metadata.effort` → `buildEffortArgs`).
- ✅ An autonomous job pinned to claude with effort `max` generates tasks that spawn with `--effort max`.
- ✅ Effort selects only render for effort-capable providers (`effortLevelsForProvider` non-null) and reset when the provider changes.
- ✅ Server-side validation rejects values outside `EFFORT_LEVELS` (job schema `z.enum(EFFORT_LEVELS)`; stage values are constrained by the UI select and no-op'd by `resolveCliEffort` at spawn, matching the existing stage provider/model posture).

## Test plan
- `cd server && npx vitest run lib/cosValidation.test.js routes/cosJobRoutes.test.js services/autonomousJobs.test.js services/agentCompletionCleanup.test.js services/cosTaskGenerator.test.js` → **156 passed**
- Added coverage: job-schema effort accept/reject + clearable-null; route-level effort passthrough + rejection; `generateTaskFromJob`/`createJob` effort persistence; pipeline next-stage effort propagation.
- `cd client && npx vite build` → clean; `npx vitest run src/utils/providers.test.js` → 65 passed.

Closes #2502