### PR TITLE
test(client): run service worker guards without jsdom

### DIFF
--- a/client/src/hooks/mountedRefConventions.test.js
+++ b/client/src/hooks/mountedRefConventions.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 /**
  * Repo-wide guard: `hooks/useMounted.js` is the only mounted-guard ref.
  *

--- a/client/src/test/sw.test.js
+++ b/client/src/test/sw.test.js
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { describe, it, expect } from 'vitest';
 import { createSwSandbox, dispatchNavigation } from './swSandbox.js';
 


### PR DESCRIPTION
## Summary
- run service-worker sandbox and mounted-ref convention suites in Vitest Node
- retain all 11 assertions while avoiding unnecessary jsdom startup

## Test plan
- npm exec -- vitest run src/hooks/mountedRefConventions.test.js src/test/sw.test.js
- npm run lint --prefix client