### PR TITLE
feat: configure Ollama generation controls

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -640,6 +640,9 @@ export function LocalLlmTab() {
         <p className="text-xs text-gray-500">
           Both backends can be installed and running at the same time — <span className="text-gray-400">Default</span> just sets which one PortOS routes local-LLM runs to. Use <span className="text-gray-400">Import from…</span> to copy or link models between them without re-downloading.
         </p>
+        <p className="text-xs text-gray-500">
+          For Ollama coding agents, configure the shared <Link to="/ai" className="text-port-accent hover:underline">temperature and thinking defaults in AI Providers</Link>. Native Ollama and OpenCode receive both controls; Claude/Ollama honors the thinking toggle. New local providers start at temperature 0.6.
+        </p>
 
         {loading && !status ? (
           <BrailleSpinner text="Loading local LLM status" />

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -64,6 +64,11 @@ beforeEach(() => {
 });
 
 describe('LocalLlmTab installed models', () => {
+  it('links to the shared Ollama generation controls', async () => {
+    await renderTab();
+    expect(screen.getByRole('link', { name: /temperature and thinking defaults/i }).getAttribute('href')).toBe('/ai');
+  });
+
   it('lets a long model id wrap instead of truncating it', async () => {
     await renderTab();
     const name = screen.getByText(LONG_ID);

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -863,6 +863,8 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [], runnerAllo
     fallbackProvider: provider?.fallbackProvider || '',
     fallbackModel: provider?.fallbackModel || '',
     numCtx: provider?.numCtx ?? '',
+    temperature: provider?.temperature ?? 0.6,
+    thinking: provider?.thinking ?? true,
     contextWindow: provider?.contextWindow ?? '',
     timeout: provider?.timeout || 300000,
     enabled: provider?.enabled !== false,
@@ -942,6 +944,10 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [], runnerAllo
     if (!input) return null;
     return /^\d+$/.test(input) ? Number(input) : value;
   };
+  const parseNumberField = (value) => {
+    const input = String(value ?? '').trim();
+    return input === '' ? undefined : Number(input);
+  };
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -960,6 +966,7 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [], runnerAllo
       headlessArgs: formData.headlessArgs ? formData.headlessArgs.split(' ').filter(Boolean) : [],
       contextWindow: parseOptionalIntField(formData.contextWindow),
       numCtx: showsNumCtx ? parseOptionalIntField(formData.numCtx) : null,
+      ...(showsNumCtx ? { temperature: parseNumberField(formData.temperature), thinking: formData.thinking } : {}),
     };
     // The generation/fallback pickers filter out embedding-only models, so a
     // stored embedding (from an older config) would be hidden in the UI yet
@@ -1365,6 +1372,33 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [], runnerAllo
               )}
             </div>
           </div>
+
+          {showsNumCtx && (
+            <div className="border-t border-port-border pt-4 mt-4">
+              <h4 className="text-sm font-medium text-gray-300 mb-3">Ollama Generation</h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <FormField label="Temperature">
+                  <input
+                    type="number"
+                    min="0"
+                    max="2"
+                    step="0.1"
+                    value={formData.temperature}
+                    onChange={(e) => setFormData(prev => ({ ...prev, temperature: e.target.value }))}
+                    className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white focus:border-port-accent focus:outline-hidden"
+                  />
+                  <p className="text-xs text-gray-500 mt-1">Defaults to 0.6 for local Ollama agent runs.</p>
+                </FormField>
+                <FormField label="Thinking mode">
+                  <label className="flex items-center gap-2 min-h-10 text-sm text-gray-300">
+                    <input type="checkbox" checked={formData.thinking} onChange={(e) => setFormData(prev => ({ ...prev, thinking: e.target.checked }))} />
+                    Enable model reasoning
+                  </label>
+                  <p className="text-xs text-gray-500 mt-1">Sent to thinking-capable Ollama models; unsupported models ignore it.</p>
+                </FormField>
+              </div>
+            </div>
+          )}
 
           {/* Fallback Provider */}
           <div className="border-t border-port-border pt-4 mt-4">

--- a/data.reference/providers.json
+++ b/data.reference/providers.json
@@ -44,6 +44,8 @@
       "models": [],
       "defaultModel": null,
       "ollamaBacked": true,
+      "temperature": 0.6,
+      "thinking": true,
       "timeout": 600000,
       "enabled": false,
       "envVars": {
@@ -142,6 +144,8 @@
       "models": [],
       "defaultModel": null,
       "ollamaBacked": true,
+      "temperature": 0.6,
+      "thinking": true,
       "timeout": 600000,
       "enabled": false,
       "envVars": {
@@ -161,6 +165,8 @@
       "models": [],
       "defaultModel": null,
       "ollamaBacked": true,
+      "temperature": 0.6,
+      "thinking": true,
       "timeout": 600000,
       "enabled": false,
       "envVars": {
@@ -178,6 +184,8 @@
       "models": [],
       "defaultModel": null,
       "ollamaBacked": true,
+      "temperature": 0.6,
+      "thinking": true,
       "timeout": 600000,
       "enabled": false,
       "envVars": {
@@ -257,6 +265,8 @@
       "type": "api",
       "endpoint": "http://localhost:11434/v1",
       "apiKey": "",
+      "temperature": 0.6,
+      "thinking": true,
       "models": [],
       "defaultModel": null,
       "timeout": 300000,

--- a/server/lib/aiToolkit/defaults/providers.sample.json
+++ b/server/lib/aiToolkit/defaults/providers.sample.json
@@ -47,6 +47,8 @@
       "models": [],
       "defaultModel": null,
       "ollamaBacked": true,
+      "temperature": 0.6,
+      "thinking": true,
       "timeout": 600000,
       "enabled": false,
       "envVars": {
@@ -66,6 +68,8 @@
       "models": [],
       "defaultModel": null,
       "ollamaBacked": true,
+      "temperature": 0.6,
+      "thinking": true,
       "timeout": 600000,
       "enabled": false,
       "envVars": {
@@ -303,6 +307,8 @@
       "type": "api",
       "endpoint": "http://localhost:11434/v1",
       "apiKey": "",
+      "temperature": 0.6,
+      "thinking": true,
       "models": [],
       "defaultModel": null,
       "timeout": 300000,

--- a/server/lib/aiToolkit/providers.js
+++ b/server/lib/aiToolkit/providers.js
@@ -548,6 +548,8 @@ export function createProviderService(config = {}) {
         fallbackProvider: providerData.fallbackProvider || null,
         fallbackModel: providerData.fallbackModel || null,
         numCtx: providerData.numCtx || null,
+        temperature: providerData.temperature,
+        thinking: providerData.thinking,
         contextWindow: providerData.contextWindow || null,
         timeout: providerData.timeout || 300000,
         enabled: providerData.enabled !== false,

--- a/server/lib/aiToolkit/providers.test.js
+++ b/server/lib/aiToolkit/providers.test.js
@@ -37,6 +37,14 @@ describe('Provider Service', () => {
     expect(provider.type).toBe('cli');
   });
 
+  it('persists Ollama generation controls when creating a provider', async () => {
+    const provider = await providerService.createProvider({
+      name: 'Local Ollama', type: 'cli', command: 'opencode', ollamaBacked: true,
+      temperature: 0.6, thinking: false,
+    });
+    expect(provider).toMatchObject({ temperature: 0.6, thinking: false });
+  });
+
   it('should get all providers', async () => {
     await providerService.createProvider({
       name: 'Test Provider 1',

--- a/server/lib/aiToolkit/runner.js
+++ b/server/lib/aiToolkit/runner.js
@@ -6,6 +6,7 @@ import { join, extname, basename, isAbsolute, delimiter } from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { randomUUID } from 'crypto';
 import { analyzeError, analyzeHttpError, ERROR_CATEGORIES } from './errorDetection.js';
+import { isOllamaBackedProvider } from './internal/ollamaBacked.js';
 
 // npm-installed CLI providers (claude, codex, opencode, …) are .cmd/.bat
 // shims on Windows; Node's spawn() can't execute those without going through
@@ -650,6 +651,12 @@ export function createRunnerService(config = {}) {
               model: model || provider.defaultModel,
               messages: [{ role: 'user', content: messageContent }],
               stream: true,
+              ...(isOllamaBackedProvider(provider)
+                ? {
+                    temperature: Number.isFinite(Number(provider.temperature)) ? Number(provider.temperature) : 0.6,
+                    ...(typeof provider.thinking === 'boolean' ? { think: provider.thinking } : {})
+                  }
+                : {}),
               // Ollama's OpenAI-compatible endpoint defaults to a ~4K context
               // window and silently truncates longer prompts. A top-level
               // num_ctx lifts it (honored by Ollama, ignored by other

--- a/server/lib/aiToolkit/runner.test.js
+++ b/server/lib/aiToolkit/runner.test.js
@@ -116,6 +116,19 @@ describe('AI Toolkit runner service', () => {
     expect(JSON.parse(fetch.mock.calls[0][1].body).num_ctx).toBe(32768);
   });
 
+  it('sends configured Ollama temperature and thinking mode', async () => {
+    const dataDir = await mkdtemp(join(tmpdir(), 'ai-toolkit-runner-'));
+    tempDirs.push(dataDir);
+    const fetch = stubStreamingFetch();
+    const runner = createRunnerService({ dataDir, hooks: { ensureProviderReady: async () => ({ success: true }) } });
+    let done;
+    const completed = new Promise((resolve) => { done = resolve; });
+    await runner.executeApiRun({ runId: 'run-ollama-options', provider: runReady({ temperature: 0.6, thinking: false }), model: null, prompt: 'hi', workspacePath: process.cwd(), screenshots: [], onData: undefined, onComplete: () => done() });
+    await completed;
+
+    expect(JSON.parse(fetch.mock.calls[0][1].body)).toMatchObject({ temperature: 0.6, think: false });
+  });
+
   it('omits num_ctx when the provider does not set it', async () => {
     const dataDir = await mkdtemp(join(tmpdir(), 'ai-toolkit-runner-'));
     tempDirs.push(dataDir);

--- a/server/lib/aiToolkit/validation.js
+++ b/server/lib/aiToolkit/validation.js
@@ -86,6 +86,10 @@ export const providerSchema = z.object({
   // Per-request context window (Ollama num_ctx). Lifts the ~4K default so long
   // prompts (e.g. a whole manuscript) aren't silently truncated. Null = unset.
   numCtx: z.number().int().min(512).max(1048576).nullable().optional(),
+  // Ollama generation controls. These are provider-level so the same local
+  // model keeps its defaults across API, CLI, and TUI launchers.
+  temperature: z.number().min(0).max(2).optional(),
+  thinking: z.boolean().optional(),
   // Planning-time context window (tokens) the editorial budgeter may assume for
   // this provider — distinct from numCtx (what we *ask Ollama for*). For cloud
   // providers numCtx stays null and this reflects the model's real ceiling.

--- a/server/lib/aiToolkit/validation.test.js
+++ b/server/lib/aiToolkit/validation.test.js
@@ -139,6 +139,18 @@ describe('providerSchema', () => {
     });
   });
 
+  describe('Ollama generation controls', () => {
+    it('accepts temperature and thinking mode within their safe bounds', () => {
+      const result = providerSchema.safeParse({ ...minimalProvider, temperature: 0.6, thinking: false });
+      expect(result.success).toBe(true);
+      expect(result.data).toMatchObject({ temperature: 0.6, thinking: false });
+    });
+
+    it('rejects an out-of-range Ollama temperature', () => {
+      expect(providerSchema.safeParse({ ...minimalProvider, temperature: 2.1 }).success).toBe(false);
+    });
+  });
+
   describe('default reasoning effort', () => {
     it('accepts known effort levels and treats an empty UI value as unset', () => {
       expect(providerSchema.safeParse({ ...minimalProvider, effort: 'xhigh' }).success).toBe(true);

--- a/server/lib/cliChildEnv.js
+++ b/server/lib/cliChildEnv.js
@@ -55,7 +55,13 @@ const CLAUDE_OLLAMA_MAX_OUTPUT_TOKENS = '65536';
 function claudeOllamaEnvDefaults(provider) {
   const command = String(provider?.command || '').split(/[\\/]/).pop()?.replace(/\.(?:cmd|exe)$/i, '').toLowerCase();
   return provider?.ollamaBacked === true && command === 'claude'
-    ? { CLAUDE_CODE_MAX_OUTPUT_TOKENS: CLAUDE_OLLAMA_MAX_OUTPUT_TOKENS }
+    ? {
+        CLAUDE_CODE_MAX_OUTPUT_TOKENS: CLAUDE_OLLAMA_MAX_OUTPUT_TOKENS,
+        // Claude Code omits the Anthropic-compatible `thinking` field when
+        // this is zero, which Ollama maps to Qwen's non-thinking mode. Do not
+        // set a value when enabled: Claude retains its normal adaptive budget.
+        ...(provider.thinking === false ? { MAX_THINKING_TOKENS: '0' } : {}),
+      }
     : {};
 }
 
@@ -69,7 +75,7 @@ function claudeOllamaEnvDefaults(provider) {
  * @param {object} options
  * @param {object|null} [options.before] - layered first, so `provider.envVars`
  *   overrides it (forgeTokenEnv, claudeSettingsEnv).
- * @param {{command?:string, envVars?:object, models?:string[], defaultModel?:string|null, ollamaBacked?:boolean, mtplxBacked?:boolean}|null} [options.provider]
+ * @param {{command?:string, envVars?:object, models?:string[], defaultModel?:string|null, ollamaBacked?:boolean, mtplxBacked?:boolean, thinking?:boolean}|null} [options.provider]
  * @param {string|null} [options.model] - the model being run this invocation,
  *   unioned into the OpenCode declared-models map. Omit when the site has no
  *   per-call model — `provider.defaultModel` is always declared regardless.

--- a/server/lib/cliChildEnv.test.js
+++ b/server/lib/cliChildEnv.test.js
@@ -162,6 +162,12 @@ describe('composeProviderEnv — delta for sites that do not spawn directly', ()
     }).CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBeUndefined();
   });
 
+  it('disables Claude/Ollama thinking when the provider requests it', () => {
+    const localClaude = { command: 'claude', ollamaBacked: true, thinking: false, envVars: {} };
+    expect(composeProviderEnv({ provider: localClaude }).MAX_THINKING_TOKENS).toBe('0');
+    expect(composeProviderEnv({ provider: { ...localClaude, thinking: true } }).MAX_THINKING_TOKENS).toBeUndefined();
+  });
+
   it('emits only the provider layers, with no base env, PWD, or strip', () => {
     const delta = composeProviderEnv({
       before: { GH_TOKEN: 'forge' },

--- a/server/lib/opencodeConfig.js
+++ b/server/lib/opencodeConfig.js
@@ -89,7 +89,7 @@ export function toBareModelIds(models, providerKey = 'ollama') {
  * @param {'ollama'|'mtplx'} [providerKey='ollama']
  * @returns {object} OpenCode config object
  */
-export function buildOpencodeConfig(models, base = null, providerKey = 'ollama') {
+export function buildOpencodeConfig(models, base = null, providerKey = 'ollama', generation = null) {
   const bareIds = toBareModelIds(models, providerKey);
   const config = (base && typeof base === 'object')
     ? structuredClone(base)
@@ -107,6 +107,20 @@ export function buildOpencodeConfig(models, base = null, providerKey = 'ollama')
       ...Object.fromEntries(bareIds.map((id) => [id, { name: id, tool_call: true }])),
     };
   }
+  // OpenCode applies generation controls to agents, not provider definitions.
+  // `build` is its primary coding agent for both `opencode run` and the TUI;
+  // unknown agent options are passed through to the provider, including
+  // Ollama's native `think` flag.
+  if (generation && providerKey === 'ollama') {
+    const temperature = Number.isFinite(Number(generation.temperature)) ? Number(generation.temperature) : 0.6;
+    const thinking = typeof generation.thinking === 'boolean' ? generation.thinking : undefined;
+    config.agent = { ...(config.agent && typeof config.agent === 'object' ? config.agent : {}) };
+    config.agent.build = {
+      ...(config.agent.build && typeof config.agent.build === 'object' ? config.agent.build : {}),
+      temperature,
+      ...(thinking === undefined ? {} : { think: thinking }),
+    };
+  }
   return config;
 }
 
@@ -120,8 +134,8 @@ export function buildOpencodeConfig(models, base = null, providerKey = 'ollama')
  * @param {'ollama'|'mtplx'} [providerKey='ollama']
  * @returns {string} JSON string for OPENCODE_CONFIG_CONTENT
  */
-export function buildOpencodeConfigContent(models, base = null, providerKey = 'ollama') {
-  return JSON.stringify(buildOpencodeConfig(models, base, providerKey));
+export function buildOpencodeConfigContent(models, base = null, providerKey = 'ollama', generation = null) {
+  return JSON.stringify(buildOpencodeConfig(models, base, providerKey, generation));
 }
 
 /**
@@ -164,6 +178,6 @@ export function buildOpencodeEnvVars(provider, model) {
     model,
   ];
   return {
-    OPENCODE_CONFIG_CONTENT: buildOpencodeConfigContent(ids, base, providerKey),
+    OPENCODE_CONFIG_CONTENT: buildOpencodeConfigContent(ids, base, providerKey, provider),
   };
 }

--- a/server/lib/opencodeConfig.test.js
+++ b/server/lib/opencodeConfig.test.js
@@ -130,10 +130,11 @@ describe('buildOpencodeEnvVars', () => {
   });
 
   it('declares the run model (bare) under provider.ollama.models', () => {
-    const result = buildOpencodeEnvVars({ command: 'opencode', ollamaBacked: true, models: [] }, 'qwen2.5:7b');
+    const result = buildOpencodeEnvVars({ command: 'opencode', ollamaBacked: true, models: [], temperature: 0.6, thinking: false }, 'qwen2.5:7b');
     expect(result.OPENCODE_CONFIG_CONTENT).toBeDefined();
     const cfg = JSON.parse(result.OPENCODE_CONFIG_CONTENT);
     expect(cfg.provider.ollama.models['qwen2.5:7b']).toEqual({ name: 'qwen2.5:7b', tool_call: true });
+    expect(cfg.agent.build).toEqual({ temperature: 0.6, think: false });
   });
 
   it('declares the run model under provider.mtplx.models for MTPLX-backed OpenCode', () => {


### PR DESCRIPTION
## Summary
- add provider-level Ollama temperature and thinking controls, defaulting local providers to 0.6
- pass controls to native Ollama API and OpenCode CLI/TUI runs, with Claude/Ollama thinking disable support
- expose the controls from the Local LLM settings area and seed local provider samples

## Test plan
- `cd server && npm test -- --run lib/opencodeConfig.test.js lib/cliChildEnv.test.js lib/aiToolkit/validation.test.js lib/aiToolkit/providers.test.js lib/aiToolkit/runner.test.js`
- `cd client && npm test -- --run components/settings/LocalLlmTab.test.jsx pages/AIProviders.test.jsx --configLoader runner`