### PR TITLE
fix([issue-3247]): validate sprite fork model pins

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -4,6 +4,10 @@
 
 - **[issue-3245] Synced Music Video projects now use each machine's own render backends.** Image and video backend pins no longer overwrite a peer's locally usable choices, while shared model and pacing settings continue to sync.
 
+## Sprite Manager
+
+- **[issue-3247] Forked sprites now validate their pinned render model before saving.** Invalid model IDs are rejected immediately instead of leaving a sprite pinned to a model that later renders cannot use or replace.
+
 ## POST
 
 - **[issue-3252] A new Practice Plan page decides what you're actually studying.** POST had grown to roughly thirty drill types across six subjects plus three standalone study surfaces, with no single place to say which of them you want. Practice Plan (`/post/plan`, also reachable from ⌘K and by voice) lists every topic with a switch, expandable to its individual drills, and shows a live "your daily POST will include…" summary that updates as you flip switches — so you can see what tomorrow's session becomes before you run it. Drill Config still owns how hard each drill is; Practice Plan owns what's in the rotation.

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -1382,7 +1382,7 @@ export const spriteForkSchema = z.object({
   id: z.string().trim().max(200).optional(),
   designPrompt: z.string().trim().min(1).max(4000),
   mode: z.enum(QUEUEABLE_IMAGE_MODES).optional(),
-  model: z.string().trim().max(64).optional(),
+  model: cloudModelIdString('model must be a valid model id').max(RECORD_RENDER_MODEL_MAX).optional(),
   effort: z.string().trim().max(32).optional(),
   initImageStrength: optionalUnitNumber,
 });

--- a/server/routes/sprites.test.js
+++ b/server/routes/sprites.test.js
@@ -124,6 +124,7 @@ import * as atlas from '../services/sprites/atlas.js';
 import * as publish from '../services/sprites/publish.js';
 import * as assets from '../services/sprites/assets.js';
 import { errorMiddleware } from '../lib/errorHandler.js';
+import { cloudModelIdString } from '../lib/validation.js';
 import spriteRoutes from './sprites.js';
 
 function makeApp() {
@@ -376,6 +377,39 @@ describe('sprites routes', () => {
     const bad = await request(app).post('/api/sprites/pioneer/fork').send({ name: 'Pioneer Fork' });
     expect(bad.status).toBe(400);
     expect(reference.forkSprite).not.toHaveBeenCalled();
+  });
+
+  it('fork, create, and update share the durable model-id validator', async () => {
+    const invalidModelId = 'gpt image 1; rm';
+    const validation = cloudModelIdString('model must be a valid model id').safeParse(invalidModelId);
+    expect(validation.success).toBe(false);
+    const expectedMessage = validation.error.issues[0].message;
+
+    const attempts = [
+      {
+        response: await request(app).post('/api/sprites/pioneer/fork')
+          .send({ name: 'Pioneer Fork', designPrompt: 'wearing a red coat', model: invalidModelId }),
+        path: 'model',
+      },
+      {
+        response: await request(app).post('/api/sprites')
+          .send({ name: 'Pioneer Fork', imageModelId: invalidModelId }),
+        path: 'imageModelId',
+      },
+      {
+        response: await request(app).patch('/api/sprites/pioneer')
+          .send({ imageModelId: invalidModelId }),
+        path: 'imageModelId',
+      },
+    ];
+
+    for (const { response, path } of attempts) {
+      expect(response.status, path).toBe(400);
+      expect(response.body.context.details).toContainEqual({ path, message: expectedMessage });
+    }
+    expect(reference.forkSprite).not.toHaveBeenCalled();
+    expect(records.createCharacter).not.toHaveBeenCalled();
+    expect(reference.patchSpriteRecord).not.toHaveBeenCalled();
   });
 
   it('POST /:id/reference/generate accepts a gallery/sprite seed source in JSON', async () => {

--- a/server/services/sprites/reference.test.js
+++ b/server/services/sprites/reference.test.js
@@ -1132,12 +1132,17 @@ describe('forkSprite', () => {
     await createCharacter(source, { name: 'Origin' });
     await lockMain(source);
     enqueueJob.mockClear();
-    const { record, jobId, target } = await forkSprite(source, { name: 'Origin Fork', designPrompt: 'wearing a red coat' });
+    const { record, jobId, target } = await forkSprite(source, {
+      name: 'Origin Fork',
+      designPrompt: 'wearing a red coat',
+      model: 'openai/gpt-image-1',
+    });
     // A fork enters the same turnaround-first workflow every new character does.
     expect(target).toBe('turnaround');
     expect(jobId).toBe('job-1234567890');
     expect(record.kind).toBe('character');
     expect(record.name).toBe('Origin Fork');
+    expect(record.imageModelId).toBe('openai/gpt-image-1');
     // The new record exists and the render was seeded from the source's ref.
     expect(await records.getRecord(record.id)).toBeTruthy();
     const call = enqueueJob.mock.calls[0][0];


### PR DESCRIPTION
## Summary
- validate fork model overrides with the same shared model-ID contract used by sprite create and update
- cover all three route write paths and confirm valid fork pins persist
- document the user-visible validation fix

## Test plan
- `cd server && npm test -- routes/sprites.test.js services/sprites/reference.test.js`

Closes #3247