### PR TITLE
feat: configure unattended investigation approval

### DIFF
--- a/client/src/components/cos/tabs/ConfigTab.jsx
+++ b/client/src/components/cos/tabs/ConfigTab.jsx
@@ -259,6 +259,7 @@ const getDefaultFormData = (config, avatarStyle) => ({
   proactiveMode: config?.proactiveMode ?? true,
   idleReviewEnabled: config?.idleReviewEnabled ?? true,
   immediateExecution: config?.immediateExecution ?? true,
+  autoApproveInvestigations: config?.autoApproveInvestigations ?? false,
   avatarStyle: config?.avatarStyle || avatarStyle || 'svg'
 });
 
@@ -502,6 +503,15 @@ export default function ConfigTab({ config, onUpdate, onEvaluate, avatarStyle })
           inputValue={formData.immediateExecution}
           onChange={v => setFormData(f => ({ ...f, immediateExecution: v }))}
           tooltip="Execute new tasks immediately instead of waiting for evaluation interval"
+        />
+        <ConfigRow
+          label="Auto-approve Investigations"
+          value={formData.autoApproveInvestigations ? 'Enabled' : 'Disabled'}
+          editing={editing}
+          type="checkbox"
+          inputValue={formData.autoApproveInvestigations}
+          onChange={v => setFormData(f => ({ ...f, autoApproveInvestigations: v }))}
+          tooltip="Automatically process system failure investigations, including investigations held because a failure is looping or part of a storm"
         />
       </div>
 

--- a/server/lib/investigationTasks.js
+++ b/server/lib/investigationTasks.js
@@ -188,6 +188,18 @@ function approvalVerdict(loopReason) {
 /** The neutral, unattended verdict — what a failed policy read falls open to. Pure. */
 export const UNATTENDED_APPROVAL_VERDICT = Object.freeze(approvalVerdict(null));
 
+/**
+ * Whether a pending investigation should be admitted by the explicit CoS
+ * auto-approval override. The override is intentionally narrow: it never
+ * changes ordinary task approval or bypasses the CoS autonomy/budget gates.
+ */
+export function isAutoApprovableInvestigation(task, config) {
+  return config?.autoApproveInvestigations === true
+    && isInvestigationTask(task)
+    && task?.status === 'pending'
+    && task?.approvalRequired === true;
+}
+
 // ===== Auto-retry of the tasks an investigation was blocking =====
 
 /**

--- a/server/lib/investigationTasks.test.js
+++ b/server/lib/investigationTasks.test.js
@@ -7,6 +7,7 @@ import {
   autoRetryMetadata,
   buildInvestigationFingerprint,
   investigationFingerprint,
+  isAutoApprovableInvestigation,
   isInvestigationTask,
   resolveInvestigationRetryTargets,
 } from './investigationTasks.js';
@@ -38,6 +39,25 @@ describe('isInvestigationTask', () => {
     expect(isInvestigationTask({ description: 'Fix the thing' })).toBe(false);
     expect(isInvestigationTask({ metadata: { isInvestigation: 'false' } })).toBe(false);
     expect(isInvestigationTask(null)).toBe(false);
+  });
+});
+
+describe('isAutoApprovableInvestigation', () => {
+  const task = {
+    status: 'pending',
+    approvalRequired: true,
+    metadata: { isInvestigation: true },
+  };
+
+  it('admits a held investigation only when explicitly configured', () => {
+    expect(isAutoApprovableInvestigation(task, { autoApproveInvestigations: true })).toBe(true);
+    expect(isAutoApprovableInvestigation(task, { autoApproveInvestigations: false })).toBe(false);
+  });
+
+  it('does not override ordinary, completed, or already-approved tasks', () => {
+    expect(isAutoApprovableInvestigation({ ...task, description: 'ordinary', metadata: {} }, { autoApproveInvestigations: true })).toBe(false);
+    expect(isAutoApprovableInvestigation({ ...task, status: 'completed' }, { autoApproveInvestigations: true })).toBe(false);
+    expect(isAutoApprovableInvestigation({ ...task, approvalRequired: false }, { autoApproveInvestigations: true })).toBe(false);
   });
 });
 

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -235,6 +235,18 @@ describe('CoS Routes', () => {
       expect(response.status).toBe(200);
       expect(cos.updateConfig).toHaveBeenCalledWith(updates);
     });
+
+    it('accepts the investigation auto-approval setting', async () => {
+      const updates = { autoApproveInvestigations: true };
+      cos.updateConfig.mockResolvedValue(updates);
+
+      const response = await request(app)
+        .put('/api/cos/config')
+        .send(updates);
+
+      expect(response.status).toBe(200);
+      expect(cos.updateConfig).toHaveBeenCalledWith(updates);
+    });
   });
 
   describe('GET /api/cos/tasks', () => {

--- a/server/routes/cosStatusRoutes.js
+++ b/server/routes/cosStatusRoutes.js
@@ -48,6 +48,7 @@ export const cosConfigSchema = z.object({
   proactiveMode: z.boolean().optional(),
   autonomousJobsEnabled: z.boolean().optional(),
   autonomyLevel: z.enum(['standby', 'assistant', 'manager', 'yolo']).optional(),
+  autoApproveInvestigations: z.boolean().optional(),
   // Per-domain autonomy guardrails (#711): partial map of domainId → mode.
   // Partial is fine — updateConfig() merges it over the stored map.
   domainAutonomy: z.object(

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -20,6 +20,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { getActiveProvider } from './providers.js';
 import { isInternalTaskId } from '../lib/taskParser.js';
+import { isAutoApprovableInvestigation } from '../lib/investigationTasks.js';
 import { isRetryHeld, isStaleRetryHold } from '../lib/taskRetryHold.js';
 import { isAppOnCooldown, markAppReviewCooldown, bindAppReviewAgent, clearStaleActiveAgents } from './appActivity.js';
 import { getActiveApps } from './apps.js';
@@ -990,7 +991,12 @@ async function spawnDequeuePriority2AutoApproved(ctx) {
   const { state, instanceId, capacity } = ctx;
 
   const cosTaskData = await getCosTasks();
-  const autoApproved = cosTaskData.autoApproved || [];
+  const autoApproved = [
+    ...(cosTaskData.autoApproved || []),
+    ...(state.config.autoApproveInvestigations
+      ? (cosTaskData.grouped?.pending || []).filter((task) => isAutoApprovableInvestigation(task, state.config))
+      : [])
+  ];
   let cosAutonomyMode = getDomainMode(state.config, 'cos');
 
   // Daily CoS budget (#711) — same enforcement as the periodic evaluator
@@ -1504,6 +1510,13 @@ export async function init() {
   });
 
   cosEvents.on('tasks:user:added', () => {
+    if (isDaemonRunning()) setImmediate(() => dequeueNextTask());
+  });
+
+  // Changing the investigation override can make an already-queued held task
+  // eligible. Re-run the normal dequeue so autonomy, budgets, leases, and
+  // capacity remain the same as for every other system task.
+  cosEvents.on('config:changed', () => {
     if (isDaemonRunning()) setImmediate(() => dequeueNextTask());
   });
 

--- a/server/services/cosState.js
+++ b/server/services/cosState.js
@@ -58,6 +58,9 @@ export const DEFAULT_CONFIG = {
   proactiveMode: true,
   autonomousJobsEnabled: true,
   autonomyLevel: 'standby',
+  // Investigation tasks normally hold only failure loops for a human. This
+  // opt-in also admits those loop/storm investigations unattended.
+  autoApproveInvestigations: false,
   // Per-domain autonomy guardrails (#711). Each domain is off | dry-run | execute.
   // Default is `execute` for every domain, reproducing pre-#711 behavior so no
   // migration is needed — an install with no stored value reads `execute`.


### PR DESCRIPTION
## Summary
- add an opt-in CoS setting for automatically approving system failure investigations
- admit already-queued held investigations through the normal autonomous dequeue path
- expose the setting in the CoS configuration UI and validate it at the API boundary

## Test plan
- npm test -- --run lib/investigationTasks.test.js routes/cos.test.js (server)
- npm test -- --run src/components/cos/tabs/ConfigTab.test.jsx (client)