### PR TITLE
fix(privacy): ensureSeeded updates curated brokers on version upgrade (#4019)

### DIFF
--- a/.changelog/next/fixed-issue-4019.md
+++ b/.changelog/next/fixed-issue-4019.md
@@ -1,0 +1,1 @@
+- privacyBrokers: ensureSeeded updates curated broker definitions on version upgrade (#4019)

--- a/scripts/migrations/265-update-curated-privacy-brokers.js
+++ b/scripts/migrations/265-update-curated-privacy-brokers.js
@@ -1,0 +1,10 @@
+/**
+ * Ensure updated curated privacy broker definitions are synced into privacy_brokers on upgrade (#4019).
+ */
+import { seedCuratedBrokers } from '../../server/services/privacyBrokers.js';
+
+export default {
+  async up() {
+    await seedCuratedBrokers().catch(() => {});
+  },
+};

--- a/scripts/migrations/265-update-curated-privacy-brokers.test.js
+++ b/scripts/migrations/265-update-curated-privacy-brokers.test.js
@@ -1,0 +1,18 @@
+/**
+ * Test for migration 265 — ensure seedCuratedBrokers is invoked.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../server/services/privacyBrokers.js', () => ({
+  seedCuratedBrokers: vi.fn().mockResolvedValue({ seeded: 52 }),
+}));
+
+import migration from './265-update-curated-privacy-brokers.js';
+import { seedCuratedBrokers } from '../../server/services/privacyBrokers.js';
+
+describe('migration 265 — update curated privacy brokers', () => {
+  it('calls seedCuratedBrokers on up()', async () => {
+    await migration.up();
+    expect(seedCuratedBrokers).toHaveBeenCalled();
+  });
+});

--- a/server/services/privacyBrokers.db.test.js
+++ b/server/services/privacyBrokers.db.test.js
@@ -37,7 +37,7 @@ describe.skipIf(!dbReady)('privacy brokers DB round-trip', () => {
   let svc;
   let scan;
   let vault;
-  const autoBrokerIds = ['test-auto-alpha', 'ca-test-beta-inc'];
+  const autoBrokerIds = ['test-auto-alpha', 'ca-test-beta-inc', 'test-auto-upgrade'];
   const createdVaultIds = [];
   const vaultTableWasEmpty = false;
   const testStart = new Date().toISOString();
@@ -76,6 +76,39 @@ describe.skipIf(!dbReady)('privacy brokers DB round-trip', () => {
     expect(parent.preferSuppression).toBe(true);
     const child = await svc.getBroker('truthfinder');
     expect(child.clusterParent).toBe('peopleconnect');
+  });
+
+  it('ensureSeeded updates curated brokers on version upgrade while preserving user settings and auto sources (#4019)', async () => {
+    svc.resetEnsureSeededForTests();
+    // 1. Disable a curated broker to verify user-modified setting is preserved
+    await svc.setBrokerEnabled('spokeo', false);
+
+    // 2. Insert a dummy non-curated broker to verify auto sources are preserved
+    await query(
+      `INSERT INTO privacy_brokers (id, name, urls, optout, tier, disclosure_fields, source, confidence, enabled, created_at, updated_at)
+       VALUES ('test-auto-upgrade', 'Auto Upgrade', '{}', '{}', 2, '[]', 'badbool', 'auto', true, NOW(), NOW())
+       ON CONFLICT (id) DO NOTHING`,
+    );
+
+    // 3. Mutate a curated broker's field in DB to simulate an older version record
+    await query(`UPDATE privacy_brokers SET name = 'Old Spokeo Name' WHERE id = 'spokeo'`);
+
+    // 4. Trigger ensureSeeded
+    svc.resetEnsureSeededForTests();
+    await svc.ensureSeeded();
+
+    // 5. Verify curated broker definition is updated from seed file (name restored)
+    const spokeo = await svc.getBroker('spokeo');
+    expect(spokeo.name).toBe('Spokeo');
+    // Verify user-modified enabled setting (false) was preserved
+    expect(spokeo.enabled).toBe(false);
+
+    // 6. Verify non-curated broker was untouched
+    const autoBroker = await svc.getBroker('test-auto-upgrade');
+    expect(autoBroker).toMatchObject({ name: 'Auto Upgrade', source: 'badbool' });
+
+    // Cleanup
+    await svc.setBrokerEnabled('spokeo', true);
   });
 
   it('refresh adds auto brokers and NEVER clobbers a curated row', async () => {

--- a/server/services/privacyBrokers.js
+++ b/server/services/privacyBrokers.js
@@ -216,8 +216,12 @@ function normalizeBroker(b) {
 
 // Upsert one broker; when `onlyIfNotCurated` is set the DO UPDATE is skipped for
 // a row already marked curated (the refresh never clobbers field-verified data).
-async function upsertBroker(client, b, { onlyIfNotCurated = false } = {}) {
-  const guard = onlyIfNotCurated ? `WHERE privacy_brokers.source <> 'curated'` : '';
+// When `onlyIfCurated` is set, the DO UPDATE is only performed for curated rows.
+async function upsertBroker(client, b, { onlyIfNotCurated = false, onlyIfCurated = false } = {}) {
+  let guard = '';
+  if (onlyIfNotCurated) guard = `WHERE privacy_brokers.source <> 'curated'`;
+  else if (onlyIfCurated) guard = `WHERE privacy_brokers.source = 'curated'`;
+
   await client.query(
     `INSERT INTO privacy_brokers
        (id, name, urls, optout, tier, disclosure_fields, cluster_parent,
@@ -230,7 +234,7 @@ async function upsertBroker(client, b, { onlyIfNotCurated = false } = {}) {
        cluster_parent = EXCLUDED.cluster_parent,
        prefer_suppression = EXCLUDED.prefer_suppression, antibot = EXCLUDED.antibot,
        source = EXCLUDED.source, confidence = EXCLUDED.confidence,
-       last_verified = EXCLUDED.last_verified, enabled = EXCLUDED.enabled,
+       last_verified = EXCLUDED.last_verified, enabled = privacy_brokers.enabled,
        updated_at = NOW()
      ${guard}`,
     [
@@ -257,16 +261,27 @@ export async function seedCuratedBrokers() {
   const brokers = await loadCuratedSeed();
   const ordered = [...brokers].sort((a, b) => (a.clusterParent ? 1 : 0) - (b.clusterParent ? 1 : 0));
   await withTransaction(async (client) => {
-    for (const b of ordered) await upsertBroker(client, b);
+    for (const b of ordered) await upsertBroker(client, b, { onlyIfCurated: true });
   });
   console.log(`🗂️ Seeded ${ordered.length} curated privacy brokers`);
   return { seeded: ordered.length };
 }
 
-// Lazy first-use seed — never at boot. Only seeds an empty table.
-async function ensureSeeded() {
-  const { rows } = await query(`SELECT COUNT(*)::int AS n FROM privacy_brokers`);
-  if (rows[0].n === 0) await seedCuratedBrokers();
+let seedPromise = null;
+
+// Lazy first-use seed — syncs curated brokers on initial use after server boot / upgrade.
+export async function ensureSeeded() {
+  if (!seedPromise) {
+    seedPromise = seedCuratedBrokers().catch((err) => {
+      seedPromise = null;
+      throw err;
+    });
+  }
+  await seedPromise;
+}
+
+export function resetEnsureSeededForTests() {
+  seedPromise = null;
 }
 
 export async function listBrokers({ enabled } = {}) {

--- a/server/services/privacyBrokers.test.js
+++ b/server/services/privacyBrokers.test.js
@@ -22,9 +22,18 @@ const {
   parseCaRegistryCsv,
   parseBadboolList,
   listBrokerCases,
+  ensureSeeded,
+  resetEnsureSeededForTests,
 } = await import('./privacyBrokers.js');
 
 beforeEach(() => queryMock.mockReset());
+
+describe('ensureSeeded — syncing curated brokers on boot/upgrade (#4019)', () => {
+  it('calls seedCuratedBrokers on initial ensureSeeded invocation', async () => {
+    resetEnsureSeededForTests();
+    await expect(ensureSeeded()).resolves.not.toThrow();
+  });
+});
 
 describe('listBrokerCases — subject scoping (#3658)', () => {
   it('always scopes to a subject and binds the state filter as $2 (not a literal)', async () => {


### PR DESCRIPTION
## Summary
Updates `ensureSeeded()` in `server/services/privacyBrokers.js` to always sync curated broker definitions on startup so upgrades pull updated opt-out URLs and new curated brokers.

## Test Plan
- Run `cd server && npm test`

Closes #4019
