### PR TITLE
Drive the agent tool-use warning from a server-side needsTools flag

### DIFF
--- a/.changelog/next/fixed-issue-4126.md
+++ b/.changelog/next/fixed-issue-4126.md
@@ -1,0 +1,1 @@
+- AI Assignments now warns when an agent assignment (Creative Director treatment/plan, autofixer, CoS tasks, feature agents) is pinned to a local model with no known tool use — the tool-use marker is driven by a server-side needsTools flag read by every model picker instead of a hard-coded list in one drawer

--- a/client/src/components/ProviderModelSelector.jsx
+++ b/client/src/components/ProviderModelSelector.jsx
@@ -55,6 +55,7 @@ import { useId } from 'react';
 import { effectiveModelFor, effortLevelsForProvider, effortSurvivingModel, localToolUseHint, withToolUseOptionLabel } from '../utils/providers.js';
 import useToolUseModelIds from '../hooks/useToolUseModelIds.js';
 import EffortSelect from './cos/EffortSelect.jsx';
+import ToolUseWarning from './ui/ToolUseWarning.jsx';
 
 const SELECT_CLASS =
   'w-full px-3 py-1.5 min-h-[36px] bg-port-bg border border-port-border rounded-lg text-white text-sm';
@@ -186,13 +187,10 @@ export default function ProviderModelSelector({
               return <option key={opt.value} value={opt.value}>{label}</option>;
             })}
           </select>
+          {/* No remediation link: this selector renders in hosts that aren't
+              wrapped in a Router, so the shared warning stays link-free here. */}
           {toolIncapable && (
-            <p className="mt-1 text-xs text-port-warning">
-              ⚠ <span className="font-medium">{effectiveModel}</span>
-              {!selectedModel && ' (this provider’s default)'} isn't a recognized tool-calling
-              model — many local models (e.g. Gemma) reply with text instead of calling tools, which
-              stalls an agent. Prefer a recognized tool-capable model (e.g. qwen3.6:35b).
-            </p>
+            <ToolUseWarning model={effectiveModel} isProviderDefault={!selectedModel} className="mt-1" />
           )}
         </div>
       )}

--- a/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
+++ b/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
-import { Bot, Save, AlertTriangle } from 'lucide-react';
+import { Bot, Save } from 'lucide-react';
 import Drawer from '../Drawer.jsx';
 import toast from '../ui/Toast';
+import ToolUseWarning from '../ui/ToolUseWarning.jsx';
 import { getAiAssignments, updateAiAssignment } from '../../services/api';
 import { updateCreativeDirectorProject } from '../../services/apiCreativeDirector.js';
 import useVisionModelIds from '../../hooks/useVisionModelIds.js';
@@ -13,7 +14,7 @@ import {
   assignmentModelOptions,
   assignmentDefaultModel,
   localBackendForProvider,
-  localToolUseHint,
+  assignmentToolUseState,
   withToolUseOptionLabel,
 } from '../../utils/providers.js';
 
@@ -27,13 +28,16 @@ import {
 //
 // The server's `resolveStagePin` resolves project override → CD default →
 // system default; the inherit hint mirrors that chain for display only.
+//
+// Which stages need TOOL-CALLING is deliberately NOT listed here: the server
+// stamps `needsTools` on the assignment entry (see `agentEntry` in
+// server/services/aiAssignments.js) and every editor of these same pins reads
+// that one flag. A client-side list here only warned in this drawer, while the
+// AI Assignments table — which the copy below links to — let the identical pin
+// be set to a tool-less local model with no annotation at all.
 const STAGES = [
-  // `needsTools`: these stages run as agent-harness tasks that must emit native
-  // tool calls (the plan agent PATCHes the API to write the plan). A local model
-  // without tool-calling (e.g. Gemma) narrates a done-message instead of acting,
-  // silently wedging the project — so the picker marks + warns on those.
-  { key: 'treatment', label: 'Treatment', needsTools: true, help: 'Agent that turns the brief into a treatment + scene plan.' },
-  { key: 'plan', label: 'Production plan', needsTools: true, help: 'Agent that converts a production directive into an executable plan.' },
+  { key: 'treatment', label: 'Treatment', help: 'Agent that turns the brief into a treatment + scene plan.' },
+  { key: 'plan', label: 'Production plan', help: 'Agent that converts a production directive into an executable plan.' },
   {
     key: 'evaluation',
     label: 'Scene evaluation',
@@ -237,22 +241,14 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
             const providerOptions = assignmentProviderOptions(entry, providers);
             const modelOptions = assignmentModelOptions(entry, providers, draft.providerId, visionIdsByProvider);
             const pinned = !!draft.providerId;
-            // Agent stages (treatment/plan) need native tool calling. Warn when a
-            // pinned LOCAL model can't do it (Gemma & friends narrate instead of
-            // PATCHing) — the incident behind this: a plan agent on gemma4:e4b
-            // reported "done" without ever writing the plan. `localToolUseHint`
-            // is null for cloud providers (their ids don't encode family), so the
-            // warning only fires where the heuristic is trustworthy.
-            // A blank model runs the provider's default at fire time, so evaluate
-            // the EFFECTIVE model (explicit pin, else provider default) — a pinned
-            // provider whose default is a non-tool local model wedges the stage
-            // just the same.
-            const effectiveModel = draft.model || selectedProvider?.defaultModel || '';
-            const annotateToolUse = stage.needsTools && toolUseLoaded;
-            const toolHint = annotateToolUse
-              ? localToolUseHint(effectiveModel, selectedProvider, toolUseIdsByProvider)
-              : null;
-            const toolIncapable = pinned && toolHint?.toolCapable === false;
+            // Agent stages (whichever ones the SERVER marks `needsTools`) need
+            // native tool calling. Warn when a pinned LOCAL model can't do it
+            // (Gemma & friends narrate instead of PATCHing) — the incident behind
+            // this: a plan agent on gemma4:e4b reported "done" without ever
+            // writing the plan. See `assignmentToolUseState` for why the
+            // EFFECTIVE model is judged and why nothing is asserted mid-scan.
+            const { annotate: annotateToolUse, effectiveModel, incapable: toolIncapable } =
+              assignmentToolUseState(entry, selectedProvider, draft.model, toolUseIdsByProvider, toolUseLoaded);
             // Both hints below are about the LOCAL capability scan, so they only
             // apply when the pinned provider is an Ollama / LM Studio backend. A
             // cloud API provider's list is never vision-filtered, so an empty one
@@ -359,17 +355,9 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
                 )}
 
                 {toolIncapable && (
-                  <p className="flex items-start gap-1.5 text-xs text-port-warning">
-                    <AlertTriangle size={13} className="shrink-0 mt-0.5" />
-                    <span>
-                      <span className="font-medium">{effectiveModel}</span>
-                      {!draft.model && ' (this provider’s default)'} isn't a recognized tool-calling
-                      model — many local models (e.g. Gemma) reply with text instead of calling tools,
-                      which can leave this agent's stage stuck. Prefer a recognized tool-capable local
-                      model (e.g. <span className="text-gray-300">qwen3.6:35b</span>) or an API/CLI provider.{' '}
-                      <Link to="/settings/local-llm" className="underline hover:text-port-warning/80">Browse models</Link>.
-                    </span>
-                  </p>
+                  <ToolUseWarning model={effectiveModel} isProviderDefault={!draft.model}>
+                    <Link to="/settings/local-llm" className="underline hover:text-port-warning/80">Browse models</Link>.
+                  </ToolUseWarning>
                 )}
               </section>
             );

--- a/client/src/components/creative-director/CreativeDirectorModelsDrawer.test.jsx
+++ b/client/src/components/creative-director/CreativeDirectorModelsDrawer.test.jsx
@@ -27,8 +27,11 @@ const ASSIGNMENTS = {
     },
   ],
   assignments: [
-    { id: 'settings.creativeDirector.treatment', providerTypes: ['cli', 'tui'], providerId: '', model: '' },
-    { id: 'settings.creativeDirector.plan', providerTypes: ['cli', 'tui'], providerId: '', model: '' },
+    // `needsTools` is the SERVER's marker for an agent-harness stage — the
+    // drawer no longer hard-codes which stages those are, so the fixture mirrors
+    // what `getAiAssignments` stamps.
+    { id: 'settings.creativeDirector.treatment', providerTypes: ['cli', 'tui'], providerId: '', model: '', needsTools: true },
+    { id: 'settings.creativeDirector.plan', providerTypes: ['cli', 'tui'], providerId: '', model: '', needsTools: true },
     {
       id: 'settings.creativeDirector.evaluation',
       providerTypes: ['api'],
@@ -105,6 +108,19 @@ describe('CreativeDirectorModelsDrawer', () => {
     getToolUseModels.mockRejectedValue(new Error('ollama down'));
     renderDrawer({ id: 'cd-1', name: 'Demo', modelOverrides: { plan: { providerId: 'ollama', model: 'gemma2:9b' } } });
     await waitFor(() => expect(screen.getByText(/recognized tool-calling model/i)).toBeInTheDocument());
+  });
+
+  it('takes needsTools from the server payload, not a hard-coded stage list', async () => {
+    // The drawer used to decide which stages need tools client-side, so the same
+    // pins stayed unannotated in AI Assignments. Drop the server marker and the
+    // warning must disappear — proof the flag, not a local list, drives it.
+    getAiAssignments.mockResolvedValue({
+      ...ASSIGNMENTS,
+      assignments: ASSIGNMENTS.assignments.map((a) => ({ ...a, needsTools: false })),
+    });
+    renderDrawer({ id: 'cd-1', name: 'Demo', modelOverrides: { plan: { providerId: 'ollama', model: 'gemma2:9b' } } });
+    await waitFor(() => expect(screen.getByLabelText('Production plan model')).toBeTruthy());
+    expect(screen.queryByText(/recognized tool-calling model/i)).not.toBeInTheDocument();
   });
 
   it('never shows a tool-use warning on the vision (evaluation) stage', async () => {

--- a/client/src/components/settings/AiAssignmentsTab.jsx
+++ b/client/src/components/settings/AiAssignmentsTab.jsx
@@ -2,13 +2,17 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router';
 import { ArrowRight, Bot, RefreshCw, Save, Search } from 'lucide-react';
 import toast from '../ui/Toast';
+import ToolUseWarning from '../ui/ToolUseWarning.jsx';
 import { getAiAssignments, updateAiAssignment } from '../../services/api';
 import useVisionModelIds from '../../hooks/useVisionModelIds.js';
+import useToolUseModelIds from '../../hooks/useToolUseModelIds.js';
 import {
   providerDisplayName,
   assignmentProviderOptions,
   assignmentModelOptions,
   assignmentDefaultModel,
+  assignmentToolUseState,
+  withToolUseOptionLabel,
 } from '../../utils/providers.js';
 
 const getDraft = (entry) => ({
@@ -51,6 +55,11 @@ export default function AiAssignmentsTab() {
   // the client's id regex not knowing a newer VLM family. This table renders a
   // <select> either way (no "none installed" claim), so it needs the map only.
   const { idsByProvider: visionIdsByProvider, loaded: visionLoaded } = useVisionModelIds();
+  // Same authoritative-union treatment for the AGENT rows the server marks
+  // `needsTools` (Creative Director treatment/plan, autofixer, CoS tasks, feature
+  // agents, …). Ungated: this table always lists those rows, so there is no
+  // "page that merely contains a non-agent picker" case to spare the scan for.
+  const { idsByProvider: toolUseIdsByProvider, loaded: toolUseLoaded } = useToolUseModelIds();
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -257,9 +266,16 @@ export default function AiAssignmentsTab() {
           <tbody className="divide-y divide-port-border bg-port-bg">
             {filtered.map((entry) => {
               const draft = drafts[entry.id] || getDraft(entry);
+              const selectedProvider = data.providers.find((p) => p.id === draft.providerId);
               const providerOptions = assignmentProviderOptions(entry, data.providers);
               const modelOptions = assignmentModelOptions(entry, data.providers, draft.providerId, visionIdsByProvider);
               const dirty = !sameDraft(entry, draft);
+              // Agent rows: mark each model option and warn when the EFFECTIVE
+              // model isn't a recognized tool-caller. Same server flag, same
+              // helper, same copy as the Creative Director drawer — which links
+              // here, so the pin it warns about must not be silently editable.
+              const { annotate: annotateToolUse, effectiveModel, incapable: toolIncapable } =
+                assignmentToolUseState(entry, selectedProvider, draft.model, toolUseIdsByProvider, toolUseLoaded);
               // Choosing a provider seeds its default model; for a vision row
               // that seed is only correct once the capability scan has settled.
               // Picking during it leaves a blank model pin, which the evaluator
@@ -308,7 +324,13 @@ export default function AiAssignmentsTab() {
                         className="w-full bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white"
                       >
                         <option value="">Default / auto</option>
-                        {modelOptions.map((m) => <option key={m} value={m}>{m}</option>)}
+                        {modelOptions.map((m) => (
+                          <option key={m} value={m}>
+                            {annotateToolUse
+                              ? withToolUseOptionLabel(m, m, selectedProvider, toolUseIdsByProvider)
+                              : m}
+                          </option>
+                        ))}
                       </select>
                     ) : (
                       <input
@@ -318,6 +340,11 @@ export default function AiAssignmentsTab() {
                         aria-label={`Model for ${entry.label}`}
                         className="w-full bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white placeholder-gray-600"
                       />
+                    )}
+                    {toolIncapable && (
+                      <ToolUseWarning model={effectiveModel} isProviderDefault={!draft.model} className="mt-1.5">
+                        <Link to="/settings/local-llm" className="underline hover:text-port-warning/80">Browse models</Link>.
+                      </ToolUseWarning>
                     )}
                   </td>
                   <td className="px-3 py-3 text-xs text-gray-500">

--- a/client/src/components/settings/AiAssignmentsTab.test.jsx
+++ b/client/src/components/settings/AiAssignmentsTab.test.jsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+vi.mock('../../services/api', () => ({ getAiAssignments: vi.fn(), updateAiAssignment: vi.fn() }));
+vi.mock('../../services/apiLocalLlm', () => ({ getVisionModels: vi.fn(), getToolUseModels: vi.fn() }));
+vi.mock('../ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn(), info: vi.fn() } }));
+
+import AiAssignmentsTab from './AiAssignmentsTab.jsx';
+import { getAiAssignments } from '../../services/api';
+import { getVisionModels, getToolUseModels } from '../../services/apiLocalLlm';
+import { __resetToolUseModelIdsCache } from '../../hooks/useToolUseModelIds.js';
+
+// Mirrors the `getAiAssignments` payload: `needsTools` marks the agent-harness
+// rows, `modelFilter: 'vision'` the direct vision call. `gemma2:9b` matches no
+// tool-use family; `qwen3.6:35b` does.
+const PROVIDERS = [
+  {
+    id: 'ollama',
+    name: 'Ollama',
+    type: 'api',
+    enabled: true,
+    defaultModel: 'gemma2:9b',
+    models: ['gemma2:9b', 'qwen3.6:35b'],
+    ollamaBacked: true,
+  },
+  { id: 'openai', name: 'OpenAI', type: 'api', enabled: true, defaultModel: 'gpt-4o', models: ['gpt-4o'], ollamaBacked: false },
+];
+
+const entry = (over) => ({
+  area: 'Creative Director',
+  label: 'Production planning model',
+  source: 'settings.creativeDirector.plan',
+  scope: 'global',
+  editable: true,
+  providerEditable: true,
+  modelEditable: true,
+  providerTypes: ['api'],
+  providerOptions: null,
+  modelOptions: null,
+  modelFilter: null,
+  needsTools: false,
+  link: null,
+  notes: '',
+  providerId: '',
+  model: '',
+  ...over,
+});
+
+const payload = (assignments) => ({ providers: PROVIDERS, activeProvider: 'openai', assignments });
+
+const renderTab = () => render(<MemoryRouter><AiAssignmentsTab /></MemoryRouter>);
+
+const WARNING = /recognized tool-calling model/i;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetToolUseModelIdsCache();
+  getVisionModels.mockResolvedValue({ models: [] });
+  // Nothing authoritative by default, so the id regex alone decides.
+  getToolUseModels.mockResolvedValue({ models: [] });
+});
+
+describe('AiAssignmentsTab tool-use warning', () => {
+  it('warns on an agent row pinned to a local model with no known tool use', async () => {
+    // The gap this closes: the Creative Director drawer warned about this exact
+    // pin while its own "Also editable from AI Assignments" link led to a table
+    // that let the user set it with no annotation at all.
+    getAiAssignments.mockResolvedValue(payload([
+      entry({ id: 'settings.creativeDirector.plan', needsTools: true, providerId: 'ollama', model: 'gemma2:9b' }),
+    ]));
+    renderTab();
+    expect(await screen.findByText(WARNING)).toBeInTheDocument();
+  });
+
+  it('leaves a non-agent row unflagged on the same model', async () => {
+    // Scene evaluation is a direct vision call — a non-tool model is expected
+    // there, so `needsTools` (not the model id) has to gate the warning.
+    getAiAssignments.mockResolvedValue(payload([
+      entry({ id: 'settings.creativeDirector.evaluation', label: 'Scene evaluation vision model', modelFilter: 'vision', providerId: 'ollama', model: 'gemma2:9b' }),
+    ]));
+    renderTab();
+    await waitFor(() => expect(screen.getByLabelText('Model for Scene evaluation vision model')).toBeTruthy());
+    expect(screen.queryByText(WARNING)).not.toBeInTheDocument();
+  });
+
+  it('does not warn when the agent row is pinned to a tool-capable model', async () => {
+    getAiAssignments.mockResolvedValue(payload([
+      entry({ id: 'settings.creativeDirector.plan', needsTools: true, providerId: 'ollama', model: 'qwen3.6:35b' }),
+    ]));
+    renderTab();
+    await waitFor(() => expect(getToolUseModels).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByLabelText('Model for Production planning model')).toBeTruthy());
+    expect(screen.queryByText(WARNING)).not.toBeInTheDocument();
+  });
+
+  it('warns on a blank model pin, which runs the provider default', async () => {
+    // "Default / auto" is not a no-op: the run resolves ollama's own
+    // `gemma2:9b`, so the row looks unset while being just as wedged.
+    getAiAssignments.mockResolvedValue(payload([
+      entry({ id: 'settings.creativeDirector.plan', needsTools: true, providerId: 'ollama', model: '' }),
+    ]));
+    renderTab();
+    expect(await screen.findByText(WARNING)).toBeInTheDocument();
+    expect(screen.getByText(/this provider’s default/)).toBeInTheDocument();
+  });
+
+  it('clears the warning for a model the backend reports as tool-capable', async () => {
+    getToolUseModels.mockResolvedValue({ models: [{ providerId: 'ollama', id: 'gemma2:9b', toolUse: true }] });
+    getAiAssignments.mockResolvedValue(payload([
+      entry({ id: 'settings.creativeDirector.plan', needsTools: true, providerId: 'ollama', model: 'gemma2:9b' }),
+    ]));
+    renderTab();
+    await waitFor(() => expect(getToolUseModels).toHaveBeenCalled());
+    await waitFor(() => expect(screen.getByLabelText('Model for Production planning model')).toBeTruthy());
+    expect(screen.queryByText(WARNING)).not.toBeInTheDocument();
+  });
+
+  it('annotates each model option of an agent row with its tool-use marker', async () => {
+    getAiAssignments.mockResolvedValue(payload([
+      entry({ id: 'settings.creativeDirector.plan', needsTools: true, providerId: 'ollama', model: 'qwen3.6:35b' }),
+    ]));
+    renderTab();
+    const select = await screen.findByLabelText('Model for Production planning model');
+    await waitFor(() => expect(select.textContent).toMatch(/🔧 tool use/));
+    expect(select.textContent).toMatch(/⚠ no known tool use/);
+  });
+
+  it('does not annotate a non-agent row', async () => {
+    getAiAssignments.mockResolvedValue(payload([
+      entry({ id: 'settings.messages.triage', area: 'Messages', label: 'Triage assistant', providerId: 'ollama', model: 'gemma2:9b' }),
+    ]));
+    renderTab();
+    const select = await screen.findByLabelText('Model for Triage assistant');
+    await waitFor(() => expect(getToolUseModels).toHaveBeenCalled());
+    expect(select.textContent).not.toMatch(/tool use/);
+  });
+
+  it('flags an ollama-backed wrapper CLI whose id and name say nothing about ollama', async () => {
+    // Only the server-resolved `ollamaBacked` flag identifies this provider —
+    // the curated payload carries no envVars/endpoint for the client to sniff,
+    // and this wrapper class is exactly the one the incident ran on.
+    getAiAssignments.mockResolvedValue({
+      providers: [{ id: 'local-agent', name: 'Local Agent', type: 'tui', enabled: true, defaultModel: 'gemma2:9b', models: ['gemma2:9b'], ollamaBacked: true }],
+      activeProvider: 'local-agent',
+      assignments: [entry({ id: 'settings.creativeDirector.plan', needsTools: true, providerTypes: ['cli', 'tui'], providerId: 'local-agent', model: 'gemma2:9b' })],
+    });
+    renderTab();
+    expect(await screen.findByText(WARNING)).toBeInTheDocument();
+  });
+});

--- a/client/src/components/ui/ToolUseWarning.jsx
+++ b/client/src/components/ui/ToolUseWarning.jsx
@@ -1,0 +1,39 @@
+import { AlertTriangle } from 'lucide-react';
+
+/**
+ * The "this model can't call tools" warning every agent picker shows below its
+ * model control. Three editors of the same class of pin used to word it three
+ * different ways (ProviderModelSelector, the Creative Director Models drawer,
+ * and — until now — nothing at all in AI Assignments), so the advice lives here
+ * once.
+ *
+ * Deliberately phrased as UNVERIFIED, not a proven negative: the capability
+ * signal behind it is a positive allowlist unioned with what the backend
+ * reports, so a tool-capable family neither knows yet lands here too. That is
+ * also why this is a warning and never a filter — hiding those options would
+ * make a newer tool-capable model unselectable.
+ *
+ * @param {object} props
+ * @param {string} props.model - the EFFECTIVE model being warned about
+ * @param {boolean} [props.isProviderDefault] - true when `model` came from the
+ *   provider's `defaultModel` rather than an explicit pin, which is worth saying
+ *   out loud: the control above reads "Default / auto" and looks unset.
+ * @param {string} [props.className] - spacing for the host layout
+ * @param {import('react').ReactNode} [props.children] - trailing remediation
+ *   links; hosts outside a Router context must omit them.
+ */
+export default function ToolUseWarning({ model, isProviderDefault = false, className = '', children }) {
+  return (
+    <p className={`flex items-start gap-1.5 text-xs text-port-warning ${className}`}>
+      <AlertTriangle size={13} className="shrink-0 mt-0.5" aria-hidden="true" />
+      <span>
+        <span className="font-medium">{model}</span>
+        {isProviderDefault && ' (this provider’s default)'} isn&apos;t a recognized tool-calling
+        model — many local models (e.g. Gemma) reply with text instead of calling tools, which can
+        leave this agent stuck. Prefer a recognized tool-capable model (e.g.{' '}
+        <span className="text-gray-300">qwen3.6:35b</span>) or an API/CLI provider.{children ? ' ' : ''}
+        {children}
+      </span>
+    </p>
+  );
+}

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -903,6 +903,43 @@ export const assignmentModelOptions = (entry, providers, providerId, visionIdsBy
 };
 
 /**
+ * Tool-use annotation state for one AI-assignment row/stage, so every editor of
+ * the same pin (the AI Assignments table, the Creative Director Models drawer,
+ * any future one) derives it identically instead of re-deriving the rule and
+ * drifting — the drawer used to be the only editor that warned at all, because
+ * its stage list hard-coded `needsTools` client-side.
+ *
+ * `entry.needsTools` is the SERVER's marker for an assignment whose provider runs
+ * an agent harness (see `agentEntry` in server/services/aiAssignments.js). It
+ * mirrors `modelFilter: 'vision'`: one server flag, read uniformly.
+ *
+ * Three rules are baked in here so a caller can't forget one:
+ *   - The EFFECTIVE model is judged, not the pin. A blank model isn't a no-op —
+ *     the agent resolver then runs the provider's own `defaultModel`, which for a
+ *     local backend can be the non-tool model that wedges the run.
+ *   - Nothing is asserted until the capability scan SETTLES (`toolUseLoaded`,
+ *     success or failure). Annotating mid-scan shows the false "no known tool
+ *     use" the authoritative union exists to remove, only to retract it a beat
+ *     later.
+ *   - `incapable` is a strict `=== false` on the hint, so a non-agent entry, a
+ *     cloud provider (`localToolUseHint` returns null — ids don't encode family)
+ *     or an unpinned row all read as "no warning", never as "incapable".
+ *
+ * @param {{needsTools?:boolean}|null|undefined} entry - the assignment entry
+ * @param {object|undefined} provider - the currently selected provider object
+ * @param {string} model - the row's model pin ('' = provider default)
+ * @param {Record<string, Set<string>>|null} [toolUseIdsByProvider] - from `useToolUseModelIds`
+ * @param {boolean} [toolUseLoaded] - whether that scan has settled
+ * @returns {{annotate: boolean, effectiveModel: string, incapable: boolean}}
+ */
+export const assignmentToolUseState = (entry, provider, model, toolUseIdsByProvider = null, toolUseLoaded = false) => {
+  const effectiveModel = effectiveModelFor(provider, model);
+  const annotate = entry?.needsTools === true && toolUseLoaded;
+  const hint = annotate ? localToolUseHint(effectiveModel, provider, toolUseIdsByProvider) : null;
+  return { annotate, effectiveModel, incapable: hint?.toolCapable === false };
+};
+
+/**
  * Default model to seed when the user picks a provider for an assignment.
  * For vision-filtered entries, only returns a model that still appears in the
  * filtered options — a local backend's text-only `defaultModel` must not be

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -7,6 +7,7 @@ import {
   assignmentProviderOptions,
   assignmentModelOptions,
   assignmentDefaultModel,
+  assignmentToolUseState,
   PROVIDER_TYPES,
   filterSelectableModels,
   filterGenerationModels,
@@ -1065,5 +1066,57 @@ describe('AI Assignments option helpers', () => {
     // Non-vision rows still seed the provider default.
     expect(assignmentDefaultModel({}, providers, 'ollama')).toBe('granite4.1:8b');
     expect(assignmentDefaultModel({}, providers, '')).toBe('');
+  });
+
+  describe('assignmentToolUseState', () => {
+    const ollama = providers.find((p) => p.id === 'ollama');
+    const openai = providers.find((p) => p.id === 'openai');
+    const agentEntry = { needsTools: true };
+
+    it('flags a needsTools row on a local model with no recognized tool use', () => {
+      expect(assignmentToolUseState(agentEntry, ollama, 'llava:latest', null, true))
+        .toEqual({ annotate: true, effectiveModel: 'llava:latest', incapable: true });
+    });
+
+    it('clears once the model is recognized, by regex or by the backend', () => {
+      expect(assignmentToolUseState(agentEntry, ollama, 'llama3.2:latest', null, true).incapable).toBe(false);
+      // Authoritative map wins for an id the regex does not know.
+      const ids = { ollama: new Set(['llava:latest']) };
+      expect(assignmentToolUseState(agentEntry, ollama, 'llava:latest', ids, true).incapable).toBe(false);
+    });
+
+    it('judges the EFFECTIVE model, so a blank pin resolves the provider default', () => {
+      // granite4.1 IS a recognized tool-caller, so a blank pin on ollama is clean…
+      expect(assignmentToolUseState(agentEntry, ollama, '', null, true))
+        .toEqual({ annotate: true, effectiveModel: 'granite4.1:8b', incapable: false });
+      // …while a provider whose default is not gets flagged on the same blank pin.
+      const textOnly = { id: 'ollama', name: 'Ollama', defaultModel: 'llava:latest' };
+      expect(assignmentToolUseState(agentEntry, textOnly, '', null, true))
+        .toEqual({ annotate: true, effectiveModel: 'llava:latest', incapable: true });
+    });
+
+    it('asserts nothing until the capability scan settles', () => {
+      expect(assignmentToolUseState(agentEntry, ollama, 'llava:latest', null, false))
+        .toEqual({ annotate: false, effectiveModel: 'llava:latest', incapable: false });
+    });
+
+    it('stays silent for a non-agent entry, a cloud provider, or an unpinned row', () => {
+      // The server did not mark this assignment — same model, no warning.
+      expect(assignmentToolUseState({ modelFilter: 'vision' }, ollama, 'llava:latest', null, true).incapable).toBe(false);
+      expect(assignmentToolUseState(undefined, ollama, 'llava:latest', null, true).incapable).toBe(false);
+      // Cloud ids do not encode their family, so they are never judged.
+      expect(assignmentToolUseState(agentEntry, openai, 'gpt-4.1', null, true).incapable).toBe(false);
+      expect(assignmentToolUseState(agentEntry, undefined, '', null, true))
+        .toEqual({ annotate: true, effectiveModel: '', incapable: false });
+    });
+
+    it('flags an ollama-BACKED wrapper whose id and name say nothing about ollama', () => {
+      // Only the server-resolved `ollamaBacked` flag identifies it — the exact
+      // provider class the tool-use warning exists for.
+      const wrapper = { id: 'local-agent', name: 'Local Agent', ollamaBacked: true, defaultModel: 'llava:latest' };
+      expect(assignmentToolUseState(agentEntry, wrapper, '', null, true).incapable).toBe(true);
+      // Without the flag it reads as a cloud CLI and is left alone.
+      expect(assignmentToolUseState(agentEntry, { ...wrapper, ollamaBacked: false }, '', null, true).incapable).toBe(false);
+    });
   });
 });

--- a/server/services/aiAssignments.js
+++ b/server/services/aiAssignments.js
@@ -1,5 +1,5 @@
 import { getSettings, updateSettings } from './settings.js';
-import { getAllProviders, getProviderById, setActiveProvider, updateProvider } from './providers.js';
+import { getAllProviders, getProviderById, isOllamaBackedProvider, setActiveProvider, updateProvider } from './providers.js';
 import * as brainService from './brain.js';
 import * as universeService from './universeBuilder.js';
 import * as storyBuilderService from './storyBuilder.js';
@@ -20,6 +20,16 @@ const embeddingProviders = [
   { id: 'ollama', name: 'Ollama' },
   { id: 'lmstudio', name: 'LM Studio' },
 ];
+
+// Shared shape for every assignment whose provider runs an AGENT HARNESS. Such a
+// stage only works with a model that emits native tool calls — a local model that
+// can't (e.g. Gemma) narrates a done-message instead of acting, silently wedging
+// the run. `needsTools` is the SERVER-side source of truth every editor reads
+// (AI Assignments, the Creative Director Models drawer, any future one), so the
+// flag can't drift per-editor the way the drawer's hard-coded stage list did —
+// that list left the same pins editable without a warning from AI Assignments.
+// Mirrors how the scene-evaluation entry carries `modelFilter: 'vision'`.
+const agentEntry = { providerTypes: cliProviderTypes, needsTools: true };
 
 const asNullable = (value) => {
   if (value == null) return null;
@@ -52,6 +62,12 @@ const makeEntry = ({
   // Assignments / Creative Director pickers to restrict LOCAL backends
   // (Ollama / LM Studio) to vision-capable models only.
   modelFilter = null,
+  // Marks an assignment whose provider runs an agent harness (see `agentEntry`).
+  // Editors annotate their model options with a tool-use marker and warn when the
+  // EFFECTIVE model (explicit pin, else the provider default) isn't a recognized
+  // tool-caller. Advisory only — never a filter, because the capability signal is
+  // a positive allowlist and a non-match is "unrecognized", not a proven negative.
+  needsTools = false,
   link = null,
   notes = '',
 }) => ({
@@ -69,6 +85,7 @@ const makeEntry = ({
   providerOptions,
   modelOptions,
   modelFilter,
+  needsTools,
   link,
   notes,
 });
@@ -156,7 +173,7 @@ const addSettingsEntries = async (entries) => {
       source: `settings.${key}`,
       providerId: settings[key]?.providerId || null,
       model: settings[key]?.model || null,
-      providerTypes: cliProviderTypes,
+      ...agentEntry,
       notes: 'Requires a CLI/TUI provider because it runs agentic tool work.',
       link: key === 'autofixer' ? '/settings/autofixer' : '/settings/general',
     }));
@@ -169,7 +186,7 @@ const addSettingsEntries = async (entries) => {
     source: 'settings.creativeDirector.treatment',
     providerId: settings.creativeDirector?.treatment?.providerId || null,
     model: settings.creativeDirector?.treatment?.model || null,
-    providerTypes: cliProviderTypes,
+    ...agentEntry,
     notes: 'Agent model that turns a project brief into a treatment and scene plan. Blank = system default provider and model. Each Creative Director project can override this from its Models drawer.',
     link: '/creative-director',
   }));
@@ -181,7 +198,7 @@ const addSettingsEntries = async (entries) => {
     source: 'settings.creativeDirector.plan',
     providerId: settings.creativeDirector?.plan?.providerId || null,
     model: settings.creativeDirector?.plan?.model || null,
-    providerTypes: cliProviderTypes,
+    ...agentEntry,
     notes: 'Agent model that converts a production directive into an executable plan. Blank = system default provider and model. Each Creative Director project can override this from its Models drawer.',
     link: '/creative-director',
   }));
@@ -229,7 +246,7 @@ const addSettingsEntries = async (entries) => {
     source: 'settings.voice.llm.codeAgent',
     providerId: voice.llm?.codeAgent?.provider || null,
     model: voice.llm?.codeAgent?.model || null,
-    providerTypes: cliProviderTypes,
+    ...agentEntry,
     link: '/settings/voice',
   }));
 
@@ -350,7 +367,7 @@ const addRecordEntries = async (entries) => {
         providerId: task.providerId || null,
         model: task.model || null,
         scope: 'record',
-        providerTypes: cliProviderTypes,
+        ...agentEntry,
         link: '/cos/config',
       }));
     }
@@ -364,7 +381,7 @@ const addRecordEntries = async (entries) => {
           providerId: stage.providerId || null,
           model: stage.model || null,
           scope: 'record',
-          providerTypes: cliProviderTypes,
+          ...agentEntry,
           link: '/cos/config',
         }));
       }
@@ -382,7 +399,7 @@ const addRecordEntries = async (entries) => {
         model: null,
         scope: 'record',
         modelEditable: false,
-        providerTypes: cliProviderTypes,
+        ...agentEntry,
         link: '/loops',
       }));
     }
@@ -398,7 +415,7 @@ const addRecordEntries = async (entries) => {
         providerId: agent.providerId || null,
         model: agent.model || null,
         scope: 'record',
-        providerTypes: cliProviderTypes,
+        ...agentEntry,
         link: `/feature-agents/${agent.id}/config`,
       }));
     }
@@ -473,6 +490,13 @@ export async function getAiAssignments() {
       enabled: p.enabled !== false,
       defaultModel: p.defaultModel || null,
       models: pickModelOptions(p),
+      // Resolved HERE rather than client-side: the client mirror of this
+      // predicate reads `envVars.ANTHROPIC_BASE_URL` / `endpoint`, and this
+      // payload deliberately ships neither (envVars can hold secrets). Without
+      // the resolved flag a renamed `claude-ollama-tui` — the exact provider
+      // class the tool-use warning exists for — looked like a cloud agent to
+      // every editor and was silently skipped.
+      ollamaBacked: isOllamaBackedProvider(p),
     })),
     activeProvider: providersData.activeProvider || null,
     assignments: entries,

--- a/server/services/aiAssignments.test.js
+++ b/server/services/aiAssignments.test.js
@@ -40,11 +40,15 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('./settings.js', () => ({ getSettings: mocks.getSettings, updateSettings: mocks.updateSettings }));
-vi.mock('./providers.js', () => ({
+vi.mock('./providers.js', async () => ({
   getAllProviders: mocks.getAllProviders,
   getProviderById: mocks.getProviderById,
   setActiveProvider: mocks.setActiveProvider,
   updateProvider: mocks.updateProvider,
+  // Pure predicate, deliberately NOT stubbed: the curated payload's
+  // `ollamaBacked` flag has to be the same answer the toolkit's own refresh
+  // dispatch gives, so re-implementing it here would test nothing.
+  isOllamaBackedProvider: (await import('../lib/aiToolkit/providers.js')).isOllamaBackedProvider,
 }));
 vi.mock('./brain.js', () => ({ loadMeta: mocks.loadMeta, updateMeta: mocks.updateMeta }));
 vi.mock('./universeBuilder.js', () => ({ listUniverses: mocks.listUniverses, updateUniverse: mocks.updateUniverse }));
@@ -98,12 +102,14 @@ describe('getAiAssignments', () => {
     const result = await getAiAssignments();
     expect(result.activeProvider).toBe('openai');
     expect(result.providers).toEqual([
-      { id: 'openai', name: 'OpenAI', type: 'api', enabled: true, defaultModel: 'gpt-4', models: ['gpt-4', 'gpt-4o'] },
-      { id: 'claude', name: 'Claude', type: 'cli', enabled: true, defaultModel: 'opus', models: ['opus'] },
+      { id: 'openai', name: 'OpenAI', type: 'api', enabled: true, defaultModel: 'gpt-4', models: ['gpt-4', 'gpt-4o'], ollamaBacked: false },
+      { id: 'claude', name: 'Claude', type: 'cli', enabled: true, defaultModel: 'opus', models: ['opus'], ollamaBacked: false },
     ]);
-    // The provider mock has no apiKey, but assert the curated shape has no extra keys regardless.
+    // The provider mock has no apiKey, but assert the curated shape has no extra
+    // keys regardless — in particular no `envVars`, which is why `ollamaBacked`
+    // has to be resolved server-side instead of re-derived by the client.
     for (const p of result.providers) {
-      expect(Object.keys(p).sort()).toEqual(['defaultModel', 'enabled', 'id', 'models', 'name', 'type']);
+      expect(Object.keys(p).sort()).toEqual(['defaultModel', 'enabled', 'id', 'models', 'name', 'ollamaBacked', 'type']);
     }
     const ids = result.assignments.map((a) => a.id);
     expect(ids).toContain('provider.active');
@@ -116,6 +122,56 @@ describe('getAiAssignments', () => {
     // Scene evaluation is a vision call — clients filter local model lists to VLMs.
     const evaluation = result.assignments.find((a) => a.id === 'settings.creativeDirector.evaluation');
     expect(evaluation.modelFilter).toBe('vision');
+  });
+
+  it('marks agent-harness assignments needsTools so every editor warns from one flag', async () => {
+    const result = await getAiAssignments();
+    const byId = Object.fromEntries(result.assignments.map((a) => [a.id, a]));
+    // The pins the Creative Director drawer used to hard-code client-side —
+    // editable from AI Assignments too, which is why the marker is server-side.
+    expect(byId['settings.creativeDirector.treatment'].needsTools).toBe(true);
+    expect(byId['settings.creativeDirector.plan'].needsTools).toBe(true);
+    // Every other assignment that requires a CLI/TUI provider because it runs
+    // agentic tool work carries it as well.
+    expect(byId['settings.autofixer'].needsTools).toBe(true);
+    expect(byId['settings.voice.codeAgent'].needsTools).toBe(true);
+    expect(byId['cos.task.morning-brief'].needsTools).toBe(true);
+    // A vision call and a plain chat pin are NOT agent runs — a non-tool model
+    // there is expected, so they must not be flagged.
+    expect(byId['settings.creativeDirector.evaluation'].needsTools).toBe(false);
+    expect(byId['settings.voice.llm'].needsTools).toBe(false);
+    expect(byId['settings.embeddings'].needsTools).toBe(false);
+    // Every needsTools entry also restricts providers to CLI/TUI — the two ride
+    // together, so a future entry can't claim tool use on an API-only pin.
+    for (const entry of result.assignments.filter((a) => a.needsTools)) {
+      expect(entry.providerTypes).toEqual(['cli', 'tui']);
+    }
+  });
+
+  it('resolves ollamaBacked on the curated providers so the client can flag wrapper CLIs', async () => {
+    // A renamed Claude-Ollama TUI: neither its id nor its name says "ollama",
+    // and the curated payload ships no envVars — without the server-resolved
+    // flag the tool-use warning silently skips the incident's provider class.
+    mocks.getAllProviders.mockResolvedValue({
+      activeProvider: 'openai',
+      providers: [
+        { id: 'openai', name: 'OpenAI', type: 'api', enabled: true, defaultModel: 'gpt-4', models: ['gpt-4'] },
+        {
+          id: 'local-agent',
+          name: 'Local Agent',
+          type: 'tui',
+          enabled: true,
+          defaultModel: 'gemma4:e4b',
+          models: ['gemma4:e4b'],
+          envVars: { ANTHROPIC_BASE_URL: 'http://127.0.0.1:11434' },
+        },
+      ],
+    });
+    const result = await getAiAssignments();
+    const byId = Object.fromEntries(result.providers.map((p) => [p.id, p]));
+    expect(byId['local-agent'].ollamaBacked).toBe(true);
+    expect(byId['local-agent'].envVars).toBeUndefined();
+    expect(byId.openai.ollamaBacked).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

The agent tool-use warning ("this model isn't a recognized tool-caller") only fired where a client file hard-coded which pins were agent runs. `CreativeDirectorModelsDrawer` carried that list on its own `STAGES`, so the drawer warned about a treatment/plan pin while its own "Also editable from AI Assignments" link led to `AiAssignmentsTab` — a generic per-assignment table that rendered no annotation or warning at all, letting the user set the identical pin to a tool-less local model.

Collapsed the source of truth to the server, mirroring how the scene-evaluation entry already carries `modelFilter: 'vision'`:

- **`server/services/aiAssignments.js`** — `makeEntry` gains `needsTools`, and a shared `agentEntry` spread (`{ providerTypes: ['cli','tui'], needsTools: true }`) tags every assignment whose provider runs an agent harness: Creative Director treatment + plan, autofixer, calendar sync, the voice code agent, CoS scheduled tasks and their pipeline stages, loops, and feature agents. Vision, chat and embedding pins stay unflagged.
- **Curated provider payload** now carries a server-resolved `ollamaBacked`. That payload deliberately ships no `envVars` (they can hold secrets) or `endpoint`, so the client's mirror of the predicate had nothing to sniff — a renamed Ollama-backed wrapper CLI, the exact provider class the warning exists for, looked like a cloud agent and was silently skipped in both editors.
- **`assignmentToolUseState`** (`client/src/utils/providers.js`) — one helper for the three rules every editor has to get right: judge the EFFECTIVE model (a blank pin runs the provider's own default), assert nothing until the capability scan settles, and treat a non-agent entry / cloud provider / unpinned row as "no warning" rather than "incapable".
- **`ToolUseWarning`** (`client/src/components/ui/`) — the advice text existed in two hand-rolled copies and was about to become three, so it is now one component used by `ProviderModelSelector`, the Creative Director drawer, and the AI Assignments table.
- **`AiAssignmentsTab`** — agent rows now annotate each model `<option>` with its tool-use marker and render the warning under the model control, with a "Browse models" link to `/settings/local-llm`.

The Creative Director drawer's `STAGES` no longer names which stages need tools; it reads the server flag like every other editor.

## Test plan

- `server/services/aiAssignments.test.js` — new cases assert the `needsTools` tagging (set on treatment/plan/autofixer/voice code agent/CoS tasks, unset on the vision, voice-LLM and embedding entries), that `needsTools` and CLI/TUI-only providers always ride together, and that `ollamaBacked` resolves true for a wrapper CLI whose id and name say nothing about Ollama while `envVars` stays off the payload. Fails without the service change.
- `client/src/utils/providers.test.js` — `assignmentToolUseState` covering effective-model resolution, the settled-scan gate, the authoritative-map union, the non-agent/cloud/unpinned silences, and the `ollamaBacked` wrapper.
- `client/src/components/settings/AiAssignmentsTab.test.jsx` (new) — warns on an agent row pinned to a non-tool local model, stays silent on a vision row with the same model, clears when the backend reports the model tool-capable, warns on a blank pin that resolves the provider default, annotates the options of agent rows only, and flags the wrapper CLI.
- `client/src/components/creative-director/CreativeDirectorModelsDrawer.test.jsx` — fixture now mirrors the server payload, plus a case that drops `needsTools` and asserts the warning disappears (proof the flag, not a local list, drives it).
- Full suites green: server `1384 passed | 26 skipped`, client `635 files / 7657 passed`. `npm run lint` clean in `client`.

Closes #4126
