### PR TITLE
docs: clarify stash vs autostash behavior in SELF_UPDATE.md (#4011)

### DIFF
--- a/docs/SELF_UPDATE.md
+++ b/docs/SELF_UPDATE.md
@@ -22,14 +22,14 @@ The release-notification poll **always queries the upstream `atomantic/PortOS`**
 
 Before pulling, both scripts check the current branch and **switch to `main` if you are anywhere else** — a feature branch or a detached HEAD. This is deliberate: the rest of the script (install, build, restart) has to run on the revision the app will boot from, and pulling on a feature branch would leave the running app on a version the update never advanced.
 
-If the working tree is dirty at that point (unstaged, staged, or untracked files), the scripts **`git stash push -u`** first so the checkout can proceed, tagging the entry `portos-update-<timestamp>`. The stash is intentionally **not** popped afterwards — the remaining steps need `main`'s contents on disk. On completion the scripts print how to get back:
+If the working tree is dirty when switching off a non-`main` branch or detached HEAD (unstaged, staged, or untracked files), the scripts perform explicit pre-checkout stashing via **`git stash push -u`** so the checkout can proceed, tagging the entry `portos-update-<timestamp>`. The stash is intentionally **not** popped afterwards — the remaining steps need `main`'s contents on disk. On completion the scripts print how to get back:
 
 ```bash
 git checkout <your-branch>   # or the recorded SHA, if you were on a detached HEAD
 git stash pop
 ```
 
-The entry is at the top of `git stash list`. Nothing is stashed when the tree is clean, and nothing is checked out when you were already on `main`. Note that `git stash pop` restores file contents but not the index — anything you had staged comes back unstaged, so re-`git add` it (or pop with `--index`).
+The entry is at the top of `git stash list`. When already on `main`, pre-checkout stashing is skipped and dirty working trees rely instead on `git pull --autostash` during the pull. Nothing is stashed when the tree is clean, and no checkout occurs when already on `main`. Note that `git stash pop` restores file contents but not the index — anything you had staged comes back unstaged, so re-`git add` it (or pop with `--index`).
 
 **So: an in-app or CLI update run from a feature branch will leave your checkout on `main` with your work parked in the stash.** Commit your work before updating if you would rather not deal with that — pushing alone does not help, since the stash covers uncommitted changes.
 


### PR DESCRIPTION
### Summary of changes
Clarified in `docs/SELF_UPDATE.md` that explicit pre-checkout stashing (`git stash push -u -m portos-update-...`) is performed when switching off a non-`main` branch or detached HEAD with uncommitted changes, whereas dirty working trees already on `main` rely on `git pull --autostash`.

### Test plan
- Verified `docs/SELF_UPDATE.md` matches `update.sh` and `update.ps1` implementation.
- Reviewed markdown formatting and text flow.

Closes #4011
