### PR TITLE
Only ask for CoS agent feedback on manually-run tasks

### DIFF
--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -149,6 +149,9 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
 
   // Determine if this is a system agent (health check, etc.)
   const isSystemAgent = agent.taskId?.startsWith('sys-') || agent.id?.startsWith('sys-');
+  // Only agents from a manually-filled task form ask for a rating —
+  // scheduled/autopilot runs are already auto-evaluated by task-learning.
+  const isManualUserAgent = agent.metadata?.taskType === 'user';
   const inactive = completed || paused;
 
   // Handle feedback submission
@@ -846,8 +849,8 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
           </div>
         )}
 
-        {/* Feedback section - shown for completed non-system local agents */}
-        {completed && !isSystemAgent && !remote && (
+        {/* Feedback section - shown for completed, manually-run, non-system local agents */}
+        {completed && !isSystemAgent && isManualUserAgent && !remote && (
           <div className="mt-3 pt-3 border-t border-port-border/50">
             <div className="flex items-center gap-3 flex-wrap">
               <span className="text-xs text-gray-500">Was this helpful?</span>

--- a/client/src/components/cos/tabs/AgentCard.test.jsx
+++ b/client/src/components/cos/tabs/AgentCard.test.jsx
@@ -23,7 +23,7 @@ const agent = {
   status: 'completed',
   startedAt: '2026-07-13T09:00:00.000Z',
   completedAt: '2026-07-13T10:00:00.000Z',
-  metadata: { taskDescription: 'Example task' },
+  metadata: { taskDescription: 'Example task', taskType: 'user' },
   result: { success: true, duration: 3600000 },
 };
 

--- a/client/src/components/cos/tabs/AgentCard.test.jsx
+++ b/client/src/components/cos/tabs/AgentCard.test.jsx
@@ -36,6 +36,21 @@ afterEach(() => {
 });
 
 describe('AgentCard feedback', () => {
+  it('hides the rating UI for a completed scheduled/autopilot agent (taskType internal)', () => {
+    const internalAgent = {
+      ...agent,
+      metadata: { ...agent.metadata, taskType: 'internal' },
+    };
+
+    render(
+      <MemoryRouter>
+        <AgentCard agent={internalAgent} completed />
+      </MemoryRouter>
+    );
+
+    expect(screen.queryByText('Was this helpful?')).not.toBeInTheDocument();
+  });
+
   it('uses the archived scheduled type for a running agent ETA', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-07-13T10:00:00.000Z'));

--- a/client/src/components/cos/tabs/AgentsTab.jsx
+++ b/client/src/components/cos/tabs/AgentsTab.jsx
@@ -19,9 +19,13 @@ const RESUME_MESSAGES = {
   superseded: 'A later agent now holds this task paused — that pause was left intact',
 };
 
+// Only agents from a manually-filled task form ask for a rating — scheduled/
+// autopilot runs (taskType 'internal') are already auto-evaluated by
+// task-learning's success/failure tracking. See cosAgentFeedback.js.
 const needsAgentFeedback = (agent) => {
   const isSystemAgent = agent.taskId?.startsWith('sys-') || agent.id?.startsWith('sys-');
-  return !isSystemAgent && !agent.feedback?.rating;
+  const isManualUserAgent = agent.metadata?.taskType === 'user';
+  return !isSystemAgent && isManualUserAgent && !agent.feedback?.rating;
 };
 
 export default function AgentsTab({ agents, onRefresh, liveOutputs, providers, apps }) {

--- a/server/services/cosAgentFeedback.js
+++ b/server/services/cosAgentFeedback.js
@@ -19,6 +19,13 @@ import { ServerError } from '../lib/errorHandler.js';
 const isSystemAgent = (agent) =>
   agent.taskId?.startsWith('sys-') || agent.id?.startsWith('sys-');
 
+// Only agents spawned from a manually-filled task form are worth asking the
+// user to rate. Scheduled-task and autopilot runs carry taskType 'internal'
+// and already get an automatic success/failure verdict from task-learning
+// (buildTaskTelemetryContext's outcomeSuccess) — asking for a manual rating
+// on top of that is redundant nagging, not a useful signal.
+const isManualUserAgent = (agent) => agent.metadata?.taskType === 'user';
+
 // Count completed user-facing agents that are still retained in live CoS state
 // and have not received a rating. Archived history is intentionally excluded:
 // actionable insights refresh every 30s, so this remains a cheap, exact count
@@ -26,7 +33,11 @@ const isSystemAgent = (agent) =>
 export async function getPendingAgentFeedbackCount() {
   const state = await loadState();
   return Object.values(state.agents)
-    .filter(agent => agent.status === 'completed' && !isSystemAgent(agent) && !agent.feedback?.rating)
+    .filter(agent =>
+      agent.status === 'completed' &&
+      !isSystemAgent(agent) &&
+      isManualUserAgent(agent) &&
+      !agent.feedback?.rating)
     .length;
 }
 

--- a/server/services/cosAgentFeedback.test.js
+++ b/server/services/cosAgentFeedback.test.js
@@ -21,12 +21,13 @@ describe('getPendingAgentFeedbackCount', () => {
     mockCosState.state = { agents: {} };
   });
 
-  it('counts only unrated completed non-system agents for the feedback insight', async () => {
+  it('counts only unrated completed non-system manually-run agents for the feedback insight', async () => {
     mockCosState.state.agents = {
-      'agent-unrated': { id: 'agent-unrated', status: 'completed', completedAt: '2026-08-01T10:00:00.000Z' },
-      'agent-rated': { id: 'agent-rated', status: 'completed', feedback: { rating: 'positive' } },
-      'agent-system': { id: 'agent-system', taskId: 'sys-health-check', status: 'completed' },
-      'agent-running': { id: 'agent-running', status: 'running' }
+      'agent-unrated': { id: 'agent-unrated', status: 'completed', completedAt: '2026-08-01T10:00:00.000Z', metadata: { taskType: 'user' } },
+      'agent-rated': { id: 'agent-rated', status: 'completed', metadata: { taskType: 'user' }, feedback: { rating: 'positive' } },
+      'agent-system': { id: 'agent-system', taskId: 'sys-health-check', status: 'completed', metadata: { taskType: 'user' } },
+      'agent-running': { id: 'agent-running', status: 'running', metadata: { taskType: 'user' } },
+      'agent-scheduled': { id: 'agent-scheduled', status: 'completed', metadata: { taskType: 'internal' } }
     };
 
     await expect(getPendingAgentFeedbackCount()).resolves.toBe(1);
@@ -34,8 +35,17 @@ describe('getPendingAgentFeedbackCount', () => {
 
   it('excludes system agents identified by id as well as taskId', async () => {
     mockCosState.state.agents = {
-      'sys-nightly-sweep': { id: 'sys-nightly-sweep', status: 'completed' },
-      'agent-real': { id: 'agent-real', status: 'completed' }
+      'sys-nightly-sweep': { id: 'sys-nightly-sweep', status: 'completed', metadata: { taskType: 'user' } },
+      'agent-real': { id: 'agent-real', status: 'completed', metadata: { taskType: 'user' } }
+    };
+
+    await expect(getPendingAgentFeedbackCount()).resolves.toBe(1);
+  });
+
+  it('excludes scheduled-task and autopilot agents (taskType internal) from the feedback ask', async () => {
+    mockCosState.state.agents = {
+      'agent-scheduled': { id: 'agent-scheduled', status: 'completed', metadata: { taskType: 'internal' } },
+      'agent-manual': { id: 'agent-manual', status: 'completed', metadata: { taskType: 'user' } }
     };
 
     await expect(getPendingAgentFeedbackCount()).resolves.toBe(1);


### PR DESCRIPTION
## Summary
- The "Was this helpful?" rating UI and the pending-feedback nudge count now only apply to CoS agents spawned from a manually-filled task form (`agent.metadata.taskType === 'user'`).
- Scheduled-task and autopilot agent runs (`taskType: 'internal'`) no longer prompt for a manual rating — they already get an automatic success/failure verdict from task-learning's outcome tracking, so asking was redundant.

## Test plan
- `cd server && npx vitest run services/cosAgentFeedback.test.js routes/cosInsightRoutes.test.js` — passes
- `cd client && npx vitest run src/components/cos/tabs/AgentCard.test.jsx` — passes, including new coverage asserting the rating UI is hidden for `taskType: 'internal'` agents