### PR TITLE
fix([issue-4038]): keep the CoS block reason on a failed update and seed it from auto-blocks

### DIFF
--- a/.changelog/next/fixed-issue-4038.md
+++ b/.changelog/next/fixed-issue-4038.md
@@ -1,0 +1,1 @@
+- Chief of Staff: the "Mark Task as Blocked" prompt now keeps your typed reason when the update fails, and pre-fills the reason for tasks the system blocked automatically.

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -138,20 +138,32 @@ export default function TaskItem({ task, isSystem, onRefresh, providers, duratio
       updates.blockedReason = blockedReasonText;
     }
     const result = await api.updateCosTask(task.id, updates, { silent: true }).catch(err => { toast.error(err.message); return null; });
-    if (!result) return;
+    if (!result) return false;
     toast.success(`Task marked as ${newStatus}`);
     onRefresh();
+    return true;
   };
 
   const handleMarkBlocked = () => {
-    setBlockedReason(task.metadata?.blocker || '');
+    // Server-side auto-blocks write `blockedReason`; a manual block writes
+    // `blocker` — seed from whichever the task carries, same as the badge below.
+    setBlockedReason(task.metadata?.blocker || task.metadata?.blockedReason || '');
     setShowBlockedModal(true);
   };
 
-  const handleConfirmBlocked = async () => {
-    await handleStatusChange('blocked', blockedReason.trim());
+  // Closing drops the typed reason rather than leaving it in state. handleMarkBlocked
+  // re-seeds from the task on every open, so nothing leaks through the UI today —
+  // this keeps that true for any future opener that doesn't re-seed.
+  const closeBlockedModal = () => {
     setShowBlockedModal(false);
     setBlockedReason('');
+  };
+
+  const handleConfirmBlocked = async () => {
+    // Keep the modal (and the typed reason) open when the update fails, so a
+    // transient API error doesn't discard what the user wrote.
+    if (!(await handleStatusChange('blocked', blockedReason.trim()))) return;
+    closeBlockedModal();
   };
 
   const handleSave = async () => {
@@ -526,7 +538,7 @@ export default function TaskItem({ task, isSystem, onRefresh, providers, duratio
       {/* Blocked Reason Modal */}
       <Modal
         open={showBlockedModal}
-        onClose={() => setShowBlockedModal(false)}
+        onClose={closeBlockedModal}
         size="sm"
         ariaLabelledBy="blocked-modal-title"
         panelClassName="bg-port-card border border-port-border rounded-lg p-4"
@@ -551,7 +563,7 @@ export default function TaskItem({ task, isSystem, onRefresh, providers, duratio
         />
         <div className="flex justify-end gap-2">
           <button
-            onClick={() => setShowBlockedModal(false)}
+            onClick={closeBlockedModal}
             className="px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors"
           >
             Cancel

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -126,6 +126,68 @@ describe('TaskItem blocked reason', () => {
   });
 });
 
+describe('TaskItem block modal state (#4038)', () => {
+  const openBlockModal = () =>
+    fireEvent.click(screen.getByRole('button', { name: 'Mark task as blocked' }));
+  const reasonField = () =>
+    screen.getByPlaceholderText('e.g., Waiting for API access, Needs design review...');
+
+  // Belt-and-braces: today the sole opener re-seeds the field from the task, so a
+  // retained reason is not reachable through the UI and this passes without the
+  // cancel-side clear. It pins the contract for a future second opener that skips
+  // the seed — which is exactly how the leak would become user-visible.
+  it('drops a typed reason when the modal is canceled', () => {
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    openBlockModal();
+    fireEvent.change(reasonField(), { target: { value: 'Waiting on design review' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    openBlockModal();
+    expect(reasonField()).toHaveValue('');
+  });
+
+  it('seeds the field from an auto-written blockedReason, not just a user-set blocker', () => {
+    // The badge already falls back to blockedReason; the edit field must match, or
+    // re-blocking a server-auto-blocked task silently clears the recorded reason.
+    const autoBlocked = { ...task, id: 'sys-auto-block', metadata: { blockedReason: 'Max total spawns exceeded' } };
+    render(<TaskItem task={autoBlocked} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    openBlockModal();
+    expect(reasonField()).toHaveValue('Max total spawns exceeded');
+  });
+
+  it('keeps the modal and the typed reason open when the update fails', async () => {
+    api.updateCosTask.mockRejectedValue(new Error('network down'));
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    openBlockModal();
+    fireEvent.change(reasonField(), { target: { value: 'Waiting on design review' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Mark Blocked' }));
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('network down'));
+    expect(reasonField()).toHaveValue('Waiting on design review');
+  });
+
+  it('closes and clears once the block succeeds', async () => {
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    openBlockModal();
+    fireEvent.change(reasonField(), { target: { value: 'Waiting on design review' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Mark Blocked' }));
+
+    await waitFor(() => expect(api.updateCosTask).toHaveBeenCalledWith(
+      'sys-model-edit',
+      { status: 'blocked', type: 'internal', blockedReason: 'Waiting on design review' },
+      { silent: true },
+    ));
+    await waitFor(() => expect(screen.queryByText('Mark Task as Blocked')).not.toBeInTheDocument());
+
+    openBlockModal();
+    expect(reasonField()).toHaveValue('');
+  });
+});
+
 describe('TaskItem long-text clamping', () => {
   // The context often holds a task's entire prompt (orchestrator tasks put the
   // whole thing there). Rendering it unclamped turned the pending list into a


### PR DESCRIPTION
## Summary

The Chief of Staff "Mark Task as Blocked" modal mishandled the reason field in three
ways. All three are in `client/src/components/cos/tabs/TaskItem.jsx`:

- **A failed update discarded the typed reason.** `handleConfirmBlocked` closed and
  cleared the modal unconditionally, so when `updateCosTask` rejected the user saw an
  error toast and an empty form. `handleStatusChange` now reports whether the update
  landed, and the modal only closes on success.
- **Re-blocking an auto-blocked task showed an empty field.** The modal seeded only
  from `metadata.blocker`, but every server-side auto-block (max-spawns, retries,
  provider-config) writes `metadata.blockedReason`. Submitting from that empty field
  silently replaced the recorded reason. It now falls back the same way the blocked
  badge already does.
- **Canceling left the typed reason in state.** Now cleared on both close paths
  (Cancel button and the modal's `onClose`).

**On the reported scenario:** the issue describes stale text reappearing when the
modal is opened for another task. That path isn't reachable today — the task list
keys each `TaskItem` by `task.id`, and the sole opener re-seeds the field from the
task on every open. The cancel-side clear is therefore hardening rather than a
live user-visible bug, and the test covering it is annotated as such. The two
defects above *are* user-visible, and are what the new regression tests pin.

## Test plan

- `client/src/components/cos/tabs/TaskItem.test.jsx` — 4 new tests covering the
  failure path, the `blockedReason` seed fallback, the success close-and-clear, and
  the cancel clear.
- Verified non-vacuous: with the source fix reverted, the two behavioral tests fail
  (the seed-fallback and failed-update ones); the cancel test passes either way, as
  explained above and noted in a comment.
- `cd client && npx vitest run src/components/cos/tabs/` — 140 passed (14 files).
- `cd client && npm run lint` — clean.

Closes #4038
