### PR TITLE
fix: dvh-cap full-screen layouts, track port-bg token on canvases, touch-visible affordance

### DIFF
--- a/client/src/components/ErrorBoundary.jsx
+++ b/client/src/components/ErrorBoundary.jsx
@@ -25,7 +25,7 @@ export default class ErrorBoundary extends Component {
       // full-screen DOM error UI can't render.
       if (this.props.fallback !== undefined) return this.props.fallback;
       return (
-        <div className="min-h-screen bg-port-bg flex items-center justify-center p-4">
+        <div className="min-h-dvh-cap bg-port-bg flex items-center justify-center p-4">
           <div className="bg-port-card border border-port-border rounded-xl p-8 max-w-md w-full">
             <div className="flex items-center justify-center mb-4">
               <AlertTriangle size={32} className="text-port-error" />

--- a/client/src/components/ProactiveAlertsWidget.jsx
+++ b/client/src/components/ProactiveAlertsWidget.jsx
@@ -152,7 +152,7 @@ const ProactiveAlertsWidget = memo(function ProactiveAlertsWidget() {
                     {alert.detail}
                   </div>
                 </div>
-                <ChevronRight size={14} className="mt-0.5 shrink-0 text-gray-600 opacity-0 group-hover:opacity-100 transition-opacity" />
+                <ChevronRight size={14} className="mt-0.5 shrink-0 text-gray-600 opacity-40 sm:opacity-0 sm:group-hover:opacity-100 transition-opacity" />
               </Link>
             );
           })}

--- a/client/src/components/brain/tabs/BrainGraph.jsx
+++ b/client/src/components/brain/tabs/BrainGraph.jsx
@@ -514,7 +514,7 @@ export default function BrainGraph() {
           <Canvas
             camera={{ position: [0, 0, 80], fov: 50 }}
             dpr={[1, 1.5]}
-            style={{ background: '#0f0f0f' }}
+            style={{ background: 'rgb(var(--port-bg))' }}
             gl={{ antialias: true }}
             onPointerMissed={handlePointerMissed}
           >

--- a/client/src/components/cos/tabs/MemoryGraph.jsx
+++ b/client/src/components/cos/tabs/MemoryGraph.jsx
@@ -224,7 +224,7 @@ export default function MemoryGraph() {
           <Canvas
             camera={{ position: [0, 0, 80], fov: 50 }}
             dpr={[1, 1.5]}
-            style={{ background: '#0f0f0f' }}
+            style={{ background: 'rgb(var(--port-bg))' }}
             gl={{ antialias: true }}
             onPointerMissed={handlePointerMissed}
           >

--- a/client/src/components/goals/GoalsTreeView.jsx
+++ b/client/src/components/goals/GoalsTreeView.jsx
@@ -515,7 +515,7 @@ export default function GoalsTreeView({ data, onRefresh }) {
             camera={{ position: [0, 15, 40], fov: 60 }}
             onPointerDown={(e) => { dragStartRef.current = { x: e.clientX, y: e.clientY }; }}
             onPointerMissed={handlePointerMissed}
-            style={{ background: '#0f0f0f' }}
+            style={{ background: 'rgb(var(--port-bg))' }}
           >
             <GoalScene
               graph={graph}

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -64,11 +64,11 @@ export default function Login() {
   };
 
   if (authEnabled === null) {
-    return <div className="min-h-screen bg-port-bg" />;
+    return <div className="min-h-dvh-cap bg-port-bg" />;
   }
 
   return (
-    <div className="min-h-screen bg-port-bg flex items-center justify-center p-4">
+    <div className="min-h-dvh-cap bg-port-bg flex items-center justify-center p-4">
       <form
         onSubmit={submit}
         className="w-full max-w-sm bg-port-card border border-port-border rounded-lg p-6 space-y-4"


### PR DESCRIPTION
## Better Audit — UX Consistency & Responsive Layout

### Summary
Above-the-fold and theme-consistency fixes.

### Changes
- **[CRITICAL]** `Login.jsx` used raw `min-h-screen`; on mobile Safari the sign-in form/button could render below the visible fold on the first screen every session hits. Swapped to the dvh-aware `min-h-dvh-cap`.
- **[HIGH]** Same `min-h-screen` → `min-h-dvh-cap` on the `ErrorBoundary` full-screen fallback.
- **[MEDIUM]** r3f `<Canvas>` backgrounds (goals tree, memory graph, brain graph) hardcoded `#0f0f0f`, rendering a black rectangle under light themes — now track the `port-bg` token via `rgb(var(--port-bg))`.
- **[LOW]** ProactiveAlertsWidget hover chevron gains a touch-visible fallback (`opacity-40 sm:opacity-0 sm:group-hover:opacity-100`).

**Merge order:** Independent — each PR owns a disjoint set of files (no cross-branch imports), so they can be merged in any order.

Part of the /do:better audit (2026-07-21). Deferred structural refactors and dependency CVEs from the same audit are tracked as issues #2832–#2848.