### PR TITLE
fix: derive the Code Review Defaults CLI-reviewer help text from the roster (#3839)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -25,3 +25,4 @@
 ## Changed
 
 - Notification panel placement now goes through the shared popover-positioning hook that the theme switcher beside it already used, so it clamps into the viewport and flips above/below on its own instead of relying on hand-written positioning.
+- The Code Review Defaults panel now names every CLI reviewer in its help text, generated from the reviewer roster itself — the sentence used to spell them out by hand and fell behind twice as new reviewers shipped, telling users their CLI reviewers ran a different way than they do.

--- a/client/src/components/cos/ReviewerPicker.jsx
+++ b/client/src/components/cos/ReviewerPicker.jsx
@@ -12,10 +12,10 @@ import {
   cleanReviewUsername,
   normalizeReviewUsernames,
   reviewerEffortLevels,
+  reviewerLabel,
   sanitizeReviewerModelInput
 } from './constants';
 
-const labelFor = (value) => REVIEWER_OPTIONS.find(o => o.value === value)?.label || value;
 const normalizeReviewerValue = (value) => value === 'gemini' ? 'antigravity' : value;
 
 /**
@@ -150,7 +150,7 @@ export default function ReviewerPicker({
       tone="warning"
       size="xs"
       className="shrink-0"
-      title={`${labelFor(token)}'s CLI binary wasn't found on this machine. It still runs (federation-wide config), but the review loop here will report it unsatisfied until it's installed.`}
+      title={`${reviewerLabel(token)}'s CLI binary wasn't found on this machine. It still runs (federation-wide config), but the review loop here will report it unsatisfied until it's installed.`}
     >
       not installed
     </Pill>
@@ -263,7 +263,7 @@ export default function ReviewerPicker({
   // the static ladder when it didn't, so a caller that passes no `modelOptions`
   // keeps a working (just unnarrowed) select rather than losing the cell.
   const renderEffortCell = (token) => {
-    const subject = labelFor(token);
+    const subject = reviewerLabel(token);
     const stored = efforts.get(token) ?? '';
     const ladder = reviewerEffortLevels(token);
     if (!ladder?.length) return renderNoPinCell(`${subject} has no reasoning-effort control`);
@@ -348,8 +348,8 @@ export default function ReviewerPicker({
   // messaging so a pre-fetch render doesn't accuse a healthy backend of being
   // empty.
   const renderModelCell = (token) => {
-    if (!MODEL_SELECTABLE_REVIEWERS.includes(token)) return renderNoPinCell(`${labelFor(token)} takes no model`);
-    const subject = labelFor(token);
+    if (!MODEL_SELECTABLE_REVIEWERS.includes(token)) return renderNoPinCell(`${reviewerLabel(token)} takes no model`);
+    const subject = reviewerLabel(token);
     const value = models.get(token) ?? '';
     const options = modelOptions?.optionsByReviewer?.[token] || [];
     const inputId = `${id}-model-${token}`;
@@ -493,7 +493,7 @@ export default function ReviewerPicker({
                       disabled={disabled || index === 0}
                       onClick={() => move(index, -1)}
                       className="text-gray-500 hover:text-white disabled:opacity-30 disabled:hover:text-gray-500"
-                      aria-label={`Move ${labelFor(value)} earlier`}
+                      aria-label={`Move ${reviewerLabel(value)} earlier`}
                     >
                       <ChevronUp size={12} />
                     </button>
@@ -502,13 +502,13 @@ export default function ReviewerPicker({
                       disabled={disabled || index === selected.length - 1}
                       onClick={() => move(index, 1)}
                       className="text-gray-500 hover:text-white disabled:opacity-30 disabled:hover:text-gray-500"
-                      aria-label={`Move ${labelFor(value)} later`}
+                      aria-label={`Move ${reviewerLabel(value)} later`}
                     >
                       <ChevronDown size={12} />
                     </button>
                   </div>
                   <span className="flex items-center gap-1 min-w-0 col-span-2 sm:col-span-1">
-                    <span className="text-xs text-gray-300 truncate">{labelFor(value)}</span>
+                    <span className="text-xs text-gray-300 truncate">{reviewerLabel(value)}</span>
                     {renderInstalledBadge(value)}
                   </span>
                   <span className={CELL_LABEL_CLASS}>Model</span>
@@ -517,19 +517,19 @@ export default function ReviewerPicker({
                   <div className="min-w-0">{renderEffortCell(value)}</div>
                   <span className={CELL_LABEL_CLASS}>Optional</span>
                   <div>
-                    {renderOptToggle(value, labelFor(value), isOptional(value)
-                      ? `${labelFor(value)} is non-blocking (~opt): an inconclusive verdict from it won't block the merge. Click to make it blocking.`
-                      : `${labelFor(value)} gates the merge. Click to make it non-blocking (~opt) — its inconclusive verdicts won't block the merge (a hard failure still does).`)}
+                    {renderOptToggle(value, reviewerLabel(value), isOptional(value)
+                      ? `${reviewerLabel(value)} is non-blocking (~opt): an inconclusive verdict from it won't block the merge. Click to make it blocking.`
+                      : `${reviewerLabel(value)} gates the merge. Click to make it non-blocking (~opt) — its inconclusive verdicts won't block the merge (a hard failure still does).`)}
                   </div>
                   <span className={CELL_LABEL_CLASS}>Max iterations</span>
-                  <div>{renderMaxRounds(value, labelFor(value))}</div>
+                  <div>{renderMaxRounds(value, reviewerLabel(value))}</div>
                   <div className="col-span-2 sm:col-span-1 justify-self-end">
                     <button
                       type="button"
                       disabled={disabled}
                       onClick={() => remove(value)}
                       className="text-gray-500 hover:text-port-error"
-                      aria-label={`Remove ${labelFor(value)}`}
+                      aria-label={`Remove ${reviewerLabel(value)}`}
                     >
                       <X size={12} />
                     </button>

--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -13,6 +13,7 @@ import {
   Newspaper,
   ChartGantt
 } from 'lucide-react';
+import { normalizeReviewerSlug } from '../../lib/reviewerPins';
 
 export const TABS = [
   { id: 'briefing', label: 'Briefing', icon: Newspaper },
@@ -208,6 +209,13 @@ export const REVIEWER_OPTIONS = [
   { value: 'lmstudio', label: 'LM Studio', description: 'Local LM Studio model reviews the diff (set model on AI Providers)' },
   { value: 'ollama', label: 'Ollama', description: 'Local Ollama model reviews the diff (set model on AI Providers)' }
 ];
+// The display label for a reviewer token — the one place UI copy turns a
+// reviewer slug into prose, so a roster addition renders everywhere without a
+// literal edit. Resolves the `gemini` alias; an `@username` (or any token with no
+// option row) falls through to itself.
+export const reviewerLabel = (value) =>
+  REVIEWER_OPTIONS.find(o => o.value === normalizeReviewerSlug(value))?.label || value;
+
 // The per-reviewer PIN vocabularies (which reviewers take a model or an effort,
 // and the values each accepts) live in `client/src/lib/reviewerPins.js` and are
 // re-exported here so existing imports keep working. They are NOT defined in this

--- a/client/src/components/cos/constants.test.js
+++ b/client/src/components/cos/constants.test.js
@@ -10,7 +10,9 @@ import {
   MUSE_STATE_SEQUENCES,
   MUSE_ANIMATION_FALLBACK,
   MUSE_SPEAKING_GESTURE,
-  MUSE_ROOT_MOTION_CLIPS
+  MUSE_ROOT_MOTION_CLIPS,
+  MODEL_CAPABLE_CLI_REVIEWERS,
+  reviewerLabel
 } from './constants';
 
 // These mirror the server's domainBudgets/domainAutonomy helpers so the UI's
@@ -103,5 +105,26 @@ describe('getDomainMode (existing helper, sanity)', () => {
     expect(getDomainMode(undefined, 'cos')).toBe(DEFAULT_DOMAIN_MODE);
     expect(getDomainMode({ domainAutonomy: { cos: 'bogus' } }, 'cos')).toBe(DEFAULT_DOMAIN_MODE);
     expect(getDomainMode({ domainAutonomy: { cos: 'off' } }, 'cos')).toBe('off');
+  });
+});
+
+// The Code Review Defaults help text renders one label per MODEL_CAPABLE_CLI_REVIEWERS
+// entry (#3839). A roster addition with no matching REVIEWER_OPTIONS row would fall
+// back to the raw slug and print "the codex, Claude, … reviewers" in the panel.
+describe('reviewerLabel', () => {
+  it('gives every model-capable CLI reviewer a display label', () => {
+    for (const slug of MODEL_CAPABLE_CLI_REVIEWERS) {
+      const label = reviewerLabel(slug);
+      expect(label).toBeTruthy();
+      expect(label).not.toBe(slug);
+    }
+  });
+
+  it('resolves the gemini alias to Antigravity', () => {
+    expect(reviewerLabel('gemini')).toBe(reviewerLabel('antigravity'));
+  });
+
+  it('passes an @username token through unchanged', () => {
+    expect(reviewerLabel('@octocat')).toBe('@octocat');
   });
 });

--- a/client/src/components/providers/CodeReviewDefaultsPanel.jsx
+++ b/client/src/components/providers/CodeReviewDefaultsPanel.jsx
@@ -8,7 +8,16 @@ import { reviewerModelsFromDefaults, reviewerModelsToDefaults, reviewerEffortsFr
 import {
   DEFAULT_REVIEWERS,
   DEFAULT_REVIEW_STOP_MODE,
+  MODEL_CAPABLE_CLI_REVIEWERS,
+  reviewerLabel,
 } from '../cos/constants';
+
+// The CLI reviewers named in the help text below, derived from the roster the
+// schema and `pickCodeReviewDefaults` generate from rather than spelled out — the
+// literal sentence drifted twice as reviewers shipped (#3839). Adding a reviewer
+// to MODEL_CAPABLE_CLI_REVIEWERS now updates this copy with no edit here.
+const CLI_REVIEWER_LIST = new Intl.ListFormat('en', { style: 'long', type: 'conjunction' })
+  .format(MODEL_CAPABLE_CLI_REVIEWERS.map(reviewerLabel));
 
 // Global Code Review Defaults — the chain the Review Loop uses when a task or
 // task-type config didn't pin its own reviewers. Lives at the top of the AI
@@ -80,7 +89,7 @@ export default function CodeReviewDefaultsPanel() {
         <h2 className="text-base font-semibold text-white">Code Review Defaults</h2>
       </div>
       <p className="text-xs text-gray-500">
-        Default Review Loop reviewer chain — used by ad-hoc CoS tasks and task-type schedules that haven't pinned their own. Local-LLM reviewers route the diff through PortOS's local code-review endpoint; the Codex, Claude, Antigravity, and Grok reviewers invoke their CLI directly. Each runs the model pinned on its row (Claude also supports an Ollama-backed CLI for local-only setups — type one of your installed Ollama models).
+        Default Review Loop reviewer chain — used by ad-hoc CoS tasks and task-type schedules that haven't pinned their own. Local-LLM reviewers route the diff through PortOS's local code-review endpoint; the {CLI_REVIEWER_LIST} reviewers invoke their CLI directly. Each runs the model pinned on its row (Claude also supports an Ollama-backed CLI for local-only setups — type one of your installed Ollama models).
       </p>
 
       {loading ? (


### PR DESCRIPTION
## Summary

The Code Review Defaults panel's help text spelled out which reviewers invoke a CLI directly as a literal sentence, and it fell behind the roster twice as `antigravity` and `grok` shipped. The sentence is now generated from `MODEL_CAPABLE_CLI_REVIEWERS` — the same roster the schema and `pickCodeReviewDefaults` derive from — so a fifth CLI reviewer updates the copy with no edit to `CodeReviewDefaultsPanel.jsx`.

- `components/cos/constants.js` gains `reviewerLabel(value)`: the one place a reviewer slug turns into prose, resolving the `gemini` alias and passing `@username` tokens through. `ReviewerPicker` drops its private `labelFor` copy in favor of it.
- The panel formats `MODEL_CAPABLE_CLI_REVIEWERS.map(reviewerLabel)` through `Intl.ListFormat`, so the sentence keeps its Oxford-comma phrasing at any roster length.
- New tests pin that every model-capable CLI reviewer has a display label (a roster entry with no `REVIEWER_OPTIONS` row would otherwise print its raw slug in the copy), plus the alias and `@username` behaviors.

Closes #3839

## Test plan

- `cd client && npx vitest run src/components/cos/constants.test.js src/components/cos/ReviewerPicker.test.jsx` — 77 passed.
- `npx biome check` clean on the four touched files.
