### PR TITLE
test: add field-contract test for renderVolumeIssue vs pipeline-volume-verify.md (#4136)

### DIFF
--- a/.changelog/next/added-issue-4136.md
+++ b/.changelog/next/added-issue-4136.md
@@ -1,0 +1,1 @@
+- Field-contract test guarding the volume-verify prompt against its rendered context, so a checklist item can no longer cite a volume/issue field the context never renders

--- a/server/services/pipeline/arcPlanner/arcCore.js
+++ b/server/services/pipeline/arcPlanner/arcCore.js
@@ -17,7 +17,7 @@ import { getSeason } from '../seasons.js';
 import { ARC_LIMITS, READER_MAP_BEAT_KINDS, buildSeason, cleanThemes, renderArcShapeGuidance, renderArcShapePositionSummary, sanitizeArc, sanitizeReaderMap, sanitizeSeason, sanitizeSeasonList } from '../../../lib/storyArc.js';
 import { sanitizeCharacterArcList } from '../../../lib/seriesCharacterArc.js';
 import { runPromptRefineRaw, trimChanges } from '../refineHelpers.js';
-import { ERR_VALIDATION, SHAPE_GUIDANCE_NONE, appendTickingClock, buildArcBaseContext, buildArcOverviewContext, buildNeighborVolumes, buildReaderMapContext, buildResolveContext, buildVerifyContext, compareIssuesByPosition, findingIdSet, makeErr, matchIssueForEpisodeEdit, matchResolvedFindings, renderVolumeIssue, resolveWorldContext, seasonIdByNumberOf, shapeEpisodeResolutions, shapeFindings, shapeSeasonOutlines, shapeVerifyIssues } from './context.js';
+import { ERR_VALIDATION, SHAPE_GUIDANCE_NONE, appendTickingClock, buildArcBaseContext, buildArcOverviewContext, buildNeighborVolumes, buildReaderMapContext, buildResolveContext, buildVerifyContext, compareIssuesByPosition, findingIdSet, makeErr, matchIssueForEpisodeEdit, matchResolvedFindings, renderVolumeFields, renderVolumeIssue, resolveWorldContext, seasonIdByNumberOf, shapeEpisodeResolutions, shapeFindings, shapeSeasonOutlines, shapeVerifyIssues } from './context.js';
 
 export async function generateArcOverview(seriesId, options = {}) {
   const series = await getSeries(seriesId);
@@ -287,15 +287,7 @@ export async function buildVolumeVerifyContext(series, season, preloadedWorld, {
   const volumeIssues = allIssues
     .filter((iss) => iss.seasonId === season.id)
     .sort(compareIssuesByPosition)
-    .map((issue) => (synopsisOnly
-      ? {
-        number: issue.number,
-        title: issue.title,
-        status: issue.status,
-        arcPosition: issue.arcPosition,
-        synopsis: (issue.stages?.idea?.input || '').trim() || null,
-      }
-      : renderVolumeIssue(issue)));
+    .map((issue) => renderVolumeIssue(issue, { synopsisOnly }));
   // Volume-specific curve placement layered on top of base's arc-wide
   // shapeGuidance so the verifier can flag "this volume inverts the expected
   // fortune at its position."
@@ -304,15 +296,7 @@ export async function buildVolumeVerifyContext(series, season, preloadedWorld, {
     || '(no story shape selected — do not flag shape adherence for this volume)';
   return {
     ...base,
-    volume: {
-      number: season.number ?? '',
-      title: season.title || '',
-      logline: season.logline || '',
-      synopsis: season.synopsis || '',
-      endingHook: season.endingHook || '',
-      episodeCountTarget: season.episodeCountTarget ?? '',
-      themesCsv: Array.isArray(season.themes) ? season.themes.join(', ') : '',
-    },
+    volume: renderVolumeFields(season),
     volumeShapePosition,
     neighborsJson: JSON.stringify(buildNeighborVolumes(series.seasons, season.id), null, 2),
     volumeIssuesJson: JSON.stringify(volumeIssues, null, 2),

--- a/server/services/pipeline/arcPlanner/context.js
+++ b/server/services/pipeline/arcPlanner/context.js
@@ -494,7 +494,10 @@ export function groupIssuesBySeasonTree(seasons, issues, { renderLeaf, seasonFie
   for (const list of issuesBySeason.values()) {
     list.sort(compareIssuesByPosition);
   }
-  const renderBucket = (list) => list.map(renderLeaf);
+  // Arity-safe: bare `list.map(renderLeaf)` would feed the array index as a
+  // second argument, so a renderer with an options bag (`renderVolumeIssue`'s
+  // `{ synopsisOnly }`) would silently receive the index as its options.
+  const renderBucket = (list) => list.map((iss) => renderLeaf(iss));
   const tree = seasons.map((s) => ({
     ...seasonFields(s),
     episodes: renderBucket(issuesBySeason.get(s.id) || []),
@@ -620,9 +623,15 @@ export function shapeEpisodeResolutions(rawEpisodes) {
 // Set exactly one of `beats` / `synopsis` so the prompt's beat-level checks
 // don't run against synopsis-only issues (and vice-versa). Beats land in
 // idea.output once the LLM-expand pass runs; before that, idea.input still
-// carries the seed synopsis.
-export function renderVolumeIssue(iss) {
-  const beats = (iss.stages?.idea?.output || '').trim();
+// carries the seed synopsis. `synopsisOnly` forces the synopsis branch for
+// callers that deliberately verify at synopsis depth even where beats exist.
+//
+// EXPORTED for the same reason as `renderVerifyIssueLeaf`: the volume-verify
+// prompt's checklist and this shape are two independent lists that must agree,
+// and a check naming a field this drops becomes a finding no resolver can close
+// — see `volumeVerifyPromptContract.test.js`.
+export function renderVolumeIssue(iss, { synopsisOnly = false } = {}) {
+  const beats = synopsisOnly ? '' : (iss.stages?.idea?.output || '').trim();
   const synopsis = (iss.stages?.idea?.input || '').trim();
   const base = {
     number: iss.number,
@@ -633,6 +642,20 @@ export function renderVolumeIssue(iss) {
   if (beats) return { ...base, beats };
   return { ...base, synopsis: synopsis || null };
 }
+
+// The volume node `pipeline-volume-verify.md` scores, as `{{volume.*}}`.
+// Exported alongside `renderVolumeIssue` so the same contract test can assert
+// every volume field the prompt interpolates is actually rendered. Empty-string
+// fallbacks (not null) keep the Mustache render clean for an unfilled volume.
+export const renderVolumeFields = (s) => ({
+  number: s.number ?? '',
+  title: s.title || '',
+  logline: s.logline || '',
+  synopsis: s.synopsis || '',
+  endingHook: s.endingHook || '',
+  episodeCountTarget: s.episodeCountTarget ?? '',
+  themesCsv: Array.isArray(s.themes) ? s.themes.join(', ') : '',
+});
 
 // Neighbor volumes — only the immediately-prior and immediately-next season
 // (by `number`) — so the LLM can check boundary continuity (#5 in the

--- a/server/services/pipeline/arcPlanner/promptContractHelpers.js
+++ b/server/services/pipeline/arcPlanner/promptContractHelpers.js
@@ -22,18 +22,29 @@ const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..'
 export const readShippedPrompt = (name) =>
   readFile(join(REPO_ROOT, 'data.reference', 'prompts', 'stages', name), 'utf-8');
 
+const IDENTIFIER = /^[a-z][A-Za-z0-9]*$/;
+
 /**
  * Candidate record-field identifiers a prompt cites in backticks. Strips the
  * illustrative value a check may attach (`episodeCountTarget: 12`) and the
  * array marker (`issues[]`) so the bare identifier is what gets tested. Only
  * single lowerCamelCase identifiers are candidates — JSON blobs, dotted paths
  * (`arc.themes`), kebab vocabulary, and prose fragments are not record fields.
+ *
+ * Angle-bracket placeholders inside the span are collected too: a `location`
+ * form like `episode:<arcPosition>` names a real record field on its right-hand
+ * side, and splitting at the colon would otherwise discard it — leaving a
+ * substituted placeholder free to cite a field nothing renders.
  */
 export const backtickedTokens = (markdown) => {
   const out = new Set();
   for (const match of markdown.matchAll(/`([^`\n]+)`/g)) {
-    const token = match[1].split(':')[0].replace(/\[\]$/, '').trim();
-    if (/^[a-z][A-Za-z0-9]*$/.test(token)) out.add(token);
+    const span = match[1];
+    const token = span.split(':')[0].replace(/\[\]$/, '').trim();
+    if (IDENTIFIER.test(token)) out.add(token);
+    for (const placeholder of span.matchAll(/<([A-Za-z][A-Za-z0-9]*)>/g)) {
+      if (IDENTIFIER.test(placeholder[1])) out.add(placeholder[1]);
+    }
   }
   return out;
 };

--- a/server/services/pipeline/arcPlanner/promptContractHelpers.js
+++ b/server/services/pipeline/arcPlanner/promptContractHelpers.js
@@ -1,0 +1,49 @@
+/**
+ * Shared test-support for the arc-planner prompt ↔ context contract suites
+ * (`verifyPromptContract.test.js`, `volumeVerifyPromptContract.test.js`).
+ *
+ * Each verify prompt's checklist and the context object that feeds it are two
+ * independent lists with nothing but those suites enforcing agreement. Both
+ * suites need the same three primitives, so they live here rather than being
+ * copied per prompt — a copy would drift exactly the way the prompts do.
+ */
+
+import { readFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+
+/**
+ * Read a SHIPPED stage prompt. Deliberately reads `data.reference/` and not
+ * `data/` — `data/` is gitignored per-install state that a user may have
+ * customized, so only the seed the repo ships is a contract worth enforcing.
+ */
+export const readShippedPrompt = (name) =>
+  readFile(join(REPO_ROOT, 'data.reference', 'prompts', 'stages', name), 'utf-8');
+
+/**
+ * Candidate record-field identifiers a prompt cites in backticks. Strips the
+ * illustrative value a check may attach (`episodeCountTarget: 12`) and the
+ * array marker (`issues[]`) so the bare identifier is what gets tested. Only
+ * single lowerCamelCase identifiers are candidates — JSON blobs, dotted paths
+ * (`arc.themes`), kebab vocabulary, and prose fragments are not record fields.
+ */
+export const backtickedTokens = (markdown) => {
+  const out = new Set();
+  for (const match of markdown.matchAll(/`([^`\n]+)`/g)) {
+    const token = match[1].split(':')[0].replace(/\[\]$/, '').trim();
+    if (/^[a-z][A-Za-z0-9]*$/.test(token)) out.add(token);
+  }
+  return out;
+};
+
+/** The `{{worldX}}` blocks a prompt interpolates. */
+export const worldVars = (markdown) => new Set(
+  [...markdown.matchAll(/\{\{\{?(world[A-Za-z0-9]*)\}?\}\}/g)].map((m) => m[1]),
+);
+
+/** The leaf names a prompt interpolates under a dotted `{{prefix.x}}` namespace. */
+export const namespacedVars = (markdown, prefix) => new Set(
+  [...markdown.matchAll(new RegExp(`\\{\\{\\{?${prefix}\\.([A-Za-z0-9]+)\\}?\\}\\}`, 'g'))].map((m) => m[1]),
+);

--- a/server/services/pipeline/arcPlanner/verifyPromptContract.test.js
+++ b/server/services/pipeline/arcPlanner/verifyPromptContract.test.js
@@ -23,14 +23,9 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { readFile } from 'fs/promises';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
 
 import { renderVerifyIssueLeaf, renderVerifySeasonFields } from './context.js';
-
-const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
-const shippedPrompt = (name) => join(REPO_ROOT, 'data.reference', 'prompts', 'stages', name);
+import { readShippedPrompt, backtickedTokens, worldVars } from './promptContractHelpers.js';
 
 // Backticked tokens that are deliberately NOT record fields. Anything backticked
 // in the prompt that is not here must be renderable — that is the whole point of
@@ -42,20 +37,6 @@ const NON_FIELD_TOKENS = new Set([
   'pilot', 'finale', 'complication', 'midpoint', 'b-plot', 'all-is-lost',
 ]);
 
-const backtickedTokens = (markdown) => {
-  const out = new Set();
-  for (const match of markdown.matchAll(/`([^`\n]+)`/g)) {
-    // Strip the illustrative value a check may attach (`episodeCountTarget: 12`)
-    // and the array marker (`issues[]`) so the bare identifier is what's tested.
-    const token = match[1].split(':')[0].replace(/\[\]$/, '').trim();
-    // Only single identifiers are candidate record fields. JSON blobs, dotted
-    // arc paths (`arc.themes` — an arc field, not a leaf/season one), and prose
-    // fragments are not.
-    if (/^[a-z][A-Za-z0-9]*$/.test(token)) out.add(token);
-  }
-  return out;
-};
-
 const renderableFields = () => new Set([
   ...Object.keys(renderVerifyIssueLeaf({ stages: { idea: { input: 'x' } } })),
   ...Object.keys(renderVerifySeasonFields({})),
@@ -63,7 +44,7 @@ const renderableFields = () => new Set([
 
 describe('pipeline-arc-verify prompt ↔ buildVerifyContext leaf contract', () => {
   it('renders every record field the shipped checklist cites', async () => {
-    const markdown = await readFile(shippedPrompt('pipeline-arc-verify.md'), 'utf-8');
+    const markdown = await readShippedPrompt('pipeline-arc-verify.md');
     const renderable = renderableFields();
     const unrenderable = [...backtickedTokens(markdown)]
       .filter((token) => !NON_FIELD_TOKENS.has(token) && !renderable.has(token));
@@ -88,14 +69,10 @@ describe('pipeline-arc-verify ↔ pipeline-arc-resolve world parity', () => {
   // world bag. A world variable the resolver renders but the verifier does not is
   // exactly the asymmetry that manufactures unsatisfiable groundedness findings:
   // the verifier calls a canon entity invented, the resolver can see it is not.
-  const worldVars = (markdown) => new Set(
-    [...markdown.matchAll(/\{\{\{?(world[A-Za-z0-9]*)\}?\}\}/g)].map((m) => m[1]),
-  );
-
   it('shows the verifier every world block the resolver can see', async () => {
     const [verify, resolve] = await Promise.all([
-      readFile(shippedPrompt('pipeline-arc-verify.md'), 'utf-8'),
-      readFile(shippedPrompt('pipeline-arc-resolve.md'), 'utf-8'),
+      readShippedPrompt('pipeline-arc-verify.md'),
+      readShippedPrompt('pipeline-arc-resolve.md'),
     ]);
     const verifyVars = worldVars(verify);
     const missing = [...worldVars(resolve)].filter((v) => !verifyVars.has(v));
@@ -103,7 +80,7 @@ describe('pipeline-arc-verify ↔ pipeline-arc-resolve world parity', () => {
   });
 
   it('renders the category canon the world actually defines', async () => {
-    const markdown = await readFile(shippedPrompt('pipeline-arc-verify.md'), 'utf-8');
+    const markdown = await readShippedPrompt('pipeline-arc-verify.md');
     expect(markdown).toContain('{{worldCategoriesText}}');
   });
 });

--- a/server/services/pipeline/arcPlanner/volumeVerifyPromptContract.test.js
+++ b/server/services/pipeline/arcPlanner/volumeVerifyPromptContract.test.js
@@ -32,16 +32,39 @@ const NON_FIELD_TOKENS = new Set([
   // `location` VALUE forms (`episode:3`, `episode:2-3`, bare `volume`), not
   // field names.
   'episode', 'volume',
+  // The ordinal placeholder in the `episode:<n>-<n+1>` boundary form.
+  'n',
 ]);
 
 // The prompt scores an issue at whichever depth it has, so BOTH branches of the
 // leaf are legitimately citable: `beats` on an LLM-expanded issue, `synopsis` on
 // an un-expanded one.
-const renderableFields = () => new Set([
+const issueLeafFields = () => new Set([
   ...Object.keys(renderVolumeIssue({ stages: { idea: { output: 'beat sheet' } } })),
   ...Object.keys(renderVolumeIssue({ stages: { idea: { input: 'seed synopsis' } } })),
+]);
+
+const renderableFields = () => new Set([
+  ...issueLeafFields(),
   ...Object.keys(renderVolumeFields({})),
 ]);
+
+// Citations the checklist makes in a SPECIFIC scope. The union assertion below
+// only proves a cited field is rendered somewhere, which is blind to the case
+// codex flagged: `synopsis` exists on both renderers, so either side could drop
+// it and the other would mask the loss. These pin the owner. New tokens still
+// get caught by the union check — this table only has to carry the names the
+// generic scan cannot attribute on its own.
+const SCOPED_CITATIONS = [
+  // "Each entry has either `beats` … OR just `synopsis`" — the issue leaf.
+  ['beats', 'issue leaf', issueLeafFields],
+  ['synopsis', 'issue leaf', issueLeafFields],
+  ['arcPosition', 'issue leaf', issueLeafFields],
+  // Checks #1/#4/#5 read these off the volume node.
+  ['logline', 'volume node', () => new Set(Object.keys(renderVolumeFields({})))],
+  ['synopsis', 'volume node', () => new Set(Object.keys(renderVolumeFields({})))],
+  ['endingHook', 'volume node', () => new Set(Object.keys(renderVolumeFields({})))],
+];
 
 const unrenderableIn = (markdown, renderable) => [...backtickedTokens(markdown)]
   .filter((token) => !NON_FIELD_TOKENS.has(token) && !renderable.has(token));
@@ -60,6 +83,20 @@ describe('pipeline-volume-verify prompt ↔ buildVolumeVerifyContext contract', 
     );
     const cited = 'Beat-level findings are only valid against issues that have `beats`.';
     expect(unrenderableIn(cited, renderableWithoutBeats)).toEqual(['beats']);
+  });
+
+  it.each(SCOPED_CITATIONS)('renders %s on the %s the checklist reads it from', (field, _scope, rendered) => {
+    expect([...rendered()]).toContain(field);
+  });
+
+  it('catches a scoped drop the other renderer would mask (bypass probe)', () => {
+    // `synopsis` lives on BOTH renderers, so the union assertion alone cannot
+    // see the issue leaf losing it — the volume node's copy keeps the union
+    // satisfied while every beat/synopsis-depth check silently loses its input.
+    const leafWithoutSynopsis = new Set([...issueLeafFields()].filter((f) => f !== 'synopsis'));
+    const union = new Set([...leafWithoutSynopsis, ...Object.keys(renderVolumeFields({}))]);
+    expect(union.has('synopsis')).toBe(true); // masked by the volume node…
+    expect(leafWithoutSynopsis.has('synopsis')).toBe(false); // …but caught here.
   });
 
   it('renders every {{volume.*}} field the prompt interpolates', async () => {

--- a/server/services/pipeline/arcPlanner/volumeVerifyPromptContract.test.js
+++ b/server/services/pipeline/arcPlanner/volumeVerifyPromptContract.test.js
@@ -18,7 +18,7 @@
 
 import { describe, it, expect } from 'vitest';
 
-import { renderVolumeIssue, renderVolumeFields } from './context.js';
+import { renderVolumeIssue, renderVolumeFields, sliceSeasonForNeighbor } from './context.js';
 import { readShippedPrompt, backtickedTokens, namespacedVars } from './promptContractHelpers.js';
 
 const PROMPT = 'pipeline-volume-verify.md';
@@ -44,26 +44,42 @@ const issueLeafFields = () => new Set([
   ...Object.keys(renderVolumeIssue({ stages: { idea: { input: 'seed synopsis' } } })),
 ]);
 
+const volumeNodeFields = () => new Set(Object.keys(renderVolumeFields({})));
+
+// `neighborsJson` — the immediately-prior/next volumes check #5 reads across the
+// boundary. A THIRD renderer feeding this one prompt, and a strict subset of the
+// volume node's fields, so the union below can never see it lose one.
+const neighborFields = () => new Set(Object.keys(sliceSeasonForNeighbor({})));
+
+// Deliberately NOT unioned with `neighborFields()`: the neighbor shape is a
+// subset of the volume node's, so folding it in would only give a dropped volume
+// field somewhere else to hide. Scope-specific coverage is `SCOPED_CITATIONS`.
 const renderableFields = () => new Set([
   ...issueLeafFields(),
-  ...Object.keys(renderVolumeFields({})),
+  ...volumeNodeFields(),
 ]);
 
 // Citations the checklist makes in a SPECIFIC scope. The union assertion below
-// only proves a cited field is rendered somewhere, which is blind to the case
-// codex flagged: `synopsis` exists on both renderers, so either side could drop
-// it and the other would mask the loss. These pin the owner. New tokens still
-// get caught by the union check — this table only has to carry the names the
-// generic scan cannot attribute on its own.
+// only proves a cited field is rendered somewhere, which is blind to a name that
+// exists on more than one of the three renderers: `synopsis` sits on both the
+// issue leaf and the volume node, and `logline`/`endingHook` on both the volume
+// node and its neighbors — so any one of them could drop the field and another
+// would mask the loss. These pin the owner. New tokens still get caught by the
+// union check; this table only carries the names the generic scan cannot
+// attribute on its own.
 const SCOPED_CITATIONS = [
   // "Each entry has either `beats` … OR just `synopsis`" — the issue leaf.
   ['beats', 'issue leaf', issueLeafFields],
   ['synopsis', 'issue leaf', issueLeafFields],
   ['arcPosition', 'issue leaf', issueLeafFields],
   // Checks #1/#4/#5 read these off the volume node.
-  ['logline', 'volume node', () => new Set(Object.keys(renderVolumeFields({})))],
-  ['synopsis', 'volume node', () => new Set(Object.keys(renderVolumeFields({})))],
-  ['endingHook', 'volume node', () => new Set(Object.keys(renderVolumeFields({})))],
+  ['logline', 'volume node', volumeNodeFields],
+  ['synopsis', 'volume node', volumeNodeFields],
+  ['endingHook', 'volume node', volumeNodeFields],
+  // Check #5 reads the PRIOR volume's `endingHook` and the NEXT volume's
+  // `logline` — off the neighbor slice, not the volume under review.
+  ['logline', 'neighbor volume', neighborFields],
+  ['endingHook', 'neighbor volume', neighborFields],
 ];
 
 const unrenderableIn = (markdown, renderable) => [...backtickedTokens(markdown)]
@@ -89,21 +105,33 @@ describe('pipeline-volume-verify prompt ↔ buildVolumeVerifyContext contract', 
     expect([...rendered()]).toContain(field);
   });
 
-  it('catches a scoped drop the other renderer would mask (bypass probe)', () => {
-    // `synopsis` lives on BOTH renderers, so the union assertion alone cannot
-    // see the issue leaf losing it — the volume node's copy keeps the union
-    // satisfied while every beat/synopsis-depth check silently loses its input.
-    const leafWithoutSynopsis = new Set([...issueLeafFields()].filter((f) => f !== 'synopsis'));
-    const union = new Set([...leafWithoutSynopsis, ...Object.keys(renderVolumeFields({}))]);
-    expect(union.has('synopsis')).toBe(true); // masked by the volume node…
-    expect(leafWithoutSynopsis.has('synopsis')).toBe(false); // …but caught here.
+  it.each([
+    ['issue leaf', 'synopsis', issueLeafFields, volumeNodeFields],
+    ['neighbor volume', 'logline', neighborFields, volumeNodeFields],
+  ])('catches %s losing %s where another renderer would mask it (bypass probe)', (
+    _scope, field, ownFields, maskingFields,
+  ) => {
+    const stripped = new Set([...ownFields()].filter((f) => f !== field));
+    const union = new Set([...stripped, ...maskingFields()]);
+    expect(union.has(field)).toBe(true); // masked by the other renderer…
+    expect(stripped.has(field)).toBe(false); // …but caught by the scoped check.
   });
 
   it('renders every {{volume.*}} field the prompt interpolates', async () => {
     const markdown = await readShippedPrompt(PROMPT);
-    const rendered = new Set(Object.keys(renderVolumeFields({})));
+    const rendered = volumeNodeFields();
     const missing = [...namespacedVars(markdown, 'volume')].filter((v) => !rendered.has(v));
     expect(missing).toEqual([]);
+  });
+
+  it('reads the field named inside a location form, not just its prefix', () => {
+    // `location` values embed a real field on the right of the colon
+    // (`episode:<arcPosition>`). Splitting at the colon and stopping there would
+    // let a substituted placeholder name a field nothing renders, so the scan
+    // has to descend into the angle brackets. Asserted directly because
+    // SCOPED_CITATIONS pins `arcPosition` independently and would stay green.
+    const tokens = backtickedTokens('Use `episode:<arcPosition>` or `episode:<n>-<n+1>`.');
+    expect([...tokens].sort()).toEqual(['arcPosition', 'episode', 'n']);
   });
 
   it('fails when an interpolated volume field is dropped (bypass probe)', () => {

--- a/server/services/pipeline/arcPlanner/volumeVerifyPromptContract.test.js
+++ b/server/services/pipeline/arcPlanner/volumeVerifyPromptContract.test.js
@@ -1,0 +1,108 @@
+/**
+ * Contract between `pipeline-volume-verify.md` and the context
+ * `buildVolumeVerifyContext` hands it — the volume-scope sibling of
+ * `verifyPromptContract.test.js`.
+ *
+ * Same failure mode, same stakes: the prompt's checklist and the rendered
+ * context are two independent lists that must agree, with nothing but this file
+ * enforcing it. The volume verifier feeds the same revert-on-any-blocker gate as
+ * the arc verifier, so a check reading a field the context never renders emits a
+ * finding no resolver can close, and the gate stalls forever on a volume with
+ * nothing wrong with it. Two instances of that class already shipped against the
+ * arc verifier (an `arcRole` check the leaf never rendered; a world-canon check
+ * reading `worldCanonText` while the canon lived in `worldCategoriesText`).
+ *
+ * Both halves of the contract are covered: the record fields the checklist cites
+ * in backticks, and the `{{volume.*}}` fields the prompt interpolates.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { renderVolumeIssue, renderVolumeFields } from './context.js';
+import { readShippedPrompt, backtickedTokens, namespacedVars } from './promptContractHelpers.js';
+
+const PROMPT = 'pipeline-volume-verify.md';
+
+// Backticked tokens that are deliberately NOT record fields. Anything backticked
+// in the prompt that is not here must be renderable — that is the whole point of
+// the guard, so extend this list only for genuinely non-field vocabulary.
+const NON_FIELD_TOKENS = new Set([
+  // Output-contract vocabulary.
+  'issues', 'severity', 'location', 'high', 'medium', 'low',
+  // `location` VALUE forms (`episode:3`, `episode:2-3`, bare `volume`), not
+  // field names.
+  'episode', 'volume',
+]);
+
+// The prompt scores an issue at whichever depth it has, so BOTH branches of the
+// leaf are legitimately citable: `beats` on an LLM-expanded issue, `synopsis` on
+// an un-expanded one.
+const renderableFields = () => new Set([
+  ...Object.keys(renderVolumeIssue({ stages: { idea: { output: 'beat sheet' } } })),
+  ...Object.keys(renderVolumeIssue({ stages: { idea: { input: 'seed synopsis' } } })),
+  ...Object.keys(renderVolumeFields({})),
+]);
+
+const unrenderableIn = (markdown, renderable) => [...backtickedTokens(markdown)]
+  .filter((token) => !NON_FIELD_TOKENS.has(token) && !renderable.has(token));
+
+describe('pipeline-volume-verify prompt ↔ buildVolumeVerifyContext contract', () => {
+  it('renders every record field the shipped checklist cites', async () => {
+    const markdown = await readShippedPrompt(PROMPT);
+    expect(unrenderableIn(markdown, renderableFields())).toEqual([]);
+  });
+
+  it('fails when a cited field is dropped from the issue leaf (bypass probe)', () => {
+    // Proves the assertion above has teeth: a checklist naming `beats` against a
+    // leaf that no longer renders it must be caught, not silently pass.
+    const renderableWithoutBeats = new Set(
+      [...renderableFields()].filter((field) => field !== 'beats'),
+    );
+    const cited = 'Beat-level findings are only valid against issues that have `beats`.';
+    expect(unrenderableIn(cited, renderableWithoutBeats)).toEqual(['beats']);
+  });
+
+  it('renders every {{volume.*}} field the prompt interpolates', async () => {
+    const markdown = await readShippedPrompt(PROMPT);
+    const rendered = new Set(Object.keys(renderVolumeFields({})));
+    const missing = [...namespacedVars(markdown, 'volume')].filter((v) => !rendered.has(v));
+    expect(missing).toEqual([]);
+  });
+
+  it('fails when an interpolated volume field is dropped (bypass probe)', () => {
+    // A renamed/removed volume field renders as an empty Mustache slot, so the
+    // prompt silently judges the volume against a blank `endingHook` instead of
+    // erroring — exactly the drift this half of the contract has to catch.
+    const rendered = new Set(
+      Object.keys(renderVolumeFields({})).filter((field) => field !== 'endingHook'),
+    );
+    const cited = namespacedVars('- **Ending hook:** {{volume.endingHook}}', 'volume');
+    expect([...cited].filter((v) => !rendered.has(v))).toEqual(['endingHook']);
+  });
+});
+
+describe('renderVolumeIssue depth selection', () => {
+  const issue = {
+    number: 4,
+    title: 'Example Issue',
+    status: 'draft',
+    arcPosition: 4,
+    stages: { idea: { input: 'seed synopsis', output: 'beat sheet' } },
+  };
+
+  it('renders beats (and never synopsis) once the expand pass has run', () => {
+    expect(renderVolumeIssue(issue)).toEqual({
+      number: 4, title: 'Example Issue', status: 'draft', arcPosition: 4, beats: 'beat sheet',
+    });
+  });
+
+  it('renders synopsis (and never beats) when synopsisOnly is requested', () => {
+    expect(renderVolumeIssue(issue, { synopsisOnly: true })).toEqual({
+      number: 4, title: 'Example Issue', status: 'draft', arcPosition: 4, synopsis: 'seed synopsis',
+    });
+  });
+
+  it('nulls synopsis rather than emitting an empty string for an unseeded issue', () => {
+    expect(renderVolumeIssue({ ...issue, stages: {} }).synopsis).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

`pipeline-volume-verify.md`'s checklist and the context `buildVolumeVerifyContext` renders were two independent lists with nothing enforcing agreement. That is the exact shape that already produced two real drift incidents against the arc verifier (an `arcRole` check the leaf never rendered; a world-canon check reading `worldCanonText` while the canon lived in `worldCategoriesText`). Both verifiers feed the same revert-on-any-blocker gate, so a check citing a field the context never renders emits a finding no resolver can close and the gate stalls forever on a volume with nothing wrong with it.

- **New `server/services/pipeline/arcPlanner/volumeVerifyPromptContract.test.js`** — mirrors `verifyPromptContract.test.js` structurally, with the volume prompt's own field set. Three layers:
  - every backticked record field the shipped checklist cites must be renderable — checked against **both** depth branches of the issue leaf (`beats` on an expanded issue, `synopsis` on a seed-only one) plus the volume fields;
  - `SCOPED_CITATIONS` pins **which** renderer each ambiguous citation is read from. Three renderers feed this one prompt (issue leaf, volume node, neighbor slice) and they share field names — `synopsis` sits on the leaf and the volume node, `logline`/`endingHook` on the volume node and its neighbors — so a union check alone lets one renderer drop a field while another masks the loss;
  - every `{{volume.*}}` the prompt interpolates must be rendered, because a renamed volume field degrades to a blank Mustache slot rather than an error.
  Each layer carries a bypass probe proving the assertion has teeth, and the leaf's depth-selection behaviour is pinned directly.
- **New `promptContractHelpers.js`** — the prompt-parsing primitives (`readShippedPrompt`, `backtickedTokens`, `worldVars`, `namespacedVars`) both contract suites need, extracted once instead of copied. `verifyPromptContract.test.js` is rewired onto them with no behaviour change. `backtickedTokens` also descends into angle-bracket placeholders, so the field named on the right of a `location` form (`episode:<arcPosition>`) is checked instead of discarded at the colon.
- **`context.js`** — exports `renderVolumeFields` (the `{{volume.*}}` node, previously an inline literal in `arcCore.js`) and folds the synopsis-only path into `renderVolumeIssue(iss, { synopsisOnly })`, so `buildVolumeVerifyContext` no longer hand-rolls two copies of shapes the contract test has to reason about.
- **`groupIssuesBySeasonTree`** — the bucket render is now arity-safe. A bare `list.map(renderLeaf)` passes the array index as the renderer's second argument, which would have silently landed in `renderVolumeIssue`'s new options bag.

The renderer/context refactors are behaviour-preserving; `buildVolumeVerifyContext`'s output is byte-identical.

### Findings and assumptions

- **No live drift.** Every identifier the current prompt cites is rendered today, so the guard is preventive rather than a fix. Verified negatively by temporarily deleting `endingHook` from the renderer — both the backticked and `{{volume.*}}` assertions failed, then passed again on restore.
- `episode` and `volume` are listed as non-field vocabulary: in this prompt they are `location` **value** forms (`episode:3`, `episode:2-3`, bare `volume`), not record fields — the same treatment the arc suite gives `arcRole` values like `pilot`/`finale`.
- Deliberately **not** added: a world-block parity assertion between the volume and arc verify prompts. The arc prompt also renders `worldLogline` / `worldPremise` / `worldStarter`, which are descriptive framing rather than the entity sets the volume prompt's world-drift check (#7) reads, so a strict parity test would fail on a non-drift.

## Test plan

- `cd server && MEMORY_BACKEND=file npx vitest run services/pipeline/` — all pipeline suites pass.
- Full server suite (`MEMORY_BACKEND=file npm test`): 28,890 passed. The 4 remaining failing files (`routes/health`, `services/backup`, `services/mediaAssetIndex/index`, `services/updateExecutor`) fail identically on `main` in this environment — environment-dependent, not introduced here.
- Without the file backend the suite is gated on a reachable Postgres in this environment; the failing-file set on this branch is a strict subset of `main`'s, so nothing new was introduced.
- Teeth verified by mutation against production code, each restored afterwards: dropping `endingHook` from `renderVolumeFields` fails the union and `{{volume.*}}` assertions; dropping `arcPosition` from the issue leaf fails the union and its scoped assertion; dropping `logline` from `sliceSeasonForNeighbor` fails only the neighbor-scoped assertion — the case the union is structurally blind to.
- Reviewed by `claude[claude-sonnet-5]` (no findings) and `codex` (two findings in round 1, two in round 2, all applied; round 3 clean).

Closes #4136
