### PR TITLE
name the unlabeled inline form controls on the a11y sweep's high-value pages

### DIFF
--- a/.changelog/next/fixed-issue-4156.md
+++ b/.changelog/next/fixed-issue-4156.md
@@ -1,0 +1,1 @@
+- Screen readers now announce the inline form controls on the Character Sheet, GitHub, Sharing, Browser, Mood Board and Video Timeline Editor pages, which previously had no accessible name

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -607,8 +607,10 @@ function localLabelWrapperNames(src) {
     const body = src.slice(bodyStart, bodyEnd);
     // {children} must sit inside a <label> — no </label> may intervene, or a
     // component rendering `<label>Header</label>{children}<label>Footer</label>`
-    // would register as a wrapper and exempt controls it never labels.
-    if (/<label\b[^>]*>(?:(?!<\/label>)[\s\S])*?\{\s*children\s*\}/.test(body)) names.add(match[1]);
+    // would register as a wrapper and exempt controls it never labels. The
+    // opening tag must also not be self-closing (`<label … />` wraps nothing,
+    // so anything after it is outside the label).
+    if (/<label\b(?:[^>]*[^/>])?>(?:(?!<\/label>)[\s\S])*?\{\s*children\s*\}/.test(body)) names.add(match[1]);
   }
   labelWrapperNamesBySource.set(src, names);
   return names;

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -594,19 +594,21 @@ function localLabelWrapperNames(src) {
   const re = /function\s+([A-Z][\w]*)\s*\(/g;
   let match;
   while ((match = re.exec(src))) {
-    let depth = 1;
-    let cursor = match.index + match[0].length;
-    for (; cursor < src.length && depth > 0; cursor++) {
-      if (src[cursor] === '(') depth++;
-      else if (src[cursor] === ')') depth--;
-    }
-    const bodyStart = src.indexOf('{', cursor);
+    // Skip the parameter list with the string-aware scanner — a default value
+    // like `{ label = ')' }` would close the parens early on a naive count and
+    // point `bodyStart` at the destructuring instead of the body.
+    const parenIndex = match.index + match[0].length - 1;
+    const params = balancedCallAt(src, parenIndex);
+    if (!params) continue;
+    const bodyStart = src.indexOf('{', parenIndex + params.length);
     if (bodyStart === -1) continue;
     const bodyEnd = matchingBraceEnd(src, bodyStart);
     if (bodyEnd === -1) continue;
     const body = src.slice(bodyStart, bodyEnd);
-    // The wrapper must render {children} between a <label> and its </label>.
-    if (/<label\b[\s\S]*?\{\s*children\s*\}[\s\S]*?<\/label>/.test(body)) names.add(match[1]);
+    // {children} must sit inside a <label> — no </label> may intervene, or a
+    // component rendering `<label>Header</label>{children}<label>Footer</label>`
+    // would register as a wrapper and exempt controls it never labels.
+    if (/<label\b[^>]*>(?:(?!<\/label>)[\s\S])*?\{\s*children\s*\}/.test(body)) names.add(match[1]);
   }
   labelWrapperNamesBySource.set(src, names);
   return names;
@@ -615,23 +617,23 @@ function localLabelWrapperNames(src) {
 function isNestedInLabelWrappingComponent(src, index) {
   for (const name of localLabelWrapperNames(src)) {
     const re = new RegExp(`</?${name}\\b`, 'g');
-    let depth = 0;
-    let outerLabel = null;
+    // Keep the label of every wrapper instance still open at `index`, not just
+    // the outermost: an inner `<Field label="…">` nested in an unlabeled outer
+    // one still names the control.
+    const open = [];
     let match;
     while ((match = re.exec(src)) && match.index < index) {
       if (match[0].startsWith('</')) {
-        depth = Math.max(0, depth - 1);
+        open.pop();
         continue;
       }
       const tag = openingTagAt(src, match.index, name.length + 1);
       if (!tag) continue;
       re.lastIndex = match.index + tag.length;
       if (/\/\s*>$/.test(tag)) continue;
-      if (depth === 0) outerLabel = normalizedAttributeValue(attributeValue(tag, 'label'));
-      depth++;
+      open.push(normalizedAttributeValue(attributeValue(tag, 'label')));
     }
-    if (depth === 0 || outerLabel === null || outerLabel === '') continue;
-    if (!/^(?:undefined|null|false)$/i.test(outerLabel)) return true;
+    if (open.some((label) => label && !/^(?:undefined|null|false)$/i.test(label))) return true;
   }
   return false;
 }

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -582,8 +582,14 @@ function isNestedInLabeledFormField(src, index) {
 // call site. Recognise those wrappers from their own source so a correctly
 // labeled control isn't forced to carry a redundant aria-label that would
 // shadow the visible text. Only same-file definitions count; a wrapper imported
-// from elsewhere stays unknown (FormField has its own dedicated check).
+// from elsewhere stays unknown (FormField has its own dedicated check), and
+// only `function` declarations are matched — a missed wrapper is a false
+// negative that simply leaves its controls on the allowlist.
+const labelWrapperNamesBySource = new Map();
+
 function localLabelWrapperNames(src) {
+  const cached = labelWrapperNamesBySource.get(src);
+  if (cached) return cached;
   const names = new Set();
   const re = /function\s+([A-Z][\w]*)\s*\(/g;
   let match;
@@ -602,6 +608,7 @@ function localLabelWrapperNames(src) {
     // The wrapper must render {children} between a <label> and its </label>.
     if (/<label\b[\s\S]*?\{\s*children\s*\}[\s\S]*?<\/label>/.test(body)) names.add(match[1]);
   }
+  labelWrapperNamesBySource.set(src, names);
   return names;
 }
 

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -576,6 +576,59 @@ function isNestedInLabeledFormField(src, index) {
   return false;
 }
 
+// Page-local field wrappers (PipelineSeries.jsx's `<Field label="…">`) render
+// their children inside a real <label>, so the control they wrap is implicitly
+// named — the <label> just lives in the component definition instead of at the
+// call site. Recognise those wrappers from their own source so a correctly
+// labeled control isn't forced to carry a redundant aria-label that would
+// shadow the visible text. Only same-file definitions count; a wrapper imported
+// from elsewhere stays unknown (FormField has its own dedicated check).
+function localLabelWrapperNames(src) {
+  const names = new Set();
+  const re = /function\s+([A-Z][\w]*)\s*\(/g;
+  let match;
+  while ((match = re.exec(src))) {
+    let depth = 1;
+    let cursor = match.index + match[0].length;
+    for (; cursor < src.length && depth > 0; cursor++) {
+      if (src[cursor] === '(') depth++;
+      else if (src[cursor] === ')') depth--;
+    }
+    const bodyStart = src.indexOf('{', cursor);
+    if (bodyStart === -1) continue;
+    const bodyEnd = matchingBraceEnd(src, bodyStart);
+    if (bodyEnd === -1) continue;
+    const body = src.slice(bodyStart, bodyEnd);
+    // The wrapper must render {children} between a <label> and its </label>.
+    if (/<label\b[\s\S]*?\{\s*children\s*\}[\s\S]*?<\/label>/.test(body)) names.add(match[1]);
+  }
+  return names;
+}
+
+function isNestedInLabelWrappingComponent(src, index) {
+  for (const name of localLabelWrapperNames(src)) {
+    const re = new RegExp(`</?${name}\\b`, 'g');
+    let depth = 0;
+    let outerLabel = null;
+    let match;
+    while ((match = re.exec(src)) && match.index < index) {
+      if (match[0].startsWith('</')) {
+        depth = Math.max(0, depth - 1);
+        continue;
+      }
+      const tag = openingTagAt(src, match.index, name.length + 1);
+      if (!tag) continue;
+      re.lastIndex = match.index + tag.length;
+      if (/\/\s*>$/.test(tag)) continue;
+      if (depth === 0) outerLabel = normalizedAttributeValue(attributeValue(tag, 'label'));
+      depth++;
+    }
+    if (depth === 0 || outerLabel === null || outerLabel === '') continue;
+    if (!/^(?:undefined|null|false)$/i.test(outerLabel)) return true;
+  }
+  return false;
+}
+
 function hasUsableAriaLabelledByReference(src, tag) {
   const raw = attributeValue(tag, 'aria-labelledby');
   const value = normalizedAttributeValue(raw);
@@ -599,6 +652,7 @@ function hasAccessibleInputName(src, tag, index) {
   if (hasUsableAccessibleNameAttribute(tag, 'aria-labelledby') && hasUsableAriaLabelledByReference(src, tag)) return true;
   if (hasUsableNativeInputName(tag)) return true;
   if (isNestedInLabel(src, index) || isNestedInLabeledFormField(src, index)) return true;
+  if (isNestedInLabelWrappingComponent(src, index)) return true;
 
   const id = normalizedAttributeValue(attributeValue(tag, 'id'));
   return id !== null && id !== '' && hasMatchingExplicitLabel(src, id);
@@ -836,25 +890,7 @@ const PREEXISTING_INPUT_NAME_ALLOWLIST = new Set([
   "src/pages/AIProviders.jsx|type=newEnvSecret ? 'password' : 'text'|placeholder=value|value=newEnvValue",
   "src/pages/Authors.jsx|placeholder=Jane Doe|value=form.name",
   "src/pages/Authors.jsx|placeholder=/images/… or https://…|value=form.headshotImageUrl",
-  "src/pages/Browser.jsx|type=text|placeholder=https://example.com|value=navUrl",
-  "src/pages/CharacterSheet.jsx|value=classVal",
-  "src/pages/CharacterSheet.jsx|placeholder=1d8|value=dmgDice",
-  "src/pages/CharacterSheet.jsx|placeholder=Description (optional)|value=dmgDesc",
-  "src/pages/CharacterSheet.jsx|type=number|placeholder=XP amount|value=xpAmount",
-  "src/pages/CharacterSheet.jsx|placeholder=Description (optional)|value=xpDesc",
-  "src/pages/CharacterSheet.jsx|placeholder=What happened?|value=evtDesc",
-  "src/pages/CharacterSheet.jsx|type=number|placeholder=XP (optional)|value=evtXp",
-  "src/pages/CharacterSheet.jsx|placeholder=Dice (e.g. 2d6)|value=evtDice",
-  "src/pages/GitHub.jsx|type=text|placeholder=Search repos...|value=search",
-  "src/pages/GitHub.jsx|type=text|placeholder=SECRET_NAME|value=newSecretName",
-  "src/pages/GitHub.jsx|type=password|placeholder=Secret value|value=newSecretValue",
   "src/pages/MediaCollectionDetail.jsx|type=text|value=nameDraft",
-  "src/pages/MoodBoardDetail.jsx|type=text|placeholder=Add a caption…",
-  "src/pages/PipelineSeries.jsx|value=series.name || ''",
-  "src/pages/PipelineSeries.jsx|placeholder=One-sentence pitch|value=series.logline || ''",
-  "src/pages/PipelineSeries.jsx|type=number|value=series.issueCountTarget || 0|min=0|max=999",
-  "src/pages/Sharing.jsx|type=text|placeholder=Display name (e.g. atomantic)|value=sharingDisplayName",
-  "src/pages/Sharing.jsx|type=text|placeholder=Optional bio / contact note (visible to recipients)|value=sharingBio",
   "src/components/meatspace/post/PostDrillConfig.jsx|type=number|value=drillConfig[field.key] ?? ''|min=field.min|max=field.max",
   "src/pages/AIProviders.jsx|type=text|placeholder=claude-sonnet-4-20250514|value=formData.defaultModel",
   "src/pages/AIProviders.jsx|type=text|placeholder=haiku|value=formData.lightModel",
@@ -875,8 +911,6 @@ const PREEXISTING_INPUT_NAME_ALLOWLIST = new Set([
   "src/pages/StackerNews.jsx|id=`${prefix}-api-key`|type=password|value=form.apiKey",
   "src/pages/StackerNews.jsx|id=`${prefix}-slug`|value=form.slug",
   "src/pages/VideoTimeline.jsx|type=text|placeholder=New project name…|value=name",
-  "src/pages/VideoTimelineEditor.jsx|type=text|value=nameDraft",
-  "src/pages/VideoTimelineEditor.jsx|type=range|value=Math.min(t, total)|min=0|max=Math.max(0.01, total)|step=0.01",
   "src/pages/DataDog.jsx|name=site|type=text|placeholder=e.g., api.custom-datadog.com|value=formData.site",
 ]);
 

--- a/client/src/pages/Browser.jsx
+++ b/client/src/pages/Browser.jsx
@@ -445,6 +445,7 @@ export default function BrowserPage() {
               >
                 <input
                   type="text"
+                  aria-label="URL to open"
                   value={navUrl}
                   onChange={e => setNavUrl(e.target.value)}
                   placeholder="https://example.com"

--- a/client/src/pages/CharacterSheet.jsx
+++ b/client/src/pages/CharacterSheet.jsx
@@ -521,6 +521,7 @@ export default function CharacterSheet() {
                 {editingClass ? (
                   <input
                     autoFocus
+                    aria-label="Character title"
                     value={classVal}
                     onChange={e => setClassVal(e.target.value)}
                     onBlur={handleClassSave}
@@ -736,6 +737,7 @@ export default function CharacterSheet() {
                 <div className="flex items-center gap-2">
                   <Dices className="w-4 h-4 text-gray-400" />
                   <input
+                    aria-label="Damage dice"
                     value={dmgDice}
                     onChange={e => setDmgDice(e.target.value)}
                     placeholder="1d8"
@@ -743,6 +745,7 @@ export default function CharacterSheet() {
                   />
                 </div>
                 <input
+                  aria-label="Damage description"
                   value={dmgDesc}
                   onChange={e => setDmgDesc(e.target.value)}
                   placeholder="Description (optional)"
@@ -769,12 +772,14 @@ export default function CharacterSheet() {
               <div className="flex flex-col sm:flex-row gap-2">
                 <input
                   type="number"
+                  aria-label="XP amount"
                   value={xpAmount}
                   onChange={e => setXpAmount(e.target.value)}
                   placeholder="XP amount"
                   className="bg-port-card border border-port-border rounded px-2 py-1.5 text-sm text-white w-28"
                 />
                 <input
+                  aria-label="XP description"
                   value={xpDesc}
                   onChange={e => setXpDesc(e.target.value)}
                   placeholder="Description (optional)"
@@ -800,6 +805,7 @@ export default function CharacterSheet() {
               </div>
               <div className="flex flex-col gap-2">
                 <input
+                  aria-label="Event description"
                   value={evtDesc}
                   onChange={e => setEvtDesc(e.target.value)}
                   placeholder="What happened?"
@@ -808,6 +814,7 @@ export default function CharacterSheet() {
                 <div className="flex flex-col sm:flex-row gap-2">
                   <input
                     type="number"
+                    aria-label="Event XP"
                     value={evtXp}
                     onChange={e => setEvtXp(e.target.value)}
                     placeholder="XP (optional)"
@@ -816,6 +823,7 @@ export default function CharacterSheet() {
                   <div className="flex items-center gap-2">
                     <Dices className="w-4 h-4 text-gray-400" />
                     <input
+                      aria-label="Event dice"
                       value={evtDice}
                       onChange={e => setEvtDice(e.target.value)}
                       placeholder="Dice (e.g. 2d6)"

--- a/client/src/pages/GitHub.jsx
+++ b/client/src/pages/GitHub.jsx
@@ -13,6 +13,7 @@ import {
 import { timeAgo } from '../utils/formatters';
 import PageSkeleton from '../components/ui/PageSkeleton';
 import Modal from '../components/ui/Modal';
+import { FormField } from '../components/ui/FormField';
 
 const FILTERS = ['all', 'npm', 'secrets', 'archived'];
 
@@ -228,6 +229,7 @@ export default function GitHub() {
           <div className="flex flex-col sm:flex-row gap-2 mb-4">
             <input
               type="text"
+              aria-label="Search repositories"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search repos..."
@@ -385,20 +387,24 @@ export default function GitHub() {
             )}
 
             <div className="flex flex-col gap-2">
-              <input
-                type="text"
-                value={newSecretName}
-                onChange={(e) => setNewSecretName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''))}
-                placeholder="SECRET_NAME"
-                className="px-3 py-2 bg-port-bg border border-port-border rounded text-white font-mono text-sm"
-              />
-              <input
-                type="password"
-                value={newSecretValue}
-                onChange={(e) => setNewSecretValue(e.target.value)}
-                placeholder="Secret value"
-                className="px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
-              />
+              <FormField label="Secret name">
+                <input
+                  type="text"
+                  value={newSecretName}
+                  onChange={(e) => setNewSecretName(e.target.value.toUpperCase().replace(/[^A-Z0-9_]/g, ''))}
+                  placeholder="SECRET_NAME"
+                  className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white font-mono text-sm"
+                />
+              </FormField>
+              <FormField label="Secret value">
+                <input
+                  type="password"
+                  value={newSecretValue}
+                  onChange={(e) => setNewSecretValue(e.target.value)}
+                  placeholder="Secret value"
+                  className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
+                />
+              </FormField>
               <button
                 onClick={handleSaveSecret}
                 disabled={savingSecret || !newSecretName.trim() || !newSecretValue}

--- a/client/src/pages/MoodBoardDetail.jsx
+++ b/client/src/pages/MoodBoardDetail.jsx
@@ -605,6 +605,7 @@ export default function MoodBoardDetail() {
                 <div className="p-2 flex flex-col gap-1">
                   <input
                     type="text"
+                    aria-label="Item caption"
                     defaultValue={item.caption || ''}
                     placeholder="Add a caption…"
                     maxLength={2000}

--- a/client/src/pages/Sharing.jsx
+++ b/client/src/pages/Sharing.jsx
@@ -316,6 +316,7 @@ function SharingBuckets({ selectedId }) {
         <div className="grid grid-cols-1 md:grid-cols-[1fr_2fr_auto] gap-3 items-start">
           <input
             type="text"
+            aria-label="Your display name"
             value={sharingDisplayName}
             onChange={(e) => setSharingDisplayName(e.target.value)}
             placeholder="Display name (e.g. atomantic)"
@@ -324,6 +325,7 @@ function SharingBuckets({ selectedId }) {
           />
           <input
             type="text"
+            aria-label="Your bio / contact note"
             value={sharingBio}
             onChange={(e) => setSharingBio(e.target.value)}
             placeholder="Optional bio / contact note (visible to recipients)"

--- a/client/src/pages/VideoTimelineEditor.jsx
+++ b/client/src/pages/VideoTimelineEditor.jsx
@@ -529,6 +529,7 @@ export default function VideoTimelineEditor() {
           </button>
           <input
             type="text"
+            aria-label="Project name"
             value={nameDraft}
             onChange={(e) => setNameDraft(e.target.value)}
             onBlur={async (e) => {
@@ -626,6 +627,7 @@ export default function VideoTimelineEditor() {
             </button>
             <input
               type="range"
+              aria-label="Playhead position"
               min={0}
               max={Math.max(0.01, total)}
               step={0.01}


### PR DESCRIPTION
## Summary

Continues the unlabeled-form-control sweep from the 2026-07-23 accessibility audit. `Instances.jsx` landed in #4274; this PR covers the rest of the "highest value first" page list in the issue.

Each candidate was verified in context rather than mass-applied — the raw scan's true-positive rate is roughly half, and most hits on these pages turned out to be already-labeled controls (wrapped in `FormField`, a page-local `<label>` wrapper, or paired via `htmlFor`/`id`), `<select>`/`<input>` mentions inside comments, or `id={expr}`/`htmlFor={expr}` pairs the naive scan can't resolve.

**Controls given a name (14):**

| Page | Controls | Approach |
| --- | --- | --- |
| `CharacterSheet.jsx` | title edit, damage dice + description, XP amount + description, event description/XP/dice | `aria-label` — compact inline action rows, no room for a visible label |
| `GitHub.jsx` | repo search | `aria-label` — toolbar |
| `GitHub.jsx` | add-secret name + value | `FormField` — stacked column with room for a visible label |
| `Sharing.jsx` | display name, bio | `aria-label` — inline strip sharing a row with its Save button |
| `Browser.jsx` | Open-URL field | `aria-label` — single-line inline form |
| `MoodBoardDetail.jsx` | item caption | `aria-label` — per-card inline field |
| `VideoTimelineEditor.jsx` | project name, playhead scrubber | `aria-label` — header/transport chrome |

**Guard change.** The repo-wide `gives every input an accessible name` test in `client/src/a11yConventions.test.js` could not see through a *page-local* field wrapper that renders its children inside a real `<label>` (`PipelineSeries.jsx`'s `<Field label="…">`). Three already-accessible controls were sitting in `PREEXISTING_INPUT_NAME_ALLOWLIST` purely because of that static-analysis gap — adding a redundant `aria-label` to each would have shadowed the visible text. `isNestedInLabelWrappingComponent()` now detects same-file components whose body renders `{children}` between `<label>` and `</label>`, mirroring the existing `isNestedInLabeledFormField()` check.

Net: **20 entries removed** from `PREEXISTING_INPUT_NAME_ALLOWLIST` (the migration tracked in #4297), so every control above is now enforced by the guard instead of exempted.

Pages from the issue list needing no change, verified per-tag: `PipelineSeries.jsx` (all controls inside the local `Field` label wrapper), `CatalogIngredient.jsx` (the one hit is a `<input type=color>` mention inside a code comment), `OpenClaw.jsx` and `LoraDatasetDetail.jsx` (already labeled).

## Test plan

- `cd client && npx vitest run src/a11yConventions.test.js` — 10 passed.
- `cd client && npx vitest run src/pages/{GitHub,Sharing,Browser,CharacterSheet,MoodBoardDetail,VideoTimelineEditor,PipelineSeries}` — 7 files, 44 tests passed.
- `cd client && npx biome lint --error-on-warnings` on every changed file — clean.
- **Bypass probe** for the new guard branch: short-circuiting `isNestedInLabelWrappingComponent()` to `false` fails the suite with exactly the three `PipelineSeries.jsx` offenders and nothing else — confirming the helper is load-bearing and does not over-exempt any other file.

Refs #4156

## Remaining

The issue's "highest value first" page list is now complete, but the long tail behind it is not. Re-running the issue's scan across every tracked `client/src/**/*.jsx` still reports ~370 candidates (again roughly half true positives), concentrated in components rather than pages:

- `components/cos/tabs/JobsTab.jsx` (~22), `components/brain/tabs/MemoryTab.jsx` (~21), `components/agents/tabs/WorldTab.jsx` (~19), `components/meatspace/tabs/AlcoholTab.jsx` (~12), `components/meatspace/tabs/NicotineTab.jsx` and `components/apps/tabs/CustomTasksSection.jsx` (~8 each), then a long tail of 1–7 per file.
- The guard covers `<input>` only. Extending `gives every input an accessible name` to `<select>` and `<textarea>` is worth doing, but it surfaces a fresh allowlist and belongs in its own PR.

Both are the same work as the `PREEXISTING_INPUT_NAME_ALLOWLIST` migration already tracked in #4297; #4156 stays open for them.
