### PR TITLE
refactor: route localStorage through safeStorage and inline setTimeout delays through sleep()

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -95,6 +95,7 @@ import {
   Clapperboard
 } from 'lucide-react';
 /* global __APP_VERSION__ */
+import { safeReadStorage, safeWriteStorage } from '../lib/safeStorage';
 import Logo from './Logo';
 import { useErrorNotifications } from '../hooks/useErrorNotifications';
 import { useNotifications } from '../hooks/useNotifications';
@@ -455,10 +456,7 @@ export function SingleNavRow({ item, collapsed, active, badgeCount, pinned, onTo
 export default function Layout() {
   const location = useLocation();
   const navigate = useNavigate();
-  const [collapsed, setCollapsed] = useState(() => {
-    const saved = localStorage.getItem(SIDEBAR_KEY);
-    return saved === 'true';
-  });
+  const [collapsed, setCollapsed] = useState(() => safeReadStorage(SIDEBAR_KEY) === 'true');
   const [mobileOpen, setMobileOpen] = useState(false);
   const [expandedSections, setExpandedSections] = useState({});
   // Collapsed-sidebar flyout: hovering or focusing a section icon opens a
@@ -559,7 +557,7 @@ export default function Layout() {
   }, [manifestNav]);
 
   useEffect(() => {
-    localStorage.setItem(SIDEBAR_KEY, String(collapsed));
+    safeWriteStorage(SIDEBAR_KEY, String(collapsed));
   }, [collapsed]);
 
   // Build dynamic nav items with app children + pipeline series.

--- a/client/src/components/meatspace/post/MorseTrainer.jsx
+++ b/client/src/components/meatspace/post/MorseTrainer.jsx
@@ -4,6 +4,7 @@ import useDrawerTab from '../../../hooks/useDrawerTab';
 import { submitTrainingEntry, getTrainingStats, submitMorseRound, getMorseProgress, updateMorseLevel } from '../../../services/api';
 import MorseProgressPanel from './MorseProgressPanel';
 import { streakGlyph } from '../../../lib/streakGlyph.js';
+import { safeReadJsonStorage, safeWriteStorage } from '../../../lib/safeStorage';
 
 export const MORSE_TABLE = {
   A: '.-',     B: '-...',   C: '-.-.',   D: '-..',    E: '.',      F: '..-.',
@@ -134,15 +135,12 @@ export const MODES = [
 const TRAINING_MODULE = 'morse';
 
 function loadPrefs() {
-  const raw = typeof window !== 'undefined' ? window.localStorage.getItem(PREFS_KEY) : null;
-  if (!raw) return { ...DEFAULT_PREFS };
-  const parsed = JSON.parse(raw);
+  const parsed = safeReadJsonStorage(PREFS_KEY);
   return { ...DEFAULT_PREFS, ...parsed };
 }
 
 function savePrefs(prefs) {
-  if (typeof window === 'undefined') return;
-  window.localStorage.setItem(PREFS_KEY, JSON.stringify(prefs));
+  safeWriteStorage(PREFS_KEY, JSON.stringify(prefs));
 }
 
 function scheduleTone(gain, startSec, durationSec) {

--- a/client/src/components/meatspace/tabs/calendar/usePersistedState.js
+++ b/client/src/components/meatspace/tabs/calendar/usePersistedState.js
@@ -1,15 +1,14 @@
 import { useCallback, useState } from 'react';
+import { safeReadJsonStorage, safeWriteStorage } from '../../../../lib/safeStorage';
 
 const STORAGE_KEY = 'portos:life-calendar';
 
 function loadGridPrefs() {
-  const raw = localStorage.getItem(STORAGE_KEY);
-  if (!raw) return {};
-  return JSON.parse(raw);
+  return safeReadJsonStorage(STORAGE_KEY, {});
 }
 
 function saveGridPrefs(prefs) {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  safeWriteStorage(STORAGE_KEY, JSON.stringify(prefs));
 }
 
 // Per-key state persisted into a single localStorage blob shared by the Life Calendar.

--- a/client/src/components/moodBoard/MoodBoardReferenceStrip.jsx
+++ b/client/src/components/moodBoard/MoodBoardReferenceStrip.jsx
@@ -20,6 +20,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { LayoutGrid, ChevronDown, ChevronRight, ExternalLink, ImageIcon } from 'lucide-react';
 import { listMoodBoards, getMoodBoard } from '../../services/api';
 import { moodBoardItemSrc } from '../../lib/moodBoardItemSrc';
+import { safeReadStorage, safeWriteStorage } from '../../lib/safeStorage';
 
 const MAX_THUMBS = 12;
 
@@ -27,9 +28,7 @@ export default function MoodBoardReferenceStrip({ storageKey = 'create', classNa
   const lsKey = `portos.moodBoardRef.${storageKey}`;
   const [expanded, setExpanded] = useState(false);
   const [boards, setBoards] = useState(null); // null = not loaded, [] = loaded-empty
-  const [selectedId, setSelectedId] = useState(() => {
-    try { return localStorage.getItem(lsKey) || ''; } catch { return ''; }
-  });
+  const [selectedId, setSelectedId] = useState(() => safeReadStorage(lsKey) || '');
   const [detail, setDetail] = useState(null); // full board (with items) for selectedId
   const [loadingDetail, setLoadingDetail] = useState(false);
 
@@ -71,7 +70,7 @@ export default function MoodBoardReferenceStrip({ storageKey = 'create', classNa
 
   const handleSelect = useCallback((id) => {
     setSelectedId(id);
-    try { if (id) localStorage.setItem(lsKey, id); } catch { /* ignore quota/denied */ }
+    if (id) safeWriteStorage(lsKey, id);
   }, [lsKey]);
 
   const thumbs = useMemo(() => {

--- a/client/src/components/voice/VoiceWidget.jsx
+++ b/client/src/components/voice/VoiceWidget.jsx
@@ -25,6 +25,7 @@ import {
   isVoiceHiddenStorageEvent,
 } from '../../services/voiceVisibility';
 import { MicroGlyph } from '../micrographics';
+import { safeReadStorage, safeWriteStorage } from '../../lib/safeStorage';
 
 // Peak below this (0..1) is usually whisper's [BLANK_AUDIO] territory.
 const QUIET_MIC_THRESHOLD = 0.02;
@@ -84,8 +85,7 @@ export default function VoiceWidget() {
   // stop can tear down tracks from the freshly-started capture.
   const cancelInFlightRef = useRef(null);
   const [handsFree, setHandsFree] = useState(() => {
-    if (typeof window === 'undefined') return true;
-    const stored = window.localStorage.getItem(HANDS_FREE_KEY);
+    const stored = safeReadStorage(HANDS_FREE_KEY);
     return stored === null ? true : stored === '1';
   });
   const [hidden, setHidden] = useState(readVoiceHidden);
@@ -550,7 +550,7 @@ export default function VoiceWidget() {
   const toggleHandsFree = useCallback(() => {
     setHandsFree((prev) => {
       const next = !prev;
-      window.localStorage.setItem(HANDS_FREE_KEY, next ? '1' : '0');
+      safeWriteStorage(HANDS_FREE_KEY, next ? '1' : '0');
       // Discard any in-flight PTT recording — toggling modes mid-utterance
       // shouldn't send a partial turn to the server.
       if (isCapturing()) stopCapture({ submit: false });

--- a/client/src/components/writers-room/WorkEditor.jsx
+++ b/client/src/components/writers-room/WorkEditor.jsx
@@ -44,6 +44,7 @@ import {
   promoteWritersRoomWorkToPipeline,
 } from '../../services/apiWritersRoom';
 import { listCatalogIngredientsForRef } from '../../services/apiCatalog';
+import { safeReadStorage, safeWriteStorage } from '../../lib/safeStorage';
 import { STATUS_LABELS } from './labels';
 import { countWords } from '../../utils/formatters';
 import StoryboardPanel, { STORYBOARD_TAB, STORYBOARD_TAB_VALUES } from './StoryboardPanel';
@@ -80,24 +81,21 @@ const READING_THEME_KEY = 'wr.readingTheme';
 const SIDEBAR_TAB_KEY = 'wr.sidebarTab';
 
 function readReadingTheme() {
-  if (typeof window === 'undefined') return 'dark';
-  return window.localStorage.getItem(READING_THEME_KEY) === 'light' ? 'light' : 'dark';
+  return safeReadStorage(READING_THEME_KEY) === 'light' ? 'light' : 'dark';
 }
 
 function readSidebarWidth() {
-  if (typeof window === 'undefined') return SIDEBAR_DEFAULT;
-  const raw = window.localStorage.getItem(SIDEBAR_WIDTH_KEY);
+  const raw = safeReadStorage(SIDEBAR_WIDTH_KEY);
   const n = raw ? parseInt(raw, 10) : NaN;
   return Number.isFinite(n) && n >= SIDEBAR_MIN ? n : SIDEBAR_DEFAULT;
 }
 
 function persistSidebarWidth(width) {
-  try { window.localStorage.setItem(SIDEBAR_WIDTH_KEY, String(Math.round(width))); } catch { return undefined; }
+  safeWriteStorage(SIDEBAR_WIDTH_KEY, String(Math.round(width)));
 }
 
 function readSidebarTab() {
-  if (typeof window === 'undefined') return STORYBOARD_TAB.BOARDS;
-  const stored = window.localStorage.getItem(SIDEBAR_TAB_KEY);
+  const stored = safeReadStorage(SIDEBAR_TAB_KEY);
   return STORYBOARD_TAB_VALUES.includes(stored) ? stored : STORYBOARD_TAB.BOARDS;
 }
 
@@ -205,7 +203,7 @@ export default function WorkEditor({ work, onChange, onToggleExercise, exerciseO
   }, [setSearchParams]);
 
   useEffect(() => {
-    try { window.localStorage.setItem(SIDEBAR_TAB_KEY, sidebarTab); } catch { /* sandboxed storage */ }
+    safeWriteStorage(SIDEBAR_TAB_KEY, sidebarTab);
   }, [sidebarTab]);
 
   const textareaRef = useRef(null);
@@ -820,7 +818,7 @@ export default function WorkEditor({ work, onChange, onToggleExercise, exerciseO
   const toggleReadingTheme = useCallback(() => {
     setReadingTheme((prev) => {
       const next = prev === 'dark' ? 'light' : 'dark';
-      try { window.localStorage.setItem(READING_THEME_KEY, next); } catch { return next; }
+      safeWriteStorage(READING_THEME_KEY, next);
       return next;
     });
   }, []);

--- a/client/src/pages/Tribe.jsx
+++ b/client/src/pages/Tribe.jsx
@@ -29,6 +29,7 @@ import toast from '../components/ui/Toast';
 import TabPills from '../components/ui/TabPills';
 import TribeCircleMap from '../components/tribe/TribeCircleMap.jsx';
 import { copyToClipboard } from '../lib/clipboard.js';
+import { safeReadStorage, safeRemoveStorage } from '../lib/safeStorage.js';
 import {
   RINGS,
   ENERGY,
@@ -82,21 +83,11 @@ function parseStoredContacts(value) {
 }
 
 function getLegacyContacts() {
-  if (typeof window === 'undefined') return [];
-  try {
-    return parseStoredContacts(window.localStorage.getItem(STORAGE_KEY));
-  } catch {
-    return [];
-  }
+  return parseStoredContacts(safeReadStorage(STORAGE_KEY));
 }
 
 function clearLegacyContacts() {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    // Storage can be unavailable in restricted browser contexts.
-  }
+  safeRemoveStorage(STORAGE_KEY);
 }
 
 function StatTile({ icon: Icon, label, value, detail, className = '' }) {

--- a/server/cos-runner/index.js
+++ b/server/cos-runner/index.js
@@ -15,7 +15,7 @@ import { writeFile, readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import http from 'http';
 import { Server as SocketServer } from 'socket.io';
-import { ensureDir, PATHS } from '../lib/fileUtils.js';
+import { ensureDir, PATHS, sleep } from '../lib/fileUtils.js';
 import { prepareCliSpawn, killProcessTree } from '../lib/bufferedSpawn.js';
 import { prepareCliPrompt } from '../lib/cliProviderArgs.js';
 import { createCodexStderrFormatter } from '../lib/codexCliOutput.js';
@@ -656,7 +656,7 @@ process.on('SIGTERM', async () => {
   }
 
   // Wait for agents to terminate
-  await new Promise(resolve => setTimeout(resolve, SHUTDOWN_DRAIN_MS));
+  await sleep(SHUTDOWN_DRAIN_MS);
 
   server.close(() => {
     console.log('👋 CoS Agent Runner stopped');

--- a/server/integrations/moltbook/api.js
+++ b/server/integrations/moltbook/api.js
@@ -10,6 +10,7 @@
 import { checkRateLimit, recordAction, syncFromExternal } from './rateLimits.js';
 import { solveChallenge } from './challengeSolver.js';
 import { fetchWithTimeout } from '../../lib/fetchWithTimeout.js';
+import { sleep } from '../../lib/fileUtils.js';
 
 const API_BASE = 'https://www.moltbook.com/api/v1';
 const MOLTBOOK_TIMEOUT_MS = 10000;
@@ -501,7 +502,7 @@ export async function heartbeat(apiKey, options = {}) {
     engagements++;
 
     // Small delay between actions
-    await new Promise(resolve => setTimeout(resolve, 1000));
+    await sleep(1000);
   }
 
   console.log(`💓 Moltbook: Heartbeat complete - ${engagements} engagements`);

--- a/server/lib/collectionStore.js
+++ b/server/lib/collectionStore.js
@@ -25,20 +25,16 @@
  *   records. The agreed shape (see the `TypeIndexConfig` typedef below):
  *
  *     config: {
- *       runs?:         [],   // append-mostly cross-record history/audit log,
- *                            //   capped by the consumer (universeBuilder caps
- *                            //   at the last 200) — the established slot
- *       featureFlags?: {},   // reserved: per-collection toggles
- *       lockPolicies?: {},   // reserved: per-collection lock rules
- *       …                    // consumers MAY add their own keys; document the
- *                            //   shape next to the consumer that owns it
+ *       runs?: [],   // append-mostly cross-record history/audit log,
+ *                    //   capped by the consumer (universeBuilder caps
+ *                    //   at the last 200) — the established slot
+ *       …            // consumers MAY add their own keys; document the
+ *                    //   shape next to the consumer that owns it
  *     }
  *
- *   `runs` is the only slot with a shipped consumer; `featureFlags` /
- *   `lockPolicies` are reserved names so the next consumer reuses them instead
- *   of inventing a synonym. Treat the slot as open-but-conventional: prefer a
- *   reserved name when one fits, and keep each key's value an object or array
- *   so the shallow-merge semantics below stay predictable.
+ *   `runs` is the only slot with a shipped consumer today. Treat the slot as
+ *   open-but-conventional: each key's value should be an object or array so
+ *   the shallow-merge semantics below stay predictable.
  *
  *   Merge semantics: `saveTypeIndex({ config })` shallow-merges at the TOP
  *   level of `config` — `{ ...current.config, ...patch.config }`. A patch that
@@ -104,19 +100,14 @@ const RESERVED_IDS = new Set(['__proto__', 'constructor', 'prototype']);
  * The type-index `config` slot — cross-record state owned by the collection as
  * a whole. See the header doc block for the convention. All keys are optional;
  * a consumer that needs a slot not listed here MAY add its own (document it
- * next to the consumer), but should prefer a reserved name when one fits. Each
- * value should be an array or plain object so the top-level shallow-merge in
- * `saveTypeIndex` stays predictable.
+ * next to the consumer). Each value should be an array or plain object so the
+ * top-level shallow-merge in `saveTypeIndex` stays predictable.
  *
  * @typedef {object} TypeIndexConfig
  * @property {Array<object>} [runs]
  *   Append-mostly cross-record history/audit log. The consumer is responsible
  *   for capping growth (universeBuilder keeps the last 200) and for sanitizing
  *   each entry on read/write. The only slot with a shipped consumer today.
- * @property {Object<string, boolean>} [featureFlags]
- *   Reserved: per-collection on/off toggles.
- * @property {Object<string, object>} [lockPolicies]
- *   Reserved: per-collection lock rules.
  */
 
 /**

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -16,7 +16,7 @@ import { getActiveProvider } from './providers.js';
 import { markProviderUsageLimit, markProviderRateLimited } from './providerStatus.js';
 import { MAX_TOTAL_SPAWNS, normalizeReviewers } from '../lib/validation.js';
 import { isInternalTaskId } from '../lib/taskParser.js';
-import { ensureDir, PATHS, tryReadFile } from '../lib/fileUtils.js';
+import { ensureDir, PATHS, sleep, tryReadFile } from '../lib/fileUtils.js';
 import { createToolExecution, startExecution, completeExecution, errorExecution } from './toolStateMachine.js';
 import { determineLane, acquire, release } from './executionLanes.js';
 import { analyzeAgentFailure, resolveFailedTaskUpdate, resolveTypeFailureSignal } from './agentErrorAnalysis.js';
@@ -650,7 +650,7 @@ export async function waitForRunnerStability() {
       const waitTime = Math.ceil(RUNNER_MIN_UPTIME_SECONDS - health.uptime);
       emitLog('info', `Waiting ${waitTime}s for runner stability (uptime: ${Math.floor(health.uptime)}s)`, { uptime: health.uptime });
     }
-    await new Promise(resolve => setTimeout(resolve, checkIntervalMs));
+    await sleep(checkIntervalMs);
   }
 
   emitLog('warn', 'Runner stability check timed out, proceeding anyway', {});

--- a/server/services/browserService.js
+++ b/server/services/browserService.js
@@ -9,7 +9,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { join, basename, resolve, extname } from 'path';
 import { EventEmitter } from 'events';
-import { ensureDir, safeJSONParse, PATHS, tryReadFile, atomicWrite } from '../lib/fileUtils.js';
+import { ensureDir, safeJSONParse, PATHS, tryReadFile, atomicWrite, sleep } from '../lib/fileUtils.js';
 import { normalizeBrowserConfig } from '../lib/browserConfig.js';
 import { fetchWithTimeout } from '../lib/fetchWithTimeout.js';
 import { readResponseJson } from '../lib/readResponseJson.js';
@@ -130,7 +130,7 @@ async function pm2Action(action, args) {
   console.log(`✅ Browser PM2 ${action} complete`);
 
   // Give PM2 a moment to settle
-  await new Promise(resolve => setTimeout(resolve, PM2_SETTLE_MS));
+  await sleep(PM2_SETTLE_MS);
 
   const status = await getHealthStatus();
   browserEvents.emit('status:changed', status);

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -24,7 +24,7 @@ import { getPerformanceSummary, checkAndRehabilitateSkippedTasks, getLearningIns
 import { schedule as scheduleEvent, cancel as cancelEvent, getStats as getSchedulerStats } from './eventScheduler.js';
 import { generateProactiveTasks as generateMissionTasks } from './missions.js';
 import { recordJobExecution } from './autonomousJobs.js';
-import { atomicWrite, safeJSONParse } from '../lib/fileUtils.js';
+import { atomicWrite, safeJSONParse, sleep } from '../lib/fileUtils.js';
 import { addNotification, NOTIFICATION_TYPES } from './notifications.js';
 import { getUserTimezone, todayInTimezone } from '../lib/timezone.js';
 import { normalizeDomainAutonomy, getDomainMode } from '../lib/domainAutonomy.js';
@@ -232,7 +232,7 @@ export async function start() {
   const { cdRecoveryDone } = await import('./creativeDirector/recovery.js');
   await Promise.race([
     cdRecoveryDone,
-    new Promise((resolve) => setTimeout(resolve, CD_RECOVERY_BOOT_TIMEOUT_MS)),
+    sleep(CD_RECOVERY_BOOT_TIMEOUT_MS),
   ]);
 
   // Then reset any orphaned in_progress tasks (no running agent)

--- a/server/services/localLlm.js
+++ b/server/services/localLlm.js
@@ -28,7 +28,7 @@ import { join } from 'path'
 import { tmpdir } from 'os'
 import { pipeline } from 'stream/promises'
 import { Readable } from 'stream'
-import { PATHS, atomicWrite, ensureDir, pathExists } from '../lib/fileUtils.js'
+import { PATHS, atomicWrite, ensureDir, pathExists, sleep } from '../lib/fileUtils.js'
 import { compareSemver } from '../lib/versionUtils.js'
 import { isBackend, mapModelToBackend } from '../lib/localLlmCatalog.js'
 import { sanitizeOllamaName } from '../lib/localLlmDisk.js'
@@ -412,7 +412,7 @@ async function waitForOllamaVersion(timeoutMs = 30_000) {
   while (Date.now() < deadline) {
     const v = await readOllamaVersion()
     if (v) return v
-    await new Promise((resolve) => setTimeout(resolve, 500))
+    await sleep(500)
   }
   return null
 }
@@ -475,7 +475,7 @@ async function upgradeOllamaMacApp(emit) {
   await runStreaming('pkill', ['-x', 'Ollama'], () => {}, 10_000).catch(() => null)
   await runStreaming('pkill', ['-x', 'ollama'], () => {}, 10_000).catch(() => null)
   // Brief settle so the OS releases the bundle before we replace it.
-  await new Promise((resolve) => setTimeout(resolve, 1500))
+  await sleep(1500)
 
   emit('Extracting…')
   const unzip = await runStreaming('unzip', ['-q', '-o', zipPath, '-d', tmpDir], emit, 5 * 60 * 1000)

--- a/server/services/ollamaManager.js
+++ b/server/services/ollamaManager.js
@@ -21,7 +21,7 @@ import { execFile, spawn } from 'child_process'
 import { promisify } from 'util'
 import { fetchWithTimeout } from '../lib/fetchWithTimeout.js'
 import { readResponseJson } from '../lib/readResponseJson.js'
-import { readJSONFile, sha256File, safeJSONParse, ensureDir } from '../lib/fileUtils.js'
+import { readJSONFile, sha256File, safeJSONParse, ensureDir, sleep } from '../lib/fileUtils.js'
 import {
   parseOllamaManifest, parseOllamaModelRef, ollamaManifestRelPath, digestToBlobFilename, buildModelfile
 } from '../lib/localLlmDisk.js'
@@ -188,7 +188,7 @@ async function waitForAvailability(expected, timeoutMs) {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline) {
     if ((await checkOllamaAvailable(true)) === expected) return true
-    await new Promise((resolve) => setTimeout(resolve, 400))
+    await sleep(400)
   }
   return (await checkOllamaAvailable(true)) === expected
 }
@@ -672,7 +672,7 @@ async function pullModel(modelId, onProgress) {
     const delayMs = PULL_RETRY_BASE_DELAY_MS * attempt
     console.warn(`🔁 Ollama pull ${modelId} hit transient error "${lastError}" (attempt ${attempt}/${PULL_MAX_ATTEMPTS}); retrying in ${delayMs}ms`)
     if (typeof onProgress === 'function') onProgress({ status: 'retrying after network error', percent: null, retrying: true })
-    await new Promise((resolve) => setTimeout(resolve, delayMs))
+    await sleep(delayMs)
   }
 
   console.error(`⚠️ Ollama pull failed for ${modelId}: ${lastError}`)

--- a/server/services/worktreeManager.js
+++ b/server/services/worktreeManager.js
@@ -12,7 +12,7 @@
 import { existsSync, realpathSync } from 'fs';
 import { readdir, rm, stat } from 'fs/promises';
 import { join } from 'path';
-import { ensureDir, PATHS, tryReadFile } from '../lib/fileUtils.js';
+import { ensureDir, PATHS, sleep, tryReadFile } from '../lib/fileUtils.js';
 import { execGit } from '../lib/execGit.js';
 import { createKeyCachedQueue } from '../lib/createKeyCachedQueue.js';
 import { ensureInstanceId } from './instances.js';
@@ -67,7 +67,7 @@ export function addWorktreeWithRetry(args, repo, attempt = 1, firstError = null)
       throw err;
     }
     console.log(`🌳 Worktree add lock contention (attempt ${attempt}/${WORKTREE_ADD_MAX_ATTEMPTS}), retrying in ${WORKTREE_ADD_RETRY_DELAY_MS}ms: ${err.message}`);
-    return new Promise(resolve => setTimeout(resolve, WORKTREE_ADD_RETRY_DELAY_MS))
+    return sleep(WORKTREE_ADD_RETRY_DELAY_MS)
       .then(() => addWorktreeWithRetry(args, repo, attempt + 1, originalError));
   });
 }


### PR DESCRIPTION
## Better Audit — DRY & YAGNI

### Summary
Consolidate two duplicated patterns onto existing canonical helpers, and drop dead config slots.

### Changes
- **[HIGH]** Route inline `localStorage` access through the existing `safeStorage.js` helpers in 7 client files (Layout, MorseTrainer, calendar persisted-state, MoodBoard, VoiceWidget, WorkEditor, Tribe). Several sites were **unguarded** and threw uncaught in Safari private-mode/sandboxed-storage — now they degrade gracefully.
- **[HIGH]** Replace inline `new Promise(r => setTimeout(r, …))` delays with the existing `sleep(ms)` from `fileUtils.js` across 9 server modules (delay values preserved).
- **[MEDIUM]** Remove the unused `featureFlags`/`lockPolicies` reserved slots from `collectionStore`'s typedef (zero consumers).

### Files
7 client components + 8 server services/integrations + collectionStore.js

**Merge order:** Independent — each PR owns a disjoint set of files (no cross-branch imports), so they can be merged in any order.

Part of the /do:better audit (2026-07-21). Deferred structural refactors and dependency CVEs from the same audit are tracked as issues #2832–#2848.