### PR TITLE
render mp4 animation clips inline in the Sprite Manager Animations group

### DIFF
--- a/client/src/components/sprites/AssetCollection.jsx
+++ b/client/src/components/sprites/AssetCollection.jsx
@@ -20,7 +20,7 @@ import { FolderOpen, RefreshCw, Scissors, Sparkles, Film, FileJson, NotebookPen 
 import AssetInspector from './AssetInspector.jsx';
 import CorrectionNote from './CorrectionNote.jsx';
 import SpritePreview from './SpritePreview.jsx';
-import { hasSpritePreview, assetVersionToken } from './spriteAssets.js';
+import { hasSpritePreview, isVideoAsset, assetVersionToken, spriteAssetUrl } from './spriteAssets.js';
 import { groupSpriteAssetsByRole } from '../../lib/spriteFacets.js';
 import { formatBytes } from '../../utils/formatters.js';
 
@@ -71,8 +71,20 @@ function AssetCard({ recordId, asset, actions, corrections, onCorrectionChange, 
         className="block w-full text-left rounded hover:opacity-80"
         title={asset.path}
       >
-        {hasSpritePreview(asset) && (
+        {hasSpritePreview(asset) ? (
           <SpritePreview recordId={recordId} path={asset.path} version={assetVersionToken(asset)} className="h-20 rounded" />
+        ) : isVideoAsset(asset) && (
+          // A raw grok clip carries its own magenta matte (not transparent),
+          // so no checkerboard behind it, matching WalkWorkflow's inline clip.
+          <video
+            src={spriteAssetUrl(recordId, asset.path, assetVersionToken(asset))}
+            className="w-full h-20 object-cover rounded bg-port-bg"
+            autoPlay
+            loop
+            muted
+            playsInline
+            aria-label={`preview of ${name}`}
+          />
         )}
         <span className="block text-[10px] text-gray-500 truncate">{name}</span>
         <span className="flex items-center gap-1 text-[10px] text-gray-600">

--- a/client/src/components/sprites/AssetCollection.test.jsx
+++ b/client/src/components/sprites/AssetCollection.test.jsx
@@ -82,6 +82,19 @@ describe('AssetCollection grouping', () => {
     expect(screen.queryAllByRole('heading', { level: 4 })).toHaveLength(0);
   });
 
+  it('plays an mp4 animation asset inline as an autoplay/loop/muted video', () => {
+    const CLIP = 'grok/walk-east-abc12345/generated/source-video.mp4';
+    render(<AssetCollection recordId="example-walker" assets={[asset(CLIP)]} />);
+    expect(groupHeadings()).toEqual(['Animations(1)']);
+    const video = screen.getByTitle(CLIP).querySelector('video');
+    expect(video).toBeTruthy();
+    expect(video).toHaveAttribute('src', expect.stringContaining(encodeURIComponent(CLIP.split('/').pop())));
+    expect(video).toHaveAttribute('autoplay');
+    expect(video).toHaveAttribute('loop');
+    // React reflects `muted` as a DOM property, not an HTML attribute.
+    expect(video.muted).toBe(true);
+  });
+
   it('keeps an unapproved run\'s strip badged `candidate` (#2938)', () => {
     render(<AssetCollection recordId="example-walker" assets={ASSETS} />);
     const stripGroup = screen.getByRole('heading', { name: /Strips/ }).parentElement;


### PR DESCRIPTION
## Summary
- Animation-role assets (grok source clips, gif/mp4/webm/mov) in the Sprite Manager's Assets tab previously rendered no thumbnail at all — `hasSpritePreview` only covers image formats, so the card fell through to filename + size, and the only way to see the clip was opening the inspector modal.
- `AssetCard` in `AssetCollection.jsx` now renders an autoplay/loop/muted `<video>` for a video asset when no image preview applies, matching the existing raw-clip preview convention in `WalkWorkflow.jsx`.

## Test plan
- Added a test asserting an mp4 animation asset renders inline as an autoplay/loop/muted `<video>` under the "Animations" group heading.
- `npx vitest run src/components/sprites/` — 171 tests pass.