### PR TITLE
Add LTX-2.5 MLX Q8 as an installable Apple Silicon video model

### DIFF
--- a/.changelog/next/added-ltx25-mlx-video-model.md
+++ b/.changelog/next/added-ltx25-mlx-video-model.md
@@ -1,0 +1,1 @@
+- Add LTX-2.5 MLX Q8 as an installable Apple Silicon video model (sibling runtime of the LTX-2.3 pin)

--- a/client/src/components/videoGen/AdvancedParamsPanel.jsx
+++ b/client/src/components/videoGen/AdvancedParamsPanel.jsx
@@ -14,6 +14,7 @@ import {
   CONTEXT_FRAME_OPTIONS, supportsContextWindow,
 } from '../../lib/videoGenParams.js';
 import { VIDEO_TILING_OPTIONS } from '../../lib/videoTilingOptions';
+import { isLtx2FamilyRuntime } from '../../lib/runnerFamilies';
 
 const inputCls = 'w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent disabled:opacity-50';
 
@@ -44,7 +45,7 @@ export default function AdvancedParamsPanel({
   const showChunks = mode !== 'a2v' && isModelAllowedForMode(currentModel, 'image');
   // ltx2 extend conditions on the source's latent rather than a single frame,
   // so image strength is meaningless for it.
-  const showImageStrength = mode === 'image' || (mode === 'extend' && currentModel?.runtime !== 'ltx2');
+  const showImageStrength = mode === 'image' || (mode === 'extend' && !isLtx2FamilyRuntime(currentModel?.runtime));
   const frameOptions = frameOptionsForModel(currentModel, numFrames);
   const fpsOptions = fpsOptionsForModel(currentModel);
   const samplerLocked = currentModel?.samplerLocked === true;

--- a/client/src/hooks/useMusicVideoSceneMedia.js
+++ b/client/src/hooks/useMusicVideoSceneMedia.js
@@ -3,6 +3,7 @@ import { updateMusicVideoScene } from '../services/apiMusicVideo.js';
 import { generateImage } from '../services/apiSystem.js';
 import { generateVideo } from '../services/apiImageVideo.js';
 import useSceneRenderLifecycle from './useSceneRenderLifecycle.js';
+import { isLtx2FamilyRuntime } from '../lib/runnerFamilies';
 
 // Audio-reactive generation conditions motion on the song itself, so the prompt
 // has to rule out anything that reads as a performance of it.
@@ -162,7 +163,7 @@ export default function useMusicVideoSceneMedia({ project, videoSettings, applyS
   const continueSceneVideo = (scene) => {
     if (!scene.videoHistoryId || !scene.referenceImageId) return;
     const { settings, activeModel, effectiveModelId, videoBlockedReason } = videoSettings;
-    if (settings.backend !== 'local' || activeModel?.runtime !== 'ltx2') {
+    if (settings.backend !== 'local' || !isLtx2FamilyRuntime(activeModel?.runtime)) {
       toast.error('Choose an LTX local model with native continuation support');
       return;
     }

--- a/client/src/hooks/useVideoGenForm.js
+++ b/client/src/hooks/useVideoGenForm.js
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router';
 import toast from '../components/ui/Toast';
 import { extractLastFrame } from '../services/api';
 import { composeStyledPrompt } from '../lib/composeStyledPrompt';
-import { videoLoraFamily, isVideoLoraFamily, loraFamilyOf, VIDEO_LORA_FAMILIES } from '../lib/runnerFamilies';
+import { videoLoraFamily, isVideoLoraFamily, loraFamilyOf, VIDEO_LORA_FAMILIES, isLtx2FamilyRuntime } from '../lib/runnerFamilies';
 import { randomSeed } from '../lib/genUtils';
 import {
   resolutionOptionsForModel, defaultResolutionForModel, snapAspectToImage,
@@ -485,7 +485,7 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled })
   // the server's accept rules (server/routes/videoGen.js ~line 574) so the
   // form blocks before a doomed POST: 2–8 entries, each pinned to a gallery
   // file, indices strictly ascending and within [0, numFrames-1].
-  const keyframesSupported = currentModel?.runtime === 'ltx2';
+  const keyframesSupported = isLtx2FamilyRuntime(currentModel?.runtime);
   const keyframesActive = mode === 'fflf' && keyframesMode && keyframesSupported;
   // Whether an FFLF last frame is a real anchor or just a hint. The server
   // decorates each model with `lastFrameAnchored` from the one runtime list
@@ -820,7 +820,7 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled })
     // extract roundtrip — the route resolves the video id to a disk path
     // server-side. Saves ~1s per pick + avoids the i2v fallback when the
     // extract fails.
-    if (currentModel?.runtime === 'ltx2') {
+    if (isLtx2FamilyRuntime(currentModel?.runtime)) {
       setExtendingFrame(false);
       return;
     }
@@ -1063,12 +1063,12 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled })
   // legacy runtime, also wait for the extracted frame).
   const extendModeBlocked = mode === 'extend' && (
     !extendFromVideoId
-    || (currentModel?.runtime !== 'ltx2' && (extendingFrame || !sourceImageFile))
+    || (!isLtx2FamilyRuntime(currentModel?.runtime) && (extendingFrame || !sourceImageFile))
   );
   // a2v requires an audio upload AND an ltx2-runtime model — the legacy
   // mlx_video runtime has no audio-conditioned pipeline. Block submit when
   // either is missing so the request fails the form, not the worker.
-  const a2vModeBlocked = mode === 'a2v' && (!audioFile || currentModel?.runtime !== 'ltx2');
+  const a2vModeBlocked = mode === 'a2v' && (!audioFile || !isLtx2FamilyRuntime(currentModel?.runtime));
   // IC-LoRA remix needs a reference clip AND an ltx2-runtime model, and the
   // resolution must divide by the weight's reference-downscale factor (the
   // server rejects otherwise). Block submit for all three so the request fails
@@ -1081,7 +1081,7 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled })
     (icImageKind
       ? (icFilledImageRefs < icSpec.minReferences || icFilledImageRefs > icSpec.maxReferences)
       : (!icReferenceFile && !icReferenceVideoId))
-    || currentModel?.runtime !== 'ltx2'
+    || !isLtx2FamilyRuntime(currentModel?.runtime)
     || !!icResolutionIssue(icSpec, width, height)
   );
   // Chaining seeds each chunk from the previous one's last frame, so it needs
@@ -1210,12 +1210,12 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled })
       loraFilenames: (loraFamily && selectedLoras.length) ? selectedLoras.map((l) => l.filename) : undefined,
       loraScales: (loraFamily && selectedLoras.length) ? selectedLoras.map((l) => l.scale) : undefined,
       sourceImageFile: (mode === 'image' || legacyFflf
-        || (mode === 'extend' && currentModel?.runtime !== 'ltx2'))
+        || (mode === 'extend' && !isLtx2FamilyRuntime(currentModel?.runtime)))
         ? (sourceImageFile || '') : '',
       sourceImage: (mode === 'image' || legacyFflf) ? (sourceImageUpload || '') : '',
       lastImageFile: legacyFflf ? (lastImageFile || '') : '',
       lastImage: legacyFflf ? (lastImageUpload || '') : '',
-      extendFromVideoId: (mode === 'extend' && currentModel?.runtime === 'ltx2')
+      extendFromVideoId: (mode === 'extend' && isLtx2FamilyRuntime(currentModel?.runtime))
         ? (extendFromVideoId || '') : '',
       // Audio File goes through under the multipart field 'audioFile'. Server
       // routes it to the durable uploads dir and into the a2v helper.

--- a/client/src/lib/runnerFamilies.js
+++ b/client/src/lib/runnerFamilies.js
@@ -37,6 +37,14 @@ export const isVideoLoraFamily = (family) => VIDEO_LORA_FAMILY_SET.has(family);
 export const MINIMAX_H3_RUNTIMES = Object.freeze(['minimax_h3', 'minimax_h3_cuda']);
 const MINIMAX_H3_RUNTIME_SET = new Set(MINIMAX_H3_RUNTIMES);
 export const isMiniMaxH3Runtime = (runtime) => MINIMAX_H3_RUNTIME_SET.has(runtime);
+// dgrauet's LTX-2.3 pin (`ltx2`) and the LTX-2.5 fork (`ltx25`) share the
+// same pipeline surface — true FFLF, video-conditioned extend, a2v, IC-LoRA —
+// so capability gates ask this predicate instead of naming one id. The venvs
+// stay separate: 2.5 is a different checkout and cannot load on the 2.3 pin.
+// Mirror of server/lib/runners.js.
+export const LTX2_FAMILY_RUNTIMES = Object.freeze(['ltx2', 'ltx25']);
+const LTX2_FAMILY_RUNTIME_SET = new Set(LTX2_FAMILY_RUNTIMES);
+export const isLtx2FamilyRuntime = (runtime) => LTX2_FAMILY_RUNTIME_SET.has(runtime);
 
 // The family an INSTALLED LoRA belongs to. `loraCompatKey` is the refined key
 // (e.g. flux2-9b) written by the importer; `runnerFamily` is the coarse legacy
@@ -72,7 +80,7 @@ export const isMlxVideoLtxLoraCapable = (model) => {
 // returns null so the VideoGen picker hides itself.
 // Mirror of server/lib/runners.js#videoLoraFamily.
 export const videoLoraFamily = (model) => {
-  if (model?.runtime === 'ltx2' || isMlxVideoLtxLoraCapable(model)) return VIDEO_LORA_FAMILIES.LTX_VIDEO;
+  if (isLtx2FamilyRuntime(model?.runtime) || isMlxVideoLtxLoraCapable(model)) return VIDEO_LORA_FAMILIES.LTX_VIDEO;
   if (model?.runtime === 'minimax_h3' && model?.runtimeLoraCapable === true) return VIDEO_LORA_FAMILIES.MINIMAX_H3;
   return null;
 };

--- a/client/src/lib/videoGenParams.js
+++ b/client/src/lib/videoGenParams.js
@@ -4,6 +4,8 @@
 // predicate. Kept in lib/ (not hooks/) because none touch React state; the
 // page and any future consumer import them directly.
 
+import { isLtx2FamilyRuntime } from './runnerFamilies';
+
 // Values follow LTX-2's 8k+1 latent boundary so the model doesn't silently
 // snap. 241 = 10s @ 24fps is the comfortable single-pass ceiling on 48 GB
 // at standard widths; the higher options (265–481) push past that and may
@@ -32,7 +34,7 @@ export const CONTEXT_FRAME_OPTIONS = [0, 11, 22, 45, 73];
 // Only a runtime with a video-conditioned extend pipeline can use a window;
 // elsewhere the server ignores the value, so the control stays hidden rather
 // than offering a knob that does nothing.
-export const supportsContextWindow = (model) => model?.runtime === 'ltx2';
+export const supportsContextWindow = (model) => isLtx2FamilyRuntime(model?.runtime);
 export const WAN_FRAME_OPTIONS = [...new Set([
   ...FRAME_OPTIONS,
   41, 61, 81, 101, 161, 201, 321,
@@ -231,6 +233,6 @@ export const icResolutionIssue = (spec, width, height) => {
 // #3737), so an absent list means the payload didn't come from the registry.
 export const isModelAllowedForMode = (model, mode) => {
   if (!model) return false;
-  if (mode === 'a2v' || isIcLoraMode(mode)) return model.runtime === 'ltx2';
+  if (mode === 'a2v' || isIcLoraMode(mode)) return isLtx2FamilyRuntime(model.runtime);
   return Array.isArray(model.supportedModes) && model.supportedModes.includes(mode);
 };

--- a/client/src/pages/MusicVideo.jsx
+++ b/client/src/pages/MusicVideo.jsx
@@ -37,6 +37,7 @@ import RenderStatusPanel from '../components/musicVideo/RenderStatusPanel.jsx';
 import AnalysisPanel from '../components/musicVideo/AnalysisPanel.jsx';
 import SceneCard from '../components/musicVideo/SceneCard.jsx';
 import { autoArrangeScenes } from '../lib/beatGrid.js';
+import { isLtx2FamilyRuntime } from '../lib/runnerFamilies';
 import { videoSrcForJob, videoPosterForJob } from '../lib/creativeDirectorPreview.js';
 
 const STATUS_COLORS = {
@@ -355,7 +356,7 @@ export default function MusicVideo() {
 
   const canContinueShot = videoSettings.settings.backend === 'local'
     && videoSettings.settings.generationMode === 'image'
-    && videoSettings.activeModel?.runtime === 'ltx2';
+    && isLtx2FamilyRuntime(videoSettings.activeModel?.runtime);
 
   // Final render filename is NOT the history id — resolve once at page level so
   // the lightbox item and the inline player share the same lookup (#3718).

--- a/client/src/pages/VideoGen.jsx
+++ b/client/src/pages/VideoGen.jsx
@@ -37,7 +37,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { useSearchParams } from 'react-router';
-import { isMiniMaxH3Runtime } from '../lib/runnerFamilies';
+import { isMiniMaxH3Runtime, isLtx2FamilyRuntime } from '../lib/runnerFamilies';
 import Drawer from '../components/Drawer';
 import { ImageGenTab } from '../components/settings/ImageGenTab';
 import LocalSetupPanel from '../components/settings/LocalSetupPanel';
@@ -1183,7 +1183,7 @@ export default function VideoGen() {
                     : textEncoderOptionBlocked ? `Download the ${selectedTextEncoder?.label || 'selected'} text encoder before generating`
                     : icWeightsBlocked ? `Download the ${icSpec?.label || 'IC-LoRA'} weight before generating`
                     : extendModeBlocked ? 'Pick a prior render and wait for the last frame to extract before generating'
-                    : a2vModeBlocked ? (currentModel?.runtime !== 'ltx2'
+                    : a2vModeBlocked ? (!isLtx2FamilyRuntime(currentModel?.runtime)
                       ? 'a2v mode requires an ltx2-runtime model — pick one from the Model dropdown'
                       : 'Pick an audio file before generating')
                     : keyframesBlocked ? keyframesError

--- a/data.reference/media-models.json
+++ b/data.reference/media-models.json
@@ -79,6 +79,28 @@
         }
       },
       {
+        "id": "ltx25_mlx_q8",
+        "name": "LTX-2.5 MLX Q8 (~68 GB, Apple Silicon)",
+        "repo": "MrMofer/ltx-2.5-mlx-q8",
+        "revision": "f1b56e7dc89f71a9af2cddac787b89ed22a8b7fc",
+        "runtime": "ltx25",
+        "steps": 8,
+        "guidance": 3,
+        "disclosure": {
+          "modelCardUrl": "https://huggingface.co/MrMofer/ltx-2.5-mlx-q8",
+          "weightsLicense": {
+            "name": "LTX-2.x Community License",
+            "url": "https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md"
+          },
+          "runtimeLicense": {
+            "name": "MIT",
+            "url": "https://github.com/MrMoferFRAN/ltx-2-mlx/blob/57952288076766abe27dda3a774b2c24f7346977/LICENSE"
+          },
+          "estimatedDownloadGb": 67.7,
+          "reviewedAt": "2026-08-09"
+        }
+      },
+      {
         "id": "minimax_h3_8bit",
         "name": "MiniMax H3 MLX 8-bit (joint video + audio, ~103 GB download, 128 GB RAM)",
         "repo": "pipenetwork/MiniMax-H3-MLX-8bit",

--- a/scripts/generate_ltx2.py
+++ b/scripts/generate_ltx2.py
@@ -64,6 +64,7 @@ import sys
 from pathlib import Path
 from typing import NoReturn
 
+DISTILLED_LORA_25 = "ltx-2.5-22b-distilled-lora-450.safetensors"
 DISTILLED_LORA_V11 = "ltx-2.3-22b-distilled-lora-384-1.1.safetensors"
 DISTILLED_LORA_LEGACY = "ltx-2.3-22b-distilled-lora-384.safetensors"
 
@@ -365,7 +366,9 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--negative-prompt", default="")
     p.add_argument("--output", required=True, help="Output .mp4 path")
     p.add_argument("--model", required=True, help="HF repo id or local path (e.g. dgrauet/ltx-2.3-mlx-q4)")
-    p.add_argument("--gemma", default="mlx-community/gemma-3-12b-it-4bit")
+    p.add_argument("--gemma", default=None,
+                   help="Shared Gemma repo for LTX-2.3. Omit on LTX-2.5 packs that "
+                        "ship Gemma 4 under text_encoder/.")
     p.add_argument("--height", type=int, default=480)
     p.add_argument("--width", type=int, default=704)
     p.add_argument("--num-frames", type=int, default=97)
@@ -606,7 +609,7 @@ def _prefer_distilled_lora(pipe, requested: str | None) -> str:
         selected = next(
             (
                 filename
-                for filename in (DISTILLED_LORA_V11, DISTILLED_LORA_LEGACY)
+                for filename in (DISTILLED_LORA_25, DISTILLED_LORA_V11, DISTILLED_LORA_LEGACY)
                 if (Path(pipe.model_dir) / filename).exists()
             ),
             DISTILLED_LORA_LEGACY,
@@ -616,6 +619,13 @@ def _prefer_distilled_lora(pipe, requested: str | None) -> str:
     return selected
 
 
+def _gemma_kwargs(args: argparse.Namespace) -> dict:
+    """LTX-2.5 packs ship Gemma 4 under text_encoder/; omit the 2.3 shared encoder."""
+    if args.gemma:
+        return {"gemma_model_id": args.gemma}
+    return {}
+
+
 def run_two_stage(args: argparse.Namespace, image: str | None = None) -> str:
     """T2V/I2V path that honors CFG via the dgrauet two-stage pipeline."""
     TwoStagePipeline = _resolve_pipeline("TI2VidTwoStagesPipeline", "TwoStagePipeline")
@@ -623,10 +633,10 @@ def run_two_stage(args: argparse.Namespace, image: str | None = None) -> str:
     emit_stage(1, 0, 1, "Loading model")
     pipe = TwoStagePipeline(
         model_dir=args.model,
-        gemma_model_id=args.gemma,
         dev_transformer=args.dev_transformer or "transformer-dev.safetensors",
         distilled_lora=args.distilled_lora or DISTILLED_LORA_LEGACY,
         distilled_lora_strength=args.lora_strength,
+        **_gemma_kwargs(args),
     )
     _prefer_distilled_lora(pipe, args.distilled_lora)
     _apply_user_loras(pipe, args.user_lora_specs)
@@ -654,7 +664,7 @@ def run_text(args: argparse.Namespace) -> str:
     OneStagePipeline = _resolve_pipeline("TI2VidOneStagePipeline", "TextToVideoPipeline")
     emit_status(f"Loading T2V pipeline ({args.model})…")
     emit_stage(1, 0, 1, "Loading model")
-    pipe = OneStagePipeline(model_dir=args.model, gemma_model_id=args.gemma)
+    pipe = OneStagePipeline(model_dir=args.model, **_gemma_kwargs(args))
     _apply_user_loras(pipe, args.user_lora_specs)
     bind_output_fps(pipe, args.fps)
     emit_stage(1, 1, 1, "Loaded")
@@ -676,7 +686,7 @@ def run_image(args: argparse.Namespace) -> str:
     OneStagePipeline = _resolve_pipeline("TI2VidOneStagePipeline", "ImageToVideoPipeline")
     emit_status(f"Loading I2V pipeline ({args.model})…")
     emit_stage(1, 0, 1, "Loading model")
-    pipe = OneStagePipeline(model_dir=args.model, gemma_model_id=args.gemma)
+    pipe = OneStagePipeline(model_dir=args.model, **_gemma_kwargs(args))
     _apply_user_loras(pipe, args.user_lora_specs)
     bind_output_fps(pipe, args.fps)
     emit_stage(1, 1, 1, "Loaded")
@@ -760,10 +770,10 @@ def run_fflf(args: argparse.Namespace) -> str:
     emit_stage(1, 0, 1, "Loading model")
     pipe = KeyframeInterpolationPipeline(
         model_dir=args.model,
-        gemma_model_id=args.gemma,
         dev_transformer=dev_transformer,
         distilled_lora=distilled_lora,
         distilled_lora_strength=args.lora_strength,
+        **_gemma_kwargs(args),
     )
     _prefer_distilled_lora(pipe, args.distilled_lora)
     _apply_user_loras(pipe, args.user_lora_specs)
@@ -803,7 +813,7 @@ def run_extend(args: argparse.Namespace) -> str:
         raise SystemExit("--extend-from-video is required for extend mode")
     emit_status(f"Loading Extend pipeline ({args.model})…")
     emit_stage(1, 0, 1, "Loading model")
-    pipe = ExtendPipeline(model_dir=args.model, gemma_model_id=args.gemma)
+    pipe = ExtendPipeline(model_dir=args.model, **_gemma_kwargs(args))
     _apply_user_loras(pipe, args.user_lora_specs)
     emit_stage(1, 1, 1, "Loaded")
     emit_status(f"Extending video {args.extend_direction} by {args.extend_frames} latent frames…")
@@ -857,7 +867,7 @@ def run_a2v(args: argparse.Namespace) -> str:
         raise SystemExit("--audio is required for a2v mode")
     emit_status(f"Loading A2V pipeline ({args.model})…")
     emit_stage(1, 0, 1, "Loading model")
-    pipe = AudioToVideoPipeline(model_dir=args.model, gemma_model_id=args.gemma)
+    pipe = AudioToVideoPipeline(model_dir=args.model, **_gemma_kwargs(args))
     _prefer_distilled_lora(pipe, args.distilled_lora)
     _apply_user_loras(pipe, args.user_lora_specs)
     emit_stage(1, 1, 1, "Loaded")
@@ -960,7 +970,7 @@ def run_ic_lora(args: argparse.Namespace) -> str:
         # which weights the reference conditioning). Upstream's CLI defaults the
         # same way.
         lora_paths=[(args.ic_lora_path, 1.0)],
-        gemma_model_id=args.gemma,
+        **_gemma_kwargs(args),
     )
     # User LoRAs go through _pending_loras (fused at DiT load), NOT lora_paths —
     # so they stack with the IC-LoRA above instead of displacing it.

--- a/scripts/generate_ltx2_teacache_test.py
+++ b/scripts/generate_ltx2_teacache_test.py
@@ -126,6 +126,18 @@ class GenerateLtx2TeaCacheTest(unittest.TestCase):
         with self.assertRaises(SystemExit):
             self.helper._resolve_pipeline("Nope1", "Nope2")
 
+    def test_prefers_25_distilled_lora_when_model_contains_it(self):
+        with tempfile.TemporaryDirectory() as model_dir:
+            Path(model_dir, self.helper.DISTILLED_LORA_25).touch()
+            Path(model_dir, self.helper.DISTILLED_LORA_V11).touch()
+            Path(model_dir, self.helper.DISTILLED_LORA_LEGACY).touch()
+            pipe = SimpleNamespace(
+                model_dir=Path(model_dir),
+                _distilled_lora=self.helper.DISTILLED_LORA_LEGACY,
+            )
+            selected = self.helper._prefer_distilled_lora(pipe, None)
+            self.assertEqual(selected, self.helper.DISTILLED_LORA_25)
+
     def test_prefers_v11_distilled_lora_when_model_contains_it(self):
         with tempfile.TemporaryDirectory() as model_dir:
             Path(model_dir, self.helper.DISTILLED_LORA_V11).touch()

--- a/scripts/setup-image-video.sh
+++ b/scripts/setup-image-video.sh
@@ -10,6 +10,7 @@
 #   PORTOS_DATA    Path to PortOS data dir (default: ./data, resolved from $REPO_ROOT)
 #   INSTALL_VIDEO  '1' to also install mlx_video for LTX video generation (default: 1 on macOS, 0 on Windows)
 #   INSTALL_LTX2   '1' to also clone + uv-sync dgrauet/ltx-2-mlx at ~/.portos/ltx-2-mlx for the second-gen LTX-2.3 pipeline (proper keyframe interpolation, true video extend, audio-to-video). Default: 0; opt in with INSTALL_LTX2=1.
+#   INSTALL_LTX25  '1' to clone + uv-sync MrMofer's ltx-2.5 fork at ~/.portos/ltx-2.5-mlx (Apple Silicon). The 2.3 pin cannot load LTX-2.5 weights. Default: 0.
 #   INSTALL_MINIMAX_H3 '1' to install the pinned MiniMax H3 MLX runtime at ~/.portos/minimax-h3-mlx (Apple Silicon). Weights remain a separate explicit Video Gen download. Default: 0.
 #   INSTALL_MINIMAX_H3_CUDA '1' to install the MiniMax H3 CUDA runtime at ~/.portos/minimax-h3-cuda (Windows + NVIDIA), via diffusers' MiniMaxH3ModularPipeline. Weights remain a separate explicit Video Gen download (~144 GB). Default: 0.
 #   INSTALL_FLUX2  '1' to also bootstrap a separate venv at ~/.portos/venv-flux2 for FLUX.2-klein (default: 1 on macOS, 0 elsewhere)
@@ -67,7 +68,7 @@ mkdir -p "${PORTOS_DATA}/video-thumbnails"
 # install ever starts — which on Linux/CPU/CUDA blocks the advertised
 # `INSTALL_ACESTEP=1 bash …` path. A bare `bash setup-image-video.sh` still
 # installs mflux as before.
-ANY_BYOV="${INSTALL_LTX2:-0}${INSTALL_WAN22:-0}${INSTALL_HUNYUAN:-0}${INSTALL_MINIMAX_H3:-0}${INSTALL_MINIMAX_H3_CUDA:-0}${INSTALL_MUSICGEN:-0}${INSTALL_AUDIOLDM2:-0}${INSTALL_ACESTEP:-0}${INSTALL_MINIMAX_MUSIC3:-0}${INSTALL_MUSCRIPTOR:-0}"
+ANY_BYOV="${INSTALL_LTX2:-0}${INSTALL_LTX25:-0}${INSTALL_WAN22:-0}${INSTALL_HUNYUAN:-0}${INSTALL_MINIMAX_H3:-0}${INSTALL_MINIMAX_H3_CUDA:-0}${INSTALL_MUSICGEN:-0}${INSTALL_AUDIOLDM2:-0}${INSTALL_ACESTEP:-0}${INSTALL_MINIMAX_MUSIC3:-0}${INSTALL_MUSCRIPTOR:-0}"
 # "no BYOV runtime was requested" = the concatenation contains no non-zero
 # character. Matching a literal string of zeros instead made this a counting
 # exercise that the string and the variable list had to agree on — and they had
@@ -273,6 +274,47 @@ if [[ "$INSTALL_LTX2" == "1" ]]; then
     exit 1
   fi
   echo "✅ ltx-2-mlx venv ready: ${LTX2_PY}"
+fi
+
+INSTALL_LTX25="${INSTALL_LTX25:-0}"
+if [[ "$INSTALL_LTX25" == "1" ]]; then
+  # MrMofer's ltx25 fork of dgrauet/ltx-2-mlx. Same pipeline API as the 2.3
+  # runtime (generate_ltx2.py), different checkout — LTX-2.5 weights do not
+  # load on the frozen 2.3 pin.
+  if ! have uv; then
+    echo "❌ INSTALL_LTX25=1 requires the 'uv' Python installer. Install with:" >&2
+    echo "   curl -LsSf https://astral.sh/uv/install.sh | sh" >&2
+    exit 1
+  fi
+  if ! have git; then
+    echo "❌ INSTALL_LTX25=1 requires git." >&2
+    exit 1
+  fi
+  LTX25_PIN="${LTX25_PIN:-57952288076766abe27dda3a774b2c24f7346977}"
+  LTX25_DIR="${HOME}/.portos/ltx-2.5-mlx"
+  LTX25_PY="${LTX25_DIR}/.venv/bin/python3"
+  mkdir -p "${HOME}/.portos"
+  if [[ ! -d "${LTX25_DIR}/.git" ]]; then
+    echo "📦 Cloning MrMoferFRAN/ltx-2-mlx (pinned to ${LTX25_PIN:0:12})..."
+    git clone https://github.com/MrMoferFRAN/ltx-2-mlx.git "${LTX25_DIR}"
+  else
+    echo "📦 Fetching ltx-2.5-mlx updates..."
+    (cd "${LTX25_DIR}" && git fetch origin)
+  fi
+  echo "📦 Checking out pinned commit ${LTX25_PIN:0:12}..."
+  git_checkout_pin "${LTX25_DIR}" "${LTX25_PIN}"
+  if [[ ! -x "${LTX25_PY}" ]]; then
+    echo "📦 Creating ltx-2.5-mlx venv with Python 3.11..."
+    (cd "${LTX25_DIR}" && uv venv --python 3.11)
+  fi
+  echo "📦 Syncing ltx-2.5-mlx packages (uv sync, no extras)..."
+  (cd "${LTX25_DIR}" && uv sync)
+  if ! "${LTX25_PY}" -c "import ltx_pipelines_mlx" 2>/dev/null; then
+    echo "❌ ltx-2.5-mlx synced but 'import ltx_pipelines_mlx' failed." >&2
+    echo "   Re-run with: rm -rf ${LTX25_DIR}/.venv && bash $0" >&2
+    exit 1
+  fi
+  echo "✅ ltx-2.5-mlx venv ready: ${LTX25_PY}"
 fi
 
 INSTALL_WAN22="${INSTALL_WAN22:-0}"
@@ -809,6 +851,9 @@ echo "   LoRAs:     ${PORTOS_DATA}/loras"
 echo "   Videos:    ${PORTOS_DATA}/videos"
 if [[ "$INSTALL_LTX2" == "1" ]]; then
   echo "   LTX-2.3:   ${HOME}/.portos/ltx-2-mlx/.venv/bin/python3 (separate venv, dgrauet pipeline @ ${LTX2_PIN:0:12})"
+fi
+if [[ "$INSTALL_LTX25" == "1" ]]; then
+  echo "   LTX-2.5:   ${HOME}/.portos/ltx-2.5-mlx/.venv/bin/python3 (MrMofer ltx25 fork @ ${LTX25_PIN:0:12})"
 fi
 if [[ "$INSTALL_WAN22" == "1" ]]; then
   echo "   Wan 2.2:  ${HOME}/.portos/mlx-gen/.venv/bin/python3 (MLX-Gen @ ${WAN22_PIN:0:12})"

--- a/server/lib/huggingfaceModel.js
+++ b/server/lib/huggingfaceModel.js
@@ -66,7 +66,7 @@ export const searchHuggingfaceModels = async (query, { pipeline, limit = 12, fet
 // default-mlx_video-plus-denylist. Kept in sync with BYOV_RUNTIME_INFO's keys
 // in server/services/videoGen/runtimes.js (the classifier stays pure, so the
 // self-service exclusions live here rather than importing that stateful module).
-export const ADDABLE_VIDEO_RUNTIMES = Object.freeze(['mlx_video', 'ltx2']);
+export const ADDABLE_VIDEO_RUNTIMES = Object.freeze(['mlx_video', 'ltx2', 'ltx25']);
 
 // Detect the underlying video runtime family from the classification blob, so
 // the allowlist above can refuse the rest symmetrically with the image path.
@@ -87,6 +87,7 @@ const detectVideoRuntime = (blob) => {
     // pipeline), not notapalindrome's `mlx_video` — auto-detect that from the
     // author/marker so an added dgrauet repo routes to the right generator.
     // Everything else LTX defaults to mlx_video (the shipped default runtime).
+    if (/ltx[\s._-]?2\.5|ltx25|mrmofer/.test(blob)) return { runtime: 'ltx25' };
     if (/dgrauet|ltx[\s._-]?pipelines/.test(blob)) return { runtime: 'ltx2' };
     return { runtime: 'mlx_video' };
   }
@@ -109,7 +110,7 @@ export const ADDABLE_IMAGE_RUNNERS = Object.freeze(
 // Default steps/guidance per target so an added entry renders sanely without
 // the user having to know each pipeline's sweet spot. Mirrors the shipped
 // DEFAULT_REGISTRY entries.
-const VIDEO_DEFAULTS = { mlx_video: { steps: 25, guidance: 3.0 }, ltx2: { steps: 8, guidance: 3.0 } };
+const VIDEO_DEFAULTS = { mlx_video: { steps: 25, guidance: 3.0 }, ltx2: { steps: 8, guidance: 3.0 }, ltx25: { steps: 8, guidance: 3.0 } };
 const IMAGE_DEFAULTS = {
   [RUNNER_FAMILIES.MFLUX]: { steps: 20, guidance: 3.5 },
   [RUNNER_FAMILIES.FLUX2]: { steps: 8, guidance: 3.5 },

--- a/server/lib/huggingfaceModel.test.js
+++ b/server/lib/huggingfaceModel.test.js
@@ -143,6 +143,14 @@ describe('classifyHfMediaModel — happy paths', () => {
     })).toEqual({ kind: 'video', runtime: 'ltx2', format: 'safetensors' });
   });
 
+  it('auto-detects an LTX-2.5 MLX repo as the ltx25 runtime', () => {
+    expect(classifyHfMediaModel({
+      repo: 'MrMofer/ltx-2.5-mlx-q8',
+      model: hf({ files: ['transformer-distilled.safetensors'], tags: ['ltx-2.5'] }),
+      isWindows: false,
+    })).toEqual({ kind: 'video', runtime: 'ltx25', format: 'safetensors' });
+  });
+
   it('detects a Qwen-Image-Edit repo and stamps the edit pipeline + editOnly', () => {
     const c = classifyHfMediaModel({
       repo: 'Qwen/Qwen-Image-Edit',

--- a/server/lib/mediaModels.js
+++ b/server/lib/mediaModels.js
@@ -238,6 +238,9 @@ const DEFAULT_REGISTRY = {
       // via `INSTALL_LTX2=1 bash scripts/setup-image-video.sh`.
       { id: 'ltx23_dgrauet_q4',   name: 'LTX-2.3 dgrauet Q4 (~16 GB, true keyframes)', repo: 'dgrauet/ltx-2.3-mlx-q4', runtime: 'ltx2', steps: 8, guidance: 3.0 },
       { id: 'ltx23_dgrauet_q8',   name: 'LTX-2.3 dgrauet Q8 (~25 GB, true keyframes)', repo: 'dgrauet/ltx-2.3-mlx-q8', runtime: 'ltx2', steps: 8, guidance: 3.0 },
+      // LTX-2.5 Q8 on MrMofer's ltx25 fork of dgrauet/ltx-2-mlx. The 2.3 pin
+      // cannot load these weights; INSTALL_LTX25 provisions a sibling venv.
+      { id: 'ltx25_mlx_q8', name: 'LTX-2.5 MLX Q8 (~68 GB, Apple Silicon)', repo: 'MrMofer/ltx-2.5-mlx-q8', revision: 'f1b56e7dc89f71a9af2cddac787b89ed22a8b7fc', runtime: 'ltx25', steps: 8, guidance: 3.0 },
       // MiniMax H3 joint video+audio through PipeNetwork's pinned MLX port.
       // The quantized DiT is one HF snapshot; the released conditioner + VAEs
       // are an exact selective file set from MiniMax's upstream snapshot. Both

--- a/server/lib/mediaModels.test.js
+++ b/server/lib/mediaModels.test.js
@@ -57,6 +57,19 @@ describe('mediaModels registry', () => {
     expect(list.every((m) => m.id && m.name)).toBe(true);
   });
 
+  it('ships LTX-2.5 MLX Q8 as a sibling runtime of the 2.3 dgrauet pin', async () => {
+    const { loadMediaModels } = await import('./mediaModels.js');
+    const ltx25 = loadMediaModels().video.macos.find((model) => model.id === 'ltx25_mlx_q8');
+    expect(ltx25).toMatchObject({
+      runtime: 'ltx25',
+      repo: 'MrMofer/ltx-2.5-mlx-q8',
+      revision: 'f1b56e7dc89f71a9af2cddac787b89ed22a8b7fc',
+      steps: 8,
+    });
+    expect(ltx25.disclosure.weightsLicense.name).toBe('LTX-2.x Community License');
+    expect(ltx25.disclosure.estimatedDownloadGb).toBe(67.7);
+  });
+
   it('ships MiniMax H3 as a pinned, keyframe-capable 128 GB BYOV profile', async () => {
     const { loadMediaModels } = await import('./mediaModels.js');
     // H3 is an Apple-silicon MLX runtime, so inspect the shipped macOS catalog

--- a/server/lib/runners.js
+++ b/server/lib/runners.js
@@ -57,6 +57,13 @@ export const isVideoLoraFamily = (family) => VIDEO_LORA_FAMILY_SET.has(family);
 export const MINIMAX_H3_RUNTIMES = Object.freeze(['minimax_h3', 'minimax_h3_cuda']);
 const MINIMAX_H3_RUNTIME_SET = new Set(MINIMAX_H3_RUNTIMES);
 export const isMiniMaxH3Runtime = (runtime) => MINIMAX_H3_RUNTIME_SET.has(runtime);
+// dgrauet's LTX-2.3 pin (`ltx2`) and the LTX-2.5 fork (`ltx25`) share the
+// same pipeline surface — true FFLF, video-conditioned extend, a2v, IC-LoRA —
+// so capability gates ask this predicate instead of naming one id. The venvs
+// stay separate: 2.5 is a different checkout and cannot load on the 2.3 pin.
+export const LTX2_FAMILY_RUNTIMES = Object.freeze(['ltx2', 'ltx25']);
+const LTX2_FAMILY_RUNTIME_SET = new Set(LTX2_FAMILY_RUNTIMES);
+export const isLtx2FamilyRuntime = (runtime) => LTX2_FAMILY_RUNTIME_SET.has(runtime);
 
 // The family an INSTALLED LoRA belongs to. `loraCompatKey` is the refined key
 // (e.g. flux2-9b) written by the importer; `runnerFamily` is the coarse legacy
@@ -91,8 +98,8 @@ export const isMlxVideoLtxLoraCapable = (model) => {
 
 // Map a video-model registry entry (which carries `runtime`, not `runner`) to
 // the LoRA family the picker filters on. Two runtimes can fuse user LoRAs:
-//   - dgrauet's `ltx2` — its `ltx_pipelines_mlx` pipelines honor a
-//     `_pending_loras` hook (see scripts/generate_ltx2.py), any LTX-2.3 quant.
+//   - dgrauet's `ltx2` / MrMofer's `ltx25` — `ltx_pipelines_mlx` honors a
+//     `_pending_loras` hook (see scripts/generate_ltx2.py).
 //   - notapalindrome's `mlx_video` on a non-quantized LTX-2.x model — fused
 //     offline into the transformer weights (see isMlxVideoLtxLoraCapable +
 //     scripts/generate_av_lora.py).
@@ -106,7 +113,7 @@ export const isMlxVideoLtxLoraCapable = (model) => {
 // The wan22 / hunyuan runtimes (and quantized mlx_video models) have no LoRA
 // path, so they return null ("no LoRA support") and the VideoGen picker hides.
 export const videoLoraFamily = (model) => {
-  if (model?.runtime === 'ltx2' || isMlxVideoLtxLoraCapable(model)) return VIDEO_LORA_FAMILIES.LTX_VIDEO;
+  if (isLtx2FamilyRuntime(model?.runtime) || isMlxVideoLtxLoraCapable(model)) return VIDEO_LORA_FAMILIES.LTX_VIDEO;
   if (model?.runtime === 'minimax_h3' && model?.runtimeLoraCapable === true) return VIDEO_LORA_FAMILIES.MINIMAX_H3;
   return null;
 };

--- a/server/lib/runners.test.js
+++ b/server/lib/runners.test.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 
-import { RUNNER_FAMILIES, VIDEO_LORA_FAMILIES, MINIMAX_H3_RUNTIMES, videoLoraFamily, isMiniMaxH3Runtime, isMlxVideoLtxLoraCapable, loraFamilyOf, isMflux, isFlux2, isZImage, isErnie, isHiDream, isQwen, flux2VariantFromModel, loraCompatKey, composeCompatKey } from './runners.js';
+import { RUNNER_FAMILIES, VIDEO_LORA_FAMILIES, MINIMAX_H3_RUNTIMES, LTX2_FAMILY_RUNTIMES, videoLoraFamily, isMiniMaxH3Runtime, isLtx2FamilyRuntime, isMlxVideoLtxLoraCapable, loraFamilyOf, isMflux, isFlux2, isZImage, isErnie, isHiDream, isQwen, flux2VariantFromModel, loraCompatKey, composeCompatKey } from './runners.js';
 
 const __dirname_self = dirname(fileURLToPath(import.meta.url));
 const CLIENT_MIRROR_PATH = join(__dirname_self, '..', '..', 'client', 'src', 'lib', 'runnerFamilies.js');
@@ -130,6 +130,8 @@ describe('VIDEO_LORA_FAMILIES / videoLoraFamily', () => {
     expect(text).toMatch(/export const loraFamilyOf/);
     expect(text).toMatch(/export const isMiniMaxH3Runtime/);
     expect(text).toMatch(/'minimax_h3', 'minimax_h3_cuda'/);
+    expect(text).toMatch(/export const isLtx2FamilyRuntime/);
+    expect(text).toMatch(/'ltx2', 'ltx25'/);
   });
 });
 
@@ -223,4 +225,18 @@ describe('isMiniMaxH3Runtime', () => {
     // Not even when a stale/synced payload claims the MLX port's probe verdict.
     expect(videoLoraFamily({ runtime: 'minimax_h3_cuda', runtimeLoraCapable: true })).toBe(null);
   });
+});
+
+describe('isLtx2FamilyRuntime', () => {
+  it('covers the 2.3 pin and the 2.5 fork, and nothing else', () => {
+    expect(LTX2_FAMILY_RUNTIMES).toEqual(['ltx2', 'ltx25']);
+    expect(isLtx2FamilyRuntime('ltx2')).toBe(true);
+    expect(isLtx2FamilyRuntime('ltx25')).toBe(true);
+    expect(videoLoraFamily({ runtime: 'ltx25' })).toBe(VIDEO_LORA_FAMILIES.LTX_VIDEO);
+  });
+
+  it.each(['mlx_video', 'wan22', 'hunyuan', 'minimax_h3', 'ltx', '', undefined, null])(
+    'reports %s as not an LTX-2 family runtime',
+    (runtime) => { expect(isLtx2FamilyRuntime(runtime)).toBe(false); },
+  );
 });

--- a/server/lib/videoContinuity.js
+++ b/server/lib/videoContinuity.js
@@ -71,7 +71,7 @@ export const LATENT_FRAME_STRIDE = 8;
 
 /**
  * Runtimes whose helper can condition on a source *video* rather than a still.
- * `ltx2` routes to ExtendPipeline.extend_from_video; the `minimax_h3`
+ * `ltx2` / `ltx25` route to ExtendPipeline.extend_from_video; the `minimax_h3`
  * runtimes, `wan22`,
  * `hunyuan` and `mlx_video` have no equivalent and take the 'frame' path.
  *
@@ -88,7 +88,7 @@ export const LATENT_FRAME_STRIDE = 8;
  * The two questions genuinely differ: "can the user pick Extend mode?" vs "can
  * this runtime condition on a source VIDEO?", and only the latter belongs here.
  */
-export const CONTEXT_WINDOW_RUNTIMES = new Set(['ltx2']);
+export const CONTEXT_WINDOW_RUNTIMES = new Set(['ltx2', 'ltx25']);
 
 /** True when the model's runtime exposes a video-conditioned extend path. */
 export const supportsContextWindow = (model) => CONTEXT_WINDOW_RUNTIMES.has(model?.runtime);

--- a/server/lib/videoContinuity.parity.test.js
+++ b/server/lib/videoContinuity.parity.test.js
@@ -52,7 +52,7 @@ describe('continuation context window — server/client parity', () => {
   });
 
   it('agrees on which runtimes can use a window', () => {
-    for (const runtime of ['ltx2', 'mlx_video', 'minimax_h3', 'wan22', 'hunyuan', undefined]) {
+    for (const runtime of ['ltx2', 'ltx25', 'mlx_video', 'minimax_h3', 'wan22', 'hunyuan', undefined]) {
       expect(clientSupportsContextWindow({ runtime })).toBe(serverSupportsContextWindow({ runtime }));
     }
     expect(clientSupportsContextWindow(null)).toBe(serverSupportsContextWindow(null));

--- a/server/lib/videoDisclosure.js
+++ b/server/lib/videoDisclosure.js
@@ -54,6 +54,7 @@ const RUNTIME_LICENSE = {
   // installs — NOT the unrelated PyPI `mlx_video`).
   mlx_video: { name: 'MIT', url: 'https://pypi.org/project/mlx-video-with-audio/' },
   ltx2: { name: 'MIT', url: 'https://github.com/dgrauet/ltx-2-mlx/blob/main/LICENSE' },
+  ltx25: { name: 'MIT', url: 'https://github.com/MrMoferFRAN/ltx-2-mlx/blob/57952288076766abe27dda3a774b2c24f7346977/LICENSE' },
   wan22: { name: 'MIT', url: 'https://github.com/lpalbou/mlx-gen/blob/main/LICENSE' },
   minimax_h3: {
     name: 'Apache-2.0',
@@ -89,6 +90,11 @@ const MINIMAX_H3_TERMS_GATE = Object.freeze({
     'United States of America',
   ]),
 });
+
+const LTX_2X_WEIGHTS = {
+  name: 'LTX-2.x Community License',
+  url: 'https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md',
+};
 
 const hfModelCard = (repo) => `https://huggingface.co/${repo}`;
 
@@ -183,6 +189,17 @@ export const VIDEO_MODEL_DISCLOSURES = Object.freeze({
       weightsLicense: customLicense('dgrauet/ltx-2.3-mlx-q8'),
       runtimeLicense: RUNTIME_LICENSE.ltx2,
       estimatedDownloadGb: 87.5,
+      reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
+    },
+  },
+  ltx25_mlx_q8: {
+    shippedRepo: 'MrMofer/ltx-2.5-mlx-q8',
+    disclosure: {
+      modelCardUrl: hfModelCard('MrMofer/ltx-2.5-mlx-q8'),
+      weightsLicense: LTX_2X_WEIGHTS,
+      runtimeLicense: RUNTIME_LICENSE.ltx25,
+      // Hugging Face usedStorage for the pinned snapshot (decimal GB).
+      estimatedDownloadGb: 67.7,
       reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     },
   },

--- a/server/lib/videoModeProfiles.js
+++ b/server/lib/videoModeProfiles.js
@@ -57,6 +57,7 @@ const MINIMAX_H3_MODE_SET = Object.freeze(['text', 'image', 'fflf']);
 export const VIDEO_RUNTIME_MODES = Object.freeze({
   mlx_video: Object.freeze(['text', 'image', 'fflf', 'extend']),
   ltx2: Object.freeze(['text', 'image', 'fflf', 'extend']),
+  ltx25: Object.freeze(['text', 'image', 'fflf', 'extend']),
   wan22: Object.freeze(['text', 'image']),
   minimax_h3: MINIMAX_H3_MODE_SET,
   minimax_h3_cuda: MINIMAX_H3_MODE_SET,

--- a/server/lib/videoModeProfiles.test.js
+++ b/server/lib/videoModeProfiles.test.js
@@ -23,6 +23,7 @@ describe('VIDEO_RUNTIME_MODES', () => {
     // on lastFrameAnchored: false, so the mode still has to be offerable.
     expect(VIDEO_RUNTIME_MODES.mlx_video).toContain('fflf');
     expect(VIDEO_RUNTIME_MODES.ltx2).toContain('fflf');
+    expect(VIDEO_RUNTIME_MODES.ltx25).toEqual(VIDEO_RUNTIME_MODES.ltx2);
     expect(VIDEO_RUNTIME_MODES.minimax_h3).toContain('fflf');
     expect(VIDEO_RUNTIME_MODES.wan22).not.toContain('fflf');
   });

--- a/server/services/videoGen/local.js
+++ b/server/services/videoGen/local.js
@@ -40,7 +40,7 @@ import { inspectModelCache, findCachedRepoFile } from '../../lib/hfCache.js';
 import { safeChildProcessEnv } from '../../lib/processEnv.js';
 import { makeVideoGenLineHandler, finalizeGeneratedVideo, isWatchdogSuccess, describeSignalDeath, describeRenderConditioning, RENDER_INPUTS_VERSION } from './generateVideoHelpers.js';
 import { assertSafeLoraFilename, getLoraKeyLayout } from '../loras.js';
-import { videoLoraFamily } from '../../lib/runners.js';
+import { videoLoraFamily, isLtx2FamilyRuntime } from '../../lib/runners.js';
 import {
   publicVideoTextEncoderOptions, resolveVideoTextEncoder,
 } from '../../lib/videoTextEncoders.js';
@@ -49,7 +49,6 @@ import {
   assertIcReferenceCount, icResolutionIssue,
 } from '../../lib/icLoraWeights.js';
 import {
-  LTX2_VENV_PYTHON,
   LTX2_HELPER_SCRIPT,
   WAN22_VENV_PYTHON,
   WAN22_HELPER_SCRIPT,
@@ -294,7 +293,7 @@ export const resolveT2vTwoStageOverride = ({
 }) => {
   const enabled = ['1', 'true', 'yes', 'on']
     .includes(String(env.PORTOS_T2V_TWO_STAGE ?? '').trim().toLowerCase());
-  if (!enabled || runtime !== 'ltx2') return null;
+  if (!enabled || !isLtx2FamilyRuntime(runtime)) return null;
   // Only the default text mode — anything explicitly fflf/a2v/extend/image
   // is conditioned and out of scope for the T2V Standard experiment.
   if (mode != null && mode !== 'text') return null;
@@ -422,7 +421,7 @@ export const icLoraArgs = ({ mode, width, height, icReferencePaths, icLoraWeight
 };
 
 const buildLtx2Args = ({ model, prompt, negativePrompt, width, height, numFrames, fps, steps, stage2Steps, guidance, seed, sourceImagePath, lastImagePath, keyframes, extendFromVideoPath, audioFilePath, audioStartSec, mode, imageStrength, disableAudio, outputPath, textEncoderRepo, loras, icReferencePaths, icLoraWeightPath, icStrength, icAttentionStrength, icSkipStage2 }) => {
-  assertByovRuntimeInstalled('ltx2');
+  assertByovRuntimeInstalled(model.runtime);
   // Map PortOS UI modes to the helper's subcommand. Native extend on ltx2
   // routes to ExtendPipeline.extend_from_video — conditions on the entire
   // source video's latent (motion + visual content) rather than just the
@@ -523,7 +522,6 @@ const buildLtx2Args = ({ model, prompt, negativePrompt, width, height, numFrames
     '--prompt', prompt,
     '--output', outputPath,
     '--model', model.repo,
-    '--gemma', textEncoderRepo,
     '--width', String(width),
     '--height', String(height),
     '--num-frames', String(numFrames),
@@ -532,6 +530,10 @@ const buildLtx2Args = ({ model, prompt, negativePrompt, width, height, numFrames
     '--steps', String(steps),
     '--cfg-scale', String(guidance),
   ];
+  // LTX-2.5 packs ship Gemma 4 under text_encoder/. Passing the shared 2.3
+  // Gemma 3 encoder would either fail load or silently condition on the wrong
+  // model. The 2.3 runtime still needs the explicit shared encoder.
+  if (model.runtime === 'ltx2') args.push('--gemma', textEncoderRepo);
   // User LoRAs — fused into the transformer via the pipeline's _pending_loras
   // hook. Emitted as a JSON list of { path, strength }; generate_ltx2.py sets
   // pipe._pending_loras before generation so the deltas fuse at load time
@@ -582,7 +584,7 @@ const buildLtx2Args = ({ model, prompt, negativePrompt, width, height, numFrames
       icStrength, icAttentionStrength, icSkipStage2,
     }));
   }
-  return { bin: LTX2_VENV_PYTHON, args };
+  return { bin: BYOV_RUNTIME_INFO[model.runtime].venvPython, args };
 };
 
 // The render-side adapter for the shared mode/source contract: `prepareParams`
@@ -847,7 +849,7 @@ const buildArgs = ({ pythonPath, modelId, model, wanModelPath, wanRequiredWeight
   // Route to the dgrauet/ltx-2-mlx helper when the model declares the new
   // runtime. Existing notapalindrome models default to runtime: 'mlx_video'
   // (or undefined in legacy registries — see backfillRuntime in mediaModels.js).
-  if (model.runtime === 'ltx2') {
+  if (isLtx2FamilyRuntime(model.runtime)) {
     return buildLtx2Args({ model, prompt, negativePrompt, width, height, numFrames, fps, steps, stage2Steps, guidance, seed, sourceImagePath, lastImagePath, keyframes, extendFromVideoPath, audioFilePath, audioStartSec, mode, imageStrength, disableAudio, outputPath, textEncoderRepo, loras, icReferencePaths, icLoraWeightPath, icStrength, icAttentionStrength, icSkipStage2 });
   }
   // IC-LoRA remix modes are an LTX-2 primitive (ICLoraPipeline) — no other

--- a/server/services/videoGen/local.js
+++ b/server/services/videoGen/local.js
@@ -420,7 +420,7 @@ export const icLoraArgs = ({ mode, width, height, icReferencePaths, icLoraWeight
   return args;
 };
 
-const buildLtx2Args = ({ model, prompt, negativePrompt, width, height, numFrames, fps, steps, stage2Steps, guidance, seed, sourceImagePath, lastImagePath, keyframes, extendFromVideoPath, audioFilePath, audioStartSec, mode, imageStrength, disableAudio, outputPath, textEncoderRepo, loras, icReferencePaths, icLoraWeightPath, icStrength, icAttentionStrength, icSkipStage2 }) => {
+const buildLtx2Args = ({ model, ltxModelPath, prompt, negativePrompt, width, height, numFrames, fps, steps, stage2Steps, guidance, seed, sourceImagePath, lastImagePath, keyframes, extendFromVideoPath, audioFilePath, audioStartSec, mode, imageStrength, disableAudio, outputPath, textEncoderRepo, loras, icReferencePaths, icLoraWeightPath, icStrength, icAttentionStrength, icSkipStage2 }) => {
   assertByovRuntimeInstalled(model.runtime);
   // Map PortOS UI modes to the helper's subcommand. Native extend on ltx2
   // routes to ExtendPipeline.extend_from_video — conditions on the entire
@@ -521,7 +521,7 @@ const buildLtx2Args = ({ model, prompt, negativePrompt, width, height, numFrames
     '--mode', helperMode,
     '--prompt', prompt,
     '--output', outputPath,
-    '--model', model.repo,
+    '--model', ltxModelPath || model.repo,
     '--width', String(width),
     '--height', String(height),
     '--num-frames', String(numFrames),
@@ -845,12 +845,12 @@ const buildHunyuanArgs = ({ model, prompt, negativePrompt, width, height, numFra
   return { bin: HUNYUAN_VENV_PYTHON, args };
 };
 
-const buildArgs = ({ pythonPath, modelId, model, wanModelPath, wanRequiredWeights, prompt, negativePrompt, width, height, numFrames, fps, steps, stage2Steps, guidance, seed, tiling, disableAudio, sourceImagePath, lastImagePath, keyframes, extendFromVideoPath, audioFilePath, audioStartSec, mode, imageStrength, textEncoderRepo, textEncoder, outputPath, loras, icReferencePaths, icLoraWeightPath, icStrength, icAttentionStrength, icSkipStage2 }) => {
+const buildArgs = ({ pythonPath, modelId, model, wanModelPath, wanRequiredWeights, ltxModelPath, prompt, negativePrompt, width, height, numFrames, fps, steps, stage2Steps, guidance, seed, tiling, disableAudio, sourceImagePath, lastImagePath, keyframes, extendFromVideoPath, audioFilePath, audioStartSec, mode, imageStrength, textEncoderRepo, textEncoder, outputPath, loras, icReferencePaths, icLoraWeightPath, icStrength, icAttentionStrength, icSkipStage2 }) => {
   // Route to the dgrauet/ltx-2-mlx helper when the model declares the new
   // runtime. Existing notapalindrome models default to runtime: 'mlx_video'
   // (or undefined in legacy registries — see backfillRuntime in mediaModels.js).
   if (isLtx2FamilyRuntime(model.runtime)) {
-    return buildLtx2Args({ model, prompt, negativePrompt, width, height, numFrames, fps, steps, stage2Steps, guidance, seed, sourceImagePath, lastImagePath, keyframes, extendFromVideoPath, audioFilePath, audioStartSec, mode, imageStrength, disableAudio, outputPath, textEncoderRepo, loras, icReferencePaths, icLoraWeightPath, icStrength, icAttentionStrength, icSkipStage2 });
+    return buildLtx2Args({ model, ltxModelPath, prompt, negativePrompt, width, height, numFrames, fps, steps, stage2Steps, guidance, seed, sourceImagePath, lastImagePath, keyframes, extendFromVideoPath, audioFilePath, audioStartSec, mode, imageStrength, disableAudio, outputPath, textEncoderRepo, loras, icReferencePaths, icLoraWeightPath, icStrength, icAttentionStrength, icSkipStage2 });
   }
   // IC-LoRA remix modes are an LTX-2 primitive (ICLoraPipeline) — no other
   // runtime has an equivalent. The route guards this too, but a non-route
@@ -1084,6 +1084,21 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
         wanRequiredWeights.push({ path: paths[i], role: roles[i] });
       }
     }
+  }
+  // Pinned LTX family entries (LTX-2.5 today) must render the verified
+  // snapshot, not whatever `main` snapshot_download would follow. Unpinned
+  // 2.3 entries keep passing the repo id so the helper's existing Hub resolve
+  // stays unchanged.
+  let ltxModelPath = model.repo;
+  if (isLtx2FamilyRuntime(model.runtime) && typeof model.revision === 'string' && model.revision) {
+    const cache = await inspectModelCache(model.repo, { revision: model.revision });
+    if (!cache.cached || !cache.snapshotPath) {
+      throw new ServerError(
+        `${model.name} revision ${model.revision.slice(0, 8)} is not fully cached. Download or repair it in Video Gen before rendering.`,
+        { status: 400, code: 'LTX2_MODEL_NOT_CACHED' },
+      );
+    }
+    ltxModelPath = cache.snapshotPath;
   }
   // Substituted prompt conditioner (#4081). `resolveVideoTextEncoder` returns
   // null for the stock choice — the whole override path stays dormant then —
@@ -1468,7 +1483,7 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
   // logic of the spawn-error handler so failure modes converge.
   let bin, args;
   try {
-    ({ bin, args } = buildArgs({ pythonPath, modelId, model: loraCapableModel, wanModelPath, wanRequiredWeights, prompt, negativePrompt, width: w, height: h, numFrames: parsedNumFrames, fps: parsedFps, steps: actualSteps, stage2Steps: actualStage2Steps, guidance: actualGuidance, seed: actualSeed, tiling, disableAudio, sourceImagePath: resolvedSourceImage, lastImagePath: resolvedLastImage, keyframes: resolvedKeyframes, extendFromVideoPath, audioFilePath, audioStartSec, mode, imageStrength: actualImageStrength, textEncoderRepo: actualTextEncoderRepo, textEncoder: resolvedTextEncoder, outputPath, loras: resolvedLoras, icReferencePaths: resolvedIcReferencePaths, icLoraWeightPath, icStrength: actualIcStrength, icAttentionStrength: actualIcAttentionStrength, icSkipStage2 }));
+    ({ bin, args } = buildArgs({ pythonPath, modelId, model: loraCapableModel, wanModelPath, wanRequiredWeights, ltxModelPath, prompt, negativePrompt, width: w, height: h, numFrames: parsedNumFrames, fps: parsedFps, steps: actualSteps, stage2Steps: actualStage2Steps, guidance: actualGuidance, seed: actualSeed, tiling, disableAudio, sourceImagePath: resolvedSourceImage, lastImagePath: resolvedLastImage, keyframes: resolvedKeyframes, extendFromVideoPath, audioFilePath, audioStartSec, mode, imageStrength: actualImageStrength, textEncoderRepo: actualTextEncoderRepo, textEncoder: resolvedTextEncoder, outputPath, loras: resolvedLoras, icReferencePaths: resolvedIcReferencePaths, icLoraWeightPath, icStrength: actualIcStrength, icAttentionStrength: actualIcAttentionStrength, icSkipStage2 }));
   } catch (err) {
     job.status = 'error';
     const reason = err.message || 'Failed to build video gen args';

--- a/server/services/videoGen/local.test.js
+++ b/server/services/videoGen/local.test.js
@@ -24,6 +24,8 @@ const MOCK_PATHS = {
 
 const isLtx2Python = (bin) => String(bin)
   .includes(join('.portos', 'ltx-2-mlx', '.venv', 'bin', 'python3'));
+const isLtx25Python = (bin) => String(bin)
+  .includes(join('.portos', 'ltx-2.5-mlx', '.venv', 'bin', 'python3'));
 
 // The two chain helpers below used to sleep a flat 100ms for the timeline
 // stitch and then read the concat spawn / stitched history entry out of the
@@ -71,6 +73,7 @@ vi.mock('../settings.js', () => ({
 vi.mock('../../lib/mediaModels.js', () => ({
   getVideoModels: vi.fn(() => [
     { id: 'ltx2_unified', name: 'LTX-2 Unified', runtime: 'ltx2', repo: 'Lightricks/LTX-Video', steps: 30, guidance: 3.5 },
+    { id: 'ltx25_mlx_q8', name: 'LTX-2.5 MLX Q8', runtime: 'ltx25', repo: 'MrMofer/ltx-2.5-mlx-q8', steps: 8, guidance: 3 },
     // bf16 LTX-2.x mlx_video model — LoRA-capable via the generate_av wrapper.
     { id: 'ltx23_unified', name: 'LTX-2.3 Unified Beta', runtime: 'mlx_video', repo: 'notapalindrome/ltx23-mlx-av', steps: 25, guidance: 3.0 },
     // quantized mlx_video model — NOT LoRA-capable (out of scope).
@@ -1003,6 +1006,51 @@ describe('generateVideo — PORTOS_T2V_TWO_STAGE arg threading', () => {
     expect(args).not.toContain('--stage2-steps');
     expect(args[args.indexOf('--steps') + 1]).toBe('30');
     expect(args[args.indexOf('--cfg-scale') + 1]).toBe('3.5');
+  });
+});
+
+describe('generateVideo — LTX-2.5 sibling runtime spawn', () => {
+  const renderLtxFamily = async (jobId, modelId) => {
+    const { spawnDetached } = await import('../../lib/detachedSpawn.js');
+    const spawnMock = vi.mocked(spawnDetached);
+    spawnMock.mockClear();
+    await generateVideo({
+      jobId,
+      pythonPath: '/usr/bin/python3',
+      modelId,
+      prompt: 'a quiet street at dusk',
+      width: 512,
+      height: 512,
+      numFrames: 25,
+      fps: 24,
+    });
+    return spawnMock.mock.calls;
+  };
+
+  it('spawns the 2.5 venv and omits the shared Gemma 3 encoder', async () => {
+    const calls = await renderLtxFamily('ltx25-spawn', 'ltx25_mlx_q8');
+    const renderCall = calls.find(
+      ([bin, args]) => isLtx25Python(bin)
+        && Array.isArray(args)
+        && args.includes('--mode')
+        && args.includes('text'),
+    );
+    expect(renderCall).toBeTruthy();
+    expect(renderCall[1]).not.toContain('--gemma');
+    expect(calls.some(([bin]) => isLtx2Python(bin))).toBe(false);
+  });
+
+  it('still threads --gemma through the 2.3 venv', async () => {
+    const calls = await renderLtxFamily('ltx2-gemma-still', 'ltx2_unified');
+    const renderCall = calls.find(
+      ([bin, args]) => isLtx2Python(bin)
+        && Array.isArray(args)
+        && args.includes('--mode')
+        && args.includes('text'),
+    );
+    expect(renderCall).toBeTruthy();
+    expect(renderCall[1]).toEqual(expect.arrayContaining(['--gemma', 'some/text-encoder']));
+    expect(calls.some(([bin]) => isLtx25Python(bin))).toBe(false);
   });
 });
 

--- a/server/services/videoGen/local.test.js
+++ b/server/services/videoGen/local.test.js
@@ -73,7 +73,12 @@ vi.mock('../settings.js', () => ({
 vi.mock('../../lib/mediaModels.js', () => ({
   getVideoModels: vi.fn(() => [
     { id: 'ltx2_unified', name: 'LTX-2 Unified', runtime: 'ltx2', repo: 'Lightricks/LTX-Video', steps: 30, guidance: 3.5 },
-    { id: 'ltx25_mlx_q8', name: 'LTX-2.5 MLX Q8', runtime: 'ltx25', repo: 'MrMofer/ltx-2.5-mlx-q8', steps: 8, guidance: 3 },
+    {
+      id: 'ltx25_mlx_q8', name: 'LTX-2.5 MLX Q8', runtime: 'ltx25',
+      repo: 'MrMofer/ltx-2.5-mlx-q8',
+      revision: 'f1b56e7dc89f71a9af2cddac787b89ed22a8b7fc',
+      steps: 8, guidance: 3,
+    },
     // bf16 LTX-2.x mlx_video model — LoRA-capable via the generate_av wrapper.
     { id: 'ltx23_unified', name: 'LTX-2.3 Unified Beta', runtime: 'mlx_video', repo: 'notapalindrome/ltx23-mlx-av', steps: 25, guidance: 3.0 },
     // quantized mlx_video model — NOT LoRA-capable (out of scope).
@@ -1027,7 +1032,7 @@ describe('generateVideo — LTX-2.5 sibling runtime spawn', () => {
     return spawnMock.mock.calls;
   };
 
-  it('spawns the 2.5 venv and omits the shared Gemma 3 encoder', async () => {
+  it('spawns the 2.5 venv, omits the shared Gemma 3 encoder, and pins --model to the cached revision', async () => {
     const calls = await renderLtxFamily('ltx25-spawn', 'ltx25_mlx_q8');
     const renderCall = calls.find(
       ([bin, args]) => isLtx25Python(bin)
@@ -1037,10 +1042,12 @@ describe('generateVideo — LTX-2.5 sibling runtime spawn', () => {
     );
     expect(renderCall).toBeTruthy();
     expect(renderCall[1]).not.toContain('--gemma');
+    expect(renderCall[1][renderCall[1].indexOf('--model') + 1]).toBe('/mock/hf/snap');
+    expect(renderCall[1]).not.toContain('MrMofer/ltx-2.5-mlx-q8');
     expect(calls.some(([bin]) => isLtx2Python(bin))).toBe(false);
   });
 
-  it('still threads --gemma through the 2.3 venv', async () => {
+  it('still threads --gemma through the 2.3 venv and leaves an unpinned repo id on --model', async () => {
     const calls = await renderLtxFamily('ltx2-gemma-still', 'ltx2_unified');
     const renderCall = calls.find(
       ([bin, args]) => isLtx2Python(bin)
@@ -1050,7 +1057,22 @@ describe('generateVideo — LTX-2.5 sibling runtime spawn', () => {
     );
     expect(renderCall).toBeTruthy();
     expect(renderCall[1]).toEqual(expect.arrayContaining(['--gemma', 'some/text-encoder']));
+    expect(renderCall[1][renderCall[1].indexOf('--model') + 1]).toBe('Lightricks/LTX-Video');
     expect(calls.some(([bin]) => isLtx25Python(bin))).toBe(false);
+  });
+
+  it('rejects a missing pinned 2.5 snapshot before spawn', async () => {
+    const { spawnDetached } = await import('../../lib/detachedSpawn.js');
+    vi.mocked(spawnDetached).mockClear();
+    mockInspectModelCache.mockResolvedValueOnce({ cached: false, snapshotPath: null, sizeBytes: 0 });
+    await expect(generateVideo({
+      jobId: 'ltx25-uncached',
+      pythonPath: '/usr/bin/python3',
+      modelId: 'ltx25_mlx_q8',
+      prompt: 'a quiet street at dusk',
+      width: 512, height: 512, numFrames: 25, fps: 24,
+    })).rejects.toMatchObject({ code: 'LTX2_MODEL_NOT_CACHED' });
+    expect(spawnDetached).not.toHaveBeenCalled();
   });
 });
 

--- a/server/services/videoGen/prepareParams.js
+++ b/server/services/videoGen/prepareParams.js
@@ -33,7 +33,7 @@ import { ServerError } from '../../lib/errorHandler.js';
 import { PATHS, ensureDir, resolveGalleryImage } from '../../lib/fileUtils.js';
 import { safeUnder } from '../../lib/ffmpeg.js';
 import { RENDER_TARGET } from '../../lib/renderTargets.js';
-import { videoLoraFamily, isMiniMaxH3Runtime } from '../../lib/runners.js';
+import { videoLoraFamily, isMiniMaxH3Runtime, isLtx2FamilyRuntime } from '../../lib/runners.js';
 import {
   isStockTextEncoder, supportsVideoTextEncoder, videoTextEncoderUnsupportedError,
 } from '../../lib/videoTextEncoders.js';
@@ -368,7 +368,7 @@ async function resolvePreparedParams({
     }
     // IC-LoRA remix is an LTX-2 primitive (ICLoraPipeline). Fail before enqueue
     // so a bad modelId can't pollute the persisted queue with a doomed job.
-    if (effectiveModel && effectiveModel.runtime !== 'ltx2') {
+    if (effectiveModel && !isLtx2FamilyRuntime(effectiveModel.runtime)) {
       await cleanupStaged();
       throw new ServerError(
         `${icSpec.label} mode requires an ltx2-runtime model. Model "${effectiveModelId}" runs on "${effectiveModel.runtime || 'mlx_video'}".`,
@@ -397,7 +397,7 @@ async function resolvePreparedParams({
   // A2V_REQUIRES_LTX2), but checking here keeps the route's "fail fast
   // before enqueue" contract so a bad modelId can't pollute the persisted
   // queue with a doomed entry.
-  if (body.mode === 'a2v' && effectiveModel && effectiveModel.runtime !== 'ltx2') {
+  if (body.mode === 'a2v' && effectiveModel && !isLtx2FamilyRuntime(effectiveModel.runtime)) {
     await cleanupStaged();
     throw new ServerError(
       `a2v mode requires an ltx2-runtime model. Model "${effectiveModelId}" runs on "${effectiveModel.runtime || 'mlx_video'}".`,
@@ -615,7 +615,7 @@ async function resolvePreparedParams({
     // pipeline has no equivalent. Mirror the a2v guard above so a bad
     // modelId can't enqueue a doomed job that will only fail in the
     // worker (with KEYFRAMES_REQUIRE_LTX2).
-    if (effectiveModel && effectiveModel.runtime !== 'ltx2') {
+    if (effectiveModel && !isLtx2FamilyRuntime(effectiveModel.runtime)) {
       await cleanupStaged();
       throw new ServerError(
         `keyframes mode requires an ltx2-runtime model. Model "${effectiveModelId}" runs on "${effectiveModel.runtime || 'mlx_video'}".`,

--- a/server/services/videoGen/runtimes.js
+++ b/server/services/videoGen/runtimes.js
@@ -17,7 +17,7 @@ import { PATHS } from '../../lib/fileUtils.js';
 import { ServerError } from '../../lib/errorHandler.js';
 import { safeChildProcessEnv } from '../../lib/processEnv.js';
 import { createSingleFlight } from '../../lib/singleFlight.js';
-import { MINIMAX_H3_RUNTIMES } from '../../lib/runners.js';
+import { MINIMAX_H3_RUNTIMES, LTX2_FAMILY_RUNTIMES } from '../../lib/runners.js';
 
 // Path to the dgrauet/ltx-2-mlx venv populated by `INSTALL_LTX2=1
 // scripts/setup-image-video.sh`. Used when a model entry has
@@ -26,6 +26,12 @@ import { MINIMAX_H3_RUNTIMES } from '../../lib/runners.js';
 // progress protocol (STAGE:/STATUS:/DOWNLOAD:) as the mlx_video CLI.
 export const LTX2_VENV_PYTHON = join(homedir(), '.portos', 'ltx-2-mlx', '.venv', 'bin', 'python3');
 export const LTX2_HELPER_SCRIPT = join(PATHS.root, 'scripts', 'generate_ltx2.py');
+
+// LTX-2.5 MLX runtime — MrMofer's ltx25 fork of dgrauet/ltx-2-mlx. Same
+// helper script as `ltx2`, separate checkout so the 2.3 pin stays frozen.
+export const LTX25_VENV_PYTHON = join(homedir(), '.portos', 'ltx-2.5-mlx', '.venv', 'bin', 'python3');
+export const LTX25_REPO_DIR = join(homedir(), '.portos', 'ltx-2.5-mlx');
+export const LTX25_EXPECTED_REVISION = '57952288076766abe27dda3a774b2c24f7346977';
 
 // Wan 2.2 MLX runtime — pinned MLX-Gen checkout provisioned on demand.
 export const WAN22_VENV_PYTHON = join(homedir(), '.portos', 'mlx-gen', '.venv', 'bin', 'python3');
@@ -212,6 +218,18 @@ export const BYOV_RUNTIME_INFO = Object.freeze({
     // Mirror scripts/generate_ltx2.py's emit_runtime_fingerprint package list.
     fingerprintPackages: ['ltx_pipelines_mlx', 'ltx_core_mlx', 'mlx', 'mlx_metal'],
   },
+  ltx25: {
+    id: 'ltx25',
+    label: 'LTX-2.5 MLX',
+    venvPython: LTX25_VENV_PYTHON,
+    repoDir: LTX25_REPO_DIR,
+    installEnvVar: 'INSTALL_LTX25',
+    repoUrl: 'https://github.com/MrMoferFRAN/ltx-2-mlx',
+    expectedRevision: LTX25_EXPECTED_REVISION,
+    pinEnvVar: 'LTX25_PIN',
+    importProbe: 'import ltx_pipelines_mlx',
+    fingerprintPackages: ['ltx_pipelines_mlx', 'ltx_core_mlx', 'mlx', 'mlx_metal'],
+  },
 });
 
 export const BYOV_VIDEO_RUNTIMES = Object.freeze(new Set(Object.keys(BYOV_RUNTIME_INFO)));
@@ -248,7 +266,7 @@ export const routesToWindowsHelper = (model) => process.platform === 'win32'
 // resize in local.js (wasted ffmpeg work otherwise), and the client's
 // "last frame is advisory" note, which reads it off the model payload via
 // `lastFrameAnchored`.
-export const LAST_FRAME_ANCHORED_RUNTIMES = Object.freeze(new Set(['ltx2', ...MINIMAX_H3_RUNTIMES]));
+export const LAST_FRAME_ANCHORED_RUNTIMES = Object.freeze(new Set([...LTX2_FAMILY_RUNTIMES, ...MINIMAX_H3_RUNTIMES]));
 
 export const modelAnchorsLastFrame = (model) => LAST_FRAME_ANCHORED_RUNTIMES.has(model?.runtime);
 

--- a/server/services/videoGen/runtimes.test.js
+++ b/server/services/videoGen/runtimes.test.js
@@ -139,7 +139,7 @@ describe('MiniMax H3 LoRA capability', () => {
     expect(runtimeMocks.spawn).toHaveBeenCalledTimes(1);
   });
 
-  it.each(['ltx2', 'wan22', 'hunyuan'])('never probes %s, which has no LoRA runtime path', async (runtime) => {
+  it.each(['ltx2', 'ltx25', 'wan22', 'hunyuan'])('never probes %s, which has no LoRA runtime path', async (runtime) => {
     await expect(resolveByovRuntimeLoraCapable(runtime)).resolves.toBe(false);
     expect(byovRuntimeLoraCapable(runtime)).toBe(false);
     expect(runtimeMocks.spawn).not.toHaveBeenCalled();
@@ -152,6 +152,7 @@ describe('MiniMax H3 LoRA capability', () => {
 describe('modelAnchorsLastFrame', () => {
   it.each([
     ['ltx2', true],
+    ['ltx25', true],
     ['minimax_h3', true],
     // Anchoring is a property of the fl2va checkpoint, not of the runner in
     // front of it, so the CUDA path must agree with the MLX one.


### PR DESCRIPTION
## Summary

Adds LTX-2.5 as a sibling Apple Silicon video runtime instead of replacing the existing LTX-2.3 pin. The 2.3 dgrauet checkout cannot load 2.5 weights, so this provisions a separate `~/.portos/ltx-2.5-mlx` venv (`INSTALL_LTX25`) from MrMofer's fork and ships `ltx25_mlx_q8` (`MrMofer/ltx-2.5-mlx-q8`, pinned revision).

2.5 reuses the LTX-2 family mode contract (text / image / FFLF / extend / a2v / IC) and the shared `generate_ltx2.py` helper, but skips the shared Gemma 3 `--gemma` encoder because 2.5 packs ship Gemma 4 under `text_encoder/`. Render resolves a pinned revision to the local HF snapshot before spawn so the helper cannot follow mutable `main`.

Default macOS video model stays LTX-2.3 Distilled Q4.

## Test plan

- [x] `cd server && npx vitest run services/videoGen/local.test.js` — 169 passed, including:
  - 2.5 spawn uses `~/.portos/ltx-2.5-mlx/.venv/bin/python3` and omits `--gemma`
  - 2.3 spawn still uses the 2.3 venv and passes `--gemma`
  - pinned 2.5 `--model` is the cached snapshot path, not the repo id
  - missing 2.5 snapshot throws `LTX2_MODEL_NOT_CACHED` before spawn
- [x] Existing family/runtime/disclosure/classifier tests (from the feature commit) cover `isLtx2FamilyRuntime`, `ltx25` install metadata, HF auto-detect, and seed/reference catalog parity
- [ ] Manual: Video Gen model picker shows **LTX-2.5 MLX Q8 (~68 GB, Apple Silicon)** as a new option on macOS; 2.3 entries remain
- [ ] Manual: Install/Repair with `INSTALL_LTX25=1` clones the pinned MrMofer fork and the import probe succeeds
- [ ] Manual: a 2.5 text render does not download the shared Gemma 3 encoder and does not pass `--gemma`