### PR TITLE
docs: add changelog entry for issue #4363

### DIFF
--- a/.changelog/next/fixed-changelog-issue-4363.md
+++ b/.changelog/next/fixed-changelog-issue-4363.md
@@ -1,0 +1,1 @@
+- GitLab-aware manual completion prompts now carry merge requests through review and merge (#4363).


### PR DESCRIPTION
## Summary

- Add the missing unreleased note for the merged GitLab completion-prompt fix.

Refs #4363

## Test plan

- npm run changelog:preview
- git diff --check