### PR TITLE
feat: manage video text encoders in Media Models

### DIFF
--- a/.changelog/next/added-agent-a2e7c7e9.md
+++ b/.changelog/next/added-agent-a2e7c7e9.md
@@ -1,0 +1,1 @@
+- Manage MiniMax H3 text encoder downloads in Media Models

--- a/client/src/pages/MediaModels.jsx
+++ b/client/src/pages/MediaModels.jsx
@@ -1,29 +1,33 @@
 /**
  * Media Models — manage the model catalog + clean up cached weights.
  *
- * Two concerns share this page:
+ * Three concerns share this page:
  *  1. Model catalog (registry): the image/video base models that can be picked
  *     in the gen forms. Built-in entries are read-only; user-added entries
  *     (installed from HuggingFace) are editable/removable. Adding a model here
  *     appends a `data/media-models.json` entry and hot-reloads the registry —
  *     no server restart (issue #2124).
- *  2. Cached weights: HF models live at HF's standard location
- *     (`~/.cache/huggingface/hub` unless HF_HOME is set). PortOS doesn't move or
- *     symlink them — it reads sizes for display and offers Delete to free disk.
+ *  2. MiniMax H3 text encoders: selectable prompt conditioners are separately
+ *     downloadable, so they need the same install/delete lifecycle as models.
+ *  3. Cached weights: HF models live at Hugging Face's configured cache
+ *     location. PortOS doesn't move or symlink them — it reads sizes for
+ *     display and offers Delete to free disk.
  *     LoRAs sit in `data/loras/`.
  *
  * The two views are JOINED on the HF repo id: a catalog row whose weights are
  * on disk shows its size and a "Delete weights" action inline, so freeing disk
  * for a model no longer means scrolling to a second list to find the same model
- * again. The cached-weights section below only lists what the catalog does NOT
- * cover (text encoders, orphaned/removed repos).
+ * again. The cached-weights section below only lists orphaned/removed repos.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { AlertTriangle, Trash2, Image as ImageIcon, Film, Plus, Pencil, Lock, X, Check, HardDrive } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import useConfirmDelete from '../hooks/useConfirmDelete';
+import { useModelDownloadStatus, textEncoderDownloadId } from '../hooks/useModelDownloadStatus';
+import ModelDownloadBadge from '../components/media/ModelDownloadBadge';
+import { formatBytes } from '../utils/formatters.js';
 import {
   listCachedModels,
   deleteCachedModel,
@@ -37,12 +41,13 @@ import {
 const DESTRUCTIVE_BTN = 'px-3 py-1.5 text-xs bg-port-error/20 hover:bg-port-error/40 text-port-error rounded disabled:opacity-50 flex items-center gap-1';
 
 /**
- * One arm-then-confirm destructive action. All four deletes on this page —
- * a catalog row's weights, a catalog row's registry entry, an orphaned cache
- * dir, a LoRA — are the same shape: a trigger that arms `confirmKey`, swapped
- * in place for the inline confirm pair. Keeping it in one component means the
- * confirm UX can't drift between them. `confirm` is a useConfirmDelete()
- * result, so only one action across the whole page is ever armed.
+ * One arm-then-confirm destructive action. Every delete on this page —
+ * a catalog row's weights, a text encoder, a catalog row's registry entry, an
+ * orphaned cache dir, or a LoRA — are the same shape: a trigger that arms
+ * `confirmKey`, swapped in place for the inline confirm pair. Keeping it in
+ * one component means the confirm UX can't drift between them. `confirm` is a
+ * useConfirmDelete() result, so only one action across the whole page is ever
+ * armed.
  */
 function DeleteAction({
   confirm,
@@ -53,6 +58,7 @@ function DeleteAction({
   confirmText = 'Delete',
   busyText = 'Deleting…',
   busy = false,
+  disabled = false,
   title,
   className = DESTRUCTIVE_BTN,
   icon: Icon = Trash2,
@@ -77,7 +83,7 @@ function DeleteAction({
     <button
       type="button"
       onClick={() => confirm.requestDelete(confirmKey)}
-      disabled={busy}
+      disabled={busy || disabled}
       title={title}
       className={className}
     >
@@ -88,7 +94,7 @@ function DeleteAction({
 
 export default function MediaModels() {
   const [data, setData] = useState({ models: [], loras: [], hubDir: '', diskUsage: {} });
-  const [registry, setRegistry] = useState({ video: [], image: [] });
+  const [registry, setRegistry] = useState({ video: [], image: [], textEncoders: [] });
   const [busy, setBusy] = useState(null);
   const [error, setError] = useState(null);
 
@@ -105,6 +111,11 @@ export default function MediaModels() {
   // (`weights:` / `entry:` on a catalog row, `cache:` / `lora:` below) because
   // a catalog row carries TWO different deletes — its weights and its entry.
   const deleteConfirm = useConfirmDelete();
+  // H3 conditioner downloads already use the video download lane (including
+  // its SSE progress and cache verification). Reuse it here so installing from
+  // Models has the exact same explicit, recoverable behavior as Video Gen.
+  const textEncoderDownloads = useModelDownloadStatus({ kind: 'video' });
+  const wasDownloadingTextEncoder = useRef(false);
 
   const refresh = useCallback(() => {
     setError(null);
@@ -120,6 +131,19 @@ export default function MediaModels() {
   }, []);
 
   useEffect(() => { refresh(); }, [refresh]);
+
+  // The shared download hook refreshes its own cache badge when an SSE pull
+  // closes. Refresh the manager's cache-directory list once too, so the new
+  // encoder immediately gains its Delete weights action without a page reload.
+  useEffect(() => {
+    if (textEncoderDownloads.downloading) {
+      wasDownloadingTextEncoder.current = true;
+      return;
+    }
+    if (!wasDownloadingTextEncoder.current) return;
+    wasDownloadingTextEncoder.current = false;
+    listCachedModels({ silent: true }).then(setData).catch(() => {});
+  }, [textEncoderDownloads.downloading]);
 
   const handleDeleteModel = async (id) => {
     setBusy(id);
@@ -138,6 +162,18 @@ export default function MediaModels() {
       .then(() => {
         toast.success('LoRA deleted');
         setData((d) => ({ ...d, loras: d.loras.filter((l) => l.filename !== filename) }));
+      })
+      .catch((err) => toast.error(err.message || 'Delete failed'))
+      .finally(() => setBusy(null));
+  };
+
+  const handleDeleteTextEncoder = async (encoder, cacheId) => {
+    setBusy(cacheId);
+    await deleteCachedModel(cacheId, { silent: true })
+      .then(async () => {
+        toast.success(`${encoder.label} deleted — re-download it before selecting it in Video Gen`);
+        setData((d) => ({ ...d, models: d.models.filter((m) => m.id !== cacheId) }));
+        await textEncoderDownloads.refresh();
       })
       .catch((err) => toast.error(err.message || 'Delete failed'))
       .finally(() => setBusy(null));
@@ -199,7 +235,7 @@ export default function MediaModels() {
         // Merge the returned fields into the matching registry row locally
         // instead of refetching the whole catalog + cache.
         const merge = (list) => list.map((m) => (m.id === id ? { ...m, ...updated } : m));
-        setRegistry((r) => ({ video: merge(r.video), image: merge(r.image) }));
+        setRegistry((r) => ({ ...r, video: merge(r.video), image: merge(r.image) }));
       })
       .catch((err) => toast.error(err.message || 'Update failed'))
       .finally(() => setBusy(null));
@@ -211,6 +247,7 @@ export default function MediaModels() {
       .then(() => {
         toast.success('Custom model removed');
         setRegistry((r) => ({
+          ...r,
           video: r.video.filter((m) => m.id !== id),
           image: r.image.filter((m) => m.id !== id),
         }));
@@ -234,11 +271,16 @@ export default function MediaModels() {
   // repo -> cached HF dir entry. Both sides key off `org/name`, so a catalog
   // row can report its own on-disk size and delete its own weights.
   const cachedByRepo = new Map((data.models || []).filter((m) => m.repo).map((m) => [m.repo, m]));
+  // Older servers only returned video/image from this endpoint. Treat an
+  // absent textEncoders field as an empty catalog rather than letting a mixed
+  // version federation/UI update turn the page into a blank error state.
+  const textEncoders = Array.isArray(registry.textEncoders) ? registry.textEncoders : [];
   const claimedRepos = new Set(
-    [...registry.video, ...registry.image].map((m) => m.repo).filter(Boolean),
+    [...registry.video, ...registry.image, ...textEncoders].map((m) => m.repo).filter(Boolean),
   );
-  // Anything the catalog doesn't cover: text encoders, and repos whose catalog
-  // entry was removed but whose (multi-GB) weights are still on disk.
+  // Anything the catalog doesn't cover: repos whose catalog entry was removed
+  // but whose (multi-GB) weights are still on disk. Text encoders now have
+  // their own first-class rows below rather than hiding in this catch-all list.
   const unclaimedCached = (data.models || []).filter((m) => !claimedRepos.has(m.repo));
 
   const renderRegistryRow = (m) => {
@@ -362,6 +404,60 @@ export default function MediaModels() {
     );
   };
 
+  const renderTextEncoderRow = (encoder) => {
+    const cached = encoder.repo ? cachedByRepo.get(encoder.repo) : null;
+    const downloadId = encoder.builtIn ? null : textEncoderDownloadId(encoder.id);
+    const status = downloadId ? textEncoderDownloads.getStatus(downloadId) : null;
+    const downloading = textEncoderDownloads.activeModelId === downloadId;
+    const estimateLabel = encoder.sizeBytes ? `~${formatBytes(encoder.sizeBytes)}` : undefined;
+    return (
+      <div key={encoder.id} className="bg-port-bg border border-port-border rounded-lg p-3">
+        <div className="flex flex-wrap items-start gap-x-3 gap-y-2">
+          <div className="flex-1 min-w-0">
+            <div className="text-sm text-white flex items-center gap-2">
+              <span className="truncate">{encoder.label}</span>
+              {encoder.builtIn && <Lock className="w-3 h-3 text-gray-500 shrink-0" title="Included with the MiniMax H3 model weights" />}
+              {cached && (
+                <span className="text-[10px] px-1 rounded bg-port-success/20 text-port-success shrink-0 flex items-center gap-1">
+                  <HardDrive className="w-2.5 h-2.5" /> {cached.sizeHuman}
+                </span>
+              )}
+            </div>
+            {encoder.description && <p className="mt-1 text-xs text-gray-500">{encoder.description}</p>}
+            <p className="mt-1 text-[11px] text-gray-600 truncate">
+              {encoder.builtIn
+                ? 'Included with MiniMax H3 model weights'
+                : `${encoder.repo} · available for ${encoder.modelIds.length === 1 ? 'MiniMax H3' : `${encoder.modelIds.length} video models`}`}
+            </p>
+          </div>
+          {!encoder.builtIn && (
+            <div className="flex flex-wrap items-center gap-2 shrink-0">
+              <ModelDownloadBadge
+                status={status}
+                onDownload={() => textEncoderDownloads.start(downloadId)}
+                onCancel={textEncoderDownloads.cancel}
+                estimateLabel={estimateLabel}
+              />
+              {cached && (
+                <DeleteAction
+                  confirm={deleteConfirm}
+                  confirmKey={`text-encoder:${encoder.id}`}
+                  prompt={`Delete ${cached.sizeHuman} of ${encoder.label} weights?`}
+                  ariaLabel={`Confirm deleting cached weights for ${encoder.label}`}
+                  label="Delete weights"
+                  title="Delete this text encoder's downloaded weights (re-download before using it again)"
+                  busy={busy === cached.id}
+                  disabled={downloading}
+                  onConfirm={() => handleDeleteTextEncoder(encoder, cached.id)}
+                />
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
   return (
     <div className="space-y-6">
       <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
@@ -396,6 +492,18 @@ export default function MediaModels() {
           <p className="text-xs text-gray-500">No models in the catalog yet — add one from HuggingFace below.</p>
         )}
       </div>
+
+      {textEncoders.length > 0 && (
+        <div className="bg-port-card border border-port-border rounded-xl p-5 space-y-3">
+          <h2 className="text-sm font-medium text-gray-300 flex items-center gap-2">
+            <HardDrive className="w-4 h-4" /> Video text encoders ({textEncoders.length})
+          </h2>
+          <p className="text-[11px] text-gray-600">
+            These prompt conditioners change how MiniMax H3 reads a prompt without changing its video weights. Choose one in Video Gen; download substitutes here ahead of time, or delete their weights to reclaim disk space.
+          </p>
+          <div className="space-y-2">{textEncoders.map(renderTextEncoderRow)}</div>
+        </div>
+      )}
 
       <div className="bg-port-card border border-port-border rounded-xl p-5 space-y-4">
         <h2 className="text-sm font-medium text-gray-300 flex items-center gap-2">
@@ -444,7 +552,7 @@ export default function MediaModels() {
           <HardDrive className="w-4 h-4" /> Other cached weights ({unclaimedCached.length})
         </h2>
         <p className="text-[11px] text-gray-600">
-          Downloads with no catalog entry — text encoders, and models you removed from the catalog above. Weights for catalog models are deleted from their own row.
+          Downloads with no catalog entry, such as models you removed from the catalog above. Text encoders and catalog-model weights are deleted from their own rows.
         </p>
         {unclaimedCached.length === 0 ? (
           <p className="text-xs text-gray-500">Nothing here — every cached download belongs to a model in the catalog above.</p>

--- a/client/src/pages/MediaModels.test.jsx
+++ b/client/src/pages/MediaModels.test.jsx
@@ -18,6 +18,21 @@ import {
   removeCustomMediaModel,
 } from '../services/api';
 
+const { textEncoderDownloadId, textEncoderDownloads } = vi.hoisted(() => {
+  const prefix = '__text_encoder_option__:';
+  return {
+    textEncoderDownloadId: (id) => `${prefix}${id}`,
+    textEncoderDownloads: {
+      getStatus: vi.fn(),
+      start: vi.fn(),
+      cancel: vi.fn(),
+      refresh: vi.fn(async () => {}),
+      activeModelId: null,
+      downloading: false,
+    },
+  };
+});
+
 vi.mock('../services/api', () => ({
   listCachedModels: vi.fn(),
   listMediaModelRegistry: vi.fn(),
@@ -30,6 +45,11 @@ vi.mock('../services/api', () => ({
 
 vi.mock('../components/ui/Toast', () => ({
   default: { success: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('../hooks/useModelDownloadStatus', () => ({
+  useModelDownloadStatus: vi.fn(() => textEncoderDownloads),
+  textEncoderDownloadId,
 }));
 
 const BUILT_IN = {
@@ -62,9 +82,31 @@ const ORPHAN = {
   size: 9e9,
   sizeHuman: '9 GB',
 };
+const H3_TEXT_ENCODER = {
+  id: 'heretic-bf16',
+  label: 'Ultra-Heretic',
+  description: 'Alternative MiniMax H3 prompt conditioner',
+  repo: 'example-org/ultra-heretic',
+  sizeBytes: 48e9,
+  builtIn: false,
+  modelIds: ['example-video'],
+};
+const STOCK_H3_TEXT_ENCODER = {
+  id: 'stock',
+  label: 'Stock — MiniMax H3',
+  builtIn: true,
+  modelIds: ['example-video'],
+};
+const CACHED_H3_TEXT_ENCODER = {
+  id: 'models--example-org--ultra-heretic',
+  repo: 'example-org/ultra-heretic',
+  label: 'Ultra-Heretic (Text Encoder)',
+  size: 48e9,
+  sizeHuman: '48 GB',
+};
 
 const CACHE_RESPONSE = {
-  models: [CACHED_BUILT_IN, ORPHAN],
+  models: [CACHED_BUILT_IN, CACHED_H3_TEXT_ENCODER, ORPHAN],
   loras: [],
   hubDir: '/example/hub',
   diskUsage: {},
@@ -74,9 +116,16 @@ describe('MediaModels catalog/cache join', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     listCachedModels.mockResolvedValue(CACHE_RESPONSE);
-    listMediaModelRegistry.mockResolvedValue({ video: [BUILT_IN], image: [CUSTOM] });
+    listMediaModelRegistry.mockResolvedValue({
+      video: [BUILT_IN], image: [CUSTOM], textEncoders: [STOCK_H3_TEXT_ENCODER, H3_TEXT_ENCODER],
+    });
     deleteCachedModel.mockResolvedValue({});
     removeCustomMediaModel.mockResolvedValue({});
+    textEncoderDownloads.getStatus.mockImplementation((id) => (
+      id === textEncoderDownloadId(H3_TEXT_ENCODER.id)
+        ? { id: H3_TEXT_ENCODER.id, cached: true, sizeBytes: H3_TEXT_ENCODER.sizeBytes }
+        : null
+    ));
   });
 
   it('shows the cached size on the catalog row and "not downloaded" when it is absent', async () => {
@@ -88,7 +137,9 @@ describe('MediaModels catalog/cache join', () => {
 
   it('deletes a BUILT-IN model\'s weights from its own row, behind a confirm', async () => {
     render(<MediaModels />);
-    fireEvent.click(await screen.findByRole('button', { name: /Delete weights/ }));
+    const modelName = await screen.findByText('Example Video Model');
+    const modelCard = modelName.closest('.bg-port-bg');
+    fireEvent.click(within(modelCard).getByRole('button', { name: /Delete weights/ }));
     expect(deleteCachedModel).not.toHaveBeenCalled();
 
     const confirmPair = screen.getByRole('group', {
@@ -110,6 +161,41 @@ describe('MediaModels catalog/cache join', () => {
     expect(screen.getByText(/Other cached weights \(1\)/)).toBeInTheDocument();
     // The built-in's cache dir is represented by its catalog row, not repeated.
     expect(screen.queryByText('Example Video Model (Video)')).not.toBeInTheDocument();
+    // A managed H3 prompt conditioner is likewise represented by its own row.
+    expect(screen.queryByText('Ultra-Heretic (Text Encoder)')).not.toBeInTheDocument();
+  });
+
+  it('manages H3 text encoders separately and deletes their cached weights behind a confirm', async () => {
+    render(<MediaModels />);
+    const encoderName = await screen.findByText('Ultra-Heretic');
+    expect(screen.getByText(/Video text encoders \(2\)/)).toBeInTheDocument();
+
+    const encoderCard = encoderName.closest('.bg-port-bg');
+    fireEvent.click(within(encoderCard).getByRole('button', { name: /Delete weights/ }));
+    const confirmPair = screen.getByRole('group', {
+      name: 'Confirm deleting cached weights for Ultra-Heretic',
+    });
+    fireEvent.click(within(confirmPair).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(deleteCachedModel).toHaveBeenCalledWith(
+      CACHED_H3_TEXT_ENCODER.id,
+      { silent: true },
+    ));
+    expect(textEncoderDownloads.refresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('starts an explicit download for an uncached H3 text encoder', async () => {
+    textEncoderDownloads.getStatus.mockImplementation((id) => (
+      id === textEncoderDownloadId(H3_TEXT_ENCODER.id)
+        ? { id: H3_TEXT_ENCODER.id, cached: false, sizeBytes: 0 }
+        : null
+    ));
+    listCachedModels.mockResolvedValue({ ...CACHE_RESPONSE, models: [CACHED_BUILT_IN, ORPHAN] });
+    render(<MediaModels />);
+    const encoderName = await screen.findByText('Ultra-Heretic');
+    const encoderCard = encoderName.closest('.bg-port-bg');
+    fireEvent.click(within(encoderCard).getByRole('button', { name: /Download \(/ }));
+    expect(textEncoderDownloads.start).toHaveBeenCalledWith(textEncoderDownloadId(H3_TEXT_ENCODER.id));
   });
 
   it('arms a separate confirm for removing a custom catalog entry', async () => {
@@ -123,5 +209,6 @@ describe('MediaModels catalog/cache join', () => {
       CUSTOM.id,
       { silent: true },
     ));
+    expect(screen.getByText(/Video text encoders \(2\)/)).toBeInTheDocument();
   });
 });

--- a/client/src/services/apiImageVideo.js
+++ b/client/src/services/apiImageVideo.js
@@ -375,8 +375,9 @@ export const deleteLora = (filename, options = {}) => request(`/image-video/mode
 
 // Media-model REGISTRY (the catalog of pickable image/video base models,
 // distinct from listCachedModels which reports on-disk HF cache usage). Returns
-// `{ video: [...], image: [...] }` with a `builtIn` flag per entry so the
-// manager renders built-ins read-only and user-added entries editable.
+// `{ video: [...], image: [...], textEncoders: [...] }`, each with a `builtIn`
+// flag. Text encoders also identify the compatible video-model ids so the
+// manager can install/delete their separate prompt-conditioner pulls.
 export const listMediaModelRegistry = () => request('/image-video/models/registry');
 
 // Search the HuggingFace Hub for candidate base-model repos. `pipeline` scopes

--- a/server/routes/imageVideoModels.js
+++ b/server/routes/imageVideoModels.js
@@ -11,11 +11,11 @@
 import { Router } from 'express';
 import { existsSync } from 'fs';
 import { readdir, stat, rm } from 'fs/promises';
-import { homedir } from 'os';
 import { join } from 'path';
 import { z } from 'zod';
 import { asyncHandler, ServerError } from '../lib/errorHandler.js';
 import { PATHS, formatBytes, dirSize } from '../lib/fileUtils.js';
+import { getHfCacheRoot } from '../lib/hfCache.js';
 import {
   getImageModels,
   getVideoModels,
@@ -24,19 +24,19 @@ import {
   patchUserModelEntry,
   removeUserModelEntry,
 } from '../lib/mediaModels.js';
+import { publicTextEncoderOption, videoTextEncoderOptions } from '../lib/videoTextEncoders.js';
 import { mapWithConcurrency } from '../lib/mapWithConcurrency.js';
 import { emptyToUndefined, validateRequest } from '../lib/validation.js';
 import { ADDABLE_IMAGE_RUNNERS, ADDABLE_VIDEO_RUNTIMES, searchHuggingfaceModels } from '../lib/huggingfaceModel.js';
 import { addModelFromHuggingface } from '../services/mediaModelInstall.js';
 
 const router = Router();
-const HF_DEFAULT_HUB = join(homedir(), '.cache', 'huggingface', 'hub');
 
-// HF stores its hub cache under <HF_HOME>/hub/models--<org>--<name>. Honor
-// HF_HOME if the user set one, otherwise fall back to HF's own default
-// (~/.cache/huggingface/hub).
-const HF_HUB_DIR = () =>
-  process.env.HF_HOME ? join(process.env.HF_HOME, 'hub') : HF_DEFAULT_HUB;
+// Keep the manager's directory listing/deletion root identical to the cache
+// status probes. In particular, HF_HUB_CACHE and XDG_CACHE_HOME are valid
+// Hugging Face overrides too — listing one root while status checks another
+// would make a downloaded encoder impossible to delete from this UI.
+const HF_HUB_DIR = getHfCacheRoot;
 
 // Friendly labels for known models, derived from the media-models registry.
 // HF stores cache dirs as `models--<org>--<name>` (slashes replaced with --).
@@ -121,10 +121,12 @@ router.get('/', asyncHandler(async (_req, res) => {
 
 // GET /registry — the media-model registry as the manager UI needs it:
 // every image + video entry flattened with a `builtIn` flag so the page can
-// render built-ins read-only and user-added entries editable/removable. This
-// is distinct from `GET /` (which reports on-disk HF *cache* usage) — this
-// reports the model *catalog* (what can be picked), including entries whose
-// weights aren't downloaded yet.
+// render built-ins read-only and user-added entries editable/removable. It also
+// includes the prompt-conditioner choices exposed by installed video runtimes
+// (currently MiniMax H3), so their separate multi-GB downloads can be managed
+// alongside the models that consume them. This is distinct from `GET /` (which
+// reports on-disk HF *cache* usage) — it reports what can be picked, including
+// entries whose weights aren't downloaded yet.
 router.get('/registry', asyncHandler(async (_req, res) => {
   const flatten = (list, kind) =>
     (Array.isArray(list) ? list : []).map((m) => ({
@@ -142,14 +144,33 @@ router.get('/registry', asyncHandler(async (_req, res) => {
       source: m.source || null,
       installedAt: m.installedAt || null,
     }));
+  // One encoder can be offered by more than one model. Keep one management row
+  // per encoder while retaining the model ids it is compatible with, rather
+  // than rendering duplicate rows (or arbitrarily hiding one relationship).
+  const videoModels = getVideoModels();
+  const textEncoderMap = new Map();
+  for (const model of videoModels) {
+    for (const option of videoTextEncoderOptions(model)) {
+      const existing = textEncoderMap.get(option.id);
+      if (existing) {
+        existing.modelIds.push(model.id);
+      } else {
+        textEncoderMap.set(option.id, {
+          ...publicTextEncoderOption(option),
+          modelIds: [model.id],
+        });
+      }
+    }
+  }
   // Use the CURRENT platform's video list (getVideoModels) rather than
   // flattening both macos+windows — that matches what's actually pickable here
   // and avoids showing duplicate rows when a shared media-models.json holds the
   // same custom id in both platform lists (macOS+Windows peer). Image entries
   // are single-list.
   res.json({
-    video: flatten(getVideoModels(), 'video'),
+    video: flatten(videoModels, 'video'),
     image: flatten(getImageModels(), 'image'),
+    textEncoders: [...textEncoderMap.values()],
   });
 }));
 

--- a/server/routes/imageVideoModels.test.js
+++ b/server/routes/imageVideoModels.test.js
@@ -8,6 +8,7 @@ import { errorMiddleware, ServerError } from '../lib/errorHandler.js';
 // live HuggingFace fetch or on-disk registry write.
 const VIDEO_LIST = [
   { id: 'ltx23_distilled_q4', name: 'LTX-2.3 Q4', repo: 'notapalindrome/ltx23-mlx-av-q4', runtime: 'mlx_video', steps: 25, guidance: 3 },
+  { id: 'minimax_h3_8bit', name: 'MiniMax H3', repo: 'pipenetwork/MiniMax-H3-MLX-8bit', runtime: 'minimax_h3', steps: 9, guidance: 0 },
   { id: 'hf-mine', name: 'Mine', repo: 'me/mine', runtime: 'ltx2', steps: 8, guidance: 3, source: 'user' },
 ];
 const IMAGE_LIST = [
@@ -35,6 +36,25 @@ vi.mock('../services/mediaModelInstall.js', () => ({
   })),
 }));
 
+const H3_TEXT_ENCODERS = [
+  { id: 'stock', label: 'Stock — MiniMax H3 Qwen3-VL-32B', builtIn: true },
+  {
+    id: 'heretic-bf16', label: 'Ultra-Heretic', repo: 'example/ultra-heretic',
+    description: 'Alternative prompt conditioner', sizeBytes: 51_000_000_000,
+  },
+];
+vi.mock('../lib/videoTextEncoders.js', () => ({
+  videoTextEncoderOptions: (model) => model?.runtime === 'minimax_h3' ? H3_TEXT_ENCODERS : [],
+  publicTextEncoderOption: (entry) => ({
+    id: entry.id,
+    label: entry.label,
+    description: entry.description,
+    builtIn: !!entry.builtIn,
+    ...(entry.repo ? { repo: entry.repo } : {}),
+    ...(entry.sizeBytes ? { sizeBytes: entry.sizeBytes } : {}),
+  }),
+}));
+
 // Avoid touching the real HF cache dir in GET / (not under test here).
 vi.mock('../lib/fileUtils.js', async (orig) => {
   const actual = await orig();
@@ -59,12 +79,24 @@ describe('GET /registry', () => {
   it('flattens video + image entries with a builtIn flag', async () => {
     const res = await request(makeApp()).get('/api/image-video/models/registry');
     expect(res.status).toBe(200);
-    expect(res.body.video).toHaveLength(2);
+    expect(res.body.video).toHaveLength(3);
     expect(res.body.image).toHaveLength(1);
     const builtIn = res.body.video.find((m) => m.id === 'ltx23_distilled_q4');
     const user = res.body.video.find((m) => m.id === 'hf-mine');
     expect(builtIn.builtIn).toBe(true);
     expect(user.builtIn).toBe(false);
+  });
+
+  it('includes the current platform\'s MiniMax H3 text-encoder choices once each', async () => {
+    const res = await request(makeApp()).get('/api/image-video/models/registry');
+    expect(res.status).toBe(200);
+    expect(res.body.textEncoders).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'stock', builtIn: true, modelIds: ['minimax_h3_8bit'] }),
+      expect.objectContaining({
+        id: 'heretic-bf16', repo: 'example/ultra-heretic', sizeBytes: 51_000_000_000,
+        modelIds: ['minimax_h3_8bit'],
+      }),
+    ]));
   });
 });
 


### PR DESCRIPTION
## Summary
- Expose video text-encoder choices, including MiniMax H3 substitutes, through the Media Models catalog API.
- Add explicit download progress and confirmed cache deletion for each separately downloaded encoder.
- Keep encoder cache paths aligned with Hugging Face cache overrides and out of the orphaned cache list.

## Test plan
- npm --prefix client test -- --run src/pages/MediaModels.test.jsx
- npm --prefix server test -- --run routes/imageVideoModels.test.js
- npm --prefix client run build