### PR TITLE
fix(issue-4037): confirm before discarding unsaved TaskItem edits

### DIFF
--- a/.changelog/next/fixed-issue-4037.md
+++ b/.changelog/next/fixed-issue-4037.md
@@ -1,0 +1,1 @@
+- Canceling an in-progress task edit in Chief of Staff now asks for confirmation before discarding unsaved changes

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -199,8 +199,20 @@ export default function TaskItem({ task, isSystem, onRefresh, providers, duratio
     }
   };
 
+  // Discarding must actually revert the draft, not just hide it — without this,
+  // reopening Edit after a confirmed discard would show the just-discarded text
+  // again instead of the task's real values, since editData is otherwise only
+  // ever seeded once at mount.
   const handleConfirmDiscard = () => {
-    confirmDiscard(() => setEditing(false));
+    confirmDiscard(() => {
+      setEditData({
+        description: task.description,
+        context: task.metadata?.context || '',
+        model: task.metadata?.model || '',
+        provider: task.metadata?.provider || ''
+      });
+      setEditing(false);
+    });
   };
 
   const handleDelete = async () => {

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -81,6 +81,11 @@ export default function TaskItem({ task, isSystem, onRefresh, providers, duratio
   const [showBlockedModal, setShowBlockedModal] = useState(false);
   const [blockedReason, setBlockedReason] = useState('');
   const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
+  // Independent armed-state from the delete confirm above — a second instance
+  // of the same single-at-a-time hook, keyed on the same task id, gates
+  // discarding an in-progress edit (#4037) behind the same inline two-click-arm
+  // pattern rather than silently dropping the draft on Cancel.
+  const { isConfirming: isConfirmingDiscard, requestDelete: requestDiscardConfirm, cancelDelete: cancelDiscardConfirm, confirmDelete: confirmDiscard } = useConfirmDelete();
   const blockedInputRef = useRef(null);
 
   // Focus input when modal opens
@@ -175,6 +180,27 @@ export default function TaskItem({ task, isSystem, onRefresh, providers, duratio
     toast.success('Task updated');
     setEditing(false);
     onRefresh();
+  };
+
+  // Compares the draft against the same task fields editData was seeded from
+  // (see the useState initializer above) — true only when the user actually
+  // changed something, so an unmodified Cancel still discards with no friction.
+  const hasUnsavedEdits =
+    editData.description !== task.description ||
+    editData.context !== (task.metadata?.context || '') ||
+    editData.model !== (task.metadata?.model || '') ||
+    editData.provider !== (task.metadata?.provider || '');
+
+  const handleCancelEdit = () => {
+    if (hasUnsavedEdits) {
+      requestDiscardConfirm(task.id);
+    } else {
+      setEditing(false);
+    }
+  };
+
+  const handleConfirmDiscard = () => {
+    confirmDiscard(() => setEditing(false));
   };
 
   const handleDelete = async () => {
@@ -336,20 +362,31 @@ export default function TaskItem({ task, isSystem, onRefresh, providers, duratio
                   </select>
                 )}
               </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={handleSave}
-                  className="flex items-center gap-1 text-sm px-3 py-2 min-h-[40px] text-port-success hover:text-port-success/80 bg-port-success/10 hover:bg-port-success/20 rounded transition-colors"
-                >
-                  <Save size={14} aria-hidden="true" /> Save
-                </button>
-                <button
-                  onClick={() => setEditing(false)}
-                  className="flex items-center gap-1 text-sm px-3 py-2 min-h-[40px] text-gray-400 hover:text-white bg-port-bg hover:bg-port-border rounded transition-colors"
-                >
-                  <X size={14} aria-hidden="true" /> Cancel
-                </button>
-              </div>
+              {isConfirmingDiscard(task.id) ? (
+                <ConfirmButtonPair
+                  prompt="Discard unsaved changes?"
+                  confirmText="Discard"
+                  ariaLabel="Confirm discard task edits"
+                  tone="warning"
+                  onConfirm={handleConfirmDiscard}
+                  onCancel={cancelDiscardConfirm}
+                />
+              ) : (
+                <div className="flex gap-2">
+                  <button
+                    onClick={handleSave}
+                    className="flex items-center gap-1 text-sm px-3 py-2 min-h-[40px] text-port-success hover:text-port-success/80 bg-port-success/10 hover:bg-port-success/20 rounded transition-colors"
+                  >
+                    <Save size={14} aria-hidden="true" /> Save
+                  </button>
+                  <button
+                    onClick={handleCancelEdit}
+                    className="flex items-center gap-1 text-sm px-3 py-2 min-h-[40px] text-gray-400 hover:text-white bg-port-bg hover:bg-port-border rounded transition-colors"
+                  >
+                    <X size={14} aria-hidden="true" /> Cancel
+                  </button>
+                </div>
+              )}
             </div>
           ) : (
             <>

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -294,10 +294,10 @@ describe('TaskItem cancel-edit confirmation (#4037)', () => {
     expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
   });
 
-  it('shows the confirm row when only a non-description field (context) changed', () => {
-    // Pins hasUnsavedEdits' context/model/provider branches, not just description —
-    // a regression narrowing the comparison to description alone would still pass
-    // every other test in this block since they all edit description.
+  it('shows the confirm row when only the context field changed', () => {
+    // Pins hasUnsavedEdits' context branch specifically — a regression narrowing
+    // the comparison to description alone would still pass every other test in
+    // this block since they all edit description.
     render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
@@ -306,6 +306,30 @@ describe('TaskItem cancel-edit confirmation (#4037)', () => {
 
     expect(screen.getByRole('group', { name: 'Confirm discard task edits' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
+
+  it('shows the confirm row when only the model select changed', () => {
+    // Pins hasUnsavedEdits' model branch in isolation (provider left untouched).
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    const [, modelSelect] = screen.getAllByRole('combobox');
+    fireEvent.change(modelSelect, { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByRole('group', { name: 'Confirm discard task edits' })).toBeInTheDocument();
+  });
+
+  it('shows the confirm row when only the provider select changed', () => {
+    // Pins hasUnsavedEdits' provider branch.
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    const [providerSelect] = screen.getAllByRole('combobox');
+    fireEvent.change(providerSelect, { target: { value: '' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByRole('group', { name: 'Confirm discard task edits' })).toBeInTheDocument();
   });
 
   it('discards the draft on a second click confirming the discard', () => {

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -294,6 +294,20 @@ describe('TaskItem cancel-edit confirmation (#4037)', () => {
     expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
   });
 
+  it('shows the confirm row when only a non-description field (context) changed', () => {
+    // Pins hasUnsavedEdits' context/model/provider branches, not just description —
+    // a regression narrowing the comparison to description alone would still pass
+    // every other test in this block since they all edit description.
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    fireEvent.change(screen.getByPlaceholderText('Context'), { target: { value: 'New context note' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByRole('group', { name: 'Confirm discard task edits' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
+
   it('discards the draft on a second click confirming the discard', () => {
     render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
 

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -267,6 +267,58 @@ describe('TaskItem long-text clamping', () => {
   });
 });
 
+describe('TaskItem cancel-edit confirmation (#4037)', () => {
+  it('discards immediately when Cancel is clicked with no unsaved changes', () => {
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    // Back to the read-only view — no confirm row, no edit fields.
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('group', { name: 'Confirm discard task edits' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit task' })).toBeInTheDocument();
+  });
+
+  it('shows an inline confirm row instead of discarding when there are unsaved changes', () => {
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    fireEvent.change(screen.getByDisplayValue(task.description), { target: { value: 'Edited description' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    // Still editing — the draft field keeps the typed value, and a confirm row
+    // replaced the Save/Cancel pair instead of silently discarding it.
+    expect(screen.getByDisplayValue('Edited description')).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Confirm discard task edits' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Save' })).not.toBeInTheDocument();
+  });
+
+  it('discards the draft on a second click confirming the discard', () => {
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    fireEvent.change(screen.getByDisplayValue(task.description), { target: { value: 'Edited description' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+
+    expect(screen.queryByDisplayValue('Edited description')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit task' })).toBeInTheDocument();
+  });
+
+  it('returns to the edit fields when the discard confirm is itself canceled', () => {
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    fireEvent.change(screen.getByDisplayValue(task.description), { target: { value: 'Edited description' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.getByDisplayValue('Edited description')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument();
+  });
+});
+
 describe('TaskItem challenge resolve controls (#2471)', () => {
   const challenged = {
     id: 'sys-challenged',

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -306,6 +306,19 @@ describe('TaskItem cancel-edit confirmation (#4037)', () => {
     expect(screen.getByRole('button', { name: 'Edit task' })).toBeInTheDocument();
   });
 
+  it('reverts the draft, not just hides it, so reopening Edit does not resurrect the discarded text', () => {
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    fireEvent.change(screen.getByDisplayValue(task.description), { target: { value: 'Edited description' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Discard' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Edit task' }));
+    expect(screen.getByDisplayValue(task.description)).toBeInTheDocument();
+    expect(screen.queryByDisplayValue('Edited description')).not.toBeInTheDocument();
+  });
+
   it('returns to the edit fields when the discard confirm is itself canceled', () => {
     render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
 


### PR DESCRIPTION
## Summary
- Clicking Cancel while editing a Chief of Staff task with unsaved changes now arms the same inline two-click confirm row already used for Delete, instead of silently discarding the draft.
- Cancel with no unsaved changes still discards immediately, with no added friction.
- Confirming the discard actually reverts the draft (`editData`) back to the task's live values — previously it only hid the edit view, so reopening Edit resurrected the just-discarded text.

Closes #4037

## Test plan
- `cd client && npx vitest run src/components/cos/tabs/TaskItem.test.jsx` — 28 tests pass, including new coverage for: no-change immediate discard, confirm row on unsaved changes (description/context/model/provider fields individually), second-click discard, canceling the discard confirm itself, and draft reversion on discard.
- Manual: opened a pending task's edit form, changed the description, clicked Cancel, saw the inline "Discard unsaved changes?" row, clicked Discard, reopened Edit and confirmed the original description was shown (not the discarded draft).