### PR TITLE
feat: recommend Qwen3.8 MLX on Apple Silicon

### DIFF
--- a/.changelog/next/changed-qwen38-mlx-macos.md
+++ b/.changelog/next/changed-qwen38-mlx-macos.md
@@ -1,0 +1,1 @@
+- Recommend the complete Qwen3.8 27B MLX 4-bit build on Apple Silicon via the LM Studio local-LLM catalog

--- a/docs/features/mtplx.md
+++ b/docs/features/mtplx.md
@@ -5,10 +5,11 @@ runtime for Apple Silicon that can run Qwen checkpoints with native
 multi-token-prediction (MTP) decoding. It exposes OpenAI-compatible and
 Anthropic-compatible local APIs; PortOS uses its OpenAI-compatible endpoint.
 
-This is an additional runtime, not an Ollama replacement. PortOS continues to
-offer **Qwen3.8 27B** in the Ollama catalog using its GGUF model path. MTPLX's
-native-MTP checkpoints and Ollama GGUF models are distinct formats, so neither
-PortOS nor Ollama attempts to load one as the other.
+This is an additional runtime, not an Ollama replacement. PortOS offers
+**Qwen3.8 27B** through the Ollama GGUF path and, on Apple Silicon, recommends
+the LM Studio MLX 4-bit build as the native-format install path. MTPLX's
+native-MTP checkpoints, MLX builds, and Ollama GGUF models are distinct
+formats, so neither PortOS nor Ollama attempts to load one as the other.
 
 ## What PortOS adds
 

--- a/docs/research/2026-08-16-qwen38-mlx-macos.md
+++ b/docs/research/2026-08-16-qwen38-mlx-macos.md
@@ -43,6 +43,10 @@ decode latency only when the target runtime supports that exact MTP architecture
 and the draft's proposed tokens are accepted often enough. A poorly matched
 draft can add overhead instead.
 
+The live MLX discovery path also excludes repositories explicitly named as MTP
+or drafter checkpoints, so these auxiliary weights are not presented as normal
+one-click chat-model installs.
+
 LM Studio has added speculative-decoding support for models with built-in MTP
 heads, but that is a different compatibility path from automatically pairing an
 arbitrary `qwen3_5_mtp` sidecar with the curated MLX base model. PortOS does not

--- a/docs/research/2026-08-16-qwen38-mlx-macos.md
+++ b/docs/research/2026-08-16-qwen38-mlx-macos.md
@@ -1,0 +1,73 @@
+# Qwen3.8 27B MLX options on macOS
+
+Date: 2026-08-16
+
+## Recommendation
+
+Recommend `lmstudio-community/Qwen3.8-27B-MLX-4bit` as PortOS's fast macOS
+install option for Qwen3.8 27B. It is a complete MLX checkpoint, is published
+by the LM Studio community for its Apple-Silicon MLX engine, and fits the
+existing LM Studio `lms get` installation path. The catalog exposes it only on
+Apple Silicon and marks it as **Fast on Apple Silicon**.
+
+This is a format/runtime recommendation, not a promise of a fixed tokens-per-
+second improvement. MLX versus GGUF speed depends on the Mac, memory pressure,
+context length, LM Studio version, and sampling settings; users should benchmark
+both builds for their workload.
+
+## Why PortOS does not implement `mlx.fast`
+
+MLX's fast API is the `mx.fast` namespace: fused operations such as rotary
+embeddings, RMS normalization, and scaled dot-product attention. It is a
+low-level primitive used by MLX model implementations, not an installer, model
+format, or alternate server endpoint. PortOS currently orchestrates Ollama and
+LM Studio from its JavaScript server and does not own an MLX Python inference
+loop where replacing operators would have an effect.
+
+There is therefore no useful PortOS feature to add for `mlx.fast` itself. The
+native MLX model is the correct integration boundary; MLX/LM Studio own the
+operator implementation and can update it independently.
+
+## Why the linked MTP repos are not catalog installs
+
+`mlx-community/Qwen3.8-27B-MTP-4bit` and `...MTP-8bit` are MTP drafter
+checkpoints. Their model cards explicitly describe them as non-standalone
+weights to pair with a compatible Qwen3.8 27B target through `mlx-vlm`
+speculative decoding. Installing one by itself would not produce a usable
+Qwen3.8 chat model, so PortOS does not present either repository as a normal
+recommended model.
+
+The linked MTP repositories also do not make the base model faster by simply
+changing its quantization. They add a second draft-model path, which can reduce
+decode latency only when the target runtime supports that exact MTP architecture
+and the draft's proposed tokens are accepted often enough. A poorly matched
+draft can add overhead instead.
+
+LM Studio has added speculative-decoding support for models with built-in MTP
+heads, but that is a different compatibility path from automatically pairing an
+arbitrary `qwen3_5_mtp` sidecar with the curated MLX base model. PortOS does not
+install or launch `mlx-vlm`, MTPLX, or an MTP sidecar runtime on the user's
+behalf. The existing MTPLX integration remains an explicit, separately managed
+operator choice.
+
+## PortOS behavior
+
+- LM Studio on Apple Silicon: recommends and installs the complete 4-bit MLX
+  target through the existing model-install endpoint.
+- LM Studio on Intel macOS and non-macOS hosts: hides the MLX recommendation;
+  the existing GGUF catalog remains available.
+- Ollama: retains the existing Qwen3.8 GGUF entry. Ollama cannot install an
+  arbitrary Hugging Face MLX safetensors repository through this catalog.
+- Migration: a known LM Studio-only MLX entry is not guessed into an Ollama
+  model name.
+
+## Sources
+
+- [`mlx.core.fast` documentation](https://ml-explore.github.io/mlx/build/html/python/fast.html)
+- [MLX-LM](https://github.com/ml-explore/mlx-lm)
+- [Complete Qwen3.8 27B MLX 4-bit checkpoint](https://huggingface.co/lmstudio-community/Qwen3.8-27B-MLX-4bit)
+- [Qwen3.8 27B MTP 4-bit drafter](https://huggingface.co/mlx-community/Qwen3.8-27B-MTP-4bit)
+- [Qwen3.8 27B MTP 8-bit drafter](https://huggingface.co/mlx-community/Qwen3.8-27B-MTP-8bit)
+- [MLX-VLM speculative decoding](https://github.com/Blaizzy/mlx-vlm)
+- [LM Studio speculative decoding](https://lmstudio.ai/docs/app/advanced/speculative-decoding)
+- [LM Studio 0.4.14 MTP support](https://lmstudio.ai/changelog/lmstudio/lmstudio-v0.4.14)

--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -38,7 +38,8 @@ export const LOCAL_LLM_CATEGORIES = [
 ];
 
 // Each entry: { key, name, category, recommendedFor?, featured?, params, size,
-//               family, description, capabilities, context?, ollama?, lmstudio? }
+//               family, description, capabilities, context?, format?,
+//               appleSiliconOnly?, ollama?, lmstudio? }
 //
 // `category` is the one primary lane that groups a model in the unfiltered
 // picker. `recommendedFor` is its intentionally broader set of use-case lanes:
@@ -52,6 +53,9 @@ export const LOCAL_LLM_CATEGORIES = [
 // `context` is the model's native context window in tokens — set it only when
 // it's a documented spec for that build (the install-card badge shows it; live
 // Hugging Face results read the true value from GGUF metadata instead).
+// `format` identifies a backend-native format such as `mlx` when the install id
+// is not a GGUF build. `appleSiliconOnly` keeps native MLX recommendations out
+// of catalogs where the selected host cannot run them.
 //
 // Ollama ids must name a build that runs LOCALLY. Several headline 2026 models
 // (mistral-large-3, glm-5.2, deepseek-v4-*, minimax-m3, kimi-k3) are published
@@ -274,6 +278,25 @@ export const LOCAL_LLM_CATALOG = [
   // Best suited for whole-manuscript editorial review, where prose quality and a
   // long context window matter most. To actually fit the manuscript, raise Ollama's
   // context window (OLLAMA_CONTEXT_LENGTH) — the default 4K window silently truncates.
+  {
+    key: 'qwen3.8-27b-mlx-4bit',
+    name: 'Qwen3.8 27B MLX 4-bit',
+    category: 'general',
+    recommendedFor: ['general', 'coding', 'reasoning', 'vision', 'multilingual'],
+    featured: {
+      label: 'Fast on Apple Silicon',
+      description: 'Recommended native-MLX Qwen3.8 install for LM Studio on Apple Silicon.'
+    },
+    params: '27B',
+    size: '15.0 GB',
+    family: 'qwen',
+    description: 'LM Studio’s 4-bit MLX build of Qwen3.8 27B — a native Apple-Silicon format with long context, coding, reasoning, tools, vision, thinking, and multilingual support.',
+    capabilities: ['chat', 'code', 'reasoning', 'tools', 'vision', 'multilingual'],
+    context: 262144,
+    format: 'mlx',
+    appleSiliconOnly: true,
+    lmstudio: 'lmstudio-community/Qwen3.8-27B-MLX-4bit'
+  },
   {
     key: 'qwen3.8-27b',
     name: 'Qwen3.8 27B',
@@ -652,13 +675,14 @@ const normalizeFor = (backend, id) =>
  *
  * @param {string} backend - 'ollama' | 'lmstudio'
  * @param {string[]} [installedIds] - ids currently installed on that backend
- * @returns {Array<{ id, key, name, category, recommendedFor, featured, params, size, family, description, capabilities, contextLength, installed }>}
+ * @param {{ appleSilicon?: boolean }} [options] - host capabilities used for platform-gated entries
+ * @returns {Array<{ id, key, name, category, recommendedFor, featured, params, size, family, description, capabilities, format, contextLength, installed }>}
  */
-export function getCatalog(backend, installedIds = []) {
+export function getCatalog(backend, installedIds = [], { appleSilicon } = {}) {
   if (!isBackend(backend)) return [];
   const installedNorm = new Set(installedIds.map((id) => normalizeFor(backend, id)));
   return LOCAL_LLM_CATALOG
-    .filter((entry) => entry[backend])
+    .filter((entry) => entry[backend] && (!entry.appleSiliconOnly || appleSilicon !== false))
     .map((entry) => {
       const recommendedFor = Array.isArray(entry.recommendedFor) && entry.recommendedFor.length
         ? [...entry.recommendedFor]
@@ -675,6 +699,7 @@ export function getCatalog(backend, installedIds = []) {
         family: entry.family,
         description: entry.description,
         capabilities: entry.capabilities,
+        format: entry.format || null,
         // Native context window (tokens), when it's a documented spec; null otherwise.
         contextLength: Number.isFinite(entry.context) ? entry.context : null,
         installed: installedNorm.has(normalizeFor(backend, entry[backend]))
@@ -686,8 +711,8 @@ export function getCatalog(backend, installedIds = []) {
  * Filter the per-backend catalog by a free-text query against name, id,
  * family, category, and description. Empty query returns the full catalog.
  */
-export function searchCatalog(backend, query, installedIds = []) {
-  const all = getCatalog(backend, installedIds);
+export function searchCatalog(backend, query, installedIds = [], options = {}) {
+  const all = getCatalog(backend, installedIds, options);
   const q = String(query || '').trim().toLowerCase();
   if (!q) return all;
   return all.filter((m) =>
@@ -724,6 +749,10 @@ export function mapModelToBackend(fromBackend, modelId, toBackend) {
   if (entry && entry[toBackend]) {
     return { targetId: entry[toBackend], exact: true };
   }
+  // A known catalog entry without a build on the target backend is not an
+  // unknown model: do not turn a native-format id (for example an MLX repo)
+  // into a misleading best-effort Ollama stem.
+  if (entry) return { targetId: null, exact: false };
 
   // No catalog match. Ollama can pull bare model names, so derive a stem and
   // try it best-effort. There's no safe way to guess a HuggingFace repo for

--- a/server/lib/localLlmCatalog.test.js
+++ b/server/lib/localLlmCatalog.test.js
@@ -50,6 +50,17 @@ describe('localLlmCatalog', () => {
       expect(list.find((m) => m.key === 'gemma4-12b').installed).toBe(true);
     });
 
+    it('gates the native Qwen MLX recommendation to Apple Silicon', () => {
+      const mlxKey = 'qwen3.8-27b-mlx-4bit';
+      expect(getCatalog('lmstudio').find((m) => m.key === mlxKey)).toMatchObject({
+        format: 'mlx',
+        id: 'lmstudio-community/Qwen3.8-27B-MLX-4bit'
+      });
+      expect(getCatalog('lmstudio', [], { appleSilicon: true }).some((m) => m.key === mlxKey)).toBe(true);
+      expect(getCatalog('lmstudio', [], { appleSilicon: false }).some((m) => m.key === mlxKey)).toBe(false);
+      expect(getCatalog('ollama', [], { appleSilicon: true }).some((m) => m.key === mlxKey)).toBe(false);
+    });
+
     it('returns [] for an unknown backend', () => {
       expect(getCatalog('nope')).toEqual([]);
     });
@@ -137,6 +148,11 @@ describe('localLlmCatalog', () => {
       const r = mapModelToBackend('lmstudio', 'someorg/Mystery-Model-7B-Instruct-GGUF', 'ollama');
       expect(r.exact).toBe(false);
       expect(r.targetId).toBe('mystery-model');
+    });
+
+    it('does not invent an Ollama target for a known LM Studio-only MLX build', () => {
+      expect(mapModelToBackend('lmstudio', 'lmstudio-community/Qwen3.8-27B-MLX-4bit', 'ollama'))
+        .toEqual({ targetId: null, exact: false });
     });
 
     it('returns null (skip) when mapping an unknown model TO LM Studio', () => {

--- a/server/routes/localLlm.js
+++ b/server/routes/localLlm.js
@@ -87,7 +87,13 @@ router.get('/catalog', asyncHandler(async (req, res) => {
   const installedForVariants = installedModels.map((m) => (
     backend === 'lmstudio' && m.quantization ? `${m.id}@${m.quantization}` : m.id
   ))
-  const models = q ? searchCatalog(backend, q, installedRaw) : getCatalog(backend, installedRaw)
+  // Native MLX entries are meaningful only on Apple Silicon. Keep this gate at
+  // the route boundary so the pure catalog remains useful to tests and other
+  // callers while the user-facing picker never offers an un-runnable format.
+  const catalogOptions = { appleSilicon: isAppleSilicon() }
+  const models = q
+    ? searchCatalog(backend, q, installedRaw, catalogOptions)
+    : getCatalog(backend, installedRaw, catalogOptions)
   // Total system memory drives the RAM-aware recommended quant (unified memory on
   // Apple Silicon also backs the GPU, so a big box can default to higher fidelity).
   const systemMemoryBytes = os.totalmem()

--- a/server/services/huggingFaceCatalog.js
+++ b/server/services/huggingFaceCatalog.js
@@ -888,6 +888,33 @@ function applyGgufVariants(result, model, { backend, usableBytes, installedIds, 
   return true
 }
 
+// MLX repos encode one quantization in the repository name and ship sharded
+// safetensors rather than a per-file GGUF picker. Keep the single-variant shape
+// shared by live Hugging Face results and curated catalog entries so both paths
+// use the same size, fit, and installed-state contract.
+function applyMlxVariant(result, model, { backend, usableBytes, installedIds }) {
+  const bytes = sumSafetensorsBytes(model)
+  if (Number.isFinite(bytes)) {
+    result.sizeBytes = bytes
+    result.size = formatBytes(bytes) || result.size
+  }
+  const quant = result.quant || mlxQuantFromRepo(result.repository || result.id)
+  if (result.quant == null && quant) result.quant = quant
+  const variant = {
+    quant: quant || 'mlx',
+    format: 'mlx',
+    installId: result.id, // bare repo — the repo name encodes the MLX quant
+    sizeBytes: Number.isFinite(result.sizeBytes) ? result.sizeBytes : null,
+    size: formatBytes(result.sizeBytes) || result.size || (quant ? quant.toUpperCase() : 'MLX'),
+    fit: classifyFit(result.sizeBytes, usableBytes),
+    installed: installIdInstalled(backend, result.id, result.repository, installedIds),
+    recommended: true
+  }
+  result.format = 'mlx'
+  result.variants = [variant]
+  result.installed = variant.installed
+}
+
 // Backfill real file sizes AND native context windows from the per-model
 // `?blobs=true` record (the search listing carries neither). Both are fetched
 // from the same cached repo record, so a result missing either triggers one
@@ -906,25 +933,7 @@ async function enrichWithSizes(results, { backend, usableBytes, installedIds = [
     const model = await fetchRepoModel(result.repository)
     if (!model) return
     if (isMlx) {
-      // MLX size = summed safetensors shards. The picker shows a single variant
-      // (the repo's quant) so the card UI matches the multi-quant GGUF cards.
-      const bytes = sumSafetensorsBytes(model)
-      if (Number.isFinite(bytes)) {
-        result.sizeBytes = bytes
-        result.size = formatBytes(bytes) || result.size
-      }
-      const variant = {
-        quant: result.quant || 'mlx',
-        format: 'mlx',
-        installId: result.id, // bare repo — mlx-community encodes the quant in the name
-        sizeBytes: Number.isFinite(result.sizeBytes) ? result.sizeBytes : null,
-        size: formatBytes(result.sizeBytes) || (result.quant ? result.quant.toUpperCase() : 'MLX'),
-        fit: classifyFit(result.sizeBytes, usableBytes),
-        installed: installIdInstalled(backend, result.id, result.repository, installedIds),
-        recommended: true
-      }
-      result.variants = [variant]
-      result.installed = variant.installed
+      applyMlxVariant(result, model, { backend, usableBytes, installedIds })
       return
     }
     if (!isAudio) {
@@ -1144,9 +1153,9 @@ async function applyOllamaRegistryVariants(entry, { usableBytes, installedIds })
 // Enrich curated-catalog entries (from localLlmCatalog.getCatalog) in place with
 // the same per-quant variant picker + RAM-aware default the live HF search uses.
 // HF-repo-backed entries (see catalogRepoForBackend) read their GGUF siblings;
-// bare Ollama registry names are enriched from the Ollama registry instead. An
-// MLX-only repo (no GGUF quants) or a model absent from the registry is left
-// untouched — the card then shows the curator's single id with no picker.
+// curated MLX entries get one native-format variant; bare Ollama registry names
+// are enriched from the Ollama registry instead. A model absent from its source
+// is left untouched so the offline catalog still renders.
 // `usableBytes` makes the recommended quant fit this machine.
 export async function enrichCatalogWithVariants(catalog, { backend, systemMemoryBytes = null, installedIds = [], timeoutMs = CATALOG_ENRICH_TIMEOUT_MS } = {}) {
   if (!isBackend(backend) || !Array.isArray(catalog)) return catalog
@@ -1164,12 +1173,16 @@ export async function enrichCatalogWithVariants(catalog, { backend, systemMemory
     const model = await fetchRepoModel(repo)
     if (!model) return
     entry.repository = repo
+    if (entry.format === 'mlx') {
+      applyMlxVariant(entry, model, { backend, usableBytes, installedIds })
+      return
+    }
     // Seed the quant from the curator's id so the no-budget fallback anchors on it.
     if (entry.quant == null) entry.quant = quantFromInstallId(backend, entry.id)
     // Keep the curated entry's stable id (rewriteInstallId: false) — the playground
     // matches installed models on it; the UI installs the recommended variant.
     const applied = applyGgufVariants(entry, model, { backend, usableBytes, installedIds, rewriteInstallId: false })
-    if (!applied) return // MLX-only / no parseable GGUF quant — leave the curated entry as-is
+    if (!applied) return // no parseable GGUF quant — leave the curated entry as-is
     entry.format = 'gguf'
     // Backfill the real size + native context window the curated list hard-codes.
     if (!Number.isFinite(entry.sizeBytes)) {

--- a/server/services/huggingFaceCatalog.js
+++ b/server/services/huggingFaceCatalog.js
@@ -568,6 +568,14 @@ function hasMlxSignal(model) {
     && hasSafetensors
 }
 
+// MTP/drafter checkpoints are auxiliary weights for speculative decoding, not
+// standalone chat models. Keep them out of the normal MLX install cards; the
+// catalog's complete target model is the safe one-click path.
+function isMlxDrafter(model) {
+  const haystack = `${repoIdOf(model)} ${tagsOf(model).join(' ')} ${model?.pipeline_tag || ''}`
+  return /(?:^|[\/_-])(?:mtp|drafter)(?:[\/_\-.]|$)/i.test(haystack)
+}
+
 // Build an MLX search result. Same shape as a GGUF result with `format: 'mlx'`,
 // a single variant (the repo's quant), and the LM Studio bare-repo install id.
 // Sizes/variant fit are backfilled in enrichWithSizes from `?blobs=true`.
@@ -1039,7 +1047,7 @@ export async function searchHuggingFaceModels({ backend, query = '', category = 
   // MLX results (LM Studio + Apple Silicon only) merge into the same list — each
   // is its own card (`format: 'mlx'`), deduped against the GGUF repos already seen.
   const mlxLive = mlxModelsRaw
-    .filter((model) => hasMlxSignal(model))
+    .filter((model) => hasMlxSignal(model) && !isMlxDrafter(model))
     .map((model) => toMlxResult(model, requestedCategory, installedIds))
     .filter(Boolean)
     .filter((model) => {

--- a/server/services/huggingFaceCatalog.test.js
+++ b/server/services/huggingFaceCatalog.test.js
@@ -751,6 +751,39 @@ describe('huggingFaceCatalog', () => {
       expect(catalog[0].sizeBytes).toBe(8_000_000_000)
     })
 
+    it('enriches a curated LM Studio MLX entry with one installed native-format variant', async () => {
+      const repo = 'lmstudio-community/Qwen3.8-27B-MLX-4bit'
+      fetch.mockResolvedValueOnce(blobs(repo, {
+        'model-00001-of-00003.safetensors': 5_400_000_000,
+        'model-00002-of-00003.safetensors': 5_300_000_000,
+        'model-00003-of-00003.safetensors': 5_300_000_000,
+      }))
+
+      const catalog = [{
+        id: repo,
+        key: 'qwen3.8-27b-mlx-4bit',
+        name: 'Qwen3.8 27B MLX 4-bit',
+        category: 'general',
+        format: 'mlx',
+        size: '15.0 GB'
+      }]
+      await enrichCatalogWithVariants(catalog, {
+        backend: 'lmstudio',
+        systemMemoryBytes: 128 * 1024 ** 3,
+        installedIds: [`${repo}@4bit`]
+      })
+
+      expect(catalog[0]).toMatchObject({ format: 'mlx', quant: '4bit', sizeBytes: 16_000_000_000, installed: true })
+      expect(catalog[0].variants).toEqual([expect.objectContaining({
+        format: 'mlx',
+        quant: '4bit',
+        installId: repo,
+        sizeBytes: 16_000_000_000,
+        installed: true,
+        recommended: true
+      })])
+    })
+
     it('enriches an Ollama hf.co curated id and keeps the hf.co install ids', async () => {
       const repo = 'unsloth/Curated-Devstral-GGUF'
       fetch.mockResolvedValueOnce(blobs(repo, {

--- a/server/services/huggingFaceCatalog.test.js
+++ b/server/services/huggingFaceCatalog.test.js
@@ -663,6 +663,20 @@ describe('huggingFaceCatalog', () => {
       expect(results.some((r) => r.repository === mlxRepo)).toBe(false)
     })
 
+    it('does not offer non-standalone MTP drafter checkpoints as MLX installs', async () => {
+      const drafterRepo = 'mlx-community/Qwen3.8-27B-MTP-4bit'
+      fetch.mockImplementation(urlRouter([
+        ['filter=mlx', [mlxListing(drafterRepo, ['model.safetensors'])]],
+        ['filter=gguf', []],
+      ]))
+
+      const results = await searchHuggingFaceModels({
+        backend: 'lmstudio', query: 'qwen3.8', appleSilicon: true
+      })
+
+      expect(results.some((r) => r.repository === drafterRepo)).toBe(false)
+    })
+
     it('does not surface MLX on a non-Apple host even for LM Studio', async () => {
       const mlxRepo = 'mlx-community/Hidden-On-Intel-4bit'
       fetch.mockImplementation(urlRouter([


### PR DESCRIPTION
## Summary\n\n- Add an Apple Silicon-only recommended LM Studio entry for lmstudio-community/Qwen3.8-27B-MLX-4bit as the native MLX 4-bit Qwen3.8 install.\n- Enrich curated MLX entries with safetensors size, install, and fit-variant metadata; prevent migration from inventing Ollama targets for MLX-only models.\n- Gate live MLX discovery to Apple Silicon and exclude non-standalone MTP/drafter checkpoints from normal install cards.\n- Document the recommendation, why mlx.fast is not a useful PortOS implementation target, and how MTP remains an advanced operator-managed path.\n\n## Recommendation\n\nUse the complete [LM Studio MLX 4-bit model](https://huggingface.co/lmstudio-community/Qwen3.8-27B-MLX-4bit) on Apple Silicon. Actual speed is machine- and workload-dependent, so users should benchmark their own hardware. The linked [MTP 4-bit](https://huggingface.co/mlx-community/Qwen3.8-27B-MTP-4bit) and [MTP 8-bit](https://huggingface.co/mlx-community/Qwen3.8-27B-MTP-8bit) repositories are draft weights for speculative decoding, not standalone catalog installs.\n\n## Test plan\n\n- npm test --prefix server -- lib/localLlmCatalog.test.js services/huggingFaceCatalog.test.js routes/localLlm.test.js\n- npm test --prefix client -- src/components/settings/LocalLlmTab.test.jsx\n- npm test --prefix server\n- git diff --check