### PR TITLE
fix: resolve low contrast overlays in day-mode themes

### DIFF
--- a/client/src/components/apps/DeployPanel.jsx
+++ b/client/src/components/apps/DeployPanel.jsx
@@ -151,7 +151,7 @@ export default function DeployPanel({ appId, appName }) {
 
           <div
             ref={outputRef}
-            className="flex-1 overflow-auto p-4 font-mono text-xs leading-relaxed bg-black/40"
+            className="always-dark flex-1 overflow-auto p-4 font-mono text-xs leading-relaxed bg-black/40"
           >
             {output.map((line, i) => (
               <div

--- a/client/src/components/apps/EditAppDrawer.jsx
+++ b/client/src/components/apps/EditAppDrawer.jsx
@@ -585,7 +585,7 @@ export default function EditAppDrawer({ app, onClose, onSave }) {
                         Wire it up in your server entry:
                       </div>
                       <div className="relative">
-                        <pre className="bg-black/40 text-gray-200 p-2 rounded overflow-x-auto font-mono text-[11px] leading-tight">{tlsResult.snippet}</pre>
+                        <pre className="always-dark bg-black/40 text-gray-200 p-2 rounded overflow-x-auto font-mono text-[11px] leading-tight">{tlsResult.snippet}</pre>
                         <button
                           type="button"
                           onClick={() => copyToClipboard(tlsResult.snippet, 'Snippet copied')}

--- a/client/src/components/creative-director/ProjectPreview.jsx
+++ b/client/src/components/creative-director/ProjectPreview.jsx
@@ -137,13 +137,13 @@ export default function ProjectPreview({ project, to }) {
           onClick={() => setPlaying(true)}
           aria-label={`Play ${preview.label}`}
           title={`Play ${preview.label}`}
-          className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-10 h-10 flex items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/80 focus:outline-none focus:ring-2 focus:ring-port-accent"
+          className="always-dark absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-10 h-10 flex items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/80 focus:outline-none focus:ring-2 focus:ring-port-accent"
         >
           <Play className="w-4 h-4" aria-hidden="true" />
         </button>
       )}
       {preview.kind !== 'none' && (
-        <span className="absolute bottom-1 left-1 px-1.5 py-0.5 rounded bg-black/60 text-white text-[10px] pointer-events-none">
+        <span className="always-dark absolute bottom-1 left-1 px-1.5 py-0.5 rounded bg-black/60 text-white text-[10px] pointer-events-none">
           {preview.label}
         </span>
       )}

--- a/client/src/components/creative-director/ScenePreview.jsx
+++ b/client/src/components/creative-director/ScenePreview.jsx
@@ -132,7 +132,7 @@ export default function ScenePreview({ jobId, label, aspectClass = 'aspect-video
         rel="noopener noreferrer"
         aria-label={`Open ${label} in new tab`}
         title="Open video in new tab"
-        className="absolute top-1 right-1 p-1 rounded bg-black/50 text-white hover:bg-black/80"
+        className="always-dark absolute top-1 right-1 p-1 rounded bg-black/50 text-white hover:bg-black/80"
       >
         <ExternalLink className="w-3 h-3" />
       </a>

--- a/client/src/components/threejsModels/ThreejsModelPreview.jsx
+++ b/client/src/components/threejsModels/ThreejsModelPreview.jsx
@@ -161,7 +161,7 @@ export default function ThreejsModelPreview({ spec, className = '' }) {
       >
         <ProceduralScene spec={spec} background={background} />
       </Canvas>
-      <div className="absolute left-2 top-2 flex max-w-[calc(100%-1rem)] flex-wrap items-center gap-1.5 rounded-lg bg-black/70 px-2 py-1.5 text-[10px] text-gray-300 backdrop-blur-sm">
+      <div className="always-dark absolute left-2 top-2 flex max-w-[calc(100%-1rem)] flex-wrap items-center gap-1.5 rounded-lg bg-black/70 px-2 py-1.5 text-[10px] text-gray-300 backdrop-blur-sm">
         <span className="mr-1 whitespace-nowrap text-gray-400">Background</span>
         <div className="flex flex-wrap gap-1" role="radiogroup" aria-label="Preview background">
           {BACKGROUND_PRESETS.map((preset) => (
@@ -188,7 +188,7 @@ export default function ThreejsModelPreview({ spec, className = '' }) {
           />
         </label>
       </div>
-      <div className="pointer-events-none absolute bottom-2 left-2 rounded bg-black/60 px-2 py-1 text-[10px] text-gray-300">
+      <div className="always-dark pointer-events-none absolute bottom-2 left-2 rounded bg-black/60 px-2 py-1 text-[10px] text-gray-300">
         Drag to orbit · scroll to zoom
       </div>
     </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -832,6 +832,27 @@ html[data-port-theme-mode="day"] [class~="hover:text-slate-100"]:hover {
   color: rgb(var(--port-text)) !important;
 }
 
+/* Keep text contrast on always-dark panels (e.g. video overlays, 3D canvas control panels, HUDs) in day mode */
+html[data-port-theme-mode="day"] .always-dark :is(.text-white, .text-zinc-50, .text-zinc-100, .text-neutral-50, .text-neutral-100, .text-gray-50, .text-gray-100, .text-slate-50, .text-slate-100) {
+  color: rgb(255 255 255) !important;
+}
+html[data-port-theme-mode="day"] .always-dark :is(.text-zinc-200, .text-zinc-300, .text-neutral-200, .text-neutral-300, .text-gray-200, .text-gray-300, .text-slate-200, .text-slate-300) {
+  color: rgb(212 212 216) !important;
+}
+html[data-port-theme-mode="day"] .always-dark :is(.text-zinc-400, .text-zinc-500, .text-neutral-400, .text-neutral-500, .text-gray-400, .text-gray-500, .text-slate-400, .text-slate-500) {
+  color: rgb(161 161 170) !important;
+}
+html[data-port-theme-mode="day"] .always-dark [class~="hover:text-white"]:hover,
+html[data-port-theme-mode="day"] .always-dark [class~="hover:text-zinc-100"]:hover,
+html[data-port-theme-mode="day"] .always-dark [class~="hover:text-neutral-100"]:hover,
+html[data-port-theme-mode="day"] .always-dark [class~="hover:text-gray-100"]:hover,
+html[data-port-theme-mode="day"] .always-dark [class~="hover:text-slate-100"]:hover {
+  color: rgb(255 255 255) !important;
+}
+html[data-port-theme-mode="day"] .always-dark [class~="aria-pressed:text-white"][aria-pressed="true"] {
+  color: rgb(255 255 255) !important;
+}
+
 /* === City (formerly CyberCity) HUD theming ===
    Class/id names keep the `cybercity` slug as a stable internal contract; the
    feature is branded "City" in the UI.


### PR DESCRIPTION
Fixes low-contrast text in overlays on the Phosphor Paper and other day-mode themes. Overrides the day-mode text remapping rules using a custom '.always-dark' utility class.