### PR TITLE
fix: silence expected Windows runtime warnings

### DIFF
--- a/.changelog/next/fixed-windows-runtime-audit.md
+++ b/.changelog/next/fixed-windows-runtime-audit.md
@@ -1,0 +1,2 @@
+- The login screen no longer reports its expected authentication challenge as a theme failure in the browser console.
+- Windows development startup no longer emits a Vite configuration compatibility warning.

--- a/client/src/hooks/useTheme.js
+++ b/client/src/hooks/useTheme.js
@@ -81,7 +81,9 @@ export default function useTheme() {
       .catch((err) => {
         // request() collapses an aborted fetch into a generic error, so check
         // the controller too — an unmount/StrictMode remount isn't a failure.
-        if (controller.signal.aborted || err.name === 'AbortError') return;
+        // The unauthenticated login screen also mounts ThemeProvider. Its
+        // AUTH_REQUIRED response is the expected gate, not a theme failure.
+        if (controller.signal.aborted || err.name === 'AbortError' || err.code === 'AUTH_REQUIRED') return;
         console.warn(`⚠️ Theme fetch failed, using localStorage fallback: ${err.message}`);
       });
     return () => controller.abort();

--- a/client/src/hooks/useTheme.test.jsx
+++ b/client/src/hooks/useTheme.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import useTheme from './useTheme.js';
 import { DEFAULT_THEME_ID, THEME_IDS } from '../themes/portosThemes.js';
 
@@ -16,6 +16,7 @@ afterEach(() => {
   document.documentElement.removeAttribute('style');
   document.documentElement.removeAttribute('data-port-theme');
   window.localStorage.clear();
+  window.history.replaceState({}, '', '/');
 });
 
 describe('useTheme localStorage resilience', () => {
@@ -61,5 +62,24 @@ describe('useTheme localStorage resilience', () => {
     window.localStorage.setItem('portos-theme', OTHER_THEME_ID);
     const { result } = renderHook(() => useTheme());
     expect(result.current.themeId).toBe(OTHER_THEME_ID);
+  });
+
+  it('does not warn when the login screen receives the expected auth challenge', async () => {
+    window.history.replaceState({}, '', '/login');
+    globalThis.fetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: 'Authentication required', code: 'AUTH_REQUIRED' })
+    });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    renderHook(() => useTheme());
+
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(warn).not.toHaveBeenCalled();
   });
 });

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -5,14 +5,15 @@ import { readFileSync, existsSync } from 'fs';
 import { resolve } from 'path';
 
 const ANALYZE_BUNDLE = process.env.ANALYZE === 'true';
+const CONFIG_DIR = import.meta.dirname;
 
-const rootPkg = JSON.parse(readFileSync(resolve(__dirname, '../package.json'), 'utf-8'));
+const rootPkg = JSON.parse(readFileSync(resolve(CONFIG_DIR, '../package.json'), 'utf-8'));
 
 // Dev proxy target: probe for the self-signed/LE cert under data/certs/. If the
 // server is running HTTPS, the dev proxy must target HTTPS too (or requests
 // through Vite return "socket hang up"). `secure: false` accepts the cert
 // whether it's the trusted LE one or the self-signed fallback.
-const CERT_PATH = resolve(__dirname, '..', 'data', 'certs', 'cert.pem');
+const CERT_PATH = resolve(CONFIG_DIR, '..', 'data', 'certs', 'cert.pem');
 const API_SCHEME = existsSync(CERT_PATH) ? 'https' : 'http';
 
 export default defineConfig(({ mode }) => {


### PR DESCRIPTION
## Summary

- Treat the login page's expected authentication challenge as a normal theme fallback instead of a browser-console warning.
- Use the ESM-native config directory in Vite so Windows startup no longer emits the compatibility warning.
- Add focused regression coverage and an unreleased changelog fragment.

## Validation

- `npm run lint --prefix client`
- `npm test --prefix client -- src/hooks/useTheme.test.jsx`
- `npm run build --prefix client`
- Live authenticated browser audit across 193 route variants, with all six PM2 services healthy and no new server error-log entries.

## Review

- Required local code-review gate completed with no findings.
- No external reviewer or auto-merge was requested.