### PR TITLE
fix: require complete labels on repo-study issues

### DIFF
--- a/.changelog/next/changed-agent-3deda7a1.md
+++ b/.changelog/next/changed-agent-3deda7a1.md
@@ -1,0 +1,1 @@
+- Repo-study issue filing now requires complete area and dispatch labels

--- a/server/lib/dispatchLabels.js
+++ b/server/lib/dispatchLabels.js
@@ -236,3 +236,51 @@ export const JIRA_DISPATCH_HINT_GUIDANCE = [
   'Also apply contributor labels when the work actually fits them — independently of the dispatch axes: `good-first-issue` (self-contained, a new contributor can ship it) and `help-wanted` (extra hands welcome, scoped enough to pick up cold). A `model-light` 40-file sweep is NOT a good-first-issue.',
   'Preserve existing category/scope labels. Never relabel a ticket you skipped as a duplicate.',
 ].join('\n');
+
+/**
+ * Current PortOS scope-label vocabulary. The forge remains the source of truth
+ * at filing time (`gh label list --search area:` / `glab label list`), while this
+ * list keeps autonomous prompts aware of the established labels instead of
+ * inventing a new area for every reference study.
+ */
+export const PORTOS_AREA_LABELS = Object.freeze([
+  'area:database',
+  'area:songs',
+  'area:federation',
+  'area:pipeline',
+  'area:story-builder',
+  'area:writers-room',
+  'area:create',
+  'area:cybercity',
+  'area:brain',
+  'area:cos-agents',
+  'area:identity',
+  'area:content',
+  'area:devtools',
+  'area:ui',
+  'area:post',
+  'area:privacy',
+  'area:life-tracking',
+  'area:media',
+]);
+
+/** Shared scope guidance for the one-shot repo-study label contract. */
+export const PORTOS_AREA_LABEL_GUIDANCE = [
+  'Scope labels (`area:*`) are required for repo-study issues. Inspect the target files and apply every relevant existing area label, preferring the narrowest label rather than a generic guess.',
+  `The current PortOS area vocabulary is: ${PORTOS_AREA_LABELS.join(', ')}. Re-check the forge with \`gh label list --search area:\` or \`glab label list\` before filing; create a genuinely missing, clearly scoped area label before applying it instead of omitting scope (GitHub: \`gh label create <name> --color 0366D6 --description \"…\" --force\`; GitLab: \`glab label create --name <name> --color \"#0366D6\" --description \"…\"\`).`,
+].join('\n');
+
+/**
+ * Repo studies have enough target-code evidence to make all three routing
+ * decisions. Keep this contract separate from the general guidance, where the
+ * model/effort axes are intentionally optional for other issue producers.
+ */
+export const REPO_STUDY_LABEL_CONTRACT = Object.freeze({
+  forgeFlags: '--label area:<area> --label model:<tier> --label effort:<level>',
+  jiraFlags: '`area:<area>` + `model-<tier>` + `effort-<level>`',
+  instructions: [
+    '**Repo-study complete-label contract (mandatory):** every NEW proposal must carry `repo-study`, `plan`, at least one relevant `area:*`, exactly one justified model label (`model:*` on GitHub/GitLab, `model-*` on JIRA), and exactly one justified effort label (`effort:*` on GitHub/GitLab, `effort-*` on JIRA). The dispatch axes are independent: choose them from the inspected PortOS files and proposed implementation, never by stamping `medium` on both.',
+    PORTOS_AREA_LABEL_GUIDANCE,
+    'If a proposal cannot be classified defensibly on all three axes, do not file that proposal; filing an incomplete issue is not a valid fallback. After each NEW issue, read its labels back and repair any missing required label before continuing; never relabel a duplicate you skipped. Contributor labels remain optional and must follow the shared guidance.',
+  ].join('\n'),
+});

--- a/server/lib/dispatchLabels.test.js
+++ b/server/lib/dispatchLabels.test.js
@@ -5,6 +5,9 @@ import {
   DISPATCH_LABEL_COLORS,
   DISPATCH_HINT_GUIDANCE,
   JIRA_DISPATCH_HINT_GUIDANCE,
+  PORTOS_AREA_LABELS,
+  PORTOS_AREA_LABEL_GUIDANCE,
+  REPO_STUDY_LABEL_CONTRACT,
   GOOD_FIRST_ISSUE_LABEL,
   HELP_WANTED_LABEL,
   JIRA_GOOD_FIRST_ISSUE_LABEL,
@@ -164,5 +167,16 @@ describe('shared guidance', () => {
     expect(JIRA_DISPATCH_HINT_GUIDANCE).toContain('good-first-issue');
     expect(JIRA_DISPATCH_HINT_GUIDANCE).toContain('help-wanted');
     expect(JIRA_DISPATCH_HINT_GUIDANCE).not.toMatch(/model:light/);
+  });
+
+  it('keeps the PortOS area vocabulary and repo-study complete-label contract explicit', () => {
+    expect(PORTOS_AREA_LABELS).toContain('area:cos-agents');
+    expect(PORTOS_AREA_LABELS).toContain('area:media');
+    expect(PORTOS_AREA_LABEL_GUIDANCE).toContain('area:*');
+    expect(PORTOS_AREA_LABEL_GUIDANCE).toContain('gh label list --search area:');
+    expect(REPO_STUDY_LABEL_CONTRACT.forgeFlags)
+      .toBe('--label area:<area> --label model:<tier> --label effort:<level>');
+    expect(REPO_STUDY_LABEL_CONTRACT.jiraFlags).toContain('model-<tier>');
+    expect(REPO_STUDY_LABEL_CONTRACT.instructions).toContain('complete-label contract (mandatory)');
   });
 });

--- a/server/lib/workTracker.js
+++ b/server/lib/workTracker.js
@@ -15,7 +15,11 @@
 // `git`). See server/services/cosTaskGenerator.js for the claim-work router
 // that consumes trackerToClaimTaskType.
 
-import { DISPATCH_HINT_GUIDANCE, JIRA_DISPATCH_HINT_GUIDANCE } from './dispatchLabels.js';
+import {
+  DISPATCH_HINT_GUIDANCE,
+  JIRA_DISPATCH_HINT_GUIDANCE,
+  REPO_STUDY_LABEL_CONTRACT,
+} from './dispatchLabels.js';
 import { getOriginInfo, readOriginRemoteUrl } from './gitRemote.js';
 
 // Every selectable value (UI + Zod enum). `'auto'` is the default; the rest are
@@ -200,6 +204,7 @@ export const TRACKER_FILING_PRESETS = {
     label: 'repo-study',
     issueLabel: 'repo-study',
     labelDescription: 'Proposed from a study of a captured reference repository',
+    issueLabelContract: REPO_STUDY_LABEL_CONTRACT,
     planItemBody: 'From the `repo-study` of <owner/repo> (<today\'s date>). <What the upstream does and why it is worth having, 1–2 sentences.> Fix: <files + functions in {appName}>. <Estimated scope.>',
     bodyRequirements: 'the provenance (the studied repo\'s owner/repo + its license + today\'s date), the 1–2 sentence rationale for {appName}, the `Fix:` line naming the {appName} files/functions to change, and the estimated scope',
     planCommitMessage: 'docs(repo-study): propose <N> item(s) from <owner/repo>',
@@ -226,8 +231,19 @@ export const TRACKER_FILING_TASK_TYPES = new Set(Object.keys(TRACKER_FILING_PRES
 export function formatTrackerInstructions(tracker, options = {}) {
   const {
     slugPrefix, label, issueLabel, labelDescription,
+    issueLabelContract,
     planItemBody, bodyRequirements, planCommitMessage,
   } = { ...TRACKER_FILING_PRESETS['reference-watch'], ...options };
+  const forgeLabelFlags = issueLabelContract?.forgeFlags
+    ? `${issueLabelContract.forgeFlags} [--label "good first issue"] [--label "help wanted"]`
+    : '[--label model:<tier>] [--label effort:<level>] [--label "good first issue"] [--label "help wanted"]';
+  const jiraLabelContract = issueLabelContract
+    ? `\n  ${issueLabelContract.instructions.split('\n').join('\n  ')}\n  For JIRA, use the equivalent labels ${issueLabelContract.jiraFlags}.`
+    : '';
+  const forgeLabelContract = issueLabelContract
+    ? `\n  3. ${issueLabelContract.instructions.split('\n').join('\n     ')}`
+    : '';
+  const forgeFileStep = issueLabelContract ? '4.' : '3.';
   // `ref-watch-` → `ref-watch`: the forge title search wants the stem, not the
   // trailing separator (`--search "ref-watch in:title"`).
   const slugStem = slugPrefix.replace(/-+$/, '');
@@ -249,9 +265,10 @@ export function formatTrackerInstructions(tracker, options = {}) {
 - **Record** each NEW proposal as a GitHub issue. Do not relabel or edit an existing issue you skipped as a duplicate. Keep the \`[<slug>]\` inventory tag in the title so later runs can de-duplicate; do NOT add \`[category]\` / \`[SEVERITY]\` / \`[model:…]\` / \`[effort:…]\` prefixes (those belong in labels).
   1. Ensure each label you will apply exists. Create the category label first (\`gh label create ${issueLabel} --description "${labelDescription}" --force\`) and \`gh label create plan --description "Tracked by /do:replan" --force\`. Then create each justified dispatch-hint label immediately before applying it.
   2. ${DISPATCH_HINT_GUIDANCE.split('\n').join('\n     ')}
-  3. File with repeated \`--label\` flags so the category/scope labels stay intact:
+${forgeLabelContract}
+  ${forgeFileStep} File with repeated \`--label\` flags so the category/scope labels stay intact:
   \`\`\`bash
-  gh issue create --title "[<slug>] <Short title>" --label ${issueLabel} --label plan [--label model:<tier>] [--label effort:<level>] [--label "good first issue"] [--label "help wanted"] --body "<body>"
+  gh issue create --title "[<slug>] <Short title>" --label ${issueLabel} --label plan ${forgeLabelFlags} --body "<body>"
   \`\`\`
   The body must contain ${bodyRequirements}. For **Maybe — needs human call** items, also add \`--label needs-decision\` (create it the same way if absent) and end the body with \`**Decision needed:** <one sentence>.\`.
 - **Finalize:** No source-code edits, no PLAN.md, no branches, no PRs — the issues ARE the deliverable. \`/claim --issues\` (the \`claim-issue\` flow) picks them up later.`,
@@ -262,9 +279,10 @@ export function formatTrackerInstructions(tracker, options = {}) {
 - **Record** each NEW proposal as a GitLab issue. Do not relabel or edit an existing issue you skipped as a duplicate. Keep the \`[<slug>]\` inventory tag in the title so later runs can de-duplicate; do NOT add \`[category]\` / \`[SEVERITY]\` / \`[model:…]\` / \`[effort:…]\` prefixes (those belong in labels).
   1. Ensure each label you will apply exists. Create the category label first (\`glab label create --name ${issueLabel} --color "#0366D6" --description "${labelDescription}" 2>/dev/null || true\`) and the same for \`plan\`. Then create each justified dispatch-hint label immediately before applying it (glab needs \`--name\` and \`#<hex>\`).
   2. ${DISPATCH_HINT_GUIDANCE.split('\n').join('\n     ')}
-  3. File with repeated \`--label\` flags so the category/scope labels stay intact:
+${forgeLabelContract}
+  ${forgeFileStep} File with repeated \`--label\` flags so the category/scope labels stay intact:
   \`\`\`bash
-  glab issue create --title "[<slug>] <Short title>" --label ${issueLabel} --label plan [--label model:<tier>] [--label effort:<level>] [--label "good first issue"] [--label "help wanted"] --description "<body>"
+  glab issue create --title "[<slug>] <Short title>" --label ${issueLabel} --label plan ${forgeLabelFlags} --description "<body>"
   \`\`\`
   (Run \`glab issue create --help\` if a flag is rejected — glab's flags evolve.) The body must contain ${bodyRequirements}. For **Maybe — needs human call** items, also add \`--label needs-decision\` and end the body with \`**Decision needed:** <one sentence>.\`.
 - **Finalize:** No source-code edits, no PLAN.md, no branches, no MRs — the issues ARE the deliverable. \`/claim --issues\` (the \`claim-issue-gitlab\` flow) picks them up later.`,
@@ -274,6 +292,7 @@ export function formatTrackerInstructions(tracker, options = {}) {
 - **Inventory:** Search existing JIRA issues (and PLAN.md, if you fall back) for the \`[${slugPrefix}…]\` slug so you don't duplicate; collect the existing slugs.
 - **Record** each NEW proposal as a JIRA issue whose summary starts with the \`[<slug>]\` tag. Do not relabel a ticket you skipped as a duplicate. The description must contain ${bodyRequirements}. Apply the category label \`${issueLabel}\` plus equivalent dispatch-hint labels when justified:
   ${JIRA_DISPATCH_HINT_GUIDANCE.split('\n').join('\n  ')}
+${jiraLabelContract}
   For **Maybe — needs human call** items, end the description with \`**Decision needed:** <one sentence>.\`.
 - **Finalize:** No source-code edits, no branches, no PRs — the tickets (or the committed PLAN.md fallback) ARE the deliverable. The \`claim-issue-jira\` flow picks them up later.`,
   };

--- a/server/lib/workTracker.trackerInstructions.test.js
+++ b/server/lib/workTracker.trackerInstructions.test.js
@@ -139,3 +139,27 @@ describe('formatTrackerInstructions — ux preset (#3273)', () => {
     }
   });
 });
+
+describe('formatTrackerInstructions — repo-study complete labels', () => {
+  const repoStudy = TRACKER_FILING_PRESETS['repo-study'];
+
+  it('requires area, model, and effort labels on every new GitHub proposal', () => {
+    const github = formatTrackerInstructions('github', repoStudy);
+    expect(github).toContain('Repo-study complete-label contract (mandatory)');
+    expect(github).toContain('area:*');
+    expect(github).toContain('model:light|medium|heavy');
+    expect(github).toContain('effort:low|medium|high|xhigh|max');
+    expect(github).toContain('--label repo-study --label plan --label area:<area> --label model:<tier> --label effort:<level>');
+    expect(github).toContain('gh label list --search area:');
+  });
+
+  it('uses the same complete-label contract on GitLab and JIRA', () => {
+    const gitlab = formatTrackerInstructions('gitlab', repoStudy);
+    expect(gitlab).toContain('--label repo-study --label plan --label area:<area> --label model:<tier> --label effort:<level>');
+    expect(gitlab).toContain('glab label list');
+
+    const jira = formatTrackerInstructions('jira', repoStudy);
+    expect(jira).toContain('Repo-study complete-label contract (mandatory)');
+    expect(jira).toContain('`area:<area>` + `model-<tier>` + `effort-<level>`');
+  });
+});

--- a/server/services/repoIntake.test.js
+++ b/server/services/repoIntake.test.js
@@ -99,6 +99,8 @@ describe('queueRepoStudy', () => {
     expect(taskData.repoStudy).toEqual({ linkId: 'link-1' });
     expect(taskData.context).toContain('gh issue create');
     expect(taskData.context).toContain('repo-study-');
+    expect(taskData.context).toContain('Repo-study complete-label contract (mandatory)');
+    expect(taskData.context).toContain('--label area:<area> --label model:<tier> --label effort:<level>');
   });
 
   // `analysisType` enrolls a task in taskSchedule's per-type consecutive-failure


### PR DESCRIPTION
## Summary
- Add a repo-study-specific label contract covering repo-study, plan, area, model, and effort labels.
- Reuse shared dispatch-label guidance and preserve GitHub, GitLab, and JIRA syntax differences.
- Require label read-back for newly created proposals and add regression coverage.

## Test plan
- cd server && npm test -- --run lib/dispatchLabels.test.js lib/workTracker.trackerInstructions.test.js services/repoIntake.test.js
- Adjacent tracker and audit suites: 112 passed.
- Full server suite: 28269 passed; unrelated baseline and environment failures remain where Postgres, file-backend, or updateExecutor assumptions are unavailable.