### PR TITLE
fix: make system resources test portable

### DIFF
--- a/.changelog/next/fixed-system-resources-windows-ci.md
+++ b/.changelog/next/fixed-system-resources-windows-ci.md
@@ -1,0 +1,1 @@
+- System Resources strict-scan coverage now passes consistently on Windows runners.

--- a/server/services/systemResources.test.js
+++ b/server/services/systemResources.test.js
@@ -194,7 +194,7 @@ describe('system resource reporting', () => {
 
   it('surfaces strict size-scan failures instead of reporting a ready zero', async () => {
     fileUtils.dirSize.mockImplementation(async (path) => {
-      if (path === '/example/portos/node_modules') return null;
+      if (String(path).replaceAll('\\', '/') === '/example/portos/node_modules') return null;
       return path.includes('Downloads') ? 900 : 100;
     });
 


### PR DESCRIPTION
## Summary

- normalize the mocked dependency path in the System Resources strict-scan regression test
- keep the assertion platform-independent across POSIX and Windows path separators
- follow up on the Windows CI failure from #4451

## Test plan

- `server`: `npx vitest run services/systemResources.test.js` (12 tests passed)
