### PR TITLE
docs: clarify authentication model in API.md (#4012)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -21,10 +21,11 @@ PortOS is designed for personal/developer use on trusted networks. It implements
 - **Network isolation**: By default, access should be restricted to trusted networks (e.g., Tailscale VPN, localhost)
 - **Command allowlist**: Shell command execution is restricted to an approved allowlist (see `server/lib/commandAllowlist.js`)
 - **Input validation**: All API inputs are validated using Zod schemas
-- **No application-level authentication**: PortOS assumes network-level access control
+- **Opt-in authentication**: Off by default (trusting private network/Tailscale), PortOS supports opt-in instance password authentication (enforced by `server/lib/authGate.js`) gating `/api/*`, `/data/*`, and `/sdapi/*` via session cookies, Bearer tokens, or HTTP Basic credentials
 
 **Important**: Do not expose PortOS APIs directly to untrusted networks. For production deployments, consider:
 - Binding to `127.0.0.1` instead of `0.0.0.0`
+- Enabling instance password authentication in Settings → Security
 - Running behind an authenticated reverse proxy
 - Using Tailscale or similar VPN for remote access
 


### PR DESCRIPTION
## Summary of Changes

Updated `docs/API.md` Security Model section to accurately describe PortOS's authentication capabilities. Previously, `docs/API.md:24` claimed that PortOS has no application-level authentication. This has been updated to explain that while authentication is off by default (trusting the private network/Tailscale), PortOS supports opt-in instance password authentication (enforced by `server/lib/authGate.js`) that gates `/api/*`, `/data/*`, and `/sdapi/*` via session cookies, Bearer tokens, or HTTP Basic credentials.

## Test Plan

- [x] Verified `docs/API.md` against `server/lib/authGate.js`, `CLAUDE.md`, and `README.md`.
- [x] Confirmed markdown formatting and links render cleanly.

Closes #4012
