### PR TITLE
Extract hand-rolled progress meter into shared ui/ProgressBar

### DIFF
--- a/.changelog/next/changed-issue-4138.md
+++ b/.changelog/next/changed-issue-4138.md
@@ -1,0 +1,1 @@
+- Shared ui/ProgressBar primitive replaces six hand-rolled progress meters; every meter now carries role=progressbar with aria-valuenow/min/max and an accessible name

--- a/client/src/components/meatspace/post/MemoryPractice.jsx
+++ b/client/src/components/meatspace/post/MemoryPractice.jsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect, useMemo } from 'react';
 import { ChevronLeft, Check, X, SkipForward, RotateCcw, Target, ChevronDown, Loader, ShieldCheck } from 'lucide-react';
 import { submitMemoryPractice, getChunkMastery, getMemoryItem, attestMemoryMastery } from '../../../services/api';
+import ProgressBar from '../../ui/ProgressBar';
 import PostCompletionActions from './PostCompletionActions';
 import { startRetryableSave } from './completionSave';
 
@@ -386,7 +387,7 @@ function MemoryPracticeRunner({ item, mode, onSelectMode, onExitMode, onBack, on
           </span>
         </div>
 
-        <ProgressBar current={spacedChunkIdx * 10 + spacedLineIdx + 1} total={chunkMastery.length * 10} />
+        <PracticeProgress current={spacedChunkIdx * 10 + spacedLineIdx + 1} total={chunkMastery.length * 10} />
 
         {/* Chunk info */}
         <div className="flex items-center gap-3 text-xs">
@@ -480,7 +481,7 @@ function MemoryPracticeRunner({ item, mode, onSelectMode, onExitMode, onBack, on
           <span className="text-gray-500 text-sm ml-auto">{currentIdx + 1} / {lines.length}</span>
         </div>
 
-        <ProgressBar current={currentIdx + 1} total={lines.length} />
+        <PracticeProgress current={currentIdx + 1} total={lines.length} />
 
         <div className="bg-port-card border border-port-border rounded-lg p-6">
           <div className="space-y-2">
@@ -547,7 +548,7 @@ function MemoryPracticeRunner({ item, mode, onSelectMode, onExitMode, onBack, on
           <span className="text-gray-500 text-sm ml-auto">{currentIdx + 1} / {lines.length - 1}</span>
         </div>
 
-        <ProgressBar current={currentIdx + 1} total={lines.length - 1} />
+        <PracticeProgress current={currentIdx + 1} total={lines.length - 1} />
 
         <div className="bg-port-card border border-port-border rounded-lg p-6">
           <div className="text-gray-400 text-xs mb-2 uppercase tracking-wide">Current line:</div>
@@ -629,7 +630,7 @@ function MemoryPracticeRunner({ item, mode, onSelectMode, onExitMode, onBack, on
           <span className="text-gray-500 text-sm ml-auto">{currentIdx + 1} / {lines.length}</span>
         </div>
 
-        <ProgressBar current={currentIdx + 1} total={lines.length} />
+        <PracticeProgress current={currentIdx + 1} total={lines.length} />
 
         <div className="bg-port-card border border-port-border rounded-lg p-6">
           <div className="text-white text-lg leading-relaxed mb-4 font-mono">{displayText}</div>
@@ -904,14 +905,18 @@ function ChunkMasteryOverview({ item }) {
             const accuracy = typeof stats?.masteredAt === 'string'
               ? 100
               : stats?.attempts > 0 ? Math.round((stats.correct / stats.attempts) * 100) : 0;
-            const barColor = accuracy >= 80 ? 'bg-port-success' : accuracy >= 40 ? 'bg-port-warning' : 'bg-gray-600';
+            const barTone = accuracy >= 80 ? 'success' : accuracy >= 40 ? 'warning' : 'muted';
 
             return (
               <div key={chunk.id} className="flex items-center gap-2">
                 <span className="text-xs text-gray-500 w-16 truncate">{chunk.label}</span>
-                <div className="flex-1 h-1.5 bg-port-border rounded-full overflow-hidden">
-                  <div className={`h-full rounded-full ${barColor}`} style={{ width: `${accuracy}%` }} />
-                </div>
+                <ProgressBar
+                  percent={accuracy}
+                  tone={barTone}
+                  track="border"
+                  className="flex-1"
+                  label={`${chunk.label} mastery`}
+                />
                 <span className="text-xs font-mono text-gray-500 w-10 text-right">{accuracy}%</span>
               </div>
             );
@@ -962,12 +967,17 @@ function SpeedRunLine({ line, index, onResult }) {
   );
 }
 
-function ProgressBar({ current, total }) {
-  const pct = Math.round((current / total) * 100);
+// The name stays generic rather than "line 3 of 12": the spaced mode measures a
+// synthetic chunk×line position, so only the percentage is meaningful across all
+// four modes — and `aria-valuenow` already carries it.
+function PracticeProgress({ current, total }) {
   return (
-    <div className="w-full h-1.5 bg-port-border rounded-full overflow-hidden">
-      <div className="h-full bg-port-accent rounded-full transition-all" style={{ width: `${pct}%` }} />
-    </div>
+    <ProgressBar
+      percent={Math.round((current / total) * 100)}
+      track="border"
+      label="Practice progress"
+      duration={150}
+    />
   );
 }
 

--- a/client/src/components/meatspace/post/PostLlmDrillRunner.jsx
+++ b/client/src/components/meatspace/post/PostLlmDrillRunner.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { CheckCircle, XCircle } from 'lucide-react';
+import ProgressBar from '../../ui/ProgressBar';
 import { scorePostLlmDrill } from '../../../services/api';
 import { DRILL_LABELS, WORDPLAY_LLM_DRILL_TYPES } from './constants';
 import { AILoadingIndicator, MissedExamplesDisplay, CompoundChainUI, BridgeWordUI, DoubleMeaningUI, IdiomTwistUI, scoreWordplayResponse } from './WordplayDrillUI';
@@ -188,9 +189,9 @@ export default function PostLlmDrillRunner({ drill, timeLimitSec, drillIndex, dr
   }
 
   const timePct = timeLimitMs > 0 ? (timeLeft / timeLimitMs) * 100 : 0;
-  let timerColor = 'bg-port-accent';
-  if (timePct <= 10) timerColor = 'bg-port-error';
-  else if (timePct <= 25) timerColor = 'bg-port-warning';
+  let timerTone = 'accent';
+  if (timePct <= 10) timerTone = 'error';
+  else if (timePct <= 25) timerTone = 'warning';
 
   // Training mode: feedback overlay
   if (isTraining && trainingFeedback) {
@@ -231,14 +232,7 @@ export default function PostLlmDrillRunner({ drill, timeLimitSec, drillIndex, dr
         >
           Next
         </button>
-        <div className="space-y-1">
-          <div className="flex justify-between text-xs text-gray-500">
-            <span>Prompt {questionIndex + 1} of {totalPrompts}</span>
-          </div>
-          <div className="w-full h-1.5 bg-port-border rounded-full overflow-hidden">
-            <div className="h-full bg-port-accent-2/60 transition-all" style={{ width: `${((questionIndex + 1) / totalPrompts) * 100}%` }} />
-          </div>
-        </div>
+        <PromptProgress index={questionIndex} total={totalPrompts} tone="accent2" showPercent={false} />
       </div>
     );
   }
@@ -257,9 +251,14 @@ export default function PostLlmDrillRunner({ drill, timeLimitSec, drillIndex, dr
       {/* Timer bar (hidden in training mode) */}
       {!isTraining && (
         <>
-          <div className="w-full h-2 bg-port-border rounded-full overflow-hidden">
-            <div className={`h-full ${timerColor} transition-all duration-100`} style={{ width: `${timePct}%` }} />
-          </div>
+          <ProgressBar
+            percent={timePct}
+            tone={timerTone}
+            size="md"
+            track="border"
+            duration={100}
+            label={`Time remaining: ${Math.ceil(timeLeft / 1000)}s`}
+          />
           <div className="text-center text-sm text-gray-500">{Math.ceil(timeLeft / 1000)}s remaining</div>
         </>
       )}
@@ -427,7 +426,7 @@ export default function PostLlmDrillRunner({ drill, timeLimitSec, drillIndex, dr
             </div>
           </div>
           <TextInput inputRef={inputRef} value={inputValue} onChange={setInputValue} onSubmit={handleSubmit} placeholder="Your micro-story (2-4 sentences)..." buttonLabel="Next" />
-          <ProgressBar index={questionIndex} total={totalPrompts} />
+          <PromptProgress index={questionIndex} total={totalPrompts} />
         </>
       )}
 
@@ -532,17 +531,23 @@ export function buildLlmResponseObj({ drillType, questionIndex, items, inputValu
 // DRILL-SPECIFIC UI COMPONENTS
 // ─────────────────────────────────────────────────────────────────────────────
 
-function ProgressBar({ index, total }) {
+// "Prompt N of M" counter over the shared meter. Both knobs exist for the
+// training-feedback screen, which draws the same counter without the numeric
+// readout and in the accent-2 tone that marks training throughout this runner.
+function PromptProgress({ index, total, tone = 'accent', showPercent = true }) {
   const pct = total > 0 ? ((index + 1) / total) * 100 : 0;
   return (
     <div className="space-y-1">
       <div className="flex justify-between text-xs text-gray-500">
         <span>Prompt {index + 1} of {total}</span>
-        <span>{Math.round(pct)}%</span>
+        {showPercent && <span>{Math.round(pct)}%</span>}
       </div>
-      <div className="w-full h-1.5 bg-port-border rounded-full overflow-hidden">
-        <div className="h-full bg-port-accent/60 transition-all" style={{ width: `${pct}%` }} />
-      </div>
+      <ProgressBar
+        percent={pct}
+        tone={tone}
+        track="border"
+        label={`Prompt ${index + 1} of ${total}`}
+      />
     </div>
   );
 }
@@ -586,7 +591,7 @@ function WordAssociationUI({ prompt, inputValue, setInputValue, onSubmit, inputR
         placeholder="Type your associations..."
         buttonLabel="Next"
       />
-      <ProgressBar index={questionIndex} total={totalPrompts} />
+      <PromptProgress index={questionIndex} total={totalPrompts} />
     </>
   );
 }
@@ -605,7 +610,7 @@ function StoryRecallUI({ exercise, phase, onStartRecall, items, inputValue, setI
         >
           I'm Ready — Show Questions
         </button>
-        <ProgressBar index={questionIndex} total={totalPrompts} />
+        <PromptProgress index={questionIndex} total={totalPrompts} />
       </>
     );
   }
@@ -647,7 +652,7 @@ function StoryRecallUI({ exercise, phase, onStartRecall, items, inputValue, setI
           Submit All Answers
         </button>
       )}
-      <ProgressBar index={questionIndex} total={totalPrompts} />
+      <PromptProgress index={questionIndex} total={totalPrompts} />
     </>
   );
 }
@@ -701,7 +706,7 @@ function VerbalFluencyUI({ category, items, inputValue, setInputValue, onAddItem
       >
         Done — Submit {items.length} items
       </button>
-      <ProgressBar index={questionIndex} total={totalPrompts} />
+      <PromptProgress index={questionIndex} total={totalPrompts} />
     </>
   );
 }
@@ -729,7 +734,7 @@ function WitComebackUI({ scenario, inputValue, setInputValue, onSubmit, inputRef
         placeholder="Your witty response..."
         buttonLabel="Next"
       />
-      <ProgressBar index={questionIndex} total={totalPrompts} />
+      <PromptProgress index={questionIndex} total={totalPrompts} />
     </>
   );
 }
@@ -753,7 +758,7 @@ function PunWordplayUI({ challenge, inputValue, setInputValue, onSubmit, inputRe
         placeholder="Your pun or wordplay..."
         buttonLabel="Next"
       />
-      <ProgressBar index={questionIndex} total={totalPrompts} />
+      <PromptProgress index={questionIndex} total={totalPrompts} />
     </>
   );
 }
@@ -776,7 +781,7 @@ function ImaginationUI({ label, prompt, badge, badgeColor, placeholder, inputVal
         placeholder={placeholder}
         buttonLabel="Next"
       />
-      <ProgressBar index={questionIndex} total={totalPrompts} />
+      <PromptProgress index={questionIndex} total={totalPrompts} />
     </>
   );
 }
@@ -827,7 +832,7 @@ function AlternativeUsesUI({ object, items, inputValue, setInputValue, onAddItem
       >
         Done — Submit {items.length} uses
       </button>
-      <ProgressBar index={questionIndex} total={totalPrompts} />
+      <PromptProgress index={questionIndex} total={totalPrompts} />
     </>
   );
 }

--- a/client/src/components/pipeline/AutopilotMilestones.jsx
+++ b/client/src/components/pipeline/AutopilotMilestones.jsx
@@ -8,6 +8,7 @@ import {
   isStoppedTerminal,
   MILESTONE_STATUS,
 } from '../../lib/autopilotMilestones';
+import ProgressBar from '../ui/ProgressBar';
 
 // Per-status chrome in ONE table — icon and tones together, so a new status
 // can't get a row color and no icon (or the reverse). `blocked` reuses the
@@ -53,19 +54,13 @@ export default function AutopilotMilestones({ plan, planTotals, progress, termin
       {/* Overall meter. A plan snapshot can under-count a step the run repeats,
           so this is honest about milestones settled — not a time estimate. */}
       {!dryRun ? (
-        <div
-          className="mt-1.5 h-1.5 w-full rounded-full bg-port-bg overflow-hidden"
-          role="progressbar"
-          aria-label="Autopilot story progress"
-          aria-valuenow={summary.percent}
-          aria-valuemin={0}
-          aria-valuemax={100}
-        >
-          <div
-            className={`h-full rounded-full transition-all duration-500 ${isStoppedTerminal(terminal) ? 'bg-port-warning' : 'bg-port-accent'}`}
-            style={{ width: `${summary.percent}%` }}
-          />
-        </div>
+        <ProgressBar
+          percent={summary.percent}
+          tone={isStoppedTerminal(terminal) ? 'warning' : 'accent'}
+          label="Autopilot story progress"
+          duration={500}
+          className="mt-1.5"
+        />
       ) : null}
 
       {/* Capped so a long plan (a comic series can project 16 milestones) can't

--- a/client/src/components/pipeline/manuscript/ManuscriptReadAloud.jsx
+++ b/client/src/components/pipeline/manuscript/ManuscriptReadAloud.jsx
@@ -22,6 +22,7 @@ import { Play, Pause, Square, Loader2, Volume2, AlertTriangle } from 'lucide-rea
 import Modal from '../../ui/Modal';
 import VoicePicker from '../../voice/VoicePicker';
 import toast from '../../ui/Toast';
+import ProgressBar from '../../ui/ProgressBar';
 import { formatDurationMs } from '../../../utils/formatters';
 import { narratePipelineProse } from '../../../services/api';
 import { STAGE_LABEL } from './constants';
@@ -293,9 +294,7 @@ export default function ManuscriptReadAloud({ open, onClose, section }) {
 
           {segments ? (
             <div className="space-y-1">
-              <div className="h-1.5 w-full rounded bg-port-bg overflow-hidden">
-                <div className="h-full bg-port-accent transition-[width] duration-150" style={{ width: `${progressPct}%` }} />
-              </div>
+              <ProgressBar percent={progressPct} label="Narration progress" duration={150} />
               <div className="flex items-center justify-between text-[11px] text-gray-500">
                 <span>
                   {segments.length} sentence{segments.length === 1 ? '' : 's'}

--- a/client/src/components/pipeline/stages/EpisodeVideoStage.jsx
+++ b/client/src/components/pipeline/stages/EpisodeVideoStage.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 import { Film, ExternalLink, Loader2, Sparkles, AlertCircle, CheckCircle2 } from 'lucide-react';
 import toast from '../../ui/Toast';
 import Banner from '../../ui/Banner';
+import ProgressBar from '../../ui/ProgressBar';
 import { generatePipelineVisualImage, listVideoModels } from '../../../services/api';
 import { getCreativeDirectorProject } from '../../../services/apiCreativeDirector';
 import { getSceneStatusBadge, PROJECT_STATUS_LABEL } from '../../creative-director/sceneStatus';
@@ -360,12 +361,11 @@ export default function EpisodeVideoStage({ issue, onStageUpdate }) {
 
           {total > 0 && (
             <div className="space-y-1">
-              <div className="h-1.5 w-full bg-port-bg rounded-full overflow-hidden">
-                <div
-                  className="h-full bg-port-accent transition-all"
-                  style={{ width: `${total ? (accepted / total) * 100 : 0}%` }}
-                />
-              </div>
+              <ProgressBar
+                percent={(accepted / total) * 100}
+                label={`Scenes accepted: ${accepted} of ${total}`}
+                duration={150}
+              />
               <ul className="flex flex-wrap gap-1.5 pt-1">
                 {sortedScenes.map((s) => {
                   const badge = getSceneStatusBadge(s.status);

--- a/client/src/components/ui/ProgressBar.jsx
+++ b/client/src/components/ui/ProgressBar.jsx
@@ -1,0 +1,114 @@
+/**
+ * ProgressBar — the shared horizontal meter: a rounded track with a tone-colored
+ * fill sized to `percent`.
+ *
+ * Six surfaces had hand-rolled the same `h-1.5 rounded-full` track +
+ * `style={{ width: `${pct}%` }}` fill (LoRA downloads, manuscript read-aloud,
+ * episode-video scenes, the POST drill runner, memory practice, and the
+ * autopilot milestone meter). They had already drifted on accessibility — only
+ * two carried `role="progressbar"` with `aria-valuenow`, so the rest were
+ * invisible to a screen reader. That is the point of centralizing: the ARIA trio
+ * plus an accessible name is emitted here, once, for every host.
+ *
+ * Knobs map to real call-site shapes — nothing speculative:
+ *   percent  — 0..100, clamped. `null`/`undefined` means INDETERMINATE (the
+ *              LoRA installer gets no Content-Length from some mirrors) and
+ *              draws a pulsing stub with no `aria-valuenow`. A non-finite
+ *              number (a `0/0` ratio) is a *broken* measurement, not an absent
+ *              one, so it renders an empty determinate bar rather than
+ *              silently claiming "indeterminate".
+ *   tone     — semantic fill color. The drill timer swaps accent → warning →
+ *              error as it runs out; chunk mastery swaps muted → warning →
+ *              success; a stopped autopilot run reads warning.
+ *   label    — the accessible name. Required in spirit; defaults to 'Progress'
+ *              so the trio is never nameless.
+ *   size     — `sm` (h-1.5, default) or `md` (h-2, the drill timer).
+ *   track    — `bg` (on a card, default) or `border` (on the page ground, where
+ *              `bg-port-bg` would vanish).
+ *   duration — fill transition in ms. Static class map, because Tailwind can't
+ *              see an interpolated `duration-${n}` and would drop it from the
+ *              build.
+ * `className` passes through for layout only (`flex-1`, `mt-1.5`).
+ */
+
+const TONES = {
+  accent: 'bg-port-accent',
+  accent2: 'bg-port-accent-2',
+  success: 'bg-port-success',
+  warning: 'bg-port-warning',
+  error: 'bg-port-error',
+  muted: 'bg-gray-600',
+};
+
+const SIZES = {
+  sm: 'h-1.5',
+  md: 'h-2',
+};
+
+const TRACKS = {
+  bg: 'bg-port-bg',
+  border: 'bg-port-border',
+};
+
+// Interpolated Tailwind class names are invisible to the build, so the only
+// durations available are the ones spelled out here.
+const DURATIONS = {
+  100: 'duration-100',
+  150: 'duration-150',
+  200: 'duration-200',
+  300: 'duration-300',
+  500: 'duration-500',
+};
+
+// `null`/`undefined` = "we can't measure this" (indeterminate). Anything else is
+// a measurement, and a broken one reads as 0 rather than collapsing into the
+// indeterminate sentinel.
+export function clampPercent(percent) {
+  if (percent === null || percent === undefined) return null;
+  const n = Number(percent);
+  if (!Number.isFinite(n)) return 0;
+  return Math.min(100, Math.max(0, n));
+}
+
+export default function ProgressBar({
+  percent,
+  tone = 'accent',
+  label = 'Progress',
+  size = 'sm',
+  track = 'bg',
+  duration = 200,
+  className = '',
+}) {
+  const value = clampPercent(percent);
+  const indeterminate = value === null;
+  const fillTone = TONES[tone] || TONES.accent;
+  const trackCls = [
+    'w-full overflow-hidden rounded-full',
+    SIZES[size] || SIZES.sm,
+    TRACKS[track] || TRACKS.bg,
+    className,
+  ]
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  const fillCls = [
+    'h-full rounded-full',
+    fillTone,
+    indeterminate
+      ? 'w-1/3 animate-pulse'
+      : `transition-[width] ${DURATIONS[duration] || DURATIONS[200]}`,
+  ].join(' ');
+
+  return (
+    <div
+      className={trackCls}
+      role="progressbar"
+      aria-label={label}
+      aria-valuenow={indeterminate ? undefined : Math.round(value)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+    >
+      <div className={fillCls} style={indeterminate ? undefined : { width: `${value}%` }} />
+    </div>
+  );
+}

--- a/client/src/components/ui/ProgressBar.test.jsx
+++ b/client/src/components/ui/ProgressBar.test.jsx
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import ProgressBar, { clampPercent } from './ProgressBar.jsx';
+
+// The fill is the only child of the track, and it carries no role of its own.
+const fillOf = (container) => container.querySelector('[role="progressbar"] > div');
+
+describe('ProgressBar', () => {
+  it('always emits the ARIA trio plus an accessible name', () => {
+    render(<ProgressBar percent={42} label="Download progress" />);
+    const bar = screen.getByRole('progressbar', { name: 'Download progress' });
+    expect(bar).toHaveAttribute('aria-valuenow', '42');
+    expect(bar).toHaveAttribute('aria-valuemin', '0');
+    expect(bar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('names the bar even when the host forgets a label', () => {
+    render(<ProgressBar percent={10} />);
+    expect(screen.getByRole('progressbar', { name: 'Progress' })).toBeInTheDocument();
+  });
+
+  it('sizes the fill to the percentage', () => {
+    const { container } = render(<ProgressBar percent={37.5} label="x" />);
+    expect(fillOf(container)).toHaveStyle({ width: '37.5%' });
+  });
+
+  it.each([
+    ['over 100', 140, '100%', '100'],
+    ['below zero', -20, '0%', '0'],
+  ])('clamps a percentage %s', (_label, percent, width, valuenow) => {
+    const { container } = render(<ProgressBar percent={percent} label="x" />);
+    expect(fillOf(container)).toHaveStyle({ width });
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', valuenow);
+  });
+
+  it('rounds aria-valuenow but keeps the fractional width', () => {
+    const { container } = render(<ProgressBar percent={33.333} label="x" />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '33');
+    expect(fillOf(container)).toHaveStyle({ width: '33.333%' });
+  });
+
+  // A `0 / 0` ratio is a BROKEN measurement, not an absent one — it must not
+  // collapse into the indeterminate sentinel and start pulsing.
+  it.each([['NaN', NaN], ['Infinity', Infinity]])(
+    'reads a non-finite %s measurement as an empty determinate bar',
+    (_label, percent) => {
+      const { container } = render(<ProgressBar percent={percent} label="x" />);
+      expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+      expect(fillOf(container).className).not.toContain('animate-pulse');
+    },
+  );
+
+  it.each([['null', null], ['undefined', undefined]])(
+    'draws an indeterminate pulse with no aria-valuenow for a %s percentage',
+    (_label, percent) => {
+      const { container } = render(<ProgressBar percent={percent} label="Downloading" />);
+      const bar = screen.getByRole('progressbar', { name: 'Downloading' });
+      expect(bar).not.toHaveAttribute('aria-valuenow');
+      // The bounds stay, so assistive tech still reads it as a 0..100 meter.
+      expect(bar).toHaveAttribute('aria-valuemin', '0');
+      expect(bar).toHaveAttribute('aria-valuemax', '100');
+      const fill = fillOf(container);
+      expect(fill.className).toContain('animate-pulse');
+      expect(fill.getAttribute('style')).toBeFalsy();
+    },
+  );
+
+  it.each([
+    ['accent', 'bg-port-accent'],
+    ['accent2', 'bg-port-accent-2'],
+    ['success', 'bg-port-success'],
+    ['warning', 'bg-port-warning'],
+    ['error', 'bg-port-error'],
+    ['muted', 'bg-gray-600'],
+  ])('paints the %s tone', (tone, cls) => {
+    const { container } = render(<ProgressBar percent={50} tone={tone} label="x" />);
+    expect(fillOf(container).className).toContain(cls);
+  });
+
+  it('falls back to the accent tone for an unknown tone', () => {
+    const { container } = render(<ProgressBar percent={50} tone="chartreuse" label="x" />);
+    expect(fillOf(container).className).toContain('bg-port-accent');
+  });
+
+  it('switches track height and ground on size / track', () => {
+    const { container } = render(<ProgressBar percent={50} size="md" track="border" label="x" />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar.className).toContain('h-2');
+    expect(bar.className).toContain('bg-port-border');
+    expect(container.querySelector('.h-1\\.5')).toBeNull();
+  });
+
+  it('defaults to the small size on the card ground', () => {
+    render(<ProgressBar percent={50} label="x" />);
+    const bar = screen.getByRole('progressbar');
+    expect(bar.className).toContain('h-1.5');
+    expect(bar.className).toContain('bg-port-bg');
+  });
+
+  it('passes layout classes through to the track', () => {
+    render(<ProgressBar percent={50} className="flex-1 mt-1.5" label="x" />);
+    expect(screen.getByRole('progressbar').className).toContain('flex-1 mt-1.5');
+  });
+
+  // Tailwind can't see an interpolated `duration-${n}`, so only mapped values
+  // survive the build — an unmapped one has to fall back, not emit a dead class.
+  it('emits a static duration class and falls back for an unmapped one', () => {
+    const { container: mapped } = render(<ProgressBar percent={50} duration={500} label="x" />);
+    expect(fillOf(mapped).className).toContain('duration-500');
+    const { container: unmapped } = render(<ProgressBar percent={50} duration={137} label="x" />);
+    expect(fillOf(unmapped).className).toContain('duration-200');
+    expect(fillOf(unmapped).className).not.toContain('duration-137');
+  });
+});
+
+describe('clampPercent', () => {
+  it.each([
+    ['null stays indeterminate', null, null],
+    ['undefined stays indeterminate', undefined, null],
+    ['NaN reads as zero', NaN, 0],
+    ['a non-numeric string reads as zero', 'abc', 0],
+    ['a numeric string is parsed', '60', 60],
+    ['over 100 clamps down', 101, 100],
+    ['under 0 clamps up', -1, 0],
+    ['an in-range value passes through', 12.5, 12.5],
+  ])('%s', (_label, input, expected) => {
+    expect(clampPercent(input)).toBe(expected);
+  });
+});

--- a/client/src/components/ui/README.md
+++ b/client/src/components/ui/README.md
@@ -1,0 +1,48 @@
+# `client/src/components/ui/` — shared UI primitives
+
+Presentational building blocks with no domain knowledge. **Grep this catalog before
+hand-rolling chrome** — nearly every primitive here exists because the same markup had
+already been copy-pasted across three-to-ten surfaces and drifted (usually on
+accessibility). Feature-specific components live under their own feature directory
+(`components/pipeline/`, `components/meatspace/`, …), not here.
+
+| Component | What it's for |
+| --- | --- |
+| `AutoSizeTextarea` | Controlled `<textarea>` that grows to fit its content — no internal scroll, no hand-resize. |
+| `Banner` | Toned alert block (icon + content + actions) for warnings, errors, and info callouts. |
+| `BeatPulse` | Metronome dot row — one dot per beat of the bar, the current one lit. |
+| `CollapsibleSection` | Disclosure section header — chevron, leading icon, collapsed summary, `aria-expanded`. |
+| `CollapsibleText` | Line-clamped text preview with a show-more/less toggle. |
+| `ConfirmButtonPair` | Compact inline confirm/cancel pair for a destructive action in a dense control row. |
+| `CopyableId` | Click-to-copy record-id badge — short prefix shown, full id copied. |
+| `diffRuns` | Renders `{ text, changed }` runs from `diffWords` as highlighted nodes (shared by the diff views). |
+| `FilePickerButton` | Opens the OS file picker, styled as a button or as a whole drop target. |
+| `FormField` | Accessible config-field wrapper — generates an id and wires `<label htmlFor>` to the input. |
+| `HunkDiff` | Hunked side-by-side diff for long texts, with unchanged runs collapsed. |
+| `ImageThumb` | List-card thumbnail with an icon fallback when the ref is missing or 404s. |
+| `InfoTooltip` | Focusable info/help tooltip — hover, keyboard focus, or tap; Esc to dismiss. |
+| `InlineConfirmRow` | Inline "question + confirm + cancel" row — PortOS's preferred alternative to `window.confirm`. |
+| `InlineDiff` | Stacked word-level diff — old row (red removals) over new row (green additions). |
+| `Kbd` | Keycap for rendering a keyboard key in help/cheatsheet UI. |
+| `Modal` | Shared modal chrome — backdrop, Esc handling, click-outside. |
+| `OverflowMenu` | "…" menu that demotes rare or destructive row actions out of the visible control set. |
+| `PageSkeleton` | Full-page loading skeleton that reserves the loaded layout so the first paint doesn't reflow. |
+| `Pill` | Inline label badge — semantic tone, optional icon, `sm`/`xs` sizes. |
+| `ProcessLogLines` | Renders a PM2 process's log lines (the body of a log pane). |
+| `ProcessLogModal` | Self-contained viewer for a PM2 process's system log. |
+| `ProgressBar` | Horizontal progress meter — `percent` (or `null` for indeterminate), semantic `tone`, and the ARIA trio with an accessible name from `label`. |
+| `ProseEditor` | Prose-writing textarea — serif face, relaxed leading, spellcheck. Markdown string in/out. |
+| `ProvenanceChip` | Chip + popover showing where a generated value came from. |
+| `SideBySideDiff` | Columnar word-level diff — old left, new right. |
+| `TabPills` | Shared tab nav — `underline` / `pills` families, with a mobile `<select>` fallback. |
+| `Toast` | Toast notification system (`toast()`, `.success()`, `.error()`, `.loading()`, `<Toaster />`). |
+| `ToggleChip` | Checkbox styled as a pill — the "pick some of these" affordance. |
+| `ToolUseWarning` | The "this model can't call tools" warning every agent/model picker shows. |
+| `UnsavedChangesConfirm` | The discard confirm every `useUnsavedChangesGuard` consumer renders from `blocked`. |
+
+There is no `index.js` barrel here — components are imported by path
+(`import ProgressBar from '../ui/ProgressBar'`), matching the rest of `components/`. The
+barrel + README rule in the root `CLAUDE.md` covers `lib/`, `hooks/`, `utils/`, and
+`services/`; this catalog exists for discovery only. **Adding a primitive here means
+adding its row above** — a catalog nobody updates is the reason six copies of the
+progress meter existed in the first place.

--- a/client/src/pages/Loras.jsx
+++ b/client/src/pages/Loras.jsx
@@ -16,6 +16,7 @@ import toast from '../components/ui/Toast';
 import Modal from '../components/ui/Modal';
 import Banner from '../components/ui/Banner';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
+import ProgressBar from '../components/ui/ProgressBar';
 import { FormField } from '../components/ui/FormField';
 import { useConfirmDelete } from '../hooks/useConfirmDelete';
 import { formatBytes } from '../utils/formatters';
@@ -476,12 +477,7 @@ function HfDownloadProgress({ progress }) {
           <span className="font-mono text-gray-500">{formatBytes(progress.received)} / {formatBytes(total)}</span>
         )}
       </div>
-      <div className="h-1.5 w-full overflow-hidden rounded-full bg-port-bg" role="progressbar" aria-valuenow={pct ?? undefined} aria-valuemin={0} aria-valuemax={100}>
-        <div
-          className={`h-full bg-port-accent ${pct != null ? 'transition-[width] duration-200' : 'w-1/3 animate-pulse'}`}
-          style={pct != null ? { width: `${pct}%` } : undefined}
-        />
-      </div>
+      <ProgressBar percent={pct} label="Download progress" duration={200} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Six surfaces had each re-implemented the same `h-1.5 rounded-full` track + `style={{ width: `${pct}%` }}` fill, and they had already drifted on accessibility — only two carried `role="progressbar"` with `aria-valuenow`, so the rest were invisible to a screen reader.

- Adds `client/src/components/ui/ProgressBar.jsx`. It always emits the ARIA trio (`role="progressbar"`, `aria-valuenow`, `aria-valuemin`, `aria-valuemax`) plus an accessible name from `label`, which defaults to `Progress` so a bar is never nameless.
- Knobs map to real call-site shapes, nothing speculative: `percent` (clamped 0..100), `tone` (accent / accent2 / success / warning / error / muted), `label`, `size` (`sm` h-1.5, `md` h-2), `track` (`bg` on a card, `border` on the page ground), `duration` (static Tailwind class map — an interpolated `duration-${n}` is invisible to the build), and `className` for layout only.
- `percent` follows the repo's sentinel rule: `null`/`undefined` means *unmeasurable* and draws the indeterminate pulse with no `aria-valuenow` (the LoRA installer gets no `Content-Length` from some mirrors), while a non-finite number is a *broken* measurement (a `0 / 0` ratio) and renders an empty determinate bar rather than silently claiming indeterminate.

Migrated call sites — no behavior change beyond the added ARIA:

| File | Meter |
| --- | --- |
| `client/src/pages/Loras.jsx` | HuggingFace byte-level download (determinate + indeterminate) |
| `client/src/components/pipeline/manuscript/ManuscriptReadAloud.jsx` | narration elapsed/total |
| `client/src/components/pipeline/stages/EpisodeVideoStage.jsx` | scenes accepted |
| `client/src/components/meatspace/post/PostLlmDrillRunner.jsx` | prompt counter, training counter, countdown timer |
| `client/src/components/meatspace/post/MemoryPractice.jsx` | practice position, per-chunk mastery |
| `client/src/components/pipeline/AutopilotMilestones.jsx` | overall milestone meter |

The two files that had a local component literally named `ProgressBar` keep a thin domain wrapper over the shared primitive — `PromptProgress` (the "Prompt N of M" counter) and `PracticeProgress` — so the shared meter is the only thing drawing a bar. Consolidating the drill runner's training block into `PromptProgress` removed a seventh near-duplicate copy.

Two cosmetic values were normalized as part of de-drifting: the drill runner's two `/60`-opacity fills are now solid semantic tones, and the read-aloud track is `rounded-full` like the other five instead of `rounded`.

Also adds `client/src/components/ui/README.md` — the directory had no catalog, which is a large part of why six copies of this markup existed. It indexes every primitive in the directory and states the rule that a new one gets a row.

Closes #4138

## Test plan

- New `client/src/components/ui/ProgressBar.test.jsx` (29 cases): ARIA trio + accessible name, the default name when a host omits `label`, fill width, clamping above 100 / below 0, rounded `aria-valuenow` with a fractional width preserved, `NaN`/`Infinity` reading as an empty determinate bar rather than the indeterminate pulse, `null`/`undefined` producing the pulse with no `aria-valuenow` but with the bounds intact, every tone class, unknown-tone fallback, size/track switching, `className` pass-through, and the static duration map with its fallback.
- `cd client && npm test` — 640/641 files pass. The one failure is `src/pages/MoodBoardDetail.test.jsx` (a `GalleryImagePicker` act-warning flake unrelated to this change: it touches no progress meter, and the file passes on its own re-run).
- `npx biome lint --error-on-warnings` clean on all eight touched files.
- `src/a11yConventions.test.js` passes.
