### PR TITLE
feat: add agent ID copy buttons

### DIFF
--- a/.changelog/next/added-agent-3e585df7.md
+++ b/.changelog/next/added-agent-3e585df7.md
@@ -1,0 +1,1 @@
+- Add copy buttons for agent IDs on active and historical agent cards

--- a/client/src/components/cos/tabs/AgentCard.jsx
+++ b/client/src/components/cos/tabs/AgentCard.jsx
@@ -22,7 +22,8 @@ import {
   GitBranch,
   GitPullRequest,
   Sparkles,
-  RefreshCw
+  RefreshCw,
+  Copy
 } from 'lucide-react';
 import * as api from '../../../services/api';
 import OutputBlocks from '../OutputBlocks';
@@ -402,6 +403,18 @@ export default function AgentCard({ agent, onPause, onKill, onDelete, onResume, 
           <div className="flex items-center gap-2 flex-wrap min-w-0 flex-1">
             <Cpu size={16} aria-hidden="true" className={`shrink-0 ${inactive ? 'text-gray-500' : 'text-port-accent animate-pulse'}`} />
             <span className="font-mono text-sm text-gray-400 truncate">{agent.id}</span>
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                copyToClipboard(agent.id, 'Agent ID copied to clipboard');
+              }}
+              className="p-1 rounded text-gray-500 hover:bg-port-border/60 hover:text-white transition-colors shrink-0"
+              title="Copy agent ID"
+              aria-label="Copy agent ID"
+            >
+              <Copy size={13} aria-hidden="true" />
+            </button>
             {remote && peerName && (
               <span className="px-1.5 py-0.5 text-xs bg-port-accent/20 text-port-accent rounded shrink-0" title={`Remote agent on ${peerName}`}>
                 {peerName}

--- a/client/src/components/cos/tabs/AgentCard.test.jsx
+++ b/client/src/components/cos/tabs/AgentCard.test.jsx
@@ -14,6 +14,11 @@ vi.mock('../../ui/Toast', () => ({
   default: { success: vi.fn(), error: vi.fn() },
 }));
 
+const copyToClipboard = vi.fn();
+vi.mock('../../../lib/clipboard', () => ({
+  copyToClipboard: (...args) => copyToClipboard(...args),
+}));
+
 import * as api from '../../../services/api';
 import AgentCard from './AgentCard';
 
@@ -160,6 +165,25 @@ describe('AgentCard feedback', () => {
       { rating: 'positive', comment: detailedAgent.feedback.comment },
       { silent: true }
     );
+  });
+});
+
+describe('AgentCard agent ID', () => {
+  it.each([
+    ['active', { ...agent, status: 'running', completedAt: null }],
+    ['historical', agent],
+  ])('copies the full ID from the %s card', async (_label, cardAgent) => {
+    const user = userEvent.setup();
+
+    render(
+      <MemoryRouter>
+        <AgentCard agent={cardAgent} completed={cardAgent.status === 'completed'} />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Copy agent ID' }));
+
+    expect(copyToClipboard).toHaveBeenCalledWith(cardAgent.id, 'Agent ID copied to clipboard');
   });
 });
 


### PR DESCRIPTION
## Summary

- Add an icon-only copy button beside the full agent ID on the shared agent card.
- Copy the full ID through the existing clipboard helper for active and historical agent views.

## Test plan

- `vitest run src/components/cos/tabs/AgentCard.test.jsx --root client --configLoader runner`
- Focused Biome lint for the changed client files.
- `npm run build` from `client/`.