### PR TITLE
feat: surface malware scan reports

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased Changes
 
+## Added
+
+- **Malware scans now leave a durable, reviewable report trail.** Git-link scans save an owned markdown artifact, surface it from the completed agent summary and Review Hub, and mark repositories with an explicit `DANGEROUS` verdict using a skull danger treatment on the Git links card.
+
 ## Quota burn
 
 - **[issue-3179] Quota-burn no longer spends window budget on runs that never happened** — a scheduled quota-burn run counted against the family's per-window dispatch cap as soon as it was considered, even when it was subsequently skipped and no agent was ever started. Those phantom dispatches ate the budget, so a family configured for e.g. 5 burns per reset window could fire far fewer — and a family capped at 1 could never fire at all, because the skipped run consumed the only slot before the next gate re-read it. A burn is now counted once its agent has actually run, and a burn that is queued or in progress holds its slot in the meantime, so the cap stays accurate without letting a second app or a repeated "Run" overshoot it.

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -3,6 +3,7 @@
 ## Added
 
 - **Malware scans now leave a durable, reviewable report trail.** Git-link scans save an owned markdown artifact, surface it from the completed agent summary and Review Hub, and mark repositories with an explicit `DANGEROUS` verdict using a skull danger treatment on the Git links card.
+- **Slashdo-free TUI agent PRs now complete their lifecycle.** Codex, Antigravity, OpenCode, and lean Claude agents hand committed work back to PortOS so it can generate a non-empty PR description, run configured reviewers, and merge after the selected gates pass instead of leaving an ownerless PR open.
 
 ## Quota burn
 

--- a/client/src/components/brain/tabs/LinksTab.jsx
+++ b/client/src/components/brain/tabs/LinksTab.jsx
@@ -16,6 +16,7 @@ import {
   FolderOpen,
   Tag,
   ShieldCheck,
+  Skull,
   Search,
   ChevronDown,
   ChevronUp,
@@ -555,7 +556,9 @@ export default function LinksTab({ onRefresh }) {
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1">
                       {link.isGitHubRepo ? (
-                        <GitBranch size={16} className="text-purple-400 shrink-0" />
+                        link.malwareScan?.verdict === 'DANGEROUS'
+                          ? <Skull size={16} className="text-port-error shrink-0" aria-label="Dangerous repository" />
+                          : <GitBranch size={16} className="text-purple-400 shrink-0" />
                       ) : (
                         <Link2 size={16} className="text-gray-400 shrink-0" />
                       )}
@@ -674,6 +677,19 @@ export default function LinksTab({ onRefresh }) {
                       <span className="text-xs text-port-error truncate max-w-[200px]" title={link.cloneError}>
                         {link.cloneError}
                       </span>
+                    )}
+
+                    {link.malwareScan?.reportId && (
+                      <a
+                        href={`/api/brain/links/${link.id}/scan-report`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={`flex items-center gap-1 text-xs ${link.malwareScan.verdict === 'DANGEROUS' ? 'text-port-error' : 'text-port-accent'} hover:underline`}
+                        title="Open malware scan markdown report"
+                      >
+                        {link.malwareScan.verdict === 'DANGEROUS' ? <Skull size={12} /> : <ShieldCheck size={12} />}
+                        {link.malwareScan.verdict || 'Scan report'}
+                      </a>
                     )}
 
                     {/* Local path */}

--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -796,13 +796,24 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
           </div>
         )}
 
-        {completed && agent.metadata?.taskSummary && (
+        {completed && (agent.metadata?.taskSummary || agent.metadata?.malwareScan?.reportUrl) && (
           <div className="mt-2 bg-port-bg/50 border border-port-border/50 rounded p-2.5">
             <div className="text-[11px] text-gray-500 mb-1 flex items-center gap-1">
               <Sparkles size={10} aria-hidden="true" className="text-emerald-400" />
               Task Summary
             </div>
-            <MarkdownOutput content={agent.metadata.taskSummary} />
+            {agent.metadata?.taskSummary && <MarkdownOutput content={agent.metadata.taskSummary} />}
+            {agent.metadata?.malwareScan?.reportUrl && (
+              <a
+                href={agent.metadata.malwareScan.reportUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`mt-2 inline-flex items-center gap-1 text-xs hover:underline ${agent.metadata.malwareScan.verdict === 'DANGEROUS' ? 'text-port-error' : 'text-port-accent'}`}
+              >
+                {agent.metadata.malwareScan.verdict === 'DANGEROUS' ? <Skull size={13} /> : <ExternalLink size={13} />}
+                View markdown scan report{agent.metadata.malwareScan.verdict ? ` (${agent.metadata.malwareScan.verdict})` : ''}
+              </a>
+            )}
           </div>
         )}
 

--- a/client/src/pages/Review.jsx
+++ b/client/src/pages/Review.jsx
@@ -746,6 +746,17 @@ function ReviewItem({ item, config, isEditing, onComplete, onDismiss, onDelete, 
                     <MarkdownOutput content={item.description} />
                   </div>
                 )}
+                {item.metadata?.reportUrl && (
+                  <a
+                    href={item.metadata.reportUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`mt-2 inline-flex items-center gap-1 text-xs hover:underline ${item.metadata.verdict === 'DANGEROUS' ? 'text-port-error' : 'text-port-accent'}`}
+                  >
+                    <FileText size={13} />
+                    View markdown scan report{item.metadata.verdict ? ` (${item.metadata.verdict})` : ''}
+                  </a>
+                )}
               </div>
               {isPending && (
                 <span className={`text-[10px] uppercase tracking-wide px-2 py-1 rounded-full border border-current/20 ${config.color}`}>

--- a/server/lib/brainValidation.js
+++ b/server/lib/brainValidation.js
@@ -386,6 +386,13 @@ export const linkRecordSchema = z.object({
   localPath: z.string().max(500).optional(),
   cloneStatus: z.enum(['pending', 'cloning', 'cloned', 'failed', 'none']).default('none'),
   cloneError: z.string().max(500).optional(),
+  malwareScan: z.object({
+    reportId: z.string().uuid(),
+    taskId: z.string().optional(),
+    status: z.enum(['completed', 'failed']).optional(),
+    verdict: z.enum(['CLEAN', 'CAUTION', 'DANGEROUS']).nullable().optional(),
+    completedAt: z.string().datetime().optional()
+  }).optional(),
   // Bucket grouping (nullable = ungrouped)
   bucketId: z.string().guid().nullable().optional(),
   bucketOrder: z.number().int().optional(),

--- a/server/routes/brainLinks.js
+++ b/server/routes/brainLinks.js
@@ -22,6 +22,8 @@ import {
 } from '../lib/brainValidation.js';
 import * as githubCloner from '../services/githubCloner.js';
 import * as cos from '../services/cos.js';
+import { randomUUID } from 'crypto';
+import { prepareScanReportDirectory, reportPathForId, getScanReport } from '../services/malwareScanReports.js';
 
 const router = Router();
 
@@ -272,6 +274,9 @@ router.post('/links/:id/scan', asyncHandler(async (req, res) => {
     });
   }
 
+  const reportId = randomUUID();
+  const reportPath = reportPathForId(reportId);
+  await prepareScanReportDirectory();
   const repoLabel = link.title || link.url;
   const description = `Malware scan: ${repoLabel}`;
   // Carry the BARE command (`metadata.slashdoCommand`) rather than inlining the
@@ -282,10 +287,20 @@ router.post('/links/:id/scan', asyncHandler(async (req, res) => {
   // peer-sync payload. Matches POST /api/cos/tasks/slashdo (#3114).
   const context = `Run the scan workflow against the cloned repository at: \`${link.localPath}\`
 
-Use that path as SCAN_DIR. Adhere to every Operational Invariant in the workflow body — this is a hostile-until-proven-safe audit. The full markdown report will be written to ~/.claude/scans/. When complete, summarize the verdict (CLEAN / CAUTION / DANGEROUS) and the top findings in your final response so the report can be surfaced in the UI.`;
+Use that path as SCAN_DIR. Adhere to every Operational Invariant in the workflow body — this is a hostile-until-proven-safe audit. End the report with exactly one verdict heading: \`## Verdict: CLEAN\`, \`## Verdict: CAUTION\`, or \`## Verdict: DANGEROUS\`. When complete, summarize the verdict and top findings in your final response.`;
 
   const result = await cos.addTask(
-    { description, context, slashdoCommand: 'scan', useWorktree: false, openPR: false, simplify: false, reviewLoop: false },
+    {
+      description,
+      context,
+      slashdoCommand: 'scan',
+      slashdoArgs: `--report-path-allow-anywhere --report-path ${JSON.stringify(reportPath)}`,
+      malwareScan: { linkId: link.id, reportId },
+      useWorktree: false,
+      openPR: false,
+      simplify: false,
+      reviewLoop: false
+    },
     'user'
   );
   if (result?.duplicate) {
@@ -297,6 +312,18 @@ Use that path as SCAN_DIR. Adhere to every Operational Invariant in the workflow
 
   console.log(`🛡️ Queued malware scan: link=${link.id} path=${link.localPath} task=${result.id}`);
   res.json({ message: 'Scan queued', taskId: result.id, linkId: link.id, scanPath: link.localPath });
+}));
+
+router.get('/links/:id/scan-report', asyncHandler(async (req, res) => {
+  const link = await brainService.getLinkById(req.params.id);
+  if (!link?.malwareScan?.reportId) {
+    throw new ServerError('No malware scan report is available for this link', { status: 404, code: 'REPORT_NOT_FOUND' });
+  }
+  const report = await getScanReport(link.malwareScan.reportId);
+  if (report === null) {
+    throw new ServerError('Malware scan report file is unavailable', { status: 404, code: 'REPORT_NOT_FOUND' });
+  }
+  res.type('text/markdown').send(report);
 }));
 
 // =============================================================================

--- a/server/services/agentCompletion.js
+++ b/server/services/agentCompletion.js
@@ -11,12 +11,17 @@ import { startAppCooldown, markAppReviewCompleted } from './appActivity.js';
 import { emitLog } from './cosEvents.js';
 import { extractAndStoreMemories } from './memoryExtractor.js';
 import { isRecoveryTask } from './recoveryTasks.js';
+import { finalizeMalwareScan } from './malwareScanReports.js';
 
 /**
  * Process post-completion tasks: memory extraction and app cooldown.
  * Shared between handleAgentCompletion (runner mode) and spawnDirectly (direct mode).
  */
 export async function processAgentCompletion(agentId, task, success, outputBuffer) {
+  await finalizeMalwareScan({ agentId, task, success }).catch(err => {
+    emitLog('warn', `Failed to finalize malware scan for ${task.id}: ${err.message}`, { taskId: task.id, agentId });
+  });
+
   // Extract memories from successful output
   if (success && outputBuffer.length > 100) {
     const memoryResult = await extractAndStoreMemories(agentId, task.id, outputBuffer, task).catch(err => {

--- a/server/services/agentCompletion.test.js
+++ b/server/services/agentCompletion.test.js
@@ -17,6 +17,9 @@ vi.mock('./cosEvents.js', () => ({
 vi.mock('./memoryExtractor.js', () => ({
   extractAndStoreMemories: vi.fn().mockResolvedValue({ created: 0, pendingApproval: 0 })
 }));
+vi.mock('./malwareScanReports.js', () => ({
+  finalizeMalwareScan: vi.fn().mockResolvedValue(null)
+}));
 
 import { processAgentCompletion } from './agentCompletion.js';
 import * as appActivity from './appActivity.js';

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -561,6 +561,7 @@ async function runAgentSpawn(task) {
         laneName,
         cleanupWorktreeFn: cleanupAgentWorktree,
         isTruthyMetaFn: isTruthyMeta,
+        leanMode,
       });
     }
     if (useRunner) {

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -754,11 +754,10 @@ const LEAVE_PR_OPEN_STEP = (step, jiraTracked = false) => `${step}. **Leave the 
  *
  * This is the single definition of "no reviewer is configured, so CI is the
  * merge gate" — shared by every flow that reaches it: the agent's own completion
- * workflow (slashdo TUI + Claude Code CLI via `buildPostPRMergeSteps`), the
- * manual/OpenCode TUI workflow, and the merge follow-up agent PortOS spawns when
- * it opened the PR itself. They differ only in how the PR is addressed and
- * whether GitLab commands are offered, so those are parameters rather than three
- * hand-written copies that drift.
+ * workflow (slashdo TUI + Claude Code CLI via `buildPostPRMergeSteps`) and the
+ * merge follow-up agent PortOS spawns when it opened the PR itself. They differ
+ * only in how the PR is addressed and whether GitLab commands are offered, so
+ * those are parameters rather than hand-written copies that drift.
  *
  * Ends on the same merge command + MERGED verification as the review-loop
  * contract (`buildReviewLoopFollowUpSection`): a true merge commit keeps the
@@ -868,8 +867,8 @@ function buildMergeFollowUpSection({ prUrl, prBranch, prNumber = '', prOwner = '
  * @param {boolean} opts.isReadOnly
  * @param {boolean} opts.isTui
  * @param {string} opts.tuiCompletionCommand - `/do:pr` or `/do:push`
- * @param {boolean} [opts.slashdoFree] - TUI without slashdo (OpenCode): the bullet
- *   points at the manual git/gh Completion Workflow instead of a `/do:*` command.
+ * @param {boolean} [opts.slashdoFree] - TUI without slashdo: the bullet points
+ *   at the manual commit + system-handoff workflow instead of a `/do:*` command.
  * @param {Object|null} opts.worktreeInfo
  * @param {boolean} opts.willOpenPR
  * @param {'review-then-merge'|'merge-on-green'|'leave-open'} opts.prCompletion
@@ -903,7 +902,7 @@ export function buildCompletionGuidelineBullet({
     // buildTuiCompletionSection — not this bullet). It's kept provider-aware and
     // directly unit-tested so the guideline stays correct if that routing changes.
     const howTo = slashdoFree
-      ? 'the Completion Workflow above (plain `git`/`gh` commands — this provider has no slashdo commands)'
+      ? 'the Completion Workflow above (plain `git` commit + PortOS handoff — this provider has no slashdo commands)'
       : `the Completion Workflow above (\`${tuiCompletionCommand}\`)`;
     return `On successful completion, YOU run ${howTo}, then write the sentinel and stop — PortOS closes the session once it sees the sentinel; do NOT run \`/quit\`.`;
   }
@@ -1490,6 +1489,8 @@ ${discardWorktree
   ? `- **Do NOT commit, push, or open a PR.** This worktree is discarded on exit — your only output is the completion sentinel (see the Completion section above).`
   : isReviewLoopFollowUp
     ? `- **Push fixes straight to the PR branch you are on** (the follow-up section above is the procedure). Stage specific files, use a \`fix:\` prefix, no Co-Authored-By annotations. Do NOT open a new PR.`
+    : isTui && tuiSlashdoFree
+    ? `- **Commit only — do NOT push.** Stage specific files, use \`feat:\`/\`fix:\`/\`breaking:\` prefix in the commit message, no Co-Authored-By annotations, then write the completion sentinel. PortOS will handle the branch after it closes the session.`
     : isTui
     ? `- **Use \`${tuiCompletionCommand}\` to ${willOpenPR ? 'commit, push, and open the PR' : 'commit and push the branch'}** — see the Completion Workflow section above. Stage specific files (no \`git add -A\`), use \`feat:\`/\`fix:\`/\`breaking:\` prefix in the commit message, no Co-Authored-By annotations.`
     : worktreeInfo && willOpenPR
@@ -1592,7 +1593,8 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
   // block where PortOS handles push+PR on exit.
   const hasSlashdo = !isTui && canTypeSlash;
   // TUI: a session that does NOT load Claude Code slash commands can't run
-  // `/do:pr` / `/do:push`, so its completion workflow uses plain git/gh instead
+  // `/do:pr` / `/do:push`, so its completion workflow uses plain git and hands
+  // the post-exit push / PR lifecycle back to PortOS
   // — an OpenCode TUI, a codex/antigravity/grok TUI, or a lean-mode Claude
   // session (`--bare` skips project command discovery, and the small local models
   // lean mode targets fumble multi-step slashdo flows anyway).
@@ -1859,40 +1861,25 @@ function buildTuiCompletionSection({ willOpenPR, prCompletion = PR_COMPLETIONS.M
 /**
  * Manual (slashdo-free) TUI completion-workflow block — for an OpenCode TUI that
  * does NOT load Claude Code slash commands and so can't run `/do:pr` / `/do:push`.
- * Drives a plain `git` commit → push → (open PR/MR) → sentinel handshake, so the
- * `.agent-done` signal still fires and the task completes.
+ * Drives a plain `git` commit → sentinel handshake. PortOS owns the post-exit
+ * push / PR / review / merge lifecycle, just as it does for non-TUI providers
+ * that cannot invoke project slash commands.
  *
- * PortOS forces `openPR:false, skipMerge:true` on TUI worktree cleanup (see
- * agentTuiSpawning.js), so nothing happens after the agent exits — the agent owns
- * the push and the PR itself.
- *
- * With review-then-merge configured, it opens the PR/MR and stops:
- * this provider can't drive the reviewer CLIs (no slashdo `/do:pr` review loop)
- * and PortOS runs no post-exit review for a TUI, so merging here would ship work
- * the user asked to have reviewed. With the review loop OFF there is no reviewer
- * and no follow-up coming, so leaving it open just leaks the PR — the agent
- * merges it once CI is green, matching every other no-review-loop flow.
- *
- * Forge-aware (GitHub `gh` + GitLab `glab`) to match the slashdo path; refs are
- * shell-quoted because a git ref can legally contain shell metacharacters.
+ * Keeping PR creation system-owned also guarantees a real generated body rather
+ * than `gh pr create --fill` producing an empty description from a one-line
+ * commit, and lets the existing follow-up machinery run configured reviewers.
  */
-function buildManualTuiCompletionSection({ willOpenPR, prCompletion = PR_COMPLETIONS.REVIEW_THEN_MERGE, simplifyEnabled, sentinelPath, branchName = null, baseBranch = null, leavePrOpen = false }) {
+function buildManualTuiCompletionSection({ willOpenPR, prCompletion = PR_COMPLETIONS.REVIEW_THEN_MERGE, simplifyEnabled, sentinelPath, leavePrOpen = false }) {
   const policyLeavesOpen = prCompletion === PR_COMPLETIONS.LEAVE_OPEN;
   const runsReviewLoop = prCompletion === PR_COMPLETIONS.REVIEW_THEN_MERGE;
-  const branchRef = shellQuote(branchName || 'HEAD');
-  // Pin the PR base to the worktree's base branch when known, so the forge CLI
-  // doesn't guess (and a fork install targets the intended branch). `--fill`
-  // still supplies title/body from the commits.
-  const ghBaseArg = baseBranch ? ` --base ${shellQuote(baseBranch)}` : '';
-  const glabBaseArg = baseBranch ? ` --target-branch ${shellQuote(baseBranch)}` : '';
   const simplifyStep = simplifyEnabled
     ? `1. Before committing, ${SIMPLIFY_INLINE_REVIEW} and fix any findings.`
     : '1. (simplify disabled — skip)';
-  const sentinelTail = willOpenPR ? '   ## PR\n   <PR URL>' : '   ## Branch\n   <branch name>';
+  const sentinelTail = '   ## Branch\n   <branch name>';
 
   const lines = [
     '## Completion Workflow',
-    'This provider does NOT have slashdo (`/do:*`) commands, so finish the handoff with plain `git` (and your forge\'s CLI). Run these in order:',
+    'This provider does NOT have slashdo (`/do:*`) commands, so finish the handoff with plain `git`. Run these in order:',
     '',
     simplifyStep,
     '2. Stage only the files you changed (never `git add -A` / `git add .`) and commit with a conventional message (`feat:`/`fix:`/`breaking:` prefix, no Co-Authored-By annotations):',
@@ -1901,36 +1888,20 @@ function buildManualTuiCompletionSection({ willOpenPR, prCompletion = PR_COMPLET
     '   git add <file> [<file> ...]',
     '   git commit -m "feat: <description>"',
     '   ```',
-    '3. Push your branch (it is a fresh worktree branch, so set upstream on first push):',
-    '',
-    '   ```bash',
-    `   git push -u origin ${branchRef}`,
-    '   ```',
   ];
 
-  let step = 4;
+  let step = 3;
   if (willOpenPR) {
-    const openNote = policyLeavesOpen
-      ? '**Leave it open — do NOT merge it.** This task is configured to stop after opening the PR so you can inspect it.'
+    const handoff = policyLeavesOpen
+      ? 'PortOS will push the branch, create a pull request with your completion summary as its description, and leave it open for inspection.'
       : leavePrOpen
-      ? '**Leave it open — do NOT merge it.** This task is tracked in JIRA: its ticket is in review and a human lands the PR and the ticket together.'
+      ? 'PortOS will push the branch and create a pull request for the JIRA-linked human handoff.'
       : runsReviewLoop
-        ? '**Leave it open for review — do NOT merge it yourself.** This provider can\'t run the reviewer loop, and PortOS won\'t merge it for a TUI task, so a configured reviewer or a human reviews and merges it.'
-        : 'No review loop is configured for this task, so you merge it yourself in the next step — nothing else will.';
-    lines.push(
-      `${step++}. Open a pull/merge request against the base branch using the CLI for this repo's forge (check \`git remote -v\`), and capture the URL it prints. ${openNote}`,
-      '',
-      '   ```bash',
-      `   # GitHub:  gh pr create --fill${ghBaseArg}`,
-      `   # GitLab:  glab mr create --fill${glabBaseArg}`,
-      '   ```',
-    );
-    if (!runsReviewLoop && !leavePrOpen && !policyLeavesOpen) {
-      // Same CI-gate procedure the slashdo workflow and the merge follow-up use.
-      const gate = buildCiMergeGateSteps(step, { prRef: '"<PR_URL>"', forge: 'unknown' });
-      lines.push(...gate.lines);
-      step = gate.nextStep;
-    }
+        ? 'PortOS will push the branch, create a pull request with your completion summary as its description, run the configured reviewer follow-up, and merge only after review and CI pass.'
+        : 'PortOS will push the branch, create a pull request with your completion summary as its description, and merge it once CI is green.';
+    lines.push(`${step++}. Do NOT push, open, or merge a pull request yourself. ${handoff}`);
+  } else {
+    lines.push(`${step++}. Do NOT push this worktree branch yourself. PortOS will merge it back after completion.`);
   }
 
   lines.push(

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -394,8 +394,8 @@ describe('buildLightContextPrompt', () => {
         { branchName: 'claim/x', worktreePath: '/tmp/wt', baseBranch: 'main' },
         isTruthyMeta,
         { isTui: true, providerId: 'opencode-ollama-tui', providerCommand: 'opencode' });
-      expect(prompt).toMatch(/gh pr create --fill/);
-      expect(prompt).toMatch(/do NOT merge it/);
+      expect(prompt).not.toMatch(/gh pr create/);
+      expect(prompt).toMatch(/JIRA-linked human handoff/);
       expect(prompt).not.toMatch(/gh pr merge/);
       expect(prompt).not.toMatch(/glab mr merge/);
     });
@@ -463,12 +463,10 @@ describe('buildLightContextPrompt', () => {
       expect(prompt).not.toMatch(/gh pr merge/);
     });
 
-    it('emits a slashdo-free, forge-aware Completion Workflow for an OpenCode TUI + openPR + Review Loop (opens PR, no auto-merge)', () => {
+    it('hands a slashdo-free OpenCode TUI PR to PortOS for description, review, and merge', () => {
       // OpenCode TUI doesn't load Claude Code slash commands, so /do:pr / /do:push
-      // would be uninvokable. The agent commits, pushes, opens the PR/MR for review,
-      // and writes the sentinel with plain git + the forge CLI. With a Review Loop
-      // configured it must NOT auto-merge (it can't run the reviewer loop and PortOS
-      // runs no post-exit review for a TUI).
+      // would be uninvokable. The agent commits and writes the sentinel; PortOS
+      // owns the PR body, configured reviewer follow-up, and merge.
       const prompt = buildLightContextPrompt(
         makeTask({ metadata: { simplify: true, openPR: true, reviewLoop: true } }),
         '/r',
@@ -482,42 +480,34 @@ describe('buildLightContextPrompt', () => {
       expect(prompt).not.toMatch(/`\/simplify`/);
       // /simplify is a Claude built-in — OpenCode gets the inline equivalent.
       expect(prompt).toMatch(/review your changed code for reuse, quality, and efficiency/i);
-      // Plain git commit → push → open PR. Base pinned to the worktree base branch.
+      // Plain git commit only — no agent-owned push or forge action.
       expect(prompt).toMatch(/git commit -m/);
-      expect(prompt).toMatch(/git push -u origin claim\/issue-1/);
-      // Forge-aware: both GitHub (gh) and GitLab (glab) create commands, base-pinned.
-      expect(prompt).toMatch(/gh pr create --fill --base main/);
-      expect(prompt).toMatch(/glab mr create --fill --target-branch main/);
-      // Opens for review — never auto-merges.
+      expect(prompt).not.toMatch(/git push/);
+      expect(prompt).not.toMatch(/gh pr create/);
+      expect(prompt).not.toMatch(/glab mr create/);
       expect(prompt).not.toMatch(/gh pr merge/);
       expect(prompt).not.toMatch(/glab mr merge/);
-      expect(prompt).toMatch(/do NOT merge it yourself/);
+      expect(prompt).toMatch(/PortOS will push the branch, create a pull request with your completion summary as its description, run the configured reviewer follow-up, and merge only after review and CI pass/);
       // Sentinel handshake still drives completion; never tell the agent to run /quit.
       expect(prompt).toMatch(/\.agent-done/);
       expect(prompt).toMatch(/NOT run `\/quit`/);
       expect(prompt).not.toMatch(/^\s*\d+\.\s*`\/quit`/m);
     });
 
-    it('OpenCode TUI + openPR WITHOUT a Review Loop merges on green CI (forge-aware)', () => {
-      // No reviewer and no PortOS follow-up is coming for a TUI task, so leaving the
-      // PR open would leak it — the agent gates on CI and merges itself.
+    it('hands a slashdo-free OpenCode TUI PR to PortOS for a green-CI merge', () => {
       const prompt = buildLightContextPrompt(
         makeTask({ metadata: { simplify: true, openPR: true } }),
         '/r',
         { branchName: 'claim/issue-1', worktreePath: '/tmp/wt', baseBranch: 'main' },
         isTruthyMeta,
         { isTui: true, providerId: 'opencode-ollama-tui', providerCommand: 'opencode' });
-      expect(prompt).toMatch(/gh pr create --fill --base main/);
-      expect(prompt).toMatch(/gh pr checks "<PR_URL>" --watch --fail-fast/);
-      expect(prompt).toMatch(/gh pr merge "<PR_URL>" --merge --delete-branch/);
-      // `glab mr merge` selects by IID or source branch — never by URL.
-      expect(prompt).toMatch(/glab mr merge <MR_NUMBER> --yes --remove-source-branch/);
-      expect(prompt).not.toMatch(/glab mr merge "?http/);
-      expect(prompt).toMatch(/gh pr view "<PR_URL>" --json state -q \.state/);
-      expect(prompt).not.toMatch(/do NOT merge it yourself/);
+      expect(prompt).not.toMatch(/gh pr create/);
+      expect(prompt).not.toMatch(/gh pr checks/);
+      expect(prompt).not.toMatch(/gh pr merge/);
+      expect(prompt).toMatch(/PortOS will push the branch, create a pull request with your completion summary as its description, and merge it once CI is green/);
     });
 
-    it('OpenCode TUI without openPR pushes the branch but opens no PR', () => {
+    it('OpenCode TUI without openPR leaves the committed branch for PortOS to merge', () => {
       const prompt = buildLightContextPrompt(
         makeTask({ metadata: { openPR: false } }),
         '/r',
@@ -526,24 +516,22 @@ describe('buildLightContextPrompt', () => {
         { isTui: true, providerId: 'opencode-ollama-tui', providerCommand: 'opencode' });
       expect(prompt).toMatch(/## Completion Workflow/);
       expect(prompt).not.toMatch(/`\/do:push`/);
-      expect(prompt).toMatch(/git push -u origin claim\/issue-2/);
-      // No PR is opened, so no forge create/merge steps.
+      expect(prompt).not.toMatch(/git push/);
       expect(prompt).not.toMatch(/gh pr create/);
       expect(prompt).not.toMatch(/glab mr create/);
       expect(prompt).not.toMatch(/gh pr merge/);
       expect(prompt).toMatch(/\.agent-done/);
     });
 
-    it('shell-quotes a branch ref containing shell metacharacters in the manual push command', () => {
-      // Git refs can legally contain `;` etc.; the emitted push command must quote it.
+    it('does not interpolate a branch ref into a shell command in the system-owned handoff', () => {
       const prompt = buildLightContextPrompt(
         makeTask({ metadata: { openPR: false } }),
         '/r',
         { branchName: 'weird;rm -rf', worktreePath: '/tmp/wt' },
         isTruthyMeta,
         { isTui: true, providerId: 'opencode-ollama-tui', providerCommand: 'opencode' });
-      expect(prompt).toMatch(/git push -u origin 'weird;rm -rf'/);
-      expect(prompt).not.toMatch(/git push -u origin weird;rm/);
+      expect(prompt).not.toMatch(/git push/);
+      expect(prompt).not.toMatch(/git .*weird;rm -rf/);
     });
 
     // #3114 acceptance criteria — the completion gates derive from
@@ -564,9 +552,11 @@ describe('buildLightContextPrompt', () => {
       expect(prompt).toMatch(/does NOT have slashdo/);
       expect(prompt).not.toMatch(/`\/do:pr`/);
       expect(prompt).not.toMatch(/`\/do:push`/);
-      // Plain git + forge CLI instead.
-      expect(prompt).toMatch(/git push -u origin claim\/x/);
-      expect(prompt).toMatch(/gh pr create --fill --base main/);
+      // Plain commit + system-owned PR handoff instead.
+      expect(prompt).toMatch(/git commit -m/);
+      expect(prompt).not.toMatch(/git push/);
+      expect(prompt).not.toMatch(/gh pr create/);
+      expect(prompt).toMatch(/PortOS will push the branch/);
       expect(prompt).toMatch(/\.agent-done/);
     });
 
@@ -594,7 +584,8 @@ describe('buildLightContextPrompt', () => {
         isTruthyMeta,
         { isTui: true, providerId: 'antigravity-tui', providerCommand: 'agy' });
       expect(prompt).not.toMatch(/`\/do:push`/);
-      expect(prompt).toMatch(/git push -u origin b/);
+      expect(prompt).not.toMatch(/git push/);
+      expect(prompt).toMatch(/PortOS will merge it back/);
     });
 
     it('a non-OpenCode TUI (claude-code-tui) keeps the slashdo /do:pr workflow', () => {
@@ -1480,12 +1471,12 @@ describe('buildCompletionGuidelineBullet', () => {
     expect(bullet).toMatch(/do NOT run `\/quit`/);
   });
 
-  it('slashdo-free TUI bullet points at the plain git/gh workflow, not a /do:* command', () => {
+  it('slashdo-free TUI bullet points at the commit + PortOS handoff, not a /do:* command', () => {
     const bullet = buildCompletionGuidelineBullet({
       isReadOnly: false, isTui: true, slashdoFree: true,
       tuiCompletionCommand: '/do:pr', worktreeInfo: { worktreePath: '/wt' }, willOpenPR: true, willReviewLoop: false,
     });
-    expect(bullet).toMatch(/plain `git`\/`gh`/);
+    expect(bullet).toMatch(/plain `git` commit \+ PortOS handoff/);
     expect(bullet).toMatch(/no slashdo commands/);
     expect(bullet).not.toMatch(/`\/do:pr`/);
     expect(bullet).toMatch(/do NOT run `\/quit`/);

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -19,7 +19,11 @@ import { finalizeAgent, releaseAgentLane } from './agentFinalization.js';
 import { activeAgents, userTerminatedAgents, pausedAgents, isFalsyMeta } from './agentState.js';
 import { PATHS } from '../lib/fileUtils.js';
 import { DONE_SENTINEL_NAME, parseSentinelPayload } from '../lib/agentSentinel.js';
+import { resolvePrCompletion } from '../lib/prDisposition.js';
+import { canTypeSlashCommands } from '../lib/slashdoInvocation.js';
+import { normalizeReviewers } from '../lib/validation.js';
 import * as git from './git.js';
+import { resolveReviewLoopOptions } from './codeReview.js';
 import { shellQuote } from '../lib/shellQuote.js';
 import { resolveCliModel, buildEffortArgs, resolveBedrockCliModel, prefixOpencodeModel, hasModelFlag, isOpencodeCommand, isClaudeCommand, applyLeanClaudeArgs, providerSuppliesGithubToken } from '../lib/providerModels.js';
 import { createStreamingAnsiStripper, stripAnsi } from '../lib/ansiStrip.js';
@@ -223,6 +227,7 @@ export async function spawnTuiAgent({
   laneName,
   cleanupWorktreeFn,
   isTruthyMetaFn,
+  leanMode = false,
 }) {
   const outputFile = join(agentDir, 'output.txt');
   // Raw PTY bytes spool to disk continuously rather than accumulate in-memory.
@@ -504,15 +509,29 @@ export async function spawnTuiAgent({
     } finally {
       if (workspacePath) await rm(join(workspacePath, DONE_SENTINEL_NAME)).catch(() => {});
 
-      // TUI agents run /do:pr (or /do:push) themselves before signaling via
-      // .agent-done, so the system-side cleanup must NOT also push or open a
-      // PR — that would double-fire. `skipMerge` is forced on so the
-      // post-exit auto-merge doesn't trip over a branch the agent already
-      // pushed. The worktree directory itself is still cleaned up.
+      // A slashdo-capable Claude TUI owns /do:pr itself. Slashdo-free TUIs
+      // (Codex, Antigravity, OpenCode, lean Claude) only commit and signal;
+      // PortOS must own their push + PR + reviewer/merge follow-up. Derive this
+      // from the same predicate used by the prompt builder so neither side can
+      // believe the other owns the PR.
+      const taskOpenPR = isTruthyMetaFn(task.metadata?.openPR);
+      const agentOwnsPR = taskOpenPR && canTypeSlashCommands({
+        providerId: provider?.id,
+        providerCommand: provider?.command,
+        leanMode,
+      });
+      const reviewOptions = finalSuccess && taskOpenPR && !agentOwnsPR
+        ? await resolveReviewLoopOptions(task.metadata, { normalize: normalizeReviewers, isTruthyMeta: isTruthyMetaFn })
+          .catch(err => {
+            emitLog('warn', `TUI review options unavailable for ${agentId}: ${err.message}`, { agentId });
+            return {};
+          })
+        : {};
       await cleanupWorktreeFn(agentId, finalSuccess, {
-        openPR: false,
-        requestCopilotReview: false,
-        skipMerge: true,
+        openPR: agentOwnsPR ? false : taskOpenPR,
+        prCompletion: resolvePrCompletion(task.metadata),
+        ...reviewOptions,
+        skipMerge: agentOwnsPR,
         description: task.description,
         agentOutput: getOutputBuffer(),
         originalTask: task

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -64,6 +64,18 @@ vi.mock('./agentFinalization.js', () => ({
   releaseAgentLane: vi.fn()
 }));
 
+vi.mock('./codeReview.js', () => ({
+  resolveReviewLoopOptions: vi.fn().mockResolvedValue({
+    reviewers: ['codex'],
+    usernames: [],
+    optionalReviewers: [],
+    reviewerMaxRounds: {},
+    reviewStopMode: 'on-clean',
+    reviewerApplies: false,
+    reviewerModels: {},
+  })
+}));
+
 vi.mock('./agentState.js', () => ({
   activeAgents: new Map(),
   userTerminatedAgents: new Set(),
@@ -509,6 +521,53 @@ describe('spawnTuiAgent runtime', () => {
 
     await capturedOnExit({ exitCode: 0, killed: false });
     await completeDone;
+  });
+
+  it('hands a slashdo-free TUI PR to PortOS for creation and review/merge follow-up', async () => {
+    const cleanupWorktreeFn = vi.fn().mockResolvedValue(undefined);
+    const spawnPromise = runSpawn({
+      provider: { id: 'codex-tui', name: 'Codex TUI', type: 'tui', command: 'codex', envVars: {} },
+      task: {
+        id: 'task-1',
+        description: 'do the thing',
+        metadata: { openPR: true, prCompletion: 'review-then-merge', reviewers: ['codex'] },
+      },
+      helpers: { cleanupWorktreeFn, isTruthyMetaFn: (value) => value === true || value === 'true' },
+    });
+    await flushMicrotasks();
+
+    await capturedOnExit({ exitCode: 0, killed: false });
+    await spawnPromise;
+
+    expect(cleanupWorktreeFn).toHaveBeenCalledWith('agent-1', true, expect.objectContaining({
+      openPR: true,
+      prCompletion: 'review-then-merge',
+      reviewers: ['codex'],
+      skipMerge: false,
+    }));
+  });
+
+  it('does not double-fire a PR owned by a slashdo-capable Claude TUI', async () => {
+    const cleanupWorktreeFn = vi.fn().mockResolvedValue(undefined);
+    const spawnPromise = runSpawn({
+      provider: { id: 'claude-code-tui', name: 'Claude TUI', type: 'tui', command: 'claude', envVars: {} },
+      task: {
+        id: 'task-1',
+        description: 'do the thing',
+        metadata: { openPR: true, prCompletion: 'review-then-merge' },
+      },
+      helpers: { cleanupWorktreeFn, isTruthyMetaFn: (value) => value === true || value === 'true' },
+    });
+    await flushMicrotasks();
+
+    await capturedOnExit({ exitCode: 0, killed: false });
+    await spawnPromise;
+
+    expect(cleanupWorktreeFn).toHaveBeenCalledWith('agent-1', true, expect.objectContaining({
+      openPR: false,
+      prCompletion: 'review-then-merge',
+      skipMerge: true,
+    }));
   });
 
   // ── 1. Successful idle-complete path ────────────────────────────────────────

--- a/server/services/cosAgentLifecycle.js
+++ b/server/services/cosAgentLifecycle.js
@@ -61,8 +61,19 @@ export async function updateAgent(agentId, updates) {
     }
     await saveState(state);
 
-    cosEvents.emit('agent:updated', state.agents[agentId]);
-    return state.agents[agentId];
+    // Completion writes the archive before later completion hooks enrich an
+    // agent's metadata (task summaries, scan reports, etc.). Mirror those
+    // post-completion updates into the archived metadata too, otherwise they
+    // disappear as soon as in-memory retention expires.
+    const updatedAgent = state.agents[agentId];
+    if (updatedAgent.status === 'completed' && updatedAgent.completedAt) {
+      const { output: _output, ...metadata } = updatedAgent;
+      const dateStr = updatedAgent.completedAt.slice(0, 10);
+      await atomicWrite(join(getAgentDir(agentId, dateStr), 'metadata.json'), metadata);
+    }
+
+    cosEvents.emit('agent:updated', updatedAgent);
+    return updatedAgent;
   });
 }
 

--- a/server/services/cosAgents.test.js
+++ b/server/services/cosAgents.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdir, rm, writeFile } from 'fs/promises';
+import { mkdir, rm, writeFile, readFile } from 'fs/promises';
 import { join } from 'path';
 
 const mockCosState = vi.hoisted(() => ({
@@ -23,7 +23,7 @@ vi.mock('./domainUsage.js', () => ({
   recordDomainUsage: vi.fn(async () => {})
 }));
 
-import { getAgent, createAgentOutputBatcher, completeAgent } from './cosAgents.js';
+import { getAgent, createAgentOutputBatcher, completeAgent, updateAgent } from './cosAgents.js';
 import { saveState } from './cosState.js';
 import { recordDomainUsage } from './domainUsage.js';
 import { cosEvents } from './cosEvents.js';
@@ -59,6 +59,19 @@ describe('cosAgents', () => {
       { line: 'full line one', timestamp: pausedAt },
       { line: 'full line two', timestamp: pausedAt }
     ]);
+  });
+
+  it('persists post-completion metadata updates in the archived agent record', async () => {
+    const agentId = 'agent-completed';
+    const completedAt = '2026-05-25T12:00:00.000Z';
+    mockCosState.state.agents[agentId] = { id: agentId, status: 'completed', completedAt, metadata: {}, output: [] };
+    const archiveDir = join(mockCosState.agentsDir, '2026-05-25', agentId);
+    await mkdir(archiveDir, { recursive: true });
+
+    await updateAgent(agentId, { metadata: { malwareScan: { verdict: 'DANGEROUS' } } });
+
+    const persisted = JSON.parse(await readFile(join(archiveDir, 'metadata.json'), 'utf8'));
+    expect(persisted.metadata.malwareScan.verdict).toBe('DANGEROUS');
   });
 });
 

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -332,6 +332,9 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
     // known (see server/lib/slashdoInvocation.js).
     if (taskData.slashdoCommand) metadata.slashdoCommand = taskData.slashdoCommand;
     if (taskData.slashdoArgs) metadata.slashdoArgs = taskData.slashdoArgs;
+    if (taskData.malwareScan && typeof taskData.malwareScan === 'object' && !Array.isArray(taskData.malwareScan)) {
+      metadata.malwareScan = taskData.malwareScan;
+    }
     if (taskData.jiraTicketId) metadata.jiraTicketId = taskData.jiraTicketId;
     if (taskData.jiraTicketUrl) metadata.jiraTicketUrl = taskData.jiraTicketUrl;
     if (taskData.screenshots?.length > 0) metadata.screenshots = taskData.screenshots;

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -251,6 +251,15 @@ describe('cosTaskStore.addTask', () => {
     expect(tasks.find(t => t.id === created.id).metadata.slashdoCommand).toBe('plan-task');
   });
 
+  it('persists malware scan report ownership through the task markdown round-trip', async () => {
+    const malwareScan = { linkId: 'a3d2c4e8-810a-4d1a-8ab1-94d3e0a13f8d', reportId: 'b38bdf75-3fe2-498c-9c36-7d512dc078d1' };
+    const created = await addTask({ description: 'Malware scan: example/repo', malwareScan }, 'user');
+    expect(created.metadata.malwareScan).toEqual(malwareScan);
+
+    const { tasks } = await getUserTasks();
+    expect(tasks.find(t => t.id === created.id).metadata.malwareScan).toEqual(malwareScan);
+  });
+
   it('omits slashdo metadata when no workflow is pinned', async () => {
     const created = await addTask({ description: 'ordinary prose task' }, 'user');
     expect(created.metadata.slashdoCommand).toBeUndefined();

--- a/server/services/malwareScanReports.js
+++ b/server/services/malwareScanReports.js
@@ -1,0 +1,64 @@
+/** Malware scan report lifecycle shared by CoS completion and Brain links. */
+
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+import { PATHS, ensureDir } from '../lib/fileUtils.js';
+
+export const SCAN_REPORTS_DIR = join(PATHS.brain, 'scans');
+const REPORT_ID_RE = /^[a-f0-9-]{36}$/i;
+const VERDICTS = new Set(['CLEAN', 'CAUTION', 'DANGEROUS']);
+
+export function reportPathForId(reportId) {
+  return REPORT_ID_RE.test(reportId || '') ? join(SCAN_REPORTS_DIR, `${reportId}.md`) : null;
+}
+
+export function extractScanVerdict(report) {
+  const match = typeof report === 'string'
+    ? report.match(/^#{1,6}\s*(?:final\s+)?verdict\s*:?\s*(CLEAN|CAUTION|DANGEROUS)\b/im)
+    : null;
+  return match && VERDICTS.has(match[1]) ? match[1] : null;
+}
+
+export async function prepareScanReportDirectory() {
+  await ensureDir(SCAN_REPORTS_DIR);
+}
+
+export async function getScanReport(reportId) {
+  const path = reportPathForId(reportId);
+  return path ? readFile(path, 'utf8').catch(() => null) : null;
+}
+
+export async function finalizeMalwareScan({ agentId, task, success }) {
+  const scan = task?.metadata?.malwareScan;
+  if (!scan?.linkId || !scan?.reportId) return null;
+
+  const report = success ? await getScanReport(scan.reportId) : null;
+  const verdict = extractScanVerdict(report);
+  const status = success && report ? 'completed' : 'failed';
+  const completedAt = new Date().toISOString();
+  const reportUrl = `/api/brain/links/${scan.linkId}/scan-report`;
+  // This module sits on every agent-completion path. Load the Brain/Review
+  // writers only for an actual scan so ordinary tasks do not pull those service
+  // graphs into the completion hot path.
+  const [brain, agents, review] = await Promise.all([
+    import('./brain.js'),
+    import('./cosAgents.js'),
+    import('./review.js')
+  ]);
+
+  await brain.updateLink(scan.linkId, {
+    malwareScan: { reportId: scan.reportId, taskId: task.id, status, verdict, completedAt }
+  });
+  await agents.updateAgent(agentId, { metadata: { malwareScan: { reportUrl, status, verdict } } });
+
+  if (report) {
+    await review.createItem({
+      type: verdict === 'DANGEROUS' ? 'alert' : 'briefing',
+      title: `${verdict || 'UNKNOWN'} malware scan: ${task.description}`,
+      description: 'Open the attached markdown report for the complete static-analysis findings.',
+      metadata: { referenceId: `malware-scan:${scan.reportId}`, reportUrl, verdict, linkId: scan.linkId }
+    });
+  }
+
+  return { status, verdict, reportUrl };
+}

--- a/server/services/malwareScanReports.js
+++ b/server/services/malwareScanReports.js
@@ -4,12 +4,15 @@ import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { PATHS, ensureDir } from '../lib/fileUtils.js';
 
-export const SCAN_REPORTS_DIR = join(PATHS.brain, 'scans');
 const REPORT_ID_RE = /^[a-f0-9-]{36}$/i;
 const VERDICTS = new Set(['CLEAN', 'CAUTION', 'DANGEROUS']);
 
+export function getScanReportsDirectory() {
+  return join(PATHS.brain, 'scans');
+}
+
 export function reportPathForId(reportId) {
-  return REPORT_ID_RE.test(reportId || '') ? join(SCAN_REPORTS_DIR, `${reportId}.md`) : null;
+  return REPORT_ID_RE.test(reportId || '') ? join(getScanReportsDirectory(), `${reportId}.md`) : null;
 }
 
 export function extractScanVerdict(report) {
@@ -20,7 +23,7 @@ export function extractScanVerdict(report) {
 }
 
 export async function prepareScanReportDirectory() {
-  await ensureDir(SCAN_REPORTS_DIR);
+  await ensureDir(getScanReportsDirectory());
 }
 
 export async function getScanReport(reportId) {

--- a/server/services/malwareScanReports.test.js
+++ b/server/services/malwareScanReports.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { extractScanVerdict, reportPathForId } from './malwareScanReports.js';
+
+describe('malware scan reports', () => {
+  it('accepts only an explicit markdown verdict heading', () => {
+    expect(extractScanVerdict('## Verdict: DANGEROUS\nStatic finding')).toBe('DANGEROUS');
+    expect(extractScanVerdict('A dependency says DANGEROUS in a comment')).toBeNull();
+  });
+
+  it('does not turn an arbitrary string into a report path', () => {
+    expect(reportPathForId('../../private')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Preserve malware scan markdown reports as durable PortOS-owned artifacts.
- Link reports from completed agent summaries, Review Hub items, and GitHub link cards.
- Mark links with a DANGEROUS verdict using a skull danger treatment.
- Hand slashdo-free TUI commits back to PortOS so PR descriptions, configured reviews, and merges have a single owner.

## Test plan
- Server targeted suites: 386 tests passed.
- Client tests/build and lint passed in the initial CI run.
- DB tests and server smoke passed in the initial CI run.
- Regression: cleanupAgentWorktree import no longer crashes when fileUtils PATHS is partially mocked.