### PR TITLE
fix(cos): streamline task approvals

### DIFF
--- a/client/src/components/cos/ActionableInsightsBanner.jsx
+++ b/client/src/components/cos/ActionableInsightsBanner.jsx
@@ -98,6 +98,7 @@ const PRIORITY_STYLES = {
 export default function ActionableInsightsBanner({ insights, onTaskUnblocked, onRefresh }) {
   const [dismissed, setDismissed] = useState([]);
   const [expanded, setExpanded] = useState({});
+  const [approvingTaskId, setApprovingTaskId] = useState(null);
   const navigate = useNavigate();
 
   const handleDismiss = (type) => {
@@ -105,6 +106,10 @@ export default function ActionableInsightsBanner({ insights, onTaskUnblocked, on
   };
 
   const handleAction = (insight) => {
+    if (insight.type === 'approval' && insight.tasks?.[0]) {
+      handleApproveTask(insight.tasks[0]);
+      return;
+    }
     // For blocked insights, toggle expand to show individual tasks
     if (insight.type === 'blocked' && insight.tasks?.length > 0) {
       setExpanded(prev => ({ ...prev, [insight.type]: !prev[insight.type] }));
@@ -113,6 +118,18 @@ export default function ActionableInsightsBanner({ insights, onTaskUnblocked, on
     if (insight.action?.route) {
       navigate(insight.action.route);
     }
+  };
+
+  const handleApproveTask = async (task) => {
+    setApprovingTaskId(task.id);
+    const result = await api.approveCosTask(task.id, { silent: true }).catch(err => {
+      toast.error(err.message);
+      return null;
+    });
+    setApprovingTaskId(null);
+    if (!result) return;
+    toast.success('Task approved');
+    onRefresh?.();
   };
 
   const handleUnblockTask = async (taskId, taskType) => {
@@ -146,6 +163,7 @@ export default function ActionableInsightsBanner({ insights, onTaskUnblocked, on
   const Icon = ICON_MAP[primaryInsight.icon] || AlertCircle;
   const isExpanded = expanded[primaryInsight.type];
   const hasBlockedTasks = primaryInsight.type === 'blocked' && primaryInsight.tasks?.length > 0;
+  const approvalTask = primaryInsight.type === 'approval' ? primaryInsight.tasks?.[0] : null;
 
   return (
     <div className={`${styles.bg} border ${styles.border} rounded-lg p-3 mb-4 transition-all`}>
@@ -209,12 +227,15 @@ export default function ActionableInsightsBanner({ insights, onTaskUnblocked, on
           {primaryInsight.action && (
             <button
               onClick={() => handleAction(primaryInsight)}
+              disabled={Boolean(approvalTask && approvingTaskId === approvalTask.id)}
               className="flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium bg-white/10 hover:bg-white/20 text-white rounded transition-colors min-h-[32px]"
             >
-              {hasBlockedTasks ? (isExpanded ? 'Collapse' : 'View Tasks') : primaryInsight.action.label}
+              {approvalTask && approvingTaskId === approvalTask.id
+                ? 'Approving…'
+                : hasBlockedTasks ? (isExpanded ? 'Collapse' : 'View Tasks') : primaryInsight.action.label}
               {hasBlockedTasks
                 ? (isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />)
-                : <ChevronRight size={12} />
+                : !approvalTask && <ChevronRight size={12} />
               }
             </button>
           )}

--- a/client/src/components/cos/ActionableInsightsBanner.test.jsx
+++ b/client/src/components/cos/ActionableInsightsBanner.test.jsx
@@ -35,7 +35,7 @@ describe('ActionableInsightsBanner insightProvenance', () => {
 // parent trigger that refetches CoS data refreshes the banner for free. These
 // tests pin the prop-driven render, the null/empty gating, and the unblock path
 // calling `onRefresh` up instead of owning its own poll.
-const api = vi.hoisted(() => ({ updateCosTask: vi.fn() }));
+const api = vi.hoisted(() => ({ updateCosTask: vi.fn(), approveCosTask: vi.fn() }));
 vi.mock('../../services/api', () => api);
 vi.mock('../ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
 
@@ -84,6 +84,22 @@ describe('ActionableInsightsBanner (presentational)', () => {
     });
     fireEvent.click(screen.getByTitle('Dismiss'));
     expect(screen.queryByText('3 approvals waiting')).not.toBeInTheDocument();
+  });
+
+  it('approves the surfaced task directly from the banner', async () => {
+    api.approveCosTask.mockResolvedValue({ id: 'a1' });
+    const onRefresh = vi.fn();
+    renderBanner({
+      insights: [{
+        type: 'approval', priority: 'high', icon: 'AlertCircle', title: '1 approval waiting',
+        action: { label: 'Approve' }, tasks: [{ id: 'a1', description: 'Investigate a failure' }],
+      }],
+      onRefresh,
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() => expect(api.approveCosTask).toHaveBeenCalledWith('a1', { silent: true }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 
   it('unblocks a task and calls onRefresh + onTaskUnblocked up (no self-poll)', async () => {

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -95,18 +95,13 @@ function getSuccessRateStyle(rate) {
   return { bg: 'bg-port-error/15', text: 'text-port-error', label: 'low' };
 }
 
-export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, providers, durations, dragHandleProps, apps, onEditingChange }) {
-  // System and approval-gated tasks are persisted in COS-TASKS.md. Every task
+export default function TaskItem({ task, isSystem, onRefresh, providers, durations, dragHandleProps, apps, onEditingChange }) {
+  // System tasks are persisted in COS-TASKS.md. Every task
   // mutation must name that source; otherwise the API's user-queue default
   // searches TASKS.md and reports the system task as missing.
-  const taskSource = isSystem || awaitingApproval ? 'internal' : 'user';
-  // DOM-id scope. An approval-gated pending task renders TWICE — TasksTab's
-  // `pendingSystemTasks` filters only on `status === 'pending'`, and the
-  // "Awaiting Approval" section renders the `approvalRequired && pending`
-  // subset again — so a bare `task-desc-${task.id}` would be duplicated across
-  // the two cards. `aria-controls` resolves by first match, which would point
-  // the approval card's toggle at the pending card's paragraph.
-  const idScope = awaitingApproval ? 'approval' : isSystem ? 'sys' : 'user';
+  const taskSource = isSystem ? 'internal' : 'user';
+  const idScope = isSystem ? 'sys' : 'user';
+  const requiresApproval = isSystem && task.approvalRequired;
   const [editing, setEditingInternal] = useState(false);
   const setEditing = useCallback((val) => {
     setEditingInternal(val);
@@ -215,6 +210,7 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   // for arbitration (→ blocked + an approval-required task). Gated while a resolve
   // is in flight so a double-click can't fire two verdicts.
   const [resolvingChallenge, setResolvingChallenge] = useState(false);
+  const [approving, setApproving] = useState(false);
   const handleResolveChallenge = async (outcome) => {
     setResolvingChallenge(true);
     const result = await api.resolveCosTaskChallenge(task.id, { outcome, resolvedBy: 'user' }, { silent: true })
@@ -226,10 +222,12 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
   };
 
   const handleApprove = async () => {
+    setApproving(true);
     const result = await api.approveCosTask(task.id, { silent: true }).catch(err => {
       toast.error(err.message);
       return null;
     });
+    setApproving(false);
     if (!result) return;
     toast.success('Task approved');
     onRefresh();
@@ -237,11 +235,11 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
 
   return (
     <div className={`bg-port-card border rounded-lg p-4 ${
-      awaitingApproval ? 'border-yellow-500/50' : 'border-port-border'
+      requiresApproval ? 'border-yellow-500/50' : 'border-port-border'
     }`}>
       <div className="flex items-start gap-3">
-        {/* Drag handle - only show for user tasks (not system or awaiting approval) */}
-        {dragHandleProps && !isSystem && !awaitingApproval && (
+        {/* Drag handle - only show for user tasks. */}
+        {dragHandleProps && !isSystem && (
           <button
             {...dragHandleProps}
             className="mt-0.5 cursor-grab active:cursor-grabbing text-gray-500 hover:text-gray-300 transition-colors touch-none"
@@ -303,12 +301,14 @@ export default function TaskItem({ task, isSystem, awaitingApproval, onRefresh, 
             {isSystem && task.autoApproved && (
               <span className="px-2 py-0.5 rounded text-xs bg-port-success/20 text-port-success">AUTO</span>
             )}
-            {awaitingApproval && (
+            {requiresApproval && (
               <button
                 onClick={handleApprove}
-                className="px-2 py-0.5 rounded text-xs bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30 transition-colors"
+                disabled={approving}
+                className="px-2 py-0.5 rounded text-xs bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30 transition-colors disabled:opacity-50"
+                aria-label={`Approve task ${task.id}`}
               >
-                APPROVE
+                {approving ? 'APPROVING…' : 'APPROVE'}
               </button>
             )}
           </div>

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -46,8 +46,8 @@ describe('TaskItem task source', () => {
     ));
   });
 
-  it('updates an approval-gated task in the internal queue when changing status', async () => {
-    render(<TaskItem task={task} awaitingApproval onRefresh={vi.fn()} providers={providers} />);
+  it('updates an approval-gated system task in the internal queue when changing status', async () => {
+    render(<TaskItem task={{ ...task, approvalRequired: true }} isSystem onRefresh={vi.fn()} providers={providers} />);
 
     fireEvent.click(screen.getByRole('button', { name: /Status: pending/i }));
 
@@ -135,12 +135,7 @@ describe('TaskItem long-text clamping', () => {
     expect(screen.queryByRole('button', { name: /Show more/ })).not.toBeInTheDocument();
   });
 
-  it('scopes the text ids so an approval-gated task rendered twice does not collide', () => {
-    // TasksTab renders `pendingSystemTasks` (status === 'pending') AND the
-    // "Awaiting Approval" subset (approvalRequired && pending), so one
-    // approval-gated task mounts two cards. Unscoped ids would duplicate, and
-    // aria-controls resolves by first match — pointing the approval card's
-    // toggle at the pending card's paragraph.
+  it('renders an approval-gated system task once with an inline approval action', async () => {
     forceOverflow();
     const gated = {
       ...task,
@@ -148,16 +143,15 @@ describe('TaskItem long-text clamping', () => {
       approvalRequired: true,
       metadata: { context: longPrompt },
     };
-    const { container: pending } = render(
-      <TaskItem task={gated} isSystem onRefresh={vi.fn()} providers={providers} />);
-    const { container: approval } = render(
-      <TaskItem task={gated} awaitingApproval onRefresh={vi.fn()} providers={providers} />);
+    api.approveCosTask.mockResolvedValue({ ...gated, approvalRequired: false });
+    const onRefresh = vi.fn();
+    const { container } = render(
+      <TaskItem task={gated} isSystem onRefresh={onRefresh} providers={providers} />);
 
-    const pendingId = pending.querySelector('[id^="task-context-"]').id;
-    const approvalId = approval.querySelector('[id^="task-context-"]').id;
-    expect(pendingId).not.toBe(approvalId);
-    expect(document.querySelectorAll(`[id="${pendingId}"]`)).toHaveLength(1);
-    expect(document.querySelectorAll(`[id="${approvalId}"]`)).toHaveLength(1);
+    expect(container.querySelectorAll('[id^="task-context-"]')).toHaveLength(1);
+    fireEvent.click(screen.getByRole('button', { name: 'Approve task sys-gated' }));
+    await waitFor(() => expect(api.approveCosTask).toHaveBeenCalledWith('sys-gated', { silent: true }));
+    expect(onRefresh).toHaveBeenCalled();
   });
 
   it('edits the context in a multi-line textarea, not a single-line input', () => {

--- a/client/src/components/cos/tabs/TasksTab.jsx
+++ b/client/src/components/cos/tabs/TasksTab.jsx
@@ -52,7 +52,6 @@ export default function TasksTab({ tasks, onRefresh, providers, apps }) {
   // Memoize task arrays to prevent unnecessary re-renders
   const userTasks = useMemo(() => tasks.user?.tasks || [], [tasks.user?.tasks]);
   const cosTasks = useMemo(() => tasks.cos?.tasks || [], [tasks.cos?.tasks]);
-  const awaitingApproval = useMemo(() => tasks.cos?.awaitingApproval || [], [tasks.cos?.awaitingApproval]);
 
   // Split tasks by status for system tasks
   const pendingSystemTasks = useMemo(() =>
@@ -351,17 +350,6 @@ export default function TasksTab({ tasks, onRefresh, providers, apps }) {
         )}
       </div>
 
-      {/* Awaiting Approval */}
-      {awaitingApproval.length > 0 && (
-        <div>
-          <h3 className="text-lg font-semibold text-yellow-500 mb-3">Awaiting Approval</h3>
-          <div className="space-y-2">
-            {awaitingApproval.map(task => (
-              <TaskItem key={task.id} task={task} awaitingApproval onRefresh={onRefresh} providers={providers} durations={durations} apps={apps} />
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/server/routes/cosInsightRoutes.js
+++ b/server/routes/cosInsightRoutes.js
@@ -69,8 +69,9 @@ router.get('/actionable-insights', asyncHandler(async (req, res) => {
       icon: 'AlertCircle',
       title: `${pendingApprovals.length} task${pendingApprovals.length > 1 ? 's' : ''} awaiting approval`,
       description: ((d) => d ? d.substring(0, 80) + (d.length > 80 ? '...' : '') : '')(pendingApprovals[0]?.description ?? ''),
-      action: { label: 'Review', route: '/cos/tasks' },
-      count: pendingApprovals.length
+      action: { label: 'Approve' },
+      count: pendingApprovals.length,
+      tasks: pendingApprovals.map(({ id, description }) => ({ id, description }))
     });
   }
 

--- a/server/routes/cosInsightRoutes.test.js
+++ b/server/routes/cosInsightRoutes.test.js
@@ -142,6 +142,10 @@ describe('CoS Insight Routes', () => {
       expect(response.body.hasActionableItems).toBe(true);
       expect(response.body.insights.length).toBeGreaterThan(0);
       expect(response.body.insights[0].type).toBe('approval');
+      expect(response.body.insights[0]).toMatchObject({
+        action: { label: 'Approve' },
+        tasks: [{ id: 'a1', description: 'Approve me' }],
+      });
     });
 
     it('should handle errors gracefully in parallel calls', async () => {


### PR DESCRIPTION
## Summary

- show approval actions on the pending system task instead of rendering a duplicate approval card
- approve the surfaced task directly from the Chief of Staff alert
- cover inline and banner approval behavior with focused tests

## Test plan

- npm test -- --run src/components/cos/tabs/TaskItem.test.jsx src/components/cos/ActionableInsightsBanner.test.jsx
- npm test -- --run routes/cosInsightRoutes.test.js