### PR TITLE
fix: promote to CoS Runner mode when the runner starts after the server (#4134)

### DIFF
--- a/.changelog/next/fixed-issue-4134.md
+++ b/.changelog/next/fixed-issue-4134.md
@@ -1,0 +1,1 @@
+- CoS Runner mode now recovers when portos-cos starts after portos-server — the spawner keeps its socket open and promotes from direct to runner mode on connect, instead of degrading for the process lifetime

--- a/docs/features/cos-agent-runner.md
+++ b/docs/features/cos-agent-runner.md
@@ -32,6 +32,15 @@ A separate `portos-cos` PM2 process that:
                                           └───────────────┘
 ```
 
+## Mode selection (runner vs direct)
+
+`portos-server` spawns agents through the runner when it is there, and directly (as its own children) when it is not. The choice is not frozen at boot:
+
+- A health probe at spawner init seeds the mode, for the window before the socket connects.
+- The Socket.IO connection is opened either way and reconnects indefinitely with capped backoff. The first `connect` **promotes** a direct-mode process to runner mode, logs `🔼 CoS Runner came up …`, and reconciles agents the runner was already driving — so starting `portos-cos` after `portos-server` takes effect immediately, with no server restart.
+- A disconnect does **not** demote. In runner mode the runner owns every agent process, so while it is down new tasks are **held** as `pending` (logged once, not per task) and resume on reconnect. Demoting would spawn them as children of `portos-server` — the orphaning this app exists to prevent.
+- Agents already spawned directly keep completing through the direct path across a promotion; reconciliation only adopts agents this server does not already own.
+
 ## Features
 
 - **Process Isolation**: Agent processes survive server restarts

--- a/server/services/cosRunnerClient.js
+++ b/server/services/cosRunnerClient.js
@@ -119,7 +119,15 @@ export function initCosRunnerConnection() {
     }
   };
 
+  // One connection-error line per outage, not one per retry. The socket is now
+  // opened unconditionally (issue #4134) so a promotion can happen when the
+  // runner comes up later — which means an install whose runner is simply off
+  // would otherwise log a `connect_error` every 10s, forever. Reset on connect
+  // so the NEXT outage is reported again.
+  let connectErrorLogged = false;
+
   socket.on('connect', () => {
+    connectErrorLogged = false;
     console.log('🔌 Connected to CoS Runner');
     for (const [sessionId, state] of tuiSessions) {
       for (const { event, payload } of state.pendingControls.splice(0)) {
@@ -135,7 +143,9 @@ export function initCosRunnerConnection() {
   });
 
   socket.on('connect_error', (err) => {
-    console.error(`🔌 CoS Runner connection error: ${err.message}`);
+    if (connectErrorLogged) return;
+    connectErrorLogged = true;
+    console.error(`🔌 CoS Runner connection error: ${err.message} — retrying until it answers`);
   });
 
   // Forward events to registered handlers
@@ -216,11 +226,14 @@ const probeRunnerHealth = (timeoutMs) =>
 /**
  * Check if CoS Runner is available.
  *
- * The BOOT-time mode decision (`setUseRunner`), taken before any socket exists,
- * which is why it probes rather than reading `socket.connected` the way
- * `isRunnerReachable` does. The generous timeout is deliberate: during a rolling
- * PM2 start the runner can be slow to answer, and a premature `false` here
- * demotes the whole process to direct mode for its lifetime.
+ * The COLD-START SEED for the mode decision (`setUseRunner`), taken before any
+ * socket exists, which is why it probes rather than reading `socket.connected`
+ * the way `isRunnerReachable` does. The generous timeout is deliberate: during a
+ * rolling PM2 start the runner can be slow to answer, and a premature `false`
+ * here starts the process in direct mode. It no longer strands it there —
+ * `connection:ready` promotes the process the moment the socket lands (#4134) —
+ * but every task dispatched in the meantime is spawned as a child of this
+ * server, so the seed is still worth getting right.
  */
 export async function isRunnerAvailable() {
   return (await probeRunnerHealth(10000)) !== null;

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -204,7 +204,10 @@ async function runInitSpawner() {
     // the recovery sweep below refuses to adopt them.
     if (!useRunner) {
       setUseRunner(true);
-      console.log('🔼 CoS Runner came up — promoting agent spawning from direct to runner mode');
+      // Through `emitLog`, like the disconnect warning above: both edges belong
+      // in the CoS log stream the UI reads, or a remote install sees the outage
+      // reported and never its resolution.
+      emitLog('info', '🔼 CoS Runner came up — promoting agent spawning from direct to runner mode');
       recoverRunnerAgents().catch(err =>
         console.error(`❌ Failed to recover runner agents after promotion: ${err.message}`)
       );

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -86,6 +86,24 @@ async function holdTask(task, reason) {
 }
 
 /**
+ * Adopt agents the runner is already driving that this process does not own.
+ *
+ * Runs on both edges that can find a live runner with pre-existing agents: the
+ * boot seed (agents that outlived a `portos-server` restart) and a mid-life
+ * promotion (a runner that was already up before this server took over). Agents
+ * this process spawned DIRECTLY are never adopted — `syncRunnerAgents` skips
+ * anything `isAgentOwnedLocally` claims, so they keep completing through their
+ * own child-process close handler.
+ */
+async function recoverRunnerAgents() {
+  const synced = await syncRunnerAgents().catch(err => {
+    console.error(`❌ Failed to sync runner agents: ${err.message}`);
+    return 0;
+  });
+  if (synced > 0) console.log(`🔄 Recovered ${synced} agents from CoS Runner`);
+}
+
+/**
  * Load a slashdo command from the bundled submodule, resolving !`cat` lib includes inline.
  */
 export async function loadSlashdoCommand(commandName) {
@@ -140,118 +158,138 @@ async function runInitSpawner() {
     if (pruned > 0) console.log(`🗑️ Pruned ${pruned} old run directories (>30 days)`);
   }
 
-  // Check if CoS Runner is available
-  const runnerAvailable = await isRunnerAvailable();
-  setUseRunner(runnerAvailable);
+  // ── SPAWN MODE. Runner mode is NOT a boot-time verdict (issue #4134).
+  //
+  // The probe is only the COLD-START SEED, for the window before the socket's
+  // first `connect` lands: `portos-cos` is a separate PM2 app that can come up
+  // after `portos-server`, and treating one probe as the answer left this
+  // process in direct mode for its whole lifetime — every agent a child of
+  // `portos-server`, dying with it, which is the exact orphaning runner mode
+  // exists to prevent. The socket reconnects forever with capped backoff, so it,
+  // not the probe, is the standing authority on whether the runner is there.
+  setUseRunner(await isRunnerAvailable());
+  console.log(useRunner
+    ? '🤖 Sub-agent spawner initialized (using CoS Runner)'
+    : '🤖 Sub-agent spawner initialized (direct mode — CoS Runner not up yet)');
 
-  if (runnerAvailable) {
-    console.log('🤖 Sub-agent spawner initialized (using CoS Runner)');
-    initCosRunnerConnection();
+  initCosRunnerConnection();
 
-    // Sync any agents that were running before server restart
-    const synced = await syncRunnerAgents().catch(err => {
-      console.error(`❌ Failed to sync runner agents: ${err.message}`);
-      return 0;
-    });
-    if (synced > 0) {
-      console.log(`🔄 Recovered ${synced} agents from CoS Runner`);
+  // Sync any agents that were running before server restart
+  if (useRunner) await recoverRunnerAgents();
+
+  // Runner liveness → the queue holds, then re-drives. `portos-cos` is a
+  // separate PM2 app the user can stop, and in runner mode it owns every agent
+  // process — so while it is down, dispatch HOLDS tasks as `pending` (see the
+  // `task:ready` listener below and `dequeueNextTask`'s gate) rather than
+  // failing them. These two events are the outage's edges: one warning when it
+  // goes, one dequeue when it returns, instead of a line per held task.
+  //
+  // The reconnect is debounced because `reconnectionAttempts` is unbounded: a
+  // crash-looping runner would otherwise drive one full five-tier dequeue
+  // cycle per restart.
+  onCosRunnerEvent('connection:lost', () => {
+    // Deliberately NOT a demotion back to direct mode. `useRunner` stays true so
+    // the dispatch gate keeps HOLDING tasks as `pending`; flipping it to false
+    // here would silently convert every held task into a direct spawn — a child
+    // of `portos-server` again — which is the orphaning runner mode exists to
+    // prevent. The outage is a hold; it clears on `connection:ready` below.
+    emitLog('warn', '⏸️ CoS Runner disconnected — staying in runner mode, holding agent tasks until it returns');
+  });
+
+  onCosRunnerEvent('connection:ready', () => {
+    // MID-LIFE PROMOTION (#4134): the runner came up after this server did, so
+    // take over from the cold-start seed. Agents already spawned directly are
+    // untouched — ownership is keyed by agent id in both maps
+    // (`isAgentOwnedLocally`), so their close handlers still finalize them and
+    // the recovery sweep below refuses to adopt them.
+    if (!useRunner) {
+      setUseRunner(true);
+      console.log('🔼 CoS Runner came up — promoting agent spawning from direct to runner mode');
+      recoverRunnerAgents().catch(err =>
+        console.error(`❌ Failed to recover runner agents after promotion: ${err.message}`)
+      );
     }
+    clearTimeout(reconnectDequeueTimer);
+    reconnectDequeueTimer = setTimeout(() => {
+      emitLog('info', '▶️ CoS Runner reconnected — resuming held agent tasks');
+      cosEvents.emit('cos:dequeue-requested');
+    }, RECONNECT_DEQUEUE_DEBOUNCE_MS);
+    reconnectDequeueTimer.unref?.();
+  });
 
-    // Runner liveness → the queue holds, then re-drives. `portos-cos` is a
-    // separate PM2 app the user can stop, and in runner mode it owns every agent
-    // process — so while it is down, dispatch HOLDS tasks as `pending` (see the
-    // `task:ready` listener below and `dequeueNextTask`'s gate) rather than
-    // failing them. These two events are the outage's edges: one warning when it
-    // goes, one dequeue when it returns, instead of a line per held task.
-    //
-    // The reconnect is debounced because `reconnectionAttempts` is unbounded: a
-    // crash-looping runner would otherwise drive one full five-tier dequeue
-    // cycle per restart.
-    onCosRunnerEvent('connection:lost', () => {
-      emitLog('warn', '⏸️ CoS Runner disconnected — holding agent tasks until it returns');
-    });
+  // Runner event handlers are registered unconditionally: they are inert in
+  // direct mode (each keys off `runnerAgents`, which only `spawnViaRunner`
+  // populates), and registering them only when the boot probe succeeded left a
+  // promoted process connected to a runner whose output/completions nothing was
+  // listening for.
+  onCosRunnerEvent('agent:output', async (data) => {
+    const { agentId, text } = data;
+    // Drop output for an agent that's already finalized/removed. The runner
+    // registers the agent in `runnerAgents` before it spawns the process
+    // (agentLifecycle spawnViaRunner), so this never drops legitimate early
+    // output — it only ignores a stray event arriving after completion, which
+    // would otherwise lazily create a never-drained batcher (Map leak).
+    if (!runnerAgents.has(agentId)) return;
+    getRunnerOutputBatcher(agentId).push(text);
 
-    onCosRunnerEvent('connection:ready', () => {
-      clearTimeout(reconnectDequeueTimer);
-      reconnectDequeueTimer = setTimeout(() => {
-        emitLog('info', '▶️ CoS Runner reconnected — resuming held agent tasks');
-        cosEvents.emit('cos:dequeue-requested');
-      }, RECONNECT_DEQUEUE_DEBOUNCE_MS);
-      reconnectDequeueTimer.unref?.();
-    });
-
-    // Set up event handlers for runner events
-    onCosRunnerEvent('agent:output', async (data) => {
-      const { agentId, text } = data;
-      // Drop output for an agent that's already finalized/removed. The runner
-      // registers the agent in `runnerAgents` before it spawns the process
-      // (agentLifecycle spawnViaRunner), so this never drops legitimate early
-      // output — it only ignores a stray event arriving after completion, which
-      // would otherwise lazily create a never-drained batcher (Map leak).
-      if (!runnerAgents.has(agentId)) return;
-      getRunnerOutputBatcher(agentId).push(text);
-
-      // Update phase on first output
-      const agent = runnerAgents.get(agentId);
-      if (agent && !agent.hasStartedWorking) {
-        agent.hasStartedWorking = true;
-        clearTimeout(agent.initializationTimeout);
-        await updateAgent(agentId, { metadata: { phase: 'working' } });
-        emitLog('info', `Agent ${agentId} working...`, { agentId, phase: 'working' });
-      }
-    });
-
-    onCosRunnerEvent('agent:completed', async (data) => {
-      const { agentId, exitCode, success, duration } = data;
-      const agent = runnerAgents.get(agentId);
-      // A runner-owned TUI is finalized by spawnTuiAgent while this server
-      // remains connected. Only a TUI recovered into runnerAgents after a
-      // server restart should use the generic runner completion path.
-      // That invariant is upheld elsewhere — `syncRunnerAgents` must not adopt an
-      // agent this process already owns (see `isAgentOwnedLocally`). When it did,
-      // this guard passed for a live TUI and double-finalized it; the sibling
-      // `agent:output` and `agent:error` handlers key off the same membership.
-      if (!agent) return;
+    // Update phase on first output
+    const agent = runnerAgents.get(agentId);
+    if (agent && !agent.hasStartedWorking) {
+      agent.hasStartedWorking = true;
       clearTimeout(agent.initializationTimeout);
-      // Drain pending output before completion so the final lines land in
-      // state before handleAgentCompletion writes the terminal record.
-      await flushRunnerOutputBatcher(agentId);
-      await handleAgentCompletion(agentId, exitCode, success, duration);
-    });
+      await updateAgent(agentId, { metadata: { phase: 'working' } });
+      emitLog('info', `Agent ${agentId} working...`, { agentId, phase: 'working' });
+    }
+  });
 
-    // Batch handler for orphaned agents (runner startup cleanup)
-    onCosRunnerEvent('agents:orphaned', async (data) => {
-      const { agents, count } = data;
-      console.log(`🧹 Processing ${count} orphaned agents from runner`);
-      for (const orphan of agents) {
-        const agent = runnerAgents.get(orphan.agentId);
-        if (agent) {
-          clearTimeout(agent.initializationTimeout);
-        }
-        await flushRunnerOutputBatcher(orphan.agentId);
-        await handleAgentCompletion(orphan.agentId, orphan.exitCode, orphan.success, 0);
-      }
-    });
+  onCosRunnerEvent('agent:completed', async (data) => {
+    const { agentId, exitCode, success, duration } = data;
+    const agent = runnerAgents.get(agentId);
+    // A runner-owned TUI is finalized by spawnTuiAgent while this server
+    // remains connected. Only a TUI recovered into runnerAgents after a
+    // server restart should use the generic runner completion path.
+    // That invariant is upheld elsewhere — `syncRunnerAgents` must not adopt an
+    // agent this process already owns (see `isAgentOwnedLocally`). When it did,
+    // this guard passed for a live TUI and double-finalized it; the sibling
+    // `agent:output` and `agent:error` handlers key off the same membership.
+    if (!agent) return;
+    clearTimeout(agent.initializationTimeout);
+    // Drain pending output before completion so the final lines land in
+    // state before handleAgentCompletion writes the terminal record.
+    await flushRunnerOutputBatcher(agentId);
+    await handleAgentCompletion(agentId, exitCode, success, duration);
+  });
 
-    onCosRunnerEvent('agent:error', async (data) => {
-      const { agentId, error } = data;
-      console.error(`❌ Agent ${agentId} error from runner: ${error}`);
-      cosEvents.emit('agent:error', { agentId, error });
-      await flushRunnerOutputBatcher(agentId);
-      const agent = runnerAgents.get(agentId);
+  // Batch handler for orphaned agents (runner startup cleanup)
+  onCosRunnerEvent('agents:orphaned', async (data) => {
+    const { agents, count } = data;
+    console.log(`🧹 Processing ${count} orphaned agents from runner`);
+    for (const orphan of agents) {
+      const agent = runnerAgents.get(orphan.agentId);
       if (agent) {
         clearTimeout(agent.initializationTimeout);
-        // Runner-level error before the run could produce work — no success
-        // criterion was evaluated, so validation is the null sentinel (issue
-        // #2344), never a false that would look like a declared-and-failed run.
-        await completeAgent(agentId, { success: false, validationPassed: null, error });
-        await completeAgentRun(agent.runId, '', 1, 0, { message: error, category: 'runner-error' });
-        runnerAgents.delete(agentId);
       }
-    });
-  } else {
-    console.log('🤖 Sub-agent spawner initialized (direct mode - CoS Runner not available)');
-  }
+      await flushRunnerOutputBatcher(orphan.agentId);
+      await handleAgentCompletion(orphan.agentId, orphan.exitCode, orphan.success, 0);
+    }
+  });
+
+  onCosRunnerEvent('agent:error', async (data) => {
+    const { agentId, error } = data;
+    console.error(`❌ Agent ${agentId} error from runner: ${error}`);
+    cosEvents.emit('agent:error', { agentId, error });
+    await flushRunnerOutputBatcher(agentId);
+    const agent = runnerAgents.get(agentId);
+    if (agent) {
+      clearTimeout(agent.initializationTimeout);
+      // Runner-level error before the run could produce work — no success
+      // criterion was evaluated, so validation is the null sentinel (issue
+      // #2344), never a false that would look like a declared-and-failed run.
+      await completeAgent(agentId, { success: false, validationPassed: null, error });
+      await completeAgentRun(agent.runId, '', 1, 0, { message: error, category: 'runner-error' });
+      runnerAgents.delete(agentId);
+    }
+  });
 
   cosEvents.on('task:ready', async (task) => {
     // ── HOLDS, at the one chokepoint all seven `task:ready` emitters funnel

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -172,9 +172,7 @@ async function runInitSpawner() {
   // exists to prevent. The socket reconnects forever with capped backoff, so it,
   // not the probe, is the standing authority on whether the runner is there.
   setUseRunner(await isRunnerAvailable());
-  console.log(useRunner
-    ? '🤖 Sub-agent spawner initialized (using CoS Runner)'
-    : '🤖 Sub-agent spawner initialized (direct mode — CoS Runner not up yet)');
+  console.log(`🤖 Sub-agent spawner initialized (${useRunner ? 'using CoS Runner' : 'direct mode — CoS Runner not up yet'})`);
 
   initCosRunnerConnection();
 
@@ -235,11 +233,16 @@ async function runInitSpawner() {
     reconnectDequeueTimer.unref?.();
   });
 
-  // Runner event handlers are registered unconditionally: they are inert in
-  // direct mode (each keys off `runnerAgents`, which only `spawnViaRunner`
-  // populates), and registering them only when the boot probe succeeded left a
-  // promoted process connected to a runner whose output/completions nothing was
-  // listening for.
+  // Runner event handlers are registered unconditionally. Registering them only
+  // when the boot probe succeeded left a promoted process connected to a runner
+  // whose output and completions nothing was listening for.
+  //
+  // Nothing fires before a promotion: these events only arrive over a connected
+  // socket, and the `connect` that carries them dispatches `connection:ready`
+  // first (same handler in `cosRunnerClient`), so this process is already in
+  // runner mode by the time any of them lands. A directly-spawned agent is safe
+  // regardless — the three per-agent handlers key off `runnerAgents`, which only
+  // `spawnViaRunner` populates.
   onCosRunnerEvent('agent:output', async (data) => {
     const { agentId, text } = data;
     // Drop output for an agent that's already finalized/removed. The runner

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -56,6 +56,10 @@ const RUNS_DIR = PATHS.runs;
 // Coalesce reconnect storms (a crash-looping runner) into one dequeue.
 const RECONNECT_DEQUEUE_DEBOUNCE_MS = 1000;
 let reconnectDequeueTimer = null;
+// In-flight runner reconciliation, awaited by the reconnect dequeue so held
+// tasks resume against a settled `runnerAgents` map — the ordering the boot
+// path gets for free by awaiting recovery before it wires anything.
+let runnerRecovery = Promise.resolve();
 
 /**
  * Decline a `task:ready` dispatch WITHOUT failing the task.
@@ -193,6 +197,11 @@ async function runInitSpawner() {
     // here would silently convert every held task into a direct spawn — a child
     // of `portos-server` again — which is the orphaning runner mode exists to
     // prevent. The outage is a hold; it clears on `connection:ready` below.
+    //
+    // Drop any armed reconnect dequeue: a drop inside the debounce window would
+    // otherwise still announce "resuming held agent tasks" and drive a dequeue
+    // cycle into a runner that is gone again. A reconnect re-arms it.
+    clearTimeout(reconnectDequeueTimer);
     emitLog('warn', '⏸️ CoS Runner disconnected — staying in runner mode, holding agent tasks until it returns');
   });
 
@@ -208,14 +217,20 @@ async function runInitSpawner() {
       // in the CoS log stream the UI reads, or a remote install sees the outage
       // reported and never its resolution.
       emitLog('info', '🔼 CoS Runner came up — promoting agent spawning from direct to runner mode');
-      recoverRunnerAgents().catch(err =>
-        console.error(`❌ Failed to recover runner agents after promotion: ${err.message}`)
-      );
+      runnerRecovery = recoverRunnerAgents();
     }
     clearTimeout(reconnectDequeueTimer);
     reconnectDequeueTimer = setTimeout(() => {
-      emitLog('info', '▶️ CoS Runner reconnected — resuming held agent tasks');
-      cosEvents.emit('cos:dequeue-requested');
+      // Resume only once reconciliation has settled, so the dequeue counts the
+      // agents the runner was already driving. `recoverRunnerAgents` swallows
+      // its own failures, so this never rejects — which matters here, on a timer
+      // callback outside any request lifecycle.
+      runnerRecovery
+        .then(() => {
+          emitLog('info', '▶️ CoS Runner reconnected — resuming held agent tasks');
+          cosEvents.emit('cos:dequeue-requested');
+        })
+        .catch(err => console.error(`❌ Failed to resume held agent tasks: ${err.message}`));
     }, RECONNECT_DEQUEUE_DEBOUNCE_MS);
     reconnectDequeueTimer.unref?.();
   });

--- a/server/services/subAgentSpawner.runnerPromotion.test.js
+++ b/server/services/subAgentSpawner.runnerPromotion.test.js
@@ -1,0 +1,148 @@
+/**
+ * Mid-life runner promotion (issue #4134).
+ *
+ * `portos-cos` is a separate PM2 app, so it can come up AFTER `portos-server`.
+ * Spawn mode used to be decided once, by the boot probe, with the socket and its
+ * connection events wired only inside that `if (runnerAvailable)` branch — so a
+ * server that booted while the runner was down stayed in direct mode for its
+ * whole lifetime: every agent a child of `portos-server`, dying with it, which
+ * is the exact orphaning runner mode exists to prevent.
+ *
+ * The socket is now always opened and the probe is only the cold-start seed;
+ * `connection:ready` is the standing authority. The reverse edge is deliberately
+ * NOT symmetric — `connection:lost` keeps runner mode so dispatch keeps HOLDING
+ * tasks as `pending`, because demoting there would silently turn every held task
+ * back into an orphan-prone direct spawn.
+ */
+
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
+
+const runnerHandlers = new Map();
+
+vi.mock('./cosRunnerClient.js', () => ({
+  onCosRunnerEvent: vi.fn((event, handler) => { runnerHandlers.set(event, handler); }),
+  initCosRunnerConnection: vi.fn(),
+  // The runner is DOWN at boot — the regression's starting condition.
+  isRunnerAvailable: vi.fn().mockResolvedValue(false),
+  isRunnerReachable: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('./cosEvents.js', () => ({
+  emitLog: vi.fn(),
+  cosEvents: { emit: vi.fn(), on: vi.fn() },
+}));
+
+vi.mock('./providerStatus.js', () => ({ initProviderStatus: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./agentRunnerSync.js', () => ({ syncRunnerAgents: vi.fn().mockResolvedValue(0) }));
+vi.mock('./cosAgentLifecycle.js', () => ({ updateAgent: vi.fn() }));
+vi.mock('./agentRunnerOutputBatchers.js', () => ({
+  getRunnerOutputBatcher: vi.fn(),
+  flushRunnerOutputBatcher: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('./agentLifecycle.js', () => ({ handleAgentCompletion: vi.fn() }));
+vi.mock('./agentManagement.js', () => ({ cleanupOrphanedAgents: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./agentRunTracking.js', () => ({ completeAgentRun: vi.fn() }));
+vi.mock('./appActivity.js', () => ({ releaseAppReviewMarker: vi.fn().mockResolvedValue(undefined) }));
+vi.mock('./updateChecker.js', () => ({ isUpdateInProgress: vi.fn().mockReturnValue(false) }));
+vi.mock('./agentOrchestrator.js', () => ({
+  completeAgent: vi.fn(),
+  spawnAgentForTask: vi.fn().mockResolvedValue('agent-1'),
+  terminateAgent: vi.fn(),
+}));
+vi.mock('fs', () => ({ existsSync: vi.fn().mockReturnValue(false) }));
+
+import { initSpawner } from './subAgentSpawner.js';
+import { initCosRunnerConnection } from './cosRunnerClient.js';
+import { syncRunnerAgents } from './agentRunnerSync.js';
+import * as agentState from './agentState.js';
+
+// Read through the module namespace: `useRunner` is reassigned by `setUseRunner`,
+// and a destructured copy would freeze the value at import time.
+const currentMode = () => agentState.useRunner;
+
+// Boot-time call counts, snapshotted before `vi.clearAllMocks()` erases them.
+const bootCalls = { initConnection: 0, sync: 0, mode: null };
+
+describe('subAgentSpawner — runner promotion (#4134)', () => {
+  beforeAll(async () => {
+    // initSpawner is memoized, so this is the one run that wires the handlers.
+    await initSpawner();
+    bootCalls.initConnection = vi.mocked(initCosRunnerConnection).mock.calls.length;
+    bootCalls.sync = vi.mocked(syncRunnerAgents).mock.calls.length;
+    bootCalls.mode = currentMode();
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agentState.setUseRunner(false);
+  });
+
+  it('seeds direct mode from the boot probe but still opens the runner socket', () => {
+    // The socket reconnects forever with capped backoff. Opening it only when
+    // the probe succeeded is what made the demotion permanent.
+    expect(bootCalls.mode).toBe(false);
+    expect(bootCalls.initConnection).toBe(1);
+  });
+
+  it('does not reconcile runner agents at boot when the probe found no runner', () => {
+    // With the probe false there is nothing to adopt, and /agents would fail
+    // anyway — the reconciliation belongs to the promotion edge instead.
+    expect(bootCalls.sync).toBe(0);
+  });
+
+  it('wires the runner event handlers in direct mode, so a promotion has somewhere to land', () => {
+    // Inert while `runnerAgents` is empty — every handler keys off it — but
+    // registered, so a runner that comes up later is actually listened to.
+    for (const event of ['agent:output', 'agent:completed', 'agents:orphaned', 'agent:error']) {
+      expect(runnerHandlers.has(event)).toBe(true);
+    }
+  });
+
+  it('promotes to runner mode when the runner comes up after the server', () => {
+    expect(currentMode()).toBe(false);
+
+    runnerHandlers.get('connection:ready')();
+
+    expect(currentMode()).toBe(true);
+  });
+
+  it('reconciles agents a runner that was already up owns, on promotion', () => {
+    runnerHandlers.get('connection:ready')();
+
+    // Adopts only agents this process does not already own, so an agent spawned
+    // DIRECTLY before the promotion keeps completing through its own close
+    // handler (`isAgentOwnedLocally`, covered in agentRunnerSync.test.js).
+    expect(syncRunnerAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it('promotes once — a later reconnect in runner mode does not re-reconcile', () => {
+    runnerHandlers.get('connection:ready')();
+    runnerHandlers.get('connection:ready')();
+    runnerHandlers.get('connection:ready')();
+
+    expect(syncRunnerAgents).toHaveBeenCalledTimes(1);
+  });
+
+  it('survives a reconciliation failure without leaving the process unpromoted', async () => {
+    vi.mocked(syncRunnerAgents).mockRejectedValueOnce(new Error('runner /agents 500'));
+
+    runnerHandlers.get('connection:ready')();
+    await Promise.resolve();
+
+    // The promotion is the point; recovery is best-effort. An unguarded
+    // rejection here would also crash the process — this runs on a socket
+    // callback, outside any request lifecycle.
+    expect(currentMode()).toBe(true);
+  });
+
+  it('keeps runner mode when the connection drops, so tasks hold instead of spawning direct', () => {
+    runnerHandlers.get('connection:ready')();
+    expect(currentMode()).toBe(true);
+
+    runnerHandlers.get('connection:lost')();
+
+    // Demoting here would flip the dispatch gate (`useRunner && !reachable`) off
+    // and spawn every held task as a child of portos-server.
+    expect(currentMode()).toBe(true);
+  });
+});

--- a/server/services/subAgentSpawner.runnerPromotion.test.js
+++ b/server/services/subAgentSpawner.runnerPromotion.test.js
@@ -54,12 +54,15 @@ vi.mock('fs', () => ({ existsSync: vi.fn().mockReturnValue(false) }));
 import { initSpawner } from './subAgentSpawner.js';
 import { initCosRunnerConnection } from './cosRunnerClient.js';
 import { syncRunnerAgents } from './agentRunnerSync.js';
-import { emitLog } from './cosEvents.js';
+import { cosEvents, emitLog } from './cosEvents.js';
 import * as agentState from './agentState.js';
 
 // Read through the module namespace: `useRunner` is reassigned by `setUseRunner`,
 // and a destructured copy would freeze the value at import time.
 const currentMode = () => agentState.useRunner;
+
+// Mirrors RECONNECT_DEQUEUE_DEBOUNCE_MS in the module under test.
+const RECONNECT_DEQUEUE_DEBOUNCE_MS = 1000;
 
 // Boot-time call counts, snapshotted before `vi.clearAllMocks()` erases them.
 const bootCalls = { initConnection: 0, sync: 0, mode: null };
@@ -144,6 +147,38 @@ describe('subAgentSpawner — runner promotion (#4134)', () => {
     // rejection here would also crash the process — this runs on a socket
     // callback, outside any request lifecycle.
     expect(currentMode()).toBe(true);
+  });
+
+  it('resumes held tasks only after reconciliation settles', async () => {
+    let finishSync;
+    vi.mocked(syncRunnerAgents).mockReturnValueOnce(new Promise(resolve => { finishSync = resolve; }));
+    vi.useFakeTimers();
+
+    runnerHandlers.get('connection:ready')();
+    await vi.advanceTimersByTimeAsync(RECONNECT_DEQUEUE_DEBOUNCE_MS);
+
+    // The debounce elapsed, but the runner has not finished listing its agents:
+    // dequeuing now would size capacity against a half-populated map.
+    expect(cosEvents.emit).not.toHaveBeenCalledWith('cos:dequeue-requested');
+
+    finishSync(0);
+    await vi.advanceTimersByTimeAsync(0);
+    vi.useRealTimers();
+
+    expect(cosEvents.emit).toHaveBeenCalledWith('cos:dequeue-requested');
+  });
+
+  it('drops an armed reconnect dequeue when the runner drops again inside the debounce window', async () => {
+    vi.useFakeTimers();
+
+    runnerHandlers.get('connection:ready')();
+    runnerHandlers.get('connection:lost')();
+    await vi.advanceTimersByTimeAsync(RECONNECT_DEQUEUE_DEBOUNCE_MS);
+    vi.useRealTimers();
+
+    // Otherwise the outage announces "resuming held agent tasks" and drives a
+    // full dequeue cycle into a runner that is gone again.
+    expect(cosEvents.emit).not.toHaveBeenCalledWith('cos:dequeue-requested');
   });
 
   it('keeps runner mode when the connection drops, so tasks hold instead of spawning direct', () => {

--- a/server/services/subAgentSpawner.runnerPromotion.test.js
+++ b/server/services/subAgentSpawner.runnerPromotion.test.js
@@ -54,6 +54,7 @@ vi.mock('fs', () => ({ existsSync: vi.fn().mockReturnValue(false) }));
 import { initSpawner } from './subAgentSpawner.js';
 import { initCosRunnerConnection } from './cosRunnerClient.js';
 import { syncRunnerAgents } from './agentRunnerSync.js';
+import { emitLog } from './cosEvents.js';
 import * as agentState from './agentState.js';
 
 // Read through the module namespace: `useRunner` is reassigned by `setUseRunner`,
@@ -104,6 +105,16 @@ describe('subAgentSpawner — runner promotion (#4134)', () => {
     runnerHandlers.get('connection:ready')();
 
     expect(currentMode()).toBe(true);
+  });
+
+  it('announces the promotion on the CoS log stream, not just stdout', () => {
+    runnerHandlers.get('connection:ready')();
+
+    // The disconnect warning goes through emitLog, so the resolution must too —
+    // otherwise the UI shows an outage that never visibly ends.
+    const promotions = vi.mocked(emitLog).mock.calls.filter(([, message]) => /promoting/.test(message));
+    expect(promotions).toHaveLength(1);
+    expect(promotions[0][0]).toBe('info');
   });
 
   it('reconciles agents a runner that was already up owns, on promotion', () => {


### PR DESCRIPTION
## Summary

`useRunner` was decided once, at boot, from a single `isRunnerAvailable()` probe — and everything that kept runner mode honest (`initCosRunnerConnection()`, the `connection:ready` re-dequeue, the `connection:lost` warning, and all four runner event handlers) lived inside that `if (runnerAvailable)` branch. So if `portos-cos` was down when `portos-server` booted, the process silently degraded to direct mode for its whole lifetime: every agent became a child of `portos-server` and died with it — the exact orphaning runner mode exists to prevent. Starting the runner afterwards recovered nothing until the next server restart, with no log saying so.

Now:

- **The socket is always opened.** `initCosRunnerConnection()` runs unconditionally; it already reconnects forever with capped backoff, so it — not the one-shot probe — is the standing authority on whether the runner is there. The probe stays as the cold-start seed for the window before the first `connect` lands.
- **`connection:ready` promotes.** The first connect while in direct mode flips `setUseRunner(true)`, logs `🔼 CoS Runner came up — promoting agent spawning from direct to runner mode`, and runs `syncRunnerAgents()` so a runner that was already up before this server took over is reconciled. Later reconnects don't re-promote or re-sync.
- **Runner event handlers register unconditionally.** Registering them only on a successful boot probe left a promoted process connected to a runner whose output and completions nothing was listening for. Nothing fires before a promotion: these events only arrive over a connected socket, and the `connect` that carries them dispatches `connection:ready` first — and the per-agent handlers key off `runnerAgents` regardless, which only `spawnViaRunner` populates.
- **Agents spawned directly before a promotion still complete via the direct path.** Ownership is keyed by agent id across both maps (`isAgentOwnedLocally`): their own child-process close handler finalizes them, and `syncRunnerAgents` refuses to adopt anything this process already owns.
- **The reconnect dequeue waits for reconciliation, and a re-drop cancels it.** The debounced `cos:dequeue-requested` now chains off the in-flight recovery so held tasks resume against a settled `runnerAgents` map (the ordering the boot path gets for free by awaiting recovery), and `connection:lost` clears an armed timer so a drop inside the debounce window can't announce "resuming held agent tasks" into a runner that is gone again.
- **The promotion is announced through `emitLog`,** like the disconnect warning, so the CoS log stream the UI reads shows the outage's resolution and not just its start.
- **Connection-error logging is throttled to one line per outage.** With the socket now always open, an install whose runner is simply off would otherwise log a `connect_error` every 10s forever. The flag resets on `connect`, so the next outage is reported again.

### Deliberate deviation: `connection:lost` does not demote

The issue sketched driving `setUseRunner` from both edges. Demoting on `connection:lost` would regress the runner-hold behaviour: the dispatch gate is `useRunner && !isRunnerReachable()`, so flipping the flag to `false` turns every held task into a direct spawn — a child of `portos-server` — which is precisely the orphaning this mode prevents. A runner outage is a **hold**, not a mode change; it clears on `connection:ready`. The lost handler keeps its single-line warning (now naming the state: "staying in runner mode, holding agent tasks until it returns"), the rationale is documented at the handler, and a test locks it in. Net state machine: direct (seed) → runner (first connect), never back.

- **`docs/features/cos-agent-runner.md`** gains a "Mode selection (runner vs direct)" section describing the seed → promote flow and why a disconnect holds rather than demotes.

## Test plan

- New `server/services/subAgentSpawner.runnerPromotion.test.js` (11 tests): boot probe seeds direct mode but still opens the socket; no boot reconciliation when the probe found no runner; runner event handlers wired in direct mode; promotion on `connection:ready`; reconciliation on promotion; promote-once across a reconnect storm; a failing reconciliation still leaves the process promoted (and cannot crash the process from a socket callback); `connection:lost` keeps runner mode; the promotion is emitted on the CoS log stream; the dequeue waits for reconciliation; a re-drop inside the debounce window cancels the armed dequeue.
- Verified each new test fails against the source it guards (7 of the original 8 against pre-fix `main`; the two ordering tests against the un-chained/un-cleared timer).
- Agent cluster suites green: `npx vitest run services/subAgentSpawner services/agent services/cos services/cosRunnerClient.test.js services/cleanupAgentWorktree.test.js` → **Test Files 50 passed (50) / Tests 1670 passed (1670)**.
- Full server suite (`cd server && npm test`) → **Test Files 54 failed | 1331 passed | 26 skipped (1411)**, **Tests 1457 failed | 27410 passed | 252 skipped (29119)**. Identical failure set to `origin/main` on this machine (**54 failed | 1330 passed (1410)**, **1457 failed | 27399 passed**) — every failure is a suite that requires a reachable PostgreSQL, which is down in this environment. The delta is exactly the 11 new passing tests.
- Not run: `npm run test:db` (DB-backed, out of scope).

Closes #4134
