### PR TITLE
fix(privacy): include unknown and update_pending holdings in declareChange (#4023)

### DIFF
--- a/.changelog/next/fixed-issue-4023.md
+++ b/.changelog/next/fixed-issue-4023.md
@@ -1,0 +1,1 @@
+- privacyChanges: declareChange includes holdings in unknown and update_pending status (#4023)

--- a/server/services/privacyChanges.js
+++ b/server/services/privacyChanges.js
@@ -158,11 +158,11 @@ export async function declareChange({ vaultRecordId, replacement, replacementRec
       [vaultRecordId],
     );
 
-    // Flip every current holding of the old record → update_pending, capturing
+    // Flip every active holding of the old record → update_pending, capturing
     // the affected orgs so we can mirror a forward-looking holding on the new one.
     const { rows: flipped } = await client.query(
       `UPDATE privacy_org_holdings SET status = 'update_pending', updated_at = NOW()
-       WHERE vault_record_id = $1 AND status = 'current'
+       WHERE vault_record_id = $1 AND status = ANY(ARRAY['current', 'unknown', 'update_pending'])
        RETURNING org_id`,
       [vaultRecordId],
     );

--- a/server/services/privacyChanges.test.js
+++ b/server/services/privacyChanges.test.js
@@ -117,11 +117,37 @@ describe('declareChange', () => {
     const insertRec = client.query.mock.calls.find(([s]) => /INSERT INTO privacy_vault_records/.test(s));
     expect(insertRec[1]).toContain('enc(742 New Ave)');
     // Both flipped orgs got a forward-looking current holding on the new record.
+    const flipQuery = client.query.mock.calls.find(([s]) => /UPDATE privacy_org_holdings SET status = 'update_pending'/.test(s));
+    expect(flipQuery[0]).toContain("ANY(ARRAY['current', 'unknown', 'update_pending'])");
     const forwardInserts = client.query.mock.calls.filter(([s]) => /INSERT INTO privacy_org_holdings/.test(s));
     expect(forwardInserts).toHaveLength(2);
     // Event kind derived from the old record type when none supplied.
     const insertEvent = client.query.mock.calls.find(([s]) => /INSERT INTO privacy_change_events/.test(s));
     expect(insertEvent[1]).toContain('address_change');
+  });
+
+  it('flips holdings in unknown and update_pending status as well as current', async () => {
+    const client = mockTransaction(async (sql) => {
+      if (/FROM privacy_vault_records WHERE id = \$1 FOR UPDATE/.test(sql)) return { rows: [{ id: 'old1', type: 'address' }] };
+      if (/INSERT INTO privacy_vault_records/.test(sql)) return { rows: [] };
+      if (/UPDATE privacy_vault_records\s+SET status = 'previous'/.test(sql)) return { rows: [] };
+      if (/UPDATE privacy_org_holdings SET status = 'update_pending'/.test(sql)) {
+        return { rows: [{ org_id: 'org-current' }, { org_id: 'org-unknown' }, { org_id: 'org-pending' }] };
+      }
+      if (/INSERT INTO privacy_org_holdings/.test(sql)) return { rows: [] };
+      if (/INSERT INTO privacy_change_events/.test(sql)) return { rows: [eventRow()] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    await declareChange({
+      vaultRecordId: 'old1',
+      replacement: { label: 'New home', value: '742 New Ave' },
+    });
+
+    const flipQuery = client.query.mock.calls.find(([s]) => /UPDATE privacy_org_holdings SET status = 'update_pending'/.test(s));
+    expect(flipQuery[0]).toMatch(/status = ANY\(ARRAY\['current', 'unknown', 'update_pending'\]\)/);
+    const forwardInserts = client.query.mock.calls.filter(([s]) => /INSERT INTO privacy_org_holdings/.test(s));
+    expect(forwardInserts).toHaveLength(3);
   });
 
   it('404s when the old record does not exist', async () => {


### PR DESCRIPTION
## Summary
Updates `declareChange` query in `server/services/privacyChanges.js` to flip holdings in `current`, `unknown`, and `update_pending` status.

## Test Plan
- Run `cd server && npm test`

Closes #4023
