### PR TITLE
ci: speed up targeted PR checks

### DIFF
--- a/.changelog/next/changed-ci-pr-speedup.md
+++ b/.changelog/next/changed-ci-pr-speedup.md
@@ -1,0 +1,1 @@
+- Speed up targeted CI by avoiding duplicate DB loads and narrowing Windows coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       build: ${{ steps.plan.outputs.build }}
       smoke: ${{ steps.plan.outputs.smoke }}
       windows: ${{ steps.plan.outputs.windows }}
+      windows_mode: ${{ steps.plan.outputs.windows_mode }}
+      windows_files: ${{ steps.plan.outputs.windows_files }}
       server_native: ${{ steps.plan.outputs.server_native }}
     steps:
       - uses: actions/checkout@v7
@@ -65,6 +67,7 @@ jobs:
           BUILD_MODE: ${{ steps.plan.outputs.build }}
           SMOKE_MODE: ${{ steps.plan.outputs.smoke }}
           WINDOWS_MODE: ${{ steps.plan.outputs.windows }}
+          WINDOWS_TEST_MODE: ${{ steps.plan.outputs.windows_mode }}
           SERVER_NATIVE: ${{ steps.plan.outputs.server_native }}
         run: |
           {
@@ -77,7 +80,7 @@ jobs:
             echo "- Client lint: \`${LINT_MODE}\`"
             echo "- Client build: \`${BUILD_MODE}\`"
             echo "- Server smoke: \`${SMOKE_MODE}\`"
-            echo "- Windows server tests: \`${WINDOWS_MODE}\`"
+            echo "- Windows server tests: \`${WINDOWS_MODE}\` (\`${WINDOWS_TEST_MODE}\`)"
             echo "- Server native rebuild: \`${SERVER_NATIVE}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -323,8 +326,8 @@ jobs:
 
       - name: Run server tests on Windows
         env:
-          CI_TEST_MODE: ${{ needs.impact.outputs.server_mode }}
-          CI_TEST_FILES: ${{ needs.impact.outputs.server_files }}
+          CI_TEST_MODE: ${{ needs.impact.outputs.windows_mode }}
+          CI_TEST_FILES: ${{ needs.impact.outputs.windows_files }}
           CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: node scripts/run-ci-tests.js server
 
@@ -360,4 +363,3 @@ jobs:
             }
             console.log("CI gate passed:", results);
           '
-

--- a/client/src/test/setup.js
+++ b/client/src/test/setup.js
@@ -20,7 +20,7 @@ installTestStorage();
 // and the resulting unhandled error fails the whole run despite passing assertions
 // (#2958). Stub it once, guarded so it never clobbers a real implementation — on real
 // DOM elements scrollIntoView is always present, so production is unaffected.
-if (!Element.prototype.scrollIntoView) {
+if (typeof Element !== 'undefined' && !Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = () => {};
 }
 

--- a/client/src/utils/animationClips.test.js
+++ b/client/src/utils/animationClips.test.js
@@ -53,3 +53,4 @@ describe('withInPlaceClips', () => {
     expect(original.tracks.length).toBe(before);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/characterXp.test.js
+++ b/client/src/utils/characterXp.test.js
@@ -189,3 +189,4 @@ describe('diffXp', () => {
     expect(d.leveledUp).toBe(false);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityActivityHeatmap.test.js
+++ b/client/src/utils/cityActivityHeatmap.test.js
@@ -140,3 +140,4 @@ describe('computeActivityHeatmap', () => {
     expect(vm.tiles.every((t) => t.z === 0)).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityArtifacts.test.js
+++ b/client/src/utils/cityArtifacts.test.js
@@ -184,3 +184,4 @@ describe('computeArtifacts', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityDistrictLayout.test.js
+++ b/client/src/utils/cityDistrictLayout.test.js
@@ -128,3 +128,4 @@ describe('scaleMetricToHeight', () => {
     expect(scaleMetricToHeight(0, { min: 2, base: 0 })).toBe(2);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityEasterEggs.test.js
+++ b/client/src/utils/cityEasterEggs.test.js
@@ -132,3 +132,4 @@ describe('computeEasterEggs', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityFederation.test.js
+++ b/client/src/utils/cityFederation.test.js
@@ -112,3 +112,4 @@ describe('computeFederationHorizon', () => {
     expect(placed.map(p => p.id)).toEqual(['a', 'b']);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityFilter.test.js
+++ b/client/src/utils/cityFilter.test.js
@@ -38,3 +38,4 @@ describe('computeFilterResult', () => {
     expect(dimmed.has('a')).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityFlowLines.test.js
+++ b/client/src/utils/cityFlowLines.test.js
@@ -87,3 +87,4 @@ describe('computeFlowConnections', () => {
     expect(conns[0].end).toEqual([2, 0.5, 0]);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityFocusState.test.js
+++ b/client/src/utils/cityFocusState.test.js
@@ -42,3 +42,4 @@ describe('resolveCityFocus', () => {
     });
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityGoalMonuments.test.js
+++ b/client/src/utils/cityGoalMonuments.test.js
@@ -445,3 +445,4 @@ describe('computeGoalForest', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityJiraDistrict.test.js
+++ b/client/src/utils/cityJiraDistrict.test.js
@@ -130,3 +130,4 @@ describe('computeJiraDistrict', () => {
     expect(d.structures[0].summary).toBe('P-9');
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityMemoryDistrict.test.js
+++ b/client/src/utils/cityMemoryDistrict.test.js
@@ -169,3 +169,4 @@ describe('computeMemoryDistrict', () => {
     expect(d.bridges.every(b => b.fromPos && b.toPos)).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityPhotoMode.test.js
+++ b/client/src/utils/cityPhotoMode.test.js
@@ -177,3 +177,4 @@ describe('getDofParams', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityPlan.test.js
+++ b/client/src/utils/cityPlan.test.js
@@ -199,3 +199,4 @@ describe('computeStreetProps', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityPlayerRig.test.js
+++ b/client/src/utils/cityPlayerRig.test.js
@@ -144,3 +144,4 @@ describe('bankAngle', () => {
     expect(bankAngle(0)).toBeCloseTo(0, 10);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityProductivity.test.js
+++ b/client/src/utils/cityProductivity.test.js
@@ -132,3 +132,4 @@ describe('computeProductivityMonument', () => {
     expect(vm.longest).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityRooftops.test.js
+++ b/client/src/utils/cityRooftops.test.js
@@ -48,3 +48,4 @@ describe('computeRooftopKit', () => {
     expect(() => computeRooftopKit('')).not.toThrow();
   });
 });
+// @vitest-environment node

--- a/client/src/utils/citySoundscape.test.js
+++ b/client/src/utils/citySoundscape.test.js
@@ -142,3 +142,4 @@ describe('applyMoodOverride', () => {
     expect(applyMoodOverride(null, null)).toBe(null);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityTaskQueue.test.js
+++ b/client/src/utils/cityTaskQueue.test.js
@@ -125,3 +125,4 @@ describe('computeTaskQueue', () => {
     expect(vm.state).toBe('queued');
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityVoiceMarker.test.js
+++ b/client/src/utils/cityVoiceMarker.test.js
@@ -117,3 +117,4 @@ describe('computeVoiceMarker', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cronHelpers.test.js
+++ b/client/src/utils/cronHelpers.test.js
@@ -82,3 +82,4 @@ describe('WEEKDAYS', () => {
     expect(WEEKDAYS[0].label).toBe('Sun');
   });
 });
+// @vitest-environment node

--- a/client/src/utils/index.test.js
+++ b/client/src/utils/index.test.js
@@ -51,3 +51,4 @@ describe('client/src/utils/ barrel', () => {
     expect(collisions, `colliding exports would silently shadow under the barrel:\n${collisions.join('\n')}`).toEqual([]);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/layeredIntelligenceReasons.test.js
+++ b/client/src/utils/layeredIntelligenceReasons.test.js
@@ -46,3 +46,4 @@ describe('liReasonTone', () => {
     expect(liReasonTone(null)).toBe('warn');
   });
 });
+// @vitest-environment node

--- a/client/src/utils/lazyWithReload.test.js
+++ b/client/src/utils/lazyWithReload.test.js
@@ -38,3 +38,4 @@ describe('importWithRetry', () => {
     vi.useRealTimers();
   });
 });
+// @vitest-environment node

--- a/client/src/utils/modelFit.test.js
+++ b/client/src/utils/modelFit.test.js
@@ -113,3 +113,4 @@ describe('fitModelToHeight', () => {
     });
   });
 });
+// @vitest-environment node

--- a/client/src/utils/sleep.test.js
+++ b/client/src/utils/sleep.test.js
@@ -23,3 +23,4 @@ describe('sleep', () => {
     await expect(sleep(0)).resolves.toBeUndefined();
   });
 });
+// @vitest-environment node

--- a/client/src/utils/timezone.test.js
+++ b/client/src/utils/timezone.test.js
@@ -66,3 +66,4 @@ describe('isValidTimezone', () => {
     expect(isValidTimezone(undefined)).toBe(false);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/urlNormalize.test.js
+++ b/client/src/utils/urlNormalize.test.js
@@ -147,3 +147,4 @@ describe('normalizeUrl', () => {
       expect(linksTabNormalize('git@host:repo')).toBe('git@host:repo'));
   });
 });
+// @vitest-environment node

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -25,7 +25,7 @@ const FULL_TRIGGER_RULES = [
   { re: /^client\/vite\.config\.js$/, reason: 'client build configuration changed' },
   { re: /^server\/index\.js$/, reason: 'server composition root changed' },
   { re: /^client\/src\/App\.jsx$/, reason: 'client composition root changed' },
-  { re: /^server\/lib\/(?:index|schemaVersions|validation)\.js$/, reason: 'shared server contract changed' },
+  { re: /^server\/lib\/(?:schemaVersions|validation)\.js$/, reason: 'shared server contract changed' },
   { re: /^scripts\/ci-test-plan(?:\.test)?\.js$/, reason: 'CI impact planner changed' },
   { re: /^scripts\/run-ci-(?:lint|tests)(?:\.test)?\.js$/, reason: 'CI runner changed' },
 ];
@@ -45,6 +45,50 @@ const WINDOWS_RISK_RULES = [
   /^server\/services\/autonomousJobs\/execution\.shellSpawn/,
   /^server\/routes\/apps\//,
   /^server\/routes\/scaffoldVite\.js$/,
+];
+
+// These are the cross-platform contracts that cannot be faithfully simulated
+// by pinning process.platform on Linux. For a Windows-risk PR, Vitest also
+// adds import-graph-related tests for the diff; this stable baseline catches
+// spawn, shell, PowerShell, PTY, and path regressions without rerunning every
+// platform-independent server assertion. Full CI still runs the entire suite.
+export const WINDOWS_CONTRACT_TESTS = [
+  'scripts/ps1-bom.test.js',
+  'server/cos-runner/allowedCommands.parity.test.js',
+  'server/cos-runner/allowedCommands.test.js',
+  'server/cos-runner/index.test.js',
+  'server/cos-runner/processStats.test.js',
+  'server/cos-runner/runnerState.test.js',
+  'server/cos-runner/streamJsonParser.test.js',
+  'server/lib/agentGuard/index.test.js',
+  'server/lib/bashResolver.test.js',
+  'server/lib/bufferedSpawn.test.js',
+  'server/lib/childProcess.guards.test.js',
+  'server/lib/childProcess.promisify.test.js',
+  'server/lib/childProcess.test.js',
+  'server/lib/cliProviderRun.test.js',
+  'server/lib/detachedSpawn.test.js',
+  'server/lib/grok.test.js',
+  'server/lib/grokVideoClip.test.js',
+  'server/lib/platform.test.js',
+  'server/lib/processEnv.spawnOptions.test.js',
+  'server/lib/processEnv.test.js',
+  'server/lib/spawnCwd.test.js',
+  'server/routes/apps/crud.test.js',
+  'server/routes/apps/icons.test.js',
+  'server/routes/apps/issues.test.js',
+  'server/routes/apps/launch.test.js',
+  'server/routes/apps/lifecycle.test.js',
+  'server/routes/apps/taskTypes.test.js',
+  'server/routes/apps/viteTls.test.js',
+  'server/routes/apps/xcode.test.js',
+  'server/services/appBuilder.test.js',
+  'server/services/autonomousJobs/execution.shellSpawn.test.js',
+  'server/services/pm2.launch.test.js',
+  'server/services/pm2.parseJlist.test.js',
+  'server/services/pm2Standardizer.test.js',
+  'server/services/shell.test.js',
+  'server/services/shellImageDrop.test.js',
 ];
 
 // Contract guards that run on EVERY plan, whatever the impact scope selects.
@@ -197,6 +241,7 @@ const uniqueSorted = (values) => [...new Set(values)].sort();
 // Guarded by trackedSet like every other selector: an untracked path handed to
 // Vitest as an exact selector makes the run exit non-zero.
 const alwaysRunTests = (trackedSet) => ALWAYS_RUN_TESTS.filter((path) => trackedSet.has(path));
+const windowsContractTests = (trackedSet) => WINDOWS_CONTRACT_TESTS.filter((path) => trackedSet.has(path));
 
 const skippedRunner = () => ({ mode: 'skip', files: [] });
 
@@ -224,6 +269,8 @@ export function buildCiTestPlan(changedFiles, { trackedFiles = [], forceFull = f
       build: true,
       smoke: true,
       windows: true,
+      windowsMode: 'full',
+      windowsFiles: [],
       serverNative: true,
     };
   }
@@ -253,6 +300,8 @@ export function buildCiTestPlan(changedFiles, { trackedFiles = [], forceFull = f
       build: false,
       smoke: false,
       windows: false,
+      windowsMode: 'skip',
+      windowsFiles: [],
       serverNative: false,
     };
   }
@@ -315,6 +364,8 @@ export function buildCiTestPlan(changedFiles, { trackedFiles = [], forceFull = f
       ? { mode: 'related', files: [] }
       : skippedRunner();
 
+  const windows = executable.some((path) => WINDOWS_RISK_RULES.some((rule) => rule.test(path)));
+
   return {
     full: false,
     reason: features.length
@@ -332,7 +383,9 @@ export function buildCiTestPlan(changedFiles, { trackedFiles = [], forceFull = f
     },
     build: hasClientSource,
     smoke: hasServerSource,
-    windows: executable.some((path) => WINDOWS_RISK_RULES.some((rule) => rule.test(path))),
+    windows,
+    windowsMode: windows ? 'related' : 'skip',
+    windowsFiles: windows ? windowsContractTests(trackedSet) : [],
     serverNative: needsServerNative(server),
   };
 }
@@ -355,6 +408,8 @@ function fullPlan(changedFiles, reason) {
     build: true,
     smoke: true,
     windows: true,
+    windowsMode: 'full',
+    windowsFiles: [],
     serverNative: true,
   };
 }
@@ -384,6 +439,8 @@ export function emitGitHubPlan(plan) {
     build: plan.build,
     smoke: plan.smoke,
     windows: plan.windows,
+    windows_mode: plan.windowsMode,
+    windows_files: JSON.stringify(plan.windowsFiles),
     server_native: plan.serverNative,
   };
 

--- a/scripts/ci-test-plan.test.js
+++ b/scripts/ci-test-plan.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildCiTestPlan } from './ci-test-plan.js';
+import { buildCiTestPlan, WINDOWS_CONTRACT_TESTS } from './ci-test-plan.js';
 
 const TRACKED = [
   'server/lib/index.test.js',
@@ -13,6 +13,8 @@ const TRACKED = [
   'server/services/sprites/atlasGrid.test.js',
   'server/services/sprites/atlasLayout.test.js',
   'server/services/taskPromptDefaults.test.js',
+  'server/lib/bufferedSpawn.test.js',
+  'server/lib/platform.test.js',
   'client/src/a11yConventions.test.js',
   'client/src/hooks/mountedRefConventions.test.js',
   'client/src/components/catalog/CatalogCard.jsx',
@@ -100,6 +102,16 @@ describe('CI test impact planner', () => {
       expect(plan.client.mode, path).toBe('full');
       expect(plan.db, path).toBe(true);
     }
+  });
+
+  it('uses related server coverage, not every CI surface, for a server barrel edit', () => {
+    const plan = buildCiTestPlan(['server/lib/index.js'], { trackedFiles: TRACKED });
+
+    expect(plan.full).toBe(false);
+    expect(plan.server.mode).toBe('related');
+    expect(plan.client.mode).toBe('skip');
+    expect(plan.db).toBe(false);
+    expect(plan.windows).toBe(false);
   });
 
   it('does not treat a source .grit or a mistyped biome.json as lint configuration', () => {
@@ -291,11 +303,34 @@ describe('CI test impact planner', () => {
     ], { trackedFiles: TRACKED });
     expect(spawn.full).toBe(false);
     expect(spawn.windows).toBe(true);
+    expect(spawn.windowsMode).toBe('related');
+    expect(spawn.windowsFiles).toEqual([
+      'server/lib/bufferedSpawn.test.js',
+      'server/lib/platform.test.js',
+    ]);
 
     const winHelper = buildCiTestPlan([
       'scripts/fix-windows-console.js',
     ], { trackedFiles: TRACKED });
     expect(winHelper.full).toBe(false);
     expect(winHelper.windows).toBe(true);
+  });
+
+  it('keeps the complete Windows suite for an explicit full-CI request', () => {
+    const plan = buildCiTestPlan(['server/lib/bufferedSpawn.js'], {
+      trackedFiles: TRACKED,
+      forceFull: true,
+    });
+
+    expect(plan.windowsMode).toBe('full');
+    expect(plan.windowsFiles).toEqual([]);
+  });
+
+  it('only names tracked Windows contract tests', () => {
+    const plan = buildCiTestPlan(['server/lib/bufferedSpawn.js'], {
+      trackedFiles: TRACKED,
+    });
+
+    expect(plan.windowsFiles.every((path) => WINDOWS_CONTRACT_TESTS.includes(path))).toBe(true);
   });
 });

--- a/server/vitest.config.js
+++ b/server/vitest.config.js
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import { vitestCiPool } from '../scripts/vitestCiPool.js';
+import { DB_TEST_INCLUDE } from './vitest.config.db.js';
 
 // `npm run test:fast` is the Windows-safe way to set the flag (a
 // `VITEST_FAST=1 vitest` script is parsed as an executable name on cmd.exe).
@@ -49,6 +50,12 @@ export default defineConfig({
     // The slashdo submodule ships its own node:test suites; vitest can't
     // parse them and the broad `../lib/**` glob would otherwise pick them up
     // as "no test suite found" failures that break --bail=1 CI runs.
+    // DB-backed suites run only in `vitest.config.db.js`, against portos_test.
+    // Keeping them in this file made ordinary Linux and Windows jobs import 29
+    // files solely to skip their 275 assertions when no test DB was configured.
+    // The DB job is the authoritative runner, so excluding the same canonical
+    // list here removes duplicate setup without reducing coverage.
+    //
     // Heavy disk/git/Sharp integration suites. `npm run test:fast`
     // (VITEST_FAST=1) drops them so a unit-only loop stays cheap; `npm test`
     // and CI keep the full run. The git-guard files are NOT listed here —
@@ -57,6 +64,7 @@ export default defineConfig({
     exclude: [
       '**/node_modules/**',
       '../lib/slashdo/**',
+      ...DB_TEST_INCLUDE,
       ...(process.env.VITEST_FAST ? [
         'services/worktreeReap.test.js',
         'services/sprites/atlas.test.js',


### PR DESCRIPTION
## Summary
- run pure client utility suites in Node instead of jsdom
- exclude DB-only suites from normal server jobs; retain the dedicated test-database job
- run a Windows platform-contract baseline plus related tests for Windows-risk PRs, while full CI remains comprehensive

## Test plan
- `npm run build --prefix client`
- `CI=1 npm test --prefix server -- scripts/ci-test-plan.test.js lib/db.guards.test.js`
- `npm test --prefix client -- <29 Node utility suites>`