### PR TITLE
feat(creative-commissions): display renders + config side-by-side on desktop with smaller preview cards

### DIFF
--- a/client/src/components/creative-commission/RenderHistory.jsx
+++ b/client/src/components/creative-commission/RenderHistory.jsx
@@ -62,7 +62,7 @@ export default function RenderHistory({ runs, feedback, projectsById, projectsLo
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
       {orderedRuns.map((r) => {
         const project = r.projectId ? projectsById.get(r.projectId) : null;
         const focused = r.id === focusRunId;
@@ -74,13 +74,15 @@ export default function RenderHistory({ runs, feedback, projectsById, projectsLo
           >
             {/* Produced-media preview (or a status-only placeholder). */}
             {project ? (
-              <ProjectPreview project={project} to={`/creative-director/${encodeURIComponent(r.projectId)}`} />
+              <div className="overflow-hidden" style={{ maxHeight: '160px' }}>
+                  <ProjectPreview project={project} to={`/creative-director/${encodeURIComponent(r.projectId)}`} />
+              </div>
             ) : (
               // `project` is null in this branch, so the placeholder falls back to
               // the default 16:9 box. Distinguish the transient load window (project
               // list still fetching) from a genuinely pruned/missing render — a real
               // render must not flash "unavailable" before the fetch resolves.
-              <div className={`${previewAspectClass()} bg-port-bg flex flex-col items-center justify-center gap-1 text-gray-600 text-xs`}>
+              <div className="h-[120px] bg-port-bg flex flex-col items-center justify-center gap-1 text-gray-600 text-xs">
                 <Film className="w-4 h-4 opacity-50" aria-hidden="true" />
                 <span>{r.projectId ? (projectsLoading ? 'loading…' : 'render unavailable') : 'no render'}</span>
               </div>

--- a/client/src/components/creative-commission/RenderHistory.jsx
+++ b/client/src/components/creative-commission/RenderHistory.jsx
@@ -80,22 +80,20 @@ export default function RenderHistory({ runs, feedback, projectsById, projectsLo
                 Constraining width instead lets aspect-ratio derive a height that
                 already fits, matching previewMaxWidthClass's documented approach
                 in lib/creativeDirectorPreview.js. */}
-            {project ? (
-              <div className="max-w-[220px] mx-auto">
+            <div className="max-w-[220px] mx-auto">
+              {project ? (
                 <ProjectPreview project={project} to={`/creative-director/${encodeURIComponent(r.projectId)}`} />
-              </div>
-            ) : (
-              // `project` is null in this branch, so the placeholder falls back to
-              // the default 16:9 box. Distinguish the transient load window (project
-              // list still fetching) from a genuinely pruned/missing render — a real
-              // render must not flash "unavailable" before the fetch resolves.
-              <div className="max-w-[220px] mx-auto">
+              ) : (
+                // `project` is null in this branch, so the placeholder falls back to
+                // the default 16:9 box. Distinguish the transient load window (project
+                // list still fetching) from a genuinely pruned/missing render — a real
+                // render must not flash "unavailable" before the fetch resolves.
                 <div className={`${previewAspectClass()} bg-port-bg flex flex-col items-center justify-center gap-1 text-gray-600 text-xs`}>
                   <Film className="w-4 h-4 opacity-50" aria-hidden="true" />
                   <span>{r.projectId ? (projectsLoading ? 'loading…' : 'render unavailable') : 'no render'}</span>
                 </div>
-              </div>
-            )}
+              )}
+            </div>
 
             <div className="p-3 flex flex-col gap-2 flex-1">
               <div className="flex items-center justify-between gap-2 text-xs">

--- a/client/src/components/creative-commission/RenderHistory.jsx
+++ b/client/src/components/creative-commission/RenderHistory.jsx
@@ -72,19 +72,28 @@ export default function RenderHistory({ runs, feedback, projectsById, projectsLo
             id={`commission-run-${r.id}`}
             className={`bg-port-card border rounded-lg overflow-hidden flex flex-col ${focused ? 'border-port-accent ring-1 ring-port-accent' : 'border-port-border'}`}
           >
-            {/* Produced-media preview (or a status-only placeholder). */}
+            {/* Produced-media preview (or a status-only placeholder). Width-capped,
+                not height-capped: ProjectPreview's box derives its height from an
+                aspect-ratio class, so clamping height with overflow-hidden crops
+                it — and pushes ProjectPreview's absolutely-centered play button
+                and bottom label below the visible area for any non-16:9 ratio.
+                Constraining width instead lets aspect-ratio derive a height that
+                already fits, matching previewMaxWidthClass's documented approach
+                in lib/creativeDirectorPreview.js. */}
             {project ? (
-              <div className="overflow-hidden" style={{ maxHeight: '160px' }}>
-                  <ProjectPreview project={project} to={`/creative-director/${encodeURIComponent(r.projectId)}`} />
+              <div className="max-w-[220px] mx-auto">
+                <ProjectPreview project={project} to={`/creative-director/${encodeURIComponent(r.projectId)}`} />
               </div>
             ) : (
               // `project` is null in this branch, so the placeholder falls back to
               // the default 16:9 box. Distinguish the transient load window (project
               // list still fetching) from a genuinely pruned/missing render — a real
               // render must not flash "unavailable" before the fetch resolves.
-              <div className="h-[120px] bg-port-bg flex flex-col items-center justify-center gap-1 text-gray-600 text-xs">
-                <Film className="w-4 h-4 opacity-50" aria-hidden="true" />
-                <span>{r.projectId ? (projectsLoading ? 'loading…' : 'render unavailable') : 'no render'}</span>
+              <div className="max-w-[220px] mx-auto">
+                <div className={`${previewAspectClass()} bg-port-bg flex flex-col items-center justify-center gap-1 text-gray-600 text-xs`}>
+                  <Film className="w-4 h-4 opacity-50" aria-hidden="true" />
+                  <span>{r.projectId ? (projectsLoading ? 'loading…' : 'render unavailable') : 'no render'}</span>
+                </div>
               </div>
             )}
 

--- a/client/src/pages/CreativeCommissionDetail.jsx
+++ b/client/src/pages/CreativeCommissionDetail.jsx
@@ -297,32 +297,35 @@ export default function CreativeCommissionDetail() {
         </div>
       </div>
 
-      {/* Renders — the headline: what this commission has actually produced. */}
-      <section className="space-y-3">
-        <h2 className="text-sm font-semibold text-gray-200">Renders</h2>
-        <RenderHistory
-          runs={commission.runs}
-          feedback={commission.feedback}
-          projectsById={projectsById}
-          projectsLoading={projectsLoading}
-          focusRunId={focusRunId}
-          onRate={handleRate}
-        />
-      </section>
-
-      {/* Configuration — the editable brief/schedule/generation. */}
-      <section className="space-y-3 border-t border-port-border pt-6">
-        <h2 className="text-sm font-semibold text-gray-200">Configuration</h2>
-        <div className="bg-port-card border border-port-border rounded-lg p-4 max-w-2xl">
-          <CommissionConfigForm
-            form={form}
-            patchForm={patchForm}
-            saving={saving}
-            onSave={handleSave}
-            saveLabel="Save changes"
+      {/* Renders + Config — side-by-side on desktop, stacked on mobile. */}
+      <div className="flex flex-col lg:flex-row gap-6">
+        {/* Renders — the headline: what this commission has actually produced. */}
+        <section className="flex-1 space-y-3 min-w-0">
+          <h2 className="text-sm font-semibold text-gray-200">Renders</h2>
+          <RenderHistory
+            runs={commission.runs}
+            feedback={commission.feedback}
+            projectsById={projectsById}
+            projectsLoading={projectsLoading}
+            focusRunId={focusRunId}
+            onRate={handleRate}
           />
-        </div>
-      </section>
+        </section>
+
+        {/* Configuration — the editable brief/schedule/generation. */}
+        <aside className="w-full lg:w-[380px] shrink-0 space-y-3">
+          <h2 className="text-sm font-semibold text-gray-200">Configuration</h2>
+          <div className="bg-port-card border border-port-border rounded-lg p-4 max-w-none">
+            <CommissionConfigForm
+              form={form}
+              patchForm={patchForm}
+              saving={saving}
+              onSave={handleSave}
+              saveLabel="Save changes"
+            />
+          </div>
+        </aside>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Displays a Creative Commission's render history alongside its editable config side-by-side on desktop (stacked on mobile), instead of stacked full-width sections
- Shrinks the render grid to 2 columns max and adds a width-capped preview thumbnail so each card reads as a compact preview rather than a full-bleed hero image

## Test plan
- [x] `npm run lint --prefix client` passes
- [x] `npx vite build --prefix client` succeeds
- [ ] Manually verify in the browser: open a commission with renders in multiple aspect ratios (16:9, 9:16, 1:1) and confirm each card's play button and label are visible and clickable
