### PR TITLE
fix(writers-room): enforce 44px touch targets on BibleSection buttons (#4014)

### DIFF
--- a/.changelog/next/fixed-issue-4014.md
+++ b/.changelog/next/fixed-issue-4014.md
@@ -1,0 +1,1 @@
+- Enforce 44px minimum touch target sizing on BibleSection action buttons for mobile responsiveness.

--- a/client/src/components/writers-room/BibleSection.jsx
+++ b/client/src/components/writers-room/BibleSection.jsx
@@ -85,7 +85,7 @@ export default function BibleSection({ workId, items: itemsProp, onItemsChange, 
         <div className="text-[11px] text-gray-500">{config.countLabel(items.length)}</div>
         <button
           onClick={() => { setCreating(true); setEditingId(null); }}
-          className="flex items-center gap-1 text-[11px] text-gray-400 hover:text-port-accent"
+          className="flex items-center justify-center min-w-[44px] min-h-[44px] -my-2 -mr-2 gap-1 text-[11px] text-gray-400 hover:text-port-accent"
         >
           <Plus size={12} /> Add
         </button>
@@ -270,7 +270,7 @@ function BibleEditor({ workId, item, config, onSaved, onDeleted, onCancel }) {
         </label>
         <button
           onClick={onCancel}
-          className="text-gray-500 hover:text-white shrink-0"
+          className="min-w-[44px] min-h-[44px] flex items-center justify-center text-gray-500 hover:text-white shrink-0 -my-2 -mr-2"
           aria-label="Cancel edit"
           title="Cancel"
         >
@@ -292,7 +292,7 @@ function BibleEditor({ workId, item, config, onSaved, onDeleted, onCancel }) {
           <button
             onClick={remove}
             disabled={saving}
-            className="flex items-center gap-1 text-[10px] text-port-error hover:underline disabled:opacity-50"
+            className="min-w-[44px] min-h-[44px] flex items-center justify-center gap-1 text-[10px] text-port-error hover:underline disabled:opacity-50 -my-2 -ml-2"
           >
             <Trash2 size={10} /> Delete
           </button>
@@ -300,7 +300,7 @@ function BibleEditor({ workId, item, config, onSaved, onDeleted, onCancel }) {
         <button
           onClick={save}
           disabled={saving}
-          className="flex items-center gap-1 px-2 py-1 bg-port-accent text-white rounded text-[10px] hover:bg-port-accent/80 disabled:opacity-50"
+          className="min-w-[44px] min-h-[44px] flex items-center justify-center gap-1 px-2 py-1 bg-port-accent text-white rounded text-[10px] hover:bg-port-accent/80 disabled:opacity-50 -my-2 -mr-2"
         >
           {saving ? <Loader2 size={10} className="animate-spin" /> : <Check size={10} />} Save
         </button>

--- a/client/src/components/writers-room/BibleSection.test.jsx
+++ b/client/src/components/writers-room/BibleSection.test.jsx
@@ -247,6 +247,31 @@ describe.each(SCENARIOS)('$label (BibleSection)', (s) => {
     expect(editBtn.className).toContain('min-w-[44px]');
   });
 
+  it('a11y: Add, Cancel, Delete, and Save buttons meet the 44px touch-target floor', async () => {
+    s.api.list.mockResolvedValue([s.existingItem]);
+
+    render(<s.Component workId="work-1" />);
+    await screen.findByText(displayText(s.existingItem));
+
+    const addBtn = screen.getByRole('button', { name: 'Add' });
+    expect(addBtn.className).toContain('min-h-[44px]');
+    expect(addBtn.className).toContain('min-w-[44px]');
+
+    await userEvent.click(screen.getByRole('button', { name: `Edit ${displayText(s.existingItem)}` }));
+
+    const cancelBtn = screen.getByRole('button', { name: 'Cancel edit' });
+    expect(cancelBtn.className).toContain('min-h-[44px]');
+    expect(cancelBtn.className).toContain('min-w-[44px]');
+
+    const deleteBtn = screen.getByRole('button', { name: 'Delete' });
+    expect(deleteBtn.className).toContain('min-h-[44px]');
+    expect(deleteBtn.className).toContain('min-w-[44px]');
+
+    const saveBtn = screen.getByRole('button', { name: 'Save' });
+    expect(saveBtn.className).toContain('min-h-[44px]');
+    expect(saveBtn.className).toContain('min-w-[44px]');
+  });
+
   it('a11y: the identity field exposes an accessible name matching its config label', async () => {
     s.api.list.mockResolvedValue([]);
     render(<s.Component workId="work-1" />);


### PR DESCRIPTION
### Summary
Updates `BibleSection.jsx` action controls (`Add`, `Cancel`, `Delete`, `Save`) to guarantee a minimum 44px touch target size (`min-h-[44px] min-w-[44px] flex items-center justify-center`), ensuring compliance with mobile touch target guidelines without disrupting spatial layout visual alignment.

### Changes
- Added `min-h-[44px] min-w-[44px]` and centering classes with offsetting negative margins to `Add`, `Cancel`, `Delete`, and `Save` buttons in `BibleSection.jsx`.
- Added accessibility unit tests in `BibleSection.test.jsx` asserting all four action buttons meet the 44px touch-target floor.
- Created changelog entry fragment `.changelog/next/fixed-issue-4014.md`.

Closes #4014
