### PR TITLE
fix: reject wrong-typed reasoner envelope fields as malformed output (#4166)

### DIFF
--- a/.changelog/next/fixed-issue-4166.md
+++ b/.changelog/next/fixed-issue-4166.md
@@ -1,0 +1,1 @@
+- Layered Intelligence now records a wrong-typed reasoner envelope field (e.g. a non-string `analysis`, an unresolvable `pause`) as `unparseable-response` instead of counting it as a successful `no-proposal` run

--- a/client/src/components/apps/LayeredIntelligenceTab.test.jsx
+++ b/client/src/components/apps/LayeredIntelligenceTab.test.jsx
@@ -29,7 +29,7 @@ describe('describeLastRun', () => {
   it('surfaces an unparseable reasoning response as a warning with actionable prose', () => {
     const r = describeLastRun({ lastRunAt: at, lastRunAction: 'no-op', lastRunReason: 'unparseable-response' });
     expect(r.tone).toBe('warn');
-    expect(r.text).toMatch(/no usable JSON/i);
+    expect(r.text).toMatch(/no usable answer/i);
   });
 
   it('treats a genuine no-proposal run as neutral (not an error)', () => {
@@ -65,7 +65,7 @@ describe('LayeredIntelligenceTab last-run status', () => {
   it('renders the durable last-run line when the config carries a run outcome', () => {
     render(<LayeredIntelligenceTab li={li({ lastRunAt: '2026-07-09T20:29:05.000Z', lastRunAction: 'no-op', lastRunReason: 'unparseable-response' })} onChange={noop} providers={[]} isPortos loaded />);
     expect(screen.getByText(/Last run/i)).toBeInTheDocument();
-    expect(screen.getByText(/no usable JSON/i)).toBeInTheDocument();
+    expect(screen.getByText(/no usable answer/i)).toBeInTheDocument();
   });
 
   it('omits the last-run line before the loop has ever run', () => {

--- a/client/src/utils/layeredIntelligenceReasons.js
+++ b/client/src/utils/layeredIntelligenceReasons.js
@@ -20,7 +20,7 @@ export const LI_NEUTRAL_REASONS = new Set([
 
 const LI_REASON_LABELS = {
   'no-provider': 'no AI provider is configured for it',
-  'unparseable-response': 'the reasoning model returned no usable JSON — try a non-reasoning model or an API provider',
+  'unparseable-response': 'the reasoning model returned no usable answer — no JSON at all, or an envelope field it got wrong (see the server log for which) — try a non-reasoning model or an API provider',
   'no-proposal': 'the loop had nothing to propose',
   'scope-suppressed': "the proposal's scope isn't allowed for this app",
   'hard-gate-excluded': "excluded before filing — the loop's own execution is degraded and this proposal maps to self-improve scope or a chronically-failing domain",

--- a/client/src/utils/layeredIntelligenceReasons.test.js
+++ b/client/src/utils/layeredIntelligenceReasons.test.js
@@ -3,7 +3,7 @@ import { formatLiReason, liReasonTone, LI_NEUTRAL_REASONS } from './layeredIntel
 
 describe('formatLiReason', () => {
   it('glosses a plain reason token', () => {
-    expect(formatLiReason({ action: 'no-op', reason: 'unparseable-response' })).toMatch(/no usable JSON/i);
+    expect(formatLiReason({ action: 'no-op', reason: 'unparseable-response' })).toMatch(/no usable answer/i);
     expect(formatLiReason({ action: 'no-op', reason: 'no-provider' })).toMatch(/no AI provider/i);
   });
 

--- a/server/services/autonomousJobs/layeredIntelligenceHooks.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHooks.js
@@ -589,20 +589,24 @@ export async function processTaskOutput({ appId, success, payload, agentId } = {
   // envelope only requires `payload` to be an object, and salvageSentinelPayload's
   // lenient extractor can surface a non-envelope object out of prose.
   const envelope = isTaskOutputPayload(payload) ? payload : null
-  const { proposal, pause } = validateReasonerResponse(envelope)
+  const { proposal, invalidFields = [], pause } = validateReasonerResponse(envelope)
 
-  // A reasoner that SUPPLIED a non-null proposal which then failed validation
-  // (missing/unknown scope, no title, unnormalizable slug) did not "look and find
-  // nothing" — it tried to propose and emitted the wrong shape. Both used to land
-  // on `no-proposal` → success. `proposal: null` stays the legitimate empty answer.
-  // Narrow on purpose: validateReasonerResponse is documented to drop invalid
-  // pieces leniently, and this only reclassifies the field that IS the deliverable.
-  const proposalAttemptedButInvalid = envelope != null && !proposal && envelope.proposal != null
+  // A reasoner that SUPPLIED an envelope field which then failed validation did not
+  // "look and find nothing" — it tried to answer and emitted the wrong shape. That
+  // used to land on `no-proposal` → success. Originally (#2727) only the `proposal`
+  // field was reclassified; #4166 extends it to every supplied-but-unusable field
+  // (`{"analysis": 7}`, a `pause` with no resolvable target), since
+  // validateReasonerResponse now reports them all in `invalidFields`. A `null` field
+  // is ABSENT, not malformed, so `proposal: null` stays the legitimate empty answer.
+  // A null envelope never reaches here with a non-empty list (the validator returns
+  // the empty triple for it), and the ternary below short-circuits on it anyway; the
+  // `= []` destructuring default keeps a stubbed validator from throwing.
+  const malformedEnvelope = invalidFields.length > 0
 
   let filedNumber = null
   let filedKey = null
   let filedAction = 'no-op'
-  let reason = envelope == null || proposalAttemptedButInvalid ? 'unparseable-response' : 'no-proposal'
+  let reason = envelope == null || malformedEnvelope ? 'unparseable-response' : 'no-proposal'
   let handedOff = false
   // §4 (#2764): when the deterministic routing gate files-for-human instead of
   // auto-handing-off a trivial+safe proposal, surface WHY on the returned result.

--- a/server/services/autonomousJobs/layeredIntelligenceHooks.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHooks.js
@@ -601,7 +601,17 @@ export async function processTaskOutput({ appId, success, payload, agentId } = {
   // A null envelope never reaches here with a non-empty list (the validator returns
   // the empty triple for it), and the ternary below short-circuits on it anyway; the
   // `= []` destructuring default keeps a stubbed validator from throwing.
+  //
+  // Asymmetry, unchanged from #2727 and deliberate: a SURVIVING proposal overwrites
+  // `reason` on every branch of the filing path below, so a junk `analysis` alongside
+  // a filed proposal records the filing outcome — but a surviving `pause` does NOT
+  // re-derive `reason`, so it still applies its blocking label while the run records
+  // `unparseable-response`. The proposal is the run's deliverable; a pause is a side
+  // effect, and a reasoner that got another field wrong is worth surfacing.
   const malformedEnvelope = invalidFields.length > 0
+  // Name the offending fields — `unparseable-response` alone can't tell an operator
+  // whether the model returned no JSON at all or one wrong-typed key.
+  if (malformedEnvelope) console.warn(`⚠️ Layered Intelligence: ${app.name} reasoner envelope has unusable fields: ${invalidFields.join(', ')}`)
 
   let filedNumber = null
   let filedKey = null

--- a/server/services/autonomousJobs/layeredIntelligenceHooks.test.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHooks.test.js
@@ -51,7 +51,7 @@ vi.mock('../layeredIntelligence.js', () => ({
   listForgeIssues: vi.fn().mockResolvedValue({ ok: true, issues: [] }),
   listBlockingIssues: vi.fn().mockResolvedValue({ ok: true, issues: [] }),
   isAppParked: vi.fn(() => false),
-  validateReasonerResponse: vi.fn(() => ({ proposal: null, pause: null })),
+  validateReasonerResponse: vi.fn(() => ({ proposal: null, pause: null, invalidFields: [] })),
   isScopeAllowed: vi.fn(() => true),
   isProposalDuplicate: vi.fn(() => false),
   checkSemanticDuplicate: vi.fn().mockResolvedValue({ available: false, duplicate: false }),
@@ -557,7 +557,7 @@ describe('processTaskOutput', () => {
   });
 
   it('records unparseable-response when the payload is null', async () => {
-    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null });
+    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null, invalidFields: [] });
     const out = await processTaskOutput({ appId: 'app-1', success: true, payload: null });
     expect(out).toMatchObject({ action: 'no-op', reason: 'unparseable-response' });
   });
@@ -569,7 +569,7 @@ describe('processTaskOutput', () => {
     // indistinguishable from a correct empty answer and got recorded as a
     // successful run. `{}` is reachable: the sentinel envelope only requires
     // `payload` to be an object.
-    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null });
+    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null, invalidFields: [] });
     for (const payload of ['just some prose', 42, ['a', 'b'], true, {}, { foo: 1 }]) {
       const out = await processTaskOutput({ appId: 'app-1', success: true, payload });
       expect(out).toMatchObject({ action: 'no-op', reason: 'unparseable-response' });
@@ -580,7 +580,7 @@ describe('processTaskOutput', () => {
     // The other side of the sentinel: the reasoner answered correctly and simply
     // had nothing to file. That is a successful run, not malformed output. Any ONE
     // documented key makes it a real answer.
-    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null });
+    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null, invalidFields: [] });
     for (const payload of [{ analysis: 'nothing worth proposing', proposal: null }, { proposal: null }, { analysis: '' }]) {
       const out = await processTaskOutput({ appId: 'app-1', success: true, payload });
       expect(out).toMatchObject({ action: 'no-op', reason: 'no-proposal' });
@@ -591,13 +591,29 @@ describe('processTaskOutput', () => {
     // The reasoner ATTEMPTED a proposal and emitted the wrong shape (no scope/title,
     // bad slug). That is malformed output, not "I looked and found nothing" — both
     // used to land on `no-proposal` and count as a successful run.
-    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null });
+    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null, invalidFields: ['proposal'] });
     const out = await processTaskOutput({ appId: 'app-1', success: true, payload: { analysis: 'x', proposal: { title: '' } } });
     expect(out).toMatchObject({ action: 'no-op', reason: 'unparseable-response' });
   });
 
+  it('records unparseable-response for a wrong-typed NON-deliverable field (#4166)', async () => {
+    // `{"analysis": 7}` is an envelope (it carries a documented key) that supplies a
+    // field it then gets wrong. Pre-#4166 the deliverable-only check let it through as
+    // `no-proposal`, i.e. a successful run indistinguishable from a correct empty
+    // answer. Any field validateReasonerResponse reports in `invalidFields` now counts.
+    for (const [payload, invalidFields] of [
+      [{ analysis: 7 }, ['analysis']],
+      [{ analysis: 'x', pause: { reason: 'no target' } }, ['pause']],
+      [{ analysis: [], pause: 3 }, ['analysis', 'pause']]
+    ]) {
+      li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null, invalidFields });
+      const out = await processTaskOutput({ appId: 'app-1', success: true, payload });
+      expect(out).toMatchObject({ action: 'no-op', reason: 'unparseable-response' });
+    }
+  });
+
   it('treats an explicit proposal:null as a legitimate empty answer, not malformed (#2727)', async () => {
-    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null });
+    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null, invalidFields: [] });
     const out = await processTaskOutput({ appId: 'app-1', success: true, payload: { analysis: 'nothing to propose', proposal: null } });
     expect(out).toMatchObject({ action: 'no-op', reason: 'no-proposal' });
   });
@@ -606,7 +622,7 @@ describe('processTaskOutput', () => {
     // readIssues is an unbounded forge call and only the has-a-proposal branch
     // consumes it. Since the #2727 hoist the hook runs while the agent still holds
     // a CoS concurrency slot, so the common no-op path must not shell out to `gh`.
-    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null });
+    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null, invalidFields: [] });
     li.listForgeIssues.mockClear();
     await processTaskOutput({ appId: 'app-1', success: true, payload: { analysis: 'nothing to do', proposal: null } });
     expect(li.listForgeIssues).not.toHaveBeenCalled();

--- a/server/services/autonomousJobs/layeredIntelligenceHooks.test.js
+++ b/server/services/autonomousJobs/layeredIntelligenceHooks.test.js
@@ -18,7 +18,11 @@ vi.mock('../../lib/workTracker.js', async (importActual) => {
   };
 });
 
-vi.mock('../../lib/fileUtils.js', () => ({
+// Only `tryReadFile` is stubbed — the rest passes through so the real validator this
+// suite imports for the #4166 end-to-end case can load its own module graph (its
+// constants reach `PATHS`/`DAY` through here). fileUtils has no load-time side effects.
+vi.mock('../../lib/fileUtils.js', async (importOriginal) => ({
+  ...(await importOriginal()),
   tryReadFile: vi.fn().mockResolvedValue(null)
 }));
 
@@ -133,6 +137,10 @@ import { resolveAppWorkTracker } from '../../lib/workTracker.js';
 import { tryReadFile } from '../../lib/fileUtils.js';
 import { getProviderById } from '../providers.js';
 import { getTaskInterval } from '../taskSchedule.js';
+// The REAL validator (its own module, so untouched by the `../layeredIntelligence.js`
+// mock above) — used by the #4166 end-to-end case so the envelope→reason verdict is
+// exercised through production validation, not a hand-written stub of it.
+import { validateReasonerResponse as realValidateReasonerResponse } from '../layeredIntelligence/proposal.js';
 
 const APP = { id: 'app-1', name: 'App One', repoPath: '/repo', taskTypeOverrides: {} };
 
@@ -158,6 +166,9 @@ beforeEach(() => {
   // so without this a test that arms the gate would leak into later ones.
   li.computeHardExclusionGate.mockReturnValue({ excluded: false, reason: null });
   li.computeHardExclusionNotice.mockReturnValue('');
+  // Same leak guard for the validator (#4166): a test that hands back a non-empty
+  // `invalidFields` would otherwise make every later run read as unparseable-response.
+  li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null, invalidFields: [] });
 });
 
 describe('buildTaskInput', () => {
@@ -610,6 +621,30 @@ describe('processTaskOutput', () => {
       const out = await processTaskOutput({ appId: 'app-1', success: true, payload });
       expect(out).toMatchObject({ action: 'no-op', reason: 'unparseable-response' });
     }
+  });
+
+  it('reaches the same verdict through the REAL validator (#4166)', async () => {
+    // End-to-end over the two halves this suite otherwise stubs apart: the real
+    // envelope validation feeding the real reason classification.
+    li.validateReasonerResponse.mockImplementation(realValidateReasonerResponse);
+    for (const payload of [{ analysis: 7 }, { analysis: 'x', pause: { reason: 'no target' } }, { proposal: { title: '' } }]) {
+      const out = await processTaskOutput({ appId: 'app-1', success: true, payload });
+      expect(out).toMatchObject({ action: 'no-op', reason: 'unparseable-response' });
+    }
+    for (const payload of [{ analysis: 'nothing worth proposing', proposal: null }, { analysis: '' }]) {
+      const out = await processTaskOutput({ appId: 'app-1', success: true, payload });
+      expect(out).toMatchObject({ action: 'no-op', reason: 'no-proposal' });
+    }
+  });
+
+  it('logs which envelope fields were unusable (#4166)', async () => {
+    // `unparseable-response` alone can't tell an operator whether the model returned
+    // no JSON at all or one wrong-typed key — the offending names must reach the log.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    li.validateReasonerResponse.mockReturnValue({ proposal: null, pause: null, invalidFields: ['analysis', 'pause'] });
+    await processTaskOutput({ appId: 'app-1', success: true, payload: { analysis: 7, pause: 3 } });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('analysis, pause'));
+    warn.mockRestore();
   });
 
   it('treats an explicit proposal:null as a legitimate empty answer, not malformed (#2727)', async () => {

--- a/server/services/layeredIntelligence.test.js
+++ b/server/services/layeredIntelligence.test.js
@@ -375,9 +375,10 @@ describe('validateReasonerResponse', () => {
   });
 
   it('handles garbage input without throwing', () => {
-    expect(validateReasonerResponse(null)).toEqual({ analysis: '', proposal: null, pause: null });
-    expect(validateReasonerResponse('nope')).toEqual({ analysis: '', proposal: null, pause: null });
-    expect(validateReasonerResponse({ proposal: [], pause: [] })).toEqual({ analysis: '', proposal: null, pause: null });
+    expect(validateReasonerResponse(null)).toEqual({ analysis: '', proposal: null, pause: null, invalidFields: [] });
+    expect(validateReasonerResponse('nope')).toEqual({ analysis: '', proposal: null, pause: null, invalidFields: [] });
+    expect(validateReasonerResponse({ proposal: [], pause: [] }))
+      .toEqual({ analysis: '', proposal: null, pause: null, invalidFields: ['proposal', 'pause'] });
   });
 
   it('normalizes proposal complexity + safe (defaults: null / false)', () => {
@@ -393,6 +394,47 @@ describe('validateReasonerResponse', () => {
     const junk = validateReasonerResponse({ proposal: { scope: 'app-improvement', slug: 'x', title: 'X', complexity: 'epic', safe: 'yes' } });
     expect(junk.proposal.complexity).toBe(null);
     expect(junk.proposal.safe).toBe(false);
+  });
+
+  describe('invalidFields (#4166)', () => {
+    it('reports a wrong-typed analysis and drops it', () => {
+      const r = validateReasonerResponse({ analysis: 7 });
+      expect(r.analysis).toBe('');
+      expect(r.invalidFields).toEqual(['analysis']);
+    });
+
+    it('reports a supplied-but-unusable proposal', () => {
+      expect(validateReasonerResponse({ proposal: { scope: 'nuke', slug: 'x', title: 'X' } }).invalidFields).toEqual(['proposal']);
+      expect(validateReasonerResponse({ proposal: 'do the thing' }).invalidFields).toEqual(['proposal']);
+    });
+
+    it('reports a supplied-but-unusable pause', () => {
+      expect(validateReasonerResponse({ pause: { blockOnIssue: 42, reason: '' } }).invalidFields).toEqual(['pause']);
+      expect(validateReasonerResponse({ pause: { reason: 'no target' } }).invalidFields).toEqual(['pause']);
+      // "this" with nothing to block on is malformed, not an empty answer.
+      expect(validateReasonerResponse({ proposal: null, pause: { blockOnIssue: 'this', reason: 'x' } }).invalidFields).toEqual(['pause']);
+    });
+
+    it('treats an absent or explicitly-null field as absent, never malformed', () => {
+      expect(validateReasonerResponse({ analysis: 'nothing to propose', proposal: null, pause: null }).invalidFields).toEqual([]);
+      expect(validateReasonerResponse({ proposal: null }).invalidFields).toEqual([]);
+      expect(validateReasonerResponse({ analysis: '' }).invalidFields).toEqual([]);
+      expect(validateReasonerResponse({}).invalidFields).toEqual([]);
+    });
+
+    it('stays empty for a fully valid envelope', () => {
+      const r = validateReasonerResponse({
+        analysis: 'a',
+        proposal: { scope: 'app-improvement', slug: 'x', title: 'X' },
+        pause: { blockOnIssue: 'this', reason: 'block on the new one' }
+      });
+      expect(r.invalidFields).toEqual([]);
+    });
+
+    it('collects every unusable field, in envelope order', () => {
+      const r = validateReasonerResponse({ analysis: [], proposal: {}, pause: 3 });
+      expect(r.invalidFields).toEqual(['analysis', 'proposal', 'pause']);
+    });
   });
 });
 

--- a/server/services/layeredIntelligence.test.js
+++ b/server/services/layeredIntelligence.test.js
@@ -415,6 +415,26 @@ describe('validateReasonerResponse', () => {
       expect(validateReasonerResponse({ proposal: null, pause: { blockOnIssue: 'this', reason: 'x' } }).invalidFields).toEqual(['pause']);
     });
 
+    it('does not double-report a "this" pause dropped as collateral of an invalid proposal', () => {
+      // The pause is well-formed — it was dropped only because the proposal it pointed
+      // at failed validation. One root cause, one report.
+      const r = validateReasonerResponse({
+        proposal: { scope: 'nuke', slug: 'x', title: 'X' },
+        pause: { blockOnIssue: 'this', reason: 'block on the new one' }
+      });
+      expect(r.pause).toBe(null);
+      expect(r.invalidFields).toEqual(['proposal']);
+    });
+
+    it('still reports a "this" pause that is itself malformed alongside a bad proposal', () => {
+      // No reason → the pause is broken on its own terms, not collateral.
+      const r = validateReasonerResponse({
+        proposal: { scope: 'nuke', slug: 'x', title: 'X' },
+        pause: { blockOnIssue: 'this', reason: '' }
+      });
+      expect(r.invalidFields).toEqual(['proposal', 'pause']);
+    });
+
     it('treats an absent or explicitly-null field as absent, never malformed', () => {
       expect(validateReasonerResponse({ analysis: 'nothing to propose', proposal: null, pause: null }).invalidFields).toEqual([]);
       expect(validateReasonerResponse({ proposal: null }).invalidFields).toEqual([]);

--- a/server/services/layeredIntelligence/proposal.js
+++ b/server/services/layeredIntelligence/proposal.js
@@ -12,17 +12,29 @@ import { normalizeSlug } from './dedup.js';
 
 /**
  * Validate + normalize the reasoner's JSON. Returns
- * `{ analysis, proposal, pause }` with invalid pieces dropped (never throws):
+ * `{ analysis, proposal, pause, invalidFields }` with invalid pieces dropped
+ * (never throws):
+ *   - `analysis` kept only when it is a string.
  *   - `proposal` kept only when it has a recognized scope + a normalizable slug
  *     + a non-empty title. `slug` is normalized in place.
  *   - `pause` kept only when it has a reason AND a resolvable target: an integer
  *     issue number, or `"this"` WITH a surviving proposal to block on. A
  *     `pause.blockOnIssue: "this"` with a null proposal is invalid → dropped.
+ *
+ * `invalidFields` (#4166) names every envelope key that was SUPPLIED (present and
+ * non-null) but could not be used — the sentinel that separates "the reasoner
+ * emitted the wrong shape" from "the reasoner had nothing to say". Dropping is
+ * still lenient (callers that only want the usable pieces can ignore it), but a
+ * caller deciding whether a run was malformed must not have to re-derive per-field
+ * validity: `{"analysis": 7}` reads as a legitimate empty answer without this.
+ * `null`/`undefined` is ABSENT, not wrong-typed — an explicit `proposal: null` is
+ * the documented "nothing to propose" answer and never lands here.
  */
 export function validateReasonerResponse(parsed) {
-  const out = { analysis: '', proposal: null, pause: null };
+  const out = { analysis: '', proposal: null, pause: null, invalidFields: [] };
   if (!parsed || typeof parsed !== 'object') return out;
   if (typeof parsed.analysis === 'string') out.analysis = parsed.analysis;
+  else if (parsed.analysis != null) out.invalidFields.push('analysis');
 
   const p = parsed.proposal;
   if (p && typeof p === 'object' && !Array.isArray(p)) {
@@ -43,6 +55,7 @@ export function validateReasonerResponse(parsed) {
       };
     }
   }
+  if (p != null && !out.proposal) out.invalidFields.push('proposal');
 
   const pause = parsed.pause;
   if (pause && typeof pause === 'object' && !Array.isArray(pause)) {
@@ -55,6 +68,8 @@ export function validateReasonerResponse(parsed) {
       out.pause = { blockOnIssue: isThis ? 'this' : num, reason };
     }
   }
+  if (pause != null && !out.pause) out.invalidFields.push('pause');
+
   return out;
 }
 

--- a/server/services/layeredIntelligence/proposal.js
+++ b/server/services/layeredIntelligence/proposal.js
@@ -2,7 +2,8 @@
  * Layered Intelligence — reasoner-output validation & hand-off shaping
  * (#2842 split of layeredIntelligence.js).
  *
- * Validates the model's JSON into a `{ analysis, proposal, pause }` triple, resolves
+ * Validates the model's JSON into an `{ analysis, proposal, pause, invalidFields }`
+ * result (the usable triple plus the malformed-field report, #4166), resolves
  * the pause target, and decides whether/how a filed proposal becomes an autonomous
  * CoS hand-off task. Also the tracker→filer dispatch table.
  */
@@ -28,7 +29,10 @@ import { normalizeSlug } from './dedup.js';
  * caller deciding whether a run was malformed must not have to re-derive per-field
  * validity: `{"analysis": 7}` reads as a legitimate empty answer without this.
  * `null`/`undefined` is ABSENT, not wrong-typed — an explicit `proposal: null` is
- * the documented "nothing to propose" answer and never lands here.
+ * the documented "nothing to propose" answer and never lands here. Deliberately
+ * ONLY `null`: the prompt documents `null` for "not proposing"/"not pausing", so a
+ * model emitting `false` or `"none"` instead is a wrong-typed field and is reported
+ * (this already matched the pre-#4166 treatment of a `false` proposal).
  */
 export function validateReasonerResponse(parsed) {
   const out = { analysis: '', proposal: null, pause: null, invalidFields: [] };
@@ -58,6 +62,13 @@ export function validateReasonerResponse(parsed) {
   if (p != null && !out.proposal) out.invalidFields.push('proposal');
 
   const pause = parsed.pause;
+  // A well-formed `blockOnIssue: "this"` pause is dropped as COLLATERAL when the
+  // proposal it pointed at was itself supplied-but-invalid. The pause isn't the
+  // malformed part, so it doesn't earn its own `invalidFields` entry — one root
+  // cause, one report. With no proposal supplied at all, `"this"` points at nothing
+  // and the pause IS malformed. Either way `invalidFields` is already non-empty, so
+  // this only sharpens the report, never the malformed/clean verdict.
+  let pauseCollateral = false;
   if (pause && typeof pause === 'object' && !Array.isArray(pause)) {
     const reason = typeof pause.reason === 'string' ? pause.reason.trim() : '';
     const target = pause.blockOnIssue;
@@ -66,9 +77,11 @@ export function validateReasonerResponse(parsed) {
     // "this" requires a surviving proposal to block on; else an explicit issue number.
     if (reason && ((isThis && out.proposal) || num)) {
       out.pause = { blockOnIssue: isThis ? 'this' : num, reason };
+    } else if (reason && isThis) {
+      pauseCollateral = out.invalidFields.includes('proposal');
     }
   }
-  if (pause != null && !out.pause) out.invalidFields.push('pause');
+  if (pause != null && !out.pause && !pauseCollateral) out.invalidFields.push('pause');
 
   return out;
 }


### PR DESCRIPTION
## Summary

`processTaskOutput` classified a reasoner run as `unparseable-response` only when the *deliverable* field failed validation (`payload.proposal` supplied but unusable). A wrong-typed **non-deliverable** field — `{"analysis": 7}`, or a `pause` with no resolvable target — still passed the envelope check, produced nothing usable, and was recorded as a legitimate `no-proposal` **success**. Garbage output was indistinguishable from "the loop correctly had nothing to propose", exactly the hole #2727 closed for `proposal`.

`validateReasonerResponse` now reports which envelope keys were **supplied but unusable** in a new `invalidFields` array, and the hook keys `unparseable-response` off that list instead of re-deriving per-field validity itself:

- `analysis` present and not a string → `'analysis'`
- `proposal` non-null and dropped (bad scope / no title / unnormalizable slug / not a plain object) → `'proposal'`
- `pause` non-null and dropped (no reason, no resolvable target, `"this"` with nothing to block on) → `'pause'`

`null`/`undefined` stays **absent**, not malformed — an explicit `proposal: null` remains the documented "nothing to propose" answer, and a valid envelope with a valid deliverable is unaffected. Dropping is still lenient and the function still never throws, so the shared contract only gains a field; the previously-returned keys are unchanged.

**Caller audit** (the issue's explicit ask): the only production caller of `validateReasonerResponse` is `layeredIntelligenceHooks.js#processTaskOutput` (plus the `layeredIntelligence` barrel re-export and the unit tests). Nothing depended on the lenient behavior for a non-deliverable field. Within the hook, a *valid* proposal overwrites `reason` on every branch of the filing path, so flagging an invalid `pause` alongside a good proposal cannot change a filed run's outcome — the new classification only reaches the no-proposal path. The user-facing reason string is unchanged (`unparseable-response` already has copy in `client/src/utils/layeredIntelligenceReasons.js`), so no client change is needed.

Also replaces the hand-rolled `proposalAttemptedButInvalid` check in the hook with the validator's own report (one source of truth for per-field validity).

From the review round:

- The hook logs which fields were unusable (`⚠️ Layered Intelligence: <app> reasoner envelope has unusable fields: analysis, pause`) — `unparseable-response` alone can't tell an operator whether the model returned no JSON at all or one wrong-typed key. That reason token feeds retry counting and the hard-exclusion gate, so the diagnostic shouldn't be discarded.
- The client gloss for `unparseable-response` was inaccurate for the newly-covered cases ("returned no usable JSON" for a payload that *is* valid JSON) — reworded to cover both.
- A well-formed `blockOnIssue: "this"` pause dropped only because its proposal failed validation is **not** double-reported: one root cause, one entry. This sharpens the report only — `invalidFields` is already non-empty in that case, so the malformed/clean verdict is unchanged.
- The `blockOnIssue`-asymmetry (a surviving *proposal* re-derives `reason`, a surviving *pause* does not) predates this PR (#2727) and is now stated in the comment rather than silently changed.
- `beforeEach` now restores the validator mock's default, matching the existing leak guards for `gatherSources` / `computeHardExclusionGate`.

## Test plan

- New `validateReasonerResponse > invalidFields (#4166)` unit block in `server/services/layeredIntelligence.test.js`: wrong-typed `analysis`; supplied-but-unusable `proposal` and `pause` (including `"this"` with no proposal); absent/explicitly-null fields never flagged; empty for a fully valid envelope; all three collected in envelope order.
- New `processTaskOutput` cases in `server/services/autonomousJobs/layeredIntelligenceHooks.test.js`: `unparseable-response` for `{"analysis": 7}`, a targetless `pause`, and a multi-field-invalid envelope; the offending field names reaching the log; and an **end-to-end** case driving the hook through the *real* `validateReasonerResponse` (the suite otherwise stubs it) so the two halves are verified together, not only in isolation. The existing "well-formed envelope that proposes nothing → `no-proposal`" and "explicit `proposal: null` → `no-proposal`" cases stay green.
- Verified every new test **fails** against the pre-fix source (8 failures) and passes after.
- `cd server && npx vitest run services/layeredIntelligence.test.js services/autonomousJobs/ services/layeredIntelligenceBarrel.test.js services/layeredIntelligenceOutcomes.test.js` → 6 files, 559 tests passed.
- `cd client && npm test` → 647 files, 7879 tests passed (covers the reworded reason gloss).
- Full server suite run: the only failures are 55 pre-existing PostgreSQL-dependent suites that fail in this environment because the configured Postgres instance is not running (`… require PostgreSQL`) — the identical set fails before the change, and none touch Layered Intelligence.

Closes #4166
