### PR TITLE
fix(AIProviders): reset addingSample state on handleAddSample failure (#4031)

### DIFF
--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -226,10 +226,12 @@ export default function AIProviders() {
     try {
       await api.createProvider(provider);
       setSampleProviders(prev => prev.filter(p => p.id !== provider.id));
-      loadData();
+      await loadData();
       toast.success(`Added ${provider.name}`);
     } catch (err) {
-      const message = err?.message || err?.error || (typeof err === 'string' ? err : 'An unknown error occurred');
+      const message = (typeof err?.message === 'string' && err.message) ||
+                      (typeof err?.error === 'string' && err.error) ||
+                      (typeof err === 'string' ? err : 'An unknown error occurred');
       toast.error(`Failed to add provider: ${message}`);
     } finally {
       setAddingSample(prev => ({ ...prev, [provider.id]: false }));

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -229,7 +229,8 @@ export default function AIProviders() {
       loadData();
       toast.success(`Added ${provider.name}`);
     } catch (err) {
-      toast.error(`Failed to add provider: ${err?.message || err}`);
+      const message = err?.message || err?.error || (typeof err === 'string' ? err : 'An unknown error occurred');
+      toast.error(`Failed to add provider: ${message}`);
     } finally {
       setAddingSample(prev => ({ ...prev, [provider.id]: false }));
     }

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -223,11 +223,16 @@ export default function AIProviders() {
 
   const handleAddSample = async (provider) => {
     setAddingSample(prev => ({ ...prev, [provider.id]: true }));
-    await api.createProvider(provider);
-    setSampleProviders(prev => prev.filter(p => p.id !== provider.id));
-    setAddingSample(prev => ({ ...prev, [provider.id]: false }));
-    loadData();
-    toast.success(`Added ${provider.name}`);
+    try {
+      await api.createProvider(provider);
+      setSampleProviders(prev => prev.filter(p => p.id !== provider.id));
+      loadData();
+      toast.success(`Added ${provider.name}`);
+    } catch (err) {
+      toast.error(`Failed to add provider: ${err?.message || err}`);
+    } finally {
+      setAddingSample(prev => ({ ...prev, [provider.id]: false }));
+    }
   };
 
   const handleAddAllSamples = async () => {

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -11,7 +11,17 @@ const api = vi.hoisted(() => ({
   createProvider: vi.fn(),
 }));
 
+const toast = vi.hoisted(() => ({
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+}));
+
 vi.mock('../services/api', () => api);
+vi.mock('../components/ui/Toast', () => ({
+  default: toast,
+}));
 vi.mock('../services/socket', () => ({
   default: {
     on: vi.fn(),
@@ -135,5 +145,6 @@ describe('handleAddSample error handling', () => {
 
     const reEnabledAddBtn = await screen.findByRole('button', { name: 'Add' });
     expect(reEnabledAddBtn).not.toBeDisabled();
+    expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Failed to add provider: Failed to create provider'));
   });
 });

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -7,6 +7,8 @@ const api = vi.hoisted(() => ({
   getApps: vi.fn(),
   getRuns: vi.fn(),
   getProviderStatuses: vi.fn(),
+  getSampleProviders: vi.fn(),
+  createProvider: vi.fn(),
 }));
 
 vi.mock('../services/api', () => api);
@@ -98,5 +100,40 @@ describe('AIProviders page load error handling', () => {
     expect(screen.queryByText('Failed to load AI providers')).not.toBeInTheDocument();
     expect(screen.queryByText('No providers configured')).not.toBeInTheDocument();
     expect(api.getProviders).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('handleAddSample error handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getApps.mockResolvedValue([]);
+    api.getRuns.mockResolvedValue({ runs: [] });
+    api.getProviderStatuses.mockResolvedValue({ providers: {} });
+    api.getProviders.mockResolvedValue({
+      providers: [],
+      activeProvider: null,
+    });
+    api.getSampleProviders.mockResolvedValue({
+      providers: [
+        { id: 'sample-1', name: 'Sample AI', type: 'api', enabled: true, endpoint: 'https://api.sample.com', models: ['model-1'] }
+      ]
+    });
+  });
+
+  it('resets addingSample state and re-enables button if api.createProvider rejects', async () => {
+    api.createProvider.mockRejectedValue(new Error('Failed to create provider'));
+
+    renderPage();
+
+    const loadSamplesBtn = await screen.findByRole('button', { name: 'Load Samples' });
+    fireEvent.click(loadSamplesBtn);
+
+    const addBtn = await screen.findByRole('button', { name: 'Add' });
+    fireEvent.click(addBtn);
+
+    expect(api.createProvider).toHaveBeenCalledWith(expect.objectContaining({ id: 'sample-1' }));
+
+    const reEnabledAddBtn = await screen.findByRole('button', { name: 'Add' });
+    expect(reEnabledAddBtn).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
## Summary
Wraps `api.createProvider(provider)` and associated operations in `handleAddSample` within a `try ... catch ... finally` block. This ensures `addingSample[provider.id]` is reset to `false` in the `finally` block regardless of whether `createProvider` succeeds or rejects with an error.

Closes #4031

## Verification
- Added unit test in `client/src/pages/AIProviders.test.jsx` verifying that `addingSample` state resets and the button re-enables when `createProvider` throws.
- Verified all client tests pass cleanly via `vitest`.
