### PR TITLE
test(client): isolate pure browser API tests from jsdom

### DIFF
--- a/client/src/hooks/index.test.js
+++ b/client/src/hooks/index.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';

--- a/client/src/lib/registerServiceWorker.test.js
+++ b/client/src/lib/registerServiceWorker.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { registerServiceWorker, unregisterServiceWorkers } from './registerServiceWorker.js';
 

--- a/client/src/pages/Dashboard.layoutRevert.test.js
+++ b/client/src/pages/Dashboard.layoutRevert.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 
 // Faithful inline model of Dashboard.jsx's active-layout switch+revert state

--- a/client/src/pages/Importer.collapse.test.jsx
+++ b/client/src/pages/Importer.collapse.test.jsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { collapseToSingleVolume, resolveRetryArcSummary } from './Importer.jsx';
 

--- a/client/src/services/browserLlm.test.js
+++ b/client/src/services/browserLlm.test.js
@@ -1,17 +1,29 @@
+// @vitest-environment node
+
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   isBrowserLlmApiPresent, nanoAvailability, isNanoReady, promptNano,
   destroyNanoSession, warmNano, NANO_AVAILABILITY,
 } from './browserLlm';
 
-// jsdom exposes `self` (=== window). We stub the Prompt API on it per test.
+// The API is defined on the global object in browsers, so Node can exercise the
+// same feature-detection contract without a jsdom window.
 const clearApi = () => {
-  delete self.LanguageModel;
-  if (self.ai) delete self.ai;
+  delete globalThis.LanguageModel;
+  if (globalThis.ai) delete globalThis.ai;
 };
 
-beforeEach(() => { destroyNanoSession(); clearApi(); });
-afterEach(() => { destroyNanoSession(); clearApi(); vi.restoreAllMocks(); });
+beforeEach(() => {
+  vi.stubGlobal('self', globalThis);
+  destroyNanoSession();
+  clearApi();
+});
+afterEach(() => {
+  destroyNanoSession();
+  clearApi();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
 
 describe('detection', () => {
   it('reports no-api when neither shape is present', async () => {
@@ -21,7 +33,7 @@ describe('detection', () => {
   });
 
   it('detects the modern global LanguageModel', async () => {
-    self.LanguageModel = { availability: vi.fn().mockResolvedValue('available') };
+    globalThis.LanguageModel = { availability: vi.fn().mockResolvedValue('available') };
     expect(isBrowserLlmApiPresent()).toBe(true);
     expect(await nanoAvailability()).toBe('available');
     expect(await isNanoReady()).toBe(true);
@@ -31,18 +43,18 @@ describe('detection', () => {
     const availability = vi.fn()
       .mockRejectedValueOnce(new Error('opts not supported'))
       .mockResolvedValueOnce('downloadable');
-    self.LanguageModel = { availability };
+    globalThis.LanguageModel = { availability };
     expect(await nanoAvailability()).toBe('downloadable');
     expect(availability).toHaveBeenCalledTimes(2);
   });
 
   it('maps the legacy capabilities() shape onto the enum', async () => {
-    self.ai = { languageModel: { capabilities: vi.fn().mockResolvedValue({ available: 'readily' }) } };
+    globalThis.ai = { languageModel: { capabilities: vi.fn().mockResolvedValue({ available: 'readily' }) } };
     expect(await nanoAvailability()).toBe('available');
   });
 
   it('returns unavailable when the availability probe throws', async () => {
-    self.LanguageModel = { availability: vi.fn().mockRejectedValue(new Error('boom')) };
+    globalThis.LanguageModel = { availability: vi.fn().mockRejectedValue(new Error('boom')) };
     expect(await nanoAvailability()).toBe(NANO_AVAILABILITY.UNAVAILABLE);
   });
 });
@@ -51,7 +63,7 @@ describe('promptNano', () => {
   it('creates a session (global shape) and returns the reply', async () => {
     const prompt = vi.fn().mockResolvedValue('hello there');
     const create = vi.fn().mockResolvedValue({ prompt, destroy: vi.fn() });
-    self.LanguageModel = { availability: vi.fn().mockResolvedValue('available'), create };
+    globalThis.LanguageModel = { availability: vi.fn().mockResolvedValue('available'), create };
     const out = await promptNano('hi', { systemPrompt: 'be nice', temperature: 0.5, topK: 2 });
     expect(out).toBe('hello there');
     expect(create).toHaveBeenCalledOnce();
@@ -66,7 +78,7 @@ describe('promptNano', () => {
     const prompt = vi.fn()
       .mockImplementationOnce((_t, opts) => (opts ? Promise.reject(new Error('no opts')) : Promise.resolve('x')))
       .mockResolvedValue('bare-ok');
-    self.LanguageModel = { availability: vi.fn().mockResolvedValue('available'), create: vi.fn().mockResolvedValue({ prompt }) };
+    globalThis.LanguageModel = { availability: vi.fn().mockResolvedValue('available'), create: vi.fn().mockResolvedValue({ prompt }) };
     const out = await promptNano('hi');
     expect(out).toBe('bare-ok');
     expect(prompt).toHaveBeenCalledTimes(2);
@@ -74,7 +86,7 @@ describe('promptNano', () => {
 
   it('rejects on timeout when the model stalls', async () => {
     const prompt = vi.fn().mockImplementation(() => new Promise(() => {})); // never resolves
-    self.LanguageModel = { availability: vi.fn().mockResolvedValue('available'), create: vi.fn().mockResolvedValue({ prompt }) };
+    globalThis.LanguageModel = { availability: vi.fn().mockResolvedValue('available'), create: vi.fn().mockResolvedValue({ prompt }) };
     await expect(promptNano('hi', { timeoutMs: 20 })).rejects.toThrow(/timeout/i);
   });
 
@@ -82,7 +94,7 @@ describe('promptNano', () => {
     const create = vi.fn()
       .mockResolvedValueOnce({ prompt: vi.fn().mockImplementation(() => new Promise(() => {})), destroy: vi.fn() }) // stalls → timeout
       .mockResolvedValueOnce({ prompt: vi.fn().mockResolvedValue('ok'), destroy: vi.fn() });
-    self.LanguageModel = { availability: vi.fn().mockResolvedValue('available'), create };
+    globalThis.LanguageModel = { availability: vi.fn().mockResolvedValue('available'), create };
     await expect(promptNano('hi', { timeoutMs: 20 })).rejects.toThrow(/timeout/i);
     // A wedged session would make this reject too; instead it builds a fresh one.
     await expect(promptNano('again', { timeoutMs: 500 })).resolves.toBe('ok');
@@ -91,7 +103,7 @@ describe('promptNano', () => {
 
   it('uses the legacy top-level systemPrompt shape', async () => {
     const create = vi.fn().mockResolvedValue({ prompt: vi.fn().mockResolvedValue('ok') });
-    self.ai = { languageModel: { capabilities: vi.fn().mockResolvedValue({ available: 'readily' }), create } };
+    globalThis.ai = { languageModel: { capabilities: vi.fn().mockResolvedValue({ available: 'readily' }), create } };
     await promptNano('hi', { systemPrompt: 'persona' });
     expect(create.mock.calls[0][0]).toMatchObject({ systemPrompt: 'persona' });
   });
@@ -99,12 +111,12 @@ describe('promptNano', () => {
 
 describe('warmNano', () => {
   it('no-ops (false) unless the model is fully available', async () => {
-    self.LanguageModel = { availability: vi.fn().mockResolvedValue('downloadable'), create: vi.fn() };
+    globalThis.LanguageModel = { availability: vi.fn().mockResolvedValue('downloadable'), create: vi.fn() };
     expect(await warmNano()).toBe(false);
   });
 
   it('builds a session when available', async () => {
-    self.LanguageModel = { availability: vi.fn().mockResolvedValue('available'), create: vi.fn().mockResolvedValue({ prompt: vi.fn(), destroy: vi.fn() }) };
+    globalThis.LanguageModel = { availability: vi.fn().mockResolvedValue('available'), create: vi.fn().mockResolvedValue({ prompt: vi.fn(), destroy: vi.fn() }) };
     expect(await warmNano({ systemPrompt: 'x' })).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- run five browser-independent client suites in Vitest Node
- preserve browser LLM feature detection with a test-local self shim
- retain all 35 assertions while avoiding unnecessary jsdom startup

## Test plan
- npm exec -- vitest run src/services/browserLlm.test.js src/lib/registerServiceWorker.test.js src/hooks/index.test.js src/pages/Dashboard.layoutRevert.test.js src/pages/Importer.collapse.test.jsx
- npm run lint --prefix client