### PR TITLE
Count a quota-burn dispatch when its agent runs, not when it is considered

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased Changes
+
+## Quota burn
+
+- **[issue-3179] Quota-burn no longer spends window budget on runs that never happened** — a scheduled quota-burn run counted against the family's per-window dispatch cap as soon as it was considered, even when it was subsequently skipped and no agent was ever started. Those phantom dispatches ate the budget, so a family configured for e.g. 5 burns per reset window could fire far fewer — and a family capped at 1 could never fire at all, because the skipped run consumed the only slot before the next gate re-read it. A burn is now counted once its agent has actually run, and a burn that is queued or in progress holds its slot in the meantime, so the cap stays accurate without letting a second app or a repeated "Run" overshoot it.

--- a/server/services/autonomousJobs/quotaBurnHooks.js
+++ b/server/services/autonomousJobs/quotaBurnHooks.js
@@ -43,11 +43,12 @@ function renderPrompt(candidate) {
 export async function buildTaskInput({ app } = {}) {
   if (!app) return { skip: { reason: 'no-app' } };
   const config = quotaBurnConfig(app);
-  // Ledger + in-flight: a quota-burn task already queued or running holds its
-  // window slot even though its ledger write lands post-agent (#3179).
-  const ledger = await getEffectiveQuotaBurnDispatches();
+  // Ledger + in-flight, NOT the bare ledger: a quota-burn task already queued or
+  // running holds its window slot even though its ledger write lands post-agent
+  // (#3179).
+  const dispatches = await getEffectiveQuotaBurnDispatches();
   const quotas = await getProviderQuotas({ refresh: true });
-  const candidates = selectBurnCandidates(quotas, config, { dispatches: ledger });
+  const candidates = selectBurnCandidates(quotas, config, { dispatches });
   const candidate = candidates[0];
   if (!candidate) return { skip: { reason: 'no-burnable-provider-quota' } };
 

--- a/server/services/autonomousJobs/quotaBurnHooks.js
+++ b/server/services/autonomousJobs/quotaBurnHooks.js
@@ -40,13 +40,14 @@ function renderPrompt(candidate) {
  * `hookMetadata`, which the generator stamps onto the task only once every gate
  * has passed, and `processTaskOutput` below records it post-agent.
  */
-export async function buildTaskInput({ app } = {}) {
+export async function buildTaskInput({ app, ignoreTaskId = null } = {}) {
   if (!app) return { skip: { reason: 'no-app' } };
   const config = quotaBurnConfig(app);
   // Ledger + in-flight, NOT the bare ledger: a quota-burn task already queued or
   // running holds its window slot even though its ledger write lands post-agent
-  // (#3179).
-  const dispatches = await getEffectiveQuotaBurnDispatches();
+  // (#3179). `ignoreTaskId` drops the run whose completion triggered this
+  // generation — it recorded itself moments ago but still reads `in_progress`.
+  const dispatches = await getEffectiveQuotaBurnDispatches({ ignoreTaskId });
   const quotas = await getProviderQuotas({ refresh: true });
   const candidates = selectBurnCandidates(quotas, config, { dispatches });
   const candidate = candidates[0];

--- a/server/services/autonomousJobs/quotaBurnHooks.js
+++ b/server/services/autonomousJobs/quotaBurnHooks.js
@@ -1,6 +1,6 @@
 import { getAllProviders } from '../providers.js';
 import { getProviderQuotas } from '../providerUsage.js';
-import { getQuotaBurnDispatches, recordQuotaBurnDispatch, selectBurnCandidates, quotaBurnConfig, QUOTA_BURN_TASK_TYPE } from '../quotaBurn.js';
+import { getEffectiveQuotaBurnDispatches, recordQuotaBurnDispatch, selectBurnCandidates, quotaBurnConfig, QUOTA_BURN_TASK_TYPE, QUOTA_BURN_DISPATCH_KEY_FIELD } from '../quotaBurn.js';
 
 function providerForFamily(providers, family) {
   const available = (providers || []).filter((provider) =>
@@ -29,11 +29,23 @@ function renderPrompt(candidate) {
  * Programmatic pre-agent hook. It refreshes quota readings immediately before
  * dispatch, pins an agent-capable provider in the selected family, and returns
  * a skip instead of spawning when any prerequisite is missing.
+ *
+ * Deliberately does NOT write the dispatch ledger (#3179). Several gates in
+ * `cosTaskGenerator.js#buildImprovementTask` run AFTER this hook returns —
+ * claim-work routing, the perpetual-work gate, branch-/issue-reconcile,
+ * reference-watch, the PLAN.md gate — and any of them can still `return null`
+ * and skip creating the task, with no agent ever spawned. A ledger write here
+ * therefore burned a slot of `family.maxDispatchesPerWindow` on a dispatch that
+ * never happened. Instead the resolved `dispatchKey` is handed back as
+ * `hookMetadata`, which the generator stamps onto the task only once every gate
+ * has passed, and `processTaskOutput` below records it post-agent.
  */
 export async function buildTaskInput({ app } = {}) {
   if (!app) return { skip: { reason: 'no-app' } };
   const config = quotaBurnConfig(app);
-  const ledger = await getQuotaBurnDispatches();
+  // Ledger + in-flight: a quota-burn task already queued or running holds its
+  // window slot even though its ledger write lands post-agent (#3179).
+  const ledger = await getEffectiveQuotaBurnDispatches();
   const quotas = await getProviderQuotas({ refresh: true });
   const candidates = selectBurnCandidates(quotas, config, { dispatches: ledger });
   const candidate = candidates[0];
@@ -46,12 +58,50 @@ export async function buildTaskInput({ app } = {}) {
   );
   if (!provider) return { skip: { reason: 'no-enabled-agent-provider-in-family' } };
 
-  await recordQuotaBurnDispatch(candidate.dispatchKey);
   return {
     prompt: renderPrompt(candidate),
     providerId: provider.id,
     model: candidate.family.model || null,
+    hookMetadata: { [QUOTA_BURN_DISPATCH_KEY_FIELD]: candidate.dispatchKey },
   };
+}
+
+/**
+ * Programmatic post-agent hook. Records the dispatch against the family's
+ * reset-window ledger — the ONLY place that write happens (#3179). By the time
+ * the finalize chokepoint runs this, an agent was actually spawned, which is the
+ * real event `family.maxDispatchesPerWindow` is meant to bound.
+ *
+ * Runs regardless of `success`: the provider quota was consumed the moment the
+ * agent ran, whether or not its run exited clean. A window's budget must count
+ * failed burns too, otherwise a family that keeps erroring out would dispatch
+ * without limit.
+ *
+ * Returns NO structured outcome, on purpose. `resolveProgrammaticIoVerdict`
+ * (agentFinalization.js) reads an output hook's outcome as the task type's
+ * success criterion, and quota-burn has none to offer: its agent does arbitrary
+ * user-configured work with no `.agent-done` payload contract, so nothing here
+ * evaluates the agent's output. Handing back no outcome keeps that verdict at
+ * the "undeclared" null sentinel, leaving quota-burn exit-code-judged exactly as
+ * it was before this hook existed. Do NOT return an object to make this "more
+ * informative" — that would declare a criterion this hook never checked.
+ *
+ * For the same reason the ledger write must not throw. finalizeAgent turns a
+ * thrown output hook into `{ ran: true, threw: true }`, which rejects the run's
+ * success criterion AND records a `hook-error` against the per-type
+ * consecutive-failure ledger that auto-parks a task type — so a transient
+ * ENOSPC/EACCES writing one JSON file could park quota-burn entirely. A failed
+ * write is environmental, not a bad run; log and move on, exactly as the
+ * verdict's own docstring prescribes for a hook whose side effect couldn't land.
+ */
+export async function processTaskOutput({ task } = {}) {
+  const dispatchKey = task?.metadata?.[QUOTA_BURN_DISPATCH_KEY_FIELD];
+  // Absent key = this task predates the metadata thread, or generation never
+  // resolved a candidate. Nothing to record; never invent a ledger entry.
+  if (typeof dispatchKey !== 'string' || !dispatchKey) return;
+  await recordQuotaBurnDispatch(dispatchKey)
+    .then(() => console.log(`🔥 Recorded quota-burn dispatch for ${dispatchKey}`))
+    .catch((err) => console.error(`❌ Failed to record quota-burn dispatch for ${dispatchKey}: ${err.message}`));
 }
 
 export const __test = { providerForFamily, renderPrompt, QUOTA_BURN_TASK_TYPE };

--- a/server/services/autonomousJobs/quotaBurnHooks.test.js
+++ b/server/services/autonomousJobs/quotaBurnHooks.test.js
@@ -1,0 +1,147 @@
+/**
+ * Tests for the quota-burn programmatic-I/O hooks (#3179).
+ *
+ * The behavior under test is WHEN the dispatch ledger is written. It used to be
+ * written inside `buildTaskInput`, before the task generator had finished
+ * gating — so any downstream skip (perpetual-work, branch-/issue-reconcile,
+ * reference-watch, PLAN.md) permanently consumed a slot of
+ * `family.maxDispatchesPerWindow` for an agent that never ran. The write now
+ * happens once, post-agent, in `processTaskOutput`.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const recordQuotaBurnDispatch = vi.fn().mockResolvedValue({});
+const selectBurnCandidates = vi.fn();
+const getEffectiveQuotaBurnDispatches = vi.fn().mockResolvedValue({});
+const getProviderQuotas = vi.fn().mockResolvedValue([]);
+const getAllProviders = vi.fn();
+
+vi.mock('../quotaBurn.js', () => ({
+  QUOTA_BURN_TASK_TYPE: 'quota-burn',
+  QUOTA_BURN_DISPATCH_KEY_FIELD: 'quotaBurnDispatchKey',
+  getEffectiveQuotaBurnDispatches: (...args) => getEffectiveQuotaBurnDispatches(...args),
+  recordQuotaBurnDispatch: (...args) => recordQuotaBurnDispatch(...args),
+  selectBurnCandidates: (...args) => selectBurnCandidates(...args),
+  quotaBurnConfig: (app) => app?.taskTypeOverrides?.['quota-burn']?.taskMetadata || { families: {} },
+}));
+vi.mock('../providerUsage.js', () => ({ getProviderQuotas: (...args) => getProviderQuotas(...args) }));
+vi.mock('../providers.js', () => ({ getAllProviders: (...args) => getAllProviders(...args) }));
+
+const { buildTaskInput, processTaskOutput } = await import('./quotaBurnHooks.js');
+const { QUOTA_BURN_DISPATCH_KEY_FIELD } = await import('../quotaBurn.js');
+const { generateTasksMarkdown, parseTasksMarkdown } = await import('../../lib/taskParser.js');
+
+const DISPATCH_KEY = 'grok:1753574400000';
+const APP = { id: 'app-1', name: 'App One', taskTypeOverrides: { 'quota-burn': { taskMetadata: { families: { grok: { enabled: true, prompt: 'Burn it.' } } } } } };
+const CANDIDATE = {
+  family: { id: 'grok', reservePercent: 20, maxDispatchesPerWindow: 2, prompt: 'Burn it.', model: 'grok-4' },
+  limit: { label: 'Weekly', scope: 'week', percentRemaining: 50 },
+  hoursUntilReset: 6,
+  dispatchKey: DISPATCH_KEY,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectBurnCandidates.mockReturnValue([CANDIDATE]);
+  getAllProviders.mockResolvedValue([{ id: 'grok-cli', enabled: true, type: 'cli' }]);
+});
+
+describe('buildTaskInput (pre-agent)', () => {
+  it('hands the dispatch key back as hookMetadata WITHOUT writing the ledger', async () => {
+    const input = await buildTaskInput({ app: APP });
+
+    expect(input.hookMetadata).toEqual({ [QUOTA_BURN_DISPATCH_KEY_FIELD]: DISPATCH_KEY });
+    expect(input.providerId).toBe('grok-cli');
+    expect(input.model).toBe('grok-4');
+    expect(input.prompt).toContain('Burn it.');
+    // The whole point of #3179: nothing is recorded until an agent actually runs.
+    expect(recordQuotaBurnDispatch).not.toHaveBeenCalled();
+  });
+
+  it('records nothing on any skip path', async () => {
+    await expect(buildTaskInput({})).resolves.toMatchObject({ skip: { reason: 'no-app' } });
+
+    selectBurnCandidates.mockReturnValue([]);
+    await expect(buildTaskInput({ app: APP })).resolves.toMatchObject({ skip: { reason: 'no-burnable-provider-quota' } });
+
+    selectBurnCandidates.mockReturnValue([CANDIDATE]);
+    getAllProviders.mockResolvedValue([{ id: 'other', enabled: true, type: 'cli' }]);
+    await expect(buildTaskInput({ app: APP })).resolves.toMatchObject({ skip: { reason: 'no-enabled-agent-provider-in-family' } });
+
+    expect(recordQuotaBurnDispatch).not.toHaveBeenCalled();
+  });
+
+  it('selects against the ledger PLUS in-flight tasks, not the bare ledger', async () => {
+    // With the write deferred to processTaskOutput, an already-queued burn is
+    // invisible to the raw ledger — so candidate selection has to consult the
+    // effective count or a sibling app (or a second on-demand Run) would dispatch
+    // straight past maxDispatchesPerWindow.
+    getEffectiveQuotaBurnDispatches.mockResolvedValue({ [DISPATCH_KEY]: 1 });
+
+    await buildTaskInput({ app: APP });
+
+    expect(getEffectiveQuotaBurnDispatches).toHaveBeenCalled();
+    expect(selectBurnCandidates).toHaveBeenCalledWith(expect.anything(), expect.anything(), { dispatches: { [DISPATCH_KEY]: 1 } });
+  });
+});
+
+describe('processTaskOutput (post-agent)', () => {
+  const task = { metadata: { [QUOTA_BURN_DISPATCH_KEY_FIELD]: DISPATCH_KEY } };
+
+  // The quota was consumed the moment the agent ran, so a failed run counts too.
+  it.each([true, false])('records the dispatch exactly once on a run with success=%s', async (success) => {
+    await processTaskOutput({ appId: 'app-1', success, payload: null, task });
+
+    expect(recordQuotaBurnDispatch).toHaveBeenCalledTimes(1);
+    expect(recordQuotaBurnDispatch).toHaveBeenCalledWith(DISPATCH_KEY);
+  });
+
+  it('swallows a ledger write failure instead of throwing', async () => {
+    // A thrown output hook is read as `{ ran: true, threw: true }` — which
+    // rejects the run's success criterion AND records a `hook-error` against the
+    // per-type failure ledger that auto-parks a task type. A full disk must not
+    // park quota-burn, so an environmental write failure stays a log line.
+    recordQuotaBurnDispatch.mockRejectedValueOnce(new Error('ENOSPC'));
+
+    await expect(processTaskOutput({ appId: 'app-1', success: true, task })).resolves.toBeUndefined();
+  });
+
+  it('no-ops when the task carries no dispatch key (task predating the metadata thread)', async () => {
+    await processTaskOutput({ success: true, task: { metadata: {} } });
+    await processTaskOutput({ success: true, task: {} });
+    await processTaskOutput({ success: true });
+    await processTaskOutput();
+    // A non-string key must not be coerced into a ledger entry either.
+    await processTaskOutput({ success: true, task: { metadata: { [QUOTA_BURN_DISPATCH_KEY_FIELD]: { id: 'grok' } } } });
+    await processTaskOutput({ success: true, task: { metadata: { [QUOTA_BURN_DISPATCH_KEY_FIELD]: '' } } });
+
+    expect(recordQuotaBurnDispatch).not.toHaveBeenCalled();
+  });
+
+  it('reads a dispatch key that survived the COS-TASKS.md round-trip', async () => {
+    // The key only reaches this hook by riding in the task's PERSISTED metadata,
+    // so the markdown format has to carry it intact. Two ways it could silently
+    // fail: `parseMetadataLine` keys on `\w+` (fine for the camelCase field), and
+    // it splits on the FIRST colon — while a dispatch key is `<family>:<epochMs>`
+    // and so contains one. A greedy value capture is what makes that work; this
+    // pins it, because a regression would look like a hook that just never fires.
+    const built = await buildTaskInput({ app: APP });
+    const persisted = { id: 'sys-abc', status: 'pending', priority: 'MEDIUM', description: 'quota burn', metadata: { app: 'app-1', analysisType: 'quota-burn', ...built.hookMetadata } };
+    const [reparsed] = parseTasksMarkdown(generateTasksMarkdown([persisted], true));
+
+    expect(reparsed.metadata[QUOTA_BURN_DISPATCH_KEY_FIELD]).toBe(DISPATCH_KEY);
+
+    await processTaskOutput({ appId: 'app-1', success: true, task: reparsed });
+    expect(recordQuotaBurnDispatch).toHaveBeenCalledWith(DISPATCH_KEY);
+  });
+
+  it('returns no structured outcome, so quota-burn stays exit-code-judged', async () => {
+    // Registering an output hook must NOT start declaring a success criterion for
+    // a task type whose agent has no `.agent-done` payload contract.
+    // resolveProgrammaticIoVerdict maps a non-object outcome to the "undeclared"
+    // null sentinel (pinned in agentFinalization.successCriteria.test.js), which
+    // keeps task-learning falling back to the exit code exactly as before.
+    expect(await processTaskOutput({ appId: 'app-1', success: true, task })).toBeUndefined();
+  });
+});

--- a/server/services/autonomousJobs/quotaBurnHooks.test.js
+++ b/server/services/autonomousJobs/quotaBurnHooks.test.js
@@ -86,6 +86,12 @@ describe('buildTaskInput (pre-agent)', () => {
     expect(getEffectiveQuotaBurnDispatches).toHaveBeenCalled();
     expect(selectBurnCandidates).toHaveBeenCalledWith(expect.anything(), expect.anything(), { dispatches: { [DISPATCH_KEY]: 1 } });
   });
+
+  it('forwards ignoreTaskId so the completing run is not counted against itself', async () => {
+    await buildTaskInput({ app: APP, ignoreTaskId: 'sys-finishing' });
+
+    expect(getEffectiveQuotaBurnDispatches).toHaveBeenCalledWith({ ignoreTaskId: 'sys-finishing' });
+  });
 });
 
 describe('processTaskOutput (post-agent)', () => {

--- a/server/services/autonomousJobs/quotaBurnHooks.test.js
+++ b/server/services/autonomousJobs/quotaBurnHooks.test.js
@@ -6,7 +6,9 @@
  * gating — so any downstream skip (perpetual-work, branch-/issue-reconcile,
  * reference-watch, PLAN.md) permanently consumed a slot of
  * `family.maxDispatchesPerWindow` for an agent that never ran. The write now
- * happens once, post-agent, in `processTaskOutput`.
+ * happens once, post-agent, in `processTaskOutput` — and because that leaves a
+ * gap where a created burn isn't in the ledger yet, candidate selection counts
+ * in-flight burns alongside it so the window cap still holds.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -1006,7 +1006,7 @@ async function spawnDequeuePriority3Missions(ctx) {
  * tasks, idle review on, auto-run in execute).
  */
 async function spawnDequeuePriority4IdleReview(ctx) {
-  const { state, capacity } = ctx;
+  const { state, capacity, ignoreTaskId } = ctx;
 
   if (!isIdleTierEligible({
     spawned: capacity.spawned,
@@ -1018,7 +1018,7 @@ async function spawnDequeuePriority4IdleReview(ctx) {
   const freshCosTasks = await getCosTasks();
   const pendingSystemTasks = freshCosTasks.autoApproved?.length || 0;
   if (pendingSystemTasks === 0) {
-    const idleTask = await generateIdleReviewTask(state);
+    const idleTask = await generateIdleReviewTask(state, { ignoreTaskId });
     if (idleTask && capacity.canSpawn(idleTask, ctx.autonomousSpawnCeiling)) {
       cosEvents.emit('task:ready', idleTask);
       capacity.trackSpawn(idleTask);
@@ -1039,7 +1039,15 @@ async function spawnDequeuePriority4IdleReview(ctx) {
  *   4. Idle review task (if idleReviewEnabled)
  * Returns silently when idle — no log noise.
  */
-async function dequeueNextTask() {
+/**
+ * `ignoreTaskId` names a task that just completed but may still read
+ * `pending`/`in_progress` on disk — `agent:completed` fires from `completeAgent`,
+ * before the completion flow's `updateTask` settles it. Generators that count
+ * in-flight work (quota-burn's dispatch tally, #3179) must exclude it or they
+ * charge the finished run twice. Only the completion continuation passes it; every
+ * other caller runs outside that window and correctly leaves it null.
+ */
+async function dequeueNextTask({ ignoreTaskId = null } = {}) {
   if (!isDaemonRunning()) return;
 
   // A global pause stops scheduled/autonomous spawning, but NOT explicit user
@@ -1071,7 +1079,8 @@ async function dequeueNextTask() {
     hasPendingUserTasks: false,
     taskSchedule: null,
     cosAutonomyMode: null,
-    autonomousSpawnCeiling: availableSlots
+    autonomousSpawnCeiling: availableSlots,
+    ignoreTaskId
   };
 
   // Priority 0 (on-demand) runs even when paused — an explicit user "Run"
@@ -1186,7 +1195,10 @@ export async function init() {
     setImmediate(() => {
       refillPerpetualForCompletedAgent(agent)
         .catch(err => console.error(`❌ Perpetual refill after ${agent?.id} failed: ${err.message}`))
-        .then(() => dequeueNextTask())
+        // Same window as the refill above: this runs before the completing
+        // task's `updateTask` settles it, so the idle tier's generator must
+        // exclude it from any in-flight tally (#3179).
+        .then(() => dequeueNextTask({ ignoreTaskId: agent?.taskId }))
         .catch(err => console.error(`❌ Dequeue after ${agent?.id} completion failed: ${err.message}`));
     });
 

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -1264,8 +1264,16 @@ describe('cos.js source — agent:completed triggers perpetual refill', () => {
     const onIdx = COS_SRC.indexOf("cosEvents.on('agent:completed'");
     const handlerSlice = COS_SRC.slice(onIdx, onIdx + 1400);
     expect(
-      /refillPerpetualForCompletedAgent\(agent\)[\s\S]*\.then\(\s*\(\)\s*=>\s*dequeueNextTask\(\)\s*\)/.test(handlerSlice),
+      /refillPerpetualForCompletedAgent\(agent\)[\s\S]*\.then\(\s*\(\)\s*=>\s*dequeueNextTask\(/.test(handlerSlice),
       'handler must run dequeueNextTask in a .then() AFTER the refill resolves'
+    ).toBe(true);
+    // Both generators on this continuation must skip the completing task, which
+    // still reads pending/in_progress until updateTask settles it (#3179): the
+    // refill excludes it via queueEligibleImprovementTasks, and the dequeue's
+    // idle-review tier via this argument.
+    expect(
+      /dequeueNextTask\(\{\s*ignoreTaskId:\s*agent\?\.taskId\s*\}\)/.test(handlerSlice),
+      'the post-refill dequeue must pass the completing task id as ignoreTaskId'
     ).toBe(true);
     // The old standalone `setImmediate(() => dequeueNextTask())` must be gone —
     // its presence would race the refill.

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -23,6 +23,7 @@ import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { sanitizeTaskMetadata, PIPELINE_BEHAVIOR_FLAGS, MAX_TOTAL_SPAWNS, normalizeReviewers, resolveReviewUsernames, resolveOptionalReviewers, resolveReviewerMaxRounds, resolveReviewerModels, reviewerModelsFromDefaults, buildReviewersCsv, LOCAL_LLM_REVIEWERS, SWARM_COUNT_MIN } from '../lib/validation.js';
+import { isPlainObject } from '../lib/objects.js';
 import { parsePlanItems, extractAllIds, findInProgressIds, pickFirstAvailable, diagnoseUnpickablePlan } from '../lib/planIds.js';
 import { loadState, saveState, withStateLock, isImprovementEnabled, isDaemonRunning } from './cosState.js';
 import { getDomainMode } from '../lib/domainAutonomy.js';
@@ -1860,13 +1861,17 @@ async function buildImprovementTaskMetadata(taskType, app, interval, taskSchedul
  * Run a task type's registered buildTaskInput hook (taskTypeHooks.js) for
  * deterministic pre-agent data collection. Returns `{ skip: true }` when the
  * hook opts out (execution recorded so cadence advances), otherwise
- * `{ skip: false, hookPrompt, hookOverride }` — the hook may fully own the
- * rendered prompt and/or pin the app's per-app provider/model.
+ * `{ skip: false, hookPrompt, hookOverride, hookMetadata }` — the hook may fully
+ * own the rendered prompt, pin the app's per-app provider/model, and hand back a
+ * metadata bag to stamp onto the created task.
+ *
+ * `hookMetadata` is normalized to null unless the hook returned a real object,
+ * so the caller's "stamp it" check can't be tripped by a stray primitive.
  */
-async function resolveTaskInputHook(app, taskType, taskSchedule) {
+export async function resolveTaskInputHook(app, taskType, taskSchedule) {
   const { getTaskInputHook } = await import('./taskTypeHooks.js');
   const inputHook = await getTaskInputHook(taskType);
-  if (!inputHook) return { skip: false, hookPrompt: null, hookOverride: {} };
+  if (!inputHook) return { skip: false, hookPrompt: null, hookOverride: {}, hookMetadata: null };
   const input = await inputHook({ app, taskType }).catch((err) => {
     emitLog('warn', `buildTaskInput hook failed for ${taskType}/${app.name}: ${err.message}`, { appId: app.id, analysisType: taskType });
     return { skip: { reason: 'input-hook-error' } };
@@ -1879,7 +1884,8 @@ async function resolveTaskInputHook(app, taskType, taskSchedule) {
   return {
     skip: false,
     hookPrompt: input?.prompt || null,
-    hookOverride: { providerId: input?.providerId || null, model: input?.model || null }
+    hookOverride: { providerId: input?.providerId || null, model: input?.model || null },
+    hookMetadata: isPlainObject(input?.hookMetadata) ? input.hookMetadata : null
   };
 }
 
@@ -2331,7 +2337,7 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
   // provider/model block below, so the per-app choice wins.
   const inputHook = await resolveTaskInputHook(app, taskType, taskSchedule);
   if (inputHook.skip) return null;
-  const { hookPrompt, hookOverride } = inputHook;
+  const { hookPrompt, hookOverride, hookMetadata } = inputHook;
 
   // claim-work single-source router: `taskType` stays 'claim-work' for
   // interval/cadence/recording; `promptTaskType` drives prompt selection, PLAN
@@ -2431,9 +2437,29 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
 
   const approval = await resolveConfidenceApproval(state, `app-improve:${taskType}`, `Task app-improve:${taskType} for ${app.name}`, metadata);
 
-  // All gates passed — record the rotation-pointer advance + emit the
-  // generation log. Deferred from the top of the function (see note there);
-  // every `return null` above this point intentionally leaves both untouched.
+  // All gates passed — stamp the buildTaskInput hook's metadata bag, record the
+  // rotation-pointer advance, and emit the generation log. Deferred from the top
+  // of the function (see note there); every `return null` above this point
+  // intentionally leaves all three untouched.
+  //
+  // The hook bag lands HERE, below the last gate, precisely so a hook can defer a
+  // side effect keyed on it until the task is certain to exist (rationale in
+  // autonomousJobs/quotaBurnHooks.js#buildTaskInput, #3179).
+  //
+  // Generator-computed keys always win. Stamping last would otherwise let a hook
+  // silently clobber a decision made a few lines earlier — `analysisType` is the
+  // dangerous one, since resolveTaskHookType reads it to dispatch the output hook,
+  // so a collision would stop the very hook that asked for the bag from ever
+  // running. Hooks pin provider/model and own the prompt through their own return
+  // fields; the bag is for values that must SURVIVE to processTaskOutput, not an
+  // override channel. Dropped collisions are logged rather than merged silently.
+  for (const [key, value] of Object.entries(hookMetadata || {})) {
+    if (key in metadata) {
+      emitLog('warn', `Ignoring ${taskType} hookMetadata key '${key}' for ${app.name}: it would overwrite generator-owned task metadata`, { appId: app.id, analysisType: taskType });
+      continue;
+    }
+    metadata[key] = value;
+  }
   await updateAppActivity(app.id, { lastImprovementType: taskType });
   emitLog('info', `Generating improvement task for ${app.name}: ${taskType}`, { appId: app.id, analysisType: taskType });
 

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -1219,7 +1219,7 @@ export async function evaluateTasks(options) {
  * @param {Object} state - Current CoS state
  * @returns {Object|null} Generated task or null if nothing to do
  */
-export async function generateIdleReviewTask(state) {
+export async function generateIdleReviewTask(state, { ignoreTaskId = null } = {}) {
   if (!isImprovementEnabled(state)) {
     emitLog('debug', 'Improvement tasks are disabled');
     return null;
@@ -1250,7 +1250,7 @@ export async function generateIdleReviewTask(state) {
       });
 
       emitLog('info', `Generating improvement task for ${nextApp.name}`, { appId: nextApp.id });
-      const idleTask = await generateManagedAppImprovementTask(nextApp, state);
+      const idleTask = await generateManagedAppImprovementTask(nextApp, state, { ignoreTaskId });
       // Only bind the active marker once a real task exists.
       if (idleTask) {
         await bindAppReviewAgent(nextApp.id, `idle-review-${Date.now()}`);
@@ -1709,7 +1709,7 @@ export function applyAppWorktreeDefault(metadata, app) {
   }
 }
 
-async function generateManagedAppImprovementTask(app, state) {
+async function generateManagedAppImprovementTask(app, state, { ignoreTaskId = null } = {}) {
   const { getAppActivityById, updateAppActivity } = await import('./appActivity.js');
   const taskSchedule = await import('./taskSchedule.js');
 
@@ -1761,7 +1761,7 @@ async function generateManagedAppImprovementTask(app, state) {
   // with the literal {prData}/{referenceData} markers and never poll. The
   // recordExecution + activity bump above already accounted for the idle
   // spawn; the per-type generator does not record execution itself.
-  return generateManagedAppImprovementTaskForType(nextType, app, state);
+  return generateManagedAppImprovementTaskForType(nextType, app, state, { ignoreTaskId });
 }
 
 /**

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -1433,7 +1433,7 @@ export async function queueEligibleImprovementTasks(state, cosTaskData, { ignore
     // agents claim the same slug (2026-05-21 incident). The generator
     // returns null on plan-gate / precondition skip; we silently continue.
     // Regression-pinned in cos.test.js.
-    const task = await generateManagedAppImprovementTaskForType(nextType, app, state);
+    const task = await generateManagedAppImprovementTaskForType(nextType, app, state, { ignoreTaskId });
     if (!task) continue;
 
     // Queue-path invariants override the generator's direct-spawn defaults
@@ -1868,11 +1868,11 @@ async function buildImprovementTaskMetadata(taskType, app, interval, taskSchedul
  * `hookMetadata` is normalized to null unless the hook returned a real object,
  * so the caller's "stamp it" check can't be tripped by a stray primitive.
  */
-export async function resolveTaskInputHook(app, taskType, taskSchedule) {
+export async function resolveTaskInputHook(app, taskType, taskSchedule, { ignoreTaskId = null } = {}) {
   const { getTaskInputHook } = await import('./taskTypeHooks.js');
   const inputHook = await getTaskInputHook(taskType);
   if (!inputHook) return { skip: false, hookPrompt: null, hookOverride: {}, hookMetadata: null };
-  const input = await inputHook({ app, taskType }).catch((err) => {
+  const input = await inputHook({ app, taskType, ignoreTaskId }).catch((err) => {
     emitLog('warn', `buildTaskInput hook failed for ${taskType}/${app.name}: ${err.message}`, { appId: app.id, analysisType: taskType });
     return { skip: { reason: 'input-hook-error' } };
   });
@@ -1923,14 +1923,17 @@ async function resolveClaimWorkRouting(app, taskType, metadata, taskSchedule) {
  * The detector keys on the RESOLVED promptTaskType. Returns `{ skip }` and
  * mutates `metadata.perpetual` on the actionable path.
  */
-async function applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, interval, taskSchedule) {
+async function applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, interval, taskSchedule, { ignoreTaskId = null } = {}) {
   if (interval.type !== taskSchedule.INTERVAL_TYPES.PERPETUAL
       || taskType === 'branch-reconcile' || taskType === 'issue-reconcile') {
     return { skip: false };
   }
   const { detectActionableWork } = await import('./perpetualWork.js');
   const detection = await detectActionableWork(promptTaskType, app, {
-    issueAuthorFilter: metadata.issueAuthorFilter || 'self'
+    issueAuthorFilter: metadata.issueAuthorFilter || 'self',
+    // A detector that counts in-flight work must skip the task whose completion
+    // triggered this refill — it is already recorded, just not yet marked done.
+    ignoreTaskId
   });
   if (detection.actionable) {
     await taskSchedule.clearPerpetualPark(taskType, app.id);
@@ -2303,7 +2306,7 @@ function applyProviderModelPins(metadata, interval, hookOverride) {
   if (hookOverride.model) { metadata.model = hookOverride.model; }
 }
 
-export async function generateManagedAppImprovementTaskForType(taskType, app, state, { skipPreconditions = false } = {}) {
+export async function generateManagedAppImprovementTaskForType(taskType, app, state, { skipPreconditions = false, ignoreTaskId = null } = {}) {
   const { updateAppActivity } = await import('./appActivity.js');
   const taskSchedule = await import('./taskSchedule.js');
   const { getTaskPrompt, getStagePrompt } = await import('./taskPromptService.js');
@@ -2335,7 +2338,11 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
   // fully OWNS its prompt. `hookOverride` may pin the app's per-app
   // provider/model — captured here but APPLIED AFTER the global-interval
   // provider/model block below, so the per-app choice wins.
-  const inputHook = await resolveTaskInputHook(app, taskType, taskSchedule);
+  // `ignoreTaskId` reaches the hook because a drain-on-completion refill runs
+  // while the completing task is still `in_progress` on disk — a hook that
+  // counts in-flight tasks (quota-burn) must not count the run that just
+  // finished and already recorded itself (#3179).
+  const inputHook = await resolveTaskInputHook(app, taskType, taskSchedule, { ignoreTaskId });
   if (inputHook.skip) return null;
   const { hookPrompt, hookOverride, hookMetadata } = inputHook;
 
@@ -2347,7 +2354,7 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
   // Perpetual (drain-until-done) gate — probes for actionable work before
   // building the prompt or burning an agent (branch-/issue-reconcile self-gate
   // in their own blocks, so this excludes them).
-  const perpetualGate = await applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, interval, taskSchedule);
+  const perpetualGate = await applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, interval, taskSchedule, { ignoreTaskId });
   if (perpetualGate.skip) return null;
 
   // branch-reconcile: deterministic git/gh pre-step that carries the actionable

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -886,3 +886,25 @@ describe('ignoreTaskId reaches the in-flight-counting gates (#3179)', () => {
     expect(seen[0]).toMatchObject({ taskType: 'quota-burn', ignoreTaskId: 'sys-finishing' });
   });
 });
+
+/**
+ * BOTH generators reachable from the `agent:completed` continuation must carry
+ * ignoreTaskId: the refill (queueEligibleImprovementTasks) AND the idle-review
+ * tier that `dequeueNextTask` runs on the same continuation. The idle path was
+ * missed on the first pass — it dropped the id and re-charged the completing
+ * burn, skipping a dispatch the family was entitled to (#3179).
+ */
+describe('ignoreTaskId reaches BOTH completion-continuation generators (#3179)', () => {
+  it('the idle-review chain threads ignoreTaskId end to end', () => {
+    expect(GEN_SRC).toMatch(/export async function generateIdleReviewTask\(state, \{ ignoreTaskId = null \} = \{\}\)/);
+    expect(GEN_SRC).toContain('generateManagedAppImprovementTask(nextApp, state, { ignoreTaskId })');
+    expect(GEN_SRC).toMatch(/async function generateManagedAppImprovementTask\(app, state, \{ ignoreTaskId = null \} = \{\}\)/);
+    expect(GEN_SRC).toContain('generateManagedAppImprovementTaskForType(nextType, app, state, { ignoreTaskId })');
+  });
+
+  it('cos.js passes the completing task id into the dequeue that follows the refill', () => {
+    expect(COS_SRC).toContain('dequeueNextTask({ ignoreTaskId: agent?.taskId })');
+    expect(COS_SRC).toMatch(/async function dequeueNextTask\(\{ ignoreTaskId = null \} = \{\}\)/);
+    expect(COS_SRC).toContain('generateIdleReviewTask(state, { ignoreTaskId })');
+  });
+});

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -842,3 +842,47 @@ describe('resolveTaskInputHook — hookMetadata threading (#3179)', () => {
     expect(stampAt).toBeGreaterThan(lastGateAt);
   });
 });
+
+/**
+ * The drain-on-completion refill regenerates while the just-finished task is
+ * still `in_progress` on disk (agent:completed fires before updateTask). A hook
+ * or detector that counts in-flight work must exclude it, or the completing run
+ * is charged twice — see #3179 and buildImprovementDedupSets' own ignoreTaskId.
+ */
+describe('ignoreTaskId reaches the in-flight-counting gates (#3179)', () => {
+  const body = () => {
+    const start = GEN_SRC.indexOf('export async function generateManagedAppImprovementTaskForType');
+    return GEN_SRC.slice(start, GEN_SRC.indexOf('return task;', start));
+  };
+
+  it('accepts ignoreTaskId and forwards it to the input hook and the perpetual gate', () => {
+    expect(GEN_SRC).toMatch(/generateManagedAppImprovementTaskForType\(taskType, app, state, \{ skipPreconditions = false, ignoreTaskId = null \} = \{\}\)/);
+    expect(body()).toContain('resolveTaskInputHook(app, taskType, taskSchedule, { ignoreTaskId })');
+    expect(body()).toContain('applyPerpetualWorkGate(app, taskType, promptTaskType, metadata, interval, taskSchedule, { ignoreTaskId })');
+  });
+
+  it('queueEligibleImprovementTasks passes its ignoreTaskId down to the generator', () => {
+    // It already forwards the same id to addTask and buildImprovementDedupSets;
+    // the generator was the one path that dropped it.
+    expect(GEN_SRC).toContain('generateManagedAppImprovementTaskForType(nextType, app, state, { ignoreTaskId })');
+  });
+
+  it('the perpetual gate hands ignoreTaskId to the work detector', () => {
+    const start = GEN_SRC.indexOf('async function applyPerpetualWorkGate');
+    const gate = GEN_SRC.slice(start, GEN_SRC.indexOf('\n}', start));
+    expect(gate).toMatch(/detectActionableWork\(promptTaskType, app, \{[\s\S]*ignoreTaskId[\s\S]*\}\)/);
+  });
+
+  it('resolveTaskInputHook passes ignoreTaskId into the hook call', async () => {
+    const seen = [];
+    vi.doMock('./taskTypeHooks.js', () => ({
+      getTaskInputHook: async () => async (args) => { seen.push(args); return { prompt: 'X' }; }
+    }));
+    try {
+      await resolveTaskInputHook({ id: 'app-1', name: 'App One' }, 'quota-burn', { recordExecution: vi.fn() }, { ignoreTaskId: 'sys-finishing' });
+    } finally {
+      vi.doUnmock('./taskTypeHooks.js');
+    }
+    expect(seen[0]).toMatchObject({ taskType: 'quota-burn', ignoreTaskId: 'sys-finishing' });
+  });
+});

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -28,7 +28,7 @@ vi.mock('./codeReview.js', async (importActual) => ({
   getCodeReviewDefaults: vi.fn(async () => ({ reviewers: ['copilot'], usernames: ['alice'], optionalReviewers: [] })),
 }));
 
-import { selectDryRunAutoApproved, exceedsMaxSpawns, resolveIssueAuthorFilterBlock, resolveSwarmBlock, isCooldownExemptTask, emitOnDemandEmpty, buildJiraTicketTask, buildImprovementDedupSets, normalizeWorkItemRef, buildTargetWorkItemBlock } from './cosTaskGenerator.js';
+import { selectDryRunAutoApproved, exceedsMaxSpawns, resolveIssueAuthorFilterBlock, resolveSwarmBlock, isCooldownExemptTask, emitOnDemandEmpty, buildJiraTicketTask, buildImprovementDedupSets, normalizeWorkItemRef, buildTargetWorkItemBlock, resolveTaskInputHook } from './cosTaskGenerator.js';
 import { cosEvents } from './cosEvents.js';
 import { MAX_TOTAL_SPAWNS } from '../lib/validation.js';
 
@@ -750,5 +750,95 @@ describe('buildImprovementDedupSets (#2614 — failure-blocked tasks occupy thei
     // Source-pinned: the queue path must consume buildImprovementDedupSets so
     // its occupancy semantics can't silently drift from the tested helper.
     expect(GEN_SRC).toMatch(/buildImprovementDedupSets\(existingTasks/);
+  });
+});
+
+/**
+ * `hookMetadata` is the channel a buildTaskInput hook uses to defer a side
+ * effect until the task is CERTAIN to exist (#3179). quota-burn rides its
+ * resolved dispatch key across on it so the ledger is written post-agent, rather
+ * than inside the input hook where any of the gates below it could still skip
+ * task creation and burn window budget on a dispatch that never ran.
+ */
+describe('resolveTaskInputHook — hookMetadata threading (#3179)', () => {
+  const app = { id: 'app-1', name: 'App One' };
+  const taskSchedule = { recordExecution: vi.fn() };
+
+  // resolveTaskInputHook resolves the hook through a DYNAMIC import, so a
+  // per-test doMock reaches it without a file-wide module mock.
+  const withInputHook = async (buildTaskInput, fn) => {
+    vi.doMock('./taskTypeHooks.js', () => ({ getTaskInputHook: async () => buildTaskInput }));
+    try {
+      return await fn();
+    } finally {
+      vi.doUnmock('./taskTypeHooks.js');
+    }
+  };
+
+  it('threads a hook metadata bag through alongside the prompt and provider pins', async () => {
+    const resolved = await withInputHook(
+      async () => ({ prompt: 'BURN', providerId: 'grok-cli', model: 'grok-4', hookMetadata: { quotaBurnDispatchKey: 'grok:123' } }),
+      () => resolveTaskInputHook(app, 'quota-burn', taskSchedule)
+    );
+    expect(resolved).toMatchObject({
+      skip: false,
+      hookPrompt: 'BURN',
+      hookOverride: { providerId: 'grok-cli', model: 'grok-4' },
+      hookMetadata: { quotaBurnDispatchKey: 'grok:123' }
+    });
+  });
+
+  it('normalizes a missing or non-object bag to null so the caller never stamps a primitive', async () => {
+    const cases = [undefined, null, 'grok:123', 42, ['grok:123']];
+    for (const hookMetadata of cases) {
+      const resolved = await withInputHook(
+        async () => ({ prompt: 'BURN', hookMetadata }),
+        () => resolveTaskInputHook(app, 'quota-burn', taskSchedule)
+      );
+      expect(resolved.hookMetadata, `hookMetadata: ${JSON.stringify(hookMetadata)}`).toBeNull();
+    }
+  });
+
+  it('returns a null bag for a task type that registers no input hook', async () => {
+    const resolved = await withInputHook(null, () => resolveTaskInputHook(app, 'performance', taskSchedule));
+    expect(resolved).toEqual({ skip: false, hookPrompt: null, hookOverride: {}, hookMetadata: null });
+  });
+
+  it('carries no bag on a skip — the task is never created, so nothing may be stamped', async () => {
+    const resolved = await withInputHook(
+      async () => ({ skip: { reason: 'no-burnable-provider-quota' } }),
+      () => resolveTaskInputHook(app, 'quota-burn', taskSchedule)
+    );
+    expect(resolved).toEqual({ skip: true });
+    expect(taskSchedule.recordExecution).toHaveBeenCalledWith('quota-burn', 'app-1');
+  });
+
+  it('drops a bag key that would overwrite generator-owned metadata', () => {
+    // The bag is stamped LAST, so a naive Object.assign would let a hook silently
+    // win over a decision made a few lines earlier. `analysisType` is the sharp
+    // edge: resolveTaskHookType reads it to dispatch the output hook, so a
+    // collision would stop the very hook that asked for the bag from running.
+    const start = GEN_SRC.indexOf('export async function generateManagedAppImprovementTaskForType');
+    const body = GEN_SRC.slice(start, GEN_SRC.indexOf('return task;', start));
+    expect(body).toContain('for (const [key, value] of Object.entries(hookMetadata || {}))');
+    expect(body).toContain('if (key in metadata)');
+    // A plain merge would reintroduce the clobber.
+    expect(body).not.toContain('Object.assign(metadata, hookMetadata)');
+  });
+
+  it('stamps the bag onto metadata BELOW every gate that can still skip task creation', () => {
+    // The ordering IS the fix. Source-pinned because it is invisible to a unit
+    // test of the generator's happy path: moving the Object.assign above any
+    // `return null` would silently restore the #3179 bug — a hook side effect
+    // keyed on the stamped metadata would fire for a task that is never built.
+    const start = GEN_SRC.indexOf('export async function generateManagedAppImprovementTaskForType');
+    expect(start, 'generateManagedAppImprovementTaskForType must exist').toBeGreaterThan(-1);
+    const body = GEN_SRC.slice(start);
+    const stampAt = body.indexOf('Object.entries(hookMetadata || {})');
+    expect(stampAt, 'the hookMetadata stamp must exist').toBeGreaterThan(-1);
+    // Bound the scan to this function: `return task;` ends it.
+    const lastGateAt = body.slice(0, body.indexOf('return task;')).lastIndexOf('return null;');
+    expect(lastGateAt, 'the gate chain must exist').toBeGreaterThan(-1);
+    expect(stampAt).toBeGreaterThan(lastGateAt);
   });
 });

--- a/server/services/perpetualWork.js
+++ b/server/services/perpetualWork.js
@@ -482,9 +482,13 @@ export function hasWorkDetector(taskType) {
 registerWorkDetector('claim-issue', detectGithubIssues);
 registerWorkDetector('claim-issue-gitlab', detectGitlabIssues);
 registerWorkDetector('plan-task', detectPlanTask);
-registerWorkDetector('quota-burn', async (app) => {
+registerWorkDetector('quota-burn', async (app, opts) => {
   const { detectQuotaBurn } = await import('./quotaBurn.js');
-  return detectQuotaBurn(app);
+  // Forward `ignoreTaskId`: on the drain-on-completion refill the just-finished
+  // burn has already written its ledger entry but still reads `in_progress`, so
+  // without this the detector counts it twice and parks a family that still has
+  // window budget left (#3179).
+  return detectQuotaBurn(app, { ignoreTaskId: opts?.ignoreTaskId || null });
 });
 
 /**

--- a/server/services/quotaBurn.js
+++ b/server/services/quotaBurn.js
@@ -34,6 +34,54 @@ export async function recordQuotaBurnDispatch(key) {
   return next;
 }
 
+/**
+ * The task-metadata key a resolved `dispatchKey` rides across on, from the
+ * pre-agent `buildTaskInput` hook to the post-agent `processTaskOutput` that
+ * writes the ledger (#3179). Lives here, beside the ledger it guards, so the
+ * producer, the consumer, and the in-flight count below can't drift on spelling.
+ */
+export const QUOTA_BURN_DISPATCH_KEY_FIELD = 'quotaBurnDispatchKey';
+
+/**
+ * Dispatch counts to select the next burn candidate against: the persisted
+ * ledger PLUS every quota-burn task already queued or running that carries a
+ * dispatch key but has not reached its post-agent ledger write yet.
+ *
+ * Counting the in-flight tasks is what keeps the window cap honest now that the
+ * ledger is written post-agent (#3179). The ledger write used to happen during
+ * generation, which incidentally serialized sibling candidates — the next reader
+ * always saw it. Deferring the write opens a gap between "task created" and
+ * "dispatch recorded", and two paths generate inside that gap: the per-app
+ * improvement loop runs once per managed app while `dispatchKey` is
+ * `<family>:<resetEpoch>` (app-independent, one global ledger), and an on-demand
+ * "Run" calls the generator directly, bypassing the per-app pending-task cap
+ * entirely. Without this, either could dispatch past `maxDispatchesPerWindow` —
+ * real quota overspend, the exact thing the cap exists to prevent, and a worse
+ * failure than the over-counting #3179 fixed.
+ *
+ * An unreadable task file degrades to the ledger-only count rather than throwing:
+ * COS-TASKS.md is the file the whole CoS queue reads, so if it is unavailable
+ * nothing is dispatching anyway, and failing the probe closed would wedge
+ * quota-burn until the next 12-hourly recheck.
+ */
+export async function getEffectiveQuotaBurnDispatches() {
+  const counts = { ...(await getQuotaBurnDispatches()) };
+  // Lazy import: cosTaskStore pulls a heavy graph (state, code review, merge),
+  // and quotaBurn.js is imported by the perpetual-work detector on a hot path.
+  const { getCosTasks } = await import('./cosTaskStore.js');
+  const cosTasks = await getCosTasks().catch((err) => {
+    console.error(`❌ Quota-burn in-flight probe failed, falling back to the ledger alone: ${err.message}`);
+    return null;
+  });
+  for (const task of cosTasks?.tasks || []) {
+    if (task?.status !== 'pending' && task?.status !== 'in_progress') continue;
+    const key = task?.metadata?.[QUOTA_BURN_DISPATCH_KEY_FIELD];
+    if (typeof key !== 'string' || !key) continue;
+    counts[key] = Number(counts[key] || 0) + 1;
+  }
+  return counts;
+}
+
 function normalizedFamily(id, value) {
   if (!value || typeof value !== 'object' || value.enabled !== true) return null;
   const config = { ...DEFAULT_QUOTA_BURN_FAMILY, ...value };
@@ -90,7 +138,7 @@ export async function detectQuotaBurn(app, { getQuotas = getProviderQuotas, now 
   if (configuredCards.length && configuredCards.every((card) => card?.error)) {
     return { actionable: false, count: 0, transient: true, reason: 'all-provider-quota-checks-failed' };
   }
-  const candidates = selectBurnCandidates(quotas, config, { now, dispatches: dispatches || await getQuotaBurnDispatches() });
+  const candidates = selectBurnCandidates(quotas, config, { now, dispatches: dispatches || await getEffectiveQuotaBurnDispatches() });
   return candidates.length
     ? { actionable: true, count: candidates.length, reason: `${candidates[0].family.id} resets in ${Math.ceil(candidates[0].hoursUntilReset)}h`, candidates }
     : { actionable: false, count: 0, reason: 'no-family-within-reset-window' };

--- a/server/services/quotaBurn.js
+++ b/server/services/quotaBurn.js
@@ -59,12 +59,21 @@ export const QUOTA_BURN_DISPATCH_KEY_FIELD = 'quotaBurnDispatchKey';
  * real quota overspend, the exact thing the cap exists to prevent, and a worse
  * failure than the over-counting #3179 fixed.
  *
+ * `ignoreTaskId` excludes one task from the in-flight tally — the same exclusion
+ * `buildImprovementDedupSets` takes, for the same reason. `agent:completed` fires
+ * from `completeAgent`, which runs AFTER the output hook wrote this run's ledger
+ * entry but BEFORE the completion flow's `updateTask` marks the task done. So
+ * during the perpetual drain-on-completion refill the just-finished burn is
+ * counted twice — once in the ledger, once as a still-`in_progress` task — and a
+ * family with `maxDispatchesPerWindow: 2` would stop after one run and likely
+ * miss its reset window. Callers on that path pass the completing task's id.
+ *
  * An unreadable task file degrades to the ledger-only count rather than throwing:
  * COS-TASKS.md is the file the whole CoS queue reads, so if it is unavailable
  * nothing is dispatching anyway, and failing the probe closed would wedge
  * quota-burn until the next 12-hourly recheck.
  */
-export async function getEffectiveQuotaBurnDispatches() {
+export async function getEffectiveQuotaBurnDispatches({ ignoreTaskId = null } = {}) {
   const counts = { ...(await getQuotaBurnDispatches()) };
   // Lazy import: cosTaskStore pulls a heavy graph (state, code review, merge),
   // and quotaBurn.js is imported by the perpetual-work detector on a hot path.
@@ -74,6 +83,7 @@ export async function getEffectiveQuotaBurnDispatches() {
     return null;
   });
   for (const task of cosTasks?.tasks || []) {
+    if (ignoreTaskId && task?.id === ignoreTaskId) continue;
     if (task?.status !== 'pending' && task?.status !== 'in_progress') continue;
     const key = task?.metadata?.[QUOTA_BURN_DISPATCH_KEY_FIELD];
     if (typeof key !== 'string' || !key) continue;
@@ -127,7 +137,7 @@ export function selectBurnCandidates(quotas, config, { now = Date.now(), dispatc
     .sort((a, b) => a.hoursUntilReset - b.hoursUntilReset || a.family.priority - b.family.priority);
 }
 
-export async function detectQuotaBurn(app, { getQuotas = getProviderQuotas, now = Date.now(), dispatches } = {}) {
+export async function detectQuotaBurn(app, { getQuotas = getProviderQuotas, now = Date.now(), dispatches, ignoreTaskId = null } = {}) {
   const config = quotaBurnConfig(app);
   const configured = Object.entries(config.families || {})
     .filter(([, family]) => family?.enabled === true)
@@ -138,7 +148,7 @@ export async function detectQuotaBurn(app, { getQuotas = getProviderQuotas, now 
   if (configuredCards.length && configuredCards.every((card) => card?.error)) {
     return { actionable: false, count: 0, transient: true, reason: 'all-provider-quota-checks-failed' };
   }
-  const candidates = selectBurnCandidates(quotas, config, { now, dispatches: dispatches || await getEffectiveQuotaBurnDispatches() });
+  const candidates = selectBurnCandidates(quotas, config, { now, dispatches: dispatches || await getEffectiveQuotaBurnDispatches({ ignoreTaskId }) });
   return candidates.length
     ? { actionable: true, count: candidates.length, reason: `${candidates[0].family.id} resets in ${Math.ceil(candidates[0].hoursUntilReset)}h`, candidates }
     : { actionable: false, count: 0, reason: 'no-family-within-reset-window' };

--- a/server/services/quotaBurn.js
+++ b/server/services/quotaBurn.js
@@ -1,6 +1,7 @@
 import { getProviderQuotas } from './providerUsage.js';
 import { join } from 'path';
 import { atomicWrite, PATHS, readJSONFile } from '../lib/fileUtils.js';
+import { createFileWriteQueue } from '../lib/fileWriteQueue.js';
 import { hoursUntilReset, normalizeResetAt } from '../lib/quotaReset.js';
 
 export const QUOTA_BURN_TASK_TYPE = 'quota-burn';
@@ -27,11 +28,23 @@ export async function getQuotaBurnDispatches() {
   return loaded && typeof loaded === 'object' ? loaded : {};
 }
 
+// Single-tail queue for the dispatch ledger's read-modify-write. Two quota-burn
+// agents (one per app) can finalize concurrently, and each finalization records a
+// dispatch — unserialized, both would read the same count and write the same
+// increment, losing one burn. An undercounted ledger then lets the window
+// dispatch past `maxDispatchesPerWindow`, which is real quota overspend. This is
+// the "serialize two write paths that mutate the same record" case, not a
+// defense against competing users. It only became reachable when the write moved
+// from generation (sequential, one app at a time) to finalize (#3179).
+const ledgerWriteQueue = createFileWriteQueue();
+
 export async function recordQuotaBurnDispatch(key) {
-  const ledger = await getQuotaBurnDispatches();
-  const next = { ...ledger, [key]: Number(ledger[key] || 0) + 1 };
-  await atomicWrite(LEDGER_FILE, next);
-  return next;
+  return ledgerWriteQueue(async () => {
+    const ledger = await getQuotaBurnDispatches();
+    const next = { ...ledger, [key]: Number(ledger[key] || 0) + 1 };
+    await atomicWrite(LEDGER_FILE, next);
+    return next;
+  });
 }
 
 /**

--- a/server/services/quotaBurn.test.js
+++ b/server/services/quotaBurn.test.js
@@ -105,4 +105,16 @@ describe('getEffectiveQuotaBurnDispatches', () => {
     const { getEffectiveQuotaBurnDispatches } = await loadStore([], { fail: true });
     await expect(getEffectiveQuotaBurnDispatches()).resolves.toEqual({ 'grok:1': 1 });
   });
+
+  it('excludes ignoreTaskId so a completing burn is not counted twice', async () => {
+    // The drain-on-completion refill runs between the output hook's ledger write
+    // and the completion flow's updateTask, so the finished burn is BOTH in the
+    // ledger and still `in_progress`. Counting both would consume two slots for
+    // one run — a family capped at 2 would stop after one and miss its window.
+    const tasks = [{ id: 'sys-finishing', status: 'in_progress', metadata: { quotaBurnDispatchKey: 'grok:1' } }];
+    const { getEffectiveQuotaBurnDispatches } = await loadStore(tasks);
+
+    await expect(getEffectiveQuotaBurnDispatches()).resolves.toEqual({ 'grok:1': 2 });
+    await expect(getEffectiveQuotaBurnDispatches({ ignoreTaskId: 'sys-finishing' })).resolves.toEqual({ 'grok:1': 1 });
+  });
 });

--- a/server/services/quotaBurn.test.js
+++ b/server/services/quotaBurn.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { detectQuotaBurn, selectBurnCandidates } from './quotaBurn.js';
 import { sanitizeTaskMetadata } from '../lib/validation.js';
 
@@ -55,5 +55,54 @@ describe('quota-burn metadata validation', () => {
       .toMatchObject({ families: { grok: { enabled: true, reservePercent: 20 } } });
     expect(sanitizeTaskMetadata({ families: { unknown: { enabled: true } } })).toBeNull();
     expect(sanitizeTaskMetadata({ families: { grok: { reservePercent: 101 } } })).toBeNull();
+  });
+});
+
+/**
+ * The window cap is only honest if a burn that has been QUEUED but whose agent
+ * has not finalized yet still holds its slot. The ledger write moved post-agent
+ * (#3179), so the raw ledger no longer covers that gap on its own.
+ */
+describe('getEffectiveQuotaBurnDispatches', () => {
+  const loadStore = async (tasks, { fail = false } = {}) => {
+    vi.resetModules();
+    vi.doMock('./cosTaskStore.js', () => ({
+      getCosTasks: fail ? async () => { throw new Error('unreadable'); } : async () => ({ tasks }),
+    }));
+    vi.doMock('../lib/fileUtils.js', async (importActual) => ({
+      ...(await importActual()),
+      readJSONFile: async () => ({ 'grok:1': 1 }),
+    }));
+    return import('./quotaBurn.js');
+  };
+
+  const burnTask = (status, key) => ({ id: `sys-${status}`, status, metadata: { quotaBurnDispatchKey: key } });
+
+  afterEach(() => { vi.doUnmock('./cosTaskStore.js'); vi.doUnmock('../lib/fileUtils.js'); vi.resetModules(); });
+
+  it('adds pending and in_progress burns on top of the persisted ledger', async () => {
+    const { getEffectiveQuotaBurnDispatches } = await loadStore([
+      burnTask('pending', 'grok:1'),
+      burnTask('in_progress', 'codex:2'),
+    ]);
+    // grok:1 = 1 persisted + 1 queued; codex:2 = 0 persisted + 1 running.
+    await expect(getEffectiveQuotaBurnDispatches()).resolves.toEqual({ 'grok:1': 2, 'codex:2': 1 });
+  });
+
+  it('ignores terminal tasks and tasks carrying no dispatch key', async () => {
+    const { getEffectiveQuotaBurnDispatches } = await loadStore([
+      burnTask('completed', 'grok:1'),
+      burnTask('blocked', 'grok:1'),
+      { id: 'sys-other', status: 'pending', metadata: { analysisType: 'performance' } },
+      { id: 'sys-empty', status: 'pending', metadata: { quotaBurnDispatchKey: '' } },
+    ]);
+    // A completed burn already wrote its ledger entry — counting it would
+    // double-charge the window; a blocked one never dispatched.
+    await expect(getEffectiveQuotaBurnDispatches()).resolves.toEqual({ 'grok:1': 1 });
+  });
+
+  it('degrades to the ledger alone when the task file cannot be read', async () => {
+    const { getEffectiveQuotaBurnDispatches } = await loadStore([], { fail: true });
+    await expect(getEffectiveQuotaBurnDispatches()).resolves.toEqual({ 'grok:1': 1 });
   });
 });

--- a/server/services/quotaBurn.test.js
+++ b/server/services/quotaBurn.test.js
@@ -118,3 +118,37 @@ describe('getEffectiveQuotaBurnDispatches', () => {
     await expect(getEffectiveQuotaBurnDispatches({ ignoreTaskId: 'sys-finishing' })).resolves.toEqual({ 'grok:1': 1 });
   });
 });
+
+/**
+ * Two quota-burn agents (one per app) can finalize concurrently, and each
+ * finalization records a dispatch. The ledger update is a read-modify-write, so
+ * without serialization both would read the same count and write the same
+ * increment — losing a burn and letting the window overspend its cap.
+ */
+describe('recordQuotaBurnDispatch serialization', () => {
+  afterEach(() => { vi.doUnmock('../lib/fileUtils.js'); vi.resetModules(); });
+
+  it('does not lose an increment when two completions race', async () => {
+    vi.resetModules();
+    let stored = {};
+    vi.doMock('../lib/fileUtils.js', async (importActual) => ({
+      ...(await importActual()),
+      readJSONFile: async () => ({ ...stored }),
+      // The delay must sit on the WRITE: it holds each read-modify-write open
+      // long enough for the next caller's read to observe the pre-write state.
+      // (A delay on the read instead resolves in a macrotask whose continuation
+      // runs the whole RMW in microtasks, so the cycles never actually overlap
+      // and the test would pass even unserialized.)
+      atomicWrite: async (_file, data) => { await new Promise((r) => setTimeout(r, 5)); stored = { ...data }; },
+    }));
+    const { recordQuotaBurnDispatch, getQuotaBurnDispatches } = await import('./quotaBurn.js');
+
+    await Promise.all([
+      recordQuotaBurnDispatch('grok:1'),
+      recordQuotaBurnDispatch('grok:1'),
+      recordQuotaBurnDispatch('codex:2'),
+    ]);
+
+    await expect(getQuotaBurnDispatches()).resolves.toEqual({ 'grok:1': 2, 'codex:2': 1 });
+  });
+});

--- a/server/services/taskTypeHooks.js
+++ b/server/services/taskTypeHooks.js
@@ -7,9 +7,18 @@
  *
  *   - `buildTaskInput({ app, taskType })` — runs BEFORE spawn, inside the task
  *     generator. Collects data beyond the base prompt (telemetry, open issues, …)
- *     and returns `{ prompt?, providerId?, model?, skip? }`:
+ *     and returns `{ prompt?, providerId?, model?, hookMetadata?, skip? }`:
  *       • `prompt`     — a fully-rendered prompt that REPLACES the template.
  *       • `providerId` / `model` — pin the agent's provider/model (per-app choice).
+ *       • `hookMetadata` — a free-form bag merged into the task's persisted
+ *         `metadata`, so a value resolved pre-agent survives to `processTaskOutput`.
+ *         The generator applies it only AFTER every gate that can still skip task
+ *         creation has passed, so a hook can safely defer a side effect until the
+ *         task really exists (quota-burn's dispatch ledger, #3179) instead of
+ *         performing it speculatively here. Untyped by design — a passthrough, not
+ *         a schema; keep the keys namespaced to the task type. A key that collides
+ *         with generator-computed metadata is DROPPED with a warning, so the bag
+ *         can't overwrite `analysisType`, provider pins, or plan ids.
  *       • `skip: { reason }` — short-circuit: no agent is spawned.
  *
  *   - `processTaskOutput({ appId, success, payload, workspacePath, agentId, task }, deps?)`
@@ -138,7 +147,8 @@ export function isNonCommittingCoordinatorTask(task) {
 
 /**
  * Resolve the pre-agent input hook for a task type, or null if it has none.
- * `buildTaskInput({ app, taskType })` → `{ prompt?, providerId?, model?, skip? }`.
+ * `buildTaskInput({ app, taskType })` → `{ prompt?, providerId?, model?, hookMetadata?, skip? }`
+ * (see the module header for each field's contract).
  */
 export async function getTaskInputHook(taskType) {
   const mod = await loadHookModule(taskType);

--- a/server/services/taskTypeHooks.js
+++ b/server/services/taskTypeHooks.js
@@ -5,9 +5,12 @@
  * sentinel`. A few need PROGRAMMATIC steps around the agent. A hook module may
  * export either or both of:
  *
- *   - `buildTaskInput({ app, taskType })` — runs BEFORE spawn, inside the task
- *     generator. Collects data beyond the base prompt (telemetry, open issues, …)
- *     and returns `{ prompt?, providerId?, model?, hookMetadata?, skip? }`:
+ *   - `buildTaskInput({ app, taskType, ignoreTaskId })` — runs BEFORE spawn, inside
+ *     the task generator. Collects data beyond the base prompt (telemetry, open
+ *     issues, …) and returns `{ prompt?, providerId?, model?, hookMetadata?, skip? }`.
+ *     `ignoreTaskId` is set on the drain-on-completion refill and names the task
+ *     that just finished but is still `in_progress` on disk — a hook that counts
+ *     in-flight work must exclude it (see quotaBurnHooks.js):
  *       • `prompt`     — a fully-rendered prompt that REPLACES the template.
  *       • `providerId` / `model` — pin the agent's provider/model (per-app choice).
  *       • `hookMetadata` — a free-form bag merged into the task's persisted


### PR DESCRIPTION
## Summary

Closes #3179.

`quotaBurnHooks.js#buildTaskInput` wrote the dispatch ledger before returning, but five gates in `generateManagedAppImprovementTaskForType` run *after* the input hook and can each `return null` without creating the task. A skip on any of them permanently consumed a slot of `family.maxDispatchesPerWindow` for an agent that never spawned.

The interaction was worse than the issue described: `quota-burn` is a **perpetual** type whose work detector (`detectQuotaBurn`) re-reads that same ledger, and `applyPerpetualWorkGate` runs on the line right after the input hook — so the write fed straight into the very next gate. With `maxDispatchesPerWindow: 1` the type could never dispatch at all.

**The fix.** The resolved `dispatchKey` now rides to the task record on a new generic `hookMetadata` passthrough in the `buildTaskInput` contract, which the generator stamps only *below the last gate*, and a new `processTaskOutput` hook records the ledger post-agent — regardless of exit status, since the quota was spent either way.

Deferring the write reopened a hole the old write incidentally closed (it serialized sibling candidates, because the next reader always saw it). `dispatchKey` is `<family>:<resetEpoch>` — app-independent, against one global ledger — so without that serialization a second managed app, or a repeated on-demand "Run" (which bypasses the per-app pending cap entirely), could dispatch past the cap. Candidate selection therefore now counts **in-flight** burns alongside the ledger. Over-counting was fail-safe; over-dispatching would be real quota overspend.

Two consequences of that in-flight tally, both surfaced by the review gate and fixed here:

- The drain-on-completion refill regenerates between the output hook's ledger write and the completion flow's `updateTask`, so the just-finished burn was counted twice. `ignoreTaskId` — which the refill already passes to `buildImprovementDedupSets` and `addTask` — is now threaded to the input hook and the work detector, on **both** generators reachable from the `agent:completed` continuation.
- Concurrent agent finalizations now race the ledger's read-modify-write, so `recordQuotaBurnDispatch` runs through `createFileWriteQueue`.

Hardening that came out of review: the ledger write can't throw (a thrown output hook is read as a rejected success criterion *and* a `hook-error` that auto-parks the task type — a full disk must not park quota-burn), the hook returns no structured outcome so `resolveProgrammaticIoVerdict` keeps its "undeclared" null sentinel and quota-burn stays exit-code-judged, and `hookMetadata` keys that collide with generator-computed metadata are dropped with a warning (`analysisType` is what `resolveTaskHookType` dispatches the output hook on, so a silent overwrite would stop the hook that asked for the bag from running).

The ledger keeps its existing `{key: count}` shape, so no migration is needed. Tasks generated by the old code carry no dispatch key, so `processTaskOutput` no-ops on them — no double count across the upgrade.

**Known gap, filed as #3182.** Output hooks only run from `finalizeAgent`. An agent completed by orphan cleanup or post-restart recovery never fires one, so a burn that genuinely ran can go unrecorded and its window slot is refunded. The fix belongs at the shared finalize chokepoint and affects every programmatic-I/O task type, not just quota-burn, so it is its own change.

## Test plan

- `cd server && npm test` — 23,133 passed, 24 DB-gated suites skipped.
- New `server/services/autonomousJobs/quotaBurnHooks.test.js`: the ledger is untouched on every `buildTaskInput` path; `processTaskOutput` records exactly once on both success and failure; no-ops without a dispatch key; a write failure is swallowed rather than thrown; selection consults the effective count and forwards `ignoreTaskId`.
- `quotaBurnHooks.test.js` also pins the COS-TASKS.md round-trip — `parseMetadataLine` splits on the first colon while a dispatch key *contains* one, so a regression there would look like a hook that simply never fires.
- `quotaBurn.test.js`: in-flight tally adds `pending`/`in_progress` burns, ignores terminal ones, honors `ignoreTaskId`, and degrades to the ledger alone when the task file is unreadable. The serialization test was verified to actually discriminate — with the queue removed it fails, losing both `grok:1` increments.
- `cosTaskGenerator.test.js`: source-pins that the metadata stamp sits below every `return null` gate (a unit test can't catch a new gate being added underneath it), that colliding keys are dropped, and that `ignoreTaskId` reaches both completion-continuation generators.
