### PR TITLE
feat: open music tracks in generative workflow

### DIFF
--- a/.changelog/next/added-music-track-generative-workflow.md
+++ b/.changelog/next/added-music-track-generative-workflow.md
@@ -1,0 +1,1 @@
+- Music track editors can now save directly into the full AI Concept → Description → Lyrics → Render workflow.

--- a/client/src/components/music/MusicDesigner.jsx
+++ b/client/src/components/music/MusicDesigner.jsx
@@ -103,7 +103,7 @@ export default function MusicDesigner() {
   const hydrateDraft = (track) => {
     setTrackId(track.id);
     if (track.title === DRAFT_TITLE) window.localStorage.setItem(ACTIVE_DRAFT_KEY, track.id);
-    else window.localStorage.removeItem(ACTIVE_DRAFT_KEY);
+    else if (window.localStorage.getItem(ACTIVE_DRAFT_KEY) === track.id) window.localStorage.removeItem(ACTIVE_DRAFT_KEY);
     setConcept(track.concept || '');
     setDescription(track.prompt || '');
     setLyrics(track.lyrics || '');

--- a/client/src/components/music/MusicDesigner.test.jsx
+++ b/client/src/components/music/MusicDesigner.test.jsx
@@ -132,6 +132,18 @@ describe('<MusicDesigner>', () => {
       expect(await screen.findByLabelText('Lyrics')).toHaveValue('[verse]\nKeep moving');
       expect(screen.getByLabelText('Lyrics')).toHaveValue('[verse]\nKeep moving');
       expect(api.getTrack).toHaveBeenCalledWith('track-saved', { silent: true });
+      expect(api.createTrack).not.toHaveBeenCalled();
+    });
+
+    it('keeps an unrelated unnamed draft resumable while designing a saved track', async () => {
+      window.localStorage.setItem('portos.musicDesigner.activeDraft', 'track-draft');
+      api.getTrack.mockResolvedValue({
+        id: 'track-saved', title: 'Named Track', concept: '', prompt: '', lyrics: '',
+      });
+      renderAt('/music/generate/concept?trackId=track-saved');
+
+      await screen.findByLabelText(/what do you want to hear/i);
+      expect(window.localStorage.getItem('portos.musicDesigner.activeDraft')).toBe('track-draft');
     });
   });
 

--- a/client/src/components/music/TracksManager.jsx
+++ b/client/src/components/music/TracksManager.jsx
@@ -6,15 +6,15 @@
  * and an audio file. Audio is stored in the shared music library; the editor
  * uploads a file or attaches an existing library track, and plays it inline.
  *
- * On-device generation (engine/model/duration) lands in Phase 4 — for now the
- * engine/model/duration are shown as read-only metadata on a generated track
- * and the prompt/lyrics fields are captured so a later Generate button can use
- * them. Mirrors the Authors/Artists master-detail pattern.
+ * The editor hosts both on-device audio generation and LLM-composed chiptunes.
+ * It can also save the open form and hand the same persisted track to the
+ * stepped MusicDesigner workflow. Mirrors the Authors/Artists master-detail
+ * pattern.
  */
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router';
-import { Plus, Loader2, Trash2, Save, Upload, Music2, Library } from 'lucide-react';
+import { Plus, Loader2, Trash2, Save, Upload, Music2, Library, Sparkles } from 'lucide-react';
 import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import FilePickerButton from '../ui/FilePickerButton';
@@ -72,6 +72,7 @@ export default function TracksManager() {
   const [loading, setLoading] = useState(true);
   const [form, setForm] = useState(emptyForm);
   const [saving, setSaving] = useState(false);
+  const [openingDesigner, setOpeningDesigner] = useState(false);
   const { isConfirming: isConfirmingDelete, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
   const [uploading, setUploading] = useState(false);
   const [libraryOpen, setLibraryOpen] = useState(false);
@@ -143,7 +144,7 @@ export default function TracksManager() {
   // for every selection change (incl. idle / not-found) so a modal/remix left
   // open can't drive the previous track (see Authors.jsx for the base pattern).
   const hydratedRef = useRef(null);
-  // Set by `handleSave` to the id it just created. The create flow navigates
+  // Set by `persistForm` to the id it just created. The create flow navigates
   // /music/tracks/new → /music/tracks/<id>, which re-runs this effect; without
   // the marker the derivation below would snap a "Chiptune score" chosen BEFORE
   // saving back to "Audio model" the moment the track came into existence
@@ -179,14 +180,14 @@ export default function TracksManager() {
     });
   };
 
-  const handleSave = async () => {
+  const persistForm = async () => {
     const title = form.title.trim();
-    if (!title) { toast.error('Track title is required'); return; }
+    if (!title) { toast.error('Track title is required'); return null; }
     setSaving(true);
     if (isCreate) {
       const created = await createTrack({ ...form, title }, { silent: true }).catch((err) => { toast.error(err.message || 'Failed to create track'); return null; });
       setSaving(false);
-      if (!created) return;
+      if (!created) return null;
       upsertLocal(created);
       // Point the async-handler ref at the new id immediately (the hydration
       // effect also sets it, but not until after navigation re-renders).
@@ -194,8 +195,7 @@ export default function TracksManager() {
       // Carry the pre-save generator choice through the create → navigate
       // hydration instead of re-deriving it from the (score-less) new track.
       justCreatedIdRef.current = created.id;
-      navigate(`/music/tracks/${encodeURIComponent(created.id)}`);
-      toast.success(`Created "${created.title}"`);
+      return created;
     } else {
       // Drop `albumId` from a metadata-only update unless the user actually
       // changed the album here — otherwise a stale form would re-send the old
@@ -206,10 +206,32 @@ export default function TracksManager() {
       if ((selected?.albumId || '') === form.albumId) delete payload.albumId;
       const updated = await updateTrack(id, payload, { silent: true }).catch((err) => { toast.error(err.message || 'Failed to save track'); return null; });
       setSaving(false);
-      if (!updated) return;
+      if (!updated) return null;
       upsertLocal(updated);
+      return updated;
+    }
+  };
+
+  const handleSave = async () => {
+    const saved = await persistForm();
+    if (!saved) return;
+    if (isCreate) {
+      navigate(`/music/tracks/${encodeURIComponent(saved.id)}`);
+      toast.success(`Created "${saved.title}"`);
+    } else {
       toast.success('Saved');
     }
+  };
+
+  // The stepped designer already knows how to hydrate and update a saved track
+  // by `trackId`. Persist the open form first so moving into the Concept →
+  // Description → Lyrics → Render flow never drops unsaved metadata or text.
+  const openDesigner = async () => {
+    setOpeningDesigner(true);
+    const saved = await persistForm();
+    setOpeningDesigner(false);
+    if (!saved) return;
+    navigate(`/music/generate/concept?trackId=${encodeURIComponent(saved.id)}`);
   };
 
   const handleDelete = async () => {
@@ -342,8 +364,8 @@ export default function TracksManager() {
     <div>
       <div className="flex items-center justify-between mb-4 flex-wrap gap-3">
         <p className="text-sm text-gray-400 max-w-2xl">
-          Tracks are singles or album members. Set the artist, write lyrics and a generation prompt, then
-          upload an audio file or attach one from your music library. On-device generation lands next update.
+          Tracks are singles or album members. Design a prompt and lyrics with AI, edit them directly, then
+          render on-device, upload an audio file, or attach one from your music library.
         </p>
         <button
           type="button"
@@ -393,6 +415,23 @@ export default function TracksManager() {
             <div className="text-gray-500 text-sm">Select a track to edit, or create a new one.</div>
           ) : (
             <div className="space-y-3">
+              <div className="flex flex-col gap-3 rounded-lg border border-port-accent/30 bg-port-accent/5 p-3 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <p className="text-sm font-medium text-white">Generative workflow</p>
+                  <p className="text-xs text-gray-400">
+                    Take this track through the same Concept → Description → Lyrics → Render steps as the Generate wizard.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  onClick={openDesigner}
+                  disabled={saving || !form.title.trim()}
+                  className="inline-flex min-h-[40px] shrink-0 items-center justify-center gap-2 rounded-lg border border-port-accent px-3 py-2 text-sm font-medium text-port-accent transition-colors hover:bg-port-accent/10 disabled:opacity-50"
+                >
+                  {openingDesigner ? <Loader2 size={15} className="animate-spin" /> : <Sparkles size={15} />}
+                  {openingDesigner ? 'Opening designer…' : (isCreate ? 'Save & design with AI' : 'Design with AI')}
+                </button>
+              </div>
               <Field label="Title">
                 <input
                   value={form.title}
@@ -427,7 +466,7 @@ export default function TracksManager() {
                   ) : null}
                 </select>
               </Field>
-              <Field label="Prompt" hint="Text/style prompt for generation (used by the upcoming on-device generators).">
+              <Field label="Prompt" hint="Text/style prompt used by the on-device generators.">
                 <textarea
                   value={form.prompt}
                   onChange={(e) => setForm((f) => ({ ...f, prompt: e.target.value }))}

--- a/client/src/components/music/TracksManager.test.jsx
+++ b/client/src/components/music/TracksManager.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, cleanup, fireEvent, waitFor, within } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router';
+import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Stub the heavy children — this suite pins the MIDI read-through wiring
@@ -36,10 +36,16 @@ import { listMusicVideoProjects } from '../../services/apiMusicVideo.js';
 
 const TRACK = { id: 'track-1', title: 'Example Song', audioFilename: 'example.mp3', renders: [] };
 
+function LocationDisplay() {
+  const location = useLocation();
+  return <div data-testid="location">{location.pathname}{location.search}</div>;
+}
+
 const renderAt = (id) => render(
   <MemoryRouter initialEntries={[`/music/tracks/${id}`]}>
     <Routes>
       <Route path="/music/tracks/:id" element={<TracksManager />} />
+      <Route path="/music/generate/:step" element={<LocationDisplay />} />
     </Routes>
   </MemoryRouter>,
 );
@@ -155,6 +161,41 @@ describe('<TracksManager> generator mode toggle', () => {
 
     expect(await screen.findByTestId('gen-panel')).toBeInTheDocument();
     expect(screen.queryByTestId('chiptune-panel')).toBeNull();
+  });
+});
+
+describe('<TracksManager> generative workflow hand-off', () => {
+  beforeEach(() => {
+    listTracks.mockResolvedValue([TRACK]);
+    listAlbums.mockResolvedValue([]);
+    listMusicVideoProjects.mockResolvedValue([]);
+  });
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('saves open edits before loading the same track in the stepped designer', async () => {
+    updateTrack.mockResolvedValue({ ...TRACK, prompt: 'A patient analog pulse.' });
+    renderAt('track-1');
+
+    const prompt = await screen.findByLabelText(/^Prompt/);
+    fireEvent.change(prompt, { target: { value: 'A patient analog pulse.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Design with AI' }));
+
+    await waitFor(() => expect(updateTrack).toHaveBeenCalledWith(
+      'track-1',
+      {
+        title: 'Example Song',
+        artistId: '',
+        artist: '',
+        lyrics: '',
+        prompt: 'A patient analog pulse.',
+        audioFilename: 'example.mp3',
+      },
+      { silent: true },
+    ));
+    expect(await screen.findByTestId('location')).toHaveTextContent('/music/generate/concept?trackId=track-1');
   });
 });
 


### PR DESCRIPTION
## Summary

- Add a Generative workflow action to music track editors.
- Save current edits before opening the same persisted track in the Concept → Description → Lyrics → Render wizard.
- Preserve unrelated unnamed music drafts when a saved track enters the designer.
- Add focused handoff and draft-resume regression coverage.

## Test plan

- cd client && npm test -- src/components/music/TracksManager.test.jsx src/components/music/MusicDesigner.test.jsx
- cd client && npm run lint
- cd client && npm run build
- Verify the track-editor callout and button layout in the browser without mutating live track data.
