### PR TITLE
Route goal selection through /goals/list/:goalId so a specific goal is deep-linkable

### DIFF
--- a/.changelog/next/changed-issue-4121.md
+++ b/.changelog/next/changed-issue-4121.md
@@ -1,0 +1,1 @@
+- Goals: opening a goal now updates the URL (/goals/list/<id>), so a specific goal is shareable, bookmarkable and reload-safe — and the Character sheet's Life Goals card links straight to the goal you clicked

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -283,6 +283,7 @@ export default function App() {
           <Route path="privacy/:tab" element={<Privacy />} />
           <Route path="goals" element={<Navigate to="/goals/tree" replace />} />
           <Route path="goals/:tab" element={<Goals />} />
+          <Route path="goals/list/:goalId" element={<Goals />} />
           <Route path="feature-agents" element={<FeatureAgents />} />
           <Route path="feature-agents/create" element={<FeatureAgentDetail />} />
           <Route path="feature-agents/:id" element={<Navigate to="overview" replace />} />

--- a/client/src/components/character/GoalsCard.jsx
+++ b/client/src/components/character/GoalsCard.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 import { Target, ArrowRight } from 'lucide-react';
 import { getGoalsTree } from '../../services/api';
 import BrailleSpinner from '../BrailleSpinner';
+import { GOALS_LIST_PATH, goalDetailPath } from '../goals/goalConstants';
 
 // The human's real life-goals, surfaced read-only on the Character sheet (#2675) so the sheet
 // reflects what the person is actually working toward. Surface, don't duplicate: the goals
@@ -12,11 +13,6 @@ import BrailleSpinner from '../BrailleSpinner';
 // Like SkillsCard/MetricsCard on the same page this is deliberately a plain read-only card —
 // Slice 5 (#2677) owns the page's framing/redesign, so it stays easy to restyle or relocate
 // wholesale.
-
-// Goals has no routed per-goal detail today (GoalsListView selects into a local `selectedGoal`
-// panel), so every row links to the list rather than inventing a deep link the router cannot
-// honor. Routing that selection through the URL is the goals feature's job — see #4121.
-export const GOALS_PATH = '/goals/list';
 
 const TOP_N = 4;
 
@@ -56,7 +52,10 @@ function GoalRow({ goal }) {
 
   return (
     <Link
-      to={GOALS_PATH}
+      // Deep-links straight to this goal's detail panel (#4121) — the sheet is a
+      // signpost, so a row that dumped the user on the generic list made them hunt
+      // for the goal they just clicked.
+      to={goalDetailPath(goal.id)}
       // Named explicitly: the row's own text nodes would otherwise concatenate into a
       // redundant "Example Goal 25%" that never says where the link goes. The bar itself is
       // decorative — the percentage text is its accessible representation, matching how the
@@ -124,7 +123,7 @@ export default function GoalsCard() {
         <h2 id="character-goals-heading" className="text-sm font-medium text-gray-300">Life Goals</h2>
         <span className="text-xs text-gray-500">— what you're actually working toward</span>
         {state.status === 'ready' && top.length > 0 && (
-          <Link to={GOALS_PATH} className="ml-auto text-xs text-port-accent hover:underline shrink-0">
+          <Link to={GOALS_LIST_PATH} className="ml-auto text-xs text-port-accent hover:underline shrink-0">
             View all
           </Link>
         )}
@@ -135,7 +134,7 @@ export default function GoalsCard() {
       {state.status === 'error' && (
         <p className="text-sm text-gray-500">
           Your goals could not be loaded right now.{' '}
-          <Link to={GOALS_PATH} className="text-port-accent hover:underline">Open Goals</Link>
+          <Link to={GOALS_LIST_PATH} className="text-port-accent hover:underline">Open Goals</Link>
         </p>
       )}
 
@@ -146,7 +145,7 @@ export default function GoalsCard() {
             Your sheet reflects what you're working toward — set a goal to fill it in.
           </p>
           <Link
-            to={GOALS_PATH}
+            to={GOALS_LIST_PATH}
             className="inline-flex items-center gap-1.5 mt-3 px-3 py-1.5 rounded-lg text-sm font-medium bg-port-accent/20 text-port-accent hover:bg-port-accent/30 transition-colors"
           >
             Set your goals <ArrowRight className="w-3.5 h-3.5" />

--- a/client/src/components/character/GoalsCard.test.jsx
+++ b/client/src/components/character/GoalsCard.test.jsx
@@ -14,7 +14,8 @@ vi.mock('../../services/api', () => ({
   getGoalsTree: (...a) => getGoalsTree(...a),
 }));
 
-import GoalsCard, { selectTopGoals, progressPct, GOALS_PATH } from './GoalsCard';
+import GoalsCard, { selectTopGoals, progressPct } from './GoalsCard';
+import { GOALS_LIST_PATH, goalDetailPath } from '../goals/goalConstants';
 
 const goal = (overrides = {}) => ({
   id: 'goal-1',
@@ -121,7 +122,7 @@ describe('progressPct', () => {
 });
 
 describe('GoalsCard — populated', () => {
-  it('renders each active goal with its title, progress and a link to Goals', async () => {
+  it('renders each active goal with its title, progress and a deep link to that goal', async () => {
     const card = await renderCard([
       goal({ id: 'a', title: 'Ship Example Project', progress: 25, urgency: 0.9 }),
       goal({ id: 'b', title: 'Learn Example Skill', progress: 60, urgency: 0.2 }),
@@ -132,9 +133,21 @@ describe('GoalsCard — populated', () => {
     expect(card.getByText('Learn Example Skill')).toBeInTheDocument();
     expect(card.getByText('60%')).toBeInTheDocument();
 
-    for (const link of card.getAllByRole('link')) {
-      expect(link).toHaveAttribute('href', GOALS_PATH);
-    }
+    // #4121: each row addresses its OWN goal, not the generic list — the whole point of
+    // routing goal selection through the URL. Asserted per-goal (not "every link matches
+    // one path") so a regression back to the bare list can't pass.
+    expect(card.getByRole('link', { name: /Ship Example Project/ }))
+      .toHaveAttribute('href', goalDetailPath('a'));
+    expect(card.getByRole('link', { name: /Learn Example Skill/ }))
+      .toHaveAttribute('href', goalDetailPath('b'));
+    // The header's "View all" is the one link that legitimately stays on the index.
+    expect(card.getByRole('link', { name: 'View all' })).toHaveAttribute('href', GOALS_LIST_PATH);
+  });
+
+  it('escapes a goal id that is not URL-safe rather than emitting a broken href', async () => {
+    const card = await renderCard([goal({ id: 'a/b?c', title: 'Example Odd Id Goal' })]);
+    expect(card.getByRole('link', { name: /Example Odd Id Goal/ }))
+      .toHaveAttribute('href', '/goals/list/a%2Fb%3Fc');
   });
 
   it('orders the rendered rows most-urgent first', async () => {
@@ -176,7 +189,7 @@ describe('GoalsCard — empty', () => {
     const card = await renderCard([]);
 
     expect(card.getByText('No active goals yet.')).toBeInTheDocument();
-    expect(card.getByRole('link', { name: /Set your goals/ })).toHaveAttribute('href', GOALS_PATH);
+    expect(card.getByRole('link', { name: /Set your goals/ })).toHaveAttribute('href', GOALS_LIST_PATH);
     // A real empty state, not a broken/blank block.
     expect(card.queryByRole('link', { name: /Open in Goals/ })).not.toBeInTheDocument();
   });
@@ -208,7 +221,7 @@ describe('GoalsCard — error', () => {
     const card = within(await screen.findByRole('region', { name: 'Life Goals' }));
     await waitFor(() => expect(card.getByText(/could not be loaded/)).toBeInTheDocument());
     expect(card.queryByText('No active goals yet.')).not.toBeInTheDocument();
-    expect(card.getByRole('link', { name: 'Open Goals' })).toHaveAttribute('href', GOALS_PATH);
+    expect(card.getByRole('link', { name: 'Open Goals' })).toHaveAttribute('href', GOALS_LIST_PATH);
   });
 
   it('treats a malformed payload as an error, not as an empty goal list', async () => {

--- a/client/src/components/goals/GoalsListView.jsx
+++ b/client/src/components/goals/GoalsListView.jsx
@@ -1,11 +1,13 @@
 import { useState, useMemo, useCallback, useEffect } from 'react';
+import { useNavigate } from 'react-router';
 import {
-  ChevronRight, ChevronDown, Plus, GripVertical, Search, Tag, Link2, Crown, Star, Wand2
+  ChevronRight, ChevronDown, Plus, GripVertical, Search, Tag, Link2, Crown, Star, Wand2, AlertTriangle
 } from 'lucide-react';
 import toast from '../ui/Toast';
 import { DndContext, DragOverlay, PointerSensor, useSensor, useSensors, useDraggable, useDroppable } from '@dnd-kit/core';
 import * as api from '../../services/api';
 import GoalDetailPanel, { CATEGORY_CONFIG, HORIZON_OPTIONS, GOAL_TYPE_CONFIG, DEFAULT_NEW_GOAL } from './GoalDetailPanel';
+import { GOALS_LIST_PATH, goalDetailPath } from './goalConstants';
 import { applyOrganizationSuggestion } from './applyOrganization';
 import EmptyState from '../EmptyState';
 import useProviderModels from '../../hooks/useProviderModels';
@@ -189,9 +191,8 @@ function RootDropZone() {
   );
 }
 
-export default function GoalsListView({ data, onRefresh }) {
+export default function GoalsListView({ data, onRefresh, selectedGoalId }) {
   const [expandedIds, setExpandedIds] = useState(new Set());
-  const [selectedGoal, setSelectedGoal] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [showNewGoal, setShowNewGoal] = useState(false);
   const [newGoal, setNewGoal] = useState({ ...DEFAULT_NEW_GOAL });
@@ -203,7 +204,18 @@ export default function GoalsListView({ data, onRefresh }) {
     setSelectedProviderId, setSelectedModel, loading: providersLoading
   } = useProviderModels({ filter: enabledApiProviderFilter });
 
+  const navigate = useNavigate();
+
   const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+
+  // Which goal is open comes from the route, so the panel is shareable/bookmarkable and
+  // survives a reload. `goalsLoaded` keeps "the tree failed to load" distinct from "this
+  // id isn't in the tree" — only the latter is a genuine not-found.
+  const goalsLoaded = Array.isArray(data?.flat);
+  const selectedGoal = selectedGoalId ? (data?.flat?.find(g => g.id === selectedGoalId) ?? null) : null;
+  const goalNotFound = Boolean(selectedGoalId) && goalsLoaded && !selectedGoal;
+
+  const closeDetail = useCallback(() => navigate(GOALS_LIST_PATH), [navigate]);
 
   useEffect(() => {
     if (!data?.roots) return;
@@ -238,9 +250,10 @@ export default function GoalsListView({ data, onRefresh }) {
     return data.roots.filter(matchesSearch);
   }, [data, searchQuery]);
 
+  // Clicking the open goal closes the panel (unchanged toggle behavior) — expressed as a
+  // navigation back to the list index rather than as a state reset.
   const handleSelect = (goal) => {
-    const full = data?.flat?.find(g => g.id === goal.id);
-    setSelectedGoal(prev => prev?.id === goal.id ? null : full || goal);
+    navigate(goal.id === selectedGoalId ? GOALS_LIST_PATH : goalDetailPath(goal.id));
   };
 
   const handleAddChild = (parentId) => {
@@ -477,7 +490,7 @@ export default function GoalsListView({ data, onRefresh }) {
                   expandedIds={expandedIds}
                   onToggle={toggleExpand}
                   onSelect={handleSelect}
-                  selectedId={selectedGoal?.id}
+                  selectedId={selectedGoalId}
                   onAddChild={handleAddChild}
                   draggedId={draggedGoal?.id}
                 />
@@ -491,17 +504,29 @@ export default function GoalsListView({ data, onRefresh }) {
       </div>
 
       {/* Detail panel — full overlay on mobile, side panel on desktop */}
-      {selectedGoal && (
+      {(selectedGoal || goalNotFound) && (
         <div className="absolute inset-0 sm:relative sm:inset-auto z-20 sm:z-auto">
-          <GoalDetailPanel
-            goal={selectedGoal}
-            allGoals={data?.flat}
-            onClose={() => setSelectedGoal(null)}
-            onRefresh={() => {
-              setSelectedGoal(null);
-              onRefresh();
-            }}
-          />
+          {selectedGoal ? (
+            <GoalDetailPanel
+              goal={selectedGoal}
+              allGoals={data?.flat}
+              onClose={closeDetail}
+              onRefresh={() => {
+                closeDetail();
+                onRefresh();
+              }}
+            />
+          ) : (
+            <div className="w-full sm:w-80 bg-port-card border-l border-port-border h-full overflow-y-auto p-4">
+              <EmptyState
+                icon={AlertTriangle}
+                title="Goal not found"
+                message="This goal no longer exists — it may have been deleted, or the link is out of date."
+                actionTo={GOALS_LIST_PATH}
+                actionLabel="Back to goals"
+              />
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/client/src/components/goals/GoalsListView.test.jsx
+++ b/client/src/components/goals/GoalsListView.test.jsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route, useLocation, useParams } from 'react-router';
 
 const { toastError, toastSuccess, organizeGoals, createGoal, applyGoalOrganization } = vi.hoisted(() => ({
   toastError: vi.fn(),
@@ -30,6 +31,23 @@ vi.mock('../../hooks/useProviderModels', () => ({
   }),
 }));
 
+// The real detail panel drags in the whole goal-editing surface (and its own API reads);
+// these tests are about WHICH goal the URL opens, so a stand-in that reports the goal it
+// was handed — and exposes its close/refresh callbacks — is the honest seam.
+vi.mock('./GoalDetailPanel', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    default: ({ goal, onClose, onRefresh }) => (
+      <div>
+        <span>Detail panel: {goal.title}</span>
+        <button type="button" onClick={onClose}>close-detail</button>
+        <button type="button" onClick={onRefresh}>refresh-detail</button>
+      </div>
+    ),
+  };
+});
+
 import GoalsListView from './GoalsListView';
 
 // Invented placeholder goals — never real records from a running install.
@@ -40,8 +58,28 @@ const GOALS = [
 // The Organize button only renders once there are >= 2 goals to reorganize.
 const DATA = { roots: GOALS, flat: GOALS };
 
-const renderList = async (onRefresh = vi.fn()) => {
-  render(<GoalsListView data={DATA} onRefresh={onRefresh} />);
+// Mirrors pages/Goals.jsx: the route owns which goal is open, the view just reads it.
+function RoutedList({ onRefresh, data }) {
+  const { goalId } = useParams();
+  return <GoalsListView data={data} onRefresh={onRefresh} selectedGoalId={goalId} />;
+}
+
+function LocationProbe() {
+  return <span data-testid="pathname">{useLocation().pathname}</span>;
+}
+
+const currentPath = () => screen.getByTestId('pathname').textContent;
+
+const renderList = async (onRefresh = vi.fn(), { path = '/goals/list', data = DATA } = {}) => {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path="/goals/list" element={<RoutedList onRefresh={onRefresh} data={data} />} />
+        <Route path="/goals/list/:goalId" element={<RoutedList onRefresh={onRefresh} data={data} />} />
+      </Routes>
+      <LocationProbe />
+    </MemoryRouter>,
+  );
   await act(async () => {});
   return onRefresh;
 };
@@ -117,5 +155,64 @@ describe('handleOrganize apply-failure path', () => {
     expect(toastError).not.toHaveBeenCalled();
     expect(toastSuccess).toHaveBeenCalledWith('Goal hierarchy applied');
     expect(onRefresh).toHaveBeenCalled();
+  });
+});
+
+// #4121: which goal is open lives in the URL, never in local state — so a specific goal is
+// shareable, bookmarkable, reload-safe, and linkable from the Character sheet's Goals card.
+describe('routed goal selection', () => {
+  it('opens no panel on the bare list route', async () => {
+    await renderList();
+    expect(screen.queryByText(/Detail panel:/)).not.toBeInTheDocument();
+  });
+
+  it('navigates to the goal’s own route when a row is clicked', async () => {
+    const user = userEvent.setup();
+    await renderList();
+
+    await user.click(screen.getByText('Restore the boat'));
+
+    expect(currentPath()).toBe('/goals/list/g2');
+    expect(screen.getByText('Detail panel: Restore the boat')).toBeInTheDocument();
+  });
+
+  it('opens the deep-linked goal on mount, without a click', async () => {
+    await renderList(vi.fn(), { path: '/goals/list/g1' });
+    expect(screen.getByText('Detail panel: Sail across an ocean')).toBeInTheDocument();
+  });
+
+  it('closes the panel by returning to the index when the open goal is clicked again', async () => {
+    const user = userEvent.setup();
+    await renderList(vi.fn(), { path: '/goals/list/g1' });
+
+    await user.click(screen.getByText('Sail across an ocean'));
+
+    expect(currentPath()).toBe('/goals/list');
+    expect(screen.queryByText(/Detail panel:/)).not.toBeInTheDocument();
+  });
+
+  it('returns to the index when the panel closes or the goal is mutated', async () => {
+    const user = userEvent.setup();
+    const onRefresh = await renderList(vi.fn(), { path: '/goals/list/g1' });
+
+    await user.click(screen.getByRole('button', { name: 'refresh-detail' }));
+
+    expect(currentPath()).toBe('/goals/list');
+    expect(onRefresh).toHaveBeenCalled();
+  });
+
+  it('shows a not-found fallback for a stale or deleted goal id', async () => {
+    await renderList(vi.fn(), { path: '/goals/list/deleted-goal' });
+
+    expect(screen.getByText('Goal not found')).toBeInTheDocument();
+    expect(screen.queryByText(/Detail panel:/)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Back to goals' })).toHaveAttribute('href', '/goals/list');
+  });
+
+  it('does NOT claim "not found" when the goal tree itself failed to load', async () => {
+    // The sentinel rule: "we could not read your goals" must never render as "this goal
+    // does not exist" — the deep link may be perfectly valid.
+    await renderList(vi.fn(), { path: '/goals/list/g1', data: null });
+    expect(screen.queryByText('Goal not found')).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/goals/goalConstants.js
+++ b/client/src/components/goals/goalConstants.js
@@ -2,6 +2,12 @@ import {
   Target, Lightbulb, Users, Heart, DollarSign, Flame
 } from 'lucide-react';
 
+// Canonical goals routes. Which goal is open lives in the URL, never in local state
+// (see client/src/CLAUDE.md), so a specific goal is shareable, bookmarkable, and
+// linkable from other surfaces — e.g. the Character sheet's Life Goals card.
+export const GOALS_LIST_PATH = '/goals/list';
+export const goalDetailPath = (goalId) => `${GOALS_LIST_PATH}/${encodeURIComponent(goalId)}`;
+
 export const CATEGORY_CONFIG = {
   creative: { label: 'Creative', icon: Lightbulb, color: 'text-purple-400', bg: 'bg-purple-500/20', hex: '#a855f7' },
   family: { label: 'Family', icon: Users, color: 'text-pink-400', bg: 'bg-pink-500/20', hex: '#ec4899' },

--- a/client/src/pages/Goals.jsx
+++ b/client/src/pages/Goals.jsx
@@ -19,7 +19,9 @@ export const TABS = [
 ];
 
 export default function Goals() {
-  const { tab: rawTab } = useParams();
+  // `/goals/list/:goalId` carries no `:tab` segment, so `useValidTab` falls back to
+  // 'list' — the only view with a routed per-goal detail panel today.
+  const { tab: rawTab, goalId } = useParams();
   const tab = useValidTab(TABS, 'list');
   const navigate = useNavigate();
   const [data, setData] = useState(null);
@@ -76,7 +78,7 @@ export default function Goals() {
         {loading ? (
           <PageSkeleton header="none" label="Loading goals" fullHeight cards={4} sidebar={false} />
         ) : tab === 'list' ? (
-          <GoalsListView data={data} onRefresh={loadData} />
+          <GoalsListView data={data} onRefresh={loadData} selectedGoalId={goalId} />
         ) : (
           <Suspense fallback={<div className="flex items-center justify-center h-full"><BrailleSpinner text="Loading" /></div>}>
             <GoalsTreeView data={data} onRefresh={loadData} />


### PR DESCRIPTION
## Summary

`GoalsListView` held the opened goal in `useState`, so which goal was open never reached the URL — it could not be shared, bookmarked, or survive a reload, and the Character sheet's Life Goals card had to send every row to the generic list because there was no per-goal destination to link to. That violated the repo's "selection lives in the URL, never in local state" convention on its own terms.

**Design choice: a `:goalId` route param, not a `?goal=` search param.** `client/src/CLAUDE.md` calls for a route param for any selectable record, and the goals page already routes its view through a path segment (`/goals/:tab`), so `/goals/list/:goalId` reads as the natural continuation and stays consistent with the other id'd detail routes (`/media/creative-director/:id/:tab`, `/feature-agents/:id/:tab`). No new nav-manifest entry is required: `/goals/list` is already registered as `nav.goals`, and the route-coverage guard deliberately skips `:param` routes.

- `client/src/App.jsx` — adds `goals/list/:goalId`. The bare `goals/:tab` route is unchanged, and the new path carries no `:tab` segment, so `useValidTab` falls back to `list` (the only view with a routed detail panel today; the 3D tree view keeps its own local selection).
- `client/src/components/goals/goalConstants.js` — new `GOALS_LIST_PATH` and `goalDetailPath(id)` (id is URL-escaped) as the one place either path is spelled.
- `client/src/components/goals/GoalsListView.jsx` — `selectedGoal` is derived from the `selectedGoalId` prop instead of local state; selecting navigates, clicking the open goal navigates back to the index (the pre-existing toggle behavior), and close/mutate navigate back too. A stale or deleted id renders a not-found fallback with a link home.
- A failed tree load stays distinct from a genuine not-found — with `data` absent, a valid deep link is *not* labeled "Goal not found" (the sentinel rule from `CLAUDE.md`).
- `client/src/components/character/GoalsCard.jsx` — each row now links to `goalDetailPath(goal.id)`; "View all", the error link, and the empty-state CTA still point at the index. The stale comment explaining why rows could not deep-link is gone.

## Test plan

- `cd client && npx vitest run src/components/goals src/components/character` — 7 files, 105 tests pass.
- New coverage in `GoalsListView.test.jsx` (`routed goal selection`): clicking a row navigates to `/goals/list/<id>`; a deep link opens the panel on mount with no click; re-clicking the open goal returns to the index; the panel's refresh/close return to the index; a stale id renders the not-found fallback; and a failed tree load does **not** render "Goal not found".
- `GoalsCard.test.jsx` asserts each row's `href` per goal (not "every link matches one path", so a regression to the bare list cannot pass), that "View all" stays on the index, and that a non-URL-safe id is escaped rather than emitting a broken href.
- `cd server && NODE_ENV=test npx vitest run lib/navManifest.test.js` — 45 tests pass (the route ↔ nav-manifest coverage guard sees the new route).
- Full client suite: 632 files / 7617 tests pass. `npx biome lint --error-on-warnings` clean on the touched trees.

Closes #4121
