### PR TITLE
fix: name 80 more unlabeled form controls in the Goals, Brain, MeatSpace and Agent tabs (#4156)

### DIFF
--- a/.changelog/next/fixed-issue-4156.md
+++ b/.changelog/next/fixed-issue-4156.md
@@ -1,1 +1,2 @@
 - Screen readers now announce the inline form controls on the Character Sheet, GitHub, Sharing, Browser, Mood Board and Video Timeline Editor pages, which previously had no accessible name
+- Screen readers now announce 80 more form controls that previously had no accessible name, across the Goals views, the Brain tabs (Daily Log, Feeds, Inbox, Links, Memory, Notes), the MeatSpace tabs (Age, Alcohol, Genome, Lifestyle, Nicotine) and the Agent World/Tools tabs — visible labels where the surface had room, `aria-label` in compact toolbars and table rows

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -568,7 +568,7 @@ function isNestedInLabeledFormField(src, index) {
     const formTag = openingTagAt(src, formMatch.index, '<FormField'.length);
     if (!formTag || /\/\s*>$/.test(formTag)) continue;
     const label = normalizedAttributeValue(attributeValue(formTag, 'label'));
-    if (label === null || label === '' || /^(?:undefined|null|false)$/i.test(label)) continue;
+    if (!isUsableLabelAttributeValue(label)) continue;
 
     let depth = 0;
     let firstChild = null;

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -436,6 +436,58 @@ function hasMatchingExplicitLabel(src, id) {
     if (htmlFor !== id || !hasUsableElementText(src, match.index, tag)) continue;
     return true;
   }
+  return hasMatchingForwardedLabel(src, id);
+}
+
+// A page-local field wrapper can own the <label> AND take the control's id as a
+// prop instead of wrapping it (LifestyleTab.jsx's `<FieldGroup label="Sleep …"
+// htmlFor="lifestyle-sleep-hours">`). Wrapping is wrong there — an implicit
+// <label> would swallow the live value readout and the hint paragraph sitting
+// beside the control into the accessible name — so the control is explicitly
+// labeled, just not by a `<label htmlFor>` written at the call site. Recognise
+// those forwarders the same way and under the same limits as
+// localLabelWrapperNames: same-file `function` declarations only, so a missed
+// one is a false negative that leaves its controls on the allowlist.
+const htmlForForwarderNamesBySource = new Map();
+
+function localHtmlForForwarderNames(src) {
+  const cached = htmlForForwarderNamesBySource.get(src);
+  if (cached) return cached;
+  const names = new Set();
+  const re = /function\s+([A-Z][\w]*)\s*\(/g;
+  let match;
+  while ((match = re.exec(src))) {
+    const parenIndex = match.index + match[0].length - 1;
+    const params = balancedCallAt(src, parenIndex);
+    if (!params) continue;
+    const bodyStart = src.indexOf('{', parenIndex + params.length);
+    if (bodyStart === -1) continue;
+    const bodyEnd = matchingBraceEnd(src, bodyStart);
+    if (bodyEnd === -1) continue;
+    const body = src.slice(bodyStart, bodyEnd);
+    // The <label> has to do both jobs before the call site's attributes can be
+    // trusted: point at the forwarded `htmlFor`, and render the `label` prop as
+    // its own text. A component that forwards the id onto a <label> it never
+    // fills with text names nothing.
+    if (/<label\b[^>]*\bhtmlFor\s*=\s*\{\s*htmlFor\s*\}(?:[^>]*[^/>])?>(?:(?!<\/label>)[\s\S])*?\{\s*label\s*\}/.test(body)) names.add(match[1]);
+  }
+  htmlForForwarderNamesBySource.set(src, names);
+  return names;
+}
+
+function hasMatchingForwardedLabel(src, id) {
+  for (const name of localHtmlForForwarderNames(src)) {
+    const re = new RegExp(`<${name}\\b`, 'g');
+    let match;
+    while ((match = re.exec(src))) {
+      const tag = openingTagAt(src, match.index, name.length + 1);
+      if (!tag) continue;
+      re.lastIndex = match.index + tag.length;
+      if (normalizedAttributeValue(attributeValue(tag, 'htmlFor')) !== id) continue;
+      const label = normalizedAttributeValue(attributeValue(tag, 'label'));
+      if (label && !/^(?:undefined|null|false)$/i.test(label)) return true;
+    }
+  }
   return false;
 }
 
@@ -704,20 +756,6 @@ const PREEXISTING_INPUT_NAME_ALLOWLIST = new Set([
   "src/components/CronInput.jsx|type=text|placeholder=0 7 * * *|value=expr",
   "src/components/EntityCombobox.jsx|id=inputId|type=text|placeholder=placeholder || `Search ${noun}s or type a new name…`|value=value|role=combobox",
   "src/components/TagPicker.jsx|id=id|type=text|placeholder=value.length >= maxTags ? `Max ${maxTags} tags` : placeholder|value=input",
-  "src/components/agents/tabs/ToolsTab.jsx|type=text|placeholder=Post title...|value=postTitle",
-  "src/components/agents/tabs/WorldTab.jsx|type=number|placeholder=X|value=newActionParams.x || ''|occurrence=1",
-  "src/components/agents/tabs/WorldTab.jsx|type=number|placeholder=Y|value=newActionParams.y || ''|occurrence=1",
-  "src/components/agents/tabs/WorldTab.jsx|type=text|placeholder=Thinking (optional)|value=newActionParams.thinking || ''",
-  "src/components/agents/tabs/WorldTab.jsx|type=text|placeholder=Thought text|value=newActionParams.thought || ''",
-  "src/components/agents/tabs/WorldTab.jsx|type=number|placeholder=X|value=newActionParams.x || ''|occurrence=2",
-  "src/components/agents/tabs/WorldTab.jsx|type=number|placeholder=Y|value=newActionParams.y || ''|occurrence=2",
-  "src/components/agents/tabs/WorldTab.jsx|type=number|placeholder=Z|value=newActionParams.z || ''",
-  "src/components/agents/tabs/WorldTab.jsx|type=text|placeholder=Message|value=newActionParams.message || ''",
-  "src/components/agents/tabs/WorldTab.jsx|type=text|placeholder=To Agent ID (optional)|value=newActionParams.sayTo || ''",
-  "src/components/agents/tabs/WorldTab.jsx|type=text|placeholder=Thinking... (optional)|value=moveThinking",
-  "src/components/agents/tabs/WorldTab.jsx|type=text|placeholder=What is this agent thinking?|value=thought",
-  "src/components/agents/tabs/WorldTab.jsx|type=text|placeholder=Message to nearby agents...|value=sayMessage",
-  "src/components/agents/tabs/WorldTab.jsx|type=text|placeholder=To Agent ID (optional — leave blank for broadcast)|value=sayTo",
   "src/components/apps/ReferenceReposPanel.jsx|placeholder=Display name (e.g. phosphene)|value=form.name",
   "src/components/apps/ReferenceReposPanel.jsx|placeholder=Branch (default: main)|value=form.branch",
   "src/components/apps/ReferenceReposPanel.jsx|placeholder=Repo URL (https://github.com/owner/repo.git) or local path|value=form.repoUrl",
@@ -726,28 +764,6 @@ const PREEXISTING_INPUT_NAME_ALLOWLIST = new Set([
   "src/components/apps/tabs/CustomTasksSection.jsx|type=text|placeholder=0 7 * * *|value=form.cronExpression || ''|title=Cron expression: minute hour dayOfMonth month dayOfWeek",
   "src/components/apps/tabs/CustomTasksSection.jsx|type=time|value=form.scheduledTime || ''|title=Run at a specific time (leave empty for any time)",
   "src/components/apps/tabs/GitTab.jsx|type=text|placeholder=Commit message...|value=commitMessage",
-  "src/components/brain/tabs/DailyLogTab.jsx|type=text|placeholder=Quick append — adds a new paragraph…|value=quickAppend",
-  "src/components/brain/tabs/FeedsTab.jsx|type=text|placeholder=Paste an RSS or Atom feed URL...|value=inputUrl|ref=inputRef",
-  "src/components/brain/tabs/InboxTab.jsx|type=text|placeholder=One thought at a time...|value=inputText|ref=inputRef",
-  "src/components/brain/tabs/LinksTab.jsx|type=text|placeholder=Paste a URL (GitHub repos auto-clone)...|value=inputUrl|ref=inputRef",
-  "src/components/brain/tabs/LinksTab.jsx|type=text|placeholder=Search links by title, URL, description, or tag...|value=search",
-  "src/components/brain/tabs/LinksTab.jsx|type=text|placeholder=Tags (comma-separated)|value=editForm.tags",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=Name|value=form.name || ''",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=Follow-ups (comma separated)|value=(form.followUps || []).join(', ')",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=Project name|value=form.name || ''",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=Next action (concrete, actionable step)|value=form.nextAction || ''",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=Title|value=form.title || ''|occurrence=1",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=One-liner (core insight)|value=form.oneLiner || ''",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=Title|value=form.title || ''|occurrence=2",
-  "src/components/brain/tabs/MemoryTab.jsx|type=date|placeholder=Due date|value=form.dueDate ? form.dueDate.split('T')[0] : ''",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=Next action|value=form.nextAction || ''",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=Title (e.g. 'DnD session tonight')|value=form.title || ''",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=Mood (e.g. happy, reflective, tired)|value=form.mood || ''",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=Tags (comma separated)|value=form.tagInput ?? (form.tags || []).join(', ')",
-  "src/components/brain/tabs/MemoryTab.jsx|type=text|placeholder=`Search ${DESTINATIONS[activeType]?.label?.toLowerCase() || 'records'}...`|value=searchQuery",
-  "src/components/brain/tabs/NotesTab.jsx|placeholder=Search notes...|value=searchQuery|ref=searchRef",
-  "src/components/brain/tabs/NotesTab.jsx|placeholder=folder/note-name|value=newNotePath",
-  "src/components/brain/tabs/NotesTab.jsx|placeholder=/path/to/obsidian/vault|value=customPath",
   "src/components/calendar/AgendaTab.jsx|type=text|placeholder=Search events...|value=search",
   "src/components/calendar/ConfigTab.jsx|type=text|placeholder=Client ID (e.g. 123456789-abc.apps.googleusercontent.com)|value=oauthForm.clientId",
   "src/components/calendar/ConfigTab.jsx|type=password|placeholder=Client Secret (e.g. GOCSPX-...)|value=oauthForm.clientSecret",
@@ -780,25 +796,6 @@ const PREEXISTING_INPUT_NAME_ALLOWLIST = new Set([
   "src/components/digital-twin/tabs/GoalsTab.jsx|type=date|value=newMilestone.targetDate",
   "src/components/digital-twin/tabs/TimeCapsuleTab.jsx|type=text|placeholder=Snapshot label (e.g., Spring 2026, Pre-career-change)|value=label",
   "src/components/digital-twin/tabs/TimeCapsuleTab.jsx|type=checkbox",
-  "src/components/goals/GoalEditForm.jsx|type=number|value=form.timeBlockConfig?.sessionDurationMinutes || 60|min=15|max=480",
-  "src/components/goals/GoalEditForm.jsx|type=text|placeholder=Add tag...|value=tagInput",
-  "src/components/goals/GoalEditForm.jsx|type=text|value=form.title",
-  "src/components/goals/GoalLinkedCalendars.jsx|type=text|placeholder=Match pattern (optional)|value=calendarMatchPattern",
-  "src/components/goals/GoalMilestones.jsx|type=text|placeholder=Add milestone...|value=newMilestone.title",
-  "src/components/goals/GoalPlanSection.jsx|type=text|value=ms.title",
-  "src/components/goals/GoalPlanSection.jsx|type=text|placeholder=Description...|value=ms.description || ''",
-  "src/components/goals/GoalPlanSection.jsx|type=text|value=phase.title",
-  "src/components/goals/GoalPlanSection.jsx|type=text|placeholder=Description...|value=phase.description || ''",
-  "src/components/goals/GoalPlanSection.jsx|type=date|value=phase.targetDate",
-  "src/components/goals/GoalProgressLog.jsx|type=date|value=progressForm.date",
-  "src/components/goals/GoalProgressLog.jsx|type=number|placeholder=Minutes (optional)|value=progressForm.durationMinutes|min=1|max=1440",
-  "src/components/goals/GoalTodoList.jsx|type=text|placeholder=Add todo...|value=newTodoTitle",
-  "src/components/goals/GoalTodoList.jsx|type=number|placeholder=Est. min|value=newTodoEstimate|min=1",
-  "src/components/goals/GoalsListView.jsx|type=text|placeholder=Search goals...|value=searchQuery",
-  "src/components/goals/GoalsListView.jsx|type=text|placeholder=Add goal...|value=quickAdd",
-  "src/components/goals/GoalsListView.jsx|type=text|placeholder=Goal title...|value=newGoal.title",
-  "src/components/goals/GoalsTreeView.jsx|type=text|placeholder=Search...|value=searchQuery",
-  "src/components/goals/GoalsTreeView.jsx|type=text|placeholder=Goal title...|value=newGoal.title",
   "src/components/imageGen/HfTokenBanner.jsx|type=password|placeholder=hf_…|value=token",
   "src/components/imageGen/LoraPicker.jsx|type=number|value=sel.scale|min=0|max=2|step=0.1",
   "src/components/insights/GoalScorecardTab.jsx|type=text|placeholder=extra keywords, comma-separated|value=drafts[rule.id] ?? ''",
@@ -820,31 +817,6 @@ const PREEXISTING_INPUT_NAME_ALLOWLIST = new Set([
   "src/components/meatspace/post/PostLlmDrillRunner.jsx|type=text|placeholder=Type a creative use and press Enter...|value=inputValue|ref=inputRef",
   "src/components/meatspace/post/WordplayDrillUI.jsx|type=text|placeholder=Type the full compound or just the other half...|value=inputValue|ref=inputRef",
   "src/components/meatspace/post/WordplayDrillUI.jsx|type=text|placeholder=The bridge word is...|value=inputValue|ref=inputRef",
-  "src/components/meatspace/tabs/AgeTab.jsx|type=date|value=input",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=text|placeholder=Name|value=buttonForm.name",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=number|placeholder=buttonVolumeUnit === 'oz' ? 'Oz' : 'mL'|value=buttonForm.oz|min=0.1|step=0.1|occurrence=1",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=number|placeholder=ABV%|value=buttonForm.abv|min=0|max=100|step=0.1|occurrence=1",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=text|placeholder=New button name|value=buttonForm.name",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=number|placeholder=buttonVolumeUnit === 'oz' ? 'Oz' : 'mL'|value=buttonForm.oz|min=0.1|step=0.1|occurrence=2",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=number|placeholder=ABV%|value=buttonForm.abv|min=0|max=100|step=0.1|occurrence=2",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=number|placeholder=volumeUnit === 'oz' ? '12' : '355'|value=oz|min=0.1|step=0.1",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=date|value=editForm.date",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=text|value=editForm.name",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=number|value=editForm.oz|min=0.1|step=0.1",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=number|value=editForm.abv|min=0|max=100|step=0.1",
-  "src/components/meatspace/tabs/AlcoholTab.jsx|type=number|value=editForm.count|min=1|max=100",
-  "src/components/meatspace/tabs/GenomeTab.jsx|type=text|placeholder=rs1801133|value=searchRsid",
-  "src/components/meatspace/tabs/LifestyleTab.jsx|type=range|value=lifestyle?.exerciseMinutesPerWeek ?? 150|min=0|max=600|step=15",
-  "src/components/meatspace/tabs/LifestyleTab.jsx|type=range|value=lifestyle?.sleepHoursPerNight ?? 7.5|min=3|max=12|step=0.5",
-  "src/components/meatspace/tabs/LifestyleTab.jsx|type=number|placeholder=e.g. 22.5|value=lifestyle?.bmi ?? ''|min=10|max=80|step=0.1",
-  "src/components/meatspace/tabs/NicotineTab.jsx|type=text|placeholder=Name|value=buttonForm.name",
-  "src/components/meatspace/tabs/NicotineTab.jsx|type=number|placeholder=mg|value=buttonForm.mgPerUnit|step=0.1|occurrence=1",
-  "src/components/meatspace/tabs/NicotineTab.jsx|type=text|placeholder=New product name|value=buttonForm.name",
-  "src/components/meatspace/tabs/NicotineTab.jsx|type=number|placeholder=mg|value=buttonForm.mgPerUnit|step=0.1|occurrence=2",
-  "src/components/meatspace/tabs/NicotineTab.jsx|type=date|value=editForm.date",
-  "src/components/meatspace/tabs/NicotineTab.jsx|type=text|value=editForm.product",
-  "src/components/meatspace/tabs/NicotineTab.jsx|type=number|value=editForm.mgPerUnit|step=0.1",
-  "src/components/meatspace/tabs/NicotineTab.jsx|type=number|value=editForm.count|min=1",
   "src/components/media/CollectionPickerShell.jsx|type=text|placeholder=searchPlaceholder|value=query",
   "src/components/media/CollectionPickerShell.jsx|type=text|placeholder=newCollectionPlaceholder|value=newName",
   "src/components/messages/InboxTab.jsx|type=text|placeholder=Search messages...|value=search",
@@ -1136,6 +1108,33 @@ describe('a11y conventions', () => {
       }
     }
     expect(offenders, `Input without an accessible name — add aria-label/aria-labelledby or an explicit/implicit <label>, or exclude type="hidden":\n${offenders.join('\n')}`).toEqual([]);
+  });
+
+  it('only credits an htmlFor-forwarding wrapper that really names the control', () => {
+    // The rule above now accepts a page-local wrapper that renders the <label>
+    // and takes the control's id as a prop. That is only a real name when the
+    // wrapper does BOTH halves of the job, so probe the bypasses: a wrapper
+    // that forwards the id onto a <label> holding no text names nothing, and a
+    // call site that omits `label=` supplies no text either. Without these, the
+    // recognizer degenerates into "any component with an htmlFor prop exempts
+    // its input" — which would silently hide the exact gap the rule scans for.
+    const forwarder = `function Group({ label, htmlFor, children }) {
+  return (
+    <div>
+      <label htmlFor={htmlFor} className="block">{label}</label>
+      {children}
+    </div>
+  );
+}`;
+    const emptyForwarder = forwarder.replace('{label}', '');
+    const namedCall = `<Group label="Sleep" htmlFor="sleep-hours"><input id="sleep-hours" type="range" /></Group>`;
+    const unnamedCall = `<Group htmlFor="sleep-hours"><input id="sleep-hours" type="range" /></Group>`;
+
+    expect(hasMatchingExplicitLabel(`${forwarder}\n${namedCall}`, 'sleep-hours')).toBe(true);
+    expect(hasMatchingExplicitLabel(`${forwarder}\n${unnamedCall}`, 'sleep-hours')).toBe(false);
+    expect(hasMatchingExplicitLabel(`${emptyForwarder}\n${namedCall}`, 'sleep-hours')).toBe(false);
+    // A different id on the same wrapper must not be swept up either.
+    expect(hasMatchingExplicitLabel(`${forwarder}\n${namedCall}`, 'other-id')).toBe(false);
   });
 
   it('meets the 44px touch-target minimum on Close buttons', () => {

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -439,6 +439,14 @@ function hasMatchingExplicitLabel(src, id) {
   return hasMatchingForwardedLabel(src, id);
 }
 
+// A `label` prop only names something when it carries text. Every literal that
+// React renders as nothing has to be rejected, `true` included: `<Field label>`
+// and `label={true}` are the same prop value, and `<label>{true}</label>` puts
+// no text in the DOM. Reading it as a name would exempt a control that has none.
+function isUsableLabelAttributeValue(value) {
+  return Boolean(value) && !/^(?:undefined|null|false|true)$/i.test(value);
+}
+
 // A page-local field wrapper can own the <label> AND take the control's id as a
 // prop instead of wrapping it (LifestyleTab.jsx's `<FieldGroup label="Sleep …"
 // htmlFor="lifestyle-sleep-hours">`). Wrapping is wrong there — an implicit
@@ -448,6 +456,10 @@ function hasMatchingExplicitLabel(src, id) {
 // those forwarders the same way and under the same limits as
 // localLabelWrapperNames: same-file `function` declarations only, so a missed
 // one is a false negative that leaves its controls on the allowlist.
+//
+// Both helpers below read whatever source they are handed. The input scan hands
+// them `maskComments(src)`, which is what keeps a commented-out wrapper — or a
+// commented-out call site — from registering; same as localLabelWrapperNames.
 const htmlForForwarderNamesBySource = new Map();
 
 function localHtmlForForwarderNames(src) {
@@ -484,8 +496,7 @@ function hasMatchingForwardedLabel(src, id) {
       if (!tag) continue;
       re.lastIndex = match.index + tag.length;
       if (normalizedAttributeValue(attributeValue(tag, 'htmlFor')) !== id) continue;
-      const label = normalizedAttributeValue(attributeValue(tag, 'label'));
-      if (label && !/^(?:undefined|null|false)$/i.test(label)) return true;
+      if (isUsableLabelAttributeValue(normalizedAttributeValue(attributeValue(tag, 'label')))) return true;
     }
   }
   return false;
@@ -687,7 +698,7 @@ function isNestedInLabelWrappingComponent(src, index) {
       if (/\/\s*>$/.test(tag)) continue;
       open.push(normalizedAttributeValue(attributeValue(tag, 'label')));
     }
-    if (open.some((label) => label && !/^(?:undefined|null|false)$/i.test(label))) return true;
+    if (open.some(isUsableLabelAttributeValue)) return true;
   }
   return false;
 }
@@ -1135,6 +1146,16 @@ describe('a11y conventions', () => {
     expect(hasMatchingExplicitLabel(`${emptyForwarder}\n${namedCall}`, 'sleep-hours')).toBe(false);
     // A different id on the same wrapper must not be swept up either.
     expect(hasMatchingExplicitLabel(`${forwarder}\n${namedCall}`, 'other-id')).toBe(false);
+    // `label` with no value is `label={true}`, which renders no text.
+    expect(hasMatchingExplicitLabel(`${forwarder}\n${namedCall.replace('label="Sleep"', 'label={true}')}`, 'sleep-hours')).toBe(false);
+    // The scan masks comments before any of this runs, so a commented-out
+    // wrapper must not register as one. Probe the source the way the scan
+    // hands it over, or this helper looks safe for the wrong reason.
+    const commentedForwarder = `function Group({ label, htmlFor, children }) {
+  // <label htmlFor={htmlFor}>{label}</label>
+  return <div>{children}</div>;
+}`;
+    expect(hasMatchingExplicitLabel(maskComments(`${commentedForwarder}\n${namedCall}`), 'sleep-hours')).toBe(false);
   });
 
   it('meets the 44px touch-target minimum on Close buttons', () => {

--- a/client/src/components/agents/tabs/ToolsTab.jsx
+++ b/client/src/components/agents/tabs/ToolsTab.jsx
@@ -583,6 +583,7 @@ export default function ToolsTab({ agentId, agent }) {
                 value={postTitle}
                 onChange={(e) => setPostTitle(e.target.value)}
                 placeholder="Post title..."
+            aria-label="Post title"
                 className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white mb-2"
               />
               <textarea

--- a/client/src/components/agents/tabs/WorldTab.jsx
+++ b/client/src/components/agents/tabs/WorldTab.jsx
@@ -403,29 +403,29 @@ export default function WorldTab({ agentId }) {
       case 'mw_explore':
         return (
           <div className="grid grid-cols-2 gap-2">
-            <input type="number" placeholder="X" value={newActionParams.x || ''} onChange={e => setNewActionParams(p => ({ ...p, x: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
-            <input type="number" placeholder="Y" value={newActionParams.y || ''} onChange={e => setNewActionParams(p => ({ ...p, y: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
-            <input type="text" placeholder="Thinking (optional)" value={newActionParams.thinking || ''} onChange={e => setNewActionParams(p => ({ ...p, thinking: e.target.value }))} className="col-span-2 px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
+            <input type="number" placeholder="X" aria-label="Queued action X coordinate" value={newActionParams.x || ''} onChange={e => setNewActionParams(p => ({ ...p, x: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
+            <input type="number" placeholder="Y" aria-label="Queued action Y coordinate" value={newActionParams.y || ''} onChange={e => setNewActionParams(p => ({ ...p, y: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
+            <input type="text" placeholder="Thinking (optional)" aria-label="Queued action thinking (optional)" value={newActionParams.thinking || ''} onChange={e => setNewActionParams(p => ({ ...p, thinking: e.target.value }))} className="col-span-2 px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
           </div>
         );
       case 'mw_think':
         return (
-          <input type="text" placeholder="Thought text" value={newActionParams.thought || ''} onChange={e => setNewActionParams(p => ({ ...p, thought: e.target.value }))} className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
+          <input type="text" placeholder="Thought text" aria-label="Queued thought text" value={newActionParams.thought || ''} onChange={e => setNewActionParams(p => ({ ...p, thought: e.target.value }))} className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
         );
       case 'mw_build':
         return (
           <div className="grid grid-cols-3 gap-2">
-            <input type="number" placeholder="X" value={newActionParams.x || ''} onChange={e => setNewActionParams(p => ({ ...p, x: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
-            <input type="number" placeholder="Y" value={newActionParams.y || ''} onChange={e => setNewActionParams(p => ({ ...p, y: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
-            <input type="number" placeholder="Z" value={newActionParams.z || ''} onChange={e => setNewActionParams(p => ({ ...p, z: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
-            <select value={newActionParams.type || 'stone'} onChange={e => setNewActionParams(p => ({ ...p, type: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm">
+            <input type="number" placeholder="X" aria-label="Queued action X coordinate" value={newActionParams.x || ''} onChange={e => setNewActionParams(p => ({ ...p, x: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
+            <input type="number" placeholder="Y" aria-label="Queued action Y coordinate" value={newActionParams.y || ''} onChange={e => setNewActionParams(p => ({ ...p, y: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
+            <input type="number" placeholder="Z" aria-label="Queued action Z coordinate" value={newActionParams.z || ''} onChange={e => setNewActionParams(p => ({ ...p, z: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
+            <select aria-label="Queued build block type" value={newActionParams.type || 'stone'} onChange={e => setNewActionParams(p => ({ ...p, type: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm">
               <option value="wood">Wood</option>
               <option value="stone">Stone</option>
               <option value="dirt">Dirt</option>
               <option value="grass">Grass</option>
               <option value="leaves">Leaves</option>
             </select>
-            <select value={newActionParams.action || 'place'} onChange={e => setNewActionParams(p => ({ ...p, action: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm">
+            <select aria-label="Queued build action" value={newActionParams.action || 'place'} onChange={e => setNewActionParams(p => ({ ...p, action: e.target.value }))} className="px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm">
               <option value="place">Place</option>
               <option value="remove">Remove</option>
             </select>
@@ -434,8 +434,8 @@ export default function WorldTab({ agentId }) {
       case 'mw_say':
         return (
           <div className="space-y-2">
-            <input type="text" placeholder="Message" value={newActionParams.message || ''} onChange={e => setNewActionParams(p => ({ ...p, message: e.target.value }))} className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
-            <input type="text" placeholder="To Agent ID (optional)" value={newActionParams.sayTo || ''} onChange={e => setNewActionParams(p => ({ ...p, sayTo: e.target.value }))} className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
+            <input type="text" placeholder="Message" aria-label="Queued message" value={newActionParams.message || ''} onChange={e => setNewActionParams(p => ({ ...p, message: e.target.value }))} className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
+            <input type="text" placeholder="To Agent ID (optional)" aria-label="Queued message recipient agent ID (optional)" value={newActionParams.sayTo || ''} onChange={e => setNewActionParams(p => ({ ...p, sayTo: e.target.value }))} className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm" />
           </div>
         );
       default:
@@ -833,6 +833,7 @@ export default function WorldTab({ agentId }) {
               value={moveThinking}
               onChange={(e) => setMoveThinking(e.target.value)}
               placeholder="Thinking... (optional)"
+              aria-label="Move thinking (optional)"
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white mb-3"
             />
             <div className="flex gap-2">
@@ -864,6 +865,7 @@ export default function WorldTab({ agentId }) {
               value={thought}
               onChange={(e) => setThought(e.target.value)}
               placeholder="What is this agent thinking?"
+              aria-label="Thought text"
               maxLength={500}
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white mb-3"
             />
@@ -957,6 +959,7 @@ export default function WorldTab({ agentId }) {
               value={sayMessage}
               onChange={(e) => setSayMessage(e.target.value)}
               placeholder="Message to nearby agents..."
+              aria-label="Message to nearby agents"
               maxLength={500}
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white mb-2"
             />
@@ -965,6 +968,7 @@ export default function WorldTab({ agentId }) {
               value={sayTo}
               onChange={(e) => setSayTo(e.target.value)}
               placeholder="To Agent ID (optional — leave blank for broadcast)"
+              aria-label="Recipient agent ID (optional — leave blank for broadcast)"
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white mb-3"
             />
             <button

--- a/client/src/components/brain/tabs/DailyLogTab.jsx
+++ b/client/src/components/brain/tabs/DailyLogTab.jsx
@@ -931,6 +931,7 @@ export default function DailyLogTab() {
                 value={quickAppend}
                 onChange={(e) => setQuickAppend(e.target.value)}
                 placeholder="Quick append — adds a new paragraph…"
+                aria-label="Quick append a paragraph to the daily log"
                 className="flex-1 min-w-0 bg-port-bg border border-port-border rounded px-3 min-h-[40px] text-sm text-white placeholder-gray-500"
               />
               <button

--- a/client/src/components/brain/tabs/FeedsTab.jsx
+++ b/client/src/components/brain/tabs/FeedsTab.jsx
@@ -146,6 +146,7 @@ export default function FeedsTab({ onRefresh }) {
             value={inputUrl}
             onChange={(e) => setInputUrl(e.target.value)}
             placeholder="Paste an RSS or Atom feed URL..."
+            aria-label="RSS or Atom feed URL"
             className="flex-1 px-4 py-3 bg-port-card border border-port-border rounded-lg text-white placeholder-gray-500 focus:outline-hidden focus:border-port-accent"
             disabled={adding}
           />

--- a/client/src/components/brain/tabs/InboxTab.jsx
+++ b/client/src/components/brain/tabs/InboxTab.jsx
@@ -323,6 +323,7 @@ export default function InboxTab({ onRefresh, settings }) {
             value={inputText}
             onChange={(e) => setInputText(e.target.value)}
             placeholder="One thought at a time..."
+            aria-label="New inbox thought"
             className="flex-1 px-4 py-3 bg-port-card border border-port-border rounded-lg text-white placeholder-gray-500 focus:outline-hidden focus:border-port-accent"
           />
           <VoiceCapture onTranscript={handleVoiceTranscript} />

--- a/client/src/components/brain/tabs/LinksTab.jsx
+++ b/client/src/components/brain/tabs/LinksTab.jsx
@@ -370,6 +370,7 @@ export default function LinksTab({ onRefresh }) {
             value={inputUrl}
             onChange={(e) => setInputUrl(e.target.value)}
             placeholder="Paste a URL (GitHub repos auto-clone)..."
+            aria-label="Link URL to save"
             className="flex-1 px-4 py-3 bg-port-card border border-port-border rounded-lg text-white placeholder-gray-500 focus:outline-hidden focus:border-port-accent"
             disabled={sending}
           />
@@ -468,6 +469,7 @@ export default function LinksTab({ onRefresh }) {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           placeholder="Search links by title, URL, description, or tag..."
+          aria-label="Search links"
           className="w-full pl-9 pr-9 py-2 bg-port-card border border-port-border rounded-lg text-white text-sm placeholder-gray-500 focus:outline-hidden focus:border-port-accent"
         />
         {search && (
@@ -551,6 +553,7 @@ export default function LinksTab({ onRefresh }) {
                       onChange={(e) => setEditForm({ ...editForm, tags: e.target.value })}
                       className="flex-1 px-2 py-1 bg-port-bg border border-port-border rounded text-white text-sm"
                       placeholder="Tags (comma-separated)"
+                      aria-label="Link tags, comma-separated"
                     />
                   </div>
                   <div className="flex gap-2">

--- a/client/src/components/brain/tabs/MemoryTab.jsx
+++ b/client/src/components/brain/tabs/MemoryTab.jsx
@@ -13,6 +13,7 @@ import {Plus,
   MessageSquareText} from 'lucide-react';
 import toast from '../../ui/Toast';
 import Banner from '../../ui/Banner';
+import { FormField } from '../../ui/FormField';
 import ConversationViewer from '../ConversationViewer';
 
 import {
@@ -315,170 +316,208 @@ export default function MemoryTab({ onRefresh }) {
       case 'people':
         return (
           <div className="space-y-3">
-            <input
-              type="text"
-              placeholder="Name"
-              value={form.name || ''}
-              onChange={(e) => setForm({ ...form, name: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
-            <textarea
-              placeholder="Context (who they are, how you know them)"
-              value={form.context || ''}
-              onChange={(e) => setForm({ ...form, context: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-              rows={2}
-            />
-            <input
-              type="text"
-              placeholder="Follow-ups (comma separated)"
-              value={(form.followUps || []).join(', ')}
-              onChange={(e) => setForm({ ...form, followUps: e.target.value.split(',').map(s => s.trim()).filter(Boolean) })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
+            <FormField label="Name" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="Name"
+                value={form.name || ''}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
+            <FormField label="Context" labelClassName="block text-xs text-gray-400 mb-1">
+              <textarea
+                placeholder="Context (who they are, how you know them)"
+                value={form.context || ''}
+                onChange={(e) => setForm({ ...form, context: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+                rows={2}
+              />
+            </FormField>
+            <FormField label="Follow-ups" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="Follow-ups (comma separated)"
+                value={(form.followUps || []).join(', ')}
+                onChange={(e) => setForm({ ...form, followUps: e.target.value.split(',').map(s => s.trim()).filter(Boolean) })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
           </div>
         );
 
       case 'projects':
         return (
           <div className="space-y-3">
-            <input
-              type="text"
-              placeholder="Project name"
-              value={form.name || ''}
-              onChange={(e) => setForm({ ...form, name: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
-            <select
-              value={form.status || 'active'}
-              onChange={(e) => setForm({ ...form, status: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            >
-              <option value="active">Active</option>
-              <option value="waiting">Waiting</option>
-              <option value="blocked">Blocked</option>
-              <option value="someday">Someday</option>
-              <option value="done">Done</option>
-            </select>
-            <input
-              type="text"
-              placeholder="Next action (concrete, actionable step)"
-              value={form.nextAction || ''}
-              onChange={(e) => setForm({ ...form, nextAction: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
-            <textarea
-              placeholder="Notes"
-              value={form.notes || ''}
-              onChange={(e) => setForm({ ...form, notes: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-              rows={2}
-            />
+            <FormField label="Project name" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="Project name"
+                value={form.name || ''}
+                onChange={(e) => setForm({ ...form, name: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
+            <FormField label="Status" labelClassName="block text-xs text-gray-400 mb-1">
+              <select
+                value={form.status || 'active'}
+                onChange={(e) => setForm({ ...form, status: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              >
+                <option value="active">Active</option>
+                <option value="waiting">Waiting</option>
+                <option value="blocked">Blocked</option>
+                <option value="someday">Someday</option>
+                <option value="done">Done</option>
+              </select>
+            </FormField>
+            <FormField label="Next action" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="Next action (concrete, actionable step)"
+                value={form.nextAction || ''}
+                onChange={(e) => setForm({ ...form, nextAction: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
+            <FormField label="Notes" labelClassName="block text-xs text-gray-400 mb-1">
+              <textarea
+                placeholder="Notes"
+                value={form.notes || ''}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+                rows={2}
+              />
+            </FormField>
           </div>
         );
 
       case 'ideas':
         return (
           <div className="space-y-3">
-            <input
-              type="text"
-              placeholder="Title"
-              value={form.title || ''}
-              onChange={(e) => setForm({ ...form, title: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
-            <select
-              value={form.status || 'active'}
-              onChange={(e) => setForm({ ...form, status: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            >
-              <option value="active">Active</option>
-              <option value="done">Done</option>
-            </select>
-            <input
-              type="text"
-              placeholder="One-liner (core insight)"
-              value={form.oneLiner || ''}
-              onChange={(e) => setForm({ ...form, oneLiner: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
-            <textarea
-              placeholder="Notes"
-              value={form.notes || ''}
-              onChange={(e) => setForm({ ...form, notes: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-              rows={2}
-            />
+            <FormField label="Title" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="Title"
+                value={form.title || ''}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
+            <FormField label="Status" labelClassName="block text-xs text-gray-400 mb-1">
+              <select
+                value={form.status || 'active'}
+                onChange={(e) => setForm({ ...form, status: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              >
+                <option value="active">Active</option>
+                <option value="done">Done</option>
+              </select>
+            </FormField>
+            <FormField label="One-liner" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="One-liner (core insight)"
+                value={form.oneLiner || ''}
+                onChange={(e) => setForm({ ...form, oneLiner: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
+            <FormField label="Notes" labelClassName="block text-xs text-gray-400 mb-1">
+              <textarea
+                placeholder="Notes"
+                value={form.notes || ''}
+                onChange={(e) => setForm({ ...form, notes: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+                rows={2}
+              />
+            </FormField>
           </div>
         );
 
       case 'admin':
         return (
           <div className="space-y-3">
-            <input
-              type="text"
-              placeholder="Title"
-              value={form.title || ''}
-              onChange={(e) => setForm({ ...form, title: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
-            <select
-              value={form.status || 'open'}
-              onChange={(e) => setForm({ ...form, status: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            >
-              <option value="open">Open</option>
-              <option value="waiting">Waiting</option>
-              <option value="done">Done</option>
-            </select>
-            <input
-              type="date"
-              placeholder="Due date"
-              value={form.dueDate ? form.dueDate.split('T')[0] : ''}
-              onChange={(e) => setForm({ ...form, dueDate: e.target.value ? new Date(e.target.value).toISOString() : null })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
-            <input
-              type="text"
-              placeholder="Next action"
-              value={form.nextAction || ''}
-              onChange={(e) => setForm({ ...form, nextAction: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
+            <FormField label="Title" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="Title"
+                value={form.title || ''}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
+            <FormField label="Status" labelClassName="block text-xs text-gray-400 mb-1">
+              <select
+                value={form.status || 'open'}
+                onChange={(e) => setForm({ ...form, status: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              >
+                <option value="open">Open</option>
+                <option value="waiting">Waiting</option>
+                <option value="done">Done</option>
+              </select>
+            </FormField>
+            <FormField label="Due date" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="date"
+                placeholder="Due date"
+                value={form.dueDate ? form.dueDate.split('T')[0] : ''}
+                onChange={(e) => setForm({ ...form, dueDate: e.target.value ? new Date(e.target.value).toISOString() : null })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
+            <FormField label="Next action" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="Next action"
+                value={form.nextAction || ''}
+                onChange={(e) => setForm({ ...form, nextAction: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
           </div>
         );
 
       case 'memories':
         return (
           <div className="space-y-3">
-            <input
-              type="text"
-              placeholder="Title (e.g. 'DnD session tonight')"
-              value={form.title || ''}
-              onChange={(e) => setForm({ ...form, title: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
-            <textarea
-              placeholder="What happened? Write your thoughts..."
-              value={form.content || ''}
-              onChange={(e) => setForm({ ...form, content: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-              rows={3}
-            />
-            <input
-              type="text"
-              placeholder="Mood (e.g. happy, reflective, tired)"
-              value={form.mood || ''}
-              onChange={(e) => setForm({ ...form, mood: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
-            <input
-              type="text"
-              placeholder="Tags (comma separated)"
-              value={form.tagInput ?? (form.tags || []).join(', ')}
-              onChange={(e) => setForm({ ...form, tagInput: e.target.value })}
-              className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
-            />
+            <FormField label="Title" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="Title (e.g. 'DnD session tonight')"
+                value={form.title || ''}
+                onChange={(e) => setForm({ ...form, title: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
+            <FormField label="What happened" labelClassName="block text-xs text-gray-400 mb-1">
+              <textarea
+                placeholder="What happened? Write your thoughts..."
+                value={form.content || ''}
+                onChange={(e) => setForm({ ...form, content: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+                rows={3}
+              />
+            </FormField>
+            <FormField label="Mood" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="Mood (e.g. happy, reflective, tired)"
+                value={form.mood || ''}
+                onChange={(e) => setForm({ ...form, mood: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
+            <FormField label="Tags" labelClassName="block text-xs text-gray-400 mb-1">
+              <input
+                type="text"
+                placeholder="Tags (comma separated)"
+                value={form.tagInput ?? (form.tags || []).join(', ')}
+                onChange={(e) => setForm({ ...form, tagInput: e.target.value })}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white"
+              />
+            </FormField>
           </div>
         );
     }
@@ -737,6 +776,7 @@ export default function MemoryTab({ onRefresh }) {
           <select
             value={statusFilter}
             onChange={(e) => setStatusFilter(e.target.value)}
+            aria-label="Filter by status"
             className="px-3 py-2 bg-port-card border border-port-border rounded-lg text-sm text-white"
           >
             <option value="">All statuses</option>
@@ -770,6 +810,7 @@ export default function MemoryTab({ onRefresh }) {
         <input
           type="text"
           placeholder={`Search ${DESTINATIONS[activeType]?.label?.toLowerCase() || 'records'}...`}
+          aria-label={`Search ${DESTINATIONS[activeType]?.label?.toLowerCase() || 'records'}`}
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           className="w-full pl-9 pr-3 py-2 bg-port-card border border-port-border rounded-lg text-sm text-white placeholder-gray-500"

--- a/client/src/components/brain/tabs/NotesTab.jsx
+++ b/client/src/components/brain/tabs/NotesTab.jsx
@@ -308,6 +308,7 @@ export default function NotesTab() {
               onChange={e => setSearchQuery(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && handleSearch()}
               placeholder="Search notes..."
+              aria-label="Search notes"
               className="w-full min-h-[44px] bg-port-bg border border-port-border rounded pl-7 pr-14 py-1.5 text-sm text-white placeholder-gray-500"
             />
             {searchQuery && (
@@ -329,6 +330,7 @@ export default function NotesTab() {
                 onChange={e => setNewNotePath(e.target.value)}
                 onKeyDown={e => e.key === 'Enter' && handleCreateNote()}
                 placeholder="folder/note-name"
+                aria-label="New note path"
                 className="flex-1 min-w-0 min-h-[44px] bg-port-bg border border-port-border rounded px-2 py-1 text-sm text-white placeholder-gray-500"
                 autoFocus
               />
@@ -746,6 +748,7 @@ function VaultSetup({ detectedVaults, vaults, customPath, setCustomPath, adding,
             value={customPath}
             onChange={e => setCustomPath(e.target.value)}
             placeholder="/path/to/obsidian/vault"
+            aria-label="Custom vault path"
             className="flex-1 min-w-0 bg-port-bg border border-port-border rounded px-3 py-2 text-sm text-white placeholder-gray-500"
           />
           <FolderPicker

--- a/client/src/components/goals/GoalEditForm.jsx
+++ b/client/src/components/goals/GoalEditForm.jsx
@@ -35,18 +35,22 @@ export default function GoalEditForm({
     .filter(Boolean);
   return (
     <div className="space-y-3">
-      <input
-        type="text"
-        value={form.title}
-        onChange={e => setForm({ ...form, title: e.target.value })}
-        className="w-full bg-port-bg border border-port-border rounded px-3 py-1.5 text-sm text-white"
-      />
-      <textarea
-        value={form.description}
-        onChange={e => setForm({ ...form, description: e.target.value })}
-        rows={3}
-        className="w-full bg-port-bg border border-port-border rounded px-3 py-1.5 text-sm text-white resize-none"
-      />
+      <FormField label="Title" labelClassName="text-xs text-gray-500">
+        <input
+          type="text"
+          value={form.title}
+          onChange={e => setForm({ ...form, title: e.target.value })}
+          className="w-full bg-port-bg border border-port-border rounded px-3 py-1.5 text-sm text-white mt-1"
+        />
+      </FormField>
+      <FormField label="Description" labelClassName="text-xs text-gray-500">
+        <textarea
+          value={form.description}
+          onChange={e => setForm({ ...form, description: e.target.value })}
+          rows={3}
+          className="w-full bg-port-bg border border-port-border rounded px-3 py-1.5 text-sm text-white resize-none mt-1"
+        />
+      </FormField>
       <FormField label="Horizon" labelClassName="text-xs text-gray-500">
         <select
           value={form.horizon}
@@ -123,8 +127,9 @@ export default function GoalEditForm({
           </div>
           <div className="flex gap-2">
             <div className="flex-1">
-              <span className="text-[10px] text-gray-600">Time slot</span>
+              <label htmlFor="goal-time-slot" className="text-[10px] text-gray-600">Time slot</label>
               <select
+                id="goal-time-slot"
                 value={form.timeBlockConfig?.timeSlot || 'morning'}
                 onChange={e => setForm({ ...form, timeBlockConfig: { ...(form.timeBlockConfig || { preferredDays: ['mon','wed','fri'], sessionDurationMinutes: 60 }), timeSlot: e.target.value } })}
                 className="w-full bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white mt-0.5"
@@ -135,8 +140,9 @@ export default function GoalEditForm({
               </select>
             </div>
             <div className="w-20">
-              <span className="text-[10px] text-gray-600">Duration</span>
+              <label htmlFor="goal-session-duration" className="text-[10px] text-gray-600">Duration</label>
               <input
+                id="goal-session-duration"
                 type="number"
                 min="15"
                 max="480"
@@ -177,6 +183,7 @@ export default function GoalEditForm({
             onChange={e => setTagInput(e.target.value)}
             onKeyDown={e => e.key === 'Enter' && (e.preventDefault(), addTag())}
             placeholder="Add tag..."
+            aria-label="Add tag"
             className="flex-1 bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white"
           />
           <button

--- a/client/src/components/goals/GoalLinkedCalendars.jsx
+++ b/client/src/components/goals/GoalLinkedCalendars.jsx
@@ -39,6 +39,7 @@ export default function GoalLinkedCalendars({
             <select
               value={selectedCalendar}
               onChange={e => setSelectedCalendar(e.target.value)}
+              aria-label="Calendar to link"
               className="flex-1 bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white"
             >
               <option value="">Link calendar...</option>
@@ -60,6 +61,7 @@ export default function GoalLinkedCalendars({
               value={calendarMatchPattern}
               onChange={e => setCalendarMatchPattern(e.target.value)}
               placeholder="Match pattern (optional)"
+              aria-label="Calendar event match pattern"
               className="w-full bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white"
             />
           )}

--- a/client/src/components/goals/GoalMilestones.jsx
+++ b/client/src/components/goals/GoalMilestones.jsx
@@ -82,6 +82,7 @@ export default function GoalMilestones({
           onChange={e => setNewMilestone({ ...newMilestone, title: e.target.value })}
           onKeyDown={e => e.key === 'Enter' && handleAddMilestone()}
           placeholder="Add milestone..."
+          aria-label="New milestone title"
           className="flex-1 bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white"
         />
         <button

--- a/client/src/components/goals/GoalPlanSection.jsx
+++ b/client/src/components/goals/GoalPlanSection.jsx
@@ -193,7 +193,7 @@ export default function GoalPlanSection({
                           next[idx] = { ...next[idx], title: e.target.value };
                           setProposedDecomposition(next);
                         }}
-                        aria-label={`Sub-goal ${idx + 1} title`}
+                        aria-label={`Milestone ${idx + 1} title`}
                         className="w-full bg-port-card border border-port-border rounded px-2 py-0.5 text-xs text-white"
                       />
                       <input
@@ -205,7 +205,7 @@ export default function GoalPlanSection({
                           setProposedDecomposition(next);
                         }}
                         placeholder="Description..."
-                        aria-label={`Sub-goal ${idx + 1} description`}
+                        aria-label={`Milestone ${idx + 1} description`}
                         className="w-full bg-port-card border border-port-border rounded px-2 py-0.5 text-xs text-gray-400 mt-0.5"
                       />
                     </div>

--- a/client/src/components/goals/GoalPlanSection.jsx
+++ b/client/src/components/goals/GoalPlanSection.jsx
@@ -79,6 +79,7 @@ export default function GoalPlanSection({
                           next[idx] = { ...next[idx], title: e.target.value };
                           setProposedPhases(next);
                         }}
+                        aria-label={`Phase ${idx + 1} title`}
                         className="w-full bg-port-card border border-port-border rounded px-2 py-0.5 text-xs text-white"
                       />
                       <input
@@ -90,6 +91,7 @@ export default function GoalPlanSection({
                           setProposedPhases(next);
                         }}
                         placeholder="Description..."
+                        aria-label={`Phase ${idx + 1} description`}
                         className="w-full bg-port-card border border-port-border rounded px-2 py-0.5 text-xs text-gray-400 mt-0.5"
                       />
                     </div>
@@ -102,6 +104,7 @@ export default function GoalPlanSection({
                           next[idx] = { ...next[idx], targetDate: e.target.value };
                           setProposedPhases(next);
                         }}
+                        aria-label={`Phase ${idx + 1} target date`}
                         className="bg-port-card border border-port-border rounded px-1 py-0.5 text-[10px] text-white"
                       />
                       <button
@@ -190,6 +193,7 @@ export default function GoalPlanSection({
                           next[idx] = { ...next[idx], title: e.target.value };
                           setProposedDecomposition(next);
                         }}
+                        aria-label={`Sub-goal ${idx + 1} title`}
                         className="w-full bg-port-card border border-port-border rounded px-2 py-0.5 text-xs text-white"
                       />
                       <input
@@ -201,6 +205,7 @@ export default function GoalPlanSection({
                           setProposedDecomposition(next);
                         }}
                         placeholder="Description..."
+                        aria-label={`Sub-goal ${idx + 1} description`}
                         className="w-full bg-port-card border border-port-border rounded px-2 py-0.5 text-xs text-gray-400 mt-0.5"
                       />
                     </div>

--- a/client/src/components/goals/GoalProgressLog.jsx
+++ b/client/src/components/goals/GoalProgressLog.jsx
@@ -36,12 +36,14 @@ export default function GoalProgressLog({
             type="date"
             value={progressForm.date}
             onChange={e => setProgressForm({ ...progressForm, date: e.target.value })}
+            aria-label="Progress date"
             className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
           />
           <textarea
             value={progressForm.note}
             onChange={e => setProgressForm({ ...progressForm, note: e.target.value })}
             placeholder="What did you work on?"
+            aria-label="Progress note"
             rows={2}
             className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white resize-none"
           />
@@ -52,6 +54,7 @@ export default function GoalProgressLog({
               value={progressForm.durationMinutes}
               onChange={e => setProgressForm({ ...progressForm, durationMinutes: e.target.value })}
               placeholder="Minutes (optional)"
+              aria-label="Duration in minutes (optional)"
               min="1"
               max="1440"
               className="flex-1 bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"

--- a/client/src/components/goals/GoalTodoList.jsx
+++ b/client/src/components/goals/GoalTodoList.jsx
@@ -74,6 +74,7 @@ export default function GoalTodoList({
             onChange={e => setNewTodoTitle(e.target.value)}
             onKeyDown={e => e.key === 'Enter' && handleAddTodo()}
             placeholder="Add todo..."
+            aria-label="New todo title"
             className="flex-1 bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white"
           />
           <button
@@ -89,6 +90,7 @@ export default function GoalTodoList({
             <select
               value={newTodoPriority}
               onChange={e => setNewTodoPriority(e.target.value)}
+              aria-label="New todo priority"
               className="bg-port-bg border border-port-border rounded px-1.5 py-0.5 text-xs text-white"
             >
               <option value="low">Low</option>
@@ -100,6 +102,7 @@ export default function GoalTodoList({
               value={newTodoEstimate}
               onChange={e => setNewTodoEstimate(e.target.value)}
               placeholder="Est. min"
+              aria-label="New todo estimate in minutes"
               min="1"
               className="w-20 bg-port-bg border border-port-border rounded px-1.5 py-0.5 text-xs text-white"
             />

--- a/client/src/components/goals/GoalsListView.jsx
+++ b/client/src/components/goals/GoalsListView.jsx
@@ -341,6 +341,7 @@ export default function GoalsListView({ data, onRefresh, selectedGoalId }) {
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               placeholder="Search goals..."
+              aria-label="Search goals"
               className="w-full bg-port-bg border border-port-border rounded-lg pl-8 pr-3 py-1.5 text-sm text-white"
             />
           </div>
@@ -352,6 +353,7 @@ export default function GoalsListView({ data, onRefresh, selectedGoalId }) {
               onChange={e => setQuickAdd(e.target.value)}
               onKeyDown={e => e.key === 'Enter' && handleQuickAdd()}
               placeholder="Add goal..."
+              aria-label="Quick-add a goal"
               className="w-full bg-port-bg border border-port-border rounded-lg pl-8 pr-3 py-1.5 text-sm text-white placeholder-gray-500"
             />
           </div>
@@ -419,6 +421,7 @@ export default function GoalsListView({ data, onRefresh, selectedGoalId }) {
                 value={newGoal.title}
                 onChange={e => setNewGoal({ ...newGoal, title: e.target.value })}
                 placeholder="Goal title..."
+                aria-label="New goal title"
                 className="flex-1 bg-port-bg border border-port-border rounded px-3 py-1.5 text-sm text-white"
                 onKeyDown={e => e.key === 'Enter' && handleCreateGoal()}
                 autoFocus

--- a/client/src/components/goals/GoalsTreeView.jsx
+++ b/client/src/components/goals/GoalsTreeView.jsx
@@ -486,6 +486,7 @@ export default function GoalsTreeView({ data, onRefresh }) {
               value={searchQuery}
               onChange={e => setSearchQuery(e.target.value)}
               placeholder="Search..."
+              aria-label="Search goals"
               className="bg-port-card/90 backdrop-blur border border-port-border rounded-lg pl-7 pr-3 py-1.5 text-sm text-white w-32 sm:w-48"
             />
           </div>
@@ -564,6 +565,7 @@ export default function GoalsTreeView({ data, onRefresh }) {
               value={newGoal.title}
               onChange={e => setNewGoal({ ...newGoal, title: e.target.value })}
               placeholder="Goal title..."
+              aria-label="New goal title"
               className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm text-white"
               onKeyDown={e => e.key === 'Enter' && handleCreateGoal()}
             />
@@ -571,6 +573,7 @@ export default function GoalsTreeView({ data, onRefresh }) {
               value={newGoal.description}
               onChange={e => setNewGoal({ ...newGoal, description: e.target.value })}
               placeholder="Description..."
+              aria-label="New goal description"
               rows={2}
               className="w-full bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm text-white resize-none"
             />
@@ -578,6 +581,7 @@ export default function GoalsTreeView({ data, onRefresh }) {
               <select
                 value={newGoal.horizon}
                 onChange={e => setNewGoal({ ...newGoal, horizon: e.target.value })}
+                aria-label="New goal horizon"
                 className="flex-1 bg-port-bg border border-port-border rounded px-2 py-1 text-sm text-white"
               >
                 {HORIZON_OPTIONS.map(h => <option key={h.value} value={h.value}>{h.label}</option>)}
@@ -585,6 +589,7 @@ export default function GoalsTreeView({ data, onRefresh }) {
               <select
                 value={newGoal.category}
                 onChange={e => setNewGoal({ ...newGoal, category: e.target.value })}
+                aria-label="New goal category"
                 className="flex-1 bg-port-bg border border-port-border rounded px-2 py-1 text-sm text-white"
               >
                 {Object.entries(CATEGORY_CONFIG).map(([k, v]) => (

--- a/client/src/components/meatspace/tabs/AgeTab.jsx
+++ b/client/src/components/meatspace/tabs/AgeTab.jsx
@@ -46,6 +46,7 @@ function BirthDateSection({ birthDate, onUpdate }) {
         <div className="flex items-center gap-3">
           <input
             type="date"
+            aria-label="Birth date"
             value={input}
             onChange={(e) => setInput(e.target.value)}
             className="bg-port-bg border border-port-border rounded px-3 py-2 text-white font-mono text-lg focus:border-port-accent focus:outline-none"

--- a/client/src/components/meatspace/tabs/AlcoholTab.jsx
+++ b/client/src/components/meatspace/tabs/AlcoholTab.jsx
@@ -352,6 +352,7 @@ export default function AlcoholTab() {
                       value={buttonForm.name}
                       onChange={e => setButtonForm(f => ({ ...f, name: e.target.value }))}
                       placeholder="Name"
+                      aria-label="Drink button name"
                       className="flex-1 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white"
                     />
                     <input
@@ -361,6 +362,7 @@ export default function AlcoholTab() {
                       value={buttonForm.oz}
                       onChange={e => setButtonForm(f => ({ ...f, oz: e.target.value }))}
                       placeholder={buttonVolumeUnit === 'oz' ? 'Oz' : 'mL'}
+                      aria-label={`Drink button volume in ${buttonVolumeUnit}`}
                       className="w-16 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white text-right"
                     />
                     <button
@@ -378,6 +380,7 @@ export default function AlcoholTab() {
                       value={buttonForm.abv}
                       onChange={e => setButtonForm(f => ({ ...f, abv: e.target.value }))}
                       placeholder="ABV%"
+                      aria-label="Drink button ABV percent"
                       className="w-16 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white text-right"
                     />
                     <button onClick={saveEditButton} className="p-1.5 text-port-success hover:text-port-success/80" title="Save" aria-label="Save">
@@ -420,6 +423,7 @@ export default function AlcoholTab() {
                   value={buttonForm.name}
                   onChange={e => setButtonForm(f => ({ ...f, name: e.target.value }))}
                   placeholder="New button name"
+                  aria-label="New drink button name"
                   className="flex-1 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white placeholder-gray-600"
                 />
                 <input
@@ -429,6 +433,7 @@ export default function AlcoholTab() {
                   value={buttonForm.oz}
                   onChange={e => setButtonForm(f => ({ ...f, oz: e.target.value }))}
                   placeholder={buttonVolumeUnit === 'oz' ? 'Oz' : 'mL'}
+                  aria-label={`New drink button volume in ${buttonVolumeUnit}`}
                   className="w-16 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white text-right placeholder-gray-600"
                 />
                 <button
@@ -446,6 +451,7 @@ export default function AlcoholTab() {
                   value={buttonForm.abv}
                   onChange={e => setButtonForm(f => ({ ...f, abv: e.target.value }))}
                   placeholder="ABV%"
+                  aria-label="New drink button ABV percent"
                   className="w-16 px-2 py-1.5 bg-port-bg border border-port-border rounded-lg text-xs text-white text-right placeholder-gray-600"
                 />
                 <button
@@ -474,7 +480,7 @@ export default function AlcoholTab() {
           </FormField>
           <div>
             <div className="flex items-center gap-1.5 mb-1">
-              <label className="text-xs text-gray-500">Volume</label>
+              <label htmlFor="alcohol-volume" className="text-xs text-gray-500">Volume</label>
               <button
                 type="button"
                 onClick={() => setVolumeUnit(u => u === 'oz' ? 'ml' : 'oz')}
@@ -484,6 +490,7 @@ export default function AlcoholTab() {
               </button>
             </div>
             <input
+              id="alcohol-volume"
               type="number"
               step="0.1"
               min="0.1"
@@ -575,6 +582,7 @@ export default function AlcoholTab() {
                               type="date"
                               value={editForm.date}
                               onChange={e => setEditForm(f => ({ ...f, date: e.target.value }))}
+                              aria-label="Entry date"
                               className="bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white"
                             />
                           ) : idx === 0 ? (
@@ -598,6 +606,7 @@ export default function AlcoholTab() {
                                 type="text"
                                 value={editForm.name}
                                 onChange={e => setEditForm(f => ({ ...f, name: e.target.value }))}
+                                aria-label="Entry name"
                                 className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white"
                               />
                             </td>
@@ -609,6 +618,7 @@ export default function AlcoholTab() {
                                   min="0.1"
                                   value={editForm.oz}
                                   onChange={e => setEditForm(f => ({ ...f, oz: e.target.value }))}
+                                  aria-label={`Entry volume in ${editVolumeUnit}`}
                                   className="w-16 px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white text-right"
                                 />
                                 <button
@@ -628,6 +638,7 @@ export default function AlcoholTab() {
                                 max="100"
                                 value={editForm.abv}
                                 onChange={e => setEditForm(f => ({ ...f, abv: e.target.value }))}
+                                aria-label="Entry ABV percent"
                                 className="w-16 px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white text-right"
                               />
                             </td>
@@ -638,6 +649,7 @@ export default function AlcoholTab() {
                                 max="100"
                                 value={editForm.count}
                                 onChange={e => setEditForm(f => ({ ...f, count: e.target.value }))}
+                                aria-label="Entry count"
                                 className="w-14 px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white text-right"
                               />
                             </td>

--- a/client/src/components/meatspace/tabs/GenomeTab.jsx
+++ b/client/src/components/meatspace/tabs/GenomeTab.jsx
@@ -862,6 +862,7 @@ export default function GenomeTab() {
             onChange={(e) => setSearchRsid(e.target.value.toLowerCase().trim())}
             onKeyDown={(e) => e.key === 'Enter' && handleSearch()}
             placeholder="rs1801133"
+            aria-label="Search SNP by rsID"
             className="flex-1 max-w-xs px-3 py-2 bg-port-card border border-port-border rounded text-sm text-white placeholder-gray-600 focus:outline-hidden focus:border-port-accent font-mono"
           />
           <button

--- a/client/src/components/meatspace/tabs/LifestyleTab.jsx
+++ b/client/src/components/meatspace/tabs/LifestyleTab.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useId } from 'react';
 import { ClipboardList, Save } from 'lucide-react';
 import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
@@ -158,9 +158,10 @@ export default function LifestyleTab() {
           </FieldGroup>
 
           {/* Exercise */}
-          <FieldGroup label="Exercise (minutes/week)">
+          <FieldGroup label="Exercise (minutes/week)" htmlFor="lifestyle-exercise-minutes">
             <div className="flex items-center gap-3">
               <input
+                id="lifestyle-exercise-minutes"
                 type="range"
                 min="0"
                 max="600"
@@ -179,9 +180,10 @@ export default function LifestyleTab() {
           </FieldGroup>
 
           {/* Sleep */}
-          <FieldGroup label="Sleep (hours/night)">
+          <FieldGroup label="Sleep (hours/night)" htmlFor="lifestyle-sleep-hours">
             <div className="flex items-center gap-3">
               <input
+                id="lifestyle-sleep-hours"
                 type="range"
                 min="3"
                 max="12"
@@ -238,9 +240,10 @@ export default function LifestyleTab() {
           </FieldGroup>
 
           {/* BMI */}
-          <FieldGroup label="BMI (auto-calculated from body data when available)">
+          <FieldGroup label="BMI (auto-calculated from body data when available)" htmlFor="lifestyle-bmi">
             <div className="flex items-center gap-3">
               <input
+                id="lifestyle-bmi"
                 type="number"
                 min="10"
                 max="80"
@@ -304,10 +307,22 @@ export default function LifestyleTab() {
   );
 }
 
-function FieldGroup({ label, children }) {
+// `htmlFor` names a single control; without it the group holds a button set
+// with no labelable control, so the text becomes the group's accessible name
+// instead of an orphan <label> pointing at nothing.
+function FieldGroup({ label, htmlFor, children }) {
+  const labelId = useId();
+  if (!htmlFor) {
+    return (
+      <div role="group" aria-labelledby={labelId}>
+        <span id={labelId} className="block text-xs text-gray-500 uppercase mb-2">{label}</span>
+        {children}
+      </div>
+    );
+  }
   return (
     <div>
-      <label className="block text-xs text-gray-500 uppercase mb-2">{label}</label>
+      <label htmlFor={htmlFor} className="block text-xs text-gray-500 uppercase mb-2">{label}</label>
       {children}
     </div>
   );

--- a/client/src/components/meatspace/tabs/NicotineTab.jsx
+++ b/client/src/components/meatspace/tabs/NicotineTab.jsx
@@ -257,6 +257,7 @@ export default function NicotineTab() {
                       onChange={e => setButtonForm({ ...buttonForm, name: e.target.value })}
                       className="flex-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-xs text-white"
                       placeholder="Name"
+                      aria-label="Product button name"
                     />
                     <input
                       type="number"
@@ -264,6 +265,7 @@ export default function NicotineTab() {
                       onChange={e => setButtonForm({ ...buttonForm, mgPerUnit: e.target.value })}
                       className="w-16 bg-port-bg border border-port-border rounded px-2 py-1.5 text-xs text-white"
                       placeholder="mg"
+                      aria-label="Product button milligrams per unit"
                       step="0.1"
                     />
                     <button aria-label="Save" onClick={saveEditButton} className="p-1.5 text-port-success hover:text-white"><Check size={14} /></button>
@@ -298,6 +300,7 @@ export default function NicotineTab() {
                   onChange={e => setButtonForm({ ...buttonForm, name: e.target.value })}
                   className="flex-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-xs text-white placeholder-gray-600"
                   placeholder="New product name"
+                  aria-label="New product button name"
                 />
                 <input
                   type="number"
@@ -305,6 +308,7 @@ export default function NicotineTab() {
                   onChange={e => setButtonForm({ ...buttonForm, mgPerUnit: e.target.value })}
                   className="w-16 bg-port-bg border border-port-border rounded px-2 py-1.5 text-xs text-white placeholder-gray-600"
                   placeholder="mg"
+                  aria-label="New product button milligrams per unit"
                   step="0.1"
                 />
                 <button type="submit" aria-label="Add product" className="px-3 py-1.5 bg-port-accent/10 text-port-accent rounded text-xs hover:bg-port-accent/20">
@@ -436,6 +440,7 @@ export default function NicotineTab() {
                               type="date"
                               value={editForm.date}
                               onChange={e => setEditForm({ ...editForm, date: e.target.value })}
+                              aria-label="Entry date"
                               className="bg-port-bg border border-port-border rounded px-2 py-1 text-xs text-white"
                             />
                           ) : idx === 0 ? (
@@ -457,6 +462,7 @@ export default function NicotineTab() {
                                 type="text"
                                 value={editForm.product}
                                 onChange={e => setEditForm({ ...editForm, product: e.target.value })}
+                                aria-label="Entry product"
                                 className="w-full px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white"
                               />
                             </td>
@@ -465,6 +471,7 @@ export default function NicotineTab() {
                                 type="number"
                                 value={editForm.mgPerUnit}
                                 onChange={e => setEditForm({ ...editForm, mgPerUnit: e.target.value })}
+                                aria-label="Entry milligrams per unit"
                                 className="w-16 px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white text-right"
                                 step="0.1"
                               />
@@ -474,6 +481,7 @@ export default function NicotineTab() {
                                 type="number"
                                 value={editForm.count}
                                 onChange={e => setEditForm({ ...editForm, count: e.target.value })}
+                                aria-label="Entry count"
                                 className="w-14 px-2 py-1 bg-port-bg border border-port-border rounded text-xs text-white text-right"
                                 min="1"
                               />


### PR DESCRIPTION
## Summary

Continues the accessible-name sweep past the page-level slice shipped in #4307. That pass worked the named pages; this one works four whole component subtrees, so the result is coherent per-area rather than a scatter of individual fixes:

- `client/src/components/goals/**` (8 files)
- `client/src/components/brain/tabs/**` (6 files)
- `client/src/components/meatspace/tabs/**` (5 files)
- `client/src/components/agents/tabs/**` (2 files)

Every candidate was read in context before being touched — controls already named by a wrapper were left alone. 80 genuinely-unnamed controls got names:

- **Visible label + `htmlFor`/`id`** where the surface had room. The shared `FormField` for `GoalEditForm`'s title/description and all five of `MemoryTab`'s add/edit forms (people, projects, ideas, admin, memories), which previously ran on placeholders alone. Existing orphan `<label>` elements — `GoalEditForm`'s "Time slot"/"Duration", `AlcoholTab`'s "Volume" — got the pairing they were missing rather than a new one bolted on.
- **`aria-label`** for compact toolbars, inline table-edit rows, and repeated list rows (`GoalPlanSection`'s phase/sub-goal rows index their labels), where a visible label would break the layout.

`LifestyleTab`'s page-local `FieldGroup` rendered a `<label>` that pointed at nothing. It now takes an `htmlFor` prop for its three single-control groups, and falls back to `role="group"` + `aria-labelledby` for the button sets, which have no labelable control. Wrapping was not an option there: an implicit `<label>` would pull the live value readout and the hint paragraph beside each slider into the accessible name.

The a11y guard learns that shape. `hasMatchingExplicitLabel` now also credits a same-file wrapper that forwards `htmlFor` onto a `<label>` it fills with its own `label` prop, under the same limits as the existing label-wrapper recognizer (same-file `function` declarations only, so a missed one is a false negative). A probe test pins the bypasses shut — a forwarder whose `<label>` holds no text, and a call site with no `label=`, both still count as unnamed.

No allowlist was broadened. All 80 corresponding `PREEXISTING_INPUT_NAME_ALLOWLIST` entries in `client/src/a11yConventions.test.js` are removed, so these controls are enforced by the repo-wide guard instead of exempted — 222 entries down to 142.

## Test plan

- `cd client && npm test` — 650 files / 7939 tests pass.
- `cd client && npm run lint` — clean.
- `client/src/a11yConventions.test.js` passes with the 80 allowlist entries deleted, which is the actual regression check: re-adding any entry is no longer needed for these files, and removing a fix without the entry fails the suite.
- New probe `only credits an htmlFor-forwarding wrapper that really names the control` asserts the new recognizer fires for a wrapper that labels, and does not fire for a text-less `<label>`, a call site missing `label=`, or a non-matching id.

## Remaining

This is a deliberate slice of a long tail, not the whole backlog. `PREEXISTING_INPUT_NAME_ALLOWLIST` still carries 142 entries, largest clusters:

- `src/pages/**` (26, mostly `AIProviders.jsx` and `StackerNews.jsx`)
- `src/components/meatspace/post/**` (14)
- `src/components/cos/tabs/**` (14)
- `src/components/settings/**` (11)
- `src/components/universeBuilder/**` (9), `src/components/pipeline/arcCanvas/**` (9), `src/components/music/**` (8), `src/components/digital-twin/tabs/**` (8), and a long tail of 1–6 per directory

`<select>` and `<textarea>` also remain outside the guard's scope entirely (it scans `<input>` only); that extension is tracked separately per the earlier discussion on this issue. This PR did name the `<select>`/`<textarea>` controls it encountered inside the four swept subtrees, but they are not yet guarded.

Refs #4156
