### PR TITLE
Add page-level provider/model/effort picker for app Issues claims

### DIFF
--- a/client/src/components/apps/tabs/IssuesTab.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.jsx
@@ -1,17 +1,26 @@
 import { useState, useEffect, useCallback, useMemo, useId, useRef } from 'react';
 import { Link } from 'react-router';
 import {
-  AlertTriangle, ChevronDown, ChevronRight, CircleDot, ExternalLink,
+  AlertTriangle, Bot, ChevronDown, ChevronRight, CircleDot, ExternalLink,
   Loader2, RefreshCw, Rocket, Search, User
 } from 'lucide-react';
 import BrailleSpinner from '../../BrailleSpinner';
 import Banner from '../../ui/Banner';
 import Pill from '../../ui/Pill';
 import toast from '../../ui/Toast';
+import ProviderModelSelector from '../../ProviderModelSelector';
+import useProviderModels from '../../../hooks/useProviderModels';
+import { isProcessProvider } from '../../../utils/providers';
 import * as api from '../../../services/api';
 import { timeAgo } from '../../../utils/formatters';
 
 const FORGE_LABEL = { github: 'GitHub', gitlab: 'GitLab' };
+
+// Module-scoped so `useProviderModels` sees a stable predicate — an inline
+// arrow would be a new identity every render, re-firing the hook's fetch
+// effect forever. Matches SlashDoRunDrawer's filter: only CODING providers
+// (CLI/TUI agents with a file-writing harness) can run a `/do:next` claim.
+const enabledProcessProviderFilter = (p) => Boolean(p?.enabled) && isProcessProvider(p);
 
 // Why the forge returned nothing, in the user's terms. Sentinel-aware: a
 // definitive "no open issues" and a failed probe are different sentences, so an
@@ -74,6 +83,17 @@ export default function IssuesTab({ appId, appName }) {
   // response lands last and shows one app's issues under another's Claim buttons.
   const requestRef = useRef(0);
 
+  // Page-level provider/model/effort pin for every Claim button on this tab —
+  // left untouched (blank), a claim resolves the app's own configured default,
+  // same as the bare button always did. This picker never persists across a
+  // reload; it's a session convenience for "claim the next several issues with
+  // model X" without reopening the Agent Operations drawer each time.
+  const {
+    providers, selectedProviderId, selectedModel, availableModels,
+    setSelectedProviderId, setSelectedModel
+  } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, silent: true, withEffort: true });
+  const [effort, setEffort] = useState('');
+
   const load = useCallback(async () => {
     const generation = requestRef.current + 1;
     requestRef.current = generation;
@@ -125,7 +145,12 @@ export default function IssuesTab({ appId, appName }) {
 
   const handleClaim = async (issue) => {
     setClaims(prev => ({ ...prev, [issue.number]: 'queuing' }));
-    const result = await api.createSlashdoTask('next', appId, { target: String(issue.number) }, { silent: true })
+    const result = await api.createSlashdoTask('next', appId, {
+      target: String(issue.number),
+      provider: selectedProviderId || undefined,
+      model: selectedModel || undefined,
+      effort: effort || undefined,
+    }, { silent: true })
       .catch(err => {
         toast.error(err?.message || `Failed to queue a claim for #${issue.number}`);
         return null;
@@ -180,6 +205,28 @@ export default function IssuesTab({ appId, appName }) {
         >
           <RefreshCw size={14} className={loading ? 'animate-spin' : ''} /> Refresh
         </button>
+      </div>
+
+      <div className="flex flex-col sm:flex-row sm:items-center gap-2 px-3 py-2 bg-port-card border border-port-border rounded-lg">
+        <span className="flex items-center gap-1.5 text-xs text-gray-500 uppercase tracking-wide shrink-0">
+          <Bot size={14} /> Claim with
+        </span>
+        <div className="flex-1">
+          <ProviderModelSelector
+            providers={providers}
+            selectedProviderId={selectedProviderId}
+            selectedModel={selectedModel}
+            availableModels={availableModels}
+            onProviderChange={(id) => { setSelectedProviderId(id); setEffort(''); }}
+            onModelChange={setSelectedModel}
+            effort={effort}
+            onEffortChange={setEffort}
+            emptyProviderOption="Auto (app default)"
+            emptyModelOption="Default model"
+            compact
+            highlightToolUse
+          />
+        </div>
       </div>
 
       {error && (

--- a/client/src/components/apps/tabs/IssuesTab.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.jsx
@@ -84,10 +84,13 @@ export default function IssuesTab({ appId, appName }) {
   const requestRef = useRef(0);
 
   // Page-level provider/model/effort pin for every Claim button on this tab —
-  // left untouched (blank), a claim resolves the app's own configured default,
-  // same as the bare button always did. This picker never persists across a
-  // reload; it's a session convenience for "claim the next several issues with
-  // model X" without reopening the Agent Operations drawer each time.
+  // left untouched (blank), a claim resolves the install's active provider,
+  // same as the bare button always did (POST /tasks/slashdo -> resolveAgentProviderAndModel;
+  // this manual path does NOT consult the app's scheduled claim-work override —
+  // that's a separate resolution used only by the automated claim-work task).
+  // This picker never persists across a reload; it's a session convenience for
+  // "claim the next several issues with model X" without reopening the Agent
+  // Operations drawer each time.
   const {
     providers, selectedProviderId, selectedModel, availableModels,
     setSelectedProviderId, setSelectedModel
@@ -221,7 +224,7 @@ export default function IssuesTab({ appId, appName }) {
             onModelChange={setSelectedModel}
             effort={effort}
             onEffortChange={setEffort}
-            emptyProviderOption="Auto (app default)"
+            emptyProviderOption="Auto (default)"
             emptyModelOption="Default model"
             compact
             highlightToolUse

--- a/client/src/components/apps/tabs/IssuesTab.test.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.test.jsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router';
 vi.mock('../../../services/api', () => ({
   getAppIssues: vi.fn(),
   createSlashdoTask: vi.fn(),
+  getProviders: vi.fn(),
 }));
 
 import * as api from '../../../services/api';
@@ -42,6 +43,7 @@ const renderTab = () => render(
 beforeEach(() => {
   api.getAppIssues.mockResolvedValue(okPayload([ISSUE]));
   api.createSlashdoTask.mockResolvedValue({ id: 'task-1' });
+  api.getProviders.mockResolvedValue({ providers: [] });
 });
 
 afterEach(() => {
@@ -83,6 +85,28 @@ describe('IssuesTab', () => {
       'next', 'app-1', { target: '42' }, { silent: true }
     ));
     expect(await screen.findByRole('link', { name: /Queued/ })).toBeInTheDocument();
+  });
+
+  it('sends the page-level provider/model/effort pin along with a claim', async () => {
+    api.getProviders.mockResolvedValue({
+      providers: [{
+        id: 'claude', name: 'Claude', type: 'cli', enabled: true,
+        models: ['claude-opus-5', 'claude-sonnet-5'], defaultModel: 'claude-sonnet-5',
+      }],
+    });
+    renderTab();
+
+    await screen.findByText('Crash on save');
+    fireEvent.change(await screen.findByLabelText('Provider'), { target: { value: 'claude' } });
+    fireEvent.change(screen.getByLabelText('Model'), { target: { value: 'claude-opus-5' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Claim/ }));
+
+    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenCalledWith(
+      'next', 'app-1',
+      { target: '42', provider: 'claude', model: 'claude-opus-5', effort: undefined },
+      { silent: true }
+    ));
   });
 
   it('re-enables the Claim button when queuing fails, instead of stranding it', async () => {


### PR DESCRIPTION
## Summary
- Add a "Claim with" provider/model/thinking-effort picker above the issue list on an app's Issues tab, reusing the existing `ProviderModelSelector` + `useProviderModels` hook (same pattern as the Agent Operations run drawer).
- Left on "Auto (default)" a claim behaves exactly as before (the install's active provider). Pinning a provider/model/effort applies it to every `Claim` click on that tab for the session, without reopening the run drawer each time.
- Fixed a review finding: the initial label ("Auto (app default)") overclaimed that a blank selection resolves an app-specific default. It actually resolves the install's globally active provider (`resolveAgentProviderAndModel`) — a separate mechanism from the app's scheduled claim-work override. Relabeled to match `SlashDoRunDrawer`'s existing "Auto (default)" wording.

## Test plan
- [x] `cd client && npx vitest run src/components/apps/tabs/IssuesTab.test.jsx` (10/10 passing, including a new test asserting the pin flows through to `createSlashdoTask`)
- [x] Full client suite: 651 files / 7956 tests passing
- [x] `npm run lint --prefix client`
- [x] Manual verification in the dev browser against `/apps/portos-default/issues`: picking a provider correctly revealed its Model and Thinking Effort selects
- [x] Local review passes (claude, codex) — clean