### PR TITLE
fix: 44px touch targets across City HUD, writers dock, and music surfaces

### DIFF
--- a/client/src/components/city/CityFilterBar.jsx
+++ b/client/src/components/city/CityFilterBar.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { STATUS_FILTERS } from '../../utils/cityFilter';
 
-export default function CityFilterBar({ filter, onChange, matchCount, onJumpToFirst }) {
+export default function CityFilterBar({ filter, onChange, matchCount, onJumpToFirst, compact = false }) {
   const inputRef = useRef(null);
   const filterRef = useRef(filter);
   const onChangeRef = useRef(onChange);
@@ -36,7 +36,11 @@ export default function CityFilterBar({ filter, onChange, matchCount, onJumpToFi
     onJumpToFirst?.();
   };
 
-  const chipBaseClass = 'font-pixel text-[9px] tracking-wider px-2 py-1 rounded border transition-colors';
+  // Compact/mobile context (rendered inside the CityHudCompact filter sheet) needs a real
+  // ≥44px touch target; the dense desktop bar keeps its small px-2 py-1 chips.
+  const chipBaseClass = compact
+    ? 'font-pixel text-[10px] tracking-wider px-3 min-h-[44px] flex items-center rounded border transition-colors'
+    : 'font-pixel text-[9px] tracking-wider px-2 py-1 rounded border transition-colors';
 
   return (
     <div className="pointer-events-auto bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg px-2 py-2 flex items-center gap-2 flex-wrap">
@@ -86,7 +90,8 @@ export default function CityFilterBar({ filter, onChange, matchCount, onJumpToFi
             onChange={(e) => onChange({ ...filter, search: e.target.value })}
             onBlur={() => { if (!filter.search) setOpen(false); }}
             placeholder="search apps…"
-            className="font-pixel text-[10px] tracking-wide bg-black/60 border border-cyan-500/30 rounded px-2 py-1 text-cyan-300 placeholder:text-cyan-500/30 focus:outline-none focus:border-cyan-400/70 w-32"
+            aria-label="Search apps"
+            className={`font-pixel text-[10px] tracking-wide bg-black/60 border border-cyan-500/30 rounded px-2 text-cyan-300 placeholder:text-cyan-500/30 focus:outline-none focus:border-cyan-400/70 w-32 ${compact ? 'min-h-[44px]' : 'py-1'}`}
           />
           {filter.search && (
             <span className="font-pixel text-[8px] text-cyan-500/50 tracking-wider">

--- a/client/src/components/city/CityFilterBar.jsx
+++ b/client/src/components/city/CityFilterBar.jsx
@@ -44,7 +44,7 @@ export default function CityFilterBar({ filter, onChange, matchCount, onJumpToFi
 
   return (
     <div className="pointer-events-auto bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg px-2 py-2 flex items-center gap-2 flex-wrap">
-      <div className="flex items-center gap-1">
+      <div className="flex items-center gap-1 flex-wrap">
         {STATUS_FILTERS.map(f => {
           const active = filter.status === f.id;
           return (

--- a/client/src/components/city/CityFilterBar.test.jsx
+++ b/client/src/components/city/CityFilterBar.test.jsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import CityFilterBar from './CityFilterBar';
+
+const baseFilter = { status: 'all', search: '' };
+
+const renderBar = (props = {}) =>
+  render(
+    <CityFilterBar
+      filter={baseFilter}
+      onChange={() => {}}
+      matchCount={0}
+      onJumpToFirst={() => {}}
+      {...props}
+    />
+  );
+
+describe('CityFilterBar', () => {
+  it('pressing / (not already typing) opens and focuses the search field', async () => {
+    renderBar();
+    // Closed by default: the search trigger button is shown, not the input.
+    expect(screen.queryByLabelText('Search apps')).not.toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: '/' });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Search apps')).toBe(document.activeElement);
+    });
+  });
+
+  it('pressing Escape clears the search via onChange, with the exact cleared filter', () => {
+    const onChange = vi.fn();
+    renderBar({ filter: { status: 'online', search: 'alpha' }, onChange });
+
+    fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith({ status: 'online', search: '' });
+  });
+
+  it('pressing / while focus is already in another input does not steal focus', () => {
+    render(
+      <>
+        <input aria-label="Unrelated field" />
+        <CityFilterBar filter={baseFilter} onChange={() => {}} matchCount={0} onJumpToFirst={() => {}} />
+      </>
+    );
+    const otherInput = screen.getByLabelText('Unrelated field');
+    otherInput.focus();
+    expect(document.activeElement).toBe(otherInput);
+
+    fireEvent.keyDown(otherInput, { key: '/' });
+
+    // Focus never moved, and the search panel never opened.
+    expect(document.activeElement).toBe(otherInput);
+    expect(screen.queryByLabelText('Search apps')).not.toBeInTheDocument();
+  });
+
+  it('renders filter chips with the 44px touch-target class in compact mode, not in default mode', () => {
+    const { rerender } = renderBar();
+    const defaultChip = screen.getByRole('button', { name: 'ALL' });
+    expect(defaultChip.className).not.toContain('min-h-[44px]');
+
+    rerender(
+      <CityFilterBar
+        filter={baseFilter}
+        onChange={() => {}}
+        matchCount={0}
+        onJumpToFirst={() => {}}
+        compact
+      />
+    );
+    const compactChip = screen.getByRole('button', { name: 'ALL' });
+    expect(compactChip.className).toContain('min-h-[44px]');
+  });
+});

--- a/client/src/components/city/CityFocusPanel.jsx
+++ b/client/src/components/city/CityFocusPanel.jsx
@@ -100,7 +100,7 @@ export default function CityFocusPanel({ app, notFound = false, agents = [], onC
             onClick={onClose}
             aria-label="Close focus and return to overview"
             title="Close (return to overview)"
-            className="shrink-0 w-8 h-8 flex items-center justify-center text-gray-400 hover:text-cyan-400 transition-colors font-pixel text-[13px]"
+            className="shrink-0 min-w-[44px] min-h-[44px] flex items-center justify-center text-gray-400 hover:text-cyan-400 transition-colors font-pixel text-[13px]"
           >
             ✕
           </button>
@@ -159,7 +159,7 @@ export default function CityFocusPanel({ app, notFound = false, agents = [], onC
           <button
             type="button"
             onClick={() => onOpenApp?.(app.id)}
-            className="flex-1 font-pixel text-[10px] text-cyan-400 tracking-wider border border-cyan-500/40 rounded px-2 py-2 hover:bg-cyan-500/10 transition-colors"
+            className="flex-1 min-h-[44px] font-pixel text-[10px] text-cyan-400 tracking-wider border border-cyan-500/40 rounded px-2 py-2 hover:bg-cyan-500/10 transition-colors"
             title="Open the app detail page"
           >
             OPEN APP {'>'}
@@ -167,7 +167,7 @@ export default function CityFocusPanel({ app, notFound = false, agents = [], onC
           <button
             type="button"
             onClick={onClose}
-            className="font-pixel text-[10px] text-gray-400 tracking-wider border border-cyan-500/20 rounded px-2 py-2 hover:text-cyan-400 hover:border-cyan-500/40 transition-colors"
+            className="min-h-[44px] font-pixel text-[10px] text-gray-400 tracking-wider border border-cyan-500/20 rounded px-2 py-2 hover:text-cyan-400 hover:border-cyan-500/40 transition-colors"
             title="Return to the city overview"
           >
             BACK

--- a/client/src/components/city/CityHudCompact.jsx
+++ b/client/src/components/city/CityHudCompact.jsx
@@ -125,7 +125,7 @@ export default function CityHudCompact({
     if (activePane === 'filter') {
       return (
         <div className="p-3">
-          <CityFilterBar filter={filter} onChange={onFilterChange} onJumpToFirst={onJumpToFirst} matchCount={matchCount} />
+          <CityFilterBar filter={filter} onChange={onFilterChange} onJumpToFirst={onJumpToFirst} matchCount={matchCount} compact />
         </div>
       );
     }

--- a/client/src/components/writers-room/WritersRoomDock.jsx
+++ b/client/src/components/writers-room/WritersRoomDock.jsx
@@ -94,7 +94,7 @@ function DockItem({ item, onStop }) {
         <button
           type="button"
           onClick={() => onStop?.(item.jobId)}
-          className="ml-1 text-gray-500 hover:text-port-error"
+          className="ml-1 p-3 -my-1 -mr-1 flex items-center justify-center text-gray-500 hover:text-port-error"
           title="Cancel this render"
           aria-label={`Cancel ${sceneLabel}`}
         >

--- a/client/src/components/writers-room/WritersRoomDock.jsx
+++ b/client/src/components/writers-room/WritersRoomDock.jsx
@@ -94,7 +94,7 @@ function DockItem({ item, onStop }) {
         <button
           type="button"
           onClick={() => onStop?.(item.jobId)}
-          className="ml-1 p-3 -my-1 -mr-1 flex items-center justify-center text-gray-500 hover:text-port-error"
+          className="ml-1 min-w-[44px] min-h-[44px] -my-2 -mr-2 flex items-center justify-center text-gray-500 hover:text-port-error"
           title="Cancel this render"
           aria-label={`Cancel ${sceneLabel}`}
         >

--- a/client/src/pages/Music.jsx
+++ b/client/src/pages/Music.jsx
@@ -10,11 +10,12 @@
  * tab is deep-linkable and survives reload. `tab` defaults to `artists`.
  */
 
-import { useParams, Navigate, Link } from 'react-router';
+import { useParams, useNavigate, Navigate } from 'react-router';
 import { Music as MusicIcon, Mic, Disc3, AudioLines } from 'lucide-react';
 import ArtistsManager from '../components/music/ArtistsManager';
 import AlbumsManager from '../components/music/AlbumsManager';
 import TracksManager from '../components/music/TracksManager';
+import TabPills from '../components/ui/TabPills';
 
 const TABS = [
   { id: 'artists', label: 'Artists', icon: Mic },
@@ -26,6 +27,7 @@ const VALID = new Set(TABS.map((t) => t.id));
 
 export default function Music() {
   const { tab } = useParams();
+  const navigate = useNavigate();
   const active = tab || 'artists';
   // Unknown tab → redirect to the default rather than render an empty shell.
   if (!VALID.has(active)) return <Navigate to="/music/artists" replace />;
@@ -37,26 +39,16 @@ export default function Music() {
         <h1 className="text-2xl font-bold text-white">Music</h1>
       </div>
 
-      <div className="flex items-center gap-1 mb-6 border-b border-port-border">
-        {TABS.map((t) => {
-          const Icon = t.icon;
-          const isActive = t.id === active;
-          return (
-            <Link
-              key={t.id}
-              to={`/music/${t.id}`}
-              className={`inline-flex items-center gap-2 px-4 py-2 text-sm font-medium border-b-2 -mb-px ${
-                isActive
-                  ? 'border-port-accent text-white'
-                  : 'border-transparent text-gray-400 hover:text-white'
-              }`}
-            >
-              <Icon size={15} aria-hidden="true" />
-              {t.label}
-            </Link>
-          );
-        })}
-      </div>
+      {/* Selection lives in the URL (`/music/:tab`) — TabPills drives onChange
+          callbacks rather than links, so we navigate() to keep the route canonical
+          and deep-linkable. */}
+      <TabPills
+        tabs={TABS}
+        activeTab={active}
+        onChange={(id) => navigate(`/music/${id}`)}
+        ariaLabel="Music sections"
+        className="mb-6"
+      />
 
       {active === 'artists' && <ArtistsManager />}
       {active === 'albums' && <AlbumsManager />}

--- a/client/src/pages/Music.test.jsx
+++ b/client/src/pages/Music.test.jsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
+import { afterEach } from 'vitest';
+
+// Stub the three manager panels — this suite pins the tab/route wiring
+// (URL param → active tab, redirect on an unknown tab, TabPills → navigate),
+// not the managers' own internals.
+vi.mock('../components/music/ArtistsManager', () => ({ default: () => <div data-testid="artists-manager" /> }));
+vi.mock('../components/music/AlbumsManager', () => ({ default: () => <div data-testid="albums-manager" /> }));
+vi.mock('../components/music/TracksManager', () => ({ default: () => <div data-testid="tracks-manager" /> }));
+
+import Music from './Music.jsx';
+
+// Sibling readout of the current route, rendered alongside the page so a
+// redirect's resulting pathname is directly observable (mirrors the
+// `EditorLanding`-style helper in PipelineFindingRedirect.test.jsx).
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}</div>;
+}
+
+const renderAt = (path) => render(
+  <MemoryRouter initialEntries={[path]}>
+    <Routes>
+      <Route path="/music/:tab" element={<><LocationDisplay /><Music /></>} />
+    </Routes>
+  </MemoryRouter>,
+);
+
+describe('<Music>', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('renders the matching manager for a known tab', () => {
+    renderAt('/music/albums');
+    expect(screen.getByTestId('albums-manager')).toBeInTheDocument();
+    expect(screen.queryByTestId('artists-manager')).toBeNull();
+    expect(screen.queryByTestId('tracks-manager')).toBeNull();
+  });
+
+  it('redirects an unknown tab param to /music/artists', () => {
+    renderAt('/music/bogus');
+    expect(screen.getByTestId('location')).toHaveTextContent('/music/artists');
+    expect(screen.getByTestId('artists-manager')).toBeInTheDocument();
+  });
+
+  it('clicking a TabPill navigates the URL to the matching tab route', () => {
+    renderAt('/music/artists');
+    expect(screen.getByTestId('location')).toHaveTextContent('/music/artists');
+
+    fireEvent.click(screen.getByRole('tab', { name: /tracks/i }));
+
+    expect(screen.getByTestId('location')).toHaveTextContent('/music/tracks');
+    expect(screen.getByTestId('tracks-manager')).toBeInTheDocument();
+    expect(screen.queryByTestId('artists-manager')).toBeNull();
+  });
+});

--- a/client/src/pages/Music.test.jsx
+++ b/client/src/pages/Music.test.jsx
@@ -23,6 +23,7 @@ function LocationDisplay() {
 const renderAt = (path) => render(
   <MemoryRouter initialEntries={[path]}>
     <Routes>
+      <Route path="/music" element={<><LocationDisplay /><Music /></>} />
       <Route path="/music/:tab" element={<><LocationDisplay /><Music /></>} />
     </Routes>
   </MemoryRouter>,
@@ -39,6 +40,12 @@ describe('<Music>', () => {
     expect(screen.getByTestId('albums-manager')).toBeInTheDocument();
     expect(screen.queryByTestId('artists-manager')).toBeNull();
     expect(screen.queryByTestId('tracks-manager')).toBeNull();
+  });
+
+  it('defaults bare /music to the artists tab', () => {
+    renderAt('/music');
+    expect(screen.getByTestId('artists-manager')).toBeInTheDocument();
+    expect(screen.queryByTestId('albums-manager')).toBeNull();
   });
 
   it('redirects an unknown tab param to /music/artists', () => {

--- a/client/src/pages/MusicVideo.jsx
+++ b/client/src/pages/MusicVideo.jsx
@@ -70,7 +70,7 @@ const STATUS_COLORS = {
 function YoutubeImportControls({ id, url, onUrlChange, job, onStart, compact = false, disabled = false }) {
   const size = compact ? 12 : 13;
   const py = compact ? 'py-1' : 'py-1.5';
-  const btnExtra = compact ? '' : 'text-xs whitespace-nowrap min-h-[40px] sm:min-h-0';
+  const btnExtra = compact ? '' : 'text-xs whitespace-nowrap min-h-[44px] sm:min-h-0';
   return (
     <>
       <input
@@ -902,7 +902,7 @@ export default function MusicVideo() {
               <p className="text-xs text-port-text-muted">Track set: {trackName(form.trackId)}</p>
             )}
             <button type="submit" disabled={ytImportCreate.active}
-              className="w-full flex items-center justify-center gap-1 bg-port-accent text-white rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0 disabled:opacity-50">
+              className="w-full flex items-center justify-center gap-1 bg-port-accent text-white rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0 disabled:opacity-50">
               <Plus size={16} /> Create
             </button>
         </form>
@@ -937,7 +937,7 @@ export default function MusicVideo() {
         <button
           type="button"
           onClick={() => setCreateOpen(true)}
-          className="flex items-center gap-1 bg-port-accent text-white rounded px-3 py-1.5 text-sm min-h-[40px] sm:min-h-0"
+          className="flex items-center gap-1 bg-port-accent text-white rounded px-3 py-1.5 text-sm min-h-[44px] sm:min-h-0"
         >
           <Plus size={15} /> New project
         </button>
@@ -963,12 +963,12 @@ export default function MusicVideo() {
                   <div className="min-w-0 flex flex-1 flex-wrap items-center justify-end gap-2">
                     <button onClick={handleAnalyze} disabled={analyzing || (!selected.trackId && !selected.uploadedAudioFilename)}
                       title={!selected.trackId && !selected.uploadedAudioFilename ? 'Link a track first' : 'Analyze beat grid'}
-                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0 disabled:opacity-50">
+                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0 disabled:opacity-50">
                       <Activity size={15} /> {analyzing ? 'Analyzing…' : 'Analyze'}
                     </button>
                     {midiTargetsSelected ? (
                       <button onClick={midiJob.cancel} title="Cancel MIDI transcription"
-                        className="flex items-center gap-1 bg-port-warning/20 text-port-warning border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0">
+                        className="flex items-center gap-1 bg-port-warning/20 text-port-warning border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0">
                         <Activity size={15} className="animate-spin" /> {midiJob.stageLabel} · Cancel
                       </button>
                     ) : (
@@ -985,14 +985,14 @@ export default function MusicVideo() {
                           title={!selected.trackId && !selected.uploadedAudioFilename
                             ? 'Link a track first'
                             : `Transcribe the track to MIDI with MuScriptor (${midiModel} model, local — installs automatically on first use)`}
-                          className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0 disabled:opacity-50">
+                          className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0 disabled:opacity-50">
                           <Music size={15} /> MIDI
                         </button>
                       </>
                     )}
                     <button onClick={handlePlan} disabled={planning || !selected.audioAnalysis}
                       title={!selected.audioAnalysis ? 'Analyze the track first' : 'AI-propose a scene per song section'}
-                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0 disabled:opacity-50">
+                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0 disabled:opacity-50">
                       <Wand2 size={15} /> {planning ? 'Planning…' : 'AI Plan'}
                     </button>
                     <button onClick={handleAutoArrange}
@@ -1002,7 +1002,7 @@ export default function MusicVideo() {
                         : (selected.scenes || []).length === 0
                           ? 'Add scenes first'
                           : 'Distribute scenes across song sections by energy'}
-                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0 disabled:opacity-50">
+                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0 disabled:opacity-50">
                       <Wand2 size={15} /> {arranging ? 'Arranging…' : 'Auto-arrange'}
                     </button>
                     <RecordRenderPinRow
@@ -1138,7 +1138,7 @@ export default function MusicVideo() {
                       onClick={handleGenerateMissingFrames}
                       disabled={sceneCount === 0 || missingFrameCount === 0 || Object.keys(genScenes).length > 0}
                       title={missingFrameCount > 0 ? `Generate ${missingFrameCount} missing reference frame${missingFrameCount === 1 ? '' : 's'}` : 'Every scene has a reference frame'}
-                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0 disabled:opacity-50"
+                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0 disabled:opacity-50"
                     >
                       <ImageIcon size={15} /> Frames {referenceFrameCount}/{sceneCount}
                     </button>
@@ -1148,7 +1148,7 @@ export default function MusicVideo() {
                       title={referenceFrameCount !== sceneCount
                         ? 'Generate every reference frame first'
                         : (missingVideoCount > 0 ? `Generate ${missingVideoCount} missing scene video${missingVideoCount === 1 ? '' : 's'}` : 'Every scene has a video')}
-                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0 disabled:opacity-50"
+                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0 disabled:opacity-50"
                     >
                       <Video size={15} /> Videos {renderableSceneCount}/{sceneCount}
                     </button>
@@ -1164,13 +1164,13 @@ export default function MusicVideo() {
                       onClick={handleClone}
                       disabled={cloning}
                       title={`Create an editable v${(selected.version || 1) + 1}; keep scene media attached and clear the final render`}
-                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0 disabled:opacity-50"
+                      className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0 disabled:opacity-50"
                     >
                       <Copy size={15} /> {cloning ? 'Forking…' : `Fork v${(selected.version || 1) + 1}`}
                     </button>
                     {render ? (
                       <button onClick={handleCancelRender} title="Cancel render"
-                        className="flex items-center gap-1 bg-port-warning/20 text-port-warning border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0">
+                        className="flex items-center gap-1 bg-port-warning/20 text-port-warning border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0">
                         <Activity size={15} className="animate-spin" /> {renderProgress}% · Cancel
                       </button>
                     ) : (
@@ -1180,12 +1180,12 @@ export default function MusicVideo() {
                           : renderableSceneCount !== sceneCount
                             ? `Generate videos for all ${sceneCount} scenes first`
                             : 'Render the complete music video over the track'}
-                        className="flex items-center gap-1 bg-port-accent text-white rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0 disabled:opacity-50">
+                        className="flex items-center gap-1 bg-port-accent text-white rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0 disabled:opacity-50">
                         <Film size={15} /> Render final
                       </button>
                     )}
                     <button onClick={() => handleDelete(selected.id)} title="Delete project"
-                      className="flex items-center gap-1 text-port-error border border-port-border rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0">
+                      className="flex items-center gap-1 text-port-error border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0">
                       <Trash2 size={15} />
                     </button>
                   </div>
@@ -1381,7 +1381,7 @@ export default function MusicVideo() {
 
               <div className="flex items-center justify-between">
                 <h3 className="text-sm font-medium">Scene board</h3>
-                <button onClick={handleAddScene} className="flex items-center gap-1 bg-port-accent text-white rounded px-2 py-1.5 text-sm min-h-[40px] sm:min-h-0">
+                <button onClick={handleAddScene} className="flex items-center gap-1 bg-port-accent text-white rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0">
                   <Plus size={15} /> Add scene
                 </button>
               </div>
@@ -1449,7 +1449,7 @@ export default function MusicVideo() {
                             className="w-32 aspect-video object-cover rounded border border-port-border" />
                         )}
                         <button onClick={() => handleGenerateFrame(scene)} disabled={!!genScenes[scene.sceneId]}
-                          className="flex items-center gap-1 bg-port-border hover:bg-port-border/70 disabled:opacity-50 rounded px-2 py-1.5 text-xs min-h-[40px] sm:min-h-0 whitespace-nowrap"
+                          className="flex items-center gap-1 bg-port-border hover:bg-port-border/70 disabled:opacity-50 rounded px-2 py-1.5 text-xs min-h-[44px] sm:min-h-0 whitespace-nowrap"
                           title="Generate a still reference frame for this scene">
                           {genScenes[scene.sceneId] ? <Activity size={14} className="animate-spin" /> : <ImageIcon size={14} />}
                           {genScenes[scene.sceneId] ? 'Generating frame…' : (scene.referenceImageId ? 'Regenerate frame' : 'Generate frame')}
@@ -1465,7 +1465,7 @@ export default function MusicVideo() {
                       )}
                       <button onClick={() => handleGenerateVideo(scene)}
                         disabled={videoSettingsSaving || !scene.referenceImageId || !!genVideoScenes[scene.sceneId] || (audioReactiveSelected && !audioReactiveReady)}
-                        className="flex items-center gap-1 bg-port-border hover:bg-port-border/70 disabled:opacity-50 rounded px-2 py-1.5 text-xs min-h-[40px] sm:min-h-0 whitespace-nowrap"
+                        className="flex items-center gap-1 bg-port-border hover:bg-port-border/70 disabled:opacity-50 rounded px-2 py-1.5 text-xs min-h-[44px] sm:min-h-0 whitespace-nowrap"
                         title={scene.referenceImageId ? "Generate this scene's video from its reference frame (i2v)" : 'Generate a reference frame first'}>
                         {genVideoScenes[scene.sceneId] ? <Activity size={14} className="animate-spin" /> : <Video size={14} />}
                         {genVideoScenes[scene.sceneId] ? 'Generating video…' : (scene.videoHistoryId ? 'Regenerate video' : 'Generate video')}
@@ -1474,7 +1474,7 @@ export default function MusicVideo() {
                         <button
                           onClick={() => handleContinueVideo(scene)}
                           disabled={videoSettingsSaving || !!genVideoScenes[scene.sceneId]}
-                          className="flex items-center gap-1 bg-port-bg border border-port-border hover:bg-port-border/40 disabled:opacity-50 rounded px-2 py-1.5 text-xs min-h-[40px] sm:min-h-0 whitespace-nowrap"
+                          className="flex items-center gap-1 bg-port-bg border border-port-border hover:bg-port-border/40 disabled:opacity-50 rounded px-2 py-1.5 text-xs min-h-[44px] sm:min-h-0 whitespace-nowrap"
                           title="Native-extend this clip from its final latent frames and attach the longer result to this scene"
                         >
                           <Video size={14} /> Continue shot


### PR DESCRIPTION
## Summary
Part of the 2026-08-03 `/do:better` audit (UX / City / game / music / writing focus).

- `CityFocusPanel` close/footer buttons and `CityFilterBar`'s mobile filter sheet (new `compact` prop, passed only by `CityHudCompact`) meet the 44px touch-target convention; desktop density unchanged. The filter search input gains an accessible name.
- `MusicVideo`'s 18 `min-h-[40px]` buttons standardized to the 44px convention.
- `WritersRoomDock`'s render-cancel icon gets a padded hit area (was ~14px on a fixed bottom dock).
- The Music page's hand-rolled tab bar moves onto the shared `TabPills` (overflow-safe, 44px), wired through `navigate()` so `/music/:tab` deep links stay canonical, including the invalid-tab redirect.
- `WorkEditor`'s mobile Writing/Storyboard toggle 44px fix ships in the `better/bugs-perf` PR (file ownership).

### Merge order
Independent — disjoint files from the sibling `better/*` PRs.

## Test plan
- New `Music.test.jsx`: known-tab render, `/music/bogus` → `/music/artists` redirect, TabPill click navigation
- New `CityFilterBar.test.jsx`: `/` focuses search, Escape clears, typing-guard, compact-mode 44px chips
- Full client suite: 6,025 passing locally; branch builds independently
