### PR TITLE
Stop release-check naming a PortOS-only changelog script that managed apps do not have

### DIFF
--- a/.changelog/next/fixed-release-check-generic-changelog-preview.md
+++ b/.changelog/next/fixed-release-check-generic-changelog-preview.md
@@ -1,0 +1,1 @@
+- release-check prompt no longer names a PortOS-only changelog preview script that managed apps do not have

--- a/server/services/taskPromptDefaults.test.js
+++ b/server/services/taskPromptDefaults.test.js
@@ -281,12 +281,17 @@ describe('taskPromptDefaults integrity snapshot', () => {
   // read as "not enough work accumulated for a release".
   it('release-check counts uncollected changelog fragments, preserving the outgoing default', () => {
     const current = DEFAULT_TASK_PROMPTS['release-check'];
-    expect(current).toContain('changelog:preview');
+    expect(current).toContain('per-branch fragments');
     expect(current).toContain('assembled');
+    // release-check is a generic {appName} prompt — it runs against managed apps,
+    // which have no `npm run changelog:preview`. It must send the agent to the
+    // repo's own documented command, never name a PortOS script to run.
+    expect(current).not.toContain('changelog:preview');
+    expect(current).toContain('Do NOT guess a command name');
 
     const previous = PREVIOUS_DEFAULT_PROMPTS['release-check'];
     const outgoing = previous[previous.length - 1];
-    expect(outgoing).not.toContain('changelog:preview');
+    expect(outgoing).not.toContain('per-branch fragments');
     expect(outgoing).not.toBe(current);
   });
 

--- a/server/services/taskPromptDefaults/integrity.snapshot.json
+++ b/server/services/taskPromptDefaults/integrity.snapshot.json
@@ -20,7 +20,7 @@
     "code-reviewer-implement": "ab2c3e16d54e195bdf856574b7702042",
     "error-handling": "9afba2e99b90a8d5771c75e7f0615d96",
     "typing": "1f2758ce0bb62d789a21aec241549531",
-    "release-check": "7184e5adc051aebd54c5a5cda5d0f12a",
+    "release-check": "746f11daaf721eae9e16845858ef55ee",
     "jira-sprint-manager": "3e63c8a3bdf0d5a05a30faaa2dc07980",
     "do-replan": "59a57f1bb445138c30ab4fa23630c6f8",
     "jira-status-report": "9d374a9d8ccb92c5c8fd0aa9899e79a5",

--- a/server/services/taskPromptDefaults/prompts.js
+++ b/server/services/taskPromptDefaults/prompts.js
@@ -1261,7 +1261,7 @@ If no documentation specifies a release flow, fall back to: source=dev, target=m
 
 Using the changelog location discovered in Step 0:
 - Read the current changelog (e.g., \`.changelog/NEXT.md\` or \`.changelog/v*.x.md\`)
-- **Also read the entries not yet folded into that file.** Repos that collect per-branch fragments (e.g. \`.changelog/next/\`, so parallel agents don't conflict on a shared file) keep unreleased entries there until the release collects them, so the staged file alone under-counts the work. Use the preview command the repo's changelog README documents (in PortOS: \`npm run changelog:preview\`) to get the assembled unreleased notes in one call, or list the fragment directory directly.
+- **Also read the entries not yet folded into that file.** Repos that collect per-branch fragments (e.g. \`.changelog/next/\`, so parallel agents don't conflict on a shared file) keep unreleased entries there until the release collects them, so the staged file alone under-counts the work. Read the fragment directory directly, and if the repo's changelog README documents a preview/collect command, use that to assemble the unreleased notes in one call. Do NOT guess a command name — only run one this repo actually documents.
 - Read the current version: \`node -p "require('{repoPath}/package.json').version"\` or equivalent
 
 Count substantive entries (lines starting with "###" or "- **" under Features, Fixes, Improvements sections) across the **assembled** unreleased notes — the staged file plus any uncollected fragments. If fewer than 2 substantive entries exist, stop and report: "Not enough work accumulated for a release." Do NOT create a PR.

--- a/server/services/taskPromptDefaults/versions.js
+++ b/server/services/taskPromptDefaults/versions.js
@@ -36,7 +36,7 @@ export const PROMPT_VERSIONS = {
   'ui-bugs': 2, // v2: generic {appName} + the app UI (older default hardcoded "PortOS" + http://localhost:5555)
   'mobile-responsive': 2, // v2: generic {appName} app-UI body (older default hardcoded "PortOS" + http://localhost:5555)
   'ux': 1, // v1: walk the running UI with Playwright MCP against a 7-item named UX checklist and file ONE tracker item per finding via {trackerInstructions} — read-only on source, no branches/PRs. Net-new type (no PREVIOUS_DEFAULT_PROMPTS entry needed).
-  'release-check': 7, // v7: Step 1 also reads the UNCOLLECTED changelog fragments (`npm run changelog:preview` / the fragment dir) and counts substantive entries across the assembled notes — reading only the staged `.changelog/NEXT.md` under-counts a release whose entries are still per-branch fragments, so a ready release reported as "not enough work". v6: generic {appName} body (older defaults hardcoded "PortOS")
+  'release-check': 7, // v7: Step 1 also reads the UNCOLLECTED changelog fragments (the fragment dir, plus whatever preview command that repo documents — release-check is a generic {appName} prompt, so it never names a PortOS script to run) and counts substantive entries across the assembled notes — reading only the staged `.changelog/NEXT.md` under-counts a release whose entries are still per-branch fragments, so a ready release reported as "not enough work". v6: generic {appName} body (older defaults hardcoded "PortOS")
 };
 
 // Audit anchor for reference-watch's read/write coupling.


### PR DESCRIPTION
## Summary

Follow-up to #4002 (issue #3998). That PR merged while the second configured reviewer (`claude`) was still running; this ships the one finding it raised.

`release-check` is a **generic `{appName}` prompt** — it runs against managed apps, not just PortOS. #4002 told it to get the assembled unreleased notes with `npm run changelog:preview`, gated only by a parenthetical "(in PortOS: …)". Every other prompt in that change deliberately avoids naming a concrete helper script for exactly this reason: a managed app has no such npm script, and an agent that runs a command which doesn't exist tends to conclude the data is unavailable rather than that it used the wrong command — the same failure shape as the `agy`-binary incident already recorded in `versions.js`.

It now reads the fragment directory directly, uses a preview command **only when that repo documents one**, and carries an explicit "Do NOT guess a command name — only run one this repo actually documents."

No version bump: `release-check` is already at v7 from #4002 and that version has not shipped in a release, so the v6 body preserved in `PREVIOUS_DEFAULT_PROMPTS` is still the correct outgoing default. The integrity snapshot is regenerated for the new v7 body.

## Test plan

- `cd server && npx vitest run services/taskPromptDefaults.test.js services/taskSchedule.test.js` → 196 passed.
- The `release-check` content test was flipped to pin the contract rather than the command: it now asserts `not.toContain('changelog:preview')` plus the no-guessing instruction, so a future edit can't quietly reintroduce a PortOS-only script into a generic prompt.
- Old-default recognition re-verified after the reword: for all 7 keys touched by #4002, the pre-#4002 `DEFAULT_TASK_PROMPTS` hash still appears in that key's `PREVIOUS_DEFAULT_PROMPTS` hashes.

Refs #3998
