### PR TITLE
Goal editor UI: pin per-goal Daily Driver feature areas (featureAreas override)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -4,6 +4,10 @@
 
 - [issue-2650] The CoS branch reconciler and issue reconciler now work on self-hosted GitHub Enterprise (`github.*`) repos, not just `github.com`. Both previously gated on the github.com-only `isGithub` origin flag (which drives PortOS's own fork/update flow), so their scans silently skipped enterprise repos even though the sibling PR-watcher already handled them. All three services now share an `isGithubHost(host)` classifier and target `gh` via a host-qualified `HOST/OWNER/REPO` selector, so enterprise repos reconcile correctly and detection stays deterministic on a fork+upstream checkout. Existing github.com behavior is unchanged.
 
+## Goals
+
+- [issue-2679] The goal editor now has a "Daily Driver Feature Areas" multi-select, so you can pin exactly which PortOS areas (Daily POST, Body Health, Writers Room, Universes, Series Pipeline, Tribe, Autobiography, Legacy Bundle, Sharing, Plan Milestones, Memory) the Daily Driver deep-links to for a given goal. Each area shows its icon and label; when you leave the selection empty the editor shows the greyed category default it falls back to, and clearing an override restores that default.
+
 ## Changed
 
 - `[issue-2651]` The CoS `claim-issue-gitlab` work detector now short-circuits the group-owner filter trap the same way `claim-issue` handles a GitHub org owner. A GitLab group-owned project's namespace is the group, which never authors issues, so `owner` author-filter mode previously found nothing and parked with the vague `no-authored-issues` reason. GitLab's owner resolver now resolves the full project namespace (including nested subgroups like `parent/subgroup`) and probes `glab api groups/<url-encoded-namespace>` (200 = group, 404 = user namespace); for a group it skips the guaranteed-empty `--author <group>` query and parks with a distinct `owner-is-group` reason carrying the real open count. The on-demand toast reads *"the \"owner\" filter matches a group, which can't author issues — set it to \"self\" or \"any\""* — GitLab-appropriate wording ("group", not "org"). A probe failure degrades to the pre-existing behavior, so no new transient park appears.

--- a/client/src/components/goals/GoalDetailPanel.jsx
+++ b/client/src/components/goals/GoalDetailPanel.jsx
@@ -95,6 +95,7 @@ export default function GoalDetailPanel({ goal, allGoals, onClose, onRefresh }) 
           setTagInput={s.setTagInput}
           addTag={s.addTag}
           removeTag={s.removeTag}
+          toggleFeatureArea={s.toggleFeatureArea}
           parentOptions={parentOptions}
           saveEdit={s.saveEdit}
           onCancel={() => s.setEditing(false)}

--- a/client/src/components/goals/GoalDetailPanel.test.jsx
+++ b/client/src/components/goals/GoalDetailPanel.test.jsx
@@ -190,11 +190,12 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
     );
   });
 
-  it('preserves forward-unknown ids when editing an unrelated field (no data loss on federated installs)', async () => {
-    // A goal synced from a newer peer carries a feature-area id this install
-    // doesn't know. Editing an unrelated field must round-trip that id intact —
-    // dropping it would LWW-propagate a truncated array back and erase the newer
-    // peer's config. The (non-strict) server schema accepts the unknown id.
+  it('omits featureAreas when the selector was untouched (no stale-snapshot clobber of a concurrent peer edit)', async () => {
+    // The editor sends a startEdit snapshot of every field. Re-sending an
+    // untouched featureAreas would let that stale value win the whole-record LWW
+    // merge and erase a featureAreas change a federated peer made while the editor
+    // was open. Omitting the field lets the service preserve whatever is stored —
+    // including any forward-unknown id from a newer peer, which is never dropped.
     await renderPanel({ ...baseGoal, featureAreas: ['someFutureAreaFromANewerPeer'] });
     fireEvent.click(screen.getByText('Edit'));
     // Change only the title; never touch the feature-area buttons.
@@ -205,7 +206,7 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
       await Promise.resolve();
     });
     const [, payload] = api.updateGoal.mock.calls[0];
-    expect(payload.featureAreas).toEqual(['someFutureAreaFromANewerPeer']);
+    expect(payload).not.toHaveProperty('featureAreas');
     expect(payload.title).toBe('Master the craft, revised');
   });
 

--- a/client/src/components/goals/GoalDetailPanel.test.jsx
+++ b/client/src/components/goals/GoalDetailPanel.test.jsx
@@ -190,11 +190,11 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
     );
   });
 
-  it('omits featureAreas from the payload when the override was not touched (forward-compat)', async () => {
-    // Editing an unrelated field must NOT round-trip featureAreas — otherwise a
-    // goal synced from a newer federated peer carrying a forward-unknown area id
-    // would 400 against the strict updateGoalInputSchema enum. Omitting the key
-    // lets the service preserve the stored value (unknown ids included).
+  it('preserves forward-unknown ids when editing an unrelated field (no data loss on federated installs)', async () => {
+    // A goal synced from a newer peer carries a feature-area id this install
+    // doesn't know. Editing an unrelated field must round-trip that id intact —
+    // dropping it would LWW-propagate a truncated array back and erase the newer
+    // peer's config. The (non-strict) server schema accepts the unknown id.
     await renderPanel({ ...baseGoal, featureAreas: ['someFutureAreaFromANewerPeer'] });
     fireEvent.click(screen.getByText('Edit'));
     // Change only the title; never touch the feature-area buttons.
@@ -205,15 +205,14 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
       await Promise.resolve();
     });
     const [, payload] = api.updateGoal.mock.calls[0];
-    expect(payload).not.toHaveProperty('featureAreas');
+    expect(payload.featureAreas).toEqual(['someFutureAreaFromANewerPeer']);
     expect(payload.title).toBe('Master the craft, revised');
   });
 
-  it('strips locally-unknown ids when the override IS changed', async () => {
-    // A goal carries a forward-unknown id plus a known one; the user toggles a
-    // known area, so the override is "changed" and gets sent — but the unknown
-    // id (invisible in this install's UI) must be stripped so the update still
-    // validates.
+  it('preserves forward-unknown ids when the override IS changed', async () => {
+    // A goal carries a forward-unknown id plus a known one; the user toggles
+    // another known area. The unknown id (invisible in this install's UI) must
+    // ride along untouched so it is never erased across federation.
     await renderPanel({ ...baseGoal, featureAreas: ['someFutureAreaFromANewerPeer', 'universes'] });
     fireEvent.click(screen.getByText('Edit'));
     // Toggle a different known area on → override changed.
@@ -223,7 +222,16 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
       await Promise.resolve();
     });
     const [, payload] = api.updateGoal.mock.calls[0];
-    expect(payload.featureAreas).toEqual(['universes', 'tribe']);
-    expect(payload.featureAreas).not.toContain('someFutureAreaFromANewerPeer');
+    expect(payload.featureAreas).toEqual(['someFutureAreaFromANewerPeer', 'universes', 'tribe']);
+  });
+
+  it('shows the category-default hint for an override of only forward-unknown ids', async () => {
+    // Only forward-unknown ids selected → no visible button is active and the
+    // Daily Driver falls back to the category default at read time, so the hint
+    // must be shown (gating on known-selection, not raw array length).
+    await renderPanel({ ...baseGoal, featureAreas: ['someFutureAreaFromANewerPeer'] });
+    fireEvent.click(screen.getByText('Edit'));
+    expect(screen.getByText(/Default \(Mastery\):/)).toBeTruthy();
+    expect(screen.getByText(/Daily POST, Memory/)).toBeTruthy();
   });
 });

--- a/client/src/components/goals/GoalDetailPanel.test.jsx
+++ b/client/src/components/goals/GoalDetailPanel.test.jsx
@@ -7,7 +7,10 @@ import { act, render, screen, fireEvent } from '@testing-library/react';
 vi.mock('../../services/api', () => ({
   getActivities: vi.fn(() => Promise.resolve([])),
   getCalendarAccounts: vi.fn(() => Promise.resolve([])),
+  updateGoal: vi.fn(() => Promise.resolve({})),
 }));
+
+import * as api from '../../services/api';
 
 import GoalDetailPanel from './GoalDetailPanel';
 
@@ -135,5 +138,55 @@ describe('GoalDetailPanel provenance chip', () => {
     expect(screen.getByText('Inferred')).toBeTruthy(); // read mode: present
     fireEvent.click(screen.getByText('Edit'));
     expect(screen.queryByText('Inferred')).toBeNull();
+  });
+});
+
+describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () => {
+  it('shows the category default (greyed) when no per-goal override is set', async () => {
+    // mastery → ['post', 'memory'] → "Daily POST, Memory" per goalFeatureMap.
+    await renderPanel();
+    fireEvent.click(screen.getByText('Edit'));
+    expect(screen.getByText(/Default \(Mastery\):/)).toBeTruthy();
+    expect(screen.getByText(/Daily POST, Memory/)).toBeTruthy();
+  });
+
+  it('initializes the multi-select from goal.featureAreas and reflects selection', async () => {
+    await renderPanel({ ...baseGoal, featureAreas: ['writersRoom'] });
+    fireEvent.click(screen.getByText('Edit'));
+    const writersBtn = screen.getByRole('button', { name: /Writers Room/ });
+    expect(writersBtn.getAttribute('aria-pressed')).toBe('true');
+    // With an override present, the category-default hint is hidden.
+    expect(screen.queryByText(/Default \(/)).toBeNull();
+  });
+
+  it('round-trips the override through updateGoal when saved', async () => {
+    await renderPanel(); // no override → falls back to category default
+    fireEvent.click(screen.getByText('Edit'));
+    // Toggle two areas on, then save.
+    fireEvent.click(screen.getByRole('button', { name: /Universes/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Tribe/ }));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+      await Promise.resolve();
+    });
+    expect(api.updateGoal).toHaveBeenCalledWith(
+      'g-1',
+      expect.objectContaining({ featureAreas: ['universes', 'tribe'] })
+    );
+  });
+
+  it('sends an empty featureAreas array when the override is cleared (falls back to category default)', async () => {
+    await renderPanel({ ...baseGoal, featureAreas: ['universes'] });
+    fireEvent.click(screen.getByText('Edit'));
+    // Toggle the sole selected area off.
+    fireEvent.click(screen.getByRole('button', { name: /Universes/ }));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+      await Promise.resolve();
+    });
+    expect(api.updateGoal).toHaveBeenCalledWith(
+      'g-1',
+      expect.objectContaining({ featureAreas: [] })
+    );
   });
 });

--- a/client/src/components/goals/GoalDetailPanel.test.jsx
+++ b/client/src/components/goals/GoalDetailPanel.test.jsx
@@ -189,4 +189,41 @@ describe('GoalDetailPanel Daily Driver feature-area override (issue #2679)', () 
       expect.objectContaining({ featureAreas: [] })
     );
   });
+
+  it('omits featureAreas from the payload when the override was not touched (forward-compat)', async () => {
+    // Editing an unrelated field must NOT round-trip featureAreas — otherwise a
+    // goal synced from a newer federated peer carrying a forward-unknown area id
+    // would 400 against the strict updateGoalInputSchema enum. Omitting the key
+    // lets the service preserve the stored value (unknown ids included).
+    await renderPanel({ ...baseGoal, featureAreas: ['someFutureAreaFromANewerPeer'] });
+    fireEvent.click(screen.getByText('Edit'));
+    // Change only the title; never touch the feature-area buttons.
+    const titleInput = screen.getByDisplayValue('Master the craft');
+    fireEvent.change(titleInput, { target: { value: 'Master the craft, revised' } });
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+      await Promise.resolve();
+    });
+    const [, payload] = api.updateGoal.mock.calls[0];
+    expect(payload).not.toHaveProperty('featureAreas');
+    expect(payload.title).toBe('Master the craft, revised');
+  });
+
+  it('strips locally-unknown ids when the override IS changed', async () => {
+    // A goal carries a forward-unknown id plus a known one; the user toggles a
+    // known area, so the override is "changed" and gets sent — but the unknown
+    // id (invisible in this install's UI) must be stripped so the update still
+    // validates.
+    await renderPanel({ ...baseGoal, featureAreas: ['someFutureAreaFromANewerPeer', 'universes'] });
+    fireEvent.click(screen.getByText('Edit'));
+    // Toggle a different known area on → override changed.
+    fireEvent.click(screen.getByRole('button', { name: /Tribe/ }));
+    await act(async () => {
+      fireEvent.click(screen.getByText('Save'));
+      await Promise.resolve();
+    });
+    const [, payload] = api.updateGoal.mock.calls[0];
+    expect(payload.featureAreas).toEqual(['universes', 'tribe']);
+    expect(payload.featureAreas).not.toContain('someFutureAreaFromANewerPeer');
+  });
 });

--- a/client/src/components/goals/GoalEditForm.jsx
+++ b/client/src/components/goals/GoalEditForm.jsx
@@ -21,8 +21,15 @@ export default function GoalEditForm({
   toggleFeatureArea, parentOptions, saveEdit, onCancel
 }) {
   const selectedAreas = form.featureAreas || [];
-  // Category default shown (greyed) when no per-goal override is set, so the
-  // user sees which areas the Daily Driver will deep-link to by default.
+  // Gate the greyed category-default hint on whether any LOCALLY-KNOWN area is
+  // selected — not on raw array length. A version-skewed goal can carry only
+  // forward-unknown ids (from a newer peer); those render no visible button and
+  // getGoalFeatureAreas filters them, so the Daily Driver still falls back to the
+  // category default. Keying on length would hide the hint in that case and lie
+  // about the actual behavior (issue #2679).
+  const hasKnownSelection = selectedAreas.some(id => FEATURE_AREAS[id]);
+  // Category default shown (greyed) when no known override is set, so the user
+  // sees which areas the Daily Driver will deep-link to by default.
   const categoryDefaultLabels = (GOAL_CATEGORY_FEATURE_MAP[form.category] || [])
     .map(id => FEATURE_AREAS[id]?.label)
     .filter(Boolean);
@@ -205,7 +212,7 @@ export default function GoalEditForm({
             );
           })}
         </div>
-        {selectedAreas.length === 0 && (
+        {!hasKnownSelection && (
           <p className="text-[10px] text-gray-600 mt-1">
             Default ({CATEGORY_CONFIG[form.category]?.label || form.category}):{' '}
             {categoryDefaultLabels.length > 0 ? categoryDefaultLabels.join(', ') : 'none for this category'}

--- a/client/src/components/goals/GoalEditForm.jsx
+++ b/client/src/components/goals/GoalEditForm.jsx
@@ -1,12 +1,31 @@
-import { X } from 'lucide-react';
+import {
+  X, Target,
+  Brain, HeartPulse, PenLine, Globe, Clapperboard, Users,
+  BookOpen, Package, Share2, ListTree, BrainCircuit,
+} from 'lucide-react';
 import Pill from '../ui/Pill';
 import { FormField } from '../ui/FormField';
 import { CATEGORY_CONFIG, HORIZON_OPTIONS, GOAL_TYPE_OPTIONS, MAX_TAGS } from './goalConstants';
+import { FEATURE_AREAS, FEATURE_AREA_IDS, GOAL_CATEGORY_FEATURE_MAP } from '../../lib/goalFeatureMap';
+
+// Resolve a feature-area icon NAME (kept as a string in goalFeatureMap.js so
+// that module stays React-free and server-mirrorable) to a lucide component.
+// Mirrors the map in DailyDriverWidget — the two render the same area set.
+const AREA_ICONS = {
+  Brain, HeartPulse, PenLine, Globe, Clapperboard, Users,
+  BookOpen, Package, Share2, ListTree, BrainCircuit, Target,
+};
 
 export default function GoalEditForm({
   form, setForm, tagInput, setTagInput, addTag, removeTag,
-  parentOptions, saveEdit, onCancel
+  toggleFeatureArea, parentOptions, saveEdit, onCancel
 }) {
+  const selectedAreas = form.featureAreas || [];
+  // Category default shown (greyed) when no per-goal override is set, so the
+  // user sees which areas the Daily Driver will deep-link to by default.
+  const categoryDefaultLabels = (GOAL_CATEGORY_FEATURE_MAP[form.category] || [])
+    .map(id => FEATURE_AREAS[id]?.label)
+    .filter(Boolean);
   return (
     <div className="space-y-3">
       <input
@@ -161,6 +180,37 @@ export default function GoalEditForm({
             Add
           </button>
         </div>
+      </div>
+      <div>
+        <label id="feature-areas-label" className="text-xs text-gray-500">Daily Driver Feature Areas</label>
+        <p className="text-[10px] text-gray-600 mt-0.5">
+          Pin which PortOS areas the Daily Driver deep-links to for this goal. Leave empty to use the category default.
+        </p>
+        <div role="group" aria-labelledby="feature-areas-label" className="flex flex-wrap gap-1 mt-1">
+          {FEATURE_AREA_IDS.map(id => {
+            const area = FEATURE_AREAS[id];
+            const Icon = AREA_ICONS[area.icon] || Target;
+            const active = selectedAreas.includes(id);
+            return (
+              <button
+                key={id}
+                type="button"
+                aria-pressed={active}
+                onClick={() => toggleFeatureArea(id)}
+                className={`flex items-center gap-1 px-1.5 py-0.5 text-[10px] rounded ${active ? 'bg-port-accent text-white' : 'bg-port-bg border border-port-border text-gray-400'}`}
+              >
+                <Icon className="w-3 h-3" />
+                {area.label}
+              </button>
+            );
+          })}
+        </div>
+        {selectedAreas.length === 0 && (
+          <p className="text-[10px] text-gray-600 mt-1">
+            Default ({CATEGORY_CONFIG[form.category]?.label || form.category}):{' '}
+            {categoryDefaultLabels.length > 0 ? categoryDefaultLabels.join(', ') : 'none for this category'}
+          </p>
+        )}
       </div>
       <div className="flex gap-2">
         <button onClick={saveEdit} className="px-3 py-1.5 text-sm rounded bg-port-accent text-white hover:bg-port-accent/80">

--- a/client/src/hooks/useGoalDetail.js
+++ b/client/src/hooks/useGoalDetail.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import * as api from '../services/api';
 import { MAX_TAGS, MAX_TAG_LENGTH } from '../components/goals/goalConstants';
+import { FEATURE_AREA_IDS } from '../lib/goalFeatureMap';
 
 // State + handlers backing GoalDetailPanel. Extracted so the panel can stay a
 // thin composition shell; behavior is identical to the prior inline logic.
@@ -68,12 +69,29 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
   };
 
   const saveEdit = async () => {
-    await api.updateGoal(goal.id, {
-      ...form,
+    // Forward-compat across federated installs (issue #2679): a goal synced
+    // from a newer peer can carry a `featureAreas` id this install doesn't know
+    // yet, and `updateGoalInputSchema`'s strict enum would 400 if we sent it.
+    // So only include `featureAreas` in the payload when the user actually
+    // changed the override — when unchanged, omit it and let the service
+    // preserve the stored value (unknown ids included). On the changed path,
+    // strip to locally-known ids so the update always validates.
+    const { featureAreas, ...rest } = form;
+    const original = goal.featureAreas || [];
+    const current = featureAreas || [];
+    const featureAreasChanged =
+      current.length !== original.length ||
+      current.some((id, i) => id !== original[i]);
+    const payload = {
+      ...rest,
       parentId: form.parentId || null,
       targetDate: form.targetDate || null,
       timeBlockConfig: form.timeBlockConfig || null
-    });
+    };
+    if (featureAreasChanged) {
+      payload.featureAreas = current.filter(id => FEATURE_AREA_IDS.includes(id));
+    }
+    await api.updateGoal(goal.id, payload);
     setEditing(false);
     onRefresh();
   };

--- a/client/src/hooks/useGoalDetail.js
+++ b/client/src/hooks/useGoalDetail.js
@@ -68,17 +68,35 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
   };
 
   const saveEdit = async () => {
-    // `form.featureAreas` carries the full override, INCLUDING any forward-unknown
-    // ids preserved from `startEdit` (issue #2679). The multi-select only toggles
-    // ids this install knows; unknown ids ride along untouched. We send the whole
-    // array so those unknown ids are never dropped — the (now non-strict) server
-    // schema accepts them and `getGoalFeatureAreas` filters them at read time.
-    await api.updateGoal(goal.id, {
-      ...form,
+    // featureAreas handling (issue #2679):
+    //  - When the user did NOT touch the selector, OMIT featureAreas from the
+    //    PATCH. The whole editor sends a startEdit snapshot, so re-sending an
+    //    untouched featureAreas would let a stale value win the whole-record LWW
+    //    merge and clobber a concurrent featureAreas edit from a federated peer.
+    //    Omitting it lets the service preserve whatever is currently stored. (The
+    //    pre-#2679 editor never sent this field at all, so this restores that
+    //    immunity for the untouched case.)
+    //  - When the user DID change it, send the full array — INCLUDING any
+    //    forward-unknown ids preserved from startEdit (the known-id-only
+    //    multi-select leaves them untouched). The update schema accepts unknown
+    //    ids and getGoalFeatureAreas filters them at read time, so they are never
+    //    dropped.
+    const { featureAreas, ...rest } = form;
+    const original = goal.featureAreas || [];
+    const current = featureAreas || [];
+    const featureAreasChanged =
+      current.length !== original.length ||
+      current.some((id, i) => id !== original[i]);
+    const payload = {
+      ...rest,
       parentId: form.parentId || null,
       targetDate: form.targetDate || null,
       timeBlockConfig: form.timeBlockConfig || null
-    });
+    };
+    if (featureAreasChanged) {
+      payload.featureAreas = current;
+    }
+    await api.updateGoal(goal.id, payload);
     setEditing(false);
     onRefresh();
   };

--- a/client/src/hooks/useGoalDetail.js
+++ b/client/src/hooks/useGoalDetail.js
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import * as api from '../services/api';
 import { MAX_TAGS, MAX_TAG_LENGTH } from '../components/goals/goalConstants';
-import { FEATURE_AREA_IDS } from '../lib/goalFeatureMap';
 
 // State + handlers backing GoalDetailPanel. Extracted so the panel can stay a
 // thin composition shell; behavior is identical to the prior inline logic.
@@ -69,29 +68,17 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
   };
 
   const saveEdit = async () => {
-    // Forward-compat across federated installs (issue #2679): a goal synced
-    // from a newer peer can carry a `featureAreas` id this install doesn't know
-    // yet, and `updateGoalInputSchema`'s strict enum would 400 if we sent it.
-    // So only include `featureAreas` in the payload when the user actually
-    // changed the override — when unchanged, omit it and let the service
-    // preserve the stored value (unknown ids included). On the changed path,
-    // strip to locally-known ids so the update always validates.
-    const { featureAreas, ...rest } = form;
-    const original = goal.featureAreas || [];
-    const current = featureAreas || [];
-    const featureAreasChanged =
-      current.length !== original.length ||
-      current.some((id, i) => id !== original[i]);
-    const payload = {
-      ...rest,
+    // `form.featureAreas` carries the full override, INCLUDING any forward-unknown
+    // ids preserved from `startEdit` (issue #2679). The multi-select only toggles
+    // ids this install knows; unknown ids ride along untouched. We send the whole
+    // array so those unknown ids are never dropped — the (now non-strict) server
+    // schema accepts them and `getGoalFeatureAreas` filters them at read time.
+    await api.updateGoal(goal.id, {
+      ...form,
       parentId: form.parentId || null,
       targetDate: form.targetDate || null,
       timeBlockConfig: form.timeBlockConfig || null
-    };
-    if (featureAreasChanged) {
-      payload.featureAreas = current.filter(id => FEATURE_AREA_IDS.includes(id));
-    }
-    await api.updateGoal(goal.id, payload);
+    });
     setEditing(false);
     onRefresh();
   };

--- a/client/src/hooks/useGoalDetail.js
+++ b/client/src/hooks/useGoalDetail.js
@@ -58,7 +58,11 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
       parentId: goal.parentId || '',
       tags: [...(goal.tags || [])],
       targetDate: goal.targetDate || '',
-      timeBlockConfig: goal.timeBlockConfig || null
+      timeBlockConfig: goal.timeBlockConfig || null,
+      // Per-goal Daily Driver feature-area override (issue #2679). An empty
+      // array = "no override" — getGoalFeatureAreas falls back to the category
+      // default, so we don't need a separate null sentinel here.
+      featureAreas: [...(goal.featureAreas || [])]
     });
     setEditing(true);
   };
@@ -259,6 +263,18 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
     setForm({ ...form, tags: form.tags.filter(t => t !== tag) });
   };
 
+  // Toggle a Daily Driver feature-area id in the per-goal override (issue #2679).
+  // Mirrors addTag/removeTag: the form owns the list, the hook owns the mutation.
+  const toggleFeatureArea = (areaId) => {
+    setForm(prev => {
+      const current = prev.featureAreas || [];
+      const next = current.includes(areaId)
+        ? current.filter(a => a !== areaId)
+        : [...current, areaId];
+      return { ...prev, featureAreas: next };
+    });
+  };
+
   // Exclude self and descendants from parent options to prevent cycles
   const getDescendantIds = (id) => {
     const ids = new Set([id]);
@@ -307,6 +323,6 @@ export function useGoalDetail({ goal, allGoals, onClose, onRefresh }) {
     handleLinkActivity, handleAddProgress, resetProgressForm, handleDeleteProgress,
     handleUnlinkActivity, handleLinkCalendar, handleUnlinkCalendar,
     handleProgressChange, handleAddTodo, handleToggleTodo, handleDeleteTodo,
-    addTag, removeTag, getDescendantIds
+    addTag, removeTag, toggleFeatureArea, getDescendantIds
   };
 }

--- a/server/lib/identityValidation.js
+++ b/server/lib/identityValidation.js
@@ -1,10 +1,21 @@
 import { z } from 'zod';
-import { FEATURE_AREA_IDS } from './goalFeatureMap.js';
 
 // Per-goal feature-area override (issue #2666): an ordered list of feature-area
 // ids the Daily Driver deep-links to for this goal, overriding the category
 // default. Absent/empty → the goal falls back to its category's default map.
-const featureAreasSchema = z.array(z.enum(FEATURE_AREA_IDS)).max(FEATURE_AREA_IDS.length);
+//
+// Forward-compat (issue #2679): this is deliberately NOT `z.enum(FEATURE_AREA_IDS)`.
+// Goals sync between federated peers as whole records (no schema-version gate),
+// so an older install can receive — and store, via dataSync's direct file write
+// which bypasses this route validation — a goal carrying a feature-area id a
+// newer peer introduced. If the edit path rejected those ids, saving that goal
+// would 400; if the client stripped them, the truncated array would LWW-propagate
+// back and erase the newer peer's config. So we accept any non-empty string id
+// here and let `getGoalFeatureAreas` filter ids this install doesn't know at read
+// time — unknown ids are preserved in storage, ignored when resolving areas. The
+// cap stays generous (not tied to this install's FEATURE_AREA_IDS.length) so a
+// goal pinning more areas than this version knows still validates.
+const featureAreasSchema = z.array(z.string().min(1)).max(64);
 
 export const sectionStatusEnum = z.enum(['active', 'pending', 'unavailable']);
 

--- a/server/lib/identityValidation.js
+++ b/server/lib/identityValidation.js
@@ -1,21 +1,27 @@
 import { z } from 'zod';
+import { FEATURE_AREA_IDS } from './goalFeatureMap.js';
 
 // Per-goal feature-area override (issue #2666): an ordered list of feature-area
 // ids the Daily Driver deep-links to for this goal, overriding the category
 // default. Absent/empty → the goal falls back to its category's default map.
 //
-// Forward-compat (issue #2679): this is deliberately NOT `z.enum(FEATURE_AREA_IDS)`.
-// Goals sync between federated peers as whole records (no schema-version gate),
-// so an older install can receive — and store, via dataSync's direct file write
-// which bypasses this route validation — a goal carrying a feature-area id a
-// newer peer introduced. If the edit path rejected those ids, saving that goal
-// would 400; if the client stripped them, the truncated array would LWW-propagate
-// back and erase the newer peer's config. So we accept any non-empty string id
-// here and let `getGoalFeatureAreas` filter ids this install doesn't know at read
-// time — unknown ids are preserved in storage, ignored when resolving areas. The
-// cap stays generous (not tied to this install's FEATURE_AREA_IDS.length) so a
-// goal pinning more areas than this version knows still validates.
-const featureAreasSchema = z.array(z.string().min(1)).max(64);
+// Two schemas, because create and update have different forward-compat needs
+// (issue #2679):
+//   - CREATE stays strict (`z.enum(FEATURE_AREA_IDS)`): a brand-new goal is
+//     authored on THIS install, so an id outside this version's set is a typo or
+//     a bug worth rejecting — `getGoalFeatureAreas` would silently discard it.
+//   - UPDATE is lenient (any non-empty string): goals sync between federated
+//     peers as whole records (no schema-version gate), so an older install can
+//     receive — and store, via dataSync's direct file write which bypasses this
+//     route validation — a goal carrying a feature-area id a newer peer
+//     introduced. If the edit path rejected those ids, saving that goal would
+//     400; so we accept unknown ids on update and let `getGoalFeatureAreas`
+//     filter ids this install doesn't know at read time (preserved in storage,
+//     ignored when resolving areas). The cap stays generous (not tied to this
+//     install's FEATURE_AREA_IDS.length) so a goal pinning more areas than this
+//     version knows still validates.
+const createFeatureAreasSchema = z.array(z.enum(FEATURE_AREA_IDS)).max(FEATURE_AREA_IDS.length);
+const updateFeatureAreasSchema = z.array(z.string().min(1)).max(64);
 
 export const sectionStatusEnum = z.enum(['active', 'pending', 'unavailable']);
 
@@ -87,7 +93,7 @@ export const createGoalInputSchema = z.object({
   tags: z.array(z.string().min(1).max(50)).max(20).optional().default([]),
   targetDate: validCalendarDate.optional(),
   timeBlockConfig: timeBlockConfigSchema.optional(),
-  featureAreas: featureAreasSchema.optional()
+  featureAreas: createFeatureAreasSchema.optional()
 });
 
 export const updateGoalInputSchema = z.object({
@@ -101,7 +107,7 @@ export const updateGoalInputSchema = z.object({
   tags: z.array(z.string().min(1).max(50)).max(20).optional(),
   targetDate: validCalendarDate.nullable().optional(),
   timeBlockConfig: timeBlockConfigSchema.nullable().optional(),
-  featureAreas: featureAreasSchema.optional()
+  featureAreas: updateFeatureAreasSchema.optional()
 });
 
 export const addMilestoneInputSchema = z.object({

--- a/server/lib/identityValidation.test.js
+++ b/server/lib/identityValidation.test.js
@@ -167,6 +167,16 @@ describe('identityValidation', () => {
       });
       expect(r.success).toBe(false);
     });
+
+    it('accepts a known featureAreas override', () => {
+      expect(createGoalInputSchema.safeParse({ title: 'x', featureAreas: ['universes', 'tribe'] }).success).toBe(true);
+    });
+
+    it('rejects an unknown featureAreas id on create (strict — catches typos/bugs)', () => {
+      // Create happens on THIS install, so an id outside this version's set is a
+      // mistake worth rejecting (issue #2679 keeps create strict).
+      expect(createGoalInputSchema.safeParse({ title: 'x', featureAreas: ['someBogusArea'] }).success).toBe(false);
+    });
   });
 
   describe('updateGoalInputSchema', () => {
@@ -180,6 +190,18 @@ describe('identityValidation', () => {
 
     it('rejects bad status value', () => {
       expect(updateGoalInputSchema.safeParse({ status: 'paused' }).success).toBe(false);
+    });
+
+    it('accepts a forward-unknown featureAreas id on update (lenient — federated forward-compat)', () => {
+      // A goal synced from a newer peer can carry an id this install doesn't know
+      // yet; the edit path must not 400 on it (issue #2679). getGoalFeatureAreas
+      // filters unknown ids at read time, so storing them is harmless.
+      const r = updateGoalInputSchema.safeParse({ featureAreas: ['universes', 'someFutureAreaFromANewerPeer'] });
+      expect(r.success).toBe(true);
+    });
+
+    it('rejects a non-string featureAreas entry on update', () => {
+      expect(updateGoalInputSchema.safeParse({ featureAreas: [123] }).success).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Adds the missing UI for the per-goal `featureAreas` override introduced in #2666. A goal can now pin exactly which PortOS feature areas the Daily Driver deep-links to, instead of always using the category default.

- New "Daily Driver Feature Areas" multi-select in `GoalEditForm`, populated from `FEATURE_AREAS`/`FEATURE_AREA_IDS` (icon + label per area), styled as a toggle-button group mirroring the tag editor.
- Initialized in `useGoalDetail.startEdit()` from `goal.featureAreas`; persists through the existing `updateGoal` path.
- When no locally-known area is selected, the editor shows the greyed category default the Daily Driver falls back to (gated on known-selection, so an override of only forward-unknown ids still displays the real fallback).
- Accessible group: `role="group"` + `aria-labelledby`, each toggle a `<button aria-pressed>` with a visible text label.

## Federation forward-compat

Goals sync between peers as whole records, so an older install can hold a goal carrying a feature-area id a newer peer introduced. This PR keeps that safe:

- **Update schema is lenient** (`z.array(z.string())`) so editing such a goal never 400s; **create schema stays strict** (`z.enum(FEATURE_AREA_IDS)`) so a new goal authored here still rejects typos. `getGoalFeatureAreas` filters unknown ids at read time.
- `saveEdit` **omits `featureAreas` when the selector was untouched** (avoids a stale whole-record snapshot clobbering a concurrent peer edit via LWW) and **preserves forward-unknown ids** when it was changed (never truncates and LWW-erases a newer peer's config).

## Test plan

- `client` — `GoalDetailPanel.test.jsx`: round-trips the override; empty selection falls back to the category default; initializes from `goal.featureAreas`; omits `featureAreas` when untouched; preserves forward-unknown ids when changed; shows the category-default hint for an unknown-only override. (16 pass)
- `server` — `identityValidation.test.js`: create rejects unknown ids (strict), update accepts forward-unknown ids (lenient) and rejects non-string entries. (53 pass)
- `client` build + lint clean.
- Reviewed with claude, ollama, and codex (series); all findings resolved.

Closes #2679