### PR TITLE
feat: classify python/go/docker/static app types in streamingDetect (#4137)

### DIFF
--- a/.changelog/next/added-issue-4137.md
+++ b/.changelog/next/added-issue-4137.md
@@ -1,0 +1,1 @@
+- App detection now classifies Python, Go, Docker, and static repos instead of labelling them `unknown`, and PM2 standardization (which writes a Node ecosystem config) is no longer offered for them

--- a/client/src/components/apps/constants.js
+++ b/client/src/components/apps/constants.js
@@ -48,13 +48,14 @@ export function resolveLaunchPanelProcess(app, result) {
 // test asserts the two Sets match). POSITIVE list: the PM2 standardizer writes a
 // NODE ecosystem config from a prompt that opens "You are analyzing a Node.js
 // application", so a Python/Go/Docker/static repo must not be offered the flow.
-// `unknown` and `desktop` stay in for continuity — see the server's rationale.
+// `express` (appSchema's default), `unknown`, and `desktop` stay in for
+// continuity with already-persisted app records — see the server's rationale.
 export const STANDARDIZABLE_TYPES = new Set([
-  'vite+express', 'vite', 'single-node-server', 'nextjs', 'desktop', 'unknown'
+  'vite+express', 'vite', 'single-node-server', 'nextjs', 'express', 'desktop', 'unknown'
 ]);
 
 /** Whether the PM2 standardizer (which writes a NODE ecosystem config) applies. */
-export const isStandardizable = (type) => STANDARDIZABLE_TYPES.has(type ?? 'unknown');
+export const isStandardizable = (type) => STANDARDIZABLE_TYPES.has(type || 'unknown');
 
 // Every app type that can reach a UI label. Kept TOTAL (with a raw-type
 // fallback) rather than a ternary chain ending in '🔨 Xcode' — that default
@@ -72,6 +73,7 @@ const APP_TYPE_LABELS = {
   'vite+express': '⚡ Vite + Express',
   vite: '⚡ Vite',
   'single-node-server': '🟢 Node',
+  express: '🟢 Express',
   nextjs: '▲ Next.js'
 };
 

--- a/client/src/components/apps/constants.js
+++ b/client/src/components/apps/constants.js
@@ -44,10 +44,38 @@ export function resolveLaunchPanelProcess(app, result) {
   return result?.results?.[processName]?.success === false ? null : processName;
 }
 
-export const getAppTypeLabel = (type) =>
-  type === 'ios-native' ? '📱 iOS' :
-  type === 'macos-native' ? '🖥️ macOS' :
-  type === 'swift' ? '🐦 Swift' : '🔨 Xcode';
+// Mirrors STANDARDIZABLE_TYPES in server/services/streamingDetect.js (a parity
+// test asserts the two Sets match). POSITIVE list: the PM2 standardizer writes a
+// NODE ecosystem config from a prompt that opens "You are analyzing a Node.js
+// application", so a Python/Go/Docker/static repo must not be offered the flow.
+// `unknown` and `desktop` stay in for continuity — see the server's rationale.
+export const STANDARDIZABLE_TYPES = new Set([
+  'vite+express', 'vite', 'single-node-server', 'nextjs', 'desktop', 'unknown'
+]);
+
+/** Whether the PM2 standardizer (which writes a NODE ecosystem config) applies. */
+export const isStandardizable = (type) => STANDARDIZABLE_TYPES.has(type ?? 'unknown');
+
+// Every app type that can reach a UI label. Kept TOTAL (with a raw-type
+// fallback) rather than a ternary chain ending in '🔨 Xcode' — that default
+// meant any type not explicitly listed rendered as an Xcode project.
+const APP_TYPE_LABELS = {
+  'ios-native': '📱 iOS',
+  'macos-native': '🖥️ macOS',
+  swift: '🐦 Swift',
+  xcode: '🔨 Xcode',
+  python: '🐍 Python',
+  go: '🐹 Go',
+  docker: '🐳 Docker',
+  static: '📄 Static',
+  desktop: '🎮 Desktop',
+  'vite+express': '⚡ Vite + Express',
+  vite: '⚡ Vite',
+  'single-node-server': '🟢 Node',
+  nextjs: '▲ Next.js'
+};
+
+export const getAppTypeLabel = (type) => APP_TYPE_LABELS[type] || type || 'Unknown';
 
 // Where an app's autonomous work items live. Mirrors WORK_TRACKERS +
 // TRACKER_LABELS in server/lib/workTracker.js — shared by the Edit App picker

--- a/client/src/components/apps/constants.js
+++ b/client/src/components/apps/constants.js
@@ -44,18 +44,20 @@ export function resolveLaunchPanelProcess(app, result) {
   return result?.results?.[processName]?.success === false ? null : processName;
 }
 
-// Mirrors STANDARDIZABLE_TYPES in server/services/streamingDetect.js (a parity
-// test asserts the two Sets match). POSITIVE list: the PM2 standardizer writes a
-// NODE ecosystem config from a prompt that opens "You are analyzing a Node.js
-// application", so a Python/Go/Docker/static repo must not be offered the flow.
-// `express` (appSchema's default), `unknown`, and `desktop` stay in for
-// continuity with already-persisted app records — see the server's rationale.
-export const STANDARDIZABLE_TYPES = new Set([
-  'vite+express', 'vite', 'single-node-server', 'nextjs', 'express', 'desktop', 'unknown'
-]);
+// Mirrors NON_NODE_TYPES / NON_STANDARDIZABLE_TYPES in
+// server/services/streamingDetect.js (parity tests assert the Sets match). The
+// PM2 standardizer writes a NODE ecosystem config from a prompt that opens "You
+// are analyzing a Node.js application", so a Python/Go/Docker/static repo must
+// not be offered the flow. It's a DENY list, not an allowlist of Node types:
+// `type` is a free-form string persisted on the app record, so records in the
+// wild carry legacy values this file has never heard of, and an allowlist would
+// silently withdraw the button from all of them. See the server's rationale.
+export const NON_NODE_TYPES = new Set(['python', 'go', 'docker', 'static']);
+
+export const NON_STANDARDIZABLE_TYPES = new Set([...NON_PM2_TYPES, ...NON_NODE_TYPES]);
 
 /** Whether the PM2 standardizer (which writes a NODE ecosystem config) applies. */
-export const isStandardizable = (type) => STANDARDIZABLE_TYPES.has(type || 'unknown');
+export const isStandardizable = (type) => !NON_STANDARDIZABLE_TYPES.has(type);
 
 // Every app type that can reach a UI label. Kept TOTAL (with a raw-type
 // fallback) rather than a ternary chain ending in '🔨 Xcode' — that default

--- a/client/src/components/apps/tabs/OverviewTab.jsx
+++ b/client/src/components/apps/tabs/OverviewTab.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router';
 import { FolderOpen, Gamepad2, Terminal, Code, RefreshCw, Wrench, Archive, ArchiveRestore, Download, Tag, AlertTriangle, Rocket, Camera, Image, Sparkles } from 'lucide-react';
 import toast from '../../ui/Toast';
-import { NON_PM2_TYPES } from '../constants';
+import { isStandardizable } from '../constants';
 import ActivityLog from '../ActivityLog';
 import SlashDoPanel from '../SlashDoPanel';
 import Banner from '../../ui/Banner';
@@ -313,8 +313,10 @@ export default function OverviewTab({ app, onRefresh }) {
           {detectingIcon ? 'Scanning...' : 'Detect Icon'}
         </button>
         {/* PortOS's own ecosystem.config.cjs is the canonical PORTS source —
-            it is never regenerated from an LLM analysis (the server refuses too). */}
-        {!NON_PM2_TYPES.has(app.type) && app.id !== api.PORTOS_APP_ID && (
+            it is never regenerated from an LLM analysis (the server refuses too).
+            `isStandardizable` also keeps the button off non-Node repos, whose
+            ecosystem config the Node-shaped prompt has no business writing. */}
+        {isStandardizable(app.type) && app.id !== api.PORTOS_APP_ID && (
           <button
             onClick={handleStandardize}
             disabled={isOperating}

--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -14,7 +14,7 @@ import { useAppOperation } from '../hooks/useAppOperation';
 import useUrlParams from '../hooks/useUrlParams';
 import * as api from '../services/api';
 import socket from '../services/socket';
-import { NON_PM2_TYPES, getAppTypeLabel } from '../components/apps/constants';
+import { NON_PM2_TYPES, isStandardizable, getAppTypeLabel } from '../components/apps/constants';
 import { formatBytes } from '../utils/formatters';
 
 export default function Apps() {
@@ -700,7 +700,10 @@ export default function Apps() {
                             <RefreshCw size={14} aria-hidden="true" className={refreshingConfig[app.id] ? 'animate-spin' : ''} />
                             Refresh Config
                           </button>
-                          {(!app.processes?.length || app.processes.some(p => !p.ports || Object.keys(p.ports).length === 0)) && (
+                          {/* The standardizer writes a NODE ecosystem config —
+                              never offer it for a Python/Go/Docker/static repo
+                              (the server refuses too). */}
+                          {isStandardizable(app.type) && (!app.processes?.length || app.processes.some(p => !p.ports || Object.keys(p.ports).length === 0)) && (
                             <button
                               onClick={() => handleStandardize(app)}
                               disabled={isOperating}

--- a/client/src/pages/CreateApp.jsx
+++ b/client/src/pages/CreateApp.jsx
@@ -7,7 +7,7 @@ import * as api from '../services/api';
 import IconPicker from '../components/IconPicker';
 import FolderPicker from '../components/FolderPicker';
 import Banner from '../components/ui/Banner';
-import { NON_PM2_TYPES } from '../components/apps/constants';
+import { NON_PM2_TYPES, isStandardizable, getAppTypeLabel } from '../components/apps/constants';
 
 const DETECTION_STEPS_PM2 = [
   { id: 'validate', label: 'Validating path' },
@@ -479,14 +479,13 @@ export default function CreateApp() {
               </div>
             )}
 
-            {/* App Type Badge */}
-            {detected && isNonPm2 && (
+            {/* App Type Badge — shown for every type the PM2 standardizer skips,
+                so a Python/Go/Docker/static repo says WHY the card below is gone
+                rather than silently offering nothing. */}
+            {detected && !isStandardizable(appType) && (
               <Banner tone="info" size="md">
                 <p className="font-medium">
-                  {appType === 'ios-native' ? '📱 iOS App' :
-                   appType === 'macos-native' ? '🖥️ macOS App' :
-                   appType === 'swift' ? '🐦 Swift Package' :
-                   '🔨 Xcode Project'} — not managed by PM2
+                  {getAppTypeLabel(appType)} — {isNonPm2 ? 'not managed by PM2' : 'not a Node.js project'}
                 </p>
               </Banner>
             )}
@@ -504,7 +503,7 @@ export default function CreateApp() {
             )}
 
             {/* Standardize PM2 config — opt-in, because it rewrites the repo */}
-            {detected && !isNonPm2 && !standardizeResult && (
+            {detected && isStandardizable(appType) && !standardizeResult && (
               <div className="bg-port-card border border-port-border rounded-xl p-4 space-y-3">
                 <h3 className="text-xs font-medium uppercase tracking-wide text-gray-500">Optional</h3>
                 <p className="text-sm text-white flex items-center gap-2">

--- a/client/src/pages/CreateApp.test.jsx
+++ b/client/src/pages/CreateApp.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { act, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 
@@ -27,8 +27,12 @@ vi.mock('../components/ui/Toast', () => ({
 
 import CreateApp from './CreateApp';
 
-/** Render the wizard and drive detection to completion for the given app type. */
-const detectApp = async (result = { type: 'node', name: 'Example App' }) => {
+/**
+ * Render the wizard and drive detection to completion for the given app type.
+ * The default is a REAL type streamingDetect emits — the standardize card is
+ * gated on a positive list now, so a made-up placeholder would be refused.
+ */
+const detectApp = async (result = { type: 'single-node-server', name: 'Example App' }) => {
   render(<MemoryRouter><CreateApp /></MemoryRouter>);
   // Let the mount effects (provider + default directory) settle.
   await act(async () => {});
@@ -70,6 +74,38 @@ describe('CreateApp — PM2 standardization is opt-in', () => {
 
     expect(screen.queryByRole('button', { name: 'Standardize PM2 config' })).toBeNull();
     expect(standardizeEmits()).toHaveLength(0);
+  });
+
+  it('offers no standardization for non-Node runtimes', async () => {
+    // The standardizer's prompt opens "You are analyzing a Node.js application";
+    // on a Python/Go/Docker/static repo it doesn't fail, it confidently writes a
+    // Node ecosystem config. The card must not render at all.
+    for (const type of ['python', 'go', 'docker', 'static']) {
+      // Each iteration renders its own wizard — tear the previous one down so a
+      // stale card from an earlier type can't satisfy (or defeat) the query.
+      cleanup();
+      emit.mockClear();
+      for (const key of Object.keys(handlers)) delete handlers[key];
+
+      await detectApp({ type, name: 'Example App' });
+
+      expect(screen.queryByRole('button', { name: 'Standardize PM2 config' })).toBeNull();
+      expect(standardizeEmits()).toHaveLength(0);
+    }
+  });
+
+  it('explains why a non-Node repo gets no standardize card', async () => {
+    await detectApp({ type: 'python', name: 'Example App' });
+
+    expect(screen.getByText(/not a Node\.js project/)).toBeInTheDocument();
+  });
+
+  it('still offers standardization for an app whose type detection could not name', async () => {
+    // `unknown` is the persisted type of every app imported before non-Node
+    // classification existed — most of them are Node apps.
+    await detectApp({ type: 'unknown', name: 'Example App' });
+
+    expect(screen.getByRole('button', { name: 'Standardize PM2 config' })).toBeEnabled();
   });
 
   it('disables the action when no LLM provider is configured', async () => {

--- a/server/services/pm2Standardizer.js
+++ b/server/services/pm2Standardizer.js
@@ -9,7 +9,7 @@ import { safeJSONParse, tryReadFile } from '../lib/fileUtils.js';
 import { runPromptThroughProvider } from '../lib/promptRunner.js';
 import { getReservedPorts, getAllApps } from './apps.js';
 import { PORTOS_APP_ID } from '../lib/appIdentity.js';
-import { usesPm2 } from './streamingDetect.js';
+import { usesPm2, isStandardizable } from './streamingDetect.js';
 import { getListeningPorts } from '../lib/platform.js';
 
 const execAsync = promisify(exec);
@@ -51,6 +51,12 @@ export function standardizeRefusalFor(app) {
   }
   if (!usesPm2(app?.type)) {
     return `${app?.type} apps are not run under PM2, so there is no ecosystem config to standardize`;
+  }
+  if (!isStandardizable(app?.type)) {
+    // The analysis prompt below opens with "You are analyzing a Node.js
+    // application" — on a Python/Go/Docker/static repo it doesn't fail, it
+    // confidently writes a Node ecosystem config. A type check, not prose.
+    return `${app?.type} apps are not Node.js projects, so there is no Node ecosystem config to generate`;
   }
   return null;
 }

--- a/server/services/pm2Standardizer.test.js
+++ b/server/services/pm2Standardizer.test.js
@@ -24,6 +24,22 @@ describe('standardizeRefusalFor', () => {
     }
   });
 
+  it('refuses non-Node runtimes — the analysis prompt is Node-shaped', () => {
+    // These types DO run under PM2, so the usesPm2 gate lets them through; the
+    // refusal is that there is no Node ecosystem config to generate for them.
+    for (const type of ['python', 'go', 'docker', 'static']) {
+      expect(standardizeRefusalFor({ id: 'app-1', type })).toMatch(/not Node\.js projects/);
+    }
+  });
+
+  it('still allows an app whose persisted type predates the classification', () => {
+    // `type` is persisted on the app record, so apps imported before non-Node
+    // classification existed keep `unknown` until re-detected — and most of
+    // them are Node apps. Refusing them would break the button on upgrade.
+    expect(standardizeRefusalFor({ id: 'app-1', type: 'unknown' })).toBeNull();
+    expect(standardizeRefusalFor({ id: 'app-1' })).toBeNull();
+  });
+
   it('refuses PortOS itself — its ecosystem.config.cjs is the canonical PORTS source', () => {
     expect(standardizeRefusalFor({ id: PORTOS_APP_ID, type: 'vite+express' }))
       .toMatch(/manages its own ecosystem\.config\.cjs/);

--- a/server/services/streamingDetect.js
+++ b/server/services/streamingDetect.js
@@ -10,6 +10,59 @@ import { detectAppIcon } from './appIconDetect.js';
 export const NON_PM2_TYPES = new Set(['ios-native', 'macos-native', 'xcode', 'swift']);
 
 /**
+ * Non-Node runtimes recognized from marker files, mapped to the files that
+ * identify them. Order is precedence: a repo's LANGUAGE beats its packaging, so
+ * a Python service that also ships a `Dockerfile` classifies as `python` (the
+ * common case), while a compose-only stack with no language markers is
+ * `docker`. `static` is last — it's the "nothing but a page here" fallback.
+ */
+const NON_NODE_MARKERS = [
+  ['python', ['pyproject.toml', 'requirements.txt', 'setup.py', 'Pipfile']],
+  ['go', ['go.mod']],
+  ['docker', ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml', 'Dockerfile']],
+  ['static', ['index.html']]
+];
+
+/** The non-Node app types `classifyNonNodeType` can emit. */
+export const NON_NODE_TYPES = new Set(NON_NODE_MARKERS.map(([type]) => type));
+
+/**
+ * Classify a repo's runtime from its top-level filenames, for repos that
+ * carried no Node or Apple signal. Returns `null` when no marker matched — the
+ * caller keeps `unknown` rather than guessing.
+ *
+ * @param {string[]} files Top-level entry names (from `readdir`).
+ * @returns {'python'|'go'|'docker'|'static'|null}
+ */
+export function classifyNonNodeType(files) {
+  const present = new Set(files || []);
+  for (const [type, markers] of NON_NODE_MARKERS) {
+    if (markers.some(marker => present.has(marker))) return type;
+  }
+  return null;
+}
+
+/**
+ * App types the PM2 standardizer may run against — a POSITIVE list, because the
+ * standardizer's prompt opens with "You are analyzing a Node.js application"
+ * and a negative list (`!NON_PM2_TYPES.has(type)`) silently swept in every
+ * unrecognized repo. On a Python/Go/Docker/static repo the LLM doesn't fail, it
+ * confidently writes a Node ecosystem config into someone else's project.
+ *
+ * `unknown` stays in the list on purpose: `type` is persisted on the app record,
+ * so every app imported before this classification existed keeps `unknown` until
+ * it's re-detected — and most of those really are Node apps. `desktop` (a Godot
+ * game binary) is here for the same continuity reason; those repos commonly
+ * carry a Node web process alongside the game and were always offered the flow.
+ */
+export const STANDARDIZABLE_TYPES = new Set([
+  'vite+express', 'vite', 'single-node-server', 'nextjs', 'desktop', 'unknown'
+]);
+
+/** Whether the PM2 standardizer (which writes a NODE ecosystem config) applies. */
+export const isStandardizable = (type) => STANDARDIZABLE_TYPES.has(type ?? 'unknown');
+
+/**
  * App types that run a GUI/desktop process with no HTTP port (e.g. a Godot
  * game binary). These are still supervised through PM2, but launched from the
  * app's own `startCommands` — never an ecosystem web-server config — and with
@@ -1208,7 +1261,18 @@ export async function streamDetection(socket, dirPath) {
       }
     }
   } else {
-    emit('package', 'done', { message: 'No package.json found' });
+    // No package.json ⇒ nothing Node owns this repo, so fall back to marker-file
+    // classification for the common non-Node runtimes. Without this, a Python
+    // service / Go binary / Docker stack / static site all landed on `unknown`
+    // and were offered Node PM2 standardization. Guarded on `unknown` so an
+    // Apple type already resolved in step 2 (a Swift repo that also ships a
+    // Dockerfile) isn't overwritten.
+    const nonNodeType = result.type === 'unknown' ? classifyNonNodeType(files) : null;
+    if (nonNodeType) result.type = nonNodeType;
+    emit('package', 'done', {
+      message: nonNodeType ? `No package.json — detected ${nonNodeType} project` : 'No package.json found',
+      type: result.type
+    });
   }
 
   // Native game launch is additive: web ports/processes remain the standard

--- a/server/services/streamingDetect.js
+++ b/server/services/streamingDetect.js
@@ -19,12 +19,19 @@ export const NON_PM2_TYPES = new Set(['ios-native', 'macos-native', 'xcode', 'sw
 const NON_NODE_MARKERS = [
   ['python', ['pyproject.toml', 'requirements.txt', 'setup.py', 'Pipfile']],
   ['go', ['go.mod']],
-  ['docker', ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml', 'Dockerfile']],
-  ['static', ['index.html']]
+  ['docker', ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml', 'Dockerfile']]
 ];
 
+/**
+ * Files meaning "something SERVES this directory". A package-less repo holding
+ * one of these is a served app, not a static site, so `static` must not claim
+ * it. `index.js` is deliberately absent: next to an `index.html` it is far more
+ * often a client-side script than a server entry point.
+ */
+const SERVER_ENTRY_MARKERS = ['server.js', 'app.js', 'ecosystem.config.js', 'ecosystem.config.cjs'];
+
 /** The non-Node app types `classifyNonNodeType` can emit. */
-export const NON_NODE_TYPES = new Set(NON_NODE_MARKERS.map(([type]) => type));
+export const NON_NODE_TYPES = new Set([...NON_NODE_MARKERS.map(([type]) => type), 'static']);
 
 /**
  * Classify a repo's runtime from its top-level filenames, for repos that
@@ -39,34 +46,38 @@ export function classifyNonNodeType(files) {
   for (const [type, markers] of NON_NODE_MARKERS) {
     if (markers.some(marker => present.has(marker))) return type;
   }
+  // `static` is the last resort and the only rule carrying a negative
+  // condition — "an index.html with no server". An index.html sitting beside a
+  // server entry point is a served app, so fall through to `unknown` (which
+  // stays standardizable) rather than wrongly withdrawing the flow.
+  if (present.has('index.html') && !SERVER_ENTRY_MARKERS.some(marker => present.has(marker))) {
+    return 'static';
+  }
   return null;
 }
 
 /**
- * App types the PM2 standardizer may run against — a POSITIVE list, because the
- * standardizer's prompt opens with "You are analyzing a Node.js application"
- * and a negative list (`!NON_PM2_TYPES.has(type)`) silently swept in every
- * unrecognized repo. On a Python/Go/Docker/static repo the LLM doesn't fail, it
- * confidently writes a Node ecosystem config into someone else's project.
+ * App types the PM2 standardizer must REFUSE: the Apple types (never PM2 at
+ * all) plus the non-Node runtimes above. The standardizer's prompt opens with
+ * "You are analyzing a Node.js application" — on a Python/Go/Docker/static repo
+ * it doesn't fail, it confidently writes a Node ecosystem config into someone
+ * else's project. That is what this predicate exists to stop.
  *
- * The list has to cover every type an install can have PERSISTED, not just the
- * ones detection emits today — `type` lives on the app record and other installs
- * upgrade on their own schedule:
- *   - `express` is `appSchema`'s default (`server/lib/validation.js`) and the
- *     type of PortOS's own app entry, so it's the most common stored value.
- *   - `unknown` is what every app imported before this classification existed
- *     kept — and most of those really are Node apps.
- *   - `desktop` (a Godot game binary) was always offered the flow; those repos
- *     commonly carry a Node web process alongside the game.
- * A missing/blank type normalizes to `unknown`, so an unrecognized legacy value
- * degrades to "offer it" rather than silently hiding the button.
+ * It is a DENY list rather than an allowlist of Node types because `type` is a
+ * free-form string (`appSchema` in `server/lib/validation.js` defaults it to
+ * `express` and accepts any value) PERSISTED on the app record. Installs
+ * upgrade on their own schedule, so app records in the wild carry values this
+ * file has never heard of — `unknown` from before this classification existed,
+ * `node`/`react`/`web` from older detection, whatever a user typed. An
+ * allowlist would silently withdraw standardization from every one of them.
+ * Only a type we have positively identified as non-Node is refused; anything
+ * unrecognized degrades to the previous behavior (offer it, and let the user
+ * decide) instead of a button that quietly disappears on upgrade.
  */
-export const STANDARDIZABLE_TYPES = new Set([
-  'vite+express', 'vite', 'single-node-server', 'nextjs', 'express', 'desktop', 'unknown'
-]);
+export const NON_STANDARDIZABLE_TYPES = new Set([...NON_PM2_TYPES, ...NON_NODE_TYPES]);
 
 /** Whether the PM2 standardizer (which writes a NODE ecosystem config) applies. */
-export const isStandardizable = (type) => STANDARDIZABLE_TYPES.has(type || 'unknown');
+export const isStandardizable = (type) => !NON_STANDARDIZABLE_TYPES.has(type);
 
 /**
  * App types that run a GUI/desktop process with no HTTP port (e.g. a Godot

--- a/server/services/streamingDetect.js
+++ b/server/services/streamingDetect.js
@@ -49,18 +49,24 @@ export function classifyNonNodeType(files) {
  * unrecognized repo. On a Python/Go/Docker/static repo the LLM doesn't fail, it
  * confidently writes a Node ecosystem config into someone else's project.
  *
- * `unknown` stays in the list on purpose: `type` is persisted on the app record,
- * so every app imported before this classification existed keeps `unknown` until
- * it's re-detected — and most of those really are Node apps. `desktop` (a Godot
- * game binary) is here for the same continuity reason; those repos commonly
- * carry a Node web process alongside the game and were always offered the flow.
+ * The list has to cover every type an install can have PERSISTED, not just the
+ * ones detection emits today — `type` lives on the app record and other installs
+ * upgrade on their own schedule:
+ *   - `express` is `appSchema`'s default (`server/lib/validation.js`) and the
+ *     type of PortOS's own app entry, so it's the most common stored value.
+ *   - `unknown` is what every app imported before this classification existed
+ *     kept — and most of those really are Node apps.
+ *   - `desktop` (a Godot game binary) was always offered the flow; those repos
+ *     commonly carry a Node web process alongside the game.
+ * A missing/blank type normalizes to `unknown`, so an unrecognized legacy value
+ * degrades to "offer it" rather than silently hiding the button.
  */
 export const STANDARDIZABLE_TYPES = new Set([
-  'vite+express', 'vite', 'single-node-server', 'nextjs', 'desktop', 'unknown'
+  'vite+express', 'vite', 'single-node-server', 'nextjs', 'express', 'desktop', 'unknown'
 ]);
 
 /** Whether the PM2 standardizer (which writes a NODE ecosystem config) applies. */
-export const isStandardizable = (type) => STANDARDIZABLE_TYPES.has(type ?? 'unknown');
+export const isStandardizable = (type) => STANDARDIZABLE_TYPES.has(type || 'unknown');
 
 /**
  * App types that run a GUI/desktop process with no HTTP port (e.g. a Godot

--- a/server/services/streamingDetect.js
+++ b/server/services/streamingDetect.js
@@ -10,32 +10,43 @@ import { detectAppIcon } from './appIconDetect.js';
 export const NON_PM2_TYPES = new Set(['ios-native', 'macos-native', 'xcode', 'swift']);
 
 /**
- * Non-Node runtimes recognized from marker files, mapped to the files that
- * identify them. Order is precedence: a repo's LANGUAGE beats its packaging, so
- * a Python service that also ships a `Dockerfile` classifies as `python` (the
- * common case), while a compose-only stack with no language markers is
- * `docker`. `static` is last — it's the "nothing but a page here" fallback.
+ * Language markers, checked FIRST: a repo's LANGUAGE beats its packaging, so a
+ * Python service that also ships a `Dockerfile` classifies as `python` (the
+ * common case) rather than as a Docker stack.
  */
-const NON_NODE_MARKERS = [
+const LANGUAGE_MARKERS = [
   ['python', ['pyproject.toml', 'requirements.txt', 'setup.py', 'Pipfile']],
-  ['go', ['go.mod']],
-  ['docker', ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml', 'Dockerfile']]
+  ['go', ['go.mod']]
 ];
 
+/** Compose/Dockerfile markers — only reached when no language marker matched. */
+const DOCKER_MARKERS = ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml', 'Dockerfile'];
+
 /**
- * Files meaning "something SERVES this directory". A package-less repo holding
- * one of these is a served app, not a static site, so `static` must not claim
- * it. `index.js` is deliberately absent: next to an `index.html` it is far more
- * often a client-side script than a server entry point.
+ * Node entry points meaning "a process runs here". Checked BEFORE the docker
+ * and static rules, and mapped to *no* classification rather than to a type: a
+ * package-less repo shipping `server.mjs` is a Node app someone containerized
+ * (or that also serves a page), and classifying it `docker`/`static` would
+ * withdraw standardization from an app that genuinely wants it — the exact
+ * false negative this predicate exists to avoid. `index` is deliberately absent
+ * from the basenames: next to an `index.html` it is far more often a
+ * client-side script than a server entry point.
  */
-const SERVER_ENTRY_MARKERS = ['server.js', 'app.js', 'ecosystem.config.js', 'ecosystem.config.cjs'];
+const SERVER_ENTRY_BASENAMES = ['server', 'app', 'main'];
+const SERVER_ENTRY_EXTENSIONS = ['.js', '.mjs', '.cjs', '.ts'];
+
+const hasNodeServerEntry = (present) =>
+  // ECOSYSTEM_CONFIG_FILENAMES (below) is the one list of PM2 config names — a
+  // repo carrying one is unambiguously a PM2-managed process app.
+  ECOSYSTEM_CONFIG_FILENAMES.some(name => present.has(name)) ||
+  SERVER_ENTRY_BASENAMES.some(base => SERVER_ENTRY_EXTENSIONS.some(ext => present.has(`${base}${ext}`)));
 
 /** The non-Node app types `classifyNonNodeType` can emit. */
-export const NON_NODE_TYPES = new Set([...NON_NODE_MARKERS.map(([type]) => type), 'static']);
+export const NON_NODE_TYPES = new Set([...LANGUAGE_MARKERS.map(([type]) => type), 'docker', 'static']);
 
 /**
  * Classify a repo's runtime from its top-level filenames, for repos that
- * carried no Node or Apple signal. Returns `null` when no marker matched — the
+ * carried no Node or Apple signal. Returns `null` when nothing matched — the
  * caller keeps `unknown` rather than guessing.
  *
  * @param {string[]} files Top-level entry names (from `readdir`).
@@ -43,16 +54,12 @@ export const NON_NODE_TYPES = new Set([...NON_NODE_MARKERS.map(([type]) => type)
  */
 export function classifyNonNodeType(files) {
   const present = new Set(files || []);
-  for (const [type, markers] of NON_NODE_MARKERS) {
+  for (const [type, markers] of LANGUAGE_MARKERS) {
     if (markers.some(marker => present.has(marker))) return type;
   }
-  // `static` is the last resort and the only rule carrying a negative
-  // condition — "an index.html with no server". An index.html sitting beside a
-  // server entry point is a served app, so fall through to `unknown` (which
-  // stays standardizable) rather than wrongly withdrawing the flow.
-  if (present.has('index.html') && !SERVER_ENTRY_MARKERS.some(marker => present.has(marker))) {
-    return 'static';
-  }
+  if (hasNodeServerEntry(present)) return null;
+  if (DOCKER_MARKERS.some(marker => present.has(marker))) return 'docker';
+  if (present.has('index.html')) return 'static';
   return null;
 }
 

--- a/server/services/streamingDetect.test.js
+++ b/server/services/streamingDetect.test.js
@@ -1138,10 +1138,22 @@ describe('classifyNonNodeType', () => {
   it('does not call an index.html beside a server entry point static', () => {
     // "index.html with NO server" is the rule. A served app that happens to
     // have an index.html must fall through to `unknown` (still standardizable)
-    // rather than have the flow withdrawn from it.
-    for (const server of ['server.js', 'app.js', 'ecosystem.config.js', 'ecosystem.config.cjs']) {
+    // rather than have the flow withdrawn from it. Every JS/TS extension counts
+    // — `server.mjs` is as much an entry point as `server.js`.
+    for (const server of [
+      'server.js', 'server.mjs', 'server.cjs', 'server.ts',
+      'app.js', 'app.mjs', 'main.js', 'main.ts',
+      'ecosystem.config.js', 'ecosystem.config.cjs'
+    ]) {
       expect(classifyNonNodeType(['index.html', server])).toBeNull();
     }
+  });
+
+  it('does not call a Node server with a Dockerfile a docker stack', () => {
+    // A containerized Node service is still a Node service — the entry point
+    // outranks the packaging, the same way a language marker does.
+    expect(classifyNonNodeType(['server.js', 'Dockerfile'])).toBeNull();
+    expect(classifyNonNodeType(['app.mjs', 'docker-compose.yml'])).toBeNull();
   });
 
   it('still treats a client-side index.js as static, not a server', () => {
@@ -1150,10 +1162,16 @@ describe('classifyNonNodeType', () => {
     expect(classifyNonNodeType(['index.html', 'index.js', 'style.css'])).toBe('static');
   });
 
+  it('keeps the language markers ahead of a Node entry point', () => {
+    // A Python repo with a stray `app.py`-adjacent `main.js` build script is
+    // still python — the language check runs first.
+    expect(classifyNonNodeType(['requirements.txt', 'main.js'])).toBe('python');
+  });
+
   it('prefers the language over the packaging when both markers are present', () => {
     // A Python service that also ships a Dockerfile is a python repo, not a
     // docker stack — the language is the more useful classification, and both
-    // land outside STANDARDIZABLE_TYPES either way.
+    // are refused by the standardize gate either way.
     expect(classifyNonNodeType(['pyproject.toml', 'Dockerfile', 'index.html'])).toBe('python');
     expect(classifyNonNodeType(['go.mod', 'docker-compose.yml'])).toBe('go');
     expect(classifyNonNodeType(['Dockerfile', 'index.html'])).toBe('docker');

--- a/server/services/streamingDetect.test.js
+++ b/server/services/streamingDetect.test.js
@@ -1154,6 +1154,16 @@ describe('isStandardizable', () => {
     expect(isStandardizable('unknown')).toBe(true);
     expect(isStandardizable(undefined)).toBe(true);
     expect(isStandardizable(null)).toBe(true);
+    expect(isStandardizable('')).toBe(true);
+  });
+
+  it("covers appSchema's default type — the most common PERSISTED value", async () => {
+    // `type` lives on the app record, and an app created without one defaults to
+    // this. A positive gate that missed it would silently hide the standardize
+    // button on every such app across every install.
+    const { appSchema } = await import('../lib/validation.js');
+    const defaultType = appSchema.parse({ name: 'Example App', repoPath: '/srv/example-app' }).type;
+    expect(isStandardizable(defaultType)).toBe(true);
   });
 
   it('refuses the non-Node runtimes', () => {

--- a/server/services/streamingDetect.test.js
+++ b/server/services/streamingDetect.test.js
@@ -1,8 +1,13 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { detectGodotNativeLaunch, parseEcosystemConfig, resolveViteConfigPortForProcess, rewriteEcosystemPorts, rewriteEcosystemPortsByProcess, writeEcosystemPorts, writeEcosystemPortsByProcess, writeEcosystemPortEdits, DESKTOP_TYPES, NON_PM2_TYPES } from './streamingDetect.js';
+import { detectGodotNativeLaunch, parseEcosystemConfig, resolveViteConfigPortForProcess, rewriteEcosystemPorts, rewriteEcosystemPortsByProcess, writeEcosystemPorts, writeEcosystemPortsByProcess, writeEcosystemPortEdits, streamDetection, classifyNonNodeType, isStandardizable, usesPm2, DESKTOP_TYPES, NON_PM2_TYPES, NON_NODE_TYPES, STANDARDIZABLE_TYPES } from './streamingDetect.js';
+
+// streamDetection shells out to PM2 and scans for an app icon; neither is under
+// test here and both are slow/environment-dependent.
+vi.mock('./pm2.js', () => ({ execPm2: vi.fn(async () => ({ stdout: '[]' })) }));
+vi.mock('./appIconDetect.js', () => ({ detectAppIcon: vi.fn(async () => null) }));
 
 describe('detectGodotNativeLaunch', () => {
   let dir;
@@ -1021,5 +1026,155 @@ describe('client mirror of the app-type sets', () => {
   it('matches NON_PM2_TYPES', async () => {
     const client = await import('../../client/src/components/apps/constants.js');
     expect([...client.NON_PM2_TYPES].sort()).toEqual([...NON_PM2_TYPES].sort());
+  });
+
+  it('matches STANDARDIZABLE_TYPES', async () => {
+    const client = await import('../../client/src/components/apps/constants.js');
+    expect([...client.STANDARDIZABLE_TYPES].sort()).toEqual([...STANDARDIZABLE_TYPES].sort());
+  });
+});
+
+describe('streamDetection app-type classification', () => {
+  let dir;
+  afterEach(() => { if (dir) rmSync(dir, { recursive: true, force: true }); dir = null; });
+
+  /** Run detection over a temp repo built from `{ filename: contents }`. */
+  const detect = async (files) => {
+    dir = mkdtempSync(join(tmpdir(), 'detect-type-'));
+    for (const [name, contents] of Object.entries(files)) {
+      writeFileSync(join(dir, name), contents);
+    }
+    let completed = null;
+    const socket = {
+      emit: (event, payload) => { if (event === 'detect:complete') completed = payload; }
+    };
+    await streamDetection(socket, dir);
+    return completed;
+  };
+
+  it('classifies a Python repo instead of leaving it unknown', async () => {
+    const { success, result } = await detect({ 'pyproject.toml': '[project]\nname = "example"\n' });
+    expect(success).toBe(true);
+    expect(result.type).toBe('python');
+    expect(isStandardizable(result.type)).toBe(false);
+  });
+
+  it('classifies a Go repo', async () => {
+    const { result } = await detect({ 'go.mod': 'module example.com/demo\n', 'main.go': 'package main\n' });
+    expect(result.type).toBe('go');
+  });
+
+  it('classifies a compose-only stack as docker', async () => {
+    const { result } = await detect({ 'docker-compose.yml': 'services:\n  web:\n    image: nginx\n' });
+    expect(result.type).toBe('docker');
+  });
+
+  it('classifies a bare index.html as static', async () => {
+    const { result } = await detect({ 'index.html': '<!doctype html><title>Example</title>' });
+    expect(result.type).toBe('static');
+  });
+
+  it('leaves a package.json repo alone — Node tooling owns it, so `unknown` stays honest', async () => {
+    // A Node repo whose deps PortOS doesn't recognize must NOT be relabelled
+    // `static` just because it also ships an index.html; `unknown` remains
+    // standardizable, which is the correct answer for a Node project.
+    const { result } = await detect({
+      'package.json': JSON.stringify({ name: 'example', dependencies: { lodash: '^4' } }),
+      'index.html': '<!doctype html>'
+    });
+    expect(result.type).toBe('unknown');
+    expect(isStandardizable(result.type)).toBe(true);
+  });
+
+  it('does not overwrite an Apple type detected from the repo layout', async () => {
+    // A Swift package that also ships a Dockerfile is still `swift`.
+    const { result } = await detect({ 'Package.swift': '// swift-tools-version:5.9\n', Dockerfile: 'FROM swift\n' });
+    expect(result.type).toBe('swift');
+  });
+
+  it('still recognizes the Node types from package.json deps', async () => {
+    const { result } = await detect({
+      'package.json': JSON.stringify({ name: 'example', dependencies: { vite: '^5', express: '^4' } })
+    });
+    expect(result.type).toBe('vite+express');
+  });
+});
+
+describe('classifyNonNodeType', () => {
+  it('classifies python from any of its marker files', () => {
+    for (const marker of ['pyproject.toml', 'requirements.txt', 'setup.py', 'Pipfile']) {
+      expect(classifyNonNodeType(['README.md', marker])).toBe('python');
+    }
+  });
+
+  it('classifies go from go.mod', () => {
+    expect(classifyNonNodeType(['go.mod', 'go.sum', 'main.go'])).toBe('go');
+  });
+
+  it('classifies docker from a compose file or Dockerfile', () => {
+    for (const marker of ['docker-compose.yml', 'docker-compose.yaml', 'compose.yml', 'compose.yaml', 'Dockerfile']) {
+      expect(classifyNonNodeType([marker])).toBe('docker');
+    }
+  });
+
+  it('classifies static from a bare index.html', () => {
+    expect(classifyNonNodeType(['index.html', 'style.css'])).toBe('static');
+  });
+
+  it('prefers the language over the packaging when both markers are present', () => {
+    // A Python service that also ships a Dockerfile is a python repo, not a
+    // docker stack — the language is the more useful classification, and both
+    // land outside STANDARDIZABLE_TYPES either way.
+    expect(classifyNonNodeType(['pyproject.toml', 'Dockerfile', 'index.html'])).toBe('python');
+    expect(classifyNonNodeType(['go.mod', 'docker-compose.yml'])).toBe('go');
+    expect(classifyNonNodeType(['Dockerfile', 'index.html'])).toBe('docker');
+  });
+
+  it('returns null when nothing matches, rather than guessing', () => {
+    expect(classifyNonNodeType(['README.md', 'LICENSE'])).toBeNull();
+    expect(classifyNonNodeType([])).toBeNull();
+    expect(classifyNonNodeType(undefined)).toBeNull();
+  });
+
+  it('emits only types the standardizer refuses', () => {
+    for (const type of NON_NODE_TYPES) {
+      expect(isStandardizable(type)).toBe(false);
+    }
+  });
+});
+
+describe('isStandardizable', () => {
+  it('allows the Node app types', () => {
+    for (const type of ['vite+express', 'vite', 'single-node-server', 'nextjs']) {
+      expect(isStandardizable(type)).toBe(true);
+    }
+  });
+
+  it('stays permissive for unknown — the persisted type of every pre-classification app', () => {
+    expect(isStandardizable('unknown')).toBe(true);
+    expect(isStandardizable(undefined)).toBe(true);
+    expect(isStandardizable(null)).toBe(true);
+  });
+
+  it('refuses the non-Node runtimes', () => {
+    for (const type of ['python', 'go', 'docker', 'static']) {
+      expect(isStandardizable(type)).toBe(false);
+    }
+  });
+
+  it('refuses the Apple types', () => {
+    for (const type of NON_PM2_TYPES) {
+      expect(isStandardizable(type)).toBe(false);
+    }
+  });
+
+  it('does not widen NON_PM2_TYPES — a Python or Go service can still run under PM2', () => {
+    // NON_PM2_TYPES means "Apple" to its other consumers (appDeployer's deploy
+    // gate, the slashdo workflow filter, the client's Xcode-only UI), so the
+    // standardizer gate is a separate predicate rather than an entry there.
+    for (const type of NON_NODE_TYPES) {
+      expect(NON_PM2_TYPES.has(type)).toBe(false);
+      expect(usesPm2(type)).toBe(true);
+    }
   });
 });

--- a/server/services/streamingDetect.test.js
+++ b/server/services/streamingDetect.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { detectGodotNativeLaunch, parseEcosystemConfig, resolveViteConfigPortForProcess, rewriteEcosystemPorts, rewriteEcosystemPortsByProcess, writeEcosystemPorts, writeEcosystemPortsByProcess, writeEcosystemPortEdits, streamDetection, classifyNonNodeType, isStandardizable, usesPm2, DESKTOP_TYPES, NON_PM2_TYPES, NON_NODE_TYPES, STANDARDIZABLE_TYPES } from './streamingDetect.js';
+import { detectGodotNativeLaunch, parseEcosystemConfig, resolveViteConfigPortForProcess, rewriteEcosystemPorts, rewriteEcosystemPortsByProcess, writeEcosystemPorts, writeEcosystemPortsByProcess, writeEcosystemPortEdits, streamDetection, classifyNonNodeType, isStandardizable, usesPm2, DESKTOP_TYPES, NON_PM2_TYPES, NON_NODE_TYPES, NON_STANDARDIZABLE_TYPES } from './streamingDetect.js';
 
 // streamDetection shells out to PM2 and scans for an app icon; neither is under
 // test here and both are slow/environment-dependent.
@@ -1028,9 +1028,14 @@ describe('client mirror of the app-type sets', () => {
     expect([...client.NON_PM2_TYPES].sort()).toEqual([...NON_PM2_TYPES].sort());
   });
 
-  it('matches STANDARDIZABLE_TYPES', async () => {
+  it('matches NON_NODE_TYPES', async () => {
     const client = await import('../../client/src/components/apps/constants.js');
-    expect([...client.STANDARDIZABLE_TYPES].sort()).toEqual([...STANDARDIZABLE_TYPES].sort());
+    expect([...client.NON_NODE_TYPES].sort()).toEqual([...NON_NODE_TYPES].sort());
+  });
+
+  it('matches NON_STANDARDIZABLE_TYPES', async () => {
+    const client = await import('../../client/src/components/apps/constants.js');
+    expect([...client.NON_STANDARDIZABLE_TYPES].sort()).toEqual([...NON_STANDARDIZABLE_TYPES].sort());
   });
 });
 
@@ -1072,6 +1077,15 @@ describe('streamDetection app-type classification', () => {
   it('classifies a bare index.html as static', async () => {
     const { result } = await detect({ 'index.html': '<!doctype html><title>Example</title>' });
     expect(result.type).toBe('static');
+  });
+
+  it('keeps a served repo standardizable even when it ships an index.html', async () => {
+    const { result } = await detect({
+      'index.html': '<!doctype html>',
+      'server.js': 'require("http").createServer().listen(3000);\n'
+    });
+    expect(result.type).toBe('unknown');
+    expect(isStandardizable(result.type)).toBe(true);
   });
 
   it('leaves a package.json repo alone — Node tooling owns it, so `unknown` stays honest', async () => {
@@ -1121,6 +1135,21 @@ describe('classifyNonNodeType', () => {
     expect(classifyNonNodeType(['index.html', 'style.css'])).toBe('static');
   });
 
+  it('does not call an index.html beside a server entry point static', () => {
+    // "index.html with NO server" is the rule. A served app that happens to
+    // have an index.html must fall through to `unknown` (still standardizable)
+    // rather than have the flow withdrawn from it.
+    for (const server of ['server.js', 'app.js', 'ecosystem.config.js', 'ecosystem.config.cjs']) {
+      expect(classifyNonNodeType(['index.html', server])).toBeNull();
+    }
+  });
+
+  it('still treats a client-side index.js as static, not a server', () => {
+    // In a static site an `index.js` is a browser script far more often than a
+    // server entry point, so it must not suppress the classification.
+    expect(classifyNonNodeType(['index.html', 'index.js', 'style.css'])).toBe('static');
+  });
+
   it('prefers the language over the packaging when both markers are present', () => {
     // A Python service that also ships a Dockerfile is a python repo, not a
     // docker stack — the language is the more useful classification, and both
@@ -1145,7 +1174,7 @@ describe('classifyNonNodeType', () => {
 
 describe('isStandardizable', () => {
   it('allows the Node app types', () => {
-    for (const type of ['vite+express', 'vite', 'single-node-server', 'nextjs']) {
+    for (const type of ['vite+express', 'vite', 'single-node-server', 'nextjs', 'desktop']) {
       expect(isStandardizable(type)).toBe(true);
     }
   });
@@ -1155,6 +1184,17 @@ describe('isStandardizable', () => {
     expect(isStandardizable(undefined)).toBe(true);
     expect(isStandardizable(null)).toBe(true);
     expect(isStandardizable('')).toBe(true);
+  });
+
+  it('stays permissive for legacy/custom persisted types', () => {
+    // `type` is a free-form string on the app record (appSchema accepts any
+    // value) and installs upgrade independently, so records in the wild carry
+    // values this file never emitted. Only a POSITIVELY identified non-Node
+    // type is refused — anything else keeps the pre-change behavior instead of
+    // the button silently vanishing on upgrade.
+    for (const type of ['express', 'node', 'react', 'web', 'anything-a-user-typed']) {
+      expect(isStandardizable(type)).toBe(true);
+    }
   });
 
   it("covers appSchema's default type — the most common PERSISTED value", async () => {


### PR DESCRIPTION
## Summary

`streamingDetect.js` only ever emitted `vite+express` / `vite` / `single-node-server` / `nextjs`, the four Apple types, or the initialized default `unknown`. A Python service, Go binary, Docker stack, or static site all fell through to `unknown` — and because the standardize gate was the *negation* of `NON_PM2_TYPES` (which means "Apple" to its three other consumers), every one of them was still offered PM2 standardization. The standardizer's prompt opens with "You are analyzing a **Node.js** application", so on a Python repo it doesn't fail — it confidently writes a Node ecosystem config.

This teaches detection to classify the non-Node runtimes and replaces the "everything unrecognized is a PM2 Node app" gate with a predicate that refuses only what it has positively identified as non-Node.

**Detection** — `classifyNonNodeType(files)` maps top-level marker files to `python` / `go` / `docker` / `static`. It runs only when there is no `package.json` (any `package.json` means Node tooling owns the repo, so `unknown` stays the honest answer) and only when nothing earlier claimed the repo, so an Apple type detected from the repo layout is never overwritten.

**Standardization gate** — new `NON_STANDARDIZABLE_TYPES` (= `NON_PM2_TYPES` ∪ `NON_NODE_TYPES`) and `isStandardizable(type)` in `streamingDetect.js`, mirrored into `client/src/components/apps/constants.js` with parity tests. `standardizeRefusalFor()` and all three UI surfaces (Add App wizard card, Apps-list row button, app Overview tab button) gate on it.

**Type labels** — `getAppTypeLabel` was a ternary chain whose fallback was `'🔨 Xcode'`, so any unlisted type rendered as an Xcode project. It is now a total map with a raw-type fallback, covering the new types.

## Decisions (unattended run)

- **`NON_PM2_TYPES` is deliberately NOT widened.** Its other consumers (`appDeployer`'s deploy gate, `cosTaskRoutes`' slashdo workflow filter, the client's Xcode-only UI branches) read it as "Apple", and a Python or Go service genuinely can run under PM2. `usesPm2()` therefore still returns `true` for the new types; the standardizer gate is a separate predicate. This follows the fix shape in the issue.
- **The gate is a deny list, not an allowlist of Node types.** `type` is a free-form string (`appSchema` defaults it to `express` and accepts any value) *persisted* on the app record, and installs upgrade independently — records in the wild carry `unknown`, `express`, and older/custom values. An allowlist would silently withdraw the standardize button from all of them on upgrade, so only a positively identified non-Node type is refused and anything unrecognized keeps the pre-change behavior. This satisfies the issue's "the predicate must stay permissive for `unknown`" requirement generally rather than case by case.
- **Classification order: language → Node server entry → docker → static.** A Python service that also ships a `Dockerfile` is `python` (language beats packaging); a package-less repo shipping `server.{js,mjs,cjs,ts}` or an `ecosystem.config.*` is a Node app someone containerized, so it outranks both the docker and static rules and falls through to `unknown` (still standardizable); a compose-only stack is `docker`; `static` is the last-resort match.
- **`server` is the only basename treated as server evidence.** `index.js`, `app.js`, and `main.js` are at least as common as browser scripts loaded by an `index.html`, so counting them would leave real static sites unclassified and still offered the Node standardizer — trading one false negative for the false positive this issue was filed about.
- **`/api/standardize/*` now standardizes the checked app's own repo.** `resolveStandardizeTarget` preferred a companion `repoPath` over `app.repoPath`, so a permitted Node `appId` paired with another directory would carry a non-Node repo past the refusal — making the gate decorative. No caller sends both (`apiSystem.js` sends one or the other), so this only closes the hole.
- **Refusal messages stay distinct** — Apple types keep the existing "not run under PM2" wording; the new types get "not Node.js projects, so there is no Node ecosystem config to generate".
- `CreateApp.test.jsx`'s shared fixture used a made-up `type: 'node'`; it now uses the real `single-node-server`.

## Test plan

- **CI is green on every job**, including `test (24.x)`, `DB tests and server smoke`, `Client tests and build`, `Windows server unit tests`, and `lint`.
- `cd server && npm test` — all affected suites pass (`streamingDetect`, `pm2Standardizer`, `routes/standardize`, `services/socket`, `routes/apps/*`, `services/apps`, `services/appDeployer`, `routes/cosTaskRoutes`: 306 passed / 1 skipped). Locally the full run also reports Postgres-backed store/route suites failing with `… requires PostgreSQL`; that is an environment condition, not a regression — the same set fails on `main` here, and CI's DB job passes.
- `cd client && npm test` — 637 files / 7716 tests, all passing.
- New coverage: `classifyNonNodeType` per marker, its ordering (language → Node entry → docker → static), every JS/TS server extension, the containerized-Node case, and the ambiguous-browser-script case; `isStandardizable` across Node / `unknown` / blank / legacy-custom / non-Node / Apple types plus a guard pinning `appSchema`'s default type; client parity tests for `NON_NODE_TYPES` and `NON_STANDARDIZABLE_TYPES`; an explicit assertion that `NON_PM2_TYPES` was not widened; end-to-end `streamDetection` runs over temp repos for each new type plus the "package.json present ⇒ stays `unknown`", "served repo with an index.html stays standardizable", and "Apple type not overwritten" guards; a route test that a companion `repoPath` cannot redirect the standardizer; `standardizeRefusalFor` refusals for the four new types; and wizard tests that the standardize card is absent for non-Node types, present for `unknown`, and that the banner explains why.

## Review

Self-review caught that `appSchema` defaults `type` to `express`. Headless `claude` review returned no findings. Headless `codex` ran three rounds and every finding is fixed in this branch: the closed allowlist that would have hidden the button for legacy persisted types, `index.html` beside a server misclassified as `static`, server entries checked after docker and only matching `.js`, `app.js`/`main.js` wrongly counted as server evidence, and the `/api/standardize/*` target resolution preferring a companion `repoPath` over the record it just type-checked.

Closes #4137
