### PR TITLE
test(client): run remaining pure suites in Node

### DIFF
--- a/client/src/components/goals/goalTreeScene.test.js
+++ b/client/src/components/goals/goalTreeScene.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import {
   CAMERA_FIT_PADDING,

--- a/client/src/lib/morsePractice.test.js
+++ b/client/src/lib/morsePractice.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, expect, it } from 'vitest';
 import { canAdvanceMorseLevel, selectMorsePrompt } from './morsePractice.js';
 

--- a/client/src/utils/platform.test.js
+++ b/client/src/utils/platform.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect, afterEach, vi } from 'vitest';
 
 // `isMac`/`modKey` are evaluated once at module load, so every case has to


### PR DESCRIPTION
## Summary
- run platform, Morse-practice, and goal-tree geometry suites in Vitest Node
- retain every existing assertion while avoiding unnecessary jsdom startup

## Test plan
- npm exec -- vitest run src/utils/platform.test.js src/lib/morsePractice.test.js src/components/goals/goalTreeScene.test.js
- npm run lint --prefix client