### PR TITLE
fix: prevent pending sing-to-score mic leaks

### DIFF
--- a/.changelog/next/fixed-issue-4236.md
+++ b/.changelog/next/fixed-issue-4236.md
@@ -1,0 +1,1 @@
+- Sing-to-score now closes a microphone stream that resolves after its permission prompt has been cancelled.

--- a/client/src/hooks/useSingToScore.js
+++ b/client/src/hooks/useSingToScore.js
@@ -61,6 +61,8 @@ export default function useSingToScore({ tempo, score = '', musicKey = 'C' } = {
   const trackRef = useRef([]);        // accumulated { tMs, hz, clarity } frames
   const captureStartRef = useRef(0);  // performance.now() at first music beat
   const capturingRef = useRef(false); // gate frames until the count-in completes
+  const startPendingRef = useRef(false);
+  const requestGenerationRef = useRef(0);
 
   // Held for exactly the window our own mic stream is open, symmetric with
   // `voiceClient` / `audioRecorder`. Sing-to-score is safe on `auto` only
@@ -81,6 +83,19 @@ export default function useSingToScore({ tempo, score = '', musicKey = 'C' } = {
     releaseSession();
     capturingRef.current = false;
   }, [releaseSession]);
+
+  // Invalidate an in-flight permission request before tearing down. A browser
+  // can resolve getUserMedia after this hook unmounts; that continuation owns
+  // its stream until it sees this generation change and stops it itself.
+  const cancel = useCallback(() => {
+    requestGenerationRef.current += 1;
+    startPendingRef.current = false;
+    teardown();
+    trackRef.current = [];
+    if (!mountedRef.current) return;
+    setPhase(SING_IDLE);
+    setBeat(null);
+  }, [teardown, mountedRef]);
 
   // Finalize: stop everything, run the transcription over the captured track.
   const finish = useCallback(() => {
@@ -104,7 +119,9 @@ export default function useSingToScore({ tempo, score = '', musicKey = 'C' } = {
   }, [phase, finish]);
 
   const start = useCallback(async () => {
-    if (phase !== SING_IDLE) return;
+    if (phase !== SING_IDLE || startPendingRef.current) return;
+    startPendingRef.current = true;
+    const requestGeneration = ++requestGenerationRef.current;
     setError(null);
     setResult(null);
     trackRef.current = [];
@@ -115,6 +132,7 @@ export default function useSingToScore({ tempo, score = '', musicKey = 'C' } = {
     // record-capable with no release left to call. Mirrors useSingToVerify.
     const getUserMedia = navigator.mediaDevices?.getUserMedia?.bind(navigator.mediaDevices);
     if (!getUserMedia) {
+      startPendingRef.current = false;
       if (mountedRef.current) setError('Microphone access requires a secure browser connection');
       return;
     }
@@ -125,12 +143,20 @@ export default function useSingToScore({ tempo, score = '', musicKey = 'C' } = {
     // below is belt-and-suspenders: the hook already releases on unmount).
     claimSession();
     const src = await getUserMedia({ audio: true }).catch((err) => {
-      releaseSession();
-      if (mountedRef.current) setError(err?.message || 'Microphone access denied');
+      if (requestGeneration === requestGenerationRef.current) {
+        startPendingRef.current = false;
+        releaseSession();
+        if (mountedRef.current) setError(err?.message || 'Microphone access denied');
+      }
       return null;
     });
     if (!src) return;
-    if (!mountedRef.current) { src.getTracks().forEach((t) => t.stop()); releaseSession(); return; }
+    if (!mountedRef.current || requestGeneration !== requestGenerationRef.current) {
+      src.getTracks().forEach((track) => track.stop());
+      if (requestGeneration === requestGenerationRef.current) releaseSession();
+      return;
+    }
+    startPendingRef.current = false;
     streamRef.current = src;
 
     const graph = createStreamAnalyser(src);
@@ -174,6 +200,9 @@ export default function useSingToScore({ tempo, score = '', musicKey = 'C' } = {
     });
     metronomeRef.current = metro;
     await metro.start().catch((err) => {
+      // A cancellation or fresh request may have already torn this capture
+      // down. Do not let its late failure tear down a newer session.
+      if (requestGeneration !== requestGenerationRef.current) return;
       if (mountedRef.current) setError(err?.message || 'Could not start audio');
       teardown();
       if (mountedRef.current) setPhase(SING_IDLE);
@@ -186,13 +215,13 @@ export default function useSingToScore({ tempo, score = '', musicKey = 'C' } = {
     setError(null);
   }, []);
 
-  // Belt-and-suspenders: tear everything down on unmount so a navigation-away
-  // mid-capture can't leave the mic open or a loop running. A ref keeps the
-  // effect's dep list empty (run cleanup exactly once on unmount) while still
-  // calling the latest `teardown`.
-  const teardownRef = useRef(teardown);
-  teardownRef.current = teardown;
-  useEffect(() => () => teardownRef.current(), []);
+  // Belt-and-suspenders: cancel everything on unmount so a navigation-away
+  // mid-permission or mid-capture can't leave the mic open or a loop running.
+  // A ref keeps the effect's dep list empty (run cleanup exactly once on
+  // unmount) while still calling the latest cancellation callback.
+  const cancelRef = useRef(cancel);
+  cancelRef.current = cancel;
+  useEffect(() => () => cancelRef.current(), []);
 
   return { phase, beat, result, error, start, stop, reset };
 }

--- a/client/src/hooks/useSingToScore.test.js
+++ b/client/src/hooks/useSingToScore.test.js
@@ -148,6 +148,30 @@ describe('useSingToScore', () => {
     expect(trackStop).toHaveBeenCalledOnce();
   });
 
+  it('ignores a permission rejection that arrives after capture was already cancelled', async () => {
+    let rejectStream;
+    navigator.mediaDevices.getUserMedia = vi.fn(() => new Promise((_resolve, reject) => {
+      rejectStream = reject;
+    }));
+    const { result, unmount } = renderHook(() => useSingToScore({ tempo: 120, score: 'time: 4/4' }));
+
+    let startPromise;
+    act(() => { startPromise = result.current.start(); });
+    unmount();
+
+    // The pending getUserMedia request rejects only after cancel() already
+    // tore this attempt down (generation bumped). The stale-generation branch
+    // in the catch handler must swallow this quietly — no error surfaced, no
+    // stream to stop, no double release.
+    await act(async () => {
+      rejectStream(new Error('Permission denied'));
+      await startPromise.catch(() => {});
+    });
+
+    expect(result.current.error).toBeNull();
+    expect(trackStop).not.toHaveBeenCalled();
+  });
+
   // `playback` REFUSES capture on iOS, and the transport-driven players declare
   // it document-wide, so this hook has to claim `play-and-record` around its own
   // getUserMedia rather than relying on nothing else having claimed first (#4131).

--- a/client/src/hooks/useSingToScore.test.js
+++ b/client/src/hooks/useSingToScore.test.js
@@ -93,6 +93,10 @@ describe('useSingToScore', () => {
     await act(async () => { await result.current.start(); });
     expect(result.current.phase).toBe(SING_IDLE);
     expect(result.current.error).toBe('Permission denied');
+
+    global.navigator.mediaDevices.getUserMedia = vi.fn(async () => fakeStream());
+    await act(async () => { await result.current.start(); });
+    expect(result.current.phase).toBe(SING_COUNT_IN);
   });
 
   it('tears down mic, analyser, tracker, and metronome on unmount', async () => {
@@ -103,6 +107,45 @@ describe('useSingToScore', () => {
     expect(trackerStop).toHaveBeenCalled();
     expect(analyserClose).toHaveBeenCalled();
     expect(trackStop).toHaveBeenCalled();
+  });
+
+  it('allows only one microphone request while permission is pending', async () => {
+    let resolveStream;
+    navigator.mediaDevices.getUserMedia = vi.fn(() => new Promise((resolve) => {
+      resolveStream = resolve;
+    }));
+    const { result } = renderHook(() => useSingToScore({ tempo: 120, score: 'time: 4/4' }));
+
+    let firstStart;
+    act(() => {
+      firstStart = result.current.start();
+      result.current.start();
+    });
+    expect(navigator.mediaDevices.getUserMedia).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveStream(fakeStream());
+      await firstStart;
+    });
+    expect(result.current.phase).toBe(SING_COUNT_IN);
+  });
+
+  it('stops a permission-pending stream when capture is cancelled', async () => {
+    let resolveStream;
+    navigator.mediaDevices.getUserMedia = vi.fn(() => new Promise((resolve) => {
+      resolveStream = resolve;
+    }));
+    const { result, unmount } = renderHook(() => useSingToScore({ tempo: 120, score: 'time: 4/4' }));
+
+    let startPromise;
+    act(() => { startPromise = result.current.start(); });
+    unmount();
+    await act(async () => {
+      resolveStream(fakeStream());
+      await startPromise;
+    });
+
+    expect(trackStop).toHaveBeenCalledOnce();
   });
 
   // `playback` REFUSES capture on iOS, and the transport-driven players declare


### PR DESCRIPTION
## Summary

`useSingToScore` had only a `phase !== SING_IDLE` guard against re-entering `start()`, and `setPhase(SING_COUNT_IN)` didn't run until after the `getUserMedia` permission prompt resolved. Two clicks inside that window both passed the guard: both `getUserMedia` calls resolved, the second silently overwrote `streamRef.current`/`analyserRef`/`trackerRef`/`metronomeRef`, and the first mic stream, analyser graph, and tracker interval were never stopped — a live microphone with no UI path to close it.

This mirrors the sibling hook `useSingToVerify`'s existing fix for the same class of bug: adds a `startPendingRef` (drops a synchronous re-entrant `start()`) and a `requestGenerationRef` counter so a superseded continuation (one invalidated by a cancel/unmount while its `getUserMedia` or `metronome.start()` was still pending) recognizes it's stale and tears down its own stream instead of clobbering a newer session's state.

Closes #4236.

## Test plan

- `cd client && npx vitest run src/hooks/useSingToScore.test.js` — 10/10 passing, including two new tests ported from `useSingToVerify.test.js` ("allows only one microphone request while permission is pending", "stops a permission-pending stream when capture is cancelled") plus a third added during review covering the stale-generation `getUserMedia` rejection path.
- Full `cd client && npm test` and `cd server && NODE_ENV=test npm test` runs pass aside from pre-existing, unrelated timeout flakes under heavy parallel-agent load (`PostDrillConfig.test.jsx`, `BrowseTab.test.jsx`, `sprites/atlas.test.js`, `universeBuilder/store.test.js`, etc.) — none touch sing-to-score, and this branch makes zero server-side changes.