### PR TITLE
fix(issue-4362): route Linux LTX video through CUDA helper

### DIFF
--- a/.changelog/next/fixed-issue-4362.md
+++ b/.changelog/next/fixed-issue-4362.md
@@ -1,0 +1,1 @@
+- Linux CUDA video renders now use the compatible LTX runtime by default.

--- a/data.reference/media-models.json
+++ b/data.reference/media-models.json
@@ -478,13 +478,13 @@
       {
         "id": "ltx_video",
         "name": "LTX-Video 0.9.5 — T2V + I2V (~9.5 GB, auto-downloads)",
-        "runtime": "mlx_video",
+        "runtime": "cuda_video",
         "steps": 25,
         "guidance": 3,
         "disclosure": {
           "runtimeLicense": {
-            "name": "MIT",
-            "url": "https://pypi.org/project/mlx-video-with-audio/"
+            "name": "Apache-2.0",
+            "url": "https://github.com/huggingface/diffusers/blob/main/LICENSE"
           },
           "reviewedAt": "2026-08-09"
         }

--- a/scripts/migrations/237-video-model-disclosure.test.js
+++ b/scripts/migrations/237-video-model-disclosure.test.js
@@ -54,7 +54,7 @@ describe('migration 237 — video model disclosure metadata', () => {
     writeJson(path, baseRegistry());
     await migration.up({ rootDir });
     const entry = readJson(path).video.windows.find((e) => e.id === 'ltx_video');
-    expect(entry.disclosure.runtimeLicense.name).toBe('MIT');
+    expect(entry.disclosure.runtimeLicense.name).toBe('Apache-2.0');
     // No repo → no model card and no weights license we can attribute.
     expect('modelCardUrl' in entry.disclosure).toBe(false);
     expect('weightsLicense' in entry.disclosure).toBe(false);

--- a/scripts/migrations/273-ltx-video-cuda-runtime.js
+++ b/scripts/migrations/273-ltx-video-cuda-runtime.js
@@ -1,0 +1,36 @@
+/**
+ * Correct the legacy LTX-Video 0.9.5 CUDA entry's runtime marker. It was
+ * stored in the CUDA bucket but incorrectly named the Apple-only MLX runtime,
+ * which sent Linux renders down an unavailable path before they could spawn.
+ */
+
+import { VIDEO_BUCKET_CUDA, readVideoBucket } from '../../server/lib/mediaModelBuckets.js';
+import { readMediaRegistryConfig, writeMediaRegistry } from './_lib.js';
+
+const REL_PATH = 'data/media-models.json';
+
+const isLegacyLtx = (entry) => (
+  entry?.id === 'ltx_video'
+  && entry.runtime === 'mlx_video'
+  && entry.repo === undefined
+);
+
+export default {
+  async up({ rootDir }) {
+    const { ok, config, path } = await readMediaRegistryConfig({ rootDir });
+    if (!ok) return;
+
+    const cuda = readVideoBucket(config?.video, VIDEO_BUCKET_CUDA);
+    if (!Array.isArray(cuda)) return;
+    let changed = false;
+    for (const entry of cuda) {
+      if (!isLegacyLtx(entry)) continue;
+      entry.runtime = 'cuda_video';
+      changed = true;
+    }
+    if (!changed) return;
+
+    await writeMediaRegistry(path, config);
+    console.log(`📝 ${REL_PATH}: corrected LTX-Video's CUDA runtime marker`);
+  },
+};

--- a/scripts/migrations/273-ltx-video-cuda-runtime.js
+++ b/scripts/migrations/273-ltx-video-cuda-runtime.js
@@ -11,7 +11,7 @@ const REL_PATH = 'data/media-models.json';
 
 const isLegacyLtx = (entry) => (
   entry?.id === 'ltx_video'
-  && entry.runtime === 'mlx_video'
+  && (entry.runtime === undefined || entry.runtime === 'mlx_video')
   && entry.repo === undefined
 );
 

--- a/scripts/migrations/273-ltx-video-cuda-runtime.test.js
+++ b/scripts/migrations/273-ltx-video-cuda-runtime.test.js
@@ -11,6 +11,18 @@ const writeRegistry = (rootDir, video) => {
 };
 
 describe('273-ltx-video-cuda-runtime', () => {
+  it('upgrades an entry persisted before the runtime field existed', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'portos-migration-'));
+    try {
+      writeRegistry(rootDir, { cuda: [{ id: 'ltx_video' }] });
+      await migration.up({ rootDir });
+      const saved = JSON.parse(readFileSync(join(rootDir, 'data', 'media-models.json'), 'utf8'));
+      expect(saved.video.cuda[0].runtime).toBe('cuda_video');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
   it('upgrades the uncustomized CUDA LTX entry', async () => {
     const rootDir = mkdtempSync(join(tmpdir(), 'portos-migration-'));
     try {

--- a/scripts/migrations/273-ltx-video-cuda-runtime.test.js
+++ b/scripts/migrations/273-ltx-video-cuda-runtime.test.js
@@ -1,0 +1,41 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import migration from './273-ltx-video-cuda-runtime.js';
+
+const writeRegistry = (rootDir, video) => {
+  const dataDir = join(rootDir, 'data');
+  mkdirSync(dataDir, { recursive: true });
+  writeFileSync(join(dataDir, 'media-models.json'), JSON.stringify({ video }));
+};
+
+describe('273-ltx-video-cuda-runtime', () => {
+  it('upgrades the uncustomized CUDA LTX entry', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'portos-migration-'));
+    try {
+      writeRegistry(rootDir, {
+        cuda: [{ id: 'ltx_video', runtime: 'mlx_video' }],
+      });
+      await migration.up({ rootDir });
+      const saved = JSON.parse(readFileSync(join(rootDir, 'data', 'media-models.json'), 'utf8'));
+      expect(saved.video.cuda[0].runtime).toBe('cuda_video');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves a repointed entry', async () => {
+    const rootDir = mkdtempSync(join(tmpdir(), 'portos-migration-'));
+    try {
+      writeRegistry(rootDir, {
+        cuda: [{ id: 'ltx_video', runtime: 'mlx_video', repo: 'example-org/ltx-fork' }],
+      });
+      await migration.up({ rootDir });
+      const saved = JSON.parse(readFileSync(join(rootDir, 'data', 'media-models.json'), 'utf8'));
+      expect(saved.video.cuda[0].runtime).toBe('mlx_video');
+    } finally {
+      rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/server/lib/mediaModels.js
+++ b/server/lib/mediaModels.js
@@ -487,7 +487,7 @@ const DEFAULT_REGISTRY = {
       },
     ])),
     cuda: applyVideoFinishProfiles(applyVideoDisclosures([
-      { id: 'ltx_video', name: 'LTX-Video 0.9.5 — T2V + I2V (~9.5 GB, auto-downloads)', runtime: 'mlx_video', steps: 25, guidance: 3.0 },
+      { id: 'ltx_video', name: 'LTX-Video 0.9.5 — T2V + I2V (~9.5 GB, auto-downloads)', runtime: 'cuda_video', steps: 25, guidance: 3.0 },
       // MiniMax H3 on NVIDIA, through diffusers' MiniMaxH3ModularPipeline —
       // the same joint video+audio model the MLX list runs on Apple Silicon, so it
       // shares H3's canvas grid, its fixed 24 fps, its locked CFG-distilled
@@ -883,7 +883,7 @@ const appendNewlyShippedEntries = (userList, defaultList, shippedIds) => {
 // 'ltx2_unified' is retired (see RETIRED_VIDEO_MODELS) but stays here: an
 // install that re-pointed its entry at a fork keeps that entry, and it still
 // needs the runtime backfill.
-const LEGACY_MLX_VIDEO_IDS = new Set(['ltx2_unified', 'ltx23_unified', 'ltx23_distilled_q4', 'ltx_video']);
+const LEGACY_MLX_VIDEO_IDS = new Set(['ltx2_unified', 'ltx23_unified', 'ltx23_distilled_q4']);
 const backfillRuntime = (list) => {
   if (!Array.isArray(list)) return list;
   return list.map((entry) => {
@@ -892,6 +892,22 @@ const backfillRuntime = (list) => {
     if (LEGACY_MLX_VIDEO_IDS.has(entry.id)) return { ...entry, runtime: 'mlx_video' };
     return entry;
   });
+};
+
+// `ltx_video` is the legacy diffusers CUDA helper, not an MLX runtime. It
+// shipped in the CUDA bucket before the bucket names made that mismatch
+// obvious, so correct an untouched persisted entry during the same early load
+// that still precedes migrations. A custom repo is deliberately left alone.
+const upgradeLegacyCudaLtxRuntime = (list) => {
+  if (!Array.isArray(list)) return list;
+  return list.map((entry) => (
+    isPlainObject(entry)
+      && entry.id === 'ltx_video'
+      && entry.runtime === 'mlx_video'
+      && entry.repo === undefined
+      ? { ...entry, runtime: 'cuda_video' }
+      : entry
+  ));
 };
 
 // Built-in video models that were delivered to installs and have since been
@@ -1045,11 +1061,15 @@ const normalizeRegistry = (parsed) => {
   // after the user's own entries are merged in) so an edge that points at a
   // model this install deleted — or a hand-edited typo — is dropped with a
   // warning instead of surfacing a Finish button targeting nothing.
-  const videoEntries = (entries) => sanitizeFinishProfiles(applyVideoFinishProfiles(
-    applyVideoDisclosures(backfillRuntime(upgradeMiniMaxH3OutputControls(dropRetiredEntries(entries)))),
-  ));
+  const videoEntries = (entries, { upgradeLegacyCudaLtx = false } = {}) => {
+    const normalized = backfillRuntime(upgradeMiniMaxH3OutputControls(dropRetiredEntries(entries)));
+    const upgraded = upgradeLegacyCudaLtx ? upgradeLegacyCudaLtxRuntime(normalized) : normalized;
+    return sanitizeFinishProfiles(applyVideoFinishProfiles(applyVideoDisclosures(upgraded)));
+  };
   const normalizedBuckets = Object.fromEntries(
-    VIDEO_BUCKETS.map((bucket) => [bucket, videoEntries(bucketResults[bucket].entries)]),
+    VIDEO_BUCKETS.map((bucket) => [bucket, videoEntries(bucketResults[bucket].entries, {
+      upgradeLegacyCudaLtx: bucket === 'cuda',
+    })]),
   );
 
   // Spread the user's own `video` keys but NOT the legacy bucket spellings: the

--- a/server/lib/mediaModels.js
+++ b/server/lib/mediaModels.js
@@ -903,7 +903,7 @@ const upgradeLegacyCudaLtxRuntime = (list) => {
   return list.map((entry) => (
     isPlainObject(entry)
       && entry.id === 'ltx_video'
-      && entry.runtime === 'mlx_video'
+      && (entry.runtime === undefined || entry.runtime === 'mlx_video')
       && entry.repo === undefined
       ? { ...entry, runtime: 'cuda_video' }
       : entry

--- a/server/lib/mediaModels.test.js
+++ b/server/lib/mediaModels.test.js
@@ -1264,6 +1264,17 @@ describe('video bucket selection is an MLX/CUDA axis, not an OS one', () => {
     expect(routesToWindowsHelper(model)).toBe(true);
   });
 
+  it('upgrades a pre-runtime-field LTX entry in the CUDA bucket', async () => {
+    const legacyLtx = { id: 'ltx_video', name: 'Legacy LTX', steps: 25, guidance: 3.0 };
+    writeFileSync(registryFile, JSON.stringify({
+      ...CANONICAL,
+      video: { ...CANONICAL.video, cuda: [legacyLtx], defaultCuda: legacyLtx.id },
+    }));
+    asPlatform('linux');
+    const { getVideoModels } = await import('./mediaModels.js');
+    expect(getVideoModels().find((entry) => entry.id === legacyLtx.id)?.runtime).toBe('cuda_video');
+  });
+
   for (const [shape, registry] of [['canonical mlx/cuda keys', CANONICAL], ['legacy macos/windows keys', LEGACY]]) {
     describe(shape, () => {
       it('serves the MLX list on darwin', async () => {

--- a/server/lib/mediaModels.test.js
+++ b/server/lib/mediaModels.test.js
@@ -1254,6 +1254,16 @@ describe('video bucket selection is an MLX/CUDA axis, not an OS one', () => {
     return { ids: getVideoModels().map((m) => m.id), defaultId: getDefaultVideoModelId() };
   };
 
+  it('routes Linux’s shipped default through the CUDA helper runtime', async () => {
+    asPlatform('linux');
+    const { getDefaultVideoModelId, getVideoModels } = await import('./mediaModels.js');
+    const { routesToWindowsHelper } = await import('../services/videoGen/runtimes.js');
+    const model = getVideoModels().find((entry) => entry.id === getDefaultVideoModelId());
+
+    expect(model).toMatchObject({ id: 'ltx_video', runtime: 'cuda_video' });
+    expect(routesToWindowsHelper(model)).toBe(true);
+  });
+
   for (const [shape, registry] of [['canonical mlx/cuda keys', CANONICAL], ['legacy macos/windows keys', LEGACY]]) {
     describe(shape, () => {
       it('serves the MLX list on darwin', async () => {

--- a/server/lib/pythonSetup.js
+++ b/server/lib/pythonSetup.js
@@ -20,7 +20,7 @@ export const REQUIRED_PACKAGES = IS_DARWIN
   ? ['mflux', 'mlx', 'mlx_vlm', 'mlx_video', 'transformers', 'safetensors', 'huggingface_hub', 'numpy', 'cv2', 'tqdm']
   : IS_WIN
     ? ['transformers', 'safetensors', 'huggingface_hub', 'numpy', 'cv2', 'tqdm', 'torch', 'diffusers']
-    : ['mflux', 'transformers', 'safetensors', 'huggingface_hub', 'numpy', 'cv2', 'tqdm'];
+    : ['mflux', 'transformers', 'safetensors', 'huggingface_hub', 'numpy', 'cv2', 'tqdm', 'torch', 'diffusers'];
 
 // Some package identifiers in REQUIRED_PACKAGES need to be probed via a
 // deeper submodule import to distinguish two PyPI packages that publish the

--- a/server/lib/pythonSetup.test.js
+++ b/server/lib/pythonSetup.test.js
@@ -97,6 +97,16 @@ const resetState = () => {
   mockState.uvPythonDirs = null;
 };
 
+describe('REQUIRED_PACKAGES', () => {
+  beforeEach(resetState);
+
+  it('includes the diffusers CUDA stack on Linux', async () => {
+    mockState.platform = 'linux';
+    const { REQUIRED_PACKAGES } = await loadModule();
+    expect(REQUIRED_PACKAGES).toEqual(expect.arrayContaining(['torch', 'diffusers']));
+  });
+});
+
 describe('HOST_ARCH', () => {
   beforeEach(resetState);
 

--- a/server/lib/runners.js
+++ b/server/lib/runners.js
@@ -85,7 +85,7 @@ const QUANTIZED_LTX_RE = /(?:^|[-_/\s])q(?:4|8)(?![0-9])/i;
 // scripts/generate_av_lora.py drives generate_av and merges the LoRA deltas into
 // the transformer weights before generation. Scoped to NON-quantized (bf16)
 // LTX-2.x models for now: the quantized q4/q8 variants need a separate
-// dequantize→merge→requantize validation pass. The Windows LTX-Video 0.9.5
+// dequantize→merge→requantize validation pass. The CUDA LTX-Video 0.9.5
 // model ("ltx_video" / "LTX-Video 0.9.5") is excluded — it has no "ltx-2"
 // marker and runs through generate_win.py, not generate_av.
 export const isMlxVideoLtxLoraCapable = (model) => {

--- a/server/lib/videoDisclosure.js
+++ b/server/lib/videoDisclosure.js
@@ -67,6 +67,7 @@ const RUNTIME_LICENSE = {
   },
   // The diffusers CUDA path executes no vendored source — the license that
   // governs the inference code is diffusers' own.
+  cuda_video: { name: 'Apache-2.0', url: 'https://github.com/huggingface/diffusers/blob/main/LICENSE' },
   minimax_h3_cuda: { name: 'Apache-2.0', url: 'https://github.com/huggingface/diffusers/blob/main/LICENSE' },
   hunyuan: {
     name: 'Tencent Hunyuan Community License',
@@ -270,13 +271,12 @@ export const VIDEO_MODEL_DISCLOSURES = Object.freeze({
       reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     },
   },
-  // Windows-only legacy entry. It carries no `repo` (the mlx_video CLI resolves
-  // the weights itself), so there is no model card to point at and no weights
-  // license we can attribute from a primary source — both stay Unknown.
+  // Legacy CUDA entry. It carries no `repo` because its diffusers helper
+  // resolves LTX-Video 0.9.5 directly, so its weights license stays Unknown.
   ltx_video: {
     shippedRepo: null,
     disclosure: {
-      runtimeLicense: RUNTIME_LICENSE.mlx_video,
+      runtimeLicense: RUNTIME_LICENSE.cuda_video,
       reviewedAt: VIDEO_DISCLOSURE_REVIEWED_AT,
     },
   },

--- a/server/lib/videoModeProfiles.js
+++ b/server/lib/videoModeProfiles.js
@@ -55,6 +55,7 @@ export const VIDEO_BASE_MODES = Object.freeze(['text', 'image', 'fflf', 'extend'
 const MINIMAX_H3_MODE_SET = Object.freeze(['text', 'image', 'fflf']);
 
 export const VIDEO_RUNTIME_MODES = Object.freeze({
+  cuda_video: Object.freeze(['text', 'image']),
   mlx_video: Object.freeze(['text', 'image', 'fflf', 'extend']),
   ltx2: Object.freeze(['text', 'image', 'fflf', 'extend']),
   ltx25: Object.freeze(['text', 'image', 'fflf', 'extend']),

--- a/server/services/videoGen/local.js
+++ b/server/services/videoGen/local.js
@@ -921,7 +921,7 @@ const buildArgs = ({ pythonPath, modelId, model, wanModelPath, wanRequiredWeight
   if (hasLoras && (!videoLoraFamily(model) || usesWindowsHelper)) {
     throw usesWindowsHelper
       ? new ServerError(
-        `LoRA fusion runs through the macOS-only mlx_video path; model "${modelId}" can't fuse LoRAs on the Windows LTX-Video helper.`,
+        `LoRA fusion runs through the macOS-only mlx_video path; model "${modelId}" can't fuse LoRAs on the CUDA LTX-Video helper.`,
         { status: 400, code: 'LORAS_REQUIRE_LTX2' },
       )
       : videoLoraUnsupportedError(model, modelId);
@@ -950,8 +950,8 @@ const buildArgs = ({ pythonPath, modelId, model, wanModelPath, wanRequiredWeight
       { status: 400, code: 'A2V_REQUIRES_LTX2' },
     );
   }
-  // The site the predicate is named for: every BYOV runtime has declined above,
-  // so what's left on win32 is the legacy LTX-Video 0.9.5 diffusers wrapper.
+  // Every BYOV runtime has declined above; the remaining declared CUDA runtime
+  // is the legacy LTX-Video 0.9.5 diffusers wrapper.
   if (routesToWindowsHelper(model)) {
     const scriptPath = join(PATHS.root, 'scripts', 'generate_win.py');
     const args = [scriptPath, '--model', modelId, '--prompt', prompt, '--height', String(height), '--width', String(width), '--num-frames', String(numFrames), '--fps', String(fps), '--steps', String(steps), '--guidance', String(guidance), '--seed', String(seed), '--output', outputPath];
@@ -1182,7 +1182,7 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
     throw new ServerError('Python path not configured — set it in Settings > Image Gen', { status: 400, code: 'VIDEO_GEN_NOT_CONFIGURED' });
   }
   // Every runner resolves its weights from a HuggingFace repo id EXCEPT the
-  // legacy Windows helper, which hardcodes Lightricks/LTX-Video. A user-edited
+  // legacy CUDA helper, which hardcodes Lightricks/LTX-Video. A user-edited
   // registry entry missing `repo` would otherwise pass `undefined` into spawn
   // args. Keyed on the runner rather than the platform, so a Windows BYOV
   // runtime — which does need its repo — is still held to it here.
@@ -1294,9 +1294,9 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
   //  - A model that routes to generate_win.py takes --last-image only so the
   //    script can log status; the LTX-Video 0.9.5 pipeline reads --image
   //    alone, so it never opens the last-frame file. That gate keys on the
-  //    RUNNER, not on the platform (see routesToWindowsHelper): Windows also
-  //    has a BYOV runtime, MiniMax H3 CUDA, whose helper genuinely anchors the
-  //    last frame, and a bare platform check would hand it an unresized frame.
+  //    RUNNER, not on the platform (see routesToWindowsHelper): both Windows
+  //    and Linux have BYOV runtimes whose helper genuinely anchors the last
+  //    frame, and a bare platform check would hand them an unresized frame.
   const lastImageWillBeUsed = !!lastImagePath && !routesToWindowsHelper(model) && mode === 'fflf'
     && (modelAnchorsLastFrame(model) || !sourceImagePath);
   // A non-null `keyframes` that ISN'T a length-≥2 array is malformed —

--- a/server/services/videoGen/runtimes.js
+++ b/server/services/videoGen/runtimes.js
@@ -248,11 +248,13 @@ export const BYOV_VIDEO_RUNTIMES = Object.freeze(new Set(Object.keys(BYOV_RUNTIM
 export const runtimeIsCacheOnly = (runtime) => BYOV_RUNTIME_INFO[runtime]?.cacheOnly === true;
 export const runtimeNeedsProcessGroupKill = (runtime) => BYOV_RUNTIME_INFO[runtime]?.killProcessGroup === true;
 
-// Does this model render through the legacy Windows helper, `generate_win.py`?
-// That script is the fallback `buildArgs` reaches only after every BYOV runtime
-// has declined, so the answer is "on win32, and not a BYOV runtime" — NOT the
-// bare `process.platform === 'win32'` this used to be spelled as at three
-// separate sites in local.js.
+// Does this model render through the legacy CUDA helper, `generate_win.py`?
+// Despite its historical name, the diffusers script is portable CUDA Python and
+// runs on Linux as well as Windows. Windows keeps its legacy fallback for any
+// non-BYOV model; Linux reaches it only for an entry that explicitly declares
+// `cuda_video`, so a Linux custom `mlx_video` entry cannot silently ignore its
+// own repo. This replaces the bare win32 predicate that used to be spelled at
+// three separate sites in local.js.
 //
 // The distinction became load-bearing the moment Windows gained a BYOV runtime
 // (MiniMax H3 CUDA): `generate_win.py` hardcodes its repo and reads only
@@ -260,8 +262,11 @@ export const runtimeNeedsProcessGroupKill = (runtime) => BYOV_RUNTIME_INFO[runti
 // that ONE script — it takes no repo id, and it never opens the last frame.
 // Applied to an H3 CUDA render those become wrong answers: it does require a
 // pinned repo, and it does anchor both keyframes.
-export const routesToWindowsHelper = (model) => process.platform === 'win32'
-  && !BYOV_VIDEO_RUNTIMES.has(model?.runtime);
+export const routesToWindowsHelper = (model) => (
+  process.platform === 'win32'
+    ? !BYOV_VIDEO_RUNTIMES.has(model?.runtime)
+    : process.platform !== 'darwin' && model?.runtime === 'cuda_video'
+);
 
 // Runtimes whose FFLF *last* frame is a real conditioning anchor rather than an
 // advisory hint: ltx2 runs a true keyframe-interpolation pipeline, and

--- a/server/services/videoGen/runtimes.test.js
+++ b/server/services/videoGen/runtimes.test.js
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { pinPlatform } from '../../lib/testHelper.js';
 
 const runtimeMocks = vi.hoisted(() => ({
   existsSync: vi.fn(() => true),
@@ -23,6 +24,7 @@ import {
   byovRuntimeLoraCapable, invalidateByovLoraCapabilityCache, invalidateByovReadyCache,
   isByovRuntimeReady, isPinnedSourceStatusClean, modelAnchorsLastFrame,
   resolveByovRuntimeLoraCapable, runtimeIsCacheOnly, runtimeNeedsProcessGroupKill,
+  routesToWindowsHelper,
 } from './runtimes.js';
 
 const REVISION = 'fcd9e9b79a1d6018d91ac477c0968de1fa067e49';
@@ -167,6 +169,36 @@ describe('modelAnchorsLastFrame', () => {
   it('treats a missing model or runtime as not anchored', () => {
     expect(modelAnchorsLastFrame(null)).toBe(false);
     expect(modelAnchorsLastFrame({})).toBe(false);
+  });
+});
+
+describe('routesToWindowsHelper', () => {
+  it.each(['win32', 'linux'])('routes legacy CUDA video through the helper on %s', (platform) => {
+    const restorePlatform = pinPlatform(platform);
+    try {
+      expect(routesToWindowsHelper({ runtime: 'cuda_video' })).toBe(true);
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it('keeps macOS and BYOV runtimes out of the legacy helper', () => {
+    const restorePlatform = pinPlatform('darwin');
+    try {
+      expect(routesToWindowsHelper({ runtime: 'cuda_video' })).toBe(false);
+    } finally {
+      restorePlatform();
+    }
+    expect(routesToWindowsHelper({ runtime: 'minimax_h3_cuda' })).toBe(false);
+  });
+
+  it('does not send a Linux custom MLX entry through the fixed-repo helper', () => {
+    const restorePlatform = pinPlatform('linux');
+    try {
+      expect(routesToWindowsHelper({ runtime: 'mlx_video', repo: 'example-org/custom-video' })).toBe(false);
+    } finally {
+      restorePlatform();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

- Classify the CUDA-bucket LTX-Video default as a CUDA runtime and route it through the compatible helper on Linux and Windows.
- Upgrade untouched persisted registries and constrain the helper to its supported video modes.
- Add Linux default-routing and migration regression coverage.

## Test plan

- `cd server && npm test -- --run lib/mediaModels.test.js lib/videoModeProfiles.test.js services/videoGen/runtimes.test.js ../scripts/migrations/273-ltx-video-cuda-runtime.test.js`

Closes #4362
