### PR TITLE
fix: ensure min-44px touch targets on StagePromptModelPicker (#4015)

### DIFF
--- a/.changelog/next/fixed-issue-4015.md
+++ b/.changelog/next/fixed-issue-4015.md
@@ -1,0 +1,1 @@
+- Ensure min 44px touch targets on StagePromptModelPicker mode buttons

--- a/client/src/components/writers-room/StagePromptModelPicker.jsx
+++ b/client/src/components/writers-room/StagePromptModelPicker.jsx
@@ -120,7 +120,7 @@ export default function StagePromptModelPicker({ stageName, label = 'Stage LLM',
           <button
             type="button"
             onClick={switchToTier}
-            className={`px-1.5 py-0.5 text-[9px] rounded ${!isSpecific ? 'bg-port-accent text-white' : 'bg-port-border text-gray-400 hover:text-white'}`}
+            className={`min-h-[44px] min-w-[44px] flex items-center justify-center px-1.5 py-0.5 text-[9px] rounded ${!isSpecific ? 'bg-port-accent text-white' : 'bg-port-border text-gray-400 hover:text-white'}`}
           >
             Tier
           </button>
@@ -128,7 +128,7 @@ export default function StagePromptModelPicker({ stageName, label = 'Stage LLM',
             type="button"
             onClick={switchToSpecific}
             disabled={providers.length === 0}
-            className={`px-1.5 py-0.5 text-[9px] rounded ${isSpecific ? 'bg-port-accent text-white' : 'bg-port-border text-gray-400 hover:text-white'} disabled:opacity-50`}
+            className={`min-h-[44px] min-w-[44px] flex items-center justify-center px-1.5 py-0.5 text-[9px] rounded ${isSpecific ? 'bg-port-accent text-white' : 'bg-port-border text-gray-400 hover:text-white'} disabled:opacity-50`}
           >
             Specific
           </button>

--- a/client/src/components/writers-room/StagePromptModelPicker.test.jsx
+++ b/client/src/components/writers-room/StagePromptModelPicker.test.jsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+vi.mock('../../services/apiPrompts', () => ({
+  getPrompt: vi.fn(),
+  savePrompt: vi.fn(),
+}));
+
+vi.mock('../../services/apiProviders', () => ({
+  getProviders: vi.fn(),
+}));
+
+vi.mock('../ui/Toast', () => ({
+  default: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
+import StagePromptModelPicker from './StagePromptModelPicker';
+import { getPrompt } from '../../services/apiPrompts';
+import { getProviders } from '../../services/apiProviders';
+
+describe('StagePromptModelPicker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('a11y: Tier and Specific mode toggle buttons meet the 44px touch-target floor', async () => {
+    getPrompt.mockResolvedValue({ provider: null, model: 'default', timeout: null });
+    getProviders.mockResolvedValue({
+      activeProvider: 'openai',
+      providers: [
+        { id: 'openai', enabled: true, defaultModel: 'gpt-4o', models: ['gpt-4o'] },
+      ],
+    });
+
+    render(<StagePromptModelPicker stageName="adapt" label="Adapt Stage" />);
+
+    const tierBtn = await screen.findByRole('button', { name: 'Tier' });
+    const specificBtn = await screen.findByRole('button', { name: 'Specific' });
+
+    expect(tierBtn.className).toContain('min-h-[44px]');
+    expect(tierBtn.className).toContain('min-w-[44px]');
+    expect(tierBtn.className).toContain('flex');
+    expect(tierBtn.className).toContain('items-center');
+    expect(tierBtn.className).toContain('justify-center');
+
+    expect(specificBtn.className).toContain('min-h-[44px]');
+    expect(specificBtn.className).toContain('min-w-[44px]');
+    expect(specificBtn.className).toContain('flex');
+    expect(specificBtn.className).toContain('items-center');
+    expect(specificBtn.className).toContain('justify-center');
+  });
+});


### PR DESCRIPTION
## Summary of Changes

- Updated the Tier and Specific mode toggle buttons in `client/src/components/writers-room/StagePromptModelPicker.jsx` to enforce minimum 44px touch targets using Tailwind utility classes (`min-h-[44px] min-w-[44px] flex items-center justify-center`).
- Added a unit test suite in `client/src/components/writers-room/StagePromptModelPicker.test.jsx` to verify that both toggle buttons meet the minimum touch target requirement.

Closes #4015
