### PR TITLE
fix: launch managed shell apps directly

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -150,6 +150,7 @@
 
 ## Fixed
 
+- **Godot launch actions now run their shell launcher correctly** — managed games launched from Apps no longer hand their game script to Node, so their normal shell setup and Godot launch sequence can start.
 - **CoS Codex review loops now parse Claude and Ollama verdicts deterministically** — Claude review logs are accepted as clean only when they contain the exact `NO FINDINGS` sentinel and no findings; otherwise Codex extracts only complete structured `FINDING N:` blocks to apply. Mixed, incomplete, or absent Claude verdicts are explicitly inconclusive instead of being guessed clean. Local Ollama/LM Studio review responses now extract and validate the JSON `.findings` field before use, surfacing the provider error when it is missing or malformed and terminating the failed review step nonzero. This prevents a text/JSON handoff mismatch from silently dropping reviewer findings or letting an ambiguous pass merge.
 
 - **[issue-3059] Wordplay training checks now stay reliable during busy CI runs** — the test suite gives a newly selected word game time to finish its normal loading path, preventing intermittent build failures without weakening coverage.

--- a/server/routes/apps/lifecycle.js
+++ b/server/routes/apps/lifecycle.js
@@ -33,6 +33,30 @@ const router = Router();
 // Delay before restarting PortOS itself so the JSON response reaches the client
 const SELF_RESTART_RESPONSE_DELAY_MS = 500;
 
+async function launchDesktopProcess(app, processName, command) {
+  const current = await pm2Service.getAppStatus(processName, app.pm2Home).catch(() => null);
+  if (['online', 'launching'].includes(current?.status)) {
+    return { success: true, alreadyRunning: true };
+  }
+
+  // PM2 keeps a stopped process's original interpreter. Recreate only inactive
+  // desktop targets so a corrected shell launcher is not still forked by Node.
+  if (['stopped', 'errored'].includes(current?.status)) {
+    const removal = await pm2Service.deleteApp(processName, app.pm2Home)
+      .catch(err => ({ success: false, error: err.message }));
+    if (removal.success === false) {
+      return { success: false, error: `Could not replace the previous launch: ${removal.error}` };
+    }
+  }
+
+  return pm2Service.startWithCommand(
+    processName,
+    app.repoPath,
+    command,
+    { autorestart: false }
+  ).catch(err => ({ success: false, error: err.message }));
+}
+
 // POST /api/apps/:id/native-launch - Launch an optional native/GUI target
 router.post('/:id/native-launch', loadApp, asyncHandler(async (req, res) => {
   const app = req.loadedApp;
@@ -44,21 +68,15 @@ router.post('/:id/native-launch', loadApp, asyncHandler(async (req, res) => {
     throw new ServerError('App repo path does not exist', { status: 400, code: 'PATH_NOT_FOUND' });
   }
 
-  const current = await pm2Service.getAppStatus(target.processName, app.pm2Home).catch(() => null);
-  if (['online', 'launching'].includes(current?.status)) {
+  const result = await launchDesktopProcess(app, target.processName, target.command);
+  if (result.alreadyRunning) {
     return res.json({
       success: true,
       processName: target.processName,
-      result: { success: true, alreadyRunning: true }
+      result
     });
   }
 
-  const result = await pm2Service.startWithCommand(
-    target.processName,
-    app.repoPath,
-    target.command,
-    { autorestart: false }
-  ).catch(err => ({ success: false, error: err.message }));
   const success = result.success !== false;
   await logAction('native-launch', app.id, app.name, { processName: target.processName, label: target.label }, success);
   notifyAppsChanged('native-launch');
@@ -128,18 +146,11 @@ router.post('/:id/start', loadApp, asyncHandler(async (req, res) => {
     for (let i = 0; i < processNames.length; i++) {
       const name = processNames[i];
       const command = commands[i] || commands[0];
-      // Single instance: a desktop/GUI process that is already up — or in the
-      // transient `launching` state a slow game build sits in — must not be
-      // relaunched into a second window. Matching more than the steady `online`
-      // is what stops a click during a slow launch from spawning a duplicate.
       if (desktop) {
-        const current = await pm2Service.getAppStatus(name, app.pm2Home).catch(() => null);
-        if (['online', 'launching'].includes(current?.status)) {
-          results[name] = { success: true, alreadyRunning: true };
-          continue;
-        }
+        results[name] = await launchDesktopProcess(app, name, command);
+        continue;
       }
-      const result = await pm2Service.startWithCommand(name, app.repoPath, command, desktop ? { autorestart: false } : {})
+      const result = await pm2Service.startWithCommand(name, app.repoPath, command, {})
         .catch(err => ({ success: false, error: err.message }));
       results[name] = result;
     }

--- a/server/routes/apps/lifecycle.test.js
+++ b/server/routes/apps/lifecycle.test.js
@@ -16,6 +16,7 @@ vi.mock('../../services/pm2.js', () => ({
   getAppStatus: vi.fn(),
   startFromEcosystem: vi.fn(),
   startWithCommand: vi.fn(),
+  deleteApp: vi.fn(),
   stopApp: vi.fn(),
   restartApp: vi.fn(),
   getLogs: vi.fn()
@@ -72,6 +73,7 @@ describe('Apps Lifecycle Routes', () => {
     it('launches the native target without replacing the web lifecycle', async () => {
       appsService.getAppById.mockResolvedValue(mockApp);
       pm2Service.getAppStatus.mockResolvedValue({ status: 'stopped' });
+      pm2Service.deleteApp.mockResolvedValue({ success: true });
       pm2Service.startWithCommand.mockResolvedValue({ success: true });
       history.logAction.mockResolvedValue();
 
@@ -82,6 +84,9 @@ describe('Apps Lifecycle Routes', () => {
       expect(pm2Service.startWithCommand).toHaveBeenCalledWith(
         'mixed-game', '/tmp', './scripts/game run', { autorestart: false }
       );
+      expect(pm2Service.deleteApp).toHaveBeenCalledWith('mixed-game', undefined);
+      expect(pm2Service.deleteApp.mock.invocationCallOrder[0])
+        .toBeLessThan(pm2Service.startWithCommand.mock.invocationCallOrder[0]);
       expect(pm2Service.startFromEcosystem).not.toHaveBeenCalled();
       expect(history.logAction).toHaveBeenCalledWith(
         'native-launch',
@@ -101,6 +106,27 @@ describe('Apps Lifecycle Routes', () => {
       expect(response.status).toBe(200);
       expect(response.body.result.alreadyRunning).toBe(true);
       expect(pm2Service.startWithCommand).not.toHaveBeenCalled();
+      expect(pm2Service.deleteApp).not.toHaveBeenCalled();
+    });
+
+    it('does not launch a replacement when removing stale PM2 metadata fails', async () => {
+      appsService.getAppById.mockResolvedValue(mockApp);
+      pm2Service.getAppStatus.mockResolvedValue({ status: 'errored' });
+      pm2Service.deleteApp.mockResolvedValue({ success: false, error: 'PM2 unavailable' });
+      history.logAction.mockResolvedValue();
+
+      const response = await request(app).post('/api/apps/app-001/native-launch');
+
+      expect(response.status).toBe(500);
+      expect(response.body.code).toBe('NATIVE_LAUNCH_FAILED');
+      expect(pm2Service.startWithCommand).not.toHaveBeenCalled();
+      expect(history.logAction).toHaveBeenCalledWith(
+        'native-launch',
+        'app-001',
+        'Mixed App',
+        { processName: 'mixed-game', label: 'Godot' },
+        false
+      );
     });
 
     it('reports the native process status independently of the web app', async () => {
@@ -163,6 +189,7 @@ describe('Apps Lifecycle Routes', () => {
       };
       appsService.getAppById.mockResolvedValue(mockApp);
       pm2Service.getAppStatus.mockResolvedValue({ status: 'stopped' }); // not running yet
+      pm2Service.deleteApp.mockResolvedValue({ success: true });
       pm2Service.startWithCommand.mockResolvedValue({ success: true });
       history.logAction.mockResolvedValue();
 
@@ -175,6 +202,7 @@ describe('Apps Lifecycle Routes', () => {
       expect(pm2Service.startWithCommand).toHaveBeenCalledWith(
         'the-game', '/tmp', './scripts/game run', { autorestart: false }
       );
+      expect(pm2Service.deleteApp).toHaveBeenCalledWith('the-game', undefined);
     });
 
     it('does not spawn a second instance when the desktop app is already online (#2991)', async () => {

--- a/server/services/pm2.js
+++ b/server/services/pm2.js
@@ -21,9 +21,9 @@ const require = createRequire(import.meta.url);
 const PM2_BIN = join(dirname(require.resolve('pm2/package.json')), 'bin', 'pm2');
 
 /**
- * Check if a script path is a JS file that PM2 can fork directly.
- * On Windows, non-JS scripts (npm, npx, vite, etc.) resolve to .cmd batch files
- * which PM2's fork mode tries to require() as JavaScript — causing SyntaxError.
+ * Check if a script path is a JS file that PM2 can fork through Node.
+ * Other executable commands (including shell scripts) must run directly so PM2
+ * does not try to parse them as JavaScript.
  */
 function isJsScript(script) {
   return /\.(?:js|mjs|cjs|ts)$/i.test(script);
@@ -169,8 +169,9 @@ export async function startApp(name, options = {}) {
         windowsHide: IS_WIN
       };
 
-      // On Windows, non-JS scripts (.cmd batch files) can't be fork'd by PM2
-      if (IS_WIN && !isJsScript(script)) {
+      // Non-JS commands must run directly: PM2 otherwise forks them through
+      // Node, which parses shell scripts as JavaScript on every platform.
+      if (!isJsScript(script)) {
         startOptions.interpreter = 'none';
       }
 
@@ -517,8 +518,9 @@ export async function startWithCommand(name, cwd, command, options = {}) {
         windowsHide: IS_WIN
       };
 
-      // On Windows, non-JS scripts (.cmd batch files) can't be fork'd by PM2
-      if (IS_WIN && !isJsScript(script)) {
+      // PM2 defaults to Node for command scripts. Run executables directly so
+      // native launchers such as `./scripts/game` honor their shebang.
+      if (!isJsScript(script)) {
         opts.interpreter = 'none';
       }
 

--- a/server/services/pm2.launch.test.js
+++ b/server/services/pm2.launch.test.js
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPm2 = vi.hoisted(() => ({
+  connect: vi.fn(),
+  disconnect: vi.fn(),
+  start: vi.fn()
+}));
+
+vi.mock('pm2', () => ({ default: mockPm2 }));
+
+import { startApp, startWithCommand } from './pm2.js';
+
+describe('PM2 command launch interpreters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPm2.connect.mockImplementation(callback => callback(null));
+    mockPm2.start.mockImplementation((options, callback) => callback(null, options));
+  });
+
+  it('executes shell-script commands directly instead of parsing them with Node', async () => {
+    await startWithCommand(
+      'elsewhere-acres-godot',
+      '/repo/elsewhere-acres',
+      './scripts/game run',
+      { autorestart: false }
+    );
+
+    expect(mockPm2.start).toHaveBeenCalledWith(expect.objectContaining({
+      name: 'elsewhere-acres-godot',
+      script: './scripts/game',
+      args: ['run'],
+      interpreter: 'none',
+      autorestart: false
+    }), expect.any(Function));
+  });
+
+  it('keeps JavaScript entrypoints on PM2\'s Node interpreter', async () => {
+    await startWithCommand('web-app', '/repo/web-app', './server.mjs');
+
+    const [options] = mockPm2.start.mock.calls[0];
+    expect(options).not.toHaveProperty('interpreter');
+  });
+
+  it('applies the same direct-execution rule to configured app scripts', async () => {
+    await startApp('tooling-app', { script: 'npm', args: 'run dev' });
+
+    expect(mockPm2.start).toHaveBeenCalledWith(expect.objectContaining({
+      script: 'npm',
+      args: 'run dev',
+      interpreter: 'none'
+    }), expect.any(Function));
+  });
+});


### PR DESCRIPTION
## Summary
- Run managed non-JavaScript launch commands directly so shell scripts honor their shebang instead of being parsed by Node.
- Recreate stopped or errored desktop PM2 processes before relaunching so repaired interpreter settings take effect.
- Cover shell launch options, JavaScript entrypoints, stale-process replacement, and safe replacement failures.

## Test plan
- `npm test --prefix server -- --run services/pm2.launch.test.js services/pm2.parseJlist.test.js routes/apps/lifecycle.test.js`
- `git diff --check`

## Review
- Local review: clean.
- Ollama: one non-actionable false positive; proposed code was already present.
- Antigravity (optional): no verdict returned; no edits made.