### PR TITLE
fix(privacy): handle stranded awaiting_processing opt-out requests (#4020)

### DIFF
--- a/.changelog/next/fixed-issue-4020.md
+++ b/.changelog/next/fixed-issue-4020.md
@@ -1,0 +1,1 @@
+- privacyOptOut: handle stranded awaiting_processing opt-out requests (#4020)

--- a/server/services/privacyBrokers.js
+++ b/server/services/privacyBrokers.js
@@ -60,7 +60,7 @@ const STATE_TRANSITIONS = Object.freeze({
   optout_in_progress: ['submitted'],
   submitted: ['verification_pending'],
   verification_pending: ['awaiting_processing'],
-  awaiting_processing: [],
+  awaiting_processing: ['human_task_queued', 'found'],
   // Post-removal / requeue paths resume opt-out work.
   human_task_queued: [
     'found', 'not_found', 'indirect_exposure', 'blocked',

--- a/server/services/privacyBrokers.test.js
+++ b/server/services/privacyBrokers.test.js
@@ -172,6 +172,12 @@ describe('allowedTransitionsFor — client action gating (issue #2417)', () => {
     expect(allowed).toContain('not_found');
   });
 
+  it('lets awaiting_processing transition to found and human_task_queued (#4020)', () => {
+    const allowed = allowedTransitionsFor('awaiting_processing');
+    expect(allowed).toContain('found');
+    expect(allowed).toContain('human_task_queued');
+  });
+
   it('returns only the any-state target for an unknown state', () => {
     expect(allowedTransitionsFor('bogus')).toEqual(['human_task_queued']);
   });

--- a/server/services/privacyOptOut.js
+++ b/server/services/privacyOptOut.js
@@ -396,16 +396,20 @@ export function planOptOutActions(casesWithBroker = []) {
 
 // ─── Verification pass ──────────────────────────────────────────────────────
 
+export const DEFAULT_MAX_VERIFICATION_RECHECKS = 3;
+
 /**
  * Poll the synced inbox for a broker confirmation for each `submitted` case and
  * advance it to `verification_pending` (anti-phishing gated). Then a verifying
  * re-scan of `verification_pending`/`awaiting_processing` cases decides
  * `confirmed_removed` (not_found) — the ONLY path to that state — leaving a
- * still-listed case in place. Deps injectable (no network in tests).
+ * still-listed case in place or transitioning it to `awaiting_processing` /
+ * `human_task_queued` (optout_unfulfilled) after max recheck attempts.
+ * Deps injectable (no network in tests).
  */
 export async function runVerificationPass({
   now = new Date(), messagesProvider = getMessages, removalProbe = probeBroker, probeDeps = {},
-  subjectId,
+  subjectId, maxVerificationRechecks = DEFAULT_MAX_VERIFICATION_RECHECKS,
 } = {}) {
   // CONSENT GATE — the verification pass re-probes brokers for the subject, so
   // it is gated exactly like the submission pass.
@@ -414,6 +418,7 @@ export async function runVerificationPass({
   const cases = await listBrokerCases({ subjectId: resolvedSubjectId });
   const advanced = [];
   const confirmed = [];
+  const unfulfilled = [];
   // 1. submitted → verification_pending when a trusted confirmation email exists.
   const submitted = cases.filter((c) => c.state === 'submitted');
   if (submitted.length) {
@@ -445,14 +450,33 @@ export async function runVerificationPass({
       // opt-out-owned states, so probeBroker classifies the CURRENT listing
       // without touching the case. `not_found` is the ONLY path to confirmed.
       const probed = await removalProbe(broker, vectors, probeDeps).catch(() => null);
-      if (probed && !probed.skipped && probed.verdict === 'not_found') {
-        await transitionCase(c.id, 'confirmed_removed', { viaRescan: true, evidence: { ...(c.evidence || {}), verifiedRemovedAt: now.toISOString() }, now });
-        confirmed.push({ caseId: c.id, brokerId: c.brokerId });
+      if (probed && !probed.skipped) {
+        if (probed.verdict === 'not_found') {
+          await transitionCase(c.id, 'confirmed_removed', { viaRescan: true, evidence: { ...(c.evidence || {}), verifiedRemovedAt: now.toISOString() }, now });
+          confirmed.push({ caseId: c.id, brokerId: c.brokerId });
+        } else {
+          // Still listed (verdict === 'found' or similar). Track recheck count.
+          const currentRechecks = c.evidence?.verificationRechecks ?? c.evidence?.recheckCount ?? 0;
+          const rechecks = currentRechecks + 1;
+          if (rechecks >= maxVerificationRechecks) {
+            await transitionCase(c.id, 'human_task_queued', {
+              reason: 'optout_unfulfilled',
+              evidence: { ...(c.evidence || {}), verificationRechecks: rechecks, unfulfilledAt: now.toISOString() },
+              now,
+            });
+            unfulfilled.push({ caseId: c.id, brokerId: c.brokerId });
+          } else {
+            await transitionCase(c.id, 'awaiting_processing', {
+              evidence: { ...(c.evidence || {}), verificationRechecks: rechecks },
+              now,
+            });
+          }
+        }
       }
     }
   }
-  console.log(`✅ Verification pass: ${advanced.length} advanced, ${confirmed.length} confirmed removed`);
-  return { advanced, confirmed };
+  console.log(`✅ Verification pass: ${advanced.length} advanced, ${confirmed.length} confirmed removed, ${unfulfilled.length} unfulfilled → human task`);
+  return { advanced, confirmed, unfulfilled };
 }
 
 // ─── Main run loop ──────────────────────────────────────────────────────────

--- a/server/services/privacyOptOut.test.js
+++ b/server/services/privacyOptOut.test.js
@@ -301,7 +301,7 @@ describe('runVerificationPass', () => {
     expect(res.confirmed).toHaveLength(1);
     expect(transitionCase).toHaveBeenCalledWith('c2', 'confirmed_removed', expect.objectContaining({ viaRescan: true }));
   });
-  it('leaves a still-listed case untouched', async () => {
+  it('increments recheck count and moves verification_pending to awaiting_processing when still found (#4020)', async () => {
     getBroker.mockResolvedValue({ id: 'spokeo', urls: { search: 'https://www.spokeo.com/{firstName}/{state}' } });
     const vault = await import('./privacyVault.js');
     vault.listScanEligibleValues.mockResolvedValue(SCAN_VALUES);
@@ -311,6 +311,24 @@ describe('runVerificationPass', () => {
     const removalProbe = vi.fn(async () => ({ verdict: 'found', found: true }));
     const res = await runVerificationPass({ removalProbe });
     expect(res.confirmed).toHaveLength(0);
+    expect(transitionCase).toHaveBeenCalledWith('c3', 'awaiting_processing', expect.objectContaining({
+      evidence: expect.objectContaining({ verificationRechecks: 1 }),
+    }));
+  });
+  it('transitions stranded awaiting_processing cases to human_task_queued with reason optout_unfulfilled after max rechecks (#4020)', async () => {
+    getBroker.mockResolvedValue({ id: 'spokeo', urls: { search: 'https://www.spokeo.com/{firstName}/{state}' } });
+    const vault = await import('./privacyVault.js');
+    vault.listScanEligibleValues.mockResolvedValue(SCAN_VALUES);
+    listBrokerCases
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ id: 'c4', brokerId: 'spokeo', state: 'awaiting_processing', evidence: { verificationRechecks: 2 } }]);
+    const removalProbe = vi.fn(async () => ({ verdict: 'found', found: true }));
+    const res = await runVerificationPass({ removalProbe, maxVerificationRechecks: 3 });
+    expect(res.unfulfilled).toHaveLength(1);
+    expect(transitionCase).toHaveBeenCalledWith('c4', 'human_task_queued', expect.objectContaining({
+      reason: 'optout_unfulfilled',
+      evidence: expect.objectContaining({ verificationRechecks: 3 }),
+    }));
   });
 });
 


### PR DESCRIPTION
## Description
Fixes issue where ignored opt-out requests become permanently stranded in `awaiting_processing`.

Changes:
- Added `human_task_queued` and `found` to `STATE_TRANSITIONS.awaiting_processing` in `privacyBrokers.js`.
- Updated `runVerificationPass` in `privacyOptOut.js` to track verification recheck attempts.
- Transition cases in `awaiting_processing` that remain `found` after max verification rechecks (3) to `human_task_queued` with reason `'optout_unfulfilled'`.
- Added unit tests in `privacyBrokers.test.js` and `privacyOptOut.test.js`.

Closes #4020