### PR TITLE
fix: remove Copilot gating from branch reconciliation

### DIFF
--- a/.changelog/next/fixed-agent-dd0a4966.md
+++ b/.changelog/next/fixed-agent-dd0a4966.md
@@ -1,0 +1,1 @@
+- Branch reconciliation now follows existing review feedback and live CI and mergeability state.

--- a/server/services/branchReconcile.js
+++ b/server/services/branchReconcile.js
@@ -1032,12 +1032,11 @@ export function desiredEndState(state, actions, { prNumber, worktreePath, collis
   }
   // IN_REVIEW
   const canMerge = actionOn(actions, 'autoMerge');
-  // The Copilot gate is time-boxed for the same reason the merge waits on CI
-  // in-session: a repo without Copilot review enabled never produces one, and an
-  // unbounded "await the review" leaves a green PR open forever. 10 minutes
-  // mirrors the claim-issue flow's Copilot poll.
-  return `Drive the open PR toward green: request/await the Copilot review and address feedback.${canMerge
-    ? ` Merge ONLY when the LATEST Copilot review reports "0 comments" (pre-resolved threads do NOT count; a PR over 20k lines is exempt from the Copilot check and needs only CI-green + mergeable). If no Copilot review lands within 10 minutes of requesting it, the Copilot gate is satisfied — this repo may not have Copilot review enabled — and CI-green + MERGEABLE is the whole gate. ${driveToMerge(pr)}`
+  // Existing PRs have already passed through whatever review workflow the repo
+  // uses. Reconciliation must not request or assume a particular reviewer; its
+  // merge gate is the forge's live CI and mergeability state.
+  return `Drive the open PR toward green: inspect any existing review feedback and address it.${canMerge
+    ? ` Merge ONLY when CI is green and the PR is MERGEABLE. ${driveToMerge(pr)}`
     : ' Do NOT merge (auto-merge is disabled) — stop once the PR is green and ready for the user to merge.'}`;
 }
 

--- a/server/services/branchReconcile.test.js
+++ b/server/services/branchReconcile.test.js
@@ -1076,10 +1076,11 @@ describe('desiredEndState', () => {
     expect(instruction).not.toContain('<num>');
   });
 
-  // A repo without Copilot review enabled never produces one — an unbounded
-  // "await the review" would strand a green PR open forever.
-  it('time-boxes the IN_REVIEW Copilot gate', () => {
-    expect(desiredEndState('IN_REVIEW', {})).toContain('within 10 minutes');
+  it('does not request or gate an IN_REVIEW branch on Copilot', () => {
+    const instruction = desiredEndState('IN_REVIEW', {});
+    expect(instruction).toContain('CI is green and the PR is MERGEABLE');
+    expect(instruction.toLowerCase()).not.toContain('copilot');
+    expect(instruction).not.toContain('request/await');
   });
 });
 


### PR DESCRIPTION
## Summary

- Remove the hardcoded Copilot review request and gate from branch-reconcile IN_REVIEW instructions.
- Reconcile existing PRs using existing feedback plus live CI and mergeability state.
- Refresh the active dispatched prompt snapshot and document the dynamic-dispatch root cause in the handoff.

## Test plan

- `cd server && npm test -- --run services/branchReconcile.test.js services/taskPromptDefaults.test.js`
- Confirmed no matching legacy sentence exists in `data.reference`.
