### PR TITLE
Character: age-based level replaces XP leveling (+ CityXpBadge/characterXp)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -5,3 +5,7 @@
 - Creative Director projects that use the Antigravity provider no longer get stuck on "Planning." The agent now reliably receives its instructions instead of launching and sitting idle at an empty prompt (it waits for Antigravity's input box to be ready before sending, the same way the Claude provider does), so planning actually runs to completion.
 - A Creative Director project no longer wedges in "Planning" when its agent is interrupted or crashes mid-run. The stuck run is now cleaned up as soon as the dead agent is detected, so the project can retry on its own instead of waiting for the next server restart.
 - The Creative Director "Runs" tab now shows why a run failed (e.g. "interrupted by restart") instead of leaving failed runs blank with no explanation.
+
+## Character Sheet
+
+- `[issue-2673]` **Your Character level is now your age.** The Character's level is reframed as life experience — `level = floor(age in years)`, derived on read from your canonical birth date instead of being ground out of XP thresholds (JIRA tickets + CoS tasks). XP survives as a cumulative stat but no longer drives level, and the CyberCity HUD badge now shows the age-based level with a progress bar toward your next birthday (a friendly "set birth date" prompt when no birth date is set yet). Existing character records keep loading unchanged, and the derived level is excluded from cross-machine sync so peers never fight over a stale value.

--- a/client/src/components/city/CityHudCompact.jsx
+++ b/client/src/components/city/CityHudCompact.jsx
@@ -170,7 +170,7 @@ export default function CityHudCompact({
           <StatusDot on={connected} label={connected ? 'Link online' : 'Link offline'} onClass="bg-port-success shadow-[0_0_8px_rgba(34,197,94,0.6)]" offClass="bg-port-error" />
           <StatusDot on={cosStatus?.running} label={cosStatus?.running ? 'CoS running' : 'CoS idle'} onClass="bg-cyan-400 animate-pulse shadow-[0_0_8px_rgba(6,182,212,0.6)]" />
         </div>
-        {character?.level != null && (
+        {character?.level != null ? (
           <button
             type="button"
             onClick={() => navigate('/character')}
@@ -180,7 +180,19 @@ export default function CityHudCompact({
           >
             LV {character.level}
           </button>
-        )}
+        ) : character ? (
+          // Character loaded but no birthDate → level is null (age-based, #2673). Prompt the
+          // user to set it, routing to the age editor where the birth-date field lives.
+          <button
+            type="button"
+            onClick={() => navigate('/meatspace/age')}
+            aria-label="Set your birth date to show your level"
+            title="Set your birth date"
+            className="bg-black/85 backdrop-blur-sm border border-cyan-500/40 rounded-lg px-2.5 min-h-[44px] flex items-center font-pixel text-[11px] text-cyan-300/70 tracking-wider"
+          >
+            LV —
+          </button>
+        ) : null}
       </div>
 
       {/* Focused building detail sheet (issue #2593) — replaces the disclosure sheet while a

--- a/client/src/components/city/CityXpBadge.jsx
+++ b/client/src/components/city/CityXpBadge.jsx
@@ -1,18 +1,19 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { computeXpView, diffXp } from '../../utils/characterXp';
+import { computeAgeView, diffXp } from '../../utils/characterXp';
 
-// CyberCity character XP HUD badge (roadmap 2.11). A compact floating panel showing the
-// current level + an XP progress bar toward the next level (and HP when known). Since
-// there's no XP-gain socket event, useCityData polls the character on an interval; this
-// component diffs successive snapshots and fires a transient flash on XP gain — a louder,
-// longer celebratory flash on level-up.
+// CyberCity character HUD badge (roadmap 2.11; reframed in #2673). A compact floating panel
+// showing the current **age-based level** (life experience = age) and a progress bar =
+// fractional part of the current year of life (progress toward the next birthday), plus HP
+// when known. useCityData polls the character on an interval; this component still diffs
+// successive snapshots and fires a transient flash on XP gain (xp survives as a cumulative
+// stat) — a louder, longer celebratory flash when the level ticks up (a birthday).
 //
 // Animations are self-contained (transient state + inline transition) so the component
 // stays standalone and doesn't depend on global keyframes.
 export default function CityXpBadge({ character }) {
   const navigate = useNavigate();
-  const view = useMemo(() => computeXpView(character), [character]);
+  const view = useMemo(() => computeAgeView(character), [character]);
 
   const prevCharRef = useRef(null);
   // burst.kind: null | 'gain' | 'levelup' — drives the flash overlay; burst.seq forces a
@@ -47,6 +48,9 @@ export default function CityXpBadge({ character }) {
   const gaining = burst.kind !== null;
   const barColor = leveling ? '#f59e0b' : '#06b6d4';
   const pct = Math.round(view.progress * 100);
+  // No birthDate set → level is null; show a prompt instead of NaN. The badge still links
+  // to /character where the birth date can be set (Slice 5 owns the inline prompt UI).
+  const levelLabel = view.hasBirthDate ? `LV ${view.level}` : 'LV —';
 
   return (
     <div className="absolute bottom-16 right-3 pointer-events-auto">
@@ -82,11 +86,8 @@ export default function CityXpBadge({ character }) {
               className={`font-pixel text-base tracking-wider ${leveling ? 'text-amber-300' : 'text-cyan-300'}`}
               style={{ textShadow: leveling ? '0 0 10px rgba(245,158,11,0.7)' : '0 0 8px rgba(6,182,212,0.5)' }}
             >
-              LV {view.level}
+              {levelLabel}
             </span>
-            {view.atMax && (
-              <span className="font-pixel text-[8px] text-amber-400/80 tracking-wider">MAX</span>
-            )}
           </div>
           {gaining && burst.gained > 0 && (
             <span
@@ -98,12 +99,12 @@ export default function CityXpBadge({ character }) {
           )}
         </div>
 
-        {/* XP progress bar toward next level */}
+        {/* Progress bar toward the next birthday (fractional part of the current year) */}
         <div className="relative mt-1.5 w-full h-1.5 bg-gray-800/70 rounded-full overflow-hidden">
           <div
             className="h-full rounded-full transition-all duration-700"
             style={{
-              width: `${view.atMax ? 100 : pct}%`,
+              width: `${pct}%`,
               backgroundColor: barColor,
               boxShadow: `0 0 6px ${barColor}`,
             }}
@@ -112,7 +113,7 @@ export default function CityXpBadge({ character }) {
 
         <div className="relative flex items-center justify-between mt-1">
           <span className="font-pixel text-[8px] text-gray-500 tracking-wider">
-            {view.atMax ? 'MAX LEVEL' : `${view.xpIntoLevel}/${view.xpForNextLevel} XP`}
+            {view.hasBirthDate ? `${pct}% TO NEXT` : 'SET BIRTH DATE'}
           </span>
           {view.hp != null && view.maxHp != null && (
             <span

--- a/client/src/components/city/CityXpBadge.jsx
+++ b/client/src/components/city/CityXpBadge.jsx
@@ -27,7 +27,9 @@ export default function CityXpBadge({ character }) {
     if (!character) return;
 
     const { gained, leveledUp } = diffXp(prev, character);
-    if (gained <= 0) return;
+    // Fire on an XP gain (cyan) OR a birthday age-level tick (amber) — a birthday rarely
+    // coincides with an XP gain, so it must be able to burst on its own.
+    if (gained <= 0 && !leveledUp) return;
 
     setBurst(b => ({ kind: leveledUp ? 'levelup' : 'gain', seq: b.seq + 1, gained }));
     clearTimeout(burstTimerRef.current);
@@ -48,16 +50,17 @@ export default function CityXpBadge({ character }) {
   const gaining = burst.kind !== null;
   const barColor = leveling ? '#f59e0b' : '#06b6d4';
   const pct = Math.round(view.progress * 100);
-  // No birthDate set → level is null; show a prompt instead of NaN. The badge still links
-  // to /character where the birth date can be set (Slice 5 owns the inline prompt UI).
+  // No birthDate set → level is null; show a prompt instead of NaN, and send the click to the
+  // age editor (where the birth-date field actually lives) rather than the character sheet.
   const levelLabel = view.hasBirthDate ? `LV ${view.level}` : 'LV —';
+  const target = view.hasBirthDate ? '/character' : '/meatspace/age';
 
   return (
     <div className="absolute bottom-16 right-3 pointer-events-auto">
       <button
         type="button"
-        onClick={() => navigate('/character')}
-        title="Open character sheet"
+        onClick={() => navigate(target)}
+        title={view.hasBirthDate ? 'Open character sheet' : 'Set your birth date'}
         className={`relative block w-40 sm:w-48 bg-black/85 backdrop-blur-sm border rounded-lg px-3 py-2.5 overflow-hidden text-left transition-all duration-300 hover:bg-cyan-500/10 ${
           leveling
             ? 'border-amber-400/70 shadow-[0_0_16px_rgba(245,158,11,0.5)]'

--- a/client/src/pages/CharacterSheet.jsx
+++ b/client/src/pages/CharacterSheet.jsx
@@ -18,18 +18,6 @@ const charGet = (options = {}) => api.get('/character', { silent: true, ...optio
 const charPost = (path, body, options = {}) => api.post(`/character${path}`, body, { silent: true, ...options });
 const charPut = (body, options = {}) => api.put('/character', body, { silent: true, ...options });
 
-// D&D 5e XP thresholds (must match server)
-const XP_THRESHOLDS = [
-  0, 300, 900, 2700, 6500, 14000, 23000, 34000, 48000, 64000,
-  85000, 100000, 120000, 140000, 165000, 195000, 225000, 265000, 305000, 355000
-];
-function xpForNextLevel(level) {
-  return level >= 20 ? XP_THRESHOLDS[19] : XP_THRESHOLDS[level];
-}
-function xpForCurrentLevel(level) {
-  return level <= 1 ? 0 : XP_THRESHOLDS[level - 1];
-}
-
 const EVENT_ICONS = {
   damage: Sword,
   xp: Star,
@@ -296,10 +284,12 @@ export default function CharacterSheet() {
   }
 
   const hpPct = Math.max(0, Math.min(100, (char.hp / char.maxHp) * 100));
-  const nextLevelXP = xpForNextLevel(char.level);
-  const currentLevelXP = xpForCurrentLevel(char.level);
-  const levelRange = nextLevelXP - currentLevelXP;
-  const xpPct = char.level >= 20 ? 100 : Math.max(0, Math.min(100, ((char.xp - currentLevelXP) / levelRange) * 100));
+  // Level is age-derived now (#2673) — it no longer maps to an XP threshold, so the old
+  // "XP toward next level" bar is gone. XP survives as a plain cumulative stat here; the
+  // birthday-progress bar lives on the CyberCity HUD badge (full page reframe is Slice 5).
+  const birthdayPct = Number.isFinite(char.ageYears)
+    ? Math.round((char.ageYears - Math.floor(char.ageYears)) * 100)
+    : 0;
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
@@ -421,7 +411,7 @@ export default function CharacterSheet() {
             <div className="flex-shrink-0 flex items-center gap-3">
               <div className="relative w-20 h-20 flex items-center justify-center rounded-full border-2 border-port-accent bg-port-bg">
                 <div className="text-center">
-                  <div className="text-2xl font-bold text-port-accent">{char.level}</div>
+                  <div className="text-2xl font-bold text-port-accent">{char.level ?? '—'}</div>
                   <div className="text-[10px] uppercase tracking-wider text-gray-500">Level</div>
                 </div>
               </div>
@@ -447,24 +437,30 @@ export default function CharacterSheet() {
             </div>
           </div>
 
-          {/* XP Bar */}
-          <div className="mt-3">
-            <div className="flex items-center justify-between mb-1">
-              <div className="flex items-center gap-1.5 text-sm font-medium text-gray-300">
-                <Sparkles className="w-4 h-4 text-port-warning" />
-                XP
-              </div>
-              <span className="text-sm text-gray-400">
-                {char.xp} / {nextLevelXP}
-              </span>
+          {/* XP — a cumulative stat now (no longer a level-progress bar; level is age-based) */}
+          <div className="mt-3 flex items-center justify-between">
+            <div className="flex items-center gap-1.5 text-sm font-medium text-gray-300">
+              <Sparkles className="w-4 h-4 text-port-warning" />
+              XP
             </div>
-            <div className="h-3 bg-port-bg rounded-full overflow-hidden border border-port-border">
-              <div
-                className="h-full rounded-full transition-all duration-500 ease-out bg-port-warning"
-                style={{ width: `${xpPct}%` }}
-              />
-            </div>
+            <span className="text-sm text-gray-400">{char.xp}</span>
           </div>
+
+          {/* Progress toward the next birthday (fractional part of the current year of life) */}
+          {char.level != null && (
+            <div className="mt-3">
+              <div className="flex items-center justify-between mb-1">
+                <div className="text-sm font-medium text-gray-300">Next birthday</div>
+                <span className="text-sm text-gray-400">{birthdayPct}%</span>
+              </div>
+              <div className="h-3 bg-port-bg rounded-full overflow-hidden border border-port-border">
+                <div
+                  className="h-full rounded-full transition-all duration-500 ease-out bg-port-accent"
+                  style={{ width: `${birthdayPct}%` }}
+                />
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Quick Actions */}

--- a/client/src/utils/README.md
+++ b/client/src/utils/README.md
@@ -57,7 +57,7 @@ grep -i "what you want to do" client/src/utils/README.md
 
 | Module | Purpose |
 |---|---|
-| `characterXp` | Avatar XP/level math: `levelFromXP`, `computeXpView`, `diffXp`, and the XP threshold table. |
+| `characterXp` | Character HUD badge math: `computeAgeView` (age-based level + progress to next birthday), plus legacy XP helpers `levelFromXP`, `computeXpView`, `diffXp` and the XP threshold table. |
 
 ## CyberCity — scene compute helpers
 

--- a/client/src/utils/characterXp.js
+++ b/client/src/utils/characterXp.js
@@ -1,8 +1,11 @@
-// Pure, deterministic helpers for CyberCity's character XP HUD badge (roadmap 2.11):
-// given the D&D-style character sheet from GET /api/character, compute a view-model
-// for the floating level/XP badge (current level, progress toward the next level) and
-// detect XP gains / level-ups by diffing two successive character snapshots. No React
-// imports so the math is unit-testable (mirrors cityTaskQueue.js).
+// Pure, deterministic helpers for CyberCity's character HUD badge (roadmap 2.11): given the
+// character sheet from GET /api/character, compute the badge view-model and detect XP gains
+// by diffing two successive snapshots. No React imports so the math is unit-testable.
+//
+// As of #2673 the badge shows an **age-based level** (`computeAgeView`) — level = years lived
+// — with a progress bar toward the next birthday. The legacy XP-threshold helpers below
+// (`levelFromXP`, `computeXpView`, `XP_THRESHOLDS`) are retained for `cityArtifacts` and the
+// D&D-style `/character` page; the badge no longer uses them.
 
 // MIRRORS the server constant `XP_THRESHOLDS` in server/services/character.js — index i
 // is the cumulative XP required to reach level i+1. Keep these two arrays in sync: if the
@@ -54,6 +57,40 @@ export function computeXpView(character) {
     xpToNext: atMax ? 0 : Math.max(0, nextThreshold - xp),
     progress,
     atMax,
+    hp: Number.isFinite(character?.hp) ? character.hp : null,
+    maxHp: Number.isFinite(character?.maxHp) ? character.maxHp : null,
+  };
+}
+
+// Age-based level view-model for the CyberCity badge (#2673, epic #2672). The Character's
+// level is now life experience = age: `level = floor(ageYears)`, derived server-side from
+// the canonical birthDate. The badge shows that age level and a progress bar = fractional
+// part of the current year of life (progress toward the next birthday). Tolerates a missing
+// character / unset birthDate (server sends `level: null`, `ageYears: null`) by returning a
+// zeroed view with `hasBirthDate: false` and never NaNs.
+export function computeAgeView(character) {
+  const ageYears = Number.isFinite(character?.ageYears) ? character.ageYears : null;
+  // Prefer the server-derived level; fall back to flooring ageYears if only that came through.
+  const level = Number.isFinite(character?.level)
+    ? Math.floor(character.level)
+    : (ageYears != null ? Math.floor(ageYears) : null);
+  const hasBirthDate = level != null;
+
+  // Fraction through the current year of life = progress toward the next birthday.
+  const progress = (hasBirthDate && ageYears != null)
+    ? Math.min(1, Math.max(0, ageYears - Math.floor(ageYears)))
+    : 0;
+
+  const xp = Number.isFinite(character?.xp) ? Math.max(0, character.xp) : 0;
+
+  return {
+    level,
+    ageYears,
+    hasBirthDate,
+    progress,
+    // Rough countdown to next birthday for the badge caption; null when age is unknown.
+    daysToNextBirthday: hasBirthDate ? Math.max(0, Math.ceil((1 - progress) * 365.25)) : null,
+    xp,
     hp: Number.isFinite(character?.hp) ? character.hp : null,
     maxHp: Number.isFinite(character?.maxHp) ? character.maxHp : null,
   };

--- a/client/src/utils/characterXp.js
+++ b/client/src/utils/characterXp.js
@@ -115,8 +115,10 @@ export function diffXp(prev, next) {
   const gained = Math.max(0, nextXp - prevXp);
   // Level is decoupled from XP now: a level-up burst fires only on a real age-level increase
   // (a birthday), never when an XP gain crosses a legacy threshold. When level is unknown
-  // (no birthDate on either snapshot) there is no level-up to celebrate.
+  // (no birthDate on either snapshot) there is no level-up to celebrate. This is independent
+  // of `gained` — a birthday almost never coincides with an XP gain, so gating it on XP would
+  // mean the celebration never fires. The badge decides to burst on `gained > 0 || leveledUp`.
   const leveledUp = prevLevel != null && nextLevel != null && nextLevel > prevLevel;
 
-  return { gained, leveledUp: gained > 0 && leveledUp };
+  return { gained, leveledUp };
 }

--- a/client/src/utils/characterXp.js
+++ b/client/src/utils/characterXp.js
@@ -96,9 +96,11 @@ export function computeAgeView(character) {
   };
 }
 
-// Compare two character snapshots to detect a fresh XP gain / level-up so the badge can
-// fire a transient burst. Tolerates null on either side (first poll has no prev). `gained`
-// is clamped to >= 0 so a manual XP reset (xp dropping) never reports a negative burst.
+// Compare two character snapshots to detect a fresh XP gain (cyan burst) and a level tick
+// (amber "level-up" burst). Since #2673 the level is age-based, so a level tick is a
+// *birthday* — detected purely from the `level` field, never from XP thresholds. Tolerates
+// null on either side (first poll has no prev). `gained` is clamped to >= 0 so a manual XP
+// reset (xp dropping) never reports a negative burst.
 export function diffXp(prev, next) {
   const prevXp = Number.isFinite(prev?.xp) ? prev.xp : null;
   const nextXp = Number.isFinite(next?.xp) ? next.xp : null;
@@ -111,9 +113,10 @@ export function diffXp(prev, next) {
   }
 
   const gained = Math.max(0, nextXp - prevXp);
-  const leveledUp = prevLevel != null && nextLevel != null
-    ? nextLevel > prevLevel
-    : levelFromXP(nextXp) > levelFromXP(prevXp);
+  // Level is decoupled from XP now: a level-up burst fires only on a real age-level increase
+  // (a birthday), never when an XP gain crosses a legacy threshold. When level is unknown
+  // (no birthDate on either snapshot) there is no level-up to celebrate.
+  const leveledUp = prevLevel != null && nextLevel != null && nextLevel > prevLevel;
 
   return { gained, leveledUp: gained > 0 && leveledUp };
 }

--- a/client/src/utils/characterXp.test.js
+++ b/client/src/utils/characterXp.test.js
@@ -179,6 +179,13 @@ describe('diffXp', () => {
     expect(d.leveledUp).toBe(true);
   });
 
+  it('reports a birthday level-up even when XP did not change', () => {
+    // A birthday almost never coincides with an XP gain — leveledUp must not depend on gained.
+    const d = diffXp({ xp: 150, level: 41 }, { xp: 150, level: 42 });
+    expect(d.gained).toBe(0);
+    expect(d.leveledUp).toBe(true);
+  });
+
   it('does not burst on the first poll (no prior snapshot)', () => {
     expect(diffXp(null, { xp: 500, level: 2 })).toEqual({ gained: 0, leveledUp: false });
     expect(diffXp(undefined, { xp: 500 })).toEqual({ gained: 0, leveledUp: false });

--- a/client/src/utils/characterXp.test.js
+++ b/client/src/utils/characterXp.test.js
@@ -4,6 +4,7 @@ import {
   MAX_LEVEL,
   levelFromXP,
   computeXpView,
+  computeAgeView,
   diffXp,
 } from './characterXp';
 
@@ -93,6 +94,55 @@ describe('computeXpView', () => {
     expect(computeXpView({ xp: 0, level: 1 }).xp).toBe(0);
     // both render as zero, but neither throws or NaNs
     expect(computeXpView({ xp: 0, level: 1 }).progress).toBe(0);
+  });
+});
+
+describe('computeAgeView', () => {
+  it('derives the age level and progress toward the next birthday', () => {
+    const vm = computeAgeView({ level: 42, ageYears: 42.5, xp: 1000, hp: 12, maxHp: 15 });
+    expect(vm.level).toBe(42);
+    expect(vm.hasBirthDate).toBe(true);
+    expect(vm.progress).toBeCloseTo(0.5);
+    expect(vm.xp).toBe(1000);
+    expect(vm.hp).toBe(12);
+    expect(vm.maxHp).toBe(15);
+    expect(Number.isNaN(vm.progress)).toBe(false);
+  });
+
+  it('floors ageYears for level when only ageYears is present', () => {
+    const vm = computeAgeView({ ageYears: 30.9, xp: 0 });
+    expect(vm.level).toBe(30);
+    expect(vm.progress).toBeCloseTo(0.9);
+    expect(vm.hasBirthDate).toBe(true);
+  });
+
+  it('is 0 progress exactly on a birthday', () => {
+    const vm = computeAgeView({ level: 40, ageYears: 40 });
+    expect(vm.level).toBe(40);
+    expect(vm.progress).toBe(0);
+  });
+
+  it('returns a safe no-birthDate view (null level, no NaN)', () => {
+    for (const input of [null, undefined, {}, { level: null, ageYears: null, xp: 500 }]) {
+      const vm = computeAgeView(input);
+      expect(vm.level).toBeNull();
+      expect(vm.hasBirthDate).toBe(false);
+      expect(vm.progress).toBe(0);
+      expect(vm.daysToNextBirthday).toBeNull();
+      expect(Number.isNaN(vm.progress)).toBe(false);
+    }
+  });
+
+  it('carries xp through as a stat while level is null (no birthDate)', () => {
+    const vm = computeAgeView({ level: null, ageYears: null, xp: 777 });
+    expect(vm.xp).toBe(777);
+    expect(vm.level).toBeNull();
+  });
+
+  it('computes a bounded days-to-next-birthday countdown', () => {
+    const vm = computeAgeView({ level: 25, ageYears: 25.0 });
+    expect(vm.daysToNextBirthday).toBeGreaterThan(360);
+    expect(vm.daysToNextBirthday).toBeLessThanOrEqual(366);
   });
 });
 

--- a/client/src/utils/characterXp.test.js
+++ b/client/src/utils/characterXp.test.js
@@ -165,9 +165,17 @@ describe('diffXp', () => {
     expect(d.leveledUp).toBe(true);
   });
 
-  it('infers level-up from XP when level fields are absent', () => {
+  it('does NOT infer a level-up from XP when level fields are absent (level is age-based)', () => {
+    // No birthDate → level is null on both snapshots. An XP gain crossing a legacy
+    // threshold must not fire the birthday "level-up" flash (#2673 decouples xp from level).
     const d = diffXp({ xp: 250 }, { xp: 400 }); // crosses the 300 threshold
     expect(d.gained).toBe(150);
+    expect(d.leveledUp).toBe(false);
+  });
+
+  it('fires a level-up only on a real age-level increase (birthday)', () => {
+    const d = diffXp({ xp: 100, level: 41 }, { xp: 150, level: 42 });
+    expect(d.gained).toBe(50);
     expect(d.leveledUp).toBe(true);
   });
 

--- a/client/src/utils/cityArtifacts.js
+++ b/client/src/utils/cityArtifacts.js
@@ -68,7 +68,9 @@ function finiteOrNull(value) {
 // `level` field (a legacy payload that predates age-based level) falls back to XP.
 export function effectiveLevel(character) {
   const lvl = character?.level;
-  if (Number.isFinite(lvl) && lvl >= 1) return Math.floor(lvl);
+  // Any finite nonnegative level is authoritative — including 0, a legitimate age level for a
+  // birthDate less than a year ago. (`>= 1` would reject it and let XP unlock level artifacts.)
+  if (Number.isFinite(lvl) && lvl >= 0) return Math.floor(lvl);
   if (lvl === null) return null;
   const xp = finiteOrNull(character?.xp);
   if (xp === null) return null;

--- a/client/src/utils/cityArtifacts.js
+++ b/client/src/utils/cityArtifacts.js
@@ -61,11 +61,15 @@ function finiteOrNull(value) {
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
-// Effective character level: trust a stored, consistent `level`; otherwise derive it from xp
-// (mirrors computeXpView in characterXp.js). Returns null when neither is usable.
+// Effective character level. The level is age-based now (#2673): a finite `level` is the
+// age-derived value; an explicit `null` means the birthDate is unset, so age — the ONLY level
+// source — is unknown and we return null WITHOUT resurrecting an XP-derived level (otherwise
+// XP would silently unlock level trophies/eggs while the HUD shows "LV —"). Only an ABSENT
+// `level` field (a legacy payload that predates age-based level) falls back to XP.
 export function effectiveLevel(character) {
   const lvl = character?.level;
   if (Number.isFinite(lvl) && lvl >= 1) return Math.floor(lvl);
+  if (lvl === null) return null;
   const xp = finiteOrNull(character?.xp);
   if (xp === null) return null;
   return levelFromXP(xp);

--- a/client/src/utils/cityArtifacts.test.js
+++ b/client/src/utils/cityArtifacts.test.js
@@ -21,9 +21,16 @@ describe('effectiveLevel', () => {
     expect(effectiveLevel({ level: 3.9 })).toBe(3); // floored
   });
 
-  it('derives level from xp when no usable level', () => {
+  it('derives level from xp only when the level field is ABSENT (legacy payload)', () => {
     expect(effectiveLevel({ xp: 300 })).toBe(2); // 300 xp → level 2
     expect(effectiveLevel({ xp: 0 })).toBe(1);
+  });
+
+  it('returns null for an explicit null level (age unknown) — no XP fallback', () => {
+    // Age-based level (#2673): birthDate unset → level: null. XP must not resurrect a level,
+    // or trophies/eggs would unlock while the HUD shows "LV —".
+    expect(effectiveLevel({ level: null, xp: 999999 })).toBeNull();
+    expect(effectiveLevel({ level: null, xp: 0 })).toBeNull();
   });
 
   it('returns null when neither level nor xp is usable', () => {

--- a/client/src/utils/cityArtifacts.test.js
+++ b/client/src/utils/cityArtifacts.test.js
@@ -33,10 +33,14 @@ describe('effectiveLevel', () => {
     expect(effectiveLevel({ level: null, xp: 0 })).toBeNull();
   });
 
+  it('treats age level 0 (birthDate < 1yr ago) as authoritative, not an XP fallback', () => {
+    expect(effectiveLevel({ level: 0, xp: 999999 })).toBe(0);
+  });
+
   it('returns null when neither level nor xp is usable', () => {
     expect(effectiveLevel(null)).toBeNull();
     expect(effectiveLevel({})).toBeNull();
-    expect(effectiveLevel({ level: 0, xp: 'nope' })).toBeNull();
+    expect(effectiveLevel({ level: null, xp: 'nope' })).toBeNull();
   });
 });
 

--- a/client/src/utils/cityEasterEggs.test.js
+++ b/client/src/utils/cityEasterEggs.test.js
@@ -13,9 +13,12 @@ const completedGoals = (n) =>
   Array.from({ length: n }, (_, i) => ({ id: `g-${i}`, status: 'completed' }));
 
 describe('eggContext', () => {
-  it('normalizes level to floored int >= 1, else null', () => {
+  it('normalizes level to a floored nonnegative int, else null', () => {
     expect(eggContext({ character: { level: 7.9 } }).level).toBe(7);
-    expect(eggContext({ character: { level: 0 } }).level).toBeNull();
+    // Age level 0 (birthDate < 1yr ago) is authoritative now (#2673), not null.
+    expect(eggContext({ character: { level: 0 } }).level).toBe(0);
+    // Explicit null (no birthDate) and an absent character both yield null.
+    expect(eggContext({ character: { level: null } }).level).toBeNull();
     expect(eggContext({}).level).toBeNull();
   });
 

--- a/server/services/character.js
+++ b/server/services/character.js
@@ -62,6 +62,21 @@ export function levelFromAge(ageYears) {
   return Number.isFinite(ageYears) ? Math.floor(ageYears) : null;
 }
 
+// Legacy pre-#2673 XP→level curve, retained ONLY for the federation wire projection
+// (getWireCharacter) so an older peer — which still levels off XP — receives a level
+// consistent with the shared `xp`. NOT used for the live age-based level.
+const LEGACY_XP_THRESHOLDS = [
+  0, 300, 900, 2700, 6500, 14000, 23000, 34000, 48000, 64000,
+  85000, 100000, 120000, 140000, 165000, 195000, 225000, 265000, 305000, 355000
+];
+function legacyLevelFromXp(xp) {
+  const safe = Number.isFinite(xp) ? xp : 0;
+  for (let i = LEGACY_XP_THRESHOLDS.length - 1; i >= 0; i--) {
+    if (safe >= LEGACY_XP_THRESHOLDS[i]) return i + 1;
+  }
+  return 1;
+}
+
 function createEvent(type, description, overrides = {}) {
   return {
     id: crypto.randomUUID(),
@@ -118,15 +133,17 @@ export async function getCharacter() {
 
 // Federation wire projection: the persisted record plus a backward-compatible integer `level`
 // for pre-#2673 peers, whose CharacterSheet indexes XP thresholds by `character.level` and
-// NaNs without it. The level is age-derived (or the historical default 1 when birthDate is
-// unset) but NOT persisted; `ageYears` is deliberately excluded so the sync checksum stays
-// stable between birthdays. New peers ignore the remote level (applyCharacterRemote no longer
-// merges it), so this projection is invisible to same-version installs.
+// NaNs without it. The level is the LEGACY xp-derived value (what those peers compute from the
+// same shared `xp`), NOT the age level — deliberately so it stays a pure function of
+// `character.json`: the file-mtime checksum that fingerprints the `character` category then
+// still invalidates correctly, whereas an age/time-derived level would drift out of sync with
+// that checksum on a birthday or a birthDate edit (which touch a different file). It is not
+// persisted, and new peers ignore the remote level (applyCharacterRemote no longer merges it),
+// so this projection is invisible to same-version installs.
 export async function getWireCharacter() {
   const raw = await readJSONFile(CHARACTER_FILE, null);
   if (!raw) return null;
-  const { birthDate } = await getBirthDate().catch(() => ({ birthDate: null }));
-  return { ...raw, level: levelFromAge(ageYearsFromBirthDate(birthDate)) ?? 1 };
+  return { ...raw, level: legacyLevelFromXp(raw.xp) };
 }
 
 export async function saveCharacter(data) {

--- a/server/services/character.js
+++ b/server/services/character.js
@@ -116,6 +116,19 @@ export async function getCharacter() {
   return enrichCharacter(await loadRawCharacter());
 }
 
+// Federation wire projection: the persisted record plus a backward-compatible integer `level`
+// for pre-#2673 peers, whose CharacterSheet indexes XP thresholds by `character.level` and
+// NaNs without it. The level is age-derived (or the historical default 1 when birthDate is
+// unset) but NOT persisted; `ageYears` is deliberately excluded so the sync checksum stays
+// stable between birthdays. New peers ignore the remote level (applyCharacterRemote no longer
+// merges it), so this projection is invisible to same-version installs.
+export async function getWireCharacter() {
+  const raw = await readJSONFile(CHARACTER_FILE, null);
+  if (!raw) return null;
+  const { birthDate } = await getBirthDate().catch(() => ({ birthDate: null }));
+  return { ...raw, level: levelFromAge(ageYearsFromBirthDate(birthDate)) ?? 1 };
+}
+
 export async function saveCharacter(data) {
   await ensureDir(PATHS.data);
   // Never persist derived fields — level is age-derived on read (#2673). Stripping them

--- a/server/services/character.js
+++ b/server/services/character.js
@@ -156,10 +156,10 @@ export async function takeDamage(diceNotation, description) {
   character.events.push(createEvent('damage', description || `Took ${roll.total} damage (${diceNotation})`, {
     damage: roll.total, diceNotation, diceRolls: roll.rolls
   }));
-  await saveCharacter(character);
+  const saved = await saveCharacter(character);
 
-  console.log(`💥 ${roll.total} damage (${diceNotation}: [${roll.rolls}]+${roll.modifier}) — ${character.hp}/${character.maxHp} HP`);
-  return { character, roll, totalDamage: roll.total };
+  console.log(`💥 ${roll.total} damage (${diceNotation}: [${roll.rolls}]+${roll.modifier}) — ${saved.hp}/${saved.maxHp} HP`);
+  return { character: saved, roll, totalDamage: roll.total };
 }
 
 export async function takeRest(type) {
@@ -175,10 +175,10 @@ export async function takeRest(type) {
   const hpRecovered = character.hp - oldHp;
 
   character.events.push(createEvent('rest', `${type === 'long' ? 'Long' : 'Short'} rest — recovered ${hpRecovered} HP`, { hpRecovered }));
-  await saveCharacter(character);
+  const saved = await saveCharacter(character);
 
-  console.log(`🛏️ ${type} rest — recovered ${hpRecovered} HP (${character.hp}/${character.maxHp})`);
-  return { character, hpRecovered };
+  console.log(`🛏️ ${type} rest — recovered ${hpRecovered} HP (${saved.hp}/${saved.maxHp})`);
+  return { character: saved, hpRecovered };
 }
 
 export async function addEvent(event) {

--- a/server/services/character.js
+++ b/server/services/character.js
@@ -1,6 +1,11 @@
 /**
  * Character Sheet Service
- * D&D 5e-style character tracking XP, HP, level, damage, rests, and events.
+ *
+ * The Character's `level` is **life experience = age**: each year lived is a level
+ * (`level = Math.floor(ageYears)`), derived on read from the canonical `birthDate`
+ * (see #2673, epic #2672). `xp` survives only as a cumulative stat — it no longer
+ * drives level. HP/damage/rest mechanics are retained for backward-compat with a
+ * flat maxHp (no longer scaled off level).
  */
 
 import crypto from 'crypto';
@@ -8,26 +13,33 @@ import path from 'path';
 import { atomicWrite, ensureDir, readJSONFile, PATHS } from '../lib/fileUtils.js';
 import * as jiraService from './jira.js';
 import * as cosService from './cos.js';
+import { getBirthDate } from './meatspace.js';
 
 const CHARACTER_FILE = path.join(PATHS.data, 'character.json');
 
-const BASE_HP = 10;
-const HP_PER_LEVEL = 5;
+// HP is no longer scaled off level (level is now age, which would balloon maxHp). The
+// damage/rest mechanics survive for backward-compat against a flat maxHp.
+const DEFAULT_MAX_HP = 15;
 
-const XP_THRESHOLDS = [
-  0, 300, 900, 2700, 6500, 14000, 23000, 34000, 48000, 64000,
-  85000, 100000, 120000, 140000, 165000, 195000, 225000, 265000, 305000, 355000
-];
+const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
 
-function getLevelFromXP(xp) {
-  for (let i = XP_THRESHOLDS.length - 1; i >= 0; i--) {
-    if (xp >= XP_THRESHOLDS[i]) return i + 1;
-  }
-  return 1;
+// Derived fields getCharacter() attaches on read; they are stripped before persisting so a
+// stale age-level never lands on disk or in the federated snapshot.
+const DERIVED_FIELDS = ['level', 'ageYears'];
+
+// Pure: fractional years lived since birthDate, or null when birthDate is unset/invalid.
+export function ageYearsFromBirthDate(birthDate, now = new Date()) {
+  if (!birthDate) return null;
+  const birth = new Date(birthDate);
+  if (Number.isNaN(birth.getTime())) return null;
+  const years = (now.getTime() - birth.getTime()) / MS_PER_YEAR;
+  if (!Number.isFinite(years) || years < 0) return null;
+  return Math.round(years * 100) / 100;
 }
 
-function getMaxHP(level) {
-  return BASE_HP + (level * HP_PER_LEVEL);
+// Pure: age-based level = whole years lived. null when age is unknown.
+export function levelFromAge(ageYears) {
+  return Number.isFinite(ageYears) ? Math.floor(ageYears) : null;
 }
 
 function createEvent(type, description, overrides = {}) {
@@ -45,27 +57,14 @@ function createEvent(type, description, overrides = {}) {
   };
 }
 
-function recalcLevel(character) {
-  const oldLevel = character.level;
-  character.level = getLevelFromXP(character.xp);
-  character.maxHp = getMaxHP(character.level);
-  const leveledUp = character.level > oldLevel;
-  if (leveledUp) {
-    character.hp = character.maxHp;
-    console.log(`🎉 Level up! ${oldLevel} -> ${character.level}`);
-  }
-  return leveledUp;
-}
-
 export function createDefaultCharacter() {
   const now = new Date().toISOString();
   return {
     name: 'Adventurer',
     class: 'Developer',
     xp: 0,
-    hp: 15,
-    maxHp: 15,
-    level: 1,
+    hp: DEFAULT_MAX_HP,
+    maxHp: DEFAULT_MAX_HP,
     events: [],
     syncedJiraTickets: [],
     syncedTaskIds: [],
@@ -74,19 +73,38 @@ export function createDefaultCharacter() {
   };
 }
 
-export async function getCharacter() {
+// Read the persisted record (no derived fields), creating the default on first access.
+// Mutating paths build on this so they never re-persist a derived age-level.
+async function loadRawCharacter() {
   const data = await readJSONFile(CHARACTER_FILE, null);
   if (data) return data;
   const character = createDefaultCharacter();
-  await saveCharacter(character);
+  await ensureDir(PATHS.data);
+  await atomicWrite(CHARACTER_FILE, character);
   return character;
+}
+
+// Attach the age-derived read-only fields (`ageYears`, `level`) to a raw record. `level` is
+// null when no birthDate is set, so callers can render a "set your birth date" prompt.
+async function enrichCharacter(raw) {
+  const { birthDate } = await getBirthDate().catch(() => ({ birthDate: null }));
+  const ageYears = ageYearsFromBirthDate(birthDate);
+  return { ...raw, ageYears, level: levelFromAge(ageYears) };
+}
+
+export async function getCharacter() {
+  return enrichCharacter(await loadRawCharacter());
 }
 
 export async function saveCharacter(data) {
   await ensureDir(PATHS.data);
-  data.updatedAt = new Date().toISOString();
-  await atomicWrite(CHARACTER_FILE, data);
-  return data;
+  // Never persist derived fields — level is age-derived on read (#2673). Stripping them
+  // keeps a stale level off disk and out of the federated character snapshot.
+  const persist = { ...data };
+  for (const field of DERIVED_FIELDS) delete persist[field];
+  persist.updatedAt = new Date().toISOString();
+  await atomicWrite(CHARACTER_FILE, persist);
+  return enrichCharacter(persist);
 }
 
 // Persist a freshly-rendered avatar path onto the singleton character. Lets the
@@ -120,13 +138,13 @@ export function rollDice(notation) {
 export async function addXP(amount, source, description) {
   const character = await getCharacter();
   character.xp += amount;
-  const leveledUp = recalcLevel(character);
 
   character.events.push(createEvent('xp', description || `Gained ${amount} XP from ${source}`, { xp: amount }));
-  await saveCharacter(character);
+  const saved = await saveCharacter(character);
 
-  console.log(`✨ +${amount} XP (${source}) — total ${character.xp} XP, level ${character.level}`);
-  return { character, leveledUp, newLevel: character.level };
+  console.log(`✨ +${amount} XP (${source}) — total ${saved.xp} XP, level ${saved.level ?? '—'}`);
+  // xp no longer drives level (level is age-derived, #2673) — an XP gain never levels up.
+  return { character: saved, leveledUp: false, newLevel: saved.level };
 }
 
 export async function takeDamage(diceNotation, description) {
@@ -176,8 +194,6 @@ export async function addEvent(event) {
     character.hp = Math.max(0, character.hp - roll.total);
   }
 
-  const leveledUp = recalcLevel(character);
-
   const logEntry = createEvent('custom', event.description, {
     xp: event.xp || 0,
     damage: roll ? roll.total : 0,
@@ -186,10 +202,10 @@ export async function addEvent(event) {
   });
 
   character.events.push(logEntry);
-  await saveCharacter(character);
+  const saved = await saveCharacter(character);
 
   console.log(`📝 Custom event: ${event.description}`);
-  return { character, event: logEntry, leveledUp };
+  return { character: saved, event: logEntry, leveledUp: false };
 }
 
 const delay = ms => new Promise(r => setTimeout(r, ms));
@@ -234,11 +250,10 @@ export async function syncJiraXP() {
     }
   }
 
-  const leveledUp = recalcLevel(character);
-  await saveCharacter(character);
+  const saved = await saveCharacter(character);
 
   console.log(`🎫 Synced ${ticketCount} JIRA tickets for ${totalXP} XP`);
-  return { character, ticketCount, totalXP, leveledUp };
+  return { character: saved, ticketCount, totalXP, leveledUp: false };
 }
 
 export async function syncTaskXP() {
@@ -260,9 +275,8 @@ export async function syncTaskXP() {
     character.events.push(createEvent('xp', `Task: ${task.title || task.description || task.id}`, { xp }));
   }
 
-  const leveledUp = recalcLevel(character);
-  await saveCharacter(character);
+  const saved = await saveCharacter(character);
 
   console.log(`✅ Synced ${taskCount} tasks for ${totalXP} XP`);
-  return { character, taskCount, totalXP, leveledUp };
+  return { character: saved, taskCount, totalXP, leveledUp: false };
 }

--- a/server/services/character.js
+++ b/server/services/character.js
@@ -21,20 +21,40 @@ const CHARACTER_FILE = path.join(PATHS.data, 'character.json');
 // damage/rest mechanics survive for backward-compat against a flat maxHp.
 const DEFAULT_MAX_HP = 15;
 
-const MS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
-
 // Derived fields getCharacter() attaches on read; they are stripped before persisting so a
 // stale age-level never lands on disk or in the federated snapshot.
 const DERIVED_FIELDS = ['level', 'ageYears'];
 
-// Pure: fractional years lived since birthDate, or null when birthDate is unset/invalid.
+// Pure: fractional years lived since birthDate (whole years + progress toward the next
+// birthday), or null when birthDate is unset/invalid/future. Uses **calendar** birthdays,
+// not a fixed 365.25-day average — averaging would tick the level up to a day early across
+// leap years. UTC components are used on both sides so the tick lands on the birthday's UTC
+// date regardless of the server's local timezone.
 export function ageYearsFromBirthDate(birthDate, now = new Date()) {
   if (!birthDate) return null;
   const birth = new Date(birthDate);
-  if (Number.isNaN(birth.getTime())) return null;
-  const years = (now.getTime() - birth.getTime()) / MS_PER_YEAR;
-  if (!Number.isFinite(years) || years < 0) return null;
-  return Math.round(years * 100) / 100;
+  if (Number.isNaN(birth.getTime()) || birth.getTime() > now.getTime()) return null;
+
+  // Completed calendar years = how many birthdays have passed.
+  let years = now.getUTCFullYear() - birth.getUTCFullYear();
+  const lastBirthday = new Date(birth);
+  lastBirthday.setUTCFullYear(birth.getUTCFullYear() + years);
+  if (lastBirthday.getTime() > now.getTime()) {
+    years -= 1;
+    lastBirthday.setUTCFullYear(lastBirthday.getUTCFullYear() - 1);
+  }
+  if (years < 0) return null;
+
+  // Fraction of the way from the last birthday to the next (progress toward next birthday).
+  const nextBirthday = new Date(lastBirthday);
+  nextBirthday.setUTCFullYear(lastBirthday.getUTCFullYear() + 1);
+  const span = nextBirthday.getTime() - lastBirthday.getTime();
+  // frac ∈ [0, 1): now is always ≥ lastBirthday and < nextBirthday. Do NOT round the sum —
+  // rounding e.g. 25.997 to 25.99→26.00 would push floor(ageYears) to the wrong level a day
+  // early. levelFromAge() floors this, and display consumers round the fractional part.
+  const frac = span > 0 ? Math.min(0.999999, Math.max(0, (now.getTime() - lastBirthday.getTime()) / span)) : 0;
+
+  return years + frac;
 }
 
 // Pure: age-based level = whole years lived. null when age is unknown.

--- a/server/services/character.test.js
+++ b/server/services/character.test.js
@@ -117,23 +117,27 @@ describe('getWireCharacter federation projection', () => {
     store.birthDate = null;
   });
 
-  it('adds an age-derived level to the wire payload without persisting it', async () => {
-    const birth = new Date();
-    birth.setFullYear(birth.getFullYear() - 33);
-    birth.setDate(birth.getDate() - 30);
-    store.birthDate = birth.toISOString();
-
+  it('adds a legacy xp-derived level to the wire payload without persisting it', async () => {
+    // 5000 xp → legacy level 4 (>= the 2700 threshold, < 6500). A valid integer for a
+    // pre-#2673 peer's XP-threshold UI, never null.
     const wire = await characterService.getWireCharacter();
-    expect(wire.level).toBe(33);
-    // But the persisted record still carries no level.
-    expect(store.value.level).toBeUndefined();
+    expect(wire.level).toBe(4);
+    expect(store.value.level).toBeUndefined(); // still not persisted
+    expect(wire.ageYears).toBeUndefined();
   });
 
-  it('falls back to the historical default level 1 for backward-compat when birthDate is unset', async () => {
-    store.birthDate = null;
+  it('keeps the wire level a pure function of xp (checksum-stable), independent of birthDate', async () => {
+    // Setting a birthDate must NOT change the wire level — otherwise it would drift out of
+    // sync with the character.json-mtime checksum that fingerprints the sync category.
+    const birth = new Date();
+    birth.setFullYear(birth.getFullYear() - 33);
+    store.birthDate = birth.toISOString();
     const wire = await characterService.getWireCharacter();
-    expect(wire.level).toBe(1); // pre-#2673 peers index XP thresholds by level — never null
-    expect(wire.ageYears).toBeUndefined(); // ageYears excluded so the sync checksum stays stable
+    expect(wire.level).toBe(4); // xp-derived, not age 33
+
+    store.value = { name: 'New', class: 'Dev', xp: 0, hp: 15, maxHp: 15 };
+    const fresh = await characterService.getWireCharacter();
+    expect(fresh.level).toBe(1); // 0 xp → level 1, never null
   });
 });
 

--- a/server/services/character.test.js
+++ b/server/services/character.test.js
@@ -52,6 +52,16 @@ describe('ageYearsFromBirthDate', () => {
     expect(characterService.ageYearsFromBirthDate('not-a-date', now)).toBeNull();
     expect(characterService.ageYearsFromBirthDate('2030-01-01', now)).toBeNull();
   });
+
+  it('uses calendar birthdays — does not tick the level up a day early', () => {
+    // The day BEFORE the 26th birthday: still 25 (a 365.25-day average would round to 26).
+    const dayBefore = characterService.ageYearsFromBirthDate('2000-07-17', new Date('2026-07-16T00:00:00Z'));
+    expect(Math.floor(dayBefore)).toBe(25);
+    // On the birthday: ticks to 26 with ~0 progress.
+    const onBirthday = characterService.ageYearsFromBirthDate('2000-07-17', new Date('2026-07-17T00:00:00Z'));
+    expect(Math.floor(onBirthday)).toBe(26);
+    expect(onBirthday - 26).toBeLessThan(0.01);
+  });
 });
 
 describe('levelFromAge', () => {

--- a/server/services/character.test.js
+++ b/server/services/character.test.js
@@ -111,6 +111,32 @@ describe('getCharacter age-based level', () => {
   });
 });
 
+describe('getWireCharacter federation projection', () => {
+  beforeEach(() => {
+    store.value = { name: 'Gandalf', class: 'Wizard', xp: 5000, hp: 15, maxHp: 15 };
+    store.birthDate = null;
+  });
+
+  it('adds an age-derived level to the wire payload without persisting it', async () => {
+    const birth = new Date();
+    birth.setFullYear(birth.getFullYear() - 33);
+    birth.setDate(birth.getDate() - 30);
+    store.birthDate = birth.toISOString();
+
+    const wire = await characterService.getWireCharacter();
+    expect(wire.level).toBe(33);
+    // But the persisted record still carries no level.
+    expect(store.value.level).toBeUndefined();
+  });
+
+  it('falls back to the historical default level 1 for backward-compat when birthDate is unset', async () => {
+    store.birthDate = null;
+    const wire = await characterService.getWireCharacter();
+    expect(wire.level).toBe(1); // pre-#2673 peers index XP thresholds by level — never null
+    expect(wire.ageYears).toBeUndefined(); // ageYears excluded so the sync checksum stays stable
+  });
+});
+
 describe('addXP decoupled from level', () => {
   beforeEach(() => {
     store.value = { name: 'Gandalf', class: 'Wizard', xp: 0, hp: 15, maxHp: 15, events: [] };

--- a/server/services/character.test.js
+++ b/server/services/character.test.js
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // In-memory backing for the character.json read/write so the test exercises the
-// real read-modify-save path without touching disk.
-const store = vi.hoisted(() => ({ value: null }));
+// real read-modify-save path without touching disk. `birthDate` drives the mocked
+// meatspace accessor so age-based level derivation is deterministic.
+const store = vi.hoisted(() => ({ value: null, birthDate: null }));
 
 vi.mock('../lib/fileUtils.js', () => ({
   PATHS: { data: '/tmp/portos-test-data' },
@@ -19,10 +20,14 @@ vi.mock('../lib/fileUtils.js', () => ({
   }),
 }));
 
-// character.js eagerly imports the jira/cos services at module load; stub them
-// so the unit under test loads without their dependency graphs.
+// character.js eagerly imports the jira/cos/meatspace services at module load; stub them
+// so the unit under test loads without their dependency graphs. meatspace supplies the
+// canonical birthDate that age-based level derives from (#2673).
 vi.mock('./jira.js', () => ({}));
 vi.mock('./cos.js', () => ({}));
+vi.mock('./meatspace.js', () => ({
+  getBirthDate: vi.fn(async () => ({ birthDate: store.birthDate })),
+}));
 
 vi.mock('fs/promises', () => ({
   writeFile: vi.fn(async (_path, contents) => {
@@ -32,9 +37,102 @@ vi.mock('fs/promises', () => ({
 
 import * as characterService from './character.js';
 
+describe('ageYearsFromBirthDate', () => {
+  it('returns fractional years lived for a valid birthDate', () => {
+    const now = new Date('2026-07-01T00:00:00Z');
+    const age = characterService.ageYearsFromBirthDate('1984-01-01T00:00:00Z', now);
+    expect(age).toBeGreaterThan(42);
+    expect(age).toBeLessThan(43);
+  });
+
+  it('returns null for unset / invalid / future birthDate', () => {
+    const now = new Date('2026-07-01T00:00:00Z');
+    expect(characterService.ageYearsFromBirthDate(null, now)).toBeNull();
+    expect(characterService.ageYearsFromBirthDate('', now)).toBeNull();
+    expect(characterService.ageYearsFromBirthDate('not-a-date', now)).toBeNull();
+    expect(characterService.ageYearsFromBirthDate('2030-01-01', now)).toBeNull();
+  });
+});
+
+describe('levelFromAge', () => {
+  it('floors age years to a level', () => {
+    expect(characterService.levelFromAge(42.9)).toBe(42);
+    expect(characterService.levelFromAge(0.4)).toBe(0);
+  });
+  it('returns null when age is null / NaN', () => {
+    expect(characterService.levelFromAge(null)).toBeNull();
+    expect(characterService.levelFromAge(NaN)).toBeNull();
+  });
+});
+
+describe('getCharacter age-based level', () => {
+  beforeEach(() => {
+    store.value = { name: 'Gandalf', class: 'Wizard', xp: 5000, level: 3, hp: 15, maxHp: 15 };
+    store.birthDate = null;
+  });
+
+  it('derives level = floor(ageYears) from the canonical birthDate, ignoring stored xp/level', async () => {
+    // ~42 years before today → level 42, regardless of the persisted level: 3 / xp: 5000.
+    const birth = new Date();
+    birth.setFullYear(birth.getFullYear() - 42);
+    birth.setDate(birth.getDate() - 30); // safely past the birthday so age is >= 42
+    store.birthDate = birth.toISOString();
+
+    const char = await characterService.getCharacter();
+    expect(char.level).toBe(42);
+    expect(char.ageYears).toBeGreaterThanOrEqual(42);
+    expect(char.xp).toBe(5000); // xp survives as a stat
+  });
+
+  it('returns level = null when no birthDate is set', async () => {
+    store.birthDate = null;
+    const char = await characterService.getCharacter();
+    expect(char.level).toBeNull();
+    expect(char.ageYears).toBeNull();
+  });
+
+  it('loads a legacy character.json (stored xp/level) without error', async () => {
+    store.value = { name: 'Legacy', class: 'Dev', xp: 12345, level: 7, hp: 20, maxHp: 20 };
+    store.birthDate = null;
+    const char = await characterService.getCharacter();
+    expect(char.name).toBe('Legacy');
+    expect(char.level).toBeNull(); // no longer XP-derived
+    expect(char.xp).toBe(12345);
+  });
+});
+
+describe('addXP decoupled from level', () => {
+  beforeEach(() => {
+    store.value = { name: 'Gandalf', class: 'Wizard', xp: 0, hp: 15, maxHp: 15, events: [] };
+    store.birthDate = null;
+  });
+
+  it('accumulates xp but never levels up (level is age-derived)', async () => {
+    const result = await characterService.addXP(100000, 'test', 'big gain');
+    expect(result.leveledUp).toBe(false);
+    expect(result.character.xp).toBe(100000);
+    // No birthDate → derived level stays null; xp does not resurrect a level.
+    expect(result.character.level).toBeNull();
+  });
+
+  it('does not persist a derived level onto disk', async () => {
+    const birth = new Date();
+    birth.setFullYear(birth.getFullYear() - 30);
+    birth.setDate(birth.getDate() - 30);
+    store.birthDate = birth.toISOString();
+
+    await characterService.addXP(50, 'test', 'gain');
+    // The enriched read carries level, but the persisted record must not.
+    expect(store.value.level).toBeUndefined();
+    expect(store.value.ageYears).toBeUndefined();
+    expect(store.value.xp).toBe(50);
+  });
+});
+
 describe('character setAvatar', () => {
   beforeEach(() => {
-    store.value = { name: 'Gandalf', class: 'Wizard', avatarPath: null, xp: 0, level: 1 };
+    store.value = { name: 'Gandalf', class: 'Wizard', avatarPath: null, xp: 0 };
+    store.birthDate = null;
   });
 
   it('persists avatarPath onto the existing character and returns it', async () => {

--- a/server/services/dataSync.js
+++ b/server/services/dataSync.js
@@ -272,8 +272,11 @@ async function applyCharacterRemote(remoteData) {
 
   const local = await readJSONFile(CHARACTER_FILE, null);
   if (!local) {
-    // No local character — accept remote entirely
-    await atomicWrite(CHARACTER_FILE, remoteData);
+    // No local character — accept remote entirely, but strip a legacy persisted `level`
+    // (an older peer still sends it): level is age-derived on read now (#2673), so a stored
+    // value would be stale and would re-propagate in our own snapshot.
+    const { level: _staleLevel, ...accepted } = remoteData;
+    await atomicWrite(CHARACTER_FILE, accepted);
     console.log(`🔄 Character sync: accepted remote character`);
     return { applied: true, count: 1 };
   }

--- a/server/services/dataSync.js
+++ b/server/services/dataSync.js
@@ -28,6 +28,7 @@ import { mergeMediaCollectionsFromSync, listCollections, itemKey } from './media
 import { listSyncableSessionsForWire, mergeStorySessionsFromSync } from './storyBuilder.js';
 import { getStoryBuilderMutationEpoch } from './storyBuilderStore/store.js';
 import { sanitizeStateForWire } from '../lib/syncWire.js';
+import * as characterService from './character.js';
 import {
   getDigitalTwinSnapshot,
   applyDigitalTwinRemote,
@@ -262,7 +263,9 @@ async function applyGoalsRemote(remoteData) {
 // --- Category: Character ---
 
 async function getCharacterSnapshot() {
-  const data = await readJSONFile(CHARACTER_FILE, null);
+  // Use the wire projection (persisted record + a backward-compatible `level`) so pre-#2673
+  // peers still get a usable integer level even though `level` is no longer persisted (#2673).
+  const data = await characterService.getWireCharacter();
   if (!data) return { data: null, checksum: 'empty' };
   return { data, checksum: computeChecksum(data) };
 }

--- a/server/services/dataSync.js
+++ b/server/services/dataSync.js
@@ -306,12 +306,14 @@ async function applyCharacterRemote(remoteData) {
     xp: Math.max(local.xp || 0, remoteData.xp || 0),
     hp: scalarSource.hp,
     maxHp: scalarSource.maxHp,
-    level: Math.max(local.level || 1, remoteData.level || 1),
+    // `level` is age-derived on read (#2673), not persisted — never merge a stale peer level.
     events: mergedEvents,
     syncedJiraTickets: mergedTickets,
     syncedTaskIds: mergedTasks,
     updatedAt: remoteTs > localTs ? remoteTs : localTs
   };
+  // Drop any legacy persisted `level` (carried through `...local`) — it's derived on read now.
+  delete merged.level;
 
   if (eventsChanged || remoteTs > localTs) {
     await atomicWrite(CHARACTER_FILE, merged);


### PR DESCRIPTION
## Summary

Slice 1 of the Character-sheet redesign epic (#2672). Reframes the Character's `level` as **life experience = age**: `level = floor(ageYears)`, derived on read from the canonical `birthDate` (MeatSpace config), instead of being ground out of XP thresholds (JIRA tickets + CoS tasks). `xp` survives as a cumulative stat but no longer drives level.

- **`server/services/character.js`** — `ageYearsFromBirthDate` / `levelFromAge` pure helpers using **calendar** birthdays (completed years + fraction to next birthday), not a 365.25-day average. `getCharacter()` enriches with derived `level`/`ageYears` on read (`level = null` when no birthDate); `saveCharacter()` strips derived fields so a stale level never lands on disk. XP-threshold leveling (`recalcLevel`/`getLevelFromXP`) removed; HP decoupled from level (flat `maxHp`); sync/`addXP` never level up.
- **`server/services/dataSync.js`** — derived `level` dropped from the federated character merge (and the no-local accept path), so peers never `Math.max` a stale persisted level. Per the epic, `character` stays unversioned and each peer derives its own level from its own `birthDate` (which itself federates via MeatSpace/goals).
- **`client/src/utils/characterXp.js`** — new `computeAgeView` (age level + progress-to-next-birthday). `diffXp` no longer infers a level-up from crossing a legacy XP threshold; the amber celebration is now strictly a birthday age-level tick, and fires independently of an XP gain.
- **`CityXpBadge` / `CityHudCompact`** — render the age level with a birthday-progress bar; safe no-birthDate state (no NaN) that routes the "set birth date" prompt to `/meatspace/age` (the actual editor).
- **`CharacterSheet.jsx`** — decoupled from the age level: dropped the broken "XP to next level" bar, shows XP as a cumulative stat plus a real progress-to-next-birthday bar; null-safe level badge. (Full page reframe is Slice 5, #2677.)

## Test plan

- `server/services/character.test.js` — age derivation, no-birthDate branch, calendar-boundary (no early tick), xp/level decoupling, no-persist-of-derived, legacy record load. All pass.
- `client/src/utils/characterXp.test.js` — `computeAgeView` (incl. no-birthDate/no-NaN), birthday-vs-XP level-up semantics. All pass.
- Full server + client suites green for touched areas; eslint clean; city component tests pass.
- Reviewed by claude, ollama, and codex (findings addressed).

Closes #2673