### PR TITLE
feat: send music renders to audio-to-video

### DIFF
--- a/client/src/components/music/TrackRenderCard.jsx
+++ b/client/src/components/music/TrackRenderCard.jsx
@@ -10,7 +10,7 @@
  */
 
 import { useState } from 'react';
-import { Maximize2, Sparkles, Download, Trash2, CheckCircle2, Music2, Upload } from 'lucide-react';
+import { Maximize2, Sparkles, Download, Trash2, CheckCircle2, Music2, Upload, Film } from 'lucide-react';
 import InlineConfirmRow from '../ui/InlineConfirmRow';
 import { formatTimecode, timeAgo } from '../../utils/formatters';
 import { trackAudioUrl } from '../../services/api';
@@ -22,6 +22,7 @@ export default function TrackRenderCard({
   onSelect,
   onRemix,
   onDelete,
+  onSendToVideo,
 }) {
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const { prompt, engine, modelId, durationSec, audioFilename, createdAt } = render;
@@ -101,6 +102,16 @@ export default function TrackRenderCard({
               title="Reuse these settings for a new render"
             >
               <Sparkles className="w-3 h-3" /> Remix
+            </button>
+          ) : null}
+          {onSendToVideo ? (
+            <button
+              type="button"
+              onClick={() => onSendToVideo(render)}
+              className="shrink-0 px-1.5 py-1 bg-port-accent/20 hover:bg-port-accent/40 text-port-accent text-[10px] rounded flex items-center justify-center gap-1"
+              title="Send this render to Audio-to-Video"
+            >
+              <Film className="w-3 h-3" /> <span className="truncate">Audio → Video</span>
             </button>
           ) : null}
           <a

--- a/client/src/components/music/TrackRenderModal.jsx
+++ b/client/src/components/music/TrackRenderModal.jsx
@@ -8,7 +8,7 @@
  * take" makes it the active render. Mirrors the image/video MediaLightbox role.
  */
 
-import { Sparkles, CheckCircle2, Download, Trash2, X } from 'lucide-react';
+import { Sparkles, CheckCircle2, Download, Trash2, X, Film } from 'lucide-react';
 import Modal from '../ui/Modal';
 import { formatTimecode, timeAgo } from '../../utils/formatters';
 import { trackAudioUrl } from '../../services/api';
@@ -22,7 +22,7 @@ function MetaRow({ label, children }) {
   );
 }
 
-export default function TrackRenderModal({ render, active = false, onClose, onSelect, onRemix, onDelete }) {
+export default function TrackRenderModal({ render, active = false, onClose, onSelect, onRemix, onDelete, onSendToVideo }) {
   if (!render) return null;
   const { prompt, lyrics, engine, modelId, durationSec, audioFilename, createdAt } = render;
   const isUpload = !engine;
@@ -111,6 +111,15 @@ export default function TrackRenderModal({ render, active = false, onClose, onSe
             className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-accent hover:bg-port-accent/90 text-white text-xs font-medium"
           >
             <Sparkles size={13} /> Remix
+          </button>
+        ) : null}
+        {onSendToVideo ? (
+          <button
+            type="button"
+            onClick={() => onSendToVideo(render)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-port-accent/20 hover:bg-port-accent/40 text-port-accent text-xs font-medium"
+          >
+            <Film size={13} /> Audio → Video
           </button>
         ) : null}
       </div>

--- a/client/src/components/music/TracksManager.jsx
+++ b/client/src/components/music/TracksManager.jsx
@@ -320,6 +320,11 @@ export default function TracksManager() {
     applyRenderResult(res, targetId);
   };
 
+  const sendRenderToVideo = (render) => {
+    if (!render?.audioFilename) return;
+    navigate(`/media/video?mode=a2v&audioFilename=${encodeURIComponent(render.audioFilename)}`);
+  };
+
   const deleteRender = async (render) => {
     const targetId = persisted?.id;
     if (!targetId) return;
@@ -597,6 +602,7 @@ export default function TracksManager() {
                           onSelect={selectRender}
                           onRemix={remixRender}
                           onDelete={deleteRender}
+                          onSendToVideo={sendRenderToVideo}
                         />
                       ))}
                     </div>
@@ -692,6 +698,7 @@ export default function TracksManager() {
           onSelect={selectRender}
           onRemix={remixRender}
           onDelete={deleteRender}
+          onSendToVideo={sendRenderToVideo}
         />
       ) : null}
     </div>

--- a/client/src/components/music/TracksManager.test.jsx
+++ b/client/src/components/music/TracksManager.test.jsx
@@ -12,8 +12,11 @@ vi.mock('./MusicGenPanel', () => ({ default: (props) => {
   return <div data-testid="gen-panel" />;
 } }));
 vi.mock('./ChiptunePanel', () => ({ default: () => <div data-testid="chiptune-panel" /> }));
-vi.mock('./TrackRenderCard', () => ({ default: ({ render: item, onRemix }) => (
-  <button type="button" data-testid="render-card" onClick={() => onRemix(item)}>Remix {item.id}</button>
+vi.mock('./TrackRenderCard', () => ({ default: ({ render: item, onRemix, onSendToVideo }) => (
+  <>
+    <button type="button" data-testid="render-card" onClick={() => onRemix(item)}>Remix {item.id}</button>
+    <button type="button" data-testid="send-to-video" onClick={() => onSendToVideo(item)}>Audio → Video {item.id}</button>
+  </>
 ) }));
 vi.mock('./TrackRenderModal', () => ({ default: () => null }));
 vi.mock('../songs/MidiVisualization.jsx', () => ({
@@ -53,6 +56,7 @@ const renderAt = (id) => render(
     <Routes>
       <Route path="/music/tracks/:id" element={<TracksManager />} />
       <Route path="/music/generate/:step" element={<LocationDisplay />} />
+      <Route path="/media/video" element={<LocationDisplay />} />
     </Routes>
   </MemoryRouter>,
 );
@@ -231,6 +235,24 @@ describe('<TracksManager> generative workflow hand-off', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Remix render-legacy' }));
     await waitFor(() => expect(musicGenProps.current?.remix?.nonce).toBe(2));
     expect(musicGenProps.current.remix).not.toHaveProperty('instrumentalOnly');
+  });
+});
+
+describe('<TracksManager> Audio-to-Video hand-off', () => {
+  beforeEach(() => {
+    listTracks.mockResolvedValue([{ ...TRACK, renders: [{ id: 'render-1', audioFilename: 'example take.mp3' }] }]);
+    listAlbums.mockResolvedValue([]);
+    listMusicVideoProjects.mockResolvedValue([]);
+  });
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('deep-links the selected render into the Media Gen Audio-to-Video form', async () => {
+    renderAt('track-1');
+    fireEvent.click(await screen.findByTestId('send-to-video'));
+    expect(screen.getByTestId('location')).toHaveTextContent('/media/video?mode=a2v&audioFilename=example%20take.mp3');
   });
 });
 

--- a/client/src/hooks/useVideoGenForm.js
+++ b/client/src/hooks/useVideoGenForm.js
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef, useMemo, useCallback } from 'react';
 import { useSearchParams } from 'react-router';
 import toast from '../components/ui/Toast';
 import { extractLastFrame } from '../services/api';
+import { trackAudioUrl } from '../services/apiTracks.js';
 import { composeStyledPrompt } from '../lib/composeStyledPrompt';
 import { videoLoraFamily, isVideoLoraFamily, loraFamilyOf, VIDEO_LORA_FAMILIES, isLtx2FamilyRuntime } from '../lib/runnerFamilies';
 import { randomSeed } from '../lib/genUtils';
@@ -59,6 +60,7 @@ const editableRemixModel = (models, defaultModelId) => {
 export function useVideoGenForm({ models, status, availableLoras, grokEnabled }) {
   const [searchParams, setSearchParams] = useSearchParams();
   const incomingSourceImage = searchParams.get('sourceImageFile');
+  const incomingAudioFilename = searchParams.get('audioFilename');
   const incomingPrompt = searchParams.get('prompt');
   const incomingNegativePrompt = searchParams.get('negativePrompt');
   const incomingWidth = searchParams.get('w');
@@ -70,7 +72,7 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled })
   const [backend, setBackend] = useState('local');
   const [grokDuration, setGrokDuration] = useState(GROK_VIDEO_DEFAULT_DURATION);
 
-  const [mode, setMode] = useState(incomingSourceImage ? 'image' : 'text');
+  const [mode, setMode] = useState(incomingAudioFilename ? 'a2v' : (incomingSourceImage ? 'image' : 'text'));
   const [prompt, setPrompt] = useState(incomingPrompt || '');
   const [negativePrompt, setNegativePrompt] = useState(incomingNegativePrompt || '');
   const [stylePreset, setStylePreset] = useState(null);
@@ -146,6 +148,38 @@ export function useVideoGenForm({ models, status, availableLoras, grokEnabled })
   // is sent as multipart field name 'audioFile'; the server stages it under
   // data/uploads, then the python helper passes it to AudioToVideoPipeline.
   const [audioFile, setAudioFile] = useState(null);
+  const audioHandoffRef = useRef(null);
+
+  // Music renders live in the shared library rather than in the browser's
+  // local file picker. Turn a render's deep-link filename into the same File
+  // object the upload panel produces, so the existing multipart submit path,
+  // size checks, and server staging remain the single source of truth.
+  useEffect(() => {
+    if (!incomingAudioFilename || audioHandoffRef.current === incomingAudioFilename) return;
+    audioHandoffRef.current = incomingAudioFilename;
+    let cancelled = false;
+    setMode('a2v');
+    setAudioFile(null);
+    fetch(trackAudioUrl(incomingAudioFilename))
+      .then((response) => {
+        if (!response.ok) throw new Error('The selected music render could not be loaded.');
+        return response.blob();
+      })
+      .then((blob) => {
+        if (cancelled) return;
+        const type = blob.type || 'audio/wav';
+        setAudioFile(new File([blob], incomingAudioFilename, { type }));
+        setSearchParams((prev) => {
+          const next = new URLSearchParams(prev);
+          next.delete('audioFilename');
+          return next;
+        }, { replace: true });
+      })
+      .catch((error) => {
+        if (!cancelled) toast.error(error.message || 'Failed to load the music render');
+      });
+    return () => { cancelled = true; };
+  }, [incomingAudioFilename, setSearchParams]);
   // IC-LoRA remix modes (issue #3100) — the reference clip is either a fresh
   // upload (multipart field 'icReference') or a prior render picked by history
   // id. The two are mutually exclusive server-side, so the panel's Clear drops

--- a/client/src/hooks/useVideoGenForm.test.jsx
+++ b/client/src/hooks/useVideoGenForm.test.jsx
@@ -59,6 +59,18 @@ describe('useVideoGenForm', () => {
     extractLastFrame.mockReset();
   });
 
+  it('loads a music-library render from an Audio-to-Video handoff URL', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(new Blob(['audio bytes'], { type: 'audio/mpeg' }), { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+    const { result } = render({ url: '/media/video?mode=a2v&audioFilename=example%20take.mp3' });
+
+    await waitFor(() => expect(result.current.audioFile).toBeInstanceOf(File));
+    expect(result.current.mode).toBe('a2v');
+    expect(result.current.audioFile.name).toBe('example take.mp3');
+    expect(fetchMock).toHaveBeenCalledWith('/data/music/example%20take.mp3');
+    vi.unstubAllGlobals();
+  });
+
   it('seeds the model from status.defaultModel without clobbering a URL pick', async () => {
     const { result } = render();
     await waitFor(() => expect(result.current.modelId).toBe(MLX.id));


### PR DESCRIPTION
## Summary
- Add an Audio → Video action to music render cards and details.
- Load shared-library renders into the existing Media Gen Audio-to-Video upload path.
- Preserve the current server validation and multipart pipeline with focused coverage.

## Test plan
- npm test -- --run src/hooks/useVideoGenForm.test.jsx src/components/music/TracksManager.test.jsx
- npm run build
- npx biome lint --error-on-warnings src/hooks/useVideoGenForm.js src/hooks/useVideoGenForm.test.jsx src/components/music/TrackRenderCard.jsx src/components/music/TrackRenderModal.jsx src/components/music/TracksManager.jsx src/components/music/TracksManager.test.jsx