### PR TITLE
Retry Windows file locks so a read racing atomicWrite stops returning the caller's default

### DIFF
--- a/.changelog/next/fixed-issue-4095.md
+++ b/.changelog/next/fixed-issue-4095.md
@@ -1,0 +1,1 @@
+- Windows: a read racing atomicWrite's backup swap no longer returns the caller's default — both the rename and the read now retry a transient lock

--- a/server/lib/fileUtils.js
+++ b/server/lib/fileUtils.js
@@ -21,6 +21,24 @@ import { createFileWriteQueue } from './fileWriteQueue.js';
 export const execFileAsync = promisify(execFile);
 const IS_WIN = process.platform === 'win32';
 
+// Call-time platform probe. `IS_WIN` above is a module-load snapshot (fine for
+// the path-shape helper at the bottom of this file); the Windows retry paths
+// below read the platform on every call so a POSIX host never carries a stale
+// decision and so the retry behavior is exercisable in tests.
+const isWindows = () => process.platform === 'win32';
+
+// Windows-only retry knobs (#4095). A destination lock from a concurrent reader
+// or an AV scan clears in milliseconds, so a handful of short retries is enough
+// to avoid both the writer's destination-missing backup swap and the reader's
+// phantom "nothing here yet".
+const WIN_RETRY_ATTEMPTS = 5;
+const WIN_RETRY_DELAY_MS = 10;
+// rename(2) failures that mean "the destination is momentarily locked", not
+// "this rename can never work".
+const WIN_RENAME_LOCK_CODES = ['EPERM', 'EACCES', 'EEXIST'];
+// read failures with the same transient meaning on the reader side.
+const WIN_READ_LOCK_CODES = ['EPERM', 'EACCES', 'EBUSY'];
+
 // Cache __dirname calculation for services importing this module
 const __lib_filename = fileURLToPath(import.meta.url);
 const __lib_dirname = dirname(__lib_filename);
@@ -259,9 +277,23 @@ export async function atomicWrite(filePath, data) {
   // overwrite), but still fails with EPERM/EACCES if the destination is locked (AV scan,
   // concurrent reader). Fall back to a backup-swap so the original file is never lost.
   const replace = async () => {
-    const err = await rename(tmp, filePath).then(() => null, (e) => e);
+    let err = await rename(tmp, filePath).then(() => null, (e) => e);
+    // Retry the ATOMIC rename before resorting to the backup swap (#4095). The
+    // swap below renames the destination away and back, so for that instant the
+    // destination DOES NOT EXIST — a concurrent read lands on ENOENT and reads
+    // it as a trustworthy "nothing here yet", silently handing the caller its
+    // default instead of the file's real contents. A transient lock clears in
+    // milliseconds, so retrying keeps almost every write on the atomic path and
+    // never opens that window.
+    if (isWindows()) {
+      for (let attempt = 1; err && attempt < WIN_RETRY_ATTEMPTS && WIN_RENAME_LOCK_CODES.includes(err.code); attempt += 1) {
+        await sleep(WIN_RETRY_DELAY_MS);
+        err = await rename(tmp, filePath).then(() => null, (e) => e);
+        if (!err) console.log(`⚠️ atomicWrite rename succeeded after ${attempt} retry(s): ${basename(filePath)}`);
+      }
+    }
     if (!err) return;
-    if (process.platform === 'win32' && ['EPERM', 'EACCES', 'EEXIST'].includes(err.code)) {
+    if (isWindows() && WIN_RENAME_LOCK_CODES.includes(err.code)) {
       const bak = `${filePath}.${process.pid}.${Date.now()}.${randomUUID()}.bak`;
       const hadExisting = await rename(filePath, bak).then(() => true, (e) => {
         if (e.code === 'ENOENT') return false;
@@ -484,6 +516,60 @@ export async function readFileTail(path, maxBytes) {
 const PARSE_FAILED = Symbol('json-parse-failed');
 
 /**
+ * True when a `<filePath>.*.tmp` or `<filePath>.*.bak` sibling is on disk — the
+ * signature of an `atomicWrite` temp write or backup swap that is still in
+ * flight for THIS file. Non-throwing: an unreadable parent directory just means
+ * "no evidence of a swap".
+ *
+ * Only consulted on win32, and only after a read already failed with ENOENT, so
+ * the directory listing never lands on a POSIX read or on a successful read.
+ *
+ * @param {string} filePath
+ * @returns {Promise<boolean>}
+ */
+async function hasSwapSibling(filePath) {
+  const entries = await readdir(dirname(filePath)).catch(() => null);
+  if (!entries) return false;
+  const prefix = `${basename(filePath)}.`;
+  return entries.some((name) => name.startsWith(prefix) && (name.endsWith('.tmp') || name.endsWith('.bak')));
+}
+
+/**
+ * `readFile(filePath, 'utf-8')` with the Windows-only retries that keep a read
+ * racing `atomicWrite` from being mistaken for an empty/absent file (#4095).
+ *
+ * On POSIX this is a straight delegate — zero extra syscalls, zero delay.
+ *
+ * On win32 two transient failures are retried with a short backoff:
+ *   - EPERM/EACCES/EBUSY — the destination is momentarily locked (AV scan, the
+ *     writer's own open handle).
+ *   - ENOENT, but ONLY when `hasSwapSibling` shows a swap is in flight. A file
+ *     that was simply never written stays a zero-cost, silent "nothing here
+ *     yet": one failed read, no retry, no sleep.
+ *
+ * Rejects with the last error once the attempts are exhausted, so the caller's
+ * existing errno handling is unchanged.
+ *
+ * @param {string} filePath
+ * @returns {Promise<string>}
+ */
+async function readTextWithSwapRetry(filePath) {
+  if (!isWindows()) return readFile(filePath, 'utf-8');
+  for (let attempt = 0; ; attempt += 1) {
+    const outcome = await readFile(filePath, 'utf-8').then((content) => ({ content }), (err) => ({ err }));
+    if (!outcome.err) {
+      if (attempt > 0) console.log(`⚠️ read succeeded after ${attempt} retry(s) — write swap in flight: ${basename(filePath)}`);
+      return outcome.content;
+    }
+    const last = attempt >= WIN_RETRY_ATTEMPTS - 1;
+    const retriable = WIN_READ_LOCK_CODES.includes(outcome.err.code)
+      || (outcome.err.code === 'ENOENT' && !last && await hasSwapSibling(filePath));
+    if (last || !retriable) throw outcome.err;
+    await sleep(WIN_RETRY_DELAY_MS);
+  }
+}
+
+/**
  * Read a JSON file, reporting whether the read is TRUSTWORTHY rather than
  * collapsing every failure into the default (the `readJSONFile` behavior below).
  *
@@ -519,9 +605,11 @@ const PARSE_FAILED = Symbol('json-parse-failed');
 export async function readJSONFileStrict(filePath, defaultValue = null, { allowArray = true, logError = true } = {}) {
   let content;
   try {
-    content = await readFile(filePath, 'utf-8');
+    content = await readTextWithSwapRetry(filePath);
   } catch (err) {
     // ENOENT = file doesn't exist → a trustworthy "nothing here yet", silently.
+    // On win32 an ENOENT that was really an `atomicWrite` swap window has
+    // already been retried above, so reaching here means genuinely absent.
     if (err.code === 'ENOENT') {
       return { ok: true, value: defaultValue };
     }

--- a/server/lib/fileUtils.js
+++ b/server/lib/fileUtils.js
@@ -524,14 +524,22 @@ const PARSE_FAILED = Symbol('json-parse-failed');
  * Only consulted on win32, and only after a read already failed with ENOENT, so
  * the directory listing never lands on a POSIX read or on a successful read.
  *
+ * Matching is case-INSENSITIVE: NTFS/FAT are case-insensitive, so the reader's
+ * `filePath` casing need not match the casing the writer used to create the
+ * file (and therefore the casing `readdir` reports). A case-sensitive compare
+ * would miss the sibling and let the phantom-empty through.
+ *
  * @param {string} filePath
  * @returns {Promise<boolean>}
  */
 async function hasSwapSibling(filePath) {
   const entries = await readdir(dirname(filePath)).catch(() => null);
   if (!entries) return false;
-  const prefix = `${basename(filePath)}.`;
-  return entries.some((name) => name.startsWith(prefix) && (name.endsWith('.tmp') || name.endsWith('.bak')));
+  const prefix = `${basename(filePath).toLowerCase()}.`;
+  return entries.some((entry) => {
+    const name = entry.toLowerCase();
+    return name.startsWith(prefix) && (name.endsWith('.tmp') || name.endsWith('.bak'));
+  });
 }
 
 /**

--- a/server/lib/fileUtils.js
+++ b/server/lib/fileUtils.js
@@ -516,13 +516,23 @@ export async function readFileTail(path, maxBytes) {
 const PARSE_FAILED = Symbol('json-parse-failed');
 
 /**
- * True when a `<filePath>.*.tmp` or `<filePath>.*.bak` sibling is on disk — the
- * signature of an `atomicWrite` temp write or backup swap that is still in
- * flight for THIS file. Non-throwing: an unreadable parent directory just means
- * "no evidence of a swap".
+ * True when a `<filePath>.*.bak` sibling is on disk — the signature of an
+ * `atomicWrite` backup swap that is mid-flight for THIS file, i.e. the only
+ * window in which the destination legitimately vanishes.
  *
- * Only consulted on win32, and only after a read already failed with ENOENT, so
- * the directory listing never lands on a POSIX read or on a successful read.
+ * Deliberately does NOT match `.tmp`: `atomicWrite` writes its temp file on
+ * EVERY write, including the first-ever create of a file that has no
+ * destination yet. Treating a `.tmp` sibling as evidence of a swap would turn a
+ * plain "not written yet" read into a retry that waits for the in-flight write
+ * and returns its brand-new contents — a different value than the read was
+ * entitled to, and a behavior change on POSIX-shaped callers. The `.bak` only
+ * exists between the swap's two renames.
+ *
+ * Non-throwing: an unreadable parent directory just means "no evidence of a
+ * swap". Only consulted on win32, and only after a read already failed with
+ * ENOENT, so the directory listing never lands on a POSIX read or a successful
+ * one. A `.bak` orphaned by a crash mid-swap costs the bounded retry budget
+ * (~50ms) on subsequent ENOENT reads of that path, never an incorrect answer.
  *
  * Matching is case-INSENSITIVE: NTFS/FAT are case-insensitive, so the reader's
  * `filePath` casing need not match the casing the writer used to create the
@@ -538,7 +548,7 @@ async function hasSwapSibling(filePath) {
   const prefix = `${basename(filePath).toLowerCase()}.`;
   return entries.some((entry) => {
     const name = entry.toLowerCase();
-    return name.startsWith(prefix) && (name.endsWith('.tmp') || name.endsWith('.bak'));
+    return name.startsWith(prefix) && name.endsWith('.bak');
   });
 }
 
@@ -551,9 +561,10 @@ async function hasSwapSibling(filePath) {
  * On win32 two transient failures are retried with a short backoff:
  *   - EPERM/EACCES/EBUSY — the destination is momentarily locked (AV scan, the
  *     writer's own open handle).
- *   - ENOENT, but ONLY when `hasSwapSibling` shows a swap is in flight. A file
- *     that was simply never written stays a zero-cost, silent "nothing here
- *     yet": one failed read, no retry, no sleep.
+ *   - ENOENT, but ONLY when `hasSwapSibling` shows a backup swap is mid-flight.
+ *     A file that was simply never written — or one whose first-ever write is
+ *     still in its temp stage — stays a silent "nothing here yet": one failed
+ *     read, no retry, no sleep.
  *
  * Rejects with the last error once the attempts are exhausted, so the caller's
  * existing errno handling is unchanged.

--- a/server/lib/fileUtils.test.js
+++ b/server/lib/fileUtils.test.js
@@ -66,6 +66,39 @@ import { fileURLToPath } from 'url';
 
 const __dirname_test = dirname(fileURLToPath(import.meta.url));
 
+// The unmocked fs/promises, used to restore the delegating mock implementations
+// after a test installs a persistent one.
+let realFsPromises;
+beforeAll(async () => {
+  realFsPromises = await vi.importActual('fs/promises');
+});
+
+const restoreFsMocks = () => {
+  for (const name of ['readFile', 'rename', 'readdir', 'mkdir']) {
+    fsPromises[name].mockReset();
+    fsPromises[name].mockImplementation((...args) => realFsPromises[name](...args));
+  }
+};
+
+/**
+ * Run `fn` with EVERY `readFile` attempt rejected by `err`, then restore the
+ * delegating mock.
+ *
+ * A single `mockRejectedValueOnce` is not enough since #4095: on win32
+ * `readJSONFileStrict` retries a transient lock, so the first attempt would
+ * consume the queued rejection and the retry would read the real file. A test
+ * pinning "an unreadable file is not an empty one" has to keep it unreadable —
+ * which is also the contract that actually survives the retries.
+ */
+async function withUnreadableFile(err, fn) {
+  fsPromises.readFile.mockImplementation(() => Promise.reject(err));
+  try {
+    return await fn();
+  } finally {
+    restoreFsMocks();
+  }
+}
+
 describe('fileUtils', () => {
   describe('isValidJSON', () => {
     it('should return true for valid JSON object', () => {
@@ -383,9 +416,8 @@ describe('fileUtils', () => {
     it('reports EACCES as NOT ok — an unreadable file is not an empty one', async () => {
       const filePath = join(testDir, 'locked.json');
       await writeFile(filePath, '{"sessions": [{"id": "s1"}]}');
-      fsPromises.readFile.mockRejectedValueOnce(eacces());
 
-      const result = await readJSONFileStrict(filePath, { sessions: [] });
+      const result = await withUnreadableFile(eacces(), () => readJSONFileStrict(filePath, { sessions: [] }));
       // `value` still carries the default so an ok-indifferent caller behaves as
       // before; `ok: false` is what makes the failure legible.
       expect(result).toEqual({ ok: false, value: { sessions: [] } });
@@ -435,8 +467,8 @@ describe('fileUtils', () => {
       // Both return the same `value`; only `ok` tells them apart — which is why the
       // parse sentinel can't be an in-band marker like null.
       expect(await readJSONFileStrict(filePath, { sessions: [] })).toEqual({ ok: true, value: { sessions: [] } });
-      fsPromises.readFile.mockRejectedValueOnce(eacces());
-      expect(await readJSONFileStrict(filePath, { sessions: [] })).toEqual({ ok: false, value: { sessions: [] } });
+      expect(await withUnreadableFile(eacces(), () => readJSONFileStrict(filePath, { sessions: [] })))
+        .toEqual({ ok: false, value: { sessions: [] } });
     });
 
     it('keeps readJSONFile’s noisy-output extraction for array defaults', async () => {
@@ -509,10 +541,10 @@ describe('fileUtils', () => {
     it('throws for an unreadable file instead of returning a fake empty', async () => {
       const filePath = join(testDir, 'locked.json');
       await writeFile(filePath, '{"sessions": []}');
-      fsPromises.readFile.mockRejectedValueOnce(Object.assign(new Error('permission denied'), { code: 'EACCES' }));
+      const eacces = Object.assign(new Error('permission denied'), { code: 'EACCES' });
 
-      await expect(readJSONFile(filePath, { sessions: [] }, { strict: true }))
-        .rejects.toThrow(/Unreadable JSON file/);
+      await withUnreadableFile(eacces, () => expect(readJSONFile(filePath, { sessions: [] }, { strict: true }))
+        .rejects.toThrow(/Unreadable JSON file/));
     });
 
     it('throws for corrupt JSON', async () => {
@@ -1282,7 +1314,6 @@ describe('Windows swap-window retries (#4095)', () => {
   const lockError = (code) => Object.assign(new Error(`${code}: simulated windows lock`), { code });
 
   let tmpRoot;
-  let realFs;
   let restorePlatform = null;
 
   const fakePlatform = (value) => {
@@ -1290,10 +1321,6 @@ describe('Windows swap-window retries (#4095)', () => {
     Object.defineProperty(process, 'platform', { value, configurable: true });
     restorePlatform = () => Object.defineProperty(process, 'platform', original);
   };
-
-  beforeAll(async () => {
-    realFs = await vi.importActual('fs/promises');
-  });
 
   beforeEach(() => {
     tmpRoot = mkdtempSync(join(tmpdir(), 'fileutils-winswap-'));
@@ -1309,12 +1336,7 @@ describe('Windows swap-window retries (#4095)', () => {
     restorePlatform = null;
     // Drop any unconsumed `*Once` queues AND re-establish the delegating
     // implementations the rest of this file relies on.
-    fsPromises.readFile.mockReset();
-    fsPromises.rename.mockReset();
-    fsPromises.readdir.mockReset();
-    fsPromises.readFile.mockImplementation((...args) => realFs.readFile(...args));
-    fsPromises.rename.mockImplementation((...args) => realFs.rename(...args));
-    fsPromises.readdir.mockImplementation((...args) => realFs.readdir(...args));
+    restoreFsMocks();
     rmSync(tmpRoot, { recursive: true, force: true });
   });
 
@@ -1396,11 +1418,24 @@ describe('Windows swap-window retries (#4095)', () => {
       writeFileSync(target, JSON.stringify({ real: true }));
       // The writer may have created the file (and therefore its swap debris)
       // under different casing than the reader's path — legal on Windows.
-      writeFileSync(join(tmpRoot, 'Casing.json.1234.5678.TMP'), 'partial');
+      writeFileSync(join(tmpRoot, 'Casing.json.1234.5678.BAK'), '{"real":true}');
       fakePlatform('win32');
       fsPromises.readFile.mockRejectedValueOnce(lockError('ENOENT'));
 
       expect(await readJSONFileStrict(target, { fallback: true })).toEqual({ ok: true, value: { real: true } });
+    });
+
+    it('does NOT treat a .tmp sibling as a swap — a first-ever write is not a vanished file', async () => {
+      // `atomicWrite` writes a `.tmp` on EVERY write, including the first create
+      // of a file that has no destination yet. Retrying on that would make a
+      // legitimate "not written yet" read block for the in-flight write and
+      // return its brand-new contents. Only the `.bak` marks the swap window.
+      const missing = join(tmpRoot, 'first-write.json');
+      writeFileSync(`${missing}.4321.8765.tmp`, '{"brand":"new"}');
+      fakePlatform('win32');
+
+      expect(await readJSONFileStrict(missing, { fallback: true })).toEqual({ ok: true, value: { fallback: true } });
+      expect(fsPromises.readFile).toHaveBeenCalledTimes(1);
     });
 
     it('does not retry a plain missing file on win32 — no sibling, no second read', async () => {

--- a/server/lib/fileUtils.test.js
+++ b/server/lib/fileUtils.test.js
@@ -1354,6 +1354,9 @@ describe('Windows swap-window retries (#4095)', () => {
     it('does not retry off win32 — a rename failure still surfaces immediately', async () => {
       const target = join(tmpRoot, 'posix.json');
       writeFileSync(target, JSON.stringify({ v: 1 }));
+      // Pinned explicitly, not inherited from the host — this suite also runs on
+      // a real Windows CI runner, where the un-faked platform IS win32.
+      fakePlatform('linux');
       fsPromises.rename.mockRejectedValueOnce(lockError('EPERM'));
 
       await expect(atomicWrite(target, { v: 2 })).rejects.toThrow(/EPERM/);
@@ -1410,6 +1413,7 @@ describe('Windows swap-window retries (#4095)', () => {
 
     it('costs a plain missing file nothing off win32 — one read, no directory scan', async () => {
       const missing = join(tmpRoot, 'never-written.json');
+      fakePlatform('linux');
 
       expect(await readJSONFileStrict(missing, { fallback: true })).toEqual({ ok: true, value: { fallback: true } });
       expect(fsPromises.readFile).toHaveBeenCalledTimes(1);
@@ -1419,6 +1423,7 @@ describe('Windows swap-window retries (#4095)', () => {
     it('does not retry a locked read off win32 — the read stays untrustworthy', async () => {
       const target = join(tmpRoot, 'posix-locked.json');
       writeFileSync(target, JSON.stringify({ real: true }));
+      fakePlatform('linux');
       fsPromises.readFile.mockRejectedValueOnce(lockError('EBUSY'));
 
       expect(await readJSONFileStrict(target, { fallback: true }, { logError: false }))

--- a/server/lib/fileUtils.test.js
+++ b/server/lib/fileUtils.test.js
@@ -1388,6 +1388,18 @@ describe('Windows swap-window retries (#4095)', () => {
       expect(fsPromises.readdir).toHaveBeenCalled();
     });
 
+    it('matches a swap sibling whose casing differs — NTFS/FAT are case-insensitive', async () => {
+      const target = join(tmpRoot, 'casing.json');
+      writeFileSync(target, JSON.stringify({ real: true }));
+      // The writer may have created the file (and therefore its swap debris)
+      // under different casing than the reader's path — legal on Windows.
+      writeFileSync(join(tmpRoot, 'Casing.json.1234.5678.TMP'), 'partial');
+      fakePlatform('win32');
+      fsPromises.readFile.mockRejectedValueOnce(lockError('ENOENT'));
+
+      expect(await readJSONFileStrict(target, { fallback: true })).toEqual({ ok: true, value: { real: true } });
+    });
+
     it('does not retry a plain missing file on win32 — no sibling, no second read', async () => {
       const missing = join(tmpRoot, 'never-written.json');
       fakePlatform('win32');

--- a/server/lib/fileUtils.test.js
+++ b/server/lib/fileUtils.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach, afterAll } from 'vitest';
 import { readFile, writeFile, rm, mkdir } from 'fs/promises';
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
@@ -11,12 +11,17 @@ import * as fsPromises from 'fs/promises';
 // no-op for root, which is how the container CI runs). Both default to delegating
 // to the real implementation (so every other test in this file is unaffected);
 // individual tests override with `mockRejectedValueOnce`.
+// `rename` and `readdir` are wrapped for the same reason (#4095): the Windows
+// swap-window retries key off transient EPERM/EACCES/EBUSY/ENOENT errnos that
+// cannot be provoked on a POSIX test host.
 vi.mock('fs/promises', async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
     mkdir: vi.fn((...args) => actual.mkdir(...args)),
     readFile: vi.fn((...args) => actual.readFile(...args)),
+    rename: vi.fn((...args) => actual.rename(...args)),
+    readdir: vi.fn((...args) => actual.readdir(...args)),
   };
 });
 import {
@@ -1258,6 +1263,156 @@ describe('fileUtils', () => {
         expect(JSON.parse(await readFile(backing, 'utf8'))).toEqual({ orig: true });
       }
     );
+  });
+});
+
+// =============================================================================
+// Windows swap-window retries (#4095)
+//
+// On win32 `atomicWrite`'s fallback backup swap renames the destination away and
+// back, so for an instant the file DOES NOT EXIST. A read landing in that window
+// used to get ENOENT and report it as a trustworthy "nothing here yet", handing
+// the caller its default instead of the real contents. These tests pin both
+// halves of the fix and that POSIX still pays nothing for it.
+// =============================================================================
+
+describe('Windows swap-window retries (#4095)', () => {
+  // Matches WIN_RETRY_ATTEMPTS in fileUtils.js.
+  const RETRY_ATTEMPTS = 5;
+  const lockError = (code) => Object.assign(new Error(`${code}: simulated windows lock`), { code });
+
+  let tmpRoot;
+  let realFs;
+  let restorePlatform = null;
+
+  const fakePlatform = (value) => {
+    const original = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', { value, configurable: true });
+    restorePlatform = () => Object.defineProperty(process, 'platform', original);
+  };
+
+  beforeAll(async () => {
+    realFs = await vi.importActual('fs/promises');
+  });
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'fileutils-winswap-'));
+    // Earlier describes in this file exercise the same fs mocks — start from a
+    // clean call log so the call-count assertions below mean what they say.
+    fsPromises.readFile.mockClear();
+    fsPromises.rename.mockClear();
+    fsPromises.readdir.mockClear();
+  });
+
+  afterEach(() => {
+    if (restorePlatform) restorePlatform();
+    restorePlatform = null;
+    // Drop any unconsumed `*Once` queues AND re-establish the delegating
+    // implementations the rest of this file relies on.
+    fsPromises.readFile.mockReset();
+    fsPromises.rename.mockReset();
+    fsPromises.readdir.mockReset();
+    fsPromises.readFile.mockImplementation((...args) => realFs.readFile(...args));
+    fsPromises.rename.mockImplementation((...args) => realFs.rename(...args));
+    fsPromises.readdir.mockImplementation((...args) => realFs.readdir(...args));
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  describe('atomicWrite', () => {
+    it('retries the atomic rename on a transient lock instead of opening the destination-missing window', async () => {
+      const target = join(tmpRoot, 'state.json');
+      writeFileSync(target, JSON.stringify({ v: 1 }));
+      fakePlatform('win32');
+      fsPromises.rename.mockRejectedValueOnce(lockError('EPERM'));
+
+      await atomicWrite(target, { v: 2 });
+
+      expect(JSON.parse(readFileSync(target, 'utf8'))).toEqual({ v: 2 });
+      // The backup swap is identified by a rename whose SOURCE is the
+      // destination itself (`rename(filePath, bak)`). The retry path must never
+      // move the destination aside — that is the window this fix closes.
+      const movedDestinationAside = fsPromises.rename.mock.calls.some(([from]) => from === target);
+      expect(movedDestinationAside).toBe(false);
+      expect(fsPromises.rename).toHaveBeenCalledTimes(2);
+    });
+
+    it('still falls back to the backup swap when every retry is refused', async () => {
+      const target = join(tmpRoot, 'stubborn.json');
+      writeFileSync(target, JSON.stringify({ v: 1 }));
+      fakePlatform('win32');
+      for (let i = 0; i < RETRY_ATTEMPTS; i += 1) fsPromises.rename.mockRejectedValueOnce(lockError('EPERM'));
+
+      await atomicWrite(target, { v: 2 });
+
+      expect(JSON.parse(readFileSync(target, 'utf8'))).toEqual({ v: 2 });
+      const movedDestinationAside = fsPromises.rename.mock.calls.some(([from]) => from === target);
+      expect(movedDestinationAside).toBe(true);
+      // …and the swap cleaned up after itself.
+      expect(readdirSync(tmpRoot).filter((n) => n.endsWith('.bak') || n.endsWith('.tmp'))).toEqual([]);
+    });
+
+    it('does not retry off win32 — a rename failure still surfaces immediately', async () => {
+      const target = join(tmpRoot, 'posix.json');
+      writeFileSync(target, JSON.stringify({ v: 1 }));
+      fsPromises.rename.mockRejectedValueOnce(lockError('EPERM'));
+
+      await expect(atomicWrite(target, { v: 2 })).rejects.toThrow(/EPERM/);
+
+      expect(fsPromises.rename).toHaveBeenCalledTimes(1);
+      // The original file is untouched and no temp debris is left behind.
+      expect(JSON.parse(readFileSync(target, 'utf8'))).toEqual({ v: 1 });
+      expect(readdirSync(tmpRoot)).toEqual(['posix.json']);
+    });
+  });
+
+  describe('readJSONFileStrict', () => {
+    it('retries a locked read on win32 and returns the real contents as trustworthy', async () => {
+      const target = join(tmpRoot, 'locked.json');
+      writeFileSync(target, JSON.stringify({ real: true }));
+      fakePlatform('win32');
+      fsPromises.readFile.mockRejectedValueOnce(lockError('EBUSY'));
+
+      expect(await readJSONFileStrict(target, { fallback: true })).toEqual({ ok: true, value: { real: true } });
+      expect(fsPromises.readFile).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries an ENOENT on win32 when a swap sibling shows a write is in flight', async () => {
+      const target = join(tmpRoot, 'swapping.json');
+      writeFileSync(target, JSON.stringify({ real: true }));
+      // The debris `atomicWrite` leaves visible while a swap is mid-flight.
+      writeFileSync(`${target}.1234.5678.bak`, '{"real":true}');
+      fakePlatform('win32');
+      fsPromises.readFile.mockRejectedValueOnce(lockError('ENOENT'));
+
+      expect(await readJSONFileStrict(target, { fallback: true })).toEqual({ ok: true, value: { real: true } });
+      expect(fsPromises.readdir).toHaveBeenCalled();
+    });
+
+    it('does not retry a plain missing file on win32 — no sibling, no second read', async () => {
+      const missing = join(tmpRoot, 'never-written.json');
+      fakePlatform('win32');
+
+      expect(await readJSONFileStrict(missing, { fallback: true })).toEqual({ ok: true, value: { fallback: true } });
+      expect(fsPromises.readFile).toHaveBeenCalledTimes(1);
+    });
+
+    it('costs a plain missing file nothing off win32 — one read, no directory scan', async () => {
+      const missing = join(tmpRoot, 'never-written.json');
+
+      expect(await readJSONFileStrict(missing, { fallback: true })).toEqual({ ok: true, value: { fallback: true } });
+      expect(fsPromises.readFile).toHaveBeenCalledTimes(1);
+      expect(fsPromises.readdir).not.toHaveBeenCalled();
+    });
+
+    it('does not retry a locked read off win32 — the read stays untrustworthy', async () => {
+      const target = join(tmpRoot, 'posix-locked.json');
+      writeFileSync(target, JSON.stringify({ real: true }));
+      fsPromises.readFile.mockRejectedValueOnce(lockError('EBUSY'));
+
+      expect(await readJSONFileStrict(target, { fallback: true }, { logError: false }))
+        .toEqual({ ok: false, value: { fallback: true } });
+      expect(fsPromises.readFile).toHaveBeenCalledTimes(1);
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

On Windows, `atomicWrite`'s fallback backup swap renames the destination away and back. Between those two renames the destination **does not exist**, so a concurrent `readJSONFileStrict` hit `ENOENT` and reported it as a trustworthy "nothing here yet" — silently handing the caller its *default* instead of the file's real contents. Every store that reads without holding the write lock could observe that phantom empty (e.g. `getOutboundCoverageForPeer` producing an empty snapshot exclude-set, which makes the source re-serve records the peer already gets by per-record push).

Both sides now retry briefly — 5 attempts, ~10ms apart — guarded to `process.platform === 'win32'` so POSIX is untouched and pays no extra syscalls:

- **`atomicWrite`** retries the atomic `rename(tmp, dest)` on `EPERM`/`EACCES`/`EEXIST` before resorting to the backup swap. A lock from a concurrent reader or an AV scan clears in milliseconds, so almost every write stays on the atomic path and the destination-missing window never opens. The backup swap is preserved as the last resort.
- **`readJSONFileStrict`** retries a locked read (`EPERM`/`EACCES`/`EBUSY`), and retries `ENOENT` **only** when a `<file>.*.bak` sibling shows a backup swap is mid-flight. A file that was simply never written still returns the default on the first read — no retry, no sleep. Sibling matching is case-insensitive, since NTFS/FAT are: the reader's path casing need not match the casing the writer used (and therefore what `readdir` reports).

The platform probe is a call-time function rather than the module-load `IS_WIN` snapshot, so the retry behavior is exercisable on a POSIX test host.

### Two deviations from the issue's wording, both deliberate

**The ENOENT probe matches `.bak` only, not `.tmp`.** The issue says "`<filePath>.*.tmp` or `<filePath>.*.bak`", but `atomicWrite` writes a `.tmp` on *every* write, including the first-ever create of a file that has no destination yet. Matching `.tmp` turns a legitimate "not written yet" read into a retry that waits for the in-flight write and returns its brand-new contents — a different value than the read was entitled to. This is not theoretical: with `process.platform` forced to `win32` across the whole server suite, it broke `brainJournal`'s "serializes obsidian syncs per date" (the settings read blocked on a concurrent first write). Only the `.bak` exists between the swap's two renames, so it is the precise signal. A `.bak` orphaned by a crash mid-swap costs the bounded ~50ms retry budget on later ENOENT reads of that path, never a wrong answer.

**"No extra `readdir`" on a plain missing file holds on POSIX, not win32.** The specified detection mechanism *is* a directory listing — the `.bak` name carries a pid/timestamp/uuid suffix, so there is no exact path to `access()`. On win32 an ENOENT read therefore costs one listing of the parent directory: bounded, non-throwing, and only reachable after a read has already failed. On POSIX the probe is unreachable and a missing file costs exactly one `readFile`, which the "costs a plain missing file nothing off win32" test pins.

## Test plan

- `cd server && NODE_ENV=test npx vitest run lib/fileUtils` — **197 passed**, including 9 new cases:
  - `atomicWrite` retries a transient `EPERM` and never moves the destination aside (no backup swap).
  - `atomicWrite` still falls back to the backup swap when all 5 retries are refused, and cleans up its `.bak`/`.tmp`.
  - `atomicWrite` does not retry off win32 — the failure still surfaces immediately, the original file is intact, no temp debris.
  - `readJSONFileStrict` retries a locked (`EBUSY`) read on win32 and returns the real contents with `ok: true`.
  - `readJSONFileStrict` retries `ENOENT` on win32 when a `.bak` sibling is present, and consults `readdir` to decide.
  - `readJSONFileStrict` matches a swap sibling whose casing differs from the read path.
  - `readJSONFileStrict` does **not** treat a `.tmp` sibling as a swap — a first-ever write is not a vanished file.
  - `readJSONFileStrict` does not retry a plain missing file on win32 (exactly one `readFile`).
  - `readJSONFileStrict` off win32: a plain missing file costs one `readFile` and zero `readdir`; a locked read still reports `ok: false`.
- **Bite check**: reverting `server/lib/fileUtils.js` to `origin/main` while keeping the new tests fails 4 of them (both `atomicWrite` cases and both win32 read-retry cases). Reverting only the `toLowerCase` pair in `hasSwapSibling` fails the casing case. The rest are POSIX / false-positive guards that pass either way by design.
- The three POSIX guard cases pin `process.platform` to a faked `linux` rather than inheriting the host, so they still assert something on the Windows CI runner (where the un-faked platform *is* `win32`).
- **Simulated Windows run**: with `Object.defineProperty(process, 'platform', { value: 'win32' })` prepended to `server/vitest.setup.js`, the full server suite fails only the 20 cases that also fail on `origin/main` under the same forcing (path/`.exe`/`which`/`tasklist` logic that genuinely needs a Windows host). That control run is what surfaced the `.tmp`-probe bug, and confirms nothing else regressed.
- Two pre-existing `readJSONFileStrict`/`readJSONFile` EACCES cases now reject on *every* attempt instead of once. A single `mockRejectedValueOnce` was consumed by the first attempt and the retry then read the real file, which is why the first push failed the Windows job. The contract they pin — a *persistently* unreadable file is not an empty one — holds on both platforms.
- `cd server && NODE_ENV=test npm test` — **1371 files passed, 26 skipped, 28459 tests passed, 0 failures**. The 26 skips are the `*.db.test.js` suites correctly refusing the non-test database; no DB-backed suite was run against the real `portos` DB.

Closes #4095
