### PR TITLE
fix(cos): require confirmation before killing running agent (#4034)

### DIFF
--- a/.changelog/next/fixed-issue-4034.md
+++ b/.changelog/next/fixed-issue-4034.md
@@ -1,0 +1,1 @@
+- cos: require confirmation before killing running agent (#4034)

--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -124,6 +124,7 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
   const [pausing, setPausing] = useState(false);
   const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
   const [killing, setKilling] = useState(false);
+  const [confirmingKill, setConfirmingKill] = useState(false);
   const [feedbackState, setFeedbackState] = useState(agent.feedback?.rating || null);
   const [btwInput, setBtwInput] = useState('');
   const [sendingBtw, setSendingBtw] = useState(false);
@@ -244,8 +245,12 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
   const handleKill = async () => {
     if (!onKill) return;
     setKilling(true);
-    await onKill(agent.id);
-    setKilling(false);
+    try {
+      await onKill(agent.id);
+    } finally {
+      setKilling(false);
+      setConfirmingKill(false);
+    }
   };
 
   // Fetch full output when expanded for completed agents (skip for remote)
@@ -479,15 +484,28 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
             )}
             {/* Kill button (force SIGKILL) */}
             {!inactive && onKill && (
-              <button
-                onClick={handleKill}
-                disabled={killing}
-                className="flex items-center gap-1.5 px-2 py-1 text-xs rounded bg-port-error/20 text-port-error hover:bg-port-error/30 transition-colors disabled:opacity-50"
-                aria-label="Force kill agent (SIGKILL)"
-              >
-                {killing ? <Loader2 size={12} aria-hidden="true" className="animate-spin" /> : <Skull size={12} aria-hidden="true" />}
-                <span className="hidden sm:inline">Kill</span>
-              </button>
+              confirmingKill ? (
+                <ConfirmButtonPair
+                  prompt="Kill?"
+                  confirmText="Confirm"
+                  cancelText="Cancel"
+                  ariaLabel="Confirm kill agent"
+                  confirmIcon={Skull}
+                  busy={killing}
+                  onConfirm={handleKill}
+                  onCancel={() => setConfirmingKill(false)}
+                />
+              ) : (
+                <button
+                  onClick={() => setConfirmingKill(true)}
+                  disabled={killing}
+                  className="flex items-center gap-1.5 px-2 py-1 text-xs rounded bg-port-error/20 text-port-error hover:bg-port-error/30 transition-colors disabled:opacity-50"
+                  aria-label="Force kill agent (SIGKILL)"
+                >
+                  {killing ? <Loader2 size={12} aria-hidden="true" className="animate-spin" /> : <Skull size={12} aria-hidden="true" />}
+                  <span className="hidden sm:inline">Kill</span>
+                </button>
+              )
             )}
             {(completed || paused) && onResume && (
               <button

--- a/client/src/components/cos/tabs/AgentCard.test.jsx
+++ b/client/src/components/cos/tabs/AgentCard.test.jsx
@@ -213,3 +213,37 @@ describe('AgentCard transcript truncation (#3498)', () => {
     expect(screen.queryByText(/Showing the last/)).not.toBeInTheDocument();
   });
 });
+
+describe('AgentCard kill confirmation (#4034)', () => {
+  it('requires confirmation before calling onKill', async () => {
+    const user = userEvent.setup();
+    const onKill = vi.fn().mockResolvedValue(true);
+    const runningAgent = {
+      ...agent,
+      status: 'running',
+      completedAt: null,
+    };
+
+    render(
+      <MemoryRouter>
+        <AgentCard agent={runningAgent} onKill={onKill} />
+      </MemoryRouter>
+    );
+
+    // Clicking Kill should show confirmation prompt and NOT call onKill immediately
+    await user.click(screen.getByRole('button', { name: 'Force kill agent (SIGKILL)' }));
+    expect(onKill).not.toHaveBeenCalled();
+    expect(screen.getByText('Kill?')).toBeInTheDocument();
+
+    // Clicking Cancel disarms confirmation state
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onKill).not.toHaveBeenCalled();
+    expect(screen.queryByText('Kill?')).not.toBeInTheDocument();
+
+    // Re-arm and click Confirm
+    await user.click(screen.getByRole('button', { name: 'Force kill agent (SIGKILL)' }));
+    await user.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onKill).toHaveBeenCalledWith(runningAgent.id);
+  });
+});
+


### PR DESCRIPTION
### Description
Requires user confirmation before force-killing a running agent in AgentCard.jsx.

### Changes
- Wrapped onKill button action in AgentCard.jsx with confirmation state using ConfirmButtonPair.
- Clicking 'Kill' arms confirmation prompt.
- Clicking 'Cancel' disarms confirmation state without calling onKill.
- Clicking 'Confirm' calls onKill(agent.id).
- Added unit tests in AgentCard.test.jsx.

Closes #4034