### PR TITLE
fix(ConfigTab): stage avatar style dropdown selection until Save button click (#4035)

### DIFF
--- a/client/src/components/cos/tabs/ConfigTab.jsx
+++ b/client/src/components/cos/tabs/ConfigTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { Settings, Activity, CheckCircle, FileText } from 'lucide-react';
+import { Settings, Activity, CheckCircle, FileText, X } from 'lucide-react';
 import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
 import ConfigRow from './ConfigRow';
@@ -276,8 +276,43 @@ export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle, s
     improvementEnabled: config?.improvementEnabled ?? config?.selfImprovementEnabled ?? true,
     proactiveMode: config?.proactiveMode ?? true,
     idleReviewEnabled: config?.idleReviewEnabled ?? true,
-    immediateExecution: config?.immediateExecution ?? true
+    immediateExecution: config?.immediateExecution ?? true,
+    avatarStyle: config?.avatarStyle || avatarStyle || 'svg'
   });
+
+  useEffect(() => {
+    if (!editing) {
+      setFormData(prev => ({
+        ...prev,
+        healthCheckIntervalMs: config?.healthCheckIntervalMs || 900000,
+        maxConcurrentAgents: config?.maxConcurrentAgents || 3,
+        maxConcurrentAgentsPerProject: config?.maxConcurrentAgentsPerProject || 2,
+        maxProcessMemoryMb: config?.maxProcessMemoryMb || 2048,
+        autoStart: config?.autoStart || false,
+        improvementEnabled: config?.improvementEnabled ?? config?.selfImprovementEnabled ?? true,
+        proactiveMode: config?.proactiveMode ?? true,
+        idleReviewEnabled: config?.idleReviewEnabled ?? true,
+        immediateExecution: config?.immediateExecution ?? true,
+        avatarStyle: config?.avatarStyle || avatarStyle || 'svg'
+      }));
+    }
+  }, [config, avatarStyle, editing]);
+
+  const handleCancel = () => {
+    setFormData({
+      healthCheckIntervalMs: config?.healthCheckIntervalMs || 900000,
+      maxConcurrentAgents: config?.maxConcurrentAgents || 3,
+      maxConcurrentAgentsPerProject: config?.maxConcurrentAgentsPerProject || 2,
+      maxProcessMemoryMb: config?.maxProcessMemoryMb || 2048,
+      autoStart: config?.autoStart || false,
+      improvementEnabled: config?.improvementEnabled ?? config?.selfImprovementEnabled ?? true,
+      proactiveMode: config?.proactiveMode ?? true,
+      idleReviewEnabled: config?.idleReviewEnabled ?? true,
+      immediateExecution: config?.immediateExecution ?? true,
+      avatarStyle: config?.avatarStyle || avatarStyle || 'svg'
+    });
+    setEditing(false);
+  };
 
   const handleLevelChange = async (params, label) => {
     // Optimistically reflect the new params via a functional update. Success toast
@@ -374,13 +409,22 @@ export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle, s
               Edit
             </button>
           ) : (
-            <button
-              onClick={handleSave}
-              className="flex items-center gap-2 px-3 py-1.5 text-sm bg-port-success/20 hover:bg-port-success/30 text-port-success rounded-lg transition-colors"
-            >
-              <CheckCircle size={14} />
-              Save
-            </button>
+            <>
+              <button
+                onClick={handleCancel}
+                className="flex items-center gap-2 px-3 py-1.5 text-sm bg-port-border hover:bg-port-border/80 text-gray-300 rounded-lg transition-colors"
+              >
+                <X size={14} />
+                Cancel
+              </button>
+              <button
+                onClick={handleSave}
+                className="flex items-center gap-2 px-3 py-1.5 text-sm bg-port-success/20 hover:bg-port-success/30 text-port-success rounded-lg transition-colors"
+              >
+                <CheckCircle size={14} />
+                Save
+              </button>
+            </>
           )}
         </div>
       </div>
@@ -489,13 +533,14 @@ export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle, s
           >
             <span className="text-gray-400 cursor-help">Default Avatar Style</span>
             <select
-              value={avatarStyle}
-              onChange={async (e) => {
+              aria-label="Default Avatar Style"
+              value={formData.avatarStyle}
+              disabled={!editing}
+              onChange={(e) => {
                 const style = e.target.value;
-                await setAvatarStyle(style);
-                toast.success(`Avatar style changed to ${AVATAR_STYLE_LABELS[style] || style}`);
+                setFormData(prev => ({ ...prev, avatarStyle: style }));
               }}
-              className="bg-port-bg border border-port-border rounded px-3 py-1.5 text-white text-sm"
+              className="bg-port-bg border border-port-border rounded px-3 py-1.5 text-white text-sm disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {Object.entries(AVATAR_STYLE_LABELS).map(([value, label]) => (
                 <option key={value} value={value}>{label}</option>

--- a/client/src/components/cos/tabs/ConfigTab.jsx
+++ b/client/src/components/cos/tabs/ConfigTab.jsx
@@ -249,7 +249,20 @@ function DomainBudgetControl({ config, usage, onBudgetChange }) {
   );
 }
 
-export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle, setAvatarStyle }) {
+const getDefaultFormData = (config, avatarStyle) => ({
+  healthCheckIntervalMs: config?.healthCheckIntervalMs || 900000,
+  maxConcurrentAgents: config?.maxConcurrentAgents || 3,
+  maxConcurrentAgentsPerProject: config?.maxConcurrentAgentsPerProject || 2,
+  maxProcessMemoryMb: config?.maxProcessMemoryMb || 2048,
+  autoStart: config?.autoStart || false,
+  improvementEnabled: config?.improvementEnabled ?? config?.selfImprovementEnabled ?? true,
+  proactiveMode: config?.proactiveMode ?? true,
+  idleReviewEnabled: config?.idleReviewEnabled ?? true,
+  immediateExecution: config?.immediateExecution ?? true,
+  avatarStyle: config?.avatarStyle || avatarStyle || 'svg'
+});
+
+export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle }) {
   const { providers, availableModels, setSelectedProviderId: setProviderHook, setSelectedModel: setModelHook, selectedProviderId: hookProviderId, selectedModel: hookModel } = useProviderModels();
   const [embeddingProviderId, setEmbeddingProviderId] = useState(config?.embeddingProviderId || 'lmstudio');
   const [embeddingModel, setEmbeddingModel] = useState(config?.embeddingModel || '');
@@ -267,50 +280,19 @@ export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle, s
   }, [config?.embeddingProviderId, config?.embeddingModel, setProviderHook, setModelHook]);
 
   const [editing, setEditing] = useState(false);
-  const [formData, setFormData] = useState({
-    healthCheckIntervalMs: config?.healthCheckIntervalMs || 900000,
-    maxConcurrentAgents: config?.maxConcurrentAgents || 3,
-    maxConcurrentAgentsPerProject: config?.maxConcurrentAgentsPerProject || 2,
-    maxProcessMemoryMb: config?.maxProcessMemoryMb || 2048,
-    autoStart: config?.autoStart || false,
-    improvementEnabled: config?.improvementEnabled ?? config?.selfImprovementEnabled ?? true,
-    proactiveMode: config?.proactiveMode ?? true,
-    idleReviewEnabled: config?.idleReviewEnabled ?? true,
-    immediateExecution: config?.immediateExecution ?? true,
-    avatarStyle: config?.avatarStyle || avatarStyle || 'svg'
-  });
+  const [formData, setFormData] = useState(() => getDefaultFormData(config, avatarStyle));
 
   useEffect(() => {
     if (!editing) {
       setFormData(prev => ({
         ...prev,
-        healthCheckIntervalMs: config?.healthCheckIntervalMs || 900000,
-        maxConcurrentAgents: config?.maxConcurrentAgents || 3,
-        maxConcurrentAgentsPerProject: config?.maxConcurrentAgentsPerProject || 2,
-        maxProcessMemoryMb: config?.maxProcessMemoryMb || 2048,
-        autoStart: config?.autoStart || false,
-        improvementEnabled: config?.improvementEnabled ?? config?.selfImprovementEnabled ?? true,
-        proactiveMode: config?.proactiveMode ?? true,
-        idleReviewEnabled: config?.idleReviewEnabled ?? true,
-        immediateExecution: config?.immediateExecution ?? true,
-        avatarStyle: config?.avatarStyle || avatarStyle || 'svg'
+        ...getDefaultFormData(config, avatarStyle)
       }));
     }
   }, [config, avatarStyle, editing]);
 
   const handleCancel = () => {
-    setFormData({
-      healthCheckIntervalMs: config?.healthCheckIntervalMs || 900000,
-      maxConcurrentAgents: config?.maxConcurrentAgents || 3,
-      maxConcurrentAgentsPerProject: config?.maxConcurrentAgentsPerProject || 2,
-      maxProcessMemoryMb: config?.maxProcessMemoryMb || 2048,
-      autoStart: config?.autoStart || false,
-      improvementEnabled: config?.improvementEnabled ?? config?.selfImprovementEnabled ?? true,
-      proactiveMode: config?.proactiveMode ?? true,
-      idleReviewEnabled: config?.idleReviewEnabled ?? true,
-      immediateExecution: config?.immediateExecution ?? true,
-      avatarStyle: config?.avatarStyle || avatarStyle || 'svg'
-    });
+    setFormData(getDefaultFormData(config, avatarStyle));
     setEditing(false);
   };
 

--- a/client/src/components/cos/tabs/ConfigTab.test.jsx
+++ b/client/src/components/cos/tabs/ConfigTab.test.jsx
@@ -77,6 +77,70 @@ describe('ConfigTab handleSave', () => {
   });
 });
 
+describe('Default Avatar Style dropdown', () => {
+  it('disables default avatar style dropdown when not editing', async () => {
+    render(<ConfigTab config={{ ...config, avatarStyle: 'svg' }} onUpdate={vi.fn()} onEvaluate={vi.fn()} avatarStyle="svg" setAvatarStyle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Default Avatar Style' })).toBeDisabled());
+
+    const select = screen.getByRole('combobox', { name: 'Default Avatar Style' });
+    expect(select).toHaveValue('svg');
+  });
+
+  it('stages dropdown selection locally without triggering immediate save call', async () => {
+    render(<ConfigTab config={{ ...config, avatarStyle: 'svg' }} onUpdate={vi.fn()} onEvaluate={vi.fn()} avatarStyle="svg" setAvatarStyle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Default Avatar Style' })).toBeDisabled());
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit/i }));
+
+    const select = screen.getByRole('combobox', { name: 'Default Avatar Style' });
+    expect(select).toBeEnabled();
+
+    fireEvent.change(select, { target: { value: 'cyber' } });
+
+    expect(select).toHaveValue('cyber');
+    expect(api.updateCosConfig).not.toHaveBeenCalled();
+  });
+
+  it('includes staged avatarStyle in updateCosConfig payload on Save click', async () => {
+    api.updateCosConfig.mockResolvedValue({ success: true });
+    const onUpdate = vi.fn();
+    render(<ConfigTab config={{ ...config, avatarStyle: 'svg' }} onUpdate={onUpdate} onEvaluate={vi.fn()} avatarStyle="svg" setAvatarStyle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Default Avatar Style' })).toBeDisabled());
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit/i }));
+
+    const select = screen.getByRole('combobox', { name: 'Default Avatar Style' });
+    fireEvent.change(select, { target: { value: 'cyber' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Save/i }));
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith('Configuration updated'));
+    expect(api.updateCosConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ avatarStyle: 'cyber' }),
+      { silent: true }
+    );
+    expect(screen.getByRole('button', { name: /Edit/i })).toBeInTheDocument();
+  });
+
+  it('reverts staged avatarStyle dropdown selection when Cancel is clicked', async () => {
+    render(<ConfigTab config={{ ...config, avatarStyle: 'svg' }} onUpdate={vi.fn()} onEvaluate={vi.fn()} avatarStyle="svg" setAvatarStyle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Default Avatar Style' })).toBeDisabled());
+
+    fireEvent.click(screen.getByRole('button', { name: /Edit/i }));
+
+    const select = screen.getByRole('combobox', { name: 'Default Avatar Style' });
+    fireEvent.change(select, { target: { value: 'cyber' } });
+    expect(select).toHaveValue('cyber');
+
+    fireEvent.click(screen.getByRole('button', { name: /Cancel/i }));
+
+    expect(screen.getByRole('button', { name: /Edit/i })).toBeInTheDocument();
+    const selectAfterCancel = screen.getByRole('combobox', { name: 'Default Avatar Style' });
+    expect(selectAfterCancel).toBeDisabled();
+    expect(selectAfterCancel).toHaveValue('svg');
+  });
+});
+
 describe('ConfigTab handleLevelChange', () => {
   // Reads the non-editing value span rendered next to a ConfigRow label.
   const rowValue = (label) => within(screen.getByText(label).closest('div')).getByText;


### PR DESCRIPTION
### Summary of Changes

- Gated the Default Avatar Style dropdown selection inside `ConfigTab` local form state when editing.
- Disabled the Default Avatar Style dropdown when not in edit mode (`disabled={!editing}`).
- Updated the dropdown `onChange` to stage the selected avatar style locally in `formData` instead of immediately calling backend API (`setAvatarStyle` / `updateCosConfig`).
- Added `avatarStyle` to `formData` and included it in the payload sent to `api.updateCosConfig` when the user clicks "Save".
- Added a "Cancel" button in edit mode and implemented `handleCancel` to revert local staged state (including `avatarStyle`) to saved config values.
- Added comprehensive unit tests in `ConfigTab.test.jsx` covering staging, saving, and canceling avatar style dropdown selections.

Closes #4035
