### PR TITLE
fix: stream app issue claim lifecycle updates

### DIFF
--- a/client/src/components/apps/tabs/IssuesTab.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.jsx
@@ -12,9 +12,25 @@ import ProviderModelSelector from '../../ProviderModelSelector';
 import useProviderModels from '../../../hooks/useProviderModels';
 import { isProcessProvider } from '../../../utils/providers';
 import * as api from '../../../services/api';
+import socket from '../../../services/socket';
 import { timeAgo } from '../../../utils/formatters';
 
 const FORGE_LABEL = { github: 'GitHub', gitlab: 'GitLab' };
+
+const CLAIM_STATUS_RANK = { queuing: 0, queued: 1, active: 2, completed: 3, blocked: 3 };
+const CLAIM_STATUS_LABEL = {
+  queued: 'Queued — view',
+  active: 'Active — view',
+  completed: 'Completed — view',
+  blocked: 'Blocked — view'
+};
+
+const claimStatusForTask = (status) => ({
+  pending: 'queued',
+  in_progress: 'active',
+  completed: 'completed',
+  blocked: 'blocked'
+}[status] || null);
 
 // Module-scoped so `useProviderModels` sees a stable predicate — an inline
 // arrow would be a new identity every render, re-firing the hook's fetch
@@ -73,10 +89,11 @@ export default function IssuesTab({ appId, appName }) {
   const [error, setError] = useState('');
   const [query, setQuery] = useState('');
   const [expanded, setExpanded] = useState(() => new Set());
-  // Per-issue claim lifecycle: 'queuing' while the POST is in flight, 'queued'
-  // once the CoS task exists. Keyed by issue number so one claim can't disable
+  // Per-issue claim lifecycle: 'queuing' while the POST is in flight, then the
+  // task's live CoS state. Keyed by issue number so one claim can't disable
   // every other row's button.
   const [claims, setClaims] = useState({});
+  const claimsRef = useRef({});
   // Generation guard: a forge list can take seconds, so a Refresh (or a switch to
   // a different app, which updates this component in place rather than
   // remounting it) can leave an older request in flight. Without this, that older
@@ -96,6 +113,95 @@ export default function IssuesTab({ appId, appName }) {
     setSelectedProviderId, setSelectedModel
   } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, silent: true, withEffort: true });
   const [effort, setEffort] = useState('');
+
+  // Keep the event-driven path based on the latest claims without putting a
+  // mutable state snapshot in its effect dependencies. Socket callbacks can
+  // arrive between the POST response and the next React render.
+  const replaceClaims = useCallback((updater) => {
+    const next = updater(claimsRef.current);
+    claimsRef.current = next;
+    setClaims(next);
+  }, []);
+
+  useEffect(() => {
+    claimsRef.current = {};
+    setClaims({});
+  }, [appId]);
+
+  useEffect(() => {
+    const subscribe = () => socket.emit('cos:subscribe');
+    if (socket.connected) subscribe();
+    socket.on('connect', subscribe);
+
+    const applyTaskUpdate = (task) => {
+      if (!task?.id) return;
+      const nextStatus = claimStatusForTask(task.status);
+      if (!nextStatus) return;
+
+      const currentClaims = claimsRef.current;
+      const nextClaims = { ...currentClaims };
+      const transitions = [];
+
+      for (const [issueNumber, rawClaim] of Object.entries(currentClaims)) {
+        const claim = typeof rawClaim === 'string' ? { status: rawClaim } : rawClaim;
+        const matchesTask = claim.taskId === task.id || (
+          !claim.taskId && task.metadata?.app === appId &&
+          String(task.metadata?.claimTarget) === issueNumber
+        );
+        if (!matchesTask) continue;
+
+        const currentStatus = claim.status || 'queuing';
+        if ((CLAIM_STATUS_RANK[nextStatus] ?? 0) < (CLAIM_STATUS_RANK[currentStatus] ?? 0)) continue;
+        if (claim.taskId === task.id && currentStatus === nextStatus) continue;
+
+        nextClaims[issueNumber] = { ...claim, taskId: claim.taskId || task.id, status: nextStatus };
+        transitions.push({ issueNumber, from: currentStatus, to: nextStatus });
+      }
+
+      if (transitions.length === 0) return;
+      replaceClaims(() => nextClaims);
+
+      for (const { issueNumber, from, to } of transitions) {
+        if (to === 'active' && from !== 'active') toast(`Claim #${issueNumber} is now active`, { icon: '▶️' });
+        if (to === 'completed' && from !== 'completed') toast.success(`Claim #${issueNumber} completed`);
+        if (to === 'blocked' && from !== 'blocked') toast.error(`Claim #${issueNumber} was blocked`);
+      }
+    };
+
+    const handleTaskChanged = (data) => applyTaskUpdate(data?.task);
+    const handleTaskListChanged = (data) => {
+      for (const task of data?.tasks || []) applyTaskUpdate(task);
+    };
+    const handleTaskCompleted = (data) => {
+      for (const task of data?.tasks || []) applyTaskUpdate(task);
+    };
+    const handleAgentSpawned = (agent) => {
+      if (agent?.taskId) applyTaskUpdate({ id: agent.taskId, status: 'in_progress' });
+    };
+    const handleAgentCompleted = (agent) => {
+      // A failed agent can be requeued or blocked by its completion path, so
+      // only the success signal is safe as an early terminal hint. The task
+      // lifecycle event below remains authoritative for all outcomes.
+      if (agent?.taskId && agent.result?.success === true) {
+        applyTaskUpdate({ id: agent.taskId, status: 'completed' });
+      }
+    };
+
+    socket.on('cos:tasks:changed', handleTaskChanged);
+    socket.on('cos:tasks:user:changed', handleTaskListChanged);
+    socket.on('cos:tasks:user:completed', handleTaskCompleted);
+    socket.on('cos:agent:spawned', handleAgentSpawned);
+    socket.on('cos:agent:completed', handleAgentCompleted);
+
+    return () => {
+      socket.off('connect', subscribe);
+      socket.off('cos:tasks:changed', handleTaskChanged);
+      socket.off('cos:tasks:user:changed', handleTaskListChanged);
+      socket.off('cos:tasks:user:completed', handleTaskCompleted);
+      socket.off('cos:agent:spawned', handleAgentSpawned);
+      socket.off('cos:agent:completed', handleAgentCompleted);
+    };
+  }, [appId, replaceClaims]);
 
   const load = useCallback(async () => {
     const generation = requestRef.current + 1;
@@ -147,7 +253,7 @@ export default function IssuesTab({ appId, appName }) {
   });
 
   const handleClaim = async (issue) => {
-    setClaims(prev => ({ ...prev, [issue.number]: 'queuing' }));
+    replaceClaims(prev => ({ ...prev, [issue.number]: { status: 'queuing', taskId: null } }));
     const result = await api.createSlashdoTask('next', appId, {
       target: String(issue.number),
       provider: selectedProviderId || undefined,
@@ -159,14 +265,29 @@ export default function IssuesTab({ appId, appName }) {
         return null;
       });
     if (!result) {
-      setClaims(prev => {
+      replaceClaims(prev => {
         const next = { ...prev };
         delete next[issue.number];
         return next;
       });
       return;
     }
-    setClaims(prev => ({ ...prev, [issue.number]: 'queued' }));
+    replaceClaims(prev => {
+      const current = prev[issue.number];
+      const currentStatus = typeof current === 'string' ? current : current?.status;
+      const resultStatus = claimStatusForTask(result.status) || 'queued';
+      const status = (CLAIM_STATUS_RANK[resultStatus] ?? 0) >= (CLAIM_STATUS_RANK[currentStatus] ?? 0)
+        ? resultStatus
+        : currentStatus;
+      return {
+        ...prev,
+        [issue.number]: {
+          ...(typeof current === 'object' ? current : {}),
+          status,
+          taskId: current?.taskId || result.id || null
+        }
+      };
+    });
     toast.success(`Queued a CoS agent to claim #${issue.number}`);
   };
 
@@ -264,7 +385,8 @@ export default function IssuesTab({ appId, appName }) {
         <div className="border border-port-border rounded-lg divide-y divide-port-border overflow-hidden">
           {issues.map(issue => {
             const isOpen = expanded.has(issue.number);
-            const claimState = claims[issue.number];
+            const claim = claims[issue.number];
+            const claimState = typeof claim === 'string' ? claim : claim?.status;
             return (
               <div key={issue.number} className="bg-port-card">
                 <div className="flex flex-col sm:flex-row sm:items-start gap-3 p-3">
@@ -322,12 +444,12 @@ export default function IssuesTab({ appId, appName }) {
                   </div>
 
                   <div className="shrink-0">
-                    {claimState === 'queued' ? (
+                    {claimState && claimState !== 'queuing' ? (
                       <Link
                         to="/cos/agents"
                         className="px-3 py-1.5 bg-port-success/20 text-port-success hover:bg-port-success/30 border border-port-border rounded-lg text-xs flex items-center gap-1.5 transition-colors"
                       >
-                        <Rocket size={14} /> Queued — view
+                        <Rocket size={14} /> {CLAIM_STATUS_LABEL[claimState] || 'Queued — view'}
                       </Link>
                     ) : (
                       <button

--- a/client/src/components/apps/tabs/IssuesTab.test.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.test.jsx
@@ -1,6 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, cleanup, waitFor, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
+
+const { socketHandlers, socketMock } = vi.hoisted(() => {
+  const handlers = new Map();
+  const mock = {
+    connected: true,
+    on: vi.fn((event, handler) => handlers.set(event, handler)),
+    off: vi.fn((event, handler) => {
+      if (handlers.get(event) === handler) handlers.delete(event);
+    }),
+    emit: vi.fn()
+  };
+  return { socketHandlers: handlers, socketMock: mock };
+});
+
+vi.mock('../../../services/socket', () => ({ default: socketMock }));
 
 vi.mock('../../../services/api', () => ({
   getAppIssues: vi.fn(),
@@ -41,6 +56,10 @@ const renderTab = () => render(
 );
 
 beforeEach(() => {
+  socketHandlers.clear();
+  socketMock.on.mockClear();
+  socketMock.off.mockClear();
+  socketMock.emit.mockClear();
   api.getAppIssues.mockResolvedValue(okPayload([ISSUE]));
   api.createSlashdoTask.mockResolvedValue({ id: 'task-1' });
   api.getProviders.mockResolvedValue({ providers: [] });
@@ -85,6 +104,43 @@ describe('IssuesTab', () => {
       'next', 'app-1', { target: '42' }, { silent: true }
     ));
     expect(await screen.findByRole('link', { name: /Queued/ })).toBeInTheDocument();
+  });
+
+  it('tracks the claimed task from queued through active and completed over the CoS socket', async () => {
+    renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Claim/ }));
+    expect(await screen.findByRole('link', { name: /Queued/ })).toBeInTheDocument();
+
+    act(() => socketHandlers.get('cos:tasks:changed')({
+      task: { id: 'task-1', status: 'in_progress' }
+    }));
+    expect(await screen.findByRole('link', { name: /Active/ })).toBeInTheDocument();
+
+    act(() => socketHandlers.get('cos:tasks:changed')({
+      task: { id: 'task-1', status: 'completed' }
+    }));
+    expect(await screen.findByRole('link', { name: /Completed/ })).toBeInTheDocument();
+  });
+
+  it('does not lose an active socket update that arrives before the POST response', async () => {
+    let resolveClaim;
+    api.createSlashdoTask.mockImplementation(() => new Promise(resolve => { resolveClaim = resolve; }));
+    renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Claim/ }));
+    act(() => socketHandlers.get('cos:tasks:changed')({
+      task: {
+        id: 'task-1', status: 'in_progress',
+        metadata: { app: 'app-1', claimTarget: '42' }
+      }
+    }));
+    expect(await screen.findByRole('link', { name: /Active/ })).toBeInTheDocument();
+
+    await act(async () => {
+      resolveClaim({ id: 'task-1', status: 'pending' });
+    });
+    expect(screen.getByRole('link', { name: /Active/ })).toBeInTheDocument();
   });
 
   it('sends the page-level provider/model/effort pin along with a claim', async () => {

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -1176,6 +1176,7 @@ describe('CoS Routes', () => {
       expect(taskData.provider).toBe('claude-cli');
       expect(taskData.model).toBe('claude-opus-5');
       expect(taskData.effort).toBe('high');
+      expect(taskData.claimTarget).toBe('412');
       expect(taskData.simplify).toBe(true);
       // The claim prompt owns its own review sequence — no CoS loop on top.
       expect(taskData.reviewLoop).toBe(false);

--- a/server/routes/cosTaskRoutes.js
+++ b/server/routes/cosTaskRoutes.js
@@ -194,7 +194,13 @@ router.post('/tasks/slashdo', asyncHandler(async (req, res) => {
       // claim flow derives it from the app's RESOLVED work tracker (a file
       // tracker commits its checklist, a forge tracker doesn't), which is more
       // specific than the catalog's commit-shaped default, so the spread wins.
-      taskMetadata: { useWorktree, openPR, worktreeChangesExpected, ...claim.taskMetadata },
+      taskMetadata: {
+        useWorktree,
+        openPR,
+        worktreeChangesExpected,
+        ...(claim.target ? { claimTarget: claim.target } : {}),
+        ...claim.taskMetadata
+      },
     };
   } else {
     shape = {

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -444,6 +444,10 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
     // no-commit gate without having to masquerade as a scheduled task type —
     // see taskTypeHooks.js#isTrackerFilingDispatch.
     if (taskData.workTracker) metadata.workTracker = taskData.workTracker;
+    // A manually pinned /do:next issue needs a durable target so realtime
+    // consumers can associate lifecycle events with the row that launched it.
+    // The route has already normalized this value, and unpinned runs omit it.
+    if (typeof taskData.claimTarget === 'string' && taskData.claimTarget) metadata.claimTarget = taskData.claimTarget;
     if (taskData.jiraTicketId) metadata.jiraTicketId = taskData.jiraTicketId;
     if (taskData.jiraTicketUrl) metadata.jiraTicketUrl = taskData.jiraTicketUrl;
     if (taskData.screenshots?.length > 0) metadata.screenshots = taskData.screenshots;

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -461,6 +461,18 @@ describe('cosTaskStore.addTask', () => {
     expect(tasks.find(t => t.id === created.id).metadata.slashdoCommand).toBe('plan-task');
   });
 
+  it('persists a pinned claim target through the task markdown round-trip', async () => {
+    const created = await addTask({
+      description: 'Claim GitHub issue 42 for Example App',
+      app: 'example-app',
+      claimTarget: '42'
+    }, 'user');
+
+    expect(created.metadata.claimTarget).toBe('42');
+    const { tasks } = await getUserTasks();
+    expect(tasks.find(t => t.id === created.id).metadata.claimTarget).toBe('42');
+  });
+
   it('persists malware scan report ownership through the task markdown round-trip', async () => {
     const malwareScan = { linkId: 'a3d2c4e8-810a-4d1a-8ab1-94d3e0a13f8d', reportId: 'b38bdf75-3fe2-498c-9c36-7d512dc078d1' };
     const created = await addTask({ description: 'Malware scan: example/repo', malwareScan }, 'user');

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -887,6 +887,10 @@ function setupCosEventForwarding() {
   cosEvents.on('log', (data) => broadcastToCos('cos:log', data));
 
   // Task events
+  // `cosTaskStore` emits this immediately for every persisted lifecycle
+  // transition. Forward the task itself so focused views can update one row
+  // without waiting for the file watcher to rebuild the entire task list.
+  cosEvents.on('tasks:changed', (data) => broadcastToCos('cos:tasks:changed', data));
   cosEvents.on('tasks:user:changed', (data) => broadcastToCos('cos:tasks:user:changed', data));
   cosEvents.on('tasks:user:added', (data) => broadcastToCos('cos:tasks:user:added', data));
   cosEvents.on('tasks:user:completed', (data) => broadcastToCos('cos:tasks:user:completed', data));

--- a/server/services/socket.test.js
+++ b/server/services/socket.test.js
@@ -144,6 +144,24 @@ describe('socket.js — initSocket', () => {
     expect(socket.emitted.some(([ev]) => ev === 'cos:unsubscribed')).toBe(true);
   });
 
+  it('forwards task lifecycle changes with the task payload to CoS subscribers', () => {
+    const socket = makeSocket('task-events');
+    createdSockets.push(socket);
+    io.connect(socket);
+    socket.handlers['cos:subscribe']();
+
+    const listener = cosEvents.on.mock.calls.find(([event]) => event === 'tasks:changed')?.[1];
+    const payload = {
+      type: 'user',
+      action: 'updated',
+      previousStatus: 'pending',
+      task: { id: 'task-1', status: 'in_progress' }
+    };
+    listener(payload);
+
+    expect(socket.emitted).toContainEqual(['cos:tasks:changed', payload]);
+  });
+
   // ===========================================================================
   // broadcast: two subscribed sockets both receive the event
   // Tested via the subscription ack — the internal Set membership is observable


### PR DESCRIPTION
## Summary

- Forward persisted CoS task lifecycle events to subscribed websocket clients.
- Persist pinned issue targets and update the App Management Issues tab from queued through active, completed, or blocked.
- Add client and server regression coverage for event delivery, correlation, and response/event ordering.

## Test plan

- npm test -- --run src/components/apps/tabs/IssuesTab.test.jsx
- npm test -- --run services/socket.test.js services/cosTaskStore.test.js routes/cos.test.js
- npm run lint
- npm run build