### PR TITLE
test: unconditionally stub jsdom media and canvas prototype methods

### DIFF
--- a/client/src/test/setup.js
+++ b/client/src/test/setup.js
@@ -26,43 +26,37 @@ if (!Element.prototype.scrollIntoView) {
 
 // Stub jsdom missing media/canvas methods to eliminate stderr noise in test runs
 if (typeof HTMLMediaElement !== 'undefined') {
-  if (!HTMLMediaElement.prototype.play) {
-    HTMLMediaElement.prototype.play = () => Promise.resolve();
-  }
-  if (!HTMLMediaElement.prototype.pause) {
-    HTMLMediaElement.prototype.pause = () => {};
-  }
+  HTMLMediaElement.prototype.play = () => Promise.resolve();
+  HTMLMediaElement.prototype.pause = () => {};
 }
 
 if (typeof HTMLCanvasElement !== 'undefined') {
-  if (!HTMLCanvasElement.prototype.getContext) {
-    HTMLCanvasElement.prototype.getContext = () => ({
-      fillRect: () => {},
-      clearRect: () => {},
-      getImageData: (x, y, w, h) => ({ data: new Uint8ClampedArray(w * h * 4) }),
-      putImageData: () => {},
-      createImageData: () => ({ data: new Uint8ClampedArray(0) }),
-      setTransform: () => {},
-      drawImage: () => {},
-      save: () => {},
-      fillText: () => {},
-      restore: () => {},
-      beginPath: () => {},
-      moveTo: () => {},
-      lineTo: () => {},
-      closePath: () => {},
-      stroke: () => {},
-      translate: () => {},
-      scale: () => {},
-      rotate: () => {},
-      arc: () => {},
-      fill: () => {},
-      measureText: () => ({ width: 0 }),
-      transform: () => {},
-      rect: () => {},
-      clip: () => {},
-    });
-  }
+  HTMLCanvasElement.prototype.getContext = () => ({
+    fillRect: () => {},
+    clearRect: () => {},
+    getImageData: (x, y, w, h) => ({ data: new Uint8ClampedArray(w * h * 4) }),
+    putImageData: () => {},
+    createImageData: () => ({ data: new Uint8ClampedArray(0) }),
+    setTransform: () => {},
+    drawImage: () => {},
+    save: () => {},
+    fillText: () => {},
+    restore: () => {},
+    beginPath: () => {},
+    moveTo: () => {},
+    lineTo: () => {},
+    closePath: () => {},
+    stroke: () => {},
+    translate: () => {},
+    scale: () => {},
+    rotate: () => {},
+    arc: () => {},
+    fill: () => {},
+    measureText: () => ({ width: 0 }),
+    transform: () => {},
+    rect: () => {},
+    clip: () => {},
+  });
 }
 
 // Fail any test that triggers React's "not wrapped in act(...)" warning (#2406).


### PR DESCRIPTION
### Description
Refines `client/src/test/setup.js` to unconditionally assign dummy stubs for `HTMLMediaElement.prototype.play/pause` and `HTMLCanvasElement.prototype.getContext`.

jsdom defines dummy placeholder functions named `notImplemented` for these prototype methods. The previous `if (!prototype.method)` conditional check evaluated to `false` because the methods were present, allowing jsdom to continue printing `Not implemented: ...` stderr warnings during test runs.

### Verified
- Ran full client unit test suite: **656 test files passed**, **8,013 tests passed**, **0 stderr notImplemented warnings**.