### PR TITLE
Make the /media/3d 'Change image' label readable over bright source images

### DIFF
--- a/client/src/pages/Media3D.jsx
+++ b/client/src/pages/Media3D.jsx
@@ -296,7 +296,7 @@ export default function Media3D() {
             </span>
           )}
           {selectedImage && (
-            <span className="absolute inset-x-2 bottom-2 rounded bg-black/70 px-2 py-1 text-center text-xs text-white">
+            <span className="absolute inset-x-2 bottom-2 rounded bg-black/90 px-2 py-1 text-center text-xs font-medium text-white">
               Change image
             </span>
           )}


### PR DESCRIPTION
## Summary

The **Change image** overlay label on the `/media/3d` source-image button used a `bg-black/70` scrim. Over a vivid source image (e.g. a magenta-background render) the image bled through the 30%-transparent scrim and washed out the white text, making the label hard to read (see the reported screenshot).

Bump the scrim to `bg-black/90` and add `font-medium` so the label stays legible over any source image, without hiding the image behind a fully-opaque bar.

## Test plan

- Visual: open `/media/3d` with a bright/high-saturation source image selected — the "Change image" label reads clearly.
- Stock Tailwind utilities only (`bg-black/90`, `font-medium`); no build/behavior change.