### PR TITLE
fix: stop emitting a codex reasoning effort codex rejects

### DIFF
--- a/.changelog/next/added-codex-effort-ladder.md
+++ b/.changelog/next/added-codex-effort-ladder.md
@@ -1,0 +1,1 @@
+- Agent failures caused by a provider CLI refusing to load its own config file are now classified as `cli-config-invalid` with a config-fix suggestion, instead of escalating to an investigation task

--- a/.changelog/next/fixed-codex-effort-ladder.md
+++ b/.changelog/next/fixed-codex-effort-ladder.md
@@ -1,0 +1,1 @@
+- Codex agents no longer die at startup with "unknown variant `max`" — codex's reasoning-effort ladder stops at `xhigh`, so `max`/`ultra` now clamp instead of being emitted as a config override codex rejects while loading its config

--- a/client/src/components/cos/EffortSelect.test.jsx
+++ b/client/src/components/cos/EffortSelect.test.jsx
@@ -23,7 +23,7 @@ describe('EffortSelect', () => {
   it('offers codex its full ladder', () => {
     render(<EffortSelect provider={CODEX} value="" onChange={() => {}} />);
     expect(screen.getAllByRole('option').map(o => o.textContent))
-      .toEqual(['Default effort', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
+      .toEqual(['Default effort', 'minimal', 'low', 'medium', 'high', 'xhigh']);
   });
 
   // The server clamps an out-of-ladder effort rather than dropping it, so the

--- a/client/src/components/pipeline/AutopilotPanel.jsx
+++ b/client/src/components/pipeline/AutopilotPanel.jsx
@@ -1130,7 +1130,7 @@ export default function AutopilotPanel({ series, onSeriesUpdate, onIssuesUpdate 
                   emptyModelOption={effModel ? `Run default (${effModel})` : 'Run default model'}
                 />
                 <p className="mt-1 text-[11px] text-gray-500">
-                  Useful for experiments such as Luna/max writing with an independent Sol/xhigh critic. Exact stage pins in Prompts still take precedence.
+                  Useful for experiments such as Luna/xhigh writing with an independent Sol/medium critic. Exact stage pins in Prompts still take precedence.
                 </p>
               </div>
             ) : null}

--- a/client/src/components/pipeline/AutopilotPanel.test.jsx
+++ b/client/src/components/pipeline/AutopilotPanel.test.jsx
@@ -351,7 +351,7 @@ describe('AutopilotPanel', () => {
     ));
   });
 
-  it('can split Luna/max creation from Sol/xhigh judging for one run', async () => {
+  it('can split Luna/xhigh creation from Sol/medium judging for one run', async () => {
     getProviders.mockResolvedValue({
       activeProvider: 'codex-tui',
       providers: [{
@@ -362,21 +362,21 @@ describe('AutopilotPanel', () => {
     renderPanel({ id: 's1', targetFormat: 'comic', llm: { provider: 'codex-tui', model: 'gpt-5.6-luna' } });
     await waitFor(() => expect(getPipelineAutopilotStatus).toHaveBeenCalled());
     fireEvent.click(screen.getByRole('button', { name: /options/i }));
-    fireEvent.change(await screen.findByLabelText('Thinking effort'), { target: { value: 'max' } });
+    fireEvent.change(await screen.findByLabelText('Thinking effort'), { target: { value: 'xhigh' } });
     fireEvent.click(screen.getByLabelText(/separate model for judging/i));
     const models = screen.getAllByLabelText('Model');
     fireEvent.change(models[1], { target: { value: 'gpt-5.6-sol' } });
     const efforts = screen.getAllByLabelText('Thinking effort');
-    fireEvent.change(efforts[1], { target: { value: 'xhigh' } });
-    expect(screen.getByText(/Luna\/max writing with an independent Sol\/xhigh critic/i)).toBeInTheDocument();
+    fireEvent.change(efforts[1], { target: { value: 'medium' } });
+    expect(screen.getByText(/Luna\/xhigh writing with an independent Sol\/medium critic/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /run autopilot/i }));
     await waitFor(() => expect(startPipelineAutopilot).toHaveBeenCalledWith(
       's1',
       {
         includeVisual: true,
         fileGaps: false,
-        effortOverride: 'max',
-        judgeLlm: { modelOverride: 'gpt-5.6-sol', effortOverride: 'xhigh' },
+        effortOverride: 'xhigh',
+        judgeLlm: { modelOverride: 'gpt-5.6-sol', effortOverride: 'medium' },
       },
       { silent: true },
     ));

--- a/client/src/hooks/useReviewerModelOptions.test.jsx
+++ b/client/src/hooks/useReviewerModelOptions.test.jsx
@@ -111,7 +111,7 @@ describe('useReviewerModelOptions', () => {
     });
 
     it('leaves every other reviewer on its static ladder', async () => {
-      expect(await levelsFor('codex', 'gpt-5.6-sol')).toContain('ultra');
+      expect(await levelsFor('codex', 'gpt-5.6-sol')).toContain('xhigh');
       expect(await levelsFor('claude', 'gemini-3.1-pro')).toContain('max');
       expect(await levelsFor('copilot', null)).toBeNull();
       expect(await levelsFor('@octocat', null)).toBeNull();

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -175,9 +175,14 @@ export const filterSelectableModels = (models) =>
  * `effortLevelsForProvider` in server/lib/providerModels.js; keep in lockstep.
  * Claude Code and agy take `--effort <level>`, Codex takes
  * `-c model_reasoning_effort=<level>`.
+ *
+ * Codex's ladder stops at `xhigh`: its config enum is
+ * `none|minimal|low|medium|high|xhigh`, and `-c model_reasoning_effort=max`
+ * makes codex fail while LOADING ITS CONFIG, killing the agent at startup.
+ * `resolveCliEffort` clamps `max`/`ultra` down to `xhigh` for codex.
  */
 export const CLAUDE_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
-export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
+export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh']);
 export const ANTIGRAVITY_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
 
 /**

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -91,7 +91,12 @@ describe('resolveCliEffort (server mirror)', () => {
     ['below agy ladder takes the weakest', 'minimal', AGY, 'low'],
     ['codex-only ultra clamps on claude', 'ultra', CLAUDE, 'max'],
     ['codex-only minimal clamps on claude', 'minimal', CLAUDE, 'low'],
-    ['codex accepts its whole ladder', 'ultra', CODEX, 'ultra'],
+    ['codex accepts its whole ladder', 'minimal', CODEX, 'minimal'],
+    // codex's config enum stops at `xhigh`; `-c model_reasoning_effort=max`
+    // makes it fail while loading its config, so the picker must never show a
+    // level the run can't use.
+    ['max clamps to codex xhigh', 'max', CODEX, 'xhigh'],
+    ['ultra clamps to codex xhigh', 'ultra', CODEX, 'xhigh'],
     ['unknown value yields no flag', 'bogus', AGY, null],
     ['effort-less provider yields no flag', 'high', GROK, null],
     ['unset yields no flag', '', AGY, null],

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -224,10 +224,10 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
   it('normalizes a token-keyed map: aliases, case, and out-of-ladder levels', () => {
     expect(normalizeReviewerEfforts({
       gemini: 'HIGH',        // alias + case-folded
-      codex: 'ultra',        // in codex's ladder only
+      codex: 'xhigh',        // in codex's ladder only
       claude: 'medium',
       ollama: ' low ',       // trimmed
-    })).toEqual({ antigravity: 'high', codex: 'ultra', claude: 'medium', ollama: 'low' });
+    })).toEqual({ antigravity: 'high', codex: 'xhigh', claude: 'medium', ollama: 'low' });
   });
 
   it('DROPS rather than clamps a level the reviewer rejects — a displayed effort must be the one it runs', () => {

--- a/server/lib/providerModels.js
+++ b/server/lib/providerModels.js
@@ -71,20 +71,40 @@ export const resolveCliModel = (model) => isConfiguredDefaultModel(model) ? null
 // Reasoning-effort levels — Claude Code (`--effort <level>`), Antigravity
 // (`--effort <level>`) and Codex (`-c model_reasoning_effort=<level>`) all
 // accept a per-invocation override of how hard the model thinks. Value sets
-// verified against claude CLI v2.1.x (`--help`), codex-cli 0.144 (config enum)
-// and agy (`--help`: "Reasoning effort for the current CLI session
-// (low|medium|high)"). Mirrored in client/src/utils/providers.js — keep in sync.
+// verified against claude CLI v2.1.x (`--help`), codex-cli 0.130 (its config
+// enum, read straight off codex's own rejection message: `none`, `minimal`,
+// `low`, `medium`, `high`, `xhigh`) and agy (`--help`: "Reasoning effort for
+// the current CLI session (low|medium|high)"). Mirrored in
+// client/src/utils/providers.js — keep in sync.
+//
+// Codex does NOT accept `max`/`ultra`. Listing them here emitted
+// `-c model_reasoning_effort=max`, which codex rejects while LOADING ITS CONFIG
+// — before the prompt is ever read — so the agent died at startup with "unknown
+// variant `max`, expected one of …" and burned every retry. `resolveCliEffort`
+// clamps those levels to `xhigh` instead, which also degrades gracefully if a
+// future codex does add them.
+//
+// `none` is a real codex variant but is deliberately NOT offered: it means "do
+// not reason at all", which no PortOS effort control should be able to select.
 // ---------------------------------------------------------------------------
 
 export const CLAUDE_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
-export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra']);
+export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh']);
 export const ANTIGRAVITY_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
+
+// Effort values no CLI ladder accepts any more, kept ACCEPTED as stored/API
+// input so records saved under an older ladder still validate after an install
+// updates (see the distribution model in CLAUDE.md — installs update
+// independently). `resolveCliEffort` clamps them to a level the target CLI
+// really takes, so none of these ever reaches a CLI verbatim.
+const LEGACY_EFFORT_LEVELS = Object.freeze(['ultra']);
 
 /** Union of every accepted effort value across effort-capable CLIs, low→high. */
 export const EFFORT_LEVELS = Object.freeze([...new Set([
   ...CODEX_EFFORT_LEVELS,
   ...CLAUDE_EFFORT_LEVELS,
   ...ANTIGRAVITY_EFFORT_LEVELS,
+  ...LEGACY_EFFORT_LEVELS,
 ])]);
 
 // ---------------------------------------------------------------------------
@@ -289,9 +309,10 @@ const EFFORT_RANK = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh', 
  * accepts, or null when the flag should be omitted entirely (no override set,
  * provider has no effort control, or the value isn't a known effort at all).
  * An out-of-range value is clamped to the nearest supported level at or below
- * it (`ultra`→`max` on claude, `xhigh`/`max`/`ultra`→`high` on agy), falling
- * back to the provider's weakest level when nothing sits below it
- * (`minimal`→`low`) — rather than being dropped.
+ * it (`ultra`→`max` on claude, `max`/`ultra`→`xhigh` on codex,
+ * `xhigh`/`max`/`ultra`→`high` on agy), falling back to the provider's weakest
+ * level when nothing sits below it (`minimal`→`low`) — rather than being
+ * dropped.
  * @param {string|null|undefined} effort
  * @param {{id?:string, command?:string, models?:unknown[]}|null|undefined} provider
  * @param {string|null} [model] - narrows the Antigravity ladder (see effortLevelsForProvider)

--- a/server/lib/providerModels.test.js
+++ b/server/lib/providerModels.test.js
@@ -343,12 +343,23 @@ describe('providerModels', () => {
   describe('buildEffortArgs', () => {
     it('emits --effort for claude and a -c config pair for codex', () => {
       expect(buildEffortArgs('high', { id: 'claude-code', command: 'claude' })).toEqual(['--effort', 'high']);
-      expect(buildEffortArgs('ultra', { id: 'codex', command: 'codex' })).toEqual(['-c', 'model_reasoning_effort=ultra']);
+      expect(buildEffortArgs('xhigh', { id: 'codex', command: 'codex' })).toEqual(['-c', 'model_reasoning_effort=xhigh']);
     });
 
     it('emits the codex shape for a RENAMED codex provider (detection and emission agree)', () => {
-      expect(buildEffortArgs('ultra', { id: 'my-codex', command: '/opt/homebrew/bin/codex' }))
-        .toEqual(['-c', 'model_reasoning_effort=ultra']);
+      expect(buildEffortArgs('xhigh', { id: 'my-codex', command: '/opt/homebrew/bin/codex' }))
+        .toEqual(['-c', 'model_reasoning_effort=xhigh']);
+    });
+
+    // Regression: codex's config enum stops at `xhigh`, and it rejects an
+    // unknown variant while LOADING ITS CONFIG — the agent dies at startup
+    // ("unknown variant `max`, expected one of …") before the prompt is read,
+    // then burns all three retries. A dispatch label of `effort:max` must clamp,
+    // never pass through.
+    it('never emits a level codex rejects (max/ultra clamp to xhigh)', () => {
+      const codex = { id: 'codex', command: 'codex' };
+      expect(buildEffortArgs('max', codex)).toEqual(['-c', 'model_reasoning_effort=xhigh']);
+      expect(buildEffortArgs('ultra', codex)).toEqual(['-c', 'model_reasoning_effort=xhigh']);
     });
 
     it('returns [] when unset, unsupported, or already baked into existing args', () => {
@@ -365,10 +376,29 @@ describe('providerModels', () => {
     });
   });
 
+  describe('EFFORT_LEVELS', () => {
+    // The union is the STORED/API vocabulary, not a CLI ladder. It stays a
+    // superset of every ladder so an effort persisted by an older install (or an
+    // older ladder on this one) still validates after an update — the clamp in
+    // resolveCliEffort, not a 400, is what keeps it off the command line.
+    it('still accepts levels no CLI ladder offers any more', () => {
+      expect(EFFORT_LEVELS).toContain('ultra');
+      expect(CODEX_EFFORT_LEVELS).not.toContain('ultra');
+      expect(EFFORT_LEVELS).toContain('max');
+    });
+
+    it('covers every per-CLI ladder', () => {
+      for (const level of [...CLAUDE_EFFORT_LEVELS, ...CODEX_EFFORT_LEVELS, ...ANTIGRAVITY_EFFORT_LEVELS]) {
+        expect(EFFORT_LEVELS).toContain(level);
+      }
+    });
+  });
+
   describe('resolveCliEffort', () => {
     it('passes a supported level through for claude and codex', () => {
       expect(resolveCliEffort('high', { id: 'claude-code', command: 'claude' })).toBe('high');
-      expect(resolveCliEffort('ultra', { id: 'codex', command: 'codex' })).toBe('ultra');
+      expect(resolveCliEffort('minimal', { id: 'codex', command: 'codex' })).toBe('minimal');
+      expect(resolveCliEffort('xhigh', { id: 'codex', command: 'codex' })).toBe('xhigh');
     });
 
     it('clamps codex-only values to the claude equivalents on a claude provider', () => {

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -1433,8 +1433,8 @@ describe('validation.js', () => {
 
   describe('buildReviewWithArgs — per-reviewer ~effort=<level> selector', () => {
     it('emits ~effort=<level> for tokens carrying an effort pin', () => {
-      expect(buildReviewWithArgs(['claude', 'codex'], { reviewerEfforts: { claude: 'high', codex: 'max' } }))
-        .toBe('--review-with claude~effort=high,codex~effort=max');
+      expect(buildReviewWithArgs(['claude', 'codex'], { reviewerEfforts: { claude: 'high', codex: 'xhigh' } }))
+        .toBe('--review-with claude~effort=high,codex~effort=xhigh');
     });
 
     it('combines model brackets, ~opt, ~max, and ~effort in canonical order', () => {

--- a/server/services/agentCliSpawning.test.js
+++ b/server/services/agentCliSpawning.test.js
@@ -428,10 +428,10 @@ describe('buildCliSpawnConfig', () => {
         { id: 'my-codex', command: '/opt/homebrew/bin/codex' },
         null,
         {},
-        { effort: 'ultra' },
+        { effort: 'xhigh' },
       );
       expect(config.args).not.toContain('--effort');
-      expect(config.args[config.args.indexOf('-c') + 1]).toBe('model_reasoning_effort=ultra');
+      expect(config.args[config.args.indexOf('-c') + 1]).toBe('model_reasoning_effort=xhigh');
     });
 
     it('respects a user-baked --effort pin in provider args (mirrors the --model rule)', () => {

--- a/server/services/agentErrorAnalysis.js
+++ b/server/services/agentErrorAnalysis.js
@@ -111,6 +111,52 @@ function snippetAround(text, index) {
  * test whose tail prints "rate limit" is NOT misread as an infra outage.
  */
 export const ERROR_PATTERNS = [
+  // ===== CLI Config Errors =====
+  // A provider CLI that refuses to START because its own config file is
+  // invalid. Codex reads `~/.codex/config.toml` (plus any `-c key=value`
+  // override) BEFORE it reads the prompt, so an unaccepted value kills every
+  // attempt identically — the run burns all three retries and the agent never
+  // gets a single token in. Listed first: the message is unmistakable, and
+  // untriaged it landed in the `unknown` bucket (Tier 4 escalate), which spawns
+  // an investigation task for what is a one-line config edit (real incident
+  // 2026-08-17: `model_reasoning_effort = "max"`, a variant codex does not
+  // accept, sitting in the global config). Deliberately does NOT echo the
+  // matched path — it embeds the OS username (see Sensitive Data & Privacy in
+  // CLAUDE.md).
+  {
+    pattern: /(?:error loading )?config\.toml(?::\d+:\d+)?:\s*unknown (variant|field) `([^`]+)`(?:[\s\S]{0,200}?in `([^`]+)`)?/i,
+    category: 'cli-config-invalid',
+    actionable: true,
+    origin: 'runner', // fully structured — the CLI's own config-load rejection
+    escalation: 'Edit the CLI config (or the PortOS override that produced it) so the rejected key holds a value the CLI accepts, then approve the retry.',
+    extract: (match) => {
+      const kind = match[1].toLowerCase();
+      const value = match[2];
+      const key = match[3] || null;
+      const keyRef = key ? `\`${key}\`` : 'the rejected key';
+      return {
+        message: `Provider CLI rejected its config: unknown ${kind} "${value}"${key ? ` for ${key}` : ''}`,
+        suggestedFix: `The CLI failed while LOADING its config, before the prompt was read, so every retry dies identically. Set ${keyRef} to a value this CLI version accepts (its own error message lists them) in the CLI's config file — for codex that is \`~/.codex/config.toml\`. If PortOS supplied the value as a \`-c <key>=<value>\` override instead, it is out of the provider's ladder in server/lib/providerModels.js.`,
+        rejectedConfigKey: key,
+        rejectedConfigValue: value
+      };
+    }
+  },
+  {
+    // Anything else that stops the CLI at config load — a TOML syntax error, an
+    // unreadable file — same blast radius and same Tier 1 fix, without the
+    // key/value detail the pattern above extracts.
+    pattern: /error loading config\.toml/i,
+    category: 'cli-config-invalid',
+    actionable: true,
+    origin: 'runner',
+    escalation: 'Fix the provider CLI config file it failed to load, then approve the retry.',
+    extract: () => ({
+      message: 'Provider CLI could not load its config file',
+      suggestedFix: 'The CLI failed while loading its own config (for codex, `~/.codex/config.toml`), before the prompt was read — every retry fails the same way until the file parses. Check it for a syntax error or a key this CLI version no longer accepts.'
+    })
+  },
+
   // ===== API & Authentication Errors =====
   {
     pattern: /API Error: 404.*model:\s*(\S+)/i,

--- a/server/services/agentErrorAnalysis.test.js
+++ b/server/services/agentErrorAnalysis.test.js
@@ -112,6 +112,29 @@ describe('analyzeAgentFailure', () => {
 // Exercises the real exported ERROR_PATTERNS via analyzeAgentFailure, replacing
 // the inline copy that used to live (and drift) in subAgentSpawner.test.js.
 describe('analyzeAgentFailure — ERROR_PATTERNS classification', () => {
+  // Real incident 2026-08-17: `model_reasoning_effort = "max"` in the global
+  // codex config. Codex rejects it while LOADING the config, before the prompt
+  // is read, so all three retries died identically and the run escalated to an
+  // investigation task instead of a Tier 1 config fix.
+  it('classifies a codex config-load rejection as cli-config-invalid', () => {
+    const line = 'Error: /home/x/.codex/config.toml:3:26: unknown variant `max`, expected one of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`\n    in `model_reasoning_effort`';
+    const analysis = analyzeAgentFailure(withLead(line), { id: 't' }, 'gpt-5.6-sol');
+    expect(analysis.category).toBe('cli-config-invalid');
+    expect(analysis.actionable).toBe(true);
+    expect(analysis.origin).toBe('runner');
+    expect(analysis.message).toContain('max');
+    expect(analysis.message).toContain('model_reasoning_effort');
+    // The rejection line embeds the OS username in its path — it must never be
+    // echoed into a failure record (Sensitive Data & Privacy, CLAUDE.md).
+    expect(analysis.message).not.toContain('/home/x/');
+  });
+
+  it('classifies a config file that fails to load at all', () => {
+    const analysis = analyzeAgentFailure(withLead('Error loading config.toml: expected a value after the equals sign'), { id: 't' }, 'x');
+    expect(analysis.category).toBe('cli-config-invalid');
+    expect(analysis.actionable).toBe(true);
+  });
+
   it('classifies a 404 model-not-found error as actionable', () => {
     const analysis = analyzeAgentFailure(withLead('API Error: 404 - model: claude-4-ultra not found'), { id: 't' }, 'claude-4-ultra');
     expect(analysis.category).toBe('model-not-found');

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -398,9 +398,11 @@ describe('agent TUI spawning', () => {
     const codex = buildTuiSpawnConfig(
       { id: 'codex-tui', command: 'codex', type: 'tui', args: [] },
       null,
-      { effort: 'ultra' },
+      // codex's config enum stops at `xhigh`; `max`/`ultra` clamp down rather
+      // than reaching the CLI, where they would fail its config load outright.
+      { effort: 'max' },
     );
-    expect(codex.args).toContain('model_reasoning_effort=ultra');
+    expect(codex.args).toContain('model_reasoning_effort=xhigh');
     expect(codex.args).not.toContain('--effort');
   });
 

--- a/server/services/autoFixer.js
+++ b/server/services/autoFixer.js
@@ -123,6 +123,10 @@ const CATEGORY_TO_TIER = {
   'billing-error': FIX_TIERS.CONFIG_ENV,
   'usage-limit': FIX_TIERS.CONFIG_ENV,
   'spawn-error': FIX_TIERS.CONFIG_ENV,
+  // A provider CLI refusing to load its own config file: deterministic, and the
+  // fix is literally a config edit — never worth three identical retries plus an
+  // investigation task.
+  'cli-config-invalid': FIX_TIERS.CONFIG_ENV,
   'permission-denied': FIX_TIERS.CONFIG_ENV,
   'file-not-found': FIX_TIERS.CONFIG_ENV,
   // Tier 2 — schema/type (malformed request/response, parse/build/format)

--- a/server/services/imageGen/codex.js
+++ b/server/services/imageGen/codex.js
@@ -41,7 +41,7 @@ import { autoCleanGeneratedImage } from '../../lib/imageClean.js';
 import { imageGenEvents } from '../imageGenEvents.js';
 import { broadcastSse, attachSseClient as attachSse, closeJobAfterDelay } from '../../lib/sseUtils.js';
 import { killWithEscalation } from '../../lib/killWithEscalation.js';
-import { buildCodexStartupArgs, buildEffortArgs, CODEX_EFFORT_LEVELS } from '../../lib/providerModels.js';
+import { buildCodexStartupArgs, buildEffortArgs, resolveCliEffort } from '../../lib/providerModels.js';
 import {
   IMAGE_GEN_MODE, CODEX_IMAGEGEN_DEFAULT_MODEL, CODEX_IMAGEGEN_DEFAULT_EFFORT,
   describeFidelity, visualReferenceRole,
@@ -189,8 +189,12 @@ export async function generateImage({
   // override for it, and the child would silently inherit Codex's own configured
   // effort instead of the promised cheap `low` default. Fall back to the default
   // so the low-effort guarantee holds even for garbage input.
+  // `resolveCliEffort` (rather than a bare `CODEX_EFFORT_LEVELS.includes`) so a
+  // level saved when codex's ladder was wider — `max`/`ultra`, which codex
+  // rejects at config load — clamps DOWN to `xhigh` instead of collapsing to the
+  // cheap default and silently rendering at a fraction of the requested effort.
   const requestedEffort = (typeof effort === 'string' && effort.trim()) ? effort.trim() : CODEX_IMAGEGEN_DEFAULT_EFFORT;
-  const effectiveEffort = CODEX_EFFORT_LEVELS.includes(requestedEffort) ? requestedEffort : CODEX_IMAGEGEN_DEFAULT_EFFORT;
+  const effectiveEffort = resolveCliEffort(requestedEffort, { command: 'codex' }) || CODEX_IMAGEGEN_DEFAULT_EFFORT;
 
   // Re-anchors every path to the approved image roots and caps the list at what
   // codex's image_gen accepts — see inputImages.js.

--- a/server/services/taskLearning/metrics.test.js
+++ b/server/services/taskLearning/metrics.test.js
@@ -499,6 +499,8 @@ describe('ENVIRONMENTAL_ERROR_CATEGORIES (issue #2618)', () => {
       'auth-error',
       'billing-error',
       'claude-error',
+      // The provider CLI never started — its own config file was invalid.
+      'cli-config-invalid',
       'connection',
       'forbidden',
       // #3358: a PR-shaped run we could not verify because `gh` couldn't reach

--- a/server/services/taskLearning/store.js
+++ b/server/services/taskLearning/store.js
@@ -242,7 +242,10 @@ export const ENVIRONMENTAL_ERROR_CATEGORIES = new Set([
   'startup-failure',
   'model-not-available',
   'model-not-found',
-  'model-not-supported'
+  'model-not-supported',
+  // The provider CLI never started — its config file was invalid. Nothing about
+  // the task itself failed, so it must not dent the task type's success rate.
+  'cli-config-invalid'
 ]);
 
 const DEFAULT_LEARNING_DATA = {


### PR DESCRIPTION
## Summary

An auto-filed investigation task reported: `Task failed 3 times: Error loading config.toml: unknown variant \`max\`, expected one of \`none\`, \`minimal\`, \`low\`, \`medium\`, \`high\`, \`xhigh\``.

Root cause is two-sided:

1. **Repo bug.** `CODEX_EFFORT_LEVELS` claimed codex accepts `max` and `ultra`. It does not — its `model_reasoning_effort` enum is `none|minimal|low|medium|high|xhigh`. A task dispatched at `effort:max` therefore spawned `codex -c model_reasoning_effort=max`, which codex rejects **while loading its config**, before the prompt is read. All three retries died identically and the run escalated to an investigation task.
2. **Local environment** (not in this diff). The same invalid value was also sitting in the machine's global codex config, so *every* codex invocation failed regardless of what PortOS passed. Repaired in place (`max` → `xhigh`).

## Changes

- Narrow the codex ladder to `xhigh`; `max`/`ultra` clamp through `resolveCliEffort`, server and client mirror together so the picker can't display a level the run won't use.
- `EFFORT_LEVELS` stays a superset via `LEGACY_EFFORT_LEVELS`, so an effort persisted under the old ladder still validates after an install updates.
- Image-gen resolves its codex effort through the clamp rather than a bare `includes()`, so a stored `max` degrades to `xhigh` instead of collapsing to the cheap `low` default.
- New `cli-config-invalid` error category: a provider CLI refusing to load its own config is now Tier 1 (config/env) with a fix-the-config suggestion and counts as environmental for task learning, instead of landing in `unknown` and escalating. The rejection line embeds the OS username, so the matched path is deliberately never echoed into the failure record.
- Autopilot help copy no longer suggests a `max` codex pairing.

## Test plan

- `cd server && npx vitest run` — all non-DB suites pass; the DB-backed suites fail identically on a clean checkout here (no Postgres in this environment).
- `cd client && npx vitest run` — passes except `a11yConventions.test.js`, which fails the same way on a clean checkout (pre-existing).
- Verified against the installed codex directly: `codex features list` now loads its config; `model_reasoning_effort=max` reproduces the rejection.