### PR TITLE
fix: prevent City HUD panel collisions

### DIFF
--- a/client/src/hooks/useCityViewport.js
+++ b/client/src/hooks/useCityViewport.js
@@ -7,26 +7,32 @@ import { useEffect, useState } from 'react';
 // once would double the always-live timers and stack the panels). We branch in JS
 // (not just CSS `lg:hidden`) so only one layout mounts and the branch is testable.
 //
-// Brackets mirror Tailwind's `sm` (640) and `lg` (1024):
-//   phone   : < 640          essential status + a single disclosure surface
-//   compact : 640 – 1023     condensed rail + collapsed launchers
-//   desktop : >= 1024        the full multi-panel cockpit (unchanged)
+// Brackets mirror Tailwind's `sm` (640) and `lg` (1024), with a height floor
+// for the full cockpit. Its top-left vitals stack and bottom-left map/action rail
+// are intentionally independent on a spacious desktop; on a short viewport those
+// anchors would otherwise overlap. The compact HUD keeps the same tools reachable
+// as one-at-a-time disclosure panels instead.
+//   phone   : < 640                    essential status + a single disclosure surface
+//   compact : 640 – 1023, or < 900px h condensed rail + collapsed launchers
+//   desktop : >= 1024 and >= 900px h   the full multi-panel cockpit
 export const CITY_PHONE_MAX = 639;
 export const CITY_COMPACT_MAX = 1023;
+export const CITY_DESKTOP_MIN_HEIGHT = 900;
 
-export function classifyCityViewport(width) {
+export function classifyCityViewport(width, height = Infinity) {
   if (width <= CITY_PHONE_MAX) return 'phone';
   if (width <= CITY_COMPACT_MAX) return 'compact';
+  if (height < CITY_DESKTOP_MIN_HEIGHT) return 'compact';
   return 'desktop';
 }
 
 export default function useCityViewport() {
   const [mode, setMode] = useState(() =>
-    typeof window === 'undefined' ? 'desktop' : classifyCityViewport(window.innerWidth),
+    typeof window === 'undefined' ? 'desktop' : classifyCityViewport(window.innerWidth, window.innerHeight),
   );
 
   useEffect(() => {
-    const onResize = () => setMode(classifyCityViewport(window.innerWidth));
+    const onResize = () => setMode(classifyCityViewport(window.innerWidth, window.innerHeight));
     onResize(); // sync once in case width changed before the listener attached
     window.addEventListener('resize', onResize);
     return () => window.removeEventListener('resize', onResize);

--- a/client/src/hooks/useCityViewport.test.jsx
+++ b/client/src/hooks/useCityViewport.test.jsx
@@ -2,9 +2,12 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import useCityViewport, { classifyCityViewport } from './useCityViewport.js';
 
-const setWidth = (w) => { window.innerWidth = w; };
+const setViewport = (width, height = 1080) => {
+  window.innerWidth = width;
+  window.innerHeight = height;
+};
 
-afterEach(() => setWidth(1024));
+afterEach(() => setViewport(1024));
 
 describe('classifyCityViewport', () => {
   it('classifies phone / compact / desktop at the sm+lg breakpoints', () => {
@@ -15,11 +18,16 @@ describe('classifyCityViewport', () => {
     expect(classifyCityViewport(1024)).toBe('desktop');
     expect(classifyCityViewport(1440)).toBe('desktop');
   });
+
+  it('uses the compact HUD when a desktop-width viewport is too short for both HUD rails', () => {
+    expect(classifyCityViewport(1440, 899)).toBe('compact');
+    expect(classifyCityViewport(1440, 900)).toBe('desktop');
+  });
 });
 
 describe('useCityViewport', () => {
   it('reports the initial bracket from the current width', () => {
-    setWidth(390);
+    setViewport(390);
     const { result } = renderHook(() => useCityViewport());
     expect(result.current.mode).toBe('phone');
     expect(result.current.isPhone).toBe(true);
@@ -27,16 +35,20 @@ describe('useCityViewport', () => {
     expect(result.current.isDesktop).toBe(false);
   });
 
-  it('updates on resize across brackets', () => {
-    setWidth(1440);
+  it('updates on resize across width and height brackets', () => {
+    setViewport(1440);
     const { result } = renderHook(() => useCityViewport());
     expect(result.current.isDesktop).toBe(true);
 
-    act(() => { setWidth(800); window.dispatchEvent(new Event('resize')); });
+    act(() => { setViewport(1440, 899); window.dispatchEvent(new Event('resize')); });
     expect(result.current.isCompact).toBe(true);
     expect(result.current.isCondensed).toBe(true);
 
-    act(() => { setWidth(375); window.dispatchEvent(new Event('resize')); });
+    act(() => { setViewport(800); window.dispatchEvent(new Event('resize')); });
+    expect(result.current.isCompact).toBe(true);
+    expect(result.current.isCondensed).toBe(true);
+
+    act(() => { setViewport(375); window.dispatchEvent(new Event('resize')); });
     expect(result.current.isPhone).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- switch City to its compact, one-panel-at-a-time dock when a desktop-width viewport is shorter than 900px
- keep Map and System Vitals reachable without allowing their HUD surfaces to overlap
- cover the height boundary and resize transition

## Validation

- `vitest run src/hooks/useCityViewport.test.jsx --root client --configLoader runner`
- `npm run lint --prefix client`
- `npm run build --prefix client`