### PR TITLE
feat: enable final staged Biome a11y rule

### DIFF
--- a/.changelog/next/changed-issue-4158.md
+++ b/.changelog/next/changed-issue-4158.md
@@ -1,1 +1,2 @@
 - Client lint now checks image alternative text and valid ARIA usage.
+- Forms now keep their labels connected to controls as accessibility checks become stricter.

--- a/client/biome.jsonc
+++ b/client/biome.jsonc
@@ -80,7 +80,8 @@
       "a11y": {
         "useAltText": "error",
         "useAriaPropsForRole": "error",
-        "useValidAriaProps": "error"
+        "useValidAriaProps": "error",
+        "noLabelWithoutControl": "error"
       },
       "complexity": {
         // eslint: no-regex-spaces

--- a/client/src/components/AppContextPicker.jsx
+++ b/client/src/components/AppContextPicker.jsx
@@ -1,3 +1,4 @@
+import { useId } from 'react';
 import AppIcon from './AppIcon';
 
 export default function AppContextPicker({
@@ -17,6 +18,7 @@ export default function AppContextPicker({
   // override this — the default text would lie about what happens.
   emptyRepoText = 'using default PortOS context'
 }) {
+  const selectId = useId();
   const selectedApp = apps.find(app => app.id === value);
   const sortedApps = [...apps].sort((a, b) =>
     (a?.name || '').localeCompare(b?.name || '', undefined, { sensitivity: 'base' })
@@ -25,6 +27,7 @@ export default function AppContextPicker({
   const content = (
     <div className="space-y-2">
       <select
+        id={selectId}
         value={value}
         onChange={(event) => onChange?.(event.target.value)}
         className={selectClassName}
@@ -65,10 +68,10 @@ export default function AppContextPicker({
   return (
     <div className={className}>
       {label ? (
-        <label className="block text-xs text-gray-400">
-          {label}
+        <>
+          <label htmlFor={selectId} className="block text-xs text-gray-400">{label}</label>
           <div className="mt-1">{content}</div>
-        </label>
+        </>
       ) : content}
     </div>
   );

--- a/client/src/components/cos/tabs/MemoryEditModal.jsx
+++ b/client/src/components/cos/tabs/MemoryEditModal.jsx
@@ -121,7 +121,7 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
         <form onSubmit={handleSubmit} className="space-y-4">
           {/* Type */}
           <div>
-            <label className="block text-sm text-gray-400 mb-2">Type</label>
+            <span className="block text-sm text-gray-400 mb-2">Type</span>
             <div className="flex flex-wrap gap-2">
               {MEMORY_TYPES.map(type => (
                 <button
@@ -205,7 +205,7 @@ export default function MemoryEditModal({ memory, apps, onSave, onClose }) {
 
           {/* Tags */}
           <div>
-            <label className="block text-sm text-gray-400 mb-2">Tags</label>
+            <span className="block text-sm text-gray-400 mb-2">Tags</span>
             <div className="flex flex-wrap gap-2 mb-3">
               {formData.tags.map(tag => (
                 <span

--- a/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
+++ b/client/src/components/cos/tabs/schedule/GlobalConfigControls.jsx
@@ -197,7 +197,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1.5">
-          <label className="text-sm text-gray-400">Global Pause</label>
+          <span className="text-sm text-gray-400">Global Pause</span>
           <InfoTooltip label="What does Global Pause do?">
             When paused, no scheduled runs will execute for this task — even if individual apps are enabled.
           </InfoTooltip>
@@ -244,7 +244,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
 
       {selectedType === 'perpetual' && (
         <div>
-          <label className="text-sm text-gray-400 block mb-2">Recheck Cadence</label>
+          <span className="text-sm text-gray-400 block mb-2">Recheck Cadence</span>
           {(recheckEditing || config.recheckCron) ? (
             <CronInput
               value={config.recheckCron || '0 9 * * *'}
@@ -444,7 +444,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
       />
 
       <div>
-        <label className="text-sm text-gray-400 block mb-2">Agent Options</label>
+        <span className="text-sm text-gray-400 block mb-2">Agent Options</span>
         <div className="space-y-2">
           {AGENT_OPTIONS.map(({ field, label, description }) => {
             const enabled = config.taskMetadata?.[field] ?? false;
@@ -529,7 +529,7 @@ export default function GlobalConfigControls({ taskType, config, onUpdate, onTri
 
       {allTaskTypes?.length > 1 && (
         <div>
-          <label className="text-sm text-gray-400 block mb-2">Run After (dependencies)</label>
+          <span className="text-sm text-gray-400 block mb-2">Run After (dependencies)</span>
           <div className="flex flex-wrap gap-2">
             {allTaskTypes.filter(t => t !== taskType).map(dep => {
               const isSelected = (config.runAfter || []).includes(dep);

--- a/client/src/components/cos/tabs/schedule/PromptEditor.jsx
+++ b/client/src/components/cos/tabs/schedule/PromptEditor.jsx
@@ -16,7 +16,7 @@ export default function PromptEditor({ config, promptValue, setPromptValue, edit
     return (
       <div>
         <div className="flex items-center justify-between mb-2">
-          <label className="text-sm text-gray-400">Task Prompt</label>
+          <span className="text-sm text-gray-400">Task Prompt</span>
           {!editingPrompt && (
             <button onClick={() => setEditingPrompt(true)} className="text-xs text-port-accent hover:text-port-accent/80">Edit</button>
           )}
@@ -59,7 +59,7 @@ export default function PromptEditor({ config, promptValue, setPromptValue, edit
   // Pipeline tabbed prompt viewer
   return (
     <div>
-      <label className="text-sm text-gray-400 block mb-2">Stage Prompts</label>
+      <span className="text-sm text-gray-400 block mb-2">Stage Prompts</span>
       <div className="border border-port-border rounded-lg overflow-hidden">
         <div className="flex border-b border-port-border bg-port-card">
           {stages.map((stage, i) => (

--- a/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
+++ b/client/src/components/creative-director/CreativeDirectorModelsDrawer.jsx
@@ -284,7 +284,7 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
                 <p className="text-xs text-gray-500">{stage.help}</p>
 
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
-                  <label className="flex flex-col gap-1">
+                  <div className="flex flex-col gap-1">
                     <span className="text-[11px] uppercase tracking-wide text-gray-500">Provider</span>
                     <select
                       value={draft.providerId}
@@ -306,9 +306,9 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
                       <option value="">{isGlobal ? 'System default' : 'Inherit default'}</option>
                       {providerOptions.map((p) => <option key={p.id} value={p.id}>{p.name}</option>)}
                     </select>
-                  </label>
+                  </div>
 
-                  <label className="flex flex-col gap-1">
+                  <div className="flex flex-col gap-1">
                     <span className="text-[11px] uppercase tracking-wide text-gray-500">Model</span>
                     {!pinned ? (
                       <div className="text-sm text-gray-600 py-2">—</div>
@@ -343,7 +343,7 @@ export default function CreativeDirectorModelsDrawer({ open, onClose, project, o
                         className="bg-port-card border border-port-border rounded px-2 py-2 text-sm text-white placeholder-gray-600"
                       />
                     )}
-                  </label>
+                  </div>
                 </div>
 
                 {noVisionModels && (

--- a/client/src/components/digital-twin/tabs/AccountsTab.jsx
+++ b/client/src/components/digital-twin/tabs/AccountsTab.jsx
@@ -294,7 +294,7 @@ export default function AccountsTab() {
 
           {/* Platform selector */}
           <div>
-            <label className="block text-xs text-gray-500 mb-1">Platform</label>
+            <span className="block text-xs text-gray-500 mb-1">Platform</span>
             <div className="grid grid-cols-4 sm:grid-cols-7 gap-2">
               {platforms.filter(p => p.id !== 'other').map(platform => {
                 const Icon = PLATFORM_ICONS[platform.id] || Link;

--- a/client/src/components/goals/GoalEditForm.jsx
+++ b/client/src/components/goals/GoalEditForm.jsx
@@ -101,7 +101,7 @@ export default function GoalEditForm({
         />
       </FormField>
       <div>
-        <label className="text-xs text-gray-500">Time Block Config</label>
+        <span className="text-xs text-gray-500">Time Block Config</span>
         <div className="mt-1 space-y-2">
           <div>
             <span className="text-[10px] text-gray-600">Preferred days</span>
@@ -165,7 +165,7 @@ export default function GoalEditForm({
         </div>
       </div>
       <div>
-        <label className="text-xs text-gray-500">Tags</label>
+        <span className="text-xs text-gray-500">Tags</span>
         <div className="flex flex-wrap gap-1 mt-1 mb-2">
           {form.tags.map(tag => (
             <Pill key={tag} tone="bare" bordered={false} className="bg-port-accent/20 text-port-accent">
@@ -196,7 +196,7 @@ export default function GoalEditForm({
         </div>
       </div>
       <div>
-        <label id="feature-areas-label" className="text-xs text-gray-500">Daily Driver Feature Areas</label>
+        <span id="feature-areas-label" className="text-xs text-gray-500">Daily Driver Feature Areas</span>
         <p className="text-[10px] text-gray-600 mt-0.5">
           Pin which PortOS areas the Daily Driver deep-links to for this goal. Leave empty to use the category default.
         </p>

--- a/client/src/components/imageGen/InitImagePicker.jsx
+++ b/client/src/components/imageGen/InitImagePicker.jsx
@@ -33,12 +33,12 @@ export default function InitImagePicker({
     : backend === 'local' ? '(image-to-image — Flux only)' : '(image-to-image)';
   return (
     <div>
-      <label className="block text-xs font-medium text-gray-400 mb-1">
+      <span className="block text-xs font-medium text-gray-400 mb-1">
         {editOnly ? 'Source image' : 'Init image'}{' '}
         <span className={`font-normal ${editOnly ? 'text-port-warning' : 'text-gray-500'}`}>
           {subtitle}
         </span>
-      </label>
+      </span>
       {initImage.previewUrl ? (
         <div className="flex items-start gap-3">
           <div className="relative shrink-0">

--- a/client/src/components/imageGen/LoraPicker.jsx
+++ b/client/src/components/imageGen/LoraPicker.jsx
@@ -68,12 +68,12 @@ export default function LoraPicker({
   return (
     <div>
       <div className="flex items-center justify-between mb-1">
-        <label className="block text-xs font-medium text-gray-400">
+        <span className="block text-xs font-medium text-gray-400">
           LoRAs <span className="text-gray-600 font-normal">
             ({compatible.length}/{availableLoras.length} compatible
             {selected.length > 0 ? ` · ${selected.length}/${MAX_SELECTED_LORAS} selected` : ''})
           </span>
-        </label>
+        </span>
         <Link to="/media/loras" className="text-[11px] text-port-accent hover:underline">Manage →</Link>
       </div>
       {compatible.length === 0 ? (

--- a/client/src/components/imageGen/ReferenceImagePicker.jsx
+++ b/client/src/components/imageGen/ReferenceImagePicker.jsx
@@ -40,10 +40,10 @@ export default function ReferenceImagePicker({
 }) {
   return (
     <div>
-      <label className="block text-xs font-medium text-gray-400 mb-1">
+      <span className="block text-xs font-medium text-gray-400 mb-1">
         Reference images
         {caption ? <span className="text-gray-500 font-normal"> ({caption})</span> : null}
-      </label>
+      </span>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
         {referenceImages.map((slot, i) => {
           const slotId = `ref-image-${i}`;

--- a/client/src/components/meatspace/post/MemoryBuilder.jsx
+++ b/client/src/components/meatspace/post/MemoryBuilder.jsx
@@ -188,7 +188,7 @@ export default function MemoryBuilder({ onBack, onSelectItem, onReviewItem = onS
           </FormField>
 
           <div>
-            <label className="block text-gray-400 text-xs mb-1.5">Type</label>
+            <span className="block text-gray-400 text-xs mb-1.5">Type</span>
             <div className="flex flex-wrap gap-2">
               {ITEM_TYPES.map(t => (
                 <button

--- a/client/src/components/meatspace/tabs/LifestyleTab.jsx
+++ b/client/src/components/meatspace/tabs/LifestyleTab.jsx
@@ -95,7 +95,7 @@ export default function LifestyleTab() {
         </div>
         <div>
           <div className="flex items-center justify-between mb-2">
-            <label className="block text-xs text-gray-500 uppercase">Biological Sex</label>
+            <span className="block text-xs text-gray-500 uppercase">Biological Sex</span>
             {config?.sexSource && (
               <span className="text-[10px] text-gray-600 italic">
                 {config.sexSource === 'genome' ? 'auto-detected from genome' : `source: ${config.sexSource}`}

--- a/client/src/components/music/AlbumsManager.jsx
+++ b/client/src/components/music/AlbumsManager.jsx
@@ -16,6 +16,7 @@ import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import GalleryImagePicker from '../imageGen/GalleryImagePicker';
 import ConfirmButtonPair from '../ui/ConfirmButtonPair';
+import Field from '../ui/FormField';
 import useMediaJobProgress from '../../hooks/useMediaJobProgress';
 import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import { DEFAULT_NEGATIVE_PROMPT } from '../../lib/imageGenDefaults';
@@ -59,16 +60,6 @@ const buildCoverPrompt = (f) => {
   ].filter(Boolean);
   return bits.join(' ');
 };
-
-function Field({ label, hint, children }) {
-  return (
-    <label className="block">
-      <span className="block text-xs uppercase tracking-wider text-gray-500 mb-1">{label}</span>
-      {children}
-      {hint ? <span className="block text-[11px] text-gray-500 mt-1">{hint}</span> : null}
-    </label>
-  );
-}
 
 export default function AlbumsManager() {
   const navigate = useNavigate();
@@ -324,7 +315,7 @@ export default function AlbumsManager() {
                   )}
                 </div>
                 <div className="flex-1 space-y-2">
-                  <Field label="Title">
+                  <Field compact label="Title">
                     <input value={form.title} onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))} placeholder="Album title" maxLength={ALBUM_TITLE_MAX} className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white" autoFocus />
                   </Field>
                   <div className="flex items-center gap-2 flex-wrap">
@@ -338,22 +329,22 @@ export default function AlbumsManager() {
                 </div>
               </div>
 
-              <Field label="Artist">
+              <Field compact label="Artist">
                 <ArtistPicker id="album-artist" value={form.artistId} name={form.artist} onChange={(artistId, artist) => setForm((f) => ({ ...f, artistId, artist }))} />
               </Field>
               <div className="grid grid-cols-2 gap-3">
-                <Field label="Genre">
+                <Field compact label="Genre">
                   <input value={form.genre} onChange={(e) => setForm((f) => ({ ...f, genre: e.target.value }))} placeholder="dream pop" maxLength={ALBUM_GENRE_MAX} className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm" />
                 </Field>
-                <Field label="Release year">
+                <Field compact label="Release year">
                   <input type="number" value={form.releaseYear} onChange={(e) => setForm((f) => ({ ...f, releaseYear: e.target.value }))} placeholder="2026" min={ALBUM_RELEASE_YEAR_MIN} max={ALBUM_RELEASE_YEAR_MAX} className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm" />
                 </Field>
               </div>
-              <Field label="Description" hint="Liner notes / blurb.">
+              <Field compact label="Description" hint="Liner notes / blurb.">
                 <textarea value={form.description} onChange={(e) => setForm((f) => ({ ...f, description: e.target.value }))} rows={3} maxLength={ALBUM_DESCRIPTION_MAX} className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm" />
               </Field>
 
-              <Field label="Tracks" hint="Ordered — reorder with the arrows. Add from your existing tracks.">
+              <Field compact label="Tracks" hint="Ordered — reorder with the arrows. Add from your existing tracks.">
                 {form.trackIds.length === 0 ? (
                   <p className="text-xs text-gray-500">No tracks on this album yet.</p>
                 ) : (
@@ -375,6 +366,7 @@ export default function AlbumsManager() {
                 )}
                 {availableTracks.length > 0 ? (
                   <select
+                    aria-label="Add a track"
                     value=""
                     onChange={(e) => { if (e.target.value) addTrack(e.target.value); }}
                     className="mt-2 w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"

--- a/client/src/components/music/ArtistsManager.jsx
+++ b/client/src/components/music/ArtistsManager.jsx
@@ -14,6 +14,7 @@ import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import GalleryImagePicker from '../imageGen/GalleryImagePicker';
 import ConfirmButtonPair from '../ui/ConfirmButtonPair';
+import Field from '../ui/FormField';
 import useMediaJobProgress from '../../hooks/useMediaJobProgress';
 import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import { DEFAULT_NEGATIVE_PROMPT } from '../../lib/imageGenDefaults';
@@ -50,16 +51,6 @@ const buildPortraitPrompt = (f) => {
   const subject = desc ? `Music artist portrait. ${desc}` : 'Music artist promotional portrait.';
   return style ? `${subject} ${style}` : subject;
 };
-
-function Field({ label, hint, children }) {
-  return (
-    <label className="block">
-      <span className="block text-xs uppercase tracking-wider text-gray-500 mb-1">{label}</span>
-      {children}
-      {hint ? <span className="block text-[11px] text-gray-500 mt-1">{hint}</span> : null}
-    </label>
-  );
-}
 
 export default function ArtistsManager() {
   const navigate = useNavigate();
@@ -269,7 +260,7 @@ export default function ArtistsManager() {
             <div className="text-gray-500 text-sm">Select an artist to edit, or create a new one.</div>
           ) : (
             <div className="space-y-3">
-              <Field label="Name">
+              <Field compact label="Name">
                 <input
                   value={form.name}
                   onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
@@ -279,7 +270,7 @@ export default function ArtistsManager() {
                   autoFocus
                 />
               </Field>
-              <Field label="Genre" hint="Primary genre(s) — e.g. 'indie folk, dream pop'.">
+              <Field compact label="Genre" hint="Primary genre(s) — e.g. 'indie folk, dream pop'.">
                 <input
                   value={form.genre}
                   onChange={(e) => setForm((f) => ({ ...f, genre: e.target.value }))}
@@ -288,7 +279,7 @@ export default function ArtistsManager() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 />
               </Field>
-              <Field label="Musical style" hint="Voice / production / instrumentation notes — fed into music-gen prompts.">
+              <Field compact label="Musical style" hint="Voice / production / instrumentation notes — fed into music-gen prompts.">
                 <textarea
                   value={form.musicalStyle}
                   onChange={(e) => setForm((f) => ({ ...f, musicalStyle: e.target.value }))}
@@ -298,7 +289,7 @@ export default function ArtistsManager() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 />
               </Field>
-              <Field label="Bio" hint="About-the-artist blurb.">
+              <Field compact label="Bio" hint="About-the-artist blurb.">
                 <textarea
                   value={form.bio}
                   onChange={(e) => setForm((f) => ({ ...f, bio: e.target.value }))}
@@ -308,7 +299,7 @@ export default function ArtistsManager() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 />
               </Field>
-              <Field label="Physical description" hint="Subject of the portrait — appearance, age, expression, wardrobe.">
+              <Field compact label="Physical description" hint="Subject of the portrait — appearance, age, expression, wardrobe.">
                 <textarea
                   value={form.physicalDescription}
                   onChange={(e) => setForm((f) => ({ ...f, physicalDescription: e.target.value }))}
@@ -318,7 +309,7 @@ export default function ArtistsManager() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 />
               </Field>
-              <Field label="Portrait style" hint="Art / photography direction for the portrait render.">
+              <Field compact label="Portrait style" hint="Art / photography direction for the portrait render.">
                 <textarea
                   value={form.portraitStyle}
                   onChange={(e) => setForm((f) => ({ ...f, portraitStyle: e.target.value }))}
@@ -328,7 +319,7 @@ export default function ArtistsManager() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 />
               </Field>
-              <Field label="Portrait image" hint="Optional — generate from the description + style, choose or upload one via the gallery, or paste a URL.">
+              <Field compact label="Portrait image" hint="Optional — generate from the description + style, choose or upload one via the gallery, or paste a URL.">
                 <div className="flex items-start gap-3">
                   {isGenerating ? (
                     <div className="relative w-20 h-20 rounded border border-port-border bg-port-bg overflow-hidden flex items-center justify-center shrink-0">
@@ -393,6 +384,7 @@ export default function ArtistsManager() {
                       </button>
                     </div>
                     <input
+                      aria-label="Portrait image URL"
                       value={form.portraitImageUrl}
                       onChange={(e) => setPortrait(e.target.value)}
                       disabled={isGenerating}

--- a/client/src/components/music/TracksManager.jsx
+++ b/client/src/components/music/TracksManager.jsx
@@ -19,6 +19,7 @@ import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import FilePickerButton from '../ui/FilePickerButton';
 import ConfirmButtonPair from '../ui/ConfirmButtonPair';
+import Field from '../ui/FormField';
 import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import { formatBytes, formatTimecode } from '../../utils/formatters';
 import ArtistPicker from './ArtistPicker';
@@ -52,16 +53,6 @@ const formFromTrack = (t) => ({
   prompt: t.prompt || '',
   audioFilename: t.audioFilename || '',
 });
-
-function Field({ label, hint, children }) {
-  return (
-    <label className="block">
-      <span className="block text-xs uppercase tracking-wider text-gray-500 mb-1">{label}</span>
-      {children}
-      {hint ? <span className="block text-[11px] text-gray-500 mt-1">{hint}</span> : null}
-    </label>
-  );
-}
 
 export default function TracksManager() {
   const navigate = useNavigate();
@@ -432,7 +423,7 @@ export default function TracksManager() {
                   {openingDesigner ? 'Opening designer…' : (isCreate ? 'Save & design with AI' : 'Design with AI')}
                 </button>
               </div>
-              <Field label="Title">
+              <Field compact label="Title">
                 <input
                   value={form.title}
                   onChange={(e) => setForm((f) => ({ ...f, title: e.target.value }))}
@@ -442,7 +433,7 @@ export default function TracksManager() {
                   autoFocus
                 />
               </Field>
-              <Field label="Artist">
+              <Field compact label="Artist">
                 <ArtistPicker
                   id="track-artist"
                   value={form.artistId}
@@ -450,7 +441,7 @@ export default function TracksManager() {
                   onChange={(artistId, artist) => setForm((f) => ({ ...f, artistId, artist }))}
                 />
               </Field>
-              <Field label="Album" hint="Optional — none means a standalone single. Saving syncs the album's tracklist.">
+              <Field compact label="Album" hint="Optional — none means a standalone single. Saving syncs the album's tracklist.">
                 <select
                   id="track-album"
                   value={form.albumId}
@@ -466,7 +457,7 @@ export default function TracksManager() {
                   ) : null}
                 </select>
               </Field>
-              <Field label="Prompt" hint="Text/style prompt used by the on-device generators.">
+              <Field compact label="Prompt" hint="Text/style prompt used by the on-device generators.">
                 <textarea
                   value={form.prompt}
                   onChange={(e) => setForm((f) => ({ ...f, prompt: e.target.value }))}
@@ -476,7 +467,7 @@ export default function TracksManager() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 />
               </Field>
-              <Field label="Lyrics" hint="Full lyrics — also the conditioning text for lyric-aware generators (Ace-Step).">
+              <Field compact label="Lyrics" hint="Full lyrics — also the conditioning text for lyric-aware generators (Ace-Step).">
                 <textarea
                   value={form.lyrics}
                   onChange={(e) => setForm((f) => ({ ...f, lyrics: e.target.value }))}

--- a/client/src/components/pipeline/StoryShapes.jsx
+++ b/client/src/components/pipeline/StoryShapes.jsx
@@ -107,7 +107,7 @@ export function ArcShapeSparkline({ shape, width = 64, height = 24, className = 
 export function ArcShapePicker({ value, onChange, disabled = false }) {
   return (
     <div className="space-y-1.5">
-      <label className="text-[10px] uppercase tracking-wider text-gray-500">Story shape (Vonnegut)</label>
+      <span className="text-[10px] uppercase tracking-wider text-gray-500">Story shape (Vonnegut)</span>
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-1.5">
         {STORY_SHAPES.map((s) => {
           const selected = value === s.id;

--- a/client/src/components/pipeline/stages/TextStagePanel.jsx
+++ b/client/src/components/pipeline/stages/TextStagePanel.jsx
@@ -462,26 +462,31 @@ export default function TextStagePanel({
         </label>
       ) : null}
 
-      <label className="block">
-        <span className="block text-xs uppercase tracking-wider text-gray-500 mb-1">Output</span>
-        {proseEditor ? (
+      {proseEditor ? (
+        <div className="block">
+          <span className="block text-xs uppercase tracking-wider text-gray-500 mb-1">Output</span>
           <ProseEditor
             value={draftOutput}
             onChange={(e) => setDraftOutput(e.target.value)}
             placeholder={outputPlaceholder}
+            aria-label="Output"
             rows={24}
             className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
           />
-        ) : (
-          <textarea
-            value={draftOutput}
-            onChange={(e) => setDraftOutput(e.target.value)}
-            placeholder={outputPlaceholder}
-            rows={24}
-            className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm font-mono leading-relaxed"
-          />
-        )}
+        </div>
+      ) : (
+      <label htmlFor={`pipeline-stage-${stageId}-output`} className="block">
+        <span className="block text-xs uppercase tracking-wider text-gray-500 mb-1">Output</span>
+        <textarea
+          id={`pipeline-stage-${stageId}-output`}
+          value={draftOutput}
+          onChange={(e) => setDraftOutput(e.target.value)}
+          placeholder={outputPlaceholder}
+          rows={24}
+          className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm font-mono leading-relaxed"
+        />
       </label>
+      )}
 
       {stage.errorMessage ? (
         <div className="text-xs text-port-error">{stage.errorMessage}</div>

--- a/client/src/components/settings/MortalLoomTab.jsx
+++ b/client/src/components/settings/MortalLoomTab.jsx
@@ -113,7 +113,7 @@ const IMPORT_FAILURE_MESSAGES = {
         </div>
 
         <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-          <label className="text-sm text-gray-400">Enabled</label>
+          <span className="text-sm text-gray-400">Enabled</span>
           <ToggleSwitch
             enabled={enabled}
             onChange={() => setEnabled(!enabled)}

--- a/client/src/components/sharing/MergeModal.jsx
+++ b/client/src/components/sharing/MergeModal.jsx
@@ -51,7 +51,7 @@ export default function MergeModal({ merge, setMerge, onExecute, onRepreview, on
         <h2 className="text-lg font-semibold text-white flex items-center gap-2"><GitMerge size={18} /> Merge {kind}</h2>
 
         <div>
-          <label className="block text-xs text-gray-400 mb-1">Keep (survivor)</label>
+          <span className="block text-xs text-gray-400 mb-1">Keep (survivor)</span>
           <div className="grid gap-2">
             {records.map((r) => (
               <label key={r.id} className={`flex items-center gap-2 px-3 py-2 rounded border cursor-pointer text-sm ${r.id === survivorId ? 'border-port-accent bg-port-accent/10 text-white' : 'border-port-border text-gray-400'}`}>
@@ -65,7 +65,7 @@ export default function MergeModal({ merge, setMerge, onExecute, onRepreview, on
 
         {multi ? (
           <div>
-            <label className="block text-xs text-gray-400 mb-1">Fold in (this merge folds one copy at a time — repeat for the rest)</label>
+            <span className="block text-xs text-gray-400 mb-1">Fold in (this merge folds one copy at a time — repeat for the rest)</span>
             <div className="grid gap-2">
               {records.filter((r) => r.id !== survivorId).map((r) => (
                 <label key={r.id} className={`flex items-center gap-2 px-3 py-2 rounded border cursor-pointer text-sm ${r.id === loserId ? 'border-port-error/60 bg-port-error/10 text-white' : 'border-port-border text-gray-400'}`}>
@@ -84,7 +84,7 @@ export default function MergeModal({ merge, setMerge, onExecute, onRepreview, on
         {preview && conflicts.length > 0 && (
           <div>
             <div className="flex items-center justify-between mb-2 gap-2">
-              <label className="block text-xs text-gray-400">{conflicts.length} conflicting field(s) — pick which value wins:</label>
+              <span className="block text-xs text-gray-400">{conflicts.length} conflicting field(s) — pick which value wins:</span>
               {onAIMerge && aiEligible && (
                 <button
                   type="button"

--- a/client/src/components/songs/ReferenceAnalysis.jsx
+++ b/client/src/components/songs/ReferenceAnalysis.jsx
@@ -786,7 +786,7 @@ export default function ReferenceAnalysis({
                     <option value="">— Layer —</option>
                     {layers.map((l) => <option key={l.id} value={l.id}>{l.label}</option>)}
                   </select>
-                  <label className="flex items-center gap-1 text-xs text-gray-400">
+                  <div className="flex items-center gap-1 text-xs text-gray-400">
                     <span>from</span>
                     <SecondsInput
                       key={`start-${seg.startMs}`}
@@ -795,11 +795,11 @@ export default function ReferenceAnalysis({
                       ariaLabel="Segment start (seconds)"
                     />
                     <span>s</span>
-                  </label>
+                  </div>
                   <button type="button" onClick={() => updateSegment(idx, { startMs: currentMs() })} title="Set start from playhead" aria-label="Set segment start from playhead" className="p-1 text-gray-500 hover:text-port-accent">
                     <Flag size={14} />
                   </button>
-                  <label className="flex items-center gap-1 text-xs text-gray-400">
+                  <div className="flex items-center gap-1 text-xs text-gray-400">
                     <span>to</span>
                     <SecondsInput
                       key={`end-${seg.endMs}`}
@@ -808,7 +808,7 @@ export default function ReferenceAnalysis({
                       ariaLabel="Segment end (seconds)"
                     />
                     <span>s</span>
-                  </label>
+                  </div>
                   <button type="button" onClick={() => updateSegment(idx, { endMs: currentMs() })} title="Set end from playhead" aria-label="Set segment end from playhead" className="p-1 text-gray-500 hover:text-port-accent">
                     <FlagOff size={14} />
                   </button>
@@ -852,7 +852,7 @@ export default function ReferenceAnalysis({
                 {isStacked(seg) && (
                   <div className="flex flex-wrap items-center gap-2 pl-1 border-l-2 border-port-accent/40 ml-1">
                     <span className="flex items-center gap-1 text-xs text-port-accent"><Layers size={12} /> Backing ref</span>
-                    <label className="flex items-center gap-1 text-xs text-gray-400">
+                    <div className="flex items-center gap-1 text-xs text-gray-400">
                       <span>from</span>
                       <SecondsInput
                         key={`bg-start-${seg.bgStartMs}`}
@@ -861,11 +861,11 @@ export default function ReferenceAnalysis({
                         ariaLabel="Backing reference start (seconds)"
                       />
                       <span>s</span>
-                    </label>
+                    </div>
                     <button type="button" onClick={() => commitBacking(idx, 'bgStartMs', currentMs())} title="Set backing start from playhead" aria-label="Set backing start from playhead" className="p-1 text-gray-500 hover:text-port-accent">
                       <Flag size={14} />
                     </button>
-                    <label className="flex items-center gap-1 text-xs text-gray-400">
+                    <div className="flex items-center gap-1 text-xs text-gray-400">
                       <span>to</span>
                       <SecondsInput
                         key={`bg-end-${seg.bgEndMs}`}
@@ -874,7 +874,7 @@ export default function ReferenceAnalysis({
                         ariaLabel="Backing reference end (seconds)"
                       />
                       <span>s</span>
-                    </label>
+                    </div>
                     <button type="button" onClick={() => commitBacking(idx, 'bgEndMs', currentMs())} title="Set backing end from playhead" aria-label="Set backing end from playhead" className="p-1 text-gray-500 hover:text-port-accent">
                       <FlagOff size={14} />
                     </button>

--- a/client/src/components/ui/FormField.jsx
+++ b/client/src/components/ui/FormField.jsx
@@ -23,9 +23,10 @@ import { useId, Children, cloneElement, isValidElement } from 'react';
 export function FormField({
   label,
   hint,
-  children,
-  className = '',
+ children,
+ className = '',
   labelClassName = 'block text-sm text-gray-400 mb-1',
+  compact = false,
 }) {
   const generatedId = useId();
   // The label must point at whatever id the first control actually has: reuse
@@ -41,8 +42,8 @@ export function FormField({
   });
   return (
     <div className={className}>
-      {label != null && <label htmlFor={controlId} className={labelClassName}>{label}</label>}
-      {hint != null && <p className="text-xs text-gray-500 mb-1">{hint}</p>}
+      {label != null && <label htmlFor={controlId} className={compact ? 'block text-xs uppercase tracking-wider text-gray-500 mb-1' : labelClassName}>{label}</label>}
+      {hint != null && <p className={compact ? 'block text-[11px] text-gray-500 mt-1' : 'text-xs text-gray-500 mb-1'}>{hint}</p>}
       {augmented}
     </div>
   );

--- a/client/src/components/ui/README.md
+++ b/client/src/components/ui/README.md
@@ -17,7 +17,7 @@ accessibility). Feature-specific components live under their own feature directo
 | `CopyableId` | Click-to-copy record-id badge — short prefix shown, full id copied. |
 | `diffRuns` | Renders `{ text, changed }` runs from `diffWords` as highlighted nodes (shared by the diff views). |
 | `FilePickerButton` | Opens the OS file picker, styled as a button or as a whole drop target. |
-| `FormField` | Accessible config-field wrapper — generates an id and wires `<label htmlFor>` to the input. |
+| `FormField` | Accessible config-field wrapper — generates an id and wires `<label htmlFor>` to the input; `compact` preserves dense editor-label styling. |
 | `HunkDiff` | Hunked side-by-side diff for long texts, with unchanged runs collapsed. |
 | `ImageThumb` | List-card thumbnail with an icon fallback when the ref is missing or 404s. |
 | `InfoTooltip` | Focusable info/help tooltip — hover, keyboard focus, or tap; Esc to dismiss. |

--- a/client/src/components/universeBuilder/UniverseBibleTab.jsx
+++ b/client/src/components/universeBuilder/UniverseBibleTab.jsx
@@ -57,9 +57,9 @@ function StyleNegativePromptEditor({ influences, onChange, locked, onToggleLock 
   return (
     <div>
       <div className="mb-1">
-        <label className="text-xs text-gray-400">
+        <span className="text-xs text-gray-400">
           Style + Negative prompts <span className="text-gray-600">— prepended to every render; drag to reorder, click × to remove</span>
-        </label>
+        </span>
       </div>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
         <div>

--- a/client/src/components/writers-room/BibleSection.jsx
+++ b/client/src/components/writers-room/BibleSection.jsx
@@ -278,12 +278,12 @@ function BibleEditor({ workId, item, config, onSaved, onDeleted, onCancel }) {
         </button>
       </div>
       {fields.map((f) => (
-        <label key={f.key} className="block">
+        <label key={f.key} htmlFor={`bible-field-${f.key}`} className="block">
           <span className="text-[9px] uppercase tracking-wider text-gray-500">{f.label}</span>
           {f.kind === 'multiline' ? (
-            <textarea value={draft[f.key]} onChange={set(f.key)} placeholder={f.placeholder} rows={f.rows || 2} className={`${inputCls} font-sans resize-y`} />
+            <textarea id={`bible-field-${f.key}`} value={draft[f.key]} onChange={set(f.key)} placeholder={f.placeholder} rows={f.rows || 2} className={`${inputCls} font-sans resize-y`} />
           ) : (
-            <input value={draft[f.key]} onChange={set(f.key)} placeholder={f.placeholder} className={inputCls} />
+            <input id={`bible-field-${f.key}`} value={draft[f.key]} onChange={set(f.key)} placeholder={f.placeholder} className={inputCls} />
           )}
         </label>
       ))}

--- a/client/src/components/writers-room/ExercisePanel.jsx
+++ b/client/src/components/writers-room/ExercisePanel.jsx
@@ -129,7 +129,7 @@ export default function ExercisePanel({ activeWork, onClose }) {
       {!active && (
         <div className="px-3 py-3 space-y-3">
           <div>
-            <label className="block text-[10px] uppercase tracking-wider text-gray-500 mb-1">Duration</label>
+            <span className="block text-[10px] uppercase tracking-wider text-gray-500 mb-1">Duration</span>
             <div className="flex flex-wrap gap-1">
               {DURATION_PRESETS.map(({ label, seconds }) => (
                 <button

--- a/client/src/pages/Authors.jsx
+++ b/client/src/pages/Authors.jsx
@@ -16,6 +16,7 @@ import { FilePen, Plus, Loader2, Trash2, Save, ImageIcon, Sparkles, X } from 'lu
 import BrailleSpinner from '../components/BrailleSpinner';
 import toast from '../components/ui/Toast';
 import GalleryImagePicker from '../components/imageGen/GalleryImagePicker';
+import Field from '../components/ui/FormField';
 import useMediaJobProgress from '../hooks/useMediaJobProgress';
 import { DEFAULT_NEGATIVE_PROMPT } from '../lib/imageGenDefaults';
 import {
@@ -50,16 +51,6 @@ const buildHeadshotPrompt = (f) => {
   const subject = desc ? `Author headshot portrait. ${desc}` : 'Professional author headshot portrait.';
   return style ? `${subject} ${style}` : subject;
 };
-
-function Field({ label, hint, children }) {
-  return (
-    <label className="block">
-      <span className="block text-xs uppercase tracking-wider text-gray-500 mb-1">{label}</span>
-      {children}
-      {hint ? <span className="block text-[11px] text-gray-500 mt-1">{hint}</span> : null}
-    </label>
-  );
-}
 
 export default function Authors() {
   const navigate = useNavigate();
@@ -296,7 +287,7 @@ export default function Authors() {
             <div className="text-gray-500 text-sm">Select an author to edit, or create a new one.</div>
           ) : (
             <div className="space-y-3">
-              <Field label="Name">
+              <Field compact label="Name">
                 <input
                   value={form.name}
                   onChange={(e) => setForm((f) => ({ ...f, name: e.target.value }))}
@@ -306,7 +297,7 @@ export default function Authors() {
                   autoFocus
                 />
               </Field>
-              <Field label="Writing style" hint="Voice / tone / craft notes — fed into stage prompts.">
+              <Field compact label="Writing style" hint="Voice / tone / craft notes — fed into stage prompts.">
                 <textarea
                   value={form.writingStyle}
                   onChange={(e) => setForm((f) => ({ ...f, writingStyle: e.target.value }))}
@@ -316,7 +307,7 @@ export default function Authors() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 />
               </Field>
-              <Field label="Bio" hint="About-the-author blurb for the back cover.">
+              <Field compact label="Bio" hint="About-the-author blurb for the back cover.">
                 <textarea
                   value={form.bio}
                   onChange={(e) => setForm((f) => ({ ...f, bio: e.target.value }))}
@@ -326,7 +317,7 @@ export default function Authors() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 />
               </Field>
-              <Field label="Physical description" hint="Subject of the cover headshot — appearance, age, expression.">
+              <Field compact label="Physical description" hint="Subject of the cover headshot — appearance, age, expression.">
                 <textarea
                   value={form.physicalDescription}
                   onChange={(e) => setForm((f) => ({ ...f, physicalDescription: e.target.value }))}
@@ -336,7 +327,7 @@ export default function Authors() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 />
               </Field>
-              <Field label="Headshot style" hint="Art / photography direction for the headshot render.">
+              <Field compact label="Headshot style" hint="Art / photography direction for the headshot render.">
                 <textarea
                   value={form.headshotStyle}
                   onChange={(e) => setForm((f) => ({ ...f, headshotStyle: e.target.value }))}
@@ -346,7 +337,7 @@ export default function Authors() {
                   className="w-full px-3 py-2 bg-port-bg border border-port-border rounded text-white text-sm"
                 />
               </Field>
-              <Field label="Headshot image" hint="Optional — generate from the description + style, choose or upload one via the gallery, or paste a URL. Used on covers.">
+              <Field compact label="Headshot image" hint="Optional — generate from the description + style, choose or upload one via the gallery, or paste a URL. Used on covers.">
                 <div className="flex items-start gap-3">
                   {isGenerating ? (
                     <div className="relative w-20 h-20 rounded border border-port-border bg-port-bg overflow-hidden flex items-center justify-center shrink-0">
@@ -411,6 +402,7 @@ export default function Authors() {
                       </button>
                     </div>
                     <input
+                      aria-label="Headshot image URL"
                       value={form.headshotImageUrl}
                       onChange={(e) => setHeadshot(e.target.value)}
                       disabled={isGenerating}

--- a/client/src/pages/CreativeDirector.jsx
+++ b/client/src/pages/CreativeDirector.jsx
@@ -352,9 +352,10 @@ export default function CreativeDirector() {
             </div>
           )}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            <label className="block text-sm">
+            <label htmlFor="creative-director-name" className="block text-sm">
               <span className="text-port-text-muted">Name</span>
               <input
+                id="creative-director-name"
                 value={form.name}
                 onChange={(e) => setForm({ ...form, name: e.target.value })}
                 placeholder="My Episode"
@@ -362,7 +363,7 @@ export default function CreativeDirector() {
                 maxLength={200}
               />
             </label>
-            <label className="block text-sm">
+            <div className="block text-sm">
               <span className="text-port-text-muted">Model</span>
               <ModelSelect
                 models={models}
@@ -371,7 +372,7 @@ export default function CreativeDirector() {
                 getLabel={(m) => m.name || m.id}
                 className="w-full mt-1 bg-port-bg border border-port-border rounded px-2 py-1 text-sm"
               />
-            </label>
+            </div>
             <label className="block text-sm">
               <span className="text-port-text-muted">Aspect ratio</span>
               <select

--- a/client/src/pages/PipelineSeries.jsx
+++ b/client/src/pages/PipelineSeries.jsx
@@ -23,6 +23,7 @@ import AutopilotPanel from '../components/pipeline/AutopilotPanel';
 import SeriesReviewPanel from '../components/pipeline/SeriesReviewPanel';
 import CatalogCastPanel from '../components/CatalogCastPanel';
 import TabPills from '../components/ui/TabPills';
+import Field from '../components/ui/FormField';
 import {
   getPipelineSeries, updatePipelineSeries,
   listPipelineIssues,
@@ -335,7 +336,7 @@ function BibleSidebar({ series, universes, patchSeries, onSeriesUpdate, onFlushP
         </button>
       </div>
 
-      <Field label="Name">
+      <Field compact label="Name">
         <input
           value={series.name || ''}
           onChange={(e) => patchSeries({ name: e.target.value })}
@@ -343,14 +344,14 @@ function BibleSidebar({ series, universes, patchSeries, onSeriesUpdate, onFlushP
           maxLength={200}
         />
       </Field>
-      <Field label="Author (cover byline + title screen)">
+      <Field compact label="Author (cover byline + title screen)">
         <AuthorPicker
           value={series.authorId}
           byline={series.author}
           onChange={(authorId, name) => patchSeries({ authorId: authorId || null, author: name })}
         />
       </Field>
-      <Field label="Logline">
+      <Field compact label="Logline">
         <input
           value={series.logline || ''}
           onChange={(e) => patchSeries({ logline: e.target.value })}
@@ -359,9 +360,10 @@ function BibleSidebar({ series, universes, patchSeries, onSeriesUpdate, onFlushP
           maxLength={500}
         />
       </Field>
-      <Field label="Target issues / episodes">
+      <Field compact label="Target issues / episodes">
         <div className="flex items-center gap-3 flex-wrap">
           <input
+            aria-label="Target issues or episodes"
             type="number"
             min={0}
             max={999}
@@ -373,10 +375,11 @@ function BibleSidebar({ series, universes, patchSeries, onSeriesUpdate, onFlushP
         </div>
       </Field>
 
-      <Field label="Primary manuscript format (source of truth)">
+      <Field compact label="Primary manuscript format (source of truth)">
         <div className="flex items-center gap-2">
           <select
             id="series-primary-manuscript"
+            aria-label="Primary manuscript format"
             value={series.primaryManuscriptType || ''}
             onChange={async (e) => {
               const value = e.target.value || null;
@@ -405,7 +408,7 @@ function BibleSidebar({ series, universes, patchSeries, onSeriesUpdate, onFlushP
         </p>
       </Field>
 
-      <Field label="Premise (the bible — fed into every stage's prompt context)">
+      <Field compact label="Premise (the bible — fed into every stage's prompt context)">
         <textarea
           value={series.premise || ''}
           onChange={(e) => patchSeries({ premise: e.target.value })}
@@ -416,7 +419,7 @@ function BibleSidebar({ series, universes, patchSeries, onSeriesUpdate, onFlushP
         />
       </Field>
 
-      <Field label="Style notes (tonal / visual)">
+      <Field compact label="Style notes (tonal / visual)">
         <textarea
           value={series.styleNotes || ''}
           onChange={(e) => patchSeries({ styleNotes: e.target.value })}
@@ -466,9 +469,10 @@ function BibleSidebar({ series, universes, patchSeries, onSeriesUpdate, onFlushP
         </p>
       </div>
 
-      <Field label="Linked Universe">
+      <Field compact label="Linked Universe">
         <div className="flex items-center gap-2">
           <select
+            aria-label="Linked universe"
             value={series.universeId || ''}
             onChange={(e) => patchSeries({ universeId: e.target.value })}
             className="flex-1 px-3 py-2 bg-port-bg border border-port-border rounded text-white"
@@ -488,7 +492,7 @@ function BibleSidebar({ series, universes, patchSeries, onSeriesUpdate, onFlushP
         </div>
       </Field>
 
-      <Field label="Universe style override (this series only)">
+      <Field compact label="Universe style override (this series only)">
         <div className="mb-2">
           <TabPills
             variant="pills"
@@ -503,6 +507,7 @@ function BibleSidebar({ series, universes, patchSeries, onSeriesUpdate, onFlushP
           />
         </div>
         <textarea
+          aria-label="Universe style override"
           value={series.stylePromptOverride || ''}
           onChange={(e) => patchSeries({ stylePromptOverride: e.target.value })}
           rows={2}
@@ -515,7 +520,7 @@ function BibleSidebar({ series, universes, patchSeries, onSeriesUpdate, onFlushP
         </p>
       </Field>
 
-      <Field label="Render backend (this series only)">
+      <Field compact label="Render backend (this series only)">
         {/* Per-record render pin (#3231 Phase 3) — this series' default image
             backend + model for storyboards, comic pages, and covers. */}
         <RecordRenderPinRow
@@ -1047,15 +1052,6 @@ function SgSelect({ id, label, value, options, onChange }) {
         {options.map(([v, l]) => <option key={v} value={v}>{l}</option>)}
       </select>
     </div>
-  );
-}
-
-function Field({ label, children }) {
-  return (
-    <label className="block">
-      <span className="block text-xs uppercase tracking-wider text-gray-500 mb-1">{label}</span>
-      {children}
-    </label>
   );
 }
 

--- a/client/src/pages/PromptManager.jsx
+++ b/client/src/pages/PromptManager.jsx
@@ -680,7 +680,7 @@ export default function PromptManager() {
                   <div className="space-y-4 mb-4">
                     <div>
                       <div className="flex items-center gap-2 mb-2">
-                        <label className="text-sm text-gray-400">Model</label>
+                        <span className="text-sm text-gray-400">Model</span>
                         <div className="flex gap-1">
                           <button
                             onClick={() => setStageConfig({ ...stageConfig, provider: null, model: 'default' })}
@@ -733,7 +733,7 @@ export default function PromptManager() {
                       onCommit={(ms) => setStageConfig({ ...stageConfig, timeout: ms })}
                     />
                     <div>
-                      <label className="block text-sm text-gray-400 mb-1">Variables Used</label>
+                      <span className="block text-sm text-gray-400 mb-1">Variables Used</span>
                       <div className="text-sm text-gray-300">
                         {(stageConfig.variables || []).join(', ') || 'None'}
                       </div>
@@ -1089,7 +1089,7 @@ export default function PromptManager() {
               <div className="space-y-4">
                 <div>
                   <div className="flex items-center gap-2 mb-2">
-                    <label className="text-sm text-gray-400">Model</label>
+                    <span className="text-sm text-gray-400">Model</span>
                     <div className="flex gap-1">
                       <button
                         type="button"


### PR DESCRIPTION
## Summary

- Enable Biome's final staged accessibility rule for labels without controls.
- Replace group-heading labels with semantic text and connect real form controls to accessible names.
- Reuse the shared field wrapper for dense editors while preserving their label styling.

## Test plan

- `cd client && npm run lint`
- `cd client && npm test -- --run`
- `cd client && npm run build`

Closes #4158
