### PR TITLE
fix: keep Music Video render pins local (#3245)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased Changes
 
+## Music Video
+
+- **[issue-3245] Synced Music Video projects now use each machine's own render backends.** Image and video backend pins no longer cross federation boundaries or overwrite a peer's locally usable choices, while shared model and pacing settings continue to sync.
+
 ## POST
 
 - **[issue-3252] A new Practice Plan page decides what you're actually studying.** POST had grown to roughly thirty drill types across six subjects plus three standalone study surfaces, with no single place to say which of them you want. Practice Plan (`/post/plan`, also reachable from ⌘K and by voice) lists every topic with a switch, expandable to its individual drills, and shows a live "your daily POST will include…" summary that updates as you flip switches — so you can see what tomorrow's session becomes before you run it. Drill Config still owns how hard each drill is; Practice Plan owns what's in the rotation.

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -2,7 +2,7 @@
 
 ## Music Video
 
-- **[issue-3245] Synced Music Video projects now use each machine's own render backends.** Image and video backend pins no longer cross federation boundaries or overwrite a peer's locally usable choices, while shared model and pacing settings continue to sync.
+- **[issue-3245] Synced Music Video projects now use each machine's own render backends.** Image and video backend pins no longer overwrite a peer's locally usable choices, while shared model and pacing settings continue to sync.
 
 ## POST
 

--- a/client/src/pages/MusicVideo.jsx
+++ b/client/src/pages/MusicVideo.jsx
@@ -485,7 +485,10 @@ export default function MusicVideo() {
   const missingVideoCount = sceneCount - renderableSceneCount;
   const finalVideo = useVideoFileSrc(selected?.renderHistoryId, { enabled: !!selected?.renderHistoryId });
   const savedVideoSettings = {
-    backend: selected?.videoSettings?.backend || 'local',
+    // Empty means this peer resolves its own configured Video Gen default.
+    // Synced projects intentionally arrive without another install's backend
+    // pin, so do not turn that absence into an explicit local override.
+    backend: selected?.videoSettings?.backend || '',
     // Empty is an intentional "follow the local Video Gen default" choice,
     // distinct from pinning the model that happens to be default today.
     modelId: selected?.videoSettings?.modelId || '',
@@ -771,10 +774,15 @@ export default function MusicVideo() {
     videoLane.startScene(scene.sceneId);
     generateVideo({
       prompt,
-      backend: savedVideoSettings.backend,
+      ...(savedVideoSettings.backend ? { backend: savedVideoSettings.backend } : {}),
       ...(savedVideoSettings.backend === 'grok'
         ? { grokDuration: savedVideoSettings.grokDuration }
-        : { modelId: savedVideoSettings.modelId || undefined, disableAudio: true }),
+        : savedVideoSettings.backend === 'local'
+          ? { modelId: savedVideoSettings.modelId || undefined, disableAudio: true }
+          // A named model is local-only machinery at the server boundary and
+          // would force the resolver off a Grok install default. Keep the
+          // shared pin saved, but omit it until this peer chooses Local.
+          : { grokDuration: savedVideoSettings.grokDuration, disableAudio: true }),
       mode: audioReactive ? 'a2v' : 'image',
       sourceImageFile: scene.referenceImageId,
       ...(audioReactive ? {
@@ -1013,6 +1021,7 @@ export default function MusicVideo() {
                       title="Saved renderer for this project's scene videos"
                       className="bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50"
                     >
+                      <option value="">Install default</option>
                       <option value="local">Local video</option>
                       <option value="grok">Grok video</option>
                     </select>

--- a/client/src/pages/MusicVideo.jsx
+++ b/client/src/pages/MusicVideo.jsx
@@ -1016,7 +1016,7 @@ export default function MusicVideo() {
                     <select
                       id="mv-video-backend"
                       value={savedVideoSettings.backend}
-                      onChange={(e) => handleVideoSettingsChange({ backend: e.target.value })}
+                      onChange={(e) => handleVideoSettingsChange({ backend: e.target.value || null })}
                       disabled={videoSettingsSaving || Object.keys(genVideoScenes).length > 0}
                       title="Saved renderer for this project's scene videos"
                       className="bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50"

--- a/client/src/pages/MusicVideo.test.jsx
+++ b/client/src/pages/MusicVideo.test.jsx
@@ -229,6 +229,20 @@ describe('MusicVideo project video renderer', () => {
     expect(generateVideo.mock.calls.at(-1)[0]).not.toHaveProperty('modelId');
   });
 
+  it('clears an existing backend pin with the Install default option', async () => {
+    await openProject(PROJECT_NO_CLIP);
+
+    fireEvent.change(await screen.findByLabelText('Scene video renderer'), {
+      target: { value: '' },
+    });
+
+    await waitFor(() => expect(updateMusicVideoProject).toHaveBeenCalledWith(
+      'mv-2',
+      { videoSettings: { backend: null } },
+      { silent: true },
+    ));
+  });
+
   it('persists the local model and uses it for scene generation', async () => {
     generateVideo.mockResolvedValue({ jobId: 'video-job-1' });
     await openProject(PROJECT_NO_CLIP);

--- a/client/src/pages/MusicVideo.test.jsx
+++ b/client/src/pages/MusicVideo.test.jsx
@@ -10,6 +10,7 @@ import toast from '../components/ui/Toast';
 const PROJECT_WITH_CLIP = {
   id: 'mv-1', name: 'Neon Run', mode: 'director', status: 'ready',
   trackId: 't1', uploadedAudioFilename: null, audioAnalysis: null, renderHistoryId: null,
+  videoSettings: { backend: 'local' },
   scenes: [{ sceneId: 's1', order: 0, prompt: 'a', referenceImageId: 'img1', videoHistoryId: 'h1' }],
 };
 const PROJECT_NO_CLIP = {
@@ -37,7 +38,11 @@ vi.mock('../services/apiMusicVideo.js', () => ({
   listMusicVideoProjects: vi.fn(async () => []),
   createMusicVideoProject: vi.fn(),
   cloneMusicVideoProject: vi.fn(),
-  updateMusicVideoProject: vi.fn(async (id, patch) => ({ id, ...patch })),
+  updateMusicVideoProject: vi.fn(async (id, patch) => ({
+    id,
+    ...patch,
+    ...(patch.videoSettings ? { videoSettings: { backend: 'local', ...patch.videoSettings } } : {}),
+  })),
   deleteMusicVideoProject: vi.fn(),
   analyzeMusicVideoProject: vi.fn(),
   planMusicVideoProject: vi.fn(),
@@ -210,6 +215,20 @@ describe('MusicVideo render control (#1760)', () => {
 });
 
 describe('MusicVideo project video renderer', () => {
+  it('lets the server resolve this install default when a synced project has no backend pin', async () => {
+    generateVideo.mockResolvedValue({ jobId: 'video-job-default' });
+    await openProject({
+      ...PROJECT_NO_CLIP,
+      videoSettings: { modelId: 'ltx23_distilled_q4' },
+    });
+
+    expect(await screen.findByLabelText('Scene video renderer')).toHaveProperty('value', '');
+    fireEvent.click(screen.getByRole('button', { name: /^Generate video$/ }));
+    await waitFor(() => expect(generateVideo).toHaveBeenCalled());
+    expect(generateVideo.mock.calls.at(-1)[0]).not.toHaveProperty('backend');
+    expect(generateVideo.mock.calls.at(-1)[0]).not.toHaveProperty('modelId');
+  });
+
   it('persists the local model and uses it for scene generation', async () => {
     generateVideo.mockResolvedValue({ jobId: 'video-job-1' });
     await openProject(PROJECT_NO_CLIP);

--- a/server/lib/conflictJournal.js
+++ b/server/lib/conflictJournal.js
@@ -35,7 +35,7 @@ import { randomUUID, createHash } from 'crypto';
 import { PATHS, atomicWrite, readJSONFile, ensureDir } from './fileUtils.js';
 import { createCollectionStore } from './collectionStore.js';
 import { canonicalStringify, isPlainObject } from './objects.js';
-import { sanitizeRecordForWire } from './syncWire.js';
+import { sanitizeRecordForWire, stripMusicVideoLocalRenderPins } from './syncWire.js';
 
 const JOURNAL_TYPE_SCHEMA_VERSION = 1;
 const BASE_HASH_FILE = () => join(PATHS.data, 'sharing', 'sync_base_hashes.json');
@@ -169,6 +169,8 @@ export function contentHashForRecord(kind, record, { maxVersion } = {}) {
   let hashInput = wire;
   if (kind === 'mediaCollection') {
     hashInput = projectCollectionScalars(wire);
+  } else if (kind === 'musicVideoProject') {
+    hashInput = stripMusicVideoLocalRenderPins(wire);
   } else if (HASH_EXCLUDED_FIELDS[kind] || HASH_FIELD_VERSION_BY_KIND[kind]) {
     const excluded = HASH_EXCLUDED_FIELDS[kind] || [];
     const introducedAt = HASH_FIELD_VERSION_BY_KIND[kind];

--- a/server/lib/conflictJournal.test.js
+++ b/server/lib/conflictJournal.test.js
@@ -233,6 +233,23 @@ describe('conflictJournal', () => {
       .not.toBe(cj.contentHashForRecord('issue', iss({ title: 'B' })));
   });
 
+  it('Music Video content hash ignores each install render pins (#3245)', () => {
+    const base = {
+      id: 'mv-1',
+      name: 'Example Video',
+      videoSettings: { modelId: 'shared-model', backend: 'local' },
+    };
+    const otherPins = {
+      ...base,
+      imageMode: 'grok',
+      imageModelId: 'example-image-model',
+      videoSettings: { ...base.videoSettings, backend: 'grok' },
+    };
+
+    expect(cj.contentHashForRecord('musicVideoProject', base))
+      .toBe(cj.contentHashForRecord('musicVideoProject', otherPins));
+  });
+
   it('a pure-renumber local drift does NOT journal a conflict when a real remote edit arrives', async () => {
     const base = iss({ number: 1 });
     await cj.setSyncBaseHash('issue', 'iss-1', cj.contentHashForRecord('issue', base));

--- a/server/lib/musicVideoValidation.js
+++ b/server/lib/musicVideoValidation.js
@@ -31,7 +31,8 @@ export const musicVideoConceptSchema = z.object({
 // is optional because Grok does not consume it; the video-gen route performs
 // the authoritative installed-model validation when a local render starts.
 export const musicVideoVideoSettingsSchema = z.object({
-  backend: z.enum(['local', 'grok']).optional(),
+  // null clears the per-project pin so this install's configured default wins.
+  backend: z.enum(['local', 'grok']).nullable().optional(),
   modelId: z.string().max(64).nullable().optional(),
   grokDuration: z.union([z.literal(6), z.literal(10)]).optional(),
   generationMode: z.enum(['image', 'audioReactive']).optional(),

--- a/server/lib/syncWire.js
+++ b/server/lib/syncWire.js
@@ -18,6 +18,23 @@ export function sanitizeSoftDeleteFields(raw) {
   return { deleted, deletedAt };
 }
 
+/**
+ * Remove Music Video render choices that belong to the receiving install.
+ * Transport keeps the legacy `videoSettings.backend` by default so an older
+ * receiver is not regressed; upgraded receivers and content hashing opt into
+ * stripping it as well.
+ */
+export function stripMusicVideoLocalRenderPins(record, { stripVideoBackend = true } = {}) {
+  if (!record || typeof record !== 'object' || Array.isArray(record)) return record;
+  const { imageMode: _imageMode, imageModelId: _imageModelId, ...shared } = record;
+  if (stripVideoBackend && shared.videoSettings
+    && typeof shared.videoSettings === 'object' && !Array.isArray(shared.videoSettings)) {
+    const { backend: _backend, ...sharedVideoSettings } = shared.videoSettings;
+    shared.videoSettings = sharedVideoSettings;
+  }
+  return shared;
+}
+
 // Single source of truth for what fields cross the federated-peer wire.
 //
 // Two transports carry universe / series / issue records between peers:
@@ -202,17 +219,12 @@ export function sanitizeRecordForWire(kind, record) {
       // preserving the rest of videoSettings (model, pacing, generation mode).
       // Stripping also keeps the wire/hash form byte-stable with peers from
       // before these fields shipped, so no schema-version gate is required.
-      const {
-        deleted: _d,
-        deletedAt: _da,
-        imageMode: _imageMode,
-        imageModelId: _imageModelId,
-        ...rest
-      } = record;
-      if (rest.videoSettings && typeof rest.videoSettings === 'object' && !Array.isArray(rest.videoSettings)) {
-        const { backend: _backend, ...sharedVideoSettings } = rest.videoSettings;
-        rest.videoSettings = sharedVideoSettings;
-      }
+      // `videoSettings.backend` predates the local-pin contract. Keep it on
+      // transport for older receivers whose LWW merge still expects it;
+      // upgraded receivers strip it before persistence, and content hashing
+      // excludes it so local choices never create phantom divergence.
+      const projected = stripMusicVideoLocalRenderPins(record, { stripVideoBackend: false });
+      const { deleted: _d, deletedAt: _da, ...rest } = projected;
       return { ...rest, ...sanitizeSoftDeleteFields(record) };
     }
     case 'writersRoomWork': {

--- a/server/lib/syncWire.js
+++ b/server/lib/syncWire.js
@@ -178,7 +178,6 @@ export function sanitizeRecordForWire(kind, record) {
     case 'moodBoard':
     case 'writersRoomFolder':
     case 'writersRoomExercise':
-    case 'musicVideoProject':
     case 'commissionFeedback': {
       // Persona/music/creative-director/mood-board records: like mediaCollection,
       // no `ephemeral` flag — always wire-syncable when present. Strip-then-tail-
@@ -190,12 +189,30 @@ export function sanitizeRecordForWire(kind, record) {
       // record LWW contract; a moodBoard (name/description/items) is the same.
       // Writers Room folders + exercises (#1645) are also body-less whole-record
       // LWW kinds with no ephemeral counters — they wire identically (no liveMode
-      // strip like writersRoomWork below). A musicVideoProject (#1770:
-      // metadata + beat-aligned scenes[]) is the same whole-record LWW contract.
       // A commissionFeedback (#2686: one reaction — commissionId/runId/rating/
       // note/tags/at) is a body-less whole-record LWW record with no local-only
       // fields to strip, so it rides this same group.
       const { deleted: _d, deletedAt: _da, ...rest } = record;
+      return { ...rest, ...sanitizeSoftDeleteFields(record) };
+    }
+    case 'musicVideoProject': {
+      // Music Video projects are whole-record LWW, but their image render pin
+      // and video backend are install-capability choices: a peer may not have
+      // the selected provider configured. Keep those fields wire-local while
+      // preserving the rest of videoSettings (model, pacing, generation mode).
+      // Stripping also keeps the wire/hash form byte-stable with peers from
+      // before these fields shipped, so no schema-version gate is required.
+      const {
+        deleted: _d,
+        deletedAt: _da,
+        imageMode: _imageMode,
+        imageModelId: _imageModelId,
+        ...rest
+      } = record;
+      if (rest.videoSettings && typeof rest.videoSettings === 'object' && !Array.isArray(rest.videoSettings)) {
+        const { backend: _backend, ...sharedVideoSettings } = rest.videoSettings;
+        rest.videoSettings = sharedVideoSettings;
+      }
       return { ...rest, ...sanitizeSoftDeleteFields(record) };
     }
     case 'writersRoomWork': {

--- a/server/lib/syncWire.test.js
+++ b/server/lib/syncWire.test.js
@@ -201,7 +201,7 @@ describe('syncWire', () => {
       expect(series.styleImageRefs).toEqual(['x.png']);
     });
 
-    it('strips Music Video render pins byte-for-byte against a pre-field peer (#3245)', () => {
+    it('strips Music Video image pins while retaining the legacy backend wire shape (#3245)', () => {
       const withPins = sanitizeRecordForWire('musicVideoProject', {
         id: 'mv-1',
         name: 'Example Video',
@@ -218,6 +218,7 @@ describe('syncWire', () => {
         id: 'mv-1',
         name: 'Example Video',
         videoSettings: {
+          backend: 'grok',
           modelId: 'example-video-model',
           grokDuration: 10,
           generationMode: 'image',
@@ -226,7 +227,7 @@ describe('syncWire', () => {
 
       expect(withPins.imageMode).toBeUndefined();
       expect(withPins.imageModelId).toBeUndefined();
-      expect(withPins.videoSettings.backend).toBeUndefined();
+      expect(withPins.videoSettings.backend).toBe('grok');
       expect(JSON.stringify(withPins)).toBe(JSON.stringify(preField));
     });
 

--- a/server/lib/syncWire.test.js
+++ b/server/lib/syncWire.test.js
@@ -201,6 +201,35 @@ describe('syncWire', () => {
       expect(series.styleImageRefs).toEqual(['x.png']);
     });
 
+    it('strips Music Video render pins byte-for-byte against a pre-field peer (#3245)', () => {
+      const withPins = sanitizeRecordForWire('musicVideoProject', {
+        id: 'mv-1',
+        name: 'Example Video',
+        imageMode: 'grok',
+        imageModelId: 'example-image-model',
+        videoSettings: {
+          backend: 'grok',
+          modelId: 'example-video-model',
+          grokDuration: 10,
+          generationMode: 'image',
+        },
+      });
+      const preField = sanitizeRecordForWire('musicVideoProject', {
+        id: 'mv-1',
+        name: 'Example Video',
+        videoSettings: {
+          modelId: 'example-video-model',
+          grokDuration: 10,
+          generationMode: 'image',
+        },
+      });
+
+      expect(withPins.imageMode).toBeUndefined();
+      expect(withPins.imageModelId).toBeUndefined();
+      expect(withPins.videoSettings.backend).toBeUndefined();
+      expect(JSON.stringify(withPins)).toBe(JSON.stringify(preField));
+    });
+
     describe('author kind', () => {
       it('passes through an author with canonical tail soft-delete fields', () => {
         const a = { id: 'auth-1', name: 'Ada', bio: 'b' };

--- a/server/routes/musicVideo.test.js
+++ b/server/routes/musicVideo.test.js
@@ -141,6 +141,13 @@ describe('musicVideo routes', () => {
     expect(svc.updateProject).toHaveBeenCalledWith('mv-1', { videoSettings });
   });
 
+  it('PATCH /:id accepts null to clear the project video-backend pin', async () => {
+    const videoSettings = { backend: null };
+    const r = await request(app).patch('/api/music-video/mv-1').send({ videoSettings });
+    expect(r.status).toBe(200);
+    expect(svc.updateProject).toHaveBeenCalledWith('mv-1', { videoSettings });
+  });
+
   it('PATCH /:id rejects invalid video-renderer settings', async () => {
     const r = await request(app).patch('/api/music-video/mv-1')
       .send({ videoSettings: { backend: 'cloud-surprise', grokDuration: 9 } });

--- a/server/services/musicVideo/projectsLogic.js
+++ b/server/services/musicVideo/projectsLogic.js
@@ -24,7 +24,7 @@ import {
   musicVideoSceneUpdateSchema,
 } from '../../lib/validation.js';
 import { compareNewerWins } from '../../lib/lwwTimestamp.js';
-import { sanitizeRecordForWire, sanitizeSoftDeleteFields } from '../../lib/syncWire.js';
+import { sanitizeSoftDeleteFields, stripMusicVideoLocalRenderPins } from '../../lib/syncWire.js';
 import { persistedRenderPinFields } from '../../lib/renderTargets.js';
 
 // Re-exported for the PG backend's typed mirror columns (mirrors the CD store).
@@ -356,7 +356,7 @@ export function mergeProjectRecord(local, remoteRaw) {
   // An older peer can still send the fields that newer peers strip. Project
   // sync remains schema-v1 compatible, so apply the same projection inbound
   // before either inserting or restoring this machine's local choices.
-  remote = sanitizeRecordForWire('musicVideoProject', remote);
+  remote = stripMusicVideoLocalRenderPins(remote);
   if (!local) return { next: remote, inserted: true, remoteWins: true, changed: true };
   // Render pins are install-capability choices and therefore wire-local
   // (#3245). sanitizeRecordForWire omits them from peer payloads; restore this

--- a/server/services/musicVideo/projectsLogic.js
+++ b/server/services/musicVideo/projectsLogic.js
@@ -351,9 +351,23 @@ export function sanitizeProjectForSync(raw) {
  * `updatedAt`, so a tombstone beats an older live copy and can't be resurrected.
  */
 export function mergeProjectRecord(local, remoteRaw) {
-  const remote = sanitizeProjectForSync(remoteRaw);
+  let remote = sanitizeProjectForSync(remoteRaw);
   if (!remote) return { next: null, inserted: false, remoteWins: false, changed: false };
   if (!local) return { next: remote, inserted: true, remoteWins: true, changed: true };
+  // Render pins are install-capability choices and therefore wire-local
+  // (#3245). sanitizeRecordForWire omits them from peer payloads; restore this
+  // machine's values before a newer remote record wholesale-replaces local.
+  // Key-presence checks preserve an intentional local empty/null value instead
+  // of confusing it with a missing field.
+  remote = { ...remote };
+  if (Object.hasOwn(local, 'imageMode')) remote.imageMode = local.imageMode;
+  if (Object.hasOwn(local, 'imageModelId')) remote.imageModelId = local.imageModelId;
+  if (local.videoSettings && typeof local.videoSettings === 'object'
+    && !Array.isArray(local.videoSettings) && Object.hasOwn(local.videoSettings, 'backend')) {
+    const remoteVideoSettings = remote.videoSettings && typeof remote.videoSettings === 'object'
+      && !Array.isArray(remote.videoSettings) ? remote.videoSettings : {};
+    remote.videoSettings = { ...remoteVideoSettings, backend: local.videoSettings.backend };
+  }
   const remoteWins = compareNewerWins(remote.updatedAt, local.updatedAt);
   const next = remoteWins ? remote : local;
   const changed = JSON.stringify(next) !== JSON.stringify(local);

--- a/server/services/musicVideo/projectsLogic.js
+++ b/server/services/musicVideo/projectsLogic.js
@@ -24,7 +24,7 @@ import {
   musicVideoSceneUpdateSchema,
 } from '../../lib/validation.js';
 import { compareNewerWins } from '../../lib/lwwTimestamp.js';
-import { sanitizeSoftDeleteFields } from '../../lib/syncWire.js';
+import { sanitizeRecordForWire, sanitizeSoftDeleteFields } from '../../lib/syncWire.js';
 import { persistedRenderPinFields } from '../../lib/renderTargets.js';
 
 // Re-exported for the PG backend's typed mirror columns (mirrors the CD store).
@@ -353,6 +353,10 @@ export function sanitizeProjectForSync(raw) {
 export function mergeProjectRecord(local, remoteRaw) {
   let remote = sanitizeProjectForSync(remoteRaw);
   if (!remote) return { next: null, inserted: false, remoteWins: false, changed: false };
+  // An older peer can still send the fields that newer peers strip. Project
+  // sync remains schema-v1 compatible, so apply the same projection inbound
+  // before either inserting or restoring this machine's local choices.
+  remote = sanitizeRecordForWire('musicVideoProject', remote);
   if (!local) return { next: remote, inserted: true, remoteWins: true, changed: true };
   // Render pins are install-capability choices and therefore wire-local
   // (#3245). sanitizeRecordForWire omits them from peer payloads; restore this

--- a/server/services/musicVideo/projectsLogic.test.js
+++ b/server/services/musicVideo/projectsLogic.test.js
@@ -469,6 +469,20 @@ describe('mergeProjectRecord (#1770 LWW)', () => {
     expect(r.next.name).toBe('X');
   });
 
+  it('strips render pins sent by a legacy peer before inserting (#3245)', () => {
+    const { next } = mergeProjectRecord(null, {
+      id: 'mv-1',
+      updatedAt: '2026-01-02T00:00:00Z',
+      imageMode: 'grok',
+      imageModelId: 'foreign-image-model',
+      videoSettings: { backend: 'grok', modelId: 'shared-video-model' },
+    });
+
+    expect(next).not.toHaveProperty('imageMode');
+    expect(next).not.toHaveProperty('imageModelId');
+    expect(next.videoSettings).toEqual({ modelId: 'shared-video-model' });
+  });
+
   it('remote with a newer updatedAt wins', () => {
     const local = { id: 'mv-1', updatedAt: '2026-01-01T00:00:00Z', name: 'old' };
     const remote = { id: 'mv-1', updatedAt: '2026-01-05T00:00:00Z', name: 'new' };
@@ -516,7 +530,9 @@ describe('mergeProjectRecord (#1770 LWW)', () => {
     const remote = {
       id: 'mv-1',
       updatedAt: '2026-01-05T00:00:00Z',
-      videoSettings: { modelId: 'shared-model' },
+      imageMode: 'grok',
+      imageModelId: 'foreign-image-model',
+      videoSettings: { backend: 'grok', modelId: 'shared-model' },
     };
 
     const { next } = mergeProjectRecord(local, remote);

--- a/server/services/musicVideo/projectsLogic.test.js
+++ b/server/services/musicVideo/projectsLogic.test.js
@@ -478,6 +478,54 @@ describe('mergeProjectRecord (#1770 LWW)', () => {
     expect(r.next.name).toBe('new');
   });
 
+  it('preserves local render pins when a newer remote edit wins (#3245)', () => {
+    const local = {
+      id: 'mv-1',
+      updatedAt: '2026-01-01T00:00:00Z',
+      name: 'local',
+      imageMode: 'codex',
+      imageModelId: 'example-image-model',
+      videoSettings: { backend: 'local', modelId: 'local-model', grokDuration: 5 },
+    };
+    const remote = {
+      id: 'mv-1',
+      updatedAt: '2026-01-05T00:00:00Z',
+      name: 'remote edit',
+      videoSettings: { modelId: 'shared-model', grokDuration: 10 },
+    };
+
+    const r = mergeProjectRecord(local, remote);
+
+    expect(r.remoteWins).toBe(true);
+    expect(r.next.name).toBe('remote edit');
+    expect(r.next.imageMode).toBe('codex');
+    expect(r.next.imageModelId).toBe('example-image-model');
+    expect(r.next.videoSettings).toEqual({
+      modelId: 'shared-model',
+      grokDuration: 10,
+      backend: 'local',
+    });
+  });
+
+  it('keeps absent local image pins absent while preserving a local video backend', () => {
+    const local = {
+      id: 'mv-1',
+      updatedAt: '2026-01-01T00:00:00Z',
+      videoSettings: { backend: 'local' },
+    };
+    const remote = {
+      id: 'mv-1',
+      updatedAt: '2026-01-05T00:00:00Z',
+      videoSettings: { modelId: 'shared-model' },
+    };
+
+    const { next } = mergeProjectRecord(local, remote);
+
+    expect(next).not.toHaveProperty('imageMode');
+    expect(next).not.toHaveProperty('imageModelId');
+    expect(next.videoSettings).toEqual({ modelId: 'shared-model', backend: 'local' });
+  });
+
   it('local with a newer updatedAt wins (no change applied)', () => {
     const local = { id: 'mv-1', updatedAt: '2026-01-05T00:00:00Z', name: 'local' };
     const remote = { id: 'mv-1', updatedAt: '2026-01-01T00:00:00Z', name: 'remote' };


### PR DESCRIPTION
## Summary
- keep Music Video image backend/model pins and the video backend local to each federated install
- preserve legacy video-backend transport compatibility while excluding local pins from upgraded-peer persistence and conflict hashes
- preserve shared Music Video settings such as model, pacing, and generation mode across sync
- let users clear an existing video-backend pin so the receiving install default applies

## Test plan
- `cd server && npm test -- --run lib/syncWire.test.js lib/conflictJournal.test.js services/musicVideo/projectsLogic.test.js services/musicVideo/projectsFile.test.js routes/musicVideo.test.js` (182 passed)
- `cd client && npm test -- --run src/pages/MusicVideo.test.jsx` (36 passed)
- `git diff --check`

Closes #3245