### PR TITLE
fix: update stale props reference-set test for ambient loops

### DIFF
--- a/server/routes/sprites.test.js
+++ b/server/routes/sprites.test.js
@@ -201,14 +201,14 @@ describe('sprites routes', () => {
     expect(reference.getReferenceSet).toHaveBeenCalledWith('pioneer');
   });
 
-  it('GET /:id skips the reference set for props records', async () => {
+  it('GET /:id returns the reference set for props records (ambient-loop identity root)', async () => {
     records.getRecordWithAssets.mockResolvedValueOnce({
       record: { id: 'crates', kind: 'props' }, assets: [],
     });
     const r = await request(app).get('/api/sprites/crates');
     expect(r.status).toBe(200);
-    expect(r.body.reference).toBeNull();
-    expect(reference.getReferenceSet).not.toHaveBeenCalled();
+    expect(r.body.reference).toEqual({ manifest: null, candidates: [] });
+    expect(reference.getReferenceSet).toHaveBeenCalledWith('crates');
   });
 
   it('GET /:id 404s on an unknown record', async () => {


### PR DESCRIPTION
## Summary
- `GET /:id skips the reference set for props records` asserted the pre-ambient-loop premise that `props`/`place`/`object` records carry no animation track and therefore skip `getReferenceSet`.
- #3045 gave those kinds an ambient-loop track with its own reference/main identity root, so every sprite kind now has at least one track and the route correctly calls `getReferenceSet` for all of them.
- Updated the test to assert the current, intended behavior instead of the stale one — this was failing `test (24.x)` on `main` for any branch merged past fe4bb1304.

## Test plan
- `cd server && npx vitest run routes/sprites.test.js` — 51/51 passing