### PR TITLE
fix: persist inbox message selection in URL

### DIFF
--- a/.changelog/next/fixed-issue-4381.md
+++ b/.changelog/next/fixed-issue-4381.md
@@ -1,0 +1,1 @@
+- Inbox message detail selections persist in shareable URLs.

--- a/client/src/components/messages/InboxTab.jsx
+++ b/client/src/components/messages/InboxTab.jsx
@@ -173,7 +173,7 @@ export default function InboxTab({ accounts }) {
   const [search, setSearch] = useState('');
   const [debouncedSearch, setDebouncedSearch] = useState('');
   const [selectedAccount, setSelectedAccount] = useState('');
-  const [selectedMessage, setSelectedMessage] = useState(null);
+  const [loadedMessage, setLoadedMessage] = useState(null);
   const [evaluating, setEvaluating] = useState(false);
   const [syncing, setSyncing] = useState(false);
   // accountId -> ISO timestamp for syncs that succeeded in this session, so the
@@ -187,6 +187,8 @@ export default function InboxTab({ accounts }) {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const rawTriage = searchParams.get('triage');
+  const messageId = searchParams.get('message');
+  const messageAccountId = searchParams.get('account');
   const VALID_TRIAGE_KEYS = TRIAGE_TABS.map(t => t.key);
   const activeTab = VALID_TRIAGE_KEYS.includes(rawTriage) ? rawTriage : 'all';
   const setActiveTab = (key) => {
@@ -195,6 +197,20 @@ export default function InboxTab({ accounts }) {
     else p.set('triage', key);
     setSearchParams(p, { replace: true });
   };
+
+  const openMessage = (message) => {
+    const p = new URLSearchParams(searchParams);
+    p.set('message', message.id);
+    p.set('account', message.accountId);
+    setSearchParams(p);
+  };
+
+  const closeMessage = useCallback(() => {
+    const p = new URLSearchParams(searchParams);
+    p.delete('message');
+    p.delete('account');
+    setSearchParams(p, { replace: true });
+  }, [searchParams, setSearchParams]);
 
   useEffect(() => {
     clearTimeout(debounceRef.current);
@@ -215,6 +231,43 @@ export default function InboxTab({ accounts }) {
   useEffect(() => {
     fetchMessages();
   }, [fetchMessages]);
+
+  // The URL is the source of truth for the open message. Resolve it from the
+  // current list when possible, then fetch it directly for a filtered-out or
+  // not-yet-loaded message so a copied URL still opens on a fresh load.
+  useEffect(() => {
+    if (!messageId) {
+      setLoadedMessage(null);
+      return undefined;
+    }
+
+    const listed = messages.find(message => (
+      String(message.id) === messageId
+      && (!messageAccountId || String(message.accountId) === messageAccountId)
+    ));
+    if (listed) {
+      setLoadedMessage(listed);
+      return undefined;
+    }
+    if (loadedMessage?.id === messageId && String(loadedMessage.accountId) === messageAccountId) {
+      return undefined;
+    }
+    if (!messageAccountId) {
+      if (!loading) closeMessage();
+      return undefined;
+    }
+
+    let cancelled = false;
+    setLoadedMessage(null);
+    api.getMessageDetail(messageAccountId, messageId)
+      .then(message => {
+        if (!cancelled) setLoadedMessage(message);
+      })
+      .catch(() => {
+        if (!cancelled) closeMessage();
+      });
+    return () => { cancelled = true; };
+  }, [messageId, messageAccountId, messages, loading, loadedMessage, closeMessage]);
 
   // Stream messages into the list as they arrive during sync
   useEffect(() => {
@@ -363,12 +416,18 @@ export default function InboxTab({ accounts }) {
     setActiveTab('all');
   };
 
-  if (selectedMessage) {
+  const selectedMessage = loadedMessage
+    && String(loadedMessage.id) === messageId
+    && (!messageAccountId || String(loadedMessage.accountId) === messageAccountId)
+    ? loadedMessage
+    : null;
+
+  if (messageId && selectedMessage) {
     return (
       <MessageDetail
         message={selectedMessage}
         accounts={accountList}
-        onBack={() => { setSelectedMessage(null); fetchMessages(); }}
+        onBack={() => { closeMessage(); fetchMessages(); }}
       />
     );
   }
@@ -515,7 +574,7 @@ export default function InboxTab({ accounts }) {
 
               {/* Message content — clickable */}
               <button
-                onClick={() => setSelectedMessage(msg)}
+                onClick={() => openMessage(msg)}
                 className="flex-1 min-w-0 text-left"
               >
                 <div className="flex items-center gap-2">
@@ -546,10 +605,10 @@ export default function InboxTab({ accounts }) {
                   const onClick = actionKey === 'reply'
                     ? (e) => handleQuickReply(msg, e)
                     : actionKey === 'review'
-                      ? (e) => { e.stopPropagation(); setSelectedMessage(msg); }
+                      ? (e) => { e.stopPropagation(); openMessage(msg); }
                       : isActionable
                         ? (e) => handleAction(msg, actionKey, e)
-                        : (e) => { e.stopPropagation(); setSelectedMessage(msg); };
+                        : (e) => { e.stopPropagation(); openMessage(msg); };
 
                   const title = isRecommended && ev?.reason
                     ? `AI: ${cfg.label} — ${ev.reason}`
@@ -583,4 +642,3 @@ export default function InboxTab({ accounts }) {
     </div>
   );
 }
-

--- a/client/src/components/messages/InboxTab.test.jsx
+++ b/client/src/components/messages/InboxTab.test.jsx
@@ -1,13 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 
 const api = vi.hoisted(() => ({
   evaluateMessages: vi.fn(),
   executeMessageAction: vi.fn(),
   fetchFullContent: vi.fn(),
   generateMessageDraft: vi.fn(),
+  getMessageDetail: vi.fn(),
   getMessageInbox: vi.fn(),
+  getMessageThread: vi.fn(),
+  getSettings: vi.fn(),
   syncMessageAccount: vi.fn(),
 }));
 const toast = vi.hoisted(() => Object.assign(vi.fn(), {
@@ -46,9 +49,28 @@ function renderInbox(accounts, { route = '/messages/inbox' } = {}) {
   );
 }
 
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{location.pathname}{location.search}</output>;
+}
+
+function renderInboxWithLocation(accounts, { route = '/messages/inbox' } = {}) {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <LocationProbe />
+      <Routes>
+        <Route path="/messages/inbox" element={<InboxTab accounts={accounts} />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   api.getMessageInbox.mockResolvedValue({ messages: [], total: 0 });
+  api.getMessageDetail.mockResolvedValue(null);
+  api.getMessageThread.mockResolvedValue({ messages: [] });
+  api.getSettings.mockResolvedValue({});
   api.syncMessageAccount.mockResolvedValue({ newMessages: 0, pruned: 0 });
 });
 
@@ -165,5 +187,45 @@ describe('InboxTab empty state', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /open config/i }));
     expect(await screen.findByText('CONFIG SCREEN')).toBeInTheDocument();
+  });
+});
+
+describe('InboxTab message selection URL', () => {
+  const message = {
+    id: 'message-1',
+    accountId: neverSyncedAccount.id,
+    subject: 'A message to inspect',
+    bodyText: 'Message body',
+    from: { name: 'Example Sender' },
+    date: '2026-08-16T00:00:00.000Z',
+    source: 'gmail',
+    evaluation: { action: 'reply', priority: 'medium' },
+  };
+
+  it('opens a selected message while preserving triage in the URL and removes selection on back', async () => {
+    api.getMessageInbox.mockResolvedValue({ messages: [message], total: 1 });
+    renderInboxWithLocation([neverSyncedAccount], { route: '/messages/inbox?triage=reply' });
+
+    fireEvent.click(await screen.findByRole('button', { name: /a message to inspect/i }));
+    expect(await screen.findByText('Message body')).toBeInTheDocument();
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      `/messages/inbox?triage=reply&message=${message.id}&account=${message.accountId}`,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }));
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/messages/inbox?triage=reply'));
+  });
+
+  it('fetches a URL-selected message when it is missing from the current list', async () => {
+    api.getMessageDetail.mockResolvedValue(message);
+    renderInboxWithLocation([neverSyncedAccount], {
+      route: `/messages/inbox?triage=review&message=${message.id}&account=${message.accountId}`,
+    });
+
+    expect(await screen.findByText('Message body')).toBeInTheDocument();
+    expect(api.getMessageDetail).toHaveBeenCalledWith(neverSyncedAccount.id, message.id);
+    expect(screen.getByTestId('location')).toHaveTextContent(
+      `/messages/inbox?triage=review&message=${message.id}&account=${message.accountId}`,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Put inbox message selection in the URL with account and message query parameters.
- Resolve deep-linked messages from the current list or fetch their detail when filtered out.
- Preserve triage filters and clear selection parameters when closing the detail view.

Closes #4381

## Test plan
- `cd client && npm test -- --run src/components/messages/InboxTab.test.jsx`
