### PR TITLE
feat([issue-2796]): extend Tribe unanswered-thread detection to Gmail via per-account sent ingestion

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -20,6 +20,10 @@
 
 - [issue-2679] The goal editor now has a "Daily Driver Feature Areas" multi-select, so you can pin exactly which PortOS areas (Daily POST, Body Health, Writers Room, Universes, Series Pipeline, Tribe, Autobiography, Legacy Bundle, Sharing, Plan Milestones, Memory) the Daily Driver deep-links to for a given goal. Each area shows its icon and label; when you leave the selection empty the editor shows the greyed category default it falls back to, and clearing an override restores that default.
 
+## Tribe outreach
+
+- **[issue-2796]** Tribe unanswered-thread nudges now cover Gmail, not just iMessage/Signal: Gmail sync ingests your recent sent mail into the activity timeline (per-account, default-on, opt out via a new "Reply detection" toggle in Messages > Config), so a thread you've already replied to is no longer surfaced as needing outreach while a genuinely unanswered email within the window still is.
+
 ## Changed
 
 - `[issue-2651]` The CoS `claim-issue-gitlab` work detector now short-circuits the group-owner filter trap the same way `claim-issue` handles a GitHub org owner. A GitLab group-owned project's namespace is the group, which never authors issues, so `owner` author-filter mode previously found nothing and parked with the vague `no-authored-issues` reason. GitLab's owner resolver now resolves the full project namespace (including nested subgroups like `parent/subgroup`) and probes `glab api groups/<url-encoded-namespace>` (200 = group, 404 = user namespace); for a group it skips the guaranteed-empty `--author <group>` query and parks with a distinct `owner-is-group` reason carrying the real open count. The on-demand toast reads *"the \"owner\" filter matches a group, which can't author issues — set it to \"self\" or \"any\""* — GitLab-appropriate wording ("group", not "org"). A probe failure degrades to the pre-existing behavior, so no new transient park appears.

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -22,7 +22,7 @@
 
 ## Tribe outreach
 
-- **[issue-2796]** Tribe unanswered-thread nudges now cover Gmail, not just iMessage/Signal: Gmail sync ingests your recent sent mail into the activity timeline (per-account, default-on, opt out via a new "Reply detection" toggle in Messages > Config), so a thread you've already replied to is no longer surfaced as needing outreach while a genuinely unanswered email within the window still is.
+- **[issue-2796]** Tribe unanswered-thread nudges now cover Gmail, not just iMessage/Signal: Gmail sync ingests your recent sent mail into the activity timeline (as activity only — sent mail never enters your inbox), so a thread you've already replied to is no longer surfaced as needing outreach while a genuinely unanswered email within the window still is. Reply detection is per-account (default-on for Gmail, opt out via a new "Reply detection" toggle in Messages > Config), only trusts an account once its sent history is actually present and current (so a just-upgraded or sync-failing account can't emit false nudges), honors Gmail's send-as aliases, and drafts email replies in an email tone rather than a text-message one. Follow-on hardening (per-account event querying, full sent-window coverage) tracked in #2820.
 
 ## Changed
 

--- a/client/src/components/messages/ConfigTab.jsx
+++ b/client/src/components/messages/ConfigTab.jsx
@@ -174,6 +174,22 @@ export default function ConfigTab({ accounts, setAccounts }) {
     setAccounts(prev => prev.map(a => a.id === account.id ? { ...a, enabled: !a.enabled } : a));
   };
 
+  // Per-account reply detection: ingest sent mail so Tribe-outreach won't nudge an
+  // already-replied thread (#2796). Default-on for Gmail (absent === on).
+  const handleToggleIngestSent = async (account) => {
+    const next = account.syncConfig?.ingestSent === false; // flipping to enabled
+    const result = await api.updateMessageAccount(
+      account.id,
+      { syncConfig: { ...account.syncConfig, ingestSent: next } },
+      { silent: true }
+    ).catch(() => null);
+    if (!result) return toast.error('Failed to update account');
+    toast.success(next ? 'Reply detection enabled' : 'Reply detection disabled');
+    setAccounts(prev => prev.map(a => a.id === account.id
+      ? { ...a, syncConfig: { ...a.syncConfig, ingestSent: next } }
+      : a));
+  };
+
   const handleClearCache = async (accountId) => {
     if (confirmClear !== accountId) {
       setConfirmClear(accountId);
@@ -355,6 +371,19 @@ export default function ConfigTab({ accounts, setAccounts }) {
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
+                  {account.type === 'gmail' && (
+                    <button
+                      onClick={() => handleToggleIngestSent(account)}
+                      className={`px-2 py-1 rounded text-xs transition-colors ${
+                        account.syncConfig?.ingestSent !== false
+                          ? 'bg-port-accent/20 text-port-accent'
+                          : 'bg-gray-700 text-gray-400'
+                      }`}
+                      title="Ingest sent mail so Tribe outreach won't nudge threads you've already replied to"
+                    >
+                      {account.syncConfig?.ingestSent !== false ? 'Reply detection: on' : 'Reply detection: off'}
+                    </button>
+                  )}
                   <button
                     onClick={() => handleToggle(account)}
                     className={`px-2 py-1 rounded text-xs transition-colors ${

--- a/server/routes/messages.js
+++ b/server/routes/messages.js
@@ -28,7 +28,9 @@ const createAccountSchema = z.object({
   syncConfig: z.object({
     maxAge: z.string().optional(),
     maxMessages: z.number().int().positive().optional(),
-    syncInterval: z.number().int().positive().optional()
+    syncInterval: z.number().int().positive().optional(),
+    // Per-account reply-detection ingestion (Gmail sent mail → timeline). #2796.
+    ingestSent: z.boolean().optional()
   }).optional()
 });
 
@@ -39,7 +41,9 @@ const updateAccountSchema = z.object({
   syncConfig: z.object({
     maxAge: z.string().optional(),
     maxMessages: z.number().int().positive().optional(),
-    syncInterval: z.number().int().positive().optional()
+    syncInterval: z.number().int().positive().optional(),
+    // Per-account reply-detection ingestion (Gmail sent mail → timeline). #2796.
+    ingestSent: z.boolean().optional()
   }).optional()
 });
 

--- a/server/services/humanActivity.js
+++ b/server/services/humanActivity.js
@@ -178,11 +178,15 @@ export function messageActivityCandidates(account, messages = []) {
     const externalId = message.externalId || message.id;
     if (!externalId) continue;
     const fromEmail = participantEmail(message.from);
-    // Direction by exact From-vs-owner match. NOTE: a reply sent from a Gmail
-    // "send-as" alias (From ≠ account.email) is classified as received, not sent —
-    // send-as aliases aren't stored per account, so we can't recognize them here.
-    // Bounded impact: such a reply won't cancel its inbound in outreach detection.
-    const sent = Boolean(selfEmail) && fromEmail === selfEmail;
+    // Direction: prefer Gmail's authoritative SENT label when the provider supplies
+    // labels — it correctly marks mail sent from a "send-as" alias (where From ≠
+    // account.email), which a bare From-vs-owner match would misclassify as received
+    // and so never cancel its inbound in outreach detection (#2796). Sources without
+    // labels (Outlook/other) fall back to matching the sender against the owner.
+    const labels = Array.isArray(message.labels) ? message.labels : null;
+    const sent = labels
+      ? labels.includes('SENT')
+      : (Boolean(selfEmail) && fromEmail === selfEmail);
     const participants = normalizeParticipants([
       message.from,
       ...(message.to || []),

--- a/server/services/humanActivity.js
+++ b/server/services/humanActivity.js
@@ -178,6 +178,10 @@ export function messageActivityCandidates(account, messages = []) {
     const externalId = message.externalId || message.id;
     if (!externalId) continue;
     const fromEmail = participantEmail(message.from);
+    // Direction by exact From-vs-owner match. NOTE: a reply sent from a Gmail
+    // "send-as" alias (From ≠ account.email) is classified as received, not sent —
+    // send-as aliases aren't stored per account, so we can't recognize them here.
+    // Bounded impact: such a reply won't cancel its inbound in outreach detection.
     const sent = Boolean(selfEmail) && fromEmail === selfEmail;
     const participants = normalizeParticipants([
       message.from,
@@ -197,6 +201,14 @@ export function messageActivityCandidates(account, messages = []) {
         threadId: message.threadId || null,
         externalId,
         channel: source,
+        // The counterpart handle for a RECEIVED message is the sender's email —
+        // set it so `enrichActivityEvent` (which resolves the top-level personId
+        // from `metadata.handle`) can tag the Tribe sender, exactly as the iMessage
+        // mapper does. Without this, email inbound never resolves to a person and
+        // Tribe-outreach detection (#2796) drops every Gmail thread. Sent turns
+        // carry no counterpart handle (mirrors iMessage); email threads group by
+        // `threadId`, so handle is never the grouping key here.
+        handle: sent ? null : (fromEmail || null),
       },
     });
   }

--- a/server/services/humanActivity.test.js
+++ b/server/services/humanActivity.test.js
@@ -174,6 +174,17 @@ describe('messageActivityCandidates', () => {
     expect(messageActivityCandidates(account, [{ subject: 'no date' }])).toEqual([]);
     expect(messageActivityCandidates(account, [{ date: '2026-07-04T10:00:00Z' }])).toEqual([]);
   });
+  it('sets metadata.handle to the sender email on received mail so the Tribe sender resolves (#2796)', () => {
+    // enrichActivityEvent derives the top-level personId from metadata.handle; without
+    // it, every email inbound is dropped and Tribe-outreach detection surfaces nothing.
+    const [received, sent] = messageActivityCandidates(account, [
+      { externalId: 'e1', date: '2026-07-04T10:00:00Z', from: 'friend@x.io', to: ['me@example.com'], subject: 'Hey' },
+      { externalId: 'e2', date: '2026-07-04T11:00:00Z', from: 'me@example.com', to: ['friend@x.io'], subject: 'Re: Hey' },
+    ]);
+    expect(received.metadata.handle).toBe('friend@x.io');
+    // Sent turns carry no counterpart handle (mirrors iMessage); email groups by threadId.
+    expect(sent.metadata.handle).toBeNull();
+  });
 });
 
 describe('calendarActivityCandidates', () => {

--- a/server/services/humanActivity.test.js
+++ b/server/services/humanActivity.test.js
@@ -185,6 +185,16 @@ describe('messageActivityCandidates', () => {
     // Sent turns carry no counterpart handle (mirrors iMessage); email groups by threadId.
     expect(sent.metadata.handle).toBeNull();
   });
+  it('classifies a reply as sent via the Gmail SENT label even from a send-as alias (#2796)', () => {
+    // From (alias@example.com) != account owner (me@example.com), but the SENT label
+    // is authoritative — without it the reply is misclassified received and never
+    // cancels its inbound.
+    const [c] = messageActivityCandidates(account, [
+      { externalId: 'e9', date: '2026-07-04T12:00:00Z', from: 'alias@example.com', to: ['friend@x.io'], subject: 'Re: Hey', labels: ['SENT'] },
+    ]);
+    expect(c.kind).toBe('message.sent');
+    expect(c.metadata.handle).toBeNull();
+  });
 });
 
 describe('calendarActivityCandidates', () => {

--- a/server/services/messageAccounts.js
+++ b/server/services/messageAccounts.js
@@ -88,3 +88,15 @@ export async function updateSyncStatus(id, status) {
   await saveAccounts(accounts);
   return accounts[id];
 }
+
+// Stamp the reply-detection watermark (#2796): the last time this account
+// successfully ingested sent mail into the activity timeline. The Tribe-outreach
+// detector trusts an account as two-way only when this is set and recent, so an
+// account is never trusted before its sent history actually exists.
+export async function markSentIngested(id, at = new Date().toISOString()) {
+  const accounts = await loadAccounts();
+  if (!accounts[id]) return null;
+  accounts[id].sentIngestedAt = at;
+  await saveAccounts(accounts);
+  return accounts[id];
+}

--- a/server/services/messageAccounts.js
+++ b/server/services/messageAccounts.js
@@ -41,7 +41,13 @@ export async function createAccount(data) {
     syncConfig: {
       maxAge: data.syncConfig?.maxAge || '30d',
       maxMessages: data.syncConfig?.maxMessages || 500,
-      syncInterval: data.syncConfig?.syncInterval || 300000
+      syncInterval: data.syncConfig?.syncInterval || 300000,
+      // Ingest sent mail into the human-activity timeline as `message.sent` events
+      // so Tribe-outreach reply detection can see a thread as answered (#2796).
+      // Only Gmail has a sent-fetch path today; default it on there, off elsewhere.
+      // Absent (existing accounts) is treated as on for Gmail by the readers, so a
+      // migration isn't needed — this only makes new accounts' stored state explicit.
+      ingestSent: data.syncConfig?.ingestSent ?? (data.type === 'gmail')
     },
     lastSyncAt: null,
     lastSyncStatus: null,

--- a/server/services/messageGmailSync.js
+++ b/server/services/messageGmailSync.js
@@ -21,11 +21,13 @@ function makeExternalId(gmailId) {
 // by a test in messageGmailSync.test.js.
 export const SENT_INGEST_DAYS = 14;
 
-// Sent mail gets its OWN fetch budget (a separate list pass), NOT a share of the
-// inbox cap: a heavy sender can send >100 mails in 14 days, and folding sent into
-// one shared-cap query would evict unread-inbox messages from the primary sync.
-// 14 days of a normal person's replies fit comfortably under this.
-export const SENT_INGEST_MAX = 50;
+// Sent mail gets its OWN fetch budget (a separate list pass), never a share of the
+// inbox cap — sent is activity-only and must not crowd inbox out of the primary
+// sync. This also bounds the per-sync detail-fetch cost (sent isn't cached, so it's
+// re-fetched each sync). 14 days of a normal person's replies fit under this; a
+// heavier sender whose replies fall beyond it is a filed follow-up (full date-bounded
+// pagination / fail-closed) — see the issue linked from the changelog.
+export const SENT_INGEST_MAX = 100;
 
 // The inbox search query for a sync mode. `unread` scopes to unread inbox; `full`
 // takes the whole inbox (capped downstream).
@@ -254,12 +256,27 @@ export async function syncGmail(account, cache, io, options = {}) {
     }
   }
 
-  if (io && messages.length > 0) {
-    io.emit('messages:sync:message', { accountId: account.id, messages });
+  // Split inbox vs sent: sent mail is ingested ONLY for the human-activity timeline
+  // (reply detection, #2796) — it must NOT enter the inbox cache, or it would show
+  // up in /api/messages/inbox, run through triage/eval, and compete with real inbox
+  // mail under the maxMessages trim (which could evict a message before its activity
+  // is recorded). A message the user sent carries Gmail's SENT label and no INBOX
+  // label; anything with INBOX (including a self-addressed SENT+INBOX message) stays
+  // inbox. syncAccount records sent activity from `sentMessages` separately.
+  const inboxMessages = [];
+  const sentMessages = [];
+  for (const m of messages) {
+    const lbl = m.labels || [];
+    if (lbl.includes('SENT') && !lbl.includes('INBOX')) sentMessages.push(m);
+    else inboxMessages.push(m);
   }
 
-  console.log(`📧 Gmail API sync complete: ${messages.length} messages fetched`);
-  return { messages, status: 'success', syncMethod: 'api' };
+  if (io && inboxMessages.length > 0) {
+    io.emit('messages:sync:message', { accountId: account.id, messages: inboxMessages });
+  }
+
+  console.log(`📧 Gmail API sync complete: ${inboxMessages.length} inbox, ${sentMessages.length} sent (activity-only)`);
+  return { messages: inboxMessages, sentMessages, status: 'success', syncMethod: 'api' };
 }
 
 /**

--- a/server/services/messageGmailSync.js
+++ b/server/services/messageGmailSync.js
@@ -13,25 +13,44 @@ function makeExternalId(gmailId) {
   return 'api-gmail-' + crypto.createHash('md5').update(gmailId).digest('hex').slice(0, 12);
 }
 
-// How far back to pull sent mail when reply-detection ingestion is on. Bounds the
-// sent-folder fetch to the Tribe-outreach detection window (DEFAULT_WITHIN_DAYS=14
-// in tribeOutreach.js) so a large sent folder can't crowd out inbox results — sent
-// mail older than the window can't answer an inbound that's still actionable.
+// How far back to pull sent mail when reply-detection ingestion is on. Must stay
+// >= tribeOutreach's DEFAULT_WITHIN_DAYS (14) — a reply older than the detection
+// window can't answer an inbound that's still actionable, so no need to ingest it;
+// but if this were SHORTER than the window, a reply inside the window would be
+// missed and its inbound would falsely read as unanswered. The coupling is pinned
+// by a test in messageGmailSync.test.js.
 export const SENT_INGEST_DAYS = 14;
 
+// Sent mail gets its OWN fetch budget (a separate list pass), NOT a share of the
+// inbox cap: a heavy sender can send >100 mails in 14 days, and folding sent into
+// one shared-cap query would evict unread-inbox messages from the primary sync.
+// 14 days of a normal person's replies fit comfortably under this.
+export const SENT_INGEST_MAX = 50;
+
+// The inbox search query for a sync mode. `unread` scopes to unread inbox; `full`
+// takes the whole inbox (capped downstream).
+export function inboxQuery(mode) {
+  return mode === 'unread' ? 'is:unread in:inbox' : 'in:inbox';
+}
+
+// Recent sent mail — no unread state, bounded by date instead. Ingested so it lands
+// in the same cache the human-activity timeline reads, recording `message.sent`
+// events that let Tribe-outreach detection see a Gmail thread as replied (#2796).
+export function sentQuery() {
+  return `in:sent newer_than:${SENT_INGEST_DAYS}d`;
+}
+
 /**
- * Build the Gmail search query. Inbox is always fetched; when `ingestSent` is on
- * (the per-account default, opt out via `syncConfig.ingestSent === false`) recent
- * sent mail is ALSO fetched so it lands in the same cache the human-activity
- * timeline ingests — recording `message.sent` events that let Tribe-outreach
- * detection see a Gmail thread as replied (#2796). `unread` mode still only scopes
- * the INBOX half to unread; sent mail has no unread state and is bounded by
- * `newer_than` instead.
+ * The ordered (query, cap) list-passes for one Gmail sync. Inbox always runs with
+ * the full `inboxCap`; recent sent mail runs as a SEPARATE pass with its own
+ * `SENT_INGEST_MAX` budget when the account opts into reply-detection ingestion
+ * (the per-account default, opt out via `syncConfig.ingestSent === false`). Separate
+ * passes mean sent volume never crowds the inbox out of a shared cap.
  */
-export function buildGmailQuery(mode, ingestSent) {
-  const inbox = mode === 'unread' ? 'is:unread in:inbox' : 'in:inbox';
-  if (!ingestSent) return inbox;
-  return `(${inbox}) OR (in:sent newer_than:${SENT_INGEST_DAYS}d)`;
+export function gmailSyncPasses(mode, ingestSent, inboxCap) {
+  const passes = [{ query: inboxQuery(mode), cap: inboxCap }];
+  if (ingestSent) passes.push({ query: sentQuery(), cap: SENT_INGEST_MAX });
+  return passes;
 }
 
 function getHeader(headers, name) {
@@ -146,28 +165,40 @@ export async function syncGmail(account, cache, io, options = {}) {
   // Ingest sent mail unless the account explicitly opted out — the default-on
   // capability powers per-account Tribe-outreach reply detection (#2796).
   const ingestSent = account?.syncConfig?.ingestSent !== false;
-  const query = buildGmailQuery(mode, ingestSent);
+  const passes = gmailSyncPasses(mode, ingestSent, maxMessages);
+  const totalCap = passes.reduce((sum, p) => sum + p.cap, 0);
 
   console.log(`📧 Gmail API sync (${mode}${ingestSent ? '+sent' : ''}) for ${account.email}`);
 
-  // Step 1: List message IDs
+  // Step 1: List message IDs — one pass per (query, cap). Dedupe across passes by
+  // gmail id (a thread can appear in both inbox and sent) so a message is fetched
+  // and recorded once.
   const messageIds = [];
-  let pageToken = null;
+  const seenGmailIds = new Set();
 
-  do {
-    io?.emit('messages:sync:progress', { accountId: account.id, current: messageIds.length, total: maxMessages });
+  for (const pass of passes) {
+    let pageToken = null;
+    let fetched = 0;
+    do {
+      io?.emit('messages:sync:progress', { accountId: account.id, current: messageIds.length, total: totalCap });
 
-    const listResult = await gmailClient.users.messages.list({
-      userId: 'me',
-      q: query,
-      maxResults: Math.min(100, maxMessages - messageIds.length),
-      ...(pageToken && { pageToken })
-    });
+      const listResult = await gmailClient.users.messages.list({
+        userId: 'me',
+        q: pass.query,
+        maxResults: Math.min(100, pass.cap - fetched),
+        ...(pageToken && { pageToken })
+      });
 
-    const items = listResult.data.messages || [];
-    messageIds.push(...items);
-    pageToken = listResult.data.nextPageToken;
-  } while (pageToken && messageIds.length < maxMessages);
+      const items = listResult.data.messages || [];
+      fetched += items.length;
+      for (const item of items) {
+        if (seenGmailIds.has(item.id)) continue;
+        seenGmailIds.add(item.id);
+        messageIds.push(item);
+      }
+      pageToken = listResult.data.nextPageToken;
+    } while (pageToken && fetched < pass.cap);
+  }
 
   console.log(`📧 Gmail: found ${messageIds.length} message IDs, fetching details`);
 

--- a/server/services/messageGmailSync.js
+++ b/server/services/messageGmailSync.js
@@ -13,6 +13,27 @@ function makeExternalId(gmailId) {
   return 'api-gmail-' + crypto.createHash('md5').update(gmailId).digest('hex').slice(0, 12);
 }
 
+// How far back to pull sent mail when reply-detection ingestion is on. Bounds the
+// sent-folder fetch to the Tribe-outreach detection window (DEFAULT_WITHIN_DAYS=14
+// in tribeOutreach.js) so a large sent folder can't crowd out inbox results — sent
+// mail older than the window can't answer an inbound that's still actionable.
+export const SENT_INGEST_DAYS = 14;
+
+/**
+ * Build the Gmail search query. Inbox is always fetched; when `ingestSent` is on
+ * (the per-account default, opt out via `syncConfig.ingestSent === false`) recent
+ * sent mail is ALSO fetched so it lands in the same cache the human-activity
+ * timeline ingests — recording `message.sent` events that let Tribe-outreach
+ * detection see a Gmail thread as replied (#2796). `unread` mode still only scopes
+ * the INBOX half to unread; sent mail has no unread state and is bounded by
+ * `newer_than` instead.
+ */
+export function buildGmailQuery(mode, ingestSent) {
+  const inbox = mode === 'unread' ? 'is:unread in:inbox' : 'in:inbox';
+  if (!ingestSent) return inbox;
+  return `(${inbox}) OR (in:sent newer_than:${SENT_INGEST_DAYS}d)`;
+}
+
 function getHeader(headers, name) {
   return headers?.find(h => h.name.toLowerCase() === name.toLowerCase())?.value || '';
 }
@@ -122,9 +143,12 @@ export async function syncGmail(account, cache, io, options = {}) {
 
   const gmailClient = gmail({ version: 'v1', auth });
   const maxMessages = mode === 'full' ? 200 : 100;
-  const query = mode === 'unread' ? 'is:unread in:inbox' : 'in:inbox';
+  // Ingest sent mail unless the account explicitly opted out — the default-on
+  // capability powers per-account Tribe-outreach reply detection (#2796).
+  const ingestSent = account?.syncConfig?.ingestSent !== false;
+  const query = buildGmailQuery(mode, ingestSent);
 
-  console.log(`📧 Gmail API sync (${mode}) for ${account.email}`);
+  console.log(`📧 Gmail API sync (${mode}${ingestSent ? '+sent' : ''}) for ${account.email}`);
 
   // Step 1: List message IDs
   const messageIds = [];

--- a/server/services/messageGmailSync.test.js
+++ b/server/services/messageGmailSync.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+
+import { buildGmailQuery, SENT_INGEST_DAYS } from './messageGmailSync.js';
+
+// buildGmailQuery is the pure search-query core (#2796). Inbox is always scoped;
+// sent mail is folded in only when the account opts into reply-detection ingestion,
+// bounded to the outreach detection window so a big sent folder can't crowd out
+// inbox results.
+describe('buildGmailQuery', () => {
+  it('inbox-only when ingestSent is off', () => {
+    expect(buildGmailQuery('unread', false)).toBe('is:unread in:inbox');
+    expect(buildGmailQuery('full', false)).toBe('in:inbox');
+  });
+
+  it('folds recent sent mail in when ingestSent is on, keeping the unread scope on inbox only', () => {
+    expect(buildGmailQuery('unread', true)).toBe(`(is:unread in:inbox) OR (in:sent newer_than:${SENT_INGEST_DAYS}d)`);
+    expect(buildGmailQuery('full', true)).toBe(`(in:inbox) OR (in:sent newer_than:${SENT_INGEST_DAYS}d)`);
+  });
+
+  it('bounds the sent fetch to the 14-day outreach detection window', () => {
+    expect(SENT_INGEST_DAYS).toBe(14);
+    expect(buildGmailQuery('full', true)).toContain('newer_than:14d');
+  });
+});

--- a/server/services/messageGmailSync.test.js
+++ b/server/services/messageGmailSync.test.js
@@ -1,24 +1,54 @@
 import { describe, it, expect } from 'vitest';
 
-import { buildGmailQuery, SENT_INGEST_DAYS } from './messageGmailSync.js';
+import {
+  inboxQuery,
+  sentQuery,
+  gmailSyncPasses,
+  SENT_INGEST_DAYS,
+  SENT_INGEST_MAX,
+} from './messageGmailSync.js';
+import { DEFAULT_WITHIN_DAYS } from './tribeOutreach.js';
 
-// buildGmailQuery is the pure search-query core (#2796). Inbox is always scoped;
-// sent mail is folded in only when the account opts into reply-detection ingestion,
-// bounded to the outreach detection window so a big sent folder can't crowd out
-// inbox results.
-describe('buildGmailQuery', () => {
-  it('inbox-only when ingestSent is off', () => {
-    expect(buildGmailQuery('unread', false)).toBe('is:unread in:inbox');
-    expect(buildGmailQuery('full', false)).toBe('in:inbox');
+// The Gmail sync's search-query core (#2796). Inbox and sent are fetched as
+// SEPARATE list passes so a heavy sender's sent mail can't crowd unread inbox out
+// of a shared cap.
+describe('inboxQuery / sentQuery', () => {
+  it('scopes the inbox pass to unread only in unread mode', () => {
+    expect(inboxQuery('unread')).toBe('is:unread in:inbox');
+    expect(inboxQuery('full')).toBe('in:inbox');
   });
 
-  it('folds recent sent mail in when ingestSent is on, keeping the unread scope on inbox only', () => {
-    expect(buildGmailQuery('unread', true)).toBe(`(is:unread in:inbox) OR (in:sent newer_than:${SENT_INGEST_DAYS}d)`);
-    expect(buildGmailQuery('full', true)).toBe(`(in:inbox) OR (in:sent newer_than:${SENT_INGEST_DAYS}d)`);
-  });
-
-  it('bounds the sent fetch to the 14-day outreach detection window', () => {
+  it('bounds the sent pass by date to the detection window', () => {
+    expect(sentQuery()).toBe(`in:sent newer_than:${SENT_INGEST_DAYS}d`);
     expect(SENT_INGEST_DAYS).toBe(14);
-    expect(buildGmailQuery('full', true)).toContain('newer_than:14d');
+  });
+});
+
+describe('gmailSyncPasses', () => {
+  it('is inbox-only (own cap) when ingestSent is off', () => {
+    expect(gmailSyncPasses('unread', false, 100)).toEqual([
+      { query: 'is:unread in:inbox', cap: 100 },
+    ]);
+    expect(gmailSyncPasses('full', false, 200)).toEqual([
+      { query: 'in:inbox', cap: 200 },
+    ]);
+  });
+
+  it('adds a separate sent pass with its OWN budget when ingestSent is on', () => {
+    expect(gmailSyncPasses('unread', true, 100)).toEqual([
+      { query: 'is:unread in:inbox', cap: 100 },
+      { query: `in:sent newer_than:${SENT_INGEST_DAYS}d`, cap: SENT_INGEST_MAX },
+    ]);
+    // The inbox cap is untouched — sent mail never eats into it.
+    expect(gmailSyncPasses('full', true, 200)[0]).toEqual({ query: 'in:inbox', cap: 200 });
+  });
+});
+
+// Constant-coupling guard: the sent-fetch window must cover the outreach detection
+// window, or a reply inside the window would be missed and its inbound would
+// falsely read as unanswered.
+describe('sent-ingest window covers the outreach detection window', () => {
+  it('SENT_INGEST_DAYS >= DEFAULT_WITHIN_DAYS', () => {
+    expect(SENT_INGEST_DAYS).toBeGreaterThanOrEqual(DEFAULT_WITHIN_DAYS);
   });
 });

--- a/server/services/messageSync.js
+++ b/server/services/messageSync.js
@@ -2,7 +2,7 @@
 import { createHash } from 'crypto';
 import { join } from 'path';
 import { atomicWrite, ensureDir, filterBySearch as genericFilterBySearch, PATHS, safeDate, safeJSONParse, UUID_RE, tryReadFile } from '../lib/fileUtils.js';
-import { getAccount, updateSyncStatus } from './messageAccounts.js';
+import { getAccount, updateSyncStatus, markSentIngested } from './messageAccounts.js';
 import { getUserTimezone, getLocalParts } from '../lib/timezone.js';
 import { v4 as uuidv4 } from '../lib/uuid.js';
 import { createKeyCachedQueue } from '../lib/createKeyCachedQueue.js';
@@ -191,6 +191,9 @@ export async function syncAccount(accountId, io, options = {}) {
     // Support structured result { messages, status } or plain array
     const newMessages = Array.isArray(providerResult) ? providerResult : providerResult?.messages ?? [];
     const providerStatus = Array.isArray(providerResult) ? 'success' : providerResult?.status ?? 'success';
+    // Sent mail (Gmail reply-detection ingest, #2796) is activity-only: recorded to
+    // the timeline but never added to the inbox cache/eval/trim. Kept separate here.
+    const sentMessages = Array.isArray(providerResult) ? [] : (providerResult?.sentMessages ?? []);
 
     // Deduplicate by externalId; update flags and body on existing messages
     const existingMap = new Map(cache.messages.filter(m => m.externalId).map(m => [m.externalId, m]));
@@ -250,8 +253,20 @@ export async function syncAccount(accountId, io, options = {}) {
     // Populate the human-activity timeline (#2150) — secondary effect, must NOT
     // fail the sync. Idempotent on (source, dedupe_key), so re-scanning the full
     // cache each sync is a no-op for already-recorded messages. Machine-local.
-    await recordMessageActivity(account, cache.messages).catch((err) =>
+    // Sent mail (activity-only, #2796) is fed IN ADDITION to the cached inbox mail
+    // so it records `message.sent` events without ever entering the inbox cache.
+    await recordMessageActivity(account, [...cache.messages, ...sentMessages]).catch((err) =>
       console.error(`🗓️  Activity ingest failed for account ${accountId}: ${err.message}`));
+
+    // Reply-detection watermark (#2796): stamp when a Gmail account with sent-ingest
+    // enabled completes a successful sync, so the outreach detector only trusts an
+    // account whose sent history is actually present and recent. Without this, an
+    // account default-on at upgrade (or after an OAuth/sync failure) would be trusted
+    // before any reply evidence exists, producing false "unanswered" nudges.
+    if (providerStatus === 'success' && account.type === 'gmail' && account.syncConfig?.ingestSent !== false) {
+      await markSentIngested(accountId).catch((err) =>
+        console.error(`🤝 Sent-ingest watermark failed for account ${accountId}: ${err.message}`));
+    }
 
     io?.emit('messages:sync:completed', { accountId, newMessages: uniqueNew.length, pruned, status: providerStatus });
     if (providerStatus === 'success') {

--- a/server/services/messageSync.test.js
+++ b/server/services/messageSync.test.js
@@ -34,7 +34,8 @@ vi.mock('../lib/fileUtils.js', () => ({
 
 vi.mock('./messageAccounts.js', () => ({
   getAccount: vi.fn(),
-  updateSyncStatus: vi.fn()
+  updateSyncStatus: vi.fn(),
+  markSentIngested: vi.fn(() => Promise.resolve())
 }));
 
 vi.mock('./messageGmailSync.js', () => ({

--- a/server/services/tribeOutreach.js
+++ b/server/services/tribeOutreach.js
@@ -234,7 +234,6 @@ export async function findUnansweredTribeThreads({
   const { sources: twoWaySources, isTwoWay } = buildTwoWayGate(
     await listAccounts().catch(() => [])
   );
-  if (twoWaySources.length === 0) return [];
   const ringById = new Map((ctx.people || []).map((p) => [p.id, p.ring]));
   const nameById = new Map((ctx.people || []).map((p) => [p.id, p.name]));
   // No non-external Tribe people → nothing to nudge about; skip the timeline scan.

--- a/server/services/tribeOutreach.js
+++ b/server/services/tribeOutreach.js
@@ -17,10 +17,11 @@
  *      and files a DRAFT through `messageDrafts.createDraft`. It NEVER auto-sends —
  *      the user reviews/approves/sends through the existing draft pipeline.
  *
- * The detection layer is source-agnostic: it works across every message source
- * that records `message.sent`/`message.received` activity events — Gmail/Outlook
- * (#2033), iMessage (#2151), Signal (#2154) — because it keys off the timeline,
- * not any one provider's cache.
+ * The detection layer is source-agnostic in shape but gated to sources whose
+ * ingestion records BOTH directions per conversation, so an "unanswered" verdict is
+ * trustworthy: iMessage (#2151) and Signal (#2154) source-wide, and Gmail (#2033)
+ * PER ACCOUNT once its sent mail is ingested as `message.sent` (#2796). See
+ * `buildTwoWayGate` for the per-account gate.
  */
 
 import { ServerError } from '../lib/errorHandler.js';
@@ -47,13 +48,58 @@ const MESSAGE_KINDS = new Set(['message.sent', 'message.received']);
 // retroactive backfill would need to re-read chat.db by rowid (macOS + Full Disk
 // Access only), so it's deliberately not attempted here.
 //
-// Sources whose ingestion records BOTH directions per conversation, so an
-// "unanswered" verdict is trustworthy. iMessage (#2151) and Signal (#2154) emit a
-// `message.sent` for every outgoing turn; email sync ingests the inbox only (no
-// `message.sent`), so a reply is invisible to the timeline and every stale inbound
-// would read as unanswered forever. Email/other one-way sources are deferred until
-// per-account sent/replied ingestion exists — see #2796.
-const TWO_WAY_SOURCES = new Set(['imessage', 'signal']);
+// Chat sources ingest BOTH directions per conversation intrinsically — iMessage
+// (#2151) and Signal (#2154) emit a `message.sent` for every outgoing turn — so an
+// "unanswered" verdict is always trustworthy regardless of which account it came
+// through. They are two-way source-wide.
+const TWO_WAY_CHAT_SOURCES = new Set(['imessage', 'signal']);
+
+// Email sources can ALSO be two-way, but only PER ACCOUNT (#2796). Gmail's API
+// sync gained an opt-out `syncConfig.ingestSent` (default on) that pulls `in:sent`
+// into the same cache the timeline ingest reads, so a replied thread cancels its
+// own inbound via the existing `lastSentT >= inbound` answered-check. The gate must
+// key on the specific accountId, NOT the source: a source-wide gate would let ONE
+// gmail account's sent import vouch for EVERY gmail account — including ones with no
+// sent evidence, whose every stale inbound would then read as unanswered forever.
+// Outlook/Teams ingest the inbox only (no sent-fetch path yet), so they stay
+// one-way until one is added — an inbound from them is never surfaced.
+const SENT_INGEST_SOURCES = new Set(['gmail']);
+
+/**
+ * Pure per-account two-way gate (unit-tested without a DB). Given the message-
+ * account list, returns the sources worth scanning and an `isTwoWay(event)`
+ * predicate. An email account counts as two-way only when ALL of: its provider has
+ * a sent-ingest path (`SENT_INGEST_SOURCES`), it isn't opted out
+ * (`syncConfig.ingestSent !== false` — absent means the default-on capability), AND
+ * it has an owner email set. The email is required because sent-vs-received
+ * direction is derived from sender === owner (see `messageActivityCandidates`); with
+ * no owner email, an account never produces `message.sent` events, so trusting it
+ * would make every inbound read as unanswered.
+ *
+ * @param {Array} accounts message-account records ({ id, type, email, syncConfig })
+ * @returns {{ sources: string[], isTwoWay: (ev: object) => boolean }}
+ */
+export function buildTwoWayGate(accounts = []) {
+  const twoWayEmailAccountIds = new Set(
+    (accounts || [])
+      .filter((a) =>
+        SENT_INGEST_SOURCES.has(a?.type) &&
+        a?.syncConfig?.ingestSent !== false &&
+        String(a?.email || '').trim() !== '')
+      .map((a) => a.id)
+  );
+  // Only scan an email source when at least one of its accounts is two-way — a
+  // one-way-only provider is never queried, so a high-volume inbox can't burn the
+  // per-source 2000-row cap on data we'd discard anyway.
+  const sources = new Set(TWO_WAY_CHAT_SOURCES);
+  for (const a of accounts || []) {
+    if (twoWayEmailAccountIds.has(a?.id)) sources.add(a.type);
+  }
+  const isTwoWay = (ev) =>
+    TWO_WAY_CHAT_SOURCES.has(ev?.source) ||
+    (ev?.accountId != null && twoWayEmailAccountIds.has(ev.accountId));
+  return { sources: [...sources], isTwoWay };
+}
 
 // Channel-appropriate reply prompt for chat outreach — generateReplyBody's default
 // template is email-toned ("Write a professional reply to this email"), which reads
@@ -175,13 +221,20 @@ export async function findUnansweredTribeThreads({
   staleAfterHours = DEFAULT_STALE_HOURS,
   limit = DEFAULT_LIMIT,
 } = {}) {
-  const [{ listEvents }, { loadResolverContext, enrichActivityEvent }] = await Promise.all([
+  const [{ listEvents }, { loadResolverContext, enrichActivityEvent }, { listAccounts }] = await Promise.all([
     import('./humanActivity.js'),
     import('./identityResolve.js'),
+    import('./messageAccounts.js'),
   ]);
 
   const ctx = await loadResolverContext().catch(() => null);
   if (!ctx) return [];
+  // Per-account two-way gate: which sources to scan, and which inbound events are
+  // trustworthy (chat source-wide, email only from sent-ingesting accounts).
+  const { sources: twoWaySources, isTwoWay } = buildTwoWayGate(
+    await listAccounts().catch(() => [])
+  );
+  if (twoWaySources.length === 0) return [];
   const ringById = new Map((ctx.people || []).map((p) => [p.id, p.ring]));
   const nameById = new Map((ctx.people || []).map((p) => [p.id, p.name]));
   // No non-external Tribe people → nothing to nudge about; skip the timeline scan.
@@ -197,7 +250,7 @@ export async function findUnansweredTribeThreads({
   // mark a thread answered.
   const received = [];
   const sent = [];
-  await Promise.all([...TWO_WAY_SOURCES].map((src) =>
+  await Promise.all(twoWaySources.map((src) =>
     // Fail CLOSED per source: if EITHER direction's query fails, drop this source's
     // turns entirely. Substituting [] for only the failed direction would leave
     // received without its sent counterpart, making every inbound look unanswered
@@ -222,10 +275,15 @@ export async function findUnansweredTribeThreads({
 
   // Drop Tapbacks/reactions from both directions — a reaction is not a message
   // awaiting a reply (it must not anchor an "unanswered" thread), and a sent
-  // reaction is not a real reply (it must not mark a thread answered).
-  const tagged = sent.filter((ev) => !ev.metadata?.isReaction);
+  // reaction is not a real reply (it must not mark a thread answered). Also drop any
+  // event from a non-two-way account: querying source `gmail` returns events from
+  // ALL gmail accounts, but only the sent-ingesting ones are trustworthy — a reply
+  // from a one-way account is invisible, so its inbound must not surface (and its
+  // sent turns, if any lingered, must not vouch for another account's thread).
+  const tagged = sent.filter((ev) => !ev.metadata?.isReaction && isTwoWay(ev));
   for (const ev of received) {
     if (ev.metadata?.isReaction) continue;
+    if (!isTwoWay(ev)) continue;
     // Scope to 1:1 conversations — a chat with more than one counterpart is a
     // group, where "you never replied" rarely means a personal obligation and
     // multi-sender turns can't be cleanly attributed or anchored. A 1:1 chat's
@@ -276,9 +334,11 @@ const inflightOutreach = new Map();
  * it through the existing draft-then-approve pipeline. USER-ACTION-GATED: only ever
  * called from an explicit request (the Tribe Outreach panel / an opt-in automation)
  * — it is the single LLM entry point here and must never be wired into a boot/sweep
- * path. Detection only surfaces the two-way chat sources (iMessage/Signal), which
- * carry no message account and no programmatic send channel, so the draft is always
- * grounded from the timeline and filed as review-only — never auto-sent.
+ * path. Detection surfaces the two-way sources — chat (iMessage/Signal) plus
+ * sent-ingesting Gmail accounts (#2796) — grounding the reply from the timeline by
+ * the detected conversation key (chatGuid / conversationId / threadId / handle). The
+ * draft is always filed as review-only (`sendVia: 'review'`) — never auto-sent, even
+ * for email, which the user approves/sends through the existing draft pipeline.
  *
  * @returns {Promise<{ draft, person: { id, name } | null }>}
  */

--- a/server/services/tribeOutreach.js
+++ b/server/services/tribeOutreach.js
@@ -68,24 +68,38 @@ const SENT_INGEST_SOURCES = new Set(['gmail']);
 /**
  * Pure per-account two-way gate (unit-tested without a DB). Given the message-
  * account list, returns the sources worth scanning and an `isTwoWay(event)`
- * predicate. An email account counts as two-way only when ALL of: its provider has
- * a sent-ingest path (`SENT_INGEST_SOURCES`), it isn't opted out
- * (`syncConfig.ingestSent !== false` — absent means the default-on capability), AND
- * it has an owner email set. The email is required because sent-vs-received
- * direction is derived from sender === owner (see `messageActivityCandidates`); with
- * no owner email, an account never produces `message.sent` events, so trusting it
- * would make every inbound read as unanswered.
+ * predicate. An email account counts as two-way only when ALL of:
+ *   - its provider has a sent-ingest path (`SENT_INGEST_SOURCES`);
+ *   - it isn't opted out (`syncConfig.ingestSent !== false` — absent means the
+ *     default-on capability);
+ *   - it has an owner email set (sent-vs-received direction needs it — see
+ *     `messageActivityCandidates`; without it no `message.sent` events are produced,
+ *     so every inbound would read as unanswered);
+ *   - it is enabled (a disabled account never syncs, so its sent history never
+ *     updates — trusting it would nudge on stale/absent reply evidence);
+ *   - it has a RECENT sent-ingest watermark (`sentIngestedAt` within `coverageMs`).
+ *     This is the reliability guard: an account default-on at upgrade, or one whose
+ *     OAuth/sync has been failing, has no current sent evidence — trusting it on
+ *     config alone would produce false "unanswered" nudges for already-replied
+ *     threads. `coverageMs` defaults to Infinity (presence-only) for pure tests; the
+ *     real caller passes the detection window.
  *
- * @param {Array} accounts message-account records ({ id, type, email, syncConfig })
+ * @param {Array} accounts message-account records ({ id, type, email, enabled, syncConfig, sentIngestedAt })
+ * @param {{ now?: number, coverageMs?: number }} opts staleness bound for the watermark
  * @returns {{ sources: string[], isTwoWay: (ev: object) => boolean }}
  */
-export function buildTwoWayGate(accounts = []) {
+export function buildTwoWayGate(accounts = [], { now = Date.now(), coverageMs = Infinity } = {}) {
   const twoWayEmailAccountIds = new Set(
     (accounts || [])
-      .filter((a) =>
-        SENT_INGEST_SOURCES.has(a?.type) &&
-        a?.syncConfig?.ingestSent !== false &&
-        String(a?.email || '').trim() !== '')
+      .filter((a) => {
+        if (!SENT_INGEST_SOURCES.has(a?.type)) return false;
+        if (a?.syncConfig?.ingestSent === false) return false;
+        if (String(a?.email || '').trim() === '') return false;
+        if (a?.enabled === false) return false;
+        const at = Date.parse(a?.sentIngestedAt);
+        if (Number.isNaN(at)) return false; // never successfully ingested sent mail
+        return (now - at) <= coverageMs; // stale watermark → coverage can't be trusted
+      })
       .map((a) => a.id)
   );
   // Only scan an email source when at least one of its accounts is two-way — a
@@ -107,6 +121,19 @@ export function buildTwoWayGate(accounts = []) {
 // resolves the {{#instructions}} conditional block, so any caller-supplied guidance
 // actually reaches the model (the default template omits it and drops it silently).
 const OUTREACH_CHAT_TEMPLATE = 'Write a brief, warm, casual reply to reconnect over a text message. Keep it short and personal — no email subject line, no formal salutation or sign-off.{{#instructions}}\n\nAdditional guidance: {{instructions}}{{/instructions}}\n\nFrom: {{from}}\nTheir message:\n{{body}}';
+
+// Channel-appropriate reply prompt for EMAIL outreach (#2796). Email threads can now
+// reach draft generation, and the chat template above explicitly forbids a salutation/
+// sign-off — wrong for email. This one asks for a natural greeting + sign-off while
+// staying warm and concise, and (like the chat one) resolves the {{#instructions}}
+// block so caller guidance reaches the model (the default template drops it silently).
+const OUTREACH_EMAIL_TEMPLATE = 'Write a brief, warm, personal email reply to reconnect. Keep it genuine and concise, with a natural greeting and a friendly sign-off.{{#instructions}}\n\nAdditional guidance: {{instructions}}{{/instructions}}\n\nFrom: {{from}}\nTheir message:\n{{body}}';
+
+// Chat sources are the two-way messaging apps; everything else here is email-shaped.
+// Picks the channel-appropriate outreach reply template.
+export function outreachTemplateForSource(source) {
+  return TWO_WAY_CHAT_SOURCES.has(source) ? OUTREACH_CHAT_TEMPLATE : OUTREACH_EMAIL_TEMPLATE;
+}
 
 // A conversation is keyed by the most specific stable identifier available:
 // chatGuid (iMessage), conversationId (Signal — its outbound turns carry no
@@ -229,10 +256,14 @@ export async function findUnansweredTribeThreads({
 
   const ctx = await loadResolverContext().catch(() => null);
   if (!ctx) return [];
+  const now = Date.now();
+  const withinMs = withinDays * DAY_MS;
   // Per-account two-way gate: which sources to scan, and which inbound events are
-  // trustworthy (chat source-wide, email only from sent-ingesting accounts).
+  // trustworthy (chat source-wide, email only from sent-ingesting accounts whose
+  // reply-evidence watermark covers the detection window).
   const { sources: twoWaySources, isTwoWay } = buildTwoWayGate(
-    await listAccounts().catch(() => [])
+    await listAccounts().catch(() => []),
+    { now, coverageMs: withinMs }
   );
   const ringById = new Map((ctx.people || []).map((p) => [p.id, p.ring]));
   const nameById = new Map((ctx.people || []).map((p) => [p.id, p.name]));
@@ -240,8 +271,7 @@ export async function findUnansweredTribeThreads({
   const hasTribe = (ctx.people || []).some((p) => p.ring && p.ring !== 'external');
   if (!hasTribe) return [];
 
-  const now = Date.now();
-  const from = new Date(now - withinDays * DAY_MS).toISOString();
+  const from = new Date(now - withinMs).toISOString();
   // Query each two-way source × kind separately, each with its own 2000-row cap.
   // A single shared query would let a high-volume source (e.g. thousands of
   // imported email events) fill the newest-2000 slice and push older iMessage /
@@ -302,7 +332,7 @@ export async function findUnansweredTribeThreads({
   const threads = groupUnansweredThreads(tagged, {
     now,
     staleAfterMs: staleAfterHours * HOUR_MS,
-    withinMs: withinDays * DAY_MS,
+    withinMs,
   });
   return threads.slice(0, Math.max(0, limit));
 }
@@ -451,7 +481,9 @@ async function generateOutreachDraftImpl({
   const aiResult = await generateReplyBody(replyTo, instructions, {
     useVoice,
     threadMessages,
-    templateOverride: OUTREACH_CHAT_TEMPLATE,
+    // Channel-appropriate template: casual/no-signoff for chat, greeting+signoff for
+    // email (Gmail threads now reach here via #2796).
+    templateOverride: outreachTemplateForSource(source),
   }).catch((err) => {
     console.error(`❌ Outreach draft generation failed: ${err.message}`);
     return null;

--- a/server/services/tribeOutreach.test.js
+++ b/server/services/tribeOutreach.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { groupUnansweredThreads, generateOutreachDraft } from './tribeOutreach.js';
+import { groupUnansweredThreads, generateOutreachDraft, buildTwoWayGate } from './tribeOutreach.js';
 
 // generateOutreachDraft dynamically imports these — mock them so the draft-side
 // logic (idempotent reuse, anchoring the reply to the detected inbound) is
@@ -158,6 +158,54 @@ describe('groupUnansweredThreads', () => {
   it('drops events with unparseable timestamps without throwing', () => {
     const out = groupUnansweredThreads([inbound({ happenedAt: 'not-a-date' })], WINDOW);
     expect(out).toHaveLength(0);
+  });
+});
+
+describe('buildTwoWayGate (per-account #2796)', () => {
+  const gmail = (over) => ({ id: 'g1', type: 'gmail', email: 'me@example.com', syncConfig: {}, ...over });
+
+  it('chat sources are always two-way, no account needed', () => {
+    const { sources, isTwoWay } = buildTwoWayGate([]);
+    expect(sources).toEqual(expect.arrayContaining(['imessage', 'signal']));
+    expect(isTwoWay({ source: 'imessage' })).toBe(true);
+    expect(isTwoWay({ source: 'signal', accountId: null })).toBe(true);
+  });
+
+  it('a Gmail account with an email and default (absent) ingestSent is two-way', () => {
+    const { sources, isTwoWay } = buildTwoWayGate([gmail()]);
+    expect(sources).toContain('gmail');
+    expect(isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(true);
+  });
+
+  it('opting a Gmail account out (ingestSent:false) drops it from the gate', () => {
+    const { sources, isTwoWay } = buildTwoWayGate([gmail({ syncConfig: { ingestSent: false } })]);
+    expect(sources).not.toContain('gmail');
+    expect(isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(false);
+  });
+
+  it('a Gmail account with no owner email is NOT two-way (sent direction underivable)', () => {
+    const { isTwoWay } = buildTwoWayGate([gmail({ email: '' })]);
+    expect(isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(false);
+  });
+
+  it('does NOT let one Gmail account vouch for another (per-account, not source-wide)', () => {
+    // g1 ingests sent; g2 opted out. Both are source `gmail`, but only g1's events
+    // are trustworthy — a source-wide gate would wrongly trust g2's inbound too.
+    const gate = buildTwoWayGate([
+      gmail({ id: 'g1' }),
+      gmail({ id: 'g2', email: 'other@example.com', syncConfig: { ingestSent: false } }),
+    ]);
+    expect(gate.sources).toContain('gmail'); // scanned because g1 is two-way
+    expect(gate.isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(true);
+    expect(gate.isTwoWay({ source: 'gmail', accountId: 'g2' })).toBe(false);
+  });
+
+  it('Outlook is never two-way (no sent-fetch path yet), even with ingestSent:true', () => {
+    const { sources, isTwoWay } = buildTwoWayGate([
+      { id: 'o1', type: 'outlook', email: 'me@example.com', syncConfig: { ingestSent: true } },
+    ]);
+    expect(sources).not.toContain('outlook');
+    expect(isTwoWay({ source: 'outlook', accountId: 'o1' })).toBe(false);
   });
 });
 

--- a/server/services/tribeOutreach.test.js
+++ b/server/services/tribeOutreach.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { groupUnansweredThreads, generateOutreachDraft, buildTwoWayGate } from './tribeOutreach.js';
+import { groupUnansweredThreads, generateOutreachDraft, buildTwoWayGate, outreachTemplateForSource } from './tribeOutreach.js';
 
 // generateOutreachDraft dynamically imports these — mock them so the draft-side
 // logic (idempotent reuse, anchoring the reply to the detected inbound) is
@@ -162,30 +162,47 @@ describe('groupUnansweredThreads', () => {
 });
 
 describe('buildTwoWayGate (per-account #2796)', () => {
-  const gmail = (over) => ({ id: 'g1', type: 'gmail', email: 'me@example.com', syncConfig: {}, ...over });
+  const NOW = Date.parse('2026-07-18T12:00:00Z');
+  const recent = new Date(NOW - 3600000).toISOString(); // 1h ago — fresh watermark
+  const OPTS = { now: NOW, coverageMs: 14 * 86400000 };
+  // A trustworthy Gmail account: email set, enabled, sent-ingest on, recent watermark.
+  const gmail = (over) => ({ id: 'g1', type: 'gmail', email: 'me@example.com', enabled: true, syncConfig: {}, sentIngestedAt: recent, ...over });
 
   it('chat sources are always two-way, no account needed', () => {
-    const { sources, isTwoWay } = buildTwoWayGate([]);
+    const { sources, isTwoWay } = buildTwoWayGate([], OPTS);
     expect(sources).toEqual(expect.arrayContaining(['imessage', 'signal']));
     expect(isTwoWay({ source: 'imessage' })).toBe(true);
     expect(isTwoWay({ source: 'signal', accountId: null })).toBe(true);
   });
 
-  it('a Gmail account with an email and default (absent) ingestSent is two-way', () => {
-    const { sources, isTwoWay } = buildTwoWayGate([gmail()]);
+  it('a Gmail account with email, default ingestSent, and a recent watermark is two-way', () => {
+    const { sources, isTwoWay } = buildTwoWayGate([gmail()], OPTS);
     expect(sources).toContain('gmail');
     expect(isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(true);
   });
 
   it('opting a Gmail account out (ingestSent:false) drops it from the gate', () => {
-    const { sources, isTwoWay } = buildTwoWayGate([gmail({ syncConfig: { ingestSent: false } })]);
+    const { sources, isTwoWay } = buildTwoWayGate([gmail({ syncConfig: { ingestSent: false } })], OPTS);
     expect(sources).not.toContain('gmail');
     expect(isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(false);
   });
 
   it('a Gmail account with no owner email is NOT two-way (sent direction underivable)', () => {
-    const { isTwoWay } = buildTwoWayGate([gmail({ email: '' })]);
-    expect(isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(false);
+    expect(buildTwoWayGate([gmail({ email: '' })], OPTS).isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(false);
+  });
+
+  it('a disabled Gmail account is NOT two-way (its sent history never syncs)', () => {
+    expect(buildTwoWayGate([gmail({ enabled: false })], OPTS).isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(false);
+  });
+
+  it('a Gmail account with NO sent-ingest watermark is NOT two-way (upgrade/first-sync window)', () => {
+    // Default-on at upgrade but no sync yet → no reply evidence → must not be trusted.
+    expect(buildTwoWayGate([gmail({ sentIngestedAt: undefined })], OPTS).isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(false);
+  });
+
+  it('a STALE watermark (older than the detection window) drops the account (sync failing)', () => {
+    const stale = new Date(NOW - 20 * 86400000).toISOString(); // 20d ago > 14d window
+    expect(buildTwoWayGate([gmail({ sentIngestedAt: stale })], OPTS).isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(false);
   });
 
   it('does NOT let one Gmail account vouch for another (per-account, not source-wide)', () => {
@@ -194,7 +211,7 @@ describe('buildTwoWayGate (per-account #2796)', () => {
     const gate = buildTwoWayGate([
       gmail({ id: 'g1' }),
       gmail({ id: 'g2', email: 'other@example.com', syncConfig: { ingestSent: false } }),
-    ]);
+    ], OPTS);
     expect(gate.sources).toContain('gmail'); // scanned because g1 is two-way
     expect(gate.isTwoWay({ source: 'gmail', accountId: 'g1' })).toBe(true);
     expect(gate.isTwoWay({ source: 'gmail', accountId: 'g2' })).toBe(false);
@@ -202,10 +219,25 @@ describe('buildTwoWayGate (per-account #2796)', () => {
 
   it('Outlook is never two-way (no sent-fetch path yet), even with ingestSent:true', () => {
     const { sources, isTwoWay } = buildTwoWayGate([
-      { id: 'o1', type: 'outlook', email: 'me@example.com', syncConfig: { ingestSent: true } },
-    ]);
+      { id: 'o1', type: 'outlook', email: 'me@example.com', enabled: true, syncConfig: { ingestSent: true }, sentIngestedAt: recent },
+    ], OPTS);
     expect(sources).not.toContain('outlook');
     expect(isTwoWay({ source: 'outlook', accountId: 'o1' })).toBe(false);
+  });
+});
+
+describe('outreachTemplateForSource (#2796)', () => {
+  it('uses a no-signoff casual template for chat sources', () => {
+    const t = outreachTemplateForSource('imessage');
+    expect(t).toContain('text message');
+    expect(t).toContain('no formal salutation or sign-off');
+    expect(outreachTemplateForSource('signal')).toBe(t);
+  });
+  it('uses a greeting+signoff email template for Gmail (not the chat template)', () => {
+    const t = outreachTemplateForSource('gmail');
+    expect(t).toContain('email reply');
+    expect(t).toContain('sign-off');
+    expect(t).not.toContain('no formal salutation');
   });
 });
 


### PR DESCRIPTION
## Summary

Extends Tribe-outreach unanswered-thread detection (#2158) to Gmail. Previously it was gated to iMessage/Signal because email sync ingested the inbox only — a Gmail reply never produced a `message.sent` timeline event, so every stale inbound read as unanswered forever.

- **Sent-mail ingestion (Gmail):** the API sync now fetches recent sent mail (`in:sent newer_than:14d`) as a **separate, capped list pass** and records it into the human-activity timeline as `message.sent` events. Sent mail is **activity-only** — it never enters the inbox cache/triage/trim, so it can't pollute `/api/messages/inbox` or evict real inbox mail. Gated per-account via `syncConfig.ingestSent` (default-on for Gmail; opt out with a new "Reply detection" toggle in Messages > Config).
- **Per-account two-way gate (not source-wide):** `buildTwoWayGate` resolves which accounts are trustworthy and filters inbound/sent events by `accountId`. A source-wide gate would let one Gmail account's sent import vouch for every Gmail account. An email account is trusted only when it's enabled, has an owner email, opts in, **and** has a recent sent-ingest watermark (`sentIngestedAt`) — so an account default-on at upgrade or with failing OAuth/sync is never trusted before reply evidence actually exists (closing the false-nudge window).
- **Correct sender resolution:** the shared email mapper now sets `metadata.handle` to the sender's email on received mail, so `enrichActivityEvent` can tag the Tribe sender (without it, every Gmail inbound was dropped).
- **Authoritative direction:** direction honors Gmail's `SENT` label, so a reply sent from a send-as alias is classified as sent and cancels its inbound.
- **Channel-appropriate drafts:** Gmail outreach drafts use an email-toned template (greeting + sign-off) rather than the casual no-signoff chat template.

Recipient/draft grounding via `threadId` was already supported and is reused unchanged.

Follow-on robustness (per-account timeline event querying, full sent-window pagination, optional legacy-row backfill) is filed as #2820.

## Test plan

- `server/services/tribeOutreach.test.js` — per-account gate: chat-source-wide, Gmail default-on, opt-out, missing owner email, disabled account, missing/stale watermark, no cross-account vouching, Outlook never two-way; plus email-vs-chat template selection.
- `server/services/messageGmailSync.test.js` — inbox/sent query builders, separate sent-pass budget, and the `SENT_INGEST_DAYS >= DEFAULT_WITHIN_DAYS` coupling guard.
- `server/services/humanActivity.test.js` — received mail sets `metadata.handle` to the sender; SENT-label direction classifies an alias-sent reply as `message.sent`.
- `server/services/messageSync.test.js` — updated for the new `markSentIngested` export; sent mail recorded as activity without entering the cache.
- Full affected suite: 172 passing. Reviewed locally with claude + ollama + codex (series); all findings fixed or filed (#2820).

Closes #2796