### PR TITLE
feat: gate LI self-improvement on delivery health

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Layered Intelligence
+
+- **[issue-3019] Layered Intelligence now notices when approved work is not being delivered** — its self-check now tracks approval-to-completion separately from reasoning-run success, so a loop that completes its own runs but repeatedly leaves approved proposals unfinished stops filing self-improvement work until delivery recovers. A five-approval floor keeps a fresh loop from being gated on cold-start noise, and the reasoner-facing notice identifies whether run health, delivery health, or both caused the guardrail.
+
 ## 3D
 
 - **Mesh preview display controls moved out of the render, and the lighting sliders now actually change the lighting** — the settings panel was an always-mounted overlay pinned inside the canvas, covering the upper-right quadrant of every model; it now lives behind a small toggle in the corner and expands as a strip *below* the render, so it can never occlude the mesh. Two of the controls it exposed were also effectively inert. The procedural studio environment lit the model at full strength and drowned out Ambient/Key/Fill — a new **Environment** slider dials the image-based lighting down (to 0 for lights-only), and the three light defaults were rebalanced against it. **Show HDRI background** revealed a cube map whose unlit areas were pure black, so the studio read as hard-edged white panels floating in a void (and only ever lit the model from three directions); an inward-facing backdrop sphere fills the gaps, and the map is rendered at 256 instead of 128. The scene-level background color was dropped in favor of the surface's CSS color it duplicated — a scene background raced the environment's own `scene.background` save/restore every time the HDRI toggle or the color picker changed.

--- a/server/services/layeredIntelligence.test.js
+++ b/server/services/layeredIntelligence.test.js
@@ -43,6 +43,8 @@ import {
   rejectionReasonBySlug,
   LI_DEGRADED_SUCCESS_THRESHOLD,
   LI_DEGRADED_MIN_SAMPLE,
+  LI_DELIVERY_MIN_SAMPLE,
+  LI_HARD_GATE_DELIVERY_THRESHOLD,
   computeScopeAwareness,
   computeExecutionByDomain,
   computePostApprovalCompletion,
@@ -871,7 +873,10 @@ describe('computeLiExecutionHealth (#2824)', () => {
   const stats = (over = {}) => ({ read: true, metrics: { completed: 10, succeeded: 3, failed: 7, successRate: 30, recentOutcomes: [], ...over } });
 
   it('reports UNKNOWN (rate null) when the store is unreadable or has no runs', () => {
-    expect(computeLiExecutionHealth(null)).toEqual({ rate: null, sample: 0, source: null, confident: false });
+    expect(computeLiExecutionHealth(null)).toEqual({
+      rate: null, sample: 0, source: null, confident: false,
+      deliveryRate: null, deliverySample: 0, deliveryConfident: false
+    });
     expect(computeLiExecutionHealth({ read: false })).toMatchObject({ rate: null, confident: false });
     expect(computeLiExecutionHealth({ read: true, metrics: null })).toMatchObject({ rate: null, confident: false });
   });
@@ -881,6 +886,22 @@ describe('computeLiExecutionHealth (#2824)', () => {
     expect(health.rate).toBe(30);
     expect(health.sample).toBe(10);
     expect(health.confident).toBe(true);
+  });
+
+  it('keeps run health independent from approval-to-completion delivery health', () => {
+    const outcomes = [
+      { outcome: 'merged', executionOutcome: 'success' },
+      ...Array.from({ length: 4 }, () => ({ outcome: 'merged', executionOutcome: null }))
+    ];
+    const health = computeLiExecutionHealth(stats({ succeeded: 9, failed: 1, successRate: 90 }), outcomes);
+    expect(health).toMatchObject({
+      rate: 90,
+      sample: 10,
+      confident: true,
+      deliveryRate: 20,
+      deliverySample: 5,
+      deliveryConfident: true
+    });
   });
 
   it('is NOT confident below LI_DEGRADED_MIN_SAMPLE runs', () => {
@@ -898,6 +919,10 @@ describe('computeHardExclusionGate (#2824)', () => {
   const healthy = { read: true, metrics: { completed: 10, succeeded: 9, failed: 1, successRate: 90, recentOutcomes: [] } };
   // Below the sample floor even though 0%.
   const thinSample = { read: true, metrics: { completed: 2, succeeded: 0, failed: 2, successRate: 0, recentOutcomes: [] } };
+  const poorDelivery = [
+    { outcome: 'merged', executionOutcome: 'success' },
+    ...Array.from({ length: 4 }, () => ({ outcome: 'merged', executionOutcome: null }))
+  ];
 
   it('never excludes a null/invalid proposal', () => {
     expect(computeHardExclusionGate({ proposal: null, liTaskStats: degraded })).toEqual({ excluded: false, reason: null });
@@ -909,6 +934,28 @@ describe('computeHardExclusionGate (#2824)', () => {
     expect(computeHardExclusionGate({ proposal: p, liTaskStats: null }).excluded).toBe(false);
     expect(computeHardExclusionGate({ proposal: p, liTaskStats: healthy }).excluded).toBe(false);
     expect(computeHardExclusionGate({ proposal: p, liTaskStats: thinSample }).excluded).toBe(false);
+  });
+
+  it('arms on a confidently-low delivery rate even when LI runs are healthy', () => {
+    const res = computeHardExclusionGate({
+      proposal: { scope: 'loop-meta' },
+      liTaskStats: healthy,
+      outcomes: poorDelivery
+    });
+    expect(res.excluded).toBe(true);
+    expect(res.rule).toBe('self-improve-scope');
+    expect(res.reason).toContain('approval-to-completion delivery health 20%');
+    expect(res.reason).toContain(`< ${LI_HARD_GATE_DELIVERY_THRESHOLD}%`);
+  });
+
+  it('does not arm the delivery signal with no approvals or fewer than its sample floor', () => {
+    const p = { scope: 'loop-meta' };
+    expect(computeHardExclusionGate({ proposal: p, liTaskStats: healthy, outcomes: [] }).excluded).toBe(false);
+    expect(computeHardExclusionGate({
+      proposal: p,
+      liTaskStats: healthy,
+      outcomes: Array.from({ length: LI_DELIVERY_MIN_SAMPLE - 1 }, () => ({ outcome: 'merged', executionOutcome: null }))
+    }).excluded).toBe(false);
   });
 
   it('excludes EVERY self-improve scope when armed, regardless of domain history', () => {
@@ -963,6 +1010,10 @@ describe('computeHardExclusionGate (#2824)', () => {
 describe('computeHardExclusionNotice (#2824)', () => {
   const degraded = { read: true, metrics: { completed: 10, succeeded: 3, failed: 7, successRate: 30, recentOutcomes: [] } };
   const healthy = { read: true, metrics: { completed: 10, succeeded: 9, failed: 1, successRate: 90, recentOutcomes: [] } };
+  const poorDelivery = [
+    { outcome: 'merged', executionOutcome: 'success' },
+    ...Array.from({ length: 4 }, () => ({ outcome: 'merged', executionOutcome: null }))
+  ];
 
   it('is empty when the gate is disarmed (healthy / unknown health)', () => {
     expect(computeHardExclusionNotice({ liTaskStats: healthy })).toBe('');
@@ -987,6 +1038,12 @@ describe('computeHardExclusionNotice (#2824)', () => {
     const notice = computeHardExclusionNotice({ liTaskStats: degraded, outcomes });
     expect(notice).toContain('chronically-failing execution domain');
     expect(notice).toContain('app-improvement');
+  });
+
+  it('names delivery health when that independent signal arms the gate', () => {
+    const notice = computeHardExclusionNotice({ liTaskStats: healthy, outcomes: poorDelivery });
+    expect(notice).toContain('approval-to-completion delivery health 20%');
+    expect(notice).toContain(`below ${LI_HARD_GATE_DELIVERY_THRESHOLD}%`);
   });
 });
 
@@ -1764,6 +1821,18 @@ describe('computeSelfEvalSummary (#2700)', () => {
     expect(report).not.toContain('execution is degraded');
   });
 
+  it('reports approval-to-completion delivery alongside LI run health', () => {
+    const report = computeSelfEvalSummary({
+      liTaskStats: liMetrics(),
+      outcomes: [
+        { outcome: 'merged', executionOutcome: 'success' },
+        ...Array.from({ length: 4 }, () => ({ outcome: 'merged', executionOutcome: null }))
+      ]
+    });
+    expect(report).toContain('80% of 10 lifetime LI runs succeeded');
+    expect(report).toContain('20% of 5 approved LI proposals completed');
+  });
+
   it('does not fire the degraded warning below the sample floor', () => {
     const report = computeSelfEvalSummary({
       liTaskStats: liMetrics({ completed: 1, succeeded: 0, failed: 1, successRate: 0 })
@@ -1810,6 +1879,8 @@ describe('computeSelfEvalSummary (#2700)', () => {
   it('exposes the degraded thresholds', () => {
     expect(LI_DEGRADED_SUCCESS_THRESHOLD).toBe(50);
     expect(LI_DEGRADED_MIN_SAMPLE).toBe(4);
+    expect(LI_DELIVERY_MIN_SAMPLE).toBe(5);
+    expect(LI_HARD_GATE_DELIVERY_THRESHOLD).toBe(50);
   });
 
   it('honors the injected clock when ageing the LI run window', () => {

--- a/server/services/layeredIntelligence/constants.js
+++ b/server/services/layeredIntelligence/constants.js
@@ -172,6 +172,18 @@ export const LI_DEGRADED_MIN_SAMPLE = 4;
 // CONFIDENT read (>= LI_DEGRADED_MIN_SAMPLE runs) — a cold loop is never locked out.
 export const LI_HARD_GATE_EXECUTION_THRESHOLD = 75;
 
+// Approved proposals need a separate evidence floor from LI's own reasoning runs:
+// a single accepted proposal that is still awaiting execution is not enough evidence
+// to lock the loop out of self-directed work. Once five approvals exist, a poor
+// approval → completion rate is a real delivery signal rather than cold-start noise.
+export const LI_DELIVERY_MIN_SAMPLE = 5;
+
+// LI's approval → completion rate (%) below which the hard pre-filing exclusion gate
+// also arms. This is intentionally independent of LI_HARD_GATE_EXECUTION_THRESHOLD:
+// a loop can complete its reasoning runs reliably while its approved proposals fail
+// to reach delivery, and neither rate is allowed to mask the other.
+export const LI_HARD_GATE_DELIVERY_THRESHOLD = 50;
+
 // The resolved outcomes a filed proposal can reach (the feedback loop, #2428).
 // A record with a null outcome is still open/unresolved. All three are
 // auto-derived from the tracker's closed state by deriveOutcome: completed →

--- a/server/services/layeredIntelligence/gates.js
+++ b/server/services/layeredIntelligence/gates.js
@@ -3,7 +3,11 @@
  * (#2842 split of layeredIntelligence.js).
  */
 
-import { PORTOS_ONLY_SCOPES, LI_HARD_GATE_EXECUTION_THRESHOLD } from './constants.js';
+import {
+  PORTOS_ONLY_SCOPES,
+  LI_HARD_GATE_EXECUTION_THRESHOLD,
+  LI_HARD_GATE_DELIVERY_THRESHOLD
+} from './constants.js';
 import { computeLiExecutionHealth } from './outcomes.js';
 import { computeExecutionByDomain, isAvoidDomain, formatDominantFailureCause, clampScopeLabel } from './awareness.js';
 
@@ -14,6 +18,19 @@ import { computeExecutionByDomain, isAvoidDomain, formatDominantFailureCause, cl
 // definition so "self-improve scope" can never drift from "the PortOS-only scopes".
 export const SELF_IMPROVE_SCOPES = PORTOS_ONLY_SCOPES;
 
+function computeArmedHealthSignals(health) {
+  const execution = health.confident && health.rate < LI_HARD_GATE_EXECUTION_THRESHOLD;
+  const delivery = health.deliveryConfident && health.deliveryRate < LI_HARD_GATE_DELIVERY_THRESHOLD;
+  return { execution, delivery, armed: execution || delivery };
+}
+
+function formatArmedHealthSignals(health, signals, comparison = '<') {
+  return [
+    signals.execution && `LI run execution health ${health.rate}% (${comparison} ${LI_HARD_GATE_EXECUTION_THRESHOLD}%)`,
+    signals.delivery && `LI approval-to-completion delivery health ${Math.round(health.deliveryRate)}% (${comparison} ${LI_HARD_GATE_DELIVERY_THRESHOLD}%; ${health.deliverySample} approved)`
+  ].filter(Boolean).join(' and ');
+}
+
 /**
  * Deterministic HARD PRE-FILING EXCLUSION gate (#2824). Given a validated proposal,
  * LI's own execution-health stats, and the app's outcome records, decides whether the
@@ -23,10 +40,11 @@ export const SELF_IMPROVE_SCOPES = PORTOS_ONLY_SCOPES;
  * (computeHardExclusionNotice): even when the reasoner "wants" to file, this gate drops
  * the proposal to null.
  *
- * Pure + side-effect-free like the sibling compute* gates. Two independent exclusion
- * rules, both ARMED only when LI's execution health is CONFIDENTLY below
- * LI_HARD_GATE_EXECUTION_THRESHOLD (75%) — unknown or below-sample-floor health leaves
- * the gate DISARMED, so a cold loop with no track record is never locked out:
+ * Pure + side-effect-free like the sibling compute* gates. The gate arms when EITHER
+ * independent health signal is confidently below its threshold: LI run success below
+ * LI_HARD_GATE_EXECUTION_THRESHOLD (75%), or approved-proposal delivery below
+ * LI_HARD_GATE_DELIVERY_THRESHOLD (50%). Unknown or below-sample-floor signals leave
+ * that signal disarmed, so a cold loop with no track record is never locked out:
  *   1. Self-improve scope — any proposal in a SELF_IMPROVE_SCOPES scope (loop-meta /
  *      portos-self) is excluded regardless of domain. A degraded loop cannot repair
  *      itself; that work is deferred to a human.
@@ -45,17 +63,18 @@ export const SELF_IMPROVE_SCOPES = PORTOS_ONLY_SCOPES;
 export function computeHardExclusionGate({ proposal, liTaskStats = null, outcomes = [], now = Date.now() } = {}) {
   if (!proposal || typeof proposal !== 'object') return { excluded: false, reason: null };
 
-  // The gate is ARMED only on a confident read of degraded execution health. Unknown
-  // health (store unreadable / no runs) or a below-floor sample disarms it — the same
-  // 0-of-1-vs-0-of-N reasoning as LI_DEGRADED_MIN_SAMPLE. A healthy loop (>= 75%) files
-  // exactly as before this gate existed.
-  const health = computeLiExecutionHealth(liTaskStats, { now });
-  if (!health.confident || health.rate >= LI_HARD_GATE_EXECUTION_THRESHOLD) {
+  // Each signal has its own evidence floor: unreadable / empty run history leaves the
+  // execution signal disarmed, while no approved proposals or fewer than five approvals
+  // leaves the delivery signal disarmed. A good rate on one side never masks a bad rate
+  // on the other.
+  const health = computeLiExecutionHealth(liTaskStats, outcomes, { now });
+  const signals = computeArmedHealthSignals(health);
+  if (!signals.armed) {
     return { excluded: false, reason: null };
   }
 
   const scope = typeof proposal.scope === 'string' && proposal.scope.trim() ? proposal.scope.trim() : null;
-  const healthClause = `LI execution health ${health.rate}% (< ${LI_HARD_GATE_EXECUTION_THRESHOLD}%)`;
+  const healthClause = formatArmedHealthSignals(health, signals);
 
   // Rule 1: self-improve scope — excluded wholesale while armed.
   if (scope && SELF_IMPROVE_SCOPES.includes(scope)) {
@@ -94,11 +113,12 @@ export function computeHardExclusionGate({ proposal, liTaskStats = null, outcome
  * carries the explicit GATE CHECK step the reasoner must run before committing.
  */
 export function computeHardExclusionNotice({ liTaskStats = null, outcomes = [], now = Date.now() } = {}) {
-  const health = computeLiExecutionHealth(liTaskStats, { now });
-  if (!health.confident || health.rate >= LI_HARD_GATE_EXECUTION_THRESHOLD) return '';
+  const health = computeLiExecutionHealth(liTaskStats, outcomes, { now });
+  const signals = computeArmedHealthSignals(health);
+  if (!signals.armed) return '';
 
   const lines = [
-    `HARD EXCLUSION GATE ARMED — your execution health is ${health.rate}% (below ${LI_HARD_GATE_EXECUTION_THRESHOLD}%). The following work is EXCLUDED this run and will be dropped BEFORE filing even if your reasoning leads you to it:`,
+    `HARD EXCLUSION GATE ARMED — ${formatArmedHealthSignals(health, signals, 'below')}. The following work is EXCLUDED this run and will be dropped BEFORE filing even if your reasoning leads you to it:`,
     `- Any self-improve-scoped proposal (${SELF_IMPROVE_SCOPES.join(', ')}). A degraded loop cannot repair itself — that work is deferred to a human.`
   ];
 

--- a/server/services/layeredIntelligence/outcomes.js
+++ b/server/services/layeredIntelligence/outcomes.js
@@ -13,7 +13,7 @@ import { formatRejectionReasons, formatRejectionReason, REJECTION_REASONS } from
 import { formatExecutionFailures } from '../layeredIntelligenceExecutionFailures.js';
 import {
   LOW_MERGE_RATE_MIN_SAMPLE, LOW_MERGE_RATE_THRESHOLD, LI_DEGRADED_MIN_SAMPLE,
-  LI_DEGRADED_SUCCESS_THRESHOLD, LI_HARD_GATE_EXECUTION_THRESHOLD, CLOSED_SUPPRESSION_MS,
+  LI_DEGRADED_SUCCESS_THRESHOLD, LI_DELIVERY_MIN_SAMPLE, LI_HARD_GATE_EXECUTION_THRESHOLD, CLOSED_SUPPRESSION_MS,
 } from './constants.js';
 import { normalizeSlug, extractSlugFromBody, isIssueWithinDedupWindow } from './dedup.js';
 import { computePostApprovalCompletion, scopeKeyOf } from './awareness.js';
@@ -416,30 +416,44 @@ export function describeSuppressedIssue(issue, reasonBySlug = null) {
  * @returns {string} the liSelfEval block body.
  */
 /**
- * Resolve LI's own EXECUTION HEALTH — the loop's reasoning-run success rate — into a
- * single structured read, so every consumer (the selfEval Signal 3 line AND the hard
- * exclusion gate, #2824) judges LI's health off the SAME number instead of each
- * re-deriving it and risking drift. Reads the LI-task metrics bucket
+ * Resolve LI's independent health signals into one structured read: the loop's own
+ * reasoning-run success rate and approved-proposal delivery rate. Every consumer (the
+ * selfEval Signal 3 line and the hard exclusion gate) reads the same values instead of
+ * re-deriving either rate and risking drift. Run health reads the LI-task metrics bucket
  * (readLiTaskMetrics) through the effective (recency-windowed-or-lifetime) success
- * rate, exactly as Signal 3 did inline.
+ * rate; delivery health composes the #3014 outcome metrics.
  *
  * @param {{ read: boolean, metrics: Object|null }|null} liTaskStats - from
  *   readLiTaskMetrics. `null`/`read:false` = the learning store was unreadable;
  *   `read:true, metrics:null` = read fine and LI has simply never run a task.
+ * @param {Array} [outcomes] - the app's li-outcomes records used for approval →
+ *   completion delivery health. Omit to preserve the former run-health behavior.
  * @param {{ now?: number }} [opts] - clock seam forwarded to computeEffectiveSuccessRate.
- * @returns {{ rate: number|null, sample: number, source: string|null, confident: boolean }}
+ * @returns {{ rate: number|null, sample: number, source: string|null, confident: boolean,
+ *   deliveryRate: number|null, deliverySample: number, deliveryConfident: boolean }}
  *   `rate` is null when health is UNKNOWN (store unreadable, no runs, or no completed
  *   runs). `confident` is true only at >= LI_DEGRADED_MIN_SAMPLE runs — the floor
- *   below which a rate (0-of-1 vs 0-of-N) is not yet evidence.
+ *   below which a rate (0-of-1 vs 0-of-N) is not yet evidence. Delivery fields keep
+ *   that same absent-versus-empty distinction: no approved proposals report a null
+ *   deliveryRate, never a misleading 0%.
  */
-export function computeLiExecutionHealth(liTaskStats = null, { now = Date.now() } = {}) {
+export function computeLiExecutionHealth(liTaskStats = null, outcomes = [], { now = Date.now() } = {}) {
+  const delivery = computeProposalOutcomeMetrics(outcomes);
+  const deliveryRate = delivery.approvalToCompletionRate;
+  const deliverySample = delivery.totalApproved;
+  const deliveryHealth = {
+    deliveryRate,
+    deliverySample,
+    deliveryConfident: deliveryRate !== null && deliverySample >= LI_DELIVERY_MIN_SAMPLE
+  };
+
   if (!liTaskStats?.read || !liTaskStats.metrics) {
-    return { rate: null, sample: 0, source: null, confident: false };
+    return { rate: null, sample: 0, source: null, confident: false, ...deliveryHealth };
   }
   const { successRate, source, windowedCompleted } = computeEffectiveSuccessRate(liTaskStats.metrics, { now });
-  if (successRate === null) return { rate: null, sample: 0, source: null, confident: false };
+  if (successRate === null) return { rate: null, sample: 0, source: null, confident: false, ...deliveryHealth };
   const sample = source === 'windowed' ? windowedCompleted : (liTaskStats.metrics.completed || 0);
-  return { rate: successRate, sample, source, confident: sample >= LI_DEGRADED_MIN_SAMPLE };
+  return { rate: successRate, sample, source, confident: sample >= LI_DEGRADED_MIN_SAMPLE, ...deliveryHealth };
 }
 
 export function computeSelfEvalSummary({
@@ -527,6 +541,7 @@ export function computeSelfEvalSummary({
   // it mirrors the cosMetrics source, which is likewise install-wide.
   let taskSignal = false;
   let liDegraded = false;
+  const health = computeLiExecutionHealth(liTaskStats, outcomes, { now });
   if (!liTaskStats?.read) {
     lines.push('- LI execution health: UNAVAILABLE — the CoS learning store could not be read.');
   } else if (!liTaskStats.metrics) {
@@ -537,7 +552,6 @@ export function computeSelfEvalSummary({
     // never disagree about LI's own success rate. Without `now` computeEffectiveSuccessRate
     // would read the real wall clock while the suppression-window branch above uses the
     // injected one — the same summary reasoning against two different "nows".
-    const health = computeLiExecutionHealth(liTaskStats, { now });
     if (health.rate === null) {
       lines.push('- LI execution health: no completed LI runs recorded yet — success rate unknown.');
     } else {
@@ -548,6 +562,21 @@ export function computeSelfEvalSummary({
         + `${taskSignal ? '' : ' — too small a sample to judge'}${liDegraded ? ' — DEGRADED' : ''}.`
       );
     }
+  }
+
+  // Delivery is intentionally reported beside LI's own run success rather than
+  // blended into it. A healthy reasoning loop can still leave approved proposals
+  // undelivered, and vice versa; keeping both lines lets the reasoner see which
+  // signal actually armed a hard gate.
+  if (!Array.isArray(outcomes)) {
+    lines.push('- LI approval-to-completion delivery health: UNAVAILABLE — no outcome history was gathered this run.');
+  } else if (health.deliveryRate === null) {
+    lines.push('- LI approval-to-completion delivery health: no approved LI proposals yet — delivery rate unknown.');
+  } else {
+    lines.push(
+      `- LI approval-to-completion delivery health: ${Math.round(health.deliveryRate)}% of ${health.deliverySample} approved LI proposals completed`
+      + `${health.deliveryConfident ? '' : ' — too small a sample to judge'}.`
+    );
   }
 
   // --- Confidence: how much do I actually know about myself? ------------------


### PR DESCRIPTION
## Summary
- Add independent approval-to-completion delivery health alongside LI run success.
- Arm the hard self-exclusion gate when either confident signal is below its threshold, while preserving cold-start safeguards.
- State the signal responsible in both the gate reason and the reasoner-facing notice.

## Test plan
- `cd server && npm test -- services/layeredIntelligence.test.js`
- `cd server && npm test` *(blocked by unavailable PostgreSQL; 1,281 unrelated storage tests fail fast)*

Closes #3019