### PR TITLE
count commits as evidence of work so release/PR agents stop failing on a clean tree

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+## Fixed
+
+- CoS agents whose deliverable is a **commit** are no longer scored as failures. The idle reaper's "did this agent do anything?" gate read only *uncommitted* changes, so a `/do:release` or `/do:pr` run that committed, pushed, and opened its PR — leaving a clean tree *because it succeeded* — was recorded as `idle-no-changes` and retried. Two consecutive release runs on 2026-08-08 each did their whole job (cut the release commit, opened the release PR, then repaired it against review findings) and were both reported failed, holding the release for two days. The gate now counts commits made inside the run window as evidence of work, alongside a dirty tree. The report-shaped half of the same problem (`/do:review`, `/do:scan`, `/do:plan-task`, `/do:replan`, whose deliverable lands outside the repo) is tracked in #3636, and the unsatisfiable `[task-<id>]` success criterion one layer up in #3637.

--- a/server/services/agentErrorAnalysis.js
+++ b/server/services/agentErrorAnalysis.js
@@ -586,7 +586,7 @@ export const COMPLETION_REASON_ANALYSES = {
     category: 'no-changes',
     actionable: false,
     message: 'Agent idled out with no file changes',
-    suggestedFix: 'The agent stopped producing output before writing any files. Check the raw transcript for where it stalled — a provider retry loop or a long-running command can outlast the idle reaper.'
+    suggestedFix: 'The agent stopped producing output without writing any files OR committing anything during the run. Check the raw transcript for where it stalled — a provider retry loop or a long-running command can outlast the idle reaper.'
   },
   'idle-no-activity': {
     category: 'startup-failure',

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -13,7 +13,7 @@ import * as shellService from './shell.js';
 import { emitLog } from './cosEvents.js';
 import { updateAgent } from './cosAgentLifecycle.js';
 import { createOutputSpooler } from './agentTuiSpawning/outputSpooler.js';
-import { captureWorktreeDiff, worktreeHasChanges, resolveErrorAnalysis } from './agentTuiSpawning/finalizeHelpers.js';
+import { captureWorktreeDiff, worktreeHasWorkEvidence, resolveErrorAnalysis } from './agentTuiSpawning/finalizeHelpers.js';
 import { finalizeAgent, releaseAgentLane } from './agentFinalization.js';
 import { activeAgents, userTerminatedAgents, pausedAgents, isFalsyMeta, registerSpawnedAgent, unregisterSpawnedAgent } from './agentState.js';
 import { PATHS } from '../lib/fileUtils.js';
@@ -100,8 +100,9 @@ const CONNECTIVITY_RECHECK_MS = 10000;
 const CONNECTIVITY_PROBE_LEAD_MS = 20000;
 
 // Output buffering/spooling (createOutputSpooler) and failure-analysis /
-// worktree-inspection helpers (readFileTail, worktreeHasChanges,
-// captureWorktreeDiff, resolveErrorAnalysis, RAW_TAIL_ANALYSIS_BYTES) live in
+// worktree-inspection helpers (readFileTail, worktreeHasChanges, commitsSince,
+// worktreeHasWorkEvidence, captureWorktreeDiff, resolveErrorAnalysis,
+// RAW_TAIL_ANALYSIS_BYTES) live in
 // ./agentTuiSpawning/ so spawnTuiAgent stays a thin orchestrator.
 
 // Sentinel-file polling. TUI agents write `.agent-done` in their workspace
@@ -1443,6 +1444,9 @@ export async function spawnTuiAgent({
         // An agent that shows activity counters but makes no file changes
         // (rambled, invalid tool calls, hit an error) should fail, not succeed.
         //
+        // "Evidence of work" is a dirty tree OR a commit made during the run,
+        // not a dirty tree alone — see worktreeHasWorkEvidence for why.
+        //
         // ...UNLESS the task declares its work product isn't files (#3102).
         // `worktreeChangesExpected: false` marks a task type whose deliverable
         // lands OUTSIDE the repo — a reference-watch run against a GitHub/GitLab/
@@ -1453,7 +1457,7 @@ export async function spawnTuiAgent({
         // distinguishes "prompt never submitted" → idle-no-activity either way.
         const worktreeChangesExpected = !isFalsyMeta(task?.metadata?.worktreeChangesExpected);
         (async () => {
-          const hasChanges = !worktreeChangesExpected || await worktreeHasChanges(cwd);
+          const hasChanges = !worktreeChangesExpected || await worktreeHasWorkEvidence(cwd, startedAt);
           // Capture any uncommitted changes for post-mortem analysis regardless
           // of outcome — the diff is useful even on success for debugging, and is
           // a no-op on a clean tree.
@@ -1462,7 +1466,7 @@ export async function spawnTuiAgent({
             finish({
               success: false,
               exitCode: 1,
-              error: 'TUI agent idled out with zero uncommitted file changes — the model may have processed but produced no work.',
+              error: 'TUI agent idled out with zero uncommitted file changes and no new commits — the model may have processed but produced no work.',
               reason: 'idle-no-changes',
             }).catch(err => {
               emitLog('error', `Failed to finalize TUI agent ${agentId}: ${err.message}`, { agentId });

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -94,6 +94,10 @@ vi.mock('./git.js', () => ({
   // to exercise the idle-no-changes failure path override via mockResolvedValueOnce.
   getStatus: vi.fn().mockResolvedValue({ clean: false, files: [{ path: 'file.txt', status: 'M' }] }),
   getDiff: vi.fn().mockResolvedValue('diff content here'),
+  // `git rev-list --count --since=…` for the commit half of the work-evidence
+  // probe. Default: zero commits during the run, so a clean tree still fails —
+  // the commit-and-push test overrides this to a non-zero count.
+  execGit: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '0\n', stderr: '' }),
   // No owner-matched gh account by default → empty overlay (ambient auth kept).
   resolveForgeTokenEnv: vi.fn().mockResolvedValue({}),
 }));
@@ -558,6 +562,7 @@ describe('spawnTuiAgent runtime', () => {
     // Tests that want to exercise the idle-no-changes failure path override this.
     vi.mocked(gitService.getStatus).mockResolvedValue({ clean: false, files: [{ path: 'file.txt', status: 'M' }] });
     vi.mocked(gitService.getDiff).mockResolvedValue('diff content here');
+    vi.mocked(gitService.execGit).mockResolvedValue({ exitCode: 0, stdout: '0\n', stderr: '' });
 
     // Reset input-recency state: no input recorded by default. The
     // recent-input test overrides this — clearAllMocks doesn't undo a
@@ -1012,6 +1017,33 @@ describe('spawnTuiAgent runtime', () => {
 
     expect(agentLifecycle.finalizeAgent).toHaveBeenCalledWith(
       expect.objectContaining({ success: false, completionReason: 'idle-no-changes' })
+    );
+  });
+
+  // ── 1a-quinquies. A COMMIT during the run is evidence of work ────────────────
+  // The #2191 gate above read only UNCOMMITTED changes, so a job whose
+  // deliverable is a commit — `/do:release`, `/do:pr` — idled out on a clean
+  // tree *because it succeeded* and was scored a failure. Rationale and the
+  // 2026-08-08 release incident: worktreeHasWorkEvidence. The clean-tree +
+  // zero-commit failure stays covered by the sibling tests above, which run on
+  // the beforeEach default of `rev-list --count` → 0.
+  it('idle-complete: a commit made during the run counts as work on a clean tree (release/do:pr jobs)', async () => {
+    vi.mocked(gitService.execGit).mockResolvedValue({ exitCode: 0, stdout: '2\n', stderr: '' });
+    await driveIdleWithWorkOnCleanTree();
+
+    expect(agentLifecycle.finalizeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: 'agent-1',
+        success: true,
+        completionReason: 'idle-complete',
+      })
+    );
+    // The probe is scoped to the run window by committer date, so commits that
+    // were already on the branch at spawn can't launder a no-op into a success.
+    expect(gitService.execGit).toHaveBeenCalledWith(
+      ['rev-list', '--count', expect.stringMatching(/^--since=\d{4}-/), 'HEAD'],
+      '/tmp/ws',
+      { ignoreExitCode: true }
     );
   });
 

--- a/server/services/agentTuiSpawning/finalizeHelpers.js
+++ b/server/services/agentTuiSpawning/finalizeHelpers.js
@@ -41,6 +41,54 @@ export async function worktreeHasChanges(workspacePath) {
 }
 
 /**
+ * Count commits reachable from HEAD whose COMMITTER date falls inside the run
+ * window. `git rev-list --since` filters on committer date, which is what makes
+ * this a usable "did this agent commit anything?" probe: commits the agent
+ * created (or rewrote via rebase) are stamped now, while commits merely pulled
+ * in from the remote keep the committer date they were written with — usually
+ * before the run started, so they don't count as this agent's work.
+ *
+ * Non-throwing: a repo with no commits yet (`rev-list HEAD` fails), a detached
+ * or broken checkout, or a git timeout all return 0.
+ */
+export async function commitsSince(workspacePath, sinceMs) {
+  if (!workspacePath || typeof workspacePath !== 'string') return 0;
+  if (!Number.isFinite(sinceMs)) return 0;
+  const since = new Date(sinceMs).toISOString();
+  // `ignoreExitCode` so a repo with no HEAD resolves to a non-zero exit we can
+  // read as "no commits" rather than rejecting — the house convention for
+  // probe-shaped git calls (see git.js `isRepo` / `getRemote`).
+  const result = await git
+    .execGit(['rev-list', '--count', `--since=${since}`, 'HEAD'], workspacePath, { ignoreExitCode: true })
+    .catch(() => null);
+  if (!result || result.exitCode !== 0) return 0;
+  const count = parseInt(result.stdout.trim(), 10);
+  return Number.isFinite(count) ? count : 0;
+}
+
+/**
+ * Did this agent leave any evidence of work behind? Dirty tree OR at least one
+ * commit made during the run.
+ *
+ * The commit half is what makes this correct for jobs whose deliverable is a
+ * COMMIT rather than a dirty tree — `/do:release` and `/do:pr` runs commit,
+ * push, and open a PR, so by the time they idle the tree is clean *because they
+ * succeeded*. Gating on `worktreeHasChanges` alone scored those as
+ * `idle-no-changes` failures: two consecutive release runs on 2026-08-08 each
+ * cut the release commit and opened/repaired the release PR, were reported as
+ * failures, and the task retried — holding the release for two days.
+ *
+ * Accepted trade-off: a run that pulls in a merge commit another agent pushed
+ * mid-run sees that commit stamped inside the window and counts it as work.
+ * That false success is rarer, and far cheaper, than failing every
+ * commit-and-push job.
+ */
+export async function worktreeHasWorkEvidence(workspacePath, sinceMs) {
+  if (await worktreeHasChanges(workspacePath)) return true;
+  return (await commitsSince(workspacePath, sinceMs)) > 0;
+}
+
+/**
  * Capture the git diff (staged + unstaged) from a worktree and save it to the
  * agent archive dir. Called before worktree cleanup so post-mortems can see
  * what changes existed even if the worktree is deleted. Non-throwing — a

--- a/server/services/agentTuiSpawning/finalizeHelpers.test.js
+++ b/server/services/agentTuiSpawning/finalizeHelpers.test.js
@@ -8,6 +8,7 @@ import { join } from 'path';
 vi.mock('../git.js', () => ({
   getStatus: vi.fn(),
   getDiff: vi.fn(),
+  execGit: vi.fn(),
 }));
 vi.mock('../agentErrorAnalysis.js', () => ({
   analyzeAgentFailure: vi.fn(),
@@ -18,6 +19,8 @@ import { analyzeAgentFailure } from '../agentErrorAnalysis.js';
 import {
   readFileTail,
   worktreeHasChanges,
+  commitsSince,
+  worktreeHasWorkEvidence,
   captureWorktreeDiff,
   resolveErrorAnalysis,
   RAW_TAIL_ANALYSIS_BYTES,
@@ -83,6 +86,74 @@ describe('finalizeHelpers', () => {
       expect(await worktreeHasChanges(null)).toBe(false);
       expect(await worktreeHasChanges('')).toBe(false);
       expect(git.getStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('commitsSince', () => {
+    const SINCE = Date.parse('2026-08-08T18:23:30.000Z');
+
+    it('counts commits inside the run window, scoped by committer date', async () => {
+      vi.mocked(git.execGit).mockResolvedValue({ exitCode: 0, stdout: '2\n', stderr: '' });
+      expect(await commitsSince('/tmp/ws', SINCE)).toBe(2);
+      expect(git.execGit).toHaveBeenCalledWith(
+        ['rev-list', '--count', '--since=2026-08-08T18:23:30.000Z', 'HEAD'],
+        '/tmp/ws',
+        { ignoreExitCode: true }
+      );
+    });
+
+    it('is 0 when nothing was committed during the run', async () => {
+      vi.mocked(git.execGit).mockResolvedValue({ exitCode: 0, stdout: '0\n', stderr: '' });
+      expect(await commitsSince('/tmp/ws', SINCE)).toBe(0);
+    });
+
+    // A repo with no commits yet makes `rev-list HEAD` exit non-zero with an
+    // empty stdout — parsing that as work would launder a no-op run.
+    it('is 0 on a non-zero git exit (no HEAD / broken checkout)', async () => {
+      vi.mocked(git.execGit).mockResolvedValue({ exitCode: 128, stdout: '', stderr: 'bad revision' });
+      expect(await commitsSince('/tmp/ws', SINCE)).toBe(0);
+    });
+
+    it('is 0 (never throws) when execGit rejects', async () => {
+      vi.mocked(git.execGit).mockRejectedValue(new Error('timeout'));
+      expect(await commitsSince('/tmp/ws', SINCE)).toBe(0);
+    });
+
+    it('is 0 for a bad path or a non-finite timestamp without touching git', async () => {
+      expect(await commitsSince(null, SINCE)).toBe(0);
+      expect(await commitsSince('/tmp/ws', undefined)).toBe(0);
+      expect(await commitsSince('/tmp/ws', NaN)).toBe(0);
+      expect(git.execGit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('worktreeHasWorkEvidence', () => {
+    const SINCE = Date.parse('2026-08-08T18:23:30.000Z');
+
+    it('is true on a dirty tree without consulting the commit log', async () => {
+      vi.mocked(git.getStatus).mockResolvedValue({ clean: false });
+      expect(await worktreeHasWorkEvidence('/tmp/ws', SINCE)).toBe(true);
+      expect(git.execGit).not.toHaveBeenCalled();
+    });
+
+    // The release-run regression: commit + push + open PR leaves a CLEAN tree,
+    // which the uncommitted-changes-only gate scored as "produced no work".
+    it('is true on a clean tree when the run committed something', async () => {
+      vi.mocked(git.getStatus).mockResolvedValue({ clean: true });
+      vi.mocked(git.execGit).mockResolvedValue({ exitCode: 0, stdout: '1\n', stderr: '' });
+      expect(await worktreeHasWorkEvidence('/tmp/ws', SINCE)).toBe(true);
+    });
+
+    it('is false on a clean tree with no in-window commits', async () => {
+      vi.mocked(git.getStatus).mockResolvedValue({ clean: true });
+      vi.mocked(git.execGit).mockResolvedValue({ exitCode: 0, stdout: '0\n', stderr: '' });
+      expect(await worktreeHasWorkEvidence('/tmp/ws', SINCE)).toBe(false);
+    });
+
+    it('falls back to the dirty-tree signal alone when no window is given', async () => {
+      vi.mocked(git.getStatus).mockResolvedValue({ clean: true });
+      expect(await worktreeHasWorkEvidence('/tmp/ws')).toBe(false);
+      expect(git.execGit).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary

The last two `/do:release` agents were reported as failures. They weren't — both did their whole job, and the reaper mislabeled them.

Timeline from the agent records and `git log`:

| Agent | Window | What it actually did | Recorded as |
|---|---|---|---|
| first | 18:23:30 → 19:07:26 | committed `chore: release v2.40.0` at 18:25:36, opened the release PR at 18:27:29, then sat in its `--review-with ollama` loop | `idle-no-changes` FAILURE |
| second (retry) | 19:07:28 → 19:40:34 | committed the review-gate fixes at 19:35:49 | `idle-no-changes` FAILURE |

Both carried `error: "TUI agent idled out with zero uncommitted file changes — the model may have processed but produced no work."`

The cause: the idle reaper's work-evidence gate (`#2191`) reads only **uncommitted** changes. A `/do:release` or `/do:pr` job commits, pushes, and opens its PR — so by the time it idles the tree is clean *because it succeeded*. Every such run was scored a failure, the task retried, and the v2.40.0 release sat unmerged.

Evidence of work is now **a dirty tree OR at least one commit made inside the run window**. The commit probe is `git rev-list --count --since=<run start> HEAD`, which filters on committer date — so commits the agent made are counted while commits merely pulled in from the remote (stamped before the run) are not.

Deliberately **not** changed:
- The `#2191` no-op detection stays live for release jobs. Stamping `worktreeChangesExpected: false` on them would have been the shallower fix — it short-circuits the gate entirely, so a release run that did nothing would report success.
- The `#3102` `worktreeChangesExpected` opt-out is untouched and still partitions cleanly: this gate covers "work landed in git," the flag covers "work landed outside git."

Two follow-ups filed rather than rolled in:
- **#3636** — the report-shaped half of the same class. `/do:review`, `/do:scan`, `/do:plan-task`, `/do:replan` produce neither a dirty tree nor a commit, and nothing stamps `worktreeChangesExpected` for slashdo tasks, so they still fail.
- **#3637** — `evaluateSuccessCriteria` computes `validationPassed` from a `[task-<id>]` commit marker that nothing in the codebase ever emits.

## Test plan

- `server/services/agentTuiSpawning/finalizeHelpers.test.js` — unit coverage for `commitsSince` (in-window count, zero, non-zero git exit, rejection, bad inputs) and `worktreeHasWorkEvidence` (dirty short-circuits without spawning git; clean+commit = work; clean+no-commit = no work).
- `server/services/agentTuiSpawning.test.js` — drives the full PTY choreography to idle-out on a clean tree and asserts `idle-complete` success when the run committed, with the probe scoped by committer date.
- **Bypass probe**: reverted `worktreeHasWorkEvidence` to the old dirty-tree-only behavior and re-ran — exactly the 2 new tests failed, 107 others passed. The guard bites.
- Full server suite: `NODE_ENV=test npx vitest run` → **1251 files, 25 733 tests passed**, 25 skipped (DB suites, gated off the non-test database).
