### PR TITLE
Pin the clock in imageGenQuota tests so they stop failing after 2026-07-31

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -7,6 +7,7 @@
 
 ## Internal
 
+- **[issue-3265] Fixed a test that broke on its own once the calendar passed 2026-07-31.** An image-quota test compared against a reset timestamp baked into its fixture; once that instant passed, the code correctly ignored the stale time and the test started comparing against the wall clock, failing every run. The test now pins its own clock, and the ignore-a-past-reset path it accidentally exercised has coverage of its own.
 - **[issue-3250] Stabilize Music Video project-selection tests under CI load.** Project-selection coverage now waits for the requested project to be available before opening its board, preventing intermittent false failures.
 
 ## Music Video

--- a/server/services/imageGenQuota.test.js
+++ b/server/services/imageGenQuota.test.js
@@ -27,7 +27,15 @@ const FAB_DIR = await mkdtemp(join(tmpdir(), 'portos-igquota-fab-'));
 await writeFile(join(FAB_DIR, 'render_sheet.py'), 'import matplotlib');
 
 // The verbatim shape Antigravity returned on 2026-07-31 (paths/ids redacted).
-const AGY_429 = 'Agy did not produce an image at the directed path. Agy said: "Here is the error details returned by the API: * **Error Code**: 429 (Resource Exhausted) * **Message**: You have exhausted your capacity on this model. Your quota will reset in approximately 5 hours (around 2026-07-31T21:38:09Z). Since the `generate_image` tool relies entirely on this backend service, I am currently unable to write the requested image to `/tmp/portos-agy-<id>/output.png`. Please try again after the quota resets."';
+// Its "(around 2026-07-31T21:38:09Z)" is an ABSOLUTE instant, and the parser
+// deliberately ignores an absolute reset that has already passed
+// (`imageGenQuota.js` `parseAbsoluteReset`: `at <= now ? null : at`). So every
+// assertion on that instant must pin `now` to before it — otherwise the test
+// silently starts exercising the relative-fallback branch instead, and compares
+// against the wall clock. Reading it off the real clock is what broke this suite
+// on 2026-08-01 (#3265).
+const FIXTURE_NOW = Date.parse('2026-07-31T16:38:09Z'); // 5h before the reset above
+const AGY_429 ='Agy did not produce an image at the directed path. Agy said: "Here is the error details returned by the API: * **Error Code**: 429 (Resource Exhausted) * **Message**: You have exhausted your capacity on this model. Your quota will reset in approximately 5 hours (around 2026-07-31T21:38:09Z). Since the `generate_image` tool relies entirely on this backend service, I am currently unable to write the requested image to `/tmp/portos-agy-<id>/output.png`. Please try again after the quota resets."';
 
 beforeEach(async () => {
   __resetImageGenQuotaHookForTests();
@@ -40,10 +48,20 @@ afterEach(async () => {
 
 describe('parseImageQuotaSignal', () => {
   it('reads the exact 429 the imagen backend returned', () => {
-    const signal = parseImageQuotaSignal(AGY_429);
+    const signal = parseImageQuotaSignal(AGY_429, { now: FIXTURE_NOW });
     expect(signal.exhausted).toBe(true);
     // The parenthetical absolute instant beats the "approximately 5 hours".
     expect(new Date(signal.resetsAt).toISOString()).toBe('2026-07-31T21:38:09.000Z');
+  });
+
+  it('ignores an absolute reset that has already passed and uses the relative window', () => {
+    // The branch that quietly took over when this suite's `now` drifted past the
+    // fixture's instant. Pinning it means a future drift fails loudly instead of
+    // re-routing another test's assertion into here.
+    const now = Date.parse('2026-08-02T00:00:00Z'); // after the message's 21:38:09Z
+    const signal = parseImageQuotaSignal(AGY_429, { now });
+    expect(signal.exhausted).toBe(true);
+    expect(new Date(signal.resetsAt).toISOString()).toBe('2026-08-02T05:00:00.000Z'); // now + 5h
   });
 
   it('falls back to the relative window when no absolute time is given', () => {
@@ -123,6 +141,18 @@ describe('initImageGenQuotaHook', () => {
   // The recorder rides the imageGenEvents bus rather than provider finalizers,
   // so a backend that emits on the bus is tracked without touching its code.
   const flush = () => new Promise((resolve) => setTimeout(resolve, 20));
+
+  // The bus handler stamps its own `Date.now()`, so unlike the `getImageGenQuota`
+  // suite below there is no `now` to thread in — freeze the clock instead.
+  // `shouldAdvanceTime` keeps `flush()`'s real 20ms timer working under the fake
+  // clock; without it the flush promise never settles and the test times out.
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    vi.setSystemTime(FIXTURE_NOW);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
 
   it('records a refused render announced on the bus', async () => {
     initImageGenQuotaHook();


### PR DESCRIPTION
## Summary

`server/services/imageGenQuota.test.js` started failing on every run on 2026-08-01, on `main`, with no code change behind it. Verified on a clean checkout of `9fdce37c0`.

The `AGY_429` fixture quotes a real 429 whose message names an **absolute** reset instant — `(around 2026-07-31T21:38:09Z)`. `parseAbsoluteReset` deliberately refuses a reset that has already passed (`at <= now ? null : at`) and falls through to the relative "approximately 5 hours" window. That is correct behavior. But two tests asserted equality against that literal instant while reading `now` off the real clock, so the moment it passed they began comparing against wall-clock time:

```
AssertionError: expected '2026-08-01T10:25:00.421Z' to be '2026-07-31T21:38:09.000Z'
```

**Production code is untouched** — only the tests assumed a clock. This is a test-only fix that unblocks CI for every open PR.

## Changes

- The parse test pins `now` to five hours before the fixture's instant, so it keeps exercising the absolute-timestamp path it means to test rather than silently sliding onto the fallback.
- The bus-driven tests stamp their own `Date.now()` deep in the handler, so there is no `now` to thread in — they freeze the clock with fake timers instead. `shouldAdvanceTime: true` keeps the suite's real 20ms `flush()` working; without it the flush promise never settles and the test times out.
- Adds the coverage whose absence let this hide: an explicit test that a **past** absolute reset falls back to the relative window. That branch silently took over the failing assertion, which is why the failure read as a wrong value rather than as an untested code path.

## Test plan

- `cd server && npx vitest run services/imageGenQuota.test.js` — 32 pass (was 2 failed / 29 passed).
- `cd server && npm test` — **1133 files / 23706 tests pass**, 24 skipped (DB suites, correctly gated off the non-test database).
- Audited the rest of the file for the same shape: every remaining unpinned `parseImageQuotaSignal` call asserts only `.exhausted` (a boolean) or `resetsAt: null`. No assertion in the file compares against a timestamp derived from the real clock.

Closes #3265
