### PR TITLE
fix: guarantee executeTuiRun's finish() always settles the run promise

### DIFF
--- a/server/lib/tuiPromptRunner.js
+++ b/server/lib/tuiPromptRunner.js
@@ -324,6 +324,25 @@ ${prompt}`;
         onComplete?.({ ...metadata, text: responseText, usedResponseFile, outputTruncated: outputBufferTruncated });
       } catch (err) {
         console.error(`❌ TUI run ${runId} finish() failed: ${err?.message || err}`);
+        // A step BEFORE onComplete threw, so the caller's onComplete-driven
+        // settle never fired. executeProviderRunOnce (promptRunner.js) settles
+        // its OUTER Promise only via onComplete (→ safeReject) or the returned
+        // promise rejecting — and our try/finally always resolves (never
+        // rejects), so `.catch(safeReject)` won't fire either. Without this,
+        // resolving the inner promise leaves the central-prompt/pipeline caller
+        // pending forever — the exact hang this patch exists to prevent. Deliver
+        // failure metadata so onComplete → safeReject settles the caller. Guard
+        // the callback itself: if IT was the throw source, don't re-throw out of
+        // finish() (which is un-awaited — an escape would become an unhandled
+        // rejection) and still fall through to resolve().
+        try {
+          onComplete?.({
+            runId, success: false, exitCode, error: `finish() failed: ${err?.message || err}`,
+            duration: Date.now() - startTime, completionReason: reason,
+          });
+        } catch (cbErr) {
+          console.error(`❌ TUI run ${runId} onComplete threw during finish() error handling: ${cbErr?.message || cbErr}`);
+        }
       } finally {
         resolve();
       }

--- a/server/lib/tuiPromptRunner.js
+++ b/server/lib/tuiPromptRunner.js
@@ -279,43 +279,54 @@ ${prompt}`;
     const finish = async ({ success, exitCode = 0, error = null, reason = 'completed' }) => {
       if (finalized) return;
       finalized = true;
-      cleanupTimers();
-      unregisterActiveRun(runId);
-      // Drop the live Shell view the moment the run ends (notifies any attached
-      // viewer via shell:exit). Idempotent — safe even if no viewer ever
-      // attached. Runs before the kill below so the session disappears from the
-      // list immediately rather than waiting on PTY teardown.
-      unregisterExternalSession(runId, { exitCode });
+      // finish() is invoked fire-and-forget from PTY/timer callbacks outside the
+      // request lifecycle (onData, onExit, sendPrompt's write-catch,
+      // responseFileWatchTimer, hardTimeoutTimer) — none of them await or
+      // .catch() this call. try/finally guarantees `resolve` below always fires
+      // exactly once even if a step throws (including the caller-supplied
+      // `onComplete` callback), so executeTuiRun's Promise can never hang forever.
+      try {
+        cleanupTimers();
+        unregisterActiveRun(runId);
+        // Drop the live Shell view the moment the run ends (notifies any attached
+        // viewer via shell:exit). Idempotent — safe even if no viewer ever
+        // attached. Runs before the kill below so the session disappears from the
+        // list immediately rather than waiting on PTY teardown.
+        unregisterExternalSession(runId, { exitCode });
 
-      // Kill the PTY if still alive — one-shot runs don't leave a session
-      // behind for the user to interact with.
-      try { if (ptyProcess && !ptyProcess.killed) ptyProcess.kill(); } catch { /* already gone */ }
+        // Kill the PTY if still alive — one-shot runs don't leave a session
+        // behind for the user to interact with.
+        try { if (ptyProcess && !ptyProcess.killed) ptyProcess.kill(); } catch { /* already gone */ }
 
-      // Prefer the response file the TUI was directed to write; fall back
-      // to the ANSI-stripped screen scrape when the file is missing/empty
-      // or the run didn't succeed. Logic lives in `resolveTuiResponseText`
-      // so it can be unit-tested without a live PTY.
-      const { text: responseText, usedResponseFile } = await resolveTuiResponseText({
-        success, responseFilePath, outputBuffer, wrappedPrompt,
-      });
+        // Prefer the response file the TUI was directed to write; fall back
+        // to the ANSI-stripped screen scrape when the file is missing/empty
+        // or the run didn't succeed. Logic lives in `resolveTuiResponseText`
+        // so it can be unit-tested without a live PTY.
+        const { text: responseText, usedResponseFile } = await resolveTuiResponseText({
+          success, responseFilePath, outputBuffer, wrappedPrompt,
+        });
 
-      // Delegate run-record finalization (output.txt + metadata.json merge
-      // + onRunCompleted/onRunFailed hooks + toolkit error analysis) to the
-      // shared runner helper. `completionReason` lands in `extras` so it
-      // gets persisted to metadata.json BEFORE the write (was previously
-      // set post-write and never made it to disk → /runs replay missed it).
-      const metadata = await finalizeRunRecord({
-        runId, output: responseText, exitCode, success, error, startTime,
-        extras: { completionReason: reason, usedResponseFile, outputTruncated: outputBufferTruncated },
-      }).catch((err) => {
-        console.error(`❌ TUI run ${runId} finalize failed: ${err.message}`);
-        return {
-          exitCode, success, error: error || err.message,
-          duration: Date.now() - startTime, completionReason: reason,
-        };
-      });
-      onComplete?.({ ...metadata, text: responseText, usedResponseFile, outputTruncated: outputBufferTruncated });
-      resolve();
+        // Delegate run-record finalization (output.txt + metadata.json merge
+        // + onRunCompleted/onRunFailed hooks + toolkit error analysis) to the
+        // shared runner helper. `completionReason` lands in `extras` so it
+        // gets persisted to metadata.json BEFORE the write (was previously
+        // set post-write and never made it to disk → /runs replay missed it).
+        const metadata = await finalizeRunRecord({
+          runId, output: responseText, exitCode, success, error, startTime,
+          extras: { completionReason: reason, usedResponseFile, outputTruncated: outputBufferTruncated },
+        }).catch((err) => {
+          console.error(`❌ TUI run ${runId} finalize failed: ${err.message}`);
+          return {
+            exitCode, success, error: error || err.message,
+            duration: Date.now() - startTime, completionReason: reason,
+          };
+        });
+        onComplete?.({ ...metadata, text: responseText, usedResponseFile, outputTruncated: outputBufferTruncated });
+      } catch (err) {
+        console.error(`❌ TUI run ${runId} finish() failed: ${err?.message || err}`);
+      } finally {
+        resolve();
+      }
     };
 
     ptyProcess.onData((data) => {

--- a/server/lib/tuiPromptRunner.js
+++ b/server/lib/tuiPromptRunner.js
@@ -279,6 +279,11 @@ ${prompt}`;
     const finish = async ({ success, exitCode = 0, error = null, reason = 'completed' }) => {
       if (finalized) return;
       finalized = true;
+      // Tracks whether the normal-path onComplete was reached, so the catch
+      // below re-surfaces failure ONLY when a step BEFORE onComplete threw —
+      // never re-invoking onComplete when onComplete itself was the throw
+      // source (that would violate the once-only completion contract).
+      let onCompleteInvoked = false;
       // finish() is invoked fire-and-forget from PTY/timer callbacks outside the
       // request lifecycle (onData, onExit, sendPrompt's write-catch,
       // responseFileWatchTimer, hardTimeoutTimer) — none of them await or
@@ -321,9 +326,16 @@ ${prompt}`;
             duration: Date.now() - startTime, completionReason: reason,
           };
         });
+        onCompleteInvoked = true;
         onComplete?.({ ...metadata, text: responseText, usedResponseFile, outputTruncated: outputBufferTruncated });
       } catch (err) {
         console.error(`❌ TUI run ${runId} finish() failed: ${err?.message || err}`);
+        // Ensure the original PTY is torn down even when a cleanup step BEFORE
+        // the kill above threw (e.g. unregisterExternalSession). Otherwise the
+        // failure we report below rejects executeProviderRunOnce and spins up a
+        // fallback provider while the original PTY keeps running — two live runs
+        // for one request. Idempotent: no-op if the kill above already fired.
+        try { if (ptyProcess && !ptyProcess.killed) ptyProcess.kill(); } catch { /* already gone */ }
         // A step BEFORE onComplete threw, so the caller's onComplete-driven
         // settle never fired. executeProviderRunOnce (promptRunner.js) settles
         // its OUTER Promise only via onComplete (→ safeReject) or the returned
@@ -331,17 +343,21 @@ ${prompt}`;
         // rejects), so `.catch(safeReject)` won't fire either. Without this,
         // resolving the inner promise leaves the central-prompt/pipeline caller
         // pending forever — the exact hang this patch exists to prevent. Deliver
-        // failure metadata so onComplete → safeReject settles the caller. Guard
-        // the callback itself: if IT was the throw source, don't re-throw out of
-        // finish() (which is un-awaited — an escape would become an unhandled
-        // rejection) and still fall through to resolve().
-        try {
-          onComplete?.({
-            runId, success: false, exitCode, error: `finish() failed: ${err?.message || err}`,
-            duration: Date.now() - startTime, completionReason: reason,
-          });
-        } catch (cbErr) {
-          console.error(`❌ TUI run ${runId} onComplete threw during finish() error handling: ${cbErr?.message || cbErr}`);
+        // failure metadata so onComplete → safeReject settles the caller. Skip
+        // this when onComplete itself was the throw source (onCompleteInvoked) —
+        // re-invoking it would break the once-only completion contract and could
+        // emit a contradictory success-then-failure. Guard the callback so a
+        // throw here doesn't escape finish() (un-awaited → unhandled rejection)
+        // and still fall through to resolve().
+        if (!onCompleteInvoked) {
+          try {
+            onComplete?.({
+              runId, success: false, exitCode, error: `finish() failed: ${err?.message || err}`,
+              duration: Date.now() - startTime, completionReason: reason,
+            });
+          } catch (cbErr) {
+            console.error(`❌ TUI run ${runId} onComplete threw during finish() error handling: ${cbErr?.message || cbErr}`);
+          }
         }
       } finally {
         resolve();

--- a/server/lib/tuiPromptRunner.test.js
+++ b/server/lib/tuiPromptRunner.test.js
@@ -753,6 +753,29 @@ describe('executeTuiRun', () => {
         success: false,
         error: expect.stringContaining('finish() failed'),
       }));
+      expect(onComplete).toHaveBeenCalledTimes(1);
+      // The PTY must still be torn down on the throw path — the failure we
+      // report spins up a fallback provider in the real caller, and a
+      // never-killed original PTY would run alongside it (two live runs).
+      expect(ptyInstances[0].kill).toHaveBeenCalled();
+    });
+
+    it('does not re-invoke onComplete when onComplete itself throws inside finish()', async () => {
+      // When the throw source is onComplete AFTER it has already been reached,
+      // the catch must NOT call onComplete a second time — that would violate
+      // the once-only completion contract and could emit a contradictory
+      // success-then-failure. The run promise must still resolve exactly once.
+      const provider = { id: 'claude', type: 'tui', command: 'echo' };
+      const onComplete = vi.fn(() => { throw new Error('boom: caller onComplete blew up'); });
+      const promise = executeTuiRun({ runId: 'run-oncomplete-throws', provider, prompt: 'a prompt long enough', workspacePath: '/cwd', onComplete, timeout: 60000 });
+      await flushAsync();
+
+      ptyInstances[0].emitExit({ exitCode: 0 });
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('finish() failed'));
+      // Reached exactly once (the normal-path call), never re-invoked by the catch.
+      expect(onComplete).toHaveBeenCalledTimes(1);
     });
 
     it('finishes with reason "killed" and surfaces the signal in the error when the PTY is terminated', async () => {

--- a/server/lib/tuiPromptRunner.test.js
+++ b/server/lib/tuiPromptRunner.test.js
@@ -723,6 +723,30 @@ describe('executeTuiRun', () => {
       }));
     });
 
+    it('still resolves the run promise exactly once when a step inside finish() throws synchronously', async () => {
+      // unregisterExternalSession is invoked un-awaited inside finish()'s try
+      // block, with no per-call try/catch of its own — unlike the PTY kill
+      // (own try/catch) and finalizeRunRecord (own .catch()). If it throws,
+      // finish()'s outer try/catch/finally must still guarantee `resolve()`
+      // fires — otherwise executeTuiRun's promise hangs forever and any
+      // caller awaiting it (pipeline stages, /runs) wedges.
+      shellMocks.unregisterExternalSession.mockImplementationOnce(() => {
+        throw new Error('boom: session registry corrupted');
+      });
+      const provider = { id: 'claude', type: 'tui', command: 'echo' };
+      const onComplete = vi.fn();
+      const promise = executeTuiRun({ runId: 'run-finish-throws', provider, prompt: 'a prompt long enough', workspacePath: '/cwd', onComplete, timeout: 60000 });
+      await flushAsync();
+
+      ptyInstances[0].emitExit({ exitCode: 0 });
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(console.error).toHaveBeenCalledWith(expect.stringContaining('finish() failed'));
+      // The throw happens before onComplete is reached in finish()'s body,
+      // so onComplete must never fire for this run.
+      expect(onComplete).not.toHaveBeenCalled();
+    });
+
     it('finishes with reason "killed" and surfaces the signal in the error when the PTY is terminated', async () => {
       const provider = { id: 'claude', type: 'tui', command: 'echo' };
       const promise = executeTuiRun({ runId: 'run-killed', provider, prompt: 'a prompt long enough', workspacePath: '/cwd', onData: undefined, onComplete: undefined, timeout: 60000 });

--- a/server/lib/tuiPromptRunner.test.js
+++ b/server/lib/tuiPromptRunner.test.js
@@ -742,9 +742,17 @@ describe('executeTuiRun', () => {
 
       await expect(promise).resolves.toBeUndefined();
       expect(console.error).toHaveBeenCalledWith(expect.stringContaining('finish() failed'));
-      // The throw happens before onComplete is reached in finish()'s body,
-      // so onComplete must never fire for this run.
-      expect(onComplete).not.toHaveBeenCalled();
+      // The throw happens before onComplete is reached in finish()'s normal
+      // path, but resolving the inner promise alone is not enough: the sole
+      // caller (executeProviderRunOnce) settles its OUTER promise only via
+      // onComplete (→ safeReject) or a rejected promise. Since finish() always
+      // resolves, the catch must still surface the failure through onComplete
+      // with failure metadata, or the pipeline/central-prompt caller hangs
+      // forever despite the inner promise settling.
+      expect(onComplete).toHaveBeenCalledWith(expect.objectContaining({
+        success: false,
+        error: expect.stringContaining('finish() failed'),
+      }));
     });
 
     it('finishes with reason "killed" and surfaces the signal in the error when the PTY is terminated', async () => {


### PR DESCRIPTION
## Better Audit — Code Quality & Style

### Summary
The async `finish()` closure in `tuiPromptRunner.js` is invoked fire-and-forget from PTY/timer callbacks outside the request lifecycle. A throw inside it (e.g. a caller-supplied `onComplete`) left `executeTuiRun`'s promise permanently unresolved — the run never finalized, the PTY was never killed, and the caller hung forever with the run stuck in `/runs`.

### Changes
- Wrap `finish()`'s body in `try/catch` with `resolve()` in a `finally`, mirroring the sibling `agentTuiSpawning.js` which documents the same callback-boundary hazard. The `finalized` guard still ensures exactly-once settlement.
- Added a regression test proving the promise still settles when an inner step throws (verified to fail when the try/finally is removed).

**Merge order:** Independent — each PR owns a disjoint set of files (no cross-branch imports), so they can be merged in any order.

Part of the /do:better audit (2026-07-21). Deferred structural refactors and dependency CVEs from the same audit are tracked as issues #2832–#2848.