### PR TITLE
feat(apps): open a run-settings drawer for /do:next instead of queuing immediately

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -21,6 +21,12 @@
 - When the system already knows why a run ended — the idle watchdog fired, the runtime budget ran out, the provider CLI wasn't installed — that is now what gets reported. Only a genuine provider or system error in the transcript can override it.
 - Failure snippets shown on an agent's record are now short, readable excerpts centered on the actual error instead of raw terminal escape codes. One failed run had been writing an 816KB blob of control characters into its own record.
 
+## Agent Operations — `/do:next` run settings
+
+- **`/do:next` on a managed app now asks before it runs.** Clicking it on an app's Overview opens a settings drawer instead of queuing immediately: let the agent pick the next eligible item as before, or **pick a specific one** from a live list of that app's claimable work — PLAN.md items, GitHub or GitLab issues, or current-sprint JIRA tickets, whichever the app's Work Tracker resolves to. A picked item is pinned into the claim prompt, which still honors every safety check (already assigned, blocked, in flight, an epic → exit cleanly).
+- The same drawer sets the run's **provider, model, and thinking effort**, whether to **simplify** before committing, and the **review-loop reviewers** (plus GitHub reviewer usernames and optional/non-blocking marks) that gate the PR merge. Leave everything untouched and you get exactly the run the old one-click button queued, using the app's configured claim-work defaults.
+- The item list is scanned with the same author filter the run will use, so it can never advertise work the agent would then skip; the filter is adjustable inline for GitHub/GitLab. An unreachable tracker now says so, instead of reporting "nothing to do."
+
 ## Universe canon corrective reference images
 
 - [issue-3103] Any Cast, Place, or Object entry in a Universe's bible can now take a corrective reference image: upload or pick a photo/render that shows what it should actually look like, and a vision model compares it against the entry's current description and proposes a correction. Reviewing and applying it both fixes the description and pins the image as that entry's reference image, so future renders for it are visually anchored to the correction instead of starting from scratch each time.

--- a/client/src/components/apps/EditAppDrawer.jsx
+++ b/client/src/components/apps/EditAppDrawer.jsx
@@ -12,18 +12,7 @@ import { copyToClipboard } from '../../lib/clipboard';
 import LayeredIntelligenceTab, { buildLayeredIntelligenceUpdate, buildLayeredIntelligenceScheduleUpdate } from './LayeredIntelligenceTab';
 import { PROVIDER_TYPES } from '../../utils/providers';
 import { DEFAULT_PR_COMPLETION, PR_COMPLETION_OPTIONS } from '../cos/constants';
-
-const WORK_TRACKER_OPTIONS = [
-  { value: 'auto', label: 'Auto (detect from git origin)' },
-  { value: 'plan', label: 'PLAN.md' },
-  { value: 'github', label: 'GitHub Issues' },
-  { value: 'gitlab', label: 'GitLab Issues' },
-  { value: 'jira', label: 'JIRA' }
-];
-
-const WORK_TRACKER_LABELS = Object.fromEntries(
-  WORK_TRACKER_OPTIONS.map(o => [o.value, o.label])
-);
+import { WORK_TRACKER_OPTIONS, WORK_TRACKER_LABELS } from './constants';
 
 const TABS = [
   { id: 'general', label: 'General' },

--- a/client/src/components/apps/SlashDoPanel.jsx
+++ b/client/src/components/apps/SlashDoPanel.jsx
@@ -3,20 +3,29 @@ import { useNavigate } from 'react-router-dom';
 import { Terminal, Loader2 } from 'lucide-react';
 import toast from '../ui/Toast';
 import { NON_PM2_TYPES } from './constants';
+import SlashDoRunDrawer from './SlashDoRunDrawer';
 import * as api from '../../services/api';
 
 const SLASHDO_COMMANDS = [
   { id: 'push', label: '/do:push', description: 'Commit and push all work', classes: 'bg-port-success/20 text-port-success hover:bg-port-success/30 border-port-success/30' },
   { id: 'review', label: '/do:review', description: 'Deep code review', classes: 'bg-port-accent/20 text-port-accent hover:bg-port-accent/30 border-port-accent/30' },
   { id: 'replan', label: '/do:replan', description: 'Audit and prune PLAN.md, removing completed items', classes: 'bg-cyan-500/20 text-cyan-400 hover:bg-cyan-500/30 border-cyan-500/30' },
-  { id: 'next', label: '/do:next', description: "Claim the next unclaimed work item (per this app's Work Tracker) and ship a PR", classes: 'bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 border-blue-500/30' },
+  // `configurable` routes the click to the pre-flight settings drawer instead of
+  // queuing straight away.
+  { id: 'next', label: '/do:next', description: "Claim a work item (per this app's Work Tracker) and ship a PR — opens run settings", classes: 'bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 border-blue-500/30', configurable: true },
   { id: 'release', label: '/do:release', description: 'Create a release PR', classes: 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30 border-purple-500/30' },
   { id: 'better', label: '/do:better', description: 'DevSecOps audit', classes: 'bg-port-warning/20 text-port-warning hover:bg-port-warning/30 border-port-warning/30', hideForSwift: true },
   { id: 'better-swift', label: '/do:better-swift', description: 'SwiftUI DevSecOps audit', classes: 'bg-port-warning/20 text-port-warning hover:bg-port-warning/30 border-port-warning/30', swiftOnly: true }
 ];
 
-export default function SlashDoPanel({ appId, appType }) {
+export default function SlashDoPanel({ appId, appName, appType }) {
   const [loading, setLoading] = useState(null);
+  // A `configurable` command opens a pre-flight drawer instead of firing
+  // immediately: the run's provider / model / effort / reviewer / simplify
+  // settings, plus (for `/do:next`) which work item to claim. Holds the whole
+  // command entry so the drawer is titled and queued for the one that was
+  // clicked. Every other command still queues on one click.
+  const [drawerCommand, setDrawerCommand] = useState(null);
   const navigate = useNavigate();
   const isSwiftApp = NON_PM2_TYPES.has(appType);
 
@@ -26,17 +35,23 @@ export default function SlashDoPanel({ appId, appType }) {
     return true;
   });
 
+  const goToQueue = (label) => {
+    toast.success(`Queued ${label} agent task`);
+    navigate('/cos/agents');
+  };
+
   const handleRun = async (command) => {
+    if (command.configurable) {
+      setDrawerCommand(command);
+      return;
+    }
     setLoading(command.id);
-    const result = await api.createSlashdoTask(command.id, appId, { silent: true }).catch(err => {
+    const result = await api.createSlashdoTask(command.id, appId, {}, { silent: true }).catch(err => {
       toast.error(err.message || `Failed to queue ${command.label}`);
       return null;
     });
     setLoading(null);
-    if (result) {
-      toast.success(`Queued ${command.label} agent task`);
-      navigate('/cos/agents');
-    }
+    if (result) goToQueue(command.label);
   };
 
   return (
@@ -56,6 +71,23 @@ export default function SlashDoPanel({ appId, appType }) {
           </button>
         ))}
       </div>
+      {/* Mounted only while open — the drawer fetches providers on mount, and
+          unmounting is what resets the form between runs. */}
+      {drawerCommand && (
+        <SlashDoRunDrawer
+          open
+          command={drawerCommand.id}
+          label={drawerCommand.label}
+          appId={appId}
+          appName={appName}
+          onClose={() => setDrawerCommand(null)}
+          onQueued={() => {
+            const { label } = drawerCommand;
+            setDrawerCommand(null);
+            goToQueue(label);
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/client/src/components/apps/SlashDoRunDrawer.jsx
+++ b/client/src/components/apps/SlashDoRunDrawer.jsx
@@ -1,0 +1,180 @@
+import { useState, useCallback } from 'react';
+import { Loader2, Terminal, Wand2 } from 'lucide-react';
+import Drawer from '../Drawer';
+import ProviderModelSelector from '../ProviderModelSelector';
+import ReviewerPicker from '../cos/ReviewerPicker';
+import EffortSelect from '../cos/EffortSelect';
+import useProviderModels from '../../hooks/useProviderModels';
+import { CodeReviewDefaultsProvider, useCodeReviewDefaults } from '../../hooks/useCodeReviewDefaults';
+import { isProcessProvider } from '../../utils/providers';
+import WorkItemPicker from './WorkItemPicker';
+import * as api from '../../services/api';
+
+// Module-scoped so `useProviderModels` sees a stable predicate — an inline arrow
+// would be a new identity each render, re-firing the hook's fetch effect forever.
+const enabledProcessProviderFilter = (p) => Boolean(p?.enabled) && isProcessProvider(p);
+
+const SELECT_CLASS = 'w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]';
+
+/**
+ * Pre-flight settings for an Agent Operations `/do:*` run: for `/do:next`, which
+ * work item to claim (or let the agent decide); for every command, the provider /
+ * model / effort pin and the task options (simplify, review-loop reviewers).
+ *
+ * Every control is optional — submitting untouched queues exactly the run the
+ * bare button used to. Reviewer fields are sent ONLY when the user edits them, so
+ * an untouched drawer still resolves the app's configured claim-work reviewers
+ * server-side rather than pinning whatever this form happened to display.
+ *
+ * Mount only while open (the parent conditionally renders it): the provider fetch
+ * runs on mount, and unmounting is what resets the form between runs.
+ */
+function SlashDoRunDrawerBody({ open, command, label, appId, appName, onClose, onQueued }) {
+  const codeReviewDefaults = useCodeReviewDefaults();
+  const {
+    providers, selectedProviderId, selectedModel, availableModels, selectedProvider,
+    setSelectedProviderId, setSelectedModel
+  } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, silent: true });
+
+  const [effort, setEffort] = useState('');
+  const [simplify, setSimplify] = useState(true);
+  // Seeded from the install's Code Review Defaults for display. `reviewDirty`
+  // gates whether they're SENT — see the component doc.
+  const [review, setReview] = useState(null);
+  const reviewValue = review ?? codeReviewDefaults;
+
+  const [work, setWork] = useState({ mode: 'auto', target: '', issueAuthorFilter: '' });
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState('');
+
+  const handleWorkChange = useCallback((next) => setWork(next), []);
+
+  const isNext = command === 'next';
+  // In pick mode an unselected item must block, not silently fall back to the
+  // agent-picked run the user just opted out of.
+  const awaitingPick = isNext && work.mode === 'pick' && !work.target;
+
+  const handleQueue = async () => {
+    setSubmitting(true);
+    setSubmitError('');
+    // silent: this drawer owns its own inline error + the caller's toast.
+    const result = await api.createSlashdoTask(command, appId, {
+      target: work.target || undefined,
+      // Only send the filter/reviewers the user actually chose — otherwise the
+      // app's configured claim-work defaults apply server-side, unchanged.
+      issueAuthorFilter: work.issueAuthorFilter || undefined,
+      provider: selectedProviderId || undefined,
+      model: selectedModel || undefined,
+      effort: effort || undefined,
+      simplify,
+      ...(review ? {
+        reviewers: review.reviewers,
+        usernames: review.usernames,
+        optionalReviewers: review.optionalReviewers
+      } : {})
+    }, { silent: true }).catch((err) => {
+      setSubmitError(err.message || 'Failed to queue the task');
+      return null;
+    });
+    setSubmitting(false);
+    if (result) onQueued?.(result);
+  };
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      title={`Run ${label}`}
+      subtitle={appName}
+      size="lg"
+      closeOnBackdrop={false}
+    >
+      <div className="space-y-6">
+        {isNext && <WorkItemPicker appId={appId} target={work.target} onChange={handleWorkChange} />}
+
+        <section className="space-y-3">
+          <div className="text-xs text-gray-500 uppercase tracking-wide">Agent</div>
+          <ProviderModelSelector
+            providers={providers}
+            selectedProviderId={selectedProviderId}
+            selectedModel={selectedModel}
+            availableModels={availableModels}
+            onProviderChange={(id) => { setSelectedProviderId(id); setEffort(''); }}
+            onModelChange={setSelectedModel}
+            emptyProviderOption="Auto (default)"
+            emptyModelOption="Default model"
+            highlightToolUse
+          />
+          <div className="sm:max-w-xs">
+            <EffortSelect
+              provider={selectedProvider}
+              value={effort}
+              onChange={setEffort}
+              className={SELECT_CLASS}
+            />
+          </div>
+        </section>
+
+        <section className="space-y-3">
+          <div className="text-xs text-gray-500 uppercase tracking-wide">Task settings</div>
+          <label className="flex items-center gap-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={simplify}
+              onChange={e => setSimplify(e.target.checked)}
+              className="w-4 h-4 rounded border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
+            />
+            <span className="flex items-center gap-1.5 text-sm text-gray-400">
+              <Wand2 size={14} className="text-port-accent-2" />
+              Simplify before committing
+            </span>
+          </label>
+          <ReviewerPicker
+            reviewers={reviewValue.reviewers}
+            usernames={reviewValue.usernames}
+            optionalReviewers={reviewValue.optionalReviewers}
+            // The claim flows substitute a reviewer CSV into their prompt and have
+            // no slashdo flag string, so stop-mode / reviewer-applies can't be honored.
+            showRunFlags={false}
+            onChange={({ reviewers, usernames, optionalReviewers }) =>
+              setReview({ reviewers, usernames, optionalReviewers })}
+          />
+          <p className="text-xs text-gray-500">
+            The claim flow opens and merges its own PR, so these reviewers gate that merge (slashdo <code>--review-with</code>).
+            {!review && ' Leave them untouched to use this app’s configured reviewers.'}
+          </p>
+        </section>
+
+        {submitError && <p className="text-xs text-port-error">{submitError}</p>}
+
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-2 bg-port-bg border border-port-border rounded-lg text-sm text-gray-400 hover:text-white transition-colors min-h-[44px]"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleQueue}
+            disabled={submitting || awaitingPick}
+            title={awaitingPick ? 'Select a work item first' : undefined}
+            className="flex items-center gap-1.5 px-3 py-2 bg-blue-500/20 hover:bg-blue-500/30 text-blue-400 border border-blue-500/30 rounded-lg text-sm transition-colors disabled:opacity-50 disabled:cursor-not-allowed min-h-[44px]"
+          >
+            {submitting ? <Loader2 size={14} className="animate-spin" /> : <Terminal size={14} />}
+            Queue {label}
+          </button>
+        </div>
+      </div>
+    </Drawer>
+  );
+}
+
+export default function SlashDoRunDrawer(props) {
+  return (
+    <CodeReviewDefaultsProvider>
+      <SlashDoRunDrawerBody {...props} />
+    </CodeReviewDefaultsProvider>
+  );
+}

--- a/client/src/components/apps/SlashDoRunDrawer.test.jsx
+++ b/client/src/components/apps/SlashDoRunDrawer.test.jsx
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SlashDoRunDrawer from './SlashDoRunDrawer';
+
+const api = vi.hoisted(() => ({
+  getCodeReviewDefaults: vi.fn(),
+  getProviders: vi.fn(),
+  getAppWorkItems: vi.fn(),
+  createSlashdoTask: vi.fn()
+}));
+
+vi.mock('../../services/api', () => api);
+
+const renderDrawer = (props = {}) => render(
+  <SlashDoRunDrawer
+    open
+    command="next"
+    label="/do:next"
+    appId="acme"
+    appName="Acme App"
+    onClose={vi.fn()}
+    onQueued={vi.fn()}
+    {...props}
+  />
+);
+
+describe('SlashDoRunDrawer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getCodeReviewDefaults.mockResolvedValue({ reviewers: ['copilot'], usernames: [], optionalReviewers: [] });
+    api.getProviders.mockResolvedValue({ providers: [] });
+    api.getAppWorkItems.mockResolvedValue({
+      tracker: 'github',
+      issueAuthorFilter: 'self',
+      items: [{ ref: '7', title: 'Fix the thing' }, { ref: '9', title: 'Add the other' }],
+      count: 2,
+      reason: 'actionable-issues',
+      transient: false
+    });
+    api.createSlashdoTask.mockResolvedValue({ id: 'task-1', status: 'pending' });
+  });
+
+  it('queues an agent-picks run without fetching the tracker', async () => {
+    const onQueued = vi.fn();
+    renderDrawer({ onQueued });
+
+    await userEvent.click(screen.getByRole('button', { name: /Queue \/do:next/ }));
+
+    await waitFor(() => expect(onQueued).toHaveBeenCalled());
+    expect(api.getAppWorkItems).not.toHaveBeenCalled();
+    const [command, appId, settings] = api.createSlashdoTask.mock.calls.at(-1);
+    expect(command).toBe('next');
+    expect(appId).toBe('acme');
+    expect(settings.target).toBeUndefined();
+    expect(settings.simplify).toBe(true);
+    // Untouched reviewer controls must NOT pin a list — the server resolves the
+    // app's configured claim-work reviewers instead.
+    expect(settings.reviewers).toBeUndefined();
+  });
+
+  it('sends the reviewer list only once the user edits it', async () => {
+    const onQueued = vi.fn();
+    renderDrawer({ onQueued });
+
+    await waitFor(() => expect(screen.getByText('Reviewers (in order):')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /Remove Copilot/ }));
+    await userEvent.click(screen.getByRole('button', { name: /Queue \/do:next/ }));
+
+    await waitFor(() => expect(onQueued).toHaveBeenCalled());
+    const [, , settings] = api.createSlashdoTask.mock.calls.at(-1);
+    expect(settings.reviewers).toEqual([]);
+  });
+
+  it('hides the stop-mode and reviewer-applies controls the claim flow cannot honor', async () => {
+    renderDrawer();
+
+    await waitFor(() => expect(screen.getByText('Reviewers (in order):')).toBeInTheDocument());
+    // Add a second, non-Copilot reviewer — the two flags render at 2+ / non-copilot.
+    await userEvent.click(screen.getByRole('button', { name: /^Claude/ }));
+
+    expect(screen.queryByText('Stop mode:')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Reviewer applies fixes/)).not.toBeInTheDocument();
+  });
+
+  it('lists the tracker items once "pick a specific" is chosen and sends the pinned ref', async () => {
+    const onQueued = vi.fn();
+    renderDrawer({ onQueued });
+
+    await userEvent.click(screen.getByRole('radio', { name: /Pick a specific/ }));
+    await waitFor(() => expect(screen.getByText('Fix the thing')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('radio', { name: /Add the other/ }));
+    await userEvent.click(screen.getByRole('button', { name: /Queue \/do:next/ }));
+
+    await waitFor(() => expect(onQueued).toHaveBeenCalled());
+    const [, , settings] = api.createSlashdoTask.mock.calls.at(-1);
+    expect(settings.target).toBe('9');
+    expect(settings.issueAuthorFilter).toBe('self');
+  });
+
+  it('blocks submission until an item is selected in pick mode', async () => {
+    renderDrawer();
+
+    await userEvent.click(screen.getByRole('radio', { name: /Pick a specific/ }));
+    await waitFor(() => expect(screen.getByText('Fix the thing')).toBeInTheDocument());
+
+    expect(screen.getByRole('button', { name: /Queue \/do:next/ })).toBeDisabled();
+  });
+
+  it('distinguishes an unreachable tracker from an empty queue', async () => {
+    api.getAppWorkItems.mockResolvedValue({
+      tracker: 'github', issueAuthorFilter: 'self', items: [], count: 0,
+      reason: 'gh-list-failed', transient: true
+    });
+    renderDrawer();
+
+    await userEvent.click(screen.getByRole('radio', { name: /Pick a specific/ }));
+
+    await waitFor(() => expect(screen.getByText(/Couldn't reach the tracker/)).toBeInTheDocument());
+  });
+
+  it('stops re-requesting after a failed fetch instead of looping', async () => {
+    api.getAppWorkItems.mockRejectedValue(new Error('boom'));
+    renderDrawer();
+
+    await userEvent.click(screen.getByRole('radio', { name: /Pick a specific/ }));
+
+    await waitFor(() => expect(screen.getByText('boom')).toBeInTheDocument());
+    expect(api.getAppWorkItems).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/apps/WorkItemPicker.jsx
+++ b/client/src/components/apps/WorkItemPicker.jsx
@@ -1,0 +1,194 @@
+import { useState, useCallback, useId } from 'react';
+import { Loader2, RefreshCw } from 'lucide-react';
+import { ISSUE_AUTHOR_FILTER_OPTIONS } from '../cos/constants';
+import { WORK_TRACKER_LABELS, workItemNoun } from './constants';
+import * as api from '../../services/api';
+
+// Trackers with an author gate — PLAN.md items and JIRA sprint tickets have none.
+const TRACKERS_WITH_AUTHOR_FILTER = new Set(['github', 'gitlab']);
+
+// Why the tracker returned nothing to pick, in the user's terms. Sentence-form
+// because these render standalone; the sibling map in hooks/useOnDemandTaskToast.js
+// glosses the same sentinels as noun phrases for its "…: no claimable issues"
+// toast, so a NEW server-side reason is worth adding to both.
+const EMPTY_REASONS = {
+  'no-repo-path': 'This app has no repo path configured.',
+  'no-plan': 'No PLAN.md found in the repo.',
+  'no-actionable-plan-items': 'Every PLAN.md item is checked, blocked, or already claimed.',
+  'no-open-issues': 'The tracker has no open issues.',
+  'no-authored-issues': 'Open issues exist, but none match the author filter — widen it to see them.',
+  'no-actionable-issues': 'Every open issue is assigned, blocked, in flight, or an epic.',
+  'owner-is-org': 'The repo owner is an organization, which never authors issues — switch the filter to "Any author".',
+  'owner-is-group': 'The project namespace is a group, which never authors issues — switch the filter to "Any author".',
+  'jira-not-configured': 'JIRA is not configured for this app.',
+  'no-open-tickets': 'No unstarted tickets in the current sprint.',
+  'no-detector': 'PortOS can\'t list this tracker\'s items — the agent can still pick one.'
+};
+
+const SELECT_CLASS = 'w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]';
+
+/** Sentinel-aware empty copy: never collapse "couldn't reach it" into "nothing to do". */
+function emptyMessage(work) {
+  if (work.transient) return `Couldn't reach the tracker (${work.reason}) — retry, or let the agent decide.`;
+  return EMPTY_REASONS[work.reason] || `Nothing to pick (${work.reason || 'unknown'}).`;
+}
+
+/**
+ * "Let the agent decide" vs "pick a specific item" for a `/do:next` run, plus
+ * the item list itself. The list is only fetched once the user asks to pick —
+ * the default run needs no forge round-trip.
+ *
+ * Controlled by the parent through `onChange({ mode, target, issueAuthorFilter })`.
+ * `mode` is `'pick'` or `'auto'`; in `'pick'` mode `target` stays `''` until the
+ * user selects an item, which is what lets the parent block submission rather
+ * than silently falling back to an agent-picked run.
+ */
+export default function WorkItemPicker({ appId, target, onChange }) {
+  const filterId = useId();
+  const [pickSpecific, setPickSpecific] = useState(false);
+  const [authorFilter, setAuthorFilter] = useState('');
+  const [work, setWork] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const loadWork = useCallback(async (filter) => {
+    setLoading(true);
+    setError('');
+    const data = await api.getAppWorkItems(appId, { issueAuthorFilter: filter || undefined })
+      .catch((err) => {
+        setError(err.message || 'Failed to load work items');
+        return null;
+      });
+    setLoading(false);
+    if (!data) return;
+    setWork(data);
+    // Adopt the server's effective filter so the select shows what was scanned.
+    if (data.issueAuthorFilter) setAuthorFilter(data.issueAuthorFilter);
+    // A pick from a previous (wider) filter must not survive a narrower scan.
+    const items = data.items || [];
+    onChange({
+      mode: 'pick',
+      target: items.some(i => i.ref === target) ? target : '',
+      issueAuthorFilter: data.issueAuthorFilter || filter || ''
+    });
+  }, [appId, target, onChange]);
+
+  // Load from the radio handler rather than an effect: "fetch once when the user
+  // opts in" is structural here, so no request-guard state is needed.
+  const choosePick = () => {
+    setPickSpecific(true);
+    onChange({ mode: 'pick', target, issueAuthorFilter: authorFilter });
+    if (!work && !loading) loadWork(authorFilter);
+  };
+
+  const chooseAuto = () => {
+    setPickSpecific(false);
+    onChange({ mode: 'auto', target: '', issueAuthorFilter: authorFilter });
+  };
+
+  const changeFilter = (value) => {
+    setAuthorFilter(value);
+    setWork(null);
+    loadWork(value);
+  };
+
+  const tracker = work?.tracker;
+  const noun = workItemNoun(tracker);
+  const items = work?.items || [];
+
+  return (
+    <section className="space-y-3">
+      <div className="text-xs text-gray-500 uppercase tracking-wide">Work item</div>
+      <div className="flex flex-col gap-2">
+        <label className="flex items-start gap-2 cursor-pointer select-none">
+          <input
+            type="radio"
+            name="do-next-scope"
+            checked={!pickSpecific}
+            onChange={chooseAuto}
+            className="mt-1 w-4 h-4 border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
+          />
+          <span className="text-sm text-gray-300">
+            Let the agent decide
+            <span className="block text-xs text-gray-500">Claims the next eligible item from this app&apos;s work tracker.</span>
+          </span>
+        </label>
+        <label className="flex items-start gap-2 cursor-pointer select-none">
+          <input
+            type="radio"
+            name="do-next-scope"
+            checked={pickSpecific}
+            onChange={choosePick}
+            className="mt-1 w-4 h-4 border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
+          />
+          <span className="text-sm text-gray-300">
+            Pick a specific {noun}
+            <span className="block text-xs text-gray-500">Pins the run to one item from PLAN.md / GitHub / GitLab / JIRA.</span>
+          </span>
+        </label>
+      </div>
+
+      {pickSpecific && (
+        <div className="space-y-3 pl-6">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs text-gray-500">
+              Tracker: <span className="text-gray-300">{WORK_TRACKER_LABELS[tracker] || (loading ? 'resolving…' : 'unknown')}</span>
+            </span>
+            <button
+              type="button"
+              onClick={() => loadWork(authorFilter)}
+              disabled={loading}
+              className="flex items-center gap-1 px-2 py-1 bg-port-bg border border-port-border rounded-lg text-xs text-gray-400 hover:text-white transition-colors disabled:opacity-50"
+            >
+              {loading ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
+              Refresh
+            </button>
+          </div>
+
+          {TRACKERS_WITH_AUTHOR_FILTER.has(tracker) && (
+            <div>
+              <label htmlFor={filterId} className="block text-xs text-gray-500 mb-1">Author filter</label>
+              <select
+                id={filterId}
+                value={authorFilter}
+                onChange={e => changeFilter(e.target.value)}
+                className={SELECT_CLASS}
+              >
+                {ISSUE_AUTHOR_FILTER_OPTIONS.map(o => (
+                  <option key={o.value} value={o.value} title={o.description}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          {error && <p className="text-xs text-port-error">{error}</p>}
+          {!error && !loading && work && items.length === 0 && (
+            <p className="text-xs text-port-warning">{emptyMessage(work)}</p>
+          )}
+          {items.length > 0 && (
+            <div className="max-h-64 overflow-y-auto border border-port-border rounded-lg divide-y divide-port-border">
+              {items.map(item => (
+                <label
+                  key={item.ref}
+                  className="flex items-start gap-2 p-2 cursor-pointer select-none hover:bg-port-bg/60 transition-colors"
+                >
+                  <input
+                    type="radio"
+                    name="do-next-item"
+                    checked={target === item.ref}
+                    onChange={() => onChange({ mode: 'pick', target: item.ref, issueAuthorFilter: authorFilter })}
+                    className="mt-1 w-4 h-4 border-port-border bg-port-bg text-port-accent focus:ring-port-accent focus:ring-offset-0"
+                  />
+                  <span className="min-w-0">
+                    <span className="text-xs font-mono text-port-accent">{item.ref}</span>
+                    <span className="block text-sm text-gray-300 break-words">{item.title || '(no title)'}</span>
+                  </span>
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/components/apps/constants.js
+++ b/client/src/components/apps/constants.js
@@ -39,6 +39,25 @@ export const getAppTypeLabel = (type) =>
   type === 'macos-native' ? '🖥️ macOS' :
   type === 'swift' ? '🐦 Swift' : '🔨 Xcode';
 
+// Where an app's autonomous work items live. Mirrors WORK_TRACKERS +
+// TRACKER_LABELS in server/lib/workTracker.js — shared by the Edit App picker
+// and the /do:next run drawer so one vocabulary describes both.
+export const WORK_TRACKER_OPTIONS = [
+  { value: 'auto', label: 'Auto (detect from git origin)' },
+  { value: 'plan', label: 'PLAN.md' },
+  { value: 'github', label: 'GitHub Issues' },
+  { value: 'gitlab', label: 'GitLab Issues' },
+  { value: 'jira', label: 'JIRA' }
+];
+
+export const WORK_TRACKER_LABELS = Object.fromEntries(
+  WORK_TRACKER_OPTIONS.map(o => [o.value, o.label])
+);
+
+/** The word a tracker uses for one work item — "issue", "ticket", "item". */
+export const workItemNoun = (tracker) =>
+  tracker === 'jira' ? 'ticket' : (tracker === 'github' || tracker === 'gitlab') ? 'issue' : 'item';
+
 export const APP_DETAIL_TABS = [
   { id: 'overview', label: 'Overview' },
   { id: 'automation', label: 'Automation' },

--- a/client/src/components/apps/tabs/OverviewTab.jsx
+++ b/client/src/components/apps/tabs/OverviewTab.jsx
@@ -317,7 +317,7 @@ export default function OverviewTab({ app, onRefresh }) {
       {/* Actions zone — back to capped readable width */}
       <div className="space-y-6 max-w-5xl">
       {/* Agent Operations */}
-      <SlashDoPanel appId={app.id} appType={app.type} />
+      <SlashDoPanel appId={app.id} appName={app.name} appType={app.type} />
 
       {/* Quick Actions */}
       <div className="flex flex-wrap gap-2 pt-2">

--- a/client/src/components/cos/EffortSelect.jsx
+++ b/client/src/components/cos/EffortSelect.jsx
@@ -1,0 +1,66 @@
+import { useId } from 'react';
+import { effortLevelsForProvider } from '../../utils/providers';
+import { FormField } from '../ui/FormField';
+
+/**
+ * The single "thinking effort" override picker for effort-capable providers
+ * (claude / codex). Renders nothing when the selected provider has no effort
+ * tiers, so callers drop it in unconditionally next to a provider/model picker
+ * — no `effortLevelsForProvider` guard of their own. `''` is the
+ * "Default effort" sentinel, meaning no override is sent.
+ *
+ * Pass `label` to get the standard `FormField` wrapper (label + optional `hint`,
+ * both hidden along with the select when the provider has no tiers). Omit it for
+ * a bare `<select>`, e.g. inside a caller-owned flex row.
+ *
+ * @param {object} props
+ * @param {object} [props.provider] - The selected provider record (not its id).
+ * @param {string} props.value - Current effort ('' = provider default).
+ * @param {function} props.onChange - Called with the new effort string.
+ * @param {string} [props.label] - Field label; enables the FormField wrapper.
+ * @param {import('react').ReactNode} [props.hint] - Help text under the select (needs `label`).
+ * @param {string} [props.className] - Classes for the <select>.
+ * @param {string} [props.fieldClassName] - Classes for the FormField wrapper.
+ * @param {string} [props.labelClassName] - Classes for the FormField label.
+ * @param {boolean} [props.disabled] - Disable the select (e.g. while saving).
+ */
+export default function EffortSelect({
+  provider,
+  value,
+  onChange,
+  label,
+  hint,
+  className = '',
+  fieldClassName,
+  labelClassName,
+  disabled = false
+}) {
+  const id = useId();
+  const levels = effortLevelsForProvider(provider);
+  if (!levels) return null;
+
+  const select = (
+    <select
+      id={id}
+      value={value || ''}
+      onChange={e => onChange(e.target.value)}
+      disabled={disabled}
+      className={className}
+      title="Thinking effort — how hard the model reasons per turn"
+      aria-label={label ? undefined : 'Thinking effort'}
+    >
+      <option value="">Default effort</option>
+      {levels.map(level => (
+        <option key={level} value={level}>{level}</option>
+      ))}
+    </select>
+  );
+
+  if (!label) return select;
+  return (
+    <FormField label={label} className={fieldClassName} labelClassName={labelClassName}>
+      {select}
+      {hint && <p className="text-xs text-gray-500 mt-1">{hint}</p>}
+    </FormField>
+  );
+}

--- a/client/src/components/cos/ReviewerPicker.jsx
+++ b/client/src/components/cos/ReviewerPicker.jsx
@@ -24,6 +24,12 @@ const normalizeReviewerValue = (value) => value === 'gemini' ? 'antigravity' : v
  * Controlled: emits the full next shape via onChange so the parent can store
  * `reviewers` / `usernames` / `reviewStopMode` / `reviewerApplies` however it
  * persists them.
+ *
+ * `showRunFlags={false}` hides the stop-mode select and the "reviewer applies
+ * fixes" checkbox for surfaces that can't honor them — the `/do:next` claim
+ * flows substitute a reviewer CSV into their prompt and have no slashdo flag
+ * string, so rendering those two controls there would be a knob wired to
+ * nothing. The reviewer list itself still applies.
  */
 export default function ReviewerPicker({
   reviewers = [],
@@ -32,7 +38,8 @@ export default function ReviewerPicker({
   stopMode = DEFAULT_REVIEW_STOP_MODE,
   reviewerApplies = false,
   onChange,
-  disabled = false
+  disabled = false,
+  showRunFlags = true
 }) {
   const id = useId();
   const [usernameInput, setUsernameInput] = useState('');
@@ -256,7 +263,7 @@ export default function ReviewerPicker({
         {usernameError && <span className="text-xs text-port-error">{usernameError}</span>}
       </div>
 
-      {selected.length >= 2 && (
+      {showRunFlags && selected.length >= 2 && (
         <div className="flex items-center gap-2">
           <label htmlFor={`${id}-stopmode`} className="text-xs text-gray-500">Stop mode:</label>
           <select
@@ -273,7 +280,7 @@ export default function ReviewerPicker({
         </div>
       )}
 
-      {hasNonCopilot && (
+      {showRunFlags && hasNonCopilot && (
         <label htmlFor={`${id}-applies`} className="flex items-center gap-2 cursor-pointer select-none text-xs text-gray-500">
           <input
             id={`${id}-applies`}

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -6,10 +6,11 @@ import * as api from '../../services/api';
 import { processScreenshotUploads, processAttachmentUploads, ATTACHMENT_ACCEPT } from '../../utils/fileUpload';
 import FilePickerButton from '../ui/FilePickerButton';
 import { formatBytes } from '../../utils/formatters';
-import { filterSelectableModels, isTuiProvider, isCliProvider, isProcessProvider, isCodexProvider, effortLevelsForProvider } from '../../utils/providers';
+import { filterSelectableModels, isTuiProvider, isCliProvider, isProcessProvider, isCodexProvider } from '../../utils/providers';
 import { DEFAULT_PR_COMPLETION, DEFAULT_REVIEWERS, DEFAULT_REVIEW_STOP_MODE, PR_COMPLETION_OPTIONS } from './constants';
 import { clickableProps } from '../../lib/a11yKeyboard';
 import ReviewerPicker from './ReviewerPicker';
+import EffortSelect from './EffortSelect';
 
 export default function TaskAddForm({ providers, apps, onTaskAdded, compact = false, defaultExpanded = false, defaultApp = '' }) {
   const [newTask, setNewTask] = useState({ description: '', model: '', provider: '', effort: '', app: defaultApp });
@@ -137,7 +138,6 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   // Get models for selected provider
   const selectedProvider = providers?.find(p => p.id === newTask.provider);
   const availableModels = filterSelectableModels(selectedProvider?.models);
-  const effortLevels = effortLevelsForProvider(selectedProvider);
   const providerModelNote = (() => {
     if (!selectedProvider) return '';
     if (isTuiProvider(selectedProvider)) return `${selectedProvider.name} runs in an attachable terminal UI session.`;
@@ -619,23 +619,12 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
               {providerModelNote}
             </div>
           ) : null}
-          {effortLevels && (
-            <div className="sm:w-40">
-              <label htmlFor="task-effort" className="sr-only">Thinking effort</label>
-              <select
-                id="task-effort"
-                value={newTask.effort}
-                onChange={e => setNewTask(t => ({ ...t, effort: e.target.value }))}
-                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
-                title="Thinking effort — how hard the model reasons per turn"
-              >
-                <option value="">Default effort</option>
-                {effortLevels.map(level => (
-                  <option key={level} value={level}>{level}</option>
-                ))}
-              </select>
-            </div>
-          )}
+          <EffortSelect
+            provider={selectedProvider}
+            value={newTask.effort}
+            onChange={effort => setNewTask(t => ({ ...t, effort }))}
+            className="sm:w-40 w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
+          />
         </div>
         {apiOnlyProviders && (
           <div className="px-3 py-2 bg-port-warning/10 border border-port-warning/40 rounded-lg text-xs text-port-warning">

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -5,9 +5,9 @@ import * as api from '../../../services/api';
 import { timeAgo, formatDateTime } from '../../../utils/formatters';
 import { CRON_PRESETS, DEFAULT_CRON, describeCron } from '../../../utils/cronHelpers';
 import WeekdayTimePicker from '../../WeekdayTimePicker';
-import { filterSelectableModels, effortLevelsForProvider } from '../../../utils/providers';
+import { filterSelectableModels } from '../../../utils/providers';
 import ProviderModelSelector from '../../ProviderModelSelector';
-import { FormField } from '../../ui/FormField';
+import EffortSelect from '../EffortSelect';
 import InlineConfirmRow from '../../ui/InlineConfirmRow';
 import { useConfirmDelete } from '../../../hooks/useConfirmDelete';
 
@@ -126,7 +126,6 @@ function JobProviderModelFields({ data, providers, onChange }) {
   if (!providers?.length) return null;
   const selectedProvider = providers.find(p => p.id === data.providerId);
   const availableModels = filterSelectableModels(selectedProvider?.models);
-  const effortLevels = effortLevelsForProvider(selectedProvider);
   return (
     <div>
       <span className="text-xs text-gray-400 block mb-1">AI Provider &amp; Model (optional)</span>
@@ -142,20 +141,15 @@ function JobProviderModelFields({ data, providers, onChange }) {
         emptyModelOption="Default model"
         alwaysShowModel
       />
-      {effortLevels && (
-        <FormField label="Thinking Effort (optional)" className="mt-2" labelClassName="text-xs text-gray-400 block mb-1">
-          <select
-            value={data.effort || ''}
-            onChange={e => onChange({ effort: e.target.value })}
-            className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-white text-xs"
-          >
-            <option value="">Default effort</option>
-            {effortLevels.map(level => (
-              <option key={level} value={level}>{level}</option>
-            ))}
-          </select>
-        </FormField>
-      )}
+      <EffortSelect
+        provider={selectedProvider}
+        value={data.effort}
+        onChange={effort => onChange({ effort })}
+        label="Thinking Effort (optional)"
+        fieldClassName="mt-2"
+        labelClassName="text-xs text-gray-400 block mb-1"
+        className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-white text-xs"
+      />
     </div>
   );
 }

--- a/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
+++ b/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
@@ -9,7 +9,8 @@ import { FormField } from '../../../ui/FormField';
 import { formatDateTime } from '../../../../utils/formatters';
 import { useCodeReviewDefaults } from '../../../../hooks/useCodeReviewDefaults';
 import ToggleSwitch from '../../../ToggleSwitch';
-import { filterSelectableModels, effortLevelsForProvider } from '../../../../utils/providers';
+import { filterSelectableModels } from '../../../../utils/providers';
+import EffortSelect from '../../EffortSelect';
 import PromptEditor from './PromptEditor';
 import RunTaskButton from './RunTaskButton';
 import { INTERVAL_DESCRIPTIONS, toggleMetadataField } from './scheduleConstants';
@@ -160,7 +161,6 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
 
   const selectedProvider = providers?.find(p => p.id === (selectedProviderId || ''));
   const availableModels = filterSelectableModels(selectedProvider?.models);
-  const effortLevels = effortLevelsForProvider(selectedProvider);
   const status = config.status || {};
 
   return (
@@ -305,22 +305,16 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
             <p className="text-xs text-gray-500 mt-1">Leave as default to use the provider's default model</p>
           </FormField>
 
-          {effortLevels && (
-            <FormField label="Thinking Effort (optional)" labelClassName="text-sm text-gray-400 block mb-2">
-              <select
-                value={selectedEffort}
-                onChange={(e) => handleEffortChange(e.target.value)}
-                disabled={updating}
-                className="w-full bg-port-card border border-port-border rounded px-3 py-2 text-white text-sm"
-              >
-                <option value="">Default effort</option>
-                {effortLevels.map(level => (
-                  <option key={level} value={level}>{level}</option>
-                ))}
-              </select>
-              <p className="text-xs text-gray-500 mt-1">How hard the model reasons per turn — higher is slower and costlier but more thorough</p>
-            </FormField>
-          )}
+          <EffortSelect
+            provider={selectedProvider}
+            value={selectedEffort}
+            onChange={handleEffortChange}
+            disabled={updating}
+            label="Thinking Effort (optional)"
+            labelClassName="text-sm text-gray-400 block mb-2"
+            hint="How hard the model reasons per turn — higher is slower and costlier but more thorough"
+            className="w-full bg-port-card border border-port-border rounded px-3 py-2 text-white text-sm"
+          />
         </>
       )}
 

--- a/client/src/components/cos/tabs/schedule/PipelineStageConfig.jsx
+++ b/client/src/components/cos/tabs/schedule/PipelineStageConfig.jsx
@@ -1,5 +1,6 @@
-import { filterSelectableModels, effortLevelsForProvider } from '../../../../utils/providers';
+import { filterSelectableModels } from '../../../../utils/providers';
 import { FormField } from '../../../ui/FormField';
+import EffortSelect from '../../EffortSelect';
 
 export default function PipelineStageConfig({ taskType, config, providers, onUpdate, updating, setUpdating }) {
   const stages = config.taskMetadata?.pipeline?.stages || [];
@@ -38,7 +39,6 @@ export default function PipelineStageConfig({ taskType, config, providers, onUpd
         {stages.map((stage, i) => {
           const stageProvider = providers?.find(p => p.id === stage.providerId);
           const stageModels = filterSelectableModels(stageProvider?.models);
-          const stageEffortLevels = effortLevelsForProvider(stageProvider);
           return (
             <div key={i} className="bg-port-card border border-port-border rounded-lg p-3">
               <div className="flex items-center gap-2 mb-3">
@@ -81,21 +81,15 @@ export default function PipelineStageConfig({ taskType, config, providers, onUpd
                     ))}
                   </select>
                 </FormField>
-                {stageEffortLevels && (
-                  <FormField label="Thinking Effort" labelClassName="text-xs text-gray-500 block mb-1">
-                    <select
-                      value={stage.effort || ''}
-                      onChange={(e) => handleStageUpdate(i, 'effort', e.target.value || null)}
-                      disabled={updating}
-                      className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-white text-xs"
-                    >
-                      <option value="">Default effort</option>
-                      {stageEffortLevels.map(level => (
-                        <option key={level} value={level}>{level}</option>
-                      ))}
-                    </select>
-                  </FormField>
-                )}
+                <EffortSelect
+                  provider={stageProvider}
+                  value={stage.effort}
+                  onChange={(effort) => handleStageUpdate(i, 'effort', effort || null)}
+                  disabled={updating}
+                  label="Thinking Effort"
+                  labelClassName="text-xs text-gray-500 block mb-1"
+                  className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-white text-xs"
+                />
               </div>
             </div>
           );

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -58,9 +58,13 @@ export const addCosTask = (task, options = {}) => request('/cos/tasks', {
   body: JSON.stringify(task),
   ...options
 });
-export const createSlashdoTask = (command, app, options = {}) => request('/cos/tasks/slashdo', {
+// Queue a `/do:*` agent task for an app. `settings` carries the run options the
+// Agent Operations drawer collects — provider/model/effort/simplify for every
+// command, plus the `/do:next`-only target work item, issue author filter, and
+// reviewer list. Omit it for a bare "run with the app's configured defaults".
+export const createSlashdoTask = (command, app, settings = {}, options = {}) => request('/cos/tasks/slashdo', {
   method: 'POST',
-  body: JSON.stringify({ command, app }),
+  body: JSON.stringify({ command, app, ...settings }),
   ...options
 });
 // Queue a CoS task to implement one specific JIRA ticket (sprint-board play button).

--- a/client/src/services/apiApps.js
+++ b/client/src/services/apiApps.js
@@ -13,6 +13,14 @@ export const getAppSpriteBindings = (id, options) =>
 // caller (EditAppDrawer) owns its own .catch fallback, so default to silent.
 export const getAppWorkTracker = (id, options) =>
   request(`/apps/${id}/work-tracker`, { silent: true, ...options });
+// Work items a `/do:next` run could claim, from whichever tracker the app
+// resolves to: { tracker, items: [{ ref, title, url? }], reason, transient }.
+// `issueAuthorFilter` previews a filter other than the app's configured one.
+// Read-only; the /do:next drawer owns its own error UI, so default to silent.
+export const getAppWorkItems = (id, { issueAuthorFilter } = {}, options) => {
+  const qs = issueAuthorFilter ? `?issueAuthorFilter=${encodeURIComponent(issueAuthorFilter)}` : '';
+  return request(`/apps/${id}/work-items${qs}`, { silent: true, ...options });
+};
 // Effective Layered Intelligence config (self-improvement loop) for an app —
 // stored partial merged over the shipped defaults. Read-only; saved through
 // updateApp (the `layeredIntelligence` key routes to the merge helper server-

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -656,6 +656,26 @@ export const ISSUE_AUTHOR_FILTERS = ['self', 'owner', 'any'];
 export const SWARM_COUNT_MIN = 2;
 export const SWARM_COUNT_MAX = 6;
 
+// POST /api/cos/tasks/slashdo — a `/do:*` button click from an app's Agent
+// Operations panel. The run-settings fields are PICKED from createCosTaskSchema
+// rather than restated, so the drawer's provider/model/effort/simplify/reviewer
+// knobs stay in lockstep with the Add Task form's (one vocabulary, one set of
+// preprocessors). `command` is only shape-checked here — the route owns the
+// allowed-command map and its 400 message. The remaining fields are `/do:next`
+// specific: `target` pins the run to ONE work item (empty ⇒ the agent picks),
+// and `issueAuthorFilter` overrides the app's configured claim-work gate.
+export const slashdoTaskSchema = createCosTaskSchema
+  .pick({
+    model: true, provider: true, effort: true, simplify: true,
+    reviewers: true, usernames: true, optionalReviewers: true
+  })
+  .extend({
+    command: z.string().min(1),
+    app: z.string().min(1),
+    target: z.preprocess(emptyToUndefined, z.string().trim().max(80).optional()),
+    issueAuthorFilter: z.enum(ISSUE_AUTHOR_FILTERS).optional(),
+  });
+
 /**
  * Sanitize taskMetadata to an allow-list of agent-option keys. Boolean flags
  * (`useWorktree`/`openPR`/`simplify`/`reviewLoop`/`readOnly`/`reviewerApplies`)

--- a/server/routes/apps/taskTypes.js
+++ b/server/routes/apps/taskTypes.js
@@ -5,6 +5,7 @@
  *   PUT  /bulk-task-type/:taskType   → { success, appsUpdated }  (all active apps)
  *   GET  /:id/task-types             → { taskTypeOverrides }
  *   GET  /:id/work-tracker           → { tracker info }
+ *   GET  /:id/work-items             → { tracker, items, reason }
  *   GET  /:id/layered-intelligence           → { config, isPortos }
  *   GET  /:id/layered-intelligence/outcomes  → { stats, execution, rejections, recent }
  *   PUT  /:id/task-types/all         → { success, taskTypeOverrides }
@@ -17,7 +18,9 @@
 import { Router } from 'express';
 import * as appsService from '../../services/apps.js';
 import { PORTOS_APP_ID } from '../../services/apps.js';
-import { sanitizeTaskMetadata } from '../../lib/validation.js';
+import { sanitizeTaskMetadata, ISSUE_AUTHOR_FILTERS } from '../../lib/validation.js';
+import { listWorkItems } from '../../services/workItems.js';
+import { resolveClaimWorkMetadata, resolveClaimAuthorFilter } from '../../services/cosTaskGenerator.js';
 import { parseCronToNextRun } from '../../services/eventScheduler.js';
 import { asyncHandler, ServerError } from '../../lib/errorHandler.js';
 import { SELF_IMPROVEMENT_TASK_TYPES } from '../../services/taskSchedule.js';
@@ -63,6 +66,25 @@ router.get('/:id/work-tracker', loadApp, asyncHandler(async (req, res) => {
   const app = req.loadedApp;
   const info = await appsService.getAppWorkTracker(app.id);
   res.json({ appId: app.id, appName: app.name, ...info });
+}));
+
+// GET /api/apps/:id/work-items - The work items a `/do:next` run could claim for
+// this app, from whichever tracker it resolves to. Backs the "pick a specific
+// item" mode of the app-overview `/do:next` drawer; the agent-picks default needs
+// no call. Scanned with the SAME author filter the claim agent will apply
+// (`?issueAuthorFilter=` overrides it for the preview) so the list can't advertise
+// items the run would then skip. Read-only: no LLM call, no claim markers set.
+router.get('/:id/work-items', loadApp, asyncHandler(async (req, res) => {
+  const app = req.loadedApp;
+  const requested = req.query.issueAuthorFilter;
+  const explicit = ISSUE_AUTHOR_FILTERS.includes(requested) ? requested : undefined;
+  // Only read the app's claim-work config when it's actually the answer — an
+  // explicit filter (every drawer refresh after the first) already wins, and the
+  // read costs a schedule load plus a per-app override read.
+  const issueAuthorFilter = explicit
+    ?? resolveClaimAuthorFilter(undefined, (await resolveClaimWorkMetadata(app)).metadata);
+  const result = await listWorkItems(app, { issueAuthorFilter });
+  res.json({ appId: app.id, appName: app.name, issueAuthorFilter, ...result });
 }));
 
 // GET /api/apps/:id/layered-intelligence - Effective Layered Intelligence config

--- a/server/routes/apps/taskTypes.test.js
+++ b/server/routes/apps/taskTypes.test.js
@@ -24,8 +24,20 @@ vi.mock('../../services/layeredIntelligenceOutcomes.js', () => ({
   listOutcomesResult: vi.fn()
 }));
 
+// The work-item picker composes the claim-work metadata resolver (so the preview
+// scans under the same author filter the run will) with the tracker lister.
+vi.mock('../../services/workItems.js', () => ({
+  listWorkItems: vi.fn()
+}));
+vi.mock('../../services/cosTaskGenerator.js', async (importActual) => ({
+  ...(await importActual()),
+  resolveClaimWorkMetadata: vi.fn()
+}));
+
 import * as appsService from '../../services/apps.js';
 import { listOutcomesResult } from '../../services/layeredIntelligenceOutcomes.js';
+import { listWorkItems } from '../../services/workItems.js';
+import { resolveClaimWorkMetadata } from '../../services/cosTaskGenerator.js';
 
 describe('Apps Task-Type Routes', () => {
   let app;
@@ -35,6 +47,60 @@ describe('Apps Task-Type Routes', () => {
     app.use(express.json());
     app.use('/api/apps', taskTypeRoutes);
     vi.clearAllMocks();
+  });
+
+  describe('GET /api/apps/:id/work-items', () => {
+    beforeEach(() => {
+      appsService.getAppById.mockResolvedValue({ id: 'app-001', name: 'App' });
+      resolveClaimWorkMetadata.mockResolvedValue({ metadata: {}, interval: {} });
+      listWorkItems.mockResolvedValue({
+        tracker: 'github', source: 'origin', promptTaskType: 'claim-issue',
+        items: [{ ref: '7', title: 'Fix the thing' }], count: 1,
+        reason: 'actionable-issues', transient: false
+      });
+    });
+
+    it('scans with the app\'s configured author filter when the caller sends none', async () => {
+      resolveClaimWorkMetadata.mockResolvedValue({ metadata: { issueAuthorFilter: 'any' }, interval: {} });
+
+      const response = await request(app).get('/api/apps/app-001/work-items');
+
+      expect(response.status).toBe(200);
+      expect(listWorkItems).toHaveBeenCalledWith(expect.objectContaining({ id: 'app-001' }), { issueAuthorFilter: 'any' });
+      // Echoed back so the picker's select shows what was actually scanned.
+      expect(response.body.issueAuthorFilter).toBe('any');
+      expect(response.body.items).toEqual([{ ref: '7', title: 'Fix the thing' }]);
+      expect(response.body.tracker).toBe('github');
+    });
+
+    it('defaults to the self boundary when nothing is configured', async () => {
+      await request(app).get('/api/apps/app-001/work-items');
+      expect(listWorkItems).toHaveBeenCalledWith(expect.anything(), { issueAuthorFilter: 'self' });
+    });
+
+    it('lets an explicit query filter override the configured one', async () => {
+      resolveClaimWorkMetadata.mockResolvedValue({ metadata: { issueAuthorFilter: 'self' }, interval: {} });
+
+      const response = await request(app).get('/api/apps/app-001/work-items?issueAuthorFilter=owner');
+
+      expect(response.status).toBe(200);
+      expect(listWorkItems).toHaveBeenCalledWith(expect.anything(), { issueAuthorFilter: 'owner' });
+    });
+
+    it('ignores an out-of-vocabulary filter rather than passing it through', async () => {
+      resolveClaimWorkMetadata.mockResolvedValue({ metadata: { issueAuthorFilter: 'any' }, interval: {} });
+
+      await request(app).get('/api/apps/app-001/work-items?issueAuthorFilter=everyone');
+
+      expect(listWorkItems).toHaveBeenCalledWith(expect.anything(), { issueAuthorFilter: 'any' });
+    });
+
+    it('returns 404 for an unknown app', async () => {
+      appsService.getAppById.mockResolvedValue(null);
+      const response = await request(app).get('/api/apps/app-999/work-items');
+      expect(response.status).toBe(404);
+      expect(listWorkItems).not.toHaveBeenCalled();
+    });
   });
 
   describe('GET /api/apps/:id/layered-intelligence', () => {

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -946,12 +946,63 @@ describe('CoS Routes', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.id).toBe('task-sd-next');
-      expect(buildClaimWorkTask).toHaveBeenCalledWith(expect.objectContaining({ id: 'my-app' }));
+      expect(buildClaimWorkTask).toHaveBeenCalledWith(expect.objectContaining({ id: 'my-app' }), expect.any(Object));
       // The raw do:next body must NOT be inlined for the next command.
       expect(loadSlashdoCommand).not.toHaveBeenCalledWith('next');
       const [taskData] = cos.addTask.mock.calls.at(-1);
       expect(taskData.context).toBe('CLAIM ISSUE PROMPT');
       expect(taskData.description).toContain('GitHub Issues');
+    });
+
+    it('threads the run drawer settings — target/author-filter/reviewers into the claim prompt, provider/model/effort/simplify onto the task', async () => {
+      getAppById.mockResolvedValue({ id: 'my-app', name: 'MyApp', repoPath: '/repo' });
+      buildClaimWorkTask.mockResolvedValue({
+        tracker: 'github',
+        source: 'config',
+        promptTaskType: 'claim-issue',
+        prompt: 'CLAIM ISSUE PROMPT',
+        taskMetadata: { useWorktree: false, openPR: false },
+        target: '412'
+      });
+      cos.addTask.mockResolvedValue({ id: 'task-sd-target', status: 'pending' });
+
+      const response = await request(app)
+        .post('/api/cos/tasks/slashdo')
+        .send({
+          command: 'next', app: 'my-app', target: '#412', issueAuthorFilter: 'any',
+          reviewers: ['claude', 'codex'], usernames: ['alice'], optionalReviewers: ['codex'],
+          provider: 'claude-cli', model: 'claude-opus-5', effort: 'high', simplify: true
+        });
+
+      expect(response.status).toBe(200);
+      expect(buildClaimWorkTask).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'my-app' }),
+        {
+          target: '#412',
+          issueAuthorFilter: 'any',
+          reviewers: ['claude', 'codex'],
+          usernames: ['alice'],
+          optionalReviewers: ['codex']
+        }
+      );
+      const [taskData] = cos.addTask.mock.calls.at(-1);
+      expect(taskData.provider).toBe('claude-cli');
+      expect(taskData.model).toBe('claude-opus-5');
+      expect(taskData.effort).toBe('high');
+      expect(taskData.simplify).toBe(true);
+      // The claim prompt owns its own review sequence — no CoS loop on top.
+      expect(taskData.reviewLoop).toBe(false);
+      // The pinned item shows in the queue description so the row is self-explaining.
+      expect(taskData.description).toContain('412');
+    });
+
+    it('rejects an out-of-vocabulary issueAuthorFilter', async () => {
+      const response = await request(app)
+        .post('/api/cos/tasks/slashdo')
+        .send({ command: 'next', app: 'my-app', issueAuthorFilter: 'everyone' });
+
+      expect(response.status).toBe(400);
+      expect(buildClaimWorkTask).not.toHaveBeenCalled();
     });
 
     it('returns 404 when /do:next targets an unknown app', async () => {

--- a/server/routes/cosTaskRoutes.js
+++ b/server/routes/cosTaskRoutes.js
@@ -14,6 +14,7 @@ import { workTrackerLabel } from '../lib/workTracker.js';
 import { asyncHandler, ServerError, failValidation } from '../lib/errorHandler.js';
 import {
   createCosTaskSchema,
+  slashdoTaskSchema,
   updateCosTaskSchema,
   challengeTaskSchema,
   resolveChallengeSchema,
@@ -117,15 +118,20 @@ router.post('/tasks/enhance', asyncHandler(async (req, res) => {
   res.json(result);
 }));
 
-// POST /api/cos/tasks/slashdo - Create a task from a slashdo command
+// POST /api/cos/tasks/slashdo - Create a task from a slashdo command.
+//
+// The body carries the run settings the app-overview drawer collects: the
+// provider/model/effort pin and `simplify` apply to every command; `target`,
+// `issueAuthorFilter`, and the reviewer choices are `/do:next`-only (they shape
+// the claim prompt, which self-manages its own PR + review loop).
 router.post('/tasks/slashdo', asyncHandler(async (req, res) => {
-  const { command, app } = req.body;
+  const {
+    command, app, provider, model, effort, simplify,
+    target, issueAuthorFilter, reviewers, usernames, optionalReviewers
+  } = validateRequest(slashdoTaskSchema, req.body);
 
-  if (!command || !SLASHDO_COMMANDS[command]) {
+  if (!SLASHDO_COMMANDS[command]) {
     throw new ServerError(`Invalid slashdo command. Allowed: ${Object.keys(SLASHDO_COMMANDS).join(', ')}`, { status: 400, code: 'VALIDATION_ERROR' });
-  }
-  if (!app) {
-    throw new ServerError('App ID is required', { status: 400, code: 'VALIDATION_ERROR' });
   }
 
   const meta = SLASHDO_COMMANDS[command];
@@ -143,7 +149,7 @@ router.post('/tasks/slashdo', asyncHandler(async (req, res) => {
     if (!appObj) {
       throw new ServerError(`App not found: ${app}`, { status: 404, code: 'APP_NOT_FOUND' });
     }
-    const claim = await buildClaimWorkTask(appObj);
+    const claim = await buildClaimWorkTask(appObj, { target, issueAuthorFilter, reviewers, usernames, optionalReviewers });
     context = claim.prompt;
     // claim.taskMetadata overrides the false/false default only where it carries
     // a key. All current claim flows (plan-task / claim-issue / claim-issue-gitlab
@@ -151,7 +157,10 @@ router.post('/tasks/slashdo', asyncHandler(async (req, res) => {
     // stands; the spread stays for a future delegated type that needs CoS-managed
     // isolation.
     taskMetadata = { ...taskMetadata, ...claim.taskMetadata };
-    description = `Run /do:next for ${appObj.name} — claim next ${workTrackerLabel(claim.tracker)} item and ship a PR`;
+    const scope = claim.target
+      ? `claim ${workTrackerLabel(claim.tracker)} item ${claim.target}`
+      : `claim next ${workTrackerLabel(claim.tracker)} item`;
+    description = `Run /do:next for ${appObj.name} — ${scope} and ship a PR`;
   } else {
     context = await loadSlashdoCommand(command);
     if (!context) {
@@ -160,7 +169,14 @@ router.post('/tasks/slashdo', asyncHandler(async (req, res) => {
     description = `Run /do:${command} for ${app} — ${meta.description}`;
   }
 
-  const taskData = { description, app, context, ...taskMetadata, simplify: false, reviewLoop: false };
+  // `reviewLoop` stays off for every slashdo task: each `/do:*` body owns its own
+  // review/PR sequence, so a CoS-managed loop on top would double-review.
+  const taskData = {
+    description, app, context, ...taskMetadata,
+    provider, model, effort,
+    simplify: simplify === true,
+    reviewLoop: false
+  };
   const result = await cos.addTask(taskData, 'user');
 
   if (result?.duplicate) {

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -268,6 +268,44 @@ Everything not covered above (claim mechanics, branch naming, verify/skip rules,
 }
 
 /**
+ * Resolve an app's configured `claim-work` metadata the same way the scheduled
+ * router does: global schedule metadata, then per-app overrides on top (managed
+ * agent fields stripped, both passes sanitized/value-constrained). This is what
+ * carries the user's `issueAuthorFilter`, reviewer, and swarm choices into the
+ * prompt. Shared by `buildClaimWorkTask` and the work-item picker route, so the
+ * items offered are scanned with the SAME author filter the claim agent will use.
+ *
+ * @returns {Promise<{ metadata: object, interval: object }>}
+ */
+export async function resolveClaimWorkMetadata(app) {
+  const taskSchedule = await import('./taskSchedule.js');
+  // Independent reads (schedule config + per-app overrides) — the merge below
+  // needs both, but neither depends on the other.
+  const [interval, appOverrides] = await Promise.all([
+    taskSchedule.getTaskInterval('claim-work'),
+    getAppTaskTypeOverrides(app.id)
+  ]);
+  const metadata = {};
+  const sanitizedGlobalMeta = sanitizeTaskMetadata(interval.taskMetadata);
+  if (sanitizedGlobalMeta) Object.assign(metadata, sanitizedGlobalMeta);
+  const strippedAppOverride = taskSchedule.stripManagedAgentOptionsFromOverride(
+    'claim-work', appOverrides['claim-work']?.taskMetadata
+  );
+  const sanitizedAppMeta = sanitizeTaskMetadata(strippedAppOverride);
+  if (sanitizedAppMeta) Object.assign(metadata, sanitizedAppMeta);
+  return { metadata, interval };
+}
+
+/**
+ * The author filter a claim run will actually apply: explicit option >
+ * configured `claim-work` metadata > `'self'` (the slashdo `/do:next --self`
+ * security boundary — only claim issues you filed).
+ */
+export function resolveClaimAuthorFilter(explicit, metadata) {
+  return explicit ?? metadata?.issueAuthorFilter ?? 'self';
+}
+
+/**
  * Build a one-off "claim the next work item" task for `app`, routed by the app's
  * configured workTracker — the manual (Slashdo `/do:next` button) counterpart to
  * the scheduled `claim-work` router below. Resolves the tracker, delegates to the
@@ -276,7 +314,7 @@ Everything not covered above (claim mechanics, branch naming, verify/skip rules,
  * delegated flow's worktree/PR posture (all four claim prompts self-manage their
  * own worktree + MR/PR, so the self-managed false/false posture is correct).
  *
- * `issueAuthorFilter` and `reviewers` default to the app's *configured*
+ * `issueAuthorFilter` and the reviewer options default to the app's *configured*
  * `claim-work` behavior (global schedule metadata → per-app override → Code
  * Review Defaults), exactly as the scheduled `claim-work` router resolves them —
  * so clicking the button honors `issueAuthorFilter: 'any'` and non-Copilot
@@ -285,30 +323,26 @@ Everything not covered above (claim mechanics, branch naming, verify/skip rules,
  * (matching the scheduled router's `promptKeyForBody` selection). Explicit
  * options still win when a caller passes them.
  *
- * @returns {Promise<{ tracker, source, promptTaskType, prompt, taskMetadata }>}
+ * `target` pins the run to ONE work item (the drawer's "pick a specific item"
+ * mode) by appending the tracker-appropriate constraint block, overriding the
+ * prompt's own Phase 1 pick while keeping every claim safety check.
+ *
+ * @returns {Promise<{ tracker, source, promptTaskType, prompt, taskMetadata, target }>}
  */
-export async function buildClaimWorkTask(app, { issueAuthorFilter, reviewers } = {}) {
+export async function buildClaimWorkTask(app, { issueAuthorFilter, reviewers, usernames, optionalReviewers, target } = {}) {
   const { resolveAppWorkTracker, trackerToClaimTaskType } = await import('../lib/workTracker.js');
   const { getTaskPrompt } = await import('./taskPromptService.js');
   const taskSchedule = await import('./taskSchedule.js');
 
-  const wt = await resolveAppWorkTracker(app);
+  // The tracker probe (a `git` shell-out), the configured claim-work metadata,
+  // and the Code Review Defaults are mutually independent — only the prompt-body
+  // read below depends on them, so overlap the three.
+  const [wt, { metadata, interval }, codeReviewDefaults] = await Promise.all([
+    resolveAppWorkTracker(app),
+    resolveClaimWorkMetadata(app),
+    getCodeReviewDefaults().catch(() => null)
+  ]);
   const promptTaskType = trackerToClaimTaskType(wt.resolved) || 'plan-task';
-
-  // Resolve the app's configured claim-work metadata the same way the scheduled
-  // router does: global schedule metadata, then per-app overrides on top (managed
-  // agent fields stripped, both passes sanitized/value-constrained). This is what
-  // carries the user's `issueAuthorFilter` and reviewer choices into the prompt.
-  const interval = await taskSchedule.getTaskInterval('claim-work');
-  const metadata = {};
-  const sanitizedGlobalMeta = sanitizeTaskMetadata(interval.taskMetadata);
-  if (sanitizedGlobalMeta) Object.assign(metadata, sanitizedGlobalMeta);
-  const appOverrides = await getAppTaskTypeOverrides(app.id);
-  const strippedAppOverride = taskSchedule.stripManagedAgentOptionsFromOverride(
-    'claim-work', appOverrides['claim-work']?.taskMetadata
-  );
-  const sanitizedAppMeta = sanitizeTaskMetadata(strippedAppOverride);
-  if (sanitizedAppMeta) Object.assign(metadata, sanitizedAppMeta);
 
   // Honor a direct claim-work prompt customization if the user set one;
   // otherwise delegate to the resolved tracker's prompt body. Mirrors the
@@ -316,36 +350,33 @@ export async function buildClaimWorkTask(app, { issueAuthorFilter, reviewers } =
   // overrides the tracker-specific body for both paths.
   const template = await getTaskPrompt(interval.prompt ? 'claim-work' : promptTaskType);
 
-  // Explicit option > configured metadata > 'self' default (the slashdo
-  // `/do:next --self` security boundary — only claim issues you filed).
-  const resolvedAuthorFilter = issueAuthorFilter ?? metadata.issueAuthorFilter ?? 'self';
+  const resolvedAuthorFilter = resolveClaimAuthorFilter(issueAuthorFilter, metadata);
 
   // Reviewers: explicit option wins; otherwise mirror the scheduler — merge
-  // configured metadata reviewers with the user's Code Review Defaults, dropping
-  // local-LLM reviewers the claim prompts can't drive, falling back to the
-  // hardcoded default when filtering empties the list. A settings read error
-  // degrades to the default inside normalizeReviewers, so it never blocks.
-  const codeReviewDefaults = await getCodeReviewDefaults().catch(() => null);
-  let reviewersList;
-  if (reviewers !== undefined) {
-    reviewersList = (Array.isArray(reviewers) ? reviewers : [reviewers]).filter(Boolean);
-  } else {
-    reviewersList = normalizeReviewers(metadata, codeReviewDefaults?.reviewers)
-      .filter((r) => !LOCAL_LLM_REVIEWERS.includes(r));
-  }
+  // configured metadata reviewers with the user's Code Review Defaults, falling
+  // back to the hardcoded default when filtering empties the list. A settings
+  // read error degrades to the default inside normalizeReviewers, so it never
+  // blocks. Local-LLM reviewers are dropped from BOTH paths: the claim prompts
+  // drive reviewers by invoking their CLI, and lmstudio/ollama have none.
+  const reviewersList = (reviewers !== undefined
+    ? (Array.isArray(reviewers) ? reviewers : [reviewers]).filter(Boolean)
+    : normalizeReviewers(metadata, codeReviewDefaults?.reviewers)
+  ).filter((r) => !LOCAL_LLM_REVIEWERS.includes(r));
   // Arbitrary GitHub reviewer usernames appended as `@user` tokens so the
-  // claim prompt's `/do:next --review-with` gates the merge on them too. A
-  // task-level list overrides the Code Review Defaults.
-  const promptUsernames = resolveReviewUsernames(metadata.usernames, codeReviewDefaults?.usernames);
-  const promptOptionalReviewers = resolveOptionalReviewers(metadata.optionalReviewers, codeReviewDefaults?.optionalReviewers);
+  // claim prompt's `/do:next --review-with` gates the merge on them too. An
+  // explicit option wins, then a task-level list, then the Code Review Defaults.
+  const promptUsernames = resolveReviewUsernames(usernames ?? metadata.usernames, codeReviewDefaults?.usernames);
+  const promptOptionalReviewers = resolveOptionalReviewers(optionalReviewers ?? metadata.optionalReviewers, codeReviewDefaults?.optionalReviewers);
   const reviewersCsv = buildReviewersCsv(reviewersList, promptUsernames, promptOptionalReviewers);
   const issueAuthorFilterBlock = resolveIssueAuthorFilterBlock(promptTaskType, resolvedAuthorFilter);
   // Swarm mode (`/do:next --swarm`) is prepended (not an in-template
   // placeholder) so it stays an opt-in orchestration wrapper that needs no
   // prompt-default version bump; empty when swarmCount is off or the tracker
   // isn't a forge issue tracker. {reviewers} inside the block is substituted by
-  // the same replacer below.
-  const swarmBlock = resolveSwarmBlock(promptTaskType, metadata.swarmCount);
+  // the same replacer below. A pinned target claims exactly one item, so the
+  // swarm wrapper (claim N in parallel) is suppressed — the two are exclusive.
+  const targetRef = normalizeWorkItemRef(target);
+  const swarmBlock = targetRef ? '' : resolveSwarmBlock(promptTaskType, metadata.swarmCount);
 
   const prompt = `${swarmBlock}${template}`
     .replace(/\{appName\}/g, app.name)
@@ -354,7 +385,8 @@ export async function buildClaimWorkTask(app, { issueAuthorFilter, reviewers } =
     // Function-form replacers so literal `$`/`$1` in the substituted text isn't
     // interpreted as a backreference (see the scheduler's same-pattern note).
     .replace(/\{reviewers\}/g, () => reviewersCsv)
-    .replace(/\{issueAuthorFilter\}/g, () => issueAuthorFilterBlock);
+    .replace(/\{issueAuthorFilter\}/g, () => issueAuthorFilterBlock)
+    + appendTargetWorkItemBlock(promptTaskType, targetRef);
 
   // Mirror the scheduler: inherit the delegated flow's isolation posture so the
   // JIRA route runs in a CoS-managed worktree rather than the live checkout.
@@ -363,7 +395,7 @@ export async function buildClaimWorkTask(app, { issueAuthorFilter, reviewers } =
   if ('useWorktree' in delegatedMeta) taskMetadata.useWorktree = delegatedMeta.useWorktree;
   if ('openPR' in delegatedMeta) taskMetadata.openPR = delegatedMeta.openPR;
 
-  return { tracker: wt.resolved, source: wt.source, promptTaskType, prompt, taskMetadata };
+  return { tracker: wt.resolved, source: wt.source, promptTaskType, prompt, taskMetadata, target: targetRef };
 }
 
 /**
@@ -383,19 +415,65 @@ async function resolveClaimReviewersCsv() {
 }
 
 /**
- * Append a "claim exactly this ticket" constraint to the claim-issue-jira body
- * — the JIRA analogue of buildPlanConstraintBlock. The base prompt's Phase 1
- * tells the agent to PICK the next-ready ticket; this overrides that to pin the
- * user's selection while keeping every safety check (already-claimed, stale,
- * too-ambiguous → exit cleanly).
+ * Normalize a user-supplied work-item reference to the token its tracker uses:
+ * a bare issue number (`#42` / `42` → `42`), an upper-cased JIRA key
+ * (`proj-12` → `PROJ-12`), or a PLAN.md slug. Junk, oversized, or shell-unsafe
+ * input returns null so the caller falls back to "agent picks" rather than
+ * splicing an arbitrary string into the prompt.
  */
-function buildTargetTicketBlock(ticketKey) {
-  return `
-
-## Target Ticket Constraint
-
-The user explicitly selected JIRA ticket \`${ticketKey}\` from the board. Override Phase 1 ("Pick the target ticket"): do NOT pick a different ticket and do NOT scan for the next-ready one — claim exactly \`${ticketKey}\`. Still honor the safety checks: if \`${ticketKey}\` is already In Progress / In Review / Done / closed, is already on a \`claim/${ticketKey}\` (or \`cos/.../${ticketKey}/...\`) branch, or its requirements are too ambiguous or too large to implement in a single PR, exit cleanly (file a Review Hub todo for ambiguous requirements) rather than forcing it. Otherwise run Phases 2–7 against \`${ticketKey}\`.`;
+export function normalizeWorkItemRef(ref) {
+  const raw = String(ref ?? '').trim().replace(/^#/, '');
+  if (!raw || raw.length > 80) return null;
+  if (/^\d+$/.test(raw)) return raw;
+  if (/^[A-Za-z][A-Za-z0-9]*-\d+$/.test(raw)) return raw.toUpperCase();
+  if (/^[a-z0-9][a-z0-9-]*$/i.test(raw)) return raw;
+  return null;
 }
+
+// GitHub and GitLab share one claim flow (identical phases, branch naming, and
+// skip-list — only the forge CLI differs), so their constraint copy is one
+// factory rather than two paragraphs that must be edited in lockstep.
+const forgeIssueConstraint = (forge) => (ref) => `## Target Issue Constraint
+
+The user explicitly selected ${forge} issue #${ref}. Override Phase 1 ("Pick the target issue"): do NOT pick a different issue and do NOT scan for the next eligible one — claim exactly #${ref}, and ignore the author filter above (an explicit selection overrides it). Still honor the safety checks: if #${ref} is already closed, already assigned, already carries \`in-progress\` / \`blocked\` / \`needs-input\`, is already on a \`claim/issue-${ref}\` (or \`cos/.../issue-${ref}/...\`) branch, is a tracking epic, or is stale (Phase 3), exit cleanly rather than forcing it. Otherwise run Phases 2–7 against #${ref}.`;
+
+// Per-claim-flow copy for the "claim exactly this item" constraint. Each entry
+// renders the tracker's own vocabulary (issue / ticket / PLAN item) over one
+// shared shape, so the four flows can't drift apart.
+const TARGET_ITEM_BLOCKS = {
+  // Provenance-neutral: the same copy serves a user-picked target and a
+  // scheduler-reserved planId (see buildPlanConstraintBlock).
+  'plan-task': (ref) => `## Item Constraint
+
+PLAN.md item \`[${ref}]\` is reserved for this run. You MUST work on that exact item — do not pick a different one, do not brainstorm. If the line is missing from PLAN.md, has already been checked, or carries \`<!-- NEEDS_INPUT -->\`, exit cleanly without commits or PR.`,
+
+  'claim-issue': forgeIssueConstraint('GitHub'),
+  'claim-issue-gitlab': forgeIssueConstraint('GitLab'),
+
+  'claim-issue-jira': (ref) => `## Target Ticket Constraint
+
+The user explicitly selected JIRA ticket \`${ref}\` from the board. Override Phase 1 ("Pick the target ticket"): do NOT pick a different ticket and do NOT scan for the next-ready one — claim exactly \`${ref}\`. Still honor the safety checks: if \`${ref}\` is already In Progress / In Review / Done / closed, is already on a \`claim/${ref}\` (or \`cos/.../${ref}/...\`) branch, or its requirements are too ambiguous or too large to implement in a single PR, exit cleanly (file a Review Hub todo for ambiguous requirements) rather than forcing it. Otherwise run Phases 2–7 against \`${ref}\`.`
+};
+
+/**
+ * The "claim exactly this item" constraint for a claim prompt body — the
+ * generalized form of buildPlanConstraintBlock, covering all four claim flows.
+ * The base prompts' Phase 1 tells the agent to PICK the next-ready item; this
+ * overrides that to pin the user's selection while keeping every safety check
+ * (already-claimed, stale, too-large → exit cleanly). Returns the bare block
+ * (callers own their own separators), or '' when there is no target (the
+ * agent-picks default) or the flow has no constraint copy.
+ */
+export function buildTargetWorkItemBlock(promptTaskType, ref) {
+  const render = TARGET_ITEM_BLOCKS[promptTaskType];
+  return (!ref || !render) ? '' : render(ref);
+}
+
+/** The same block with the leading blank-line separator a prompt append needs. */
+const appendTargetWorkItemBlock = (promptTaskType, ref) => {
+  const block = buildTargetWorkItemBlock(promptTaskType, ref);
+  return block ? `\n\n${block}` : '';
+};
 
 /**
  * Build a one-off "implement THIS JIRA ticket" task for `app` — the per-card
@@ -414,7 +492,10 @@ The user explicitly selected JIRA ticket \`${ticketKey}\` from the board. Overri
  */
 export async function buildJiraTicketTask(app, ticketKey) {
   const { getTaskPrompt } = await import('./taskPromptService.js');
-  const key = String(ticketKey || '').toUpperCase();
+  // Same normalizer the `/do:next` target uses — one definition of "a valid work
+  // item ref". The route's Zod key regex has already rejected junk by here, so a
+  // null (unnormalizable) key can only come from a direct service caller.
+  const key = normalizeWorkItemRef(ticketKey);
 
   // Independent reads (prompt body + Code Review Defaults) — fetch concurrently.
   const [template, reviewersCsv] = await Promise.all([
@@ -428,7 +509,7 @@ export async function buildJiraTicketTask(app, ticketKey) {
     // Function-form replacer so a literal `$` in the reviewers CSV isn't read as
     // a backreference.
     .replace(/\{reviewers\}/g, () => reviewersCsv)
-    + buildTargetTicketBlock(key);
+    + appendTargetWorkItemBlock('claim-issue-jira', key);
 
   return { ticketKey: key, prompt, taskMetadata: { useWorktree: false, openPR: false } };
 }
@@ -486,14 +567,12 @@ async function applyPlanIdMetadata(taskType, repoPath, metadata) {
 /**
  * Build the `{planConstraint}` substitution block. Empty when no planId —
  * the prompt's existing Phase 1 fallback (brainstorm or exit-clean) takes over.
+ * Shares the pin-to-one-item copy with the user-selected `/do:next` target
+ * (`buildTargetWorkItemBlock`) so the two provenances can't drift.
  */
 function buildPlanConstraintBlock(planId) {
   if (!planId) return '';
-  return `
-## Item Constraint
-
-The scheduler has reserved PLAN.md item \`[${planId}]\` for you. You MUST work on that exact item — do not pick a different one, do not brainstorm. If the line is missing from PLAN.md, has already been checked, or carries \`<!-- NEEDS_INPUT -->\`, exit cleanly without commits or PR.
-`;
+  return `\n${buildTargetWorkItemBlock('plan-task', planId)}\n`;
 }
 
 /**

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -28,7 +28,7 @@ vi.mock('./codeReview.js', async (importActual) => ({
   getCodeReviewDefaults: vi.fn(async () => ({ reviewers: ['copilot'], usernames: ['alice'], optionalReviewers: [] })),
 }));
 
-import { selectDryRunAutoApproved, exceedsMaxSpawns, resolveIssueAuthorFilterBlock, resolveSwarmBlock, isCooldownExemptTask, emitOnDemandEmpty, buildJiraTicketTask, buildImprovementDedupSets } from './cosTaskGenerator.js';
+import { selectDryRunAutoApproved, exceedsMaxSpawns, resolveIssueAuthorFilterBlock, resolveSwarmBlock, isCooldownExemptTask, emitOnDemandEmpty, buildJiraTicketTask, buildImprovementDedupSets, normalizeWorkItemRef, buildTargetWorkItemBlock } from './cosTaskGenerator.js';
 import { cosEvents } from './cosEvents.js';
 import { MAX_TOTAL_SPAWNS } from '../lib/validation.js';
 
@@ -223,20 +223,76 @@ describe('claim-work single-source routing', () => {
   it('buildClaimWorkTask resolves issueAuthorFilter + reviewers from configured claim-work metadata (parity with scheduler)', () => {
     // The manual button must honor the app's configured Work Tracker behavior
     // (issueAuthorFilter:'any', non-Copilot reviewers), not force owner+copilot.
-    const fn = GEN_SRC.slice(GEN_SRC.indexOf('export async function buildClaimWorkTask('));
-    // Merges global schedule metadata then per-app overrides, same as the scheduler.
-    expect(fn).toMatch(/getTaskInterval\('claim-work'\)/);
-    expect(fn).toMatch(/getAppTaskTypeOverrides\(app\.id\)/);
-    expect(fn).toMatch(/stripManagedAgentOptionsFromOverride\(\s*'claim-work'/);
+    // The metadata merge itself lives in resolveClaimWorkMetadata, shared with the
+    // work-item picker route so both scan under the SAME author filter.
+    const resolver = GEN_SRC.slice(GEN_SRC.indexOf('export async function resolveClaimWorkMetadata('));
+    expect(resolver).toMatch(/getTaskInterval\('claim-work'\)/);
+    expect(resolver).toMatch(/getAppTaskTypeOverrides\(app\.id\)/);
+    expect(resolver).toMatch(/stripManagedAgentOptionsFromOverride\(\s*'claim-work'/);
     // issueAuthorFilter: explicit option > configured metadata > 'self'
     // (the slashdo /do:next --self security boundary).
-    expect(fn).toMatch(/issueAuthorFilter \?\? metadata\.issueAuthorFilter \?\? 'self'/);
+    expect(GEN_SRC).toMatch(/return explicit \?\? metadata\?\.issueAuthorFilter \?\? 'self'/);
+    const fn = GEN_SRC.slice(GEN_SRC.indexOf('export async function buildClaimWorkTask('));
+    expect(fn).toMatch(/resolveClaimWorkMetadata\(app\)/);
+    expect(fn).toMatch(/resolveClaimAuthorFilter\(issueAuthorFilter, metadata\)/);
     // reviewers fall back to Code Review Defaults via normalizeReviewers, dropping local-LLM reviewers.
     expect(fn).toMatch(/normalizeReviewers\(metadata, codeReviewDefaults\?\.reviewers\)/);
     expect(fn).toMatch(/LOCAL_LLM_REVIEWERS\.includes/);
     // A direct claim-work prompt customization overrides the tracker body, same
     // as the scheduled router's promptKeyForBody selection.
     expect(fn).toMatch(/getTaskPrompt\(interval\.prompt \? 'claim-work' : promptTaskType\)/);
+  });
+});
+
+// The "/do:next — pick a specific item" target. One normalizer + one block
+// builder serve all four claim flows (and the scheduler's reserved planId), so
+// the pin-to-one-item contract can't drift per tracker.
+describe('work-item target', () => {
+  describe('normalizeWorkItemRef', () => {
+    it('accepts issue numbers with or without the # prefix', () => {
+      expect(normalizeWorkItemRef('412')).toBe('412');
+      expect(normalizeWorkItemRef('#412')).toBe('412');
+      expect(normalizeWorkItemRef(' #412 ')).toBe('412');
+    });
+
+    it('upper-cases a JIRA key', () => {
+      expect(normalizeWorkItemRef('proj-1234')).toBe('PROJ-1234');
+    });
+
+    it('passes a PLAN.md slug through', () => {
+      expect(normalizeWorkItemRef('fix-the-thing')).toBe('fix-the-thing');
+    });
+
+    it('rejects absent, oversized, and shell-unsafe refs', () => {
+      expect(normalizeWorkItemRef(undefined)).toBeNull();
+      expect(normalizeWorkItemRef('')).toBeNull();
+      expect(normalizeWorkItemRef('a'.repeat(81))).toBeNull();
+      expect(normalizeWorkItemRef('12; rm -rf /')).toBeNull();
+      expect(normalizeWorkItemRef('$(whoami)')).toBeNull();
+    });
+  });
+
+  describe('buildTargetWorkItemBlock', () => {
+    it('is empty without a target, so the agent keeps its own Phase 1 pick', () => {
+      expect(buildTargetWorkItemBlock('claim-issue', null)).toBe('');
+      expect(buildTargetWorkItemBlock('claim-issue', '')).toBe('');
+    });
+
+    it('is empty for a flow with no constraint copy', () => {
+      expect(buildTargetWorkItemBlock('feature-ideas', '42')).toBe('');
+    });
+
+    it.each([
+      ['claim-issue', '42', '## Target Issue Constraint', 'claim/issue-42'],
+      ['claim-issue-gitlab', '42', '## Target Issue Constraint', 'claim/issue-42'],
+      ['claim-issue-jira', 'ACME-9', '## Target Ticket Constraint', 'claim/ACME-9'],
+      ['plan-task', 'do-thing', '## Item Constraint', 'NEEDS_INPUT']
+    ])('%s pins %s with the tracker\'s own vocabulary', (taskType, ref, heading, marker) => {
+      const block = buildTargetWorkItemBlock(taskType, ref);
+      expect(block).toContain(heading);
+      expect(block).toContain(ref);
+      expect(block).toContain(marker);
+    });
   });
 });
 
@@ -269,7 +325,7 @@ describe('buildJiraTicketTask', () => {
     expect(GEN_SRC).toContain('export async function buildJiraTicketTask(');
     // Routes the JIRA flow directly, not via buildClaimWorkTask.
     expect(GEN_SRC).toMatch(/buildJiraTicketTask[\s\S]*getTaskPrompt\('claim-issue-jira'\)/);
-    expect(GEN_SRC).toMatch(/buildJiraTicketTask[\s\S]*buildTargetTicketBlock\(key\)/);
+    expect(GEN_SRC).toMatch(/buildJiraTicketTask[\s\S]*appendTargetWorkItemBlock\('claim-issue-jira', key\)/);
   });
 });
 

--- a/server/services/perpetualWork.js
+++ b/server/services/perpetualWork.js
@@ -41,6 +41,13 @@ export const NON_ACTIONABLE_ISSUE_LABELS = new Set([
 
 const CLI_TIMEOUT_MS = 15000;
 
+// How many actionable work items a detector carries back in `items`. The
+// detectors exist for the perpetual drain (which only needs `actionable`/`count`),
+// but the same scan is what the "/do:next — pick a specific item" picker needs, so
+// each detector also returns the claimable items themselves. Capped so a repo with
+// hundreds of open issues can't balloon the response the picker renders.
+export const WORK_ITEM_LIMIT = 50;
+
 /**
  * Best-effort CLI runner mirroring git.js#spawnCli (which isn't exported).
  * Never rejects: a spawn error, non-zero exit, or timeout all resolve to a
@@ -321,7 +328,7 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self' } =
   // upstream (author filter / empty repo), never by the skip-list — so the toast
   // reads a clean "0 of N open" with no redundant "N filtered".
   const parked = (reason, total = 0) => ({
-    actionable: false, count: 0, total, inFlightCount: 0, filteredCount: 0, reason
+    actionable: false, count: 0, total, inFlightCount: 0, filteredCount: 0, items: [], reason
   });
 
   const args = [...cfg.listArgs];
@@ -405,13 +412,23 @@ async function detectForgeIssues(forgeKey, app, { issueAuthorFilter = 'self' } =
     inFlightCount,
     filteredCount,
     reason: actionable.length > 0 ? 'actionable-issues' : 'no-actionable-issues',
-    sample: actionable.slice(0, 5).map((i) => i.number)
+    sample: actionable.slice(0, 5).map((i) => i.number),
+    items: actionable.slice(0, WORK_ITEM_LIMIT).map((i) => ({ ref: String(i.number), title: i.title || '' }))
   };
 }
 
 // Forge-specific detector entry points (thin wrappers over the shared factory).
 export const detectGithubIssues = (app, opts) => detectForgeIssues('claim-issue', app, opts);
 export const detectGitlabIssues = (app, opts) => detectForgeIssues('claim-issue-gitlab', app, opts);
+
+/**
+ * Human-readable title for a PLAN.md item — the checkbox line's text with the
+ * trailing HTML comments (`<!-- NEEDS_INPUT -->`, drift markers) and surrounding
+ * whitespace stripped, so the picker shows the item, not the bookkeeping.
+ */
+function planItemTitle(item) {
+  return (item.rest || '').replace(/<!--[\s\S]*?-->/g, '').trim();
+}
 
 /**
  * plan-task detector. Mirrors applyPlanIdMetadata's pick gate: an item is
@@ -429,13 +446,14 @@ export async function detectPlanTask(app) {
   const knownIds = new Set(extractAllIds(planMd));
   const inFlight = await findInProgressIds(repoPath, knownIds).catch(() => new Set());
   const pick = pickFirstAvailable(items, inFlight);
-  const count = items.filter((it) =>
+  const available = items.filter((it) =>
     !it.checked && !it.needsInput && !it.drifted && it.id && !inFlight.has(it.id)
-  ).length;
+  );
   return {
     actionable: !!pick,
-    count,
-    reason: pick ? 'actionable-plan-items' : 'no-actionable-plan-items'
+    count: available.length,
+    reason: pick ? 'actionable-plan-items' : 'no-actionable-plan-items',
+    items: available.slice(0, WORK_ITEM_LIMIT).map((it) => ({ ref: it.id, title: planItemTitle(it) }))
   };
 }
 

--- a/server/services/perpetualWork.test.js
+++ b/server/services/perpetualWork.test.js
@@ -199,6 +199,12 @@ describe('perpetualWork', () => {
       expect(out.total).toBe(5);
       expect(out.inFlightCount).toBe(1);
       expect(out.filteredCount).toBe(2);
+      // The claimable items themselves, for the /do:next "pick a specific issue"
+      // picker — the same scan, so the list can't advertise work the run skips.
+      expect(out.items).toEqual([
+        { ref: '1', title: 'plain' },
+        { ref: '5', title: 'also plain' }
+      ]);
     });
 
     it('converges (0 actionable) on a queue whose only unblocked issue is a "[Epic]"-prefixed one with no epic label', async () => {

--- a/server/services/workItems.js
+++ b/server/services/workItems.js
@@ -1,0 +1,78 @@
+/**
+ * Claimable work-item listing for a managed app.
+ *
+ * `/do:next` normally lets the agent pick its own item. The app-overview
+ * "Run /do:next" drawer also offers picking ONE specific item, which needs the
+ * same candidate list the agent would walk. Rather than re-implementing the
+ * forge queries, this dispatches on the app's resolved Work Tracker to the
+ * detector that ALREADY produces that list:
+ *
+ *   plan   → detectPlanTask        (PLAN.md unchecked/unclaimed items)
+ *   github → detectGithubIssues    (`gh issue list` minus the claim skip-list)
+ *   gitlab → detectGitlabIssues    (`glab issue list`, same skip-list)
+ *   jira   → the app's current-sprint tickets (no detector exists for JIRA —
+ *            perpetual mode parks on 'no-detector' — so it reads the same sprint
+ *            query the app's Kanban board uses, minus already-started tickets)
+ *
+ * Sentinel discipline (CLAUDE.md): a failed probe returns `items: []` WITH the
+ * detector's `reason` + `transient: true`, so the caller can say "couldn't
+ * reach the tracker" instead of the lie "no work available".
+ */
+
+import { resolveAppWorkTracker, trackerToClaimTaskType } from '../lib/workTracker.js';
+import { detectActionableWork, WORK_ITEM_LIMIT } from './perpetualWork.js';
+import { fetchMyCurrentSprintTickets } from './jira.js';
+
+// JIRA statuses whose tickets are already underway or finished — the claim flow
+// skips them (claim-issue-jira Phase 1), so they never belong in the picker.
+const JIRA_SKIP_CATEGORIES = new Set(['In Progress', 'Done']);
+
+/**
+ * Current-sprint tickets for a JIRA-tracked app, shaped like a detector result.
+ * Only the tickets the claim flow would consider (not already In Progress/Done).
+ * A missing JIRA config is a definitive "nothing to pick"; a fetch failure is
+ * transient so the UI says "couldn't load" rather than "no tickets".
+ */
+async function listJiraTickets(app) {
+  const { instanceId, projectKey } = app?.jira || {};
+  if (!app?.jira?.enabled || !instanceId || !projectKey) {
+    return { items: [], count: 0, reason: 'jira-not-configured' };
+  }
+  const tickets = await fetchMyCurrentSprintTickets(instanceId, projectKey).catch((err) => {
+    console.warn(`⚠️ JIRA work-item fetch failed for ${projectKey}: ${err.message}`);
+    return null;
+  });
+  if (!tickets) return { items: [], count: 0, reason: 'jira-fetch-failed', transient: true };
+  const open = tickets.filter(t => !JIRA_SKIP_CATEGORIES.has(t.statusCategory));
+  return {
+    items: open.slice(0, WORK_ITEM_LIMIT).map(t => ({ ref: t.key, title: t.summary || '', url: t.url })),
+    count: open.length,
+    reason: open.length > 0 ? 'actionable-tickets' : 'no-open-tickets'
+  };
+}
+
+/**
+ * List the work items `/do:next` could claim for `app`, honoring the same
+ * author filter the claim flow uses on forge trackers.
+ *
+ * @param {object} app - managed app record (needs `id`, `repoPath`, `jira`)
+ * @param {{ issueAuthorFilter?: 'self'|'owner'|'any' }} [opts]
+ * @returns {Promise<{tracker, source, promptTaskType, items, count, reason, transient}>}
+ */
+export async function listWorkItems(app, { issueAuthorFilter } = {}) {
+  const wt = await resolveAppWorkTracker(app);
+  const promptTaskType = trackerToClaimTaskType(wt.resolved) || 'plan-task';
+  const base = { tracker: wt.resolved, source: wt.source, promptTaskType };
+
+  const result = promptTaskType === 'claim-issue-jira'
+    ? await listJiraTickets(app)
+    : await detectActionableWork(promptTaskType, app, issueAuthorFilter ? { issueAuthorFilter } : {});
+
+  return {
+    ...base,
+    items: Array.isArray(result.items) ? result.items : [],
+    count: Number.isFinite(result.count) ? result.count : 0,
+    reason: result.reason || null,
+    transient: result.transient === true
+  };
+}

--- a/server/services/workItems.test.js
+++ b/server/services/workItems.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../lib/workTracker.js', async (importActual) => ({
+  ...(await importActual()),
+  resolveAppWorkTracker: vi.fn()
+}));
+vi.mock('./perpetualWork.js', () => ({
+  detectActionableWork: vi.fn(),
+  WORK_ITEM_LIMIT: 50
+}));
+vi.mock('./jira.js', () => ({
+  fetchMyCurrentSprintTickets: vi.fn()
+}));
+
+import { resolveAppWorkTracker } from '../lib/workTracker.js';
+import { detectActionableWork } from './perpetualWork.js';
+import { fetchMyCurrentSprintTickets } from './jira.js';
+import { listWorkItems } from './workItems.js';
+
+const app = { id: 'acme', repoPath: '/repos/acme' };
+
+describe('listWorkItems', () => {
+  beforeEach(() => {
+    resolveAppWorkTracker.mockReset();
+    detectActionableWork.mockReset();
+    fetchMyCurrentSprintTickets.mockReset();
+  });
+
+  it('delegates a forge tracker to the claim detector, honoring the author filter', async () => {
+    resolveAppWorkTracker.mockResolvedValue({ resolved: 'github', source: 'origin' });
+    detectActionableWork.mockResolvedValue({
+      actionable: true, count: 2, reason: 'actionable-issues',
+      items: [{ ref: '7', title: 'Fix the thing' }, { ref: '9', title: 'Add the other' }]
+    });
+
+    const out = await listWorkItems(app, { issueAuthorFilter: 'any' });
+
+    expect(detectActionableWork).toHaveBeenCalledWith('claim-issue', app, { issueAuthorFilter: 'any' });
+    expect(out).toMatchObject({
+      tracker: 'github',
+      promptTaskType: 'claim-issue',
+      count: 2,
+      reason: 'actionable-issues',
+      transient: false
+    });
+    expect(out.items).toHaveLength(2);
+  });
+
+  it('routes PLAN.md apps to the plan-task detector', async () => {
+    resolveAppWorkTracker.mockResolvedValue({ resolved: 'plan', source: 'fallback' });
+    detectActionableWork.mockResolvedValue({ actionable: true, count: 1, reason: 'actionable-plan-items', items: [{ ref: 'do-thing', title: 'Do the thing' }] });
+
+    const out = await listWorkItems(app);
+
+    expect(detectActionableWork).toHaveBeenCalledWith('plan-task', app, {});
+    expect(out.tracker).toBe('plan');
+    expect(out.items).toEqual([{ ref: 'do-thing', title: 'Do the thing' }]);
+  });
+
+  it('surfaces a transient probe failure as transient with an empty list (not "no work")', async () => {
+    resolveAppWorkTracker.mockResolvedValue({ resolved: 'gitlab', source: 'origin' });
+    detectActionableWork.mockResolvedValue({ actionable: false, count: 0, reason: 'glab-list-failed', transient: true });
+
+    const out = await listWorkItems(app);
+
+    expect(out).toMatchObject({ tracker: 'gitlab', items: [], count: 0, reason: 'glab-list-failed', transient: true });
+  });
+
+  it('lists JIRA sprint tickets, skipping ones already started or done', async () => {
+    resolveAppWorkTracker.mockResolvedValue({ resolved: 'jira', source: 'configured' });
+    fetchMyCurrentSprintTickets.mockResolvedValue([
+      { key: 'ACME-1', summary: 'Ready to go', statusCategory: 'To Do', url: 'https://example.com/browse/ACME-1' },
+      { key: 'ACME-2', summary: 'Underway', statusCategory: 'In Progress' },
+      { key: 'ACME-3', summary: 'Finished', statusCategory: 'Done' }
+    ]);
+
+    const out = await listWorkItems({ ...app, jira: { enabled: true, instanceId: 'i1', projectKey: 'ACME' } });
+
+    expect(detectActionableWork).not.toHaveBeenCalled();
+    expect(out.tracker).toBe('jira');
+    expect(out.items).toEqual([{ ref: 'ACME-1', title: 'Ready to go', url: 'https://example.com/browse/ACME-1' }]);
+    expect(out.reason).toBe('actionable-tickets');
+  });
+
+  it('reports jira-not-configured rather than probing when the app has no JIRA config', async () => {
+    resolveAppWorkTracker.mockResolvedValue({ resolved: 'jira', source: 'configured' });
+
+    const out = await listWorkItems(app);
+
+    expect(fetchMyCurrentSprintTickets).not.toHaveBeenCalled();
+    expect(out).toMatchObject({ items: [], reason: 'jira-not-configured', transient: false });
+  });
+
+  it('marks a failed JIRA fetch transient so the UI says "couldn\'t load", not "no tickets"', async () => {
+    resolveAppWorkTracker.mockResolvedValue({ resolved: 'jira', source: 'configured' });
+    fetchMyCurrentSprintTickets.mockRejectedValue(new Error('502 from JIRA'));
+
+    const out = await listWorkItems({ ...app, jira: { enabled: true, instanceId: 'i1', projectKey: 'ACME' } });
+
+    expect(out).toMatchObject({ items: [], reason: 'jira-fetch-failed', transient: true });
+  });
+});


### PR DESCRIPTION
## Summary

Clicking `/do:next` on a managed app's Overview queued a run against the app's stored defaults with no chance to redirect it — you could not aim it at a specific work item, nor change the provider/model/effort, simplify, or reviewer gate for that one run.

The button now opens a settings drawer that:

- Pins an optional **specific work item** into the claim prompt, resolved live from whichever tracker the app's Work Tracker points at (PLAN.md items, GitHub/GitLab issues, or current-sprint JIRA tickets). Leaving it on "let the agent pick" preserves the old behavior.
- Sets the run's **provider, model, and thinking effort**, whether to **simplify** before committing, and the **review-loop reviewers** (including GitHub reviewer usernames and optional/non-blocking marks) that gate the PR merge.

Left untouched, the drawer reproduces exactly the run the old one-click button queued.

A pinned item still passes every claim safety check (already assigned, blocked, in flight, epic → exit cleanly) — pinning chooses which item to *attempt*, it does not bypass the gates.

New modules: `server/services/workItems.js` (tracker-agnostic claimable-work resolver), `client/src/components/apps/WorkItemPicker.jsx`, `client/src/components/apps/SlashDoRunDrawer.jsx`, `client/src/components/cos/EffortSelect.jsx`.

## Test plan

- `cd server && npx vitest run services/workItems services/perpetualWork services/cosTaskGenerator routes/apps/taskTypes routes/cos.test.js lib/cosValidation` — 330 passing
- `cd client && npx vitest run src/components/apps src/components/cos` — 217 passing
- New suites: `server/services/workItems.test.js`, `client/src/components/apps/SlashDoRunDrawer.test.jsx`