### PR TITLE
fix: retry concurrent Git fetches

### DIFF
--- a/.changelog/next/fixed-fix-git-update-fetch-race.md
+++ b/.changelog/next/fixed-fix-git-update-fetch-race.md
@@ -1,0 +1,1 @@
+- Retry transient Git ref-lock races from the Apps Git Update action

--- a/server/services/git.fetchOrigin.test.js
+++ b/server/services/git.fetchOrigin.test.js
@@ -1,0 +1,52 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const execGitMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../lib/execGit.js', () => ({
+  execGit: execGitMock
+}));
+
+import { fetchOrigin } from './git.js';
+
+describe('fetchOrigin', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    execGitMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('retries when another fetch advances the remote ref first', async () => {
+    execGitMock
+      .mockRejectedValueOnce(new Error("error: cannot lock ref 'refs/remotes/origin/main': is at aaaaaaa but expected bbbbbbb"))
+      .mockResolvedValueOnce({ stdout: '', stderr: '', exitCode: 0 });
+
+    const result = fetchOrigin('/repo');
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(result).resolves.toBe(true);
+    expect(execGitMock).toHaveBeenCalledTimes(2);
+    expect(execGitMock).toHaveBeenNthCalledWith(1, ['fetch', 'origin'], '/repo');
+    expect(execGitMock).toHaveBeenNthCalledWith(2, ['fetch', 'origin'], '/repo');
+  });
+
+  it('does not retry a permanent fetch failure', async () => {
+    execGitMock.mockRejectedValueOnce(new Error('fatal: repository not found'));
+
+    await expect(fetchOrigin('/repo')).rejects.toThrow(/repository not found/);
+    expect(execGitMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the lock error after the retry budget is exhausted', async () => {
+    execGitMock.mockRejectedValue(new Error('error: cannot lock ref'));
+
+    const result = fetchOrigin('/repo');
+    const assertion = expect(result).rejects.toThrow(/cannot lock ref/);
+    await vi.runAllTimersAsync();
+
+    await assertion;
+    expect(execGitMock).toHaveBeenCalledTimes(4);
+  });
+});

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -1,8 +1,8 @@
 import { spawn } from '../lib/childProcess.js';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { safeJSONParse, PATHS } from '../lib/fileUtils.js';
-import { listWorktrees } from './worktreeManager.js';
+import { safeJSONParse, PATHS, sleep } from '../lib/fileUtils.js';
+import { isGitLockError, listWorktrees } from './worktreeManager.js';
 import { execGit } from '../lib/execGit.js';
 import {
   parseStatus,
@@ -183,9 +183,22 @@ export async function getRemote(dir) {
 /**
  * Fetch from origin
  */
-export async function fetchOrigin(dir) {
-  await execGit(['fetch', 'origin'], dir);
-  return true;
+const FETCH_MAX_ATTEMPTS = 4;
+const FETCH_RETRY_DELAY_MS = 250;
+
+function fetchOriginAttempt(dir, attempt) {
+  return execGit(['fetch', 'origin'], dir).then(
+    () => true,
+    (err) => {
+      // Another PortOS surface or agent may advance the same remote ref mid-fetch.
+      if (attempt >= FETCH_MAX_ATTEMPTS || !isGitLockError(err.message)) throw err;
+      return sleep(FETCH_RETRY_DELAY_MS).then(() => fetchOriginAttempt(dir, attempt + 1));
+    }
+  );
+}
+
+export function fetchOrigin(dir) {
+  return fetchOriginAttempt(dir, 1);
 }
 
 /**


### PR DESCRIPTION
## Summary

- retry transient Git ref-lock contention during the Apps Git Update fetch
- leave permanent fetch failures immediate and preserve the final lock error
- cover recovery, non-retryable failure, and exhausted-retry behavior

## Root cause

The Update action can fetch at the same time as another PortOS surface or agent. If the other fetch advances a remote-tracking ref first, Git rejects the stale expected ref value in the competing fetch. Retrying the fetch resolves that transient race.

## Test plan

- [x] Focused Git service and route suite: 5 files, 183 tests
- [x] Full local review of every changed file
- [x] `git diff --check`