### PR TITLE
drop the refusal-behavior advisory from the text-encoder picker

### DIFF
--- a/.changelog/next/changed-agent-07a78738.md
+++ b/.changelog/next/changed-agent-07a78738.md
@@ -1,0 +1,1 @@
+- The uncensored text-encoder option no longer prints a refusal-behavior advisory under the picker; its model card and license links stay.

--- a/client/src/components/videoGen/TextEncoderPicker.jsx
+++ b/client/src/components/videoGen/TextEncoderPicker.jsx
@@ -64,11 +64,6 @@ export default function TextEncoderPicker({
       {selected.description && (
         <p className="text-[10px] text-gray-500 leading-snug mt-1">{selected.description}</p>
       )}
-      {/* An uncensored conditioner is a deliberate choice, not a default —
-          state what changed rather than leaving it to the model card. */}
-      {selected.advisory && (
-        <p className="text-[10px] text-port-warning leading-snug mt-1">{selected.advisory}</p>
-      )}
       {/* Same provenance affordance a MODEL gets (ModelDisclosure/FactLink): a
           substitute is someone else's tens-of-GB checkpoint, so its card and
           license stay one click away instead of being facts only the registry

--- a/client/src/components/videoGen/TextEncoderPicker.test.jsx
+++ b/client/src/components/videoGen/TextEncoderPicker.test.jsx
@@ -10,7 +10,6 @@ const HERETIC = {
   description: 'Abliterated Qwen3-VL-32B conditioner.',
   builtIn: false,
   sizeBytes: 51506295440,
-  advisory: 'This conditioner has had its refusal behavior removed.',
   disclosure: {
     modelCardUrl: 'https://huggingface.co/example/heretic',
     weightsLicense: { name: 'Apache-2.0', url: 'https://www.apache.org/licenses/LICENSE-2.0' },
@@ -43,16 +42,16 @@ describe('TextEncoderPicker', () => {
     expect(screen.getByRole('option', { name: 'Stock — H3 Qwen3-VL-32B' })).toBeInTheDocument();
   });
 
-  // An uncensored conditioner is a deliberate choice, so the picker states what
-  // changed instead of leaving it to an external model card.
-  it('shows the advisory only for the option that carries one', () => {
+  // The blurb under the select describes the option you actually picked, not
+  // whichever one happened to render first.
+  it('describes the selected option', () => {
     const { rerender } = render(<TextEncoderPicker options={OPTIONS} value="stock" onChange={vi.fn()} />);
-    expect(screen.queryByText(HERETIC.advisory)).not.toBeInTheDocument();
     expect(screen.getByText(STOCK.description)).toBeInTheDocument();
+    expect(screen.queryByText(HERETIC.description)).not.toBeInTheDocument();
 
     rerender(<TextEncoderPicker options={OPTIONS} value="heretic-bf16" onChange={vi.fn()} />);
-    expect(screen.getByText(HERETIC.advisory)).toBeInTheDocument();
     expect(screen.getByText(HERETIC.description)).toBeInTheDocument();
+    expect(screen.queryByText(STOCK.description)).not.toBeInTheDocument();
   });
 
   // The built-in option ships inside the model's own weights — badging it would

--- a/client/src/lib/videoGenParams.js
+++ b/client/src/lib/videoGenParams.js
@@ -81,7 +81,7 @@ export const supportsVideoAudioPromptControls = (model) => model?.supportsAudioP
 
 // Substitutable prompt conditioners (#4081). The OPTIONS themselves are not
 // mirrored here — the server decorates each model entry with its own
-// `textEncoderOptions` (label, description, size, advisory) in
+// `textEncoderOptions` (label, description, size) in
 // `videoGen/local.js#decorateVideoModel`, so the picker renders whatever this
 // build's runner can actually key-map and a stale client can't offer one it
 // can't. Only the "no override" sentinel is duplicated, and it must stay equal

--- a/docs/features/video-text-encoders.md
+++ b/docs/features/video-text-encoders.md
@@ -28,9 +28,6 @@ schedule, same joint video+audio output.
 | **Stock** | The conditioner inside `MiniMaxAI/MiniMax-H3`'s `FL2VA/text_encoder/` | none — already downloaded with the model |
 | **Ultra-Heretic uncensored** | `ethanfel/Qwen3-VL-32B-Ultra-Heretic-H3-ComfyUI-INT8-ConvRot`, bf16 variant — Qwen3-VL-32B-Instruct abliterated with Heretic v1.2.0 (attention-targeted), repackaged for H3 | ~48 GB, one pinned file |
 
-The Ultra-Heretic option has had its refusal behavior removed. It follows
-prompts the stock conditioner declines; the picker says so inline.
-
 Only the **bf16** file is usable here. The repo's INT8 ConvRot and NVFP4/AWQ
 variants use ComfyUI's own quantization (learned row-wise rotation matrices,
 group size 256) that the MLX loader cannot dequantize, and the `50_63`
@@ -112,7 +109,6 @@ integrity scan and the render path all read from that table.
   finalNormKey: 'model.norm.weight',  // omit if the checkpoint ships its own norm
   sizeBytes: 12345,              // exact published size — the UI formats this
   disclosure: { modelCardUrl, weightsLicense, baseModel, estimatedDownloadGb, reviewedAt },
-  advisory: '…',                 // required when behavior differs from stock
 }
 ```
 

--- a/server/lib/videoTextEncoders.js
+++ b/server/lib/videoTextEncoders.js
@@ -83,12 +83,6 @@ const TEXT_ENCODERS_BY_RUNTIME = Object.freeze({
         weightsLicense: APACHE_2,
         reviewedAt: '2026-08-14',
       }),
-      // Informational, NOT a second license. This conditioner is Apache-2.0
-      // with nothing extra to accept. The picker states the behavior change
-      // inline at the moment of choosing.
-      advisory:
-        'This conditioner has had its refusal behavior removed. It will follow prompts the stock '
-        + 'conditioner declines. You remain responsible for what you generate.',
     }),
   ]),
 });
@@ -185,7 +179,6 @@ export const publicTextEncoderOption = (entry) => ({
   builtIn: !!entry.builtIn,
   ...(entry.repo ? { repo: entry.repo } : {}),
   ...(entry.sizeBytes ? { sizeBytes: entry.sizeBytes } : {}),
-  ...(entry.advisory ? { advisory: entry.advisory } : {}),
   ...(entry.disclosure ? { disclosure: entry.disclosure } : {}),
 });
 

--- a/server/lib/videoTextEncoders.test.js
+++ b/server/lib/videoTextEncoders.test.js
@@ -108,7 +108,6 @@ describe('videoTextEncoders', () => {
       builtIn: false,
       label: expect.any(String),
       description: expect.any(String),
-      advisory: expect.any(String),
       // The exact published byte count — the picker formats it, so there is no
       // second "~N GB" literal that could drift from the real download.
       sizeBytes: expect.any(Number),
@@ -141,11 +140,10 @@ describe('videoTextEncoders', () => {
     expect(entry.disclosure.weightsLicense).toBe(APACHE_2);
   });
 
-  // An uncensored conditioner is a deliberate choice; the picker states what
-  // changed rather than leaving it to an external model card.
-  it('carries an advisory on every non-built-in option', () => {
+  // A substitute is someone else's tens-of-GB checkpoint, so its provenance
+  // stays one click away — the picker links the card it declares here.
+  it('carries a model card on every non-built-in option', () => {
     for (const entry of downloadableVideoTextEncoders()) {
-      expect(entry.advisory).toBeTruthy();
       expect(entry.disclosure?.modelCardUrl).toMatch(/^https:\/\/huggingface\.co\//);
     }
   });

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -638,7 +638,7 @@ const textEncoderDownloadTarget = (entry) => ({
   only: [entry.file],
 });
 // Paired with its entry so the status lane can project the registry fields
-// (label, advisory, size) alongside the cache verdict without a second lookup.
+// (label, size) alongside the cache verdict without a second lookup.
 const textEncoderDownloadTargets = () => downloadableVideoTextEncoders()
   .map((entry) => ({ entry, target: textEncoderDownloadTarget(entry) }));
 


### PR DESCRIPTION
## Summary

The abliterated text-encoder option (`heretic-bf16`) rendered an inline advisory under the picker whenever it was selected. That copy is informational only — the conditioner is Apache-2.0 with nothing extra to accept — so it's removed.

Removed at the registry rather than hidden in the picker, so no unused field is left projecting to the client:

- `server/lib/videoTextEncoders.js` — dropped the `advisory` entry field and its projection in `publicTextEncoderOption`
- `client/src/components/videoGen/TextEncoderPicker.jsx` — dropped the paragraph that rendered it

The option's model card and license links are unchanged, and the description under the select still says what the substitute is.

## Test plan

- `server`: `lib/videoTextEncoders.test.js` + `routes/videoGen*` — 171 passed. The projection test no longer expects `advisory`; the registry test that asserted "every non-built-in option carries an advisory" now asserts the model-card requirement it also covered.
- `client`: `src/components/videoGen/` + `src/lib/videoGenParams` — 119 passed. The picker test that covered the advisory now pins the surviving behavior: the blurb under the select describes the selected option (and only that one).