### PR TITLE
fix: recommend MLX Community Qwen3.8 model

### DIFF
--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -290,12 +290,12 @@ export const LOCAL_LLM_CATALOG = [
     params: '27B',
     size: '15.0 GB',
     family: 'qwen',
-    description: 'LM Studio’s 4-bit MLX build of Qwen3.8 27B — a native Apple-Silicon format with long context, coding, reasoning, tools, vision, thinking, and multilingual support.',
+    description: 'MLX Community’s current 4-bit Qwen3.8 27B build — a native Apple-Silicon format with long context, coding, reasoning, tools, vision, thinking, and multilingual support.',
     capabilities: ['chat', 'code', 'reasoning', 'tools', 'vision', 'multilingual'],
     context: 262144,
     format: 'mlx',
     appleSiliconOnly: true,
-    lmstudio: 'lmstudio-community/Qwen3.8-27B-MLX-4bit'
+    lmstudio: 'mlx-community/Qwen3.8-27B-4bit'
   },
   {
     key: 'qwen3.8-27b',

--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -39,7 +39,8 @@ export const LOCAL_LLM_CATEGORIES = [
 
 // Each entry: { key, name, category, recommendedFor?, featured?, params, size,
 //               family, description, capabilities, context?, format?,
-//               appleSiliconOnly?, ollama?, lmstudio? }
+//               appleSiliconOnly?, ollama?, lmstudio?, ollamaAliases?,
+//               lmstudioAliases? }
 //
 // `category` is the one primary lane that groups a model in the unfiltered
 // picker. `recommendedFor` is its intentionally broader set of use-case lanes:
@@ -50,6 +51,8 @@ export const LOCAL_LLM_CATEGORIES = [
 // `ollama` / `lmstudio` are the exact pull/download ids for that backend.
 // A missing id means there is no well-known build of that model for that
 // backend (the user can still free-text install one).
+// `ollamaAliases` / `lmstudioAliases` preserve recognized ids retired by an
+// upstream publisher without making them available as fresh install targets.
 // `context` is the model's native context window in tokens — set it only when
 // it's a documented spec for that build (the install-card badge shows it; live
 // Hugging Face results read the true value from GGUF metadata instead).
@@ -295,7 +298,8 @@ export const LOCAL_LLM_CATALOG = [
     context: 262144,
     format: 'mlx',
     appleSiliconOnly: true,
-    lmstudio: 'mlx-community/Qwen3.8-27B-4bit'
+    lmstudio: 'mlx-community/Qwen3.8-27B-4bit',
+    lmstudioAliases: ['lmstudio-community/Qwen3.8-27B-MLX-4bit']
   },
   {
     key: 'qwen3.8-27b',
@@ -668,6 +672,14 @@ const normalizeLmStudioId = (id) => String(id || '')
 const normalizeFor = (backend, id) =>
   backend === 'ollama' ? normalizeOllamaId(id) : normalizeLmStudioId(id);
 
+const entryIdsForBackend = (entry, backend) => [
+  entry[backend],
+  ...(Array.isArray(entry[`${backend}Aliases`]) ? entry[`${backend}Aliases`] : [])
+].filter(Boolean);
+
+const entryMatchesBackendId = (entry, backend, normalizedId) =>
+  entryIdsForBackend(entry, backend).some((id) => normalizeFor(backend, id) === normalizedId);
+
 /**
  * Return the catalog projected onto a single backend: only entries that ship
  * a known build for `backend`, each with the backend-specific install id
@@ -702,7 +714,8 @@ export function getCatalog(backend, installedIds = [], { appleSilicon } = {}) {
         format: entry.format || null,
         // Native context window (tokens), when it's a documented spec; null otherwise.
         contextLength: Number.isFinite(entry.context) ? entry.context : null,
-        installed: installedNorm.has(normalizeFor(backend, entry[backend]))
+        installed: entryIdsForBackend(entry, backend)
+          .some((id) => installedNorm.has(normalizeFor(backend, id)))
       };
     });
 }
@@ -744,7 +757,7 @@ export function mapModelToBackend(fromBackend, modelId, toBackend) {
   // Suggested models first, then models retired from the picker — an install
   // that predates a catalog refresh still migrates exactly.
   const entry = [...LOCAL_LLM_CATALOG, ...RETIRED_MODEL_MAPPINGS].find(
-    (e) => e[fromBackend] && normalizeFor(fromBackend, e[fromBackend]) === fromNorm
+    (e) => entryMatchesBackendId(e, fromBackend, fromNorm)
   );
   if (entry && entry[toBackend]) {
     return { targetId: entry[toBackend], exact: true };

--- a/server/lib/localLlmCatalog.test.js
+++ b/server/lib/localLlmCatalog.test.js
@@ -50,11 +50,11 @@ describe('localLlmCatalog', () => {
       expect(list.find((m) => m.key === 'gemma4-12b').installed).toBe(true);
     });
 
-    it('gates the native Qwen MLX recommendation to Apple Silicon', () => {
+    it('gates the current MLX Community Qwen recommendation to Apple Silicon', () => {
       const mlxKey = 'qwen3.8-27b-mlx-4bit';
       expect(getCatalog('lmstudio').find((m) => m.key === mlxKey)).toMatchObject({
         format: 'mlx',
-        id: 'lmstudio-community/Qwen3.8-27B-MLX-4bit'
+        id: 'mlx-community/Qwen3.8-27B-4bit'
       });
       expect(getCatalog('lmstudio', [], { appleSilicon: true }).some((m) => m.key === mlxKey)).toBe(true);
       expect(getCatalog('lmstudio', [], { appleSilicon: false }).some((m) => m.key === mlxKey)).toBe(false);
@@ -151,7 +151,7 @@ describe('localLlmCatalog', () => {
     });
 
     it('does not invent an Ollama target for a known LM Studio-only MLX build', () => {
-      expect(mapModelToBackend('lmstudio', 'lmstudio-community/Qwen3.8-27B-MLX-4bit', 'ollama'))
+      expect(mapModelToBackend('lmstudio', 'mlx-community/Qwen3.8-27B-4bit', 'ollama'))
         .toEqual({ targetId: null, exact: false });
     });
 

--- a/server/lib/localLlmCatalog.test.js
+++ b/server/lib/localLlmCatalog.test.js
@@ -56,6 +56,8 @@ describe('localLlmCatalog', () => {
         format: 'mlx',
         id: 'mlx-community/Qwen3.8-27B-4bit'
       });
+      expect(getCatalog('lmstudio', ['lmstudio-community/Qwen3.8-27B-MLX-4bit'])
+        .find((m) => m.key === mlxKey)?.installed).toBe(true);
       expect(getCatalog('lmstudio', [], { appleSilicon: true }).some((m) => m.key === mlxKey)).toBe(true);
       expect(getCatalog('lmstudio', [], { appleSilicon: false }).some((m) => m.key === mlxKey)).toBe(false);
       expect(getCatalog('ollama', [], { appleSilicon: true }).some((m) => m.key === mlxKey)).toBe(false);
@@ -152,6 +154,8 @@ describe('localLlmCatalog', () => {
 
     it('does not invent an Ollama target for a known LM Studio-only MLX build', () => {
       expect(mapModelToBackend('lmstudio', 'mlx-community/Qwen3.8-27B-4bit', 'ollama'))
+        .toEqual({ targetId: null, exact: false });
+      expect(mapModelToBackend('lmstudio', 'lmstudio-community/Qwen3.8-27B-MLX-4bit', 'ollama'))
         .toEqual({ targetId: null, exact: false });
     });
 

--- a/server/services/huggingFaceCatalog.test.js
+++ b/server/services/huggingFaceCatalog.test.js
@@ -766,8 +766,8 @@ describe('huggingFaceCatalog', () => {
       expect(catalog[0].sizeBytes).toBe(8_000_000_000)
     })
 
-    it('enriches a curated LM Studio MLX entry with one installed native-format variant', async () => {
-      const repo = 'lmstudio-community/Qwen3.8-27B-MLX-4bit'
+    it('enriches the curated MLX Community Qwen entry with one installed native-format variant', async () => {
+      const repo = 'mlx-community/Qwen3.8-27B-4bit'
       fetch.mockResolvedValueOnce(blobs(repo, {
         'model-00001-of-00003.safetensors': 5_400_000_000,
         'model-00002-of-00003.safetensors': 5_300_000_000,


### PR DESCRIPTION
## Summary

- Point the Apple Silicon Qwen3.8 27B MLX recommendation at the current mlx-community 4-bit repository.
- Keep catalog mapping and MLX variant enrichment coverage aligned with the install identifier.

## Test plan

- `cd server && npm test -- lib/localLlmCatalog.test.js services/huggingFaceCatalog.test.js`