### PR TITLE
fix: pair the VideoGen Image Strength label with its slider

### DIFF
--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -1943,10 +1943,11 @@ export default function VideoGen() {
             {(mode === 'image' || (mode === 'extend' && currentModel?.runtime !== 'ltx2')) && (
               <div className="col-span-2 sm:col-span-3">
                 <div className="flex items-center justify-between gap-3 mb-1">
-                  <label className="block text-xs font-medium text-gray-400">Image Strength</label>
+                  <label htmlFor="video-image-strength" className="block text-xs font-medium text-gray-400">Image Strength</label>
                   <span className="text-[11px] text-gray-500">{imageStrength || '1.0'}</span>
                 </div>
                 <input
+                  id="video-image-strength"
                   type="range" min={0} max={1} step={0.05}
                   value={imageStrength || 1}
                   onChange={(e) => setImageStrength(e.target.value)}


### PR DESCRIPTION
## Better Audit — Code Quality & Style

`client/src/pages/VideoGen.jsx` — the "Image Strength" `<label>` carried no `htmlFor` and its range `<input>` no `id`, unlike every sibling field on the same form (which either uses `FormField`'s `useId` wiring or a hand-written pair such as `video-seed` / `chunks-select`).

### Wrong outcome
Clicking the "Image Strength" text did nothing instead of focusing the slider — while clicking the adjacent "Steps" or "CFG Scale" labels does — and a screen reader announced the control with no accessible name. This violates the documented `htmlFor`/`id` pairing convention in `client/src/CLAUDE.md`.

Fixed by adding the matching `htmlFor` / `id="video-image-strength"` pair. The surrounding row (label plus a live value readout) is kept as-is rather than converted to `FormField`, so rendering is unchanged.

### Test plan
`cd client && npx vitest run src/pages/VideoGen` passes; full client suite green (499 files / 5617 tests).

Found by a `/do:better` DevSecOps audit (2026-08-01).
