### PR TITLE
fix: preserve settings and display error state on fetch failure in CodeReviewDefaultsPanel (#4030)

### DIFF
--- a/.changelog/next/fixed-issue-4030.md
+++ b/.changelog/next/fixed-issue-4030.md
@@ -1,0 +1,1 @@
+- Preserved user settings and displayed inline error state with Retry button on fetch failure in CodeReviewDefaultsPanel

--- a/client/src/components/providers/CodeReviewDefaultsPanel.jsx
+++ b/client/src/components/providers/CodeReviewDefaultsPanel.jsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ShieldCheck } from 'lucide-react';
 import toast from '../ui/Toast';
+import Banner from '../ui/Banner';
 import * as api from '../../services/api';
 import ReviewerPicker from '../cos/ReviewerPicker';
 import useReviewerModelOptions from '../../hooks/useReviewerModelOptions';
@@ -27,6 +28,7 @@ const CLI_REVIEWER_LIST = new Intl.ListFormat('en', { style: 'long', type: 'conj
 // the model option lists (via useReviewerModelOptions) and the save.
 export default function CodeReviewDefaultsPanel() {
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [saving, setSaving] = useState(false);
   const [reviewers, setReviewers] = useState(DEFAULT_REVIEWERS);
   const [usernames, setUsernames] = useState([]);
@@ -39,10 +41,11 @@ export default function CodeReviewDefaultsPanel() {
   const [installed, setInstalled] = useState({});
   const modelOptions = useReviewerModelOptions();
 
-  useEffect(() => {
+  const loadDefaults = useCallback(() => {
+    setLoading(true);
+    setLoadError(false);
     let cancelled = false;
     api.getCodeReviewDefaults({ silent: true })
-      .catch(() => null)
       .then((defaults) => {
         if (cancelled) return;
         if (defaults) {
@@ -57,13 +60,25 @@ export default function CodeReviewDefaultsPanel() {
           setStopMode(defaults.stopMode || DEFAULT_REVIEW_STOP_MODE);
           setReviewerApplies(defaults.reviewerApplies === true);
           setInstalled(defaults.installed && typeof defaults.installed === 'object' && !Array.isArray(defaults.installed) ? defaults.installed : {});
+        } else {
+          setLoadError(true);
         }
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setLoadError(true);
         setLoading(false);
       });
     return () => { cancelled = true; };
   }, []);
 
+  useEffect(() => {
+    return loadDefaults();
+  }, [loadDefaults]);
+
   const handleSave = async () => {
+    if (saving || loadError) return;
     setSaving(true);
     const payload = {
       reviewers,
@@ -92,6 +107,25 @@ export default function CodeReviewDefaultsPanel() {
         Default Review Loop reviewer chain — used by ad-hoc CoS tasks and task-type schedules that haven't pinned their own. Local-LLM reviewers route the diff through PortOS's local code-review endpoint; the {CLI_REVIEWER_LIST} reviewers invoke their CLI directly. Each runs the model pinned on its row (Claude also supports an Ollama-backed CLI for local-only setups — type one of your installed Ollama models).
       </p>
 
+      {loadError && (
+        <Banner
+          tone="error"
+          size="sm"
+          align="center"
+          actions={
+            <button
+              type="button"
+              onClick={loadDefaults}
+              className="px-2.5 py-1 text-xs font-medium bg-port-error/20 hover:bg-port-error/30 text-port-error rounded transition-colors"
+            >
+              Retry
+            </button>
+          }
+        >
+          Failed to load code review defaults.
+        </Banner>
+      )}
+
       {loading ? (
         <div className="text-xs text-gray-500">Loading defaults…</div>
       ) : (
@@ -107,7 +141,7 @@ export default function CodeReviewDefaultsPanel() {
             installed={installed}
             stopMode={stopMode}
             reviewerApplies={reviewerApplies}
-            disabled={saving}
+            disabled={saving || loadError}
             onChange={({ reviewers: r, usernames: u, optionalReviewers: o, reviewerMaxRounds: m, reviewerModels: dm, reviewerEfforts: de, stopMode: s, reviewerApplies: a }) => {
               setReviewers(r);
               setUsernames(u);
@@ -124,7 +158,7 @@ export default function CodeReviewDefaultsPanel() {
             <button
               type="button"
               onClick={handleSave}
-              disabled={saving}
+              disabled={saving || loadError}
               className="px-3 py-1.5 text-sm bg-port-accent hover:bg-port-accent/80 disabled:opacity-50 text-white rounded transition-colors"
             >
               {saving ? 'Saving…' : 'Save defaults'}
@@ -135,3 +169,4 @@ export default function CodeReviewDefaultsPanel() {
     </div>
   );
 }
+

--- a/client/src/components/providers/CodeReviewDefaultsPanel.test.jsx
+++ b/client/src/components/providers/CodeReviewDefaultsPanel.test.jsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import CodeReviewDefaultsPanel from './CodeReviewDefaultsPanel';
+import * as api from '../../services/api';
+
+vi.mock('../../services/api', () => ({
+  getCodeReviewDefaults: vi.fn(),
+  updateSettings: vi.fn(),
+}));
+
+vi.mock('../../hooks/useReviewerModelOptions', () => ({
+  default: () => ({ ctxById: {} }),
+}));
+
+vi.mock('../ui/Toast', () => ({
+  default: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('CodeReviewDefaultsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders loading state initially and populates panel when fetch succeeds', async () => {
+    api.getCodeReviewDefaults.mockResolvedValue({
+      reviewers: ['codex'],
+      usernames: [],
+      optionalReviewers: [],
+      reviewerMaxRounds: {},
+      stopMode: 'consensus',
+      reviewerApplies: false,
+    });
+
+    render(<CodeReviewDefaultsPanel />);
+
+    expect(screen.getByText('Loading defaults…')).toBeInTheDocument();
+
+    expect(await screen.findByText('Save defaults')).toBeInTheDocument();
+    expect(screen.queryByText('Failed to load code review defaults.')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save defaults' })).not.toBeDisabled();
+    expect(api.getCodeReviewDefaults).toHaveBeenCalledWith({ silent: true });
+  });
+
+  it('renders error banner with Retry button and disables Save button when fetch rejects', async () => {
+    api.getCodeReviewDefaults.mockRejectedValue(new Error('Network error'));
+
+    render(<CodeReviewDefaultsPanel />);
+
+    expect(await screen.findByText('Failed to load code review defaults.')).toBeInTheDocument();
+    const retryBtn = screen.getByRole('button', { name: 'Retry' });
+    expect(retryBtn).toBeInTheDocument();
+
+    const saveBtn = screen.getByRole('button', { name: 'Save defaults' });
+    expect(saveBtn).toBeDisabled();
+  });
+
+  it('re-fetches defaults when Retry button is clicked and enables Save button on success', async () => {
+    api.getCodeReviewDefaults
+      .mockRejectedValueOnce(new Error('Network error'))
+      .mockResolvedValueOnce({
+        reviewers: ['codex'],
+        usernames: [],
+        optionalReviewers: [],
+        reviewerMaxRounds: {},
+        stopMode: 'consensus',
+        reviewerApplies: false,
+      });
+
+    render(<CodeReviewDefaultsPanel />);
+
+    expect(await screen.findByText('Failed to load code review defaults.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save defaults' })).toBeDisabled();
+
+    const retryBtn = screen.getByRole('button', { name: 'Retry' });
+    fireEvent.click(retryBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Failed to load code review defaults.')).not.toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: 'Save defaults' })).not.toBeDisabled();
+    expect(api.getCodeReviewDefaults).toHaveBeenCalledTimes(2);
+  });
+
+  it('handles save when Save defaults button is clicked', async () => {
+    api.getCodeReviewDefaults.mockResolvedValue({
+      reviewers: ['codex'],
+      usernames: [],
+      optionalReviewers: [],
+      reviewerMaxRounds: {},
+      stopMode: 'consensus',
+      reviewerApplies: false,
+    });
+    api.updateSettings.mockResolvedValue({ success: true });
+
+    render(<CodeReviewDefaultsPanel />);
+
+    const saveBtn = await screen.findByRole('button', { name: 'Save defaults' });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(api.updateSettings).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Prevents overwriting user settings when defaults fetch fails by adding loadError state and retry UI.

Closes #4030