### PR TITLE
fix(branch-reconcile): protect gh-pages and prioritize work branches

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,9 @@
+# Unreleased Changes
+
+## Fixed
+
+- **Branch reconciler no longer hands long-lived shared branches to the coordinator agent.** `gh-pages` (the GitHub Pages publishing branch) is now protected alongside `main`/`master`/`dev`/`develop`/`release`, so the scheduled `branch-reconcile` task never tries to "open a PR" merging it into the default branch (which would break the published site). The reconciler now reuses the single canonical `PROTECTED_BRANCHES` set in `server/lib/gitArgs.js` instead of its own narrower list, so it also picks up `dev`/`develop` protection.
+
+## Changed
+
+- **Branch reconciler prioritizes recognized work branches.** The in-flight set handed to the coordinator agent is now ordered by branch prefix — `claim/`, `cos/`, `next/`, `feature/`, `fix/`, and other conventional prefixes are reconciled ahead of unrecognized/ad-hoc branches — so a bounded run spends its budget on real deliverables first. Both `/` and `-` separators match.

--- a/server/lib/gitArgs.js
+++ b/server/lib/gitArgs.js
@@ -2,8 +2,12 @@
 // child-process access — these sanitize/shape the inputs that
 // server/services/git.js passes to execGit.
 
-// Branches that must never be deleted by the branch-cleanup paths.
-export const PROTECTED_BRANCHES = ['main', 'master', 'dev', 'develop', 'release'];
+// Long-lived shared branches that must never be deleted by the branch-cleanup
+// paths, nor handed to the branch-reconcile coordinator agent — they are not
+// disposable work. `gh-pages` is the GitHub Pages publishing branch: deleting it
+// (or letting reconcile try to "open a PR" merging it into the default branch)
+// would break the published site, so it is protected everywhere the others are.
+export const PROTECTED_BRANCHES = ['main', 'master', 'dev', 'develop', 'release', 'gh-pages'];
 
 /**
  * Validate file paths to prevent command injection and path traversal.

--- a/server/lib/gitArgs.test.js
+++ b/server/lib/gitArgs.test.js
@@ -3,7 +3,7 @@ import { PROTECTED_BRANCHES, validateFilePaths, toLiteralPathspec } from './gitA
 
 describe('PROTECTED_BRANCHES', () => {
   it('lists the branches that must never be deleted', () => {
-    expect(PROTECTED_BRANCHES).toEqual(['main', 'master', 'dev', 'develop', 'release']);
+    expect(PROTECTED_BRANCHES).toEqual(['main', 'master', 'dev', 'develop', 'release', 'gh-pages']);
   });
 });
 

--- a/server/services/branchReconcile.js
+++ b/server/services/branchReconcile.js
@@ -24,10 +24,51 @@ import { execGh } from './github.js';
 import { getOriginInfo } from '../lib/gitRemote.js';
 import { githubRepoSpec } from '../lib/workTracker.js';
 import { safeJSONParse, PATHS } from '../lib/fileUtils.js';
+import { PROTECTED_BRANCHES } from '../lib/gitArgs.js';
 
-// Never reconciled — these are long-lived shared branches, not disposable work.
-// The resolved default branch is added on top at runtime.
-export const PROTECTED_BRANCHES = ['main', 'master', 'release'];
+// Never reconciled — the canonical long-lived-branch set (`main`/`master`/`dev`/
+// `develop`/`release`/`gh-pages`) shared with the git branch-cleanup guards in
+// `../lib/gitArgs.js`, so a branch that can't be deleted also can't be handed to
+// the coordinator agent. The resolved default branch is added on top at runtime.
+// Re-exported for callers that reach for it from this module.
+export { PROTECTED_BRANCHES };
+
+// Recognized work-branch prefixes, in priority order. A branch whose name marks
+// it as tracked work — a human/scheduler claim (`claim/`), a CoS sub-agent branch
+// (`cos/`), a `/do:next` issue branch (`next/`), or a conventional feature/fix
+// branch — is reconciled AHEAD of anything unrecognized, so the coordinator agent
+// spends its bounded run on real deliverables first and only reaches ad-hoc or
+// experimental branches once those are drained. Both `/` and `-` separators match
+// (branch `feature/x` and worktree-derived `feature-x` alike).
+export const WORK_BRANCH_PREFIXES = [
+  'claim', 'cos', 'next', 'feature', 'fix', 'bugfix', 'hotfix',
+  'chore', 'refactor', 'docs', 'test', 'perf', 'build', 'ci', 'style'
+];
+
+/**
+ * Priority rank of a branch by its work-branch prefix — lower sorts first; an
+ * unrecognized branch ranks last (after every recognized prefix). Pure.
+ * @param {string} branch
+ * @returns {number}
+ */
+export function branchPriorityRank(branch) {
+  const name = branch || '';
+  const idx = WORK_BRANCH_PREFIXES.findIndex((p) => name.startsWith(`${p}/`) || name.startsWith(`${p}-`));
+  return idx === -1 ? WORK_BRANCH_PREFIXES.length : idx;
+}
+
+/**
+ * Stable priority sort of classified branches: recognized work-branch prefixes
+ * first (in WORK_BRANCH_PREFIXES order), then everything else, ties broken by
+ * branch name so the order is deterministic. Pure — does not mutate the input.
+ * @param {object[]} branches - entries carrying a `branch` field
+ * @returns {object[]}
+ */
+export function prioritizeBranches(branches) {
+  return [...branches].sort(
+    (a, b) => branchPriorityRank(a.branch) - branchPriorityRank(b.branch) || (a.branch || '').localeCompare(b.branch || '')
+  );
+}
 
 // A `claim-*` worktree is normally protected as a human `/claim` session that
 // self-cleans in the /claim Phase-7 flow. But when that flow never runs (the
@@ -431,7 +472,12 @@ export async function reconcile(repoPath = PATHS.root, { cleanup = true, activeA
   const classified = classifyBranches(inputs);
 
   const merged = classified.filter((c) => c.state === 'MERGED');
-  const inFlight = classified.filter((c) => ['ABANDONED_WIP', 'CONFLICTED', 'IN_REVIEW', 'NEEDS_PR'].includes(c.state));
+  // Priority-ordered so the coordinator agent works recognized work branches
+  // (claim/cos/next/feature/fix/…) before anything unrecognized. The order flows
+  // straight through filterActionable (a stable filter) into the prompt block.
+  const inFlight = prioritizeBranches(
+    classified.filter((c) => ['ABANDONED_WIP', 'CONFLICTED', 'IN_REVIEW', 'NEEDS_PR'].includes(c.state))
+  );
   const wip = classified.filter((c) => c.state === 'WIP');
 
   const { cleaned, skipped } = cleanup

--- a/server/services/branchReconcile.test.js
+++ b/server/services/branchReconcile.test.js
@@ -49,7 +49,8 @@ vi.mock('../lib/fileUtils.js', () => ({
 import {
   classifyBranch, classifyBranches, cleanupMerged, reconcile, gatherBranchState, worktreeProtectionReason,
   isAbandonedAgentWorktree, gatherDivergence,
-  actionOn, filterActionable, desiredEndState, formatInFlightForPrompt, actionableSignature
+  actionOn, filterActionable, desiredEndState, formatInFlightForPrompt, actionableSignature,
+  branchPriorityRank, prioritizeBranches
 } from './branchReconcile.js';
 import * as git from './git.js';
 import * as wt from './worktreeManager.js';
@@ -225,6 +226,9 @@ describe('gatherBranchState', () => {
     git.getBranches.mockResolvedValue([
       { name: 'main', isDefault: true, current: true, tracking: 'origin/main', merged: false },
       { name: 'release', isDefault: false, current: false, tracking: 'origin/release', merged: false },
+      // Long-lived shared branches that must never be reconciled or handed to the agent.
+      { name: 'develop', isDefault: false, current: false, tracking: 'origin/develop', merged: false },
+      { name: 'gh-pages', isDefault: false, current: false, tracking: 'origin/gh-pages', merged: false },
       { name: 'next/issue-2199', isDefault: false, current: false, tracking: 'origin/next/issue-2199', merged: false },
       { name: 'next/issue-2190', isDefault: false, current: false, tracking: 'origin/next/issue-2190', merged: true }
     ]);
@@ -238,7 +242,7 @@ describe('gatherBranchState', () => {
 
     const inputs = await gatherBranchState('/repo', { defaultBranch: 'main' });
     const names = inputs.map((i) => i.branch);
-    expect(names).toEqual(['next/issue-2199', 'next/issue-2190']); // main + release excluded
+    expect(names).toEqual(['next/issue-2199', 'next/issue-2190']); // main/release/develop/gh-pages excluded
 
     const i2199 = inputs.find((i) => i.branch === 'next/issue-2199');
     expect(i2199.hasWorktree).toBe(true);
@@ -383,7 +387,52 @@ describe('gatherDivergence', () => {
   });
 });
 
+describe('branchPriorityRank / prioritizeBranches', () => {
+  it('ranks recognized work-branch prefixes ahead of unrecognized ones, in list order', () => {
+    expect(branchPriorityRank('claim/issue-1')).toBeLessThan(branchPriorityRank('cos/task/agent'));
+    expect(branchPriorityRank('cos/task/agent')).toBeLessThan(branchPriorityRank('feature/x'));
+    expect(branchPriorityRank('feature/x')).toBeLessThan(branchPriorityRank('random-scratch'));
+    // Hyphen and slash separators both match; a bare keyword substring does not.
+    expect(branchPriorityRank('feature-x')).toBe(branchPriorityRank('feature/x'));
+    expect(branchPriorityRank('featureful')).toBe(branchPriorityRank('random-scratch'));
+  });
+
+  it('sorts by priority, ties broken by name, without mutating the input', () => {
+    const input = [
+      { branch: 'zzz-scratch' },
+      { branch: 'feature/b' },
+      { branch: 'claim/issue-9' },
+      { branch: 'feature/a' },
+      { branch: 'cos/task/agent-1' }
+    ];
+    const out = prioritizeBranches(input);
+    expect(out.map((b) => b.branch)).toEqual([
+      'claim/issue-9', 'cos/task/agent-1', 'feature/a', 'feature/b', 'zzz-scratch'
+    ]);
+    // Pure: original order untouched.
+    expect(input[0].branch).toBe('zzz-scratch');
+  });
+});
+
 describe('reconcile', () => {
+  it('orders in-flight branches by work-branch priority', async () => {
+    // A plain unrecognized branch, a feature branch, and a claim branch — all
+    // NEEDS_PR (pushed, not merged, no PR, clean). The claim/feature branches must
+    // lead the unrecognized one regardless of gather order.
+    git.getBranches.mockResolvedValue([
+      { name: 'scratch-thing', isDefault: false, current: false, tracking: 'origin/scratch-thing', merged: false },
+      { name: 'feature/new-thing', isDefault: false, current: false, tracking: 'origin/feature/new-thing', merged: false },
+      { name: 'claim/issue-42', isDefault: false, current: false, tracking: 'origin/claim/issue-42', merged: false }
+    ]);
+    wt.listWorktrees.mockResolvedValue([]);
+    execGh.mockResolvedValue('[]');
+    git.isBranchMergedInto.mockResolvedValue(false);
+
+    const res = await reconcile('/repo');
+    expect(res.inFlight.map((i) => i.branch)).toEqual(['claim/issue-42', 'feature/new-thing', 'scratch-thing']);
+    expect(res.inFlight.every((i) => i.state === 'NEEDS_PR')).toBe(true);
+  });
+
   it('cleans merged, returns in-flight + wip partitions', async () => {
     git.getBranches.mockResolvedValue([
       { name: 'next/issue-2190', isDefault: false, current: false, tracking: 'origin/x', merged: true },

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -1088,7 +1088,7 @@ export async function checkoutRemoteBranch(dir, branchName) {
 
 /**
  * Delete all merged branches (local and remote) in one operation.
- * Skips protected branches (main, master, dev, develop, release), the current branch,
+ * Skips the `PROTECTED_BRANCHES` set (see `../lib/gitArgs.js`), the current branch,
  * branches checked out in worktrees, and any explicitly excluded branches.
  * @param {string} dir - Working directory
  * @param {object} options


### PR DESCRIPTION
## Summary

The scheduled `branch-reconcile` task enumerates local branches, classifies them, and hands an "in-flight" set to a coordinator AI agent to open PRs / resolve conflicts / merge. Two fixes:

1. **Never hand long-lived shared branches to the agent.** The reconciler used its own narrow `['main','master','release']` list, so `gh-pages` was treated as ordinary work — it classified `NEEDS_PR` and the agent would try to "open a PR" merging it into the default branch (which would corrupt the published Pages site). It now reuses the single canonical `PROTECTED_BRANCHES` set in `server/lib/gitArgs.js` (which now also includes `gh-pages`), so a branch that can't be deleted also can't be reconciled. This additionally picks up `dev`/`develop` protection the reconciler's old list lacked. `release` was already covered.

2. **Prioritize recognized work branches.** The in-flight set is now ordered by branch prefix — `claim/`, `cos/`, `next/`, `feature/`, `fix/`, and other conventional prefixes rank ahead of unrecognized/ad-hoc branches — so a bounded coordinator run spends its budget on real deliverables first. Both `/` and `-` separators match. The order flows through `filterActionable` (a stable filter) into the coordinator prompt; `actionableSignature` sorts internally, so the perpetual-drain progress signature is unaffected.

`gh-pages` is now also protected from deletion at the three `git.js` branch-cleanup call sites — desirable and non-regressing (those sites only ever refuse to delete it).

## Changes

- `server/lib/gitArgs.js` — add `gh-pages` to the canonical `PROTECTED_BRANCHES`.
- `server/services/branchReconcile.js` — import + re-export the canonical list (drop the local narrower one); add pure `WORK_BRANCH_PREFIXES` / `branchPriorityRank` / `prioritizeBranches` and apply them to `reconcile().inFlight`.
- `server/services/git.js` — docstring now references the `PROTECTED_BRANCHES` set instead of a hardcoded list that had gone stale.
- Tests + changelog updated.

## Test plan

- `cd server && npx vitest run services/branchReconcile.test.js lib/gitArgs.test.js services/git.test.js` → 107 passing.
- New coverage: `gatherBranchState` excludes `develop`/`gh-pages` against the real (unmocked) `gitArgs` list; `branchPriorityRank`/`prioritizeBranches` contract tests (relative ordering, `/` vs `-`, purity); `reconcile` orders the in-flight set by work-branch priority.