### PR TITLE
Add LI scope-awareness so task generation steers by historical completion rates

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -88,3 +88,9 @@
 ### Changed
 
 - [issue-2686] Creative Commissions now federate across your machines as a split record: the **brief** (name, intent, genre, generation settings) and your **taste feedback** (👍/👎 + notes) sync to your other peers, while each machine keeps its own **schedule** and **run history** — so the same commission and its accumulated taste appear everywhere, but only the machine you scheduled it on fires the cron (no double-run). A reaction rated on one machine steers that commission's next run on another. Two new sync-category toggles appear under a peer — **Commissions** (the brief) and **Commission Feedback** (the reactions) — both PostgreSQL-backed with soft-delete tombstones so removals propagate instead of resurrecting. Feedback moved out of an inline field into its own `commissionFeedback` record kind (one row per reaction, capped per commission); existing inline reactions are split into the federated store automatically at boot.
+
+## Layered Intelligence
+
+### Changed
+
+- [issue-2760] **Layered Intelligence now steers its proposals toward work it can actually finish.** Each run reads its own track record — which kinds of task it has historically completed versus consistently failed — and hands the reasoner an explicit "prefer these, avoid those" summary before it decides what to propose. So the loop stops repeatedly filing work in areas where its follow-through fails and concentrates on the kinds of improvement it lands reliably. The read is fresh every run, so an area recovers on its own the moment its success rate climbs back — nothing to reset by hand. This only kicks in once an area has enough completed runs to be meaningful, and applies to PortOS's own self-improvement loop (managed apps, which don't track these run stats, are unaffected).

--- a/server/services/autonomousJobs/layeredIntelligenceHooks.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHooks.js
@@ -302,7 +302,7 @@ export async function buildTaskInput({ app } = {}) {
   // (#2698) can read the app's committed backlog off the SAME tracker the loop
   // files to — gatherSources has no other way to know where work lives.
   const [sources, issuesRead] = await Promise.all([
-    gatherSources(app, config, { tracker: { filer, forgeCli, cwd, jira } }),
+    gatherSources(app, config, { tracker: { filer, forgeCli, cwd, jira }, isPortos }),
     readIssues({ filer, forgeCli, cwd, jira, config })
   ])
   const { openIssues, existingIssues, trackerReadFailed } = issuesRead

--- a/server/services/autonomousJobs/layeredIntelligenceHooks.test.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHooks.test.js
@@ -230,7 +230,7 @@ describe('buildTaskInput', () => {
     expect(li.gatherSources).toHaveBeenCalledWith(
       APP,
       expect.anything(),
-      { tracker: { filer: 'forge', forgeCli: 'gh', cwd: '/repo', jira: null } }
+      { tracker: { filer: 'forge', forgeCli: 'gh', cwd: '/repo', jira: null }, isPortos: expect.any(Boolean) }
     );
   });
 
@@ -241,7 +241,7 @@ describe('buildTaskInput', () => {
     expect(li.gatherSources).toHaveBeenCalledWith(
       jiraApp,
       expect.anything(),
-      { tracker: expect.objectContaining({ filer: 'jira', jira: expect.objectContaining({ instanceId: 'i1', projectKey: 'PROJ' }) }) }
+      { tracker: expect.objectContaining({ filer: 'jira', jira: expect.objectContaining({ instanceId: 'i1', projectKey: 'PROJ' }) }), isPortos: expect.any(Boolean) }
     );
   });
 

--- a/server/services/layeredIntelligence.js
+++ b/server/services/layeredIntelligence.js
@@ -166,6 +166,32 @@ export const LI_DEGRADED_MIN_SAMPLE = 4;
 // to merged for trackers that report no stateReason.
 export const PROPOSAL_OUTCOMES = ['merged', 'rejected', 'abandoned'];
 
+// Scope-awareness thresholds (#2760). LI's own execution data shows several CoS
+// task-type scopes it consistently fails at (e.g. self-improve:layered-intelligence,
+// branch-reconcile, accessibility all sit at 0%) while others succeed reliably
+// (plan-task, test-coverage, performance at ~100%). Since an LI proposal is later
+// EXECUTED as a CoS task, proposing work that maps to a chronically-failing scope is
+// systematic waste. These bound a deterministic, self-clearing classifier
+// (computeScopeAwareness) that surfaces the avoid/prefer split to the reasoner so it
+// can steer proposals toward scopes that actually execute.
+//
+// A scope is "avoid" when its lifetime success rate is below AVOID and it has enough
+// completed runs to be evidence; "prefer" when at/above PREFER with the same sample
+// floor. Reusing the degraded-execution boundary (50%) for AVOID keeps LI's two
+// success signals — its own loop health and per-scope executability — on the same
+// coin-flip line. Because the classification is recomputed from fresh learning.json
+// every run, an "avoid" scope self-clears the moment its rate recovers past AVOID —
+// no persisted avoid-list to go stale (the issue's "dynamic adjustment" requirement).
+export const SCOPE_AVOID_SUCCESS_THRESHOLD = LI_DEGRADED_SUCCESS_THRESHOLD; // < 50% → avoid
+export const SCOPE_PREFER_SUCCESS_THRESHOLD = 75;                          // >= 75% → prefer
+
+// Minimum completed runs before a scope's rate is trusted for avoid/prefer, mirroring
+// LI_DEGRADED_MIN_SAMPLE's rationale (0-of-1 and 0-of-50 are both "0%", only the
+// second is evidence). Set to 3 per #2760 — one below the degraded floor because the
+// prompt guidance is advisory (it steers the reasoner, it does not hard-suppress a
+// proposal), so a slightly lower bar to surface the signal is acceptable.
+export const SCOPE_AWARENESS_MIN_SAMPLE = 3;
+
 /**
  * The default per-app config. PortOS (isPortos) additionally gets the meta/self
  * scopes so the loop can extend itself; every other app is capped at its own
@@ -896,6 +922,51 @@ export function computeSelfEvalSummary({
  * block with calibration guidance when non-empty (#2428). `selfEvalReport` (from
  * computeSelfEvalSummary) is injected as a `liSelfEval` block the same way (#2700).
  */
+/**
+ * Scope-awareness report (#2760). Classifies each CoS task-type scope by its lifetime
+ * execution success rate into "avoid" (chronically failing) and "prefer" (reliably
+ * succeeding), then renders guidance the reasoner can use to steer a proposal toward
+ * work that will actually execute. Pure — takes the already-parsed per-type metrics
+ * map (the `summary` gatherSources builds from learning.byTaskType) and returns a
+ * report string, or '' when no scope has enough runs to qualify either way.
+ *
+ * `metricsByType[type] = { lifetimeSuccessRate: number|null, lifetimeCompleted: number, ... }`.
+ * The steering is advisory, not a hard gate: LI still MAY propose in an avoid scope
+ * when it is genuinely the highest-value work, but it must justify doing so. Because
+ * the input is re-read every run, the split is dynamic and self-clearing — a scope
+ * leaves "avoid" automatically once its rate climbs back past the threshold.
+ */
+export function computeScopeAwareness({ metricsByType = {} } = {}) {
+  const avoid = [];
+  const prefer = [];
+  for (const [type, m] of Object.entries(metricsByType || {})) {
+    const rate = m?.lifetimeSuccessRate;
+    const n = m?.lifetimeCompleted || 0;
+    // Only a scope with enough evidence is classified; a NUMBER rate is required so a
+    // never-run scope (null) neither avoids nor prefers — it defaults to neutral.
+    if (typeof rate !== 'number' || n < SCOPE_AWARENESS_MIN_SAMPLE) continue;
+    if (rate < SCOPE_AVOID_SUCCESS_THRESHOLD) avoid.push({ type, rate, n });
+    else if (rate >= SCOPE_PREFER_SUCCESS_THRESHOLD) prefer.push({ type, rate, n });
+  }
+  if (!avoid.length && !prefer.length) return '';
+  // Worst-first for avoid, best-first for prefer — the reasoner reads the sharpest
+  // signal at the top of each list.
+  avoid.sort((a, b) => a.rate - b.rate);
+  prefer.sort((a, b) => b.rate - a.rate);
+  const fmt = ({ type, rate, n }) => `- ${type}: ${Math.round(rate)}% success over ${n} runs`;
+  const lines = [];
+  if (avoid.length) {
+    lines.push(`AVOID — these scopes' work has historically FAILED to execute (below ${SCOPE_AVOID_SUCCESS_THRESHOLD}% success):`);
+    lines.push(avoid.map(fmt).join('\n'));
+  }
+  if (prefer.length) {
+    if (lines.length) lines.push('');
+    lines.push(`PREFER — these scopes execute reliably (at or above ${SCOPE_PREFER_SUCCESS_THRESHOLD}% success):`);
+    lines.push(prefer.map(fmt).join('\n'));
+  }
+  return lines.join('\n');
+}
+
 export function buildPrompt({ app, config, sources = {}, openIssues = [], isPortos = false, outcomesReport = '', selfEvalReport = '' }) {
   const allowed = (config.allowedScopes || []).filter(s =>
     isScopeAllowed({ scope: s, allowedScopes: config.allowedScopes, isPortos })
@@ -906,7 +977,7 @@ export function buildPrompt({ app, config, sources = {}, openIssues = [], isPort
   // under the committed backlog it refers to instead of drifting to wherever
   // object key order happens to put it.
   const sourceBlocks = Object.entries(sources)
-    .filter(([k]) => k !== 'plannedWork')
+    .filter(([k]) => k !== 'plannedWork' && k !== 'scopeGuidance')
     .filter(([, v]) => typeof v === 'string' && v.trim())
     .map(([k, v]) => `### ${k}\n${v.trim()}`)
     .join('\n\n');
@@ -953,6 +1024,15 @@ export function buildPrompt({ app, config, sources = {}, openIssues = [], isPort
     ? `\n### liSelfEval\n${selfEvalReport.trim()}\n\nWeigh this against the sources above before you commit to a proposal. Filing nothing (proposal: null) is a legitimate, and sometimes the correct, outcome — a marginal issue costs the user triage time and lowers your merge rate further.\n`
     : '';
 
+  // Scope-awareness (#2760): your proposal, once filed, is EXECUTED as a CoS task, so
+  // the historical per-scope execution-success rates below predict whether the work
+  // you propose will actually land. Steer toward PREFER scopes and away from AVOID
+  // ones; if the highest-value work genuinely falls in an AVOID scope, you may still
+  // propose it, but scope it narrowly and justify why it will execute this time.
+  const scopeGuidanceBlock = (typeof sources.scopeGuidance === 'string' && sources.scopeGuidance.trim())
+    ? `\n### liScopeAwareness\n${sources.scopeGuidance.trim()}\n\nYour proposals are executed as CoS tasks in these scopes. Favor work that maps to a PREFER scope; treat AVOID scopes as needing a narrow scope and an explicit justification (or a null proposal) rather than a default.\n`
+    : '';
+
   return `You are the Layered Intelligence reasoner for the app "${app.name}". Your job is to evaluate how THIS app is performing against its OWN goals and purpose${isPortos ? '' : ', not how well PortOS\'s tooling manages it'}. Decide the SINGLE highest-value improvement to propose this run (signal, not noise), grounded in the app's own goals and its own performance metrics (user success, KPIs, production telemetry). You never write code; you return structured JSON that a deterministic system files as ONE tracker issue.
 ${handoffNote}${metricsGuidance}
 Rules & guidance from the operator:
@@ -966,7 +1046,7 @@ ${openList}
 
 Gathered sources:
 ${sourceBlocks || (plannedWorkBlock ? '(no other sources available — you may propose an app-data-gap to add telemetry)' : '(no sources available — you may propose an app-data-gap to add telemetry)')}
-${plannedWorkBlock}${outcomesBlock}${selfEvalBlock}
+${plannedWorkBlock}${outcomesBlock}${selfEvalBlock}${scopeGuidanceBlock}
 Respond with JSON only (no markdown fences):
 {
   "analysis": "brief reasoning summary",
@@ -1222,6 +1302,14 @@ export async function gatherSources(app, config, { cosPath = PATHS.cos, trustShe
         };
       }
       out.cosMetrics = JSON.stringify(summary).slice(0, 4000);
+      // Scope-awareness guidance (#2760): a deterministic avoid/prefer split derived
+      // from the SAME per-type rates above, so the reasoner gets an interpreted signal
+      // alongside the raw JSON instead of being asked to spot the pattern itself.
+      // Rendered as its own prompt block (see buildPrompt), not a generic source dump.
+      // Gated implicitly on the cosMetrics source being enabled — which is the
+      // PortOS-vs-managed boundary these self-execution rates belong to.
+      const scopeGuidance = computeScopeAwareness({ metricsByType: summary });
+      if (scopeGuidance) out.scopeGuidance = scopeGuidance;
     }
   }
   for (const custom of src.custom || []) {

--- a/server/services/layeredIntelligence.js
+++ b/server/services/layeredIntelligence.js
@@ -175,13 +175,15 @@ export const PROPOSAL_OUTCOMES = ['merged', 'rejected', 'abandoned'];
 // (computeScopeAwareness) that surfaces the avoid/prefer split to the reasoner so it
 // can steer proposals toward scopes that actually execute.
 //
-// A scope is "avoid" when its lifetime success rate is below AVOID and it has enough
-// completed runs to be evidence; "prefer" when at/above PREFER with the same sample
-// floor. Reusing the degraded-execution boundary (50%) for AVOID keeps LI's two
-// success signals — its own loop health and per-scope executability — on the same
-// coin-flip line. Because the classification is recomputed from fresh learning.json
-// every run, an "avoid" scope self-clears the moment its rate recovers past AVOID —
-// no persisted avoid-list to go stale (the issue's "dynamic adjustment" requirement).
+// A scope is "avoid" when its effective (recency-windowed-or-lifetime) success rate is
+// below AVOID and it has enough completed runs to be evidence; "prefer" when at/above
+// PREFER with the same sample floor. Reusing the degraded-execution boundary (50%) for
+// AVOID keeps LI's two success signals — its own loop health and per-scope
+// executability — on the same coin-flip line. The classification is recomputed from
+// fresh metrics every run and keyed on the windowed rate, so an "avoid" scope
+// self-clears once it recovers in-window — no persisted avoid-list to go stale (the
+// issue's "dynamic adjustment" requirement). See computeScopeAwareness for why the
+// windowed rate, not the near-permanent lifetime rate, is the right basis.
 export const SCOPE_AVOID_SUCCESS_THRESHOLD = LI_DEGRADED_SUCCESS_THRESHOLD; // < 50% → avoid
 export const SCOPE_PREFER_SUCCESS_THRESHOLD = 75;                          // >= 75% → prefer
 
@@ -915,36 +917,45 @@ export function computeSelfEvalSummary({
 }
 
 /**
- * Build the JSON-only reasoning prompt for one app. Deterministic: given the
- * gathered sources, open issues, and config, produces the exact string sent to
- * the model. Meta/self scopes are only offered when the app is PortOS.
- * `outcomesReport` (from computeOutcomesReport) is injected as a `liOutcomes`
- * block with calibration guidance when non-empty (#2428). `selfEvalReport` (from
- * computeSelfEvalSummary) is injected as a `liSelfEval` block the same way (#2700).
- */
-/**
- * Scope-awareness report (#2760). Classifies each CoS task-type scope by its lifetime
- * execution success rate into "avoid" (chronically failing) and "prefer" (reliably
- * succeeding), then renders guidance the reasoner can use to steer a proposal toward
- * work that will actually execute. Pure — takes the already-parsed per-type metrics
- * map (the `summary` gatherSources builds from learning.byTaskType) and returns a
- * report string, or '' when no scope has enough runs to qualify either way.
+ * Scope-awareness report (#2760). Classifies each CoS task-type scope by its execution
+ * success rate into "avoid" (chronically failing) and "prefer" (reliably succeeding),
+ * then renders guidance the reasoner can use to steer a proposal toward work that will
+ * actually execute. Pure — takes the already-parsed per-type metrics map (the `summary`
+ * gatherSources builds from learning.byTaskType) and returns a report string, or ''
+ * when no scope has enough runs to qualify either way.
  *
- * `metricsByType[type] = { lifetimeSuccessRate: number|null, lifetimeCompleted: number, ... }`.
- * The steering is advisory, not a hard gate: LI still MAY propose in an avoid scope
- * when it is genuinely the highest-value work, but it must justify doing so. Because
- * the input is re-read every run, the split is dynamic and self-clearing — a scope
- * leaves "avoid" automatically once its rate climbs back past the threshold.
+ * `metricsByType[type] = { lifetimeSuccessRate, lifetimeCompleted, recentSuccessRate, recentCompleted, ... }`.
+ *
+ * Classification judges on the EFFECTIVE rate — the recency-windowed rate when the
+ * scope has run in-window, else lifetime — NOT the raw lifetime rate. This matters for
+ * the issue's "dynamic adjustment" requirement: the lifetime rate barely decays (an
+ * old failure burst depresses it near-permanently), so a scope that has actually
+ * recovered would stay stuck on the avoid list for dozens of runs. Using the windowed
+ * rate lets a recovered scope leave "avoid" promptly — and keeps this advisory list
+ * moving in the same direction the scheduler's own skip logic acts on
+ * (isSkipCandidate / computeEffectiveSuccessRate in taskLearning also key off the
+ * effective rate). The sample floor still gates on LIFETIME completed: a scope needs
+ * enough TOTAL evidence to be judged at all, even if only a couple of those runs are
+ * in-window.
+ *
+ * The thresholds (50/75) are deliberately NOT the scheduler's 30% hard-skip line: this
+ * steering is advisory (it nudges what LI PROPOSES, it never suppresses execution), so
+ * a wider, more cautious net is correct here. LI still MAY propose in an avoid scope
+ * when it is genuinely the highest-value work — it just has to justify doing so.
  */
 export function computeScopeAwareness({ metricsByType = {} } = {}) {
   const avoid = [];
   const prefer = [];
   for (const [type, m] of Object.entries(metricsByType || {})) {
-    const rate = m?.lifetimeSuccessRate;
     const n = m?.lifetimeCompleted || 0;
-    // Only a scope with enough evidence is classified; a NUMBER rate is required so a
-    // never-run scope (null) neither avoids nor prefers — it defaults to neutral.
-    if (typeof rate !== 'number' || n < SCOPE_AWARENESS_MIN_SAMPLE) continue;
+    if (n < SCOPE_AWARENESS_MIN_SAMPLE) continue; // not enough total evidence to judge
+    // Effective rate: trust the recency window when it has runs, else fall back to
+    // lifetime. recentSuccessRate is null (not 0) when the window is empty (#2460), so
+    // guard on recentCompleted before using it.
+    const rate = (m?.recentCompleted > 0 && typeof m?.recentSuccessRate === 'number')
+      ? m.recentSuccessRate
+      : m?.lifetimeSuccessRate;
+    if (typeof rate !== 'number') continue; // a never-run scope stays neutral
     if (rate < SCOPE_AVOID_SUCCESS_THRESHOLD) avoid.push({ type, rate, n });
     else if (rate >= SCOPE_PREFER_SUCCESS_THRESHOLD) prefer.push({ type, rate, n });
   }
@@ -954,19 +965,30 @@ export function computeScopeAwareness({ metricsByType = {} } = {}) {
   avoid.sort((a, b) => a.rate - b.rate);
   prefer.sort((a, b) => b.rate - a.rate);
   const fmt = ({ type, rate, n }) => `- ${type}: ${Math.round(rate)}% success over ${n} runs`;
-  const lines = [];
-  if (avoid.length) {
-    lines.push(`AVOID — these scopes' work has historically FAILED to execute (below ${SCOPE_AVOID_SUCCESS_THRESHOLD}% success):`);
-    lines.push(avoid.map(fmt).join('\n'));
-  }
-  if (prefer.length) {
-    if (lines.length) lines.push('');
-    lines.push(`PREFER — these scopes execute reliably (at or above ${SCOPE_PREFER_SUCCESS_THRESHOLD}% success):`);
-    lines.push(prefer.map(fmt).join('\n'));
-  }
-  return lines.join('\n');
+  const section = (header, items) => `${header}\n${items.map(fmt).join('\n')}`;
+  const sections = [];
+  if (avoid.length) sections.push(section(`AVOID — these scopes' work has historically FAILED to execute (below ${SCOPE_AVOID_SUCCESS_THRESHOLD}% success):`, avoid));
+  if (prefer.length) sections.push(section(`PREFER — these scopes execute reliably (at or above ${SCOPE_PREFER_SUCCESS_THRESHOLD}% success):`, prefer));
+  return sections.join('\n\n');
 }
 
+// Source keys that buildPrompt renders as their OWN dedicated block (with tailored
+// guidance) instead of dumping into the generic "### <key>\n<value>" source list.
+// Keeping them in one named set — rather than accreting `&& k !== 'x'` clauses on the
+// filter — documents WHY these keys are special and gives the next dedicated-block
+// signal a single edit point.
+const BESPOKE_SOURCE_BLOCK_KEYS = new Set(['plannedWork', 'scopeGuidance']);
+
+/**
+ * Build the JSON-only reasoning prompt for one app. Deterministic: given the
+ * gathered sources, open issues, and config, produces the exact string sent to
+ * the model. Meta/self scopes are only offered when the app is PortOS.
+ * `outcomesReport` (from computeOutcomesReport) is injected as a `liOutcomes`
+ * block with calibration guidance when non-empty (#2428). `selfEvalReport` (from
+ * computeSelfEvalSummary) is injected as a `liSelfEval` block the same way (#2700).
+ * `sources.scopeGuidance` (from computeScopeAwareness) is injected as a
+ * `liScopeAwareness` block the same way (#2760).
+ */
 export function buildPrompt({ app, config, sources = {}, openIssues = [], isPortos = false, outcomesReport = '', selfEvalReport = '' }) {
   const allowed = (config.allowedScopes || []).filter(s =>
     isScopeAllowed({ scope: s, allowedScopes: config.allowedScopes, isPortos })
@@ -977,7 +999,7 @@ export function buildPrompt({ app, config, sources = {}, openIssues = [], isPort
   // under the committed backlog it refers to instead of drifting to wherever
   // object key order happens to put it.
   const sourceBlocks = Object.entries(sources)
-    .filter(([k]) => k !== 'plannedWork' && k !== 'scopeGuidance')
+    .filter(([k]) => !BESPOKE_SOURCE_BLOCK_KEYS.has(k))
     .filter(([, v]) => typeof v === 'string' && v.trim())
     .map(([k, v]) => `### ${k}\n${v.trim()}`)
     .join('\n\n');

--- a/server/services/layeredIntelligence.js
+++ b/server/services/layeredIntelligence.js
@@ -29,7 +29,7 @@ import { fetchPublicText } from '../lib/safeUrlFetch.js';
 import { validateCommand } from '../lib/commandSecurity.js';
 import { getSettings } from './settings.js';
 import { createTicket, searchIssues, addLabels, escapeJql } from './jira.js';
-import { computeWindowedStats, computeEffectiveSuccessRate, extractTaskType } from './taskLearning/store.js';
+import { computeWindowedStats, computeEffectiveSuccessRate, EFFECTIVE_RATE_MIN_WINDOW_SAMPLES, extractTaskType } from './taskLearning/store.js';
 import { formatRejectionReasons, formatRejectionReason, REJECTION_REASONS } from './layeredIntelligenceRejections.js';
 
 // Tracker labels + slug marker. The slug is the stable dedup key the reasoner
@@ -180,7 +180,8 @@ export const PROPOSAL_OUTCOMES = ['merged', 'rejected', 'abandoned'];
 // PREFER with the same sample floor. Reusing the degraded-execution boundary (50%) for
 // AVOID keeps LI's two success signals — its own loop health and per-scope
 // executability — on the same coin-flip line. The classification is recomputed from
-// fresh metrics every run and keyed on the windowed rate, so an "avoid" scope
+// fresh metrics every run and keyed on the windowed rate (once the window clears the
+// scheduler's own EFFECTIVE_RATE_MIN_WINDOW_SAMPLES floor), so an "avoid" scope
 // self-clears once it recovers in-window — no persisted avoid-list to go stale (the
 // issue's "dynamic adjustment" requirement). See computeScopeAwareness for why the
 // windowed rate, not the near-permanent lifetime rate, is the right basis.
@@ -927,16 +928,21 @@ export function computeSelfEvalSummary({
  * `metricsByType[type] = { lifetimeSuccessRate, lifetimeCompleted, recentSuccessRate, recentCompleted, ... }`.
  *
  * Classification judges on the EFFECTIVE rate — the recency-windowed rate when the
- * scope has run in-window, else lifetime — NOT the raw lifetime rate. This matters for
- * the issue's "dynamic adjustment" requirement: the lifetime rate barely decays (an
- * old failure burst depresses it near-permanently), so a scope that has actually
+ * window has enough samples, else lifetime — NOT the raw lifetime rate. This matters
+ * for the issue's "dynamic adjustment" requirement: the lifetime rate barely decays
+ * (an old failure burst depresses it near-permanently), so a scope that has actually
  * recovered would stay stuck on the avoid list for dozens of runs. Using the windowed
- * rate lets a recovered scope leave "avoid" promptly — and keeps this advisory list
- * moving in the same direction the scheduler's own skip logic acts on
- * (isSkipCandidate / computeEffectiveSuccessRate in taskLearning also key off the
- * effective rate). The sample floor still gates on LIFETIME completed: a scope needs
- * enough TOTAL evidence to be judged at all, even if only a couple of those runs are
- * in-window.
+ * rate lets a recovered scope leave "avoid" promptly — and, critically, this uses the
+ * SAME window floor as the scheduler's own skip logic
+ * (EFFECTIVE_RATE_MIN_WINDOW_SAMPLES, the threshold in computeEffectiveSuccessRate /
+ * isSkipCandidate): the window is trusted only at >= that many in-window runs, so a
+ * single noisy recent result can't flip a lifetime-reliable scope to avoid (or vice
+ * versa). Below that floor the lifetime rate governs, exactly as the scheduler does,
+ * so this advisory list moves in the same direction the scheduler acts on. The base
+ * sample floor still gates on LIFETIME completed: a scope needs enough TOTAL evidence
+ * to be judged at all. Each rendered rate is paired with the run count of the SAME
+ * basis (windowed count when the window governs, lifetime count otherwise) so the
+ * "N% over M runs" line never mixes a windowed rate with a lifetime count.
  *
  * The thresholds (50/75) are deliberately NOT the scheduler's 30% hard-skip line: this
  * steering is advisory (it nudges what LI PROPOSES, it never suppresses execution), so
@@ -947,15 +953,19 @@ export function computeScopeAwareness({ metricsByType = {} } = {}) {
   const avoid = [];
   const prefer = [];
   for (const [type, m] of Object.entries(metricsByType || {})) {
-    const n = m?.lifetimeCompleted || 0;
-    if (n < SCOPE_AWARENESS_MIN_SAMPLE) continue; // not enough total evidence to judge
-    // Effective rate: trust the recency window when it has runs, else fall back to
-    // lifetime. recentSuccessRate is null (not 0) when the window is empty (#2460), so
-    // guard on recentCompleted before using it.
-    const rate = (m?.recentCompleted > 0 && typeof m?.recentSuccessRate === 'number')
-      ? m.recentSuccessRate
-      : m?.lifetimeSuccessRate;
+    const lifetimeN = m?.lifetimeCompleted || 0;
+    if (lifetimeN < SCOPE_AWARENESS_MIN_SAMPLE) continue; // not enough total evidence to judge
+    // Effective rate: trust the recency window ONLY when it carries enough samples —
+    // the same EFFECTIVE_RATE_MIN_WINDOW_SAMPLES floor the scheduler's
+    // computeEffectiveSuccessRate uses — so one noisy recent run can't flip a
+    // lifetime-reliable scope. Below the floor (including an empty window, where
+    // recentSuccessRate is null, not 0 — #2460), lifetime governs. Pair the rate with
+    // the count of its own basis so the rendered "N% over M runs" is truthful.
+    const useWindow = m?.recentCompleted >= EFFECTIVE_RATE_MIN_WINDOW_SAMPLES
+      && typeof m?.recentSuccessRate === 'number';
+    const rate = useWindow ? m.recentSuccessRate : m?.lifetimeSuccessRate;
     if (typeof rate !== 'number') continue; // a never-run scope stays neutral
+    const n = useWindow ? m.recentCompleted : lifetimeN;
     if (rate < SCOPE_AVOID_SUCCESS_THRESHOLD) avoid.push({ type, rate, n });
     else if (rate >= SCOPE_PREFER_SUCCESS_THRESHOLD) prefer.push({ type, rate, n });
   }

--- a/server/services/layeredIntelligence.js
+++ b/server/services/layeredIntelligence.js
@@ -195,6 +195,15 @@ export const SCOPE_PREFER_SUCCESS_THRESHOLD = 75;                          // >=
 // proposal), so a slightly lower bar to surface the signal is acceptable.
 export const SCOPE_AWARENESS_MIN_SAMPLE = 3;
 
+// Prompt-size bounds for the scope-awareness block, so a long-lived install with many
+// task types (mission task keys embed an unbounded mission name) can't render an
+// oversized block — the raw cosMetrics source is already char-capped for the same
+// reason. Cap the entries surfaced per list (the lists are sorted sharpest-first, so
+// the cap keeps the most decision-relevant scopes) and truncate any single task-type
+// name so one pathological key can't blow the budget.
+export const SCOPE_AWARENESS_MAX_PER_LIST = 12;
+export const SCOPE_AWARENESS_MAX_TYPE_LEN = 80;
+
 /**
  * The default per-app config. PortOS (isPortos) additionally gets the meta/self
  * scopes so the loop can extend itself; every other app is capped at its own
@@ -918,12 +927,22 @@ export function computeSelfEvalSummary({
 }
 
 /**
- * Scope-awareness report (#2760). Classifies each CoS task-type scope by its execution
- * success rate into "avoid" (chronically failing) and "prefer" (reliably succeeding),
- * then renders guidance the reasoner can use to steer a proposal toward work that will
- * actually execute. Pure — takes the already-parsed per-type metrics map (the `summary`
+ * Scope-awareness report (#2760). Classifies each CoS task TYPE by its completion rate
+ * into low-completion and high-completion lists, as directional context for the
+ * reasoner. Pure — takes the already-parsed per-type metrics map (the `summary`
  * gatherSources builds from learning.byTaskType) and returns a report string, or ''
- * when no scope has enough runs to qualify either way.
+ * when no type has enough runs to qualify either way.
+ *
+ * IMPORTANT (codex P1): this is per-task-TYPE, install-wide completion telemetry — NOT
+ * a per-proposal execution record. An LI proposal is later implemented through a
+ * claim/plan/handoff task whose task type does NOT carry the proposal's domain (a
+ * handoff becomes `internal-task`; a claimed issue runs under the claim task type), so
+ * these buckets are populated by independently-scheduled jobs, not by LI's own
+ * proposals bucketed by subject. The block is therefore framed as "work of this KIND
+ * tends to (not) get finished here" — useful directional context (especially LI's own
+ * reasoning-run type, self-improve:layered-intelligence, which IS LI's execution) — and
+ * deliberately NOT a claim that a given proposal maps 1:1 onto a listed type. Proper
+ * per-proposal-domain outcome correlation is tracked as a follow-up (#2765).
  *
  * `metricsByType[type] = { lifetimeSuccessRate, lifetimeCompleted, recentSuccessRate, recentCompleted, ... }`.
  *
@@ -974,11 +993,27 @@ export function computeScopeAwareness({ metricsByType = {} } = {}) {
   // signal at the top of each list.
   avoid.sort((a, b) => a.rate - b.rate);
   prefer.sort((a, b) => b.rate - a.rate);
-  const fmt = ({ type, rate, n }) => `- ${type}: ${Math.round(rate)}% success over ${n} runs`;
-  const section = (header, items) => `${header}\n${items.map(fmt).join('\n')}`;
+  // Cap each list (sharpest-first) and truncate a pathological task-type name so the
+  // block stays bounded on a long-lived install.
+  const clampType = (type) => type.length > SCOPE_AWARENESS_MAX_TYPE_LEN
+    ? `${type.slice(0, SCOPE_AWARENESS_MAX_TYPE_LEN - 1)}…`
+    : type;
+  const fmt = ({ type, rate, n }) => `- ${clampType(type)}: ${Math.round(rate)}% completed over ${n} runs`;
+  const section = (header, items) => {
+    const shown = items.slice(0, SCOPE_AWARENESS_MAX_PER_LIST);
+    const more = items.length - shown.length;
+    const lines = shown.map(fmt);
+    if (more > 0) lines.push(`- …and ${more} more`);
+    return `${header}\n${lines.join('\n')}`;
+  };
   const sections = [];
-  if (avoid.length) sections.push(section(`AVOID — these scopes' work has historically FAILED to execute (below ${SCOPE_AVOID_SUCCESS_THRESHOLD}% success):`, avoid));
-  if (prefer.length) sections.push(section(`PREFER — these scopes execute reliably (at or above ${SCOPE_PREFER_SUCCESS_THRESHOLD}% success):`, prefer));
+  // Honest framing (#2760, codex P1): these are per-task-TYPE completion rates for the
+  // whole install — NOT a per-proposal execution record. An LI proposal is implemented
+  // through a claim/plan/handoff task whose type does not carry the proposal's domain,
+  // so this is directional context ("work of this kind tends to (not) get finished
+  // here"), not a claim that a given proposal maps 1:1 onto a listed type.
+  if (avoid.length) sections.push(section(`LOW-COMPLETION task types — work of this kind is finished below ${SCOPE_AVOID_SUCCESS_THRESHOLD}% of the time on this install:`, avoid));
+  if (prefer.length) sections.push(section(`HIGH-COMPLETION task types — finished at or above ${SCOPE_PREFER_SUCCESS_THRESHOLD}%:`, prefer));
   return sections.join('\n\n');
 }
 
@@ -1056,13 +1091,15 @@ export function buildPrompt({ app, config, sources = {}, openIssues = [], isPort
     ? `\n### liSelfEval\n${selfEvalReport.trim()}\n\nWeigh this against the sources above before you commit to a proposal. Filing nothing (proposal: null) is a legitimate, and sometimes the correct, outcome — a marginal issue costs the user triage time and lowers your merge rate further.\n`
     : '';
 
-  // Scope-awareness (#2760): your proposal, once filed, is EXECUTED as a CoS task, so
-  // the historical per-scope execution-success rates below predict whether the work
-  // you propose will actually land. Steer toward PREFER scopes and away from AVOID
-  // ones; if the highest-value work genuinely falls in an AVOID scope, you may still
-  // propose it, but scope it narrowly and justify why it will execute this time.
-  const scopeGuidanceBlock = (typeof sources.scopeGuidance === 'string' && sources.scopeGuidance.trim())
-    ? `\n### liScopeAwareness\n${sources.scopeGuidance.trim()}\n\nYour proposals are executed as CoS tasks in these scopes. Favor work that maps to a PREFER scope; treat AVOID scopes as needing a narrow scope and an explicit justification (or a null proposal) rather than a default.\n`
+  // Scope-awareness (#2760): install-wide completion rates by CoS task TYPE — directional
+  // context for how reliably different KINDS of work get finished here. PortOS-only
+  // (codex P2): these rates are this install's own CoS execution history, meaningless to
+  // a managed app, so the block is gated on isPortos even if a managed app enabled the
+  // cosMetrics source. It is context, not a rule (codex P1): a proposal does not map 1:1
+  // onto a listed type, so treat a low-completion type as a reason for extra scrutiny /
+  // a narrower scope, not a hard veto.
+  const scopeGuidanceBlock = (isPortos && typeof sources.scopeGuidance === 'string' && sources.scopeGuidance.trim())
+    ? `\n### liScopeAwareness\n${sources.scopeGuidance.trim()}\n\nThese are per-task-type completion rates for THIS install — how reliably each KIND of work tends to get finished, not a per-proposal record (your proposals don't map 1:1 onto these types). Use it as directional context: a proposal whose implementation resembles a low-completion type deserves extra scrutiny or a narrower scope; high-completion kinds are safer bets. A low rate on self-improve:layered-intelligence is LI's OWN reasoning-run rate — a direct signal to propose conservatively.\n`
     : '';
 
   return `You are the Layered Intelligence reasoner for the app "${app.name}". Your job is to evaluate how THIS app is performing against its OWN goals and purpose${isPortos ? '' : ', not how well PortOS\'s tooling manages it'}. Decide the SINGLE highest-value improvement to propose this run (signal, not noise), grounded in the app's own goals and its own performance metrics (user success, KPIs, production telemetry). You never write code; you return structured JSON that a deterministic system files as ONE tracker issue.
@@ -1267,7 +1304,7 @@ export async function gatherPlannedWork({
  * (`{ filer, forgeCli, cwd, jira }`, resolved by the caller) enables the
  * plannedWork source — absent, that source is simply skipped.
  */
-export async function gatherSources(app, config, { cosPath = PATHS.cos, trustShellSources, tracker = null } = {}) {
+export async function gatherSources(app, config, { cosPath = PATHS.cos, trustShellSources, tracker = null, isPortos = false } = {}) {
   const out = {};
   const src = config.sources || {};
   const repo = app.repoPath;
@@ -1334,14 +1371,18 @@ export async function gatherSources(app, config, { cosPath = PATHS.cos, trustShe
         };
       }
       out.cosMetrics = JSON.stringify(summary).slice(0, 4000);
-      // Scope-awareness guidance (#2760): a deterministic avoid/prefer split derived
-      // from the SAME per-type rates above, so the reasoner gets an interpreted signal
-      // alongside the raw JSON instead of being asked to spot the pattern itself.
-      // Rendered as its own prompt block (see buildPrompt), not a generic source dump.
-      // Gated implicitly on the cosMetrics source being enabled — which is the
-      // PortOS-vs-managed boundary these self-execution rates belong to.
-      const scopeGuidance = computeScopeAwareness({ metricsByType: summary });
-      if (scopeGuidance) out.scopeGuidance = scopeGuidance;
+      // Scope-awareness guidance (#2760): a deterministic low/high-completion split
+      // derived from the SAME per-type rates above, so the reasoner gets an interpreted
+      // signal alongside the raw JSON instead of being asked to spot the pattern itself.
+      // Rendered as its own prompt block (see buildPrompt). Gated on isPortos (codex P2):
+      // these are THIS install's own CoS completion rates, meaningless to a managed app —
+      // and a managed app CAN enable the cosMetrics source, so the cosMetrics toggle
+      // alone is not the PortOS boundary. buildPrompt re-checks isPortos as defense in
+      // depth; deriving it here only for PortOS also avoids the wasted work.
+      if (isPortos) {
+        const scopeGuidance = computeScopeAwareness({ metricsByType: summary });
+        if (scopeGuidance) out.scopeGuidance = scopeGuidance;
+      }
     }
   }
   for (const custom of src.custom || []) {

--- a/server/services/layeredIntelligence.test.js
+++ b/server/services/layeredIntelligence.test.js
@@ -506,26 +506,39 @@ describe('computeScopeAwareness (#2760)', () => {
   });
 
   it('judges on the recency-windowed rate so a RECOVERED scope leaves avoid (#2760 dynamic adjustment)', () => {
-    // Lifetime is dragged to 10% by an old failure burst, but the recent window is all
-    // successes → the effective rate is high, so the scope must NOT be on the avoid
-    // list (and here clears PREFER). Proves self-clearing works off the windowed rate,
-    // which the near-permanent lifetime rate could never deliver.
+    // Lifetime is dragged to 10% by an old failure burst, but the recent window (>= the
+    // 5-sample floor) is all successes → the effective rate is high, so the scope must
+    // NOT be on the avoid list (and here clears PREFER). Proves self-clearing works off
+    // the windowed rate, which the near-permanent lifetime rate could never deliver.
+    // The rendered count matches the rate's basis: windowed rate → windowed count.
     const out = computeScopeAwareness({ metricsByType: {
-      'branch-reconcile': { lifetimeSuccessRate: 10, lifetimeCompleted: 20, recentSuccessRate: 100, recentCompleted: 5 }
+      'branch-reconcile': { lifetimeSuccessRate: 10, lifetimeCompleted: 20, recentSuccessRate: 100, recentCompleted: 6 }
     } });
     expect(out).not.toContain('AVOID');
     expect(out).toContain('PREFER');
-    expect(out).toContain('branch-reconcile: 100% success over 20 runs'); // rate = windowed, count = lifetime total
+    expect(out).toContain('branch-reconcile: 100% success over 6 runs'); // windowed rate AND windowed count
   });
 
   it('judges on the windowed rate so a REGRESSED scope enters avoid despite a high lifetime rate', () => {
-    // Lifetime looks great (95%) but the recent window has collapsed → treat as avoid.
+    // Lifetime looks great (95%) but the recent window (>= floor) has collapsed → avoid.
     const out = computeScopeAwareness({ metricsByType: {
-      'performance': { lifetimeSuccessRate: 95, lifetimeCompleted: 40, recentSuccessRate: 20, recentCompleted: 5 }
+      'performance': { lifetimeSuccessRate: 95, lifetimeCompleted: 40, recentSuccessRate: 20, recentCompleted: 8 }
     } });
     expect(out).toContain('AVOID');
-    expect(out).toContain('performance: 20% success over 40 runs');
+    expect(out).toContain('performance: 20% success over 8 runs'); // windowed rate AND windowed count
     expect(out).not.toContain('PREFER');
+  });
+
+  it('ignores a THIN recent window (below the sample floor) and lets lifetime govern (#2760)', () => {
+    // Only 1 recent run — below EFFECTIVE_RATE_MIN_WINDOW_SAMPLES (5) — so one noisy
+    // recent failure must NOT flip a lifetime-reliable scope to avoid; lifetime (95%)
+    // governs → PREFER, matching the scheduler's own effective-rate floor.
+    const out = computeScopeAwareness({ metricsByType: {
+      'plan-task': { lifetimeSuccessRate: 95, lifetimeCompleted: 40, recentSuccessRate: 0, recentCompleted: 1 }
+    } });
+    expect(out).toContain('PREFER');
+    expect(out).toContain('plan-task: 95% success over 40 runs'); // lifetime rate AND lifetime count
+    expect(out).not.toContain('AVOID');
   });
 
   it('falls back to the lifetime rate when the recency window is empty', () => {

--- a/server/services/layeredIntelligence.test.js
+++ b/server/services/layeredIntelligence.test.js
@@ -505,6 +505,38 @@ describe('computeScopeAwareness (#2760)', () => {
     } })).toBe('');
   });
 
+  it('judges on the recency-windowed rate so a RECOVERED scope leaves avoid (#2760 dynamic adjustment)', () => {
+    // Lifetime is dragged to 10% by an old failure burst, but the recent window is all
+    // successes → the effective rate is high, so the scope must NOT be on the avoid
+    // list (and here clears PREFER). Proves self-clearing works off the windowed rate,
+    // which the near-permanent lifetime rate could never deliver.
+    const out = computeScopeAwareness({ metricsByType: {
+      'branch-reconcile': { lifetimeSuccessRate: 10, lifetimeCompleted: 20, recentSuccessRate: 100, recentCompleted: 5 }
+    } });
+    expect(out).not.toContain('AVOID');
+    expect(out).toContain('PREFER');
+    expect(out).toContain('branch-reconcile: 100% success over 20 runs'); // rate = windowed, count = lifetime total
+  });
+
+  it('judges on the windowed rate so a REGRESSED scope enters avoid despite a high lifetime rate', () => {
+    // Lifetime looks great (95%) but the recent window has collapsed → treat as avoid.
+    const out = computeScopeAwareness({ metricsByType: {
+      'performance': { lifetimeSuccessRate: 95, lifetimeCompleted: 40, recentSuccessRate: 20, recentCompleted: 5 }
+    } });
+    expect(out).toContain('AVOID');
+    expect(out).toContain('performance: 20% success over 40 runs');
+    expect(out).not.toContain('PREFER');
+  });
+
+  it('falls back to the lifetime rate when the recency window is empty', () => {
+    // recentCompleted 0 / recentSuccessRate null → lifetime rate governs.
+    const out = computeScopeAwareness({ metricsByType: {
+      'plan-task': { lifetimeSuccessRate: 100, lifetimeCompleted: 10, recentSuccessRate: null, recentCompleted: 0 }
+    } });
+    expect(out).toContain('PREFER');
+    expect(out).toContain('plan-task: 100% success over 10 runs');
+  });
+
   it('sorts AVOID worst-first and PREFER best-first', () => {
     const out = computeScopeAwareness({ metricsByType: {
       'branch-reconcile': { lifetimeSuccessRate: 20, lifetimeCompleted: 5 },
@@ -536,7 +568,7 @@ describe('computeScopeAwareness (#2760)', () => {
 describe('buildPrompt', () => {
   const app = { name: 'TestApp' };
 
-  it('injects the scope-awareness block + steering guidance only when present (#2760)', () => {
+  it('injects the scope-awareness block only when present, under its own heading (#2760)', () => {
     const base = { app, isPortos: true, config: { allowedScopes: ['loop-meta'], rules: '' } };
     const without = buildPrompt(base);
     expect(without).not.toContain('liScopeAwareness');
@@ -547,17 +579,8 @@ describe('buildPrompt', () => {
     expect(withGuidance).toContain('### liScopeAwareness');
     expect(withGuidance).toContain('branch-reconcile: 0% success over 4 runs');
     expect(withGuidance).toContain('executed as CoS tasks');
-  });
-
-  it('does not render scopeGuidance as a generic source block', () => {
-    const out = buildPrompt({
-      app, isPortos: true,
-      config: { allowedScopes: ['loop-meta'], rules: '' },
-      sources: { scopeGuidance: 'PREFER — plan-task: 100% success over 10 runs' }
-    });
-    // rendered under its dedicated heading, never as "### scopeGuidance"
-    expect(out).not.toContain('### scopeGuidance');
-    expect(out).toContain('### liScopeAwareness');
+    // rendered under its dedicated heading, never as a generic "### scopeGuidance" dump
+    expect(withGuidance).not.toContain('### scopeGuidance');
   });
 
   it('only offers meta/self scopes on PortOS', () => {

--- a/server/services/layeredIntelligence.test.js
+++ b/server/services/layeredIntelligence.test.js
@@ -46,6 +46,7 @@ import {
   SCOPE_AVOID_SUCCESS_THRESHOLD,
   SCOPE_PREFER_SUCCESS_THRESHOLD,
   SCOPE_AWARENESS_MIN_SAMPLE,
+  SCOPE_AWARENESS_MAX_PER_LIST,
   PROPOSAL_OUTCOMES,
   extractPlanSlugs,
   appendProposalToPlan,
@@ -478,18 +479,18 @@ describe('computeScopeAwareness (#2760)', () => {
     const out = computeScopeAwareness({ metricsByType: {
       'self-improve:layered-intelligence': { lifetimeSuccessRate: 0, lifetimeCompleted: 9 }
     } });
-    expect(out).toContain('AVOID');
-    expect(out).toContain('self-improve:layered-intelligence: 0% success over 9 runs');
-    expect(out).not.toContain('PREFER');
+    expect(out).toContain('LOW-COMPLETION');
+    expect(out).toContain('self-improve:layered-intelligence: 0% completed over 9 runs');
+    expect(out).not.toContain('HIGH-COMPLETION');
   });
 
   it('classifies an at/above-threshold scope with enough runs as PREFER', () => {
     const out = computeScopeAwareness({ metricsByType: {
       'plan-task': { lifetimeSuccessRate: 100, lifetimeCompleted: 10 }
     } });
-    expect(out).toContain('PREFER');
-    expect(out).toContain('plan-task: 100% success over 10 runs');
-    expect(out).not.toContain('AVOID');
+    expect(out).toContain('HIGH-COMPLETION');
+    expect(out).toContain('plan-task: 100% completed over 10 runs');
+    expect(out).not.toContain('LOW-COMPLETION');
   });
 
   it('leaves a mid-band scope (between avoid and prefer) unclassified', () => {
@@ -514,9 +515,9 @@ describe('computeScopeAwareness (#2760)', () => {
     const out = computeScopeAwareness({ metricsByType: {
       'branch-reconcile': { lifetimeSuccessRate: 10, lifetimeCompleted: 20, recentSuccessRate: 100, recentCompleted: 6 }
     } });
-    expect(out).not.toContain('AVOID');
-    expect(out).toContain('PREFER');
-    expect(out).toContain('branch-reconcile: 100% success over 6 runs'); // windowed rate AND windowed count
+    expect(out).not.toContain('LOW-COMPLETION');
+    expect(out).toContain('HIGH-COMPLETION');
+    expect(out).toContain('branch-reconcile: 100% completed over 6 runs'); // windowed rate AND windowed count
   });
 
   it('judges on the windowed rate so a REGRESSED scope enters avoid despite a high lifetime rate', () => {
@@ -524,9 +525,9 @@ describe('computeScopeAwareness (#2760)', () => {
     const out = computeScopeAwareness({ metricsByType: {
       'performance': { lifetimeSuccessRate: 95, lifetimeCompleted: 40, recentSuccessRate: 20, recentCompleted: 8 }
     } });
-    expect(out).toContain('AVOID');
-    expect(out).toContain('performance: 20% success over 8 runs'); // windowed rate AND windowed count
-    expect(out).not.toContain('PREFER');
+    expect(out).toContain('LOW-COMPLETION');
+    expect(out).toContain('performance: 20% completed over 8 runs'); // windowed rate AND windowed count
+    expect(out).not.toContain('HIGH-COMPLETION');
   });
 
   it('ignores a THIN recent window (below the sample floor) and lets lifetime govern (#2760)', () => {
@@ -536,9 +537,9 @@ describe('computeScopeAwareness (#2760)', () => {
     const out = computeScopeAwareness({ metricsByType: {
       'plan-task': { lifetimeSuccessRate: 95, lifetimeCompleted: 40, recentSuccessRate: 0, recentCompleted: 1 }
     } });
-    expect(out).toContain('PREFER');
-    expect(out).toContain('plan-task: 95% success over 40 runs'); // lifetime rate AND lifetime count
-    expect(out).not.toContain('AVOID');
+    expect(out).toContain('HIGH-COMPLETION');
+    expect(out).toContain('plan-task: 95% completed over 40 runs'); // lifetime rate AND lifetime count
+    expect(out).not.toContain('LOW-COMPLETION');
   });
 
   it('falls back to the lifetime rate when the recency window is empty', () => {
@@ -546,8 +547,8 @@ describe('computeScopeAwareness (#2760)', () => {
     const out = computeScopeAwareness({ metricsByType: {
       'plan-task': { lifetimeSuccessRate: 100, lifetimeCompleted: 10, recentSuccessRate: null, recentCompleted: 0 }
     } });
-    expect(out).toContain('PREFER');
-    expect(out).toContain('plan-task: 100% success over 10 runs');
+    expect(out).toContain('HIGH-COMPLETION');
+    expect(out).toContain('plan-task: 100% completed over 10 runs');
   });
 
   it('sorts AVOID worst-first and PREFER best-first', () => {
@@ -562,7 +563,17 @@ describe('computeScopeAwareness (#2760)', () => {
     // best prefer (performance 100%) precedes the milder one (test-coverage 80%)
     expect(out.indexOf('performance')).toBeLessThan(out.indexOf('test-coverage'));
     // AVOID section precedes PREFER section
-    expect(out.indexOf('AVOID')).toBeLessThan(out.indexOf('PREFER'));
+    expect(out.indexOf('LOW-COMPLETION')).toBeLessThan(out.indexOf('HIGH-COMPLETION'));
+  });
+
+  it('truncates a pathologically long task-type name (#2760 codex P2)', () => {
+    const longType = 'self-improve:mission-' + 'x'.repeat(200);
+    const out = computeScopeAwareness({ metricsByType: {
+      [longType]: { lifetimeSuccessRate: 0, lifetimeCompleted: 5 }
+    } });
+    expect(out).toContain('LOW-COMPLETION');
+    expect(out).not.toContain(longType); // full 200-char name never rendered verbatim
+    expect(out).toContain('…');           // truncation marker present
   });
 
   it('honors the exported thresholds at their exact boundaries', () => {
@@ -570,7 +581,7 @@ describe('computeScopeAwareness (#2760)', () => {
     const atPrefer = computeScopeAwareness({ metricsByType: {
       x: { lifetimeSuccessRate: SCOPE_PREFER_SUCCESS_THRESHOLD, lifetimeCompleted: SCOPE_AWARENESS_MIN_SAMPLE }
     } });
-    expect(atPrefer).toContain('PREFER');
+    expect(atPrefer).toContain('HIGH-COMPLETION');
     const atAvoidBoundary = computeScopeAwareness({ metricsByType: {
       x: { lifetimeSuccessRate: SCOPE_AVOID_SUCCESS_THRESHOLD, lifetimeCompleted: SCOPE_AWARENESS_MIN_SAMPLE }
     } });
@@ -587,13 +598,26 @@ describe('buildPrompt', () => {
     expect(without).not.toContain('liScopeAwareness');
     const withGuidance = buildPrompt({
       ...base,
-      sources: { scopeGuidance: 'AVOID — these scopes have historically FAILED:\n- branch-reconcile: 0% success over 4 runs' }
+      sources: { scopeGuidance: 'LOW-COMPLETION task types:\n- branch-reconcile: 0% completed over 4 runs' }
     });
     expect(withGuidance).toContain('### liScopeAwareness');
-    expect(withGuidance).toContain('branch-reconcile: 0% success over 4 runs');
-    expect(withGuidance).toContain('executed as CoS tasks');
+    expect(withGuidance).toContain('branch-reconcile: 0% completed over 4 runs');
+    expect(withGuidance).toContain('completion rates for THIS install'); // honest framing (codex P1)
     // rendered under its dedicated heading, never as a generic "### scopeGuidance" dump
     expect(withGuidance).not.toContain('### scopeGuidance');
+  });
+
+  it('suppresses the scope-awareness block on a managed (non-PortOS) app (#2760 codex P2)', () => {
+    // Even if a stray scopeGuidance string reaches a managed app's sources, buildPrompt
+    // must not render it — the rates are this install's own CoS history, meaningless
+    // there. Defense-in-depth alongside gatherSources gating the derivation on isPortos.
+    const out = buildPrompt({
+      app, isPortos: false,
+      config: { allowedScopes: ['app-improvement'], rules: '' },
+      sources: { scopeGuidance: 'LOW-COMPLETION task types:\n- plan-task: 0% completed over 9 runs' }
+    });
+    expect(out).not.toContain('liScopeAwareness');
+    expect(out).not.toContain('plan-task: 0% completed over 9 runs');
   });
 
   it('only offers meta/self scopes on PortOS', () => {
@@ -1974,7 +1998,7 @@ describe('gatherSources cosMetrics windowed rate (issue #2460)', () => {
     expect(out.cosMetrics).toBeUndefined();
   });
 
-  it('emits scopeGuidance derived from the same per-type rates (#2760)', async () => {
+  it('emits scopeGuidance derived from the same per-type rates on PortOS (#2760)', async () => {
     await writeLearning({
       byTaskType: {
         'self-improve:layered-intelligence': { completed: 9, succeeded: 0, failed: 9, successRate: 0, recentOutcomes: [] },
@@ -1982,11 +2006,11 @@ describe('gatherSources cosMetrics windowed rate (issue #2460)', () => {
         'feature-ideas': { completed: 8, succeeded: 5, failed: 3, successRate: 63, recentOutcomes: [] } // mid-band → neither
       }
     });
-    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: true } }, { cosPath: dir });
-    expect(out.scopeGuidance).toContain('AVOID');
-    expect(out.scopeGuidance).toContain('self-improve:layered-intelligence: 0% success over 9 runs');
-    expect(out.scopeGuidance).toContain('PREFER');
-    expect(out.scopeGuidance).toContain('plan-task: 100% success over 10 runs');
+    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: true } }, { cosPath: dir, isPortos: true });
+    expect(out.scopeGuidance).toContain('LOW-COMPLETION');
+    expect(out.scopeGuidance).toContain('self-improve:layered-intelligence: 0% completed over 9 runs');
+    expect(out.scopeGuidance).toContain('HIGH-COMPLETION');
+    expect(out.scopeGuidance).toContain('plan-task: 100% completed over 10 runs');
     expect(out.scopeGuidance).not.toContain('feature-ideas');
   });
 
@@ -1994,16 +2018,44 @@ describe('gatherSources cosMetrics windowed rate (issue #2460)', () => {
     await writeLearning({
       byTaskType: { 'plan-task': { completed: 2, succeeded: 2, failed: 0, successRate: 100, recentOutcomes: [] } }
     });
-    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: true } }, { cosPath: dir });
+    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: true } }, { cosPath: dir, isPortos: true });
     expect(out.cosMetrics).toBeDefined(); // raw metrics still surfaced
     expect(out.scopeGuidance).toBeUndefined();
+  });
+
+  it('does NOT emit scopeGuidance for a managed app even when it enabled cosMetrics (#2760 codex P2)', async () => {
+    // These completion rates are the install's own CoS history — irrelevant to a
+    // managed app — so the derivation is gated on isPortos, not just the cosMetrics
+    // toggle (which a managed app CAN turn on). cosMetrics itself is still surfaced.
+    await writeLearning({
+      byTaskType: { 'plan-task': { completed: 10, succeeded: 0, failed: 10, successRate: 0, recentOutcomes: [] } }
+    });
+    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: true } }, { cosPath: dir, isPortos: false });
+    expect(out.cosMetrics).toBeDefined();
+    expect(out.scopeGuidance).toBeUndefined();
+  });
+
+  it('caps the number of task types per list and notes the overflow (#2760 codex P2)', async () => {
+    // Overflow the cap by 3 chronically-failing types (all past the sample floor) → the
+    // block must cap at SCOPE_AWARENESS_MAX_PER_LIST and note the remainder, not dump all.
+    const overflow = 3;
+    const total = SCOPE_AWARENESS_MAX_PER_LIST + overflow;
+    const byTaskType = {};
+    for (let i = 0; i < total; i++) {
+      byTaskType[`self-improve:fail-scope-${i}`] = { completed: 5, succeeded: 0, failed: 5, successRate: 0, recentOutcomes: [] };
+    }
+    await writeLearning({ byTaskType });
+    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: true } }, { cosPath: dir, isPortos: true });
+    const listedTypes = (out.scopeGuidance.match(/self-improve:fail-scope-\d+/g) || []).length;
+    expect(listedTypes).toBe(SCOPE_AWARENESS_MAX_PER_LIST);
+    expect(out.scopeGuidance).toContain(`and ${overflow} more`);
   });
 
   it('does not emit scopeGuidance when cosMetrics is off (#2760)', async () => {
     await writeLearning({
       byTaskType: { 'accessibility': { completed: 4, succeeded: 0, failed: 4, successRate: 0, recentOutcomes: [] } }
     });
-    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: false } }, { cosPath: dir });
+    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: false } }, { cosPath: dir, isPortos: true });
     expect(out.scopeGuidance).toBeUndefined();
   });
 });

--- a/server/services/layeredIntelligence.test.js
+++ b/server/services/layeredIntelligence.test.js
@@ -42,6 +42,10 @@ import {
   rejectionReasonBySlug,
   LI_DEGRADED_SUCCESS_THRESHOLD,
   LI_DEGRADED_MIN_SAMPLE,
+  computeScopeAwareness,
+  SCOPE_AVOID_SUCCESS_THRESHOLD,
+  SCOPE_PREFER_SUCCESS_THRESHOLD,
+  SCOPE_AWARENESS_MIN_SAMPLE,
   PROPOSAL_OUTCOMES,
   extractPlanSlugs,
   appendProposalToPlan,
@@ -455,8 +459,106 @@ describe('filerForTracker / trackerSupportsPause (dispatch)', () => {
   });
 });
 
+describe('computeScopeAwareness (#2760)', () => {
+  it('returns empty string when no scope clears the sample floor', () => {
+    // Both under SCOPE_AWARENESS_MIN_SAMPLE (3) → neither classified.
+    expect(computeScopeAwareness({ metricsByType: {
+      'plan-task': { lifetimeSuccessRate: 100, lifetimeCompleted: 2 },
+      'accessibility': { lifetimeSuccessRate: 0, lifetimeCompleted: 1 }
+    } })).toBe('');
+  });
+
+  it('returns empty string for an empty / missing map', () => {
+    expect(computeScopeAwareness({})).toBe('');
+    expect(computeScopeAwareness()).toBe('');
+    expect(computeScopeAwareness({ metricsByType: {} })).toBe('');
+  });
+
+  it('classifies a below-threshold scope with enough runs as AVOID', () => {
+    const out = computeScopeAwareness({ metricsByType: {
+      'self-improve:layered-intelligence': { lifetimeSuccessRate: 0, lifetimeCompleted: 9 }
+    } });
+    expect(out).toContain('AVOID');
+    expect(out).toContain('self-improve:layered-intelligence: 0% success over 9 runs');
+    expect(out).not.toContain('PREFER');
+  });
+
+  it('classifies an at/above-threshold scope with enough runs as PREFER', () => {
+    const out = computeScopeAwareness({ metricsByType: {
+      'plan-task': { lifetimeSuccessRate: 100, lifetimeCompleted: 10 }
+    } });
+    expect(out).toContain('PREFER');
+    expect(out).toContain('plan-task: 100% success over 10 runs');
+    expect(out).not.toContain('AVOID');
+  });
+
+  it('leaves a mid-band scope (between avoid and prefer) unclassified', () => {
+    // 60% is >= AVOID (50) and < PREFER (75) → neither list.
+    expect(computeScopeAwareness({ metricsByType: {
+      'feature-ideas': { lifetimeSuccessRate: 60, lifetimeCompleted: 8 }
+    } })).toBe('');
+  });
+
+  it('ignores a never-run scope (null rate) even with a high completed count artifact', () => {
+    expect(computeScopeAwareness({ metricsByType: {
+      'idle-review': { lifetimeSuccessRate: null, lifetimeCompleted: 12 }
+    } })).toBe('');
+  });
+
+  it('sorts AVOID worst-first and PREFER best-first', () => {
+    const out = computeScopeAwareness({ metricsByType: {
+      'branch-reconcile': { lifetimeSuccessRate: 20, lifetimeCompleted: 5 },
+      'accessibility': { lifetimeSuccessRate: 0, lifetimeCompleted: 4 },
+      'test-coverage': { lifetimeSuccessRate: 80, lifetimeCompleted: 5 },
+      'performance': { lifetimeSuccessRate: 100, lifetimeCompleted: 3 }
+    } });
+    // worst avoid (accessibility 0%) precedes the milder one (branch-reconcile 20%)
+    expect(out.indexOf('accessibility')).toBeLessThan(out.indexOf('branch-reconcile'));
+    // best prefer (performance 100%) precedes the milder one (test-coverage 80%)
+    expect(out.indexOf('performance')).toBeLessThan(out.indexOf('test-coverage'));
+    // AVOID section precedes PREFER section
+    expect(out.indexOf('AVOID')).toBeLessThan(out.indexOf('PREFER'));
+  });
+
+  it('honors the exported thresholds at their exact boundaries', () => {
+    // exactly PREFER threshold → prefer; exactly AVOID threshold → neither (< is strict)
+    const atPrefer = computeScopeAwareness({ metricsByType: {
+      x: { lifetimeSuccessRate: SCOPE_PREFER_SUCCESS_THRESHOLD, lifetimeCompleted: SCOPE_AWARENESS_MIN_SAMPLE }
+    } });
+    expect(atPrefer).toContain('PREFER');
+    const atAvoidBoundary = computeScopeAwareness({ metricsByType: {
+      x: { lifetimeSuccessRate: SCOPE_AVOID_SUCCESS_THRESHOLD, lifetimeCompleted: SCOPE_AWARENESS_MIN_SAMPLE }
+    } });
+    expect(atAvoidBoundary).toBe(''); // 50% is not < 50 and not >= 75
+  });
+});
+
 describe('buildPrompt', () => {
   const app = { name: 'TestApp' };
+
+  it('injects the scope-awareness block + steering guidance only when present (#2760)', () => {
+    const base = { app, isPortos: true, config: { allowedScopes: ['loop-meta'], rules: '' } };
+    const without = buildPrompt(base);
+    expect(without).not.toContain('liScopeAwareness');
+    const withGuidance = buildPrompt({
+      ...base,
+      sources: { scopeGuidance: 'AVOID — these scopes have historically FAILED:\n- branch-reconcile: 0% success over 4 runs' }
+    });
+    expect(withGuidance).toContain('### liScopeAwareness');
+    expect(withGuidance).toContain('branch-reconcile: 0% success over 4 runs');
+    expect(withGuidance).toContain('executed as CoS tasks');
+  });
+
+  it('does not render scopeGuidance as a generic source block', () => {
+    const out = buildPrompt({
+      app, isPortos: true,
+      config: { allowedScopes: ['loop-meta'], rules: '' },
+      sources: { scopeGuidance: 'PREFER — plan-task: 100% success over 10 runs' }
+    });
+    // rendered under its dedicated heading, never as "### scopeGuidance"
+    expect(out).not.toContain('### scopeGuidance');
+    expect(out).toContain('### liScopeAwareness');
+  });
 
   it('only offers meta/self scopes on PortOS', () => {
     const nonPortos = buildPrompt({
@@ -1834,6 +1936,39 @@ describe('gatherSources cosMetrics windowed rate (issue #2460)', () => {
     await writeLearning({ byTaskType: { x: { successRate: 50, recentOutcomes: [] } } });
     const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: false } }, { cosPath: dir });
     expect(out.cosMetrics).toBeUndefined();
+  });
+
+  it('emits scopeGuidance derived from the same per-type rates (#2760)', async () => {
+    await writeLearning({
+      byTaskType: {
+        'self-improve:layered-intelligence': { completed: 9, succeeded: 0, failed: 9, successRate: 0, recentOutcomes: [] },
+        'plan-task': { completed: 10, succeeded: 10, failed: 0, successRate: 100, recentOutcomes: [] },
+        'feature-ideas': { completed: 8, succeeded: 5, failed: 3, successRate: 63, recentOutcomes: [] } // mid-band → neither
+      }
+    });
+    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: true } }, { cosPath: dir });
+    expect(out.scopeGuidance).toContain('AVOID');
+    expect(out.scopeGuidance).toContain('self-improve:layered-intelligence: 0% success over 9 runs');
+    expect(out.scopeGuidance).toContain('PREFER');
+    expect(out.scopeGuidance).toContain('plan-task: 100% success over 10 runs');
+    expect(out.scopeGuidance).not.toContain('feature-ideas');
+  });
+
+  it('omits scopeGuidance when no scope clears the sample floor (#2760)', async () => {
+    await writeLearning({
+      byTaskType: { 'plan-task': { completed: 2, succeeded: 2, failed: 0, successRate: 100, recentOutcomes: [] } }
+    });
+    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: true } }, { cosPath: dir });
+    expect(out.cosMetrics).toBeDefined(); // raw metrics still surfaced
+    expect(out.scopeGuidance).toBeUndefined();
+  });
+
+  it('does not emit scopeGuidance when cosMetrics is off (#2760)', async () => {
+    await writeLearning({
+      byTaskType: { 'accessibility': { completed: 4, succeeded: 0, failed: 4, successRate: 0, recentOutcomes: [] } }
+    });
+    const out = await gatherSources({ repoPath: dir }, { sources: { cosMetrics: false } }, { cosPath: dir });
+    expect(out.scopeGuidance).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #2760.

Layered Intelligence's task generation had no awareness of which kinds of work this install actually completes. Several CoS task types sit at 0% completion (`self-improve:layered-intelligence`, `branch-reconcile`, `accessibility`) while others complete reliably (`plan-task`, `test-coverage`, `performance`), yet the reasoner proposed in a vacuum — wasting runs on work that tends not to land.

This adds a deterministic `computeScopeAwareness` classifier and a new `liScopeAwareness` prompt block:

- Splits per-CoS-task-type completion metrics into **low-completion** (< 50%) and **high-completion** (≥ 75%) lists, gated on a ≥3-run lifetime sample floor.
- Judges on the **effective (recency-windowed-or-lifetime) rate**, using the scheduler's own `EFFECTIVE_RATE_MIN_WINDOW_SAMPLES` (5) floor — so a recovered scope self-clears promptly (the issue's "dynamic adjustment" requirement) and the advisory list never contradicts the scheduler's skip view over a single noisy sample.
- Recomputed from fresh metrics every run — no persisted avoid-list to go stale.
- **Honest framing:** these are install-wide per-task-TYPE completion rates, surfaced as directional context ("work of this kind tends to (not) get finished here"), **not** a claim that an LI proposal maps 1:1 onto a listed task type (a proposal is implemented via a claim/plan/handoff task whose type doesn't carry its domain). Proper per-proposal-domain outcome correlation is filed as a follow-up (#2765).
- **PortOS-only** and **bounded**: gated on `isPortos` (a managed app that enables `cosMetrics` is not steered by this install's history), and the block caps entries per list + truncates pathological task-type names, mirroring the existing `cosMetrics` char cap.

## Test plan

- `cd server && npm test -- services/layeredIntelligence.test.js services/autonomousJobs/layeredIntelligenceHooks.test.js services/cosTaskGenerator.test.js` — all green (397+ assertions).
- New coverage: avoid/prefer classification, boundary thresholds, effective-rate windowing (recovery, regression, thin-window-below-floor, empty-window fallback), entry-cap + overflow note, task-type-name truncation, managed-app suppression (derivation + render), and the end-to-end `gatherSources → buildPrompt` wiring.

## Review

Reviewed by claude (caught the window-sample-floor divergence), ollama (clean), and codex (3 findings: the per-proposal-vs-task-type framing, the managed-app gate, and the unbounded block — all fixed here), plus a `/simplify` pass. Follow-up #2765 tracks the deeper per-proposal-domain correlation.