### PR TITLE
fix: resolve Windows test suite failures and add Windows CI job (#4077)

### DIFF
--- a/.changelog/next/fixed-issue-4077.md
+++ b/.changelog/next/fixed-issue-4077.md
@@ -1,0 +1,1 @@
+- Pin LF line endings in .gitattributes, platform-gate POSIX binary tests, raise Vitest timeouts on Windows, and add Windows job to CI (#4077)

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,32 @@
+# Pin LF line endings for text files cross-platform
+* text=auto eol=lf
 *.sh text eol=lf
+
+# Binary file declarations
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.glb binary
+*.gltf binary
+*.mp3 binary
+*.mp4 binary
+*.wav binary
+*.webm binary
+*.pdf binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.tgz binary
+*.db binary
+*.sqlite binary
+*.wasm binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.eot binary
 
 # Changelog fragments are one file per branch (see scripts/changelogFragments.js),
 # so two branches normally touch two different paths and never conflict. `union`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,10 +225,43 @@ jobs:
           CI_LINT_FILES: ${{ needs.impact.outputs.lint_files }}
         run: node scripts/run-ci-lint.js
 
+  windows-server:
+    name: Windows server unit tests
+    needs: impact
+    if: needs.impact.outputs.server_mode != 'skip'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v7
+        with:
+          node-version: 24.x
+          cache: npm
+          cache-dependency-path: server/package-lock.json
+
+      - name: Install server dependencies
+        run: npm ci --prefix server
+
+      - name: Rebuild trusted native dependencies
+        run: node scripts/trusted-rebuilds.js server
+
+      - name: Check server entry-point syntax
+        run: node --check server/index.js
+
+      - name: Run server tests on Windows
+        env:
+          CI_TEST_MODE: ${{ needs.impact.outputs.server_mode }}
+          CI_TEST_FILES: ${{ needs.impact.outputs.server_files }}
+          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: node scripts/run-ci-tests.js server
+
   gate:
     name: CI Gate
     if: always()
-    needs: [impact, server, client, database, lint]
+    needs: [impact, server, client, database, lint, windows-server]
     runs-on: ubuntu-latest
     steps:
       - name: Require every selected job to pass
@@ -238,6 +271,7 @@ jobs:
           CLIENT_RESULT: ${{ needs.client.result }}
           DATABASE_RESULT: ${{ needs.database.result }}
           LINT_RESULT: ${{ needs.lint.result }}
+          WINDOWS_SERVER_RESULT: ${{ needs.windows-server.result }}
         run: |
           node -e '
             const results = {
@@ -246,6 +280,7 @@ jobs:
               client: process.env.CLIENT_RESULT,
               database: process.env.DATABASE_RESULT,
               lint: process.env.LINT_RESULT,
+              windows_server: process.env.WINDOWS_SERVER_RESULT,
             };
             const failed = Object.entries(results)
               .filter(([, result]) => !["success", "skipped"].includes(result));
@@ -255,3 +290,4 @@ jobs:
             }
             console.log("CI gate passed:", results);
           '
+

--- a/autofixer/sandbox.js
+++ b/autofixer/sandbox.js
@@ -225,15 +225,15 @@ const DEFAULT_MAX_DIFF_BYTES = 200 * 1024; // 200 KB — a bug fix, not a rewrit
 // Files the autofixer must never modify on the live checkout, even if the diff
 // applies cleanly. Secrets, VCS internals, and CI/hook config are out of scope.
 const FORBIDDEN_PATH_PATTERNS = [
-  /(^|\/)\.git(\/|$)/,
-  /(^|\/)\.env(\.|$)/,
-  /(^|\/)\.npmrc$/,
-  /(^|\/)\.aws(\/|$)/,
-  /(^|\/)\.ssh(\/|$)/,
-  /(^|\/)id_rsa/,
+  /(^|[\\/])\.git([\\/]|$)/,
+  /(^|[\\/])\.env(\.|$)/,
+  /(^|[\\/])\.npmrc$/,
+  /(^|[\\/])\.aws([\\/]|$)/,
+  /(^|[\\/])\.ssh([\\/]|$)/,
+  /(^|[\\/])id_rsa/,
   /\.pem$/,
-  /(^|\/)\.github(\/|$)/,
-  /(^|\/)\.claude(\/|$)/,
+  /(^|[\\/])\.github([\\/]|$)/,
+  /(^|[\\/])\.claude([\\/]|$)/,
 ];
 
 /**

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -67,6 +67,17 @@ See [VERSIONING.md](./VERSIONING.md) for full details.
 
 > **Note:** Some older code or automation notes may still reference a `dev` branch workflow. The `main`→`release` workflow described here is the current source of truth.
 
+### Line Endings on Windows
+
+`.gitattributes` pins `eol=lf` for text files across all platforms. If you have an existing repository clone on Windows from before this setting landed, run:
+
+```bash
+git rm --cached -r .
+git reset --hard
+```
+
+to re-index files with LF line endings.
+
 ### Commit Messages
 
 Use conventional commit format:

--- a/scripts/generate_minimax_h3.test.js
+++ b/scripts/generate_minimax_h3.test.js
@@ -5,7 +5,8 @@ import { describe, expect, it } from 'vitest';
 
 const script = join(dirname(fileURLToPath(import.meta.url)), 'generate_minimax_h3.py');
 
-const runPython = (source) => execFileSync('python3', ['-c', source, script], {
+const pyBin = process.platform === 'win32' ? 'python' : 'python3';
+const runPython = (source) => execFileSync(pyBin, ['-c', source, script], {
   encoding: 'utf8',
 });
 

--- a/server/lib/cliProviderRun.test.js
+++ b/server/lib/cliProviderRun.test.js
@@ -125,10 +125,18 @@ describe('runCliProviderPrompt', () => {
     // completes — proves the resolved path, not the bare provider.command,
     // is what actually gets spawned.
     const { execFileSync } = await import('child_process');
-    const catPath = execFileSync('which', ['cat']).toString().trim();
+    const isWin = process.platform === 'win32';
+    const catPath = isWin
+      ? execFileSync('where', ['node']).toString().split(/\r?\n/)[0].trim()
+      : execFileSync('which', ['cat']).toString().trim();
     vi.mocked(resolveWindowsExecutable).mockReturnValueOnce(catPath);
     const result = await runCliProviderPrompt({
-      provider: { id: 'gemini-cli', type: 'cli', command: 'this-name-is-never-spawned-directly', args: [] },
+      provider: {
+        id: 'gemini-cli',
+        type: 'cli',
+        command: 'this-name-is-never-spawned-directly',
+        args: isWin ? ['-e', 'process.stdin.pipe(process.stdout)'] : [],
+      },
       prompt: 'resolved path round-trip',
     });
     expect(result.error).toBeUndefined();

--- a/server/lib/zipWriter.test.js
+++ b/server/lib/zipWriter.test.js
@@ -131,7 +131,8 @@ describe('createZip', () => {
   it('produces a compressed archive the system unzip tool can extract', () => {
     let unzipPath;
     try {
-      unzipPath = execFileSync('which', ['unzip']).toString().trim();
+      const lookup = process.platform === 'win32' ? 'where' : 'which';
+      unzipPath = execFileSync(lookup, ['unzip']).toString().split(/\r?\n/)[0].trim();
     } catch {
       return; // no unzip on this host — skip
     }
@@ -155,7 +156,8 @@ describe('createZip', () => {
     // the central directory) would tolerate but a real tool would reject.
     let unzipPath;
     try {
-      unzipPath = execFileSync('which', ['unzip']).toString().trim();
+      const lookup = process.platform === 'win32' ? 'where' : 'which';
+      unzipPath = execFileSync(lookup, ['unzip']).toString().split(/\r?\n/)[0].trim();
     } catch {
       return; // no unzip on this host — skip rather than fail
     }

--- a/server/vitest.config.db.js
+++ b/server/vitest.config.db.js
@@ -52,7 +52,7 @@ export const DB_TEST_INCLUDE = [
  */
 export default defineConfig({
   test: {
-    testTimeout: 15000,
+    testTimeout: process.platform === 'win32' ? 30000 : 15000,
     globals: true,
     setupFiles: ['./vitest.setup.js'],
     // One file at a time — these suites assume exclusive access to their tables.

--- a/server/vitest.config.js
+++ b/server/vitest.config.js
@@ -2,7 +2,7 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    testTimeout: 10000,
+    testTimeout: process.platform === 'win32' ? 30000 : 10000,
     // Print worker console output directly instead of forwarding it to the main
     // thread over RPC. This codebase logs heavily from fire-and-forget callbacks
     // (the documented `.catch(() => console.log(...))` pattern, PTY/timer hooks,


### PR DESCRIPTION
## Summary
Fixes Windows test suite failures across CRLF line endings, path-separator assertions, POSIX binary resolution, and Vitest timeouts, and adds a Windows CI job.

- **Stage 1**: Add `.gitattributes` pinning `eol=lf` for text files cross-platform and declaring binary extensions. Updated `docs/CONTRIBUTING.md` with re-indexing command for existing Windows clones.
- **Stage 2 & 3**: Fixed path-separator assertions and platform-gated POSIX-binary lookups (`where` vs `which`, Node stdin piping fallback in CLI provider tests, python binary resolution).
- **Stage 4**: Raised Vitest timeouts on Windows (`30000ms`) in `server/vitest.config.js` and `server/vitest.config.db.js` to account for slower Windows I/O.
- **Stage 5**: Added `windows-server` job to `.github/workflows/ci.yml` and wired it into the required CI Gate.

## Test Plan
- Ran unit test suite with `MEMORY_BACKEND=file npm test` in `server/`.
- Verified `.gitattributes` binary declarations and LF line ending configuration.
- Verified CI workflow configuration syntax and gate wiring.

Closes #4077