### PR TITLE
test: assert videoGen POST / rolls back staged uploads on every failure path

### DIFF
--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -80,9 +80,11 @@ vi.mock('../services/mediaJobQueue/index.js', () => ({
 // this via `setPendingUpload({ fieldname, ... })` before issuing the request;
 // the mocked uploadFields middleware reads it off the holder, attaches it as
 // req.files keyed by fieldname, and clears it. Mutable wrapper avoids
-// reaching into vi mock internals.
+// reaching into vi mock internals. Several files may be staged in one request
+// (`setPendingUpload(a, b)`) — the rollback cases need more than one durable
+// copy in flight to prove a later failure unwinds the earlier ones.
 const pendingUpload = { current: null };
-const setPendingUpload = (file) => { pendingUpload.current = file; };
+const setPendingUpload = (...files) => { pendingUpload.current = files.flat(); };
 
 vi.mock('../lib/multipart.js', () => ({
   // Bypass the streaming parser. If a test set a pending upload via
@@ -90,8 +92,7 @@ vi.mock('../lib/multipart.js', () => ({
   // route exercises the upload-staging path; otherwise pass through.
   uploadFields: () => (req, _res, next) => {
     if (pendingUpload.current) {
-      const f = pendingUpload.current;
-      req.files = { [f.fieldname]: f };
+      req.files = Object.fromEntries(pendingUpload.current.map((f) => [f.fieldname, f]));
       pendingUpload.current = null;
     }
     next();
@@ -134,6 +135,7 @@ vi.mock('fs/promises', () => ({
   copyFile: vi.fn(async () => {}),
 }));
 
+import { copyFile, unlink } from 'fs/promises';
 import * as videoGenService from '../services/videoGen/local.js';
 import * as mediaJobQueue from '../services/mediaJobQueue/index.js';
 import { getProject as getMusicVideoProject } from '../services/musicVideo/projects.js';
@@ -1249,6 +1251,122 @@ describe('videoGen routes', () => {
           expect(mediaJobQueue.enqueueJob).not.toHaveBeenCalled();
         });
       });
+    });
+  });
+
+  // Every throw path in POST / runs cleanupAllStaged()/cleanupTempUploads()
+  // before it rethrows, and stageUploadDurable rolls its own half-written
+  // destination back when copyFile rejects. None of that was asserted anywhere
+  // — a regression that dropped the cleanup entirely would still return the
+  // same status/body while leaking a 100MB durable copy under data/uploads on
+  // every rejected request (#3289).
+  describe('POST / — upload staging rollback (#3289)', () => {
+    const sourceUpload = {
+      fieldname: 'sourceImage',
+      path: '/tmp/upload-frame.png',
+      originalname: 'frame.png',
+      mimetype: 'image/png',
+      size: 2048,
+    };
+    const audioUpload = {
+      fieldname: 'audioFile',
+      path: '/tmp/upload-beats.wav',
+      originalname: 'beats.wav',
+      mimetype: 'audio/wav',
+      size: 1234,
+    };
+    const icUpload = {
+      fieldname: 'icReference',
+      path: '/tmp/upload-depth.mp4',
+      originalname: 'depth.mp4',
+      mimetype: 'video/mp4',
+      size: 4321,
+    };
+    const unlinkedPaths = () => unlink.mock.calls.map(([p]) => p);
+    // Durable copies live under PATHS.uploads (mocked to /mock/uploads); the
+    // multipart temp files live under /tmp. Splitting them keeps the
+    // "durable survives" assertion below from being satisfied by a temp unlink.
+    const durableUnlinks = () => unlinkedPaths().filter((p) => p.startsWith('/mock/uploads/'));
+
+    it('unlinks the half-written destination AND every earlier staged copy when copyFile rejects', async () => {
+      // sourceImage stages fine, audioFile's copy blows up — the failure has
+      // to take BOTH the destination it was writing and the already-staged
+      // sourceImage copy with it, since the job is never enqueued and the
+      // worker's cleanup therefore never runs.
+      copyFile
+        .mockImplementationOnce(async () => {})
+        .mockRejectedValueOnce(new Error('ENOSPC: no space left on device'));
+      setPendingUpload(sourceUpload, audioUpload);
+      const r = await request(app).post('/api/video-gen/').send({
+        prompt: 'beat-synced dancer',
+        mode: 'a2v',
+      });
+      expect(r.status).toBe(500);
+      expect(r.body.code).toBe('VIDEO_GEN_UPLOAD_STAGE_FAILED');
+      expect(mediaJobQueue.enqueueJob).not.toHaveBeenCalled();
+      const unlinked = unlinkedPaths();
+      expect(unlinked).toEqual(expect.arrayContaining([
+        // the destination the failed copy may have partially written
+        expect.stringMatching(/^\/mock\/uploads\/video-audio-[^/]+\.wav$/),
+        // …and the durable copy staged before it (stagedDurablePaths)
+        expect.stringMatching(/^\/mock\/uploads\/video-source-[^/]+\.png$/),
+        // …and both multipart temp files
+        sourceUpload.path,
+        audioUpload.path,
+      ]));
+    });
+
+    it('unlinks the pre-staged reference frame when the music-video scene lookup 404s', async () => {
+      // Late-stage throw: the scene lookup runs AFTER the source frame has
+      // already been copied into data/uploads.
+      getMusicVideoProject.mockResolvedValueOnce(null);
+      setPendingUpload(sourceUpload);
+      const r = await request(app).post('/api/video-gen/').send({
+        prompt: 'rain pulses with the percussion',
+        mode: 'a2v',
+        musicVideo: { projectId: 'mv-example', sceneId: 'scene-missing' },
+      });
+      expect(r.status).toBe(404);
+      expect(r.body.code).toBe('NOT_FOUND');
+      expect(mediaJobQueue.enqueueJob).not.toHaveBeenCalled();
+      expect(unlinkedPaths()).toEqual(expect.arrayContaining([
+        expect.stringMatching(/^\/mock\/uploads\/video-source-[^/]+\.png$/),
+        sourceUpload.path,
+      ]));
+    });
+
+    it('unlinks the pre-staged IC reference and source frame when a later validation throws', async () => {
+      // keyframes are rejected for any non-fflf mode — by then both the source
+      // frame and the IC reference clip are staged under data/uploads.
+      setPendingUpload(sourceUpload, icUpload);
+      const r = await request(app).post('/api/video-gen/').send({
+        prompt: 'follow the depth clip',
+        mode: 'ic-control',
+        keyframes: [{ file: 'a.png', index: 0 }, { file: 'b.png', index: 24 }],
+      });
+      expect(r.status).toBe(400);
+      expect(r.body.code).toBe('KEYFRAMES_MODE_MISMATCH');
+      expect(mediaJobQueue.enqueueJob).not.toHaveBeenCalled();
+      expect(unlinkedPaths()).toEqual(expect.arrayContaining([
+        expect.stringMatching(/^\/mock\/uploads\/video-source-[^/]+\.png$/),
+        expect.stringMatching(/^\/mock\/uploads\/video-ic-ref-[^/]+\.mp4$/),
+        sourceUpload.path,
+        icUpload.path,
+      ]));
+    });
+
+    it('drops only the OS temp file on the happy path — the durable copy survives for the worker', async () => {
+      setPendingUpload(sourceUpload);
+      const r = await request(app).post('/api/video-gen/').send({
+        prompt: 'a fox running through snow',
+        mode: 'image',
+      });
+      expect(r.status).toBe(200);
+      expect(mediaJobQueue.enqueueJob).toHaveBeenCalled();
+      expect(unlinkedPaths()).toContain(sourceUpload.path);
+      // The queue worker owns the durable copy's lifetime — unlinking it here
+      // would hand the worker a path that no longer exists.
+      expect(durableUnlinks()).toEqual([]);
     });
   });
 

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -1362,7 +1362,21 @@ describe('videoGen routes', () => {
         mode: 'image',
       });
       expect(r.status).toBe(200);
-      expect(mediaJobQueue.enqueueJob).toHaveBeenCalled();
+      // Pin the durable copy as actually having happened, and to the exact
+      // destination the job was handed. Asserting only "nothing under
+      // /mock/uploads was unlinked" would pass just as well if staging were
+      // skipped altogether — there'd be no durable path to unlink.
+      expect(copyFile).toHaveBeenCalledWith(
+        sourceUpload.path,
+        expect.stringMatching(/^\/mock\/uploads\/video-source-[^/]+\.png$/),
+      );
+      const [, durableDest] = copyFile.mock.calls[0];
+      expect(mediaJobQueue.enqueueJob).toHaveBeenCalledWith(expect.objectContaining({
+        params: expect.objectContaining({
+          sourceImagePath: durableDest,
+          uploadedTempPath: durableDest,
+        }),
+      }));
       expect(unlinkedPaths()).toContain(sourceUpload.path);
       // The queue worker owns the durable copy's lifetime — unlinking it here
       // would hand the worker a path that no longer exists.

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -1268,6 +1268,13 @@ describe('videoGen routes', () => {
       mimetype: 'image/png',
       size: 2048,
     };
+    const lastImageUpload = {
+      fieldname: 'lastImage',
+      path: '/tmp/upload-end-frame.png',
+      originalname: 'end-frame.png',
+      mimetype: 'image/png',
+      size: 3072,
+    };
     const audioUpload = {
       fieldname: 'audioFile',
       path: '/tmp/upload-beats.wav',
@@ -1352,6 +1359,28 @@ describe('videoGen routes', () => {
         expect.stringMatching(/^\/mock\/uploads\/video-ic-ref-[^/]+\.mp4$/),
         sourceUpload.path,
         icUpload.path,
+      ]));
+    });
+
+    it('unlinks both staged frames when an FFLF request mixes legacy inputs with keyframes', async () => {
+      // lastImage is the one upload field with no rollback coverage above —
+      // it stages between the source frame and the audio/IC fields, so a
+      // durable copy that never made it into stagedDurablePaths would leak
+      // here alone while every other case stayed green.
+      setPendingUpload(sourceUpload, lastImageUpload);
+      const r = await request(app).post('/api/video-gen/').send({
+        prompt: 'morph between the anchors',
+        mode: 'fflf',
+        keyframes: [{ file: 'a.png', index: 0 }, { file: 'b.png', index: 24 }],
+      });
+      expect(r.status).toBe(400);
+      expect(r.body.code).toBe('KEYFRAMES_LEGACY_INPUTS_CONFLICT');
+      expect(mediaJobQueue.enqueueJob).not.toHaveBeenCalled();
+      expect(unlinkedPaths()).toEqual(expect.arrayContaining([
+        expect.stringMatching(/^\/mock\/uploads\/video-source-[^/]+\.png$/),
+        expect.stringMatching(/^\/mock\/uploads\/video-last-[^/]+\.png$/),
+        sourceUpload.path,
+        lastImageUpload.path,
       ]));
     });
 


### PR DESCRIPTION
## Summary

`server/routes/videoGen.js` `POST /` has 20+ throw sites that call `cleanupAllStaged()` / `cleanupTempUploads()` before rethrowing, plus a `copyFile` rejection branch in `stageUploadDurable` that unlinks its own half-written destination and rolls back every earlier staged copy. `videoGen.test.js` mocked `unlink` and `copyFile` but never asserted on either mock — across all 97 tests, error paths asserted only `r.status` / `r.body` / `enqueueJob` not-called. A regression that dropped the cleanup entirely, or unlinked the wrong path, stayed green while leaking a durable copy under `data/uploads` on every rejected request. The `copyFile` rejection branch was never exercised at all, since the mock always resolved.

Five new cases in a `POST / — upload staging rollback (#3289)` block:

1. **`copyFile` rejects mid-staging** — `sourceImage` stages, `audioFile`'s copy fails. Asserts 500 `VIDEO_GEN_UPLOAD_STAGE_FAILED` **and** that `unlink` got the half-written destination, the already-staged `sourceImage` durable copy (`stagedDurablePaths`), and both multipart temp files.
2. **Late-stage throw — music-video scene 404** — the scene lookup runs after the reference frame is already copied into `data/uploads`; asserts that copy is unlinked.
3. **Late-stage throw — keyframes/mode mismatch** — fires with both a staged source frame and a staged IC-reference clip in flight; asserts both durable copies plus both temp files are unlinked.
4. **Late-stage throw — legacy inputs vs keyframes** — the only path that stages an uploaded `lastImage` before a rejection, so a durable copy missing from `stagedDurablePaths` would leak here and nowhere else.
5. **Happy path** — `copyFile` wrote the durable destination, the job was handed that exact path, the OS temp file is dropped, and nothing under `data/uploads` is — the queue worker owns the durable copy's lifetime.

The only production-code-adjacent change is to the test harness: `setPendingUpload` now accepts several files so one request can carry more than one durable copy in flight. That is what makes the rollback observable at all. `server/routes/videoGen.js` is untouched.

This unblocks #3288 (extracting the `POST /` handler into a service) — that refactor needs this safety net in place first.

Review also surfaced a genuine production leak that is out of scope for a test-only change and is filed separately as #3326: a *rejected await* after staging (e.g. `getMusicVideoProject`, `getTrack`, `loadHistory`, `enqueueJob`) bubbles past `cleanupAllStaged()` entirely, since only explicit `throw` sites call it.

## Test plan

- `cd server && npx vitest run routes/videoGen.test.js` → 110 passed (was 105).
- Full `cd server && npm test`: the 54 failing files are all Postgres-backed suites failing identically on unmodified `main` in this environment (no local Postgres); none is `videoGen.test.js`.
- **Falsifiability** — each cleanup call was broken in turn in `videoGen.js`, the suite re-run, and the source restored. Every break failed exactly one test, the intended one:
  - drop `unlink(durablePath)` in `stageUploadDurable`'s catch → case 1 fails
  - drop `cleanupAllStaged()` in `stageUploadDurable`'s catch → case 1 fails
  - drop `cleanupAllStaged()` before the music-video 404 → case 2 fails
  - drop `cleanupAllStaged()` before the keyframes mismatch throw → case 3 fails
  - drop `cleanupAllStaged()` before the legacy-inputs conflict throw → case 4 fails
  - pop `lastImage` off `stagedDurablePaths` → case 4 fails
  - unlink `durablePath` instead of `file.path` on the success path → case 5 fails
  - skip staging entirely (hand the raw temp path through) → case 5 fails

Closes #3289