### PR TITLE
Let the Image Gen Test Render panel pick its backend

### DIFF
--- a/.changelog/next/changed-issue-4128.md
+++ b/.changelog/next/changed-issue-4128.md
@@ -1,0 +1,1 @@
+- Image Gen settings: the Test Render panel now picks its own backend, so you can smoke-test Agy or Grok without making it your default

--- a/client/src/components/settings/ImageGenTab.jsx
+++ b/client/src/components/settings/ImageGenTab.jsx
@@ -22,7 +22,7 @@ import {
   registerTool, updateTool, getToolsList,
   saveHfToken, clearHfToken,
 } from '../../services/api';
-import { isCloudCliMode, IMAGE_GEN_MODE, AGY_IMAGEGEN_DEFAULT_MODEL, AGY_IMAGEGEN_IMAGE_MODEL, CODEX_IMAGEGEN_DEFAULT_EFFORT, GROK_ASPECT_RATIOS, RENDER_TARGET_BACKEND_AUTO, RENDER_TARGET_OPTIONS, VIDEO_RENDER_MODES, modeLabel, normalizeRenderPinValue, supportsCloudModelOverride } from '../../lib/imageGenBackends';
+import { deriveAvailableBackends, isCloudCliMode, IMAGE_GEN_MODE, AGY_IMAGEGEN_DEFAULT_MODEL, AGY_IMAGEGEN_IMAGE_MODEL, CODEX_IMAGEGEN_DEFAULT_EFFORT, GROK_ASPECT_RATIOS, RENDER_TARGET_BACKEND_AUTO, RENDER_TARGET_OPTIONS, VIDEO_RENDER_MODES, modeLabel, normalizeRenderPinValue, supportsCloudModelOverride } from '../../lib/imageGenBackends';
 import { resolveCleanersFromConfig } from '../../lib/imageCleaners';
 import { useMediaJobSse } from '../../hooks/useMediaJobSse';
 import { useAgyModels } from '../../hooks/useAgyModels';
@@ -183,6 +183,12 @@ export function ImageGenTab() {
   const [agyToolRegistered, setAgyToolRegistered] = useState(false);
 
   const [testPrompt, setTestPrompt] = useState(DEFAULT_TEST_PROMPT);
+  // Backend the Test Render panel should render through. '' is the sentinel for
+  // "follow the saved default" — NOT a picked backend — so the panel tracks a
+  // default the user changes on the Backend tab instead of pinning whatever was
+  // saved the first time this tab painted (#4128).
+  const [testMode, setTestMode] = useState('');
+  const testModeId = useId();
   const [rendering, setRendering] = useState(false);
   const [renderResult, setRenderResult] = useState(null);
   // Shared per-job SSE subscriber — same hook ImageGen/VideoGen use to await
@@ -332,6 +338,33 @@ export function ImageGenTab() {
       .catch(() => setStatus({ connected: false, reason: 'Check failed', forTab: mediaTab }))
       .finally(() => setChecking(false));
   }, [probeMode, mediaTab]);
+
+  // Backends the Test Render picker may offer — derived from the SAVED slice,
+  // not the live form, because a test render runs against what the server has
+  // persisted (the same reason handleRenderTest reads `saved.mode`). The
+  // settings-shaped argument is what `deriveAvailableBackends` (the client
+  // mirror of the server's usability gate) consumes, so enabling a backend is
+  // still one edit in one place.
+  const savedBackends = deriveAvailableBackends({
+    imageGen: {
+      local: { pythonPath: saved.pythonPath },
+      codex: { enabled: saved.codexEnabled },
+      grok: { enabled: saved.grokEnabled },
+      agy: { enabled: saved.agyEnabled },
+      external: { sdapiUrl: saved.sdapiUrl },
+    },
+  });
+
+  // The saved default always stays selectable even when it isn't "usable" by
+  // the derivation above (e.g. external with a blank URL) — the server would
+  // still route the render there, so hiding it would make the select disagree
+  // with what the button actually does.
+  const testModeOptions = savedBackends.some((b) => b.id === saved.mode)
+    ? savedBackends
+    : [{ id: saved.mode, label: modeLabel(saved.mode) }, ...savedBackends];
+  // A pick that a later save disabled falls back to the saved default rather
+  // than queueing a render that can only 400.
+  const effectiveTestMode = testModeOptions.some((b) => b.id === testMode) ? testMode : saved.mode;
 
   const isDirty = mode !== saved.mode
     || normalizeUrl(sdapiUrl) !== saved.sdapiUrl
@@ -527,13 +560,13 @@ export function ImageGenTab() {
     setRendering(true);
     setRenderResult(null);
     try {
-      // Use saved.mode (not the live `mode` state) so the test render
-      // always reflects what's actually persisted server-side. The
-      // disabled={isDirty} guard already prevents this branch from running
-      // with unsaved changes, but reading from `saved` makes the contract
-      // explicit. Codex is async like local (returns a job descriptor
-      // immediately) so the SSE branch handles it.
-      const result = await generateImage({ prompt: testPrompt.trim(), mode: saved.mode }, { silent: true });
+      // `effectiveTestMode` is the panel's own picker, defaulting to saved.mode
+      // (not the live `mode` state) so an unchanged picker still reflects what's
+      // actually persisted server-side. The disabled={isDirty} guard already
+      // prevents this branch from running with unsaved changes, but resolving
+      // through `saved` makes the contract explicit. Codex is async like local
+      // (returns a job descriptor immediately) so the SSE branch handles it.
+      const result = await generateImage({ prompt: testPrompt.trim(), mode: effectiveTestMode }, { silent: true });
       // Local + Codex modes return immediately after spawning the child —
       // the PNG isn't on disk yet. Subscribe to the per-job SSE and only
       // mark the render complete on the `complete` event (or fail on
@@ -1246,9 +1279,28 @@ export function ImageGenTab() {
           <h2 className="text-lg font-semibold">Test Render</h2>
         </div>
         <p className="text-xs text-gray-500">
-          Send a prompt through the active backend to verify end-to-end. For richer controls, visit the
+          Send a prompt through {modeLabel(effectiveTestMode)} to verify end-to-end. For richer controls, visit the
           <a href="/media/image" className="text-port-accent hover:underline ml-1">Image Gen</a> page.
         </p>
+        <div>
+          <label htmlFor={testModeId} className="block text-sm text-gray-300 mb-1">Backend</label>
+          <select
+            id={testModeId}
+            value={effectiveTestMode}
+            onChange={(e) => setTestMode(e.target.value)}
+            disabled={rendering}
+            className="w-full sm:w-64 bg-port-bg border border-port-border rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50"
+          >
+            {testModeOptions.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.label}{b.id === saved.mode ? ' (default)' : ''}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-500 mt-1">
+            Only enabled backends are listed — smoke-test one without making it your default.
+          </p>
+        </div>
         <label htmlFor="test-render-prompt" className="sr-only">Test prompt</label>
         <textarea
           id="test-render-prompt"
@@ -1264,7 +1316,7 @@ export function ImageGenTab() {
           onClick={handleRenderTest}
           disabled={rendering || isDirty || !testPrompt.trim()}
           className="flex items-center gap-2 px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-white text-sm rounded-lg transition-colors disabled:opacity-50 min-h-[40px]"
-          title={isDirty ? 'Save settings first' : 'Generate a test image'}
+          title={isDirty ? 'Save settings first' : `Generate a test image with ${modeLabel(effectiveTestMode)}`}
         >
           {rendering ? <BrailleSpinner /> : <Sparkles size={14} />}
           {rendering ? 'Rendering...' : 'Render Test Image'}

--- a/client/src/components/settings/ImageGenTab.test.jsx
+++ b/client/src/components/settings/ImageGenTab.test.jsx
@@ -32,7 +32,7 @@ vi.mock('../../hooks/useMediaJobSse', () => ({
 }));
 
 import {
-  getSettings, getToolsList, updateSettings, listAgyImageModels, getImageGenStatus,
+  getSettings, getToolsList, updateSettings, listAgyImageModels, getImageGenStatus, generateImage,
 } from '../../services/api';
 import { useHfTokenStatus } from '../../hooks/useHfTokenStatus';
 import { ImageGenTab, MEDIA_TABS } from './ImageGenTab';
@@ -231,6 +231,87 @@ describe('ImageGenTab grouped tabs', () => {
     await waitFor(() => expect(updateSettings).toHaveBeenCalled());
     const patch = updateSettings.mock.calls[0][0];
     expect(patch.videoGen).toEqual({ mode: 'local', defaultModelId: 'ltx23_distilled_q4' });
+  });
+});
+
+describe('ImageGenTab — Test Render backend picker (#4128)', () => {
+  const multiBackendSettings = {
+    imageGen: {
+      mode: 'external',
+      external: { sdapiUrl: 'http://localhost:7860' },
+      local: { pythonPath: '' },
+      codex: { enabled: false },
+      grok: { enabled: true, grokPath: 'grok' },
+      agy: { enabled: true, agyPath: 'agy' },
+      expose: { a1111: false },
+    },
+  };
+
+  it('offers every enabled backend and marks the saved default as the initial pick', async () => {
+    getSettings.mockResolvedValue(multiBackendSettings);
+    await renderTab(['/media/image?mediaTab=test']);
+    const select = screen.getByLabelText('Backend');
+    expect(select.value).toBe('external');
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toEqual(['grok', 'agy', 'external']);
+    // Local has no python path and codex is disabled — neither is renderable,
+    // so neither may be offered.
+    expect(options).not.toContain('local');
+    expect(options).not.toContain('codex');
+    expect(screen.getByText(/Send a prompt through External/)).toBeTruthy();
+  });
+
+  it('renders through the picked backend instead of the saved default', async () => {
+    getSettings.mockResolvedValue(multiBackendSettings);
+    generateImage.mockResolvedValue({ mode: 'grok', path: '/data/renders/test.png', filename: 'test.png' });
+    await renderTab(['/media/image?mediaTab=test']);
+    fireEvent.change(screen.getByLabelText('Backend'), { target: { value: 'grok' } });
+    expect(screen.getByText(/Send a prompt through Grok/)).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /Render Test Image/i }));
+    await waitFor(() => expect(generateImage).toHaveBeenCalled());
+    expect(generateImage.mock.calls[0][0].mode).toBe('grok');
+  });
+
+  it('keeps the saved default selectable even when it is not otherwise renderable', async () => {
+    // External is the saved default with a blank URL: the server still routes
+    // the render there, so the select must not silently show a different
+    // backend than the button uses.
+    getSettings.mockResolvedValue({
+      imageGen: {
+        mode: 'external',
+        external: { sdapiUrl: '' },
+        grok: { enabled: true, grokPath: 'grok' },
+      },
+    });
+    generateImage.mockResolvedValue({ mode: 'external', path: '/data/renders/test.png', filename: 'test.png' });
+    await renderTab(['/media/image?mediaTab=test']);
+    const select = screen.getByLabelText('Backend');
+    expect(select.value).toBe('external');
+    expect(Array.from(select.options).map((o) => o.value)).toEqual(['external', 'grok']);
+    fireEvent.click(screen.getByRole('button', { name: /Render Test Image/i }));
+    await waitFor(() => expect(generateImage).toHaveBeenCalled());
+    expect(generateImage.mock.calls[0][0].mode).toBe('external');
+  });
+
+  it('falls a pick back to the saved default once that backend is disabled and saved', async () => {
+    getSettings.mockResolvedValue(multiBackendSettings);
+    generateImage.mockResolvedValue({ mode: 'external', path: '/data/renders/test.png', filename: 'test.png' });
+    await renderTab(['/media/image?mediaTab=test']);
+    fireEvent.change(screen.getByLabelText('Backend'), { target: { value: 'grok' } });
+
+    // Disable Grok on its own tab and save — the pick is now unrenderable.
+    fireEvent.click(screen.getByRole('tab', { name: /Grok CLI/i }));
+    fireEvent.click(screen.getByLabelText(/Enable Grok/i));
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/ }));
+    await waitFor(() => expect(updateSettings).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('tab', { name: /^Test$/i }));
+    const select = screen.getByLabelText('Backend');
+    expect(select.value).toBe('external');
+    expect(Array.from(select.options).map((o) => o.value)).not.toContain('grok');
+    fireEvent.click(screen.getByRole('button', { name: /Render Test Image/i }));
+    await waitFor(() => expect(generateImage).toHaveBeenCalled());
+    expect(generateImage.mock.calls[0][0].mode).toBe('external');
   });
 });
 


### PR DESCRIPTION
## Summary

Test Connection already probes the provider whose sub-tab is open, but the Test tab's `handleRenderTest` still rendered through `saved.mode` — so smoke-testing an Agy or Grok render meant first making that backend your install-wide default.

The Test Render panel now owns a backend `<select>`:

- Options come from `deriveAvailableBackends` (the client mirror of the server's usability gate) applied to the **saved** slice, not the live form — a test render runs against what the server has persisted, which is the same reason the button gates on `isDirty`. Disabled/unconfigured backends are never offered.
- The saved default is the initial pick and is labelled `(default)`. It stays selectable even when the derivation wouldn't call it renderable (e.g. `external` with a blank URL), because the server still routes the render there — a select that disagreed with the button would be a lie.
- `''` is the sentinel for "follow the saved default" rather than a picked backend, so changing the default on the Backend tab moves the Test panel with it, and a pick whose backend is later disabled + saved falls back to the saved default instead of queueing a render that can only 400.
- The chosen mode is threaded into `generateImage({ mode })`, and the panel copy + button tooltip now name the selected backend instead of saying "the active backend".

## Test plan

- `cd client && npm test -- src/components/settings/ImageGenTab.test.jsx` — 27 passed.
- Four new tests cover: only-enabled-backends in the option list, rendering through the picked backend (asserting the `generateImage` mode argument), the saved default staying selectable when otherwise unrenderable, and the fallback after the picked backend is disabled and saved. All four fail against the pre-change component (verified by stashing the source edit: 4 failed / 23 passed).
- `cd client && npm run lint` — clean.

Closes #4128
