### PR TITLE
fix(creative-director): stop instructing CD agents to /do:push at task end

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -6,6 +6,7 @@
 - Creative Director projects that use the Antigravity provider no longer get stuck on "Planning." The agent now reliably receives its instructions instead of launching and sitting idle at an empty prompt (it waits for Antigravity's input box to be ready before sending, the same way the Claude provider does), so planning actually runs to completion.
 - A Creative Director project no longer wedges in "Planning" when its agent is interrupted or crashes mid-run. The stuck run is now cleaned up as soon as the dead agent is detected, so the project can retry on its own instead of waiting for the next server restart.
 - The Creative Director "Runs" tab now shows why a run failed (e.g. "interrupted by restart") instead of leaving failed runs blank with no explanation.
+- Creative Director agents are no longer told to run `/do:push` (or open a pull request) when they finish. A CD agent's job is to write its plan or update a scene over the API, not to change code — so the end-of-task "commit and push" instruction was wrong and just made the agent load that command for nothing. They now get a completion step that matches what they actually do.
 
 ## Character Sheet
 

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -528,10 +528,13 @@ ${rprBody ? `\n### /do:rpr Reference (full procedure)\n\nWhen following the proc
  */
 export function buildCompletionGuidelineBullet({
   isReadOnly, isTui, tuiCompletionCommand, slashdoFree = false,
-  worktreeInfo, willOpenPR, willReviewLoop, discardWorktree = false,
+  worktreeInfo, willOpenPR, willReviewLoop, discardWorktree = false, noCodeOutput = false,
 }) {
   if (discardWorktree) {
     return '**This is a reasoning-only task.** The worktree is discarded on exit — do NOT commit, push, merge, or open a PR. Write your result to the completion sentinel (see the Completion section) and stop.';
+  }
+  if (noCodeOutput) {
+    return '**This task produces no code output.** Its result is the API request your instructions describe — do NOT run `/do:push`, `/do:pr`, `/simplify`, `git commit`, `git push`, or open a PR. Write the completion sentinel (see the Completion section) and stop.';
   }
   if (isReadOnly) {
     return '**This is a read-only task.** Do NOT commit, push, or modify any files in the repository. Only read data and generate reports.';
@@ -604,6 +607,27 @@ export function buildReadOnlyCompletionSection({ isTui = false, sentinelPath = n
     notice,
     '',
     `When you have finished, write a short markdown summary of what you found (and where you recorded it) to \`${sentinelPath}\`, then stop. PortOS polls this sentinel every 2s, finalizes the run, and closes the session for you — do NOT run \`/quit\` and do NOT wait for anything after writing the sentinel.`
+  ].join('\n');
+}
+
+/**
+ * Completion block for a **no-code / API-action** task (e.g. a Creative Director
+ * plan/treatment/evaluate agent). The agent's deliverable is the HTTP request its
+ * task instructions already describe (a PATCH to a PortOS endpoint), NOT a code
+ * change — so the normal `/do:push`+PR completion workflow is wrong: there is
+ * nothing to commit or push, and telling the agent to run `/do:push` just makes it
+ * load that skill for no reason (and can contradict the task prompt's own
+ * "on a 200 your task is complete"). A TUI agent still writes a `.agent-done`
+ * sentinel so the 2s poll finalizes it promptly instead of waiting on the idle
+ * reaper.
+ */
+export function buildActionOutputCompletionSection({ isTui = false, sentinelPath = null } = {}) {
+  const notice = '## Completion (No Code Output)\nThis task produces **no code change** — its result is delivered by the API request your instructions describe (a PATCH to a PortOS endpoint), not by a commit. Do NOT run `/do:push`, `/do:pr`, `/simplify`, `git commit`, `git push`, or open a pull request; there is nothing to push.';
+  if (!isTui || !sentinelPath) return notice;
+  return [
+    notice,
+    '',
+    `Your task is complete once that request succeeds. Then write a one-line summary to \`${sentinelPath}\` and stop — PortOS polls this sentinel every 2s, finalizes the run, and closes the session for you. Do NOT run \`/quit\` and do NOT wait for anything after writing the sentinel.`
   ].join('\n');
 }
 
@@ -699,6 +723,9 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
   // away on exit with no commit/merge/PR (see agentWorktreeCleanup.js). Suppresses
   // all commit/push/PR completion guidance in favor of the sentinel-only contract.
   const discardWorktree = isTruthyMetaFn(task.metadata?.discardWorktree);
+  // No-code / API-action task (e.g. Creative Director agents): deliverable is an
+  // HTTP PATCH, not a commit — suppress the /do:push completion workflow.
+  const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput);
   const isWorktreeOnExistingBranch = worktreeInfo?.existingBranch === true;
   const worktreeSection = worktreeInfo ? `
 ## Git Worktree Context
@@ -782,17 +809,19 @@ After completing your work and before committing, ${simplifyInstruction}. Fix an
   // over the fallback template's commit/push instructions below.
   const tuiCompletionSection = discardWorktree
     ? buildProgrammaticOutputCompletionSection(sentinelPath)
-    : isTui
-      ? buildTuiCompletionSection({
-          willOpenPR, willReviewLoop, simplifyEnabled, providerId,
-          sentinelPath,
-          reviewers: taskReviewers,
-          usernames: taskReviewerUsernames,
-          optionalReviewers: taskOptionalReviewers,
-          reviewStopMode: taskReviewStopMode,
-          reviewerApplies: taskReviewerApplies
-        })
-      : '';
+    : noCodeOutput
+      ? buildActionOutputCompletionSection({ isTui, sentinelPath })
+      : isTui
+        ? buildTuiCompletionSection({
+            willOpenPR, willReviewLoop, simplifyEnabled, providerId,
+            sentinelPath,
+            reviewers: taskReviewers,
+            usernames: taskReviewerUsernames,
+            optionalReviewers: taskOptionalReviewers,
+            reviewStopMode: taskReviewStopMode,
+            reviewerApplies: taskReviewerApplies
+          })
+        : '';
 
   // Build review loop section if enabled. The agent itself does NOT open the PR
   // or run /do:rpr — by the time the PR exists, the agent has already exited.
@@ -955,7 +984,7 @@ ${(() => {
   const bullet = buildCompletionGuidelineBullet({
     isReadOnly: isTruthyMetaFn(task.metadata?.readOnly),
     isTui, tuiCompletionCommand, slashdoFree: isTui && isOpencodeCommand(providerCommand),
-    worktreeInfo, willOpenPR, willReviewLoop, discardWorktree,
+    worktreeInfo, willOpenPR, willReviewLoop, discardWorktree, noCodeOutput,
   });
   return bullet ? `- ${bullet}` : '';
 })()}
@@ -1031,6 +1060,10 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
   const simplifyEnabled = isTruthyMetaFn(task.metadata?.simplify);
   const isReadOnly = isTruthyMetaFn(task.metadata?.readOnly);
   const discardWorktree = isTruthyMetaFn(task.metadata?.discardWorktree);
+  // A no-code / API-action task (e.g. a Creative Director plan/treatment/evaluate
+  // agent): its deliverable is an HTTP PATCH, not a commit — suppress the
+  // /do:push completion workflow (see buildActionOutputCompletionSection).
+  const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput);
   const isReviewLoopFollowUp = isTruthyMetaFn(task.metadata?.reviewLoopFollowUp);
   const isWorktreeOnExistingBranch = worktreeInfo?.existingBranch === true;
   // Ordered reviewer list + flags for the Review Loop (task metadata wins; else
@@ -1135,6 +1168,11 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
     // output hook) is the sole output; the worktree is discarded on exit. Wins
     // over the isTui / CLI push-and-PR completion workflows below.
     sections.push(buildProgrammaticOutputCompletionSection(`${worktreeInfo?.worktreePath || workspaceDir}/.agent-done`));
+  } else if (noCodeOutput) {
+    sections.push(buildActionOutputCompletionSection({
+      isTui,
+      sentinelPath: `${worktreeInfo?.worktreePath || workspaceDir}/.agent-done`,
+    }));
   } else if (isReadOnly) {
     sections.push(buildReadOnlyCompletionSection({
       isTui,

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -724,8 +724,11 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
   // all commit/push/PR completion guidance in favor of the sentinel-only contract.
   const discardWorktree = isTruthyMetaFn(task.metadata?.discardWorktree);
   // No-code / API-action task (e.g. Creative Director agents): deliverable is an
-  // HTTP PATCH, not a commit — suppress the /do:push completion workflow.
-  const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput);
+  // HTTP PATCH, not a commit — suppress the /do:push completion workflow. Also
+  // derive from a CD task's own `creativeDirector` marker so tasks queued as
+  // `pending` BEFORE this flag existed (persisted across an upgrade) are still
+  // recognized without a metadata migration.
+  const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput) || !!task.metadata?.creativeDirector;
   const isWorktreeOnExistingBranch = worktreeInfo?.existingBranch === true;
   const worktreeSection = worktreeInfo ? `
 ## Git Worktree Context
@@ -1062,8 +1065,10 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
   const discardWorktree = isTruthyMetaFn(task.metadata?.discardWorktree);
   // A no-code / API-action task (e.g. a Creative Director plan/treatment/evaluate
   // agent): its deliverable is an HTTP PATCH, not a commit — suppress the
-  // /do:push completion workflow (see buildActionOutputCompletionSection).
-  const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput);
+  // /do:push completion workflow (see buildActionOutputCompletionSection). Also
+  // derive from a CD task's `creativeDirector` marker so pre-upgrade `pending`
+  // tasks (queued before this flag existed) are recognized without a migration.
+  const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput) || !!task.metadata?.creativeDirector;
   const isReviewLoopFollowUp = isTruthyMetaFn(task.metadata?.reviewLoopFollowUp);
   const isWorktreeOnExistingBranch = worktreeInfo?.existingBranch === true;
   // Ordered reviewer list + flags for the Review Loop (task metadata wins; else

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -130,6 +130,19 @@ describe('no-code / API-action task completion (CD agents must NOT be told to /d
     expect(prompt).not.toMatch(/## Completion Workflow/);
   });
 
+  it('recognizes a legacy CD task by its creativeDirector marker (pre-upgrade pending, no explicit flag)', () => {
+    // A CD task queued before the noCodeOutput flag existed carries only the
+    // creativeDirector marker — it must STILL skip the /do:push workflow.
+    const legacyCdTask = makeTask({
+      metadata: { context: 'PATCH the plan', creativeDirector: { projectId: 'p', kind: 'plan' }, openPR: false },
+    });
+    const prompt = buildLightContextPrompt(legacyCdTask, '/repo', null, isTruthyMeta, {
+      providerId: 'claude-code-tui', providerCommand: 'claude',
+    });
+    expect(prompt).toMatch(/## Completion \(No Code Output\)/);
+    expect(prompt).not.toMatch(/## Completion Workflow/);
+  });
+
   it('a normal code task on the same provider still gets the /do:push Completion Workflow', () => {
     const prompt = buildLightContextPrompt(
       makeTask({ metadata: { openPR: false } }), '/repo', null, isTruthyMeta,

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -109,6 +109,38 @@ describe('reconcileSplitContext', () => {
   });
 });
 
+describe('no-code / API-action task completion (CD agents must NOT be told to /do:push)', () => {
+  // A Creative Director agent's deliverable is an HTTP PATCH described in its
+  // prompt, not a commit — so it must get the No-Code completion section, never
+  // the /do:push "Completion Workflow" (which just makes it load that skill for
+  // nothing and contradicts its "on a 200 your task is complete" instructions).
+  const cdTask = () => makeTask({
+    metadata: { context: 'PATCH /api/creative-director/x/plan with the plan', noCodeOutput: true, openPR: false },
+  });
+
+  it('a no-code TUI task gets the No-Code completion section, not the /do:push Completion Workflow', () => {
+    const prompt = buildLightContextPrompt(cdTask(), '/repo', null, isTruthyMeta, {
+      providerId: 'claude-code-tui', providerCommand: 'claude',
+    });
+    expect(prompt).toMatch(/## Completion \(No Code Output\)/);
+    expect(prompt).toMatch(/there is nothing to push/);
+    expect(prompt).toMatch(/\.agent-done/); // still writes the sentinel so it finalizes promptly
+    // The /do:push "Completion Workflow" section must be absent (the only literal
+    // `/do:push` left is inside the "do NOT run /do:push" instruction itself).
+    expect(prompt).not.toMatch(/## Completion Workflow/);
+  });
+
+  it('a normal code task on the same provider still gets the /do:push Completion Workflow', () => {
+    const prompt = buildLightContextPrompt(
+      makeTask({ metadata: { openPR: false } }), '/repo', null, isTruthyMeta,
+      { providerId: 'claude-code-tui', providerCommand: 'claude' },
+    );
+    expect(prompt).toMatch(/## Completion Workflow/);
+    expect(prompt).toMatch(/\/do:push/);
+    expect(prompt).not.toMatch(/## Completion \(No Code Output\)/);
+  });
+});
+
 describe('buildLightContextPrompt', () => {
   describe('what it omits', () => {
     it('does NOT include the obsolete "# Chief of Staff Agent Briefing" header', () => {

--- a/server/services/creativeDirector/agentBridge.js
+++ b/server/services/creativeDirector/agentBridge.js
@@ -69,6 +69,12 @@ async function buildTaskRecord(project, kind, scene, context) {
         ...assignment,
         useWorktree: false,
         readOnly: false,
+        // A CD agent's deliverable is the HTTP PATCH its prompt describes (write
+        // the plan / update the scene), not a code change — so it must NOT be told
+        // to run /do:push/open a PR at the end (there is nothing to push, and it
+        // just loads that skill for no reason). Routes the prompt builder to the
+        // no-code completion section (agentPromptBuilder#buildActionOutputCompletionSection).
+        noCodeOutput: true,
       },
       approvalRequired: false,
       autoApproved: true,

--- a/server/services/creativeDirector/agentBridge.test.js
+++ b/server/services/creativeDirector/agentBridge.test.js
@@ -63,6 +63,9 @@ describe('Creative Director agent bridge model assignments', () => {
     const [task] = mocks.addTask.mock.calls[0];
     expect(task.metadata).not.toHaveProperty('provider');
     expect(task.metadata).not.toHaveProperty('model');
+    // A CD agent's deliverable is an HTTP PATCH, not code — it must NOT be told to
+    // /do:push at the end (agentPromptBuilder routes on this flag). (#2705 follow-up)
+    expect(task.metadata.noCodeOutput).toBe(true);
   });
 
   it('prefers the project-level override over the global assignment', async () => {


### PR DESCRIPTION
## Summary

A Creative Director plan/treatment/evaluate agent's deliverable is the HTTP `PATCH` its prompt describes (write the plan / update a scene), **not** a code change. But the shared agent completion workflow (`agentPromptBuilder.js`) appended `/do:push` (or `/do:pr`) to every agent's prompt — so a CD agent loaded that skill at the end for nothing, and it directly contradicted the CD task prompt's own "On a 200 response your task is complete."

## Fix

- Mark CD agent tasks with `metadata.noCodeOutput: true` (`creativeDirector/agentBridge.js`).
- New `buildActionOutputCompletionSection` emits a **No-Code completion**: do NOT run `/do:push`/`/do:pr`/`/simplify`/commit/push/PR; the task is done when the API request succeeds; write the `.agent-done` sentinel and stop (so a TUI agent still finalizes promptly via the 2s poll instead of idle-reaping).
- Routed on both the light (TUI — the path CD uses) and full (api) completion selections, plus the api-path guideline bullet, so the flag is honored consistently.

## Test plan

- [x] `agentPromptBuilder.test.js`: a `noCodeOutput` TUI task gets the No-Code section, no `## Completion Workflow`, still writes `.agent-done`; a normal task still gets the `/do:push` workflow.
- [x] `agentBridge.test.js`: CD plan tasks carry `noCodeOutput: true`.
- [x] Changed suites: 86 pass.

Follow-up to #2705.