### PR TITLE
refactor: import countWords from formatters in letteringDensity (#4024)

### DIFF
--- a/.changelog/next/changed-issue-4024.md
+++ b/.changelog/next/changed-issue-4024.md
@@ -1,0 +1,1 @@
+- Import countWords from formatters in letteringDensity

--- a/client/src/lib/letteringDensity.js
+++ b/client/src/lib/letteringDensity.js
@@ -13,6 +13,8 @@
 // newline-joined string, so each non-empty line counts). SFX counts toward the
 // panel/page WORD load but is not a balloon.
 
+import { countWords } from '../utils/formatters.js';
+
 export const DEFAULT_LETTERING_THRESHOLDS = Object.freeze({
   maxWordsPerBalloon: 25,
   maxWordsPerPanel: 50,
@@ -22,13 +24,7 @@ export const DEFAULT_LETTERING_THRESHOLDS = Object.freeze({
 
 const LETTERING_SEVERITIES = ['high', 'medium', 'low'];
 
-// Count words in a free-text lettering string (runs of non-whitespace). 0 for
-// non-strings.
-export function countWords(text) {
-  if (typeof text !== 'string') return 0;
-  const matched = text.trim().match(/\S+/g);
-  return matched ? matched.length : 0;
-}
+export { countWords };
 
 // Severity scaled by how far over the threshold a count runs: ≥2× → high, ≥1.4×
 // → medium, else low.


### PR DESCRIPTION
### Summary
Remove local `countWords` implementation in `client/src/lib/letteringDensity.js` and import it from `client/src/utils/formatters.js`, re-exporting `countWords` from `letteringDensity.js` to maintain backwards compatibility.

Closes #4024

### Test Plan
- Ran `npx vitest run src/lib/letteringDensity.test.js` (passed 5/5).
- Ran full `client` test suite via `npm test` (610 test files passed, 7317 tests passed).
