### PR TITLE
fix: clean up merged branches; skip untrusted Codex startup hooks

### DIFF
--- a/.changelog/next/fixed-agent-22b0b665.md
+++ b/.changelog/next/fixed-agent-22b0b665.md
@@ -1,0 +1,1 @@
+- Codex agents now safely continue past hook-review prompts instead of losing their task prompt.

--- a/server/lib/tuiHandshake.js
+++ b/server/lib/tuiHandshake.js
@@ -295,6 +295,16 @@ export const TUI_TRUST_PROMPT_PATTERN =
 export const TUI_AUTO_MODE_PROMPT_PATTERN =
   /automodeyourdefaultpermissionmode|setautomodeasmydefaultpermissionmode/i;
 
+// Codex can stop before its composer on a hook-review selector when a newly
+// configured hook has not yet been trusted. `--dangerously-bypass-approvals-and-
+// sandbox` deliberately does not answer this prompt: trusting a hook permits
+// code outside the sandbox, so unattended PortOS runs must choose Codex's
+// explicit "Continue without trusting" option instead. Without this gate the
+// normal startup paste lands in the selector and all paste retries are swallowed.
+// Match the stable heading after whitespace stripping; the exact count/plural
+// wording below it varies with the configured hooks.
+export const TUI_HOOK_REVIEW_PROMPT_PATTERN = /hooksneedreview/i;
+
 // Antigravity (agy) needs a SECOND, positive readiness signal on top of paste
 // mode. agy enables bracketed paste the moment it enters the alt screen — while
 // it is still "Signing in…", before its folder-trust gate has painted and long
@@ -343,6 +353,11 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
   // false until the 45s deadline. Arm-once, same as the gates above it.
   let needsAutoModeChoice = false;
   let autoModeAnswered = false;
+  // Like the auto-mode offer, hook-review text remains in the rolling tail
+  // after its selector closes. A terminal acknowledgement prevents a repaint
+  // from re-arming the dialog and blocking delivery forever.
+  let needsHookReview = false;
+  let hookReviewAnswered = false;
   let tail = '';
   // node-pty can split `ESC[?2004h` across reads. Keep only the trailing
   // prefix of that exact toggle so the next chunk can complete it without
@@ -360,13 +375,16 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
     // modal is still swallowing input. Cleared by ackAutoModeChoice() once the
     // spawner has answered it.
     get ready() {
-      return sawCommandRun && pasteModeOn && !needsAutoModeChoice
+      return sawCommandRun && pasteModeOn && !needsAutoModeChoice && !needsHookReview
         && (!readyTextPattern || sawReadyText);
     },
     get needsTrust() { return needsTrust; },
     get needsAutoModeChoice() { return needsAutoModeChoice; },
+    get needsHookReview() { return needsHookReview; },
     /** Spawner reports the dismissal keystrokes went out; re-arms `ready`. */
     ackAutoModeChoice() { needsAutoModeChoice = false; autoModeAnswered = true; },
+    /** Spawner selected Codex's safe "Continue without trusting" option. */
+    ackHookReview() { needsHookReview = false; hookReviewAnswered = true; },
     // rawText: un-stripped chunk (paste-mode toggles live here);
     // strippedText: ANSI-stripped chunk (the trust-gate / composer text).
     observe(rawText, strippedText) {
@@ -387,6 +405,7 @@ export function createInputReadyTracker({ readyTextPattern = null, directLaunch 
         tail = (tail + strippedText.replace(/\s+/g, '')).slice(-OBSERVE_TAIL_MAX_LEN);
         if (!needsTrust && TUI_TRUST_PROMPT_PATTERN.test(tail)) needsTrust = true;
         if (!needsAutoModeChoice && !autoModeAnswered && TUI_AUTO_MODE_PROMPT_PATTERN.test(tail)) needsAutoModeChoice = true;
+        if (!needsHookReview && !hookReviewAnswered && TUI_HOOK_REVIEW_PROMPT_PATTERN.test(tail)) needsHookReview = true;
         if (readyTextPattern && !sawReadyText && readyTextPattern.test(tail)) sawReadyText = true;
       }
     },

--- a/server/lib/tuiHandshake.test.js
+++ b/server/lib/tuiHandshake.test.js
@@ -1073,6 +1073,29 @@ describe('createInputReadyTracker', () => {
     });
   });
 
+  describe('Codex hook-review offer', () => {
+    const OFFER = 'Hooks need review\n'
+      + '1 hook is new or changed.\n'
+      + '1. Review hooks\n'
+      + '2. Trust all and continue\n'
+      + "3. Continue without trusting (hooks won't run)\n";
+
+    it('latches the selector and does not re-arm after the safe dismissal', () => {
+      const tracker = createInputReadyTracker();
+      tracker.observe(`${PASTE_OFF}${PASTE_ON}`, OFFER);
+      expect(tracker.needsHookReview).toBe(true);
+      expect(tracker.ready).toBe(false);
+
+      tracker.ackHookReview();
+      expect(tracker.needsHookReview).toBe(false);
+      expect(tracker.ready).toBe(true);
+
+      tracker.observe('', 'Codex ready'); // rolling tail still contains the offer
+      expect(tracker.needsHookReview).toBe(false);
+      expect(tracker.ready).toBe(true);
+    });
+  });
+
   it('matches a marker split across two PTY chunks (rolling tail)', () => {
     const tracker = createInputReadyTracker();
     tracker.observe('', '> Yes, I trust th');

--- a/server/lib/tuiPromptRunner.js
+++ b/server/lib/tuiPromptRunner.js
@@ -304,6 +304,7 @@ ${prompt}`;
   // doesn't need a matching flag below — ackAutoModeChoice() latches it false
   // permanently on the tracker itself (see autoModeAnswered in tuiHandshake.js).
   let trustAccepted = false;
+  let hookReviewDeclined = false;
 
   // The wrapped prompt directs the model to write its COMPLETE response to
   // `responseFilePath` and then finish. That file appearing is the model's
@@ -782,6 +783,17 @@ ${prompt}`;
       }
       const now = Date.now();
       const elapsed = now - startTime;
+      // Codex's hook-review selector precedes its composer. An unattended run
+      // must not grant hooks permission to execute outside the sandbox, so take
+      // the explicit "Continue without trusting" option before ordinary
+      // readiness/fallback delivery can paste into the selector.
+      if (inputReady.needsHookReview && !hookReviewDeclined) {
+        hookReviewDeclined = true;
+        if (dismissStartupDialog('\x1b[B\x1b[B\r', 'hook-review prompt')) {
+          inputReady.ackHookReview();
+        }
+        return;
+      }
       if (requiresInputReady) {
         if (inputReady.needsTrust && !trustAccepted) {
           trustAccepted = true;

--- a/server/lib/tuiPromptRunner.test.js
+++ b/server/lib/tuiPromptRunner.test.js
@@ -568,6 +568,38 @@ describe('executeTuiRun', () => {
       await promise;
     });
 
+    it('declines Codex hook trust and pastes only after its selector clears', async () => {
+      vi.useFakeTimers({
+        toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'],
+      });
+      const provider = { id: 'codex', type: 'tui', command: 'codex', tuiPromptDelayMs: 50 };
+      const promise = executeTuiRun({
+        runId: 'run-codex-hook-review', provider, prompt: 'return one structured response',
+        workspacePath: TEST_WORKSPACE, timeout: 60000,
+      });
+      await flushAsync();
+
+      const pty = ptyInstances[0];
+      pty.emitData(
+        'Hooks need review\n'
+        + '1 hook is new or changed.\n'
+        + '1. Review hooks\n'
+        + '2. Trust all and continue\n'
+        + "3. Continue without trusting (hooks won't run)\n",
+      );
+      await vi.advanceTimersByTimeAsync(400);
+
+      expect(pty.write).toHaveBeenCalledWith('\x1b[B\x1b[B\r');
+      expect(pty.write).not.toHaveBeenCalledWith(expect.stringContaining('\x1b[200~'));
+
+      pty.emitData('OpenAI Codex ready\n');
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(pty.write).toHaveBeenCalledWith(expect.stringContaining('\x1b[200~'));
+
+      pty.emitExit({ exitCode: 0 });
+      await promise;
+    });
+
     it('keeps non-Claude TUIs on the existing idle fallback when startup output resembles Claude trust text', async () => {
       vi.useFakeTimers({
         toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'],

--- a/server/services/agentTuiSpawning.js
+++ b/server/services/agentTuiSpawning.js
@@ -596,6 +596,7 @@ export async function spawnTuiAgent({
   });
   let trustAccepted = false;
   let autoModeDeclined = false;
+  let hookReviewDeclined = false;
   // True once shell.js actually injects the `claude` command (after its
   // round-trip readiness probe). The probe runs its OWN shell command first,
   // which toggles bracketed-paste mode and would otherwise advance the
@@ -1304,6 +1305,19 @@ export async function spawnTuiAgent({
     }
     const now = Date.now();
     const elapsed = now - startedAt;
+
+    // Codex can present a hook-review selector before its composer exists.
+    // Do not trust hooks from an unattended run: option 3 keeps them disabled
+    // for this session and lets the agent continue without executing code
+    // outside its sandbox. This must run for every TUI, not only the positive
+    // input-ready providers below — Codex currently uses the idle/deadline path.
+    if (inputReady.needsHookReview && !hookReviewDeclined) {
+      hookReviewDeclined = true;
+      shellService.writeToSession(sessionId, '\x1b[B\x1b[B\r');
+      inputReady.ackHookReview();
+      appendLine(`📟 Continued ${tuiConfig.command} without trusting startup hooks for session ${sessionId.slice(0, 8)}`);
+      return;
+    }
 
     if (requireInputReady) {
       // Auto-confirm the first-run "trust this folder?" gate (claude's and agy's

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -1051,6 +1051,34 @@ describe('spawnTuiAgent runtime', () => {
     expect(pasteCount()).toBe(1);
   });
 
+  it('codex hook-review offer: continues without trusting hooks before pasting the prompt', async () => {
+    runSpawn();
+    await flushMicrotasks();
+
+    await capturedOnData(Buffer.from(
+      'Hooks need review\n'
+      + '1 hook is new or changed.\n'
+      + '› 1. Review hooks\n'
+      + '2. Trust all and continue\n'
+      + "3. Continue without trusting (hooks won't run)\n",
+    ));
+    await flushMicrotasks();
+    await vi.advanceTimersByTimeAsync(400);
+    await flushMicrotasks();
+
+    // Two down-arrows select option 3, preserving the sandbox boundary.
+    expect(vi.mocked(shellService.writeToSession).mock.calls.map(([, data]) => data))
+      .toContain('\x1b[B\x1b[B\r');
+    expect(pasteCount()).toBe(0);
+
+    // The selector clears and Codex repaints its composer; only then can the
+    // ordinary Codex readiness path paste the task.
+    await capturedOnData(Buffer.from('OpenAI Codex ready\n'));
+    await vi.advanceTimersByTimeAsync(2000);
+    await flushMicrotasks();
+    expect(pasteCount()).toBe(1);
+  });
+
   it('tui-not-ready: claude that never shows an input prompt finalizes failure without pasting', async () => {
     let resolveComplete;
     const completeDone = new Promise((r) => { resolveComplete = r; });


### PR DESCRIPTION
## Summary
- Clean up merged branches (two passes)
- Skip untrusted Codex startup hooks

## Test plan
- CI Gate must pass before merge (required by branch ruleset)