### PR TITLE
fix([issue-3248]): preserve local video controls under Grok pin

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -4,6 +4,10 @@
 
 - **[issue-3245] Synced Music Video projects now use each machine's own render backends.** Image and video backend pins no longer overwrite a peer's locally usable choices, while shared model and pacing settings continue to sync.
 
+## Video Generation
+
+- **[issue-3248] Requeued local videos now keep their original render controls when Grok is the default.** Frame count, frame rate, steps, guidance, seed, image strength, and tiling settings keep the render on the local backend instead of being silently discarded.
+
 ## Sprite Manager
 
 - **[issue-3247] Forked sprites now validate their pinned render model before saving.** Invalid model IDs are rejected immediately instead of leaving a sprite pinned to a model that later renders cannot use or replace.

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -128,6 +128,19 @@ const optionalInt = (min, max, label) => z.preprocess(
 // still enforced against the mode's own spec (assertIcReferenceCount).
 const MAX_IC_REFERENCES = Math.max(...listIcLoraWeights().map((s) => s.maxReferences));
 
+// Render controls that only the local runtimes understand. Keep their schemas
+// together so Grok eligibility and request validation cannot drift when a new
+// local-only knob is added.
+export const LOCAL_ONLY_VIDEO_PARAMS = Object.freeze({
+  numFrames: optionalInt(1, 1024, 'numFrames'),
+  fps: optionalNum(1, 60, 'fps'),
+  steps: optionalNum(1, 200, 'steps'),
+  guidanceScale: optionalNum(0, 30, 'guidanceScale'),
+  seed: optionalNum(0, Number.MAX_SAFE_INTEGER, 'seed'),
+  imageStrength: optionalNum(0, 1, 'imageStrength'),
+  tiling: z.enum(['auto', 'none', 'spatial', 'temporal']).optional(),
+});
+
 const generateBodySchema = z.object({
   // Render backend: the local runtimes (default) or the Grok Build CLI's
   // image-first image_to_video flow (#2859 phase 2). Grok ignores the
@@ -147,14 +160,8 @@ const generateBodySchema = z.object({
   modelId: z.string().max(64).optional(),
   width: optionalNum(64, 2048, 'width'),
   height: optionalNum(64, 2048, 'height'),
-  numFrames: optionalInt(1, 1024, 'numFrames'),
-  fps: optionalNum(1, 60, 'fps'),
-  steps: optionalNum(1, 200, 'steps'),
-  guidanceScale: optionalNum(0, 30, 'guidanceScale'),
-  seed: optionalNum(0, Number.MAX_SAFE_INTEGER, 'seed'),
-  imageStrength: optionalNum(0, 1, 'imageStrength'),
+  ...LOCAL_ONLY_VIDEO_PARAMS,
   audioStartSec: optionalNum(0, 36000, 'audioStartSec'),
-  tiling: z.enum(['auto', 'none', 'spatial', 'temporal']).optional(),
   disableAudio: z.union([z.boolean(), z.literal('true'), z.literal('false')]).optional(),
   sourceImageFile: z.string().max(512).optional(),
   // Gallery-pick filename for the FFLF end-frame. The end-frame can also
@@ -768,6 +775,7 @@ router.post('/', frameImageUpload, asyncHandler(async (req, res) => {
     // would silently discard the model the caller asked for (e.g. a media
     // requeue rebuilding a local render's config without a backend field).
     && !body.modelId
+    && !Object.keys(LOCAL_ONLY_VIDEO_PARAMS).some((param) => body[param] !== undefined)
     && !uploads.lastImage && !body.lastImageFile
     && !uploads.audioFile
     && !uploads.icReference && !body.icReferenceVideoIds?.length && !body.icReferenceImageFiles?.length

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -140,7 +140,7 @@ import { getProject as getMusicVideoProject } from '../services/musicVideo/proje
 import { getTrack } from '../services/tracks/index.js';
 import { resolveGalleryImage } from '../lib/fileUtils.js';
 import { listIcLoraWeights } from '../lib/icLoraWeights.js';
-import videoGenRoutes, { isAudioMime } from './videoGen.js';
+import videoGenRoutes, { isAudioMime, LOCAL_ONLY_VIDEO_PARAMS } from './videoGen.js';
 
 // isAudioMime is the gating function inside the fileFilter callback. The
 // multipart mock in these route tests bypasses fileFilter entirely, so we
@@ -347,6 +347,33 @@ describe('videoGen routes', () => {
       const [call] = mediaJobQueue.enqueueJob.mock.calls;
       expect(call[0].params.mode).not.toBe('grok');
       expect(call[0].params.modelId).toBe('ltx2_unified');
+    });
+
+    it.each(Object.entries({
+      numFrames: 49,
+      fps: 24,
+      steps: 25,
+      guidanceScale: 3,
+      seed: 0,
+      imageStrength: 0.5,
+      tiling: 'auto',
+    }))('keeps %s on the local path under a grok pin', async (param, value) => {
+      expect(Object.keys(LOCAL_ONLY_VIDEO_PARAMS)).toEqual([
+        'numFrames',
+        'fps',
+        'steps',
+        'guidanceScale',
+        'seed',
+        'imageStrength',
+        'tiling',
+      ]);
+      const { getSettings } = await import('../services/settings.js');
+      getSettings.mockResolvedValueOnce({ imageGen: grokReady, videoGen: { mode: 'grok' } });
+      const r = await request(app).post('/api/video-gen/').send({ prompt: 'a fox', [param]: value });
+      expect(r.status).toBe(200);
+      const [call] = mediaJobQueue.enqueueJob.mock.calls;
+      expect(call[0].params.mode).not.toBe('grok');
+      expect(call[0].params[param]).toBe(value);
     });
 
     it('a grok pin degrades to local when the request carries local-only machinery', async () => {


### PR DESCRIPTION
## Summary
- make local-only video parameter schemas the single source of truth for Grok eligibility
- keep requests carrying frame, sampling, seed, strength, or tiling controls on the local renderer
- cover every local-only parameter independently, including falsy-valid values

## Test plan
- `cd server && npm test -- routes/videoGen.test.js` (105 passed)
- `cd server && npm test` (not green in this fresh worktree: DB-primary universe suites require the dedicated test database; focused route suite passes)

Closes #3248
