### PR TITLE
ci: run pure component tests in Node

### DIFF
--- a/client/src/components/brain/links/bucketReorder.test.js
+++ b/client/src/components/brain/links/bucketReorder.test.js
@@ -68,3 +68,4 @@ describe('reorderLinksInBucket', () => {
     expect(renumbered.map(r => r.id)).toEqual(['b', 'a']);
   });
 });
+// @vitest-environment node

--- a/client/src/components/brain/tabs/MemoryTab.transcriptTeaser.test.js
+++ b/client/src/components/brain/tabs/MemoryTab.transcriptTeaser.test.js
@@ -25,3 +25,4 @@ describe('transcriptTeaser', () => {
     expect(transcriptTeaser('Short note.')).toBe('Short note.');
   });
 });
+// @vitest-environment node

--- a/client/src/components/city/audio/citySynthMusic.test.js
+++ b/client/src/components/city/audio/citySynthMusic.test.js
@@ -299,3 +299,4 @@ describe('citySynthMusic', () => {
     expect(fakeCtx.oscillators.map(o => o.stop.mock.calls.length)).toEqual(stopCallCounts);
   });
 });
+// @vitest-environment node

--- a/client/src/components/city/cityLayout.test.js
+++ b/client/src/components/city/cityLayout.test.js
@@ -92,3 +92,4 @@ describe('computeCityLayout', () => {
     expect(pos.get('stopped')).toMatchObject({ x: 12, z: 0, district: 'downtown' });
   });
 });
+// @vitest-environment node

--- a/client/src/components/city/cityTheme.test.js
+++ b/client/src/components/city/cityTheme.test.js
@@ -326,3 +326,4 @@ describe('quality-preset gates', () => {
     expect(cityShowInteriorWindows({ effectiveTier: 'ultra' })).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/components/cos/CoSBackgroundCamera.test.js
+++ b/client/src/components/cos/CoSBackgroundCamera.test.js
@@ -47,3 +47,4 @@ describe('computeCameraDistance', () => {
     expect(computeCameraDistance({ width: 1280, height: undefined }, z)).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/components/cos/constants.test.js
+++ b/client/src/components/cos/constants.test.js
@@ -217,3 +217,4 @@ describe('reviewerLabel', () => {
     expect(reviewerLabel('@octocat')).toBe('@octocat');
   });
 });
+// @vitest-environment node

--- a/client/src/components/cos/tabs/LearningTab.runsLabel.test.jsx
+++ b/client/src/components/cos/tabs/LearningTab.runsLabel.test.jsx
@@ -15,3 +15,4 @@ describe('LearningTab runsLabel', () => {
     expect(runsLabel({ completed: 55 }, 'tasks')).toBe('55 tasks');
   });
 });
+// @vitest-environment node

--- a/client/src/components/cos/tabs/schedule/scheduleConstants.test.js
+++ b/client/src/components/cos/tabs/schedule/scheduleConstants.test.js
@@ -189,3 +189,4 @@ describe('coverageTone', () => {
     expect(coverageTone(2, 5).bar).toBe('bg-port-warning');
   });
 });
+// @vitest-environment node

--- a/client/src/components/creative-commission/commissionForm.test.js
+++ b/client/src/components/creative-commission/commissionForm.test.js
@@ -288,3 +288,4 @@ describe('commissionForm helpers', () => {
     });
   });
 });
+// @vitest-environment node

--- a/client/src/components/digital-twin/tabs/PersonalityTab.test.jsx
+++ b/client/src/components/digital-twin/tabs/PersonalityTab.test.jsx
@@ -62,3 +62,4 @@ describe('PersonalityTab helpers', () => {
     expect(alignmentColor(0.1)).toBe('text-port-error');
   });
 });
+// @vitest-environment node

--- a/client/src/components/digital-twin/tabs/TasteTab.test.jsx
+++ b/client/src/components/digital-twin/tabs/TasteTab.test.jsx
@@ -45,3 +45,4 @@ describe('TasteTab "Go deeper" reporting', () => {
     });
   });
 });
+// @vitest-environment node

--- a/client/src/components/goals/applyOrganization.test.js
+++ b/client/src/components/goals/applyOrganization.test.js
@@ -207,3 +207,4 @@ describe('applyOrganizationSuggestion — failure reporting and toast layering',
     expect(api.applyGoalOrganization).toHaveBeenCalledWith(expect.anything(), { silent: true });
   });
 });
+// @vitest-environment node

--- a/client/src/components/meatspace/post/completionSave.test.js
+++ b/client/src/components/meatspace/post/completionSave.test.js
@@ -42,3 +42,4 @@ describe('completion saves', () => {
     expect(flaky).toHaveBeenCalledTimes(2);
   });
 });
+// @vitest-environment node

--- a/client/src/components/meatspace/post/constants.test.js
+++ b/client/src/components/meatspace/post/constants.test.js
@@ -242,3 +242,4 @@ describe('resolveTopicForDrillType client mirror', () => {
     expect(resolveTopicForDrillType('nope')).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/components/meatspace/tabs/calendar/lifeGridMath.test.js
+++ b/client/src/components/meatspace/tabs/calendar/lifeGridMath.test.js
@@ -120,3 +120,4 @@ describe('MS_PER_DAY', () => {
     expect(MS_PER_DAY).toBe(24 * 60 * 60 * 1000);
   });
 });
+// @vitest-environment node

--- a/client/src/components/media/normalize.test.js
+++ b/client/src/components/media/normalize.test.js
@@ -291,3 +291,4 @@ describe('getRenderConfigForItem - video', () => {
     expect(cfg.mode).toBe('text');
   });
 });
+// @vitest-environment node

--- a/client/src/components/media/variants.test.js
+++ b/client/src/components/media/variants.test.js
@@ -117,3 +117,4 @@ describe('computeImageVariantGroup', () => {
     expect(computeImageVariantGroup(other, [orig, cleaned, other])).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/components/pipeline/constants.test.js
+++ b/client/src/components/pipeline/constants.test.js
@@ -55,3 +55,4 @@ describe('pipeline severity palette', () => {
     expect(src).not.toContain(SEVERITY_COLORS.low);
   });
 });
+// @vitest-environment node

--- a/client/src/components/songbook/constants.test.js
+++ b/client/src/components/songbook/constants.test.js
@@ -150,3 +150,4 @@ describe('cross-links to other music records (#4103)', () => {
     expect(songLinks({ links: [{ type: 'round', id: 'r1' }] })).toEqual([{ type: 'round', id: 'r1' }]);
   });
 });
+// @vitest-environment node

--- a/client/src/components/sprites/spriteAssets.test.js
+++ b/client/src/components/sprites/spriteAssets.test.js
@@ -82,3 +82,4 @@ describe('assetVersionToken', () => {
     expect(assetVersionToken(asset)).toBeUndefined();
   });
 });
+// @vitest-environment node


### PR DESCRIPTION
## Summary
- move 21 verified browser-independent component suites from jsdom to Node
- retain jsdom for rendered UI and browser-API coverage

## Test plan
- `npm test --prefix client -- <21 pure component suites>`
- `npm run lint --prefix client`