### PR TITLE
fix: re-anchor agy's --print <prompt> at the end of the argv so trailing extraArgs can't strand it

### DIFF
--- a/.changelog/next/fixed-issue-4110.md
+++ b/.changelog/next/fixed-issue-4110.md
@@ -1,0 +1,1 @@
+- Antigravity CLI runs with extra arguments no longer strand them after the prompt — `--print <prompt>` is re-anchored as the final argv pair at spawn time

--- a/server/lib/antigravity.js
+++ b/server/lib/antigravity.js
@@ -201,23 +201,25 @@ const NOOP_CLEANUP = () => {};
  * no-op for the already-trailing case.
  *
  * The flag's original SPELLING is preserved (`-p` / `--prompt` / `--print`) so a
- * user-baked short form still reaches agy as they wrote it.
+ * user-baked short form still reaches agy as they wrote it — the LAST spelling
+ * wins, matching which flag agy itself would have honored.
+ *
+ * EVERY print flag is lifted, not just the last one. `ensureAntigravityPrintArgs`
+ * strips baked print flags from the provider's saved argv, but the `extraArgs`
+ * concatenated on afterwards are never stripped — so leaving an earlier `-p`
+ * behind would have agy consume the token following IT as the prompt.
  *
  * @param {string[]} args - argv as built by ensureAntigravityPrintArgs
  * @param {string} prompt - the full prompt text
  * @returns {{ args: string[], useStdin: false, cleanup: () => void }}
  */
 export function prepareAntigravityPrompt(args = [], prompt = '') {
-  const out = [...args];
-  // Find the LAST print flag so the prompt lands as its value even if the argv
-  // carries stray tokens (it shouldn't, post-ensureAntigravityPrintArgs).
-  let idx = -1;
-  for (let i = out.length - 1; i >= 0; i--) {
-    if (ANTIGRAVITY_PRINT_FLAGS.includes(out[i])) { idx = i; break; }
+  let flag = '--print';
+  const out = [];
+  for (const arg of args) {
+    if (ANTIGRAVITY_PRINT_FLAGS.includes(arg)) flag = arg;
+    else out.push(arg);
   }
-  // No print flag at all → add one. Otherwise lift the existing marker out of
-  // its current position so it can be re-appended as the final pair.
-  const flag = idx === -1 ? '--print' : out.splice(idx, 1)[0];
   out.push(flag, prompt);
   return { args: out, useStdin: false, cleanup: NOOP_CLEANUP };
 }

--- a/server/lib/antigravity.js
+++ b/server/lib/antigravity.js
@@ -78,8 +78,9 @@ export function parseAntigravityModelList(stdout) {
 
 // agy print flags. Unlike the old Gemini CLI (which read the prompt from stdin),
 // `agy --print`/`-p`/`--prompt` takes the prompt as the flag's VALUE and does
-// NOT read stdin at all. So the print flag must be the FINAL token, with the
-// prompt spliced in right after it at spawn time by prepareAntigravityPrompt.
+// NOT read stdin at all. So `--print <prompt>` must be the FINAL pair in the
+// argv; prepareAntigravityPrompt relocates the flag to the end and appends the
+// prompt as its value at spawn time.
 export const ANTIGRAVITY_PRINT_FLAGS = ['--print', '-p', '--prompt'];
 
 /**
@@ -172,6 +173,11 @@ export function ensureAntigravityPrintArgs(args = [], overrides = {}) {
   // (e.g. --dangerously-skip-permissions) after --print would make agy consume
   // THAT flag as the prompt text (the bug that shipped the flag name to the
   // model instead of the task — see server/lib/antigravity.js history).
+  //
+  // Callers may still append after this (cliProviderRun.js#runCliProviderPrompt
+  // concatenates the call's `extraArgs` onto buildCliArgs' output), so "last"
+  // here is only true at build time — prepareAntigravityPrompt re-anchors the
+  // pair at spawn time (#4110).
   out.push('--print');
   return out;
 }
@@ -179,10 +185,23 @@ export function ensureAntigravityPrintArgs(args = [], overrides = {}) {
 const NOOP_CLEANUP = () => {};
 
 /**
- * Spawn-time prompt delivery for the antigravity CLI: splice the prompt in as
- * the VALUE of the trailing print flag (agy does not read stdin). Mirrors the
- * `{ args, useStdin, cleanup }` shape of grok.js#prepareGrokPromptFile so the
- * spawn sites can dispatch through a single helper (see prepareCliPrompt).
+ * Spawn-time prompt delivery for the antigravity CLI: re-anchor the print flag
+ * at the END of the argv and append the prompt as its VALUE (agy does not read
+ * stdin). Mirrors the `{ args, useStdin, cleanup }` shape of
+ * grok.js#prepareGrokPromptFile so the spawn sites can dispatch through a
+ * single helper (see prepareCliPrompt).
+ *
+ * MOVING the flag rather than splicing after it in place is what makes this
+ * correct for a non-empty `extraArgs` call (#4110):
+ * `cliProviderRun.js#runCliProviderPrompt` appends extraArgs *after* the
+ * trailing `--print` marker `ensureAntigravityPrintArgs` left, so an in-place
+ * splice would leave `--print <prompt> <extraArg>…` and turn every extraArg into
+ * a stray positional agy may reject. Relocating the pair keeps `--print
+ * <prompt>` the final two tokens no matter what got concatenated on, and is a
+ * no-op for the already-trailing case.
+ *
+ * The flag's original SPELLING is preserved (`-p` / `--prompt` / `--print`) so a
+ * user-baked short form still reaches agy as they wrote it.
  *
  * @param {string[]} args - argv as built by ensureAntigravityPrintArgs
  * @param {string} prompt - the full prompt text
@@ -196,11 +215,10 @@ export function prepareAntigravityPrompt(args = [], prompt = '') {
   for (let i = out.length - 1; i >= 0; i--) {
     if (ANTIGRAVITY_PRINT_FLAGS.includes(out[i])) { idx = i; break; }
   }
-  if (idx === -1) {
-    out.push('--print', prompt);
-  } else {
-    out.splice(idx + 1, 0, prompt);
-  }
+  // No print flag at all → add one. Otherwise lift the existing marker out of
+  // its current position so it can be re-appended as the final pair.
+  const flag = idx === -1 ? '--print' : out.splice(idx, 1)[0];
+  out.push(flag, prompt);
   return { args: out, useStdin: false, cleanup: NOOP_CLEANUP };
 }
 

--- a/server/lib/antigravity.test.js
+++ b/server/lib/antigravity.test.js
@@ -170,6 +170,42 @@ describe('prepareAntigravityPrompt', () => {
     const { cleanup } = prepareAntigravityPrompt(['--print'], 'x');
     expect(() => cleanup()).not.toThrow();
   });
+
+  // #4110: runCliProviderPrompt concatenates a call's extraArgs onto
+  // buildCliArgs' output, which for agy already ends in the bare `--print`
+  // marker (cliProviderRun.js). Splicing
+  // the prompt in after the flag's *current* position would leave the extraArgs
+  // trailing the prompt as stray positionals; the pair must be re-anchored.
+  it('re-anchors --print + prompt at the END when extraArgs trail the marker', () => {
+    const built = ensureAntigravityPrintArgs([]);
+    const extraArgs = ['--include-directories', '/srv/example'];
+    const { args } = prepareAntigravityPrompt([...built, ...extraArgs], 'PROMPT');
+    expect(args).toEqual([
+      '--dangerously-skip-permissions',
+      '--include-directories',
+      '/srv/example',
+      '--print',
+      'PROMPT',
+    ]);
+    // the pair is final, and every extraArg precedes it
+    expect(args.slice(-2)).toEqual(['--print', 'PROMPT']);
+    for (const extra of extraArgs) {
+      expect(args.indexOf(extra)).toBeLessThan(args.indexOf('--print'));
+    }
+    // exactly one print flag survives the move
+    expect(args.filter((a) => a === '--print')).toHaveLength(1);
+  });
+
+  it('leaves the empty-extraArgs shape unchanged (no duplicate or moved flag)', () => {
+    const built = ensureAntigravityPrintArgs([]);
+    const { args } = prepareAntigravityPrompt([...built], 'PROMPT');
+    expect(args).toEqual(['--dangerously-skip-permissions', '--print', 'PROMPT']);
+  });
+
+  it('preserves the print flag spelling when relocating it', () => {
+    const { args } = prepareAntigravityPrompt(['-p', '--verbose'], 'PROMPT');
+    expect(args).toEqual(['--verbose', '-p', 'PROMPT']);
+  });
 });
 
 describe('ensureAntigravityTuiArgs', () => {

--- a/server/lib/antigravity.test.js
+++ b/server/lib/antigravity.test.js
@@ -206,6 +206,15 @@ describe('prepareAntigravityPrompt', () => {
     const { args } = prepareAntigravityPrompt(['-p', '--verbose'], 'PROMPT');
     expect(args).toEqual(['--verbose', '-p', 'PROMPT']);
   });
+
+  // extraArgs are concatenated on AFTER ensureAntigravityPrintArgs has stripped
+  // baked print flags, so they can smuggle a second one in. A leftover flag
+  // would make agy read the token after IT as the prompt.
+  it('lifts EVERY print flag, not just the last, and the last spelling wins', () => {
+    const { args } = prepareAntigravityPrompt(['--print', '--verbose', '-p'], 'PROMPT');
+    expect(args).toEqual(['--verbose', '-p', 'PROMPT']);
+    expect(args.filter((a) => a === '--print')).toHaveLength(0);
+  });
 });
 
 describe('ensureAntigravityTuiArgs', () => {

--- a/server/lib/cliProviderArgs.test.js
+++ b/server/lib/cliProviderArgs.test.js
@@ -278,6 +278,28 @@ describe('cliProviderArgs', () => {
       })).toEqual(['--model', 'gemini-3.6-flash', '--effort', 'medium', '--dangerously-skip-permissions', '--print']);
     });
 
+    // #4110: mirrors runCliProviderPrompt's `[...buildCliArgs(p), ...extraArgs]` — agy's
+    // print flag is a bare trailing marker at build time, so extraArgs land past
+    // it and prepareCliPrompt has to re-anchor `--print <prompt>` at the end.
+    it('keeps --print + prompt final for Antigravity even with trailing extraArgs', () => {
+      const provider = { id: 'antigravity-cli', command: 'agy', defaultModel: 'gemini-3.6-flash', models: AGY_CATALOG };
+      const extraArgs = ['--include-directories', '/srv/example'];
+      const built = [...buildCliArgs(provider), ...extraArgs];
+      const { args, useStdin } = prepareCliPrompt('agy', built, 'write a haiku');
+      expect(args.slice(-2)).toEqual(['--print', 'write a haiku']);
+      expect(args.filter((a) => a === '--print')).toHaveLength(1);
+      for (const extra of extraArgs) expect(args.indexOf(extra)).toBeLessThan(args.indexOf('--print'));
+      expect(useStdin).toBe(false);
+    });
+
+    it('is unchanged for Antigravity with no extraArgs', () => {
+      const provider = { id: 'antigravity-cli', command: 'agy', defaultModel: 'gemini-3.6-flash', models: AGY_CATALOG };
+      const { args } = prepareCliPrompt('agy', buildCliArgs(provider), 'write a haiku');
+      expect(args).toEqual([
+        '--model', 'gemini-3.6-flash', '--dangerously-skip-permissions', '--print', 'write a haiku',
+      ]);
+    });
+
     it('is a no-op for providers with no effort control', () => {
       expect(buildCliArgs({ id: 'opencode', command: 'opencode', defaultModel: 'qwen3', effort: 'high' }))
         .toEqual(['run', '-m', 'qwen3']);

--- a/server/lib/cliProviderRun.js
+++ b/server/lib/cliProviderRun.js
@@ -94,6 +94,10 @@ export function runCliProviderPrompt(args = {}) {
   // Deliver the prompt per provider convention: antigravity gets it as the
   // --print VALUE (no stdin); grok's `--prompt-file /dev/stdin` is fed via stdin
   // on POSIX / a temp file on Windows (useStdin=false); everyone else via stdin.
+  // NOTE: extraArgs land AFTER buildCliArgs' output, so for antigravity they sit
+  // past the trailing `--print` marker. prepareAntigravityPrompt relocates the
+  // `--print <prompt>` pair to the very end to absorb that (#4110) — don't
+  // "fix" it by re-ordering the concatenation above.
   const { args: spawnArgs, useStdin, cleanup: cleanupPromptFile } = prepareCliPrompt(provider.command, builtArgs, prompt);
 
   return new Promise((resolve) => {


### PR DESCRIPTION
## Summary

`ensureAntigravityPrintArgs` deliberately leaves a bare `--print` marker as the last token of an agy argv, because `agy --print` takes the prompt as the flag's VALUE (it never reads stdin). But `runCliProviderPrompt` (`server/lib/cliProviderRun.js`) builds `[...buildCliArgs(provider), ...extraArgs]` — so with a non-empty `extraArgs` the marker is no longer last, and `prepareAntigravityPrompt`'s in-place splice produced:

```
… --dangerously-skip-permissions --print <PROMPT> <extraArg1> <extraArg2> …
```

The prompt still reached agy as `--print`'s value, but every extraArg became a stray positional agy may reject or misinterpret.

This takes the issue's **fix shape 2**: `prepareAntigravityPrompt` now lifts the print flag out of its current position and re-appends `<flag> <prompt>` as the final two tokens, so the pair is last no matter what got concatenated on. That is more local than rewriting the concatenation site, and it holds for any future caller that appends to a built agy argv — not just the one that does today.

Details:

- The flag's original **spelling** is preserved when relocating (`-p` / `--prompt` / `--print`), so a user-baked short form still reaches agy as written.
- The **empty-`extraArgs`** shape is byte-identical to before — the existing spawn paths (Creative Director, Run Prompt, ask, vision, `services/imageGen/agy.js`) are unaffected.
- `server/lib/aiToolkit/internal/antigravity.js` needs no mirror change: it has no prompt preparer, only the arg builders.
- Comments at both ends now name the real concatenation site. The issue attributed it to `executeCliRun`; that function (`server/services/runner.js`) takes no `extraArgs` — `runCliProviderPrompt` is the one that concatenates.

## Test plan

- `cd server && NODE_ENV=test npx vitest run ../server/lib/antigravity.test.js ../server/lib/cliProviderArgs.test.js ../server/lib/cliProviderRun.test.js` — 88 passed.
- New regression coverage:
  - `server/lib/antigravity.test.js` — with non-empty `extraArgs` appended past the marker, the argv ends with `--print <PROMPT>`, every extraArg precedes it, and exactly one print flag survives the move; the empty-`extraArgs` shape is unchanged; the flag spelling is preserved.
  - `server/lib/cliProviderArgs.test.js` — the same assertion one level up, through the real `prepareCliPrompt` vendor dispatch, over an argv built exactly the way `runCliProviderPrompt` builds it (`[...buildCliArgs(provider), ...extraArgs]`), plus the unchanged no-extraArgs shape.
- Bypass probe: reverting `prepareAntigravityPrompt` to the old in-place splice fails all 3 new assertions, confirming they are not vacuous.
- Wider suites unaffected: `server/lib` (310 files / 7705 tests) green; `server/services/imageGen`, `agentCliSpawning`, `slashdoInvocation`, `tuiHandshake`, `runner`, `askService`, `codeReview`, `cos-runner` all green.

Closes #4110
