### PR TITLE
prefill the video prompt from the render being continued

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -1,0 +1,5 @@
+# Unreleased
+
+## Changed
+
+- **Continuing a video carries its prompt forward.** Continuing or extending a clip we generated now prefills the Video Gen prompt (and negative prompt) with the one that produced the source, instead of dropping you into an empty box. This covers both entry points: the **Continue** action on a video card/lightbox, and picking a prior render in Extend mode. Text you typed yourself is never overwritten — only a blank box or a value an earlier pick filled — and a clip we didn't generate (an import, or a legacy render with no stored prompt) leaves the field alone rather than clearing it. The style preset is dropped along with the prefill, since history stores the already-composed prompt and re-applying a preset would prefix it twice.

--- a/client/src/components/videoGen/ExtendPanel.jsx
+++ b/client/src/components/videoGen/ExtendPanel.jsx
@@ -5,6 +5,10 @@
  * Presentational — the picked video id, in-flight extract flag, extracted
  * source-image filename, and the visible history list are owned by the
  * VideoGen page. `onPick('')` clears the selection.
+ *
+ * `onPick` also receives the picked record itself, since this is where the
+ * option list lives: the form prefills its prompt from it, and looking it up
+ * here beats handing the whole history array down into the form hook.
  */
 import ImagePreview from './ImagePreview';
 
@@ -26,7 +30,7 @@ export default function ExtendPanel({
       <select
         value={extendFromVideoId}
         disabled={extendingFrame}
-        onChange={(e) => onPick(e.target.value)}
+        onChange={(e) => onPick(e.target.value, visibleHistory.find((v) => v.id === e.target.value))}
         aria-label="Pick a previous video to extend"
         className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-xs text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
       >

--- a/client/src/components/videoGen/ExtendPanel.test.jsx
+++ b/client/src/components/videoGen/ExtendPanel.test.jsx
@@ -20,7 +20,8 @@ describe('ExtendPanel', () => {
       />,
     );
     fireEvent.change(screen.getByLabelText(/Pick a previous video to extend/i), { target: { value: 'v1' } });
-    expect(onPick).toHaveBeenCalledWith('v1');
+    // The picked record rides along — the form prefills its prompt from it.
+    expect(onPick).toHaveBeenCalledWith('v1', HISTORY[0]);
   });
 
   it('shows the extracting state and disables the picker', () => {

--- a/client/src/hooks/useMediaPreviewActions.js
+++ b/client/src/hooks/useMediaPreviewActions.js
@@ -25,6 +25,24 @@ function buildImageGenParams(item) {
   return params;
 }
 
+// Common params for every /media/video handoff — Send-to-Video (an image
+// becomes the i2v source) and Continue (a clip's last frame does). Both open
+// the form on the direction that produced the source, so the user isn't
+// retyping a prompt the record already carries. `(no prompt)` is the sidecar
+// placeholder for items that lost theirs — skip it so the next render doesn't
+// start with that literal, and an item we never generated lands on a blank
+// prompt rather than a bogus one. The caller adds `sourceImageFile`, which is
+// the only thing that differs between the two.
+function buildVideoGenParams(item) {
+  const params = new URLSearchParams();
+  if (item.prompt && item.prompt !== '(no prompt)') params.set('prompt', item.prompt);
+  const neg = item.negativePrompt || item.raw?.negativePrompt || item.raw?.negative_prompt;
+  if (neg) params.set('negativePrompt', neg);
+  if (item.width) params.set('w', String(item.width));
+  if (item.height) params.set('h', String(item.height));
+  return params;
+}
+
 /**
  * Shared MediaPreview / MediaLightbox action handlers. The same four
  * callbacks (`onRemix`, `onSendToVideo`, `onContinue`, `onClean`) used to
@@ -113,17 +131,11 @@ export default function useMediaPreviewActions({ onCleanComplete = null } = {}) 
   }, [navigate]);
 
   // Send to Video: open the Video Gen page with the image queued as the
-  // i2v source. `negativePrompt` is resolved from any of the legacy aliases
-  // (`raw.negativePrompt` / `raw.negative_prompt`) so older metadata still
-  // populates the field.
+  // i2v source.
   const handleSendToVideo = useCallback((item) => {
     if (!item?.filename) return;
-    const params = new URLSearchParams({ sourceImageFile: item.filename });
-    if (item.prompt && item.prompt !== '(no prompt)') params.set('prompt', item.prompt);
-    const neg = item.negativePrompt || item.raw?.negativePrompt || item.raw?.negative_prompt;
-    if (neg) params.set('negativePrompt', neg);
-    if (item.width) params.set('w', String(item.width));
-    if (item.height) params.set('h', String(item.height));
+    const params = buildVideoGenParams(item);
+    params.set('sourceImageFile', item.filename);
     navigate(`/media/video?${params}`);
   }, [navigate]);
 
@@ -139,6 +151,9 @@ export default function useMediaPreviewActions({ onCleanComplete = null } = {}) 
   // with it as the i2v source — the canonical "extend this take" path.
   // `item.id` is the video job id; extractLastFrame returns the new image
   // filename. Toast handles the error path; the caller doesn't need to.
+  // Takes the NORMALIZED item (normalizeVideo) — buildVideoGenParams reads the
+  // prompt/negative off that shape, so a raw history record must be normalized
+  // by the caller rather than passed through.
   const handleContinue = useCallback(async (item) => {
     if (!item?.id) return;
     const { filename } = await extractLastFrame(item.id, { silent: true }).catch((err) => {
@@ -146,9 +161,8 @@ export default function useMediaPreviewActions({ onCleanComplete = null } = {}) 
       return {};
     });
     if (!filename) return;
-    const params = new URLSearchParams({ sourceImageFile: filename });
-    if (item.width) params.set('w', String(item.width));
-    if (item.height) params.set('h', String(item.height));
+    const params = buildVideoGenParams(item);
+    params.set('sourceImageFile', filename);
     navigate(`/media/video?${params}`);
   }, [navigate]);
 

--- a/client/src/hooks/useMediaPreviewActions.test.jsx
+++ b/client/src/hooks/useMediaPreviewActions.test.jsx
@@ -11,7 +11,7 @@ vi.mock('../services/apiImageVideo', () => ({
   removeImageWatermark: vi.fn(),
 }));
 
-import { removeImageWatermark, cleanGalleryImage } from '../services/apiImageVideo';
+import { removeImageWatermark, cleanGalleryImage, extractLastFrame } from '../services/apiImageVideo';
 
 const parseNav = () => {
   const url = navigate.mock.calls.at(-1)?.[0] || '';
@@ -55,6 +55,34 @@ describe('useMediaPreviewActions.handleSendToImage', () => {
     result.current.handleSendToImage({ kind: 'video', filename: 'clip.mp4' });
     result.current.handleSendToImage({ kind: 'image' });
     expect(navigate).not.toHaveBeenCalled();
+  });
+});
+
+describe('useMediaPreviewActions.handleContinue', () => {
+  beforeEach(() => { navigate.mockReset(); extractLastFrame.mockReset(); });
+
+  it('carries the source clip prompt into the continuation form', async () => {
+    extractLastFrame.mockResolvedValue({ filename: 'last.png' });
+    const { result } = renderHook(() => useMediaPreviewActions());
+    await result.current.handleContinue({
+      kind: 'video', id: 'vid-1', prompt: 'a neon alley, rain', width: 768, height: 512,
+      raw: { negative_prompt: 'blurry' },
+    });
+    const { path, params } = parseNav();
+    expect(path).toBe('/media/video');
+    expect(params.get('sourceImageFile')).toBe('last.png');
+    expect(params.get('prompt')).toBe('a neon alley, rain');
+    expect(params.get('negativePrompt')).toBe('blurry');
+    expect(params.get('w')).toBe('768');
+  });
+
+  it('leaves the prompt out for a clip we did not generate', async () => {
+    extractLastFrame.mockResolvedValue({ filename: 'last.png' });
+    const { result } = renderHook(() => useMediaPreviewActions());
+    await result.current.handleContinue({ kind: 'video', id: 'vid-2', prompt: '(no prompt)' });
+    const { params } = parseNav();
+    expect(params.get('sourceImageFile')).toBe('last.png');
+    expect(params.get('prompt')).toBeNull();
   });
 });
 

--- a/client/src/hooks/useVideoGenForm.js
+++ b/client/src/hooks/useVideoGenForm.js
@@ -150,8 +150,13 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled })
       setMode((m) => (m === 'text' ? 'image' : m));
     }
   }, [incomingSourceImage]);
+  // A prompt handed in through the URL (Continue, Send-to-Video, Remix) is the
+  // COMPOSED prompt of an existing render — composeStyledPrompt already prefixed
+  // it with whatever style preset produced it. Drop the picker's selection with
+  // it, or the next submit prefixes a preset onto a prompt that already carries
+  // one (the same double-styling applyRemix clears the preset to avoid).
   useEffect(() => {
-    if (incomingPrompt) setPrompt(incomingPrompt);
+    if (incomingPrompt) { setPrompt(incomingPrompt); setStylePreset(null); }
   }, [incomingPrompt]);
   useEffect(() => {
     if (incomingNegativePrompt) setNegativePrompt(incomingNegativePrompt);
@@ -714,7 +719,35 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled })
   // Capture the token at request time and only apply the result when it
   // still matches the latest pick.
   const extendPickTokenRef = useRef(0);
-  const handleExtendPick = async (videoId) => {
+  // Fill a prompt field the user hasn't claimed: blank, or still holding the
+  // exact text an earlier pick put there. Text the user typed is never
+  // clobbered, and re-picking a different source still replaces a stale
+  // auto-fill. Returns whether it filled.
+  const autofilledRef = useRef({});
+  const fillIfUntouched = (key, value, current, setter) => {
+    if (!value || (current.trim() && current !== autofilledRef.current[key])) return false;
+    setter(value);
+    autofilledRef.current[key] = value;
+    return true;
+  };
+  // Continuing a shot almost always means continuing its direction too, so
+  // picking a source render drops that render's own prompt into the form
+  // instead of leaving the user to retype it. A source with no prompt (a clip
+  // we didn't generate, or a legacy render made before prompts were stamped)
+  // is a no-op, not a wipe.
+  const prefillPromptFromSource = (source) => {
+    if (!source) return;
+    const srcPrompt = (source.prompt === '(no prompt)' ? '' : source.prompt || '').trim();
+    const srcNeg = (source.negativePrompt || source.negative_prompt || '').trim();
+    // History stores the COMPOSED prompt (composeStyledPrompt prefixes the
+    // preset), so a preset left selected would prefix itself a second time on
+    // the next submit — the same reason applyRemix clears it.
+    if (fillIfUntouched('prompt', srcPrompt, prompt, setPrompt)) setStylePreset(null);
+    fillIfUntouched('negativePrompt', srcNeg, negativePrompt, setNegativePrompt);
+  };
+  // `source` is the history record behind `videoId`, supplied by the picker
+  // that rendered it — the hook never needs the whole history list for this.
+  const handleExtendPick = async (videoId, source = null) => {
     // Bumping the token cancels any in-flight extract from a prior pick:
     // the awaited promise still resolves, but the result-application block
     // sees the mismatch and bails. Clearing the spinner here too means a
@@ -727,6 +760,9 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled })
       setExtendingFrame(false);
       return;
     }
+    // Carry the source render's prompt forward before the runtime branch below,
+    // so both the ltx2 (no extraction) and legacy (ffmpeg extract) paths prefill.
+    prefillPromptFromSource(source);
     // ltx2 runtime: native ExtendPipeline conditions on the entire source
     // video's latent, so we DON'T need a last-frame PNG. Skip the ffmpeg
     // extract roundtrip — the route resolves the video id to a disk path

--- a/client/src/hooks/useVideoGenForm.test.jsx
+++ b/client/src/hooks/useVideoGenForm.test.jsx
@@ -142,6 +142,49 @@ describe('useVideoGenForm', () => {
     expect(payload.sourceImageFile).toBe('');
   });
 
+  it('prefills the prompt from the render being continued, dropping the style preset', async () => {
+    const first = { id: 'vid-1', prompt: 'a neon alley, rain', negativePrompt: 'blurry' };
+    const second = { id: 'vid-2', prompt: 'a desert highway' };
+    const { result } = render();
+    await waitFor(() => expect(result.current.modelId).toBe(MLX.id));
+    // The stored prompt is already style-composed; leaving a preset selected
+    // would prefix a second one onto it at submit.
+    act(() => result.current.setStylePreset({ id: 'noir', prompt: 'film noir' }));
+
+    extractLastFrame.mockResolvedValue({ filename: 'last.png' });
+    act(() => result.current.handleModeChange('extend'));
+    await act(async () => { await result.current.handleExtendPick('vid-1', first); });
+    expect(result.current.prompt).toBe('a neon alley, rain');
+    expect(result.current.negativePrompt).toBe('blurry');
+    expect(result.current.stylePreset).toBeNull();
+    expect(result.current.buildGeneratePayload().prompt).toBe('a neon alley, rain');
+
+    // Re-picking replaces the earlier auto-fill rather than stranding it, and
+    // a source with no negative leaves the earlier fill standing (not wiped).
+    await act(async () => { await result.current.handleExtendPick('vid-2', second); });
+    expect(result.current.prompt).toBe('a desert highway');
+    expect(result.current.negativePrompt).toBe('blurry');
+  });
+
+  it('never clobbers a typed prompt, and leaves it alone for a source with none', async () => {
+    const { result } = render();
+    await waitFor(() => expect(result.current.modelId).toBe(MLX.id));
+    extractLastFrame.mockResolvedValue({ filename: 'last.png' });
+    act(() => result.current.handleModeChange('extend'));
+
+    act(() => result.current.setPrompt('my own direction'));
+    await act(async () => {
+      await result.current.handleExtendPick('vid-1', { id: 'vid-1', prompt: 'a neon alley, rain' });
+    });
+    expect(result.current.prompt).toBe('my own direction');
+
+    // A clip we didn't generate carries no prompt — prefill is a no-op, not a wipe.
+    await act(async () => {
+      await result.current.handleExtendPick('imported', { id: 'imported', filename: 'clip.mp4' });
+    });
+    expect(result.current.prompt).toBe('my own direction');
+  });
+
   it('ignores a stale extract when a newer pick has already landed', async () => {
     const { result } = render();
     await waitFor(() => expect(result.current.modelId).toBe(MLX.id));

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -36,7 +36,7 @@
  */
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
-import { useSearchParams, useNavigate } from 'react-router';
+import { useSearchParams } from 'react-router';
 import Drawer from '../components/Drawer';
 import { ImageGenTab } from '../components/settings/ImageGenTab';
 import LocalSetupPanel from '../components/settings/LocalSetupPanel';
@@ -72,11 +72,12 @@ import { useMediaJobSse } from '../hooks/useMediaJobSse';
 import { useMediaCompletionRefresh } from '../hooks/useMediaCompletionRefresh';
 import { useMediaAnnotations } from '../hooks/useMediaAnnotations';
 import usePreviewRoute from '../hooks/usePreviewRoute';
+import useMediaPreviewActions from '../hooks/useMediaPreviewActions';
 import { useVideoGenQueue } from '../hooks/useVideoGenQueue.js';
 import { useVideoGenForm } from '../hooks/useVideoGenForm.js';
 import {
   getVideoGenStatus, generateVideo, cancelVideoGen,
-  listVideoHistory, deleteVideoHistoryItem, setVideoHidden, extractLastFrame,
+  listVideoHistory, deleteVideoHistoryItem, setVideoHidden,
   upscaleVideo,
   patchSettingsSlice,
   getActiveVideoJob,
@@ -222,7 +223,6 @@ export default function VideoGen() {
   // `preview` is URL-driven via `usePreviewRoute(previewItems)` — declared
   // after `previewItems` below so the resolver can match against it.
   const [showHidden, setShowHidden] = useState(false);
-  const navigate = useNavigate();
 
   const refreshHistory = useCallback(() => {
     listVideoHistory().then((items) => setHistory(Array.isArray(items) ? items : [])).catch(() => {});
@@ -236,6 +236,11 @@ export default function VideoGen() {
   }), [history]);
   const [favoritesOnly, setFavoritesOnly] = useState(false);
   const { annotations, updateAnnotation, getCardProps } = useMediaAnnotations();
+  // "Continue" is the same action here as on every other media surface (extract
+  // the last frame, open the form on it with the source's prompt), so it comes
+  // from the shared hook rather than a page-local copy. It takes the normalized
+  // shape — gallery callers hand over raw history records, so they normalize.
+  const { handleContinue } = useMediaPreviewActions();
   // Gallery sections respect the favorites filter; the extend-mode dropdown
   // (which reads visibleHistory directly) intentionally does not, since
   // hiding non-favorites from the "pick a previous video" picker would
@@ -286,18 +291,6 @@ export default function VideoGen() {
       setHistory((h) => [result.video, ...h]);
       toast.success('Upscaled 2×');
     }
-  };
-
-  const handleContinueHistory = async (item) => {
-    const { filename } = await extractLastFrame(item.id, { silent: true }).catch((err) => {
-      toast.error(err.message || 'Failed to extract last frame');
-      return {};
-    });
-    if (!filename) return;
-    const params = new URLSearchParams({ sourceImageFile: filename });
-    if (item?.width) params.set('w', String(item.width));
-    if (item?.height) params.set('h', String(item.height));
-    navigate(`/media/video?${params.toString()}`);
   };
 
   // Remix a prior render: hand all its params back into the form (the hook
@@ -1233,7 +1226,7 @@ export default function VideoGen() {
         onToggleFavorites={() => setFavoritesOnly((v) => !v)}
         onToggleShowHidden={() => setShowHidden((s) => !s)}
         onPreview={setPreview}
-        onContinue={handleContinueHistory}
+        onContinue={(v) => handleContinue(normalizeVideo(v))}
         onUpscale={handleUpscaleHistory}
         onDelete={handleDeleteHistory}
         onToggleHidden={handleToggleHistoryHidden}
@@ -1248,7 +1241,7 @@ export default function VideoGen() {
         items={previewItems}
         annotations={annotations}
         updateAnnotation={updateAnnotation}
-        onContinue={(item) => handleContinueHistory(item.raw)}
+        onContinue={handleContinue}
         onRemix={(item) => item?.raw && handleRemixVideo(item.raw)}
       />
 


### PR DESCRIPTION
## Summary

Continuing or extending a clip we generated dropped the user into an empty prompt box, so the obvious next step — keep going with the same direction — meant retyping (or hunting down) the prompt that produced the source. Both entry points now carry it forward:

- **Continue** (video card / lightbox, on any media surface) passes the source's prompt and negative prompt through the `/media/video` handoff alongside the extracted last frame.
- **Extend mode** prefills them in place when you pick a prior render from the picker.

Guard rails:

- Text the user typed is never overwritten — only a blank box, or a value an earlier pick filled (so re-picking a different source still replaces a stale auto-fill).
- A clip we didn't generate (an import, or a legacy render with no stored prompt) leaves the field alone rather than clearing it.
- The style preset is dropped alongside a prefill. History stores the already-*composed* prompt, so a preset left selected would prefix itself a second time at submit — the same reason `applyRemix` clears it.

### Consolidation along the way

- `VideoGen.jsx`'s hand-copied `handleContinueHistory` is deleted in favor of the shared `useMediaPreviewActions.handleContinue`. It was a third copy of the `/media/video` handoff contract and had already diverged on the negative-prompt alias chain; the gallery now normalizes its raw record (`normalizeVideo`) and the lightbox passes its already-normalized item straight through instead of un-normalizing it with `item.raw`.
- The two `/media/video` param builders (`handleSendToVideo` + `handleContinue`) collapse into one `buildVideoGenParams`, mirroring the existing `buildImageGenParams`.
- `useVideoGenForm` takes the picked record from the picker that rendered it rather than the whole history array, so no gallery data is threaded into the form hook.

## Test plan

- `client`: full suite green — 578 files / 6860 tests.
- New coverage: prefill + preset drop + re-pick replacement; typed-text-wins and missing-prompt-is-a-no-op; `handleContinue` carries prompt/negative and skips the `(no prompt)` placeholder; `ExtendPanel` hands back the picked record.
- Bypass-probed the new tests (removed the prefill call) to confirm they fail without the change.
- `biome lint --error-on-warnings src` clean; `vite build` succeeds.