### PR TITLE
fix: persist calendar event selection in URL (#4382)

### DIFF
--- a/.changelog/next/fixed-issue-4382.md
+++ b/.changelog/next/fixed-issue-4382.md
@@ -1,0 +1,1 @@
+- Calendar event drawers now reopen from shareable URLs and survive refreshes.

--- a/client/src/components/calendar/AgendaTab.jsx
+++ b/client/src/components/calendar/AgendaTab.jsx
@@ -6,6 +6,7 @@ import socket from '../../services/socket';
 import EventDetail from './EventDetail';
 import { formatTimeOfDay as formatTime, formatWeekdayDate } from '../../utils/formatters';
 import BrailleSpinner from '../BrailleSpinner';
+import useUrlParams from '../../hooks/useUrlParams';
 
 const RSVP_STYLES = {
   accepted: 'bg-port-success/20 text-port-success',
@@ -45,7 +46,7 @@ export default function AgendaTab({ accounts }) {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState('');
   const [accountFilter, setAccountFilter] = useState('');
-  const [selectedEvent, setSelectedEvent] = useState(null);
+  const [searchParams, updateParams] = useUrlParams();
   const [syncing, setSyncing] = useState(false);
 
   const fetchEvents = useCallback(async () => {
@@ -80,6 +81,8 @@ export default function AgendaTab({ accounts }) {
   };
 
   const grouped = groupEventsByDay(events);
+  const selectedEventKey = searchParams.get('event');
+  const selectedEvent = events.find((event) => `${event.accountId}:${event.id}` === selectedEventKey) || null;
 
   return (
     <div className="space-y-4">
@@ -140,7 +143,7 @@ export default function AgendaTab({ accounts }) {
                 {group.events.map((event) => (
                   <button
                     key={`${event.accountId}-${event.id}`}
-                    onClick={() => setSelectedEvent(event)}
+                    onClick={() => updateParams({ event: `${event.accountId}:${event.id}` })}
                     className="w-full text-left flex items-center gap-3 p-3 bg-port-card rounded-lg border border-port-border hover:border-port-accent/50 transition-colors"
                   >
                     <div className="flex-1 min-w-0">
@@ -188,7 +191,7 @@ export default function AgendaTab({ accounts }) {
 
       {/* Event detail slide-out */}
       {selectedEvent && (
-        <EventDetail event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+        <EventDetail event={selectedEvent} onClose={() => updateParams({ event: null })} />
       )}
     </div>
   );

--- a/client/src/components/calendar/DayView.jsx
+++ b/client/src/components/calendar/DayView.jsx
@@ -7,6 +7,7 @@ import ChronotypeOverlay from './ChronotypeOverlay';
 import { buildSubcalendarColorMap } from './calendarUtils';
 import { formatDateFull } from '../../utils/formatters';
 import BrailleSpinner from '../BrailleSpinner';
+import useUrlParams from '../../hooks/useUrlParams';
 
 const START_HOUR = 6;
 const END_HOUR = 23;
@@ -105,7 +106,7 @@ export default function DayView({ accounts }) {
   });
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [selectedEvent, setSelectedEvent] = useState(null);
+  const [searchParams, updateParams] = useUrlParams();
 
   const fetchEvents = useCallback(async () => {
     const startDate = date.toISOString();
@@ -141,6 +142,8 @@ export default function DayView({ accounts }) {
   const timedEvents = useMemo(() => events.filter(e => !e.isAllDay), [events]);
   const layout = useMemo(() => layoutEvents(timedEvents), [timedEvents]);
   const colorMap = useMemo(() => buildSubcalendarColorMap(accounts), [accounts]);
+  const selectedEventKey = searchParams.get('event');
+  const selectedEvent = events.find((event) => `${event.accountId}:${event.id}` === selectedEventKey) || null;
 
   // Current time indicator — update every 60s so the red line moves
   const [now, setNow] = useState(() => new Date());
@@ -185,7 +188,7 @@ export default function DayView({ accounts }) {
                 return (
                   <button
                     key={`${event.accountId}-${event.id}`}
-                    onClick={() => setSelectedEvent(event)}
+                    onClick={() => updateParams({ event: `${event.accountId}:${event.id}` })}
                     className="w-full text-left px-3 py-2 rounded text-sm transition-colors hover:brightness-125"
                     style={{
                       backgroundColor: adColor ? `${adColor}20` : 'rgb(59 130 246 / 0.1)',
@@ -235,7 +238,7 @@ export default function DayView({ accounts }) {
                 return (
                   <button
                     key={key}
-                    onClick={() => setSelectedEvent(event)}
+                    onClick={() => updateParams({ event: `${event.accountId}:${event.id}` })}
                     className={`absolute px-1.5 py-0.5 border-l-2 rounded text-left overflow-hidden transition-colors ${eventColor ? 'hover:brightness-125' : 'hover:bg-port-accent/30'}`}
                     style={{
                       top,
@@ -269,7 +272,7 @@ export default function DayView({ accounts }) {
         </>
       )}
 
-      {selectedEvent && <EventDetail event={selectedEvent} onClose={() => setSelectedEvent(null)} />}
+      {selectedEvent && <EventDetail event={selectedEvent} onClose={() => updateParams({ event: null })} />}
     </div>
   );
 }

--- a/client/src/components/calendar/MonthView.jsx
+++ b/client/src/components/calendar/MonthView.jsx
@@ -6,6 +6,7 @@ import EventDetail from './EventDetail';
 import { buildSubcalendarColorMap } from './calendarUtils';
 import BrailleSpinner from '../BrailleSpinner';
 import { formatMonthYear, formatTimeOfDay } from '../../utils/formatters';
+import useUrlParams from '../../hooks/useUrlParams';
 
 function getMonthGrid(year, month) {
   const firstDay = new Date(year, month, 1);
@@ -39,7 +40,7 @@ export default function MonthView({ accounts }) {
   const [month, setMonth] = useState(now.getMonth());
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [selectedEvent, setSelectedEvent] = useState(null);
+  const [searchParams, updateParams] = useUrlParams();
 
   const cells = getMonthGrid(year, month);
   const monthLabel = formatMonthYear(new Date(year, month));
@@ -85,6 +86,8 @@ export default function MonthView({ accounts }) {
   }
 
   const colorMap = useMemo(() => buildSubcalendarColorMap(accounts), [accounts]);
+  const selectedEventKey = searchParams.get('event');
+  const selectedEvent = events.find((event) => `${event.accountId}:${event.id}` === selectedEventKey) || null;
   const todayStr = now.toDateString();
 
   return (
@@ -146,7 +149,7 @@ export default function MonthView({ accounts }) {
                       return (
                         <button
                           key={`${event.accountId}-${event.id}`}
-                          onClick={() => setSelectedEvent(event)}
+                          onClick={() => updateParams({ event: `${event.accountId}:${event.id}` })}
                           className="w-full text-left px-1 py-0.5 rounded text-[10px] truncate transition-colors hover:brightness-125"
                           style={{
                             backgroundColor: evColor ? `${evColor}20` : 'rgb(59 130 246 / 0.15)',
@@ -173,7 +176,7 @@ export default function MonthView({ accounts }) {
         </div>
       )}
 
-      {selectedEvent && <EventDetail event={selectedEvent} onClose={() => setSelectedEvent(null)} />}
+      {selectedEvent && <EventDetail event={selectedEvent} onClose={() => updateParams({ event: null })} />}
     </div>
   );
 }

--- a/client/src/components/calendar/WeekView.jsx
+++ b/client/src/components/calendar/WeekView.jsx
@@ -7,6 +7,7 @@ import ChronotypeOverlay from './ChronotypeOverlay';
 import { buildSubcalendarColorMap } from './calendarUtils';
 import BrailleSpinner from '../BrailleSpinner';
 import { formatMonthDay, formatWeekdayShort, formatDateShort } from '../../utils/formatters';
+import useUrlParams from '../../hooks/useUrlParams';
 
 const START_HOUR = 6;
 const END_HOUR = 23;
@@ -112,7 +113,7 @@ export default function WeekView({ accounts }) {
   const [weekStart, setWeekStart] = useState(() => getWeekStart(new Date()));
   const [events, setEvents] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [selectedEvent, setSelectedEvent] = useState(null);
+  const [searchParams, updateParams] = useUrlParams();
 
   const weekDays = getWeekDays(weekStart);
   const weekEnd = new Date(weekStart);
@@ -151,6 +152,8 @@ export default function WeekView({ accounts }) {
   };
 
   const colorMap = useMemo(() => buildSubcalendarColorMap(accounts), [accounts]);
+  const selectedEventKey = searchParams.get('event');
+  const selectedEvent = events.find((event) => `${event.accountId}:${event.id}` === selectedEventKey) || null;
 
   // Group events by day
   const eventsByDay = useMemo(() => weekDays.map(day => {
@@ -230,7 +233,7 @@ export default function WeekView({ accounts }) {
                     return (
                       <button
                         key={eventKey(event)}
-                        onClick={() => setSelectedEvent(event)}
+                        onClick={() => updateParams({ event: `${event.accountId}:${event.id}` })}
                         className="w-full text-left px-1 py-0.5 rounded text-[10px] truncate transition-colors hover:brightness-125"
                         style={{
                           backgroundColor: adColor ? `${adColor}20` : 'rgb(59 130 246 / 0.15)',
@@ -289,7 +292,7 @@ export default function WeekView({ accounts }) {
                       return (
                         <button
                           key={key}
-                          onClick={() => setSelectedEvent(event)}
+                        onClick={() => updateParams({ event: `${event.accountId}:${event.id}` })}
                           className={`absolute px-0.5 py-0.5 border-l-2 rounded text-left overflow-hidden transition-colors ${evColor ? 'hover:brightness-125' : 'hover:bg-port-accent/30'}`}
                           style={{
                             top,
@@ -320,7 +323,7 @@ export default function WeekView({ accounts }) {
         </div>
       )}
 
-      {selectedEvent && <EventDetail event={selectedEvent} onClose={() => setSelectedEvent(null)} />}
+      {selectedEvent && <EventDetail event={selectedEvent} onClose={() => updateParams({ event: null })} />}
     </div>
   );
 }

--- a/client/src/pages/Calendar.jsx
+++ b/client/src/pages/Calendar.jsx
@@ -6,6 +6,7 @@ import PageSkeleton from '../components/ui/PageSkeleton';
 import PageHeader from '../components/PageHeader';
 import TabPills from '../components/ui/TabPills';
 import { useValidTab } from '../hooks/useValidTab';
+import useUrlParams from '../hooks/useUrlParams';
 
 import AgendaTab from '../components/calendar/AgendaTab';
 import DayView from '../components/calendar/DayView';
@@ -32,6 +33,7 @@ export const TABS = [
 export default function Calendar() {
   const navigate = useNavigate();
   const activeTab = useValidTab(TABS, 'agenda');
+  const [searchParams] = useUrlParams();
   const [accounts, setAccounts] = useState([]);
   const [loading, setLoading] = useState(true);
 
@@ -46,7 +48,8 @@ export default function Calendar() {
   }, [fetchAccounts]);
 
   const handleTabChange = (tabId) => {
-    navigate(`/calendar/${tabId}`);
+    const query = searchParams.toString();
+    navigate(`/calendar/${tabId}${query ? `?${query}` : ''}`);
   };
 
   const renderTabContent = () => {


### PR DESCRIPTION
## Summary
- Persist calendar event selection in the `event` query parameter using the account and event IDs.
- Restore the EventDetail drawer from the URL across agenda, day, week, and month views.
- Preserve the selection query parameter when switching calendar tabs and clear it when closing the drawer.

## Test plan
- `cd client && npm test`
- `cd client && npm run lint`

Closes #4382
