### PR TITLE
refactor(issue-4028): dedupe capitalize helper into shared formatters

### DIFF
--- a/.changelog/next/changed-issue-4028.md
+++ b/.changelog/next/changed-issue-4028.md
@@ -1,0 +1,1 @@
+- Deduplicated the repeated capitalize() helper in clinicianReport and tabNotation into the shared formatters module

--- a/client/src/lib/clinicianReport.js
+++ b/client/src/lib/clinicianReport.js
@@ -8,7 +8,7 @@
  */
 
 import { REFERENCE_RANGES, getBloodValueStatus } from '../components/meatspace/constants.js';
-import { formatDateTime } from '../utils/formatters';
+import { formatDateTime, capitalize } from '../utils/formatters';
 
 // Blood-marker category grouping — canonical source for the marker→category map.
 // BloodTestCard imports getCategoryForKey from here so the on-screen tab grouping
@@ -131,10 +131,6 @@ export function buildLifestyleModel(config) {
     rows.push({ label: 'Chronic conditions', value: conditions.join(', ') });
   }
   return rows;
-}
-
-function capitalize(s) {
-  return typeof s === 'string' && s.length ? s[0].toUpperCase() + s.slice(1) : s;
 }
 
 /**

--- a/client/src/lib/tabNotation.js
+++ b/client/src/lib/tabNotation.js
@@ -30,6 +30,8 @@
 //                  values populate meta, renderers hide the raw line
 //   'text'       — everything else (incl. non-meta {directive} lines)
 
+import { capitalize } from '../utils/formatters.js';
+
 // ---------------------------------------------------------------------------
 // Chord tokens
 // ---------------------------------------------------------------------------
@@ -196,8 +198,6 @@ const BRACKET_SECTION_RE = /^\s*\[([^\]]+)\]\s*$/;
 const WORD_SECTION_RE =
   /^\s*(intro|verse|chorus|pre[- ]?chorus|bridge|outro|solo|interlude|instrumental|refrain|coda)(\s+\d+)?\s*:?\s*$/i;
 const META_ALIASES = { t: 'title', subtitle: 'artist', st: 'artist' };
-
-const capitalize = (s) => (s ? s[0].toUpperCase() + s.slice(1) : s);
 
 // Short ChordPro section codes → [start|end, kind].
 const CHORDPRO_SHORT = {

--- a/client/src/utils/formatters.js
+++ b/client/src/utils/formatters.js
@@ -666,3 +666,14 @@ export function clamp(n, min, max) {
   return Math.min(max, Math.max(min, n));
 }
 
+/**
+ * Capitalize the first character of a string, leaving the rest untouched
+ * (e.g. "female" → "Female"). Non-strings and empty strings pass through
+ * unchanged rather than throwing.
+ * @param {string} s
+ * @returns {string}
+ */
+export function capitalize(s) {
+  return typeof s === 'string' && s.length ? s[0].toUpperCase() + s.slice(1) : s;
+}
+


### PR DESCRIPTION
Closes #4028

## Summary
- `client/src/lib/clinicianReport.js` and `client/src/lib/tabNotation.js` each locally redefined a private `capitalize(s)` helper.
- Added a single canonical `capitalize` export to `client/src/utils/formatters.js` (matching the stricter, safer of the two original implementations: `typeof` guarded, so non-string/empty input passes through unchanged instead of throwing) and pointed both lib modules at it, deleting their local copies.

## Test plan
- `cd client && npx vitest run` — full suite: 617 files / 7391 tests passed
- `npx biome lint` on the three changed files: clean