### PR TITLE
fix(AIProviders): handle partial failure in handleAddAllSamples (#4032)

### DIFF
--- a/.changelog/next/fixed-issue-4032.md
+++ b/.changelog/next/fixed-issue-4032.md
@@ -1,0 +1,1 @@
+- Handle partial failure during sample AI provider batch addition

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -239,12 +239,28 @@ export default function AIProviders() {
   };
 
   const handleAddAllSamples = async () => {
+    const succeededIds = [];
+    const failedIds = [];
+
     for (const provider of sampleProviders) {
-      await api.createProvider(provider);
+      try {
+        await api.createProvider(provider);
+        succeededIds.push(provider.id);
+      } catch (err) {
+        failedIds.push(provider.id);
+      }
     }
-    setSampleProviders([]);
-    loadData();
-    toast.success(`Added ${sampleProviders.length} providers`);
+
+    setSampleProviders(prev => prev.filter(p => !succeededIds.includes(p.id)));
+    await loadData();
+
+    if (failedIds.length === 0) {
+      toast.success(`Added ${succeededIds.length} provider${succeededIds.length === 1 ? '' : 's'}`);
+    } else if (succeededIds.length === 0) {
+      toast.error(`Failed to add ${failedIds.length} provider${failedIds.length === 1 ? '' : 's'}`);
+    } else {
+      toast.warning(`Added ${succeededIds.length} provider${succeededIds.length === 1 ? '' : 's'}, ${failedIds.length} failed`);
+    }
   };
 
   const selectedRunProvider = providers.find(p => p.id === activeProviderId);

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -239,6 +239,8 @@ export default function AIProviders() {
   };
 
   const handleAddAllSamples = async () => {
+    if (sampleProviders.length === 0) return;
+
     const succeededIds = [];
     const failedIds = [];
 
@@ -247,6 +249,7 @@ export default function AIProviders() {
         await api.createProvider(provider);
         succeededIds.push(provider.id);
       } catch (err) {
+        console.error(`Failed to add sample provider ${provider.name || provider.id}:`, err);
         failedIds.push(provider.id);
       }
     }

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -148,3 +148,45 @@ describe('handleAddSample error handling', () => {
     expect(toast.error).toHaveBeenCalledWith(expect.stringContaining('Failed to add provider: Failed to create provider'));
   });
 });
+
+describe('handleAddAllSamples partial failure handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getApps.mockResolvedValue([]);
+    api.getRuns.mockResolvedValue({ runs: [] });
+    api.getProviderStatuses.mockResolvedValue({ providers: {} });
+    api.getProviders.mockResolvedValue({
+      providers: [],
+      activeProvider: null,
+    });
+    api.getSampleProviders.mockResolvedValue({
+      providers: [
+        { id: 'sample-1', name: 'Sample AI 1', type: 'api', enabled: true, endpoint: 'https://api.sample1.com', models: ['model-1'] },
+        { id: 'sample-2', name: 'Sample AI 2', type: 'api', enabled: true, endpoint: 'https://api.sample2.com', models: ['model-2'] },
+        { id: 'sample-3', name: 'Sample AI 3', type: 'api', enabled: true, endpoint: 'https://api.sample3.com', models: ['model-3'] },
+      ]
+    });
+  });
+
+  it('handles partial failure when adding all samples', async () => {
+    api.createProvider
+      .mockResolvedValueOnce({ id: 'sample-1' })
+      .mockRejectedValueOnce(new Error('Creation failed'))
+      .mockResolvedValueOnce({ id: 'sample-3' });
+
+    renderPage();
+
+    const loadSamplesBtn = await screen.findByRole('button', { name: 'Load Samples' });
+    fireEvent.click(loadSamplesBtn);
+
+    const addAllBtn = await screen.findByRole('button', { name: 'Add All (3)' });
+    fireEvent.click(addAllBtn);
+
+    expect(await screen.findByText('Sample AI 2')).toBeInTheDocument();
+    expect(screen.queryByText('Sample AI 1')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sample AI 3')).not.toBeInTheDocument();
+    expect(toast.warning).toHaveBeenCalledWith('Added 2 providers, 1 failed');
+    expect(api.getProviders).toHaveBeenCalledTimes(2);
+  });
+});
+


### PR DESCRIPTION
Closes #4032

### Summary of Changes
- Updated `handleAddAllSamples` in `client/src/pages/AIProviders.jsx` to wrap each provider creation (`api.createProvider`) in a `try...catch` block.
- Maintained lists of `succeededIds` and `failedIds` during the batch operation.
- Updated `sampleProviders` state to filter out only successfully created providers, preserving failed items in the panel for retry.
- Invoked `loadData()` after processing to ensure the main AI provider list is refreshed.
- Displayed a summary toast message specifying created and failed counts (`Added X provider(s), Y failed`).
- Added unit test cases in `AIProviders.test.jsx` covering batch additions with partial failures.

### Test Plan
- Run `npm test -- AIProviders.test.jsx` in `client` directory to verify unit test coverage for partial failure handling.
- Run `npm test` across all client test suites to ensure no regressions.
