### PR TITLE
feat: add claim override context to app issues

### DIFF
--- a/.changelog/next/added-agent-b8aa8662.md
+++ b/.changelog/next/added-agent-b8aa8662.md
@@ -1,0 +1,1 @@
+- App Issues claims now accept optional override context and instructions.

--- a/client/src/components/apps/tabs/IssuesTab.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.jsx
@@ -84,6 +84,7 @@ function LabelChip({ label }) {
  */
 export default function IssuesTab({ appId, appName }) {
   const searchId = useId();
+  const overrideContextId = useId();
   const [data, setData] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -113,6 +114,7 @@ export default function IssuesTab({ appId, appName }) {
     setSelectedProviderId, setSelectedModel
   } = useProviderModels({ filter: enabledProcessProviderFilter, allowDefault: true, silent: true, withEffort: true });
   const [effort, setEffort] = useState('');
+  const [overrideContext, setOverrideContext] = useState('');
 
   // Keep the event-driven path based on the latest claims without putting a
   // mutable state snapshot in its effect dependencies. Socket callbacks can
@@ -126,6 +128,7 @@ export default function IssuesTab({ appId, appName }) {
   useEffect(() => {
     claimsRef.current = {};
     setClaims({});
+    setOverrideContext('');
   }, [appId]);
 
   useEffect(() => {
@@ -254,6 +257,7 @@ export default function IssuesTab({ appId, appName }) {
 
   const handleClaim = async (issue) => {
     replaceClaims(prev => ({ ...prev, [issue.number]: { status: 'queuing', taskId: null } }));
+    const trimmedOverrideContext = overrideContext.trim();
     const result = await api.createSlashdoTask('next', appId, {
       target: String(issue.number),
       issueContext: {
@@ -265,6 +269,7 @@ export default function IssuesTab({ appId, appName }) {
       provider: selectedProviderId || undefined,
       model: selectedModel || undefined,
       effort: effort || undefined,
+      ...(trimmedOverrideContext ? { overrideContext: trimmedOverrideContext } : {}),
     }, { silent: true })
       .catch(err => {
         toast.error(err?.message || `Failed to queue a claim for #${issue.number}`);
@@ -337,25 +342,44 @@ export default function IssuesTab({ appId, appName }) {
         </button>
       </div>
 
-      <div className="flex flex-col sm:flex-row sm:items-center gap-2 px-3 py-2 bg-port-card border border-port-border rounded-lg">
-        <span className="flex items-center gap-1.5 text-xs text-gray-500 uppercase tracking-wide shrink-0">
-          <Bot size={14} /> Claim with
-        </span>
-        <div className="flex-1">
-          <ProviderModelSelector
-            providers={providers}
-            selectedProviderId={selectedProviderId}
-            selectedModel={selectedModel}
-            availableModels={availableModels}
-            onProviderChange={(id) => { setSelectedProviderId(id); setEffort(''); }}
-            onModelChange={setSelectedModel}
-            effort={effort}
-            onEffortChange={setEffort}
-            emptyProviderOption="Auto (default)"
-            emptyModelOption="Default model"
-            compact
-            highlightToolUse
+      <div className="space-y-3 px-3 py-2 bg-port-card border border-port-border rounded-lg">
+        <div className="flex flex-col sm:flex-row sm:items-center gap-2">
+          <span className="flex items-center gap-1.5 text-xs text-gray-500 uppercase tracking-wide shrink-0">
+            <Bot size={14} /> Claim with
+          </span>
+          <div className="flex-1">
+            <ProviderModelSelector
+              providers={providers}
+              selectedProviderId={selectedProviderId}
+              selectedModel={selectedModel}
+              availableModels={availableModels}
+              onProviderChange={(id) => { setSelectedProviderId(id); setEffort(''); }}
+              onModelChange={setSelectedModel}
+              effort={effort}
+              onEffortChange={setEffort}
+              emptyProviderOption="Auto (default)"
+              emptyModelOption="Default model"
+              compact
+              highlightToolUse
+            />
+          </div>
+        </div>
+        <div className="space-y-1">
+          <label htmlFor={overrideContextId} className="block text-xs text-gray-400">
+            Override context or instructions <span className="text-gray-600">(optional)</span>
+          </label>
+          <textarea
+            id={overrideContextId}
+            value={overrideContext}
+            onChange={e => setOverrideContext(e.target.value)}
+            maxLength={4000}
+            rows={2}
+            placeholder="Add guidance for this claim, such as a preferred implementation focus…"
+            className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm placeholder:text-gray-600 focus:border-port-accent focus:outline-hidden resize-y"
           />
+          <p className="text-xs text-gray-600">
+            Appended to the selected claim&apos;s instructions; blank leaves the claim prompt unchanged.
+          </p>
         </div>
       </div>
 

--- a/client/src/components/apps/tabs/IssuesTab.test.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.test.jsx
@@ -184,6 +184,25 @@ describe('IssuesTab', () => {
     ));
   });
 
+  it('sends optional override context with the selected claim', async () => {
+    renderTab();
+
+    await screen.findByText('Crash on save');
+    fireEvent.change(screen.getByLabelText(/Override context or instructions/), {
+      target: { value: 'Prefer a small, focused fix and add a regression test.' }
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Claim/ }));
+
+    await waitFor(() => expect(api.createSlashdoTask).toHaveBeenCalledWith(
+      'next', 'app-1',
+      expect.objectContaining({
+        target: '42',
+        overrideContext: 'Prefer a small, focused fix and add a regression test.'
+      }),
+      { silent: true }
+    ));
+  });
+
   it('re-enables the Claim button when queuing fails, instead of stranding it', async () => {
     api.createSlashdoTask.mockRejectedValue(new Error('CoS is not running'));
     renderTab();

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -61,8 +61,9 @@ export const addCosTask = (task, options = {}) => request('/cos/tasks', {
 });
 // Queue a `/do:*` agent task for an app. `settings` carries the run options the
 // Agent Operations drawer collects — provider/model/effort/simplify for every
-// command, plus the `/do:next`-only target work item, issue author filter, and
-// reviewer list. Omit it for a bare "run with the app's configured defaults".
+// command, plus the `/do:next`-only target work item, issue author filter,
+// reviewer list, and optional override context. Omit it for a bare "run with
+// the app's configured defaults".
 export const createSlashdoTask = (command, app, settings = {}, options = {}) => request('/cos/tasks/slashdo', {
   method: 'POST',
   body: JSON.stringify({ command, app, ...settings }),

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -986,6 +986,15 @@ const prefetchedIssueContextSchema = z.object({
   url: z.string().max(2048).optional(),
 });
 
+// Optional guidance entered on the managed-app Issues tab. It is appended to
+// the selected claim prompt, not stored as the task's human note, so it reaches
+// the agent even though the claim prompt is assembled before queueing.
+export const CLAIM_OVERRIDE_CONTEXT_MAX_CHARS = 4_000;
+const claimOverrideContextSchema = z.preprocess(
+  v => typeof v === 'string' ? (v.trim() || undefined) : v,
+  z.string().max(CLAIM_OVERRIDE_CONTEXT_MAX_CHARS).optional()
+);
+
 export const createCosTaskSchema = z.object({
   description: z.string().min(1),
   diagnostics: cosTaskDiagnosticsSchema.optional(),
@@ -1436,7 +1445,9 @@ export const SWARM_COUNT_MAX = 6;
 // allowed-command map and its 400 message. The remaining fields are `/do:next`
 // specific: `target` pins the run to ONE work item (empty ⇒ the agent picks),
 // `issueContext` carries title/body already fetched by the app Issues tab, and
-// `issueAuthorFilter` overrides the app's configured claim-work gate.
+// `issueAuthorFilter` overrides the app's configured claim-work gate. The
+// optional `overrideContext` is user guidance appended to the selected claim
+// prompt, rather than the queue's one-line human note.
 export const slashdoTaskSchema = createCosTaskSchema
   .pick({
     model: true, provider: true, effort: true, simplify: true,
@@ -1451,6 +1462,7 @@ export const slashdoTaskSchema = createCosTaskSchema
     // targeted forge claim. `buildClaimWorkTask` embeds it in the agent prompt;
     // scheduled/self-claim flows omit it and continue to read live issue state.
     issueContext: prefetchedIssueContextSchema.optional(),
+    overrideContext: claimOverrideContextSchema,
     issueAuthorFilter: z.enum(ISSUE_AUTHOR_FILTERS).optional(),
   });
 

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -1159,6 +1159,7 @@ describe('CoS Routes', () => {
             body: 'Capture the request timing in the health endpoint.',
             url: 'https://github.com/acme/widget/issues/412'
           },
+          overrideContext: 'Prefer the smallest safe fix and include a regression test.',
           reviewers: ['claude', 'codex'], usernames: ['alice'], optionalReviewers: ['codex'],
           reviewerMaxRounds: { codex: 2, ollama: 1 },
           provider: 'claude-cli', model: 'claude-opus-5', effort: 'high', simplify: true
@@ -1175,6 +1176,7 @@ describe('CoS Routes', () => {
             body: 'Capture the request timing in the health endpoint.',
             url: 'https://github.com/acme/widget/issues/412'
           },
+          overrideContext: 'Prefer the smallest safe fix and include a regression test.',
           issueAuthorFilter: 'any',
           reviewers: ['claude', 'codex'],
           usernames: ['alice'],
@@ -1214,6 +1216,15 @@ describe('CoS Routes', () => {
           target: '412',
           issueContext: { number: 412, body: 'x'.repeat(12_001) }
         });
+
+      expect(response.status).toBe(400);
+      expect(buildClaimWorkTask).not.toHaveBeenCalled();
+    });
+
+    it('rejects oversized claim override context at the route boundary', async () => {
+      const response = await request(app)
+        .post('/api/cos/tasks/slashdo')
+        .send({ command: 'next', app: 'my-app', overrideContext: 'x'.repeat(4_001) });
 
       expect(response.status).toBe(400);
       expect(buildClaimWorkTask).not.toHaveBeenCalled();

--- a/server/routes/cosTaskRoutes.js
+++ b/server/routes/cosTaskRoutes.js
@@ -116,7 +116,8 @@ router.post('/tasks/enhance', asyncHandler(async (req, res) => {
 // `issueAuthorFilter`, and the reviewer choices are `/do:next`-only (they shape
 // the claim prompt, which self-manages its own PR + review loop). `issueContext`
 // is the selected issue's content already fetched by the managed-app Issues tab;
-// it avoids making the agent retrieve the same title/body again.
+// it avoids making the agent retrieve the same title/body again. The optional
+// `overrideContext` is user guidance appended to that claim prompt.
 //
 // The launchable-command allowlist is the shared catalog in
 // `server/lib/slashdoCatalog.js` (#3114) — the CoS quick templates read the same
@@ -124,7 +125,7 @@ router.post('/tasks/enhance', asyncHandler(async (req, res) => {
 router.post('/tasks/slashdo', asyncHandler(async (req, res) => {
   const {
     command, app, provider, model, effort, simplify,
-    target, issueContext, issueAuthorFilter, reviewers, usernames, optionalReviewers,
+    target, issueContext, overrideContext, issueAuthorFilter, reviewers, usernames, optionalReviewers,
     reviewerMaxRounds, reviewerModels, reviewerEfforts
   } = validateRequest(slashdoTaskSchema, req.body);
 
@@ -183,6 +184,7 @@ router.post('/tasks/slashdo', asyncHandler(async (req, res) => {
     const claim = await buildClaimWorkTask(appObj, {
       target,
       issueContext,
+      ...(overrideContext !== undefined ? { overrideContext } : {}),
       issueAuthorFilter,
       reviewers,
       usernames,

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -22,7 +22,7 @@
 import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { sanitizeTaskMetadata, PIPELINE_BEHAVIOR_FLAGS, MAX_TOTAL_SPAWNS, normalizeReviewers, resolveReviewUsernames, resolveOptionalReviewers, resolveReviewerMaxRounds, resolveReviewerPins, buildReviewerEffortNote, buildReviewersCsv, LOCAL_LLM_REVIEWERS, SWARM_COUNT_MIN, ISSUE_AUTHOR_FILTERS } from '../lib/validation.js';
+import { sanitizeTaskMetadata, PIPELINE_BEHAVIOR_FLAGS, MAX_TOTAL_SPAWNS, normalizeReviewers, resolveReviewUsernames, resolveOptionalReviewers, resolveReviewerMaxRounds, resolveReviewerPins, buildReviewerEffortNote, buildReviewersCsv, LOCAL_LLM_REVIEWERS, SWARM_COUNT_MIN, ISSUE_AUTHOR_FILTERS, CLAIM_OVERRIDE_CONTEXT_MAX_CHARS } from '../lib/validation.js';
 import { isPlainObject } from '../lib/objects.js';
 import { parsePlanItems, extractAllIds, findInProgressIds, pickFirstAvailable, diagnoseUnpickablePlan } from '../lib/planIds.js';
 import { loadState, saveState, withStateLock, isImprovementEnabled, isDaemonRunning } from './cosState.js';
@@ -425,7 +425,8 @@ export async function buildClaimWorkTask(app, {
   reviewerModels,
   reviewerEfforts,
   target,
-  issueContext
+  issueContext,
+  overrideContext
 } = {}) {
   const { resolveAppWorkTracker, trackerToClaimTaskType } = await import('../lib/workTracker.js');
   const { getTaskPrompt } = await import('./taskPromptService.js');
@@ -497,6 +498,7 @@ export async function buildClaimWorkTask(app, {
     .replace(/\{issueAuthorFilter\}/g, () => issueAuthorFilterBlock)
     + appendTargetWorkItemBlock(promptTaskType, targetRef)
     + appendPrefetchedIssueContext(promptTaskType, targetRef, issueContext)
+    + appendClaimOverrideContext(overrideContext)
     + appendReviewerEffortBlock(reviewersList, promptReviewerEfforts);
 
   // Mirror the scheduler: inherit the delegated flow's isolation posture so the
@@ -640,6 +642,32 @@ ${body || '(empty)'}
 /** The same block with the leading blank-line separator used by prompt appends. */
 const appendPrefetchedIssueContext = (promptTaskType, target, issueContext) => {
   const block = buildPrefetchedIssueContextBlock(promptTaskType, target, issueContext);
+  return block ? `\n\n${block}` : '';
+};
+
+/**
+ * Render optional guidance entered by the user on the managed-app Issues tab.
+ * This is deliberately an appended section rather than a template placeholder:
+ * customized claim templates from older installs still receive the guidance.
+ * Keep the claim workflow's safety and delivery requirements in force even when
+ * the user asks for a different implementation focus.
+ */
+export function buildClaimOverrideContextBlock(overrideContext) {
+  if (typeof overrideContext !== 'string') return '';
+  const context = overrideContext.trim().slice(0, CLAIM_OVERRIDE_CONTEXT_MAX_CHARS);
+  if (!context) return '';
+
+  return `## Claim Override Context
+
+The following guidance was entered by the user for this claim. Apply it when it helps complete the selected work item, but it does not replace the claim workflow's safety, ownership, verification, reviewer, or PR requirements.
+
+<portos-claim-override>
+${context}
+</portos-claim-override>`;
+}
+
+const appendClaimOverrideContext = (overrideContext) => {
+  const block = buildClaimOverrideContextBlock(overrideContext);
   return block ? `\n\n${block}` : '';
 };
 

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -48,6 +48,7 @@ import {
   normalizeWorkItemRef,
   buildTargetWorkItemBlock,
   buildPrefetchedIssueContextBlock,
+  buildClaimOverrideContextBlock,
   resolveTaskInputHook,
   resolveReconcileDrainGate,
   applyPerpetualDrainCap
@@ -426,9 +427,30 @@ describe('work-item target', () => {
     });
   });
 
+  describe('buildClaimOverrideContextBlock', () => {
+    it('renders user guidance as a delimited, safety-preserving prompt section', () => {
+      const block = buildClaimOverrideContextBlock('  Focus on the smallest safe fix.  ');
+
+      expect(block).toContain('## Claim Override Context');
+      expect(block).toContain('Focus on the smallest safe fix.');
+      expect(block).toContain('<portos-claim-override>');
+      expect(block).toContain('</portos-claim-override>');
+      expect(block).toContain('safety, ownership, verification, reviewer, or PR requirements');
+    });
+
+    it('omits blank guidance and caps direct service payloads', () => {
+      expect(buildClaimOverrideContextBlock('   ')).toBe('');
+
+      const block = buildClaimOverrideContextBlock('x'.repeat(8_000));
+      expect(block).toContain('x'.repeat(4_000));
+      expect(block).not.toContain('x'.repeat(4_001));
+    });
+  });
+
   it('wires the prefetch block into the manual claim prompt assembly', () => {
     const claimBuilder = GEN_SRC.slice(GEN_SRC.indexOf('export async function buildClaimWorkTask('));
     expect(claimBuilder).toContain('appendPrefetchedIssueContext(promptTaskType, targetRef, issueContext)');
+    expect(claimBuilder).toContain('appendClaimOverrideContext(overrideContext)');
   });
 });
 


### PR DESCRIPTION
## Summary
- add an optional override context field to managed-app issue claims
- carry bounded guidance into the claim prompt while preserving claim safety requirements

## Test plan
- `npm test -- --run routes/cos.test.js services/cosTaskGenerator.test.js` (server)
- `npm test -- --run src/components/apps/tabs/IssuesTab.test.jsx` (client)
- `npm run lint` (client)
- `git diff --check`
- broad client suite: 656 files and 8,024 tests passed
- broad server suite is blocked by unavailable PostgreSQL test setup in this worktree; focused suites pass