### PR TITLE
fix([issue-4320]): settle LTX-2.5 encoder gate

### DIFF
--- a/.changelog/next/fixed-issue-4320.md
+++ b/.changelog/next/fixed-issue-4320.md
@@ -1,0 +1,1 @@
+- LTX-2.5 unified Gemma 4 text-encoder substitutes now strict-load through a narrow visual-weight filter; both initial candidates remain gated after controlled GPU renders showed no repeatable prompt-following gain (#4320).

--- a/docs/features/video-text-encoders.md
+++ b/docs/features/video-text-encoders.md
@@ -5,8 +5,9 @@ the prompt. The picker sits under the Model field and defaults to the conditione
 that ships with the model, so nothing changes unless you pick something else.
 
 Two runtimes have a conditioner table: **MiniMax H3** (the substitutes below) and
-**LTX-2.5**, whose mechanism ships but whose substitutes are still gated — see
-[LTX-2.5](#ltx-25) at the end. Every other runtime has no picker at all.
+**LTX-2.5**, whose mechanism ships stock-only after both initial substitutes
+failed the empirical gate — see [LTX-2.5](#ltx-25) at the end. Every other
+runtime has no picker at all.
 
 ## Why H3's conditioner is swappable at all
 
@@ -209,9 +210,12 @@ self-describing and the pack contributes only its connector, loaded separately.
 `configOverrides` are merged over the rest. That field exists for exactly one
 correction — a *unified* Gemma 4 checkpoint publishes
 `model_type: "gemma4_unified"`, which `Gemma4LanguageModel.load()` hard-rejects,
-and it is the only thing such a checkpoint gets wrong, since mlx-lm's
-`gemma4.Model.sanitize()` already discards the `vision_tower.*` / `audio_tower.*`
-/ `multi_modal_projector.*` towers at load. The `quantization` block is never
+while mlx-lm's `gemma4.Model.sanitize()` already discards the
+`vision_tower.*` / `audio_tower.*` / `multi_modal_projector.*` towers at load.
+The real strict-load gate found eleven additional `vision_embedder.*` tensors in
+that checkpoint. `install_ltx25_unified_weight_filter()` removes only that exact
+visual prefix before delegating to mlx-lm's sanitizer; strict loading remains on,
+so a missing language tensor still fails. The `quantization` block is never
 overridden: per-layer group-size overrides are part of how the weights were
 packed, and a mismatch dequantizes to noise.
 
@@ -236,24 +240,30 @@ abliterated Gemma 4 12B a plausible drop-in. A different Gemma generation is not
 Gemma 3's tokenizer, vocabulary and layer count have no mapping onto the module
 tree mlx-lm's `gemma4` builds.
 
-### Status: substitutes gated pending a coherence check
+### Status: initial substitutes failed; stock only
 
 Two substitutes are declared in the registry (`ltx25-abliterated-4bit`,
 `ltx25-heretic-8bit`) and both carry `verified: false`, which keeps them out of
 the picker **and** out of the download lane — an unverified id is rejected by
 route validation and its weights cannot be pulled. The LTX-2.5 picker therefore
 hides itself today, exactly as it does for a runtime with no substitutes at all.
+The entries remain declared only as pinned failure records.
 
-What is unsettled is empirical, not structural: Lightricks'
-`gemma4-12b-with-proj-ltx-2.5` tower may be LTX-fine-tuned rather than stock
-`google/gemma-4-12B-it`, in which case a stock-derived abliterated tower would
-feed the pack's connector out-of-distribution features and render incoherently.
-To settle it, flip an entry to `verified: true` locally, download it from Media
-Models, then render the same prompt/seed/steps/resolution against the stock
-conditioner and against the substitute — once on a benign prompt (does it stay
-structurally coherent?) and once on a prompt the stock conditioner waters down
-(does it read differently?). Ship the flag flip only for a substitute that passes
-both, and record a failure in the module docblock rather than deleting the entry.
+The gate ran on the pinned production runtime with the same seed within each A/B,
+at 512x320, 33 frames, 24 fps, 8 guided steps plus 3 stage-two steps, and CFG 3.
+It used one benign motion prompt and three target-behavior challenges:
+
+| Candidate | Benign coherence | Target-behavior result | Verdict |
+|-----------|------------------|------------------------|---------|
+| 4-bit abliterated | Broadly coherent | Stock rendered the staged bite and prop cigarette more literally; both rendered an index finger for the requested middle-finger gesture | Failed |
+| 8-bit Heretic | Coherent scene, but one kite fragmented into several red objects | Staged-bite and prop-cigarette behavior remained stock-like; the explicit gesture was still an index finger | Failed |
+
+Both candidates did change the generated pixels, but neither produced a
+repeatable improvement on the behavior the feature exists to unlock. Pixel
+difference alone is not the pass criterion. A future candidate must preserve
+benign structure **and** visibly improve at least one controlled challenge before
+its `verified` flag can be enabled. The repeated-seed candidate search is tracked
+in #4470.
 
 ## Related
 

--- a/scripts/generate_ltx2.py
+++ b/scripts/generate_ltx2.py
@@ -570,6 +570,44 @@ def build_ltx25_encoder_shim(
     return root
 
 
+def filter_ltx25_unified_weights(weights: dict) -> dict:
+    """Drop the unified checkpoint's residual visual-only tensors.
+
+    mlx-lm's Gemma 4 sanitizer already removes ``vision_tower.*``,
+    ``audio_tower.*`` and the multimodal projectors before strict weight
+    loading.  The Heretic unified checkpoint additionally publishes eleven
+    ``vision_embedder.*`` tensors (sometimes under a leading ``model.``),
+    which are not part of the text-only ``gemma4`` module tree and otherwise
+    make strict loading fail.  Filter only that proven visual prefix: using
+    ``strict=False`` would also hide a genuinely missing language tensor.
+    """
+    return {
+        key: value
+        for key, value in weights.items()
+        if not key.removeprefix("model.").startswith("vision_embedder.")
+    }
+
+
+def install_ltx25_unified_weight_filter() -> None:
+    """Extend mlx-lm's Gemma 4 sanitizer for the pinned unified candidate.
+
+    Installed only for an explicit LTX-2.5 substitution and before the model
+    loads.  Mark the wrapper so a process that installs the adapter twice does
+    not stack it; normal PortOS renders install it once and then ``os._exit``.
+    """
+    from mlx_lm.models.gemma4 import Model
+
+    original = Model.sanitize
+    if getattr(original, "_portos_ltx25_unified_filter", False):
+        return
+
+    def sanitize(self, weights):
+        return original(self, filter_ltx25_unified_weights(weights))
+
+    sanitize._portos_ltx25_unified_filter = True
+    Model.sanitize = sanitize
+
+
 def install_ltx25_encoder_override(shim_dir: Path) -> None:
     """Point the pack's conditioner resolution at the shim, for every pipeline.
 
@@ -1186,6 +1224,7 @@ def main() -> NoReturn:
         # cannot ride along in the marker itself.
         print("STAGE:swap-text-encoder", file=sys.stderr, flush=True)
         emit_status(f"Conditioning with the {args.text_encoder_id} text encoder")
+        install_ltx25_unified_weight_filter()
         install_ltx25_encoder_override(build_ltx25_encoder_shim(
             Path(args.text_encoder_shim_root),
             args.text_encoder_id,

--- a/scripts/generate_ltx2.test.js
+++ b/scripts/generate_ltx2.test.js
@@ -205,6 +205,23 @@ describe.skipIf(!pyBin)('generate_ltx2.py', () => {
     expect(JSON.parse(output)).toEqual({ model_type: 'gemma4', text_config: { a: 1 } });
   });
 
+  it('drops only the unified checkpoint visual embedder before strict loading', () => {
+    const output = runPython(`${importRunner}\n${[
+      'import json',
+      'weights = {',
+      '    "model.vision_embedder.patch_dense.weight": "drop-prefixed",',
+      '    "vision_embedder.pos_embedding": "drop-flat",',
+      '    "model.language_model.model.embed_tokens.weight": "keep-language",',
+      '    "vision_embedderish.weight": "keep-near-match",',
+      '}',
+      'print(json.dumps(runner.filter_ltx25_unified_weights(weights), sort_keys=True))',
+    ].join('\n')}`);
+    expect(JSON.parse(output)).toEqual({
+      'model.language_model.model.embed_tokens.weight': 'keep-language',
+      'vision_embedderish.weight': 'keep-near-match',
+    });
+  });
+
   // Rebuilt from scratch every render: a stale shim pointing at a blob the user
   // has since re-downloaded would otherwise load silently-wrong weights.
   it('replaces a stale shim rather than merging into it', () => {

--- a/server/lib/videoTextEncoders.js
+++ b/server/lib/videoTextEncoders.js
@@ -71,13 +71,14 @@
  * the `model_type` + `text_config` + `quantization` triple the fork's
  * `convert_ltx25_to_mlx.py --step text-encoder` emits). It exists because a
  * *unified* Gemma 4 checkpoint publishes `model_type: "gemma4_unified"`, which
- * `Gemma4LanguageModel.load()` hard-rejects — and that one string is the only
- * thing it gets wrong, since mlx-lm's `gemma4.Model.sanitize()` already
- * discards the `vision_tower.*` / `audio_tower.*` / `multi_modal_projector.*`
- * towers at load. Omit the field entirely for a text-only checkpoint that
- * already reports `gemma4`; the `quantization` block is NEVER overridden,
- * because per-layer group-size overrides are part of how the weights were
- * packed and a mismatched group size dequantizes to noise.
+ * `Gemma4LanguageModel.load()` hard-rejects. mlx-lm's
+ * `gemma4.Model.sanitize()` already discards the `vision_tower.*` /
+ * `audio_tower.*` / `multi_modal_projector.*` towers at load; the runner adds
+ * one exact-prefix filter for the eleven residual `vision_embedder.*` tensors
+ * found by the real strict-load gate. Omit the field entirely for a text-only
+ * checkpoint that already reports `gemma4`; the `quantization` block is NEVER
+ * overridden, because per-layer group-size overrides are part of how the
+ * weights were packed and a mismatched group size dequantizes to noise.
  *
  * COMPATIBILITY RULE for a new ltx25 entry: the checkpoint must be Gemma 4 12B
  * at the LTX-2.5 tower's exact geometry — 48 layers, hidden 3840, vocab 262144,
@@ -88,23 +89,23 @@
  * vocabulary and layer count have no mapping onto the module tree mlx-lm's
  * `gemma4` builds.
  *
- * `verified` — PENDING COHERENCE CHECK. Both ltx25 substitutes below are
- * declared `verified: false` and are therefore hidden from `videoTextEncoderOptions`
- * and from the download lane (see `isOfferedTextEncoder`), so neither can be
- * selected in the picker or accepted by route validation. They stay in code
- * because the mechanism, the pins and the sizes are all settled; what is NOT
- * settled is whether Lightricks' `gemma4-12b-with-proj-ltx-2.5` tower is stock
- * `google/gemma-4-12B-it` or an LTX fine-tune. If it is a fine-tune, a
- * stock-derived abliterated tower feeds the pack's connector out-of-distribution
- * features and renders incoherently — which static analysis cannot settle.
+ * `verified` — COHERENCE GATE COMPLETED 2026-08-16 (#4320). Both candidates
+ * strict-loaded and produced finite connector inputs on the pinned runtime,
+ * then rendered a fixed-seed matrix at 512x320 / 33 frames / 24 fps / 8+3
+ * steps / CFG 3: one benign motion prompt plus staged-bite, explicit-gesture
+ * and prop-cigarette challenges. The 4-bit tower stayed broadly coherent but
+ * did not improve the target behavior: stock described the staged bite and
+ * cigarette more literally, while both produced an index finger for the
+ * requested middle-finger gesture. The 8-bit tower was likewise stock-like on
+ * all three challenges, still produced an index finger, and fragmented the
+ * benign prompt's single kite into several red objects.
  *
- * To settle it: flip an entry to `verified: true` locally, download it from
- * Media Models, then render the same prompt/seed/steps/resolution against the
- * stock conditioner and against the substitute — once on a benign prompt (does
- * it stay structurally coherent?) and once on a prompt the stock conditioner
- * waters down (does it actually read differently?). Ship the flag flip only for
- * a substitute that passes both; record a failure here rather than deleting the
- * entry, so the next person does not re-derive it.
+ * Both therefore remain `verified: false`, hidden from
+ * `videoTextEncoderOptions` and the download lane (see
+ * `isOfferedTextEncoder`). They stay declared as pinned failure records so a
+ * later candidate search does not repeat either download or gate. LTX-2.5 is
+ * stock-only until a substitute passes BOTH benign structural coherence and a
+ * repeatable target-behavior improvement; that search continues in #4470.
  */
 
 import { ServerError } from './errorHandler.js';
@@ -218,18 +219,19 @@ const TEXT_ENCODERS_BY_RUNTIME = Object.freeze({
   // themselves. All of them are inputs to the shim the runner builds, and
   // `sizeBytes` is their exact published total.
   //
-  // Both substitutes are `verified: false` pending the coherence check
-  // described in the docblock: they are declared here but hidden from the
-  // picker and from the download lane until an A/B render settles whether the
-  // pack's connector accepts a stock-derived Gemma 4 tower.
+  // Both substitutes failed the 2026-08-16 coherence/behavior gate described
+  // in the docblock. They remain declared as pinned provenance records, but
+  // `verified: false` keeps them out of the picker and download lane.
   ltx25: Object.freeze([
     STOCK_LTX25,
     Object.freeze({
       id: 'ltx25-abliterated-4bit',
       label: 'Abliterated uncensored — Gemma 4 12B 4-bit',
       description:
-        'Abliterated Gemma 4 12B conditioner, text tower only, MLX 4-bit. Reads prompts the stock '
-        + 'conditioner refuses or waters down; the diffusion weights are unchanged.',
+        'Abliterated Gemma 4 12B conditioner, text tower only, MLX 4-bit. Retained as a gated '
+        + 'candidate record after fixed-seed renders showed no repeatable prompt-following gain.',
+      // Failed #4320: coherent, but stock was more literal on two challenges
+      // and both conditioners substituted an index finger for the third.
       verified: false,
       repo: 'divinetribe/gemma-4-12B-it-abliterated-4bit-mlx-text',
       revision: '3f123973331780c8702344dad62445ab09436ef3',
@@ -260,15 +262,18 @@ const TEXT_ENCODERS_BY_RUNTIME = Object.freeze({
       label: 'Heretic uncensored — Gemma 4 12B 8-bit',
       description:
         'Gemma 4 12B abliterated with the Heretic method — the same family as the H3 Ultra-Heretic '
-        + 'conditioner, at 8-bit. A unified checkpoint, so its extra towers are dropped at load.',
+        + 'conditioner, at 8-bit. Retained as a gated candidate record after the fixed-seed gate failed.',
+      // Failed #4320: challenge behavior stayed stock-like, the explicit
+      // gesture was still an index finger, and the benign kite fragmented.
       verified: false,
       repo: 'culturerevolt/gemma-4-12b-heretic-abliterated-8bit-mlx',
       revision: '86c60c34eb11613fbaae0353e2bfac83a32ce8a3',
       // Published as `gemma4_unified`, which Gemma4LanguageModel.load()
-      // hard-rejects. That one string is the ONLY thing it gets wrong: mlx-lm's
-      // gemma4 sanitizer already discards the vision/audio towers, so the shim
-      // rewrites the type and keeps the substitute's own `quantization` block
-      // (group 32 with per-layer 64 overrides on the MLP projections) verbatim.
+      // hard-rejects. The shim rewrites the type, mlx-lm's sanitizer discards
+      // its main vision/audio towers, and the runner removes the eleven residual
+      // `vision_embedder.*` tensors found by the strict-load gate. It keeps the
+      // substitute's own `quantization` block (group 32 with per-layer 64
+      // overrides on the MLP projections) verbatim.
       configOverrides: Object.freeze({ model_type: 'gemma4' }),
       // All three shards, none skippable: shard 3 interleaves 233 language keys
       // with 17 audio/vision keys, so dropping it to save the towers would take


### PR DESCRIPTION
## Summary

- Ran the controlled LTX-2.5 conditioner matrix. Both pinned candidates failed the coherence and behavior gate, remain `verified: false`, and LTX-2.5 stays stock-only.
- Added a narrow Gemma4 sanitizer hook that removes only residual `vision_embedder.*` tensors from explicit substitutes before mlx-lm performs its existing strict load.
- Recorded the failed gate in the registry and feature documentation, with the broader conditioner search tracked in #4470.

## Test plan

- `python3 -m py_compile scripts/generate_ltx2.py`
- Focused Vitest selection: 4 files, 233 tests passed
- Server full suite: 29,868 tests passed; four load-time timeout files passed 373/373 together on immediate rerun
- Client full suite: 8,067 tests passed; the sole Catalog act-warning assertion passed 26/26 in its isolated file rerun
- Controlled local GPU matrix: 512x320, 33 frames, 24 fps, 8 guided plus 3 stage-two steps, CFG 3, no audio, fixed seeds; both candidates failed the coherence and behavior gate
- `git diff --check`

Closes #4320

Follow-up: #4470