### PR TITLE
fix: make the CoS memory graph usable on a phone — viewport-relative canvas, collapsible legend, clamped tooltip (#4117)

### DIFF
--- a/.changelog/next/fixed-issue-4117.md
+++ b/.changelog/next/fixed-issue-4117.md
@@ -1,0 +1,1 @@
+- CoS memory graph is usable on a phone: the 3D canvas is viewport-relative instead of a fixed 500px, the legend collapses behind a toggle on a small viewport, and the hover tooltip is clamped inside the window

--- a/client/src/components/cos/tabs/MemoryGraph.jsx
+++ b/client/src/components/cos/tabs/MemoryGraph.jsx
@@ -2,11 +2,18 @@ import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls } from '@react-three/drei';
 import * as THREE from 'three';
+import { Info } from 'lucide-react';
 import * as api from '../../../services/api';
 import { MEMORY_TYPES, MEMORY_TYPE_COLORS } from '../constants';
 import { buildGraph } from '../../../lib/graphSimulation';
 import BrailleSpinner from '../../BrailleSpinner';
+import useHoverTooltip from '../../../hooks/useHoverTooltip';
 import { formatDateNumeric } from '../../../utils/formatters';
+
+// Widest the hover tooltip renders. Single source for both its max-width and
+// the clamp that keeps it inside the viewport — as a CSS class plus a mirrored
+// constant the two silently drift apart.
+const TOOLTIP_WIDTH = 320;
 
 const TYPE_HEX = {
   fact: '#3b82f6',
@@ -86,7 +93,10 @@ function GraphScene({ graph, selectedId, adjacentIds, onSelect, onHover }) {
             scale={radius}
             position={[node.x, node.y, node.z]}
             onClick={(e) => { e.stopPropagation(); onSelect(node); }}
-            onPointerOver={(e) => { e.stopPropagation(); onHover(node); }}
+            // Pass the enter event's coordinates up: the wrapper's onPointerMove
+            // only tracks the cursor WHILE a node is hovered, so the tooltip's
+            // first frame has to be placed from this event.
+            onPointerOver={(e) => { e.stopPropagation(); onHover(node, { x: e.clientX, y: e.clientY }); }}
             onPointerOut={() => onHover(null)}
           >
             <meshStandardMaterial
@@ -116,9 +126,12 @@ export default function MemoryGraph() {
   const [loading, setLoading] = useState(true);
   const [selectedNode, setSelectedNode] = useState(null);
   const [fullMemory, setFullMemory] = useState(null);
-  const [hoveredNode, setHoveredNode] = useState(null);
-  const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+  // Hover tooltip state + the ref-gated pointer tracking that keeps a plain
+  // mouse move from re-rendering this component when nothing can paint.
+  const { hoveredNode, tooltipPos, handleHover, handlePointerMove } = useHoverTooltip();
   const [layoutKey, setLayoutKey] = useState(0);
+  // Mobile-only: the legend auto-shows on a roomy viewport (CSS, not this flag).
+  const [legendOpen, setLegendOpen] = useState(false);
 
   const graphRef = useRef(null);
   const dragStartRef = useRef(null);
@@ -171,10 +184,6 @@ export default function MemoryGraph() {
     setSelectedNode(prev => prev?.id === node.id ? null : node);
   }, []);
 
-  const handleHover = useCallback((node) => {
-    setHoveredNode(node);
-  }, []);
-
   const handlePointerMissed = useCallback((e) => {
     const start = dragStartRef.current;
     if (!start) return;
@@ -214,12 +223,15 @@ export default function MemoryGraph() {
         </button>
       </div>
 
-      {/* 3D Canvas */}
+      {/* 3D Canvas. Viewport-relative rather than a flat 500px: the canvas is a
+          touch-action:none dead zone for page scrolling, so on a phone (and
+          especially in landscape, where 500px overflowed the whole viewport) it
+          has to leave room to scroll past. Caps at the original 500px on
+          desktop, floors at 240px so it stays usable on a short viewport. */}
       <div
-        className="relative bg-port-card border border-port-border rounded-lg overflow-hidden"
-        style={{ height: '500px' }}
+        className="relative bg-port-card border border-port-border rounded-lg overflow-hidden h-[clamp(240px,45vh,500px)]"
         onPointerDown={(e) => { dragStartRef.current = { x: e.clientX, y: e.clientY }; }}
-        onPointerMove={(e) => setTooltipPos({ x: e.clientX, y: e.clientY })}
+        onPointerMove={handlePointerMove}
       >
         {graph && (
           <Canvas
@@ -239,34 +251,68 @@ export default function MemoryGraph() {
           </Canvas>
         )}
 
-        {/* Legend */}
-        <div className="absolute bottom-3 left-3 bg-port-bg/90 border border-port-border rounded-lg p-3 text-xs space-y-1.5 pointer-events-none">
-          {MEMORY_TYPES.map(t => (
-            <div key={t} className="flex items-center gap-2">
-              <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: TYPE_HEX[t] }} />
-              <span className="text-gray-400">{t}</span>
-            </div>
-          ))}
-          <div className="border-t border-port-border pt-1.5 mt-1.5 space-y-1">
-            <div className="flex items-center gap-2">
-              {/* Stays a fixed blue (not port-accent) to match GraphEdges' hardcoded
-                  #3b82f6 three.js edge color below — theming just the legend would
-                  desync it from the actual rendered edge color on non-blue themes. */}
-              <span className="inline-block w-4 h-0 border-t border-blue-400" />
-              <span className="text-gray-500">linked</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="inline-block w-4 h-0 border-t border-gray-500" />
-              <span className="text-gray-500">similar</span>
+        {/* Legend. Its ~200px blankets a short canvas, so it auto-shows only on
+            a `roomy-viewport` (wide AND tall — see index.css); otherwise it
+            collapses behind a toggle and expands upward from the corner. The
+            height half of that variant is what makes a landscape phone work: it
+            is wider than `sm` but only ~390px tall, so a width-only rule
+            force-showed the legend over a floored 240px canvas AND hid the
+            toggle — blanketing the graph with no way out.
+            (The edge colours exist nowhere else in this tab, hence a toggle
+            rather than dropping the legend on small screens.) */}
+        {/* pointer-events-none on the WRAPPER, not just the panel: it covers a
+            corner of the canvas, and as a hit-testable box it would swallow the
+            orbit drags the panel alone used to let through (pointer-events is
+            inherited, so the panel needs no declaration of its own; the toggle
+            opts back in). */}
+        <div className="absolute bottom-3 left-3 z-10 flex flex-col items-start gap-1.5 pointer-events-none">
+          <div
+            data-testid="graph-legend"
+            className={`${legendOpen ? 'block' : 'hidden'} roomy-viewport:block bg-port-bg/90 border border-port-border rounded-lg p-3 text-xs space-y-1.5`}
+          >
+            {MEMORY_TYPES.map(t => (
+              <div key={t} className="flex items-center gap-2">
+                <span className="inline-block w-2.5 h-2.5 rounded-full" style={{ backgroundColor: TYPE_HEX[t] }} />
+                <span className="text-gray-400">{t}</span>
+              </div>
+            ))}
+            <div className="border-t border-port-border pt-1.5 mt-1.5 space-y-1">
+              <div className="flex items-center gap-2">
+                {/* Stays a fixed blue (not port-accent) to match GraphEdges' hardcoded
+                    #3b82f6 three.js edge color below — theming just the legend would
+                    desync it from the actual rendered edge color on non-blue themes. */}
+                <span className="inline-block w-4 h-0 border-t border-blue-400" />
+                <span className="text-gray-500">linked</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <span className="inline-block w-4 h-0 border-t border-gray-500" />
+                <span className="text-gray-500">similar</span>
+              </div>
             </div>
           </div>
+          <button
+            onClick={() => setLegendOpen(o => !o)}
+            aria-expanded={legendOpen}
+            className="roomy-viewport:hidden pointer-events-auto flex items-center gap-1.5 px-2.5 py-1.5 min-h-[32px] text-[11px] bg-port-bg/90 border border-port-border text-gray-400 hover:text-white rounded-lg transition-colors"
+          >
+            <Info size={12} />
+            Legend
+          </button>
         </div>
 
-        {/* Tooltip */}
+        {/* Hover tooltip. Suppressed on a coarse pointer: there is no hover to
+            preview with — a tap selects the node and the detail panel below
+            already shows the same record — and it would otherwise flash under
+            the user's own finger. Position is clamped so it can't run off the
+            right edge of a narrow window, where `x + 12` alone would clip it. */}
         {hoveredNode && (
           <div
-            className="fixed z-50 pointer-events-none bg-port-bg border border-port-border rounded-lg px-3 py-2 shadow-lg max-w-xs"
-            style={{ left: tooltipPos.x + 12, top: tooltipPos.y - 12 }}
+            className="fixed z-50 pointer-events-none pointer-coarse:hidden bg-port-bg border border-port-border rounded-lg px-3 py-2 shadow-lg"
+            style={{
+              maxWidth: TOOLTIP_WIDTH,
+              left: Math.max(8, Math.min(tooltipPos.x + 12, window.innerWidth - TOOLTIP_WIDTH - 8)),
+              top: Math.max(8, tooltipPos.y - 12)
+            }}
           >
             <div className="flex items-center gap-2 mb-1">
               <span className={`px-1.5 py-0.5 text-[10px] rounded-full border ${MEMORY_TYPE_COLORS[hoveredNode.type] || 'border-port-border text-gray-400'}`}>

--- a/client/src/components/cos/tabs/MemoryGraph.test.jsx
+++ b/client/src/components/cos/tabs/MemoryGraph.test.jsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// The three.js stack can't run in jsdom (no WebGL context), and none of it is
+// under test here — this file covers the responsive chrome AROUND the canvas.
+// The stub deliberately drops `children` from the render: mounting the scene
+// would create <bufferGeometry>/<mesh> as unknown DOM elements. It still
+// *captures* the element so a test can reach GraphScene's callbacks (the only
+// way to open the hover tooltip without a real raycast).
+let sceneElement = null;
+vi.mock('@react-three/fiber', () => ({
+  Canvas: ({ children }) => {
+    sceneElement = children;
+    return <div data-testid="graph-canvas" />;
+  },
+}));
+vi.mock('@react-three/drei', () => ({ OrbitControls: () => null }));
+
+vi.mock('../../../services/api', () => ({
+  getMemoryGraph: vi.fn(),
+  getMemory: vi.fn(),
+}));
+
+import * as api from '../../../services/api';
+import MemoryGraph from './MemoryGraph';
+
+const GRAPH = {
+  nodes: [
+    { id: 'n1', type: 'fact', category: 'general', summary: 'first', importance: 0.5 },
+    { id: 'n2', type: 'learning', category: 'general', summary: 'second', importance: 0.5 },
+  ],
+  edges: [{ source: 'n1', target: 'n2', type: 'linked', weight: 0.9 }],
+};
+
+const renderGraph = async () => {
+  render(<MemoryGraph />);
+  // Settle the mount-effect fetch inside act (see src/test/setup.js).
+  await act(async () => {});
+};
+
+// Open the tooltip the way a hovered node does — GraphScene is never mounted,
+// so call the handler the component handed it.
+const hoverNode = async (node, point) => {
+  await act(async () => { sceneElement.props.onHover(node, point); });
+};
+
+const originalInnerWidth = window.innerWidth;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sceneElement = null;
+  api.getMemoryGraph.mockResolvedValue(GRAPH);
+  api.getMemory.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  window.innerWidth = originalInnerWidth;
+});
+
+describe('canvas sizing', () => {
+  it('sizes the canvas relative to the viewport, not a fixed pixel height', async () => {
+    await renderGraph();
+    const shell = screen.getByTestId('graph-canvas').parentElement;
+    // The regression guarded here is the old `style={{ height: '500px' }}`,
+    // which overflowed a landscape phone and left no room to scroll past a
+    // canvas that swallows drags. The exact clamp values are free to be tuned,
+    // so only assert it is viewport-relative.
+    expect(shell.style.height).toBe('');
+    expect(shell.className).toMatch(/h-\[clamp\([^\]]*vh[^\]]*\)\]/);
+  });
+});
+
+// The legend sits over the canvas and blankets a phone-sized graph, so on a
+// small viewport it hides behind a toggle. It must stay reachable — the edge
+// colours appear nowhere else in this tab — rather than be dropped.
+describe('legend disclosure', () => {
+  it('starts collapsed and expands when the mobile toggle is pressed', async () => {
+    const user = userEvent.setup();
+    await renderGraph();
+
+    const toggle = screen.getByRole('button', { name: /legend/i });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    // `hidden` is the mobile-collapsed state — the panel stays in the DOM, and
+    // `roomy-viewport:block` re-shows it on a roomy viewport regardless.
+    expect(screen.getByTestId('graph-legend')).toHaveClass('hidden');
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByTestId('graph-legend')).not.toHaveClass('hidden');
+  });
+
+  it('gates the auto-show on viewport height as well as width', async () => {
+    await renderGraph();
+    // A landscape phone is WIDER than `sm` but only ~390px tall, so a width-only
+    // (`sm:`) gate force-shows the legend over a floored 240px canvas while
+    // hiding the toggle — un-dismissable, in the exact case this targets.
+    expect(screen.getByTestId('graph-legend')).toHaveClass('roomy-viewport:block');
+    expect(screen.getByTestId('graph-legend')).not.toHaveClass('sm:block');
+    expect(screen.getByRole('button', { name: /legend/i })).toHaveClass('roomy-viewport:hidden');
+  });
+
+  it('does not swallow the canvas drags underneath it', async () => {
+    await renderGraph();
+    // The legend's wrapper covers a corner of the canvas. It must not be
+    // hit-testable, or it eats the orbit drags that pass through the panel —
+    // pointer-events is inherited, so the wrapper carries the opt-out and only
+    // the toggle opts back in.
+    expect(screen.getByTestId('graph-legend').parentElement).toHaveClass('pointer-events-none');
+    expect(screen.getByRole('button', { name: /legend/i })).toHaveClass('pointer-events-auto');
+  });
+
+  it('keeps the edge-colour key reachable when collapsed', async () => {
+    await renderGraph();
+    for (const label of ['linked', 'similar']) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+});
+
+describe('hover tooltip placement', () => {
+  const tooltipOf = (node) => node.closest('.fixed');
+
+  it('clamps against the right edge of a narrow viewport', async () => {
+    window.innerWidth = 375;
+    await renderGraph();
+    // Unclamped this was `left: x + 12` = 372px on a 375px-wide screen, which
+    // pushed a ~320px tooltip almost entirely off-screen.
+    await hoverNode(GRAPH.nodes[0], { x: 360, y: 200 });
+
+    const tooltip = tooltipOf(screen.getByText('first'));
+    // 375 - 320 (tooltip width) - 8 (gutter) = 47.
+    expect(tooltip.style.left).toBe('47px');
+    expect(tooltip.style.maxWidth).toBe('320px');
+  });
+
+  it('keeps the cursor offset when there is room, and floors the top edge', async () => {
+    window.innerWidth = 1024;
+    await renderGraph();
+    await hoverNode(GRAPH.nodes[1], { x: 100, y: 4 });
+
+    const tooltip = tooltipOf(screen.getByText('second'));
+    expect(tooltip.style.left).toBe('112px');
+    // `y - 12` would be -8, floating the tooltip above the window.
+    expect(tooltip.style.top).toBe('8px');
+  });
+
+  it('is suppressed on a coarse pointer rather than flashing under a finger', async () => {
+    await renderGraph();
+    await hoverNode(GRAPH.nodes[0], { x: 100, y: 100 });
+    expect(tooltipOf(screen.getByText('first'))).toHaveClass('pointer-coarse:hidden');
+  });
+});


### PR DESCRIPTION
## Summary

`client/src/components/cos/tabs/MemoryGraph.jsx` is a near-literal fork of BrainGraph's canvas shell and still carried all three defects the Brain Graph mobile pass already fixed. This ports each fix across independently — per the issue, no shared `<GraphCanvasShell>` is extracted, since there are only two call sites and the surrounding chrome has genuinely diverged.

- **Viewport-relative canvas.** `style={{ height: '500px' }}` → `h-[clamp(240px,45vh,500px)]`. The canvas is a `touch-action: none` dead zone for page scrolling, so a flat 500px overflowed a landscape phone with no room to scroll past it. Caps at the original 500px on desktop, floors at 240px.
- **Mobile-aware legend.** The always-on `absolute bottom-3 left-3` block now auto-shows only on a `roomy-viewport` (wide **and** tall — the custom variant in `index.css`) and otherwise collapses behind an `Info` toggle. The height half of that gate is what makes landscape work: a landscape phone is wider than `sm` but ~390px tall, so a width-only rule would force-show a ~200px legend over a floored 240px canvas *and* hide the toggle. The legend's wrapper is `pointer-events-none` so it doesn't swallow orbit drags; the toggle opts back in. The legend is collapsed rather than dropped because the edge-colour key (linked / similar) appears nowhere else in the tab.
- **Clamped tooltip.** `left: tooltipPos.x + 12` with `max-w-xs` → a single `TOOLTIP_WIDTH` constant driving both `maxWidth` and a clamp against the window's right edge, plus a floor on `top`. Also `pointer-coarse:hidden`, matching BrainGraph: a finger has no hover to preview with, and the tooltip would otherwise flash under the user's own touch.

The hand-rolled `hoveredNode` / `tooltipPos` state is replaced by the existing `useHoverTooltip` hook (`client/src/hooks/useHoverTooltip.js`) that BrainGraph already uses — it is the ref-gated companion to `pointer-coarse:hidden`, dropping pointer moves that can't paint instead of re-rendering the tab on every pixel.

## Test plan

New `client/src/components/cos/tabs/MemoryGraph.test.jsx` (8 tests), mirroring BrainGraph's suite. The three.js stack can't run in jsdom, so `Canvas` is stubbed childless; the stub captures the `GraphScene` element so a test can invoke its `onHover` callback and open the tooltip without a real raycast.

- canvas sizing: no inline `style.height`, class matches a `vh`-relative clamp
- legend: starts collapsed, toggle flips `aria-expanded` and the `hidden` class; auto-show is `roomy-viewport:block` and explicitly **not** `sm:block`; wrapper is `pointer-events-none` / toggle `pointer-events-auto`; the linked/similar key stays in the DOM
- tooltip: clamps to `left: 47px` on a 375px viewport (unclamped it was 372px), keeps the `+12` cursor offset when there is room, floors `top` at 8px, carries `pointer-coarse:hidden`

```
cd client && npx vitest run src/components/cos src/components/brain
  → 30 files, 351 tests passed
npx biome lint src/components/cos/tabs/MemoryGraph.jsx src/components/cos/tabs/MemoryGraph.test.jsx
  → clean
```

Closes #4117
