### PR TITLE
fix: restore media lightbox Escape cascade

### DIFF
--- a/.changelog/next/fixed-issue-4260.md
+++ b/.changelog/next/fixed-issue-4260.md
@@ -1,0 +1,1 @@
+- Media previews use Esc to leave full screen or close a prompt panel before closing the viewer.

--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -256,7 +256,6 @@ export default function MediaLightbox({
       aria-label={`Media viewer — ${item.filename || item.key || 'item'}`}
       className={`fixed inset-0 z-50 bg-black/90 flex items-center justify-center ${overlayPad}`}
       onClick={onClose}
-      onKeyDown={(e) => e.key === 'Escape' && onClose()}
     >
       {hasPrevious && (
         <button

--- a/client/src/components/media/MediaLightbox.test.jsx
+++ b/client/src/components/media/MediaLightbox.test.jsx
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import MediaLightbox from './MediaLightbox';
 
-// The footer's AddToCollectionMenu and the (closed) PromptRefineModal pull the
-// whole API surface (and useProviderModels) into the import graph. Neither is
-// under test here, so stub them to inert nodes — that keeps the test focused
-// on MediaLightbox's own <video> markup and off the network.
+// The footer's AddToCollectionMenu and prompt modals pull the whole API surface
+// (and useProviderModels) into the import graph. Keep the mocks inert except
+// for PromptRefineModal's open state, which lets the Escape regression assert
+// that it closes without pulling its provider hooks into the test.
 vi.mock('./AddToCollectionMenu', () => ({ default: () => null }));
-vi.mock('./PromptRefineModal', () => ({ default: () => null }));
+vi.mock('./PromptRefineModal', () => ({
+  default: ({ open }) => open ? <div data-testid="refine-modal" /> : null,
+}));
 vi.mock('./PromptFromMedia', () => ({ default: () => null, PromptFromMediaModal: () => null }));
 
 const videoItem = {
@@ -111,6 +113,35 @@ describe('MediaLightbox overlay portal', () => {
     expect(dialog.parentElement).toBe(document.body);
     // The component's own rendered subtree holds nothing at all.
     expect(container.querySelector('[role="dialog"]')).toBeNull();
+  });
+});
+
+describe('MediaLightbox Escape cascade', () => {
+  it('exits full screen without closing the lightbox', () => {
+    const onClose = vi.fn();
+    render(<MediaLightbox item={imageItem} onClose={onClose} />);
+
+    fireEvent.keyDown(screen.getByRole('button', { name: 'Full screen' }), { key: 'f' });
+    const exitFullScreen = screen.getByRole('button', { name: 'Exit full screen' });
+
+    fireEvent.keyDown(exitFullScreen, { key: 'Escape' });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Full screen' })).toBeTruthy();
+  });
+
+  it('closes the refine modal without closing the lightbox', () => {
+    const onClose = vi.fn();
+    render(<MediaLightbox item={imageItem} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Refine Prompt' }));
+    const refineModal = screen.getByTestId('refine-modal');
+
+    fireEvent.keyDown(refineModal, { key: 'Escape' });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('refine-modal')).toBeNull();
+    expect(screen.getByRole('dialog')).toBeTruthy();
   });
 });
 

--- a/client/src/components/media/MediaLightbox.test.jsx
+++ b/client/src/components/media/MediaLightbox.test.jsx
@@ -10,7 +10,10 @@ vi.mock('./AddToCollectionMenu', () => ({ default: () => null }));
 vi.mock('./PromptRefineModal', () => ({
   default: ({ open }) => open ? <div data-testid="refine-modal" /> : null,
 }));
-vi.mock('./PromptFromMedia', () => ({ default: () => null, PromptFromMediaModal: () => null }));
+vi.mock('./PromptFromMedia', () => ({
+  default: () => null,
+  PromptFromMediaModal: ({ open }) => open ? <div data-testid="prompt-from-modal" /> : null,
+}));
 
 const videoItem = {
   kind: 'video',
@@ -142,6 +145,29 @@ describe('MediaLightbox Escape cascade', () => {
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.queryByTestId('refine-modal')).toBeNull();
     expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('closes the prompt-from-media modal without closing the lightbox', () => {
+    const onClose = vi.fn();
+    render(<MediaLightbox item={imageItem} onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Prompt from this' }));
+    const promptFromModal = screen.getByTestId('prompt-from-modal');
+
+    fireEvent.keyDown(promptFromModal, { key: 'Escape' });
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('prompt-from-modal')).toBeNull();
+    expect(screen.getByRole('dialog')).toBeTruthy();
+  });
+
+  it('closes the lightbox when Escape is pressed with nothing else open', () => {
+    const onClose = vi.fn();
+    render(<MediaLightbox item={imageItem} onClose={onClose} />);
+
+    fireEvent.keyDown(screen.getByRole('dialog'), { key: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- `MediaLightbox.jsx` documents an Escape-key cascade (`refineOpen` → `promptFromOpen` → `fullScreen` → `onClose`) handled by a window-level keydown listener, but the overlay `<div>` also carried a redundant `onKeyDown={(e) => e.key === 'Escape' && onClose()}` handler.
- Because `useFocusTrap` keeps focus inside the overlay, every Escape keydown bubbled to that React handler first (React dispatches from its container, below `window`), so `onClose()` fired unconditionally and the cascade never got a turn — Escape always closed the whole lightbox instead of backing out of full screen or a sub-modal one level at a time.
- Removes the redundant `onKeyDown` prop so the window-level listener is the sole Escape handler.

Closes #4260.

## Test plan
- Added regression tests in `MediaLightbox.test.jsx` covering all three cascade levels (`fullScreen`, `refineOpen`, `promptFromOpen`) plus the baseline case (Escape with nothing open still closes the lightbox).
- `cd client && npx vitest run src/components/media/MediaLightbox.test.jsx` — 10/10 passing.