### PR TITLE
fix: fold the series render pin into comic page and cover renders (#3840)

### DIFF
--- a/.changelog/NEXT.md
+++ b/.changelog/NEXT.md
@@ -21,6 +21,7 @@
 - Merge follow-ups already stranded that way are revived on upgrade, so the pull requests they left open finally land. Their blocking reason was exempt from both the failed-task reaper and the automatic retry, so they would otherwise have sat blocked forever.
 - Task metadata that has no value is no longer written to the task file at all. Any unset field previously became the literal word "null", which every reader then saw as a real value — the same class of bug as the blocked merge follow-up above. Task files an older version already wrote are repaired on read.
 - Blocking a task that exists to merge a pull request now raises a notification naming that PR, so it can be landed by hand instead of going unnoticed. This covers every way a task can get blocked, not just the one fixed above.
+- A series' pinned image backend now actually renders its comic pages and covers. The pin was saved on the series and honoured by first-pass portraits, but the comic stage sent the install-wide default as an explicit choice — which outranks any pin — so a series pinned to one backend quietly rendered every page and cover on another. The Pipeline visuals default from Settings → Image Gen now applies to these renders too, and a pin naming a backend you have since turned off falls back instead of failing the render.
 
 ## Changed
 

--- a/client/src/components/pipeline/stages/ComicScriptStage.jsx
+++ b/client/src/components/pipeline/stages/ComicScriptStage.jsx
@@ -36,7 +36,9 @@ import usePreviewRoute from '../../../hooks/usePreviewRoute';
 import Drawer from '../../Drawer';
 import ImageGenSettingsForm from '../../imageGen/ImageGenSettingsForm';
 import ExtractCanonButton from './ExtractCanonButton';
-import { deriveAvailableBackends, IMAGE_GEN_MODE } from '../../../lib/imageGenBackends';
+import {
+  applyRecordRenderPin, deriveAvailableBackends, IMAGE_GEN_MODE, renderTargetPin, RENDER_TARGET,
+} from '../../../lib/imageGenBackends';
 import {
   PIPELINE_IMAGE_DEFAULTS,
   readPipelineImageSettings,
@@ -248,7 +250,11 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
   useEffect(() => {
     let cancelled = false;
     Promise.all([
-      getSettings().catch(() => ({})),
+      // `null` on failure, NOT `{}` — a `{}` stand-in derives an empty backend
+      // list, which `renderPinLadder` reads as "loaded, nothing enabled" and
+      // uses to suppress every pin. A settings fetch that failed must not look
+      // like an install with no backends.
+      getSettings().catch(() => null),
       listImageModels().catch(() => []),
     ]).then(([s, modelList]) => {
       if (cancelled) return;
@@ -284,7 +290,24 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
     });
   }, [setSearchParams]);
 
-  const renderOpts = useMemo(() => pipelineImageCfgToRenderOpts(imageCfg), [imageCfg]);
+  // Comic pages and covers send an EXPLICIT `mode`, which outranks every pin on
+  // the server ladder (`resolveRenderTargetConfig`) — so the series' own render
+  // pin has to be folded in here or it does nothing (#3840). Ladder: the
+  // series' pin, then the Pipeline-visuals `renderDefaults` pin, then the saved
+  // stage config. `imageCfg` stays the raw saved config so the settings drawer
+  // keeps editing the install-wide default rather than a pin-overridden value.
+  // Backends pass as `null` until settings land — `[]` means "loaded, nothing
+  // enabled" and would suppress the pin entirely (see renderPinLadder).
+  const renderCfg = useMemo(
+    () => applyRecordRenderPin(
+      imageCfg,
+      [series, renderTargetPin(sysSettings, RENDER_TARGET.PIPELINE_VISUAL)],
+      sysSettings ? availableBackends : null,
+    ),
+    [imageCfg, sysSettings, availableBackends, series?.imageMode, series?.imageModelId],
+  );
+
+  const renderOpts = useMemo(() => pipelineImageCfgToRenderOpts(renderCfg), [renderCfg]);
 
   // Front + back cover live on stages.comicPages.cover / .backCover; both
   // persist alongside the page renders. Each owns a draft string separate
@@ -485,7 +508,7 @@ export default function ComicScriptStage({ issue, series, onStageUpdate, actions
             type="button"
             onClick={openImageSettings}
             className="inline-flex items-center gap-1 px-2 py-1.5 rounded-lg bg-port-card border border-port-border text-gray-300 text-xs hover:border-port-accent/50 hover:text-white"
-            title={`Image gen settings — backend: ${imageCfg.mode}`}
+            title={`Image gen settings — backend: ${renderCfg.mode}${renderCfg.mode === imageCfg.mode ? '' : ' (pinned by the series or the pipeline-visual default)'}`}
           >
             <SettingsIcon size={12} /> Image gen
           </button>

--- a/client/src/components/pipeline/stages/ComicScriptStage.renderPin.test.jsx
+++ b/client/src/components/pipeline/stages/ComicScriptStage.renderPin.test.jsx
@@ -1,0 +1,118 @@
+/**
+ * The series' own backend pin (Series → render pin row) has to reach the comic
+ * page / cover render bodies (#3840): those POST an EXPLICIT `mode`, and an
+ * explicit mode outranks every record pin on the server ladder
+ * (`resolveRenderTargetConfig`). Before this, a series pinned to agy rendered
+ * its covers on whatever the install-wide default resolved to.
+ *
+ * Asserts the WIRE BODY (what the server actually receives), not an internal
+ * memo — the memo is where the bug lived, the body is what proves it's fixed.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+vi.mock('../../../services/api', () => ({
+  PIPELINE_STAGE_LABELS: { comicScript: 'Comic Script' },
+  PIPELINE_STAGE_STATUS_LABEL: { empty: 'Empty', ready: 'Ready' },
+  PIPELINE_STAGE_STATUS_COLOR: {},
+  generatePipelineStage: vi.fn(),
+  extractPipelineComicPages: vi.fn(),
+  generatePipelineComicPage: vi.fn(),
+  generatePipelineComicCover: vi.fn(),
+  generatePipelineComicBackCover: vi.fn(),
+  generatePipelineComicCoverConcepts: vi.fn(),
+  updatePipelineComicPage: vi.fn(),
+  refinePipelineComicPageRender: vi.fn(),
+  updatePipelineIssue: vi.fn(),
+}));
+vi.mock('../../../services/apiSystem', () => ({
+  getSettings: vi.fn(),
+  patchSettingsSlice: vi.fn(),
+}));
+vi.mock('../../../services/apiImageVideo', () => ({ listImageModels: vi.fn() }));
+vi.mock('../../ui/Toast', () => ({
+  default: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
+import ComicScriptStage from './ComicScriptStage';
+import { generatePipelineComicCover } from '../../../services/api';
+import { getSettings } from '../../../services/apiSystem';
+import { listImageModels } from '../../../services/apiImageVideo';
+
+// Both cloud CLIs enabled, so `readPipelineImageSettings` resolves the
+// install-wide default to codex — which means an observed 'agy' can ONLY have
+// come from a pin.
+const CLOUD_ON = { codex: { enabled: true }, agy: { enabled: true } };
+
+const issue = {
+  id: 'iss-1',
+  seriesId: 'ser-1',
+  stages: {
+    comicScript: { status: 'ready', output: '' },
+    comicPages: { pages: [], cover: { script: 'Cover concept' } },
+  },
+};
+const series = { id: 'ser-1', name: 'Example Series' };
+
+const renderStage = (seriesRecord = series) => render(
+  <MemoryRouter>
+    <ComicScriptStage issue={issue} series={seriesRecord} onStageUpdate={vi.fn()} />
+  </MemoryRouter>,
+);
+
+// The cover "Render proof" button is the shortest path to a render body; the
+// page renders build theirs from the same `renderOpts`.
+const clickRenderProof = async () => {
+  // Flush the mount-time settings + model fetch. Clicking before those land
+  // would capture PIPELINE_IMAGE_DEFAULTS ('local') instead of the resolved
+  // ladder, and every case below would pass for the wrong reason.
+  await act(async () => { await Promise.resolve(); });
+  const buttons = await screen.findAllByRole('button', { name: /Render proof/i });
+  await userEvent.click(buttons[0]);
+  await waitFor(() => expect(generatePipelineComicCover).toHaveBeenCalled());
+  return generatePipelineComicCover.mock.calls[0][1];
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  listImageModels.mockResolvedValue([]);
+  generatePipelineComicCover.mockResolvedValue({ jobId: 'job-1', mode: 'agy' });
+});
+
+describe('ComicScriptStage — series render pin (#3840)', () => {
+  it('folds the series pin over the install-wide settings default', async () => {
+    getSettings.mockResolvedValue({ imageGen: CLOUD_ON });
+    renderStage({ ...series, imageMode: 'agy', imageModelId: 'gemini-3.5-pro' });
+    const body = await clickRenderProof();
+    expect(body.mode).toBe('agy');
+    expect(body.cloudModel).toBe('gemini-3.5-pro');
+  });
+
+  it('keeps the install-wide default for an unpinned series', async () => {
+    getSettings.mockResolvedValue({ imageGen: CLOUD_ON });
+    renderStage();
+    const body = await clickRenderProof();
+    expect(body.mode).toBe('codex');
+  });
+
+  it('falls through an unpinned series to the pipeline-visual renderDefaults pin', async () => {
+    getSettings.mockResolvedValue({
+      imageGen: CLOUD_ON,
+      renderDefaults: { 'pipeline-visual': { imageMode: 'agy', imageModel: 'gemini-3.5-pro' } },
+    });
+    renderStage();
+    const body = await clickRenderProof();
+    expect(body.mode).toBe('agy');
+    expect(body.cloudModel).toBe('gemini-3.5-pro');
+  });
+
+  it('ignores a pin whose backend this install no longer has enabled', async () => {
+    getSettings.mockResolvedValue({ imageGen: { codex: { enabled: true } } });
+    renderStage({ ...series, imageMode: 'agy' });
+    const body = await clickRenderProof();
+    expect(body.mode).toBe('codex');
+  });
+});

--- a/client/src/lib/imageGenModes.js
+++ b/client/src/lib/imageGenModes.js
@@ -55,6 +55,7 @@ export const RENDER_TARGET_BACKEND_AUTO = 'auto';
 // bound to the server's RENDER_TARGETS by renderTargets.parity.test.js.
 export const RENDER_TARGET = Object.freeze({
   UNIVERSE_BIBLE: 'universe-bible',
+  PIPELINE_VISUAL: 'pipeline-visual',
 });
 export const RENDER_TARGET_OPTIONS = Object.freeze([
   { id: 'universe-bible', label: 'Universe Bible & canon renders' },

--- a/client/src/pages/Sprites.jsx
+++ b/client/src/pages/Sprites.jsx
@@ -8,7 +8,7 @@ import {
   generateSpriteWalk, generateSpriteTrack, generateSpriteReference, listSpriteThumbnails,
 } from '../services/apiSprites.js';
 import { getSettings } from '../services/apiSystem.js';
-import { deriveAvailableBackends } from '../lib/imageGenBackends.js';
+import { deriveAvailableBackends, renderPinLadder } from '../lib/imageGenBackends.js';
 import ReferenceWorkflow from '../components/sprites/ReferenceWorkflow.jsx';
 import WalkWorkflow from '../components/sprites/WalkWorkflow.jsx';
 import TrackWorkflow from '../components/sprites/TrackWorkflow.jsx';
@@ -226,13 +226,20 @@ export default function Sprites() {
   // available, so a pinned-but-since-disabled backend degrades to the server
   // ladder's graceful fallback instead of being sent as an explicit (and
   // erroring) body.mode. Unpinned records keep the current page mode.
+  // `imageBackends || []` rather than `imageBackends`: `renderPinLadder` reads
+  // `null` as "availability unknown, don't gate", but this seat is a one-way
+  // seed into page state — a pin applied before the backend list lands would
+  // stick even if that backend turns out to be disabled. The effect re-runs
+  // once `imageBackends` loads, so gating on the loaded list loses nothing.
   const detailPinMode = detail?.record?.imageMode || '';
   const detailRecordId = detail?.record?.id || '';
+  const seedPinMode = useMemo(
+    () => renderPinLadder([{ imageMode: detailPinMode }], imageBackends || []).mode,
+    [detailPinMode, imageBackends],
+  );
   useEffect(() => {
-    if (detailPinMode && (imageBackends || []).some((b) => b.id === detailPinMode)) {
-      setImageMode(detailPinMode);
-    }
-  }, [detailPinMode, detailRecordId, imageBackends]);
+    if (seedPinMode) setImageMode(seedPinMode);
+  }, [seedPinMode, detailRecordId]);
 
   // Run ids the walk selection has approved. An approved run's strip/frames
   // never move on disk (approval is recorded in the selection, not the path),

--- a/server/lib/renderTargets.parity.test.js
+++ b/server/lib/renderTargets.parity.test.js
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { RENDER_TARGETS, RENDER_TARGET_BACKEND_AUTO } from './renderTargets.js';
+import { RENDER_TARGET, RENDER_TARGETS, RENDER_TARGET_BACKEND_AUTO } from './renderTargets.js';
 import {
   CLOUD_IMAGE_GEN_MODES, EDIT_INCAPABLE_IMAGE_MODES, IMAGE_GEN_MODES,
 } from '../services/imageGen/modes.js';
@@ -24,6 +24,7 @@ import { cloudPromptRequired, maxInputImages } from '../services/imageGen/cloudP
 // lucide-react, which is not installed in the server CI job (this exact import
 // broke main's CI when Phase 2 landed pointing at imageGenBackends).
 import {
+  RENDER_TARGET as CLIENT_RENDER_TARGET,
   RENDER_TARGET_OPTIONS as CLIENT_OPTIONS,
   RENDER_TARGET_BACKEND_AUTO as CLIENT_AUTO,
   I2I_CAPABLE_MODES as CLIENT_I2I_CAPABLE,
@@ -49,6 +50,16 @@ describe('render-target client mirror parity (#3231)', () => {
     for (const id of RENDER_TARGETS) {
       expect(client.has(id) || DELIBERATELY_UNLISTED.has(id),
         `server render target "${id}" is neither in client RENDER_TARGET_OPTIONS nor allowlisted as deliberately unlisted`).toBe(true);
+    }
+  });
+
+  // The client's named-id map is the subset of targets the CLIENT resolves
+  // itself via `renderTargetPin`. A drifting id there is worse than a drifting
+  // option label: the pin silently reads an absent `settings.renderDefaults`
+  // key and every render falls through to the install default with no error.
+  it('every client RENDER_TARGET id matches the server constant of the same name', () => {
+    for (const [name, id] of Object.entries(CLIENT_RENDER_TARGET)) {
+      expect(RENDER_TARGET[name], `client RENDER_TARGET.${name} has no server counterpart`).toBe(id);
     }
   });
 


### PR DESCRIPTION
## Summary

`PipelineSeries` persists `imageMode`/`imageModelId` on a series through the shared `RecordRenderPinRow`, but `ComicScriptStage` built its render body from install-wide settings and sent an explicit `mode` — which outranks every record pin on the server ladder (`resolveRenderTargetConfig`). So the series pin did nothing for comic pages and covers, even though `SERIES_FIRST_PASS` (resolved server-side) honoured it.

- `ComicScriptStage.jsx` now resolves the client-side ladder through the existing helpers: `applyRecordRenderPin(imageCfg, [series, renderTargetPin(settings, RENDER_TARGET.PIPELINE_VISUAL)], …)`. Availability is passed as `null` until settings land (`[]` means "loaded, nothing enabled" and would suppress every pin), so a pin naming a since-disabled backend falls through instead of queueing a job that can only 400. `imageCfg` stays the raw saved config, so the settings drawer keeps editing the install-wide default rather than a pin-overridden value.
- The mount-time settings fetch now falls back to `null` instead of `{}` — a `{}` stand-in derives an empty backend list, which reads as "nothing enabled" and silently suppresses the pin on a failed fetch.
- `PIPELINE_VISUAL` added to the client's `RENDER_TARGET` map, and `renderTargets.parity.test.js` now binds that named-id map to the server constants (it previously covered only `RENDER_TARGET_OPTIONS`). A drifting id there is a pin that reads an absent `renderDefaults` key and silently does nothing.
- `Sprites.jsx`'s hand-rolled pin + availability gate collapses onto `renderPinLadder` (it kept the loaded-list gate deliberately — that seat is a one-way seed into page state).

`NounsStage.jsx` was listed in the issue but needs no change: both of its render call sites already run `renderCfg`, and its renders are shared *universe* canon (same records as the Universe Builder's cast rows), so the universe pin + `UNIVERSE_BIBLE` rung is the correct ladder — a series pin must not retarget canon shared across crossover series.

Closes #3840

## Test plan

- New `client/src/components/pipeline/stages/ComicScriptStage.renderPin.test.jsx` asserts the **wire body** the server receives (not an internal memo) across all four rungs: series pin wins over the install default, an unpinned series keeps the default, `renderDefaults['pipeline-visual']` is the next rung, and a pin whose backend is disabled falls through. Verified as a real guard by reverting `renderOpts` to `imageCfg` — 2 of the 4 fail.
- `cd client && npx vitest run src/components/pipeline/stages/ComicScriptStage.renderPin.test.jsx src/pages/Sprites src/hooks/useUniverseDraft src/lib/imageGen` — 96 passed.
- `cd server && NODE_ENV=test npx vitest run lib/renderTargets.parity.test.js` — 7 passed.
- `cd client && npx biome lint --error-on-warnings` on the changed files — clean.
