### PR TITLE
fix(utils): remove unreferenced importWithRetry re-export (#4027)

### DIFF
--- a/.changelog/next/fixed-issue-4027.md
+++ b/.changelog/next/fixed-issue-4027.md
@@ -1,0 +1,1 @@
+- Removed unused importWithRetry re-export from utils barrel

--- a/client/src/utils/index.js
+++ b/client/src/utils/index.js
@@ -29,7 +29,7 @@ export * from './providers.js';
 export * from './layeredIntelligenceReasons.js';
 
 // === Module loading / resilience ===
-export * from './lazyWithReload.js';
+export { lazyWithReload } from './lazyWithReload.js';
 export * from './staleChunkReload.js';
 
 // === File handling ===


### PR DESCRIPTION
### Summary of Changes
- Removed unreferenced `importWithRetry` re-export from `client/src/utils/index.js` barrel export, leaving `lazyWithReload` as the sole public export for stale chunk reloading.
- Retained `importWithRetry` export in `client/src/utils/lazyWithReload.js` for unit testing.
- Added changelog entry for the change.

### Test Plan
- Ran `cd client && npm test` - all 613 test files and 7334 tests passed.

Closes #4027
