### PR TITLE
docs: correct brctl exit-0 iCloud materialization claims (#3708)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -36,7 +36,7 @@
 
 ## Fixed
 
-- **iCloud materialization logs now say a download was *requested*, not that the file is local.** `brctl download` returns exit 0 the moment it accepts and queues the request — it does not block until the bytes arrive, and it returns 0 even when the sync layer ultimately can't fetch the file. The on-demand materialize path logged that exit 0 as "materialized from iCloud", so an operator reading these lines during an iCloud outage would conclude a file was readable when it was still dataless. The logs now report the request, and the code comments spell out that the authoritative check is the `stat()` re-screen in `readIfMaterialized` — the reason the subsequent re-read stays safe and must not be removed. No behavior change.
+- **iCloud materialization logs now say a download was *requested*, not that the file is local.** `brctl download` returns exit 0 the moment it accepts and queues the request — it does not block until the bytes arrive, and it returns 0 even when the sync layer ultimately can't fetch the file. The on-demand materialize path logged that exit 0 as "materialized from iCloud", so an operator reading these lines during an iCloud outage would conclude a file was readable when it was still dataless. The logs now report the request, and the code comments spell out that the read path (`readStoreAtPathResult`/`readIfMaterialized`) fails closed — rejecting a dataless file rather than reading it — which is the reason the subsequent re-read stays safe and must not be removed. No behavior change.
 
 - Preserve a Series Autopilot run's reasoning-effort override when the foundation gate delegates a worldbuilding repair to Universe Builder.
 

--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -36,6 +36,8 @@
 
 ## Fixed
 
+- **iCloud materialization logs now say a download was *requested*, not that the file is local.** `brctl download` returns exit 0 the moment it accepts and queues the request — it does not block until the bytes arrive, and it returns 0 even when the sync layer ultimately can't fetch the file. The on-demand materialize path logged that exit 0 as "materialized from iCloud", so an operator reading these lines during an iCloud outage would conclude a file was readable when it was still dataless. The logs now report the request, and the code comments spell out that the authoritative check is the `stat()` re-screen in `readIfMaterialized` — the reason the subsequent re-read stays safe and must not be removed. No behavior change.
+
 - Preserve a Series Autopilot run's reasoning-effort override when the foundation gate delegates a worldbuilding repair to Universe Builder.
 
 - Keep foundation worldbuilding repairs focused on the narrative bible they actually persist instead of spending most of the response on discarded image-prompt variations, reference sheets, and canon candidates.

--- a/server/lib/icloudFile.js
+++ b/server/lib/icloudFile.js
@@ -313,11 +313,13 @@ export function requestMaterialization(path, options = {}) {
   child.on('exit', (code, signal) => {
     settle();
     if (code === 0) {
-      // brctl exit 0 means the download was ACCEPTED AND QUEUED, not that the
-      // bytes are local yet — brctl returns immediately and materializes async
-      // (and returns 0 even when the sync layer ultimately can't fetch the file).
-      // Log a request, not a completion, so an operator reading these during an
-      // outage doesn't conclude the file is now readable when it isn't.
+      // brctl exit 0 means the download was ACCEPTED/QUEUED, not that the bytes
+      // are local yet — brctl can return 0 before materialization completes, and
+      // returns 0 even when the sync layer ultimately can't fetch the file. It is
+      // not a completion signal (and under a wedged iCloud brctl can instead hang,
+      // which is why the awaited-write path bounds it with a timeout). Log a
+      // request, not a completion, so an operator reading these during an outage
+      // doesn't conclude the file is now readable when it isn't.
       console.log(`📥 ${label} iCloud download requested: ${path}`);
       return;
     }

--- a/server/lib/icloudFile.js
+++ b/server/lib/icloudFile.js
@@ -313,7 +313,12 @@ export function requestMaterialization(path, options = {}) {
   child.on('exit', (code, signal) => {
     settle();
     if (code === 0) {
-      console.log(`📥 ${label} materialized from iCloud: ${path}`);
+      // brctl exit 0 means the download was ACCEPTED AND QUEUED, not that the
+      // bytes are local yet — brctl returns immediately and materializes async
+      // (and returns 0 even when the sync layer ultimately can't fetch the file).
+      // Log a request, not a completion, so an operator reading these during an
+      // outage doesn't conclude the file is now readable when it isn't.
+      console.log(`📥 ${label} iCloud download requested: ${path}`);
       return;
     }
     notifyFailure();

--- a/server/services/mortalLoomStore.js
+++ b/server/services/mortalLoomStore.js
@@ -156,15 +156,17 @@ function icloudPlaceholderPath(path) {
 // dataless (Optimize-Mac-Storage-evicted) file or an `.icloud` placeholder.
 //
 // CRITICAL: exit 0 means the download was ACCEPTED/QUEUED, NOT that the bytes are
-// local. brctl returns 0 as soon as it queues the request — it does not block
-// until materialization completes, and it returns 0 even when the sync layer
-// ultimately can't fetch the file (device offline / iCloud wedged). So a `true`
-// here is NOT proof the file is readable. What makes the caller's subsequent
-// re-read safe is the `stat()` re-screen in `readIfMaterialized` (see
-// readStoreAtPathResult): it re-checks st_blocks and rejects with
-// ICLOUD_NOT_MATERIALIZED again if the bytes still aren't local, so a false-
-// positive `true` from here just falls back through to refuse-to-overwrite
-// rather than issuing a read that would hang the libuv threadpool.
+// local. brctl can return 0 before materialization completes, and returns 0 even
+// when the sync layer ultimately can't fetch the file (device offline / iCloud
+// wedged); under a wedged iCloud it can instead hang, which is why we await it
+// with a timeout below. So a `true` here is NOT proof the file is readable. What
+// keeps the caller's subsequent re-read safe is that it routes through
+// `readIfMaterialized` (see readStoreAtPathResult), which returns a store it could
+// NOT actually read as null instead of issuing a blocking read: a still-dataless
+// file rejects on the `Stats.blocks` re-screen with ICLOUD_NOT_MATERIALIZED, and
+// an absent path shadowed by a legacy `.icloud` placeholder rejects on ENOENT.
+// Either way the store stays null and the caller refuses to overwrite, so a
+// false-positive `true` from here can never truncate data (nor hang the pool).
 //
 // We await brctl's exit (bounded by a timeout) and let the caller re-read.
 // Resolves `true` only on a clean exit-0 — non-darwin, missing brctl, spawn
@@ -444,11 +446,12 @@ export async function updateStore(mutator) {
   if (unsafeToSeed) {
     // `materializeNow` resolving `true` only means brctl ACCEPTED the download
     // request (exit 0), NOT that the bytes are local — see its docblock. Do NOT
-    // remove the re-read's re-screen on the strength of that `true`: `readStoreAtPath`
-    // routes through `readIfMaterialized`, whose `stat()` check re-verifies the file
-    // is actually materialized and rejects again (→ store stays null → refuse to
-    // overwrite) if it isn't. That re-screen is the authority that keeps this path
-    // failing closed instead of issuing a read that would hang the threadpool.
+    // remove the re-read's screening on the strength of that `true`: `readStoreAtPath`
+    // routes through `readIfMaterialized`, which returns null for a store it could
+    // not actually read instead of issuing a blocking read — a still-dataless file
+    // rejects on the `stat()` re-screen, an absent-but-placeholder-shadowed path
+    // rejects on ENOENT. Either way store stays null and we refuse to overwrite
+    // rather than issuing a read that would hang the threadpool.
     const materialized = await materializeNow(path);
     if (materialized) {
       store = await readStoreAtPath(path);

--- a/server/services/mortalLoomStore.js
+++ b/server/services/mortalLoomStore.js
@@ -152,13 +152,25 @@ function icloudPlaceholderPath(path) {
 
 // Unlike the fire-and-forget pinAgainstEviction() at boot, the write path needs
 // to KNOW an evicted file is materialized before deciding whether refusing to
-// overwrite is warranted. `brctl download <path>` materializes a dataless
-// (Optimize-Mac-Storage-evicted) file or an `.icloud` placeholder and exits 0
-// once the bytes are local; we await that exit (bounded by a timeout) and let
-// the caller re-read. Resolves `true` only on a clean exit-0 — non-darwin,
-// missing brctl, spawn error, timeout, and non-zero exit all resolve `false`,
-// every one of which falls through to the caller's existing refuse-to-overwrite
-// guard. So this can only ever recover the situation, never worsen it.
+// overwrite is warranted. `brctl download <path>` asks iCloud to materialize a
+// dataless (Optimize-Mac-Storage-evicted) file or an `.icloud` placeholder.
+//
+// CRITICAL: exit 0 means the download was ACCEPTED/QUEUED, NOT that the bytes are
+// local. brctl returns 0 as soon as it queues the request — it does not block
+// until materialization completes, and it returns 0 even when the sync layer
+// ultimately can't fetch the file (device offline / iCloud wedged). So a `true`
+// here is NOT proof the file is readable. What makes the caller's subsequent
+// re-read safe is the `stat()` re-screen in `readIfMaterialized` (see
+// readStoreAtPathResult): it re-checks st_blocks and rejects with
+// ICLOUD_NOT_MATERIALIZED again if the bytes still aren't local, so a false-
+// positive `true` from here just falls back through to refuse-to-overwrite
+// rather than issuing a read that would hang the libuv threadpool.
+//
+// We await brctl's exit (bounded by a timeout) and let the caller re-read.
+// Resolves `true` only on a clean exit-0 — non-darwin, missing brctl, spawn
+// error, timeout, and non-zero exit all resolve `false`, every one of which
+// falls through to the caller's existing refuse-to-overwrite guard. So this can
+// only ever recover the situation, never worsen it.
 //
 // Exposed (not const) so tests can drop the timeout without waiting on it.
 export let MATERIALIZE_TIMEOUT_MS = 20000;
@@ -430,10 +442,17 @@ export async function updateStore(mutator) {
     ? !isPlainObject(store)
     : existsSync(icloudPlaceholderPath(path));
   if (unsafeToSeed) {
+    // `materializeNow` resolving `true` only means brctl ACCEPTED the download
+    // request (exit 0), NOT that the bytes are local — see its docblock. Do NOT
+    // remove the re-read's re-screen on the strength of that `true`: `readStoreAtPath`
+    // routes through `readIfMaterialized`, whose `stat()` check re-verifies the file
+    // is actually materialized and rejects again (→ store stays null → refuse to
+    // overwrite) if it isn't. That re-screen is the authority that keeps this path
+    // failing closed instead of issuing a read that would hang the threadpool.
     const materialized = await materializeNow(path);
     if (materialized) {
       store = await readStoreAtPath(path);
-      console.log(`📥 MortalLoom store materialized from iCloud before write: ${path}`);
+      console.log(`📥 MortalLoom store iCloud download requested before write: ${path}`);
     }
     if (!isPlainObject(store)) {
       // Log the resolved path server-side for diagnostics; keep the thrown

--- a/server/services/mortalLoomStore.js
+++ b/server/services/mortalLoomStore.js
@@ -160,13 +160,17 @@ function icloudPlaceholderPath(path) {
 // when the sync layer ultimately can't fetch the file (device offline / iCloud
 // wedged); under a wedged iCloud it can instead hang, which is why we await it
 // with a timeout below. So a `true` here is NOT proof the file is readable. What
-// keeps the caller's subsequent re-read safe is that it routes through
-// `readIfMaterialized` (see readStoreAtPathResult), which returns a store it could
-// NOT actually read as null instead of issuing a blocking read: a still-dataless
-// file rejects on the `Stats.blocks` re-screen with ICLOUD_NOT_MATERIALIZED, and
-// an absent path shadowed by a legacy `.icloud` placeholder rejects on ENOENT.
-// Either way the store stays null and the caller refuses to overwrite, so a
-// false-positive `true` from here can never truncate data (nor hang the pool).
+// keeps the caller's subsequent re-read safe is `readStoreAtPathResult`: it calls
+// `readIfMaterialized`, which REJECTS rather than issuing a blocking read for a
+// file it can't safely read — a still-dataless file rejects with
+// ICLOUD_NOT_MATERIALIZED (its `Stats.blocks` screen); an absent path shadowed by
+// a legacy `.icloud` placeholder surfaces as ENOENT — and `readStoreAtPathResult`
+// catches both and yields `store: null` (which `readStoreAtPath` unwraps). Either
+// way the store stays null and the caller refuses to overwrite, so a false-
+// positive `true` from here can't truncate data. (It does not eliminate the
+// bounded eviction race documented in `readIfMaterialized`, which can still
+// strand one threadpool slot per path — see server/lib/icloudFile.js — but this
+// path never makes that worse.)
 //
 // We await brctl's exit (bounded by a timeout) and let the caller re-read.
 // Resolves `true` only on a clean exit-0 — non-darwin, missing brctl, spawn
@@ -447,11 +451,12 @@ export async function updateStore(mutator) {
     // `materializeNow` resolving `true` only means brctl ACCEPTED the download
     // request (exit 0), NOT that the bytes are local — see its docblock. Do NOT
     // remove the re-read's screening on the strength of that `true`: `readStoreAtPath`
-    // routes through `readIfMaterialized`, which returns null for a store it could
-    // not actually read instead of issuing a blocking read — a still-dataless file
+    // → `readStoreAtPathResult` calls `readIfMaterialized`, which REJECTS instead of
+    // issuing a blocking read for a file it can't safely read — a still-dataless file
     // rejects on the `stat()` re-screen, an absent-but-placeholder-shadowed path
-    // rejects on ENOENT. Either way store stays null and we refuse to overwrite
-    // rather than issuing a read that would hang the threadpool.
+    // surfaces as ENOENT — and `readStoreAtPathResult` catches both and returns
+    // `store: null`. Either way store stays null and we refuse to overwrite rather
+    // than reading blindly (which is what would risk stranding a threadpool slot).
     const materialized = await materializeNow(path);
     if (materialized) {
       store = await readStoreAtPath(path);


### PR DESCRIPTION
## Summary

`brctl download <path>` returns exit 0 the moment it **accepts and queues** the download request — it does not block until the bytes are local, and it returns 0 even when the sync layer ultimately can't fetch the file (device offline / iCloud wedged). Two places in the iCloud materialization path claimed otherwise. This corrects the claims; **no behavior changes.**

- `server/lib/icloudFile.js` — `requestMaterialization`'s exit-0 branch logged `📥 <label> materialized from iCloud`, which reads as "the file is now local." During an iCloud outage an operator would wrongly conclude the file is readable. It now logs that the download was **requested**, with a comment explaining why exit 0 ≠ bytes-local.
- `server/services/mortalLoomStore.js` — `materializeNow`'s docblock said `brctl download` "exits 0 once the bytes are local." It now states exit 0 means the request was **accepted**, and names the `stat()` re-screen in `readIfMaterialized` (reached via `readStoreAtPath` → `readStoreAtPathResult`) as the authority that makes the subsequent re-read safe. The parallel `updateStore` "materialized before write" log is corrected to "download requested before write" for the same reason.
- `server/services/mortalLoomStore.js` — added a comment at the `materializeNow` → re-read call site in `updateStore` recording **why the re-screen cannot be removed**: a false-positive `true` from `materializeNow` falls back through to refuse-to-overwrite because `readIfMaterialized` re-verifies with `stat()` and rejects again if the bytes still aren't local — which is what keeps the path failing closed instead of issuing a read that would hang the libuv threadpool.

## Test plan

- `cd server && npx vitest run services/mortalLoomStore lib/icloudFile` → **108 passed**.
- Full `cd server && npm test`: the only failures are the 53 PostgreSQL-backed suites, which fail solely on the test-runner DB guard (`portos_test` cannot be provisioned in this environment due to a pre-existing schema-setup error unrelated to this change). Zero assertion errors; neither edited file appears among the failures. This change touches only comments and log strings — no DB, no runtime behavior.

Closes #3708
