### PR TITLE
refactor: drop the 85 redundant windowsHide literals the wrapper already supplies (#4315)

### DIFF
--- a/.changelog/next/changed-issue-4315.md
+++ b/.changelog/next/changed-issue-4315.md
@@ -1,0 +1,1 @@
+- Removed the 85 now-redundant windowsHide literals left at server spawn call sites by the earlier per-call-site sweeps — server/lib/childProcess.js already injects that value, and a guard now fails if one comes back

--- a/server/cos-runner/index.js
+++ b/server/cos-runner/index.js
@@ -390,8 +390,7 @@ app.post('/spawn', async (req, res) => {
     cwd,
     shell: false,
     stdio: ['pipe', 'pipe', 'pipe'],
-    env: childEnv,
-    windowsHide: true
+    env: childEnv
   });
 
   // Detect if stream-json format is active (Claude CLI with streaming)

--- a/server/cos-runner/processStats.js
+++ b/server/cos-runner/processStats.js
@@ -79,7 +79,7 @@ export async function getProcessStats(pid) {
   const psCmd = isWindows
     ? `tasklist /FI "PID eq ${safePid}" /FO CSV /NH`
     : `ps -p ${safePid} -o pid=,pcpu=,rss=,state=`;
-  const result = await execAsync(psCmd, { windowsHide: true }).catch(() => ({ stdout: '' }));
+  const result = await execAsync(psCmd).catch(() => ({ stdout: '' }));
   const line = result.stdout.trim();
 
   if (!line) {
@@ -114,12 +114,12 @@ export async function checkProcessRunning(pid) {
   }
 
   if (process.platform === 'win32') {
-    const result = await execAsync(`tasklist /FI "PID eq ${safePid}" /FO CSV /NH`, { windowsHide: true }).catch(() => ({ stdout: '' }));
+    const result = await execAsync(`tasklist /FI "PID eq ${safePid}" /FO CSV /NH`).catch(() => ({ stdout: '' }));
     // tasklist prints a CSV row containing the PID when the process exists;
     // otherwise it emits an "INFO: No tasks…" line that won't contain the PID.
     return result.stdout.includes(`"${safePid}"`);
   }
 
-  const result = await execAsync(`ps -p ${safePid} -o pid=`, { windowsHide: true }).catch(() => ({ stdout: '' }));
+  const result = await execAsync(`ps -p ${safePid} -o pid=`).catch(() => ({ stdout: '' }));
   return result.stdout.trim() !== '';
 }

--- a/server/cos-runner/processStats.test.js
+++ b/server/cos-runner/processStats.test.js
@@ -44,8 +44,11 @@ describe('cos-runner processStats', () => {
     const loadWithMockedExec = async (stdout) => {
       const calls = [];
       vi.resetModules();
+      // Variadic like node's own `exec`: the callback is the last argument, and
+      // the options slot is optional. A fixed `(cmd, opts, cb)` signature ties
+      // the mock to whether the caller happens to pass options at all.
       vi.doMock('../lib/childProcess.js', () => ({
-        exec: (cmd, _opts, cb) => { calls.push(cmd); cb(null, { stdout, stderr: '' }); },
+        exec: (cmd, ...rest) => { calls.push(cmd); rest.at(-1)(null, { stdout, stderr: '' }); },
       }));
       vi.stubGlobal('process', { ...process, platform: 'win32' });
       const mod = await import('./processStats.js');
@@ -91,8 +94,11 @@ describe('cos-runner processStats', () => {
     const loadWithMockedExec = async (stdout) => {
       const calls = [];
       vi.resetModules();
+      // Variadic like node's own `exec`: the callback is the last argument, and
+      // the options slot is optional. A fixed `(cmd, opts, cb)` signature ties
+      // the mock to whether the caller happens to pass options at all.
       vi.doMock('../lib/childProcess.js', () => ({
-        exec: (cmd, _opts, cb) => { calls.push(cmd); cb(null, { stdout, stderr: '' }); },
+        exec: (cmd, ...rest) => { calls.push(cmd); rest.at(-1)(null, { stdout, stderr: '' }); },
       }));
       vi.stubGlobal('process', { ...process, platform: 'win32' });
       const mod = await import('./processStats.js');

--- a/server/lib/bashResolver.js
+++ b/server/lib/bashResolver.js
@@ -54,7 +54,7 @@ function standardGitBashPaths() {
 function gitBashFromPath() {
   let gitExe = '';
   try {
-    gitExe = execFileSync('where', ['git'], { encoding: 'utf8', windowsHide: true }).split(/\r?\n/)[0].trim();
+    gitExe = execFileSync('where', ['git'], { encoding: 'utf8' }).split(/\r?\n/)[0].trim();
   } catch {
     return null;
   }

--- a/server/lib/bufferedSpawn.js
+++ b/server/lib/bufferedSpawn.js
@@ -238,7 +238,7 @@ export const MAX_OUTPUT_BYTES = 64 * 1024;
 export function killProcessTree(child, signal = 'SIGTERM', { processGroup = false } = {}) {
   if (IS_WIN32 && child.pid && child instanceof ChildProcess) {
     child.killed = true;
-    spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore', windowsHide: true })
+    spawn('taskkill', ['/T', '/F', '/PID', String(child.pid)], { stdio: 'ignore' })
       .on('error', () => {})
       .unref();
     return;
@@ -289,7 +289,6 @@ export function bufferedSpawn(cmd, args, { cwd, timeoutMs, shell } = {}) {
       // copy of process.env when no cwd was given, matching the previous
       // implicit-inherit behavior exactly.
       env: withSpawnCwdEnv(process.env, cwd),
-      windowsHide: true,
       shell: shell === undefined ? needsShell(cmd) : shell,
     });
     let stdout = '';

--- a/server/lib/bufferedSpawn.test.js
+++ b/server/lib/bufferedSpawn.test.js
@@ -105,7 +105,7 @@ describe('killProcessTree', () => {
     killProcessTree(child);
     expect(spawnMock).toHaveBeenCalledWith(
       'taskkill', ['/T', '/F', '/PID', '999'],
-      expect.objectContaining({ stdio: 'ignore', windowsHide: true })
+      expect.objectContaining({ stdio: 'ignore' })
     );
     // taskkill runs in a detached process that never touches `child` itself —
     // .killed must be set synchronously here so re-entrant kill/abort guards
@@ -357,8 +357,9 @@ describe('bufferedSpawn — structured result', () => {
       success: true, code: 0, signal: null,
       stdout: 'out-data', stderr: 'err-data', timedOut: false,
     });
-    // cwd + windowsHide passed through; shell defaults to needsShell(cmd).
-    expect(spawnMock).toHaveBeenCalledWith('echo', ['hi'], expect.objectContaining({ cwd: '/tmp', windowsHide: true }));
+    // cwd passed through; shell defaults to needsShell(cmd). windowsHide is the
+    // wrapper's job now, so it isn't in what bufferedSpawn itself passes.
+    expect(spawnMock).toHaveBeenCalledWith('echo', ['hi'], expect.objectContaining({ cwd: '/tmp' }));
   });
 
   it('resolves failure (not throw) on a non-zero exit', async () => {

--- a/server/lib/childProcess.guards.test.js
+++ b/server/lib/childProcess.guards.test.js
@@ -94,23 +94,47 @@ const allFiles = [
 // pure CPU to `npm test` for nothing. A hit inside a comment survives the
 // pre-filter and is then correctly discarded by blankComments, so narrowing
 // this way cannot hide a violation.
-const candidates = allFiles
-  .map((rel) => ({ rel, raw: readServerSource(rel) }))
+const allSources = allFiles.map((rel) => ({ rel, raw: readServerSource(rel) }));
+
+const candidates = allSources
   .filter(({ raw }) => raw.includes('child_process') || /['"]pm2['"]/.test(raw));
 
 const parsed = new Map(candidates.map(({ rel, raw }) => [rel, blankComments(raw)]));
 
 const inCallSiteTree = (rel) => CALL_SITE_TREES.some((t) => rel.startsWith(t));
 
-// A separate pre-filter for the redundant-literal rule below. The `candidates`
-// set above keys on the string `child_process`, which a file that has correctly
-// moved to the wrapper no longer contains — so reusing it there would scan
-// exactly the files the rule does not apply to and pass green forever.
-const IMPORTS_WRAPPER = /['"][^'"]*childProcess\.js['"]/;
-const wrapperImporters = allFiles
-  .filter((rel) => rel !== WRAPPER && !inCallSiteTree(rel))
-  .map((rel) => ({ rel, raw: readServerSource(rel) }))
-  .filter(({ raw }) => IMPORTS_WRAPPER.test(raw));
+// Pre-filter for the redundant-literal rule below, keyed on `windowsHide`
+// rather than on `child_process`. Two reasons it cannot reuse `candidates`:
+// a file that has correctly moved to the wrapper no longer contains the string
+// `child_process` at all, and a file can reach a spawn through an intermediate
+// (`bufferedSpawn.js`, `detachedSpawn.js`, `execGit.js`) without naming either
+// module. Anything that mentions windowsHide is in scope; nothing else can
+// violate the rule.
+const hideMentions = allSources.filter(({ rel, raw }) => (
+  rel !== WRAPPER && !inCallSiteTree(rel) && raw.includes('windowsHide')
+));
+
+/**
+ * Call expressions in `raw` that pass a redundant `windowsHide: true`.
+ *
+ * Any callee, not just the child_process names: most spawns here are reached
+ * through a promisified local alias (`execAsync`, `execFileAsync`), which is
+ * exactly where several of the removed literals lived. Scoping to call
+ * ARGUMENTS is what leaves an options *builder* alone — `processEnv.js`'s
+ * `safeChildProcessOptions` returns an object rather than passing one to a
+ * spawn, and states `windowsHide` on purpose.
+ * @param {string} raw
+ * @returns {{name: string, text: string, line: number}[]}
+ */
+function redundantHideCalls(raw) {
+  const hits = callExpressions(blankComments(raw), null)
+    .filter((call) => /windowsHide\s*:\s*true/.test(call.text));
+  // A nested match also reports every call wrapping it, so keep the innermost
+  // one — that is the line someone has to edit.
+  return hits.filter((hit) => !hits.some((inner) => (
+    inner.text.length < hit.text.length && hit.text.includes(inner.text)
+  )));
+}
 
 describe('comment blanking', () => {
   // Every rule below filters through blankComments, so a stripper that blanked
@@ -180,35 +204,33 @@ describe('child_process import guard', () => {
     ).toEqual([]);
   });
 
+  it('detects a redundant literal without flagging an options builder', () => {
+    // The rule below expects an EMPTY list, so it would pass just as green if
+    // the detector matched nothing at all. Pin the detector on fixtures first.
+    expect(redundantHideCalls("spawn('git', args, { cwd, windowsHide: true });").map((c) => c.name))
+      .toEqual(['spawn']);
+    // Reached through a promisified alias, which is where several of the
+    // removed literals actually lived.
+    expect(redundantHideCalls("await execAsync(cmd, { windowsHide: true });").map((c) => c.name))
+      .toEqual(['execAsync']);
+    // Only the innermost call, not every call wrapping it.
+    expect(redundantHideCalls("new Promise(() => { spawn('git', { windowsHide: true }); });").map((c) => c.name))
+      .toEqual(['spawn']);
+    // An options BUILDER states windowsHide deliberately — it is not a call
+    // argument, so it stays (processEnv.js's safeChildProcessOptions).
+    expect(redundantHideCalls('function opts(o) {\n  return { ...o, windowsHide: true };\n}')).toEqual([]);
+    // An explicit opt-out is a decision, not a redundant restatement.
+    expect(redundantHideCalls("spawn('code', ['.'], { windowsHide: false });")).toEqual([]);
+  });
+
   it('drops the redundant windowsHide literal wherever the wrapper supplies it', () => {
-    // The inverse of the rule above, and the reason #4315 existed: the v1.5.x /
-    // v1.6.7 per-call-site sweeps left ~85 `windowsHide: true` literals behind,
-    // and once the wrapper injects the identical value they are two competing
-    // conventions in one file — the loud one being the one a newcomer copies.
-    // Any callee, not just the child_process names: most spawns here are reached
-    // through a promisified local alias (`execAsync`, `execFileAsync`), which is
-    // exactly where several of those literals lived.
-    //
-    // Scoped to call ARGUMENTS, which is what leaves `processEnv.js`'s
-    // `safeChildProcessOptions` alone — it authors a canonical options object
-    // rather than passing one to a spawn, and states `windowsHide` on purpose.
-    expect(wrapperImporters.length, 'no wrapper importers found — has the scan broken?').toBeGreaterThan(40);
-
-    const hits = [];
-    for (const { rel, raw } of wrapperImporters) {
-      for (const call of callExpressions(blankComments(raw), null)) {
-        if (/windowsHide\s*:\s*true/.test(call.text)) hits.push({ rel, ...call });
-      }
-    }
-
-    // `names: null` matches nested calls too, so the literal inside
-    // `spawn(…)` also reports the `new Promise(…)` wrapping it. Keep only the
-    // innermost call holding each literal, so the list points at the fix.
-    const offenders = hits
-      .filter((hit) => !hits.some((inner) => (
-        inner.rel === hit.rel && inner.text.length < hit.text.length && hit.text.includes(inner.text)
-      )))
-      .map(({ rel, line, name }) => `${rel}:${line} ${name}(…)`);
+    // The inverse of the import rule above, and the reason #4315 existed: the
+    // v1.5.x / v1.6.7 per-call-site sweeps left 85 `windowsHide: true` literals
+    // behind, and once the wrapper injects the identical value they are two
+    // competing conventions in one file — the loud one being what gets copied.
+    const offenders = hideMentions.flatMap(({ rel, raw }) => (
+      redundantHideCalls(raw).map(({ line, name }) => `${rel}:${line} ${name}(…)`)
+    ));
 
     expect(
       offenders,

--- a/server/lib/childProcess.guards.test.js
+++ b/server/lib/childProcess.guards.test.js
@@ -102,6 +102,16 @@ const parsed = new Map(candidates.map(({ rel, raw }) => [rel, blankComments(raw)
 
 const inCallSiteTree = (rel) => CALL_SITE_TREES.some((t) => rel.startsWith(t));
 
+// A separate pre-filter for the redundant-literal rule below. The `candidates`
+// set above keys on the string `child_process`, which a file that has correctly
+// moved to the wrapper no longer contains — so reusing it there would scan
+// exactly the files the rule does not apply to and pass green forever.
+const IMPORTS_WRAPPER = /['"][^'"]*childProcess\.js['"]/;
+const wrapperImporters = allFiles
+  .filter((rel) => rel !== WRAPPER && !inCallSiteTree(rel))
+  .map((rel) => ({ rel, raw: readServerSource(rel) }))
+  .filter(({ raw }) => IMPORTS_WRAPPER.test(raw));
+
 describe('comment blanking', () => {
   // Every rule below filters through blankComments, so a stripper that blanked
   // too much would silently turn all of them into no-ops.
@@ -167,6 +177,43 @@ describe('child_process import guard', () => {
       'These files import child_process directly, so their spawns default to a\n' +
         'visible console on Windows. Import from server/lib/childProcess.js instead:\n' +
         offenders.map((f) => `  - ${f}`).join('\n')
+    ).toEqual([]);
+  });
+
+  it('drops the redundant windowsHide literal wherever the wrapper supplies it', () => {
+    // The inverse of the rule above, and the reason #4315 existed: the v1.5.x /
+    // v1.6.7 per-call-site sweeps left ~85 `windowsHide: true` literals behind,
+    // and once the wrapper injects the identical value they are two competing
+    // conventions in one file — the loud one being the one a newcomer copies.
+    // Any callee, not just the child_process names: most spawns here are reached
+    // through a promisified local alias (`execAsync`, `execFileAsync`), which is
+    // exactly where several of those literals lived.
+    //
+    // Scoped to call ARGUMENTS, which is what leaves `processEnv.js`'s
+    // `safeChildProcessOptions` alone — it authors a canonical options object
+    // rather than passing one to a spawn, and states `windowsHide` on purpose.
+    expect(wrapperImporters.length, 'no wrapper importers found — has the scan broken?').toBeGreaterThan(40);
+
+    const hits = [];
+    for (const { rel, raw } of wrapperImporters) {
+      for (const call of callExpressions(blankComments(raw), null)) {
+        if (/windowsHide\s*:\s*true/.test(call.text)) hits.push({ rel, ...call });
+      }
+    }
+
+    // `names: null` matches nested calls too, so the literal inside
+    // `spawn(…)` also reports the `new Promise(…)` wrapping it. Keep only the
+    // innermost call holding each literal, so the list points at the fix.
+    const offenders = hits
+      .filter((hit) => !hits.some((inner) => (
+        inner.rel === hit.rel && inner.text.length < hit.text.length && hit.text.includes(inner.text)
+      )))
+      .map(({ rel, line, name }) => `${rel}:${line} ${name}(…)`);
+
+    expect(
+      offenders,
+      'The wrapper already defaults windowsHide: true — drop the literal:\n' +
+        offenders.map((o) => `  - ${o}`).join('\n')
     ).toEqual([]);
   });
 

--- a/server/lib/cliProviderRun.js
+++ b/server/lib/cliProviderRun.js
@@ -131,7 +131,6 @@ export function runCliProviderPrompt(args = {}) {
       cwd: effectiveCwd,
       stdio: ['pipe', 'pipe', 'pipe'],
       env: childEnv,
-      windowsHide: true,
     });
 
     // Single settlement gate — the timer, spawn error, and close handler all

--- a/server/lib/cudaCapability.js
+++ b/server/lib/cudaCapability.js
@@ -86,7 +86,7 @@ export async function detectCudaGpus({ execFileImpl = execFile, timeoutMs = 8000
     execFileImpl(
       'nvidia-smi',
       [...NVIDIA_SMI_QUERY_ARGS],
-      { timeout: timeoutMs, windowsHide: true },
+      { timeout: timeoutMs },
       (err, stdout) => resolve({ err, stdout: String(stdout ?? '') }),
     );
   }).catch((err) => ({ err, stdout: '' }));

--- a/server/lib/cudaCapability.test.js
+++ b/server/lib/cudaCapability.test.js
@@ -58,7 +58,7 @@ describe('detectCudaGpus', () => {
     expect(execFileImpl).toHaveBeenCalledWith(
       'nvidia-smi',
       [...NVIDIA_SMI_QUERY_ARGS],
-      expect.objectContaining({ windowsHide: true }),
+      expect.objectContaining({ timeout: expect.any(Number) }),
       expect.any(Function),
     );
     expect(result).toMatchObject({ status: 'available', maxVramGb: 40 });

--- a/server/lib/detachedSpawn.js
+++ b/server/lib/detachedSpawn.js
@@ -247,7 +247,7 @@ export async function spawnDetached(bin, args = [], {
   // is a POSIX-only guarantee; Windows keeps its prior spawn semantics apart
   // from `kill`, which is replaced with a tree-kill below.
   if (process.platform === 'win32') {
-    const child = spawn(bin, args, { env: withSpawnCwdEnv(env ?? process.env, cwd), cwd, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
+    const child = spawn(bin, args, { env: withSpawnCwdEnv(env ?? process.env, cwd), cwd, stdio: ['ignore', 'pipe', 'pipe'] });
     // A bare `child.kill()` terminates ONLY the runner. Windows has no process
     // group for the POSIX `-pid` trick `killProcessGroup` relies on, so whatever
     // the runner spawned (the ffmpeg mux a CUDA video runtime shells out to, a
@@ -355,7 +355,6 @@ export async function spawnDetached(bin, args = [], {
     // Pin PWD to the spawn cwd — see withSpawnCwdEnv (#3193).
     env: withSpawnCwdEnv(env ?? process.env, cwd),
     cwd,
-    windowsHide: true,
     detached: true,
     stdio: 'ignore',
   });

--- a/server/lib/execGit.js
+++ b/server/lib/execGit.js
@@ -24,8 +24,7 @@ export function execGit(args, cwd, options = {}) {
     // platforms (including Windows) without a shell wrapper.
     const child = spawn('git', args, {
       cwd,
-      shell: false,
-      windowsHide: true
+      shell: false
     });
 
     let stdout = '';

--- a/server/lib/execGit.test.js
+++ b/server/lib/execGit.test.js
@@ -34,8 +34,7 @@ describe('execGit', () => {
     await promise;
     expect(spawn).toHaveBeenCalledWith('git', ['status'], expect.objectContaining({
       cwd: '/repo',
-      shell: false,
-      windowsHide: true
+      shell: false
     }));
   });
 

--- a/server/lib/icloudFile.js
+++ b/server/lib/icloudFile.js
@@ -324,7 +324,7 @@ export function requestMaterialization(path, options = {}) {
   // is still correctly refused either way.
   let child;
   try {
-    child = spawn('brctl', ['download', path], { detached: true, stdio: 'ignore', windowsHide: true });
+    child = spawn('brctl', ['download', path], { detached: true, stdio: 'ignore' });
     child.unref();
   } catch (err) {
     // Nothing was reserved yet — the slot is claimed below, after a successful

--- a/server/lib/memoryStats.js
+++ b/server/lib/memoryStats.js
@@ -24,7 +24,7 @@ function fallback() {
 }
 
 async function macMemory() {
-  const { stdout } = await execAsync('vm_stat', { windowsHide: true, timeout: 5000 });
+  const { stdout } = await execAsync('vm_stat', { timeout: 5000 });
   const pageSizeMatch = stdout.match(/page size of (\d+) bytes/);
   const pageSize = pageSizeMatch ? parseInt(pageSizeMatch[1], 10) : 16384;
 

--- a/server/lib/openFolder.js
+++ b/server/lib/openFolder.js
@@ -31,7 +31,7 @@ export function openFolderInSystemExplorer(localPath) {
     args = [localPath];
   }
 
-  const child = spawn(cmd, args, { detached: true, stdio: 'ignore', windowsHide: true });
+  const child = spawn(cmd, args, { detached: true, stdio: 'ignore' });
   child.on('error', (err) => {
     console.error(`❌ openFolderInSystemExplorer spawn failed (${cmd}): ${err.message}`);
   });

--- a/server/lib/planIds.js
+++ b/server/lib/planIds.js
@@ -234,8 +234,7 @@ export function listOpenPullRequestHeadRefs(repoPath) {
   return new Promise(resolve => {
     const child = spawn('gh', ['pr', 'list', '--state', 'open', '--json', 'headRefName', '-q', '.[].headRefName'], {
       cwd: repoPath,
-      shell: false,
-      windowsHide: true
+      shell: false
     });
     let out = '';
     let settled = false;

--- a/server/lib/platform.js
+++ b/server/lib/platform.js
@@ -91,7 +91,7 @@ function portProbeFor(targetPlatform) {
 export async function getListeningPorts({ platform: targetPlatform = platform, exec: run = execAsync } = {}) {
   const command = portProbeFor(targetPlatform);
   try {
-    const { stdout } = await run(command, { windowsHide: true });
+    const { stdout } = await run(command);
     return parseListeningPorts(stdout, targetPlatform);
   } catch (cause) {
     const error = new Error(`Unable to discover listening ports with ${command}: ${cause.message}`);

--- a/server/lib/platform.test.js
+++ b/server/lib/platform.test.js
@@ -44,7 +44,7 @@ describe('platform module', () => {
         .mockRejectedValueOnce(new Error('ss: command not found'))
 
       await expect(getListeningPorts({ platform: 'linux', exec })).resolves.toEqual([6000])
-      expect(exec).toHaveBeenCalledWith('ss -lntp', { windowsHide: true })
+      expect(exec).toHaveBeenCalledWith('ss -lntp')
       await expect(getListeningPorts({ platform: 'linux', exec })).rejects.toMatchObject({
         code: 'PORT_DISCOVERY_FAILED',
         command: 'ss -lntp',

--- a/server/lib/testHelper.js
+++ b/server/lib/testHelper.js
@@ -313,7 +313,7 @@ export function resolveTestPython() {
 
   return candidates.find((candidate) => {
     try {
-      execFileSync(candidate, ['-c', 'pass'], { stdio: 'ignore', windowsHide: true });
+      execFileSync(candidate, ['-c', 'pass'], { stdio: 'ignore' });
       return true;
     } catch {
       return false;

--- a/server/routes/apps/launch.js
+++ b/server/routes/apps/launch.js
@@ -28,7 +28,6 @@ function spawnDetached(cmd, args, options = {}) {
   const child = spawn(cmd, args, {
     detached: true,
     stdio: 'ignore',
-    windowsHide: true,
     ...options
   });
   child.on('error', (err) => console.error(`❌ Failed to launch '${cmd}': ${err.message}`));

--- a/server/routes/database.js
+++ b/server/routes/database.js
@@ -25,7 +25,7 @@ const router = Router();
  */
 function runCmd(cmd, args, timeout = 120_000, env = process.env) {
   return new Promise((resolve) => {
-    execFile(cmd, args, { cwd: rootDir, timeout, env, windowsHide: true }, (err, stdout, stderr) => {
+    execFile(cmd, args, { cwd: rootDir, timeout, env }, (err, stdout, stderr) => {
       const exitCode = err ? (typeof err.code === 'number' ? err.code : 1) : 0;
       if (exitCode !== 0) {
         const detail = stripAnsi(stderr || stdout || err.message || '').replace(/\s+/g, ' ').trim();
@@ -321,7 +321,7 @@ export function importDumpFile(dumpFile, port, env, timeout = 120_000) {
     const psql = spawn('psql', [
       '-h', 'localhost', '-p', String(port), '-U', pgUser, '-d', pgDb,
       '-v', 'ON_ERROR_STOP=1', '--single-transaction'
-    ], { cwd: rootDir, env, windowsHide: true });
+    ], { cwd: rootDir, env });
 
     // The dump read stream — declared up front so finish() can tear it down. If
     // psql exits early (ON_ERROR_STOP rollback) or the timeout SIGKILLs it, the

--- a/server/routes/detect.js
+++ b/server/routes/detect.js
@@ -190,7 +190,7 @@ router.post('/port', asyncHandler(async (req, res) => {
     ? `lsof -i :${safePort} -P -n | grep LISTEN`
     : `ss -lntp | grep :${safePort}`;
 
-  const { stdout } = await execAsync(command, { windowsHide: true }).catch(() => ({ stdout: '' }));
+  const { stdout } = await execAsync(command).catch(() => ({ stdout: '' }));
 
   if (stdout.trim()) {
     result.inUse = true;

--- a/server/routes/scaffold.js
+++ b/server/routes/scaffold.js
@@ -436,7 +436,7 @@ module.exports = {
   // Run npm install (skip for Xcode projects — no npm)
   if (template !== 'ios-native' && template !== 'xcode-multiplatform') {
     const installCmd = template === 'portos-stack' ? 'npm run install:all' : 'npm install';
-    const { stderr: installErr } = await execAsync(installCmd, { cwd: repoPath, windowsHide: true })
+    const { stderr: installErr } = await execAsync(installCmd, { cwd: repoPath })
       .catch(err => ({ stderr: err.message }));
 
     if (installErr && !installErr.includes('npm warn')) {
@@ -447,7 +447,7 @@ module.exports = {
   }
 
   // Initialize git
-  await execAsync('git init', { cwd: repoPath, windowsHide: true });
+  await execAsync('git init', { cwd: repoPath });
 
   // Create .gitignore
   let gitignoreContent;
@@ -510,7 +510,7 @@ Thumbs.db
   await writeFile(join(repoPath, '.gitignore'), gitignoreContent);
   // Use spawn with shell:false to avoid shell injection
   const spawnGit = (args) => new Promise((resolve, reject) => {
-    const proc = spawn('git', args, { cwd: repoPath, shell: false, windowsHide: true });
+    const proc = spawn('git', args, { cwd: repoPath, shell: false });
     let stderr = '';
     proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
     proc.on('close', (code) => code === 0 ? resolve() : reject(new Error(`git ${args[0]} failed: ${stderr.trim()}`)));
@@ -527,7 +527,7 @@ Thumbs.db
     const ghArgs = ['repo', 'create', repoName, '--source=.', '--push', '--private'];
 
     const { stderr: ghErr } = await new Promise((resolve) => {
-      const child = spawn('gh', ghArgs, { cwd: repoPath, shell: false, windowsHide: true });
+      const child = spawn('gh', ghArgs, { cwd: repoPath, shell: false });
       let stderr = '';
       child.stderr.on('data', (data) => { stderr += data.toString(); });
       child.on('close', () => resolve({ stderr }));

--- a/server/routes/scaffoldIOS.js
+++ b/server/routes/scaffoldIOS.js
@@ -309,7 +309,7 @@ echo "🧹 Cleaned build artifacts"
 `;
   await writeFile(join(repoPath, 'deploy.sh'), deployScript);
   // Make deploy.sh executable
-  await execAsync(`chmod +x "${join(repoPath, 'deploy.sh')}"`, { windowsHide: true });
+  await execAsync(`chmod +x "${join(repoPath, 'deploy.sh')}"`);
 
   // CLAUDE.md
   await writeFile(join(repoPath, 'CLAUDE.md'), `# ${name}
@@ -353,7 +353,7 @@ Requires \`.env\` file with App Store Connect API credentials (see \`.env.exampl
   addStep('Create iOS project', 'done');
 
   // Run xcodegen if available
-  const { stderr: xgenErr } = await execAsync('xcodegen generate', { cwd: repoPath, windowsHide: true })
+  const { stderr: xgenErr } = await execAsync('xcodegen generate', { cwd: repoPath })
     .catch(err => ({ stderr: err.message }));
 
   if (xgenErr && !xgenErr.includes('Created project')) {

--- a/server/routes/scaffoldVite.js
+++ b/server/routes/scaffoldVite.js
@@ -20,8 +20,7 @@ export async function scaffoldVite({ repoPath, dirName, parentDir, template, uiP
   const { stderr } = await new Promise((resolve) => {
     const child = spawn('npm', ['create', 'vite@latest', dirName, '--', '--template', 'react'], {
       cwd: parentDir,
-      shell: process.platform === 'win32',
-      windowsHide: true
+      shell: process.platform === 'win32'
     });
     let stderr = '';
     child.stderr.on('data', (data) => { stderr += data.toString(); });

--- a/server/routes/scaffoldXcode.js
+++ b/server/routes/scaffoldXcode.js
@@ -447,7 +447,7 @@ Screenshots are saved to \`screenshots/{locale}/{device}/\` for upload to App St
   addStep('Create multi-platform Xcode project', 'done');
 
   // Run xcodegen if available
-  const { stderr: xgenErr } = await execAsync('xcodegen generate', { cwd: repoPath, windowsHide: true })
+  const { stderr: xgenErr } = await execAsync('xcodegen generate', { cwd: repoPath })
     .catch(err => ({ stderr: err.message }));
 
   if (xgenErr && !xgenErr.includes('Created project')) {

--- a/server/services/agentCliSpawning.js
+++ b/server/services/agentCliSpawning.js
@@ -385,7 +385,6 @@ export async function spawnDirectly({
     cwd,
     shell: false,
     stdio: ['pipe', 'pipe', 'pipe'],
-    windowsHide: true,
     env: childEnv
   });
 

--- a/server/services/agentManagement.js
+++ b/server/services/agentManagement.js
@@ -666,7 +666,7 @@ export async function getAgentProcessStats(agentId) {
     const psCmd = process.platform === 'win32'
       ? `tasklist /FI "PID eq ${agent.pid}" /FO CSV /NH`
       : `ps -p ${agent.pid} -o pid=,pcpu=,rss=,state=`;
-    const result = await execAsync(psCmd, { windowsHide: true }).catch(() => ({ stdout: '' }));
+    const result = await execAsync(psCmd).catch(() => ({ stdout: '' }));
     const line = result.stdout.trim();
 
     if (!line) {

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -231,7 +231,7 @@ function shellHasLiveChild(shellPid) {
   return new Promise((resolve) => {
     // `-Ao ppid=` is POSIX (all processes, ppid column only, no header) and
     // works on both macOS (BSD ps) and Linux (procps).
-    execFile('ps', ['-Ao', 'ppid='], { timeout: 2000, windowsHide: true }, (err, stdout) => {
+    execFile('ps', ['-Ao', 'ppid='], { timeout: 2000 }, (err, stdout) => {
       if (err) { resolve(true); return; }
       resolve(stdout.split('\n').some((line) => parseInt(line, 10) === shellPid));
     });

--- a/server/services/agents.js
+++ b/server/services/agents.js
@@ -128,7 +128,7 @@ async function findUnixProcesses(pattern) {
   // Security: Pattern is validated above to only contain safe characters
   const cmd = `ps -ww -eo pid,ppid,%cpu,%mem,etime,command | grep -i "${safePattern}" | grep -v grep`;
 
-  const result = await execAsync(cmd, { maxBuffer: 10 * 1024 * 1024, windowsHide: true }).catch(() => ({ stdout: '' }));
+  const result = await execAsync(cmd, { maxBuffer: 10 * 1024 * 1024 }).catch(() => ({ stdout: '' }));
 
   const lines = result.stdout.trim().split('\n').filter(Boolean);
   const processes = [];
@@ -203,7 +203,7 @@ async function findWindowsProcesses(pattern) {
   const result = await execFileAsync(
     'powershell',
     ['-NoProfile', '-NonInteractive', '-Command', script],
-    { windowsHide: true, maxBuffer: 8 * 1024 * 1024 },
+    { maxBuffer: 8 * 1024 * 1024 },
   ).catch((err) => {
     // Keep the empty-result behavior (the caller treats [] as "none running"),
     // but never again fail SILENTLY — a broken process probe is why this was
@@ -351,9 +351,9 @@ export async function killProcess(pid) {
   const platform = process.platform;
 
   if (platform === 'win32') {
-    await execAsync(`taskkill /PID ${safePid} /F`, { windowsHide: true });
+    await execAsync(`taskkill /PID ${safePid} /F`);
   } else {
-    await execAsync(`kill -9 ${safePid}`, { windowsHide: true });
+    await execAsync(`kill -9 ${safePid}`);
   }
 
   console.log(`🔪 Killed process ${safePid}`);
@@ -374,7 +374,7 @@ export async function getProcessInfo(pid) {
 
   if (platform === 'darwin' || platform === 'linux') {
     const cmd = `ps -ww -p ${safePid} -o pid,ppid,%cpu,%mem,etime,command`;
-    const result = await execAsync(cmd, { windowsHide: true }).catch(() => null);
+    const result = await execAsync(cmd).catch(() => null);
     if (!result) return null;
 
     const lines = result.stdout.trim().split('\n');

--- a/server/services/appDeployer.js
+++ b/server/services/appDeployer.js
@@ -69,7 +69,6 @@ export function deployApp(app, flags, emit) {
     const child = spawn(resolveBashBinary(), ['deploy.sh', ...safeFlags], {
       cwd: dir,
       shell: false,
-      windowsHide: true,
       env: { ...process.env, FORCE_COLOR: '0' }
     });
 

--- a/server/services/askService.js
+++ b/server/services/askService.js
@@ -624,7 +624,6 @@ async function* streamCompletion(provider, model, prompt, signal) {
       env: childEnv,
       stdio: ['pipe', 'pipe', 'pipe'],
       shell: false,
-      windowsHide: true,
     });
 
     // Single settlement gate — the timer, the abort listener, and the close

--- a/server/services/autonomousJobs/execution.js
+++ b/server/services/autonomousJobs/execution.js
@@ -87,8 +87,7 @@ async function executeShellJob(job) {
     const child = spawn(spawnCommand, spawnArgs, {
       cwd: PATHS.root,
       env: childEnv,
-      shell: false,
-      windowsHide: true
+      shell: false
     })
 
     const timer = setTimeout(() => {

--- a/server/services/autonomousJobs/execution.shellSpawn.test.js
+++ b/server/services/autonomousJobs/execution.shellSpawn.test.js
@@ -52,7 +52,6 @@ describe('executeShellJob — Windows CLI shim resolution', () => {
     await executeShellJob({ id: 'job-1', name: 'System Health Check', command: 'pm2 jlist' })
     const [, , opts] = spawnMock.mock.calls[0]
     expect(opts.shell).toBe(false)
-    expect(opts.windowsHide).toBe(true)
   })
 
   it('resolves the command against the CHILD env, not process.env', async () => {

--- a/server/services/autonomousJobs/scriptHandlers.js
+++ b/server/services/autonomousJobs/scriptHandlers.js
@@ -29,7 +29,6 @@ function runMoltworldExploration() {
     const child = spawn('node', [scriptPath, durationMinutes], {
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env },
-      windowsHide: true,
     })
 
     const output = []

--- a/server/services/autonomousJobs/selfDiagnostics.js
+++ b/server/services/autonomousJobs/selfDiagnostics.js
@@ -159,7 +159,6 @@ function runCli(cmd, args, options = {}) {
     // caller (mirrors layeredIntelligence/runCli.js, which has the same shape).
     const child = spawn(cmd, args, {
       shell: false,
-      windowsHide: true,
       ...options,
       env: withSpawnCwdEnv(options.env ?? process.env, options.cwd),
     })

--- a/server/services/backup.js
+++ b/server/services/backup.js
@@ -125,7 +125,7 @@ export function resolveRsyncBinary(env = process.env) {
 function runRsync(srcDir, destDir, flags = []) {
   return new Promise((resolve, reject) => {
     const args = ['--archive', '--itemize-changes', ...flags, srcDir + '/', destDir];
-    const proc = spawn(resolveRsyncBinary(), args, { shell: false, windowsHide: true });
+    const proc = spawn(resolveRsyncBinary(), args, { shell: false });
 
     const changed = [];
     let stderr = '';
@@ -342,7 +342,6 @@ export async function dumpPostgres(outputPath) {
       '-f', outputPath
     ], {
       shell: false,
-      windowsHide: true,
       env: { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'portos' }
     });
 
@@ -593,7 +592,7 @@ export async function restorePostgres(destPath, snapshotId, { dryRun = true } = 
       '-v', 'ON_ERROR_STOP=1',
       '--single-transaction',
       '-h', pgHost, '-p', pgPort, '-U', pgUser, '-d', pgDb, '-f', sqlPath
-    ], { shell: false, windowsHide: true, env: { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'portos' } });
+    ], { shell: false, env: { ...process.env, PGPASSWORD: process.env.PGPASSWORD || 'portos' } });
 
     let stderr = '';
     proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });

--- a/server/services/backup.test.js
+++ b/server/services/backup.test.js
@@ -837,7 +837,7 @@ describe('restoreSnapshot subdirFilter guard', () => {
       expect(spawn).toHaveBeenCalledWith(
         '/custom/bin/rsync',
         expect.arrayContaining(['--archive', '--itemize-changes', '--dry-run']),
-        { shell: false, windowsHide: true },
+        { shell: false },
       );
     } finally {
       if (previous === undefined) delete process.env.PORTOS_RSYNC;
@@ -858,7 +858,7 @@ describe('restoreSnapshot subdirFilter guard', () => {
       await restore;
 
       expect(spawn.mock.calls[0][0]).toBe('rsync');
-      expect(spawn.mock.calls[0][2]).toEqual({ shell: false, windowsHide: true });
+      expect(spawn.mock.calls[0][2]).toEqual({ shell: false });
     } finally {
       if (previous === undefined) delete process.env.PORTOS_RSYNC;
       else process.env.PORTOS_RSYNC = previous;
@@ -1238,7 +1238,7 @@ describe('runBackup lifecycle', () => {
     // --- rsync invocation -------------------------------------------------
     const [bin, args, opts] = spawn.mock.calls[0];
     expect(bin).toBe('rsync');
-    expect(opts).toEqual({ shell: false, windowsHide: true });
+    expect(opts).toEqual({ shell: false });
     expect(args.slice(0, 2)).toEqual(['--archive', '--itemize-changes']);
     // Source is PATHS.data with a trailing slash (copy contents, not the dir);
     // destination is the snapshot's data/ subdir.

--- a/server/services/claudeCodeUsage.js
+++ b/server/services/claudeCodeUsage.js
@@ -217,7 +217,7 @@ function runUsageCli() {
   return new Promise((resolve, reject) => {
     const tz = systemTimeZone();
     const env = tz ? { ...process.env, TZ: tz } : process.env;
-    const child = spawn(CLI_COMMAND, CLI_ARGS, { stdio: ['pipe', 'pipe', 'pipe'], env, windowsHide: true });
+    const child = spawn(CLI_COMMAND, CLI_ARGS, { stdio: ['pipe', 'pipe', 'pipe'], env });
     let stdout = '';
     let stderr = '';
     let settled = false;

--- a/server/services/commands.js
+++ b/server/services/commands.js
@@ -46,8 +46,7 @@ export function executeCommand(command, workspacePath, onData, onComplete) {
   const child = spawn(baseCommand, args, {
     cwd: commandCwd,
     env: withSpawnCwdEnv(safeChildProcessEnv({ FORCE_COLOR: '1' }), commandCwd),
-    shell: false,
-    windowsHide: true
+    shell: false
   });
 
   activeCommands.set(commandId, child);

--- a/server/services/dataManager.js
+++ b/server/services/dataManager.js
@@ -168,10 +168,10 @@ const SAFE_NAME = /^[a-z0-9_-]+$/;
 async function getDirSizeAndCount(dirPath) {
   if (!existsSync(dirPath)) return { size: 0, fileCount: 0 };
   const [duOut, findOut] = await Promise.all([
-    execFileAsync('du', ['-sk', dirPath], { windowsHide: true, timeout: 30000 })
+    execFileAsync('du', ['-sk', dirPath], { timeout: 30000 })
       .then(r => r.stdout.trim())
       .catch(() => '0'),
-    execFileAsync('find', [dirPath, '-type', 'f'], { windowsHide: true, timeout: 30000 })
+    execFileAsync('find', [dirPath, '-type', 'f'], { timeout: 30000 })
       .then(r => r.stdout.trim().split('\n').filter(Boolean).length)
       .catch(() => 0)
   ]);
@@ -277,7 +277,7 @@ export async function archiveCategory(categoryKey, options = {}) {
     // Write file list to temp file to avoid shell argument limits
     const listPath = join(backupDir, `.filelist-${Date.now()}.txt`);
     await fsWriteFile(listPath, oldFiles.join('\n'));
-    await execFileAsync('tar', ['-czf', archivePath, '-C', dirPath, '-T', listPath], { timeout: 120000, windowsHide: true });
+    await execFileAsync('tar', ['-czf', archivePath, '-C', dirPath, '-T', listPath], { timeout: 120000 });
     await rm(listPath).catch(() => {});
 
     for (const f of oldFiles) {
@@ -289,7 +289,7 @@ export async function archiveCategory(categoryKey, options = {}) {
   }
 
   // Generic: archive entire category contents
-  await execFileAsync('tar', ['-czf', archivePath, '-C', DATA_DIR, categoryKey], { timeout: 120000, windowsHide: true });
+  await execFileAsync('tar', ['-czf', archivePath, '-C', DATA_DIR, categoryKey], { timeout: 120000 });
   const archiveStat = await stat(archivePath).catch(() => null);
 
   return {

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -308,7 +308,7 @@ export async function checkout(dir, branchName) {
 
 function spawnCli(cmd, args, options = {}) {
   return new Promise((resolve) => {
-    const child = spawn(cmd, args, { shell: false, windowsHide: true, ...options });
+    const child = spawn(cmd, args, { shell: false, ...options });
     let stdout = '', stderr = '';
     child.stdout.on('data', (d) => { stdout += d.toString(); });
     child.stderr.on('data', (d) => { stderr += d.toString(); });
@@ -437,7 +437,7 @@ export async function createPR(dir, { title, body, base, head }) {
   const meta = { cli, account, owner, host };
 
   return new Promise((resolve) => {
-    const child = spawn(cli, args, { cwd: dir, env, shell: false, windowsHide: true });
+    const child = spawn(cli, args, { cwd: dir, env, shell: false });
 
     let stdout = '';
     let stderr = '';
@@ -481,7 +481,7 @@ export async function mergePR(dir, prNumber) {
 
   return new Promise((resolve) => {
     const child = spawn('gh', ['pr', 'merge', String(prNumber), '--merge', '--delete-branch'], {
-      cwd: dir, env, shell: false, windowsHide: true
+      cwd: dir, env, shell: false
     });
     let stderr = '';
     child.stderr.on('data', (data) => { stderr += data.toString(); });
@@ -540,7 +540,7 @@ export async function requestCopilotReview(dir, prUrl) {
   );
 
   return new Promise((resolve) => {
-    const child = spawn(cli, args, { cwd: dir, env, shell: false, windowsHide: true });
+    const child = spawn(cli, args, { cwd: dir, env, shell: false });
     let stderr = '';
     child.stderr.on('data', (data) => { stderr += data.toString(); });
     child.on('close', (code) => {

--- a/server/services/github.js
+++ b/server/services/github.js
@@ -51,7 +51,6 @@ export function execGh(args, timeoutMs = DEFAULT_EXEC_GH_TIMEOUT_MS, { cwd = nul
     const baseEnv = env || process.env;
     const child = spawn('gh', args, {
       shell: false,
-      windowsHide: true,
       ...(cwd ? { cwd, env: withSpawnCwdEnv(baseEnv, cwd) } : (env ? { env } : {}))
     });
     let stdout = '';
@@ -260,8 +259,7 @@ export async function syncSecretToRepos(name) {
 function syncOneSecret(name, value, fullName) {
   return new Promise((resolve) => {
     const child = spawn('gh', ['secret', 'set', name, '--repo', fullName], {
-      shell: false,
-      windowsHide: true
+      shell: false
     });
     let stderr = '';
     child.stderr.on('data', (d) => { stderr += d.toString(); });
@@ -448,7 +446,7 @@ function probeGh(timeoutMs, hostname) {
     // targets github.com regardless of cwd, so an enterprise repo would be
     // gated on a host it never talks to.
     const args = hostname ? ['api', 'rate_limit', '--hostname', hostname] : ['api', 'rate_limit'];
-    const child = spawn('gh', args, { shell: false, windowsHide: true });
+    const child = spawn('gh', args, { shell: false });
     let stderr = '';
     let settled = false;
     const done = (result) => { if (!settled) { settled = true; clearTimeout(timer); resolve(result); } };

--- a/server/services/githubCloner.js
+++ b/server/services/githubCloner.js
@@ -84,8 +84,7 @@ export async function cloneRepo(url, options = {}) {
   return new Promise((resolve, reject) => {
     const child = spawn('git', args, {
       env: process.env,
-      shell: false,
-      windowsHide: true
+      shell: false
     });
 
     let stderr = '';
@@ -136,8 +135,7 @@ export async function pullRepo(localPath) {
     const child = spawn('git', ['pull', '--ff-only'], {
       cwd: localPath,
       env: process.env,
-      shell: false,
-      windowsHide: true
+      shell: false
     });
 
     let stdout = '';
@@ -183,8 +181,7 @@ export async function getRepoInfo(localPath) {
     const child = spawn('git', ['log', '-1', '--format=%H|%s|%ci'], {
       cwd: localPath,
       env: process.env,
-      shell: false,
-      windowsHide: true
+      shell: false
     });
 
     let stdout = '';

--- a/server/services/gitlab.js
+++ b/server/services/gitlab.js
@@ -23,7 +23,7 @@ const DEFAULT_EXEC_GLAB_TIMEOUT_MS = 60000;
  */
 export function execGlab(args, cwd, timeoutMs = DEFAULT_EXEC_GLAB_TIMEOUT_MS) {
   return new Promise((resolve) => {
-    const child = spawn('glab', args, { cwd, shell: false, windowsHide: true });
+    const child = spawn('glab', args, { cwd, shell: false });
     let stdout = '';
     let settled = false;
     // One settle path so the timeout can't resolve a promise `close` already

--- a/server/services/imageGen/agy.js
+++ b/server/services/imageGen/agy.js
@@ -110,7 +110,7 @@ export function listModels({ agyPath } = {}) {
   const bin = agyPath || DEFAULT_BIN;
   const { command, args } = prepareCliSpawn(bin, ['models']);
   return new Promise((resolve) => {
-    const proc = spawn(command, args, { shell: false, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
+    const proc = spawn(command, args, { shell: false, stdio: ['pipe', 'pipe', 'pipe'] });
     let stdout = '';
     let stderr = '';
     let settled = false;
@@ -312,7 +312,7 @@ async function runAgy(job, jobId, bin, args, {
   // Pin PWD to the spawn cwd — see withSpawnCwdEnv (#3193). agy reads
   // process.cwd(), so this is defensive rather than a live fix; it keeps every
   // scratch-dir spawn telling the child one consistent story about where it is.
-  const proc = spawn(command, spawnArgs, { cwd: scratchDir, env: withSpawnCwdEnv(process.env, scratchDir), shell: false, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
+  const proc = spawn(command, spawnArgs, { cwd: scratchDir, env: withSpawnCwdEnv(process.env, scratchDir), shell: false, stdio: ['ignore', 'pipe', 'pipe'] });
   activeProcs.set(jobId, proc);
   const removeScratch = () => rm(scratchDir, { recursive: true, force: true }).catch(() => {});
   let stdoutTail = '';

--- a/server/services/imageGen/codex.js
+++ b/server/services/imageGen/codex.js
@@ -121,7 +121,7 @@ export async function checkConnection({ codexPath } = {}) {
   // (which would consume the user's Codex quota); the settings UI just wants
   // "yes the binary exists and is reachable".
   const bin = codexPath || DEFAULT_BIN;
-  const proc = spawn(bin, ['--version'], { shell: false, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
+  const proc = spawn(bin, ['--version'], { shell: false, stdio: ['ignore', 'pipe', 'pipe'] });
   let out = '';
   proc.stdout.on('data', (c) => { out += c.toString(); });
   proc.stderr.on('data', (c) => { out += c.toString(); });
@@ -305,7 +305,7 @@ export const noImageReason = (stdoutTail = '') => buildNoImageReason(stdoutTail,
 });
 
 async function runCodex(job, jobId, bin, args, outputPath, filename, meta, { cleanC2PA = false, denoise = false } = {}) {
-  const proc = spawn(bin, args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true });
+  const proc = spawn(bin, args, { shell: false, stdio: ['ignore', 'pipe', 'pipe'] });
   activeProcs.set(jobId, proc);
 
   let sessionId = null;

--- a/server/services/imageGen/grok.js
+++ b/server/services/imageGen/grok.js
@@ -313,7 +313,7 @@ async function runGrok(job, jobId, bin, args, {
   // Pin PWD to the spawn cwd — see withSpawnCwdEnv (#3193). grok reads
   // process.cwd(), so this is defensive rather than a live fix; it keeps every
   // scratch-dir spawn telling the child one consistent story about where it is.
-  const proc = spawn(spawnBin, spawnArgs, { cwd: scratchDir, env: withSpawnCwdEnv(process.env, scratchDir), shell: false, stdio: [useStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'], windowsHide: true });
+  const proc = spawn(spawnBin, spawnArgs, { cwd: scratchDir, env: withSpawnCwdEnv(process.env, scratchDir), shell: false, stdio: [useStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'] });
   activeProcs.set(jobId, proc);
   const removeScratch = () => rm(scratchDir, { recursive: true, force: true }).catch(() => {});
 

--- a/server/services/layeredIntelligence/runCli.js
+++ b/server/services/layeredIntelligence/runCli.js
@@ -15,7 +15,6 @@ export function runCli(cmd, args, options = {}) {
     // every caller's behalf rather than each one remembering it.
     const child = spawn(cmd, args, {
       shell: false,
-      windowsHide: true,
       ...options,
       env: withSpawnCwdEnv(options.env ?? process.env, options.cwd),
     });

--- a/server/services/localLlm.js
+++ b/server/services/localLlm.js
@@ -224,7 +224,7 @@ const manager = (backend) => (backend === 'ollama' ? ollamaManager : lmStudioMan
  */
 function runStreaming(cmd, args, onLine, timeoutMs = 0) {
   return new Promise((resolve) => {
-    const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true })
+    const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] })
     let buffer = ''
     let settled = false
     const tail = [] // recent non-empty lines, capped by char budget for the error message

--- a/server/services/loraTraining/displayPower.js
+++ b/server/services/loraTraining/displayPower.js
@@ -30,7 +30,7 @@ export function isDisplaySleepEnabled(settings) {
 // can't block or outlive its purpose; errors are swallowed (telemetry-grade,
 // never fatal to a training run).
 function runPowerCmd(cmd, args) {
-  const proc = spawn(cmd, args, { stdio: 'ignore', windowsHide: true });
+  const proc = spawn(cmd, args, { stdio: 'ignore' });
   proc.on('error', () => {}); // command missing / not permitted → ignore
   proc.unref();
   return proc;

--- a/server/services/loraTraining/index.js
+++ b/server/services/loraTraining/index.js
@@ -682,7 +682,7 @@ export async function runTraining({ jobId, runId, pythonPath = null, resumeCheck
   // protection doesn't wait on the OS idle timeout. Best-effort — caffeinate
   // exits with the child.
   if (platform() === 'darwin' && proc.pid) {
-    const caf = spawn('caffeinate', ['-is', '-w', String(proc.pid)], { stdio: 'ignore', windowsHide: true });
+    const caf = spawn('caffeinate', ['-is', '-w', String(proc.pid)], { stdio: 'ignore' });
     caf.on('error', () => {});
     caf.unref();
   }

--- a/server/services/ollamaManager.js
+++ b/server/services/ollamaManager.js
@@ -243,7 +243,6 @@ async function startServer() {
   const child = spawn('ollama', ['serve'], {
     detached: true,
     stdio: ['ignore', 'ignore', 'pipe'],
-    windowsHide: true,
     env: process.env
   })
   rememberManagedProcess(child)

--- a/server/services/perpetualWork.js
+++ b/server/services/perpetualWork.js
@@ -56,7 +56,7 @@ export const WORK_ITEM_LIMIT = 50;
 function runCli(cmd, args, cwd) {
   return new Promise((resolve) => {
     let stdout = '', stderr = '', settled = false;
-    const child = spawn(cmd, args, { cwd, shell: false, windowsHide: true });
+    const child = spawn(cmd, args, { cwd, shell: false });
     const done = (result) => { if (!settled) { settled = true; clearTimeout(timer); resolve(result); } };
     child.stdout.on('data', (d) => { stdout += d.toString(); });
     child.stderr.on('data', (d) => { stderr += d.toString(); });

--- a/server/services/pm2Standardizer.js
+++ b/server/services/pm2Standardizer.js
@@ -452,7 +452,7 @@ export async function createGitBackup(repoPath) {
   }
 
   // Refuse to overwrite uncommitted changes
-  const { stdout: statusOut } = await execAsync('git status --porcelain', { cwd: repoPath, windowsHide: true });
+  const { stdout: statusOut } = await execAsync('git status --porcelain', { cwd: repoPath });
   if (statusOut.trim()) {
     return { success: false, code: 'DIRTY_WORKTREE', reason: 'Working tree has uncommitted changes — commit or discard them before standardizing' };
   }
@@ -463,7 +463,7 @@ export async function createGitBackup(repoPath) {
   // Create backup branch from current HEAD (captures committed state without stashing)
   // Use spawn with shell:false to avoid shell injection via branch name
   await new Promise((resolve, reject) => {
-    const proc = spawn('git', ['branch', branch], { cwd: repoPath, shell: false, windowsHide: true });
+    const proc = spawn('git', ['branch', branch], { cwd: repoPath, shell: false });
     let stderr = '';
     proc.stderr.on('data', (chunk) => { stderr += chunk.toString(); });
     proc.on('close', (code) => code === 0 ? resolve() : reject(new Error(`git branch failed: ${stderr.trim()}`)));

--- a/server/services/runner.js
+++ b/server/services/runner.js
@@ -303,8 +303,7 @@ export async function executeCliRun({ runId, provider, prompt, workspacePath, on
 
   childProcess = spawn(spawnCommand, spawnArgs, {
     cwd: effectiveCwd,
-    env: childEnv,
-    windowsHide: true
+    env: childEnv
   });
 
   // Pass prompt via stdin to avoid OS argv limits. When grok is delivered via a

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -89,7 +89,6 @@ export async function executeUpdate(tag, emit, { forceCleanWorkspaces } = {}) {
     ? spawn(cmd, args, {
         detached: true,
         stdio: ['ignore', 'pipe', 'pipe'],
-        windowsHide: true,
         cwd: PATHS.root,
         env: childEnv
       })

--- a/server/services/videoGen/grok.js
+++ b/server/services/videoGen/grok.js
@@ -200,7 +200,7 @@ async function runGrokVideo(job, jobId, bin, args, {
   // Pin PWD to the spawn cwd — see withSpawnCwdEnv (#3193). grok reads
   // process.cwd(), so this is defensive rather than a live fix; it keeps every
   // scratch-dir spawn telling the child one consistent story about where it is.
-  const proc = spawn(spawnBin, spawnArgs, { cwd: scratchDir, env: withSpawnCwdEnv(process.env, scratchDir), shell: false, stdio: [useStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'], windowsHide: true });
+  const proc = spawn(spawnBin, spawnArgs, { cwd: scratchDir, env: withSpawnCwdEnv(process.env, scratchDir), shell: false, stdio: [useStdin ? 'pipe' : 'ignore', 'pipe', 'pipe'] });
   activeProcs.set(jobId, proc);
   const removeScratch = () => rm(scratchDir, { recursive: true, force: true }).catch(() => {});
   // The route stages a multipart source image into data/uploads and hands us

--- a/server/services/visionCli.js
+++ b/server/services/visionCli.js
@@ -243,7 +243,6 @@ async function runCliVisionSpawn({ provider, model, invocation, timeout, spawnIm
     const child = spawnImpl(spawnCommand, spawnArgs, {
       cwd,
       env: childEnv,
-      windowsHide: true,
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     let out = '';


### PR DESCRIPTION
## Summary

`server/lib/childProcess.js` defaults `windowsHide: true` on every spawn and all server runtime code imports it, so the literals the v1.5.x and v1.6.7 sweeps left at individual call sites say nothing the wrapper isn't already saying. Leaving them isn't a bug, but it leaves two conventions in the source — the loud per-call-site one and the structural one — and the loud one is what the next author copies.

- **85 literals removed across 52 files** (`lib/`, `routes/`, `services/`, `cos-runner/`), every one of which already imports the wrapper. Where an options object existed only to carry `windowsHide`, the argument goes too rather than being left as `{}`.
- **`childProcess.guards.test.js` gains the inverse of its import rule**, so a literal can't creep back into a wrapper-importing file. Scoped to call *arguments*, and deduped to the innermost call so the failure message points at the actual fix.
- Seven test assertions that pinned `windowsHide` in spawn call args are dropped — the wrapper's own `childProcess.test.js` already covers the default.

**Untouched, and not leftovers:**

| Kept | Why |
|---|---|
| `services/pm2.js` `app.windowsHide` / `windowsHide: IS_WIN`, `ecosystem.config.cjs` | PM2 ecosystem *app-definition* fields, not spawn options |
| `lib/processEnv.js` `safeChildProcessOptions` | Authors a canonical options object rather than passing one to a spawn, and states `windowsHide` on purpose |
| `lib/aiToolkit/`, `autofixer/`, `browser/` | Cannot import the wrapper; the existing per-call-site guard still *requires* the literal there |

No behavior change: the wrapper supplies the same value the literals did, and it already honors an explicit caller value.

### Two things worth review attention

1. **The new guard needed its own pre-filter.** The existing `candidates` set keys on the string `child_process`, which a file that has correctly moved to the wrapper no longer contains. Reusing it would have scanned only the files the rule does not apply to and passed green forever — verified by probe: with `candidates`, a reintroduced literal in `execGit.js` did *not* fail the suite; with the wrapper-importer filter it reports `lib/execGit.js:25 spawn(…)`.
2. **`cos-runner/processStats.test.js` mocked `exec` with a fixed `(cmd, opts, cb)` signature.** Dropping the options argument shifts the callback into the options slot under `promisify`, so the mock never called back. It is now variadic like node's own `exec` — the mock was pinned to whether the caller happened to pass options, which is not part of the contract.

## Test plan

- `cd server && NODE_ENV=test npm test` — **1418 files / 29k tests pass**. The one failing file, `routes/health.test.js` (2 cases), fails identically on a clean tree at the same base (verified by stashing this branch's changes and re-running) and is unrelated.
- The issue's acceptance grep returns only the two excluded categories:
  ```
  grep -rn "windowsHide" server/ --include='*.js' \
    | grep -v "\.test\.js" | grep -v "lib/childProcess.js" | grep -v aiToolkit \
    | grep -v "windowsHide: IS_WIN"
  → server/lib/processEnv.js:31,34 and server/services/pm2.js:670-672 only
  ```
- Guard bypass probe: reintroducing `windowsHide: true` into `server/lib/execGit.js` fails the new rule with `lib/execGit.js:25 spawn(…)`; removing it passes again.

Closes #4315
