### PR TITLE
fix: align creative commissions with media capabilities

### DIFF
--- a/data.reference/prompts/stages/cd-plan.md
+++ b/data.reference/prompts/stages/cd-plan.md
@@ -16,6 +16,8 @@ You are the Creative Director acting as a general creative ORCHESTRATOR. Your jo
 
 **Constraints (JSON):** {{directive.constraintsJson}}
 
+For a Creative Commission, these constraints contain the user's authoritative `targetAbility` and sanitized `generation` form choices. Start from them. Do not substitute a different output type, backend, model, duration, count, quality, or aspect ratio.
+
 {{#hasCurrentPlan}}
 ## Current plan (revise this)
 
@@ -38,7 +40,9 @@ Parameters (JSON schema): {{parametersJson}}
 
 ## Locked render settings
 
-This project is locked to **{{render.aspectRatio}}** ({{render.width}}×{{render.height}}), **{{render.quality}}** quality, target ~{{render.targetDurationSeconds}}s. For any `media_enqueueVideoJob` step, set ONLY the creative params (`prompt`, `negativePrompt`, `style`, and optionally a shorter per-beat `durationSeconds`). Do NOT set `aspectRatio`, `width`, `height`, `fps`, or `steps` — the server forces the locked geometry onto every render, so any values you supply for those are ignored.
+This project is locked to **{{render.aspectRatio}}** ({{render.width}}×{{render.height}}), **{{render.quality}}** quality, target ~{{render.targetDurationSeconds}}s, using **{{render.modelName}}** (`{{render.modelId}}`). The selected model exposes these same options in the Video Gen UI: {{render.modelOptionsJson}}.
+
+For any `media_enqueueVideoJob` step, set only `prompt`, `style`, and optionally a shorter per-beat `durationSeconds`.{{#render.supportsNegativePrompt}} You may also set `negativePrompt`.{{/render.supportsNegativePrompt}}{{^render.supportsNegativePrompt}} Do NOT set `negativePrompt`; this model does not expose it in the UI.{{/render.supportsNegativePrompt}} Do not set or override backend, model, aspect ratio, width, height, FPS, frame count, steps, guidance, tiling, or audio controls. The server derives them from the user's commission and snaps them to the selected model's advertised options.
 
 ## Referencing a prior step's result
 

--- a/scripts/migrations/277-cd-plan-commission-controls.js
+++ b/scripts/migrations/277-cd-plan-commission-controls.js
@@ -1,0 +1,25 @@
+/**
+ * Keep Creative Commission planning anchored to the user's selected output and
+ * model capabilities. Hash replacement preserves customized stage prompts.
+ */
+
+import { makePromptReplaceMigration } from './_lib.js';
+
+export const ACCEPTED_OLD_MD5 = {
+  'cd-plan.md': ['ef0d96f6ebde43af6c4579969d31cfb7'],
+};
+
+export const NEW_SHIPPED_MD5 = {
+  'cd-plan.md': '41a61590896d1327df2c6915557361de',
+};
+
+const { applyMigration, up } = makePromptReplaceMigration({
+  accepted: ACCEPTED_OLD_MD5,
+  current: NEW_SHIPPED_MD5,
+  label: 'Creative Director commission controls',
+  customizedHint: () =>
+    '   Compare data.reference/prompts/stages/cd-plan.md with data/prompts/stages/cd-plan.md and merge the commission/model-control guidance.',
+});
+
+export { applyMigration };
+export default { up };

--- a/scripts/migrations/277-cd-plan-commission-controls.test.js
+++ b/scripts/migrations/277-cd-plan-commission-controls.test.js
@@ -1,0 +1,26 @@
+import { readFileSync } from 'fs';
+import { describe, expect, it } from 'vitest';
+
+import { repoRoot, runPromptMigrationTests } from './_testHelpers.js';
+import migration, {
+  ACCEPTED_OLD_MD5,
+  NEW_SHIPPED_MD5,
+  applyMigration,
+} from './277-cd-plan-commission-controls.js';
+
+describe('migration 277 — Creative Director commission controls', () => {
+  runPromptMigrationTests({
+    migration,
+    applyMigration,
+    ACCEPTED_OLD_MD5,
+    NEW_SHIPPED_MD5,
+    prefix: 'migration-277-cd-plan-controls-',
+  });
+
+  it('keeps the planner anchored to commission and model capabilities', () => {
+    const prompt = readFileSync(`${repoRoot}/data.reference/prompts/stages/cd-plan.md`, 'utf8');
+    expect(prompt).toContain("authoritative `targetAbility`");
+    expect(prompt).toContain('does not expose it in the UI');
+    expect(prompt).toContain("snaps them to the selected model's advertised options");
+  });
+});

--- a/server/lib/creativeDirectorPrompts.js
+++ b/server/lib/creativeDirectorPrompts.js
@@ -25,7 +25,6 @@ import {
   presetToRenderParams,
 } from './creativeDirectorPresets.js';
 import { PORTOS_API_URL } from './ports.js';
-import { getVideoModels } from './mediaModels.js';
 import { buildPrompt } from '../services/promptService.js';
 
 // Shared project-block view used by both prompt stages. Defaults out
@@ -86,7 +85,7 @@ export async function buildTreatmentPrompt(project) {
 // module and lib must not import it (nor pull its heavy import-time tool graph
 // into every prompt build). The template iterates `tools` + renders the
 // directive brief + the current plan (present only on a re-plan).
-function buildPlanView(project, toolSpecs) {
+function buildPlanView(project, toolSpecs, videoModels) {
   const directive = project.directive && typeof project.directive === 'object' ? project.directive : {};
   const deliverables = Array.isArray(directive.deliverables) ? directive.deliverables : [];
   const tools = (Array.isArray(toolSpecs) ? toolSpecs : []).map((s) => ({
@@ -100,7 +99,7 @@ function buildPlanView(project, toolSpecs) {
   // server forces these onto every video render (see media.js
   // enforceVideoRenderPreset). `width`/`height` degrade to 0 on an unknown ratio.
   const aspect = resolveAspectDimensions(project.aspectRatio, { width: 0, height: 0 });
-  const videoModel = getVideoModels().find((model) => model.id === project.modelId) || null;
+  const videoModel = videoModels.find((model) => model.id === project.modelId) || null;
   const render = {
     aspectRatio: project.aspectRatio,
     quality: project.quality,
@@ -150,7 +149,12 @@ function buildPlanView(project, toolSpecs) {
 }
 
 export async function buildPlanPrompt(project, { toolSpecs } = {}) {
-  const view = buildPlanView(project, toolSpecs);
+  // Keep the media registry off the treatment/evaluation import path. Several
+  // focused consumers intentionally mock only the PATHS keys they use; loading
+  // the on-disk model catalog is specific to planning and should happen only
+  // when a plan prompt is actually requested.
+  const { getVideoModels } = await import('./mediaModels.js');
+  const view = buildPlanView(project, toolSpecs, getVideoModels());
   return buildPrompt('cd-plan', view);
 }
 

--- a/server/lib/creativeDirectorPrompts.js
+++ b/server/lib/creativeDirectorPrompts.js
@@ -25,6 +25,7 @@ import {
   presetToRenderParams,
 } from './creativeDirectorPresets.js';
 import { PORTOS_API_URL } from './ports.js';
+import { getVideoModels } from './mediaModels.js';
 import { buildPrompt } from '../services/promptService.js';
 
 // Shared project-block view used by both prompt stages. Defaults out
@@ -99,12 +100,22 @@ function buildPlanView(project, toolSpecs) {
   // server forces these onto every video render (see media.js
   // enforceVideoRenderPreset). `width`/`height` degrade to 0 on an unknown ratio.
   const aspect = resolveAspectDimensions(project.aspectRatio, { width: 0, height: 0 });
+  const videoModel = getVideoModels().find((model) => model.id === project.modelId) || null;
   const render = {
     aspectRatio: project.aspectRatio,
     quality: project.quality,
     width: aspect.width,
     height: aspect.height,
     targetDurationSeconds: project.targetDurationSeconds,
+    modelId: project.modelId,
+    modelName: videoModel?.name || project.modelId,
+    supportsNegativePrompt: videoModel?.supportsNegativePrompt !== false,
+    modelOptionsJson: JSON.stringify({
+      resolutions: videoModel?.resolutionOptions || [],
+      frameCounts: videoModel?.frameOptions || [],
+      fps: videoModel?.fpsOptions || [],
+      samplerLocked: videoModel?.samplerLocked === true,
+    }),
   };
   return {
     project: buildProjectView(project),

--- a/server/lib/creativeDirectorPrompts.test.js
+++ b/server/lib/creativeDirectorPrompts.test.js
@@ -73,7 +73,7 @@ describe('buildPlanPrompt — locked render settings', () => {
     expect(out).toContain('**9:16** (432×768)');
     expect(out).toContain('**high** quality');
     // Instructs the planner not to author the enforced params.
-    expect(out).toMatch(/Do NOT set `aspectRatio`, `width`, `height`, `fps`, or `steps`/);
+    expect(out).toContain('Do not set or override backend, model, aspect ratio, width, height, FPS, frame count, steps');
   });
 });
 

--- a/server/lib/creativeDirectorValidation.js
+++ b/server/lib/creativeDirectorValidation.js
@@ -66,6 +66,12 @@ export const creativeDirectorDirectiveSchema = z.object({
     seriesId: z.string().max(120).nullable().optional(),
     formats: z.array(z.string().min(1).max(64)).max(20).optional(),
     budgetCap: z.number().int().min(0).max(100000).nullable().optional(),
+    // Structured commission provenance for the planner. The output type is the
+    // same enum the commission form selected; generation is the already-
+    // sanitized set of form choices. They are context/locking inputs, not a
+    // second mutable configuration surface.
+    targetAbility: z.enum(['video', 'image', 'music', 'music-video', 'series']).optional(),
+    generation: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).optional(),
   }).default({}),
 });
 
@@ -517,4 +523,3 @@ export const importerCommitSchema = z.object({
   // Defaults to false to preserve the additive merge behavior.
   replaceMode: z.boolean().optional().default(false),
 }).strict();
-

--- a/server/routes/creativeDirector.js
+++ b/server/routes/creativeDirector.js
@@ -239,6 +239,13 @@ router.patch('/:id/treatment', asyncHandler(async (req, res) => {
 // the plan advance loop so execution begins on the returned plan.
 router.patch('/:id/plan', asyncHandler(async (req, res) => {
   const plan = validateRequest(creativeDirectorPlanSchema, req.body);
+  const project = await getProject(req.params.id);
+  if (!project) throw new ServerError('Project not found', { status: 404, code: 'NOT_FOUND' });
+  const { getCommissionPlanError } = await import('../services/creative/toolRegistry.js');
+  const commissionPlanError = getCommissionPlanError(plan, project.directive);
+  if (commissionPlanError) {
+    throw new ServerError(commissionPlanError, { status: 400, code: 'INVALID_COMMISSION_PLAN' });
+  }
   const updated = await setPlan(req.params.id, plan);
   const { advanceAfterPlanStepSettled } = await import('../services/creativeDirector/planAdvance.js');
   advanceAfterPlanStepSettled(req.params.id)

--- a/server/routes/creativeDirector.test.js
+++ b/server/routes/creativeDirector.test.js
@@ -27,6 +27,7 @@ vi.mock('../services/creativeDirector/planAdvance.js', () => ({
 }));
 vi.mock('../services/creative/toolRegistry.js', () => ({
   getAllCreativeToolMetadata: vi.fn(() => [{ id: 'universe_create', costClass: 'free', longRunning: false, destructive: false }]),
+  getCommissionPlanError: vi.fn(() => null),
 }));
 vi.mock('../lib/domainAutonomy.js', () => ({ getCreativeAutonomyMode: vi.fn(() => 'dry-run') }));
 vi.mock('../services/domainUsage.js', () => ({ getDomainBudgetStatus: vi.fn(async () => ({ withinBudget: false, exceeded: 'actions' })) }));
@@ -59,6 +60,7 @@ import * as autoCast from '../services/creativeDirector/autoCast.js';
 import * as hook from '../services/creativeDirector/completionHook.js';
 import * as firstPass from '../services/creativeDirector/firstPassGen.js';
 import * as firstPassMusicBed from '../services/creativeDirector/firstPassMusicGen.js';
+import * as creativeTools from '../services/creative/toolRegistry.js';
 import { CREATIVE_DIRECTOR_IDS_BATCH_MAX } from '../lib/creativeDirectorValidation.js';
 import creativeDirectorRoutes from './creativeDirector.js';
 
@@ -667,10 +669,22 @@ describe('creativeDirector routes', () => {
     const validStep = { stepId: 'create-series', toolName: 'pipeline_createSeries', args: { name: 'Nova' }, dependsOn: [] };
 
     it('accepts a word/hyphen stepId', async () => {
+      cdService.getProject.mockResolvedValue({ id: 'cd-1', directive: { goal: 'x', constraints: {} } });
       cdService.setPlan.mockResolvedValue({ id: 'cd-1', plan: { steps: [validStep] } });
       const r = await request(app).patch('/api/creative-director/cd-1/plan').send({ steps: [validStep] });
       expect(r.status).toBe(200);
       expect(cdService.setPlan).toHaveBeenCalled();
+    });
+
+    it('rejects a plan that violates commission output controls', async () => {
+      cdService.getProject.mockResolvedValue({
+        id: 'cd-1', directive: { goal: 'image', constraints: { targetAbility: 'image' } },
+      });
+      creativeTools.getCommissionPlanError.mockReturnValueOnce('Tool is not allowed for an image commission');
+      const r = await request(app).patch('/api/creative-director/cd-1/plan').send({ steps: [validStep] });
+      expect(r.status).toBe(400);
+      expect(r.body.code).toBe('INVALID_COMMISSION_PLAN');
+      expect(cdService.setPlan).not.toHaveBeenCalled();
     });
 
     it('400s on a stepId with a dot (unreferenceable by the result-reference grammar)', async () => {

--- a/server/services/creative/toolRegistry.js
+++ b/server/services/creative/toolRegistry.js
@@ -134,8 +134,28 @@ const toSpec = (t) => {
 export const filterDestructive = (tools, includeDestructive) =>
   tools.filter((t) => includeDestructive || !t.destructive);
 
-export const getToolSpecs = ({ includeDestructive = false } = {}) =>
-  filterDestructive(CREATIVE_TOOLS, includeDestructive).map(toSpec);
+// A commission has already chosen its output type in the UI. Give its planner
+// only the tools capable of producing that output, instead of asking the LLM to
+// rediscover the choice from prose while staring at the entire creative suite.
+// Hand-created/general Creative Director projects have no targetAbility and
+// retain the full registry.
+const ABILITY_TOOL_NAMES = Object.freeze({
+  video: new Set(['media_enqueueVideoJob']),
+  image: new Set(['media_enqueueImageJob']),
+  music: new Set(['media_enqueueAudioJob']),
+  'music-video': new Set(['media_enqueueAudioJob', 'media_enqueueImageJob', 'media_enqueueVideoJob']),
+});
+
+export const filterForTargetAbility = (tools, targetAbility) => {
+  if (targetAbility === 'series') {
+    return tools.filter((tool) => tool.name.startsWith('pipeline_') || tool.name.startsWith('universe_'));
+  }
+  const allowed = ABILITY_TOOL_NAMES[targetAbility];
+  return allowed ? tools.filter((tool) => allowed.has(tool.name)) : tools;
+};
+
+export const getToolSpecs = ({ includeDestructive = false, targetAbility = null } = {}) =>
+  filterForTargetAbility(filterDestructive(CREATIVE_TOOLS, includeDestructive), targetAbility).map(toSpec);
 
 export const getAllCreativeToolNames = () => CREATIVE_TOOLS.map((t) => t.name);
 

--- a/server/services/creative/toolRegistry.js
+++ b/server/services/creative/toolRegistry.js
@@ -147,12 +147,46 @@ const ABILITY_TOOL_NAMES = Object.freeze({
 });
 
 export const filterForTargetAbility = (tools, targetAbility) => {
+  return tools.filter((tool) => isToolAllowedForTargetAbility(tool.name, targetAbility));
+};
+
+export function isToolAllowedForTargetAbility(toolName, targetAbility) {
+  if (!targetAbility) return true;
   if (targetAbility === 'series') {
-    return tools.filter((tool) => tool.name.startsWith('pipeline_') || tool.name.startsWith('universe_'));
+    return toolName.startsWith('pipeline_') || toolName.startsWith('universe_');
   }
   const allowed = ABILITY_TOOL_NAMES[targetAbility];
-  return allowed ? tools.filter((tool) => allowed.has(tool.name)) : tools;
-};
+  return allowed ? allowed.has(toolName) : true;
+}
+
+/**
+ * Validate the production shape selected by the commission form. Tool schemas
+ * still validate each step's args at dispatch; this guard locks the output lane
+ * and requested artifact count before any autonomous work starts.
+ */
+export function getCommissionPlanError(plan, directive) {
+  const targetAbility = directive?.constraints?.targetAbility;
+  if (!targetAbility) return null;
+  const steps = Array.isArray(plan?.steps) ? plan.steps : [];
+  const disallowed = steps.find((step) => !isToolAllowedForTargetAbility(step.toolName, targetAbility));
+  if (disallowed) {
+    return `Tool "${disallowed.toolName}" is not allowed for commission type ${targetAbility}`;
+  }
+  const count = (name) => steps.filter((step) => step.toolName === name && step.status !== 'skipped').length;
+  const requiredCounts = {
+    video: [['media_enqueueVideoJob', 1]],
+    image: [['media_enqueueImageJob', Number(directive.constraints.generation?.imageCount) || 1]],
+    music: [['media_enqueueAudioJob', 1]],
+    'music-video': [['media_enqueueAudioJob', 1], ['media_enqueueVideoJob', 1]],
+  }[targetAbility] || [];
+  for (const [toolName, expected] of requiredCounts) {
+    const actual = count(toolName);
+    if (actual !== expected) {
+      return `${targetAbility} commission requires exactly ${expected} ${toolName} step${expected === 1 ? '' : 's'}; received ${actual}`;
+    }
+  }
+  return null;
+}
 
 export const getToolSpecs = ({ includeDestructive = false, targetAbility = null } = {}) =>
   filterForTargetAbility(filterDestructive(CREATIVE_TOOLS, includeDestructive), targetAbility).map(toSpec);
@@ -225,6 +259,9 @@ async function recordLedger(ctx, entry) {
 export async function dispatchCreativeTool(name, args = {}, ctx = {}) {
   const tool = byName.get(name);
   if (!tool) throw new Error(`Unknown creative tool: ${name}`);
+  if (!isToolAllowedForTargetAbility(name, ctx.targetAbility)) {
+    throw new Error(`Creative tool "${name}" is not allowed for commission type ${ctx.targetAbility}`);
+  }
 
   // Validate up front — a Zod parse failure throws before any gating/side effect.
   const parsed = tool.schema.parse(args ?? {});

--- a/server/services/creative/toolRegistry.test.js
+++ b/server/services/creative/toolRegistry.test.js
@@ -92,6 +92,8 @@ import {
   getAllCreativeToolNames,
   getCreativeToolMetadata,
   filterDestructive,
+  getCommissionPlanError,
+  isToolAllowedForTargetAbility,
   assertCreativeToolIntegrity,
   dispatchCreativeTool,
 } from './toolRegistry.js';
@@ -148,6 +150,27 @@ describe('registry shape', () => {
       .toEqual(['media_enqueueAudioJob', 'media_enqueueImageJob', 'media_enqueueVideoJob']);
     expect(getToolSpecs({ targetAbility: 'series' }).every((s) =>
       s.function.name.startsWith('pipeline_') || s.function.name.startsWith('universe_'))).toBe(true);
+  });
+
+  it('validates a commission plan against its selected lane and artifact count', () => {
+    const directive = { constraints: { targetAbility: 'image', generation: { imageCount: 2 } } };
+    expect(getCommissionPlanError({ steps: [
+      { toolName: 'media_enqueueImageJob' },
+      { toolName: 'media_enqueueImageJob' },
+    ] }, directive)).toBeNull();
+    expect(getCommissionPlanError({ steps: [{ toolName: 'media_enqueueVideoJob' }] }, directive))
+      .toMatch(/not allowed/);
+    expect(getCommissionPlanError({ steps: [{ toolName: 'media_enqueueImageJob' }] }, directive))
+      .toMatch(/exactly 2/);
+    expect(isToolAllowedForTargetAbility('pipeline_createSeries', 'series')).toBe(true);
+    expect(isToolAllowedForTargetAbility('media_enqueueVideoJob', 'series')).toBe(false);
+  });
+
+  it('rejects an unadvertised commission tool again at dispatch', async () => {
+    await expect(dispatchCreativeTool(
+      'media_enqueueVideoJob', { params: { prompt: 'p' } }, { targetAbility: 'image' },
+    )).rejects.toThrow(/not allowed for commission type image/);
+    expect(enqueueJob).not.toHaveBeenCalled();
   });
 
   it('hydrates catalog_searchIngredients from the voice tool\'s RESOLVED spec (custom types survive)', () => {

--- a/server/services/creative/toolRegistry.test.js
+++ b/server/services/creative/toolRegistry.test.js
@@ -137,6 +137,19 @@ describe('registry shape', () => {
     }
   });
 
+  it('limits a commission planner to tools for the selected UI output type', () => {
+    expect(getToolSpecs({ targetAbility: 'video' }).map((s) => s.function.name))
+      .toEqual(['media_enqueueVideoJob']);
+    expect(getToolSpecs({ targetAbility: 'image' }).map((s) => s.function.name))
+      .toEqual(['media_enqueueImageJob']);
+    expect(getToolSpecs({ targetAbility: 'music' }).map((s) => s.function.name))
+      .toEqual(['media_enqueueAudioJob']);
+    expect(getToolSpecs({ targetAbility: 'music-video' }).map((s) => s.function.name).sort())
+      .toEqual(['media_enqueueAudioJob', 'media_enqueueImageJob', 'media_enqueueVideoJob']);
+    expect(getToolSpecs({ targetAbility: 'series' }).every((s) =>
+      s.function.name.startsWith('pipeline_') || s.function.name.startsWith('universe_'))).toBe(true);
+  });
+
   it('hydrates catalog_searchIngredients from the voice tool\'s RESOLVED spec (custom types survive)', () => {
     const meta = getCreativeToolMetadata('catalog_searchIngredients');
     expect(meta.description).toBe('VOICE catalog search description');

--- a/server/services/creative/tools/media.js
+++ b/server/services/creative/tools/media.js
@@ -13,6 +13,7 @@ import { renderTargetDefaults, resolveRenderTargetConfig } from '../../imageGen/
 import { RENDER_TARGET } from '../../../lib/renderTargets.js';
 import { VIDEO_GEN_MODE, VIDEO_GEN_MODES } from '../../videoGen/modes.js';
 import { grokVideoJobParams, resolveVideoBackendPin } from '../../videoGen/backendPin.js';
+import { getDefaultVideoModelId, getVideoModels } from '../../../lib/mediaModels.js';
 import { COST_RENDER, resolveOwner } from './shared.js';
 
 const paramsSchema = z.object({ params: z.record(z.any()).default({}), owner: z.string().optional() });
@@ -34,7 +35,7 @@ const paramsSchema = z.object({ params: z.record(z.any()).default({}), owner: z.
  * unrecognized aspect/quality (hand-edited/legacy project) falls through to the
  * LLM's params untouched — best-effort, never throws.
  */
-async function enforceVideoRenderPreset(params, project) {
+function enforceVideoRenderPreset(params, project) {
   // Only a directive-driven CD project locks a preset; a bare enqueue (no
   // recognized aspect/quality) keeps the caller's params as-is.
   if (!project || !ASPECT_PRESETS[project.aspectRatio] || !QUALITY_PRESETS[project.quality]) {
@@ -61,6 +62,45 @@ async function enforceVideoRenderPreset(params, project) {
     steps: preset.steps,
     guidanceScale: preset.guidanceScale,
   };
+}
+
+export function reconcileVideoParamsWithModel(params, project, models = getVideoModels()) {
+  const locked = enforceVideoRenderPreset(params, project);
+  if (locked === params) return params;
+  const requestedModelId = locked.modelId || project.modelId || getDefaultVideoModelId();
+  const model = models.find((entry) => entry.id === requestedModelId) || null;
+  const aspectValue = locked.width / locked.height;
+  const resolution = Array.isArray(model?.resolutionOptions) && model.resolutionOptions.length
+    ? model.resolutionOptions.reduce((best, option) => {
+      const distance = Math.abs((Number(option.w) / Number(option.h)) - aspectValue);
+      return !best || distance < best.distance ? { option, distance } : best;
+    }, null)?.option
+    : null;
+  const fpsOptions = Array.isArray(model?.fpsOptions) ? model.fpsOptions.filter(Number.isFinite) : [];
+  const fps = fpsOptions.includes(locked.fps) ? locked.fps : (fpsOptions[0] || locked.fps);
+  const requestedFrames = Math.max(1, Math.round((locked.numFrames / locked.fps) * fps));
+  const frameOptions = Array.isArray(model?.frameOptions) ? model.frameOptions.filter(Number.isFinite) : [];
+  const numFrames = frameOptions.length
+    ? frameOptions.reduce((best, value) => (
+      Math.abs(value - requestedFrames) < Math.abs(best - requestedFrames) ? value : best
+    ))
+    : locked.numFrames;
+  const reconciled = {
+    ...locked,
+    modelId: requestedModelId,
+    width: Number(resolution?.w) || locked.width,
+    height: Number(resolution?.h) || locked.height,
+    fps,
+    numFrames,
+  };
+  if (model?.samplerLocked) {
+    delete reconciled.steps;
+    delete reconciled.guidanceScale;
+  }
+  if (model?.supportsNegativePrompt === false) delete reconciled.negativePrompt;
+  if (model?.supportsDisableAudio === false) delete reconciled.disableAudio;
+  if (model?.supportsTiling === false) delete reconciled.tiling;
+  return reconciled;
 }
 
 /**
@@ -261,8 +301,16 @@ const mediaTool = (kind, label) => ({
       // Image + video both consult the owning project: video for its locked
       // geometry preset, both for a pinned render backend (#3135).
       const project = await loadOwningProject(ctx);
-      if (kind === 'video') params = await enforceVideoRenderPreset(params, project);
+      if (kind === 'video') params = enforceVideoRenderPreset(params, project);
       params = await enforceRenderBackendPin(kind, params, project);
+      // Resolve the selected local model AFTER the backend ladder has applied
+      // project/install pins. The same model-catalog fields that drive Video
+      // Gen's visible controls then snap the autonomous job onto that model's
+      // canvas/FPS/frame options and remove controls the UI disables (for
+      // example MiniMax H3's negative prompt and sampler knobs).
+      if (kind === 'video' && params?.mode !== VIDEO_GEN_MODE.GROK) {
+        params = reconcileVideoParamsWithModel(params, project);
+      }
     }
     return enqueueJob({ kind, params, owner: resolveOwner(args, ctx) });
   },

--- a/server/services/creative/tools/media.js
+++ b/server/services/creative/tools/media.js
@@ -31,7 +31,8 @@ const paramsSchema = z.object({ params: z.record(z.any()).default({}), owner: z.
  * them deterministically here rather than trusting the LLM to reproduce them.
  *
  * The planner still owns the CREATIVE params (`prompt`, `negativePrompt`,
- * `style`, `durationSeconds`). Only the render geometry is enforced. An
+ * `style`). Commission duration is form-locked; a general CD project may use
+ * shorter per-step beats. Only render controls are enforced. An
  * unrecognized aspect/quality (hand-edited/legacy project) falls through to the
  * LLM's params untouched — best-effort, never throws.
  */
@@ -43,8 +44,12 @@ function enforceVideoRenderPreset(params, project) {
   }
   // The planner may legitimately ask for a shorter beat than the project target,
   // so a positive per-step durationSeconds wins; otherwise use the project's.
+  const targetAbility = project.directive?.constraints?.targetAbility;
+  const commissionLocked = targetAbility === 'video' || targetAbility === 'music-video';
   const stepDuration = Number(params?.durationSeconds);
-  const durationSeconds = stepDuration > 0 ? stepDuration : (project.targetDurationSeconds || 10);
+  const durationSeconds = commissionLocked
+    ? (project.targetDurationSeconds || 10)
+    : (stepDuration > 0 ? stepDuration : (project.targetDurationSeconds || 10));
   const preset = presetToRenderParams({
     aspectRatio: project.aspectRatio,
     quality: project.quality,
@@ -55,12 +60,32 @@ function enforceVideoRenderPreset(params, project) {
   const { aspectRatio: _ignored, ...rest } = params || {};
   return {
     ...rest,
+    durationSeconds,
     width: preset.width,
     height: preset.height,
     fps: preset.fps,
     numFrames: preset.numFrames,
     steps: preset.steps,
     guidanceScale: preset.guidanceScale,
+  };
+}
+
+function enforceImageRenderPreset(params, project) {
+  const targetAbility = project?.directive?.constraints?.targetAbility;
+  if ((targetAbility !== 'image' && targetAbility !== 'music-video')
+      || !ASPECT_PRESETS[project.aspectRatio] || !QUALITY_PRESETS[project.quality]) {
+    return params;
+  }
+  const aspect = ASPECT_PRESETS[project.aspectRatio];
+  const quality = QUALITY_PRESETS[project.quality];
+  const { aspectRatio: _ignored, ...rest } = params || {};
+  return {
+    ...rest,
+    width: aspect.width,
+    height: aspect.height,
+    steps: quality.steps,
+    guidance: quality.guidance,
+    cfgScale: quality.guidance,
   };
 }
 
@@ -120,14 +145,35 @@ export function reconcileVideoParamsWithModel(params, project, models = getVideo
  */
 async function configureMusicJob(params, ctx) {
   if (!ctx?.projectId) return params;
+  const project = await loadOwningProject(ctx);
+  if ((ctx.targetAbility === 'music' || ctx.targetAbility === 'music-video') && !project) {
+    throw new Error('commission-project-unavailable');
+  }
   const { getCommissionMusicContextForProject } = await import('../../creativeCommissions/store.js');
   // Do not collapse a failed local provenance lookup into "not a taste run".
   // That would let planner-authored renderer/prompt guesses escape onto an
   // opted-in commission precisely when the local store is unavailable.
   const context = await getCommissionMusicContextForProject(ctx.projectId);
   if (!context) {
-    if (params?.creativeDirectorMusicBed) return params;
-    return { ...params, creativeDirectorMusicBed: { projectId: ctx.projectId } };
+    const targetAbility = project?.directive?.constraints?.targetAbility;
+    if (targetAbility !== 'music' && targetAbility !== 'music-video') {
+      if (params?.creativeDirectorMusicBed) return params;
+      return { ...params, creativeDirectorMusicBed: { projectId: ctx.projectId } };
+    }
+    const {
+      engine: _plannerEngine,
+      modelId: _plannerModel,
+      repo: _plannerRepo,
+      durationSec: _plannerDuration,
+      durationMode: _plannerDurationMode,
+      provenance: _plannerProvenance,
+      ...rest
+    } = params || {};
+    return {
+      ...rest,
+      durationSec: project.targetDurationSeconds,
+      creativeDirectorMusicBed: { projectId: ctx.projectId },
+    };
   }
   if (typeof context.prompt !== 'string' || !context.prompt.trim()) {
     throw new Error('taste-commission-prompt-unavailable');
@@ -301,7 +347,9 @@ const mediaTool = (kind, label) => ({
       // Image + video both consult the owning project: video for its locked
       // geometry preset, both for a pinned render backend (#3135).
       const project = await loadOwningProject(ctx);
+      if (ctx.targetAbility && !project) throw new Error('commission-project-unavailable');
       if (kind === 'video') params = enforceVideoRenderPreset(params, project);
+      if (kind === 'image') params = enforceImageRenderPreset(params, project);
       params = await enforceRenderBackendPin(kind, params, project);
       // Resolve the selected local model AFTER the backend ladder has applied
       // project/install pins. The same model-catalog fields that drive Video

--- a/server/services/creative/tools/media.test.js
+++ b/server/services/creative/tools/media.test.js
@@ -14,7 +14,7 @@ vi.mock('../../creativeCommissions/store.js', () => ({
 import { enqueueJob } from '../../mediaJobQueue/index.js';
 import { getSettings } from '../../settings.js';
 import { getProject } from '../../creativeDirector/local.js';
-import { MEDIA_TOOLS } from './media.js';
+import { MEDIA_TOOLS, reconcileVideoParamsWithModel } from './media.js';
 
 const tool = (name) => MEDIA_TOOLS.find((t) => t.name === name);
 const run = (name, params, ctx = {}) => tool(name).execute({ params }, ctx);
@@ -29,6 +29,39 @@ beforeEach(() => {
   getSettings.mockResolvedValue({});
   getProject.mockResolvedValue(null);
   getCommissionMusicContextForProject.mockResolvedValue(null);
+});
+
+describe('model-aware autonomous video controls', () => {
+  it('uses the same H3 options as Video Gen and drops controls its UI disables', () => {
+    const params = reconcileVideoParamsWithModel({
+      prompt: 'an example shot',
+      negativePrompt: 'blur',
+      disableAudio: true,
+      tiling: 'spatial',
+    }, {
+      aspectRatio: '16:9', quality: 'standard', targetDurationSeconds: 10,
+      modelId: 'minimax-h3-example',
+    }, [{
+      id: 'minimax-h3-example',
+      resolutionOptions: [{ w: 1344, h: 768 }, { w: 768, h: 1344 }],
+      fpsOptions: [24],
+      frameOptions: [226, 243],
+      samplerLocked: true,
+      supportsNegativePrompt: false,
+      supportsDisableAudio: false,
+      supportsTiling: false,
+    }]);
+
+    expect(params).toMatchObject({
+      prompt: 'an example shot', modelId: 'minimax-h3-example',
+      width: 1344, height: 768, fps: 24, numFrames: 243,
+    });
+    expect(params).not.toHaveProperty('negativePrompt');
+    expect(params).not.toHaveProperty('disableAudio');
+    expect(params).not.toHaveProperty('tiling');
+    expect(params).not.toHaveProperty('steps');
+    expect(params).not.toHaveProperty('guidanceScale');
+  });
 });
 
 describe('render-backend pin — the auto/unpinned path is a strict no-op (#3135)', () => {

--- a/server/services/creative/tools/media.test.js
+++ b/server/services/creative/tools/media.test.js
@@ -158,6 +158,19 @@ describe('render-backend pin — the auto/unpinned path is a strict no-op (#3135
 });
 
 describe('render-backend pin — image (#3135)', () => {
+  it('locks an image commission to the form aspect and quality presets', async () => {
+    getProject.mockResolvedValue({
+      id: 'cd-1', aspectRatio: '9:16', quality: 'high',
+      directive: { constraints: { targetAbility: 'image' } },
+    });
+    await run('media_enqueueImageJob', {
+      prompt: 'p', width: 1024, height: 1024, steps: 4, cfgScale: 12,
+    }, { projectId: 'cd-1' });
+    expect(enqueued().params).toMatchObject({
+      prompt: 'p', width: 432, height: 768, steps: 30, guidance: 3.5, cfgScale: 3.5,
+    });
+  });
+
   it('forces a codex pin onto the job params, overriding the planner LLM', async () => {
     getSettings.mockResolvedValue({ imageGen: { codex: { enabled: true, codexPath: '/bin/codex', model: 'example-model', effort: 'low' } } });
     getProject.mockResolvedValue(projectWithPin({ image: { mode: 'codex' } }));
@@ -216,6 +229,15 @@ describe('render-backend pin — image (#3135)', () => {
 });
 
 describe('render-backend pin — video (#3135)', () => {
+  it('locks a video commission to the form duration instead of a planner beat', async () => {
+    getProject.mockResolvedValue({
+      id: 'cd-1', aspectRatio: '16:9', quality: 'standard', targetDurationSeconds: 10,
+      directive: { constraints: { targetAbility: 'video' } },
+    });
+    await run('media_enqueueVideoJob', { prompt: 'p', durationSeconds: 5 }, { projectId: 'cd-1' });
+    expect(enqueued().params.durationSeconds).toBe(10);
+  });
+
   it('forces a grok pin with the grok discriminator + the semantic in videoMode', async () => {
     getSettings.mockResolvedValue({ imageGen: { grok: { enabled: true, grokPath: '/bin/grok', aspectRatio: '9:16' } } });
     getProject.mockResolvedValue(projectWithPin({ video: { mode: 'grok' } }));
@@ -355,11 +377,25 @@ describe('render-backend pin — video (#3135)', () => {
 });
 
 describe('audio enqueues', () => {
-  it('tags the music bed without reading the project or settings', async () => {
+  it('tags a general project music bed without reading settings', async () => {
     await run('media_enqueueAudioJob', { prompt: 'a mournful synth score' }, { projectId: 'cd-1' });
     expect(enqueued().params.creativeDirectorMusicBed).toEqual({ projectId: 'cd-1' });
-    expect(getProject).not.toHaveBeenCalled();
+    expect(getProject).toHaveBeenCalledTimes(1);
     expect(getSettings).not.toHaveBeenCalled();
+  });
+
+  it('locks a non-taste music commission to its form duration and install renderer', async () => {
+    getProject.mockResolvedValue({
+      id: 'cd-1', targetDurationSeconds: 75,
+      directive: { constraints: { targetAbility: 'music', generation: { lengthSeconds: 75 } } },
+    });
+    await run('media_enqueueAudioJob', {
+      prompt: 'a mournful synth score', engine: 'planner-engine', modelId: 'planner-model', durationSec: 5,
+    }, { projectId: 'cd-1' });
+    expect(enqueued().params).toEqual({
+      prompt: 'a mournful synth score', durationSec: 75,
+      creativeDirectorMusicBed: { projectId: 'cd-1' },
+    });
   });
 
   it('authoritatively applies a taste commission recipe and configured renderer', async () => {

--- a/server/services/creativeCommissions/abilityAdapters.js
+++ b/server/services/creativeCommissions/abilityAdapters.js
@@ -153,7 +153,7 @@ function buildVideoGeometryParams(commission, { defaultVideoModelId } = {}) {
     // (lib/creativeDirectorPrompts.js) and the teaser tool inherits. Neither set
     // ⇒ the install default, exactly as before.
     modelId: gen?.videoModelId || gen?.model || (typeof defaultVideoModelId === 'function' ? defaultVideoModelId() : undefined),
-    targetDurationSeconds: gen?.targetDurationSeconds || 10,
+    targetDurationSeconds: gen?.targetDurationSeconds || gen?.lengthSeconds || 10,
     // Only passed when the commission actually pinned a backend (#3135), so an
     // unpinned commission's createProject call is byte-identical to a hand-made
     // project's — both omit the arg and buildProjectRecord stores `null`, exactly

--- a/server/services/creativeCommissions/abilityAdapters.js
+++ b/server/services/creativeCommissions/abilityAdapters.js
@@ -79,7 +79,17 @@ function briefContext(commission, leadSentence) {
   if (brief.category) lines.push(`Category: ${brief.category}.`);
   if (brief.styleSpec) lines.push(`Style: ${brief.styleSpec}.`);
   const digest = renderFeedbackDigest(commission?.feedback, commission?.feedbackWindow ?? 5);
-  const constraints = {};
+  // Preserve the user's structured form choices alongside the prose brief.
+  // The planner uses targetAbility to receive a matching tool subset and sees
+  // generation as authoritative starting configuration rather than guessing
+  // renderer/model controls from the intent text.
+  const constraints = {
+    targetAbility: commission?.targetAbility,
+    generation: sanitizeGenerationFor(
+      CREATIVE_COMMISSION_ABILITIES.includes(commission?.targetAbility) ? commission.targetAbility : 'video',
+      commission?.generation,
+    ),
+  };
   if (brief.constraints?.universeId) constraints.universeId = brief.constraints.universeId;
   if (brief.constraints?.seriesId) constraints.seriesId = brief.constraints.seriesId;
   return { lines, digest, constraints };

--- a/server/services/creativeCommissions/abilityAdapters.test.js
+++ b/server/services/creativeCommissions/abilityAdapters.test.js
@@ -33,7 +33,8 @@ describe('buildCommissionDirective — video (unchanged brief/feedback fold)', (
     expect(directive.goal).toContain('Genre: surrealism.');
     expect(directive.goal).toContain('Style: flat color, Magritte.');
     expect(directive.deliverables).toEqual(['One rendered video matching the brief']);
-    expect(directive.constraints).toEqual({ universeId: 'u-123' });
+    expect(directive.constraints).toMatchObject({ universeId: 'u-123', targetAbility: 'video' });
+    expect(directive.constraints.generation).toMatchObject({ quality: 'standard', videoMode: 'auto' });
   });
 
   it('folds recent feedback into the goal', () => {
@@ -47,8 +48,9 @@ describe('buildCommissionDirective — video (unchanged brief/feedback fold)', (
     expect(directive.goal).toContain('Recent dislikes: less horror.');
   });
 
-  it('omits absent constraints', () => {
-    expect(buildCommissionDirective({ targetAbility: 'video', brief: { intent: 'x' } }).constraints).toEqual({});
+  it('always carries the selected output and sanitized generation starting point', () => {
+    expect(buildCommissionDirective({ targetAbility: 'video', brief: { intent: 'x' } }).constraints)
+      .toMatchObject({ targetAbility: 'video', generation: { quality: 'standard', videoMode: 'auto' } });
   });
 
   it('clamps the goal under the CD 5000-char cap with a large feedback window + long notes', () => {
@@ -124,7 +126,7 @@ describe('per-ability directives steer the planner to the right tools', () => {
     const withU = buildCommissionDirective({ targetAbility: 'series', brief: { intent: 'noir', constraints: { universeId: 'u-9' } }, generation: { episodeCount: 2 } });
     expect(withU.goal).toContain('Create the series within the provided universe');
     expect(withU.goal).toContain('first 2 issues/episodes');
-    expect(withU.constraints).toEqual({ universeId: 'u-9' });
+    expect(withU.constraints).toMatchObject({ universeId: 'u-9', targetAbility: 'series', generation: { episodeCount: 2 } });
 
     const noU = buildCommissionDirective({ targetAbility: 'series', brief: { intent: 'noir' }, generation: { episodeCount: 1 } });
     expect(noU.goal).toContain('Invent a fitting universe');

--- a/server/services/creativeCommissions/abilityAdapters.test.js
+++ b/server/services/creativeCommissions/abilityAdapters.test.js
@@ -197,6 +197,11 @@ describe('buildProjectParams — every type yields well-formed render settings',
       expect(typeof p.targetDurationSeconds).toBe('number');
     }
   });
+
+  it('carries the music form length onto the owning project', () => {
+    const p = getAbilityAdapter('music').buildProjectParams({ generation: { lengthSeconds: 75 } }, ctx);
+    expect(p.targetDurationSeconds).toBe(75);
+  });
 });
 
 describe('buildRenderBackendPin — per-commission render backend (#3135)', () => {

--- a/server/services/creativeDirector/agentBridge.js
+++ b/server/services/creativeDirector/agentBridge.js
@@ -175,7 +175,8 @@ export async function enqueueTreatmentTask(project) {
 // builder never imports the registry. Malformed plan output retries like the
 // treatment stage — the agent reads the 4xx error body and re-PATCHes.
 export async function enqueuePlanTask(project) {
-  const context = await buildPlanPrompt(project, { toolSpecs: getToolSpecs() });
+  const targetAbility = project?.directive?.constraints?.targetAbility || null;
+  const context = await buildPlanPrompt(project, { toolSpecs: getToolSpecs({ targetAbility }) });
   const built = await buildTaskRecord(project, 'plan', null, context);
   return persistAndEmit(built, project, 'plan', null);
 }

--- a/server/services/creativeDirector/agentBridge.test.js
+++ b/server/services/creativeDirector/agentBridge.test.js
@@ -68,6 +68,15 @@ describe('Creative Director agent bridge model assignments', () => {
     expect(task.metadata.noCodeOutput).toBe(true);
   });
 
+  it('requests only the tool set matching a commission project output type', async () => {
+    await enqueuePlanTask({
+      ...project,
+      directive: { constraints: { targetAbility: 'image' } },
+    });
+
+    expect(mocks.getToolSpecs).toHaveBeenCalledWith({ targetAbility: 'image' });
+  });
+
   it('prefers the project-level override over the global assignment', async () => {
     mocks.getSettings.mockResolvedValue({
       creativeDirector: { treatment: { providerId: 'global-agent', model: 'global-model' } },

--- a/server/services/creativeDirector/planAdvance.js
+++ b/server/services/creativeDirector/planAdvance.js
@@ -404,7 +404,11 @@ async function runPlanStep(project, step) {
   console.log(`▶️  CD plan ${projectId}: dispatching step "${step.stepId}" (${step.toolName})`);
   // Outside the request lifecycle — catch so a throw becomes a settle, never an
   // unhandled rejection.
-  const dispatch = await dispatchCreativeTool(resolvedStep.toolName, resolvedStep.args, { projectId })
+  const targetAbility = project.directive?.constraints?.targetAbility;
+  const dispatch = await dispatchCreativeTool(resolvedStep.toolName, resolvedStep.args, {
+    projectId,
+    ...(targetAbility ? { targetAbility } : {}),
+  })
     .catch((err) => ({ ok: false, threw: true, error: err.message }));
   return settlePlanStepDispatch(projectId, resolvedStep, run?.runId, dispatch);
 }


### PR DESCRIPTION
## Summary
- carry the commission output type and sanitized generation choices into the Creative Director directive
- limit commission planners to tools that can produce the selected output
- derive autonomous local-video controls from the same model catalog used by Video Gen, including MiniMax H3 canvas, frame, FPS, sampler, and negative-prompt capabilities
- migrate the production-plan prompt so existing installs treat commission choices as authoritative

## Test plan
- `MEMORY_BACKEND=file npm test -- --run services/creativeCommissions services/creative/tools/media.test.js services/creative/toolRegistry.test.js services/creativeDirector/agentBridge.test.js lib/creativeDirectorPrompts.test.js lib/creativeDirectorValidation.test.js ../scripts/migrations/277-cd-plan-commission-controls.test.js` (293 tests)
- `git diff --check`
- full server suite attempted; it reached an unrelated existing PostgreSQL-required backup test failure, while the affected suites above pass