### PR TITLE
fix: make local music-engine readiness VRAM-aware

### DIFF
--- a/.changelog/next/fixed-issue-4360.md
+++ b/.changelog/next/fixed-issue-4360.md
@@ -1,0 +1,1 @@
+- Local CUDA music engines now report VRAM readiness and refuse installs or renders when the required profile is unknown or insufficient.

--- a/client/src/components/music/MusicGenPanel.jsx
+++ b/client/src/components/music/MusicGenPanel.jsx
@@ -49,13 +49,21 @@ function engineSetupState(engine, selectedModelReady = null, selectedModelSizeGb
   const needsRuntime = engine.runtimeReady !== true;
   const needsWeights = engine.fixedModelInstall === true
     && (selectedModelReady === null ? engine.modelReady === false : selectedModelReady === false);
+  // Older servers do not send a VRAM verdict. Preserve their CUDA-only
+  // behavior during rolling upgrades; a new explicit verdict is authoritative.
+  const vramBlocked = engine.cudaRequired === true
+    && engine.vramState != null
+    && engine.vramState !== 'sufficient';
   const blocked = engine.platformSupported === false
-    || (engine.cudaRequired === true && engine.cudaState !== 'available');
+    || (engine.cudaRequired === true && engine.cudaState !== 'available')
+    || vramBlocked;
 
   let message;
   if (engine.platformSupported === false) message = `${engine.name} requires ${engine.platformLabel || 'a different host'} and is unavailable on this machine.`;
   else if (engine.cudaRequired === true && engine.cudaState === 'unknown') message = `${engine.name} is disabled because CUDA availability could not be determined.`;
   else if (engine.cudaRequired === true && engine.cudaState !== 'available') message = `${engine.name} requires an NVIDIA CUDA GPU and is unavailable on this host.`;
+  else if (engine.cudaRequired === true && engine.vramState === 'insufficient') message = `${engine.name} requires at least ${engine.minVramGb} GB of VRAM for the ${engine.vramProfileLabel || 'selected'} profile; this host reports ${engine.maxVramGb} GB.`;
+  else if (engine.cudaRequired === true && engine.vramState === 'unknown-size') message = `${engine.name} cannot run because the GPU VRAM requirement has not been measured for the ${engine.vramProfileLabel || 'selected'} execution profile.`;
   else if (engine.runtimeReady === false && needsWeights) message = `${engine.name} needs its runtime and model weights before generation.`;
   else if (engine.runtimeReady === false) message = `${engine.name} needs its runtime before generation.`;
   else if (needsWeights) message = `${engine.name} ${engine.modelReadyById && selectedModelReady === false ? 'selected model weights' : 'model weights'} are not installed yet.`;
@@ -386,7 +394,7 @@ export default function MusicGenPanel({ track, title = '', artistId = '', artist
             className="w-full px-2 py-1.5 bg-port-bg border border-port-border rounded text-white text-sm"
           >
             {engines.map((e) => (
-              <option key={e.id} value={e.id}>{e.name}{e.platformSupported === false ? ' (unavailable on this host)' : e.cudaRequired && e.cudaState !== 'available' ? ' (CUDA unavailable)' : e.ready ? '' : ' (setup required)'}</option>
+              <option key={e.id} value={e.id}>{e.name}{e.platformSupported === false ? ' (unavailable on this host)' : e.cudaRequired && e.cudaState !== 'available' ? ' (CUDA unavailable)' : e.vramState === 'insufficient' ? ' (insufficient VRAM)' : e.vramState === 'unknown-size' ? ' (VRAM unknown)' : e.ready ? '' : ' (setup required)'}</option>
             ))}
           </select>
         </label>

--- a/client/src/components/music/MusicGenPanel.test.jsx
+++ b/client/src/components/music/MusicGenPanel.test.jsx
@@ -162,6 +162,48 @@ describe('MusicGenPanel', () => {
     expect(screen.queryByRole('button', { name: /download model weights/i })).not.toBeInTheDocument();
   });
 
+  it('explains an insufficient CUDA VRAM profile and hides install actions', async () => {
+    api.listMusicEngines.mockResolvedValue({
+      defaultEngine: 'minimax-music3',
+      engines: [minimax({
+        ready: false,
+        runtimeReady: true,
+        modelReady: true,
+        vramState: 'insufficient',
+        minVramGb: 32,
+        maxVramGb: 24,
+        vramProfileLabel: 'CUDA BF16 (single GPU)',
+      })],
+    });
+
+    render(<MusicGenPanel track={{ id: 'track-1' }} prompt="cinematic score" lyrics="Example lyrics" />);
+
+    expect(await screen.findByText(/requires at least 32 GB of VRAM/i)).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /insufficient VRAM/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^generate$/i })).toBeDisabled();
+  });
+
+  it('keeps an unknown-size CUDA profile distinct from insufficient VRAM', async () => {
+    api.listMusicEngines.mockResolvedValue({
+      defaultEngine: 'minimax-music3',
+      engines: [minimax({
+        ready: false,
+        runtimeReady: true,
+        modelReady: true,
+        vramState: 'unknown-size',
+        maxVramGb: null,
+        minVramGb: null,
+      })],
+    });
+
+    render(<MusicGenPanel track={{ id: 'track-1' }} prompt="cinematic score" lyrics="Example lyrics" />);
+
+    expect(await screen.findByText(/VRAM requirement has not been measured/i)).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /VRAM unknown/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
+  });
+
   it('generates an unsaved standalone track without requiring a title or associations', async () => {
     api.listMusicEngines.mockResolvedValue({
       defaultEngine: 'musicgen',

--- a/server/lib/cudaCapability.test.js
+++ b/server/lib/cudaCapability.test.js
@@ -71,6 +71,12 @@ describe('detectCudaGpus', () => {
     expect(result.maxVramGb).toBe(24);
   });
 
+  it('keeps CUDA available but VRAM size unknown when nvidia-smi cannot size a card', async () => {
+    const result = await detectCudaGpus({ execFileImpl: execStub(null, 'GRID V100D-32Q, [N/A]\n') });
+    expect(result).toMatchObject({ status: 'available', maxVramGb: null });
+    expect(result.gpus).toEqual([{ name: 'GRID V100D-32Q', vramMib: null, vramGb: null }]);
+  });
+
   it('treats a missing nvidia-smi as a definitive "no GPU", not a failed probe', async () => {
     const enoent = Object.assign(new Error('spawn nvidia-smi ENOENT'), { code: 'ENOENT' });
     expect(await detectCudaGpus({ execFileImpl: execStub(enoent) })).toMatchObject({

--- a/server/routes/music.js
+++ b/server/routes/music.js
@@ -30,7 +30,8 @@ import { createLineReader } from '../lib/streamLines.js';
 import { SETUP_IMAGE_VIDEO_SCRIPT, spawnSetupScript, stopSetupScript } from '../lib/setupScriptRunner.js';
 import {
   ENGINES, getEngine, isEngineHealthy, isEnginePlatformSupported,
-  enginePlatformLabel,
+  enginePlatformLabel, resolveEngineVramReadiness, MUSIC_VRAM_READINESS,
+  formatEngineVramReadinessMessage,
 } from '../services/pipeline/musicGen.js';
 import { listEngineModels, addAudioModel, removeAudioModel, isValidRepoId } from '../services/audioModels.js';
 import { listMusicEngineCapabilities } from '../services/musicEngineCapabilities.js';
@@ -102,6 +103,11 @@ router.get('/setup/runtime-install', asyncHandler(async (req, res) => {
       send({ type: 'error', message: cuda.status === 'unknown'
         ? `${engine.name} cannot be installed because CUDA availability could not be determined.`
         : `${engine.name} requires an NVIDIA CUDA GPU and cannot be installed on this host.` });
+      return safeEnd();
+    }
+    const vram = resolveEngineVramReadiness(engine.id, cuda);
+    if (vram.state !== MUSIC_VRAM_READINESS.SUFFICIENT) {
+      send({ type: 'error', message: formatEngineVramReadinessMessage(engine.id, vram, 'installed') });
       return safeEnd();
     }
   }

--- a/server/routes/music.test.js
+++ b/server/routes/music.test.js
@@ -15,16 +15,16 @@ const gen = vi.hoisted(() => ({
   unsupportedPlatform: null,
 }));
 const mediaQueue = vi.hoisted(() => ({ jobs: [], enqueue: vi.fn() }));
-const cuda = vi.hoisted(() => ({ status: 'available' }));
+const cuda = vi.hoisted(() => ({ status: 'available', maxVramGb: 40 }));
 vi.mock('../lib/cudaCapability.js', () => ({
-  getCudaCapability: vi.fn(async () => ({ status: cuda.status, gpus: [], maxVramGb: null, error: null })),
+  getCudaCapability: vi.fn(async () => ({ status: cuda.status, gpus: [], maxVramGb: cuda.maxVramGb, error: null })),
 }));
 vi.mock('../services/pipeline/musicGen.js', () => {
   const ENGINES = {
     musicgen: { id: 'musicgen', name: 'MusicGen', models: [{ id: 'm', name: 'M' }], defaultModelId: 'm', minDurationSec: 1, maxDurationSec: 30, defaultDurationSec: 12, installEnv: 'INSTALL_MUSICGEN', venvDefault: '/v/mg', resolvePython: () => (gen.ready ? '/v/mg/bin/python3' : null), customModels: true },
     acestep: { id: 'acestep', name: 'ACE-Step', models: [{ id: 'a', name: 'A' }], defaultModelId: 'a', minDurationSec: 1, maxDurationSec: 240, defaultDurationSec: 60, installEnv: 'INSTALL_ACESTEP', venvDefault: '/v/ace', resolvePython: () => (gen.ready ? '/v/ace/bin/python3' : null), lyrics: true, customModels: false },
     acestep15: { id: 'acestep15', name: 'ACE-Step 1.5', models: [{ id: 'ace-step-v1.5', repo: 'ACE-Step/Ace-Step1.5', name: 'ACE-Step 1.5' }], defaultModelId: 'ace-step-v1.5', minDurationSec: 1, maxDurationSec: 240, defaultDurationSec: 60, installEnv: 'INSTALL_ACESTEP15', venvDefault: '/v/ace15', resolvePython: () => (gen.ready ? '/v/ace15/bin/python3' : null), lyrics: true, customModels: false, fixedModelInstall: true },
-    'minimax-music3': { id: 'minimax-music3', name: 'MiniMax Music 3', models: [{ id: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', name: 'MiniMax Music 3', downloadIgnore: ['qwen_7B/*', 'flowmatching_vae.pth', 'dav.pth', 'figures/*'], downloadSizeGb: 29 }], defaultModelId: 'minimax-music3', minDurationSec: 1, maxDurationSec: 300, defaultDurationSec: 60, installEnv: 'INSTALL_MINIMAX_MUSIC3', venvDefault: '/v/minimax', resolvePython: () => (gen.ready ? '/v/minimax/bin/python3' : null), lyrics: true, customModels: false, fixedModelInstall: true, cudaRequired: true, autoDuration: true },
+    'minimax-music3': { id: 'minimax-music3', name: 'MiniMax Music 3', models: [{ id: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', name: 'MiniMax Music 3', downloadIgnore: ['qwen_7B/*', 'flowmatching_vae.pth', 'dav.pth', 'figures/*'], downloadSizeGb: 29 }], defaultModelId: 'minimax-music3', minDurationSec: 1, maxDurationSec: 300, defaultDurationSec: 60, installEnv: 'INSTALL_MINIMAX_MUSIC3', venvDefault: '/v/minimax', resolvePython: () => (gen.ready ? '/v/minimax/bin/python3' : null), lyrics: true, customModels: false, fixedModelInstall: true, cudaRequired: true, autoDuration: true, executionProfile: 'cuda-bf16-single-gpu', vramProfiles: { 'cuda-bf16-single-gpu': { label: 'CUDA BF16 (single GPU)', minVramGb: null, recommendedVramGb: null } } },
     'minimax-music3-mlx': { id: 'minimax-music3-mlx', name: 'MiniMax Music 3 (MLX)', models: [
       { id: 'minimax-music3-mlx-8bit', repo: 'mlx-community/MiniMax-Music3-8bit', revision: '10aa4ca578d04c6f5256c1bc22fc8405a09602b5', downloadSizeGb: 14, name: 'MiniMax Music 3 MLX 8-bit' },
       { id: 'minimax-music3-mlx-bf16', repo: 'mlx-community/MiniMax-Music3-bf16', revision: '83a5f2d365673689df5c8f36e21e108751fd92ea', downloadSizeGb: 29, name: 'MiniMax Music 3 MLX BF16' },
@@ -41,6 +41,30 @@ vi.mock('../services/pipeline/musicGen.js', () => {
     // `ready` knobs so existing cases keep their meaning.
     isEnginePlatformSupported: (engineId) => (gen.unsupportedPlatform ? engineId !== gen.unsupportedPlatform : true),
     enginePlatformLabel: () => 'macOS on Apple Silicon (MLX)',
+    resolveEngineVramReadiness: (engineId, capability) => {
+      const engine = ENGINES[engineId] || ENGINES.musicgen;
+      const profile = engine.vramProfiles?.[engine.executionProfile];
+      const state = !engine.cudaRequired
+        ? 'sufficient'
+        : profile?.minVramGb == null || capability.status !== 'available' || !Number.isFinite(capability.maxVramGb)
+          ? 'unknown-size'
+          : capability.maxVramGb >= profile.minVramGb ? 'sufficient' : 'insufficient';
+      return {
+        state,
+        executionProfile: engine.executionProfile || null,
+        profileLabel: profile?.label || null,
+        minVramGb: profile?.minVramGb ?? null,
+        recommendedVramGb: profile?.recommendedVramGb ?? null,
+        maxVramGb: Number.isFinite(capability.maxVramGb) ? capability.maxVramGb : null,
+      };
+    },
+    MUSIC_VRAM_READINESS: { SUFFICIENT: 'sufficient', INSUFFICIENT: 'insufficient', UNKNOWN_SIZE: 'unknown-size' },
+    formatEngineVramReadinessMessage: (engineId, readiness, action = 'run') => {
+      const engine = ENGINES[engineId] || ENGINES.musicgen;
+      if (readiness.state === 'insufficient') return `${engine.name} requires at least ${readiness.minVramGb} GB of VRAM for the ${readiness.profileLabel || 'selected'} profile; this host reports ${readiness.maxVramGb} GB.`;
+      if (readiness.state === 'unknown-size') return `${engine.name} cannot be ${action} because the GPU VRAM requirement has not been measured for the ${readiness.profileLabel || 'selected'} execution profile.`;
+      return null;
+    },
     isEngineHealthy: async (engineId) => {
       if (gen.healthyByEngine) return gen.healthyByEngine[engineId] === true;
       if (gen.healthy !== null) return gen.healthy;
@@ -178,6 +202,7 @@ describe('music routes', () => {
     cache.byRevision = null;
     cache.calls.length = 0;
     cuda.status = 'available';
+    cuda.maxVramGb = 40;
     models.list.mockResolvedValue([{ id: 'm', name: 'M', userAdded: false }]);
     designer.describeMusic.mockReset().mockResolvedValue({ description: 'Lush pads over a broken beat.', llm: { provider: 'fake-provider', model: 'fake-model' } });
     designer.writeLyrics.mockReset().mockResolvedValue({ lyrics: '[verse]\nrain on the window', llm: { provider: 'fake-provider', model: 'fake-model' } });
@@ -305,7 +330,8 @@ describe('music routes', () => {
     cache.cached = false;
     const supported = await request(app).get('/api/music/engines');
     expect(supported.body.engines.find((e) => e.id === 'minimax-music3')).toMatchObject({
-      cudaState: 'available', fixedModelInstall: true, modelReady: false, runtimeReady: true, ready: false,
+      cudaState: 'available', vramState: 'unknown-size', fixedModelInstall: true, modelReady: false, runtimeReady: true, ready: false,
+      executionProfile: 'cuda-bf16-single-gpu', minVramGb: null, recommendedVramGb: null, maxVramGb: 40,
       // The UI puts this on the install button so the user knows the size of the
       // pull before starting it.
       modelSizeGb: 29,
@@ -314,8 +340,15 @@ describe('music routes', () => {
     cuda.status = 'absent';
     const unsupported = await request(app).get('/api/music/engines');
     expect(unsupported.body.engines.find((e) => e.id === 'minimax-music3')).toMatchObject({
-      cudaState: 'absent', ready: false,
+      cudaState: 'absent', vramState: 'unknown-size', ready: false,
     });
+  });
+
+  it('refuses MiniMax runtime installation when profile VRAM is unknown', async () => {
+    const r = await request(app).get('/api/music/setup/runtime-install?runtime=minimax-music3');
+    expect(r.status).toBe(200);
+    expect(r.text).toContain('VRAM requirement has not been measured');
+    expect(setup.spawn).not.toHaveBeenCalled();
   });
 
   it('GET /engines reports MLX readiness separately for the 8-bit and BF16 snapshots', async () => {

--- a/server/services/federatedMediaProvider.js
+++ b/server/services/federatedMediaProvider.js
@@ -92,6 +92,12 @@ function readinessReason(engine, modelReady) {
   if (engine.cudaRequired && engine.cudaState !== 'available') {
     return engine.cudaState === 'unknown' ? 'cuda-unknown' : 'cuda-absent';
   }
+  // Mixed-version compatibility: older capability payloads omit vramState and
+  // retain the pre-VRAM behavior, while newer local capabilities fail closed
+  // for an insufficient or unmeasured CUDA execution profile.
+  if (engine.cudaRequired && engine.vramState && engine.vramState !== 'sufficient') {
+    return engine.vramState === 'unknown-size' ? 'vram-unknown-size' : 'vram-insufficient';
+  }
   if (!modelReady) return 'model-unavailable';
   return null;
 }

--- a/server/services/federatedMediaProvider.test.js
+++ b/server/services/federatedMediaProvider.test.js
@@ -155,6 +155,15 @@ describe('federated media provider capacity and idempotency', () => {
     expect(status.capabilities[0]).not.toHaveProperty('_engine');
   });
 
+  it('reports an unmeasured CUDA VRAM profile as unavailable instead of optimistic capacity', async () => {
+    state.capabilities.engines = [readyEngine({ vramState: 'unknown-size' })];
+    const status = await getFederatedMediaProviderStatus(config());
+    expect(status).toMatchObject({ status: 'unavailable' });
+    expect(status.capabilities[0]).toMatchObject({
+      ready: false, unavailableReason: 'vram-unknown-size',
+    });
+  });
+
   it('queues allowlisted audio without exposing the prompt in its response', async () => {
     const result = await submitFederatedMediaJob({
       callerId: 'peer-example', config: config(), input: input(), idempotencyKey: 'commission-1',

--- a/server/services/musicEngineCapabilities.js
+++ b/server/services/musicEngineCapabilities.js
@@ -16,6 +16,7 @@ import {
   isEngineHealthy,
   isEnginePlatformSupported,
   enginePlatformLabel,
+  resolveEngineVramReadiness,
 } from './pipeline/musicGen.js';
 import { listEngineModels } from './audioModels.js';
 
@@ -40,6 +41,7 @@ export async function listMusicEngineCapabilities() {
       : null;
     const runtimeReady = await isEngineHealthy(engine.id);
     const cudaState = engine.cudaRequired ? cuda.status : 'available';
+    const vram = resolveEngineVramReadiness(engine.id, cuda);
 
     return {
       id: engine.id,
@@ -62,7 +64,16 @@ export async function listMusicEngineCapabilities() {
       platformSupported: isEnginePlatformSupported(engine.id),
       platformLabel: enginePlatformLabel(engine.id),
       cudaState,
-      ready: runtimeReady && (!engine.cudaRequired || cudaState === 'available') && modelReady,
+      executionProfile: vram.executionProfile,
+      vramState: vram.state,
+      vramProfileLabel: vram.profileLabel,
+      minVramGb: vram.minVramGb,
+      recommendedVramGb: vram.recommendedVramGb,
+      maxVramGb: vram.maxVramGb,
+      ready: runtimeReady
+        && (!engine.cudaRequired || cudaState === 'available')
+        && (!engine.cudaRequired || vram.state === 'sufficient')
+        && modelReady,
       installEnv: engine.installEnv,
       venvDefault: engine.venvDefault,
     };

--- a/server/services/pipeline/musicGen.js
+++ b/server/services/pipeline/musicGen.js
@@ -131,6 +131,24 @@ export const MINIMAX_MUSIC3_MODELS = Object.freeze([
   },
 ]);
 
+// VRAM requirements belong to the execution profile, not the model name. The
+// current CUDA sidecar has no reproducible PortOS memory benchmark yet, so its
+// contract deliberately carries null floors and remains unknown-size until the
+// measured profile is recorded. A missing measurement must not be interpreted
+// as zero VRAM or as permission to start a run that will fail during loading.
+export const MUSIC_VRAM_READINESS = Object.freeze({
+  SUFFICIENT: 'sufficient',
+  INSUFFICIENT: 'insufficient',
+  UNKNOWN_SIZE: 'unknown-size',
+});
+export const MINIMAX_MUSIC3_VRAM_PROFILES = Object.freeze({
+  'cuda-bf16-single-gpu': Object.freeze({
+    label: 'CUDA BF16 (single GPU)',
+    minVramGb: null,
+    recommendedVramGb: null,
+  }),
+});
+
 // These are immutable HF revisions because a shipped model must not silently
 // change underneath an existing install. The 8-bit conversion is the practical
 // default for general Apple-Silicon installs (~14 GB); BF16 remains selectable
@@ -297,6 +315,8 @@ export const ENGINES = Object.freeze({
     customModels: false,
     fixedModelInstall: true,
     cudaRequired: true,
+    executionProfile: 'cuda-bf16-single-gpu',
+    vramProfiles: MINIMAX_MUSIC3_VRAM_PROFILES,
   },
   'minimax-music3-mlx': {
     id: 'minimax-music3-mlx',
@@ -367,6 +387,57 @@ export function isEnginePlatformSupported(engineId) {
 // null for a portable engine.
 export function enginePlatformLabel(engineId) {
   return getEngine(engineId).requiresPlatform?.label || null;
+}
+
+/**
+ * Resolve a VRAM contract without collapsing an unreadable measurement into
+ * zero. Keeping this pure makes the three readiness states testable without a
+ * CUDA host and lets callers use the exact same comparison at every boundary.
+ */
+export function resolveVramReadiness({ cudaStatus, maxVramGb, minVramGb } = {}) {
+  if (!Number.isFinite(minVramGb) || cudaStatus !== 'available' || !Number.isFinite(maxVramGb)) {
+    return MUSIC_VRAM_READINESS.UNKNOWN_SIZE;
+  }
+  return maxVramGb >= minVramGb
+    ? MUSIC_VRAM_READINESS.SUFFICIENT
+    : MUSIC_VRAM_READINESS.INSUFFICIENT;
+}
+
+/**
+ * Resolve the selected engine's execution-profile requirement against the
+ * largest CUDA card reported by cudaCapability. Portable engines are
+ * sufficient by definition; CUDA engines with no measured profile remain
+ * unknown-size and are fail-closed by install/generation callers.
+ */
+export function resolveEngineVramReadiness(engineId, cuda = {}) {
+  const engine = getEngine(engineId);
+  const profile = engine.vramProfiles?.[engine.executionProfile] || null;
+  const state = engine.cudaRequired
+    ? resolveVramReadiness({
+      cudaStatus: cuda.status,
+      maxVramGb: cuda.maxVramGb,
+      minVramGb: profile?.minVramGb,
+    })
+    : MUSIC_VRAM_READINESS.SUFFICIENT;
+  return {
+    state,
+    executionProfile: engine.executionProfile || null,
+    profileLabel: profile?.label || null,
+    minVramGb: profile?.minVramGb ?? null,
+    recommendedVramGb: profile?.recommendedVramGb ?? null,
+    maxVramGb: Number.isFinite(cuda.maxVramGb) ? cuda.maxVramGb : null,
+  };
+}
+
+export function formatEngineVramReadinessMessage(engineId, readiness, action = 'run') {
+  const engine = getEngine(engineId);
+  if (readiness?.state === MUSIC_VRAM_READINESS.INSUFFICIENT) {
+    return `${engine.name} requires at least ${readiness.minVramGb} GB of VRAM for the ${readiness.profileLabel || 'selected'} profile; this host reports ${readiness.maxVramGb} GB.`;
+  }
+  if (readiness?.state === MUSIC_VRAM_READINESS.UNKNOWN_SIZE) {
+    return `${engine.name} cannot be ${action} because the GPU VRAM requirement has not been measured for the ${readiness.profileLabel || 'selected'} execution profile.`;
+  }
+  return null;
 }
 
 // Whether a backend's venv interpreter exists. Cheap (an existsSync behind the
@@ -578,6 +649,15 @@ export async function generateMusic({ prompt, lyrics, engine: engineId = DEFAULT
         cuda.status === 'unknown' ? 'CUDA availability could not be determined.' : `${engine.name} requires an NVIDIA CUDA GPU.`,
         { status: 503, code: 'PIPELINE_MUSIC_CUDA_REQUIRED' },
       );
+    }
+    const vram = resolveEngineVramReadiness(engine.id, cuda);
+    if (vram.state !== MUSIC_VRAM_READINESS.SUFFICIENT) {
+      throw new ServerError(formatEngineVramReadinessMessage(engine.id, vram), {
+        status: 503,
+        code: vram.state === MUSIC_VRAM_READINESS.INSUFFICIENT
+          ? 'PIPELINE_MUSIC_VRAM_INSUFFICIENT'
+          : 'PIPELINE_MUSIC_VRAM_UNKNOWN',
+      });
     }
   }
   if (engine.fixedModelInstall) {

--- a/server/services/pipeline/musicGen.test.js
+++ b/server/services/pipeline/musicGen.test.js
@@ -4,8 +4,9 @@ import { join } from 'path';
 import { rm, readdir } from 'fs/promises';
 import { writeFileSync, mkdtempSync } from 'fs';
 
+const cuda = vi.hoisted(() => ({ status: 'available', maxVramGb: 40 }));
 vi.mock('../../lib/cudaCapability.js', () => ({
-  getCudaCapability: vi.fn(async () => ({ status: 'available', gpus: [], maxVramGb: null, error: null })),
+  getCudaCapability: vi.fn(async () => ({ status: cuda.status, gpus: [], maxVramGb: cuda.maxVramGb, error: null })),
 }));
 
 vi.mock('../../lib/hfCache.js', () => ({
@@ -32,6 +33,9 @@ import {
   MIN_DURATION_SEC,
   MAX_DURATION_SEC,
   DEFAULT_DURATION_SEC,
+  MUSIC_VRAM_READINESS,
+  resolveVramReadiness,
+  resolveEngineVramReadiness,
 } from './musicGen.js';
 
 describe('MUSICGEN_MODELS registry', () => {
@@ -131,6 +135,40 @@ describe('ENGINES backend registry', () => {
     expect(ENGINES.musicgen.minDurationSec).toBe(MIN_DURATION_SEC);
     expect(ENGINES.musicgen.maxDurationSec).toBe(MAX_DURATION_SEC);
     expect(ENGINES.musicgen.defaultDurationSec).toBe(DEFAULT_DURATION_SEC);
+  });
+
+  it('declares MiniMax VRAM requirements per execution profile', () => {
+    const engine = ENGINES['minimax-music3'];
+    expect(engine.executionProfile).toBe('cuda-bf16-single-gpu');
+    expect(engine.vramProfiles[engine.executionProfile]).toMatchObject({
+      label: 'CUDA BF16 (single GPU)',
+      minVramGb: null,
+      recommendedVramGb: null,
+    });
+  });
+});
+
+describe('VRAM readiness', () => {
+  it('distinguishes sufficient, insufficient, and unknown measurements', () => {
+    expect(resolveVramReadiness({ cudaStatus: 'available', maxVramGb: 32, minVramGb: 24 }))
+      .toBe(MUSIC_VRAM_READINESS.SUFFICIENT);
+    expect(resolveVramReadiness({ cudaStatus: 'available', maxVramGb: 12, minVramGb: 24 }))
+      .toBe(MUSIC_VRAM_READINESS.INSUFFICIENT);
+    expect(resolveVramReadiness({ cudaStatus: 'available', maxVramGb: null, minVramGb: 24 }))
+      .toBe(MUSIC_VRAM_READINESS.UNKNOWN_SIZE);
+    expect(resolveVramReadiness({ cudaStatus: 'unknown', maxVramGb: 32, minVramGb: 24 }))
+      .toBe(MUSIC_VRAM_READINESS.UNKNOWN_SIZE);
+  });
+
+  it('keeps an unmeasured CUDA execution profile unknown-size', () => {
+    expect(resolveEngineVramReadiness('minimax-music3', {
+      status: 'available', maxVramGb: 80,
+    })).toMatchObject({
+      state: MUSIC_VRAM_READINESS.UNKNOWN_SIZE,
+      minVramGb: null,
+      recommendedVramGb: null,
+      maxVramGb: 80,
+    });
   });
 });
 
@@ -443,6 +481,8 @@ beforeEach(() => {
   h.probeOk = true;
   h.osPlatform = 'darwin';
   h.osArch = 'arm64';
+  cuda.status = 'available';
+  cuda.maxVramGb = 40;
   invalidateEngineHealth();
 });
 
@@ -463,16 +503,17 @@ describe('generateMusic backend selection', () => {
     expect(res.filename).toMatch(/^music-gen-.*\.wav$/);
   });
 
-  it('sizes MiniMax auto mode from lyric length instead of using the 60-second default', async () => {
-    await generateMusic({
+  it('blocks MiniMax when its CUDA profile has no measured VRAM floor', async () => {
+    await expect(generateMusic({
       prompt: 'warm cinematic pop',
       lyrics: `[verse]\n${'word '.repeat(150)}\n[outro]`,
       engine: 'minimax-music3',
       durationMode: 'auto',
+    })).rejects.toMatchObject({
+      status: 503,
+      code: 'PIPELINE_MUSIC_VRAM_UNKNOWN',
     });
-
-    const duration = spawnCalls[0].args[spawnCalls[0].args.indexOf('--duration') + 1];
-    expect(duration).toBe('120');
+    expect(spawnCalls).toHaveLength(0);
   });
 
   it('routes MiniMax Music 3 MLX to its sibling venv and pins the selected checkpoint', async () => {


### PR DESCRIPTION
## Summary

- Adds an execution-profile-keyed VRAM readiness contract to CUDA-backed music engines.
- Exposes `sufficient`, `insufficient`, and `unknown-size` readiness through the music engine capabilities API and UI.
- Blocks runtime installation and `generateMusic` when the profile is not known to fit, and keeps federation readiness fail-closed.

## Remaining

- Run a reproducible PortOS benchmark for the current MiniMax Music 3 CUDA BF16 sidecar, then populate its minimum and recommended VRAM fields and add any benchmarked lower-memory profile.

## Tests

- Focused server: 4 files, 144 tests passed.
- Focused client: 18 tests passed.
- `npm run build --prefix client` passed.
- Full workspace suites were attempted but stopped after unrelated baseline failures from unavailable `portos_test`/Postgres fixtures and disk-full churn.

Refs #4360
