### PR TITLE
docs: update npm run dev descriptions to reflect PM2 lifecycle (#4010)

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,8 +324,10 @@ PM2 keeps PortOS running in the background and auto-restarts on reboot (with `pm
 
 ```bash
 npm run setup          # Install all dependencies (alias: npm run install:all)
-npm run dev            # Vite hot-reload on :5554, API on :5555 — open :5554 in dev
+npm run dev            # Starts PostgreSQL, launches full PM2 ecosystem, and tails logs
 ```
+
+`npm run dev` executes `scripts/dev-start.js` to initialize PostgreSQL, stop existing PM2 processes, and launch the complete PM2 process ecosystem defined in `ecosystem.config.cjs` (`portos-server`, `portos-cos`, `portos-ui`, `portos-autofixer`, `portos-autofixer-ui`, `portos-browser`) while tailing logs. The React frontend runs with Vite hot-reload on `:5554` and the API on `:5555`.
 
 `:5554` is **only** used in dev for the Vite hot-reload server; in production (`npm start` / PM2) the React build is served from `:5555` directly.
 
@@ -352,7 +354,7 @@ PortOS binds to `0.0.0.0` so you can access it from any device on your Tailscale
 
 ```
 PortOS/
-├── client/              # React + Vite frontend (Vite dev on :5554)
+├── client/              # React + Vite frontend (Vite dev server on :5554 under npm run dev)
 ├── server/              # Express API (always serves on :5555)
 ├── autofixer/           # Standalone crash-detection/repair worker
 ├── data/                # Runtime data (apps, providers, history, brain, pipeline, …)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -11,9 +11,11 @@ npm run install:all
 # Start development
 npm run dev
 
-# Or with PM2
+# Or with PM2 directly
 pm2 start ecosystem.config.cjs
 ```
+
+`npm run dev` executes `scripts/dev-start.js` to initialize PostgreSQL, stop any existing PM2 processes, and start the complete PM2 process ecosystem defined in `ecosystem.config.cjs` (`portos-server`, `portos-cos`, `portos-ui`, `portos-autofixer`, `portos-autofixer-ui`, `portos-browser`) while tailing logs.
 
 **PostgreSQL is a mandatory dependency** — the server fails fast at boot without a healthy database. `npm run install:all` runs `npm run setup:db`, which provisions either the system PostgreSQL (`:5432`) or a Docker container (`:5561`, via `docker-compose.yml`). See [STORAGE.md](./STORAGE.md) and the [Postgres ADR](./decisions/2026-06-07-postgres-as-primary-datastore.md).
 
@@ -81,7 +83,7 @@ refactor: code restructuring
 
 ```
 PortOS/
-├── client/           # React + Vite frontend (port 5554)
+├── client/           # React + Vite frontend (Vite dev server on port 5554 under npm run dev)
 │   └── src/
 │       ├── components/
 │       ├── pages/


### PR DESCRIPTION
## Summary of Changes
Updated `README.md` and `docs/CONTRIBUTING.md` to accurately document that `npm run dev` executes `scripts/dev-start.js`, initializing PostgreSQL and launching the complete 6-process PM2 ecosystem defined in `ecosystem.config.cjs` while tailing logs.

## Test Plan
- Verified `README.md` and `docs/CONTRIBUTING.md` rendered formatting and accuracy against `scripts/dev-start.js` and `ecosystem.config.cjs`.
- Ran `git diff origin/main..HEAD` to confirm clean documentation updates.

Closes #4010
