### PR TITLE
fix: retry transient network failures during TRELLIS.2 install (#2952)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,6 +3,7 @@
 ## 3D
 
 - **[issue-2953] Install image-to-3D models from a new 3D page** — a new **3D** page under Create lists the available image-to-3D models (starting with Microsoft TRELLIS.2) and shows each one's state at a glance: **Ready**, an **Install** button, or a note explaining why your hardware can't run it (e.g. needs an Apple Silicon Mac with enough memory). Installing runs entirely on-device with a live progress log — the same in-app install experience as the image generators — so you never touch a terminal. Reachable from the sidebar, ⌘K, and voice. (Turning one of your rendered images into a 3D mesh from this page lands next.)
+- **[issue-2952] TRELLIS.2 install now survives network hiccups** — the multi-gigabyte TRELLIS.2 install pulls from several code repositories, and a single dropped connection mid-download used to abort the whole thing with a cryptic error. The installer now automatically retries a step that fails from a transient network drop (with a short backoff), and already-downloaded pieces are kept — so a flaky connection resumes instead of starting over. If it still can't finish, the error now says plainly that it was a network hiccup and that clicking **Install** again picks up where it left off.
 
 ## Internal
 

--- a/server/routes/imageTo3d.js
+++ b/server/routes/imageTo3d.js
@@ -82,7 +82,15 @@ router.get('/trellis2/install', asyncHandler(async (req, res) => {
   trellis2InstallInFlight = promise;
   promise
     .then(() => installLog.success())
-    .catch((err) => emit({ type: 'error', message: err?.message || 'Install failed', stage: err?.stage }))
+    .catch((err) => {
+      // A transient network drop that survived the in-install retries: the partial
+      // clones on disk are idempotent (setup.sh's `if [ ! -d ]` guards + git's
+      // failed-clone cleanup), so re-running Install resumes rather than restarts.
+      const hint = err?.transient
+        ? ' This looks like a network hiccup — click Install again to resume (already-downloaded pieces are kept).'
+        : '';
+      emit({ type: 'error', message: `${err?.message || 'Install failed'}${hint}`, stage: err?.stage });
+    })
     .finally(() => {
       trellis2InstallInFlight = null;
       safeEnd();

--- a/server/routes/imageTo3d.test.js
+++ b/server/routes/imageTo3d.test.js
@@ -79,6 +79,41 @@ describe('GET /trellis2/install (SSE)', () => {
     expect(trellis2.installTrellis2).not.toHaveBeenCalled();
   });
 
+  it('appends a resume hint when the install fails with a transient network error', async () => {
+    trellis2.isTrellis2Installed.mockReturnValueOnce(false);
+    targets.isTargetAvailable.mockReturnValueOnce(true);
+    trellis2.installTrellis2.mockImplementationOnce(() => ({
+      promise: Promise.reject(Object.assign(
+        new Error("TRELLIS.2 install step 'setup' exited 128"),
+        { code: 'TRELLIS2_INSTALL_FAILED', stage: 'setup', transient: true },
+      )),
+      kill: vi.fn(),
+    }));
+    const res = await request(makeApp()).get('/api/image-to-3d/trellis2/install');
+    const frames = sseFrames(res.text);
+    expect(frames.at(-1)).toMatchObject({
+      type: 'error',
+      stage: 'setup',
+      message: expect.stringMatching(/exited 128.*network hiccup — click Install again to resume/is),
+    });
+  });
+
+  it('does NOT append the resume hint for a non-transient failure', async () => {
+    trellis2.isTrellis2Installed.mockReturnValueOnce(false);
+    targets.isTargetAvailable.mockReturnValueOnce(true);
+    trellis2.installTrellis2.mockImplementationOnce(() => ({
+      promise: Promise.reject(Object.assign(
+        new Error('TRELLIS.2 install step \'setup\' exited 1'),
+        { code: 'TRELLIS2_INSTALL_FAILED', stage: 'setup', transient: false },
+      )),
+      kill: vi.fn(),
+    }));
+    const res = await request(makeApp()).get('/api/image-to-3d/trellis2/install');
+    const frames = sseFrames(res.text);
+    expect(frames.at(-1)).toMatchObject({ type: 'error', message: expect.stringMatching(/exited 1$/) });
+    expect(frames.at(-1).message).not.toMatch(/network hiccup/i);
+  });
+
   it('refuses on unsupported hardware', async () => {
     trellis2.installTrellis2.mockClear();
     trellis2.isTrellis2Installed.mockReturnValueOnce(false);

--- a/server/services/imageTo3d/trellis2.js
+++ b/server/services/imageTo3d/trellis2.js
@@ -60,17 +60,26 @@ export function isTrellis2Installed({ base, exists = existsSync } = {}) {
 /**
  * The install as an ordered list of `{stage, command, args, cwd?}` steps: shallow-
  * clone the port, then run its `setup.sh` (which builds the venv + fetches weights).
- * Pure — the SSE install route executes these; keeping them a data structure makes
- * the plan assertable without running it.
+ * Keeping the plan a data structure makes it assertable without running it.
+ *
+ * **The clone step is skipped when the repo is already present** (`<root>/.git`
+ * exists). This is load-bearing for resume: if a prior install cloned the top-level
+ * repo but failed inside `setup.sh` (the common #2952 case — a dep clone dropped),
+ * re-running with an unconditional `git clone … <root>` would abort ("destination
+ * path already exists and is not an empty directory") and never reach the idempotent
+ * `setup.sh`. `exists` is injectable so the skip is deterministic in tests.
  * @param {string} [base]
+ * @param {{exists?: (p: string) => boolean}} [opts]
  * @returns {Array<{stage: string, command: string, args: string[], cwd?: string}>}
  */
-export function buildInstallSteps(base) {
+export function buildInstallSteps(base, { exists = existsSync } = {}) {
   const root = trellis2Root(base);
-  return [
-    { stage: 'clone', command: 'git', args: ['clone', '--depth', '1', TRELLIS2_REPO, root] },
-    { stage: 'setup', command: 'bash', args: ['setup.sh'], cwd: root },
-  ];
+  const steps = [];
+  if (!exists(join(root, '.git'))) {
+    steps.push({ stage: 'clone', command: 'git', args: ['clone', '--depth', '1', TRELLIS2_REPO, root] });
+  }
+  steps.push({ stage: 'setup', command: 'bash', args: ['setup.sh'], cwd: root });
+  return steps;
 }
 
 /**
@@ -176,8 +185,11 @@ export function installTrellis2({
   spawnImpl = spawn,
   maxRetries = 3,
   sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+  exists = existsSync,
 } = {}) {
-  const steps = buildInstallSteps(base);
+  // `exists` lets the clone step be skipped when the repo is already on disk (resume
+  // after a setup-stage failure) — see buildInstallSteps.
+  const steps = buildInstallSteps(base, { exists });
   let currentChild = null;
   let canceled = false;
 

--- a/server/services/imageTo3d/trellis2.js
+++ b/server/services/imageTo3d/trellis2.js
@@ -114,6 +114,40 @@ export function parseGenerateProgress(line) {
 }
 
 /**
+ * Signatures of a *transient* network failure during the install's git clones /
+ * pip fetches — the kind that self-heals on a retry rather than indicating a real
+ * config/hardware problem. The reference failure (#2952) was a mid-clone
+ * `curl 56 Recv failure: Connection reset by peer` → `early EOF` →
+ * `fetch-pack: invalid index-pack output` → git exiting 128 while cloning one of
+ * `setup.sh`'s ~half-dozen deps. Kept broad (git-over-HTTPS, DNS, TLS, pip) because
+ * every match only *earns a retry* of an idempotent step — a false positive costs
+ * one extra attempt, never a wrong install.
+ */
+const TRANSIENT_INSTALL_ERROR_RE = new RegExp(
+  [
+    'curl\\s+\\d+', 'RPC failed', 'early EOF', 'fetch-pack', 'index-pack',
+    'unexpected disconnect', 'Connection reset', 'Recv failure', 'Send failure',
+    'Could not resolve host', 'Failed to connect', 'Operation timed out',
+    'Connection timed out', 'timed out', 'TLS', 'SSL', 'gnutls', 'GnuTLS',
+    'Temporary failure in name resolution', 'Broken pipe', 'ECONNRESET', 'ETIMEDOUT',
+    'Read error', 'transfer closed', 'Network is unreachable',
+    'Retrieving .* failed', 'Connection aborted', 'IncompleteRead',
+  ].join('|'),
+  'i',
+);
+
+/**
+ * Whether a captured chunk of install output looks like a transient network error
+ * (see `TRANSIENT_INSTALL_ERROR_RE`). Exported so the route/UI and tests can share
+ * the exact classification instead of re-implementing the pattern.
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function isTransientInstallError(text) {
+  return TRANSIENT_INSTALL_ERROR_RE.test(String(text ?? ''));
+}
+
+/**
  * Run the install as a killable, event-emitting job: execute `buildInstallSteps()`
  * sequentially (clone the MPS port → run its `setup.sh`, ~15 GB), emitting a
  * `{ type:'stage' }` per step, `{ type:'log' }` for subprocess output, and a
@@ -122,10 +156,27 @@ export function parseGenerateProgress(line) {
  * only. `spawnImpl` injectable so the step sequencing / cancel / failure paths are
  * unit-testable without a real 15 GB install.
  *
- * @param {{base?: string, onEvent?: (ev: object) => void, spawnImpl?: Function}} [opts]
+ * **Transient-failure retry.** A multi-GB install over `setup.sh`'s ~half-dozen git
+ * clones routinely eats a mid-transfer `Connection reset` / `early EOF` (#2952) that
+ * exits git 128. Both steps are *idempotent* — git removes a failed clone's target
+ * dir, our top-level clone re-clones cleanly, and `setup.sh`'s `if [ ! -d ]` guards
+ * skip already-cloned deps and resume from the one that dropped — so a step whose
+ * output matches a transient-network signature is retried in place up to `maxRetries`
+ * times with a short backoff, rather than aborting the whole install on one blip.
+ * A non-transient failure (bad config, unsupported host, real setup error) is NOT
+ * retried — it fails fast. `sleep` is injectable so tests don't wait on real backoff.
+ *
+ * @param {{base?: string, onEvent?: (ev: object) => void, spawnImpl?: Function,
+ *          maxRetries?: number, sleep?: (ms: number) => Promise<void>}} [opts]
  * @returns {{promise: Promise<{ok: true}>, kill: () => void}}
  */
-export function installTrellis2({ base, onEvent = () => {}, spawnImpl = spawn } = {}) {
+export function installTrellis2({
+  base,
+  onEvent = () => {},
+  spawnImpl = spawn,
+  maxRetries = 3,
+  sleep = (ms) => new Promise((r) => setTimeout(r, ms)),
+} = {}) {
   const steps = buildInstallSteps(base);
   let currentChild = null;
   let canceled = false;
@@ -136,9 +187,14 @@ export function installTrellis2({ base, onEvent = () => {}, spawnImpl = spawn } 
     // request lifecycle (CLAUDE.md child-process exception).
     const child = spawnImpl(step.command, step.args, step.cwd ? { cwd: step.cwd } : {});
     currentChild = child;
+    // Retain a bounded tail of combined output so a non-zero exit can be classified
+    // as transient-network vs. a real failure (the clue is in the subprocess text,
+    // not the exit code — git exits 128 for both a network drop and a bad ref).
+    let outputTail = '';
     const log = (buf) => {
       const message = String(buf).trim();
       if (message) onEvent({ type: 'log', stage: step.stage, message });
+      outputTail = `${outputTail}${buf}`.slice(-4000);
     };
     child.stdout?.on('data', log);
     child.stderr?.on('data', log);
@@ -151,9 +207,37 @@ export function installTrellis2({ base, onEvent = () => {}, spawnImpl = spawn } 
       const err = new Error(`TRELLIS.2 install step '${step.stage}' exited ${code}`);
       err.code = 'TRELLIS2_INSTALL_FAILED';
       err.stage = step.stage;
+      err.transient = isTransientInstallError(outputTail);
       reject(err);
     });
   });
+
+  // Retry an idempotent step in place while its failure looks like a transient
+  // network drop and attempts remain; otherwise surface the error unchanged.
+  const runStepWithRetry = async (step) => {
+    for (let attempt = 0; ; attempt += 1) {
+      if (canceled) {
+        const err = new Error('TRELLIS.2 install canceled');
+        err.code = 'TRELLIS2_INSTALL_CANCELED';
+        throw err;
+      }
+      try {
+        await runStep(step);
+        return;
+      } catch (err) {
+        const canRetry = err?.code === 'TRELLIS2_INSTALL_FAILED'
+          && err.transient && attempt < maxRetries && !canceled;
+        if (!canRetry) throw err;
+        const backoffMs = Math.min(30000, 2000 * 2 ** attempt);
+        onEvent({
+          type: 'log',
+          stage: step.stage,
+          message: `⚠️ Transient network error — retrying in ${Math.round(backoffMs / 1000)}s (attempt ${attempt + 2}/${maxRetries + 1})…`,
+        });
+        await sleep(backoffMs);
+      }
+    }
+  };
 
   const promise = (async () => {
     for (const step of steps) {
@@ -162,7 +246,7 @@ export function installTrellis2({ base, onEvent = () => {}, spawnImpl = spawn } 
         err.code = 'TRELLIS2_INSTALL_CANCELED';
         throw err;
       }
-      await runStep(step);
+      await runStepWithRetry(step);
     }
     onEvent({ type: 'complete', message: 'TRELLIS.2 installed.' });
     return { ok: true };

--- a/server/services/imageTo3d/trellis2.test.js
+++ b/server/services/imageTo3d/trellis2.test.js
@@ -48,13 +48,23 @@ describe('isTrellis2Installed', () => {
 });
 
 describe('buildInstallSteps', () => {
-  it('clones the MPS port then runs its setup.sh', () => {
-    const steps = buildInstallSteps(BASE);
+  it('clones the MPS port then runs its setup.sh when nothing is on disk', () => {
+    const steps = buildInstallSteps(BASE, { exists: () => false });
     expect(steps.map((s) => s.stage)).toEqual(['clone', 'setup']);
     expect(steps[0]).toMatchObject({ command: 'git' });
     expect(steps[0].args).toContain(TRELLIS2_REPO);
     expect(steps[0].args).toContain(trellis2Root(BASE));
     expect(steps[1]).toMatchObject({ command: 'bash', args: ['setup.sh'], cwd: trellis2Root(BASE) });
+  });
+
+  it('skips the clone step and resumes at setup.sh when the repo is already present', () => {
+    // A prior install cloned the top-level repo but failed inside setup.sh (the
+    // #2952 case). Re-cloning into the non-empty root would abort, so resume must
+    // begin at the idempotent setup.sh.
+    const gitDir = `${trellis2Root(BASE)}/.git`;
+    const steps = buildInstallSteps(BASE, { exists: (p) => p === gitDir });
+    expect(steps.map((s) => s.stage)).toEqual(['setup']);
+    expect(steps[0]).toMatchObject({ command: 'bash', args: ['setup.sh'], cwd: trellis2Root(BASE) });
   });
 });
 
@@ -248,6 +258,21 @@ describe('installTrellis2', () => {
     const { promise } = installTrellis2({ base: BASE, spawnImpl: () => child });
     child.emit('close', 1);
     await expect(promise).rejects.toMatchObject({ code: 'TRELLIS2_INSTALL_FAILED', stage: 'clone' });
+  });
+
+  it('resumes at setup (no re-clone) when the repo is already on disk', async () => {
+    // Re-running Install after a setup-stage failure must NOT re-clone into the
+    // existing root; it must go straight to the idempotent setup.sh.
+    const child = makeChild();
+    const spawnImpl = vi.fn(() => child);
+    const gitDir = `${trellis2Root(BASE)}/.git`;
+    const { promise } = installTrellis2({
+      base: BASE, spawnImpl, exists: (p) => p === gitDir, sleep: () => Promise.resolve(),
+    });
+    expect(spawnImpl).toHaveBeenCalledTimes(1);
+    expect(spawnImpl).toHaveBeenNthCalledWith(1, 'bash', ['setup.sh'], { cwd: trellis2Root(BASE) });
+    child.emit('close', 0);
+    await expect(promise).resolves.toEqual({ ok: true });
   });
 
   it('retries a transient network failure in place and succeeds on the retry', async () => {

--- a/server/services/imageTo3d/trellis2.test.js
+++ b/server/services/imageTo3d/trellis2.test.js
@@ -11,7 +11,10 @@ import {
   parseGenerateProgress,
   runTrellis2Generate,
   installTrellis2,
+  isTransientInstallError,
 } from './trellis2.js';
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
 const BASE = '/tmp/portos-test-home';
 
@@ -165,6 +168,43 @@ describe('runTrellis2Generate', () => {
   });
 });
 
+describe('isTransientInstallError', () => {
+  it('matches the #2952 mid-clone network drop signatures', () => {
+    // The exact failure chain the user hit installing via the UI.
+    const log = [
+      "Cloning into 'deps/trellis2-apple'...",
+      'error: RPC failed; curl 56 Recv failure: Connection reset by peer',
+      'error: 6483 bytes of body are still expected',
+      'fetch-pack: unexpected disconnect while reading sideband packet',
+      'fatal: early EOF',
+      'fatal: fetch-pack: invalid index-pack output',
+    ].join('\n');
+    expect(isTransientInstallError(log)).toBe(true);
+  });
+
+  it.each([
+    'error: RPC failed; curl 18 transfer closed with outstanding read data remaining',
+    'fatal: unable to access ...: Could not resolve host: github.com',
+    'ssl_read: Connection reset by peer',
+    'pip: Read timed out.',
+    'urllib3 ... IncompleteRead',
+  ])('flags transient network error: %s', (line) => {
+    expect(isTransientInstallError(line)).toBe(true);
+  });
+
+  it.each([
+    "fatal: repository 'https://example.test/x.git/' not found",
+    'error: pathspec did not match any file(s) known to git',
+    "bash: setup.sh: Permission denied",
+    'ModuleNotFoundError: No module named torch',
+    '',
+    null,
+    undefined,
+  ])('does NOT flag a non-transient/real failure: %s', (line) => {
+    expect(isTransientInstallError(line)).toBe(false);
+  });
+});
+
 describe('installTrellis2', () => {
   const makeChild = () => {
     const child = new EventEmitter();
@@ -184,7 +224,7 @@ describe('installTrellis2', () => {
     // step 1 (clone) — first spawn call, then close it 0 to advance to step 2
     expect(spawnImpl).toHaveBeenNthCalledWith(1, 'git', expect.arrayContaining(['clone']), {});
     children[0].emit('close', 0);
-    await Promise.resolve(); // let the await in the loop advance
+    await flush(); // let the await in the loop (through the retry wrapper) advance
     expect(spawnImpl).toHaveBeenNthCalledWith(2, 'bash', ['setup.sh'], { cwd: trellis2Root(BASE) });
     children[1].emit('close', 0);
     await expect(promise).resolves.toEqual({ ok: true });
@@ -208,6 +248,58 @@ describe('installTrellis2', () => {
     const { promise } = installTrellis2({ base: BASE, spawnImpl: () => child });
     child.emit('close', 1);
     await expect(promise).rejects.toMatchObject({ code: 'TRELLIS2_INSTALL_FAILED', stage: 'clone' });
+  });
+
+  it('retries a transient network failure in place and succeeds on the retry', async () => {
+    // clone attempt 1 (transient fail) → clone attempt 2 (ok) → setup (ok)
+    const children = [makeChild(), makeChild(), makeChild()];
+    let i = 0;
+    const spawnImpl = vi.fn(() => children[i++]);
+    const events = [];
+    const { promise } = installTrellis2({
+      base: BASE, spawnImpl, onEvent: (e) => events.push(e), sleep: () => Promise.resolve(),
+    });
+
+    children[0].stderr.emit('data', 'error: RPC failed; curl 56 Recv failure: Connection reset by peer\n');
+    children[0].emit('close', 128);
+    await flush(); // drain the retry backoff + respawn
+
+    expect(spawnImpl).toHaveBeenCalledTimes(2); // clone was retried
+    expect(spawnImpl).toHaveBeenNthCalledWith(2, 'git', expect.arrayContaining(['clone']), {});
+    children[1].emit('close', 0);
+    await flush();
+    children[2].emit('close', 0); // setup
+    await expect(promise).resolves.toEqual({ ok: true });
+
+    expect(events.some((e) => e.type === 'log' && /retrying/i.test(e.message))).toBe(true);
+  });
+
+  it('fails fast (no retry) on a non-transient step failure', async () => {
+    const spawnImpl = vi.fn(() => makeChild());
+    const { promise } = installTrellis2({ base: BASE, spawnImpl, sleep: () => Promise.resolve() });
+    const child = spawnImpl.mock.results[0].value;
+    child.stderr.emit('data', 'fatal: repository not found\n');
+    child.emit('close', 128);
+    await expect(promise).rejects.toMatchObject({ code: 'TRELLIS2_INSTALL_FAILED', transient: false });
+    expect(spawnImpl).toHaveBeenCalledTimes(1); // never retried
+  });
+
+  it('gives up after maxRetries and surfaces a transient-flagged error', async () => {
+    const children = [makeChild(), makeChild()];
+    let i = 0;
+    const spawnImpl = vi.fn(() => children[i++]);
+    const { promise } = installTrellis2({
+      base: BASE, spawnImpl, maxRetries: 1, sleep: () => Promise.resolve(),
+    });
+
+    children[0].stderr.emit('data', 'fatal: early EOF\n');
+    children[0].emit('close', 128);
+    await flush();
+    children[1].stderr.emit('data', 'fatal: early EOF\n');
+    children[1].emit('close', 128);
+
+    await expect(promise).rejects.toMatchObject({ code: 'TRELLIS2_INSTALL_FAILED', transient: true, stage: 'clone' });
+    expect(spawnImpl).toHaveBeenCalledTimes(2); // initial + 1 retry, then gave up
   });
 
   it('kill() SIGTERMs the running child and cancels before the next step', async () => {


### PR DESCRIPTION
## Summary

Installing TRELLIS.2 via the new 3D page runs the Apple Silicon port's `setup.sh`, which clones roughly half a dozen git dependencies up front before building the venv. A single dropped connection mid-clone aborted the **entire** multi-gigabyte install with a bare `TRELLIS.2 install step 'setup' exited 128` and no hint that a retry would fix it. Observed failure chain:

```
Cloning into 'deps/trellis2-apple'...
error: RPC failed; curl 56 Recv failure: Connection reset by peer
fatal: early EOF
fatal: fetch-pack: invalid index-pack output
```

Both install steps are **idempotent**: git removes a failed clone's target dir, our top-level clone re-clones cleanly, and `setup.sh`'s `if [ ! -d ]` guards skip already-cloned deps and resume from the one that dropped. So this makes the installer **retry a step in place** when its output matches a transient-network signature — up to `maxRetries` (default 3) with exponential backoff — instead of failing the whole install on one blip. Non-transient failures (bad config, unsupported host, real setup error) still **fail fast**. When a transient error survives all retries, the SSE route appends an actionable hint that re-running **Install** resumes (already-downloaded pieces are kept).

### Changes
- `server/services/imageTo3d/trellis2.js` — new exported `isTransientInstallError()` classifier (git-over-HTTPS / DNS / TLS / pip signatures); `installTrellis2()` gains transient-retry with injectable `sleep`/`maxRetries`, capturing a bounded output tail to classify non-zero exits (git exits 128 for both a network drop and a bad ref, so the exit code alone can't distinguish them).
- `server/routes/imageTo3d.js` — appends the resume hint to the SSE `error` frame when the terminal failure is transient.

This is the reliability half of #2952 surfaced by hands-on install. The remaining hands-on items (a full on-device install/render, confirming the real `generate.py` progress wording, and the create/generate DB record + endpoints) stay open — hence `Refs`, not `Closes`.

## Test plan
- `server/services/imageTo3d/trellis2.test.js` — classifier matches the exact #2952 failure chain + a table of transient signatures; rejects real failures and empty/null input. `installTrellis2` retry: retries-then-succeeds, fails-fast on non-transient, gives-up-after-`maxRetries` with a `transient: true` error.
- `server/routes/imageTo3d.test.js` — the SSE `error` frame carries the resume hint on a transient failure and omits it otherwise.
- `cd server && npx vitest run services/imageTo3d/ routes/imageTo3d.test.js` → 61 passed.

Refs #2952.