### PR TITLE
refactor: hoist the pipeline severity palette to a shared manuscript constant (#4109)

### DIFF
--- a/.changelog/next/changed-issue-4109.md
+++ b/.changelog/next/changed-issue-4109.md
@@ -1,0 +1,1 @@
+- Pipeline severity styling (series review, autopilot, arc-canvas verification and completeness panels) now reads one shared palette instead of three duplicate inline copies, so a tweak can't land on one panel only.

--- a/client/src/components/pipeline/AutopilotPanel.jsx
+++ b/client/src/components/pipeline/AutopilotPanel.jsx
@@ -27,6 +27,7 @@ import Pill from '../ui/Pill';
 import ProviderModelSelector from '../ProviderModelSelector';
 import AutopilotMilestones from './AutopilotMilestones';
 import SeriesAutopilotSchedule from './SeriesAutopilotSchedule';
+import { severityColor } from './constants.js';
 
 // Convergence-round bounds — mirror the server (seriesAutopilot.js + the
 // pipelineEditorialChecks settings schema). 0 = skip that gate entirely.
@@ -266,12 +267,6 @@ function RoundInput({ id, label, settingKey, value, setValue, persist, max = ROU
   );
 }
 
-const SEVERITY_COLORS = {
-  high: 'text-port-error border-port-error/40 bg-port-error/10',
-  medium: 'text-port-warning border-port-warning/40 bg-port-warning/10',
-  low: 'text-gray-400 border-gray-500/30 bg-gray-700/20',
-};
-
 // Step labels are shared with the milestone map (lib/autopilotMilestones.js) so
 // the live status line and the map can't name the same step differently.
 const stepLabel = autopilotStepLabel;
@@ -477,7 +472,7 @@ function Findings({ items }) {
   return (
     <ul className="space-y-1.5 mt-2">
       {items.map((f, i) => (
-        <li key={i} className={`text-xs p-2 rounded border ${SEVERITY_COLORS[f.severity] || SEVERITY_COLORS.medium}`}>
+        <li key={i} className={`text-xs p-2 rounded border ${severityColor(f.severity)}`}>
           <div className="flex items-center gap-2">
             <AlertCircle size={12} />
             <span className="uppercase tracking-wider font-semibold">{f.severity || 'note'}</span>

--- a/client/src/components/pipeline/SeriesReviewPanel.jsx
+++ b/client/src/components/pipeline/SeriesReviewPanel.jsx
@@ -19,12 +19,7 @@ import {
   getPipelineSeries,
   listPipelineIssues,
 } from '../../services/api';
-
-const SEVERITY_STYLES = {
-  high: 'text-port-error border-port-error/40 bg-port-error/10',
-  medium: 'text-port-warning border-port-warning/40 bg-port-warning/10',
-  low: 'text-gray-400 border-gray-500/30 bg-gray-700/20',
-};
+import { severityColor } from './constants.js';
 
 const RUN_ENDED = new Set(['complete', 'canceled', 'error']);
 // The fix run's terminal frames: `rejected` = the cos gate/budget refused it.
@@ -425,7 +420,7 @@ export default function SeriesReviewPanel({ series, onSeriesUpdate, onIssuesUpda
                   </div>
                   <ul className="space-y-1">
                     {g.items.map((f) => (
-                      <li key={f.commentId} className={`p-2 rounded border ${SEVERITY_STYLES[f.severity] || SEVERITY_STYLES.medium}`}>
+                      <li key={f.commentId} className={`p-2 rounded border ${severityColor(f.severity)}`}>
                         <div className="flex items-center gap-2">
                           <AlertCircle size={11} />
                           <span className="uppercase tracking-wider font-semibold text-[10px]">{f.severity}</span>

--- a/client/src/components/pipeline/arcCanvas/CompletenessResults.jsx
+++ b/client/src/components/pipeline/arcCanvas/CompletenessResults.jsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { Link } from 'react-router';
 import { X, FileSearch, FileText } from 'lucide-react';
-import { SEVERITY_COLORS } from './shared.js';
+import { severityColor } from '../constants.js';
 
 // Human-readable labels for the manuscript-completeness categories.
 const COMPLETENESS_CATEGORY_LABELS = {
@@ -55,7 +55,7 @@ export default function CompletenessResults({ issues, onDismiss, seriesId }) {
             <span className="text-[11px] uppercase tracking-wider text-gray-500">{COMPLETENESS_CATEGORY_LABELS[cat]} ({list.length})</span>
             <ul className="space-y-1">
               {list.map((iss, i) => (
-                <li key={i} className={`text-xs p-2 rounded border ${SEVERITY_COLORS[iss.severity] || SEVERITY_COLORS.medium}`}>
+                <li key={i} className={`text-xs p-2 rounded border ${severityColor(iss.severity)}`}>
                   {iss.location ? <span className="font-medium">{iss.location}: </span> : null}
                   <span>{iss.problem}</span>
                   {iss.suggestion ? <p className="mt-1 text-gray-300"><span className="opacity-70">Suggestion: </span>{iss.suggestion}</p> : null}

--- a/client/src/components/pipeline/arcCanvas/VerifyResults.jsx
+++ b/client/src/components/pipeline/arcCanvas/VerifyResults.jsx
@@ -1,5 +1,5 @@
 import { AlertCircle, Wand2, Loader2, Lock } from 'lucide-react';
-import { SEVERITY_COLORS } from './shared.js';
+import { severityColor } from '../constants.js';
 
 export default function VerifyResults({ issues, onDismiss, onResolveAll, onResolveOne, resolvingAll, resolvingIdx, title = 'Verification', lockedNote = null }) {
   const busy = resolvingAll || (resolvingIdx && resolvingIdx.size > 0);
@@ -39,7 +39,7 @@ export default function VerifyResults({ issues, onDismiss, onResolveAll, onResol
         {issues.map((iss, i) => {
           const resolvingThis = resolvingIdx && resolvingIdx.has(i);
           return (
-            <li key={i} className={`text-xs p-2 rounded border ${SEVERITY_COLORS[iss.severity] || SEVERITY_COLORS.medium}`}>
+            <li key={i} className={`text-xs p-2 rounded border ${severityColor(iss.severity)}`}>
               <div className="flex items-center gap-2 mb-1">
                 <AlertCircle size={12} />
                 <span className="uppercase tracking-wider font-semibold">{iss.severity}</span>

--- a/client/src/components/pipeline/arcCanvas/shared.js
+++ b/client/src/components/pipeline/arcCanvas/shared.js
@@ -1,8 +1,0 @@
-// Shared design tokens for the Arc Canvas subtree. Severity → Tailwind class
-// map used by both verification panels (VerifyResults) and the manuscript-
-// completeness panel (CompletenessResults).
-export const SEVERITY_COLORS = {
-  high: 'text-port-error border-port-error/40 bg-port-error/10',
-  medium: 'text-port-warning border-port-warning/40 bg-port-warning/10',
-  low: 'text-gray-400 border-gray-500/30 bg-gray-700/20',
-};

--- a/client/src/components/pipeline/constants.js
+++ b/client/src/components/pipeline/constants.js
@@ -1,0 +1,30 @@
+/**
+ * Shared display constants for the Pipeline component subtree. Pure data —
+ * co-located with the pipeline components that render it.
+ */
+
+// Severity → Tailwind classes for a finding/issue card (text + border + fill).
+// One palette for every pipeline surface that lists severity-tagged findings:
+// the series review panel, the autopilot panel, and the arc-canvas verification
+// and manuscript-completeness panels. It used to be three byte-identical inline
+// copies (#4109); keep it here so a tweak can't land on one panel only.
+//
+// The class names are complete literal strings on purpose — Tailwind's build
+// scans source text, so a name assembled by interpolation is silently absent
+// from the bundle.
+export const SEVERITY_COLORS = {
+  high: 'text-port-error border-port-error/40 bg-port-error/10',
+  medium: 'text-port-warning border-port-warning/40 bg-port-warning/10',
+  low: 'text-gray-400 border-gray-500/30 bg-gray-700/20',
+};
+
+// Resolve a finding's severity to its card classes, defaulting to `medium` for
+// an absent or unrecognized value. Use this rather than a bare
+// `SEVERITY_COLORS[severity] || SEVERITY_COLORS.medium`: findings arrive from
+// LLM output and older peers, so a severity of `constructor` / `__proto__` /
+// `toString` would otherwise resolve to an inherited Object.prototype member —
+// truthy, so the `||` fallback wouldn't catch it, and it lands in a className.
+export const severityColor = (severity) =>
+  (Object.hasOwn(SEVERITY_COLORS, severity) && typeof SEVERITY_COLORS[severity] === 'string'
+    ? SEVERITY_COLORS[severity]
+    : SEVERITY_COLORS.medium);

--- a/client/src/components/pipeline/constants.test.js
+++ b/client/src/components/pipeline/constants.test.js
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describe, it, expect } from 'vitest';
+import { SEVERITY_COLORS, severityColor } from './constants.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+// Every pipeline surface that renders a severity-tagged finding card. These used
+// to carry three byte-identical inline copies of the palette (#4109); the guard
+// below fails if one of them grows a private copy again.
+const CONSUMERS = [
+  'SeriesReviewPanel.jsx',
+  'AutopilotPanel.jsx',
+  'arcCanvas/VerifyResults.jsx',
+  'arcCanvas/CompletenessResults.jsx',
+];
+
+const readConsumer = (rel) => readFileSync(join(HERE, rel), 'utf8');
+
+describe('pipeline severity palette', () => {
+  it('exposes complete literal Tailwind class strings per severity', () => {
+    // Literal, not interpolated — Tailwind scans source text, so an assembled
+    // class name is silently dropped from the bundle.
+    expect(SEVERITY_COLORS).toEqual({
+      high: 'text-port-error border-port-error/40 bg-port-error/10',
+      medium: 'text-port-warning border-port-warning/40 bg-port-warning/10',
+      low: 'text-gray-400 border-gray-500/30 bg-gray-700/20',
+    });
+    for (const classes of Object.values(SEVERITY_COLORS)) {
+      expect(classes).not.toMatch(/[`${}]/);
+    }
+  });
+
+  it('resolves each known severity to its palette entry', () => {
+    for (const [severity, classes] of Object.entries(SEVERITY_COLORS)) {
+      expect(severityColor(severity)).toBe(classes);
+    }
+  });
+
+  it('falls back to medium for absent, unknown, and prototype-key severities', () => {
+    for (const severity of [undefined, null, '', 'critical', '__proto__', 'constructor', 'toString', 'hasOwnProperty']) {
+      expect(severityColor(severity)).toBe(SEVERITY_COLORS.medium);
+    }
+  });
+
+  it.each(CONSUMERS)('%s renders the shared palette rather than a private copy', (rel) => {
+    const src = readConsumer(rel);
+    expect(src).toMatch(/import \{ severityColor \} from '\.{1,2}\/constants\.js'/);
+    expect(src).toContain('severityColor(');
+    // No local severity→class map, and no hand-inlined palette class strings.
+    expect(src).not.toMatch(/(SEVERITY_STYLES|SEVERITY_COLORS)\s*=\s*\{/);
+    expect(src).not.toContain(SEVERITY_COLORS.high);
+    expect(src).not.toContain(SEVERITY_COLORS.medium);
+    expect(src).not.toContain(SEVERITY_COLORS.low);
+  });
+});


### PR DESCRIPTION
## Summary

The `port-error`/`port-warning` severity → Tailwind class map was duplicated three times across the pipeline UI. This hoists it to one shared export and points every call site at it.

**Where the copies actually were** (the issue's file list was slightly off): `SEVERITY_STYLES` in `client/src/components/pipeline/SeriesReviewPanel.jsx`, `SEVERITY_COLORS` in `client/src/components/pipeline/AutopilotPanel.jsx`, and `client/src/components/pipeline/arcCanvas/shared.js` — the `ArcCanvas.jsx` copy had already been lifted into that subtree module, whose only export was the same map, read by `VerifyResults.jsx` and `CompletenessResults.jsx`. Three definitions, four call sites. **All three were byte-identical**, so nothing had to be reconciled and no component's rendering changes.

**New home: `client/src/components/pipeline/constants.js`**, not `pipeline/manuscript/constants.js` as the issue proposed. Three of the four consumers live outside `manuscript/`, so putting a pipeline-wide token there would have made `arcCanvas/` depend on `manuscript/`; `pipeline/` is the lowest common ancestor. A component-local `constants.js` is not one of the barrel/README-enforced directories (`client/src/lib`, `hooks`, `utils`, `services`), so no catalog entry is required — confirmed against those enforcement tests. `arcCanvas/shared.js` is deleted rather than left as a re-export shim, since the map was its only export.

Rolled into the same diff:

- **`severityColor(severity)` resolver.** All four call sites repeated the identical `MAP[sev] || MAP.medium` expression, so it moves into the shared module too. It uses an `Object.hasOwn` + `typeof === 'string'` guard rather than the bare `||`: findings arrive from LLM output and older peers, and a severity of `constructor` / `__proto__` / `toString` would otherwise resolve to an inherited `Object.prototype` member — truthy, so `||` wouldn't catch it, and it would land in a `className`. Same guard `subtypeLabel` already uses next door in `manuscript/constants.js`.
- **Tailwind safety.** The class names stay complete literal strings in the shared export (never assembled by interpolation), so the build's content scan still emits them. A test asserts that.
- **`SEVERITY_TONE` in `manuscript/constants.js` is deliberately left alone** — it is a different palette (`bg-port-error/15` badge pill vs `bg-port-error/10` card, `low` on `border-port-border`), not a fourth copy of this one.

## Test plan

- New `client/src/components/pipeline/constants.test.js`:
  - pins the exact literal class strings per severity and asserts none contain interpolation syntax (the Tailwind content-scan guard);
  - asserts `severityColor` resolves every known severity to its palette entry and falls back to `medium` for absent / unknown / prototype-key values;
  - **divergence guard** — reads all four consumer sources and fails if any imports something other than the shared `severityColor`, or regrows a local `SEVERITY_STYLES`/`SEVERITY_COLORS` map or a hand-inlined palette string.
- **Bypass probe**: re-inlined a private copy in `VerifyResults.jsx` and confirmed the guard fails (1 failed / 6 passed), then reverted — so the guard bites rather than passing vacuously.
- `cd client && npm test` → 620 files, 7427 tests, all passing.
- `cd client && npm run lint` → clean (1995 files).
- Server untouched, so no server suite run.

Closes #4109
