### PR TITLE
fix(writers-room): enforce min 44px touch target on AnalysisHistory refresh button (#4016)

### DIFF
--- a/.changelog/next/fixed-issue-4016.md
+++ b/.changelog/next/fixed-issue-4016.md
@@ -1,0 +1,1 @@
+- Analysis History refresh button meets mobile touch target minimum.

--- a/client/src/components/writers-room/AnalysisHistory.jsx
+++ b/client/src/components/writers-room/AnalysisHistory.jsx
@@ -64,7 +64,7 @@ export default function AnalysisHistory({ work, activeHash, onApplyFormat }) {
         <button
           onClick={refresh}
           disabled={loading}
-          className="text-gray-500 hover:text-white disabled:opacity-50"
+          className="min-w-[44px] min-h-[44px] flex items-center justify-center -my-2 -mr-2 text-gray-500 hover:text-white disabled:opacity-50"
           aria-label="Refresh"
         >
           <RotateCcw size={12} className={loading ? 'animate-spin' : ''} />


### PR DESCRIPTION
## Summary
Enforces a minimum 44px touch target on the Analysis History refresh button in the Writers Room.

## Test Plan
- Verified button styling with min 44px width/height.
- Verified client unit tests pass.

Closes #4016
