### PR TITLE
Add collapsible third-level navigation

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased Changes
 
+## Navigation
+
+- Third-level Create navigation for Series and Universes can now be collapsed and expanded independently.
+
 ## Client linting
 
 - Client linting now uses ESLint 10 with the maintained ESLint React rule set, preserving PortOS's key React correctness checks without relying on the unmaintained `eslint-plugin-react` compatibility range.

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -465,6 +465,7 @@ export default function Layout() {
   const [collapsed, setCollapsed] = useState(() => safeReadStorage(SIDEBAR_KEY) === 'true');
   const [mobileOpen, setMobileOpen] = useState(false);
   const [expandedSections, setExpandedSections] = useState({});
+  const [expandedSubSections, setExpandedSubSections] = useState({});
   // Collapsed-sidebar flyout: hovering or focusing a section icon opens a
   // fixed-position popover to the right listing the section's children, so the
   // user can reach siblings (e.g. Writers Room from Create) without expanding
@@ -657,6 +658,15 @@ export default function Layout() {
         if (isChildActive) {
           setExpandedSections(prev => ({ ...prev, [item.label]: true }));
         }
+        item.children.forEach(child => {
+          const grandChildren = Array.isArray(child.grandChildren) ? child.grandChildren : [];
+          if (grandChildren.some(grandChild => {
+            const prefix = grandChild.activePathPrefix || grandChild.to;
+            return location.pathname === prefix || location.pathname.startsWith(prefix + '/');
+          })) {
+            setExpandedSubSections(prev => ({ ...prev, [child.to]: true }));
+          }
+        });
       }
     });
   }, [location.pathname, resolvedNavItems]);
@@ -670,6 +680,13 @@ export default function Layout() {
     setExpandedSections(prev => ({
       ...prev,
       [label]: !prev[label]
+    }));
+  };
+
+  const toggleSubSection = (path) => {
+    setExpandedSubSections(prev => ({
+      ...prev,
+      [path]: prev[path] === false,
     }));
   };
 
@@ -863,17 +880,33 @@ export default function Layout() {
                 ? location.pathname === child.to
                 : isActive(child.to);
               const grandChildren = Array.isArray(child.grandChildren) ? child.grandChildren : [];
+              const grandChildrenExpanded = expandedSubSections[child.to] !== false;
               const childIsPinned = isPinned(child.to);
               return (
                 <div key={child.to} className="min-w-0">
-                  <WorkingSetRow
-                    entry={{ path: child.to, label: child.label, icon: ChildIcon, end: child.end }}
-                    pinned={childIsPinned}
-                    onTogglePin={() => (childIsPinned ? unpin(child.to) : pin(child.to))}
-                    onNavigate={() => setMobileOpen(false)}
-                    isActive={childActive}
-                  />
-                  {grandChildren.length > 0 && (
+                  <div className="flex items-center min-w-0">
+                    <div className="min-w-0 flex-1">
+                      <WorkingSetRow
+                        entry={{ path: child.to, label: child.label, icon: ChildIcon, end: child.end }}
+                        pinned={childIsPinned}
+                        onTogglePin={() => (childIsPinned ? unpin(child.to) : pin(child.to))}
+                        onNavigate={() => setMobileOpen(false)}
+                        isActive={childActive}
+                      />
+                    </div>
+                    {grandChildren.length > 0 && (
+                      <button
+                        type="button"
+                        aria-label={grandChildrenExpanded ? `Collapse ${child.label}` : `Expand ${child.label}`}
+                        aria-expanded={grandChildrenExpanded}
+                        onClick={() => toggleSubSection(child.to)}
+                        className="px-2 py-2 text-gray-500 hover:text-white hover:bg-port-border/50 rounded-lg"
+                      >
+                        {grandChildrenExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+                      </button>
+                    )}
+                  </div>
+                  {grandChildren.length > 0 && grandChildrenExpanded && (
                     <div className="ml-6 mt-0.5 mb-1 border-l border-port-border/50 pl-2 min-w-0">
                       {grandChildren.map((gc) => {
                         // Prefer the explicit prefix (e.g. `/pipeline/issues/<id>`)

--- a/client/src/components/Layout.test.jsx
+++ b/client/src/components/Layout.test.jsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, within, act, fireEvent } from '@testing-library/react';
+import { render, screen, within, act, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { PINNED_KEY } from '../utils/navWorkingSet.js';
+import * as api from '../services/api';
 
 // This suite locks the *integration* path that SingleNavRow.test.jsx can't reach:
 // pinning a top-level `single: true` row (Dashboard `/`, Review Hub `/review`,
@@ -87,6 +88,8 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  api.listPipelineSeries.mockResolvedValue([]);
+  api.listUniverses.mockResolvedValue([]);
 });
 
 describe('Layout — pinned single nav rows', () => {
@@ -174,5 +177,32 @@ describe('Layout — persistent mobile touch targets', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Expand Create' }));
 
     expect(screen.getByRole('link', { name: 'Authors' })).toHaveAttribute('href', '/authors');
+  });
+});
+
+describe('Layout — dynamic third-level navigation', () => {
+  it('collapses and expands the Series and Universes children', async () => {
+    api.listPipelineSeries.mockResolvedValue([{ id: 'series-1', name: 'Example Series' }]);
+    api.listUniverses.mockResolvedValue([{ id: 'universe-1', name: 'Example Universe' }]);
+
+    await renderLayout('/media');
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Example Series' })).toHaveAttribute('href', '/pipeline/series/series-1');
+      expect(screen.getByRole('link', { name: 'Example Universe' })).toHaveAttribute('href', '/universes/universe-1');
+    });
+
+    const collapseSeries = screen.getByRole('button', { name: 'Collapse Series Pipeline' });
+    const collapseUniverses = screen.getByRole('button', { name: 'Collapse Universes' });
+    fireEvent.click(collapseSeries);
+    fireEvent.click(collapseUniverses);
+    expect(screen.queryByRole('link', { name: 'Example Series' })).toBeNull();
+    expect(screen.queryByRole('link', { name: 'Example Universe' })).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand Series Pipeline' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Expand Universes' }));
+    expect(screen.getByRole('link', { name: 'Example Series' })).toBeTruthy();
+    expect(screen.getByRole('link', { name: 'Example Universe' })).toBeTruthy();
+
   });
 });


### PR DESCRIPTION
## Summary
- Add independent collapse/expand controls for Series and Universes under Create.
- Preserve visible-by-default behavior and auto-expand active detail paths.
- Add integration coverage and changelog entry.

## Test plan
- npm test -- --run src/components/Layout.test.jsx
- npm run lint -- --no-warn-ignored src/components/Layout.jsx src/components/Layout.test.jsx