### PR TITLE
Demote the Creative Director smoke test into a '…' menu behind an inline confirm

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -115,3 +115,6 @@
 ## Apps
 
 - **[issue-3286] Delete is no longer the loudest button on an app row.** Every app card rendered `Archive`, `Manage` and a red-tinted `Delete` as three equal-weight buttons, so the most destructive and rarest action was the highest-contrast control on the page — sixteen permanently-armed Delete buttons stacked down the list, sitting a thumb's width from `Manage` once the row wrapped on a phone. `Archive` and `Delete` now live behind a per-row "…" menu (arrow keys, Escape, and 40px touch targets included), `Manage` is the row's single filled primary, the app name reads as an actual link, and deleting asks for an inline confirmation naming the app before anything is removed.
+## Creative Director
+
+- **[issue-3287] The developer smoke test no longer leads the Creative Director action bar.** `Run smoke test` sat in the leading position of a four-button header where the eye lands first, named a mechanism rather than an outcome, and consumed one of the seven interactive elements that fit above the fold on a phone — despite spending real render time on every click. It now lives behind a "…" menu beside `Model defaults`, reads `Render a 6s test clip` so the cost is legible before you commit, and asks for an inline confirmation naming what it will spend. The header bar reads `New directive` · `Model defaults` · `New project`.

--- a/client/src/pages/CreativeDirector.jsx
+++ b/client/src/pages/CreativeDirector.jsx
@@ -1,7 +1,9 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { Link, useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import { Plus, Film, Trash2, Play, Pause, FlaskConical, Sparkles, Wand2, SlidersHorizontal } from 'lucide-react';
 import toast from '../components/ui/Toast';
+import InlineConfirmRow from '../components/ui/InlineConfirmRow';
+import OverflowMenu from '../components/ui/OverflowMenu';
 import {
   listCreativeDirectorProjects,
   createCreativeDirectorProject,
@@ -60,6 +62,12 @@ export default function CreativeDirector() {
   // them into the project cast + links catalog_ingredient_refs.
   const [remixIds, setRemixIds] = useState([]);
   const [remixIngredients, setRemixIngredients] = useState([]);
+  // The smoke test renders three real video clips, so it is NOT a header button
+  // (#3287): it lives in the "…" menu beside Model defaults and routes through
+  // an inline confirm, so a stray tap can never spend render budget.
+  const [confirmingSmokeTest, setConfirmingSmokeTest] = useState(false);
+  const [startingSmokeTest, setStartingSmokeTest] = useState(false);
+  const smokeMenuTriggerRef = useRef(null);
   const [form, setForm] = useState({
     name: '',
     aspectRatio: '16:9',
@@ -234,6 +242,22 @@ export default function CreativeDirector() {
     }
   };
 
+  const handleSmokeTest = async () => {
+    setConfirmingSmokeTest(false);
+    setStartingSmokeTest(true);
+    // Hand focus back to the "…" trigger before the confirm row unmounts, or a
+    // keyboard user is stranded on <body> while the render kicks off.
+    smokeMenuTriggerRef.current?.focus();
+    const created = await createSmokeTestCreativeDirectorProject({ silent: true }).catch((e) => {
+      toast.error(e?.message || 'Smoke test failed to start');
+      return null;
+    });
+    setStartingSmokeTest(false);
+    if (!created) return;
+    toast.success('Test clip render started');
+    setProjects((prev) => [created, ...prev]);
+  };
+
   if (loading) {
     return <div className="p-6 text-port-text-muted">Loading projects…</div>;
   }
@@ -246,22 +270,6 @@ export default function CreativeDirector() {
         subtitle="Long-form video projects driven by an autonomous CoS agent"
         actions={
           <>
-            <button
-              onClick={async () => {
-                const created = await createSmokeTestCreativeDirectorProject({ silent: true }).catch((e) => {
-                  toast.error(e?.message || 'Smoke test failed to start');
-                  return null;
-                });
-                if (!created) return;
-                toast.success('Smoke test project started');
-                setProjects((prev) => [created, ...prev]);
-              }}
-              className="flex items-center gap-2 bg-port-card border border-port-border hover:bg-port-card/60 text-port-text px-3 py-2 rounded text-sm"
-              title="Create + start a deterministic 3-scene colored-ball project (auto-accept, no audio)"
-            >
-              <FlaskConical className="w-4 h-4" />
-              Run smoke test
-            </button>
             <button
               onClick={openDirective}
               className="flex items-center gap-2 bg-port-card border border-port-border hover:bg-port-card/60 text-port-text px-3 py-2 rounded text-sm"
@@ -278,6 +286,19 @@ export default function CreativeDirector() {
               <SlidersHorizontal className="w-4 h-4" />
               Model defaults
             </button>
+            <OverflowMenu
+              label="More Creative Director actions"
+              triggerRef={smokeMenuTriggerRef}
+              items={[
+                {
+                  id: 'smoke-test',
+                  label: startingSmokeTest ? 'Starting…' : 'Render a 6s test clip',
+                  icon: FlaskConical,
+                  disabled: startingSmokeTest,
+                  onSelect: () => setConfirmingSmokeTest(true),
+                },
+              ]}
+            />
             <button
               onClick={() => { setShowForm((s) => !s); clearRemix(); }}
               className="flex items-center gap-2 bg-port-accent hover:bg-port-accent/80 text-white px-3 py-2 rounded text-sm"
@@ -288,6 +309,24 @@ export default function CreativeDirector() {
           </>
         }
       />
+
+      {confirmingSmokeTest && (
+        <InlineConfirmRow
+          className="shrink-0"
+          variant="separator"
+          tone="warning"
+          autoFocus
+          question="Render a 6s test clip? This sends three 2-second scenes to your default video model and spends real render time."
+          confirmText="Render test clip"
+          confirmTitle="Create + start a deterministic 3-scene colored-ball project (auto-accept, no audio)"
+          aria-label="Confirm rendering a 6 second Creative Director test clip"
+          onConfirm={handleSmokeTest}
+          onCancel={() => {
+            setConfirmingSmokeTest(false);
+            smokeMenuTriggerRef.current?.focus();
+          }}
+        />
+      )}
 
       {showForm && (
         <form onSubmit={handleCreate} className="shrink-0 p-6 border-b border-port-border bg-port-card/40 space-y-3">

--- a/client/src/pages/CreativeDirector.test.jsx
+++ b/client/src/pages/CreativeDirector.test.jsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+
+vi.mock('../services/apiCreativeDirector.js', () => ({
+  listCreativeDirectorProjects: vi.fn(() => Promise.resolve([])),
+  createCreativeDirectorProject: vi.fn(() => Promise.resolve({})),
+  createSmokeTestCreativeDirectorProject: vi.fn(() => Promise.resolve({ id: 'smoke-1', name: 'CD smoke test (colored ball)', status: 'planning' })),
+  deleteCreativeDirectorProject: vi.fn(() => Promise.resolve({})),
+  startCreativeDirectorProject: vi.fn(() => Promise.resolve({})),
+  pauseCreativeDirectorProject: vi.fn(() => Promise.resolve({})),
+}));
+vi.mock('../services/apiCatalog.js', () => ({ listCatalogIngredientsByIds: vi.fn(() => Promise.resolve([])) }));
+vi.mock('../services/apiImageVideo.js', () => ({ listVideoModels: vi.fn(() => Promise.resolve([{ id: 'model-a', name: 'Model A' }])) }));
+vi.mock('../services/apiUniverseBuilder.js', () => ({ listUniverses: vi.fn(() => Promise.resolve([])) }));
+vi.mock('../services/apiPipeline.js', () => ({ listPipelineSeries: vi.fn(() => Promise.resolve([])) }));
+vi.mock('../components/creative-director/CreativeDirectorModelsDrawer.jsx', () => ({ default: () => null }));
+vi.mock('../components/ui/Toast', () => ({
+  default: { success: vi.fn(), error: vi.fn(), info: vi.fn(), warning: vi.fn() },
+}));
+
+import * as cdApi from '../services/apiCreativeDirector.js';
+import CreativeDirector from './CreativeDirector';
+
+const MENU_LABEL = 'More Creative Director actions';
+const ITEM_LABEL = 'Render a 6s test clip';
+const CONFIRM_LABEL = 'Render test clip';
+
+const renderPage = async () => {
+  render(<MemoryRouter><CreativeDirector /></MemoryRouter>);
+  await screen.findByRole('button', { name: 'New project' });
+};
+
+const openMenu = async (user) => {
+  await user.click(screen.getByRole('button', { name: MENU_LABEL }));
+};
+
+describe('CreativeDirector header action hierarchy (#3287)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cdApi.listCreativeDirectorProjects.mockResolvedValue([]);
+    cdApi.createSmokeTestCreativeDirectorProject.mockResolvedValue({ id: 'smoke-1', name: 'CD smoke test (colored ball)', status: 'planning' });
+  });
+
+  it('keeps the smoke test out of the resting header bar', async () => {
+    await renderPage();
+
+    expect(screen.queryByRole('button', { name: /smoke test/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: ITEM_LABEL })).toBeNull();
+    // The bar itself is New directive · Model defaults · … · New project.
+    expect(screen.getByRole('button', { name: 'New directive' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Model defaults' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'New project' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: MENU_LABEL })).toBeTruthy();
+  });
+
+  it('exposes the test-clip render only through the overflow menu, labelled by outcome', async () => {
+    const user = userEvent.setup();
+    await renderPage();
+
+    await openMenu(user);
+    expect(screen.getByRole('menuitem', { name: ITEM_LABEL })).toBeTruthy();
+  });
+
+  it('does not spend render budget until the inline confirm is accepted', async () => {
+    const user = userEvent.setup();
+    await renderPage();
+
+    await openMenu(user);
+    await user.click(screen.getByRole('menuitem', { name: ITEM_LABEL }));
+
+    expect(cdApi.createSmokeTestCreativeDirectorProject).not.toHaveBeenCalled();
+    expect(screen.getByText(/spends real render time/i)).toBeTruthy();
+
+    await user.click(screen.getByRole('button', { name: CONFIRM_LABEL }));
+    await waitFor(() => expect(cdApi.createSmokeTestCreativeDirectorProject).toHaveBeenCalledTimes(1));
+    // The confirm is consumed by the run, not left armed.
+    expect(screen.queryByRole('button', { name: CONFIRM_LABEL })).toBeNull();
+  });
+
+  it('cancelling the confirm runs nothing and returns focus to the "…" trigger', async () => {
+    const user = userEvent.setup();
+    await renderPage();
+
+    await openMenu(user);
+    await user.click(screen.getByRole('menuitem', { name: ITEM_LABEL }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(cdApi.createSmokeTestCreativeDirectorProject).not.toHaveBeenCalled();
+    expect(screen.queryByText(/spends real render time/i)).toBeNull();
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: MENU_LABEL }));
+  });
+
+  it('returns focus to the "…" trigger after confirming, instead of stranding it on <body>', async () => {
+    const user = userEvent.setup();
+    await renderPage();
+
+    await openMenu(user);
+    await user.click(screen.getByRole('menuitem', { name: ITEM_LABEL }));
+    await user.click(screen.getByRole('button', { name: CONFIRM_LABEL }));
+
+    await waitFor(() => expect(cdApi.createSmokeTestCreativeDirectorProject).toHaveBeenCalled());
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: MENU_LABEL }));
+  });
+
+  it('adds the started test-clip project to the list', async () => {
+    const user = userEvent.setup();
+    await renderPage();
+
+    await openMenu(user);
+    await user.click(screen.getByRole('menuitem', { name: ITEM_LABEL }));
+    await user.click(screen.getByRole('button', { name: CONFIRM_LABEL }));
+
+    await screen.findByText('CD smoke test (colored ball)');
+  });
+
+  it('leaves the list untouched when the render fails to start', async () => {
+    cdApi.createSmokeTestCreativeDirectorProject.mockRejectedValue(new Error('no video model'));
+    const user = userEvent.setup();
+    await renderPage();
+
+    await openMenu(user);
+    await user.click(screen.getByRole('menuitem', { name: ITEM_LABEL }));
+    await user.click(screen.getByRole('button', { name: CONFIRM_LABEL }));
+
+    await waitFor(() => expect(cdApi.createSmokeTestCreativeDirectorProject).toHaveBeenCalled());
+    // Menu item is re-enabled so the user can retry after fixing the model.
+    await openMenu(user);
+    await waitFor(() => expect(screen.getByRole('menuitem', { name: ITEM_LABEL }).disabled).toBe(false));
+  });
+});


### PR DESCRIPTION
## Summary

The `/creative-director` header bar led with `Run smoke test` — a developer diagnostic occupying the leading position of four equal-weight buttons, where the eye lands first. Its label named a mechanism rather than an outcome, and it isn't free: clicking it immediately creates *and starts* a project that renders three video clips through the default video model. At 375x812 the bar consumed four of the seven interactive elements that fit above the fold, so the diagnostic was among the first things a mobile user saw.

`Run smoke test` stays reachable — it's the fastest end-to-end health check for the CD pipeline (sceneRunner → mediaJobQueue → completionHook → stitchRunner) and is genuinely useful right after a provider or model change — but it is demoted, following the row-action pattern established in #3286:

- Moved into the shared `ui/OverflowMenu` (`…`) beside `Model defaults`, so the header bar reads `New directive` · `Model defaults` · `…` · **`New project`**.
- Relabelled in outcome terms: **`Render a 6s test clip`**. The issue guessed 10s; the fixture in `server/services/creativeDirector/smokeTest.js` is 3 x 2s scenes, so the label states what actually gets rendered.
- Gated behind the shared `ui/InlineConfirmRow` in `warning` tone (expensive but not destructive) naming the cost, per the documented preference for inline confirm rows over two-click-arm.
- Focus returns to the `…` trigger on both confirm and cancel, matching the focus-management fixes in 2797ae618 / 779b25a84, so the keyboard path never strands focus on `<body>`.
- The menu item disables and reads `Starting…` while the request is in flight, and re-enables on failure so a retry is possible.

No server change — the endpoint and fixture are untouched.

## Test plan

- New `client/src/pages/CreativeDirector.test.jsx` (7 cases): the smoke test is absent from the resting header bar; the other three header buttons are present; the action is reachable only as a menu item labelled by outcome; the API is **not** called until the inline confirm is accepted; cancel runs nothing and returns focus to the `…` trigger; confirm returns focus to the trigger; the started project is prepended to the list; a failed start leaves the list untouched and re-enables the item.
- `cd client && npx vitest run` — 513 files / 5832 tests pass.
- `npx eslint src/pages/CreativeDirector.jsx src/pages/CreativeDirector.test.jsx` — clean.

Closes #3287