### PR TITLE
fix: escape backticks in DataDog job prompt template that broke server boot

### DIFF
--- a/server/services/autonomousJobs/defaults.js
+++ b/server/services/autonomousJobs/defaults.js
@@ -172,7 +172,7 @@ Phase 3 — File Issues and Queue Fixes:
 5. For each genuinely new error:
    - Update the error cache with the new fingerprint (always, regardless of JIRA config)
    - If app has jira.enabled = true AND jira.instanceId AND jira.projectKey are set:
-     Create a JIRA ticket with labels ["datadog-auto", "cos-detected"] plus equivalent dispatch/contributor labels when independently justified (`model-light|model-medium|model-heavy`, `effort-low|effort-medium|effort-high|effort-xhigh|effort-max`, `good-first-issue`, `help-wanted` — omit an axis rather than guessing; a recurring unknown crash is not a good-first-issue):
+     Create a JIRA ticket with labels ["datadog-auto", "cos-detected"] plus equivalent dispatch/contributor labels when independently justified (\`model-light|model-medium|model-heavy\`, \`effort-low|effort-medium|effort-high|effort-xhigh|effort-max\`, \`good-first-issue\`, \`help-wanted\` — omit an axis rather than guessing; a recurring unknown crash is not a good-first-issue):
      POST /api/jira/instances/:instanceId/tickets with projectKey, summary, description, issueType: "Bug", labels
    - Create a CoS task to fix the error in an isolated worktree:
      POST /api/cos/tasks with type: "internal", useWorktree: true, openPR: true, the error stack trace, JIRA ticket reference (if created), and instructions to implement fix + open PR


### PR DESCRIPTION
## Summary

`server/services/autonomousJobs/defaults.js` line 175 (the DataDog Error Monitor `promptTemplate`) has raw, unescaped backticks around inline code examples (`` `model-light|model-medium|model-heavy` ``, etc). Since that string is itself inside a template literal, those backticks close it early — the remainder of the file becomes invalid JS and throws `SyntaxError: Unexpected identifier 'model'` on import.

This landed in #4351 (merged as part of #4368) and has broken server boot on `main` since — `npm run smoke` crashes immediately, and CI's "Smoke-boot server" step has been red on every PR since, blocking merges repo-wide.

Fix: escape the backticks the same way the file already does a few lines up (`` Use the \`gh\` CLI ``), matching the established convention in this file.

## Test plan

- [x] `node -e "import('./server/services/autonomousJobs/defaults.js')"` — imports cleanly, 11 jobs loaded (previously threw)
- [x] `npm run smoke` — server boots and shuts down cleanly (previously crashed within the boot window)
- [x] `cd server && npx vitest run services/autonomousJobs` — 5 files, 148 tests pass