### PR TITLE
Refuse a series review/fix start whose options differ from the in-flight run

### DIFF
--- a/.changelog/next/fixed-issue-4113.md
+++ b/.changelog/next/fixed-issue-4113.md
@@ -1,0 +1,1 @@
+- Series review: a second Review/Fix start whose options differ from the run already in flight is now refused with an explicit conflict instead of silently attaching to that run and dropping its own note, provider, gate, or finding set

--- a/client/src/components/pipeline/SeriesReviewPanel.jsx
+++ b/client/src/components/pipeline/SeriesReviewPanel.jsx
@@ -215,6 +215,15 @@ export default function SeriesReviewPanel({ series, onSeriesUpdate, onIssuesUpda
       .catch((err) => { toast.error(err.message || 'Could not start review'); return null; });
     setStarting(false);
     if (!res) return;
+    // A review with DIFFERENT options is already in flight (a second tab, or a
+    // peer-triggered run). The server refused to coalesce this one onto it
+    // (#4113) — binding to that stream would report its verdict as this
+    // request's while silently dropping this note/provider/gate. Surface it and
+    // leave the running review (and the note) alone.
+    if (res.conflict) {
+      toast.error('A different review is already running for this series — wait for it to finish, or cancel it first.');
+      return;
+    }
     // The note has now been consumed by this run — clear it so a later re-review
     // (after fixes clear `review`, re-showing the textarea) can't silently re-seed
     // the same note as a fresh duplicate finding. Don't clear when the server
@@ -241,6 +250,13 @@ export default function SeriesReviewPanel({ series, onSeriesUpdate, onIssuesUpda
       .catch((err) => { toast.error(err?.message || 'Could not start fixing'); return null; });
     setFixStarting(false);
     if (!res) return;
+    // A fix pass over a DIFFERENT finding set is already in flight. That run
+    // WRITES the manuscript, so reporting its totals as this request's would be
+    // worse than misleading — refuse to bind and say so (#4113).
+    if (res.conflict) {
+      toast.error('A different fix pass is already running for this series — wait for it to finish, or cancel it first.');
+      return;
+    }
     fixRunIdRef.current = res.runId || null;
     setConfirmDismissed(true);
     setFixing(true);

--- a/client/src/components/pipeline/SeriesReviewPanel.test.jsx
+++ b/client/src/components/pipeline/SeriesReviewPanel.test.jsx
@@ -1,0 +1,113 @@
+/**
+ * SeriesReviewPanel — the kickoff-conflict contract (#4113).
+ *
+ * The server refuses to coalesce a review/fix start whose options diverge from
+ * the run already in flight, answering `{ alreadyRunning: true, conflict: true }`
+ * instead. The panel must SURFACE that rather than binding its progress UI (and
+ * its terminal-frame success handler) to a run computed from someone else's
+ * options — and, for the review, must keep the user's un-taken note.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+vi.mock('../../services/api', () => ({
+  startPipelineSeriesReview: vi.fn(),
+  getPipelineSeriesReview: vi.fn(),
+  getPipelineSeriesReviewStatus: vi.fn(),
+  cancelPipelineSeriesReview: vi.fn(),
+  pipelineSeriesReviewSseUrl: (id) => `/api/pipeline/series/${id}/review/progress`,
+  startPipelineSeriesFix: vi.fn(),
+  getPipelineSeriesFixStatus: vi.fn(),
+  pipelineSeriesFixSseUrl: (id) => `/api/pipeline/series/${id}/review/fix/progress`,
+  getPipelineSeries: vi.fn(),
+  listPipelineIssues: vi.fn(),
+}));
+vi.mock('../ui/Toast', () => ({
+  default: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn(), warning: vi.fn() }),
+}));
+// No EventSource in jsdom — and this suite never needs a live stream.
+vi.mock('../../hooks/usePipelineProgress', () => ({
+  usePipelineProgress: () => ({ latest: null, frames: [], closed: false }),
+}));
+
+import {
+  startPipelineSeriesReview,
+  getPipelineSeriesReview,
+  getPipelineSeriesReviewStatus,
+  startPipelineSeriesFix,
+  getPipelineSeriesFixStatus,
+} from '../../services/api';
+import toast from '../ui/Toast';
+import SeriesReviewPanel from './SeriesReviewPanel';
+
+const FINDINGS = [{ commentId: 'mrc-1', severity: 'high', issueNumber: 1, summary: 'the middle sags', location: 'V1' }];
+const ISSUES_VERDICT = {
+  verdict: 'issues', findings: FINDINGS, findingCount: 1, foundationThreshold: 7.5,
+};
+
+const renderPanel = () => render(
+  <MemoryRouter>
+    <SeriesReviewPanel series={{ id: 'ser-1' }} onSeriesUpdate={vi.fn()} onIssuesUpdate={vi.fn()} />
+  </MemoryRouter>,
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getPipelineSeriesReview.mockResolvedValue({ review: null, fix: { mode: 'execute', canFix: true } });
+  getPipelineSeriesReviewStatus.mockResolvedValue({ active: false });
+  getPipelineSeriesFixStatus.mockResolvedValue({ active: false });
+});
+
+describe('SeriesReviewPanel — review kickoff conflict', () => {
+  it('reports the conflict and does NOT enter the reviewing state', async () => {
+    startPipelineSeriesReview.mockResolvedValue({ runId: 'other-run', alreadyRunning: true, conflict: true });
+    renderPanel();
+    fireEvent.click(await screen.findByRole('button', { name: /Review series/i }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/different review is already running/i)));
+    // Still offering the action — never swapped to the in-flight run's "Stop".
+    expect(screen.getByRole('button', { name: /Review series/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Stop/i })).toBeNull();
+  });
+
+  it('keeps the note the conflicting run never took', async () => {
+    startPipelineSeriesReview.mockResolvedValue({ runId: 'other-run', alreadyRunning: true, conflict: true });
+    renderPanel();
+    const note = await screen.findByLabelText(/Anything specific/i);
+    fireEvent.change(note, { target: { value: 'volume 1 has no real development' } });
+    fireEvent.click(screen.getByRole('button', { name: /Review series/i }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalled());
+    expect(note).toHaveValue('volume 1 has no real development');
+  });
+
+  it('still tracks a normal (non-conflicting) start', async () => {
+    startPipelineSeriesReview.mockResolvedValue({ runId: 'run-1', alreadyRunning: false });
+    renderPanel();
+    fireEvent.click(await screen.findByRole('button', { name: /Review series/i }));
+    await waitFor(() => expect(screen.getByRole('button', { name: /Stop/i })).toBeInTheDocument());
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('SeriesReviewPanel — fix kickoff conflict', () => {
+  beforeEach(() => {
+    getPipelineSeriesReview.mockResolvedValue({ review: ISSUES_VERDICT, fix: { mode: 'execute', canFix: true } });
+  });
+
+  it('reports the conflict instead of adopting the other pass as its own', async () => {
+    startPipelineSeriesFix.mockResolvedValue({ runId: 'other-fix', alreadyRunning: true, conflict: true });
+    renderPanel();
+    fireEvent.click(await screen.findByRole('button', { name: /Fix these issues/i }));
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith(expect.stringMatching(/different fix pass is already running/i)));
+    // The confirm block is still up — the panel never entered the fixing state.
+    expect(screen.getByRole('button', { name: /Fix these issues/i })).toBeInTheDocument();
+  });
+
+  it('still tracks a normal (non-conflicting) fix start', async () => {
+    startPipelineSeriesFix.mockResolvedValue({ runId: 'fix-1', alreadyRunning: false });
+    renderPanel();
+    fireEvent.click(await screen.findByRole('button', { name: /Fix these issues/i }));
+    await waitFor(() => expect(toast.success).toHaveBeenCalledWith(expect.stringMatching(/Fixing started/i)));
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+});

--- a/server/routes/pipeline/editorial.js
+++ b/server/routes/pipeline/editorial.js
@@ -243,7 +243,11 @@ router.get('/series/:id/review', asyncHandler(async (req, res) => {
   res.json(await seriesReview.getSeriesReview(req.params.id));
 }));
 
-// Kick off the holistic review (batch — progress via SSE).
+// Kick off the holistic review (batch — progress via SSE). The runner coalesces
+// a re-kick of the SAME review onto the in-flight run (`alreadyRunning`) but
+// refuses one whose options diverge, answering `conflict: true` (#4113) — spread
+// the runner's result verbatim so that reaches the client instead of reading as
+// a normal attach.
 router.post('/series/:id/review', asyncHandler(async (req, res) => {
   const body = validateRequest(seriesReviewRunSchema, req.body ?? {});
   await seriesSvc.getSeries(req.params.id).catch((err) => { throw mapServiceError(err); });

--- a/server/routes/pipeline/editorial.test.js
+++ b/server/routes/pipeline/editorial.test.js
@@ -150,6 +150,24 @@ describe('Holistic "Review this series" (#2664)', () => {
     expect(res.status).toBe(404);
     expect(startSeriesFixRun).not.toHaveBeenCalled();
   });
+
+  // The runner refuses to coalesce a start whose options diverge from the run
+  // already in flight (#4113). The route must PASS THAT THROUGH — picking named
+  // fields off the runner result instead of spreading it would swallow the
+  // conflict and leave the client believing it owns the running run.
+  it('POST /series/:id/review passes a kickoff conflict through to the client', async () => {
+    startSeriesReviewRun.mockReturnValueOnce({ runId: 'rev-live', alreadyRunning: true, conflict: true });
+    const res = await request(app).post('/api/pipeline/series/ser-1/review').send({ force: true });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ runId: 'rev-live', alreadyRunning: true, conflict: true });
+  });
+
+  it('POST /series/:id/review/fix passes a kickoff conflict through to the client', async () => {
+    startSeriesFixRun.mockReturnValueOnce({ runId: 'fix-live', alreadyRunning: true, conflict: true });
+    const res = await request(app).post('/api/pipeline/series/ser-1/review/fix').send({ commentIds: ['mrc-9'] });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ runId: 'fix-live', alreadyRunning: true, conflict: true });
+  });
 });
 
 describe('GET /api/pipeline/series/:id/voice-fingerprint (#2194)', () => {

--- a/server/services/pipeline/seriesReview.js
+++ b/server/services/pipeline/seriesReview.js
@@ -682,7 +682,33 @@ export async function runSeriesFix(seriesId, { commentIds, providerOverride, mod
 
 const runner = createSseRunner({ logLabel: 'series review' });
 
+/**
+ * Identity of a review kickoff: what the run would actually do. Two starts with
+ * the same signature produce the same verdict, so the second can safely attach
+ * to the first's in-flight run (a reload/remount re-attaching to its own
+ * request). A DIFFERENT signature would review with a different note, provider,
+ * or gate — attaching to the running one would silently drop those options and
+ * report its verdict as this request's, so the factory reports a `conflict`
+ * instead (#4113). Pure.
+ *
+ * `feedback` is trimmed to match the service's own `feedback && trim()` gate, so
+ * a blank note and an absent one are the same work.
+ */
+export function seriesReviewRequestSig({ feedback, providerOverride, modelOverride, force, readinessGate } = {}) {
+  return JSON.stringify({
+    feedback: String(feedback ?? '').trim() || null,
+    providerOverride: providerOverride ?? null,
+    modelOverride: modelOverride ?? null,
+    force: !!force,
+    readinessGate: readinessGate ?? null,
+  });
+}
+
 export function startSeriesReviewRun(seriesId, options = {}) {
+  // A second start while a review is in flight coalesces ONLY when it would run
+  // the same review; a divergent one gets `{ alreadyRunning: true, conflict:
+  // true }` so the caller can surface it rather than lose its options.
+  const sig = seriesReviewRequestSig(options);
   return runner.start(seriesId, async ({ runId, signal, record, broadcast }) => {
     broadcast({ type: 'start', runId });
     const result = await runSeriesReview(seriesId, {
@@ -705,7 +731,7 @@ export function startSeriesReviewRun(seriesId, options = {}) {
       findingCount: result.findingCount,
       completedAt: nowIso(),
     });
-  });
+  }, { sig });
 }
 
 export const attachClient = (seriesId, res) => runner.attachClient(seriesId, res);
@@ -717,7 +743,25 @@ export const cancelSeriesReview = (seriesId) => runner.cancel(seriesId);
 // runner maps — a review SSE and a fix SSE never collide).
 const fixRunner = createSseRunner({ logLabel: 'series fix' });
 
+/**
+ * Identity of a fix kickoff. Same contract as `seriesReviewRequestSig`, and the
+ * stakes are higher: the fix path WRITES the manuscript, so a start scoped to a
+ * different finding set must never bind onto the in-flight run and report its
+ * `fixed/skipped` totals as its own. `commentIds` is sorted (and deduped) so the
+ * same finding set in a different order is the same work; absent/empty both mean
+ * "every open finding", which is what `runSeriesFix` does with either. Pure.
+ */
+export function seriesFixRequestSig({ commentIds, providerOverride, modelOverride } = {}) {
+  const ids = Array.isArray(commentIds) && commentIds.length ? [...new Set(commentIds)].sort() : null;
+  return JSON.stringify({
+    commentIds: ids,
+    providerOverride: providerOverride ?? null,
+    modelOverride: modelOverride ?? null,
+  });
+}
+
 export function startSeriesFixRun(seriesId, options = {}) {
+  const sig = seriesFixRequestSig(options);
   return fixRunner.start(seriesId, async ({ runId, signal, record, broadcast }) => {
     broadcast({ type: 'start', runId });
     const result = await runSeriesFix(seriesId, {
@@ -744,7 +788,7 @@ export function startSeriesFixRun(seriesId, options = {}) {
       budgetStopped: result.budgetStopped === true,
       completedAt: nowIso(),
     });
-  });
+  }, { sig });
 }
 
 export const attachFixClient = (seriesId, res) => fixRunner.attachClient(seriesId, res);

--- a/server/services/pipeline/seriesReview.run.test.js
+++ b/server/services/pipeline/seriesReview.run.test.js
@@ -46,6 +46,10 @@ vi.mock('./canonReadiness.js', partial({ checkSeriesCanonReadiness: vi.fn() }));
 vi.mock('./editorial/checkRunner.js', partial({ runEditorialChecks: vi.fn() }));
 vi.mock('./editorialScore.js', partial({ getSeriesHealth: vi.fn() }));
 vi.mock('./manuscriptReview.js', partial({ getReview: vi.fn(), seedReviewFromFindings: vi.fn() }));
+// The fix runner's autonomy gate. An empty config leaves the cos domain off, so
+// `runSeriesFix` rejects immediately and writes nothing — the coalescing tests
+// below only care about which starts reach a run at all.
+vi.mock('../cosState.js', partial({ loadState: vi.fn(async () => ({ config: {} })) }));
 
 const { judgeFoundation } = await import('./foundationJudge.js');
 const { checkSeriesCanonReadiness } = await import('./canonReadiness.js');
@@ -54,7 +58,10 @@ const { getSeriesHealth } = await import('./editorialScore.js');
 const { getReview, seedReviewFromFindings } = await import('./manuscriptReview.js');
 const { getSeries } = await import('./series.js');
 const { listIssues } = await import('./issues.js');
-const { runSeriesReview, getSeriesReview } = await import('./seriesReview.js');
+const {
+  runSeriesReview, getSeriesReview,
+  startSeriesReviewRun, startSeriesFixRun, isSeriesReviewActive, isSeriesFixActive,
+} = await import('./seriesReview.js');
 
 afterAll(() => rmSync(TEST_DATA_ROOT, { recursive: true, force: true }));
 
@@ -317,5 +324,87 @@ describe('getSeriesReview — reviewed-source staleness (#4111)', () => {
     const { review } = await getSeriesReview('ser-test');
     expect(review.stale).toBe(false);
     expect(review.staleReason).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Signature-based coalescing on the SSE runners (#4113).
+//
+// Before this, ANY second start while a run was in flight was attached to it and
+// its own feedback/provider/force/gate (or, for the fix pass, its finding set)
+// was silently dropped — the caller got the running run's id back and bound its
+// success handler to a verdict computed from someone else's options.
+// ---------------------------------------------------------------------------
+
+// The background run is fire-and-forget, so let the event loop drain until the
+// runner reports the key idle (bounded, so a hang fails the test rather than the
+// suite). A finished run lingers in the map for its replay window but is no
+// longer `active`, which is exactly the state the restart assertions need.
+const settle = async (isActive, key) => {
+  for (let i = 0; i < 500 && isActive(key); i += 1) await new Promise((r) => setTimeout(r, 0));
+  expect(isActive(key)).toBe(false);
+};
+
+describe('startSeriesReviewRun — conflicting start options (#4113)', () => {
+  it('coalesces a second start that would run the SAME review', async () => {
+    const first = startSeriesReviewRun('ser-same', { feedback: 'the middle sags' });
+    const second = startSeriesReviewRun('ser-same', { feedback: 'the middle sags' });
+    expect(second).toEqual({ runId: first.runId, alreadyRunning: true });
+    expect(second.conflict).toBeUndefined();
+    await settle(isSeriesReviewActive, 'ser-same');
+    // One coordinator, not two.
+    expect(runEditorialChecks).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a conflict for a start carrying a DIFFERENT note instead of dropping it', async () => {
+    const first = startSeriesReviewRun('ser-note', { feedback: 'the middle sags' });
+    const second = startSeriesReviewRun('ser-note', { feedback: 'the ending lands flat' });
+    expect(second).toMatchObject({ runId: first.runId, alreadyRunning: true, conflict: true });
+    await settle(isSeriesReviewActive, 'ser-note');
+    // The conflicting start never became a second run — and its note was never
+    // seeded, which is the whole point of refusing it out loud.
+    expect(runEditorialChecks).toHaveBeenCalledTimes(1);
+    expect(seedReviewFromFindings).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['a provider override', { providerOverride: 'example-provider' }],
+    ['force', { force: true }],
+    ['a readiness gate', { readinessGate: 'noOpenHighOrMedium' }],
+  ])('reports a conflict for a start carrying %s', async (label, options) => {
+    const key = `ser-opt-${label.replace(/[^a-z]/gi, '')}`;
+    startSeriesReviewRun(key, {});
+    expect(startSeriesReviewRun(key, options)).toMatchObject({ alreadyRunning: true, conflict: true });
+    await settle(isSeriesReviewActive, key);
+  });
+
+  it('starts a fresh run for divergent options once the first has finished', async () => {
+    const first = startSeriesReviewRun('ser-after', {});
+    await settle(isSeriesReviewActive, 'ser-after');
+    // The finished run is still in its replay window — it must NOT report a
+    // conflict, it must be replaced.
+    const second = startSeriesReviewRun('ser-after', { force: true });
+    expect(second.alreadyRunning).toBe(false);
+    expect(second.conflict).toBeUndefined();
+    expect(second.runId).not.toBe(first.runId);
+    await settle(isSeriesReviewActive, 'ser-after');
+    expect(runEditorialChecks).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('startSeriesFixRun — conflicting start options (#4113)', () => {
+  it('coalesces a second start over the same finding set', async () => {
+    const first = startSeriesFixRun('ser-fix-same', { commentIds: ['mrc-1', 'mrc-2'] });
+    // Same set, different order — the same work.
+    const second = startSeriesFixRun('ser-fix-same', { commentIds: ['mrc-2', 'mrc-1'] });
+    expect(second).toEqual({ runId: first.runId, alreadyRunning: true });
+    await settle(isSeriesFixActive, 'ser-fix-same');
+  });
+
+  it('reports a conflict for a start scoped to a DIFFERENT finding set', async () => {
+    const first = startSeriesFixRun('ser-fix-diff', { commentIds: ['mrc-1'] });
+    const second = startSeriesFixRun('ser-fix-diff', { commentIds: ['mrc-1', 'mrc-2'] });
+    expect(second).toMatchObject({ runId: first.runId, alreadyRunning: true, conflict: true });
+    await settle(isSeriesFixActive, 'ser-fix-diff');
   });
 });

--- a/server/services/pipeline/seriesReview.test.js
+++ b/server/services/pipeline/seriesReview.test.js
@@ -8,6 +8,8 @@ import {
   seriesReviewInputsHash,
   isSeriesReviewSourceStale,
   isSeriesReviewFindingsStale,
+  seriesReviewRequestSig,
+  seriesFixRequestSig,
 } from './seriesReview.js';
 
 describe('computeReviewVerdict', () => {
@@ -288,5 +290,64 @@ describe('isSeriesReviewFindingsStale', () => {
 
   it('accepts an array of live ids (not only a Set)', () => {
     expect(isSeriesReviewFindingsStale({ findingIds: ['a'] }, ['a'])).toBe(false);
+  });
+});
+
+// The signatures the SSE runner coalesces on (#4113). Same signature = same work
+// (safe to attach a second start to the in-flight run); different signature =
+// different work, which must report a conflict instead of silently dropping the
+// second start's options.
+describe('seriesReviewRequestSig', () => {
+  it('matches for two starts that would run the same review', () => {
+    expect(seriesReviewRequestSig({ feedback: 'pacing drags', force: true }))
+      .toBe(seriesReviewRequestSig({ feedback: 'pacing drags', force: true }));
+  });
+
+  it('treats absent, empty, and whitespace-only feedback as the same (no) note', () => {
+    const none = seriesReviewRequestSig({});
+    expect(seriesReviewRequestSig({ feedback: '' })).toBe(none);
+    expect(seriesReviewRequestSig({ feedback: '   \n' })).toBe(none);
+  });
+
+  it('ignores surrounding whitespace on a real note, matching the service trim', () => {
+    expect(seriesReviewRequestSig({ feedback: '  pacing drags  ' }))
+      .toBe(seriesReviewRequestSig({ feedback: 'pacing drags' }));
+  });
+
+  it.each([
+    ['a different note', { feedback: 'pacing drags' }, { feedback: 'the ending lands flat' }],
+    ['a provider override', {}, { providerOverride: 'example-provider' }],
+    ['a model override', {}, { modelOverride: 'example-model' }],
+    ['force', {}, { force: true }],
+    ['a readiness gate', {}, { readinessGate: 'noOpenHighOrMedium' }],
+  ])('diverges on %s', (_label, a, b) => {
+    expect(seriesReviewRequestSig(a)).not.toBe(seriesReviewRequestSig(b));
+  });
+
+  it('does not conflate a note with the same text in another field', () => {
+    expect(seriesReviewRequestSig({ feedback: 'x' })).not.toBe(seriesReviewRequestSig({ modelOverride: 'x' }));
+  });
+});
+
+describe('seriesFixRequestSig', () => {
+  it('matches for the same finding set in a different order', () => {
+    expect(seriesFixRequestSig({ commentIds: ['mrc-2', 'mrc-1'] }))
+      .toBe(seriesFixRequestSig({ commentIds: ['mrc-1', 'mrc-2'] }));
+  });
+
+  it('treats an absent and an empty id list as the same "every open finding" pass', () => {
+    expect(seriesFixRequestSig({ commentIds: [] })).toBe(seriesFixRequestSig({}));
+  });
+
+  it('diverges when the finding set differs — that run WRITES the manuscript', () => {
+    expect(seriesFixRequestSig({ commentIds: ['mrc-1'] }))
+      .not.toBe(seriesFixRequestSig({ commentIds: ['mrc-1', 'mrc-2'] }));
+    // A scoped pass is NOT the same work as the unscoped "fix everything" pass.
+    expect(seriesFixRequestSig({ commentIds: ['mrc-1'] })).not.toBe(seriesFixRequestSig({}));
+  });
+
+  it('diverges on a provider/model override', () => {
+    expect(seriesFixRequestSig({})).not.toBe(seriesFixRequestSig({ providerOverride: 'example-provider' }));
+    expect(seriesFixRequestSig({})).not.toBe(seriesFixRequestSig({ modelOverride: 'example-model' }));
   });
 });


### PR DESCRIPTION
## Summary

`startSeriesReviewRun` coalesced **any** second start for a `seriesId` onto the run already in flight, so a start carrying different `feedback` / `providerId` / `model` / `force` / `readinessGate` got the running run's id back and its own options were silently dropped — the caller then bound its success handler to a verdict computed from someone else's request. `startSeriesFixRun` had the same shape with higher stakes: it *writes* the manuscript, so a start scoped to a different finding set could report another pass's `fixed`/`skipped` totals as its own.

`createSseRunner` already supports optional signature-based coalescing (the `sig` parameter, used today by `storyBuilderRunner`). Both runners now pass one:

- `seriesReviewRequestSig({ feedback, providerOverride, modelOverride, force, readinessGate })` — feedback trimmed, so a blank note and an absent one are the same work (matching the service's own `feedback && trim()` gate).
- `seriesFixRequestSig({ commentIds, providerOverride, modelOverride })` — `commentIds` deduped and sorted, so the same finding set in a different order is the same work; absent and empty both mean "every open finding", which is what `runSeriesFix` does with either.

A matching signature still coalesces (a reload/remount re-attaching to its own request); a divergent one returns `{ runId, alreadyRunning: true, conflict: true }`. The routes already spread the runner result verbatim, so the conflict reaches the client unchanged — now covered by a route test so a later refactor that picks named fields off the result can't swallow it. `SeriesReviewPanel` surfaces the conflict with a toast and stays out of the reviewing/fixing state, keeping the user's un-taken note in the textarea instead of clearing it.

Scope note: the fix runner was rolled in rather than left for a follow-up — identical bug, same helper shape, and the consequence there is a misreported manuscript write.

## Test plan

- `cd server && NODE_ENV=test npx vitest run services/pipeline routes/pipeline lib/sseUtils.test.js services/storyBuilderRunner.test.js` — 2280 passed, 13 skipped.
- `cd client && npx vitest run src/components/pipeline` — 290 passed (23 files), including the new `SeriesReviewPanel.test.jsx`.
- `cd client && npm run lint` — clean.
- New coverage:
  - `seriesReview.test.js` — the two pure signature helpers (whitespace-only note ≡ no note, reordered `commentIds` ≡ same set, divergence on each option).
  - `seriesReview.run.test.js` — same-options start coalesces to one coordinator; divergent note / provider / force / readiness gate reports `conflict` and never seeds a second run; a finished run in its replay window is replaced rather than reported as a conflict; both cases for the fix runner.
  - `routes/pipeline/editorial.test.js` — the conflict passes through both POST routes with a 200.

Closes #4113
