### PR TITLE
Gallery Clean lineage reads 'Cleaned (resize-squeeze)' (route Clean through /clean)

### DIFF
--- a/client/src/components/media/variants.test.js
+++ b/client/src/components/media/variants.test.js
@@ -41,6 +41,17 @@ describe('computeImageVariantGroup', () => {
     expect(result.active.label).toBe('Cleaned (aggressive)');
   });
 
+  it('labels a resize-squeeze clean as "Cleaned (resize-squeeze)" (issue #1764)', () => {
+    const orig = img('a.png');
+    const cleaned = img('a_clean-resize-squeeze.png', { cleanedFrom: 'a.png', cleanLevel: 'resize-squeeze' });
+    const result = computeImageVariantGroup(orig, [orig, cleaned]);
+    expect(result).not.toBeNull();
+    expect(result.group).toEqual([
+      { label: 'Original', item: orig },
+      { label: 'Cleaned (resize-squeeze)', item: cleaned },
+    ]);
+  });
+
   it('orders light before aggressive when both legacy clean variants exist', () => {
     const orig = img('a.png');
     const aggressive = img('a_clean-aggressive.png', { cleanedFrom: 'a.png', cleanLevel: 'aggressive' });

--- a/client/src/hooks/useMediaPreviewActions.js
+++ b/client/src/hooks/useMediaPreviewActions.js
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toast from '../components/ui/Toast';
-import { regenerateGalleryImage, extractLastFrame, removeImageWatermark } from '../services/apiImageVideo';
+import { cleanGalleryImage, extractLastFrame, removeImageWatermark } from '../services/apiImageVideo';
 import { VIDEO_TILING_ENUM_SET } from '../lib/videoTilingOptions';
 
 // Common image render-setting params shared by the image branch of Remix and by
@@ -144,20 +144,21 @@ export default function useMediaPreviewActions({ onCleanComplete = null } = {}) 
     navigate(`/media/video?${params}`);
   }, [navigate]);
 
-  // Clean: run the CPU resize-squeeze (light regen). This downscale→upscale
-  // resolution shift re-encodes to PNG — so it still strips the C2PA provenance
-  // chunk and ancillary metadata as a side effect — AND perturbs SynthID's
-  // resolution-dependent carriers (issue #1764: validated best-effort against
-  // OpenAI's SynthID detector — it makes the detector fail to return a positive;
-  // best-effort/detector-dependent, never a guaranteed removal). This replaces
-  // the old metadata+denoise "aggressive" clean, which did NOT touch SynthID.
-  // The light method is synchronous and returns the new gallery variant directly
-  // (no FLUX runner / GPU needed). `onCleanComplete` is the consumer-specific
-  // post-step (add-to-collection / prepend-to-history / etc.) — fired AFTER the
-  // success toast so a failing post-step still shows the user it succeeded.
+  // Clean: run the gallery clean endpoint, which applies the CPU resize-squeeze
+  // (a downscale→upscale resolution shift) — it re-encodes to PNG so it still
+  // strips the C2PA provenance chunk AND perturbs SynthID's resolution-dependent
+  // carriers (issue #1764: validated best-effort against OpenAI's SynthID
+  // detector — it makes the detector fail to return a positive; best-effort/
+  // detector-dependent, never a guaranteed removal). Runs on the /clean endpoint
+  // (not the regen endpoint) so the result is tagged as a clean — its lineage
+  // reads "Cleaned (resize-squeeze)", distinct from the Regenerate panel's own
+  // light pass ("Regenerated (light)"). Returns the new gallery variant directly.
+  // `onCleanComplete` is the consumer-specific post-step (add-to-collection /
+  // prepend-to-history / etc.) — fired AFTER the success toast so a failing
+  // post-step still shows the user it succeeded.
   const handleClean = useCallback(async (img) => {
     if (!img?.filename) throw new Error('Missing filename');
-    const cleaned = await regenerateGalleryImage(img.filename, { method: 'light' }).catch((err) => {
+    const cleaned = await cleanGalleryImage(img.filename, { silent: true }).catch((err) => {
       toast.error(err.message || 'Failed to clean image');
       throw err;
     });

--- a/client/src/hooks/useMediaPreviewActions.test.jsx
+++ b/client/src/hooks/useMediaPreviewActions.test.jsx
@@ -6,12 +6,12 @@ const navigate = vi.fn();
 vi.mock('react-router-dom', () => ({ useNavigate: () => navigate }));
 vi.mock('../components/ui/Toast', () => ({ default: { error: vi.fn(), success: vi.fn() } }));
 vi.mock('../services/apiImageVideo', () => ({
-  regenerateGalleryImage: vi.fn(),
+  cleanGalleryImage: vi.fn(),
   extractLastFrame: vi.fn(),
   removeImageWatermark: vi.fn(),
 }));
 
-import { removeImageWatermark, regenerateGalleryImage } from '../services/apiImageVideo';
+import { removeImageWatermark, cleanGalleryImage } from '../services/apiImageVideo';
 
 const parseNav = () => {
   const url = navigate.mock.calls.at(-1)?.[0] || '';
@@ -80,15 +80,15 @@ describe('useMediaPreviewActions.handleRemoveWatermark', () => {
 });
 
 describe('useMediaPreviewActions.handleClean', () => {
-  beforeEach(() => regenerateGalleryImage.mockReset());
+  beforeEach(() => cleanGalleryImage.mockReset());
 
-  it('runs the CPU resize-squeeze (light regen), not the aggressive denoise clean', async () => {
-    const variant = { filename: 'cat_regen-light.png', regenMethod: 'light-spatial' };
-    regenerateGalleryImage.mockResolvedValue(variant);
+  it('runs the gallery clean endpoint (resize-squeeze) and returns the cleaned variant', async () => {
+    const variant = { filename: 'cat_clean-resize-squeeze.png', cleanLevel: 'resize-squeeze' };
+    cleanGalleryImage.mockResolvedValue(variant);
     const onCleanComplete = vi.fn();
     const { result } = renderHook(() => useMediaPreviewActions({ onCleanComplete }));
     const returned = await result.current.handleClean({ filename: 'cat.png' });
-    expect(regenerateGalleryImage).toHaveBeenCalledWith('cat.png', { method: 'light' });
+    expect(cleanGalleryImage).toHaveBeenCalledWith('cat.png', { silent: true });
     expect(onCleanComplete).toHaveBeenCalledWith(variant);
     expect(returned).toBe(variant);
   });
@@ -96,6 +96,6 @@ describe('useMediaPreviewActions.handleClean', () => {
   it('throws when the image has no filename', async () => {
     const { result } = renderHook(() => useMediaPreviewActions());
     await expect(result.current.handleClean({})).rejects.toThrow('Missing filename');
-    expect(regenerateGalleryImage).not.toHaveBeenCalled();
+    expect(cleanGalleryImage).not.toHaveBeenCalled();
   });
 });

--- a/server/lib/imageClean.js
+++ b/server/lib/imageClean.js
@@ -53,9 +53,12 @@ export function resolveCleanersFromConfig(modeCfg, mode) {
 // covers reasonable photos (12000×8000) without allowing pathological inputs.
 const MAX_PIXELS = 96 * 1000 * 1000;
 
-// Exported as a single-value array so the Zod enum shape stays stable if a
+// Clean-level tags stamped on a cleaned gallery variant's sidecar (read by the
+// lightbox lineage row). `aggressive` = the legacy metadata+denoise clean;
+// `resize-squeeze` = the gallery Clean button's CPU resize-squeeze pass
+// (issue #1764). Kept as an array so the Zod enum shape stays stable if a
 // future variant is added.
-export const CLEAN_LEVELS = ['aggressive'];
+export const CLEAN_LEVELS = ['aggressive', 'resize-squeeze'];
 
 // Magic-byte sniff so we re-encode as the source format and emit the right
 // MIME type — extension/header is supplied by the client and not trustworthy.

--- a/server/routes/imageGen.clean.test.js
+++ b/server/routes/imageGen.clean.test.js
@@ -74,8 +74,8 @@ beforeAll(async () => {
   // to a real path when the route reads from it.
   sandbox = await mkdtemp(join(tmpdir(), 'portos-imageclean-'));
   ({ default: imageGenRoutes } = await import('./imageGen.js'));
-  // Noisy 16×16 RGB so light vs aggressive denoise produce visibly different
-  // outputs. A solid-color fixture would round-trip identically through both.
+  // Noisy 16×16 RGB so the resize-squeeze round-trip visibly moves pixels.
+  // A solid-color fixture would round-trip near-identically.
   const raw = Buffer.alloc(16 * 16 * 3);
   for (let i = 0; i < raw.length; i += 1) raw[i] = (i * 73 + 11) % 256;
   pngFixture = await sharp(raw, { raw: { width: 16, height: 16, channels: 3 } })
@@ -101,7 +101,7 @@ describe('POST /api/image-gen/:filename/clean', () => {
     addItemMock.mockResolvedValue({});
   });
 
-  it('cleans an existing PNG and writes _clean-aggressive.png back to the gallery', async () => {
+  it('cleans an existing PNG and writes _clean-resize-squeeze.png back to the gallery', async () => {
     await writeFile(join(sandbox, 'render-1.png'), pngFixture);
     await writeFile(join(sandbox, 'render-1.metadata.json'), JSON.stringify({
       prompt: 'a red square', seed: 42, modelId: 'flux-v1',
@@ -109,16 +109,16 @@ describe('POST /api/image-gen/:filename/clean', () => {
 
     const res = await request(app).post('/api/image-gen/render-1.png/clean').send({});
     expect(res.status).toBe(200);
-    expect(res.body.filename).toBe('render-1_clean-aggressive.png');
+    expect(res.body.filename).toBe('render-1_clean-resize-squeeze.png');
     expect(res.body.cleanedFrom).toBe('render-1.png');
-    expect(res.body.cleanLevel).toBe('aggressive');
+    expect(res.body.cleanLevel).toBe('resize-squeeze');
     // Source sidecar carried forward so the cleaned copy retains lineage.
     expect(res.body.prompt).toBe('a red square');
     expect(res.body.seed).toBe(42);
     expect(res.body.modelId).toBe('flux-v1');
 
-    expect(existsSync(join(sandbox, 'render-1_clean-aggressive.png'))).toBe(true);
-    expect(existsSync(join(sandbox, 'render-1_clean-aggressive.metadata.json'))).toBe(true);
+    expect(existsSync(join(sandbox, 'render-1_clean-resize-squeeze.png'))).toBe(true);
+    expect(existsSync(join(sandbox, 'render-1_clean-resize-squeeze.metadata.json'))).toBe(true);
   });
 
   it('idempotent: running clean twice overwrites instead of accumulating', async () => {
@@ -126,7 +126,7 @@ describe('POST /api/image-gen/:filename/clean', () => {
     const first = await request(app).post('/api/image-gen/render-3.png/clean').send({});
     const second = await request(app).post('/api/image-gen/render-3.png/clean').send({});
     expect(first.body.filename).toBe(second.body.filename);
-    expect(first.body.filename).toBe('render-3_clean-aggressive.png');
+    expect(first.body.filename).toBe('render-3_clean-resize-squeeze.png');
   });
 
   it('rejects non-PNG filenames (gallery is PNG-only)', async () => {
@@ -147,9 +147,9 @@ describe('POST /api/image-gen/:filename/clean', () => {
   it('writes a sidecar that records the cleaning lineage', async () => {
     await writeFile(join(sandbox, 'render-6.png'), pngFixture);
     await request(app).post('/api/image-gen/render-6.png/clean').send({});
-    const sidecar = JSON.parse(await readFile(join(sandbox, 'render-6_clean-aggressive.metadata.json'), 'utf-8'));
+    const sidecar = JSON.parse(await readFile(join(sandbox, 'render-6_clean-resize-squeeze.metadata.json'), 'utf-8'));
     expect(sidecar.cleanedFrom).toBe('render-6.png');
-    expect(sidecar.cleanLevel).toBe('aggressive');
+    expect(sidecar.cleanLevel).toBe('resize-squeeze');
     expect(typeof sidecar.createdAt).toBe('string');
   });
 
@@ -163,7 +163,7 @@ describe('POST /api/image-gen/:filename/clean', () => {
     expect(res.body.hidden).toBeUndefined();
     expect(res.body.prompt).toBe('a hidden render');
 
-    const sidecar = JSON.parse(await readFile(join(sandbox, 'render-hidden_clean-aggressive.metadata.json'), 'utf-8'));
+    const sidecar = JSON.parse(await readFile(join(sandbox, 'render-hidden_clean-resize-squeeze.metadata.json'), 'utf-8'));
     expect(sidecar.hidden).toBeUndefined();
   });
 
@@ -171,7 +171,7 @@ describe('POST /api/image-gen/:filename/clean', () => {
     await writeFile(join(sandbox, 'my..render.png'), pngFixture);
     const res = await request(app).post(`/api/image-gen/${encodeURIComponent('my..render.png')}/clean`).send({});
     expect(res.status).toBe(200);
-    expect(res.body.filename).toBe('my..render_clean-aggressive.png');
+    expect(res.body.filename).toBe('my..render_clean-resize-squeeze.png');
   });
 
   it('output file size is reflected in sizeBytes / sizeAfter', async () => {
@@ -199,8 +199,8 @@ describe('POST /api/image-gen/:filename/clean', () => {
       expect(addItemMock).toHaveBeenCalledTimes(2);
       const calls = addItemMock.mock.calls.map(([id, item]) => ({ id, item }));
       expect(calls).toEqual(expect.arrayContaining([
-        { id: 'col-a', item: { kind: 'image', ref: 'render-coll_clean-aggressive.png' } },
-        { id: 'col-b', item: { kind: 'image', ref: 'render-coll_clean-aggressive.png' } },
+        { id: 'col-a', item: { kind: 'image', ref: 'render-coll_clean-resize-squeeze.png' } },
+        { id: 'col-b', item: { kind: 'image', ref: 'render-coll_clean-resize-squeeze.png' } },
       ]));
       expect(calls.find((c) => c.id === 'col-c-unrelated')).toBeUndefined();
     });
@@ -226,7 +226,7 @@ describe('POST /api/image-gen/:filename/clean', () => {
       const res = await request(app).post('/api/image-gen/render-dup.png/clean').send({});
       // The clean itself succeeds; the duplicate is swallowed.
       expect(res.status).toBe(200);
-      expect(res.body.filename).toBe('render-dup_clean-aggressive.png');
+      expect(res.body.filename).toBe('render-dup_clean-resize-squeeze.png');
     });
 
     it('clean succeeds even if listCollections throws (best-effort)', async () => {
@@ -235,9 +235,9 @@ describe('POST /api/image-gen/:filename/clean', () => {
 
       const res = await request(app).post('/api/image-gen/render-listfail.png/clean').send({});
       expect(res.status).toBe(200);
-      expect(res.body.filename).toBe('render-listfail_clean-aggressive.png');
+      expect(res.body.filename).toBe('render-listfail_clean-resize-squeeze.png');
       // The cleaned file still landed on disk.
-      expect(existsSync(join(sandbox, 'render-listfail_clean-aggressive.png'))).toBe(true);
+      expect(existsSync(join(sandbox, 'render-listfail_clean-resize-squeeze.png'))).toBe(true);
     });
 
     it('clean succeeds even when one addItem throws a non-DUPLICATE error (best-effort, others still fire)', async () => {

--- a/server/services/imageGen/variants.js
+++ b/server/services/imageGen/variants.js
@@ -22,7 +22,7 @@ import { readFile, writeFile } from 'fs/promises';
 import { join } from 'node:path';
 import { ServerError } from '../../lib/errorHandler.js';
 import { atomicWrite, PATHS } from '../../lib/fileUtils.js';
-import { cleanImageBuffer } from '../../lib/imageClean.js';
+import { stripPngC2PAChunk } from '../../lib/imageClean.js';
 import { removeCornerWatermark } from '../../lib/imageWatermark.js';
 import { applyLightRegen, computePixelDelta } from './regen.js';
 import { listCollections, addItem, ERR_DUPLICATE } from '../mediaCollections.js';
@@ -118,9 +118,21 @@ export async function persistVariant({
 // ---------------------------------------------------------------------------
 
 /**
- * C2PA-strip + denoise clean for /:filename/clean.
- * Reads the source, applies cleanImageBuffer, builds the variant record,
- * and delegates to persistVariant.
+ * Gallery "clean" for /:filename/clean — the CPU resize-squeeze.
+ * Reads the source, applies `applyLightRegen` (a downscale→upscale resolution
+ * shift that re-encodes to PNG), builds the variant record, and delegates to
+ * persistVariant.
+ *
+ * Why resize-squeeze and not metadata+denoise: the old "aggressive" clean
+ * (metadata strip + median/sharpen) did NOT touch SynthID. The resize-squeeze
+ * still strips the C2PA provenance chunk (via the PNG re-encode) AND perturbs
+ * SynthID's resolution-dependent carriers — a best-effort disruption validated
+ * against OpenAI's SynthID detector (issue #1764; detector-dependent, never a
+ * guaranteed removal). It runs here (the /clean endpoint), NOT the Regenerate
+ * panel's `method:'light'` pass, so the result is tagged as a CLEAN
+ * (`cleanLevel: 'resize-squeeze'`) and its lineage reads "Cleaned
+ * (resize-squeeze)", distinct from the regen panel's "Regenerated (light)"
+ * even though both call the same underlying `applyLightRegen`.
  *
  * @param {object} opts
  * @param {string} opts.filename    - gallery basename
@@ -134,17 +146,18 @@ export async function applyImageClean({ filename, sourceMeta }) {
     throw err;
   });
 
-  // Gallery "clean" is the aggressive variant: metadata strip + denoise.
-  const result = await cleanImageBuffer(buffer, { metadata: true, denoise: true });
-  if (result.format !== 'png') {
-    throw new ServerError('Gallery images must be PNG', { status: 400, code: 'UNSUPPORTED_FORMAT' });
+  // Detect the C2PA chunk BEFORE the re-encode drops it, so the sidecar can
+  // report whether provenance was actually stripped (lossless walk, no decode).
+  const c2paStripped = stripPngC2PAChunk(buffer).stripped;
+
+  // Resize-squeeze (best-effort SynthID disruption + C2PA strip via re-encode).
+  const light = await applyLightRegen(buffer);
+  if (!light) {
+    throw new ServerError('Invalid or corrupt image', { status: 400, code: 'INVALID_IMAGE' });
   }
 
-  // The `_clean-aggressive` filename suffix and `cleanLevel: 'aggressive'`
-  // sidecar field survive the light/aggressive collapse so already-cleaned
-  // images on disk keep round-tripping through the gallery unchanged.
   const base = filename.slice(0, -'.png'.length);
-  const outFilename = `${base}_clean-aggressive.png`;
+  const outFilename = `${base}_clean-resize-squeeze.png`;
   const createdAt = new Date().toISOString();
 
   // Strip `hidden` so a clean of a hidden source still surfaces in the gallery
@@ -156,27 +169,27 @@ export async function applyImageClean({ filename, sourceMeta }) {
     ...sourceMetaForCleaned,
     createdAt,
     cleanedFrom: filename,
-    cleanLevel: 'aggressive',
-    c2paStripped: result.c2paStripped,
+    cleanLevel: 'resize-squeeze',
+    c2paStripped,
   };
 
   return persistVariant({
     sourceFilename: filename,
     outFilename,
-    data: result.data,
+    data: light.data,
     variantMeta,
-    width: result.width,
-    height: result.height,
-    sizeBefore: result.sizeBefore,
-    sizeAfter: result.sizeAfter,
-    logLine: `🧼 Cleaned ${filename} → ${outFilename} (${result.sizeBefore}B → ${result.sizeAfter}B, c2pa=${result.c2paStripped})`,
+    width: light.width,
+    height: light.height,
+    sizeBefore: buffer.length,
+    sizeAfter: light.data.length,
+    logLine: `🧼 Cleaned ${filename} → ${outFilename} (resize-squeeze, ${buffer.length}B → ${light.data.length}B, c2pa=${c2paStripped})`,
     extraFields: {
       // sourceMeta fields already in variantMeta; these explicit fields win on
       // key collisions so createdAt reflects the cleaning, not the original.
       createdAt,
       cleanedFrom: filename,
-      cleanLevel: 'aggressive',
-      c2paStripped: result.c2paStripped,
+      cleanLevel: 'resize-squeeze',
+      c2paStripped,
     },
   });
 }


### PR DESCRIPTION
Refs #1764. Follow-up polish to PR #2806.

## Summary

In #2806 the gallery **Clean** button was pointed at the regenerate endpoint (`method=light`), which tagged the result as a *regen* — so its lineage read **"Regenerated (light) from …"**, an odd label for a Clean action and indistinguishable from the Regenerate panel's own light pass.

This routes Clean back through the **`/clean` endpoint**, but makes `applyImageClean` perform the **resize-squeeze** (`applyLightRegen`) instead of the old metadata+denoise pass. The result is tagged as a clean (`cleanLevel: 'resize-squeeze'`, `_clean-resize-squeeze.png`), so its lineage now reads **"Cleaned (resize-squeeze)"** — distinct from the Regenerate panel's "Regenerated (light)", even though both call the same underlying `applyLightRegen`.

Behavior is otherwise identical to #2806: Clean still does the resize-squeeze (best-effort SynthID disruption + C2PA strip via re-encode; C2PA presence detected with `stripPngC2PAChunk` before the re-encode drops it). No server schema/API changes beyond the new `cleanLevel` value.

- `handleClean` reverts to `cleanGalleryImage` (the /clean endpoint).
- `applyImageClean` → resize-squeeze; `_clean-resize-squeeze.png`; `cleanLevel: 'resize-squeeze'`.
- `CLEAN_LEVELS` gains `'resize-squeeze'`.
- The separate Regenerate → light pass is untouched (still "Regenerated (light)").

## Test plan

- `server/routes/imageGen.clean.test.js` updated to the `_clean-resize-squeeze` / `cleanLevel: 'resize-squeeze'` naming — **82/82 server tests pass** (clean route, regen grouping of legacy `_clean-aggressive` files, imageClean).
- `client/src/components/media/variants.test.js` gains a test pinning "Cleaned (resize-squeeze)"; `useMediaPreviewActions.test.jsx` reverted to assert the /clean endpoint — **25/25 client tests pass**. ESLint clean.
- Legacy `_clean-aggressive` / `_clean-light` on-disk variants still label correctly (back-compat preserved).