### PR TITLE
refactor: single server definition of DEFAULT_NEGATIVE_PROMPT

### DIFF
--- a/client/src/lib/imageGenDefaults.js
+++ b/client/src/lib/imageGenDefaults.js
@@ -1,8 +1,9 @@
 // Image-gen defaults shared between the full Image Gen form and quick-submit
 // entry points (e.g. the Dashboard Quick Image widget).
 //
-// The server mirrors DEFAULT_NEGATIVE_PROMPT in
-// `server/services/imageGen/index.js` and `server/services/imageGen/external.js`
-// — when changing this string, update both server copies too.
+// The server keeps its own copy in `server/services/imageGen/defaults.js`
+// (the client cannot import server modules). The two are pinned together by
+// `server/services/imageGen/defaults.parity.test.js` — change one, and the
+// test names the other until they match again.
 
 export const DEFAULT_NEGATIVE_PROMPT = 'blurry, low quality, distorted, deformed, ugly, watermark, text, signature';

--- a/server/services/imageGen/defaults.js
+++ b/server/services/imageGen/defaults.js
@@ -1,0 +1,12 @@
+/**
+ * Image Gen — shared default constants.
+ *
+ * Standalone for the same reason as modes.js: the dispatcher (`index.js`)
+ * and the provider modules (`external.js`, …) both import, so the base
+ * negative prompt is defined exactly once on the server. The client keeps
+ * its own mirror in `client/src/lib/imageGenDefaults.js` because it cannot
+ * import server modules; `defaults.parity.test.js` fails when the two
+ * drift apart.
+ */
+
+export const DEFAULT_NEGATIVE_PROMPT = 'blurry, low quality, distorted, deformed, ugly, watermark, text, signature';

--- a/server/services/imageGen/defaults.parity.test.js
+++ b/server/services/imageGen/defaults.parity.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { DEFAULT_NEGATIVE_PROMPT } from './defaults.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const read = (p) => readFileSync(join(HERE, p), 'utf8');
+
+describe('imageGen defaults', () => {
+  it('matches the client mirror, which cannot import this module', () => {
+    // client/src/lib/imageGenDefaults.js hardcodes the same string for the
+    // Image Gen form and the Dashboard Quick Image widget. If it drifts,
+    // the user edits against one default while the server applies another —
+    // silently, which is why this is a test and not a comment.
+    const clientSrc = read('../../../client/src/lib/imageGenDefaults.js');
+    const match = clientSrc.match(/DEFAULT_NEGATIVE_PROMPT = '([^']+)'/);
+    expect(match, 'client mirror not found — did DEFAULT_NEGATIVE_PROMPT move?').toBeTruthy();
+    expect(match[1]).toBe(DEFAULT_NEGATIVE_PROMPT);
+  });
+
+  it('is the only server-side definition of the base negative prompt', () => {
+    // The dedupe this module exists for: discover the service's modules
+    // rather than listing them, so a fresh pasted-in copy cannot sneak back
+    // in next to a new provider.
+    const offenders = readdirSync(HERE)
+      .filter((f) => f.endsWith('.js') && !f.endsWith('.test.js') && f !== 'defaults.js')
+      .map((f) => [f, read(f)])
+      .filter(([, src]) => src.includes("'blurry, low quality"))
+      .map(([f]) => f);
+    expect(offenders, 'literal copies found outside defaults.js').toEqual([]);
+  });
+});

--- a/server/services/imageGen/external.js
+++ b/server/services/imageGen/external.js
@@ -15,8 +15,8 @@ import { fetchWithTimeout } from '../../lib/fetchWithTimeout.js';
 import { autoCleanGeneratedImage } from '../../lib/imageClean.js';
 import { imageGenEvents } from '../imageGenEvents.js';
 import { IMAGE_GEN_MODE } from './modes.js';
+import { DEFAULT_NEGATIVE_PROMPT } from './defaults.js';
 
-const DEFAULT_NEGATIVE_PROMPT = 'blurry, low quality, distorted, deformed, ugly, watermark, text, signature';
 const PROGRESS_POLL_INTERVAL = 500;
 const IMAGE_PREVIEW_THROTTLE = 2000;
 const MODEL_CACHE_TTL = 5 * 60 * 1000;

--- a/server/services/imageGen/index.js
+++ b/server/services/imageGen/index.js
@@ -23,6 +23,7 @@ import * as agy from './agy.js';
 import {
   IMAGE_GEN_MODE, IMAGE_GEN_MODES, CLOUD_IMAGE_GEN_MODES, isEditCapableMode,
 } from './modes.js';
+import { DEFAULT_NEGATIVE_PROMPT } from './defaults.js';
 import { resolveCloudProviderConfig } from './cloudProviderConfig.js';
 import { rejectDegenerateFrame } from './frameGuard.js';
 import { PATHS } from '../../lib/fileUtils.js';
@@ -156,8 +157,6 @@ async function guardResolvedFrame(result) {
   if (reason) throw new ServerError(reason, { status: 502, code: 'DEGENERATE_FRAME' });
   return result;
 }
-
-const DEFAULT_NEGATIVE_PROMPT = 'blurry, low quality, distorted, deformed, ugly, watermark, text, signature';
 
 // Build the default avatar prompt for the human-centered Character surface (#2677).
 // The Character page portrays the real human user, so a blank identity must NOT


### PR DESCRIPTION
Closes #4376.

## What changed

- New `server/services/imageGen/defaults.js` exporting `DEFAULT_NEGATIVE_PROMPT` — standalone for the same cycle-avoidance reason as `modes.js`, per the issue's decision. Not in `server/lib/` (no lib consumer).
- `imageGen/index.js` and `imageGen/external.js` import it; their local consts are gone. Per-call-site suffixes (`nude, nsfw` in the avatar default) stay local, as specified.
- `defaults.parity.test.js` follows the `uploadLimits.test.js` prior art: it reads the client module (which cannot import server modules) and asserts string equality, and additionally scans the service's modules so a freshly pasted literal cannot sneak back in next to a new provider.
- The client comment no longer says "update both server copies" — it points at the parity test that names the drift instead.

## How I verified

`cd server && npx vitest run services/imageGen` — 19 files, 311 tests pass, including both new ones. (First run caught my own path bug — the client mirror is three levels up from `services/imageGen/`, not two — which is the parity test doing exactly its job.)
