### PR TITLE
fix: green the Windows CI suite (CRLF split + fixed-sleep peer-sync waits)

### DIFF
--- a/.changelog/next/fixed-issue-4088.md
+++ b/.changelog/next/fixed-issue-4088.md
@@ -1,0 +1,1 @@
+- Windows CI: the HuggingFace download helper test now splits Python output on CRLF, and the peer-sync subscribe tests wait on the real drain instead of a 10ms sleep.

--- a/scripts/hf_download_repo.test.js
+++ b/scripts/hf_download_repo.test.js
@@ -54,7 +54,10 @@ print(helper.incomplete_bytes("/tmp/portos-hf-cache-does-not-exist"))
 print(helper.format_bytes_stage(1, 1, 26843545600, 51506295440, "qwen3vl.safetensors"))
 print(helper.format_verify_stage(1, 1, "qwen3vl.safetensors"))
 `);
-    const [bytes, verify] = output.trim().split('\n');
+    // Python's print() emits CRLF on Windows, and `.trim()` only strips the ends
+    // of the whole payload — a bare split('\n') leaves a trailing \r on every
+    // line but the last, so the first assertion compared against 'STAGE:…\r'.
+    const [bytes, verify] = output.trim().split(/\r?\n/);
     expect(bytes).toBe('STAGE:bytes:1/1:26843545600/51506295440:qwen3vl.safetensors');
     expect(verify).toBe('STAGE:verify:1/1:qwen3vl.safetensors');
   });

--- a/server/services/sharing/peerSync.test.js
+++ b/server/services/sharing/peerSync.test.js
@@ -460,13 +460,17 @@ describe('peerSync', () => {
       vi.mocked(getUniverse).mockResolvedValue({ id: 'u1', name: 'Foo' });
       vi.mocked(peerFetch).mockResolvedValue({ ok: true, json: async () => ({ missingAssets: [] }) });
       await subscribePeer({ peerId: 'peer-a', recordKind: 'universe', recordId: 'u1' });
-      await new Promise((r) => setTimeout(r, 10));
+      // subscribePeer registers the fire-and-forget initial push BEFORE it
+      // resolves, so the drain is a deterministic barrier for it. A fixed 10ms
+      // sleep was not: on a contended Windows CI runner the push chain had not
+      // reached peerFetch yet and this asserted 0 > 0.
+      await __drainForTests();
       // First subscribe DID push.
       expect(vi.mocked(peerFetch).mock.calls.length).toBeGreaterThan(0);
       vi.mocked(peerFetch).mockClear();
       // Second subscribe is idempotent — no push should fire.
       const second = await subscribePeer({ peerId: 'peer-a', recordKind: 'universe', recordId: 'u1' });
-      await new Promise((r) => setTimeout(r, 10));
+      await __drainForTests();
       expect(second.created).toBe(false);
       expect(vi.mocked(peerFetch)).not.toHaveBeenCalled();
     });
@@ -495,9 +499,11 @@ describe('peerSync', () => {
         { peerId: 'peer-a', recordKind: 'universe', recordId: 'u1' },
         { adoptedFromReverse: true },
       );
-      // peerFetch may have been called for some other reason, but NOT
-      // synchronously from this code path. Allow a small wait to be sure.
-      await new Promise((r) => setTimeout(r, 10));
+      // peerFetch may have been called for some other reason, but NOT from
+      // this code path. Drain rather than sleep: a negative assertion has to
+      // outlast any push that WOULD have been scheduled, and the drain does
+      // that deterministically instead of betting on a 10ms budget.
+      await __drainForTests();
       expect(peerFetch).not.toHaveBeenCalled();
     });
   });
@@ -1199,9 +1205,11 @@ describe('peerSync', () => {
       // Create a sub with the initial push FAILING — leaves lastPushedAt=null.
       vi.mocked(peerFetch).mockResolvedValueOnce(null);
       await subscribePeer({ peerId: 'peer-a', recordKind: 'universe', recordId: 'u1' });
-      // Wait for the fire-and-forget initial push to settle so the
-      // persisted lastPushedAt is final before we re-check it.
-      await new Promise((r) => setTimeout(r, 10));
+      // Wait for the fire-and-forget initial push to settle so the persisted
+      // lastPushedAt is final before we re-check it. Deterministic drain, not a
+      // fixed sleep — the assertion below is a negative (lastPushedAt stayed
+      // null), which vi.waitFor cannot poll for.
+      await __drainForTests();
       const stale = await findPeerSubscription('peer-a', 'universe', 'u1');
       expect(stale.lastPushedAt).toBeNull();
       // Peer comes back — retry must succeed and stamp lastPushedAt.


### PR DESCRIPTION
## Summary

Greens the `Windows server unit tests` job, which was red on `main` behind two
Windows-only test failures. The job runs with `--bail=1`, so each failure hid
whatever came after it — the reason the issue described this as a chain.

**1. `scripts/hf_download_repo.test.js` — CRLF.** The test splits the Python
helper's two-line stdout on `'\n'`. Python's `print()` emits CRLF on Windows and
`.trim()` only strips the ends of the whole payload, so the first line kept a
trailing `\r` and the assertion compared `'STAGE:…safetensors\r'` against
`'STAGE:…safetensors'`. Now splits on `/\r?\n/`, matching the convention
`scripts/generate_minimax_h3.test.js` already uses. Platform-correct assertion,
not a platform skip.

**2. `server/services/sharing/peerSync.test.js` — fixed 10ms sleeps.** Three
tests waited on `setTimeout(r, 10)` for `subscribePeer`'s fire-and-forget initial
push. On a contended Windows runner the push chain had not reached `peerFetch`
inside that budget, producing `AssertionError: expected 0 to be greater than 0`
(this is what turned CI red on `676e957d`). `subscribePeer` registers the push in
the background-operation registry *before* it resolves, so the suite's existing
`__drainForTests()` is a deterministic barrier for it — and it is also the right
tool for the two negative assertions in that block, which have to outlast a push
that *would* have been scheduled. Same reasoning the file already documents at
its `forcePushRecord` test.

Also swept the class the issue flagged: the four remaining
`toHaveBeenCalledWith('/mock…')` assertions (all in
`services/cleanupAgentWorktree.test.js`) are **correct as written** — those paths
come back verbatim from the mocked agent metadata, not from a `join()` in the
source, so they need no change. The `icloudFile.test.js` case named in the issue
was already fixed on `main` with a `describe.skipIf(process.platform === 'win32')`.

## Verification

The issue notes the only way to enumerate what sits behind a `--bail=1` failure
is to run the suite on Windows. I did — the full `server` suite on Windows 11,
native, **without** `--bail`, so nothing is masked:

```
Test Files  1366 passed | 26 skipped (1392)
      Tests  28316 passed | 300 skipped (28616)
```

Zero failures. There is no remaining chain behind the two fixes — the same run
against `main` before them reproduced exactly these and nothing else.

Worth recording for the next person: a developer shell with `NODE_ENV` already
set to anything (e.g. `development`) makes ~1,450 server tests fail locally,
because vitest only defaults `NODE_ENV=test` when it is unset and
`isFileBackend()` keys on it — every PG/file store then tries to reach Postgres.
Run the suite with `NODE_ENV=test` explicitly. CI is unaffected (GitHub runners
do not set it).

## Test plan

- `cd server && NODE_ENV=test npx vitest run` on Windows — 1366 files / 28,316
  tests, all passing, no bail.
- `cd server && NODE_ENV=test npx vitest run ../scripts/hf_download_repo.test.js services/sharing/peerSync.test.js` — 255 passed (the hf tests are not skipped here: a Python interpreter resolves, so the CRLF path is genuinely exercised).
- CI on this PR: `Windows server unit tests` + `CI Gate` green.

## Follow-up filed

#4095 — on Windows, a read racing `atomicWrite`'s two-rename backup swap can
silently return the caller's *default* value (the destination genuinely does not
exist between the two renames, and `readJSONFileStrict` treats `ENOENT` as a
trustworthy "nothing here yet"). Surfaced as a one-off
`getOutboundCoverageForPeer` failure during an earlier, heavily contended
full-suite run. Left out of this PR deliberately: it is a behavior change to a
data-loss-critical helper, not a CI-green fix, and it deserves its own tests.

Closes #4088
