### PR TITLE
fix: make four a11y-guard scanners JSX-context-aware, the way matchingBraceEnd was (#4333)

### DIFF
--- a/.changelog/next/fixed-issue-4333.md
+++ b/.changelog/next/fixed-issue-4333.md
@@ -1,0 +1,1 @@
+- a11y guard: quoted attributes, string-bearing ternaries, and comments no longer make a named control read as unnamed

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -80,11 +80,23 @@ function maskedSourceOf(file) {
 /**
  * Slice out the full opening tag starting at `index`, tolerating `>` inside
  * JSX expression containers (`className={`a > b`}`) by tracking brace depth.
+ *
+ * Quoted regions are skipped whole, because everything between the tag name and
+ * its `>` is either an attribute value or a JavaScript expression — never JSX
+ * text, so a quote here always opens a string. Without that, ordinary prose in
+ * an attribute breaks the file's busiest scanner (18 call sites) two ways:
+ * a `>` ends the tag early, so `<input placeholder="a > b" aria-label="Search"/>`
+ * loses the `aria-label` and reads as UNNAMED; and a lone `{` or `}` drives the
+ * depth negative and returns null, which every call site treats as `continue` —
+ * dropping the control (or its <label>) out of the scan entirely. Both are
+ * false negatives in a guard, and the first already triggers on product code:
+ * `pages/Instances.jsx` has a `>` inside a `title` attribute.
  */
 function openingTagAt(src, index, nameLength) {
   let depth = 0;
   for (let i = index + nameLength; i < src.length; i++) {
     const c = src[i];
+    if (c === '"' || c === '\'' || c === '`') { i = skipString(src, i); continue; }
     if (c === '{') depth++;
     else if (c === '}') depth--;
     else if (c === '>' && depth === 0) return src.slice(index, i + 1);
@@ -102,6 +114,29 @@ function skipString(src, from) {
   let i = from + 1;
   for (; i < src.length && src[i] !== src[from]; i++) if (src[i] === '\\') i++;
   return i;
+}
+
+// Index of the LAST character of the comment opening at `src[from]`, or -1 when
+// no comment opens there — the same "land on the last char, let the caller's
+// `for` step past" contract as `skipString`. An unterminated comment returns
+// `src.length`, ending the walk.
+//
+// A `/` in JavaScript can also be division or a regex delimiter, but neither
+// can be followed by `/` or `*` (an empty regex `//` IS a line comment, and a
+// regex may not start with a quantifier), so the two-character check is exact.
+// Only JavaScript and tag-interior context may call this: inside JSX element
+// text a `//` is ordinary visible text.
+function commentEnd(src, from) {
+  if (src[from] !== '/') return -1;
+  if (src[from + 1] === '/') {
+    const newline = src.indexOf('\n', from + 2);
+    return newline === -1 ? src.length : newline - 1;
+  }
+  if (src[from + 1] === '*') {
+    const close = src.indexOf('*/', from + 2);
+    return close === -1 ? src.length : close + 1;
+  }
+  return -1;
 }
 
 /**
@@ -197,6 +232,8 @@ function matchingBraceEnd(s, idx) {
     }
 
     if (mode === 'jsx-tag') {
+      const comment = commentEnd(s, i);
+      if (comment !== -1) { i = comment; continue; }
       if (c === '"' || c === '\'' || c === '`') { i = skipString(s, i); continue; }
       if (c === '{') { openBrace(); continue; }
       if (c !== '>') continue;
@@ -219,6 +256,16 @@ function matchingBraceEnd(s, idx) {
       continue;
     }
 
+    // JavaScript-expression context. `maskComments` has line/block-comment
+    // states and this walk did not, yet it is reached from UNMASKED source
+    // (`findButtonBody` → `isIconOnlyBody` → `soleTopLevelNode`, which strips
+    // only `{/* … */}`). So a `//` or inline `/* */` inside the expression
+    // survived to here: `{ // don't\n open ? <Up/> : <Down/> }` returned -1 (the
+    // apostrophe opened a string that never closed) and the button was silently
+    // dropped from the icon-only rule, while `{ /* } */ <Icon/> }` returned the
+    // comment's brace — wrong bounds, no error.
+    const codeComment = commentEnd(s, i);
+    if (codeComment !== -1) { i = codeComment; continue; }
     if (c === '"' || c === '\'' || c === '`') { i = skipString(s, i); continue; }
     if (c === '{') { openBrace(); continue; }
     if (c === '}') {
@@ -285,24 +332,34 @@ function soleTopLevelNode(rawBody) {
   return null; // bare text at top level
 }
 
-function matchTernaryIcons(inner) {
+// Index of the first `char` at bracket depth 0 in a JavaScript expression, or
+// -1. Quoted regions are skipped whole: `inner` is an expression, so a `?` or
+// `:` inside a string is not the ternary's — `mode === 'a?b' ? <IconA/> :
+// <IconB/>` and `cond ? <IconA title="a:b"/> : <IconB/>` both used to read as
+// "not a ternary", quietly dropping an icon-only button from the rule that
+// requires it to have a name.
+const topLevelOperatorIn = (inner, char, from) => {
   let depth = 0;
-  let qIdx = -1;
-  for (let i = 0; i < inner.length; i++) {
+  for (let i = from; i < inner.length; i++) {
     const c = inner[i];
+    // `inner` is raw expression source — `soleTopLevelNode` strips only
+    // `{/* … */}` — so a comment can hold an apostrophe (`// don't`) that would
+    // otherwise open a string swallowing the rest of the expression.
+    const comment = commentEnd(inner, i);
+    if (comment !== -1) { i = comment; continue; }
+    if (c === '"' || c === '\'' || c === '`') { i = skipString(inner, i); continue; }
     if (c === '(' || c === '{' || c === '[') depth++;
     else if (c === ')' || c === '}' || c === ']') depth--;
-    else if (c === '?' && depth === 0 && inner[i + 1] !== '.') { qIdx = i; break; }
+    // `?.` is optional chaining, not the start of a ternary.
+    else if (c === char && depth === 0 && !(char === '?' && inner[i + 1] === '.')) return i;
   }
+  return -1;
+};
+
+function matchTernaryIcons(inner) {
+  const qIdx = topLevelOperatorIn(inner, '?', 0);
   if (qIdx === -1) return false;
-  depth = 0;
-  let cIdx = -1;
-  for (let i = qIdx + 1; i < inner.length; i++) {
-    const c = inner[i];
-    if (c === '(' || c === '{' || c === '[') depth++;
-    else if (c === ')' || c === '}' || c === ']') depth--;
-    else if (c === ':' && depth === 0) { cIdx = i; break; }
-  }
+  const cIdx = topLevelOperatorIn(inner, ':', qIdx + 1);
   if (cIdx === -1) return false;
   const a = inner.slice(qIdx + 1, cIdx).trim();
   const b = inner.slice(cIdx + 1).trim();
@@ -410,9 +467,17 @@ function normalizedAttributeValue(value) {
 // examples. This is a small lexer rather than a quote-only scan: apostrophes,
 // slashes, and URLs are ordinary JSX text and must not put the rest of a file
 // into a fake JavaScript string/comment state.
-function maskComments(src) {
+//
+// `startMode` is where the slice BEGINS. A whole file starts in `'code'` (the
+// default), but a mid-file slice need not: an element's body is JSX text, and
+// masking it as code opens a fake line comment on the first `//` of visible
+// label text — `<label htmlFor="x">// see docs</label>` masked to
+// `'// see docs'` → `'           '` reports a correctly labeled input as
+// unnamed. That is #4318's defect exactly: the machine has to be told where it
+// is, and the caller is the only one that knows.
+function maskComments(src, { startMode = 'code' } = {}) {
   const chars = [...src];
-  let mode = 'code';
+  let mode = startMode;
   let quote = null;
   let braceDepth = 0;
   let tagBraceDepth = 0;
@@ -631,7 +696,8 @@ function hasUsableElementText(src, index, tag) {
   if (!name) return false;
   const closeIndex = src.indexOf(`</${name}>`, index + tag.length);
   if (closeIndex === -1) return false;
-  const body = stripHiddenElementContent(maskComments(src.slice(index + tag.length, closeIndex)))
+  // The slice is the element's BODY — JSX text, not code. See `maskComments`.
+  const body = stripHiddenElementContent(maskComments(src.slice(index + tag.length, closeIndex), { startMode: 'jsx-text' }))
     .replace(/<\/?[A-Za-z][^>]*>/g, ' ')
     .trim();
   if (!body) return false;
@@ -2060,6 +2126,86 @@ describe('a11y conventions', () => {
     const nested = (wrapper, name) => `${wrapper}<${name}>\n  <${name} label="Rounds">\n    <select><option>a</option></select>\n  </${name}>\n</${name}>`;
     expect(isNamed(nested(implicitWrapper, 'Field'), 'select')).toBe(true);
     expect(isNamed(nested(clonedWrapper, 'FormField'), 'select')).toBe(true);
+  });
+
+  it('reads a quoted attribute as a string, not as tag structure (#4333)', () => {
+    // Between a tag name and its `>` there is only attribute-value or
+    // expression context, so a quote there always opens a string. Prose in an
+    // attribute used to break `openingTagAt` two ways — both FALSE NEGATIVES,
+    // which is why the suite stayed green with them present.
+    // 1. A `>` ended the tag early, losing every attribute after it.
+    expect(isNamed('<input type="text" placeholder="a > b" aria-label="Search" />')).toBe(true);
+    // 2. A lone brace drove the depth negative and returned null. All 18 call
+    //    sites read null as `continue`, so the <label> left the scan entirely
+    //    and the input it names read as unnamed.
+    expect(isNamed('<label htmlFor="a" title="use { to open">Rounds</label>\n<input id="a" type="text" />')).toBe(true);
+    //    Same when the unbalanced brace is on the CONTROL's own tag.
+    expect(isNamed('<input id="b" title="a } brace" aria-label="Search" />')).toBe(true);
+    // The fix must not credit a control that still has no name: `placeholder`
+    // is an anchor attribute, never an accessible name.
+    expect(isNamed('<input type="text" placeholder="a > b" />')).toBe(false);
+  });
+
+  it('reads a ternary operator through quoted attributes and strings (#4333)', () => {
+    // An icon-only button whose ternary carries a `?` or `:` inside a string
+    // used to read as "not a ternary" and drop out of the rule that requires it
+    // to have a name — a false negative in a guard.
+    const isIconOnly = (body) => {
+      const src = `<button onClick={run}>${body}</button>`;
+      const open = src.indexOf('<button');
+      const tag = openingTagAt(src, open, '<button'.length);
+      return isIconOnlyBody(findButtonBody(src, open + tag.length));
+    };
+    expect(isIconOnly("{mode === 'a?b' ? <IconA /> : <IconB />}")).toBe(true);
+    expect(isIconOnly('{cond ? <IconA title="a:b" /> : <IconB />}')).toBe(true);
+    // Optional chaining is still not a ternary, and a non-icon branch still
+    // disqualifies the shape — the string skip must not widen either.
+    expect(isIconOnly('{cond ? <IconA /> : "Save"}')).toBe(false);
+    expect(isIconOnly('{icons?.primary}')).toBe(false);
+  });
+
+  it('masks an element body as JSX text, not as code (#4333)', () => {
+    // `hasUsableElementText` hands `maskComments` a mid-file slice that is an
+    // element BODY. Started in 'code' the machine opened a fake line comment on
+    // the first `//` of visible label text, blanking the rest of the line — so a
+    // correctly labeled input was reported UNNAMED.
+    expect(maskComments('Discount 50 // 50', { startMode: 'jsx-text' })).toBe('Discount 50 // 50');
+    expect(maskComments('Discount 50 // 50')).toBe('Discount 50      ');
+    expect(isNamed('<label htmlFor="x">// see docs</label>\n<input id="x" type="text" />')).toBe(true);
+    // A genuinely empty label still names nothing.
+    expect(isNamed('<label htmlFor="y"></label>\n<input id="y" type="text" />')).toBe(false);
+  });
+
+  it('reads comments inside a brace expression as comments (#4333)', () => {
+    // `matchingBraceEnd` is reached from UNMASKED source, and `soleTopLevelNode`
+    // strips only `{/* … */}` — so a `//` or inline `/* */` inside the
+    // expression reaches this walk raw. Both cases are silent: no error, just a
+    // button that leaves the icon-only rule.
+    const isIconOnly = (body) => {
+      const src = `<button onClick={run}>${body}</button>`;
+      const open = src.indexOf('<button');
+      const tag = openingTagAt(src, open, '<button'.length);
+      return isIconOnlyBody(findButtonBody(src, open + tag.length));
+    };
+    // A line comment whose text holds an apostrophe used to open a string that
+    // never closed, so `matchingBraceEnd` returned -1 and the button vanished
+    // from the rule entirely — a live false negative.
+    expect(isIconOnly("{ // don't\n  open ? <Up /> : <Down /> }")).toBe(true);
+    // A `}` inside a block comment used to be read as the closing brace: wrong
+    // bounds with no error. This one is latent — no verdict flips today, since
+    // a bare `{<Icon />}` is not an icon-only shape either way — so it is
+    // pinned on the helper directly rather than through a rule that would pass
+    // for the wrong reason.
+    const blockComment = '{ /* } */ <Icon /> }';
+    expect(matchingBraceEnd(blockComment, 0)).toBe(blockComment.length - 1);
+    // Same inside a TAG, the walk's other JavaScript-ish context: an apostrophe
+    // in the comment opened a string that ran to the end of the slice, and a
+    // `>` in the comment ended the tag early and left the walk in element text.
+    const tagComments = ["{ <Up /* don't */ /> }", '{ <Up /* a > b */ /> }'];
+    for (const shape of tagComments) expect(matchingBraceEnd(shape, 0)).toBe(shape.length - 1);
+    // Division and regex literals must not be mistaken for comment openers.
+    expect(isIconOnly('{ ratio / 2 > 1 ? <Up /> : <Down /> }')).toBe(true);
+    expect(isIconOnly('{ /up/.test(dir) ? <Up /> : <Down /> }')).toBe(true);
   });
 
   it('reads an apostrophe in JSX text as text, not a string opener (#4318)', () => {

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -122,8 +122,14 @@ function skipString(src, from) {
 // `src.length`, ending the walk.
 //
 // A `/` in JavaScript can also be division or a regex delimiter, but neither
-// can be followed by `/` or `*` (an empty regex `//` IS a line comment, and a
-// regex may not start with a quantifier), so the two-character check is exact.
+// can OPEN with `/` or `*` — `//` is a line comment to the JS grammar itself,
+// never an empty regex, and a regex may not start with a quantifier — so the
+// two-character check is exact at the start of a token. It is not exact INSIDE
+// a regex body (`/[//]/` reads as a comment here), which is the same blind spot
+// `skipString` already has there; regex literals are outside this lexer's model
+// and stay that way until the scanners share one machine (#4333's remaining
+// consolidation).
+//
 // Only JavaScript and tag-interior context may call this: inside JSX element
 // text a `//` is ordinary visible text.
 function commentEnd(src, from) {

--- a/client/src/a11yConventions.test.js
+++ b/client/src/a11yConventions.test.js
@@ -81,25 +81,35 @@ function maskedSourceOf(file) {
  * Slice out the full opening tag starting at `index`, tolerating `>` inside
  * JSX expression containers (`className={`a > b`}`) by tracking brace depth.
  *
- * Quoted regions are skipped whole, because everything between the tag name and
- * its `>` is either an attribute value or a JavaScript expression — never JSX
- * text, so a quote here always opens a string. Without that, ordinary prose in
- * an attribute breaks the file's busiest scanner (18 call sites) two ways:
- * a `>` ends the tag early, so `<input placeholder="a > b" aria-label="Search"/>`
- * loses the `aria-label` and reads as UNNAMED; and a lone `{` or `}` drives the
- * depth negative and returns null, which every call site treats as `continue` —
- * dropping the control (or its <label>) out of the scan entirely. Both are
- * false negatives in a guard, and the first already triggers on product code:
- * `pages/Instances.jsx` has a `>` inside a `title` attribute.
+ * A quoted ATTRIBUTE VALUE is skipped whole: at tag level a quote always opens
+ * a string. Counting braces alone made ordinary prose in an attribute break the
+ * file's busiest scanner (18 call sites) two ways — a `>` ended the tag early,
+ * so `<input placeholder="a > b" aria-label="Search"/>` lost its `aria-label`
+ * and read as UNNAMED; and a lone `{` or `}` drove the depth negative and
+ * returned null, which every call site treats as `continue`, dropping the
+ * control (or its <label>) out of the scan entirely. Both are false negatives
+ * in a guard, and the first already triggers on product code: `pages/
+ * Instances.jsx` has a `>` inside a `title` attribute.
+ *
+ * An expression container is handed to `matchingBraceEnd` and skipped whole,
+ * rather than having its quotes read here. Inside `{…}` the context is no
+ * longer "tag": `render={<span>don't</span>}` puts JSX TEXT in the middle of a
+ * tag, where an apostrophe is an ordinary character. Reading it as a string
+ * opener runs the scan off the end of the file and returns null — trading the
+ * bug above for the same bug in a rarer shape. `matchingBraceEnd` already
+ * tracks that nesting; this scanner just has to not second-guess it.
  */
 function openingTagAt(src, index, nameLength) {
-  let depth = 0;
   for (let i = index + nameLength; i < src.length; i++) {
     const c = src[i];
     if (c === '"' || c === '\'' || c === '`') { i = skipString(src, i); continue; }
-    if (c === '{') depth++;
-    else if (c === '}') depth--;
-    else if (c === '>' && depth === 0) return src.slice(index, i + 1);
+    if (c === '{') {
+      const end = matchingBraceEnd(src, i);
+      if (end === -1) return null;
+      i = end;
+      continue;
+    }
+    if (c === '>') return src.slice(index, i + 1);
   }
   return null;
 }
@@ -291,14 +301,21 @@ function matchingBraceEnd(s, idx) {
 // respecting `{...}` attribute-expression nesting and quoted strings inside
 // them. Returns `{ end, selfClosing }`, `end` being the index just past `>`.
 function tagBoundaryAt(s, idx) {
-  let depth = 0;
   for (let i = idx + 1; i < s.length; i++) {
     const c = s[i];
-    if (c === '{') depth++;
-    else if (c === '}') depth--;
-    else if ((c === '"' || c === '\'' || c === '`') && depth > 0) {
-      i = skipString(s, i);
-    } else if (c === '>' && depth === 0) {
+    // Same two contexts, same handling, as `openingTagAt` — see its comment.
+    // This scanner skipped strings only at `depth > 0`, so a `>` in a top-level
+    // attribute value (`<Icon title="a > b" />`) ended the tag at the wrong
+    // character AND reported `selfClosing: false`, which is how a self-closing
+    // icon stops looking self-closing to `isIconOnlyBody`.
+    if (c === '"' || c === '\'' || c === '`') { i = skipString(s, i); continue; }
+    if (c === '{') {
+      const end = matchingBraceEnd(s, i);
+      if (end === -1) return null;
+      i = end;
+      continue;
+    }
+    if (c === '>') {
       let back = i - 1;
       while (back > idx && /\s/.test(s[back])) back--;
       return { end: i + 1, selfClosing: s[back] === '/' };
@@ -499,6 +516,11 @@ function maskComments(src, { startMode = 'code' } = {}) {
   // lexer in `code` mode where the following `</select>` reads as a
   // less-than, never pops, and strands the rest of the file in `jsx-text`.
   const jsxStack = [];
+  // Where a comment hands back when it ends. A comment can open from JavaScript
+  // OR from inside a tag (`<Icon // note\n name={x} />`), and resetting to
+  // 'code' on exit dropped the lexer out of the half-read tag — every later
+  // `>` and quote in that tag then read in the wrong context.
+  let commentParentMode = 'code';
 
   // The mask is the only caller that needs the tag's identity as well as its
   // direction — it stacks the name to decide what a `</…>` closes.
@@ -513,7 +535,7 @@ function maskComments(src, { startMode = 'code' } = {}) {
     const c = chars[i];
 
     if (mode === 'line-comment') {
-      if (c === '\n') mode = 'code';
+      if (c === '\n') mode = commentParentMode;
       else chars[i] = ' ';
       continue;
     }
@@ -521,7 +543,7 @@ function maskComments(src, { startMode = 'code' } = {}) {
       if (c === '*' && chars[i + 1] === '/') {
         chars[i] = ' ';
         chars[++i] = ' ';
-        mode = 'code';
+        mode = commentParentMode;
       } else if (c !== '\n') {
         chars[i] = ' ';
       }
@@ -548,12 +570,14 @@ function maskComments(src, { startMode = 'code' } = {}) {
       if (c === '/' && chars[i + 1] === '/') {
         chars[i] = ' ';
         chars[++i] = ' ';
+        commentParentMode = mode;
         mode = 'line-comment';
         continue;
       }
       if (c === '/' && chars[i + 1] === '*') {
         chars[i] = ' ';
         chars[++i] = ' ';
+        commentParentMode = mode;
         mode = 'block-comment';
         continue;
       }
@@ -596,12 +620,14 @@ function maskComments(src, { startMode = 'code' } = {}) {
     if (c === '/' && chars[i + 1] === '/') {
       chars[i] = ' ';
       chars[++i] = ' ';
+      commentParentMode = mode;
       mode = 'line-comment';
       continue;
     }
     if (c === '/' && chars[i + 1] === '*') {
       chars[i] = ' ';
       chars[++i] = ' ';
+      commentParentMode = mode;
       mode = 'block-comment';
       continue;
     }
@@ -2150,6 +2176,40 @@ describe('a11y conventions', () => {
     // The fix must not credit a control that still has no name: `placeholder`
     // is an anchor attribute, never an accessible name.
     expect(isNamed('<input type="text" placeholder="a > b" />')).toBe(false);
+
+    // Inside `{…}` the context is no longer "tag", so the quote skip must NOT
+    // apply there: `render={<span>don't</span>}` puts JSX text mid-tag, where an
+    // apostrophe is an ordinary character. Reading it as a string opener runs
+    // off the end of the file and returns null — the same class of bug, one
+    // shape rarer. The expression is handed to `matchingBraceEnd` instead.
+    const attrExpressions = [
+      "<Foo render={<span>don't</span>} />",
+      "<Foo x={/* don't */ 1} />",
+      '<Foo c={`a > b`} />', // the case the original brace counting existed for
+    ];
+    for (const shape of attrExpressions) expect(openingTagAt(shape, 0, 4)).toBe(shape);
+
+    // `tagBoundaryAt` answers the same question for the icon rules and skipped
+    // strings only at depth > 0, so a `>` in a top-level attribute value ended
+    // the tag at the wrong character AND reported `selfClosing: false` — which
+    // is how a self-closing icon stops looking self-closing.
+    const iconTag = '<Icon title="a > b" />';
+    expect(tagBoundaryAt(iconTag, 0)).toEqual({ end: iconTag.length, selfClosing: true });
+  });
+
+  it('hands a comment back to the context that opened it (#4333)', () => {
+    // A comment can open from JavaScript or from inside a TAG. `maskComments`
+    // reset to 'code' on exit either way, which dropped the lexer out of the
+    // half-read tag: the tag's `>` no longer closed it, the element never
+    // reached 'jsx-text', and the visible text after it was lexed as JavaScript
+    // — so a `//` in ordinary label text got masked away. That is the #4318
+    // failure again, reached through the comment states instead.
+    for (const opener of ['// note\n', '/* note */']) {
+      const src = `<Foo ${opener} bar="x">see // docs</Foo>`;
+      expect(maskComments(src).endsWith('>see // docs</Foo>')).toBe(true);
+    }
+    // A comment opened from JavaScript still hands back to JavaScript.
+    expect(maskComments('const a = 1; // note\nconst b = 2;')).toBe('const a = 1;        \nconst b = 2;');
   });
 
   it('reads a ternary operator through quoted attributes and strings (#4333)', () => {


### PR DESCRIPTION
## Summary

#4318 fixed `matchingBraceEnd()` by making it track JSX-text vs JavaScript-expression context. The same context-blindness was still live in four sibling scanners in `client/src/a11yConventions.test.js`. **Every case here is a false *negative*** — a control that IS named reported as unnamed, or a button silently dropped from a rule — which is exactly why the suite stayed green with all of them present. Nothing unsafe was being exempted; the bugs were invisible.

**A. `openingTagAt` was quote-blind** — the file's busiest scanner, 18 call sites. It counted only `{`/`}` and stopped at the first depth-0 `>`.
- A `>` in a quoted attribute truncated the tag: `<input placeholder="a > b" aria-label="Search" />` ended at `placeholder="a >`, so the `aria-label` was never read and the control was UNNAMED.
- A `{` or `}` in a quoted attribute drove the depth negative and returned `null`. All 18 call sites do `if (!tag) continue`, so the control — or the `<label>` that names it — left the scan entirely.

Between a tag name and its `>` there is only attribute-value or expression context, so a quote there always opens a string; it's now skipped whole via the shared `skipString`. The truncation already triggers on product code (`pages/Instances.jsx` has a `>` inside a `title` attribute). It's harmless *there* only because that button has visible text — which is the point: the trigger is ordinary prose, not a contrived fixture.

**B. `matchTernaryIcons` was quote-blind.** It found the top-level `?` and `:` by bracket depth with no string handling, so `mode === 'a?b' ? <IconA/> : <IconB/>` and `cond ? <IconA title="a:b"/> : <IconB/>` both read as "not a ternary" — an icon-only button escaping the rule that requires it to have a name. Its two near-identical scan loops collapse into one `topLevelOperatorIn`.

**C. `hasUsableElementText` masked a mid-file slice with the wrong start mode.** The slice is an element *body* — JSX-text context — but `maskComments` always started in `'code'`, so a `//` in visible label text opened a fake line comment: `<label htmlFor="x">// see docs</label>` blanked to nothing and a correctly labeled input reported UNNAMED. `maskComments` now takes a `startMode`; only the caller knows where its slice begins.

**D. `matchingBraceEnd` had no comment states**, yet it is reached from *unmasked* source (`findButtonBody` → `isIconOnlyBody` → `soleTopLevelNode`, which strips only `{/* … */}`).
- `{ // don't\n open ? <Up/> : <Down/> }` returned `-1` — the apostrophe opened a string that never closed — and the button vanished from the icon-only rule.
- `{ /* } */ <Icon/> }` returned the comment's brace: wrong bounds, no error.

A shared `commentEnd` (same land-on-the-last-character contract as `skipString`) now covers both its JavaScript and tag-interior contexts, and `topLevelOperatorIn`, which sees the same raw expression text.

**E. Three more, from review.** The tag-level quote skip in A was itself a regression in one shape, and chasing it surfaced two siblings with the same root cause:
- **`openingTagAt` again.** Skipping quotes at tag level is right, but `{…}` is *not* tag level: `render={<span>don't</span>}` puts JSX **text** in the middle of a tag, where an apostrophe is an ordinary character. Reading it as a string opener ran the scan off the end of the file and returned `null` — trading A's bug for the same bug in a rarer shape. The expression container now goes to `matchingBraceEnd`, which already tracks that nesting, and the local brace counter is gone.
- **`tagBoundaryAt`** (pre-existing) skipped strings only at `depth > 0`, so `<Icon title="a > b" />` ended at the `>` *inside* the attribute **and** reported `selfClosing: false` — which is how a self-closing icon stops looking self-closing to the icon-only rule. Now identical handling to `openingTagAt`.
- **`maskComments`** (pre-existing) reset to `'code'` when a comment ended, whichever context opened it. From inside a tag that dropped the lexer out of the half-read tag: its `>` no longer closed it, the element never reached `'jsx-text'`, and the visible text after it was lexed as JavaScript — so a `//` in ordinary label text got masked away. That is C's failure again, reached through the comment states. Comments now hand back to whatever opened them.

**Not taken:** review also asked for a regex-literal state machine, since `commentEnd` reads `/[//]/` as a comment. Real, but it is the blind spot `skipString` already has inside a regex body — regex literals are outside this lexer's model, consistently. A `looksLikeRegexStart` heuristic (division vs regex after `)` or an identifier) is exactly the kind of guess that belongs in the one shared machine below, not bolted onto two scanners here. No tracked file hits it: the suite is green and the allowlists assert both directions.

## Remaining

This PR fixes every **defect** the issue names. What's left is the pure-refactor half of D — the `jsxScanner(src, { from, mode })` generator that would collapse `maskComments`, `matchingBraceEnd`, `balancedCallAt`, `tagBoundaryAt`, `matchTernaryIcons`, and `stripJsxTags` onto one machine, after which `balancedCallAt`'s retry-without-strings fallback (the oldest bandaid for this same root cause) can go. It carries real regression risk across six scanners for no behavior change, so it is deliberately not bundled with the live fixes. The issue stays open for it; `startMode` (C) is the parameterization that work needs, and it is now in place.

## Test plan

- `cd client && NODE_ENV=test npx vitest run src/a11yConventions.test.js` — 29 passed. Full client suite: 651 files / 7977 tests passed. `biome lint --error-on-warnings` clean.
- **No allowlist row changed** — these shapes are either absent from the tree today or sit where the control was named some other way. The suite asserts both directions (unnamed controls missing from the list *and* stale entries now named), so a verdict change either way would go red.
- Five new probes, and **every** fix was verified by reverting it and re-running — each insertion point reddens exactly its own test. (This is not ceremony: two probe drafts passed with their fix removed and had to be rewritten. The first closed-wrapper fixture was rejected by a different code path, and the first `maskComments` fixture produced byte-identical output in both modes because the lost mode only affects *downstream* lexing.)
  - `reads a quoted attribute as a string, not as tag structure` — both A shapes, on the control's own tag and on its `<label>`, plus a negative (a bare `placeholder` is an anchor attribute, never a name).
  - `reads a ternary operator through quoted attributes and strings` — both B shapes, plus negatives so the string skip doesn't widen the rule (optional chaining is still not a ternary; a non-icon branch still disqualifies).
  - `reads comments inside a brace expression as comments` — D's line-comment case through the real rule (it flips a verdict), D's block-comment and in-tag cases pinned on `matchingBraceEnd` directly, since those are latent bounds bugs that don't flip a verdict — probing them through a rule would have passed for the wrong reason. Plus division and regex literals, so `/` isn't misread as a comment opener.
  - C is pinned both on `maskComments` directly (`'Discount 50 // 50'` in each mode) and end-to-end through a labeled input.
  - `hands a comment back to the context that opened it` — E's `maskComments` fix, for both comment kinds, plus a JavaScript-opened comment so the fix doesn't invert the common case.
  - E's `openingTagAt` and `tagBoundaryAt` fixes are pinned inside the quoted-attribute probe, including the template-literal shape the original brace counting existed for.

Refs #4333
