### PR TITLE
fix(issue-4365): retry Hugging Face auth-denied catalog repos

### DIFF
--- a/.changelog/next/fixed-issue-4365.md
+++ b/.changelog/next/fixed-issue-4365.md
@@ -1,0 +1,1 @@
+- Hugging Face catalog metadata retries after repository access or credentials change.

--- a/server/services/huggingFaceCatalog.js
+++ b/server/services/huggingFaceCatalog.js
@@ -694,11 +694,16 @@ const hfSearchGate = createConcurrencyGate(2)
 // curated catalog and the live search, and neither caches until it resolves.
 const repoModelFlight = createSingleFlight()
 
-// Statuses that are a real, durable "this repo has no data for you" answer and
-// so are safe to cache. Everything else non-OK (429 rate limit, 5xx, 408) is the
-// Hub having a bad moment — mirrors `resolveRegistryBody` in
-// ollamaRegistryCatalog.js, which has always drawn this line.
-const HF_PERMANENT_NOT_FOUND = new Set([401, 403, 404, 410])
+// Statuses that are a real, durable "this repo has no data" answer and so are
+// safe to cache. Everything else non-OK (including auth denials, rate limits,
+// 5xx, and 408) may change and must be retried on a later lookup — mirrors
+// `resolveRegistryBody` in ollamaRegistryCatalog.js, which has always drawn this
+// line.
+// Authentication denials are deliberately excluded: a user can add a token or
+// gain access to a gated repo at any time, so caching a 401/403 would keep the
+// catalog blank until the seven-day repo-cache TTL expires. A genuinely missing
+// or gone repo remains a durable no-data answer.
+const HF_PERMANENT_NOT_FOUND = new Set([404, 410])
 
 // Single door to the Hub: bounded concurrency + the shared one-shot retry.
 //
@@ -783,10 +788,10 @@ const TRANSIENT_FETCH = Symbol('transient-fetch')
 //
 // `null` = fetched-but-unavailable, and it is cached at both tiers (per the
 // absent-vs-empty sentinel rule) so a sizeless repo isn't re-probed every search
-// — but ONLY when the Hub gave a durable answer (401/403/404/410). A rate limit,
-// a 5xx, or a dropped connection also returns null and is NOT cached, so a
-// recovered Hub re-enriches on the next request instead of staying blank for the
-// week the disk TTL would otherwise hold it.
+// — but ONLY when the Hub gave a durable answer (404/410). An auth denial, rate
+// limit, 5xx, or dropped connection also returns null and is NOT cached, so a
+// newly authorized or recovered Hub re-enriches on the next request instead of
+// staying blank for the week the disk TTL would otherwise hold it.
 async function fetchRepoModel(repoId) {
   if (repoModelCache.has(repoId)) return repoModelCache.get(repoId)
   return repoModelFlight.run(repoId, async () => {
@@ -807,7 +812,8 @@ async function fetchRepoModel(repoId) {
     // as "no data" would bake a bad moment into the disk tier for the full TTL,
     // and a restart would no longer clear it the way the old memory-only cache did.
     if (result === TRANSIENT_FETCH || result.outcome === 'transient') return null
-    // 'permanent' (gated / private / gone) IS a real answer — cache the null.
+    // 'permanent' (gone) IS a real answer — cache the null. Auth denials are
+    // transient because the user's credentials or repository access can change.
     const model = result.outcome === 'ok' ? result.data : null
     rememberRepoModel(repoId, model)
     await writeCachedRepoModel(repoId, model)

--- a/server/services/huggingFaceCatalog.test.js
+++ b/server/services/huggingFaceCatalog.test.js
@@ -35,6 +35,7 @@ describe('huggingFaceCatalog', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
   })
 
   it('maps GGUF search results to Ollama hf.co install ids with preferred quants', async () => {
@@ -1058,10 +1059,8 @@ describe('huggingFaceCatalog', () => {
 
     // A durable answer IS worth caching — the counterpart to the test above, so a
     // fix for one can't quietly disable the other.
-    it.each([
-      ['a 404 (repo gone)', 404],
-      ['a 403 (gated)', 403]
-    ])('caches %s as a durable "no data" answer', async (_label, status) => {
+    it('caches a 404 (repo gone) as a durable "no data" answer', async () => {
+      const status = 404
       const repo = `permanent-${status}/Repo-GGUF`
       const { writeCachedRepoModel } = await import('./huggingFaceRepoCache.js')
 
@@ -1077,6 +1076,41 @@ describe('huggingFaceCatalog', () => {
       })
 
       expect(writeCachedRepoModel.mock.calls).toEqual([[repo, null]])
+    })
+
+    it('re-fetches a gated repo after credentials are configured', async () => {
+      const repo = 'gated-auth/Repo-GGUF'
+      const { writeCachedRepoModel } = await import('./huggingFaceRepoCache.js')
+      let blobsCalls = 0
+      vi.stubEnv('HUGGINGFACE_TOKEN', '')
+      vi.stubEnv('HF_TOKEN', '')
+      fetch.mockImplementation(async (url, options) => {
+        if (!String(url).includes('blobs=true')) return response([])
+        blobsCalls += 1
+        if (blobsCalls === 1) {
+          expect(options.headers.Authorization).toBeUndefined()
+          return { ok: false, status: 403, json: vi.fn(), text: vi.fn(async () => 'gated') }
+        }
+        expect(options.headers.Authorization).toBe('Bearer test-token')
+        return response({ id: repo, siblings: [{ rfilename: 'G-Q4_K_M.gguf', size: 4_000_000_000 }] })
+      })
+
+      const first = [{ id: repo, key: 'gated-first', name: 'Gated', category: 'chat', size: '2.0 GB' }]
+      await enrichCatalogWithVariants(first, {
+        backend: 'lmstudio', systemMemoryBytes: 128 * 1024 ** 3, installedIds: [], timeoutMs: 0
+      })
+      expect(first[0].variants).toBeUndefined()
+      expect(writeCachedRepoModel.mock.calls).toEqual([])
+
+      vi.stubEnv('HUGGINGFACE_TOKEN', 'test-token')
+      const second = [{ id: repo, key: 'gated-second', name: 'Gated', category: 'chat', size: '2.0 GB' }]
+      await enrichCatalogWithVariants(second, {
+        backend: 'lmstudio', systemMemoryBytes: 128 * 1024 ** 3, installedIds: [], timeoutMs: 0
+      })
+
+      expect(blobsCalls).toBe(2)
+      expect(second[0].variants).toHaveLength(1)
+      expect(writeCachedRepoModel.mock.calls).toEqual([[repo, expect.any(Object)]])
     })
 
     // The gate must bound open CONNECTIONS, not just header waits — releasing the

--- a/server/services/huggingFaceRepoCache.js
+++ b/server/services/huggingFaceRepoCache.js
@@ -24,7 +24,10 @@ import { PATHS, readJSONFileStrict, atomicWrite, ensureDir } from '../lib/fileUt
 const CACHE_FILE = join(PATHS.data, 'cache', 'huggingface-repos.json')
 // Bump when the envelope shape changes — a mismatch drops the file and refetches
 // rather than trying to read an older layout.
-const CACHE_SCHEMA_VERSION = 1
+// v2 invalidates legacy `model: null` entries, which may represent a cached
+// 401/403 from before auth denials became retryable (#4365). Their envelope did
+// not retain the HTTP status, so selective migration is impossible.
+const CACHE_SCHEMA_VERSION = 2
 // 7 days. Long because the payload is near-immutable (published file sizes never
 // change); bounded because a repo CAN gain a new quant, and a stale card would
 // hide it indefinitely.

--- a/server/services/huggingFaceRepoCache.test.js
+++ b/server/services/huggingFaceRepoCache.test.js
@@ -62,7 +62,7 @@ describe('huggingFaceRepoCache', () => {
     const stale = Date.now() - (8 * 24 * 60 * 60 * 1000); // 8 days — TTL is 7
     await mkdir(join(tempRoot, 'cache'), { recursive: true });
     await writeFile(cacheFile(), JSON.stringify({
-      schemaVersion: 1,
+      schemaVersion: 2,
       entries: {
         'old/Repo': { fetchedAt: stale, model: { id: 'old/Repo' } },
         'new/Repo': { fetchedAt: Date.now(), model: { id: 'new/Repo' } }


### PR DESCRIPTION
## Summary

- Stop caching Hugging Face 401/403 metadata denials so credentials or gated-repository access changes are retried immediately.
- Preserve the seven-day durable cache for repositories that are actually absent (404/410).
- Add coverage for retrying a gated repository after a token is configured.

## Test plan

- `cd server && npm test -- huggingFaceCatalog.test.js`

Closes #4365
