### PR TITLE
fix: portal MediaLightbox's fixed overlay out of glass-theme cards (#4151)

### DIFF
--- a/.changelog/next/fixed-issue-4151.md
+++ b/.changelog/next/fixed-issue-4151.md
@@ -1,0 +1,1 @@
+- Media lightbox no longer gets trapped inside a gallery card on glass themes — its overlay now portals to the document body so it covers the full viewport

--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import {
   X, Copy, Sparkles, Film, Image as ImageIcon, Download, Eraser, Wand2,
   ChevronLeft, ChevronRight, Maximize2, Minimize2, Star, Box, ScanEye,
@@ -33,8 +34,9 @@ import { formatDateTime, formatDateNumeric } from '../../utils/formatters';
 // (A mobile tap-to-open bottom-sheet drawer existed pre-ed0e4859 and was
 // removed because it covered the image area in fullscreen.)
 // Opting out means owning the dialog semantics Modal would have supplied:
-// the overlay carries role="dialog"/aria-modal and runs useFocusTrap itself,
-// and `a11yConventions.test.js` allowlists it on that basis.
+// the overlay carries role="dialog"/aria-modal, runs useFocusTrap itself, and
+// portals to <body> in place of Modal's `usePortal` (see the render below);
+// `a11yConventions.test.js` allowlists it on that basis.
 
 const NOTE_MAX = 2000;
 const NOTE_DEBOUNCE_MS = 500;
@@ -238,7 +240,15 @@ export default function MediaLightbox({
   // — bottom-anchoring would bury them in the SettingsPane underneath.
   const chevronPositionClass = fullScreen ? 'bottom-4' : 'top-1/2 -translate-y-1/2';
 
-  return (
+  // Portal to <body>. The overlay is a hand-rolled `fixed inset-0` (this file
+  // opts out of <ui/Modal> and its `usePortal`, see the note at the top), and
+  // the lightbox is opened from inside themed gallery cards. On "glass" themes
+  // (`--port-backdrop-filter` non-none) `index.css` gives every bordered/rounded
+  // `.bg-port-card` a backdrop-filter, which makes it the containing block for
+  // position:fixed descendants — an inline overlay would be sized to the card
+  // instead of the viewport. Same fix as GalleryImagePicker / FolderPicker,
+  // reached through createPortal directly because Modal isn't in play here.
+  return createPortal(
     <div
       ref={overlayRef}
       role="dialog"
@@ -369,7 +379,8 @@ export default function MediaLightbox({
       </div>
       <PromptRefineModal item={item} open={refineOpen} onClose={() => setRefineOpen(false)} />
       <PromptFromMediaModal item={item} open={promptFromOpen} onClose={() => setPromptFromOpen(false)} />
-    </div>
+    </div>,
+    document.body
   );
 }
 

--- a/client/src/components/media/MediaLightbox.test.jsx
+++ b/client/src/components/media/MediaLightbox.test.jsx
@@ -31,6 +31,10 @@ const imageItem = {
   createdAt: Date.now(),
 };
 
+// The overlay portals to <body>, so it is outside render()'s container —
+// query the whole document for the media element.
+const videoEl = () => document.body.querySelector('video');
+
 describe('MediaLightbox video element (mobile playback)', () => {
   // jsdom doesn't implement HTMLMediaElement.play; stub it per-test so we can
   // drive the unmute-on-open effect down both the granted and blocked paths.
@@ -44,8 +48,8 @@ describe('MediaLightbox video element (mobile playback)', () => {
   });
 
   it('renders the <video> with a poster + playsInline + muted autoplay baseline so it loads on mobile', () => {
-    const { container } = render(<MediaLightbox item={videoItem} onClose={() => {}} />);
-    const video = container.querySelector('video');
+    render(<MediaLightbox item={videoItem} onClose={() => {}} />);
+    const video = videoEl();
     expect(video).toBeTruthy();
     // src points at the full asset
     expect(video.getAttribute('src')).toBe('/data/videos/abc.mp4');
@@ -62,8 +66,8 @@ describe('MediaLightbox video element (mobile playback)', () => {
   });
 
   it('unmutes and plays for sound when the opening gesture allows audible playback', async () => {
-    const { container } = render(<MediaLightbox item={videoItem} onClose={() => {}} />);
-    const video = container.querySelector('video');
+    render(<MediaLightbox item={videoItem} onClose={() => {}} />);
+    const video = videoEl();
     await waitFor(() => expect(playMock).toHaveBeenCalled());
     // play() resolved (gesture activation present) → stays unmuted for sound.
     expect(video.muted).toBe(false);
@@ -71,8 +75,8 @@ describe('MediaLightbox video element (mobile playback)', () => {
 
   it('falls back to muted playback when audible autoplay is blocked', async () => {
     playMock.mockImplementation(() => Promise.reject(new Error('NotAllowedError')));
-    const { container } = render(<MediaLightbox item={videoItem} onClose={() => {}} />);
-    const video = container.querySelector('video');
+    render(<MediaLightbox item={videoItem} onClose={() => {}} />);
+    const video = videoEl();
     // First (unmuted) play rejects → effect re-mutes and re-plays so the clip
     // still runs; the user can unmute via the controls.
     await waitFor(() => expect(video.muted).toBe(true));
@@ -80,11 +84,33 @@ describe('MediaLightbox video element (mobile playback)', () => {
   });
 
   it('omits poster when the video has no thumbnail rather than rendering an empty poster', () => {
-    const { container } = render(
+    render(
       <MediaLightbox item={{ ...videoItem, previewUrl: null }} onClose={() => {}} />
     );
-    const video = container.querySelector('video');
+    const video = videoEl();
     expect(video.hasAttribute('poster')).toBe(false);
+  });
+});
+
+describe('MediaLightbox overlay portal', () => {
+  it('portals the overlay to <body>, escaping a backdrop-filter containing-block ancestor', () => {
+    // Mirror a themed gallery: the lightbox is opened from inside a
+    // `.bg-port-card` tile, which gains `backdrop-filter` on "glass" themes. A
+    // backdrop-filter ancestor becomes the containing block for position:fixed
+    // descendants, so an inline overlay would be sized to the card instead of
+    // the viewport. The portal has to move it to <body> to escape that trap.
+    const { container } = render(
+      <div className="bg-port-card border rounded-xl" style={{ backdropFilter: 'blur(22px)' }} data-testid="glass-card">
+        <MediaLightbox item={imageItem} onClose={() => {}} />
+      </div>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toContain('fixed inset-0');
+    expect(screen.getByTestId('glass-card').contains(dialog)).toBe(false);
+    expect(dialog.parentElement).toBe(document.body);
+    // The component's own rendered subtree holds nothing at all.
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

On "glass" themes, the rule in `client/src/index.css` that gives every bordered/rounded `.bg-port-card` a `backdrop-filter` also makes that card the containing block for `position: fixed` descendants. `MediaLightbox` renders a hand-rolled `fixed inset-0` overlay — it deliberately opts out of `<ui/Modal>` (viewport-edge chevrons + its own Esc cascade), so it never inherited Modal's `usePortal` escape. Opening the lightbox from a themed gallery tile therefore sized the overlay to the card instead of the viewport.

The overlay now renders through `createPortal(…, document.body)`, the same escape `GalleryImagePicker` and `FolderPicker` get via `Modal`'s `usePortal`. Nothing else about the component changes: the focus trap, scroll lock, Esc cascade, and the nested refine/prompt-from modals all still hang off the same React subtree, so events and context are unaffected.

The two file-top comments that document the Modal opt-out are updated so the portal is discoverable from the same place as the rest of the opt-out contract.

## Test plan

- New `MediaLightbox overlay portal` test renders the lightbox inside a `.bg-port-card` ancestor carrying `backdrop-filter` and asserts the `role="dialog"` overlay is **not** inside that ancestor, is parented to `<body>`, and is absent from the component's own rendered subtree. Verified it fails against the pre-fix (non-portaled) render and passes after.
- The four existing video-element tests queried the overlay through `render()`'s `container`, which no longer holds it; they now go through a shared `videoEl()` document query.
- `cd client && npx vitest run src/components/media/ src/pages/MusicVideo.test.jsx src/a11yConventions.test.js` — 15 files / 162 tests pass (covers every in-repo suite that touches the lightbox).
- `cd client && npm test` — 645 files / 7866 tests pass.
- `cd client && npx biome lint --error-on-warnings` on both changed files — clean.

Closes #4151
