### PR TITLE
Expose Qwen3.8 MLX models in the Local LLM catalog

### DIFF
--- a/docs/features/mtplx.md
+++ b/docs/features/mtplx.md
@@ -6,10 +6,11 @@ multi-token-prediction (MTP) decoding. It exposes OpenAI-compatible and
 Anthropic-compatible local APIs; PortOS uses its OpenAI-compatible endpoint.
 
 This is an additional runtime, not an Ollama replacement. PortOS offers
-**Qwen3.8 27B** through the Ollama GGUF path and, on Apple Silicon, recommends
-the LM Studio MLX 4-bit build as the native-format install path. MTPLX's
-native-MTP checkpoints, MLX builds, and Ollama GGUF models are distinct
-formats, so neither PortOS nor Ollama attempts to load one as the other.
+**Qwen3.8 27B** through Ollama's GGUF path on supported hosts and, on Apple
+Silicon, recommends native MLX builds for both Ollama and LM Studio. MTPLX's
+native-MTP checkpoints remain a distinct runtime: PortOS maps only the known
+packaged Ollama and LM Studio MLX equivalents and does not treat an MTP sidecar
+as a standalone chat model.
 
 ## What PortOS adds
 

--- a/docs/research/2026-08-16-qwen38-mlx-macos.md
+++ b/docs/research/2026-08-16-qwen38-mlx-macos.md
@@ -4,11 +4,11 @@ Date: 2026-08-16
 
 ## Recommendation
 
-Recommend `lmstudio-community/Qwen3.8-27B-MLX-4bit` as PortOS's fast macOS
-install option for Qwen3.8 27B. It is a complete MLX checkpoint, is published
-by the LM Studio community for its Apple-Silicon MLX engine, and fits the
-existing LM Studio `lms get` installation path. The catalog exposes it only on
-Apple Silicon and marks it as **Fast on Apple Silicon**.
+Recommend the native Qwen3.8 27B MLX build through both supported local
+backends on Apple Silicon: `qwen3.8:27b-mlx` for Ollama and
+`mlx-community/Qwen3.8-27B-4bit` for LM Studio. Both are complete MLX
+checkpoints and fit the backends' existing installation paths. The catalog
+exposes them only on Apple Silicon and marks them as **Fast on Apple Silicon**.
 
 This is a format/runtime recommendation, not a promise of a fixed tokens-per-
 second improvement. MLX versus GGUF speed depends on the Mac, memory pressure,
@@ -54,22 +54,35 @@ install or launch `mlx-vlm`, MTPLX, or an MTP sidecar runtime on the user's
 behalf. The existing MTPLX integration remains an explicit, separately managed
 operator choice.
 
+## Uncensored evaluation variant
+
+PortOS also catalogs `orcarouter/Qwen3.8-27B-Uncensored-MLX` for explicit
+red-team and unrestricted local evaluation. The repository is gated on Hugging
+Face and publishes several quantizations under one repository, so it is an
+Apple-Silicon LM Studio entry rather than an Ollama pull target. Users must
+accept the repository terms and authenticate in LM Studio before installing;
+LM Studio resolves the appropriate available quantization.
+
 ## PortOS behavior
 
+- Ollama on Apple Silicon: recommends and pulls the packaged
+  `qwen3.8:27b-mlx` model through Ollama's native MLX engine.
 - LM Studio on Apple Silicon: recommends and installs the complete 4-bit MLX
   target through the existing model-install endpoint.
 - LM Studio on Intel macOS and non-macOS hosts: hides the MLX recommendation;
   the existing GGUF catalog remains available.
-- Ollama: retains the existing Qwen3.8 GGUF entry. Ollama cannot install an
-  arbitrary Hugging Face MLX safetensors repository through this catalog.
-- Migration: a known LM Studio-only MLX entry is not guessed into an Ollama
-  model name.
+- Ollama on non-Apple hosts: hides the MLX recommendation; the existing GGUF
+  entry remains available.
+- Migration: the known backend-specific MLX ids map exactly so switching
+  backends re-pulls the equivalent package instead of guessing a model name.
 
 ## Sources
 
 - [`mlx.core.fast` documentation](https://ml-explore.github.io/mlx/build/html/python/fast.html)
 - [MLX-LM](https://github.com/ml-explore/mlx-lm)
-- [Complete Qwen3.8 27B MLX 4-bit checkpoint](https://huggingface.co/lmstudio-community/Qwen3.8-27B-MLX-4bit)
+- [Ollama's MLX engine announcement](https://ollama.com/blog/mlx)
+- [Complete Qwen3.8 27B MLX 4-bit checkpoint](https://huggingface.co/mlx-community/Qwen3.8-27B-4bit)
+- [OrcaRouter Qwen3.8 27B Uncensored MLX](https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX)
 - [Qwen3.8 27B MTP 4-bit drafter](https://huggingface.co/mlx-community/Qwen3.8-27B-MTP-4bit)
 - [Qwen3.8 27B MTP 8-bit drafter](https://huggingface.co/mlx-community/Qwen3.8-27B-MTP-8bit)
 - [MLX-VLM speculative decoding](https://github.com/Blaizzy/mlx-vlm)

--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -38,7 +38,7 @@ export const LOCAL_LLM_CATEGORIES = [
 ];
 
 // Each entry: { key, name, category, recommendedFor?, featured?, params, size,
-//               family, description, capabilities, context?, format?,
+//               family, description, note?, capabilities, context?, format?,
 //               appleSiliconOnly?, ollama?, lmstudio?, ollamaAliases?,
 //               lmstudioAliases? }
 //
@@ -288,7 +288,7 @@ export const LOCAL_LLM_CATALOG = [
     recommendedFor: ['general', 'coding', 'reasoning', 'vision', 'multilingual'],
     featured: {
       label: 'Fast on Apple Silicon',
-      description: 'Recommended native-MLX Qwen3.8 install for LM Studio on Apple Silicon.'
+      description: 'Recommended native-MLX Qwen3.8 install on Apple Silicon.'
     },
     params: '27B',
     size: '15.0 GB',
@@ -298,8 +298,26 @@ export const LOCAL_LLM_CATALOG = [
     context: 262144,
     format: 'mlx',
     appleSiliconOnly: true,
+    ollama: 'qwen3.8:27b-mlx',
     lmstudio: 'mlx-community/Qwen3.8-27B-4bit',
     lmstudioAliases: ['lmstudio-community/Qwen3.8-27B-MLX-4bit']
+  },
+  {
+    key: 'qwen3.8-27b-uncensored-mlx',
+    name: 'Qwen3.8 27B Uncensored MLX',
+    category: 'general',
+    recommendedFor: ['general', 'coding', 'reasoning', 'vision', 'multilingual'],
+    params: '27B',
+    size: 'varies',
+    family: 'qwen',
+    description: 'OrcaRouter’s abliterated Qwen3.8 variant for red-team and unrestricted local evaluation, with 2-, 4-, 6-, and 8-bit MLX builds plus vision, tools, reasoning, and multilingual support.',
+    note: 'Gated on Hugging Face — accept the repository terms and authenticate in LM Studio before installing; LM Studio selects the quantization for this machine.',
+    capabilities: ['chat', 'code', 'reasoning', 'tools', 'vision', 'multilingual'],
+    context: 262144,
+    format: 'mlx',
+    appleSiliconOnly: true,
+    lmstudio: 'https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX',
+    lmstudioAliases: ['orcarouter/Qwen3.8-27B-Uncensored-MLX']
   },
   {
     key: 'qwen3.8-27b',
@@ -688,7 +706,7 @@ const entryMatchesBackendId = (entry, backend, normalizedId) =>
  * @param {string} backend - 'ollama' | 'lmstudio'
  * @param {string[]} [installedIds] - ids currently installed on that backend
  * @param {{ appleSilicon?: boolean }} [options] - host capabilities used for platform-gated entries
- * @returns {Array<{ id, key, name, category, recommendedFor, featured, params, size, family, description, capabilities, format, contextLength, installed }>}
+ * @returns {Array<{ id, key, name, category, recommendedFor, featured, params, size, family, description, note, capabilities, format, contextLength, installed }>}
  */
 export function getCatalog(backend, installedIds = [], { appleSilicon } = {}) {
   if (!isBackend(backend)) return [];
@@ -710,6 +728,7 @@ export function getCatalog(backend, installedIds = [], { appleSilicon } = {}) {
         size: entry.size,
         family: entry.family,
         description: entry.description,
+        note: entry.note || null,
         capabilities: entry.capabilities,
         format: entry.format || null,
         // Native context window (tokens), when it's a documented spec; null otherwise.

--- a/server/lib/localLlmCatalog.test.js
+++ b/server/lib/localLlmCatalog.test.js
@@ -50,17 +50,33 @@ describe('localLlmCatalog', () => {
       expect(list.find((m) => m.key === 'gemma4-12b').installed).toBe(true);
     });
 
-    it('gates the current MLX Community Qwen recommendation to Apple Silicon', () => {
+    it('gates the current Qwen MLX recommendations to Apple Silicon', () => {
       const mlxKey = 'qwen3.8-27b-mlx-4bit';
+      const uncensoredKey = 'qwen3.8-27b-uncensored-mlx';
       expect(getCatalog('lmstudio').find((m) => m.key === mlxKey)).toMatchObject({
         format: 'mlx',
         id: 'mlx-community/Qwen3.8-27B-4bit'
       });
+      expect(getCatalog('ollama', [], { appleSilicon: true }).find((m) => m.key === mlxKey)).toMatchObject({
+        format: 'mlx',
+        id: 'qwen3.8:27b-mlx'
+      });
+      expect(getCatalog('ollama', ['qwen3.8:27b-mlx'], { appleSilicon: true })
+        .find((m) => m.key === mlxKey)?.installed).toBe(true);
       expect(getCatalog('lmstudio', ['lmstudio-community/Qwen3.8-27B-MLX-4bit'])
         .find((m) => m.key === mlxKey)?.installed).toBe(true);
       expect(getCatalog('lmstudio', [], { appleSilicon: true }).some((m) => m.key === mlxKey)).toBe(true);
       expect(getCatalog('lmstudio', [], { appleSilicon: false }).some((m) => m.key === mlxKey)).toBe(false);
-      expect(getCatalog('ollama', [], { appleSilicon: true }).some((m) => m.key === mlxKey)).toBe(false);
+      expect(getCatalog('ollama', [], { appleSilicon: false }).some((m) => m.key === mlxKey)).toBe(false);
+      expect(getCatalog('lmstudio', [], { appleSilicon: true }).find((m) => m.key === uncensoredKey)).toMatchObject({
+        format: 'mlx',
+        id: 'https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX',
+        note: expect.stringContaining('Gated on Hugging Face')
+      });
+      expect(getCatalog('lmstudio', ['orcarouter/Qwen3.8-27B-Uncensored-MLX'], { appleSilicon: true })
+        .find((m) => m.key === uncensoredKey)?.installed).toBe(true);
+      expect(getCatalog('lmstudio', [], { appleSilicon: false }).some((m) => m.key === uncensoredKey)).toBe(false);
+      expect(getCatalog('ollama', [], { appleSilicon: true }).some((m) => m.key === uncensoredKey)).toBe(false);
     });
 
     it('returns [] for an unknown backend', () => {
@@ -152,10 +168,17 @@ describe('localLlmCatalog', () => {
       expect(r.targetId).toBe('mystery-model');
     });
 
-    it('does not invent an Ollama target for a known LM Studio-only MLX build', () => {
+    it('maps the known Qwen MLX build across backend-specific registries', () => {
       expect(mapModelToBackend('lmstudio', 'mlx-community/Qwen3.8-27B-4bit', 'ollama'))
-        .toEqual({ targetId: null, exact: false });
+        .toEqual({ targetId: 'qwen3.8:27b-mlx', exact: true });
       expect(mapModelToBackend('lmstudio', 'lmstudio-community/Qwen3.8-27B-MLX-4bit', 'ollama'))
+        .toEqual({ targetId: 'qwen3.8:27b-mlx', exact: true });
+      expect(mapModelToBackend('ollama', 'qwen3.8:27b-mlx', 'lmstudio'))
+        .toEqual({ targetId: 'mlx-community/Qwen3.8-27B-4bit', exact: true });
+    });
+
+    it('does not invent an Ollama target for the LM Studio-only uncensored MLX build', () => {
+      expect(mapModelToBackend('lmstudio', 'orcarouter/Qwen3.8-27B-Uncensored-MLX', 'ollama'))
         .toEqual({ targetId: null, exact: false });
     });
 

--- a/server/routes/localLlm.js
+++ b/server/routes/localLlm.js
@@ -139,9 +139,10 @@ router.get('/huggingface-search', asyncHandler(async (req, res) => {
   // fit verdicts. On unified-memory Macs this pool also backs the GPU, so a big
   // box can default to a higher-fidelity build than the old Q4-always pick.
   const systemMemoryBytes = os.totalmem()
-  // MLX models surface only on Apple Silicon (and only for LM Studio) — gate the
-  // extra MLX query on the host so non-Apple installs don't see un-installable
-  // results. Detected here at the route boundary; the service stays deterministic.
+  // Live Hugging Face MLX results surface only on Apple Silicon through LM Studio;
+  // packaged Ollama MLX tags live in the curated catalog above. Gate this extra
+  // Hub query so non-Apple installs don't see un-installable results. Detected at
+  // the route boundary so the service stays deterministic.
   const appleSilicon = isAppleSilicon()
   const models = await searchHuggingFaceModels({ backend, query: q, category, limit, installedIds: installed, installedAudioRepos, systemMemoryBytes, appleSilicon })
   res.json({ backend, source: 'huggingface', models, systemMemoryGb: Math.round(systemMemoryBytes / 1024 ** 3), appleSilicon })

--- a/server/services/huggingFaceCatalog.js
+++ b/server/services/huggingFaceCatalog.js
@@ -531,9 +531,9 @@ function isInstalled(backend, result, installedIds) {
 // ---- MLX (Apple Silicon) ----------------------------------------------------
 // MLX is Apple's native ML format. It ships sharded `.safetensors` + a config
 // (no single GGUF), and is installable ONLY via LM Studio (`lms get <repo>`) on
-// Apple Silicon — Ollama's MLX path accelerates GGUF from its own registry and
-// can't pull arbitrary HF safetensors repos, so MLX is never surfaced for the
-// Ollama backend (the search gates the whole MLX query on lmstudio+Apple Silicon).
+// Apple Silicon — Ollama packages supported native MLX builds through its own
+// registry and can't pull arbitrary HF safetensors repos, so MLX is never surfaced
+// for the Ollama backend (the search gates the whole MLX query on LM Studio + Apple Silicon).
 const MLX_PUBLISHER = 'mlx-community'
 const SAFETENSORS_RE = /\.safetensors$/i
 
@@ -1076,7 +1076,10 @@ export async function searchHuggingFaceModels({ backend, query = '', category = 
 // from the Ollama registry tags/manifests instead (see applyOllamaRegistryVariants).
 function catalogRepoForBackend(backend, id) {
   const raw = String(id || '')
-  if (backend === 'lmstudio') return raw.includes('/') ? raw.split('@')[0] : null
+  if (backend === 'lmstudio') {
+    const hfUrl = raw.match(/^https?:\/\/(?:www\.)?huggingface\.co\/([^/?#]+\/[^/?#]+)/i)
+    return hfUrl?.[1] || (raw.includes('/') ? raw.split('@')[0] : null)
+  }
   const m = raw.match(/^hf\.co\/(.+)$/i)
   return m ? m[1].split(':')[0] : null
 }

--- a/server/services/huggingFaceCatalog.test.js
+++ b/server/services/huggingFaceCatalog.test.js
@@ -799,6 +799,36 @@ describe('huggingFaceCatalog', () => {
       })])
     })
 
+    it('enriches an exact Hugging Face URL while keeping it as the LM Studio install id', async () => {
+      const repo = 'orcarouter/Qwen3.8-27B-Uncensored-MLX'
+      const url = `https://huggingface.co/${repo}`
+      fetch.mockResolvedValueOnce(blobs(repo, {
+        '4-bit/model-00001-of-00002.safetensors': 7_000_000_000,
+        '4-bit/model-00002-of-00002.safetensors': 7_000_000_000,
+      }))
+
+      const catalog = [{
+        id: url,
+        key: 'qwen3.8-27b-uncensored-mlx',
+        name: 'Qwen3.8 27B Uncensored MLX',
+        category: 'general',
+        format: 'mlx',
+        size: 'varies'
+      }]
+      await enrichCatalogWithVariants(catalog, {
+        backend: 'lmstudio',
+        systemMemoryBytes: 128 * 1024 ** 3,
+        installedIds: []
+      })
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining(`/api/models/${repo}?blobs=true`),
+        expect.any(Object)
+      )
+      expect(catalog[0]).toMatchObject({ id: url, repository: repo, format: 'mlx' })
+      expect(catalog[0].variants).toEqual([expect.objectContaining({ installId: url })])
+    })
+
     it('enriches an Ollama hf.co curated id and keeps the hf.co install ids', async () => {
       const repo = 'unsloth/Curated-Devstral-GGUF'
       fetch.mockResolvedValueOnce(blobs(repo, {


### PR DESCRIPTION
## Summary

- expose Ollama’s packaged `qwen3.8:27b-mlx` build on Apple Silicon and map it exactly to the LM Studio MLX build
- add the gated OrcaRouter Qwen3.8 27B Uncensored MLX repository as an LM Studio catalog option
- preserve full Hugging Face URLs as LM Studio install IDs while parsing their repository metadata correctly
- update the Qwen3.8/MTPLX documentation for Ollama’s native MLX engine

## Test plan

- `server/node_modules/.bin/vitest run lib/localLlmCatalog.test.js services/localLlm.test.js services/huggingFaceCatalog.test.js --root server --configLoader runner`
- `server/node_modules/.bin/vitest run routes/localLlm.test.js --root server --configLoader runner`
- `git diff --check`