### PR TITLE
fix: guard async fetch effects against stale responses, name the calendar expand toggle

### DIFF
--- a/client/src/components/calendar/ConfigTab.jsx
+++ b/client/src/components/calendar/ConfigTab.jsx
@@ -284,7 +284,12 @@ export default function ConfigTab({ accounts, setAccounts }) {
                 <div className="flex items-center justify-between p-4">
                   <div className="flex items-center gap-3">
                     {isGoogle && (
-                      <button onClick={() => toggleExpand(account.id)} className="p-0.5 text-gray-500 hover:text-white">
+                      <button
+                        onClick={() => toggleExpand(account.id)}
+                        aria-label={isExpanded ? `Collapse calendars for ${account.name}` : `Expand calendars for ${account.name}`}
+                        aria-expanded={isExpanded}
+                        className="p-0.5 text-gray-500 hover:text-white"
+                      >
                         {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
                       </button>
                     )}

--- a/client/src/components/feature-agents/OutputTab.jsx
+++ b/client/src/components/feature-agents/OutputTab.jsx
@@ -9,8 +9,10 @@ export default function OutputTab({ agent }) {
   const bottomRef = useRef(null);
 
   useEffect(() => {
+    let cancelled = false;
     const fetch = () => {
       api.getFeatureAgentOutput(agent.id).then(data => {
+        if (cancelled) return;
         if (data) {
           setOutput(data.output || '');
           setAgentId(data.agentId);
@@ -28,6 +30,7 @@ export default function OutputTab({ agent }) {
     socket.on('cos:feature-agent:output', handler);
 
     return () => {
+      cancelled = true;
       socket.off('cos:agent:output', handler);
       socket.off('cos:feature-agent:output', handler);
     };

--- a/client/src/components/feature-agents/OutputTab.test.jsx
+++ b/client/src/components/feature-agents/OutputTab.test.jsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+
+const getFeatureAgentOutput = vi.fn();
+
+vi.mock('../../services/api', () => ({
+  getFeatureAgentOutput: (...args) => getFeatureAgentOutput(...args),
+}));
+
+vi.mock('../../services/socket', () => ({
+  default: {
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
+import OutputTab from './OutputTab.jsx';
+
+beforeEach(() => {
+  getFeatureAgentOutput.mockReset();
+});
+
+describe('OutputTab staleness', () => {
+  it('does not let a slow prior agent response overwrite the newer agent selection', async () => {
+    // Agent A's fetch resolves late; agent B's fetch resolves fast.
+    let resolveA;
+    const aPromise = new Promise((res) => { resolveA = res; });
+    getFeatureAgentOutput.mockImplementation((agentId) => {
+      if (agentId === 'agent-a') return aPromise;
+      if (agentId === 'agent-b') return Promise.resolve({ output: 'B output', agentId: 'run-b' });
+      return Promise.resolve(null);
+    });
+
+    const { rerender } = render(<OutputTab agent={{ id: 'agent-a', currentAgentId: null }} />);
+
+    // Switch to agent B before A's fetch resolves — B's effect cleanup marks
+    // A's in-flight fetch cancelled.
+    rerender(<OutputTab agent={{ id: 'agent-b', currentAgentId: null }} />);
+    await act(async () => {});
+
+    expect(screen.getByText(/B output/)).toBeInTheDocument();
+    expect(screen.getByText(/run-b/)).toBeInTheDocument();
+
+    // Now the stale agent-A response finally arrives — it must be ignored.
+    await act(async () => {
+      resolveA({ output: 'A output', agentId: 'run-a' });
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText(/B output/)).toBeInTheDocument();
+    expect(screen.getByText(/run-b/)).toBeInTheDocument();
+    expect(screen.queryByText(/A output/)).not.toBeInTheDocument();
+  });
+});

--- a/client/src/components/feature-agents/RunsTab.jsx
+++ b/client/src/components/feature-agents/RunsTab.jsx
@@ -10,10 +10,13 @@ export default function RunsTab({ agent }) {
   const [expanded, setExpanded] = useState({});
 
   useEffect(() => {
+    let cancelled = false;
     api.getFeatureAgentRuns(agent.id, 50).then(data => {
+      if (cancelled) return;
       setRuns(data || []);
       setLoading(false);
-    }).catch(() => setLoading(false));
+    }).catch(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
   }, [agent.id]);
 
   if (loading) {

--- a/client/src/components/messages/MessageDetail.jsx
+++ b/client/src/components/messages/MessageDetail.jsx
@@ -98,11 +98,13 @@ export default function MessageDetail({ message, accounts, onBack }) {
   // Load thread messages if this message is part of a thread
   useEffect(() => {
     if (!message.threadId || !message.accountId) return;
+    let cancelled = false;
     setThreadLoading(true);
     api.getMessageThread(message.accountId, message.threadId)
-      .then(data => setThreadMessages(data?.messages || []))
-      .catch(() => setThreadMessages([]))
-      .finally(() => setThreadLoading(false));
+      .then(data => { if (!cancelled) setThreadMessages(data?.messages || []); })
+      .catch(() => { if (!cancelled) setThreadMessages([]); })
+      .finally(() => { if (!cancelled) setThreadLoading(false); });
+    return () => { cancelled = true; };
   }, [message.threadId, message.accountId]);
 
   const handleRefresh = async () => {


### PR DESCRIPTION
## Better Audit — Stack-Specific (React)

Two independent React correctness/accessibility fixes.

### 1. Stale async responses overwriting a newer selection (3 components)
A data-fetching `useEffect` with no cancellation guard lets a slow response for a previous selection land *after* the effect re-ran for a new one:

- `client/src/components/feature-agents/OutputTab.jsx` — open Agent A's Output tab, switch to Agent B before A resolves, and A's response overwrites B's already-loaded output **and** `agentId`. Worst of the three, because the corrupted `agentId` is secondary state that does not self-heal.
- `client/src/components/feature-agents/RunsTab.jsx` — same class; can show one agent's run history under another. Self-corrects on the next fetch.
- `client/src/components/messages/MessageDetail.jsx` — selecting message A then quickly message B can render A's thread under B's detail view.

Each now declares `let cancelled = false`, gates **every** state setter (including error and loading-state setters) on it, and returns a `() => { cancelled = true; }` cleanup. The idiom is copied verbatim from the existing `client/src/components/apps/ReferenceReposPanel.jsx` rather than introducing `AbortController` or a new shared hook.

### 2. Unnamed calendar expand toggle
`client/src/components/calendar/ConfigTab.jsx` — the chevron that expands an account's subcalendar list rendered only an icon, with no `aria-label` and no `aria-expanded`. It is keyboard-reachable, but a screen-reader user heard only "button", with no indication of what it does or whether the section is open. Both attributes added, using the `isExpanded` state already in scope.

### Test plan
New `OutputTab.test.jsx` renders with agent A (fetch held pending), rerenders with agent B (resolves immediately), then resolves A afterwards and asserts B's output and `agentId` still display and A's never appears. Verified falsifiable — reverting `OutputTab.jsx` fails the test with A's output clobbering B's in the DOM.

Full client suite green (499 files / 5617 tests); build succeeds.

Found by a `/do:better` DevSecOps audit (2026-08-01).
