### PR TITLE
fix([issue-2855]): repair stored Gmail activity rows when send-as aliases are learned

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,6 +3,7 @@
 ## Tribe outreach
 
 - **[issue-2831] Unanswered 1:1 emails to a Gmail alias now surface as outreach nudges** — a message delivered to one of your Gmail send-as aliases (not your primary address) is correctly treated as a one-on-one conversation instead of a group thread, so a genuinely unanswered email to an alias no longer gets silently skipped. Your own alias addresses never appear as a Tribe contact.
+- **[issue-2855] Alias-addressed emails already on your timeline get repaired too** — the first time an account's Gmail send-as aliases are learned, existing activity entries that still list your own alias as a participant are cleaned up in place. Previously only newly-synced mail benefited, so an unanswered 1:1 sent to an alias before the upgrade stayed invisible to outreach nudges until it aged out of the two-week window.
 
 ## Render Queue
 

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,7 +3,7 @@
 ## Tribe outreach
 
 - **[issue-2831] Unanswered 1:1 emails to a Gmail alias now surface as outreach nudges** — a message delivered to one of your Gmail send-as aliases (not your primary address) is correctly treated as a one-on-one conversation instead of a group thread, so a genuinely unanswered email to an alias no longer gets silently skipped. Your own alias addresses never appear as a Tribe contact.
-- **[issue-2855] Alias-addressed emails already on your timeline get repaired too** — the first time an account's Gmail send-as aliases are learned, existing activity entries that still list your own alias as a participant are cleaned up in place. Previously only newly-synced mail benefited, so an unanswered 1:1 sent to an alias before the upgrade stayed invisible to outreach nudges until it aged out of the two-week window.
+- **[issue-2855] Alias-addressed emails already on your timeline get repaired too** — existing activity entries that still list one of your own Gmail aliases as a participant are cleaned up in place — once at upgrade for aliases already on file, and again whenever an account learns a new alias. Previously only newly-synced mail benefited, so an unanswered 1:1 sent to an alias before the upgrade stayed invisible to outreach nudges until it aged out of the two-week window.
 
 ## Render Queue
 

--- a/server/scripts/db-migrations/001-strip-send-as-aliases-from-activity-participants.js
+++ b/server/scripts/db-migrations/001-strip-send-as-aliases-from-activity-participants.js
@@ -1,0 +1,47 @@
+/**
+ * 001 — strip already-known Gmail send-as aliases from stored activity participants (#2855).
+ *
+ * `messageActivityCandidates` excludes every owner address (primary + send-as
+ * aliases) from a received message's participants, but rows recorded BEFORE an
+ * account's alias set was learned kept the alias as a second participant. Because
+ * activity inserts are `ON CONFLICT (source, dedupe_key) DO NOTHING` (a deliberate
+ * "re-syncs are no-ops" contract), a re-sync never rewrites them — so a 1:1 email
+ * delivered to an alias keeps looking like a group thread to the Tribe-outreach
+ * detector.
+ *
+ * The sync path (`messageSync.repairActivityAliasParticipants`) repairs rows when
+ * an account learns a NEW alias, but that delta trigger can't help an install whose
+ * alias set was ALREADY learned by an earlier build — the set never changes again,
+ * so the trigger never fires. This migration closes that gap once, at upgrade, by
+ * stripping every currently-stored alias from that account's existing rows.
+ *
+ * Idempotent by construction (the `EXISTS` gate means a second run matches nothing),
+ * and recorded in `schema_migrations` so it only runs once anyway.
+ */
+import { join } from 'path';
+import { PATHS, safeJSONParse, tryReadFile } from '../../lib/fileUtils.js';
+import { isPlainObject } from '../../lib/objects.js';
+import { stripParticipantsForAccount } from '../../services/humanActivity.js';
+
+export async function up(client) {
+  const content = await tryReadFile(join(PATHS.messages, 'accounts.json'));
+  if (!content) return; // no message accounts on this install — nothing to repair
+  const parsed = safeJSONParse(content, {}, { context: 'migration-001-send-as-aliases' });
+  if (!isPlainObject(parsed)) return;
+
+  let repaired = 0;
+  for (const account of Object.values(parsed)) {
+    if (!account?.id) continue;
+    // Reuses the service's scoped rewrite, but on the migration's transaction
+    // client so the repair shares this migration's all-or-nothing semantics.
+    repaired += await stripParticipantsForAccount(
+      account.id,
+      account.type || 'message',
+      account.sendAsAliases,
+      { client },
+    );
+  }
+  if (repaired > 0) {
+    console.log(`🗓️  Migration 001: stripped owner send-as aliases from ${repaired} activity event(s)`);
+  }
+}

--- a/server/scripts/db-migrations/001-strip-send-as-aliases-from-activity-participants.js
+++ b/server/scripts/db-migrations/001-strip-send-as-aliases-from-activity-participants.js
@@ -18,16 +18,44 @@
  * Idempotent by construction (the `EXISTS` gate means a second run matches nothing),
  * and recorded in `schema_migrations` so it only runs once anyway.
  */
+import { readFile } from 'fs/promises';
 import { join } from 'path';
-import { PATHS, safeJSONParse, tryReadFile } from '../../lib/fileUtils.js';
+import { PATHS } from '../../lib/fileUtils.js';
 import { isPlainObject } from '../../lib/objects.js';
 import { stripParticipantsForAccount } from '../../services/humanActivity.js';
 
+// Repo-relative label for error messages — never interpolate the absolute path,
+// which embeds the OS username.
+const ACCOUNTS_LABEL = 'data/messages/accounts.json';
+
 export async function up(client) {
-  const content = await tryReadFile(join(PATHS.messages, 'accounts.json'));
-  if (!content) return; // no message accounts on this install — nothing to repair
-  const parsed = safeJSONParse(content, {}, { context: 'migration-001-send-as-aliases' });
-  if (!isPlainObject(parsed)) return;
+  // Read WITHOUT the usual `tryReadFile`/`safeJSONParse` swallowing: those collapse
+  // "file absent" and "read/parse FAILED" into the same empty result, and here the
+  // difference is permanent. This migration is recorded in `schema_migrations` the
+  // moment `up()` returns normally, so a transient unreadable/corrupt accounts file
+  // would mark the one-shot backfill done and it would never run — and the sync-time
+  // delta can't cover for it either (those aliases are already stored, so the delta
+  // is empty forever). Only a genuinely absent file means "no work"; any other
+  // failure throws, which rolls the migration back UNAPPLIED so the next boot
+  // retries it. (try/catch is sanctioned here — this runs at boot, outside the
+  // Express request lifecycle.)
+  let content;
+  try {
+    content = await readFile(join(PATHS.messages, 'accounts.json'), 'utf8');
+  } catch (err) {
+    if (err?.code === 'ENOENT') return; // no message accounts on this install — nothing to repair
+    throw new Error(`migration 001: cannot read ${ACCOUNTS_LABEL} (${err?.code || 'read error'}) — refusing to mark the send-as-alias backfill applied: ${err.message}`);
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch (err) {
+    throw new Error(`migration 001: ${ACCOUNTS_LABEL} is not valid JSON — refusing to mark the send-as-alias backfill applied: ${err.message}`);
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(`migration 001: ${ACCOUNTS_LABEL} did not contain an account map — refusing to mark the send-as-alias backfill applied.`);
+  }
 
   let repaired = 0;
   for (const account of Object.values(parsed)) {

--- a/server/scripts/db-migrations/001-strip-send-as-aliases-from-activity-participants.test.js
+++ b/server/scripts/db-migrations/001-strip-send-as-aliases-from-activity-participants.test.js
@@ -1,0 +1,74 @@
+/**
+ * Tests for migration 001 (#2855) — no live DB: the pg transaction client is a
+ * stub that records the statements the migration issues, and the accounts file
+ * is mocked. Asserts the migration reads each account's ALREADY-stored send-as
+ * aliases and issues the scoped repair on the supplied transaction client (the
+ * gap the sync-path delta trigger can't close, since the set never changes again
+ * on an install that learned it under an earlier build).
+ *
+ * `*.test.js` files in this directory are ignored by the migration runner.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const tryReadFile = vi.fn();
+vi.mock('../../lib/fileUtils.js', () => ({
+  tryReadFile,
+  PATHS: { messages: '/mock/data/messages', data: '/mock/data' },
+  safeJSONParse: (content, fallback) => { try { return JSON.parse(content); } catch { return fallback; } },
+  ensureDir: vi.fn(),
+  atomicWrite: vi.fn(),
+}));
+
+const { up } = await import('./001-strip-send-as-aliases-from-activity-participants.js');
+
+const makeClient = () => {
+  const calls = [];
+  return { calls, query: (sql, params) => { calls.push({ sql, params }); return Promise.resolve({ rowCount: 1 }); } };
+};
+
+const accountsFile = (accounts) => JSON.stringify(accounts);
+
+describe('migration 001 — strip send-as aliases from activity participants (#2855)', () => {
+  beforeEach(() => tryReadFile.mockReset());
+
+  it('repairs each account that already has stored aliases, scoped by id + type', async () => {
+    tryReadFile.mockResolvedValue(accountsFile({
+      a: { id: 'acct-a', type: 'gmail', sendAsAliases: ['Alias@Example.com'] },
+      b: { id: 'acct-b', type: 'outlook', sendAsAliases: ['b1@example.com', 'b2@example.com'] },
+    }));
+    const client = makeClient();
+    await up(client);
+    expect(client.calls).toHaveLength(2);
+    // Aliases are normalized (lowercased) before they reach the statement.
+    expect(client.calls[0].params).toEqual(['acct-a', 'gmail', ['alias@example.com']]);
+    expect(client.calls[1].params).toEqual(['acct-b', 'outlook', ['b1@example.com', 'b2@example.com']]);
+    expect(client.calls[0].sql).toContain('UPDATE human_activity_events');
+  });
+
+  it('skips accounts with no aliases, no id, or a non-Gmail account that never learned any', async () => {
+    tryReadFile.mockResolvedValue(accountsFile({
+      a: { id: 'acct-a', type: 'gmail', sendAsAliases: [] },
+      b: { id: 'acct-b', type: 'outlook' },
+      c: { type: 'gmail', sendAsAliases: ['x@example.com'] }, // no id — unscopeable
+    }));
+    const client = makeClient();
+    await up(client);
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it('is a no-op on an install with no message accounts file', async () => {
+    tryReadFile.mockResolvedValue(null);
+    const client = makeClient();
+    await up(client);
+    expect(client.calls).toHaveLength(0);
+  });
+
+  it('is a no-op when the accounts file is corrupt or not an object', async () => {
+    const client = makeClient();
+    tryReadFile.mockResolvedValue('{ not json');
+    await up(client);
+    tryReadFile.mockResolvedValue('[]');
+    await up(client);
+    expect(client.calls).toHaveLength(0);
+  });
+});

--- a/server/scripts/db-migrations/001-strip-send-as-aliases-from-activity-participants.test.js
+++ b/server/scripts/db-migrations/001-strip-send-as-aliases-from-activity-participants.test.js
@@ -1,19 +1,31 @@
 /**
  * Tests for migration 001 (#2855) — no live DB: the pg transaction client is a
  * stub that records the statements the migration issues, and the accounts file
- * is mocked. Asserts the migration reads each account's ALREADY-stored send-as
- * aliases and issues the scoped repair on the supplied transaction client (the
- * gap the sync-path delta trigger can't close, since the set never changes again
- * on an install that learned it under an earlier build).
+ * read is mocked. Asserts the migration reads each account's ALREADY-stored
+ * send-as aliases and issues the scoped repair on the supplied transaction client
+ * (the gap the sync-path delta trigger can't close, since the set never changes
+ * again on an install that learned it under an earlier build).
+ *
+ * Also pins the absent-vs-failed distinction: the runner records this migration
+ * as applied the moment `up()` returns, so a swallowed read failure would mark
+ * the one-shot backfill done and it could never run again. Only ENOENT is "no
+ * work"; every other failure must throw so the migration rolls back unapplied.
  *
  * `*.test.js` files in this directory are ignored by the migration runner.
  */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-const tryReadFile = vi.fn();
+// Each test sets its own readFile implementation, and the client stub is rebuilt
+// per test, so no beforeEach reset is needed — and adding one is actively harmful:
+// under vitest 4, clearing this factory-created mock makes the errors its
+// implementation throws surface as unhandled test failures even though up()
+// catches them.
+const readFile = vi.fn();
+vi.mock('fs/promises', () => ({ readFile }));
+
 vi.mock('../../lib/fileUtils.js', () => ({
-  tryReadFile,
   PATHS: { messages: '/mock/data/messages', data: '/mock/data' },
+  tryReadFile: vi.fn(),
   safeJSONParse: (content, fallback) => { try { return JSON.parse(content); } catch { return fallback; } },
   ensureDir: vi.fn(),
   atomicWrite: vi.fn(),
@@ -26,13 +38,12 @@ const makeClient = () => {
   return { calls, query: (sql, params) => { calls.push({ sql, params }); return Promise.resolve({ rowCount: 1 }); } };
 };
 
-const accountsFile = (accounts) => JSON.stringify(accounts);
+const enoent = () => Object.assign(new Error('no such file'), { code: 'ENOENT' });
+const ioError = () => Object.assign(new Error('permission denied'), { code: 'EACCES' });
 
 describe('migration 001 — strip send-as aliases from activity participants (#2855)', () => {
-  beforeEach(() => tryReadFile.mockReset());
-
   it('repairs each account that already has stored aliases, scoped by id + type', async () => {
-    tryReadFile.mockResolvedValue(accountsFile({
+    readFile.mockResolvedValue(JSON.stringify({
       a: { id: 'acct-a', type: 'gmail', sendAsAliases: ['Alias@Example.com'] },
       b: { id: 'acct-b', type: 'outlook', sendAsAliases: ['b1@example.com', 'b2@example.com'] },
     }));
@@ -45,8 +56,8 @@ describe('migration 001 — strip send-as aliases from activity participants (#2
     expect(client.calls[0].sql).toContain('UPDATE human_activity_events');
   });
 
-  it('skips accounts with no aliases, no id, or a non-Gmail account that never learned any', async () => {
-    tryReadFile.mockResolvedValue(accountsFile({
+  it('skips accounts with no aliases, no id, or one that never learned any', async () => {
+    readFile.mockResolvedValue(JSON.stringify({
       a: { id: 'acct-a', type: 'gmail', sendAsAliases: [] },
       b: { id: 'acct-b', type: 'outlook' },
       c: { type: 'gmail', sendAsAliases: ['x@example.com'] }, // no id — unscopeable
@@ -56,19 +67,36 @@ describe('migration 001 — strip send-as aliases from activity participants (#2
     expect(client.calls).toHaveLength(0);
   });
 
-  it('is a no-op on an install with no message accounts file', async () => {
-    tryReadFile.mockResolvedValue(null);
+  it('is a no-op on an install with no message accounts file (ENOENT is genuine "no work")', async () => {
+    readFile.mockImplementation(() => { throw enoent(); });
     const client = makeClient();
-    await up(client);
+    await expect(up(client)).resolves.toBeUndefined();
     expect(client.calls).toHaveLength(0);
   });
 
-  it('is a no-op when the accounts file is corrupt or not an object', async () => {
-    const client = makeClient();
-    tryReadFile.mockResolvedValue('{ not json');
-    await up(client);
-    tryReadFile.mockResolvedValue('[]');
-    await up(client);
-    expect(client.calls).toHaveLength(0);
+  // The three cases below MUST throw. Returning normally would let the runner
+  // record the migration as applied, permanently skipping the one-shot backfill —
+  // and the sync-time delta can't recover it, because those aliases are already
+  // stored so the delta is empty forever.
+  it('throws when the accounts file exists but cannot be read, so the migration retries next boot', async () => {
+    readFile.mockImplementation(() => { throw ioError(); });
+    await expect(up(makeClient())).rejects.toThrow(/cannot read data\/messages\/accounts\.json/);
+  });
+
+  it('throws when the accounts file is malformed JSON', async () => {
+    readFile.mockResolvedValue('{ not json');
+    await expect(up(makeClient())).rejects.toThrow(/not valid JSON/);
+  });
+
+  it('throws when the accounts file parses to a non-object', async () => {
+    readFile.mockResolvedValue('[]');
+    await expect(up(makeClient())).rejects.toThrow(/did not contain an account map/);
+  });
+
+  it('never leaks the absolute accounts path (which embeds the OS username) into an error', async () => {
+    readFile.mockImplementation(() => { throw ioError(); });
+    const err = await up(makeClient()).catch((e) => e);
+    expect(err.message).not.toContain('/mock/data/messages');
+    expect(err.message).toContain('data/messages/accounts.json');
   });
 });

--- a/server/services/humanActivity.db.test.js
+++ b/server/services/humanActivity.db.test.js
@@ -3,6 +3,7 @@
  *   - recordEvents()   — idempotent insert via ON CONFLICT (source, dedupe_key)
  *   - listEvents()     — range / source / kind / personId filters
  *   - getDaySummary()  — local-day window + hourly histogram + tallies
+ *   - stripParticipantsForAccount() — scoped send-as-alias backfill (#2855)
  *
  * `*.db.test.js` → runs ONLY via `npm run test:db` against `portos_test`, never
  * the real `portos` DB (the db.js runner guard + the suite skip below enforce
@@ -12,7 +13,7 @@
  */
 import { describe, it, expect, afterAll } from 'vitest';
 import { checkHealth, ensureSchema, close, query } from '../lib/db.js';
-import { recordEvents, listEvents, getDaySummary } from './humanActivity.js';
+import { recordEvents, listEvents, getDaySummary, stripParticipantsForAccount } from './humanActivity.js';
 
 let dbReady = false;
 let skipReason = '';
@@ -30,10 +31,14 @@ if (!dbReady) console.log(`⏭️ humanActivity.db.test: skipping suite — ${sk
 const nonce = `ha${Date.now()}`;
 const SOURCE = `test-${nonce}`;
 const PERSON = `person-${nonce}`;
+// The alias-backfill tests need their own source: stripParticipantsForAccount is
+// scoped by (account_id, source), and a shared source would let one test's repair
+// touch another's rows.
+const ALIAS_SOURCE = `test-${nonce}-alias`;
 
 afterAll(async () => {
   if (dbReady) {
-    await query('DELETE FROM human_activity_events WHERE source = $1', [SOURCE]).catch(() => {});
+    await query('DELETE FROM human_activity_events WHERE source = ANY($1::text[])', [[SOURCE, ALIAS_SOURCE]]).catch(() => {});
     await close();
   }
 });
@@ -127,5 +132,99 @@ describe.skipIf(!dbReady)('humanActivity store (#2150)', () => {
     expect(summary.histogram).toHaveLength(24);
     expect(typeof summary.counts.total).toBe('number');
     expect(summary.counts.bySource).toBeTruthy();
+  });
+});
+
+describe.skipIf(!dbReady)('stripParticipantsForAccount — send-as alias backfill (#2855)', () => {
+  const ACCT = `acct-${nonce}`;
+  const OTHER_ACCT = `other-${nonce}`;
+  const ALIAS = 'alias@example.com';
+
+  const aliasRow = (over = {}) => ({
+    source: ALIAS_SOURCE,
+    accountId: ACCT,
+    kind: 'message.received',
+    happenedAt: '2026-07-04T15:00:00Z',
+    title: 'Hey',
+    metadata: { handle: 'friend@x.io', threadId: 't-1' },
+    ...over,
+  });
+
+  const fetchRow = async (dedupeKey) => {
+    const rows = await listEvents({ source: ALIAS_SOURCE, limit: 2000 });
+    return rows.find((r) => r.dedupeKey === dedupeKey);
+  };
+
+  it('strips the alias from an existing 1:1 row, leaving the sender and metadata.handle intact', async () => {
+    await recordEvents([aliasRow({
+      dedupeKey: 'alias-1',
+      participants: [{ email: 'friend@x.io' }, { email: ALIAS }],
+    })]);
+
+    const repaired = await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, [ALIAS]);
+    expect(repaired).toBeGreaterThanOrEqual(1);
+
+    const row = await fetchRow('alias-1');
+    // Now a true 1:1 — exactly one counterpart, so outreach detection stops
+    // rejecting it as a group conversation.
+    expect(row.participants).toEqual([{ email: 'friend@x.io' }]);
+    // The sender pointer is untouched — it identifies the person, not the owner.
+    expect(row.metadata.handle).toBe('friend@x.io');
+  });
+
+  it('matches the alias case-insensitively and accepts an unnormalized input list', async () => {
+    await recordEvents([aliasRow({
+      dedupeKey: 'alias-case',
+      participants: [{ email: 'friend@x.io' }, { email: ALIAS }],
+    })]);
+    await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, ['  Alias@EXAMPLE.com ']);
+    const row = await fetchRow('alias-case');
+    expect(row.participants).toEqual([{ email: 'friend@x.io' }]);
+  });
+
+  it('leaves rows with no alias participant untouched', async () => {
+    const participants = [{ name: 'Pat', email: 'pat@x.io' }, { email: 'sam@x.io' }];
+    await recordEvents([aliasRow({ dedupeKey: 'alias-none', participants })]);
+    await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, [ALIAS]);
+    const row = await fetchRow('alias-none');
+    expect(row.participants).toEqual(participants);
+  });
+
+  it('is scoped to the account — another account keeping the same address is untouched', async () => {
+    await recordEvents([aliasRow({
+      dedupeKey: 'alias-other-acct',
+      accountId: OTHER_ACCT,
+      participants: [{ email: 'friend@x.io' }, { email: ALIAS }],
+    })]);
+    await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, [ALIAS]);
+    const row = await fetchRow('alias-other-acct');
+    expect(row.participants.map((p) => p.email)).toContain(ALIAS);
+  });
+
+  it('yields an empty array (not NULL) when every participant was an owner address', async () => {
+    await recordEvents([aliasRow({
+      dedupeKey: 'alias-all',
+      participants: [{ email: ALIAS }],
+    })]);
+    await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, [ALIAS]);
+    const row = await fetchRow('alias-all');
+    expect(row.participants).toEqual([]);
+  });
+
+  it('is idempotent — a second repair matches nothing and reports 0 rows', async () => {
+    await recordEvents([aliasRow({
+      dedupeKey: 'alias-idem',
+      participants: [{ email: 'friend@x.io' }, { email: ALIAS }],
+    })]);
+    await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, [ALIAS]);
+    const second = await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, [ALIAS]);
+    expect(second).toBe(0);
+  });
+
+  it('no-ops without touching the DB when the alias list is empty or the scope is missing', async () => {
+    expect(await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, [])).toBe(0);
+    expect(await stripParticipantsForAccount(null, ALIAS_SOURCE, [ALIAS])).toBe(0);
+    expect(await stripParticipantsForAccount(ACCT, '', [ALIAS])).toBe(0);
+    expect(await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, ['', null])).toBe(0);
   });
 });

--- a/server/services/humanActivity.db.test.js
+++ b/server/services/humanActivity.db.test.js
@@ -221,10 +221,19 @@ describe.skipIf(!dbReady)('stripParticipantsForAccount — send-as alias backfil
     expect(second).toBe(0);
   });
 
-  it('no-ops without touching the DB when the alias list is empty or the scope is missing', async () => {
-    expect(await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, [])).toBe(0);
-    expect(await stripParticipantsForAccount(null, ALIAS_SOURCE, [ALIAS])).toBe(0);
-    expect(await stripParticipantsForAccount(ACCT, '', [ALIAS])).toBe(0);
-    expect(await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, ['', null])).toBe(0);
+  it('runs on a caller-supplied transaction client when one is passed (boot migration path)', async () => {
+    await recordEvents([aliasRow({
+      dedupeKey: 'alias-tx',
+      participants: [{ email: 'friend@x.io' }, { email: ALIAS }],
+    })]);
+    // A thin client shim over the pool is enough to prove the option routes the
+    // statement through the supplied client instead of the module's own query().
+    const calls = [];
+    const client = { query: (sql, params) => { calls.push(sql); return query(sql, params); } };
+    const repaired = await stripParticipantsForAccount(ACCT, ALIAS_SOURCE, [ALIAS], { client });
+    expect(repaired).toBe(1);
+    expect(calls).toHaveLength(1);
+    const row = await fetchRow('alias-tx');
+    expect(row.participants).toEqual([{ email: 'friend@x.io' }]);
   });
 });

--- a/server/services/humanActivity.js
+++ b/server/services/humanActivity.js
@@ -230,6 +230,20 @@ export function messageActivityCandidates(account, messages = []) {
   return out;
 }
 
+// Owner addresses present in `next` but not in `previous` — the aliases an
+// account just LEARNED (#2855). Only these can appear as a stale participant on
+// already-stored rows, so the backfill repairs exactly this set; a removed alias
+// needs no repair, and an unchanged set means there is nothing to do (which keeps
+// every routine sync from re-UPDATEing the whole table). Lowercased + deduped so
+// a casing-only refresh doesn't read as a change.
+export function newlyLearnedAliases(previous, next) {
+  const norm = (list) => (Array.isArray(list) ? list : [])
+    .map((e) => String(e || '').trim().toLowerCase())
+    .filter(Boolean);
+  const before = new Set(norm(previous));
+  return [...new Set(norm(next))].filter((e) => !before.has(e));
+}
+
 // Resolve a calendar time value to a UTC instant, interpreting OFFSET-LESS
 // values in the given timezone instead of the Node process's OS timezone.
 // Google all-day events are normalized to "YYYY-MM-DDT00:00:00" (no offset) —
@@ -372,6 +386,54 @@ async function insertActivityChunk(rows) {
     values,
   );
   return result.rowCount || 0;
+}
+
+// Repair already-stored events whose participants still list an owner address
+// (#2855, follow-up to #2831). `messageActivityCandidates` strips every owner
+// address at INSERT time, but rows written BEFORE an account's send-as aliases
+// were learned kept the alias as a second participant — and since re-syncs are
+// no-ops (`ON CONFLICT (source, dedupe_key) DO NOTHING`, a deliberate contract
+// shared with `tribe_touchpoints`), they never self-correct. A 1:1 message
+// delivered to an alias therefore keeps looking like a group conversation to
+// `findUnansweredTribeThreads` until it ages out of the 14-day window.
+//
+// This is a SCOPED backfill, not a change to the insert contract: it rewrites
+// only rows for one account+source that actually contain one of the named
+// alias emails, and only removes those participant entries. `metadata.handle`
+// (the counterpart sender) is left untouched. Returns the number of rows
+// repaired. Emails are compared lowercased (participants are stored that way).
+export async function stripParticipantsForAccount(accountId, source, aliasEmails = []) {
+  const emails = [...new Set(
+    (Array.isArray(aliasEmails) ? aliasEmails : [])
+      .map((e) => String(e || '').trim().toLowerCase())
+      .filter(Boolean),
+  )];
+  if (!accountId || !source || emails.length === 0) return 0;
+  await ensureReady();
+  // jsonb_agg over the filtered elements rebuilds the array; COALESCE covers the
+  // case where every participant was an owner address (jsonb_agg returns NULL for
+  // an empty set, which would null out a NOT NULL column).
+  const result = await query(
+    `UPDATE human_activity_events
+        SET participants = COALESCE((
+              SELECT jsonb_agg(p)
+                FROM jsonb_array_elements(participants) AS p
+               WHERE lower(COALESCE(p->>'email', '')) <> ALL($3::text[])
+            ), '[]'::jsonb)
+      WHERE account_id = $1
+        AND source = $2
+        AND EXISTS (
+              SELECT 1
+                FROM jsonb_array_elements(participants) AS p
+               WHERE lower(COALESCE(p->>'email', '')) = ANY($3::text[])
+            )`,
+    [String(accountId), String(source), emails],
+  );
+  const repaired = result.rowCount || 0;
+  if (repaired > 0) {
+    console.log(`🗓️  Repaired ${repaired} activity event(s) for account ${accountId} (${emails.length} owner alias(es) stripped)`);
+  }
+  return repaired;
 }
 
 // Query events with optional filters. `from`/`to` are ISO timestamps (inclusive

--- a/server/services/humanActivity.js
+++ b/server/services/humanActivity.js
@@ -22,6 +22,7 @@
  */
 import { v4 as uuidv4 } from '../lib/uuid.js';
 import { ensureSchema, query } from '../lib/db.js';
+import { normalizeIdentifier } from '../lib/tribeMatch.js';
 import { getUserTimezone, getLocalParts, getUtcOffsetMs, todayInTimezone } from '../lib/timezone.js';
 
 // ---------------------------------------------------------------------------
@@ -162,7 +163,14 @@ export function summarizeCounts(events) {
 
 function participantEmail(p) {
   if (!p) return '';
-  return String((typeof p === 'string' ? p : p.email) || '').trim().toLowerCase();
+  return normalizeIdentifier(typeof p === 'string' ? p : p.email);
+}
+
+// Lowercase + trim + dedupe a list of email addresses, dropping empties. Shares
+// `normalizeIdentifier` with the Tribe matcher so owner-address comparison here
+// can't drift from the identity matching that consumes these events.
+export function normalizeEmailList(list) {
+  return [...new Set((Array.isArray(list) ? list : []).map(normalizeIdentifier).filter(Boolean))];
 }
 
 // Map an account's cached messages to activity candidates. Direction (sent vs
@@ -176,9 +184,7 @@ export function messageActivityCandidates(account, messages = []) {
   // (messageGmailSync → messageAccounts.sendAsAliases); absent/failed fetch leaves the
   // set as just the primary email, i.e. today's behavior.
   const ownerEmails = new Set(
-    [selfEmail, ...(Array.isArray(account?.sendAsAliases) ? account.sendAsAliases : [])]
-      .map((e) => String(e || '').trim().toLowerCase())
-      .filter(Boolean)
+    normalizeEmailList([selfEmail, ...(Array.isArray(account?.sendAsAliases) ? account.sendAsAliases : [])])
   );
   const source = account?.type || 'message';
   const accountId = account?.id || null;
@@ -237,11 +243,8 @@ export function messageActivityCandidates(account, messages = []) {
 // every routine sync from re-UPDATEing the whole table). Lowercased + deduped so
 // a casing-only refresh doesn't read as a change.
 export function newlyLearnedAliases(previous, next) {
-  const norm = (list) => (Array.isArray(list) ? list : [])
-    .map((e) => String(e || '').trim().toLowerCase())
-    .filter(Boolean);
-  const before = new Set(norm(previous));
-  return [...new Set(norm(next))].filter((e) => !before.has(e));
+  const before = new Set(normalizeEmailList(previous));
+  return normalizeEmailList(next).filter((e) => !before.has(e));
 }
 
 // Resolve a calendar time value to a UTC instant, interpreting OFFSET-LESS
@@ -402,33 +405,50 @@ async function insertActivityChunk(rows) {
 // alias emails, and only removes those participant entries. `metadata.handle`
 // (the counterpart sender) is left untouched. Returns the number of rows
 // repaired. Emails are compared lowercased (participants are stored that way).
-export async function stripParticipantsForAccount(accountId, source, aliasEmails = []) {
-  const emails = [...new Set(
-    (Array.isArray(aliasEmails) ? aliasEmails : [])
-      .map((e) => String(e || '').trim().toLowerCase())
-      .filter(Boolean),
-  )];
+//
+// `client` (optional) runs the rewrite on a caller-supplied pg transaction client
+// instead of the pool — the boot db-migration that repairs already-known alias
+// sets passes its transaction client so the repair shares the migration's
+// all-or-nothing semantics, without re-stating the statement.
+//
+// The EXISTS gate keeps the rewrite off rows that don't need it (so a re-run is a
+// genuine no-op and reports 0 rows), and jsonb_agg over the filtered elements
+// rebuilds the array. COALESCE covers the all-owner row: jsonb_agg returns NULL
+// over an empty set, which would null the column.
+//
+// The predicate is deliberately stated twice (positive in EXISTS, negated in the
+// rebuild) rather than shared via one LATERAL unnest: Postgres rejects an
+// `UPDATE t … FROM LATERAL (… t.col …)` with "invalid reference to FROM-clause
+// entry", so the target row's participants can't be expanded once and reused.
+const STRIP_OWNER_PARTICIPANTS_SQL = `
+  UPDATE human_activity_events
+     SET participants = COALESCE((
+           SELECT jsonb_agg(p)
+             FROM jsonb_array_elements(participants) AS p
+            WHERE lower(COALESCE(p->>'email', '')) <> ALL($3::text[])
+         ), '[]'::jsonb)
+   WHERE account_id = $1
+     AND source = $2
+     AND EXISTS (
+           SELECT 1
+             FROM jsonb_array_elements(participants) AS p
+            WHERE lower(COALESCE(p->>'email', '')) = ANY($3::text[])
+         )`;
+
+export async function stripParticipantsForAccount(accountId, source, aliasEmails = [], { client } = {}) {
+  const emails = normalizeEmailList(aliasEmails);
   if (!accountId || !source || emails.length === 0) return 0;
-  await ensureReady();
-  // jsonb_agg over the filtered elements rebuilds the array; COALESCE covers the
-  // case where every participant was an owner address (jsonb_agg returns NULL for
-  // an empty set, which would null out a NOT NULL column).
-  const result = await query(
-    `UPDATE human_activity_events
-        SET participants = COALESCE((
-              SELECT jsonb_agg(p)
-                FROM jsonb_array_elements(participants) AS p
-               WHERE lower(COALESCE(p->>'email', '')) <> ALL($3::text[])
-            ), '[]'::jsonb)
-      WHERE account_id = $1
-        AND source = $2
-        AND EXISTS (
-              SELECT 1
-                FROM jsonb_array_elements(participants) AS p
-               WHERE lower(COALESCE(p->>'email', '')) = ANY($3::text[])
-            )`,
-    [String(accountId), String(source), emails],
-  );
+  const params = [String(accountId), String(source), emails];
+  let result;
+  if (client) {
+    // The migration runner ensures the base schema before applying migrations,
+    // so ensureReady() (which would go through the pool) is neither needed nor
+    // safe to run inside someone else's transaction.
+    result = await client.query(STRIP_OWNER_PARTICIPANTS_SQL, params);
+  } else {
+    await ensureReady();
+    result = await query(STRIP_OWNER_PARTICIPANTS_SQL, params);
+  }
   const repaired = result.rowCount || 0;
   if (repaired > 0) {
     console.log(`🗓️  Repaired ${repaired} activity event(s) for account ${accountId} (${emails.length} owner alias(es) stripped)`);

--- a/server/services/humanActivity.test.js
+++ b/server/services/humanActivity.test.js
@@ -16,6 +16,7 @@ import {
   summarizeCounts,
   messageActivityCandidates,
   calendarActivityCandidates,
+  newlyLearnedAliases,
 } from './humanActivity.js';
 
 describe('shortSummary', () => {
@@ -259,5 +260,30 @@ describe('calendarActivityCandidates', () => {
       { externalId: 'ad2', title: 'Zoomed', startTime: '2026-07-04T09:00:00Z', endTime: '2026-07-04T09:30:00Z' },
     ], nowLate, 'America/Los_Angeles');
     expect(z.happenedAt).toBe('2026-07-04T09:00:00.000Z');
+  });
+});
+
+describe('newlyLearnedAliases (#2855)', () => {
+  it('returns only the aliases added since the previous set', () => {
+    expect(newlyLearnedAliases(['a@x.io'], ['a@x.io', 'b@x.io'])).toEqual(['b@x.io']);
+  });
+  it('treats a first-ever fetch (no prior set) as all-new', () => {
+    expect(newlyLearnedAliases(undefined, ['a@x.io', 'b@x.io'])).toEqual(['a@x.io', 'b@x.io']);
+    expect(newlyLearnedAliases([], ['a@x.io'])).toEqual(['a@x.io']);
+  });
+  it('is empty for an unchanged set, so a routine sync does no repair work', () => {
+    expect(newlyLearnedAliases(['a@x.io', 'b@x.io'], ['b@x.io', 'a@x.io'])).toEqual([]);
+  });
+  it('ignores casing and whitespace so a cosmetic refresh is not a change', () => {
+    expect(newlyLearnedAliases(['A@x.io'], [' a@X.io '])).toEqual([]);
+  });
+  it('ignores removals — a dropped alias needs no backfill', () => {
+    expect(newlyLearnedAliases(['a@x.io', 'b@x.io'], ['a@x.io'])).toEqual([]);
+  });
+  it('dedupes and drops empty entries', () => {
+    expect(newlyLearnedAliases([], ['a@x.io', 'a@x.io', '', null])).toEqual(['a@x.io']);
+  });
+  it('returns [] for non-array input', () => {
+    expect(newlyLearnedAliases(null, null)).toEqual([]);
   });
 });

--- a/server/services/humanActivity.test.js
+++ b/server/services/humanActivity.test.js
@@ -17,6 +17,7 @@ import {
   messageActivityCandidates,
   calendarActivityCandidates,
   newlyLearnedAliases,
+  stripParticipantsForAccount,
 } from './humanActivity.js';
 
 describe('shortSummary', () => {
@@ -285,5 +286,21 @@ describe('newlyLearnedAliases (#2855)', () => {
   });
   it('returns [] for non-array input', () => {
     expect(newlyLearnedAliases(null, null)).toEqual([]);
+  });
+});
+
+describe('stripParticipantsForAccount guards (#2855)', () => {
+  // The DB round-trip lives in humanActivity.db.test.js; these cases never reach
+  // the database at all — they assert the early return that keeps a pointless
+  // UPDATE (and a pool connection) off every routine sync.
+  const noDbClient = { query: () => { throw new Error('should not query'); } };
+  it('no-ops when the alias list is empty or normalizes to empty', async () => {
+    expect(await stripParticipantsForAccount('acct-1', 'gmail', [], { client: noDbClient })).toBe(0);
+    expect(await stripParticipantsForAccount('acct-1', 'gmail', ['', null], { client: noDbClient })).toBe(0);
+    expect(await stripParticipantsForAccount('acct-1', 'gmail', 'not-an-array', { client: noDbClient })).toBe(0);
+  });
+  it('no-ops when the account or source scope is missing', async () => {
+    expect(await stripParticipantsForAccount(null, 'gmail', ['a@x.io'], { client: noDbClient })).toBe(0);
+    expect(await stripParticipantsForAccount('acct-1', '', ['a@x.io'], { client: noDbClient })).toBe(0);
   });
 });

--- a/server/services/messageSync.js
+++ b/server/services/messageSync.js
@@ -270,10 +270,24 @@ export async function syncAccount(accountId, io, options = {}) {
       // so repair exactly those rows once, right when the set changes.
       const previousAliases = account.sendAsAliases;
       account.sendAsAliases = sendAsAliases;
-      await updateSendAsAliases(accountId, sendAsAliases).catch((err) =>
-        console.error(`📧 Send-as alias persist failed for account ${accountId}: ${err.message}`));
-      await repairActivityAliasParticipants(account, previousAliases, sendAsAliases).catch((err) =>
-        console.error(`🗓️  Activity alias backfill failed for account ${accountId}: ${err.message}`));
+      // ORDER IS LOAD-BEARING: repair BEFORE persisting the new set. The repair is
+      // triggered by the delta between the stored set and this sync's set, so if we
+      // persisted first and the repair then failed transiently, the next sync would
+      // see an UNCHANGED set, compute an empty delta, and never retry — the stale
+      // rows would stay broken forever. Leaving the old set stored on failure means
+      // the next sync recomputes the same delta and tries again. The cost is that a
+      // failed repair also defers the persist by one sync interval; the in-memory
+      // set is already updated above, so THIS sync's activity ingest still excludes
+      // every owner address either way.
+      let repaired = true;
+      await repairActivityAliasParticipants(account, previousAliases, sendAsAliases).catch((err) => {
+        repaired = false;
+        console.error(`🗓️  Activity alias backfill failed for account ${accountId} — deferring alias persist so the next sync retries: ${err.message}`);
+      });
+      if (repaired) {
+        await updateSendAsAliases(accountId, sendAsAliases).catch((err) =>
+          console.error(`📧 Send-as alias persist failed for account ${accountId}: ${err.message}`));
+      }
     }
 
     // Populate the human-activity timeline (#2150) — secondary effect, must NOT

--- a/server/services/messageSync.js
+++ b/server/services/messageSync.js
@@ -264,9 +264,16 @@ export async function syncAccount(accountId, io, options = {}) {
     // Best-effort: a `null` sentinel (fetch failed / non-Gmail provider) leaves the
     // stored set untouched; persist failure must not fail the sync.
     if (Array.isArray(sendAsAliases)) {
+      // Aliases learned for the FIRST time this sync (#2855). Rows recorded before
+      // the alias set was known still carry the alias as a participant, and the
+      // `ON CONFLICT DO NOTHING` insert contract means they never self-correct —
+      // so repair exactly those rows once, right when the set changes.
+      const previousAliases = account.sendAsAliases;
       account.sendAsAliases = sendAsAliases;
       await updateSendAsAliases(accountId, sendAsAliases).catch((err) =>
         console.error(`📧 Send-as alias persist failed for account ${accountId}: ${err.message}`));
+      await repairActivityAliasParticipants(account, previousAliases, sendAsAliases).catch((err) =>
+        console.error(`🗓️  Activity alias backfill failed for account ${accountId}: ${err.message}`));
     }
 
     // Populate the human-activity timeline (#2150) — secondary effect, must NOT
@@ -520,4 +527,15 @@ export async function recordMessageActivity(account, messages = []) {
   const candidates = messageActivityCandidates(account, messages);
   if (candidates.length === 0) return { recorded: 0, skipped: 0 };
   return recordEvents(candidates);
+}
+
+// One-shot repair of activity rows recorded BEFORE this account's send-as aliases
+// were known (#2855). Runs only for the aliases newly learned this sync, so a
+// routine sync with an unchanged set does no DB work at all. Returns the number of
+// rows repaired. Secondary effect — the caller must not let it fail the sync.
+export async function repairActivityAliasParticipants(account, previousAliases, nextAliases) {
+  const { newlyLearnedAliases, stripParticipantsForAccount } = await import('./humanActivity.js');
+  const learned = newlyLearnedAliases(previousAliases, nextAliases);
+  if (learned.length === 0) return 0;
+  return stripParticipantsForAccount(account?.id, account?.type || 'message', learned);
 }

--- a/server/services/messageSyncAliasBackfill.test.js
+++ b/server/services/messageSyncAliasBackfill.test.js
@@ -28,9 +28,17 @@ vi.mock('../lib/fileUtils.js', () => ({
 
 vi.mock('./messageAccounts.js', () => ({
   getAccount: vi.fn(),
-  updateSyncStatus: vi.fn(),
+  updateSyncStatus: vi.fn(() => Promise.resolve()),
   markSentIngested: vi.fn(() => Promise.resolve()),
   updateSendAsAliases: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('./messageGmailSync.js', () => ({ syncGmail: vi.fn() }));
+
+// tribe.js is loaded dynamically by logMessageTouchpoints; stub it so the sync
+// path doesn't need a live Postgres.
+vi.mock('./tribe.js', () => ({
+  autoLogTouchpoints: vi.fn().mockResolvedValue({ created: 0, matched: 0 }),
 }));
 
 // Keep the REAL pure helpers (notably `newlyLearnedAliases` — re-stating it in a
@@ -42,7 +50,10 @@ vi.mock('./humanActivity.js', async (importOriginal) => ({
   recordEvents: vi.fn(() => Promise.resolve({ recorded: 0, skipped: 0 })),
 }));
 
-const { repairActivityAliasParticipants } = await import('./messageSync.js');
+const { repairActivityAliasParticipants, syncAccount } = await import('./messageSync.js');
+const { getAccount, updateSendAsAliases } = await import('./messageAccounts.js');
+const { syncGmail } = await import('./messageGmailSync.js');
+const { tryReadFile } = await import('../lib/fileUtils.js');
 
 const account = { id: 'acct-1', type: 'gmail', email: 'me@example.com' };
 
@@ -72,5 +83,64 @@ describe('repairActivityAliasParticipants (#2855)', () => {
   it('falls back to a generic source when the account has no type', async () => {
     await repairActivityAliasParticipants({ id: 'acct-2' }, [], ['x@example.com']);
     expect(stripParticipantsForAccount).toHaveBeenCalledWith('acct-2', 'message', ['x@example.com']);
+  });
+});
+
+// Regression: the ORDER of repair-vs-persist inside syncAccount (#2855).
+//
+// Persisting the learned alias set before the repair succeeds makes a transient
+// repair failure PERMANENT: the stored set never changes again, so every later
+// sync computes an empty delta and the stale rows are never retried. The repair
+// must therefore run first, and the persist must be skipped when it fails.
+describe('syncAccount alias repair/persist ordering (#2855)', () => {
+  const ACCT = '22222222-2222-2222-2222-222222222222';
+  const mockIo = { emit: vi.fn() };
+
+  const runSync = async ({ storedAliases, fetchedAliases }) => {
+    getAccount.mockResolvedValue({
+      id: ACCT, name: 'Gmail', type: 'gmail', email: 'me@example.com',
+      enabled: true, sendAsAliases: storedAliases,
+    });
+    tryReadFile.mockResolvedValue(JSON.stringify({ syncCursor: null, messages: [] }));
+    syncGmail.mockResolvedValue({ messages: [], sentMessages: [], status: 'success', sendAsAliases: fetchedAliases });
+    return syncAccount(ACCT, mockIo);
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stripParticipantsForAccount.mockResolvedValue(2);
+  });
+
+  it('repairs BEFORE persisting, so the persist reflects a completed repair', async () => {
+    const order = [];
+    stripParticipantsForAccount.mockImplementation(() => { order.push('repair'); return Promise.resolve(1); });
+    updateSendAsAliases.mockImplementation(() => { order.push('persist'); return Promise.resolve(); });
+
+    await runSync({ storedAliases: [], fetchedAliases: ['alias@example.com'] });
+
+    expect(order).toEqual(['repair', 'persist']);
+    expect(stripParticipantsForAccount).toHaveBeenCalledWith(ACCT, 'gmail', ['alias@example.com']);
+  });
+
+  it('does NOT persist the new alias set when the repair fails, so the next sync retries', async () => {
+    stripParticipantsForAccount.mockRejectedValue(new Error('transient DB failure'));
+
+    const result = await runSync({ storedAliases: [], fetchedAliases: ['alias@example.com'] });
+
+    // The failure must not fail the sync — it is a secondary effect.
+    expect(result.status).toBe('success');
+    // …and critically, the alias set stays unpersisted: leaving the stored set at
+    // its old value is what keeps the delta non-empty on the next sync. Persisting
+    // here would zero the delta forever and strand the stale rows.
+    expect(updateSendAsAliases).not.toHaveBeenCalled();
+  });
+
+  it('still persists when there is nothing to repair (alias removed → empty delta)', async () => {
+    await runSync({ storedAliases: ['a@example.com', 'b@example.com'], fetchedAliases: ['a@example.com'] });
+
+    expect(stripParticipantsForAccount).not.toHaveBeenCalled();
+    // A removal changes the set without producing newly-learned aliases — the
+    // persist must still happen or the removal would never be recorded.
+    expect(updateSendAsAliases).toHaveBeenCalledWith(ACCT, ['a@example.com']);
   });
 });

--- a/server/services/messageSyncAliasBackfill.test.js
+++ b/server/services/messageSyncAliasBackfill.test.js
@@ -1,0 +1,76 @@
+/**
+ * Wiring test for the send-as-alias activity backfill (#2855).
+ *
+ * The pure diff (`newlyLearnedAliases`) and the JSONB repair
+ * (`stripParticipantsForAccount`) are covered in humanActivity.test.js /
+ * humanActivity.db.test.js. What's asserted here is the piece neither covers:
+ * that a sync which learns a NEW alias triggers the repair with the right scope,
+ * and that a sync with an unchanged alias set touches the DB not at all.
+ *
+ * Lives in its own file so `./humanActivity.js` can be mocked wholesale without
+ * affecting the rest of messageSync.test.js.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/fileUtils.js', () => ({
+  tryReadFile: vi.fn(),
+  atomicWrite: vi.fn().mockResolvedValue(undefined),
+  ensureDir: vi.fn(),
+  // `data` is needed too: the real humanActivity.js (kept unmocked for its pure
+  // helpers) pulls in lib/timezone.js → services/settings.js, which resolves a
+  // settings path at module load.
+  PATHS: { messages: '/mock/data/messages', data: '/mock/data' },
+  safeJSONParse: vi.fn((content, fallback) => (content ? JSON.parse(content) : fallback)),
+  UUID_RE: /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+  safeDate: (d) => { const t = new Date(d).getTime(); return Number.isNaN(t) ? 0 : t; },
+  filterBySearch: (items) => items,
+}));
+
+vi.mock('./messageAccounts.js', () => ({
+  getAccount: vi.fn(),
+  updateSyncStatus: vi.fn(),
+  markSentIngested: vi.fn(() => Promise.resolve()),
+  updateSendAsAliases: vi.fn(() => Promise.resolve()),
+}));
+
+// Keep the REAL pure helpers (notably `newlyLearnedAliases` — re-stating it in a
+// mock would test the mock) and stub only the DB-touching entry points.
+const stripParticipantsForAccount = vi.fn(() => Promise.resolve(2));
+vi.mock('./humanActivity.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  stripParticipantsForAccount,
+  recordEvents: vi.fn(() => Promise.resolve({ recorded: 0, skipped: 0 })),
+}));
+
+const { repairActivityAliasParticipants } = await import('./messageSync.js');
+
+const account = { id: 'acct-1', type: 'gmail', email: 'me@example.com' };
+
+describe('repairActivityAliasParticipants (#2855)', () => {
+  beforeEach(() => stripParticipantsForAccount.mockClear());
+
+  it('repairs scoped to the account + source when an alias is learned for the first time', async () => {
+    await repairActivityAliasParticipants(account, undefined, ['alias@example.com']);
+    expect(stripParticipantsForAccount).toHaveBeenCalledWith('acct-1', 'gmail', ['alias@example.com']);
+  });
+
+  it('repairs only the newly-added alias when the set grows', async () => {
+    await repairActivityAliasParticipants(account, ['old@example.com'], ['old@example.com', 'new@example.com']);
+    expect(stripParticipantsForAccount).toHaveBeenCalledWith('acct-1', 'gmail', ['new@example.com']);
+  });
+
+  it('does no DB work when the alias set is unchanged (every routine sync)', async () => {
+    await repairActivityAliasParticipants(account, ['a@example.com'], ['A@example.com']);
+    expect(stripParticipantsForAccount).not.toHaveBeenCalled();
+  });
+
+  it('does no DB work when an alias is only removed', async () => {
+    await repairActivityAliasParticipants(account, ['a@example.com', 'b@example.com'], ['a@example.com']);
+    expect(stripParticipantsForAccount).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a generic source when the account has no type', async () => {
+    await repairActivityAliasParticipants({ id: 'acct-2' }, [], ['x@example.com']);
+    expect(stripParticipantsForAccount).toHaveBeenCalledWith('acct-2', 'message', ['x@example.com']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #2855. Follow-up to #2831.

#2831 excludes Gmail send-as aliases from *newly inserted* activity events, but rows synced **before** the alias set was learned still list the alias as a participant. Activity inserts are `ON CONFLICT (source, dedupe_key) DO NOTHING` — a deliberate "re-syncs are no-ops" contract shared with `tribe_touchpoints` — so those rows never self-correct, and a 1:1 message delivered to an alias keeps reading as a group conversation to `findUnansweredTribeThreads` until it ages out of the 14-day outreach window.

This adds a **scoped backfill** rather than loosening the global insert dedup contract:

- **`stripParticipantsForAccount(accountId, source, aliasEmails, { client })`** (`humanActivity.js`) — a JSONB rewrite that touches only rows for one account+source that actually contain a named alias, removing just those participant entries. `metadata.handle` (the sender) is left intact. An `EXISTS` gate keeps it off rows that don't need it, so a re-run is a true no-op reporting 0 rows.
- **Sync-path trigger** (`messageSync.js`) — fires for the aliases *newly learned* that sync, so a steady-state sync issues zero DB statements.
- **Boot migration `001`** — the delta trigger can't help an install whose aliases were already learned by an earlier build (the set never changes again, so the delta is empty forever). The migration reads each account's stored aliases once at upgrade and runs the same repair, reusing `stripParticipantsForAccount` on its own transaction client rather than copying the statement.

Also extracts `normalizeEmailList` on top of `lib/tribeMatch.normalizeIdentifier`, replacing three hand-rolled trim/lowercase/dedupe copies so owner-address comparison can't drift from the Tribe identity matching that consumes these events.

### Two ordering/sentinel bugs caught in review

Both were the same class — letting a *failure* look like *nothing to do*, where the mistake is permanent:

1. **Repair now runs before the alias set is persisted.** Persisting first meant a transient repair failure was forever: the next sync saw an unchanged set, computed an empty delta, and never retried. The persist is skipped when the repair fails, so the stored set stays put and the next sync recomputes the same delta.
2. **Migration 001 throws instead of silently skipping on an unreadable accounts file.** `tryReadFile`/`safeJSONParse` collapse "absent" and "read/parse failed" into the same empty result, and the runner marks the migration applied the moment `up()` returns — so a transient failure would permanently skip the one-shot backfill. Only `ENOENT` is "no work"; anything else throws and rolls back unapplied so the next boot retries.

The global `ON CONFLICT DO NOTHING` insert contract is unchanged.

## Test plan

- `server/services/humanActivity.test.js` — `newlyLearnedAliases` delta semantics (added / unchanged-modulo-casing / removal-only / non-array) and the `stripParticipantsForAccount` guards that keep it off the DB entirely.
- `server/services/humanActivity.db.test.js` — DB-backed: strips the alias while preserving the sender and `metadata.handle`, case-insensitive matching, leaves non-alias rows and other accounts untouched, yields `[]` (not NULL) when every participant was an owner address, idempotent on re-run, and honors a caller-supplied transaction client.
- `server/services/messageSyncAliasBackfill.test.js` — repair scoping, plus `syncAccount` regressions pinning repair-before-persist ordering, no-persist-on-repair-failure, and that a pure alias *removal* (empty delta, nothing to repair) still persists.
- `server/scripts/db-migrations/001-….test.js` — per-account scoping and normalization, skips accounts with no aliases/no id, ENOENT is a genuine no-op, and the three failure modes throw rather than mark applied (including that the error never leaks the absolute path).
- Full suite: **20894 passed / 1013 files**. DB suite (`npm run test:db` against `portos_test`): **210 passed**.
- Migration verified end-to-end through the real runner against `portos_test`: applies once, lands in the `schema_migrations` ledger, re-runs as a clean no-op.
- Reviewed with `codex review` — two defects found and fixed (above); third pass clean.