### PR TITLE
docs: remove duplicate changelog entry for issue #4363

### DIFF
--- a/.changelog/next/fixed-changelog-issue-4363.md
+++ b/.changelog/next/fixed-changelog-issue-4363.md
@@ -1,1 +1,0 @@
-- GitLab-aware manual completion prompts now carry merge requests through review and merge (#4363).


### PR DESCRIPTION
## Summary

- Remove the duplicate unreleased note introduced by the bookkeeping correction; retain the original issue fragment.

Refs #4363

## Test plan

- git diff --check
- Confirm exactly one #4363 fragment remains on main after merge.