### PR TITLE
Give sub-region loaders a shaped skeleton instead of a bare spinner

### DIFF
--- a/.changelog/next/changed-issue-4147.md
+++ b/.changelog/next/changed-issue-4147.md
@@ -1,0 +1,1 @@
+- Loading sub-regions that refetch after a page has already painted — the Brain, Goals, and Digital Twin tab-body Suspense fallbacks, the Data Manager category detail panel, the provider-usage section, and the per-app sprint board — now reserve a skeleton shaped to their content instead of a centered spinner

--- a/client/src/components/ui/PageSkeleton.jsx
+++ b/client/src/components/ui/PageSkeleton.jsx
@@ -1,7 +1,10 @@
+import { SkeletonBlock, SkeletonCard, skeletonRepeat } from './Skeleton';
+
 // Shared full-page loading skeleton. Reserves the dimensions a page renders
 // once loaded so the first paint doesn't reflow (issue #2843 — most pages used
 // to show a centered BrailleSpinner with no reserved layout, so content popped
-// in above the fold on every navigation).
+// in above the fold on every navigation). Built from the shared placeholder
+// primitives in `Skeleton.jsx`, which sub-region skeletons also use (#4147).
 //
 // Three axes cover every primary page shape in PortOS:
 //
@@ -89,31 +92,17 @@ export default function PageSkeleton({
     ? 'flex flex-wrap items-center justify-between gap-x-3 gap-y-2'
     : 'flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4');
 
-  // Callers derive counts from live data (`TABS.length`, a config value), so
-  // clamp rather than trusting them: `Array.from` throws on a negative or
-  // infinite length, and no page shell ever needs more than a few dozen blocks.
-  const repeat = (n) => Array.from({ length: Math.min(64, Math.max(0, Math.floor(n) || 0)) });
-
-  const cardBlocks = repeat(cards).map((_, i) => (
-    <div
-      key={i}
-      className="rounded-lg border border-port-border bg-port-card p-4 sm:p-6 animate-pulse"
-    >
-      <div className="h-5 w-2/3 rounded bg-port-border mb-3" />
-      <div className="h-4 w-1/2 rounded bg-port-border mb-2" />
-      <div className="h-4 w-1/3 rounded bg-port-border" />
-    </div>
-  ));
+  const cardBlocks = skeletonRepeat(cards).map((_, i) => <SkeletonCard key={i} />);
 
   const stackedCards = <div className="space-y-4">{cardBlocks}</div>;
 
-  const tabRows = repeat(tabs);
-  const sideBlockRows = repeat(sideBlocks);
+  const tabRows = skeletonRepeat(tabs);
+  const sideBlockRows = skeletonRepeat(sideBlocks);
   const renderTabStrip = (bordered) => tabRows.length > 0 ? (
     <div className={`shrink-0 flex gap-1 overflow-hidden ${bordered ? 'border-b border-port-border' : ''}`}>
       {tabRows.map((_, i) => (
         <div key={i} className="h-[44px] w-20 sm:w-24 flex items-center px-2">
-          <div className="h-4 w-full rounded bg-port-card animate-pulse" />
+          <SkeletonBlock className="h-4 w-full" />
         </div>
       ))}
     </div>
@@ -124,14 +113,14 @@ export default function PageSkeleton({
   if (layout === 'split') {
     const sideRail = (
       <>
-        <div className={`h-5 w-2/3 rounded bg-port-card animate-pulse ${sideHero ? 'mx-auto' : ''}`} />
+        <SkeletonBlock className={`h-5 w-2/3 ${sideHero ? 'mx-auto' : ''}`} />
         {sideHero && (
-          <div className="mx-auto h-24 w-24 sm:h-32 sm:w-32 lg:h-40 lg:w-40 rounded-full bg-port-card animate-pulse" />
+          <SkeletonBlock roundedClass="rounded-full" className="mx-auto h-24 w-24 sm:h-32 sm:w-32 lg:h-40 lg:w-40" />
         )}
         {sideBlockRows.length > 0 && (
           <div className={`grid gap-1.5 ${sideBlockColsClass}`}>
             {sideBlockRows.map((_, i) => (
-              <div key={i} className="h-[52px] rounded border border-port-border bg-port-card animate-pulse" />
+              <SkeletonBlock key={i} className="h-[52px] border border-port-border" />
             ))}
           </div>
         )}
@@ -174,14 +163,7 @@ export default function PageSkeleton({
       <div className={`grid grid-cols-1 gap-6 items-start ${sidebar ? 'lg:grid-cols-[1fr_360px]' : ''}`}>
         {stackedCards}
         {sidebar && (
-          <div className="rounded-lg border border-port-border bg-port-card p-4 sm:p-6 animate-pulse">
-            <div className="h-5 w-1/3 rounded bg-port-border mb-4" />
-            <div className="space-y-2">
-              <div className="h-4 w-full rounded bg-port-border" />
-              <div className="h-4 w-5/6 rounded bg-port-border" />
-              <div className="h-4 w-4/6 rounded bg-port-border" />
-            </div>
-          </div>
+          <SkeletonCard titleWidthClass="w-1/3" lineWidths={['w-full', 'w-5/6', 'w-4/6']} />
         )}
       </div>
     );
@@ -202,15 +184,15 @@ export default function PageSkeleton({
                 stacks the ACTION under the title (what the page does) rather
                 than breaking the icon off onto its own line. */}
             <div className="flex items-center gap-2 sm:gap-3 min-w-0">
-              <div className="w-6 h-6 sm:w-7 sm:h-7 shrink-0 rounded bg-port-card animate-pulse" />
+              <SkeletonBlock className="w-6 h-6 sm:w-7 sm:h-7 shrink-0" />
               <div className="min-w-0">
-                <div className={`h-6 sm:h-7 rounded bg-port-card animate-pulse ${titleWidthClass}`} />
+                <SkeletonBlock className={`h-6 sm:h-7 ${titleWidthClass}`} />
                 {showSubtitle && (
-                  <div className={`${subtitleOnMobile ? '' : 'hidden sm:block'} h-4 w-64 max-w-full rounded bg-port-card animate-pulse mt-1`} />
+                  <SkeletonBlock className={`${subtitleOnMobile ? '' : 'hidden sm:block'} h-4 w-64 max-w-full mt-1`} />
                 )}
               </div>
             </div>
-            {showAction && <div className="h-6 w-24 rounded bg-port-card animate-pulse" />}
+            {showAction && <SkeletonBlock className="h-6 w-24" />}
           </div>
           {/* Pages that nest their tab row inside the header block (no divider
               between title and tabs) reserve it here rather than below the bar. */}
@@ -234,12 +216,12 @@ export default function PageSkeleton({
       {header !== 'none' && (
         <div className={`${headerRow} mb-6`}>
           <div className="min-w-0">
-            <div className={`h-8 rounded bg-port-card animate-pulse ${titleWidthClass}`} />
+            <SkeletonBlock className={`h-8 ${titleWidthClass}`} />
             {showSubtitle && (
-              <div className="h-4 w-56 max-w-full rounded bg-port-card animate-pulse mt-2" />
+              <SkeletonBlock className="h-4 w-56 max-w-full mt-2" />
             )}
           </div>
-          {showAction && <div className="h-10 w-full sm:w-48 rounded bg-port-card animate-pulse" />}
+          {showAction && <SkeletonBlock className="h-10 w-full sm:w-48" />}
         </div>
       )}
       {tabRows.length > 0 && <div className="mb-4">{renderTabStrip(true)}</div>}

--- a/client/src/components/ui/PageSkeleton.test.jsx
+++ b/client/src/components/ui/PageSkeleton.test.jsx
@@ -66,8 +66,10 @@ describe('PageSkeleton', () => {
 
   it('omits the header entirely for header="none" (page already rendered its own)', () => {
     const { container } = render(<PageSkeleton header="none" cards={1} sidebar={false} />);
-    // Only the single card block remains — no title/action placeholders.
-    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(1);
+    // Only the single card block remains — no title/action placeholders. Its
+    // own title + two body lines are the only pulsing blocks left.
+    expect(cardCount(container)).toBe(1);
+    expect(container.querySelectorAll('.animate-pulse')).toHaveLength(3);
   });
 
   it('reserves a bordered PageHeader bar for header="bar"', () => {

--- a/client/src/components/ui/README.md
+++ b/client/src/components/ui/README.md
@@ -34,6 +34,7 @@ accessibility). Feature-specific components live under their own feature directo
 | `ProseEditor` | Prose-writing textarea — serif face, relaxed leading, spellcheck. Markdown string in/out. |
 | `ProvenanceChip` | Chip + popover showing where a generated value came from. |
 | `SideBySideDiff` | Columnar word-level diff — old left, new right. |
+| `Skeleton` | Loading-placeholder primitives (`SkeletonBlock` / `Lines` / `Card` / `Rows` / `Region`) — what `PageSkeleton` is built from, and what a sub-region loader should reserve its shape with instead of a bare spinner. |
 | `TabPills` | Shared tab nav — `underline` / `pills` families, with a mobile `<select>` fallback. |
 | `Toast` | Toast notification system (`toast()`, `.success()`, `.error()`, `.loading()`, `<Toaster />`). |
 | `ToggleChip` | Checkbox styled as a pill — the "pick some of these" affordance. |

--- a/client/src/components/ui/Skeleton.jsx
+++ b/client/src/components/ui/Skeleton.jsx
@@ -1,0 +1,111 @@
+// Shared skeleton placeholder primitives.
+//
+// `PageSkeleton` reserves a WHOLE page's shape at first paint (#2843). These are
+// the pieces it is built from, exported so a SUB-REGION that refetches after the
+// surrounding page has already rendered — a Suspense fallback for a tab body, a
+// detail panel loading its rows — can reserve its own shape too, instead of
+// dropping a centered `BrailleSpinner` into a tall empty box (#4147).
+//
+// Two tones, because a placeholder has to sit a step off whatever is behind it:
+//   'card'   — on the page background (`bg-port-card`). The default.
+//   'border' — INSIDE a card, where `bg-port-card` would vanish into the card
+//              itself (`bg-port-border`).
+//
+// Every block pulses, and every block honors `prefers-reduced-motion` via
+// `motion-reduce:animate-none` — so a reduced-motion user gets the reserved
+// dimensions without the throb.
+const TONES = {
+  card: 'bg-port-card',
+  border: 'bg-port-border',
+};
+
+// Callers derive counts from live data (`TABS.length`, a config value), so clamp
+// rather than trusting them: `Array.from` throws on a negative or infinite
+// length, and no skeleton ever needs more than a few dozen blocks.
+export function skeletonRepeat(n) {
+  return Array.from({ length: Math.min(64, Math.max(0, Math.floor(n) || 0)) });
+}
+
+// One pulsing block. Size it entirely through `className` (`h-4 w-1/2`, …) —
+// the primitive owns only the fill, the rounding, and the animation. Rounding is
+// its own prop rather than something `className` overrides, because two
+// competing `rounded*` utilities resolve by stylesheet order, not by the order
+// they appear in the attribute — so a `rounded-full` avatar block passed through
+// `className` would be a coin flip.
+export function SkeletonBlock({ tone = 'card', roundedClass = 'rounded', className = '' }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`${roundedClass} ${TONES[tone] || TONES.card} animate-pulse motion-reduce:animate-none ${className}`}
+    />
+  );
+}
+
+// A stack of text lines. `widths` doubles as the count, so ragged line lengths
+// (the thing that makes a skeleton read as prose rather than as a grey slab)
+// are the default rather than an extra prop.
+export function SkeletonLines({
+  widths = ['w-full', 'w-5/6', 'w-4/6'],
+  tone = 'card',
+  heightClass = 'h-4',
+  gapClass = 'space-y-2',
+  className = '',
+}) {
+  return (
+    <div className={`${gapClass} ${className}`}>
+      {widths.map((width, i) => (
+        <SkeletonBlock key={i} tone={tone} className={`${heightClass} ${width}`} />
+      ))}
+    </div>
+  );
+}
+
+// A bordered content card: title line over body lines. The card chrome matches a
+// real PortOS card (`rounded-lg border border-port-border bg-port-card`) so the
+// swap to loaded content doesn't move the border.
+export function SkeletonCard({
+  titleWidthClass = 'w-2/3',
+  lineWidths = ['w-1/2', 'w-1/3'],
+  className = '',
+}) {
+  return (
+    <div className={`rounded-lg border border-port-border bg-port-card p-4 sm:p-6 ${className}`}>
+      <SkeletonBlock tone="border" className={`h-5 mb-3 ${titleWidthClass}`} />
+      <SkeletonLines tone="border" widths={lineWidths} />
+    </div>
+  );
+}
+
+// Table/list rows. `columnWidthClasses` is one entry per column, so the reserved
+// row lines up with the real table's columns instead of being a single bar.
+export function SkeletonRows({
+  rows = 5,
+  columnWidthClasses = ['flex-1', 'w-14', 'w-10'],
+  heightClass = 'h-3',
+  tone = 'card',
+  rowClassName = 'flex items-center gap-2 px-3 py-2 border-b border-port-border/20',
+  className = '',
+}) {
+  return (
+    <div className={className}>
+      {skeletonRepeat(rows).map((_, row) => (
+        <div key={row} className={rowClassName}>
+          {columnWidthClasses.map((width, col) => (
+            <SkeletonBlock key={col} tone={tone} className={`${heightClass} ${width}`} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// The busy-region wrapper. A sub-region skeleton still has to ANNOUNCE itself —
+// the spinner it replaces was the only thing telling a screen reader the panel
+// was loading, so keep `label` specific ("Loading data contents", not "Loading").
+export function SkeletonRegion({ label = 'Loading', className = '', children }) {
+  return (
+    <div role="status" aria-busy="true" aria-label={label} className={className}>
+      {children}
+    </div>
+  );
+}

--- a/client/src/components/ui/Skeleton.test.jsx
+++ b/client/src/components/ui/Skeleton.test.jsx
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import {
+  SkeletonBlock,
+  SkeletonCard,
+  SkeletonLines,
+  SkeletonRegion,
+  SkeletonRows,
+  skeletonRepeat,
+} from './Skeleton';
+
+const pulses = (container) => container.querySelectorAll('.animate-pulse');
+
+describe('skeletonRepeat', () => {
+  it('produces the requested number of slots', () => {
+    expect(skeletonRepeat(3)).toHaveLength(3);
+  });
+
+  // Counts come from live data, so a bad one must degrade to empty rather than
+  // throwing inside `Array.from`.
+  it.each([[-4], [0], [NaN], ['nope'], [undefined]])(
+    'clamps %p to zero slots instead of throwing',
+    (bad) => {
+      expect(skeletonRepeat(bad)).toHaveLength(0);
+    }
+  );
+
+  // A runaway count is capped rather than zeroed — something IS loading, so the
+  // region should still reserve a plausible amount of space.
+  it.each([[10_000], [Infinity]])('caps %p at the block ceiling', (huge) => {
+    expect(skeletonRepeat(huge)).toHaveLength(64);
+  });
+});
+
+describe('SkeletonBlock', () => {
+  it('pulses but stands down for prefers-reduced-motion', () => {
+    const { container } = render(<SkeletonBlock className="h-4 w-8" />);
+    const block = container.firstChild;
+    expect(block.className).toContain('animate-pulse');
+    expect(block.className).toContain('motion-reduce:animate-none');
+  });
+
+  it('is hidden from assistive tech — the region wrapper owns the announcement', () => {
+    const { container } = render(<SkeletonBlock />);
+    expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('defaults to the page-background tone and swaps to the in-card tone', () => {
+    const { container: onPage } = render(<SkeletonBlock />);
+    expect(onPage.firstChild.className).toContain('bg-port-card');
+
+    const { container: inCard } = render(<SkeletonBlock tone="border" />);
+    expect(inCard.firstChild.className).toContain('bg-port-border');
+    expect(inCard.firstChild.className).not.toContain('bg-port-card');
+  });
+
+  // Two `rounded*` utilities resolve by stylesheet order, so rounding is a prop
+  // rather than something a caller layers on through className.
+  it('takes rounding as a prop so it fully replaces the default', () => {
+    const { container } = render(<SkeletonBlock roundedClass="rounded-full" />);
+    expect(container.firstChild.className).toContain('rounded-full');
+    expect(container.firstChild.className.split(/\s+/)).not.toContain('rounded');
+  });
+
+  it('applies caller sizing', () => {
+    const { container } = render(<SkeletonBlock className="h-24 w-24" />);
+    expect(container.firstChild.className).toContain('h-24');
+    expect(container.firstChild.className).toContain('w-24');
+  });
+});
+
+describe('SkeletonLines', () => {
+  it('renders one line per width so ragged lengths read as prose', () => {
+    const { container } = render(<SkeletonLines widths={['w-full', 'w-1/2']} />);
+    expect(pulses(container)).toHaveLength(2);
+    expect(container.innerHTML).toContain('w-1/2');
+  });
+});
+
+describe('SkeletonCard', () => {
+  it('carries real card chrome so the border does not move on swap', () => {
+    const { container } = render(<SkeletonCard />);
+    expect(container.firstChild.className).toContain('rounded-lg');
+    expect(container.firstChild.className).toContain('border-port-border');
+    expect(container.firstChild.className).toContain('bg-port-card');
+  });
+
+  it('renders a title line plus one line per body width', () => {
+    const { container } = render(<SkeletonCard lineWidths={['w-1/2', 'w-1/3', 'w-1/4']} />);
+    expect(pulses(container)).toHaveLength(4);
+  });
+});
+
+describe('SkeletonRows', () => {
+  it('renders one block per column per row so the reserved row matches the table', () => {
+    const { container } = render(
+      <SkeletonRows rows={3} columnWidthClasses={['flex-1', 'w-14', 'w-10']} />
+    );
+    expect(pulses(container)).toHaveLength(9);
+  });
+
+  it('clamps a bad row count instead of throwing', () => {
+    const { container } = render(<SkeletonRows rows={-2} />);
+    expect(pulses(container)).toHaveLength(0);
+  });
+});
+
+describe('SkeletonRegion', () => {
+  it('announces itself as a busy status region with the caller label', () => {
+    render(
+      <SkeletonRegion label="Loading data contents">
+        <SkeletonBlock />
+      </SkeletonRegion>
+    );
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-busy', 'true');
+    expect(region).toHaveAttribute('aria-label', 'Loading data contents');
+  });
+});

--- a/client/src/pages/Apps.jsx
+++ b/client/src/pages/Apps.jsx
@@ -5,8 +5,8 @@ import toast from '../components/ui/Toast';
 import InlineConfirmRow from '../components/ui/InlineConfirmRow';
 import OverflowMenu from '../components/ui/OverflowMenu';
 import AppIcon from '../components/AppIcon';
-import BrailleSpinner from '../components/BrailleSpinner';
 import PageSkeleton from '../components/ui/PageSkeleton';
+import { SkeletonBlock, SkeletonRegion, skeletonRepeat } from '../components/ui/Skeleton';
 import KanbanBoard from '../components/KanbanBoard';
 import StatusBadge from '../components/StatusBadge';
 import AppOperationBanner from '../components/apps/AppOperationBanner';
@@ -614,10 +614,27 @@ export default function Apps() {
                           <div className="mt-3">
                             <div className="text-xs text-gray-500 uppercase tracking-wide mb-2">My Sprint Tickets</div>
                             {loadingTickets[sprintKey(app)] ? (
-                              <div className="flex items-center gap-2 px-3 py-2 text-sm text-gray-400">
-                                <BrailleSpinner text="" />
-                                <span>Loading tickets...</span>
-                              </div>
+                              // Reserve the board's three columns instead of a
+                              // one-line spinner (#4147) — the board is ~120px
+                              // tall, so the spinner row let everything below
+                              // the expansion jump when the tickets landed.
+                              <SkeletonRegion
+                                label={`Loading sprint tickets for ${app.name}`}
+                                className="flex gap-3 overflow-x-auto pb-2"
+                              >
+                                {skeletonRepeat(3).map((_, col) => (
+                                  <div
+                                    key={col}
+                                    className="flex-1 min-w-[220px] min-h-[120px] rounded-lg border border-port-border p-3"
+                                  >
+                                    <SkeletonBlock className="h-4 w-24 mb-3" />
+                                    <div className="space-y-2">
+                                      <SkeletonBlock className="h-10 w-full" />
+                                      <SkeletonBlock className="h-10 w-full" />
+                                    </div>
+                                  </div>
+                                ))}
+                              </SkeletonRegion>
                             ) : ticketErrors[sprintKey(app)] ? (
                               <div className="flex flex-wrap items-center gap-3 px-3 py-2 bg-port-card border border-port-error/30 rounded-lg">
                                 <AlertTriangle size={16} aria-hidden="true" className="text-port-error shrink-0" />

--- a/client/src/pages/Apps.test.jsx
+++ b/client/src/pages/Apps.test.jsx
@@ -539,3 +539,33 @@ describe('Apps sprint-ticket cache keying (#3437)', () => {
     expect(api.getMySprintTickets).toHaveBeenLastCalledWith('jira-1', 'OTHER', { silent: true });
   });
 });
+
+// The Kanban board is a ~120px-tall region that loads after the row expands, so
+// the one-line spinner it used to show let everything below the expansion jump
+// once the tickets landed (#4147).
+describe('Apps sprint-ticket loading state (#4147)', () => {
+  const JIRA_APP = {
+    ...APPS[0],
+    jira: { enabled: true, instanceId: 'jira-1', projectKey: 'EX', issueType: 'Task' }
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getApps.mockResolvedValue([JIRA_APP]);
+  });
+
+  it('reserves the board columns instead of a one-line spinner', async () => {
+    // Never resolves — hold the expansion on its ticket-loading branch.
+    api.getMySprintTickets.mockReturnValue(new Promise(() => {}));
+    const user = userEvent.setup();
+    await renderApps();
+
+    await user.click(screen.getByRole('button', { name: /Expand Example App details/ }));
+
+    const region = await screen.findByRole('status', { name: 'Loading sprint tickets for Example App' });
+    expect(region).toHaveAttribute('aria-busy', 'true');
+    // Three columns, each reserving a heading plus two ticket cards.
+    expect(region.querySelectorAll('.animate-pulse')).toHaveLength(9);
+    expect(region.querySelectorAll('.min-h-\\[120px\\]')).toHaveLength(3);
+  });
+});

--- a/client/src/pages/Brain.jsx
+++ b/client/src/pages/Brain.jsx
@@ -2,7 +2,6 @@ import { useCallback, lazy, Suspense } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import * as api from '../services/api';
 import {Brain as BrainIcon} from 'lucide-react';
-import BrailleSpinner from '../components/BrailleSpinner';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import PageHeader from '../components/PageHeader';
 import TabPills from '../components/ui/TabPills';
@@ -145,7 +144,12 @@ export default function Brain() {
       {/* Tab content — full-bleed tabs own their own scroll and fill height;
           document-style tabs scroll inside a padded wrapper. */}
       <div className={`flex-1 min-h-0 ${fullBleed ? 'overflow-hidden' : 'overflow-auto p-3 sm:p-4'}`}>
-        <Suspense fallback={<div className="flex items-center justify-center h-64"><BrailleSpinner text="Loading" /></div>}>
+        {/* The lazy tab chunk lands in a region the page has already sized, so
+            reserve that region's card stack rather than centering a spinner in
+            it (#4147). Mirror the wrapper: a document-style tab is padded by the
+            wrapper already, a full-bleed one isn't, so the skeleton pads itself
+            there instead of running its cards into the edges. */}
+        <Suspense fallback={<PageSkeleton header="none" label="Loading brain section" cards={3} sidebar={false} padded={fullBleed} />}>
           {renderTabContent()}
         </Suspense>
       </div>

--- a/client/src/pages/DataManager.jsx
+++ b/client/src/pages/DataManager.jsx
@@ -2,8 +2,8 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { HardDrive, RefreshCw, Archive, Trash2, ChevronDown, ChevronRight, FolderOpen, File, Package } from 'lucide-react';
 import * as api from '../services/api';
 import { formatBytes, formatDateNumeric } from '../utils/formatters';
-import BrailleSpinner from '../components/BrailleSpinner';
 import PageSkeleton from '../components/ui/PageSkeleton';
+import { SkeletonRegion, SkeletonRows } from '../components/ui/Skeleton';
 import toast from '../components/ui/Toast';
 import socket from '../services/socket';
 import { useAsyncAction } from '../hooks/useAsyncAction';
@@ -284,9 +284,17 @@ function CategoryRow({ cat, maxSize, onExpand, expanded, detail, onArchive, onPu
               )}
             </div>
           ) : (
-            <div className="p-3 flex items-center gap-2 text-xs text-gray-500">
-              <BrailleSpinner text="Loading" />
-      </div>
+            // Reserve the item table's rows and columns rather than centering a
+            // spinner in the panel (#4147). `max-h-64` matches the loaded
+            // scroller so expanding a category doesn't resize when it fills in.
+            <SkeletonRegion label={`Loading ${cat.label} contents`} className="max-h-64 overflow-hidden">
+              <SkeletonRows
+                rows={5}
+                columnWidthClasses={itemScoped
+                  ? ['flex-1', 'w-14', 'w-10', 'w-4']
+                  : ['flex-1', 'w-14', 'w-10']}
+              />
+            </SkeletonRegion>
           )}
         </div>
       )}

--- a/client/src/pages/DataManager.test.jsx
+++ b/client/src/pages/DataManager.test.jsx
@@ -316,3 +316,28 @@ describe('DataManager full-width shell (#4145)', () => {
     expect(skeletonScrollers[0].className).toContain('p-4');
   });
 });
+
+// The category detail panel refetches after the page has already rendered, so
+// it used to drop a bare BrailleSpinner into a panel the row had just expanded
+// to full height (#4147).
+describe('DataManager category detail loading state (#4147)', () => {
+  beforeEach(() => {
+    getDataOverview.mockReset().mockResolvedValue(overview);
+    // Never resolves — hold the expanded category on its detail-loading branch.
+    getDataCategory.mockReset().mockReturnValue(new Promise(() => {}));
+  });
+
+  it('reserves the item table instead of centering a spinner', async () => {
+    render(<DataManager />);
+    await waitFor(() => expect(screen.getAllByText('Prompts').length).toBeGreaterThan(0));
+
+    expandRow('Prompts');
+
+    const panel = await screen.findByRole('status', { name: 'Loading Prompts contents' });
+    expect(panel).toHaveAttribute('aria-busy', 'true');
+    // Five rows × three columns (Name / Size / Files) of reserved blocks.
+    expect(panel.querySelectorAll('.animate-pulse')).toHaveLength(15);
+    // Matches the loaded scroller's cap so filling in doesn't resize the panel.
+    expect(panel.className).toContain('max-h-64');
+  });
+});

--- a/client/src/pages/DigitalTwin.jsx
+++ b/client/src/pages/DigitalTwin.jsx
@@ -2,7 +2,6 @@ import { useCallback, lazy, Suspense } from 'react';
 import { useParams, useNavigate } from 'react-router';
 import * as api from '../services/api';
 import { Heart } from 'lucide-react';
-import BrailleSpinner from '../components/BrailleSpinner';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import { useAutoRefetch } from '../hooks/useAutoRefetch';
 import { sameJsonShape } from '../lib/sameJsonShape';
@@ -167,7 +166,9 @@ export default function DigitalTwin() {
 
       {/* Tab content */}
       <div className="flex-1 overflow-auto p-4">
-        <Suspense fallback={<div className="flex justify-center py-12"><BrailleSpinner text="Loading" /></div>}>
+        {/* Reserve the section's card stack while its lazy chunk loads — the
+            wrapper already owns the padding and the scroll (#4147). */}
+        <Suspense fallback={<PageSkeleton header="none" label="Loading digital twin section" cards={3} sidebar={false} />}>
           {renderTabContent()}
         </Suspense>
       </div>

--- a/client/src/pages/Goals.jsx
+++ b/client/src/pages/Goals.jsx
@@ -6,7 +6,6 @@ import GoalsListView from '../components/goals/GoalsListView';
 import MortalLoomBanner from '../components/MortalLoomBanner';
 import PageHeader from '../components/PageHeader';
 import TabPills from '../components/ui/TabPills';
-import BrailleSpinner from '../components/BrailleSpinner';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import { useValidTab } from '../hooks/useValidTab';
 
@@ -80,7 +79,10 @@ export default function Goals() {
         ) : tab === 'list' ? (
           <GoalsListView data={data} onRefresh={loadData} selectedGoalId={goalId} />
         ) : (
-          <Suspense fallback={<div className="flex items-center justify-center h-full"><BrailleSpinner text="Loading" /></div>}>
+          // Same reserved shape the page's own load branch uses above — the tree
+          // chunk arriving late shouldn't look different from the data arriving
+          // late (#4147).
+          <Suspense fallback={<PageSkeleton header="none" label="Loading goal tree" fullHeight cards={4} sidebar={false} />}>
             <GoalsTreeView data={data} onRefresh={loadData} />
           </Suspense>
         )}

--- a/client/src/pages/UsagePage.jsx
+++ b/client/src/pages/UsagePage.jsx
@@ -295,7 +295,16 @@ function ProviderQuotaSection() {
       </div>
 
       {loading && !quotas && (
-        <div className="py-6"><BrailleSpinner text="Reading provider usage" /></div>
+        // Reserve the quota-card grid below rather than a centered spinner
+        // (#4147) — the cards are the whole section, so the reading arriving
+        // shouldn't jump the page down by their height.
+        <PageSkeleton
+          header="none"
+          label="Reading provider usage"
+          layout="grid"
+          gridColsClass="lg:grid-cols-2"
+          cards={4}
+        />
       )}
 
       {!loading && error && !quotas && (

--- a/client/src/pages/UsagePage.test.jsx
+++ b/client/src/pages/UsagePage.test.jsx
@@ -231,3 +231,21 @@ describe('UsagePage provider reset times', () => {
     expect(reset.textContent).not.toContain(resetsAt);
   });
 });
+
+// The provider-quota section reads every provider on mount, well after the page
+// shell has painted. A centered spinner there let the whole page below it jump
+// by the card grid's height once the reading landed (#4147).
+describe('UsagePage provider-quota loading state (#4147)', () => {
+  it('reserves the quota card grid instead of centering a spinner', async () => {
+    // Never resolves — hold the section on its loading branch.
+    api.getProviderUsage.mockReturnValue(new Promise(() => {}));
+
+    render(<MemoryRouter><UsagePage /></MemoryRouter>);
+
+    const region = await screen.findByRole('status', { name: 'Reading provider usage' });
+    expect(region).toHaveAttribute('aria-busy', 'true');
+    expect(region.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    // Mirrors the loaded grid so the cards land where the placeholders were.
+    expect(region.innerHTML).toContain('lg:grid-cols-2');
+  });
+});

--- a/client/src/pages/suspenseFallbackSkeletons.test.jsx
+++ b/client/src/pages/suspenseFallbackSkeletons.test.jsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router';
+
+// One file rather than three, because the assertion is a single cross-page
+// contract: a tab body's lazy chunk arriving late must reserve the region's
+// shape, not drop a centered BrailleSpinner into a tall empty box (#4147).
+// Brain / Goals / DigitalTwin all need the same scaffolding (router param, a
+// resolved data fetch, and a tab child that is still suspended), so splitting
+// it three ways would be the same 40 lines of mocks copied three times.
+
+// A lazily-imported tab body that never finishes rendering: throwing a promise
+// that never settles is exactly what a still-downloading chunk does to React,
+// so the page stays parked on its Suspense fallback.
+// (`vi.mock` factories are hoisted above the module body, so each one builds
+// its own suspending component rather than closing over a shared const.)
+vi.mock('../components/brain/tabs/InboxTab', () => ({
+  default: () => { throw new Promise(() => {}); },
+}));
+vi.mock('../components/goals/GoalsTreeView', () => ({
+  default: () => { throw new Promise(() => {}); },
+}));
+vi.mock('../components/digital-twin/tabs/OverviewTab', () => ({
+  default: () => { throw new Promise(() => {}); },
+}));
+
+vi.mock('../services/api', () => ({
+  getBrainSummary: vi.fn(() => Promise.resolve({ counts: {}, needsReview: 0 })),
+  getBrainSettings: vi.fn(() => Promise.resolve({})),
+  getDigitalTwinStatus: vi.fn(() => Promise.resolve({ healthScore: 50, documentCount: 0, enabledDocuments: 0 })),
+  getDigitalTwinSettings: vi.fn(() => Promise.resolve({})),
+  getGoalsTree: vi.fn(() => Promise.resolve({ flat: [], tree: [] })),
+}));
+
+const renderAt = async (path, routePath, Page) => {
+  render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route path={routePath} element={<Page />} />
+      </Routes>
+    </MemoryRouter>
+  );
+  // The first-paint skeleton and the Suspense fallback are both `role=status`,
+  // so wait for the fallback's specific label before asserting on it.
+  return waitFor(() => expect(screen.getAllByRole('status').length).toBeGreaterThan(0));
+};
+
+describe('tab-body Suspense fallbacks reserve a skeleton, not a spinner (#4147)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('Brain reserves the tab region while the tab chunk is still loading', async () => {
+    const { default: Brain } = await import('./Brain');
+    await renderAt('/brain/inbox', '/brain/:tab', Brain);
+
+    await waitFor(() =>
+      expect(screen.getByRole('status', { name: 'Loading brain section' })).toBeInTheDocument()
+    );
+    // The BrailleSpinner renders its frames as text; a skeleton reserves boxes.
+    expect(document.querySelector('.animate-pulse')).toBeTruthy();
+  });
+
+  it('Goals reserves the tree region while the tree chunk is still loading', async () => {
+    const { default: Goals } = await import('./Goals');
+    await renderAt('/goals/tree', '/goals/:tab', Goals);
+
+    await waitFor(() =>
+      expect(screen.getByRole('status', { name: 'Loading goal tree' })).toBeInTheDocument()
+    );
+    expect(document.querySelector('.animate-pulse')).toBeTruthy();
+  });
+
+  it('DigitalTwin reserves the section region while the section chunk is still loading', async () => {
+    const { default: DigitalTwin } = await import('./DigitalTwin');
+    await renderAt('/digital-twin/overview', '/digital-twin/:tab', DigitalTwin);
+
+    await waitFor(() =>
+      expect(screen.getByRole('status', { name: 'Loading digital twin section' })).toBeInTheDocument()
+    );
+    expect(document.querySelector('.animate-pulse')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

The #2843 loading-skeleton rollout covered first-paint page loads. Sub-regions that refetch *after* the surrounding page has already painted — tab-body Suspense fallbacks, detail panels — still dropped a bare centered `BrailleSpinner` into a tall empty box, so the content landing under them jumped the page.

`PageSkeleton`'s placeholder markup is extracted into shared primitives in `client/src/components/ui/Skeleton.jsx` — `SkeletonBlock` / `SkeletonLines` / `SkeletonCard` / `SkeletonRows` / `SkeletonRegion` plus the count-clamping `skeletonRepeat`. `PageSkeleton` is rebuilt on them (no visual change beyond the pulse moving from the card wrapper to its lines), so the page shell and the sub-regions now reserve space the same way. Two things fall out of having one place to put them:

- every block gets `motion-reduce:animate-none`, so a reduced-motion user gets the reserved dimensions without the throb;
- rounding is a prop rather than a `className` override, because two competing `rounded*` utilities resolve by stylesheet order rather than attribute order — a `rounded-full` avatar block passed through `className` was a coin flip.

Converted sub-regions, each reserving that region's own shape:

| Region | Reserves |
| --- | --- |
| `Brain.jsx` tab-body Suspense fallback | the tab's card stack; pads itself only on full-bleed tabs, where the wrapper doesn't |
| `Goals.jsx` tree Suspense fallback | the same shape the page's own load branch already used |
| `DigitalTwin.jsx` section Suspense fallback | the section's card stack |
| `DataManager.jsx` category detail | the item table's rows and columns, capped at the loaded scroller's `max-h-64` |
| `UsagePage.jsx` provider-quota section | the `lg:grid-cols-2` quota card grid |
| `Apps.jsx` per-app sprint board | the board's three `min-h-[120px]` columns |

Each carries a specific `role="status"` / `aria-label` (`Loading brain section`, `Loading Prompts contents`, …), so the announcement the spinner used to make survives — and says what is loading.

**Left as spinners, deliberately** — these are not region loads, and a skeleton would be the wrong affordance:

- `UsagePage.jsx:128` — the inline "Reading quota…" line *inside* an already-rendered provider card, and `:787`'s backfill button spinner. Both are inline status on existing chrome, not a region being filled.
- `CharacterSheet.jsx:484` — the avatar overlay during generation. It sits on top of an avatar that is already there and has its own step counter underneath; a skeleton would hide the image being replaced and misreport progress as a load.

## Test plan

- `client/src/components/ui/Skeleton.test.jsx` (new, 18 cases) — tone/rounding/sizing on `SkeletonBlock`, `aria-hidden` on blocks vs the `role="status"` announcement on `SkeletonRegion`, line/row/column counts, `motion-reduce`, and `skeletonRepeat`'s clamping (negative / `NaN` / non-numeric → 0 slots; `10_000` and `Infinity` → the 64 ceiling).
- `client/src/pages/suspenseFallbackSkeletons.test.jsx` (new) — renders Brain, Goals, and Digital Twin with their lazy tab body mocked to a component that suspends forever, and asserts each parks on its named skeleton region with pulsing blocks, not a spinner. One file because the assertion is a single cross-page contract over identical scaffolding.
- `DataManager.test.jsx`, `UsagePage.test.jsx`, `Apps.test.jsx` — a case each, holding the region's fetch on a never-resolving promise and asserting the reserved row/column/card counts and the `max-h-64` / `lg:grid-cols-2` / `min-h-[120px]` sizing that keeps the swap layout-neutral.
- `PageSkeleton.test.jsx` — one assertion updated: the `header="none"` case counted pulsing elements, which moved from the card wrapper to its three lines; it now asserts the card count *and* the line count.
- `cd client && npm test` → 645 files, 7857 tests, all passing.
- `cd client && npm run lint` (biome, `--error-on-warnings`) → clean.

Closes #4147
