### PR TITLE
ci: run pure client tests in node

### DIFF
--- a/.changelog/next/changed-ci-node-test-expansion.md
+++ b/.changelog/next/changed-ci-node-test-expansion.md
@@ -1,0 +1,1 @@
+- Run browser-independent client tests in Node to reduce PR CI setup time

--- a/client/src/lib/a11yKeyboard.test.js
+++ b/client/src/lib/a11yKeyboard.test.js
@@ -92,3 +92,4 @@ describe('clickableProps', () => {
     expect(handler).toHaveBeenCalledTimes(1);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/applyManuscriptEdits.test.js
+++ b/client/src/lib/applyManuscriptEdits.test.js
@@ -72,3 +72,4 @@ describe('planManuscriptEdits', () => {
     expect(plan).toMatchObject({ applied: 2, notFound: 0, overlapping: 0 });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/autopilotMilestones.test.js
+++ b/client/src/lib/autopilotMilestones.test.js
@@ -175,3 +175,4 @@ describe('autopilotMarkerTerminal (#4140)', () => {
     expect(statuses(rows).foundationGate).toBe(MILESTONE_STATUS.BLOCKED);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/brainGraphFocus.test.js
+++ b/client/src/lib/brainGraphFocus.test.js
@@ -54,3 +54,4 @@ describe('currentFocusId', () => {
     expect(currentFocusId([{ id: 'a', label: 'A' }, { id: 'b', label: 'B' }])).toBe('b');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/chordPlayback.test.js
+++ b/client/src/lib/chordPlayback.test.js
@@ -172,3 +172,4 @@ describe('resolveChordPlayhead', () => {
     expect(resolveChordPlayhead(null, 1)).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/chordPlayer.test.js
+++ b/client/src/lib/chordPlayer.test.js
@@ -150,3 +150,4 @@ describe('createChordPlayer', () => {
     expect(ended).toHaveBeenCalled();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/cleanPlatePrompt.test.js
+++ b/client/src/lib/cleanPlatePrompt.test.js
@@ -81,3 +81,4 @@ describe('composeCleanPlatePrompt', () => {
     expect(out.prompt).toContain('a rooftop helipad');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/clinicianReport.test.js
+++ b/client/src/lib/clinicianReport.test.js
@@ -150,3 +150,4 @@ describe('buildClinicianReport + reportToMarkdown', () => {
     expect(conditionRow.match(/(?<!\\)\|/g)).toHaveLength(4);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/compareHelpers.test.js
+++ b/client/src/lib/compareHelpers.test.js
@@ -108,3 +108,4 @@ describe('equalListByKeys', () => {
     expect(equalListByKeys([], [], ['id'])).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/composeStyledPrompt.test.js
+++ b/client/src/lib/composeStyledPrompt.test.js
@@ -56,3 +56,4 @@ describe('composeCanonStyledPrompt', () => {
     expect(out).toEqual({ prompt: 'Vale: detective', negativePrompt: 'lowres' });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/cosTaskType.test.js
+++ b/client/src/lib/cosTaskType.test.js
@@ -59,3 +59,4 @@ describe('extractCosTaskType', () => {
       .toBe(EXTERNAL_UNTYPED_TASK_TYPE);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/diffLines.test.js
+++ b/client/src/lib/diffLines.test.js
@@ -91,3 +91,4 @@ describe('diffLineBlocks', () => {
     expect(LINE_DIFF_CELL_CAP).toBe(4_000_000);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/diffWords.test.js
+++ b/client/src/lib/diffWords.test.js
@@ -68,3 +68,4 @@ describe('diffWords', () => {
     expect(DIFF_CELL_CAP).toBe(4_000_000);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/dndTransform.test.js
+++ b/client/src/lib/dndTransform.test.js
@@ -27,3 +27,4 @@ describe('dndTransformToCss', () => {
     expect(dndTransformToCss(undefined)).toBeUndefined();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/editorialHealth.test.js
+++ b/client/src/lib/editorialHealth.test.js
@@ -227,3 +227,4 @@ describe('snapshotDiff', () => {
     expect(snapshotDiff(noChecks, prev).bySeverity.length).toBeGreaterThan(0);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/editorialRoadmap.test.js
+++ b/client/src/lib/editorialRoadmap.test.js
@@ -49,3 +49,4 @@ describe('projectAnalyzedPoints', () => {
     expect(projectAnalyzedPoints()).toEqual([]);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/healthProvenance.test.js
+++ b/client/src/lib/healthProvenance.test.js
@@ -50,3 +50,4 @@ describe('healthProvenance', () => {
     expect(getProvenanceLevel(42)).toBe(PROVENANCE_LEVELS.inferred);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/importerDeepLink.test.js
+++ b/client/src/lib/importerDeepLink.test.js
@@ -67,3 +67,4 @@ describe('resolveImporterDeepLink', () => {
     expect(resolveImporterDeepLink({ universes, series })).toEqual({ universeName: '', seriesName: '' });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/index.test.js
+++ b/client/src/lib/index.test.js
@@ -27,3 +27,4 @@ describe('client/src/lib/ barrel', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/lib/kanbanColumns.test.js
+++ b/client/src/lib/kanbanColumns.test.js
@@ -115,3 +115,4 @@ describe('columnConfig', () => {
     expect(columnConfig({ name: 'Mystery', category: 'Weird' }).dot).toBe('bg-port-accent');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/letteringDensity.test.js
+++ b/client/src/lib/letteringDensity.test.js
@@ -47,3 +47,4 @@ describe('letteringDensity (client mirror)', () => {
     expect(analyzeComicLettering([{ panels: [{ dialogue: [balloon('A', 8)], caption: 'A beat.' }] }])).toEqual([]);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/localLlmTargetKey.test.js
+++ b/client/src/lib/localLlmTargetKey.test.js
@@ -23,3 +23,4 @@ describe('localLlmTargetKey', () => {
     expect(targets.map(localLlmTargetKey)).toEqual(['ollama\nm1', 'lmstudio\nm2']);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/lossSparkline.test.js
+++ b/client/src/lib/lossSparkline.test.js
@@ -50,3 +50,4 @@ describe('lossSparklineGeometry', () => {
     expect(lossSparklineGeometry(undefined)).toMatchObject({ points: '', last: null });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/manuscriptAnchors.test.js
+++ b/client/src/lib/manuscriptAnchors.test.js
@@ -96,3 +96,4 @@ describe('buildHighlightSegments', () => {
     expect(segs[0]).toEqual({ text: 'ab', commentIds: ['x'], topSeverity: 'low' });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/manuscriptFormat.test.js
+++ b/client/src/lib/manuscriptFormat.test.js
@@ -247,3 +247,4 @@ describe('formatManuscript — whitespace hygiene (all stages)', () => {
     expect(formatManuscript(null, 'prose')).toBe('');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/mediaCollectionList.test.js
+++ b/client/src/lib/mediaCollectionList.test.js
@@ -159,3 +159,4 @@ describe('applyCollectionView', () => {
     expect(applyCollectionView([])).toEqual([]);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/mediaNavigation.test.js
+++ b/client/src/lib/mediaNavigation.test.js
@@ -42,3 +42,4 @@ describe('getMediaNavProps', () => {
     expect(onSelect.mock.calls).toEqual([[{ key: 'one' }], [{ key: 'three' }]]);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/mediaSearch.test.js
+++ b/client/src/lib/mediaSearch.test.js
@@ -77,3 +77,4 @@ describe('filterByQuery', () => {
     expect(filterByQuery(items, 'neon sdxl')).toHaveLength(0);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/midiPlayback.test.js
+++ b/client/src/lib/midiPlayback.test.js
@@ -155,3 +155,4 @@ describe('createMidiPlayer', () => {
     expect(ended).toHaveBeenCalledTimes(1);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/postQuickSession.test.js
+++ b/client/src/lib/postQuickSession.test.js
@@ -77,3 +77,4 @@ describe('postQuickSession', () => {
     })).toMatchObject({ count: 5, steps: 4, maxDigits: 2 });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/powersBreakdown.test.js
+++ b/client/src/lib/powersBreakdown.test.js
@@ -23,3 +23,4 @@ describe('powersBreakdown', () => {
     expect(powersBreakdownFromPrompt('not a power')).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/quotaBurnPatch.test.js
+++ b/client/src/lib/quotaBurnPatch.test.js
@@ -140,3 +140,4 @@ describe('dispatch cap helpers', () => {
     expect(dispatchCapInput(50)).toBe(50);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/reverseOutlineGrid.test.js
+++ b/client/src/lib/reverseOutlineGrid.test.js
@@ -52,3 +52,4 @@ describe('sceneComponentCount', () => {
     expect(sceneComponentCount(null)).toBe(0);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/roundDraft.test.js
+++ b/client/src/lib/roundDraft.test.js
@@ -45,3 +45,4 @@ describe('roundDraft ids', () => {
     ]);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/runnerFamilies.test.js
+++ b/client/src/lib/runnerFamilies.test.js
@@ -61,3 +61,4 @@ describe('runnerFamilies mirror', () => {
     expect(isVideoLoraFamily(null)).toBe(false);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/sameJsonShape.test.js
+++ b/client/src/lib/sameJsonShape.test.js
@@ -30,3 +30,4 @@ describe('sameJsonShape', () => {
     expect(sameJsonShape(null, null)).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/scoreNotation.test.js
+++ b/client/src/lib/scoreNotation.test.js
@@ -238,3 +238,4 @@ describe('scoreHasMusic', () => {
     expect(scoreHasMusic('')).toBe(false);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/scorePlayback.test.js
+++ b/client/src/lib/scorePlayback.test.js
@@ -261,3 +261,4 @@ describe('createMultiScorePlayer', () => {
     expect(ended).toHaveBeenCalled();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/seriesReviewProgress.test.js
+++ b/client/src/lib/seriesReviewProgress.test.js
@@ -116,3 +116,4 @@ describe('summarizeReviewProgress', () => {
     expect(s.headline).toBe(`${REVIEW_STEP_LABELS.canon}…`);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/singToScore.test.js
+++ b/client/src/lib/singToScore.test.js
@@ -221,3 +221,4 @@ describe('transcribePitchTrack (round-trip)', () => {
     expect(transcribePitchTrack(synth([{ note: null, durMs: 1000 }]), { bpm: 120 })).toBe('');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/sketchCanvas.test.js
+++ b/client/src/lib/sketchCanvas.test.js
@@ -82,3 +82,4 @@ describe('drawStrokes renderer', () => {
     expect(ctx.stroke).not.toHaveBeenCalled();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/songCraft.test.js
+++ b/client/src/lib/songCraft.test.js
@@ -133,3 +133,4 @@ describe('songCraft reference data', () => {
     expect(harmonyPartOrder('custom-unknown')).toBe(99);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/songProgress.test.js
+++ b/client/src/lib/songProgress.test.js
@@ -213,3 +213,4 @@ describe('hideLevelFor', () => {
     expect(hideLevelFor(null)).toBe('show');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/spriteTrimmer.test.js
+++ b/client/src/lib/spriteTrimmer.test.js
@@ -130,3 +130,4 @@ describe('buildTrimmerSources', () => {
     expect(buildTrimmerSources({ runs: [] }, null)).toEqual([]);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/syncCounts.test.js
+++ b/client/src/lib/syncCounts.test.js
@@ -100,3 +100,4 @@ describe('describeDirectional', () => {
       .toEqual({ state: 'pending', text: 'checking…' });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/terminalTheme.test.js
+++ b/client/src/lib/terminalTheme.test.js
@@ -119,3 +119,4 @@ describe('buildTerminalTheme', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/lib/threejsExplode.test.js
+++ b/client/src/lib/threejsExplode.test.js
@@ -282,3 +282,4 @@ describe('computeExplodeLayout', () => {
     expect(buildPartSelectionIndex(undefined).owners).toEqual({});
   });
 });
+// @vitest-environment node

--- a/client/src/lib/threejsRig.test.js
+++ b/client/src/lib/threejsRig.test.js
@@ -51,3 +51,4 @@ describe('summarizeThreejsArticulation', () => {
     expect(Object.getPrototypeOf(summary.jointsByPartId)).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/threejsSculpt.test.js
+++ b/client/src/lib/threejsSculpt.test.js
@@ -121,3 +121,4 @@ describe('sculptMaterialProps', () => {
     expect(props).toEqual({ color: '#ffffff', opacity: 1, transparent: false, wireframe: false });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/tribeCadence.contract.test.js
+++ b/client/src/lib/tribeCadence.contract.test.js
@@ -85,3 +85,4 @@ describe('tribeCadence — cadence rules (semantics preserved from #2032)', () =
     expect(clientCadenceStatus({ ring: 'core', lastContact: daysAgo(13), cadenceDays: 21 }).state).toBe('steady');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/universeBuilderCounts.test.js
+++ b/client/src/lib/universeBuilderCounts.test.js
@@ -92,3 +92,4 @@ describe('universeBuilderCounts — scopedPromptCount', () => {
     expect(scopedPromptCount(world(), scope)).toBe(5);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/universeRunTag.test.js
+++ b/client/src/lib/universeRunTag.test.js
@@ -28,3 +28,4 @@ describe('buildUniverseSectionRenderTag', () => {
     expect(buildUniverseSectionRenderTag(universe, '', entry)).toBeNull(); // no kindKey
   });
 });
+// @vitest-environment node

--- a/client/src/lib/unsorted.test.js
+++ b/client/src/lib/unsorted.test.js
@@ -32,3 +32,4 @@ describe('buildUnsortedCollection', () => {
     expect(result.synthetic).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/upsertByIdPrepend.test.js
+++ b/client/src/lib/upsertByIdPrepend.test.js
@@ -24,3 +24,4 @@ describe('upsertByIdPrepend', () => {
     expect(list).toEqual([{ id: 'a' }, { id: 'b' }]);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/uuid.test.js
+++ b/client/src/lib/uuid.test.js
@@ -53,3 +53,4 @@ describe('uuidv4', () => {
     });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/videoGenResolutions.test.js
+++ b/client/src/lib/videoGenResolutions.test.js
@@ -70,3 +70,4 @@ describe('model-specific video resolutions', () => {
     expect(defaultResolutionForModel({})).toEqual(DEFAULT_VIDEO_RESOLUTION);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/voiceLabel.test.js
+++ b/client/src/lib/voiceLabel.test.js
@@ -51,3 +51,4 @@ describe('formatVoiceLabel', () => {
     expect(formatVoiceLabel({ engine: 'elevenlabs', id: 'elevenlabs:rachel' })).toBe('elevenlabs:rachel');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/wrImageDefaults.test.js
+++ b/client/src/lib/wrImageDefaults.test.js
@@ -35,3 +35,4 @@ describe('buildSceneRenderPayload', () => {
     expect(payload).not.toHaveProperty('writersRoom');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/wrSceneCursor.test.js
+++ b/client/src/lib/wrSceneCursor.test.js
@@ -94,3 +94,4 @@ describe('sceneAtCursor', () => {
     expect(sceneAtCursor(dupScenes, dupBody, firstCaret)?.scene.id).toBe('a');
   });
 });
+// @vitest-environment node

--- a/client/src/services/apiCatalog.test.js
+++ b/client/src/services/apiCatalog.test.js
@@ -93,3 +93,4 @@ describe('getCatalogFacets (#1762)', () => {
     expect(request).toHaveBeenCalledWith('/catalog/facets', undefined);
   });
 });
+// @vitest-environment node

--- a/client/src/services/apiCreativeDirector.test.js
+++ b/client/src/services/apiCreativeDirector.test.js
@@ -76,3 +76,4 @@ describe('getCreativeDirectorProjectsByIds', () => {
     expect(request.mock.calls[0][1]).toEqual({ silent: true });
   });
 });
+// @vitest-environment node

--- a/client/src/services/apiDigitalTwin.test.js
+++ b/client/src/services/apiDigitalTwin.test.js
@@ -66,3 +66,4 @@ describe('interactive Spotify import wrappers', () => {
     expect(JSON.parse(options.body)).toEqual({ providerId: 'local', model: 'example-model' });
   });
 });
+// @vitest-environment node

--- a/client/src/services/apiGames.test.js
+++ b/client/src/services/apiGames.test.js
@@ -50,3 +50,4 @@ describe('apiGames', () => {
     expect(request).toHaveBeenCalledWith('/games/game%2F1/integrity', { silent: true });
   });
 });
+// @vitest-environment node

--- a/client/src/services/apiGoals.test.js
+++ b/client/src/services/apiGoals.test.js
@@ -47,3 +47,4 @@ describe('organizeGoals', () => {
     expect(toastError).toHaveBeenCalledTimes(1);
   });
 });
+// @vitest-environment node

--- a/client/src/services/apiMeatspace.test.js
+++ b/client/src/services/apiMeatspace.test.js
@@ -82,3 +82,4 @@ describe('apiMeatspace double-toast wrappers forward options', () => {
     expect(options.method).toBe('POST');
   });
 });
+// @vitest-environment node

--- a/client/src/services/apiMedia.test.js
+++ b/client/src/services/apiMedia.test.js
@@ -101,3 +101,4 @@ describe('saveCleanResult', () => {
     expect(out.filename).toBe('upload-abc.png');
   });
 });
+// @vitest-environment node

--- a/client/src/services/apiPeerSync.test.js
+++ b/client/src/services/apiPeerSync.test.js
@@ -133,3 +133,4 @@ describe('pullMissingMetadata', () => {
     expect(result).toEqual({ attempted: 5001, recovered: 11 });
   });
 });
+// @vitest-environment node

--- a/client/src/services/apiSystem.test.js
+++ b/client/src/services/apiSystem.test.js
@@ -173,3 +173,4 @@ describe('getCharacter query building (#2676)', () => {
     expect(request.mock.calls[0][1]).toEqual({ silent: true });
   });
 });
+// @vitest-environment node

--- a/client/src/services/index.test.js
+++ b/client/src/services/index.test.js
@@ -31,3 +31,4 @@ describe('client/src/services/ catalog', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/services/voiceFastPath.test.js
+++ b/client/src/services/voiceFastPath.test.js
@@ -249,3 +249,4 @@ describe('resolveTurn', () => {
     expect(promptNano).not.toHaveBeenCalled();
   });
 });
+// @vitest-environment node


### PR DESCRIPTION
## Summary
- move browser-independent client library and service suites from jsdom to Node
- retain jsdom for tests that exercise browser APIs or rendered UI

## Test plan
- `npm test --prefix client -- <70 Node lib and service suites>`