### PR TITLE
fix a11y guard: an apostrophe in JSX text no longer hides a labeled control

### DIFF
--- a/.changelog/next/fixed-issue-4318.md
+++ b/.changelog/next/fixed-issue-4318.md
@@ -1,0 +1,1 @@
+- a11y guard: an apostrophe in JSX text no longer hides a labeled control from the accessible-name scan

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -113,19 +113,112 @@ function balancedCallAt(src, openIndex, skipStrings = true) {
 
 // --- helpers for the icon-only-button-name and 44px-close-target rules ---
 
+// Whether `src[index]` (a `<`) opens a JSX tag rather than a less-than, and
+// which tag it opens. Shared by `matchingBraceEnd` and `maskComments`, which
+// have to draw the JavaScript/JSX line in exactly the same place.
+const jsxTagInfoAt = (src, index) => {
+  const closing = src.startsWith('</', index);
+  const fragment = src.startsWith('<>', index) || src.startsWith('</>', index);
+  const name = src.slice(index + (closing ? 2 : 1)).match(/^([A-Za-z][\w.-]*)/)?.[1] || null;
+  return { closing, fragment, name };
+};
+
+const looksLikeJsxTagStart = (src, index) => {
+  const next = src[index + 1];
+  if (!(next === '/' || next === '>' || /[A-Za-z]/.test(next || ''))) return false;
+  let previous = index - 1;
+  while (previous >= 0 && /\s/.test(src[previous])) previous--;
+  if (previous < 0 || '=([{,:;!?&|>'.includes(src[previous])) return true;
+  return /(?:return|yield|=>)\s*$/.test(src.slice(Math.max(0, index - 12), index));
+};
+
+// In JSX element text, `<` only opens a tag when a name, `/`, or `>` follows.
+const opensJsxTagInText = (src, index) => src[index] === '<'
+  && (src[index + 1] === '/' || /[A-Za-z>]/.test(src[index + 1] || ''));
+
 // Find the index of the `}` matching the `{` at `s[idx]`, respecting nested
-// braces and quoted/template strings.
+// braces, quoted/template strings, and JSX.
+//
+// A quote delimits a string only in JavaScript-expression context. In JSX
+// element *text* an apostrophe is an ordinary character — `<option>Use the
+// provider's default</option>` — and reading it as a string opener swallows
+// every brace after it, so the helper returns -1 and whatever recognizer sits
+// on top of it silently sees nothing (#4318). `maskComments` separates the two
+// contexts for the same reason; this walk mirrors its mode machine and adds
+// the brace accounting the mask has no use for.
 function matchingBraceEnd(s, idx) {
   let depth = 0;
+  let mode = 'code';
+  // The tag being read, `{ closing, parentMode }`, whenever `mode` is
+  // 'jsx-tag' — `parentMode` is where a self-closing tag hands back to.
+  let tag = null;
+  // The state to resume when each open brace closes: an attribute expression
+  // returns to the tag holding it, a child expression to the element's text.
+  // The half-read tag rides along, because an attribute expression can itself
+  // hold a whole element (`label={<span>…</span>}`) whose own `>` would
+  // otherwise be mistaken for the end of the outer tag.
+  const braceFrames = [];
+  // One entry per open element, marking whether it was opened from JavaScript.
+  // Its closing tag hands back there rather than to an enclosing element's text.
+  const jsxStack = [];
+
+  const skipString = (from) => {
+    let i = from + 1;
+    for (; i < s.length && s[i] !== s[from]; i++) if (s[i] === '\\') i++;
+    return i;
+  };
+
+  const openBrace = () => {
+    braceFrames.push({ mode, tag });
+    depth++;
+    mode = 'code';
+    tag = null;
+  };
+
+  const openTag = (at, parentMode) => {
+    tag = { closing: jsxTagInfoAt(s, at).closing, parentMode };
+    mode = 'jsx-tag';
+  };
+
   for (let i = idx; i < s.length; i++) {
     const c = s[i];
-    if (c === '"' || c === '\'' || c === '`') {
-      const q = c;
-      for (i++; i < s.length && s[i] !== q; i++) if (s[i] === '\\') i++;
+
+    if (mode === 'jsx-text') {
+      if (c === '{') openBrace();
+      else if (opensJsxTagInText(s, i)) openTag(i, 'jsx-text');
       continue;
     }
-    if (c === '{') depth++;
-    else if (c === '}') { depth--; if (depth === 0) return i; }
+
+    if (mode === 'jsx-tag') {
+      if (c === '"' || c === '\'' || c === '`') { i = skipString(i); continue; }
+      if (c === '{') { openBrace(); continue; }
+      if (c !== '>') continue;
+      let back = i - 1;
+      while (back > idx && /\s/.test(s[back])) back--;
+      if (tag.closing) {
+        const entry = jsxStack.pop();
+        mode = entry?.root ? 'code' : (jsxStack.length ? 'jsx-text' : 'code');
+      } else if (s[back] === '/') {
+        mode = tag.parentMode;
+      } else {
+        jsxStack.push({ root: tag.parentMode === 'code' });
+        mode = 'jsx-text';
+      }
+      tag = null;
+      continue;
+    }
+
+    if (c === '"' || c === '\'' || c === '`') { i = skipString(i); continue; }
+    if (c === '{') { openBrace(); continue; }
+    if (c === '}') {
+      depth--;
+      if (depth === 0) return i;
+      const frame = braceFrames.pop();
+      mode = frame?.mode ?? 'code';
+      tag = frame?.tag ?? null;
+      continue;
+    }
+    if (c === '<' && looksLikeJsxTagStart(s, i)) openTag(i, 'code');
   }
   return -1;
 }
@@ -326,22 +419,6 @@ function maskComments(src) {
   // less-than, never pops, and strands the rest of the file in `jsx-text`.
   const jsxStack = [];
 
-  const jsxTagInfoAt = (index) => {
-    const closing = src.startsWith('</', index);
-    const fragment = src.startsWith('<>', index) || src.startsWith('</>', index);
-    const name = src.slice(index + (closing ? 2 : 1)).match(/^([A-Za-z][\w.-]*)/)?.[1] || null;
-    return { closing, fragment, name };
-  };
-
-  const looksLikeJsxTagStart = (index) => {
-    const next = src[index + 1];
-    if (!(next === '/' || next === '>' || /[A-Za-z]/.test(next || ''))) return false;
-    let previous = index - 1;
-    while (previous >= 0 && /\s/.test(src[previous])) previous--;
-    if (previous < 0 || '=([{,:;!?&|>'.includes(src[previous])) return true;
-    return /(?:return|yield|=>)\s*$/.test(src.slice(Math.max(0, index - 12), index));
-  };
-
   for (let i = 0; i < chars.length; i++) {
     const c = chars[i];
 
@@ -369,8 +446,8 @@ function maskComments(src) {
       if (c === '{') {
         mode = 'code';
         braceDepth = 1;
-      } else if (c === '<' && (src[i + 1] === '/' || /[A-Za-z>]/.test(src[i + 1] || ''))) {
-        tagInfo = jsxTagInfoAt(i);
+      } else if (opensJsxTagInText(src, i)) {
+        tagInfo = jsxTagInfoAt(src, i);
         tagParentMode = 'jsx-text';
         tagBraceDepth = 0;
         mode = 'jsx-tag';
@@ -447,8 +524,8 @@ function maskComments(src) {
       if (braceDepth === 0) mode = 'jsx-text';
       continue;
     }
-    if (c === '<' && looksLikeJsxTagStart(i)) {
-      tagInfo = jsxTagInfoAt(i);
+    if (c === '<' && looksLikeJsxTagStart(src, i)) {
+      tagInfo = jsxTagInfoAt(src, i);
       tagParentMode = 'code';
       tagBraceDepth = 0;
       mode = 'jsx-tag';
@@ -1107,20 +1184,16 @@ function controlSourceAnchor(file, src, index, tagName) {
 
 // These are pre-existing controls exposed when the rule was generalized; the
 // migration is tracked in #4297. What is left is no longer a backlog of unnamed
-// controls — all three are shapes the scan cannot resolve, not gaps in the UI:
-//   * EntityCombobox / TagPicker take the control's `id` as a prop and every
-//     caller pairs its own `<label htmlFor>`, which lives in the caller's file.
-//     A same-file scan cannot see it, and an `aria-label` here would OVERRIDE
-//     the caller's visible label — a regression, not a fix. Tracked in #4321.
-//   * AIProviders' fallback-model input sits in a labeled `<FormField>` whose
-//     conditional child holds an apostrophe in JSX text; `matchingBraceEnd`
-//     reads it as a string opener and loses the expression bounds (#4318).
+// controls — both are one shape the scan cannot resolve, not a gap in the UI:
+// EntityCombobox / TagPicker take the control's `id` as a prop and every caller
+// pairs its own `<label htmlFor>`, which lives in the caller's file. A same-file
+// scan cannot see it, and an `aria-label` here would OVERRIDE the caller's
+// visible label — a regression, not a fix. Tracked in #4321.
 // So: do not "fix" these by bolting an aria-label onto the control. Fix the
 // recognizer, then delete the row.
 const PREEXISTING_INPUT_NAME_ALLOWLIST = new Set([
   "src/components/EntityCombobox.jsx|input|id=inputId|type=text|placeholder=placeholder || `Search ${noun}s or type a new name…`|value=value|role=combobox",
   "src/components/TagPicker.jsx|input|id=id|type=text|placeholder=value.length >= maxTags ? `Max ${maxTags} tags` : placeholder|value=input",
-  "src/pages/AIProviders.jsx|input|type=text|placeholder=Use fallback provider's default|value=formData.fallbackModel",
 ]);
 
 // The <select>/<textarea> half of the same rule, seeded when #4309 widened the
@@ -1248,7 +1321,6 @@ const PREEXISTING_SELECT_TEXTAREA_NAME_ALLOWLIST = new Set([
   "src/components/writers-room/StagePromptModelPicker.jsx|select|value=stage.model || 'default'",
   "src/components/writers-room/StoryboardConfigTab.jsx|select|value=value.presetId",
   "src/pages/AIProviders.jsx|select|value=activeProviderId || ''",
-  "src/pages/AIProviders.jsx|select|value=formData.fallbackModel",
   "src/pages/AIProviders.jsx|select|value=selectedWorkspace",
   "src/pages/AIProviders.jsx|textarea|placeholder=Enter your prompt...|value=runPrompt|rows=3",
   "src/pages/Ask.jsx|select|id=e.target.value;",
@@ -1683,6 +1755,32 @@ describe('a11y conventions', () => {
     // Same for a locally-declared `FormField` that is not a cloning wrapper.
     const shadowed = `function FormField({ label, children }) {\n  return <div>{label}{children}</div>;\n}\n${ternary.replace(/^import[^\n]*\n/, '')}`;
     expect(credits(shadowed)).toBe(false);
+  });
+
+  it('reads an apostrophe in JSX text as text, not a string opener (#4318)', () => {
+    // `matchingBraceEnd` used to treat `'` as a string delimiter everywhere. In
+    // JSX element text it is an ordinary character, so a brace expression
+    // containing one never found its closing brace: the helper returned -1 and
+    // every recognizer built on it — the conditional-child credit above, the
+    // component-body walk the wrapper registry runs on — silently saw nothing.
+    // This is the shape that left pages/AIProviders.jsx's fallback-model
+    // controls on the allowlists while their four identical siblings passed.
+    const field = (child) => `import FormField from '../ui/FormField';\n<FormField label="Fallback Model">\n  ${child}\n</FormField>`;
+
+    const apostrophe = field(`{opts.length > 0 ? (<select><option value="">Use the provider's default</option></select>) : (<input type="text" placeholder="Use the provider's default" />)}`);
+    expect(isNamed(apostrophe, 'select')).toBe(true);
+    expect(isNamed(apostrophe, 'input')).toBe(true);
+
+    // A quote in JavaScript-expression context is still a delimiter, so a `}`
+    // inside a string cannot pass for the expression's end — that would cut the
+    // scan short of the control and lose the credit the other way.
+    const braceInString = field(`{mode === 'a}b' ? (<select><option>a</option></select>) : (<input type="text" />)}`);
+    expect(isNamed(braceInString, 'select')).toBe(true);
+
+    // The fix widens what the scanner can READ, not what it credits: a rendered
+    // list is still vetoed once its bounds are legible.
+    const list = field(`{fields.map((f) => (<input key={f} type="text" placeholder="it's here" />))}`);
+    expect(isNamed(list, 'input')).toBe(false);
   });
 
   it('recognizes a wrapper wherever it is declared and however it names', () => {

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -85,6 +85,16 @@ function openingTagAt(src, index, nameLength) {
 
 const lineOf = (src, index) => src.slice(0, index).split('\n').length;
 
+// Index of the quote closing the string that opens at `src[from]`, honoring
+// backslash escapes. Every scanner in this file walks strings the same way, so
+// they share one loop; each lands on the closing quote and lets its own `for`
+// step past. An unterminated string returns `src.length`, ending the walk.
+function skipString(src, from) {
+  let i = from + 1;
+  for (; i < src.length && src[i] !== src[from]; i++) if (src[i] === '\\') i++;
+  return i;
+}
+
 /**
  * Slice a call's full argument list, `(` through its matching `)`, starting at
  * the opening paren. Skips over string and template literals so a `)` inside
@@ -95,7 +105,7 @@ function balancedCallAt(src, openIndex, skipStrings = true) {
   for (let i = openIndex; i < src.length; i++) {
     const c = src[i];
     if (skipStrings && (c === '\'' || c === '"' || c === '`')) {
-      for (i++; i < src.length && src[i] !== c; i++) if (src[i] === '\\') i++;
+      i = skipString(src, i);
       continue;
     }
     if (c === '(') depth++;
@@ -113,28 +123,22 @@ function balancedCallAt(src, openIndex, skipStrings = true) {
 
 // --- helpers for the icon-only-button-name and 44px-close-target rules ---
 
-// Whether `src[index]` (a `<`) opens a JSX tag rather than a less-than, and
-// which tag it opens. Shared by `matchingBraceEnd` and `maskComments`, which
-// have to draw the JavaScript/JSX line in exactly the same place.
-const jsxTagInfoAt = (src, index) => {
-  const closing = src.startsWith('</', index);
-  const fragment = src.startsWith('<>', index) || src.startsWith('</>', index);
-  const name = src.slice(index + (closing ? 2 : 1)).match(/^([A-Za-z][\w.-]*)/)?.[1] || null;
-  return { closing, fragment, name };
-};
+// A `<` opens a JSX tag, rather than being a less-than, when a name, `/`, or
+// `>` follows it. That is the whole test inside an element's text, where a
+// comparison cannot appear.
+const opensJsxTagInText = (src, index) => src[index] === '<'
+  && (src[index + 1] === '/' || /[A-Za-z>]/.test(src[index + 1] || ''));
 
+// In JavaScript the same `<` also has to sit where an expression may start.
+// Built on the text predicate so `matchingBraceEnd` and `maskComments` cannot
+// drift on where the JavaScript/JSX line falls — widening one widens both.
 const looksLikeJsxTagStart = (src, index) => {
-  const next = src[index + 1];
-  if (!(next === '/' || next === '>' || /[A-Za-z]/.test(next || ''))) return false;
+  if (!opensJsxTagInText(src, index)) return false;
   let previous = index - 1;
   while (previous >= 0 && /\s/.test(src[previous])) previous--;
   if (previous < 0 || '=([{,:;!?&|>'.includes(src[previous])) return true;
   return /(?:return|yield|=>)\s*$/.test(src.slice(Math.max(0, index - 12), index));
 };
-
-// In JSX element text, `<` only opens a tag when a name, `/`, or `>` follows.
-const opensJsxTagInText = (src, index) => src[index] === '<'
-  && (src[index + 1] === '/' || /[A-Za-z>]/.test(src[index + 1] || ''));
 
 // Find the index of the `}` matching the `{` at `s[idx]`, respecting nested
 // braces, quoted/template strings, and JSX.
@@ -147,36 +151,30 @@ const opensJsxTagInText = (src, index) => src[index] === '<'
 // contexts for the same reason; this walk mirrors its mode machine and adds
 // the brace accounting the mask has no use for.
 function matchingBraceEnd(s, idx) {
-  let depth = 0;
   let mode = 'code';
   // The tag being read, `{ closing, parentMode }`, whenever `mode` is
   // 'jsx-tag' — `parentMode` is where a self-closing tag hands back to.
   let tag = null;
-  // The state to resume when each open brace closes: an attribute expression
-  // returns to the tag holding it, a child expression to the element's text.
-  // The half-read tag rides along, because an attribute expression can itself
-  // hold a whole element (`label={<span>…</span>}`) whose own `>` would
-  // otherwise be mistaken for the end of the outer tag.
+  // One frame per open brace, holding the state to resume when it closes: an
+  // attribute expression returns to the tag holding it, a child expression to
+  // the element's text. The half-read tag rides along, because an attribute
+  // expression can itself hold a whole element (`label={<span>…</span>}`)
+  // whose own `>` would otherwise be mistaken for the end of the outer tag.
+  // The stack doubles as the brace depth, so there is no second counter to
+  // keep in step with it.
   const braceFrames = [];
   // One entry per open element, marking whether it was opened from JavaScript.
   // Its closing tag hands back there rather than to an enclosing element's text.
   const jsxStack = [];
 
-  const skipString = (from) => {
-    let i = from + 1;
-    for (; i < s.length && s[i] !== s[from]; i++) if (s[i] === '\\') i++;
-    return i;
-  };
-
   const openBrace = () => {
     braceFrames.push({ mode, tag });
-    depth++;
     mode = 'code';
     tag = null;
   };
 
   const openTag = (at, parentMode) => {
-    tag = { closing: jsxTagInfoAt(s, at).closing, parentMode };
+    tag = { closing: s.startsWith('</', at), parentMode };
     mode = 'jsx-tag';
   };
 
@@ -190,32 +188,36 @@ function matchingBraceEnd(s, idx) {
     }
 
     if (mode === 'jsx-tag') {
-      if (c === '"' || c === '\'' || c === '`') { i = skipString(i); continue; }
+      if (c === '"' || c === '\'' || c === '`') { i = skipString(s, i); continue; }
       if (c === '{') { openBrace(); continue; }
       if (c !== '>') continue;
-      let back = i - 1;
-      while (back > idx && /\s/.test(s[back])) back--;
       if (tag.closing) {
+        // A closing tag can outnumber the opens in a slice that starts mid-
+        // element, so the pop may come back empty — fall back to JavaScript.
         const entry = jsxStack.pop();
         mode = entry?.root ? 'code' : (jsxStack.length ? 'jsx-text' : 'code');
-      } else if (s[back] === '/') {
-        mode = tag.parentMode;
       } else {
-        jsxStack.push({ root: tag.parentMode === 'code' });
-        mode = 'jsx-text';
+        let back = i - 1;
+        while (back > idx && /\s/.test(s[back])) back--;
+        if (s[back] === '/') {
+          mode = tag.parentMode;
+        } else {
+          jsxStack.push({ root: tag.parentMode === 'code' });
+          mode = 'jsx-text';
+        }
       }
       tag = null;
       continue;
     }
 
-    if (c === '"' || c === '\'' || c === '`') { i = skipString(i); continue; }
+    if (c === '"' || c === '\'' || c === '`') { i = skipString(s, i); continue; }
     if (c === '{') { openBrace(); continue; }
     if (c === '}') {
-      depth--;
-      if (depth === 0) return i;
+      // The frame for the brace at `idx` is the last one out, so popping is
+      // only reached with a frame to pop.
       const frame = braceFrames.pop();
-      mode = frame?.mode ?? 'code';
-      tag = frame?.tag ?? null;
+      if (braceFrames.length === 0) return i;
+      ({ mode, tag } = frame);
       continue;
     }
     if (c === '<' && looksLikeJsxTagStart(s, i)) openTag(i, 'code');
@@ -233,8 +235,7 @@ function tagBoundaryAt(s, idx) {
     if (c === '{') depth++;
     else if (c === '}') depth--;
     else if ((c === '"' || c === '\'' || c === '`') && depth > 0) {
-      const q = c;
-      for (i++; i < s.length && s[i] !== q; i++) if (s[i] === '\\') i++;
+      i = skipString(s, i);
     } else if (c === '>' && depth === 0) {
       let back = i - 1;
       while (back > idx && /\s/.test(s[back])) back--;
@@ -419,6 +420,15 @@ function maskComments(src) {
   // less-than, never pops, and strands the rest of the file in `jsx-text`.
   const jsxStack = [];
 
+  // The mask is the only caller that needs the tag's identity as well as its
+  // direction — it stacks the name to decide what a `</…>` closes.
+  const jsxTagInfoAt = (index) => {
+    const closing = src.startsWith('</', index);
+    const fragment = src.startsWith('<>', index) || src.startsWith('</>', index);
+    const name = src.slice(index + (closing ? 2 : 1)).match(/^([A-Za-z][\w.-]*)/)?.[1] || null;
+    return { closing, fragment, name };
+  };
+
   for (let i = 0; i < chars.length; i++) {
     const c = chars[i];
 
@@ -447,7 +457,7 @@ function maskComments(src) {
         mode = 'code';
         braceDepth = 1;
       } else if (opensJsxTagInText(src, i)) {
-        tagInfo = jsxTagInfoAt(src, i);
+        tagInfo = jsxTagInfoAt(i);
         tagParentMode = 'jsx-text';
         tagBraceDepth = 0;
         mode = 'jsx-tag';
@@ -525,7 +535,7 @@ function maskComments(src) {
       continue;
     }
     if (c === '<' && looksLikeJsxTagStart(src, i)) {
-      tagInfo = jsxTagInfoAt(src, i);
+      tagInfo = jsxTagInfoAt(i);
       tagParentMode = 'code';
       tagBraceDepth = 0;
       mode = 'jsx-tag';
@@ -894,8 +904,7 @@ function stripJsxTags(source) {
       if (c === '{') depth++;
       else if (c === '}') depth--;
       else if (c === '"' || c === '\'' || c === '`') {
-        const quote = c;
-        for (i++; i < source.length && source[i] !== quote; i++) if (source[i] === '\\') i++;
+        i = skipString(source, i);
       } else if (c === '>' && depth === 0) break;
     }
     // An unterminated tag swallows the rest: nothing after it is text.
@@ -1777,10 +1786,11 @@ describe('a11y conventions', () => {
     const braceInString = field(`{mode === 'a}b' ? (<select><option>a</option></select>) : (<input type="text" />)}`);
     expect(isNamed(braceInString, 'select')).toBe(true);
 
-    // The fix widens what the scanner can READ, not what it credits: a rendered
-    // list is still vetoed once its bounds are legible.
-    const list = field(`{fields.map((f) => (<input key={f} type="text" placeholder="it's here" />))}`);
-    expect(isNamed(list, 'input')).toBe(false);
+    // The fix widens what the scanner can READ, not what it credits: with the
+    // apostrophe in element text — the position that used to blind the scan —
+    // the rendered-list veto still applies now that the bounds are legible.
+    const list = field(`{fields.map((f) => (<select key={f}><option>it's here</option></select>))}`);
+    expect(isNamed(list, 'select')).toBe(false);
   });
 
   it('recognizes a wrapper wherever it is declared and however it names', () => {


### PR DESCRIPTION
## Summary

`matchingBraceEnd()` in `client/src/a11yConventions.test.js` treated `'` as a string delimiter unconditionally. In JSX *text* an apostrophe is an ordinary character, so a brace expression containing one never found its closing brace and the helper returned `-1` — a silent false negative for every recognizer built on it, including `blockBodyAt` → `forEachLocalComponent`, which the wrapper registry walks to decide whether a component names its control.

The scan now tracks the same JavaScript-expression / JSX-text contexts `maskComments` already distinguishes for exactly this reason (its `jsxStack` carries a comment saying so), and the two share the tag-detection helpers (`jsxTagInfoAt`, `looksLikeJsxTagStart`, `opensJsxTagInText`) instead of each carrying a private copy. Quotes stay delimiters in JavaScript-expression and attribute context, so a `}` inside a string still cannot pass for the expression's end.

Both fallback-model controls in `pages/AIProviders.jsx` — the `<select>` and the `<input>` in the same ternary, whose `<option>` text reads `Use fallback provider's default` — are now correctly recognized as named by their `<FormField>`, so their rows come off the pre-existing allowlists:

- `PREEXISTING_INPUT_NAME_ALLOWLIST` — the `<input>` row named in the issue.
- `PREEXISTING_SELECT_TEXTAREA_NAME_ALLOWLIST` — the sibling `<select>` row, stranded by the same parse artifact. The stale-entry guard surfaced it as soon as the fix landed.

Both were parser artifacts, not real a11y gaps, so nothing unsafe was exempted and no control needed a new `aria-label`.

## Test plan

- New probe `reads an apostrophe in JSX text as text, not a string opener (#4318)` asserts all three directions: an apostrophe in element text no longer hides either branch's control; a `}` inside a JavaScript string still does not end the expression early; and the rendered-list veto still rejects a `.map()` once its bounds are legible.
- Verified the probe is not vacuous — reintroducing quote-skipping in `jsx-text` mode makes it fail (`expected false to be true`), and reverting makes it pass.
- `cd client && npx vitest run src/a11yConventions.test.js` — 21 passed, including both `keeps no stale … entries` guards with the two rows deleted.
- `cd client && npx vitest run` — 651 files / 7964 tests passed.
- `cd client && npm run lint` — clean.

Closes #4318


---

## Follow-up commit (`/simplify` pass)

Quality-only, no behavior change; suite re-verified green after each.

- Hoisted `skipString(src, from)` — the same escape-aware quote loop was written out four times (`balancedCallAt`, `tagBoundaryAt`, `stripJsxTags`, and the new `matchingBraceEnd`).
- Built `looksLikeJsxTagStart` on `opensJsxTagInText` instead of re-spelling its character class, so the two walkers cannot drift on where the JavaScript/JSX line falls — that drift is what caused #4318 in the first place.
- Dropped `matchingBraceEnd`'s `depth` counter (moved in lockstep with `braceFrames`, so the stack *is* the depth) and the dead `??` fallbacks on the popped frame. The sibling `jsxStack` pop really can come back empty and keeps its guard.
- Returned `jsxTagInfoAt` to a closure in `maskComments`, its only caller that reads the `name`/`fragment` fields.
- Moved the probe's list-veto apostrophe into JSX text, where it exercises the new mode machine — inside a quoted attribute it never reached the string scanner, so that assertion was decoration rather than coverage.

## Deferred

The altitude review found the same context-blindness still live in three *other* pre-existing scanners in this file (`openingTagAt`, `matchTernaryIcons`, `hasUsableElementText`), plus the missing comment states in `matchingBraceEnd` itself. All are false negatives, all are outside this diff, and each needs its own probe — filed as #4333 rather than expanded into this PR.
