### PR TITLE
fix: clear stale chunkPrompts when a video retry drops back to 1 chunk

### DIFF
--- a/server/routes/mediaJobs.js
+++ b/server/routes/mediaJobs.js
@@ -285,6 +285,7 @@ router.post('/:id/retry', asyncHandler(async (req, res) => {
   for (const key of ['seed', 'steps', 'guidanceScale', 'imageStrength']) {
     if (rawOverrides[key] === null) delete params[key];
   }
+  if (rawOverrides.chunks === 1) delete params.chunkPrompts;
   // Grok video jobs use `mode` as the cloud-dispatch discriminator, not the
   // local semantic mode validated by prepareParams.
   if (job.kind === 'video' && params.mode !== 'grok') await validateVideoRetryParams(params);

--- a/server/services/videoGen/prepareParams.js
+++ b/server/services/videoGen/prepareParams.js
@@ -59,6 +59,9 @@ import {
 import { videoModeContractError, videoChainUnsupportedError } from './modeContract.js';
 import { resolveByovRuntimeLoraCapable, videoLoraUnsupportedError } from './runtimes.js';
 
+// Retries reuse persisted worker parameters instead of passing through the
+// multipart preparation path. Keep the model/mode gates here so a model edit
+// cannot delete the original history row before the replacement is renderable.
 export async function validateVideoRetryParams(params = {}) {
   const modelId = params.modelId || defaultVideoModelId();
   const model = listVideoModels().find((entry) => entry.id === modelId);


### PR DESCRIPTION
## Summary
- An interrupted stash-pop conflict left `validateVideoRetryParams` fully landed on main via prior commits, but silently dropped the `chunkPrompts` cleanup the stash also carried.
- Retrying a chained video render after dropping `chunks` back to 1 now clears the stale per-chunk prompt array instead of leaving it attached to the new single-chunk job.

## Test plan
- `cd server && npx vitest run routes/mediaJobs services/videoGen/prepareParams` — 73 passed
- Verified server boots cleanly under PM2 after the fix (no syntax errors from the prior unresolved conflict markers)