### PR TITLE
fix: clear stale MidiPianoRoll hover overlay on data/chords swap

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+## Fixed
+
+- **[issue-2510] MidiPianoRoll: clear the stale hover overlay when the transcription data changes.** The piano-roll kept its hovered note/chord identity (objects from the previous parse) when the `data`/`chords` props swapped on a mounted instance, so a re-transcription or Retry while a hover was active and the pointer sat still would keep stroking the old note at coordinates mapped into the new file until the next pointer move or Escape. A `useEffect` now drops the hover identity whenever `data`/`chords` change.

--- a/client/src/components/songs/MidiPianoRoll.jsx
+++ b/client/src/components/songs/MidiPianoRoll.jsx
@@ -447,6 +447,14 @@ export default function MidiPianoRoll({
 
   useEffect(() => { draw(); }, [draw, zoom]);
 
+  // Drop the hovered note/chord identity when the underlying file swaps
+  // (re-transcription updating `data`, or the Retry path replacing `chords`).
+  // The identity holds objects from the PREVIOUS parse; without this, a
+  // stationary hover over the canvas would keep `paintOverlay` stroking the
+  // stale note/chord at coordinates mapped into the NEW file until the next
+  // pointer move or Escape.
+  useEffect(() => { setHover(null); }, [data, chords]);
+
   // Playback rAF loop: while playing, read the live audio position into the
   // playhead ref, page the view to keep it visible, compute the sounding
   // pitch set for the gutter, and repaint — but only when a frame is visually

--- a/client/src/components/songs/MidiPianoRoll.test.jsx
+++ b/client/src/components/songs/MidiPianoRoll.test.jsx
@@ -58,6 +58,34 @@ describe('<MidiPianoRoll>', () => {
     expect(labels).toContain('Cmaj');
   });
 
+  it('clears the stale hover identity when the data prop swaps', () => {
+    const { container, rerender } = render(
+      <MidiPianoRoll data={DATA} chords={[]} showChords={false} zoom={1} onZoomChange={() => {}} height={240} />,
+    );
+    // Hover the C4 note (midi 60, t≈0.15s) — a plain pointer move (no capture)
+    // takes the hit-test branch and sets the hover identity → tooltip appears.
+    fireEvent.pointerMove(container.querySelector('canvas'), { clientX: 100, clientY: 150 });
+    expect(container.textContent).toContain('C4');
+    ctx.stroke.mockClear();
+
+    // Swap in a different parse (no C4). The hover held a note object from the
+    // old `data`; the clear effect must drop it so the overlay stops stroking it.
+    const NEXT = {
+      durationSec: 2,
+      minMidi: 67,
+      maxMidi: 71,
+      notes: [{ id: '1:0', midi: 67, startSec: 0, durationSec: 0.5, velocity: 0.8, track: 0, name: 'G4' }],
+      tracks: [{ index: 0, name: null, noteCount: 1 }],
+    };
+    rerender(<MidiPianoRoll data={NEXT} chords={[]} showChords={false} zoom={1} onZoomChange={() => {}} height={240} />);
+    // Hover identity is gone: the tooltip no longer shows the old note…
+    expect(container.textContent).not.toContain('C4');
+    // …and a fresh repaint at the settled state strokes no hovered note.
+    ctx.stroke.mockClear();
+    rerender(<MidiPianoRoll data={NEXT} chords={[]} showChords={false} zoom={2} onZoomChange={() => {}} height={240} />);
+    expect(ctx.stroke).not.toHaveBeenCalled();
+  });
+
   it('renders an empty/default view-model without crashing', () => {
     const empty = { durationSec: 0, minMidi: 60, maxMidi: 71, notes: [], tracks: [] };
     expect(() => render(


### PR DESCRIPTION
## Summary

`client/src/components/songs/MidiPianoRoll.jsx` held its `hover` identity (a `{ kind, note|chord }` referencing objects from the *previous* `data`/`chords`) but never pruned it when the `data`/`chords` props swapped on a mounted instance. `paintOverlay` would then stroke the stale note/chord at coordinates mapped into the **new** file until the next pointer move or Escape — visible when a re-transcription (updating `midiTranscription.filename`) or the Retry path replaces the parse while a hover is active and the pointer is stationary over the canvas.

Fix: a `useEffect(() => setHover(null), [data, chords])` drops the stale hover identity on any file swap. The parent (`MidiVisualization.jsx`) memoizes both `data` (from `useMidiNotes`) and `chords` (`useMemo(..., [data])`), so both are referentially stable until the file actually changes — the effect never fires on ordinary re-renders and can't interfere with live hovering.

## Test plan

- Added a focused test to `MidiPianoRoll.test.jsx`: hover the C4 note, swap in a different parse (no C4), and assert the hover tooltip is gone and a subsequent repaint strokes no hovered note.
- Verified the test **fails** without the source fix and **passes** with it.
- `cd client && npx vitest run src/components/songs/MidiPianoRoll.test.jsx` → 8/8 passing.

Closes #2510