### PR TITLE
Cover the 11 untested useUniverseDraft actions, and fix the double lock PATCH they surfaced

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -26,6 +26,7 @@
 ## Universe Builder
 
 - **A failed settings load no longer resets your image-gen mode.** Opening Universe Builder fetched providers, image models, LoRAs and settings together, and treated any request that failed exactly like one that came back empty. A brief network blip therefore rendered the page as if nothing were configured — and worse, the settings read was used to recompute the render backend, so a failed fetch silently reset your saved image-gen mode to Local and the pipeline image config to defaults. Each request now keeps its last known-good value when it fails, while a genuinely empty response still applies.
+- **[issue-3290] Locking a bible field now writes once instead of twice.** Clicking the padlock on the logline, premise, style notes or either influence list sent its save request from inside a React state update, which React is free to run more than once per click — so a single lock toggle fired two identical writes at the server's queue. The save now happens alongside the state change rather than inside it, and eleven previously untested Universe Builder actions — delete, lock, render pin, bucket moves, category add/remove, and the save preflight — are covered by tests that pin the exact request each one sends.
 
 ## Calendar
 

--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -471,18 +471,23 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
 
   const toggleLock = useCallback((field) => {
     if (!WORLD_LOCKABLE_FIELDS.includes(field)) return;
-    setDraft((current) => {
-      const nextLocked = { ...(current.locked || {}) };
-      if (nextLocked[field]) delete nextLocked[field];
-      else nextLocked[field] = true;
-      const next = { ...current, locked: nextLocked };
-      if (selectedId && next.name?.trim()) {
-        updateUniverse(selectedId, { locked: nextLocked }, { silent: true })
-          .catch((error) => toast.error(`Lock save failed: ${error.message}`));
-      }
-      return next;
-    });
-  }, [selectedId]);
+    // The next lock map is derived from the freshest draft OUTSIDE the state
+    // updater, and the PATCH fires from here rather than from inside it. A
+    // state updater must be pure: React is free to invoke it more than once
+    // for a single setState (StrictMode double-invocation, an interrupted
+    // concurrent render), and a request issued from within one is sent once
+    // per invocation — one lock click produced two identical PATCHes. Mirrors
+    // setRenderPin / assignBucketKind, which already patch outside the updater.
+    const current = draftRef.current || draft;
+    const nextLocked = { ...(current.locked || {}) };
+    if (nextLocked[field]) delete nextLocked[field];
+    else nextLocked[field] = true;
+    setDraft((value) => ({ ...value, locked: nextLocked }));
+    if (selectedId && current.name?.trim()) {
+      updateUniverse(selectedId, { locked: nextLocked }, { silent: true })
+        .catch((error) => toast.error(`Lock save failed: ${error.message}`));
+    }
+  }, [draft, selectedId]);
 
   // Per-record render pin (#3231 Phase 3) — this universe's default image
   // backend + cloud model. Mirrors toggleLock: reactive local update plus an

--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -469,6 +469,16 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     });
   }, [canonDirty]);
 
+  // Serializes lock PATCHes. The server replaces the stored `locked` map
+  // wholesale on every arrival, so ORDER is load-bearing: two toggles fired
+  // back-to-back that land reversed persist the older map, leaving a field
+  // locked on disk while the UI shows it unlocked. Chaining them means the
+  // second is not even sent until the first settles. The style-reference
+  // mutators need no such tail — they send deltas the server applies in any
+  // order (#3109) — which is exactly the difference that makes one necessary
+  // here.
+  const lockWriteTailRef = useRef(Promise.resolve());
+
   const toggleLock = useCallback((field) => {
     if (!WORLD_LOCKABLE_FIELDS.includes(field)) return;
     // The next lock map is derived from the freshest draft OUTSIDE the state
@@ -490,7 +500,8 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     draftRef.current = { ...current, locked: nextLocked };
     setDraft((value) => ({ ...value, locked: nextLocked }));
     if (selectedId && current.name?.trim()) {
-      updateUniverse(selectedId, { locked: nextLocked }, { silent: true })
+      lockWriteTailRef.current = lockWriteTailRef.current
+        .then(() => updateUniverse(selectedId, { locked: nextLocked }, { silent: true }))
         .catch((error) => toast.error(`Lock save failed: ${error.message}`));
     }
   }, [draft, selectedId]);

--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -469,15 +469,20 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     });
   }, [canonDirty]);
 
-  // Serializes lock PATCHes. The server replaces the stored `locked` map
-  // wholesale on every arrival, so ORDER is load-bearing: two toggles fired
-  // back-to-back that land reversed persist the older map, leaving a field
-  // locked on disk while the UI shows it unlocked. Chaining them means the
-  // second is not even sent until the first settles. The style-reference
-  // mutators need no such tail — they send deltas the server applies in any
-  // order (#3109) — which is exactly the difference that makes one necessary
-  // here.
-  const lockWriteTailRef = useRef(Promise.resolve());
+  // Serializes lock PATCHes, PER UNIVERSE. The server replaces the stored
+  // `locked` map wholesale on every arrival, so ORDER is load-bearing: two
+  // toggles fired back-to-back that land reversed persist the older map,
+  // leaving a field locked on disk while the UI shows it unlocked. Chaining
+  // them means the second is not even sent until the first settles. The
+  // style-reference mutators need no such tail — they send deltas the server
+  // applies in any order (#3109) — which is exactly the difference that makes
+  // one necessary here.
+  //
+  // Keyed by id rather than held as one tail for the hook, because a request
+  // has no timeout: a stalled write for the universe the user just left would
+  // otherwise block every lock on the one they navigated to, indefinitely and
+  // silently (the draft still updates optimistically, so nothing surfaces it).
+  const lockWriteTailsRef = useRef(new Map());
 
   const toggleLock = useCallback((field) => {
     if (!WORLD_LOCKABLE_FIELDS.includes(field)) return;
@@ -500,9 +505,10 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     draftRef.current = { ...current, locked: nextLocked };
     setDraft((value) => ({ ...value, locked: nextLocked }));
     if (selectedId && current.name?.trim()) {
-      lockWriteTailRef.current = lockWriteTailRef.current
+      const tail = lockWriteTailsRef.current.get(selectedId) || Promise.resolve();
+      lockWriteTailsRef.current.set(selectedId, tail
         .then(() => updateUniverse(selectedId, { locked: nextLocked }, { silent: true }))
-        .catch((error) => toast.error(`Lock save failed: ${error.message}`));
+        .catch((error) => toast.error(`Lock save failed: ${error.message}`)));
     }
   }, [draft, selectedId]);
 

--- a/client/src/hooks/useUniverseDraft.js
+++ b/client/src/hooks/useUniverseDraft.js
@@ -482,6 +482,12 @@ export default function useUniverseDraft({ selectedId, goToWorld }) {
     const nextLocked = { ...(current.locked || {}) };
     if (nextLocked[field]) delete nextLocked[field];
     else nextLocked[field] = true;
+    // Advance the mirror synchronously. The effect that syncs `draftRef` runs a
+    // commit later, so two toggles inside one tick would otherwise both read the
+    // pre-toggle map — the second re-sending the first's write instead of
+    // composing on top of it. The functional updater still owns the draft
+    // itself, so a concurrent edit to another field is not clobbered.
+    draftRef.current = { ...current, locked: nextLocked };
     setDraft((value) => ({ ...value, locked: nextLocked }));
     if (selectedId && current.name?.trim()) {
       updateUniverse(selectedId, { locked: nextLocked }, { silent: true })

--- a/client/src/hooks/useUniverseDraft.test.jsx
+++ b/client/src/hooks/useUniverseDraft.test.jsx
@@ -667,7 +667,7 @@ describe('useUniverseDraft', () => {
       const { result } = renderDraft();
       await waitFor(() => expect(result.current.draft.id).toBe('u1'));
 
-      act(() => result.current.toggleLock('logline'));
+      await act(async () => { result.current.toggleLock('logline'); });
       expect(apiMocks.updateUniverse).toHaveBeenLastCalledWith(
         'u1',
         { locked: { logline: true } },
@@ -677,7 +677,7 @@ describe('useUniverseDraft', () => {
 
       // Unlocking DELETES the key rather than writing `false` — the stored map
       // is sparse, and lockedSchema is strict about nothing else riding along.
-      act(() => result.current.toggleLock('logline'));
+      await act(async () => { result.current.toggleLock('logline'); });
       expect(apiMocks.updateUniverse).toHaveBeenLastCalledWith(
         'u1',
         { locked: {} },
@@ -694,22 +694,49 @@ describe('useUniverseDraft', () => {
       const { result } = renderDraft();
       await waitFor(() => expect(result.current.draft.id).toBe('u1'));
 
-      act(() => {
+      await act(async () => {
         result.current.toggleLock('logline');
         result.current.toggleLock('logline');
       });
 
-      expect(apiMocks.updateUniverse).toHaveBeenCalledTimes(2);
       expect(apiMocks.updateUniverse.mock.calls.map((call) => call[1]))
         .toEqual([{ locked: { logline: true } }, { locked: {} }]);
       expect(result.current.draft.locked).toEqual({});
+    });
+
+    // The server replaces `locked` wholesale per PATCH, so if those two writes
+    // reached it reversed the record would persist the lock the user just
+    // cleared. Holding the first request open proves the second is not even
+    // issued until it settles.
+    it('holds the second lock write until the first has settled', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      let releaseFirst;
+      apiMocks.updateUniverse.mockImplementationOnce(
+        () => new Promise((resolve) => { releaseFirst = resolve; }),
+      );
+
+      await act(async () => {
+        result.current.toggleLock('logline');
+        result.current.toggleLock('logline');
+      });
+      expect(apiMocks.updateUniverse).toHaveBeenCalledTimes(1);
+
+      await act(async () => { releaseFirst({ ...universe, locked: { logline: true } }); });
+
+      expect(apiMocks.updateUniverse).toHaveBeenCalledTimes(2);
+      expect(apiMocks.updateUniverse).toHaveBeenLastCalledWith(
+        'u1',
+        { locked: {} },
+        { silent: true },
+      );
     });
 
     it('accepts the per-influence-list lock keys, not just the bible scalars', async () => {
       const { result } = renderDraft();
       await waitFor(() => expect(result.current.draft.id).toBe('u1'));
 
-      act(() => result.current.toggleLock('influencesEmbrace'));
+      await act(async () => { result.current.toggleLock('influencesEmbrace'); });
 
       // `influencesEmbrace` / `influencesAvoid` are real LOCKABLE_FIELDS keys;
       // the legacy whole-block `influences` key is not what the UI writes.
@@ -724,7 +751,7 @@ describe('useUniverseDraft', () => {
       const { result } = renderDraft();
       await waitFor(() => expect(result.current.draft.id).toBe('u1'));
 
-      act(() => result.current.toggleLock('categories'));
+      await act(async () => { result.current.toggleLock('categories'); });
 
       expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
       expect(result.current.draft.locked).toEqual({});
@@ -734,7 +761,7 @@ describe('useUniverseDraft', () => {
       const { result } = renderUnsaved();
       await waitFor(() => expect(result.current.loading).toBe(false));
 
-      act(() => result.current.toggleLock('premise'));
+      await act(async () => { result.current.toggleLock('premise'); });
 
       expect(result.current.draft.locked).toEqual({ premise: true });
       expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
@@ -749,7 +776,7 @@ describe('useUniverseDraft', () => {
       const { result } = renderDraft({ wrapper: StrictMode });
       await waitFor(() => expect(result.current.draft.id).toBe('u1'));
 
-      act(() => result.current.toggleLock('logline'));
+      await act(async () => { result.current.toggleLock('logline'); });
 
       expect(apiMocks.updateUniverse).toHaveBeenCalledTimes(1);
       expect(result.current.draft.locked).toEqual({ logline: true });

--- a/client/src/hooks/useUniverseDraft.test.jsx
+++ b/client/src/hooks/useUniverseDraft.test.jsx
@@ -1,6 +1,13 @@
+import { StrictMode } from 'react';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// These constant stand-ins mirror the REAL values exported from
+// services/apiUniverseBuilder.js (WORLD_CATEGORIES, WORLD_LOCKABLE_FIELDS,
+// WORLD_CATEGORY_KEY_MAX). Because the suite mocks the whole api module, a
+// convenience list here that drifts from the shipped one would let a body the
+// server's `.strict()` Zod schemas reject pass green — the exact failure mode
+// this suite's wire-shape assertions exist to catch.
 const apiMocks = vi.hoisted(() => ({
   addUniverseStyleReference: vi.fn(),
   createUniverse: vi.fn(),
@@ -15,8 +22,10 @@ const apiMocks = vi.hoisted(() => ({
   removeUniverseStyleReference: vi.fn(),
   updateUniverse: vi.fn(),
   WORLD_CATEGORY_KEY_MAX: 64,
-  WORLD_CATEGORIES: ['characters', 'places', 'objects'],
-  WORLD_LOCKABLE_FIELDS: ['starterPrompt', 'logline', 'premise', 'styleNotes'],
+  WORLD_CATEGORIES: ['landscapes', 'environments', 'structures', 'vehicles'],
+  WORLD_LOCKABLE_FIELDS: [
+    'starterPrompt', 'logline', 'premise', 'styleNotes', 'influencesEmbrace', 'influencesAvoid',
+  ],
   ensureInfluences: (value) => ({
     embrace: Array.isArray(value?.embrace) ? value.embrace : [],
     avoid: Array.isArray(value?.avoid) ? value.avoid : [],
@@ -78,6 +87,10 @@ beforeEach(() => {
   apiMocks.updateUniverse.mockImplementation(async (id, payload) => ({
     ...universe, id, ...payload, updatedAt: tickServerClock(),
   }));
+  apiMocks.createUniverse.mockImplementation(async (payload) => ({
+    ...universe, ...payload, id: 'u-new', updatedAt: tickServerClock(),
+  }));
+  apiMocks.deleteUniverse.mockResolvedValue({ ok: true });
   apiMocks.addUniverseStyleReference.mockImplementation(async (id, { reference, adopt } = {}) => {
     const next = [...serverRefsFor(id), reference];
     serverReferences.set(id, next);
@@ -92,11 +105,31 @@ beforeEach(() => {
   });
 });
 
-const renderDraft = () => {
+const renderDraft = (options) => {
   const goToWorld = vi.fn();
-  const hook = renderHook(() => useUniverseDraft({ selectedId: 'u1', goToWorld }));
+  const hook = renderHook(() => useUniverseDraft({ selectedId: 'u1', goToWorld }), options);
   return { ...hook, goToWorld };
 };
+
+// An unsaved universe: no `selectedId`, so the draft starts from
+// createEmptyUniverseDraft() and every mutator takes its "nothing to PATCH
+// yet, defer to the next Save" branch.
+const renderUnsaved = () => {
+  const goToWorld = vi.fn();
+  const hook = renderHook(() => useUniverseDraft({ selectedId: null, goToWorld }));
+  return { ...hook, goToWorld };
+};
+
+// The seeded bucket map every draft starts from — the four WORLD_CATEGORIES
+// with no `kind` yet. Spelled out (rather than derived from
+// ensureDraftCategories) so a create payload assertion pins the literal wire
+// shape instead of restating the implementation.
+const seededCategories = () => ({
+  landscapes: { variations: [] },
+  environments: { variations: [] },
+  structures: { variations: [] },
+  vehicles: { variations: [] },
+});
 
 // A second universe to navigate to, for the tests that exercise a selection
 // switch. Overridden per-test where the switch target needs its own references.
@@ -570,5 +603,520 @@ describe('useUniverseDraft', () => {
     expect(ok).toBe(false);
     expect(toastMock.error).toHaveBeenCalledWith('Reference save failed: at capacity');
     expect(result.current.draft.styleReferences).toEqual([]);
+  });
+
+  // ---- Destructive: delete (#3290) ----
+
+  describe('handleDelete', () => {
+    it('drops the universe from the list, clears the draft, and navigates away', async () => {
+      const { result, goToWorld } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      act(() => result.current.setPendingDeleteId('u1'));
+
+      await act(async () => { await result.current.handleDelete(); });
+
+      expect(apiMocks.deleteUniverse).toHaveBeenCalledWith('u1', { silent: true });
+      expect(result.current.universes).toEqual([]);
+      expect(result.current.draft.id).toBeUndefined();
+      expect(result.current.draft.name).toBe('');
+      expect(result.current.pendingDeleteId).toBe(null);
+      expect(goToWorld).toHaveBeenCalledWith(null);
+      expect(toastMock.success).toHaveBeenCalledWith('World deleted');
+    });
+
+    // The failure path is the one that matters: a delete that 500s must leave
+    // the user exactly where they were, still looking at the record. Navigating
+    // away (or filtering the list) on a failed delete would make a live
+    // universe look gone until the next reload.
+    it('keeps the universe and stays put when the delete fails', async () => {
+      const { result, goToWorld } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      apiMocks.deleteUniverse.mockRejectedValueOnce(new Error('record is locked'));
+
+      await act(async () => { await result.current.handleDelete(); });
+
+      expect(toastMock.error).toHaveBeenCalledWith('Delete failed: record is locked');
+      expect(result.current.universes).toEqual([universe]);
+      expect(result.current.draft.id).toBe('u1');
+      expect(goToWorld).not.toHaveBeenCalled();
+      expect(toastMock.success).not.toHaveBeenCalledWith('World deleted');
+    });
+
+    it('is a no-op on an unsaved universe', async () => {
+      const { result, goToWorld } = renderUnsaved();
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => { await result.current.handleDelete(); });
+
+      expect(apiMocks.deleteUniverse).not.toHaveBeenCalled();
+      expect(goToWorld).not.toHaveBeenCalled();
+    });
+  });
+
+  // ---- Fire-and-forget PATCHes: exact wire bodies (#3290) ----
+  //
+  // Each of these sends a targeted PATCH whose body the mocked api module can
+  // never validate. The server's patchSchema is built from `.strict()` pieces
+  // (lockedSchema, influencesSchema) and refuses an empty patch outright, so a
+  // body that drifts here 400s in production behind a green suite. These
+  // assertions therefore pin the EXACT object handed to updateUniverse, not
+  // just "some call happened".
+
+  describe('toggleLock', () => {
+    it('PATCHes only the lock map when a field is locked, and again when it is cleared', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      act(() => result.current.toggleLock('logline'));
+      expect(apiMocks.updateUniverse).toHaveBeenLastCalledWith(
+        'u1',
+        { locked: { logline: true } },
+        { silent: true },
+      );
+      expect(result.current.draft.locked).toEqual({ logline: true });
+
+      // Unlocking DELETES the key rather than writing `false` — the stored map
+      // is sparse, and lockedSchema is strict about nothing else riding along.
+      act(() => result.current.toggleLock('logline'));
+      expect(apiMocks.updateUniverse).toHaveBeenLastCalledWith(
+        'u1',
+        { locked: {} },
+        { silent: true },
+      );
+      expect(result.current.draft.locked).toEqual({});
+    });
+
+    it('accepts the per-influence-list lock keys, not just the bible scalars', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      act(() => result.current.toggleLock('influencesEmbrace'));
+
+      // `influencesEmbrace` / `influencesAvoid` are real LOCKABLE_FIELDS keys;
+      // the legacy whole-block `influences` key is not what the UI writes.
+      expect(apiMocks.updateUniverse).toHaveBeenLastCalledWith(
+        'u1',
+        { locked: { influencesEmbrace: true } },
+        { silent: true },
+      );
+    });
+
+    it('ignores a field that is not lockable', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      act(() => result.current.toggleLock('categories'));
+
+      expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
+      expect(result.current.draft.locked).toEqual({});
+    });
+
+    it('updates the draft without PATCHing an unsaved universe', async () => {
+      const { result } = renderUnsaved();
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      act(() => result.current.toggleLock('premise'));
+
+      expect(result.current.draft.locked).toEqual({ premise: true });
+      expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
+    });
+
+    // Regression (#3290): the PATCH used to be issued from inside the setDraft
+    // updater. React may invoke an updater more than once per setState — under
+    // StrictMode it always does — so a single lock click sent two identical
+    // PATCHes. State updaters must be pure; the request belongs beside
+    // setRenderPin's, outside the updater.
+    it('sends exactly one PATCH per toggle under StrictMode', async () => {
+      const { result } = renderDraft({ wrapper: StrictMode });
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      act(() => result.current.toggleLock('logline'));
+
+      expect(apiMocks.updateUniverse).toHaveBeenCalledTimes(1);
+      expect(result.current.draft.locked).toEqual({ logline: true });
+    });
+
+    it('surfaces a failed lock save', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      apiMocks.updateUniverse.mockRejectedValueOnce(new Error('write queue busy'));
+
+      await act(async () => { result.current.toggleLock('premise'); });
+
+      expect(toastMock.error).toHaveBeenCalledWith('Lock save failed: write queue busy');
+    });
+  });
+
+  describe('setRenderPin', () => {
+    it('PATCHes both pin fields together and mirrors them onto the draft', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      await act(async () => {
+        result.current.setRenderPin({ imageMode: 'local', imageModelId: null });
+      });
+
+      expect(apiMocks.updateUniverse).toHaveBeenLastCalledWith(
+        'u1',
+        { imageMode: 'local', imageModelId: null },
+        { silent: true },
+      );
+      expect(result.current.draft).toMatchObject({ imageMode: 'local', imageModelId: null });
+    });
+
+    // Clearing the pin must send explicit nulls, never omit the keys: an
+    // all-undefined body JSON.stringifies to `{}`, which the server's
+    // "patch must include at least one field" refinement rejects — and
+    // key-absent means "preserve" there, so the pin would never clear.
+    it('clears the pin with explicit nulls rather than an empty patch', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      await act(async () => {
+        result.current.setRenderPin({ imageMode: null, imageModelId: null });
+      });
+
+      const body = apiMocks.updateUniverse.mock.calls.at(-1)[1];
+      expect(body).toEqual({ imageMode: null, imageModelId: null });
+      expect(Object.keys(JSON.parse(JSON.stringify(body)))).toEqual(['imageMode', 'imageModelId']);
+    });
+
+    it('updates the draft without PATCHing an unsaved universe', async () => {
+      const { result } = renderUnsaved();
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => {
+        result.current.setRenderPin({ imageMode: 'agy', imageModelId: 'imagen-3' });
+      });
+
+      expect(result.current.draft).toMatchObject({ imageMode: 'agy', imageModelId: 'imagen-3' });
+      expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
+    });
+
+    it('surfaces a failed pin save', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      apiMocks.updateUniverse.mockRejectedValueOnce(new Error('unknown model'));
+
+      await act(async () => {
+        result.current.setRenderPin({ imageMode: 'agy', imageModelId: 'nope' });
+      });
+
+      expect(toastMock.error).toHaveBeenCalledWith('Render pin save failed: unknown model');
+    });
+  });
+
+  describe('assignBucketKind', () => {
+    it('PATCHes only the moved bucket, keyed by bucket name', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      await act(async () => { await result.current.assignBucketKind('heroes', 'places'); });
+
+      // A single-key `categories` map: the server merges per bucket key, so
+      // sending the whole map would be both wasteful and a clobber risk.
+      expect(apiMocks.updateUniverse).toHaveBeenLastCalledWith(
+        'u1',
+        { categories: { heroes: { kind: 'places', variations: [] } } },
+        { silent: true },
+      );
+      expect(result.current.draft.categories.heroes.kind).toBe('places');
+      expect(result.current.universes[0].categories.heroes.kind).toBe('places');
+      expect(toastMock.success).toHaveBeenCalledWith('Moved "Heroes" to Places');
+    });
+
+    it('tags the bucket locally and defers to Save on an unsaved universe', async () => {
+      const { result } = renderUnsaved();
+      await waitFor(() => expect(result.current.loading).toBe(false));
+
+      await act(async () => { await result.current.assignBucketKind('landscapes', 'places'); });
+
+      expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
+      expect(result.current.draft.categories.landscapes).toEqual({ kind: 'places', variations: [] });
+      expect(toastMock.success).toHaveBeenCalledWith('Tagged "Landscapes" as Places — save to persist');
+    });
+
+    it('ignores an unknown trunk kind or an unknown bucket', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      await act(async () => {
+        await result.current.assignBucketKind('heroes', 'sidekicks');
+        await result.current.assignBucketKind('no-such-bucket', 'places');
+      });
+
+      expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
+      expect(result.current.draft.categories.heroes.kind).toBe('characters');
+    });
+
+    it('surfaces a failed move and leaves the list untouched', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      apiMocks.updateUniverse.mockRejectedValueOnce(new Error('bucket cap reached'));
+
+      await act(async () => { await result.current.assignBucketKind('heroes', 'objects'); });
+
+      expect(toastMock.error).toHaveBeenCalledWith('Move failed: bucket cap reached');
+      // The optimistic local move stands (same contract as toggleLock /
+      // setRenderPin); only the shared list is left alone.
+      expect(result.current.universes[0].categories.heroes.kind).toBe('characters');
+    });
+  });
+
+  // ---- Local category + draft editors (#3290) ----
+
+  describe('addCategory', () => {
+    it('normalizes the typed name into a bucket key and clears the input', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      act(() => result.current.setNewCategoryName('Ancient Ruins & Relics'));
+      act(() => result.current.addCategory());
+
+      expect(result.current.draft.categories.ancient_ruins_and_relics).toEqual({ variations: [] });
+      expect(result.current.newCategoryName).toBe('');
+      expect(toastMock.error).not.toHaveBeenCalled();
+    });
+
+    it('rejects a name that normalizes onto an existing bucket', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      // 'Heroes' normalizes to the `heroes` key the universe already has.
+      act(() => result.current.setNewCategoryName('Heroes'));
+      act(() => result.current.addCategory());
+
+      expect(toastMock.error).toHaveBeenCalledWith('Category already exists');
+      // Untouched — including the input, so the user can correct it in place.
+      expect(result.current.draft.categories.heroes).toEqual({ kind: 'characters', variations: [] });
+      expect(result.current.newCategoryName).toBe('Heroes');
+    });
+
+    it('rejects a name with no usable characters', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      const before = result.current.draft.categories;
+
+      act(() => result.current.setNewCategoryName('!!! ???'));
+      act(() => result.current.addCategory());
+
+      expect(toastMock.error).toHaveBeenCalledWith('Use letters or numbers for the category name');
+      expect(result.current.draft.categories).toEqual(before);
+    });
+  });
+
+  describe('removeCategory', () => {
+    it('removes a custom bucket outright', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      act(() => result.current.removeCategory('heroes'));
+
+      expect(result.current.draft.categories).not.toHaveProperty('heroes');
+      expect(result.current.draft.categories).toEqual(seededCategories());
+    });
+
+    // A built-in bucket can't actually be removed — the server re-seeds all
+    // four WORLD_CATEGORIES on every read, so removing one empties it instead.
+    // Mirroring that here keeps the draft from showing a bucket-shaped hole the
+    // next hydration would fill back in.
+    it('empties rather than deletes a built-in bucket', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      const variation = { id: 'v1', label: 'Salt flats', prompt: 'a cracked white plain' };
+      act(() => result.current.updateCategory('landscapes', [variation]));
+      expect(result.current.draft.categories.landscapes.variations).toEqual([variation]);
+
+      act(() => result.current.removeCategory('landscapes'));
+
+      expect(result.current.draft.categories.landscapes).toEqual({ variations: [] });
+    });
+  });
+
+  it('updateCategory replaces one bucket\'s variations while preserving its kind', async () => {
+    const { result } = renderDraft();
+    await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+    const variation = { id: 'v1', label: 'Scout', prompt: 'a wiry outrider' };
+
+    act(() => result.current.updateCategory('heroes', [variation]));
+
+    expect(result.current.draft.categories.heroes).toEqual({
+      kind: 'characters',
+      variations: [variation],
+    });
+    expect(result.current.isDraftDirty()).toBe(true);
+    // Local edit only — it rides along on the next general Save.
+    expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
+  });
+
+  it('updateCompositeSheets replaces the sheet list on the draft', async () => {
+    const { result } = renderDraft();
+    await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+    const sheets = [{ id: 's1', kind: 'reference_sheet', label: 'Cast board', prompt: 'six figures' }];
+
+    act(() => result.current.updateCompositeSheets(sheets));
+
+    expect(result.current.draft.compositeSheets).toEqual(sheets);
+    expect(result.current.isDraftDirty()).toBe(true);
+    expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
+  });
+
+  // ---- Save preflight + canon reconciliation (#3290) ----
+
+  describe('flushDraftIfDirty', () => {
+    it('reports success without saving when the draft is clean', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      let flushed;
+      await act(async () => { flushed = await result.current.flushDraftIfDirty(); });
+
+      expect(flushed).toBe(true);
+      expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
+    });
+
+    it('saves a dirty draft first so the server acts on what the user sees', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      act(() => result.current.updateDraft({ premise: 'Pre-flight premise' }));
+
+      let flushed;
+      await act(async () => { flushed = await result.current.flushDraftIfDirty(); });
+
+      expect(flushed).toBe(true);
+      expect(apiMocks.updateUniverse.mock.calls.at(-1)[1].premise).toBe('Pre-flight premise');
+      expect(result.current.isDraftDirty()).toBe(false);
+    });
+
+    it('reports failure when the preflight save fails, so the caller aborts', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      act(() => result.current.updateDraft({ premise: 'Doomed premise' }));
+      apiMocks.updateUniverse.mockRejectedValueOnce(new Error('disk full'));
+
+      let flushed;
+      await act(async () => { flushed = await result.current.flushDraftIfDirty(); });
+
+      expect(flushed).toBe(false);
+      expect(toastMock.error).toHaveBeenCalledWith('Save failed: disk full');
+    });
+  });
+
+  describe('handleCanonChange', () => {
+    it('adopts the canon editor\'s arrays wholesale when nothing is pending', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      act(() => result.current.handleCanonChange({
+        characters: [{ name: 'Editor Character' }],
+        places: [{ name: 'Editor Place' }],
+        objects: [],
+        updatedAt: '2026-02-02T00:00:00.000Z',
+      }));
+
+      expect(result.current.draft.characters).toEqual([{ name: 'Editor Character' }]);
+      expect(result.current.draft.places).toEqual([{ name: 'Editor Place' }]);
+      expect(result.current.draft.objects).toEqual([]);
+      expect(result.current.draft.updatedAt).toBe('2026-02-02T00:00:00.000Z');
+    });
+
+    it('preserves unsaved additions when canon is dirty', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      act(() => {
+        result.current.setCanonDirty(true);
+        result.current.pendingCanonAdditionsRef.current.characters = [{ name: 'Pending Character' }];
+      });
+
+      act(() => result.current.handleCanonChange({
+        characters: [{ name: 'Editor Character' }],
+        places: [],
+        objects: [],
+        updatedAt: '2026-02-02T00:00:00.000Z',
+      }));
+
+      // The editor's list wins on collision; the not-yet-saved addition is
+      // appended rather than dropped on the floor.
+      expect(result.current.draft.characters.map((entry) => entry.name))
+        .toEqual(['Editor Character', 'Pending Character']);
+    });
+
+    it('ignores a null payload', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      act(() => result.current.handleCanonChange(null));
+
+      expect(result.current.draft.characters).toEqual([{ name: 'Stale Draft Character' }]);
+    });
+  });
+
+  // ---- Create-a-second-universe from the name field (#3290) ----
+
+  describe('handleCreateNamed', () => {
+    it('creates a blank universe alongside the selected one and navigates to it', async () => {
+      const { result, goToWorld } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      await act(async () => { await result.current.handleCreateNamed('  Spin-off World  '); });
+
+      // A named-create is deliberately EMPTY apart from the name — it must not
+      // carry the currently open universe's bible over to the new record.
+      expect(apiMocks.createUniverse).toHaveBeenCalledWith({
+        name: 'Spin-off World',
+        starterPrompt: '',
+        logline: '',
+        premise: '',
+        styleNotes: '',
+        categories: seededCategories(),
+        compositeSheets: [],
+        influences: { embrace: [], avoid: [] },
+        styleReferences: [],
+        locked: {},
+        llm: { provider: null, model: null },
+      }, { silent: true });
+      expect(apiMocks.updateUniverse).not.toHaveBeenCalled();
+      expect(result.current.universes[0].id).toBe('u-new');
+      expect(goToWorld).toHaveBeenCalledWith('u-new');
+      expect(toastMock.success).toHaveBeenCalledWith('World created');
+    });
+
+    it('rejects an all-whitespace name before touching the server', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      await act(async () => { await result.current.handleCreateNamed('   '); });
+
+      expect(toastMock.error).toHaveBeenCalledWith('Name is required');
+      expect(apiMocks.createUniverse).not.toHaveBeenCalled();
+    });
+
+    it('falls through to the normal Save on an unsaved universe', async () => {
+      const { result, goToWorld } = renderUnsaved();
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      act(() => result.current.updateDraft({ name: 'Fresh World', premise: 'Typed premise' }));
+
+      await act(async () => { await result.current.handleCreateNamed('Fresh World'); });
+
+      // handleSave's payload, not the blank-draft one — the premise the user
+      // already typed has to survive the create.
+      const payload = apiMocks.createUniverse.mock.calls.at(-1)[0];
+      expect(payload).toMatchObject({ name: 'Fresh World', premise: 'Typed premise' });
+      expect(payload.characters).toEqual([]);
+      expect(goToWorld).toHaveBeenCalledWith('u-new');
+    });
+
+    it('surfaces a failed create and stays on the current universe', async () => {
+      const { result, goToWorld } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+      apiMocks.createUniverse.mockRejectedValueOnce(new Error('name taken'));
+
+      await act(async () => { await result.current.handleCreateNamed('Spin-off World'); });
+
+      expect(toastMock.error).toHaveBeenCalledWith('Create failed: name taken');
+      expect(result.current.universes).toEqual([universe]);
+      expect(result.current.saving).toBe(false);
+      expect(goToWorld).not.toHaveBeenCalled();
+    });
   });
 });

--- a/client/src/hooks/useUniverseDraft.test.jsx
+++ b/client/src/hooks/useUniverseDraft.test.jsx
@@ -732,6 +732,32 @@ describe('useUniverseDraft', () => {
       );
     });
 
+    // The tail is per universe, not per hook. A request has no timeout, so one
+    // stalled write for the universe the user just left must not block every
+    // lock on the one they navigated to — silently, since the draft still
+    // updates optimistically either way.
+    it('does not let a stalled lock write for one universe block another', async () => {
+      apiMocks.getUniverse.mockImplementation(async (id) => (id === 'u2' ? universeTwo : universe));
+      const { result, rerender } = renderSelectable();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      // u1's lock write never settles.
+      apiMocks.updateUniverse.mockImplementationOnce(() => new Promise(() => {}));
+      await act(async () => { result.current.toggleLock('logline'); });
+      expect(apiMocks.updateUniverse).toHaveBeenCalledTimes(1);
+
+      await act(async () => { rerender({ selectedId: 'u2' }); });
+      await waitFor(() => expect(result.current.draft.id).toBe('u2'));
+      await act(async () => { result.current.toggleLock('premise'); });
+
+      expect(apiMocks.updateUniverse).toHaveBeenCalledTimes(2);
+      expect(apiMocks.updateUniverse).toHaveBeenLastCalledWith(
+        'u2',
+        { locked: { premise: true } },
+        { silent: true },
+      );
+    });
+
     it('accepts the per-influence-list lock keys, not just the bible scalars', async () => {
       const { result } = renderDraft();
       await waitFor(() => expect(result.current.draft.id).toBe('u1'));

--- a/client/src/hooks/useUniverseDraft.test.jsx
+++ b/client/src/hooks/useUniverseDraft.test.jsx
@@ -686,6 +686,25 @@ describe('useUniverseDraft', () => {
       expect(result.current.draft.locked).toEqual({});
     });
 
+    // Two clicks inside one tick: the lock map has to compose across them.
+    // `draftRef` is normally refreshed by a passive effect that runs a commit
+    // later, so a naive read of it would let the second toggle re-send the
+    // first's write and leave the field locked forever.
+    it('composes back-to-back toggles that land before a re-render', async () => {
+      const { result } = renderDraft();
+      await waitFor(() => expect(result.current.draft.id).toBe('u1'));
+
+      act(() => {
+        result.current.toggleLock('logline');
+        result.current.toggleLock('logline');
+      });
+
+      expect(apiMocks.updateUniverse).toHaveBeenCalledTimes(2);
+      expect(apiMocks.updateUniverse.mock.calls.map((call) => call[1]))
+        .toEqual([{ locked: { logline: true } }, { locked: {} }]);
+      expect(result.current.draft.locked).toEqual({});
+    });
+
     it('accepts the per-influence-list lock keys, not just the bible scalars', async () => {
       const { result } = renderDraft();
       await waitFor(() => expect(result.current.draft.id).toBe('u1'));


### PR DESCRIPTION
## Summary

`client/src/hooks/useUniverseDraft.js` exports ~20 functions; 11 of them had no coverage at all, and the hook's only consumer (`UniverseBuilderPage.jsx`) has no test file, so none were exercised end to end either. This adds 38 cases covering `handleDelete`, `toggleLock`, `setRenderPin`, `assignBucketKind`, `addCategory`, `removeCategory`, `updateCategory`, `updateCompositeSheets`, `flushDraftIfDirty`, `handleCanonChange` and `handleCreateNamed`.

Writing them surfaced a real bug in `toggleLock`, and fixing it correctly took three passes — each with a regression test verified failing without its fix:

1. **Two PATCHes per click.** `toggleLock` issued its `updateUniverse` PATCH from *inside* the `setDraft` updater. A state updater must be pure — React is free to invoke it more than once per `setState`, and always does under `StrictMode`, which this app runs under — so one lock click sent two identical writes into the record's write queue. The request now fires beside `setDraft`, matching `setRenderPin` and `assignBucketKind`.
2. **Same-tick toggles stopped composing.** Reading the lock map from `draftRef` reintroduced staleness the functional updater had been hiding: the effect that syncs `draftRef` runs a commit later, so two clicks before it ran both saw the pre-toggle map and the second re-sent the first's write. `draftRef`'s `locked` slot is now advanced synchronously; the functional updater still owns the draft, so a concurrent edit to another field is unaffected.
3. **Ordering, then head-of-line blocking.** The server replaces `locked` wholesale per PATCH, so two writes landing reversed persist the lock the user just cleared. Lock writes are now chained onto a tail — keyed *per universe*, because requests here have no timeout and a single shared tail would let a stalled write for the universe the user just left block every lock on the one they navigated to, indefinitely and invisibly (the draft updates optimistically either way).

Only `toggleLock` is touched. The style-reference mutators deliberately have no such tail — they send deltas the server applies in any order (#3109), which is the difference that makes one necessary here.

### Wire-shape verification

The three fire-and-forget mutators assert the *exact* body handed to `updateUniverse`, not just "some call happened" — this suite mocks `services/api`, so a body the server's strict Zod `patchSchema` would reject stays invisible until it 400s in production. Each asserted body was cross-checked against `server/routes/universeBuilder.js`:

- `toggleLock` → `{ locked: { <field>: true } }` against the `.strict()` `lockedSchema`; unlock deletes the key rather than writing `false`, matching the sparse stored shape.
- `setRenderPin` → `{ imageMode, imageModelId }` against `recordRenderPinFields`; a test pins that clearing sends explicit `null`s, since an all-`undefined` body `JSON.stringify`s to `{}` and the schema's "patch must include at least one field" refinement would reject it.
- `assignBucketKind` → a single-key `{ categories: { <bucket>: { kind, variations } } }` against `categoriesSchema`, matching the server's per-key `categories` merge.

No mismatch was found in the bodies themselves. The mocked `WORLD_CATEGORIES` / `WORLD_LOCKABLE_FIELDS` stand-ins *were* wrong, though: they named categories that do not exist (`characters`/`places`/`objects` instead of `landscapes`/`environments`/`structures`/`vehicles`) and omitted the two influence lock keys. Both are corrected to the real shipped lists, so the assertions run against constants the server actually accepts.

Closes #3290

## Test plan

- `cd client && npx vitest run src/hooks/useUniverseDraft.test.jsx` — 53 passed (15 pre-existing + 38 new).
- `cd client && npm test` — 512 files / 5862 tests passed, no collateral breakage.
- `npx eslint src/hooks/useUniverseDraft.js src/hooks/useUniverseDraft.test.jsx` — clean.
- Each of the three fixes was confirmed by reverting it and watching only its own test fail: `sends exactly one PATCH per toggle under StrictMode` (2 calls), `composes back-to-back toggles that land before a re-render` (second toggle re-sent the first's map), `holds the second lock write until the first has settled` (both flew immediately), `does not let a stalled lock write for one universe block another` (u2's write never issued).