### PR TITLE
Stamp media-collection provenance server-side instead of guessing it on the client

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -120,3 +120,7 @@
 ## Creative Director
 
 - **[issue-3287] The developer smoke test no longer leads the Creative Director action bar.** `Run smoke test` sat in the leading position of a four-button header where the eye lands first, named a mechanism rather than an outcome, and consumed one of the seven interactive elements that fit above the fold on a phone — despite spending real render time on every click. It now lives behind a "…" menu beside `Model defaults`, reads `Render a 6s test clip` so the cost is legible before you commit, and asks for an inline confirmation naming what it will spend. The header bar reads `New directive` · `Model defaults` · `New project`.
+
+## Media Collections
+
+- **[issue-3311] A collection now records who created it instead of the grid guessing from its name.** The "auto-generated" ordering and badge shipped in #3283 reverse-engineered provenance on the client from four independent clues — a name prefix, an `Auto-…` description, a `uc-`/`sc-` id, or a universe/series link — so every new machine-created bucket quietly sorted as if you had made it yourself until someone remembered to extend that list. Collections are now stamped `auto` or `user` when they are created, existing ones were classified once by a migration, and the old clue-matching only runs for a record a peer on an older version has not stamped yet.

--- a/client/src/lib/mediaCollectionList.js
+++ b/client/src/lib/mediaCollectionList.js
@@ -15,7 +15,12 @@ import { tokenizeQuery, matchHaystack } from './mediaSearch.js';
 // make, paired with the badge label the card renders above the title instead
 // of inside it — otherwise every auto-generated card shows the same clipped
 // prefix and the trailing project name/date that tells them apart is what gets
-// cut. Keep in sync with the server-side creators: `universeCollectionNameFor`
+// cut. This list drives PRESENTATION (the badge) plus the provenance fallback
+// for records an older peer sent without a `source` stamp — the classification
+// itself comes from `collection.source` now (#3311), so a new auto-creator only
+// has to stamp `source: 'auto'` server-side, not extend this list (it should
+// still add its prefix here if it wants the badge). Keep in sync with the
+// server-side creators: `universeCollectionNameFor`
 // / `seriesCollectionNameFor` in `server/services/mediaCollections.js`,
 // `server/services/creativeDirector/projects{DB,File}.js`, and
 // `server/services/writersRoom/local.js`.
@@ -59,14 +64,26 @@ export function splitCollectionName(name) {
 
 /**
  * True when a collection was created by an automated flow rather than by the
- * user. Any one of the four independent markers is sufficient — an install can
- * hold records from before a given marker existed, so this must not require
- * all of them to agree.
+ * user.
+ *
+ * The server stamps provenance at mint time (`source: 'auto' | 'user'`, #3311)
+ * and migration 220 backfilled existing records, so the stamp is authoritative
+ * whenever it is present — a new auto-creator no longer has to remember to
+ * extend a client-side list.
+ *
+ * An ABSENT `source` is a third state, NOT a synonym for `'user'`: the record
+ * came from a federated peer still running a PortOS that predates the field (or
+ * was restored from a pre-migration backup). Those fall back to the marker
+ * heuristic below, where any ONE of the four independent markers is sufficient
+ * — an install can hold records from before a given marker existed, so this
+ * must not require all of them to agree.
  * @param {object} collection
  * @returns {boolean}
  */
 export function isAutoCollection(collection) {
   if (!collection || collection.synthetic) return false;
+  if (collection.source === 'auto') return true;
+  if (collection.source === 'user') return false;
   if (splitCollectionName(collection.name).badge) return true;
   const description = typeof collection.description === 'string' ? collection.description : '';
   if (AUTO_DESCRIPTION_PREFIXES.some((p) => description.startsWith(p))) return true;

--- a/client/src/lib/mediaCollectionList.js
+++ b/client/src/lib/mediaCollectionList.js
@@ -71,10 +71,13 @@ export function splitCollectionName(name) {
  * whenever it is present — a new auto-creator no longer has to remember to
  * extend a client-side list.
  *
- * An ABSENT `source` is a third state, NOT a synonym for `'user'`: the record
- * came from a federated peer still running a PortOS that predates the field (or
- * was restored from a pre-migration backup). Those fall back to the marker
- * heuristic below, where any ONE of the four independent markers is sufficient
+ * An ABSENT `source` is a third state, NOT a synonym for `'user'`. The stamp is
+ * local to each install (it is stripped from the sync wire — see
+ * `sanitizeRecordForWire`), so an unstamped record is one this install received
+ * from a peer after its own migration ran, or restored from a pre-migration
+ * backup. Those fall back to the marker heuristic below, which is what
+ * classified every collection before #3311 — so the fallback is never worse
+ * than the old behavior. Any ONE of the four independent markers is sufficient
  * — an install can hold records from before a given marker existed, so this
  * must not require all of them to agree.
  * @param {object} collection

--- a/client/src/lib/mediaCollectionList.test.js
+++ b/client/src/lib/mediaCollectionList.test.js
@@ -64,6 +64,25 @@ describe('isAutoCollection', () => {
     expect(isAutoCollection(unsorted)).toBe(false);
     expect(isAutoCollection(null)).toBe(false);
   });
+
+  it('prefers the server-stamped source over the markers in both directions', () => {
+    // source:'auto' classifies a record no marker would have caught — the whole
+    // point of stamping provenance server-side (#3311).
+    expect(isAutoCollection({ id: 'x', name: 'Nightly Renders', source: 'auto' })).toBe(true);
+    // source:'user' wins over a name that merely looks auto-generated.
+    expect(isAutoCollection({ id: 'x', name: 'Universe: My Own Bucket', source: 'user' })).toBe(false);
+    expect(isAutoCollection({ id: 'x', name: 'Foo', universeId: 'u1', source: 'user' })).toBe(false);
+    // Synthetic still short-circuits ahead of any stamp.
+    expect(isAutoCollection({ ...unsorted, source: 'auto' })).toBe(false);
+  });
+
+  it('falls back to the markers when a peer sends no source at all', () => {
+    // An older peer strips the field; absent must NOT read as 'user'.
+    expect(isAutoCollection({ id: 'uc-universe-1', name: 'Universe: Example' })).toBe(true);
+    expect(isAutoCollection({ id: 'x', name: 'Concept Art', source: undefined })).toBe(false);
+    // A garbage value is not a stamp either — fall through to the markers.
+    expect(isAutoCollection({ id: 'x', name: 'Writers Room: The Deep', source: 'nonsense' })).toBe(true);
+  });
 });
 
 describe('collectionItemCount', () => {

--- a/scripts/migrations/220-backfill-media-collection-source.js
+++ b/scripts/migrations/220-backfill-media-collection-source.js
@@ -58,15 +58,21 @@ import { join } from 'path';
 // The client heuristic has a FOURTH marker this migration deliberately does not
 // use: the `Creative Director: ` / `Writers Room: ` / `Universe: ` / `Series: `
 // NAME prefix. Nothing reserves those prefixes — the create route takes a free
-// name — so a user-made collection called `Universe: Notes` matches it, and
-// stamping is permanent (a stamped record is skipped on every later pass, and
-// there is no API to correct it). Leaving name-only matches unstamped keeps
-// them on the client fallback, which classifies them exactly as it does today
-// and still re-evaluates if the user renames them. Nothing is lost: every real
-// auto-creator also carries one of the markers below — Creative Director and
-// Writers Room stamp an `Auto-…` description (the create form takes a name
-// only, so a user cannot produce one), and universe/series buckets carry the
-// deterministic id and/or the owner link.
+// name — so a user-made collection called `Universe: Notes` matches it, and a
+// stamped record is skipped on every later pass rather than re-evaluated.
+// Leaving name-only matches unstamped keeps them on the client fallback, which
+// classifies them exactly as it does today and still re-evaluates if the user
+// renames them. Nothing is lost: every real auto-creator also carries one of
+// the markers below — Creative Director and Writers Room stamp an `Auto-…`
+// description, and universe/series buckets carry the deterministic id and/or
+// the owner link.
+//
+// The description prefixes are far weaker evidence than the id/link markers
+// (the POST/PATCH routes do accept a free description), but they are the ONLY
+// markers a legacy Creative Director / Writers Room bucket carries — those get
+// a random uuid and no owner link. `PATCH /api/media/collections/:id` accepts
+// `source`, so the rare user collection described as `Auto-created for project
+// …` can be corrected rather than being stuck.
 const AUTO_DESCRIPTION_PREFIXES = ['Auto-created for project ', 'Auto-generated images for '];
 const AUTO_ID_PREFIXES = ['uc-', 'sc-'];
 

--- a/scripts/migrations/220-backfill-media-collection-source.js
+++ b/scripts/migrations/220-backfill-media-collection-source.js
@@ -76,6 +76,8 @@ import { join } from 'path';
 const AUTO_DESCRIPTION_PREFIXES = ['Auto-created for project ', 'Auto-generated images for '];
 const AUTO_ID_PREFIXES = ['uc-', 'sc-'];
 
+const isNonEmptyString = (v) => typeof v === 'string' && v !== '';
+
 /**
  * True when a record carries a marker of machine creation that a user could not
  * have produced through the create form. A subset of `isAutoCollection` in
@@ -89,7 +91,11 @@ export function isAutoCreated(record) {
   if (!record || typeof record !== 'object') return false;
   if (typeof record.description === 'string' && AUTO_DESCRIPTION_PREFIXES.some((p) => record.description.startsWith(p))) return true;
   if (typeof record.id === 'string' && AUTO_ID_PREFIXES.some((p) => record.id.startsWith(p))) return true;
-  return Boolean(record.universeId || record.seriesId);
+  // Owner link must be a non-empty STRING, matching `sanitizeCollection` — this
+  // reads raw disk, where the client only ever sees sanitized records. A
+  // hand-edited/corrupt `universeId: true` is dropped to null on the next read,
+  // so treating it as a machine-owned marker would stamp a record that has none.
+  return isNonEmptyString(record.universeId) || isNonEmptyString(record.seriesId);
 }
 
 /**

--- a/scripts/migrations/220-backfill-media-collection-source.js
+++ b/scripts/migrations/220-backfill-media-collection-source.js
@@ -1,0 +1,138 @@
+/**
+ * Migration 220 — backfill `source: 'auto'` on media collections that a machine
+ * flow created before the field existed (#3311).
+ *
+ * Background:
+ *   Every Creative Director project, Writers Room work, and universe/series
+ *   render bucket auto-files itself as a media collection. Until #3311 nothing
+ *   recorded that fact, so the grid reverse-engineered it on the CLIENT from
+ *   four independent markers — a name prefix, an `Auto-…` description, a
+ *   `uc-`/`sc-` id, or a universe/series link. Every new auto-creator silently
+ *   regressed the ordering until someone remembered to extend that list.
+ *
+ *   `server/services/mediaCollections.js` now stamps `source` at mint time.
+ *   This migration performs the one-time classification of records already on
+ *   disk, using the SAME four markers, so the client heuristic stops being
+ *   load-bearing for anything this install already had.
+ *
+ * What it writes:
+ *   `source: 'auto'` on each live record matching a marker and carrying no
+ *   `source` yet. Nothing else — in particular `updatedAt` is deliberately NOT
+ *   bumped: this is a derived classification, not a user edit, and advancing
+ *   the LWW clock would make every collection look freshly edited to peers and
+ *   out-race real remote edits. `source` is not part of the conflict journal's
+ *   scalar projection either, so no base hashes churn.
+ *
+ * Deliberately NOT written:
+ *   - `source: 'user'` on non-matching records. The client treats an ABSENT
+ *     stamp as "fall back to the marker heuristic", which returns false for
+ *     exactly these records — identical behavior with no extra writes, and no
+ *     risk of freezing a misclassification.
+ *   - Tombstones (`deleted: true`). `deleteCollection` clears the owner links
+ *     and items; nothing renders a tombstone, and rewriting one only adds sync
+ *     noise.
+ *
+ * Cross-install: `source` is additive and rides the wire's `.passthrough()`
+ * record schema, so no `schemaVersions` bump is needed. Peers upgrade and run
+ * this independently; because the markers are deterministic, two peers classify
+ * the same record identically, and `mergeMediaCollectionsFromSync` keeps a stamp
+ * sticky rather than letting an older peer's unstamped copy erase it.
+ *
+ * The legacy monolithic `data/media-collections.json` is not read — migration
+ * 059 split it into `data/media-collections/<id>/index.json` and runs first.
+ *
+ * Idempotent: a record that already carries a `source` is skipped, so a second
+ * pass writes nothing.
+ */
+
+import { readdir, readFile, writeFile, rename } from 'fs/promises';
+import { join } from 'path';
+
+// Frozen snapshot of the markers as of #3311. Kept INLINE rather than imported
+// from `client/src/lib/mediaCollectionList.js` / `services/mediaCollections.js`
+// on purpose: a migration is a point-in-time transform and must not shift if
+// those lists later evolve.
+const AUTO_NAME_PREFIXES = ['Creative Director: ', 'Writers Room: ', 'Universe: ', 'Series: '];
+const AUTO_DESCRIPTION_PREFIXES = ['Auto-created for project ', 'Auto-generated images for '];
+const AUTO_ID_PREFIXES = ['uc-', 'sc-'];
+
+// The name check requires a non-empty remainder (`splitCollectionName` only
+// yields a badge when the title survives the prefix), while the description
+// check is a bare prefix match — mirroring the two client predicates exactly so
+// this migration and the fallback heuristic can never disagree on a record.
+const hasAutoName = (value) =>
+  typeof value === 'string' && AUTO_NAME_PREFIXES.some((p) => value.startsWith(p) && value.length > p.length);
+const hasAutoDescription = (value) =>
+  typeof value === 'string' && AUTO_DESCRIPTION_PREFIXES.some((p) => value.startsWith(p));
+
+/**
+ * True when a record carries any marker of machine creation. Mirrors
+ * `isAutoCollection` in `client/src/lib/mediaCollectionList.js` — ANY one
+ * marker suffices, because an install can hold records from before a given
+ * marker existed.
+ * @param {object} record
+ * @returns {boolean}
+ */
+export function isAutoCreated(record) {
+  if (!record || typeof record !== 'object') return false;
+  if (hasAutoName(record.name)) return true;
+  if (hasAutoDescription(record.description)) return true;
+  if (typeof record.id === 'string' && AUTO_ID_PREFIXES.some((p) => record.id.startsWith(p))) return true;
+  return Boolean(record.universeId || record.seriesId);
+}
+
+/**
+ * Decide the new record for one on-disk collection. Returns `null` when the
+ * record should be left exactly as it is (already stamped, tombstoned, or no
+ * marker matched).
+ * @param {object} record
+ * @returns {object|null}
+ */
+export function stampAutoSource(record) {
+  if (!record || typeof record !== 'object') return null;
+  if (record.source === 'auto' || record.source === 'user') return null;
+  if (record.deleted === true) return null;
+  if (!isAutoCreated(record)) return null;
+  return { ...record, source: 'auto' };
+}
+
+const readJson = async (abs) => {
+  const raw = await readFile(abs, 'utf-8').catch((err) => { if (err.code === 'ENOENT') return null; throw err; });
+  if (raw == null) return null;
+  try { return JSON.parse(raw); } catch { return null; }
+};
+
+const writeJsonAtomic = async (abs, value) => {
+  const tmp = `${abs}.tmp-220`;
+  await writeFile(tmp, JSON.stringify(value, null, 2) + '\n');
+  await rename(tmp, abs);
+};
+
+export default {
+  async up({ rootDir }) {
+    const typeDir = join(rootDir, 'data', 'media-collections');
+    const entries = await readdir(typeDir, { withFileTypes: true })
+      .catch((err) => { if (err.code === 'ENOENT') return null; throw err; });
+    if (entries === null) {
+      console.log('📦 migration 220: no data/media-collections dir — fresh install, no-op');
+      return { ok: true, reason: 'no-collections' };
+    }
+
+    let stamped = 0;
+    let scanned = 0;
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue; // skips the type-level index.json
+      const recordPath = join(typeDir, entry.name, 'index.json');
+      const record = await readJson(recordPath);
+      if (!record) continue; // missing or unparseable — leave it for the store to drop
+      scanned += 1;
+      const next = stampAutoSource(record);
+      if (!next) continue;
+      await writeJsonAtomic(recordPath, next);
+      stamped += 1;
+    }
+
+    console.log(`📦 migration 220: stamped source:auto on ${stamped} of ${scanned} media collection(s)`);
+    return { ok: true, reason: stamped ? 'migrated' : 'nothing-to-stamp', stamped, scanned };
+  },
+};

--- a/scripts/migrations/220-backfill-media-collection-source.js
+++ b/scripts/migrations/220-backfill-media-collection-source.js
@@ -27,9 +27,12 @@
  *
  * Deliberately NOT written:
  *   - `source: 'user'` on non-matching records. The client treats an ABSENT
- *     stamp as "fall back to the marker heuristic", which returns false for
- *     exactly these records — identical behavior with no extra writes, and no
- *     risk of freezing a misclassification.
+ *     stamp as "fall back to the marker heuristic" — which is exactly the
+ *     classification those records get today — so stamping them would add
+ *     writes without changing behavior, while freezing an answer the heuristic
+ *     would otherwise re-evaluate (a name-only match is the case that matters:
+ *     it stays auto until the user renames the collection, and then correctly
+ *     stops being auto).
  *   - Tombstones (`deleted: true`). `deleteCollection` clears the owner links
  *     and items; nothing renders a tombstone, and rewriting one only adds sync
  *     noise.

--- a/scripts/migrations/220-backfill-media-collection-source.js
+++ b/scripts/migrations/220-backfill-media-collection-source.js
@@ -16,8 +16,10 @@
  *   load-bearing for anything this install already had.
  *
  * What it writes:
- *   `source: 'auto'` on each live record matching a marker and carrying no
- *   `source` yet. Nothing else — in particular `updatedAt` is deliberately NOT
+ *   `source: 'auto'` on each live record matching a non-forgeable marker and
+ *   carrying no `source` yet (see the marker note below — a bare name prefix is
+ *   deliberately NOT enough, since the create route lets a user pick one).
+ *   Nothing else — in particular `updatedAt` is deliberately NOT
  *   bumped: this is a derived classification, not a user edit, and advancing
  *   the LWW clock would make every collection look freshly edited to peers and
  *   out-race real remote edits. `source` is not part of the conflict journal's
@@ -32,11 +34,11 @@
  *     and items; nothing renders a tombstone, and rewriting one only adds sync
  *     noise.
  *
- * Cross-install: `source` is additive and rides the wire's `.passthrough()`
- * record schema, so no `schemaVersions` bump is needed. Peers upgrade and run
- * this independently; because the markers are deterministic, two peers classify
- * the same record identically, and `mergeMediaCollectionsFromSync` keeps a stamp
- * sticky rather than letting an older peer's unstamped copy erase it.
+ * Cross-install: `source` is LOCAL-ONLY — `sanitizeRecordForWire` strips it, so
+ * no `schemaVersions` bump is needed and no peer's checksum moves. Each peer
+ * upgrades and runs this independently over ITS OWN copy of the shared
+ * collections; because the markers are deterministic, they classify the same
+ * record identically.
  *
  * The legacy monolithic `data/media-collections.json` is not read — migration
  * 059 split it into `data/media-collections/<id>/index.json` and runs first.
@@ -52,31 +54,34 @@ import { join } from 'path';
 // from `client/src/lib/mediaCollectionList.js` / `services/mediaCollections.js`
 // on purpose: a migration is a point-in-time transform and must not shift if
 // those lists later evolve.
-const AUTO_NAME_PREFIXES = ['Creative Director: ', 'Writers Room: ', 'Universe: ', 'Series: '];
+//
+// The client heuristic has a FOURTH marker this migration deliberately does not
+// use: the `Creative Director: ` / `Writers Room: ` / `Universe: ` / `Series: `
+// NAME prefix. Nothing reserves those prefixes — the create route takes a free
+// name — so a user-made collection called `Universe: Notes` matches it, and
+// stamping is permanent (a stamped record is skipped on every later pass, and
+// there is no API to correct it). Leaving name-only matches unstamped keeps
+// them on the client fallback, which classifies them exactly as it does today
+// and still re-evaluates if the user renames them. Nothing is lost: every real
+// auto-creator also carries one of the markers below — Creative Director and
+// Writers Room stamp an `Auto-…` description (the create form takes a name
+// only, so a user cannot produce one), and universe/series buckets carry the
+// deterministic id and/or the owner link.
 const AUTO_DESCRIPTION_PREFIXES = ['Auto-created for project ', 'Auto-generated images for '];
 const AUTO_ID_PREFIXES = ['uc-', 'sc-'];
 
-// The name check requires a non-empty remainder (`splitCollectionName` only
-// yields a badge when the title survives the prefix), while the description
-// check is a bare prefix match — mirroring the two client predicates exactly so
-// this migration and the fallback heuristic can never disagree on a record.
-const hasAutoName = (value) =>
-  typeof value === 'string' && AUTO_NAME_PREFIXES.some((p) => value.startsWith(p) && value.length > p.length);
-const hasAutoDescription = (value) =>
-  typeof value === 'string' && AUTO_DESCRIPTION_PREFIXES.some((p) => value.startsWith(p));
-
 /**
- * True when a record carries any marker of machine creation. Mirrors
- * `isAutoCollection` in `client/src/lib/mediaCollectionList.js` — ANY one
- * marker suffices, because an install can hold records from before a given
- * marker existed.
+ * True when a record carries a marker of machine creation that a user could not
+ * have produced through the create form. A subset of `isAutoCollection` in
+ * `client/src/lib/mediaCollectionList.js` — see the note above on why the name
+ * prefix is excluded. ANY one marker suffices, because an install can hold
+ * records from before a given marker existed.
  * @param {object} record
  * @returns {boolean}
  */
 export function isAutoCreated(record) {
   if (!record || typeof record !== 'object') return false;
-  if (hasAutoName(record.name)) return true;
-  if (hasAutoDescription(record.description)) return true;
+  if (typeof record.description === 'string' && AUTO_DESCRIPTION_PREFIXES.some((p) => record.description.startsWith(p))) return true;
   if (typeof record.id === 'string' && AUTO_ID_PREFIXES.some((p) => record.id.startsWith(p))) return true;
   return Boolean(record.universeId || record.seriesId);
 }

--- a/scripts/migrations/220-backfill-media-collection-source.test.js
+++ b/scripts/migrations/220-backfill-media-collection-source.test.js
@@ -107,6 +107,11 @@ describe('migration 220 — backfill media collection source', () => {
     // The same record with a marker the create form cannot produce does qualify.
     expect(isAutoCreated({ id: 'x', name: 'Universe: Example', universeId: 'u1' })).toBe(true);
     expect(isAutoCreated({ id: 'x', description: 'Auto-created for project x' })).toBe(true);
+    // A corrupt owner link is not a marker — `sanitizeCollection` drops a
+    // non-string universeId/seriesId on the next read, so stamping from one
+    // would classify a record that has no machine-owned marker at all.
+    expect(isAutoCreated({ id: 'x', universeId: true })).toBe(false);
+    expect(isAutoCreated({ id: 'x', seriesId: '' })).toBe(false);
     expect(isAutoCreated(null)).toBe(false);
     expect(stampAutoSource('nope')).toBe(null);
   });

--- a/scripts/migrations/220-backfill-media-collection-source.test.js
+++ b/scripts/migrations/220-backfill-media-collection-source.test.js
@@ -49,9 +49,9 @@ afterEach(() => {
 });
 
 describe('migration 220 — backfill media collection source', () => {
-  it('stamps every auto marker and leaves user-made, stamped, and tombstoned records alone', async () => {
-    await writeRecord('cd-1', { name: 'Creative Director: Example Project' });
-    await writeRecord('wr-1', { name: 'Writers Room: Example Work' });
+  it('stamps every non-forgeable marker and leaves user-made, stamped, and tombstoned records alone', async () => {
+    await writeRecord('cd-1', { name: 'Creative Director: Example Project', description: 'Auto-created for project cd-1' });
+    await writeRecord('wr-1', { name: 'Writers Room: Example Work', description: 'Auto-generated images for "Example Work"' });
     await writeRecord('desc-1', { description: 'Auto-created for project abc' });
     await writeRecord('desc-2', { description: 'Auto-generated images for "Example Work"' });
     await writeRecord('uc-universe-1', { name: 'Universe: Example Universe', universeId: 'universe-1' });
@@ -59,9 +59,13 @@ describe('migration 220 — backfill media collection source', () => {
     await writeRecord('linked-legacy', { name: 'Renamed Bucket', universeId: 'universe-2' });
     // Left alone:
     await writeRecord('user-1', {});
+    // A user is free to NAME a collection with an auto-creator's prefix — the
+    // create route reserves nothing — so a bare name match must never freeze a
+    // permanent 'auto' stamp. It keeps flowing through the client fallback.
+    await writeRecord('name-only-1', { name: 'Universe: Notes I Made Myself' });
     await writeRecord('user-2', { source: 'user', name: 'Universe: Named Like An Auto One' });
     await writeRecord('already-auto', { source: 'auto', name: 'Creative Director: Example Project' });
-    await writeRecord('tombstone-1', { name: 'Universe: Deleted One', deleted: true, deletedAt: STAMP });
+    await writeRecord('tombstone-1', { name: 'Universe: Deleted One', universeId: 'universe-3', deleted: true, deletedAt: STAMP });
     // Unparseable record — skipped without failing the run.
     await mkdir(join(typeDir(), 'broken-1'), { recursive: true });
     await writeFile(join(typeDir(), 'broken-1', 'index.json'), '{ not json');
@@ -78,6 +82,7 @@ describe('migration 220 — backfill media collection source', () => {
       expect(rec.updatedAt, id).toBe(STAMP);
     }
     expect((await readRecord('user-1')).source).toBeUndefined();
+    expect((await readRecord('name-only-1')).source).toBeUndefined();
     expect((await readRecord('user-2')).source).toBe('user');
     expect((await readRecord('already-auto')).source).toBe('auto');
     expect((await readRecord('tombstone-1')).source).toBeUndefined();
@@ -96,10 +101,12 @@ describe('migration 220 — backfill media collection source', () => {
     expect(await migration.up({ rootDir: ROOT })).toMatchObject({ ok: true, reason: 'no-collections' });
   });
 
-  it('mirrors the client heuristic on prefix-only names and non-record input', () => {
-    // A bare prefix with no title yields no badge client-side, so it is not a marker.
-    expect(isAutoCreated({ id: 'x', name: 'Universe: ' })).toBe(false);
-    expect(isAutoCreated({ id: 'x', name: 'Universe: Example' })).toBe(true);
+  it('ignores the user-forgeable name prefix and tolerates non-record input', () => {
+    // The create route takes a free name, so a prefix alone proves nothing.
+    expect(isAutoCreated({ id: 'x', name: 'Universe: Example' })).toBe(false);
+    // The same record with a marker the create form cannot produce does qualify.
+    expect(isAutoCreated({ id: 'x', name: 'Universe: Example', universeId: 'u1' })).toBe(true);
+    expect(isAutoCreated({ id: 'x', description: 'Auto-created for project x' })).toBe(true);
     expect(isAutoCreated(null)).toBe(false);
     expect(stampAutoSource('nope')).toBe(null);
   });

--- a/scripts/migrations/220-backfill-media-collection-source.test.js
+++ b/scripts/migrations/220-backfill-media-collection-source.test.js
@@ -1,0 +1,106 @@
+/**
+ * Migration 220 — backfill `source: 'auto'` on machine-created media
+ * collections (#3311). Lays down one record per marker the classifier honors
+ * plus the four records it must leave alone (user-made, already stamped,
+ * tombstoned, unparseable) and asserts exactly the auto ones gain the stamp —
+ * with `updatedAt` untouched, since a derived classification must not advance
+ * the LWW clock.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { mkdir, writeFile, readFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import migration, { isAutoCreated, stampAutoSource } from './220-backfill-media-collection-source.js';
+
+let ROOT;
+const typeDir = () => join(ROOT, 'data', 'media-collections');
+
+const STAMP = '2026-01-01T00:00:00.000Z';
+
+async function writeRecord(id, patch) {
+  await mkdir(join(typeDir(), id), { recursive: true });
+  await writeFile(join(typeDir(), id, 'index.json'), JSON.stringify({
+    id,
+    name: 'Concept Art',
+    description: '',
+    coverKey: null,
+    universeId: null,
+    seriesId: null,
+    items: [],
+    createdAt: STAMP,
+    updatedAt: STAMP,
+    deleted: false,
+    deletedAt: null,
+    ...patch,
+  }, null, 2));
+}
+
+const readRecord = async (id) => JSON.parse(await readFile(join(typeDir(), id, 'index.json'), 'utf-8'));
+
+beforeEach(async () => {
+  ROOT = mkdtempSync(join(tmpdir(), 'migration-220-'));
+  await mkdir(typeDir(), { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+});
+
+describe('migration 220 — backfill media collection source', () => {
+  it('stamps every auto marker and leaves user-made, stamped, and tombstoned records alone', async () => {
+    await writeRecord('cd-1', { name: 'Creative Director: Example Project' });
+    await writeRecord('wr-1', { name: 'Writers Room: Example Work' });
+    await writeRecord('desc-1', { description: 'Auto-created for project abc' });
+    await writeRecord('desc-2', { description: 'Auto-generated images for "Example Work"' });
+    await writeRecord('uc-universe-1', { name: 'Universe: Example Universe', universeId: 'universe-1' });
+    await writeRecord('sc-series-1', { name: 'Series: Example Series', seriesId: 'series-1' });
+    await writeRecord('linked-legacy', { name: 'Renamed Bucket', universeId: 'universe-2' });
+    // Left alone:
+    await writeRecord('user-1', {});
+    await writeRecord('user-2', { source: 'user', name: 'Universe: Named Like An Auto One' });
+    await writeRecord('already-auto', { source: 'auto', name: 'Creative Director: Example Project' });
+    await writeRecord('tombstone-1', { name: 'Universe: Deleted One', deleted: true, deletedAt: STAMP });
+    // Unparseable record — skipped without failing the run.
+    await mkdir(join(typeDir(), 'broken-1'), { recursive: true });
+    await writeFile(join(typeDir(), 'broken-1', 'index.json'), '{ not json');
+    // The type-level index is a FILE, not a record dir — must not be touched.
+    await writeFile(join(typeDir(), 'index.json'), JSON.stringify({ schemaVersion: 1, type: 'mediaCollections' }));
+
+    const result = await migration.up({ rootDir: ROOT });
+    expect(result).toMatchObject({ ok: true, reason: 'migrated', stamped: 7 });
+
+    for (const id of ['cd-1', 'wr-1', 'desc-1', 'desc-2', 'uc-universe-1', 'sc-series-1', 'linked-legacy']) {
+      const rec = await readRecord(id);
+      expect(rec.source, id).toBe('auto');
+      // A derived classification must not look like a user edit to a peer.
+      expect(rec.updatedAt, id).toBe(STAMP);
+    }
+    expect((await readRecord('user-1')).source).toBeUndefined();
+    expect((await readRecord('user-2')).source).toBe('user');
+    expect((await readRecord('already-auto')).source).toBe('auto');
+    expect((await readRecord('tombstone-1')).source).toBeUndefined();
+    expect(JSON.parse(await readFile(join(typeDir(), 'index.json'), 'utf-8')).schemaVersion).toBe(1);
+  });
+
+  it('is idempotent — a second pass stamps nothing', async () => {
+    await writeRecord('uc-universe-1', { name: 'Universe: Example Universe', universeId: 'universe-1' });
+    expect((await migration.up({ rootDir: ROOT })).stamped).toBe(1);
+    const second = await migration.up({ rootDir: ROOT });
+    expect(second).toMatchObject({ reason: 'nothing-to-stamp', stamped: 0, scanned: 1 });
+  });
+
+  it('no-ops on a fresh install with no media-collections dir', async () => {
+    rmSync(typeDir(), { recursive: true, force: true });
+    expect(await migration.up({ rootDir: ROOT })).toMatchObject({ ok: true, reason: 'no-collections' });
+  });
+
+  it('mirrors the client heuristic on prefix-only names and non-record input', () => {
+    // A bare prefix with no title yields no badge client-side, so it is not a marker.
+    expect(isAutoCreated({ id: 'x', name: 'Universe: ' })).toBe(false);
+    expect(isAutoCreated({ id: 'x', name: 'Universe: Example' })).toBe(true);
+    expect(isAutoCreated(null)).toBe(false);
+    expect(stampAutoSource('nope')).toBe(null);
+  });
+});

--- a/server/lib/syncWire.js
+++ b/server/lib/syncWire.js
@@ -184,7 +184,23 @@ export function sanitizeRecordForWire(kind, record) {
       // Collections have no `ephemeral` field — unlike universe/series,
       // they are always wire-syncable when non-ephemeral (there is no
       // collection-level ephemeral flag), so no ephemeral minimization path.
-      const { deleted: _d, deletedAt: _da, ...rest } = record;
+      //
+      // `source` (#3311 provenance: 'auto' vs 'user') is LOCAL-ONLY, stripped
+      // here for the same reason as `ephemeral`/`importDraft` above. It drives
+      // the grid's card ordering + badge, not record content, and every install
+      // derives its own: the creators stamp at mint time and migration 220
+      // classifies whatever was already on disk. Emitting it would give an
+      // upgraded peer a permanently different `mediaCollections` checksum from a
+      // not-yet-upgraded one (whose sanitizer drops the unknown field), which
+      // the UI reads as "behind" forever and the 60s snapshot loop re-exchanges
+      // every cycle for a merge that can never converge. The alternative —
+      // bumping `schemaVersions.mediaCollections` — would pause ALL collection
+      // sync between version-mismatched peers over a card-ordering flag. A peer
+      // that receives an unstamped record falls back to the marker heuristic in
+      // `client/src/lib/mediaCollectionList.js`, exactly as it did before #3311.
+      // If provenance ever needs to federate, it needs a schemaVersions bump —
+      // do NOT simply stop stripping it here.
+      const { deleted: _d, deletedAt: _da, source: _source, ...rest } = record;
       return { ...rest, ...sanitizeSoftDeleteFields(record) };
     }
     case 'author':

--- a/server/lib/syncWire.test.js
+++ b/server/lib/syncWire.test.js
@@ -255,6 +255,27 @@ describe('syncWire', () => {
         expect(sanitizeRecordForWire('author', { name: 'no id' })).toBeNull();
       });
     });
+
+    describe('mediaCollection kind', () => {
+      it('strips the local-only provenance stamp so an upgraded peer stays checksum-stable', () => {
+        // #3311: `source` drives the grid's ordering/badge on THIS install only.
+        // A peer that predates the field would sanitize it away, leaving the two
+        // installs permanently checksum-mismatched on the mediaCollections
+        // category — so it must not cross the wire at all.
+        const stamped = { id: 'c1', name: 'Universe: Example', source: 'auto', items: [] };
+        const unstamped = { id: 'c1', name: 'Universe: Example', items: [] };
+        expect(sanitizeRecordForWire('mediaCollection', stamped).source).toBeUndefined();
+        expect(JSON.stringify(sanitizeRecordForWire('mediaCollection', stamped)))
+          .toBe(JSON.stringify(sanitizeRecordForWire('mediaCollection', unstamped)));
+      });
+
+      it('strips the stamp from the snapshot-category projection too', () => {
+        const { data } = sanitizeStateForWire('mediaCollections', {
+          collections: [{ id: 'c1', name: 'Concept Art', source: 'user', items: [] }],
+        });
+        expect(data.collections[0].source).toBeUndefined();
+      });
+    });
   });
 
   describe('sanitizeStateForWire', () => {

--- a/server/routes/mediaCollections.js
+++ b/server/routes/mediaCollections.js
@@ -2,7 +2,7 @@
  *   GET    /api/media/collections                  → Collection[]
  *   POST   /api/media/collections                  → Collection         (body: { name, description? })
  *   GET    /api/media/collections/:id              → Collection
- *   PATCH  /api/media/collections/:id              → Collection         (body: { name?, description?, coverKey? })
+ *   PATCH  /api/media/collections/:id              → Collection         (body: { name?, description?, coverKey?, source? })
  *   DELETE /api/media/collections/:id              → { id }
  *   POST   /api/media/collections/:id/items        → Collection         (body: { kind, ref })
  *   POST   /api/media/collections/:id/items/bulk   → { collection, added, removed }
@@ -43,6 +43,12 @@ const patchSchema = z.object({
   description: descriptionSchema.optional(),
   // coverKey: null clears it (auto = newest); a string pins a specific item.
   coverKey: z.union([z.string().trim().min(1).max(svc.REF_MAX_LENGTH + 8), z.null()]).optional(),
+  // Provenance override (#3311) — lets the user correct a collection the
+  // migration's marker classification stamped wrong. Deliberately absent from
+  // `createSchema`: a POST is a person creating a collection, which the service
+  // stamps 'user' on its own, so accepting the field there would only let a
+  // client mislabel its own new collection.
+  source: z.enum(svc.COLLECTION_SOURCES).optional(),
 }).refine((p) => Object.keys(p).length > 0, { message: 'patch must include at least one field' });
 
 const itemSchema = z.object({

--- a/server/routes/mediaCollections.test.js
+++ b/server/routes/mediaCollections.test.js
@@ -7,6 +7,8 @@ import { errorMiddleware } from '../lib/errorHandler.js';
 // → response wiring without standing up the real file-backed store.
 const stubs = {
   bulkUpdateCollectionItems: vi.fn(),
+  updateCollection: vi.fn(async (id, patch) => ({ id, ...patch })),
+  createCollection: vi.fn(async (input) => ({ id: 'new', ...input })),
 };
 
 vi.mock('../services/mediaCollections.js', async () => {
@@ -14,6 +16,8 @@ vi.mock('../services/mediaCollections.js', async () => {
   return {
     ...actual,
     bulkUpdateCollectionItems: (...args) => stubs.bulkUpdateCollectionItems(...args),
+    updateCollection: (...args) => stubs.updateCollection(...args),
+    createCollection: (...args) => stubs.createCollection(...args),
   };
 });
 
@@ -97,5 +101,26 @@ describe('mediaCollections routes — POST /:id/items/bulk', () => {
       add: [{ kind: 'image', ref: 'a.png' }],
     });
     expect(r.status).toBe(409);
+  });
+});
+
+describe('mediaCollections routes — provenance (#3311)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes a valid source through PATCH and rejects an unknown one', async () => {
+    const ok = await request(makeApp()).patch('/api/media/collections/c1').send({ source: 'user' });
+    expect(ok.status).toBe(200);
+    expect(stubs.updateCollection).toHaveBeenCalledWith('c1', { source: 'user' });
+
+    const bad = await request(makeApp()).patch('/api/media/collections/c1').send({ source: 'robot' });
+    expect(bad.status).toBe(400);
+  });
+
+  it('strips source from a create body so a client cannot claim provenance', async () => {
+    await request(makeApp()).post('/api/media/collections').send({ name: 'Concept Art', source: 'auto' });
+    // Zod drops the unknown key → the service applies its own 'user' default.
+    expect(stubs.createCollection).toHaveBeenCalledWith({ name: 'Concept Art', description: '' });
   });
 });

--- a/server/services/creativeDirector/projectsDB.js
+++ b/server/services/creativeDirector/projectsDB.js
@@ -124,7 +124,7 @@ export async function listProjectIds({ includeDeleted = false } = {}) {
 export async function createProject(input) {
   const id = `cd-${randomUUID()}`;
   const now = new Date().toISOString();
-  const collection = await createCollection({ name: `Creative Director: ${input.name}`, description: `Auto-created for project ${id}` });
+  const collection = await createCollection({ name: `Creative Director: ${input.name}`, description: `Auto-created for project ${id}`, source: 'auto' });
   const project = buildProjectRecord(input, { id, now, collectionId: collection.id });
   await persist(query, project);
   console.log(`🎬 Created Creative Director project: ${id} (${input.name})`);

--- a/server/services/creativeDirector/projectsFile.js
+++ b/server/services/creativeDirector/projectsFile.js
@@ -74,7 +74,7 @@ export async function createProject(input) {
   const now = new Date().toISOString();
   // Auto-create a media collection scoped to this project. All segment renders
   // + the final stitched output land in here.
-  const collection = await createCollection({ name: `Creative Director: ${input.name}`, description: `Auto-created for project ${id}` });
+  const collection = await createCollection({ name: `Creative Director: ${input.name}`, description: `Auto-created for project ${id}`, source: 'auto' });
   const project = buildProjectRecord(input, { id, now, collectionId: collection.id });
   const all = await loadAll();
   all.push(project);

--- a/server/services/dataSync.js
+++ b/server/services/dataSync.js
@@ -554,7 +554,15 @@ async function getMediaCollectionsSnapshot({ exclude } = {}) {
   // forever. Sort collections by id (stable, unique) and each collection's
   // items by `<kind>:<ref>` (the same key used for set membership in
   // `mergeCollectionItems`).
-  const canonical = filtered
+  // Project through the SHARED wire sanitizer before canonicalizing, so this
+  // snapshot and the per-record push agree on which fields cross the wire
+  // instead of each deciding for itself (see `sanitizeRecordForWire` — it
+  // normalizes the soft-delete pair to tail position, which service-sanitized
+  // records already satisfy, and drops the local-only `source` provenance stamp
+  // added in #3311 so an upgraded peer's checksum stays byte-stable against a
+  // not-yet-upgraded one).
+  const { data: wire } = sanitizeStateForWire('mediaCollections', { collections: filtered });
+  const canonical = wire.collections
     .map((c) => ({
       ...c,
       items: [...(c.items || [])].sort((a, b) => itemKey(a).localeCompare(itemKey(b))),

--- a/server/services/mediaCollections.js
+++ b/server/services/mediaCollections.js
@@ -116,16 +116,20 @@ const SERIES_ID_MAX = 80;
 // `'user'` = the person created it through the API. The grid uses it to sort
 // auto-generated empties last and to badge the card.
 //
+// **LOCAL-ONLY.** `sanitizeRecordForWire` strips it, so provenance never
+// crosses to a peer — see the rationale there (an emitted field would leave an
+// upgraded peer permanently checksum-mismatched against an older one, and
+// gating it behind a `schemaVersions` bump would pause all collection sync).
+// Every install derives its own: the creators below stamp at mint time and
+// `scripts/migrations/220-backfill-media-collection-source.js` classifies
+// whatever was already on disk when the install upgraded.
+//
 // **Absent is a THIRD state, not a synonym for `'user'`.** A record written
-// before this field shipped, or received from a peer still running an older
-// PortOS, carries no stamp at all — the client falls back to its marker
+// before this field shipped, or received from a peer after this install's
+// migration ran, carries no stamp at all — the client falls back to its marker
 // heuristic for those rather than mislabeling them user-made. So the sanitizer
 // OMITS the key entirely rather than defaulting it (same posture as
-// `sanitizeItem`'s optional `origin`), which also keeps unstamped records
-// byte-identical on the wire for peers that never learn about the field.
-// `scripts/migrations/220-backfill-media-collection-source.js` backfills
-// `'auto'` on existing local records so the heuristic stops being load-bearing
-// for anything this install already had.
+// `sanitizeItem`'s optional `origin`).
 const COLLECTION_SOURCES = Object.freeze(['auto', 'user']);
 const sanitizeSource = (raw) => (COLLECTION_SOURCES.includes(raw) ? raw : null);
 
@@ -1058,23 +1062,18 @@ export async function mergeMediaCollectionsFromSync(remoteCollections, { source 
       const coverKey = !scalarDeleted && scalarSource.coverKey && presentKeys.has(scalarSource.coverKey)
         ? scalarSource.coverKey
         : null;
-      // Provenance is STICKY, not LWW (#3311). A peer running a PortOS that
-      // predates the field strips `source` from the wire entirely, so a
-      // remote-wins scalar overwrite must not erase a stamp we already hold —
-      // that would silently demote a machine-made bucket back to the client's
-      // marker heuristic (or worse, to "user-made") on every sync from an older
-      // machine. Prefer the LWW winner's stamp, then whichever side has one,
-      // then leave it unstamped. `source` is excluded from the conflict
-      // journal's scalar projection (MEDIA_COLLECTION_SCALAR_FIELDS), so
-      // adopting it here can't churn base hashes.
-      const nextSource = sanitizeSource(scalarSource.source)
-        || sanitizeSource(local.source)
-        || sanitizeSource(sanitized.source);
+      // NOTE — `source` (#3311) is deliberately absent from the scalar list
+      // below. It is a LOCAL-ONLY provenance stamp that `sanitizeRecordForWire`
+      // strips before sending, so a remote record never carries one and a
+      // remote-wins overwrite must not be able to clear ours. The `...local`
+      // spread preserves it; a brand-new record inserted above keeps whatever
+      // the sanitizer accepted (an offline export/import bundle can legitimately
+      // carry it). Do NOT add it to the LWW scalars without also un-stripping it
+      // on the wire — and that needs a schemaVersions bump.
       const next = {
         ...local,
         name: scalarSource.name,
         description: scalarSource.description,
-        ...(nextSource ? { source: nextSource } : {}),
         coverKey: scalarDeleted ? null : coverKey,
         universeId: scalarDeleted ? null : scalarSource.universeId,
         seriesId: scalarDeleted ? null : scalarSource.seriesId,

--- a/server/services/mediaCollections.js
+++ b/server/services/mediaCollections.js
@@ -130,7 +130,7 @@ const SERIES_ID_MAX = 80;
 // heuristic for those rather than mislabeling them user-made. So the sanitizer
 // OMITS the key entirely rather than defaulting it (same posture as
 // `sanitizeItem`'s optional `origin`).
-const COLLECTION_SOURCES = Object.freeze(['auto', 'user']);
+export const COLLECTION_SOURCES = Object.freeze(['auto', 'user']);
 const sanitizeSource = (raw) => (COLLECTION_SOURCES.includes(raw) ? raw : null);
 
 const sanitizeCollection = (raw) => {
@@ -688,6 +688,11 @@ export const unlinkCollectionsForUniverse = (universeId) =>
 export const renameCollectionForUniverse = (universeId, newUniverseName) =>
   renameOwnerLinked('universeId', universeId, UNIVERSE_ID_MAX, universeCollectionNameFor, newUniverseName);
 
+// The `updateCollection` patch keys that peers can actually observe. Anything
+// outside this list is local-only and must not advance `updatedAt` (the LWW
+// clock every peer compares against) — see the `source` note below.
+const WIRE_VISIBLE_PATCH_FIELDS = ['name', 'description', 'coverKey'];
+
 export async function updateCollection(id, patch) {
   assertCollectionId(id);
   const merged = await store().queueRecordWrite(id, async () => {
@@ -724,7 +729,19 @@ export async function updateCollection(id, patch) {
       ...('name' in patch ? { name: patch.name } : {}),
       ...('description' in patch ? { description: patch.description } : {}),
       ...('coverKey' in patch ? { coverKey: patch.coverKey } : {}),
-      updatedAt: new Date().toISOString(),
+      // Provenance is correctable (#3311). The migration classifies legacy
+      // records from markers a user could in principle have typed themselves
+      // (a description starting `Auto-created for project …`), so "the stamp is
+      // wrong and I can't fix it" must not be a dead end. Local-only like the
+      // rest of the field — this edit never leaves the install.
+      ...('source' in patch ? { source: patch.source } : {}),
+      // A source-only edit changes nothing a peer can see (the field is
+      // stripped from the wire), so it must NOT advance the shared LWW clock —
+      // same reasoning as migration 220 leaving `updatedAt` alone. Otherwise
+      // correcting a badge locally would out-race a peer's real edit.
+      updatedAt: WIRE_VISIBLE_PATCH_FIELDS.some((k) => k in patch)
+        ? new Date().toISOString()
+        : cur.updatedAt,
     };
     await store().saveOneNow(id, merged);
     return merged;

--- a/server/services/mediaCollections.js
+++ b/server/services/mediaCollections.js
@@ -111,6 +111,24 @@ const sanitizeItem = (raw) => {
 const UNIVERSE_ID_MAX = 80;
 const SERIES_ID_MAX = 80;
 
+// Provenance stamp (#3311). `'auto'` = minted by a machine flow (Creative
+// Director project, Writers Room work, universe/series render bucket);
+// `'user'` = the person created it through the API. The grid uses it to sort
+// auto-generated empties last and to badge the card.
+//
+// **Absent is a THIRD state, not a synonym for `'user'`.** A record written
+// before this field shipped, or received from a peer still running an older
+// PortOS, carries no stamp at all — the client falls back to its marker
+// heuristic for those rather than mislabeling them user-made. So the sanitizer
+// OMITS the key entirely rather than defaulting it (same posture as
+// `sanitizeItem`'s optional `origin`), which also keeps unstamped records
+// byte-identical on the wire for peers that never learn about the field.
+// `scripts/migrations/220-backfill-media-collection-source.js` backfills
+// `'auto'` on existing local records so the heuristic stops being load-bearing
+// for anything this install already had.
+const COLLECTION_SOURCES = Object.freeze(['auto', 'user']);
+const sanitizeSource = (raw) => (COLLECTION_SOURCES.includes(raw) ? raw : null);
+
 const sanitizeCollection = (raw) => {
   if (!raw || typeof raw !== 'object') return null;
   // Reject ids the store can't persist (path-segment allowlist) so a peer-
@@ -162,7 +180,21 @@ const sanitizeCollection = (raw) => {
   // happened at or after the last edit, so createdAt would make the tombstone
   // look far older than it is and skew LWW merges + the GC cutoff window.
   const deletedAt = deleted && typeof raw.deletedAt === 'string' ? raw.deletedAt : (deleted ? updatedAt : null);
-  return { id: raw.id, name, description, coverKey, universeId, seriesId, items, createdAt, updatedAt, deleted, deletedAt };
+  const source = sanitizeSource(raw.source);
+  return {
+    id: raw.id,
+    name,
+    description,
+    coverKey,
+    universeId,
+    seriesId,
+    ...(source ? { source } : {}),
+    items,
+    createdAt,
+    updatedAt,
+    deleted,
+    deletedAt,
+  };
 };
 
 // Storage-layout (type-level) schema version stamped on
@@ -223,13 +255,20 @@ const announceNewCollection = (id) => {
   autoSubscribeRecordToAllPeers('mediaCollection', id).catch(() => {});
 };
 
-export async function createCollection({ name, description = '' }) {
+// `source` defaults to 'user' because the HTTP POST route is the only caller
+// that doesn't pass it — a person clicking "New collection". Machine flows
+// (Creative Director, Writers Room) pass `source: 'auto'` explicitly. The route
+// schema doesn't accept `source`, so a client can't claim either stamp.
+export async function createCollection({ name, description = '', source = 'user' }) {
   // Service-layer guards mirror sanitizeCollection so a direct caller
   // (tests, future internal usage) can't persist a record that the next
   // listCollections() read would silently drop.
   const trimmedName = typeof name === 'string' ? name.trim() : '';
   if (!trimmedName || trimmedName.length > NAME_MAX_LENGTH) {
     throw makeErr('Collection name is required (1..' + NAME_MAX_LENGTH + ' chars)', ERR_VALIDATION);
+  }
+  if (!COLLECTION_SOURCES.includes(source)) {
+    throw makeErr(`source must be one of ${COLLECTION_SOURCES.join('|')}`, ERR_VALIDATION);
   }
   const trimmedDescription = typeof description === 'string'
     ? description.trim().slice(0, DESCRIPTION_MAX_LENGTH)
@@ -242,6 +281,7 @@ export async function createCollection({ name, description = '' }) {
       name: trimmedName,
       description: trimmedDescription,
       coverKey: null,
+      source,
       items: [],
       createdAt: now,
       updatedAt: now,
@@ -265,6 +305,11 @@ export async function createCollection({ name, description = '' }) {
 // The legacy `universeId` parameter remains for callers that need the
 // best-effort backfill of an unlinked legacy bucket, but new code should
 // prefer the universeId-first helper.
+//
+// Records this mints are stamped `source: 'auto'` (#3311) like the other
+// provisioners: reaching this helper means a script or hook asked for a bucket,
+// which is not the same as a person creating one in the UI (that path is
+// `createCollection`, which defaults to `'user'`).
 export async function findOrCreateCollectionByName({ name, description = '', universeId = null }) {
   const trimmed = typeof name === 'string' ? name.trim() : '';
   if (!trimmed || trimmed.length > NAME_MAX_LENGTH) {
@@ -332,6 +377,8 @@ export async function findOrCreateCollectionByName({ name, description = '', uni
       description: trimmedDescription,
       coverKey: null,
       universeId: normalizedUniverseId,
+      // Programmatic provisioner — see the docstring above (#3311).
+      source: 'auto',
       items: [],
       createdAt: now,
       updatedAt: now,
@@ -475,6 +522,8 @@ export async function findOrCreateUniverseCollection({ universeId, universeName,
       description: trimmedDescription,
       coverKey: null,
       universeId: normalizedUniverseId,
+      // Machine-provisioned render bucket — never a user-made collection (#3311).
+      source: 'auto',
       items: [],
       createdAt: now,
       updatedAt: now,
@@ -531,6 +580,8 @@ export async function findOrCreateSeriesCollection({ seriesId, seriesName, descr
       description: trimmedDescription,
       coverKey: null,
       seriesId: normalizedSeriesId,
+      // Machine-provisioned render bucket — never a user-made collection (#3311).
+      source: 'auto',
       items: [],
       createdAt: now,
       updatedAt: now,
@@ -1007,10 +1058,23 @@ export async function mergeMediaCollectionsFromSync(remoteCollections, { source 
       const coverKey = !scalarDeleted && scalarSource.coverKey && presentKeys.has(scalarSource.coverKey)
         ? scalarSource.coverKey
         : null;
+      // Provenance is STICKY, not LWW (#3311). A peer running a PortOS that
+      // predates the field strips `source` from the wire entirely, so a
+      // remote-wins scalar overwrite must not erase a stamp we already hold —
+      // that would silently demote a machine-made bucket back to the client's
+      // marker heuristic (or worse, to "user-made") on every sync from an older
+      // machine. Prefer the LWW winner's stamp, then whichever side has one,
+      // then leave it unstamped. `source` is excluded from the conflict
+      // journal's scalar projection (MEDIA_COLLECTION_SCALAR_FIELDS), so
+      // adopting it here can't churn base hashes.
+      const nextSource = sanitizeSource(scalarSource.source)
+        || sanitizeSource(local.source)
+        || sanitizeSource(sanitized.source);
       const next = {
         ...local,
         name: scalarSource.name,
         description: scalarSource.description,
+        ...(nextSource ? { source: nextSource } : {}),
         coverKey: scalarDeleted ? null : coverKey,
         universeId: scalarDeleted ? null : scalarSource.universeId,
         seriesId: scalarDeleted ? null : scalarSource.seriesId,

--- a/server/services/mediaCollections.test.js
+++ b/server/services/mediaCollections.test.js
@@ -1812,6 +1812,22 @@ describe('source provenance', () => {
     expect('source' in (await svc.getCollection('c-bogus'))).toBe(false);
   });
 
+  it('is correctable via updateCollection WITHOUT advancing the LWW clock', async () => {
+    // The migration classifies from markers a user could in principle have
+    // typed (an `Auto-…` description), so a wrong stamp must be fixable. And
+    // because the field never reaches a peer, fixing it must not bump
+    // `updatedAt` — that would out-race a peer's real edit for a change no peer
+    // can even see.
+    const c = await svc.createCollection({ name: 'Renders', source: 'auto' });
+    const fixed = await svc.updateCollection(c.id, { source: 'user' });
+    expect(fixed.source).toBe('user');
+    expect(fixed.updatedAt).toBe(c.updatedAt);
+    // A patch that DOES touch wire-visible state still bumps it.
+    const renamed = await svc.updateCollection(c.id, { name: 'Renders 2', source: 'auto' });
+    expect(renamed.source).toBe('auto');
+    expect(renamed.updatedAt).not.toBe(c.updatedAt);
+  });
+
   it('survives an edit and rides through the tombstone', async () => {
     const c = await svc.createCollection({ name: 'Writers Room: Example Work', source: 'auto' });
     expect((await svc.updateCollection(c.id, { description: 'edited' })).source).toBe('auto');

--- a/server/services/mediaCollections.test.js
+++ b/server/services/mediaCollections.test.js
@@ -1819,9 +1819,10 @@ describe('source provenance', () => {
     expect((await svc.getCollection(c.id, { includeDeleted: true })).source).toBe('auto');
   });
 
-  it('merge keeps a local stamp when an older peer sends the record without one', async () => {
-    // The cross-install case: a peer predating #3311 strips `source` from the
-    // wire. Its (newer) scalars win LWW, but they must not erase provenance.
+  it('merge keeps the local stamp when a peer sends the record without one', async () => {
+    // The cross-install case: `source` never crosses the wire (sanitizeRecordForWire
+    // strips it), so every remote record arrives unstamped. Its (newer) scalars
+    // win LWW, but they must not erase local provenance.
     const c = await svc.createCollection({ name: 'Writers Room: Example Work', source: 'auto' });
     const result = await svc.mergeMediaCollectionsFromSync([{
       id: c.id, name: 'Writers Room: Renamed', description: '', coverKey: null,
@@ -1834,26 +1835,9 @@ describe('source provenance', () => {
     expect(merged.source).toBe('auto');
   });
 
-  it('merge adopts a remote stamp onto an unstamped local record even when local wins LWW', async () => {
-    await seedState({
-      collections: [{
-        id: 'c-legacy', name: 'Universe: Example Universe', description: '', coverKey: null,
-        universeId: null, seriesId: null, items: [],
-        createdAt: '2026-05-22T00:00:00Z', updatedAt: '2099-01-01T00:00:00Z',
-      }],
-    });
-    const result = await svc.mergeMediaCollectionsFromSync([{
-      id: 'c-legacy', name: 'Universe: Stale Name', description: '', coverKey: null,
-      universeId: null, seriesId: null, items: [], source: 'auto',
-      createdAt: '2026-05-22T00:00:00Z', updatedAt: '2026-05-22T00:00:00Z',
-    }]);
-    expect(result.applied).toBe(true);
-    const merged = await svc.getCollection('c-legacy');
-    expect(merged.name).toBe('Universe: Example Universe'); // local still wins LWW
-    expect(merged.source).toBe('auto');
-  });
-
-  it('merge inserts a new remote record carrying its stamp', async () => {
+  it('merge inserts a stamp that an offline export/import bundle legitimately carries', async () => {
+    // Peer sync always strips `source`, but the merge also backs the import
+    // path — a record that does arrive stamped is inserted verbatim.
     await svc.mergeMediaCollectionsFromSync([{
       id: 'c-remote', name: 'Concept Art', description: '', coverKey: null,
       universeId: null, seriesId: null, items: [], source: 'user',

--- a/server/services/mediaCollections.test.js
+++ b/server/services/mediaCollections.test.js
@@ -1758,3 +1758,107 @@ describe('pruneTombstonedCollections', () => {
     expect(await svc.pruneTombstonedCollections(Infinity)).toEqual({ pruned: 0 });
   });
 });
+
+// Provenance stamp (#3311) — the server records whether a collection was minted
+// by a machine flow or by the user, so the grid stops reverse-engineering it
+// from name/description/id markers.
+describe('source provenance', () => {
+  it('createCollection defaults to user and accepts an explicit auto stamp', async () => {
+    const byUser = await svc.createCollection({ name: 'Concept Art' });
+    expect(byUser.source).toBe('user');
+    expect((await readStored(byUser.id)).source).toBe('user');
+
+    const byMachine = await svc.createCollection({ name: 'Writers Room: Example Work', source: 'auto' });
+    expect(byMachine.source).toBe('auto');
+    expect((await svc.getCollection(byMachine.id)).source).toBe('auto');
+  });
+
+  it('createCollection rejects an unknown source rather than persisting it', async () => {
+    await expect(svc.createCollection({ name: 'A', source: 'robot' }))
+      .rejects.toMatchObject({ code: svc.ERR_VALIDATION });
+    expect(await svc.listCollections()).toEqual([]);
+  });
+
+  it('stamps auto on the universe- and series-linked render buckets', async () => {
+    const uc = await svc.findOrCreateUniverseCollection({ universeId: 'universe-1', universeName: 'Example Universe' });
+    const sc = await svc.findOrCreateSeriesCollection({ seriesId: 'series-1', seriesName: 'Example Series' });
+    expect(uc.source).toBe('auto');
+    expect(sc.source).toBe('auto');
+  });
+
+  it('leaves a legacy record UNSTAMPED rather than defaulting it to user', async () => {
+    // Absent is a third state: the client falls back to its marker heuristic for
+    // these. Defaulting them to 'user' here would mislabel every pre-#3311
+    // auto-created bucket as user-made on a peer that never ran migration 220.
+    await seedState({
+      collections: [{
+        id: 'c-legacy', name: 'Universe: Example Universe', description: '', coverKey: null,
+        universeId: null, seriesId: null, items: [],
+        createdAt: '2026-05-22T00:00:00Z', updatedAt: '2026-05-22T00:00:00Z',
+      }],
+    });
+    const [legacy] = await svc.listCollections();
+    expect('source' in legacy).toBe(false);
+  });
+
+  it('drops a garbage stamp instead of persisting it', async () => {
+    await seedState({
+      collections: [{
+        id: 'c-bogus', name: 'Bogus', description: '', coverKey: null, source: 'robot',
+        universeId: null, seriesId: null, items: [],
+        createdAt: '2026-05-22T00:00:00Z', updatedAt: '2026-05-22T00:00:00Z',
+      }],
+    });
+    expect('source' in (await svc.getCollection('c-bogus'))).toBe(false);
+  });
+
+  it('survives an edit and rides through the tombstone', async () => {
+    const c = await svc.createCollection({ name: 'Writers Room: Example Work', source: 'auto' });
+    expect((await svc.updateCollection(c.id, { description: 'edited' })).source).toBe('auto');
+    await svc.deleteCollection(c.id);
+    expect((await svc.getCollection(c.id, { includeDeleted: true })).source).toBe('auto');
+  });
+
+  it('merge keeps a local stamp when an older peer sends the record without one', async () => {
+    // The cross-install case: a peer predating #3311 strips `source` from the
+    // wire. Its (newer) scalars win LWW, but they must not erase provenance.
+    const c = await svc.createCollection({ name: 'Writers Room: Example Work', source: 'auto' });
+    const result = await svc.mergeMediaCollectionsFromSync([{
+      id: c.id, name: 'Writers Room: Renamed', description: '', coverKey: null,
+      universeId: null, seriesId: null, items: [],
+      createdAt: c.createdAt, updatedAt: '2099-01-01T00:00:00Z',
+    }]);
+    expect(result.applied).toBe(true);
+    const merged = await svc.getCollection(c.id);
+    expect(merged.name).toBe('Writers Room: Renamed');
+    expect(merged.source).toBe('auto');
+  });
+
+  it('merge adopts a remote stamp onto an unstamped local record even when local wins LWW', async () => {
+    await seedState({
+      collections: [{
+        id: 'c-legacy', name: 'Universe: Example Universe', description: '', coverKey: null,
+        universeId: null, seriesId: null, items: [],
+        createdAt: '2026-05-22T00:00:00Z', updatedAt: '2099-01-01T00:00:00Z',
+      }],
+    });
+    const result = await svc.mergeMediaCollectionsFromSync([{
+      id: 'c-legacy', name: 'Universe: Stale Name', description: '', coverKey: null,
+      universeId: null, seriesId: null, items: [], source: 'auto',
+      createdAt: '2026-05-22T00:00:00Z', updatedAt: '2026-05-22T00:00:00Z',
+    }]);
+    expect(result.applied).toBe(true);
+    const merged = await svc.getCollection('c-legacy');
+    expect(merged.name).toBe('Universe: Example Universe'); // local still wins LWW
+    expect(merged.source).toBe('auto');
+  });
+
+  it('merge inserts a new remote record carrying its stamp', async () => {
+    await svc.mergeMediaCollectionsFromSync([{
+      id: 'c-remote', name: 'Concept Art', description: '', coverKey: null,
+      universeId: null, seriesId: null, items: [], source: 'user',
+      createdAt: '2026-05-22T00:00:00Z', updatedAt: '2026-05-22T00:00:00Z',
+    }]);
+    expect((await svc.getCollection('c-remote')).source).toBe('user');
+  });
+});

--- a/server/services/mediaCollections.test.js
+++ b/server/services/mediaCollections.test.js
@@ -1818,14 +1818,21 @@ describe('source provenance', () => {
     // because the field never reaches a peer, fixing it must not bump
     // `updatedAt` — that would out-race a peer's real edit for a change no peer
     // can even see.
-    const c = await svc.createCollection({ name: 'Renders', source: 'auto' });
-    const fixed = await svc.updateCollection(c.id, { source: 'user' });
+    const seeded = '2026-05-22T00:00:00Z';
+    await seedState({
+      collections: [{
+        id: 'c-fix', name: 'Renders', description: '', coverKey: null,
+        universeId: null, seriesId: null, source: 'auto', items: [],
+        createdAt: seeded, updatedAt: seeded,
+      }],
+    });
+    const fixed = await svc.updateCollection('c-fix', { source: 'user' });
     expect(fixed.source).toBe('user');
-    expect(fixed.updatedAt).toBe(c.updatedAt);
+    expect(fixed.updatedAt).toBe(seeded);
     // A patch that DOES touch wire-visible state still bumps it.
-    const renamed = await svc.updateCollection(c.id, { name: 'Renders 2', source: 'auto' });
+    const renamed = await svc.updateCollection('c-fix', { name: 'Renders 2', source: 'auto' });
     expect(renamed.source).toBe('auto');
-    expect(renamed.updatedAt).not.toBe(c.updatedAt);
+    expect(renamed.updatedAt).not.toBe(seeded);
   });
 
   it('survives an edit and rides through the tombstone', async () => {

--- a/server/services/sharing/peerSync.test.js
+++ b/server/services/sharing/peerSync.test.js
@@ -2065,6 +2065,37 @@ describe('peerSync', () => {
       expect(captured.linkedCollection.items).toHaveLength(1);
     });
 
+    it('strips the local-only provenance stamp from a bundled linkedCollection', async () => {
+      // #3311: `source` is per-install and must not cross the wire in ANY
+      // transport. The standalone mediaCollection push goes through
+      // sanitizeRecordForWire; the bundled copy has to as well, or the two
+      // forms of the same record disagree and an upgraded peer's collection
+      // checksum drifts from a not-yet-upgraded one's.
+      vi.mocked(getUniverse).mockResolvedValue({ id: 'u1', name: 'Universe' });
+      vi.mocked(findCollectionByUniverseId).mockResolvedValueOnce({
+        id: 'col-1',
+        name: 'Universe: U',
+        description: '',
+        coverKey: null,
+        universeId: 'u1',
+        seriesId: null,
+        source: 'auto',
+        items: [],
+        createdAt: '2026-05-22T00:00:00Z',
+        updatedAt: '2026-05-22T01:00:00Z',
+      });
+      let captured = null;
+      vi.mocked(peerFetch).mockImplementation(async (_url, opts) => {
+        captured = JSON.parse(opts.body);
+        return { ok: true, json: async () => ({}) };
+      });
+      await pushRecordToPeer({
+        id: 's', peerId: 'peer-a', recordKind: 'universe', recordId: 'u1',
+      });
+      expect(captured.linkedCollection.id).toBe('col-1');
+      expect(captured.linkedCollection.source).toBeUndefined();
+    });
+
     it('re-pushes when only the linked collection items change (universe record byte-identical)', async () => {
       vi.mocked(getUniverse).mockResolvedValue({ id: 'u1', name: 'Universe' });
       vi.mocked(findCollectionByUniverseId)

--- a/server/services/sharing/peerSyncPush.js
+++ b/server/services/sharing/peerSyncPush.js
@@ -630,13 +630,19 @@ export async function buildPushPayload(sub, sourceInstanceId) {
     const catalogBundle = record.deleted === true
       ? null
       : await buildCatalogBundleForRef('universe', sub.recordId);
+    // The bundled collection goes through the SAME wire projection as a
+    // standalone `mediaCollection` push (below) — the raw service record would
+    // otherwise smuggle peer-local fields (the `source` provenance stamp,
+    // #3311) past the receiver's insert path and leave the bundled and
+    // standalone forms of the same record disagreeing byte-for-byte.
+    const bundledCollection = sanitizeRecordForWire('mediaCollection', linkedCollection);
     return {
       kind: 'universe',
       record: sanitized,
       assetManifest,
       sourceInstanceId,
       portosMeta,
-      ...(linkedCollection ? { linkedCollection } : {}),
+      ...(bundledCollection ? { linkedCollection: bundledCollection } : {}),
       ...(catalogBundle ? { catalogBundle } : {}),
     };
   }
@@ -706,6 +712,8 @@ export async function buildPushPayload(sub, sourceInstanceId) {
       : await import('../pipeline/reverseOutline.js')
         .then(({ getStoredOutline }) => getStoredOutline(sub.recordId))
         .catch(() => null);
+    // Same wire projection as the universe branch — see the note there.
+    const bundledCollection = sanitizeRecordForWire('mediaCollection', linkedCollection);
     return {
       kind: 'series',
       record: sanitized,
@@ -713,7 +721,7 @@ export async function buildPushPayload(sub, sourceInstanceId) {
       assetManifest,
       sourceInstanceId,
       portosMeta,
-      ...(linkedCollection ? { linkedCollection } : {}),
+      ...(bundledCollection ? { linkedCollection: bundledCollection } : {}),
       ...(manuscriptReview && manuscriptReview.comments?.length ? { manuscriptReview } : {}),
       ...(reverseOutline && reverseOutline.status === 'complete' ? { reverseOutline } : {}),
     };

--- a/server/services/writersRoom/local.js
+++ b/server/services/writersRoom/local.js
@@ -210,6 +210,9 @@ export async function ensureWorkMediaCollection(workId) {
   const collection = await createCollection({
     name: `Writers Room: ${manifest.title}`.slice(0, 80),
     description: `Auto-generated images for "${manifest.title}"`,
+    // Machine-provisioned bucket — this work's renders land here without the
+    // user ever asking for a collection (#3311).
+    source: 'auto',
   });
   await saveManifest(workId, { ...manifest, mediaCollectionId: collection.id, updatedAt: nowIso() });
   return collection;


### PR DESCRIPTION
## Summary

Media collections now record **who created them** instead of the grid guessing from their name.

`isAutoCollection()` (#3283) classified a collection by reverse-engineering four independent markers on the client — a name prefix, an `Auto-…` description, a `uc-`/`sc-` id, or a universe/series link. Nothing enforced that contract, so every new server-side auto-creator silently regressed the card ordering until someone remembered to extend the client list.

- **`source: 'auto' | 'user'`** added to `sanitizeCollection` in `server/services/mediaCollections.js`.
- **Auto-creators stamp `'auto'`**: `createCollection` callers in `creativeDirector/projects{DB,File}.js` and `writersRoom/local.js`, plus `findOrCreate{Universe,Series}Collection` and `findOrCreateCollectionByName` (a programmatic provisioner). `createCollection` defaults to `'user'` — the HTTP POST route is its only caller that omits the argument, and `createSchema` doesn't accept `source`, so a client can't claim either stamp. An unknown value throws `VALIDATION_ERROR`.
- **`scripts/migrations/220-backfill-media-collection-source.js`** classifies existing records once. It walks `data/media-collections/<id>/index.json` (the layout migration 059 produces), skips tombstones and already-stamped records, and deliberately does **not** bump `updatedAt` — a derived classification must not advance the LWW clock and make every collection look freshly edited to peers.
- **Client** (`client/src/lib/mediaCollectionList.js`): `isAutoCollection()` returns on `source === 'auto'` / `'user'` first and only falls through to the markers when there is no stamp.
- **`PATCH /api/media/collections/:id` accepts `source`**, so a wrong stamp is correctable. A source-only patch does not bump `updatedAt` (see below).

## Cross-install compatibility

**No `schemaVersions.mediaCollections` bump — because the field never crosses the wire.** `sanitizeRecordForWire('mediaCollection', …)` strips `source`, alongside the existing local-only flags `ephemeral` / `importDraft`. The reasoning:

- Emitting it would leave an upgraded peer **permanently checksum-mismatched** against a not-yet-upgraded one on the `mediaCollections` snapshot category: the older peer's sanitizer drops the unknown field, so the 60s loop re-exchanges the snapshot every cycle for a merge that can never converge, and the UI reads it as "behind" forever. That is exactly the failure mode `sanitizeRecordForWire`'s own docblock exists to prevent.
- Gating it behind a version bump instead would **pause all media-collection sync** between version-mismatched peers over a card-ordering flag — the tradeoff this project has explicitly declined for additive fields elsewhere (see the `catalog` / `manuscriptReview` notes in `server/lib/schemaVersions.js`).
- Provenance is a per-install presentation concern, and every install derives its own: the creators stamp at mint time and migration 220 classifies whatever was already on disk — including a peer's records, since each machine runs the migration over its own copies. A record received **after** this install's migration ran arrives unstamped and falls back to the marker heuristic, i.e. exactly the behavior shipped in #3283. **The fallback is never worse than today.**

Stripping is applied on **every** transport, not just the standalone `mediaCollection` push: `buildPushPayload`'s universe and series branches used to bundle their `linkedCollection` as a raw service record, and `getMediaCollectionsSnapshot` hand-rolled its own payload. Both now project through the shared wire sanitizer, so the bundled and standalone forms of one record can't disagree.

Two related safety choices:

- **The migration ignores the name prefix.** Nothing reserves `Universe: ` — the create route takes a free name — so a user-made `Universe: Notes` would have been permanently stamped `auto`. It stamps only the `Auto-…` descriptions, the `uc-`/`sc-` id prefix, and a non-empty string owner link (matching `sanitizeCollection`, since the migration reads raw disk). That still covers all four real auto-creators; name-only records keep flowing through the client fallback, which classifies them as it does today and re-evaluates on rename.
- **A source-only PATCH does not bump `updatedAt`.** The field never reaches a peer, so advancing the shared LWW clock for it would let a local badge fix out-race a peer's real edit.

Not included (as the issue notes): `splitCollectionName` still needs the prefix list for the badge — that is presentation, not provenance.

## Test plan

- `cd server && NODE_ENV=test npm test` — 23,831 passed. The three failures (`lib/dataRoot.test.js`, `services/installState.test.js`, `services/taskPromptDefaults.test.js`) reproduce on a stashed tree at the same commit; they are pre-existing and environment-related (this worktree has no `data/` install root).
- `cd client && npm test` — 5,892 passed, 515 files, no failures.
- New coverage:
  - `scripts/migrations/220-…test.js` — every non-forgeable marker stamped; user-made, name-only, already-stamped, tombstoned and unparseable records left alone; `updatedAt` preserved; idempotent; fresh-install no-op; corrupt owner link rejected.
  - `server/services/mediaCollections.test.js` (`source provenance`) — create defaults, invalid-source rejection, universe/series buckets, legacy record left unstamped, garbage stamp dropped, survives edit + tombstone, PATCH correction without an `updatedAt` bump, and merge cases for an unstamped peer record and a stamped import bundle.
  - `server/lib/syncWire.test.js` — the stamp is stripped from both the per-record and snapshot-category projections, and a stamped record serializes byte-identically to an unstamped one.
  - `server/services/sharing/peerSync.test.js` — a bundled `linkedCollection` on a universe push carries no stamp.
  - `server/routes/mediaCollections.test.js` — PATCH accepts a valid `source` and 400s an unknown one; POST strips it.
  - Client `isAutoCollection` — the stamp wins in both directions, `synthetic` still short-circuits ahead of it, and an absent or garbage `source` falls back to the markers.

Closes #3311
