### PR TITLE
fix(ai-providers): silence duplicate error toast on prompt run failure

### DIFF
--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -196,7 +196,7 @@ export default function AIProviders() {
       prompt: runPrompt,
       workspacePath: workspace?.repoPath,
       workspaceName: workspace?.name
-    }).catch(err => ({ error: err.message }));
+    }, { silent: true }).catch(err => ({ error: err.message }));
 
     if (result.error) {
       setRunOutput(`Error: ${result.error}`);

--- a/client/src/services/apiRuns.js
+++ b/client/src/services/apiRuns.js
@@ -3,9 +3,10 @@ import { request } from './apiCore.js';
 // Runs
 export const getRuns = (limit = 50, offset = 0, source = 'all') =>
   request(`/runs?limit=${limit}&offset=${offset}&source=${source}`);
-export const createRun = (data) => request('/runs', {
+export const createRun = (data, options) => request('/runs', {
   method: 'POST',
-  body: JSON.stringify(data)
+  body: JSON.stringify(data),
+  ...options
 });
 export const getRun = (id) => request(`/runs/${id}`);
 // These endpoints deliberately return text/plain. A model response can itself


### PR DESCRIPTION
## Summary
- `handleExecuteRun` in `AIProviders.jsx` already surfaces prompt-run failures inline via `setRunOutput`, but `api.createRun`'s shared `request()` helper also toasted the same error — a failed run showed the error twice.
- Threads an `options` param through `apiRuns.js`'s `createRun` so callers can opt out of the shared toast via `{ silent: true }`.

Fixes #4033

## Test plan
- [ ] Trigger a prompt run that fails (e.g. invalid workspace) in AI Providers and confirm only one error surfaces (inline output, no toast).
- [ ] Confirm other `createRun` callers (without `options`) still toast on failure as before.