### PR TITLE
feat: add system health refresh controls

### DIFF
--- a/client/src/components/SystemHealthWidget.jsx
+++ b/client/src/components/SystemHealthWidget.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, memo, useMemo } from 'react';
+import { useState, memo, useMemo } from 'react';
 import { Link } from 'react-router';
 import {
   Activity,
@@ -11,28 +11,26 @@ import {
   CheckCircle,
   XCircle,
   Clock,
-  Zap
+  Zap,
+  RefreshCw
 } from 'lucide-react';
-import * as api from '../services/api';
 import { MicroGlyph } from './micrographics';
 
 /**
  * SystemHealthWidget - Compact system health overview for the Dashboard
  * Shows server uptime, memory/CPU usage, process status, and warnings
  */
-const SystemHealthWidget = memo(function SystemHealthWidget() {
-  const [health, setHealth] = useState(null);
-  const [loading, setLoading] = useState(true);
+const SystemHealthWidget = memo(function SystemHealthWidget({ dashboardState }) {
+  const health = dashboardState?.health;
+  const refetchHealth = dashboardState?.refetchHealth;
+  const [refreshing, setRefreshing] = useState(false);
 
-  useEffect(() => {
-    const loadData = async () => {
-      const data = await api.getSystemHealth({ silent: true }).catch(() => null);
-      setHealth(data);
-      setLoading(false);
-    };
-
-    loadData();
-  }, []);
+  const handleRefresh = async () => {
+    if (!refetchHealth || refreshing) return;
+    setRefreshing(true);
+    await refetchHealth();
+    setRefreshing(false);
+  };
 
   // Decorative chrome that reflects real state — top row reads as a HUD
   // readout (memory/cpu/proc/apps/disk), rows below fade so the eye
@@ -61,11 +59,6 @@ const SystemHealthWidget = memo(function SystemHealthWidget() {
     }
     return cells;
   }, [memPct, cpuPct, diskPct, procOnline, procTotal, appOnline, appTotal]);
-
-  // Don't render while loading
-  if (loading) {
-    return null;
-  }
 
   // Don't render if no data
   if (!health) {
@@ -133,6 +126,16 @@ const SystemHealthWidget = memo(function SystemHealthWidget() {
           >
             <MicroGlyph variant="matrix" size={28} intensity={matrixIntensity} />
           </span>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={!refetchHealth || refreshing}
+            className="inline-flex min-h-[40px] min-w-[40px] items-center justify-center rounded text-gray-400 transition-colors hover:bg-port-border/50 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            title="Refresh system health"
+            aria-label={refreshing ? 'Refreshing system health' : 'Refresh system health'}
+          >
+            <RefreshCw size={15} className={refreshing ? 'animate-spin' : ''} aria-hidden="true" />
+          </button>
           <Link
             to="/system-health"
             className="flex items-center gap-1 text-sm text-port-accent hover:text-port-accent/80 transition-colors min-h-[40px] px-2"

--- a/client/src/components/SystemHealthWidget.test.jsx
+++ b/client/src/components/SystemHealthWidget.test.jsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+import SystemHealthWidget from './SystemHealthWidget';
+
+const HEALTH = {
+  overallHealth: 'healthy',
+  warnings: [],
+  system: {
+    uptimeFormatted: '3h 12m',
+    memory: { usagePercent: 40, usedFormatted: '12 GB', totalFormatted: '32 GB' },
+    cpu: { usagePercent: 20, cores: 8 },
+    disk: { usagePercent: 60, usedFormatted: '600 GB', totalFormatted: '1 TB' },
+  },
+  processes: { online: 3, total: 3, errored: 0, stopped: 0 },
+  apps: { online: 2, total: 2, stopped: 0, notStarted: 0, unmanaged: 0 },
+  cos: null,
+};
+
+const renderWidget = (dashboardState) => render(
+  <MemoryRouter>
+    <SystemHealthWidget dashboardState={dashboardState} />
+  </MemoryRouter>
+);
+
+describe('SystemHealthWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refreshes the displayed stats from the widget control', async () => {
+    const user = userEvent.setup();
+    let currentHealth = HEALTH;
+    const refreshedHealth = {
+      ...HEALTH,
+      system: { ...HEALTH.system, memory: { ...HEALTH.system.memory, usagePercent: 55 } },
+    };
+    const refetchHealth = vi.fn(async () => {
+      currentHealth = refreshedHealth;
+      return currentHealth;
+    });
+    const { rerender } = renderWidget({ health: currentHealth, refetchHealth });
+
+    expect(screen.getByText('40%')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Refresh system health' }));
+    expect(refetchHealth).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <MemoryRouter>
+        <SystemHealthWidget dashboardState={{ health: currentHealth, refetchHealth }} />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('55%')).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -77,11 +77,20 @@ export default function Dashboard() {
   // scroll when the user switched layouts while the add was still saving.
   const activeLayoutIdRef = useRef(null);
 
+  const refreshHealth = useCallback(async () => {
+    // Keep the last good snapshot visible when a manual refresh hits a
+    // transient failure. `undefined` is the failed-to-fetch sentinel; a real
+    // response is always an object, even when some of its collections are empty.
+    const data = await api.getSystemHealth({ silent: true }).catch(() => undefined);
+    if (data) setHealth(data);
+    return data;
+  }, []);
+
   const fetchData = useCallback(async () => {
     setDataError(null);
-    const [appsData, healthData, usageData, tribeCareData, feedsData, meatspaceLoggingData, dailyDriverData] = await Promise.all([
+    const [appsData, , usageData, tribeCareData, feedsData, meatspaceLoggingData, dailyDriverData] = await Promise.all([
       api.getApps().catch((err) => { setDataError(err.message); return []; }),
-      api.checkHealth().catch(() => null),
+      refreshHealth(),
       api.getUsage().catch(() => null),
       api.getTribeCareSummary({ silent: true }).catch(() => null),
       api.getFeedStats({ silent: true }).catch(() => null),
@@ -91,14 +100,13 @@ export default function Dashboard() {
       api.getDailyDriverState().catch(() => null),
     ]);
     setApps(appsData);
-    setHealth(healthData);
     setUsage(usageData);
     setTribeCare(tribeCareData);
     setFeeds(feedsData);
     setMeatspaceLogging(meatspaceLoggingData);
     setDailyDriver(dailyDriverData);
     setLoading(false);
-  }, []);
+  }, [refreshHealth]);
 
   useEffect(() => {
     fetchData();
@@ -193,8 +201,8 @@ export default function Dashboard() {
   }), [activeApps]);
 
   const dashboardState = useMemo(
-    () => ({ apps, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, refetch: fetchData }),
-    [apps, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, fetchData]
+    () => ({ apps, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, refetch: fetchData, refetchHealth: refreshHealth }),
+    [apps, sortedApps, activeApps, appStats, health, usage, tribeCare, feeds, meatspaceLogging, dailyDriver, fetchData, refreshHealth]
   );
 
   // Falls back to a local minimal layout only AFTER the initial fetch has

--- a/client/src/pages/SystemHealthPage.jsx
+++ b/client/src/pages/SystemHealthPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { Link } from 'react-router';
-import { Activity, AlertTriangle, CheckCircle, XCircle, HardDrive, Cpu, Database, ServerCog, Zap } from 'lucide-react';
+import { Activity, AlertTriangle, CheckCircle, XCircle, HardDrive, Cpu, Database, ServerCog, Zap, RefreshCw } from 'lucide-react';
 import * as api from '../services/api';
 import toast from '../components/ui/Toast';
 import PageSkeleton from '../components/ui/PageSkeleton';
@@ -49,6 +49,7 @@ function barTone(pct, warn, critical) {
 export default function SystemHealthPage() {
   const [draft, setDraft] = useState(null);
   const [saving, setSaving] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
   // Tracks whether the user has acquired an editable draft. Cleared after a
   // successful save so the next refetch re-seeds with the persisted thresholds.
   const draftSeededRef = useRef(false);
@@ -57,6 +58,13 @@ export default function SystemHealthPage() {
     () => api.getSystemHealth({ silent: true }),
     15_000,
   );
+
+  const handleRefresh = async () => {
+    if (refreshing) return;
+    setRefreshing(true);
+    await refetch();
+    setRefreshing(false);
+  };
 
   // Seed the editable draft from server state on first load and after each save.
   useEffect(() => {
@@ -77,7 +85,7 @@ export default function SystemHealthPage() {
     if (result) {
       toast.success('Thresholds saved');
       draftSeededRef.current = false;
-      refetch();
+      await handleRefresh();
     }
   };
 
@@ -120,16 +128,29 @@ export default function SystemHealthPage() {
 
   return (
     <div className="max-w-5xl mx-auto space-y-4">
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h2 className="text-xl font-bold text-white flex items-center gap-2">
             <ServerCog size={20} />
             System Health
           </h2>
-          <div className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border border-current/20 ${style.color} ${style.bg}`}>
-            <StatusIcon size={16} />
-            <span className="font-semibold">{style.label}</span>
-            <span className="text-gray-500">·</span>
-            <span className="text-gray-400 text-sm">{health.system.uptimeFormatted}</span>
+          <div className="flex flex-wrap items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={handleRefresh}
+              disabled={refreshing}
+              className="inline-flex min-h-[40px] items-center gap-1.5 rounded-lg border border-port-border bg-port-card px-3 py-1.5 text-sm text-gray-300 transition-colors hover:border-gray-600 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+              title="Refresh system health"
+              aria-label={refreshing ? 'Refreshing system health' : 'Refresh system health'}
+            >
+              <RefreshCw size={14} className={refreshing ? 'animate-spin' : ''} aria-hidden="true" />
+              {refreshing ? 'Refreshing…' : 'Refresh'}
+            </button>
+            <div className={`flex items-center gap-2 px-3 py-1.5 rounded-lg border border-current/20 ${style.color} ${style.bg}`}>
+              <StatusIcon size={16} />
+              <span className="font-semibold">{style.label}</span>
+              <span className="text-gray-500">·</span>
+              <span className="text-gray-400 text-sm">{health.system.uptimeFormatted}</span>
+            </div>
           </div>
         </div>
 

--- a/client/src/pages/SystemHealthPage.test.jsx
+++ b/client/src/pages/SystemHealthPage.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 
 const HEALTH = {
@@ -85,5 +86,22 @@ describe('SystemHealthPage remediation links', () => {
     const nav = await screen.findByRole('navigation', { name: 'System drill-downs' });
     const cards = screen.getByText('Memory').closest('section');
     expect(nav.compareDocumentPosition(cards) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('refreshes the displayed stats from the page control', async () => {
+    const user = userEvent.setup();
+    api.getSystemHealth
+      .mockResolvedValueOnce(HEALTH)
+      .mockResolvedValueOnce({
+        ...HEALTH,
+        system: { ...HEALTH.system, memory: { ...HEALTH.system.memory, usagePercent: 55 } },
+      });
+    renderPage();
+
+    await screen.findByText('40%');
+    await user.click(screen.getByRole('button', { name: 'Refresh system health' }));
+
+    await waitFor(() => expect(screen.getByText('55%')).toBeInTheDocument());
+    expect(api.getSystemHealth).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary

- Add manual refresh controls to the dashboard System Health widget and System Health page.
- Share the dashboard health-details snapshot with the widget and preserve the last good snapshot after transient refresh failures.

## Test plan

- `cd client && npm test`
- `cd client && npm run lint`
- `cd client && npm run build`