### PR TITLE
fix(creative-director): deliver antigravity TUI prompts + settle orphaned CD runs (#2705)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,7 @@
+# Unreleased Changes
+
+## Fixed
+
+- Creative Director projects that use the Antigravity provider no longer get stuck on "Planning." The agent now reliably receives its instructions instead of launching and sitting idle at an empty prompt (it waits for Antigravity's input box to be ready before sending, the same way the Claude provider does), so planning actually runs to completion.
+- A Creative Director project no longer wedges in "Planning" when its agent is interrupted or crashes mid-run. The stuck run is now cleaned up as soon as the dead agent is detected, so the project can retry on its own instead of waiting for the next server restart.
+- The Creative Director "Runs" tab now shows why a run failed (e.g. "interrupted by restart") instead of leaving failed runs blank with no explanation.

--- a/client/src/components/creative-director/RunsTab.jsx
+++ b/client/src/components/creative-director/RunsTab.jsx
@@ -38,6 +38,13 @@ export default function RunsTab({ project }) {
             </div>
           )}
           {r.error && <div className="text-xs text-port-error mt-1">{r.error}</div>}
+          {/* failureReason is what recovery + orphan-settle write (e.g. "interrupted
+              by restart", "agent process terminated unexpectedly (orphaned)") — a
+              failed run with no `error` used to render blank, so surface it too so a
+              failed run always says WHY (issue #2705). */}
+          {r.failureReason && r.failureReason !== r.error && (
+            <div className="text-xs text-port-error mt-1">{r.failureReason}</div>
+          )}
         </div>
       ))}
     </div>

--- a/client/src/components/creative-director/RunsTab.test.jsx
+++ b/client/src/components/creative-director/RunsTab.test.jsx
@@ -1,0 +1,63 @@
+/**
+ * RunsTab — surfaces a failed run's failureReason so a failed run always says
+ * WHY (issue #2705). Recovery + orphan-settle write `failureReason` (not `error`),
+ * and the tab previously rendered only `error`, so those runs showed blank.
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+
+import RunsTab from './RunsTab.jsx';
+
+const renderTab = (project) =>
+  render(
+    <MemoryRouter>
+      <RunsTab project={project} />
+    </MemoryRouter>,
+  );
+
+describe('RunsTab — run failure reasons', () => {
+  it('renders a failed run\'s failureReason', () => {
+    renderTab({
+      runs: [
+        {
+          runId: 'r1', kind: 'plan', status: 'failed',
+          startedAt: '2026-07-16T23:52:34.206Z',
+          failureReason: 'interrupted by restart',
+        },
+      ],
+    });
+    expect(screen.getByText('interrupted by restart')).toBeInTheDocument();
+  });
+
+  it('surfaces the orphan-settle reason (the case that used to render blank)', () => {
+    renderTab({
+      runs: [
+        {
+          runId: 'r2', kind: 'plan', status: 'failed',
+          startedAt: '2026-07-16T23:59:30.600Z',
+          failureReason: 'agent process terminated unexpectedly (orphaned)',
+        },
+      ],
+    });
+    expect(screen.getByText(/orphaned/)).toBeInTheDocument();
+  });
+
+  it('does not duplicate the message when error and failureReason are identical', () => {
+    renderTab({
+      runs: [
+        {
+          runId: 'r3', kind: 'treatment', status: 'failed',
+          startedAt: '2026-07-16T23:59:30.600Z',
+          error: 'same message', failureReason: 'same message',
+        },
+      ],
+    });
+    expect(screen.getAllByText('same message')).toHaveLength(1);
+  });
+
+  it('shows an empty-state message when there are no runs', () => {
+    renderTab({ runs: [] });
+    expect(screen.getByText(/No runs yet/)).toBeInTheDocument();
+  });
+});

--- a/server/services/agentManagement.js
+++ b/server/services/agentManagement.js
@@ -478,6 +478,34 @@ export async function isPidAlive(pid) {
  * - Creates investigation task after max retries exceeded
  * - Triggers evaluation to spawn new agents
  */
+
+/**
+ * Settle a Creative Director run tied to an orphaned/reaped agent (issue #2705).
+ *
+ * A CD plan/treatment agent that dies without issuing its completion PATCH leaves
+ * its `runs[]` row stuck `running`. `maybeEnqueuePlan`'s guard then treats that
+ * non-terminal run as "a worker is already on it" and refuses to re-dispatch — so
+ * the project wedges in `planning` until the NEXT server restart runs boot
+ * recovery (`recoverInFlightProjects`). Reaping the run here — mirroring recovery's
+ * reap — lets the project advance without a restart (the orphan-task retry then
+ * re-dispatches the plan). No-op for non-CD tasks; the `creativeDirector/local.js`
+ * import is deferred so non-CD orphans pay nothing. Exported for unit testing.
+ *
+ * @param {object|null} task - the orphaned agent's task record.
+ * @returns {Promise<boolean>} true if a CD run was settled, false for a non-CD task.
+ */
+export async function settleOrphanedCreativeDirectorRun(task) {
+  const cd = task?.metadata?.creativeDirector;
+  if (!cd?.projectId || !cd?.runId) return false;
+  const { updateRun } = await import('./creativeDirector/local.js');
+  await updateRun(cd.projectId, cd.runId, {
+    status: 'failed',
+    completedAt: new Date().toISOString(),
+    failureReason: 'agent process terminated unexpectedly (orphaned)',
+  }).catch((err) => console.log(`⚠️ CD orphan settle: run ${cd.runId?.slice(0, 8)} of ${cd.projectId} failed: ${err.message}`));
+  return true;
+}
+
 export async function cleanupOrphanedAgents() {
   const { getAgents, completeAgent: markComplete, evaluateTasks, getTaskById: getTask } = await import('./cos.js');
   const agents = await getAgents();
@@ -543,6 +571,13 @@ export async function cleanupOrphanedAgents() {
   // agent's own worktree is safe and stays.
   for (const { agentId } of orphanedTaskIds) {
     await cleanupAgentWorktree(agentId, false);
+  }
+
+  // Settle any Creative Director run tied to an orphaned agent (issue #2705)
+  // BEFORE the retry below, so the project can advance without a server restart.
+  for (const { taskId } of orphanedTaskIds) {
+    const task = await getTask(taskId).catch(() => null);
+    await settleOrphanedCreativeDirectorRun(task);
   }
 
   // Handle orphaned tasks - reset for retry or create investigation task

--- a/server/services/agentManagement.js
+++ b/server/services/agentManagement.js
@@ -486,10 +486,30 @@ export async function isPidAlive(pid) {
  * its `runs[]` row stuck `running`. `maybeEnqueuePlan`'s guard then treats that
  * non-terminal run as "a worker is already on it" and refuses to re-dispatch — so
  * the project wedges in `planning` until the NEXT server restart runs boot
- * recovery (`recoverInFlightProjects`). Reaping the run here — mirroring recovery's
- * reap — lets the project advance without a restart (the orphan-task retry then
- * re-dispatches the plan). No-op for non-CD tasks; the `creativeDirector/local.js`
- * import is deferred so non-CD orphans pay nothing. Exported for unit testing.
+ * recovery (`recoverInFlightProjects`). This helper reproduces recovery's per-project
+ * reap so the project recovers without a restart. It does THREE things, in the
+ * same order and shape recovery does — this is boot-ordering-critical:
+ *
+ *   1. **Fail the stuck run** so `maybeEnqueuePlan`'s non-terminal-run guard clears.
+ *   2. **Retire the CoS task** (`status:'completed'`), NOT leave it running for
+ *      `handleOrphanedTask` to requeue. This is load-bearing for boot ordering:
+ *      `cleanupOrphanedAgents` runs BEFORE `recoverInFlightProjects` awaits its gate
+ *      (`cos.js` start sequence), and recovery only reaps runs still marked
+ *      `running` — so once we've failed the run in step 1, recovery would no longer
+ *      retire this task. If we left it, `handleOrphanedTask` would requeue a stale
+ *      agent that races recovery's fresh dispatch. Retiring it here makes
+ *      `handleOrphanedTask` skip it (it skips `completed` tasks) — matching exactly
+ *      what recovery's own `updateTask(status:'completed')` reap does. (#2705 review)
+ *   3. **Re-dispatch via the deduped advance loop** (`advanceAfterPlanStepSettled` for
+ *      directive projects, `advanceAfterSceneSettled` otherwise) — the SAME functions
+ *      recovery calls, so the project retries on its own in steady state, and at boot
+ *      the call is idempotent with recovery's advance (both go through the in-memory
+ *      inflight-dedup guards, so no double dispatch). This deliberately does NOT use
+ *      `handleOrphanedTask`/`resetOrphanedTasks`' raw task respawn, which the
+ *      `cdRecoveryDone` gate exists to keep from racing recovery.
+ *
+ * No-op for non-CD tasks; the CD-module imports are deferred so non-CD orphans pay
+ * nothing. Exported for unit testing.
  *
  * @param {object|null} task - the orphaned agent's task record.
  * @returns {Promise<boolean>} true if a CD run was settled, false for a non-CD task.
@@ -497,12 +517,36 @@ export async function isPidAlive(pid) {
 export async function settleOrphanedCreativeDirectorRun(task) {
   const cd = task?.metadata?.creativeDirector;
   if (!cd?.projectId || !cd?.runId) return false;
-  const { updateRun } = await import('./creativeDirector/local.js');
+  const now = new Date().toISOString();
+  const { updateRun, getProject } = await import('./creativeDirector/local.js');
+  // 1. Fail the stuck run (clears the maybeEnqueuePlan non-terminal-run guard).
   await updateRun(cd.projectId, cd.runId, {
     status: 'failed',
-    completedAt: new Date().toISOString(),
+    completedAt: now,
     failureReason: 'agent process terminated unexpectedly (orphaned)',
   }).catch((err) => console.log(`⚠️ CD orphan settle: run ${cd.runId?.slice(0, 8)} of ${cd.projectId} failed: ${err.message}`));
+  // 2. Retire the task the same way recovery does, so handleOrphanedTask (which
+  //    skips `completed` tasks) can't requeue a stale agent to race recovery.
+  //    CD tasks are internal (agentBridge#persistAndEmit adds them as 'internal').
+  if (task.id) {
+    await updateTask(task.id, {
+      status: 'completed',
+      metadata: { ...task.metadata, orphanedRunSettledAt: now },
+    }, 'internal').catch((err) => console.log(`⚠️ CD orphan settle: retire task ${task.id} failed: ${err.message}`));
+  }
+  // 3. Re-dispatch via the deduped advance loop (fire-and-forget, like recovery).
+  const project = await getProject(cd.projectId).catch(() => null);
+  if (project && project.status !== 'paused' && project.status !== 'failed') {
+    if (project.directive) {
+      const { advanceAfterPlanStepSettled } = await import('./creativeDirector/planAdvance.js');
+      advanceAfterPlanStepSettled(cd.projectId)
+        .catch((e) => console.log(`⚠️ CD orphan settle: plan advance for ${cd.projectId} failed: ${e.message}`));
+    } else {
+      const { advanceAfterSceneSettled } = await import('./creativeDirector/completionHook.js');
+      advanceAfterSceneSettled(cd.projectId)
+        .catch((e) => console.log(`⚠️ CD orphan settle: advance for ${cd.projectId} failed: ${e.message}`));
+    }
+  }
   return true;
 }
 

--- a/server/services/agentManagement.test.js
+++ b/server/services/agentManagement.test.js
@@ -74,13 +74,41 @@ vi.mock('./agentLifecycle.js', () => ({
   syncRunnerAgents: vi.fn().mockResolvedValue(0)
 }));
 vi.mock('./worktreeManager.js', () => ({ cleanupOrphanedWorktrees: vi.fn() }));
+vi.mock('./creativeDirector/local.js', () => ({ updateRun: vi.fn().mockResolvedValue(undefined) }));
 
-import { handleOrphanedTask, pauseAgent } from './agentManagement.js';
+import { handleOrphanedTask, pauseAgent, settleOrphanedCreativeDirectorRun } from './agentManagement.js';
+import { updateRun } from './creativeDirector/local.js';
 import { updateTask, addTask, getTaskById } from './cos.js';
 import { updateAgent } from './cosAgents.js';
 import { pauseAgentViaRunner } from './cosRunnerClient.js';
 import * as shellService from './shell.js';
 import { activeAgents, runnerAgents, pausedAgents } from './agentState.js';
+
+describe('settleOrphanedCreativeDirectorRun — reap a dead CD agent run (#2705)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('marks the orphaned CD plan agent run failed with an orphan reason', async () => {
+    const task = {
+      id: 'cd-cd-p1-plan-abc',
+      metadata: { creativeDirector: { projectId: 'cd-p1', runId: 'run-abc', kind: 'plan', sceneId: null } },
+    };
+    const settled = await settleOrphanedCreativeDirectorRun(task);
+    expect(settled).toBe(true);
+    expect(updateRun).toHaveBeenCalledWith(
+      'cd-p1',
+      'run-abc',
+      expect.objectContaining({ status: 'failed', failureReason: expect.stringContaining('orphaned') }),
+    );
+  });
+
+  it('is a no-op (no updateRun) for a non-CD task or a CD task missing projectId/runId', async () => {
+    expect(await settleOrphanedCreativeDirectorRun({ id: 't', metadata: {} })).toBe(false);
+    expect(await settleOrphanedCreativeDirectorRun(null)).toBe(false);
+    // metadata present but incomplete — must not settle a run it can't identify.
+    expect(await settleOrphanedCreativeDirectorRun({ metadata: { creativeDirector: { projectId: 'cd-p1' } } })).toBe(false);
+    expect(updateRun).not.toHaveBeenCalled();
+  });
+});
 
 describe('handleOrphanedTask — duplicate-investigation guard', () => {
   beforeEach(() => {

--- a/server/services/agentManagement.test.js
+++ b/server/services/agentManagement.test.js
@@ -74,10 +74,17 @@ vi.mock('./agentLifecycle.js', () => ({
   syncRunnerAgents: vi.fn().mockResolvedValue(0)
 }));
 vi.mock('./worktreeManager.js', () => ({ cleanupOrphanedWorktrees: vi.fn() }));
-vi.mock('./creativeDirector/local.js', () => ({ updateRun: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./creativeDirector/local.js', () => ({
+  updateRun: vi.fn().mockResolvedValue(undefined),
+  getProject: vi.fn().mockResolvedValue(null),
+}));
+vi.mock('./creativeDirector/planAdvance.js', () => ({ advanceAfterPlanStepSettled: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./creativeDirector/completionHook.js', () => ({ advanceAfterSceneSettled: vi.fn().mockResolvedValue(undefined) }));
 
 import { handleOrphanedTask, pauseAgent, settleOrphanedCreativeDirectorRun } from './agentManagement.js';
-import { updateRun } from './creativeDirector/local.js';
+import { updateRun, getProject } from './creativeDirector/local.js';
+import { advanceAfterPlanStepSettled } from './creativeDirector/planAdvance.js';
+import { advanceAfterSceneSettled } from './creativeDirector/completionHook.js';
 import { updateTask, addTask, getTaskById } from './cos.js';
 import { updateAgent } from './cosAgents.js';
 import { pauseAgentViaRunner } from './cosRunnerClient.js';
@@ -87,26 +94,62 @@ import { activeAgents, runnerAgents, pausedAgents } from './agentState.js';
 describe('settleOrphanedCreativeDirectorRun — reap a dead CD agent run (#2705)', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  it('marks the orphaned CD plan agent run failed with an orphan reason', async () => {
+  it('fails the run AND retires the task (so handleOrphanedTask skips it), then advances the plan', async () => {
+    // Directive project → the deduped plan-advance loop re-dispatches.
+    getProject.mockResolvedValueOnce({ id: 'cd-p1', status: 'planning', directive: { goal: 'x' } });
     const task = {
       id: 'cd-cd-p1-plan-abc',
       metadata: { creativeDirector: { projectId: 'cd-p1', runId: 'run-abc', kind: 'plan', sceneId: null } },
     };
     const settled = await settleOrphanedCreativeDirectorRun(task);
     expect(settled).toBe(true);
+    // (1) run failed with an orphan reason
     expect(updateRun).toHaveBeenCalledWith(
       'cd-p1',
       'run-abc',
       expect.objectContaining({ status: 'failed', failureReason: expect.stringContaining('orphaned') }),
     );
+    // (2) task retired to `completed` — the boot-race fix: handleOrphanedTask skips completed tasks
+    expect(updateTask).toHaveBeenCalledWith(
+      'cd-cd-p1-plan-abc',
+      expect.objectContaining({ status: 'completed' }),
+      'internal',
+    );
+    // (3) re-dispatch via the deduped advance loop, not raw task respawn
+    expect(advanceAfterPlanStepSettled).toHaveBeenCalledWith('cd-p1');
+    expect(advanceAfterSceneSettled).not.toHaveBeenCalled();
   });
 
-  it('is a no-op (no updateRun) for a non-CD task or a CD task missing projectId/runId', async () => {
+  it('uses the scene-advance loop for a legacy (non-directive) project', async () => {
+    getProject.mockResolvedValueOnce({ id: 'cd-p2', status: 'rendering', directive: null });
+    await settleOrphanedCreativeDirectorRun({
+      id: 'cd-cd-p2-evaluate-x',
+      metadata: { creativeDirector: { projectId: 'cd-p2', runId: 'run-xyz', kind: 'evaluate', sceneId: 's1' } },
+    });
+    expect(advanceAfterSceneSettled).toHaveBeenCalledWith('cd-p2');
+    expect(advanceAfterPlanStepSettled).not.toHaveBeenCalled();
+  });
+
+  it('does NOT re-dispatch a paused or failed project', async () => {
+    getProject.mockResolvedValueOnce({ id: 'cd-p3', status: 'paused', directive: { goal: 'x' } });
+    await settleOrphanedCreativeDirectorRun({
+      id: 'cd-cd-p3-plan-z',
+      metadata: { creativeDirector: { projectId: 'cd-p3', runId: 'run-z', kind: 'plan' } },
+    });
+    // still failed the run + retired the task, but no advance for a paused project
+    expect(updateRun).toHaveBeenCalled();
+    expect(updateTask).toHaveBeenCalledWith('cd-cd-p3-plan-z', expect.objectContaining({ status: 'completed' }), 'internal');
+    expect(advanceAfterPlanStepSettled).not.toHaveBeenCalled();
+    expect(advanceAfterSceneSettled).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op (no updateRun/updateTask) for a non-CD task or a CD task missing projectId/runId', async () => {
     expect(await settleOrphanedCreativeDirectorRun({ id: 't', metadata: {} })).toBe(false);
     expect(await settleOrphanedCreativeDirectorRun(null)).toBe(false);
     // metadata present but incomplete — must not settle a run it can't identify.
     expect(await settleOrphanedCreativeDirectorRun({ metadata: { creativeDirector: { projectId: 'cd-p1' } } })).toBe(false);
     expect(updateRun).not.toHaveBeenCalled();
+    expect(updateTask).not.toHaveBeenCalled();
   });
 });
 

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -1123,7 +1123,17 @@ export async function spawnTuiAgent({
   // POSITIVE input-ready footer (see createInputReadyTracker), auto-confirm the
   // trust gate, and NEVER blind-paste: if the prompt never appears we surface a
   // failure. Other TUI providers keep the original idle heuristic + deadline.
-  const requireInputReady = commandName === 'claude';
+  //
+  // Antigravity (agy) gets the SAME positive gate (issue #2705). agy's TUI also
+  // enables bracketed-paste mode (`ESC[?2004h`) exactly when its input box is
+  // live — the identical signal createInputReadyTracker keys on — but the old
+  // blind-paste path fired into agy's still-initializing banner, so the prompt
+  // never landed and the agent sat idle at an empty prompt until it was reaped
+  // having done nothing. agy has no folder-trust gate (`needsTrust` stays false,
+  // so the auto-confirm branch below is inert for it); and if agy ever fails to
+  // signal ready, the requireInputReady path fails fast with a surfaced startup
+  // error instead of silently idle-reaping.
+  const requireInputReady = isClaudeCommand(tuiConfig.command) || isAntigravityCommand(tuiConfig.command);
   // sendPrompt / finishStartupFailure are async and dispatched fire-and-forget
   // from the interval below. A setInterval callback can't await, and an
   // unhandled rejection there (e.g. a finalizeAgent throw inside finish())

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -1129,8 +1129,12 @@ export async function spawnTuiAgent({
   // live — the identical signal createInputReadyTracker keys on — but the old
   // blind-paste path fired into agy's still-initializing banner, so the prompt
   // never landed and the agent sat idle at an empty prompt until it was reaped
-  // having done nothing. agy has no folder-trust gate (`needsTrust` stays false,
-  // so the auto-confirm branch below is inert for it); and if agy ever fails to
+  // having done nothing. agy DOES have a first-run folder-trust gate ("Do you
+  // trust the contents of this project?") like claude's — production spawns agy
+  // with `--dangerously-skip-permissions`, which bypasses it; and if it does
+  // appear (agy launched without that flag), its "Yes, I trust this folder"
+  // option matches TUI_TRUST_PROMPT_PATTERN, so the requireInputReady auto-confirm
+  // branch below handles it exactly as it does claude's. If agy ever fails to
   // signal ready, the requireInputReady path fails fast with a surfaced startup
   // error instead of silently idle-reaping.
   const requireInputReady = isClaudeCommand(tuiConfig.command) || isAntigravityCommand(tuiConfig.command);

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -825,6 +825,8 @@ describe('spawnTuiAgent runtime', () => {
 
   // ── 1c. claude waits for bracketed-paste mode (input ready) before pasting ───
   const claudeTuiConfig = { command: 'claude', args: [], commandLine: 'claude', promptDelayMs: 100, idleTimeoutMs: 50 };
+  // Antigravity (agy) gets the SAME positive input-ready gate as claude (#2705).
+  const agyTuiConfig = { command: 'agy', args: [], commandLine: 'agy', promptDelayMs: 100, idleTimeoutMs: 50 };
   const pasteCount = () => vi.mocked(shellService.writeToSession).mock.calls
     .filter(([, d]) => typeof d === 'string' && d.includes('\x1b[200~')).length;
   // The launch shell turns bracketed-paste OFF to run the command, then claude
@@ -899,6 +901,53 @@ describe('spawnTuiAgent runtime', () => {
     runSpawn({ tuiConfig: claudeTuiConfig });
     await flushMicrotasks();
     await capturedOnData(Buffer.from('some startup noise but no input box ever appears\n'));
+    await flushMicrotasks();
+
+    // Advance past TUI_INPUT_READY_DEADLINE_MS (45s).
+    await vi.advanceTimersByTimeAsync(46000);
+    vi.useRealTimers();
+    await completeDone;
+
+    expect(pasteCount()).toBe(0);
+    expect(agentLifecycle.finalizeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'agent-1', success: false, completionReason: 'tui-not-ready' })
+    );
+  });
+
+  // ── 1c-bis. Antigravity (agy) uses the SAME positive input-ready gate (#2705) ─
+  // agy's TUI emits the bracketed-paste-mode toggle exactly like claude, so it
+  // must gate the paste on paste-mode-re-enabled rather than blind-pasting on the
+  // idle heuristic (which fired into agy's still-initializing banner and left the
+  // agent sitting at an empty prompt until it was reaped). Without the fix agy
+  // took the idle-heuristic path and WOULD have pasted after ~2s of banner idle;
+  // asserting pasteCount()===0 there is what discriminates the fix.
+  it('agy input-ready: does NOT paste on the startup banner, only once paste mode is re-enabled', async () => {
+    runSpawn({ tuiConfig: agyTuiConfig });
+    await flushMicrotasks();
+
+    // Startup banner (and the shell turning paste mode OFF to run the command).
+    await capturedOnData(Buffer.from(`${PASTE_OFF}Antigravity CLI 1.1.3\nGemini 3.5 Flash (Medium)\n`));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(pasteCount()).toBe(0); // banner / paste-mode-off is not "input ready"
+
+    // agy re-enables bracketed-paste mode → input box live, safe to paste.
+    await capturedOnData(Buffer.from(PASTE_ON));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(400);
+    await flushMicrotasks();
+    expect(pasteCount()).toBe(1);
+  });
+
+  it('agy tui-not-ready: an agy TUI that never signals input-ready fails fast instead of idle-reaping', async () => {
+    let resolveComplete;
+    const completeDone = new Promise((r) => { resolveComplete = r; });
+    vi.mocked(agentLifecycle.finalizeAgent).mockImplementation(async () => { resolveComplete(); });
+
+    runSpawn({ tuiConfig: agyTuiConfig });
+    await flushMicrotasks();
+    await capturedOnData(Buffer.from('some agy startup noise but no input box ever appears\n'));
     await flushMicrotasks();
 
     // Advance past TUI_INPUT_READY_DEADLINE_MS (45s).


### PR DESCRIPTION
## Summary

Fixes #2705 — Creative Director projects using the Antigravity provider got stuck in "Planning" forever. Two root causes plus a UI gap:

**Bug 1 — antigravity (agy) TUI agents never received their prompt.** The positive input-ready paste gate in `agentTuiSpawning.js` was claude-only (`requireInputReady = commandName === 'claude'`). agy fell to the legacy blind-paste path, which fired the prompt into agy's still-initializing banner — so the paste was lost and the agent sat idle at an empty `>` prompt until it was reaped, having done nothing (it never issued its `PATCH /plan`). agy's TUI emits the **same** bracketed-paste-mode ready signal (`ESC[?2004h`) that claude does, so the fix routes agy through the same positive gate. If agy never signals ready, the path now **fails fast** with a surfaced startup error instead of silently idle-reaping.

**Bug 2 — an orphaned/reaped CD agent left its run wedged.** A plan/treatment agent that dies without its completion `PATCH` — while its task is in orphan-cooldown — is torn down via `cleanupOrphanedAgents`, which calls `completeAgent` (agent-state only) and never routes through `handleCreativeDirectorCompletion`. So the `runs[]` row stayed `running`, and `maybeEnqueuePlan`'s guard (a non-terminal `plan` run = "a worker is on it") permanently blocked re-dispatch — the project wedged in `planning` until the next server restart ran boot recovery. New `settleOrphanedCreativeDirectorRun` helper reaps that run during orphan cleanup (mirroring boot recovery), so the project advances without a restart.

**UI — the Runs tab now surfaces `failureReason`.** Recovery and orphan-settle write `failureReason` (e.g. "interrupted by restart"), but the tab only rendered `error`, so failed runs showed blank ("many failures with no reason"). Now a failed run always says why.

## Verification

- **Bug 1 verified end-to-end against the real agy 1.1.3 CLI** (via a PTY probe): agy emits `ESC[?2004h` when its input is ready, and a bracketed paste sent after that lands in agy's live input box (confirmed the marker rendered in the `>` prompt). No prompt was submitted, so zero LLM calls were made. The old blind-paste failed because it fired during agy's ~1.8s init, before the input was ready.
- New unit tests: agy uses the input-ready gate (doesn't paste on the banner, pastes on `ESC[?2004h`) and fails fast when never ready (`agentTuiSpawning.test.js`); `settleOrphanedCreativeDirectorRun` reaps a CD run and no-ops for non-CD tasks (`agentManagement.test.js`); RunsTab renders `failureReason` (`RunsTab.test.jsx`).
- `cd server && npx vitest run` for the changed suites: **86 pass**; client RunsTab: **4 pass**.

## Test plan

- [x] `server/services/agentTuiSpawning.test.js` — 54 pass (incl. 2 new agy input-ready tests)
- [x] `server/services/agentManagement.test.js` — new `settleOrphanedCreativeDirectorRun` tests pass
- [x] `client/src/components/creative-director/RunsTab.test.jsx` — 4 pass
- [x] End-to-end PTY verification that agy receives a pasted prompt
