### PR TITLE
fix: submit OpenCode TUI pastes with Enter

### DIFF
--- a/.changelog/next/fixed-agent-d1618386.md
+++ b/.changelog/next/fixed-agent-d1618386.md
@@ -1,0 +1,1 @@
+- OpenCode TUI pastes now submit with Enter instead of being repeated.

--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -33,10 +33,11 @@ export const PASTE_DEADLINE_MS = 10000;
 // path; the non-claude providers use PASTE_DEADLINE_MS.
 export const TUI_INPUT_READY_DEADLINE_MS = 45000;
 
-// Claude Code emits `[Pasted text #N +M lines]`, while Codex emits
-// `[Pasted Content N chars]`, after committing a paste. Watch for either
-// marker (or fall back after PASTE_TO_ENTER_FALLBACK_MS) before sending `\r`
-// so Enter doesn't get swallowed mid-paste-commit.
+// Claude Code emits `[Pasted text #N +M lines]`, Codex emits
+// `[Pasted Content N chars]`, and OpenCode emits `[Pasted ~N lines]` after
+// committing a paste. Watch for any of these markers (or fall back after
+// PASTE_TO_ENTER_FALLBACK_MS) before sending `\r` so Enter doesn't get
+// swallowed mid-paste-commit.
 //
 // CRITICAL: the marker must be matched against ANSI-STRIPPED output, never the
 // raw PTY stream. Claude Code renders the marker by positioning each token with
@@ -62,7 +63,7 @@ export const PASTE_RETRY_MAX_ATTEMPTS = 3;
 export const PASTE_RETRY_BASE_DELAY_MS = 800;
 // Minimum prefix length for verification (shorter prompts verify whole-text)
 const MIN_VERIFIABLE_PREFIX_LEN = 15;
-export const PASTE_MARKER_PATTERN = /\[Pasted\s*(?:text\s*#\d+[^\]]*|content\s*\d+\s*chars)\]/i;
+export const PASTE_MARKER_PATTERN = /\[Pasted\s*(?:text\s*#\d+[^\]]*|content\s*\d+\s*chars|~\s*\d+\s*lines?)\]/i;
 export const PASTE_TO_ENTER_MIN_DELAY_MS = 200;
 export const PASTE_TO_ENTER_FALLBACK_MS = 3500;
 
@@ -124,7 +125,8 @@ export function verifyPasteRendered(strippedBuffer, prefix) {
 }
 
 /**
- * Count the `[Pasted text #N …]` paste-commit markers in `strippedText`.
+ * Count paste-commit markers from Claude Code, Codex, or OpenCode in
+ * `strippedText`.
  * Callers MUST pass ANSI-STRIPPED output (see PASTE_MARKER_PATTERN above for why
  * the raw stream never matches). Shared by both TUI consumers so the
  * strip-then-match contract can't drift between them.
@@ -200,12 +202,12 @@ export function isCollapsedPasteChip(strippedText) {
  * paste — the gate before sending the submit Enter(s). Two independent signals,
  * checked in priority order:
  *
- *   1. The TUI's own paste-commit MARKER (`[Pasted text #N]`) count exceeds the
- *      count the prompt itself carried (promptMarkerCount). This is AUTHORITATIVE
- *      and is checked FIRST because Claude Code collapses a multi-line bracketed
- *      paste INTO that chip and HIDES the pasted body text from the buffer — so on
- *      every multi-line prompt the literal text is genuinely absent even though
- *      the paste landed perfectly. Real incident (2026-07-05): every
+ *   1. The TUI's own paste-commit marker count exceeds the count the prompt
+ *      itself carried (promptMarkerCount). This is AUTHORITATIVE and is checked
+ *      FIRST because Claude Code collapses a multi-line bracketed paste into a
+ *      chip and HIDES the pasted body text from the buffer — so on every
+ *      multi-line prompt the literal text is genuinely absent even though the
+ *      paste landed perfectly. Real incident (2026-07-05): every
  *      claude-code-tui CoS agent failed `paste-not-rendered` after 3 retries
  *      because #2192's text-only check never saw the collapsed body — while the
  *      marker was sitting right there. (agent-656efa6e et al.)

--- a/server/lib/tuiHandshake.test.js
+++ b/server/lib/tuiHandshake.test.js
@@ -101,6 +101,13 @@ describe('tuiHandshake — paste timing constants', () => {
     expect(PASTE_MARKER_PATTERN.test('[PastedContent2431chars]')).toBe(true);
   });
 
+  it('PASTE_MARKER_PATTERN matches OpenCode paste-commit chips', () => {
+    expect(PASTE_MARKER_PATTERN.test('[Pasted ~46 lines]')).toBe(true);
+    expect(PASTE_MARKER_PATTERN.test('[Pasted~46lines]')).toBe(true);
+    expect(PASTE_MARKER_PATTERN.test('[Pasted ~1 line]')).toBe(true);
+    expect(PASTE_MARKER_PATTERN.test('[Pasted ~46 chars]')).toBe(false);
+  });
+
   it('PASTE_MARKER_PATTERN matches the SPACE-COLLAPSED form left after ANSI strip', () => {
     // The raw PTY stream renders the marker with absolute-column cursor moves
     // between tokens (`[Pasted\x1b[11Gtext\x1b[16G#1…`), so once ANSI is stripped
@@ -1494,6 +1501,12 @@ describe('tuiHandshake.isPasteConfirmed', () => {
   it('confirms when the prompt text DID render inline (markerless small paste)', () => {
     const inlineBuffer = '❯ Onthetaskspagewhenwerenderpending/active/blockedtaskcards Begin working on the task now.';
     expect(isPasteConfirmed(inlineBuffer, { verifiablePrefix: prefix, promptMarkerCount: 0 })).toBe(true);
+  });
+
+  it('confirms an OpenCode line-count chip even when the prompt body is hidden', () => {
+    const opencodeBuffer = 'Build · hf.co/example/model Ollama [Pasted ~46 lines]';
+    expect(verifyPasteRendered(opencodeBuffer, prefix)).toBe(false);
+    expect(isPasteConfirmed(opencodeBuffer, { verifiablePrefix: prefix, promptMarkerCount: 0 })).toBe(true);
   });
 
   it('does NOT confirm when neither the marker nor the text appears (paste swallowed by a not-ready TUI)', () => {

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -549,11 +549,11 @@ function createPasteRetryController({
     };
 
     // Confirms the TUI actually received the paste before we submit. The
-    // paste-commit MARKER ([Pasted text #N]) is authoritative — Claude Code
-    // collapses a multi-line paste into that chip and HIDES the body text, so a
-    // literal text check false-negatives on every multi-line prompt (real
-    // incident 2026-07-05: agent-656efa6e et al. failed `paste-not-rendered`
-    // despite the marker being present). Literal-text verification is only the
+    // paste-commit marker is authoritative — Claude Code and OpenCode can
+    // collapse a multi-line paste into a chip and HIDE the body text, so a
+    // literal text check false-negatives on multi-line prompts (real incident
+    // 2026-07-05: agent-656efa6e et al. failed `paste-not-rendered` despite
+    // Claude's marker being present). Literal-text verification is only the
     // fallback for the markerless path — see isPasteConfirmed.
     const pasteConfirmed = (buffer) =>
       isPasteConfirmed(buffer, { verifiablePrefix, promptMarkerCount });
@@ -1498,7 +1498,7 @@ export async function spawnTuiAgent({
   // failure mode that left the input empty. The `\r` is split from the paste
   // write because a fixed delay races Claude Code's paste-commit on large
   // prompts; instead we poll Claude Code's raw output for its
-  // `[Pasted text #N +M lines]` marker, then wait an extra
+  // provider paste-commit marker, then wait an extra
   // PASTE_TO_ENTER_MIN_DELAY_MS before submitting. A fallback timer fires
   // the Enter unconditionally if the marker never appears (very small
   // prompts won't trigger the marker). All timers are tracked so finish()


### PR DESCRIPTION
## Summary

- Recognize OpenCode’s `[Pasted ~N lines]` commit marker in the shared TUI handshake.
- Submit the recognized paste with Enter instead of treating it as failed and repeating the paste.
- Add regression coverage and a changelog fragment.

## Test plan

- `npm --prefix server test -- lib/tuiHandshake.test.js services/agentTuiSpawning.test.js lib/tuiPromptRunner.test.js`