### PR TITLE
test(client): run playback helpers without jsdom

### DIFF
--- a/client/src/components/songs/ScoreSheet.test.jsx
+++ b/client/src/components/songs/ScoreSheet.test.jsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import ScoreSheet from './ScoreSheet.jsx';

--- a/client/src/lib/chiptunePlayback.test.js
+++ b/client/src/lib/chiptunePlayback.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 // Schedule + audio-session tests for the chiptune preview (#2911). Most of this
 // file exercises the Web-Audio-free exports (buildChiptuneSchedule /
 // parseChiptunePitch); the timing semantics there MUST agree with

--- a/client/src/lib/clipboard.test.js
+++ b/client/src/lib/clipboard.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const toastMock = { success: vi.fn(), error: vi.fn() };

--- a/client/src/lib/drumPlayer.test.js
+++ b/client/src/lib/drumPlayer.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { parseDrumChart } from './drumNotation.js';
 import { createDrumPlayer } from './drumPlayback.js';

--- a/client/src/lib/scorePlayback.race.test.js
+++ b/client/src/lib/scorePlayback.race.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 // Resume-window race guard for the score players. Lives in its own file because
 // the module memoizes one shared AudioContext on first use — a fresh module
 // registry (per Vitest file) lets the first play() create a *suspended* context

--- a/client/src/pages/Login.test.jsx
+++ b/client/src/pages/Login.test.jsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { sanitizeNext } from './Login';
 

--- a/client/src/pages/RunsHistoryPage.test.jsx
+++ b/client/src/pages/RunsHistoryPage.test.jsx
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect, vi } from 'vitest';
 
 // RunsHistoryPage pulls in the API barrel transitively; stub it so importing the


### PR DESCRIPTION
## Summary
- run seven pure client and audio-helper suites in Vitest Node
- retain all 85 assertions while avoiding unnecessary jsdom startup

## Test plan
- npm exec -- vitest run src/pages/RunsHistoryPage.test.jsx src/pages/Login.test.jsx src/components/songs/ScoreSheet.test.jsx src/lib/clipboard.test.js src/lib/drumPlayer.test.js src/lib/chiptunePlayback.test.js src/lib/scorePlayback.race.test.js
- npm run lint --prefix client