### PR TITLE
fix(writers-room): enforce min 44px touch target on StoryboardConfigTab seed randomizer button (#4018)

### DIFF
--- a/.changelog/next/fixed-issue-4018.md
+++ b/.changelog/next/fixed-issue-4018.md
@@ -1,0 +1,1 @@
+- StoryboardConfigTab seed randomizer button meets mobile touch target minimum.

--- a/client/src/components/writers-room/StoryboardConfigTab.jsx
+++ b/client/src/components/writers-room/StoryboardConfigTab.jsx
@@ -236,7 +236,7 @@ function ImageGenSettingsRow({ cfg, models, availableBackends = [], onChange }) 
               <button
                 type="button"
                 onClick={() => onChange({ ...cfg, seed: randomSeed() })}
-                className="px-1.5 text-gray-500 hover:text-port-accent border border-port-border rounded"
+                className="min-h-[44px] min-w-[44px] flex items-center justify-center text-gray-500 hover:text-port-accent border border-port-border rounded"
                 title="Randomize seed"
                 aria-label="Randomize seed"
               >

--- a/client/src/components/writers-room/StoryboardConfigTab.test.jsx
+++ b/client/src/components/writers-room/StoryboardConfigTab.test.jsx
@@ -42,4 +42,12 @@ describe('StoryboardConfigTab', () => {
 
     expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
   });
+
+  it('a11y: the seed randomizer button meets the 44px touch-target floor', () => {
+    render(<StoryboardConfigTab {...baseProps} />);
+
+    const seedBtn = screen.getByRole('button', { name: 'Randomize seed' });
+    expect(seedBtn.className).toContain('min-h-[44px]');
+    expect(seedBtn.className).toContain('min-w-[44px]');
+  });
 });


### PR DESCRIPTION
## Summary
Enforces a minimum 44px touch target on the StoryboardConfigTab seed randomizer button in the Writers Room.

## Test Plan
- Verified button styling with min 44px width/height.
- Verified client unit tests pass.

Closes #4018
