### PR TITLE
fix: use Postgres array literal for empty disclosure_fields in DB test

### DIFF
--- a/server/services/privacyBrokers.db.test.js
+++ b/server/services/privacyBrokers.db.test.js
@@ -86,7 +86,7 @@ describe.skipIf(!dbReady)('privacy brokers DB round-trip', () => {
     // 2. Insert a dummy non-curated broker to verify auto sources are preserved
     await query(
       `INSERT INTO privacy_brokers (id, name, urls, optout, tier, disclosure_fields, source, confidence, enabled, created_at, updated_at)
-       VALUES ('test-auto-upgrade', 'Auto Upgrade', '{}', '{}', 2, '[]', 'badbool', 'auto', true, NOW(), NOW())
+       VALUES ('test-auto-upgrade', 'Auto Upgrade', '{}', '{}', 2, '{}', 'badbool', 'auto', true, NOW(), NOW())
        ON CONFLICT (id) DO NOTHING`,
     );
 


### PR DESCRIPTION
## Summary
- #4019's new `privacyBrokers.db.test.js` test inserted `disclosure_fields` (a `TEXT[]` column) using JSON-array syntax `'[]'`, which Postgres rejects with `malformed array literal: "[]"` — the correct empty-array literal is `'{}'`.
- This has been failing `DB tests and server smoke` in CI on every run of `main` since #4019 merged.

## Test plan
- `cd server && npx vitest run --config vitest.config.db.js services/privacyBrokers.db.test.js` — 7/7 pass (was 1 failing)
- `cd server && npx vitest run --config vitest.config.db.js` — full DB suite, 28 files / 253 tests pass