### PR TITLE
fix: guard stale fetch, pair label htmlFor/id, make clickable divs keyboard-accessible

### DIFF
--- a/client/src/components/NotificationDropdown.jsx
+++ b/client/src/components/NotificationDropdown.jsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Bell, X, CheckCheck, Trash2, Brain, ListTodo, AlertTriangle, Code, HelpCircle, BellRing, Sparkles } from 'lucide-react';
 import { timeAgo } from '../utils/formatters';
+import { clickableProps } from '../lib/a11yKeyboard';
 
 const NOTIFICATION_TYPE_CONFIG = {
   memory_approval: {
@@ -161,8 +162,6 @@ export default function NotificationDropdown({
                 return (
                   <div
                     key={notification.id}
-                    role="menuitem"
-                    tabIndex={0}
                     className={`
                       group px-4 py-3 border-b border-port-border last:border-b-0 cursor-pointer
                       hover:bg-port-border/50 transition-colors focus:outline-hidden focus:bg-port-border/50
@@ -170,7 +169,7 @@ export default function NotificationDropdown({
                       border-l-2 ${PRIORITY_COLORS[notification.priority] || PRIORITY_COLORS.medium}
                     `}
                     onClick={() => handleNotificationClick(notification)}
-                    onKeyDown={(e) => e.key === 'Enter' && handleNotificationClick(notification)}
+                    {...clickableProps(() => handleNotificationClick(notification), { role: 'menuitem' })}
                   >
                     <div className="flex items-start gap-3">
                       <div className={`p-1.5 rounded ${config.bgColor}`} aria-hidden="true">

--- a/client/src/components/agents/AgentList.jsx
+++ b/client/src/components/agents/AgentList.jsx
@@ -335,16 +335,18 @@ export default function AgentList() {
             </FormField>
 
             <div className="flex items-center gap-4 mb-4">
-              <label className="block text-sm text-gray-400">Avatar Emoji</label>
+              <label htmlFor="agent-avatar-emoji" className="block text-sm text-gray-400">Avatar Emoji</label>
               <input
+                id="agent-avatar-emoji"
                 type="text"
                 value={formData.avatar.emoji || ''}
                 onChange={(e) => setFormData({ ...formData, avatar: { ...formData.avatar, emoji: e.target.value } })}
                 className="w-16 px-3 py-2 bg-port-bg border border-port-border rounded text-white text-center"
                 maxLength={2}
               />
-              <label className="block text-sm text-gray-400">Color</label>
+              <label htmlFor="agent-avatar-color" className="block text-sm text-gray-400">Color</label>
               <input
+                id="agent-avatar-color"
                 type="color"
                 value={formData.avatar.color || '#3b82f6'}
                 onChange={(e) => setFormData({ ...formData, avatar: { ...formData.avatar, color: e.target.value } })}

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -7,6 +7,7 @@ import { processScreenshotUploads, processAttachmentUploads } from '../../utils/
 import { formatBytes } from '../../utils/formatters';
 import { filterSelectableModels, isTuiProvider, isCliProvider, isProcessProvider, isCodexProvider, effortLevelsForProvider } from '../../utils/providers';
 import { DEFAULT_REVIEWERS, DEFAULT_REVIEW_STOP_MODE } from './constants';
+import { clickableProps } from '../../lib/a11yKeyboard';
 import ReviewerPicker from './ReviewerPicker';
 
 export default function TaskAddForm({ providers, apps, onTaskAdded, compact = false, defaultExpanded = false, defaultApp = '' }) {
@@ -374,10 +375,8 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
               {templates.map(template => (
                 <div
                   key={template.id}
-                  role="button"
-                  tabIndex={0}
                   onClick={() => applyTemplate(template)}
-                  onKeyDown={(e) => e.key === 'Enter' && applyTemplate(template)}
+                  {...clickableProps(() => applyTemplate(template))}
                   className="group relative flex items-center gap-1.5 px-3 py-1.5 bg-port-card border border-port-border rounded-lg text-sm text-gray-300 hover:text-white hover:border-port-accent/50 transition-colors cursor-pointer"
                   title={template.description}
                 >

--- a/client/src/components/digital-twin/NextActionBanner.jsx
+++ b/client/src/components/digital-twin/NextActionBanner.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Sparkles,
@@ -79,9 +79,15 @@ export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
     setQuestion(null);
   }, [gapKey]);
 
+  // Guards against an older in-flight request overwriting state after a newer
+  // one has already resolved (e.g. activeCategory changes again mid-fetch).
+  const requestIdRef = useRef(0);
+
   const loadQuestion = useCallback(async (category, skipList = []) => {
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     const q = await api.getDigitalTwinEnrichQuestion(category, undefined, undefined, skipList.length ? skipList : undefined).catch(() => null);
+    if (requestId !== requestIdRef.current) return; // stale response — a newer request superseded this one
     if (!q) {
       // Category exhausted — advance to the next gap with available questions
       setCurrentGapIdx(prev => {

--- a/client/src/components/meatspace/post/ElementsSong.jsx
+++ b/client/src/components/meatspace/post/ElementsSong.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { ChevronLeft, ChevronRight, BookOpen, Zap, Target, Check, X, SkipForward, Loader, Search, Eye, BarChart3, Gauge, Layers, RotateCw } from 'lucide-react';
 import { submitMemoryPractice, getMemoryMastery, getMemoryItem } from '../../../services/api';
 import { RapidReaderModal } from '../../RapidReader';
+import { clickableProps } from '../../../lib/a11yKeyboard';
 
 // Standard periodic table layout: [row][col] = symbol or null
 const PERIODIC_TABLE = [
@@ -226,6 +227,7 @@ function ElementsSongMain({ item, mastery, setMode, onBack }) {
                     }}
                     onMouseLeave={() => { setHoveredElement(null); setHoverPos(null); }}
                     onClick={() => setSelectedElement(prev => prev === sym ? null : sym)}
+                    {...clickableProps(() => setSelectedElement(prev => prev === sym ? null : sym))}
                   >
                     {atomicNum && <span className="text-[7px] leading-none opacity-50 absolute top-0.5 left-1">{atomicNum}</span>}
                     <span className="text-[10px] leading-none font-semibold">{sym}</span>

--- a/client/src/pages/Sharing.jsx
+++ b/client/src/pages/Sharing.jsx
@@ -367,11 +367,12 @@ function SharingBuckets({ selectedId }) {
             </FormField>
           </div>
           <div>
-            <label className="block text-xs uppercase tracking-wider text-gray-500 mb-1">
+            <label htmlFor="share-folder-path" className="block text-xs uppercase tracking-wider text-gray-500 mb-1">
               Folder path
             </label>
             <div className="flex gap-2 items-stretch">
               <input
+                id="share-folder-path"
                 type="text"
                 value={form.path}
                 onChange={(e) => setForm((f) => ({ ...f, path: e.target.value }))}

--- a/client/src/pages/StoryBuilder.jsx
+++ b/client/src/pages/StoryBuilder.jsx
@@ -709,9 +709,10 @@ function RefineBox({ onRefine, disabled, busy, running, phase }) {
   const [feedback, setFeedback] = useState('');
   return (
     <div className="border-t border-port-border pt-3 mt-3">
-      <label className="block text-xs text-gray-500 mb-1">AI refinement feedback</label>
+      <label htmlFor="story-refine-feedback" className="block text-xs text-gray-500 mb-1">AI refinement feedback</label>
       <div className="flex gap-2">
         <input
+          id="story-refine-feedback"
           type="text" value={feedback} onChange={(e) => setFeedback(e.target.value)}
           placeholder="e.g. make the midpoint reveal land harder"
           disabled={disabled || busy}


### PR DESCRIPTION
## Better Audit — Stack-Specific (Node/React)

### Summary
React correctness + accessibility fixes.

### Changes
- **[MEDIUM]** `NextActionBanner` question fetch now uses a request-generation guard so a slow earlier response can't overwrite a newer question.
- **[MEDIUM]** Pair `<label htmlFor>`/`id` on the Avatar Emoji/Color (AgentList), Folder path (Sharing), and AI-refinement (StoryBuilder) inputs (PortOS requires the pairing).
- **[MEDIUM/LOW]** Make hand-rolled clickable elements keyboard-accessible via the shared `clickableProps` helper: ElementsSong element tile (was unreachable by keyboard), NotificationDropdown row and TaskAddForm template picker (were Enter-only — Space now works).

**Merge order:** Independent — each PR owns a disjoint set of files (no cross-branch imports), so they can be merged in any order.

Part of the /do:better audit (2026-07-21). Deferred structural refactors and dependency CVEs from the same audit are tracked as issues #2832–#2848.