### PR TITLE
fix(writers-room): enforce min 44px touch target on SceneCard debug menu button (#4017)

### DIFF
--- a/.changelog/next/fixed-issue-4017.md
+++ b/.changelog/next/fixed-issue-4017.md
@@ -1,0 +1,1 @@
+- SceneCard debug menu button meets mobile touch target minimum.

--- a/client/src/components/writers-room/SceneCard.jsx
+++ b/client/src/components/writers-room/SceneCard.jsx
@@ -304,7 +304,7 @@ const SceneCard = forwardRef(function SceneCard({
           <div className="relative" ref={debugMenuRef}>
             <button
               onClick={() => setShowDebugMenu((v) => !v)}
-              className="p-1 text-gray-500 hover:text-white"
+              className="min-w-[44px] min-h-[44px] flex items-center justify-center -my-1 text-gray-500 hover:text-white"
               aria-label="Debug this scene"
               title="Debug this scene"
             >


### PR DESCRIPTION
## Summary
Enforces a minimum 44px touch target on the SceneCard debug menu button in the Writers Room.

## Test Plan
- Verified button styling with min 44px width/height.
- Verified client unit tests pass.

Closes #4017
