### PR TITLE
fix: unbreak AgentsTab feedback-queue tests after taskType gating change

### DIFF
--- a/client/src/components/cos/tabs/AgentsTab.test.jsx
+++ b/client/src/components/cos/tabs/AgentsTab.test.jsx
@@ -71,7 +71,7 @@ const completedAgent = (id, description, extra = {}) => ({
   status: 'completed',
   completedAt: '2026-07-13T10:00:00.000Z',
   startedAt: '2026-07-13T09:00:00.000Z',
-  metadata: { taskDescription: description },
+  metadata: { taskDescription: description, taskType: 'user' },
   ...extra,
 });
 
@@ -189,6 +189,16 @@ describe('AgentsTab feedback review queue', () => {
     expect(screen.queryByText('Rated task')).not.toBeInTheDocument();
     expect(screen.queryByText('System task')).not.toBeInTheDocument();
     expect(needsFeedback).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('excludes scheduled/autopilot runs (taskType internal) from the feedback queue', async () => {
+    renderTab([
+      completedAgent('unrated', 'Unrated task'),
+      completedAgent('scheduled', 'Scheduled task', { metadata: { taskDescription: 'Scheduled task', taskType: 'internal' } }),
+    ]);
+    await act(async () => {});
+
+    expect(screen.getByRole('button', { name: 'Needs feedback: 1' })).toBeInTheDocument();
   });
 
   it('opens the feedback queue directly from the URL', async () => {


### PR DESCRIPTION
## Summary
- #4072 restricted the CoS agent feedback UI/count to `taskType === 'user'` agents, but `AgentsTab.test.jsx`'s `completedAgent()` fixture never set `taskType`, so every fixture in that file stopped counting as needing feedback once the change merged, breaking `Needs feedback: N` assertions on `main`.
- Adds `taskType: 'user'` to the fixture default and a new test asserting `taskType: 'internal'` agents are excluded from the queue.

## Test plan
- `cd client && npx vitest run` — full client suite passes (614 files / 7339 tests)
- `cd server && NODE_ENV=test npx vitest run services/cosAgentFeedback.test.js routes/cosInsightRoutes.test.js` — passes