### PR TITLE
ci: run pure utility tests in Node

### DIFF
--- a/client/src/utils/cityAgentMotion.test.js
+++ b/client/src/utils/cityAgentMotion.test.js
@@ -142,3 +142,4 @@ describe('computeTrailColors', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityAiCore.test.js
+++ b/client/src/utils/cityAiCore.test.js
@@ -361,3 +361,4 @@ describe('computeAiCore with afterglow ops', () => {
     expect(vm.activeCount).toBe(0);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityBackupVault.test.js
+++ b/client/src/utils/cityBackupVault.test.js
@@ -131,3 +131,4 @@ describe('computeBackupVault', () => {
     expect(computeBackupVault({ status: 'never' }, NOW).lastRun).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityChronotype.test.js
+++ b/client/src/utils/cityChronotype.test.js
@@ -178,3 +178,4 @@ describe('computeChronotypeEnergy — display modifiers', () => {
     expect(Object.keys(mod)).toEqual(['computeChronotypeEnergy']);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityDataHarbor.test.js
+++ b/client/src/utils/cityDataHarbor.test.js
@@ -130,3 +130,4 @@ describe('harbor sits inside the world', () => {
     expect(Math.abs(z)).toBeLessThanOrEqual(WORLD.bound);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityFocusCamera.test.js
+++ b/client/src/utils/cityFocusCamera.test.js
@@ -73,3 +73,4 @@ describe('computeFocusCamera', () => {
     expect(a.distance).toBeCloseTo(b.distance, 6);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityHealthTower.test.js
+++ b/client/src/utils/cityHealthTower.test.js
@@ -155,3 +155,4 @@ describe('computeHealthTower', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityInteriorWindows.test.js
+++ b/client/src/utils/cityInteriorWindows.test.js
@@ -99,3 +99,4 @@ describe('computeWindowGrid', () => {
     expect(computeWindowGrid({ width: 2, depth: 2, height: 1, seed: 1 })).toEqual([]);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityMiniMap.test.js
+++ b/client/src/utils/cityMiniMap.test.js
@@ -252,3 +252,4 @@ describe('projectGeography', () => {
     expect(geo.harbor.ny).toBeLessThan(geo.shorelineY);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/citySeasonalDecor.test.js
+++ b/client/src/utils/citySeasonalDecor.test.js
@@ -128,3 +128,4 @@ describe('computeSeasonalDecor', () => {
     expect(vm.base).toEqual(SEASONAL_DECOR.base);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityTaskFlowRiver.test.js
+++ b/client/src/utils/cityTaskFlowRiver.test.js
@@ -159,3 +159,4 @@ describe('computeTaskFlowRiver — idle resilience', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityTimeline.test.js
+++ b/client/src/utils/cityTimeline.test.js
@@ -117,3 +117,4 @@ describe('buildTimelineBuckets', () => {
     expect(msgs).toEqual(['good']);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/coalesce.test.js
+++ b/client/src/utils/coalesce.test.js
@@ -72,3 +72,4 @@ describe('coalesce', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/formatters.test.js
+++ b/client/src/utils/formatters.test.js
@@ -541,3 +541,4 @@ describe('canonical date/time formatters (#3870)', () => {
     });
   });
 });
+// @vitest-environment node

--- a/client/src/utils/markdownText.test.js
+++ b/client/src/utils/markdownText.test.js
@@ -154,3 +154,4 @@ describe('dropsMarkupWhenFlattened', () => {
     expect(dropsMarkupWhenFlattened(42)).toBe(false);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -1126,3 +1126,4 @@ describe('AI Assignments option helpers', () => {
     });
   });
 });
+// @vitest-environment node


### PR DESCRIPTION
## Summary
- move 16 verified browser-independent utility suites from jsdom to Node
- retain jsdom for the NUL-fixture hash test and browser-dependent suites

## Test plan
- `npm test --prefix client -- <17 utility suites>`
- `npm run lint --prefix client`