### PR TITLE
fix: identify Creative Director renders in video queue

### DIFF
--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -24,6 +24,16 @@ const STATUS_BADGE = {
 
 const KIND_ICON = { video: Film, image: ImageIcon, training: Cpu };
 
+// Creative Director scene renders use the same durable media queue as manual
+// Video Gen renders, but carry an owner tag so the orchestrator can reconcile
+// completion. Keep that ownership visible in the shared queue: otherwise an
+// agent-enqueued render looks like an unrelated anonymous video job (or, when
+// the prompt is absent on a malformed projection, like no useful row at all).
+const isCreativeDirectorJob = (job) => typeof job?.owner === 'string'
+  && (job.owner.startsWith('cd:') || job.owner.startsWith('creative-director:'));
+
+const ownerLabel = (job) => isCreativeDirectorJob(job) ? 'Creative Director' : job?.owner;
+
 // Safe-read a Codex job's stored reasoning effort. Mirrors codex.js's server-side
 // guard (`typeof effort === 'string' && effort.trim()`): a non-string value from
 // hand-edited media-jobs.json returns '' instead of throwing on `.trim()`, and a
@@ -379,7 +389,7 @@ function JobRow({ job, onCancel, onRetry, onRunNow, onDelete }) {
               {job.kind === 'training'
                 ? trainingSummary(job.params)
                 : (job.params?.prompt ? `"${job.params.prompt.slice(0, 80)}${job.params.prompt.length > 80 ? '…' : ''}"` : 'no prompt')}
-              {job.owner && <span> · {job.owner}</span>}
+              {ownerLabel(job) && <span> · {ownerLabel(job)}</span>}
             </div>
           </div>
         </div>

--- a/client/src/components/media/MediaJobsQueue.test.jsx
+++ b/client/src/components/media/MediaJobsQueue.test.jsx
@@ -93,6 +93,26 @@ describe('MediaJobsQueue — unavailable state', () => {
   });
 });
 
+describe('MediaJobsQueue — Creative Director renders', () => {
+  it('surfaces a Creative Director-owned video job in the live queue', async () => {
+    listMediaJobs.mockResolvedValue([{
+      id: 'cdvideo0000live',
+      kind: 'video',
+      owner: 'cd:example-project',
+      status: 'queued',
+      position: 2,
+      queuedAt: '2026-06-19T10:00:00Z',
+      params: { prompt: 'an invented establishing shot', modelId: 'example-video-model' },
+    }]);
+
+    render(<MediaJobsQueue kind="video" />);
+
+    await waitFor(() => expect(screen.getByText(/Creative Director/)).toBeInTheDocument());
+    expect(screen.getByText(/#2 in queue/)).toBeInTheDocument();
+    expect(screen.getByText(/an invented establishing shot/)).toBeInTheDocument();
+  });
+});
+
 describe('MediaJobsQueue — Codex reasoning-effort retry control', () => {
   it('surfaces the job effort in the row label', async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary
- Tag Creative Director-owned jobs (`owner` starting with `cd:` or `creative-director:`) in the media jobs queue with a readable "Creative Director" label instead of the raw owner string, so agent-enqueued renders are distinguishable from manual Video Gen jobs.

## Test plan
- `npx vitest run src/components/media/MediaJobsQueue.test.jsx` — 15 passed