### PR TITLE
Unify Cyber Muse's base-loop and montage animation maps into one motion map

### DIFF
--- a/.changelog/next/changed-issue-4118.md
+++ b/.changelog/next/changed-issue-4118.md
@@ -1,0 +1,1 @@
+- Cyber Muse avatar: one motion map per agent state (clip list with an explicit loop mode) replaces the split base-loop/montage maps — a montage now degrades structurally to its first step

--- a/client/src/components/cos/MuseCoSAvatar.jsx
+++ b/client/src/components/cos/MuseCoSAvatar.jsx
@@ -4,17 +4,15 @@ import { useGLTF, Sparkles } from '@react-three/drei';
 import * as THREE from 'three';
 import {
   AGENT_STATES,
-  MUSE_STATE_ANIMATIONS,
-  MUSE_STATE_SEQUENCES,
+  resolveMuseMotion,
   MUSE_IN_PLACE_SUFFIX,
-  MUSE_ANIMATION_FALLBACK,
   MUSE_SPEAKING_GESTURE,
   MUSE_ROOT_MOTION_CLIPS,
 } from './constants';
 import CoSAvatarOrbitControls from './CoSAvatarOrbitControls';
 import CoSBackgroundCamera from './CoSBackgroundCamera';
 import CoSCanvasGuard from './CoSCanvasGuard';
-import { withInPlaceClips, inPlaceClipName } from '../../utils/animationClips';
+import { withInPlaceClips } from '../../utils/animationClips';
 import useClonedGltf, { GltfPrimitive } from '../../hooks/useClonedGltf';
 
 const MODEL_URL = '/api/avatar/model.glb';
@@ -68,111 +66,77 @@ function GLBAvatar({ state, speaking }) {
   }, [scene]);
 
   // --- Animation driving -------------------------------------------------
-  // A state resolves to EITHER a single looping base clip (desiredBaseRef) or a
-  // montage that cycles clips (sequenceRef). `gestureActiveRef` defers and
-  // restores around the one-shot speaking gesture so a state change mid-gesture
-  // still lands on the latest state.
-  const activeRef = useRef(null);          // currently-playing action
-  const desiredBaseRef = useRef(null);     // { name, timeScale, once } to rest on
-  const sequenceRef = useRef(null);        // { steps, index } | null when looping
+  // Every state resolves to ONE ordered step list (see `resolveMuseMotion`): a
+  // length-1 list is a plain base loop, a longer one is a montage this
+  // component's `finished` listener advances through. `gestureActiveRef` defers
+  // and restores around the one-shot speaking gesture so a state change
+  // mid-gesture still lands on the latest state.
+  const activeRef = useRef(null);                       // currently-playing action
+  const motionRef = useRef({ steps: [], index: 0 });    // live step list + position
   const gestureActiveRef = useRef(false);
   const speakingRef = useRef(false);
 
-  // Crossfade the currently-active action to `clipName`. `once` → play a single
-  // LoopOnce and clamp; `reps` → a finite LoopRepeat that fires `finished` after
-  // N cycles (used to advance a montage); neither → an infinite base loop.
-  const fadeTo = useCallback((clipName, opts = {}) => {
+  // Crossfade the currently-active action to `clipName`. `loop`: 'once' → a
+  // single LoopOnce; `{ reps: N }` → a finite LoopRepeat that fires `finished`
+  // after N cycles (used to advance a montage); 'infinite' → an endless loop.
+  const fadeTo = useCallback((clipName, { timeScale = 1, loop = 'infinite', duration = FADE } = {}) => {
     const next = actions[clipName];
     if (!next) return;
-    const dur = opts.duration ?? FADE;
     next.reset();
     next.enabled = true;
-    next.setEffectiveTimeScale(opts.timeScale ?? 1);
+    next.setEffectiveTimeScale(timeScale);
     next.setEffectiveWeight(1);
-    if (opts.once || opts.reps) {
+    const reps = loop === 'once' ? 1 : (loop?.reps ?? 0);
+    if (reps > 0) {
       // Finite: one shot (`once`) or N reps of a montage step. Clamp on the last
       // frame so it holds its (near-neutral) end pose through the crossfade to
       // the next action instead of snapping toward the bind pose.
-      next.setLoop(opts.once ? THREE.LoopOnce : THREE.LoopRepeat, opts.once ? 1 : opts.reps);
+      next.setLoop(loop === 'once' ? THREE.LoopOnce : THREE.LoopRepeat, reps);
       next.clampWhenFinished = true;
     } else {
       next.setLoop(THREE.LoopRepeat, Infinity);
       next.clampWhenFinished = false;
     }
-    next.fadeIn(dur).play();
+    next.fadeIn(duration).play();
     const prev = activeRef.current;
-    if (prev && prev !== next) prev.fadeOut(dur);
+    if (prev && prev !== next) prev.fadeOut(duration);
     activeRef.current = next;
   }, [actions]);
 
-  // Play montage step `index` (wraps). `index` is always ≥ 0 at every call site
-  // (0, the current index, or current+1), so a plain modulo is enough. Steps
-  // were pre-filtered to present clips.
-  const playSequenceStep = useCallback((index, duration) => {
-    const seq = sequenceRef.current;
-    if (!seq || !seq.steps.length) return;
-    const i = index % seq.steps.length;
-    seq.index = i;
-    const step = seq.steps[i];
-    fadeTo(step.clip, { timeScale: step.timeScale, reps: step.reps ?? 1, duration });
+  // Play step `index` of the current motion (wraps). `index` is always ≥ 0 at
+  // every call site (0, the current index, or current + 1), so a plain modulo is
+  // enough. Steps were pre-filtered to clips the loaded GLB actually has.
+  const playStep = useCallback((index, duration) => {
+    const motion = motionRef.current;
+    if (!motion.steps.length) return;
+    const i = index % motion.steps.length;
+    motion.index = i;
+    const step = motion.steps[i];
+    fadeTo(step.clip, { timeScale: step.timeScale, loop: step.loop, duration });
   }, [fadeTo]);
 
-  // Resume the current state's motion — the montage from `fromIndex`, or the
-  // single base loop. Both the state effect and the gesture-finish handler need
-  // this exact "sequence vs base loop" decision, so it lives in one place.
-  const resumeMotion = useCallback((fromIndex, duration) => {
-    if (sequenceRef.current) { playSequenceStep(fromIndex, duration); return; }
-    const rest = desiredBaseRef.current;
-    if (rest?.name) fadeTo(rest.name, { timeScale: rest.timeScale, once: rest.once, duration });
-  }, [fadeTo, playSequenceStep]);
+  // The current state's playable steps, resolved against the loaded clips (which
+  // include the synthesized in-place variants, so a montage can name `Running`
+  // without drifting the fixed frame). Memoized so the state effect below has a
+  // stable dependency.
+  const steps = useMemo(() => resolveMuseMotion(state, names), [state, names]);
 
-  // Resolve the base loop clip for the current state (guarded against a GLB
-  // that lacks the mapped clip).
-  const baseCfg = MUSE_STATE_ANIMATIONS[state] || {};
-  const baseClip = useMemo(() => {
-    if (!hasClips) return null;
-    if (baseCfg.clip && names.includes(baseCfg.clip)) return baseCfg.clip;
-    if (names.includes(MUSE_ANIMATION_FALLBACK)) return MUSE_ANIMATION_FALLBACK;
-    // Last resort for a custom GLB with clips but none mapped: prefer the first
-    // in-place clip so a leading walk cycle can't drift the fixed-frame avatar
-    // out of view; fall back to names[0] only if every clip is root-motion.
-    return names.find((n) => !MUSE_ROOT_MOTION_CLIPS.includes(n)) || names[0];
-  }, [hasClips, names, baseCfg.clip]);
-
-  // Resolve the montage steps for the current state against the loaded clips.
-  // The step's clip is auto-routed to its in-place variant if it's a root-motion
-  // clip — so the sequence data names real GLB clips (`Running`) and the
-  // fixed-frame no-drift guarantee is enforced here, not by a naming convention.
-  // A state needs ≥2 resolvable steps to run as a montage; otherwise it falls
-  // back to its single base loop (so a GLB missing the sequence clips — or the
-  // in-place variant — still animates). Kept as a memo so the state effect's
-  // dependency is stable.
-  const sequenceSteps = useMemo(() => {
-    if (!hasClips) return null;
-    const def = MUSE_STATE_SEQUENCES[state];
-    if (!Array.isArray(def)) return null;
-    const steps = def
-      .map((s) => ({ ...s, clip: inPlaceClipName(s.clip, MUSE_ROOT_MOTION_CLIPS, MUSE_IN_PLACE_SUFFIX) }))
-      .filter((s) => names.includes(s.clip));
-    return steps.length >= 2 ? steps : null;
-  }, [hasClips, names, state]);
-
-  // Start / crossfade to the current state's motion (montage or base loop).
+  // Start / crossfade to the current state's motion.
   useEffect(() => {
-    if (!baseClip) return;
-    desiredBaseRef.current = { name: baseClip, timeScale: baseCfg.timeScale, once: baseCfg.once };
-    sequenceRef.current = sequenceSteps ? { steps: sequenceSteps, index: 0 } : null;
+    if (!steps.length) return;
+    motionRef.current = { steps, index: 0 };
     // Mid-gesture: don't crossfade now — the gesture's finish handler restores
-    // to whatever the refs point at, so the latest state still wins.
+    // from the ref, so the latest state still wins.
     if (gestureActiveRef.current) return;
-    resumeMotion(0);
-  }, [resumeMotion, baseClip, baseCfg.timeScale, baseCfg.once, sequenceSteps]);
+    playStep(0);
+  }, [playStep, steps]);
 
   // Persistent `finished` listener with two jobs: (1) when the one-shot speaking
-  // gesture finishes, hand control back to the live base loop / montage (read
-  // from the refs so a state change mid-gesture still lands correctly); (2) when
-  // a finite montage step finishes, advance to the next step. Non-sequence base
-  // loops are infinite (never fire) and the clamped `sleeping` pose is ignored.
+  // gesture finishes, hand control back to the live motion (read from the ref so
+  // a state change mid-gesture still lands correctly); (2) when a finite montage
+  // step finishes, advance to the next step. A single-step motion is either an
+  // infinite loop (never fires) or a clamped pose that must hold (`sleeping`),
+  // so only a multi-step motion advances.
   useEffect(() => {
     if (!hasClips) return;
     const gesture = actions[MUSE_SPEAKING_GESTURE];
@@ -180,20 +144,20 @@ function GLBAvatar({ state, speaking }) {
       if (gestureActiveRef.current) {
         if (gesture && e.action !== gesture) return; // ignore body clips finishing
         gestureActiveRef.current = false;
-        resumeMotion(sequenceRef.current?.index ?? 0, 0.25); // back to montage / base loop
+        playStep(motionRef.current.index, 0.25); // back to the step we were on
         return;
       }
       // Advance the montage when the active step completes its reps.
-      if (sequenceRef.current && e.action === activeRef.current) {
-        playSequenceStep(sequenceRef.current.index + 1);
+      if (motionRef.current.steps.length > 1 && e.action === activeRef.current) {
+        playStep(motionRef.current.index + 1);
       }
     };
     mixer.addEventListener('finished', onFinished);
     return () => mixer.removeEventListener('finished', onFinished);
-  }, [resumeMotion, playSequenceStep, hasClips, actions, mixer]);
+  }, [playStep, hasClips, actions, mixer]);
 
   // Speaking overlay: on the false→true edge, crossfade to the gesture once.
-  // The persistent listener above returns to the base loop / montage when it
+  // The persistent listener above returns to the current motion step when it
   // finishes.
   useEffect(() => {
     if (!hasClips) return;
@@ -203,12 +167,12 @@ function GLBAvatar({ state, speaking }) {
 
     const gesture = actions[MUSE_SPEAKING_GESTURE];
     if (!gesture) return;
-    // Skip if a non-montage state is already resting on the gesture clip.
-    const base = desiredBaseRef.current;
-    if (!sequenceRef.current && base && gesture === actions[base.name]) return;
+    // Skip if a single-step state is already resting on the gesture clip.
+    const current = motionRef.current.steps;
+    if (current.length === 1 && gesture === actions[current[0].clip]) return;
 
     gestureActiveRef.current = true;
-    fadeTo(MUSE_SPEAKING_GESTURE, { once: true, duration: 0.2 });
+    fadeTo(MUSE_SPEAKING_GESTURE, { loop: 'once', duration: 0.2 });
   }, [fadeTo, speaking, hasClips, actions]);
 
   // Subtle container float. The clip drives the body; this only adds the gentle

--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -14,6 +14,7 @@ import {
   ChartGantt
 } from 'lucide-react';
 import { normalizeReviewerSlug } from '../../lib/reviewerPins';
+import { inPlaceClipName } from '../../utils/animationClips';
 
 export const TABS = [
   { id: 'briefing', label: 'Briefing', icon: Newspaper },
@@ -62,91 +63,120 @@ export const AGENT_STATES = {
   ideating: { label: 'Ideating', color: '#f97316', icon: '💡' },
 };
 
-// Cyber Muse (3D) avatar animation triggers. The bundled default model
+// Cyber Muse (3D) avatar motion map. The bundled default model
 // (data.reference/avatar/model.glb) is three.js's RobotExpressive (CC0), which
 // ships 14 clips: Idle, Walking, Running, Dance, Death, Sitting, Standing,
 // Jump, Yes, No, Wave, Punch, ThumbsUp, WalkJump.
 //
-// Each of the 7 AGENT_STATES maps to an IN-PLACE base loop. Walking / Running /
-// WalkJump carry root translation (they move the model forward) and are
-// intentionally excluded so a fixed-frame avatar can't drift out of view. The
-// `speaking` boolean fires a one-shot gesture overlay (MUSE_SPEAKING_GESTURE)
-// that hands control back to the base loop when it finishes.
+// ONE map drives every state: `state → [{ clip, timeScale, loop }]`, an ordered
+// list of steps. `loop` is
+//   'infinite'   — loop the clip forever (never fires the mixer's `finished`)
+//   'once'       — a single LoopOnce clamped on its final frame (a pose or
+//                  transition clip like `Sitting`, held instead of looping)
+//   { reps: N }  — a finite LoopRepeat of N cycles; `finished` then advances to
+//                  the next step, wrapping around
+//
+// A length-1 list is a plain base loop. A longer list is a montage — `coding`
+// cycles jab → sprint → leap → approve → stride → celebrate so a working agent
+// reads as energetic and varied rather than one clip on repeat. THE FIRST STEP
+// IS ALSO THE STATE'S FALLBACK: when the loaded GLB resolves fewer than two
+// steps, `resolveMuseMotion` collapses the list to its first resolvable step and
+// loops that — so "the montage degrades to its base clip" is structural, not a
+// convention two maps had to agree on.
+//
+// Steps name real GLB clips. Walking / Running / WalkJump carry root
+// translation (they move the model forward) and would drift a fixed-frame
+// avatar out of view, so `resolveMuseMotion` auto-routes them to the
+// neutralized in-place variants the avatar synthesizes at load time. A step's
+// FIRST entry must still be an in-place clip (it is the fallback loop, played
+// as named); the constants test asserts that.
 //
 // Consumed by MuseCoSAvatar's AnimationMixer (via drei useAnimations). Clip
-// names are matched case-sensitively against the loaded GLB and guarded: a GLB
-// missing a mapped clip falls back to MUSE_ANIMATION_FALLBACK, and a GLB with
-// NO clips at all falls back to the fully-procedural rotation/glow behavior so
-// static models and other variants keep working. `once: true` clamps a
-// pose/transition clip (Sitting) on its final frame instead of looping it.
+// names are matched case-sensitively against the loaded GLB: unresolvable steps
+// are dropped, a state with none left falls back to MUSE_ANIMATION_FALLBACK,
+// and a GLB with NO clips at all falls back to the fully-procedural
+// rotation/glow behavior so static models and other variants keep working.
+//
 // The emote clips (Yes/No/Wave/Punch/ThumbsUp) start and end near a neutral
 // pose, so looping them reads as a repeated, deliberate gesture (nodding,
-// scanning, jabbing) rather than snapping — that's what lets us give each
-// state its own body language instead of collapsing everything onto Idle. The
-// read for each: sleeping = seated rest; thinking = calm contemplation (Idle);
-// coding = jabbing away at the work (Punch); investigating = slow side-to-side
-// scan (No); reviewing = approving nod (Yes); planning = confident "locked in"
+// scanning, jabbing) rather than snapping — that's what lets us give each state
+// its own body language instead of collapsing everything onto Idle. The read
+// for each: sleeping = seated rest; thinking = calm contemplation (Idle);
+// coding = an energetic work montage; investigating = slow side-to-side scan
+// (No); reviewing = approving nod (Yes); planning = confident "locked in"
 // thumbs-up (ThumbsUp); ideating = creative celebration (Dance).
 //
-// This map is the single-clip base loop for each state — also the graceful
-// fallback for any state that ALSO has a MUSE_STATE_SEQUENCES entry (below) but
-// whose GLB is missing the sequence clips. Keep every entry mapped to an
-// in-place clip; the constants test asserts none is a MUSE_ROOT_MOTION_CLIPS.
-export const MUSE_STATE_ANIMATIONS = {
-  sleeping:      { clip: 'Sitting',  timeScale: 0.8, once: true },
-  thinking:      { clip: 'Idle',     timeScale: 0.85 },
-  coding:        { clip: 'Punch',    timeScale: 1.1 },
-  investigating: { clip: 'No',       timeScale: 0.7 },
-  reviewing:     { clip: 'Yes',      timeScale: 0.8 },
-  planning:      { clip: 'ThumbsUp', timeScale: 0.85 },
-  ideating:      { clip: 'Dance',    timeScale: 1.0 },
+// The `speaking` boolean fires a one-shot gesture overlay
+// (MUSE_SPEAKING_GESTURE) that hands control back to the current step when it
+// finishes.
+export const MUSE_STATE_MOTIONS = {
+  sleeping:      [{ clip: 'Sitting',  timeScale: 0.8,  loop: 'once' }],
+  thinking:      [{ clip: 'Idle',     timeScale: 0.85, loop: 'infinite' }],
+  coding: [
+    { clip: 'Punch',    timeScale: 1.2,  loop: { reps: 2 } },
+    { clip: 'Running',  timeScale: 1.1,  loop: { reps: 4 } },
+    { clip: 'Jump',     timeScale: 1.0,  loop: { reps: 1 } },
+    { clip: 'ThumbsUp', timeScale: 0.95, loop: { reps: 1 } },
+    { clip: 'Walking',  timeScale: 1.2,  loop: { reps: 4 } },
+    { clip: 'Dance',    timeScale: 1.0,  loop: { reps: 1 } },
+  ],
+  investigating: [{ clip: 'No',       timeScale: 0.7,  loop: 'infinite' }],
+  reviewing:     [{ clip: 'Yes',      timeScale: 0.8,  loop: 'infinite' }],
+  planning:      [{ clip: 'ThumbsUp', timeScale: 0.85, loop: 'infinite' }],
+  ideating:      [{ clip: 'Dance',    timeScale: 1.0,  loop: 'infinite' }],
 };
 
 // Naming suffix for the neutralized "run/walk in place" clip variants that
 // MuseCoSAvatar synthesizes at load time (see `withInPlaceClips` in
 // client/src/utils/animationClips.js). This is an INTERNAL implementation
-// detail — sequences below reference real GLB clip names (`Running`) and the
-// avatar auto-routes any root-motion clip to its stripped variant. Exported
-// only so the avatar and the clip util agree on the suffix.
+// detail — the motion map above references real GLB clip names (`Running`) and
+// `resolveMuseMotion` routes any root-motion clip to its stripped variant.
+// Exported only so the avatar and the clip util agree on the suffix.
 export const MUSE_IN_PLACE_SUFFIX = ' (in place)';
 
-// Multi-clip montages: a state can cycle through an ordered list of clips
-// instead of looping one. Each step plays for `reps` repetitions (finite
-// LoopRepeat), then the AnimationMixer's `finished` event advances to the next
-// step, wrapping around — so `coding` reads as an energetic, varied work
-// montage (jab, sprint, leap, approve, stride, celebrate) rather than a single
-// clip on infinite repeat. Steps name real GLB clips; root-motion clips
-// (`Running`/`Walking`) are automatically routed to their neutralized in-place
-// variant by the avatar, so they can't drift the fixed frame. Steps are
-// resolved against the loaded GLB at runtime; unresolvable clips are dropped,
-// and a state whose GLB yields fewer than 2 resolvable steps falls back to its
-// MUSE_STATE_ANIMATIONS base loop.
-export const MUSE_STATE_SEQUENCES = {
-  coding: [
-    { clip: 'Punch',    timeScale: 1.2,  reps: 2 },
-    { clip: 'Running',  timeScale: 1.1,  reps: 4 },
-    { clip: 'Jump',     timeScale: 1.0,  reps: 1 },
-    { clip: 'ThumbsUp', timeScale: 0.95, reps: 1 },
-    { clip: 'Walking',  timeScale: 1.2,  reps: 4 },
-    { clip: 'Dance',    timeScale: 1.0,  reps: 1 },
-  ],
-};
-
-// Clip used when a mapped state clip is absent from the loaded GLB.
+// Clip used when none of a state's mapped clips is in the loaded GLB.
 export const MUSE_ANIMATION_FALLBACK = 'Idle';
 
 // One-shot gesture played on the rising edge of `speaking`, then the avatar
-// returns to its base state loop (or resumes its montage).
+// returns to the motion step it was on.
 export const MUSE_SPEAKING_GESTURE = 'Wave';
 
 // RobotExpressive clips that carry root translation (they walk the model
-// forward). Never used as a base loop for the fixed-frame avatar — the state
-// map above avoids them, the constants test asserts it, and MuseCoSAvatar's
-// "GLB has clips but none are mapped" fallback skips them so a custom GLB
-// whose first clip happens to be a walk cycle can't drift out of view. When a
-// montage step names one of these, the avatar auto-routes it to its neutralized
-// in-place variant (root-translation stripped) so it no longer drifts.
+// forward). Never played as-is by the fixed-frame avatar: `resolveMuseMotion`
+// routes a step naming one of these to its neutralized in-place variant, and
+// the "GLB has clips but none are mapped" fallback skips them so a custom GLB
+// whose first clip happens to be a walk cycle can't drift out of view.
 export const MUSE_ROOT_MOTION_CLIPS = ['Walking', 'Running', 'WalkJump'];
+
+// Last-resort clip for a GLB that has clips but none the state maps: prefer the
+// canonical fallback, else the first in-place clip so a leading walk cycle can't
+// drift the fixed-frame avatar, else whatever the GLB leads with.
+const fallbackClip = (names) => (
+  names.includes(MUSE_ANIMATION_FALLBACK)
+    ? MUSE_ANIMATION_FALLBACK
+    : names.find((n) => !MUSE_ROOT_MOTION_CLIPS.includes(n)) || names[0]
+);
+
+// Resolve a state's motion steps against `names`, the clip roster of the loaded
+// GLB (which already includes the synthesized in-place variants). Root-motion
+// steps are routed to their in-place variant, then any step the GLB can't
+// supply is dropped. Returns the playable step list:
+//   ≥2 steps → the montage, cycled by the avatar's `finished` listener
+//    1 step  → a base loop; a finite `{ reps }` degrades to 'infinite' because
+//              there is no next step to advance to, while an explicit 'once'
+//              pose keeps clamping
+//    0 steps → the state's first step re-pointed at a fallback clip, looped
+// An empty/absent roster yields `[]` (the caller runs procedural-only).
+export function resolveMuseMotion(state, names) {
+  if (!Array.isArray(names) || names.length === 0) return [];
+  const declared = MUSE_STATE_MOTIONS[state] || [];
+  const resolved = declared
+    .map((step) => ({ ...step, clip: inPlaceClipName(step.clip, MUSE_ROOT_MOTION_CLIPS, MUSE_IN_PLACE_SUFFIX) }))
+    .filter((step) => names.includes(step.clip));
+  if (resolved.length >= 2) return resolved;
+  const step = resolved[0] || { ...declared[0], clip: fallbackClip(names) };
+  return [{ ...step, loop: step.loop === 'once' ? 'once' : 'infinite' }];
+}
 
 // Default messages shown when no specific event message is available
 export const STATE_MESSAGES = {

--- a/client/src/components/cos/constants.test.js
+++ b/client/src/components/cos/constants.test.js
@@ -6,11 +6,12 @@ import {
   getDomainMode,
   DEFAULT_DOMAIN_MODE,
   AGENT_STATES,
-  MUSE_STATE_ANIMATIONS,
-  MUSE_STATE_SEQUENCES,
+  MUSE_STATE_MOTIONS,
+  MUSE_IN_PLACE_SUFFIX,
   MUSE_ANIMATION_FALLBACK,
   MUSE_SPEAKING_GESTURE,
   MUSE_ROOT_MOTION_CLIPS,
+  resolveMuseMotion,
   MODEL_CAPABLE_CLI_REVIEWERS,
   reviewerLabel
 } from './constants';
@@ -50,53 +51,141 @@ describe('getDomainBudget (client mirror)', () => {
   });
 });
 
-// The Cyber Muse avatar drives RobotExpressive's clips off CoS state. Two
-// invariants must hold or the fixed-frame avatar breaks: every agent state
-// needs a base clip, and no mapped clip may carry root translation (those
-// walk the model out of view — enumerated in MUSE_ROOT_MOTION_CLIPS).
+// The Cyber Muse avatar drives RobotExpressive's clips off CoS state through a
+// single map: state → an ordered step list. Invariants that must hold or the
+// fixed-frame avatar breaks: every agent state needs at least one step, and the
+// FIRST step (the structural fallback, played as named) may not carry root
+// translation — those walk the model out of view (MUSE_ROOT_MOTION_CLIPS).
 
-describe('muse avatar animation triggers', () => {
-  it('maps every agent state to a base clip', () => {
+// The bundled default GLB's clip roster, as MuseCoSAvatar sees it: the 14
+// RobotExpressive clips plus the in-place variants it synthesizes at load time.
+const ROBOT_EXPRESSIVE_CLIPS = [
+  'Idle', 'Walking', 'Running', 'Dance', 'Death', 'Sitting', 'Standing',
+  'Jump', 'Yes', 'No', 'Wave', 'Punch', 'ThumbsUp', 'WalkJump'
+];
+const LOADED_CLIPS = [
+  ...ROBOT_EXPRESSIVE_CLIPS,
+  ...MUSE_ROOT_MOTION_CLIPS.map((n) => `${n}${MUSE_IN_PLACE_SUFFIX}`)
+];
+
+const LOOP_KINDS = ['infinite', 'once'];
+
+describe('muse avatar motion map', () => {
+  it('gives every agent state at least one well-formed step', () => {
     for (const state of Object.keys(AGENT_STATES)) {
-      expect(MUSE_STATE_ANIMATIONS[state], `state "${state}" must map to a clip`).toBeTruthy();
-      expect(typeof MUSE_STATE_ANIMATIONS[state].clip).toBe('string');
-      expect(MUSE_STATE_ANIMATIONS[state].clip.length).toBeGreaterThan(0);
+      const steps = MUSE_STATE_MOTIONS[state];
+      expect(Array.isArray(steps), `state "${state}" must map to a step list`).toBe(true);
+      expect(steps.length, `state "${state}" needs at least one step`).toBeGreaterThan(0);
+      for (const step of steps) {
+        expect(typeof step.clip, `state "${state}" step needs a clip name`).toBe('string');
+        expect(step.clip.length).toBeGreaterThan(0);
+        expect(typeof step.timeScale, `state "${state}" step needs a timeScale`).toBe('number');
+        expect(step.timeScale).toBeGreaterThan(0);
+        if (typeof step.loop === 'string') {
+          expect(LOOP_KINDS, `state "${state}" has an unknown loop kind`).toContain(step.loop);
+        } else {
+          expect(Number.isInteger(step.loop?.reps) && step.loop.reps > 0, `state "${state}" reps must be a positive integer`).toBe(true);
+        }
+      }
     }
   });
 
-  it('never maps a state (or the fallback / speaking gesture) to a root-motion clip', () => {
-    for (const [state, cfg] of Object.entries(MUSE_STATE_ANIMATIONS)) {
-      expect(MUSE_ROOT_MOTION_CLIPS, `state "${state}" uses a root-motion clip`).not.toContain(cfg.clip);
+  it('never uses a root-motion clip as a state fallback (or as the fallback / speaking gesture)', () => {
+    // The first step doubles as the state's fallback loop and is played as
+    // named, so it must be in-place. Later montage steps may name a root-motion
+    // clip — resolveMuseMotion routes those to their in-place variant.
+    for (const [state, steps] of Object.entries(MUSE_STATE_MOTIONS)) {
+      expect(MUSE_ROOT_MOTION_CLIPS, `state "${state}" falls back to a root-motion clip`).not.toContain(steps[0].clip);
     }
     expect(MUSE_ROOT_MOTION_CLIPS).not.toContain(MUSE_ANIMATION_FALLBACK);
     expect(MUSE_ROOT_MOTION_CLIPS).not.toContain(MUSE_SPEAKING_GESTURE);
   });
+
+  it('gives the coding state a montage of at least 2 steps', () => {
+    expect(MUSE_STATE_MOTIONS.coding.length).toBeGreaterThanOrEqual(2);
+  });
 });
 
-// The `coding` montage cycles several clips so the working avatar reads as
-// varied/dynamic (jab, sprint, leap, approve, stride, celebrate). Steps name
-// real GLB clips; root-motion clips are auto-routed to their neutralized
-// in-place variant by the avatar (see animationClips.test.js for that routing),
-// so the data can freely name a walk/run cycle without risking drift. These
-// invariants just keep the montage steps well-formed.
+// Pin the clip sequence each state actually plays on the bundled model. These
+// are the exact clips/timeScales/loops the split base-map + montage-map design
+// produced, so the unified map stays behaviour-preserving.
 
-describe('muse avatar state sequences (montages)', () => {
-  it('gives the coding state a montage of at least 2 steps', () => {
-    expect(Array.isArray(MUSE_STATE_SEQUENCES.coding)).toBe(true);
-    expect(MUSE_STATE_SEQUENCES.coding.length).toBeGreaterThanOrEqual(2);
+describe('resolveMuseMotion (bundled RobotExpressive roster)', () => {
+  const expected = {
+    sleeping:      [{ clip: 'Sitting',  timeScale: 0.8,  loop: 'once' }],
+    thinking:      [{ clip: 'Idle',     timeScale: 0.85, loop: 'infinite' }],
+    coding: [
+      { clip: 'Punch',                             timeScale: 1.2,  loop: { reps: 2 } },
+      { clip: `Running${MUSE_IN_PLACE_SUFFIX}`,    timeScale: 1.1,  loop: { reps: 4 } },
+      { clip: 'Jump',                              timeScale: 1.0,  loop: { reps: 1 } },
+      { clip: 'ThumbsUp',                          timeScale: 0.95, loop: { reps: 1 } },
+      { clip: `Walking${MUSE_IN_PLACE_SUFFIX}`,    timeScale: 1.2,  loop: { reps: 4 } },
+      { clip: 'Dance',                             timeScale: 1.0,  loop: { reps: 1 } },
+    ],
+    investigating: [{ clip: 'No',       timeScale: 0.7,  loop: 'infinite' }],
+    reviewing:     [{ clip: 'Yes',      timeScale: 0.8,  loop: 'infinite' }],
+    planning:      [{ clip: 'ThumbsUp', timeScale: 0.85, loop: 'infinite' }],
+    ideating:      [{ clip: 'Dance',    timeScale: 1.0,  loop: 'infinite' }],
+  };
+
+  it('covers every agent state', () => {
+    expect(Object.keys(expected).sort()).toEqual(Object.keys(AGENT_STATES).sort());
   });
 
-  it('has well-formed steps (string clip + positive integer reps when present)', () => {
-    for (const [state, steps] of Object.entries(MUSE_STATE_SEQUENCES)) {
-      expect(Array.isArray(steps), `sequence "${state}" must be an array`).toBe(true);
-      for (const step of steps) {
-        expect(typeof step.clip, `sequence "${state}" step needs a clip name`).toBe('string');
-        expect(step.clip.length).toBeGreaterThan(0);
-        if (step.reps !== undefined) {
-          expect(Number.isInteger(step.reps) && step.reps > 0, `sequence "${state}" reps must be a positive integer`).toBe(true);
-        }
-      }
-    }
+  for (const [state, steps] of Object.entries(expected)) {
+    it(`resolves "${state}" to its pre-unification clip sequence`, () => {
+      expect(resolveMuseMotion(state, LOADED_CLIPS)).toEqual(steps);
+    });
+  }
+});
+
+describe('resolveMuseMotion (degraded GLBs)', () => {
+  it('returns nothing when the GLB has no clips (procedural-only)', () => {
+    expect(resolveMuseMotion('coding', [])).toEqual([]);
+    expect(resolveMuseMotion('coding', undefined)).toEqual([]);
+  });
+
+  it('drops montage steps the GLB lacks, keeping the rest in order', () => {
+    const names = ['Punch', 'Jump', 'Dance'];
+    expect(resolveMuseMotion('coding', names)).toEqual([
+      { clip: 'Punch', timeScale: 1.2, loop: { reps: 2 } },
+      { clip: 'Jump',  timeScale: 1.0, loop: { reps: 1 } },
+      { clip: 'Dance', timeScale: 1.0, loop: { reps: 1 } },
+    ]);
+  });
+
+  it('collapses a lone resolvable step to an infinite loop (no next step to advance to)', () => {
+    expect(resolveMuseMotion('coding', ['Punch', 'Idle'])).toEqual([
+      { clip: 'Punch', timeScale: 1.2, loop: 'infinite' },
+    ]);
+  });
+
+  it('keeps a clamped one-shot pose clamped', () => {
+    expect(resolveMuseMotion('sleeping', ['Sitting', 'Idle'])).toEqual([
+      { clip: 'Sitting', timeScale: 0.8, loop: 'once' },
+    ]);
+  });
+
+  it('falls back to the canonical fallback clip when none of the state clips exist', () => {
+    expect(resolveMuseMotion('ideating', ['Idle', 'Walking'])).toEqual([
+      { clip: MUSE_ANIMATION_FALLBACK, timeScale: 1.0, loop: 'infinite' },
+    ]);
+  });
+
+  it('prefers an in-place clip over a root-motion one for an unmapped GLB', () => {
+    expect(resolveMuseMotion('coding', ['Walking', 'Standing'])).toEqual([
+      { clip: 'Standing', timeScale: 1.2, loop: 'infinite' },
+    ]);
+    // Every clip carries root motion — nothing safer to pick than the first.
+    expect(resolveMuseMotion('coding', ['Walking', 'Running'])).toEqual([
+      { clip: 'Walking', timeScale: 1.2, loop: 'infinite' },
+    ]);
+  });
+
+  it('still animates an unknown state', () => {
+    expect(resolveMuseMotion('bogus', LOADED_CLIPS)).toEqual([
+      { clip: MUSE_ANIMATION_FALLBACK, loop: 'infinite' },
+    ]);
   });
 });
 

--- a/data.reference/avatar/README.md
+++ b/data.reference/avatar/README.md
@@ -16,12 +16,16 @@ It ships 14 animation clips — `Idle`, `Walking`, `Running`, `Dance`, `Death`,
 `Sitting`, `Standing`, `Jump`, `Yes`, `No`, `Wave`, `Punch`, `ThumbsUp`,
 `WalkJump` — plus 3 face morph targets (`Angry`, `Surprised`, `Sad`).
 
-MuseCoSAvatar drives these clips from the CoS runtime via an `AnimationMixer`,
-mapping each agent state to an **in-place** clip (see `MUSE_STATE_ANIMATIONS` in
-`client/src/components/cos/constants.js`). `Walking` / `Running` / `WalkJump`
-carry root translation and are never used as a base loop so the fixed-frame
-avatar can't drift out of view. The `speaking` flag fires a one-shot `Wave`
-overlay that returns to the base loop (or resumes the montage).
+MuseCoSAvatar drives these clips from the CoS runtime via an `AnimationMixer`.
+One map — `MUSE_STATE_MOTIONS` in `client/src/components/cos/constants.js` —
+gives each agent state an ordered list of steps, `{ clip, timeScale, loop }`,
+where `loop` is `'infinite'`, `'once'` (clamped on the final frame), or
+`{ reps: N }` (a finite repeat that advances to the next step). A single-step
+list is a plain base loop; a longer one is a montage. `Walking` / `Running` /
+`WalkJump` carry root translation, so a step naming one is auto-routed to a
+synthesized **in-place** variant and the fixed-frame avatar can't drift out of
+view. The `speaking` flag fires a one-shot `Wave` overlay that returns to the
+step it interrupted.
 
 The model is rendered with its **own textures and full color** — the per-state
 hue lives in the surrounding lights, halo, ground glow, and sparkles, not as a
@@ -36,12 +40,12 @@ tint painted onto the mesh.
 | reviewing | `Yes` | approving nod |
 | planning | `ThumbsUp` | confident "locked in" |
 | ideating | `Dance` | creative celebration |
-| _speaking_ | `Wave` | one-shot gesture, then back to base loop |
+| _speaking_ | `Wave` | one-shot gesture, then back to the interrupted step |
 
 ### `coding` montage
 
-Rather than looping a single clip, the `coding` state cycles an ordered montage
-(`MUSE_STATE_SEQUENCES.coding`) so a working agent reads as dynamic and varied:
+Rather than looping a single clip, the `coding` state's step list cycles an
+ordered montage so a working agent reads as dynamic and varied:
 **Punch → Running → Jump → ThumbsUp → Walking → Dance**, then repeats. Each step
 plays for a set number of repetitions before the mixer's `finished` event
 advances to the next.
@@ -50,8 +54,9 @@ The montage names real GLB clips. `Running` / `Walking` carry root translation,
 so the avatar auto-routes them to synthesized **"in place"** variants — cloned
 clips with their root-translation (`.position`) tracks stripped (the treadmill
 technique, in `client/src/utils/animationClips.js`) — so the gait animates
-without drifting the fixed frame. A GLB missing the montage clips falls back to
-the single-clip base loop (`MUSE_STATE_ANIMATIONS.coding` = `Punch`).
+without drifting the fixed frame. A GLB missing the montage clips degrades to
+the list's **first** step (`Punch`), looped — the fallback is structural, so
+every state (montage or not) resolves the same way.
 
 A GLB with none of these clips (or no clips at all) falls back to the
 procedural float treatment, so static models still render.


### PR DESCRIPTION
## Summary

The Cyber Muse 3D avatar kept two parallel maps — `MUSE_STATE_ANIMATIONS` (one base clip per state, `{ clip, timeScale, once }`) and `MUSE_STATE_SEQUENCES` (an optional montage, `{ clip, timeScale, reps }`) — and `MuseCoSAvatar.jsx` forked base-vs-sequence handling in three places.

This collapses them into one map, `MUSE_STATE_MOTIONS`: `state → [{ clip, timeScale, loop }]` where `loop` is `'infinite'`, `'once'` (LoopOnce clamped on the final frame), or `{ reps: N }` (finite LoopRepeat that advances the montage on the mixer's `finished` event).

- Single-clip states are length-1 lists; `coding` stays a montage.
- **The montage's fallback is now structural.** A new pure `resolveMuseMotion(state, names)` in `constants.js` routes root-motion steps to their synthesized in-place variant, drops steps the loaded GLB lacks, and — when fewer than two steps survive — collapses the list to its first resolvable step played as a loop (a `'once'` pose keeps clamping). Zero survivors fall back to `MUSE_ANIMATION_FALLBACK`, then the first in-place clip, exactly as before. No second map, no comment-enforced invariant.
- `MuseCoSAvatar.jsx` drops `desiredBaseRef`/`sequenceRef`/`resumeMotion`/`baseClip`/`sequenceSteps` for a single `motionRef` + `playStep`; `fadeTo` takes the `loop` descriptor directly. A single-step motion no longer advances on `finished`, so the clamped `sleeping` pose still holds.
- `data.reference/avatar/README.md` updated to describe the one map and the structural fallback.

Behaviour-preserving: on the bundled RobotExpressive model every state resolves to the exact clip/timeScale/loop sequence it played before, pinned by a new expected-sequence table in `constants.test.js`. One deliberate difference, only on a GLB missing 5 of the 6 `coding` clips: the fallback loop now runs at the montage first step's `timeScale` 1.2 instead of the old separate base entry's 1.1 — the price of making the fallback structural, and invisible on the shipped model.

A visual re-verification pass of the avatar (each state plus the `speaking` overlay) is still worth a human look.

## Test plan

- `cd client && npx vitest run src/components/cos src/utils/animationClips.test.js` — 20 files / 270 tests pass, including the new `resolveMuseMotion` parity table and degraded-GLB cases (missing steps, lone step, clamped pose, unmapped GLB, root-motion-only GLB, unknown state, empty roster).
- `cd client && npx vitest run` — 627/628 files pass; the single failure varies per run across `Catalog`/`QuotaBurn`/`pitchDetect` (known act()/timing flakes under parallel load) and all three pass in isolation. None touch the avatar.
- `cd client && npx biome lint --error-on-warnings src/components/cos src/utils` — clean.

Closes #4118
