### PR TITLE
Dedupe same-fingerprint investigation tasks across federated peers

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased Changes
 
+## Federation
+
+- [issue-2628] Same-cause auto-investigation tasks no longer pile up across federated machines. The per-machine "one open investigation per failure fingerprint" guard couldn't see a second machine that minted its own investigation for the same cause before the next sync, so both survived the peer merge. The CoS task merge now collapses same-fingerprint OPEN investigations to a single active row: it keeps the older copy (or, if one is already being worked, the in-progress copy so a running investigation is never cut off), folds every duplicate's list of blocked tasks onto the survivor, and marks the others done rather than deleting them (so the collapse converges the same way on every peer). Two machines that each opened an investigation for one failure now settle on one.
+
 ## Enterprise GitHub support
 
 - [issue-2650] The CoS branch reconciler and issue reconciler now work on self-hosted GitHub Enterprise (`github.*`) repos, not just `github.com`. Both previously gated on the github.com-only `isGithub` origin flag (which drives PortOS's own fork/update flow), so their scans silently skipped enterprise repos even though the sibling PR-watcher already handled them. All three services now share an `isGithubHost(host)` classifier and target `gh` via a host-qualified `HOST/OWNER/REPO` selector, so enterprise repos reconcile correctly and detection stays deterministic on a fork+upstream checkout. Existing github.com behavior is unchanged.

--- a/server/services/cosTaskMerge.js
+++ b/server/services/cosTaskMerge.js
@@ -278,11 +278,24 @@ function normalizeAdopted(task) {
   };
 }
 
-// (rule 4) The terminal status an OPEN investigation loser is flipped to when a
-// same-fingerprint winner is chosen. `completed` (not `blocked`) — the duplicate
-// is subsumed, not stuck; it needs no further work. Marked with `supersededBy` so
-// the collapse is auditable and the pass stays idempotent (a superseded copy is
-// terminal, so it never re-enters the open-duplicate set on the next sweep).
+// (rule 4) The statuses at which an investigation is still OPEN — a live dedup
+// candidate that suppresses new same-cause creates. MUST mirror
+// agentErrorAnalysis.OPEN_INVESTIGATION_STATUSES (can't import it — that module
+// depends on cosTaskStore, which imports THIS module, so the import would cycle;
+// kept in sync by this comment). Crucially this INCLUDES `blocked`: a blocked
+// investigation still tracks its failure cause, so two `blocked` (or blocked +
+// pending) same-fingerprint copies are exactly the pile-up this pass must collapse
+// — filtering on the merge module's terminal set (completed AND blocked) would let
+// them escape. Only `completed` (the status a superseded loser is flipped to) is
+// settled, which keeps the pass idempotent: a collapsed loser never re-enters the
+// open set on the next sweep.
+const OPEN_INVESTIGATION_STATUSES = new Set(['pending', 'in_progress', 'challenged', 'blocked']);
+const isOpenInvestigation = (task) => OPEN_INVESTIGATION_STATUSES.has(task.status);
+
+// The terminal status an OPEN investigation loser is flipped to when a
+// same-fingerprint winner is chosen. `completed` — the duplicate is subsumed, not
+// stuck; it needs no further work. Marked with `supersededBy` so the collapse is
+// auditable and the pass stays idempotent (see the open-status note above).
 const SUPERSEDED_STATUS = 'completed';
 const SUPERSEDED_BY_KEY = 'supersededBy';
 
@@ -297,8 +310,9 @@ const affectedTaskIds = (task) => {
 };
 
 /**
- * Choose the surviving row among the OPEN (non-terminal) copies of one
- * investigation fingerprint. An `in_progress` copy wins outright so an in-flight
+ * Choose the surviving row among the OPEN copies (pending/in_progress/challenged/
+ * blocked — see OPEN_INVESTIGATION_STATUSES) of one investigation fingerprint. An
+ * `in_progress` copy wins outright so an in-flight
  * investigation (an agent is running it) is never orphaned by the collapse; if
  * MORE than one is `in_progress` (two peers both spawned in the sub-second claim
  * window), return null to skip the collapse this sweep — both run to completion
@@ -337,7 +351,7 @@ function dedupeInvestigations(tasks) {
 
   const rewrites = new Map(); // original task ref -> replacement
   for (const group of groups.values()) {
-    const open = group.filter((t) => !isTerminalStatus(t.status));
+    const open = group.filter(isOpenInvestigation);
     if (open.length === 0) continue;
     // Act on a genuine open duplicate, OR to re-fold a prior collapse whose
     // survivor a mid-propagation per-id LWW may have reverted to a partial
@@ -359,9 +373,26 @@ function dedupeInvestigations(tasks) {
     const affectedChanged =
       unionAffected.length !== currentAffected.length ||
       unionAffected.some((id, i) => id !== currentAffected[i]);
-    if (affectedChanged && unionAffected.length > 0) {
+
+    // Also surface the peer-contributed ids in the survivor's DESCRIPTION, not
+    // just metadata: the investigation agent/user reads the body (the metadata
+    // union is what the isReapableInvestigation reaper consumes, but "What
+    // unblocks" only lists ids the body mentions). Mirrors agentErrorAnalysis's
+    // local same-fingerprint path, which appends an "Also blocks" line per new id.
+    // Append only ids not already textually present (idempotent), in the sorted
+    // union order (deterministic) — so both peers reach the identical body and no
+    // agentId/timestamp enters the text to break convergence.
+    const currentDesc = survivor.description || '';
+    const missingMentions = unionAffected.filter((id) => !currentDesc.includes(`\`${id}\``));
+    const appended = missingMentions
+      .map((id) => `\n- Also blocks task \`${id}\` (same cause; merged across federated peers).`)
+      .join('');
+    const newDesc = currentDesc + appended;
+
+    if ((affectedChanged || appended) && unionAffected.length > 0) {
       rewrites.set(survivor, {
         ...survivor,
+        description: newDesc,
         metadata: { ...(survivor.metadata || {}), [AFFECTED_TASKS_KEY]: unionAffected },
       });
     }

--- a/server/services/cosTaskMerge.js
+++ b/server/services/cosTaskMerge.js
@@ -47,13 +47,25 @@
  *     install never mints two open investigations for one failure cause — but two
  *     federated peers can each mint one before the next sweep, and rule 1's
  *     union-by-id keeps BOTH. A deterministic, side-independent post-pass folds
- *     them to a single active row: keep the older/lower-id copy (or the copy
- *     holding a live lease, so an in-flight investigation is never orphaned),
- *     union every duplicate's `metadata.affectedTasks` onto it, and flip the
- *     other open copies to `completed` (never delete — LWW sync never propagates
- *     deletions; a terminal status converges via rule 2's status rank). Runs
- *     identically on both peers over the converged per-id set, so they reach the
- *     same single survivor regardless of which side sweeps.
+ *     them to a single active row: keep the copy that is `in_progress` (an agent
+ *     is running it — never orphan an in-flight investigation) or, when none is,
+ *     the older/lower-id copy; union every duplicate's `metadata.affectedTasks`
+ *     onto it, and flip the other open copies to `completed` (never delete — LWW
+ *     sync never propagates deletions; a terminal status converges via rule 2's
+ *     status rank). Runs identically on both peers over the converged per-id set,
+ *     so they reach the same single survivor regardless of which side sweeps.
+ *
+ *     The no-orphan guarantee keys on the `in_progress` STATUS rather than lease
+ *     liveness on purpose: status propagates through rule 2's rank, so once both
+ *     peers have the converged view they agree an actively-worked copy is the
+ *     survivor even if its lease timestamp hasn't replicated yet — whereas keying
+ *     on `isLeaseLive` would let a peer whose copy still shows an (unexpired-
+ *     elsewhere) lease as expired flip a running investigation to `completed`. It
+ *     is still best-effort across ≥3 peers: a peer holding a pre-claim snapshot
+ *     (never yet saw the `in_progress` transition) can supersede a copy another
+ *     peer is running. That residual race is acceptable — investigation tasks are
+ *     approval-gated diagnostics that execute nothing on their own, and the storm
+ *     is already bounded to at most one per peer per cause.
  */
 
 import { isLeaseLive, getClaimOwner, CLAIM_METADATA_KEYS, parseTimestampMs } from './cosTaskClaim.js';
@@ -286,18 +298,25 @@ const affectedTaskIds = (task) => {
 
 /**
  * Choose the surviving row among the OPEN (non-terminal) copies of one
- * investigation fingerprint. A copy holding a live lease wins outright so an
- * in-flight investigation is never orphaned by the collapse; if MORE than one is
- * live-leased (two peers both spawned in the sub-second claim window), return null
- * to skip the collapse this sweep — both run to completion and the group self-heals
- * as each turns terminal, rather than killing a running agent. With no live lease,
- * the older/lower-id copy wins deterministically (investigation ids embed a base36
- * creation timestamp, so lower id == older), side-independent so both peers agree.
+ * investigation fingerprint. An `in_progress` copy wins outright so an in-flight
+ * investigation (an agent is running it) is never orphaned by the collapse; if
+ * MORE than one is `in_progress` (two peers both spawned in the sub-second claim
+ * window), return null to skip the collapse this sweep — both run to completion
+ * and the group self-heals as each turns terminal, rather than killing a running
+ * agent. With no `in_progress` copy, the older/lower-id copy wins deterministically
+ * (investigation ids embed a base36 creation timestamp, so lower id == older),
+ * side-independent so both peers agree.
+ *
+ * Keys on the `in_progress` STATUS, not lease liveness: the status replicates via
+ * rule 2's rank, so a peer whose lease timestamp is stale still recognizes an
+ * actively-worked copy and won't flip it to terminal. See the rule-4 note in the
+ * module header for the residual (pre-claim-snapshot) race this narrows but can't
+ * fully close across ≥3 peers.
  */
-function pickInvestigationSurvivor(openCopies, now) {
-  const leased = openCopies.filter((t) => isLeaseLive(t.metadata, now));
-  if (leased.length > 1) return null;
-  if (leased.length === 1) return leased[0];
+function pickInvestigationSurvivor(openCopies) {
+  const active = openCopies.filter((t) => t.status === 'in_progress');
+  if (active.length > 1) return null;
+  if (active.length === 1) return active[0];
   return openCopies.reduce((a, b) => (a.id <= b.id ? a : b));
 }
 
@@ -307,7 +326,7 @@ function pickInvestigationSurvivor(openCopies, now) {
  * only for the rows it rewrites), never mutates inputs. Deterministic over the
  * converged per-id merge output, so both peers reach the same single survivor.
  */
-function dedupeInvestigations(tasks, now) {
+function dedupeInvestigations(tasks) {
   const groups = new Map();
   for (const t of tasks) {
     const fp = t?.metadata?.[FINGERPRINT_KEY];
@@ -326,8 +345,8 @@ function dedupeInvestigations(tasks, now) {
     const collapsedBefore = group.some((t) => t?.metadata?.[SUPERSEDED_BY_KEY]);
     if (open.length < 2 && !collapsedBefore) continue;
 
-    const survivor = pickInvestigationSurvivor(open, now);
-    if (!survivor) continue; // multiple live leases — don't orphan; wait a sweep
+    const survivor = pickInvestigationSurvivor(open);
+    if (!survivor) continue; // multiple in-flight copies — don't orphan; wait a sweep
 
     // Union affectedTasks across EVERY copy (open + already-superseded) so the one
     // surviving row names every task blocked on this cause. Sorted so both peers
@@ -393,5 +412,5 @@ export function mergeTaskLists(localTasks, remoteTasks, { now = Date.now() } = {
   }
   // (rule 4) Collapse same-fingerprint OPEN investigation duplicates that the
   // per-id union above let survive across two peers (#2628).
-  return dedupeInvestigations(merged, now);
+  return dedupeInvestigations(merged);
 }

--- a/server/services/cosTaskMerge.js
+++ b/server/services/cosTaskMerge.js
@@ -40,6 +40,20 @@
  *     guard. A claim is never kept on a terminal (completed/blocked) task —
  *     that mirrors cosTaskStore's release-on-transition so a finished task is
  *     freely re-claimable.
+ *
+ *  4. After the per-id merge, collapse same-`investigationFingerprint` OPEN
+ *     investigation duplicates (#2628). The per-process fingerprint dedup in
+ *     agentErrorAnalysis (#2615) is serialized on a module-level tail, so a single
+ *     install never mints two open investigations for one failure cause — but two
+ *     federated peers can each mint one before the next sweep, and rule 1's
+ *     union-by-id keeps BOTH. A deterministic, side-independent post-pass folds
+ *     them to a single active row: keep the older/lower-id copy (or the copy
+ *     holding a live lease, so an in-flight investigation is never orphaned),
+ *     union every duplicate's `metadata.affectedTasks` onto it, and flip the
+ *     other open copies to `completed` (never delete — LWW sync never propagates
+ *     deletions; a terminal status converges via rule 2's status rank). Runs
+ *     identically on both peers over the converged per-id set, so they reach the
+ *     same single survivor regardless of which side sweeps.
  */
 
 import { isLeaseLive, getClaimOwner, CLAIM_METADATA_KEYS, parseTimestampMs } from './cosTaskClaim.js';
@@ -252,6 +266,100 @@ function normalizeAdopted(task) {
   };
 }
 
+// (rule 4) The terminal status an OPEN investigation loser is flipped to when a
+// same-fingerprint winner is chosen. `completed` (not `blocked`) — the duplicate
+// is subsumed, not stuck; it needs no further work. Marked with `supersededBy` so
+// the collapse is auditable and the pass stays idempotent (a superseded copy is
+// terminal, so it never re-enters the open-duplicate set on the next sweep).
+const SUPERSEDED_STATUS = 'completed';
+const SUPERSEDED_BY_KEY = 'supersededBy';
+
+// The metadata marker every investigation task carries (#2615). Grouping keys off
+// this so only real investigation duplicates are ever collapsed.
+const FINGERPRINT_KEY = 'investigationFingerprint';
+const AFFECTED_TASKS_KEY = 'affectedTasks';
+
+const affectedTaskIds = (task) => {
+  const arr = task?.metadata?.[AFFECTED_TASKS_KEY];
+  return Array.isArray(arr) ? arr.filter((id) => typeof id === 'string' && id) : [];
+};
+
+/**
+ * Choose the surviving row among the OPEN (non-terminal) copies of one
+ * investigation fingerprint. A copy holding a live lease wins outright so an
+ * in-flight investigation is never orphaned by the collapse; if MORE than one is
+ * live-leased (two peers both spawned in the sub-second claim window), return null
+ * to skip the collapse this sweep — both run to completion and the group self-heals
+ * as each turns terminal, rather than killing a running agent. With no live lease,
+ * the older/lower-id copy wins deterministically (investigation ids embed a base36
+ * creation timestamp, so lower id == older), side-independent so both peers agree.
+ */
+function pickInvestigationSurvivor(openCopies, now) {
+  const leased = openCopies.filter((t) => isLeaseLive(t.metadata, now));
+  if (leased.length > 1) return null;
+  if (leased.length === 1) return leased[0];
+  return openCopies.reduce((a, b) => (a.id <= b.id ? a : b));
+}
+
+/**
+ * (rule 4) Collapse same-fingerprint OPEN investigation duplicates that rule 1's
+ * union-by-id let survive across two peers. Pure: returns a new array (new objects
+ * only for the rows it rewrites), never mutates inputs. Deterministic over the
+ * converged per-id merge output, so both peers reach the same single survivor.
+ */
+function dedupeInvestigations(tasks, now) {
+  const groups = new Map();
+  for (const t of tasks) {
+    const fp = t?.metadata?.[FINGERPRINT_KEY];
+    if (typeof fp !== 'string' || !fp) continue;
+    if (!groups.has(fp)) groups.set(fp, []);
+    groups.get(fp).push(t);
+  }
+
+  const rewrites = new Map(); // original task ref -> replacement
+  for (const group of groups.values()) {
+    const open = group.filter((t) => !isTerminalStatus(t.status));
+    if (open.length === 0) continue;
+    // Act on a genuine open duplicate, OR to re-fold a prior collapse whose
+    // survivor a mid-propagation per-id LWW may have reverted to a partial
+    // affectedTasks set (a terminal `supersededBy` sibling marks that history).
+    const collapsedBefore = group.some((t) => t?.metadata?.[SUPERSEDED_BY_KEY]);
+    if (open.length < 2 && !collapsedBefore) continue;
+
+    const survivor = pickInvestigationSurvivor(open, now);
+    if (!survivor) continue; // multiple live leases — don't orphan; wait a sweep
+
+    // Union affectedTasks across EVERY copy (open + already-superseded) so the one
+    // surviving row names every task blocked on this cause. Sorted so both peers
+    // serialize an identical set (their group order differs by local-first).
+    const affected = new Set();
+    for (const t of group) for (const id of affectedTaskIds(t)) affected.add(id);
+    const unionAffected = [...affected].sort();
+
+    const currentAffected = affectedTaskIds(survivor);
+    const affectedChanged =
+      unionAffected.length !== currentAffected.length ||
+      unionAffected.some((id, i) => id !== currentAffected[i]);
+    if (affectedChanged && unionAffected.length > 0) {
+      rewrites.set(survivor, {
+        ...survivor,
+        metadata: { ...(survivor.metadata || {}), [AFFECTED_TASKS_KEY]: unionAffected },
+      });
+    }
+
+    for (const loser of open) {
+      if (loser === survivor) continue;
+      const metadata = { ...(loser.metadata || {}) };
+      for (const key of CLAIM_METADATA_KEYS) delete metadata[key]; // terminal → no claim
+      metadata[SUPERSEDED_BY_KEY] = survivor.id;
+      rewrites.set(loser, { ...loser, status: SUPERSEDED_STATUS, metadata });
+    }
+  }
+
+  if (rewrites.size === 0) return tasks;
+  return tasks.map((t) => rewrites.get(t) || t);
+}
+
 /**
  * Merge a peer's task list into the local one. Pure: returns a new array, never
  * mutates the inputs. `now` is injectable for deterministic tests.
@@ -283,5 +391,7 @@ export function mergeTaskLists(localTasks, remoteTasks, { now = Date.now() } = {
     seen.add(r.id);
     merged.push(normalizeAdopted(r));
   }
-  return merged;
+  // (rule 4) Collapse same-fingerprint OPEN investigation duplicates that the
+  // per-id union above let survive across two peers (#2628).
+  return dedupeInvestigations(merged, now);
 }

--- a/server/services/cosTaskMerge.test.js
+++ b/server/services/cosTaskMerge.test.js
@@ -346,32 +346,63 @@ describe('mergeTaskLists', () => {
       expect(survivor.metadata.affectedTasks).toEqual(['task-1', 'task-2', 'task-3']);
     });
 
-    it('never orphans an in-flight investigation: a live-leased loser survives over a lower idle id', () => {
-      // The lower id (sys-a) is idle; the higher id (sys-b) holds a live lease —
-      // an agent is actively investigating it. The live copy must survive so its
-      // execution is not orphaned, even though its id sorts later.
+    it('never orphans an in-flight investigation: an in_progress loser survives over a lower idle id', () => {
+      // The lower id (sys-a) is idle; the higher id (sys-b) is in_progress —
+      // an agent is actively investigating it. The in-flight copy must survive so
+      // its execution is not orphaned, even though its id sorts later. Symmetric:
+      // both peers converge on the same survivor regardless of who sweeps.
       const local = [inv('sys-a', 'pending', 'fp-1', { affectedTasks: ['task-1'] })];
       const remote = [
         inv('sys-b', 'in_progress', 'fp-1', { affectedTasks: ['task-2'], metadata: liveClaim('instance-B') }),
       ];
-      const merged = mergeTaskLists(local, remote, { now: NOW });
-      const byId = Object.fromEntries(merged.map((t) => [t.id, t]));
-      expect(byId['sys-b'].status).toBe('in_progress');
-      expect(byId['sys-b'].metadata.claimedBy).toBe('instance-B');
-      expect(byId['sys-b'].metadata.affectedTasks).toEqual(['task-1', 'task-2']);
-      expect(byId['sys-a'].status).toBe('completed');
-      expect(byId['sys-a'].metadata.supersededBy).toBe('sys-b');
+      for (const merged of [
+        mergeTaskLists(local, remote, { now: NOW }),
+        mergeTaskLists(remote, local, { now: NOW }),
+      ]) {
+        const byId = Object.fromEntries(merged.map((t) => [t.id, t]));
+        expect(byId['sys-b'].status).toBe('in_progress');
+        expect(byId['sys-b'].metadata.claimedBy).toBe('instance-B');
+        expect(byId['sys-b'].metadata.affectedTasks).toEqual(['task-1', 'task-2']);
+        expect(byId['sys-a'].status).toBe('completed');
+        expect(byId['sys-a'].metadata.supersededBy).toBe('sys-b');
+      }
     });
 
-    it('does NOT collapse when both copies hold a live lease (two in-flight agents)', () => {
+    it('keeps an in_progress survivor even when its lease timestamp looks expired (stale-lease-proof)', () => {
+      // The no-orphan guard keys on the in_progress STATUS, not lease liveness: a
+      // peer whose view of sys-b's lease has gone stale (agent still running, but
+      // the renewal hasn't replicated) must NOT flip the running copy to completed
+      // just because the lower-id sys-a sorts first. Status survives that staleness.
+      const expiredLease = { claimedBy: 'instance-B', claimedAt: past(LEASE_DURATION_MS * 2), leaseExpiresAt: past(1000) };
+      const local = [inv('sys-a', 'pending', 'fp-1', { affectedTasks: ['task-1'] })];
+      const remote = [inv('sys-b', 'in_progress', 'fp-1', { affectedTasks: ['task-2'], metadata: expiredLease })];
+      for (const merged of [
+        mergeTaskLists(local, remote, { now: NOW }),
+        mergeTaskLists(remote, local, { now: NOW }),
+      ]) {
+        const byId = Object.fromEntries(merged.map((t) => [t.id, t]));
+        expect(byId['sys-b'].status).toBe('in_progress'); // running copy survives
+        expect(byId['sys-a'].status).toBe('completed');
+        expect(byId['sys-a'].metadata.supersededBy).toBe('sys-b');
+      }
+    });
+
+    it('does NOT collapse when both copies are in_progress (two in-flight agents)', () => {
       // Sub-second claim race: both peers spawned. Killing either orphans a running
       // agent, so the collapse is skipped this sweep — the group self-heals as each
       // investigation completes (turns terminal) and drops out of the open set.
+      // Symmetric, and both live claims survive untouched.
       const local = [inv('sys-a', 'in_progress', 'fp-1', { metadata: liveClaim('instance-A') })];
       const remote = [inv('sys-b', 'in_progress', 'fp-1', { metadata: liveClaim('instance-B') })];
-      const merged = mergeTaskLists(local, remote, { now: NOW });
-      const open = merged.filter((t) => t.status === 'in_progress');
-      expect(open.map((t) => t.id).sort()).toEqual(['sys-a', 'sys-b']);
+      for (const merged of [
+        mergeTaskLists(local, remote, { now: NOW }),
+        mergeTaskLists(remote, local, { now: NOW }),
+      ]) {
+        const open = merged.filter((t) => t.status === 'in_progress');
+        expect(open.map((t) => t.id).sort()).toEqual(['sys-a', 'sys-b']);
+        expect(open.every((t) => t.metadata.claimedBy)).toBe(true); // claims untouched
+        expect(open.every((t) => t.metadata.supersededBy === undefined)).toBe(true);
+      }
     });
 
     it('does not collapse a single open investigation (no duplicate)', () => {

--- a/server/services/cosTaskMerge.test.js
+++ b/server/services/cosTaskMerge.test.js
@@ -296,4 +296,126 @@ describe('mergeTaskLists', () => {
       expect(merged.metadata.claimedBy).toBe('peer-A');
     });
   });
+
+  describe('cross-peer investigation fingerprint dedup (#2628)', () => {
+    // An investigation task carries a durable fingerprint marker (#2615). Two
+    // federated peers can each mint one for the SAME failure cause before syncing;
+    // rule 1 unions them by id so both survive. `inv` builds one.
+    const inv = (id, status, fp, overrides = {}) =>
+      task(id, status, {
+        metadata: {
+          isInvestigation: true,
+          investigationFingerprint: fp,
+          ...(overrides.affectedTasks ? { affectedTasks: overrides.affectedTasks } : {}),
+          ...(overrides.metadata || {}),
+        },
+        ...(overrides.priority ? { priority: overrides.priority } : {}),
+      });
+
+    it('collapses two same-fingerprint OPEN investigations from two peers to one active row', () => {
+      const local = [inv('sys-a', 'pending', 'fp-1', { affectedTasks: ['task-1'] })];
+      const remote = [inv('sys-b', 'pending', 'fp-1', { affectedTasks: ['task-2'] })];
+
+      // Symmetric: same survivor regardless of which side initiates the sweep.
+      for (const merged of [
+        mergeTaskLists(local, remote, { now: NOW }),
+        mergeTaskLists(remote, local, { now: NOW }),
+      ]) {
+        const byId = Object.fromEntries(merged.map((t) => [t.id, t]));
+        // Older/lower id survives as the single OPEN row.
+        expect(byId['sys-a'].status).toBe('pending');
+        // Loser flipped to a terminal status — NOT deleted (LWW never propagates a
+        // delete), and marked so the collapse is auditable + idempotent.
+        expect(byId['sys-b'].status).toBe('completed');
+        expect(byId['sys-b'].metadata.supersededBy).toBe('sys-a');
+        // affectedTasks unioned (deduped, sorted) onto the survivor.
+        expect(byId['sys-a'].metadata.affectedTasks).toEqual(['task-1', 'task-2']);
+        // Exactly one non-terminal investigation remains for this fingerprint.
+        const open = merged.filter(
+          (t) => t.metadata?.investigationFingerprint === 'fp-1' && t.status !== 'completed'
+        );
+        expect(open).toHaveLength(1);
+      }
+    });
+
+    it('unions affectedTasks by id (no duplicates)', () => {
+      const local = [inv('sys-a', 'pending', 'fp-1', { affectedTasks: ['task-1', 'task-2'] })];
+      const remote = [inv('sys-b', 'pending', 'fp-1', { affectedTasks: ['task-2', 'task-3'] })];
+      const merged = mergeTaskLists(local, remote, { now: NOW });
+      const survivor = merged.find((t) => t.id === 'sys-a');
+      expect(survivor.metadata.affectedTasks).toEqual(['task-1', 'task-2', 'task-3']);
+    });
+
+    it('never orphans an in-flight investigation: a live-leased loser survives over a lower idle id', () => {
+      // The lower id (sys-a) is idle; the higher id (sys-b) holds a live lease —
+      // an agent is actively investigating it. The live copy must survive so its
+      // execution is not orphaned, even though its id sorts later.
+      const local = [inv('sys-a', 'pending', 'fp-1', { affectedTasks: ['task-1'] })];
+      const remote = [
+        inv('sys-b', 'in_progress', 'fp-1', { affectedTasks: ['task-2'], metadata: liveClaim('instance-B') }),
+      ];
+      const merged = mergeTaskLists(local, remote, { now: NOW });
+      const byId = Object.fromEntries(merged.map((t) => [t.id, t]));
+      expect(byId['sys-b'].status).toBe('in_progress');
+      expect(byId['sys-b'].metadata.claimedBy).toBe('instance-B');
+      expect(byId['sys-b'].metadata.affectedTasks).toEqual(['task-1', 'task-2']);
+      expect(byId['sys-a'].status).toBe('completed');
+      expect(byId['sys-a'].metadata.supersededBy).toBe('sys-b');
+    });
+
+    it('does NOT collapse when both copies hold a live lease (two in-flight agents)', () => {
+      // Sub-second claim race: both peers spawned. Killing either orphans a running
+      // agent, so the collapse is skipped this sweep — the group self-heals as each
+      // investigation completes (turns terminal) and drops out of the open set.
+      const local = [inv('sys-a', 'in_progress', 'fp-1', { metadata: liveClaim('instance-A') })];
+      const remote = [inv('sys-b', 'in_progress', 'fp-1', { metadata: liveClaim('instance-B') })];
+      const merged = mergeTaskLists(local, remote, { now: NOW });
+      const open = merged.filter((t) => t.status === 'in_progress');
+      expect(open.map((t) => t.id).sort()).toEqual(['sys-a', 'sys-b']);
+    });
+
+    it('does not collapse a single open investigation (no duplicate)', () => {
+      const local = [inv('sys-a', 'pending', 'fp-1', { affectedTasks: ['task-1'] })];
+      const merged = mergeTaskLists(local, [], { now: NOW });
+      expect(merged).toHaveLength(1);
+      expect(merged[0].status).toBe('pending');
+      expect(merged[0].metadata.supersededBy).toBeUndefined();
+    });
+
+    it('does not collapse investigations with DIFFERENT fingerprints', () => {
+      const local = [inv('sys-a', 'pending', 'fp-1')];
+      const remote = [inv('sys-b', 'pending', 'fp-2')];
+      const merged = mergeTaskLists(local, remote, { now: NOW });
+      expect(merged.every((t) => t.status === 'pending')).toBe(true);
+    });
+
+    it('ignores non-investigation tasks (no fingerprint) entirely', () => {
+      const local = [task('task-a', 'pending'), task('task-b', 'pending')];
+      const merged = mergeTaskLists(local, [], { now: NOW });
+      expect(merged.every((t) => t.status === 'pending')).toBe(true);
+      expect(merged.every((t) => t.metadata.supersededBy === undefined)).toBe(true);
+    });
+
+    it('is idempotent — re-merging the collapsed result changes nothing', () => {
+      const local = [inv('sys-a', 'pending', 'fp-1', { affectedTasks: ['task-1'] })];
+      const remote = [inv('sys-b', 'pending', 'fp-1', { affectedTasks: ['task-2'] })];
+      const once = mergeTaskLists(local, remote, { now: NOW });
+      const twice = mergeTaskLists(once, [], { now: NOW });
+      expect(twice).toEqual(once);
+    });
+
+    it('re-folds affectedTasks onto the survivor after a partial per-id revert', () => {
+      // Mid-propagation, a peer can hold the survivor with a stale (partial)
+      // affectedTasks while a terminal `supersededBy` sibling records the collapse.
+      // The pass must re-fold the full union rather than leave the survivor partial.
+      const partialSurvivor = inv('sys-a', 'pending', 'fp-1', { affectedTasks: ['task-1'] });
+      const supersededSibling = inv('sys-b', 'completed', 'fp-1', {
+        affectedTasks: ['task-2'],
+        metadata: { supersededBy: 'sys-a' },
+      });
+      const merged = mergeTaskLists([partialSurvivor, supersededSibling], [], { now: NOW });
+      const survivor = merged.find((t) => t.id === 'sys-a');
+      expect(survivor.metadata.affectedTasks).toEqual(['task-1', 'task-2']);
+    });
+  });
 });

--- a/server/services/cosTaskMerge.test.js
+++ b/server/services/cosTaskMerge.test.js
@@ -310,6 +310,7 @@ describe('mergeTaskLists', () => {
           ...(overrides.metadata || {}),
         },
         ...(overrides.priority ? { priority: overrides.priority } : {}),
+        ...(overrides.description ? { description: overrides.description } : {}),
       });
 
     it('collapses two same-fingerprint OPEN investigations from two peers to one active row', () => {
@@ -403,6 +404,63 @@ describe('mergeTaskLists', () => {
         expect(open.every((t) => t.metadata.claimedBy)).toBe(true); // claims untouched
         expect(open.every((t) => t.metadata.supersededBy === undefined)).toBe(true);
       }
+    });
+
+    it('collapses two blocked same-fingerprint copies (blocked is an OPEN investigation status)', () => {
+      // agentErrorAnalysis treats `blocked` as an open investigation, so two blocked
+      // copies for one cause are the same pile-up — they must collapse, not escape.
+      const local = [inv('sys-a', 'blocked', 'fp-1', { affectedTasks: ['task-1'] })];
+      const remote = [inv('sys-b', 'blocked', 'fp-1', { affectedTasks: ['task-2'] })];
+      for (const merged of [
+        mergeTaskLists(local, remote, { now: NOW }),
+        mergeTaskLists(remote, local, { now: NOW }),
+      ]) {
+        const byId = Object.fromEntries(merged.map((t) => [t.id, t]));
+        expect(byId['sys-a'].status).toBe('blocked'); // lower id survives, still blocked
+        expect(byId['sys-b'].status).toBe('completed'); // loser superseded
+        expect(byId['sys-b'].metadata.supersededBy).toBe('sys-a');
+        expect(byId['sys-a'].metadata.affectedTasks).toEqual(['task-1', 'task-2']);
+      }
+    });
+
+    it('collapses a blocked + pending same-fingerprint pair', () => {
+      const local = [inv('sys-a', 'blocked', 'fp-1')];
+      const remote = [inv('sys-b', 'pending', 'fp-1')];
+      const merged = mergeTaskLists(local, remote, { now: NOW });
+      const open = merged.filter((t) => t.metadata?.investigationFingerprint === 'fp-1' && t.status !== 'completed');
+      expect(open).toHaveLength(1);
+    });
+
+    it('surfaces peer-contributed affected tasks in the survivor DESCRIPTION (not just metadata)', () => {
+      // The investigation agent/user reads the body; the local path appends an
+      // "Also blocks" line per new id. The federation collapse mirrors that so the
+      // survivor names every blocked task, deterministically and idempotently.
+      const local = [inv('sys-a', 'pending', 'fp-1', { affectedTasks: ['task-1'] })]; // default body `desc sys-a`
+      const remote = [inv('sys-b', 'pending', 'fp-1', { affectedTasks: ['task-2'] })];
+      const once = mergeTaskLists(local, remote, { now: NOW });
+      const survivor = once.find((t) => t.id === 'sys-a');
+      expect(survivor.description).toContain('Also blocks task `task-2`');
+      // task-1 is the survivor's own id — not re-appended as a peer contribution
+      // unless it was already absent from the body; the default body doesn't mention
+      // it, so it IS appended once. Re-merging must NOT append it (or task-2) again.
+      const twice = mergeTaskLists(once, [], { now: NOW });
+      const survivor2 = twice.find((t) => t.id === 'sys-a');
+      expect(survivor2.description).toBe(survivor.description); // idempotent
+      const occurrences = (survivor2.description.match(/Also blocks task `task-2`/g) || []).length;
+      expect(occurrences).toBe(1);
+    });
+
+    it('does not append a description line already present in the body', () => {
+      // The survivor's body already mentions task-2 — the collapse must not duplicate it.
+      const local = [inv('sys-a', 'pending', 'fp-1', {
+        affectedTasks: ['task-1'],
+        description: 'Investigate failure. Original task `task-2` is affected.',
+      })];
+      const remote = [inv('sys-b', 'pending', 'fp-1', { affectedTasks: ['task-2'] })];
+      const merged = mergeTaskLists(local, remote, { now: NOW });
+      const survivor = merged.find((t) => t.id === 'sys-a');
+      const occurrences = (survivor.description.match(/`task-2`/g) || []).length;
+      expect(occurrences).toBe(1); // already present — not re-appended
     });
 
     it('does not collapse a single open investigation (no duplicate)', () => {


### PR DESCRIPTION
## Summary

Two federated peers can each create an investigation task for the same `metadata.investigationFingerprint` before the next sync sweep. The per-process fingerprint dedup added in #2615 is serialized on a module-level promise tail, so a single install never mints two open investigations for one failure cause — but `cosTaskMerge.js` unions cross-peer records by id, so both peers' rows survive synchronization.

This adds a deterministic, side-independent dedup pass at the peer-merge boundary in `server/services/cosTaskMerge.js` (a new rule 4, run after the existing per-id union). For each `investigationFingerprint` group with more than one OPEN copy it:

- **Picks one survivor deterministically** so both peers converge on the same active row: an `in_progress` copy wins outright (an agent is running it — never orphan an in-flight investigation); otherwise the lower-id / older copy wins. When more than one copy is `in_progress`, the collapse is skipped for that sweep (both run to completion and the group self-heals as each turns terminal).
- **Unions `metadata.affectedTasks`** (deduped, sorted) onto the survivor, and mirrors the peer-contributed ids into the survivor's description (idempotent, deterministic) so the investigation agent/user — and the `isReapableInvestigation` reaper — see every task blocked on the cause, matching the local same-fingerprint path in `agentErrorAnalysis`.
- **Flips the other open copies to `completed`** with a `supersededBy` marker rather than deleting them (LWW sync never propagates deletions; a terminal status converges via the existing rule-2 status rank). The `supersededBy` marker keeps the pass idempotent and lets a mid-propagation partial survivor re-fold the full union.

The no-orphan guard keys on the `in_progress` **status** (which replicates via rule-2 rank) rather than lease liveness, so a peer whose lease timestamp is stale still recognizes an actively-worked copy. "Open" matches `agentErrorAnalysis.OPEN_INVESTIGATION_STATUSES` (pending/in_progress/challenged/**blocked**), so two `blocked` same-cause copies are collapsed too. The residual pre-claim-snapshot race across ≥3 peers is documented and accepted (investigation tasks are approval-gated diagnostics that execute nothing on their own; the storm is already bounded to one per peer per cause).

## Test plan

- `cd server && npm test -- cosTaskMerge` — 43 tests pass, including new coverage proving two same-fingerprint tasks from two peers converge to one active row (both sweep directions), the in_progress-survivor no-orphan case (including a stale/expired-lease copy), both-in-progress skip, `affectedTasks` union dedupe, blocked+blocked and blocked+pending collapse, description mirroring + idempotency, and re-fold after a partial per-id revert.
- `cd server && npm test -- cosTask agentErrorAnalysis peerSync` — 606 related federation/task tests pass (no regression).

Reviewed locally with claude, ollama, and codex (series). claude flagged that keying the no-orphan guard on lease liveness was stale-prone across 3+ peers (fixed → status-based); codex flagged that `blocked` investigations escaped the terminal filter and that merged affected tasks weren't surfaced in the survivor's description (both fixed).

Closes #2628
