### PR TITLE
ci: expand pure library tests on Node

### DIFF
--- a/client/src/lib/beatGrid.test.js
+++ b/client/src/lib/beatGrid.test.js
@@ -325,3 +325,4 @@ describe('shouldMarkBeatAligned', () => {
     expect(shouldMarkBeatAligned({ kind: 'move', snapped: true, wasPersisted: true })).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/bibleLimits.test.js
+++ b/client/src/lib/bibleLimits.test.js
@@ -49,3 +49,4 @@ describe('appendImageRefById', () => {
     expect(appendImageRefById([{ id: 'a' }], 'a', null)).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/boundedMap.test.js
+++ b/client/src/lib/boundedMap.test.js
@@ -53,3 +53,4 @@ describe('evictOldest', () => {
     expect(ORPHAN_BUFFER_MAX).toBe(64);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/catalogTypes.test.js
+++ b/client/src/lib/catalogTypes.test.js
@@ -67,3 +67,4 @@ describe('catalogTypes — character sheet sections', () => {
     expect(Object.isFrozen(CATALOG_TYPES)).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/cityPlaybackFrame.test.js
+++ b/client/src/lib/cityPlaybackFrame.test.js
@@ -143,3 +143,4 @@ describe('mergeFrameIntoCityProps', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/lib/clientErrorReporter.test.js
+++ b/client/src/lib/clientErrorReporter.test.js
@@ -231,3 +231,4 @@ describe('browser-extension errors', () => {
     expect(body.message).toBe('Genuine PortOS failure');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/colorMatch.test.js
+++ b/client/src/lib/colorMatch.test.js
@@ -226,3 +226,4 @@ describe('gradesFromPerNote', () => {
     expect(gradesFromPerNote(tl)).toEqual({});
   });
 });
+// @vitest-environment node

--- a/client/src/lib/creativeDirectorPlan.test.js
+++ b/client/src/lib/creativeDirectorPlan.test.js
@@ -135,3 +135,4 @@ describe('isDirectiveProject / DELIVERABLE_OPTIONS', () => {
     expect(DELIVERABLE_OPTIONS.map((o) => o.id)).toContain('video-teaser');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/creativeDirectorPreview.test.js
+++ b/client/src/lib/creativeDirectorPreview.test.js
@@ -300,3 +300,4 @@ describe('selectProjectPreview', () => {
     expect(selectProjectPreview({ plan: { steps: [null, undefined] } }).kind).toBe('none');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/drumKits.test.js
+++ b/client/src/lib/drumKits.test.js
@@ -119,3 +119,4 @@ describe('drumKits', () => {
     for (const id of DRUM_KIT_IDS) expect(DRUM_KITS[id].voices.click).toBeUndefined();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/drumNotation.test.js
+++ b/client/src/lib/drumNotation.test.js
@@ -417,3 +417,4 @@ describe('describeDrumPosition', () => {
     expect(describeDrumPosition(1, 5, 5)).toBe('bar 1, count “2”');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/drumPlayback.test.js
+++ b/client/src/lib/drumPlayback.test.js
@@ -281,3 +281,4 @@ describe('clampClickVolume', () => {
     expect(DEFAULT_CLICK_VOLUME).toBe(1); // the fallback is FULL, never silence
   });
 });
+// @vitest-environment node

--- a/client/src/lib/editorialChecks.test.js
+++ b/client/src/lib/editorialChecks.test.js
@@ -467,3 +467,4 @@ describe('canon entity references in findings (#1631)', () => {
     expect(canonEntityLink(null)).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/flowsDoc.test.js
+++ b/client/src/lib/flowsDoc.test.js
@@ -86,3 +86,4 @@ describe('flows.json', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/lib/imageGenBackends.test.js
+++ b/client/src/lib/imageGenBackends.test.js
@@ -189,3 +189,4 @@ describe('applyRecordRenderPin', () => {
     expect(out.cloudModel).toBe('gpt-5.6-luna');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/imageGenResolutions.test.js
+++ b/client/src/lib/imageGenResolutions.test.js
@@ -84,3 +84,4 @@ describe('clampImageDimensions', () => {
     expect(clampImageDimensions(undefined, undefined)).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/loopbackHost.test.js
+++ b/client/src/lib/loopbackHost.test.js
@@ -97,3 +97,4 @@ describe('describeMicAvailability', () => {
     expect(describeMicAvailability()).toEqual({ available: false, reason: 'insecure-context' });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/midiNotes.test.js
+++ b/client/src/lib/midiNotes.test.js
@@ -171,3 +171,4 @@ describe('parseMidiFile', () => {
     expect(Number.isFinite(vm.maxMidi)).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/moodBoardItemSrc.test.js
+++ b/client/src/lib/moodBoardItemSrc.test.js
@@ -83,3 +83,4 @@ describe('moodBoardItemAnalysisSource (#4188 Phase 3)', () => {
     expect(moodBoardItemAnalysisSource(null)).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/musicDuration.test.js
+++ b/client/src/lib/musicDuration.test.js
@@ -46,3 +46,4 @@ describe('music duration recommendations', () => {
     expect(result.suggestedDurationSec).toBe(30);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/pianoKeyboard.test.js
+++ b/client/src/lib/pianoKeyboard.test.js
@@ -95,3 +95,4 @@ describe('buildKeyboardLayout', () => {
     expect(lastWhite).toBeLessThan(firstBlack);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/pipelineImageDefaults.test.js
+++ b/client/src/lib/pipelineImageDefaults.test.js
@@ -53,3 +53,4 @@ describe('pipelineImageCfgToRenderOpts', () => {
       .toBeUndefined();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/promptStageGroups.test.js
+++ b/client/src/lib/promptStageGroups.test.js
@@ -238,3 +238,4 @@ describe('shipped stage catalog', () => {
     expect(groups[groups.length - 1].label).toBe(OTHER_GROUP_LABEL);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/referenceAnalysis.test.js
+++ b/client/src/lib/referenceAnalysis.test.js
@@ -259,3 +259,4 @@ describe('proposeStackedSegmentScore', () => {
     expect(STACKED_CLARITY_THRESHOLD).toBeLessThan(1);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/shotContinuity.test.js
+++ b/client/src/lib/shotContinuity.test.js
@@ -102,3 +102,4 @@ describe('sceneShotWarnings', () => {
     expect(sceneShotWarnings(null)).toEqual([]);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/singToVerify.test.js
+++ b/client/src/lib/singToVerify.test.js
@@ -71,3 +71,4 @@ describe('alignSingToVerify', () => {
     expect(rows[3].grade).toBe(GRADE.PENDING);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/spriteCollectionActions.test.js
+++ b/client/src/lib/spriteCollectionActions.test.js
@@ -218,3 +218,4 @@ describe('trimFor', () => {
     expect(build().trimFor(asset('runtime/v3/example-v3.png'))).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/lib/spriteFacets.test.js
+++ b/client/src/lib/spriteFacets.test.js
@@ -193,3 +193,4 @@ describe('groupSpriteAssetsByRole', () => {
     expect(group.assets[0]).toMatchObject({ size: 12, facets: { direction: 'east', runId: 'walk-east-abc12345' } });
   });
 });
+// @vitest-environment node

--- a/client/src/lib/spriteRecordGroups.test.js
+++ b/client/src/lib/spriteRecordGroups.test.js
@@ -81,3 +81,4 @@ describe('exported constants', () => {
     expect(NEW_SPRITE_KINDS.map((k) => k.value)).toEqual(['character', 'place', 'object']);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/spriteWalkUnlock.test.js
+++ b/client/src/lib/spriteWalkUnlock.test.js
@@ -78,3 +78,4 @@ describe('walkUnlockCopy', () => {
     expect(WALK_UNLOCK_TOAST).toMatch(/unlocked/);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/tabNotation.test.js
+++ b/client/src/lib/tabNotation.test.js
@@ -504,3 +504,4 @@ describe('transposeText', () => {
     expect(transposeText('C G', NaN)).toBe('C G');
   });
 });
+// @vitest-environment node

--- a/client/src/lib/tribe.test.js
+++ b/client/src/lib/tribe.test.js
@@ -159,3 +159,4 @@ describe('matchesStatusFilter', () => {
     expect(STATUS_FILTER_IDS.every((id) => Boolean(STATUS_FILTER_LABELS[id]))).toBe(true);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/universeBuilderExpand.test.js
+++ b/client/src/lib/universeBuilderExpand.test.js
@@ -340,3 +340,4 @@ describe('mergeExpandIntoDraft', () => {
     expect(Object.keys(expandedDraft.categories).sort()).toEqual(['defaultBucket', 'weapons']);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/universeBuilderShared.test.js
+++ b/client/src/lib/universeBuilderShared.test.js
@@ -181,3 +181,4 @@ describe('adoptServerCategoryIds', () => {
     expect(adoptServerCategoryIds(local, null)).toBe(local);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/videoFinish.test.js
+++ b/client/src/lib/videoFinish.test.js
@@ -109,3 +109,4 @@ describe('finishTargetForRecord', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/lib/videoGenParams.test.js
+++ b/client/src/lib/videoGenParams.test.js
@@ -186,3 +186,4 @@ describe('IC-LoRA remix modes (#3100)', () => {
     expect(icLoraSpecForMode('ic-colorize').uploadLabel).toMatch(/B&W/);
   });
 });
+// @vitest-environment node

--- a/client/src/lib/writingGuide.test.js
+++ b/client/src/lib/writingGuide.test.js
@@ -122,3 +122,4 @@ describe('classifyByWordCount', () => {
     expect(classifyByWordCount(39999).id).toBe('novella');
   });
 });
+// @vitest-environment node

--- a/client/src/themes/portosThemes.test.js
+++ b/client/src/themes/portosThemes.test.js
@@ -116,3 +116,4 @@ describe('DEFAULT_AVATAR_COLOR', () => {
     expect(DEFAULT_AVATAR_COLOR).toBe(`#${hex}`);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityAgentMotion.test.js
+++ b/client/src/utils/cityAgentMotion.test.js
@@ -142,3 +142,4 @@ describe('computeTrailColors', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityAiCore.test.js
+++ b/client/src/utils/cityAiCore.test.js
@@ -361,3 +361,4 @@ describe('computeAiCore with afterglow ops', () => {
     expect(vm.activeCount).toBe(0);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityBackupVault.test.js
+++ b/client/src/utils/cityBackupVault.test.js
@@ -131,3 +131,4 @@ describe('computeBackupVault', () => {
     expect(computeBackupVault({ status: 'never' }, NOW).lastRun).toBeNull();
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityChronotype.test.js
+++ b/client/src/utils/cityChronotype.test.js
@@ -178,3 +178,4 @@ describe('computeChronotypeEnergy — display modifiers', () => {
     expect(Object.keys(mod)).toEqual(['computeChronotypeEnergy']);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityDataHarbor.test.js
+++ b/client/src/utils/cityDataHarbor.test.js
@@ -130,3 +130,4 @@ describe('harbor sits inside the world', () => {
     expect(Math.abs(z)).toBeLessThanOrEqual(WORLD.bound);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityFocusCamera.test.js
+++ b/client/src/utils/cityFocusCamera.test.js
@@ -73,3 +73,4 @@ describe('computeFocusCamera', () => {
     expect(a.distance).toBeCloseTo(b.distance, 6);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityHealthTower.test.js
+++ b/client/src/utils/cityHealthTower.test.js
@@ -155,3 +155,4 @@ describe('computeHealthTower', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityInteriorWindows.test.js
+++ b/client/src/utils/cityInteriorWindows.test.js
@@ -99,3 +99,4 @@ describe('computeWindowGrid', () => {
     expect(computeWindowGrid({ width: 2, depth: 2, height: 1, seed: 1 })).toEqual([]);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityMiniMap.test.js
+++ b/client/src/utils/cityMiniMap.test.js
@@ -252,3 +252,4 @@ describe('projectGeography', () => {
     expect(geo.harbor.ny).toBeLessThan(geo.shorelineY);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/citySeasonalDecor.test.js
+++ b/client/src/utils/citySeasonalDecor.test.js
@@ -128,3 +128,4 @@ describe('computeSeasonalDecor', () => {
     expect(vm.base).toEqual(SEASONAL_DECOR.base);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityTaskFlowRiver.test.js
+++ b/client/src/utils/cityTaskFlowRiver.test.js
@@ -159,3 +159,4 @@ describe('computeTaskFlowRiver — idle resilience', () => {
     }
   });
 });
+// @vitest-environment node

--- a/client/src/utils/cityTimeline.test.js
+++ b/client/src/utils/cityTimeline.test.js
@@ -117,3 +117,4 @@ describe('buildTimelineBuckets', () => {
     expect(msgs).toEqual(['good']);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/coalesce.test.js
+++ b/client/src/utils/coalesce.test.js
@@ -72,3 +72,4 @@ describe('coalesce', () => {
     expect(fn).toHaveBeenCalledTimes(1);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/formatters.test.js
+++ b/client/src/utils/formatters.test.js
@@ -541,3 +541,4 @@ describe('canonical date/time formatters (#3870)', () => {
     });
   });
 });
+// @vitest-environment node

--- a/client/src/utils/markdownText.test.js
+++ b/client/src/utils/markdownText.test.js
@@ -154,3 +154,4 @@ describe('dropsMarkupWhenFlattened', () => {
     expect(dropsMarkupWhenFlattened(42)).toBe(false);
   });
 });
+// @vitest-environment node

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -1126,3 +1126,4 @@ describe('AI Assignments option helpers', () => {
     });
   });
 });
+// @vitest-environment node


### PR DESCRIPTION
## Summary
- move 38 verified browser-independent library and theme suites from jsdom to Node
- retain jsdom for `canvasRoll.test.js`, which exercises `window.getComputedStyle`

## Test plan
- `npm test --prefix client -- <38 Node library and theme suites>`
- `npm run lint --prefix client`