### PR TITLE
fix: stop a failed settings fetch from resetting the Universe Builder image-gen mode

### DIFF
--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -29,6 +29,11 @@ import {
   normalizeCategoryKey,
 } from '../lib/universeBuilderShared';
 
+// Distinguishes "this request failed" from "this request returned nothing". A unique
+// object is used rather than null/undefined so it can never collide with a legitimate
+// empty payload from any of the endpoints refresh() fans out to.
+const FETCH_FAILED = Symbol('fetch-failed');
+
 export const createEmptyUniverseDraft = () => ({
   name: '',
   starterPrompt: '',
@@ -164,23 +169,35 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
 
   const refresh = async () => {
     setLoading(true);
+    // FETCH_FAILED is a sentinel, not a value: it keeps "the request failed" distinct
+    // from "the request succeeded and the answer is empty". Collapsing both to `[]`/`{}`
+    // is what made a transient blip look identical to an unconfigured install — and, for
+    // settings, silently rewrote the user's saved image-gen mode (see below).
     const [list, providerData, models, loras, settings] = await Promise.all([
-      listUniverses().catch(() => []),
-      getProviders().catch(() => ({ providers: [] })),
-      listImageModels().catch(() => []),
-      listLorasFull().catch(() => []),
-      getSettings().catch(() => ({})),
+      listUniverses().catch(() => FETCH_FAILED),
+      getProviders().catch(() => FETCH_FAILED),
+      listImageModels().catch(() => FETCH_FAILED),
+      listLorasFull().catch(() => FETCH_FAILED),
+      getSettings().catch(() => FETCH_FAILED),
     ]);
-    setWorlds(list);
-    setProviders(providerData.providers || []);
-    setActiveProviderId(providerData.activeProvider || null);
-    setImageModels(models || []);
-    setAvailableLoras(Array.isArray(loras) ? loras : []);
-    const backends = deriveAvailableBackends(settings, { excludeExternal: true });
-    setAvailableBackends(backends);
-    const saved = settings?.imageGen?.mode;
-    setDefaultMode(backends.find((backend) => backend.id === saved)?.id || backends[0]?.id || IMAGE_GEN_MODE.LOCAL);
-    setImageCfg(readPipelineImageSettings(settings));
+    if (list !== FETCH_FAILED) setWorlds(list);
+    if (providerData !== FETCH_FAILED) {
+      setProviders(providerData.providers || []);
+      setActiveProviderId(providerData.activeProvider || null);
+    }
+    if (models !== FETCH_FAILED) setImageModels(models || []);
+    if (loras !== FETCH_FAILED) setAvailableLoras(Array.isArray(loras) ? loras : []);
+    // Deriving the backend list / default mode / image config from a `{}` stand-in on a
+    // failed settings read reset the picker to IMAGE_GEN_MODE.LOCAL and the pipeline
+    // image config to defaults — overwriting the user's real configuration because a
+    // request happened to fail. Leave all three at their last-known-good values instead.
+    if (settings !== FETCH_FAILED) {
+      const backends = deriveAvailableBackends(settings, { excludeExternal: true });
+      setAvailableBackends(backends);
+      const saved = settings?.imageGen?.mode;
+      setDefaultMode(backends.find((backend) => backend.id === saved)?.id || backends[0]?.id || IMAGE_GEN_MODE.LOCAL);
+      setImageCfg(readPipelineImageSettings(settings));
+    }
     setLoading(false);
   };
 
@@ -585,6 +602,9 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     providerLabel,
     providerModels,
     providers,
+    // Exposed so a consumer can retry the catalog/settings load after a failed
+    // refresh instead of forcing a full page reload.
+    refresh,
     persistStyleReference,
     removeCategory,
     removeStyleReference,

--- a/client/src/hooks/useUniverseDraft.test.jsx
+++ b/client/src/hooks/useUniverseDraft.test.jsx
@@ -124,6 +124,73 @@ describe('useUniverseDraft', () => {
     expect(result.current.isDraftDirty()).toBe(false);
   });
 
+  // A failed fetch and an empty response must not land in the same state. The refresh()
+  // fan-out used to `.catch(() => [])` / `.catch(() => ({}))` every call, so a transient
+  // failure was indistinguishable from a real empty answer — and for settings it was
+  // actively destructive, since deriving from a `{}` stand-in reset the user's saved
+  // image-gen mode and pipeline image config to defaults.
+  describe('refresh() failure handling', () => {
+    // NOTE: refresh() runs from a mount-only effect, so a rerender() does NOT re-run it.
+    // These tests invoke result.current.refresh() directly — otherwise the second load
+    // never happens and the assertions pass vacuously against untouched initial state.
+    it('keeps the last-known image-gen mode and config when the settings fetch fails', async () => {
+      apiMocks.getSettings.mockResolvedValue({ imageGen: { mode: 'local' }, localImageGen: {} });
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      const modeBefore = result.current.defaultMode;
+      const cfgBefore = result.current.imageCfg;
+      const backendsBefore = result.current.availableBackends;
+      expect(modeBefore).toBeTruthy();
+
+      // Second load fails. Nothing derived from settings may change.
+      apiMocks.getSettings.mockRejectedValueOnce(new Error('network blip'));
+      await act(async () => { await result.current.refresh(); });
+
+      expect(result.current.defaultMode).toBe(modeBefore);
+      expect(result.current.imageCfg).toEqual(cfgBefore);
+      expect(result.current.availableBackends).toEqual(backendsBefore);
+    });
+
+    it('keeps the previously loaded providers and image models when their fetches fail', async () => {
+      apiMocks.getProviders.mockResolvedValue({
+        providers: [{ id: 'p1', name: 'Provider One' }], activeProvider: 'p1',
+      });
+      apiMocks.listImageModels.mockResolvedValue([{ id: 'm1' }]);
+      apiMocks.listLorasFull.mockResolvedValue([{ id: 'l1' }]);
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.providers).toHaveLength(1));
+
+      apiMocks.getProviders.mockRejectedValueOnce(new Error('down'));
+      apiMocks.listImageModels.mockRejectedValueOnce(new Error('down'));
+      apiMocks.listLorasFull.mockRejectedValueOnce(new Error('down'));
+      await act(async () => { await result.current.refresh(); });
+
+      // Not wiped to [] — a failed read is not evidence that nothing is configured.
+      expect(result.current.providers).toEqual([{ id: 'p1', name: 'Provider One' }]);
+      expect(result.current.activeProviderId).toBe('p1');
+      expect(result.current.imageModels).toEqual([{ id: 'm1' }]);
+      expect(result.current.availableLoras).toEqual([{ id: 'l1' }]);
+    });
+
+    it('still applies a genuinely empty response (empty is not treated as failure)', async () => {
+      apiMocks.getProviders.mockResolvedValue({
+        providers: [{ id: 'p1', name: 'Provider One' }], activeProvider: 'p1',
+      });
+      apiMocks.listImageModels.mockResolvedValue([{ id: 'm1' }]);
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.providers).toHaveLength(1));
+
+      apiMocks.getProviders.mockResolvedValueOnce({ providers: [], activeProvider: null });
+      apiMocks.listImageModels.mockResolvedValueOnce([]);
+      await act(async () => { await result.current.refresh(); });
+
+      expect(result.current.providers).toEqual([]);
+      expect(result.current.activeProviderId).toBe(null);
+      expect(result.current.imageModels).toEqual([]);
+    });
+  });
+
   it('saves general draft edits without replacing canon when canon is clean', async () => {
     const { result } = renderDraft();
     await waitFor(() => expect(result.current.draft.id).toBe('u1'));


### PR DESCRIPTION
## Better Audit — Bugs, Performance & Error Handling

`useUniverseDraft`'s `refresh()` fans out five requests and gave every one a `.catch(() => [])` / `.catch(() => ({}))` fallback, so **"the request failed" and "the request returned nothing" landed in identical state**.

### Concrete wrong outcome
For the list reads, a transient blip made the Universe Builder render exactly like an unconfigured install (empty provider/model dropdowns). For settings it was actively destructive: deriving `availableBackends` / `defaultMode` / `imageCfg` from a `{}` stand-in reset the user's saved image-gen mode to `IMAGE_GEN_MODE.LOCAL` and the pipeline image config to defaults — overwriting real configuration because a request happened to fail.

This is the absent-vs-empty conflation the project convention calls out, and the same codebase already demonstrates the correct pattern at `client/src/pages/Sprites.jsx:503-505` (`null` = not loaded, `[]` = loaded and empty) — so this was an inconsistency, not an accepted idiom.

### Fix
Each call now resolves to a `FETCH_FAILED` sentinel on rejection, and its state is left at the last known-good value. A genuinely empty response still applies normally. `refresh()` is also returned from the hook so a consumer can retry without a full page reload.

### Test plan
Three new cases in `useUniverseDraft.test.jsx`, all verified falsifiable — reverting the source change fails all three:
1. A failed settings fetch leaves `defaultMode` / `imageCfg` / `availableBackends` untouched.
2. Failed provider/model/LoRA fetches leave the previously loaded values intact.
3. A genuinely empty response still applies (empty is not treated as failure).

Note: these tests drive `result.current.refresh()` directly. `refresh()` runs from a mount-only effect, so a `rerender()` does **not** re-run it — an earlier draft of these tests passed vacuously against untouched initial state until that was corrected.

Full client suite green (499 files / 5617 tests).

Found by a `/do:better` DevSecOps audit (2026-08-01).
