### PR TITLE
Upgrade recommended local Qwen chat model to Qwen3.8 27B

### DIFF
--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -252,8 +252,8 @@ export const LOCAL_LLM_CATALOG = [
   // long context window matter most. To actually fit the manuscript, raise Ollama's
   // context window (OLLAMA_CONTEXT_LENGTH) — the default 4K window silently truncates.
   {
-    key: 'qwen3.6-27b',
-    name: 'Qwen3.6 27B',
+    key: 'qwen3.8-27b',
+    name: 'Qwen3.8 27B',
     category: 'chat',
     params: '27B',
     size: '17 GB',
@@ -261,8 +261,8 @@ export const LOCAL_LLM_CATALOG = [
     description: 'Dense current-generation Qwen with a 256K context, vision, tools, and a thinking mode — the strongest all-round narrative editor that still fits 32GB.',
     capabilities: ['chat', 'reasoning', 'tools', 'vision'],
     context: 262144,
-    ollama: 'qwen3.6:27b',
-    lmstudio: 'lmstudio-community/Qwen3.6-27B-GGUF'
+    ollama: 'hf.co/unsloth/Qwen3.8-27B-GGUF:Q4_K_M',
+    lmstudio: 'unsloth/Qwen3.8-27B-GGUF'
   },
   {
     key: 'gemma4-26b-a4b',

--- a/server/lib/localLlmCatalog.test.js
+++ b/server/lib/localLlmCatalog.test.js
@@ -73,8 +73,8 @@ describe('localLlmCatalog', () => {
       const ollama = getCatalog('ollama');
       // granite4.1-8b documents a 128K window.
       expect(ollama.find((m) => m.key === 'granite4.1-8b').contextLength).toBe(131072);
-      // qwen3.6-27b documents a native 256K window.
-      expect(ollama.find((m) => m.key === 'qwen3.6-27b').contextLength).toBe(262144);
+      // qwen3.8-27b documents a native 256K window.
+      expect(ollama.find((m) => m.key === 'qwen3.8-27b').contextLength).toBe(262144);
       // Entries whose real window isn't a documented round number expose null
       // (never undefined) rather than an invented one.
       expect(ollama.find((m) => m.key === 'glm-4.7-flash').contextLength).toBeNull();


### PR DESCRIPTION
## Summary
- Replace the `qwen3.6-27b` entry in the local LLM catalog's large-narrative tier with `qwen3.8-27b`, pointing at the `unsloth/Qwen3.8-27B-GGUF` build (matches the precedent set by the prior Qwen coding model upgrade, which replaced the catalog entry in place rather than adding a duplicate).
- Since this build isn't yet published to Ollama's own registry, the `ollama` id uses the `hf.co/unsloth/Qwen3.8-27B-GGUF:Q4_K_M` pull form (same convention used elsewhere in the catalog for HF-backed builds).

## Test plan
- `npx vitest run lib/localLlmCatalog.test.js` — 18 passed