### PR TITLE
Stop offering (and silently redirecting) a text-to-image-only backend on sprite i2i renders

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -36,6 +36,7 @@
 ## Sprites
 
 - **The panel close buttons and the Lock/Approve controls are now big enough to tap.** The close buttons on the import and new-sprite panels were a bare 16px icon with no padding, and the reference/walk workflow's Lock, Unlock and Approve confirmations were roughly 18-26px tall — well under the 44px target the rest of the interface uses. On a phone these are the controls that dismiss a blocking panel and commit a candidate, so a mis-tap mattered.
+- **[issue-3331] Forking a sprite no longer offers a backend that cannot redraw an image.** A fork is always image+text→image — it seeds the new character from the source's locked reference — but the Backend picker listed every configured image backend, including Agy, which renders text-to-image only. Picking it was accepted, saved as the new character's render pin, and then quietly rendered somewhere else. The fork picker now lists only backends that can take an input image, and the server refuses an explicitly chosen text-to-image-only backend on any seeded sprite render up front, before a record is created, instead of diverging silently. A backend inherited from a saved pin still degrades gracefully to a capable one, the way a pin whose backend was switched off already does.
 
 ## Internal
 

--- a/client/src/components/sprites/ForkSpriteModal.jsx
+++ b/client/src/components/sprites/ForkSpriteModal.jsx
@@ -6,29 +6,41 @@
 // forkSpriteRecord → the server creates the record and queues that render;
 // on success we hand the new record back so the page can navigate to it.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { GitFork, RefreshCw, X } from 'lucide-react';
 import Modal from '../ui/Modal';
 import toast from '../ui/Toast';
 import SpritePreview from './SpritePreview.jsx';
 import { forkSpriteRecord } from '../../services/apiSprites.js';
+import { isI2iCapableMode } from '../../lib/imageGenBackends';
 import { useAsyncAction } from '../../hooks/useAsyncAction.js';
 
 export default function ForkSpriteModal({ open, onClose, source, referencePath, fromTurnaround = false, backends, mode, onForked }) {
   const [name, setName] = useState(`${source?.name || ''} fork`);
   const [id, setId] = useState('');
   const [designPrompt, setDesignPrompt] = useState('');
-  const [forkMode, setForkMode] = useState(mode || '');
+  const [forkMode, setForkMode] = useState(isI2iCapableMode(mode) ? mode : '');
   const [strength, setStrength] = useState(0.65);
+
+  // The fork's first render is ALWAYS image+text→image, so a backend that cannot
+  // take an input image (Agy) must never be offered here — the page's list is
+  // shared with the reference workflow, whose from-scratch turnaround legitimately
+  // can run text-to-image (#3331). The server refuses such a mode outright; this
+  // filter keeps the picker from putting the user in that position at all.
+  const i2iBackends = useMemo(
+    () => (Array.isArray(backends) ? backends.filter((b) => isI2iCapableMode(b.id)) : []),
+    [backends],
+  );
 
   // The page's image `mode` can resolve AFTER this modal mounts (settings fetch
   // lands after the locked-main detail renders, and the modal is mounted
   // eagerly while `mainLocked`). Backfill an empty selection when it arrives so
   // the Backend select — and the canSubmit gate that requires it — aren't
-  // stuck empty; a user's explicit pick (non-empty) is preserved.
-  useEffect(() => { setForkMode((m) => m || mode || ''); }, [mode]);
+  // stuck empty; a user's explicit pick (non-empty) is preserved. A page mode
+  // that can't do i2i is ignored for the same reason it isn't listed.
+  useEffect(() => { setForkMode((m) => m || (isI2iCapableMode(mode) ? mode : '')); }, [mode]);
 
-  const hasBackends = Array.isArray(backends) && backends.length > 0;
+  const hasBackends = i2iBackends.length > 0;
 
   const [submit, submitting] = useAsyncAction(async () => {
     const { record } = await forkSpriteRecord(source.id, {
@@ -126,7 +138,7 @@ export default function ForkSpriteModal({ open, onClose, source, referencePath, 
                 onChange={(e) => setForkMode(e.target.value)}
                 className="bg-port-bg border border-port-border rounded px-2 py-1 text-sm text-white"
               >
-                {backends.map((b) => <option key={b.id} value={b.id}>{b.label || b.id}</option>)}
+                {i2iBackends.map((b) => <option key={b.id} value={b.id}>{b.label || b.id}</option>)}
               </select>
             </label>
           )}
@@ -146,7 +158,8 @@ export default function ForkSpriteModal({ open, onClose, source, referencePath, 
         </div>
         {!hasBackends && (
           <p className="text-xs text-port-warning">
-            No image backend configured — enable Codex or Grok, or set a local Python path, in Settings → Image Gen.
+            No image-to-image backend configured — enable Codex or Grok, or set a local Python path, in
+            Settings → Image Gen. A fork redraws this reference, which text-to-image-only backends cannot do.
           </p>
         )}
       </div>

--- a/client/src/components/sprites/ForkSpriteModal.test.jsx
+++ b/client/src/components/sprites/ForkSpriteModal.test.jsx
@@ -123,10 +123,45 @@ describe('ForkSpriteModal submit gating', () => {
   it('drops the backend requirement (and warns) when no backend is configured', async () => {
     renderModal({ backends: [], mode: '' });
     expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
-    expect(screen.getByText(/No image backend configured/)).toBeInTheDocument();
+    expect(screen.getByText(/No image-to-image backend configured/)).toBeInTheDocument();
 
     await userEvent.type(promptBox(), 'now with a red coat');
     expect(forkButton()).toBeEnabled();
+  });
+});
+
+/**
+ * #3331 — the fork's first render is unconditionally image+text→image, but the
+ * `backends` list is the page's, shared with the reference workflow whose
+ * from-scratch turnaround legitimately runs text-to-image. So a backend that
+ * cannot take an input image reaches this modal and must be dropped here; the
+ * server refuses such a `mode` outright, so offering it is a guaranteed 400.
+ */
+describe('ForkSpriteModal backend filtering', () => {
+  const WITH_AGY = [...BACKENDS, { id: 'agy', label: 'Agy' }];
+
+  it('omits a text-to-image-only backend from the picker', () => {
+    renderModal({ backends: WITH_AGY });
+    const options = [...screen.getByRole('combobox').options].map((o) => o.value);
+    expect(options).toEqual(['codex', 'grok']);
+  });
+
+  it('ignores a text-to-image-only page mode instead of adopting it', async () => {
+    renderModal({ backends: WITH_AGY, mode: 'agy' });
+    await userEvent.type(promptBox(), 'now with a red coat');
+    // An adopted mode satisfies the backend half of the submit gate, so a still
+    // disabled button with a written prompt is exactly "agy was not adopted".
+    expect(forkButton()).toBeDisabled();
+
+    await userEvent.selectOptions(screen.getByRole('combobox'), 'grok');
+    await userEvent.click(forkButton());
+    expect(forkSpriteRecord.mock.calls[0][1].mode).toBe('grok');
+  });
+
+  it('warns instead of offering a picker when every backend is text-to-image-only', () => {
+    renderModal({ backends: [{ id: 'agy', label: 'Agy' }], mode: 'agy' });
+    expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+    expect(screen.getByText(/No image-to-image backend configured/)).toBeInTheDocument();
   });
 });
 

--- a/server/lib/renderTargets.parity.test.js
+++ b/server/lib/renderTargets.parity.test.js
@@ -16,12 +16,14 @@
 
 import { describe, it, expect } from 'vitest';
 import { RENDER_TARGETS, RENDER_TARGET_BACKEND_AUTO } from './renderTargets.js';
+import { EDIT_INCAPABLE_IMAGE_MODES } from '../services/imageGen/modes.js';
 // Import the node-safe leaf, NOT imageGenBackends.js — that module imports
 // lucide-react, which is not installed in the server CI job (this exact import
 // broke main's CI when Phase 2 landed pointing at imageGenBackends).
 import {
   RENDER_TARGET_OPTIONS as CLIENT_OPTIONS,
   RENDER_TARGET_BACKEND_AUTO as CLIENT_AUTO,
+  I2I_CAPABLE_MODES as CLIENT_I2I_CAPABLE,
 } from '../../client/src/lib/imageGenModes.js';
 
 // Targets the Settings UI deliberately does NOT list — a pin nobody's
@@ -47,5 +49,26 @@ describe('render-target client mirror parity (#3231)', () => {
 
   it('the auto sentinel matches across packages', () => {
     expect(CLIENT_AUTO).toBe(RENDER_TARGET_BACKEND_AUTO);
+  });
+});
+
+/**
+ * The client's `I2I_CAPABLE_MODES` is what the i2i-only pickers (the sprite fork
+ * modal, #3331) filter their backend options through, and the server's
+ * `EDIT_INCAPABLE_IMAGE_MODES` is what rejects such a mode at request time. If a
+ * future edit-incapable backend were added server-side and not removed from the
+ * client list, every i2i picker would go back to offering a backend the server
+ * 400s — the exact bug #3331 fixed, re-introduced silently.
+ *
+ * Only one direction is asserted: the client list ALSO omits `external`, which is
+ * edit-capable server-side but isn't queueable and has no i2i UI, so an equality
+ * check would be wrong.
+ */
+describe('edit-capability client mirror parity (#3331)', () => {
+  it('no server edit-incapable backend appears in the client i2i-capable list', () => {
+    for (const mode of EDIT_INCAPABLE_IMAGE_MODES) {
+      expect(CLIENT_I2I_CAPABLE.includes(mode),
+        `"${mode}" is edit-incapable server-side but still listed in the client I2I_CAPABLE_MODES`).toBe(false);
+    }
   });
 });

--- a/server/routes/imageGen.js
+++ b/server/routes/imageGen.js
@@ -19,6 +19,7 @@ import {
 import { optionalUploadFields } from '../lib/multipart.js';
 import * as imageGen from '../services/imageGen/index.js';
 import { local, IMAGE_GEN_MODE, IMAGE_GEN_MODES } from '../services/imageGen/index.js';
+import { editIncapableModeError, isEditCapableMode } from '../services/imageGen/modes.js';
 import { resolveCloudProviderConfig } from '../services/imageGen/cloudProviderConfig.js';
 import setupRouter from './imageGenSetup.js';
 import { enqueueJob, attachSseClient as attachQueueSseClient, cancelJob, listJobs } from '../services/mediaJobQueue/index.js';
@@ -415,11 +416,8 @@ router.post('/generate', imageGenUploads, asyncHandler(async (req, res) => {
     // gated behind an explicit toggle each (not every Codex account has access
     // to the image_gen tool, and grok spends the user's Grok quota).
     if (!cloud.enabled) throw cloud.disabledError;
-    if (mode === IMAGE_GEN_MODE.AGY && (params.initImagePath || params.referenceImagePaths?.length)) {
-      throw new ServerError('Agy Imagegen supports text-to-image only', {
-        status: 400,
-        code: 'AGY_IMAGE_EDIT_UNSUPPORTED',
-      });
+    if (!isEditCapableMode(mode) && (params.initImagePath || params.referenceImagePaths?.length)) {
+      throw editIncapableModeError(mode);
     }
     // `mode` inside jobParams is the queue's discriminator — laneForJob()
     // routes cloud jobs to the parallel cloud lane, and runJob's image branch

--- a/server/services/imageGen/agy.js
+++ b/server/services/imageGen/agy.js
@@ -26,7 +26,9 @@ import { broadcastSse, attachSseClient as attachSse, closeJobAfterDelay } from '
 import { imageGenEvents } from '../imageGenEvents.js';
 import { buildNoImageReason } from './noImageReason.js';
 import { checkFabrication, noFabricationClause } from './fabricationGuard.js';
-import { AGY_IMAGEGEN_IMAGE_MODEL, IMAGE_GEN_MODE, IMAGE_TOOL_NAMES, nearestAgyAspectRatio } from './modes.js';
+import {
+  AGY_IMAGEGEN_IMAGE_MODEL, IMAGE_GEN_MODE, IMAGE_TOOL_NAMES, editIncapableModeError, nearestAgyAspectRatio,
+} from './modes.js';
 import { withSpawnCwdEnv } from '../../lib/spawnCwd.js';
 
 const AGY_TIMEOUT_MS = (() => {
@@ -177,12 +179,7 @@ export async function generateImage({
   cleanC2PA = false,
   denoise = false,
 }) {
-  if (initImagePath || referenceImagePaths?.length) {
-    throw new ServerError('Agy Imagegen supports text-to-image only', {
-      status: 400,
-      code: 'AGY_IMAGE_EDIT_UNSUPPORTED',
-    });
-  }
+  if (initImagePath || referenceImagePaths?.length) throw editIncapableModeError(IMAGE_GEN_MODE.AGY);
   if (!prompt.trim()) {
     throw new ServerError('Prompt is required', { status: 400, code: 'VALIDATION_ERROR' });
   }

--- a/server/services/imageGen/index.js
+++ b/server/services/imageGen/index.js
@@ -14,13 +14,14 @@
 
 import { getSettings } from '../settings.js';
 import { resolveCleanersFromConfig } from '../../lib/imageClean.js';
-import { ServerError } from '../../lib/errorHandler.js';
 import * as external from './external.js';
 import * as local from './local.js';
 import * as codex from './codex.js';
 import * as grok from './grok.js';
 import * as agy from './agy.js';
-import { IMAGE_GEN_MODE, IMAGE_GEN_MODES, CLOUD_IMAGE_GEN_MODES } from './modes.js';
+import {
+  IMAGE_GEN_MODE, IMAGE_GEN_MODES, CLOUD_IMAGE_GEN_MODES, editIncapableModeError, isEditCapableMode,
+} from './modes.js';
 import { resolveCloudProviderConfig } from './cloudProviderConfig.js';
 
 // Cloud-CLI provider modules keyed by mode, so the shared gate in
@@ -120,11 +121,8 @@ export async function generateImage(params) {
   const cloud = resolveCloudProviderConfig(s, mode, { model: cloudModel });
   if (cloud) {
     if (!cloud.enabled) throw cloud.disabledError;
-    if (mode === IMAGE_GEN_MODE.AGY && (normalized.initImagePath || normalized.referenceImagePaths?.length)) {
-      throw new ServerError('Agy Imagegen supports text-to-image only', {
-        status: 400,
-        code: 'AGY_IMAGE_EDIT_UNSUPPORTED',
-      });
+    if (!isEditCapableMode(mode) && (normalized.initImagePath || normalized.referenceImagePaths?.length)) {
+      throw editIncapableModeError(mode);
     }
     return CLOUD_PROVIDERS[mode].generateImage({ ...cloud.providerParams, cleanC2PA, denoise, ...normalized });
   }

--- a/server/services/imageGen/modes.js
+++ b/server/services/imageGen/modes.js
@@ -8,7 +8,13 @@
  * `IMAGE_GEN_MODE.X` is the preferred form at branching/tagging sites.
  * `IMAGE_GEN_MODES` is the alphabet for Zod / OpenAI tool-spec enums.
  * Single source of truth: derive the array from `Object.values(...)`.
+ *
+ * The lone import is the error type — `errorHandler.js` pulls in nothing but
+ * node's `events`, so it cannot reintroduce the provider cycle this module was
+ * split out to avoid.
  */
+
+import { ServerError } from '../../lib/errorHandler.js';
 
 export const IMAGE_GEN_MODE = Object.freeze({
   EXTERNAL: 'external',
@@ -74,6 +80,24 @@ export const EDIT_INCAPABLE_IMAGE_MODES = Object.freeze([IMAGE_GEN_MODE.AGY]);
 
 /** Can `mode` accept an input image (i2i / edit)? */
 export const isEditCapableMode = (mode) => !EDIT_INCAPABLE_IMAGE_MODES.includes(mode);
+
+/**
+ * The one 400 for "this backend was handed an input image and cannot take one".
+ *
+ * Four verbatim copies of this throw existed — `agy.js`, the dispatcher,
+ * `prepareParams.js` and the imageGen route — before the sprite reference paths
+ * needed a fifth (#3331), so it now lives beside the predicate that decides it.
+ * Every caller gates on `isEditCapableMode`, so adding a backend to
+ * EDIT_INCAPABLE_IMAGE_MODES still stays a one-line change.
+ *
+ * The `AGY_IMAGE_EDIT_UNSUPPORTED` code keeps the name it shipped under (it is
+ * the only edit-incapable backend today) so existing clients and docs still
+ * match; the message names whichever backend was actually asked for.
+ */
+export const editIncapableModeError = (mode) => new ServerError(
+  `${mode ? mode[0].toUpperCase() + mode.slice(1) : 'This'} Imagegen supports text-to-image only`,
+  { status: 400, code: 'AGY_IMAGE_EDIT_UNSUPPORTED' },
+);
 
 // Cloud-CLI providers expose no numeric i2i denoise knob, so map the
 // local-runner-style strength (0..1, lower = more faithful to the source)

--- a/server/services/imageGen/prepareParams.js
+++ b/server/services/imageGen/prepareParams.js
@@ -28,6 +28,7 @@ import { ServerError } from '../../lib/errorHandler.js';
 import { PATHS, ensureDir, resolveGalleryImage } from '../../lib/fileUtils.js';
 import { getSettings } from '../settings.js';
 import { IMAGE_GEN_MODE, CLOUD_IMAGE_GEN_MODES, resolveImageCleaners } from './index.js';
+import { editIncapableModeError, isEditCapableMode } from './modes.js';
 import { resolveRenderTargetConfig } from './cloudProviderConfig.js';
 import { RENDER_TARGET, recordRenderPin } from '../../lib/renderTargets.js';
 import { getProject as getMusicVideoProject } from '../musicVideo/projects.js';
@@ -103,12 +104,9 @@ export async function prepareGenerateParams({ data, files, referenceImageFields 
     mode = resolved.mode;
     if (!data.cloudModel && resolved.cloud?.modelId) data.cloudModel = resolved.cloud.modelId;
   }
-  if (mode === IMAGE_GEN_MODE.AGY && (initUpload || data.initImageFile)) {
+  if (!isEditCapableMode(mode) && (initUpload || data.initImageFile)) {
     cleanupReqFilesTemp();
-    throw new ServerError('Agy Imagegen supports text-to-image only', {
-      status: 400,
-      code: 'AGY_IMAGE_EDIT_UNSUPPORTED',
-    });
+    throw editIncapableModeError(mode);
   }
 
   // Resolve cleaners ONCE at the route layer so all three dispatch paths

--- a/server/services/sprites/reference.js
+++ b/server/services/sprites/reference.js
@@ -33,7 +33,7 @@ import { createKeyCachedQueue } from '../../lib/createKeyCachedQueue.js';
 import { enqueueJob } from '../mediaJobQueue/index.js';
 import {
   IMAGE_GEN_MODE, resolveQueueImageMode, resolveQueueImageEditMode,
-  LOCAL_IMAGEGEN_DEFAULT_MODEL,
+  LOCAL_IMAGEGEN_DEFAULT_MODEL, editIncapableModeError, isEditCapableMode,
 } from '../imageGen/modes.js';
 import { resolveImageCleaners } from '../imageGen/index.js';
 import { pickUsableMode, renderTargetDefaults, resolveRenderTargetConfig } from '../imageGen/cloudProviderConfig.js';
@@ -549,7 +549,21 @@ async function startReferenceGenerationImpl(recordId, body, upload = null) {
     // pipeline i2i renders on that platform. Cloud modes are unaffected.
   }
 
-  if (mode === IMAGE_GEN_MODE.AGY && initImagePath) {
+  // An edit-incapable backend cannot run an i2i render at all (#3243/#3331), and
+  // every reference render but a from-scratch turnaround carries a seed. How that
+  // backend was chosen decides what happens:
+  //   • an explicit request-level `body.mode` is a REQUEST — fail it here, with a
+  //     message naming the backend, rather than silently rendering somewhere else
+  //     (the picker that sent it would otherwise show one backend and get another,
+  //     and #3231 persists the choice as the record's render pin);
+  //   • a record/target/settings pin is a PREFERENCE — fall through to an
+  //     edit-capable backend, exactly as pickUsableMode's contract degrades a pin
+  //     whose backend is disabled.
+  // `mode === body.mode` is what distinguishes the two: resolveQueueImageMode
+  // drops an explicit-but-disabled body.mode to the ladder, and that ladder result
+  // is a preference again.
+  if (initImagePath && !isEditCapableMode(mode)) {
+    if (body.mode === mode) throw editIncapableModeError(mode);
     mode = resolveQueueImageEditMode(undefined, settings);
   }
   const { cleanC2PA, denoise } = resolveImageCleaners(undefined, settings, mode);
@@ -764,6 +778,12 @@ export async function listSpriteThumbnails() {
  * behind. User-triggered only.
  */
 export async function forkSprite(sourceId, body) {
+  // A fork is unconditionally image+text→image, so a backend that cannot take an
+  // input image can never run one (#3331). Refuse before `createCharacter` for the
+  // same reason the source is resolved first — a 400 must not leave an orphan
+  // record behind, and the doomed backend would be persisted as the new record's
+  // render pin (#3231 Phase 3) on the way past.
+  if (body.mode && !isEditCapableMode(body.mode)) throw editIncapableModeError(body.mode);
   await resolveSourceReference(sourceId); // fail fast before creating a record
   // The fork's chosen backend/model seeds the NEW record's render pin
   // (#3231 Phase 3) in the create itself, so re-rolls keep rendering where

--- a/server/services/sprites/reference.test.js
+++ b/server/services/sprites/reference.test.js
@@ -45,6 +45,9 @@ const settings = {
     mode: 'codex',
     codex: { enabled: true, codexPath: '/usr/local/bin/codex', model: 'gpt-5.6-luna', effort: 'low' },
     grok: { enabled: true, grokPath: '/usr/local/bin/grok', aspectRatio: '1:1' },
+    // Enabled so the edit-incapable-backend suite (#3331) can ask for it; the
+    // saved `mode` is still codex, so no other test's resolution changes.
+    agy: { enabled: true, agyPath: '/usr/local/bin/agy', model: 'gemini-3.5-flash-low' },
     local: { pythonPath: '/usr/bin/python3', modelId: 'flux-dev-4bit' },
   },
 };
@@ -1126,6 +1129,45 @@ describe('listSpriteThumbnails', () => {
   });
 });
 
+/**
+ * #3331 — a backend that cannot take an input image (agy) may still render a
+ * from-scratch turnaround, but nothing downstream of it. The distinction the
+ * service draws is not "which target" but "where did the mode come from":
+ * an explicit request-level pick fails loudly, a pin degrades quietly.
+ */
+describe('edit-incapable backends on the seeded reference paths (#3331)', () => {
+  it('400s an explicitly requested edit-incapable mode on a seeded render', async () => {
+    const id = newId();
+    await createCharacter(id);
+    await lockTurnaround(id);
+    enqueueJob.mockClear();
+    // The main always derives from the locked sheet, so this render is i2i.
+    await expect(startReferenceGeneration(id, { target: 'main', mode: 'agy' }))
+      .rejects.toMatchObject({ code: 'AGY_IMAGE_EDIT_UNSUPPORTED', status: 400 });
+    expect(enqueueJob).not.toHaveBeenCalled();
+  });
+
+  it('still runs an explicitly requested edit-incapable mode for a from-scratch turnaround', async () => {
+    const id = newId();
+    await createCharacter(id);
+    const result = await startReferenceGeneration(id, { target: 'turnaround', designPrompt: 'a wiry ranger', mode: 'agy' });
+    expect(result.mode).toBe('agy');
+    expect(enqueueJob.mock.calls.at(-1)[0].params.mode).toBe('agy');
+  });
+
+  it('degrades a record PIN to an edit-capable backend rather than failing the render', async () => {
+    const id = newId();
+    await createCharacter(id, { imageMode: 'agy' });
+    await lockTurnaround(id);
+    enqueueJob.mockClear();
+    const { mode } = await startReferenceGeneration(id, { target: 'main' });
+    // A pin is a preference — the same way pickUsableMode degrades a pin whose
+    // backend was switched off, rather than 400ing a request the user didn't make.
+    expect(mode).toBe('codex');
+    expect(enqueueJob.mock.calls.at(-1)[0].params.mode).toBe('codex');
+  });
+});
+
 describe('forkSprite', () => {
   it('creates a new character and queues its turnaround seeded from the source sheet', async () => {
     const source = newId();
@@ -1148,6 +1190,22 @@ describe('forkSprite', () => {
     const call = enqueueJob.mock.calls[0][0];
     expect(call.params.spriteRef.recordId).toBe(record.id);
     expect(call.params.initImagePath).toBe(join(TEST_ROOT, 'sprites', source, `reference/${source}-turnaround-v1.png`));
+  });
+
+  it('400s a fork onto a text-to-image-only backend and creates no orphan record', async () => {
+    const source = newId();
+    await createCharacter(source, { name: 'Origin' });
+    await lockMain(source);
+    enqueueJob.mockClear();
+    const before = (await records.listRecords()).length;
+    // A fork ALWAYS seeds from the source reference, so agy can never run one —
+    // and the picker used to offer it, accept the request, and only diverge
+    // later (#3331). The refusal must land before createCharacter, or the doomed
+    // backend is persisted as the new record's render pin on the way past.
+    await expect(forkSprite(source, { name: 'Agy Fork', designPrompt: 'x', mode: 'agy' }))
+      .rejects.toMatchObject({ code: 'AGY_IMAGE_EDIT_UNSUPPORTED', status: 400 });
+    expect((await records.listRecords()).length).toBe(before);
+    expect(enqueueJob).not.toHaveBeenCalled();
   });
 
   it('400s forking a source with no locked main and creates no orphan record', async () => {


### PR DESCRIPTION
## Summary

A sprite fork is unconditionally image+text→image — it seeds the new character from the source's locked reference — but `ForkSpriteModal`'s Backend picker listed every configured image backend, including Agy, which cannot take an input image at all. Picking it was accepted, persisted as the new record's render pin (#3231 Phase 3), and then quietly rendered on a *different* backend by the AGY-specific downgrade in `startReferenceGeneration`.

- **Client** — the fork picker filters its options through the existing `isI2iCapableMode` predicate, and ignores a page-level `mode` that can't do i2i instead of pre-selecting it. The empty-state copy now explains why a text-to-image-only backend doesn't count. The list stays unfiltered for the reference workflow, whose from-scratch turnaround legitimately runs text-to-image.
- **Server** — `startReferenceGenerationImpl` now decides by *where the mode came from* rather than by which backend it is. An explicit request-level `body.mode` is a request, so an edit-incapable one 400s at request time with a message naming the backend; a record/target/settings pin is a preference, so it still degrades to a capable backend exactly as `pickUsableMode` degrades a pin whose backend was switched off. Every sprite i2i render funnels through this one function, so `/reference/generate`, `/fork` and the asset-card regenerate are all covered by the single predicate.
- `forkSprite` refuses before `createCharacter`, for the same reason the source is resolved first: a rejected fork must leave no orphan record, and the doomed backend would otherwise be written as the new record's render pin on the way past.
- **Cleanup rolled in** — the same 400 existed verbatim at four sites (`agy.js`, the dispatcher, `prepareParams.js`, the imageGen route) and this would have been a fifth, so it is now one `editIncapableModeError(mode)` factory beside `EDIT_INCAPABLE_IMAGE_MODES`, and each site gates on `isEditCapableMode` instead of naming Agy. The error code and message are unchanged for Agy.

## Test plan

- `cd server && npx vitest run services/imageGen routes/imageGen.test.js routes/imageGen.multipart.test.js routes/sprites.test.js services/sprites lib/renderTargets.parity.test.js lib/index.test.js` — 48 files, 1132 passed.
- `cd client && npm test` — 518 files, 5946 passed.
- New coverage: an explicitly requested edit-incapable mode 400s on a seeded render and enqueues nothing; the same mode still runs a from-scratch turnaround; a record *pin* degrades to codex instead of failing; a fork onto that backend 400s and creates no record; the fork picker omits it, doesn't adopt it from the page, and warns when it's the only backend configured; a cross-package parity test fails if a server-side edit-incapable backend is ever left in the client's `I2I_CAPABLE_MODES`.
- The full `cd server && npm test` run has 54 pre-existing failures in DB-backed suites (`Pipeline series require PostgreSQL …`) — reproduced identically on a stashed, clean tree, and none of them touch the changed files.

Closes #3331
