### PR TITLE
fix: keep wiki note selection in URL (#4380)

### DIFF
--- a/client/src/components/wiki/tabs/BrowseTab.jsx
+++ b/client/src/components/wiki/tabs/BrowseTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { useLocation } from 'react-router';
+import { useSearchParams } from 'react-router';
 import * as api from '../../../services/api';
 import {FileText, FolderOpen,
   ChevronDown, ChevronRight, ArrowLeft, Tag, Link2, Edit3, Save,
@@ -17,7 +17,8 @@ const WIKI_FOLDERS = WIKI_CATEGORIES.map(c => ({ key: c.folder, label: c.label, 
 const RAW_FOLDERS = [{ key: 'raw', label: 'Raw Sources', icon: FolderOpen, color: 'text-gray-400' }];
 
 export default function BrowseTab({ vaultId, notes, rawNotes, allNotes, onRefresh }) {
-  const location = useLocation();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const noteParam = searchParams.get('note');
   const [selectedNote, setSelectedNote] = useState(null);
   const [noteContent, setNoteContent] = useState('');
   const [editing, setEditing] = useState(false);
@@ -38,14 +39,28 @@ export default function BrowseTab({ vaultId, notes, rawNotes, allNotes, onRefres
     content: noteContent
   });
 
-  // Handle deep-link from overview
+  const updateNoteParam = (notePath, options) => {
+    setSearchParams(prev => {
+      const next = new URLSearchParams(prev);
+      // URLSearchParams percent-encodes slashes in the serialized URL.
+      if (notePath) next.set('note', notePath);
+      else next.delete('note');
+      return next;
+    }, options);
+  };
+
+  // Handle deep-link from the URL.
   useEffect(() => {
-    if (location.state?.openNote) {
-      handleSelectNote(location.state.openNote);
+    if (noteParam && !loadingNote) {
+      // URLSearchParams already decodes the serialized query value. Keeping
+      // the returned path intact also preserves literal percent signs in note paths.
+      const notePath = noteParam;
+      if (selectedNote?.path !== notePath) handleSelectNote(notePath);
     }
-  }, [location.state]);
+  }, [noteParam, selectedNote?.path, loadingNote]);
 
   const handleSelectNote = async (notePath) => {
+    updateNoteParam(notePath);
     setLoadingNote(true);
     setEditing(false);
     const data = await api.getNote(vaultId, notePath).catch(() => null);
@@ -72,6 +87,7 @@ export default function BrowseTab({ vaultId, notes, rawNotes, allNotes, onRefres
     toast.success('Note deleted');
     setConfirmDelete(null);
     if (selectedNote?.path === notePath) setSelectedNote(null);
+    if (noteParam === notePath) updateNoteParam(null, { replace: true });
     onRefresh();
   };
 
@@ -220,7 +236,7 @@ export default function BrowseTab({ vaultId, notes, rawNotes, allNotes, onRefres
             {/* Note header */}
             <div className="px-4 py-3 border-b border-port-border flex items-center gap-3">
               <button
-                onClick={() => setSelectedNote(null)}
+                onClick={() => { setSelectedNote(null); updateNoteParam(null, { replace: true }); }}
                 aria-label="Back to list"
                 className="p-1 rounded hover:bg-port-card text-gray-400 hover:text-white md:hidden"
               >

--- a/client/src/components/wiki/tabs/BrowseTab.test.jsx
+++ b/client/src/components/wiki/tabs/BrowseTab.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router';
+import { MemoryRouter, useLocation } from 'react-router';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import BrowseTab from './BrowseTab';
 import * as api from '../../../services/api';
@@ -24,10 +24,16 @@ const notes = [
   { path: 'wiki/sources/example.md', name: 'Example Source', folder: 'wiki/sources' },
 ];
 
-function renderTab() {
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location">{location.pathname}{location.search}</output>;
+}
+
+function renderTab(initialEntries = ['/wiki/browse']) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={initialEntries}>
       <BrowseTab vaultId="v1" notes={notes} rawNotes={[]} allNotes={notes} onRefresh={() => {}} />
+      <LocationProbe />
     </MemoryRouter>
   );
 }
@@ -63,7 +69,18 @@ describe('BrowseTab responsive list/detail', () => {
     expect(back.className).toContain('md:hidden');
 
     fireEvent.click(back);
-    await waitFor(() => expect(screen.getByText('Select a page to view')).toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByRole('heading', { name: 'Example Source' })).toBeNull());
+    expect(screen.getByTestId('location')).toHaveTextContent('/wiki/browse');
+  });
+
+  it('opens a note from the URL and removes the note param when closed', async () => {
+    renderTab(['/wiki/browse?vault=v1&note=wiki%2Fsources%2Fexample.md']);
+
+    await waitFor(() => expect(api.getNote).toHaveBeenCalledWith('v1', 'wiki/sources/example.md'));
+    expect(await screen.findByRole('heading', { name: 'Example Source' })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back to list' }));
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/wiki/browse?vault=v1'));
   });
 });
 

--- a/client/src/components/wiki/tabs/GraphTab.jsx
+++ b/client/src/components/wiki/tabs/GraphTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import * as api from '../../../services/api';
 import { RefreshCw, Network, ZoomIn, ZoomOut } from 'lucide-react';
 import { WIKI_CATEGORIES } from '../constants.jsx';
@@ -8,6 +8,7 @@ import OfflineNotesNotice from '../../OfflineNotesNotice.jsx';
 
 export default function GraphTab({ vaultId }) {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const canvasRef = useRef(null);
   const [graphData, setGraphData] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -177,9 +178,11 @@ export default function GraphTab({ vaultId }) {
 
   const handleClick = useCallback(() => {
     if (hoveredNode) {
-      navigate('/wiki/browse', { state: { openNote: hoveredNode } });
+      const next = new URLSearchParams(searchParams);
+      next.set('note', hoveredNode);
+      navigate({ pathname: '/wiki/browse', search: next.toString() });
     }
-  }, [hoveredNode, navigate]);
+  }, [hoveredNode, navigate, searchParams]);
 
   if (loading) {
     return (

--- a/client/src/components/wiki/tabs/OverviewTab.jsx
+++ b/client/src/components/wiki/tabs/OverviewTab.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import * as api from '../../../services/api';
 import { FolderOpen, RefreshCw, AlertTriangle } from 'lucide-react';
 import { timeAgo } from '../../../utils/formatters';
@@ -7,10 +7,17 @@ import { WIKI_CATEGORIES, PageTypeIcon } from '../constants.jsx';
 
 export default function OverviewTab({ vaultId, stats, notes, allNotes, onRefresh }) {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [lintReport, setLintReport] = useState(null);
   const [loadingLint, setLoadingLint] = useState(false);
 
   const lintExists = allNotes?.some(n => n.path === 'wiki/lint-report.md');
+
+  const openNote = (notePath) => {
+    const next = new URLSearchParams(searchParams);
+    next.set('note', notePath);
+    navigate({ pathname: '/wiki/browse', search: next.toString() });
+  };
 
   useEffect(() => {
     if (lintExists) loadLintReport();
@@ -62,7 +69,7 @@ export default function OverviewTab({ vaultId, stats, notes, allNotes, onRefresh
             ) : recentPages.map(note => (
               <button
                 key={note.path}
-                onClick={() => navigate('/wiki/browse', { state: { openNote: note.path } })}
+                onClick={() => openNote(note.path)}
                 className="w-full flex items-center gap-3 px-4 py-2.5 text-left hover:bg-port-bg/50 transition-colors"
               >
                 <PageTypeIcon folder={note.folder} />

--- a/client/src/components/wiki/tabs/SearchTab.jsx
+++ b/client/src/components/wiki/tabs/SearchTab.jsx
@@ -1,11 +1,12 @@
 import { useState, useCallback, useRef } from 'react';
-import { useNavigate } from 'react-router';
+import { useNavigate, useSearchParams } from 'react-router';
 import * as api from '../../../services/api';
 import { Search, FileText, X, RefreshCw, Tag } from 'lucide-react';
 import OfflineNotesNotice from '../../OfflineNotesNotice.jsx';
 
 export default function SearchTab({ vaultId }) {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const [query, setQuery] = useState('');
   const [results, setResults] = useState(null);
   const [searching, setSearching] = useState(false);
@@ -20,7 +21,9 @@ export default function SearchTab({ vaultId }) {
   }, [query, vaultId]);
 
   const openNote = (notePath) => {
-    navigate('/wiki/browse', { state: { openNote: notePath } });
+    const next = new URLSearchParams(searchParams);
+    next.set('note', notePath);
+    navigate({ pathname: '/wiki/browse', search: next.toString() });
   };
 
   return (


### PR DESCRIPTION
## Summary

- Store wiki note selection in the URL alongside the selected vault.
- Open notes from Overview, Search, and Graph with the `note` query parameter.
- Clear the note parameter when closing the mobile note view, including browser-safe replacement navigation.

## Test plan

- `npm test -- --run src/pages/Wiki.test.jsx src/components/wiki/tabs/BrowseTab.test.jsx`
- `npm run build`

Closes #4380

