### PR TITLE
refactor: fold the a11y guard's two wrapper-openness scanners into one (#4328)

### DIFF
--- a/.changelog/next/changed-issue-4328.md
+++ b/.changelog/next/changed-issue-4328.md
@@ -1,0 +1,1 @@
+- a11y guard: the implicit and cloned label-wrapper matchers share one 'which wrapper is open here' scanner

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -715,95 +715,119 @@ function isDirectElementInExpression(src, start, index) {
   return depth === 0;
 }
 
+// Which instances of `<Name>` are still open at `index`? Both ancestor-based
+// wrapper shapes need exactly this fact — `implicit` to read the wrapper's own
+// label prop, `cloned` to walk the wrapper's body — so it lives in one scanner
+// rather than two. Keeping every still-open instance (not just the outermost)
+// is what lets an inner `<Field label="…">` nested in an unlabeled outer one
+// name the control. `contentStart` is where that instance's children begin, for
+// callers that need to walk the body.
+function openWrapperInstancesAt(src, name, index) {
+  const re = new RegExp(`</?${name}\\b`, 'g');
+  const open = [];
+  let match;
+  while ((match = re.exec(src)) && match.index < index) {
+    if (match[0].startsWith('</')) {
+      open.pop();
+      continue;
+    }
+    const tag = openingTagAt(src, match.index, name.length + 1);
+    if (!tag) continue;
+    re.lastIndex = match.index + tag.length;
+    if (/\/\s*>$/.test(tag)) continue;
+    open.push({ tag, contentStart: match.index + tag.length });
+  }
+  return open;
+}
+
+// Is the control at `index` the FIRST direct child of the wrapper whose body
+// starts at `contentStart`? A cloning wrapper clones its id onto its first
+// React child only, so a later control (DataDog's optional custom-site input)
+// must remain actionable. The walk has to survive every JSX shape that can
+// legitimately precede or contain the control inside a wrapper body: whitespace
+// and text nodes, `{expr}` children, fragments, and self-closing tags.
+function isFirstDirectChild(src, contentStart, index) {
+  let depth = 0;
+  let firstChild = null;
+  let cursor = contentStart;
+  while (cursor < index) {
+    if (/\s/.test(src[cursor])) {
+      cursor++;
+      continue;
+    }
+    if (src[cursor] === '{') {
+      const end = matchingBraceEnd(src, cursor);
+      if (end === -1) return false;
+      if (end >= index) {
+        // The control lives inside this expression rather than after it.
+        return depth === 0 && firstChild === null && isDirectElementInExpression(src, cursor + 1, index);
+      }
+      if (src.slice(cursor + 1, end).trim()) firstChild = firstChild || 'expression';
+      cursor = end + 1;
+      continue;
+    }
+    if (src[cursor] !== '<') {
+      const nextTag = src.indexOf('<', cursor);
+      const nextExpression = src.indexOf('{', cursor);
+      const next = Math.min(
+        nextTag === -1 ? index : nextTag,
+        nextExpression === -1 ? index : nextExpression,
+        index,
+      );
+      if (depth === 0 && src.slice(cursor, next).trim()) firstChild = firstChild || 'text';
+      cursor = next;
+      continue;
+    }
+
+    const closing = src.startsWith('</', cursor);
+    const name = src.slice(cursor + (closing ? 2 : 1)).match(/^([A-Za-z][\w.-]*)/)?.[1];
+    if (!name) {
+      if (src.startsWith('<>', cursor)) {
+        if (depth === 0) firstChild = firstChild || 'fragment';
+        depth++;
+        cursor += 2;
+        continue;
+      }
+      if (src.startsWith('</>', cursor)) {
+        depth = Math.max(0, depth - 1);
+        cursor += 3;
+        continue;
+      }
+      cursor++;
+      continue;
+    }
+    if (closing) {
+      const end = src.indexOf('>', cursor);
+      if (end === -1) return false;
+      if (depth > 0) depth--;
+      cursor = end + 1;
+      continue;
+    }
+    const tag = tagBoundaryAt(src, cursor);
+    if (!tag) return false;
+    if (depth === 0) firstChild = firstChild || name;
+    if (!tag.selfClosing) depth++;
+    cursor = tag.end;
+  }
+  // `firstChild === null` — rather than a comparison against `'input'` — is what
+  // makes "nothing at all preceded the control" the credited case. `firstChild`
+  // otherwise holds a real tag name, so a control preceded by a literal
+  // `<input>` sibling would read as "the control IS the first child" and be
+  // credited by a wrapper that never named it: harmless while the scan only
+  // ever asked about `<input>`, a live bypass now that a `<select>` can follow
+  // one.
+  return depth === 0 && firstChild === null && cursor === index;
+}
+
 // The "cloned" shape: the wrapper generates the id itself and clones it onto
 // its first React child (components/ui/FormField.jsx), so the control is named
 // without either side writing a `<label htmlFor>` next to it.
 function isNestedInLabeledCloner(src, { index }, { labelProp }, wrapperName) {
   if (index === undefined) return false;
-  const wrapperRe = new RegExp(`<${wrapperName}\\b`, 'g');
-  let wrapperMatch;
-  while ((wrapperMatch = wrapperRe.exec(src)) && wrapperMatch.index < index) {
-    const wrapperTag = openingTagAt(src, wrapperMatch.index, wrapperName.length + 1);
-    if (!wrapperTag || /\/\s*>$/.test(wrapperTag)) continue;
-    if (!isUsableLabelAttributeValue(normalizedAttributeValue(attributeValue(wrapperTag, labelProp)))) continue;
-
-    let depth = 0;
-    let firstChild = null;
-    let closed = false;
-    let cursor = wrapperMatch.index + wrapperTag.length;
-    while (cursor < index) {
-      if (/\s/.test(src[cursor])) {
-        cursor++;
-        continue;
-      }
-      if (src[cursor] === '{') {
-        const end = matchingBraceEnd(src, cursor);
-        if (end === -1) break;
-        if (end >= index) {
-          // The control lives inside this expression rather than after it.
-          if (depth === 0 && firstChild === null && isDirectElementInExpression(src, cursor + 1, index)) return true;
-          break;
-        }
-        if (src.slice(cursor + 1, end).trim()) firstChild = firstChild || 'expression';
-        cursor = end + 1;
-        continue;
-      }
-      if (src[cursor] !== '<') {
-        const nextTag = src.indexOf('<', cursor);
-        const nextExpression = src.indexOf('{', cursor);
-        const next = Math.min(
-          nextTag === -1 ? index : nextTag,
-          nextExpression === -1 ? index : nextExpression,
-          index,
-        );
-        if (depth === 0 && src.slice(cursor, next).trim()) firstChild = firstChild || 'text';
-        cursor = next;
-        continue;
-      }
-
-      const closing = src.startsWith('</', cursor);
-      const name = src.slice(cursor + (closing ? 2 : 1)).match(/^([A-Za-z][\w.-]*)/)?.[1];
-      if (!name) {
-        if (src.startsWith('<>', cursor)) {
-          if (depth === 0) firstChild = firstChild || 'fragment';
-          depth++;
-          cursor += 2;
-          continue;
-        }
-        if (src.startsWith('</>', cursor)) {
-          depth = Math.max(0, depth - 1);
-          cursor += 3;
-          continue;
-        }
-        cursor++;
-        continue;
-      }
-      if (closing) {
-        const end = src.indexOf('>', cursor);
-        if (end === -1) break;
-        if (depth > 0) depth--;
-        else if (name === wrapperName) { closed = true; break; }
-        cursor = end + 1;
-        continue;
-      }
-      const tag = tagBoundaryAt(src, cursor);
-      if (!tag) break;
-      if (depth === 0) firstChild = firstChild || name;
-      if (!tag.selfClosing) depth++;
-      cursor = tag.end;
-    }
-    // `#control` rather than `'input'`: `firstChild` otherwise holds a real tag
-    // name, so a control preceded by a literal `<input>` sibling would read as
-    // "the control IS the first child" and be credited by a wrapper that never
-    // named it. Harmless while the scan only ever asked about `<input>`; a live
-    // bypass now that a `<select>` can follow one.
-    if (!closed && depth === 0 && firstChild === null && cursor === index) firstChild = '#control';
-    // A cloning wrapper clones only its first React child. The current control
-    // is named by the wrapper only when it is that first, direct child; a later
-    // control (DataDog's optional custom-site input) must remain actionable here.
-    if (!closed && depth === 0 && firstChild === '#control') return true;
-  }
-  return false;
+  return openWrapperInstancesAt(src, wrapperName, index).some(({ tag, contentStart }) => (
+    isUsableLabelAttributeValue(normalizedAttributeValue(attributeValue(tag, labelProp)))
+    && isFirstDirectChild(src, contentStart, index)
+  ));
 }
 
 // --- the wrapper registry -------------------------------------------------
@@ -1189,24 +1213,9 @@ function withVirtualSources(sources, run) {
 
 function isNestedInLabelWrapper(src, { index }, { labelProp }, name) {
   if (index === undefined) return false;
-  const re = new RegExp(`</?${name}\\b`, 'g');
-  // Keep every wrapper instance still open at `index`, not just the outermost:
-  // an inner `<Field label="…">` nested in an unlabeled outer one still names
-  // the control.
-  const open = [];
-  let match;
-  while ((match = re.exec(src)) && match.index < index) {
-    if (match[0].startsWith('</')) {
-      open.pop();
-      continue;
-    }
-    const tag = openingTagAt(src, match.index, name.length + 1);
-    if (!tag) continue;
-    re.lastIndex = match.index + tag.length;
-    if (/\/\s*>$/.test(tag)) continue;
-    open.push(tag);
-  }
-  return open.some((tag) => isUsableLabelAttributeValue(normalizedAttributeValue(attributeValue(tag, labelProp))));
+  return openWrapperInstancesAt(src, name, index).some(({ tag }) => (
+    isUsableLabelAttributeValue(normalizedAttributeValue(attributeValue(tag, labelProp)))
+  ));
 }
 
 // One matcher per shape `wrapperShapes` can emit. Adding a naming strategy is a
@@ -2008,6 +2017,18 @@ describe('a11y conventions', () => {
     // so a <select> after an <input> is still unnamed.
     const afterInput = field('<input type="text" />\n  <select><option>a</option></select>');
     expect(credits(afterInput, 'select')).toBe(false);
+
+    // Openness comes from the shared `openWrapperInstancesAt` scanner, so both
+    // directions of "which wrapper is still open here" need a probe. A wrapper
+    // that has already CLOSED names nothing after it — and the control has to
+    // be the first thing following the close, or the "first direct child" walk
+    // would reject it for a reason that has nothing to do with openness...
+    const afterClosedField = `import FormField from '../ui/FormField';\n<FormField label="Rounds"></FormField>\n<select><option>a</option></select>`;
+    expect(credits(afterClosedField, 'select')).toBe(false);
+    // ...while an inner labeled wrapper nested in an unlabeled outer one still
+    // names its own first child.
+    const nested = `import FormField from '../ui/FormField';\n<FormField>\n  <FormField label="Rounds">\n    <select><option>a</option></select>\n  </FormField>\n</FormField>`;
+    expect(credits(nested, 'select')).toBe(true);
 
     // Only the element the expression yields directly is cloned; a control
     // nested inside a wrapper element gets no id.

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -574,6 +574,14 @@ function isUsableLabelAttributeValue(value) {
   return Boolean(value) && !/^(?:undefined|null|false|true)$/i.test(value);
 }
 
+// Does this wrapper instance carry a usable name in the prop its own source
+// names its label with? Every shape matcher asks it, so the three-deep read
+// (`attributeValue` → `normalizedAttributeValue` → `isUsableLabelAttributeValue`)
+// lives here rather than being respelled at each one.
+function hasUsableLabelProp(tag, labelProp) {
+  return isUsableLabelAttributeValue(normalizedAttributeValue(attributeValue(tag, labelProp)));
+}
+
 // A field wrapper can own the <label> AND take the control's id as a prop
 // instead of wrapping it (LifestyleTab.jsx's `<FieldGroup label="Sleep …"
 // htmlFor="lifestyle-sleep-hours">`). Wrapping is wrong there — an implicit
@@ -604,7 +612,7 @@ function forwardsLabelForId(src, { id }, { idProp, labelProp }, name) {
       if (hasUsableElementText(src, match.index, tag)) return true;
       continue;
     }
-    if (isUsableLabelAttributeValue(normalizedAttributeValue(attributeValue(tag, labelProp)))) return true;
+    if (hasUsableLabelProp(tag, labelProp)) return true;
   }
   return false;
 }
@@ -635,20 +643,8 @@ function hasUsableElementText(src, index, tag) {
 }
 
 function isNestedInLabel(src, index) {
-  const labels = [];
-  const re = /<\/?label\b/g;
-  let match;
-  while ((match = re.exec(src)) && match.index < index) {
-    if (match[0].startsWith('</')) {
-      labels.pop();
-      continue;
-    }
-    const tag = openingTagAt(src, match.index, '<label'.length);
-    if (!tag) continue;
-    if (!/\/\s*>$/.test(tag)) labels.push({ index: match.index, tag });
-    re.lastIndex = match.index + tag.length;
-  }
-  return labels.some(({ index: labelIndex, tag }) => hasUsableElementText(src, labelIndex, tag));
+  return openWrapperInstancesAt(src, 'label', index)
+    .some(({ index: labelIndex, tag }) => hasUsableElementText(src, labelIndex, tag));
 }
 
 function hasUsableAccessibleNameAttribute(tag, name) {
@@ -733,23 +729,35 @@ function openWrapperInstancesAt(src, name, index) {
     }
     const tag = openingTagAt(src, match.index, name.length + 1);
     if (!tag) continue;
-    re.lastIndex = match.index + tag.length;
+    const contentStart = match.index + tag.length;
+    re.lastIndex = contentStart;
     if (/\/\s*>$/.test(tag)) continue;
-    open.push({ tag, contentStart: match.index + tag.length });
+    open.push({ tag, index: match.index, contentStart });
   }
   return open;
 }
 
 // Is the control at `index` the FIRST direct child of the wrapper whose body
-// starts at `contentStart`? A cloning wrapper clones its id onto its first
+// starts at `openContentStart`? A cloning wrapper clones its id onto its first
 // React child only, so a later control (DataDog's optional custom-site input)
-// must remain actionable. The walk has to survive every JSX shape that can
-// legitimately precede or contain the control inside a wrapper body: whitespace
-// and text nodes, `{expr}` children, fragments, and self-closing tags.
-function isFirstDirectChild(src, contentStart, index) {
+// must remain actionable. The question is only ever "did ANYTHING precede the
+// control" — a boolean, not the preceding node's identity, so that a control
+// preceded by a literal `<input>` sibling can never read as the first child of
+// a wrapper that never named it. The walk has to survive every JSX shape that
+// can legitimately precede or contain the control inside a wrapper body:
+// whitespace and text nodes, `{expr}` children, fragments, self-closing tags.
+//
+// PRECONDITION: the instance must still be OPEN at `index` — feed this only a
+// `contentStart` from `openWrapperInstancesAt`. It deliberately treats a
+// depth-0 closing tag as stray markup to skip (a wrapper body can contain one),
+// so a CLOSED wrapper's body start would walk straight past its own `</Name>`
+// and report the next control as its first child. The shared stack is what
+// rules that out; a hand-rolled `indexOf` for the wrapper would not, and would
+// fail silent — the control just drops off the offender list.
+function isFirstDirectChild(src, openContentStart, index) {
   let depth = 0;
-  let firstChild = null;
-  let cursor = contentStart;
+  let sawPrecedingChild = false;
+  let cursor = openContentStart;
   while (cursor < index) {
     if (/\s/.test(src[cursor])) {
       cursor++;
@@ -760,9 +768,9 @@ function isFirstDirectChild(src, contentStart, index) {
       if (end === -1) return false;
       if (end >= index) {
         // The control lives inside this expression rather than after it.
-        return depth === 0 && firstChild === null && isDirectElementInExpression(src, cursor + 1, index);
+        return depth === 0 && !sawPrecedingChild && isDirectElementInExpression(src, cursor + 1, index);
       }
-      if (src.slice(cursor + 1, end).trim()) firstChild = firstChild || 'expression';
+      if (src.slice(cursor + 1, end).trim()) sawPrecedingChild = true;
       cursor = end + 1;
       continue;
     }
@@ -774,7 +782,7 @@ function isFirstDirectChild(src, contentStart, index) {
         nextExpression === -1 ? index : nextExpression,
         index,
       );
-      if (depth === 0 && src.slice(cursor, next).trim()) firstChild = firstChild || 'text';
+      if (depth === 0 && src.slice(cursor, next).trim()) sawPrecedingChild = true;
       cursor = next;
       continue;
     }
@@ -783,7 +791,7 @@ function isFirstDirectChild(src, contentStart, index) {
     const name = src.slice(cursor + (closing ? 2 : 1)).match(/^([A-Za-z][\w.-]*)/)?.[1];
     if (!name) {
       if (src.startsWith('<>', cursor)) {
-        if (depth === 0) firstChild = firstChild || 'fragment';
+        if (depth === 0) sawPrecedingChild = true;
         depth++;
         cursor += 2;
         continue;
@@ -805,18 +813,13 @@ function isFirstDirectChild(src, contentStart, index) {
     }
     const tag = tagBoundaryAt(src, cursor);
     if (!tag) return false;
-    if (depth === 0) firstChild = firstChild || name;
+    if (depth === 0) sawPrecedingChild = true;
     if (!tag.selfClosing) depth++;
     cursor = tag.end;
   }
-  // `firstChild === null` — rather than a comparison against `'input'` — is what
-  // makes "nothing at all preceded the control" the credited case. `firstChild`
-  // otherwise holds a real tag name, so a control preceded by a literal
-  // `<input>` sibling would read as "the control IS the first child" and be
-  // credited by a wrapper that never named it: harmless while the scan only
-  // ever asked about `<input>`, a live bypass now that a `<select>` can follow
-  // one.
-  return depth === 0 && firstChild === null && cursor === index;
+  // `cursor === index` matters as much as the rest: a walk that broke out early
+  // or overshot never proved anything about the control.
+  return depth === 0 && !sawPrecedingChild && cursor === index;
 }
 
 // The "cloned" shape: the wrapper generates the id itself and clones it onto
@@ -825,8 +828,7 @@ function isFirstDirectChild(src, contentStart, index) {
 function isNestedInLabeledCloner(src, { index }, { labelProp }, wrapperName) {
   if (index === undefined) return false;
   return openWrapperInstancesAt(src, wrapperName, index).some(({ tag, contentStart }) => (
-    isUsableLabelAttributeValue(normalizedAttributeValue(attributeValue(tag, labelProp)))
-    && isFirstDirectChild(src, contentStart, index)
+    hasUsableLabelProp(tag, labelProp) && isFirstDirectChild(src, contentStart, index)
   ));
 }
 
@@ -1213,9 +1215,7 @@ function withVirtualSources(sources, run) {
 
 function isNestedInLabelWrapper(src, { index }, { labelProp }, name) {
   if (index === undefined) return false;
-  return openWrapperInstancesAt(src, name, index).some(({ tag }) => (
-    isUsableLabelAttributeValue(normalizedAttributeValue(attributeValue(tag, labelProp)))
-  ));
+  return openWrapperInstancesAt(src, name, index).some(({ tag }) => hasUsableLabelProp(tag, labelProp));
 }
 
 // One matcher per shape `wrapperShapes` can emit. Adding a naming strategy is a
@@ -2018,18 +2018,6 @@ describe('a11y conventions', () => {
     const afterInput = field('<input type="text" />\n  <select><option>a</option></select>');
     expect(credits(afterInput, 'select')).toBe(false);
 
-    // Openness comes from the shared `openWrapperInstancesAt` scanner, so both
-    // directions of "which wrapper is still open here" need a probe. A wrapper
-    // that has already CLOSED names nothing after it — and the control has to
-    // be the first thing following the close, or the "first direct child" walk
-    // would reject it for a reason that has nothing to do with openness...
-    const afterClosedField = `import FormField from '../ui/FormField';\n<FormField label="Rounds"></FormField>\n<select><option>a</option></select>`;
-    expect(credits(afterClosedField, 'select')).toBe(false);
-    // ...while an inner labeled wrapper nested in an unlabeled outer one still
-    // names its own first child.
-    const nested = `import FormField from '../ui/FormField';\n<FormField>\n  <FormField label="Rounds">\n    <select><option>a</option></select>\n  </FormField>\n</FormField>`;
-    expect(credits(nested, 'select')).toBe(true);
-
     // Only the element the expression yields directly is cloned; a control
     // nested inside a wrapper element gets no id.
     const wrapped = field(`{isSelect ? (<select />) : (<div><input type="number" /></div>)}`);
@@ -2049,6 +2037,29 @@ describe('a11y conventions', () => {
     // Same for a locally-declared `FormField` that is not a cloning wrapper.
     const shadowed = `function FormField({ label, children }) {\n  return <div>{label}{children}</div>;\n}\n${ternary.replace(/^import[^\n]*\n/, '')}`;
     expect(credits(shadowed)).toBe(false);
+  });
+
+  it('shares one open-wrapper scanner between the implicit and cloned matchers (#4328)', () => {
+    // Both ancestor-based shapes ask `openWrapperInstancesAt` the same question,
+    // so both DIRECTIONS of it need pinning — and through BOTH matchers, or the
+    // fold that stopped the two from drifting is witnessed on one path only.
+    const implicitWrapper = 'const Field = ({ label, children }) => (\n  <label className="block"><span>{label}</span>{children}</label>\n);\n';
+    const clonedWrapper = "import FormField from '../ui/FormField';\n";
+
+    // A wrapper that has already CLOSED names nothing after it. The control has
+    // to be the first thing following the close: with a preceding sibling the
+    // cloned path would reject it via the first-direct-child walk instead, for
+    // a reason that has nothing to do with openness.
+    const afterClose = (wrapper, name) => `${wrapper}<${name} label="Rounds"></${name}>\n<select><option>a</option></select>`;
+    expect(isNamed(afterClose(implicitWrapper, 'Field'), 'select')).toBe(false);
+    expect(isNamed(afterClose(clonedWrapper, 'FormField'), 'select')).toBe(false);
+
+    // An inner labeled wrapper nested in an unlabeled outer one still names its
+    // own first child — the reason the scanner keeps EVERY open instance rather
+    // than just the outermost.
+    const nested = (wrapper, name) => `${wrapper}<${name}>\n  <${name} label="Rounds">\n    <select><option>a</option></select>\n  </${name}>\n</${name}>`;
+    expect(isNamed(nested(implicitWrapper, 'Field'), 'select')).toBe(true);
+    expect(isNamed(nested(clonedWrapper, 'FormField'), 'select')).toBe(true);
   });
 
   it('reads an apostrophe in JSX text as text, not a string opener (#4318)', () => {


### PR DESCRIPTION
## Summary

The a11y guard had **three** hand-rolled copies of "which instances of this wrapper are still open at `index`":

- `isNestedInLabelWrapper` (the `implicit` shape) — a push/pop stack over `</?Name\b`.
- `isNestedInLabeledCloner` (the `cloned` shape) — the same fact re-derived inside a ~70-line single pass that *simultaneously* tracked whether the control was the wrapper's first direct child.
- `isNestedInLabel` — the same walk again, for literal `<label>`.

The JSX edge cases the cloner's pass documents — fragments, `{expr}` children, self-closing tags, a `.map()` in the other ternary branch — were handled in one copy and not the others, so a fix to any of them drifted from the rest, and the largest, least-probed path was the one carrying them. (#4318 and #4327 were both cases of one scanner in this file learning something its siblings didn't.)

All three now share one scanner, and the two facts the cloner conflated are separated:

- **`openWrapperInstancesAt(src, name, index)`** → the still-open instances as `{ tag, index, contentStart }`.
- **`isFirstDirectChild(src, openContentStart, index)`** → the body walk alone, starting from a given content start rather than discovering the wrapper itself.

Each of the three matchers reduces to a `.some()` over the shared scanner. The walk no longer needs the wrapper's name: the `closed` flag it used to compute is exactly what the shared stack already decides, so a depth-0 closing tag is now the same stray-markup skip the original already applied to every non-wrapper name. That coupling is a real precondition, so it's stated on the function and the parameter is named `openContentStart` — feeding it a *closed* wrapper's body start would walk past that wrapper's own `</Name>` and credit the next control.

`forwardsLabelForId` is untouched — it is an id-keyed scan, unbounded by `index` (a forwarder need not enclose the control at all), and stays correctly separate.

Two smaller cleanups fell out of self-review:

- The extraction removed the `'#control'` sentinel, which was the only place the *value* of `firstChild` was ever read. Four sites still manufactured strings nothing consumed; it's a `sawPrecedingChild` boolean now, which makes the miscrediting hazard structural instead of a comment — a boolean can't collide with a tag name.
- The three-deep label-prop read (`attributeValue` → `normalizedAttributeValue` → `isUsableLabelAttributeValue`), spelled out at three call sites, is now `hasUsableLabelProp(tag, labelProp)`.

## Test plan

- `cd client && NODE_ENV=test npx vitest run src/a11yConventions.test.js` — 24 passed. `npx biome lint --error-on-warnings` clean.
- **Behavior-preserving: no allowlist row changed.** The suite asserts both directions — unnamed controls missing from the list *and* stale entries that are now named — so a verdict change either way goes red.
- A new `it('shares one open-wrapper scanner between the implicit and cloned matchers')` pins both directions of the shared fact, through **both** ancestor matchers (probing only the cloned path would witness half of a fold whose whole point is that the two stop drifting):
  - a wrapper that has already **closed** names nothing after it;
  - an inner labeled wrapper nested in an **unlabeled outer** one still names its own first child.
- Each probe was verified against a mutated scanner rather than assumed: never-pop → 4 tests fail; keep-only-outermost → 1 fails; ignore `sawPrecedingChild` → 1 fails. The closed-wrapper fixture puts the control immediately after the close on purpose — with a preceding sibling it is rejected by the first-direct-child walk instead, which made the first draft of that probe vacuous (the mutation caught it).

Follow-up filed as #4337 for the three remaining *flat* tag-iteration scanners, which share a different (stack-free) seam.

Closes #4328
