### PR TITLE
fix: add a timeout to execGh so a stalled gh CLI call can't hang scheduled jobs

### DIFF
--- a/server/services/github.js
+++ b/server/services/github.js
@@ -35,24 +35,45 @@ async function save(data) {
   cacheTimestamp = Date.now();
 }
 
+const DEFAULT_EXEC_GH_TIMEOUT_MS = 60000;
+
 /**
- * Execute a gh CLI command safely using spawn
+ * Execute a gh CLI command safely using spawn. `gh` hits the network, so a
+ * stalled call (bad credentials prompt, hung network) would otherwise leave
+ * the returned promise pending forever and wedge scheduled jobs (prWatcher,
+ * issueReconcile, branchReconcile, updateChecker) while orphaning the child
+ * process. `timeoutMs` kills the child and rejects with a clear error; it's
+ * cleared on normal exit so it never fires for a completed run.
  */
-export function execGh(args) {
+export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS) {
   return new Promise((resolve, reject) => {
     const child = spawn('gh', args, { shell: false, windowsHide: true });
     let stdout = '';
     let stderr = '';
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // setTimeout callback boundary — guard so a kill() throw can't crash
+      // the process (e.g. the child already exited between checks).
+      try { child.kill('SIGKILL'); } catch (err) { console.error(`❌ execGh: failed to kill timed-out 'gh ${args.join(' ')}': ${err.message}`); }
+      reject(new Error(`gh ${args.join(' ')} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
     child.stdout.on('data', (d) => { stdout += d.toString(); });
     child.stderr.on('data', (d) => { stderr += d.toString(); });
     child.on('close', (code) => {
+      if (timedOut) return;
+      clearTimeout(timer);
       if (code !== 0) {
         reject(new Error(stderr.trim() || `gh exited with code ${code}`));
       } else {
         resolve(stdout.trim());
       }
     });
-    child.on('error', (err) => reject(err));
+    child.on('error', (err) => {
+      if (timedOut) return;
+      clearTimeout(timer);
+      reject(err);
+    });
   });
 }
 

--- a/server/services/github.test.js
+++ b/server/services/github.test.js
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'events';
+
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, spawn: vi.fn() };
+});
+
+import { spawn } from 'child_process';
+import { execGh } from './github.js';
+
+const makeChild = () => {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  return child;
+};
+
+describe('execGh', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('rejects with a timeout error and kills the child when it never closes', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const promise = execGh(['api', 'slow'], 50);
+    // Suppress unhandled-rejection noise until we await below.
+    promise.catch(() => {});
+    vi.advanceTimersByTime(50);
+    await expect(promise).rejects.toThrow(/timed out after 50ms/);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('resolves with trimmed stdout on a successful close', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const promise = execGh(['api', 'repos'], 5000);
+    child.stdout.emit('data', Buffer.from('  {"ok":true}  \n'));
+    child.emit('close', 0);
+    await expect(promise).resolves.toBe('{"ok":true}');
+  });
+
+  it('rejects with stderr on a non-zero close', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const promise = execGh(['api', 'bad'], 5000);
+    child.stderr.emit('data', Buffer.from('not found'));
+    child.emit('close', 1);
+    await expect(promise).rejects.toThrow(/not found/);
+  });
+
+  it('falls back to a generic error message when stderr is empty on non-zero close', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const promise = execGh(['api', 'bad'], 5000);
+    child.emit('close', 7);
+    await expect(promise).rejects.toThrow(/gh exited with code 7/);
+  });
+
+  it('does not fire the timeout timer on a fast normal completion', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const promise = execGh(['api', 'fast'], 5000);
+    child.stdout.emit('data', Buffer.from('done'));
+    child.emit('close', 0);
+    await expect(promise).resolves.toBe('done');
+    // Advancing well past the timeout must not reject/kill after settling.
+    vi.advanceTimersByTime(10000);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('rejects on a child spawn error', async () => {
+    const child = makeChild();
+    spawn.mockReturnValue(child);
+    const promise = execGh(['api', 'x'], 5000);
+    child.emit('error', new Error('spawn gh ENOENT'));
+    await expect(promise).rejects.toThrow(/ENOENT/);
+  });
+});


### PR DESCRIPTION
## Better Audit — Bugs, Performance & Error Handling

### Summary
`execGh()` spawned the `gh` CLI (a network call) with no timeout, so a stalled call (hung network, credential prompt) left the awaiting promise pending forever — wedging the scheduled PR-watcher / issue- and branch-reconcile / update-check jobs and orphaning `gh` child processes.

### Changes
- Add a configurable timeout (60s default) that `SIGKILL`s the child and rejects with a clear error, cleared on normal exit. A `timedOut` flag prevents double-settle; the `kill()` is guarded (setTimeout-callback boundary). Backward compatible — all 8 existing 1-arg call sites keep the default.
- Added 6 tests (timeout+kill, normal resolve, non-zero reject, no-fire-on-fast-completion) — verified to fail when the timeout is removed.

**Merge order:** Independent — each PR owns a disjoint set of files (no cross-branch imports), so they can be merged in any order.

Part of the /do:better audit (2026-07-21). Deferred structural refactors and dependency CVEs from the same audit are tracked as issues #2832–#2848.