### PR TITLE
refactor: wire up StatCard's activeLabel across variants; unify Learning cards onto it (#4129)

### DIFF
--- a/.changelog/next/changed-issue-4129.md
+++ b/.changelog/next/changed-issue-4129.md
@@ -1,0 +1,1 @@
+- CoS StatCard now renders its active sub-label on every variant and accepts onClick + a health tone; both Learning tiles use it instead of hand-rolled buttons

--- a/client/src/components/cos/StatCard.jsx
+++ b/client/src/components/cos/StatCard.jsx
@@ -13,8 +13,10 @@ const TONE_CLASSES = {
 
 // The `mini` and `default` variants share one stacked layout and differ only by
 // scale, so they live in a size table instead of two near-identical returns.
+// `compact` keeps its own row layout but reads its shell classes from here too.
 const SIZES = {
   default: {
+    bg: 'bg-port-card',
     root: 'rounded-lg p-2 sm:p-3 lg:p-4',
     activeBorder: 'border-port-accent shadow-lg shadow-port-accent/20',
     header: 'mb-0.5 sm:mb-1 lg:mb-2',
@@ -23,6 +25,7 @@ const SIZES = {
     activeLabel: 'text-xs mt-0.5 sm:mt-1 animate-pulse',
   },
   mini: {
+    bg: 'bg-port-card',
     root: 'rounded p-1.5 sm:p-2 lg:p-3',
     activeBorder: 'border-port-accent shadow-md shadow-port-accent/20',
     header: 'mb-0.5',
@@ -30,9 +33,13 @@ const SIZES = {
     value: 'text-sm sm:text-base lg:text-xl',
     activeLabel: 'text-[9px] mt-0.5',
   },
+  compact: {
+    bg: 'bg-port-card/80',
+    root: 'rounded px-2 py-1.5 flex items-center gap-2',
+    activeBorder: 'border-port-accent shadow-md shadow-port-accent/20',
+    activeLabel: 'text-[9px]',
+  },
 };
-
-const COMPACT_ACTIVE_BORDER = 'border-port-accent shadow-md shadow-port-accent/20';
 
 export default function StatCard({ label, value, icon, active, activeLabel, compact, mini, tone, onClick, title }) {
   const ariaLabel = `${label}: ${value}${active && activeLabel ? `, ${activeLabel}` : ''}`;
@@ -42,22 +49,27 @@ export default function StatCard({ label, value, icon, active, activeLabel, comp
   const iconClass = ['shrink-0', active ? 'animate-pulse' : '', toneStyles?.icon ?? ''].filter(Boolean).join(' ');
   const subLabelClass = toneStyles?.label ?? 'text-port-accent';
   const showActiveLabel = Boolean(active && activeLabel);
-  const borderClass = (activeBorder) => toneStyles?.border ?? (active ? activeBorder : 'border-port-border');
+
+  const size = compact ? SIZES.compact : (mini ? SIZES.mini : SIZES.default);
+  const borderClass = toneStyles?.border ?? (active ? size.activeBorder : 'border-port-border');
 
   // `onClick` promotes the card to a real <button> so it's keyboard- and
-  // screen-reader-reachable; without it the card stays a labelled group.
+  // screen-reader-reachable; without it the card stays a labelled group. A card
+  // already wearing a tone or active border keeps that color on hover — the
+  // border-hover affordance only applies where the border is still neutral.
   const Wrapper = onClick ? 'button' : 'div';
   const wrapperProps = onClick
     ? { type: 'button', onClick, title, 'aria-label': ariaLabel }
     : { role: 'group', title, 'aria-label': ariaLabel };
-  const interactiveClass = onClick ? 'text-left hover:bg-port-card/60' : '';
+  const hasNeutralBorder = !toneStyles?.border && !active;
+  const interactiveClass = onClick
+    ? `text-left hover:bg-port-card/60${hasNeutralBorder ? ' hover:border-port-accent-2/50' : ''}`
+    : '';
+  const shellClass = `${size.bg} border transition-all ${size.root} ${borderClass} ${interactiveClass}`;
 
   if (compact) {
     return (
-      <Wrapper
-        {...wrapperProps}
-        className={`bg-port-card/80 border rounded px-2 py-1.5 flex items-center gap-2 transition-all ${borderClass(COMPACT_ACTIVE_BORDER)} ${interactiveClass}`}
-      >
+      <Wrapper {...wrapperProps} className={shellClass}>
         <div className={iconClass} aria-hidden="true">
           {icon}
         </div>
@@ -71,7 +83,7 @@ export default function StatCard({ label, value, icon, active, activeLabel, comp
           <div className="text-[10px] text-gray-500 truncate">{label}</div>
           <div className="text-sm font-bold text-white">{value}</div>
           {showActiveLabel && (
-            <div className={`text-[9px] truncate ${subLabelClass}`} aria-live="polite">
+            <div className={`${size.activeLabel} truncate ${subLabelClass}`} aria-live="polite">
               {activeLabel}
             </div>
           )}
@@ -80,13 +92,8 @@ export default function StatCard({ label, value, icon, active, activeLabel, comp
     );
   }
 
-  const size = mini ? SIZES.mini : SIZES.default;
-
   return (
-    <Wrapper
-      {...wrapperProps}
-      className={`bg-port-card border transition-all ${size.root} ${borderClass(size.activeBorder)} ${interactiveClass}`}
-    >
+    <Wrapper {...wrapperProps} className={shellClass}>
       <div className={`flex items-center justify-between ${size.header}`}>
         <span className={`${size.label} text-gray-500 truncate`}>{label}</span>
         <div className={iconClass} aria-hidden="true">

--- a/client/src/components/cos/StatCard.jsx
+++ b/client/src/components/cos/StatCard.jsx
@@ -1,66 +1,104 @@
-export default function StatCard({ label, value, icon, active, activeLabel, compact, mini }) {
+// Status tones for a card whose color reflects a health signal rather than the
+// generic "something is running" `active` state. Border, icon and sub-label all
+// read from one entry so the three can't drift apart — which is exactly what
+// happened while the CoS Learning tiles were hand-rolled buttons (#4129).
+// A tone with `border: null` tints only the icon and leaves the border to the
+// `active` treatment below.
+const TONE_CLASSES = {
+  critical: { icon: 'text-port-error', border: 'border-port-error shadow-md shadow-port-error/20', label: 'text-port-error' },
+  warning: { icon: 'text-port-warning', border: 'border-port-warning shadow-md shadow-port-warning/20', label: 'text-port-warning' },
+  good: { icon: 'text-port-accent-2', border: null, label: 'text-port-accent-2' },
+  default: { icon: 'text-gray-500', border: null, label: null },
+};
+
+// The `mini` and `default` variants share one stacked layout and differ only by
+// scale, so they live in a size table instead of two near-identical returns.
+const SIZES = {
+  default: {
+    root: 'rounded-lg p-2 sm:p-3 lg:p-4',
+    activeBorder: 'border-port-accent shadow-lg shadow-port-accent/20',
+    header: 'mb-0.5 sm:mb-1 lg:mb-2',
+    label: 'text-xs sm:text-sm mr-1',
+    value: 'text-lg sm:text-xl lg:text-2xl',
+    activeLabel: 'text-xs mt-0.5 sm:mt-1 animate-pulse',
+  },
+  mini: {
+    root: 'rounded p-1.5 sm:p-2 lg:p-3',
+    activeBorder: 'border-port-accent shadow-md shadow-port-accent/20',
+    header: 'mb-0.5',
+    label: 'text-[10px] sm:text-xs',
+    value: 'text-sm sm:text-base lg:text-xl',
+    activeLabel: 'text-[9px] mt-0.5',
+  },
+};
+
+const COMPACT_ACTIVE_BORDER = 'border-port-accent shadow-md shadow-port-accent/20';
+
+export default function StatCard({ label, value, icon, active, activeLabel, compact, mini, tone, onClick, title }) {
   const ariaLabel = `${label}: ${value}${active && activeLabel ? `, ${activeLabel}` : ''}`;
+  // Only tint the icon when a tone was asked for — tone-less callers pass a
+  // pre-colored icon element of their own.
+  const toneStyles = tone ? (TONE_CLASSES[tone] ?? TONE_CLASSES.default) : null;
+  const iconClass = ['shrink-0', active ? 'animate-pulse' : '', toneStyles?.icon ?? ''].filter(Boolean).join(' ');
+  const subLabelClass = toneStyles?.label ?? 'text-port-accent';
+  const showActiveLabel = Boolean(active && activeLabel);
+  const borderClass = (activeBorder) => toneStyles?.border ?? (active ? activeBorder : 'border-port-border');
+
+  // `onClick` promotes the card to a real <button> so it's keyboard- and
+  // screen-reader-reachable; without it the card stays a labelled group.
+  const Wrapper = onClick ? 'button' : 'div';
+  const wrapperProps = onClick
+    ? { type: 'button', onClick, title, 'aria-label': ariaLabel }
+    : { role: 'group', title, 'aria-label': ariaLabel };
+  const interactiveClass = onClick ? 'text-left hover:bg-port-card/60' : '';
 
   if (compact) {
     return (
-      <div
-        role="group"
-        aria-label={ariaLabel}
-        className={`bg-port-card/80 border rounded px-2 py-1.5 flex items-center gap-2 ${
-          active ? 'border-port-accent shadow-md shadow-port-accent/20' : 'border-port-border'
-        }`}
+      <Wrapper
+        {...wrapperProps}
+        className={`bg-port-card/80 border rounded px-2 py-1.5 flex items-center gap-2 transition-all ${borderClass(COMPACT_ACTIVE_BORDER)} ${interactiveClass}`}
       >
-        <div className={`shrink-0 ${active ? 'animate-pulse' : ''}`} aria-hidden="true">
+        <div className={iconClass} aria-hidden="true">
           {icon}
         </div>
+        {/* Stacked, not a flex row: as flex items these keep min-width:auto, so
+            on a narrow card the sub-label can't shrink and spills out. (The
+            `min-w-0` here is what lets the column shrink at all — a nowrap
+            label in a `min-width:auto` flex item can't.) The value itself stays
+            wrappable: truncate the label, leave the value alone, or a wide
+            value like 'No data' clips to 'No dat…'. */}
         <div className="flex-1 min-w-0">
           <div className="text-[10px] text-gray-500 truncate">{label}</div>
           <div className="text-sm font-bold text-white">{value}</div>
+          {showActiveLabel && (
+            <div className={`text-[9px] truncate ${subLabelClass}`} aria-live="polite">
+              {activeLabel}
+            </div>
+          )}
         </div>
-      </div>
+      </Wrapper>
     );
   }
 
-  if (mini) {
-    return (
-      <div
-        role="group"
-        aria-label={ariaLabel}
-        className={`bg-port-card border rounded p-1.5 sm:p-2 lg:p-3 transition-all ${
-          active ? 'border-port-accent shadow-md shadow-port-accent/20' : 'border-port-border'
-        }`}
-      >
-        <div className="flex items-center justify-between mb-0.5">
-          <span className="text-[10px] sm:text-xs text-gray-500 truncate">{label}</span>
-          <div className={`shrink-0 ${active ? 'animate-pulse' : ''}`} aria-hidden="true">
-            {icon}
-          </div>
-        </div>
-        <div className="text-sm sm:text-base lg:text-xl font-bold text-white">{value}</div>
-      </div>
-    );
-  }
+  const size = mini ? SIZES.mini : SIZES.default;
 
   return (
-    <div
-      role="group"
-      aria-label={ariaLabel}
-      className={`bg-port-card border rounded-lg p-2 sm:p-3 lg:p-4 transition-all ${
-        active ? 'border-port-accent shadow-lg shadow-port-accent/20' : 'border-port-border'
-      }`}
+    <Wrapper
+      {...wrapperProps}
+      className={`bg-port-card border transition-all ${size.root} ${borderClass(size.activeBorder)} ${interactiveClass}`}
     >
-      <div className="flex items-center justify-between mb-0.5 sm:mb-1 lg:mb-2">
-        <span className="text-xs sm:text-sm text-gray-500 truncate mr-1">{label}</span>
-        <div className={`shrink-0 ${active ? 'animate-pulse' : ''}`} aria-hidden="true">
+      <div className={`flex items-center justify-between ${size.header}`}>
+        <span className={`${size.label} text-gray-500 truncate`}>{label}</span>
+        <div className={iconClass} aria-hidden="true">
           {icon}
         </div>
       </div>
-      <div className="text-lg sm:text-xl lg:text-2xl font-bold text-white">{value}</div>
-      {active && activeLabel && (
-        <div className="text-xs text-port-accent mt-0.5 sm:mt-1 truncate animate-pulse" aria-live="polite">
+      <div className={`${size.value} font-bold text-white`}>{value}</div>
+      {showActiveLabel && (
+        <div className={`${size.activeLabel} truncate ${subLabelClass}`} aria-live="polite">
           {activeLabel}
         </div>
       )}
-    </div>
+    </Wrapper>
   );
 }

--- a/client/src/components/cos/StatCard.test.jsx
+++ b/client/src/components/cos/StatCard.test.jsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import StatCard from './StatCard';
+
+// `activeLabel` used to be rendered ONLY by the default variant — the `compact`
+// and `mini` variants folded it into the aria-label and dropped it from the
+// markup, so a sighted user saw nothing (#4129). Every variant now paints it.
+const VARIANTS = [
+  ['default', {}],
+  ['compact', { compact: true }],
+  ['mini', { mini: true }],
+];
+
+const root = (container) => container.firstChild;
+
+describe('StatCard activeLabel', () => {
+  for (const [name, variantProps] of VARIANTS) {
+    it(`renders the active sub-label visibly in the ${name} variant`, () => {
+      render(<StatCard label="Learning" value="84%" activeLabel="3 skipped" active {...variantProps} />);
+      expect(screen.getByText('3 skipped')).toBeInTheDocument();
+    });
+
+    it(`announces the active sub-label in the ${name} variant's accessible name`, () => {
+      render(<StatCard label="Learning" value="84%" activeLabel="3 skipped" active {...variantProps} />);
+      expect(screen.getByRole('group', { name: 'Learning: 84%, 3 skipped' })).toBeInTheDocument();
+    });
+
+    it(`omits the sub-label when the ${name} variant is not active`, () => {
+      render(<StatCard label="Learning" value="84%" activeLabel="3 skipped" {...variantProps} />);
+      expect(screen.queryByText('3 skipped')).not.toBeInTheDocument();
+      expect(screen.getByRole('group', { name: 'Learning: 84%' })).toBeInTheDocument();
+    });
+  }
+
+  it('truncates the sub-label so it clips inside the card instead of spilling', () => {
+    render(<StatCard label="Learning" value="84%" activeLabel="3 skipped" active compact />);
+    expect(screen.getByText('3 skipped').classList.contains('truncate')).toBe(true);
+  });
+});
+
+describe('StatCard onClick', () => {
+  it('stays a labelled group — not a button — without onClick', () => {
+    render(<StatCard label="Active" value={2} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Active: 2' })).toBeInTheDocument();
+  });
+
+  it('promotes the card to a real button that fires on click', async () => {
+    const onClick = vi.fn();
+    render(<StatCard label="Learning" value="84%" onClick={onClick} compact />);
+
+    const button = screen.getByRole('button', { name: 'Learning: 84%' });
+    // type="button" keeps a card inside a form from submitting it.
+    expect(button.getAttribute('type')).toBe('button');
+    await userEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes title through for the hover hint', () => {
+    render(<StatCard label="Learning" value="84%" title="2 need attention" onClick={() => {}} mini />);
+    expect(screen.getByRole('button', { name: 'Learning: 84%' }).getAttribute('title')).toBe('2 need attention');
+  });
+});
+
+describe('StatCard tone', () => {
+  it('paints border, icon and sub-label from one tone entry', () => {
+    const { container } = render(
+      <StatCard label="Learning" value="12%" icon={<svg data-testid="icon" />} activeLabel="3 skipped" active tone="critical" mini />,
+    );
+
+    expect(root(container).className).toContain('border-port-error');
+    expect(screen.getByTestId('icon').parentElement.className).toContain('text-port-error');
+    expect(screen.getByText('3 skipped').className).toContain('text-port-error');
+  });
+
+  it('lets the tone border win over the generic active accent', () => {
+    // `active` also drives the pulsing accent border; a card carrying a health
+    // tone must read as that health state, not as "something is running".
+    const { container } = render(<StatCard label="Learning" value="12%" active tone="warning" compact />);
+    expect(root(container).className).toContain('border-port-warning');
+    expect(root(container).className).not.toContain('border-port-accent');
+  });
+
+  it('tints only the icon for the good tone, leaving the border to active', () => {
+    const { container } = render(<StatCard label="Learning" value="98%" icon={<svg data-testid="icon" />} tone="good" mini />);
+    expect(screen.getByTestId('icon').parentElement.className).toContain('text-port-accent-2');
+    expect(root(container).className).toContain('border-port-border');
+  });
+
+  it('falls back to the neutral tone for a status it does not know', () => {
+    // The learning summary also emits `ok` / `none`; an unmapped tone must go
+    // gray rather than inherit whatever text color the page happens to set.
+    render(<StatCard label="Learning" value="—" icon={<svg data-testid="icon" />} tone="none" mini />);
+    expect(screen.getByTestId('icon').parentElement.className).toContain('text-gray-500');
+  });
+
+  it('leaves a tone-less card\'s own pre-colored icon alone', () => {
+    render(<StatCard label="Active" value={2} icon={<svg data-testid="icon" className="text-port-accent" />} compact />);
+    const wrapper = screen.getByTestId('icon').parentElement;
+    expect(wrapper.className).not.toContain('text-gray-500');
+    expect(wrapper.className).toContain('shrink-0');
+  });
+});

--- a/client/src/components/cos/StatCard.test.jsx
+++ b/client/src/components/cos/StatCard.test.jsx
@@ -57,6 +57,21 @@ describe('StatCard onClick', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
+  it('offers a border-hover affordance while the border is still neutral', () => {
+    const { container } = render(<StatCard label="Learning" value="84%" onClick={() => {}} mini />);
+    expect(root(container).className).toContain('hover:border-port-accent-2/50');
+  });
+
+  it('does not hover-recolor a border already carrying a tone or the active accent', () => {
+    // Hovering a red "critical" card must not flash it accent-2 — the health
+    // color is the signal, and Tailwind's hover: variant would win over it.
+    const { container: toned } = render(<StatCard label="Learning" value="12%" onClick={() => {}} tone="critical" mini />);
+    expect(root(toned).className).not.toContain('hover:border-');
+
+    const { container: activeCard } = render(<StatCard label="Active" value={2} onClick={() => {}} active mini />);
+    expect(root(activeCard).className).not.toContain('hover:border-');
+  });
+
   it('passes title through for the hover hint', () => {
     render(<StatCard label="Learning" value="84%" title="2 need attention" onClick={() => {}} mini />);
     expect(screen.getByRole('button', { name: 'Learning: 84%' }).getAttribute('title')).toBe('2 need attention');

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -518,13 +518,16 @@ export default function ChiefOfStaff() {
 
   // Learning tile behaviour shared by the compact (sidebar/mobile) and mini
   // (ascii stats bar) renderings — only the icon scale and the empty-state
-  // value differ between them. `skipped > 0` is exactly the server's `critical`
-  // status (taskLearning/insights.js), so the sub-label lands red via the tone.
+  // value differ between them. A skipped task type is critical on its own
+  // terms: derive that here rather than trusting the server's status chain to
+  // keep classifying `skipped > 0` as `critical`, or a reorder there would
+  // silently drop the red signal while the tile still reads "N skipped".
+  const learningSkipped = learningSummary?.skipped ?? 0;
   const learningStatProps = {
     label: 'Learning',
-    tone: learningSummary?.status || 'default',
-    active: (learningSummary?.skipped ?? 0) > 0,
-    activeLabel: learningSummary?.skipped ? `${learningSummary.skipped} skipped` : null,
+    tone: learningSkipped > 0 ? 'critical' : (learningSummary?.status || 'default'),
+    active: learningSkipped > 0,
+    activeLabel: learningSkipped > 0 ? `${learningSkipped} skipped` : null,
     title: learningSummary?.statusMessage || 'View learning analytics',
     onClick: () => navigate('/cos/learning'),
   };

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -523,6 +523,10 @@ export default function ChiefOfStaff() {
   // keep classifying `skipped > 0` as `critical`, or a reorder there would
   // silently drop the red signal while the tile still reads "N skipped".
   const learningSkipped = learningSummary?.skipped ?? 0;
+  // `!= null`, not truthiness — a real 0% success rate is the highest-signal
+  // state and must not render as the empty state. `null` is the sentinel each
+  // tile falls back from to its own (differently sized) empty-state string.
+  const learningRate = learningSummary?.overallSuccessRate != null ? `${learningSummary.overallSuccessRate}%` : null;
   const learningStatProps = {
     label: 'Learning',
     tone: learningSkipped > 0 ? 'critical' : (learningSummary?.status || 'default'),
@@ -563,7 +567,7 @@ export default function ChiefOfStaff() {
       />
       <StatCard
         {...learningStatProps}
-        value={learningSummary?.overallSuccessRate != null ? `${learningSummary.overallSuccessRate}%` : 'No data'}
+        value={learningRate ?? 'No data'}
         icon={<Brain className="w-4 h-4" />}
         compact
       />
@@ -886,7 +890,7 @@ export default function ChiefOfStaff() {
           {/* Learning Health - clickable to go to Learning tab */}
           <StatCard
             {...learningStatProps}
-            value={learningSummary?.overallSuccessRate != null ? `${learningSummary.overallSuccessRate}%` : '—'}
+            value={learningRate ?? '—'}
             icon={<Brain className="w-3 h-3 sm:w-4 sm:h-4 lg:w-5 lg:h-5" />}
             mini
           />

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -516,6 +516,19 @@ export default function ChiefOfStaff() {
 
   const hasCanvasAvatar = CANVAS_AVATAR_STYLES.has(avatarStyle);
 
+  // Learning tile behaviour shared by the compact (sidebar/mobile) and mini
+  // (ascii stats bar) renderings — only the icon scale and the empty-state
+  // value differ between them. `skipped > 0` is exactly the server's `critical`
+  // status (taskLearning/insights.js), so the sub-label lands red via the tone.
+  const learningStatProps = {
+    label: 'Learning',
+    tone: learningSummary?.status || 'default',
+    active: (learningSummary?.skipped ?? 0) > 0,
+    activeLabel: learningSummary?.skipped ? `${learningSummary.skipped} skipped` : null,
+    title: learningSummary?.statusMessage || 'View learning analytics',
+    onClick: () => navigate('/cos/learning'),
+  };
+
   // Compact stats card grid — rendered both inside the desktop CoS sidebar and
   // the mobile compressed header so the metrics always live "inside" CoS.
   const statsGridCards = (
@@ -545,39 +558,12 @@ export default function ChiefOfStaff() {
         icon={<AlertCircle className={`w-4 h-4 ${hasIssues ? 'text-port-error' : 'text-gray-500'}`} />}
         compact
       />
-      <button
-        onClick={() => navigate('/cos/learning')}
-        className={`bg-port-card/80 border rounded px-2 py-1.5 flex items-center gap-2 transition-all ${
-          learningSummary?.status === 'critical' ? 'border-port-error shadow-md shadow-port-error/20' :
-          learningSummary?.status === 'warning' ? 'border-port-warning' :
-          'border-port-border'
-        }`}
-      >
-        <Brain className={`w-4 h-4 shrink-0 ${
-          learningSummary?.status === 'critical' ? 'text-port-error' :
-          learningSummary?.status === 'warning' ? 'text-port-warning' :
-          learningSummary?.status === 'good' ? 'text-port-accent-2' :
-          'text-gray-500'
-        }`} />
-        <div className="flex-1 min-w-0 text-left">
-          <div className="text-[10px] text-gray-500 truncate">Learning</div>
-          {/* Stacked, not a flex row: as flex items these keep min-width:auto,
-              so on a narrow card the skipped label can't shrink and spills out.
-              (The `min-w-0` on the column above is what lets it shrink at all —
-              a nowrap label in a `min-width:auto` flex item can't.) The value
-              itself stays wrappable — `truncate` would clip the widest value,
-              'No data', to 'No dat…'. Mirrors StatCard's compact variant:
-              truncate the label, leave the value alone. */}
-          <div className="text-sm font-bold text-white">
-            {learningSummary?.overallSuccessRate != null ? `${learningSummary.overallSuccessRate}%` : 'No data'}
-          </div>
-          {learningSummary?.skipped > 0 && (
-            <div className="text-[9px] text-port-error font-normal truncate">
-              {learningSummary.skipped} skipped
-            </div>
-          )}
-        </div>
-      </button>
+      <StatCard
+        {...learningStatProps}
+        value={learningSummary?.overallSuccessRate != null ? `${learningSummary.overallSuccessRate}%` : 'No data'}
+        icon={<Brain className="w-4 h-4" />}
+        compact
+      />
       {status?.running ? (
         <>
           <button
@@ -895,33 +881,12 @@ export default function ChiefOfStaff() {
             mini
           />
           {/* Learning Health - clickable to go to Learning tab */}
-          <button
-            onClick={() => navigate('/cos/learning')}
-            className={`bg-port-card border rounded p-1.5 sm:p-2 lg:p-3 transition-all text-left hover:bg-port-card/80 ${
-              learningSummary?.status === 'critical' ? 'border-port-error shadow-md shadow-port-error/20' :
-              learningSummary?.status === 'warning' ? 'border-port-warning shadow-md shadow-port-warning/20' :
-              'border-port-border hover:border-port-accent-2/50'
-            }`}
-            title={learningSummary?.statusMessage || 'View learning analytics'}
-          >
-            <div className="flex items-center justify-between mb-0.5">
-              <span className="text-[10px] sm:text-xs text-gray-500 truncate">Learning</span>
-              <Brain className={`w-3 h-3 sm:w-4 sm:h-4 lg:w-5 lg:h-5 shrink-0 ${
-                learningSummary?.status === 'critical' ? 'text-port-error' :
-                learningSummary?.status === 'warning' ? 'text-port-warning' :
-                learningSummary?.status === 'good' ? 'text-port-accent-2' :
-                'text-gray-500'
-              }`} />
-            </div>
-            <div className="text-sm sm:text-base lg:text-xl font-bold text-white">
-              {learningSummary?.overallSuccessRate != null ? `${learningSummary.overallSuccessRate}%` : '—'}
-            </div>
-            {learningSummary?.skipped > 0 && (
-              <div className="text-[9px] text-port-error mt-0.5 truncate">
-                {learningSummary.skipped} skipped
-              </div>
-            )}
-          </button>
+          <StatCard
+            {...learningStatProps}
+            value={learningSummary?.overallSuccessRate != null ? `${learningSummary.overallSuccessRate}%` : '—'}
+            icon={<Brain className="w-3 h-3 sm:w-4 sm:h-4 lg:w-5 lg:h-5" />}
+            mini
+          />
         </div>
 
         {/* Tabs - scrollable with arrow navigation */}

--- a/client/src/pages/ChiefOfStaff.test.jsx
+++ b/client/src/pages/ChiefOfStaff.test.jsx
@@ -275,6 +275,19 @@ describe('ChiefOfStaff Learning card skipped label', () => {
     }
   });
 
+  it('paints a skipped tile as critical even if the server status disagrees', async () => {
+    // The tile derives `critical` from `skipped > 0` itself instead of trusting
+    // the server's status chain to keep classifying it that way — this fixture
+    // is deliberately the mismatched combination (skipped 3 / status 'warning').
+    api.getCosLearningSummary.mockResolvedValue(summaryWithSkipped);
+    renderAt('config');
+
+    for (const card of await learningCards()) {
+      expect(within(card).getByText(/skipped/).className).toContain('text-port-error');
+      expect(card.className).toContain('border-port-error');
+    }
+  });
+
   it('omits the skipped label entirely when nothing was skipped', async () => {
     api.getCosLearningSummary.mockResolvedValue({ ...summaryWithSkipped, skipped: 0, status: 'good' });
     renderAt('config');


### PR DESCRIPTION
## Summary

`StatCard`'s `activeLabel` prop had zero callers and was rendered only by the default variant — the `compact` and `mini` variants folded it into the `aria-label` string and dropped it from the markup entirely. Meanwhile the two CoS "Learning" tiles in `ChiefOfStaff.jsx` were hand-rolled `<button>` elements, each independently duplicating the same three-way status-color ternary for both the icon color and the border/shadow, precisely because `StatCard` supported neither `onClick`, nor a status-driven border color, nor a visible sub-label on the compact/mini variants.

This wires the prop up rather than deleting it, which resolves the duplication in the same pass.

- **`activeLabel` now renders on every variant** (`compact`, `mini`, `default`), matching the default variant's `{active && activeLabel && (…)}` treatment, with `aria-live="polite"` and `truncate` so it clips inside the card instead of spilling.
- **New `tone` prop** (`critical` | `warning` | `good` | `default`, unknown values fall back to neutral) drives border, icon tint and sub-label color from one `TONE_CLASSES` entry, so the three can't drift apart the way the hand-rolled tiles did. A tone border wins over the generic `active` accent border; `good` tints only the icon. Tone-less callers keep their own pre-colored icon elements untouched.
- **New `onClick` prop** promotes the card to a real `<button type="button">` (keyboard- and screen-reader-reachable, with the accessible name the group already carried); without it the card stays a labelled `role="group"` div. A `title` prop passes the hover hint through.
- **Both Learning tiles now render `<StatCard … onClick tone activeLabel />`**, deleting both hand-rolled buttons and both copies of the status ternary. Their shared props live in one `learningStatProps` object; only the icon scale and the empty-state value string differ between the two sites.
- Internally, the `mini` and `default` variants collapsed from two near-identical returns into one stacked layout driven by a `SIZES` table.

Behavior is preserved at both call sites. The tile derives its `critical` tone from `skipped > 0` locally rather than trusting the server's status chain to keep classifying it that way, so the skipped sub-label still paints `text-port-error` even if that chain is reordered. The one deliberate unification is that the compact tile's `warning` border now carries the same `shadow-md` the mini tile already had.

## Test plan

- New `client/src/components/cos/StatCard.test.jsx` (20 cases): sub-label renders visibly and lands in the accessible name across all three variants, is omitted when inactive, and truncates; `onClick` yields a `type="button"` button that fires and a `role="group"` div when absent; `title` passthrough; the border-hover affordance appears only while the border is still neutral (never recoloring a toned or active card on hover); tone paints border/icon/sub-label from one entry, wins over the `active` accent, tints only the icon for `good`, falls back to neutral for an unknown status, and leaves a tone-less card's own icon color alone.
- `client/src/pages/ChiefOfStaff.test.jsx` gains a guard that a skipped tile paints critical even when the server status disagrees (the tile derives that itself rather than trusting the server's status chain). Its existing Learning-card containment suite (stacked sub-label, `truncate`, `min-w-0` shrinkable column, `!= null` 0% branch, wrappable "No data" value) passes unchanged against the converted tiles.
- `cd client && npm test` → **Test Files 636 passed (636)**, **Tests 7682 passed (7682)**.
- `cd client && npm run build` → clean.

Closes #4129
