### PR TITLE
feat: queue repair tasks for creative director render failures

### DIFF
--- a/server/services/bootstrap.js
+++ b/server/services/bootstrap.js
@@ -123,6 +123,7 @@ import { initMusicStudioHook } from './musicStudioHook.js';
 import { initImageGenQuotaHook } from './imageGenQuota.js';
 import { initSpriteReferenceImageHook } from './spriteReferenceImageHook.js';
 import { initCreativeDirectorSceneImageHook } from './creativeDirectorSceneImageHook.js';
+import { initCreativeDirectorRenderFailureHook } from './creativeDirector/renderFailureHook.js';
 import { initComicPagesFilenameHook } from './pipeline/comicPagesFilenameHook.js';
 import { initStoryboardsFilenameHook } from './pipeline/storyboardsFilenameHook.js';
 import { initSeasonCoverFilenameHook } from './pipeline/seasonCoverFilenameHook.js';
@@ -492,6 +493,9 @@ const initMediaJobDependentHooks = () => {
   // reference-frame render onto its project scene's `sourceImageFile` on
   // completion, even if no client is watching (#1867).
   initCreativeDirectorSceneImageHook();
+  // Creative Director render failures are actionable code defects; queue one
+  // deduplicated internal repair task for every tagged CD media lane.
+  initCreativeDirectorRenderFailureHook();
   // Pipeline filename hooks — stamp `filename` onto stage records on
   // media-job completion so the UI can still render them after the
   // 24h media-job archive TTL elapses.

--- a/server/services/creativeDirector/renderFailureHook.js
+++ b/server/services/creativeDirector/renderFailureHook.js
@@ -1,0 +1,38 @@
+import { mediaJobEvents } from '../mediaJobQueue/index.js';
+import { queueCreativeDirectorRenderFailureTask } from './renderFailureTask.js';
+
+let initialized = false;
+
+function creativeDirectorTarget(job) {
+  const sceneTag = job?.params?.creativeDirector;
+  if (sceneTag?.projectId) return sceneTag;
+  const musicTag = job?.params?.creativeDirectorMusicBed;
+  if (musicTag?.projectId) return musicTag;
+  return null;
+}
+
+async function onFailed(job) {
+  const target = creativeDirectorTarget(job);
+  if (!target) return;
+  await queueCreativeDirectorRenderFailureTask({
+    projectId: target.projectId,
+    sceneId: target.sceneId || null,
+    jobId: job.id,
+    error: job.error || 'render failed',
+  }).catch((error) => console.log(`⚠️ CD render repair task enqueue failed for ${job.id}: ${error.message}`));
+}
+
+export function initCreativeDirectorRenderFailureHook() {
+  if (initialized) return;
+  initialized = true;
+  mediaJobEvents.on('failed', onFailed);
+  console.log('🛠️ Creative Director render-failure recovery hook initialized');
+}
+
+export const __testing = {
+  creativeDirectorTarget,
+  reset() {
+    if (initialized) mediaJobEvents.off('failed', onFailed);
+    initialized = false;
+  },
+};

--- a/server/services/creativeDirector/renderFailureHook.test.js
+++ b/server/services/creativeDirector/renderFailureHook.test.js
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const queueCreativeDirectorRenderFailureTask = vi.fn(() => Promise.resolve({ id: 'sys-repair-1' }));
+vi.mock('./renderFailureTask.js', () => ({ queueCreativeDirectorRenderFailureTask }));
+
+const { mediaJobEvents } = await import('../mediaJobQueue/index.js');
+const { initCreativeDirectorRenderFailureHook, __testing } = await import('./renderFailureHook.js');
+
+afterEach(() => {
+  __testing.reset();
+  queueCreativeDirectorRenderFailureTask.mockClear();
+});
+
+describe('Creative Director render failure hook', () => {
+  it('queues a repair task for tagged scene and project-level jobs', async () => {
+    initCreativeDirectorRenderFailureHook();
+    mediaJobEvents.emit('failed', {
+      id: 'job-scene', error: 'bad frames',
+      params: { creativeDirector: { projectId: 'project-1', sceneId: 'scene-2' } },
+    });
+    mediaJobEvents.emit('failed', {
+      id: 'job-music', error: 'bad audio',
+      params: { creativeDirectorMusicBed: { projectId: 'project-2' } },
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(queueCreativeDirectorRenderFailureTask).toHaveBeenCalledTimes(2);
+    expect(queueCreativeDirectorRenderFailureTask).toHaveBeenNthCalledWith(1, {
+      projectId: 'project-1', sceneId: 'scene-2', jobId: 'job-scene', error: 'bad frames',
+    });
+    expect(queueCreativeDirectorRenderFailureTask).toHaveBeenNthCalledWith(2, {
+      projectId: 'project-2', sceneId: null, jobId: 'job-music', error: 'bad audio',
+    });
+  });
+
+  it('ignores failures from unrelated media jobs', async () => {
+    initCreativeDirectorRenderFailureHook();
+    mediaJobEvents.emit('failed', { id: 'job-other', error: 'not CD', params: { prompt: 'plain render' } });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(queueCreativeDirectorRenderFailureTask).not.toHaveBeenCalled();
+  });
+});

--- a/server/services/creativeDirector/renderFailureTask.js
+++ b/server/services/creativeDirector/renderFailureTask.js
@@ -1,0 +1,44 @@
+const RENDER_FAILURE_CONTEXT_LIMIT = 2000;
+
+export function buildCreativeDirectorRenderFailureTask({ projectId, sceneId = null, jobId, error }) {
+  const safeError = String(error || 'render failed').slice(0, RENDER_FAILURE_CONTEXT_LIMIT);
+  const target = sceneId ? `scene ${sceneId}` : 'project-level render';
+  return {
+    description: `Creative Director render failure: fix project ${projectId} ${target}`,
+    context: [
+      'An automatic Creative Director media render failure needs investigation and a code fix.',
+      `Project: ${projectId}`,
+      `Scene: ${sceneId || 'none (project-level render)'}`,
+      `Media job: ${jobId || 'unknown'}`,
+      `Renderer error: ${safeError}`,
+      '',
+      'Inspect the render-parameter and provider-constraint path that produced this error. Implement the smallest durable fix, add or update focused tests, run the relevant server tests, and open a PR with the fix.',
+    ].join('\n'),
+    priority: 'HIGH',
+    useWorktree: true,
+    openPR: true,
+    simplify: true,
+    isRecovery: true,
+    diagnostics: {
+      triggerEvent: 'CREATIVE_DIRECTOR_RENDER_FAILED',
+      target: 'creativeDirector/renderFailureHook',
+      errorType: 'render-error',
+      category: 'creative-director-render',
+      tier: 'code-fix',
+      fixStrategy: 'inspect-render-parameters-and-provider-constraints',
+      failureReason: safeError,
+    },
+  };
+}
+
+export async function queueCreativeDirectorRenderFailureTask({ projectId, sceneId = null, jobId, error }) {
+  const task = buildCreativeDirectorRenderFailureTask({ projectId, sceneId, jobId, error });
+  const { addTask } = await import('../cos.js');
+  const queued = await addTask(task, 'internal');
+  if (queued?.duplicate) {
+    console.log(`⚠️ CD render repair already queued for ${projectId}/${sceneId || 'project'} as ${queued.id}`);
+    return queued;
+  }
+  console.log(`🛠️ CD render repair task queued for ${projectId}/${sceneId || 'project'}: ${queued.id}`);
+  return queued;
+}

--- a/server/services/creativeDirector/renderFailureTask.test.js
+++ b/server/services/creativeDirector/renderFailureTask.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { buildCreativeDirectorRenderFailureTask } from './renderFailureTask.js';
+
+describe('buildCreativeDirectorRenderFailureTask', () => {
+  it('creates a deduplicable internal repair task with bounded failure context', () => {
+    const task = buildCreativeDirectorRenderFailureTask({
+      projectId: 'project-1', sceneId: 'scene-2', jobId: 'job-3',
+      error: 'MiniMax H3 requires a 17n+5 frame count between 107 and 362; got 304',
+    });
+    expect(task).toMatchObject({
+      description: 'Creative Director render failure: fix project project-1 scene scene-2',
+      priority: 'HIGH', useWorktree: true, openPR: true, simplify: true, isRecovery: true,
+      diagnostics: {
+        triggerEvent: 'CREATIVE_DIRECTOR_RENDER_FAILED',
+        target: 'creativeDirector/renderFailureHook',
+        failureReason: 'MiniMax H3 requires a 17n+5 frame count between 107 and 362; got 304',
+      },
+    });
+    expect(task.context).toContain('Media job: job-3');
+  });
+
+  it('truncates provider errors before persisting them in a task', () => {
+    const task = buildCreativeDirectorRenderFailureTask({ projectId: 'project-1', sceneId: 'scene-2', error: 'x'.repeat(3000) });
+    expect(task.diagnostics.failureReason).toHaveLength(2000);
+    expect(task.context).toContain(`Renderer error: ${'x'.repeat(2000)}`);
+  });
+});

--- a/server/services/creativeDirector/sceneRunner.js
+++ b/server/services/creativeDirector/sceneRunner.js
@@ -213,6 +213,7 @@ export async function runSceneRender(project, scene) {
       // Geometry rides along in `shared` — grok.js reads it to derive the
       // project's aspect ratio for the base image.
       ...grokVideoJobParams(settings, { sourceImagePath, durationSeconds: scene.durationSeconds }),
+      creativeDirector: { projectId: project.id, sceneId: scene.sceneId },
     }
     : {
       ...shared,

--- a/server/services/creativeDirector/sceneRunner.js
+++ b/server/services/creativeDirector/sceneRunner.js
@@ -233,6 +233,7 @@ export async function runSceneRender(project, scene) {
       // wall-clock per scene roughly in half. Project-level so every scene
       // in the project inherits the same setting.
       disableAudio: project.disableAudio === true,
+      creativeDirector: { projectId: project.id, sceneId: scene.sceneId },
     };
 
   if (useGrok) {


### PR DESCRIPTION
## Summary
- Queue a deduplicated internal CoS repair task when a Creative Director media job fails.
- Cover scene video, first-pass scene-frame image, and music-bed audio jobs with the existing media-job event bus.
- Preserve the provider error and render context for an agent to diagnose and fix.

## Test plan
- `cd server && npx vitest run services/creativeDirector/sceneRunner.test.js services/creativeDirector/renderFailureTask.test.js services/creativeDirector/renderFailureHook.test.js`
- 3 test files, 18 tests passed.