### PR TITLE
feat: let creative director choose video duration

### DIFF
--- a/client/src/components/creative-commission/CommissionConfigForm.jsx
+++ b/client/src/components/creative-commission/CommissionConfigForm.jsx
@@ -257,6 +257,7 @@ function GenerationSection({ ability, generation, patchForm }) {
       <h3 className="text-sm font-semibold text-gray-200">Generation ({abilityLabel})</h3>
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
         {fields.map((field) => {
+          if (field.key === 'targetDurationSeconds' && generation?.durationMode === 'auto') return null;
           const id = `commission-gen-${field.key}`;
           const value = generation?.[field.key] ?? '';
           return (
@@ -281,6 +282,9 @@ function GenerationSection({ ability, generation, patchForm }) {
                   value={value}
                   onChange={(e) => patchForm(['generation', field.key], e.target.value)}
                 />
+              )}
+              {field.key === 'durationMode' && value === 'auto' && (
+                <p className="text-xs text-gray-500 mt-1">The Creative Director selects a suitable length for each commission.</p>
               )}
             </div>
           );

--- a/client/src/components/creative-commission/CommissionConfigForm.test.jsx
+++ b/client/src/components/creative-commission/CommissionConfigForm.test.jsx
@@ -100,3 +100,24 @@ describe('CommissionConfigForm music taste controls', () => {
     expect(screen.getByLabelText('Creative output')).toHaveValue('music');
   });
 });
+
+describe('CommissionConfigForm video duration controls', () => {
+  it('defaults to Creative Director choice and reveals a manual length when selected', () => {
+    function VideoHarness() {
+      const [form, setForm] = useState(toForm({ brief: { intent: 'a drifting city' } }));
+      return (
+        <CommissionConfigForm
+          form={form}
+          patchForm={(path, value) => setForm((prev) => patchFormState(prev, path, value))}
+          saving={false}
+          onSave={() => {}}
+        />
+      );
+    }
+    render(<VideoHarness />);
+    expect(screen.getByLabelText('Video length')).toHaveValue('auto');
+    expect(screen.queryByLabelText('Duration (sec)')).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Video length'), { target: { value: 'manual' } });
+    expect(screen.getByLabelText('Duration (sec)')).toHaveValue(10);
+  });
+});

--- a/client/src/components/creative-commission/CommissionConfigForm.test.jsx
+++ b/client/src/components/creative-commission/CommissionConfigForm.test.jsx
@@ -115,13 +115,13 @@ describe('CommissionConfigForm video duration controls', () => {
       );
     }
     render(<VideoHarness />);
-    expect(screen.getByLabelText('Video length')).toHaveValue('auto');
-    expect(screen.queryByLabelText('Duration (sec)')).not.toBeInTheDocument();
-    fireEvent.change(screen.getByLabelText('Video length'), { target: { value: 'manual' } });
-    expect(screen.getByLabelText('Duration (sec)')).toHaveValue(10);
     await waitFor(() => {
       expect(api.getProviders).toHaveBeenCalled();
       expect(api.getSettings).toHaveBeenCalled();
     });
+    expect(screen.getByLabelText('Video length')).toHaveValue('auto');
+    expect(screen.queryByLabelText('Duration (sec)')).not.toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('Video length'), { target: { value: 'manual' } });
+    expect(screen.getByLabelText('Duration (sec)')).toHaveValue(10);
   });
 });

--- a/client/src/components/creative-commission/CommissionConfigForm.test.jsx
+++ b/client/src/components/creative-commission/CommissionConfigForm.test.jsx
@@ -102,7 +102,7 @@ describe('CommissionConfigForm music taste controls', () => {
 });
 
 describe('CommissionConfigForm video duration controls', () => {
-  it('defaults to Creative Director choice and reveals a manual length when selected', () => {
+  it('defaults to Creative Director choice and reveals a manual length when selected', async () => {
     function VideoHarness() {
       const [form, setForm] = useState(toForm({ brief: { intent: 'a drifting city' } }));
       return (
@@ -119,5 +119,9 @@ describe('CommissionConfigForm video duration controls', () => {
     expect(screen.queryByLabelText('Duration (sec)')).not.toBeInTheDocument();
     fireEvent.change(screen.getByLabelText('Video length'), { target: { value: 'manual' } });
     expect(screen.getByLabelText('Duration (sec)')).toHaveValue(10);
+    await waitFor(() => {
+      expect(api.getProviders).toHaveBeenCalled();
+      expect(api.getSettings).toHaveBeenCalled();
+    });
   });
 });

--- a/client/src/components/creative-commission/commissionForm.js
+++ b/client/src/components/creative-commission/commissionForm.js
@@ -25,6 +25,7 @@ export const ABILITY_OPTIONS = [
 const QUALITY_FIELD = { key: 'quality', label: 'Quality', type: 'select', options: [['draft', 'Draft'], ['standard', 'Standard'], ['high', 'High']] };
 const ASPECT_FIELD = { key: 'aspectRatio', label: 'Aspect ratio', type: 'select', options: [['16:9', '16:9'], ['9:16', '9:16'], ['1:1', '1:1']] };
 const DURATION_FIELD = { key: 'targetDurationSeconds', label: 'Duration (sec)', type: 'number', min: 5, max: 600 };
+const DURATION_MODE_FIELD = { key: 'durationMode', label: 'Video length', type: 'select', options: [['auto', 'Creative Director chooses'], ['manual', 'Set a specific length']] };
 
 // Render-backend pin (#3135) — the client mirror of the server's
 // CREATIVE_COMMISSION_IMAGE_MODES / _VIDEO_MODES. `auto` is the default and means
@@ -73,10 +74,10 @@ const VIDEO_BACKEND_FIELD = {
 // client-internal invariant (every field has a matching default), not server↔client
 // parity.
 export const GENERATION_FIELDS_BY_ABILITY = {
-  video: [QUALITY_FIELD, ASPECT_FIELD, DURATION_FIELD, VIDEO_BACKEND_FIELD],
+  video: [QUALITY_FIELD, ASPECT_FIELD, DURATION_MODE_FIELD, DURATION_FIELD, VIDEO_BACKEND_FIELD],
   image: [QUALITY_FIELD, ASPECT_FIELD, { key: 'imageCount', label: 'Image count', type: 'number', min: 1, max: 6 }, IMAGE_BACKEND_FIELD],
   music: [{ key: 'lengthSeconds', label: 'Length (sec)', type: 'number', min: 5, max: 600 }],
-  'music-video': [QUALITY_FIELD, ASPECT_FIELD, DURATION_FIELD, VIDEO_BACKEND_FIELD, IMAGE_BACKEND_FIELD],
+  'music-video': [QUALITY_FIELD, ASPECT_FIELD, DURATION_MODE_FIELD, DURATION_FIELD, VIDEO_BACKEND_FIELD, IMAGE_BACKEND_FIELD],
   series: [{ key: 'episodeCount', label: 'Episodes', type: 'number', min: 1, max: 6 }],
 };
 
@@ -84,11 +85,11 @@ export const GENERATION_FIELDS_BY_ABILITY = {
 // project a stored record into the form and to seed the fields when the user
 // switches output type.
 export const GENERATION_DEFAULTS_BY_ABILITY = {
-  video: { quality: 'standard', aspectRatio: '16:9', targetDurationSeconds: 10, videoMode: RENDER_BACKEND_AUTO, videoModelId: null },
+  video: { quality: 'standard', aspectRatio: '16:9', targetDurationSeconds: 10, durationMode: 'auto', videoMode: RENDER_BACKEND_AUTO, videoModelId: null },
   image: { quality: 'standard', aspectRatio: '16:9', imageCount: 1, imageMode: RENDER_BACKEND_AUTO, imageModelId: null },
   music: { lengthSeconds: 30 },
   'music-video': {
-    quality: 'standard', aspectRatio: '16:9', targetDurationSeconds: 10,
+    quality: 'standard', aspectRatio: '16:9', targetDurationSeconds: 10, durationMode: 'auto',
     videoMode: RENDER_BACKEND_AUTO, videoModelId: null, imageMode: RENDER_BACKEND_AUTO, imageModelId: null,
   },
   series: { episodeCount: 1 },
@@ -159,6 +160,7 @@ export function generationToPayload(ability, generation) {
     }
     out[field.key] = field.type === 'number' ? Number(v) : v;
   }
+  if (out.durationMode === 'auto') delete out.targetDurationSeconds;
   return out;
 }
 
@@ -209,7 +211,16 @@ export function toForm(c) {
     },
     // Per-ability generation (#2769): only the selected type's fields, filled
     // from the record or the type's defaults.
-    generation: generationToForm(c.targetAbility || 'video', c.generation),
+    generation: (() => {
+      const generation = generationToForm(c.targetAbility || 'video', c.generation);
+      // Records written before durationMode existed are legacy pinned-length
+      // commissions; only new blank forms default to Creative Director choice.
+      if ((c.targetAbility === 'video' || c.targetAbility === 'music-video' || !c.targetAbility)
+        && !Object.hasOwn(c.generation || {}, 'durationMode') && c.generation?.targetDurationSeconds != null) {
+        generation.durationMode = 'manual';
+      }
+      return generation;
+    })(),
     // Which AI provider/model processes the commission's CD stages. Empty
     // providerId → the install's default AI Assignment.
     assignment: {

--- a/client/src/components/creative-commission/commissionForm.test.js
+++ b/client/src/components/creative-commission/commissionForm.test.js
@@ -197,6 +197,14 @@ describe('commissionForm helpers', () => {
       expect(generationToPayload('image', { quality: 'standard', aspectRatio: '1:1', imageCount: '3' }))
         .toEqual({ quality: 'standard', aspectRatio: '1:1', imageCount: 3, imageMode: 'auto', imageModelId: null });
       expect(generationToPayload('music', { lengthSeconds: '45' })).toEqual({ lengthSeconds: 45 });
+      expect(generationToPayload('video', {
+        quality: 'standard', aspectRatio: '16:9', durationMode: 'auto', targetDurationSeconds: 45,
+      })).toEqual({ quality: 'standard', aspectRatio: '16:9', durationMode: 'auto', videoMode: 'auto', videoModelId: null });
+    });
+
+    it('keeps legacy video records pinned while blank forms use automatic duration', () => {
+      expect(toForm({}).generation.durationMode).toBe('auto');
+      expect(toForm({ targetAbility: 'video', generation: { targetDurationSeconds: 20 } }).generation.durationMode).toBe('manual');
     });
 
     it('toPayload round-trips a non-video commission', () => {

--- a/client/src/components/creative-commission/commissionForm.test.js
+++ b/client/src/components/creative-commission/commissionForm.test.js
@@ -18,7 +18,7 @@ describe('commissionForm helpers', () => {
       expect(f.schedule.kind).toBe('DAILY');
       expect(f.schedule.atLocalTime).toBe('02:00');
       expect(f.generation).toEqual({
-        quality: 'standard', aspectRatio: '16:9', targetDurationSeconds: 10,
+        quality: 'standard', aspectRatio: '16:9', targetDurationSeconds: 10, durationMode: 'auto',
         videoMode: 'auto', videoModelId: null,
       });
       expect(f.assignment).toEqual({ providerId: '', model: '' });

--- a/server/lib/creativeCommissionValidation.js
+++ b/server/lib/creativeCommissionValidation.js
@@ -85,6 +85,7 @@ export const GENERATION_KEY_DEFS = Object.freeze({
   quality: { type: 'enum', values: CREATIVE_COMMISSION_QUALITIES, default: 'standard' },
   aspectRatio: { type: 'enum', values: CREATIVE_COMMISSION_ASPECT_RATIOS, default: '16:9' },
   targetDurationSeconds: { type: 'int', min: 5, max: 600, default: 10 },
+  durationMode: { type: 'enum', values: ['auto', 'manual'], default: 'manual' },
   imageCount: { type: 'int', min: 1, max: 6, default: 1 },
   lengthSeconds: { type: 'int', min: 5, max: 600, default: 30 },
   episodeCount: { type: 'int', min: 1, max: 6, default: 1 },
@@ -113,10 +114,10 @@ export const GENERATION_KEY_DEFS = Object.freeze({
 // it too). `music` and `series` carry neither — a series' per-issue renders are
 // pinned on the pipeline series/stage records, not here.
 const ABILITY_GENERATION_KEYS = Object.freeze({
-  video: ['quality', 'aspectRatio', 'targetDurationSeconds', 'videoMode', 'videoModelId'],
+  video: ['quality', 'aspectRatio', 'targetDurationSeconds', 'durationMode', 'videoMode', 'videoModelId'],
   image: ['quality', 'aspectRatio', 'imageCount', 'imageMode', 'imageModelId'],
   music: ['lengthSeconds'],
-  'music-video': ['quality', 'aspectRatio', 'targetDurationSeconds', 'videoMode', 'videoModelId', 'imageMode', 'imageModelId'],
+  'music-video': ['quality', 'aspectRatio', 'targetDurationSeconds', 'durationMode', 'videoMode', 'videoModelId', 'imageMode', 'imageModelId'],
   series: ['episodeCount'],
 });
 

--- a/server/services/creativeCommissions/abilityAdapters.js
+++ b/server/services/creativeCommissions/abilityAdapters.js
@@ -153,7 +153,12 @@ function buildVideoGeometryParams(commission, { defaultVideoModelId } = {}) {
     // (lib/creativeDirectorPrompts.js) and the teaser tool inherits. Neither set
     // ⇒ the install default, exactly as before.
     modelId: gen?.videoModelId || gen?.model || (typeof defaultVideoModelId === 'function' ? defaultVideoModelId() : undefined),
-    targetDurationSeconds: gen?.targetDurationSeconds || gen?.lengthSeconds || 10,
+    // Auto mode lets the planner choose a per-step duration; retain a valid
+    // project fallback for plans that omit one. Music-video commissions still
+    // use their legacy audio length as the manual fallback.
+    targetDurationSeconds: gen?.durationMode === 'auto'
+      ? 10
+      : (gen?.targetDurationSeconds || gen?.lengthSeconds || 10),
     // Only passed when the commission actually pinned a backend (#3135), so an
     // unpinned commission's createProject call is byte-identical to a hand-made
     // project's — both omit the arg and buildProjectRecord stores `null`, exactly
@@ -173,7 +178,9 @@ const videoAdapter = {
   sanitizeGeneration: (raw) => sanitizeGenerationFor('video', raw),
   buildProjectParams: buildVideoGeometryParams,
   buildDirective(commission) {
-    const { lines, digest, constraints } = briefContext(commission, 'Create a short-form video piece.');
+    const duration = commission?.generation?.durationMode === 'auto'
+      ? ' Choose an appropriate duration between 5 and 600 seconds for the brief.' : '';
+    const { lines, digest, constraints } = briefContext(commission, `Create a short-form video piece.${duration}`);
     return { goal: composeDirectiveGoal(lines, digest), deliverables: ['One rendered video matching the brief'], constraints };
   },
 };
@@ -221,7 +228,9 @@ const musicVideoAdapter = {
   sanitizeGeneration: (raw) => sanitizeGenerationFor('music-video', raw),
   buildProjectParams: buildVideoGeometryParams,
   buildDirective(commission) {
-    const lead = 'Create a short-form music video: generate an original music bed AND a matching video scored to it.';
+    const duration = commission?.generation?.durationMode === 'auto'
+      ? ' Choose an appropriate video duration between 5 and 600 seconds for the brief.' : '';
+    const lead = `Create a short-form music video:${duration} Generate an original music bed AND a matching video scored to it.`;
     const { lines, digest, constraints } = briefContext(commission, lead);
     return {
       goal: composeDirectiveGoal(lines, digest),

--- a/server/services/creativeCommissions/abilityAdapters.test.js
+++ b/server/services/creativeCommissions/abilityAdapters.test.js
@@ -138,7 +138,7 @@ describe('sanitizeGeneration — fills defaults and preserves only the type keys
     const g = getAbilityAdapter('video').sanitizeGeneration({ quality: 'high', aspectRatio: '9:16', targetDurationSeconds: 20, imageCount: 5, model: ' ltx ' });
     expect(g).toEqual({
       model: 'ltx', quality: 'high', aspectRatio: '9:16', targetDurationSeconds: 20,
-      videoMode: 'auto', videoModelId: null,
+      durationMode: 'manual', videoMode: 'auto', videoModelId: null,
     });
   });
 

--- a/server/services/creativeCommissions/abilityAdapters.test.js
+++ b/server/services/creativeCommissions/abilityAdapters.test.js
@@ -175,6 +175,13 @@ describe('buildProjectParams — every type yields well-formed render settings',
     expect(p).toEqual({ aspectRatio: '1:1', quality: 'draft', modelId: 'ltx-default', targetDurationSeconds: 15 });
   });
 
+  it('lets the Creative Director choose the video length in auto mode', () => {
+    const commission = { targetAbility: 'video', generation: { durationMode: 'auto' }, brief: { intent: 'a drifting city' } };
+    const p = getAbilityAdapter('video').buildProjectParams(commission, ctx);
+    expect(p.targetDurationSeconds).toBe(10);
+    expect(buildCommissionDirective(commission).goal).toMatch(/choose an appropriate duration between 5 and 600 seconds/i);
+  });
+
   it('the pinned local video model becomes the project model', () => {
     // `project.modelId` is what the CD planner prompt reports to the LLM and what
     // the teaser tool inherits, so a videoModelId that stopped at


### PR DESCRIPTION
## Summary
- Add an optional Creative Director-selected duration mode for video and music-video commissions.
- Preserve legacy commissions as manually pinned at their existing duration.
- Tell the planner to choose a bounded 5–600 second duration when auto mode is selected.

## Test plan
- `npm test -- --run services/creativeCommissions/abilityAdapters.test.js` (server)
- `npm test -- --run src/components/creative-commission/commissionForm.test.js src/components/creative-commission/CommissionConfigForm.test.jsx` (client)
- Broader commission store tests require the unavailable PostgreSQL test backend in this worktree.