### PR TITLE
Version-gate universe style-reference saves so a stale re-hydration GET can't clobber a newer in-flight mutation

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -18,3 +18,7 @@
 
 - [issue-3103] Any Cast, Place, or Object entry in a Universe's bible can now take a corrective reference image: upload or pick a photo/render that shows what it should actually look like, and a vision model compares it against the entry's current description and proposes a correction. Reviewing and applying it both fixes the description and pins the image as that entry's reference image, so future renders for it are visually anchored to the correction instead of starting from scratch each time.
 - Reference-image pinning (the star toggle on a canon entry's thumbnail) now feeds every future render of that entry, not just its thumbnail — if you'd already pinned a reference image before this update, its next render will be visually anchored to that image too.
+
+## Universe art references
+
+- **[issue-3099] Adding or removing an art reference no longer flickers back when you navigate away and return mid-save** — if you changed a universe's art references and switched to another universe and back before the change finished saving, a slower page refresh could briefly restore the pre-change list on screen, making the next add or remove operate on the wrong set. The saved change now always wins over the older refresh it raced.

--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -125,6 +125,13 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
   // is scoped to exactly the fields the winning PATCH wrote; every other field
   // still comes from G, which may legitimately be fresher (peer sync, canon).
   //
+  // The guide carries its OWN `guidanceEpoch` rather than riding the reference
+  // epoch, because the two move independently: a plain add/remove bumps `epoch`
+  // without writing the guide. Overlaying on the reference epoch alone would
+  // let such a mutation resurrect a long-settled adopt over a newer peer edit
+  // that G legitimately carries. Overlay only when a PATCH wrote the guide
+  // AFTER G was issued.
+  //
   // The guard is deliberately "a mutation always beats a concurrent GET", not a
   // monotonic issued-at sequence shared by all writers: G is issued AFTER M yet
   // reads state the server may not have written M into yet, so ordering by
@@ -152,21 +159,27 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
   }, []);
 
   const styleReferenceState = useCallback(
-    (id) => styleReferenceStatesRef.current.get(id) ?? { references: null, guidance: null, epoch: 0 },
+    (id) => styleReferenceStatesRef.current.get(id)
+      ?? { references: null, guidance: null, guidanceEpoch: 0, epoch: 0 },
     [],
   );
 
   // Record a mutation's confirmed values for `id`, bumping its epoch so any
   // hydration GET still in flight for that universe knows its body is stale.
   // `guidance` is null for a mutation that didn't write the style guide; the
-  // previous entry's guidance carries forward so a later plain add/remove
-  // doesn't drop an earlier adopt's confirmed values.
+  // previous entry's guidance carries forward (so an adopt followed by a plain
+  // add/remove during one GET doesn't drop the adopted values) but keeps its
+  // ORIGINAL `guidanceEpoch` — the epoch at which a PATCH last actually wrote
+  // the style guide. That stamp is what lets the hydration arbiter tell "this
+  // guidance is newer than the GET" from "the GET already contains it."
   const applyStyleReferenceMutation = useCallback((id, references, guidance = null) => {
     const previous = styleReferenceState(id);
+    const epoch = previous.epoch + 1;
     styleReferenceStatesRef.current.set(id, {
       references,
+      epoch,
       guidance: guidance ?? previous.guidance,
-      epoch: previous.epoch + 1,
+      guidanceEpoch: guidance ? epoch : previous.guidanceEpoch,
     });
   }, [styleReferenceState]);
 
@@ -177,14 +190,19 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
   const applyStyleReferenceHydration = useCallback((id, issuedEpoch, references) => {
     const state = styleReferenceState(id);
     if (state.epoch !== issuedEpoch) {
-      return { styleReferences: state.references, ...(state.guidance || {}) };
+      // References always come from the winning mutation. The style guide only
+      // does when a PATCH actually wrote it AFTER this GET was issued
+      // (`guidanceEpoch > issuedEpoch`) — otherwise this GET already read that
+      // guidance back from the server, and overlaying the stashed copy would
+      // clobber a genuinely newer value the GET carries (a peer edit made while
+      // the user was on another universe) and — via markDraftSaved — bank the
+      // clobbered value so a later general Save pushes it back server-side.
+      return {
+        styleReferences: state.references,
+        ...(state.guidanceEpoch > issuedEpoch ? state.guidance : null),
+      };
     }
-    // This GET won, so its body IS the new baseline — including the style
-    // guide. Drop the stashed guidance: it describes an older PATCH the server
-    // has since confirmed, so carrying it past this point would let a LATER
-    // plain add/remove (which contributes no guidance of its own) overlay
-    // those spent values over a genuinely newer server styleNotes/influences.
-    styleReferenceStatesRef.current.set(id, { ...state, references, guidance: null });
+    styleReferenceStatesRef.current.set(id, { ...state, references });
     return { styleReferences: references };
   }, [styleReferenceState]);
 

--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -179,7 +179,12 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     if (state.epoch !== issuedEpoch) {
       return { styleReferences: state.references, ...(state.guidance || {}) };
     }
-    styleReferenceStatesRef.current.set(id, { ...state, references });
+    // This GET won, so its body IS the new baseline — including the style
+    // guide. Drop the stashed guidance: it describes an older PATCH the server
+    // has since confirmed, so carrying it past this point would let a LATER
+    // plain add/remove (which contributes no guidance of its own) overlay
+    // those spent values over a genuinely newer server styleNotes/influences.
+    styleReferenceStatesRef.current.set(id, { ...state, references, guidance: null });
     return { styleReferences: references };
   }, [styleReferenceState]);
 

--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -107,6 +107,22 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
   // universes' queues are independent.
   const styleReferenceQueuesRef = useRef(new Map());
   const styleReferenceSnapshotsRef = useRef(new Map());
+  // Per-universe count of mutation (add/remove PATCH) responses already folded
+  // into styleReferenceSnapshotsRef. This version-gates the OTHER writer — the
+  // hydration effect's `getUniverse` — against the last remaining reordering
+  // race: a mutation M issued before the user navigates away and back, and a
+  // re-hydration GET G issued on the return. When M resolves first, G's body
+  // is a PRE-mutation read of the same universe, so letting it write would
+  // silently revert M client-side. G therefore captures this counter when it
+  // is ISSUED and only writes its own array back if no mutation landed while
+  // it was in flight; otherwise it defers to the mutation's newer result.
+  //
+  // Note the guard is deliberately "a mutation always beats a concurrent GET",
+  // not a plain monotonic issued-at sequence shared by all three writers: G is
+  // issued AFTER M yet reads state the server may not have written M into yet,
+  // so ordering by issue time would make a late-resolving M lose to an
+  // earlier-issued G — reintroducing the A -> B -> A loss fixed previously.
+  const styleReferenceMutationEpochRef = useRef(new Map());
   // Mirrors `selectedId` synchronously during render (not via a passive
   // effect, which runs one tick later and would leave a window where a
   // resolving PATCH still sees the OLD selection as current). Mutators
@@ -122,6 +138,27 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
 
   const clearPendingCanonAdditions = useCallback(() => {
     pendingCanonAdditionsRef.current = emptyPendingCanon();
+  }, []);
+
+  // Record a mutation's confirmed styleReferences for `id` and bump its epoch,
+  // so any hydration GET still in flight for that universe knows its own body
+  // is now stale.
+  const applyStyleReferenceMutation = useCallback((id, references) => {
+    const epochs = styleReferenceMutationEpochRef.current;
+    epochs.set(id, (epochs.get(id) ?? 0) + 1);
+    styleReferenceSnapshotsRef.current.set(id, references);
+  }, []);
+
+  // Fold a hydration GET's styleReferences into `id`'s snapshot, unless a
+  // mutation resolved while the GET was in flight (epoch changed) — in which
+  // case the mutation's result stands. Returns whichever array is authoritative
+  // so the hydrated draft renders that one rather than the stale server read.
+  const applyStyleReferenceHydration = useCallback((id, issuedEpoch, references) => {
+    if ((styleReferenceMutationEpochRef.current.get(id) ?? 0) !== issuedEpoch) {
+      return styleReferenceSnapshotsRef.current.get(id) ?? references;
+    }
+    styleReferenceSnapshotsRef.current.set(id, references);
+    return references;
   }, []);
 
   const markDraftSaved = useCallback((snapshotSource) => {
@@ -185,12 +222,28 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
       return undefined;
     }
     let cancelled = false;
+    // Captured BEFORE the fetch is issued — see styleReferenceMutationEpochRef.
+    const issuedEpoch = styleReferenceMutationEpochRef.current.get(selectedId) ?? 0;
     Promise.all([
       getUniverse(selectedId).catch(() => null),
       listWorldRuns(selectedId).catch(() => []),
     ]).then(([universe, nextRuns]) => {
       if (cancelled) return;
       if (universe) {
+        // Refresh this universe's styleReferences snapshot from the server on
+        // every successful hydration — a stale map entry from an earlier
+        // local mutation (or absence of one, on first visit) must not shadow
+        // changes made while this universe wasn't selected (peer sync, the
+        // image-delete purge route). The next add/remove needs this fresh
+        // baseline, not a leftover cache (codex review finding). The epoch
+        // guard is the one exception: a mutation that resolved while this GET
+        // was in flight is newer than the body we just read, so it wins and
+        // the draft renders ITS references rather than this stale read.
+        const styleReferences = applyStyleReferenceHydration(
+          selectedId,
+          issuedEpoch,
+          universe.styleReferences || [],
+        );
         const hydrated = {
           ...universe,
           categories: ensureDraftCategories(universe.categories),
@@ -199,24 +252,17 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
           premise: universe.premise || '',
           styleNotes: universe.styleNotes || '',
           influences: ensureInfluences(universe.influences),
-          styleReferences: universe.styleReferences || [],
+          styleReferences,
           locked: universe.locked || {},
           llm: universe.llm || { provider: null, model: null },
         };
         setDraft(hydrated);
         markDraftSaved(hydrated);
-        // Refresh this universe's styleReferences snapshot from the server on
-        // every successful hydration — a stale map entry from an earlier
-        // local mutation (or absence of one, on first visit) must not shadow
-        // changes made while this universe wasn't selected (peer sync, the
-        // image-delete purge route). The next add/remove needs this fresh
-        // baseline, not a leftover cache (codex review finding).
-        styleReferenceSnapshotsRef.current.set(selectedId, hydrated.styleReferences);
       }
       setRuns(nextRuns);
     });
     return () => { cancelled = true; };
-  }, [selectedId]);
+  }, [selectedId, applyStyleReferenceHydration]);
 
   const handleSave = async () => {
     if (!draft.name?.trim()) {
@@ -360,8 +406,10 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     // selected — a later add/remove for targetId (including one after the
     // user navigates away and back) must build from this result, not a
     // pre-save list (codex review finding: an A→B→A round trip must not lose
-    // A's in-flight save).
-    styleReferenceSnapshotsRef.current.set(targetId, updated.styleReferences || []);
+    // A's in-flight save). Bumping targetId's mutation epoch also invalidates
+    // any re-hydration GET for targetId still in flight, whose body predates
+    // this PATCH.
+    applyStyleReferenceMutation(targetId, updated.styleReferences || []);
     // But only touch the currently DISPLAYED draft if the user is still on
     // targetId — applying it otherwise would poison a DIFFERENT, now-selected
     // universe's state with targetId's references (codex review finding).
@@ -387,7 +435,7 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     setWorlds((previous) => upsertByIdPrepend(previous, updated));
     toast.success(adopt ? 'Art reference added and style guide updated' : 'Art reference added');
     return true;
-  }, [draft, markStyleGuidanceSaved, selectedId]);
+  }, [applyStyleReferenceMutation, draft, markStyleGuidanceSaved, selectedId]);
 
   const removeStyleReference = useCallback((referenceId) => {
     if (!selectedId) return Promise.resolve(false);
@@ -411,8 +459,9 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
       if (!updated) return false;
       // Keep targetId's own snapshot current regardless of what's currently
       // selected (codex review finding: an A→B→A round trip must not lose
-      // A's in-flight removal).
-      styleReferenceSnapshotsRef.current.set(targetId, updated.styleReferences || []);
+      // A's in-flight removal). The epoch bump invalidates any re-hydration
+      // GET for targetId still in flight, whose body predates this PATCH.
+      applyStyleReferenceMutation(targetId, updated.styleReferences || []);
       // Only touch the currently DISPLAYED draft if the user is still on
       // targetId — selectedIdRef mirrors selectedId synchronously during
       // render, so there is no passive-effect timing window where a
@@ -434,7 +483,7 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     // inheriting a rejected chain.
     styleReferenceQueuesRef.current.set(targetId, task.catch(() => {}));
     return task;
-  }, [draft, selectedId]);
+  }, [applyStyleReferenceMutation, draft, selectedId]);
 
   const handleCanonChange = useCallback((updated) => {
     if (!updated) return;

--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -105,24 +105,25 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
   // additionally serializes same-universe calls through the matching queue
   // entry so back-to-back removals on one universe never overlap; different
   // universes' queues are independent.
-  const styleReferenceQueuesRef = useRef(new Map());
-  const styleReferenceSnapshotsRef = useRef(new Map());
-  // Per-universe count of mutation (add/remove PATCH) responses already folded
-  // into styleReferenceSnapshotsRef. This version-gates the OTHER writer — the
-  // hydration effect's `getUniverse` — against the last remaining reordering
-  // race: a mutation M issued before the user navigates away and back, and a
-  // re-hydration GET G issued on the return. When M resolves first, G's body
-  // is a PRE-mutation read of the same universe, so letting it write would
-  // silently revert M client-side. G therefore captures this counter when it
-  // is ISSUED and only writes its own array back if no mutation landed while
-  // it was in flight; otherwise it defers to the mutation's newer result.
   //
-  // Note the guard is deliberately "a mutation always beats a concurrent GET",
-  // not a plain monotonic issued-at sequence shared by all three writers: G is
-  // issued AFTER M yet reads state the server may not have written M into yet,
-  // so ordering by issue time would make a late-resolving M lose to an
-  // earlier-issued G — reintroducing the A -> B -> A loss fixed previously.
-  const styleReferenceMutationEpochRef = useRef(new Map());
+  // Each entry is `{ references, epoch }`, where `epoch` counts the MUTATION
+  // responses folded into `references` so far. The epoch version-gates the
+  // other writer — the hydration effect's `getUniverse` — against the last
+  // reordering race: a mutation M issued before the user navigates away and
+  // back, and the re-hydration GET G issued on the return. When M resolves
+  // first, G's body is a PRE-mutation read, so letting it write would silently
+  // revert M client-side. G captures the epoch when it is ISSUED and writes its
+  // own array back only if no mutation landed while it was in flight.
+  //
+  // The guard is deliberately "a mutation always beats a concurrent GET", not a
+  // monotonic issued-at sequence shared by all writers: G is issued AFTER M yet
+  // reads state the server may not have written M into yet, so ordering by
+  // issue time would make a late-resolving M lose to an earlier-issued G —
+  // reintroducing the A → B → A loss fixed above. Keeping `epoch` in the same
+  // record as `references` is what makes "the epoch moves whenever the array
+  // does" structural rather than a convention writers must remember.
+  const styleReferenceQueuesRef = useRef(new Map());
+  const styleReferenceStatesRef = useRef(new Map());
   // Mirrors `selectedId` synchronously during render (not via a passive
   // effect, which runs one tick later and would leave a window where a
   // resolving PATCH still sees the OLD selection as current). Mutators
@@ -140,26 +141,27 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     pendingCanonAdditionsRef.current = emptyPendingCanon();
   }, []);
 
-  // Record a mutation's confirmed styleReferences for `id` and bump its epoch,
-  // so any hydration GET still in flight for that universe knows its own body
-  // is now stale.
-  const applyStyleReferenceMutation = useCallback((id, references) => {
-    const epochs = styleReferenceMutationEpochRef.current;
-    epochs.set(id, (epochs.get(id) ?? 0) + 1);
-    styleReferenceSnapshotsRef.current.set(id, references);
-  }, []);
+  const styleReferenceState = useCallback(
+    (id) => styleReferenceStatesRef.current.get(id) ?? { references: null, epoch: 0 },
+    [],
+  );
 
-  // Fold a hydration GET's styleReferences into `id`'s snapshot, unless a
-  // mutation resolved while the GET was in flight (epoch changed) — in which
-  // case the mutation's result stands. Returns whichever array is authoritative
-  // so the hydrated draft renders that one rather than the stale server read.
+  // Record a mutation's confirmed styleReferences for `id`, bumping its epoch so
+  // any hydration GET still in flight for that universe knows its body is stale.
+  const applyStyleReferenceMutation = useCallback((id, references) => {
+    styleReferenceStatesRef.current.set(id, { references, epoch: styleReferenceState(id).epoch + 1 });
+  }, [styleReferenceState]);
+
+  // Fold a hydration GET's styleReferences into `id`'s state, unless a mutation
+  // resolved while the GET was in flight (epoch moved) — in which case the
+  // mutation's result stands. Returns whichever array is authoritative, so the
+  // hydrated draft renders that one rather than the stale server read.
   const applyStyleReferenceHydration = useCallback((id, issuedEpoch, references) => {
-    if ((styleReferenceMutationEpochRef.current.get(id) ?? 0) !== issuedEpoch) {
-      return styleReferenceSnapshotsRef.current.get(id) ?? references;
-    }
-    styleReferenceSnapshotsRef.current.set(id, references);
+    const { references: current, epoch } = styleReferenceState(id);
+    if (epoch !== issuedEpoch) return current;
+    styleReferenceStatesRef.current.set(id, { references, epoch });
     return references;
-  }, []);
+  }, [styleReferenceState]);
 
   const markDraftSaved = useCallback((snapshotSource) => {
     savedDraftSnapshotRef.current = universeDraftSnapshot(snapshotSource);
@@ -211,7 +213,7 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     setCanonDirty(false);
     clearPendingCanonAdditions();
     // No styleReference queue/snapshot reset needed here — both are keyed by
-    // universe id (see styleReferenceQueuesRef/styleReferenceSnapshotsRef
+    // universe id (see styleReferenceQueuesRef/styleReferenceStatesRef
     // above), so switching away and back naturally finds each universe's own
     // state exactly as it left it.
     if (!selectedId) {
@@ -222,8 +224,8 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
       return undefined;
     }
     let cancelled = false;
-    // Captured BEFORE the fetch is issued — see styleReferenceMutationEpochRef.
-    const issuedEpoch = styleReferenceMutationEpochRef.current.get(selectedId) ?? 0;
+    // Captured BEFORE the fetch is issued — see styleReferenceStatesRef.
+    const issuedEpoch = styleReferenceState(selectedId).epoch;
     Promise.all([
       getUniverse(selectedId).catch(() => null),
       listWorldRuns(selectedId).catch(() => []),
@@ -235,10 +237,9 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
         // local mutation (or absence of one, on first visit) must not shadow
         // changes made while this universe wasn't selected (peer sync, the
         // image-delete purge route). The next add/remove needs this fresh
-        // baseline, not a leftover cache (codex review finding). The epoch
-        // guard is the one exception: a mutation that resolved while this GET
-        // was in flight is newer than the body we just read, so it wins and
-        // the draft renders ITS references rather than this stale read.
+        // baseline, not a leftover cache (codex review finding) — except when
+        // a mutation resolved while this GET was in flight, which the epoch
+        // guard defers to (see styleReferenceStatesRef).
         const styleReferences = applyStyleReferenceHydration(
           selectedId,
           issuedEpoch,
@@ -262,7 +263,7 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
       setRuns(nextRuns);
     });
     return () => { cancelled = true; };
-  }, [selectedId, applyStyleReferenceHydration]);
+  }, [selectedId, applyStyleReferenceHydration, styleReferenceState]);
 
   const handleSave = async () => {
     if (!draft.name?.trim()) {
@@ -383,7 +384,7 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     // draftRef here instead would miss a removal still settling for the same
     // universe and could resurrect the item it just removed once this add's
     // wholesale-replace PATCH lands.
-    const baseStyleReferences = styleReferenceSnapshotsRef.current.get(targetId)
+    const baseStyleReferences = styleReferenceState(targetId).references
       ?? (targetId === current.id && Array.isArray(current.styleReferences) ? current.styleReferences : []);
     if (baseStyleReferences.length >= WORLD_STYLE_REFERENCES_MAX) {
       toast.error(`A universe can hold up to ${WORLD_STYLE_REFERENCES_MAX} art references`);
@@ -406,9 +407,8 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     // selected — a later add/remove for targetId (including one after the
     // user navigates away and back) must build from this result, not a
     // pre-save list (codex review finding: an A→B→A round trip must not lose
-    // A's in-flight save). Bumping targetId's mutation epoch also invalidates
-    // any re-hydration GET for targetId still in flight, whose body predates
-    // this PATCH.
+    // A's in-flight save). The epoch bump invalidates any re-hydration GET for
+    // targetId still in flight — see styleReferenceStatesRef.
     applyStyleReferenceMutation(targetId, updated.styleReferences || []);
     // But only touch the currently DISPLAYED draft if the user is still on
     // targetId — applying it otherwise would poison a DIFFERENT, now-selected
@@ -435,7 +435,7 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     setWorlds((previous) => upsertByIdPrepend(previous, updated));
     toast.success(adopt ? 'Art reference added and style guide updated' : 'Art reference added');
     return true;
-  }, [applyStyleReferenceMutation, draft, markStyleGuidanceSaved, selectedId]);
+  }, [applyStyleReferenceMutation, draft, markStyleGuidanceSaved, selectedId, styleReferenceState]);
 
   const removeStyleReference = useCallback((referenceId) => {
     if (!selectedId) return Promise.resolve(false);
@@ -449,7 +449,7 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     // universe happens to be selected when its turn comes up.
     const queue = styleReferenceQueuesRef.current.get(targetId) ?? Promise.resolve();
     const task = queue.then(async () => {
-      const base = styleReferenceSnapshotsRef.current.get(targetId)
+      const base = styleReferenceState(targetId).references
         ?? (targetId === current.id && Array.isArray(current.styleReferences) ? current.styleReferences : []);
       const styleReferences = base.filter((item) => item.id !== referenceId);
       const updated = await updateUniverse(targetId, { styleReferences }, { silent: true }).catch((error) => {
@@ -460,7 +460,7 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
       // Keep targetId's own snapshot current regardless of what's currently
       // selected (codex review finding: an A→B→A round trip must not lose
       // A's in-flight removal). The epoch bump invalidates any re-hydration
-      // GET for targetId still in flight, whose body predates this PATCH.
+      // GET for targetId still in flight — see styleReferenceStatesRef.
       applyStyleReferenceMutation(targetId, updated.styleReferences || []);
       // Only touch the currently DISPLAYED draft if the user is still on
       // targetId — selectedIdRef mirrors selectedId synchronously during
@@ -483,7 +483,7 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     // inheriting a rejected chain.
     styleReferenceQueuesRef.current.set(targetId, task.catch(() => {}));
     return task;
-  }, [applyStyleReferenceMutation, draft, selectedId]);
+  }, [applyStyleReferenceMutation, draft, selectedId, styleReferenceState]);
 
   const handleCanonChange = useCallback((updated) => {
     if (!updated) return;

--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -106,22 +106,32 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
   // entry so back-to-back removals on one universe never overlap; different
   // universes' queues are independent.
   //
-  // Each entry is `{ references, epoch }`, where `epoch` counts the MUTATION
-  // responses folded into `references` so far. The epoch version-gates the
-  // other writer — the hydration effect's `getUniverse` — against the last
-  // reordering race: a mutation M issued before the user navigates away and
-  // back, and the re-hydration GET G issued on the return. When M resolves
-  // first, G's body is a PRE-mutation read, so letting it write would silently
-  // revert M client-side. G captures the epoch when it is ISSUED and writes its
-  // own array back only if no mutation landed while it was in flight.
+  // Each entry is `{ references, guidance, epoch }`, where `epoch` counts the
+  // MUTATION responses folded in so far. The epoch version-gates the other
+  // writer — the hydration effect's `getUniverse` — against the last reordering
+  // race: a mutation M issued before the user navigates away and back, and the
+  // re-hydration GET G issued on the return. When M resolves first, G's body is
+  // a PRE-mutation read, so letting it write would silently revert M
+  // client-side. G captures the epoch when it is ISSUED and keeps its own body
+  // only if no mutation landed while it was in flight.
+  //
+  // `guidance` is `{ styleNotes, influences }` when the mutation was an ADOPT —
+  // that PATCH writes the style guide in the SAME request as the references, so
+  // both halves are equally stale in a losing G. Overriding only the references
+  // would let G revert the adopted guidance AND (via markDraftSaved) bank the
+  // reverted values as the saved baseline, so the draft reads clean and the
+  // next general Save pushes the stale guidance back server-side — a worse
+  // outcome than the client-only revert this guard exists to stop. The override
+  // is scoped to exactly the fields the winning PATCH wrote; every other field
+  // still comes from G, which may legitimately be fresher (peer sync, canon).
   //
   // The guard is deliberately "a mutation always beats a concurrent GET", not a
   // monotonic issued-at sequence shared by all writers: G is issued AFTER M yet
   // reads state the server may not have written M into yet, so ordering by
   // issue time would make a late-resolving M lose to an earlier-issued G —
   // reintroducing the A → B → A loss fixed above. Keeping `epoch` in the same
-  // record as `references` is what makes "the epoch moves whenever the array
-  // does" structural rather than a convention writers must remember.
+  // record as the values it guards is what makes "the epoch moves whenever
+  // those values do" structural rather than a convention writers must remember.
   const styleReferenceQueuesRef = useRef(new Map());
   const styleReferenceStatesRef = useRef(new Map());
   // Mirrors `selectedId` synchronously during render (not via a passive
@@ -142,25 +152,35 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
   }, []);
 
   const styleReferenceState = useCallback(
-    (id) => styleReferenceStatesRef.current.get(id) ?? { references: null, epoch: 0 },
+    (id) => styleReferenceStatesRef.current.get(id) ?? { references: null, guidance: null, epoch: 0 },
     [],
   );
 
-  // Record a mutation's confirmed styleReferences for `id`, bumping its epoch so
-  // any hydration GET still in flight for that universe knows its body is stale.
-  const applyStyleReferenceMutation = useCallback((id, references) => {
-    styleReferenceStatesRef.current.set(id, { references, epoch: styleReferenceState(id).epoch + 1 });
+  // Record a mutation's confirmed values for `id`, bumping its epoch so any
+  // hydration GET still in flight for that universe knows its body is stale.
+  // `guidance` is null for a mutation that didn't write the style guide; the
+  // previous entry's guidance carries forward so a later plain add/remove
+  // doesn't drop an earlier adopt's confirmed values.
+  const applyStyleReferenceMutation = useCallback((id, references, guidance = null) => {
+    const previous = styleReferenceState(id);
+    styleReferenceStatesRef.current.set(id, {
+      references,
+      guidance: guidance ?? previous.guidance,
+      epoch: previous.epoch + 1,
+    });
   }, [styleReferenceState]);
 
   // Fold a hydration GET's styleReferences into `id`'s state, unless a mutation
-  // resolved while the GET was in flight (epoch moved) — in which case the
-  // mutation's result stands. Returns whichever array is authoritative, so the
-  // hydrated draft renders that one rather than the stale server read.
+  // resolved while the GET was in flight (epoch moved) — in which case that
+  // mutation's values stand. Returns the draft fields the winning writer owns,
+  // to be spread LAST over the hydrated draft so they override the server read.
   const applyStyleReferenceHydration = useCallback((id, issuedEpoch, references) => {
-    const { references: current, epoch } = styleReferenceState(id);
-    if (epoch !== issuedEpoch) return current;
-    styleReferenceStatesRef.current.set(id, { references, epoch });
-    return references;
+    const state = styleReferenceState(id);
+    if (state.epoch !== issuedEpoch) {
+      return { styleReferences: state.references, ...(state.guidance || {}) };
+    }
+    styleReferenceStatesRef.current.set(id, { ...state, references });
+    return { styleReferences: references };
   }, [styleReferenceState]);
 
   const markDraftSaved = useCallback((snapshotSource) => {
@@ -232,19 +252,6 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     ]).then(([universe, nextRuns]) => {
       if (cancelled) return;
       if (universe) {
-        // Refresh this universe's styleReferences snapshot from the server on
-        // every successful hydration — a stale map entry from an earlier
-        // local mutation (or absence of one, on first visit) must not shadow
-        // changes made while this universe wasn't selected (peer sync, the
-        // image-delete purge route). The next add/remove needs this fresh
-        // baseline, not a leftover cache (codex review finding) — except when
-        // a mutation resolved while this GET was in flight, which the epoch
-        // guard defers to (see styleReferenceStatesRef).
-        const styleReferences = applyStyleReferenceHydration(
-          selectedId,
-          issuedEpoch,
-          universe.styleReferences || [],
-        );
         const hydrated = {
           ...universe,
           categories: ensureDraftCategories(universe.categories),
@@ -253,9 +260,21 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
           premise: universe.premise || '',
           styleNotes: universe.styleNotes || '',
           influences: ensureInfluences(universe.influences),
-          styleReferences,
+          styleReferences: universe.styleReferences || [],
           locked: universe.locked || {},
           llm: universe.llm || { provider: null, model: null },
+          // Refresh this universe's styleReferences snapshot from the server on
+          // every successful hydration — a stale map entry from an earlier
+          // local mutation (or absence of one, on first visit) must not shadow
+          // changes made while this universe wasn't selected (peer sync, the
+          // image-delete purge route). The next add/remove needs this fresh
+          // baseline, not a leftover cache (codex review finding) — except when
+          // a mutation resolved while this GET was in flight, in which case
+          // this spread overrides the fields THAT PATCH wrote with its newer
+          // confirmed values (see styleReferenceStatesRef). Spread LAST so it
+          // wins over the server read above; markDraftSaved then banks the
+          // overridden values, not the stale ones.
+          ...applyStyleReferenceHydration(selectedId, issuedEpoch, universe.styleReferences || []),
         };
         setDraft(hydrated);
         markDraftSaved(hydrated);
@@ -408,8 +427,13 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     // user navigates away and back) must build from this result, not a
     // pre-save list (codex review finding: an A→B→A round trip must not lose
     // A's in-flight save). The epoch bump invalidates any re-hydration GET for
-    // targetId still in flight — see styleReferenceStatesRef.
-    applyStyleReferenceMutation(targetId, updated.styleReferences || []);
+    // targetId still in flight — see styleReferenceStatesRef. On the adopt
+    // path the SAME PATCH wrote the style guide, so hand that over too or a
+    // losing GET reverts the adopted guidance while the references survive.
+    applyStyleReferenceMutation(targetId, updated.styleReferences || [], adopt ? {
+      styleNotes: updated.styleNotes || '',
+      influences: ensureInfluences(updated.influences),
+    } : null);
     // But only touch the currently DISPLAYED draft if the user is still on
     // targetId — applying it otherwise would poison a DIFFERENT, now-selected
     // universe's state with targetId's references (codex review finding).

--- a/client/src/hooks/useUniverseDraft.test.jsx
+++ b/client/src/hooks/useUniverseDraft.test.jsx
@@ -403,4 +403,69 @@ describe('useUniverseDraft', () => {
     expect(apiMocks.updateUniverse.mock.calls.at(-1)).toEqual(['u1', { styleReferences: [refX] }, { silent: true }]);
     expect(result.current.draft.styleReferences).toEqual([refX]);
   });
+
+  it('drops an adopt\'s stashed guidance once an un-raced hydration supersedes it (agy review finding)', async () => {
+    const refX = { id: 'style-ref-x', title: 'Ref X', prompt: 'x', imageRefs: ['x.png'] };
+    // u1's server body after the adopt, then again after a peer changes the
+    // style guide externally while the user is away.
+    let u1Fetches = 0;
+    let resolveLateHydration;
+    apiMocks.getUniverse.mockImplementation(async (id) => {
+      if (id === 'u2') return universeTwo;
+      u1Fetches += 1;
+      if (u1Fetches === 1) return { ...universe, styleReferences: [], styleNotes: '' };
+      // Fetch 2 is the un-raced hydration that confirms the adopt server-side.
+      if (u1Fetches === 2) return { ...universe, styleReferences: [refX], styleNotes: 'Adopted notes' };
+      // Fetch 3 races a later plain mutation and carries a PEER's newer notes.
+      return new Promise((resolve) => { resolveLateHydration = resolve; });
+    });
+
+    const { result, rerender } = renderSelectable();
+    await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+    // Adopt on u1 — stashes { styleNotes: 'Adopted notes', … } as guidance.
+    await act(async () => {
+      await result.current.persistStyleReference({
+        reference: refX,
+        proposed: { styleNotes: 'Adopted notes', influences: { embrace: [], avoid: [] } },
+        adopt: true,
+      });
+    });
+
+    // u1 -> u2 -> u1, with nothing in flight: hydration fetch 2 wins un-raced,
+    // so the server has confirmed the adopt and the stash is spent.
+    await act(async () => { rerender({ selectedId: 'u2' }); });
+    await waitFor(() => expect(result.current.draft.id).toBe('u2'));
+    await act(async () => { rerender({ selectedId: 'u1' }); });
+    await waitFor(() => expect(result.current.draft.styleNotes).toBe('Adopted notes'));
+
+    // Now: a plain removal races hydration fetch 3, which carries a peer's
+    // newer notes. The removal writes no guidance of its own.
+    await act(async () => { rerender({ selectedId: 'u2' }); });
+    await waitFor(() => expect(result.current.draft.id).toBe('u2'));
+    await act(async () => { rerender({ selectedId: 'u1' }); });
+    await waitFor(() => expect(resolveLateHydration).toBeTypeOf('function'));
+
+    let resolveRemoval;
+    apiMocks.updateUniverse.mockImplementationOnce(() => new Promise((resolve) => { resolveRemoval = resolve; }));
+    // removeStyleReference chains onto the per-universe queue, so its PATCH is
+    // issued a microtask later — wait for the mock to be entered before resolving.
+    const pendingRemoval = result.current.removeStyleReference(refX.id);
+    await waitFor(() => expect(resolveRemoval).toBeTypeOf('function'));
+    await act(async () => {
+      resolveRemoval({ ...universe, styleReferences: [], styleNotes: 'Peer notes' });
+      await pendingRemoval;
+    });
+    await act(async () => {
+      resolveLateHydration({ ...universe, styleReferences: [refX], styleNotes: 'Peer notes' });
+      await Promise.resolve();
+    });
+
+    // The removal still wins on references (it wrote them)...
+    await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+    expect(result.current.draft.styleReferences).toEqual([]);
+    // ...but must NOT resurrect the spent 'Adopted notes' over the peer's newer
+    // value, which the removal's PATCH never wrote.
+    expect(result.current.draft.styleNotes).toBe('Peer notes');
+  });
 });

--- a/client/src/hooks/useUniverseDraft.test.jsx
+++ b/client/src/hooks/useUniverseDraft.test.jsx
@@ -332,4 +332,60 @@ describe('useUniverseDraft', () => {
     await act(async () => { await result.current.removeStyleReference(refExternal.id); });
     expect(apiMocks.updateUniverse.mock.calls.at(-1)).toEqual(['u1', { styleReferences: [] }, { silent: true }]);
   });
+
+  it('keeps a mutation that resolves BEFORE the re-hydration GET it raced (codex review finding)', async () => {
+    const universeTwo = { ...universe, id: 'u2', name: 'Second Universe', styleReferences: [] };
+    const refX = { id: 'style-ref-x', title: 'Ref X', prompt: 'x', imageRefs: ['x.png'] };
+    // The re-hydration fetch on the return to u1 is held open so it can be
+    // resolved AFTER the mutation, with the PRE-mutation body the server would
+    // have returned had it read before the PATCH landed.
+    let u1Fetches = 0;
+    let resolveU1Hydration;
+    apiMocks.getUniverse.mockImplementation(async (id) => {
+      if (id === 'u2') return universeTwo;
+      u1Fetches += 1;
+      if (u1Fetches === 2) return new Promise((resolve) => { resolveU1Hydration = resolve; });
+      return { ...universe, styleReferences: [] };
+    });
+
+    const goToWorld = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ selectedId }) => useUniverseDraft({ selectedId, goToWorld }),
+      { initialProps: { selectedId: 'u1' } },
+    );
+    await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+    // Mutation M on u1, held open.
+    let resolveU1Save;
+    apiMocks.updateUniverse.mockImplementationOnce(() => new Promise((resolve) => { resolveU1Save = resolve; }));
+    const pendingSave = result.current.persistStyleReference({ reference: refX, adopt: false });
+
+    // u1 -> u2 -> u1; the return issues re-hydration GET G, which stays pending.
+    await act(async () => { rerender({ selectedId: 'u2' }); });
+    await waitFor(() => expect(result.current.draft.id).toBe('u2'));
+    await act(async () => { rerender({ selectedId: 'u1' }); });
+    await waitFor(() => expect(resolveU1Hydration).toBeTypeOf('function'));
+
+    // M resolves FIRST — the reordering this guard exists for.
+    await act(async () => {
+      resolveU1Save({ ...universe, styleReferences: [refX] });
+      await pendingSave;
+    });
+
+    // ...then G resolves carrying the stale, pre-mutation reference list.
+    await act(async () => {
+      resolveU1Hydration({ ...universe, styleReferences: [] });
+      await Promise.resolve();
+    });
+
+    // G must not have reverted M: the displayed draft still shows refX...
+    await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+    expect(result.current.draft.styleReferences).toEqual([refX]);
+
+    // ...and the next mutation builds from [refX], not G's empty snapshot —
+    // otherwise this PATCH would be a no-op and refX would linger server-side.
+    await act(async () => { await result.current.removeStyleReference(refX.id); });
+    expect(apiMocks.updateUniverse.mock.calls.at(-1)).toEqual(['u1', { styleReferences: [] }, { silent: true }]);
+    expect(result.current.draft.styleReferences).toEqual([]);
+  });
 });

--- a/client/src/hooks/useUniverseDraft.test.jsx
+++ b/client/src/hooks/useUniverseDraft.test.jsx
@@ -468,4 +468,59 @@ describe('useUniverseDraft', () => {
     // value, which the removal's PATCH never wrote.
     expect(result.current.draft.styleNotes).toBe('Peer notes');
   });
+
+  it('does not let a plain mutation resurrect an older adopt over a newer peer edit the GET carries (codex review finding)', async () => {
+    const refX = { id: 'style-ref-x', title: 'Ref X', prompt: 'x', imageRefs: ['x.png'] };
+    // Same class as the test above, but with NO hydration landing between the
+    // adopt and the racing mutation — so the guard cannot rely on a winning
+    // hydration to retire the stashed guidance. Only the guidance's own epoch
+    // stamp distinguishes "written after this GET" from "the GET already has it."
+    let u1Fetches = 0;
+    let resolveLateHydration;
+    apiMocks.getUniverse.mockImplementation(async (id) => {
+      if (id === 'u2') return universeTwo;
+      u1Fetches += 1;
+      if (u1Fetches === 1) return { ...universe, styleReferences: [], styleNotes: '' };
+      return new Promise((resolve) => { resolveLateHydration = resolve; });
+    });
+
+    const { result, rerender } = renderSelectable();
+    await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+    // Adopt on u1 — stashes guidance at the epoch it was written.
+    await act(async () => {
+      await result.current.persistStyleReference({
+        reference: refX,
+        proposed: { styleNotes: 'Adopted notes', influences: { embrace: [], avoid: [] } },
+        adopt: true,
+      });
+    });
+
+    // u1 -> u2 -> u1 with the adopt already settled. The return's GET reads a
+    // peer's newer style notes; it is issued AFTER the adopt, so it already
+    // contains the adopted state plus the peer's later edit.
+    await act(async () => { rerender({ selectedId: 'u2' }); });
+    await waitFor(() => expect(result.current.draft.id).toBe('u2'));
+    await act(async () => { rerender({ selectedId: 'u1' }); });
+    await waitFor(() => expect(resolveLateHydration).toBeTypeOf('function'));
+
+    // A plain removal races that GET and wins on references — but it wrote no
+    // style guide, so it must not drag the older adopt's notes along with it.
+    let resolveRemoval;
+    apiMocks.updateUniverse.mockImplementationOnce(() => new Promise((resolve) => { resolveRemoval = resolve; }));
+    const pendingRemoval = result.current.removeStyleReference(refX.id);
+    await waitFor(() => expect(resolveRemoval).toBeTypeOf('function'));
+    await act(async () => {
+      resolveRemoval({ ...universe, styleReferences: [], styleNotes: 'Peer notes' });
+      await pendingRemoval;
+    });
+    await act(async () => {
+      resolveLateHydration({ ...universe, styleReferences: [refX], styleNotes: 'Peer notes' });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+    expect(result.current.draft.styleReferences).toEqual([]);
+    expect(result.current.draft.styleNotes).toBe('Peer notes');
+  });
 });

--- a/client/src/hooks/useUniverseDraft.test.jsx
+++ b/client/src/hooks/useUniverseDraft.test.jsx
@@ -333,6 +333,11 @@ describe('useUniverseDraft', () => {
   });
 
   it('keeps a mutation that resolves BEFORE the re-hydration GET it raced (codex review finding)', async () => {
+    // u1 starts with refA already saved, so the post-mutation list ([refA, refX])
+    // and G's stale list ([refA]) differ in a way the FINAL removal payload can
+    // discriminate — with an empty starting list both branches would emit the
+    // same `{ styleReferences: [] }` and the assertion would prove nothing.
+    const refA = { id: 'style-ref-a', title: 'Ref A', prompt: 'a', imageRefs: ['a.png'] };
     const refX = { id: 'style-ref-x', title: 'Ref X', prompt: 'x', imageRefs: ['x.png'] };
     // The re-hydration fetch on the return to u1 is held open so it can be
     // resolved AFTER the mutation, with the PRE-mutation body the server would
@@ -343,16 +348,21 @@ describe('useUniverseDraft', () => {
       if (id === 'u2') return universeTwo;
       u1Fetches += 1;
       if (u1Fetches === 2) return new Promise((resolve) => { resolveU1Hydration = resolve; });
-      return { ...universe, styleReferences: [] };
+      return { ...universe, styleReferences: [refA] };
     });
 
     const { result, rerender } = renderSelectable();
-    await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+    await waitFor(() => expect(result.current.draft.styleReferences).toEqual([refA]));
 
-    // Mutation M on u1, held open.
+    // Adopt mutation M on u1, held open — adopt so the assertions also cover the
+    // style guide the same PATCH writes, not just the references.
     let resolveU1Save;
     apiMocks.updateUniverse.mockImplementationOnce(() => new Promise((resolve) => { resolveU1Save = resolve; }));
-    const pendingSave = result.current.persistStyleReference({ reference: refX, adopt: false });
+    const pendingSave = result.current.persistStyleReference({
+      reference: refX,
+      proposed: { styleNotes: 'Adopted notes', influences: { embrace: ['ink'], avoid: [] } },
+      adopt: true,
+    });
 
     // u1 -> u2 -> u1; the return issues re-hydration GET G, which stays pending.
     await act(async () => { rerender({ selectedId: 'u2' }); });
@@ -362,24 +372,35 @@ describe('useUniverseDraft', () => {
 
     // M resolves FIRST — the reordering this guard exists for.
     await act(async () => {
-      resolveU1Save({ ...universe, styleReferences: [refX] });
+      resolveU1Save({
+        ...universe,
+        styleReferences: [refA, refX],
+        styleNotes: 'Adopted notes',
+        influences: { embrace: ['ink'], avoid: [] },
+      });
       await pendingSave;
     });
 
-    // ...then G resolves carrying the stale, pre-mutation reference list.
+    // ...then G resolves carrying the stale, pre-mutation body.
     await act(async () => {
-      resolveU1Hydration({ ...universe, styleReferences: [] });
+      resolveU1Hydration({ ...universe, styleReferences: [refA], styleNotes: '' });
       await Promise.resolve();
     });
 
-    // G must not have reverted M: the displayed draft still shows refX...
+    // G must not have reverted M: the displayed draft still shows refX, and the
+    // style guide the SAME adopt PATCH wrote survives alongside it.
     await waitFor(() => expect(result.current.draft.id).toBe('u1'));
-    expect(result.current.draft.styleReferences).toEqual([refX]);
+    expect(result.current.draft.styleReferences).toEqual([refA, refX]);
+    expect(result.current.draft.styleNotes).toBe('Adopted notes');
+    // markDraftSaved banked the overridden values, so the adopted guidance is
+    // not silently re-saved as the stale '' on the next general Save.
+    expect(result.current.isDraftDirty()).toBe(false);
 
-    // ...and the next mutation builds from [refX], not G's empty snapshot —
-    // otherwise this PATCH would be a no-op and refX would linger server-side.
-    await act(async () => { await result.current.removeStyleReference(refX.id); });
-    expect(apiMocks.updateUniverse.mock.calls.at(-1)).toEqual(['u1', { styleReferences: [] }, { silent: true }]);
-    expect(result.current.draft.styleReferences).toEqual([]);
+    // The next mutation builds from [refA, refX], not G's stale [refA] — with a
+    // stale base this PATCH would emit `{ styleReferences: [] }` and leave refX
+    // lingering server-side.
+    await act(async () => { await result.current.removeStyleReference(refA.id); });
+    expect(apiMocks.updateUniverse.mock.calls.at(-1)).toEqual(['u1', { styleReferences: [refX] }, { silent: true }]);
+    expect(result.current.draft.styleReferences).toEqual([refX]);
   });
 });

--- a/client/src/hooks/useUniverseDraft.test.jsx
+++ b/client/src/hooks/useUniverseDraft.test.jsx
@@ -64,6 +64,21 @@ const renderDraft = () => {
   return { ...hook, goToWorld };
 };
 
+// A second universe to navigate to, for the tests that exercise a selection
+// switch. Overridden per-test where the switch target needs its own references.
+const universeTwo = { ...universe, id: 'u2', name: 'Second Universe', styleReferences: [] };
+
+// Same as renderDraft, but with `selectedId` driven by rerender props so a test
+// can switch universes mid-flight.
+const renderSelectable = () => {
+  const goToWorld = vi.fn();
+  const hook = renderHook(
+    ({ selectedId }) => useUniverseDraft({ selectedId, goToWorld }),
+    { initialProps: { selectedId: 'u1' } },
+  );
+  return { ...hook, goToWorld };
+};
+
 describe('useUniverseDraft', () => {
   it('hydrates the selected universe and its run history', async () => {
     const { result } = renderDraft();
@@ -212,19 +227,13 @@ describe('useUniverseDraft', () => {
   });
 
   it('does not let a stale in-flight save for one universe overwrite a different, now-selected universe (codex review finding)', async () => {
-    const universeTwo = {
-      ...universe,
-      id: 'u2',
-      name: 'Second Universe',
+    const universeTwoWithRef = {
+      ...universeTwo,
       styleReferences: [{ id: 'style-ref-b2', title: 'Ref B2', prompt: 'b2', imageRefs: ['b2.png'] }],
     };
-    apiMocks.getUniverse.mockImplementation(async (id) => (id === 'u2' ? universeTwo : universe));
+    apiMocks.getUniverse.mockImplementation(async (id) => (id === 'u2' ? universeTwoWithRef : universe));
 
-    const goToWorld = vi.fn();
-    const { result, rerender } = renderHook(
-      ({ selectedId }) => useUniverseDraft({ selectedId, goToWorld }),
-      { initialProps: { selectedId: 'u1' } },
-    );
+    const { result, rerender } = renderSelectable();
     await waitFor(() => expect(result.current.draft.id).toBe('u1'));
 
     // Start a save for u1 but hold its PATCH response open — simulates the
@@ -238,7 +247,7 @@ describe('useUniverseDraft', () => {
     // Switch to u2 while u1's save is still pending.
     await act(async () => { rerender({ selectedId: 'u2' }); });
     await waitFor(() => expect(result.current.draft.id).toBe('u2'));
-    expect(result.current.draft.styleReferences).toEqual(universeTwo.styleReferences);
+    expect(result.current.draft.styleReferences).toEqual(universeTwoWithRef.styleReferences);
 
     // Now let u1's stale save resolve.
     await act(async () => {
@@ -248,25 +257,20 @@ describe('useUniverseDraft', () => {
 
     // u2's displayed draft must be untouched by u1's stale, now-resolved response.
     expect(result.current.draft.id).toBe('u2');
-    expect(result.current.draft.styleReferences).toEqual(universeTwo.styleReferences);
+    expect(result.current.draft.styleReferences).toEqual(universeTwoWithRef.styleReferences);
 
     // A subsequent removal on u2 must build its PATCH from u2's OWN
     // references, not from u1's stale snapshot.
     await act(async () => {
-      await result.current.removeStyleReference(universeTwo.styleReferences[0].id);
+      await result.current.removeStyleReference(universeTwoWithRef.styleReferences[0].id);
     });
     expect(apiMocks.updateUniverse.mock.calls.at(-1)).toEqual(['u2', { styleReferences: [] }, { silent: true }]);
   });
 
   it('reconciles a save that resolves after an A -> B -> A round trip, instead of losing it (codex review finding)', async () => {
-    const universeTwo = { ...universe, id: 'u2', name: 'Second Universe', styleReferences: [] };
     apiMocks.getUniverse.mockImplementation(async (id) => (id === 'u2' ? universeTwo : { ...universe, styleReferences: [] }));
 
-    const goToWorld = vi.fn();
-    const { result, rerender } = renderHook(
-      ({ selectedId }) => useUniverseDraft({ selectedId, goToWorld }),
-      { initialProps: { selectedId: 'u1' } },
-    );
+    const { result, rerender } = renderSelectable();
     await waitFor(() => expect(result.current.draft.id).toBe('u1'));
 
     // Start a save on u1 and hold its response open.
@@ -301,7 +305,6 @@ describe('useUniverseDraft', () => {
   });
 
   it('refreshes the cached snapshot from the server on re-hydration, so an external change is not shadowed (codex review finding)', async () => {
-    const universeTwo = { ...universe, id: 'u2', name: 'Second Universe', styleReferences: [] };
     const refOld = { id: 'style-ref-old', title: 'Old', prompt: 'old', imageRefs: ['old.png'] };
     const refExternal = { id: 'style-ref-external', title: 'External', prompt: 'external', imageRefs: ['external.png'] };
     // First visit to u1 returns refOld; a peer sync / image-delete purge then
@@ -314,11 +317,7 @@ describe('useUniverseDraft', () => {
       return { ...universe, styleReferences: u1FetchCount === 1 ? [refOld] : [refExternal] };
     });
 
-    const goToWorld = vi.fn();
-    const { result, rerender } = renderHook(
-      ({ selectedId }) => useUniverseDraft({ selectedId, goToWorld }),
-      { initialProps: { selectedId: 'u1' } },
-    );
+    const { result, rerender } = renderSelectable();
     await waitFor(() => expect(result.current.draft.styleReferences).toEqual([refOld]));
 
     await act(async () => { rerender({ selectedId: 'u2' }); });
@@ -334,7 +333,6 @@ describe('useUniverseDraft', () => {
   });
 
   it('keeps a mutation that resolves BEFORE the re-hydration GET it raced (codex review finding)', async () => {
-    const universeTwo = { ...universe, id: 'u2', name: 'Second Universe', styleReferences: [] };
     const refX = { id: 'style-ref-x', title: 'Ref X', prompt: 'x', imageRefs: ['x.png'] };
     // The re-hydration fetch on the return to u1 is held open so it can be
     // resolved AFTER the mutation, with the PRE-mutation body the server would
@@ -348,11 +346,7 @@ describe('useUniverseDraft', () => {
       return { ...universe, styleReferences: [] };
     });
 
-    const goToWorld = vi.fn();
-    const { result, rerender } = renderHook(
-      ({ selectedId }) => useUniverseDraft({ selectedId, goToWorld }),
-      { initialProps: { selectedId: 'u1' } },
-    );
+    const { result, rerender } = renderSelectable();
     await waitFor(() => expect(result.current.draft.id).toBe('u1'));
 
     // Mutation M on u1, held open.


### PR DESCRIPTION
## Summary

Closes #3099.

`useUniverseDraft` keeps a per-universe-id cache of `styleReferences` because the server contract for style references is a **wholesale array replace**, which forces the client into read-modify-write. Two writers touch that cache: the selection-hydration effect's `getUniverse` (a GET), and `persistStyleReference` / `removeStyleReference` on their PATCH completion (mutations).

**The race:** a mutation M for universe A is in flight when the user navigates A → B → A. The return issues a fresh re-hydration GET G. G is issued *after* M, but reads server state that may not include M's write yet. When M resolved **before** G, G's later write clobbered M's newer result — silently reverting the change on screen and leaving the next add/remove building its wholesale-replace PATCH from the pre-mutation list (so the mutation was effectively undone server-side on the following edit).

**The fix:** a per-universe mutation **epoch**, stored in the same record as the values it guards (`Map<id, { references, guidance, guidanceEpoch, epoch }>`). G captures the epoch when it is *issued* and keeps its own body only if no mutation landed while it was in flight; otherwise the mutation's confirmed values are spread last over the hydrated draft.

Two things worth calling out:

- **Not a shared issued-at sequence.** The issue sketched a single monotonic counter shared by all three writers. That doesn't work: G is issued after M yet reads state the server may not have written M into, so ordering by issue time makes a late-resolving M lose to an earlier-issued G — which reintroduces the A → B → A loss a previous fix closed (and breaks its still-passing test). The correct invariant is "a mutation always beats a concurrent GET."
- **The style guide is guarded separately.** On the adopt path the *same* PATCH writes `styleNotes`/`influences`, so both halves are equally stale in a losing G. But the guide moves independently of the references — a plain add/remove bumps the reference epoch without touching it — so it carries its own `guidanceEpoch` and is overlaid only when a PATCH wrote it *after* the losing GET was issued. Without that stamp, a plain mutation could resurrect a long-settled adopt over a newer peer edit the GET legitimately carries, and `markDraftSaved` would bank the clobbered value so a later general Save pushed it back server-side.

Follow-up #3109 files the architectural fix this keeps circling: move style-reference add/remove to the server's existing queued mutator (`updateUniverse(id, async (latest) => patch)`) so the client stops owning a base array at all. No client-side epoch can observe server-side writers (the image-delete purge, peer sync), so the current design has a ceiling below "correct."

## Test plan

- `client/src/hooks/useUniverseDraft.test.jsx` — 3 new regression tests, each verified to **fail** without its guard:
  - mutation resolves *before* the re-hydration GET it raced → the mutation's references and adopted guidance both survive, and the draft is not left dirty
  - an un-raced hydration supersedes a stashed adopt → a later plain mutation doesn't resurrect it
  - an adopt settles with no hydration between → a plain mutation racing the return GET doesn't resurrect it over a newer peer edit
- The 10 pre-existing tests covering the already-fixed races still pass (notably the A → B → A round-trip test, which pins the opposite ordering).
- Full client suite green: 461 files / 5006 tests.
- Reviewed by claude, agy, and codex in series; all findings fixed, codex re-review confirmed clean.