### PR TITLE
Fix StrictMode freeze in MusicGenPanel and useAsyncAction; show the track generator toggle before save

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -7,6 +7,7 @@
 
 ## Internal
 
+- **[issue-3264] Fixed a development-mode freeze that left panels loading and buttons stuck after one click.** Under `npm run dev`, a mount guard used across fourteen components and hooks was never re-armed after React StrictMode double-mounts a component, so anything gated on it silently stopped updating — the music generator panel sat on "Loading generators…" forever, and every button backed by the shared async-action hook stayed disabled after its first click. All fourteen now use the shared hook that re-arms correctly, and a test fails if the broken shape is reintroduced anywhere in the client.
 - **[issue-3250] Stabilize Music Video project-selection tests under CI load.** Project-selection coverage now waits for the requested project to be available before opening its board, preventing intermittent false failures.
 
 ## Music Video
@@ -38,3 +39,7 @@
 - **[issue-3249] "Up next" recommendations now start the practice instead of dropping you on a page.** A due memory item like *Review "The Elements Song"* used to link at the memory list, where you still had to find the item, open it, scroll past the periodic table, and pick one of five practice modes — four clicks and two scrolls to reach an actual drill. It's now one click straight into a running drill: the Elements Song opens its recall test, and any other memory item opens spaced repetition, which targets its weakest verses.
 - **[issue-3249] Every memory practice mode now has its own link.** Practising a memory item is addressable — `/post/memory/<item>/spaced`, `/post/memory/elements/element-flash` — so a drill can be bookmarked, shared, reopened after a reload, and reached from ⌘K or by voice, the same way the Morse modes already work. Browser Back now steps out of a drill to the mode list and then to your items, and the Elements Song modes (Flash Cards, Element Flash, Fill the Lyrics, Learn Lyrics) are each individually reachable from the command palette.
 - **[issue-3249] The Elements Song page leads with practice and suggests where to start.** The periodic table used to fill the screen before any of the five practice modes came into view, with nothing to say which one to pick. Practice now sits at the top, and the mode that fits your current mastery is flagged "Start here" — the study deck when you haven't drilled the elements yet, the recall test while they're still shaky, the lyrics drill once the symbols are solid.
+
+## Music
+
+- **[issue-3264] The track generator picker is now visible before you save a new track.** Clicking New Track showed nothing at all where the generators belong, so there was no way to tell the Audio model and Chiptune score generators existed until after the first save. The picker now appears right away with a note that saving is required to generate, and a mode chosen before saving stays selected once the track is created.

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -30,26 +30,19 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { trackedJsxFiles as trackedJsx, trackedSourceFiles as trackedSources } from './test/trackedFiles.js';
 
 const CLIENT_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-function trackedJsxFiles() {
-  const out = execSync('git ls-files src', { cwd: CLIENT_ROOT, encoding: 'utf8' });
-  return out.trim().split('\n').filter(f => f.endsWith('.jsx') && !f.includes('.test.'));
-}
-
-// Same, but including plain `.js` — hooks and services hold JSX and refs too
-// (the OpenClaw composer's file-input ref lived in `hooks/useOpenClawAttachments.js`),
-// so a rule that only scans `.jsx` has a hole exactly where a shared helper
-// would reintroduce the pattern for many call sites at once.
-function trackedSourceFiles() {
-  const out = execSync('git ls-files src', { cwd: CLIENT_ROOT, encoding: 'utf8' });
-  return out.trim().split('\n').filter(f => /\.jsx?$/.test(f) && !f.includes('.test.'));
-}
+// Shared with the other repo-hygiene guards (see `src/test/trackedFiles.js` for
+// why `.js` is included alongside `.jsx`: the OpenClaw composer's file-input ref
+// lived in `hooks/useOpenClawAttachments.js`, exactly the hole a `.jsx`-only
+// scan leaves open).
+const trackedJsxFiles = () => trackedJsx(CLIENT_ROOT);
+const trackedSourceFiles = () => trackedSources(CLIENT_ROOT);
 
 /**
  * Slice out the full opening tag starting at `index`, tolerating `>` inside

--- a/client/src/components/TagPicker.jsx
+++ b/client/src/components/TagPicker.jsx
@@ -14,6 +14,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
+import useMounted from '../hooks/useMounted';
 import { X } from 'lucide-react';
 import { listCatalogTags } from '../services/apiCatalog';
 import { canonicalTagKey } from '../lib/catalogTypes';
@@ -29,8 +30,7 @@ export default function TagPicker({
   const [input, setInput] = useState('');
   const [suggestions, setSuggestions] = useState([]);
   const [open, setOpen] = useState(false);
-  const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  const mountedRef = useMounted();
 
   // Debounced autocomplete fetch. A stale generation counter prevents an
   // earlier-but-slower response from clobbering a later one's results.

--- a/client/src/components/WhileAwayWidget.jsx
+++ b/client/src/components/WhileAwayWidget.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import useMounted from '../hooks/useMounted';
 import { Link } from 'react-router-dom';
 import {
   Moon,
@@ -68,7 +69,7 @@ export default function WhileAwayWidget() {
   const sinceRef = useRef(null);
   // A socket-driven refresh can land after the widget unmounts — guard the
   // async setState so it doesn't fire into the void (CLAUDE.md unmount rule).
-  const mountedRef = useRef(true);
+  const mountedRef = useMounted();
 
   const load = useCallback(() => {
     const since = readLastSeen();
@@ -86,7 +87,6 @@ export default function WhileAwayWidget() {
     const refresh = () => load();
     socket.on('cos:agent:completed', refresh);
     return () => {
-      mountedRef.current = false;
       socket.off('cos:agent:completed', refresh);
     };
   }, [load]);

--- a/client/src/components/loraTraining/CheckpointPicker.jsx
+++ b/client/src/components/loraTraining/CheckpointPicker.jsx
@@ -10,7 +10,8 @@
  * overwrites the deployed LoRA in place.
  */
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback } from 'react';
+import useMounted from '../../hooks/useMounted';
 import { Layers, Loader2, CheckCircle2, AlertTriangle } from 'lucide-react';
 import toast from '../ui/Toast';
 import {
@@ -26,8 +27,7 @@ export default function CheckpointPicker({ run, onPromoted }) {
   // Guards the background preview-poll setTimeout chain from firing after the
   // component unmounts (deferred-work-respects-unmount rule). Not reset to true
   // so dev-mode double-mount can't re-arm a stale chain.
-  const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  const mountedRef = useMounted();
 
   const load = useCallback(() => {
     setLoading(true);

--- a/client/src/components/loraTraining/CheckpointPicker.jsx
+++ b/client/src/components/loraTraining/CheckpointPicker.jsx
@@ -25,8 +25,7 @@ export default function CheckpointPicker({ run, onPromoted }) {
   const [loading, setLoading] = useState(false);
   const [promotingStep, setPromotingStep] = useState(null);
   // Guards the background preview-poll setTimeout chain from firing after the
-  // component unmounts (deferred-work-respects-unmount rule). Not reset to true
-  // so dev-mode double-mount can't re-arm a stale chain.
+  // component unmounts (deferred-work-respects-unmount rule).
   const mountedRef = useMounted();
 
   const load = useCallback(() => {

--- a/client/src/components/music/MusicGenPanel.jsx
+++ b/client/src/components/music/MusicGenPanel.jsx
@@ -12,7 +12,8 @@
  * inline (streamed download), then selected immediately.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import useMounted from '../../hooks/useMounted';
 import { Loader2, Wand2, Download, X } from 'lucide-react';
 import toast from '../ui/Toast';
 import {
@@ -33,8 +34,7 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
   const [installProgress, setInstallProgress] = useState(null);
   const [runtimeInstallEngine, setRuntimeInstallEngine] = useState(null);
   const [userSelectedEngine, setUserSelectedEngine] = useState(false);
-  const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  const mountedRef = useMounted();
 
   const loadEngines = async () => {
     const data = await listMusicEngines({ silent: true }).catch(() => null);

--- a/client/src/components/music/MusicGenPanel.test.jsx
+++ b/client/src/components/music/MusicGenPanel.test.jsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StrictMode } from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import MusicGenPanel from './MusicGenPanel';
 import * as api from '../../services/api';
@@ -87,5 +88,28 @@ describe('MusicGenPanel', () => {
 
     fireEvent.change(select, { target: { value: 'acestep' } });
     expect(await screen.findByText(/ACE-Step .* is not installed yet/i)).toBeInTheDocument();
+  });
+
+  // The app mounts under <React.StrictMode> (client/src/main.jsx), whose dev
+  // double-mount reuses the component's refs. A cleanup-only mounted guard is
+  // left false by the simulated unmount, so `loadEngines` bailed before
+  // `setLoading(false)` and the panel sat on "Loading generators…" forever
+  // (#3264). Rendering the real StrictMode wrapper is the only way this
+  // regression is visible — every other test here mounts the panel bare.
+  it('loads the engine list under StrictMode instead of hanging on "Loading generators…"', async () => {
+    api.listMusicEngines.mockResolvedValue({
+      defaultEngine: 'musicgen',
+      engines: [engine({ id: 'musicgen', name: 'MusicGen (MLX)', ready: true })],
+    });
+
+    render(
+      <StrictMode>
+        <MusicGenPanel track={{ id: 'track-1' }} prompt="" lyrics="" />
+      </StrictMode>,
+    );
+
+    const select = await screen.findByRole('combobox', { name: /engine/i });
+    expect(select).toHaveValue('musicgen');
+    expect(screen.queryByText(/Loading generators/i)).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/music/TracksManager.jsx
+++ b/client/src/components/music/TracksManager.jsx
@@ -471,9 +471,7 @@ export default function TracksManager() {
                 </div>
                 {!persisted ? (
                   <p className="text-xs text-gray-500">
-                    {genMode === 'chiptune'
-                      ? 'Save the track first, then generate a chiptune score.'
-                      : 'Save the track first, then generate with an audio model.'}
+                    Save the track first, then generate {genMode === 'chiptune' ? 'a chiptune score' : 'with an audio model'}.
                   </p>
                 ) : genMode === 'chiptune' ? (
                   <ChiptunePanel
@@ -581,7 +579,9 @@ export default function TracksManager() {
                   ) : null}
                 </div>
               ) : (
-                <p className="text-xs text-gray-500">Save the track first to generate, upload, or attach audio.</p>
+                /* Generation has its own hint under the mode toggle above
+                   (#3264), so this covers only what the renders block offers. */
+                <p className="text-xs text-gray-500">Save the track first to upload or attach audio.</p>
               )}
 
               {/* MIDI piano-roll (#2477) — read through from the linked Music

--- a/client/src/components/music/TracksManager.jsx
+++ b/client/src/components/music/TracksManager.jsx
@@ -140,6 +140,13 @@ export default function TracksManager() {
   // for every selection change (incl. idle / not-found) so a modal/remix left
   // open can't drive the previous track (see Authors.jsx for the base pattern).
   const hydratedRef = useRef(null);
+  // Set by `handleSave` to the id it just created. The create flow navigates
+  // /music/tracks/new → /music/tracks/<id>, which re-runs this effect; without
+  // the marker the derivation below would snap a "Chiptune score" chosen BEFORE
+  // saving back to "Audio model" the moment the track came into existence
+  // (#3264). Consumed once — a later re-selection of the same track hydrates
+  // from `chiptuneScore` normally.
+  const justCreatedIdRef = useRef(null);
   const selectionKey = id ?? null;
   useEffect(() => {
     if (loading) return;
@@ -147,9 +154,19 @@ export default function TracksManager() {
     hydratedRef.current = selectionKey;
     selectedIdRef.current = selectionKey;
     resetTrackViewState();
-    if (isCreate) setForm(emptyForm());
-    else if (selected) setForm(formFromTrack(selected));
-    setGenMode(selected?.chiptuneScore ? 'chiptune' : 'audio');
+    if (isCreate) {
+      setForm(emptyForm());
+      // Deliberately no `setGenMode` here. A new track has no score to derive
+      // from, so the derivation could only ever force 'audio' — and the create
+      // editor renders while `listTracks` is still in flight, so it would also
+      // clobber a mode the user picked during that window.
+    } else if (selected) {
+      setForm(formFromTrack(selected));
+      // Skip the derivation exactly once for the track `handleSave` just made,
+      // so the pre-save choice survives the create → navigate hydration.
+      if (justCreatedIdRef.current === selectionKey) justCreatedIdRef.current = null;
+      else setGenMode(selected.chiptuneScore ? 'chiptune' : 'audio');
+    }
   }, [selectionKey, isCreate, selected, loading]);
 
   const upsertLocal = (track) => {
@@ -171,6 +188,9 @@ export default function TracksManager() {
       // Point the async-handler ref at the new id immediately (the hydration
       // effect also sets it, but not until after navigation re-renders).
       selectedIdRef.current = created.id;
+      // Carry the pre-save generator choice through the create → navigate
+      // hydration instead of re-deriving it from the (score-less) new track.
+      justCreatedIdRef.current = created.id;
       navigate(`/music/tracks/${encodeURIComponent(created.id)}`);
       toast.success(`Created "${created.title}"`);
     } else {
@@ -425,55 +445,66 @@ export default function TracksManager() {
                 />
               </Field>
 
-              {/* Generation — available once the track is saved (the server
-                  attaches the audio + metadata to the persisted track). Two
-                  modes: the on-device audio models (MusicGen/AudioLDM2/ACE-Step)
-                  and the LLM-composed looping chiptune score (#2911). */}
-              {persisted ? (
-                <div className="space-y-2">
-                  <div className="inline-flex rounded-lg border border-port-border overflow-hidden text-sm" role="group" aria-label="Generation mode">
-                    {[['audio', 'Audio model'], ['chiptune', 'Chiptune score']].map(([mode, label]) => (
-                      <button
-                        key={mode}
-                        type="button"
-                        onClick={() => setGenMode(mode)}
-                        className={`px-3 py-1.5 ${genMode === mode ? 'bg-port-accent/20 text-white' : 'bg-port-bg text-gray-400 hover:text-white'}`}
-                      >
-                        {label}
-                      </button>
-                    ))}
-                  </div>
-                  {genMode === 'chiptune' ? (
-                    <ChiptunePanel
-                      track={persisted}
-                      remix={chiptuneRemix}
-                      onTrackUpdate={(updated) => {
-                        upsertLocal(updated); // list update is id-keyed → always safe
-                        if (selectedIdRef.current === updated.id) {
-                          setForm((f) => ({ ...f, audioFilename: updated.audioFilename || f.audioFilename }));
-                        }
-                      }}
-                    />
-                  ) : (
-                    <MusicGenPanel
-                      track={persisted}
-                      prompt={form.prompt}
-                      lyrics={form.lyrics}
-                      remix={remix}
-                      onGenerated={(updated) => {
-                        upsertLocal(updated); // list update is id-keyed → always safe
-                        // Merge ONLY the server-set generation fields into the open
-                        // form (the active audio pointer mirrors onto the form) so any
-                        // UNSAVED edits the user made to title/artist/album/prompt/
-                        // lyrics before clicking Generate survive.
-                        if (selectedIdRef.current === updated.id) {
-                          setForm((f) => ({ ...f, audioFilename: updated.audioFilename || '' }));
-                        }
-                      }}
-                    />
-                  )}
+              {/* Generation — two modes: the on-device audio models
+                  (MusicGen/AudioLDM2/ACE-Step) and the LLM-composed looping
+                  chiptune score (#2911).
+
+                  The mode TOGGLE renders even before the track is saved: mode
+                  is pure local state and needs no track id, and hiding it left
+                  a brand-new track showing no sign either generator existed
+                  (#3264). The PANELS stay gated on `persisted` — the server
+                  attaches audio + gen metadata to a saved id — but the gate now
+                  explains itself instead of rendering an empty region. */}
+              <div className="space-y-2">
+                <div className="inline-flex rounded-lg border border-port-border overflow-hidden text-sm" role="group" aria-label="Generation mode">
+                  {[['audio', 'Audio model'], ['chiptune', 'Chiptune score']].map(([mode, label]) => (
+                    <button
+                      key={mode}
+                      type="button"
+                      onClick={() => setGenMode(mode)}
+                      aria-pressed={genMode === mode}
+                      className={`px-3 py-1.5 ${genMode === mode ? 'bg-port-accent/20 text-white' : 'bg-port-bg text-gray-400 hover:text-white'}`}
+                    >
+                      {label}
+                    </button>
+                  ))}
                 </div>
-              ) : null}
+                {!persisted ? (
+                  <p className="text-xs text-gray-500">
+                    {genMode === 'chiptune'
+                      ? 'Save the track first, then generate a chiptune score.'
+                      : 'Save the track first, then generate with an audio model.'}
+                  </p>
+                ) : genMode === 'chiptune' ? (
+                  <ChiptunePanel
+                    track={persisted}
+                    remix={chiptuneRemix}
+                    onTrackUpdate={(updated) => {
+                      upsertLocal(updated); // list update is id-keyed → always safe
+                      if (selectedIdRef.current === updated.id) {
+                        setForm((f) => ({ ...f, audioFilename: updated.audioFilename || f.audioFilename }));
+                      }
+                    }}
+                  />
+                ) : (
+                  <MusicGenPanel
+                    track={persisted}
+                    prompt={form.prompt}
+                    lyrics={form.lyrics}
+                    remix={remix}
+                    onGenerated={(updated) => {
+                      upsertLocal(updated); // list update is id-keyed → always safe
+                      // Merge ONLY the server-set generation fields into the open
+                      // form (the active audio pointer mirrors onto the form) so any
+                      // UNSAVED edits the user made to title/artist/album/prompt/
+                      // lyrics before clicking Generate survive.
+                      if (selectedIdRef.current === updated.id) {
+                        setForm((f) => ({ ...f, audioFilename: updated.audioFilename || '' }));
+                      }
+                    }}
+                  />
+                )}
+              </div>
 
               {/* Render history — every generated/uploaded take as a card. The
                   active take is highlighted; each card opens a detail/remix modal,

--- a/client/src/components/music/TracksManager.test.jsx
+++ b/client/src/components/music/TracksManager.test.jsx
@@ -107,6 +107,10 @@ describe('<TracksManager> generator mode toggle', () => {
     expect(screen.getByText(/Save the track first, then generate with an audio model/i)).toBeInTheDocument();
     expect(screen.queryByTestId('gen-panel')).toBeNull();
     expect(screen.queryByTestId('chiptune-panel')).toBeNull();
+    // The renders block's own hint no longer claims to cover generation, so an
+    // unsaved track doesn't show two near-identical "save first" sentences.
+    expect(screen.getByText(/Save the track first to upload or attach audio/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Save the track first to generate, upload/i)).toBeNull();
   });
 
   it('switches mode before save and names the selected mode in the hint', async () => {
@@ -125,13 +129,7 @@ describe('<TracksManager> generator mode toggle', () => {
     const created = { id: 'track-new', title: 'Fresh Cut', renders: [] };
     createTrack.mockResolvedValue(created);
 
-    render(
-      <MemoryRouter initialEntries={['/music/tracks/new']}>
-        <Routes>
-          <Route path="/music/tracks/:id" element={<TracksManager />} />
-        </Routes>
-      </MemoryRouter>,
-    );
+    renderAt('new');
     await screen.findByRole('group', { name: /generation mode/i });
 
     fireEvent.click(modeButton('Chiptune score'));

--- a/client/src/components/music/TracksManager.test.jsx
+++ b/client/src/components/music/TracksManager.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, cleanup } from '@testing-library/react';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // (#2477 follow-up), not the editor/generation internals.
 vi.mock('./ArtistPicker', () => ({ default: () => <div data-testid="artist-picker" /> }));
 vi.mock('./MusicGenPanel', () => ({ default: () => <div data-testid="gen-panel" /> }));
+vi.mock('./ChiptunePanel', () => ({ default: () => <div data-testid="chiptune-panel" /> }));
 vi.mock('./TrackRenderCard', () => ({ default: () => <div data-testid="render-card" /> }));
 vi.mock('./TrackRenderModal', () => ({ default: () => null }));
 vi.mock('../songs/MidiVisualization.jsx', () => ({
@@ -30,7 +31,7 @@ vi.mock('../../services/api', () => ({
 vi.mock('../../services/apiMusicVideo.js', () => ({ listMusicVideoProjects: vi.fn() }));
 
 import TracksManager from './TracksManager.jsx';
-import { listTracks, listAlbums } from '../../services/api';
+import { listTracks, listAlbums, createTrack } from '../../services/api';
 import { listMusicVideoProjects } from '../../services/apiMusicVideo.js';
 
 const TRACK = { id: 'track-1', title: 'Example Song', audioFilename: 'example.mp3', renders: [] };
@@ -76,5 +77,87 @@ describe('<TracksManager> MIDI transcription read-through', () => {
     await screen.findByDisplayValue('Example Song');
     expect(screen.queryByTestId('midi-viz')).toBeNull();
     expect(screen.queryByText('MIDI transcription')).toBeNull();
+  });
+});
+
+// #3264: the generator toggle used to live INSIDE the `persisted ?` gate, so a
+// brand-new track rendered nothing at all where the generators belong and there
+// was no way to learn the two modes existed until after the first save.
+describe('<TracksManager> generator mode toggle', () => {
+  beforeEach(() => {
+    listTracks.mockResolvedValue([TRACK]);
+    listAlbums.mockResolvedValue([]);
+    listMusicVideoProjects.mockResolvedValue([]);
+  });
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  const modeButton = (name) => screen.getByRole('button', { name });
+
+  it('shows the toggle on an unsaved track, with a hint instead of a panel', async () => {
+    renderAt('new');
+    await screen.findByRole('group', { name: /generation mode/i });
+
+    expect(modeButton('Audio model')).toBeInTheDocument();
+    expect(modeButton('Chiptune score')).toBeInTheDocument();
+    // Gating generation on a saved track is correct and stays — but it must
+    // explain itself rather than render an empty region.
+    expect(screen.getByText(/Save the track first, then generate with an audio model/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('gen-panel')).toBeNull();
+    expect(screen.queryByTestId('chiptune-panel')).toBeNull();
+  });
+
+  it('switches mode before save and names the selected mode in the hint', async () => {
+    renderAt('new');
+    await screen.findByRole('group', { name: /generation mode/i });
+
+    fireEvent.click(modeButton('Chiptune score'));
+
+    expect(modeButton('Chiptune score')).toHaveAttribute('aria-pressed', 'true');
+    expect(modeButton('Audio model')).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByText(/Save the track first, then generate a chiptune score/i)).toBeInTheDocument();
+    expect(screen.queryByTestId('chiptune-panel')).toBeNull();
+  });
+
+  it('keeps a pre-save chiptune choice after Create navigates to the new track', async () => {
+    const created = { id: 'track-new', title: 'Fresh Cut', renders: [] };
+    createTrack.mockResolvedValue(created);
+
+    render(
+      <MemoryRouter initialEntries={['/music/tracks/new']}>
+        <Routes>
+          <Route path="/music/tracks/:id" element={<TracksManager />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    await screen.findByRole('group', { name: /generation mode/i });
+
+    fireEvent.click(modeButton('Chiptune score'));
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Fresh Cut' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    // The hydration effect re-runs on the create → navigate transition; the
+    // created track carries no `chiptuneScore`, so a naive re-derivation would
+    // snap the editor back to "Audio model" the instant the track existed.
+    expect(await screen.findByTestId('chiptune-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('gen-panel')).toBeNull();
+    expect(modeButton('Chiptune score')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('still opens an existing scored track on the chiptune panel', async () => {
+    listTracks.mockResolvedValue([{ ...TRACK, chiptuneScore: { tempo: 120 } }]);
+    renderAt('track-1');
+
+    expect(await screen.findByTestId('chiptune-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('gen-panel')).toBeNull();
+  });
+
+  it('opens an existing unscored track on the audio panel', async () => {
+    renderAt('track-1');
+
+    expect(await screen.findByTestId('gen-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('chiptune-panel')).toBeNull();
   });
 });

--- a/client/src/components/pipeline/editorial/EditorialCustomCheckForm.jsx
+++ b/client/src/components/pipeline/editorial/EditorialCustomCheckForm.jsx
@@ -12,6 +12,7 @@
  * committing the check to the catalog.
  */
 import { useEffect, useRef, useState } from 'react';
+import useMounted from '../../../hooks/useMounted';
 import { FlaskConical, Loader2, Save, X } from 'lucide-react';
 import { CHECK_SCOPE_ORDER, scopeLabel, SEVERITY_BADGE_CLASSES } from '../../../lib/editorialChecks';
 
@@ -53,8 +54,7 @@ export default function EditorialCustomCheckForm({ check = null, saving = false,
   const [previewing, setPreviewing] = useState(false);
   const [previewError, setPreviewError] = useState('');
   const previewReqRef = useRef(0);
-  const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  const mountedRef = useMounted();
 
   // Invalidate + clear any preview when the draft or the target series changes.
   const invalidatePreview = () => {

--- a/client/src/components/pipeline/manuscript/ManuscriptImpactPreview.jsx
+++ b/client/src/components/pipeline/manuscript/ManuscriptImpactPreview.jsx
@@ -50,7 +50,7 @@ export default function ManuscriptImpactPreview({ open, onClose, seriesId, secti
 
   // The accept-all pass awaits one network round-trip per note; if the user
   // closes the preview mid-batch, late callbacks must not fire into a torn-down
-  // parent. Never reset to true (handles dev-mode double-mount cleanly).
+  // parent.
   const mountedRef = useMounted();
 
   const changed = useMemo(() => {

--- a/client/src/components/pipeline/manuscript/ManuscriptImpactPreview.jsx
+++ b/client/src/components/pipeline/manuscript/ManuscriptImpactPreview.jsx
@@ -16,7 +16,8 @@
  * red/green. Diffs per changed section, never one giant concatenation.
  */
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useState } from 'react';
+import useMounted from '../../../hooks/useMounted';
 import { Check, Loader2, X } from 'lucide-react';
 import Modal from '../../ui/Modal';
 import HunkDiff from '../../ui/HunkDiff';
@@ -50,8 +51,7 @@ export default function ManuscriptImpactPreview({ open, onClose, seriesId, secti
   // The accept-all pass awaits one network round-trip per note; if the user
   // closes the preview mid-batch, late callbacks must not fire into a torn-down
   // parent. Never reset to true (handles dev-mode double-mount cleanly).
-  const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  const mountedRef = useMounted();
 
   const changed = useMemo(() => {
     if (!open) return [];

--- a/client/src/components/sync/SyncDetailDrawer.jsx
+++ b/client/src/components/sync/SyncDetailDrawer.jsx
@@ -14,6 +14,7 @@
  */
 
 import { useEffect, useState, useCallback, useRef } from 'react';
+import useMounted from '../../hooks/useMounted';
 import { RefreshCw, ArrowUpCircle, Download, CheckCircle2, AlertTriangle, WifiOff, Loader2 } from 'lucide-react';
 import toast from '../ui/Toast';
 import Drawer from '../Drawer';
@@ -261,8 +262,7 @@ export default function SyncDetailDrawer({ kind, recordId, onClose }) {
   // Drop async results that resolve after the drawer unmounts (fast route
   // change / close while a fetch is in flight) to avoid setState-on-unmounted
   // warnings. Never reset to true — handles dev-mode double-mount cleanly.
-  const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  const mountedRef = useMounted();
   // Generation counter so only the LATEST in-flight fetch commits state — a
   // rapid recordId change (or switch to empty) bumps this, and an older fetch
   // that resolves afterward fails the equality check and is dropped, instead

--- a/client/src/components/sync/SyncDetailDrawer.jsx
+++ b/client/src/components/sync/SyncDetailDrawer.jsx
@@ -261,7 +261,7 @@ export default function SyncDetailDrawer({ kind, recordId, onClose }) {
 
   // Drop async results that resolve after the drawer unmounts (fast route
   // change / close while a fetch is in flight) to avoid setState-on-unmounted
-  // warnings. Never reset to true — handles dev-mode double-mount cleanly.
+  // warnings.
   const mountedRef = useMounted();
   // Generation counter so only the LATEST in-flight fetch commits state — a
   // rapid recordId change (or switch to empty) bumps this, and an older fetch

--- a/client/src/components/universeBuilder/UniverseCategoryEditor.jsx
+++ b/client/src/components/universeBuilder/UniverseCategoryEditor.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import useMounted from '../../hooks/useMounted';
 import {
   ArrowUpCircle, Edit3, FolderTree, Loader2, Lock, Play, Plus,
   Sparkles, Trash2, Unlock, X,
@@ -77,8 +78,7 @@ export function CategoryEditor({
     return () => document.removeEventListener('keydown', onKey);
   }, [assignOpen]);
 
-  const editorMountedRef = useRef(true);
-  useEffect(() => () => { editorMountedRef.current = false; }, []);
+  const editorMountedRef = useMounted();
   const runPromote = async (idx, variation, opts) => {
     if (!onPromote) return;
     setPickerIdx(null);

--- a/client/src/hooks/mountedRefConventions.test.js
+++ b/client/src/hooks/mountedRefConventions.test.js
@@ -16,35 +16,53 @@
  * stuck on "Loading generators…" forever, and every `useAsyncAction` button stuck
  * in its disabled/spinner state after one click (#3264).
  *
- * `hooks/useMounted.js` is the fix and the only sanctioned form: it assigns `true`
- * in the effect setup body, so the StrictMode remount re-arms the guard.
+ * `hooks/useMounted.js` is the fix, and the sanctioned form for new code. (A dozen
+ * older sites still inline the same body correctly — they DO set `true` on setup,
+ * so they are safe and this guard passes them; converting them is follow-up
+ * cleanup, not a correctness fix.)
  *
- * The rule below is deliberately shape-based rather than name-based — a ref called
- * `editorMountedRef` (or anything else) carries the identical bug, and one of the
- * sites this guard was written for was named exactly that. Scoped to git-tracked
- * sources under `client/src` per the repo-hygiene convention in
- * `client/src/a11yConventions.test.js`, so an untracked scratch file can't fail it.
+ * The rule is deliberately shape-based rather than name-based — a ref called
+ * `editorMountedRef` carries the identical bug, and one of the sites this guard
+ * was written for was named exactly that.
+ *
+ * ## What this guard CANNOT see
+ *
+ * It is a source grep, not a scope-aware AST pass, so these semantically identical
+ * shapes slip through. They are listed so the next person extending it knows where
+ * the floor is rather than trusting a green run too far:
+ *
+ *   - `let`/`var` declarations (the pattern hardcodes `const`).
+ *   - A non-literal seed: `const INIT = true; const r = useRef(INIT)`.
+ *   - Two components in ONE file where A is correct and B is broken — the scan is
+ *     file-scoped, so A's `= true` satisfies B. Live risk: three separate
+ *     `mountedRef`s coexist in `components/meatspace/post/PostCognitiveDrillRunner.jsx`.
+ *   - A ref created in one file and lowered in another (a hook returning its ref to
+ *     a caller that writes `ref.current = false`).
+ *   - Aliasing (`const g = mountedRef; g.current = false`), computed access
+ *     (`ref['current']`), or assignment funneled through a setter function.
+ *   - An assignment that only appears inside a comment (no comment stripping).
+ *
+ * Tightening any of these means moving to an AST pass; the shapes above are all
+ * unusual enough in this codebase that the grep earns its keep as-is.
  */
 
 import { describe, it, expect } from 'vitest';
-import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { trackedSourceFiles } from '../test/trackedFiles.js';
 
 const CLIENT_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
-
-function trackedSourceFiles() {
-  const out = execSync('git ls-files src', { cwd: CLIENT_ROOT, encoding: 'utf8' });
-  return out.trim().split('\n').filter((f) => /\.jsx?$/.test(f) && !f.includes('.test.'));
-}
 
 // `const <name> = useRef(true)` — the seed value that marks a mounted-style guard.
 // A ref seeded `useRef(false)` and raised to `true` on mount is a different (and
 // correct) pattern, so it is intentionally out of scope.
 const TRUE_SEEDED_REF = /const\s+([A-Za-z_$][\w$]*)\s*=\s*useRef\(\s*true\s*\)/g;
 
-const assignsRe = (name, value) => new RegExp(`\\b${name}\\.current\\s*=\\s*${value}\\b`);
+// `=` and `||=` both count as re-arming. Matching only `=` would report a ref
+// re-armed with `ref.current ||= true` as broken — a false positive that would
+// push someone to "fix" already-correct code.
+const assignsRe = (name, value) => new RegExp(`\\b${name}\\.current\\s*(?:\\|\\|)?=\\s*${value}\\b`);
 
 /** Refs in `src` that are lowered to false but never re-raised to true. */
 function findOneWayRefs(src) {
@@ -60,8 +78,13 @@ function findOneWayRefs(src) {
 
 describe('mounted-guard refs re-arm on mount (StrictMode)', () => {
   it('has no ref that is only ever set to false', () => {
+    const files = trackedSourceFiles(CLIENT_ROOT);
+    // A broken `git ls-files` (wrong cwd, detached checkout) would otherwise make
+    // this guard pass by scanning nothing at all.
+    expect(files.length).toBeGreaterThan(100);
+
     const violations = [];
-    for (const file of trackedSourceFiles()) {
+    for (const file of files) {
       const src = readFileSync(join(CLIENT_ROOT, file), 'utf8');
       for (const name of findOneWayRefs(src)) violations.push(`${file}: ${name}`);
     }
@@ -80,7 +103,7 @@ describe('mounted-guard refs re-arm on mount (StrictMode)', () => {
 
   // Guards the guard: if the detector stops recognizing the broken shape, the test
   // above goes vacuously green and the bug class walks straight back in.
-  it('detects the broken shape and accepts the useMounted shape', () => {
+  it('detects the broken shape and accepts every correct re-arm', () => {
     const broken = `
       const mountedRef = useRef(true);
       useEffect(() => () => { mountedRef.current = false; }, []);
@@ -96,14 +119,21 @@ describe('mounted-guard refs re-arm on mount (StrictMode)', () => {
         return () => { mountedRef.current = false; };
       }, []);
     `;
+    // `||=` re-arms just as well as `=`; flagging it would be a false positive.
+    const fixedLogicalAssign = `
+      const mountedRef = useRef(true);
+      useEffect(() => {
+        mountedRef.current ||= true;
+        return () => { mountedRef.current = false; };
+      }, []);
+    `;
+    // A ref that is never lowered has nothing to re-arm.
+    const neverLowered = 'const readyRef = useRef(true);';
+
     expect(findOneWayRefs(broken)).toEqual(['mountedRef']);
     expect(findOneWayRefs(brokenRenamed)).toEqual(['editorMountedRef']);
     expect(findOneWayRefs(fixed)).toEqual([]);
-  });
-
-  it('scans a non-empty set of tracked sources', () => {
-    // A broken `git ls-files` (wrong cwd, detached checkout) would otherwise make
-    // the whole guard pass by scanning nothing.
-    expect(trackedSourceFiles().length).toBeGreaterThan(100);
+    expect(findOneWayRefs(fixedLogicalAssign)).toEqual([]);
+    expect(findOneWayRefs(neverLowered)).toEqual([]);
   });
 });

--- a/client/src/hooks/mountedRefConventions.test.js
+++ b/client/src/hooks/mountedRefConventions.test.js
@@ -1,0 +1,109 @@
+/**
+ * Repo-wide guard: a mounted-guard ref must re-arm itself on mount.
+ *
+ * The broken shape is a ref seeded `useRef(true)` whose ONLY assignment is
+ * `false` in an effect cleanup:
+ *
+ *   const mountedRef = useRef(true);
+ *   useEffect(() => () => { mountedRef.current = false; }, []);   // ← no setup body
+ *
+ * It reads as correct, and it is — in production. But the app runs under
+ * `React.StrictMode` (`client/src/main.jsx`), and React's dev build mounts every
+ * component as setup → cleanup → setup on the SAME instance. Refs survive that
+ * cycle, so the cleanup flips the flag to `false` and nothing ever flips it back:
+ * every `if (mountedRef.current) setX(...)` in the component is dead for the rest
+ * of the dev session. That shipped as two user-visible freezes — MusicGenPanel
+ * stuck on "Loading generators…" forever, and every `useAsyncAction` button stuck
+ * in its disabled/spinner state after one click (#3264).
+ *
+ * `hooks/useMounted.js` is the fix and the only sanctioned form: it assigns `true`
+ * in the effect setup body, so the StrictMode remount re-arms the guard.
+ *
+ * The rule below is deliberately shape-based rather than name-based — a ref called
+ * `editorMountedRef` (or anything else) carries the identical bug, and one of the
+ * sites this guard was written for was named exactly that. Scoped to git-tracked
+ * sources under `client/src` per the repo-hygiene convention in
+ * `client/src/a11yConventions.test.js`, so an untracked scratch file can't fail it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const CLIENT_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function trackedSourceFiles() {
+  const out = execSync('git ls-files src', { cwd: CLIENT_ROOT, encoding: 'utf8' });
+  return out.trim().split('\n').filter((f) => /\.jsx?$/.test(f) && !f.includes('.test.'));
+}
+
+// `const <name> = useRef(true)` — the seed value that marks a mounted-style guard.
+// A ref seeded `useRef(false)` and raised to `true` on mount is a different (and
+// correct) pattern, so it is intentionally out of scope.
+const TRUE_SEEDED_REF = /const\s+([A-Za-z_$][\w$]*)\s*=\s*useRef\(\s*true\s*\)/g;
+
+const assignsRe = (name, value) => new RegExp(`\\b${name}\\.current\\s*=\\s*${value}\\b`);
+
+/** Refs in `src` that are lowered to false but never re-raised to true. */
+function findOneWayRefs(src) {
+  const offenders = [];
+  for (const match of src.matchAll(TRUE_SEEDED_REF)) {
+    const name = match[1];
+    if (assignsRe(name, 'false').test(src) && !assignsRe(name, 'true').test(src)) {
+      offenders.push(name);
+    }
+  }
+  return offenders;
+}
+
+describe('mounted-guard refs re-arm on mount (StrictMode)', () => {
+  it('has no ref that is only ever set to false', () => {
+    const violations = [];
+    for (const file of trackedSourceFiles()) {
+      const src = readFileSync(join(CLIENT_ROOT, file), 'utf8');
+      for (const name of findOneWayRefs(src)) violations.push(`${file}: ${name}`);
+    }
+
+    expect(
+      violations,
+      'These refs are seeded `useRef(true)` and set to `false` on cleanup, but never '
+      + 'back to `true` on setup. Under React.StrictMode the dev mount→cleanup→mount '
+      + 'cycle reuses the same ref, so each one is permanently false after first mount '
+      + 'and every setState it guards silently no-ops.\n'
+      + 'Fix: replace the ref + its cleanup effect with `useMounted()` from '
+      + '`client/src/hooks/useMounted.js`.\n'
+      + `Offenders:\n  ${violations.join('\n  ')}`,
+    ).toEqual([]);
+  });
+
+  // Guards the guard: if the detector stops recognizing the broken shape, the test
+  // above goes vacuously green and the bug class walks straight back in.
+  it('detects the broken shape and accepts the useMounted shape', () => {
+    const broken = `
+      const mountedRef = useRef(true);
+      useEffect(() => () => { mountedRef.current = false; }, []);
+    `;
+    const brokenRenamed = `
+      const editorMountedRef = useRef(true);
+      useEffect(() => () => { editorMountedRef.current = false; }, []);
+    `;
+    const fixed = `
+      const mountedRef = useRef(true);
+      useEffect(() => {
+        mountedRef.current = true;
+        return () => { mountedRef.current = false; };
+      }, []);
+    `;
+    expect(findOneWayRefs(broken)).toEqual(['mountedRef']);
+    expect(findOneWayRefs(brokenRenamed)).toEqual(['editorMountedRef']);
+    expect(findOneWayRefs(fixed)).toEqual([]);
+  });
+
+  it('scans a non-empty set of tracked sources', () => {
+    // A broken `git ls-files` (wrong cwd, detached checkout) would otherwise make
+    // the whole guard pass by scanning nothing.
+    expect(trackedSourceFiles().length).toBeGreaterThan(100);
+  });
+});

--- a/client/src/hooks/useAsyncAction.js
+++ b/client/src/hooks/useAsyncAction.js
@@ -1,5 +1,6 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState } from 'react';
 import toast from '../components/ui/Toast';
+import useMounted from './useMounted.js';
 
 /**
  * Wraps an async action with `running` state and toast-on-error.
@@ -19,14 +20,15 @@ import toast from '../components/ui/Toast';
  * The trailing `setRunning(false)` is gated on a `mountedRef` so an action
  * that resolves after the component unmounts (navigate-away mid-request)
  * doesn't call `setState` on an unmounted component — React warns about
- * that and it's a latent memory-leak signal.
+ * that and it's a latent memory-leak signal. The guard MUST come from
+ * `useMounted`, which re-arms the ref on every effect setup: StrictMode runs
+ * mount→cleanup→mount on the same instance (refs survive), so a cleanup-only
+ * ref stays false forever and every button in the app would stay stuck in its
+ * disabled/spinner state after one click.
  */
 export function useAsyncAction(fn, { errorMessage } = {}) {
   const [running, setRunning] = useState(false);
-  const mountedRef = useRef(true);
-  // Never reset to `true` on re-mount — this handles dev-mode double-mount
-  // cleanly (the cleanup runs once, the flag stays false for the dead tree).
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  const mountedRef = useMounted();
   const run = async (...args) => {
     setRunning(true);
     const result = await fn(...args).catch((err) => {

--- a/client/src/hooks/useAsyncAction.test.jsx
+++ b/client/src/hooks/useAsyncAction.test.jsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { StrictMode } from 'react';
 import { renderHook, act } from '@testing-library/react';
 import { useAsyncAction } from './useAsyncAction';
 
@@ -76,5 +77,25 @@ describe('useAsyncAction', () => {
     );
     expect(sawUnmountWarning).toBe(false);
     setStateSpy.mockRestore();
+  });
+
+  // The unmount guard above must not cost us the ordinary case. The app runs
+  // under <React.StrictMode>, whose dev double-mount reuses the hook's refs — a
+  // cleanup-only guard is left false by the simulated unmount, so `setRunning
+  // (false)` never fires and EVERY button backed by this hook stays disabled
+  // after one click (#3264). `useMounted` re-arms on setup; this pins it.
+  it('clears running under StrictMode so the action can be run again', async () => {
+    const { result } = renderHook(() => useAsyncAction(async (x) => x * 2), {
+      wrapper: StrictMode,
+    });
+
+    await act(async () => { await result.current[0](1); });
+    expect(result.current[1]).toBe(false);
+
+    // The second click is the one that broke: the button was still disabled.
+    let second;
+    await act(async () => { second = await result.current[0](21); });
+    expect(second).toBe(42);
+    expect(result.current[1]).toBe(false);
   });
 });

--- a/client/src/hooks/useCatalogTypes.jsx
+++ b/client/src/hooks/useCatalogTypes.jsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { createContext, useContext, useState, useEffect, useCallback, useMemo } from 'react';
+import useMounted from './useMounted';
 import { listCatalogTypes } from '../services/apiCatalogTypes';
 import { CATALOG_TYPES, mergeCatalogTypes } from '../lib/catalogTypes';
 
@@ -34,8 +35,7 @@ const buildRegistry = (userTypesRaw) => mergeCatalogTypes(CATALOG_TYPES, userTyp
 function useRegistryFetcher(enabled = true) {
   const [registry, setRegistry] = useState(() => buildRegistry([]));
   const [loading, setLoading] = useState(true);
-  const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  const mountedRef = useMounted();
 
   const refresh = useCallback(() => listCatalogTypes({ silent: true })
     .then((data) => {

--- a/client/src/hooks/useCityPlayback.js
+++ b/client/src/hooks/useCityPlayback.js
@@ -24,7 +24,7 @@ export function useCityPlayback() {
   const [error, setError] = useState(false);
 
   // Guards a deferred/interval callback against firing after unmount (CLAUDE.md
-  // deferred-work rule). Never reset to true — handles dev double-mount cleanly.
+  // deferred-work rule).
   const mountedRef = useMounted();
 
   const enter = useCallback(async () => {

--- a/client/src/hooks/useCityPlayback.js
+++ b/client/src/hooks/useCityPlayback.js
@@ -1,4 +1,5 @@
-import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect, useMemo } from 'react';
+import useMounted from './useMounted';
 import { getCitySnapshots } from '../services/apiCity.js';
 import { isPlayableFrame, buildPlaybackStats } from '../lib/cityPlaybackFrame.js';
 
@@ -24,8 +25,7 @@ export function useCityPlayback() {
 
   // Guards a deferred/interval callback against firing after unmount (CLAUDE.md
   // deferred-work rule). Never reset to true — handles dev double-mount cleanly.
-  const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  const mountedRef = useMounted();
 
   const enter = useCallback(async () => {
     setActive(true);

--- a/client/src/hooks/useShellSession.js
+++ b/client/src/hooks/useShellSession.js
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
+import useMounted from './useMounted';
 import { useSearchParams, useParams, useNavigate } from 'react-router-dom';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
@@ -105,8 +106,7 @@ export function useShellSession({ isFullscreen } = {}) {
   // Flipped on unmount so deferred work (setTimeout-scheduled recovery attaches)
   // can short-circuit instead of firing shell:attach from a teardown component —
   // which would claim a session with no listener left to render it.
-  const mountedRef = useRef(true);
-  useEffect(() => () => { mountedRef.current = false; }, []);
+  const mountedRef = useMounted();
   // useCallback for stable identity so consumers can list these in dep arrays without
   // causing useEffect re-binds on every render. They only touch a ref, so empty deps is correct.
   const setPendingAttach = useCallback((target) => {

--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useMounted from './useMounted';
 import toast from '../components/ui/Toast';
 import {
   addUniverseStyleReference,
@@ -86,7 +87,7 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
   const [newCategoryName, setNewCategoryName] = useState('');
   const [canonDirty, setCanonDirty] = useState(false);
 
-  const mountedRef = useRef(true);
+  const mountedRef = useMounted();
   const draftRef = useRef(null);
   const savedDraftSnapshotRef = useRef(universeDraftSnapshot(createEmptyUniverseDraft()));
   const savedStyleSnapshotRef = useRef(ensureInfluences(createEmptyUniverseDraft().influences));
@@ -134,7 +135,6 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     lastSeenUpdatedAtRef.current.set(id, updatedAt);
   }, []);
 
-  useEffect(() => () => { mountedRef.current = false; }, []);
   useEffect(() => { draftRef.current = draft; }, [draft]);
 
   const clearPendingCanonAdditions = useCallback(() => {

--- a/client/src/pages/LocalLlmPlayground.jsx
+++ b/client/src/pages/LocalLlmPlayground.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import useMounted from '../hooks/useMounted';
 import { Link, useSearchParams } from 'react-router-dom';
 import { ArrowLeft, ArrowRightLeft, Brain, Check, ChevronDown, Clock, Copy, Cpu, Gauge, MessageSquare, Play, RefreshCw, Send, TriangleAlert, X } from 'lucide-react';
 import BrailleSpinner from '../components/BrailleSpinner';
@@ -242,7 +243,7 @@ export default function LocalLlmPlayground() {
   // the prompt/controls stay above the fold. Open by default on first load.
   const [modelsOpen, setModelsOpen] = useState(true);
 
-  const mountedRef = useRef(true);
+  const mountedRef = useMounted();
   // Holds the AbortController for the in-flight run so the Cancel button can
   // abort the client fetch (which closes the server-side stream early). Cleared
   // in each run's .finally(). Abort the live request on unmount too.
@@ -257,7 +258,6 @@ export default function LocalLlmPlayground() {
   const reasoningBufRef = useRef('');
   const flushTimerRef = useRef(null);
   useEffect(() => () => {
-    mountedRef.current = false;
     runControllerRef.current?.abort();
     if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
   }, []);

--- a/client/src/test/trackedFiles.js
+++ b/client/src/test/trackedFiles.js
@@ -1,0 +1,41 @@
+/**
+ * Shared file walker for the repo-hygiene test suites.
+ *
+ * Several guards (`src/a11yConventions.test.js`, `src/hooks/mountedRefConventions.test.js`)
+ * enforce a rule across the whole client tree by grepping its sources. They all
+ * need the same answer to "which files count", and that answer has been revised
+ * before — the a11y guard originally scanned only `.jsx` and had to grow a `.js`
+ * variant once a shared hook reintroduced the pattern it was policing. Keeping
+ * one definition means the next such correction lands for every guard at once.
+ *
+ * Scoped to git-tracked files so an untracked scratch file can't fail a suite,
+ * and test files are excluded so a guard can't trip over its own fixtures.
+ *
+ * Node-only (`child_process`, `fs`) — imported by test files exclusively, never
+ * by app code, so it stays out of the browser bundle. It lives in `src/test/`
+ * rather than `src/lib/` for that reason: `lib/` carries the enforced barrel +
+ * README rule, and a node-builtin module has no business in a browser barrel.
+ */
+
+import { execSync } from 'child_process';
+
+const isTest = (f) => f.includes('.test.');
+
+function gitTracked(clientRoot) {
+  const out = execSync('git ls-files src', { cwd: clientRoot, encoding: 'utf8' });
+  return out.trim().split('\n');
+}
+
+/** Git-tracked non-test `.jsx` under `client/src`. */
+export function trackedJsxFiles(clientRoot) {
+  return gitTracked(clientRoot).filter((f) => f.endsWith('.jsx') && !isTest(f));
+}
+
+/**
+ * Git-tracked non-test `.js` AND `.jsx` under `client/src`. Hooks and services
+ * hold JSX and refs too, so a rule that only scans `.jsx` has a hole exactly
+ * where a shared helper would reintroduce the pattern for many call sites at once.
+ */
+export function trackedSourceFiles(clientRoot) {
+  return gitTracked(clientRoot).filter((f) => /\.jsx?$/.test(f) && !isTest(f));
+}

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -137,6 +137,14 @@ const structuralTestsFor = (changedFiles, trackedSet) => {
   if (changedFiles.some((path) => /^client\/src\/.*\.jsx$/.test(path))) {
     add('client/src/a11yConventions.test.js');
   }
+  // Both `.js` and `.jsx`: the StrictMode mounted-ref bug this guards against
+  // reached its widest blast radius through a plain-`.js` hook (`useAsyncAction`),
+  // so a `.jsx`-only trigger would miss the case that matters most. Nothing else
+  // selects this file — it has no source sibling and imports no app module, so
+  // without this entry it only ever runs on a full suite.
+  if (changedFiles.some((path) => /^client\/src\/.*\.jsx?$/.test(path))) {
+    add('client/src/hooks/mountedRefConventions.test.js');
+  }
 
   return selected;
 };

--- a/scripts/ci-test-plan.test.js
+++ b/scripts/ci-test-plan.test.js
@@ -13,6 +13,7 @@ const TRACKED = [
   'server/services/sprites/atlasGrid.test.js',
   'server/services/sprites/atlasLayout.test.js',
   'client/src/a11yConventions.test.js',
+  'client/src/hooks/mountedRefConventions.test.js',
   'client/src/components/catalog/CatalogCard.jsx',
   'client/src/components/catalog/CatalogCard.test.jsx',
   'client/src/components/sprites/WalkWorkflow.test.jsx',
@@ -117,6 +118,7 @@ describe('CI test impact planner', () => {
     expect(plan.client.mode).toBe('related');
     expect(plan.client.files).toContain('client/src/lib/index.test.js');
     expect(plan.client.files).toContain('client/src/a11yConventions.test.js');
+    expect(plan.client.files).toContain('client/src/hooks/mountedRefConventions.test.js');
     expect(plan.lint).toEqual({
       mode: 'files',
       files: [
@@ -125,6 +127,16 @@ describe('CI test impact planner', () => {
       ],
     });
     expect(plan.build).toBe(true);
+  });
+
+  it('selects the mounted-ref guard for a plain-.js client change', () => {
+    // The a11y guard only triggers on `.jsx`, but the StrictMode mounted-ref bug
+    // reached 94 call sites through a `.js` hook — so this guard must be selected
+    // by a change that touches no `.jsx` at all.
+    const plan = buildCiTestPlan(['client/src/hooks/useAsyncAction.js'], { trackedFiles: TRACKED });
+
+    expect(plan.client.files).toContain('client/src/hooks/mountedRefConventions.test.js');
+    expect(plan.client.files).not.toContain('client/src/a11yConventions.test.js');
   });
 
   it('runs the DB suite when a database-backed adapter changes', () => {


### PR DESCRIPTION
## Summary

Fixes both defects reported in #3264.

**1. "Loading generators…" never resolved under `npm run dev`.** Fourteen components and hooks seeded a mounted-guard ref with `useRef(true)` and only ever lowered it in an effect cleanup. React.StrictMode's dev mount→cleanup→mount reuses the same component instance — and its refs — so the flag went false on the first mount and stayed there. Everything gated on it was dead for the rest of the session.

Two user-visible freezes came from that:
- `MusicGenPanel` sat on "Loading generators…" forever. The engine list had already arrived; `loadEngines` bailed at the guard before reaching `setLoading(false)`.
- Every button backed by `useAsyncAction` stayed disabled after one click — 94 call sites. That hook carried a comment asserting the non-reset was deliberate because StrictMode builds a separate "dead tree". It does not; it remounts the same instance. The comment is gone along with the code it defended.

All fourteen now use the existing `useMounted()` hook, which re-arms on effect setup. Three of them were not in the issue's table and had the identical defect — `WhileAwayWidget`, `LocalLlmPlayground`, and `UniverseCategoryEditor`'s `editorMountedRef`. They were found by the new guard, which is shape-based rather than name-based for exactly that reason.

**2. The generator toggle was invisible until the track was saved.** The "Audio model" / "Chiptune score" toggle sat inside the `persisted ?` gate in `TracksManager`, so clicking **New Track** rendered nothing at all where the generators belong — no way to learn either generator existed until after the first save.

The gate itself is correct and stays: the server attaches audio and generation metadata to a saved track id. Only its visibility changes. The toggle now renders unconditionally (mode is pure local state and needs no track id), and the unsaved case shows a hint naming the selected mode instead of an empty region. A mode picked before saving now survives **Create** — the hydration effect used to re-derive `genMode` from the brand-new, score-less record and snap a pre-save "Chiptune score" back to "Audio model".

Per the issue's explicit decision, no draft track is auto-created to sidestep the gate.

## Regression guard

`client/src/hooks/mountedRefConventions.test.js` fails when any git-tracked source under `client/src` holds a `useRef(true)` that is assigned `false` and never `true`, pointing the reader at `useMounted`. It self-tests its own detector so the rule cannot rot into a vacuous pass, and its docstring enumerates the shapes it **cannot** see (`let`/`var`, non-literal seed, multi-component files, cross-file refs, aliasing) rather than letting a green run imply coverage. The file-scoped hole is live today — `PostCognitiveDrillRunner` declares three separate `mountedRef`s in one file.

The guard is registered in `scripts/ci-test-plan.js`. Without that it would have run only on a full suite: it has no source sibling and imports no app module, so targeted CI mode selected nothing. Its trigger is deliberately broader than the a11y guard's `.jsx`-only one — the bug reached its widest blast radius through a plain-`.js` hook.

## Test plan

- `cd client && npm test` — **493 files / 5571 tests pass**.
- `cd server && npx vitest run ../scripts/ci-test-plan.test.js` — 11 pass, including a new case pinning that a `.js`-only client change selects the guard (and that the a11y guard, correctly, is not selected).
- `cd client && npx eslint src --max-warnings=0` — clean.
- **Both new StrictMode tests were verified to fail against the broken behavior**, not just to pass against the fix: reverting the `mountedRef.current = true` line inside `useMounted` turns them red and nothing else, then green again on restore.
  - `MusicGenPanel.test.jsx` — renders inside a real `<StrictMode>` and asserts the engine list appears. Every other test in that file mounts the panel bare, which is why this regression was invisible.
  - `useAsyncAction.test.jsx` — asserts `running` returns to `false` and a **second** call still works. The second click is the one that broke.
- `TracksManager.test.jsx` — five new cases: toggle visible and switchable on an unsaved track with the mode-specific hint and no panels; pre-save chiptune choice survives **Create**; an existing scored track still opens on the chiptune panel; an unscored one on the audio panel.

## Known-unrelated failure

`server/services/imageGenQuota.test.js` fails on `main` as of today — verified on a clean checkout of `9fdce37c0` with no local modifications. Its fixture embeds a hardcoded reset timestamp (`2026-07-31T21:38:09Z`) that went into the past, so the parser's past-timestamp fallback takes over and the assertion compares against wall-clock. Filed as #3265; untouched here.

## Follow-ups filed

- #3265 — the `imageGenQuota` time-bomb test above.
- #3266 — thirteen sites still hand-roll `useMounted`'s body *correctly*. Not a correctness fix, so deliberately not folded in; the copy-paste risk is that dropping one setup line reproduces this bug.
- #3267 — `useAsyncAction`'s guard is a no-op on React 19 (the warning it cites was removed in React 18; confirmed absent from the pinned `react-dom` 19.2.8 dev build), and its unmount test asserts on that absent warning, so it cannot fail.

Closes #3264
