### PR TITLE
feat([issue-4079]): add MiniMax Music 3 engine

### DIFF
--- a/.changelog/next/added-issue-4079.md
+++ b/.changelog/next/added-issue-4079.md
@@ -1,0 +1,1 @@
+- MiniMax Music 3 can now be installed and generated from Music on supported NVIDIA CUDA hosts.

--- a/client/src/components/music/MusicGenPanel.jsx
+++ b/client/src/components/music/MusicGenPanel.jsx
@@ -84,6 +84,24 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
 
   const canGenerate = !!engine?.ready && !!prompt?.trim() && !generating && !!track?.id;
 
+  const handleFixedModelInstall = async () => {
+    const model = engine?.models?.find((item) => item.id === engine.defaultModelId) || engine?.models?.[0];
+    if (!engine || !model?.repo) return;
+    setInstalling(true);
+    setInstallProgress({ message: `Starting ${model.name}…` });
+    let failed = false;
+    await installAudioModel({ engine: engine.id, repo: model.repo }, (ev) => {
+      if (!mountedRef.current) return;
+      if (ev.type === 'progress') setInstallProgress({ message: `${ev.file || 'downloading'} — ${Math.round((ev.progress || 0) * 100)}%`, progress: ev.progress });
+      else if (ev.type === 'stage') setInstallProgress({ message: ev.stage });
+      else if (ev.type === 'error') { failed = true; toast.error(ev.message || 'Download failed'); }
+    }).catch((err) => { failed = true; if (mountedRef.current) toast.error(err.message || 'Install failed'); });
+    if (!mountedRef.current) return;
+    setInstalling(false);
+    setInstallProgress(null);
+    if (!failed) { await loadEngines(); toast.success(`${model.name} installed`); }
+  };
+
   const handleGenerate = async () => {
     if (!engine) return;
     if (!track?.id) { toast.error('Save the track first, then generate'); return; }
@@ -162,7 +180,7 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
             className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm"
           >
             {engines.map((e) => (
-              <option key={e.id} value={e.id}>{e.name}{e.ready ? '' : ' (not installed)'}</option>
+              <option key={e.id} value={e.id}>{e.name}{e.cudaRequired && e.cudaState !== 'available' ? ' (CUDA unavailable)' : e.ready ? '' : ' (setup required)'}</option>
             ))}
           </select>
         </label>
@@ -197,9 +215,15 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
       {showRuntimeInstallHint ? (
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-lg border border-port-warning/30 bg-port-warning/10 px-3 py-2">
           <p className="text-[11px] text-port-warning">
-            {engine.name} is not installed yet. Install the runtime to enable generation.
+            {engine.cudaRequired && engine.cudaState === 'absent'
+              ? `${engine.name} requires an NVIDIA CUDA GPU and is unavailable on this host.`
+              : engine.cudaRequired && engine.cudaState === 'unknown'
+                ? `${engine.name} is disabled because CUDA availability could not be determined.`
+                : engine.fixedModelInstall && engine.modelReady === false
+                  ? `${engine.name} runtime and model weights must both be installed before generation.`
+                  : `${engine.name} is not installed yet. Install the runtime to enable generation.`}
           </p>
-          <button
+          {!engine.cudaRequired || engine.cudaState === 'available' ? <button
             type="button"
             onClick={() => setRuntimeInstallEngine(engine)}
             className="inline-flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg bg-port-bg border border-port-warning/50 text-port-warning text-xs font-medium hover:border-port-warning disabled:opacity-50"
@@ -207,6 +231,15 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
             <Download size={13} />
             Install runtime
           </button>
+          : null}
+        </div>
+      ) : null}
+      {engine?.fixedModelInstall && !engine.modelReady && engine.cudaState === 'available' ? (
+        <div className="rounded-lg border border-port-border px-3 py-2">
+          <button type="button" onClick={handleFixedModelInstall} disabled={installing} className="inline-flex items-center gap-2 text-xs text-port-accent disabled:opacity-50">
+            {installing ? <Loader2 size={13} className="animate-spin" /> : <Download size={13} />} Install model
+          </button>
+          {installProgress ? <p className="mt-1 truncate text-[11px] text-gray-500">{installProgress.message}</p> : null}
         </div>
       ) : null}
       {engine?.lyrics ? (

--- a/client/src/components/music/MusicGenPanel.test.jsx
+++ b/client/src/components/music/MusicGenPanel.test.jsx
@@ -112,4 +112,23 @@ describe('MusicGenPanel', () => {
     expect(select).toHaveValue('musicgen');
     expect(screen.queryByText(/Loading generators/i)).not.toBeInTheDocument();
   });
+
+  it('explains CUDA gating and hides install actions on an unsupported host', async () => {
+    api.listMusicEngines.mockResolvedValue({
+      defaultEngine: 'minimax-music3',
+      engines: [engine({
+        id: 'minimax-music3', name: 'MiniMax Music 3 (CUDA only)', ready: false,
+        cudaRequired: true, cudaState: 'absent', fixedModelInstall: true, modelReady: false,
+        customModels: false, lyrics: true, maxDurationSec: 300, defaultDurationSec: 60,
+        models: [{ id: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', name: 'MiniMax Music 3' }],
+        defaultModelId: 'minimax-music3',
+      })],
+    });
+
+    render(<MusicGenPanel track={{ id: 'track-1' }} prompt="cinematic score" lyrics="Example lyrics" />);
+
+    expect(await screen.findByText(/requires an NVIDIA CUDA GPU/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /install runtime/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /install model/i })).not.toBeInTheDocument();
+  });
 });

--- a/scripts/generate_minimax_music3.py
+++ b/scripts/generate_minimax_music3.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""MiniMax Music 3 Diffusers sidecar using PortOS' STAGE/RESULT protocol."""
+import argparse
+import json
+import os
+import sys
+import wave
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model', required=True)
+    parser.add_argument('--text', required=True)
+    parser.add_argument('--lyrics', default='')
+    parser.add_argument('--duration', type=float, required=True)
+    parser.add_argument('--output', required=True)
+    parser.add_argument('--runtime-dir', default='')
+    args = parser.parse_args()
+    if args.runtime_dir:
+        sys.path.insert(0, args.runtime_dir)
+
+    import numpy as np
+    import torch
+    from diffusers import ModularPipeline
+
+    if not torch.cuda.is_available():
+        raise RuntimeError('MiniMax Music 3 requires CUDA')
+    print('STAGE:load-model', file=sys.stderr, flush=True)
+    pipe = ModularPipeline.from_pretrained(args.model)
+    pipe.load_components(dtype=torch.bfloat16)
+    pipe.to('cuda')
+    print('STAGE:generate', file=sys.stderr, flush=True)
+    audio = pipe(
+        prompt=args.text,
+        lyrics=args.lyrics,
+        audio_duration=float(max(1, min(300, args.duration))),
+        output='audios',
+    )[0].float().cpu().numpy()
+    if audio.ndim == 1:
+        audio = np.stack([audio, audio])
+    if audio.shape[0] != 2:
+        audio = audio.T
+    source_rate = int(pipe.sampling_rate)
+    if source_rate != 32000:
+        source_x = np.arange(audio.shape[1], dtype=np.float64)
+        target_x = np.linspace(0, audio.shape[1] - 1, round(audio.shape[1] * 32000 / source_rate))
+        audio = np.stack([np.interp(target_x, source_x, channel) for channel in audio])
+    pcm = np.clip(audio, -1, 1)
+    pcm = (pcm.T * 32767).astype(np.int16)
+    os.makedirs(os.path.dirname(args.output), exist_ok=True)
+    with wave.open(args.output, 'wb') as wav:
+        wav.setnchannels(2); wav.setsampwidth(2); wav.setframerate(32000); wav.writeframes(pcm.tobytes())
+    print('RESULT:' + json.dumps({'durationSec': len(pcm) / 32000}), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/setup-image-video.sh
+++ b/scripts/setup-image-video.sh
@@ -63,7 +63,7 @@ mkdir -p "${PORTOS_DATA}/video-thumbnails"
 # install ever starts — which on Linux/CPU/CUDA blocks the advertised
 # `INSTALL_ACESTEP=1 bash …` path. A bare `bash setup-image-video.sh` still
 # installs mflux as before.
-ANY_BYOV="${INSTALL_LTX2:-0}${INSTALL_WAN22:-0}${INSTALL_HUNYUAN:-0}${INSTALL_MINIMAX_H3:-0}${INSTALL_MUSICGEN:-0}${INSTALL_AUDIOLDM2:-0}${INSTALL_ACESTEP:-0}${INSTALL_MUSCRIPTOR:-0}"
+ANY_BYOV="${INSTALL_LTX2:-0}${INSTALL_WAN22:-0}${INSTALL_HUNYUAN:-0}${INSTALL_MINIMAX_H3:-0}${INSTALL_MUSICGEN:-0}${INSTALL_AUDIOLDM2:-0}${INSTALL_ACESTEP:-0}${INSTALL_MINIMAX_MUSIC3:-0}${INSTALL_MUSCRIPTOR:-0}"
 if [[ "$ANY_BYOV" == "00000000" ]]; then
   DEFAULT_INSTALL_MFLUX=1
   DEFAULT_INSTALL_VIDEO=$(is_macos && echo 1 || echo 0)
@@ -581,6 +581,19 @@ if [[ "$INSTALL_ACESTEP" == "1" ]]; then
     exit 1
   fi
   echo "✅ ACE-Step venv ready: $ACESTEP_PY"
+fi
+
+INSTALL_MINIMAX_MUSIC3="${INSTALL_MINIMAX_MUSIC3:-0}"
+if [[ "$INSTALL_MINIMAX_MUSIC3" == "1" ]]; then
+  MINIMAX_MUSIC3_VENV="${HOME}/.portos/venv-minimax-music3"
+  MINIMAX_MUSIC3_PY="$MINIMAX_MUSIC3_VENV/bin/python3"
+  [[ -x "$MINIMAX_MUSIC3_PY" || -x "$MINIMAX_MUSIC3_VENV/Scripts/python.exe" ]] || "$PYTHON_BIN" -m venv "$MINIMAX_MUSIC3_VENV"
+  [[ -x "$MINIMAX_MUSIC3_PY" ]] || MINIMAX_MUSIC3_PY="$MINIMAX_MUSIC3_VENV/Scripts/python.exe"
+  "$MINIMAX_MUSIC3_PY" -m pip install --upgrade pip wheel setuptools
+  "$MINIMAX_MUSIC3_PY" -m pip install --upgrade torch transformers accelerate huggingface_hub numpy \
+    'diffusers @ git+https://github.com/huggingface/diffusers.git@7cd51fa'
+  "$MINIMAX_MUSIC3_PY" -c "import torch; from diffusers import ModularPipeline; assert torch.cuda.is_available()"
+  echo "✅ MiniMax Music 3 venv ready: $MINIMAX_MUSIC3_PY"
 fi
 
 INSTALL_MUSCRIPTOR="${INSTALL_MUSCRIPTOR:-0}"

--- a/server/lib/pythonSetup.js
+++ b/server/lib/pythonSetup.js
@@ -350,6 +350,32 @@ export function invalidateAcestepPython() {
   cachedAcestepPython = null;
 }
 
+const MINIMAX_MUSIC3_VENV_CANDIDATES = IS_WIN
+  ? [
+      join(HOME, '.portos', 'venv-minimax-music3', 'Scripts', 'python.exe'),
+      join(PATHS.data, 'python', 'venv-minimax-music3', 'Scripts', 'python.exe'),
+    ]
+  : [
+      join(HOME, '.portos', 'venv-minimax-music3', 'bin', 'python3'),
+      join(PATHS.data, 'python', 'venv-minimax-music3', 'bin', 'python3'),
+    ];
+
+export const MINIMAX_MUSIC3_VENV_DEFAULT = MINIMAX_MUSIC3_VENV_CANDIDATES[0];
+export const MINIMAX_MUSIC3_RUNTIME_DIR = '';
+
+let cachedMinimaxMusic3Python = null;
+export function resolveMinimaxMusic3Python() {
+  if (cachedMinimaxMusic3Python && existsSync(cachedMinimaxMusic3Python)) return cachedMinimaxMusic3Python;
+  for (const p of MINIMAX_MUSIC3_VENV_CANDIDATES) {
+    if (existsSync(p)) { cachedMinimaxMusic3Python = p; return p; }
+  }
+  return null;
+}
+
+export function invalidateMinimaxMusic3Python() {
+  cachedMinimaxMusic3Python = null;
+}
+
 // MuScriptor (audio → MIDI transcription for the Rounds workbench + Music Video
 // parsing, #reference-audio-to-midi) runs in its own venv at
 // ~/.portos/venv-muscriptor — the `muscriptor` pip package pulls its own torch

--- a/server/routes/music.js
+++ b/server/routes/music.js
@@ -31,6 +31,7 @@ import { listEngineModels, addAudioModel, removeAudioModel, isValidRepoId } from
 import { startHfDownloadStream, openSseStream } from '../lib/sseDownload.js';
 import { createInstallLogger } from '../lib/installLogger.js';
 import { inspectModelCache } from '../lib/hfCache.js';
+import { getCudaCapability } from '../lib/cudaCapability.js';
 import * as tracks from '../services/tracks/index.js';
 import * as albums from '../services/albums/index.js';
 
@@ -41,7 +42,10 @@ const router = Router();
 // (the opt-in venv is provisioned). The UI gates its Generate affordance + shows
 // the install hint from this.
 router.get('/engines', asyncHandler(async (_req, res) => {
-  const engines = await Promise.all(Object.values(ENGINES).map(async (engine) => ({
+  const cuda = await getCudaCapability();
+  const engines = await Promise.all(Object.values(ENGINES).map(async (engine) => {
+    const modelCache = engine.fixedModelInstall ? await inspectModelCache(engine.models[0].repo).catch(() => ({ cached: false })) : null;
+    return ({
     id: engine.id,
     name: engine.name,
     models: await listEngineModels(engine.id),
@@ -54,10 +58,14 @@ router.get('/engines', asyncHandler(async (_req, res) => {
     // the "install/select model" UI). ACE-Step resolves a single foundation
     // checkpoint via checkpoint_dir, so custom repos don't apply to it.
     customModels: engine.customModels === true,
-    ready: isEngineReady(engine.id),
+    fixedModelInstall: engine.fixedModelInstall === true,
+    modelReady: modelCache ? modelCache.cached === true : true,
+    cudaRequired: engine.cudaRequired === true,
+    cudaState: engine.cudaRequired ? cuda.state : 'available',
+    ready: isEngineReady(engine.id) && (!engine.cudaRequired || cuda.state === 'available') && (!modelCache || modelCache.cached === true),
     installEnv: engine.installEnv,
     venvDefault: engine.venvDefault,
-  })));
+  }); }));
   res.json({ engines, defaultEngine: DEFAULT_ENGINE_ID });
 }));
 
@@ -100,6 +108,15 @@ router.get('/setup/runtime-install', asyncHandler(async (req, res) => {
   if (runtimeInstallInFlight.has(engine.id)) {
     send({ type: 'error', message: `Another ${engine.name} install is already running. Wait for it to finish or restart PortOS.` });
     return safeEnd();
+  }
+  if (engine.cudaRequired) {
+    const cuda = await getCudaCapability();
+    if (cuda.state !== 'available') {
+      send({ type: 'error', message: cuda.state === 'unknown'
+        ? `${engine.name} cannot be installed because CUDA availability could not be determined.`
+        : `${engine.name} requires an NVIDIA CUDA GPU and cannot be installed on this host.` });
+      return safeEnd();
+    }
   }
   runtimeInstallInFlight.set(engine.id, null);
 
@@ -208,12 +225,14 @@ router.post('/models', asyncHandler(async (req, res) => {
   // Reject install for engines that can't render a custom HF checkpoint (e.g.
   // ACE-Step, which uses a fixed checkpoint_dir) — otherwise a downloaded repo
   // would register as selectable but the sidecar would ignore it.
-  if (!ENGINES[body.engine].customModels) {
+  const engine = ENGINES[body.engine];
+  const fixedModel = engine.fixedModelInstall && engine.models.some((model) => model.repo === body.repo);
+  if (!engine.customModels && !fixedModel) {
     throw new ServerError(`${ENGINES[body.engine].name} does not support custom HuggingFace models`, { status: 400, code: 'AUDIO_MODEL_ENGINE_FIXED' });
   }
   if (!isValidRepoId(body.repo)) throw new ServerError('Invalid HuggingFace repo id', { status: 400, code: 'AUDIO_MODEL_INVALID_REPO' });
   // Register first so it's durable before the stream signals completion.
-  await addAudioModel({ engine: body.engine, repo: body.repo, name: body.name });
+  if (!fixedModel) await addAudioModel({ engine: body.engine, repo: body.repo, name: body.name });
   // Hand the response to the shared SSE driver — it owns writeHead/end + the
   // in-flight dedupe + client-disconnect kill. Resolves after the stream ends.
   await startHfDownloadStream({ req, res, repo: body.repo });
@@ -222,7 +241,7 @@ router.post('/models', asyncHandler(async (req, res) => {
   // is logged by the service, not surfaced (the response already closed).
   const cached = await inspectModelCache(body.repo).catch(() => ({ cached: false }));
   if (!cached.cached) {
-    await removeAudioModel({ engine: body.engine, id: body.repo }).catch(() => {});
+    if (!fixedModel) await removeAudioModel({ engine: body.engine, id: body.repo }).catch(() => {});
   }
 }));
 

--- a/server/services/pipeline/musicGen.js
+++ b/server/services/pipeline/musicGen.js
@@ -39,7 +39,10 @@ import {
   resolveMusicgenPython, MUSICGEN_RUNTIME_DIR, MUSICGEN_VENV_DEFAULT,
   resolveAudioldm2Python, AUDIOLDM2_RUNTIME_DIR, AUDIOLDM2_VENV_DEFAULT,
   resolveAcestepPython, ACESTEP_RUNTIME_DIR, ACESTEP_VENV_DEFAULT,
+  resolveMinimaxMusic3Python, MINIMAX_MUSIC3_RUNTIME_DIR, MINIMAX_MUSIC3_VENV_DEFAULT,
 } from '../../lib/pythonSetup.js';
+import { getCudaCapability } from '../../lib/cudaCapability.js';
+import { inspectModelCache } from '../../lib/hfCache.js';
 import { ServerError } from '../../lib/errorHandler.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -48,6 +51,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const MUSICGEN_SCRIPT = join(__dirname, '../../../scripts/generate_musicgen.py');
 const AUDIOLDM2_SCRIPT = join(__dirname, '../../../scripts/generate_audioldm2.py');
 const ACESTEP_SCRIPT = join(__dirname, '../../../scripts/generate_acestep.py');
+const MINIMAX_MUSIC3_SCRIPT = join(__dirname, '../../../scripts/generate_minimax_music3.py');
 // Back-compat alias for the pre-multi-engine `buildMusicGenArgs` default.
 const SIDECAR_SCRIPT = MUSICGEN_SCRIPT;
 
@@ -87,6 +91,9 @@ export const ACESTEP_MODELS = Object.freeze([
   { id: 'ace-step-v1-3.5b', repo: 'ACE-Step/ACE-Step-v1-3.5B', name: 'ACE-Step v1 3.5B (full song + vocals)' },
 ]);
 export const DEFAULT_ACESTEP_MODEL_ID = 'ace-step-v1-3.5b';
+export const MINIMAX_MUSIC3_MODELS = Object.freeze([
+  { id: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', name: 'MiniMax Music 3 (CUDA, up to 5 minutes)' },
+]);
 
 /**
  * Backend registry. Each engine is fully described here so the route, UI and
@@ -156,6 +163,24 @@ export const ENGINES = Object.freeze({
     // therefore disabled for it (customModels falsy) — the sidecar ignores
     // --model by design.
     customModels: false,
+  },
+  'minimax-music3': {
+    id: 'minimax-music3',
+    name: 'MiniMax Music 3 (CUDA only)',
+    models: MINIMAX_MUSIC3_MODELS,
+    defaultModelId: 'minimax-music3',
+    minDurationSec: 1,
+    maxDurationSec: 300,
+    defaultDurationSec: 60,
+    scriptPath: MINIMAX_MUSIC3_SCRIPT,
+    runtimeDir: MINIMAX_MUSIC3_RUNTIME_DIR,
+    resolvePython: resolveMinimaxMusic3Python,
+    venvDefault: MINIMAX_MUSIC3_VENV_DEFAULT,
+    installEnv: 'INSTALL_MINIMAX_MUSIC3',
+    lyrics: true,
+    customModels: false,
+    fixedModelInstall: true,
+    cudaRequired: true,
   },
 });
 
@@ -272,6 +297,23 @@ export async function generateMusic({ prompt, lyrics, engine: engineId = DEFAULT
     : shippedModel;
   const resolvedDuration = durationSec ?? engine.defaultDurationSec;
   const pythonPath = engine.resolvePython();
+  if (engine.cudaRequired) {
+    const cuda = await getCudaCapability();
+    if (cuda.state !== 'available') {
+      throw new ServerError(
+        cuda.state === 'unknown' ? 'CUDA availability could not be determined.' : `${engine.name} requires an NVIDIA CUDA GPU.`,
+        { status: 503, code: 'PIPELINE_MUSIC_CUDA_REQUIRED' },
+      );
+    }
+  }
+  if (engine.fixedModelInstall) {
+    const cache = await inspectModelCache(model.repo).catch(() => ({ cached: false }));
+    if (!cache.cached) {
+      throw new ServerError(`${engine.name} model weights are not installed. Install them from Music before generating.`, {
+        status: 503, code: 'PIPELINE_MUSIC_MODEL_MISSING',
+      });
+    }
+  }
   if (!pythonPath) {
     throw new ServerError(
       `${engine.name} runtime not found. Run \`${engine.installEnv}=1 bash scripts/setup-image-video.sh\` to bootstrap it (expected venv at ${engine.venvDefault}).`,

--- a/server/services/pipeline/musicGen.test.js
+++ b/server/services/pipeline/musicGen.test.js
@@ -63,7 +63,7 @@ describe('AUDIOLDM2_MODELS registry', () => {
 
 describe('ENGINES backend registry', () => {
   it('exposes all backends with the fields the route + UI consume', () => {
-    expect(Object.keys(ENGINES).sort()).toEqual(['acestep', 'audioldm2', 'musicgen']);
+    expect(Object.keys(ENGINES).sort()).toEqual(['acestep', 'audioldm2', 'minimax-music3', 'musicgen']);
     for (const engine of Object.values(ENGINES)) {
       expect(typeof engine.id).toBe('string');
       expect(typeof engine.name).toBe('string');
@@ -136,6 +136,15 @@ describe('clampDuration', () => {
 });
 
 describe('buildSidecarArgs', () => {
+  it('builds MiniMax Music 3 args with lyrics and clamps to five minutes', () => {
+    const { args } = buildSidecarArgs({
+      engineId: 'minimax-music3', pythonPath: '/venv/python', repo: 'MiniMaxAI/MiniMax-Music3',
+      prompt: 'cinematic synthwave', lyrics: 'Example lyrics', durationSec: 999, outputPath: '/tmp/out.wav',
+    });
+    expect(args).toContain('MiniMaxAI/MiniMax-Music3');
+    expect(args.slice(args.indexOf('--duration'), args.indexOf('--duration') + 2)).toEqual(['--duration', '300']);
+    expect(args.slice(args.indexOf('--lyrics'), args.indexOf('--lyrics') + 2)).toEqual(['--lyrics', 'Example lyrics']);
+  });
   const base = {
     pythonPath: '/venv/bin/python3',
     repo: 'facebook/musicgen-medium',


### PR DESCRIPTION
## Summary
- add MiniMax Music 3 as a fixed, lyrics-aware CUDA-only Music engine
- expose separate CUDA, runtime, and official-model readiness with UI-driven SSE installs
- generate 1–300 second tracks through the pinned Diffusers modular pipeline and persist 32 kHz, 16-bit stereo WAV output
- preserve MusicGen as the default and leave existing MusicGen, AudioLDM2, and ACE-Step flows unchanged

## Test plan
- `npm test --prefix server -- --run services/pipeline/musicGen.test.js routes/music.test.js` (62 passed)
- `npm test --prefix client -- --run src/components/music/MusicGenPanel.test.jsx` (4 passed)
- `node --check server/services/pipeline/musicGen.js`
- `node --check server/routes/music.js`
- `git diff --check`

Hardware CUDA generation remains to be exercised on the CUDA test instance after merge/deployment.

Closes #4079
