### PR TITLE
fix(prompt-manager): sequence preview requests and disable preview button while loading (#4005)

### DIFF
--- a/.changelog/next/fixed-issue-4005.md
+++ b/.changelog/next/fixed-issue-4005.md
@@ -1,0 +1,1 @@
+- Prompt preview requests now sequence correctly to prevent stale out-of-order responses from overwriting newer previews.

--- a/client/src/pages/PromptManager.jsx
+++ b/client/src/pages/PromptManager.jsx
@@ -109,6 +109,8 @@ export default function PromptManager() {
   const [pendingJobSkill, setPendingJobSkill] = useState(null);
   const [jobSkillMeta, setJobSkillMeta] = useState({});
   const [jobSkillPreview, setJobSkillPreview] = useState('');
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const previewSeqRef = useRef(0);
   const isJobSkillDirty = Boolean(selectedJobSkill) && jobSkillContent !== savedJobSkillContent;
   // `saveJobSkill` resumes after an await holding the values its closure captured
   // at click time, so it reads the live selection/text through these refs to tell
@@ -317,6 +319,8 @@ export default function PromptManager() {
   // PREVIOUS skill's template rendered under the newly selected skill's heading.
   useEffect(() => {
     setJobSkillPreview('');
+    setPreviewLoading(false);
+    previewSeqRef.current++;
     setJobSkillContent('');
     setSavedJobSkillContent('');
     setPendingJobSkill(null);
@@ -390,12 +394,18 @@ export default function PromptManager() {
 
   const previewJobSkill = async () => {
     const previewFor = selectedJobSkill;
+    const seq = ++previewSeqRef.current;
+    setPreviewLoading(true);
     const res = await apiPreviewJobSkill(previewFor, { silent: true })
       .catch((err) => { toast.error(`Failed to preview: ${err.message || 'Unknown error'}`); return null; });
+    if (previewSeqRef.current === seq) {
+      setPreviewLoading(false);
+    }
     if (!res) return;
     // A preview that lands after the user moved on belongs to the previous
     // skill — rendering it under the new one's heading would misattribute it.
     if (previewFor !== jobSkillLiveRef.current.selected) return;
+    if (previewSeqRef.current !== seq) return;
     setJobSkillPreview(res.preview || '');
   };
 
@@ -972,7 +982,8 @@ export default function PromptManager() {
                     <div className="flex gap-2">
                       <button
                         onClick={previewJobSkill}
-                        className="flex items-center gap-1 px-3 py-1 text-sm bg-port-border hover:bg-port-border/80 text-white rounded"
+                        disabled={previewLoading}
+                        className="flex items-center gap-1 px-3 py-1 text-sm bg-port-border hover:bg-port-border/80 text-white rounded disabled:opacity-50"
                       >
                         <Eye size={14} /> Preview
                       </button>

--- a/client/src/pages/PromptManager.test.jsx
+++ b/client/src/pages/PromptManager.test.jsx
@@ -773,4 +773,55 @@ describe('PromptManager job skill unsaved-edit guard', () => {
     expect(screen.queryByText(/Discard unsaved changes/)).toBeNull();
     await waitFor(() => expect(currentSearch()).toContain('skill=doc-writer'));
   });
+
+  it('disables Preview button while request is in flight and re-enables when complete', async () => {
+    let resolvePreview;
+    previewJobSkill.mockReset().mockImplementationOnce(() => new Promise((r) => { resolvePreview = r; }));
+    renderPage('/prompts?tab=job-skills&skill=code-fixer');
+    await screen.findByText('Job code-fixer');
+
+    const previewBtn = screen.getByRole('button', { name: /preview/i });
+    expect(previewBtn.disabled).toBe(false);
+
+    fireEvent.click(previewBtn);
+    expect(previewBtn.disabled).toBe(true);
+
+    resolvePreview({ preview: 'latest preview content' });
+    await waitFor(() => expect(previewBtn.disabled).toBe(false));
+    expect(screen.getByText('latest preview content')).toBeTruthy();
+  });
+
+  it('sequences preview requests for the same skill and ignores stale out-of-order responses', async () => {
+    let resolveFirst;
+    let resolveSecond;
+    let previewBtn;
+
+    previewJobSkill
+      .mockReset()
+      .mockImplementationOnce(() => {
+        fireEvent.click(previewBtn);
+        return new Promise((r) => { resolveFirst = r; });
+      })
+      .mockImplementationOnce(() => new Promise((r) => { resolveSecond = r; }));
+
+    renderPage('/prompts?tab=job-skills&skill=code-fixer');
+    await screen.findByText('Job code-fixer');
+
+    previewBtn = screen.getByRole('button', { name: /preview/i });
+
+    // Trigger first request (which synchronously triggers second request)
+    fireEvent.click(previewBtn);
+
+    // Resolve second request first
+    resolveSecond({ preview: 'second response' });
+    await waitFor(() => expect(screen.getByText('second response')).toBeTruthy());
+
+    // Resolve first request later (stale out-of-order response)
+    resolveFirst({ preview: 'stale first response' });
+
+    // Verify stale response is ignored and second response remains rendered
+    expect(screen.queryByText('stale first response')).toBeNull();
+    expect(screen.getByText('second response')).toBeTruthy();
+  });
 });
+


### PR DESCRIPTION
### Summary of Changes

- Added `previewSeqRef` counter ref in `PromptManager.jsx` to track request sequence for job skill preview requests.
- Added `previewLoading` state to track in-flight preview requests and disabled the Preview button while loading.
- Ignored out-of-order preview responses if the captured sequence number does not match the latest request sequence number.
- Reset preview loading state and incremented sequence counter when selecting a new job skill.
- Added unit tests in `PromptManager.test.jsx` covering Preview button disabling during request loading and preview request sequence tracking for overlapping requests.

Closes #4005
