### PR TITLE
refactor: use parsePagination helper across route handlers

### DIFF
--- a/server/routes/apps/agents.js
+++ b/server/routes/apps/agents.js
@@ -7,6 +7,7 @@
 import { Router } from 'express';
 import * as cos from '../../services/cos.js';
 import { asyncHandler } from '../../lib/errorHandler.js';
+import { parsePagination } from '../../lib/validation.js';
 import { loadApp } from './shared.js';
 
 const router = Router();
@@ -14,7 +15,7 @@ const router = Router();
 // GET /api/apps/:id/agents - Recent CoS agents for this app
 router.get('/:id/agents', loadApp, asyncHandler(async (req, res) => {
   const app = req.loadedApp;
-  const limit = parseInt(req.query.limit, 10) || 50;
+  const { limit } = parsePagination(req.query, { defaultLimit: 50, maxLimit: 500 });
 
   // Get running agents filtered by this app
   const runningAgents = await cos.getAgents().catch(() => []);

--- a/server/routes/brainDailyLog.js
+++ b/server/routes/brainDailyLog.js
@@ -6,7 +6,7 @@
 
 import { Router } from 'express';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { validateRequest } from '../lib/validation.js';
+import { validateRequest, parsePagination } from '../lib/validation.js';
 import { dailyLogSettingsSchema, activityDigestSettingsSchema } from '../lib/brainValidation.js';
 import * as journal from '../services/brainJournal.js';
 import * as activityDigest from '../services/activityDigest.js';
@@ -33,13 +33,7 @@ const resolveJournalDate = async (date) => {
  * List daily log entries (most recent first)
  */
 router.get('/daily-log', asyncHandler(async (req, res) => {
-  // Clamp pagination: negative or zero limit / negative offset would slice
-  // unpredictably (or from the end of the array). Match the convention used
-  // by other paginated brain routes.
-  const parsedLimit = parseInt(req.query.limit, 10);
-  const parsedOffset = parseInt(req.query.offset, 10);
-  const limit = Math.min(Math.max(Number.isNaN(parsedLimit) ? 50 : parsedLimit, 1), 200);
-  const offset = Math.max(Number.isNaN(parsedOffset) ? 0 : parsedOffset, 0);
+  const { limit, offset } = parsePagination(req.query, { defaultLimit: 50, maxLimit: 200 });
   // Opt-in to full entries; default is slim summaries (date + segmentCount +
   // obsidianPath) so the sidebar doesn't pull every day's content on load.
   const includeContent = req.query.includeContent === '1' || req.query.includeContent === 'true';

--- a/server/routes/brainDigest.js
+++ b/server/routes/brainDigest.js
@@ -7,7 +7,7 @@
 import { Router } from 'express';
 import * as brainService from '../services/brain.js';
 import { asyncHandler } from '../lib/errorHandler.js';
-import { validateRequest } from '../lib/validation.js';
+import { validateRequest, parsePagination } from '../lib/validation.js';
 import { brainDigestRunSchema } from '../lib/brainValidation.js';
 
 const router = Router();
@@ -26,7 +26,7 @@ router.get('/digest/latest', asyncHandler(async (req, res) => {
  * Get digest history
  */
 router.get('/digests', asyncHandler(async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 10;
+  const { limit } = parsePagination(req.query, { defaultLimit: 10, maxLimit: 500 });
   const digests = await brainService.getDigests(limit);
   res.json(digests);
 }));
@@ -55,7 +55,7 @@ router.get('/review/latest', asyncHandler(async (req, res) => {
  * Get review history
  */
 router.get('/reviews', asyncHandler(async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 10;
+  const { limit } = parsePagination(req.query, { defaultLimit: 10, maxLimit: 500 });
   const reviews = await brainService.getReviews(limit);
   res.json(reviews);
 }));

--- a/server/routes/catalog.js
+++ b/server/routes/catalog.js
@@ -8,7 +8,7 @@ import { resolveRefs, listDanglingRefs } from '../services/catalogRefResolver.js
 import { projectToCanon } from '../services/catalogCanonProjection.js';
 import { withTransaction } from '../lib/db.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { validateRequest } from '../lib/validation.js';
+import { validateRequest, parsePagination } from '../lib/validation.js';
 import {
   catalogScrapCreateSchema,
   catalogScrapPatchSchema,
@@ -58,8 +58,7 @@ router.get('/stats', asyncHandler(async (req, res) => {
 }));
 
 router.get('/scraps', asyncHandler(async (req, res) => {
-  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 50, 1), 200);
-  const offset = Math.max(parseInt(req.query.offset, 10) || 0, 0);
+  const { limit, offset } = parsePagination(req.query, { defaultLimit: 50, maxLimit: 200 });
   res.json(await catalogDB.listScraps({ limit, offset }));
 }));
 
@@ -713,7 +712,7 @@ router.get('/sync', asyncHandler(async (req, res) => {
       since = (typeof sinceRaw === 'string' && /^\d+$/.test(sinceRaw)) ? sinceRaw : '0';
     }
   }
-  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 100, 1), 1000);
+  const { limit } = parsePagination(req.query, { defaultLimit: 100, maxLimit: 1000 });
   const changes = await catalogSync.getChangesSince(since, limit);
   res.json({
     ...changes,

--- a/server/routes/cosInsightRoutes.js
+++ b/server/routes/cosInsightRoutes.js
@@ -10,6 +10,7 @@ import * as productivity from '../services/productivity.js';
 import * as goalProgress from '../services/goalProgress.js';
 import * as decisionLog from '../services/decisionLog.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
+import { parsePagination } from '../lib/validation.js';
 
 const router = Router();
 
@@ -179,7 +180,7 @@ router.get('/actionable-insights', asyncHandler(async (req, res) => {
 
 // GET /api/cos/recent-tasks - Get recent completed tasks for dashboard widget
 router.get('/recent-tasks', asyncHandler(async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 10;
+  const { limit } = parsePagination(req.query, { defaultLimit: 10, maxLimit: 500 });
   const recentTasks = await cos.getRecentTasks(limit);
   res.json(recentTasks);
 }));
@@ -273,7 +274,7 @@ router.get('/goal-progress/summary', asyncHandler(async (req, res) => {
 
 // GET /api/cos/decisions - Get recent decisions
 router.get('/decisions', asyncHandler(async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 20;
+  const { limit } = parsePagination(req.query, { defaultLimit: 20, maxLimit: 500 });
   const type = req.query.type || null;
   const decisions = await decisionLog.getRecentDecisions(limit, type);
   res.json({ decisions });

--- a/server/routes/cosLearningRoutes.js
+++ b/server/routes/cosLearningRoutes.js
@@ -12,6 +12,7 @@ import {
   dismissRecommendationSchema,
   restoreRecommendationSchema,
   generateWeeklyDigestSchema,
+  parsePagination,
 } from '../lib/validation.js';
 
 const router = Router();
@@ -89,7 +90,7 @@ router.get('/learning/summary', asyncHandler(async (req, res) => {
 
 // GET /api/cos/learning/insights - Get recent learning insights
 router.get('/learning/insights', asyncHandler(async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 10;
+  const { limit } = parsePagination(req.query, { defaultLimit: 10, maxLimit: 500 });
   const insights = await taskLearning.getRecentInsights(limit);
   res.json({
     count: insights.length,

--- a/server/routes/cosScheduleRoutes.js
+++ b/server/routes/cosScheduleRoutes.js
@@ -6,7 +6,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import * as taskSchedule from '../services/taskSchedule.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { sanitizeTaskMetadata, validateRequest } from '../lib/validation.js';
+import { sanitizeTaskMetadata, validateRequest, parsePagination } from '../lib/validation.js';
 import { EFFORT_LEVELS } from '../lib/providerModels.js';
 
 const templateTaskSchema = z.object({
@@ -92,7 +92,7 @@ router.get('/schedule', asyncHandler(async (req, res) => {
 
 // GET /api/cos/upcoming - Get upcoming tasks preview
 router.get('/upcoming', asyncHandler(async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 10;
+  const { limit } = parsePagination(req.query, { defaultLimit: 10, maxLimit: 500 });
   const upcoming = await taskSchedule.getUpcomingTasks(limit);
   res.json(upcoming);
 }));

--- a/server/routes/cosScheduleRoutes.test.js
+++ b/server/routes/cosScheduleRoutes.test.js
@@ -30,6 +30,13 @@ vi.mock('../lib/validation.js', () => ({
     }
     return result.data;
   }),
+  parsePagination: vi.fn((query, { defaultLimit = 50, maxLimit = 200 } = {}) => {
+    const rawLimit = parseInt(query?.limit, 10);
+    const rawOffset = parseInt(query?.offset, 10);
+    const limit = Number.isFinite(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, maxLimit) : defaultLimit;
+    const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
+    return { limit, offset };
+  }),
 }));
 
 import * as taskSchedule from '../services/taskSchedule.js';

--- a/server/routes/cosTemplateRoutes.js
+++ b/server/routes/cosTemplateRoutes.js
@@ -5,7 +5,7 @@
 import { Router } from 'express';
 import * as taskTemplates from '../services/taskTemplates.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { validateRequest } from '../lib/validation.js';
+import { validateRequest, parsePagination } from '../lib/validation.js';
 import {
   createTaskTemplateSchema,
   updateTaskTemplateSchema,
@@ -22,7 +22,7 @@ router.get('/templates', asyncHandler(async (req, res) => {
 
 // GET /api/cos/templates/popular - Get popular templates
 router.get('/templates/popular', asyncHandler(async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 5;
+  const { limit } = parsePagination(req.query, { defaultLimit: 5, maxLimit: 500 });
   const templates = await taskTemplates.getPopularTemplates(limit);
   res.json({ templates });
 }));

--- a/server/routes/digital-twin/feedback.js
+++ b/server/routes/digital-twin/feedback.js
@@ -6,7 +6,7 @@
 import { Router } from 'express';
 import * as feedbackService from '../../services/feedbackLoop.js';
 import { asyncHandler } from '../../lib/errorHandler.js';
-import { validateRequest } from '../../lib/validation.js';
+import { validateRequest, parsePagination } from '../../lib/validation.js';
 import { feedbackInputSchema } from '../../lib/digitalTwinValidation.js';
 
 const router = Router();
@@ -45,7 +45,7 @@ router.post('/feedback/recalculate', asyncHandler(async (req, res) => {
  */
 router.get('/feedback/recent', asyncHandler(async (req, res) => {
   const contentType = req.query.contentType || null;
-  const limit = Math.min(parseInt(req.query.limit, 10) || 20, 50);
+  const { limit } = parsePagination(req.query, { defaultLimit: 20, maxLimit: 50 });
   const entries = await feedbackService.getRecentFeedback(contentType, limit);
   res.json(entries);
 }));

--- a/server/routes/featureAgents.js
+++ b/server/routes/featureAgents.js
@@ -4,7 +4,7 @@
 
 import { Router } from 'express';
 import * as featureAgents from '../services/featureAgents.js';
-import { validateRequest, featureAgentSchema, featureAgentUpdateSchema } from '../lib/validation.js';
+import { validateRequest, featureAgentSchema, featureAgentUpdateSchema, parsePagination } from '../lib/validation.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 
 const router = Router();
@@ -82,7 +82,7 @@ router.post('/:id/stop', asyncHandler(async (req, res) => {
 
 // GET /:id/runs - Run history
 router.get('/:id/runs', asyncHandler(async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 20;
+  const { limit } = parsePagination(req.query, { defaultLimit: 20, maxLimit: 500 });
   const runs = await featureAgents.getFeatureAgentRuns(req.params.id, limit);
   res.json(runs);
 }));

--- a/server/routes/loras.js
+++ b/server/routes/loras.js
@@ -11,7 +11,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 import { asyncHandler } from '../lib/errorHandler.js';
 import { deepMerge, isPlainObject } from '../lib/objects.js';
-import { emptyToUndefined, validateRequest, isPaginationRequested, paginateArray } from '../lib/validation.js';
+import { emptyToUndefined, validateRequest, isPaginationRequested, paginateArray, parsePagination } from '../lib/validation.js';
 import {
   deleteLora,
   getLora,
@@ -47,7 +47,7 @@ router.get('/', asyncHandler(async (req, res) => {
 // panel; users can paste a URL for anything specific.
 router.get('/suggestions', asyncHandler(async (req, res) => {
   const force = req.query.force === '1' || req.query.force === 'true';
-  const limit = Math.max(1, Math.min(24, Number(req.query.limit) || 4));
+  const { limit } = parsePagination(req.query, { defaultLimit: 4, maxLimit: 24 });
   const [civitai, video] = await Promise.all([
     getSuggestions({ force, limit }),
     getVideoSuggestions({ force }),

--- a/server/routes/meatspacePostRoutes.js
+++ b/server/routes/meatspacePostRoutes.js
@@ -7,7 +7,7 @@
 
 import { Router } from 'express';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { validateRequest } from '../lib/validation.js';
+import { validateRequest, parsePagination } from '../lib/validation.js';
 import {
   postSessionSubmitSchema,
   postConfigUpdateSchema,
@@ -318,7 +318,7 @@ router.get('/post/training/stats', asyncHandler(async (req, res) => {
  * Recent training entries
  */
 router.get('/post/training/entries', asyncHandler(async (req, res) => {
-  const limit = Math.min(parseInt(req.query.limit, 10) || 20, 100);
+  const { limit } = parsePagination(req.query, { defaultLimit: 20, maxLimit: 100 });
   const entries = await trainingService.getTrainingEntries(limit);
   res.json(entries);
 }));

--- a/server/routes/memory.js
+++ b/server/routes/memory.js
@@ -9,7 +9,7 @@ import * as embeddings from '../services/memoryEmbeddings.js';
 import * as memorySync from '../services/memorySync.js';
 import { checkHealth } from '../lib/db.js';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { validateRequest } from '../lib/validation.js';
+import { validateRequest, parsePagination } from '../lib/validation.js';
 import {
   memoryCreateSchema,
   memoryUpdateSchema,
@@ -25,14 +25,15 @@ const router = Router();
 
 // GET /api/memory - List memories with filters
 router.get('/', asyncHandler(async (req, res) => {
+  const { limit, offset } = parsePagination(req.query, { defaultLimit: 50, maxLimit: 500 });
   const options = {
     types: req.query.types ? req.query.types.split(',') : undefined,
     categories: req.query.categories ? req.query.categories.split(',') : undefined,
     tags: req.query.tags ? req.query.tags.split(',') : undefined,
     status: req.query.status || 'active',
     appId: req.query.appId || undefined,
-    limit: parseInt(req.query.limit, 10) || 50,
-    offset: parseInt(req.query.offset, 10) || 0,
+    limit,
+    offset,
     sortBy: req.query.sortBy || 'createdAt',
     sortOrder: req.query.sortOrder || 'desc'
   };
@@ -61,11 +62,12 @@ router.get('/tags', asyncHandler(async (req, res) => {
 
 // GET /api/memory/timeline - Get timeline view
 router.get('/timeline', asyncHandler(async (req, res) => {
+  const { limit } = parsePagination(req.query, { defaultLimit: 100, maxLimit: 500 });
   const options = {
     startDate: req.query.startDate,
     endDate: req.query.endDate,
     types: req.query.types ? req.query.types.split(',') : undefined,
-    limit: parseInt(req.query.limit, 10) || 100
+    limit
   };
 
   const timeline = await memory.getTimeline(options);
@@ -92,7 +94,7 @@ router.get('/sync', asyncHandler(async (req, res) => {
     throw new ServerError('Sync requires PostgreSQL backend', { status: 400 });
   }
   const since = /^\d+$/.test(req.query.since) ? req.query.since : '0';
-  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 100, 1), 1000);
+  const { limit } = parsePagination(req.query, { defaultLimit: 100, maxLimit: 1000 });
   const result = await memorySync.getChangesSince(since, limit);
   res.json(result);
 }));
@@ -187,7 +189,7 @@ router.get('/:id', asyncHandler(async (req, res) => {
 
 // GET /api/memory/:id/related - Get related memories
 router.get('/:id/related', asyncHandler(async (req, res) => {
-  const limit = parseInt(req.query.limit, 10) || 10;
+  const { limit } = parsePagination(req.query, { defaultLimit: 10, maxLimit: 500 });
   const related = await memory.getRelatedMemories(req.params.id, limit);
   res.json(related);
 }));

--- a/server/routes/tribe.js
+++ b/server/routes/tribe.js
@@ -2,7 +2,7 @@ import { Router } from 'express';
 import { z } from 'zod';
 
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
-import { validateRequest } from '../lib/validation.js';
+import { validateRequest, parsePagination } from '../lib/validation.js';
 import { partialWithoutDefaults } from '../lib/zodCompat.js';
 import * as tribe from '../services/tribe.js';
 import * as tribeOutreach from '../services/tribeOutreach.js';
@@ -111,7 +111,7 @@ router.get('/people', asyncHandler(async (req, res) => {
 // Care summary — overdue-contact status computed server-side (single source of
 // truth) for the dashboard widget and proactive-alerts check.
 router.get('/care', asyncHandler(async (req, res) => {
-  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 5, 1), 50);
+  const { limit } = parsePagination(req.query, { defaultLimit: 5, maxLimit: 50 });
   const summary = await tribe.getCareSummary(limit);
   res.json(summary);
 }));
@@ -120,7 +120,7 @@ router.get('/care', asyncHandler(async (req, res) => {
 // timeline (#2158). Detection only — NO LLM. Feeds the Tribe Outreach panel and
 // mirrors the `tribe_unanswered` proactive alert.
 router.get('/outreach', asyncHandler(async (req, res) => {
-  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 8, 1), 50);
+  const { limit } = parsePagination(req.query, { defaultLimit: 8, maxLimit: 50 });
   const threads = await tribeOutreach.findUnansweredTribeThreads({ limit });
   res.json({ threads });
 }));
@@ -164,7 +164,7 @@ router.delete('/people/:id', asyncHandler(async (req, res) => {
 }));
 
 router.get('/people/:id/touchpoints', asyncHandler(async (req, res) => {
-  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 50, 1), 200);
+  const { limit } = parsePagination(req.query, { defaultLimit: 50, maxLimit: 200 });
   const touchpoints = await tribe.listTouchpoints(req.params.id, limit);
   res.json({ touchpoints });
 }));


### PR DESCRIPTION
## Better Audit — DRY & YAGNI

Replaces 22 hand-rolled pagination-parsing sites across 15 route files with the existing `parsePagination` helper in `server/lib/validation.js`.

### Why this is a behaviour fix, not just deduplication
The hand-rolled pattern was `const limit = parseInt(req.query.limit, 10) || N`:
- `limit=0` and negative values are falsy, so they silently substituted the default instead of clamping.
- Several sites had **no max clamp at all**, so `?limit=999999` was honoured all the way to the datastore.

### New `maxLimit` ceilings
Chosen generously (500) wherever a site previously had none, so no existing caller can be truncated: `apps/agents.js`, `brainDigest.js` (digests, reviews), `cosInsightRoutes.js` (recent-tasks, decisions), `cosLearningRoutes.js`, `cosScheduleRoutes.js` (upcoming), `cosTemplateRoutes.js` (templates, popular), `featureAgents.js` (`:id/runs`), `memory.js` (list, timeline, `:id/related`).

Sites that already clamped keep their exact prior default/max: `brainDailyLog.js`, `catalog.js`, `digital-twin/feedback.js`, `loras.js`, `meatspacePostRoutes.js`, `memory.js` sync, `tribe.js`.

### 3 sites deliberately skipped
Substituting a numeric default would have changed the contract:
- `meatspacePostRoutes.js` `/post/recommendations` — absent `limit` passes `undefined` so the service applies its own default.
- `meatspacePostRoutes.js` `/post/review/reps` — explicitly allows `limit=0` to mean "return zero reps".
- `notifications.js` — `limit: undefined` means **unbounded**; a numeric default would newly truncate a previously-unbounded response.

### Test plan
- `cd server && MEMORY_BACKEND=file npx vitest run routes/` → 118 files / 2477 tests pass on this branch alone.
- Full server suite shows no new failures (3 pre-existing failures are unrelated and also fail on `main`).
- `cosScheduleRoutes.test.js` mocks `lib/validation.js` directly, so its mock gained a `parsePagination` implementation matching the real helper's clamp semantics.
- The helper's boundary contract is pinned by new direct tests in the companion `better/tests` PR.

Found by a `/do:better` DevSecOps audit (2026-08-01).
