### PR TITLE
fix: use eight-forward MiniMax H3 MLX denoising schedule

### DIFF
--- a/.changelog/next/fixed-minimax-h3-mlx-denoising-count.md
+++ b/.changelog/next/fixed-minimax-h3-mlx-denoising-count.md
@@ -1,0 +1,1 @@
+- Use the MLX MiniMax H3 reference denoising schedule by default

--- a/data.reference/media-models.json
+++ b/data.reference/media-models.json
@@ -169,10 +169,10 @@
           }
         ],
         "memoryGb": 128,
-        "steps": 8,
+        "steps": 9,
         "guidance": 0,
         "samplerLocked": true,
-        "samplerNote": "MiniMax H3 is CFG-distilled; this profile locks the validated 8-point sigma schedule and does not use CFG.",
+        "samplerNote": "MiniMax H3 is CFG-distilled; this profile locks the MLX reference 9-point sigma schedule (8 DiT forwards) and does not use CFG.",
         "supportsNegativePrompt": false,
         "supportsTiling": false,
         "supportsDisableAudio": false,

--- a/scripts/_minimax_h3_common.py
+++ b/scripts/_minimax_h3_common.py
@@ -38,15 +38,21 @@ FRAME_MODULUS = 17
 FRAME_REMAINDER = 5
 
 
-def add_h3_common_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+def add_h3_common_args(
+    parser: argparse.ArgumentParser,
+    *,
+    steps_default: int = 8,
+) -> argparse.ArgumentParser:
     """Declare the CLI surface both runners present to PortOS.
 
     `validate_h3_output_args` below reads exactly these fields off the parsed
     Namespace, so the schema and its validator have to agree — declaring them
-    apart is how one runner's `--steps` default drifts from the other's with
+    apart is how one runner's `--steps` surface drifts from the other's with
     nothing failing until a render. Each runner adds its own flags on top
     (`--checkpoint-*` and the LoRA / text-encoder pairs for MLX, `--repo-file`
-    and `--offload-profile` for CUDA).
+    and `--offload-profile` for CUDA). The runners pass their own sampler
+    default because the MLX port's sigma-grid argument is one larger than its
+    desired transformer-forward count, while diffusers counts forwards.
     """
     parser.add_argument("--model-repo", required=True)
     parser.add_argument("--model-revision", required=True)
@@ -55,7 +61,7 @@ def add_h3_common_args(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     parser.add_argument("--height", type=int, required=True)
     parser.add_argument("--num-frames", type=int, required=True)
     parser.add_argument("--fps", type=int, default=FPS)
-    parser.add_argument("--steps", type=int, default=8)
+    parser.add_argument("--steps", type=int, default=steps_default)
     parser.add_argument("--seed", type=int, default=0)
     parser.add_argument("--image", action="append", default=[],
                         help="keyframe conditioning image (repeatable, max 2)")

--- a/scripts/_minimax_h3_common.test.js
+++ b/scripts/_minimax_h3_common.test.js
@@ -63,8 +63,8 @@ describe.skipIf(!pyBin)('_minimax_h3_common.py — checkpoint facts shared by bo
   // The shared validator reads these exact fields off the parsed Namespace, so
   // the two runners have to present the same surface or one of them can hand it
   // an attribute that doesn't exist. Declaring the flags once is what makes that
-  // true; this pins the set so a runner can't quietly drop one back into its own
-  // parser with a different type or default.
+  // true; the per-runner sampler default is an explicit parameter because MLX
+  // and diffusers count their schedules differently.
   it('declares the CLI surface both runners share', () => {
     const output = lines(runPython(`${importShared}\n${[
       'import argparse',

--- a/scripts/generate_minimax_h3.py
+++ b/scripts/generate_minimax_h3.py
@@ -41,7 +41,7 @@ STEP_RE = re.compile(r"\bstep\s+(\d+)/(\d+)\b", re.IGNORECASE)
 
 
 def parse_args() -> argparse.Namespace:
-    parser = add_h3_common_args(argparse.ArgumentParser(description=__doc__))
+    parser = add_h3_common_args(argparse.ArgumentParser(description=__doc__), steps_default=9)
     parser.add_argument("--runtime-dir", required=True)
     parser.add_argument("--runtime-revision", required=True)
     parser.add_argument("--checkpoint-repo", required=True)

--- a/scripts/generate_minimax_h3.test.js
+++ b/scripts/generate_minimax_h3.test.js
@@ -50,7 +50,7 @@ const VALIDATE_ARGS_DEFAULTS = {
   width: 512,
   height: 320,
   num_frames: 124,
-  steps: 8,
+  steps: 9,
   image: [],
   anchor: [],
   lora: [],
@@ -68,6 +68,19 @@ const argsExpr = (overrides = {}) => {
 };
 
 describe.skipIf(!pyBin)('generate_minimax_h3.py', () => {
+  it('defaults the MLX runner to nine sigma points for eight forwards', () => {
+    const output = runPython(`${importRunner}\n${[
+      'import sys',
+      'sys.argv = ["generate_minimax_h3.py", "--model-repo", "example/model", "--model-revision", "revision",',
+      '    "--runtime-dir", "/tmp/runtime", "--runtime-revision", "revision",',
+      '    "--checkpoint-repo", "example/checkpoint", "--checkpoint-revision", "revision",',
+      '    "--prompt", "a test prompt", "--width", "1344", "--height", "768",',
+      '    "--num-frames", "124", "--output", "test.mp4"]',
+      'print(runner.parse_args().steps)',
+    ].join('\n')}`);
+    expect(output.trim()).toBe('9');
+  });
+
   // Only this runner shells out to ffmpeg (the CUDA sibling muxes in-process
   // via PyAV), so the preflight lives here rather than in the shared module.
   // Tens of GB of weights load before the mux; discovering a missing ffmpeg

--- a/scripts/generate_minimax_h3_cuda.py
+++ b/scripts/generate_minimax_h3_cuda.py
@@ -67,7 +67,7 @@ def log(message: str) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = add_h3_common_args(argparse.ArgumentParser(description=__doc__))
+    parser = add_h3_common_args(argparse.ArgumentParser(description=__doc__), steps_default=8)
     parser.add_argument("--repo-file", action="append", default=[],
                         help="repo-relative diffusers component file that must already be cached (repeatable)")
     parser.add_argument("--offload-profile", choices=OFFLOAD_PROFILES, default="auto",

--- a/scripts/migrations/271-minimax-h3-mlx-denoising-count.js
+++ b/scripts/migrations/271-minimax-h3-mlx-denoising-count.js
@@ -1,0 +1,45 @@
+/**
+ * Move existing MiniMax H3 MLX rows from the old eight-point sigma grid
+ * (seven transformer forwards) to the MLX reference's nine-point grid
+ * (eight forwards).
+ *
+ * Only the shipped PipeNetwork row with the old shipped sampler contract is
+ * eligible. A hand-tuned step count, guidance value, lock state, or note is
+ * preserved rather than silently overwritten.
+ */
+
+import { readMediaRegistry, writeMediaRegistry } from './_lib.js';
+import {
+  MINIMAX_H3_OUTPUT_PROFILE,
+  upgradeMiniMaxH3DenoisingCount,
+} from '../../server/lib/mediaModels.js';
+
+const REL_PATH = 'data/media-models.json';
+const { id: H3_ID, shippedRepo: SHIPPED_REPO } = MINIMAX_H3_OUTPUT_PROFILE;
+
+export default {
+  async up({ rootDir }) {
+    const { ok, config, entries: mlxEntries, path } = await readMediaRegistry({ rootDir });
+    if (!ok) return;
+
+    const entry = mlxEntries.find((model) => model?.id === H3_ID);
+    if (!entry) {
+      console.log(`✅ ${REL_PATH}: no '${H3_ID}' entry — user removed it, nothing to migrate`);
+      return;
+    }
+    if (entry.repo !== SHIPPED_REPO) {
+      console.log(`✅ ${REL_PATH}: '${H3_ID}' points at ${entry.repo} — user-repointed, leaving it alone`);
+      return;
+    }
+
+    const [upgraded] = upgradeMiniMaxH3DenoisingCount([entry]);
+    if (upgraded === entry) {
+      console.log(`✅ ${REL_PATH}: MiniMax H3 sampler is current or customized`);
+      return;
+    }
+
+    Object.assign(entry, upgraded);
+    await writeMediaRegistry(path, config);
+    console.log(`📝 ${REL_PATH}: updated MiniMax H3 MLX to 9 sigma points (8 DiT forwards)`);
+  },
+};

--- a/scripts/migrations/271-minimax-h3-mlx-denoising-count.test.js
+++ b/scripts/migrations/271-minimax-h3-mlx-denoising-count.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import migration from './271-minimax-h3-mlx-denoising-count.js';
+
+const H3_ID = 'minimax_h3_8bit';
+const OLD_NOTE = 'MiniMax H3 is CFG-distilled; this profile locks the validated 8-point sigma schedule and does not use CFG.';
+const NEW_NOTE = 'MiniMax H3 is CFG-distilled; this profile locks the MLX reference 9-point sigma schedule (8 DiT forwards) and does not use CFG.';
+
+const h3 = (extra = {}) => ({
+  id: H3_ID,
+  repo: 'pipenetwork/MiniMax-H3-MLX-8bit',
+  steps: 8,
+  guidance: 0,
+  samplerLocked: true,
+  samplerNote: OLD_NOTE,
+  ...extra,
+});
+
+const registryWith = (entry) => ({
+  video: { macos: entry ? [entry] : [], windows: [] },
+  image: [],
+});
+
+const writeJson = (path, value) => writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf-8'));
+
+describe('migration 271 — MiniMax H3 MLX denoising count', () => {
+  let rootDir;
+  let path;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'migration-271-'));
+    mkdirSync(join(rootDir, 'data'), { recursive: true });
+    path = join(rootDir, 'data', 'media-models.json');
+  });
+
+  afterEach(() => rmSync(rootDir, { recursive: true, force: true }));
+
+  it('updates the old shipped sampler contract to eight forwards', async () => {
+    writeJson(path, registryWith(h3()));
+    await migration.up({ rootDir });
+
+    expect(readJson(path).video.macos[0]).toMatchObject({
+      steps: 9,
+      samplerNote: NEW_NOTE,
+    });
+  });
+
+  it('is idempotent', async () => {
+    writeJson(path, registryWith(h3()));
+    await migration.up({ rootDir });
+    const once = readFileSync(path, 'utf-8');
+    await migration.up({ rootDir });
+    expect(readFileSync(path, 'utf-8')).toBe(once);
+  });
+
+  it('preserves customized sampler settings and repointed rows', async () => {
+    const custom = { ...h3({ steps: 12, samplerNote: 'local experiment' }) };
+    writeJson(path, registryWith(custom));
+    await migration.up({ rootDir });
+    expect(readJson(path)).toEqual(registryWith(custom));
+
+    const repointed = h3({ repo: 'example-org/h3-fork' });
+    writeJson(path, registryWith(repointed));
+    await migration.up({ rootDir });
+    expect(readJson(path)).toEqual(registryWith(repointed));
+  });
+
+  it('does nothing when the registry or shipped row is absent', async () => {
+    await expect(migration.up({ rootDir })).resolves.toBeUndefined();
+    writeJson(path, registryWith(null));
+    await migration.up({ rootDir });
+    expect(readJson(path)).toEqual(registryWith(null));
+  });
+});

--- a/server/lib/mediaModels.js
+++ b/server/lib/mediaModels.js
@@ -126,6 +126,10 @@ export const MINIMAX_H3_OUTPUT_PROFILE = Object.freeze({
   shippedRepo: 'pipenetwork/MiniMax-H3-MLX-8bit',
   oldFrameOptions: h3FrameGrid(124, 362),
   frameOptions: h3FrameGrid(107, 362),
+  oldMlxSteps: 8,
+  mlxSteps: 9,
+  oldMlxSamplerNote: 'MiniMax H3 is CFG-distilled; this profile locks the validated 8-point sigma schedule and does not use CFG.',
+  mlxSamplerNote: 'MiniMax H3 is CFG-distilled; this profile locks the MLX reference 9-point sigma schedule (8 DiT forwards) and does not use CFG.',
   ...MINIMAX_H3_CANVAS,
 });
 
@@ -201,10 +205,31 @@ const sameValues = (left, right) => (
   && left.every((value, index) => value === right[index])
 );
 
+const upgradeMiniMaxH3DenoisingCountEntry = (entry, profile) => {
+  if (!isPlainObject(entry) || entry.id !== profile.id || entry.repo !== profile.shippedRepo) return entry;
+  // The MLX port treats `steps` as sigma-grid points, with the terminal zero
+  // excluded from transformer evaluation. The old shipped value therefore
+  // ran seven forwards, while the reference quality example uses nine grid
+  // points for eight forwards. Preserve a hand-tuned sampler contract.
+  const samplerIsLegacyShipped = entry.steps === profile.oldMlxSteps
+    && (!Object.hasOwn(entry, 'guidance') || entry.guidance === 0)
+    && (!Object.hasOwn(entry, 'samplerLocked') || entry.samplerLocked === true)
+    && (!Object.hasOwn(entry, 'samplerNote') || entry.samplerNote === profile.oldMlxSamplerNote);
+  return samplerIsLegacyShipped
+    ? { ...entry, steps: profile.mlxSteps, samplerNote: profile.mlxSamplerNote }
+    : entry;
+};
+
+export const upgradeMiniMaxH3DenoisingCount = (list) => {
+  if (!Array.isArray(list)) return list;
+  const profile = MINIMAX_H3_OUTPUT_PROFILE;
+  return list.map((entry) => upgradeMiniMaxH3DenoisingCountEntry(entry, profile));
+};
+
 export const upgradeMiniMaxH3OutputControls = (list) => {
   if (!Array.isArray(list)) return list;
   const profile = MINIMAX_H3_OUTPUT_PROFILE;
-  return list.map((entry) => {
+  const withGeometry = list.map((entry) => {
     if (!isPlainObject(entry) || entry.id !== profile.id || entry.repo !== profile.shippedRepo) return entry;
     let next = entry;
     if (sameValues(next.frameOptions, profile.oldFrameOptions)) {
@@ -225,6 +250,7 @@ export const upgradeMiniMaxH3OutputControls = (list) => {
     }
     return next;
   });
+  return upgradeMiniMaxH3DenoisingCount(withGeometry);
 };
 
 const DEFAULT_REGISTRY = {
@@ -283,10 +309,10 @@ const DEFAULT_REGISTRY = {
         ...MINIMAX_H3_CANVAS,
         resolutionOptions: MINIMAX_H3_CANVAS.resolutionOptions.map((preset) => ({ ...preset })),
         memoryGb: 128,
-        steps: 8,
+        steps: MINIMAX_H3_OUTPUT_PROFILE.mlxSteps,
         guidance: 0,
         samplerLocked: true,
-        samplerNote: 'MiniMax H3 is CFG-distilled; this profile locks the validated 8-point sigma schedule and does not use CFG.',
+        samplerNote: MINIMAX_H3_OUTPUT_PROFILE.mlxSamplerNote,
         supportsNegativePrompt: false,
         supportsTiling: false,
         supportsDisableAudio: false,

--- a/server/lib/mediaModels.test.js
+++ b/server/lib/mediaModels.test.js
@@ -88,7 +88,8 @@ describe('mediaModels registry', () => {
       fpsOptions: [24],
       memoryGb: 128,
       samplerLocked: true,
-      steps: 8,
+      steps: 9,
+      samplerNote: 'MiniMax H3 is CFG-distilled; this profile locks the MLX reference 9-point sigma schedule (8 DiT forwards) and does not use CFG.',
     });
     expect(h3.frameOptions).toEqual([107, 124, 141, 158, 175, 192, 209, 226, 243, 260, 277, 294, 311, 328, 345, 362]);
     expect(h3.resolutionOptions).toEqual([
@@ -641,6 +642,8 @@ describe('mediaModels registry', () => {
         resolutionStep: 32,
       });
       expect(entry.frameOptions[0]).toBe(107);
+      expect(entry.steps).toBe(9);
+      expect(entry.samplerNote).toContain('9-point sigma schedule (8 DiT forwards)');
       expect(entry.resolutionOptions).toContainEqual({
         label: '1536x672 (21:9 H3 native)', w: 1536, h: 672,
       });


### PR DESCRIPTION
Summary:
- Align the MLX MiniMax H3 default with the reference 9-point sigma schedule, which performs 8 DiT forwards.
- Keep the CUDA runner and registry at its existing 8-forward setting.
- Update the shipped registry and MLX CLI default, and add load-time plus migration-271 compatibility upgrades for legacy shipped rows.
- Preserve custom sampler settings and repointed model repositories.

Test plan:
- Full server suite: 1,403 test files passed and 29,417 tests passed; 27 database-dependent files skipped by the repository safety gate because the test database was unavailable.
- Focused H3/media suite: 7 files passed, 306 tests passed.
- Native MLX H3 render completed at the native 1344x768 geometry, 124 frames, and 24 fps with the 8-forward schedule; sampled frames were clear and coherent.