### PR TITLE
fix: opt /creative-commission/new out of nav-coverage guard

### DIFF
--- a/server/lib/navManifest.test.js
+++ b/server/lib/navManifest.test.js
@@ -310,6 +310,7 @@ const APP_JSX = path.join(REPO_ROOT, 'client/src/App.jsx');
 // not from ⌘K / voice / the sidebar.
 const NAV_COVERAGE_OPT_OUT = new Map([
   ['/apps/create', 'create-app form, reached via the "New App" button on /apps'],
+  ['/creative-commission/new', 'create-commission drawer, reached via the "New Commission" button on /creative-commission'],
   ['/feature-agents/create', 'create-agent form, reached via the "New Agent" button'],
   ['/login', 'auth gate — surfaced only when settings.secrets.auth is enabled, reached via 401 redirect'],
   ['/songbook/import', 'import-song form, reached via the "Import" button on /songbook'],


### PR DESCRIPTION
## Summary

Follow-up to #2750. That PR added a static `/creative-commission/new` route for the create drawer; the nav-coverage guard in `server/lib/navManifest.test.js` flags any concrete leaf route lacking a `NAV_COMMANDS` entry, so main's server suite went red on `expected [ '/creative-commission/new' ] to deeply equal []`.

`/creative-commission/new` is a create-mode route reached via the "New Commission" button (like the already-opted-out `/universes/new` and `/apps/create`), not something you navigate to from ⌘K / voice / the sidebar — the index `/creative-commission` is the navigable page. Added it to `NAV_COVERAGE_OPT_OUT` with a reason.

## Test plan

- `navManifest.test.js` green (45/45), including the "no stale opt-out entries" guard.
- The `legacyExport` full-suite ordering flake seen locally passes in isolation and did not fail on #2750's CI run — unrelated to this change.

https://claude.ai/code/session_017EBzH5zcQzXptE7YNbrX6D