### PR TITLE
Retire Moltbook/Moltworld class aliases and pin the services catalog

### DIFF
--- a/.changelog/next/changed-molt-client-aliases-and-services-readme.md
+++ b/.changelog/next/changed-molt-client-aliases-and-services-readme.md
@@ -1,0 +1,1 @@
+- Retired the unused Moltbook/Moltworld class aliases and pinned the services README catalog.

--- a/client/src/services/README.md
+++ b/client/src/services/README.md
@@ -9,7 +9,8 @@ either `import * as api from '.../services/api'` or `import { specificFn } from 
 
 This directory has no `index.js` barrel because every file already follows the `apiX.js`
 naming convention, and `api.js` already aggregates them. When you add a new `apiX.js`,
-add it to `api.js` and add a row here.
+add it to `api.js` and add a row here. `index.test.js` fails if either side drifts
+(or if a non-api helper is added without a README row).
 
 ## Discovery rule
 
@@ -79,6 +80,7 @@ toasts on throw). **Custom catch ⇒ `silent: true`** — otherwise toasts fire 
 | `apiMortalLoom.js` | Mortality tracking. |
 | `apiMoodBoard.js` | Mood boards (inspiration canvas + items). |
 | `apiTribe.js` | Tribe people (relationship rings + contacts). |
+| `apiTimeline.js` | Human-activity timeline: `/timeline/day` + `/timeline/events`. |
 | `apiCalendar.js` | Calendar events. |
 | `apiMessages.js` | Messages / notifications + iMessage manager (#2413). |
 | `apiStackerNews.js` | Stacker News account, territory, review-action, and safe analysis APIs. |

--- a/client/src/services/index.test.js
+++ b/client/src/services/index.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import * as barrel from './api.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const BARREL_SRC = readFileSync(join(HERE, 'api.js'), 'utf8');
+const README_SRC = readFileSync(join(HERE, 'README.md'), 'utf8');
+
+const sourceFiles = readdirSync(HERE).filter(
+  (f) => (f.endsWith('.js') || f.endsWith('.jsx'))
+    && !f.endsWith('.test.js') && !f.endsWith('.test.jsx')
+    && f !== 'api.js',
+);
+
+const apiFiles = sourceFiles.filter((f) => f.startsWith('api') && f.endsWith('.js'));
+
+describe('client/src/services/ catalog', () => {
+  it('re-exports every apiX.js from api.js', () => {
+    expect(Object.keys(barrel).length).toBeGreaterThan(0);
+    for (const f of apiFiles) {
+      expect(BARREL_SRC, `missing barrel re-export for ${f}`).toContain(`'./${f}'`);
+    }
+  });
+
+  it('every non-test source file has a README row', () => {
+    for (const f of sourceFiles) {
+      const base = f.replace(/\.(js|jsx)$/, '');
+      expect(README_SRC, `missing README entry for ${f}`).toContain(base);
+    }
+  });
+});

--- a/server/integrations/moltbook/index.js
+++ b/server/integrations/moltbook/index.js
@@ -19,7 +19,7 @@ export {
   clearRateLimitState
 } from './rateLimits.js';
 
-// Export a convenience client class for stateful usage
+// Export a convenience client factory for stateful usage
 import * as api from './api.js';
 import { getRateLimitStatus } from './rateLimits.js';
 
@@ -66,9 +66,6 @@ export function createMoltbookClient(apiKey) {
   };
   return client;
 }
-
-/** @deprecated Use createMoltbookClient() */
-export const MoltbookClient = createMoltbookClient;
 
 /**
  * Register a new agent on Moltbook (doesn't require an existing API key)

--- a/server/integrations/moltworld/index.js
+++ b/server/integrations/moltworld/index.js
@@ -20,7 +20,7 @@ export {
   clearRateLimitState
 } from './rateLimits.js';
 
-// Export a convenience client class for stateful usage
+// Export a convenience client factory for stateful usage
 import * as api from './api.js';
 import { getRateLimitStatus } from './rateLimits.js';
 
@@ -44,9 +44,6 @@ export function createMoltworldClient(apiKey, agentId) {
     getRateLimitStatus: () => getRateLimitStatus(agentId),
   };
 }
-
-/** @deprecated Use createMoltworldClient() */
-export const MoltworldClient = createMoltworldClient;
 
 /**
  * Register a new agent on Moltworld (doesn't require an existing agent ID)

--- a/server/routes/agentTools.js
+++ b/server/routes/agentTools.js
@@ -24,7 +24,7 @@ import * as agentActivity from '../services/agentActivity.js';
 import * as agentDrafts from '../services/agentDrafts.js';
 import { generatePost, generateComment, generateReply } from '../services/agentContentGenerator.js';
 import { findRelevantPosts } from '../services/agentFeedFilter.js';
-import { MoltbookClient } from '../integrations/moltbook/index.js';
+import { createMoltbookClient } from '../integrations/moltbook/index.js';
 import { collectPublishedPosts } from '../services/agentPublished.js';
 import { sleep } from '../lib/fileUtils.js';
 
@@ -35,7 +35,7 @@ const MOLTBOOK_ACTION_DELAY_MS = 1500;
 const router = Router();
 
 /**
- * Get authenticated MoltbookClient for an account
+ * Get an authenticated Moltbook client for an account
  */
 async function getClientAndAgent(accountId, agentId) {
   const account = await platformAccounts.getAccountWithCredentials(accountId);
@@ -51,7 +51,7 @@ async function getClientAndAgent(accountId, agentId) {
     throw new ServerError('Agent not found', { status: 404, code: 'NOT_FOUND' });
   }
 
-  const client = new MoltbookClient(account.credentials.apiKey);
+  const client = createMoltbookClient(account.credentials.apiKey);
   return { client, agent, account };
 }
 
@@ -242,7 +242,7 @@ router.get('/feed', asyncHandler(async (req, res) => {
     throw new ServerError('Account not found', { status: 404, code: 'NOT_FOUND' });
   }
 
-  const client = new MoltbookClient(account.credentials.apiKey);
+  const client = createMoltbookClient(account.credentials.apiKey);
   const feed = await client.getFeed(sort, parseInt(limit, 10));
   res.json(feed);
 }));
@@ -277,7 +277,7 @@ router.get('/submolts', asyncHandler(async (req, res) => {
     throw new ServerError('Account not found', { status: 404, code: 'NOT_FOUND' });
   }
 
-  const client = new MoltbookClient(account.credentials.apiKey);
+  const client = createMoltbookClient(account.credentials.apiKey);
   const submolts = await client.getSubmolts();
   res.json(submolts);
 }));
@@ -298,7 +298,7 @@ router.get('/post/:postId', asyncHandler(async (req, res) => {
     throw new ServerError('Account not found', { status: 404, code: 'NOT_FOUND' });
   }
 
-  const client = new MoltbookClient(account.credentials.apiKey);
+  const client = createMoltbookClient(account.credentials.apiKey);
   const [post, commentsResponse] = await Promise.all([
     client.getPost(postId),
     client.getComments(postId)
@@ -325,7 +325,7 @@ router.get('/rate-limits', asyncHandler(async (req, res) => {
     throw new ServerError('Account not found', { status: 404, code: 'NOT_FOUND' });
   }
 
-  const client = new MoltbookClient(account.credentials.apiKey);
+  const client = createMoltbookClient(account.credentials.apiKey);
   const rateLimits = client.getRateLimitStatus();
   res.json(rateLimits);
 }));

--- a/server/routes/agentTools.test.js
+++ b/server/routes/agentTools.test.js
@@ -32,7 +32,7 @@ vi.mock('../services/agentFeedFilter.js', () => fnMap([
 ]));
 vi.mock('../services/agentPublished.js', () => fnMap(['collectPublishedPosts']));
 
-// MoltbookClient is a factory; checkRateLimit gates the engage loop's writes.
+// createMoltbookClient is a factory; checkRateLimit gates the engage loop's writes.
 const moltbookClient = vi.hoisted(() => ({
   upvote: vi.fn(() => Promise.resolve({})),
   createComment: vi.fn(() => Promise.resolve({ id: 'c1' })),
@@ -42,9 +42,7 @@ const moltbookClient = vi.hoisted(() => ({
 }));
 const checkRateLimitMock = vi.hoisted(() => vi.fn(() => ({ allowed: true })));
 vi.mock('../integrations/moltbook/index.js', () => ({
-  // The route calls `new MoltbookClient(apiKey)`; a plain function returning
-  // the shared mock client is constructable (new returns the object).
-  MoltbookClient: function MoltbookClient() { return moltbookClient; },
+  createMoltbookClient: () => moltbookClient,
   checkRateLimit: checkRateLimitMock,
 }));
 

--- a/server/routes/moltworldTools.js
+++ b/server/routes/moltworldTools.js
@@ -11,13 +11,13 @@ import { validateRequest, moltworldJoinSchema, moltworldBuildSchema, moltworldEx
 import * as platformAccounts from '../services/platformAccounts.js';
 import * as agentPersonalities from '../services/agentPersonalities.js';
 import * as agentActivity from '../services/agentActivity.js';
-import { MoltworldClient } from '../integrations/moltworld/index.js';
+import { createMoltworldClient } from '../integrations/moltworld/index.js';
 import * as moltworldQueue from '../services/moltworldQueue.js';
 
 const router = Router();
 
 /**
- * Get authenticated MoltworldClient for an account
+ * Get an authenticated Moltworld client for an account
  */
 async function getClientAndAgent(accountId, agentId) {
   const account = await platformAccounts.getAccountWithCredentials(accountId);
@@ -35,7 +35,7 @@ async function getClientAndAgent(accountId, agentId) {
 
   // Moltworld uses agentId for all API calls; fall back to apiKey which serves as the agent identifier
   const moltworldAgentId = account.credentials.agentId || account.credentials.apiKey;
-  const client = new MoltworldClient(
+  const client = createMoltworldClient(
     account.credentials.apiKey,
     moltworldAgentId
   );

--- a/server/routes/platformAccounts.js
+++ b/server/routes/platformAccounts.js
@@ -175,7 +175,7 @@ router.post('/:id/test', asyncHandler(async (req, res) => {
 
   if (account.platform === 'moltbook') {
     // Test with real Moltbook API - fetch profile (read-only, no side effects)
-    const client = new moltbook.MoltbookClient(account.credentials.apiKey);
+    const client = moltbook.createMoltbookClient(account.credentials.apiKey);
     const profileResult = await client.getProfile();
     const agent = profileResult.agent || profileResult;
     const platformStatus = agent.is_claimed ? 'active' : 'pending_claim';
@@ -200,7 +200,7 @@ router.post('/:id/test', asyncHandler(async (req, res) => {
     res.json(testResult);
   } else if (account.platform === 'moltworld') {
     // Test with Moltworld API — fetch profile + balance
-    const client = new moltworld.MoltworldClient(
+    const client = moltworld.createMoltworldClient(
       account.credentials.apiKey,
       account.credentials.agentId
     );

--- a/server/services/agentActionExecutor.js
+++ b/server/services/agentActionExecutor.js
@@ -10,8 +10,8 @@ import { scheduleEvents } from './automationScheduler.js';
 import * as agentActivity from './agentActivity.js';
 import * as platformAccounts from './platformAccounts.js';
 import * as agentPersonalities from './agentPersonalities.js';
-import { MoltbookClient, checkRateLimit, isAccountSuspended } from '../integrations/moltbook/index.js';
-import { MoltworldClient } from '../integrations/moltworld/index.js';
+import { createMoltbookClient, checkRateLimit, isAccountSuspended } from '../integrations/moltbook/index.js';
+import { createMoltworldClient } from '../integrations/moltworld/index.js';
 import { generatePost, generateComment, generateReply } from './agentContentGenerator.js';
 import { findRelevantPosts, findReplyOpportunities } from './agentFeedFilter.js';
 import { sleep as delay } from '../lib/fileUtils.js';
@@ -31,7 +31,7 @@ async function executeAction(schedule, account, agent) {
     return executeMoltworldAction(action, account, agent);
   }
 
-  const client = new MoltbookClient(account.credentials.apiKey);
+  const client = createMoltbookClient(account.credentials.apiKey);
 
   switch (action.type) {
     case 'heartbeat':
@@ -406,7 +406,7 @@ async function executeMonitor(client, agent, schedule, params) {
  * Dispatch a Moltworld action
  */
 async function executeMoltworldAction(action, account, agent) {
-  const client = new MoltworldClient(
+  const client = createMoltworldClient(
     account.credentials.apiKey,
     account.credentials.agentId
   );

--- a/server/services/agentActionExecutor.test.js
+++ b/server/services/agentActionExecutor.test.js
@@ -44,13 +44,13 @@ vi.mock('./agentPersonalities.js', () => ({
 }));
 
 vi.mock('../integrations/moltbook/index.js', () => ({
-  MoltbookClient: vi.fn(function () { return mockMoltbookClient; }),
+  createMoltbookClient: vi.fn(() => mockMoltbookClient),
   checkRateLimit: vi.fn(() => ({ allowed: true })),
   isAccountSuspended: vi.fn(() => false)
 }));
 
 vi.mock('../integrations/moltworld/index.js', () => ({
-  MoltworldClient: vi.fn(function () { return mockMoltworldClient; })
+  createMoltworldClient: vi.fn(() => mockMoltworldClient)
 }));
 
 vi.mock('./agentContentGenerator.js', () => ({
@@ -67,8 +67,6 @@ vi.mock('./agentFeedFilter.js', () => ({
 import * as agentActivity from './agentActivity.js';
 import * as platformAccounts from './platformAccounts.js';
 import * as agentPersonalities from './agentPersonalities.js';
-import { MoltbookClient, checkRateLimit, isAccountSuspended } from '../integrations/moltbook/index.js';
-import { MoltworldClient } from '../integrations/moltworld/index.js';
 import { generatePost, generateComment, generateReply } from './agentContentGenerator.js';
 import { findRelevantPosts, findReplyOpportunities } from './agentFeedFilter.js';
 import { init } from './agentActionExecutor.js';


### PR DESCRIPTION
## Summary

Two leftover cleanups from the good-first-issue scan, landed as one change instead of two tickets.

**Moltbook / Moltworld clients.** `MoltbookClient` and `MoltworldClient` were `@deprecated` aliases of `createMoltbookClient` / `createMoltworldClient`. Every production caller still used the aliases via `new`, which only worked because a factory that returns an object is constructable. Call sites now use the factory; the aliases are gone. Tests mock the factory.

**Services catalog.** `apiTimeline.js` was the last `apiX.js` missing from `client/src/services/README.md`. `index.test.js` now fails if a new `apiX.js` is not re-exported from `api.js`, or if any non-test source file is missing from the README — same contract as `hooks/`, `lib/`, and `utils/`.

## Test plan

- [x] `cd server && npx vitest run services/agentActionExecutor.test.js routes/agentTools.test.js integrations/moltbook integrations/moltworld`
- [x] `cd client && npx vitest run src/services/index.test.js`
- [ ] Grep for `MoltbookClient` / `MoltworldClient` should only hit mock-object names and comments, not exports