### PR TITLE
ui: replace bare "Loading..." text with the shared spinner/skeleton

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Changed
+
+- **Every view that used to show a bare "Loading…" text node now uses the shared loading affordances.** ~35 views across Music, MeatSpace, Media, Pipeline, Sprites, Writers Room, Sync, Catalog and a dozen pages rendered unstyled text while fetching, which read as broken content rather than a deliberate loading state. Small inline loads (buttons, side lists, drawer subtitles, popover menus) now render `BrailleSpinner`; full-page and card-grid loads render `PageSkeleton`, which reserves the eventual content's dimensions so the first paint doesn't reflow and announces itself via `role="status"`/`aria-busy`. Several hand-rolled `Loader2 + animate-spin` one-offs collapsed onto the same two components, and the pipeline audio music-library panel lost its duplicate second spinner.
+
 ## Fixed
 
 - **Replaced a real Tailscale identity with placeholders across tracked files, and added a guard so it can't come back.** A real MagicDNS tailnet suffix, real device names, and a real CGNAT peer IP had been committed across server routes/lib, client lib, several test fixtures, two design-plan docs, and two released changelog entries — ~14 tracked files in a public repo. This violates the repo's own `CLAUDE.md` "Sensitive Data & Privacy" rule, which lists Tailscale node/MagicDNS names and Tailscale/LAN IPs as never-commit categories. Every occurrence is now an obviously-fake placeholder (`example-tailnet.ts.net`, `host-alpha`/`beta`/`gamma`/`delta`, a documented CGNAT test IP), preserving the two-host distinctness some tests relied on. A new `scripts/tailnet-identity-leak.test.js` enumerates *tracked* files via `git grep` and fails the moment a real-looking tailnet host or CGNAT address lands again — whether via a pasted log line, a doc example lifted from a live install, or a copy-pasted test fixture.

--- a/client/src/components/FolderPicker.jsx
+++ b/client/src/components/FolderPicker.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Folder, FolderOpen, ChevronUp, HardDrive, Home, X, Check, AlertCircle } from 'lucide-react';
 import * as api from '../services/api';
+import BrailleSpinner from './BrailleSpinner';
 import Modal from './ui/Modal.jsx';
 
 export default function FolderPicker({ value, onChange, defaultPath }) {
@@ -164,8 +165,8 @@ export default function FolderPicker({ value, onChange, defaultPath }) {
           {/* Directory List */}
           <div className="flex-1 overflow-auto p-2 min-h-[300px]">
             {loading ? (
-              <div className="flex items-center justify-center h-full text-gray-500">
-                Loading...
+              <div className="flex items-center justify-center h-full">
+                <BrailleSpinner text="Loading" />
               </div>
             ) : error ? (
               <div className="flex flex-col items-center justify-center h-full gap-2 text-gray-500 px-4">

--- a/client/src/components/agents/tabs/PublishedTab.jsx
+++ b/client/src/components/agents/tabs/PublishedTab.jsx
@@ -79,7 +79,7 @@ export default function PublishedTab({ agentId }) {
             disabled={publishedLoading}
             className="px-3 py-1 text-sm bg-port-accent/20 text-port-accent rounded hover:bg-port-accent/30 disabled:opacity-50"
           >
-            {publishedLoading ? 'Loading...' : 'Refresh'}
+            {publishedLoading ? <BrailleSpinner text="Loading" /> : 'Refresh'}
           </button>
         </div>
       </div>

--- a/client/src/components/agents/tabs/ToolsTab.jsx
+++ b/client/src/components/agents/tabs/ToolsTab.jsx
@@ -377,7 +377,7 @@ export default function ToolsTab({ agentId, agent }) {
                     disabled={feedLoading}
                     className="px-3 py-1 text-sm bg-port-accent/20 text-port-accent rounded hover:bg-port-accent/30 disabled:opacity-50"
                   >
-                    {feedLoading ? 'Loading...' : 'Browse Feed'}
+                    {feedLoading ? <BrailleSpinner text="Loading" /> : 'Browse Feed'}
                   </button>
                   <button
                     onClick={handleFindRelevant}

--- a/client/src/components/agents/tabs/WorldTab.jsx
+++ b/client/src/components/agents/tabs/WorldTab.jsx
@@ -505,7 +505,7 @@ export default function WorldTab({ agentId }) {
                 disabled={statusLoading}
                 className="px-3 py-1 text-sm bg-port-border text-gray-300 rounded hover:bg-port-border/80 disabled:opacity-50"
               >
-                {statusLoading ? 'Loading...' : 'Refresh'}
+                {statusLoading ? <BrailleSpinner text="Loading" /> : 'Refresh'}
               </button>
             </div>
 
@@ -683,7 +683,7 @@ export default function WorldTab({ agentId }) {
             </div>
             {history.length === 0 ? (
               <p className="text-sm text-gray-500 text-center py-4">
-                {historyLoading ? 'Loading...' : 'No activity history yet'}
+                {historyLoading ? <BrailleSpinner text="Loading" /> : 'No activity history yet'}
               </p>
             ) : (
               <div className="space-y-1.5 max-h-[400px] overflow-y-auto">
@@ -717,7 +717,7 @@ export default function WorldTab({ agentId }) {
                     disabled={historyLoading}
                     className="w-full py-2 text-xs text-gray-400 hover:text-white bg-port-bg rounded disabled:opacity-50"
                   >
-                    {historyLoading ? 'Loading...' : 'Load More'}
+                    {historyLoading ? <BrailleSpinner text="Loading" /> : 'Load More'}
                   </button>
                 )}
               </div>

--- a/client/src/components/catalog/CatalogAlbum.jsx
+++ b/client/src/components/catalog/CatalogAlbum.jsx
@@ -11,6 +11,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { ChevronRight, ChevronDown, Loader2 } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import CatalogCard from './CatalogCard';
 
 export default function CatalogAlbum({
@@ -124,8 +125,8 @@ export default function CatalogAlbum({
       {expanded && (
         <div className="px-3 sm:px-4 pb-3 sm:pb-4">
           {loading ? (
-            <div className="flex items-center gap-2 text-sm text-gray-500 py-3">
-              <Loader2 size={14} className="animate-spin" /> Loading…
+            <div className="text-sm py-3">
+              <BrailleSpinner text="Loading…" />
             </div>
           ) : error ? (
             <div className="flex items-center gap-3 py-3">

--- a/client/src/components/cos/tabs/AgentsTab.jsx
+++ b/client/src/components/cos/tabs/AgentsTab.jsx
@@ -4,6 +4,7 @@ import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
 import AgentCard from './AgentCard';
 import ResumeAgentModal from './ResumeAgentModal';
+import BrailleSpinner from '../../BrailleSpinner';
 import InlineConfirmRow from '../../ui/InlineConfirmRow';
 
 const needsAgentFeedback = (agent) => {
@@ -362,7 +363,7 @@ export default function AgentsTab({ agents, onRefresh, liveOutputs, providers, a
                 className="w-full py-2 text-sm text-port-accent hover:text-white bg-port-card border border-port-border rounded-lg transition-colors flex items-center justify-center gap-1 disabled:opacity-50"
               >
                 {loadingMore ? (
-                  'Loading...'
+                  <BrailleSpinner text="Loading" />
                 ) : (
                   <>
                     <ChevronDown size={14} />

--- a/client/src/components/dashboard/builtins/AutoFixMetricsWidget.jsx
+++ b/client/src/components/dashboard/builtins/AutoFixMetricsWidget.jsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
 import { Link } from 'react-router';
 import { Wrench, ArrowRight } from 'lucide-react';
+import BrailleSpinner from '../../BrailleSpinner';
 import * as api from '../../../services/api';
 import { useAutoRefetch } from '../../../hooks/useAutoRefetch';
 import { formatDurationMs } from '../../../utils/formatters';
@@ -111,7 +112,7 @@ function AutoFixMetricsWidget() {
   );
 
   if (loading && !data) {
-    return shell(<div className="text-xs text-gray-500">Loading…</div>);
+    return shell(<div className="text-xs"><BrailleSpinner text="Loading" /></div>);
   }
 
   // Empty state — no diagnostics-bearing tasks yet. Distinct from a 0% rate.

--- a/client/src/components/meatspace/MetricCard.jsx
+++ b/client/src/components/meatspace/MetricCard.jsx
@@ -1,6 +1,7 @@
 import {
   LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer
 } from 'recharts';
+import BrailleSpinner from '../BrailleSpinner';
 import useChartColors from '../../hooks/useChartColors.js';
 
 export default function MetricCard({ data = [], loading = false, config, latestValue }) {
@@ -35,7 +36,7 @@ export default function MetricCard({ data = [], loading = false, config, latestV
     <div className="bg-port-card border border-port-border rounded-xl p-6">
       <h3 className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">{label}</h3>
       {loading ? (
-        <div className="flex items-center justify-center h-40 text-gray-600 text-sm">Loading...</div>
+        <div className="flex items-center justify-center h-40 text-sm"><BrailleSpinner text="Loading" /></div>
       ) : showLatest ? (
         <div className="flex flex-col items-center justify-center h-40">
           <span className="text-3xl font-bold text-white font-mono">{latestDisplay}</span>

--- a/client/src/components/meatspace/SleepCard.jsx
+++ b/client/src/components/meatspace/SleepCard.jsx
@@ -1,6 +1,7 @@
 import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer
 } from 'recharts';
+import BrailleSpinner from '../BrailleSpinner';
 import useChartColors from '../../hooks/useChartColors.js';
 
 const CustomTooltip = ({ active, payload, label, colors }) => {
@@ -44,7 +45,7 @@ export default function SleepCard({ data = [], loading = false }) {
     <div className="bg-port-card border border-port-border rounded-xl p-6">
       <h3 className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-3">Sleep</h3>
       {loading ? (
-        <div className="flex items-center justify-center h-40 text-gray-600 text-sm">Loading...</div>
+        <div className="flex items-center justify-center h-40 text-sm"><BrailleSpinner text="Loading" /></div>
       ) : avg == null ? (
         <div className="flex items-center justify-center h-40 text-gray-600 text-sm">No sleep data available</div>
       ) : (

--- a/client/src/components/media/CollectionPickerShell.jsx
+++ b/client/src/components/media/CollectionPickerShell.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Plus, Search } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import { listMediaCollections, createMediaCollection } from '../../services/api';
 import usePopoverPosition, { VIEWPORT_PADDING } from '../../hooks/usePopoverPosition.js';
@@ -236,7 +237,7 @@ export default function CollectionPickerShell({
       )}
       <div className="flex-1 min-h-0 overflow-y-auto">
         {collectionsState == null && (
-          <div className="text-[11px] text-gray-500 px-2 py-2">Loading…</div>
+          <div className="text-[11px] px-2 py-2"><BrailleSpinner text="Loading…" /></div>
         )}
         {collectionsState != null && collectionsState.length === 0 && (
           <div className="text-[11px] text-gray-500 px-2 py-2">{emptyMessage}</div>

--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useCallback, useEffect } from 'react';
 import { ListOrdered, Image as ImageIcon, Film, Cpu, X, RefreshCw, ChevronDown, ChevronRight, Trash2, RotateCw, Zap, Pencil } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import ConfirmButtonPair from '../ui/ConfirmButtonPair';
 import { FormField } from '../ui/FormField';
@@ -188,7 +189,7 @@ export default function MediaJobsQueue({ kind, recentLimit = 10, className = '' 
       </div>
 
       {loading ? (
-        <div className="text-port-text-muted text-xs">Loading…</div>
+        <div className="text-xs"><BrailleSpinner text="Loading…" /></div>
       ) : live.length === 0 && recent.length === 0 ? (
         <div className="text-port-text-muted text-xs">
           No {kind || 'media'} {kind === 'training' ? 'runs' : 'renders'} queued.

--- a/client/src/components/messages/IMessageTab.jsx
+++ b/client/src/components/messages/IMessageTab.jsx
@@ -68,7 +68,7 @@ function ConversationList({ conversations, selectedKey, onSelect, query, onQuery
       </div>
       <div className="flex-1 overflow-y-auto">
         {loading ? (
-          <div className="py-10 text-center text-gray-500 text-sm">Loading…</div>
+          <div className="py-10 text-center text-sm"><BrailleSpinner text="Loading…" /></div>
         ) : conversations.length === 0 ? (
           <div className="px-4 py-10 text-center text-sm text-gray-500">
             No conversations yet.

--- a/client/src/components/music/AlbumsManager.jsx
+++ b/client/src/components/music/AlbumsManager.jsx
@@ -11,6 +11,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { Plus, Loader2, Trash2, Save, Upload, ImageIcon, Sparkles, X, ArrowUp, ArrowDown } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import FilePickerButton from '../ui/FilePickerButton';
 import GalleryImagePicker from '../imageGen/GalleryImagePicker';
@@ -272,7 +273,7 @@ export default function AlbumsManager() {
       <div className="grid grid-cols-1 md:grid-cols-[260px_1fr] gap-4">
         <div className="bg-port-card border border-port-border rounded-lg p-2">
           {loading ? (
-            <div className="text-gray-500 text-sm p-2">Loading…</div>
+            <div className="text-sm p-2"><BrailleSpinner text="Loading…" /></div>
           ) : albums.length === 0 ? (
             <div className="text-gray-500 text-sm p-2">No albums yet. Click <span className="text-port-accent">New Album</span>.</div>
           ) : (

--- a/client/src/components/music/ArtistsManager.jsx
+++ b/client/src/components/music/ArtistsManager.jsx
@@ -10,6 +10,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { Plus, Loader2, Trash2, Save, Upload, ImageIcon, Sparkles, X } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import FilePickerButton from '../ui/FilePickerButton';
 import GalleryImagePicker from '../imageGen/GalleryImagePicker';
@@ -256,7 +257,7 @@ export default function ArtistsManager() {
       <div className="grid grid-cols-1 md:grid-cols-[260px_1fr] gap-4">
         <div className="bg-port-card border border-port-border rounded-lg p-2">
           {loading ? (
-            <div className="text-gray-500 text-sm p-2">Loading…</div>
+            <div className="text-sm p-2"><BrailleSpinner text="Loading…" /></div>
           ) : artists.length === 0 ? (
             <div className="text-gray-500 text-sm p-2">No artists yet. Click <span className="text-port-accent">New Artist</span>.</div>
           ) : (

--- a/client/src/components/music/TracksManager.jsx
+++ b/client/src/components/music/TracksManager.jsx
@@ -15,6 +15,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
 import { Plus, Loader2, Trash2, Save, Upload, Music2, Library } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import FilePickerButton from '../ui/FilePickerButton';
 import ConfirmButtonPair from '../ui/ConfirmButtonPair';
@@ -356,7 +357,7 @@ export default function TracksManager() {
       <div className="grid grid-cols-1 md:grid-cols-[260px_1fr] gap-4">
         <div className="bg-port-card border border-port-border rounded-lg p-2">
           {loading ? (
-            <div className="text-gray-500 text-sm p-2">Loading…</div>
+            <div className="text-sm p-2"><BrailleSpinner text="Loading…" /></div>
           ) : tracks.length === 0 ? (
             <div className="text-gray-500 text-sm p-2">No tracks yet. Click <span className="text-port-accent">New Track</span>.</div>
           ) : (

--- a/client/src/components/pipeline/ComparativeRankView.jsx
+++ b/client/src/components/pipeline/ComparativeRankView.jsx
@@ -12,6 +12,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { Loader2, Trophy, Swords, AlertTriangle } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import { getComparativeRank, runComparativeRank } from '../../services/apiPipeline';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
 
@@ -73,7 +74,7 @@ export default function ComparativeRankView({ seriesId, hasContent }) {
       </div>
 
       {loading ? (
-        <p className="text-xs text-gray-500 italic">Loading…</p>
+        <p className="text-xs"><BrailleSpinner text="Loading…" /></p>
       ) : status === 'insufficient' ? (
         <p className="text-xs text-gray-500 italic">
           Need at least two drafted issues to run a head-to-head ranking.

--- a/client/src/components/pipeline/SeriesAutopilotSchedule.jsx
+++ b/client/src/components/pipeline/SeriesAutopilotSchedule.jsx
@@ -5,6 +5,7 @@ import { getProviders } from '../../services/apiProviders';
 import { getCosConfig } from '../../services/apiAgents';
 import { describeCron } from '../../utils/cronHelpers';
 import { providerDisplayName, assignmentModelOptions } from '../../utils/providers';
+import BrailleSpinner from '../BrailleSpinner';
 import CronInput from '../CronInput';
 import ProviderModelSelector from '../ProviderModelSelector';
 import toast from '../ui/Toast';
@@ -145,7 +146,7 @@ export default function SeriesAutopilotSchedule({ series }) {
       </div>
 
       {!loaded ? (
-        <p className="text-xs text-gray-500">Loading…</p>
+        <p className="text-xs"><BrailleSpinner text="Loading…" /></p>
       ) : (
         <>
           {/* Schedule time */}

--- a/client/src/components/pipeline/stages/AudioStage.jsx
+++ b/client/src/components/pipeline/stages/AudioStage.jsx
@@ -13,6 +13,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, Sparkles, Wand2, Mic, Music, Upload, Trash2, ListMusic } from 'lucide-react';
+import BrailleSpinner from '../../BrailleSpinner';
 import toast from '../../ui/Toast';
 import InlineConfirmRow from '../../ui/InlineConfirmRow';
 import FilePickerButton from '../../ui/FilePickerButton';
@@ -1125,14 +1126,9 @@ export default function AudioStage({ issue, onStageUpdate }) {
 
         {musicPickerOpen ? (
           <div className="mt-3 p-3 bg-port-bg border border-port-border rounded-lg">
-            <div className="flex items-center justify-between mb-2">
-              <span className="text-xs uppercase tracking-wider text-gray-500">Library</span>
-              {musicLibraryLoading ? (
-                <Loader2 size={12} className="animate-spin text-gray-500" />
-              ) : null}
-            </div>
+            <div className="text-xs uppercase tracking-wider text-gray-500 mb-2">Library</div>
             {musicLibrary === null || musicLibraryLoading ? (
-              <p className="text-xs text-gray-500">Loading…</p>
+              <p className="text-xs"><BrailleSpinner text="Loading…" /></p>
             ) : musicLibrary.length === 0 ? (
               <p className="text-xs text-gray-500 italic">
                 Library is empty. Click <strong>Upload track</strong> above to add your first one.

--- a/client/src/components/pipeline/stages/PovRewritePanel.jsx
+++ b/client/src/components/pipeline/stages/PovRewritePanel.jsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, Sparkles, Trash2, ChevronDown, ChevronRight, Drama } from 'lucide-react';
+import BrailleSpinner from '../../BrailleSpinner';
 import toast from '../../ui/Toast';
 import {
   getPipelinePerspectiveRewrites,
@@ -230,7 +231,7 @@ export default function PovRewritePanel({ issue, series }) {
       </div>
 
       {loading ? (
-        <div className="flex items-center gap-2 text-sm text-gray-500"><Loader2 size={14} className="animate-spin" /> Loading…</div>
+        <div className="text-sm"><BrailleSpinner text="Loading…" /></div>
       ) : (
         <>
           <div className="flex items-end gap-2 flex-wrap">

--- a/client/src/components/settings/EmbeddingsTab.jsx
+++ b/client/src/components/settings/EmbeddingsTab.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Boxes, RefreshCw, AlertTriangle, Check } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import { getSettings, updateSettings } from '../../services/apiSystem';
 import { getLocalLlmStatus } from '../../services/apiLocalLlm';
@@ -84,9 +85,7 @@ export default function EmbeddingsTab() {
     }).finally(() => setSaving(false));
   };
 
-  if (loading) {
-    return <div className="text-sm text-gray-400">Loading…</div>;
-  }
+  if (loading) return <BrailleSpinner text="Loading embeddings settings" />;
 
   return (
     <div className="space-y-6">

--- a/client/src/components/settings/ImageGenTab.jsx
+++ b/client/src/components/settings/ImageGenTab.jsx
@@ -1067,7 +1067,7 @@ export function ImageGenTab() {
                   disabled={agyModelsLoading}
                   className="text-xs text-port-accent hover:underline disabled:opacity-50"
                 >
-                  {agyModelsLoading ? 'Loading…' : 'Refresh models'}
+                  {agyModelsLoading ? <BrailleSpinner text="Loading…" /> : 'Refresh models'}
                 </button>
               </div>
               <input

--- a/client/src/components/sprites/AnimationTypesDrawer.jsx
+++ b/client/src/components/sprites/AnimationTypesDrawer.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'react-router';
 import { AlertTriangle, Info, Lock, Pencil, Plus, RotateCcw, Trash2 } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import Drawer from '../Drawer';
 import Banner from '../ui/Banner';
 import Pill from '../ui/Pill';
@@ -491,7 +492,7 @@ export default function AnimationTypesDrawer({ open, onClose }) {
         </div>
       );
     }
-    if (tracks === null) return <p className="text-sm text-gray-500">Loading…</p>;
+    if (tracks === null) return <p className="text-sm"><BrailleSpinner text="Loading…" /></p>;
 
     // A stale `?editTrack=` (a shared link to a type since deleted, or a typo) must
     // say so rather than silently falling through to the blank create form, which

--- a/client/src/components/sync/SyncDetailDrawer.jsx
+++ b/client/src/components/sync/SyncDetailDrawer.jsx
@@ -17,6 +17,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import useMounted from '../../hooks/useMounted';
 import { RefreshCw, ArrowUpCircle, Download, CheckCircle2, AlertTriangle, WifiOff, Loader2 } from 'lucide-react';
 import toast from '../ui/Toast';
+import BrailleSpinner from '../BrailleSpinner';
 import Drawer from '../Drawer';
 import { useSyncIntegrity } from '../../hooks/useSyncIntegrity';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
@@ -96,9 +97,8 @@ function StatusPill({ status }) {
 function CollectionPreview({ collection, loading, error }) {
   if (loading) {
     return (
-      <div className="flex items-center gap-2 text-gray-500 text-sm py-2">
-        <Loader2 className="w-4 h-4 animate-spin" />
-        Loading…
+      <div className="text-sm py-2">
+        <BrailleSpinner text="Loading…" />
       </div>
     );
   }
@@ -363,7 +363,7 @@ export default function SyncDetailDrawer({ kind, recordId, onClose }) {
       open
       onClose={onClose}
       title="Sync Details"
-      subtitle={recordName ?? (recordLoading ? 'Loading…' : null)}
+      subtitle={recordName ?? (recordLoading ? <BrailleSpinner text="Loading…" /> : null)}
       size="sm"
       bodyClassName="space-y-5"
       closeLabel="Close sync details"

--- a/client/src/components/writers-room/AnalysisHistory.jsx
+++ b/client/src/components/writers-room/AnalysisHistory.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { AlertTriangle, Check, Clapperboard, FileSignature, MapPin, RotateCcw, Sparkles, Users } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import { listWritersRoomAnalyses, getWritersRoomAnalysis } from '../../services/apiWritersRoom';
 import { timeAgo } from '../../utils/formatters';
@@ -99,7 +100,7 @@ export default function AnalysisHistory({ work, activeHash, onApplyFormat }) {
               </button>
               {isOpen && (
                 <div className="border-t border-port-border bg-port-bg/40 p-2 space-y-2">
-                  {!full && <div className="text-gray-500">Loading…</div>}
+                  {!full && <BrailleSpinner text="Loading…" />}
                   {full?.status === 'failed' && (
                     <div className="text-port-error text-[11px] whitespace-pre-wrap">{full.error || 'Unknown error'}</div>
                   )}

--- a/client/src/components/writers-room/BibleSection.jsx
+++ b/client/src/components/writers-room/BibleSection.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { AlertTriangle, Check, Loader2, Pencil, Plus, Trash2, X } from 'lucide-react';
+import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import useMounted from '../../hooks/useMounted';
 
@@ -91,7 +92,7 @@ export default function BibleSection({ workId, items: itemsProp, onItemsChange, 
       </div>
 
       {loading && items.length === 0 && (
-        <div className="text-gray-500 italic">Loading…</div>
+        <BrailleSpinner text="Loading…" />
       )}
 
       {!loading && items.length === 0 && !creating && (

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -4,6 +4,7 @@ import * as api from '../services/api';
 import socket from '../services/socket';
 import { filterSelectableModels, filterGenerationModels, isEmbeddingModel, mergeModelLists, configuredDefaultIn, localBackendForProvider, modelOptionLabel, providerTypeClass, isTuiProvider, isApiProvider, isProcessProvider, isOllamaBackedProvider, isAntigravityProvider, isGrokBuildCli, isLocalEndpoint, effectiveModelContextWindow } from '../utils/providers';
 import useLocalModels from '../hooks/useLocalModels';
+import BrailleSpinner from '../components/BrailleSpinner';
 import EmptyState from '../components/EmptyState';
 import {
   formatDurationMs,
@@ -291,7 +292,7 @@ export default function AIProviders() {
             onClick={handleLoadSamples}
             className="px-4 py-2 bg-port-border hover:bg-port-border/80 text-white rounded-lg transition-colors text-sm sm:text-base"
           >
-            {loadingSamples ? 'Loading...' : 'Load Samples'}
+            {loadingSamples ? <BrailleSpinner text="Loading" /> : 'Load Samples'}
           </button>
           <button
             onClick={() => { setEditingProvider(null); setShowForm(true); }}

--- a/client/src/pages/Ask.jsx
+++ b/client/src/pages/Ask.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import { Send, Loader2, MessageCircle, Trash2, Pin, Brain, Calendar, Target, BookOpen, FileText, ExternalLink, ListTodo, CheckCircle2 } from 'lucide-react';
 import * as api from '../services/api';
+import BrailleSpinner from '../components/BrailleSpinner';
 import toast from '../components/ui/Toast';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import { useConfirmDelete } from '../hooks/useConfirmDelete';
@@ -63,7 +64,7 @@ function Sidebar({ conversations, activeId, onPick, onNew, isConfirmingDelete, o
         </button>
       </div>
       <div className="py-1">
-        {loading && <div className="p-3 text-xs text-gray-500">Loading…</div>}
+        {loading && <div className="p-3 text-xs"><BrailleSpinner text="Loading…" /></div>}
         {!loading && conversations.length === 0 && (
           <div className="p-3 text-xs text-gray-500">No conversations yet. Ask yourself something.</div>
         )}
@@ -670,7 +671,7 @@ export default function Ask() {
         </div>
 
         <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 md:px-6 py-4 space-y-3">
-          {loadingConv && <div className="text-sm text-gray-500"><Loader2 size={14} className="inline animate-spin mr-1" /> Loading…</div>}
+          {loadingConv && <div className="text-sm"><BrailleSpinner text="Loading…" /></div>}
           {showEmptyState && (
             <div className="max-w-2xl mx-auto mt-8 text-center text-gray-400 space-y-3">
               <h2 className="text-xl text-white">Talk to your digital twin.</h2>

--- a/client/src/pages/Authors.jsx
+++ b/client/src/pages/Authors.jsx
@@ -13,6 +13,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { FilePen, Plus, Loader2, Trash2, Save, Upload, ImageIcon, Sparkles, X } from 'lucide-react';
+import BrailleSpinner from '../components/BrailleSpinner';
 import toast from '../components/ui/Toast';
 import FilePickerButton from '../components/ui/FilePickerButton';
 import GalleryImagePicker from '../components/imageGen/GalleryImagePicker';
@@ -286,7 +287,7 @@ export default function Authors() {
       <div className="grid grid-cols-1 md:grid-cols-[260px_1fr] gap-4">
         <div className="bg-port-card border border-port-border rounded-lg p-2">
           {loading ? (
-            <div className="text-gray-500 text-sm p-2">Loading…</div>
+            <div className="text-sm p-2"><BrailleSpinner text="Loading…" /></div>
           ) : authors.length === 0 ? (
             <div className="text-gray-500 text-sm p-2">No authors yet. Click <span className="text-port-accent">New Author</span>.</div>
           ) : (

--- a/client/src/pages/Browser.jsx
+++ b/client/src/pages/Browser.jsx
@@ -12,6 +12,7 @@ import {
   getBrowserLogs, navigateBrowser,
   browserDownloadUrl, deleteBrowserDownload
 } from '../services/api';
+import BrailleSpinner from '../components/BrailleSpinner';
 import toast from '../components/ui/Toast';
 import { FormField } from '../components/ui/FormField';
 import { formatBytes, formatDateTime } from '../utils/formatters';
@@ -303,7 +304,7 @@ export default function BrowserPage() {
             </button>
           </div>
           <pre className="p-3 text-xs text-gray-400 font-mono overflow-auto max-h-64 whitespace-pre-wrap">
-            {logs || 'Loading...'}
+            {logs || <BrailleSpinner text="Loading logs" />}
           </pre>
         </div>
       )}

--- a/client/src/pages/Catalog.jsx
+++ b/client/src/pages/Catalog.jsx
@@ -17,6 +17,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { Sparkles, Plus, Search, FileInput, Loader2, RefreshCw, Wand2, X, LayoutGrid, Library, FolderPlus } from 'lucide-react';
+import BrailleSpinner from '../components/BrailleSpinner';
 import toast from '../components/ui/Toast';
 import {
   listCatalogIngredients,
@@ -878,7 +879,7 @@ export default function Catalog() {
                   className="absolute bottom-full mb-2 left-0 right-0 sm:left-auto sm:min-w-[220px] max-h-[60vh] sm:max-h-72 overflow-y-auto bg-port-card border border-port-border rounded-lg shadow-lg"
                 >
                   {placeTargetsLoading || placeTargets === null ? (
-                    <p className="px-3 py-2 text-sm text-gray-500">Loading…</p>
+                    <p className="px-3 py-2 text-sm"><BrailleSpinner text="Loading…" /></p>
                   ) : !hasPlaceTargets ? (
                     <p className="px-3 py-2 text-sm text-gray-500">No universes or series yet.</p>
                   ) : (

--- a/client/src/pages/CreativeCommissionDetail.jsx
+++ b/client/src/pages/CreativeCommissionDetail.jsx
@@ -15,6 +15,7 @@
 import { useEffect, useMemo, useRef, useState, useCallback } from 'react';
 import { useNavigate, useParams, useLocation, useSearchParams, Link } from 'react-router';
 import { ArrowLeft, Sparkles, Clock, Cpu, Zap, Pause, Play, Trash2 } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import { useConfirmDelete } from '../hooks/useConfirmDelete';
@@ -192,7 +193,11 @@ export default function CreativeCommissionDetail() {
   };
 
   if (loading && !commission) {
-    return <div className="max-w-6xl mx-auto text-gray-500 text-sm">Loading…</div>;
+    return (
+      <div className="max-w-6xl mx-auto">
+        <PageSkeleton label="Loading commission" titleWidthClass="w-56" cards={2} sidebar={false} />
+      </div>
+    );
   }
 
   if (notFound) {

--- a/client/src/pages/CreativeCommissions.jsx
+++ b/client/src/pages/CreativeCommissions.jsx
@@ -17,6 +17,7 @@
 import { useEffect, useMemo, useState, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { Plus, Sparkles, Trash2, Clock, Cpu, Pause, Play, Zap } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import Drawer from '../components/Drawer';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
@@ -143,7 +144,7 @@ export default function CreativeCommissions() {
       </div>
 
       {loading ? (
-        <div className="text-gray-500 text-sm">Loading…</div>
+        <PageSkeleton header="none" label="Loading commissions" cards={3} sidebar={false} />
       ) : sorted.length === 0 ? (
         <div className="border border-dashed border-port-border rounded-lg p-10 text-center">
           <Sparkles className="w-8 h-8 text-gray-600 mx-auto mb-3" />

--- a/client/src/pages/CreativeDirectorDetail.jsx
+++ b/client/src/pages/CreativeDirectorDetail.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router';
 import { ArrowLeft, Play, Pause, RefreshCw, SlidersHorizontal } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import {
   getCreativeDirectorProject,
@@ -172,7 +173,24 @@ export default function CreativeDirectorDetail() {
     }
   };
 
-  if (loading) return <div className="p-6 text-port-text-muted">Loading…</div>;
+  if (loading) {
+    return (
+      <PageSkeleton
+        header="bar"
+        label="Loading creative director project"
+        barClassName="px-6 pt-6 pb-3"
+        titleWidthClass="w-56"
+        showSubtitle
+        subtitleOnMobile
+        tabs={TABS.length}
+        tabsInBar
+        fullHeight
+        padded
+        bodyClassName="p-6"
+        cards={3}
+      />
+    );
+  }
   if (!project) return <div className="p-6 text-port-error">Project not found.</div>;
 
   const goTo = (tabId) => navigate(`/creative-director/${id}/${tabId}`);

--- a/client/src/pages/CreativeDirectorDetail.jsx
+++ b/client/src/pages/CreativeDirectorDetail.jsx
@@ -188,6 +188,7 @@ export default function CreativeDirectorDetail() {
         padded
         bodyClassName="p-6"
         cards={3}
+        sidebar={false}
       />
     );
   }

--- a/client/src/pages/Loras.jsx
+++ b/client/src/pages/Loras.jsx
@@ -10,6 +10,8 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router';
 import { Trash2, Download, ExternalLink, Sparkles, AlertTriangle, KeyRound, Check, X, RefreshCw, Wand2, Search } from 'lucide-react';
+import BrailleSpinner from '../components/BrailleSpinner';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import Modal from '../components/ui/Modal';
 import Banner from '../components/ui/Banner';
@@ -405,7 +407,7 @@ export default function Loras() {
           part of the video section. */}
       <div className="border-t border-port-border pt-6">
         <h2 className="text-lg font-semibold text-white mb-3">Installed</h2>
-        {loading && <div className="text-sm text-gray-500">Loading…</div>}
+        {loading && <PageSkeleton header="none" label="Loading installed LoRAs" layout="grid" cards={6} />}
         {error && (
           <Banner tone="error" size="md" icon={AlertTriangle} align="center">{error}</Banner>
         )}
@@ -789,8 +791,7 @@ function SuggestionsSection({ label, hint, cards, alwaysShow = false, runner = n
             disabled={loading}
             className="text-xs text-gray-300 hover:text-white px-4 py-1.5 rounded border border-port-border hover:border-port-accent/40 disabled:opacity-50 flex items-center gap-1.5"
           >
-            {loading ? <RefreshCw size={12} className="animate-spin" /> : <Download size={12} />}
-            {loading ? 'Loading…' : 'Load more'}
+            {loading ? <BrailleSpinner text="Loading…" /> : <><Download size={12} /> Load more</>}
           </button>
         </div>
       )}

--- a/client/src/pages/MediaCollectionDetail.jsx
+++ b/client/src/pages/MediaCollectionDetail.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router';
 import { ArrowLeft, CheckSquare, Copy, DatabaseZap, FolderInput, Inbox, Lock, Pencil, Star, StarOff, Trash2, X } from 'lucide-react';
 import ShareToButton from '../components/sharing/ShareToButton';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import MediaCard from '../components/media/MediaCard';
 import MediaPreview from '../components/media/MediaPreview';
@@ -294,7 +295,7 @@ export default function MediaCollectionDetail() {
     },
   });
 
-  if (loading) return <div className="text-gray-500 text-sm">Loading…</div>;
+  if (loading) return <PageSkeleton label="Loading collection" titleWidthClass="w-56" layout="grid" cards={6} />;
   if (!collection) return (
     <div className="text-gray-500 text-sm">
       <Link to="/media/collections" className="text-port-accent hover:underline">← Back to collections</Link>

--- a/client/src/pages/MediaCollectionDetail.jsx
+++ b/client/src/pages/MediaCollectionDetail.jsx
@@ -295,7 +295,17 @@ export default function MediaCollectionDetail() {
     },
   });
 
-  if (loading) return <PageSkeleton label="Loading collection" titleWidthClass="w-56" layout="grid" cards={6} />;
+  if (loading) {
+    return (
+      <PageSkeleton
+        label="Loading collection"
+        titleWidthClass="w-56"
+        layout="grid"
+        cards={10}
+        gridColsClass="grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+      />
+    );
+  }
   if (!collection) return (
     <div className="text-gray-500 text-sm">
       <Link to="/media/collections" className="text-port-accent hover:underline">← Back to collections</Link>

--- a/client/src/pages/MediaCollections.jsx
+++ b/client/src/pages/MediaCollections.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { Plus, FolderOpen, Inbox, Trash2, Image as ImageIcon, Film, Search } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import {
   listMediaCollections, createMediaCollection, deleteMediaCollection,
@@ -258,7 +259,7 @@ export default function MediaCollections() {
       </div>
 
       {loading ? (
-        <div className="text-gray-500 text-sm">Loading…</div>
+        <PageSkeleton header="none" label="Loading collections" cards={4} sidebar={false} />
       ) : (
         <div className="space-y-2">
           {/* Precedence chain, not independent gates. First run wins only when

--- a/client/src/pages/MediaHistory.jsx
+++ b/client/src/pages/MediaHistory.jsx
@@ -232,7 +232,7 @@ export default function MediaHistory() {
       </div>
 
       {loading ? (
-        <PageSkeleton header="none" label="Loading media history" layout="grid" cards={6} />
+        <PageSkeleton header="none" label="Loading media history" layout="grid" cards={10} gridColsClass="grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5" />
       ) : filtered.length === 0 ? (
         <div className="bg-port-card border border-port-border rounded-xl p-8 text-center text-gray-500 text-sm">
           {query.trim()

--- a/client/src/pages/MediaHistory.jsx
+++ b/client/src/pages/MediaHistory.jsx
@@ -7,6 +7,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { Combine, Image as ImageIcon, Film, Search, X } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import MediaCard from '../components/media/MediaCard';
 import MediaPreview from '../components/media/MediaPreview';
@@ -231,7 +232,7 @@ export default function MediaHistory() {
       </div>
 
       {loading ? (
-        <div className="text-gray-500 text-sm">Loading…</div>
+        <PageSkeleton header="none" label="Loading media history" layout="grid" cards={6} />
       ) : filtered.length === 0 ? (
         <div className="bg-port-card border border-port-border rounded-xl p-8 text-center text-gray-500 text-sm">
           {query.trim()

--- a/client/src/pages/MoodBoardDetail.jsx
+++ b/client/src/pages/MoodBoardDetail.jsx
@@ -12,6 +12,7 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router';
 import { ArrowLeft, ImageIcon, FileText, Trash2, Plus, Save, Link2, Unlink, RefreshCw } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import InlineConfirmRow from '../components/ui/InlineConfirmRow';
 import {
@@ -160,7 +161,7 @@ export default function MoodBoardDetail() {
   };
 
   if (loading) {
-    return <div className="text-gray-400 text-sm py-8 text-center">Loading…</div>;
+    return <PageSkeleton label="Loading mood board" titleWidthClass="w-56" layout="grid" cards={6} />;
   }
   if (!board) {
     return (

--- a/client/src/pages/MoodBoardDetail.jsx
+++ b/client/src/pages/MoodBoardDetail.jsx
@@ -161,7 +161,17 @@ export default function MoodBoardDetail() {
   };
 
   if (loading) {
-    return <PageSkeleton label="Loading mood board" titleWidthClass="w-56" layout="grid" cards={6} />;
+    return (
+      <div className="max-w-5xl mx-auto">
+        <PageSkeleton
+          label="Loading mood board"
+          titleWidthClass="w-56"
+          layout="grid"
+          cards={8}
+          gridColsClass="grid-cols-2 md:grid-cols-3 lg:grid-cols-4"
+        />
+      </div>
+    );
   }
   if (!board) {
     return (

--- a/client/src/pages/MoodBoards.jsx
+++ b/client/src/pages/MoodBoards.jsx
@@ -11,6 +11,7 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router';
 import { Plus, Palette, Trash2, ImageIcon, FileText } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import InlineConfirmRow from '../components/ui/InlineConfirmRow';
 import { timeAgo } from '../utils/formatters';
@@ -83,7 +84,7 @@ export default function MoodBoards() {
       </p>
 
       {loading ? (
-        <div className="text-gray-400 text-sm py-8 text-center">Loading…</div>
+        <PageSkeleton header="none" label="Loading mood boards" cards={3} sidebar={false} />
       ) : boards.length === 0 ? (
         <div className="text-gray-400 text-sm py-12 text-center border border-dashed border-port-border rounded">
           No mood boards yet. Create one to start pinning references.

--- a/client/src/pages/PipelineSeriesRoadmap.jsx
+++ b/client/src/pages/PipelineSeriesRoadmap.jsx
@@ -16,6 +16,7 @@ import { Link, useParams, useNavigate, useSearchParams } from 'react-router';
 import {
   ArrowLeft, Loader2, Sparkles, ChevronRight, ChevronDown, AlertTriangle, Crown, ChartSpline, Users, Swords,
 } from 'lucide-react';
+import BrailleSpinner from '../components/BrailleSpinner';
 import toast from '../components/ui/Toast';
 import { ArcRoadmapChart } from '../components/pipeline/ArcCanvas';
 import ReaderPanelView from '../components/pipeline/ReaderPanelView';
@@ -148,7 +149,7 @@ function IssueRow({ entry, quality, onAnalyze, analyzing }) {
       {open && entry.analyzed ? (
         <div className="border-t border-port-border p-2.5">
           {loadingDetail ? (
-            <div className="text-xs text-gray-500 flex items-center gap-1.5"><Loader2 size={12} className="animate-spin" /> Loading…</div>
+            <div className="text-xs"><BrailleSpinner text="Loading…" /></div>
           ) : detail?.sections?.length ? (
             <ul className="space-y-1.5">
               {detail.sections.map((s, i) => <SectionRow key={s.id ?? `${s.title ?? 'section'}-${i}`} section={s} index={i} />)}

--- a/client/src/pages/RunsHistoryPage.jsx
+++ b/client/src/pages/RunsHistoryPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router';
 import { Trash2, RotateCcw, MessageSquarePlus, ScrollText } from 'lucide-react';
 import * as api from '../services/api';
 import { formatTime, formatRuntime, formatBytes, formatDateTime } from '../utils/formatters';
+import BrailleSpinner from '../components/BrailleSpinner';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import Banner from '../components/ui/Banner';
 import ProcessLogModal from '../components/ui/ProcessLogModal';
@@ -381,7 +382,7 @@ export function RunsHistoryPage() {
                         <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">Prompt</div>
                         <div className="bg-port-card border border-port-border rounded-lg p-3 max-h-48 overflow-auto">
                           <pre className="text-sm text-gray-300 font-mono whitespace-pre-wrap break-all">
-                            {expandedDetails[run.id]?.prompt || run.prompt || 'Loading...'}
+                            {expandedDetails[run.id]?.prompt || run.prompt || <BrailleSpinner text="Loading prompt" />}
                           </pre>
                         </div>
                       </div>

--- a/client/src/pages/Sharing.jsx
+++ b/client/src/pages/Sharing.jsx
@@ -12,6 +12,7 @@ import { useParams, useNavigate, Link } from 'react-router';
 import {
   Share2, Plus, Trash2, Folder, Inbox, History, Save, Loader2, Check, X, Users, AlertCircle, RefreshCw, Copy, GitMerge,
 } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import InlineConfirmRow from '../components/ui/InlineConfirmRow';
 import { FormField } from '../components/ui/FormField';
@@ -434,7 +435,7 @@ function SharingBuckets({ selectedId }) {
         {/* Bucket list */}
         <aside>
           {loading ? (
-            <div className="text-gray-500 text-sm">Loading…</div>
+            <PageSkeleton header="none" label="Loading buckets" cards={3} sidebar={false} />
           ) : buckets.length === 0 ? (
             <div className="p-4 bg-port-card border border-port-border rounded-lg text-sm text-gray-500">
               No buckets yet. Click <span className="text-port-accent">Add bucket</span> to register a synced folder.

--- a/client/src/pages/Sprites.jsx
+++ b/client/src/pages/Sprites.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router';
 import { PersonStanding, LayoutGrid, Images, Scissors, Film } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import {
   listSpriteRecords, getSpriteRecord,
@@ -439,7 +440,7 @@ export default function Sprites() {
           {!id ? (
             // The bare /sprites route IS the Library catalog now.
             records === null ? (
-              <p className="text-sm text-gray-500">Loading…</p>
+              <PageSkeleton header="none" label="Loading sprite library" layout="grid" cards={6} />
             ) : records.length === 0 ? (
               <p className="text-sm text-gray-500">
                 No sprites yet. Import a production set from a sprite-pipeline checkout to get started.
@@ -464,7 +465,7 @@ export default function Sprites() {
               <button onClick={() => setRetryTick((t) => t + 1)} className="text-port-accent hover:underline">Retry</button>
             </div>
           ) : !detail ? (
-            <p className="text-sm text-gray-500">Loading…</p>
+            <PageSkeleton header="none" label="Loading sprite" cards={3} sidebar={false} />
           ) : (
             <div className="space-y-4">
               <SpriteDetailHeader

--- a/client/src/pages/Sprites.jsx
+++ b/client/src/pages/Sprites.jsx
@@ -440,7 +440,13 @@ export default function Sprites() {
           {!id ? (
             // The bare /sprites route IS the Library catalog now.
             records === null ? (
-              <PageSkeleton header="none" label="Loading sprite library" layout="grid" cards={6} />
+              <PageSkeleton
+                header="none"
+                label="Loading sprite library"
+                layout="grid"
+                cards={10}
+                gridColsClass="grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
+              />
             ) : records.length === 0 ? (
               <p className="text-sm text-gray-500">
                 No sprites yet. Import a production set from a sprite-pipeline checkout to get started.

--- a/client/src/pages/StoryBuilder.jsx
+++ b/client/src/pages/StoryBuilder.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams, useLocation, Link } from 'react-router';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import { filterSelectableModels } from '../utils/providers';
 import { composeCanonStyledPrompt } from '../lib/composeStyledPrompt';
 import { descriptorForCanonEntry } from '../lib/canonPrompt';
@@ -1307,7 +1308,7 @@ function StoryBuilderDetail({ storyId, stepParam }) {
     toast.success('Re-baselined to this machine');
   };
 
-  if (loading) return <div className="p-6 text-gray-400 flex items-center gap-2"><Loader2 className="w-5 h-5 animate-spin" /> Loading…</div>;
+  if (loading) return <PageSkeleton label="Loading story session" padded fullHeight titleWidthClass="w-64" cards={3} sidebar={false} />;
   if (!session) return <div className="p-6 text-gray-400">Session not found. <Link to="/story-builder" className="text-port-accent">Back to Story Builder</Link></div>;
 
   return (

--- a/client/src/pages/StoryBuilder.jsx
+++ b/client/src/pages/StoryBuilder.jsx
@@ -1308,7 +1308,15 @@ function StoryBuilderDetail({ storyId, stepParam }) {
     toast.success('Re-baselined to this machine');
   };
 
-  if (loading) return <PageSkeleton label="Loading story session" padded fullHeight titleWidthClass="w-64" cards={3} sidebar={false} />;
+  if (loading) {
+    return (
+      <div className="h-full overflow-y-auto p-4 md:p-6">
+        <div className="max-w-5xl mx-auto">
+          <PageSkeleton label="Loading story session" titleWidthClass="w-64" cards={3} sidebar={false} />
+        </div>
+      </div>
+    );
+  }
   if (!session) return <div className="p-6 text-gray-400">Session not found. <Link to="/story-builder" className="text-port-accent">Back to Story Builder</Link></div>;
 
   return (

--- a/client/src/pages/ThreejsModelDetail.jsx
+++ b/client/src/pages/ThreejsModelDetail.jsx
@@ -121,7 +121,13 @@ export default function ThreejsModelDetail() {
     if (ok) navigate('/media/threejs');
   };
 
-  if (loading) return <PageSkeleton label="Loading model" titleWidthClass="w-56" cards={2} sidebar={false} />;
+  if (loading) {
+    return (
+      <div className="mx-auto max-w-7xl">
+        <PageSkeleton label="Loading model" titleWidthClass="w-56" cards={2} sidebar={false} />
+      </div>
+    );
+  }
   if (notFound || !record) {
     return (
       <div className="py-12 text-center">

--- a/client/src/pages/ThreejsModelDetail.jsx
+++ b/client/src/pages/ThreejsModelDetail.jsx
@@ -4,6 +4,7 @@ import { Link, useNavigate, useParams } from 'react-router';
 import MediaImage from '../components/MediaImage';
 import ProviderModelSelector from '../components/ProviderModelSelector';
 import ThreejsModelPreview from '../components/threejsModels/ThreejsModelPreview';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import InlineConfirmRow from '../components/ui/InlineConfirmRow';
 import useProviderModels from '../hooks/useProviderModels';
 import {
@@ -120,7 +121,7 @@ export default function ThreejsModelDetail() {
     if (ok) navigate('/media/threejs');
   };
 
-  if (loading) return <div className="py-10 text-center text-sm text-gray-500">Loading…</div>;
+  if (loading) return <PageSkeleton label="Loading model" titleWidthClass="w-56" cards={2} sidebar={false} />;
   if (notFound || !record) {
     return (
       <div className="py-12 text-center">

--- a/client/src/pages/ThreejsModels.jsx
+++ b/client/src/pages/ThreejsModels.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Box, ImagePlus, LoaderCircle, Sparkles } from 'lucide-react';
 import { Link, useNavigate, useSearchParams } from 'react-router';
 import GalleryImagePicker from '../components/imageGen/GalleryImagePicker';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import MediaImage from '../components/MediaImage';
 import ProviderModelSelector from '../components/ProviderModelSelector';
 import useProviderModels from '../hooks/useProviderModels';
@@ -191,7 +192,7 @@ export default function ThreejsModels() {
       <section>
         <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-400">Model workspaces</h2>
         {loading ? (
-          <div className="py-8 text-center text-sm text-gray-500">Loading…</div>
+          <PageSkeleton header="none" label="Loading model workspaces" layout="grid" cards={3} />
         ) : models.length === 0 ? (
           <div className="rounded-xl border border-dashed border-port-border py-10 text-center text-sm text-gray-500">
             No procedural models yet.

--- a/client/src/pages/ThreejsModels.jsx
+++ b/client/src/pages/ThreejsModels.jsx
@@ -192,7 +192,7 @@ export default function ThreejsModels() {
       <section>
         <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-400">Model workspaces</h2>
         {loading ? (
-          <PageSkeleton header="none" label="Loading model workspaces" layout="grid" cards={3} />
+          <PageSkeleton header="none" label="Loading model workspaces" layout="grid" cards={3} gridColsClass="sm:grid-cols-2 lg:grid-cols-3" />
         ) : models.length === 0 ? (
           <div className="rounded-xl border border-dashed border-port-border py-10 text-center text-sm text-gray-500">
             No procedural models yet.

--- a/client/src/pages/Timeline.jsx
+++ b/client/src/pages/Timeline.jsx
@@ -4,6 +4,7 @@ import {
   CalendarClock, ChevronLeft, ChevronRight, Mail, MailOpen, Send,
   CalendarDays, Music, Play, MessageSquare, Activity, MapPin, Globe,
 } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import PageHeader from '../components/PageHeader';
 import SpotifyImportPanel from '../components/timeline/SpotifyImportPanel';
 import TakeoutLocationImportPanel from '../components/timeline/TakeoutLocationImportPanel';
@@ -236,7 +237,7 @@ export default function Timeline() {
       </div>
 
       {loading ? (
-        <div className="py-12 text-center text-gray-500">Loading…</div>
+        <PageSkeleton header="none" label="Loading timeline" cards={4} sidebar={false} />
       ) : events.length === 0 ? (
         <div className="rounded border border-dashed border-port-border py-12 text-center text-gray-500">
           No recorded activity on this day.

--- a/client/src/pages/VideoDownloaderPage.jsx
+++ b/client/src/pages/VideoDownloaderPage.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Download, Film, Loader2, Trash2, ExternalLink, Video } from 'lucide-react';
+import BrailleSpinner from '../components/BrailleSpinner';
 import toast from '../components/ui/Toast';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import { useVideoDownload, useConfirmDelete } from '../hooks';
@@ -107,9 +108,7 @@ export default function VideoDownloaderPage() {
       <section>
         <h2 className="text-sm font-semibold text-gray-300 mb-2">Downloaded ({downloads.length})</h2>
         {loading ? (
-          <p className="text-sm text-gray-500 flex items-center gap-2">
-            <Loader2 size={14} className="animate-spin" /> Loading…
-          </p>
+          <p className="text-sm"><BrailleSpinner text="Loading…" /></p>
         ) : downloads.length === 0 ? (
           <p className="text-sm text-gray-500">No videos downloaded yet.</p>
         ) : (

--- a/client/src/pages/VideoTimeline.jsx
+++ b/client/src/pages/VideoTimeline.jsx
@@ -87,7 +87,7 @@ export default function VideoTimeline() {
         </button>
       </form>
 
-      {loading && <PageSkeleton header="none" label="Loading timeline projects" layout="grid" cards={3} />}
+      {loading && <PageSkeleton header="none" label="Loading timeline projects" layout="grid" cards={3} gridColsClass="sm:grid-cols-2 lg:grid-cols-3" />}
 
       {!loading && projects.length === 0 && (
         <div className="text-center py-12 text-gray-500">

--- a/client/src/pages/VideoTimeline.jsx
+++ b/client/src/pages/VideoTimeline.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import { Plus, Film, Trash2, Clock } from 'lucide-react';
+import PageSkeleton from '../components/ui/PageSkeleton';
 import toast from '../components/ui/Toast';
 import * as api from '../services/api';
 import { formatDurationSec } from '../utils/formatters';
@@ -86,9 +87,7 @@ export default function VideoTimeline() {
         </button>
       </form>
 
-      {loading && (
-        <div className="text-gray-500 text-sm">Loading…</div>
-      )}
+      {loading && <PageSkeleton header="none" label="Loading timeline projects" layout="grid" cards={3} />}
 
       {!loading && projects.length === 0 && (
         <div className="text-center py-12 text-gray-500">

--- a/client/src/pages/WorkspaceContexts.jsx
+++ b/client/src/pages/WorkspaceContexts.jsx
@@ -2,8 +2,9 @@ import { useState, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import {
   Layers, GitBranch, SquareTerminal, ListChecks, Save, RotateCcw,
-  Trash2, RefreshCw, FolderGit2, AlertCircle, CheckCircle2, ArrowRight
+  Trash2, FolderGit2, AlertCircle, CheckCircle2, ArrowRight
 } from 'lucide-react';
+import BrailleSpinner from '../components/BrailleSpinner';
 import toast from '../components/ui/Toast';
 import { useAsyncAction } from '../hooks/useAsyncAction';
 import { timeAgo } from '../utils/formatters';
@@ -67,7 +68,7 @@ function ContextDetail({ appId }) {
   }, { errorMessage: 'Failed to clear context' });
 
   if (loading) {
-    return <div className="text-gray-500 text-sm flex items-center gap-2"><RefreshCw size={14} className="animate-spin" /> Loading…</div>;
+    return <div className="text-sm"><BrailleSpinner text="Loading…" /></div>;
   }
   if (!ctx) return null;
 
@@ -208,7 +209,7 @@ function ContextList() {
   useEffect(() => { load(); }, [load]);
 
   if (loading) {
-    return <div className="text-gray-500 text-sm flex items-center gap-2"><RefreshCw size={14} className="animate-spin" /> Loading projects…</div>;
+    return <div className="text-sm"><BrailleSpinner text="Loading projects…" /></div>;
   }
 
   if (rows.length === 0) {


### PR DESCRIPTION
## Summary

~35 client views rendered a bare `Loading...` / `Loading…` text node with no visual loading affordance, while the rest of the app already used `client/src/components/BrailleSpinner.jsx` or `client/src/components/ui/PageSkeleton.jsx`. On a slow or first load those read as unstyled/broken content rather than a deliberate loading state.

This is a per-site judgment pass, not a mechanical sed:

- **`BrailleSpinner`** for small/indeterminate inline loads — button labels (Refresh / Load More / Browse Feed / Load Samples / Refresh models), narrow master-detail side lists (Artists / Albums / Tracks / Authors), popover and menu bodies (Catalog place-target menu, media collection picker), the Sync drawer subtitle, and `<pre>` fallbacks (Browser logs, runs-history prompt).
- **`PageSkeleton`** wherever the eventual content has a predictable shape, so the first paint reserves its dimensions instead of reflowing — full-page early returns (Creative Commission detail, Creative Director detail, Media Collection detail, Mood Board detail, Story Builder, Three.js model detail) and card list/grid body regions under an already-rendered header (`header="none"`: Creative Commissions, Media Collections, Media History, Mood Boards, Sharing, Sprites, Three.js models, Timeline, Video Timeline, installed LoRAs).

`PageSkeleton` brings `role="status"` + `aria-busy` + a specific `label` ("Loading commissions", "Loading sprite library", …) with it, so those regions now announce what is loading instead of being silent. Creative Director detail's skeleton mirrors that page's actual shell — bordered header bar with the tab strip nested inside it, full-height, `p-6` body.

While in each file, several hand-rolled `Loader2`/`RefreshCw` + `animate-spin` one-offs that sat next to the same text collapsed onto the shared components (Catalog album, POV rewrite panel, Sync detail drawer, Ask, Pipeline series roadmap, Video downloader, Workspace contexts, LoRA "Load more"). The pipeline AudioStage music-library panel also lost its header spinner, which always rendered simultaneously with the body one — a duplicate indicator for a single fetch.

Two `Loading…` sites are deliberately left alone:

- `components/dashboard/WidgetSkeleton.jsx` already **is** a skeleton (`animate-pulse` + `role="status"` + `aria-label`); its text is the widget label, not a bare fallback.
- `components/loraTraining/UniverseCharacterPicker.jsx` renders its "Loading…" inside a native `<option>`, which cannot host a component.

No new components, no changes to `BrailleSpinner` / `PageSkeleton` themselves, no hardcoded colors — the spinner uses the existing `text-port-accent` token and the skeleton the existing `bg-port-card` / `border-port-border` tokens.

Closes #3449

## Test plan

- `cd client && npm test` → **534 files / 6184 tests passed** (run before and after the AudioStage cleanup; the pipeline subset re-ran green after).
- `cd client && npm run lint` → clean (caught one now-unused `RefreshCw` import in `WorkspaceContexts.jsx`, removed).
- `grep -rn "Loading\.\.\.\|Loading…" client/src --include='*.jsx'` now returns only comments, the two intentional exceptions above, and test titles.
- No test asserted on the removed literal text, so no test changes were needed; `AnimationTypesDrawer.test.jsx`'s `getByText(/Loading…/)` still matches because `BrailleSpinner` renders the frame and label in one text node.


## Known limitation

`PageSkeleton` only expresses a RIGHT-hand 360px sidebar, so the left-side rails on Three.js model detail (240px) and Story Builder (220px) are not reserved — those two skeletons match the page max-width and card stack but not the rail. Everything else reserves the page's real `gridColsClass` and container width.
