### PR TITLE
feat(issue-2827): expose Codex reasoning-effort in the media-job retry editor

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Render Queue
+
+- **[issue-2827] Inspect and change Codex reasoning effort when retrying a render** — a failed Codex image job now shows the reasoning-effort level it used in the Render Queue, and the Edit & Retry editor gains a Codex-only Reasoning-effort control so you can pin a different level or reset it to the default before re-queuing.
+
 ## Security
 
 - Guard paid-provider API keys against SSRF / key-exfiltration: `streamCompletion` (askService), voice-LLM endpoint resolution, and the local-LLM playground now validate a provider's endpoint through the shared endpoint guard before attaching the `Authorization: Bearer` header, so a mistyped or malicious custom endpoint (including cloud-metadata hosts) never receives the key unless the provider opts in via `allowCustomEndpoint`.

--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -6,6 +6,7 @@ import { FormField } from '../ui/FormField';
 import { listMediaJobs, cancelMediaJob, cancelQueuedMediaJobs, deleteMediaJob, retryMediaJob, runMediaJobNow } from '../../services/apiMediaJobs.js';
 import { listLoraTrainingCheckpoints } from '../../services/apiLoraTraining.js';
 import { IMAGE_GEN_MODE } from '../../lib/imageGenBackends';
+import { CODEX_EFFORT_LEVELS } from '../../utils/providers';
 import { lossSparklineGeometry } from '../../lib/lossSparkline';
 import { useAutoRefetch } from '../../hooks/useAutoRefetch';
 import { useConfirmDelete } from '../../hooks/useConfirmDelete';
@@ -33,7 +34,9 @@ function modelLabel(params) {
   }
   if (params.mode === IMAGE_GEN_MODE.CODEX) {
     const m = (params.model || '').trim();
-    return m ? `codex / ${m}` : 'codex';
+    const eff = (params.effort || '').trim();
+    const base = m ? `codex / ${m}` : 'codex';
+    return eff ? `${base} · ${eff}` : base;
   }
   const id = (params.modelId || '').trim();
   if (!id) return 'local';
@@ -440,8 +443,15 @@ function JobRow({ job, onCancel, onRetry, onRunNow, onDelete }) {
   );
 }
 
+// Clear-to-default sentinel for the Codex reasoning-effort control — mirrors the
+// server's EFFORT_CLEAR_SENTINEL in routes/mediaJobs.js. A job with no explicit
+// effort is "using the shipped default", represented in the <select> by this value;
+// submitting it against a job that HAD an explicit effort tells the server to reset
+// to the default (drop params.effort).
+const EFFORT_DEFAULT_OPTION = 'default';
+
 // Inline form for the Edit-and-retry flow. Shows the fields the server's
-// retry override schema accepts (prompt, negative, model, dimensions, steps)
+// retry override schema accepts (prompt, negative, model, dimensions, steps, effort)
 // and submits only the keys the user actually changed — leaving unchanged
 // fields out of the patch so the original job's values ride through.
 function EditRetryForm({ job, onSubmit, onCancel }) {
@@ -454,6 +464,11 @@ function EditRetryForm({ job, onSubmit, onCancel }) {
   const [width, setWidth] = useState(p.width ?? '');
   const [height, setHeight] = useState(p.height ?? '');
   const [steps, setSteps] = useState(p.steps ?? '');
+  // The job's stored effort (a CODEX_EFFORT_LEVELS value) or the "default" option
+  // when it carried none. On submit we only send `effort` when this differs from
+  // the original — the sentinel resets to default, a level pins that level.
+  const originalEffort = (p.effort || '').trim() || EFFORT_DEFAULT_OPTION;
+  const [effort, setEffort] = useState(originalEffort);
 
   const submit = (e) => {
     e.preventDefault();
@@ -467,6 +482,9 @@ function EditRetryForm({ job, onSubmit, onCancel }) {
     if (!numEq(width, p.width) && width !== '') overrides.width = Number(width);
     if (!numEq(height, p.height) && height !== '') overrides.height = Number(height);
     if (!numEq(steps, p.steps) && steps !== '') overrides.steps = Number(steps);
+    // Codex-only: send effort only when changed. The sentinel ('default') resets
+    // to the shipped default; a concrete level pins the retry to that level.
+    if (isCodex && effort !== originalEffort) overrides.effort = effort;
     onSubmit(Object.keys(overrides).length ? overrides : null);
   };
 
@@ -526,6 +544,21 @@ function EditRetryForm({ job, onSubmit, onCancel }) {
           />
         </FormField>
       </div>
+      {isCodex && (
+        <FormField label="Reasoning effort" labelClassName="block text-[10px] uppercase tracking-wide text-port-text-muted">
+          <select
+            id="retry-codex-effort"
+            value={effort}
+            onChange={(e) => setEffort(e.target.value)}
+            className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-white text-xs"
+          >
+            <option value={EFFORT_DEFAULT_OPTION}>Default (low)</option>
+            {CODEX_EFFORT_LEVELS.map((lvl) => (
+              <option key={lvl} value={lvl}>{lvl}</option>
+            ))}
+          </select>
+        </FormField>
+      )}
       <div className="flex items-center justify-end gap-2 pt-1">
         <button
           type="button"

--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -21,6 +21,13 @@ const STATUS_BADGE = {
 
 const KIND_ICON = { video: Film, image: ImageIcon, training: Cpu };
 
+// Safe-read a Codex job's stored reasoning effort. Mirrors codex.js's server-side
+// guard (`typeof effort === 'string' && effort.trim()`): a non-string value from
+// hand-edited media-jobs.json returns '' instead of throwing on `.trim()`, and a
+// blank/absent value returns '' so callers can apply their own fallback (the row
+// resolves to the shipped default level; the retry editor to its 'default' option).
+const codexEffortOf = (raw) => (typeof raw === 'string' ? raw.trim() : '');
+
 // Compact "engine / model" badge so a failed row tells the user *what* failed,
 // not just that it failed. Codex jobs carry `params.model`; local image/video
 // jobs carry `params.modelId`; training jobs carry a runtime + character.
@@ -34,10 +41,11 @@ function modelLabel(params) {
   }
   if (params.mode === IMAGE_GEN_MODE.CODEX) {
     const m = (params.model || '').trim();
-    // Resolve an absent effort to the shipped default — a job that ran on the
-    // default stores no `effort`, but codex.js still rendered it at `low`, so
-    // the row must show the effective level, not a blank.
-    const eff = (params.effort || '').trim() || CODEX_IMAGEGEN_DEFAULT_EFFORT;
+    // Resolve the effective effort. `codexEffortOf` mirrors codex.js's own guard
+    // (`typeof === 'string' && trim`) so a non-string effort from hand-edited
+    // media-jobs.json can't throw on `.trim()`; an absent/blank value resolves to
+    // the shipped default the server actually rendered at.
+    const eff = codexEffortOf(params.effort) || CODEX_IMAGEGEN_DEFAULT_EFFORT;
     const base = m ? `codex / ${m}` : 'codex';
     return `${base} · ${eff}`;
   }
@@ -470,7 +478,7 @@ function EditRetryForm({ job, onSubmit, onCancel }) {
   // The job's stored effort (a CODEX_EFFORT_LEVELS value) or the "default" option
   // when it carried none. On submit we only send `effort` when this differs from
   // the original — the sentinel resets to default, a level pins that level.
-  const originalEffort = (p.effort || '').trim() || EFFORT_DEFAULT_OPTION;
+  const originalEffort = codexEffortOf(p.effort) || EFFORT_DEFAULT_OPTION;
   const [effort, setEffort] = useState(originalEffort);
 
   const submit = (e) => {

--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -5,7 +5,7 @@ import ConfirmButtonPair from '../ui/ConfirmButtonPair';
 import { FormField } from '../ui/FormField';
 import { listMediaJobs, cancelMediaJob, cancelQueuedMediaJobs, deleteMediaJob, retryMediaJob, runMediaJobNow } from '../../services/apiMediaJobs.js';
 import { listLoraTrainingCheckpoints } from '../../services/apiLoraTraining.js';
-import { IMAGE_GEN_MODE } from '../../lib/imageGenBackends';
+import { IMAGE_GEN_MODE, CODEX_IMAGEGEN_DEFAULT_EFFORT } from '../../lib/imageGenBackends';
 import { CODEX_EFFORT_LEVELS } from '../../utils/providers';
 import { lossSparklineGeometry } from '../../lib/lossSparkline';
 import { useAutoRefetch } from '../../hooks/useAutoRefetch';
@@ -34,9 +34,12 @@ function modelLabel(params) {
   }
   if (params.mode === IMAGE_GEN_MODE.CODEX) {
     const m = (params.model || '').trim();
-    const eff = (params.effort || '').trim();
+    // Resolve an absent effort to the shipped default — a job that ran on the
+    // default stores no `effort`, but codex.js still rendered it at `low`, so
+    // the row must show the effective level, not a blank.
+    const eff = (params.effort || '').trim() || CODEX_IMAGEGEN_DEFAULT_EFFORT;
     const base = m ? `codex / ${m}` : 'codex';
-    return eff ? `${base} · ${eff}` : base;
+    return `${base} · ${eff}`;
   }
   const id = (params.modelId || '').trim();
   if (!id) return 'local';
@@ -546,13 +549,14 @@ function EditRetryForm({ job, onSubmit, onCancel }) {
       </div>
       {isCodex && (
         <FormField label="Reasoning effort" labelClassName="block text-[10px] uppercase tracking-wide text-port-text-muted">
+          {/* No fixed id — FormField wires the label to a useId()-generated id,
+              so two retry editors open at once don't collide on one shared id. */}
           <select
-            id="retry-codex-effort"
             value={effort}
             onChange={(e) => setEffort(e.target.value)}
             className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-white text-xs"
           >
-            <option value={EFFORT_DEFAULT_OPTION}>Default (low)</option>
+            <option value={EFFORT_DEFAULT_OPTION}>Default ({CODEX_IMAGEGEN_DEFAULT_EFFORT})</option>
             {CODEX_EFFORT_LEVELS.map((lvl) => (
               <option key={lvl} value={lvl}>{lvl}</option>
             ))}

--- a/client/src/components/media/MediaJobsQueue.test.jsx
+++ b/client/src/components/media/MediaJobsQueue.test.jsx
@@ -1,15 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 // Mock the media-jobs API so the queue renders a controlled job list without
 // the network. useAutoRefetch calls the fetcher on mount.
 const listMediaJobs = vi.fn();
+const retryMediaJob = vi.fn();
 vi.mock('../../services/apiMediaJobs.js', () => ({
   listMediaJobs: (...a) => listMediaJobs(...a),
   cancelMediaJob: vi.fn(),
   cancelQueuedMediaJobs: vi.fn(),
   deleteMediaJob: vi.fn(),
-  retryMediaJob: vi.fn(),
+  retryMediaJob: (...a) => retryMediaJob(...a),
   runMediaJobNow: vi.fn(),
 }));
 
@@ -40,6 +42,85 @@ const trainingJob = {
 beforeEach(() => {
   listMediaJobs.mockReset();
   listLoraTrainingCheckpoints.mockReset();
+  retryMediaJob.mockReset();
+  retryMediaJob.mockResolvedValue({ jobId: 'new-job-1234' });
+});
+
+const failedCodexJob = {
+  id: 'codexfail0000dead',
+  kind: 'image',
+  status: 'failed',
+  error: 'boom',
+  queuedAt: '2026-06-19T10:00:00Z',
+  params: { prompt: 'a fox', mode: 'codex', model: 'gpt-5.6-luna', effort: 'high' },
+};
+
+const failedLocalJob = {
+  id: 'localfail0000beef',
+  kind: 'image',
+  status: 'failed',
+  error: 'boom',
+  queuedAt: '2026-06-19T10:00:00Z',
+  params: { prompt: 'a fox', mode: 'local', modelId: 'z-image-turbo' },
+};
+
+// Failed/canceled jobs live in the collapsed "recent" reel — expand it so the
+// JobRow (and its Edit-and-retry control) renders.
+async function expandReel(user) {
+  const toggle = await screen.findByText(/Show failed \/ canceled/);
+  await user.click(toggle);
+}
+
+describe('MediaJobsQueue — Codex reasoning-effort retry control', () => {
+  it('surfaces the job effort in the row label', async () => {
+    const user = userEvent.setup();
+    listMediaJobs.mockResolvedValue([failedCodexJob]);
+    render(<MediaJobsQueue kind="image" />);
+    await expandReel(user);
+    await waitFor(() => expect(screen.getByText(/codex \/ gpt-5.6-luna · high/)).toBeInTheDocument());
+  });
+
+  it('renders the effort select (Codex only) and pins a new level on retry', async () => {
+    const user = userEvent.setup();
+    listMediaJobs.mockResolvedValue([failedCodexJob]);
+    render(<MediaJobsQueue kind="image" />);
+    await expandReel(user);
+    await user.click(await screen.findByLabelText('Edit and retry'));
+
+    const select = await screen.findByLabelText('Reasoning effort');
+    // Pre-filled with the job's stored effort.
+    expect(select.value).toBe('high');
+    await user.selectOptions(select, 'medium');
+    await user.click(screen.getByRole('button', { name: /Retry with changes/i }));
+
+    expect(retryMediaJob).toHaveBeenCalledWith('codexfail0000dead', { effort: 'medium' }, { silent: true });
+  });
+
+  it('sends the clear sentinel when the effort is reset to Default', async () => {
+    const user = userEvent.setup();
+    listMediaJobs.mockResolvedValue([failedCodexJob]);
+    render(<MediaJobsQueue kind="image" />);
+    await expandReel(user);
+    await user.click(await screen.findByLabelText('Edit and retry'));
+
+    const select = await screen.findByLabelText('Reasoning effort');
+    await user.selectOptions(select, 'default');
+    await user.click(screen.getByRole('button', { name: /Retry with changes/i }));
+
+    expect(retryMediaJob).toHaveBeenCalledWith('codexfail0000dead', { effort: 'default' }, { silent: true });
+  });
+
+  it('does not render the effort control for non-Codex jobs', async () => {
+    const user = userEvent.setup();
+    listMediaJobs.mockResolvedValue([failedLocalJob]);
+    render(<MediaJobsQueue kind="image" />);
+    await expandReel(user);
+    await user.click(await screen.findByLabelText('Edit and retry'));
+
+    // Edit form is open (Prompt field visible) but no effort control.
+    await waitFor(() => expect(screen.getByText('Prompt')).toBeInTheDocument());
+    expect(screen.queryByLabelText('Reasoning effort')).not.toBeInTheDocument();
+  });
 });
 
 describe('MediaJobsQueue — training rows', () => {

--- a/client/src/components/media/MediaJobsQueue.test.jsx
+++ b/client/src/components/media/MediaJobsQueue.test.jsx
@@ -71,6 +71,16 @@ async function expandReel(user) {
   await user.click(toggle);
 }
 
+const failedCodexDefaultEffortJob = {
+  id: 'codexdef00000dead',
+  kind: 'image',
+  status: 'failed',
+  error: 'boom',
+  queuedAt: '2026-06-19T10:00:00Z',
+  // No explicit effort → ran on the shipped default.
+  params: { prompt: 'a fox', mode: 'codex', model: 'gpt-5.6-luna' },
+};
+
 describe('MediaJobsQueue — Codex reasoning-effort retry control', () => {
   it('surfaces the job effort in the row label', async () => {
     const user = userEvent.setup();
@@ -78,6 +88,28 @@ describe('MediaJobsQueue — Codex reasoning-effort retry control', () => {
     render(<MediaJobsQueue kind="image" />);
     await expandReel(user);
     await waitFor(() => expect(screen.getByText(/codex \/ gpt-5.6-luna · high/)).toBeInTheDocument());
+  });
+
+  it('shows the effective default effort in the row label when the job stored none', async () => {
+    const user = userEvent.setup();
+    listMediaJobs.mockResolvedValue([failedCodexDefaultEffortJob]);
+    render(<MediaJobsQueue kind="image" />);
+    await expandReel(user);
+    // Default-effort jobs store no `effort`, but codex still rendered at `low`.
+    await waitFor(() => expect(screen.getByText(/codex \/ gpt-5.6-luna · low/)).toBeInTheDocument());
+  });
+
+  it('pre-fills the retry editor to Default for a job that stored no effort', async () => {
+    const user = userEvent.setup();
+    listMediaJobs.mockResolvedValue([failedCodexDefaultEffortJob]);
+    render(<MediaJobsQueue kind="image" />);
+    await expandReel(user);
+    await user.click(await screen.findByLabelText('Edit and retry'));
+    const select = await screen.findByLabelText('Reasoning effort');
+    expect(select.value).toBe('default');
+    // Leaving it on Default and retrying sends no effort override (nothing changed).
+    await user.click(screen.getByRole('button', { name: /Retry with changes/i }));
+    expect(retryMediaJob).toHaveBeenCalledWith('codexdef00000dead', null, { silent: true });
   });
 
   it('renders the effort select (Codex only) and pins a new level on retry', async () => {

--- a/client/src/components/media/MediaJobsQueue.test.jsx
+++ b/client/src/components/media/MediaJobsQueue.test.jsx
@@ -99,6 +99,19 @@ describe('MediaJobsQueue — Codex reasoning-effort retry control', () => {
     await waitFor(() => expect(screen.getByText(/codex \/ gpt-5.6-luna · low/)).toBeInTheDocument());
   });
 
+  it('does not crash on a non-string effort from hand-edited data', async () => {
+    const user = userEvent.setup();
+    // A hand-edited media-jobs.json could carry a numeric effort; the row label
+    // must coerce safely (mirror of codex.js) instead of throwing on .trim().
+    listMediaJobs.mockResolvedValue([{
+      ...failedCodexDefaultEffortJob, id: 'codexbadeff00dead', params: { ...failedCodexDefaultEffortJob.params, effort: 5 },
+    }]);
+    render(<MediaJobsQueue kind="image" />);
+    await expandReel(user);
+    // Non-string → treated as absent → resolves to the shipped default.
+    await waitFor(() => expect(screen.getByText(/codex \/ gpt-5.6-luna · low/)).toBeInTheDocument());
+  });
+
   it('pre-fills the retry editor to Default for a job that stored no effort', async () => {
     const user = userEvent.setup();
     listMediaJobs.mockResolvedValue([failedCodexDefaultEffortJob]);

--- a/client/src/components/settings/ImageGenTab.jsx
+++ b/client/src/components/settings/ImageGenTab.jsx
@@ -22,7 +22,7 @@ import {
   registerTool, updateTool, getToolsList,
   getHfTokenStatus, saveHfToken, clearHfToken,
 } from '../../services/api';
-import { IMAGE_GEN_MODE } from '../../lib/imageGenBackends';
+import { IMAGE_GEN_MODE, CODEX_IMAGEGEN_DEFAULT_EFFORT } from '../../lib/imageGenBackends';
 import { resolveCleanersFromConfig } from '../../lib/imageCleaners';
 import { useMediaJobSse } from '../../hooks/useMediaJobSse';
 import { CODEX_EFFORT_LEVELS } from '../../utils/providers';
@@ -31,9 +31,11 @@ const SDAPI_TOOL_ID = 'sdapi';
 const CODEX_TOOL_ID = 'codex-imagegen';
 // Mirror of server/services/imageGen/modes.js — shown as placeholder/default
 // hints so the user sees what a blank Model / Effort field will actually use.
-// The server owns the real default; these are display-only.
+// The server owns the real default; these are display-only. The effort default
+// lives in the shared imageGenBackends lib (imported above) so the Render Queue
+// and this settings form don't drift; the model default stays local (only used
+// here as a placeholder string).
 const CODEX_IMAGEGEN_DEFAULT_MODEL = 'gpt-5.6-luna';
-const CODEX_IMAGEGEN_DEFAULT_EFFORT = 'low';
 const DEFAULT_TEST_PROMPT = 'a small cyberpunk fox sitting on a neon-lit rooftop at night, cinematic, highly detailed';
 const normalizeUrl = (url) => (url || '').trim().replace(/\/+$/, '');
 

--- a/client/src/lib/imageGenBackends.js
+++ b/client/src/lib/imageGenBackends.js
@@ -2,6 +2,13 @@ import { Cpu, Terminal, Cloud } from 'lucide-react';
 
 export const IMAGE_GEN_MODE = Object.freeze({ LOCAL: 'local', CODEX: 'codex', EXTERNAL: 'external' });
 
+// Shipped default Codex reasoning-effort level — the client mirror of the
+// server's CODEX_IMAGEGEN_DEFAULT_EFFORT (server/services/imageGen/modes.js).
+// A Codex job with no explicit effort renders at this level, so any UI that
+// displays or pre-fills "the effort a job used" must resolve an absent value to
+// this default rather than showing a blank.
+export const CODEX_IMAGEGEN_DEFAULT_EFFORT = 'low';
+
 const META = {
   [IMAGE_GEN_MODE.LOCAL]:    { label: 'Local',    icon: Cpu },
   [IMAGE_GEN_MODE.CODEX]:    { label: 'Codex',    icon: Terminal },

--- a/server/routes/mediaJobs.js
+++ b/server/routes/mediaJobs.js
@@ -11,6 +11,7 @@ import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { validateRequest } from '../lib/validation.js';
 import { listJobs, getJob, cancelJob, cancelQueuedJobs, enqueueJob, removeArchivedJob, runJobNow, JOB_KINDS, JOB_STATUSES } from '../services/mediaJobQueue/index.js';
 import { refineMediaPrompt } from '../services/mediaPromptRefiner.js';
+import { CODEX_EFFORT_LEVELS } from '../lib/providerModels.js';
 
 const router = Router();
 
@@ -73,6 +74,11 @@ const PARAM_ALLOWLIST = new Set([
   // video providers carry a registry-id). Without it the UI can't tell which
   // codex model a failed job tried to use — the row would just say "codex".
   'model',
+  // `effort` is the Codex per-render reasoning-effort level (`low` by default).
+  // Surfacing it lets the Render Queue row show which effort a failed job used
+  // and lets the retry editor pre-fill the current level (see the retry-editor
+  // Reasoning-effort control). Codex-only; local/external/video jobs never set it.
+  'effort',
   'width', 'height', 'numFrames', 'fps', 'steps', 'guidanceScale',
   'seed', 'tiling', 'disableAudio', 'mode', 'imageStrength',
   'cfgScale', 'guidance', 'quantize',
@@ -181,11 +187,29 @@ const emptyToUndef = (s) => {
   const v = (s ?? '').trim();
   return v.length > 0 ? v : undefined;
 };
+
+// Clear-to-default sentinel for the Codex reasoning-effort override. Unlike the
+// string fields above, an absent (`undefined`) effort override means "keep the
+// job's original effort" — so `emptyToUndef` alone can NEVER express "reset the
+// effort back to the shipped default", because the drop-undefined merge below
+// would silently retain the old value. This sentinel is a distinct signal: when
+// the retry payload sends `effort: 'default'`, the handler DELETES `params.effort`
+// so the render falls back to CODEX_IMAGEGEN_DEFAULT_EFFORT (`low`). A real job
+// never stores `'default'` as an effort (it's always a CODEX_EFFORT_LEVELS value),
+// so the sentinel can't collide with a legitimate level.
+const EFFORT_CLEAR_SENTINEL = 'default';
 const RETRY_OVERRIDE_SCHEMA = z.object({
   prompt: z.string().trim().min(1).max(8000).optional(),
   negativePrompt: z.string().trim().max(8000).optional(),
   model: z.string().max(200).optional().transform(emptyToUndef),
   modelId: z.string().max(200).optional().transform(emptyToUndef),
+  // Codex reasoning-effort override: a valid CODEX_EFFORT_LEVELS value pins the
+  // retry to that level; the EFFORT_CLEAR_SENTINEL (`'default'`) resets it to the
+  // shipped default; empty/whitespace → undefined (keep the original job's effort).
+  effort: z.string().max(20).optional().transform(emptyToUndef).refine(
+    (v) => v === undefined || v === EFFORT_CLEAR_SENTINEL || CODEX_EFFORT_LEVELS.includes(v),
+    { message: `effort must be one of ${CODEX_EFFORT_LEVELS.join(', ')} or '${EFFORT_CLEAR_SENTINEL}'` },
+  ),
   width: z.number().int().min(64).max(4096).optional(),
   height: z.number().int().min(64).max(4096).optional(),
   steps: z.number().int().min(1).max(200).optional(),
@@ -226,14 +250,25 @@ router.post('/:id/retry', asyncHandler(async (req, res) => {
     );
   }
   const body = validateRequest(retryBodySchema, req.body ?? {}) ?? {};
+  const rawOverrides = body.params ?? {};
+  // A `effort: 'default'` override is a clear-to-default signal, not a value to
+  // merge — handled by deleting params.effort below so the render falls back to
+  // the shipped CODEX_IMAGEGEN_DEFAULT_EFFORT. Exclude it from the merge set.
+  const clearEffort = rawOverrides.effort === EFFORT_CLEAR_SENTINEL;
   // Strip undefined override values before merging — Zod's emptyToUndef
-  // transform turns "" → undefined for model/modelId, and a naive spread
+  // transform turns "" → undefined for model/modelId/effort, and a naive spread
   // would still set those keys to undefined on the merged params (clobbering
   // the original job's values). Filtering keeps unchanged fields intact.
   const overrides = Object.fromEntries(
-    Object.entries(body.params ?? {}).filter(([, v]) => v !== undefined),
+    Object.entries(rawOverrides).filter(
+      ([k, v]) => v !== undefined && !(k === 'effort' && clearEffort),
+    ),
   );
   const params = { ...job.params, ...overrides };
+  // Reset Codex effort to the shipped default: dropping the key lets codex.js's
+  // fallback (CODEX_IMAGEGEN_DEFAULT_EFFORT) take over, which a merged sentinel
+  // string could not do (it would fail the CODEX_EFFORT_LEVELS validation).
+  if (clearEffort) delete params.effort;
   const result = enqueueJob({ kind: job.kind, params, owner: job.owner });
   // Drop the original failed/canceled row from archive — the new job inherits
   // its work, and leaving both visible just lets users keep clicking Retry on

--- a/server/routes/mediaJobs.test.js
+++ b/server/routes/mediaJobs.test.js
@@ -145,6 +145,67 @@ describe('mediaJobs routes', () => {
     expect(call.params.steps).toBe(40);
   });
 
+  it('GET /:id surfaces the Codex reasoning effort a job used (allowlisted)', async () => {
+    jobStore.set('j-eff', {
+      id: 'j-eff', kind: 'image', owner: null, status: 'failed',
+      params: { prompt: 'cat', mode: 'codex', model: 'gpt-5.6-luna', effort: 'high' },
+    });
+    const r = await request(makeApp()).get('/api/media-jobs/j-eff');
+    expect(r.status).toBe(200);
+    expect(r.body.params.effort).toBe('high');
+  });
+
+  it('POST /:id/retry preserves an explicit Codex effort on a plain retry', async () => {
+    jobStore.set('j-eff-keep', {
+      id: 'j-eff-keep', kind: 'image', owner: null, status: 'failed',
+      params: { prompt: 'cat', mode: 'codex', model: 'gpt-5.6-luna', effort: 'high' },
+    });
+    const r = await request(makeApp()).post('/api/media-jobs/j-eff-keep/retry').send({});
+    expect(r.status).toBe(200);
+    expect(stubs.enqueueJob.mock.calls[0][0].params.effort).toBe('high');
+  });
+
+  it('POST /:id/retry pins a new Codex effort when overridden', async () => {
+    jobStore.set('j-eff-pin', {
+      id: 'j-eff-pin', kind: 'image', owner: null, status: 'failed',
+      params: { prompt: 'cat', mode: 'codex', effort: 'low' },
+    });
+    const r = await request(makeApp())
+      .post('/api/media-jobs/j-eff-pin/retry')
+      .send({ params: { effort: 'medium' } });
+    expect(r.status).toBe(200);
+    expect(stubs.enqueueJob.mock.calls[0][0].params.effort).toBe('medium');
+  });
+
+  it('POST /:id/retry resets Codex effort to the default when the clear sentinel is sent', async () => {
+    jobStore.set('j-eff-clear', {
+      id: 'j-eff-clear', kind: 'image', owner: null, status: 'failed',
+      params: { prompt: 'cat', mode: 'codex', model: 'gpt-5.6-luna', effort: 'high' },
+    });
+    const r = await request(makeApp())
+      .post('/api/media-jobs/j-eff-clear/retry')
+      .send({ params: { effort: 'default' } });
+    expect(r.status).toBe(200);
+    const call = stubs.enqueueJob.mock.calls[0][0];
+    // The key is DROPPED (not set to the sentinel or to undefined) so codex.js's
+    // CODEX_IMAGEGEN_DEFAULT_EFFORT fallback takes over.
+    expect('effort' in call.params).toBe(false);
+    // other params are untouched by the clear
+    expect(call.params.model).toBe('gpt-5.6-luna');
+  });
+
+  it('POST /:id/retry rejects an invalid Codex effort override', async () => {
+    jobStore.set('j-eff-bad', {
+      id: 'j-eff-bad', kind: 'image', owner: null, status: 'failed',
+      params: { prompt: 'cat', mode: 'codex' },
+    });
+    const r = await request(makeApp())
+      .post('/api/media-jobs/j-eff-bad/retry')
+      .send({ params: { effort: 'turbo' } });
+    expect(r.status).toBe(400);
+    expect(stubs.enqueueJob).not.toHaveBeenCalled();
+  });
+
   it('POST /:id/retry rejects override fields outside the whitelist', async () => {
     jobStore.set('j-bad', {
       id: 'j-bad', kind: 'image', owner: null, status: 'failed',


### PR DESCRIPTION
## Summary

The Edit & Retry flow for a failed Codex image job had no way to inspect or change the per-render reasoning `effort` (added in #2826/#2828), and the server had no way to reset it back to the shipped default. This wires the full contract #2826 deliberately deferred:

- **Server (`routes/mediaJobs.js`)** — re-add `effort` to `PARAM_ALLOWLIST` (so the Render Queue row and retry base surface the effort a job used) and to `RETRY_OVERRIDE_SCHEMA`, validated against `CODEX_EFFORT_LEVELS`. A distinct clear-to-default sentinel (`effort: 'default'`) lets a retry actually reset the effort: the handler *deletes* `params.effort` so `codex.js`'s `CODEX_IMAGEGEN_DEFAULT_EFFORT` fallback takes over — a merged sentinel string could never do this (it would fail the level validation), and `emptyToUndef` alone can't express "reset" (the drop-undefined merge silently retains the old value).
- **Client (`MediaJobsQueue.jsx`)** — the Render Queue row now shows the effective effort a Codex job ran at (resolving an absent value to the shipped default), and `EditRetryForm` gains a Codex-only Reasoning-effort `<select>` (levels from `CODEX_EFFORT_LEVELS` plus a "Default" choice) wired into the override payload. Pin a level, or reset to default, before re-queuing.
- Extracted `CODEX_IMAGEGEN_DEFAULT_EFFORT` into the shared `imageGenBackends` lib (deduping the settings form's local copy) and a `codexEffortOf` guard mirroring `codex.js`'s `typeof === 'string' && trim`, so a non-string effort from hand-edited data can't throw at render.

Closes #2827

## Test plan

- `server/routes/mediaJobs.test.js` — retry preserves an explicit effort on a plain retry; pins a new level when overridden; resets to the default (drops the key) on the clear sentinel; rejects an invalid level; the effort is exposed via GET.
- `client/src/components/media/MediaJobsQueue.test.jsx` — the effort control renders for Codex jobs only (hidden for local); pins a level and sends the clear sentinel; the row + editor show/pre-fill the effective default when a job stored no effort; a non-string persisted effort doesn't crash the row.
- Reviewed by claude (in-process), ollama (`gemma-4-12B-coder`), and codex (`codex review`); all findings addressed.
