### PR TITLE
fix(privacy): pass subjectId to getOrgsBySocialAccounts in social-account-links route (#4022)

### DIFF
--- a/.changelog/next/fixed-issue-4022.md
+++ b/.changelog/next/fixed-issue-4022.md
@@ -1,0 +1,1 @@
+- privacy: GET /api/privacy/social-account-links respects subjectId query parameter (#4022)

--- a/server/routes/privacy.js
+++ b/server/routes/privacy.js
@@ -207,8 +207,9 @@ router.post('/orgs', asyncHandler(async (req, res) => {
 
 // Digital Twin ↔ org cross-link (issue #2147): which social accounts are in
 // the org registry. Declared before `/orgs/:id` so the literal path wins.
-router.get('/social-account-links', asyncHandler(async (_req, res) => {
-  res.json(await getOrgsBySocialAccounts());
+router.get('/social-account-links', asyncHandler(async (req, res) => {
+  const { subjectId } = validateRequest(privacySubjectScopeQuerySchema, req.query);
+  res.json(await getOrgsBySocialAccounts({ subjectId }));
 }));
 
 router.get('/orgs/:id', asyncHandler(async (req, res) => {

--- a/server/routes/privacy.test.js
+++ b/server/routes/privacy.test.js
@@ -280,7 +280,19 @@ describe('GET /api/privacy/social-account-links', () => {
     const res = await request(makeApp()).get('/api/privacy/social-account-links');
     expect(res.status).toBe(200);
     expect(res.body).toEqual([{ socialAccountId: 'acct-1', orgId: 'o1', orgName: 'Acme Bank' }]);
-    expect(orgService.getOrgsBySocialAccounts).toHaveBeenCalled();
+    expect(orgService.getOrgsBySocialAccounts).toHaveBeenCalledWith({ subjectId: undefined });
+  });
+
+  it('passes subjectId to getOrgsBySocialAccounts when subjectId query param is provided (#4022)', async () => {
+    const res = await request(makeApp()).get(`/api/privacy/social-account-links?subjectId=${VALID_UUID}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ socialAccountId: 'acct-1', orgId: 'o1', orgName: 'Acme Bank' }]);
+    expect(orgService.getOrgsBySocialAccounts).toHaveBeenCalledWith({ subjectId: VALID_UUID });
+  });
+
+  it('rejects invalid subjectId query param (#4022)', async () => {
+    const res = await request(makeApp()).get('/api/privacy/social-account-links?subjectId=not-a-uuid');
+    expect(res.status).toBe(400);
   });
 });
 


### PR DESCRIPTION
## Summary
Fixes `GET /api/privacy/social-account-links` route to validate `req.query` with `privacySubjectScopeQuerySchema` and pass `{ subjectId }` to `getOrgsBySocialAccounts`.

## Test Plan
- Run `cd server && npm test`

Closes #4022
