### PR TITLE
Decompose spawnTuiAgent() into cohesive helpers (#2833)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -25,6 +25,7 @@
 
 ## Changed
 
+- **[issue-2833] Decompose the ~1000-line `spawnTuiAgent()`** — extract the output buffering/spooling pipeline into `agentTuiSpawning/outputSpooler.js` and the failure-analysis + worktree-inspection helpers into `agentTuiSpawning/finalizeHelpers.js`, leaving `spawnTuiAgent` as a thinner orchestrator. No behavior change to spawn/timeout/completion semantics; adds unit coverage for both extracted modules.
 - Route client `localStorage` access through the `safeStorage` helpers (Layout, MorseTrainer, calendar persisted-state, MoodBoard reference strip, VoiceWidget, WorkEditor, Tribe) — several sites previously threw uncaught in Safari private mode instead of degrading gracefully.
 - Replace inline `new Promise(r => setTimeout(r, …))` delays with the shared `sleep(ms)` helper across nine server modules.
 

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -8,12 +8,13 @@
 
 import { join } from 'path';
 import { existsSync } from 'fs';
-import { appendFile, readFile, rm, open, stat as fsStat, writeFile } from 'fs/promises';
+import { readFile, rm } from 'fs/promises';
 import * as shellService from './shell.js';
 import { emitLog } from './cosEvents.js';
-import { appendAgentOutputLines, updateAgent } from './cosAgents.js';
+import { updateAgent } from './cosAgents.js';
 import { registerSpawnedAgent, unregisterSpawnedAgent } from './agents.js';
-import { analyzeAgentFailure } from './agentErrorAnalysis.js';
+import { createOutputSpooler } from './agentTuiSpawning/outputSpooler.js';
+import { captureWorktreeDiff, worktreeHasChanges, resolveErrorAnalysis } from './agentTuiSpawning/finalizeHelpers.js';
 import { finalizeAgent, releaseAgentLane } from './agentLifecycle.js';
 import { activeAgents, userTerminatedAgents, pausedAgents } from './agentState.js';
 import { PATHS } from '../lib/fileUtils.js';
@@ -47,9 +48,6 @@ import {
   scheduleSubmitEnters,
   PASTE_DEADLINE_MS,
   TUI_INPUT_READY_DEADLINE_MS,
-  OUTPUT_BUFFER_CAP,
-  OUTPUT_BUFFER_HEADROOM,
-  RAW_SPOOL_MAX_BYTES,
   inferTuiCommand,
   applyCommandDefaults,
   PASTE_VERIFY_POLL_MS,
@@ -73,99 +71,12 @@ const DEFAULT_TUI_MIN_RUNTIME_MS = 15000;
 // handshake windows in tuiHandshake.js (PASTE_DEADLINE_MS=10s) without
 // meaningfully weakening the idle-reap protection once input truly stops.
 const PASTE_INPUT_GRACE_MS = 15000;
-// Tail-read window for raw.txt at failure analysis. analyzeAgentFailure only
-// inspects the last ~200 lines, so reading the whole file (which has no upper
-// bound for long-running agents) would reintroduce the OOM risk the disk
-// spool was meant to avoid. 1MB easily contains the last 200 lines of any
-// realistic PTY stream while keeping peak finalize memory bounded.
-const RAW_TAIL_ANALYSIS_BYTES = 1024 * 1024;
 
-// RAW_SPOOL_MAX_BYTES lives in tuiHandshake.js so the test suite can shrink
-// the cap via the same vi.mock pattern that overrides the output-buffer
-// thresholds — saves the truncation test from having to push hundreds of MB
-// through the spawner. A misbehaving (or compromised) TUI agent could in
-// principle emit MB/sec forever and fill the volume; realistic agents idle
-// out at 180s and emit <10MB total. At this threshold the spool is truncated
-// (rewritten with the current batch) so the most-recent data remains, which
-// is what readFileTail at finalize needs anyway. Warn fires once per agent
-// run; the `rawSpoolTruncated` metadata flag persists in the agent record
-// so the operator can spot the affected runs after the fact.
+// Output buffering/spooling (createOutputSpooler) and failure-analysis /
+// worktree-inspection helpers (readFileTail, worktreeHasChanges,
+// captureWorktreeDiff, resolveErrorAnalysis, RAW_TAIL_ANALYSIS_BYTES) live in
+// ./agentTuiSpawning/ so spawnTuiAgent stays a thin orchestrator.
 
-/**
- * Read at most `maxBytes` from the end of a file. Returns null when the file
- * doesn't exist or can't be opened; an empty string for a zero-byte file.
- * Used to bound the memory footprint of failure-analysis reads against the
- * uncapped raw PTY spool. Non-throwing — any failure surfaces as null so
- * the caller's failure-analysis path can fall back to outputBuffer instead
- * of aborting `finish()` before finalizeAgent runs.
- */
-async function readFileTail(path, maxBytes) {
-  const st = await fsStat(path).catch(() => null);
-  if (!st) return null;
-  if (st.size === 0) return '';
-  const start = Math.max(0, st.size - maxBytes);
-  const length = st.size - start;
-  const fh = await open(path, 'r').catch(() => null);
-  if (!fh) return null;
-  try {
-    const buf = Buffer.alloc(length);
-    // Honour bytesRead — the file can shrink between stat and read, or the
-    // OS can return a short read; decoding the whole `buf` would otherwise
-    // append NULs to the returned string. Read failures surface as null so
-    // callers can distinguish "empty file" ('') from "read error" (null) —
-    // a `bytesRead: 0` fallback would conflate the two.
-    const readResult = await fh.read(buf, 0, length, start).catch(() => null);
-    if (readResult === null) return null;
-    return buf.toString('utf8', 0, readResult.bytesRead);
-  } finally {
-    await fh.close().catch(() => {});
-  }
-}
-/**
- * Check if a worktree has any uncommitted changes. Returns true when the
- * working tree is dirty (staged or unstaged changes exist). Used to gate
- * idle-complete success — an agent that idled out with zero file changes
- * should fail, not succeed.
- */
-async function worktreeHasChanges(workspacePath) {
-  if (!workspacePath || typeof workspacePath !== 'string') return false;
-  const status = await git.getStatus(workspacePath).catch(() => null);
-  return status && !status.clean;
-}
-
-/**
- * Capture the git diff (staged + unstaged) from a worktree and save it to the
- * agent archive dir. Called before worktree cleanup so post-mortems can see
- * what changes existed even if the worktree is deleted. Non-throwing — a
- * failure to capture shouldn't block finalize.
- *
- * @returns {string|null} The captured diff, or null if none/error.
- */
-async function captureWorktreeDiff(workspacePath, agentDir) {
-  if (!workspacePath || typeof workspacePath !== 'string') return null;
-  if (!agentDir || typeof agentDir !== 'string') return null;
-  const [staged, unstaged] = await Promise.all([
-    git.getDiff(workspacePath, true).catch(() => ''),
-    git.getDiff(workspacePath, false).catch(() => ''),
-  ]);
-  const combined = [
-    staged ? `### STAGED CHANGES ###\n${staged}` : '',
-    unstaged ? `### UNSTAGED CHANGES ###\n${unstaged}` : '',
-  ].filter(Boolean).join('\n\n');
-  if (!combined.trim()) return null;
-  const diffFile = join(agentDir, 'worktree-diff.txt');
-  await writeFile(diffFile, combined).catch((err) => {
-    console.error(`❌ Failed to capture worktree diff for agent: ${err.message}`);
-  });
-  return combined;
-}
-
-// Debounce window for batching parsed output to disk + state. A chatty TUI can
-// emit hundreds of lines/sec; without batching, each line triggers a full
-// state load+save (see appendAgentOutput) and a small appendFile, which slows
-// the PTY event loop and thrashes the filesystem. 250ms is invisible to the
-// live tail but cuts I/O by 1-2 orders of magnitude.
-const OUTPUT_FLUSH_INTERVAL_MS = 250;
 // Sentinel-file polling. TUI agents write `.agent-done` in their workspace
 // when they've finished /simplify + /do:pr (or /do:push) — we poll for it
 // here so the agent gets cleanly finalized as soon as the work is done,
@@ -334,7 +245,6 @@ export async function spawnTuiAgent({
   // way the post-paste buffer is counted, or the gate undercounts and fires early.
   const promptMarkerCount = countPasteMarkers(stripAnsi(prompt));
 
-  let outputBuffer = '';
   let finalized = false;
   let immediateFallbackAnalysis = null;
   const detectImmediateFallbackSignal = createImmediateFallbackSignalDetector();
@@ -404,13 +314,7 @@ export async function spawnTuiAgent({
   let commandInjected = false;
   let firstOutputAt = null;
   let lastOutputAt = Date.now();
-  let lastLine = '';
   let sessionId = null;
-  // True once outputBuffer crossed its HEADROOM and the head was dropped.
-  // Mirrors `outputBufferTruncated` in `tuiPromptRunner.js`: warn once per
-  // buffer and surface via agent metadata so the agent record distinguishes
-  // a long-run-with-overflow from a clean short run.
-  let outputBufferTruncated = false;
 
   // Bounded post-paste accumulator. Lives only while pasteEnterTimer is
   // running (a few seconds at most), so the in-memory cost is bounded by
@@ -419,14 +323,6 @@ export async function spawnTuiAgent({
   // resolves or the agent finalizes.
   let postPasteBuffer = null;
 
-  let pendingLines = [];
-  let flushTimer = null;
-  let flushing = null;
-  let pendingRawChunks = [];
-  let rawFlushTimer = null;
-  let rawFlushing = null;
-  let rawBytesWritten = 0;
-  let rawSpoolTruncationWarned = false;
   let pasteEnterTimer = null;
   let pasteVerifyTimer = null;
   let submitEnterTimer = null;
@@ -439,120 +335,13 @@ export async function spawnTuiAgent({
 
   const streamingStrip = createStreamingAnsiStripper();
 
-  const flushPendingLines = async () => {
-    if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
-    if (pendingLines.length === 0) return;
-    const batch = pendingLines;
-    pendingLines = [];
-    await Promise.all([
-      appendAgentOutputLines(agentId, batch).catch(() => {}),
-      appendFile(outputFile, batch.map(l => `${l}\n`).join('')).catch(() => {})
-    ]);
-  };
-
-  const scheduleFlush = () => {
-    if (flushTimer || flushing) return;
-    flushTimer = setTimeout(() => {
-      flushTimer = null;
-      flushing = flushPendingLines().finally(() => {
-        flushing = null;
-        // Catch chunks that arrived during the in-flight flush — without
-        // this, a producer that goes quiet right after the flush starts
-        // strands its last batch in pendingLines until finalize.
-        if (pendingLines.length > 0) scheduleFlush();
-      });
-    }, OUTPUT_FLUSH_INTERVAL_MS);
-  };
-
-  // Raw PTY flush pipeline. Parallel to flushPendingLines but appends the
-  // unprocessed chunks (no ANSI strip, no line semantics) to raw.txt.
-  // shellService surfaces node-pty output as already-decoded UTF-8 strings
-  // (node-pty's internal StringDecoder handles multi-byte boundaries before
-  // we see chunks), so queueing strings here is sufficient — no Buffer
-  // bookkeeping needed. pendingRawChunks holds whatever arrives during the
-  // 250ms debounce window AND while an appendFile is in-flight (the next
-  // scheduleRawFlush is gated by rawFlushing); join() runs once per flush
-  // tick, so peak in-memory raw data is bounded by one debounce-plus-IO
-  // window of TUI output (typically hundreds of KB on a chatty agent).
-  const flushPendingRawChunks = async () => {
-    if (rawFlushTimer) { clearTimeout(rawFlushTimer); rawFlushTimer = null; }
-    if (pendingRawChunks.length === 0) return;
-    const batch = pendingRawChunks.join('');
-    pendingRawChunks = [];
-    // Count UTF-8 bytes actually written to disk, NOT the UTF-16 code-unit
-    // length of the JS string — non-ASCII output would otherwise under-
-    // report and let the spool exceed the safety cap.
-    const batchBytes = Buffer.byteLength(batch, 'utf8');
-    if (rawBytesWritten + batchBytes > RAW_SPOOL_MAX_BYTES) {
-      // Safety valve: rewrite the file with just this batch instead of
-      // appending. The tail-read at finalize wants the MOST RECENT bytes,
-      // not the oldest, so truncating preserves what analyzeAgentFailure
-      // actually uses while bounding disk usage at ~RAW_SPOOL_MAX_BYTES.
-      // If a single debounce-window batch exceeds the cap (runaway producer
-      // emitting MB/sec), slice to the trailing RAW_SPOOL_MAX_BYTES bytes
-      // first — Buffer-slice to keep UTF-8 byte semantics correct (a
-      // string.slice would index by UTF-16 code units and produce torn
-      // multi-byte sequences at the boundary).
-      let writeBuf;
-      if (batchBytes > RAW_SPOOL_MAX_BYTES) {
-        const buf = Buffer.from(batch, 'utf8');
-        writeBuf = buf.subarray(buf.length - RAW_SPOOL_MAX_BYTES);
-      } else {
-        writeBuf = batch;
-      }
-      const writeBytes = typeof writeBuf === 'string' ? batchBytes : writeBuf.length;
-      if (!rawSpoolTruncationWarned) {
-        rawSpoolTruncationWarned = true;
-        console.warn(`⚠️ TUI agent ${agentId} raw PTY spool reached ${Math.round(RAW_SPOOL_MAX_BYTES / 1024 / 1024)}MB — truncating spool (oldest bytes dropped; tail-read still reflects most recent)`);
-        updateAgent(agentId, { metadata: { rawSpoolTruncated: true } })
-          .catch(err => console.error(`❌ TUI agent ${agentId} rawSpoolTruncated metadata write failed: ${err.message}`));
-      }
-      // Only update the byte counter on successful write — a failed write
-      // would otherwise inflate rawBytesWritten and make subsequent flush
-      // decisions race the actual on-disk state.
-      const wrote = await writeFile(rawFile, writeBuf).then(() => true).catch(() => false);
-      if (wrote) rawBytesWritten = writeBytes;
-      return;
-    }
-    const wrote = await appendFile(rawFile, batch).then(() => true).catch(() => false);
-    if (wrote) rawBytesWritten += batchBytes;
-  };
-
-  const scheduleRawFlush = () => {
-    if (rawFlushTimer || rawFlushing) return;
-    rawFlushTimer = setTimeout(() => {
-      rawFlushTimer = null;
-      rawFlushing = flushPendingRawChunks().finally(() => {
-        rawFlushing = null;
-        // Same re-schedule guard as scheduleFlush: chunks that arrived
-        // during the in-flight appendFile would otherwise sit until
-        // finalize if the producer goes quiet immediately after.
-        if (pendingRawChunks.length > 0) scheduleRawFlush();
-      });
-    }, OUTPUT_FLUSH_INTERVAL_MS);
-  };
-
-  // TUI agents only emit a handful of internal status lines (session-started,
-  // prompt-pasted, completion) — see handleData for why per-line capture of
-  // the PTY stream itself is intentionally dropped.
-  const appendLine = (line) => {
-    const cleanLine = line.trim();
-    if (!cleanLine || cleanLine === lastLine) return;
-
-    lastLine = cleanLine;
-    outputBuffer += `${cleanLine}\n`;
-    if (outputBuffer.length > OUTPUT_BUFFER_HEADROOM) {
-      outputBuffer = outputBuffer.slice(-OUTPUT_BUFFER_CAP);
-      if (!outputBufferTruncated) {
-        outputBufferTruncated = true;
-        console.warn(`⚠️ TUI agent ${agentId} parsed-output buffer exceeded ${Math.round(OUTPUT_BUFFER_HEADROOM / 1024 / 1024)}MB — head dropped (output.txt is the authoritative on-disk record)`);
-        updateAgent(agentId, { metadata: { outputBufferTruncated: true } })
-          .catch(err => console.error(`❌ TUI agent ${agentId} outputBufferTruncated metadata write failed: ${err.message}`));
-      }
-    }
-    pendingLines.push(cleanLine);
-    scheduleFlush();
-  };
+  // Output buffering + raw PTY spooling (parsed-line → output.txt/state,
+  // raw bytes → raw.txt, both debounced) live in the extracted spooler so
+  // this function stays orchestration. `appendLine` records a status line,
+  // `pushRaw` queues a raw chunk, `drainLines`/`drainRaw` flush at finalize,
+  // and `getOutputBuffer` reads the capped buffer for failure-analysis fallback.
+  const spooler = createOutputSpooler({ agentId, outputFile, rawFile });
+  const { appendLine, pushRaw, flushRaw, drainLines, drainRaw, getOutputBuffer } = spooler;
 
   // Read the `.agent-done` sentinel (if present) and append its markdown task
   // summary line-by-line into the agent's output so downstream consumers
@@ -610,10 +399,8 @@ export async function spawnTuiAgent({
 
     // Drain pending parsed lines AND raw chunks before the final state
     // writes so completion events don't beat the last output batch to disk.
-    if (flushing) await flushing.catch(() => {});
-    await flushPendingLines();
-    if (rawFlushing) await rawFlushing.catch(() => {});
-    await flushPendingRawChunks();
+    await drainLines();
+    await drainRaw();
 
     if (pausedAgents.has(agentId)) {
       pausedAgents.delete(agentId);
@@ -644,28 +431,24 @@ export async function spawnTuiAgent({
       errorExecutionMessage: finalError || `TUI agent ended: ${reason}`,
     });
 
-    // output.txt has already been incrementally appended via flushPendingLines;
-    // do NOT writeFile() it from outputBuffer at finalize — outputBuffer is
+    // output.txt has already been incrementally appended via the spooler;
+    // do NOT writeFile() it from the output buffer at finalize — the buffer is
     // capped at OUTPUT_BUFFER_CAP and would silently truncate the on-disk
     // record for long runs. The append-only stream is the authoritative copy.
     //
-    // For failure analysis: read only the tail of the raw PTY spool — the
-    // analyzer's window is the last ~200 lines, so reading the full file
-    // (potentially many MB on long agents) would defeat the disk-spool's
-    // memory-bound guarantee. Successful runs skip the read entirely.
-    // raw.txt stays in agentDir alongside output.txt as the persistent
-    // record of the agent's full PTY transcript.
-    const rawAnalysisText = finalSuccess
-      ? null
-      : await readFileTail(rawFile, RAW_TAIL_ANALYSIS_BYTES);
-    // `??` (not `||`) so an empty raw spool ('') stays distinguishable from
-    // a read failure (null) — readFileTail's contract. A zero-byte raw.txt
-    // (file was created but the PTY never emitted) lets failure analysis
-    // run against ''; both a missing file AND a read error return null and
-    // fall back to outputBuffer (which has the spawn-startup notices).
-    const errorAnalysis = finalSuccess
-      ? null
-      : (immediateFallbackAnalysis || analyzeAgentFailure(rawAnalysisText ?? outputBuffer, task, model));
+    // For failure analysis: resolveErrorAnalysis reads only the tail of the raw
+    // PTY spool (the analyzer's window is the last ~200 lines) and falls back to
+    // the capped output buffer if the spool is missing/unreadable. Successful
+    // runs skip the read entirely. raw.txt stays in agentDir alongside
+    // output.txt as the persistent record of the agent's full PTY transcript.
+    const errorAnalysis = await resolveErrorAnalysis({
+      finalSuccess,
+      rawFile,
+      fallbackText: getOutputBuffer(),
+      task,
+      model,
+      immediateFallbackAnalysis,
+    });
 
     // try/finally so a throw from finalizeAgent (e.g. processAgentCompletion
     // hook crash) still runs the local cleanup — sentinel removal, worktree
@@ -681,7 +464,7 @@ export async function spawnTuiAgent({
         success: finalSuccess,
         exitCode,
         duration,
-        outputBuffer,
+        outputBuffer: getOutputBuffer(),
         errorAnalysis,
         terminatedByUser,
         isTruthyMetaFn,
@@ -702,7 +485,7 @@ export async function spawnTuiAgent({
         requestCopilotReview: false,
         skipMerge: true,
         description: task.description,
-        agentOutput: outputBuffer,
+        agentOutput: getOutputBuffer(),
         originalTask: task
       }).catch(err => emitLog('warn', `TUI worktree cleanup failed for ${agentId}: ${err.message}`, { agentId }));
 
@@ -731,8 +514,7 @@ export async function spawnTuiAgent({
       // a Buffer-emitting encoding.
       const text = typeof data === 'string' ? data : String(data);
       const stripped = streamingStrip(text);
-      pendingRawChunks.push(text);
-      scheduleRawFlush();
+      pushRaw(text);
       // Accumulate the ANSI-STRIPPED chunk (not the raw text): the paste marker
       // is rendered with absolute-column cursor moves between glyphs, so it only
       // matches after stripping (see countPasteMarkers). Appending raw text here
@@ -893,7 +675,7 @@ export async function spawnTuiAgent({
     // Flush any debounced raw-PTY chunks first so the captured tail includes
     // the CLI's most recent output (e.g. claude's final error before exiting),
     // not just whatever happened to be on disk before the last 250ms window.
-    await flushPendingRawChunks().catch(() => {});
+    await flushRaw().catch(() => {});
     const raw = await readFile(rawFile, 'utf8').catch(() => '');
     const tail = raw
       ? stripAnsi(raw).split('\n').map((s) => s.trimEnd()).filter(Boolean).slice(-12).join('\n')

--- a/server/services/agentTuiSpawning/finalizeHelpers.js
+++ b/server/services/agentTuiSpawning/finalizeHelpers.js
@@ -1,0 +1,112 @@
+/**
+ * Agent TUI finalize helpers
+ *
+ * Failure-analysis + worktree-inspection support for spawnTuiAgent's finalize
+ * path. All side-effect-narrow and non-throwing: a failure to read the raw
+ * spool, inspect the worktree, or capture a diff must never abort finish()
+ * before finalizeAgent runs. Extracted from spawnTuiAgent so the "read the
+ * spool tail → analyze the failure" concern is self-contained and testable.
+ */
+
+import { join } from 'path';
+import { open, stat as fsStat, writeFile } from 'fs/promises';
+import * as git from '../git.js';
+import { analyzeAgentFailure } from '../agentErrorAnalysis.js';
+
+// Tail-read window for raw.txt at failure analysis. analyzeAgentFailure only
+// inspects the last ~200 lines, so reading the whole file (which has no upper
+// bound for long-running agents) would reintroduce the OOM risk the disk
+// spool was meant to avoid. 1MB easily contains the last 200 lines of any
+// realistic PTY stream while keeping peak finalize memory bounded.
+export const RAW_TAIL_ANALYSIS_BYTES = 1024 * 1024;
+
+/**
+ * Read at most `maxBytes` from the end of a file. Returns null when the file
+ * doesn't exist or can't be opened; an empty string for a zero-byte file.
+ * Used to bound the memory footprint of failure-analysis reads against the
+ * uncapped raw PTY spool. Non-throwing — any failure surfaces as null so
+ * the caller's failure-analysis path can fall back to outputBuffer instead
+ * of aborting `finish()` before finalizeAgent runs.
+ */
+export async function readFileTail(path, maxBytes) {
+  const st = await fsStat(path).catch(() => null);
+  if (!st) return null;
+  if (st.size === 0) return '';
+  const start = Math.max(0, st.size - maxBytes);
+  const length = st.size - start;
+  const fh = await open(path, 'r').catch(() => null);
+  if (!fh) return null;
+  try {
+    const buf = Buffer.alloc(length);
+    // Honour bytesRead — the file can shrink between stat and read, or the
+    // OS can return a short read; decoding the whole `buf` would otherwise
+    // append NULs to the returned string. Read failures surface as null so
+    // callers can distinguish "empty file" ('') from "read error" (null) —
+    // a `bytesRead: 0` fallback would conflate the two.
+    const readResult = await fh.read(buf, 0, length, start).catch(() => null);
+    if (readResult === null) return null;
+    return buf.toString('utf8', 0, readResult.bytesRead);
+  } finally {
+    await fh.close().catch(() => {});
+  }
+}
+
+/**
+ * Check if a worktree has any uncommitted changes. Returns true when the
+ * working tree is dirty (staged or unstaged changes exist). Used to gate
+ * idle-complete success — an agent that idled out with zero file changes
+ * should fail, not succeed.
+ */
+export async function worktreeHasChanges(workspacePath) {
+  if (!workspacePath || typeof workspacePath !== 'string') return false;
+  const status = await git.getStatus(workspacePath).catch(() => null);
+  return status && !status.clean;
+}
+
+/**
+ * Capture the git diff (staged + unstaged) from a worktree and save it to the
+ * agent archive dir. Called before worktree cleanup so post-mortems can see
+ * what changes existed even if the worktree is deleted. Non-throwing — a
+ * failure to capture shouldn't block finalize.
+ *
+ * @returns {string|null} The captured diff, or null if none/error.
+ */
+export async function captureWorktreeDiff(workspacePath, agentDir) {
+  if (!workspacePath || typeof workspacePath !== 'string') return null;
+  if (!agentDir || typeof agentDir !== 'string') return null;
+  const [staged, unstaged] = await Promise.all([
+    git.getDiff(workspacePath, true).catch(() => ''),
+    git.getDiff(workspacePath, false).catch(() => ''),
+  ]);
+  const combined = [
+    staged ? `### STAGED CHANGES ###\n${staged}` : '',
+    unstaged ? `### UNSTAGED CHANGES ###\n${unstaged}` : '',
+  ].filter(Boolean).join('\n\n');
+  if (!combined.trim()) return null;
+  const diffFile = join(agentDir, 'worktree-diff.txt');
+  await writeFile(diffFile, combined).catch((err) => {
+    console.error(`❌ Failed to capture worktree diff for agent: ${err.message}`);
+  });
+  return combined;
+}
+
+/**
+ * Resolve the error-analysis payload for a finalizing agent. Successful runs
+ * skip the raw-spool read entirely (that's what keeps the disk-spool's
+ * bounded-memory guarantee for healthy long runs); failures read only the
+ * tail of raw.txt and hand it to analyzeAgentFailure.
+ *
+ * `??` (not `||`) so an empty raw spool ('') stays distinguishable from a read
+ * failure (null) — readFileTail's contract. A zero-byte raw.txt lets analysis
+ * run against ''; both a missing file AND a read error return null and fall
+ * back to `fallbackText` (the capped output buffer, which has the spawn-startup
+ * notices). An immediate-fallback signal, if one was detected mid-stream,
+ * short-circuits the analysis entirely.
+ *
+ * @returns {Promise<object|null>} The error-analysis object, or null on success.
+ */
+export async function resolveErrorAnalysis({ finalSuccess, rawFile, fallbackText, task, model, immediateFallbackAnalysis }) {
+  if (finalSuccess) return null;
+  const rawAnalysisText = await readFileTail(rawFile, RAW_TAIL_ANALYSIS_BYTES);
+  return immediateFallbackAnalysis || analyzeAgentFailure(rawAnalysisText ?? fallbackText, task, model);
+}

--- a/server/services/agentTuiSpawning/finalizeHelpers.test.js
+++ b/server/services/agentTuiSpawning/finalizeHelpers.test.js
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, readFile, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// git + failure analyzer are mocked; fs/promises stays REAL so readFileTail /
+// captureWorktreeDiff are exercised against actual temp files.
+vi.mock('../git.js', () => ({
+  getStatus: vi.fn(),
+  getDiff: vi.fn(),
+}));
+vi.mock('../agentErrorAnalysis.js', () => ({
+  analyzeAgentFailure: vi.fn(),
+}));
+
+import * as git from '../git.js';
+import { analyzeAgentFailure } from '../agentErrorAnalysis.js';
+import {
+  readFileTail,
+  worktreeHasChanges,
+  captureWorktreeDiff,
+  resolveErrorAnalysis,
+  RAW_TAIL_ANALYSIS_BYTES,
+} from './finalizeHelpers.js';
+
+describe('finalizeHelpers', () => {
+  let dir;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    dir = await mkdtemp(join(tmpdir(), 'finalize-helpers-'));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  describe('readFileTail', () => {
+    it('returns null for a missing file (distinct from empty)', async () => {
+      expect(await readFileTail(join(dir, 'nope.txt'), 1024)).toBeNull();
+    });
+
+    it('returns an empty string for a zero-byte file', async () => {
+      const p = join(dir, 'empty.txt');
+      await writeFile(p, '');
+      expect(await readFileTail(p, 1024)).toBe('');
+    });
+
+    it('returns the whole file when maxBytes exceeds its size', async () => {
+      const p = join(dir, 'small.txt');
+      await writeFile(p, 'hello');
+      expect(await readFileTail(p, 1024)).toBe('hello');
+    });
+
+    it('returns only the trailing maxBytes when the file is larger', async () => {
+      const p = join(dir, 'big.txt');
+      await writeFile(p, 'abcdefghij'); // 10 bytes
+      expect(await readFileTail(p, 4)).toBe('ghij');
+    });
+
+    it('RAW_TAIL_ANALYSIS_BYTES is a sane 1MB bound', () => {
+      expect(RAW_TAIL_ANALYSIS_BYTES).toBe(1024 * 1024);
+    });
+  });
+
+  describe('worktreeHasChanges', () => {
+    it('is true when git reports an unclean worktree', async () => {
+      vi.mocked(git.getStatus).mockResolvedValue({ clean: false });
+      expect(await worktreeHasChanges('/tmp/ws')).toBe(true);
+    });
+
+    it('is false when git reports a clean worktree', async () => {
+      vi.mocked(git.getStatus).mockResolvedValue({ clean: true });
+      expect(await worktreeHasChanges('/tmp/ws')).toBe(false);
+    });
+
+    it('is falsy (never throws) when getStatus rejects', async () => {
+      vi.mocked(git.getStatus).mockRejectedValue(new Error('not a repo'));
+      expect(await worktreeHasChanges('/tmp/ws')).toBeFalsy();
+    });
+
+    it('is false for a non-string / empty path without touching git', async () => {
+      expect(await worktreeHasChanges(null)).toBe(false);
+      expect(await worktreeHasChanges('')).toBe(false);
+      expect(git.getStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('captureWorktreeDiff', () => {
+    it('writes a combined staged+unstaged diff and returns it', async () => {
+      vi.mocked(git.getDiff).mockImplementation(async (_dir, staged) => (staged ? 'S-DIFF' : 'U-DIFF'));
+      const combined = await captureWorktreeDiff('/tmp/ws', dir);
+      expect(combined).toContain('### STAGED CHANGES ###');
+      expect(combined).toContain('S-DIFF');
+      expect(combined).toContain('### UNSTAGED CHANGES ###');
+      expect(combined).toContain('U-DIFF');
+      // Persisted alongside the agent archive dir for post-mortems.
+      expect(await readFile(join(dir, 'worktree-diff.txt'), 'utf8')).toBe(combined);
+    });
+
+    it('returns null when there is no diff to capture', async () => {
+      vi.mocked(git.getDiff).mockResolvedValue('');
+      expect(await captureWorktreeDiff('/tmp/ws', dir)).toBeNull();
+    });
+
+    it('returns null for invalid args', async () => {
+      expect(await captureWorktreeDiff(null, dir)).toBeNull();
+      expect(await captureWorktreeDiff('/tmp/ws', null)).toBeNull();
+    });
+  });
+
+  describe('resolveErrorAnalysis', () => {
+    it('returns null on success WITHOUT reading the spool or analyzing', async () => {
+      const result = await resolveErrorAnalysis({
+        finalSuccess: true, rawFile: join(dir, 'raw.txt'), fallbackText: 'buf', task: {}, model: 'm',
+      });
+      expect(result).toBeNull();
+      expect(analyzeAgentFailure).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits to an immediate fallback signal when present', async () => {
+      const signal = { message: 'fallback required' };
+      const result = await resolveErrorAnalysis({
+        finalSuccess: false, rawFile: join(dir, 'raw.txt'), fallbackText: 'buf',
+        task: {}, model: 'm', immediateFallbackAnalysis: signal,
+      });
+      expect(result).toBe(signal);
+      expect(analyzeAgentFailure).not.toHaveBeenCalled();
+    });
+
+    it('analyzes the raw-spool tail on failure', async () => {
+      const p = join(dir, 'raw.txt');
+      await writeFile(p, 'PTY TAIL OUTPUT');
+      vi.mocked(analyzeAgentFailure).mockReturnValue({ classification: 'x' });
+      const task = { id: 't' };
+      const result = await resolveErrorAnalysis({
+        finalSuccess: false, rawFile: p, fallbackText: 'buf', task, model: 'm',
+      });
+      expect(analyzeAgentFailure).toHaveBeenCalledWith('PTY TAIL OUTPUT', task, 'm');
+      expect(result).toEqual({ classification: 'x' });
+    });
+
+    it('falls back to the output buffer when the spool is missing (read returns null)', async () => {
+      vi.mocked(analyzeAgentFailure).mockReturnValue({ classification: 'fb' });
+      const result = await resolveErrorAnalysis({
+        finalSuccess: false, rawFile: join(dir, 'missing.txt'), fallbackText: 'BUFFER FALLBACK',
+        task: {}, model: 'm',
+      });
+      // Missing file → readFileTail null → `?? fallbackText` supplies the buffer.
+      expect(analyzeAgentFailure).toHaveBeenCalledWith('BUFFER FALLBACK', {}, 'm');
+      expect(result).toEqual({ classification: 'fb' });
+    });
+  });
+});

--- a/server/services/agentTuiSpawning/outputSpooler.js
+++ b/server/services/agentTuiSpawning/outputSpooler.js
@@ -1,0 +1,212 @@
+/**
+ * Agent TUI output spooler
+ *
+ * Owns the two batched write pipelines a TUI agent spawn needs:
+ *
+ *  1. Parsed status lines → the in-memory `outputBuffer` (capped) AND the
+ *     append-only `output.txt` + agent state stream (via appendAgentOutputLines).
+ *  2. Raw PTY bytes → the append-only `raw.txt` disk spool (no ANSI strip, no
+ *     line semantics) that `analyzeAgentFailure` reads on failure.
+ *
+ * Both pipelines debounce writes on a 250ms window (see CLAUDE.md "High-
+ * frequency state writes must batch") — a chatty TUI emits hundreds of chunks
+ * /sec, and per-chunk state writes would thrash the filesystem and slow the PTY
+ * event loop. Extracted from spawnTuiAgent so the buffering/spooling concern is
+ * self-contained and independently testable; the spawner keeps only the
+ * orchestration.
+ */
+
+import { appendFile, writeFile } from 'fs/promises';
+import { appendAgentOutputLines, updateAgent } from '../cosAgents.js';
+import { OUTPUT_BUFFER_CAP, OUTPUT_BUFFER_HEADROOM, RAW_SPOOL_MAX_BYTES } from '../../lib/tuiHandshake.js';
+
+// Debounce window for batching parsed output AND raw chunks to disk + state.
+// 250ms is invisible to the live tail but cuts I/O by 1-2 orders of magnitude.
+const OUTPUT_FLUSH_INTERVAL_MS = 250;
+
+// RAW_SPOOL_MAX_BYTES lives in tuiHandshake.js so the test suite can shrink the
+// cap via the same vi.mock pattern that overrides the output-buffer thresholds
+// — saves the truncation test from having to push hundreds of MB through the
+// spawner. A misbehaving (or compromised) TUI agent could in principle emit
+// MB/sec forever and fill the volume; realistic agents idle out at 180s and
+// emit <10MB total. At this threshold the spool is truncated (rewritten with
+// the current batch) so the most-recent data remains, which is what the
+// tail-read at finalize needs anyway. Warn fires once per agent run; the
+// `rawSpoolTruncated` metadata flag persists in the agent record so the
+// operator can spot the affected runs after the fact.
+
+/**
+ * Create the per-agent output spooler. Returns the small surface the spawner
+ * drives: append a parsed line, push a raw PTY chunk, drain both pipelines at
+ * finalize, and read the capped in-memory buffer for failure-analysis fallback.
+ *
+ * @param {object} opts
+ * @param {string} opts.agentId  Agent id (used for warn logs + metadata writes).
+ * @param {string} opts.outputFile  Absolute path to output.txt.
+ * @param {string} opts.rawFile  Absolute path to raw.txt.
+ */
+export function createOutputSpooler({ agentId, outputFile, rawFile }) {
+  let outputBuffer = '';
+  let lastLine = '';
+  // True once outputBuffer crossed its HEADROOM and the head was dropped.
+  // Mirrors `outputBufferTruncated` in `tuiPromptRunner.js`: warn once per
+  // buffer and surface via agent metadata so the agent record distinguishes
+  // a long-run-with-overflow from a clean short run.
+  let outputBufferTruncated = false;
+
+  let pendingLines = [];
+  let flushTimer = null;
+  let flushing = null;
+  let pendingRawChunks = [];
+  let rawFlushTimer = null;
+  let rawFlushing = null;
+  let rawBytesWritten = 0;
+  let rawSpoolTruncationWarned = false;
+
+  const flushPendingLines = async () => {
+    if (flushTimer) { clearTimeout(flushTimer); flushTimer = null; }
+    if (pendingLines.length === 0) return;
+    const batch = pendingLines;
+    pendingLines = [];
+    await Promise.all([
+      appendAgentOutputLines(agentId, batch).catch(() => {}),
+      appendFile(outputFile, batch.map(l => `${l}\n`).join('')).catch(() => {})
+    ]);
+  };
+
+  const scheduleFlush = () => {
+    if (flushTimer || flushing) return;
+    flushTimer = setTimeout(() => {
+      flushTimer = null;
+      flushing = flushPendingLines().finally(() => {
+        flushing = null;
+        // Catch chunks that arrived during the in-flight flush — without
+        // this, a producer that goes quiet right after the flush starts
+        // strands its last batch in pendingLines until finalize.
+        if (pendingLines.length > 0) scheduleFlush();
+      });
+    }, OUTPUT_FLUSH_INTERVAL_MS);
+  };
+
+  // Raw PTY flush pipeline. Parallel to flushPendingLines but appends the
+  // unprocessed chunks (no ANSI strip, no line semantics) to raw.txt.
+  // shellService surfaces node-pty output as already-decoded UTF-8 strings
+  // (node-pty's internal StringDecoder handles multi-byte boundaries before
+  // we see chunks), so queueing strings here is sufficient — no Buffer
+  // bookkeeping needed. pendingRawChunks holds whatever arrives during the
+  // 250ms debounce window AND while an appendFile is in-flight (the next
+  // scheduleRawFlush is gated by rawFlushing); join() runs once per flush
+  // tick, so peak in-memory raw data is bounded by one debounce-plus-IO
+  // window of TUI output (typically hundreds of KB on a chatty agent).
+  const flushPendingRawChunks = async () => {
+    if (rawFlushTimer) { clearTimeout(rawFlushTimer); rawFlushTimer = null; }
+    if (pendingRawChunks.length === 0) return;
+    const batch = pendingRawChunks.join('');
+    pendingRawChunks = [];
+    // Count UTF-8 bytes actually written to disk, NOT the UTF-16 code-unit
+    // length of the JS string — non-ASCII output would otherwise under-
+    // report and let the spool exceed the safety cap.
+    const batchBytes = Buffer.byteLength(batch, 'utf8');
+    if (rawBytesWritten + batchBytes > RAW_SPOOL_MAX_BYTES) {
+      // Safety valve: rewrite the file with just this batch instead of
+      // appending. The tail-read at finalize wants the MOST RECENT bytes,
+      // not the oldest, so truncating preserves what analyzeAgentFailure
+      // actually uses while bounding disk usage at ~RAW_SPOOL_MAX_BYTES.
+      // If a single debounce-window batch exceeds the cap (runaway producer
+      // emitting MB/sec), slice to the trailing RAW_SPOOL_MAX_BYTES bytes
+      // first — Buffer-slice to keep UTF-8 byte semantics correct (a
+      // string.slice would index by UTF-16 code units and produce torn
+      // multi-byte sequences at the boundary).
+      let writeBuf;
+      if (batchBytes > RAW_SPOOL_MAX_BYTES) {
+        const buf = Buffer.from(batch, 'utf8');
+        writeBuf = buf.subarray(buf.length - RAW_SPOOL_MAX_BYTES);
+      } else {
+        writeBuf = batch;
+      }
+      const writeBytes = typeof writeBuf === 'string' ? batchBytes : writeBuf.length;
+      if (!rawSpoolTruncationWarned) {
+        rawSpoolTruncationWarned = true;
+        console.warn(`⚠️ TUI agent ${agentId} raw PTY spool reached ${Math.round(RAW_SPOOL_MAX_BYTES / 1024 / 1024)}MB — truncating spool (oldest bytes dropped; tail-read still reflects most recent)`);
+        updateAgent(agentId, { metadata: { rawSpoolTruncated: true } })
+          .catch(err => console.error(`❌ TUI agent ${agentId} rawSpoolTruncated metadata write failed: ${err.message}`));
+      }
+      // Only update the byte counter on successful write — a failed write
+      // would otherwise inflate rawBytesWritten and make subsequent flush
+      // decisions race the actual on-disk state.
+      const wrote = await writeFile(rawFile, writeBuf).then(() => true).catch(() => false);
+      if (wrote) rawBytesWritten = writeBytes;
+      return;
+    }
+    const wrote = await appendFile(rawFile, batch).then(() => true).catch(() => false);
+    if (wrote) rawBytesWritten += batchBytes;
+  };
+
+  const scheduleRawFlush = () => {
+    if (rawFlushTimer || rawFlushing) return;
+    rawFlushTimer = setTimeout(() => {
+      rawFlushTimer = null;
+      rawFlushing = flushPendingRawChunks().finally(() => {
+        rawFlushing = null;
+        // Same re-schedule guard as scheduleFlush: chunks that arrived
+        // during the in-flight appendFile would otherwise sit until
+        // finalize if the producer goes quiet immediately after.
+        if (pendingRawChunks.length > 0) scheduleRawFlush();
+      });
+    }, OUTPUT_FLUSH_INTERVAL_MS);
+  };
+
+  // TUI agents only emit a handful of internal status lines (session-started,
+  // prompt-pasted, completion) — see handleData for why per-line capture of
+  // the PTY stream itself is intentionally dropped.
+  const appendLine = (line) => {
+    const cleanLine = line.trim();
+    if (!cleanLine || cleanLine === lastLine) return;
+
+    lastLine = cleanLine;
+    outputBuffer += `${cleanLine}\n`;
+    if (outputBuffer.length > OUTPUT_BUFFER_HEADROOM) {
+      outputBuffer = outputBuffer.slice(-OUTPUT_BUFFER_CAP);
+      if (!outputBufferTruncated) {
+        outputBufferTruncated = true;
+        console.warn(`⚠️ TUI agent ${agentId} parsed-output buffer exceeded ${Math.round(OUTPUT_BUFFER_HEADROOM / 1024 / 1024)}MB — head dropped (output.txt is the authoritative on-disk record)`);
+        updateAgent(agentId, { metadata: { outputBufferTruncated: true } })
+          .catch(err => console.error(`❌ TUI agent ${agentId} outputBufferTruncated metadata write failed: ${err.message}`));
+      }
+    }
+    pendingLines.push(cleanLine);
+    scheduleFlush();
+  };
+
+  // Queue a raw PTY chunk for the debounced raw.txt spool.
+  const pushRaw = (text) => {
+    pendingRawChunks.push(text);
+    scheduleRawFlush();
+  };
+
+  // Drain the parsed-line pipeline: await any in-flight flush, then flush
+  // whatever is still pending. Called at finalize (and mirrored order matters —
+  // see drainRaw) so completion events don't beat the last batch to disk.
+  const drainLines = async () => {
+    if (flushing) await flushing.catch(() => {});
+    await flushPendingLines();
+  };
+
+  // Drain the raw-chunk pipeline. Same shape as drainLines.
+  const drainRaw = async () => {
+    if (rawFlushing) await rawFlushing.catch(() => {});
+    await flushPendingRawChunks();
+  };
+
+  return {
+    appendLine,
+    pushRaw,
+    // Flush only the raw pipeline immediately (no in-flight await) — used by the
+    // startup-failure path so the captured raw.txt tail includes the CLI's most
+    // recent output before it's read back.
+    flushRaw: flushPendingRawChunks,
+    drainLines,
+    drainRaw,
+    getOutputBuffer: () => outputBuffer,
+  };
+}

--- a/server/services/agentTuiSpawning/outputSpooler.test.js
+++ b/server/services/agentTuiSpawning/outputSpooler.test.js
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Replace the disk + state + config deps so the spooler's batching/spooling
+// wiring can be asserted in isolation. Tiny caps trip the truncation paths
+// without pushing MB through the pipeline.
+vi.mock('fs/promises', () => ({
+  appendFile: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../cosAgents.js', () => ({
+  appendAgentOutputLines: vi.fn().mockResolvedValue(undefined),
+  updateAgent: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../lib/tuiHandshake.js', () => ({
+  OUTPUT_BUFFER_HEADROOM: 100,
+  OUTPUT_BUFFER_CAP: 50,
+  RAW_SPOOL_MAX_BYTES: 100,
+}));
+
+import { appendFile, writeFile } from 'fs/promises';
+import { appendAgentOutputLines, updateAgent } from '../cosAgents.js';
+import { createOutputSpooler } from './outputSpooler.js';
+
+const OUTPUT_FILE = '/tmp/agent/output.txt';
+const RAW_FILE = '/tmp/agent/raw.txt';
+
+const makeSpooler = () => createOutputSpooler({ agentId: 'agent-1', outputFile: OUTPUT_FILE, rawFile: RAW_FILE });
+
+describe('createOutputSpooler', () => {
+  let warnSpy;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+  });
+
+  it('appendLine flushes to output.txt AND the agent state stream on drain', async () => {
+    const s = makeSpooler();
+    s.appendLine('hello world');
+    await s.drainLines();
+
+    expect(appendAgentOutputLines).toHaveBeenCalledWith('agent-1', ['hello world']);
+    expect(appendFile).toHaveBeenCalledWith(OUTPUT_FILE, 'hello world\n');
+    expect(s.getOutputBuffer()).toBe('hello world\n');
+  });
+
+  it('dedupes an immediately-repeated line and ignores blank lines', async () => {
+    const s = makeSpooler();
+    s.appendLine('same');
+    s.appendLine('same');   // consecutive duplicate → dropped
+    s.appendLine('   ');    // blank after trim → dropped
+    s.appendLine('next');
+    await s.drainLines();
+
+    expect(appendAgentOutputLines).toHaveBeenCalledWith('agent-1', ['same', 'next']);
+    expect(s.getOutputBuffer()).toBe('same\nnext\n');
+  });
+
+  it('warns once and flags metadata when the output buffer overflows HEADROOM', async () => {
+    const s = makeSpooler();
+    s.appendLine('x'.repeat(200)); // > HEADROOM (100) → truncate to CAP (50)
+    s.appendLine('y'.repeat(200)); // trips again, but warn/metadata fire only once
+
+    const warns = warnSpy.mock.calls.filter(a => String(a[0]).includes('parsed-output buffer exceeded'));
+    expect(warns).toHaveLength(1);
+    const metaCalls = vi.mocked(updateAgent).mock.calls.filter(([, p]) => p?.metadata?.outputBufferTruncated === true);
+    expect(metaCalls).toHaveLength(1);
+    // Buffer is kept at the CAP tail, never unbounded.
+    expect(s.getOutputBuffer().length).toBeLessThanOrEqual(50);
+  });
+
+  it('pushRaw appends raw chunks to raw.txt on drain', async () => {
+    const s = makeSpooler();
+    s.pushRaw('abc');
+    await s.drainRaw();
+    expect(appendFile).toHaveBeenCalledWith(RAW_FILE, 'abc');
+  });
+
+  it('truncates the raw spool (writeFile) once it crosses the cap, warning + flagging once', async () => {
+    const s = makeSpooler();
+    s.pushRaw('a'.repeat(80)); // under cap (100) → appendFile
+    await s.drainRaw();
+    s.pushRaw('b'.repeat(80)); // 80 + 80 = 160 > cap → writeFile safety valve
+    await s.drainRaw();
+
+    const rawWrites = vi.mocked(writeFile).mock.calls.filter(([p]) => p === RAW_FILE);
+    expect(rawWrites.length).toBeGreaterThan(0);
+
+    const warns = warnSpy.mock.calls.filter(a => String(a[0]).includes('raw PTY spool reached'));
+    expect(warns).toHaveLength(1);
+    const metaCalls = vi.mocked(updateAgent).mock.calls.filter(([, p]) => p?.metadata?.rawSpoolTruncated === true);
+    expect(metaCalls).toHaveLength(1);
+  });
+
+  it('drainLines / drainRaw are no-ops when nothing is pending', async () => {
+    const s = makeSpooler();
+    await s.drainLines();
+    await s.drainRaw();
+    expect(appendFile).not.toHaveBeenCalled();
+    expect(appendAgentOutputLines).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

`spawnTuiAgent()` in `server/services/agentTuiSpawning.js` had grown to ~1000 lines, handling PTY spawn, output buffering/spooling, sentinel polling, idle/runtime timeouts, paste-marker handshaking, and failure analysis in one function body. This extracts the two most cohesive, self-contained sub-concerns into sibling modules so `spawnTuiAgent` reads as an orchestrator:

- **`agentTuiSpawning/outputSpooler.js`** — `createOutputSpooler({ agentId, outputFile, rawFile })` owns both batched write pipelines: parsed status lines → `output.txt` + agent state stream, and raw PTY bytes → the `raw.txt` disk spool (with the once-per-run overflow warn + metadata flag, the disk-safety-valve truncation, and the 250ms debounce). Exposes `appendLine`, `pushRaw`, `flushRaw`, `drainLines`, `drainRaw`, `getOutputBuffer`.
- **`agentTuiSpawning/finalizeHelpers.js`** — the failure-analysis + worktree-inspection helpers that were module-level functions: `readFileTail`, `worktreeHasChanges`, `captureWorktreeDiff`, plus a new `resolveErrorAnalysis` that folds the finalize-path "read the raw-spool tail, else fall back to the output buffer, else honor an immediate-fallback signal" logic into one call. `RAW_TAIL_ANALYSIS_BYTES` moves here.

The main module drops from ~1385 to ~1166 lines. No behavior change to spawn/timeout/completion semantics — the extracted code is byte-for-byte the same logic, only relocated, and every call site in `spawnTuiAgent` (`finish()` drain + error-analysis + `outputBuffer` reads, `handleData` raw push, `finishStartupFailure` raw flush) is rewired to the new surface with identical ordering.

## Test plan

- `npx vitest run services/agentTuiSpawning.test.js` — all 54 existing agent-spawn tests pass unchanged (idle-complete/idle-no-activity/idle-no-changes, max-runtime, paste handshake, MCP-boot budget, raw-spool truncation, tail-read, sentinel ingestion, etc.).
- New `services/agentTuiSpawning/outputSpooler.test.js` (7 cases) covers appendLine flush + dedup + blank-drop, output-buffer overflow warn/metadata (once), raw append vs. truncation dispatch, and no-op drains.
- New `services/agentTuiSpawning/finalizeHelpers.test.js` (15 cases) covers `readFileTail` (missing → null, empty → '', whole-file, tail-slice), `worktreeHasChanges` (dirty/clean/reject/empty-path), `captureWorktreeDiff` (combined write + return, no-diff, invalid args), and `resolveErrorAnalysis` (success skips read, immediate-fallback short-circuit, tail analyze, missing-spool fallback).
- `npx vitest run services/agentManagement.test.js` — 34 pass (downstream consumer unaffected).

Closes #2833