### PR TITLE
fix(catalog): track intra-batch write timestamps to prevent stale duplicate ingredient overwrite (#4006)

### DIFF
--- a/.changelog/next/fixed-issue-4006.md
+++ b/.changelog/next/fixed-issue-4006.md
@@ -1,0 +1,1 @@
+- Catalog canon projection now preserves write ordering when multiple entries reference the same ingredient in one save batch.

--- a/server/services/catalogCanonProjection.batch.test.js
+++ b/server/services/catalogCanonProjection.batch.test.js
@@ -165,4 +165,51 @@ describe('projectToCatalog batching', () => {
     expect(await projectToCatalog('universe-1', null)).toEqual({ written: 0, skipped: 0 });
     expect(catalogDB.getIngredientTimestamps).not.toHaveBeenCalled();
   });
+
+  it('prevents older duplicate ingredientId from overwriting newer entry in same batch (#4006)', async () => {
+    catalogDB.getIngredientTimestamps.mockResolvedValue(timestampMap([['ing-dup', ROW_AT]]));
+
+    const stats = await projectToCatalog('universe-1', {
+      characters: [
+        entry('ing-dup', { name: 'Newer Entry', updatedAt: NEWER }),
+        entry('ing-dup', { name: 'Stale Duplicate', updatedAt: OLDER }),
+      ],
+    });
+
+    // Newer entry writes first; older duplicate entry is evaluated against appliedTimestamps (NEWER) and skipped
+    expect(catalogDB.updateIngredient).toHaveBeenCalledTimes(1);
+    expect(catalogDB.updateIngredient).toHaveBeenCalledWith(
+      'ing-dup',
+      { name: 'Newer Entry', payload: expect.anything() },
+      expect.anything(),
+    );
+    expect(stats).toEqual({ written: 1, skipped: 1 });
+  });
+
+  it('allows newer duplicate ingredientId to update older entry written earlier in same batch (#4006)', async () => {
+    catalogDB.getIngredientTimestamps.mockResolvedValue(timestampMap([['ing-dup', ROW_AT]]));
+
+    const stats = await projectToCatalog('universe-1', {
+      characters: [
+        entry('ing-dup', { name: 'Older First', updatedAt: ROW_AT }),
+        entry('ing-dup', { name: 'Newer Second', updatedAt: NEWER }),
+      ],
+    });
+
+    expect(catalogDB.updateIngredient).toHaveBeenCalledTimes(2);
+    expect(catalogDB.updateIngredient).toHaveBeenNthCalledWith(
+      1,
+      'ing-dup',
+      { name: 'Older First', payload: expect.anything() },
+      expect.anything(),
+    );
+    expect(catalogDB.updateIngredient).toHaveBeenNthCalledWith(
+      2,
+      'ing-dup',
+      { name: 'Newer Second', payload: expect.anything() },
+      expect.anything(),
+    );
+    expect(stats).toEqual({ written: 2, skipped: 0 });
+  });
 });
+

--- a/server/services/catalogCanonProjection.js
+++ b/server/services/catalogCanonProjection.js
@@ -197,8 +197,13 @@ export async function projectToCatalog(universeId, canonArrays, { guardToken = n
   // by design: each updateIngredient is a multi-statement write (sanitize +
   // update + revision), and firing N of them at once would trade the read
   // stampede this fix removed for a write one.
+  //
+  // Track writes applied within this call in `appliedTimestamps` so if multiple
+  // candidates reference the same ingredientId in one batch, an older entry
+  // cannot overwrite a newer entry written earlier in the same pass (#4006).
+  const appliedTimestamps = new Map(timestamps);
   for (const { ingredientId, entry } of candidates) {
-    const rowUpdatedAt = timestamps.get(ingredientId);
+    const rowUpdatedAt = appliedTimestamps.get(ingredientId);
     if (rowUpdatedAt === undefined) { stats.skipped++; continue; }   // no live row
     // LWW on updatedAt — only overwrite the catalog row when the embedded entry
     // is at-least-as-fresh. An older embedded snapshot (e.g. a concurrent
@@ -212,6 +217,7 @@ export async function projectToCatalog(universeId, canonArrays, { guardToken = n
         { name: entry.name, payload: entryToPayload(entry) },
         { source: 'sync', actor: 'canon-projection' },
       );
+      appliedTimestamps.set(ingredientId, entry.updatedAt);
       stats.written++;
     } catch (err) {
       console.error(`🔁 projectToCatalog: ingredient ${ingredientId} update failed: ${err.message}`);

--- a/server/services/catalogCanonProjection.js
+++ b/server/services/catalogCanonProjection.js
@@ -217,7 +217,7 @@ export async function projectToCatalog(universeId, canonArrays, { guardToken = n
         { name: entry.name, payload: entryToPayload(entry) },
         { source: 'sync', actor: 'canon-projection' },
       );
-      appliedTimestamps.set(ingredientId, entry.updatedAt);
+      appliedTimestamps.set(ingredientId, entry.updatedAt || rowUpdatedAt);
       stats.written++;
     } catch (err) {
       console.error(`🔁 projectToCatalog: ingredient ${ingredientId} update failed: ${err.message}`);


### PR DESCRIPTION
## Summary

`projectToCatalog` in `server/services/catalogCanonProjection.js` batches timestamp reads using `catalogDB.getIngredientTimestamps`. When multiple candidates in the same batch resolve to the same `ingredientId`, an older entry processed later in the batch could overwrite a newer entry processed earlier because both were compared against the stale initial DB snapshot.

This fix tracks writes applied within `projectToCatalog` in a local `appliedTimestamps` map (seeded from the batched timestamp read), updating it after each successful write. This ensures write-ordering is preserved when multiple canon entries reference the same ingredient in a single save batch, without introducing additional database round-trips.

## Changes
- Seed `appliedTimestamps` map from batched `getIngredientTimestamps` read.
- Check `appliedTimestamps` before writing and update `appliedTimestamps.set(ingredientId, entry.updatedAt)` after writing.
- Add unit tests in `server/services/catalogCanonProjection.batch.test.js` to cover duplicate `ingredientId` handling in a single projection pass.
- Added changelog fragment `.changelog/next/fixed-issue-4006.md`.

Closes #4006
