### PR TITLE
Remove the unreferenced XP-threshold helpers from characterXp (#3895)

### DIFF
--- a/.changelog/next/removed-issue-3895.md
+++ b/.changelog/next/removed-issue-3895.md
@@ -1,0 +1,1 @@
+- Unreferenced XP-threshold helpers (`computeXpView`, `MAX_LEVEL`) in the character HUD math; `levelFromXP` stays for the CyberCity artifact unlocks.

--- a/client/src/utils/README.md
+++ b/client/src/utils/README.md
@@ -60,7 +60,7 @@ grep -i "what you want to do" client/src/utils/README.md
 
 | Module | Purpose |
 |---|---|
-| `characterXp` | Character HUD badge math: `computeAgeView` (age-based level + progress to next birthday), plus legacy XP helpers `levelFromXP`, `computeXpView`, `diffXp` and the XP threshold table. |
+| `characterXp` | Character HUD badge math: `computeAgeView` (age-based level + progress to next birthday), `diffXp` (XP-gain / birthday burst diff), `birthDateCta` (missing-birth-date call to action), plus the legacy `levelFromXP` XP-curve lookup used by `cityArtifacts`. |
 
 ## CyberCity — scene compute helpers
 

--- a/client/src/utils/characterXp.js
+++ b/client/src/utils/characterXp.js
@@ -3,63 +3,28 @@
 // by diffing two successive snapshots. No React imports so the math is unit-testable.
 //
 // As of #2673 the badge shows an **age-based level** (`computeAgeView`) — level = years lived
-// — with a progress bar toward the next birthday. The legacy XP-threshold helpers below
-// (`levelFromXP`, `computeXpView`, `XP_THRESHOLDS`) are retained for `cityArtifacts` and the
-// D&D-style `/character` page; the badge no longer uses them.
+// — with a progress bar toward the next birthday. The only surviving XP-threshold helper is
+// `levelFromXP`, used by `cityArtifacts` to unlock level artifacts when a character has XP but
+// no usable birth date; the badge no longer uses it.
 
-// MIRRORS the server constant `XP_THRESHOLDS` in server/services/character.js — index i
+// MIRRORS the server constant `LEGACY_XP_THRESHOLDS` in server/services/character.js — index i
 // is the cumulative XP required to reach level i+1. Keep these two arrays in sync: if the
-// server's level curve changes, update this copy (and the test) in the same change.
-export const XP_THRESHOLDS = [
+// server's level curve changes, update this copy (and the test) in the same change. Module-local
+// on purpose: `levelFromXP` is the only supported way to read the curve (#3895).
+const XP_THRESHOLDS = [
   0, 300, 900, 2700, 6500, 14000, 23000, 34000, 48000, 64000,
   85000, 100000, 120000, 140000, 165000, 195000, 225000, 265000, 305000, 355000,
 ];
 
-export const MAX_LEVEL = XP_THRESHOLDS.length;
-
 // Level for a given total XP, mirroring server `getLevelFromXP`. Clamps negative/NaN xp
-// to level 1 so a missing/garbage value can't produce a negative or NaN level.
+// to level 1 so a missing/garbage value can't produce a negative or NaN level, and saturates
+// at the top of the curve (level 20) for arbitrarily large XP.
 export function levelFromXP(xp) {
   const safeXp = Number.isFinite(xp) ? xp : 0;
   for (let i = XP_THRESHOLDS.length - 1; i >= 0; i--) {
     if (safeXp >= XP_THRESHOLDS[i]) return i + 1;
   }
   return 1;
-}
-
-// Derived view-model for the XP badge. Tolerates a missing/null character (returns a sane
-// level-1 zero view). `progress` is 0..1 within the current level; at max level it pins to
-// 1 with `atMax: true` and never produces NaN (no "next threshold" to divide by).
-export function computeXpView(character) {
-  const rawXp = character?.xp;
-  const xp = Number.isFinite(rawXp) ? Math.max(0, rawXp) : 0;
-  // Trust the server's stored level when present and consistent; otherwise derive it so a
-  // legacy/absent level field still yields a correct badge.
-  const level = Number.isFinite(character?.level) && character.level >= 1
-    ? Math.min(MAX_LEVEL, Math.floor(character.level))
-    : levelFromXP(xp);
-
-  const atMax = level >= MAX_LEVEL;
-  const levelFloor = XP_THRESHOLDS[level - 1] ?? 0;
-  const nextThreshold = atMax ? null : XP_THRESHOLDS[level];
-
-  const xpIntoLevel = Math.max(0, xp - levelFloor);
-  const xpForNextLevel = atMax ? 0 : nextThreshold - levelFloor;
-  const progress = atMax
-    ? 1
-    : (xpForNextLevel > 0 ? Math.min(1, Math.max(0, xpIntoLevel / xpForNextLevel)) : 0);
-
-  return {
-    xp,
-    level,
-    xpIntoLevel,
-    xpForNextLevel,
-    xpToNext: atMax ? 0 : Math.max(0, nextThreshold - xp),
-    progress,
-    atMax,
-    hp: Number.isFinite(character?.hp) ? character.hp : null,
-    maxHp: Number.isFinite(character?.maxHp) ? character.maxHp : null,
-  };
 }
 
 // Age-based level view-model for the CyberCity badge (#2673, epic #2672). The Character's

--- a/client/src/utils/characterXp.test.js
+++ b/client/src/utils/characterXp.test.js
@@ -1,13 +1,16 @@
 import { describe, it, expect } from 'vitest';
+import * as characterXp from './characterXp';
 import {
-  XP_THRESHOLDS,
-  MAX_LEVEL,
   levelFromXP,
-  computeXpView,
   computeAgeView,
   diffXp,
   birthDateCta,
 } from './characterXp';
+
+// The curve is module-local (#3895); these mirror server/services/character.js
+// `LEGACY_XP_THRESHOLDS` so a curve change fails here instead of silently drifting.
+const TOP_THRESHOLD = 355_000;
+const TOP_LEVEL = 20;
 
 describe('levelFromXP', () => {
   it('maps XP to the right level at and above each threshold', () => {
@@ -18,9 +21,10 @@ describe('levelFromXP', () => {
     expect(levelFromXP(900)).toBe(3);
   });
 
-  it('caps at MAX_LEVEL for very high XP', () => {
-    expect(levelFromXP(XP_THRESHOLDS[MAX_LEVEL - 1])).toBe(MAX_LEVEL);
-    expect(levelFromXP(10_000_000)).toBe(MAX_LEVEL);
+  it('saturates at the top of the curve for very high XP', () => {
+    expect(levelFromXP(TOP_THRESHOLD - 1)).toBe(TOP_LEVEL - 1);
+    expect(levelFromXP(TOP_THRESHOLD)).toBe(TOP_LEVEL);
+    expect(levelFromXP(10_000_000)).toBe(TOP_LEVEL);
   });
 
   it('clamps negative / NaN XP to level 1', () => {
@@ -30,71 +34,12 @@ describe('levelFromXP', () => {
   });
 });
 
-describe('computeXpView', () => {
-  it('computes progress mid-level', () => {
-    // Level 2 spans [300, 900) — 600 XP wide. At 600 XP we're 300 into 600.
-    const vm = computeXpView({ xp: 600, level: 2 });
-    expect(vm.level).toBe(2);
-    expect(vm.xpIntoLevel).toBe(300);
-    expect(vm.xpForNextLevel).toBe(600);
-    expect(vm.progress).toBeCloseTo(0.5);
-    expect(vm.xpToNext).toBe(300);
-    expect(vm.atMax).toBe(false);
-  });
-
-  it('is 0 progress exactly at a level floor (inclusive boundary)', () => {
-    const vm = computeXpView({ xp: 300, level: 2 });
-    expect(vm.level).toBe(2);
-    expect(vm.xpIntoLevel).toBe(0);
-    expect(vm.progress).toBe(0);
-  });
-
-  it('approaches 1 just below the next threshold without reaching it', () => {
-    const vm = computeXpView({ xp: 899, level: 2 });
-    expect(vm.progress).toBeGreaterThan(0.99);
-    expect(vm.progress).toBeLessThan(1);
-  });
-
-  it('at max level: atMax true, progress pinned to 1, no NaN', () => {
-    const maxXp = XP_THRESHOLDS[MAX_LEVEL - 1] + 50_000;
-    const vm = computeXpView({ xp: maxXp, level: MAX_LEVEL });
-    expect(vm.level).toBe(MAX_LEVEL);
-    expect(vm.atMax).toBe(true);
-    expect(vm.progress).toBe(1);
-    expect(vm.xpForNextLevel).toBe(0);
-    expect(vm.xpToNext).toBe(0);
-    expect(Number.isNaN(vm.progress)).toBe(false);
-  });
-
-  it('returns a sane zero view for null / missing character', () => {
-    for (const input of [null, undefined, {}]) {
-      const vm = computeXpView(input);
-      expect(vm.xp).toBe(0);
-      expect(vm.level).toBe(1);
-      expect(vm.progress).toBe(0);
-      expect(vm.atMax).toBe(false);
-      expect(vm.hp).toBeNull();
-      expect(vm.maxHp).toBeNull();
-      expect(Number.isNaN(vm.progress)).toBe(false);
-    }
-  });
-
-  it('derives level from xp when the level field is absent / invalid', () => {
-    const vm = computeXpView({ xp: 1000 }); // no level field → derive (level 3)
-    expect(vm.level).toBe(3);
-  });
-
-  it('carries hp / maxHp through when present', () => {
-    const vm = computeXpView({ xp: 0, level: 1, hp: 12, maxHp: 15 });
-    expect(vm.hp).toBe(12);
-    expect(vm.maxHp).toBe(15);
-  });
-
-  it('distinguishes absent xp (zero view) from a legitimate zero xp', () => {
-    expect(computeXpView({}).xp).toBe(0);
-    expect(computeXpView({ xp: 0, level: 1 }).xp).toBe(0);
-    // both render as zero, but neither throws or NaNs
-    expect(computeXpView({ xp: 0, level: 1 }).progress).toBe(0);
+describe('removed legacy XP helpers (#3895)', () => {
+  it('no longer exports the XP-threshold view helpers', () => {
+    // Dead progression math removed; the module must not grow them back as public API.
+    expect(characterXp.computeXpView).toBeUndefined();
+    expect(characterXp.XP_THRESHOLDS).toBeUndefined();
+    expect(characterXp.MAX_LEVEL).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

`computeXpView` and `MAX_LEVEL` in `client/src/utils/characterXp.js` lost their last callers when the CyberCity character badge moved to age-based levels in #2673, and the `XP_THRESHOLDS` table was only read by `computeXpView` itself. This removes both and un-exports the table.

`levelFromXP` is kept and still exported — `client/src/utils/cityArtifacts.js` uses it to unlock level artifacts for a character that has XP but no usable birth date. Its comment now correctly names the server-side constant it mirrors (`LEGACY_XP_THRESHOLDS` in `server/services/character.js`, renamed there previously) and documents the top-of-curve saturation, and the `client/src/utils/README.md` row is updated to describe the surviving exports.

Closes #3895

## Test plan

- `grep` across `client/src` and `server` confirms no remaining references to `computeXpView`, `MAX_LEVEL`, or `XP_THRESHOLDS` outside the module (the only hits are `server/services/character.js`'s own unrelated private `LEGACY_XP_THRESHOLDS`)
- `npx vitest run src/utils/characterXp.test.js src/utils/index.test.js src/utils/cityArtifacts.test.js` — 3 files, 54 tests pass, verified after rebasing onto current `main`
- `characterXp.test.js` drops the specs for the removed helpers and keeps `levelFromXP` coverage; `index.test.js` still asserts the barrel exports `levelFromXP`