### PR TITLE
feat([issue-3168]): add concept/style editor to Music Video projects

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased Changes
 
+## Music Video
+
+- **[issue-3168] Music Video projects now have a Concept and Visual style field.** Set them before clicking "AI Plan" to steer the proposed scenes toward a story or theme, and every generated frame and shot prompt now carries your chosen visual style automatically.
+
 ## Usage cost reporting
 
 - **[issue-3156] Historical usage estimates can now be reconciled against provider transcripts.** The Usage page offers an explicit, progress-reporting repair that matches transcripts only to PortOS run windows, preserves configured provider IDs, replaces each old estimate once, and rebuilds corrected totals without inventing legacy cost.

--- a/client/src/hooks/useFieldDraft.js
+++ b/client/src/hooks/useFieldDraft.js
@@ -24,5 +24,11 @@ export default function useFieldDraft(persisted, onCommit) {
     setDraft(undefined);
   };
 
-  return { value, onChange, onBlur };
+  // Discards a pending, uncommitted edit without firing onCommit — for a caller
+  // whose `persisted` identity can change out from under a still-focused input
+  // (e.g. the user navigates to a different record before blurring), so the
+  // stale draft can't be blurred onto the new record on the next unrelated blur.
+  const reset = () => setDraft(undefined);
+
+  return { value, onChange, onBlur, reset };
 }

--- a/client/src/pages/MusicVideo.jsx
+++ b/client/src/pages/MusicVideo.jsx
@@ -22,6 +22,7 @@ import {
   cancelMusicVideoMidiTranscription,
 } from '../services/apiMusicVideo.js';
 import useMidiTranscription from '../hooks/useMidiTranscription.js';
+import useFieldDraft from '../hooks/useFieldDraft.js';
 import MidiInstallModal from '../components/install/MidiInstallModal.jsx';
 import MidiGatedModal from '../components/install/MidiGatedModal.jsx';
 import MidiVisualization from '../components/songs/MidiVisualization.jsx';
@@ -462,16 +463,21 @@ export default function MusicVideo() {
       .catch((err) => toast.error(err?.message || 'Failed to save scene'));
   };
 
-  // Project-level concept/style (issue #3168) — same optimistic-local + silent-PATCH
-  // blur pattern as scene fields. Consumed by buildScenePlanPrompt (AI Plan) and by
-  // buildFramePrompt/buildShotPrompt's style suffix, both already reading concept.
-  const editConceptLocal = (patch) => {
+  // Project-level concept/style (issue #3168) — optimistic-local + silent-PATCH on
+  // commit, same as commitSceneTiming below. Sends only the changed sub-field;
+  // the server merges it into the existing concept (applyProjectPatch), so a
+  // stale local copy can't clobber a sibling sub-field. Consumed by
+  // buildScenePlanPrompt (AI Plan) and by buildFramePrompt/buildShotPrompt's
+  // style suffix, both already reading concept.
+  const commitConcept = (patch) => {
     replaceProject({ ...selected, concept: { ...selected.concept, ...patch } });
-  };
-  const saveConcept = (patch) => {
-    updateMusicVideoProject(selected.id, { concept: { ...selected.concept, ...patch } }, { silent: true })
+    updateMusicVideoProject(selected.id, { concept: patch }, { silent: true })
       .catch((err) => toast.error(err?.message || 'Failed to save concept'));
   };
+  // Buffered so a concept/style keystroke doesn't fire a round-trip per character,
+  // and a focus-without-edit blur doesn't re-PATCH an unchanged value.
+  const conceptDraft = useFieldDraft(selected?.concept?.prompt, (v) => commitConcept({ prompt: v }));
+  const styleDraft = useFieldDraft(selected?.concept?.style, (v) => commitConcept({ style: v }));
   // BeatTimeline drag commit — same optimistic-local + silent-PATCH pattern as
   // the other scene field editors (#1854).
   const commitSceneTiming = (sceneId, patch) => {
@@ -717,19 +723,17 @@ export default function MusicVideo() {
                   </div>
                 </div>
                 {/* Concept & style — optional global direction for the whole video,
-                    set before "AI Plan" so buildScenePlanPrompt (server) can build on
-                    it, and reused by buildFramePrompt/buildShotPrompt's style suffix
-                    (issue #3168). Local-edit + blur-save, same pattern as scene fields. */}
+                    set before "AI Plan" (see commitConcept above for what reads it). */}
                 <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
                   <div>
                     <label htmlFor="mv-concept" className="block text-xs text-port-text-muted mb-1">Concept</label>
                     <textarea
                       id="mv-concept"
-                      value={selected.concept?.prompt || ''}
+                      value={conceptDraft.value}
                       rows={2}
                       maxLength={8000}
-                      onChange={(e) => editConceptLocal({ prompt: e.target.value })}
-                      onBlur={(e) => saveConcept({ prompt: e.target.value })}
+                      onChange={conceptDraft.onChange}
+                      onBlur={conceptDraft.onBlur}
                       placeholder="What is this video about — story, theme, or narrative thread for the AI plan to build on."
                       className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm"
                     />
@@ -738,11 +742,11 @@ export default function MusicVideo() {
                     <label htmlFor="mv-style" className="block text-xs text-port-text-muted mb-1">Visual style</label>
                     <textarea
                       id="mv-style"
-                      value={selected.concept?.style || ''}
+                      value={styleDraft.value}
                       rows={2}
                       maxLength={2000}
-                      onChange={(e) => editConceptLocal({ style: e.target.value })}
-                      onBlur={(e) => saveConcept({ style: e.target.value })}
+                      onChange={styleDraft.onChange}
+                      onBlur={styleDraft.onBlur}
                       placeholder="Art style, references, palette, mood — appended to every generated frame and shot prompt."
                       className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm"
                     />

--- a/client/src/pages/MusicVideo.jsx
+++ b/client/src/pages/MusicVideo.jsx
@@ -478,6 +478,13 @@ export default function MusicVideo() {
   // and a focus-without-edit blur doesn't re-PATCH an unchanged value.
   const conceptDraft = useFieldDraft(selected?.concept?.prompt, (v) => commitConcept({ prompt: v }));
   const styleDraft = useFieldDraft(selected?.concept?.style, (v) => commitConcept({ style: v }));
+  // The route (not a remount) drives which project is "selected" here, so a
+  // still-focused, unblurred draft survives a project switch (deep link,
+  // browser Back, future ⌘K/voice jump) with the OLD project's typed text.
+  // Without this, the next incidental blur would commit that leftover draft
+  // onto the NEW project via commitConcept's captured `selected`. Discard
+  // (never auto-commit) any pending edit the instant the selection changes.
+  useEffect(() => { conceptDraft.reset(); styleDraft.reset(); }, [selectedId]);
   // BeatTimeline drag commit — same optimistic-local + silent-PATCH pattern as
   // the other scene field editors (#1854).
   const commitSceneTiming = (sceneId, patch) => {

--- a/client/src/pages/MusicVideo.jsx
+++ b/client/src/pages/MusicVideo.jsx
@@ -461,6 +461,17 @@ export default function MusicVideo() {
     updateMusicVideoScene(selected.id, sceneId, patch, { silent: true })
       .catch((err) => toast.error(err?.message || 'Failed to save scene'));
   };
+
+  // Project-level concept/style (issue #3168) — same optimistic-local + silent-PATCH
+  // blur pattern as scene fields. Consumed by buildScenePlanPrompt (AI Plan) and by
+  // buildFramePrompt/buildShotPrompt's style suffix, both already reading concept.
+  const editConceptLocal = (patch) => {
+    replaceProject({ ...selected, concept: { ...selected.concept, ...patch } });
+  };
+  const saveConcept = (patch) => {
+    updateMusicVideoProject(selected.id, { concept: { ...selected.concept, ...patch } }, { silent: true })
+      .catch((err) => toast.error(err?.message || 'Failed to save concept'));
+  };
   // BeatTimeline drag commit — same optimistic-local + silent-PATCH pattern as
   // the other scene field editors (#1854).
   const commitSceneTiming = (sceneId, patch) => {
@@ -703,6 +714,38 @@ export default function MusicVideo() {
                       className="flex items-center gap-1 text-port-error border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0">
                       <Trash2 size={15} />
                     </button>
+                  </div>
+                </div>
+                {/* Concept & style — optional global direction for the whole video,
+                    set before "AI Plan" so buildScenePlanPrompt (server) can build on
+                    it, and reused by buildFramePrompt/buildShotPrompt's style suffix
+                    (issue #3168). Local-edit + blur-save, same pattern as scene fields. */}
+                <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
+                  <div>
+                    <label htmlFor="mv-concept" className="block text-xs text-port-text-muted mb-1">Concept</label>
+                    <textarea
+                      id="mv-concept"
+                      value={selected.concept?.prompt || ''}
+                      rows={2}
+                      maxLength={8000}
+                      onChange={(e) => editConceptLocal({ prompt: e.target.value })}
+                      onBlur={(e) => saveConcept({ prompt: e.target.value })}
+                      placeholder="What is this video about — story, theme, or narrative thread for the AI plan to build on."
+                      className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm"
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="mv-style" className="block text-xs text-port-text-muted mb-1">Visual style</label>
+                    <textarea
+                      id="mv-style"
+                      value={selected.concept?.style || ''}
+                      rows={2}
+                      maxLength={2000}
+                      onChange={(e) => editConceptLocal({ style: e.target.value })}
+                      onBlur={(e) => saveConcept({ style: e.target.value })}
+                      placeholder="Art style, references, palette, mood — appended to every generated frame and shot prompt."
+                      className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm"
+                    />
                   </div>
                 </div>
                 {/* Track picker — pick an existing library track or import fresh audio

--- a/client/src/pages/MusicVideo.test.jsx
+++ b/client/src/pages/MusicVideo.test.jsx
@@ -248,6 +248,48 @@ describe('MusicVideo autonomous shot planner (#1855)', () => {
   });
 });
 
+describe('MusicVideo concept & style editor (#3168)', () => {
+  it('seeds the fields from the project and persists each on blur', async () => {
+    const withConcept = { ...PROJECT_NO_CLIP, concept: { prompt: 'A road trip through neon ruins', style: 'Cyberpunk anime' } };
+    await openProject(withConcept);
+
+    const conceptField = await screen.findByLabelText('Concept');
+    const styleField = screen.getByLabelText('Visual style');
+    expect(conceptField).toHaveValue('A road trip through neon ruins');
+    expect(styleField).toHaveValue('Cyberpunk anime');
+
+    fireEvent.change(conceptField, { target: { value: 'A heist across a dying star' } });
+    fireEvent.blur(conceptField);
+    await waitFor(() => expect(updateMusicVideoProject).toHaveBeenCalledWith(
+      'mv-2',
+      { concept: { prompt: 'A heist across a dying star', style: 'Cyberpunk anime' } },
+      { silent: true },
+    ));
+
+    fireEvent.change(styleField, { target: { value: 'Watercolor noir' } });
+    fireEvent.blur(styleField);
+    await waitFor(() => expect(updateMusicVideoProject).toHaveBeenCalledWith(
+      'mv-2',
+      { concept: { prompt: 'A heist across a dying star', style: 'Watercolor noir' } },
+      { silent: true },
+    ));
+  });
+
+  it('starts empty and enables AI Plan to use them once set', async () => {
+    await openProject(PROJECT_ANALYZED);
+    const conceptField = await screen.findByLabelText('Concept');
+    expect(conceptField).toHaveValue('');
+
+    fireEvent.change(conceptField, { target: { value: 'Underwater festival' } });
+    fireEvent.blur(conceptField);
+    await waitFor(() => expect(updateMusicVideoProject).toHaveBeenCalledWith(
+      'mv-3',
+      { concept: { prompt: 'Underwater festival' } },
+      { silent: true },
+    ));
+  });
+});
+
 describe('MusicVideo YouTube audio import (#1945)', () => {
   it('starts an import from the detail view and attaches the finished track to the project', async () => {
     await openProject(PROJECT_NO_CLIP);

--- a/client/src/pages/MusicVideo.test.jsx
+++ b/client/src/pages/MusicVideo.test.jsx
@@ -285,6 +285,31 @@ describe('MusicVideo concept & style editor (#3168)', () => {
     expect(updateMusicVideoProject).not.toHaveBeenCalled();
   });
 
+  it('discards an unsaved draft on project switch instead of leaking it onto the next project', async () => {
+    // The page reuses one component instance across projects (route param
+    // change, no remount) — an edit left unblurred when the selection changes
+    // (deep link, browser Back, ⌘K) must not survive to be committed against
+    // whichever project is now selected.
+    const projectB = { ...PROJECT_NO_CLIP, id: 'mv-3', name: 'Other Project', concept: { prompt: 'B original' } };
+    listMusicVideoProjects.mockResolvedValue([PROJECT_NO_CLIP, projectB]);
+    renderMV();
+    fireEvent.click(await screen.findByRole('button', { name: new RegExp(PROJECT_NO_CLIP.name) }));
+
+    const conceptField = await screen.findByLabelText('Concept');
+    fireEvent.change(conceptField, { target: { value: 'A unsaved draft' } });
+    // No blur — switch projects while the edit is still pending.
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(projectB.name) }));
+
+    await waitFor(() => expect(screen.getByLabelText('Concept')).toHaveValue('B original'));
+    fireEvent.blur(screen.getByLabelText('Concept'));
+    await settle();
+    expect(updateMusicVideoProject).not.toHaveBeenCalledWith(
+      'mv-3',
+      { concept: { prompt: 'A unsaved draft' } },
+      { silent: true },
+    );
+  });
+
   it('starts empty and enables AI Plan to use them once set', async () => {
     await openProject(PROJECT_ANALYZED);
     const conceptField = await screen.findByLabelText('Concept');

--- a/client/src/pages/MusicVideo.test.jsx
+++ b/client/src/pages/MusicVideo.test.jsx
@@ -262,7 +262,7 @@ describe('MusicVideo concept & style editor (#3168)', () => {
     fireEvent.blur(conceptField);
     await waitFor(() => expect(updateMusicVideoProject).toHaveBeenCalledWith(
       'mv-2',
-      { concept: { prompt: 'A heist across a dying star', style: 'Cyberpunk anime' } },
+      { concept: { prompt: 'A heist across a dying star' } },
       { silent: true },
     ));
 
@@ -270,9 +270,19 @@ describe('MusicVideo concept & style editor (#3168)', () => {
     fireEvent.blur(styleField);
     await waitFor(() => expect(updateMusicVideoProject).toHaveBeenCalledWith(
       'mv-2',
-      { concept: { prompt: 'A heist across a dying star', style: 'Watercolor noir' } },
+      { concept: { style: 'Watercolor noir' } },
       { silent: true },
     ));
+  });
+
+  it('does not re-PATCH when a field is focused and blurred without an edit', async () => {
+    const withConcept = { ...PROJECT_NO_CLIP, concept: { prompt: 'Unchanged', style: 'Unchanged' } };
+    await openProject(withConcept);
+    const conceptField = await screen.findByLabelText('Concept');
+    fireEvent.focus(conceptField);
+    fireEvent.blur(conceptField);
+    await settle();
+    expect(updateMusicVideoProject).not.toHaveBeenCalled();
   });
 
   it('starts empty and enables AI Plan to use them once set', async () => {

--- a/server/services/musicVideo/projectsLogic.js
+++ b/server/services/musicVideo/projectsLogic.js
@@ -87,6 +87,14 @@ export function applyProjectPatch(project, patch) {
   if (patch.status && !MUSIC_VIDEO_STATUSES.includes(patch.status)) {
     throw new ServerError(`Invalid status: ${patch.status}`, { status: 400, code: 'VALIDATION_ERROR' });
   }
+  // A `concept` patch merges into the existing concept sub-fields rather than
+  // replacing the whole object — mirrors applySceneUpdate's per-field scene merge
+  // below, so a caller sending only the sub-field it edited (e.g. { style: '…' })
+  // can't clobber a sibling sub-field (e.g. prompt) set concurrently by another
+  // sync peer (#3168). An explicit `concept: null` still clears it outright.
+  const mergedPatch = ('concept' in patch && patch.concept && project.concept)
+    ? { ...patch, concept: { ...project.concept, ...patch.concept } }
+    : patch;
   // Changing the audio source invalidates the cached beat/tempo analysis —
   // it was computed from the OLD track. AI Plan / Auto-arrange / BeatTimeline
   // gate on `audioAnalysis` truthiness, and the render's beat-snap step reads
@@ -100,7 +108,7 @@ export function applyProjectPatch(project, patch) {
   // the flag set would render the old song's cut points against new audio.
   const trackChanged = ('trackId' in patch && patch.trackId !== project.trackId)
     || ('uploadedAudioFilename' in patch && patch.uploadedAudioFilename !== project.uploadedAudioFilename);
-  if (!trackChanged) return touch(project, patch);
+  if (!trackChanged) return touch(project, mergedPatch);
   const scenes = (project.scenes || []).map((s) => (s.beatAligned ? { ...s, beatAligned: false } : s));
   // Clearing audioAnalysis means the project must be re-analyzed before it can be
   // planned/arranged/rendered, so a status that implies analysis existed
@@ -112,7 +120,7 @@ export function applyProjectPatch(project, patch) {
   const statusPatch = regressStatus ? { status: 'draft' } : {};
   // The MIDI transcription was produced from the OLD audio too — clear it with
   // the analysis so a stale .mid can't masquerade as the new track's score.
-  return touch(project, { ...patch, ...statusPatch, audioAnalysis: null, midiTranscription: null, scenes });
+  return touch(project, { ...mergedPatch, ...statusPatch, audioAnalysis: null, midiTranscription: null, scenes });
 }
 
 /**

--- a/server/services/musicVideo/projectsLogic.test.js
+++ b/server/services/musicVideo/projectsLogic.test.js
@@ -142,6 +142,23 @@ describe('applyProjectPatch', () => {
     const next = applyProjectPatch(withScenes, { name: 'Renamed' });
     expect(next.scenes[0].beatAligned).toBe(true);
   });
+
+  it('merges a concept patch into the existing concept instead of replacing it (#3168)', () => {
+    const withConcept = { ...baseProject(), concept: { prompt: 'A road trip', style: 'Cyberpunk anime' } };
+    const next = applyProjectPatch(withConcept, { concept: { style: 'Watercolor noir' } });
+    expect(next.concept).toEqual({ prompt: 'A road trip', style: 'Watercolor noir' });
+  });
+
+  it('sets a concept sub-field on a project with no existing concept', () => {
+    const next = applyProjectPatch(baseProject(), { concept: { prompt: 'Underwater festival' } });
+    expect(next.concept).toEqual({ prompt: 'Underwater festival' });
+  });
+
+  it('clears the concept outright when the patch sets it to null', () => {
+    const withConcept = { ...baseProject(), concept: { prompt: 'A road trip', style: 'Cyberpunk anime' } };
+    const next = applyProjectPatch(withConcept, { concept: null });
+    expect(next.concept).toBeNull();
+  });
 });
 
 describe('setAudioAnalysis', () => {


### PR DESCRIPTION
## Summary
- Adds a "Concept" and "Visual style" textarea to the Music Video project detail view, set before clicking "AI Plan" so the server's scene-plan prompt (and every generated frame/shot prompt) can build on them.
- Fixes `applyProjectPatch` to merge a `concept` patch into the existing sub-fields instead of replacing the whole object (mirrors the existing per-field scene-update merge), so the client can send just the sub-field it edited without risking clobbering a sibling sub-field set by another sync peer.
- Fixes a draft-leak bug found in local review: since the page reuses one component instance across a project-switch route change (no remount), an unsaved, unblurred concept/style edit could survive the switch and get committed onto the wrong project on the next incidental blur. `useFieldDraft` now exposes `reset()`, called on project-selection change.

Closes #3168

## Test plan
- `cd client && npx vitest run src/pages/MusicVideo.test.jsx` — 27 tests pass, including new coverage for seeding/persisting concept+style, no-op blur, empty-start state, and the project-switch draft-discard regression.
- `cd server && npx vitest run services/musicVideo/projectsLogic.test.js routes/musicVideo.test.js` — 81 tests pass, including new coverage for the concept merge-vs-replace behavior and explicit-null clearing.
- Full client (`npx vitest run`, 5277 tests) and server (`npx vitest run`, 22992 tests, DB suites skipped) suites pass.
- `eslint` clean on all changed client files.
