### PR TITLE
fix(manuscript): scope unsaved changes save guard to dirty tab sections (#4004)

### DIFF
--- a/.changelog/next/fixed-issue-4004.md
+++ b/.changelog/next/fixed-issue-4004.md
@@ -1,0 +1,1 @@
+- Unsaved changes confirmation dialog no longer stays hidden when an unrelated manuscript tab is saving.

--- a/client/src/pages/PipelineManuscriptEditor.jsx
+++ b/client/src/pages/PipelineManuscriptEditor.jsx
@@ -162,17 +162,22 @@ export default function PipelineManuscriptEditor() {
   // unless the tab itself carries one (#3399). Also the route guard's reactive
   // dirty signal (#3995) — `baselineRef` is for handlers that read outside the
   // render cycle, and can't drive a re-evaluation on its own.
-  const dirtyNumbers = useMemo(() => {
-    const set = new Set();
-    sections.forEach((s) => { if (isSectionDirty(baselines, s)) set.add(s.number); });
-    return set;
-  }, [sections, baselines]);
+  const dirtySections = useMemo(
+    () => sections.filter((s) => isSectionDirty(baselines, s)),
+    [sections, baselines]
+  );
+  const dirtyNumbers = useMemo(
+    () => new Set(dirtySections.map((s) => s.number)),
+    [dirtySections]
+  );
 
   // Guards BOTH exit doors (#3958/#3995): tab close/reload, and any in-app
   // navigation — a sidebar link, ⌘K, voice `ui_navigate`, the browser Back
   // button. This is a splat route, so switching issue tabs changes the pathname
   // WITHOUT leaving the editor; `scopePath` lets those through unguarded.
-  const savingAny = Object.values(saveState).some((s) => s === 'saving');
+  // Suppress the discard confirm ONLY when the dirty section(s) are actively saving (#4004).
+  const savingDirty =
+    dirtySections.length > 0 && dirtySections.every((s) => saveState[s.issueId] === 'saving');
   const routeGuard = useUnsavedChangesGuard(dirtyNumbers.size > 0, {
     scopePath: `/pipeline/series/${seriesId}/manuscript`,
   });
@@ -743,7 +748,7 @@ export default function PipelineManuscriptEditor() {
           guard then releases the parked navigation on its own. */}
       <UnsavedChangesConfirm
         guard={routeGuard}
-        when={!savingAny}
+        when={!savingDirty}
         question="Discard your unsaved manuscript edits?"
         label={`Discard unsaved manuscript edits to ${series?.name || 'this series'}`}
         onDiscard={discardAndExit}

--- a/client/src/pages/PipelineManuscriptEditor.test.jsx
+++ b/client/src/pages/PipelineManuscriptEditor.test.jsx
@@ -693,5 +693,27 @@ describe('PipelineManuscriptEditor — generate-edits streamed review', () => {
       expect(await screen.findByDisplayValue('Issue two body.')).toBeInTheDocument();
       expect(screen.queryByText(CONFIRM)).not.toBeInTheDocument();
     });
+
+    it('shows discard confirm immediately when navigating away from a dirty tab while an unrelated tab is saving (#4004)', async () => {
+      api.getPipelineManuscript.mockResolvedValue(twoIssues);
+      const { router } = renderEditor('/pipeline/series/ser-1/manuscript/1');
+      await typeUnsaved('Issue one body.', 'Issue one, edited.');
+
+      fireEvent.click(within(screen.getByRole('navigation', { name: 'Issues' })).getByRole('link', { name: /Issue 2/ }));
+      const area2 = await screen.findByDisplayValue('Issue two body.');
+
+      let resolveSave2;
+      api.savePipelineManuscriptSection.mockReturnValue(new Promise((res) => { resolveSave2 = res; }));
+      fireEvent.change(area2, { target: { value: 'Issue two, saving.' } });
+      fireEvent.blur(area2);
+
+      await act(async () => { await router.navigate('/dashboard'); });
+
+      expect(await screen.findByText(CONFIRM)).toBeInTheDocument();
+
+      await act(async () => {
+        resolveSave2({ section: { issueId: 'iss-2', number: 2, title: 'Two', stageId: 'prose', content: 'Issue two, saving.' } });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Problem
`PipelineManuscriptEditor.jsx` computed `savingAny = Object.values(saveState).some((s) => s === 'saving')` across all open manuscript issue tabs. If Tab 1 is dirty and idle while Tab 2 is saving (e.g. AI reformat), navigating away from the editor suppresses the discard confirmation modal entirely, parking navigation silently with no explanation until Tab 2 finishes.

## Fix
Scope the unsaved changes save guard (`savingDirty`) to only suppress confirmation when the specific section(s) currently reported dirty by `isSectionDirty` are actively saving. If Tab 1 is dirty and not saving, navigating away immediately displays the discard confirmation dialog regardless of Tab 2's save state.

Closes #4004
