### PR TITLE
feat(sprites): unlock main references for revision

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -6,6 +6,7 @@
 
 ## Sprites
 
+- Locked main references can now be explicitly reopened from Sprite Manager while keeping the turnaround and the other directional anchors intact. Reopening the main preserves versioned evidence, clears only the south identity, and reopens its dependent walk/scanner approvals so a better turnaround-derived main can be reviewed and locked as the next version.
 - Sprite turnaround and directional-reference candidates now request a square canvas from image generation and explicitly treat the locked turnaround as the source of truth for accessory side and occlusion. This prevents arbitrary Codex ImageGen candidate aspect ratios and reduces mirrored hip-bag drift before an anchor is locked.
 
 ## CoS agent failure reporting

--- a/client/src/components/sprites/ReferenceWorkflow.jsx
+++ b/client/src/components/sprites/ReferenceWorkflow.jsx
@@ -6,7 +6,7 @@ import {
 import toast from '../ui/Toast';
 import {
   generateSpriteReference, lockSpriteReference,
-  unlockSpriteReferenceAnchor, unlockSpriteTurnaround, updateSpriteRecord,
+  unlockSpriteReferenceAnchor, unlockSpriteMainReference, unlockSpriteTurnaround, updateSpriteRecord,
 } from '../../services/apiSprites.js';
 import { useAsyncAction } from '../../hooks/useAsyncAction.js';
 import SpritePreview from './SpritePreview.jsx';
@@ -257,9 +257,13 @@ export default function ReferenceWorkflow({ record, reference, renders, correcti
   const [galleryOpen, setGalleryOpen] = useState(false);
   const [spritePickerOpen, setSpritePickerOpen] = useState(false);
   const [forkOpen, setForkOpen] = useState(false);
+  const [mainUnlockConfirming, setMainUnlockConfirming] = useState(false);
   const [turnaroundUnlockConfirming, setTurnaroundUnlockConfirming] = useState(false);
   const [turnaroundCorrections, setTurnaroundCorrections] = useState({});
-  useEffect(() => { setTurnaroundUnlockConfirming(false); }, [recordId]);
+  useEffect(() => {
+    setMainUnlockConfirming(false);
+    setTurnaroundUnlockConfirming(false);
+  }, [recordId]);
   useEffect(() => { setTurnaroundCorrections({}); }, [recordId]);
 
   // Revoke the previous upload's object URL whenever the source changes or the
@@ -363,6 +367,15 @@ export default function ReferenceWorkflow({ record, reference, renders, correcti
       : `${direction} anchor unlocked`);
     onChanged();
   }, { errorMessage: 'Failed to unlock anchor' });
+
+  const [unlockMain, mainUnlocking] = useAsyncAction(async () => {
+    const result = await unlockSpriteMainReference(recordId, { silent: true });
+    toast.success(result.walkInvalidated || result.scannerInvalidated
+      ? 'Main reference unlocked; its south animations were reopened'
+      : 'Main reference unlocked; ready to regenerate from the turnaround');
+    setMainUnlockConfirming(false);
+    onChanged();
+  }, { errorMessage: 'Failed to unlock main reference' });
 
   const [unlockTurnaround, turnaroundUnlocking] = useAsyncAction(async () => {
     const result = await unlockSpriteTurnaround(recordId, { silent: true });
@@ -711,8 +724,43 @@ export default function ReferenceWorkflow({ record, reference, renders, correcti
                   <Lock className="h-3.5 w-3.5" /> Frozen · turnaround-derived
                 </p>
                 <p className="text-[11px] leading-relaxed text-gray-500">
-                  This front-facing reference seeds thumbnails and the walk-south identity. Fork for a separate character, or reopen the turnaround to rebuild this reference chain.
+                  This front-facing reference seeds thumbnails and the walk-south identity. Reopen it to derive a better front view from this turnaround, or reopen the turnaround to rebuild the full reference chain.
                 </p>
+                {turnaroundLocked && (mainUnlockConfirming ? (
+                  <div className="rounded border border-port-warning/40 bg-port-warning/10 p-2 text-[11px]">
+                    <p className="text-port-warning">
+                      Reopen the main reference and its south walk/scanner? The turnaround and other directions stay locked; existing files remain in history.
+                    </p>
+                    <div className="mt-2 flex gap-2">
+                      <button
+                        type="button"
+                        aria-label="Confirm unlock main reference"
+                        onClick={unlockMain}
+                        disabled={mainUnlocking}
+                        className="flex-1 rounded bg-port-warning px-2 py-1.5 font-medium text-black disabled:opacity-50"
+                      >
+                        {mainUnlocking ? 'Unlocking…' : 'Unlock for regeneration'}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setMainUnlockConfirming(false)}
+                        disabled={mainUnlocking}
+                        className="rounded px-2 py-1.5 text-gray-400 hover:text-white disabled:opacity-50"
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => setMainUnlockConfirming(true)}
+                    disabled={mainUnlocking}
+                    className="flex min-h-9 w-full items-center justify-center gap-1.5 rounded border border-port-border bg-port-card px-2.5 py-1.5 text-xs text-gray-300 hover:border-port-warning hover:text-port-warning disabled:opacity-50"
+                  >
+                    <Unlock className="h-3.5 w-3.5" /> Unlock main reference
+                  </button>
+                ))}
                 <button
                   type="button"
                   onClick={() => setForkOpen(true)}

--- a/client/src/components/sprites/ReferenceWorkflow.test.jsx
+++ b/client/src/components/sprites/ReferenceWorkflow.test.jsx
@@ -6,6 +6,7 @@ vi.mock('../../services/apiSprites.js', () => ({
   generateSpriteReference: vi.fn(() => Promise.resolve({ jobId: 'job-1' })),
   lockSpriteReference: vi.fn(() => Promise.resolve({})),
   unlockSpriteReferenceAnchor: vi.fn(() => Promise.resolve({ walkInvalidated: true })),
+  unlockSpriteMainReference: vi.fn(() => Promise.resolve({ walkInvalidated: true })),
   unlockSpriteTurnaround: vi.fn(() => Promise.resolve({
     walkInvalidatedDirections: ['south', 'east'],
   })),
@@ -28,7 +29,7 @@ vi.mock('./SpritePreview.jsx', () => ({
 import ReferenceWorkflow from './ReferenceWorkflow.jsx';
 import {
   generateSpriteReference,
-  unlockSpriteReferenceAnchor, unlockSpriteTurnaround,
+  unlockSpriteReferenceAnchor, unlockSpriteMainReference, unlockSpriteTurnaround,
 } from '../../services/apiSprites.js';
 
 const DIRECTIONS = ['south', 'south-east', 'east', 'north-east', 'north', 'north-west', 'west', 'south-west'];
@@ -144,6 +145,23 @@ describe('ReferenceWorkflow workspace', () => {
       'example-pioneer',
       { silent: true },
     );
+  });
+
+  it('reopens the main while retaining the locked turnaround', async () => {
+    const user = userEvent.setup();
+    unlockSpriteMainReference.mockClear();
+    renderWorkflow({
+      turnaround: {
+        locked: true,
+        path: 'reference/example-pioneer-turnaround-v1.png',
+      },
+    });
+
+    const main = screen.getByRole('region', { name: 'Main reference' });
+    await user.click(within(main).getByRole('button', { name: 'Unlock main reference' }));
+    expect(within(main).getByText(/Reopen the main reference and its south walk\/scanner/)).toBeInTheDocument();
+    await user.click(within(main).getByRole('button', { name: 'Confirm unlock main reference' }));
+    expect(unlockSpriteMainReference).toHaveBeenCalledWith('example-pioneer', { silent: true });
   });
 
   it('re-processes one turnaround attempt with its own correction note', async () => {

--- a/client/src/services/apiSprites.js
+++ b/client/src/services/apiSprites.js
@@ -90,6 +90,13 @@ export const unlockSpriteReferenceAnchor = (id, body, options = {}) => request(`
   method: 'POST', body: JSON.stringify(body), ...options,
 });
 
+// Re-open the main (south) reference while preserving the locked turnaround
+// and other directional anchors. Any dependent south walk/scanner is reopened.
+export const unlockSpriteMainReference = (id, options = {}) => request(
+  `/sprites/${encodeURIComponent(id)}/reference/main/unlock`,
+  { method: 'POST', ...options },
+);
+
 // Re-open the turnaround identity root and its full dependent chain. Old
 // versioned references, walks, and atlases remain available as history.
 export const unlockSpriteTurnaround = (id, options = {}) => request(

--- a/server/routes/sprites.js
+++ b/server/routes/sprites.js
@@ -54,7 +54,7 @@ import { WALK_TRACK, SCANNER_TRACK, AMBIENT_TRACK, kindSupportsTrack, tracksForK
 import {
   getWalkState, startWalkGeneration, approveWalkDirection, rerunWalkPostprocess, unlockWalkSet,
   reopenWalkDirection, setWalkTarget, getWalkSourceFrames,
-  unlockDirectionalAnchor, unlockTurnaroundReference,
+  unlockDirectionalAnchor, unlockMainReference, unlockTurnaroundReference,
 } from '../services/sprites/walk.js';
 import { getScannerState, startScannerGeneration, approveScannerDirection } from '../services/sprites/scanner.js';
 import { getAmbientState, startAmbientGeneration, approveAmbientLoop } from '../services/sprites/ambient.js';
@@ -175,6 +175,13 @@ router.post('/:id/reference/lock', asyncHandler(async (req, res) => {
 router.post('/:id/reference/unlock', asyncHandler(async (req, res) => {
   const body = validateRequest(spriteReferenceUnlockSchema, req.body);
   res.json(await unlockDirectionalAnchor(req.params.id, body));
+}));
+
+// Re-open the main (south) reference while keeping the turnaround and the
+// other directional anchors locked. Its dependent walk/scanner approvals are
+// invalidated so they cannot survive a changed source image.
+router.post('/:id/reference/main/unlock', asyncHandler(async (req, res) => {
+  res.json(await unlockMainReference(req.params.id));
 }));
 
 // Re-open the turnaround identity root for regeneration. This deliberately

--- a/server/routes/sprites.test.js
+++ b/server/routes/sprites.test.js
@@ -45,6 +45,12 @@ vi.mock('../services/sprites/walk.js', () => ({
     candidates: [],
     walkInvalidated: true,
   })),
+  unlockMainReference: vi.fn(async () => ({
+    manifest: { status: 'needs-main-reference' },
+    candidates: [],
+    walkInvalidated: true,
+    scannerInvalidated: false,
+  })),
   unlockTurnaroundReference: vi.fn(async () => ({
     manifest: { status: 'needs-turnaround' },
     candidates: [],
@@ -370,6 +376,15 @@ describe('sprites routes', () => {
     const south = await request(app).post('/api/sprites/pioneer/reference/unlock').send({ direction: 'south' });
     expect(south.status).toBe(400);
     expect(walk.unlockDirectionalAnchor).toHaveBeenCalledTimes(1);
+  });
+
+  it('POST /:id/reference/main/unlock reopens only the main reference chain', async () => {
+    const unlocked = await request(app)
+      .post('/api/sprites/pioneer/reference/main/unlock')
+      .send();
+    expect(unlocked.status).toBe(200);
+    expect(unlocked.body.manifest.status).toBe('needs-main-reference');
+    expect(walk.unlockMainReference).toHaveBeenCalledWith('pioneer');
   });
 
   it('POST /:id/reference/turnaround/unlock reopens the full dependent chain', async () => {

--- a/server/services/sprites/reference.js
+++ b/server/services/sprites/reference.js
@@ -16,9 +16,10 @@
  *
  * Evidence contract: a locked artifact is never overwritten. A
  * turnaround-derived directional anchor may be deliberately reopened on its
- * own; the turnaround may also be deliberately reopened together with every
- * artifact that descends from it. In either revision flow the old versioned
- * PNG stays on disk and the replacement lands at the next `-vN` filename.
+ * own; the main may be deliberately reopened while retaining its turnaround;
+ * the turnaround may also be deliberately reopened together with every
+ * artifact that descends from it. In every revision flow the old versioned PNG
+ * stays on disk and the replacement lands at the next `-vN` filename.
  */
 
 import { join } from 'path';
@@ -796,6 +797,15 @@ export function unlockReferenceAnchor(recordId, args) {
 }
 
 /**
+ * Re-open the main (south) reference while retaining the locked turnaround
+ * and the independent directional anchors derived from it. The walk service
+ * coordinates invalidating the south animations before this manifest reset.
+ */
+export function unlockReferenceMain(recordId) {
+  return manifestWriteTail(recordId, () => unlockReferenceMainImpl(recordId));
+}
+
+/**
  * Re-open the turnaround identity root and every reference artifact derived
  * from it. The walk service coordinates dependent animation invalidation before
  * calling this write; this layer owns only the reference manifest reset.
@@ -829,6 +839,24 @@ async function loadUnlockableReferenceAnchor(recordId, direction) {
 // reopened; unlockReferenceAnchor repeats the check inside its write tail.
 export async function assertReferenceAnchorUnlockable(recordId, { direction }) {
   await loadUnlockableReferenceAnchor(recordId, direction);
+}
+
+async function loadUnlockableReferenceMain(recordId) {
+  await requireCharacter(recordId);
+  const manifest = await loadManifest(recordId);
+  if (!manifest?.turnaround?.locked) {
+    throw new ServerError('Lock the turnaround sheet before revising the main reference', { status: 409, code: 'TURNAROUND_NOT_LOCKED' });
+  }
+  if (!manifest.mainReference?.locked) {
+    throw new ServerError('Main reference is not locked', { status: 409, code: 'MAIN_NOT_LOCKED' });
+  }
+  return { manifest };
+}
+
+// Read-only preflight for the cross-service revision coordinator. A south walk
+// approval must not be invalidated unless the main pointer can be reopened.
+export async function assertReferenceMainUnlockable(recordId) {
+  await loadUnlockableReferenceMain(recordId);
 }
 
 async function loadUnlockableReferenceTurnaround(recordId) {
@@ -865,6 +893,34 @@ async function unlockReferenceAnchorImpl(recordId, { direction }) {
   await updateRecord(recordId, { status: 'reference' });
   await saveManifest(recordId, manifest);
   console.log(`🔓 sprite reference anchor ${recordId}/${direction} unlocked`);
+  return getReferenceSet(recordId);
+}
+
+async function unlockReferenceMainImpl(recordId) {
+  const { manifest } = await loadUnlockableReferenceMain(recordId);
+  manifest.mainReference = {
+    path: null,
+    role: 'immutable-root',
+    background: 'chroma-key',
+    locked: false,
+  };
+  const south = findAnchor(manifest, anchorIdForDirection('south'));
+  if (south) Object.assign(south, {
+    status: 'pending',
+    source: 'main-reference',
+  });
+  if (south) {
+    delete south.path;
+    delete south.lockedFrom;
+    delete south.lockedAt;
+    delete south.sha256;
+    delete south.clipWarning;
+  }
+  manifest.status = 'needs-main-reference';
+
+  await updateRecord(recordId, { status: 'reference' });
+  await saveManifest(recordId, manifest);
+  console.log(`🔓 sprite main reference ${recordId} unlocked with south anchor reset`);
   return getReferenceSet(recordId);
 }
 

--- a/server/services/sprites/reference.test.js
+++ b/server/services/sprites/reference.test.js
@@ -53,7 +53,7 @@ vi.mock('../settings.js', () => ({ getSettings: async () => settings }));
 const records = await import('./records.js');
 const {
   getReferenceSet, startReferenceGeneration, attachReferenceCandidate, lockReference, patchSpriteRecord,
-  unlockReferenceAnchor, unlockReferenceTurnaround,
+  unlockReferenceAnchor, unlockReferenceMain, unlockReferenceTurnaround,
   listReferenceSources, listSpriteThumbnails, forkSprite,
   requireCharacter, requireAnimatable,
 } = await import('./reference.js');
@@ -859,6 +859,40 @@ describe('lockReference', () => {
       .rejects.toMatchObject({ status: 400, code: 'INVALID_TARGET' });
     await expect(unlockReferenceAnchor(id, { direction: 'east' }))
       .rejects.toMatchObject({ status: 409, code: 'ANCHOR_NOT_LOCKED' });
+  });
+
+  it('reopens the main and south anchor while retaining the turnaround and other anchors', async () => {
+    const id = newId();
+    await createCharacter(id);
+    const first = await lockMain(id);
+    const eastCandidate = await placeCandidate(id, 'east', 'walk-east-candidate-01.png');
+    const withEast = await lockReference(id, { target: 'east', candidate: eastCandidate });
+    const oldMainPath = first.manifest.mainReference.path;
+    const oldEastPath = withEast.manifest.anchors.find((anchor) => anchor.direction === 'east').path;
+
+    const reopened = await unlockReferenceMain(id);
+    expect(reopened.manifest).toMatchObject({
+      status: 'needs-main-reference',
+      turnaround: { locked: true },
+      mainReference: { locked: false, path: null },
+    });
+    expect(reopened.manifest.anchors.find((anchor) => anchor.direction === 'south'))
+      .toMatchObject({ status: 'pending', source: 'main-reference' });
+    expect(reopened.manifest.anchors.find((anchor) => anchor.direction === 'east'))
+      .toMatchObject({ status: 'locked', path: oldEastPath });
+    expect(await readFile(join(TEST_ROOT, 'sprites', id, oldMainPath))).toBeTruthy();
+
+    await startReferenceGeneration(id, { target: 'main' });
+    const replacement = await placeCandidate(id, 'main', 'walk-south-candidate-02.png');
+    const relocked = await lockReference(id, { target: 'main', candidate: replacement });
+    expect(relocked.manifest.mainReference.path).toBe(`reference/${id}-walk-south-v2.png`);
+  });
+
+  it('refuses to reopen a main reference without a locked turnaround', async () => {
+    const id = newId();
+    await createCharacter(id);
+    await expect(unlockReferenceMain(id))
+      .rejects.toMatchObject({ status: 409, code: 'TURNAROUND_NOT_LOCKED' });
   });
 
   it('reopens the full turnaround chain, preserves v1 evidence, and relocks the sheet as v2', async () => {

--- a/server/services/sprites/walk.js
+++ b/server/services/sprites/walk.js
@@ -37,6 +37,7 @@ import {
 import {
   requireCharacter, loadManifest,
   assertReferenceAnchorUnlockable, unlockReferenceAnchor,
+  assertReferenceMainUnlockable, unlockReferenceMain,
   assertReferenceTurnaroundUnlockable, unlockReferenceTurnaround,
 } from './reference.js';
 import { SPRITE_DIRECTIONS, anchorIdForDirection, buildWalkVideoPrompt } from './prompts.js';
@@ -1878,6 +1879,19 @@ export async function unlockDirectionalAnchor(recordId, { direction }) {
   const walkInvalidated = await invalidateWalkDirectionForAnchorRevision(recordId, { direction });
   const scannerInvalidated = await invalidateScannerDirectionForAnchorRevision(recordId, { direction });
   const reference = await unlockReferenceAnchor(recordId, { direction });
+  return { ...reference, walkInvalidated, scannerInvalidated };
+}
+
+/**
+ * Reopen the main (south) reference and invalidate only animations conditioned
+ * on it. The locked turnaround and every non-south anchor remain usable.
+ */
+export async function unlockMainReference(recordId) {
+  await assertReferenceMainUnlockable(recordId);
+  const direction = 'south';
+  const walkInvalidated = await invalidateWalkDirectionForAnchorRevision(recordId, { direction });
+  const scannerInvalidated = await invalidateScannerDirectionForAnchorRevision(recordId, { direction });
+  const reference = await unlockReferenceMain(recordId);
   return { ...reference, walkInvalidated, scannerInvalidated };
 }
 

--- a/server/services/sprites/walk.test.js
+++ b/server/services/sprites/walk.test.js
@@ -122,7 +122,7 @@ const { lockReference } = await import('./reference.js');
 const {
   getWalkState, startWalkGeneration, attachTuiWalkResult, approveWalkDirection, rerunWalkPostprocess, unlockWalkSet,
   reopenWalkDirection, invalidateWalkDirectionForAnchorRevision,
-  unlockDirectionalAnchor, unlockTurnaroundReference,
+  unlockDirectionalAnchor, unlockMainReference, unlockTurnaroundReference,
   setWalkTarget, importedWalkDirections, getWalkSourceFrames,
 } = await import('./walk.js');
 const { SPRITE_DIRECTIONS, ANCHOR_DIRECTIONS } = await import('./prompts.js');
@@ -1040,6 +1040,24 @@ describe('invalidateWalkDirectionForAnchorRevision', () => {
       });
     }
     expect((await records.getRecord(id)).status).toBe('reference');
+  });
+
+  it('invalidates only south before reopening the main reference', async () => {
+    const id = await characterWithLockedAnchors(newId(), ['south', 'east']);
+    const south = await makeCandidateRun(id, 'south');
+    const east = await makeCandidateRun(id, 'east');
+    await approveWalkDirection(id, { direction: 'south', runId: south.runId });
+    await approveWalkDirection(id, { direction: 'east', runId: east.runId });
+
+    const result = await unlockMainReference(id);
+    const state = await getWalkState(id);
+    expect(result.walkInvalidated).toBe(true);
+    expect(result.manifest.turnaround.locked).toBe(true);
+    expect(result.manifest.mainReference).toMatchObject({ locked: false, path: null });
+    expect(result.manifest.anchors.find((anchor) => anchor.direction === 'south')).toMatchObject({ status: 'pending' });
+    expect(result.manifest.anchors.find((anchor) => anchor.direction === 'east')).toMatchObject({ status: 'locked' });
+    expect(state.selection.directions.south).toBeUndefined();
+    expect(state.selection.directions.east.status).toBe('approved');
   });
 });
 


### PR DESCRIPTION
## Summary
- add a confirmed main-reference unlock action in Sprite Manager
- retain turnaround and non-south anchors while preserving versioned evidence
- invalidate only south-dependent walk and scanner approvals before regeneration

## Testing
- `npm test -- --run services/sprites/reference.test.js services/sprites/walk.test.js routes/sprites.test.js` (server)
- `npm test -- --run src/components/sprites/ReferenceWorkflow.test.jsx` (client)
- `npm run lint --prefix client`