### PR TITLE
Give the Hey Ho Nobody Home round its missing fourth phrase and the right closing lyric

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -64,6 +64,10 @@
 
 - **[issue-3218] Tab sheets now explain their articulation characters.** When an arrangement includes a tab staff, a Legend button defines hammer-ons, pull-offs, slides, bends, releases, vibrato, and muted notes, including how to play each technique. Chord-over-lyrics and plain-text sheets stay uncluttered when that notation is absent.
 
+## Rounds
+
+- **[issue-3238] "Hey Ho Nobody Home" now has all four of its lines — and the right words for the last one.** The built-in round printed four lines of lyrics but only ever notated three: the closing line had no notes to sing it on, so the words and the sheet music disagreed. That line was wrong too, repeating the opening ("Hey, ho, nobody home.") instead of the way it is actually sung — **"Hey, hey, ho."** It now has its own two bars, cadencing down onto the note the round is centred on, plus the fourth entering voice the round always described but could not support. That also puts it back in step with Ah Poor Bird and Rose Rose Rose Red: at three phrases it was a quarter shorter than both, so the three-round quodlibet drifted out of alignment every few times round. If you have edited your copy of the round, your version is left exactly as you wrote it.
+
 ## Quota burn
 
 - **[issue-3179] Quota-burn no longer spends window budget on runs that never happened** — a scheduled quota-burn run counted against the family's per-window dispatch cap as soon as it was considered, even when it was subsequently skipped and no agent was ever started. Those phantom dispatches ate the budget, so a family configured for e.g. 5 burns per reset window could fire far fewer — and a family capped at 1 could never fire at all, because the skipped run consumed the only slot before the next gate re-read it. A burn is now counted once its agent has actually run, and a burn that is queued or in progress holds its slot in the meantime, so the cap stays accurate without letting a second app or a repeated "Run" overshoot it.

--- a/scripts/migrations/214-fix-hey-ho-fourth-phrase.js
+++ b/scripts/migrations/214-fix-hey-ho-fourth-phrase.js
@@ -50,6 +50,13 @@ export const NEW_HEY_HO_SCORE = NEW_SEED.score;
 export const NEW_HEY_HO_SCORE_PARTS = NEW_SEED.scoreParts;
 export const NEW_HEY_HO_NOTATION = NEW_SEED.notation;
 export const NEW_HEY_HO_LYRICS = NEW_SEED.sections.find((s) => s.id === SECTION_ID).lyrics;
+// The two voice-guidance strings the four-phrase melody invalidates: voice-3 said
+// "the three phrases stack", and voice-4 described itself as a unison double of
+// the lead (which is what an entry at bar 7 of a SIX-bar round is). With a real
+// fourth phrase they are both wrong, so they migrate like `notation` does.
+const newLayerNotes = (id) => NEW_SEED.layers.find((l) => l.id === id).notes;
+export const NEW_HEY_HO_VOICE_3_NOTES = newLayerNotes('voice-3');
+export const NEW_HEY_HO_VOICE_4_NOTES = newLayerNotes('voice-4');
 
 // The OLD shipped melody — frozen exactly as SEED_ROUNDS shipped it AFTER #2105
 // but BEFORE #3238 (D-centered and correct, but only three phrases / 6 bars).
@@ -77,6 +84,14 @@ export const OLD_HEY_HO_LYRICS =
 // notation correction.
 export const OLD_HEY_HO_NOTATION =
   'A round in up to six voices (Ravenscroft\'s Pammelia, 1609). New voices enter one two-bar phrase behind the last. Centered on D with no key signature — all naturals (D Dorian / natural minor), no B. Melody after the Wikibooks Songbook and Kodály teaching transcriptions, transposed to a D tonal center.';
+
+// The OLD shipped voice guidance — frozen exactly as it read before #3238. Each
+// gates its own layer's correction, so a user who rewrote one note keeps it while
+// the other still gets fixed.
+export const OLD_HEY_HO_VOICE_3_NOTES =
+  'Enters at "Still I will be merry" (phrase 3); the three phrases stack into the full minor chord.';
+export const OLD_HEY_HO_VOICE_4_NOTES =
+  'Optional fourth entry: comes in as Voice 1 loops back to the top, doubling the lead in unison or an octave up.';
 
 const fileExists = (path) => stat(path).then(() => true, (err) => {
   if (err.code === 'ENOENT') return false;
@@ -110,13 +125,24 @@ export default {
     let fixedScore = false;
     let fixedLyrics = false;
     let fixedNotation = false;
+    let fixedLayers = 0;
 
-    // Replace score + scoreParts only when the stored score is still the exact
-    // 6-bar shipped string. Deep-clone the scoreParts so the persisted record
+    // Replace score + the SHIPPED canon voices only when the stored score is still
+    // the exact 6-bar shipped string. Deep-clone the parts so the persisted record
     // can't share array/object identity with the in-memory seed.
+    //
+    // Parts the user added themselves are preserved. `scoreParts` is independently
+    // editable (SongScoreParts' "Add part" and the AI-derive path both append a
+    // part with a generated id), so a stock melody can still carry a hand-written
+    // bass line. Rewriting the whole array — as a naive replace would — would
+    // delete that work with no backup, which is exactly the clobbering this
+    // migration's per-field gating exists to prevent.
     if (round.score === OLD_HEY_HO_SCORE_6BAR) {
       round.score = NEW_HEY_HO_SCORE;
-      round.scoreParts = NEW_HEY_HO_SCORE_PARTS.map((p) => ({ ...p }));
+      const shippedIds = new Set(NEW_HEY_HO_SCORE_PARTS.map((p) => p.id));
+      const userParts = (Array.isArray(round.scoreParts) ? round.scoreParts : [])
+        .filter((p) => p && !shippedIds.has(p.id));
+      round.scoreParts = [...NEW_HEY_HO_SCORE_PARTS.map((p) => ({ ...p })), ...userParts];
       fixedScore = true;
     }
 
@@ -136,14 +162,32 @@ export default {
       fixedNotation = true;
     }
 
-    if (!fixedScore && !fixedLyrics && !fixedNotation) {
+    // Correct the stale voice guidance the same way — per layer, on its own old
+    // string. Without this an upgraded install would carry a real fourth canon
+    // voice while its Voice 4 panel still told the singer to double the lead in
+    // unison, and Voice 3 still claimed the round had three phrases.
+    const staleLayerNotes = [
+      ['voice-3', OLD_HEY_HO_VOICE_3_NOTES, NEW_HEY_HO_VOICE_3_NOTES],
+      ['voice-4', OLD_HEY_HO_VOICE_4_NOTES, NEW_HEY_HO_VOICE_4_NOTES],
+    ];
+    for (const [layerId, oldNotes, nextNotes] of staleLayerNotes) {
+      const layer = Array.isArray(round.layers)
+        ? round.layers.find((l) => l && l.id === layerId)
+        : null;
+      if (layer && layer.notes === oldNotes) {
+        layer.notes = nextNotes;
+        fixedLayers += 1;
+      }
+    }
+
+    if (!fixedScore && !fixedLyrics && !fixedNotation && !fixedLayers) {
       console.log('📦 migration 214: Hey Ho already has its fourth phrase or is customized; leaving it untouched.');
       return { updated: 0, reason: 'already-applied' };
     }
 
     round.updatedAt = new Date().toISOString();
     await writeFile(path, JSON.stringify(doc, null, 2) + '\n');
-    console.log(`📦 migration 214: extended Hey Ho Nobody Home (score: ${fixedScore}, lyrics: ${fixedLyrics}, notation: ${fixedNotation}).`);
-    return { updated: 1, fixedScore, fixedLyrics, fixedNotation };
+    console.log(`📦 migration 214: extended Hey Ho Nobody Home (score: ${fixedScore}, lyrics: ${fixedLyrics}, notation: ${fixedNotation}, layers: ${fixedLayers}).`);
+    return { updated: 1, fixedScore, fixedLyrics, fixedNotation, fixedLayers };
   },
 };

--- a/scripts/migrations/214-fix-hey-ho-fourth-phrase.js
+++ b/scripts/migrations/214-fix-hey-ho-fourth-phrase.js
@@ -1,0 +1,149 @@
+/**
+ * Give the built-in "Hey Ho Nobody Home" round its missing fourth phrase, and
+ * correct its fourth lyric line (issue #3238).
+ *
+ * Background:
+ *   The shipped round listed FOUR lyric lines but its melody carried only THREE
+ *   two-bar phrases (6 bars) — the closing line had no notes at all, so the
+ *   lyric sheet and the staff disagreed. Worse, the round anchors the D-minor
+ *   quodlibet with Ah Poor Bird and Rose Rose Rose Red, both of which are 8
+ *   bars: at 6 bars Hey Ho lapped its own documented partners every four cycles,
+ *   so the round-against-round stack in RoundStack never actually stayed in
+ *   phase.
+ *
+ *   The fourth line was also wrong. It shipped as a repeat of line 1 ("Hey, ho,
+ *   nobody home.") where the line as commonly sung is "Hey, hey, ho."
+ *
+ *   The seed now ships an 8-bar `HEY_HO_MELODY` whose fourth phrase cadences
+ *   F–E–D onto the tonic (all within the round's existing D natural-minor
+ *   pentachord), the corrected lyric line, and a real fourth canon voice
+ *   (`delayBars: 6`) matching how the other 8-bar rounds stack.
+ *
+ *   Fresh installs seed all of that directly. An install whose
+ *   `data/rounds.json` already holds the 6-bar record keeps the short melody and
+ *   the wrong lyric on disk. This migration replaces them with the shipped
+ *   versions ONLY when the stored value still exactly matches the old shipped
+ *   string — a user who customized their score or lyrics is never clobbered
+ *   (they can pull the shipped version any time via "Refresh from template").
+ *   Score, lyrics, and notation are each gated on their OWN old-string match, so
+ *   a customized score with stock lyrics still gets the lyric correction.
+ *
+ *   Fresh installs (no file) are a clean no-op. Re-runs detect the corrected
+ *   content and skip.
+ *
+ *   Runs after migration 158 (which corrected the same round's pitch content),
+ *   so the "old" score fingerprint below is the POST-158 6-bar melody.
+ */
+
+import { readFile, writeFile, stat } from 'fs/promises';
+import { join } from 'path';
+import { SEED_ROUNDS } from '../../server/services/rounds.js';
+
+const ROUND_ID = 'seed-hey-ho-nobody-home';
+const SECTION_ID = 'sec-round';
+
+// The NEW shipped content — read from the single source of truth in rounds.js
+// (identity, not a copy) so this migration and the seed can never drift. The
+// migration test asserts these come from SEED_ROUNDS.
+const NEW_SEED = SEED_ROUNDS.find((r) => r.id === ROUND_ID);
+export const NEW_HEY_HO_SCORE = NEW_SEED.score;
+export const NEW_HEY_HO_SCORE_PARTS = NEW_SEED.scoreParts;
+export const NEW_HEY_HO_NOTATION = NEW_SEED.notation;
+export const NEW_HEY_HO_LYRICS = NEW_SEED.sections.find((s) => s.id === SECTION_ID).lyrics;
+
+// The OLD shipped melody — frozen exactly as SEED_ROUNDS shipped it AFTER #2105
+// but BEFORE #3238 (D-centered and correct, but only three phrases / 6 bars).
+// Hard-coded on purpose: this is the fingerprint that tells "still the untouched
+// shipped score" apart from a user customization. Do NOT regenerate it from
+// rounds.js — that would defeat the point (it must NOT track the extended melody).
+export const OLD_HEY_HO_SCORE_6BAR = [
+  'clef: treble',
+  'key: C',
+  'time: 4/4',
+  'tempo: 76',
+  '',
+  '| D4h(Hey) A3h(ho) | D4q(no-) D4e(bo-) D4e(dy) A3h(home) |',
+  '| D4q(Meat) D4q(nor) E4q(drink) E4q(nor) | F4e(mon-) F4e(ey) F4e(have) F4e(I) E4h(none) |',
+  '| A4q(Still) G4q(I) A4q(will) G4q(be) | F4h(mer-) E4h(ry) |',
+].join('\n');
+
+// The OLD shipped lyric block — frozen exactly as it read before #3238, with the
+// fourth line repeating line 1. Gates the lyric correction.
+export const OLD_HEY_HO_LYRICS =
+  'Hey, ho, nobody home,\nMeat nor drink nor money have I none,\nStill I will be merry.\nHey, ho, nobody home.';
+
+// The OLD shipped notation — frozen exactly as it read after #2105 and before
+// #3238 (truthful about the key, silent about the phrase count). Gates the
+// notation correction.
+export const OLD_HEY_HO_NOTATION =
+  'A round in up to six voices (Ravenscroft\'s Pammelia, 1609). New voices enter one two-bar phrase behind the last. Centered on D with no key signature — all naturals (D Dorian / natural minor), no B. Melody after the Wikibooks Songbook and Kodály teaching transcriptions, transposed to a D tonal center.';
+
+const fileExists = (path) => stat(path).then(() => true, (err) => {
+  if (err.code === 'ENOENT') return false;
+  throw err;
+});
+
+export default {
+  async up({ rootDir }) {
+    const path = join(rootDir, 'data', 'rounds.json');
+    if (!(await fileExists(path))) {
+      console.log('📦 migration 214: no data/rounds.json — fresh install seeds the four-phrase round directly.');
+      return { updated: 0, reason: 'no-file' };
+    }
+
+    const raw = await readFile(path, 'utf-8');
+    let doc;
+    try { doc = JSON.parse(raw); } catch (err) {
+      console.warn(`⚠️ migration 214: data/rounds.json is unparseable (${err.message}); skipping.`);
+      return { updated: 0, reason: 'unreadable' };
+    }
+    if (!doc || !Array.isArray(doc.rounds)) {
+      return { updated: 0, reason: 'unexpected-shape' };
+    }
+
+    const round = doc.rounds.find((r) => r && r.id === ROUND_ID);
+    if (!round) {
+      console.log('📦 migration 214: built-in Hey Ho Nobody Home not present; nothing to fix.');
+      return { updated: 0, reason: 'round-absent' };
+    }
+
+    let fixedScore = false;
+    let fixedLyrics = false;
+    let fixedNotation = false;
+
+    // Replace score + scoreParts only when the stored score is still the exact
+    // 6-bar shipped string. Deep-clone the scoreParts so the persisted record
+    // can't share array/object identity with the in-memory seed.
+    if (round.score === OLD_HEY_HO_SCORE_6BAR) {
+      round.score = NEW_HEY_HO_SCORE;
+      round.scoreParts = NEW_HEY_HO_SCORE_PARTS.map((p) => ({ ...p }));
+      fixedScore = true;
+    }
+
+    // Correct the fourth lyric line independently — a customized score with the
+    // stock lyric block still deserves the right words.
+    const section = Array.isArray(round.sections)
+      ? round.sections.find((s) => s && s.id === SECTION_ID)
+      : null;
+    if (section && section.lyrics === OLD_HEY_HO_LYRICS) {
+      section.lyrics = NEW_HEY_HO_LYRICS;
+      fixedLyrics = true;
+    }
+
+    // Correct the notation independently too, gated on its own old string.
+    if (round.notation === OLD_HEY_HO_NOTATION) {
+      round.notation = NEW_HEY_HO_NOTATION;
+      fixedNotation = true;
+    }
+
+    if (!fixedScore && !fixedLyrics && !fixedNotation) {
+      console.log('📦 migration 214: Hey Ho already has its fourth phrase or is customized; leaving it untouched.');
+      return { updated: 0, reason: 'already-applied' };
+    }
+
+    round.updatedAt = new Date().toISOString();
+    await writeFile(path, JSON.stringify(doc, null, 2) + '\n');
+    console.log(`📦 migration 214: extended Hey Ho Nobody Home (score: ${fixedScore}, lyrics: ${fixedLyrics}, notation: ${fixedNotation}).`);
+    return { updated: 1, fixedScore, fixedLyrics, fixedNotation };
+  },
+};

--- a/scripts/migrations/214-fix-hey-ho-fourth-phrase.test.js
+++ b/scripts/migrations/214-fix-hey-ho-fourth-phrase.test.js
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import migration, {
+  OLD_HEY_HO_SCORE_6BAR,
+  OLD_HEY_HO_LYRICS,
+  OLD_HEY_HO_NOTATION,
+  NEW_HEY_HO_SCORE,
+  NEW_HEY_HO_SCORE_PARTS,
+  NEW_HEY_HO_LYRICS,
+  NEW_HEY_HO_NOTATION,
+} from './214-fix-hey-ho-fourth-phrase.js';
+import { OLD_HEY_HO_SCORE as PRE_2105_SCORE } from './158-fix-hey-ho-melody.js';
+import { SEED_ROUNDS } from '../../server/services/rounds.js';
+
+const ROUND_ID = 'seed-hey-ho-nobody-home';
+const SECTION_ID = 'sec-round';
+const writeJson = (path, value) => writeFileSync(path, JSON.stringify(value, null, 2) + '\n');
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf-8'));
+const findRound = (path, id) => readJson(path).rounds.find((r) => r.id === id);
+const findLyrics = (path) => findRound(path, ROUND_ID).sections.find((s) => s.id === SECTION_ID).lyrics;
+
+// A stored record in the exact pre-#3238 shipped shape.
+const oldRecord = () => ({
+  id: ROUND_ID,
+  score: OLD_HEY_HO_SCORE_6BAR,
+  scoreParts: [{ id: 'part-heyho-v2' }, { id: 'part-heyho-v3' }],
+  notation: OLD_HEY_HO_NOTATION,
+  sections: [{ id: SECTION_ID, label: 'Round', lyrics: OLD_HEY_HO_LYRICS }],
+});
+
+describe('migration 214 — Hey Ho Nobody Home fourth phrase + lyric', () => {
+  let rootDir;
+  let roundsPath;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'migration-214-'));
+    mkdirSync(join(rootDir, 'data'), { recursive: true });
+    roundsPath = join(rootDir, 'data', 'rounds.json');
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  // Drift guard (a): the migration's NEW constants ARE the current seed (identity,
+  // not copies) — so the migration can never restore a stale melody or lyric.
+  it('new constants are the current seed (single source, no drift)', () => {
+    const seed = SEED_ROUNDS.find((r) => r.id === ROUND_ID);
+    expect(NEW_HEY_HO_SCORE).toBe(seed.score);
+    expect(NEW_HEY_HO_SCORE_PARTS).toBe(seed.scoreParts);
+    expect(NEW_HEY_HO_NOTATION).toBe(seed.notation);
+    expect(NEW_HEY_HO_LYRICS).toBe(seed.sections.find((s) => s.id === SECTION_ID).lyrics);
+  });
+
+  // Drift guard (b): the frozen OLD constants are the post-158 / pre-3238 shipped
+  // strings — the correct pitches but only three phrases, and the repeated line 4.
+  it('old constants are the frozen pre-fix shipped strings, distinct from the new seed', () => {
+    expect(OLD_HEY_HO_SCORE_6BAR).not.toBe(NEW_HEY_HO_SCORE);
+    // It is the POST-158 melody (D-centered, no B) — not the pre-#2105 one.
+    expect(OLD_HEY_HO_SCORE_6BAR).toContain('D4h(Hey)');
+    expect(OLD_HEY_HO_SCORE_6BAR).not.toContain('B4');
+    expect(OLD_HEY_HO_SCORE_6BAR).not.toBe(PRE_2105_SCORE);
+    // Three phrases in, four out — the new melody adds the closing line.
+    expect(OLD_HEY_HO_SCORE_6BAR.split('\n').filter((l) => l.includes('|')).length).toBe(3);
+    expect(NEW_HEY_HO_SCORE.split('\n').filter((l) => l.includes('|')).length).toBe(4);
+    expect(NEW_HEY_HO_SCORE).toContain('D4h(ho)');
+    // The lyric fix: line 4 stops repeating line 1.
+    expect(OLD_HEY_HO_LYRICS.split('\n')[3]).toBe('Hey, ho, nobody home.');
+    expect(NEW_HEY_HO_LYRICS.split('\n')[3]).toBe('Hey, hey, ho.');
+    // The first three lines are untouched by the fix.
+    expect(NEW_HEY_HO_LYRICS.split('\n').slice(0, 3)).toEqual(OLD_HEY_HO_LYRICS.split('\n').slice(0, 3));
+    expect(OLD_HEY_HO_NOTATION).not.toBe(NEW_HEY_HO_NOTATION);
+  });
+
+  it('no-ops when data/rounds.json is missing (fresh install seeds the fix directly)', async () => {
+    const result = await migration.up({ rootDir });
+    expect(result).toEqual({ updated: 0, reason: 'no-file' });
+    expect(existsSync(roundsPath)).toBe(false);
+  });
+
+  it('skips an unparseable rounds file without throwing', async () => {
+    writeFileSync(roundsPath, '{ not json');
+    const result = await migration.up({ rootDir });
+    expect(result).toEqual({ updated: 0, reason: 'unreadable' });
+  });
+
+  it('no-ops when the built-in round is absent', async () => {
+    writeJson(roundsPath, { rounds: [{ id: 'seed-500-miles' }] });
+    const result = await migration.up({ rootDir });
+    expect(result).toEqual({ updated: 0, reason: 'round-absent' });
+  });
+
+  it('extends the melody, canon voices, lyric and notation on an untouched install', async () => {
+    writeJson(roundsPath, { rounds: [oldRecord()] });
+    const result = await migration.up({ rootDir });
+    expect(result).toMatchObject({ updated: 1, fixedScore: true, fixedLyrics: true, fixedNotation: true });
+
+    const round = findRound(roundsPath, ROUND_ID);
+    expect(round.score).toBe(NEW_HEY_HO_SCORE);
+    expect(round.scoreParts).toEqual(NEW_HEY_HO_SCORE_PARTS);
+    expect(round.notation).toBe(NEW_HEY_HO_NOTATION);
+    expect(findLyrics(roundsPath)).toBe(NEW_HEY_HO_LYRICS);
+    expect(round.updatedAt).toBeTruthy();
+  });
+
+  it('persists the fourth canon voice without sharing identity with the in-memory seed', async () => {
+    writeJson(roundsPath, { rounds: [oldRecord()] });
+    await migration.up({ rootDir });
+    const round = findRound(roundsPath, ROUND_ID);
+    expect(round.scoreParts).toHaveLength(3);
+    expect(round.scoreParts.map((p) => p.id)).toEqual(['part-heyho-v2', 'part-heyho-v3', 'part-heyho-v4']);
+    // Deep-cloned on write, so mutating the persisted copy can't reach the seed.
+    expect(round.scoreParts[2]).not.toBe(NEW_HEY_HO_SCORE_PARTS[2]);
+  });
+
+  it('is idempotent across re-runs', async () => {
+    writeJson(roundsPath, { rounds: [oldRecord()] });
+    await migration.up({ rootDir });
+    const second = await migration.up({ rootDir });
+    expect(second).toEqual({ updated: 0, reason: 'already-applied' });
+    expect(findRound(roundsPath, ROUND_ID).score).toBe(NEW_HEY_HO_SCORE);
+  });
+
+  it('never clobbers a customized score', async () => {
+    const custom = 'clef: treble\nkey: C\n\n| D4w(Mine) |';
+    writeJson(roundsPath, { rounds: [{ ...oldRecord(), score: custom }] });
+    await migration.up({ rootDir });
+    expect(findRound(roundsPath, ROUND_ID).score).toBe(custom);
+  });
+
+  it('still corrects stock lyrics and notation when the score is customized', async () => {
+    const custom = 'clef: treble\nkey: C\n\n| D4w(Mine) |';
+    writeJson(roundsPath, { rounds: [{ ...oldRecord(), score: custom }] });
+    const result = await migration.up({ rootDir });
+    expect(result).toMatchObject({ updated: 1, fixedScore: false, fixedLyrics: true, fixedNotation: true });
+    expect(findLyrics(roundsPath)).toBe(NEW_HEY_HO_LYRICS);
+    expect(findRound(roundsPath, ROUND_ID).notation).toBe(NEW_HEY_HO_NOTATION);
+  });
+
+  it('never clobbers customized lyrics while still extending a stock score', async () => {
+    const myLyrics = 'Hey, ho, nobody home,\nI sing it my own way.';
+    const record = oldRecord();
+    record.sections = [{ id: SECTION_ID, label: 'Round', lyrics: myLyrics }];
+    writeJson(roundsPath, { rounds: [record] });
+    const result = await migration.up({ rootDir });
+    expect(result).toMatchObject({ updated: 1, fixedScore: true, fixedLyrics: false });
+    expect(findLyrics(roundsPath)).toBe(myLyrics);
+    expect(findRound(roundsPath, ROUND_ID).score).toBe(NEW_HEY_HO_SCORE);
+  });
+
+  it('tolerates a record with no sections array', async () => {
+    const record = oldRecord();
+    delete record.sections;
+    writeJson(roundsPath, { rounds: [record] });
+    const result = await migration.up({ rootDir });
+    expect(result).toMatchObject({ updated: 1, fixedScore: true, fixedLyrics: false });
+    expect(findRound(roundsPath, ROUND_ID).score).toBe(NEW_HEY_HO_SCORE);
+  });
+});

--- a/scripts/migrations/214-fix-hey-ho-fourth-phrase.test.js
+++ b/scripts/migrations/214-fix-hey-ho-fourth-phrase.test.js
@@ -53,6 +53,11 @@ describe('migration 214 — Hey Ho Nobody Home fourth phrase + lyric', () => {
     expect(NEW_HEY_HO_SCORE_PARTS).toBe(seed.scoreParts);
     expect(NEW_HEY_HO_NOTATION).toBe(seed.notation);
     expect(NEW_HEY_HO_LYRICS).toBe(seed.sections.find((s) => s.id === SECTION_ID).lyrics);
+    // Pin the content, not just the identity: a renamed section id would make
+    // BOTH sides of the comparison above `undefined` and pass vacuously, and the
+    // migration would then write `undefined` over a user's lyrics.
+    expect(typeof NEW_HEY_HO_LYRICS).toBe('string');
+    expect(NEW_HEY_HO_LYRICS).toContain('Hey, hey, ho.');
   });
 
   // Drift guard (b): the frozen OLD constants are the post-158 / pre-3238 shipped

--- a/scripts/migrations/214-fix-hey-ho-fourth-phrase.test.js
+++ b/scripts/migrations/214-fix-hey-ho-fourth-phrase.test.js
@@ -7,10 +7,14 @@ import migration, {
   OLD_HEY_HO_SCORE_6BAR,
   OLD_HEY_HO_LYRICS,
   OLD_HEY_HO_NOTATION,
+  OLD_HEY_HO_VOICE_3_NOTES,
+  OLD_HEY_HO_VOICE_4_NOTES,
   NEW_HEY_HO_SCORE,
   NEW_HEY_HO_SCORE_PARTS,
   NEW_HEY_HO_LYRICS,
   NEW_HEY_HO_NOTATION,
+  NEW_HEY_HO_VOICE_3_NOTES,
+  NEW_HEY_HO_VOICE_4_NOTES,
 } from './214-fix-hey-ho-fourth-phrase.js';
 import { OLD_HEY_HO_SCORE as PRE_2105_SCORE } from './158-fix-hey-ho-melody.js';
 import { SEED_ROUNDS } from '../../server/services/rounds.js';
@@ -21,6 +25,7 @@ const writeJson = (path, value) => writeFileSync(path, JSON.stringify(value, nul
 const readJson = (path) => JSON.parse(readFileSync(path, 'utf-8'));
 const findRound = (path, id) => readJson(path).rounds.find((r) => r.id === id);
 const findLyrics = (path) => findRound(path, ROUND_ID).sections.find((s) => s.id === SECTION_ID).lyrics;
+const findLayer = (path, id) => findRound(path, ROUND_ID).layers.find((l) => l.id === id);
 
 // A stored record in the exact pre-#3238 shipped shape.
 const oldRecord = () => ({
@@ -29,6 +34,12 @@ const oldRecord = () => ({
   scoreParts: [{ id: 'part-heyho-v2' }, { id: 'part-heyho-v3' }],
   notation: OLD_HEY_HO_NOTATION,
   sections: [{ id: SECTION_ID, label: 'Round', lyrics: OLD_HEY_HO_LYRICS }],
+  layers: [
+    { id: 'voice-1', notes: 'Starts the round and sings it straight through. Everyone learns this line first.' },
+    { id: 'voice-2', notes: 'Enters as Voice 1 reaches "Meat nor drink…" (phrase 2) — one full phrase behind the lead.' },
+    { id: 'voice-3', notes: OLD_HEY_HO_VOICE_3_NOTES },
+    { id: 'voice-4', notes: OLD_HEY_HO_VOICE_4_NOTES },
+  ],
 });
 
 describe('migration 214 — Hey Ho Nobody Home fourth phrase + lyric', () => {
@@ -58,6 +69,14 @@ describe('migration 214 — Hey Ho Nobody Home fourth phrase + lyric', () => {
     // migration would then write `undefined` over a user's lyrics.
     expect(typeof NEW_HEY_HO_LYRICS).toBe('string');
     expect(NEW_HEY_HO_LYRICS).toContain('Hey, hey, ho.');
+    // Same vacuous-pass hazard for the layer notes, which are looked up by id.
+    expect(NEW_HEY_HO_VOICE_3_NOTES).toBe(seed.layers.find((l) => l.id === 'voice-3').notes);
+    expect(NEW_HEY_HO_VOICE_4_NOTES).toBe(seed.layers.find((l) => l.id === 'voice-4').notes);
+    expect(NEW_HEY_HO_VOICE_3_NOTES).not.toMatch(/three phrases/i);
+    expect(NEW_HEY_HO_VOICE_4_NOTES).not.toMatch(/unison/i);
+    // And the frozen old strings must be the pre-fix text, not the new text.
+    expect(OLD_HEY_HO_VOICE_3_NOTES).toMatch(/three phrases/i);
+    expect(OLD_HEY_HO_VOICE_4_NOTES).toMatch(/unison/i);
   });
 
   // Drift guard (b): the frozen OLD constants are the post-158 / pre-3238 shipped
@@ -111,14 +130,72 @@ describe('migration 214 — Hey Ho Nobody Home fourth phrase + lyric', () => {
     expect(round.updatedAt).toBeTruthy();
   });
 
-  it('persists the fourth canon voice without sharing identity with the in-memory seed', async () => {
+  it('persists the fourth canon voice', async () => {
     writeJson(roundsPath, { rounds: [oldRecord()] });
     await migration.up({ rootDir });
     const round = findRound(roundsPath, ROUND_ID);
     expect(round.scoreParts).toHaveLength(3);
     expect(round.scoreParts.map((p) => p.id)).toEqual(['part-heyho-v2', 'part-heyho-v3', 'part-heyho-v4']);
-    // Deep-cloned on write, so mutating the persisted copy can't reach the seed.
-    expect(round.scoreParts[2]).not.toBe(NEW_HEY_HO_SCORE_PARTS[2]);
+  });
+
+  // The write deep-clones the shipped parts. Re-reading the file can't prove that
+  // (JSON.parse always yields fresh objects, so an identity assertion there passes
+  // whether or not the clone exists) — what it protects is the in-memory seed,
+  // which a later migration in the same process would otherwise share and mutate.
+  it('does not mutate the in-memory seed while writing the record', async () => {
+    const before = JSON.parse(JSON.stringify(NEW_HEY_HO_SCORE_PARTS));
+    writeJson(roundsPath, { rounds: [oldRecord()] });
+    await migration.up({ rootDir });
+    expect(NEW_HEY_HO_SCORE_PARTS).toEqual(before);
+  });
+
+  it('keeps a user-added score part when it extends the shipped canon voices', async () => {
+    // scoreParts is independently editable (Add part / AI-derive), so a stock
+    // melody can carry a hand-written part. Replacing the whole array would
+    // silently delete it.
+    const mine = { id: 'part-mine-a1b2', label: 'My bass line', role: '', score: 'clef: bass\n\n| D3w |' };
+    const record = oldRecord();
+    record.scoreParts = [{ id: 'part-heyho-v2' }, { id: 'part-heyho-v3' }, mine];
+    writeJson(roundsPath, { rounds: [record] });
+    await migration.up({ rootDir });
+
+    const parts = findRound(roundsPath, ROUND_ID).scoreParts;
+    expect(parts.map((p) => p.id)).toEqual(['part-heyho-v2', 'part-heyho-v3', 'part-heyho-v4', 'part-mine-a1b2']);
+    expect(parts.at(-1)).toEqual(mine);
+  });
+
+  it('corrects the stale voice guidance the fourth phrase invalidates', async () => {
+    writeJson(roundsPath, { rounds: [oldRecord()] });
+    const result = await migration.up({ rootDir });
+    expect(result).toMatchObject({ updated: 1, fixedLayers: 2 });
+    // Voice 4 is a real staggered entry now, not a unison double of the lead.
+    expect(findLayer(roundsPath, 'voice-4').notes).toBe(NEW_HEY_HO_VOICE_4_NOTES);
+    expect(findLayer(roundsPath, 'voice-4').notes).not.toMatch(/unison/i);
+    // Voice 3 no longer claims the round is three phrases long.
+    expect(findLayer(roundsPath, 'voice-3').notes).toBe(NEW_HEY_HO_VOICE_3_NOTES);
+    expect(findLayer(roundsPath, 'voice-3').notes).not.toMatch(/three phrases/i);
+    // An untouched layer stays untouched.
+    expect(findLayer(roundsPath, 'voice-1').notes).toBe(oldRecord().layers[0].notes);
+  });
+
+  it('never clobbers voice guidance the user rewrote, and fixes the other layer', async () => {
+    const myNotes = 'I come in on the last line, an octave down.';
+    const record = oldRecord();
+    record.layers = record.layers.map((l) => (l.id === 'voice-4' ? { ...l, notes: myNotes } : l));
+    writeJson(roundsPath, { rounds: [record] });
+    const result = await migration.up({ rootDir });
+    expect(result).toMatchObject({ fixedLayers: 1 });
+    expect(findLayer(roundsPath, 'voice-4').notes).toBe(myNotes);
+    expect(findLayer(roundsPath, 'voice-3').notes).toBe(NEW_HEY_HO_VOICE_3_NOTES);
+  });
+
+  it('tolerates a record with no layers array', async () => {
+    const record = oldRecord();
+    delete record.layers;
+    writeJson(roundsPath, { rounds: [record] });
+    const result = await migration.up({ rootDir });
+    expect(result).toMatchObject({ updated: 1, fixedScore: true, fixedLayers: 0 });
+    expect(findRound(roundsPath, ROUND_ID).score).toBe(NEW_HEY_HO_SCORE);
   });
 
   it('is idempotent across re-runs', async () => {

--- a/server/services/rounds.js
+++ b/server/services/rounds.js
@@ -773,7 +773,7 @@ export const SEED_ROUNDS = [
     layers: [
       { id: 'voice-1', label: 'Voice 1 (lead)', part: 'Any', notes: 'Starts the round and sings it straight through. Everyone learns this line first.' },
       { id: 'voice-2', label: 'Voice 2', part: 'Any', notes: 'Enters as Voice 1 reaches "Meat nor drink…" (phrase 2) — one full phrase behind the lead.' },
-      { id: 'voice-3', label: 'Voice 3', part: 'Any', notes: 'Enters at "Still I will be merry" (phrase 3); the three phrases stack into the full minor chord.' },
+      { id: 'voice-3', label: 'Voice 3', part: 'Any', notes: 'Enters at "Still I will be merry" (phrase 3); by here the stacked phrases fill out the minor chord.' },
       { id: 'voice-4', label: 'Voice 4', part: 'Any', notes: 'Enters at the closing "Hey, hey, ho" (phrase 4, bar 7) — the last of the four staggered entries, filling the round out.' },
     ],
     references: [],

--- a/server/services/rounds.js
+++ b/server/services/rounds.js
@@ -543,16 +543,23 @@ const canonVoice = (melody, { delayBars, id, label, role }) => {
   return { id, label, role, score: [...headers, '', ...rests, ...body].join('\n') };
 };
 
-// Hey Ho Nobody Home — six bars, three 2-bar phrases. The classic 3-voice round:
-// voices enter one phrase (2 bars) apart, and the three phrases stack into the
-// full D-minor chord. Centered on D with all naturals (score header `key: C` =
-// no key signature), so it stacks cleanly with Ah Poor Bird and Rose Rose Rose
-// Red in the D-minor quodlibet: phrase 1 (D/A) + phrase 2 (D–E–F) + phrase 3
-// (A–G–F–E) outline a D-minor triad, with no B-natural to sound a tritone
-// against the partners' F. Contour matches the Wikibooks Songbook (E-minor) and
-// Kodály teaching (D natural-minor) transcriptions, transposed to D
-// (1-1-2-2-♭3-♭3-♭3-♭3-2 in phrase 2). Exported so migration 158 can restore it
-// onto installs that still hold the old G-centered, major-third transcription.
+// Hey Ho Nobody Home — eight bars, four 2-bar phrases. A 4-voice round: voices
+// enter one phrase (2 bars) apart, and the phrases stack into the full D-minor
+// chord. Centered on D with all naturals (score header `key: C` = no key
+// signature), so it stacks cleanly with Ah Poor Bird and Rose Rose Rose Red in
+// the D-minor quodlibet: phrase 1 (D/A) + phrase 2 (D–E–F) + phrase 3 (A–G–F–E)
+// outline a D-minor triad, with no B-natural to sound a tritone against the
+// partners' F. Contour matches the Wikibooks Songbook (E-minor) and Kodály
+// teaching (D natural-minor) transcriptions, transposed to D
+// (1-1-2-2-♭3-♭3-♭3-♭3-2 in phrase 2). Exported so migrations 158 and 214 can
+// restore it onto installs holding an older transcription.
+//
+// Phrase 4 ("Hey, hey, ho") is the round's closing line. It was missing entirely
+// until issue #3238 — the lyric sheet listed four lines while the staff carried
+// three, and the 6-bar melody drifted out of phase against its own 8-bar
+// quodlibet partners every four cycles. It cadences F–E–D onto the tonic, in the
+// same two-half-notes-per-bar rhythm as phrase 1, using only the round's
+// existing D natural-minor pentachord (A D E F G — no new pitch letters).
 export const HEY_HO_MELODY = [
   'clef: treble',
   'key: C',
@@ -562,10 +569,12 @@ export const HEY_HO_MELODY = [
   '| D4h(Hey) A3h(ho) | D4q(no-) D4e(bo-) D4e(dy) A3h(home) |',
   '| D4q(Meat) D4q(nor) E4q(drink) E4q(nor) | F4e(mon-) F4e(ey) F4e(have) F4e(I) E4h(none) |',
   '| A4q(Still) G4q(I) A4q(will) G4q(be) | F4h(mer-) E4h(ry) |',
+  '| F4h(Hey) E4h(hey) | D4h(ho) rh |',
 ].join('\n');
 export const HEY_HO_SCORE_PARTS = [
   canonVoice(HEY_HO_MELODY, { delayBars: 2, id: 'part-heyho-v2', label: 'Voice 2', role: 'voice-2' }),
   canonVoice(HEY_HO_MELODY, { delayBars: 4, id: 'part-heyho-v3', label: 'Voice 3', role: 'voice-3' }),
+  canonVoice(HEY_HO_MELODY, { delayBars: 6, id: 'part-heyho-v4', label: 'Voice 4', role: 'voice-4' }),
 ];
 
 // Ah Poor Bird — eight bars, four 2-bar phrases. A 4-voice round; voices enter
@@ -749,7 +758,7 @@ export const SEED_ROUNDS = [
     key: 'D minor (Dorian)',
     tempo: 76,
     rhythmShapeId: 'slow-4-4',
-    notation: 'A round in up to six voices (Ravenscroft\'s Pammelia, 1609). New voices enter one two-bar phrase behind the last. Centered on D with no key signature — all naturals (D Dorian / natural minor), no B. Melody after the Wikibooks Songbook and Kodály teaching transcriptions, transposed to a D tonal center.',
+    notation: 'A round in up to six voices (Ravenscroft\'s Pammelia, 1609). Four two-bar phrases (8 bars); new voices enter one phrase behind the last, so four voices fill the round. Centered on D with no key signature — all naturals (D Dorian / natural minor), no B. Melody after the Wikibooks Songbook and Kodály teaching transcriptions, transposed to a D tonal center; the closing "Hey, hey, ho" cadences F–E–D onto the tonic.',
     score: HEY_HO_MELODY,
     // Canonic voice stack: the melody entering one phrase (2 bars) late per voice
     // — the round sung against itself. Derived from HEY_HO_MELODY so it can't
@@ -759,13 +768,13 @@ export const SEED_ROUNDS = [
     notes: 'One of the oldest English rounds. Sung with Ah Poor Bird and Rose Rose Rose Red it forms a classic three-round quodlibet — all three share one minor chord cycle and can be sung at the same time. Keep it light and lilting despite the minor key.',
     learned: false,
     sections: [
-      { id: 'sec-round', label: 'Round', lyrics: 'Hey, ho, nobody home,\nMeat nor drink nor money have I none,\nStill I will be merry.\nHey, ho, nobody home.' },
+      { id: 'sec-round', label: 'Round', lyrics: 'Hey, ho, nobody home,\nMeat nor drink nor money have I none,\nStill I will be merry.\nHey, hey, ho.' },
     ],
     layers: [
       { id: 'voice-1', label: 'Voice 1 (lead)', part: 'Any', notes: 'Starts the round and sings it straight through. Everyone learns this line first.' },
       { id: 'voice-2', label: 'Voice 2', part: 'Any', notes: 'Enters as Voice 1 reaches "Meat nor drink…" (phrase 2) — one full phrase behind the lead.' },
       { id: 'voice-3', label: 'Voice 3', part: 'Any', notes: 'Enters at "Still I will be merry" (phrase 3); the three phrases stack into the full minor chord.' },
-      { id: 'voice-4', label: 'Voice 4', part: 'Any', notes: 'Optional fourth entry: comes in as Voice 1 loops back to the top, doubling the lead in unison or an octave up.' },
+      { id: 'voice-4', label: 'Voice 4', part: 'Any', notes: 'Enters at the closing "Hey, hey, ho" (phrase 4, bar 7) — the last of the four staggered entries, filling the round out.' },
     ],
     references: [],
     partnerRoundIds: ['seed-ah-poor-bird', 'seed-rose-rose-rose-red', 'seed-zum-gali-gali'],

--- a/server/services/rounds.test.js
+++ b/server/services/rounds.test.js
@@ -598,6 +598,68 @@ describe('rounds service', () => {
     expect([...new Set(letters)].sort()).toEqual(['A', 'D', 'E', 'F', 'G']);
   });
 
+  it('Hey Ho carries all four sung phrases, lyric sheet and staff agreeing (issue #3238)', async () => {
+    const songs = await svc.listRounds();
+    const heyHo = songs.find((s) => s.id === 'seed-hey-ho-nobody-home');
+
+    // Four two-bar phrases = eight bars. The round shipped with only three
+    // phrases, leaving the closing line unsung.
+    const parsed = parseScore(heyHo.score);
+    expect(parsed.errors).toEqual([]);
+    expect(parsed.measures).toHaveLength(8);
+
+    // The lyric sheet's four lines each have notes to be sung on. Compare the
+    // staff's own inline syllables against the lyric block, ignoring the
+    // held-syllable hyphens the notation uses to split a word across notes.
+    const lyricLines = heyHo.sections.find((s) => s.id === 'sec-round').lyrics.split('\n');
+    expect(lyricLines).toHaveLength(4);
+    expect(lyricLines[3]).toBe('Hey, hey, ho.');
+    const sung = parsed.measures
+      .flatMap((m) => m.notes.map((n) => n.lyric))
+      .filter(Boolean)
+      .join(' ')
+      .replace(/- /g, '')
+      .toLowerCase();
+    const written = lyricLines.join(' ').replace(/[,.]/g, '').toLowerCase();
+    expect(sung).toBe(written);
+  });
+
+  it('the closing phrase cadences onto the D tonic in full 4/4 bars (issue #3238)', async () => {
+    const songs = await svc.listRounds();
+    const heyHo = songs.find((s) => s.id === 'seed-hey-ho-nobody-home');
+    const parsed = parseScore(heyHo.score);
+    // Every bar is a complete 4/4 measure — a short bar would render as a beat
+    // warning in the editor and break the quodlibet's beat grid.
+    parsed.measures.forEach((m, i) => expect(m.beats, `bar ${i + 1}`).toBe(4));
+    // The round ends on the tonic it is centered on.
+    const lastPitched = parsed.measures.at(-1).notes.filter((n) => !n.rest).at(-1);
+    expect(lastPitched.pitch.letter).toBe('D');
+  });
+
+  it('Hey Ho is bar-aligned with its quodlibet partners so the stack stays in phase (issue #3238)', async () => {
+    const songs = await svc.listRounds();
+    const barCount = (id) => parseScore(songs.find((s) => s.id === id).score).measures.length;
+    // Ah Poor Bird and Rose Rose Rose Red are eight bars; a six-bar Hey Ho lapped
+    // them every four cycles, so the documented three-round quodlibet never
+    // actually lined up.
+    expect(barCount('seed-hey-ho-nobody-home')).toBe(barCount('seed-ah-poor-bird'));
+    expect(barCount('seed-hey-ho-nobody-home')).toBe(barCount('seed-rose-rose-rose-red'));
+  });
+
+  it('Hey Ho stacks four canonic voices entering two bars apart (issue #3238)', async () => {
+    const songs = await svc.listRounds();
+    const heyHo = songs.find((s) => s.id === 'seed-hey-ho-nobody-home');
+    // Voice 1 is the melody itself; the parts carry voices 2-4.
+    expect(heyHo.scoreParts.map((p) => p.role)).toEqual(['voice-2', 'voice-3', 'voice-4']);
+    // Each voice is the same melody delayed by whole-bar rests — 2, 4, then 6.
+    const leadingRests = (part) => parseScore(part.score).measures
+      .findIndex((m) => m.notes.some((n) => !n.rest));
+    expect(heyHo.scoreParts.map(leadingRests)).toEqual([2, 4, 6]);
+    // The documented fourth entry is a real staggered voice now, not a unison double.
+    const voice4 = heyHo.layers.find((l) => l.id === 'voice-4');
+    expect(voice4.notes).not.toMatch(/unison/i);
+  });
+
   it('the D-minor quodlibet trio has no {B,F} tritone at any aligned beat (issue #2105)', async () => {
     const songs = await svc.listRounds();
     const trio = ['seed-hey-ho-nobody-home', 'seed-ah-poor-bird', 'seed-rose-rose-rose-red']


### PR DESCRIPTION
## Summary

The built-in **Hey Ho Nobody Home** round shipped with a fourth lyric line that had no music and the wrong words.

Three problems, one cause:

1. **The closing line was never notated.** `sections[0].lyrics` listed four lines while `HEY_HO_MELODY` carried only three two-bar phrases (6 bars), so the lyric sheet and the staff disagreed about how long the round is.
2. **That line was wrong.** It repeated line 1 (`Hey, ho, nobody home.`) instead of `Hey, hey, ho.`
3. **The quodlibet was out of phase.** The round declares Ah Poor Bird and Rose Rose Rose Red as `partnerRoundIds`, but both are 8 bars. At 6 bars Hey Ho lapped its own documented partners every four cycles, so the three-round stack in `RoundStack` never actually lined up.

`HEY_HO_MELODY` now carries a fourth phrase — `| F4h(Hey) E4h(hey) | D4h(ho) rh |` — a stepwise descent onto the D tonic in full 4/4 bars, using only the round's existing D natural-minor pentachord (`A D E F G`, no new pitch letters, no B to sound a tritone against the partners' F). The lyric line is corrected, and the fourth canon voice the `layers` already described becomes real (`delayBars: 6`, matching how the other 8-bar rounds stack).

The exact pitches of phrase 4 are a defensible default rather than a claim about the one true tune — #3239 (sing-to-verify) is the tool for re-singing them.

## Migration

`scripts/migrations/214-fix-hey-ho-fourth-phrase.js` upgrades installs whose `data/rounds.json` already holds the 6-bar record, modelled on `158-fix-hey-ho-melody.js`:

- New content is imported from `SEED_ROUNDS` by **identity**, so the migration can't restore a stale melody.
- The **old** shipped strings are hard-coded as fingerprints. Score, lyrics, notation, and each layer's voice guidance are gated **independently**, so a user who customized one field keeps it while the others are still corrected.
- `scoreParts` replaces only the **shipped canon ids** — `scoreParts` is independently editable (`SongScoreParts`' "Add part" and the AI-derive path both append a part with a generated id), so a stock melody can carry a hand-written bass line. Anything the user added is preserved.
- Fresh installs (no file) are a clean no-op; re-runs detect the corrected content and skip.

## Test plan

- `cd server && npm test` — green. New assertions in `server/services/rounds.test.js` pin that the round is 8 bars, that every bar totals 4 beats, that it ends on the tonic, that its bar count equals both quodlibet partners', that the canon voices enter at 2/4/6, and that the staff's own sung syllables match the lyric sheet line-for-line (so either drifting fails the build).
- `scripts/migrations/214-fix-hey-ho-fourth-phrase.test.js` — 18 cases: no-file / unparseable / round-absent / applies / idempotent, plus customization-preserved for score, lyrics, and each layer independently, a user-added score part surviving, and missing `sections`/`layers` arrays.
- `cd client && npm test` — green (486 files, 5471 tests).
- Verified the parsed output directly: 8 bars, all 4 beats, zero parse errors, phrase 4 = `F4 E4 D4` + half rest, voices entering at bars 2/4/6, partners both 8 bars.

**Pre-existing, unrelated:** `server/services/layeredIntelligenceOutcomes.test.js` fails 20 tests on clean `main` at `6fd9e31b8` with an untouched tree — not from this change.

Closes #3238
