### PR TITLE
fix: disable idle reap for local model agents

### DIFF
--- a/.changelog/next/fixed-agent-d6cc023f.md
+++ b/.changelog/next/fixed-agent-d6cc023f.md
@@ -1,0 +1,1 @@
+- Local-runtime TUI agents no longer use idle-reap timeouts while slow models are generating

--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -1127,26 +1127,29 @@ export function createBackgroundShellTracker() {
  *     prompt QUOTES `gh pr checks` / `gh pr merge` / `--delete-branch`, so the
  *     TUI's echo of that prompt latches `mergeQueueActive` before any work runs,
  *     and the agent — which is told to "Exit", makes no commit, and on
- *     Antigravity often skips the sentinel — then idles into (4)'s
+ *     Antigravity often skips the sentinel — then idles into (4)/(5)'s
  *     needs-manual-finish verdict 15 minutes later, gets retried twice more, and
  *     lands in Blocked with a HIGH "PR left open" card naming an already-merged
  *     PR (task sys-rl-msr1j1a5, PR #3909, 2026-08-13).
- *  2. Not yet at the (possibly extended) deadline → keep waiting.
- *  3–4. The extended-grace reaps: a latched merge queue / multi-reviewer loop
+ *  2. A null base timeout (local-runtime model) → keep waiting indefinitely;
+ *     `tuiMaxRuntimeMs` remains the separate wall-clock backstop.
+ *  3. Not yet at the (possibly extended) deadline → keep waiting.
+ *  4–5. The extended-grace reaps: a latched merge queue / multi-reviewer loop
  *     that blew even its 15-minute window is a needs-manual-finish FAILURE
  *     (#2074, PR #2084) — the run really did go dark mid-merge.
- *  5. `idle-no-activity` (#1229) — provider renders a work counter and it never
+ *  6. `idle-no-activity` (#1229) — provider renders a work counter and it never
  *     advanced: the prompt never submitted.
- *  6. Otherwise the pre-existing permissive `idle-complete`, which the caller
+ *  7. Otherwise the pre-existing permissive `idle-complete`, which the caller
  *     still gates on worktree evidence (#2191) before recording success.
  *
  * Note `backgroundShellActive` extends the deadline but carries NO verdict of
  * its own — a background-shell wait that blows its window falls through to the
- * ordinary (5)/(6) reasoning, unchanged.
+ * ordinary (6)/(7) reasoning, unchanged.
  *
  * @param {Object} signals
  * @param {number} signals.idle - ms since the last PTY output
- * @param {number} signals.baseIdleTimeoutMs - the run's configured idle window
+ * @param {number|null} signals.baseIdleTimeoutMs - the run's configured idle
+ *   window, or null to disable idle reaping for a local-runtime model
  * @param {boolean} [signals.mergeQueueActive]
  * @param {boolean} [signals.reviewLoopActive]
  * @param {boolean} [signals.backgroundShellActive]
@@ -1165,17 +1168,22 @@ export function decideIdleReap({
   workActive = false,
   rendersCounter = false,
 } = {}) {
-  const effectiveIdleTimeoutMs = mergeQueueActive
-    ? Math.max(baseIdleTimeoutMs, MERGE_QUEUE_IDLE_TIMEOUT_MS)
-    : reviewLoopActive
-      ? Math.max(baseIdleTimeoutMs, REVIEW_LOOP_IDLE_TIMEOUT_MS)
-      : backgroundShellActive
-        ? Math.max(baseIdleTimeoutMs, BACKGROUND_SHELL_IDLE_TIMEOUT_MS)
-        : baseIdleTimeoutMs;
-  if (prFollowUpMerged && idle >= baseIdleTimeoutMs) {
+  const idleTimeoutDisabled = baseIdleTimeoutMs === null;
+  const effectiveIdleTimeoutMs = idleTimeoutDisabled
+    ? Infinity
+    : mergeQueueActive
+      ? Math.max(baseIdleTimeoutMs, MERGE_QUEUE_IDLE_TIMEOUT_MS)
+      : reviewLoopActive
+        ? Math.max(baseIdleTimeoutMs, REVIEW_LOOP_IDLE_TIMEOUT_MS)
+        : backgroundShellActive
+          ? Math.max(baseIdleTimeoutMs, BACKGROUND_SHELL_IDLE_TIMEOUT_MS)
+          : baseIdleTimeoutMs;
+  if (!idleTimeoutDisabled && prFollowUpMerged && idle >= baseIdleTimeoutMs) {
     return { action: 'reap', success: true, reason: 'pr-follow-up-merged', effectiveIdleTimeoutMs };
   }
-  if (idle < effectiveIdleTimeoutMs) return { action: 'wait', effectiveIdleTimeoutMs };
+  if (idleTimeoutDisabled || idle < effectiveIdleTimeoutMs) {
+    return { action: 'wait', effectiveIdleTimeoutMs };
+  }
   if (mergeQueueActive) {
     return { action: 'reap', success: false, reason: 'merge-queue-idle-timeout', effectiveIdleTimeoutMs };
   }

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -240,6 +240,12 @@ function shellHasLiveChild(shellPid) {
   });
 }
 
+// Local-runtime models can spend many minutes between TUI output chunks while
+// generating. Their separate max-runtime ceiling still bounds a genuinely stuck
+// session, but silence must not be treated as completion or failure.
+const isLocalModelProvider = (provider) =>
+  isOllamaBackedProvider(provider) || provider?.mtplxBacked === true;
+
 export function buildTuiSpawnConfig(provider, model, { systemPromptFile = null, effort = null } = {}) {
   const command = provider?.command || inferTuiCommand(provider?.id);
   const baseArgs = applyCommandDefaults(command, [...(provider?.args || [])]);
@@ -261,7 +267,9 @@ export function buildTuiSpawnConfig(provider, model, { systemPromptFile = null, 
     args,
     commandLine: [command, ...args].map(shellQuote).join(' '),
     promptDelayMs: provider?.tuiPromptDelayMs || DEFAULT_TUI_PROMPT_DELAY_MS,
-    idleTimeoutMs: provider?.tuiIdleTimeoutMs || DEFAULT_TUI_IDLE_TIMEOUT_MS,
+    idleTimeoutMs: isLocalModelProvider(provider)
+      ? null
+      : provider?.tuiIdleTimeoutMs || DEFAULT_TUI_IDLE_TIMEOUT_MS,
     maxRuntimeMs: provider?.tuiMaxRuntimeMs || DEFAULT_TUI_MAX_RUNTIME_MS
   };
 }
@@ -723,6 +731,10 @@ export async function spawnTuiAgent({
   const doneSentinelPath = resolveDoneSentinelPath(workspacePath, agentId);
   const promptPreview = prompt.replace(/\s+/g, ' ').slice(0, 100);
   const commandName = tuiConfig.command.split('/').pop();
+  // Derive this again at the enforcement point so a caller that supplied a
+  // stale/pre-built config cannot accidentally re-arm the idle reaper for a
+  // local model.
+  const idleTimeoutMs = isLocalModelProvider(provider) ? null : tuiConfig.idleTimeoutMs;
 
   let finalized = false;
   let immediateFallbackAnalysis = null;
@@ -1707,7 +1719,7 @@ export async function spawnTuiAgent({
     // of a drifting inline copy. This body just executes what it returns.
     const decision = decideIdleReap({
       idle,
-      baseIdleTimeoutMs: tuiConfig.idleTimeoutMs,
+      baseIdleTimeoutMs: idleTimeoutMs,
       mergeQueueActive: mergeQueue.active,
       reviewLoopActive: reviewLoop.active,
       backgroundShellActive: backgroundShell.active,
@@ -1721,7 +1733,7 @@ export async function spawnTuiAgent({
     // synchronously by the NEXT tick's decision). Keyed on the base window, not
     // the extended one, precisely because the extended one is the bug: a merge
     // follow-up latches the merge-queue grace off its own echoed prompt.
-    if (idle >= tuiConfig.idleTimeoutMs) refreshFollowUpPrState();
+    if (Number.isFinite(idleTimeoutMs) && idle >= idleTimeoutMs) refreshFollowUpPrState();
     // Once within the LEAD window of the (possibly extended) reap deadline, keep
     // a reachability reading fresh (throttled, non-blocking) so the gate below
     // can read it synchronously and won't reap an agent that's only silent
@@ -1936,7 +1948,7 @@ export async function spawnTuiAgent({
       tuiSessionId: sessionId,
       tuiCommand: tuiConfig.commandLine,
       tuiKind,
-      tuiIdleTimeoutMs: tuiConfig.idleTimeoutMs,
+      tuiIdleTimeoutMs: idleTimeoutMs,
       tuiMaxRuntimeMs: tuiConfig.maxRuntimeMs
     }
   });

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -399,6 +399,25 @@ describe('agent TUI spawning', () => {
     expect(config.idleTimeoutMs).toBe(180000);
   });
 
+  it('disables idle reaping for local-runtime TUI providers', () => {
+    const ollama = buildTuiSpawnConfig({
+      id: 'claude-ollama-tui', type: 'tui', command: 'claude', ollamaBacked: true,
+      tuiIdleTimeoutMs: 30000,
+    }, 'qwen3:35b');
+    expect(ollama.idleTimeoutMs).toBeNull();
+
+    const mtplx = buildTuiSpawnConfig({
+      id: 'opencode-mtplx-tui', type: 'tui', command: 'opencode', mtplxBacked: true,
+      tuiIdleTimeoutMs: 30000,
+    }, 'mtplx');
+    expect(mtplx.idleTimeoutMs).toBeNull();
+
+    const cloud = buildTuiSpawnConfig({
+      id: 'codex-tui', type: 'tui', command: 'codex', tuiIdleTimeoutMs: 30000,
+    }, 'gpt-5.6-terra');
+    expect(cloud.idleTimeoutMs).toBe(30000);
+  });
+
   it('omits the --model flag when model is null/empty', () => {
     const config = buildTuiSpawnConfig({ id: 'codex-tui', command: 'codex', type: 'tui', args: [] }, null);
     expect(config.args).toEqual(['--dangerously-bypass-approvals-and-sandbox', '-c', 'check_for_update_on_startup=false']);
@@ -881,6 +900,45 @@ describe('spawnTuiAgent runtime', () => {
         success: true,
         completionReason: 'idle-complete',
       })
+    );
+  });
+
+  it('does not idle-reap an Ollama-backed TUI while a local model is silent', async () => {
+    let resolveComplete;
+    const completeDone = new Promise((r) => { resolveComplete = r; });
+    vi.mocked(agentLifecycle.finalizeAgent).mockImplementation(async () => { resolveComplete(); });
+    const checkOnlineFn = vi.fn().mockResolvedValue(true);
+
+    const spawnPromise = runSpawn({
+      provider: { id: 'claude-ollama-tui', name: 'Claude Ollama TUI', type: 'tui', command: 'claude', ollamaBacked: true, envVars: {} },
+      checkOnlineFn,
+    });
+    await flushMicrotasks();
+
+    await capturedOnData(Buffer.from('Claude Code booting...\n'));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    await capturedOnData(Buffer.from('do the thing\n'));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(3600);
+    await flushMicrotasks();
+    await capturedOnData(Buffer.from('(1s · thinking with high effort)\n'));
+    await vi.advanceTimersByTimeAsync(800);
+    await capturedOnData(Buffer.from('(2s · thinking with high effort)\n'));
+
+    // The supplied config has a 50ms idle window, but local-runtime providers
+    // disable it at the enforcement point. The max-runtime ceiling is hours out.
+    await vi.advanceTimersByTimeAsync(21000);
+    await flushMicrotasks();
+    expect(agentLifecycle.finalizeAgent).not.toHaveBeenCalled();
+    expect(checkOnlineFn).not.toHaveBeenCalled();
+
+    await capturedOnExit({ exitCode: 0, killed: false });
+    await spawnPromise;
+    await completeDone;
+    expect(agentLifecycle.finalizeAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ success: true, completionReason: 'shell-exit' })
     );
   });
 
@@ -2635,6 +2693,20 @@ describe('spawnTuiAgent runtime', () => {
 // fake-timer harness above, not by this pure function.
 describe('agentTuiSpawning — idle reap decision (#2074)', () => {
   const BASE = 180000;
+
+  it('waits indefinitely when a local-runtime model disables idle reaping', () => {
+    const r = decideIdleReap({
+      idle: Number.MAX_SAFE_INTEGER,
+      baseIdleTimeoutMs: null,
+      mergeQueueActive: true,
+      reviewLoopActive: true,
+      backgroundShellActive: true,
+      workActive: false,
+      rendersCounter: true,
+    });
+    expect(r.action).toBe('wait');
+    expect(r.effectiveIdleTimeoutMs).toBe(Infinity);
+  });
 
   it('does NOT reap at the 3-min default while in a merge queue — grace extends to 15min', () => {
     const r = decideIdleReap({ idle: BASE + 5000, baseIdleTimeoutMs: BASE, mergeQueueActive: true, workActive: true, rendersCounter: true });


### PR DESCRIPTION
## Summary

- Disable TUI idle reaping for Ollama-backed and MTPLX-backed local model providers.
- Preserve prompt handshakes, sentinel completion, shell-exit handling, and the absolute max-runtime ceiling.
- Keep configured idle behavior unchanged for cloud TUI providers.

## Test plan

- npm test -- services/agentTuiSpawning.test.js
- npm test -- services/agentTuiSpawning.test.js lib/tuiHandshake.test.js