### PR TITLE
feat: target brain repo studies to managed apps

### DIFF
--- a/client/src/components/QuickBrainCapture.jsx
+++ b/client/src/components/QuickBrainCapture.jsx
@@ -217,6 +217,9 @@ export default function QuickBrainCapture() {
         idPrefix="quick-brain-repo"
         repo={repoIntake.repo}
         options={repoIntake.options}
+        managedApps={repoIntake.managedApps}
+        targetAppId={repoIntake.targetAppId}
+        onTargetAppChange={repoIntake.setTargetAppId}
         onToggle={repoIntake.toggle}
       />
 

--- a/client/src/components/QuickBrainCapture.test.jsx
+++ b/client/src/components/QuickBrainCapture.test.jsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router';
 vi.mock('../services/api', () => ({
   captureBrainThought: vi.fn(),
   getYoutubeIngestSettings: vi.fn(),
+  getApps: vi.fn(),
 }));
 // The ingest hook reaches for apiBrain directly (not through the `api` barrel),
 // so mock it separately — that keeps the REAL useYoutubeIngest/useSseJobSlot
@@ -28,7 +29,7 @@ class StubEventSource {
 }
 globalThis.EventSource = StubEventSource;
 
-import { captureBrainThought, getYoutubeIngestSettings } from '../services/api';
+import { captureBrainThought, getApps, getYoutubeIngestSettings } from '../services/api';
 import { startYoutubeIngest } from '../services/apiBrain.js';
 import toast from './ui/Toast';
 import QuickBrainCapture from './QuickBrainCapture';
@@ -62,6 +63,10 @@ describe('QuickBrainCapture', () => {
       defaultDownloadVideo: false,
       defaultIngestAudio: false,
     });
+    getApps.mockResolvedValue([
+      { id: 'portos-default', name: 'PortOS', repoPath: '/srv/portos' },
+      { id: 'app-example', name: 'Example App', repoPath: '/srv/example-app' },
+    ]);
     startYoutubeIngest.mockResolvedValue({ jobId: 'job-1' });
   });
 
@@ -112,7 +117,7 @@ describe('QuickBrainCapture', () => {
 
       type(REPO);
       expect(screen.getByLabelText('Scan for malware')).toBeInTheDocument();
-      expect(screen.getByLabelText('Study for PortOS ideas')).toBeInTheDocument();
+      expect(screen.getByLabelText('Study for app ideas')).toBeInTheDocument();
       expect(screen.getByText(/will be cloned locally/)).toBeInTheDocument();
       expect(screen.getByText('Will save as link and clone the repo')).toBeInTheDocument();
     });
@@ -134,11 +139,31 @@ describe('QuickBrainCapture', () => {
     it('sends the ticked actions with the capture', async () => {
       renderWidget();
       type(REPO);
-      fireEvent.click(screen.getByLabelText('Study for PortOS ideas'));
+      fireEvent.click(screen.getByLabelText('Study for app ideas'));
       fireEvent.click(screen.getByLabelText('Capture'));
 
       await waitFor(() => expect(captureBrainThought).toHaveBeenCalled());
-      expect(captureBrainThought.mock.calls[0][3].repoIntake).toEqual({ malwareScan: false, learn: true });
+      expect(captureBrainThought.mock.calls[0][3].repoIntake).toEqual({
+        malwareScan: false,
+        learn: true,
+        targetAppId: 'portos-default',
+      });
+    });
+
+    it('sends the selected managed app as the study target', async () => {
+      renderWidget();
+      type(REPO);
+      fireEvent.click(screen.getByLabelText('Study for app ideas'));
+      await waitFor(() => expect(screen.getByLabelText('File study issues against')).toBeInTheDocument());
+      fireEvent.change(screen.getByLabelText('File study issues against'), { target: { value: 'app-example' } });
+      fireEvent.click(screen.getByLabelText('Capture'));
+
+      await waitFor(() => expect(captureBrainThought).toHaveBeenCalled());
+      expect(captureBrainThought.mock.calls[0][3].repoIntake).toEqual({
+        malwareScan: false,
+        learn: true,
+        targetAppId: 'app-example',
+      });
     });
 
     it('remembers the choice across mounts', () => {

--- a/client/src/components/brain/RepoIntakeOptions.jsx
+++ b/client/src/components/brain/RepoIntakeOptions.jsx
@@ -19,7 +19,7 @@ export const REPO_INTAKE_OPTIONS = [
   },
   {
     key: 'learn',
-    label: 'Study for PortOS ideas',
+    label: 'Study for app ideas',
     Icon: Lightbulb,
     hint: 'An agent reads the clone for implementation ideas worth adopting and files the good ones as issues. Clean-room — it never copies code.',
   },
@@ -34,7 +34,7 @@ export const REPO_INTAKE_OPTIONS = [
  * @param {{malwareScan: boolean, learn: boolean}} props.options
  * @param {(key: string) => void} props.onToggle
  */
-export default function RepoIntakeOptions({ idPrefix, repo, options, onToggle }) {
+export default function RepoIntakeOptions({ idPrefix, repo, options, managedApps = [], targetAppId, onTargetAppChange, onToggle }) {
   if (!repo) return null;
 
   return (
@@ -58,6 +58,19 @@ export default function RepoIntakeOptions({ idPrefix, repo, options, onToggle })
           />
         ))}
       </div>
+      {options.learn && managedApps.length > 0 && (
+        <label htmlFor={`${idPrefix}-target-app`} className="block text-xs text-gray-400">
+          File study issues against
+          <select
+            id={`${idPrefix}-target-app`}
+            value={targetAppId}
+            onChange={e => onTargetAppChange?.(e.target.value)}
+            className="ml-2 px-2 py-1 bg-port-bg border border-port-border rounded text-gray-200 text-xs"
+          >
+            {managedApps.map(app => <option key={app.id} value={app.id}>{app.name}</option>)}
+          </select>
+        </label>
+      )}
       {REPO_INTAKE_OPTIONS.some(({ key }) => options[key]) && (
         <p className="text-xs text-gray-500">
           A CoS agent starts once the clone finishes — track it in Chief of Staff.

--- a/client/src/components/brain/tabs/InboxTab.jsx
+++ b/client/src/components/brain/tabs/InboxTab.jsx
@@ -366,6 +366,9 @@ export default function InboxTab({ onRefresh, settings }) {
           idPrefix="inbox-capture-repo"
           repo={repoIntake.repo}
           options={repoIntake.options}
+          managedApps={repoIntake.managedApps}
+          targetAppId={repoIntake.targetAppId}
+          onTargetAppChange={repoIntake.setTargetAppId}
           onToggle={repoIntake.toggle}
         />
       </form>

--- a/client/src/hooks/useRepoIntake.js
+++ b/client/src/hooks/useRepoIntake.js
@@ -1,7 +1,9 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocalStorageBool } from './useLocalStorageBool.js';
 import { parseBareUrl } from '../lib/bareUrl.js';
 import { parseGitHubUrl } from '../lib/githubRepoUrl.js';
+import * as api from '../services/api.js';
+import { PORTOS_APP_ID } from '../lib/appIdentity.js';
 
 /**
  * The Brain capture boxes' "this URL is a GitHub repo" state.
@@ -47,15 +49,35 @@ export function capturedGitHubRepo(text) {
 export function useRepoIntake(text) {
   const [malwareScan, setMalwareScan] = useLocalStorageBool(STORAGE_KEYS.malwareScan, false);
   const [learn, setLearn] = useLocalStorageBool(STORAGE_KEYS.learn, false);
+  const [managedApps, setManagedApps] = useState([{ id: PORTOS_APP_ID, name: 'PortOS' }]);
+  const [targetAppId, setTargetAppId] = useState(PORTOS_APP_ID);
 
   const repo = useMemo(() => capturedGitHubRepo(text), [text]);
   const options = useMemo(() => ({ malwareScan, learn }), [malwareScan, learn]);
   const setters = { malwareScan: setMalwareScan, learn: setLearn };
 
+  useEffect(() => {
+    if (!repo || !learn || typeof api.getApps !== 'function') return;
+    api.getApps({ silent: true }).then((apps) => {
+      const eligible = (Array.isArray(apps) ? apps : [])
+        .filter(app => app?.id && app.repoPath && !app.archived)
+        .sort((a, b) => (a.id === PORTOS_APP_ID ? -1 : b.id === PORTOS_APP_ID ? 1 : a.name.localeCompare(b.name)));
+      if (eligible.length) {
+        setManagedApps(eligible);
+        setTargetAppId(current => eligible.some(app => app.id === current) ? current : eligible[0].id);
+      }
+    }).catch(() => {});
+  }, [repo, learn]);
+
   return {
     repo,
     options,
+    managedApps,
+    targetAppId,
+    setTargetAppId,
     toggle: (key) => setters[key](v => !v),
-    intakeFor: (submitted) => (capturedGitHubRepo(submitted) ? { ...options } : undefined),
+    intakeFor: (submitted) => (capturedGitHubRepo(submitted)
+      ? { ...options, ...(learn ? { targetAppId } : {}) }
+      : undefined),
   };
 }

--- a/server/lib/brainValidation.js
+++ b/server/lib/brainValidation.js
@@ -191,7 +191,9 @@ export const reviewRecordSchema = z.object({
 // Opt-in post-clone agent actions for a captured GitHub repo URL. Keys derive
 // from REPO_INTAKE_KEYS so the wire contract can't drift from the normalizer
 // that reads it (server/lib/repoIntakeActions.js).
-export const repoIntakeSchema = z.object(optionalBooleanMap(REPO_INTAKE_KEYS));
+export const repoIntakeSchema = z.object(optionalBooleanMap(REPO_INTAKE_KEYS)).extend({
+  targetAppId: z.string().trim().min(1).max(200).optional()
+});
 const repoIntakeInputSchema = repoIntakeSchema.optional();
 
 // Capture input schema
@@ -203,9 +205,9 @@ export const captureInputSchema = z.object({
   // (vs a todo/reference). Creative notes are later batch-sendable into the
   // creative catalog as ingredients (see catalog brain-bridge ingest).
   creative: z.boolean().optional(),
-  // Post-clone agent actions for a bare GitHub repo URL. Ignored for every other
-  // capture — only a repo URL gets cloned, and only a clone can be scanned or
-  // studied (services/brain.js#createLinkFromUrl).
+  // Post-clone agent actions for a bare GitHub repo URL. `targetAppId` selects
+  // the managed app whose tracker receives repo-study issues; omitted means
+  // PortOS for backward compatibility. Ignored for every other capture.
   repoIntake: repoIntakeInputSchema
 });
 

--- a/server/lib/dispatchLabels.js
+++ b/server/lib/dispatchLabels.js
@@ -295,3 +295,14 @@ export const REPO_STUDY_LABEL_CONTRACT = Object.freeze({
     'If a proposal cannot be classified defensibly on all three axes, do not file that proposal; filing an incomplete issue is not a valid fallback. After each NEW issue, read its labels back and repair any missing required label before continuing; never relabel a duplicate you skipped. Contributor labels remain optional and must follow the shared guidance.',
   ].join('\n'),
 });
+
+/** Repo-study contract for managed apps whose label taxonomy is not PortOS's. */
+export const GENERIC_REPO_STUDY_LABEL_CONTRACT = Object.freeze({
+  forgeFlags: '--label area:<area> --label model:<tier> --label effort:<level>',
+  jiraFlags: '`area:<area>` + `model-<tier>` + `effort-<level>`',
+  instructions: [
+    '**Repo-study complete-label contract (mandatory):** every NEW proposal must carry `repo-study`, `plan`, at least one relevant `area:*`, exactly one justified model label (`model:*` on GitHub/GitLab, `model-*` on JIRA), and exactly one justified effort label (`effort:*` on GitHub/GitLab, `effort-*` on JIRA). The dispatch axes are independent: choose them from the inspected target-app files and proposed implementation, never by stamping `medium` on both.',
+    'Scope labels (`area:*`) are required for repo-study issues. Inspect the target app\'s existing tracker labels and apply the narrowest relevant labels; create a genuinely missing, clearly scoped area label only when the tracker supports it.',
+    'If a proposal cannot be classified defensibly on all three axes, do not file that proposal; filing an incomplete issue is not a valid fallback. After each NEW issue, read its labels back and repair any missing required label before continuing; never relabel a duplicate you skipped. Contributor labels remain optional and must follow the shared guidance.',
+  ].join('\n'),
+});

--- a/server/lib/repoIntakeActions.js
+++ b/server/lib/repoIntakeActions.js
@@ -27,5 +27,9 @@ export const REPO_INTAKE_KEYS = ['malwareScan', 'learn'];
 export function normalizeRepoIntake(input) {
   if (!isPlainObject(input)) return null;
   const normalized = Object.fromEntries(REPO_INTAKE_KEYS.map(key => [key, input[key] === true]));
-  return REPO_INTAKE_KEYS.some(key => normalized[key]) ? normalized : null;
+  if (!REPO_INTAKE_KEYS.some(key => normalized[key])) return null;
+  if (normalized.learn && typeof input.targetAppId === 'string' && input.targetAppId.trim()) {
+    normalized.targetAppId = input.targetAppId.trim();
+  }
+  return normalized;
 }

--- a/server/lib/repoIntakeActions.test.js
+++ b/server/lib/repoIntakeActions.test.js
@@ -22,6 +22,18 @@ describe('normalizeRepoIntake', () => {
     expect(normalizeRepoIntake({ learn: true, rmRf: true })).toEqual({ malwareScan: false, learn: true });
   });
 
+  it('keeps a selected target app only for repo study', () => {
+    expect(normalizeRepoIntake({ learn: true, targetAppId: ' app-2 ' })).toEqual({
+      malwareScan: false,
+      learn: true,
+      targetAppId: 'app-2',
+    });
+    expect(normalizeRepoIntake({ malwareScan: true, targetAppId: 'app-2' })).toEqual({
+      malwareScan: true,
+      learn: false,
+    });
+  });
+
   it('rejects non-objects, including arrays', () => {
     expect(normalizeRepoIntake([true])).toBeNull();
     expect(normalizeRepoIntake('malwareScan')).toBeNull();

--- a/server/lib/workTracker.js
+++ b/server/lib/workTracker.js
@@ -323,13 +323,16 @@ ${jiraLabelContract}
  * (cosTaskGenerator.js), the on-commit reference-watch trigger
  * (referenceRepos.js), and the one-off `repo-study` (repoIntake.js).
  */
-export async function resolveTrackerFilingBlock(app, taskType) {
+export async function resolveTrackerFilingBlock(app, taskType, options = {}) {
   if (!TRACKER_FILING_TASK_TYPES.has(taskType)) return { trackerInstructions: '', workTracker: null };
   // Never throws — degrades to the PLAN.md block, which `isFileTracker` then
   // agrees with, so the flag and the instructions stay consistent.
   const workTracker = await resolveAppWorkTracker(app).catch(() => ({ resolved: 'plan' }));
   return {
-    trackerInstructions: formatTrackerInstructions(workTracker.resolved, TRACKER_FILING_PRESETS[taskType]),
+    trackerInstructions: formatTrackerInstructions(workTracker.resolved, {
+      ...TRACKER_FILING_PRESETS[taskType],
+      ...options,
+    }),
     workTracker: workTracker.resolved,
     worktreeChangesExpected: isFileTracker(workTracker.resolved),
   };

--- a/server/services/repoIntake.js
+++ b/server/services/repoIntake.js
@@ -158,6 +158,10 @@ export async function queueRepoStudy(link, targetAppId = PORTOS_APP_ID) {
   const result = await cos.addTask(
     {
       description: `Repo study: ${repoLabel(link)} — what can ${app.name} learn from it?`,
+      // Workspace routing must follow the same managed app whose tracker and
+      // repo path are described in the prompt; otherwise agent preparation
+      // defaults to the PortOS workspace.
+      app: app.id,
       context: buildRepoStudyContext(link, {
         appName: app.name,
         repoPath: app.repoPath,

--- a/server/services/repoIntake.js
+++ b/server/services/repoIntake.js
@@ -141,10 +141,10 @@ End with: the studied repo, its license, how many proposals you filed (with thei
  *
  * @returns {Promise<{ queued: boolean, reason?: string, taskId?: string, linkPatch?: object }>}
  */
-export async function queueRepoStudy(link) {
+export async function queueRepoStudy(link, targetAppId = PORTOS_APP_ID) {
   if (!isCloneReadable(link)) return { queued: false, reason: 'not-cloned' };
 
-  const app = await getAppById(PORTOS_APP_ID);
+  const app = await getAppById(targetAppId || PORTOS_APP_ID);
   if (!app?.repoPath) return { queued: false, reason: 'app-not-found' };
 
   // Same four-part resolution every tracker-filing dispatch runs: the block
@@ -210,7 +210,9 @@ export async function runRepoIntake(link, intake) {
   let patch = {};
   for (const [key, queue] of Object.entries(INTAKE_QUEUERS)) {
     if (!requested[key]) continue;
-    const result = await queue(link).catch(err => ({ queued: false, reason: err.message }));
+    const result = key === 'learn'
+      ? await queue(link, requested.targetAppId).catch(err => ({ queued: false, reason: err.message }))
+      : await queue(link).catch(err => ({ queued: false, reason: err.message }));
     if (result.queued) patch = { ...patch, ...result.linkPatch };
     else console.error(`❌ Capture-time ${key} not queued for link ${link.id}: ${result.reason}`);
   }

--- a/server/services/repoIntake.js
+++ b/server/services/repoIntake.js
@@ -22,6 +22,7 @@ import * as cos from './cos.js';
 import { getAppById, PORTOS_APP_ID } from './apps.js';
 import { prepareScanReportDirectory, reportPathForId } from './malwareScanReports.js';
 import { resolveTrackerFilingBlock } from '../lib/workTracker.js';
+import { GENERIC_REPO_STUDY_LABEL_CONTRACT } from '../lib/dispatchLabels.js';
 import { normalizeRepoIntake } from '../lib/repoIntakeActions.js';
 
 /** `owner/repo` when the link carries GitHub metadata, else its display title. */
@@ -153,7 +154,9 @@ export async function queueRepoStudy(link, targetAppId = PORTOS_APP_ID) {
   // never disagree (a github/gitlab/jira run files out of band and leaves the
   // tree clean; without the flag it is mistaken for missing code work, #3102).
   const { trackerInstructions, workTracker, worktreeChangesExpected } =
-    await resolveTrackerFilingBlock(app, 'repo-study');
+    await resolveTrackerFilingBlock(app, 'repo-study', app.id === PORTOS_APP_ID
+      ? {}
+      : { issueLabelContract: GENERIC_REPO_STUDY_LABEL_CONTRACT });
 
   const result = await cos.addTask(
     {

--- a/server/services/repoIntake.js
+++ b/server/services/repoIntake.js
@@ -146,7 +146,7 @@ export async function queueRepoStudy(link, targetAppId = PORTOS_APP_ID) {
   if (!isCloneReadable(link)) return { queued: false, reason: 'not-cloned' };
 
   const app = await getAppById(targetAppId || PORTOS_APP_ID);
-  if (!app?.repoPath) return { queued: false, reason: 'app-not-found' };
+  if (!app?.repoPath || app.archived) return { queued: false, reason: 'app-not-found' };
 
   // Same four-part resolution every tracker-filing dispatch runs: the block
   // telling the agent where to file, the tracker it names, and the

--- a/server/services/repoIntake.test.js
+++ b/server/services/repoIntake.test.js
@@ -108,6 +108,7 @@ describe('queueRepoStudy', () => {
     getAppById.mockImplementation(async id => id === target.id ? target : null);
     await queueRepoStudy(LINK, target.id);
     expect(getAppById).toHaveBeenCalledWith(target.id);
+    expect(addTask.mock.calls[0][0].app).toBe(target.id);
     expect(addTask.mock.calls[0][0].context).toContain('Example App');
   });
 

--- a/server/services/repoIntake.test.js
+++ b/server/services/repoIntake.test.js
@@ -132,6 +132,12 @@ describe('queueRepoStudy', () => {
     expect(taskData.context).toContain('PLAN.md');
   });
 
+  it('does not queue against an app archived after capture', async () => {
+    getAppById.mockResolvedValue({ ...APP, archived: true });
+    expect(await queueRepoStudy(LINK)).toEqual({ queued: false, reason: 'app-not-found' });
+    expect(addTask).not.toHaveBeenCalled();
+  });
+
   it('degrades to the PLAN.md block when the origin lookup fails', async () => {
     getAppById.mockResolvedValue({ ...APP, workTracker: 'auto' });
     readOriginRemoteUrl.mockRejectedValue(new Error('not a git repository'));

--- a/server/services/repoIntake.test.js
+++ b/server/services/repoIntake.test.js
@@ -103,6 +103,14 @@ describe('queueRepoStudy', () => {
     expect(taskData.context).toContain('--label area:<area> --label model:<tier> --label effort:<level>');
   });
 
+  it('files against the selected managed app', async () => {
+    const target = { id: 'app-2', name: 'Example App', repoPath: '/srv/example-app', workTracker: 'github' };
+    getAppById.mockImplementation(async id => id === target.id ? target : null);
+    await queueRepoStudy(LINK, target.id);
+    expect(getAppById).toHaveBeenCalledWith(target.id);
+    expect(addTask.mock.calls[0][0].context).toContain('Example App');
+  });
+
   // `analysisType` enrolls a task in taskSchedule's per-type consecutive-failure
   // ledger (agentFinalization.js), which auto-parks and notifies. A hand-queued
   // repo study has no schedule to park, so it must reach the no-commit gate via

--- a/server/services/repoIntake.test.js
+++ b/server/services/repoIntake.test.js
@@ -110,6 +110,8 @@ describe('queueRepoStudy', () => {
     expect(getAppById).toHaveBeenCalledWith(target.id);
     expect(addTask.mock.calls[0][0].app).toBe(target.id);
     expect(addTask.mock.calls[0][0].context).toContain('Example App');
+    expect(addTask.mock.calls[0][0].context).toContain('inspected target-app files');
+    expect(addTask.mock.calls[0][0].context).not.toContain('current PortOS area vocabulary');
   });
 
   // `analysisType` enrolls a task in taskSchedule's per-type consecutive-failure


### PR DESCRIPTION
## Summary
- add an active managed-app dropdown when studying a pasted GitHub repository
- carry the selected app through capture, clone intake, task workspace routing, and tracker filing
- preserve PortOS as the backward-compatible default and use target-app label guidance elsewhere

## Test plan
- npx vitest run services/repoIntake.test.js lib/repoIntakeActions.test.js lib/workTracker.trackerInstructions.test.js lib/dispatchLabels.test.js
- npx vitest run src/components/QuickBrainCapture.test.jsx
- npm run build (client)
- codex review --base main (clean)