### PR TITLE
show capability icons for installed Ollama/LM Studio models

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -95,6 +95,28 @@ function summarizeMigrate(r) {
   return `${labelFor(r.from)} → ${labelFor(r.to)}: ${parts.join(', ') || 'nothing to move'}`;
 }
 
+// Shared capability-icon row for both catalog/search-result cards and the
+// installed-models list, so the two surfaces render the same badges the same way.
+function CapabilityBadges({ capabilities }) {
+  return (capabilities || []).map((capability) => {
+    const meta = CAPABILITY_META[capability];
+    if (!meta) {
+      return <span key={capability} className="px-1.5 py-0.5 bg-port-border/60 rounded">{capability}</span>;
+    }
+    const Icon = meta.Icon;
+    return (
+      <span
+        key={capability}
+        title={meta.label}
+        aria-label={meta.label}
+        className={`inline-flex items-center justify-center w-5 h-5 rounded border ${meta.cls}`}
+      >
+        <Icon size={12} />
+      </span>
+    );
+  });
+}
+
 function BackendCard({ backend, status, isDefault, busy, actionInProgress, runAction, setConfirmAction }) {
   const data = status?.[backend.id];
   const Icon = backend.icon;
@@ -897,23 +919,7 @@ export function LocalLlmTab() {
                           </span>
                         )}
                         {isHf && m.license && <span>{m.license}</span>}
-                        {(m.capabilities || []).map((capability) => {
-                          const meta = CAPABILITY_META[capability];
-                          if (!meta) {
-                            return <span key={capability} className="px-1.5 py-0.5 bg-port-border/60 rounded">{capability}</span>;
-                          }
-                          const Icon = meta.Icon;
-                          return (
-                            <span
-                              key={capability}
-                              title={meta.label}
-                              aria-label={meta.label}
-                              className={`inline-flex items-center justify-center w-5 h-5 rounded border ${meta.cls}`}
-                            >
-                              <Icon size={12} />
-                            </span>
-                          );
-                        })}
+                        <CapabilityBadges capabilities={m.capabilities} />
                       </div>
                     </div>
                     <div className="flex flex-col items-end gap-1 shrink-0">
@@ -1002,6 +1008,11 @@ export function LocalLlmTab() {
                 <div className="text-xs text-gray-500 truncate">
                   {[m.params, m.quantization, m.family, formatContextLength(m.contextLength)].filter(Boolean).join(' · ')}
                 </div>
+                {(m.capabilities || []).length > 0 && (
+                  <div className="flex items-center gap-1 flex-wrap mt-1">
+                    <CapabilityBadges capabilities={m.capabilities} />
+                  </div>
+                )}
               </div>
               {m.size != null && <span className="text-xs text-gray-400 shrink-0">{formatBytes(m.size)}</span>}
               <Link

--- a/server/services/localLlm.js
+++ b/server/services/localLlm.js
@@ -32,7 +32,7 @@ import { PATHS, atomicWrite, ensureDir, pathExists, sleep } from '../lib/fileUti
 import { compareSemver } from '../lib/versionUtils.js'
 import { isBackend, mapModelToBackend } from '../lib/localLlmCatalog.js'
 import { sanitizeOllamaName } from '../lib/localLlmDisk.js'
-import { recommendEditorialModel, isVisionModel, isVisionCapableCliProvider } from '../lib/localModelHeuristics.js'
+import { recommendEditorialModel, isVisionModel, isVisionCapableCliProvider, isToolUseModel } from '../lib/localModelHeuristics.js'
 import * as ollamaManager from './ollamaManager.js'
 import * as lmStudioManager from './lmStudioManager.js'
 import { getProviderById, getAllProviders, updateProvider } from './providers.js'
@@ -614,6 +614,37 @@ export async function controlOllamaServer(action) {
   return { success: false, error: `Unknown Ollama action: ${action}` }
 }
 
+// Ollama's /api/show reports capabilities in its own vocabulary
+// (completion/tools/vision/embedding/thinking/insert). Map the ones that have
+// a home onto the badge vocabulary the Models catalog cards already render
+// (CAPABILITY_META in LocalLlmTab.jsx: chat/code/reasoning/vision/embeddings/
+// tools/audio) so installed models can show the same icons. Only capabilities
+// the daemon actually reported are surfaced — nothing is guessed here.
+const OLLAMA_CAPABILITY_BADGES = {
+  completion: 'chat',
+  tools: 'tools',
+  vision: 'vision',
+  embedding: 'embeddings',
+  thinking: 'reasoning'
+}
+
+function ollamaBadgeCapabilities(rawCapabilities) {
+  return (Array.isArray(rawCapabilities) ? rawCapabilities : [])
+    .map((c) => OLLAMA_CAPABILITY_BADGES[String(c).toLowerCase()])
+    .filter(Boolean)
+}
+
+// LM Studio's native model list tags each model's `type` (`llm` / `vlm` /
+// `embeddings`) — authoritative for chat/vision/embeddings. It reports no
+// tool-calling flag, so fall back to the shared id heuristic for `tools`.
+function lmStudioBadgeCapabilities(m) {
+  const type = m?.type ? String(m.type).toLowerCase() : null
+  const caps = type === 'embeddings' ? ['embeddings'] : ['chat']
+  if (type === 'vlm') caps.push('vision')
+  if (type !== 'embeddings' && isToolUseModel(m?.id)) caps.push('tools')
+  return caps
+}
+
 /** Normalize each backend's installed-model shape into one card shape. */
 function normalizeModels(backend, models) {
   if (backend === 'ollama') {
@@ -626,7 +657,8 @@ function normalizeModels(backend, models) {
       // path, or the listVisionModels enrichment below) prefer it; otherwise
       // fall back to the id heuristic. Passing the object lets a vision-capable
       // MoE like `qwen3.6:35b` (no `vl`/`vision` token in its id) resolve true.
-      vision: isVisionModel(Array.isArray(m.capabilities) ? { id: m.id, capabilities: m.capabilities } : m.id)
+      vision: isVisionModel(Array.isArray(m.capabilities) ? { id: m.id, capabilities: m.capabilities } : m.id),
+      capabilities: ollamaBadgeCapabilities(m.capabilities)
     }))
   }
   return models.map((m) => ({
@@ -635,7 +667,8 @@ function normalizeModels(backend, models) {
     contextLength: m.maxContextLength ?? null,
     // LM Studio's native model list tags vision models `type: 'vlm'` — prefer
     // that over the id regex.
-    vision: isVisionModel(m)
+    vision: isVisionModel(m),
+    capabilities: lmStudioBadgeCapabilities(m)
   }))
 }
 

--- a/server/services/localLlm.test.js
+++ b/server/services/localLlm.test.js
@@ -376,6 +376,36 @@ describe('localLlm', () => {
     });
   });
 
+  describe('listModels capability badges', () => {
+    it('maps Ollama /api/show capabilities onto the catalog badge vocabulary', async () => {
+      mocks.ollama.getInstalledModels.mockResolvedValueOnce([
+        { id: 'qwen3.6:35b', name: 'qwen3.6:35b', capabilities: ['completion', 'tools', 'vision', 'thinking'] },
+        { id: 'nomic-embed-text', name: 'nomic-embed-text', capabilities: ['embedding'] },
+        { id: 'legacy-model', name: 'legacy-model' },
+      ]);
+      const models = await svc.listModels('ollama');
+      expect(models.find((m) => m.id === 'qwen3.6:35b').capabilities.sort())
+        .toEqual(['chat', 'reasoning', 'tools', 'vision']);
+      expect(models.find((m) => m.id === 'nomic-embed-text').capabilities).toEqual(['embeddings']);
+      // No reported capabilities → no guessed badges (unlike the vision id heuristic).
+      expect(models.find((m) => m.id === 'legacy-model').capabilities).toEqual([]);
+    });
+
+    it('derives LM Studio badges from the native `type` field plus the shared tool-use id heuristic', async () => {
+      mocks.lmstudio.getAvailableModels.mockResolvedValueOnce([
+        { id: 'qwen2.5-7b-instruct', type: 'llm' },
+        { id: 'llava-1.5-7b', type: 'vlm' },
+        { id: 'nomic-embed-text', type: 'embeddings' },
+      ]);
+      const models = await svc.listModels('lmstudio');
+      expect(models.find((m) => m.id === 'qwen2.5-7b-instruct').capabilities.sort())
+        .toEqual(['chat', 'tools']);
+      expect(models.find((m) => m.id === 'llava-1.5-7b').capabilities.sort())
+        .toEqual(['chat', 'vision']);
+      expect(models.find((m) => m.id === 'nomic-embed-text').capabilities).toEqual(['embeddings']);
+    });
+  });
+
   describe('listVisionModels', () => {
     it('detects a vision-capable Ollama model whose id lacks a vl/vision token via /api/show capabilities', async () => {
       mocks.ollama.getInstalledModels.mockResolvedValueOnce([


### PR DESCRIPTION
## Summary

- The "Installed on Ollama/LM Studio" list in Local LLM settings showed params/quant/family but not the chat/code/reasoning/vision/embeddings/tools capability icons already shown on catalog and search-result cards.
- `normalizeModels` in `server/services/localLlm.js` now derives a `capabilities` array per installed model — from Ollama's `/api/show` capability set (mapped onto the existing badge vocabulary) and from LM Studio's model `type` field plus the shared tool-use id heuristic.
- Extracted a shared `CapabilityBadges` component in `LocalLlmTab.jsx` so the catalog cards and the installed-models list render the same icons the same way.

## Test plan

- [x] `cd server && npx vitest run localLlm.test.js` — 55/55 passing, including two new tests for the capability derivation
- [x] `cd client && npx eslint src/components/settings/LocalLlmTab.jsx` — clean
- [x] Local review passes (claude, ollama, agy) all returned clean with zero findings