### PR TITLE
Dismiss Claude Code's auto-mode modal, and stop filing never-started runs as lint errors

### DIFF
--- a/.changelog/next/fixed-agent-12743ad5.md
+++ b/.changelog/next/fixed-agent-12743ad5.md
@@ -1,0 +1,1 @@
+- CoS TUI agents no longer die on startup when Claude Code offers to make auto mode the default permission mode, and a swallowed paste is reported as a startup failure instead of being misfiled as a lint error

--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -275,6 +275,24 @@ export const BRACKETED_PASTE_MODE_PATTERN = /\x1b\[\?2004([hl])/g;
 export const TUI_TRUST_PROMPT_PATTERN =
   /trustthisfolder|isthisaprojectyou(?:created|trust)/i;
 
+// Claude Code's auto-mode opt-in offer ("Make auto mode your default permission
+// mode? → 1. Yes, set auto mode as my default permission mode / 2. No, keep
+// don't ask"), added in v2.1.233. Like the trust gate it is NOT bypassed by
+// `--dangerously-skip-permissions`, but unlike the trust gate it paints AFTER
+// the composer is live — bracketed-paste mode is already ON, so `ready` goes
+// true and the prompt is pasted straight into a modal that ignores it. Every
+// one of the four claude-code-tui agents launched on 2026-08-14 died
+// `paste-not-rendered` this way (agent-f71b794e et al.).
+//
+// The spawner answers "2. No, keep don't ask" rather than accepting the
+// highlighted default: option 1 rewrites the HUMAN's global default permission
+// mode in `~/.claude.json`, and an unattended agent must not mutate the
+// operator's config as a side effect of dismissing a dialog. Option 2 preserves
+// whatever posture the user already chose, and the agent's own session keeps
+// the `--dangerously-skip-permissions` it was launched with either way.
+export const TUI_AUTO_MODE_PROMPT_PATTERN =
+  /automodeyourdefaultpermissionmode|setautomodeasmydefaultpermissionmode/i;
+
 // Antigravity (agy) needs a SECOND, positive readiness signal on top of paste
 // mode. agy enables bracketed paste the moment it enters the alt screen — while
 // it is still "Signing in…", before its folder-trust gate has painted and long
@@ -316,6 +334,13 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
   let sawCommandRun = directLaunch;
   let needsTrust = false;
   let sawReadyText = false;
+  // Auto-mode offer: latched when seen, cleared once answered. `autoModeAnswered`
+  // makes the ack TERMINAL — `tail` is a rolling 4000-char window, so the modal's
+  // text lingers in it long after the dialog is gone and would otherwise re-arm
+  // the flag on the very next chunk, re-answering forever and pinning `ready`
+  // false until the 45s deadline. Arm-once, same as the gates above it.
+  let needsAutoModeChoice = false;
+  let autoModeAnswered = false;
   let tail = '';
   return {
     // Ready once the TUI has RE-ENABLED bracketed-paste mode after the launch
@@ -324,10 +349,18 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
     // initial ON does not count: sawCommandRun gates on the intervening OFF.)
     // Providers that enable paste mode before their composer exists supply a
     // readyTextPattern to close the gap.
+    // The auto-mode offer is the one gate that paints with paste mode already ON,
+    // so it must SUPPRESS ready — every other signal here says "go" while the
+    // modal is still swallowing input. Cleared by ackAutoModeChoice() once the
+    // spawner has answered it.
     get ready() {
-      return sawCommandRun && pasteModeOn && (!readyTextPattern || sawReadyText);
+      return sawCommandRun && pasteModeOn && !needsAutoModeChoice
+        && (!readyTextPattern || sawReadyText);
     },
     get needsTrust() { return needsTrust; },
+    get needsAutoModeChoice() { return needsAutoModeChoice; },
+    /** Spawner reports the dismissal keystrokes went out; re-arms `ready`. */
+    ackAutoModeChoice() { needsAutoModeChoice = false; autoModeAnswered = true; },
     // rawText: un-stripped chunk (paste-mode toggles live here);
     // strippedText: ANSI-stripped chunk (the trust-gate / composer text).
     observe(rawText, strippedText) {
@@ -340,6 +373,7 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
       if (strippedText) {
         tail = (tail + strippedText.replace(/\s+/g, '')).slice(-OBSERVE_TAIL_MAX_LEN);
         if (!needsTrust && TUI_TRUST_PROMPT_PATTERN.test(tail)) needsTrust = true;
+        if (!needsAutoModeChoice && !autoModeAnswered && TUI_AUTO_MODE_PROMPT_PATTERN.test(tail)) needsAutoModeChoice = true;
         if (readyTextPattern && !sawReadyText && readyTextPattern.test(tail)) sawReadyText = true;
       }
     },

--- a/server/lib/tuiHandshake.test.js
+++ b/server/lib/tuiHandshake.test.js
@@ -1288,6 +1288,59 @@ describe('createInputReadyTracker', () => {
     expect(agy.needsTrust).toBe(true);
   });
 
+  // Claude Code v2.1.233's auto-mode offer. Unlike the trust gate it paints with
+  // bracketed paste ALREADY ON, so `ready` was true and the prompt went into a
+  // modal that ignored it — four agents died `paste-not-rendered` on 2026-08-14.
+  describe('claude auto-mode default offer', () => {
+    // Verbatim wording from agent-f71b794e's transcript.
+    const OFFER = 'Make auto mode your default permission mode?\n'
+      + '   ❯ 1. Yes, set auto mode as my default permission mode\n'
+      + '     2. No, keep don\'t ask\n';
+
+    const readyTracker = () => {
+      const tracker = createInputReadyTracker();
+      tracker.observe(`${PASTE_OFF}${PASTE_ON}`, '');
+      return tracker;
+    };
+
+    it('suppresses ready while the offer is up, even with paste mode on', () => {
+      const tracker = readyTracker();
+      expect(tracker.ready).toBe(true); // composer live...
+
+      tracker.observe('', OFFER);
+      expect(tracker.needsAutoModeChoice).toBe(true);
+      expect(tracker.ready).toBe(false); // ...but the modal owns input now
+    });
+
+    it('re-arms ready once the spawner acks the dismissal', () => {
+      const tracker = readyTracker();
+      tracker.observe('', OFFER);
+      tracker.ackAutoModeChoice();
+      expect(tracker.needsAutoModeChoice).toBe(false);
+      expect(tracker.ready).toBe(true);
+    });
+
+    // The rolling tail keeps the modal text for 4000 chars after the dialog is
+    // gone. Without a terminal ack that stale text re-arms the flag on the next
+    // chunk — re-answering forever and pinning `ready` false to the 45s deadline.
+    it('does not re-arm from the stale tail after being answered', () => {
+      const tracker = readyTracker();
+      tracker.observe('', OFFER);
+      tracker.ackAutoModeChoice();
+
+      tracker.observe('', 'bypass permissions on'); // tail still holds the offer
+      expect(tracker.needsAutoModeChoice).toBe(false);
+      expect(tracker.ready).toBe(true);
+    });
+
+    it('leaves the tracker alone when no offer appears', () => {
+      const tracker = readyTracker();
+      tracker.observe('', 'Try "fix lint errors"');
+      expect(tracker.needsAutoModeChoice).toBe(false);
+      expect(tracker.ready).toBe(true);
+    });
+  });
+
   it('matches a marker split across two PTY chunks (rolling tail)', () => {
     const tracker = createInputReadyTracker();
     tracker.observe('', '> Yes, I trust th');

--- a/server/services/agentErrorAnalysis.js
+++ b/server/services/agentErrorAnalysis.js
@@ -569,6 +569,19 @@ export const ERROR_PATTERNS = [
 export const FAILURE_WINDOW_MAX_LINES = 200;
 export const FAILURE_WINDOW_MAX_CHARS = 16000;
 
+// Claude Code's EMPTY-composer placeholder — `❯ Try "fix lint errors"`. It is
+// the TUI advertising what you could ask for, not anything that happened, and it
+// is on screen precisely when the agent did nothing. The suggestion rotates
+// ("fix lint errors", "fix typecheck errors", …), so it can trip several
+// ERROR_PATTERNS by pure coincidence; `lint-error` is the one that actually
+// shipped a bogus diagnosis (agent-f71b794e). Dropped from the analysis window
+// so no pattern — present or future — can classify a run off a hint the user
+// never followed.
+//
+// Anchored on the `❯ Try "` chrome rather than the suggestion text: real agent
+// prose can say "fix lint errors", and only the composer prefixes it this way.
+const TUI_PLACEHOLDER_HINT_PATTERN = /^\s*[❯>]\s*Try\s+["'].*$/gm;
+
 /**
  * Reduce raw agent output to the tail worth classifying.
  *
@@ -586,6 +599,7 @@ export const FAILURE_WINDOW_MAX_CHARS = 16000;
 function getFailureAnalysisWindow(output) {
   const windowed = stripAnsi(output)
     .replace(/\r\n?/g, '\n')
+    .replace(TUI_PLACEHOLDER_HINT_PATTERN, '')
     .split('\n')
     .filter(l => l.trim())
     .slice(-FAILURE_WINDOW_MAX_LINES)
@@ -648,6 +662,30 @@ export const COMPLETION_REASON_ANALYSES = {
     actionable: false,
     message: 'Agent idled out before any work started',
     suggestedFix: 'The prompt likely never submitted — no working indicator ever appeared. Check the TUI paste/submit path and provider availability.'
+  },
+  // The two startup verdicts the TUI spawner resolves itself (agentTuiSpawning.js:
+  // `retryOrFailPaste` and the TUI_INPUT_READY_DEADLINE_MS branch). Both were
+  // missing here, and the cost was not merely a vaguer message: with no
+  // structural def, `analyzeAgentFailure` falls through to the regex sweep over a
+  // repaint-mangled TUI screen. Claude Code's idle composer renders a rotating
+  // placeholder hint — `❯ Try "fix lint errors"` — so a run that never submitted
+  // anything at all got filed as `lint-error` / "Linting failed", pointing every
+  // reader (and the auto-fixer tier) at a lint problem that did not exist
+  // (agent-f71b794e, 2026-08-14; the actual blocker was claude's new auto-mode
+  // modal). Registering the reasons restores the documented precedence — the
+  // spawner's own verdict beats a keyword sweep — and the `startup-failure`
+  // category is reused rather than minted so downstream taxonomies are unchanged.
+  'paste-not-rendered': {
+    category: 'startup-failure',
+    actionable: false,
+    message: 'Prompt never rendered in the TUI input box',
+    suggestedFix: 'The provider CLI accepted the bracketed paste but the prompt never appeared, so nothing was ever submitted. Usually the TUI was still initializing, or a startup dialog (folder trust, an opt-in offer, an account banner) was up and swallowed the paste. Check the tail of the raw transcript for a modal — if it is one PortOS does not know about yet, it needs a dismissal branch in agentTuiSpawning.js.'
+  },
+  'tui-not-ready': {
+    category: 'startup-failure',
+    actionable: false,
+    message: 'TUI never presented an input prompt',
+    suggestedFix: 'The provider CLI never signalled that its input box was live, so no prompt was sent. Check the raw transcript for a stalled sign-in, an unresolved startup dialog, or a CLI that exited back to the shell during boot.'
   },
   'review-loop-idle-timeout': {
     category: 'timeout',
@@ -780,14 +818,35 @@ export function endsAwaitingUserInput(analysisOutput) {
 const AWAITING_INPUT_REFINABLE_REASONS = new Set(['idle-no-changes', 'idle-no-activity', 'idle-no-deliverable']);
 
 /**
- * Re-word an idle-out whose transcript ends on an unanswered prompt. The
+ * The startup counterparts: the prompt never landed, and the transcript ends on a
+ * dialog. Same evidence, different story — no reaper was involved and the run
+ * never started, so the idle prose above ("re-running as-is will stall the same
+ * way", "invoke the non-interactive form") is wrong on every clause. Here the
+ * dialog is a STARTUP gate the spawner does not know how to dismiss, and the fix
+ * is a dismissal branch, not a reworded task.
+ */
+const STARTUP_GATE_REFINABLE_REASONS = new Set(['paste-not-rendered', 'tui-not-ready']);
+
+/**
+ * Re-word a run whose transcript ends on an unanswered prompt — an idle-out that
+ * stalled ON one, or a startup verdict where a dialog was up BEFORE the prompt
+ * could land (the two groups get different prose; see the reason sets). The
  * original `category` is preserved — downstream taxonomies (auto-fix tiers,
  * layered-intelligence failure buckets) keep classifying it exactly as they did,
  * and both idle reasons already escalate rather than blind-retry. Only the prose
  * a human reads changes. Pure.
  */
 function refineIdleReasonAnalysis(def, completionReason, analysisOutput) {
-  if (!def || !AWAITING_INPUT_REFINABLE_REASONS.has(completionReason)) return def;
+  if (!def) return def;
+  if (STARTUP_GATE_REFINABLE_REASONS.has(completionReason)) {
+    if (!endsAwaitingUserInput(analysisOutput)) return def;
+    return {
+      ...def,
+      message: 'Agent never started — a startup dialog swallowed the prompt',
+      suggestedFix: 'The transcript ends on an unanswered dialog (a choice selector or opt-in offer) that was up before the prompt could land, so nothing was ever submitted and the run is a no-op rather than a failed attempt. PortOS auto-answers the dialogs it knows (folder trust, claude\'s auto-mode offer); a new one from a CLI update needs its own pattern and dismissal branch in tuiHandshake.js / agentTuiSpawning.js. Read the tail of the raw transcript to see which dialog it was.'
+    };
+  }
+  if (!AWAITING_INPUT_REFINABLE_REASONS.has(completionReason)) return def;
   if (!endsAwaitingUserInput(analysisOutput)) return def;
   return {
     ...def,

--- a/server/services/agentErrorAnalysis.test.js
+++ b/server/services/agentErrorAnalysis.test.js
@@ -1073,6 +1073,67 @@ describe('analyzeAgentFailure — runner completion reason (COMPLETION_REASON_AN
   });
 });
 
+// agent-f71b794e (2026-08-14): claude v2.1.233 put its auto-mode offer up before
+// the paste landed, so the run submitted nothing. With no COMPLETION_REASON entry
+// for `paste-not-rendered` the analyzer fell through to the regex sweep and matched
+// the idle composer's placeholder hint — filing a never-started run as `lint-error`
+// / "Linting failed", which is what the follow-up investigation task was named for.
+describe('analyzeAgentFailure — TUI startup gates are not lint errors', () => {
+  // Verbatim shape of the failing screen: banner, the composer's rotating
+  // placeholder, then the modal that swallowed the paste.
+  const stuckOnAutoModeOffer = withLead(
+    [
+      'Claude Code v2.1.233',
+      'Opus 5 with high effort · Claude Max',
+      '❯ Try "fix lint errors"',
+      '⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents',
+      'Make auto mode your default permission mode?',
+      '   ❯ 1. Yes, set auto mode as my default permission mode',
+      "     2. No, keep don't ask",
+    ].join('\n')
+  );
+
+  it('classifies a swallowed paste as a startup failure, not a lint error', () => {
+    const analysis = analyzeAgentFailure(stuckOnAutoModeOffer, { id: 't' }, 'x', {
+      completionReason: 'paste-not-rendered',
+      completionError: 'claude was still initializing and the paste was silently swallowed.',
+    });
+    expect(analysis.category).toBe('startup-failure');
+    expect(analysis.category).not.toBe('lint-error');
+    expect(analysis.origin).toBe('runner');
+  });
+
+  it('names the unanswered dialog as the cause instead of blaming the idle reaper', () => {
+    const analysis = analyzeAgentFailure(stuckOnAutoModeOffer, { id: 't' }, 'x', {
+      completionReason: 'paste-not-rendered',
+    });
+    expect(analysis.message).toMatch(/startup dialog/i);
+    // The idle-out prose would be wrong here — no reaper was involved.
+    expect(analysis.suggestedFix).not.toMatch(/idle reaper/i);
+  });
+
+  it('registers both spawner-resolved startup verdicts', () => {
+    expect(COMPLETION_REASON_ANALYSES['paste-not-rendered'].category).toBe('startup-failure');
+    expect(COMPLETION_REASON_ANALYSES['tui-not-ready'].category).toBe('startup-failure');
+  });
+
+  // Defense in depth for the case with no completion reason to lean on: the
+  // placeholder is the TUI advertising what you COULD ask, and its suggestion
+  // rotates — so leaving it in the window lets it trip patterns by coincidence.
+  it('ignores the empty-composer placeholder hint when there is no runner verdict', () => {
+    const analysis = analyzeAgentFailure(stuckOnAutoModeOffer, { id: 't' }, 'x');
+    expect(analysis.category).not.toBe('lint-error');
+  });
+
+  it('still classifies a genuine lint failure the agent actually hit', () => {
+    const analysis = analyzeAgentFailure(
+      withLead('npm run lint\n/src/app.js\n  12:1  error  Unexpected var\n\nlint failed with 1 error'),
+      { id: 't' }, 'x'
+    );
+    expect(analysis.category).toBe('lint-error');
+  });
+});
+
 describe('createInvestigationTask body', () => {
   beforeEach(() => {
     addTask.mockReset();

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -804,6 +804,7 @@ export async function spawnTuiAgent({
     directLaunch: useDurableRunner,
   });
   let trustAccepted = false;
+  let autoModeDeclined = false;
   // True once shell.js actually injects the `claude` command (after its
   // round-trip readiness probe). The probe runs its OWN shell command first,
   // which toggles bracketed-paste mode and would otherwise advance the
@@ -1589,6 +1590,21 @@ export async function spawnTuiAgent({
         trustAccepted = true;
         shellService.writeToSession(sessionId, '\r');
         appendLine(`📟 Auto-confirmed ${tuiConfig.command} folder-trust prompt for session ${sessionId.slice(0, 8)}`);
+        return;
+      }
+      // Decline claude's "make auto mode your default permission mode?" offer
+      // (v2.1.233+). Unlike the trust gate this one paints AFTER the composer is
+      // live, so it swallows the paste and every retry unless it is cleared
+      // first — see TUI_AUTO_MODE_PROMPT_PATTERN. Arrow-down + Enter rather than
+      // the digit `2`: it lands on "No, keep don't ask" under both of Ink's
+      // selection models (digit-immediate-select and navigate-then-confirm),
+      // whereas a bare `\r` would accept the highlighted option 1 and rewrite the
+      // user's global permission default.
+      if (inputReady.needsAutoModeChoice && !autoModeDeclined) {
+        autoModeDeclined = true;
+        shellService.writeToSession(sessionId, '\x1b[B\r');
+        inputReady.ackAutoModeChoice();
+        appendLine(`📟 Declined ${tuiConfig.command} auto-mode default offer for session ${sessionId.slice(0, 8)}`);
         return;
       }
       if (inputReady.ready && elapsed >= tuiConfig.promptDelayMs) {

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -1591,6 +1591,41 @@ describe('spawnTuiAgent runtime', () => {
     expect(pasteCount()).toBe(1);
   });
 
+  // Claude Code v2.1.233's auto-mode offer. The trust gate above paints BEFORE
+  // the composer; this one paints after, with paste mode already on — so the old
+  // gate said "ready" and the prompt went into a modal that ignored it. All four
+  // claude-code-tui agents on 2026-08-14 died `paste-not-rendered` this way.
+  it('claude auto-mode offer: declines it and pastes only after it is cleared', async () => {
+    runSpawn({ tuiConfig: claudeTuiConfig });
+    await flushMicrotasks();
+
+    // Composer comes up live — under the old gate this alone would paste.
+    await capturedOnData(Buffer.from(`${PASTE_OFF}${PASTE_ON}`));
+    await flushMicrotasks();
+
+    // ...then the modal paints over it, before the prompt delay elapses.
+    await capturedOnData(Buffer.from(
+      'Make auto mode your default permission mode?\n'
+      + '   ❯ 1. Yes, set auto mode as my default permission mode\n'
+      + "     2. No, keep don't ask\n"
+    ));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(700);
+    await flushMicrotasks();
+
+    // Down+Enter selects option 2. A BARE Enter would accept the highlighted
+    // option 1 and rewrite the user's global permission default — assert we did
+    // not do that.
+    const writes = vi.mocked(shellService.writeToSession).mock.calls.map(([, d]) => d);
+    expect(writes).toContain('\x1b[B\r');
+    expect(writes).not.toContain('\r');
+
+    // Only once the dialog is answered does the prompt go out — and exactly once.
+    await vi.advanceTimersByTimeAsync(3000);
+    await flushMicrotasks();
+    expect(pasteCount()).toBe(1);
+  });
+
   it('tui-not-ready: claude that never shows an input prompt finalizes failure without pasting', async () => {
     let resolveComplete;
     const completeDone = new Promise((r) => { resolveComplete = r; });


### PR DESCRIPTION
## Summary

Investigation of the `lint-error` agent failure (`Task failed 3 times: Linting failed`). There was no lint error. Two independent bugs produced that report:

**1. A new startup modal swallowed the prompt.** Claude Code v2.1.233 offers *"Make auto mode your default permission mode?"* on startup. Unlike the folder-trust gate it paints **after** the composer is live, so bracketed-paste mode is already on, the input-ready tracker reports ready, and the prompt is pasted into a modal that ignores it. All four `claude-code-tui` CoS agents launched on 2026-08-14 died `paste-not-rendered` this way — the run never started.

The tracker now latches the offer and holds `ready` down while it is up, and the spawner answers it before pasting. It picks option 2 (*"No, keep don't ask"*) rather than the highlighted default: **option 1 rewrites the human operator's global permission default in `~/.claude.json`**, and an unattended agent must not mutate the user's config as a side effect of clearing a dialog. The agent's own session is launched with `--dangerously-skip-permissions` either way.

**2. That failure was then misfiled as a lint error.** `paste-not-rendered` and `tui-not-ready` were missing from `COMPLETION_REASON_ANALYSES`, so a run the spawner had already diagnosed fell through to the regex sweep over the transcript. That transcript is a repaint of an idle Claude Code screen, whose empty composer advertises a rotating placeholder hint — `❯ Try "fix lint errors"` — and the lint pattern matched it. A run that submitted nothing at all was reported as "Linting failed", which is what the follow-up investigation task was named after and what the auto-fixer tier was handed.

Three layers, each independently sufficient to kill this instance:

- register both spawner-resolved startup verdicts, restoring the documented precedence that a structural verdict beats a keyword sweep
- when the transcript ends on a dialog, say a startup gate swallowed the prompt rather than reusing the idle-out prose (no reaper was involved, and "invoke the non-interactive form" is wrong advice for a run that never began)
- drop the composer placeholder from the analysis window entirely, so the rotating suggestion cannot trip this or any future pattern by coincidence

The dismissal ack is deliberately terminal: the tracker's 4000-char rolling tail keeps the modal text long after the dialog closes, and without that latch the stale text re-arms the flag on the next chunk and pins `ready` false until the 45s deadline.

## Test plan

- `server/lib/tuiHandshake.test.js` — 4 new cases: ready is suppressed while the offer is up, re-arms on ack, does **not** re-arm from the stale tail, and is untouched when no offer appears.
- `server/services/agentTuiSpawning.test.js` — 1 new case mirroring the existing folder-trust gate test: the modal is answered with Down+Enter (option 2), a bare Enter is asserted NOT to be sent, and the prompt pastes exactly once, only after the dialog clears.
- `server/services/agentErrorAnalysis.test.js` — 5 new cases built on the verbatim failing screen: the swallowed paste classifies as `startup-failure` not `lint-error`, the message names the dialog instead of the idle reaper, both verdicts are registered, the placeholder is ignored with no runner verdict, and **a genuine lint failure still classifies as `lint-error`**.
- Every new test was verified to bite by reverting the specific line it guards (ready-suppression, terminal ack, the reason entries, the placeholder strip) and confirming only the matching tests fail.
- Full server suite: 28438 passed. The 2 failures are pre-existing local flakes in untouched areas — `settings.secretsStrip` (5s timeout on first-test DB connect, passes with headroom) and `imageGenQuota` (ordering-dependent, passes in isolation).

Deferred: #4180 — `tuiPromptRunner` (the one-shot TUI path) still handles neither the trust gate nor this one, and is a separate execution path with its own fallback semantics.
