### PR TITLE
fix: collapse VideoGen advanced params so Generate sits above the fold (#3279)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -57,6 +57,7 @@
 
 - **Clicking the "Image Strength" label now focuses its slider.** The label was never associated with its input, so unlike every other field on the form clicking it did nothing, and a screen reader announced the slider with no name.
 - **[issue-3248] Requeued local videos now keep their original render controls when Grok is the default.** Frame count, frame rate, steps, guidance, seed, image strength, and tiling settings keep the render on the local backend instead of being silently discarded.
+- **[issue-3279] Generate is back above the fold on the Video tab.** Frames, chunks, frame rate, seed, steps, CFG scale, image strength, tiling and the audio flags now sit behind a closed-by-default "Advanced" disclosure, leaving Model and Resolution inline exactly like the sibling Image tab — so the button that starts the render is on screen when you finish typing the prompt instead of roughly 600px below it. The collapsed header still shows the frame count, frame rate and seed a remix carried in, and every value survives collapsing.
 
 ## Sprite Manager
 

--- a/client/src/components/videoGen/AdvancedParamsPanel.jsx
+++ b/client/src/components/videoGen/AdvancedParamsPanel.jsx
@@ -1,0 +1,222 @@
+/**
+ * "Advanced" disclosure for the local-backend sampler knobs — frames, chunks,
+ * fps, seed, steps, CFG scale, image strength, tiling and the audio flags.
+ *
+ * Closed by default so the Generate button sits above the fold on /media/video
+ * the way it already does on the sibling /media/image tab (issue #3279), which
+ * keeps only Model + Resolution inline too. Every value lives in the VideoGen
+ * page's state, so collapsing the panel never discards one — and the collapsed
+ * summary line surfaces the values a remix most often carries in (frames, fps,
+ * seed) without making the user expand to see them.
+ *
+ * Presentational: all state and handlers are owned by the VideoGen page.
+ *
+ * The body is conditionally rendered rather than merely hidden on purpose: a
+ * number input that is out of its min/max range while invisible would make the
+ * browser refuse the form submit ("invalid form control is not focusable"), so
+ * a half-typed Steps/CFG value behind a collapsed panel must not be in the DOM.
+ */
+import { useState } from 'react';
+import { ChevronDown, Dice5 } from 'lucide-react';
+import { FormField } from '../ui/FormField';
+import { FRAME_OPTIONS, FPS_OPTIONS } from '../../lib/videoGenParams.js';
+import { VIDEO_TILING_OPTIONS } from '../../lib/videoTilingOptions';
+
+const CHUNK_OPTIONS = [1, 2, 3, 4, 5, 6, 7, 8];
+
+const inputCls = 'w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50';
+
+export default function AdvancedParamsPanel({
+  mode,
+  currentModel,
+  numFrames, onNumFramesChange,
+  chunks, onChunksChange, keyframesActive,
+  fps, onFpsChange,
+  seed, onSeedChange, onRandomSeed,
+  steps, onStepsChange,
+  guidanceScale, onGuidanceScaleChange,
+  imageStrength, onImageStrengthChange,
+  tiling, onTilingChange,
+  disableAudio, onDisableAudioChange,
+  noMusic, onNoMusicChange,
+}) {
+  const [open, setOpen] = useState(false);
+  // a2v derives its length + audio track from the uploaded audio, so chunking
+  // and the audio flags don't apply there.
+  const showAudioFlags = mode !== 'a2v';
+  const showChunks = mode !== 'a2v';
+  // ltx2 extend conditions on the source's latent rather than a single frame,
+  // so image strength is meaningless for it.
+  const showImageStrength = mode === 'image' || (mode === 'extend' && currentModel?.runtime !== 'ltx2');
+
+  const summary = `${numFrames}f @ ${fps}fps · ${(numFrames / fps).toFixed(1)}s · seed ${seed === '' || seed == null ? 'random' : seed}`;
+
+  return (
+    <div className="border-t border-port-border pt-2">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-controls="video-advanced-params"
+        className="w-full flex items-center gap-2 text-xs font-medium text-gray-400 hover:text-white min-h-[32px]"
+      >
+        <ChevronDown className={`w-3.5 h-3.5 shrink-0 transition-transform ${open ? '' : '-rotate-90'}`} />
+        <span>Advanced</span>
+        <span className="font-normal text-[11px] text-gray-500 truncate">{summary}</span>
+      </button>
+
+      {open && (
+        <div id="video-advanced-params" className="grid grid-cols-2 sm:grid-cols-3 gap-3 mt-3">
+          <FormField label="Frames" labelClassName="block text-xs font-medium text-gray-400 mb-1">
+            <select
+              value={numFrames}
+              onChange={(e) => onNumFramesChange(Number(e.target.value))}
+              className={inputCls}
+            >
+              {FRAME_OPTIONS.map((f) => <option key={f} value={f}>{f} ({(f / fps).toFixed(1)}s @ {fps}fps)</option>)}
+            </select>
+            {numFrames > 241 && (
+              <p className="text-[10px] text-gray-500 leading-snug mt-1">
+                Past 241 frames a single-pass render may swap or OOM at 48 GB. For reliable longer clips, render up to ~10s and then use <strong>Extend</strong> on the result — it conditions on the source&apos;s full latent rather than a single last frame.
+              </p>
+            )}
+          </FormField>
+
+          {showChunks && (
+            <div>
+              <label htmlFor="chunks-select" className="block text-xs font-medium text-gray-400 mb-1" title="Chain N renders end-to-end. Each chunk's last frame seeds the next, then they're stitched into one clip. Wall time scales linearly with chunks.">
+                Chunks
+              </label>
+              <select
+                id="chunks-select"
+                value={keyframesActive ? 1 : chunks}
+                onChange={(e) => onChunksChange(Number(e.target.value))}
+                disabled={keyframesActive}
+                title={keyframesActive ? 'Multi-keyframe renders anchor a single clip — chunking is unavailable.' : undefined}
+                className={`${inputCls} disabled:cursor-not-allowed`}
+              >
+                {CHUNK_OPTIONS.map((n) => (
+                  <option key={n} value={n}>
+                    {n === 1 ? '1 (single)' : `${n} (~${((n * numFrames) / fps).toFixed(0)}s total)`}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
+
+          <FormField label="FPS" labelClassName="block text-xs font-medium text-gray-400 mb-1">
+            <select
+              value={fps}
+              onChange={(e) => onFpsChange(Number(e.target.value))}
+              className={inputCls}
+            >
+              {FPS_OPTIONS.map((f) => <option key={f} value={f}>{f}</option>)}
+            </select>
+          </FormField>
+
+          <div>
+            <label htmlFor="video-seed" className="block text-xs font-medium text-gray-400 mb-1">Seed</label>
+            <div className="flex items-center gap-1">
+              <input
+                id="video-seed"
+                type="number"
+                value={seed}
+                onChange={(e) => onSeedChange(e.target.value)}
+                placeholder="Random"
+                className={`flex-1 ${inputCls}`}
+              />
+              <button
+                type="button"
+                onClick={onRandomSeed}
+                className="p-2 text-gray-400 hover:text-white border border-port-border rounded-lg hover:bg-port-border/50 disabled:opacity-50 min-h-[40px] min-w-[40px] flex items-center justify-center"
+                title="Randomize seed"
+              >
+                <Dice5 className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+
+          <FormField
+            label={<>Steps {currentModel?.steps && `(default: ${currentModel.steps})`}</>}
+            labelClassName="block text-xs font-medium text-gray-400 mb-1"
+          >
+            <input
+              type="number" min={1} max={150}
+              value={steps}
+              onChange={(e) => onStepsChange(e.target.value)}
+              placeholder={String(currentModel?.steps || 25)}
+              className={inputCls}
+            />
+          </FormField>
+
+          <FormField
+            label={<>CFG Scale {currentModel?.guidance != null && `(default: ${currentModel.guidance})`}</>}
+            labelClassName="block text-xs font-medium text-gray-400 mb-1"
+          >
+            <input
+              type="number" min={0} max={20} step={0.5}
+              value={guidanceScale}
+              onChange={(e) => onGuidanceScaleChange(e.target.value)}
+              placeholder={String(currentModel?.guidance ?? 3.0)}
+              className={inputCls}
+            />
+          </FormField>
+
+          {showImageStrength && (
+            <div className="col-span-2 sm:col-span-3">
+              <div className="flex items-center justify-between gap-3 mb-1">
+                <label htmlFor="video-image-strength" className="block text-xs font-medium text-gray-400">Image Strength</label>
+                <span className="text-[11px] text-gray-500">{imageStrength || '1.0'}</span>
+              </div>
+              <input
+                id="video-image-strength"
+                type="range" min={0} max={1} step={0.05}
+                value={imageStrength || 1}
+                onChange={(e) => onImageStrengthChange(e.target.value)}
+                className="w-full accent-port-accent"
+                title="Higher values preserve the source frame more strongly"
+              />
+            </div>
+          )}
+
+          <FormField className="col-span-2 sm:col-span-3" label="Tiling" labelClassName="block text-xs font-medium text-gray-400 mb-1">
+            <select
+              value={tiling}
+              onChange={(e) => onTilingChange(e.target.value)}
+              className={inputCls}
+            >
+              {VIDEO_TILING_OPTIONS.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
+            </select>
+          </FormField>
+
+          {showAudioFlags && (
+            <label className="col-span-2 sm:col-span-3 flex items-center gap-2 text-xs text-gray-400 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={disableAudio}
+                onChange={(e) => onDisableAudioChange(e.target.checked)}
+                className="rounded"
+              />
+              Disable audio (LTX-2 only — speeds up generation)
+            </label>
+          )}
+          {showAudioFlags && (
+            <label
+              className={`col-span-2 sm:col-span-3 flex items-center gap-2 text-xs cursor-pointer ${disableAudio ? 'text-gray-600 cursor-not-allowed' : 'text-gray-400'}`}
+              title="LTX-2 conditions audio on the prompt — appending 'no music, no soundtrack' at submit time pushes the model toward ambient/diegetic sound only"
+            >
+              <input
+                type="checkbox"
+                checked={noMusic}
+                disabled={disableAudio}
+                onChange={(e) => onNoMusicChange(e.target.checked)}
+                className="rounded"
+              />
+              No music — keep ambient/diegetic sound only (LTX-2)
+            </label>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/components/videoGen/AdvancedParamsPanel.test.jsx
+++ b/client/src/components/videoGen/AdvancedParamsPanel.test.jsx
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import AdvancedParamsPanel from './AdvancedParamsPanel';
+
+const baseProps = {
+  mode: 'text',
+  currentModel: { steps: 30, guidance: 3.0 },
+  numFrames: 121, onNumFramesChange: vi.fn(),
+  chunks: 1, onChunksChange: vi.fn(), keyframesActive: false,
+  fps: 24, onFpsChange: vi.fn(),
+  seed: '', onSeedChange: vi.fn(), onRandomSeed: vi.fn(),
+  steps: '', onStepsChange: vi.fn(),
+  guidanceScale: '', onGuidanceScaleChange: vi.fn(),
+  imageStrength: '', onImageStrengthChange: vi.fn(),
+  tiling: 'auto', onTilingChange: vi.fn(),
+  disableAudio: false, onDisableAudioChange: vi.fn(),
+  noMusic: false, onNoMusicChange: vi.fn(),
+};
+
+const renderPanel = (props = {}) => render(<AdvancedParamsPanel {...baseProps} {...props} />);
+const toggle = () => screen.getByRole('button', { name: /Advanced/i });
+
+describe('AdvancedParamsPanel', () => {
+  it('starts collapsed so the Generate button stays above the fold', () => {
+    renderPanel();
+    expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByLabelText('Frames')).toBeNull();
+    expect(screen.queryByLabelText('FPS')).toBeNull();
+    expect(screen.queryByLabelText('Seed')).toBeNull();
+    expect(screen.queryByLabelText('Tiling')).toBeNull();
+  });
+
+  it('summarizes the hidden values while collapsed', () => {
+    renderPanel({ numFrames: 121, fps: 24, seed: '42' });
+    expect(screen.getByText(/121f @ 24fps/)).toBeTruthy();
+    expect(screen.getByText(/5\.0s/)).toBeTruthy();
+    expect(screen.getByText(/seed 42/)).toBeTruthy();
+  });
+
+  it('reads "random" in the summary when no seed is pinned', () => {
+    renderPanel({ seed: '' });
+    expect(screen.getByText(/seed random/)).toBeTruthy();
+  });
+
+  it('reveals every sampler knob when expanded', () => {
+    renderPanel();
+    fireEvent.click(toggle());
+    expect(toggle().getAttribute('aria-expanded')).toBe('true');
+    expect(screen.getByLabelText('Frames')).toBeTruthy();
+    expect(screen.getByLabelText('Chunks')).toBeTruthy();
+    expect(screen.getByLabelText('FPS')).toBeTruthy();
+    expect(screen.getByLabelText('Seed')).toBeTruthy();
+    expect(screen.getByLabelText(/Steps/)).toBeTruthy();
+    expect(screen.getByLabelText(/CFG Scale/)).toBeTruthy();
+    expect(screen.getByLabelText('Tiling')).toBeTruthy();
+    expect(screen.getByText(/Disable audio/)).toBeTruthy();
+    expect(screen.getByText(/No music/)).toBeTruthy();
+  });
+
+  it('collapses again on a second click', () => {
+    renderPanel();
+    fireEvent.click(toggle());
+    fireEvent.click(toggle());
+    expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    expect(screen.queryByLabelText('Frames')).toBeNull();
+  });
+
+  it('propagates edits to the page handlers', () => {
+    const onFpsChange = vi.fn();
+    const onStepsChange = vi.fn();
+    const onTilingChange = vi.fn();
+    renderPanel({ onFpsChange, onStepsChange, onTilingChange });
+    fireEvent.click(toggle());
+    fireEvent.change(screen.getByLabelText('FPS'), { target: { value: '30' } });
+    expect(onFpsChange).toHaveBeenCalledWith(30);
+    fireEvent.change(screen.getByLabelText(/Steps/), { target: { value: '40' } });
+    expect(onStepsChange).toHaveBeenCalledWith('40');
+    fireEvent.change(screen.getByLabelText('Tiling'), { target: { value: 'none' } });
+    expect(onTilingChange).toHaveBeenCalledWith('none');
+  });
+
+  it('fires onRandomSeed from the dice button', () => {
+    const onRandomSeed = vi.fn();
+    renderPanel({ onRandomSeed });
+    fireEvent.click(toggle());
+    fireEvent.click(screen.getByTitle('Randomize seed'));
+    expect(onRandomSeed).toHaveBeenCalled();
+  });
+
+  it('hides chunks + the audio flags in a2v mode', () => {
+    renderPanel({ mode: 'a2v' });
+    fireEvent.click(toggle());
+    expect(screen.queryByLabelText('Chunks')).toBeNull();
+    expect(screen.queryByText(/Disable audio/)).toBeNull();
+    expect(screen.queryByText(/No music/)).toBeNull();
+    // The rest of the knobs still apply.
+    expect(screen.getByLabelText('Frames')).toBeTruthy();
+  });
+
+  it('locks chunks to 1 while multi-keyframe mode is active', () => {
+    renderPanel({ chunks: 4, keyframesActive: true });
+    fireEvent.click(toggle());
+    const select = screen.getByLabelText('Chunks');
+    expect(select.value).toBe('1');
+    expect(select.disabled).toBe(true);
+  });
+
+  it('shows image strength only where it applies', () => {
+    const { unmount } = renderPanel({ mode: 'text' });
+    fireEvent.click(toggle());
+    expect(screen.queryByLabelText('Image Strength')).toBeNull();
+    unmount();
+
+    renderPanel({ mode: 'image' });
+    fireEvent.click(toggle());
+    expect(screen.getByLabelText('Image Strength')).toBeTruthy();
+  });
+
+  it('hides image strength for an ltx2 extend render', () => {
+    const { unmount } = renderPanel({ mode: 'extend', currentModel: { runtime: 'ltx2' } });
+    fireEvent.click(toggle());
+    expect(screen.queryByLabelText('Image Strength')).toBeNull();
+    unmount();
+
+    renderPanel({ mode: 'extend', currentModel: { runtime: 'mlx_video' } });
+    fireEvent.click(toggle());
+    expect(screen.getByLabelText('Image Strength')).toBeTruthy();
+  });
+
+  it('disables the no-music flag when audio is off entirely', () => {
+    renderPanel({ disableAudio: true });
+    fireEvent.click(toggle());
+    expect(screen.getByLabelText(/No music/).disabled).toBe(true);
+  });
+});

--- a/client/src/lib/videoTilingOptions.js
+++ b/client/src/lib/videoTilingOptions.js
@@ -1,5 +1,6 @@
 // Single source of truth for video tiling modes. Consumed by:
-//   - pages/VideoGen.jsx — the <select> options + remix-prefill guard.
+//   - components/videoGen/AdvancedParamsPanel.jsx — the <select> options.
+//   - pages/VideoGen.jsx — the remix-prefill guard (VIDEO_TILING_ENUM_SET).
 //   - hooks/useMediaPreviewActions.js — the Remix URL builder.
 // The server's z.enum in server/routes/videoGen.js must match these values;
 // add a new mode here and to the server enum together.

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -41,6 +41,7 @@ import KeyframePanel from '../components/videoGen/KeyframePanel';
 import AudioPanel from '../components/videoGen/AudioPanel';
 import ExtendPanel from '../components/videoGen/ExtendPanel';
 import IcLoraPanel from '../components/videoGen/IcLoraPanel';
+import AdvancedParamsPanel from '../components/videoGen/AdvancedParamsPanel';
 import RuntimeFingerprint from '../components/videoGen/RuntimeFingerprint';
 import ModelRepairBanner from '../components/videoGen/ModelRepairBanner';
 import VideoPreviewPanel from '../components/videoGen/VideoPreviewPanel';
@@ -51,7 +52,7 @@ import { normalizeVideo } from '../components/media/normalize';
 import { composeStyledPrompt } from '../lib/composeStyledPrompt';
 import {
   Film, Sparkles, Settings as SettingsIcon, RefreshCw, AlertTriangle,
-  Dice5, X, Type, Image as ImageIcon, GitBranch, ListPlus, Music, SlidersHorizontal,
+  X, Type, Image as ImageIcon, GitBranch, ListPlus, Music, SlidersHorizontal,
 } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import BatchQueuePanel from '../components/media/BatchQueuePanel';
@@ -83,9 +84,9 @@ import { VIDEO_RESOLUTIONS, snapAspectToImage } from '../lib/videoGenResolutions
 import { clampImageEdge } from '../lib/imageGenResolutions';
 import { GROK_VIDEO_DURATIONS, GROK_VIDEO_DEFAULT_DURATION } from '../lib/grokVideoClip.js';
 import ResolutionField from '../components/media/ResolutionField';
-import { VIDEO_TILING_OPTIONS, VIDEO_TILING_ENUM_SET } from '../lib/videoTilingOptions';
+import { VIDEO_TILING_ENUM_SET } from '../lib/videoTilingOptions';
 import {
-  FRAME_OPTIONS, FPS_OPTIONS, VIDEO_EDGE_BOUNDS,
+  VIDEO_EDGE_BOUNDS,
   videoModelMemoryGb, computeFflfSafeFrames, isModelAllowedForMode,
   IC_LORA_MODES, icLoraSpecForMode, icResolutionIssue,
 } from '../lib/videoGenParams.js';
@@ -1845,155 +1846,27 @@ export default function VideoGen() {
               note="Each edge 64–2048px; the server rounds each down to the nearest multiple of 64."
             />
 
-            <FormField label="Frames" labelClassName="block text-xs font-medium text-gray-400 mb-1">
-              <select
-                value={numFrames}
-                onChange={(e) => setNumFrames(Number(e.target.value))}
-                className="w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
-              >
-                {FRAME_OPTIONS.map((f) => <option key={f} value={f}>{f} ({(f / fps).toFixed(1)}s @ {fps}fps)</option>)}
-              </select>
-              {numFrames > 241 && (
-                <p className="text-[10px] text-gray-500 leading-snug mt-1">
-                  Past 241 frames a single-pass render may swap or OOM at 48 GB. For reliable longer clips, render up to ~10s and then use <strong>Extend</strong> on the result — it conditions on the source's full latent rather than a single last frame.
-                </p>
-              )}
-            </FormField>
-
-            {mode !== 'a2v' && (
-              <div>
-                <label htmlFor="chunks-select" className="block text-xs font-medium text-gray-400 mb-1" title="Chain N renders end-to-end. Each chunk's last frame seeds the next, then they're stitched into one clip. Wall time scales linearly with chunks.">
-                  Chunks
-                </label>
-                <select
-                  id="chunks-select"
-                  value={keyframesActive ? 1 : chunks}
-                  onChange={(e) => setChunks(Number(e.target.value))}
-                  disabled={keyframesActive}
-                  title={keyframesActive ? 'Multi-keyframe renders anchor a single clip — chunking is unavailable.' : undefined}
-                  className="w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {[1, 2, 3, 4, 5, 6, 7, 8].map((n) => (
-                    <option key={n} value={n}>
-                      {n === 1 ? '1 (single)' : `${n} (~${((n * numFrames) / fps).toFixed(0)}s total)`}
-                    </option>
-                  ))}
-                </select>
-              </div>
-            )}
-
-            <FormField label="FPS" labelClassName="block text-xs font-medium text-gray-400 mb-1">
-              <select
-                value={fps}
-                onChange={(e) => setFps(Number(e.target.value))}
-                className="w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
-              >
-                {FPS_OPTIONS.map((f) => <option key={f} value={f}>{f}</option>)}
-              </select>
-            </FormField>
-
-            <div>
-              <label htmlFor="video-seed" className="block text-xs font-medium text-gray-400 mb-1">Seed</label>
-              <div className="flex items-center gap-1">
-                <input
-                  id="video-seed"
-                  type="number"
-                  value={seed}
-                  onChange={(e) => setSeed(e.target.value)}
-                  placeholder="Random"
-                  className="flex-1 bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
-                />
-                <button
-                  type="button"
-                  onClick={handleRandomSeed}
-                  className="p-2 text-gray-400 hover:text-white border border-port-border rounded-lg hover:bg-port-border/50 disabled:opacity-50 min-h-[40px] min-w-[40px] flex items-center justify-center"
-                  title="Randomize seed"
-                >
-                  <Dice5 className="w-4 h-4" />
-                </button>
-              </div>
-            </div>
-
-            <FormField
-              label={<>Steps {currentModel?.steps && `(default: ${currentModel.steps})`}</>}
-              labelClassName="block text-xs font-medium text-gray-400 mb-1"
-            >
-              <input
-                type="number" min={1} max={150}
-                value={steps}
-                onChange={(e) => setSteps(e.target.value)}
-                placeholder={String(currentModel?.steps || 25)}
-                className="w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
-              />
-            </FormField>
-
-            <FormField
-              label={<>CFG Scale {currentModel?.guidance != null && `(default: ${currentModel.guidance})`}</>}
-              labelClassName="block text-xs font-medium text-gray-400 mb-1"
-            >
-              <input
-                type="number" min={0} max={20} step={0.5}
-                value={guidanceScale}
-                onChange={(e) => setGuidanceScale(e.target.value)}
-                placeholder={String(currentModel?.guidance ?? 3.0)}
-                className="w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
-              />
-            </FormField>
-
-            {(mode === 'image' || (mode === 'extend' && currentModel?.runtime !== 'ltx2')) && (
-              <div className="col-span-2 sm:col-span-3">
-                <div className="flex items-center justify-between gap-3 mb-1">
-                  <label htmlFor="video-image-strength" className="block text-xs font-medium text-gray-400">Image Strength</label>
-                  <span className="text-[11px] text-gray-500">{imageStrength || '1.0'}</span>
-                </div>
-                <input
-                  id="video-image-strength"
-                  type="range" min={0} max={1} step={0.05}
-                  value={imageStrength || 1}
-                  onChange={(e) => setImageStrength(e.target.value)}
-                  className="w-full accent-port-accent"
-                  title="Higher values preserve the source frame more strongly"
-                />
-              </div>
-            )}
-
-            <FormField className="col-span-2 sm:col-span-3" label="Tiling" labelClassName="block text-xs font-medium text-gray-400 mb-1">
-              <select
-                value={tiling}
-                onChange={(e) => setTiling(e.target.value)}
-                className="w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
-              >
-                {VIDEO_TILING_OPTIONS.map((t) => <option key={t.value} value={t.value}>{t.label}</option>)}
-              </select>
-            </FormField>
-
-            {mode !== 'a2v' && (
-              <label className="col-span-2 sm:col-span-3 flex items-center gap-2 text-xs text-gray-400 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={disableAudio}
-                  onChange={(e) => setDisableAudio(e.target.checked)}
-                  className="rounded"
-                />
-                Disable audio (LTX-2 only — speeds up generation)
-              </label>
-            )}
-            {mode !== 'a2v' && (
-              <label
-                className={`col-span-2 sm:col-span-3 flex items-center gap-2 text-xs cursor-pointer ${disableAudio ? 'text-gray-600 cursor-not-allowed' : 'text-gray-400'}`}
-                title="LTX-2 conditions audio on the prompt — appending 'no music, no soundtrack' at submit time pushes the model toward ambient/diegetic sound only"
-              >
-                <input
-                  type="checkbox"
-                  checked={noMusic}
-                  disabled={disableAudio}
-                  onChange={(e) => setNoMusic(e.target.checked)}
-                  className="rounded"
-                />
-                No music — keep ambient/diegetic sound only (LTX-2)
-              </label>
-            )}
           </div>
+          )}
+
+          {/* Sampler/output knobs live behind a closed-by-default disclosure so
+              Generate stays above the fold — the sibling /media/image tab keeps
+              only Model + Resolution inline for the same reason (issue #3279). */}
+          {!isGrok && (
+            <AdvancedParamsPanel
+              mode={mode}
+              currentModel={currentModel}
+              numFrames={numFrames} onNumFramesChange={setNumFrames}
+              chunks={chunks} onChunksChange={setChunks} keyframesActive={keyframesActive}
+              fps={fps} onFpsChange={setFps}
+              seed={seed} onSeedChange={setSeed} onRandomSeed={handleRandomSeed}
+              steps={steps} onStepsChange={setSteps}
+              guidanceScale={guidanceScale} onGuidanceScaleChange={setGuidanceScale}
+              imageStrength={imageStrength} onImageStrengthChange={setImageStrength}
+              tiling={tiling} onTilingChange={setTiling}
+              disableAudio={disableAudio} onDisableAudioChange={setDisableAudio}
+              noMusic={noMusic} onNoMusicChange={setNoMusic}
+            />
           )}
 
           <div className="flex flex-wrap items-center gap-2 pt-1">


### PR DESCRIPTION
## Summary

On `/media/video` the Generate button rendered roughly 600px below the fold at 1440x900 — the left column ran Model → LTX/LoRA notices → Resolution → Frames → Chunks → FPS → Seed → Steps → CFG Scale → Image Strength → Tiling → audio flags before reaching it. The sibling `/media/image` tab keeps only Model + Resolution inline, so the same "write a prompt, render it" task had two different shapes depending on which tab you were on.

Implements option (a) from the issue:

- New `client/src/components/videoGen/AdvancedParamsPanel.jsx` — a closed-by-default "Advanced" disclosure holding Frames, Chunks, FPS, Seed, Steps, CFG Scale, Image Strength, Tiling and the two audio flags. Follows the existing `videoGen/` panel convention (`FramePanel`, `AudioPanel`, `ExtendPanel`, …): purely presentational, all state and handlers stay in the page.
- `VideoGen.jsx` keeps Model (+ download badges), the video-LoRA picker, the LTX-LoRA hint and Resolution inline — the same inline set as ImageGen — then renders the panel, then Generate / Add to queue.
- The collapsed header carries a summary (`121f @ 24fps · 5.0s · seed random`) so a remix that pinned a seed/frame count is still visible without expanding.
- The Grok backend branch is untouched (it already fits above the fold) and the panel is skipped there.
- Submit gating is unchanged: Generate is still `disabled` on an empty prompt and on the per-mode blockers, with the same `title` reasons.

Two details worth calling out:

- The panel body is **conditionally rendered**, not hidden with CSS. A number input that is out of its `min`/`max` range while invisible makes the browser refuse the submit with "an invalid form control is not focusable", so a half-typed Steps/CFG value behind a collapsed panel must not be in the DOM. Because the values live in the page's state, unmounting the inputs loses nothing.
- Dropped `Dice5`, `FRAME_OPTIONS`, `FPS_OPTIONS` and `VIDEO_TILING_OPTIONS` from `VideoGen.jsx` (now imported by the panel) and refreshed the consumer list in the `videoTilingOptions.js` header comment.

Closes #3279

## Test plan

- `cd client && npm test` — 501 files / 5643 tests pass, including the new `AdvancedParamsPanel.test.jsx` (12 cases): default-collapsed, expand/collapse via the toggle with `aria-expanded` tracking, every knob present once expanded, edits propagating to the page handlers, the dice button firing `onRandomSeed`, the collapsed summary (including `seed random` when unpinned), chunks + audio flags hidden in `a2v`, chunks locked to 1 under multi-keyframe mode, Image Strength shown only for `image` / non-ltx2 `extend`, and No-music disabled when audio is off.
- `cd client && npm run build` — clean.
- `npx eslint` on the changed files — clean.
- Manual: at 1440x900 the left column now ends at Resolution → Advanced → Generate, with Generate on screen as soon as the prompt is typed; expanding Advanced restores every previous control, and collapsing/expanding round-trips values.