### PR TITLE
fix: default goal status to active during normalization (#4123)

### DIFF
--- a/.changelog/next/fixed-issue-4123.md
+++ b/.changelog/next/fixed-issue-4123.md
@@ -1,0 +1,1 @@
+- MortalLoom-synced goals with no status field are normalized to status 'active', so check-in scheduling, Telegram digests, insights, job gates, and the identity dashboard no longer silently skip goals the voice tools and Character card list as active

--- a/client/src/components/character/GoalsCard.jsx
+++ b/client/src/components/character/GoalsCard.jsx
@@ -24,13 +24,13 @@ const TOP_N = 4;
 // is stable. Real urgencies are clamped to [0,1] server-side, so -1 can never collide.
 const urgencyRank = (urgency) => (Number.isFinite(urgency) ? urgency : -1);
 
-// A missing `status` counts as active, matching server/services/voice/tools/goals.js. Goals
-// synced in from MortalLoom are only run through `normalizeGoal` (server/services/identity/
-// store.js), whose PORTOS_GOAL_DEFAULTS backfills every field EXCEPT status — so a
-// status-less goal is a real, reachable shape, and dropping it here would render a
-// user's populated goal list as "No active goals yet". Erring toward showing a goal is the
-// safe direction: the cost is at worst one stale row, versus a card that lies about the
-// user having no goals at all.
+// A missing `status` counts as active, matching server/services/voice/tools/goals.js.
+// `normalizeGoal` (server/services/identity/store.js) now defaults status to 'active' at the
+// MortalLoom sync boundary (#4123), so the server should no longer hand us a status-less goal —
+// but this stays lenient on purpose: a goals.json record written before status existed never
+// passes through that normalization, and dropping it here would render a user's populated goal
+// list as "No active goals yet". Erring toward showing a goal is the safe direction: the cost is
+// at worst one stale row, versus a card that lies about the user having no goals at all.
 const isActive = (goal) => Boolean(goal) && (goal.status === 'active' || !goal.status);
 
 export function selectTopGoals(goals, limit = TOP_N) {

--- a/client/src/components/character/GoalsCard.test.jsx
+++ b/client/src/components/character/GoalsCard.test.jsx
@@ -60,9 +60,10 @@ describe('selectTopGoals', () => {
   });
 
   it('keeps a status-less goal rather than dropping it', () => {
-    // MortalLoom-synced goals pass through normalizeGoal, whose defaults backfill every field
-    // EXCEPT status. Dropping them would render a populated goal list as "No active goals
-    // yet" — the exact lie the empty state must never tell.
+    // normalizeGoal now stamps status:'active' at the MortalLoom sync boundary (#4123), but a
+    // goals.json record written before status existed never passes through it. Dropping such a
+    // goal would render a populated goal list as "No active goals yet" — the exact lie the
+    // empty state must never tell.
     const picked = selectTopGoals([goal({ id: 'ml', status: undefined })]);
     expect(picked.map(g => g.id)).toEqual(['ml']);
   });

--- a/server/services/identity/store.js
+++ b/server/services/identity/store.js
@@ -17,10 +17,27 @@ export const PORTOS_GOAL_DEFAULTS = {
   scheduledEvents: [],
   checkIns: [],
   milestones: [],
-  goalType: 'standard'
+  goalType: 'standard',
+  // A PortOS-created goal always gets `status: 'active'` (`createGoal` in goals.js), but a
+  // MortalLoom-synced one may carry no status at all — and this is the ONLY normalization it
+  // passes through. Without a default the codebase splits on what that means: the voice tools
+  // and the Character card treat a status-less goal as active, while check-in scheduling,
+  // Telegram digests, insights, jobGates, and getGoalsTree's own urgency enrichment all test
+  // `status === 'active'` and silently skip it. Same goal, listed in one place and invisible in
+  // the other. Defaulting here makes both readings agree at the sync boundary (#4123).
+  status: 'active'
 };
 
-export const normalizeGoal = g => ({ ...PORTOS_GOAL_DEFAULTS, ...g });
+// A falsy status — absent, null, or '' — is never a legitimate value (there is no "no status"
+// goal state), so it collapses to the default rather than surviving the spread. That is what
+// makes the strict `status === 'active'` consumers agree with the lenient
+// `status === 'active' || !status` ones for every normalized goal: the set of goals the lenient
+// predicate calls active is exactly the set this stamps 'active'. A plain `{ ...defaults, ...g }`
+// would let an explicit `status: null` from MortalLoom re-open the split.
+export const normalizeGoal = g => {
+  const merged = { ...PORTOS_GOAL_DEFAULTS, ...g };
+  return merged.status ? merged : { ...merged, status: PORTOS_GOAL_DEFAULTS.status };
+};
 
 // === File paths ===
 

--- a/server/services/identity/store.test.js
+++ b/server/services/identity/store.test.js
@@ -23,7 +23,16 @@ vi.mock('../mortalLoomStore.js', () => ({
   mlReplace: vi.fn(async () => {}),
 }));
 
-const { loadJSON, GOALS_FILE, LONGEVITY_FILE, DEFAULT_GOALS, DEFAULT_LONGEVITY } = await import('./store.js');
+// getIdentityStatus is the real strict `status === 'active'` consumer these tests reach through
+// (#4123). Its other two inputs are unrelated domains — stubbed to "nothing uploaded" so the
+// goals section is the only thing under test.
+vi.mock('../genome.js', () => ({ getGenomeSummary: vi.fn(async () => null) }));
+vi.mock('../taste-questionnaire.js', () => ({
+  getTasteProfile: vi.fn(async () => ({ completedCount: 0, totalSections: 0, lastSessionAt: null })),
+}));
+
+const { loadJSON, normalizeGoal, GOALS_FILE, LONGEVITY_FILE, DEFAULT_GOALS, DEFAULT_LONGEVITY, PORTOS_GOAL_DEFAULTS } = await import('./store.js');
+const { getIdentityStatus } = await import('./status.js');
 
 afterAll(() => rmSync(TEST_DATA_ROOT, { recursive: true, force: true }));
 
@@ -111,5 +120,69 @@ describe('loadJSON — strict defers to the active MortalLoom source (#2726)', (
     const data = await loadJSON(GOALS_FILE, DEFAULT_GOALS, { strict: true });
     expect(data.goals).toEqual([expect.objectContaining({ id: 'ml1' })]);
     expect(data.birthDate).toBe('1990-01-01'); // metadata still comes from local
+  });
+});
+
+// A MortalLoom-synced goal passes through normalizeGoal and nothing else. Before #4123 the
+// defaults backfilled every field EXCEPT status, so half the codebase (voice tools, the Character
+// card) counted a status-less goal as active while the other half (check-in scheduling, Telegram
+// digests, insights, jobGates, getGoalsTree's urgency enrichment, getIdentityStatus) tested
+// `status === 'active'` and silently skipped it.
+describe('normalizeGoal — status defaulting (#4123)', () => {
+  it('stamps status:active on a goal that arrives without one', () => {
+    expect(normalizeGoal({ id: 'ml1', title: 'Sync me' }).status).toBe('active');
+  });
+
+  it.each([['null', null], ['undefined', undefined], ['an empty string', '']])(
+    'treats a falsy status (%s) as active rather than passing it through',
+    (_label, status) => {
+      // A falsy status is never a legitimate goal state — there is no "no status" goal — so it
+      // must not survive the spread. `{ ...defaults, ...g }` alone would let an explicit null
+      // re-open the split: null overwrites the default but still fails `status === 'active'`.
+      expect(normalizeGoal({ id: 'ml1', status }).status).toBe('active');
+    });
+
+  it.each(['completed', 'abandoned', 'paused'])('preserves a real non-active status (%s)', (status) => {
+    expect(normalizeGoal({ id: 'ml1', status }).status).toBe(status);
+  });
+
+  it('still backfills every other default alongside status', () => {
+    const normalized = normalizeGoal({ id: 'ml1' });
+    for (const [key, value] of Object.entries(PORTOS_GOAL_DEFAULTS)) {
+      expect(normalized[key]).toEqual(value);
+    }
+    expect(normalized.id).toBe('ml1');
+  });
+
+  it('does not let the status default clobber a caller-supplied field', () => {
+    const normalized = normalizeGoal({ id: 'ml1', progress: 42, goalType: 'habit', status: 'completed' });
+    expect(normalized).toMatchObject({ progress: 42, goalType: 'habit', status: 'completed' });
+  });
+});
+
+describe('loadJSON — status-less MortalLoom goals reach strict active-goal consumers (#4123)', () => {
+  it('normalizes a status-less MortalLoom goal to active on the way out of loadJSON', async () => {
+    ml.goals = [{ id: 'ml1', title: 'No status from the phone' }, { id: 'ml2', status: null }];
+
+    const data = await loadJSON(GOALS_FILE, DEFAULT_GOALS);
+    expect(data.goals.map(g => g.status)).toEqual(['active', 'active']);
+  });
+
+  it('reports the goals section active in getIdentityStatus, which filters on status === active', async () => {
+    // The end-to-end shape of the bug: a MortalLoom user with status-less goals saw the Character
+    // card list them while the identity dashboard called the Goals section "unavailable".
+    ml.goals = [{ id: 'ml1', title: 'No status from the phone' }];
+
+    const status = await getIdentityStatus();
+    expect(status.sections.goals).toMatchObject({ status: 'active', goalCount: 1 });
+  });
+
+  it('still reports unavailable when every synced goal is genuinely finished', async () => {
+    // The default must not paper over real non-active goals — otherwise the section would claim
+    // active goals for a user who has completed all of them.
+    ml.goals = [{ id: 'ml1', status: 'completed' }, { id: 'ml2', status: 'abandoned' }];
+
+    const status = await getIdentityStatus();
+    expect(status.sections.goals.status).toBe('unavailable');
   });
 });


### PR DESCRIPTION
## Summary

Goals synced in from MortalLoom pass through exactly one normalization step — `normalizeGoal` in `server/services/identity/store.js` — and its `PORTOS_GOAL_DEFAULTS` backfilled every field *except* `status`. That left the codebase disagreeing about what a status-less goal means:

- **Counted as active:** `server/services/voice/tools/goals.js` and `client/src/components/character/GoalsCard.jsx` (`status === 'active' || !status`).
- **Silently skipped:** `jobGates.js`, `telegram.js`, `goalCheckIn.js`, `identity/insights.js`, `identity/status.js`, and `identity/goals.js` (including `getGoalsTree`'s own urgency enrichment), all of which test `status === 'active'`.

So a user with status-less synced goals saw them ranked by voice and listed on the Character card, while check-in scheduling, digests, insights, and the identity dashboard behaved as if the user had none.

Fix: default `status: 'active'` in `PORTOS_GOAL_DEFAULTS`, normalizing at the sync boundary in one place instead of touching ten call sites. `normalizeGoal` also collapses a *falsy* status (`null`, `''`) to the default rather than letting it survive the object spread — an explicit `status: null` from the synced store would otherwise overwrite the default and re-open the same split. The result is that the strict and lenient predicates select exactly the same set for every normalized goal.

The lenient call sites stay lenient on purpose (comments updated to say why rather than describing the now-fixed bug): a `goals.json` record written before `status` existed is read straight off the local file and never passes through `normalizeGoal`, so dropping it would still render a populated goal list as "No active goals yet". PortOS-created goals are unaffected — `createGoal` has always stamped `status: 'active'`.

## Test plan

- `cd server && NODE_ENV=test npx vitest run services/identity/ services/jobGates` — 70 passed.
- `cd server && NODE_ENV=test npx vitest run services/voice services/telegram services/goalCheckIn services/reviewQueue services/askService` — 524 passed.
- `cd client && npx vitest run src/components/character/GoalsCard.test.jsx` — 21 passed.
- `cd client && npm run lint` — clean.
- **Fail-without-the-fix verified:** reverting `store.js` to the old `PORTOS_GOAL_DEFAULTS` + plain-spread `normalizeGoal` fails 6 of the new tests, including the end-to-end one that drives a status-less synced goal through `loadJSON` into `getIdentityStatus` (a real strict `status === 'active'` consumer) and asserts the Goals section reports active.

New coverage in `server/services/identity/store.test.js`:
- `normalizeGoal` stamps `active` for absent / `null` / `undefined` / `''` status, preserves real non-active statuses (`completed`, `abandoned`, `paused`), and still backfills every other default without clobbering caller-supplied fields.
- A status-less synced goal survives `loadJSON` as active and is counted by `getIdentityStatus`, while a fully completed/abandoned set still reports the Goals section `unavailable` — so the default doesn't paper over genuinely finished goals.

Closes #4123
