### PR TITLE
feat: pin LTX-specific conditioner candidate

### DIFF
--- a/.changelog/next/changed-issue-4470.md
+++ b/.changelog/next/changed-issue-4470.md
@@ -1,0 +1,1 @@
+- Pinned an LTX-specific Gemma 4 conditioner candidate while keeping it unavailable until the repeated-seed LTX-2.5 behavior gate passes.

--- a/docs/features/video-text-encoders.md
+++ b/docs/features/video-text-encoders.md
@@ -240,14 +240,13 @@ abliterated Gemma 4 12B a plausible drop-in. A different Gemma generation is not
 Gemma 3's tokenizer, vocabulary and layer count have no mapping onto the module
 tree mlx-lm's `gemma4` builds.
 
-### Status: initial substitutes failed; stock only
+### Status: initial substitutes failed; LTX-specific follow-up gated
 
-Two substitutes are declared in the registry (`ltx25-abliterated-4bit`,
-`ltx25-heretic-8bit`) and both carry `verified: false`, which keeps them out of
-the picker **and** out of the download lane — an unverified id is rejected by
-route validation and its weights cannot be pulled. The LTX-2.5 picker therefore
-hides itself today, exactly as it does for a runtime with no substitutes at all.
-The entries remain declared only as pinned failure records.
+The two initial substitutes (`ltx25-abliterated-4bit`,
+`ltx25-heretic-8bit`) carry `verified: false`, which keeps them out of the
+picker **and** out of the download lane — an unverified id is rejected by route
+validation and its weights cannot be pulled. The entries remain declared only
+as pinned failure records.
 
 The gate ran on the pinned production runtime with the same seed within each A/B,
 at 512x320, 33 frames, 24 fps, 8 guided steps plus 3 stage-two steps, and CFG 3.
@@ -264,6 +263,22 @@ difference alone is not the pass criterion. A future candidate must preserve
 benign structure **and** visibly improve at least one controlled challenge before
 its `verified` flag can be enabled. The repeated-seed candidate search is tracked
 in #4470.
+
+That search identified `nightmedia/gemma-4-12B-it-uncensored-heretic-mxfp8-mlx`
+at revision `20c9f4b167e56f3f749ea3e428188a5e7a35318a`. It is an exact MLX
+quantization of the Heretic language backbone named by DeepNeuralNerd's
+LTX-2.5-specific ComfyUI conversion. The ComfyUI artifact combines that
+backbone with LTX's own projections; PortOS already loads those projections and
+the connector from the pinned model pack, so the MLX candidate preserves the
+same separation rather than duplicating them inside the substitute.
+
+The candidate is pinned as `ltx25-ltx-heretic-mxfp8` with all three weight
+shards and support files (12,375,013,657 published bytes). Its index contains
+all 48 language layers, the embedding and final norm at the required 3840-wide /
+262144-vocabulary geometry, and eleven residual visual-only tensors handled by
+the existing exact-prefix sanitizer; MXFP8 metadata remains untouched. It stays
+`verified: false` until the production matrix confirms the behavioral gate, so
+LTX-2.5 remains stock-only while that evidence is incomplete.
 
 ## Related
 

--- a/docs/features/video-text-encoders.md
+++ b/docs/features/video-text-encoders.md
@@ -275,10 +275,23 @@ same separation rather than duplicating them inside the substitute.
 The candidate is pinned as `ltx25-ltx-heretic-mxfp8` with all three weight
 shards and support files (12,375,013,657 published bytes). Its index contains
 all 48 language layers, the embedding and final norm at the required 3840-wide /
-262144-vocabulary geometry, and eleven residual visual-only tensors handled by
-the existing exact-prefix sanitizer; MXFP8 metadata remains untouched. It stays
-`verified: false` until the production matrix confirms the behavioral gate, so
-LTX-2.5 remains stock-only while that evidence is incomplete.
+262144-vocabulary geometry, and ten residual visual-only tensors handled by
+the existing exact-prefix sanitizer; MXFP8 metadata remains untouched.
+
+The production technical preflight passed on 2026-08-17. The shim strict-loaded
+with zero missing and zero extra language tensors after removing exactly those
+ten visual tensors. Each of the four controlled prompts produced 49 finite
+hidden states shaped `[1, 1024, 3840]`; the pack's unchanged connector produced
+finite video inputs shaped `[1, 1024, 4096]` and audio inputs shaped
+`[1, 1024, 2048]`.
+
+That establishes loader and connector compatibility, but not the empirical
+behavior required by #4470. The complete stock/candidate matrix (four prompts,
+two fixed seeds, both conditioners) and its layerwise cosine/RMS comparison did
+not finish in this run, so there is no valid two-seed visual verdict. The entry
+therefore stays `verified: false`; LTX-2.5 remains stock-only until the full
+matrix proves benign object persistence and repeatable improvements on at least
+two of the three target-behavior prompts.
 
 ## Related
 

--- a/server/lib/videoTextEncoders.js
+++ b/server/lib/videoTextEncoders.js
@@ -89,7 +89,7 @@
  * vocabulary and layer count have no mapping onto the module tree mlx-lm's
  * `gemma4` builds.
  *
- * `verified` — COHERENCE GATE COMPLETED 2026-08-16 (#4320). Both candidates
+ * `verified` — COHERENCE GATE COMPLETED 2026-08-16 (#4320). Both initial candidates
  * strict-loaded and produced finite connector inputs on the pinned runtime,
  * then rendered a fixed-seed matrix at 512x320 / 33 frames / 24 fps / 8+3
  * steps / CFG 3: one benign motion prompt plus staged-bite, explicit-gesture
@@ -103,9 +103,19 @@
  * Both therefore remain `verified: false`, hidden from
  * `videoTextEncoderOptions` and the download lane (see
  * `isOfferedTextEncoder`). They stay declared as pinned failure records so a
- * later candidate search does not repeat either download or gate. LTX-2.5 is
- * stock-only until a substitute passes BOTH benign structural coherence and a
- * repeatable target-behavior improvement; that search continues in #4470.
+ * later candidate search does not repeat either download or gate.
+ *
+ * #4470 adds a third, still-gated candidate from the exact Heretic language
+ * backbone used by DeepNeuralNerd's LTX-2.5-specific ComfyUI conversion. That
+ * conversion keeps LTX's projection weights; PortOS already loads the pinned
+ * pack's connector separately, so the equivalent MLX artifact is the same
+ * language tower paired with that stock connector. Its three-shard MXFP8 export
+ * preserves all 48 language layers and the checkpoint's quantization metadata,
+ * while the existing narrow unified-checkpoint sanitizer removes only the
+ * eleven residual `vision_embedder.*` tensors. It remains unreachable until the
+ * repeated-seed render matrix passes. LTX-2.5 is stock-only until a substitute
+ * passes BOTH benign structural coherence and a repeatable target-behavior
+ * improvement.
  */
 
 import { ServerError } from './errorHandler.js';
@@ -219,9 +229,10 @@ const TEXT_ENCODERS_BY_RUNTIME = Object.freeze({
   // themselves. All of them are inputs to the shim the runner builds, and
   // `sizeBytes` is their exact published total.
   //
-  // Both substitutes failed the 2026-08-16 coherence/behavior gate described
-  // in the docblock. They remain declared as pinned provenance records, but
-  // `verified: false` keeps them out of the picker and download lane.
+  // The first two substitutes failed the 2026-08-16 coherence/behavior gate
+  // described in the docblock. The third is the LTX-specific follow-up being
+  // evaluated in #4470. All remain pinned provenance records, while
+  // `verified: false` keeps every non-passing entry out of both public lanes.
   ltx25: Object.freeze([
     STOCK_LTX25,
     Object.freeze({
@@ -294,6 +305,41 @@ const TEXT_ENCODERS_BY_RUNTIME = Object.freeze({
         modelCardUrl: 'https://huggingface.co/culturerevolt/gemma-4-12b-heretic-abliterated-8bit-mlx',
         weightsLicense: GEMMA_TERMS,
         reviewedAt: '2026-08-15',
+      }),
+    }),
+    Object.freeze({
+      id: 'ltx25-ltx-heretic-mxfp8',
+      label: 'LTX Heretic uncensored — Gemma 4 12B MXFP8',
+      description:
+        'The Heretic language backbone used by an LTX-2.5-specific conditioner conversion, '
+        + 'paired with the model pack\'s original LTX connector. Gated pending the repeated-seed render matrix.',
+      // #4470: the static gate passes (48 complete language layers, exact
+      // geometry, immutable MXFP8 metadata). Keep this false until the
+      // production render matrix proves benign coherence and repeatable gains.
+      verified: false,
+      repo: 'nightmedia/gemma-4-12B-it-uncensored-heretic-mxfp8-mlx',
+      revision: '20c9f4b167e56f3f749ea3e428188a5e7a35318a',
+      // Exact MLX quantization of llmfan46's Heretic backbone — the same source
+      // named by DeepNeuralNerd's LTX-2.5 conversion. The unified checkpoint
+      // carries eleven visual-only `vision_embedder.*` tensors; the runner's
+      // narrow sanitizer drops those while strict-loading every language key.
+      configOverrides: Object.freeze({ model_type: 'gemma4' }),
+      files: Object.freeze([
+        'config.json',
+        'generation_config.json',
+        'chat_template.jinja',
+        'model-00001-of-00003.safetensors',
+        'model-00002-of-00003.safetensors',
+        'model-00003-of-00003.safetensors',
+        'model.safetensors.index.json',
+        'tokenizer.json',
+        'tokenizer_config.json',
+      ]),
+      sizeBytes: 12375013657,
+      disclosure: Object.freeze({
+        modelCardUrl: 'https://huggingface.co/nightmedia/gemma-4-12B-it-uncensored-heretic-mxfp8-mlx',
+        weightsLicense: GEMMA_TERMS,
+        reviewedAt: '2026-08-17',
       }),
     }),
   ]),

--- a/server/lib/videoTextEncoders.js
+++ b/server/lib/videoTextEncoders.js
@@ -111,11 +111,14 @@
  * pack's connector separately, so the equivalent MLX artifact is the same
  * language tower paired with that stock connector. Its three-shard MXFP8 export
  * preserves all 48 language layers and the checkpoint's quantization metadata,
- * while the existing narrow unified-checkpoint sanitizer removes only the
- * eleven residual `vision_embedder.*` tensors. It remains unreachable until the
- * repeated-seed render matrix passes. LTX-2.5 is stock-only until a substitute
- * passes BOTH benign structural coherence and a repeatable target-behavior
- * improvement.
+ * while the existing narrow unified-checkpoint sanitizer removes only its
+ * residual `vision_embedder.*` tensors. The 2026-08-17 production preflight
+ * removed exactly ten such tensors, strict-loaded with zero missing or extra
+ * language keys, and produced finite connector inputs for all four controlled
+ * prompts. The full repeated-seed visual matrix did not complete, so this is
+ * technical compatibility evidence, not a behavioral pass. It remains
+ * unreachable until that matrix proves BOTH benign structural coherence and a
+ * repeatable target-behavior improvement.
  */
 
 import { ServerError } from './errorHandler.js';
@@ -313,15 +316,16 @@ const TEXT_ENCODERS_BY_RUNTIME = Object.freeze({
       description:
         'The Heretic language backbone used by an LTX-2.5-specific conditioner conversion, '
         + 'paired with the model pack\'s original LTX connector. Gated pending the repeated-seed render matrix.',
-      // #4470: the static gate passes (48 complete language layers, exact
-      // geometry, immutable MXFP8 metadata). Keep this false until the
-      // production render matrix proves benign coherence and repeatable gains.
+      // #4470: the production technical gate passes (strict language load,
+      // exact geometry, finite connector outputs, immutable MXFP8 metadata).
+      // Keep this false until the full repeated-seed render matrix proves
+      // benign coherence and repeatable behavior gains.
       verified: false,
       repo: 'nightmedia/gemma-4-12B-it-uncensored-heretic-mxfp8-mlx',
       revision: '20c9f4b167e56f3f749ea3e428188a5e7a35318a',
       // Exact MLX quantization of llmfan46's Heretic backbone — the same source
       // named by DeepNeuralNerd's LTX-2.5 conversion. The unified checkpoint
-      // carries eleven visual-only `vision_embedder.*` tensors; the runner's
+      // carries ten visual-only `vision_embedder.*` tensors; the runner's
       // narrow sanitizer drops those while strict-loading every language key.
       configOverrides: Object.freeze({ model_type: 'gemma4' }),
       files: Object.freeze([

--- a/server/lib/videoTextEncoders.test.js
+++ b/server/lib/videoTextEncoders.test.js
@@ -107,10 +107,10 @@ describe('videoTextEncoders', () => {
     expect(finalNormKey.startsWith('model.language_model.')).toBe(false);
   });
 
-  // The ltx25 substitutes are declared but not yet coherence-checked against
-  // the pack's connector (#4320 step 6), so they must be unreachable: not in
-  // the picker, not accepted by route validation, and not downloadable — an
-  // 11-13 GB pull for something no render can select is pure waste.
+  // Failed or not-yet-complete ltx25 gates remain unreachable: not in the
+  // picker, not accepted by route validation, and not downloadable. Declaring
+  // a pinned candidate is not permission to spend 11-13 GB on weights a render
+  // still cannot select.
   describe('unverified substitutes', () => {
     const UNVERIFIED = [
       'ltx25-abliterated-4bit',

--- a/server/lib/videoTextEncoders.test.js
+++ b/server/lib/videoTextEncoders.test.js
@@ -112,7 +112,11 @@ describe('videoTextEncoders', () => {
   // the picker, not accepted by route validation, and not downloadable — an
   // 11-13 GB pull for something no render can select is pure waste.
   describe('unverified substitutes', () => {
-    const UNVERIFIED = ['ltx25-abliterated-4bit', 'ltx25-heretic-8bit'];
+    const UNVERIFIED = [
+      'ltx25-abliterated-4bit',
+      'ltx25-heretic-8bit',
+      'ltx25-ltx-heretic-mxfp8',
+    ];
 
     it('offers ltx25 only its built-in conditioner', () => {
       expect(videoTextEncoderOptions(LTX25).map((option) => option.id)).toEqual([STOCK_TEXT_ENCODER_ID]);
@@ -186,6 +190,9 @@ describe('videoTextEncoders', () => {
         .find((entry) => entry.id === 'ltx25-abliterated-4bit').configOverrides).toBeUndefined();
       expect(declaredVideoTextEncoders()
         .find((entry) => entry.id === 'ltx25-heretic-8bit').configOverrides)
+        .toEqual({ model_type: 'gemma4' });
+      expect(declaredVideoTextEncoders()
+        .find((entry) => entry.id === 'ltx25-ltx-heretic-mxfp8').configOverrides)
         .toEqual({ model_type: 'gemma4' });
     });
   });

--- a/server/services/videoGen/local.test.js
+++ b/server/services/videoGen/local.test.js
@@ -1110,7 +1110,11 @@ describe('generateVideo — LTX-2.5 sibling runtime spawn', () => {
 
   // Every ltx25 substitute is still gated behind the coherence check, so the
   // route/service path must reject its id rather than half-wire a render.
-  it.each(['ltx25-abliterated-4bit', 'ltx25-heretic-8bit'])('rejects the unverified %s', async (textEncoderId) => {
+  it.each([
+    'ltx25-abliterated-4bit',
+    'ltx25-heretic-8bit',
+    'ltx25-ltx-heretic-mxfp8',
+  ])('rejects the unverified %s', async (textEncoderId) => {
     await expect(generateVideo({
       jobId: `ltx25-unverified-${textEncoderId}`,
       pythonPath: '/usr/bin/python3',


### PR DESCRIPTION
## Summary

- Pin `nightmedia/gemma-4-12B-it-uncensored-heretic-mxfp8-mlx` at its immutable revision as the LTX-specific follow-up candidate for #4470, including its exact nine-file manifest, published byte total, Gemma license disclosure, and Gemma 4 loader override.
- Keep the candidate `verified: false`, outside both the LTX-2.5 picker and Media Models download lane, until the required repeated-seed visual gate has a complete verdict.
- Record production preflight evidence: the exact-prefix sanitizer removed ten visual-only tensors, strict loading reported zero missing/extra language tensors, and all four controlled prompts produced finite 49-state hidden stacks plus finite video/audio connector inputs.
- Extend registry and service tests so the gated candidate cannot be selected, resolved, or downloaded prematurely.

## Test plan

- `python3 -m py_compile scripts/generate_ltx2.py`
- Focused Vitest selection: 5 files, 258 tests passed
- Production technical preflight on the pinned LTX-2.5 runtime: strict language load 0 missing / 0 extra; 49 finite `[1,1024,3840]` hidden states; finite `[1,1024,4096]` video and `[1,1024,2048]` audio connector inputs for all four controlled prompts
- `git diff --check`

## Remaining

- Complete the stock/candidate matrix at both fixed seeds for the benign, theatrical-bite, explicit-gesture, and prop-cigarette prompts, then inspect every A/B pair for object persistence and literal target behavior.
- Record valid layerwise cosine/RMS deltas for stock LTX versus the candidate (and the stock Gemma baseline where available).
- Set `verified: true` only if benign coherence holds on both seeds and at least two of three target behaviors improve over stock on both seeds; then rerun the exposed picker/download/repair/delete client and server paths.

Refs #4470
