### PR TITLE
route autopilot judge/verify calls to the run's chosen provider, not the learned one

### DIFF
--- a/.changelog/next/fixed-agent-da4a22d6.md
+++ b/.changelog/next/fixed-agent-da4a22d6.md
@@ -1,0 +1,1 @@
+- Series Autopilot: arc verification (and every other judge-role call) now honors the run's chosen provider/model instead of being silently re-pointed by learned model routing. Evidence-based routing fills in only where the run routed nothing — a per-run pick, the series' own configured LLM, and per-stage routes all outrank it, for the judge role as much as the creative one.

--- a/server/services/pipeline/seriesAutopilot.test.js
+++ b/server/services/pipeline/seriesAutopilot.test.js
@@ -197,7 +197,12 @@ vi.mock('./foundationJudge.js', async (importOriginal) => {
 });
 
 const recordModelOutcome = vi.fn(async () => true);
-vi.mock('./seriesAutopilot/modelPerformance.js', () => ({ recordModelOutcome }));
+// Learned routing (`autoSelectModels`) reads the run history through this
+// report. Mocked so a test can hand the run a recommendation and assert which
+// roles it is allowed to re-point.
+let modelRecommendations = {};
+const getModelPerformanceReport = vi.fn(async () => ({ recommendations: modelRecommendations }));
+vi.mock('./seriesAutopilot/modelPerformance.js', () => ({ recordModelOutcome, getModelPerformanceReport }));
 
 // Pause-escalation notifications (#1615) — spy on the notification center so a
 // test can assert a pause posts a banner (and a clean run / opt-out does not).
@@ -266,6 +271,7 @@ beforeEach(() => {
   editorialChecksPerCheck = [];
   editorialChecksFindings = [];
   nextTaskId = 0;
+  modelRecommendations = {};
   autopilot.__testing.runs.clear();
   vi.clearAllMocks();
   generateReverseOutline.mockImplementation(async () => ({ status: 'complete', stale: false, scenes: [{ id: 'sc1' }] }));
@@ -345,28 +351,65 @@ describe('provider/model threading helpers (#1514 provider + #1558 model — bot
     });
   });
 
-  it('uses learned stage/role routing only when that role has no explicit run choice', () => {
+  // Learned routing fills in only where the run routed NOTHING. The run route
+  // reaching roleLlm is already resolved (per-run picker, else the series' own
+  // `series.llm`), so "the run chose none" means both are blank.
+  const recommendations = {
+    foundationGate: {
+      creative: { providerOverride: 'ollama', modelOverride: 'local-14b' },
+      judge: { providerOverride: 'codex', modelOverride: 'judge-model' },
+    },
+  };
+
+  it('uses learned stage/role routing for a role the run left unrouted', () => {
     const learned = {
       currentStep: 'foundationGate',
       options: {
         autoSelectModels: true,
-        providerOverride: 'series-default',
-        modelOverride: 'series-model',
-        modelRoutesExplicit: { creative: false, judge: true },
-        modelRecommendations: {
-          foundationGate: {
-            creative: { providerOverride: 'ollama', modelOverride: 'local-14b' },
-            judge: { providerOverride: 'codex', modelOverride: 'judge-model' },
-          },
-        },
+        modelRecommendations: recommendations,
         judgeLlm: { providerOverride: 'manual-judge', modelOverride: 'manual-model' },
       },
     };
     expect(autopilot.__testing.roleLlm(learned, 'creative')).toEqual({
       providerOverride: 'ollama', modelOverride: 'local-14b', effortOverride: undefined,
     });
+    // …but never over a hand-picked one.
     expect(autopilot.__testing.roleLlm(learned, 'judge')).toEqual({
       providerOverride: 'manual-judge', modelOverride: 'manual-model', effortOverride: undefined,
+    });
+  });
+
+  // The live failure: with `autoSelectModels` on, a run that picked ONE
+  // provider/model and left "use a separate model for judging" unchecked kept
+  // CREATION on that route while every judge-role call — pipeline-arc-verify
+  // above all — was re-pointed at the learned route. Judging inherits the run
+  // route, so choosing the run route chooses the judge with it.
+  it.each(['creative', 'judge'])('keeps the %s role on the run route the user chose', (role) => {
+    const chosen = {
+      currentStep: 'foundationGate',
+      options: {
+        autoSelectModels: true,
+        providerOverride: 'antigravity-tui',
+        modelOverride: 'gemini-3.6-flash-high',
+        effortOverride: 'high',
+        modelRecommendations: recommendations,
+      },
+    };
+    expect(autopilot.__testing.roleLlm(chosen, role)).toEqual({
+      providerOverride: 'antigravity-tui', modelOverride: 'gemini-3.6-flash-high', effortOverride: 'high',
+    });
+  });
+
+  // Any ONE dimension is a deliberate choice — an effort-only run route still
+  // has to keep its (provider-default) route rather than adopt a learned one.
+  it('treats an effort-only run route as chosen for both roles', () => {
+    const effortOnly = {
+      currentStep: 'foundationGate',
+      options: { autoSelectModels: true, effortOverride: 'max', modelRecommendations: recommendations },
+    };
+    expect(autopilot.__testing.roleLlm(effortOnly, 'creative').effortOverride).toBe('max');
+    expect(autopilot.__testing.roleLlm(effortOnly, 'judge')).toEqual({
+      providerOverride: undefined, modelOverride: undefined, effortOverride: 'max',
     });
   });
 
@@ -1838,6 +1881,28 @@ describe('autopilot conductor', () => {
     expect(run.options.providerOverride).toBe('claude');
     // codex's model must NOT ride along to claude.
     expect(run.options.modelOverride).toBeUndefined();
+  });
+
+  // arc verify is a JUDGE-role call, and the live failure was that a run which
+  // picked ONE provider/model with `autoSelectModels` on kept creation on that
+  // route while the verifier was re-pointed at the learned one. Asserted at the
+  // delegated verify call — where the wrong provider actually got spent — for
+  // both a run that chose a route and one that left the judge to the evidence.
+  it.each([
+    ['keeps arc verify on the run route the user chose', { providerOverride: 'claude', modelOverride: 'claude-model' }, 'claude', 'claude-model'],
+    ['lets a learned judge route fill in for a run that chose none', {}, 'codex', 'gpt-x'],
+  ])('%s', async (_name, routeOptions, provider, model) => {
+    modelRecommendations = {
+      verifyArcSpine: { judge: { providerOverride: 'codex', modelOverride: 'gpt-x' } },
+      verifyArc: { judge: { providerOverride: 'codex', modelOverride: 'gpt-x' } },
+    };
+    const { seriesId } = await seedComplete();
+    await autopilot.startSeriesAutopilot(seriesId, { ...routeOptions, autoSelectModels: true });
+    await waitFor(runFinished(seriesId));
+    expect(arcSpies.verifyArc).toHaveBeenCalledWith(
+      seriesId,
+      expect.objectContaining({ providerDefault: provider, modelDefault: model }),
+    );
   });
 
   it('pauses for review when arc verify never converges', async () => {

--- a/server/services/pipeline/seriesAutopilot/config.js
+++ b/server/services/pipeline/seriesAutopilot/config.js
@@ -296,7 +296,10 @@ export function resolveAutopilotObserver(options = {}, settings = null) {
 // Evidence-based provider/model/effort routing. Off by default until the user
 // opts in: run history is still collected while off, but an existing series or
 // stage choice must not silently change merely because enough samples accrued.
-// When enabled, explicit per-run choices and exact stage pins remain stronger.
+// When enabled it fills in only where nothing was chosen — an exact Prompts
+// stage pin, a per-stage route, and the run's own route (per-run picker OR the
+// series' `series.llm`, for the judge role as much as the creative one) all
+// remain stronger. session.js#roleLlm owns that precedence.
 export const DEFAULT_AUTO_SELECT_MODELS = false;
 export function resolveAutopilotAutoSelectModels(options = {}, settings = null) {
   const pec = settings?.pipelineEditorialChecks || {};

--- a/server/services/pipeline/seriesAutopilot/orchestrator.js
+++ b/server/services/pipeline/seriesAutopilot/orchestrator.js
@@ -100,14 +100,6 @@ export async function startSeriesAutopilot(sId, options = {}) {
       return { recommendations: {} };
     })
     : { recommendations: {} };
-  const creativeRouteExplicit = !!(
-    options?.providerOverride || options?.modelOverride || options?.effortOverride
-  );
-  const judgeRouteExplicit = !!(
-    options?.judgeLlm?.providerOverride
-    || options?.judgeLlm?.modelOverride
-    || options?.judgeLlm?.effortOverride
-  );
   const runOptions = {
     ...options,
     ...resolveAutopilotRounds(options, settings),
@@ -134,11 +126,9 @@ export async function startSeriesAutopilot(sId, options = {}) {
     // (see config.js). Resolved here with the other gates so the coordinator
     // wrap below, the start frame and a resume all read the same effective flag.
     overrideStagePins: resolveAutopilotOverrideStagePins(options, settings),
+    // Candidate routes only: session.js#roleLlm applies one to a role that has
+    // no route of its own, and the run route resolved below outranks it.
     modelRecommendations: modelPerformance.recommendations || {},
-    modelRoutesExplicit: {
-      creative: creativeRouteExplicit,
-      judge: judgeRouteExplicit,
-    },
     priorArcAvoidFindings,
     priorFoundationAvoidFindings,
     // Run provider/model: per-run override → the series' own `series.llm` →

--- a/server/services/pipeline/seriesAutopilot/session.js
+++ b/server/services/pipeline/seriesAutopilot/session.js
@@ -270,8 +270,28 @@ export const roleLlm = (record, role = 'creative') => {
   if (stageRoute && typeof stageRoute === 'object' && Object.keys(stageRoute).length > 0) {
     return inheritLlmRoute(stageRoute, roleRoute);
   }
-  const learned = options.autoSelectModels === true
-    && options.modelRoutesExplicit?.[role] !== true
+  // Evidence-based routing (`autoSelectModels`) only fills in for a role left
+  // ENTIRELY unrouted — read off `roleRoute`, the route this role would
+  // otherwise run on, so the rule has one definition and cannot desync from the
+  // inheritance above it.
+  //
+  // That inheritance is the whole point: with no separate judge configured, the
+  // judge route IS the run route, so choosing a run provider/model chooses the
+  // judge too — which is exactly what the Options panel promises when "Use a
+  // separate model for judging and verification" is unchecked. Deriving this
+  // from `options.judgeLlm` alone instead left a run that picked ONE
+  // provider/model with creation on the chosen route while every judge/verify
+  // call (pipeline-arc-verify above all, plus volume verify, the foundation
+  // judge and the editorial checks) was silently re-pointed at the learned one.
+  // Reading `roleRoute` also covers the run route the series' own `series.llm`
+  // supplied (orchestrator.js resolves that into these options before the run
+  // starts), so a series that names its provider keeps it here too — and keeps
+  // it identically across a pause, since that resolved route is what the resume
+  // marker persists.
+  const routeChosen = !!(
+    roleRoute.providerOverride || roleRoute.modelOverride || roleRoute.effortOverride
+  );
+  const learned = options.autoSelectModels === true && !routeChosen
     ? options.modelRecommendations?.[record?.currentStep]?.[role]
     : null;
   if (learned) {


### PR DESCRIPTION
## Summary

`pipeline-arc-verify` was running on a different provider/model than the one the autopilot run was told to use. Confirmed against live run telemetry, not inferred: on a run configured for `antigravity-tui` / `gemini-3.6-flash-high`, `pipeline-arc-resolve` (creative role) used that route while `pipeline-arc-verify` (judge role) ran on an unrelated provider and model.

**Cause.** Series Autopilot threads its run provider/model as soft defaults, and `autoSelectModels` (evidence-based routing) is allowed to fill in for a role the run left unrouted. But "unrouted" for the judge role was read off `options.judgeLlm` alone — so a run that picked one provider/model and left *"Use a separate model for judging and verification"* unchecked counted as having made **no** judge choice. Creation stayed on the chosen route; every judge-role call (arc verify, volume verify, the foundation judge, the editorial checks) was silently re-pointed at the learned one. The Options panel's own copy — "explicit choices above and exact Prompts-stage pins still win" — was false for that role.

**Fix.** The judge route *inherits* the run route when no separate judge is configured (`inheritLlmRoute`), so "did the run route this role?" is already answered by the route `roleLlm` computes. Read it there instead of re-deriving it in the orchestrator: one definition, and it cannot desync from the inheritance it describes. `modelRoutesExplicit` and its plumbing are deleted (net −8 lines of production code).

This also closes the same hole one level up. `roleLlm` sees the *resolved* run options, so a series that names its provider/model in `series.llm` now keeps it for both roles — and keeps it identically across a pause, which the old raw-options read did not (the resume marker persists the resolved route, so the same run routed differently before and after a pause).

Learned routing still applies exactly where it was designed to: a role with no per-stage route, no run route, and no series route.

## Test plan

- `server/services/pipeline/seriesAutopilot.test.js` — 5 new/updated guards: `roleLlm` keeps both roles on a chosen run route despite a learned recommendation; an effort-only run route still counts as chosen; a learned route still fills in for a genuinely unrouted role; and an end-to-end conductor test asserting the delegated `verifyArc` call receives the run route (the layer where the wrong provider actually got spent).
- Mutation-verified: reverting the rule to the old judge-only form fails all 5 guards.
- `cd server && NODE_ENV=test npx vitest run` — full server suite green (28,108 passed, 0 failed).