### PR TITLE
fix(JobsTab): disable Run Now action when editing job (#4036)

### DIFF
--- a/.changelog/next/fixed-issue-4036.md
+++ b/.changelog/next/fixed-issue-4036.md
@@ -1,0 +1,1 @@
+- Disable Run Now action on job cards while editing

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -425,11 +425,11 @@ function JobCard({ job, apps, providers, onToggle, onTrigger, onDelete, onUpdate
           <button
             onClick={() => onTrigger(job.id)}
             disabled={editing}
-            className={`p-1.5 transition-colors ${
-              editing ? 'text-gray-600 opacity-50 cursor-not-allowed' : 'text-gray-500 hover:text-port-accent'
+            className={`p-1.5 transition-colors text-gray-500 ${
+              editing ? 'opacity-50 cursor-not-allowed' : 'hover:text-port-accent'
             }`}
             title={editing ? 'Save changes before running job' : 'Run now'}
-            aria-label="Run now"
+            aria-label={editing ? 'Save changes before running job' : 'Run now'}
           >
             <Play size={14} />
           </button>

--- a/client/src/components/cos/tabs/JobsTab.jsx
+++ b/client/src/components/cos/tabs/JobsTab.jsx
@@ -424,8 +424,12 @@ function JobCard({ job, apps, providers, onToggle, onTrigger, onDelete, onUpdate
         <div className="flex items-center gap-1">
           <button
             onClick={() => onTrigger(job.id)}
-            className="p-1.5 text-gray-500 hover:text-port-accent transition-colors"
-            title="Run now" aria-label="Run now"
+            disabled={editing}
+            className={`p-1.5 transition-colors ${
+              editing ? 'text-gray-600 opacity-50 cursor-not-allowed' : 'text-gray-500 hover:text-port-accent'
+            }`}
+            title={editing ? 'Save changes before running job' : 'Run now'}
+            aria-label="Run now"
           >
             <Play size={14} />
           </button>

--- a/client/src/components/cos/tabs/JobsTab.test.jsx
+++ b/client/src/components/cos/tabs/JobsTab.test.jsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const api = vi.hoisted(() => ({
+  getCosJobs: vi.fn(),
+  triggerCosJob: vi.fn(),
+  updateCosJob: vi.fn(),
+  toggleCosJob: vi.fn(),
+  deleteCosJob: vi.fn(),
+  getJobHistory: vi.fn(),
+  getApps: vi.fn(),
+  getProviders: vi.fn(),
+}));
+
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+
+vi.mock('../../../services/api', () => api);
+vi.mock('../../ui/Toast', () => ({ default: toast }));
+
+const JobsTab = (await import('./JobsTab')).default;
+
+const mockJob = {
+  id: 'job-1',
+  name: 'Test Job',
+  description: 'Test job description',
+  type: 'agent',
+  interval: 'daily',
+  intervalMs: 86400000,
+  priority: 'MEDIUM',
+  autonomyLevel: 'medium',
+  enabled: true,
+  promptTemplate: 'Do test things',
+  category: 'General',
+  lastRun: null,
+  runCount: 0
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getCosJobs.mockResolvedValue({ jobs: [mockJob] });
+  api.getJobHistory.mockResolvedValue({ runs: [] });
+  api.triggerCosJob.mockResolvedValue({ success: true });
+  api.updateCosJob.mockResolvedValue({ job: mockJob });
+  api.getApps.mockResolvedValue([]);
+  api.getProviders.mockResolvedValue({ providers: [] });
+});
+
+describe('JobsTab / JobCard Run Now disable behavior (#4036)', () => {
+  it('enables the Run now button when not editing and disables it while editing', async () => {
+    render(<JobsTab apps={[]} providers={[]} />);
+
+    // Wait for jobs to load
+    await waitFor(() => expect(screen.getByText('Test Job')).toBeInTheDocument());
+
+    const runNowButton = screen.getByRole('button', { name: 'Run now' });
+    expect(runNowButton).not.toBeDisabled();
+    expect(runNowButton).toHaveAttribute('title', 'Run now');
+
+    // Click edit button
+    const editButton = screen.getByRole('button', { name: 'Edit' });
+    fireEvent.click(editButton);
+
+    // Now Run now button should be disabled
+    expect(runNowButton).toBeDisabled();
+    expect(runNowButton).toHaveAttribute('title', 'Save changes before running job');
+
+    // Attempting to click Run now while editing should not trigger job
+    fireEvent.click(runNowButton);
+    expect(api.triggerCosJob).not.toHaveBeenCalled();
+
+    // Saving edits should re-enable the button
+    const saveButton = screen.getByRole('button', { name: 'Save' });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(runNowButton).not.toBeDisabled());
+    expect(runNowButton).toHaveAttribute('title', 'Run now');
+  });
+});

--- a/client/src/components/cos/tabs/JobsTab.test.jsx
+++ b/client/src/components/cos/tabs/JobsTab.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import JobsTab from './JobsTab';
 
 const api = vi.hoisted(() => ({
   getCosJobs: vi.fn(),
@@ -16,8 +17,6 @@ const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
 
 vi.mock('../../../services/api', () => api);
 vi.mock('../../ui/Toast', () => ({ default: toast }));
-
-const JobsTab = (await import('./JobsTab')).default;
 
 const mockJob = {
   id: 'job-1',
@@ -46,7 +45,7 @@ beforeEach(() => {
 });
 
 describe('JobsTab / JobCard Run Now disable behavior (#4036)', () => {
-  it('enables the Run now button when not editing and disables it while editing', async () => {
+  it('enables the Run now button when not editing and disables it while editing (save flow)', async () => {
     render(<JobsTab apps={[]} providers={[]} />);
 
     // Wait for jobs to load
@@ -60,19 +59,37 @@ describe('JobsTab / JobCard Run Now disable behavior (#4036)', () => {
     const editButton = screen.getByRole('button', { name: 'Edit' });
     fireEvent.click(editButton);
 
-    // Now Run now button should be disabled
-    expect(runNowButton).toBeDisabled();
-    expect(runNowButton).toHaveAttribute('title', 'Save changes before running job');
+    // Now Run now button should be disabled with updated title & aria-label
+    const disabledRunNowButton = screen.getByRole('button', { name: 'Save changes before running job' });
+    expect(disabledRunNowButton).toBeDisabled();
+    expect(disabledRunNowButton).toHaveAttribute('title', 'Save changes before running job');
 
     // Attempting to click Run now while editing should not trigger job
-    fireEvent.click(runNowButton);
+    fireEvent.click(disabledRunNowButton);
     expect(api.triggerCosJob).not.toHaveBeenCalled();
 
     // Saving edits should re-enable the button
     const saveButton = screen.getByRole('button', { name: 'Save' });
     fireEvent.click(saveButton);
 
-    await waitFor(() => expect(runNowButton).not.toBeDisabled());
-    expect(runNowButton).toHaveAttribute('title', 'Run now');
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Run now' })).not.toBeDisabled());
+  });
+
+  it('re-enables the Run now button when exiting edit mode via Cancel', async () => {
+    render(<JobsTab apps={[]} providers={[]} />);
+
+    await waitFor(() => expect(screen.getByText('Test Job')).toBeInTheDocument());
+
+    const editButton = screen.getByRole('button', { name: 'Edit' });
+    fireEvent.click(editButton);
+
+    expect(screen.getByRole('button', { name: 'Save changes before running job' })).toBeDisabled();
+
+    // Click Cancel button
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    fireEvent.click(cancelButton);
+
+    const reEnabledRunNow = screen.getByRole('button', { name: 'Run now' });
+    expect(reEnabledRunNow).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
Closes #4036

### Summary of Changes
- In `client/src/components/cos/tabs/JobsTab.jsx`, updated the `JobCard` component's "Run now" (Play icon) action button to be disabled (`disabled={editing}`) while `editing` is true.
- Styled the disabled state with lowered opacity, `cursor-not-allowed`, and a helpful tooltip title ("Save changes before running job") so users are informed that pending edits must be saved first.
- Added a unit test suite in `client/src/components/cos/tabs/JobsTab.test.jsx` verifying that the button is disabled during edit mode and re-enabled upon saving.
- Added changelog entry via `npm run changelog:add`.

### Test Plan
- Ran unit tests via Vitest: `JobsTab.test.jsx` passes clean.
- Verified all client unit tests pass (614 test files, 7335 tests passed).
