### PR TITLE
fix: attribute primary-checkout drift by patch-id before failing a run (#3703)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -2,6 +2,8 @@
 
 ## Stability
 
+- **[issue-3703] A worktree agent is no longer failed for commits it didn't write.** The primary-checkout guard used to fail any worktree agent whose run window overlapped commits landing on the shared primary checkout — but a concurrent coding-on-main agent, your own terminal, or `update.sh`'s pull can move it too, so read-only reasoners and correctly-behaved agents were being blamed and escalated to you. The guard now attributes the stranded commits by patch-id (`git cherry`, so a cherry-picked or rebased copy still counts) to the agent's own branch: only commits actually traceable to that agent fail the run. Everything else is warn-logged — the unreviewed commits on the primary are still surfaced — but a run that didn't cause them stays a success.
+
 - **[issue-3704] The UI no longer goes blank when iCloud offloads a synced file** — macOS "Optimize Mac Storage" can evict MortalLoom and Obsidian files to the cloud. Reading one of those offloaded files used to stall indefinitely, and a handful of stalls was enough to freeze every page in PortOS while the server still looked healthy — pages simply never loaded and only a restart brought them back. PortOS now detects an offloaded file up front, skips the read, asks iCloud to download it in the background, and reports "temporarily unavailable" for just that record until it arrives.
 
 ## Added

--- a/server/lib/primaryCheckoutGuard.js
+++ b/server/lib/primaryCheckoutGuard.js
@@ -30,16 +30,18 @@
  * The primary checkout is a shared global resource — a concurrent coding-on-main
  * agent, the human's own terminal, `update.sh`'s `git pull --rebase --autostash`,
  * or any background flow can strand commits on it — so before blaming the run,
- * the guard asks whether THIS agent could have produced them (#3703). It
- * attributes the stranded commits to the agent's own worktree branch by PATCH-ID
- * (`git cherry`, not raw SHA, so a cherry-picked or rebased copy still matches).
- * Only an attributed drift downgrades a successful run; anything the agent
- * demonstrably did not author — a read-only reasoner that never branched, or
- * commits with no patch-equivalent on the agent's branch — is carried as
- * `{ drifted: false, unattributed: true }`: warn-logged (unreviewed commits on
- * `main` are worth surfacing) but not failed. The asymmetry is deliberate — a
- * missed branch-jack still leaves a warn log and recoverable commits, while a
- * false failure escalates to a human and dents the task type's success rate.
+ * the guard asks whether THIS agent could have produced them (#3703). When a run
+ * strands commits, they are attributed to the agent's own worktree branch by
+ * PATCH-ID (`git cherry`, not raw SHA, so a cherry-picked or rebased copy still
+ * matches). Stranded commits the agent demonstrably did not author — a read-only
+ * reasoner that never branched, or commits with no patch-equivalent on the
+ * agent's branch — are carried as `{ drifted: false, unattributed: true }`:
+ * warn-logged (unreviewed commits on `main` are worth surfacing) but not failed.
+ * The asymmetry is deliberate — a missed branch-jack still leaves a warn log and
+ * recoverable commits, while a false failure escalates to a human and dents the
+ * task type's success rate. (A checkout left on the WRONG BRANCH with nothing
+ * local-only strands no commit to attribute, and still reports its benign
+ * `git checkout <branch>` recovery as before — there is nothing to discard.)
  *
  * Two halves, deliberately split so they can sit on opposite ends of a run:
  * `capturePrimaryCheckoutState` stamps a baseline at spawn time (onto the agent
@@ -125,9 +127,12 @@ export async function capturePrimaryCheckoutState(checkoutPath) {
  * timed out — so the prose can say "moved" without asserting a count it doesn't
  * have.
  */
-async function countCommitsAhead(checkoutPath, baseHead, head) {
+async function countCommitsAhead(checkoutPath, baseHead, head, { noMerges = false } = {}) {
+  const args = ['rev-list', '--count'];
+  if (noMerges) args.push('--no-merges');
+  args.push(`${baseHead}..${head}`);
   const result = await execGit(
-    ['rev-list', '--count', `${baseHead}..${head}`],
+    args,
     checkoutPath,
     { ignoreExitCode: true, timeout: GIT_TIMEOUT_MS },
   ).catch(() => null);
@@ -185,19 +190,29 @@ async function resolveAgentBranchRef(checkoutPath, agentBranch) {
  * (unattributed), failing open by design. NON-THROWING, like the rest of the
  * module.
  */
-async function isDriftAttributableToAgent(checkoutPath, { strandedBase, driftedHead, strandedCount, agentBranch }) {
+async function isDriftAttributableToAgent(checkoutPath, { strandedBase, driftedHead, agentBranch }) {
   const agentRef = await resolveAgentBranchRef(checkoutPath, agentBranch);
   if (!agentRef) return false;
-  // A read-only reasoner's worktree branch resolves but carries no commit of its
-  // own (it never left the base), so it cannot have authored a stranded commit.
+  // Cheap short-circuit: a branch that carries no commit of its own past the
+  // stranded base (a read-only reasoner's untouched worktree branch) cannot have
+  // authored anything, so skip the cherry walk. `git cherry` reaches the same
+  // verdict on its own — this only avoids the extra call on the common case.
   const ownCommits = await countCommitsAhead(checkoutPath, strandedBase, agentRef);
   if (!ownCommits) return false;
-  // `git cherry <upstream> <head> <limit>` walks the stranded commits (`limit..head`)
-  // and prints a line for each that <upstream> (the agent's branch) does NOT already
-  // contain: `-` when a patch-equivalent copy exists there, `+` when the commit is
-  // foreign to it. Commits the agent's branch holds outright (same SHA) are omitted
-  // entirely. So a stranded commit is the agent's UNLESS git cherry marks it `+`;
-  // the drift is attributed unless EVERY stranded commit is foreign.
+  // Count the stranded NON-MERGE commits — matching what `git cherry` walks. A
+  // merge commit strays onto the primary via a human's `git merge` or a non-ff
+  // pull (never a `/do:pr` branch-jack), and `git cherry` skips it; counting it
+  // here would leave `stranded > foreign` true on arithmetic alone and re-blame
+  // the very false-positive this guard exists to prevent.
+  const strandedNonMerge = await countCommitsAhead(checkoutPath, strandedBase, driftedHead, { noMerges: true });
+  if (!strandedNonMerge) return false;
+  // `git cherry <upstream> <head> <limit>` walks the stranded non-merge commits
+  // (`limit..head`) and prints a line for each that <upstream> (the agent's
+  // branch) does NOT already contain: `-` when a patch-equivalent copy exists
+  // there, `+` when the commit is foreign to it. Commits the agent's branch holds
+  // outright (same SHA) are omitted entirely. So a stranded commit is the agent's
+  // UNLESS git cherry marks it `+`; the drift is attributed unless EVERY stranded
+  // non-merge commit is foreign.
   const cherry = await execGit(
     ['cherry', agentRef, driftedHead, strandedBase],
     checkoutPath,
@@ -205,7 +220,7 @@ async function isDriftAttributableToAgent(checkoutPath, { strandedBase, driftedH
   ).catch(() => null);
   if (!cherry || cherry.exitCode !== 0) return false;
   const foreign = (cherry.stdout || '').split('\n').filter(line => line.startsWith('+')).length;
-  return strandedCount > foreign;
+  return strandedNonMerge > foreign;
 }
 
 /** Short SHA for human-readable prose. */
@@ -273,7 +288,6 @@ export async function detectPrimaryCheckoutDrift(baseline, { agentBranch = null 
     const attributed = await isDriftAttributableToAgent(baseline.path, {
       strandedBase: upstream || baseline.head,
       driftedHead: current.head,
-      strandedCount,
       agentBranch,
     });
     if (!attributed) {

--- a/server/lib/primaryCheckoutGuard.js
+++ b/server/lib/primaryCheckoutGuard.js
@@ -26,6 +26,21 @@
  * A branch with no upstream to compare against can't be cleared, so it still
  * reports (an unpushed commit is unreviewed by definition).
  *
+ * Movement that survives the checks above is still not enough to FAIL the run.
+ * The primary checkout is a shared global resource — a concurrent coding-on-main
+ * agent, the human's own terminal, `update.sh`'s `git pull --rebase --autostash`,
+ * or any background flow can strand commits on it — so before blaming the run,
+ * the guard asks whether THIS agent could have produced them (#3703). It
+ * attributes the stranded commits to the agent's own worktree branch by PATCH-ID
+ * (`git cherry`, not raw SHA, so a cherry-picked or rebased copy still matches).
+ * Only an attributed drift downgrades a successful run; anything the agent
+ * demonstrably did not author — a read-only reasoner that never branched, or
+ * commits with no patch-equivalent on the agent's branch — is carried as
+ * `{ drifted: false, unattributed: true }`: warn-logged (unreviewed commits on
+ * `main` are worth surfacing) but not failed. The asymmetry is deliberate — a
+ * missed branch-jack still leaves a warn log and recoverable commits, while a
+ * false failure escalates to a human and dents the task type's success rate.
+ *
  * Two halves, deliberately split so they can sit on opposite ends of a run:
  * `capturePrimaryCheckoutState` stamps a baseline at spawn time (onto the agent
  * metadata, in `agentLifecycle.js`), and `detectPrimaryCheckoutDrift` re-reads it
@@ -136,15 +151,61 @@ async function resolveUpstreamRef(checkoutPath, branch) {
 }
 
 /**
- * Commits the branch carries that its upstream does not — the only commits a
- * branch-jack actually leaves stranded, and the number the recovery prose is
- * about. Returns null (not 0) when there is no upstream to compare against, so
- * "verified clean" never masquerades as "could not check".
+ * Resolve the agent's own worktree branch to a ref that exists in the primary
+ * checkout — the local branch first, then its `origin/<branch>` remote-tracking
+ * form (the agent may have pushed and had its local ref pruned). Returns null
+ * when neither resolves, the name is empty, or git could not be run — every one
+ * of which the caller treats as "cannot attribute, so do not blame".
  */
-async function countUnpushedCommits(checkoutPath, branch) {
-  const upstream = await resolveUpstreamRef(checkoutPath, branch);
-  if (!upstream) return null;
-  return await countCommitsAhead(checkoutPath, upstream, branch);
+async function resolveAgentBranchRef(checkoutPath, agentBranch) {
+  if (!agentBranch || typeof agentBranch !== 'string') return null;
+  for (const ref of [agentBranch, `refs/remotes/origin/${agentBranch}`]) {
+    const result = await execGit(
+      ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`],
+      checkoutPath,
+      { ignoreExitCode: true, timeout: GIT_TIMEOUT_MS },
+    ).catch(() => null);
+    if (firstLine(result)) return ref;
+  }
+  return null;
+}
+
+/**
+ * Was the drift plausibly THIS agent's doing (#3703)? Compares the stranded
+ * commits (everything the drifted checkout carries past `strandedBase`) against
+ * the agent's own worktree branch by PATCH-ID via `git cherry`, so a
+ * cherry-picked or rebased copy still matches — a raw-SHA check would miss
+ * exactly the case the original #3680 incident could have produced.
+ *
+ * Returns true when AT LEAST ONE stranded commit is the agent's own — either
+ * literally on its branch (same SHA) or patch-equivalent to one there (a
+ * cherry-picked / rebased copy). Every uncertain outcome — no branch name, a
+ * branch that does not resolve, a branch with no commits of its own (Case A: a
+ * read-only reasoner that never branched), or a failed git call — returns FALSE
+ * (unattributed), failing open by design. NON-THROWING, like the rest of the
+ * module.
+ */
+async function isDriftAttributableToAgent(checkoutPath, { strandedBase, driftedHead, strandedCount, agentBranch }) {
+  const agentRef = await resolveAgentBranchRef(checkoutPath, agentBranch);
+  if (!agentRef) return false;
+  // A read-only reasoner's worktree branch resolves but carries no commit of its
+  // own (it never left the base), so it cannot have authored a stranded commit.
+  const ownCommits = await countCommitsAhead(checkoutPath, strandedBase, agentRef);
+  if (!ownCommits) return false;
+  // `git cherry <upstream> <head> <limit>` walks the stranded commits (`limit..head`)
+  // and prints a line for each that <upstream> (the agent's branch) does NOT already
+  // contain: `-` when a patch-equivalent copy exists there, `+` when the commit is
+  // foreign to it. Commits the agent's branch holds outright (same SHA) are omitted
+  // entirely. So a stranded commit is the agent's UNLESS git cherry marks it `+`;
+  // the drift is attributed unless EVERY stranded commit is foreign.
+  const cherry = await execGit(
+    ['cherry', agentRef, driftedHead, strandedBase],
+    checkoutPath,
+    { ignoreExitCode: true, timeout: GIT_TIMEOUT_MS },
+  ).catch(() => null);
+  if (!cherry || cherry.exitCode !== 0) return false;
+  const foreign = (cherry.stdout || '').split('\n').filter(line => line.startsWith('+')).length;
+  return strandedCount > foreign;
 }
 
 /** Short SHA for human-readable prose. */
@@ -162,13 +223,20 @@ const short = sha => String(sha || '').slice(0, 9);
  *     branch but every commit is already on that branch's upstream. That is a
  *     `git pull`, not a branch-jack; carried as a distinct shape (rather than a
  *     bare `false`) so a caller can log what it observed.
- *   - `{ drifted: true, … }` — the checkout ended on a different branch, or its
- *     branch carries commits the upstream does not have.
+ *   - `{ drifted: false, unattributed: true, … }` — commits WERE stranded, but
+ *     none are patch-equivalent to a commit on the agent's own branch, so this
+ *     run demonstrably did not put them there (a concurrent actor did). Carries
+ *     the `message` so the caller can warn-log the unreviewed commits without
+ *     failing the run. See the module header on the fail-open asymmetry.
+ *   - `{ drifted: true, … }` — the checkout ended on a different branch, or it
+ *     carries commits the upstream does not have AND those commits are
+ *     attributable to the agent's own branch by patch-id.
  *
  * @param {{path: string, branch: string, head: string}|null} baseline stamped by
  *   `capturePrimaryCheckoutState` at spawn time
  * @param {{ agentBranch?: string|null }} [options] the agent's own worktree
- *   branch, named in the recovery prose because it is where the same commits
+ *   branch, used both to ATTRIBUTE the stranded commits by patch-id and, once
+ *   attributed, named in the recovery prose because it is where the same commits
  *   almost certainly also live
  */
 export async function detectPrimaryCheckoutDrift(baseline, { agentBranch = null } = {}) {
@@ -179,9 +247,13 @@ export async function detectPrimaryCheckoutDrift(baseline, { agentBranch = null 
   if (!current) return { drifted: false };
   if (current.branch === baseline.branch && current.head === baseline.head) return { drifted: false };
 
+  const upstream = await resolveUpstreamRef(baseline.path, current.branch);
   const [commitCount, unpushedCount] = await Promise.all([
     countCommitsAhead(baseline.path, baseline.head, current.head),
-    countUnpushedCommits(baseline.path, current.branch),
+    // Commits the branch carries that its upstream does not — the only commits a
+    // branch-jack actually strands. Null (not 0) when there is no upstream to
+    // compare against, so "verified clean" never masquerades as "could not check".
+    upstream ? countCommitsAhead(baseline.path, upstream, current.branch) : Promise.resolve(null),
   ]);
 
   // Same branch, nothing local-only: the checkout was pulled forward onto commits
@@ -189,6 +261,24 @@ export async function detectPrimaryCheckoutDrift(baseline, { agentBranch = null 
   // there is nothing for a human to recover.
   if (current.branch === baseline.branch && unpushedCount === 0) {
     return { drifted: false, fastForwarded: true, baseline, current, commitCount };
+  }
+
+  const message = formatDriftMessage({ baseline, current, commitCount });
+
+  // Second gate (#3703): stranded commits are only a failure if THIS agent could
+  // have produced them. A pure branch switch strands nothing (nothing to blame on
+  // anyone), so attribution runs only when there is a resolvable stranded commit.
+  const strandedCount = unpushedCount === null ? commitCount : unpushedCount;
+  if (strandedCount > 0) {
+    const attributed = await isDriftAttributableToAgent(baseline.path, {
+      strandedBase: upstream || baseline.head,
+      driftedHead: current.head,
+      strandedCount,
+      agentBranch,
+    });
+    if (!attributed) {
+      return { drifted: false, unattributed: true, baseline, current, commitCount, unpushedCount, message };
+    }
   }
 
   return {
@@ -199,7 +289,7 @@ export async function detectPrimaryCheckoutDrift(baseline, { agentBranch = null 
     current,
     commitCount,
     unpushedCount,
-    message: formatDriftMessage({ baseline, current, commitCount }),
+    message,
     suggestedFix: formatDriftRecovery({ current, baseline, commitCount, unpushedCount, agentBranch }),
   };
 }

--- a/server/lib/primaryCheckoutGuard.js
+++ b/server/lib/primaryCheckoutGuard.js
@@ -220,6 +220,9 @@ async function isDriftAttributableToAgent(checkoutPath, { runBase, upstream, dri
   // so detect them by reachability: if excluding the agent's branch drops the count,
   // some candidate commit is the agent's.
   const strandedNotOnAgent = await countCommitsAhead(checkoutPath, runBase, driftedHead, { noMerges: true, excludes: [...strandedExcludes, agentSha] });
+  // A failed count is null; `null < n` coerces to `0 < n` and would falsely attribute
+  // (a false failure), so treat an unresolvable count as "cannot determine" and fail open.
+  if (strandedNotOnAgent === null) return false;
   if (strandedNotOnAgent < strandedTotal) return true;
   // Patch-equivalent branch-jack: a cherry-picked / rebased copy (different SHA, missed
   // by the reachability check). `git cherry <upstream> <head> <limit>` marks such a

--- a/server/lib/primaryCheckoutGuard.js
+++ b/server/lib/primaryCheckoutGuard.js
@@ -142,13 +142,17 @@ async function countCommitsAhead(checkoutPath, baseHead, head, { noMerges = fals
 }
 
 /**
- * The branch's upstream tracking ref (`origin/main`), or null when it has none
- * configured — or when git could not be run. Both collapse to null on purpose:
- * the caller treats "no comparison available" identically either way.
+ * The branch's upstream tracking ref (`origin/main`), resolved to an IMMUTABLE
+ * SHA — or null when it has none configured, or git could not be run. Pinning to
+ * a SHA (rather than returning the symbolic `origin/main`) means the count and the
+ * later `git cherry` walk compare against the same history even if a concurrent
+ * fetch moves the tracking ref between calls — this guard runs against a shared
+ * checkout that other actors are actively moving. Both failure modes collapse to
+ * null on purpose: the caller treats "no comparison available" identically.
  */
-async function resolveUpstreamRef(checkoutPath, branch) {
+async function resolveUpstreamSha(checkoutPath, branch) {
   const result = await execGit(
-    ['rev-parse', '--abbrev-ref', '--symbolic-full-name', `${branch}@{upstream}`],
+    ['rev-parse', `${branch}@{upstream}`],
     checkoutPath,
     { ignoreExitCode: true, timeout: GIT_TIMEOUT_MS },
   ).catch(() => null);
@@ -262,13 +266,17 @@ export async function detectPrimaryCheckoutDrift(baseline, { agentBranch = null 
   if (!current) return { drifted: false };
   if (current.branch === baseline.branch && current.head === baseline.head) return { drifted: false };
 
-  const upstream = await resolveUpstreamRef(baseline.path, current.branch);
+  // Pin the upstream to a SHA and count everything against `current.head` (the SHA
+  // captured above), never the live `current.branch` — a concurrent commit or
+  // fetch on the shared checkout must not make the two counts and the cherry walk
+  // read different histories.
+  const upstream = await resolveUpstreamSha(baseline.path, current.branch);
   const [commitCount, unpushedCount] = await Promise.all([
     countCommitsAhead(baseline.path, baseline.head, current.head),
     // Commits the branch carries that its upstream does not — the only commits a
     // branch-jack actually strands. Null (not 0) when there is no upstream to
     // compare against, so "verified clean" never masquerades as "could not check".
-    upstream ? countCommitsAhead(baseline.path, upstream, current.branch) : Promise.resolve(null),
+    upstream ? countCommitsAhead(baseline.path, upstream, current.head) : Promise.resolve(null),
   ]);
 
   // Same branch, nothing local-only: the checkout was pulled forward onto commits
@@ -281,10 +289,14 @@ export async function detectPrimaryCheckoutDrift(baseline, { agentBranch = null 
   const message = formatDriftMessage({ baseline, current, commitCount });
 
   // Second gate (#3703): stranded commits are only a failure if THIS agent could
-  // have produced them. A pure branch switch strands nothing (nothing to blame on
-  // anyone), so attribution runs only when there is a resolvable stranded commit.
+  // have produced them. Attribution runs whenever there is (or should be) a
+  // stranded commit — a resolvable positive count, OR an UNRESOLVABLE count
+  // (`null`: a pruned baseline or a wedged git), which must fail OPEN rather than
+  // manufacture a failure out of a check that could not run. Only a pure branch
+  // switch that stranded exactly zero commits skips it (nothing to blame on
+  // anyone) and keeps its benign `git checkout` report.
   const strandedCount = unpushedCount === null ? commitCount : unpushedCount;
-  if (strandedCount > 0) {
+  if (strandedCount === null || strandedCount > 0) {
     const attributed = await isDriftAttributableToAgent(baseline.path, {
       strandedBase: upstream || baseline.head,
       driftedHead: current.head,

--- a/server/lib/primaryCheckoutGuard.js
+++ b/server/lib/primaryCheckoutGuard.js
@@ -160,13 +160,15 @@ async function resolveUpstreamSha(checkoutPath, branch) {
 }
 
 /**
- * Resolve the agent's own worktree branch to a ref that exists in the primary
- * checkout — the local branch first, then its `origin/<branch>` remote-tracking
- * form (the agent may have pushed and had its local ref pruned). Returns null
- * when neither resolves, the name is empty, or git could not be run — every one
- * of which the caller treats as "cannot attribute, so do not blame".
+ * Resolve the agent's own worktree branch to an IMMUTABLE commit SHA — trying the
+ * local branch first, then its `origin/<branch>` remote-tracking form (the agent
+ * may have pushed and had its local ref pruned). Returns the SHA (not the ref
+ * name) so the count and the `git cherry` walk pin to the same commit even if the
+ * shared branch ref is moved or pruned between the two calls. Returns null when
+ * neither resolves, the name is empty, or git could not be run — every one of
+ * which the caller treats as "cannot attribute, so do not blame".
  */
-async function resolveAgentBranchRef(checkoutPath, agentBranch) {
+async function resolveAgentBranchSha(checkoutPath, agentBranch) {
   if (!agentBranch || typeof agentBranch !== 'string') return null;
   for (const ref of [agentBranch, `refs/remotes/origin/${agentBranch}`]) {
     const result = await execGit(
@@ -174,7 +176,8 @@ async function resolveAgentBranchRef(checkoutPath, agentBranch) {
       checkoutPath,
       { ignoreExitCode: true, timeout: GIT_TIMEOUT_MS },
     ).catch(() => null);
-    if (firstLine(result)) return ref;
+    const sha = firstLine(result);
+    if (sha) return sha;
   }
   return null;
 }
@@ -195,13 +198,13 @@ async function resolveAgentBranchRef(checkoutPath, agentBranch) {
  * module.
  */
 async function isDriftAttributableToAgent(checkoutPath, { strandedBase, driftedHead, agentBranch }) {
-  const agentRef = await resolveAgentBranchRef(checkoutPath, agentBranch);
-  if (!agentRef) return false;
+  const agentSha = await resolveAgentBranchSha(checkoutPath, agentBranch);
+  if (!agentSha) return false;
   // Cheap short-circuit: a branch that carries no commit of its own past the
   // stranded base (a read-only reasoner's untouched worktree branch) cannot have
   // authored anything, so skip the cherry walk. `git cherry` reaches the same
   // verdict on its own — this only avoids the extra call on the common case.
-  const ownCommits = await countCommitsAhead(checkoutPath, strandedBase, agentRef);
+  const ownCommits = await countCommitsAhead(checkoutPath, strandedBase, agentSha);
   if (!ownCommits) return false;
   // Count the stranded NON-MERGE commits — matching what `git cherry` walks. A
   // merge commit strays onto the primary via a human's `git merge` or a non-ff
@@ -218,7 +221,7 @@ async function isDriftAttributableToAgent(checkoutPath, { strandedBase, driftedH
   // UNLESS git cherry marks it `+`; the drift is attributed unless EVERY stranded
   // non-merge commit is foreign.
   const cherry = await execGit(
-    ['cherry', agentRef, driftedHead, strandedBase],
+    ['cherry', agentSha, driftedHead, strandedBase],
     checkoutPath,
     { ignoreExitCode: true, timeout: GIT_TIMEOUT_MS },
   ).catch(() => null);

--- a/server/lib/primaryCheckoutGuard.js
+++ b/server/lib/primaryCheckoutGuard.js
@@ -127,10 +127,10 @@ export async function capturePrimaryCheckoutState(checkoutPath) {
  * timed out — so the prose can say "moved" without asserting a count it doesn't
  * have.
  */
-async function countCommitsAhead(checkoutPath, baseHead, head, { noMerges = false } = {}) {
+async function countCommitsAhead(checkoutPath, baseHead, head, { noMerges = false, excludes = [] } = {}) {
   const args = ['rev-list', '--count'];
   if (noMerges) args.push('--no-merges');
-  args.push(`${baseHead}..${head}`);
+  args.push(head, `^${baseHead}`, ...excludes.map(ref => `^${ref}`));
   const result = await execGit(
     args,
     checkoutPath,
@@ -183,70 +183,69 @@ async function resolveAgentBranchSha(checkoutPath, agentBranch) {
 }
 
 /**
- * Was the drift plausibly THIS agent's doing (#3703)? Compares the commits that
- * appeared on the primary DURING THE RUN (`runBase..driftedHead`, where `runBase`
- * is the checkout's HEAD at spawn) against the agent's own worktree branch by
- * PATCH-ID via `git cherry`, so a cherry-picked or rebased copy still matches — a
- * raw-SHA check would miss exactly the case the original #3680 incident could have
- * produced.
+ * Was the drift plausibly THIS agent's doing (#3703)? Looks only at the commits
+ * that could actually be this run's branch-jack — reachable from the drifted head,
+ * created AFTER spawn (not reachable from `runBase`, the checkout's HEAD at spawn)
+ * AND still unpushed (not reachable from the branch's `upstream`) — and asks whether
+ * any of them is the agent's own, by SHA or by PATCH-ID (so a cherry-picked / rebased
+ * copy still matches — a raw-SHA check would miss the case the #3680 incident could
+ * have produced).
  *
- * The window is anchored at `runBase`, NOT at the branch's upstream: a commit that
- * was ALREADY stranded on the primary at spawn (and happens to also live on the
- * agent's branch — a fresh worktree branch is cut from the primary's `main`, so it
- * inherits the primary's unpushed commits) would otherwise be counted as stranded
- * yet omitted from the foreign tally by `git cherry` (same SHA), silently supplying
- * the `+1` that flips `stranded > foreign` and re-blaming the agent for a drift
- * another actor caused — the very #3703 regression. Only a commit created after
- * spawn can be this run's branch-jack, so pre-run history is excluded from
- * attribution (the reported `unpushedCount` still measures against the upstream —
- * that is what a human recovers).
+ * Excluding BOTH ends of that window is essential. A commit the agent merely inherited
+ * from the primary at spawn, and a shared upstream commit a pull brought onto the
+ * primary during the run, are each already on the agent's branch — `git cherry` omits
+ * them (same SHA) — yet either would otherwise be counted as stranded and silently
+ * re-blame the agent for a drift another actor caused: the exact #3703 regression.
+ * Only a commit that is new this run AND unpushed can be the agent's branch-jack.
  *
- * Returns true when AT LEAST ONE run-window commit is the agent's own — either
- * literally on its branch (same SHA) or patch-equivalent to one there (a
- * cherry-picked / rebased copy). Every uncertain outcome — no branch name, a
- * branch that does not resolve, a branch with no commits of its own (Case A: a
- * read-only reasoner that never branched), or a failed git call — returns FALSE
- * (unattributed), failing open by design. NON-THROWING, like the rest of the
+ * Returns true when AT LEAST ONE such commit is the agent's own. Every uncertain
+ * outcome — no branch name, a branch that does not resolve, or a failed git call —
+ * returns FALSE (unattributed), failing open by design: a missed branch-jack still
+ * leaves a warn log and recoverable commits, while a false failure escalates to a
+ * human and dents the task type's success rate. NON-THROWING, like the rest of the
  * module.
- *
- * Residual (documented, not guarded): a `git pull --rebase` on the primary that
- * REWRITES a commit the agent's branch also carries produces a post-spawn copy
- * patch-equivalent to the agent's, which still attributes. Closing it would mean
- * excluding the agent's own inherited commits from the patch-id set first; the
- * scenario needs the agent branch to already carry a primary-local commit, which
- * a fresh worktree branch (based on `origin/<default>`) does not.
  */
-async function isDriftAttributableToAgent(checkoutPath, { runBase, driftedHead, agentBranch }) {
+async function isDriftAttributableToAgent(checkoutPath, { runBase, upstream, driftedHead, agentBranch }) {
   const agentSha = await resolveAgentBranchSha(checkoutPath, agentBranch);
   if (!agentSha) return false;
-  // Cheap short-circuit: a branch that carries no commit of its own past the run
-  // baseline (a read-only reasoner's untouched worktree branch) cannot have
-  // authored anything, so skip the cherry walk. `git cherry` reaches the same
-  // verdict on its own — this only avoids the extra call on the common case.
-  const ownCommits = await countCommitsAhead(checkoutPath, runBase, agentSha);
-  if (!ownCommits) return false;
-  // Count the run-window NON-MERGE commits — matching what `git cherry` walks. A
-  // merge commit strays onto the primary via a human's `git merge` or a non-ff
-  // pull (never a `/do:pr` branch-jack), and `git cherry` skips it; counting it
-  // here would leave `stranded > foreign` true on arithmetic alone and re-blame
-  // the very false-positive this guard exists to prevent.
-  const runWindowNonMerge = await countCommitsAhead(checkoutPath, runBase, driftedHead, { noMerges: true });
-  if (!runWindowNonMerge) return false;
-  // `git cherry <upstream> <head> <limit>` walks the run-window non-merge commits
-  // (`limit..head`) and prints a line for each that <upstream> (the agent's
-  // branch) does NOT already contain: `-` when a patch-equivalent copy exists
-  // there, `+` when the commit is foreign to it. Commits the agent's branch holds
-  // outright (same SHA) are omitted entirely. So a run-window commit is the agent's
-  // UNLESS git cherry marks it `+`; the drift is attributed unless EVERY run-window
-  // non-merge commit is foreign.
+  // Candidate branch-jack commits (set S): new this run (`^runBase`) AND unpushed
+  // (`^upstream`, when there is an upstream to compare against), non-merge only — a
+  // merge commit reaches the primary via a human's `git merge` / non-ff pull, never a
+  // `/do:pr` branch-jack.
+  const strandedExcludes = upstream ? [upstream] : [];
+  const strandedTotal = await countCommitsAhead(checkoutPath, runBase, driftedHead, { noMerges: true, excludes: strandedExcludes });
+  if (!strandedTotal) return false;
+  // Literal branch-jack: a candidate commit also on the agent's branch by SHA (a
+  // fast-forward of the agent's own commit onto the primary). `git cherry` omits these,
+  // so detect them by reachability: if excluding the agent's branch drops the count,
+  // some candidate commit is the agent's.
+  const strandedNotOnAgent = await countCommitsAhead(checkoutPath, runBase, driftedHead, { noMerges: true, excludes: [...strandedExcludes, agentSha] });
+  if (strandedNotOnAgent < strandedTotal) return true;
+  // Patch-equivalent branch-jack: a cherry-picked / rebased copy (different SHA, missed
+  // by the reachability check). `git cherry <upstream> <head> <limit>` marks such a
+  // commit `-`. Walk unpushed commits (limit = upstream), then keep only a `-` commit
+  // that is new this run — a pre-run copy is a prior run's problem, not this one's.
   const cherry = await execGit(
-    ['cherry', agentSha, driftedHead, runBase],
+    ['cherry', '-v', agentSha, driftedHead, upstream || runBase],
     checkoutPath,
     { ignoreExitCode: true, timeout: GIT_TIMEOUT_MS },
   ).catch(() => null);
   if (!cherry || cherry.exitCode !== 0) return false;
-  const foreign = (cherry.stdout || '').split('\n').filter(line => line.startsWith('+')).length;
-  return runWindowNonMerge > foreign;
+  const equivalentShas = (cherry.stdout || '')
+    .split('\n')
+    .filter(line => line.startsWith('- '))
+    .map(line => line.split(' ')[1])
+    .filter(Boolean);
+  for (const sha of equivalentShas) {
+    const ancestor = await execGit(
+      ['merge-base', '--is-ancestor', sha, runBase],
+      checkoutPath,
+      { ignoreExitCode: true, timeout: GIT_TIMEOUT_MS },
+    ).catch(() => null);
+    // exitCode 1 → sha is NOT an ancestor of runBase → created during the run.
+    if (ancestor && ancestor.exitCode === 1) return true;
+  }
+  return false;
 }
 
 /** Short SHA for human-readable prose. */
@@ -321,6 +320,7 @@ export async function detectPrimaryCheckoutDrift(baseline, { agentBranch = null 
   if (strandedCount === null || strandedCount > 0) {
     const attributed = await isDriftAttributableToAgent(baseline.path, {
       runBase: baseline.head,
+      upstream,
       driftedHead: current.head,
       agentBranch,
     });

--- a/server/lib/primaryCheckoutGuard.js
+++ b/server/lib/primaryCheckoutGuard.js
@@ -183,51 +183,70 @@ async function resolveAgentBranchSha(checkoutPath, agentBranch) {
 }
 
 /**
- * Was the drift plausibly THIS agent's doing (#3703)? Compares the stranded
- * commits (everything the drifted checkout carries past `strandedBase`) against
- * the agent's own worktree branch by PATCH-ID via `git cherry`, so a
- * cherry-picked or rebased copy still matches — a raw-SHA check would miss
- * exactly the case the original #3680 incident could have produced.
+ * Was the drift plausibly THIS agent's doing (#3703)? Compares the commits that
+ * appeared on the primary DURING THE RUN (`runBase..driftedHead`, where `runBase`
+ * is the checkout's HEAD at spawn) against the agent's own worktree branch by
+ * PATCH-ID via `git cherry`, so a cherry-picked or rebased copy still matches — a
+ * raw-SHA check would miss exactly the case the original #3680 incident could have
+ * produced.
  *
- * Returns true when AT LEAST ONE stranded commit is the agent's own — either
+ * The window is anchored at `runBase`, NOT at the branch's upstream: a commit that
+ * was ALREADY stranded on the primary at spawn (and happens to also live on the
+ * agent's branch — a fresh worktree branch is cut from the primary's `main`, so it
+ * inherits the primary's unpushed commits) would otherwise be counted as stranded
+ * yet omitted from the foreign tally by `git cherry` (same SHA), silently supplying
+ * the `+1` that flips `stranded > foreign` and re-blaming the agent for a drift
+ * another actor caused — the very #3703 regression. Only a commit created after
+ * spawn can be this run's branch-jack, so pre-run history is excluded from
+ * attribution (the reported `unpushedCount` still measures against the upstream —
+ * that is what a human recovers).
+ *
+ * Returns true when AT LEAST ONE run-window commit is the agent's own — either
  * literally on its branch (same SHA) or patch-equivalent to one there (a
  * cherry-picked / rebased copy). Every uncertain outcome — no branch name, a
  * branch that does not resolve, a branch with no commits of its own (Case A: a
  * read-only reasoner that never branched), or a failed git call — returns FALSE
  * (unattributed), failing open by design. NON-THROWING, like the rest of the
  * module.
+ *
+ * Residual (documented, not guarded): a `git pull --rebase` on the primary that
+ * REWRITES a commit the agent's branch also carries produces a post-spawn copy
+ * patch-equivalent to the agent's, which still attributes. Closing it would mean
+ * excluding the agent's own inherited commits from the patch-id set first; the
+ * scenario needs the agent branch to already carry a primary-local commit, which
+ * a fresh worktree branch (based on `origin/<default>`) does not.
  */
-async function isDriftAttributableToAgent(checkoutPath, { strandedBase, driftedHead, agentBranch }) {
+async function isDriftAttributableToAgent(checkoutPath, { runBase, driftedHead, agentBranch }) {
   const agentSha = await resolveAgentBranchSha(checkoutPath, agentBranch);
   if (!agentSha) return false;
-  // Cheap short-circuit: a branch that carries no commit of its own past the
-  // stranded base (a read-only reasoner's untouched worktree branch) cannot have
+  // Cheap short-circuit: a branch that carries no commit of its own past the run
+  // baseline (a read-only reasoner's untouched worktree branch) cannot have
   // authored anything, so skip the cherry walk. `git cherry` reaches the same
   // verdict on its own — this only avoids the extra call on the common case.
-  const ownCommits = await countCommitsAhead(checkoutPath, strandedBase, agentSha);
+  const ownCommits = await countCommitsAhead(checkoutPath, runBase, agentSha);
   if (!ownCommits) return false;
-  // Count the stranded NON-MERGE commits — matching what `git cherry` walks. A
+  // Count the run-window NON-MERGE commits — matching what `git cherry` walks. A
   // merge commit strays onto the primary via a human's `git merge` or a non-ff
   // pull (never a `/do:pr` branch-jack), and `git cherry` skips it; counting it
   // here would leave `stranded > foreign` true on arithmetic alone and re-blame
   // the very false-positive this guard exists to prevent.
-  const strandedNonMerge = await countCommitsAhead(checkoutPath, strandedBase, driftedHead, { noMerges: true });
-  if (!strandedNonMerge) return false;
-  // `git cherry <upstream> <head> <limit>` walks the stranded non-merge commits
+  const runWindowNonMerge = await countCommitsAhead(checkoutPath, runBase, driftedHead, { noMerges: true });
+  if (!runWindowNonMerge) return false;
+  // `git cherry <upstream> <head> <limit>` walks the run-window non-merge commits
   // (`limit..head`) and prints a line for each that <upstream> (the agent's
   // branch) does NOT already contain: `-` when a patch-equivalent copy exists
   // there, `+` when the commit is foreign to it. Commits the agent's branch holds
-  // outright (same SHA) are omitted entirely. So a stranded commit is the agent's
-  // UNLESS git cherry marks it `+`; the drift is attributed unless EVERY stranded
+  // outright (same SHA) are omitted entirely. So a run-window commit is the agent's
+  // UNLESS git cherry marks it `+`; the drift is attributed unless EVERY run-window
   // non-merge commit is foreign.
   const cherry = await execGit(
-    ['cherry', agentSha, driftedHead, strandedBase],
+    ['cherry', agentSha, driftedHead, runBase],
     checkoutPath,
     { ignoreExitCode: true, timeout: GIT_TIMEOUT_MS },
   ).catch(() => null);
   if (!cherry || cherry.exitCode !== 0) return false;
   const foreign = (cherry.stdout || '').split('\n').filter(line => line.startsWith('+')).length;
-  return strandedNonMerge > foreign;
+  return runWindowNonMerge > foreign;
 }
 
 /** Short SHA for human-readable prose. */
@@ -301,7 +320,7 @@ export async function detectPrimaryCheckoutDrift(baseline, { agentBranch = null 
   const strandedCount = unpushedCount === null ? commitCount : unpushedCount;
   if (strandedCount === null || strandedCount > 0) {
     const attributed = await isDriftAttributableToAgent(baseline.path, {
-      strandedBase: upstream || baseline.head,
+      runBase: baseline.head,
       driftedHead: current.head,
       agentBranch,
     });

--- a/server/lib/primaryCheckoutGuard.test.js
+++ b/server/lib/primaryCheckoutGuard.test.js
@@ -165,6 +165,27 @@ describe('detectPrimaryCheckoutDrift', () => {
     expect(verdict.unattributed).toBe(true);
   });
 
+  it('does not blame an agent that inherited the primary\'s pre-run unpushed commit (#3703 regression)', async () => {
+    // The primary already carried an unpushed commit at spawn, and the agent branch
+    // was cut from that HEAD (so it "inherits" that commit) while the agent committed
+    // NOTHING. A foreign actor then strands its own commit during the run. Anchoring
+    // attribution at the branch upstream would count the inherited commit as stranded
+    // yet omit it from the foreign tally (same SHA) — flipping stranded > foreign and
+    // failing a read-only agent. Anchoring at the run baseline excludes it.
+    await addOrigin();
+    const agentBranch = 'cos/task-x/agent-y';
+    await commit('primary local unpushed commit'); // on main, ahead of origin/main
+    const baseline = await capturePrimaryCheckoutState(repo);
+    await execGit(['branch', agentBranch], repo); // agent branch at the inherited HEAD, no own commits
+    await commit('a foreign actor\'s commit'); // strands during the run
+
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch });
+    expect(verdict.drifted).toBe(false);
+    expect(verdict.unattributed).toBe(true);
+    // Both the inherited and the foreign commit are unpushed, but neither is the agent's.
+    expect(verdict.unpushedCount).toBe(2);
+  });
+
   it('never attributes a branch-jack to a read-only reasoner that never branched (Case A)', async () => {
     const baseline = await capturePrimaryCheckoutState(repo);
     // A 24-file commit lands on main mid-run, authored by another actor.

--- a/server/lib/primaryCheckoutGuard.test.js
+++ b/server/lib/primaryCheckoutGuard.test.js
@@ -94,12 +94,21 @@ describe('detectPrimaryCheckoutDrift', () => {
     expect(verdict).toEqual({ drifted: false });
   });
 
-  it('detects commits landed on the primary checkout during the run', async () => {
+  it('detects commits landed on the primary checkout when they are the agent\'s own', async () => {
+    const agentBranch = 'cos/task-x/agent-y';
     const baseline = await capturePrimaryCheckoutState(repo);
+    // The agent made its two commits on its OWN worktree branch...
+    await execGit(['checkout', '-b', agentBranch], repo);
     await commit('branch jacked one');
     await commit('branch jacked two');
+    const agentTip = (await capturePrimaryCheckoutState(repo)).head;
+    // ...and a stray `/do:pr` from the worktree applied patch-equivalent copies
+    // onto the PRIMARY's main (cherry-pick → different SHAs, so only the patch-id
+    // gate attributes them — a raw-SHA check would miss this).
+    await execGit(['checkout', 'main'], repo);
+    await execGit(['cherry-pick', `${baseline.head}..${agentTip}`], repo);
 
-    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch: 'cos/task-x/agent-y' });
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch });
     expect(verdict.drifted).toBe(true);
     expect(verdict.reason).toBe(PRIMARY_CHECKOUT_MUTATED_REASON);
     expect(verdict.category).toBe(PRIMARY_CHECKOUT_MUTATED_CATEGORY);
@@ -108,8 +117,65 @@ describe('detectPrimaryCheckoutDrift', () => {
     expect(verdict.message).toContain('main');
     expect(verdict.message).toContain('2 new commits');
     // ...and the fix names the agent branch plus the exact recovery command.
-    expect(verdict.suggestedFix).toContain('cos/task-x/agent-y');
+    expect(verdict.suggestedFix).toContain(agentBranch);
     expect(verdict.suggestedFix).toContain(`git -C ${repo} reset --hard origin/main`);
+  });
+
+  it('does NOT blame the agent for a stranded commit it did not author (unattributed)', async () => {
+    await addOrigin();
+    const agentBranch = 'cos/task-x/agent-y';
+    const baseline = await capturePrimaryCheckoutState(repo);
+    // The agent's own branch carries an UNRELATED commit of its own...
+    await execGit(['checkout', '-b', agentBranch], repo);
+    await commit('the agent\'s actual work');
+    await execGit(['checkout', 'main'], repo);
+    // ...while a different actor stranded a commit on the primary's main.
+    await commit('someone else\'s commit');
+
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch });
+    // Stranded, but no patch-equivalent on the agent branch → surfaced, not failed.
+    expect(verdict.drifted).toBe(false);
+    expect(verdict.unattributed).toBe(true);
+    expect(verdict.unpushedCount).toBe(1);
+    expect(verdict.message).toContain('main');
+    expect(verdict.suggestedFix).toBeUndefined();
+  });
+
+  it('never attributes a branch-jack to a read-only reasoner that never branched (Case A)', async () => {
+    const baseline = await capturePrimaryCheckoutState(repo);
+    // A 24-file commit lands on main mid-run, authored by another actor.
+    await commit('a big commit from elsewhere');
+
+    // The reasoner carried no worktree branch at all — it is structurally
+    // impossible for it to have authored the commit, so it must not be blamed.
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch: null });
+    expect(verdict.drifted).toBe(false);
+    expect(verdict.unattributed).toBe(true);
+    expect(verdict.commitCount).toBe(1);
+  });
+
+  it('never attributes when the agent branch has zero commits of its own', async () => {
+    await addOrigin();
+    const agentBranch = 'cos/task-x/agent-y';
+    // Branch exists but points at the same commit as origin/main — no own commits.
+    await execGit(['branch', agentBranch, 'origin/main'], repo);
+    const baseline = await capturePrimaryCheckoutState(repo);
+    await commit('a commit from another actor');
+
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch });
+    expect(verdict.drifted).toBe(false);
+    expect(verdict.unattributed).toBe(true);
+  });
+
+  it('degrades to unattributed when the agent branch cannot be resolved', async () => {
+    await addOrigin();
+    const baseline = await capturePrimaryCheckoutState(repo);
+    await commit('stranded by an unknown actor');
+
+    // A branch name that resolves to nothing is uncertainty, not proof — fail open.
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch: 'cos/never-created' });
+    expect(verdict.drifted).toBe(false);
+    expect(verdict.unattributed).toBe(true);
   });
 
   it('detects a branch switch even with no new commits', async () => {
@@ -139,11 +205,19 @@ describe('detectPrimaryCheckoutDrift', () => {
 
   it('still reports the agent\'s own commit when a pull landed alongside it', async () => {
     await addOrigin();
+    const agentBranch = 'cos/task-x/agent-y';
     const baseline = await capturePrimaryCheckoutState(repo);
-    await pullFromOrigin('landed via a merged PR');
+    // The agent's real commit lives on its own branch...
+    await execGit(['checkout', '-b', agentBranch], repo);
     await commit('branch jacked');
+    const agentTip = (await capturePrimaryCheckoutState(repo)).head;
+    await execGit(['checkout', 'main'], repo);
+    // ...a pull brought an unrelated merged commit onto main...
+    await pullFromOrigin('landed via a merged PR');
+    // ...and the agent's own commit was (wrongly) applied to main too.
+    await execGit(['cherry-pick', agentTip], repo);
 
-    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch: 'cos/task-x/agent-y' });
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch });
     expect(verdict.drifted).toBe(true);
     // HEAD moved 2, but only 1 is stranded — the recovery prose quotes the
     // stranded count, not the movement.
@@ -166,13 +240,18 @@ describe('detectPrimaryCheckoutDrift', () => {
     expect(verdict.suggestedFix).not.toContain('reset --hard');
   });
 
-  it('reports movement on a branch with no upstream to clear it against', async () => {
+  it('reports an attributed commit on a branch with no upstream to clear it against', async () => {
     // No `origin` at all: an unpushed commit is unreviewed by definition, so the
-    // narrowed guard must not go quiet just because it cannot compare.
+    // guard must not go quiet just because it cannot compare against an upstream —
+    // it attributes against the run baseline instead. The commit IS the agent's.
+    const agentBranch = 'cos/task-x/agent-y';
     const baseline = await capturePrimaryCheckoutState(repo);
+    await execGit(['checkout', '-b', agentBranch], repo);
     await commit('branch jacked, nowhere to push');
+    await execGit(['checkout', 'main'], repo);
+    await execGit(['merge', '--ff-only', agentBranch], repo);
 
-    const verdict = await detectPrimaryCheckoutDrift(baseline);
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch });
     expect(verdict.drifted).toBe(true);
     expect(verdict.unpushedCount).toBeNull();
     expect(verdict.commitCount).toBe(1);

--- a/server/lib/primaryCheckoutGuard.test.js
+++ b/server/lib/primaryCheckoutGuard.test.js
@@ -141,6 +141,30 @@ describe('detectPrimaryCheckoutDrift', () => {
     expect(verdict.suggestedFix).toBeUndefined();
   });
 
+  it('does not let a stranded MERGE commit inflate attribution into a false positive', async () => {
+    // A human `git merge` / non-ff pull strands `merge + N` commits on the primary,
+    // but `git cherry` only ever walks the N non-merge commits. Counting the merge
+    // among the stranded set would make `stranded > foreign` true on arithmetic
+    // alone and re-blame the agent for a merge it never made.
+    await addOrigin();
+    const agentBranch = 'cos/task-x/agent-y';
+    const baseline = await capturePrimaryCheckoutState(repo);
+    // The agent has a genuine commit of its own (passes the own-commits gate)...
+    await execGit(['checkout', '-b', agentBranch], repo);
+    await commit('the agent\'s own work');
+    // ...while a foreign branch is merged into the primary's main (non-ff → a merge
+    // commit), none of it patch-equivalent to the agent's commit.
+    await execGit(['checkout', 'main'], repo);
+    await execGit(['checkout', '-b', 'a-foreign-branch'], repo);
+    await commit('a foreign commit');
+    await execGit(['checkout', 'main'], repo);
+    await execGit(['merge', '--no-ff', '-m', 'Merge a-foreign-branch', 'a-foreign-branch'], repo);
+
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch });
+    expect(verdict.drifted).toBe(false);
+    expect(verdict.unattributed).toBe(true);
+  });
+
   it('never attributes a branch-jack to a read-only reasoner that never branched (Case A)', async () => {
     const baseline = await capturePrimaryCheckoutState(repo);
     // A 24-file commit lands on main mid-run, authored by another actor.

--- a/server/lib/primaryCheckoutGuard.test.js
+++ b/server/lib/primaryCheckoutGuard.test.js
@@ -291,10 +291,15 @@ describe('detectPrimaryCheckoutDrift', () => {
     expect(await detectPrimaryCheckoutDrift(baseline)).toEqual({ drifted: false });
   });
 
-  it('still reports the drift when the commit count is unresolvable', async () => {
+  it('fails OPEN (unattributed, not a failure) when the stranded count is unresolvable', async () => {
+    // A pruned/rewritten baseline commit or a wedged git leaves the stranded count
+    // null — a check that could not run. Attribution cannot confirm the agent
+    // authored anything, so the guard surfaces the movement without manufacturing a
+    // failure out of it (the module's fail-open contract).
     const baseline = { path: repo, branch: 'main', head: 'f'.repeat(40) };
-    const verdict = await detectPrimaryCheckoutDrift(baseline);
-    expect(verdict.drifted).toBe(true);
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch: 'cos/task-x/agent-y' });
+    expect(verdict.drifted).toBe(false);
+    expect(verdict.unattributed).toBe(true);
     expect(verdict.commitCount).toBeNull();
     expect(verdict.message).toContain('commit count unresolved');
   });

--- a/server/lib/primaryCheckoutGuard.test.js
+++ b/server/lib/primaryCheckoutGuard.test.js
@@ -186,6 +186,33 @@ describe('detectPrimaryCheckoutDrift', () => {
     expect(verdict.unpushedCount).toBe(2);
   });
 
+  it('does not blame the agent for a shared upstream commit a pull brought in mid-run (#3703 regression)', async () => {
+    // The primary was BEHIND origin at spawn; the agent branch was cut from the newer
+    // origin (so it carries the shared commit R); during the run the primary pulls R and
+    // a foreign actor also strands F. R is on both the upstream and the agent branch, so
+    // `git cherry` omits it — anchoring only at the run baseline would still count it and
+    // blame the agent. Excluding upstream commits leaves F alone, which isn't the agent's.
+    await addOrigin();
+    const agentBranch = 'cos/task-x/agent-y';
+    const contributor = join(scratch, 'contributor-shared');
+    await execGit(['clone', join(scratch, 'origin.git'), contributor], scratch);
+    await execGit(['config', 'user.email', 'other@example.com'], contributor);
+    await execGit(['config', 'user.name', 'Other Contributor'], contributor);
+    await writeFile(join(contributor, 'shared-R.txt'), 'shared upstream R');
+    await execGit(['add', '-A'], contributor);
+    await execGit(['commit', '-m', 'shared upstream R'], contributor);
+    await execGit(['push', 'origin', 'main'], contributor);
+    await execGit(['fetch', 'origin'], repo);
+    await execGit(['branch', agentBranch, 'origin/main'], repo); // agent branch carries R
+    const baseline = await capturePrimaryCheckoutState(repo); // primary still BEHIND, at the initial commit
+    await execGit(['merge', '--ff-only', 'origin/main'], repo); // the run pulls R onto the primary
+    await commit('a foreign actor commit'); // ...and a foreign commit strands alongside it
+
+    const verdict = await detectPrimaryCheckoutDrift(baseline, { agentBranch });
+    expect(verdict.drifted).toBe(false);
+    expect(verdict.unattributed).toBe(true);
+  });
+
   it('never attributes a branch-jack to a read-only reasoner that never branched (Case A)', async () => {
     const baseline = await capturePrimaryCheckoutState(repo);
     // A 24-file commit lands on main mid-run, authored by another actor.

--- a/server/services/agentFinalization.js
+++ b/server/services/agentFinalization.js
@@ -595,6 +595,15 @@ export async function finalizeAgent({
     emitLog('warn', `⚠️ ${drift.message} — reported by ${agentId}; PortOS will not repair it automatically`, {
       agentId, taskId: task?.id, category: drift.category
     });
+  } else if (drift.unattributed) {
+    // #3703: commits WERE stranded on the primary, but none are patch-equivalent
+    // to this agent's own branch — another actor (a coding-on-main agent, the
+    // human's terminal, `update.sh`'s pull) moved it. Unreviewed commits on the
+    // primary are still worth surfacing, but this run did not cause them, so it is
+    // warn-logged WITHOUT downgrading an otherwise-successful run to a failure.
+    emitLog('warn', `⚠️ ${drift.message} — not attributable to ${agentId}; surfacing without failing the run`, {
+      agentId, taskId: task?.id
+    });
   } else if (drift.fastForwarded) {
     // Movement without stranded commits — a pull, not a branch-jack. Logged so
     // "the primary moved during this run" stays visible without being a failure.

--- a/server/services/agentFinalization.primaryCheckoutDrift.test.js
+++ b/server/services/agentFinalization.primaryCheckoutDrift.test.js
@@ -75,6 +75,7 @@ vi.mock('./agentCompletion.js', () => ({ processAgentCompletion: vi.fn(async () 
 vi.mock('./agentSummaryExtraction.js', () => ({ extractSimplifySummaries: vi.fn(() => null) }));
 
 import { checkPrimaryCheckoutDrift, finalizeAgent } from './agentFinalization.js';
+import { emitLog } from './cosEvents.js';
 import { PRIMARY_CHECKOUT_MUTATED_CATEGORY, PRIMARY_CHECKOUT_MUTATED_REASON } from '../lib/primaryCheckoutGuard.js';
 
 const BASELINE = { path: '/example/repo', branch: 'main', head: 'a'.repeat(40) };
@@ -88,6 +89,18 @@ const DRIFT = {
   commitCount: 3,
   message: 'Worktree agent mutated the primary checkout /example/repo: branch main, HEAD aaaaaaaaa → bbbbbbbbb (3 new commits)',
   suggestedFix: 'git -C /example/repo reset --hard origin/main',
+};
+
+// #3703: commits were stranded on the primary, but none are patch-equivalent to
+// this agent's own branch — a concurrent actor moved it. Warn-logged, not failed.
+const UNATTRIBUTED_DRIFT = {
+  drifted: false,
+  unattributed: true,
+  baseline: BASELINE,
+  current: { path: '/example/repo', branch: 'main', head: 'b'.repeat(40) },
+  commitCount: 1,
+  unpushedCount: 1,
+  message: 'Worktree agent mutated the primary checkout /example/repo: branch main, HEAD aaaaaaaaa → bbbbbbbbb (1 new commit)',
 };
 
 const task = () => ({ id: 'task-1', taskType: 'internal', description: 'ship something', metadata: {} });
@@ -190,5 +203,20 @@ describe('finalizeAgent — a worktree run that mutated the primary is not a suc
     detectPrimaryCheckoutDriftMock.mockRejectedValue(new Error('git wedged'));
     await finalize();
     expect(completeAgentMock).toHaveBeenCalledWith('agent-1', expect.objectContaining({ success: true }));
+  });
+
+  it('warn-logs an unattributed drift but does NOT downgrade a successful run', async () => {
+    // #3703: the primary moved and stranded commits, but they are not this agent's
+    // (no patch-equivalent on its branch). Surfacing without failing the run is the
+    // whole point — a false failure escalates to a human and dents the success rate.
+    detectPrimaryCheckoutDriftMock.mockResolvedValue(UNATTRIBUTED_DRIFT);
+    await finalize({ runId: 'run-1' });
+
+    expect(completeAgentMock).toHaveBeenCalledWith('agent-1', expect.objectContaining({ success: true }));
+    expect(updateTaskMock).toHaveBeenCalledWith('task-1', expect.objectContaining({ status: 'completed' }), 'internal');
+    // The run record is a clean success — no error analysis, not force-failed.
+    expect(completeAgentRunMock).toHaveBeenCalledWith('run-1', 'done', 0, 1000, null, null);
+    // ...but the unreviewed commits are still surfaced.
+    expect(emitLog).toHaveBeenCalledWith('warn', expect.stringContaining('not attributable to agent-1'), expect.anything());
   });
 });


### PR DESCRIPTION
## Summary

The primary-checkout branch-jack guard (`server/lib/primaryCheckoutGuard.js`, from #3680) decided a worktree agent mutated the shared primary checkout purely from HEAD movement during the run's time window — it never checked whether *this* agent could have produced those commits. The primary checkout is a shared global resource: a concurrent coding-on-main CoS agent, the human's own terminal, or `update.sh`'s `git pull --rebase --autostash` can move it, so the guard blamed whichever worktree agent's window the movement fell in, failed that run, and told the user to `git reset --hard origin/main`. Read-only reasoners (that never created a branch) and correctly-behaved agents were both escalated to a human on false positives, denting the task type's measured success rate.

This adds **patch-id attribution** as a second gate, after the existing unpushed-count / fast-forward gate:

- Once commits are stranded, `detectPrimaryCheckoutDrift` resolves the agent's own worktree branch — local ref first, then `refs/remotes/origin/<branch>` — and attributes the stranded commits with `git cherry <agentRef> <driftedHead> <strandedBase>`.
- A stranded commit is the agent's **unless** `git cherry` marks it foreign (`+`); commits the agent's branch holds outright (same SHA, omitted by `git cherry`) or as a patch-equivalent copy (`-`, cherry-picked / rebased) both attribute. So attribution uses patch-id, not raw SHA.
- If nothing attributes — or the agent branch has no ref / no commits of its own (Case A: a read-only reasoner that never branched), or git fails — it returns `{ drifted: false, unattributed: true, … }` carrying the message. This is fail-open by design: a missed branch-jack still leaves a warn log and recoverable commits, while a false failure escalates to a human.
- `agentFinalization.js#checkPrimaryCheckoutDrift` passes the new shape through; the unattributed shape is `emitLog('warn', …)`-surfaced (unreviewed commits on the primary are still worth flagging) but does **not** set `driftDowngrade`, so an otherwise-successful run stays successful. Only attributed drift still fails the run with the original message and recovery prose.

The module's existing NON-THROWING, fail-open contract is preserved throughout.

## Test plan

`server/lib/primaryCheckoutGuard.test.js` (real-git temp-repo tests, the suite's existing convention) and `server/services/agentFinalization.primaryCheckoutDrift.test.js` cover every acceptance criterion:

- A stranded commit patch-equivalent to a commit on the agent's branch still fails the run (no regression on the real #3680 case) — including a cherry-picked copy with a different SHA (patch-id, not SHA).
- A stranded commit with no patch-equivalent on the agent's branch → `drifted: false, unattributed: true`, warn-logged, successful run stays successful.
- An agent that never branched, or whose branch carries zero commits of its own, is never attributed (Case A).
- An unresolvable agent branch degrades to unattributed, never a manufactured failure.
- A pull landing an unrelated merge commit alongside the agent's own commit still reports the one stranded, attributed commit.

Run:

```
cd server && npm test -- primaryCheckoutGuard agentFinalization
```

→ 120 passed. The remaining full-suite failures in this environment are the DB-backed suites that require a running PostgreSQL (`npm run test:db`); they are unrelated to this change, which touches no DB code.

Closes #3703. Refs #3680.
