### PR TITLE
feat: reprocess turnaround candidates with corrections

### DIFF
--- a/client/src/components/sprites/CorrectionNote.jsx
+++ b/client/src/components/sprites/CorrectionNote.jsx
@@ -24,7 +24,7 @@ export function correctionPromptPayload(corrections, direction) {
   return note ? { correctionPrompt: note } : {};
 }
 
-export default function CorrectionNote({ direction, value, onChange, onValueChange, placeholder, className = '' }) {
+export default function CorrectionNote({ direction, value, onChange, onValueChange, placeholder, ariaLabel, className = '' }) {
   return (
     <textarea
       value={value || ''}
@@ -32,7 +32,7 @@ export default function CorrectionNote({ direction, value, onChange, onValueChan
         ? onValueChange(e.target.value)
         : onChange((prev) => ({ ...prev, [direction]: e.target.value }))}
       rows={2}
-      aria-label={`Correction guidance for the ${direction} pose`}
+      aria-label={ariaLabel || `Correction guidance for the ${direction} pose`}
       placeholder={placeholder || 'Correction (optional), e.g. no pocket on the right sleeve'}
       className={`w-full px-1.5 py-1 bg-port-bg border border-port-border rounded text-gray-300 placeholder-gray-600 resize-y focus:border-port-accent focus:outline-none ${className}`}
     />

--- a/client/src/components/sprites/ReferenceWorkflow.jsx
+++ b/client/src/components/sprites/ReferenceWorkflow.jsx
@@ -45,7 +45,7 @@ function SpriteImg({ recordId, path, className }) {
 // Candidate thumbnail with an inline lock confirm. Locking freezes this
 // version and its downstream workflow until the relevant explicit unlock, so
 // the consequential action stays visible in an inline confirm row.
-function CandidateTile({ recordId, candidate, locking, onLock, clipRisk, correction, onCorrectionChange, onReprocess, reprocessing }) {
+function CandidateTile({ recordId, candidate, locking, onLock, clipRisk, correction, onCorrectionChange, onReprocess, reprocessing, canReprocess = true }) {
   const [confirming, setConfirming] = useState(false);
   return (
     <div className="flex min-w-0 flex-col gap-2 rounded-lg border border-port-border bg-port-card p-2">
@@ -62,6 +62,7 @@ function CandidateTile({ recordId, candidate, locking, onLock, clipRisk, correct
           direction={candidate.path}
           value={correction}
           onValueChange={onCorrectionChange}
+          ariaLabel="Correction guidance for this turnaround attempt"
           placeholder="Correction for this attempt, e.g. add the missing sleeve pocket"
           className="text-[10px]"
         />
@@ -70,7 +71,7 @@ function CandidateTile({ recordId, candidate, locking, onLock, clipRisk, correct
         <button
           type="button"
           onClick={onReprocess}
-          disabled={reprocessing || !correction?.trim()}
+          disabled={!canReprocess || reprocessing || !correction?.trim()}
           title="Render this turnaround again with the correction note"
           className="flex min-h-8 w-full items-center justify-center gap-1 rounded border border-port-border bg-port-bg px-1.5 py-1 text-xs text-gray-300 hover:border-port-accent disabled:opacity-50"
         >
@@ -674,6 +675,7 @@ export default function ReferenceWorkflow({ record, reference, renders, correcti
                         onCorrectionChange={(value) => setTurnaroundCorrections((prev) => ({ ...prev, [candidate.path]: value }))}
                         onReprocess={() => reprocessTurnaround(candidate)}
                         reprocessing={Boolean(pendingJobs.turnaround)}
+                        canReprocess={Boolean(mode)}
                       />
                     ))}
                   </div>

--- a/client/src/components/sprites/ReferenceWorkflow.test.jsx
+++ b/client/src/components/sprites/ReferenceWorkflow.test.jsx
@@ -57,7 +57,7 @@ const renderWorkflow = ({ turnaround } = {}) => render(
       },
       candidates: [{
         target: 'turnaround',
-        path: 'reference/example-pioneer-turnaround-candidate-01.png',
+        path: 'reference/candidates/example-pioneer-turnaround-candidate-01.png',
         mode: 'codex',
       }],
     }}
@@ -157,7 +157,7 @@ describe('ReferenceWorkflow workspace', () => {
     expect(generateSpriteReference).toHaveBeenCalledWith('example-pioneer', {
       target: 'turnaround',
       mode: 'codex',
-      initImageCandidate: 'reference/example-pioneer-turnaround-candidate-01.png',
+      initImageCandidate: 'reference/candidates/example-pioneer-turnaround-candidate-01.png',
       correctionPrompt: 'add the missing sleeve pocket',
     }, { silent: true });
   });

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -1105,11 +1105,14 @@ export const spriteReferenceGenerateSchema = z.object({
   model: z.string().trim().max(64).optional(),
   effort: z.string().trim().max(32).optional(),
   designPrompt: z.string().max(4000).optional(),
-  // Extra free-text guidance appended to an anchor re-roll (e.g. "no pocket on
-  // the right sleeve") so regenerating diverges from the previous render
-  // instead of reproducing the same mistake. Anchor targets only — the main
-  // target iterates via `designPrompt`.
+  // Extra free-text guidance appended to a turnaround or anchor re-roll (e.g.
+  // "no pocket on the right sleeve") so regenerating diverges from the
+  // previous render instead of reproducing the same mistake.
   correctionPrompt: z.string().max(4000).optional(),
+  // Re-process one existing turnaround candidate with a correction note. The
+  // service validates that this is a real turnaround candidate owned by the
+  // record before using it as the i2i seed.
+  initImageCandidate: z.string().trim().max(500).optional(),
   initImageStrength: optionalUnitNumber,
   // Alternative i2i seed sources for the main target — resolved server-side and
   // mutually exclusive with an uploaded `referenceImage` file (which the route
@@ -1118,8 +1121,6 @@ export const spriteReferenceGenerateSchema = z.object({
   // seeds this one (the "fork"/derive-from case). Ignored for anchor targets.
   initImageGalleryFile: z.string().trim().max(300).optional(),
   initImageSpriteId: z.string().trim().max(200).optional(),
-  // Re-process one turnaround candidate as the i2i seed (turnaround target only).
-  initImageCandidate: z.string().trim().max(300).optional(),
 });
 
 // Fork a new character from an existing sprite's locked main reference: create


### PR DESCRIPTION
## Summary
- add a per-turnaround-candidate correction and re-process action
- use the selected candidate as the image-generation seed and preserve provenance
- validate candidate ownership/type and cover the request in client/server tests

## Test plan
- `git diff --check`
- `node --check server/services/sprites/reference.js`
- `node --check server/services/sprites/prompts.js`
- `node --check server/lib/validation.js`
- Vitest targeted suites could not run because dependencies are not installed in this worktree (`vitest: command not found`).