### PR TITLE
fix(a11y): give icon-only buttons accessible names and 44px tap targets

### DIFF
--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -87,6 +87,140 @@ function balancedCallAt(src, openIndex, skipStrings = true) {
   return skipStrings ? balancedCallAt(src, openIndex, false) : null;
 }
 
+// --- helpers for the icon-only-button-name and 44px-close-target rules ---
+
+// Find the index of the `}` matching the `{` at `s[idx]`, respecting nested
+// braces and quoted/template strings.
+function matchingBraceEnd(s, idx) {
+  let depth = 0;
+  for (let i = idx; i < s.length; i++) {
+    const c = s[i];
+    if (c === '"' || c === '\'' || c === '`') {
+      const q = c;
+      for (i++; i < s.length && s[i] !== q; i++) if (s[i] === '\\') i++;
+      continue;
+    }
+    if (c === '{') depth++;
+    else if (c === '}') { depth--; if (depth === 0) return i; }
+  }
+  return -1;
+}
+
+// Find the top-level `>` closing a JSX opening tag starting at `s[idx]` (`<`),
+// respecting `{...}` attribute-expression nesting and quoted strings inside
+// them. Returns `{ end, selfClosing }`, `end` being the index just past `>`.
+function tagBoundaryAt(s, idx) {
+  let depth = 0;
+  for (let i = idx + 1; i < s.length; i++) {
+    const c = s[i];
+    if (c === '{') depth++;
+    else if (c === '}') depth--;
+    else if ((c === '"' || c === '\'' || c === '`') && depth > 0) {
+      const q = c;
+      for (i++; i < s.length && s[i] !== q; i++) if (s[i] === '\\') i++;
+    } else if (c === '>' && depth === 0) {
+      let back = i - 1;
+      while (back > idx && /\s/.test(s[back])) back--;
+      return { end: i + 1, selfClosing: s[back] === '/' };
+    }
+  }
+  return null;
+}
+
+const stripJsxComments = (s) => s.replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, '');
+
+// A button body counts as icon-only when it is a SOLE top-level JSX child: a
+// single self-closing capitalized component, or a `{...}` expression whose
+// entire content is a ternary/`&&` between two such components (the
+// play/pause, expand/collapse shape). A naive `^<Icon.../>$`-shaped regex
+// over the raw body text is unsafe here — a wildcard greedily matches straight
+// across sibling boundaries, so `<Icon/><span>text</span>` misreads as one
+// self-closing element with a visible-text sibling silently absorbed into it.
+// Walking to the true boundary of the first top-level node and checking
+// nothing follows it is what catches that case (see ui/ProvenanceChip.jsx,
+// whose icon + <span>label</span> + icon button must NOT be flagged, since
+// the <span> already gives it an accessible name).
+function soleTopLevelNode(rawBody) {
+  const s = stripJsxComments(rawBody).trim();
+  if (!s) return null;
+  if (s[0] === '<') {
+    const boundary = tagBoundaryAt(s, 0);
+    if (!boundary) return null;
+    if (s.slice(boundary.end).trim() !== '') return null; // more than one top-level node
+    return { kind: 'element', raw: s.slice(0, boundary.end), selfClosing: boundary.selfClosing };
+  }
+  if (s[0] === '{') {
+    const end = matchingBraceEnd(s, 0);
+    if (end === -1) return null;
+    if (s.slice(end + 1).trim() !== '') return null; // more than one top-level node
+    return { kind: 'expr', inner: s.slice(1, end).trim() };
+  }
+  return null; // bare text at top level
+}
+
+function matchTernaryIcons(inner) {
+  let depth = 0;
+  let qIdx = -1;
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i];
+    if (c === '(' || c === '{' || c === '[') depth++;
+    else if (c === ')' || c === '}' || c === ']') depth--;
+    else if (c === '?' && depth === 0 && inner[i + 1] !== '.') { qIdx = i; break; }
+  }
+  if (qIdx === -1) return false;
+  depth = 0;
+  let cIdx = -1;
+  for (let i = qIdx + 1; i < inner.length; i++) {
+    const c = inner[i];
+    if (c === '(' || c === '{' || c === '[') depth++;
+    else if (c === ')' || c === '}' || c === ']') depth--;
+    else if (c === ':' && depth === 0) { cIdx = i; break; }
+  }
+  if (cIdx === -1) return false;
+  const a = inner.slice(qIdx + 1, cIdx).trim();
+  const b = inner.slice(cIdx + 1).trim();
+  const iconRe = /^<[A-Z][\w.]*(\s[^]*)?\/>$/;
+  return iconRe.test(a) && iconRe.test(b);
+}
+
+function isIconOnlyBody(rawBody) {
+  const node = soleTopLevelNode(rawBody);
+  if (!node) return false;
+  if (node.kind === 'element') return node.selfClosing && /^<[A-Z]/.test(node.raw);
+  const inner = node.inner;
+  if (matchTernaryIcons(inner)) return true;
+  const andMatch = inner.match(/^.*&&\s*(<[A-Z][\w.]*(\s[^]*)?\/>)\s*$/s);
+  if (!andMatch) return false;
+  return /^<[A-Z][\w.]*(\s[^]*)?\/>$/.test(andMatch[1].trim());
+}
+
+// Buttons don't nest in valid HTML/JSX, so the first `</button>` after the
+// opening tag's end is its match.
+function findButtonBody(src, openEnd) {
+  const closeIdx = src.indexOf('</button>', openEnd);
+  return closeIdx === -1 ? null : src.slice(openEnd, closeIdx);
+}
+
+// Tailwind `h-`/`w-`/`min-h-`/`min-w-` token → px, for both an arbitrary
+// value (`min-h-[44px]`) and the spacing scale (`h-11` = 11 * 4px = 44px).
+function tokenPx(token) {
+  const arb = token.match(/^(?:min-)?[hw]-\[(\d+(?:\.\d+)?)px\]$/);
+  if (arb) return parseFloat(arb[1]);
+  const scale = token.match(/^(?:min-)?[hw]-(\d+(?:\.5)?)$/);
+  if (scale) return parseFloat(scale[1]) * 4;
+  return null;
+}
+
+function hasFortyFourMinTouchTarget(cls) {
+  let hOk = false;
+  let wOk = false;
+  for (const token of cls.split(/\s+/)) {
+    if (/^(?:min-)?h-/.test(token) && tokenPx(token) >= 44) hOk = true;
+    if (/^(?:min-)?w-/.test(token) && tokenPx(token) >= 44) wOk = true;
+  }
+  return hOk && wOk;
+}
+
 describe('a11y conventions', () => {
   // Modal.jsx IS the shared implementation; Drawer and Layout use the same
   // backdrop treatment for a slide-in panel / mobile nav scrim, both of which
@@ -251,5 +385,62 @@ describe('a11y conventions', () => {
       }
     }
     expect(offenders, `role="switch" without aria-checked:\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it('gives every icon-only button an accessible name', () => {
+    // A <button> whose entire body is an icon (including one chosen by a
+    // ternary, e.g. play/pause, expand/collapse) has no text content for a
+    // screen reader to announce. `title` alone doesn't fill that gap — it's
+    // mouse-hover-only (no touch discoverability, and this app is opened from
+    // other devices over the tailnet) and browser/AT support for `title` as
+    // the accessible name is inconsistent. aria-label (or aria-labelledby) is
+    // required; media/MediaCard.jsx's Annotate button (title + a paired
+    // aria-label) is the existing convention.
+    const offenders = [];
+    for (const file of trackedJsxFiles()) {
+      const src = readFileSync(join(CLIENT_ROOT, file), 'utf8');
+      const re = /<button\b/g;
+      let m;
+      while ((m = re.exec(src))) {
+        const tag = openingTagAt(src, m.index, '<button'.length);
+        if (!tag || tag.endsWith('/>')) continue; // self-closing — no body to judge
+        if (/\baria-label\s*=/.test(tag) || /\baria-labelledby\s*=/.test(tag)) continue;
+        const openEnd = m.index + tag.length;
+        const body = findButtonBody(src, openEnd);
+        if (body === null || !isIconOnlyBody(body)) continue;
+        offenders.push(`${file}:${lineOf(src, m.index)}`);
+      }
+    }
+    expect(offenders, `Icon-only <button> with no aria-label/aria-labelledby — title alone isn't touch-discoverable and isn't reliably read as the accessible name; see media/MediaCard.jsx's Annotate button for the convention:\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it('meets the 44px touch-target minimum on Close buttons', () => {
+    // Close buttons keep shipping sized to their bare icon (w-4 h-4, p-1,
+    // p-1.5) instead of a real tap target. components/Drawer.jsx:106 is the
+    // convention: min-h-[44px] min-w-[44px] + flex items-center
+    // justify-center, so the icon stays centered in the larger box.
+    //
+    // `inset-0` buttons are exempt: a full-bleed tap-anywhere-to-dismiss
+    // backdrop (e.g. brain/tabs/DailyLogTab.jsx's mobile history scrim)
+    // already covers the entire screen/panel, so a min-w/min-h floor is
+    // meaningless — the element's box is already forced to fill its
+    // positioned ancestor.
+    const CLOSE_LABEL_RE = /aria-label\s*=\s*"(Close[^"]*)"/;
+    const offenders = [];
+    for (const file of trackedJsxFiles()) {
+      const src = readFileSync(join(CLIENT_ROOT, file), 'utf8');
+      const re = /<button\b/g;
+      let m;
+      while ((m = re.exec(src))) {
+        const tag = openingTagAt(src, m.index, '<button'.length);
+        if (!tag || !CLOSE_LABEL_RE.test(tag)) continue;
+        if (/\binset-0\b/.test(tag)) continue;
+        const clsMatch = tag.match(/className\s*=\s*"([^"]*)"/);
+        if (!clsMatch) continue; // dynamic className — reviewed by hand, not scanned here
+        if (hasFortyFourMinTouchTarget(clsMatch[1])) continue;
+        offenders.push(`${file}:${lineOf(src, m.index)}`);
+      }
+    }
+    expect(offenders, `Close button under the 44px touch-target minimum — add min-h-[44px] min-w-[44px] + flex items-center justify-center (see Drawer.jsx:106):\n${offenders.join('\n')}`).toEqual([]);
   });
 });

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -183,7 +183,25 @@ function matchTernaryIcons(inner) {
   return iconRe.test(a) && iconRe.test(b);
 }
 
-function isIconOnlyBody(rawBody) {
+// Unwrap presentational wrappers: a button whose body is `<span><X/></span>`
+// (an extra element for padding, a hover background, or a badge) is still
+// icon-only, but a walker that stops at the wrapper's opening tag reads its
+// children as "more than one top-level node" and skips the button entirely.
+// Recurse through lowercase host elements that carry no text of their own.
+function unwrapPresentational(rawBody, depth = 0) {
+  if (depth > 4) return rawBody;
+  const s = stripJsxComments(rawBody).trim();
+  const m = s.match(/^<([a-z][\w-]*)\b/);
+  if (!m) return s;
+  const boundary = tagBoundaryAt(s, 0);
+  if (!boundary || boundary.selfClosing) return s;
+  const close = `</${m[1]}>`;
+  if (!s.endsWith(close)) return s;
+  return unwrapPresentational(s.slice(boundary.end, s.length - close.length), depth + 1);
+}
+
+function isIconOnlyBody(rawBodyIn) {
+  const rawBody = unwrapPresentational(rawBodyIn);
   const node = soleTopLevelNode(rawBody);
   if (!node) return false;
   if (node.kind === 'element') return node.selfClosing && /^<[A-Z]/.test(node.raw);
@@ -425,7 +443,14 @@ describe('a11y conventions', () => {
     // already covers the entire screen/panel, so a min-w/min-h floor is
     // meaningless — the element's box is already forced to fill its
     // positioned ancestor.
-    const CLOSE_LABEL_RE = /aria-label\s*=\s*"(Close[^"]*)"/;
+    // Matches both a literal `aria-label="Close…"` and an expression form
+    // `aria-label={cond ? 'Close panel' : …}` / {`Close ${x}`} / {closeLabel}.
+    // Scanning only the literal form is how a live 16px close button in
+    // apps/DeployPanel.jsx (dynamic label, no sizing at all) hid from this
+    // guard while it reported zero offenders — the canonical Drawer.jsx close
+    // button uses a dynamic label too, so the literal-only form misses the
+    // exact shape the convention was written from.
+    const CLOSE_LABEL_RE = /aria-label\s*=\s*(?:"Close[^"]*"|\{[^}]*(?:['"`]Close|[Cc]loseLabel)[^}]*\})/;
     const offenders = [];
     for (const file of trackedJsxFiles()) {
       const src = readFileSync(join(CLIENT_ROOT, file), 'utf8');

--- a/client/src/components/EntityCombobox.jsx
+++ b/client/src/components/EntityCombobox.jsx
@@ -142,7 +142,7 @@ export default function EntityCombobox({
         <button
           type="button"
           onClick={() => setOpen((p) => !p)}
-          className="absolute right-1 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-white"
+          className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center justify-center min-h-[44px] min-w-[44px] text-gray-500 hover:text-white"
           aria-label={open ? `Close ${noun} list` : `Open ${noun} list`}
           tabIndex={-1}
         >

--- a/client/src/components/FolderPicker.jsx
+++ b/client/src/components/FolderPicker.jsx
@@ -117,7 +117,7 @@ export default function FolderPicker({ value, onChange, defaultPath }) {
             <button
               type="button"
               onClick={() => setIsOpen(false)}
-              className="p-1 text-gray-400 hover:text-white"
+              className="p-1 text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
               aria-label="Close folder picker"
             >
               <X size={20} />
@@ -134,7 +134,7 @@ export default function FolderPicker({ value, onChange, defaultPath }) {
               type="button"
               onClick={() => handleNavigate('~')}
               className="p-1 text-gray-500 hover:text-white shrink-0"
-              title="Home directory"
+              title="Home directory" aria-label="Home directory"
             >
               <Home size={16} />
             </button>

--- a/client/src/components/IngredientPicker.jsx
+++ b/client/src/components/IngredientPicker.jsx
@@ -139,7 +139,7 @@ export default function IngredientPicker({
           type="button"
           onClick={onClose}
           aria-label="Close ingredient picker"
-          className="p-2 text-gray-500 hover:text-white rounded"
+          className="p-2 text-gray-500 hover:text-white rounded min-h-[44px] min-w-[44px] flex items-center justify-center"
         >
           <X size={18} aria-hidden="true" />
         </button>

--- a/client/src/components/KeyboardHelp.jsx
+++ b/client/src/components/KeyboardHelp.jsx
@@ -104,7 +104,7 @@ export default function KeyboardHelp() {
           <button
             ref={closeButtonRef}
             onClick={close}
-            className="p-1 text-gray-500 hover:text-white transition-colors rounded"
+            className="p-1 text-gray-500 hover:text-white transition-colors rounded min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Close keyboard shortcuts"
           >
             <X size={16} />

--- a/client/src/components/RapidReader.jsx
+++ b/client/src/components/RapidReader.jsx
@@ -211,7 +211,7 @@ export default function RapidReader({
             <button
               type="button"
               onClick={onClose}
-              className="min-h-10 min-w-10 flex items-center justify-center rounded-lg border border-port-border text-gray-400 hover:text-white hover:bg-port-bg/60 ml-1"
+              className="min-h-[44px] min-w-[44px] flex items-center justify-center rounded-lg border border-port-border text-gray-400 hover:text-white hover:bg-port-bg/60 ml-1"
               title="Close (Esc)"
               aria-label="Close"
             >
@@ -323,7 +323,7 @@ export function RapidReaderModal({ open, text, title, onClose, ...readerProps })
         <button
           type="button"
           onClick={onClose}
-          className="min-h-10 min-w-10 flex items-center justify-center text-gray-400 hover:text-white"
+          className="min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-400 hover:text-white"
           aria-label="Close rapid reader"
         >
           <X size={18} />

--- a/client/src/components/apps/DeployPanel.jsx
+++ b/client/src/components/apps/DeployPanel.jsx
@@ -141,7 +141,7 @@ export default function DeployPanel({ appId, appName }) {
             </div>
             <button
               onClick={handleClose}
-              className="text-gray-400 hover:text-white transition-colors"
+              className="flex items-center justify-center min-h-[44px] min-w-[44px] text-gray-400 hover:text-white transition-colors"
               title={isDeploying ? 'Hide (deploy keeps running)' : 'Close'}
               aria-label={isDeploying ? 'Hide deploy output' : 'Close deploy panel'}
             >

--- a/client/src/components/apps/ReferenceReposPanel.jsx
+++ b/client/src/components/apps/ReferenceReposPanel.jsx
@@ -315,14 +315,14 @@ function RefRow({ reference, snapshot, checking, editingNotes, onCheck, onMarkRe
           <button
             onClick={onEditNotes}
             className="px-2 py-1 text-gray-400 hover:text-white rounded"
-            title="Edit notes"
+            title="Edit notes" aria-label="Edit notes"
           >
             <Edit3 size={12} />
           </button>
           <button
             onClick={onDelete}
             className="px-2 py-1 text-gray-400 hover:text-port-error rounded"
-            title="Remove this reference"
+            title="Remove this reference" aria-label="Remove this reference"
           >
             <Trash2 size={12} />
           </button>

--- a/client/src/components/apps/tabs/CustomTasksSection.jsx
+++ b/client/src/components/apps/tabs/CustomTasksSection.jsx
@@ -372,10 +372,10 @@ export default function CustomTasksSection({ appId, appName }) {
                       </div>
                     </div>
                     <div className="flex items-center gap-1 shrink-0">
-                      <button onClick={() => handleTrigger(job)} disabled={triggering === job.id || !job.enabled} className="p-1.5 text-gray-500 hover:text-port-accent transition-colors disabled:opacity-40" title="Run now">
+                      <button onClick={() => handleTrigger(job)} disabled={triggering === job.id || !job.enabled} className="p-1.5 text-gray-500 hover:text-port-accent transition-colors disabled:opacity-40" title="Run now" aria-label="Run now">
                         <Play size={14} />
                       </button>
-                      <button onClick={() => startEdit(job)} className="p-1.5 text-gray-500 hover:text-white transition-colors" title="Edit">
+                      <button onClick={() => startEdit(job)} className="p-1.5 text-gray-500 hover:text-white transition-colors" title="Edit" aria-label="Edit">
                         <Edit3 size={14} />
                       </button>
                       {isConfirming(job.id) ? (
@@ -386,7 +386,7 @@ export default function CustomTasksSection({ appId, appName }) {
                           ariaLabel="Confirm delete custom task"
                         />
                       ) : (
-                        <button onClick={() => requestDelete(job.id)} className="p-1.5 text-red-400/60 hover:text-red-400 transition-colors" title="Delete">
+                        <button onClick={() => requestDelete(job.id)} className="p-1.5 text-red-400/60 hover:text-red-400 transition-colors" title="Delete" aria-label="Delete">
                           <Trash2 size={14} />
                         </button>
                       )}

--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -691,7 +691,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
                             <button
                               onClick={() => setMergeConfirm(branch.name)}
                               className={`${iconBtnCls} text-gray-400 hover:text-port-accent hover:bg-port-bg rounded`}
-                              title={`Merge ${branch.name} into current branch`}
+                              title={`Merge ${branch.name} into current branch`} aria-label={`Merge ${branch.name} into current branch`}
                             >
                               <GitMerge size={14} />
                             </button>
@@ -805,7 +805,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
                           <button
                             onClick={() => setDeleteConfirm(rb.name)}
                             className={`${iconBtnCls} text-gray-500 hover:text-port-error hover:bg-port-bg rounded`}
-                            title="Delete branch"
+                            title="Delete branch" aria-label="Delete branch"
                           >
                             <Trash2 size={14} />
                           </button>
@@ -865,7 +865,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
       >
         <div className="flex items-center justify-between p-4 border-b border-port-border">
           <h3 id="git-diff-modal-title" className="font-medium text-white">Git Diff</h3>
-          <button onClick={() => setShowDiff(false)} aria-label="Close" className="text-gray-400 hover:text-white">×</button>
+          <button onClick={() => setShowDiff(false)} aria-label="Close" className="text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center">×</button>
         </div>
         <pre className="p-4 overflow-auto max-h-[70vh] text-sm font-mono">
           {diff.split('\n').map((line, i) => {
@@ -894,7 +894,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
             <Rocket size={18} className="text-port-accent" />
             Create Release PR for {appName}
           </h3>
-          <button onClick={() => setShowReleaseConfirm(false)} aria-label="Close" className="text-gray-400 hover:text-white">×</button>
+          <button onClick={() => setShowReleaseConfirm(false)} aria-label="Close" className="text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center">×</button>
         </div>
         <div className="p-4 space-y-3">
           <p className="text-sm text-gray-300">

--- a/client/src/components/apps/tabs/ProcessesTab.jsx
+++ b/client/src/components/apps/tabs/ProcessesTab.jsx
@@ -261,7 +261,7 @@ export default function ProcessesTab({ appId, pm2ProcessNames, filterFn }) {
               <button
                 onClick={() => setFullscreen(false)}
                 className="p-2 text-gray-400 hover:text-white"
-                title="Exit fullscreen"
+                title="Exit fullscreen" aria-label="Exit fullscreen"
               >
                 <X size={20} />
               </button>

--- a/client/src/components/brain/ConversationViewer.jsx
+++ b/client/src/components/brain/ConversationViewer.jsx
@@ -38,7 +38,7 @@ export default function ConversationViewer({ record, onClose }) {
         <h3 className="font-medium text-white truncate pr-4">{record.title}</h3>
         <button
           onClick={onClose}
-          className="text-gray-400 hover:text-white flex-shrink-0"
+          className="text-gray-400 hover:text-white flex-shrink-0 min-h-[44px] min-w-[44px] flex items-center justify-center"
           aria-label="Close conversation viewer"
         >
           <X size={18} />

--- a/client/src/components/brain/links/BucketCard.jsx
+++ b/client/src/components/brain/links/BucketCard.jsx
@@ -184,14 +184,14 @@ export default function BucketCard({
           <button
             onClick={startEdit}
             className="p-1 text-gray-400 hover:text-white transition-colors"
-            title="Edit bucket"
+            title="Edit bucket" aria-label="Edit bucket"
           >
             <Edit2 size={13} />
           </button>
           <button
             onClick={() => setConfirmDelete(true)}
             className="p-1 text-gray-400 hover:text-port-error transition-colors"
-            title="Delete bucket"
+            title="Delete bucket" aria-label="Delete bucket"
           >
             <Trash2 size={13} />
           </button>
@@ -247,7 +247,7 @@ export default function BucketCard({
           type="submit"
           disabled={adding || !addUrl.trim()}
           className="shrink-0 px-2 py-1 bg-port-accent/80 hover:bg-port-accent text-white rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
-          title="Add link to bucket"
+          title="Add link to bucket" aria-label="Add link to bucket"
         >
           {adding ? <BrailleSpinner /> : <Plus size={14} />}
         </button>

--- a/client/src/components/brain/links/LinkChip.jsx
+++ b/client/src/components/brain/links/LinkChip.jsx
@@ -50,7 +50,7 @@ export default function LinkChip({ link, onRemove, draggable }) {
         <button
           onClick={() => onRemove(link)}
           className="shrink-0 p-0.5 text-gray-600 hover:text-port-error opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
-          title="Remove from bucket"
+          title="Remove from bucket" aria-label="Remove from bucket"
         >
           <X size={13} />
         </button>

--- a/client/src/components/brain/tabs/DailyLogTab.jsx
+++ b/client/src/components/brain/tabs/DailyLogTab.jsx
@@ -539,14 +539,14 @@ export default function DailyLogTab() {
           <button
             onClick={() => setShowSettings((s) => !s)}
             className="ml-auto min-h-[40px] min-w-[40px] flex items-center justify-center rounded text-gray-400 hover:text-white hover:bg-port-card"
-            title="Daily log settings"
+            title="Daily log settings" aria-label="Daily log settings"
           >
             <Settings size={14} />
           </button>
           <button
             onClick={() => setHistoryOpen(false)}
-            className="md:hidden min-h-[40px] min-w-[40px] flex items-center justify-center rounded text-gray-400 hover:text-white hover:bg-port-card"
-            title="Close history"
+            className="md:hidden min-h-[44px] min-w-[44px] flex items-center justify-center rounded text-gray-400 hover:text-white hover:bg-port-card"
+            title="Close history" aria-label="Close history"
           >
             <X size={14} />
           </button>
@@ -703,7 +703,7 @@ export default function DailyLogTab() {
           <button
             onClick={() => setDate(shiftDate(date, -1))}
             className="min-h-[40px] min-w-[40px] flex items-center justify-center rounded hover:bg-port-card text-gray-400 hover:text-white"
-            title="Previous day"
+            title="Previous day" aria-label="Previous day"
           >
             <ChevronLeft size={16} />
           </button>
@@ -717,7 +717,7 @@ export default function DailyLogTab() {
             onClick={() => setDate(shiftDate(date, 1))}
             disabled={date >= serverToday}
             className="min-h-[40px] min-w-[40px] flex items-center justify-center rounded hover:bg-port-card text-gray-400 hover:text-white disabled:opacity-30"
-            title="Next day"
+            title="Next day" aria-label="Next day"
           >
             <ChevronRight size={16} />
           </button>

--- a/client/src/components/brain/tabs/FeedsTab.jsx
+++ b/client/src/components/brain/tabs/FeedsTab.jsx
@@ -251,14 +251,14 @@ export default function FeedsTab({ onRefresh }) {
                   <button
                     onClick={(e) => { e.stopPropagation(); handleRefreshFeed(feed.id); }}
                     className="p-1 text-gray-500 hover:text-white rounded"
-                    title="Refresh feed"
+                    title="Refresh feed" aria-label="Refresh feed"
                   >
                     <RefreshCw size={10} />
                   </button>
                   <button
                     onClick={(e) => { e.stopPropagation(); setConfirmingDeleteId(feed.id); }}
                     className="p-1 text-gray-500 hover:text-port-error rounded"
-                    title="Remove feed"
+                    title="Remove feed" aria-label="Remove feed"
                   >
                     <Trash2 size={10} />
                   </button>

--- a/client/src/components/brain/tabs/InboxTab.jsx
+++ b/client/src/components/brain/tabs/InboxTab.jsx
@@ -336,7 +336,7 @@ export default function InboxTab({ onRefresh, settings }) {
             type="submit"
             disabled={!inputText.trim()}
             className="px-4 py-3 bg-port-accent hover:bg-port-accent/80 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-            title="Capture thought"
+            title="Capture thought" aria-label="Capture thought"
           >
             <Send className="w-5 h-5" />
           </button>
@@ -431,14 +431,14 @@ export default function InboxTab({ onRefresh, settings }) {
                             <button
                               onClick={() => handleSaveEdit(entry.id)}
                               className="p-1 text-port-success hover:bg-port-success/20 rounded transition-colors"
-                              title="Save changes"
+                              title="Save changes" aria-label="Save changes"
                             >
                               <Save size={14} />
                             </button>
                             <button
                               onClick={handleCancelEdit}
                               className="p-1 text-gray-400 hover:bg-port-border/50 rounded transition-colors"
-                              title="Cancel editing"
+                              title="Cancel editing" aria-label="Cancel editing"
                             >
                               <X size={14} />
                             </button>
@@ -451,14 +451,14 @@ export default function InboxTab({ onRefresh, settings }) {
                             <button
                               onClick={() => handleEdit(entry)}
                               className="p-1 text-gray-400 hover:text-white transition-colors"
-                              title="Edit text"
+                              title="Edit text" aria-label="Edit text"
                             >
                               <Edit2 size={14} />
                             </button>
                             <button
                               onClick={() => setConfirmingDeleteId(entry.id)}
                               className="p-1 text-gray-400 hover:text-port-error transition-colors"
-                              title="Delete entry"
+                              title="Delete entry" aria-label="Delete entry"
                             >
                               <Trash2 size={14} />
                             </button>
@@ -604,14 +604,14 @@ export default function InboxTab({ onRefresh, settings }) {
                           <button
                             onClick={() => handleSaveEdit(entry.id)}
                             className="p-1 text-port-success hover:bg-port-success/20 rounded transition-colors"
-                            title="Save changes"
+                            title="Save changes" aria-label="Save changes"
                           >
                             <Save size={14} />
                           </button>
                           <button
                             onClick={handleCancelEdit}
                             className="p-1 text-gray-400 hover:bg-port-border/50 rounded transition-colors"
-                            title="Cancel editing"
+                            title="Cancel editing" aria-label="Cancel editing"
                           >
                             <X size={14} />
                           </button>
@@ -624,14 +624,14 @@ export default function InboxTab({ onRefresh, settings }) {
                           <button
                             onClick={() => handleEdit(entry)}
                             className="p-1 text-gray-400 hover:text-white transition-colors"
-                            title="Edit text"
+                            title="Edit text" aria-label="Edit text"
                           >
                             <Edit2 size={14} />
                           </button>
                           <button
                             onClick={() => setConfirmingDeleteId(entry.id)}
                             className="p-1 text-gray-400 hover:text-port-error transition-colors"
-                            title="Delete entry"
+                            title="Delete entry" aria-label="Delete entry"
                           >
                             <Trash2 size={14} />
                           </button>
@@ -719,7 +719,7 @@ export default function InboxTab({ onRefresh, settings }) {
                         <button
                           onClick={() => setConfirmingDeleteId(entry.id)}
                           className="p-1 text-gray-400 hover:text-port-error transition-colors"
-                          title="Delete entry"
+                          title="Delete entry" aria-label="Delete entry"
                         >
                           <Trash2 size={14} />
                         </button>
@@ -864,7 +864,7 @@ export default function InboxTab({ onRefresh, settings }) {
                           <button
                             onClick={() => setConfirmingDeleteId(entry.id)}
                             className="p-1 text-gray-500 hover:text-port-error transition-colors"
-                            title="Delete entry"
+                            title="Delete entry" aria-label="Delete entry"
                           >
                             <Trash2 size={14} />
                           </button>

--- a/client/src/components/brain/tabs/LinksTab.jsx
+++ b/client/src/components/brain/tabs/LinksTab.jsx
@@ -459,7 +459,7 @@ export default function LinksTab({ onRefresh }) {
           <button
             onClick={() => setSearch('')}
             className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-500 hover:text-white transition-colors"
-            title="Clear search"
+            title="Clear search" aria-label="Clear search"
           >
             <X size={14} />
           </button>
@@ -586,14 +586,14 @@ export default function LinksTab({ onRefresh }) {
                     <button
                       onClick={() => handleEdit(link)}
                       className="p-1.5 text-gray-400 hover:text-white transition-colors"
-                      title="Edit"
+                      title="Edit" aria-label="Edit"
                     >
                       <Edit2 size={14} />
                     </button>
                     <button
                       onClick={() => setConfirmingDeleteId(link.id)}
                       className="p-1.5 text-gray-400 hover:text-port-error transition-colors"
-                      title="Delete"
+                      title="Delete" aria-label="Delete"
                     >
                       <Trash2 size={14} />
                     </button>

--- a/client/src/components/brain/tabs/MemoryTab.jsx
+++ b/client/src/components/brain/tabs/MemoryTab.jsx
@@ -593,7 +593,7 @@ export default function MemoryTab({ onRefresh }) {
               <button
                 onClick={() => handleMarkDone(record)}
                 className="p-1.5 text-gray-400 hover:text-port-success rounded hover:bg-port-success/20"
-                title="Mark done"
+                title="Mark done" aria-label="Mark done"
               >
                 <CheckCircle2 size={14} />
               </button>
@@ -609,14 +609,14 @@ export default function MemoryTab({ onRefresh }) {
             <button
               onClick={() => startEdit(record)}
               className="p-1.5 text-gray-400 hover:text-white rounded hover:bg-port-border/50"
-              title="Edit"
+              title="Edit" aria-label="Edit"
             >
               <Edit2 size={14} />
             </button>
             <button
               onClick={() => requestDelete(record.id)}
               className="p-1.5 text-gray-400 hover:text-port-error rounded hover:bg-port-error/20"
-              title="Delete"
+              title="Delete" aria-label="Delete"
             >
               <Trash2 size={14} />
             </button>
@@ -738,7 +738,7 @@ export default function MemoryTab({ onRefresh }) {
           <button
             onClick={() => setSearchQuery('')}
             aria-label="Close"
-            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white"
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
           >
             <X size={14} />
           </button>

--- a/client/src/components/brain/tabs/NotesTab.jsx
+++ b/client/src/components/brain/tabs/NotesTab.jsx
@@ -275,14 +275,14 @@ export default function NotesTab() {
             <button
               onClick={() => setShowVaultSetup(true)}
               className="p-1.5 rounded hover:bg-port-card text-gray-400 hover:text-white"
-              title="Manage vaults"
+              title="Manage vaults" aria-label="Manage vaults"
             >
               <Settings size={14} />
             </button>
             <button
               onClick={() => { setShowCreateForm(true); setNewNotePath(''); }}
               className="p-1.5 rounded hover:bg-port-card text-gray-400 hover:text-port-accent"
-              title="New note"
+              title="New note" aria-label="New note"
             >
               <Plus size={14} />
             </button>
@@ -303,7 +303,7 @@ export default function NotesTab() {
               <button
                 onClick={clearSearch}
                 aria-label="Close"
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
               >
                 <X size={14} />
               </button>
@@ -331,7 +331,7 @@ export default function NotesTab() {
               <button
                 onClick={() => setShowCreateForm(false)}
                 aria-label="Close"
-                className="p-1 rounded hover:bg-port-card text-gray-400"
+                className="p-1 rounded hover:bg-port-card text-gray-400 min-h-[44px] min-w-[44px] flex items-center justify-center"
               >
                 <X size={14} />
               </button>
@@ -357,14 +357,14 @@ export default function NotesTab() {
           <button
             onClick={() => { loadTags(); setShowTags(!showTags); }}
             className={`ml-auto p-0.5 rounded ${showTags ? 'text-port-accent' : 'text-gray-500 hover:text-white'}`}
-            title="Tags"
+            title="Tags" aria-label="Tags"
           >
             <Tag size={12} />
           </button>
           <button
             onClick={loadNotes}
             className="p-0.5 rounded text-gray-500 hover:text-white"
-            title="Refresh"
+            title="Refresh" aria-label="Refresh"
           >
             <RefreshCw size={12} className={scanning ? 'animate-spin' : ''} />
           </button>
@@ -480,7 +480,7 @@ export default function NotesTab() {
                     <button
                       onClick={() => { setEditing(false); setNoteContent(selectedNote.content); }}
                       aria-label="Close editor"
-                      className="p-1.5 rounded hover:bg-port-card text-gray-400 hover:text-white"
+                      className="p-1.5 rounded hover:bg-port-card text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
                     >
                       <X size={16} />
                     </button>
@@ -497,7 +497,7 @@ export default function NotesTab() {
                 <button
                   onClick={() => requestDelete(selectedNote.path)}
                   className="p-1.5 rounded hover:bg-port-card text-gray-400 hover:text-port-error"
-                  title="Delete note"
+                  title="Delete note" aria-label="Delete note"
                 >
                   <Trash2 size={14} />
                 </button>
@@ -647,7 +647,7 @@ function VaultSetup({ detectedVaults, vaults, customPath, setCustomPath, adding,
           </p>
         </div>
         {vaults.length > 0 && (
-          <button onClick={onClose} aria-label="Close" className="p-1.5 rounded hover:bg-port-card text-gray-400 hover:text-white">
+          <button onClick={onClose} aria-label="Close" className="p-1.5 rounded hover:bg-port-card text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center">
             <X size={16} />
           </button>
         )}

--- a/client/src/components/brain/tabs/TrustTab.jsx
+++ b/client/src/components/brain/tabs/TrustTab.jsx
@@ -268,7 +268,7 @@ export default function TrustTab({ onRefresh }) {
                   <button
                     onClick={() => setExpandedId(isExpanded ? null : entry.id)}
                     className="p-1.5 text-gray-400 hover:text-white rounded hover:bg-port-border/50"
-                    title="View details"
+                    title="View details" aria-label="View details"
                   >
                     {isExpanded ? <ChevronDown size={16} /> : <Eye size={16} />}
                   </button>

--- a/client/src/components/brain/tabs/TrustTab.jsx
+++ b/client/src/components/brain/tabs/TrustTab.jsx
@@ -268,7 +268,8 @@ export default function TrustTab({ onRefresh }) {
                   <button
                     onClick={() => setExpandedId(isExpanded ? null : entry.id)}
                     className="p-1.5 text-gray-400 hover:text-white rounded hover:bg-port-border/50"
-                    title="View details" aria-label="View details"
+                    title={isExpanded ? 'Hide details' : 'View details'}
+                    aria-label={isExpanded ? 'Hide details' : 'View details'}
                   >
                     {isExpanded ? <ChevronDown size={16} /> : <Eye size={16} />}
                   </button>

--- a/client/src/components/calendar/ReviewTab.jsx
+++ b/client/src/components/calendar/ReviewTab.jsx
@@ -243,7 +243,7 @@ export default function ReviewTab() {
                           onClick={() => handleConfirm(event, true)}
                           disabled={confirming === eventId}
                           className="p-1.5 rounded hover:bg-port-success/20 text-gray-500 hover:text-port-success transition-colors"
-                          title="Confirm - it happened"
+                          title="Confirm - it happened" aria-label="Confirm - it happened"
                         >
                           <Check size={16} />
                         </button>
@@ -251,7 +251,7 @@ export default function ReviewTab() {
                           onClick={() => handleConfirm(event, false)}
                           disabled={confirming === eventId}
                           className="p-1.5 rounded hover:bg-red-500/20 text-gray-500 hover:text-red-400 transition-colors"
-                          title="Skip - didn't happen"
+                          title="Skip - didn't happen" aria-label="Skip - didn't happen"
                         >
                           <X size={16} />
                         </button>

--- a/client/src/components/cos/ActionableInsightsBanner.jsx
+++ b/client/src/components/cos/ActionableInsightsBanner.jsx
@@ -242,7 +242,7 @@ export default function ActionableInsightsBanner({ insights, onTaskUnblocked, on
           <button
             onClick={() => handleDismiss(primaryInsight.type)}
             className="p-1.5 text-gray-500 hover:text-gray-300 hover:bg-white/5 rounded transition-colors min-w-[32px] min-h-[32px] flex items-center justify-center"
-            title="Dismiss"
+            title="Dismiss" aria-label="Dismiss"
           >
             <X size={14} />
           </button>

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -446,10 +446,12 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
                   {!template.isBuiltin && (
                     <button
                       onClick={(e) => deleteTemplate(template.id, e)}
-                      className="flex md:hidden md:group-hover:flex absolute -top-1 -right-1 w-4 h-4 bg-port-error rounded-full items-center justify-center"
+                      className="flex md:hidden md:group-hover:flex absolute -top-[18px] -right-[18px] w-11 h-11 items-center justify-center"
                       aria-label="Delete template"
                     >
-                      <X size={10} />
+                      <span className="flex items-center justify-center w-4 h-4 bg-port-error rounded-full">
+                        <X size={10} />
+                      </span>
                     </button>
                   )}
                 </div>

--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -1002,7 +1002,7 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
             )}
             <button
               onClick={() => setPromptOpen(false)}
-              className="text-xs px-2 py-1 rounded bg-port-border/40 text-gray-400 hover:text-white"
+              className="text-xs px-2 py-1 rounded bg-port-border/40 text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
               aria-label="Close prompt viewer"
             >
               Close

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -357,7 +357,7 @@ function JobCard({ job, apps, providers, onToggle, onTrigger, onDelete, onUpdate
           className={`shrink-0 transition-colors ${
             job.enabled ? 'text-port-success' : 'text-gray-600'
           }`}
-          title={job.enabled ? 'Disable job' : 'Enable job'}
+          title={job.enabled ? 'Disable job' : 'Enable job'} aria-label={job.enabled ? 'Disable job' : 'Enable job'}
         >
           {job.enabled ? <ToggleRight size={24} /> : <ToggleLeft size={24} />}
         </button>
@@ -418,20 +418,21 @@ function JobCard({ job, apps, providers, onToggle, onTrigger, onDelete, onUpdate
           <button
             onClick={() => onTrigger(job.id)}
             className="p-1.5 text-gray-500 hover:text-port-accent transition-colors"
-            title="Run now"
+            title="Run now" aria-label="Run now"
           >
             <Play size={14} />
           </button>
           <button
             onClick={startEditing}
             className="p-1.5 text-gray-500 hover:text-white transition-colors"
-            title="Edit"
+            title="Edit" aria-label="Edit"
           >
             <Edit3 size={14} />
           </button>
           <button
             onClick={() => setExpanded(!expanded)}
             className="p-1.5 text-gray-500 hover:text-white transition-colors"
+            title={expanded ? 'Collapse' : 'Expand'} aria-label={expanded ? 'Collapse' : 'Expand'}
           >
             {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
           </button>

--- a/client/src/components/cos/tabs/MemoryEditModal.jsx
+++ b/client/src/components/cos/tabs/MemoryEditModal.jsx
@@ -112,7 +112,7 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
           <button
             onClick={onClose}
             aria-label="Close edit memory"
-            className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-500 hover:text-white transition-colors rounded-lg"
+            className="p-2 min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-500 hover:text-white transition-colors rounded-lg"
           >
             <X size={22} aria-hidden="true" />
           </button>

--- a/client/src/components/cos/tabs/MemoryTab.jsx
+++ b/client/src/components/cos/tabs/MemoryTab.jsx
@@ -201,7 +201,7 @@ export default function MemoryTab({ apps = [] }) {
           <button
             onClick={() => { setSearchResults(null); setSearchQuery(''); }}
             aria-label="Close"
-            className="px-2 py-1.5 flex items-center justify-center bg-port-border text-gray-400 hover:text-white rounded-lg transition-colors"
+            className="px-2 py-1.5 flex items-center justify-center bg-port-border text-gray-400 hover:text-white rounded-lg transition-colors min-h-[44px] min-w-[44px]"
           >
             <X size={18} />
           </button>

--- a/client/src/components/cos/tabs/ResumeAgentModal.jsx
+++ b/client/src/components/cos/tabs/ResumeAgentModal.jsx
@@ -110,7 +110,7 @@ export default function ResumeAgentModal({ agent, taskType = 'user', providers, 
           <button
             onClick={onClose}
             aria-label="Close resume agent modal"
-            className="text-gray-500 hover:text-white transition-colors"
+            className="text-gray-500 hover:text-white transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
           >
             <X size={20} aria-hidden="true" />
           </button>

--- a/client/src/components/cos/tabs/workflow/ScheduleEditor.jsx
+++ b/client/src/components/cos/tabs/workflow/ScheduleEditor.jsx
@@ -149,7 +149,7 @@ export default function ScheduleEditor({ node, allNodes, timezone, onClose, onSa
           <h3 className="mt-1 truncate font-semibold text-white" title={node.label}>{node.label}</h3>
           <p className="mt-1 text-xs text-gray-500">Times use {timezone || 'the configured timezone'}.</p>
         </div>
-        <button type="button" onClick={onClose} className="rounded p-1 text-gray-500 hover:bg-port-border hover:text-white" aria-label="Close schedule editor">
+        <button type="button" onClick={onClose} className="rounded p-1 text-gray-500 hover:bg-port-border hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close schedule editor">
           <X className="h-4 w-4" />
         </button>
       </div>

--- a/client/src/components/dashboard/LayoutEditor.jsx
+++ b/client/src/components/dashboard/LayoutEditor.jsx
@@ -211,7 +211,7 @@ export default function LayoutEditor({ layouts, activeLayoutId, limits, onClose,
     >
         <div className="flex items-center justify-between px-5 py-4 border-b border-port-border">
           <h2 id="layout-editor-title" className="text-sm font-semibold text-white">Edit Layouts</h2>
-          <button ref={closeRef} onClick={close} className="p-1 text-gray-500 hover:text-white transition-colors rounded" aria-label="Close">
+          <button ref={closeRef} onClick={close} className="p-1 text-gray-500 hover:text-white transition-colors rounded min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close">
             <X size={16} />
           </button>
         </div>

--- a/client/src/components/digital-twin/ListEnrichment.jsx
+++ b/client/src/components/digital-twin/ListEnrichment.jsx
@@ -195,7 +195,7 @@ export default function ListEnrichment({
                 <button
                   onClick={() => removeItem(index)}
                   className="absolute top-2 right-2 p-1.5 text-gray-500 hover:text-red-400 opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
-                  title="Remove"
+                  title="Remove" aria-label="Remove"
                 >
                   <X size={16} />
                 </button>

--- a/client/src/components/digital-twin/NextActionBanner.jsx
+++ b/client/src/components/digital-twin/NextActionBanner.jsx
@@ -255,7 +255,7 @@ export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
                     setTimeout(() => setCopied(false), 2000);
                   }}
                   className="absolute top-2 right-2 p-1.5 text-gray-400 hover:text-white bg-port-bg rounded"
-                  title="Copy prompt"
+                  title="Copy prompt" aria-label="Copy prompt"
                 >
                   {copied ? <Check size={14} className="text-port-success" /> : <Copy size={14} />}
                 </button>
@@ -396,7 +396,7 @@ export default function NextActionBanner({ gaps, status, traits, onRefresh }) {
                     setTimeout(() => setCopied(false), 2000);
                   }}
                   className="absolute top-2 right-2 p-1.5 text-gray-400 hover:text-white bg-port-bg rounded"
-                  title="Copy prompt"
+                  title="Copy prompt" aria-label="Copy prompt"
                 >
                   {copied ? <Check size={14} className="text-port-success" /> : <Copy size={14} />}
                 </button>

--- a/client/src/components/digital-twin/tabs/AccountsTab.jsx
+++ b/client/src/components/digital-twin/tabs/AccountsTab.jsx
@@ -240,7 +240,7 @@ export default function AccountsTab() {
           <button
             onClick={loadData}
             className="p-2 text-gray-400 hover:text-white border border-port-border rounded-lg hover:bg-port-card transition-colors min-h-[40px] min-w-[40px] flex items-center justify-center"
-            title="Refresh"
+            title="Refresh" aria-label="Refresh"
           >
             <RefreshCw className="w-4 h-4" />
           </button>
@@ -286,7 +286,7 @@ export default function AccountsTab() {
             <button
               onClick={handleCancel}
               aria-label="Close"
-              className="p-1 text-gray-400 hover:text-white transition-colors"
+              className="p-1 text-gray-400 hover:text-white transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
             >
               <X className="w-4 h-4" />
             </button>
@@ -529,7 +529,7 @@ export default function AccountsTab() {
                     <button
                       onClick={() => handleEdit(account)}
                       className="p-1.5 text-gray-400 hover:text-white rounded transition-colors min-h-[40px] min-w-[40px] flex items-center justify-center"
-                      title="Edit"
+                      title="Edit" aria-label="Edit"
                     >
                       <Edit3 className="w-4 h-4" />
                     </button>

--- a/client/src/components/digital-twin/tabs/AutobiographyTab.jsx
+++ b/client/src/components/digital-twin/tabs/AutobiographyTab.jsx
@@ -249,7 +249,7 @@ export default function AutobiographyTab({ onRefresh }) {
           <button
             onClick={() => setShowConfig(!showConfig)}
             className="p-2 rounded text-gray-400 hover:text-white hover:bg-port-card transition-colors"
-            title="Settings"
+            title="Settings" aria-label="Settings"
           >
             <Settings size={16} />
           </button>
@@ -311,7 +311,7 @@ export default function AutobiographyTab({ onRefresh }) {
             <button
               onClick={() => setFollowUps(null)}
               aria-label="Close"
-              className="p-1 text-gray-500 hover:text-white"
+              className="p-1 text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
             >
               <X size={14} />
             </button>
@@ -374,7 +374,7 @@ export default function AutobiographyTab({ onRefresh }) {
             <button
               onClick={() => { setWriting(false); setCurrentPrompt(null); setStoryContent(''); setParentStoryId(null); }}
               aria-label="Close"
-              className="p-1 text-gray-500 hover:text-white"
+              className="p-1 text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
             >
               <X size={16} />
             </button>

--- a/client/src/components/digital-twin/tabs/DocumentsTab.jsx
+++ b/client/src/components/digital-twin/tabs/DocumentsTab.jsx
@@ -129,7 +129,7 @@ export default function DocumentsTab({ onRefresh }) {
           <button
             onClick={() => setShowCreate(true)}
             className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-400 hover:text-white transition-colors"
-            title="Create document"
+            title="Create document" aria-label="Create document"
           >
             <Plus size={18} />
           </button>
@@ -189,7 +189,7 @@ export default function DocumentsTab({ onRefresh }) {
                   <button
                     onClick={() => setSelectedDoc(null)}
                     className="lg:hidden p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-400 hover:text-white transition-colors"
-                    title="Back to list"
+                    title="Back to list" aria-label="Back to list"
                   >
                     <ArrowLeft size={18} />
                   </button>
@@ -220,7 +220,7 @@ export default function DocumentsTab({ onRefresh }) {
                     className={`p-2 min-h-[40px] min-w-[40px] flex items-center justify-center transition-colors ${
                       selectedDoc.enabled ? 'text-port-success' : 'text-gray-500'
                     }`}
-                    title={selectedDoc.enabled ? 'Disable for CoS injection' : 'Enable for CoS injection'}
+                    title={selectedDoc.enabled ? 'Disable for CoS injection' : 'Enable for CoS injection'} aria-label={selectedDoc.enabled ? 'Disable for CoS injection' : 'Enable for CoS injection'}
                   >
                     {selectedDoc.enabled ? <ToggleRight size={20} /> : <ToggleLeft size={20} />}
                   </button>
@@ -230,7 +230,7 @@ export default function DocumentsTab({ onRefresh }) {
                         onClick={handleSave}
                         disabled={saving}
                         className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-port-success hover:text-port-success/80 transition-colors disabled:opacity-50"
-                        title="Save"
+                        title="Save" aria-label="Save"
                       >
                         <Save size={18} />
                       </button>
@@ -240,7 +240,7 @@ export default function DocumentsTab({ onRefresh }) {
                           setEditMode(false);
                         }}
                         className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-400 hover:text-white transition-colors"
-                        title="Cancel"
+                        title="Cancel" aria-label="Cancel"
                       >
                         <X size={18} />
                       </button>
@@ -250,14 +250,14 @@ export default function DocumentsTab({ onRefresh }) {
                       <button
                         onClick={() => setEditMode(true)}
                         className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-400 hover:text-white transition-colors"
-                        title="Edit"
+                        title="Edit" aria-label="Edit"
                       >
                         <Edit2 size={18} />
                       </button>
                       <button
                         onClick={() => setDeleteConfirm(selectedDoc.id)}
                         className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-400 hover:text-red-400 transition-colors"
-                        title="Delete"
+                        title="Delete" aria-label="Delete"
                       >
                         <Trash2 size={18} />
                       </button>

--- a/client/src/components/digital-twin/tabs/ExportTab.jsx
+++ b/client/src/components/digital-twin/tabs/ExportTab.jsx
@@ -261,14 +261,14 @@ export default function ExportTab({ onRefresh: _onRefresh }) {
               <button
                 onClick={handleCopyExport}
                 className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-400 hover:text-white transition-colors"
-                title="Copy to clipboard"
+                title="Copy to clipboard" aria-label="Copy to clipboard"
               >
                 {copied ? <Check size={18} className="text-port-success" /> : <Copy size={18} />}
               </button>
               <button
                 onClick={downloadFile}
                 className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-400 hover:text-white transition-colors"
-                title="Download"
+                title="Download" aria-label="Download"
               >
                 <Download size={18} />
               </button>

--- a/client/src/components/digital-twin/tabs/GoalsTab.jsx
+++ b/client/src/components/digital-twin/tabs/GoalsTab.jsx
@@ -408,6 +408,7 @@ export default function GoalsTab({ onRefresh }) {
                               <div key={ms.id} className="flex items-center gap-2 text-sm">
                                 <button
                                   onClick={() => !ms.completedAt && handleCompleteMilestone(goal.id, ms.id)}
+                                  aria-label={ms.completedAt ? `${ms.title} — completed` : `Mark ${ms.title} complete`}
                                   className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 ${
                                     ms.completedAt
                                       ? 'bg-port-success/20 border-port-success text-port-success'

--- a/client/src/components/digital-twin/tabs/OverviewTab.jsx
+++ b/client/src/components/digital-twin/tabs/OverviewTab.jsx
@@ -202,7 +202,7 @@ export default function OverviewTab({ status, settings, onRefresh }) {
           <button
             onClick={() => setShowSettings(!showSettings)}
             className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-400 hover:text-white transition-colors"
-            title="Settings"
+            title="Settings" aria-label="Settings"
           >
             <Settings size={20} />
           </button>

--- a/client/src/components/digital-twin/tabs/TimeCapsuleTab.jsx
+++ b/client/src/components/digital-twin/tabs/TimeCapsuleTab.jsx
@@ -224,7 +224,7 @@ export default function TimeCapsuleTab({ onRefresh: _onRefresh }) {
               <GitCompare size={16} />
               Comparison: {compareResult.snapshot1.label} vs {compareResult.snapshot2.label}
             </h3>
-            <button onClick={() => setCompareResult(null)} aria-label="Close" className="p-1 text-gray-400 hover:text-white">
+            <button onClick={() => setCompareResult(null)} aria-label="Close" className="p-1 text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center">
               <X size={16} />
             </button>
           </div>
@@ -362,7 +362,7 @@ export default function TimeCapsuleTab({ onRefresh: _onRefresh }) {
                           <button
                             onClick={() => setConfirmDelete(snap.id)}
                             className="p-2 min-h-[40px] min-w-[40px] flex items-center justify-center text-gray-400 hover:text-red-400 rounded-lg hover:bg-port-border transition-colors"
-                            title="Delete snapshot"
+                            title="Delete snapshot" aria-label="Delete snapshot"
                           >
                             <Trash2 size={16} />
                           </button>

--- a/client/src/components/goals/GoalLinkedActivities.jsx
+++ b/client/src/components/goals/GoalLinkedActivities.jsx
@@ -21,7 +21,7 @@ export default function GoalLinkedActivities({
               <button
                 onClick={() => handleUnlinkActivity(link.activityName)}
                 className="p-0.5 text-gray-600 hover:text-red-400"
-                title="Unlink"
+                title="Unlink" aria-label="Unlink"
               >
                 <Unlink className="w-3 h-3" />
               </button>

--- a/client/src/components/goals/GoalLinkedCalendars.jsx
+++ b/client/src/components/goals/GoalLinkedCalendars.jsx
@@ -25,7 +25,7 @@ export default function GoalLinkedCalendars({
               <button
                 onClick={() => handleUnlinkCalendar(lc.subcalendarId)}
                 className="p-0.5 text-gray-600 hover:text-red-400"
-                title="Unlink"
+                title="Unlink" aria-label="Unlink"
               >
                 <Unlink className="w-3 h-3" />
               </button>

--- a/client/src/components/goals/GoalMilestones.jsx
+++ b/client/src/components/goals/GoalMilestones.jsx
@@ -20,6 +20,7 @@ export default function GoalMilestones({
               <div className="flex items-center gap-2 text-sm">
                 <button
                   onClick={() => !ms.completedAt && handleCompleteMilestone(ms.id)}
+                  aria-label={ms.completedAt ? `${ms.title} — completed` : `Mark ${ms.title} complete`}
                   className={`w-4 h-4 rounded border flex items-center justify-center shrink-0 ${
                     ms.completedAt
                       ? 'bg-port-success/20 border-port-success text-port-success'
@@ -46,6 +47,7 @@ export default function GoalMilestones({
                       <div key={task.id} className="flex items-center gap-1.5 text-[11px]">
                         <button
                           onClick={() => handleCompleteMilestoneTask?.(ms.id, task.id)}
+                          aria-label={done ? `Mark ${task.title} incomplete` : `Mark ${task.title} complete`}
                           className={`w-3.5 h-3.5 rounded border flex items-center justify-center shrink-0 ${
                             done
                               ? 'bg-port-success/20 border-port-success text-port-success'

--- a/client/src/components/goals/GoalProgressLog.jsx
+++ b/client/src/components/goals/GoalProgressLog.jsx
@@ -25,7 +25,7 @@ export default function GoalProgressLog({
         <button
           onClick={() => setShowProgressForm(!showProgressForm)}
           className="p-0.5 text-gray-500 hover:text-port-accent"
-          title="Log progress"
+          title="Log progress" aria-label="Log progress"
         >
           <Plus className="w-3.5 h-3.5" />
         </button>
@@ -94,7 +94,7 @@ export default function GoalProgressLog({
               <button
                 onClick={() => requestDelete(entry.id)}
                 className="p-0.5 text-gray-700 hover:text-red-400 opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 shrink-0"
-                title="Delete"
+                title="Delete" aria-label="Delete"
               >
                 <Trash2 className="w-3 h-3" />
               </button>

--- a/client/src/components/goals/GoalTodoList.jsx
+++ b/client/src/components/goals/GoalTodoList.jsx
@@ -47,7 +47,7 @@ export default function GoalTodoList({
               <button
                 onClick={() => requestDelete(todo.id)}
                 className="p-0.5 text-gray-700 hover:text-red-400 opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 shrink-0"
-                title="Delete"
+                title="Delete" aria-label="Delete"
               >
                 <Trash2 className="w-3 h-3" />
               </button>

--- a/client/src/components/goals/GoalsListView.jsx
+++ b/client/src/components/goals/GoalsListView.jsx
@@ -87,6 +87,7 @@ function GoalRow({ goal, depth, expandedIds, onToggle, onSelect, selectedId, onA
           <button
             onClick={(e) => { e.stopPropagation(); onToggle(goal.id); }}
             className="p-0.5 text-gray-500 hover:text-white shrink-0"
+            title={expanded ? 'Collapse' : 'Expand'} aria-label={expanded ? 'Collapse' : 'Expand'}
           >
             {expanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
           </button>
@@ -151,7 +152,7 @@ function GoalRow({ goal, depth, expandedIds, onToggle, onSelect, selectedId, onA
         <button
           onClick={(e) => { e.stopPropagation(); onAddChild(goal.id); }}
           className="p-1 text-gray-600 hover:text-port-accent shrink-0"
-          title="Add sub-goal"
+          title="Add sub-goal" aria-label="Add sub-goal"
         >
           <Plus className="w-3.5 h-3.5" />
         </button>

--- a/client/src/components/goals/GoalsTreeView.jsx
+++ b/client/src/components/goals/GoalsTreeView.jsx
@@ -273,7 +273,7 @@ function OrganizePanel({ suggestion, goals, onApply, onClose, applying }) {
           <Wand2 className="w-4 h-4 text-port-accent" />
           <h3 className="text-sm font-semibold text-white">Goal Organization</h3>
         </div>
-        <button onClick={onClose} aria-label="Close" className="p-1 text-gray-400 hover:text-white"><X className="w-4 h-4" /></button>
+        <button onClick={onClose} aria-label="Close" className="p-1 text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"><X className="w-4 h-4" /></button>
       </div>
 
       {suggestion.analysis && (

--- a/client/src/components/imageGen/Flux2InstallModal.jsx
+++ b/client/src/components/imageGen/Flux2InstallModal.jsx
@@ -87,7 +87,7 @@ export default function Flux2InstallModal({ open, onClose, onComplete }) {
           </div>
           <button
             onClick={handleClose}
-            className="text-gray-400 hover:text-white p-1"
+            className="text-gray-400 hover:text-white p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Close installer"
           >
             <X size={18} />

--- a/client/src/components/imageGen/GalleryImagePicker.jsx
+++ b/client/src/components/imageGen/GalleryImagePicker.jsx
@@ -133,7 +133,7 @@ export default function GalleryImagePicker({ open, onClose, onSelect, allowUploa
         <button
           type="button"
           onClick={onClose}
-          className="shrink-0 p-1.5 text-gray-400 hover:text-white rounded"
+          className="shrink-0 p-1.5 text-gray-400 hover:text-white rounded min-h-[44px] min-w-[44px] flex items-center justify-center"
           aria-label="Close"
         >
           <X className="w-4 h-4" />

--- a/client/src/components/imageGen/ImageGenControls.jsx
+++ b/client/src/components/imageGen/ImageGenControls.jsx
@@ -163,7 +163,7 @@ export default function ImageGenControls({
               onClick={() => onSeedChange?.(randomSeed())}
               disabled={disabled}
               className="p-2 text-gray-400 hover:text-white border border-port-border rounded-lg hover:bg-port-border/50 disabled:opacity-50 min-h-[40px] min-w-[40px] flex items-center justify-center"
-              title="Randomize seed"
+              title="Randomize seed" aria-label="Randomize seed"
             >
               <Dice5 className="w-4 h-4" />
             </button>

--- a/client/src/components/install/RuntimeInstallModal.jsx
+++ b/client/src/components/install/RuntimeInstallModal.jsx
@@ -73,7 +73,7 @@ export default function RuntimeInstallModal({
           </div>
           <button
             onClick={handleClose}
-            className="text-gray-400 hover:text-white p-1"
+            className="text-gray-400 hover:text-white p-1 min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Close installer"
           >
             <X size={18} />

--- a/client/src/components/loraTraining/DatasetImageGrid.jsx
+++ b/client/src/components/loraTraining/DatasetImageGrid.jsx
@@ -40,7 +40,7 @@ function DatasetImageLightbox({ datasetId, images, index, onIndexChange, onClose
         <button
           type="button"
           onClick={onClose}
-          className="absolute -top-1 right-0 z-10 p-2 rounded-full bg-white text-black hover:bg-white/85 shadow-lg focus:outline-none focus:ring-2 focus:ring-port-accent"
+          className="absolute -top-1 right-0 z-10 p-2 rounded-full bg-white text-black hover:bg-white/85 shadow-lg focus:outline-none focus:ring-2 focus:ring-port-accent min-h-[44px] min-w-[44px] flex items-center justify-center"
           aria-label="Close (Esc)"
           title="Close (Esc)"
         >

--- a/client/src/components/loraTraining/ImportGalleryDialog.jsx
+++ b/client/src/components/loraTraining/ImportGalleryDialog.jsx
@@ -109,7 +109,7 @@ export default function ImportGalleryDialog({ dataset, onClose, onImported }) {
         <button
           type="button"
           onClick={onClose}
-          className="shrink-0 p-1.5 text-gray-400 hover:text-white rounded"
+          className="shrink-0 p-1.5 text-gray-400 hover:text-white rounded min-h-[44px] min-w-[44px] flex items-center justify-center"
           aria-label="Close"
         >
           <X className="w-4 h-4" />

--- a/client/src/components/meatspace/post/ElementsSong.jsx
+++ b/client/src/components/meatspace/post/ElementsSong.jsx
@@ -570,7 +570,7 @@ function SelectedElementDetail({ sym, elementMap, mastery, inSong, category, ver
             {category && <div className="text-xs text-gray-500">{category.label}</div>}
           </div>
         </div>
-        <button aria-label="Close" onClick={onClear} className="text-gray-500 hover:text-white transition-colors"><X size={16} /></button>
+        <button aria-label="Close" onClick={onClear} className="text-gray-500 hover:text-white transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"><X size={16} /></button>
       </div>
       {inSong ? (
         <>

--- a/client/src/components/meatspace/post/MemoryBuilder.jsx
+++ b/client/src/components/meatspace/post/MemoryBuilder.jsx
@@ -171,7 +171,7 @@ export default function MemoryBuilder({ onBack, onSelectItem, onReviewItem = onS
         <div className="bg-port-card border border-port-accent/30 rounded-lg p-5 space-y-4 max-w-2xl">
           <div className="flex items-center justify-between">
             <h3 className="text-white font-medium">Add Memory Item</h3>
-            <button aria-label="Close" onClick={resetCreateForm} className="text-gray-500 hover:text-white transition-colors">
+            <button aria-label="Close" onClick={resetCreateForm} className="text-gray-500 hover:text-white transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center">
               <X size={16} />
             </button>
           </div>

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -380,10 +380,10 @@ export default function AlcoholTab() {
                       placeholder="ABV%"
                       className="w-16 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white text-right"
                     />
-                    <button onClick={saveEditButton} className="p-1.5 text-port-success hover:text-port-success/80" title="Save">
+                    <button onClick={saveEditButton} className="p-1.5 text-port-success hover:text-port-success/80" title="Save" aria-label="Save">
                       <Check size={14} />
                     </button>
-                    <button onClick={cancelEditButton} className="p-1.5 text-gray-500 hover:text-gray-300" title="Cancel">
+                    <button onClick={cancelEditButton} className="p-1.5 text-gray-500 hover:text-gray-300" title="Cancel" aria-label="Cancel">
                       <X size={14} />
                     </button>
                   </>
@@ -392,7 +392,7 @@ export default function AlcoholTab() {
                     <span className="flex-1 text-xs text-gray-300">{drink.name}</span>
                     <span className="text-xs text-gray-500">{drink.oz}oz</span>
                     <span className="text-xs text-gray-500">{drink.abv}%</span>
-                    <button onClick={() => startEditButton(idx)} className="p-1.5 text-gray-600 hover:text-port-accent" title="Edit">
+                    <button onClick={() => startEditButton(idx)} className="p-1.5 text-gray-600 hover:text-port-accent" title="Edit" aria-label="Edit">
                       <Pencil size={12} />
                     </button>
                     {isConfirming(`btn:${idx}`) ? (
@@ -405,7 +405,7 @@ export default function AlcoholTab() {
                         onCancel={cancelDelete}
                       />
                     ) : (
-                      <button onClick={() => requestDelete(`btn:${idx}`)} className="p-1.5 text-gray-600 hover:text-port-error" title="Remove">
+                      <button onClick={() => requestDelete(`btn:${idx}`)} className="p-1.5 text-gray-600 hover:text-port-error" title="Remove" aria-label="Remove">
                         <Trash2 size={12} />
                       </button>
                     )}
@@ -649,14 +649,14 @@ export default function AlcoholTab() {
                                 <button
                                   onClick={saveEdit}
                                   className="p-1 text-port-success hover:text-port-success/80 transition-colors"
-                                  title="Save"
+                                  title="Save" aria-label="Save"
                                 >
                                   <Check size={14} />
                                 </button>
                                 <button
                                   onClick={cancelEdit}
                                   className="p-1 text-gray-500 hover:text-gray-300 transition-colors"
-                                  title="Cancel"
+                                  title="Cancel" aria-label="Cancel"
                                 >
                                   <X size={14} />
                                 </button>
@@ -675,7 +675,7 @@ export default function AlcoholTab() {
                                 <button
                                   onClick={() => startEdit(entry.date, idx, drink)}
                                   className="p-1 text-gray-600 hover:text-port-accent transition-colors"
-                                  title="Edit drink"
+                                  title="Edit drink" aria-label="Edit drink"
                                 >
                                   <Pencil size={12} />
                                 </button>
@@ -692,7 +692,7 @@ export default function AlcoholTab() {
                                   <button
                                     onClick={() => requestDelete(key)}
                                     className="p-1 text-gray-600 hover:text-port-error transition-colors"
-                                    title="Remove drink"
+                                    title="Remove drink" aria-label="Remove drink"
                                   >
                                     <Trash2 size={12} />
                                   </button>

--- a/client/src/components/meatspace/tabs/BodyTab.jsx
+++ b/client/src/components/meatspace/tabs/BodyTab.jsx
@@ -226,7 +226,7 @@ export default function BodyTab() {
                           <button
                             onClick={() => startEditEye(exam, realIdx)}
                             className="p-1 text-gray-600 hover:text-port-accent transition-colors"
-                            title="Edit"
+                            title="Edit" aria-label="Edit"
                           >
                             <Pencil size={12} />
                           </button>
@@ -242,7 +242,7 @@ export default function BodyTab() {
                             <button
                               onClick={() => requestDelete(realIdx)}
                               className="p-1 text-gray-600 hover:text-port-error transition-colors"
-                              title="Delete"
+                              title="Delete" aria-label="Delete"
                             >
                               <Trash2 size={12} />
                             </button>

--- a/client/src/components/meatspace/tabs/CalendarTab.jsx
+++ b/client/src/components/meatspace/tabs/CalendarTab.jsx
@@ -198,7 +198,7 @@ export default function CalendarTab() {
               <button
                 onClick={() => handleRemoveActivity(i)}
                 className="opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity text-gray-600 hover:text-port-error p-0.5"
-                title="Remove activity"
+                title="Remove activity" aria-label="Remove activity"
               >
                 <Trash2 size={12} />
               </button>

--- a/client/src/components/meatspace/tabs/calendar/LifeEventsPanel.jsx
+++ b/client/src/components/meatspace/tabs/calendar/LifeEventsPanel.jsx
@@ -77,14 +77,14 @@ export default function LifeEventsPanel({ events, onAdd, onToggle, onRemove }) {
                   <button
                     onClick={() => onToggle(event.id, !event.enabled)}
                     className="text-gray-500 hover:text-white transition-colors p-0.5"
-                    title={event.enabled ? 'Disable' : 'Enable'}
+                    title={event.enabled ? 'Disable' : 'Enable'} aria-label={event.enabled ? 'Disable' : 'Enable'}
                   >
                     {event.enabled ? <Eye size={12} /> : <EyeOff size={12} />}
                   </button>
                   <button
                     onClick={() => onRemove(event.id)}
                     className="opacity-40 sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 transition-opacity text-gray-600 hover:text-port-error p-0.5"
-                    title="Remove"
+                    title="Remove" aria-label="Remove"
                   >
                     <Trash2 size={12} />
                   </button>

--- a/client/src/components/media/AddToCollectionMenu.jsx
+++ b/client/src/components/media/AddToCollectionMenu.jsx
@@ -96,7 +96,7 @@ export default function AddToCollectionMenu({ item, size = 'sm' }) {
         type="button"
         onClick={handleToggleOpen}
         className={`shrink-0 ${sizeCls.button} bg-port-border hover:bg-port-border/70 text-white rounded flex items-center justify-center`}
-        title="Add to collection"
+        title="Add to collection" aria-label="Add to collection"
         aria-haspopup="menu"
         aria-expanded={open}
       >

--- a/client/src/components/media/CollectionPickerShell.jsx
+++ b/client/src/components/media/CollectionPickerShell.jsx
@@ -260,7 +260,7 @@ export default function CollectionPickerShell({
           type="submit"
           disabled={creating || busy || !newName.trim()}
           className="px-2 py-1 bg-port-accent/20 hover:bg-port-accent/40 text-port-accent text-[11px] rounded disabled:opacity-40 flex items-center gap-1"
-          title={createTitle}
+          title={createTitle} aria-label={createTitle}
         >
           <Plus className="w-3 h-3" />
         </button>

--- a/client/src/components/media/MediaCard.jsx
+++ b/client/src/components/media/MediaCard.jsx
@@ -174,7 +174,7 @@ export default function MediaCard({
                 type="button"
                 onClick={() => onSendToVideo(item)}
                 className="shrink-0 px-1.5 py-1 bg-port-success/20 hover:bg-port-success/40 text-port-success text-[10px] rounded flex items-center justify-center"
-                title="Send to Video"
+                title="Send to Video" aria-label="Send to Video"
               >
                 <Film className="w-3 h-3" />
               </button>
@@ -205,7 +205,7 @@ export default function MediaCard({
                 type="button"
                 onClick={() => onUpscale(item)}
                 className="shrink-0 px-1.5 py-1 bg-port-border hover:bg-port-border/70 text-white text-[10px] rounded flex items-center justify-center"
-                title="Upscale 2× (Lanczos, ~10s)"
+                title="Upscale 2× (Lanczos, ~10s)" aria-label="Upscale 2× (Lanczos, ~10s)"
               >
                 <Maximize2 className="w-3 h-3" />
               </button>

--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -180,7 +180,7 @@ export default function MediaJobsQueue({ kind, recentLimit = 10, className = '' 
           <button
             onClick={fetchJobs}
             className="p-1.5 rounded text-gray-400 hover:text-white hover:bg-port-border/50"
-            title="Refresh"
+            title="Refresh" aria-label="Refresh"
           >
             <RefreshCw className="w-3.5 h-3.5" />
           </button>

--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -315,7 +315,7 @@ export default function MediaLightbox({
           <button
             type="button"
             onClick={(e) => { e.stopPropagation(); onClose(); }}
-            className="absolute top-2 left-2 z-30 p-2 rounded-full bg-white text-black hover:bg-white/85 shadow-lg focus:outline-none focus:ring-2 focus:ring-port-accent"
+            className="absolute top-2 left-2 z-30 p-2 rounded-full bg-white text-black hover:bg-white/85 shadow-lg focus:outline-none focus:ring-2 focus:ring-port-accent min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Close"
             title="Close (Esc)"
           >
@@ -512,7 +512,7 @@ function SettingsPane({
           <button
             type="button"
             onClick={onClose}
-            className="p-1.5 rounded text-gray-400 hover:text-white hover:bg-port-border/50"
+            className="p-1.5 rounded text-gray-400 hover:text-white hover:bg-port-border/50 min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Close"
           >
             <X className="w-4 h-4" />
@@ -529,7 +529,7 @@ function SettingsPane({
                 type="button"
                 onClick={() => copy(item.prompt, 'Prompt')}
                 className="p-1 rounded text-gray-400 hover:text-white hover:bg-port-border/50"
-                title="Copy prompt"
+                title="Copy prompt" aria-label="Copy prompt"
               >
                 <Copy className="w-3 h-3" />
               </button>
@@ -570,7 +570,7 @@ function SettingsPane({
                 type="button"
                 onClick={() => copy(item.negativePrompt, 'Negative prompt')}
                 className="p-1 rounded text-gray-400 hover:text-white hover:bg-port-border/50"
-                title="Copy negative prompt"
+                title="Copy negative prompt" aria-label="Copy negative prompt"
               >
                 <Copy className="w-3 h-3" />
               </button>
@@ -619,7 +619,7 @@ function SettingsPane({
                         type="button"
                         onClick={() => copy(String(v), k)}
                         className="p-0.5 rounded text-gray-400 hover:text-white hover:bg-port-border/50"
-                        title={`Copy ${k.toLowerCase()}`}
+                        title={`Copy ${k.toLowerCase()}`} aria-label={`Copy ${k.toLowerCase()}`}
                       >
                         <Copy className="w-3 h-3" />
                       </button>

--- a/client/src/components/media/PinToMoodBoardMenu.jsx
+++ b/client/src/components/media/PinToMoodBoardMenu.jsx
@@ -173,7 +173,7 @@ export default function PinToMoodBoardMenu({ item, size = 'sm' }) {
         type="button"
         onClick={handleToggleOpen}
         className={`shrink-0 ${sizeCls.button} bg-port-border hover:bg-port-border/70 text-white rounded flex items-center justify-center`}
-        title="Pin to mood board"
+        title="Pin to mood board" aria-label="Pin to mood board"
         aria-haspopup="menu"
         aria-expanded={open}
       >

--- a/client/src/components/media/PromptRefineModal.jsx
+++ b/client/src/components/media/PromptRefineModal.jsx
@@ -130,7 +130,7 @@ export default function PromptRefineModal({ item, open, onClose }) {
         <button
           type="button"
           onClick={onClose}
-          className="p-1.5 rounded text-gray-400 hover:text-white hover:bg-port-border/50"
+          className="p-1.5 rounded text-gray-400 hover:text-white hover:bg-port-border/50 min-h-[44px] min-w-[44px] flex items-center justify-center"
           aria-label="Close"
         >
           <X className="w-4 h-4" />

--- a/client/src/components/messages/DraftsTab.jsx
+++ b/client/src/components/messages/DraftsTab.jsx
@@ -111,7 +111,7 @@ export default function DraftsTab({ accounts }) {
                   <button
                     onClick={() => handleApprove(draft.id)}
                     className="p-1 text-gray-400 hover:text-port-success transition-colors"
-                    title="Approve"
+                    title="Approve" aria-label="Approve"
                   >
                     <Check size={16} />
                   </button>
@@ -124,7 +124,7 @@ export default function DraftsTab({ accounts }) {
                   <button
                     onClick={() => handleSend(draft.id)}
                     className="p-1 text-gray-400 hover:text-port-accent transition-colors"
-                    title="Send"
+                    title="Send" aria-label="Send"
                   >
                     <Send size={16} />
                   </button>
@@ -151,7 +151,7 @@ export default function DraftsTab({ accounts }) {
                   <button
                     onClick={() => requestDelete(draft.id)}
                     className="p-1 text-gray-400 hover:text-port-error transition-colors"
-                    title="Delete"
+                    title="Delete" aria-label="Delete"
                   >
                     <Trash2 size={16} />
                   </button>

--- a/client/src/components/messages/InboxTab.jsx
+++ b/client/src/components/messages/InboxTab.jsx
@@ -564,7 +564,7 @@ export default function InboxTab({ accounts }) {
                           ? `${cfg.bg} ${cfg.color} ring-1 ring-current`
                           : 'text-gray-500 hover:text-gray-300 hover:bg-port-border/50'
                       }`}
-                      title={title}
+                      title={title} aria-label={title}
                     >
                       {actionInProgress === msg.id && isActionable
                         ? <Loader2 size={14} className="animate-spin" />

--- a/client/src/components/music/AlbumsManager.jsx
+++ b/client/src/components/music/AlbumsManager.jsx
@@ -329,7 +329,7 @@ export default function AlbumsManager() {
                   ) : form.coverImageUrl ? (
                     <div className="relative">
                       <img src={form.coverImageUrl} alt="Album cover" className="w-28 h-28 rounded object-cover border border-port-border bg-port-bg" />
-                      <button type="button" onClick={() => setCover('')} title="Remove cover" className="absolute -top-2 -right-2 p-1 rounded-full bg-port-bg border border-port-border text-gray-400 hover:text-port-error">
+                      <button type="button" onClick={() => setCover('')} title="Remove cover" aria-label="Remove cover" className="absolute -top-2 -right-2 p-1 rounded-full bg-port-bg border border-port-border text-gray-400 hover:text-port-error">
                         <X size={12} />
                       </button>
                     </div>

--- a/client/src/components/music/ArtistsManager.jsx
+++ b/client/src/components/music/ArtistsManager.jsx
@@ -379,7 +379,7 @@ export default function ArtistsManager() {
                       <button
                         type="button"
                         onClick={() => setPortrait('')}
-                        title="Remove portrait"
+                        title="Remove portrait" aria-label="Remove portrait"
                         className="absolute -top-2 -right-2 p-1 rounded-full bg-port-bg border border-port-border text-gray-400 hover:text-port-error"
                       >
                         <X size={12} />

--- a/client/src/components/music/TrackRenderModal.jsx
+++ b/client/src/components/music/TrackRenderModal.jsx
@@ -45,7 +45,7 @@ export default function TrackRenderModal({ render, active = false, onClose, onSe
             </span>
           ) : null}
         </h2>
-        <button onClick={onClose} className="text-gray-400 hover:text-white p-1" aria-label="Close">
+        <button onClick={onClose} className="text-gray-400 hover:text-white p-1 min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close">
           <X size={18} />
         </button>
       </div>

--- a/client/src/components/musicVideo/ProjectToolbar.jsx
+++ b/client/src/components/musicVideo/ProjectToolbar.jsx
@@ -138,7 +138,7 @@ export default function ProjectToolbar({
             <Film size={15} /> Render final
           </button>
         )}
-        <button onClick={onDelete} title="Delete project"
+        <button onClick={onDelete} title="Delete project" aria-label="Delete project"
           className="flex items-center gap-1 text-port-error border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0">
           <Trash2 size={15} />
         </button>

--- a/client/src/components/pipeline/CanonCard.jsx
+++ b/client/src/components/pipeline/CanonCard.jsx
@@ -269,7 +269,7 @@ function WardrobeRow({ wardrobe, editable, onCommit, onRemove }) {
         <button
           type="button"
           onClick={onRemove}
-          title={`Remove ${wardrobe.name || 'this outfit'}`}
+          title={`Remove ${wardrobe.name || 'this outfit'}`} aria-label={`Remove ${wardrobe.name || 'this outfit'}`}
           className="shrink-0 text-gray-500 hover:text-port-error"
         >
           <Trash2 size={12} />
@@ -687,6 +687,8 @@ export default function CanonCard({
                       onPatchEntry(entry.id, { primaryImageRef: isPrimary ? null : ref });
                     }}
                     title={isPrimary
+                      ? `Unpin ${ref} as primary reference`
+                      : `Pin ${ref} as ${entry.name}'s primary reference`} aria-label={isPrimary
                       ? `Unpin ${ref} as primary reference`
                       : `Pin ${ref} as ${entry.name}'s primary reference`}
                     className={`absolute top-0.5 right-0.5 p-0.5 rounded ${

--- a/client/src/components/pipeline/arcCanvas/CompletenessResults.jsx
+++ b/client/src/components/pipeline/arcCanvas/CompletenessResults.jsx
@@ -44,7 +44,7 @@ export default function CompletenessResults({ issues, onDismiss, seriesId }) {
               <FileText size={12} /> Open editor
             </Link>
           ) : null}
-          <button type="button" onClick={onDismiss} aria-label="Close" className="text-gray-500 hover:text-white"><X size={16} /></button>
+          <button type="button" onClick={onDismiss} aria-label="Close" className="text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"><X size={16} /></button>
         </div>
       </div>
       {issues.length === 0 ? (

--- a/client/src/components/pipeline/arcCanvas/DeriveFromManuscriptPreview.jsx
+++ b/client/src/components/pipeline/arcCanvas/DeriveFromManuscriptPreview.jsx
@@ -65,7 +65,7 @@ export default function DeriveFromManuscriptPreview({ preview, committing, onCan
           <BookText size={14} className="text-port-accent" />
           Derived from manuscript — review before applying
         </h3>
-        <button type="button" onClick={onCancel} disabled={committing} aria-label="Close" className="text-gray-500 hover:text-white disabled:opacity-40">
+        <button type="button" onClick={onCancel} disabled={committing} aria-label="Close" className="text-gray-500 hover:text-white disabled:opacity-40 min-h-[44px] min-w-[44px] flex items-center justify-center">
           <X size={16} />
         </button>
       </div>

--- a/client/src/components/pipeline/editorial/EditorialHealthPanel.jsx
+++ b/client/src/components/pipeline/editorial/EditorialHealthPanel.jsx
@@ -386,7 +386,7 @@ export default function EditorialHealthPanel({
               onClick={() => setSelectedSnapshot(null)}
               aria-label="Close snapshot detail"
               title="Close snapshot detail"
-              className="shrink-0 rounded p-0.5 text-gray-500 transition-colors hover:bg-port-border/50 hover:text-gray-300"
+              className="shrink-0 rounded p-0.5 text-gray-500 transition-colors hover:bg-port-border/50 hover:text-gray-300 min-h-[44px] min-w-[44px] flex items-center justify-center"
             >
               <X size={13} />
             </button>

--- a/client/src/components/pipeline/manuscript/AnnotatedManuscriptSection.jsx
+++ b/client/src/components/pipeline/manuscript/AnnotatedManuscriptSection.jsx
@@ -45,7 +45,7 @@ export default function AnnotatedManuscriptSection({
       <button
         type="button"
         onClick={onCloseComment}
-        className="absolute right-1 top-1 z-10 text-gray-500 hover:text-white"
+        className="absolute right-1 top-1 z-10 text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
         aria-label="Close note"
         title="Close note"
       >

--- a/client/src/components/pipeline/manuscript/ManuscriptImpactPreview.jsx
+++ b/client/src/components/pipeline/manuscript/ManuscriptImpactPreview.jsx
@@ -142,7 +142,7 @@ export default function ManuscriptImpactPreview({ open, onClose, seriesId, secti
                   : `Accept all ${totalEdits} edit${totalEdits === 1 ? '' : 's'}`}
               </button>
             ) : null}
-            <button type="button" onClick={onClose} className="text-gray-400 hover:text-white" aria-label="Close preview" title="Close (Esc)">
+            <button type="button" onClick={onClose} className="text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close preview" title="Close (Esc)">
               <X size={18} />
             </button>
           </div>

--- a/client/src/components/pipeline/manuscript/ManuscriptLiveSection.jsx
+++ b/client/src/components/pipeline/manuscript/ManuscriptLiveSection.jsx
@@ -184,7 +184,7 @@ export default function ManuscriptLiveSection({
             <div className="rounded-lg border border-port-accent/50 bg-port-card shadow-xl shadow-black/50">
               <div className="flex items-center justify-between gap-2 px-2.5 py-1.5 border-b border-port-border">
                 <span className="text-[10px] uppercase tracking-wider text-gray-400">Editorial note</span>
-                <button type="button" onClick={onCloseComment} className="text-gray-500 hover:text-white" aria-label="Close note" title="Close note (Esc)">
+                <button type="button" onClick={onCloseComment} className="text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close note" title="Close note (Esc)">
                   <X size={13} />
                 </button>
               </div>

--- a/client/src/components/pipeline/manuscript/ManuscriptReadAloud.jsx
+++ b/client/src/components/pipeline/manuscript/ManuscriptReadAloud.jsx
@@ -239,7 +239,7 @@ export default function ManuscriptReadAloud({ open, onClose, section }) {
           <button
             type="button"
             onClick={onClose}
-            className="ml-auto text-gray-500 hover:text-white text-sm px-2"
+            className="ml-auto text-gray-500 hover:text-white text-sm px-2 min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Close read-aloud"
           >
             ✕

--- a/client/src/components/pipeline/stages/AudioStage.jsx
+++ b/client/src/components/pipeline/stages/AudioStage.jsx
@@ -1182,7 +1182,7 @@ export default function AudioStage({ issue, onStageUpdate }) {
                           <button
                             type="button"
                             onClick={() => setPendingLibraryDelete(track.filename)}
-                            title="Delete from library (issues that point at this file will fail playback)"
+                            title="Delete from library (issues that point at this file will fail playback)" aria-label="Delete from library (issues that point at this file will fail playback)"
                             className="inline-flex items-center gap-1 px-2 py-1 rounded text-xs border border-port-border text-gray-400 hover:text-port-error hover:border-port-error/50"
                           >
                             <Trash2 size={12} />

--- a/client/src/components/pipeline/stages/StageHistoryModal.jsx
+++ b/client/src/components/pipeline/stages/StageHistoryModal.jsx
@@ -72,7 +72,7 @@ export default function StageHistoryModal({
             type="button"
             onClick={onClose}
             aria-label="Close"
-            className="text-gray-400 hover:text-white"
+            className="text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
           >
             <X size={18} />
           </button>

--- a/client/src/components/settings/DatabaseTab.jsx
+++ b/client/src/components/settings/DatabaseTab.jsx
@@ -248,7 +248,7 @@ export function DatabaseTab() {
             onClick={loadStatus}
             disabled={dbLoading}
             className="p-1.5 text-gray-400 hover:text-white transition-colors"
-            title="Refresh status"
+            title="Refresh status" aria-label="Refresh status"
           >
             <RefreshCw size={14} className={dbLoading ? 'animate-spin' : ''} />
           </button>

--- a/client/src/components/settings/LocalSetupPanel.jsx
+++ b/client/src/components/settings/LocalSetupPanel.jsx
@@ -193,7 +193,7 @@ export default function LocalSetupPanel({ pythonPath, onPythonPathChange, onPack
               onClick={() => refreshCheck(pythonPath)}
               disabled={checking}
               className="p-1.5 rounded text-gray-400 hover:text-white hover:bg-port-border/50 disabled:opacity-50"
-              title="Re-check"
+              title="Re-check" aria-label="Re-check"
             >
               <RefreshCw size={14} className={checking ? 'animate-spin' : ''} />
             </button>

--- a/client/src/components/settings/VoiceTab.jsx
+++ b/client/src/components/settings/VoiceTab.jsx
@@ -414,7 +414,7 @@ export function VoiceTab() {
               type="button"
               onClick={() => handlePreviewVoice(activeVoice)}
               disabled={!activeVoice || !!previewingVoice || !!downloadingVoice}
-              title={downloadingVoice ? `Downloading ${downloadingVoice}…` : 'Preview this voice'}
+              title={downloadingVoice ? `Downloading ${downloadingVoice}…` : 'Preview this voice'} aria-label={downloadingVoice ? `Downloading ${downloadingVoice}…` : 'Preview this voice'}
               className="shrink-0 p-2 rounded-lg bg-port-border hover:bg-port-border/70 text-white disabled:opacity-50"
             >
               {previewingVoice === activeVoice || downloadingVoice === activeVoice

--- a/client/src/components/sharing/ConflictsTab.jsx
+++ b/client/src/components/sharing/ConflictsTab.jsx
@@ -104,7 +104,7 @@ function ConflictEntry({ entry, onResolved }) {
             className="px-2 py-1 rounded border border-port-border text-gray-400 hover:text-white text-[11px]">
             Discard
           </button>
-          <button type="button" onClick={remove} disabled={busy} className="p-1 text-gray-500 hover:text-port-error" title="Remove entry">
+          <button type="button" onClick={remove} disabled={busy} className="p-1 text-gray-500 hover:text-port-error" title="Remove entry" aria-label="Remove entry">
             <Trash2 size={13} />
           </button>
         </div>

--- a/client/src/components/shell/ShellSessionTabs.jsx
+++ b/client/src/components/shell/ShellSessionTabs.jsx
@@ -39,7 +39,7 @@ export default function ShellSessionTabs({ sessions, activeSessionId, onSwitch, 
               className={`shrink-0 ml-0.5 p-0.5 rounded transition-colors ${
                 isActive ? 'text-port-accent/60 hover:text-port-error' : 'text-gray-600 hover:text-port-error'
               }`}
-              title={isRun ? 'Stop run' : 'Kill session'}
+              title={isRun ? 'Stop run' : 'Kill session'} aria-label={isRun ? 'Stop run' : 'Kill session'}
             >
               <X size={14} />
             </button>
@@ -49,7 +49,7 @@ export default function ShellSessionTabs({ sessions, activeSessionId, onSwitch, 
       <button
         onClick={onNew}
         className="flex items-center gap-1 px-2 py-1.5 text-xs text-gray-500 hover:text-white hover:bg-port-border rounded transition-colors min-h-[40px]"
-        title="New session"
+        title="New session" aria-label="New session"
       >
         <Plus size={14} />
       </button>

--- a/client/src/components/songbook/DrumSheetView.jsx
+++ b/client/src/components/songbook/DrumSheetView.jsx
@@ -210,7 +210,7 @@ const HitReadout = ({ info, position, onClose }) => (
         type="button"
         onClick={onClose}
         aria-label="Close note explanation"
-        className="shrink-0 rounded px-1.5 leading-none text-base text-gray-500 hover:text-gray-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-port-accent"
+        className="shrink-0 rounded px-1.5 leading-none text-base text-gray-500 hover:text-gray-200 focus:outline-none focus-visible:ring-1 focus-visible:ring-port-accent min-h-[44px] min-w-[44px] flex items-center justify-center"
       >
         <span aria-hidden="true">×</span>
       </button>

--- a/client/src/components/songs/ReferenceAnalysis.jsx
+++ b/client/src/components/songs/ReferenceAnalysis.jsx
@@ -196,7 +196,7 @@ export function ReferenceAudioAttach({ reference, onUpdate }) {
             <button
               type="button"
               onClick={() => onUpdate('midiFilename', '')}
-              title="Remove the MIDI transcription"
+              title="Remove the MIDI transcription" aria-label="Remove the MIDI transcription"
               className="flex items-center gap-1 px-1.5 py-1 text-xs rounded-lg border border-port-border text-gray-400 hover:text-port-error"
             >
               <X size={13} />
@@ -205,7 +205,7 @@ export function ReferenceAudioAttach({ reference, onUpdate }) {
         ) : midiJob.active ? (
           <span className="flex items-center gap-1.5 px-2 py-1 text-xs rounded-lg border border-port-border text-gray-300">
             <Loader2 size={13} className="animate-spin" /> {midiJob.stageLabel}
-            <button type="button" onClick={midiJob.cancel} title="Cancel MIDI transcription" className="ml-1 text-gray-400 hover:text-port-error">
+            <button type="button" onClick={midiJob.cancel} title="Cancel MIDI transcription" aria-label="Cancel MIDI transcription" className="ml-1 text-gray-400 hover:text-port-error">
               <X size={13} />
             </button>
           </span>
@@ -291,7 +291,7 @@ export function ReferenceAudioAttach({ reference, onUpdate }) {
         {downloading ? (
           <span className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs rounded-lg border border-port-border text-gray-300">
             <Loader2 size={14} className="animate-spin" /> {downloadLabel}
-            <button type="button" onClick={audioImport.cancel} title="Cancel download" className="ml-1 text-gray-400 hover:text-port-error">
+            <button type="button" onClick={audioImport.cancel} title="Cancel download" aria-label="Cancel download" className="ml-1 text-gray-400 hover:text-port-error">
               <X size={13} />
             </button>
           </span>

--- a/client/src/components/sprites/AssetInspector.jsx
+++ b/client/src/components/sprites/AssetInspector.jsx
@@ -86,7 +86,7 @@ export default function AssetInspector({ recordId, asset, onClose, onDeleted = n
             type="button"
             onClick={onClose}
             aria-label="Close asset inspector"
-            className="shrink-0 text-gray-400 hover:text-white"
+            className="shrink-0 text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
           >
             <X className="w-4 h-4" />
           </button>

--- a/client/src/components/sprites/ForkSpriteModal.jsx
+++ b/client/src/components/sprites/ForkSpriteModal.jsx
@@ -71,7 +71,7 @@ export default function ForkSpriteModal({ open, onClose, source, referencePath, 
         <h2 className="text-sm font-medium text-white flex items-center gap-1.5">
           <GitFork className="w-4 h-4" /> Fork {source?.name}
         </h2>
-        <button type="button" onClick={onClose} aria-label="Close" className="p-1.5 text-gray-400 hover:text-white rounded">
+        <button type="button" onClick={onClose} aria-label="Close" className="p-1.5 text-gray-400 hover:text-white rounded min-h-[44px] min-w-[44px] flex items-center justify-center">
           <X className="w-4 h-4" />
         </button>
       </div>

--- a/client/src/components/sprites/SpriteLightbox.jsx
+++ b/client/src/components/sprites/SpriteLightbox.jsx
@@ -33,7 +33,7 @@ export default function SpriteLightbox({ recordId, path, version, alt, onClose }
             type="button"
             onClick={onClose}
             aria-label="Close preview"
-            className="shrink-0 text-gray-400 hover:text-white"
+            className="shrink-0 text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
           >
             <X className="w-4 h-4" />
           </button>

--- a/client/src/components/sprites/SpriteReferencePicker.jsx
+++ b/client/src/components/sprites/SpriteReferencePicker.jsx
@@ -73,7 +73,7 @@ export default function SpriteReferencePicker({ open, onClose, onSelect, exclude
         <button
           type="button"
           onClick={onClose}
-          className="shrink-0 p-1.5 text-gray-400 hover:text-white rounded"
+          className="shrink-0 p-1.5 text-gray-400 hover:text-white rounded min-h-[44px] min-w-[44px] flex items-center justify-center"
           aria-label="Close"
         >
           <X className="w-4 h-4" />

--- a/client/src/components/sync/SyncDetailDrawer.jsx
+++ b/client/src/components/sync/SyncDetailDrawer.jsx
@@ -383,7 +383,7 @@ export default function SyncDetailDrawer({ kind, recordId, onClose }) {
           <button
             type="button"
             onClick={() => { refresh(); loadRecord(); }}
-            title="Refresh sync status + reload record"
+            title="Refresh sync status + reload record" aria-label="Refresh sync status + reload record"
             className="p-1 text-gray-500 hover:text-gray-300 rounded"
           >
             <RefreshCw className="w-3.5 h-3.5" />

--- a/client/src/components/ui/ProcessLogModal.jsx
+++ b/client/src/components/ui/ProcessLogModal.jsx
@@ -126,7 +126,7 @@ export default function ProcessLogModal({ open, onClose, processName, title = 'S
             </button>
             <button
               onClick={onClose}
-              className="p-1.5 text-gray-400 hover:text-white transition-colors"
+              className="p-1.5 text-gray-400 hover:text-white transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
               title="Close"
               aria-label="Close logs"
             >

--- a/client/src/components/universe/CharacterDetailEditor.jsx
+++ b/client/src/components/universe/CharacterDetailEditor.jsx
@@ -207,7 +207,7 @@ function ListRow({ row, idx, columns, swatchHex, onChange, onDelete, disabled })
         type="button"
         onClick={() => onDelete(idx)}
         disabled={disabled}
-        title="Remove row"
+        title="Remove row" aria-label="Remove row"
         className="shrink-0 text-gray-500 hover:text-port-error disabled:opacity-30"
       >
         <Trash2 size={12} />
@@ -561,7 +561,7 @@ function ArcFrameworkControls({ entry, onPatch, disabled, idPrefix }) {
                     type="button"
                     onClick={() => patchSlider(axis, null)}
                     disabled={disabled}
-                    title={`Clear ${axis}`}
+                    title={`Clear ${axis}`} aria-label={`Clear ${axis}`}
                     className="text-gray-500 hover:text-port-error disabled:opacity-30"
                   >
                     <Trash2 size={11} />

--- a/client/src/components/universe/CorrectiveReferenceModal.jsx
+++ b/client/src/components/universe/CorrectiveReferenceModal.jsx
@@ -83,7 +83,7 @@ export default function CorrectiveReferenceModal({
             <Sparkles size={14} className="text-port-accent" />
             Corrective reference for {subject}
           </h3>
-          <button type="button" onClick={close} disabled={analyzing || applying} className="text-gray-500 hover:text-white disabled:opacity-50" aria-label="Close">
+          <button type="button" onClick={close} disabled={analyzing || applying} className="text-gray-500 hover:text-white disabled:opacity-50 min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close">
             <X size={16} />
           </button>
         </div>

--- a/client/src/components/universe/EntryThumbSlot.jsx
+++ b/client/src/components/universe/EntryThumbSlot.jsx
@@ -96,7 +96,7 @@ export default function EntryThumbSlot({
       type="button"
       onClick={() => onRender?.()}
       disabled={!onRender || !canRender}
-      title={canRender ? 'Render image for this item' : 'Save the universe first to enable render'}
+      title={canRender ? 'Render image for this item' : 'Save the universe first to enable render'} aria-label={canRender ? 'Render image for this item' : 'Save the universe first to enable render'}
       className={`${dim} shrink-0 flex items-center justify-center rounded border border-dashed border-port-border bg-port-bg/40 text-gray-500 hover:border-port-accent/50 hover:text-port-accent hover:bg-port-accent/5 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-port-border disabled:hover:text-gray-500 disabled:hover:bg-port-bg/40 transition-colors`}
     >
       <Sparkles size={iconSize} />

--- a/client/src/components/universe/VisionDescribeModal.jsx
+++ b/client/src/components/universe/VisionDescribeModal.jsx
@@ -218,7 +218,7 @@ export default function VisionDescribeModal({
             <Sparkles size={14} className="text-port-accent" />
             {entryName ? `"${entryName}"` : `This ${noun}`} from image{multi ? 's' : ''}
           </h3>
-          <button type="button" onClick={onClose} className="text-gray-500 hover:text-white" aria-label="Close">
+          <button type="button" onClick={onClose} className="text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close">
             <X size={16} />
           </button>
         </div>

--- a/client/src/components/universeBuilder/CompositeSheetsEditor.jsx
+++ b/client/src/components/universeBuilder/CompositeSheetsEditor.jsx
@@ -205,7 +205,7 @@ export default function CompositeSheetsEditor({ sheets, onChange, canRender = fa
                         onClick={() => onRender(sheet)}
                         disabled={!canRender}
                         className="p-1 text-gray-400 hover:text-port-accent disabled:opacity-30 disabled:cursor-not-allowed rounded"
-                        title={canRender ? 'Render this board' : 'Save the world and configure a render backend to enable'}
+                        title={canRender ? 'Render this board' : 'Save the world and configure a render backend to enable'} aria-label={canRender ? 'Render this board' : 'Save the world and configure a render backend to enable'}
                       >
                         <Play size={14} />
                       </button>
@@ -213,7 +213,7 @@ export default function CompositeSheetsEditor({ sheets, onChange, canRender = fa
                     <button
                       onClick={() => toggleLockAt(idx)}
                       className={`p-1 rounded ${sheet.locked ? 'text-port-accent hover:bg-port-accent/20' : 'text-gray-500 hover:text-gray-300'}`}
-                      title={sheet.locked ? 'Locked — AI expand will preserve this board' : 'Lock this board against AI expand'}
+                      title={sheet.locked ? 'Locked — AI expand will preserve this board' : 'Lock this board against AI expand'} aria-label={sheet.locked ? 'Locked — AI expand will preserve this board' : 'Lock this board against AI expand'}
                       aria-pressed={!!sheet.locked}
                     >
                       {sheet.locked ? <Lock size={14} /> : <Unlock size={14} />}
@@ -221,14 +221,14 @@ export default function CompositeSheetsEditor({ sheets, onChange, canRender = fa
                     <button
                       onClick={() => startEdit(idx, sheet)}
                       className="p-1 text-gray-400 hover:text-port-accent rounded"
-                      title="Edit"
+                      title="Edit" aria-label="Edit"
                     >
                       <Edit3 size={14} />
                     </button>
                     <button
                       onClick={() => removeAt(idx)}
                       className="p-1 text-gray-400 hover:text-port-error rounded"
-                      title="Remove"
+                      title="Remove" aria-label="Remove"
                     >
                       <X size={14} />
                     </button>

--- a/client/src/components/universeBuilder/UniverseCategoryEditor.jsx
+++ b/client/src/components/universeBuilder/UniverseCategoryEditor.jsx
@@ -298,7 +298,7 @@ export function CategoryEditor({
             <button
               onClick={onRemove}
               className="p-1 text-gray-400 hover:text-port-error rounded"
-              title="Remove category"
+              title="Remove category" aria-label="Remove category"
             >
               <Trash2 size={14} />
             </button>
@@ -491,7 +491,7 @@ function VariationCard({
             }}
             disabled={!canPromote || promotingIdx !== null}
             className="p-1 text-gray-400 hover:text-port-success disabled:opacity-30 disabled:cursor-not-allowed rounded"
-            title={promoteTitle}
+            title={promoteTitle} aria-label={promoteTitle}
             aria-haspopup={requiresTargetKind ? 'menu' : undefined}
             aria-expanded={requiresTargetKind ? pickerIdx === idx : undefined}
           >
@@ -526,7 +526,7 @@ function VariationCard({
           onClick={() => onRenderVariation(v)}
           disabled={!canRender}
           className="p-1 text-gray-400 hover:text-port-accent disabled:opacity-30 disabled:cursor-not-allowed rounded"
-          title={canRender ? 'Render this variation' : 'Save the world and configure a render backend to enable'}
+          title={canRender ? 'Render this variation' : 'Save the world and configure a render backend to enable'} aria-label={canRender ? 'Render this variation' : 'Save the world and configure a render backend to enable'}
         >
           <Play size={14} />
         </button>
@@ -534,7 +534,7 @@ function VariationCard({
       <button
         onClick={toggleLock}
         className={`p-1 rounded ${locked ? 'text-port-accent hover:bg-port-accent/20' : 'text-gray-500 hover:text-gray-300'}`}
-        title={locked ? 'Locked — AI expand will preserve this variation' : 'Lock this variation against AI expand'}
+        title={locked ? 'Locked — AI expand will preserve this variation' : 'Lock this variation against AI expand'} aria-label={locked ? 'Locked — AI expand will preserve this variation' : 'Lock this variation against AI expand'}
         aria-pressed={locked}
       >
         {locked ? <Lock size={14} /> : <Unlock size={14} />}
@@ -542,14 +542,14 @@ function VariationCard({
       <button
         onClick={startEdit}
         className="p-1 text-gray-400 hover:text-port-accent rounded"
-        title="Edit"
+        title="Edit" aria-label="Edit"
       >
         <Edit3 size={14} />
       </button>
       <button
         onClick={remove}
         className="p-1 text-gray-400 hover:text-port-error rounded"
-        title="Remove"
+        title="Remove" aria-label="Remove"
       >
         <X size={14} />
       </button>

--- a/client/src/components/universeBuilder/UniverseStyleReferences.jsx
+++ b/client/src/components/universeBuilder/UniverseStyleReferences.jsx
@@ -213,7 +213,7 @@ export default function UniverseStyleReferences({
               <h2 className="text-base font-semibold text-white">Add art style reference</h2>
               <p className="text-xs text-gray-500">Choose an image, analyze it, then preview whether to adopt its style.</p>
             </div>
-            <button type="button" onClick={close} disabled={analyzing || persisting} className="p-1 text-gray-400 hover:text-white" aria-label="Close">
+            <button type="button" onClick={close} disabled={analyzing || persisting} className="p-1 text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close">
               <X size={18} />
             </button>
           </div>

--- a/client/src/components/videoGen/AdvancedParamsPanel.jsx
+++ b/client/src/components/videoGen/AdvancedParamsPanel.jsx
@@ -129,7 +129,7 @@ export default function AdvancedParamsPanel({
                 type="button"
                 onClick={onRandomSeed}
                 className="p-2 text-gray-400 hover:text-white border border-port-border rounded-lg hover:bg-port-border/50 disabled:opacity-50 min-h-[40px] min-w-[40px] flex items-center justify-center"
-                title="Randomize seed"
+                title="Randomize seed" aria-label="Randomize seed"
               >
                 <Dice5 className="w-4 h-4" />
               </button>

--- a/client/src/components/voice/VoiceWidget.jsx
+++ b/client/src/components/voice/VoiceWidget.jsx
@@ -694,6 +694,7 @@ export default function VoiceWidget() {
           <button
             onClick={hideWidget}
             title="Hide voice widget (restore from the sidebar or Settings → Voice)"
+            aria-label="Hide voice widget"
             className={`p-2 rounded-full bg-port-card border text-gray-400 hover:text-white ${fabSurface}`}
           >
             <EyeOff size={14} />
@@ -706,6 +707,7 @@ export default function VoiceWidget() {
                 : 'bg-port-card text-white'
             }`}
             title="Open voice controls"
+            aria-label="Open voice controls"
           >
             <Icon size={20} />
           </button>
@@ -719,6 +721,7 @@ export default function VoiceWidget() {
               <button
                 onClick={handleClear}
                 title="Clear conversation"
+                aria-label="Clear conversation"
                 className="p-1 rounded text-gray-400 hover:text-port-error hover:bg-port-error/10"
               >
                 <Trash2 size={12} />
@@ -757,6 +760,7 @@ export default function VoiceWidget() {
             type="submit"
             disabled={!draft.trim()}
             title="Send text (Enter)"
+            aria-label="Send text"
             className="p-2 rounded-full text-gray-400 hover:text-white hover:bg-port-border/70 disabled:opacity-30 disabled:hover:bg-transparent disabled:hover:text-gray-400"
           >
             <Send size={14} />
@@ -830,6 +834,7 @@ export default function VoiceWidget() {
             <button
               onClick={() => setCollapsed((c) => !c)}
               title={collapsed ? 'Show conversation' : 'Hide conversation'}
+              aria-label={collapsed ? 'Show conversation' : 'Hide conversation'}
               className="p-1.5 rounded-full text-gray-400 hover:text-white hover:bg-port-border/70"
             >
               {collapsed ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
@@ -839,6 +844,7 @@ export default function VoiceWidget() {
             <button
               onClick={interrupt}
               title="Interrupt"
+              aria-label="Interrupt"
               className="p-2 rounded-full text-port-error hover:bg-port-error/10"
             >
               <Square size={14} />
@@ -861,12 +867,16 @@ export default function VoiceWidget() {
                 ? `Click or press ${hotkey} to send`
                 : `Click or press ${hotkey} to listen`;
             })()}
+            aria-label={handsFree
+              ? (capturing ? 'Stop hands-free listening' : 'Start hands-free listening')
+              : (capturing ? 'Send voice message' : 'Start listening')}
           >
             <Icon size={16} />
           </button>
           <button
             onClick={() => setExpanded(false)}
             title="Minimize voice controls"
+            aria-label="Minimize voice controls"
             className="md:hidden p-2 rounded-full text-gray-400 hover:text-white hover:bg-port-border/70"
           >
             <X size={14} />
@@ -874,6 +884,7 @@ export default function VoiceWidget() {
           <button
             onClick={hideWidget}
             title="Hide voice widget (restore from the sidebar or Settings → Voice)"
+            aria-label="Hide voice widget"
             className="p-2 rounded-full text-gray-400 hover:text-white hover:bg-port-border/70"
           >
             <EyeOff size={14} />

--- a/client/src/components/wiki/tabs/BrowseTab.jsx
+++ b/client/src/components/wiki/tabs/BrowseTab.jsx
@@ -123,7 +123,7 @@ export default function BrowseTab({ vaultId, notes, rawNotes, allNotes, onRefres
           <button
             onClick={() => { loadTags(); setShowTags(!showTags); }}
             className={`p-1.5 rounded ${showTags ? 'text-port-accent' : 'text-gray-500 hover:text-white'}`}
-            title="Tags"
+            title="Tags" aria-label="Tags"
           >
             <Tag size={14} />
           </button>
@@ -259,7 +259,7 @@ export default function BrowseTab({ vaultId, notes, rawNotes, allNotes, onRefres
                 <button
                   onClick={() => setConfirmDelete(selectedNote.path)}
                   className="p-1.5 rounded hover:bg-port-card text-gray-400 hover:text-port-error"
-                  title="Delete note"
+                  title="Delete note" aria-label="Delete note"
                 >
                   <Trash2 size={14} />
                 </button>

--- a/client/src/components/writers-room/ExercisePanel.jsx
+++ b/client/src/components/writers-room/ExercisePanel.jsx
@@ -121,7 +121,7 @@ export default function ExercisePanel({ activeWork, onClose }) {
       <div className="flex items-center gap-2 px-3 py-2 border-b border-port-border bg-port-bg/40">
         <Timer size={14} className="text-port-accent" />
         <h3 className="text-sm font-semibold text-white flex-1">Write for {Math.round(duration / 60)}</h3>
-        <button onClick={onClose} className="text-gray-500 hover:text-white" aria-label="Close exercise">
+        <button onClick={onClose} className="text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close exercise">
           <X size={14} />
         </button>
       </div>
@@ -183,7 +183,7 @@ export default function ExercisePanel({ activeWork, onClose }) {
             </button>
             <button onClick={() => finishSession({ keep: false })}
               className="flex items-center gap-1 px-2 py-1 text-gray-500 text-xs rounded hover:text-port-error"
-              title="Discard"
+              title="Discard" aria-label="Discard"
             >
               <X size={12} />
             </button>

--- a/client/src/components/writers-room/ProseTokenPopover.jsx
+++ b/client/src/components/writers-room/ProseTokenPopover.jsx
@@ -207,7 +207,7 @@ export default function ProseTokenPopover({
           <button
             type="button"
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-200"
+            className="text-gray-500 hover:text-gray-200 min-h-[44px] min-w-[44px] flex items-center justify-center"
             aria-label="Close"
           >
             <X size={12} />

--- a/client/src/pages/Authors.jsx
+++ b/client/src/pages/Authors.jsx
@@ -399,7 +399,7 @@ export default function Authors() {
                       <button
                         type="button"
                         onClick={() => setHeadshot('')}
-                        title="Remove headshot"
+                        title="Remove headshot" aria-label="Remove headshot"
                         className="absolute -top-2 -right-2 p-1 rounded-full bg-port-bg border border-port-border text-gray-400 hover:text-port-error"
                       >
                         <X size={12} />

--- a/client/src/pages/Browser.jsx
+++ b/client/src/pages/Browser.jsx
@@ -603,7 +603,7 @@ export default function BrowserPage() {
                             <button
                               onClick={() => handleDeleteDownload(file.name)}
                               className="p-1.5 rounded-md text-gray-400 hover:text-port-error hover:bg-port-border/50 transition-colors"
-                              title="Delete file"
+                              title="Delete file" aria-label="Delete file"
                             >
                               <Trash2 size={16} />
                             </button>

--- a/client/src/pages/CatalogIngredient.jsx
+++ b/client/src/pages/CatalogIngredient.jsx
@@ -1261,12 +1261,12 @@ function MediaTile({ m, missing, isPortrait = false, onSetPortrait, onDetach }) 
       )}
       <div className="absolute top-1 right-1 flex gap-1 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
         {!isPortrait && isImage && (
-          <button type="button" onClick={() => onSetPortrait(m.mediaKey)} title="Set as portrait"
+          <button type="button" onClick={() => onSetPortrait(m.mediaKey)} title="Set as portrait" aria-label="Set as portrait"
             className="p-2 sm:p-1 rounded bg-black/60 text-gray-200 hover:text-port-warning">
             <Star size={12} aria-hidden="true" />
           </button>
         )}
-        <button type="button" onClick={() => onDetach(m.mediaKey, m.kind)} title="Detach"
+        <button type="button" onClick={() => onDetach(m.mediaKey, m.kind)} title="Detach" aria-label="Detach"
           className="p-2 sm:p-1 rounded bg-black/60 text-gray-200 hover:text-port-error">
           <X size={12} aria-hidden="true" />
         </button>
@@ -1298,7 +1298,7 @@ function GalleryPickerModal({ onClose, onPick }) {
       <>
         <div className="flex items-center justify-between p-3 border-b border-port-border shrink-0">
           <h3 id="gallery-picker-title" className="text-sm font-semibold text-white">Pick from media gallery</h3>
-          <button type="button" onClick={onClose} className="text-gray-400 hover:text-white" aria-label="Close">
+          <button type="button" onClick={onClose} className="text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close">
             <X size={16} />
           </button>
         </div>

--- a/client/src/pages/CharacterSheet.jsx
+++ b/client/src/pages/CharacterSheet.jsx
@@ -435,7 +435,7 @@ export default function CharacterSheet() {
         <button
           onClick={() => { setLoading(true); load(); }}
           className="p-2 rounded-lg text-gray-400 hover:text-white hover:bg-port-border/50"
-          title="Refresh"
+          title="Refresh" aria-label="Refresh"
         >
           <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
         </button>
@@ -728,7 +728,7 @@ export default function CharacterSheet() {
             <div className="mt-3 p-3 bg-port-bg rounded-lg border border-port-error/30 space-y-2">
               <div className="flex items-center justify-between">
                 <span className="text-sm font-medium text-port-error">Roll Damage</span>
-                <button onClick={() => setActiveAction(null)} aria-label="Close" className="text-gray-500 hover:text-white">
+                <button onClick={() => setActiveAction(null)} aria-label="Close" className="text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center">
                   <X className="w-4 h-4" />
                 </button>
               </div>
@@ -762,7 +762,7 @@ export default function CharacterSheet() {
             <div className="mt-3 p-3 bg-port-bg rounded-lg border border-port-warning/30 space-y-2">
               <div className="flex items-center justify-between">
                 <span className="text-sm font-medium text-port-warning">Add Experience</span>
-                <button onClick={() => setActiveAction(null)} aria-label="Close" className="text-gray-500 hover:text-white">
+                <button onClick={() => setActiveAction(null)} aria-label="Close" className="text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center">
                   <X className="w-4 h-4" />
                 </button>
               </div>
@@ -794,7 +794,7 @@ export default function CharacterSheet() {
             <div className="mt-3 p-3 bg-port-bg rounded-lg border border-port-accent-2/30 space-y-2">
               <div className="flex items-center justify-between">
                 <span className="text-sm font-medium text-port-accent-2">Log Event</span>
-                <button onClick={() => setActiveAction(null)} aria-label="Close" className="text-gray-500 hover:text-white">
+                <button onClick={() => setActiveAction(null)} aria-label="Close" className="text-gray-500 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center">
                   <X className="w-4 h-4" />
                 </button>
               </div>

--- a/client/src/pages/CreativeCommissions.jsx
+++ b/client/src/pages/CreativeCommissions.jsx
@@ -197,7 +197,7 @@ export default function CreativeCommissions() {
               </button>
               <button
                 onClick={() => toggleEnabled(c)}
-                title={c.enabled ? 'Pause' : 'Resume'}
+                title={c.enabled ? 'Pause' : 'Resume'} aria-label={c.enabled ? 'Pause' : 'Resume'}
                 className="p-2 text-gray-400 hover:text-gray-100"
               >
                 {c.enabled ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}

--- a/client/src/pages/DataManager.jsx
+++ b/client/src/pages/DataManager.jsx
@@ -338,7 +338,7 @@ function BackupsSection({ backups, loading, onDelete }) {
                     <button
                       onClick={() => requestDelete(b.name)}
                       className="text-gray-500 hover:text-port-error transition-colors"
-                      title="Delete backup"
+                      title="Delete backup" aria-label="Delete backup"
                     >
                       <Trash2 size={12} />
                     </button>
@@ -484,7 +484,7 @@ export default function DataManager() {
           <button
             onClick={() => { setLoading(true); fetchOverview(); }}
             className="p-2 text-gray-400 hover:text-white hover:bg-port-card rounded transition-colors"
-            title="Refresh"
+            title="Refresh" aria-label="Refresh"
           >
             <RefreshCw size={16} />
           </button>

--- a/client/src/pages/FeatureAgents.jsx
+++ b/client/src/pages/FeatureAgents.jsx
@@ -85,7 +85,7 @@ export default function FeatureAgents() {
             <button
               onClick={fetchAgents}
               className="p-2 text-gray-400 hover:text-white hover:bg-port-border/50 rounded-lg transition-colors"
-              title="Refresh"
+              title="Refresh" aria-label="Refresh"
             >
               <RefreshCw size={16} />
             </button>

--- a/client/src/pages/ImageGen.jsx
+++ b/client/src/pages/ImageGen.jsx
@@ -1118,7 +1118,7 @@ export default function ImageGen() {
             onClick={() => refreshStatus(effectiveMode)}
             disabled={statusLoading}
             className="p-1.5 rounded text-gray-400 hover:text-white hover:bg-port-border/50 disabled:opacity-50"
-            title="Refresh status"
+            title="Refresh status" aria-label="Refresh status"
           >
             <RefreshCw className={`w-3.5 h-3.5 ${statusLoading ? 'animate-spin' : ''}`} />
           </button>

--- a/client/src/pages/Instances.jsx
+++ b/client/src/pages/Instances.jsx
@@ -1282,7 +1282,7 @@ function PeerCard({ peer, onRefresh, syncStatus, tailnetInfo }) {
             onClick={handleProbe}
             disabled={probing}
             className="p-1.5 text-gray-500 hover:text-white transition-colors disabled:opacity-50"
-            title="Probe now"
+            title="Probe now" aria-label="Probe now"
           >
             <RefreshCw size={14} className={probing ? 'animate-spin' : ''} />
           </button>
@@ -1302,7 +1302,7 @@ function PeerCard({ peer, onRefresh, syncStatus, tailnetInfo }) {
             <button
               onClick={() => setConfirmRemove(true)}
               className="p-1.5 text-gray-600 hover:text-port-error transition-colors"
-              title="Remove peer"
+              title="Remove peer" aria-label="Remove peer"
             >
               <Trash2 size={14} />
             </button>

--- a/client/src/pages/Loops.jsx
+++ b/client/src/pages/Loops.jsx
@@ -250,19 +250,19 @@ function LoopCard({ loop, onAction, expandedId, onToggle }) {
         <div className="flex items-center gap-1">
           {loop.isRunning ? (
             <>
-              <button onClick={e => { e.stopPropagation(); onAction('trigger', loop.id); }} className="p-1.5 rounded hover:bg-port-border text-gray-400 hover:text-port-accent" title="Run now">
+              <button onClick={e => { e.stopPropagation(); onAction('trigger', loop.id); }} className="p-1.5 rounded hover:bg-port-border text-gray-400 hover:text-port-accent" title="Run now" aria-label="Run now">
                 <Zap size={14} />
               </button>
-              <button onClick={e => { e.stopPropagation(); onAction('stop', loop.id); }} className="p-1.5 rounded hover:bg-port-border text-gray-400 hover:text-port-warning" title="Stop">
+              <button onClick={e => { e.stopPropagation(); onAction('stop', loop.id); }} className="p-1.5 rounded hover:bg-port-border text-gray-400 hover:text-port-warning" title="Stop" aria-label="Stop">
                 <Square size={14} />
               </button>
             </>
           ) : (
-            <button onClick={e => { e.stopPropagation(); onAction('resume', loop.id); }} className="p-1.5 rounded hover:bg-port-border text-gray-400 hover:text-port-success" title="Resume">
+            <button onClick={e => { e.stopPropagation(); onAction('resume', loop.id); }} className="p-1.5 rounded hover:bg-port-border text-gray-400 hover:text-port-success" title="Resume" aria-label="Resume">
               <Play size={14} />
             </button>
           )}
-          <button onClick={e => { e.stopPropagation(); onAction('delete', loop.id); }} className="p-1.5 rounded hover:bg-port-border text-gray-400 hover:text-port-error" title="Delete">
+          <button onClick={e => { e.stopPropagation(); onAction('delete', loop.id); }} className="p-1.5 rounded hover:bg-port-border text-gray-400 hover:text-port-error" title="Delete" aria-label="Delete">
             <Trash2 size={14} />
           </button>
           {expanded ? <ChevronDown size={14} className="text-gray-500" /> : <ChevronRight size={14} className="text-gray-500" />}
@@ -394,7 +394,7 @@ export default function Loops() {
         <div className="flex items-center gap-3 text-xs text-gray-400">
           {runningCount > 0 && <span className="text-port-success">{runningCount} active</span>}
           <span>{loops.length} total</span>
-          <button onClick={fetchLoops} className="p-1 rounded hover:bg-port-border" title="Refresh">
+          <button onClick={fetchLoops} className="p-1 rounded hover:bg-port-border" title="Refresh" aria-label="Refresh">
             <RefreshCw size={14} />
           </button>
         </div>

--- a/client/src/pages/Loras.jsx
+++ b/client/src/pages/Loras.jsx
@@ -976,7 +976,7 @@ function CivitaiAuthModal({ pendingUrl, message, auth, onClose, onSaved, onRetry
           <KeyRound size={18} className="text-port-accent" />
           <h2 id="civitai-auth-title" className="text-base font-semibold text-white">Civitai API key</h2>
         </div>
-        <button onClick={onClose} className="text-gray-400 hover:text-gray-200" aria-label="Close">
+        <button onClick={onClose} className="text-gray-400 hover:text-gray-200 min-h-[44px] min-w-[44px] flex items-center justify-center" aria-label="Close">
           <X size={16} />
         </button>
       </div>
@@ -1169,7 +1169,7 @@ function LoraCard({ lora, onDelete, deleting }) {
             onClick={onDelete}
             disabled={deleting}
             className="text-port-error hover:text-port-error/80 p-1.5 rounded hover:bg-port-error/10 disabled:opacity-50"
-            title="Delete LoRA"
+            title="Delete LoRA" aria-label="Delete LoRA"
           >
             <Trash2 size={14} />
           </button>

--- a/client/src/pages/MediaCollectionDetail.jsx
+++ b/client/src/pages/MediaCollectionDetail.jsx
@@ -533,7 +533,7 @@ export default function MediaCollectionDetail() {
                         ? 'bg-port-accent text-white border-port-accent'
                         : 'bg-black/60 text-gray-300 border-port-border hover:text-white'
                     }`}
-                    title={isCover ? 'Cover (click to reset to newest)' : 'Set as cover'}
+                    title={isCover ? 'Cover (click to reset to newest)' : 'Set as cover'} aria-label={isCover ? 'Cover (click to reset to newest)' : 'Set as cover'}
                   >
                     <Star className="w-3.5 h-3.5" fill={isCover ? 'currentColor' : 'none'} />
                   </button>

--- a/client/src/pages/MediaCollections.jsx
+++ b/client/src/pages/MediaCollections.jsx
@@ -346,7 +346,7 @@ export default function MediaCollections() {
                           type="button"
                           onClick={() => handleDelete(c)}
                           className="px-1.5 py-1 bg-port-error/20 hover:bg-port-error/40 text-port-error text-[10px] rounded flex items-center gap-1"
-                          title="Delete collection"
+                          title="Delete collection" aria-label="Delete collection"
                         >
                           <Trash2 className="w-3 h-3" />
                         </button>

--- a/client/src/pages/MediaHistory.jsx
+++ b/client/src/pages/MediaHistory.jsx
@@ -175,7 +175,7 @@ export default function MediaHistory() {
                 type="button"
                 onClick={() => setQuery('')}
                 className="absolute right-1 top-1/2 -translate-y-1/2 p-0.5 text-gray-500 hover:text-white"
-                title="Clear search"
+                title="Clear search" aria-label="Clear search"
               >
                 <X className="w-3.5 h-3.5" />
               </button>

--- a/client/src/pages/PipelineIssue.jsx
+++ b/client/src/pages/PipelineIssue.jsx
@@ -445,7 +445,7 @@ export default function PipelineIssue() {
               <button
                 type="button"
                 onClick={() => setSettingsOpen(false)}
-                className="p-1 text-gray-400 hover:text-white"
+                className="p-1 text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
                 aria-label="Close"
               >
                 <X size={16} />

--- a/client/src/pages/PipelineSeries.jsx
+++ b/client/src/pages/PipelineSeries.jsx
@@ -905,7 +905,7 @@ function CharacterArcsSection({ series, patchSeries }) {
                   type="button"
                   onClick={() => removeArc(i)}
                   className="text-gray-500 hover:text-port-error shrink-0"
-                  title="Remove this character arc"
+                  title="Remove this character arc" aria-label="Remove this character arc"
                 >
                   <Trash2 size={14} />
                 </button>
@@ -962,7 +962,7 @@ function CharacterArcsSection({ series, patchSeries }) {
                         type="button"
                         onClick={() => removeTransition(i, j)}
                         className="text-gray-500 hover:text-port-error shrink-0"
-                        title="Remove this transition"
+                        title="Remove this transition" aria-label="Remove this transition"
                       >
                         <Trash2 size={12} />
                       </button>

--- a/client/src/pages/PromptManager.jsx
+++ b/client/src/pages/PromptManager.jsx
@@ -377,7 +377,7 @@ export default function PromptManager() {
         <button
           onClick={loadData}
           className="p-2 text-gray-400 hover:text-white self-end sm:self-auto"
-          title="Reload"
+          title="Reload" aria-label="Reload"
         >
           <RefreshCw size={20} />
         </button>
@@ -421,7 +421,7 @@ export default function PromptManager() {
               <button
                 onClick={() => setCreatingStage(true)}
                 className="p-1 text-port-accent hover:text-port-accent/80"
-                title="New Stage"
+                title="New Stage" aria-label="New Stage"
               >
                 <Plus size={16} />
               </button>
@@ -900,7 +900,7 @@ export default function PromptManager() {
             <button
               onClick={() => setCreatingStage(false)}
               aria-label="Close"
-              className="text-gray-400 hover:text-white"
+              className="text-gray-400 hover:text-white min-h-[44px] min-w-[44px] flex items-center justify-center"
             >
               ✕
             </button>

--- a/client/src/pages/Review.jsx
+++ b/client/src/pages/Review.jsx
@@ -450,7 +450,7 @@ export default function Review() {
                 <button
                   onClick={() => setBriefingFullscreen(prev => !prev)}
                   className="p-1 text-gray-500 hover:text-white transition-colors rounded-md hover:bg-white/5"
-                  title={briefingFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
+                  title={briefingFullscreen ? 'Exit fullscreen' : 'Fullscreen'} aria-label={briefingFullscreen ? 'Exit fullscreen' : 'Fullscreen'}
                 >
                   {briefingFullscreen ? <Minimize2 size={14} /> : <Maximize2 size={14} />}
                 </button>
@@ -658,14 +658,14 @@ function QueueRow({ item, onDrill, onDismiss, onResolve, onPromoteAsk, resolving
         <button
           onClick={() => onDrill(item)}
           className="p-1.5 text-gray-500 hover:text-port-accent transition-colors"
-          title="Open"
+          title="Open" aria-label="Open"
         >
           <ArrowRight size={16} />
         </button>
         <button
           onClick={() => onDismiss(item.id)}
           className="p-1.5 text-gray-500 hover:text-port-warning transition-colors"
-          title="Dismiss from queue (this session)"
+          title="Dismiss from queue (this session)" aria-label="Dismiss from queue (this session)"
         >
           <X size={16} />
         </button>
@@ -816,7 +816,7 @@ function ReviewItem({ item, config, idScope, isEditing, onComplete, onDismiss, o
             <button
               onClick={onStartEdit}
               className="p-1.5 text-gray-500 hover:text-white transition-colors"
-              title="Edit"
+              title="Edit" aria-label="Edit"
             >
               <Pencil size={14} />
             </button>
@@ -824,21 +824,21 @@ function ReviewItem({ item, config, idScope, isEditing, onComplete, onDismiss, o
           <button
             onClick={() => onComplete(item.id)}
             className="p-1.5 text-gray-500 hover:text-port-success transition-colors"
-            title={item.type === 'alert' ? 'Accept' : 'Complete'}
+            title={item.type === 'alert' ? 'Accept' : 'Complete'} aria-label={item.type === 'alert' ? 'Accept' : 'Complete'}
           >
             <CheckCircle2 size={16} />
           </button>
           <button
             onClick={() => onDismiss(item.id)}
             className="p-1.5 text-gray-500 hover:text-port-warning transition-colors"
-            title={item.type === 'alert' ? 'Reject' : 'Dismiss'}
+            title={item.type === 'alert' ? 'Reject' : 'Dismiss'} aria-label={item.type === 'alert' ? 'Reject' : 'Dismiss'}
           >
             <X size={16} />
           </button>
           <button
             onClick={() => onDelete(item.id)}
             className="p-1.5 text-gray-500 hover:text-port-error transition-colors"
-            title="Delete"
+            title="Delete" aria-label="Delete"
           >
             <Trash2 size={14} />
           </button>

--- a/client/src/pages/RunsHistoryPage.jsx
+++ b/client/src/pages/RunsHistoryPage.jsx
@@ -300,7 +300,7 @@ export function RunsHistoryPage() {
                         <button
                           onClick={(e) => handleResume(run, e)}
                           className="p-1 text-gray-500 hover:text-port-accent transition-colors sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 sm:focus-visible:opacity-100"
-                          title="Resume run"
+                          title="Resume run" aria-label="Resume run"
                           data-testid={`resume-run-${run.id}`}
                         >
                           <RotateCcw size={14} />
@@ -309,7 +309,7 @@ export function RunsHistoryPage() {
                       <button
                         onClick={(e) => handleDelete(run.id, e)}
                         className="p-1 text-gray-500 hover:text-port-error transition-colors sm:opacity-0 sm:group-hover:opacity-100 focus-visible:opacity-100 sm:focus-visible:opacity-100"
-                        title="Delete run"
+                        title="Delete run" aria-label="Delete run"
                         data-testid={`delete-run-${run.id}`}
                       >
                         <Trash2 size={14} />

--- a/client/src/pages/Security.jsx
+++ b/client/src/pages/Security.jsx
@@ -402,7 +402,7 @@ export default function Security() {
                     ? 'bg-port-card border border-port-border text-white hover:bg-port-border'
                     : 'bg-port-error/20 text-port-error'
                 } disabled:opacity-50 disabled:cursor-not-allowed`}
-                title={videoEnabled ? 'Disable camera' : 'Enable camera'}
+                title={videoEnabled ? 'Disable camera' : 'Enable camera'} aria-label={videoEnabled ? 'Disable camera' : 'Enable camera'}
               >
                 {videoEnabled ? <Video size={20} /> : <VideoOff size={20} />}
               </button>
@@ -415,7 +415,7 @@ export default function Security() {
                     ? 'bg-port-card border border-port-border text-white hover:bg-port-border'
                     : 'bg-port-error/20 text-port-error'
                 } disabled:opacity-50 disabled:cursor-not-allowed`}
-                title={audioEnabled ? 'Mute microphone' : 'Unmute microphone'}
+                title={audioEnabled ? 'Mute microphone' : 'Unmute microphone'} aria-label={audioEnabled ? 'Mute microphone' : 'Unmute microphone'}
               >
                 {audioEnabled ? <Mic size={20} /> : <MicOff size={20} />}
               </button>
@@ -441,7 +441,7 @@ export default function Security() {
                 onClick={fetchDevices}
                 disabled={isLoading}
                 className="p-3 rounded-full bg-port-card border border-port-border text-gray-400 hover:text-white hover:bg-port-border transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                title="Refresh devices"
+                title="Refresh devices" aria-label="Refresh devices"
               >
                 <RefreshCw size={20} className={isLoading ? 'animate-spin' : ''} />
               </button>

--- a/client/src/pages/Uploads.jsx
+++ b/client/src/pages/Uploads.jsx
@@ -159,7 +159,7 @@ export default function Uploads() {
           <button
             onClick={fetchUploads}
             className="flex items-center gap-2 px-3 py-2 bg-port-card border border-port-border rounded-lg text-gray-400 hover:text-white hover:border-port-accent/50 transition-colors"
-            title="Refresh"
+            title="Refresh" aria-label="Refresh"
           >
             <RefreshCw size={16} />
           </button>
@@ -280,7 +280,7 @@ export default function Uploads() {
                     <button
                       onClick={() => requestDelete(file.filename)}
                       className="p-2 text-gray-500 hover:text-port-error transition-colors"
-                      title="Delete"
+                      title="Delete" aria-label="Delete"
                     >
                       <Trash2 size={18} />
                     </button>

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -603,7 +603,7 @@ export default function VideoGen() {
             onClick={refreshStatus}
             disabled={statusLoading}
             className="p-1.5 rounded text-gray-400 hover:text-white hover:bg-port-border/50 disabled:opacity-50"
-            title="Refresh status"
+            title="Refresh status" aria-label="Refresh status"
           >
             <RefreshCw className={`w-3.5 h-3.5 ${statusLoading ? 'animate-spin' : ''}`} />
           </button>

--- a/client/src/pages/VideoTimeline.jsx
+++ b/client/src/pages/VideoTimeline.jsx
@@ -129,7 +129,7 @@ export default function VideoTimeline() {
                       type="button"
                       onClick={() => handleDelete(project)}
                       className="p-1 text-gray-500 hover:text-port-error transition-colors"
-                      title="Delete project"
+                      title="Delete project" aria-label="Delete project"
                     >
                       <Trash2 className="w-4 h-4" />
                     </button>

--- a/client/src/pages/VideoTimelineEditor.jsx
+++ b/client/src/pages/VideoTimelineEditor.jsx
@@ -523,7 +523,7 @@ export default function VideoTimelineEditor() {
             type="button"
             onClick={() => navigate('/media/timeline')}
             className="p-1.5 text-gray-400 hover:text-white"
-            title="Back to projects"
+            title="Back to projects" aria-label="Back to projects"
           >
             <ArrowLeft className="w-4 h-4" />
           </button>
@@ -612,7 +612,7 @@ export default function VideoTimelineEditor() {
               onClick={() => setPlaying((p) => !p)}
               disabled={clips.length === 0}
               className="p-2 bg-port-card border border-port-border rounded-md hover:border-port-accent disabled:opacity-40"
-              title={playing ? 'Pause' : 'Play'}
+              title={playing ? 'Pause' : 'Play'} aria-label={playing ? 'Pause' : 'Play'}
             >
               {playing ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4" />}
             </button>
@@ -620,7 +620,7 @@ export default function VideoTimelineEditor() {
               type="button"
               onClick={() => setMuted((m) => !m)}
               className="p-2 bg-port-card border border-port-border rounded-md hover:border-port-accent"
-              title={muted ? 'Unmute' : 'Mute'}
+              title={muted ? 'Unmute' : 'Mute'} aria-label={muted ? 'Unmute' : 'Mute'}
             >
               {muted ? <VolumeX className="w-4 h-4" /> : <Volume2 className="w-4 h-4" />}
             </button>


### PR DESCRIPTION
## Summary

Two accessibility gaps the codebase already had conventions for but applied unevenly. Both fixes are mechanical; the guard test is what keeps them from regressing.

### Icon-only buttons without an accessible name — 184 buttons, 86 files

These carried only a `title` attribute. That's insufficient on two counts: `title` is mouse-hover-only, so it's undiscoverable on touch — and this app is explicitly mobile-responsive and opened from phones and tablets over the tailnet — and browser/AT support for using `title` as the accessible name is inconsistent.

The convention already existed (`media/MediaCard.jsx`'s Annotate button pairs `title` with `aria-label`); it just wasn't applied. **Adding `aria-label` changes no rendered output.**

### Close buttons below the 44px touch minimum — 62 buttons, 54 files

Sized to their bare icon (`w-4 h-4`, `p-1`) rather than a real tap target; one had no sizing at all, leaving roughly a 16px target. `Drawer.jsx` was already the 44px convention — only 9 of 59 files with a Close button followed it.

Where a button already carried a smaller `min-h` token, it was **replaced** rather than paired: two competing `min-h-*` utilities resolve by stylesheet order, not source order, so layering a `[44px]` alongside an existing `[40px]` silently does nothing.

### The guard

`a11yConventions.test.js` now enforces both rules, and writing it found **five more** buttons with no accessible name at all — worse than the `title`-only case the audit set out to fix.

Its icon-only detector walks to the true JSX node boundary rather than pattern-matching. That distinction matters: a wildcard regex matches greedily across sibling boundaries, so `<Icon/><span>label</span><Icon/>` reads as one icon-only button — which would have clobbered `ui/ProvenanceChip.jsx`, whose visible `<span>` already gives it a correct accessible name.

Full-bleed `inset-0` dismiss backdrops are exempt via a general rule (their box already fills the positioned ancestor, so a min-size floor is meaningless), not a one-off allowlist.

## Test plan

- `npm run build` — passes; added classes spot-checked in the compiled CSS, since a Tailwind class with an undefined variant is silently dropped from the build
- Client suite — 6,186 passed (baseline 6,184; +2 are the new guard rules)
- Server suite — 24,462 passed / 211 skipped, matching baseline
- Both guard rules verified to fail on a reintroduced violation, then reverted

Deferred: #3449 (34 views showing bare `Loading...` text — changes rendered output, wants per-site design judgment), #3453 (theme tokens for a progress bar).

Found by a `/do:better` audit sweep.
