### PR TITLE
fix Universe Canon AI differentiate: three prompt stages shipped a template with no stage-config entry

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -6,6 +6,8 @@
 
 ## Fixed
 
+- **Universe Canon — "AI: differentiate cast" and per-character "AI: differentiate" now run.** Both threw `Stage pipeline-character-differentiate-cast not found` / `Stage pipeline-character-refine not found` on every install since they shipped: the prompt templates landed in `data.reference/prompts/stages/` but their `stage-config.json` entries were never authored, and `buildPrompt()` resolves the config entry first. Arc-verification **auto-resolve** (`pipeline-arc-resolve`) was dead the same way. All three entries now ship, migration 232 seeds them onto existing installs, and a new catalog-parity guard fails the build if a prompt template ever ships without its config entry again (or the reverse). The inverse gap on the Digital Twin side — ten stages whose config entry ships with no template, so each soul/twin AI pass silently runs its fallback — is tracked in #3644.
+
 - A manual Autonomous-mode run now uses the series' own configured AI provider (the picker in the series header), matching scheduled runs and every other Pipeline action. It previously ignored `series.llm` and ran on the install's active provider, so the series header said one thing and the run did another. It stays a *soft* default: a stage pinned in Prompts keeps its pin, and an unavailable provider falls back instead of failing the run.
 
 - Series Pipeline and Manuscript Editor pages can now scroll through their full content on mobile.

--- a/data.reference/prompts/stage-config.json
+++ b/data.reference/prompts/stage-config.json
@@ -457,6 +457,13 @@
       "returnsJson": true,
       "variables": []
     },
+    "pipeline-arc-resolve": {
+      "name": "Pipeline — Arc Verification Auto-Resolve",
+      "description": "Rewrite an authored arc + its volume/season outlines so every finding from the arc verification pass is resolved, preserving as much of the user's original work as possible. Grounds rewrites in the linked universe's canon entities when the series has one. Returns the corrected arc + seasons plus a per-finding resolution note.",
+      "model": "heavy",
+      "returnsJson": true,
+      "variables": []
+    },
     "pipeline-volume-verify": {
       "name": "Pipeline — Volume / Season Verification",
       "description": "Deep continuity pass on a single volume / season: volume-internal arc shape, within-volume continuity, beat-level escalation (issues with beats), promise drift, boundary continuity with neighbor volumes, cast economy, volume-scope world-entity drift, and obvious length-vs-weight mismatches. Complement to the cross-volume arc verify, deeper because the scope is smaller. Returns actionable { severity, location, problem, suggestion } issues — empty list means clean.",
@@ -594,6 +601,20 @@
       "name": "Importer — Issue Proposal",
       "description": "Split a finished work into PortOS pipeline issues with titles + arcPosition + arcRole + verbatim prose excerpts. Honors source-marked issue / chapter / volume headers.",
       "model": "heavy",
+      "returnsJson": true,
+      "variables": []
+    },
+    "pipeline-character-refine": {
+      "name": "Pipeline — Differentiate One Character",
+      "description": "Rewrite one character's `physicalDescription` so they render visually distinct from every peer in the cast — ethnicity, age decade, build, hair, eye color, distinguishing features, signature wardrobe, posture. Sees the full peer cast so it can push away from collisions; preserves evidence and firstAppearance. Backs the per-character \"AI: differentiate\" button on the Universe Canon and series Nouns views.",
+      "model": "default",
+      "returnsJson": true,
+      "variables": []
+    },
+    "pipeline-character-differentiate-cast": {
+      "name": "Pipeline — Differentiate Cast (Universe-Wide)",
+      "description": "One call rewrites EVERY character's `physicalDescription` so the cast as a whole has no visually-colliding pairs — the cast-wide counterpart to the per-character refine. Backs the \"AI: differentiate cast\" button on the Universe Canon view; locked characters are still shown to the model for contrast but are skipped when the rewrites are applied.",
+      "model": "default",
       "returnsJson": true,
       "variables": []
     },

--- a/scripts/migrations/232-universe-canon-character-stages.js
+++ b/scripts/migrations/232-universe-canon-character-stages.js
@@ -1,0 +1,28 @@
+/**
+ * Seed the three canon/arc stages that shipped a `.md` template but never got a
+ * `stage-config.json` entry.
+ *
+ * `pipeline-character-refine`, `pipeline-character-differentiate-cast`, and
+ * `pipeline-arc-resolve` all landed with their templates in
+ * `data.reference/prompts/stages/` while the matching stage-config entries were
+ * never authored. `promptService.buildPrompt()` resolves a stage through
+ * `getStage()` (stage-config), NOT through the template file — so every install,
+ * fresh or upgraded, threw `Stage <name> not found` the moment the user pressed
+ * "AI: differentiate cast" / "AI: differentiate" on the Universe Canon view, or
+ * ran arc-verification auto-resolve. The entries are added to
+ * `data.reference/prompts/stage-config.json` in the same change; this migration
+ * is what carries them onto installs that already have a `data/` tree.
+ *
+ * Customization-safe + idempotent per `_seedStageHelpers.js` — each template is
+ * copied only when missing and each config entry merged only when absent, so an
+ * install whose templates are already present (the common case here, since the
+ * `.md` files did ship) picks up only the config entries.
+ */
+
+import { makeSeedMigrations } from './_seedStageHelpers.js';
+
+export default makeSeedMigrations([
+  'pipeline-character-refine',
+  'pipeline-character-differentiate-cast',
+  'pipeline-arc-resolve',
+]);

--- a/scripts/migrations/232-universe-canon-character-stages.test.js
+++ b/scripts/migrations/232-universe-canon-character-stages.test.js
@@ -1,0 +1,21 @@
+import { describe } from 'vitest';
+
+import migration from './232-universe-canon-character-stages.js';
+import { runSeedStageMigrationTests } from './_seedStageTestHelpers.js';
+
+// The two Universe Canon character-differentiation stages plus arc auto-resolve.
+// All three shipped a template with no stage-config entry, which is exactly what
+// the drift catch here guards: `buildPrompt()` resolves stages through
+// stage-config, so a template that ships without its entry throws
+// "Stage <name> not found" at the button press with nothing failing first.
+describe('migration 232 — seed the canon character + arc-resolve stages', () => {
+  runSeedStageMigrationTests({
+    migration,
+    stages: [
+      'pipeline-character-refine',
+      'pipeline-character-differentiate-cast',
+      'pipeline-arc-resolve',
+    ],
+    prefix: 'migration-232-',
+  });
+});

--- a/server/lib/promptStageCallSites.generated.json
+++ b/server/lib/promptStageCallSites.generated.json
@@ -83,6 +83,9 @@
   "pipeline-character-differentiate-cast": [
     "server/services/universeCanon.js"
   ],
+  "pipeline-character-refine": [
+    "server/services/universeCanon.js"
+  ],
   "pipeline-comic-cover-concepts": [
     "server/services/pipeline/arcPlanner/coverConcepts.js"
   ],

--- a/server/lib/promptSystemStages.test.js
+++ b/server/lib/promptSystemStages.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -56,13 +56,63 @@ describe('promptSystemStages', () => {
 // until it was given a real entry.
 describe('shipped stage catalog parity', () => {
   const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+  const referenceStagesDir = resolve(repoRoot, 'data.reference', 'prompts', 'stages');
   const shipped = JSON.parse(
     readFileSync(resolve(repoRoot, 'data.reference', 'prompts', 'stage-config.json'), 'utf8'),
   ).stages;
+  const shippedTemplates = new Set(
+    readdirSync(referenceStagesDir)
+      .filter((file) => file.endsWith('.md'))
+      .map((file) => file.slice(0, -'.md'.length)),
+  );
+
+  // The ten Digital Twin stages tracked by #3644: config entry ships, template
+  // does not, so `buildPrompt()` throws "Template for <stage> not found" and
+  // every call site's `.catch(() => null)` fallback runs instead. Both lists
+  // below are asserted EXACTLY, not subtracted — so a new gap fails on the
+  // actual side and a gap that was closed (template authored, key deleted)
+  // fails on the expected side. #3644 lands when both are empty.
+  const STAGES_WITHOUT_SHIPPED_TEMPLATE = [
+    'soul-contradiction-detector',
+    'soul-enrichment',
+    'soul-enrichment-process',
+    'soul-test-generator',
+    'soul-test-scorer',
+    'soul-writing-analyzer',
+    'twin-confidence-analyzer',
+    'twin-import-analyzer',
+    'twin-trait-extractor',
+  ];
+  // Same #3644 debt from the other side: `twin-interview-analyze` is called by
+  // `digital-twin-import.js` but ships neither a config entry nor a template.
+  const CALL_SITES_WITHOUT_SHIPPED_CONFIG = ['twin-interview-analyze'];
 
   it('ships a stage-config entry for every system stage', () => {
     const missing = SYSTEM_STAGE_KEYS.filter((key) => !shipped[key]);
     expect(missing).toEqual([]);
+  });
+
+  // The failure this catches is the one that shipped `pipeline-arc-resolve`,
+  // `pipeline-character-refine`, and `pipeline-character-differentiate-cast`:
+  // all three landed with a template and no config entry, and `buildPrompt()`
+  // resolves the CONFIG first — so the Universe Canon "AI: differentiate cast"
+  // button threw "Stage pipeline-character-differentiate-cast not found" on
+  // every install, fresh or upgraded, with nothing failing here first.
+  it('ships a stage-config entry for every shipped template', () => {
+    const orphaned = [...shippedTemplates].filter((key) => !shipped[key]).sort();
+    expect(orphaned).toEqual([]);
+  });
+
+  it('ships a stage-config entry for every stage the server calls by literal key', () => {
+    const missing = Object.keys(STAGE_CALL_SITES).filter((key) => !shipped[key]).sort();
+    expect(missing).toEqual(CALL_SITES_WITHOUT_SHIPPED_CONFIG);
+  });
+
+  // The inverse orphan: a config entry the Prompt Manager renders as a row the
+  // user can open and edit, backed by no template at all.
+  it('ships a template for every stage-config entry', () => {
+    const missing = Object.keys(shipped).filter((key) => !shippedTemplates.has(key)).sort();
+    expect(missing).toEqual(STAGES_WITHOUT_SHIPPED_TEMPLATE);
   });
 });
 


### PR DESCRIPTION
## Summary

Three prompt stages shipped a `.md` template but never got a `stage-config.json` entry. `buildPrompt()` resolves the config entry first and the template second (`server/services/promptService.js:71`), so all three threw `Stage <name> not found` on **every** install, fresh or upgraded:

| Stage | What was dead |
| --- | --- |
| `pipeline-character-differentiate-cast` | Universe Canon → **"AI: differentiate cast"** (the reported bug) |
| `pipeline-character-refine` | Universe Canon / series Nouns → per-character **"AI: differentiate"** |
| `pipeline-arc-resolve` | Series arc-verification **auto-resolve** |

The entries now ship in `data.reference/prompts/stage-config.json`, with `model` tiers matching their siblings (`heavy` for arc-resolve alongside `pipeline-arc-verify`/`-overview`, `default` for the two character stages) and `variables: []` verified against what each template actually references.

**Migration 232** carries the entries onto installs that already have a `data/` tree. Boot runs migrations but not `setup-data.js`, so a `git pull && pm2 restart` upgrade would otherwise leave the stages unseeded — the same reason the 60-odd sibling seed migrations exist. It reuses `makeSeedMigrations` unchanged (copy-if-missing, merge-if-absent, one atomic config write).

**Guard against the class.** `promptSystemStages.test.js`'s existing "shipped stage catalog parity" block was widened from one direction (system stages have a config entry) to the whole catalog in both directions:

- every shipped template has a config entry — unconditional, and the case that would have caught this bug
- every stage the server calls by literal key has a config entry
- every config entry has a shipped template

The last two assert **exact** gap sets rather than subtracting an allowlist, so a newly-closed gap fails on the expected side and can't rot into permanent suppression. The one known gap — ten Digital Twin stages whose config entry ships with **no** template, so each soul/twin AI pass silently runs its `.catch(() => null)` fallback — is filed as #3644.

## Test plan

- `cd server && NODE_ENV=test npm test` — **1252 files / 25753 tests pass**, 25 DB suites correctly skipped off the real `portos` database.
- Bypass-probed the new guard in both directions: deleting `pipeline-arc-resolve`'s entry fails 2 cases, planting an orphan config entry fails a 3rd; restoring makes all 15 pass.
- Smoke-rendered both character templates through `applyTemplate` + `expandPartials` — no unresolved `{{…}}` and the injected `castJson`/`targetJson` land.
- New `scripts/migrations/232-*.test.js` via `runSeedStageMigrationTests` (seeds-when-absent, no-op re-run, no-clobber, reference-drift catch).
- `node scripts/generate-prompt-stage-call-sites.js` regenerated the manifest; its drift test passes. `pipeline-character-refine` is now deletion-protected too, which it wasn't before.
