### PR TITLE
fix: portal ProcessesTab's fullscreen log overlay out of glass-theme cards

### DIFF
--- a/.changelog/next/fixed-issue-4152.md
+++ b/.changelog/next/fixed-issue-4152.md
@@ -1,0 +1,1 @@
+- Fullscreen process-log view no longer gets trapped inside a card on glass themes — its overlay now portals to the document body so it covers the full viewport

--- a/client/src/components/apps/tabs/ProcessesTab.jsx
+++ b/client/src/components/apps/tabs/ProcessesTab.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef, Fragment } from 'react';
+import { createPortal } from 'react-dom';
 import { Maximize2, X } from 'lucide-react';
 import * as api from '../../../services/api';
 import { executeCommand } from '../../../services/api';
@@ -227,8 +228,19 @@ export default function ProcessesTab({ appId, pm2ProcessNames, filterFn }) {
         </div>
       </div>
 
-      {/* Fullscreen Log Modal */}
-      {fullscreen && expandedProcess && (
+      {/*
+        Fullscreen Log Modal — portaled to <body>.
+
+        This tab renders inside an app-detail / processes-page card tree, and on
+        "glass" themes (`--port-backdrop-filter` non-none) `index.css` gives every
+        bordered/rounded `.bg-port-card` a backdrop-filter, which makes that card
+        the containing block for `position:fixed` descendants. Rendered inline the
+        overlay would be sized to the card instead of the viewport. Same escape
+        GalleryImagePicker / FolderPicker get via <ui/Modal>'s `usePortal`, and the
+        same fix MediaLightbox took in #4151 — reached through createPortal
+        directly because this overlay isn't a <Modal>.
+      */}
+      {fullscreen && expandedProcess && createPortal(
         <div className="fixed inset-0 bg-port-bg z-50 flex flex-col">
           <div className="flex items-center justify-between px-6 py-4 border-b border-port-border bg-port-card">
             <div className="flex items-center gap-4">
@@ -273,7 +285,8 @@ export default function ProcessesTab({ appId, pm2ProcessNames, filterFn }) {
           >
             <ProcessLogLines logs={logs} subscribed={subscribed} showTimestamps timestampGap="mr-3" />
           </div>
-        </div>
+        </div>,
+        document.body
       )}
     </>
   );

--- a/client/src/components/apps/tabs/ProcessesTab.test.jsx
+++ b/client/src/components/apps/tabs/ProcessesTab.test.jsx
@@ -38,4 +38,26 @@ describe('ProcessesTab', () => {
 
     expect(useProcessLogs).toHaveBeenLastCalledWith('example-api', { lines: 500, appId: 'app-1' });
   });
+
+  // On "glass" themes a bordered/rounded `.bg-port-card` gets a backdrop-filter,
+  // which makes it the containing block for `position:fixed` descendants — an
+  // inline overlay would be sized to the card, not the viewport. Portaling to
+  // <body> is the escape, so assert the overlay leaves the component's subtree.
+  it('portals the fullscreen log overlay to <body> so glass-theme cards cannot trap it', () => {
+    const { container } = render(<ProcessesTab appId="app-1" pm2ProcessNames={['example-api']} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand details for example-api' }));
+    fireEvent.click(screen.getByTitle('Fullscreen'));
+
+    const overlay = document.body.querySelector('.fixed.inset-0');
+    expect(overlay).toBeTruthy();
+    // Rendered out of the tab tree entirely, directly under <body>.
+    expect(container.contains(overlay)).toBe(false);
+    expect(overlay.parentElement).toBe(document.body);
+    expect(screen.getByText('Logs: example-api')).toBeTruthy();
+
+    // Exiting fullscreen tears the portaled overlay back down.
+    fireEvent.click(screen.getByRole('button', { name: 'Exit fullscreen' }));
+    expect(document.body.querySelector('.fixed.inset-0')).toBeNull();
+  });
 });


### PR DESCRIPTION
## Summary

On "glass" themes the `index.css` rule that gives every bordered/rounded `.bg-port-card` a `backdrop-filter` also makes that card the containing block for `position:fixed` descendants. `ProcessesTab` renders its fullscreen log view as a hand-rolled `fixed inset-0` overlay inline in the app-detail / processes-page tab tree, so opening it from inside a themed card sized the overlay to the card instead of the viewport.

Render the overlay through `createPortal` to `document.body` — the same escape `GalleryImagePicker` and `FolderPicker` get via `<ui/Modal>`'s `usePortal`, and the same fix `MediaLightbox` took in #4151. The overlay uses `bg-port-bg` (not a `bg-black/N` scrim), so it never tripped — and still doesn't trip — the `a11yConventions` hand-rolled-backdrop guard.

Closes #4152

## Test plan

- `cd client && npm test -- src/components/apps/tabs/ProcessesTab.test.jsx` — 2 passed. New case asserts the fullscreen overlay renders outside the component's own container, directly under `<body>`, and is torn down on exit.
- Bypass probe: temporarily reverting the `createPortal` wrapper fails the new test (it is a real guard, not a vacuous one); restored and re-verified green.
- `cd client && npm test -- src/a11yConventions.test.js src/components/apps` — 13 files / 136 tests passed.
