### PR TITLE
fix: enable standalone music generation

### DIFF
--- a/.changelog/next/changed-music-quick-generate.md
+++ b/.changelog/next/changed-music-quick-generate.md
@@ -1,0 +1,1 @@
+- Music now opens with a standalone tune generator, and audio-model runtime and weight setup can be completed directly from the generation panel.

--- a/client/src/components/music/MusicGenPanel.jsx
+++ b/client/src/components/music/MusicGenPanel.jsx
@@ -21,7 +21,16 @@ import {
 } from '../../services/api';
 import RuntimeInstallModal from '../install/RuntimeInstallModal';
 
-export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remix }) {
+function engineSetupMessage(engine) {
+  if (engine.cudaRequired && engine.cudaState === 'absent') return `${engine.name} requires an NVIDIA CUDA GPU and is unavailable on this host.`;
+  if (engine.cudaRequired && engine.cudaState === 'unknown') return `${engine.name} is disabled because CUDA availability could not be determined.`;
+  if (engine.runtimeReady === false && engine.fixedModelInstall && engine.modelReady === false) return `${engine.name} needs its runtime and model weights before generation.`;
+  if (engine.runtimeReady === false) return `${engine.name} needs its runtime before generation.`;
+  if (engine.fixedModelInstall && engine.modelReady === false) return `${engine.name} model weights are not installed yet.`;
+  return `${engine.name} is not installed yet. Install the runtime to enable generation.`;
+}
+
+export default function MusicGenPanel({ track, title = '', artistId = '', artist = '', albumId = '', prompt, lyrics, onGenerated, remix }) {
   const [engines, setEngines] = useState([]);
   const [loading, setLoading] = useState(true);
   const [engineId, setEngineId] = useState('');
@@ -82,7 +91,7 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
     setDurationSec((d) => (d == null ? engine.defaultDurationSec : d));
   }, [engine?.id, engine?.models]);
 
-  const canGenerate = !!engine?.ready && !!prompt?.trim() && !generating && !!track?.id;
+  const canGenerate = !!engine?.ready && !!prompt?.trim() && !generating;
 
   const handleFixedModelInstall = async () => {
     const model = engine?.models?.find((item) => item.id === engine.defaultModelId) || engine?.models?.[0];
@@ -104,7 +113,6 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
 
   const handleGenerate = async () => {
     if (!engine) return;
-    if (!track?.id) { toast.error('Save the track first, then generate'); return; }
     if (!prompt?.trim()) { toast.error('Add a generation prompt first'); return; }
     setGenerating(true);
     const body = {
@@ -112,8 +120,14 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
       lyrics: engine.lyrics ? (lyrics || '') : '',
       engine: engine.id,
       modelId,
-      trackId: track.id,
     };
+    if (track?.id) body.trackId = track.id;
+    else {
+      body.title = title.trim();
+      body.artistId = artistId;
+      body.artist = artist;
+      body.albumId = albumId;
+    }
     if (Number.isFinite(durationSec)) body.durationSec = durationSec;
     const res = await generateMusic(body, { silent: true }).catch((err) => { toast.error(err.message || 'Generation failed'); return null; });
     if (!mountedRef.current) return;
@@ -161,6 +175,7 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
 
   const selectedUserModel = engine?.models?.find((m) => m.id === modelId && m.userAdded);
   const showRuntimeInstallHint = !!engine && !engine.ready && (!!prompt?.trim() || userSelectedEngine);
+  const canInstallRuntime = engine?.runtimeReady !== true && (!engine?.cudaRequired || engine?.cudaState === 'available');
 
   return (
     <div className="space-y-2 border border-port-border rounded-lg p-3 bg-port-bg/40">
@@ -215,15 +230,9 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
       {showRuntimeInstallHint ? (
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 rounded-lg border border-port-warning/30 bg-port-warning/10 px-3 py-2">
           <p className="text-[11px] text-port-warning">
-            {engine.cudaRequired && engine.cudaState === 'absent'
-              ? `${engine.name} requires an NVIDIA CUDA GPU and is unavailable on this host.`
-              : engine.cudaRequired && engine.cudaState === 'unknown'
-                ? `${engine.name} is disabled because CUDA availability could not be determined.`
-                : engine.fixedModelInstall && engine.modelReady === false
-                  ? `${engine.name} runtime and model weights must both be installed before generation.`
-                  : `${engine.name} is not installed yet. Install the runtime to enable generation.`}
+            {engineSetupMessage(engine)}
           </p>
-          {!engine.cudaRequired || engine.cudaState === 'available' ? <button
+          {canInstallRuntime ? <button
             type="button"
             onClick={() => setRuntimeInstallEngine(engine)}
             className="inline-flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg bg-port-bg border border-port-warning/50 text-port-warning text-xs font-medium hover:border-port-warning disabled:opacity-50"
@@ -251,11 +260,11 @@ export default function MusicGenPanel({ track, prompt, lyrics, onGenerated, remi
           type="button"
           onClick={handleGenerate}
           disabled={!canGenerate}
-          title={!track?.id ? 'Save the track first' : !prompt?.trim() ? 'Add a generation prompt' : !engine?.ready ? 'Engine not installed' : 'Generate audio'}
+          title={!prompt?.trim() ? 'Add a generation prompt' : !engine?.ready ? 'Complete engine setup first' : track?.id ? 'Generate audio' : 'Generate and create a standalone track'}
           className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-port-accent text-white text-sm font-medium disabled:opacity-50"
         >
           {generating ? <Loader2 size={14} className="animate-spin" /> : <Wand2 size={14} />}
-          {generating ? 'Generating…' : 'Generate'}
+          {generating ? 'Generating…' : track?.id ? 'Generate' : 'Generate track'}
         </button>
         {selectedUserModel ? (
           <button

--- a/client/src/components/music/MusicGenPanel.test.jsx
+++ b/client/src/components/music/MusicGenPanel.test.jsx
@@ -131,4 +131,45 @@ describe('MusicGenPanel', () => {
     expect(screen.queryByRole('button', { name: /install runtime/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /install model/i })).not.toBeInTheDocument();
   });
+
+  it('generates an unsaved standalone track without requiring a title or associations', async () => {
+    api.listMusicEngines.mockResolvedValue({
+      defaultEngine: 'musicgen',
+      engines: [engine({ ready: true })],
+    });
+    api.generateMusic.mockResolvedValue({ track: { id: 'generated-track', title: 'Ambient sunrise' } });
+    const onGenerated = vi.fn();
+
+    render(<MusicGenPanel prompt="Ambient sunrise" lyrics="" onGenerated={onGenerated} />);
+
+    fireEvent.click(await screen.findByRole('button', { name: /generate track/i }));
+    await waitFor(() => expect(api.generateMusic).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: 'Ambient sunrise',
+      title: '',
+      artistId: '',
+      artist: '',
+      albumId: '',
+    }), { silent: true }));
+    expect(api.generateMusic.mock.calls[0][0]).not.toHaveProperty('trackId');
+    expect(onGenerated).toHaveBeenCalledWith(expect.objectContaining({ id: 'generated-track' }));
+  });
+
+  it('offers the fixed-model install without suggesting a runtime reinstall', async () => {
+    api.listMusicEngines.mockResolvedValue({
+      defaultEngine: 'minimax-music3',
+      engines: [engine({
+        id: 'minimax-music3', name: 'MiniMax Music 3 (CUDA only)', ready: false,
+        runtimeReady: true, modelReady: false, fixedModelInstall: true,
+        cudaRequired: true, cudaState: 'available', customModels: false,
+        models: [{ id: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', name: 'MiniMax Music 3' }],
+        defaultModelId: 'minimax-music3',
+      })],
+    });
+
+    render(<MusicGenPanel prompt="cinematic score" lyrics="" />);
+
+    expect(await screen.findByText(/model weights are not installed yet/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /install model/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /install runtime/i })).not.toBeInTheDocument();
+  });
 });

--- a/client/src/components/music/QuickMusicGenerator.jsx
+++ b/client/src/components/music/QuickMusicGenerator.jsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import MusicGenPanel from './MusicGenPanel';
+
+export default function QuickMusicGenerator() {
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [lyrics, setLyrics] = useState('');
+
+  return (
+    <section className="max-w-4xl space-y-4">
+      <div>
+        <h2 className="text-lg font-semibold text-white">Generate a tune</h2>
+        <p className="text-sm text-gray-400">Start with an idea. Artist and album are optional and can be added later.</p>
+      </div>
+      <label htmlFor="quick-music-title" className="block">
+        <span className="mb-1 block text-xs uppercase tracking-wider text-gray-500">Title (optional)</span>
+        <input
+          id="quick-music-title"
+          value={title}
+          onChange={(event) => setTitle(event.target.value)}
+          maxLength={200}
+          placeholder="Derived from the prompt if left blank"
+          className="w-full rounded border border-port-border bg-port-bg px-3 py-2 text-sm text-white"
+        />
+      </label>
+      <label htmlFor="quick-music-prompt" className="block">
+        <span className="mb-1 block text-xs uppercase tracking-wider text-gray-500">Music description</span>
+        <textarea
+          id="quick-music-prompt"
+          value={prompt}
+          onChange={(event) => setPrompt(event.target.value)}
+          rows={3}
+          maxLength={8000}
+          placeholder="Warm instrumental soul, relaxed pocket, Rhodes piano, 92 BPM…"
+          className="w-full rounded border border-port-border bg-port-bg px-3 py-2 text-sm text-white"
+        />
+      </label>
+      <label htmlFor="quick-music-lyrics" className="block">
+        <span className="mb-1 block text-xs uppercase tracking-wider text-gray-500">Lyrics (optional)</span>
+        <textarea
+          id="quick-music-lyrics"
+          value={lyrics}
+          onChange={(event) => setLyrics(event.target.value)}
+          rows={6}
+          maxLength={20000}
+          placeholder={'[verse]\n…\n[chorus]\n…'}
+          className="w-full rounded border border-port-border bg-port-bg px-3 py-2 font-mono text-sm text-white"
+        />
+      </label>
+      <MusicGenPanel
+        title={title}
+        prompt={prompt}
+        lyrics={lyrics}
+        onGenerated={(track) => navigate(`/music/tracks/${encodeURIComponent(track.id)}`)}
+      />
+    </section>
+  );
+}

--- a/client/src/components/music/TracksManager.jsx
+++ b/client/src/components/music/TracksManager.jsx
@@ -452,12 +452,8 @@ export default function TracksManager() {
                   (MusicGen/AudioLDM2/ACE-Step) and the LLM-composed looping
                   chiptune score (#2911).
 
-                  The mode TOGGLE renders even before the track is saved: mode
-                  is pure local state and needs no track id, and hiding it left
-                  a brand-new track showing no sign either generator existed
-                  (#3264). The PANELS stay gated on `persisted` — the server
-                  attaches audio + gen metadata to a saved id — but the gate now
-                  explains itself instead of rendering an empty region. */}
+                  Audio-model generation can create a standalone track directly;
+                  chiptune composition still needs a persisted score record. */}
               <div className="space-y-2">
                 <div className="inline-flex rounded-lg border border-port-border overflow-hidden text-sm" role="group" aria-label="Generation mode">
                   {[['audio', 'Audio model'], ['chiptune', 'Chiptune score']].map(([mode, label]) => (
@@ -472,9 +468,9 @@ export default function TracksManager() {
                     </button>
                   ))}
                 </div>
-                {!persisted ? (
+                {!persisted && genMode === 'chiptune' ? (
                   <p className="text-xs text-gray-500">
-                    Save the track first, then generate {genMode === 'chiptune' ? 'a chiptune score' : 'with an audio model'}.
+                    Save the track first, then generate a chiptune score.
                   </p>
                 ) : genMode === 'chiptune' ? (
                   <ChiptunePanel
@@ -490,11 +486,21 @@ export default function TracksManager() {
                 ) : (
                   <MusicGenPanel
                     track={persisted}
+                    title={form.title}
+                    artistId={form.artistId}
+                    artist={form.artist}
+                    albumId={form.albumId}
                     prompt={form.prompt}
                     lyrics={form.lyrics}
                     remix={remix}
                     onGenerated={(updated) => {
                       upsertLocal(updated); // list update is id-keyed → always safe
+                      if (!persisted) {
+                        justCreatedIdRef.current = updated.id;
+                        setForm((f) => ({ ...f, audioFilename: updated.audioFilename || '' }));
+                        navigate(`/music/tracks/${encodeURIComponent(updated.id)}`);
+                        return;
+                      }
                       // Merge ONLY the server-set generation fields into the open
                       // form (the active audio pointer mirrors onto the form) so any
                       // UNSAVED edits the user made to title/artist/album/prompt/

--- a/client/src/components/music/TracksManager.test.jsx
+++ b/client/src/components/music/TracksManager.test.jsx
@@ -96,16 +96,14 @@ describe('<TracksManager> generator mode toggle', () => {
 
   const modeButton = (name) => screen.getByRole('button', { name });
 
-  it('shows the toggle on an unsaved track, with a hint instead of a panel', async () => {
+  it('shows audio generation on an unsaved track while keeping chiptune gated', async () => {
     renderAt('new');
     await screen.findByRole('group', { name: /generation mode/i });
 
     expect(modeButton('Audio model')).toBeInTheDocument();
     expect(modeButton('Chiptune score')).toBeInTheDocument();
-    // Gating generation on a saved track is correct and stays — but it must
-    // explain itself rather than render an empty region.
-    expect(screen.getByText(/Save the track first, then generate with an audio model/i)).toBeInTheDocument();
-    expect(screen.queryByTestId('gen-panel')).toBeNull();
+    expect(screen.getByTestId('gen-panel')).toBeInTheDocument();
+    expect(screen.queryByText(/Save the track first, then generate with an audio model/i)).toBeNull();
     expect(screen.queryByTestId('chiptune-panel')).toBeNull();
     // The renders block's own hint no longer claims to cover generation, so an
     // unsaved track doesn't show two near-identical "save first" sentences.

--- a/client/src/pages/Music.jsx
+++ b/client/src/pages/Music.jsx
@@ -11,13 +11,15 @@
  */
 
 import { useParams, useNavigate, Navigate } from 'react-router';
-import { Music as MusicIcon, Mic, Disc3, AudioLines } from 'lucide-react';
+import { Music as MusicIcon, Mic, Disc3, AudioLines, Wand2 } from 'lucide-react';
 import ArtistsManager from '../components/music/ArtistsManager';
 import AlbumsManager from '../components/music/AlbumsManager';
 import TracksManager from '../components/music/TracksManager';
+import QuickMusicGenerator from '../components/music/QuickMusicGenerator';
 import TabPills from '../components/ui/TabPills';
 
 const TABS = [
+  { id: 'generate', label: 'Generate', icon: Wand2 },
   { id: 'artists', label: 'Artists', icon: Mic },
   { id: 'albums', label: 'Albums', icon: Disc3 },
   { id: 'tracks', label: 'Tracks', icon: AudioLines },
@@ -28,9 +30,9 @@ const VALID = new Set(TABS.map((t) => t.id));
 export default function Music() {
   const { tab } = useParams();
   const navigate = useNavigate();
-  const active = tab || 'artists';
+  const active = tab || 'generate';
   // Unknown tab → redirect to the default rather than render an empty shell.
-  if (!VALID.has(active)) return <Navigate to="/music/artists" replace />;
+  if (!VALID.has(active)) return <Navigate to="/music/generate" replace />;
 
   return (
     <div>
@@ -50,6 +52,7 @@ export default function Music() {
         className="mb-6"
       />
 
+      {active === 'generate' && <QuickMusicGenerator />}
       {active === 'artists' && <ArtistsManager />}
       {active === 'albums' && <AlbumsManager />}
       {active === 'tracks' && <TracksManager />}

--- a/client/src/pages/Music.test.jsx
+++ b/client/src/pages/Music.test.jsx
@@ -9,6 +9,7 @@ import { afterEach } from 'vitest';
 vi.mock('../components/music/ArtistsManager', () => ({ default: () => <div data-testid="artists-manager" /> }));
 vi.mock('../components/music/AlbumsManager', () => ({ default: () => <div data-testid="albums-manager" /> }));
 vi.mock('../components/music/TracksManager', () => ({ default: () => <div data-testid="tracks-manager" /> }));
+vi.mock('../components/music/QuickMusicGenerator', () => ({ default: () => <div data-testid="quick-generator" /> }));
 
 import Music from './Music.jsx';
 
@@ -42,16 +43,16 @@ describe('<Music>', () => {
     expect(screen.queryByTestId('tracks-manager')).toBeNull();
   });
 
-  it('defaults bare /music to the artists tab', () => {
+  it('defaults bare /music to quick generation', () => {
     renderAt('/music');
-    expect(screen.getByTestId('artists-manager')).toBeInTheDocument();
+    expect(screen.getByTestId('quick-generator')).toBeInTheDocument();
     expect(screen.queryByTestId('albums-manager')).toBeNull();
   });
 
   it('redirects an unknown tab param to /music/artists', () => {
     renderAt('/music/bogus');
-    expect(screen.getByTestId('location')).toHaveTextContent('/music/artists');
-    expect(screen.getByTestId('artists-manager')).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent('/music/generate');
+    expect(screen.getByTestId('quick-generator')).toBeInTheDocument();
   });
 
   it('clicking a TabPill navigates the URL to the matching tab route', () => {

--- a/server/routes/music.js
+++ b/server/routes/music.js
@@ -45,27 +45,30 @@ router.get('/engines', asyncHandler(async (_req, res) => {
   const cuda = await getCudaCapability();
   const engines = await Promise.all(Object.values(ENGINES).map(async (engine) => {
     const modelCache = engine.fixedModelInstall ? await inspectModelCache(engine.models[0].repo).catch(() => ({ cached: false })) : null;
+    const runtimeReady = isEngineReady(engine.id);
     return ({
-    id: engine.id,
-    name: engine.name,
-    models: await listEngineModels(engine.id),
-    defaultModelId: engine.defaultModelId,
-    minDurationSec: engine.minDurationSec,
-    maxDurationSec: engine.maxDurationSec,
-    defaultDurationSec: engine.defaultDurationSec,
-    lyrics: engine.lyrics === true,
-    // Whether this engine can render an arbitrary HuggingFace checkpoint (gates
-    // the "install/select model" UI). ACE-Step resolves a single foundation
-    // checkpoint via checkpoint_dir, so custom repos don't apply to it.
-    customModels: engine.customModels === true,
-    fixedModelInstall: engine.fixedModelInstall === true,
-    modelReady: modelCache ? modelCache.cached === true : true,
-    cudaRequired: engine.cudaRequired === true,
-    cudaState: engine.cudaRequired ? cuda.state : 'available',
-    ready: isEngineReady(engine.id) && (!engine.cudaRequired || cuda.state === 'available') && (!modelCache || modelCache.cached === true),
-    installEnv: engine.installEnv,
-    venvDefault: engine.venvDefault,
-  }); }));
+      id: engine.id,
+      name: engine.name,
+      models: await listEngineModels(engine.id),
+      defaultModelId: engine.defaultModelId,
+      minDurationSec: engine.minDurationSec,
+      maxDurationSec: engine.maxDurationSec,
+      defaultDurationSec: engine.defaultDurationSec,
+      lyrics: engine.lyrics === true,
+      // Whether this engine can render an arbitrary HuggingFace checkpoint (gates
+      // the "install/select model" UI). ACE-Step resolves a single foundation
+      // checkpoint via checkpoint_dir, so custom repos don't apply to it.
+      customModels: engine.customModels === true,
+      fixedModelInstall: engine.fixedModelInstall === true,
+      modelReady: modelCache ? modelCache.cached === true : true,
+      runtimeReady,
+      cudaRequired: engine.cudaRequired === true,
+      cudaState: engine.cudaRequired ? cuda.status : 'available',
+      ready: runtimeReady && (!engine.cudaRequired || cuda.status === 'available') && (!modelCache || modelCache.cached === true),
+      installEnv: engine.installEnv,
+      venvDefault: engine.venvDefault,
+    });
+  }));
   res.json({ engines, defaultEngine: DEFAULT_ENGINE_ID });
 }));
 
@@ -111,8 +114,8 @@ router.get('/setup/runtime-install', asyncHandler(async (req, res) => {
   }
   if (engine.cudaRequired) {
     const cuda = await getCudaCapability();
-    if (cuda.state !== 'available') {
-      send({ type: 'error', message: cuda.state === 'unknown'
+    if (cuda.status !== 'available') {
+      send({ type: 'error', message: cuda.status === 'unknown'
         ? `${engine.name} cannot be installed because CUDA availability could not be determined.`
         : `${engine.name} requires an NVIDIA CUDA GPU and cannot be installed on this host.` });
       return safeEnd();

--- a/server/routes/music.test.js
+++ b/server/routes/music.test.js
@@ -11,10 +11,15 @@ const gen = vi.hoisted(() => ({
   ready: true,
   readyByEngine: null,
 }));
+const cuda = vi.hoisted(() => ({ status: 'available' }));
+vi.mock('../lib/cudaCapability.js', () => ({
+  getCudaCapability: vi.fn(async () => ({ status: cuda.status, gpus: [], maxVramGb: null, error: null })),
+}));
 vi.mock('../services/pipeline/musicGen.js', () => {
   const ENGINES = {
     musicgen: { id: 'musicgen', name: 'MusicGen', models: [{ id: 'm', name: 'M' }], defaultModelId: 'm', minDurationSec: 1, maxDurationSec: 30, defaultDurationSec: 12, installEnv: 'INSTALL_MUSICGEN', venvDefault: '/v/mg', resolvePython: () => (gen.ready ? '/v/mg/bin/python3' : null), customModels: true },
     acestep: { id: 'acestep', name: 'ACE-Step', models: [{ id: 'a', name: 'A' }], defaultModelId: 'a', minDurationSec: 1, maxDurationSec: 240, defaultDurationSec: 60, installEnv: 'INSTALL_ACESTEP', venvDefault: '/v/ace', resolvePython: () => (gen.ready ? '/v/ace/bin/python3' : null), lyrics: true, customModels: false },
+    'minimax-music3': { id: 'minimax-music3', name: 'MiniMax Music 3', models: [{ id: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', name: 'MiniMax Music 3' }], defaultModelId: 'minimax-music3', minDurationSec: 1, maxDurationSec: 300, defaultDurationSec: 60, installEnv: 'INSTALL_MINIMAX_MUSIC3', venvDefault: '/v/minimax', resolvePython: () => (gen.ready ? '/v/minimax/bin/python3' : null), lyrics: true, customModels: false, fixedModelInstall: true, cudaRequired: true },
   };
   return {
     ENGINES,
@@ -104,6 +109,7 @@ describe('music routes', () => {
     gen.ready = true;
     gen.readyByEngine = null;
     cache.cached = true;
+    cuda.status = 'available';
     models.list.mockResolvedValue([{ id: 'm', name: 'M', userAdded: false }]);
   });
 
@@ -127,6 +133,20 @@ describe('music routes', () => {
     expect(r.status).toBe(200);
     expect(r.body.engines.find((e) => e.id === 'musicgen').ready).toBe(true);
     expect(r.body.engines.find((e) => e.id === 'acestep').ready).toBe(false);
+  });
+
+  it('GET /engines uses the CUDA capability status to expose installable MiniMax readiness', async () => {
+    cache.cached = false;
+    const supported = await request(app).get('/api/music/engines');
+    expect(supported.body.engines.find((e) => e.id === 'minimax-music3')).toMatchObject({
+      cudaState: 'available', fixedModelInstall: true, modelReady: false, runtimeReady: true, ready: false,
+    });
+
+    cuda.status = 'absent';
+    const unsupported = await request(app).get('/api/music/engines');
+    expect(unsupported.body.engines.find((e) => e.id === 'minimax-music3')).toMatchObject({
+      cudaState: 'absent', ready: false,
+    });
   });
 
   it('POST /models rejects an engine that does not support custom models (acestep)', async () => {

--- a/server/services/pipeline/musicGen.js
+++ b/server/services/pipeline/musicGen.js
@@ -299,9 +299,9 @@ export async function generateMusic({ prompt, lyrics, engine: engineId = DEFAULT
   const pythonPath = engine.resolvePython();
   if (engine.cudaRequired) {
     const cuda = await getCudaCapability();
-    if (cuda.state !== 'available') {
+    if (cuda.status !== 'available') {
       throw new ServerError(
-        cuda.state === 'unknown' ? 'CUDA availability could not be determined.' : `${engine.name} requires an NVIDIA CUDA GPU.`,
+        cuda.status === 'unknown' ? 'CUDA availability could not be determined.' : `${engine.name} requires an NVIDIA CUDA GPU.`,
         { status: 503, code: 'PIPELINE_MUSIC_CUDA_REQUIRED' },
       );
     }


### PR DESCRIPTION
## Summary
- make Music open on a standalone Generate tab where title, artist, and album are optional
- allow audio-model generation from an unsaved track draft, creating the track automatically on success
- fix MiniMax CUDA detection by consuming the shared probe's `status` field
- expose separate runtime/model readiness and show only the missing in-UI install actions

## Test plan
- `npm test --prefix server -- --run routes/music.test.js services/pipeline/musicGen.test.js` (63 passed)
- `npm test --prefix client -- --run src/pages/Music.test.jsx src/components/music/MusicGenPanel.test.jsx src/components/music/TracksManager.test.jsx` (20 passed)
- final focused rerun: 25 route tests + 6 MusicGenPanel tests passed
- `git diff --check`

## Note
The in-app browser smoke test was unavailable because the desktop browser runtime could not access its required AppData path; component coverage pins the new route, direct-create, CUDA, and setup-action behavior.
