### PR TITLE
fix(creative-director): honor locked aspect ratio + surface final video for directive-plan commissions

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,6 +1,9 @@
 # Unreleased
 
-## CoS self-learning reliability
+## Creative Director
+
+- **Commissioned videos now honor the project's locked aspect ratio** — a scheduled Creative Commission (e.g. a daily 9:16 clip) whose plan renders through `media_enqueueVideoJob` was rendering at the video worker's default 768×512 landscape box: the planner authored an `aspectRatio` string the worker doesn't read, and the project's locked preset was never resolved into the `width`/`height` the renderer actually consumes. The server now deterministically forces every directive-plan video render onto the project's locked aspect/quality/duration preset (the planner keeps ownership of prompt/style), and the `cd-plan` prompt documents the locked settings so the plan preview stays honest.
+- **A completed video commission no longer looks like it "did nothing"** — the directive-plan flow marked the project `complete` but never promoted the rendered clip to `finalVideoId`, so the Creative Director overview showed "Final video: not yet rendered" even though the render had landed in the media library. Plan completion now promotes the last rendered video to the project's final video (and backfills it on re-entry for already-complete projects).
 
 - **[issue-2620] Layered Intelligence stops re-proposing finished work** — completed plan items stay recognized as done, and proposal outcomes now distinguish merged, rejected, and abandoned instead of counting every closed issue as merged.
 - **[issue-2617] Task learning forgives fixed problems** — scheduling, model-routing, and self-diagnostics decisions now weigh recent runs instead of lifetime totals, so a task type recovers as soon as it starts succeeding again.

--- a/data.reference/prompts/stages/cd-plan.md
+++ b/data.reference/prompts/stages/cd-plan.md
@@ -36,6 +36,10 @@ Parameters (JSON schema): {{parametersJson}}
 
 {{/tools}}
 
+## Locked render settings
+
+This project is locked to **{{render.aspectRatio}}** ({{render.width}}×{{render.height}}), **{{render.quality}}** quality, target ~{{render.targetDurationSeconds}}s. For any `media_enqueueVideoJob` step, set ONLY the creative params (`prompt`, `negativePrompt`, `style`, and optionally a shorter per-beat `durationSeconds`). Do NOT set `aspectRatio`, `width`, `height`, `fps`, or `steps` — the server forces the locked geometry onto every render, so any values you supply for those are ignored.
+
 ## Task
 
 1. Decompose the directive into the smallest sequence of registry tool calls that delivers the requested deliverables. Prefer existing records over creating new ones where the constraints name a target universe/series id.

--- a/scripts/migrations/193-cd-plan-locked-render-settings.js
+++ b/scripts/migrations/193-cd-plan-locked-render-settings.js
@@ -1,0 +1,46 @@
+/**
+ * Update the `cd-plan` stage prompt to document the project's LOCKED render
+ * settings (aspect ratio / dimensions / quality / target duration).
+ *
+ * Background: the Creative Director planner authors `media_enqueueVideoJob`
+ * steps freehand. It historically guessed an `aspectRatio` string the video
+ * worker doesn't even read (`generateVideo` consumes `width`/`height`, not
+ * `aspectRatio`), so a commission locked to 9:16 rendered at the worker's
+ * default 768×512 box. The server now forces the locked geometry onto every
+ * render (server/services/creative/tools/media.js#enforceVideoRenderPreset);
+ * this prompt change tells the planner to stop supplying those params so the
+ * plan preview stays honest and the LLM doesn't fight the enforcement.
+ *
+ * Strategy: hash-driven prompt-replace via `./_lib.js`. Idempotent — only an
+ * install still carrying the pre-change shipped template is auto-updated; a
+ * customized copy is left alone with a merge hint.
+ */
+
+import { makePromptReplaceMigration } from './_lib.js';
+
+export const ACCEPTED_OLD_MD5 = {
+  'cd-plan.md': ['3ce871196a8fd04781b71b6780e89c86'], // pre-193 shipped
+};
+
+export const NEW_SHIPPED_MD5 = {
+  'cd-plan.md': '0768d6809645c2c1fe73cacae9740fe9', // post-193 (locked render settings)
+};
+
+const { applyMigration, up } = makePromptReplaceMigration({
+  accepted: ACCEPTED_OLD_MD5,
+  current: NEW_SHIPPED_MD5,
+  label: 'creative-director stage prompt',
+  customizedHint: (filename) =>
+    `   To apply the locked-render-settings note manually, diff:\n` +
+    `     data.reference/prompts/stages/${filename}\n` +
+    `   against your current:\n` +
+    `     data/prompts/stages/${filename}\n` +
+    `   and add the "## Locked render settings" section.`,
+  skipFooter: (count) =>
+    `⚠️  ${count} cd-plan prompt(s) could not be auto-updated because they were customized.\n` +
+    `   Video renders still get the locked aspect ratio (the server enforces it),\n` +
+    `   but the planner won't see the note until you merge it manually.`,
+});
+
+export { applyMigration };
+export default { up };

--- a/scripts/migrations/193-cd-plan-locked-render-settings.test.js
+++ b/scripts/migrations/193-cd-plan-locked-render-settings.test.js
@@ -1,0 +1,24 @@
+/**
+ * Test for migration 193 — cd-plan gains the "## Locked render settings" note.
+ *
+ * Uses the shared prompt-migration harness (seeds a fixture from the live
+ * data.reference/ template, asserts an install on the accepted-old hash is
+ * auto-updated to the new shipped hash and a customized copy is left alone).
+ *
+ * Picked up via the vitest include glob in server/vitest.config.js
+ * (`../scripts/**\/*.test.js`).
+ */
+import { describe } from 'vitest';
+
+import { runPromptMigrationTests } from './_testHelpers.js';
+import migration, { applyMigration, ACCEPTED_OLD_MD5, NEW_SHIPPED_MD5 } from './193-cd-plan-locked-render-settings.js';
+
+describe('migration 193 — cd-plan locked render settings', () => {
+  runPromptMigrationTests({
+    migration,
+    applyMigration,
+    ACCEPTED_OLD_MD5,
+    NEW_SHIPPED_MD5,
+    prefix: 'migration-193-',
+  });
+});

--- a/scripts/setup-data-drift.test.js
+++ b/scripts/setup-data-drift.test.js
@@ -48,6 +48,7 @@ const EXPECTED_STAGE_OLD = {
   'pipeline-editorial-on-the-nose.md': ['48182b49149e6b5829fbed71b3ffc242'],
   'pipeline-tv-script.md': ['3f6fecc25573ed054b47db392250034a'],
   'cd-treatment.md': ['2ffa482e7bfb6fe8b7224505fedbf712', '16d0ef6a7fd2533719a846019122ebee', '95b7685690ecfee4f682b0293b790277'],
+  'cd-plan.md': ['3ce871196a8fd04781b71b6780e89c86'],
   'pipeline-series-generate.md': ['bc72731124a2bd6304362f4402c6305d'],
 };
 const EXPECTED_STAGE_NEW = {
@@ -75,6 +76,7 @@ const EXPECTED_STAGE_NEW = {
   'pipeline-editorial-on-the-nose.md': 'e5786fb019e5bf19c7aa6ed0c8b35cda',
   'pipeline-tv-script.md': '376f779f4687b598f1c92ca4e770fd5a',
   'cd-treatment.md': 'd940eadfb406ce584f0e244032f33382',
+  'cd-plan.md': '0768d6809645c2c1fe73cacae9740fe9',
   'pipeline-series-generate.md': '21352c21ed6d4edb7a4b7c32704eff55',
 };
 const EXPECTED_PARTIAL_OLD = {

--- a/server/lib/creativeDirectorPrompts.js
+++ b/server/lib/creativeDirectorPrompts.js
@@ -94,9 +94,22 @@ function buildPlanView(project, toolSpecs) {
     parametersJson: JSON.stringify(s?.function?.parameters ?? {}),
   }));
   const currentSteps = Array.isArray(project.plan?.steps) ? project.plan.steps : [];
+  // Resolved render geometry for the LOCKED preset. Surfaced so the planner's
+  // media_enqueueVideoJob steps don't guess an aspectRatio/dimensions — the
+  // server forces these onto every video render (see media.js
+  // enforceVideoRenderPreset). `width`/`height` degrade to 0 on an unknown ratio.
+  const aspect = resolveAspectDimensions(project.aspectRatio, { width: 0, height: 0 });
+  const render = {
+    aspectRatio: project.aspectRatio,
+    quality: project.quality,
+    width: aspect.width,
+    height: aspect.height,
+    targetDurationSeconds: project.targetDurationSeconds,
+  };
   return {
     project: buildProjectView(project),
     apiUrl: PORTOS_API_URL,
+    render,
     directive: {
       goal: directive.goal || '',
       hasDeliverables: deliverables.length > 0,

--- a/server/lib/creativeDirectorPrompts.test.js
+++ b/server/lib/creativeDirectorPrompts.test.js
@@ -32,7 +32,7 @@ vi.mock('../services/promptService.js', () => ({
   }),
 }));
 
-const { buildTreatmentPrompt, buildEvaluatePrompt } = await import('./creativeDirectorPrompts.js');
+const { buildTreatmentPrompt, buildEvaluatePrompt, buildPlanPrompt } = await import('./creativeDirectorPrompts.js');
 
 const baseProject = {
   id: 'cd-1',
@@ -61,6 +61,20 @@ const baseScene = {
 
 beforeEach(() => {
   // Templates are loaded fresh from disk — no state to reset.
+});
+
+describe('buildPlanPrompt — locked render settings', () => {
+  const planProject = { ...baseProject, aspectRatio: '9:16', quality: 'high', directive: { goal: 'make a surreal clip', deliverables: [], constraints: {} } };
+  const toolSpecs = [{ type: 'function', function: { name: 'media_enqueueVideoJob', description: 'render', parameters: { type: 'object' } } }];
+
+  it('surfaces the project preset (9:16 → 432×768) so the planner stops guessing dimensions', async () => {
+    const out = await buildPlanPrompt(planProject, { toolSpecs });
+    expect(out).toContain('## Locked render settings');
+    expect(out).toContain('**9:16** (432×768)');
+    expect(out).toContain('**high** quality');
+    // Instructs the planner not to author the enforced params.
+    expect(out).toMatch(/Do NOT set `aspectRatio`, `width`, `height`, `fps`, or `steps`/);
+  });
 });
 
 describe('buildTreatmentPrompt — template-rendered output', () => {

--- a/server/services/creative/toolRegistry.test.js
+++ b/server/services/creative/toolRegistry.test.js
@@ -70,6 +70,10 @@ vi.mock('../pipeline/visualStages.js', () => ({
   refineComicPageRender: vi.fn(async () => ({ jobId: 'pgr1', variant: 'proof', pageIndex: 0 })),
 }));
 vi.mock('../mediaJobQueue/index.js', () => ({ enqueueJob: vi.fn(() => ({ jobId: 'mj1' })) }));
+// media_enqueueVideoJob reconciles render geometry against the project's locked
+// preset via a dynamic import of the CD project store — mock it so the video
+// preset-enforcement path is observable without a DB.
+vi.mock('../creativeDirector/local.js', () => ({ getProject: vi.fn(async () => null) }));
 vi.mock('../catalogDB.js', () => ({ listIngredients: vi.fn(async () => ({ items: [] })) }));
 vi.mock('../creativeDirector/autoCast.js', () => ({ suggestCastForBrief: vi.fn(async () => []) }));
 
@@ -81,6 +85,7 @@ import { generateStage } from '../pipeline/textStages.js';
 import { startSeriesAutopilot } from '../pipeline/seriesAutopilot.js';
 import { renderComicCover, renderVolumeCover, renderComicPage, refineComicPageRender } from '../pipeline/visualStages.js';
 import { enqueueJob } from '../mediaJobQueue/index.js';
+import { getProject } from '../creativeDirector/local.js';
 import {
   CREATIVE_TOOLS,
   getToolSpecs,
@@ -233,6 +238,39 @@ describe('budget charging', () => {
     await dispatchCreativeTool('media_enqueueImageJob', { params: { prompt: 'p' } }, { projectId: 'p1' });
     expect(recordDomainUsage).toHaveBeenCalledWith('cos', { actions: 1 });
     expect(enqueueJob).toHaveBeenCalledWith({ kind: 'image', params: { prompt: 'p' }, owner: 'creative-director:p1' });
+  });
+
+  it('forces a video render onto the project LOCKED aspect preset, dropping the planner-guessed aspectRatio', async () => {
+    setMode('execute');
+    // Project is locked to 9:16; the planner (wrongly) emitted a 16:9 string and
+    // no width/height — the exact shape that produced a 768×512 landscape render.
+    getProject.mockResolvedValueOnce({
+      id: 'p1', aspectRatio: '9:16', quality: 'high', targetDurationSeconds: 10,
+    });
+    await dispatchCreativeTool(
+      'media_enqueueVideoJob',
+      { params: { prompt: 'a surreal hallway', aspectRatio: '16:9', durationSeconds: 6 } },
+      { projectId: 'p1' },
+    );
+    const enqueued = enqueueJob.mock.calls.at(-1)[0];
+    expect(enqueued.kind).toBe('video');
+    // 9:16 preset → 432×768 (portrait), NOT the worker's 768×512 default.
+    expect(enqueued.params.width).toBe(432);
+    expect(enqueued.params.height).toBe(768);
+    // The worker-ignored aspectRatio key is stripped so it can't mislead.
+    expect(enqueued.params).not.toHaveProperty('aspectRatio');
+    // Creative content the planner owns is preserved.
+    expect(enqueued.params.prompt).toBe('a surreal hallway');
+    // A shorter per-beat duration wins for numFrames (6s × 30fps → 180, /8-rounded).
+    expect(enqueued.params.numFrames).toBe(184);
+    expect(enqueued.params.fps).toBe(30); // high quality
+  });
+
+  it('leaves video params untouched when there is no owning project (bare enqueue)', async () => {
+    setMode('execute');
+    // No projectId → the preset reconciliation short-circuits before any project read.
+    await dispatchCreativeTool('media_enqueueVideoJob', { params: { prompt: 'p', width: 640 } }, {});
+    expect(enqueueJob).toHaveBeenCalledWith({ kind: 'video', params: { prompt: 'p', width: 640 }, owner: 'creative' });
   });
 
   it('does not charge a free tool', async () => {

--- a/server/services/creative/tools/media.js
+++ b/server/services/creative/tools/media.js
@@ -6,9 +6,59 @@
 
 import { z } from 'zod';
 import { enqueueJob } from '../../mediaJobQueue/index.js';
+import { ASPECT_PRESETS, QUALITY_PRESETS, presetToRenderParams } from '../../../lib/creativeDirectorPresets.js';
 import { COST_RENDER, resolveOwner } from './shared.js';
 
 const paramsSchema = z.object({ params: z.record(z.any()).default({}), owner: z.string().optional() });
+
+/**
+ * Force a video render's dimensions + quality knobs onto the project's LOCKED
+ * preset, overriding whatever the planner LLM authored.
+ *
+ * The planner (cd-plan) writes `media_enqueueVideoJob` params freehand and has
+ * historically guessed an `aspectRatio` string (e.g. "16:9") that the video
+ * worker doesn't even read — `generateVideo` consumes `width`/`height`, not
+ * `aspectRatio`, and defaults to a 768×512 box when they're absent. That silently
+ * dropped the project's chosen 9:16. A project's aspect ratio / quality / target
+ * duration are locked at creation (see creativeDirectorPresets.js), so resolve
+ * them deterministically here rather than trusting the LLM to reproduce them.
+ *
+ * The planner still owns the CREATIVE params (`prompt`, `negativePrompt`,
+ * `style`, `durationSeconds`). Only the render geometry is enforced. An
+ * unrecognized aspect/quality (hand-edited/legacy project) falls through to the
+ * LLM's params untouched — best-effort, never throws.
+ */
+async function enforceVideoRenderPreset(params, ctx) {
+  if (!ctx?.projectId) return params;
+  const { getProject } = await import('../../creativeDirector/local.js');
+  const project = await getProject(ctx.projectId).catch(() => null);
+  // Only a directive-driven CD project locks a preset; a bare enqueue (no
+  // recognized aspect/quality) keeps the caller's params as-is.
+  if (!project || !ASPECT_PRESETS[project.aspectRatio] || !QUALITY_PRESETS[project.quality]) {
+    return params;
+  }
+  // The planner may legitimately ask for a shorter beat than the project target,
+  // so a positive per-step durationSeconds wins; otherwise use the project's.
+  const stepDuration = Number(params?.durationSeconds);
+  const durationSeconds = stepDuration > 0 ? stepDuration : (project.targetDurationSeconds || 10);
+  const preset = presetToRenderParams({
+    aspectRatio: project.aspectRatio,
+    quality: project.quality,
+    durationSeconds,
+  });
+  // Drop the worker-ignored `aspectRatio` key so a stale value can't mislead, and
+  // force the locked geometry + quality-derived knobs.
+  const { aspectRatio: _ignored, ...rest } = params || {};
+  return {
+    ...rest,
+    width: preset.width,
+    height: preset.height,
+    fps: preset.fps,
+    numFrames: preset.numFrames,
+    steps: preset.steps,
+    guidanceScale: preset.guidanceScale,
+  };
+}
 
 const mediaTool = (kind, label) => ({
   name: `media_enqueue${label}Job`,
@@ -24,7 +74,12 @@ const mediaTool = (kind, label) => ({
     },
     required: ['params'],
   },
-  execute: (args, ctx) => enqueueJob({ kind, params: args.params || {}, owner: resolveOwner(args, ctx) }),
+  execute: async (args, ctx) => {
+    const params = kind === 'video'
+      ? await enforceVideoRenderPreset(args.params || {}, ctx)
+      : (args.params || {});
+    return enqueueJob({ kind, params, owner: resolveOwner(args, ctx) });
+  },
 });
 
 export const MEDIA_TOOLS = [

--- a/server/services/creativeDirector/planAdvance.js
+++ b/server/services/creativeDirector/planAdvance.js
@@ -38,6 +38,28 @@ const AUTOPILOT_TOOL_NAME = 'pipeline_startSeriesAutopilot';
 
 const nowISO = () => new Date().toISOString();
 
+// The registry tool a plan step uses to render a video. Its done result carries
+// `{ jobId }`, and a video history entry's id === its jobId — so the last such
+// step's jobId is the project's final video (see the `complete` branch below).
+const VIDEO_RENDER_TOOL_NAME = 'media_enqueueVideoJob';
+
+/**
+ * The jobId of the LAST done video-render step in a plan (or null). Used to
+ * promote a directive plan's produced video to the project's `finalVideoId` on
+ * completion so the CD overview surfaces it. Pure + last-wins: a multi-render
+ * plan resolves to its final cut in listed order.
+ */
+export function lastRenderedVideoJobId(plan) {
+  const steps = Array.isArray(plan?.steps) ? plan.steps : [];
+  for (let i = steps.length - 1; i >= 0; i -= 1) {
+    const step = steps[i];
+    if (step?.toolName === VIDEO_RENDER_TOOL_NAME && step.status === 'done' && step.result?.jobId) {
+      return step.result.jobId;
+    }
+  }
+  return null;
+}
+
 /**
  * Pure next-step derivation over a plan DAG. Exported + side-effect-free so the
  * ordering/dependency/terminal logic is unit-tested directly against fixtures.
@@ -174,13 +196,24 @@ export async function advanceAfterPlanStepSettled(projectId) {
       // hand-edited/legacy record). Send it through the failure handler.
       return handlePlanStepFailure(projectId, action.steps[0]);
     case 'empty':
-    case 'complete':
-      if (project.status !== 'complete') {
-        await updateProject(projectId, { status: 'complete' })
+    case 'complete': {
+      // Promote the plan's produced video so the CD overview has an artifact to
+      // show. Unlike the legacy scene/stitch flow (stitchRunner sets
+      // finalVideoId), the directive-plan flow historically only flipped status
+      // to `complete` — so a finished video commission looked like it "did
+      // nothing" even though a render landed in the media library. A video
+      // history entry's id === its jobId, so the last done video-render step's
+      // jobId IS the final video id. Null when already set or a video-less plan
+      // (e.g. a comic) — which also keeps a re-entry from re-writing state.
+      const videoId = project.finalVideoId ? null : lastRenderedVideoJobId(project.plan);
+      if (project.status !== 'complete' || videoId) {
+        const patch = { status: 'complete', ...(videoId ? { finalVideoId: videoId } : {}) };
+        await updateProject(projectId, patch)
           .catch((e) => console.log(`⚠️ CD plan complete for ${projectId} failed: ${e.message}`));
-        console.log(`✅ CD plan ${projectId} complete`);
+        console.log(`✅ CD plan ${projectId} complete${videoId ? ` (final video ${videoId})` : ''}`);
       }
       return;
+    }
     case 'run':
       return runPlanStep(project, action.step);
     default:

--- a/server/services/creativeDirector/planAdvance.test.js
+++ b/server/services/creativeDirector/planAdvance.test.js
@@ -12,9 +12,30 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ---- pure derivation (no mocks needed) -------------------------------------
-import { deriveNextPlanAction } from './planAdvance.js';
+import { deriveNextPlanAction, lastRenderedVideoJobId } from './planAdvance.js';
 
 const step = (id, over = {}) => ({ stepId: id, toolName: 't', args: {}, dependsOn: [], status: 'pending', ...over });
+
+describe('lastRenderedVideoJobId (pure)', () => {
+  const vstep = (id, over = {}) => step(id, { toolName: 'media_enqueueVideoJob', status: 'done', ...over });
+  it('returns the jobId of the last done video-render step', () => {
+    const plan = { steps: [
+      vstep('r1', { result: { jobId: 'v1' } }),
+      step('mid', { toolName: 'pipeline_createSeries', status: 'done' }),
+      vstep('r2', { result: { jobId: 'v2' } }),
+    ] };
+    expect(lastRenderedVideoJobId(plan)).toBe('v2'); // last wins
+  });
+  it('ignores non-done video steps and non-video steps', () => {
+    expect(lastRenderedVideoJobId({ steps: [vstep('r1', { status: 'failed', result: { jobId: 'v1' } })] })).toBeNull();
+    expect(lastRenderedVideoJobId({ steps: [step('x', { toolName: 'media_enqueueImageJob', status: 'done', result: { jobId: 'i1' } })] })).toBeNull();
+  });
+  it('returns null for a video step with no jobId, empty, or missing plan', () => {
+    expect(lastRenderedVideoJobId({ steps: [vstep('r1', { result: {} })] })).toBeNull();
+    expect(lastRenderedVideoJobId({ steps: [] })).toBeNull();
+    expect(lastRenderedVideoJobId(null)).toBeNull();
+  });
+});
 
 describe('deriveNextPlanAction (pure)', () => {
   it('empty plan → { type: empty }', () => {
@@ -200,6 +221,25 @@ describe('advanceAfterPlanStepSettled — executor', () => {
     const p = read();
     expect(p.plan.steps.map((s) => s.status)).toEqual(['done', 'done']);
     expect(p.status).toBe('complete');
+  });
+
+  it('promotes the last done video-render step to finalVideoId on completion', async () => {
+    const read = makeStore(planProject([
+      step('render', { toolName: 'media_enqueueVideoJob', status: 'done', result: { jobId: 'vid-42' } }),
+    ]));
+    await advanceAfterPlanStepSettled('cd-1');
+    const p = read();
+    expect(p.status).toBe('complete');
+    expect(p.finalVideoId).toBe('vid-42'); // overview now has an artifact to show
+  });
+
+  it('does not overwrite an existing finalVideoId on re-entry', async () => {
+    const read = makeStore(planProject([
+      step('render', { toolName: 'media_enqueueVideoJob', status: 'done', result: { jobId: 'vid-new' } }),
+    ], { status: 'complete', finalVideoId: 'vid-original' }));
+    await advanceAfterPlanStepSettled('cd-1');
+    expect(read().finalVideoId).toBe('vid-original');
+    expect(mockUpdateProject).not.toHaveBeenCalled(); // already complete + set → no redundant write
   });
 
   it('records a run per step and stores an id-only result summary', async () => {


### PR DESCRIPTION
## Summary

A scheduled Creative Commission (e.g. a daily 9:16 clip) whose plan renders through `media_enqueueVideoJob` was rendering at the video worker's default **768×512 landscape** box, and the Creative Director overview showed **"Final video: not yet rendered"** even though the clip had landed in the media library. Two independent defects, both in the **directive → planner → `media_enqueueVideoJob`** path (which bypasses the scene-render flow that already resolves locked presets):

**1. Aspect ratio ignored.** The LLM planner authored `media_enqueueVideoJob` params freehand — including an `aspectRatio` string the video worker doesn't even read (`generateVideo` consumes `width`/`height`, defaulting to 768×512). The project's locked preset was never resolved into concrete dimensions.
- `media.js#enforceVideoRenderPreset` now deterministically forces `width/height/fps/numFrames/steps/guidanceScale` from the project's locked aspect/quality/duration preset on every CD-owned video render, strips the worker-ignored `aspectRatio` key, and keeps the planner's creative params (prompt/style).
- The `cd-plan` prompt now documents the locked settings so the plan preview stays honest (migration `193` + drift-table entries, per the stage-prompt-migration rule).

**2. Final video never surfaced.** The directive-plan completion path flipped status to `complete` but never set `finalVideoId` (only the legacy scene/stitch flow did), so the overview had no artifact to show.
- `planAdvance` now promotes the last done video-render step's `jobId` to `finalVideoId` on completion (a video history entry's id === its jobId), backfilling on re-entry and skipping redundant writes for video-less plans (e.g. comics).

## Test plan

- `server/services/creative/toolRegistry.test.js` — 9:16 preset forced to 432×768, `aspectRatio` stripped, creative params + shorter per-beat duration preserved; bare enqueue (no project) passes params through untouched.
- `server/services/creativeDirector/planAdvance.test.js` — `finalVideoId` promoted on completion; existing `finalVideoId` not overwritten on re-entry; `lastRenderedVideoJobId` pure cases.
- `server/lib/creativeDirectorPrompts.test.js` — plan prompt renders the locked-render-settings note with resolved dimensions.
- `scripts/migrations/193-…test.js` + `scripts/setup-data-drift.test.js` — migration auto-updates an install on the pre-change shipped hash; drift table sweep includes `cd-plan.md`.
- Full server suite: **19,746 passed / 0 failed** (197 DB-gated skips).