### PR TITLE
fix: constrain sprite reference candidates

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -4,6 +4,10 @@
 
 - Client linting now uses ESLint 10 with the maintained ESLint React rule set, preserving PortOS's key React correctness checks without relying on the unmaintained `eslint-plugin-react` compatibility range.
 
+## Sprites
+
+- Sprite turnaround and directional-reference candidates now request a square canvas from image generation and explicitly treat the locked turnaround as the source of truth for accessory side and occlusion. This prevents arbitrary Codex ImageGen candidate aspect ratios and reduces mirrored hip-bag drift before an anchor is locked.
+
 ## CoS agent failure reporting
 
 - Failed agent runs are classified far more accurately. A terminal-UI agent's transcript is a repainted *screen*, not a log — it can run to hundreds of kilobytes while containing barely any line breaks — so the analyzer's "look at the recent output" window was quietly reading the entire session. Any keyword anywhere in it, including commands the agent itself typed, decided the verdict: one run reaped for going idle was reported as "Context length exceeded", which blocked its task and auto-filed an investigation for a problem that never happened.

--- a/server/services/sprites/prompts.js
+++ b/server/services/sprites/prompts.js
@@ -62,6 +62,10 @@ export function keyColorPhrase(hex) {
 // read a given facing from.
 export const TURNAROUND_VIEWS = ['south', 'east', 'north', 'west'];
 
+// Reference candidates are reviewed before their foreground is normalized onto
+// the locked square frame, so generation itself must hold the sprite canvas.
+export const SPRITE_REFERENCE_CANVAS_SIZE = 1024;
+
 // --- View geometry (issue #3004) -------------------------------------------
 // The turnaround's dominant failure mode is that the model MIRRORS the front
 // figure instead of rotating the character: a hip bag worn on the FRONT of the
@@ -187,7 +191,7 @@ export function buildTurnaroundPrompt({ name, designPrompt, chromaKey, correctio
     + 'it is visible at all in a given panel is decided by that panel\'s rule below. '
     + `${panelRules} `
     + 'Flat non-isometric pixel-art game sprite '
-    + `reference on a plain exact ${keyColorPhrase(chromaKey)} background. No panel borders, `
+    + `reference on a plain exact ${keyColorPhrase(chromaKey)} background on a square 1:1 canvas. No panel borders, `
     + 'labels, captions, arrows, grid, shadows, scenery, wireframe, or extra characters. '
     + 'Return exactly one PNG.'
     + correction
@@ -251,7 +255,7 @@ export function buildMainReferencePrompt({ name, designPrompt, chromaKey, fromTu
     + 'level on one baseline, arms relaxed, with a clear readable silhouette. Match the '
     + 'attached visual reference when provided. Preserve physical-left and physical-right '
     + `accessories exactly. ${geometryRule('south')}Flat non-isometric pixel-art game sprite reference, centered on `
-    + `a plain exact ${keyColorPhrase(chromaKey)} background. No motion, labels, grid, shadows, scenery, `
+    + `a plain exact ${keyColorPhrase(chromaKey)} background on a square 1:1 canvas. No motion, labels, grid, shadows, scenery, `
     + 'wireframe, or extra figures. Return exactly one PNG.'
   );
 }
@@ -268,7 +272,7 @@ export function buildAmbientReferencePrompt({ name, kind, designPrompt, chromaKe
   return (
     `Create one centered game-sprite ${kind} named ${name}. Design: ${description} `
     + 'Show its at-rest state with a clear readable silhouette. Match the attached visual reference when provided. '
-    + `Use a plain exact ${keyColorPhrase(chromaKey)} background. No people, scenery, text, labels, grid, `
+    + `Use a plain exact ${keyColorPhrase(chromaKey)} background on a square 1:1 canvas. No people, scenery, text, labels, grid, `
     + 'camera angle, shadows, wireframe, or extra objects. Return exactly one PNG.'
   );
 }
@@ -327,9 +331,11 @@ export function buildAnchorPrompt({ name, direction, chromaKey, correctionPrompt
     + `Redraw the attached ${name} character as one `
     + `full-body figure in a neutral standing pose, ${facing}. Keep the exact same `
     + 'identity, proportions, palette, clothing, hairstyle, and accessories/straps on the '
-    + 'same anatomical side as the attached reference. This is a rotation of the character, '
+    + 'same anatomical side as the attached reference. Treat the turnaround panels as the source of truth: '
+    + 'identify each accessory\'s anatomical side and depth placement there, then draw it only where this '
+    + 'facing can physically reveal it. This is a rotation of the character, '
     + `not a mirrored copy of the reference. ${geometryRule(direction)}Flat, non-isometric view; a `
-    + `single centered figure; plain flat ${keyColorPhrase(chromaKey)} background; no labels, no `
+    + `single centered figure on a square 1:1 canvas; plain flat ${keyColorPhrase(chromaKey)} background; no labels, no `
     + 'grid lines, no wireframe or guide colors. Return exactly one PNG.'
     + correction
   );

--- a/server/services/sprites/prompts.test.js
+++ b/server/services/sprites/prompts.test.js
@@ -2,10 +2,14 @@ import { describe, it, expect } from 'vitest';
 import {
   SPRITE_DIRECTIONS, ANCHOR_DIRECTIONS, REFERENCE_FACING, anchorIdForDirection,
   keyColorPhrase, buildMainReferencePrompt, buildAnchorPrompt, buildTurnaroundPrompt,
-  buildWalkVideoPrompt, viewGeometryClause, TURNAROUND_VIEWS,
+  buildWalkVideoPrompt, viewGeometryClause, TURNAROUND_VIEWS, SPRITE_REFERENCE_CANVAS_SIZE,
 } from './prompts.js';
 
 describe('sprite direction contracts', () => {
+  it('uses a square canvas for reviewable reference candidates', () => {
+    expect(SPRITE_REFERENCE_CANVAS_SIZE).toBe(1024);
+  });
+
   it('exposes the canonical 8-direction order starting at south', () => {
     expect(SPRITE_DIRECTIONS).toHaveLength(8);
     expect(SPRITE_DIRECTIONS[0]).toBe('south');
@@ -68,6 +72,8 @@ describe('buildAnchorPrompt', () => {
     expect(p).toContain('facing due east, a strict right-facing side profile');
     expect(p).toContain('magenta (#FF00FF) background');
     expect(p).toContain('attached Scout character');
+    expect(p).toContain('square 1:1 canvas');
+    expect(p).toContain('Treat the turnaround panels as the source of truth');
   });
 
   it('appends a trimmed correction clause when provided', () => {
@@ -100,6 +106,7 @@ describe('buildTurnaroundPrompt (#2979)', () => {
     // The constraint the sheet exists to enforce.
     expect(p).toContain('SAME anatomical side');
     expect(p).toContain('green (#00FF00) background');
+    expect(p).toContain('square 1:1 canvas');
   });
 
   it('falls back to the attached reference when no design prompt is given', () => {

--- a/server/services/sprites/reference.js
+++ b/server/services/sprites/reference.js
@@ -40,6 +40,7 @@ import { getRecord, updateRecord, listRecords, createCharacter } from './records
 import { spriteDir, resolveSpriteAssetPath, listSpriteAssets } from './paths.js';
 import {
   SPRITE_DIRECTIONS, ANCHOR_DIRECTIONS, anchorIdForDirection, TURNAROUND_VIEWS, TURNAROUND_ID,
+  SPRITE_REFERENCE_CANVAS_SIZE,
   buildMainReferencePrompt, buildAmbientReferencePrompt, buildAnchorPrompt, buildTurnaroundPrompt,
 } from './prompts.js';
 import { pickChromaKey, keyProximityWarning, CHROMA_KEY_HEXES, DEFAULT_CHROMA_KEY } from './chromaKey.js';
@@ -523,6 +524,10 @@ async function startReferenceGenerationImpl(recordId, body, upload = null) {
       : null;
   const baseParams = {
     prompt,
+    // Codex ImageGen otherwise selects an arbitrary native aspect ratio. The
+    // review candidates must already match the square frame locked anchors use.
+    width: SPRITE_REFERENCE_CANVAS_SIZE,
+    height: SPRITE_REFERENCE_CANVAS_SIZE,
     ...(initImagePath ? { initImagePath, initImageStrength } : {}),
     cleanC2PA,
     denoise,

--- a/server/services/sprites/reference.test.js
+++ b/server/services/sprites/reference.test.js
@@ -184,6 +184,7 @@ describe('startReferenceGeneration', () => {
     expect(call.kind).toBe('image');
     expect(call.params.mode).toBe('codex');
     expect(call.params.model).toBe('gpt-5.6-luna');
+    expect(call.params).toMatchObject({ width: 1024, height: 1024 });
     expect(call.params.prompt).toContain('named Hero');
     expect(call.params.prompt).toContain('a wiry ranger');
     expect(call.params.prompt).toContain('magenta (#FF00FF)');
@@ -249,6 +250,7 @@ describe('startReferenceGeneration', () => {
     const call = enqueueJob.mock.calls[0][0];
     expect(call.params.initImagePath).toContain(`${id}-turnaround-v1.png`);
     expect(call.params.initImageStrength).toBe(0.8);
+    expect(call.params).toMatchObject({ width: 1024, height: 1024 });
     expect(call.params.prompt).toContain('turnaround model sheet');
     expect(call.params.prompt).toContain('facing the viewer (front)');
     // The design prompt persists from the turnaround step — the main render


### PR DESCRIPTION
## Summary
- request a 1024x1024 canvas for sprite reference candidates
- require square reference canvases in turnaround, main, ambient, and anchor prompts
- reinforce turnaround-derived accessory side and occlusion constraints

## Validation
- npm test -- --run services/sprites/prompts.test.js services/sprites/reference.test.js
- node --check server/services/sprites/prompts.js
- node --check server/services/sprites/reference.js
- git diff --check