### PR TITLE
feat: guide creative commissions for model-aware video prompts

### DIFF
--- a/server/services/creativeCommissions/abilityAdapters.js
+++ b/server/services/creativeCommissions/abilityAdapters.js
@@ -103,11 +103,13 @@ function genValue(commission, key) {
   return coerceGenerationValue(key, commission?.generation);
 }
 
-function videoPromptGuidanceFor(commission, { defaultVideoModelId, effectiveVideoMode } = {}) {
+function videoPromptGuidanceFor(commission, {
+  defaultVideoModelId, effectiveVideoMode, effectiveVideoModelId,
+} = {}) {
   const generation = commission?.generation;
   const isCloudVideo = (effectiveVideoMode || generation?.videoMode) === VIDEO_GEN_MODE.GROK;
   const modelId = isCloudVideo ? undefined : (
-    generation?.videoModelId || generation?.model
+    generation?.videoModelId || generation?.model || effectiveVideoModelId
       || (typeof defaultVideoModelId === 'function' ? defaultVideoModelId() : undefined)
   );
   return buildVideoPromptGuidance(modelId);
@@ -189,11 +191,11 @@ const videoAdapter = {
   label: 'Video',
   sanitizeGeneration: (raw) => sanitizeGenerationFor('video', raw),
   buildProjectParams: buildVideoGeometryParams,
-  buildDirective(commission, { defaultVideoModelId, effectiveVideoMode } = {}) {
+  buildDirective(commission, { defaultVideoModelId, effectiveVideoMode, effectiveVideoModelId } = {}) {
     const duration = commission?.generation?.durationMode === 'auto'
       ? ' Choose an appropriate duration between 5 and 600 seconds for the brief.' : '';
     const { lines, digest, constraints } = briefContext(commission, `Create a short-form video piece.${duration}`);
-    lines.unshift(videoPromptGuidanceFor(commission, { defaultVideoModelId, effectiveVideoMode }));
+    lines.unshift(videoPromptGuidanceFor(commission, { defaultVideoModelId, effectiveVideoMode, effectiveVideoModelId }));
     return { goal: composeDirectiveGoal(lines, digest), deliverables: ['One rendered video matching the brief'], constraints };
   },
 };
@@ -240,12 +242,12 @@ const musicVideoAdapter = {
   label: 'Music video',
   sanitizeGeneration: (raw) => sanitizeGenerationFor('music-video', raw),
   buildProjectParams: buildVideoGeometryParams,
-  buildDirective(commission, { defaultVideoModelId, effectiveVideoMode } = {}) {
+  buildDirective(commission, { defaultVideoModelId, effectiveVideoMode, effectiveVideoModelId } = {}) {
     const duration = commission?.generation?.durationMode === 'auto'
       ? ' Choose an appropriate video duration between 5 and 600 seconds for the brief.' : '';
     const lead = `Create a short-form music video:${duration} Generate an original music bed AND a matching video scored to it.`;
     const { lines, digest, constraints } = briefContext(commission, lead);
-    lines.unshift(videoPromptGuidanceFor(commission, { defaultVideoModelId, effectiveVideoMode }));
+    lines.unshift(videoPromptGuidanceFor(commission, { defaultVideoModelId, effectiveVideoMode, effectiveVideoModelId }));
     return {
       goal: composeDirectiveGoal(lines, digest),
       deliverables: ['One original music bed', 'One video matching the brief, scored to the music bed'],

--- a/server/services/creativeCommissions/abilityAdapters.js
+++ b/server/services/creativeCommissions/abilityAdapters.js
@@ -35,6 +35,7 @@ import {
   ABILITY_GENERATION_SPEC, GENERATION_KEY_DEFS, CREATIVE_COMMISSION_ABILITIES,
   COMMISSION_RENDER_BACKEND_AUTO,
 } from '../../lib/creativeCommissionValidation.js';
+import { VIDEO_GEN_MODE } from '../../videoGen/modes.js';
 import { buildVideoPromptGuidance } from './videoPromptGuidance.js';
 
 const isStr = (v) => typeof v === 'string';
@@ -104,8 +105,11 @@ function genValue(commission, key) {
 
 function videoPromptGuidanceFor(commission, { defaultVideoModelId } = {}) {
   const generation = commission?.generation;
-  const modelId = generation?.videoModelId || generation?.model
-    || (typeof defaultVideoModelId === 'function' ? defaultVideoModelId() : undefined);
+  const isCloudVideo = generation?.videoMode === VIDEO_GEN_MODE.GROK;
+  const modelId = isCloudVideo ? undefined : (
+    generation?.videoModelId || generation?.model
+      || (typeof defaultVideoModelId === 'function' ? defaultVideoModelId() : undefined)
+  );
   return buildVideoPromptGuidance(modelId);
 }
 

--- a/server/services/creativeCommissions/abilityAdapters.js
+++ b/server/services/creativeCommissions/abilityAdapters.js
@@ -35,7 +35,7 @@ import {
   ABILITY_GENERATION_SPEC, GENERATION_KEY_DEFS, CREATIVE_COMMISSION_ABILITIES,
   COMMISSION_RENDER_BACKEND_AUTO,
 } from '../../lib/creativeCommissionValidation.js';
-import { VIDEO_GEN_MODE } from '../../videoGen/modes.js';
+import { VIDEO_GEN_MODE } from '../videoGen/modes.js';
 import { buildVideoPromptGuidance } from './videoPromptGuidance.js';
 
 const isStr = (v) => typeof v === 'string';
@@ -103,9 +103,9 @@ function genValue(commission, key) {
   return coerceGenerationValue(key, commission?.generation);
 }
 
-function videoPromptGuidanceFor(commission, { defaultVideoModelId } = {}) {
+function videoPromptGuidanceFor(commission, { defaultVideoModelId, effectiveVideoMode } = {}) {
   const generation = commission?.generation;
-  const isCloudVideo = generation?.videoMode === VIDEO_GEN_MODE.GROK;
+  const isCloudVideo = (effectiveVideoMode || generation?.videoMode) === VIDEO_GEN_MODE.GROK;
   const modelId = isCloudVideo ? undefined : (
     generation?.videoModelId || generation?.model
       || (typeof defaultVideoModelId === 'function' ? defaultVideoModelId() : undefined)
@@ -189,11 +189,11 @@ const videoAdapter = {
   label: 'Video',
   sanitizeGeneration: (raw) => sanitizeGenerationFor('video', raw),
   buildProjectParams: buildVideoGeometryParams,
-  buildDirective(commission, { defaultVideoModelId } = {}) {
+  buildDirective(commission, { defaultVideoModelId, effectiveVideoMode } = {}) {
     const duration = commission?.generation?.durationMode === 'auto'
       ? ' Choose an appropriate duration between 5 and 600 seconds for the brief.' : '';
     const { lines, digest, constraints } = briefContext(commission, `Create a short-form video piece.${duration}`);
-    lines.unshift(videoPromptGuidanceFor(commission, { defaultVideoModelId }));
+    lines.unshift(videoPromptGuidanceFor(commission, { defaultVideoModelId, effectiveVideoMode }));
     return { goal: composeDirectiveGoal(lines, digest), deliverables: ['One rendered video matching the brief'], constraints };
   },
 };
@@ -240,12 +240,12 @@ const musicVideoAdapter = {
   label: 'Music video',
   sanitizeGeneration: (raw) => sanitizeGenerationFor('music-video', raw),
   buildProjectParams: buildVideoGeometryParams,
-  buildDirective(commission, { defaultVideoModelId } = {}) {
+  buildDirective(commission, { defaultVideoModelId, effectiveVideoMode } = {}) {
     const duration = commission?.generation?.durationMode === 'auto'
       ? ' Choose an appropriate video duration between 5 and 600 seconds for the brief.' : '';
     const lead = `Create a short-form music video:${duration} Generate an original music bed AND a matching video scored to it.`;
     const { lines, digest, constraints } = briefContext(commission, lead);
-    lines.unshift(videoPromptGuidanceFor(commission, { defaultVideoModelId }));
+    lines.unshift(videoPromptGuidanceFor(commission, { defaultVideoModelId, effectiveVideoMode }));
     return {
       goal: composeDirectiveGoal(lines, digest),
       deliverables: ['One original music bed', 'One video matching the brief, scored to the music bed'],

--- a/server/services/creativeCommissions/abilityAdapters.js
+++ b/server/services/creativeCommissions/abilityAdapters.js
@@ -35,6 +35,7 @@ import {
   ABILITY_GENERATION_SPEC, GENERATION_KEY_DEFS, CREATIVE_COMMISSION_ABILITIES,
   COMMISSION_RENDER_BACKEND_AUTO,
 } from '../../lib/creativeCommissionValidation.js';
+import { buildVideoPromptGuidance } from './videoPromptGuidance.js';
 
 const isStr = (v) => typeof v === 'string';
 
@@ -99,6 +100,11 @@ function briefContext(commission, leadSentence) {
 // sanitizer applies (so the goal never quotes an out-of-range count).
 function genValue(commission, key) {
   return coerceGenerationValue(key, commission?.generation);
+}
+
+function videoPromptGuidanceFor(commission) {
+  const generation = commission?.generation;
+  return buildVideoPromptGuidance(generation?.videoModelId || generation?.model);
 }
 
 /**
@@ -181,6 +187,7 @@ const videoAdapter = {
     const duration = commission?.generation?.durationMode === 'auto'
       ? ' Choose an appropriate duration between 5 and 600 seconds for the brief.' : '';
     const { lines, digest, constraints } = briefContext(commission, `Create a short-form video piece.${duration}`);
+    lines.unshift(videoPromptGuidanceFor(commission));
     return { goal: composeDirectiveGoal(lines, digest), deliverables: ['One rendered video matching the brief'], constraints };
   },
 };
@@ -232,6 +239,7 @@ const musicVideoAdapter = {
       ? ' Choose an appropriate video duration between 5 and 600 seconds for the brief.' : '';
     const lead = `Create a short-form music video:${duration} Generate an original music bed AND a matching video scored to it.`;
     const { lines, digest, constraints } = briefContext(commission, lead);
+    lines.unshift(videoPromptGuidanceFor(commission));
     return {
       goal: composeDirectiveGoal(lines, digest),
       deliverables: ['One original music bed', 'One video matching the brief, scored to the music bed'],

--- a/server/services/creativeCommissions/abilityAdapters.js
+++ b/server/services/creativeCommissions/abilityAdapters.js
@@ -199,7 +199,7 @@ const imageAdapter = {
   label: 'Image',
   sanitizeGeneration: (raw) => sanitizeGenerationFor('image', raw),
   buildProjectParams: buildVideoGeometryParams,
-  buildDirective(commission, { defaultVideoModelId } = {}) {
+  buildDirective(commission) {
     const count = genValue(commission, 'imageCount');
     const noun = count === 1 ? 'a single still image' : `${count} still images`;
     const lead = `Produce ${noun}. Use the image / catalog generation tools; do NOT plan a video or music render.`;

--- a/server/services/creativeCommissions/abilityAdapters.js
+++ b/server/services/creativeCommissions/abilityAdapters.js
@@ -108,8 +108,12 @@ function videoPromptGuidanceFor(commission, {
 } = {}) {
   const generation = commission?.generation;
   const isCloudVideo = (effectiveVideoMode || generation?.videoMode) === VIDEO_GEN_MODE.GROK;
+  const hasExplicitLocalModel = generation?.videoMode === VIDEO_GEN_MODE.LOCAL && generation?.videoModelId;
   const modelId = isCloudVideo ? undefined : (
-    generation?.videoModelId || generation?.model || effectiveVideoModelId
+    (hasExplicitLocalModel ? generation.videoModelId : undefined)
+      || effectiveVideoModelId
+      || generation?.videoModelId
+      || generation?.model
       || (typeof defaultVideoModelId === 'function' ? defaultVideoModelId() : undefined)
   );
   return buildVideoPromptGuidance(modelId);

--- a/server/services/creativeCommissions/abilityAdapters.js
+++ b/server/services/creativeCommissions/abilityAdapters.js
@@ -102,9 +102,11 @@ function genValue(commission, key) {
   return coerceGenerationValue(key, commission?.generation);
 }
 
-function videoPromptGuidanceFor(commission) {
+function videoPromptGuidanceFor(commission, { defaultVideoModelId } = {}) {
   const generation = commission?.generation;
-  return buildVideoPromptGuidance(generation?.videoModelId || generation?.model);
+  const modelId = generation?.videoModelId || generation?.model
+    || (typeof defaultVideoModelId === 'function' ? defaultVideoModelId() : undefined);
+  return buildVideoPromptGuidance(modelId);
 }
 
 /**
@@ -183,11 +185,11 @@ const videoAdapter = {
   label: 'Video',
   sanitizeGeneration: (raw) => sanitizeGenerationFor('video', raw),
   buildProjectParams: buildVideoGeometryParams,
-  buildDirective(commission) {
+  buildDirective(commission, { defaultVideoModelId } = {}) {
     const duration = commission?.generation?.durationMode === 'auto'
       ? ' Choose an appropriate duration between 5 and 600 seconds for the brief.' : '';
     const { lines, digest, constraints } = briefContext(commission, `Create a short-form video piece.${duration}`);
-    lines.unshift(videoPromptGuidanceFor(commission));
+    lines.unshift(videoPromptGuidanceFor(commission, { defaultVideoModelId }));
     return { goal: composeDirectiveGoal(lines, digest), deliverables: ['One rendered video matching the brief'], constraints };
   },
 };
@@ -197,7 +199,7 @@ const imageAdapter = {
   label: 'Image',
   sanitizeGeneration: (raw) => sanitizeGenerationFor('image', raw),
   buildProjectParams: buildVideoGeometryParams,
-  buildDirective(commission) {
+  buildDirective(commission, { defaultVideoModelId } = {}) {
     const count = genValue(commission, 'imageCount');
     const noun = count === 1 ? 'a single still image' : `${count} still images`;
     const lead = `Produce ${noun}. Use the image / catalog generation tools; do NOT plan a video or music render.`;
@@ -234,12 +236,12 @@ const musicVideoAdapter = {
   label: 'Music video',
   sanitizeGeneration: (raw) => sanitizeGenerationFor('music-video', raw),
   buildProjectParams: buildVideoGeometryParams,
-  buildDirective(commission) {
+  buildDirective(commission, { defaultVideoModelId } = {}) {
     const duration = commission?.generation?.durationMode === 'auto'
       ? ' Choose an appropriate video duration between 5 and 600 seconds for the brief.' : '';
     const lead = `Create a short-form music video:${duration} Generate an original music bed AND a matching video scored to it.`;
     const { lines, digest, constraints } = briefContext(commission, lead);
-    lines.unshift(videoPromptGuidanceFor(commission));
+    lines.unshift(videoPromptGuidanceFor(commission, { defaultVideoModelId }));
     return {
       goal: composeDirectiveGoal(lines, digest),
       deliverables: ['One original music bed', 'One video matching the brief, scored to the music bed'],

--- a/server/services/creativeCommissions/abilityAdapters.test.js
+++ b/server/services/creativeCommissions/abilityAdapters.test.js
@@ -134,6 +134,30 @@ describe('buildCommissionDirective — video (unchanged brief/feedback fold)', (
     );
     expect(directive.goal).toContain('MiniMax H3 prompt template');
   });
+
+  it('uses the resolved target model for auto mode even when the commission has a stale model', () => {
+    const directive = buildCommissionDirective(
+      {
+        targetAbility: 'video',
+        brief: { intent: 'a quiet harbor' },
+        generation: { videoMode: 'auto', videoModelId: 'minimax_h3_8bit' },
+      },
+      { effectiveVideoMode: 'local', effectiveVideoModelId: 'ltx-2.5' },
+    );
+    expect(directive.goal).not.toContain('MiniMax H3 prompt template');
+  });
+
+  it('keeps an explicitly pinned local commission model ahead of the target default', () => {
+    const directive = buildCommissionDirective(
+      {
+        targetAbility: 'video',
+        brief: { intent: 'a quiet harbor' },
+        generation: { videoMode: 'local', videoModelId: 'minimax_h3_8bit' },
+      },
+      { effectiveVideoMode: 'local', effectiveVideoModelId: 'ltx-2.5' },
+    );
+    expect(directive.goal).toContain('MiniMax H3 prompt template');
+  });
 });
 
 describe('per-ability directives steer the planner to the right tools', () => {

--- a/server/services/creativeCommissions/abilityAdapters.test.js
+++ b/server/services/creativeCommissions/abilityAdapters.test.js
@@ -3,6 +3,7 @@ import {
   ABILITY_ADAPTERS, getAbilityAdapter, buildCommissionDirective, buildRenderBackendPin,
 } from './abilityAdapters.js';
 import { CREATIVE_COMMISSION_ABILITIES, ABILITY_GENERATION_SPEC } from '../../lib/creativeCommissionValidation.js';
+import { buildVideoPromptGuidance, isMiniMaxVideoModel } from './videoPromptGuidance.js';
 
 describe('ability adapter registry', () => {
   it('has an adapter for every supported ability (and no extras)', () => {
@@ -73,6 +74,32 @@ describe('buildCommissionDirective — video (unchanged brief/feedback fold)', (
   it('falls back to the video adapter for an unknown ability', () => {
     const directive = buildCommissionDirective({ targetAbility: 'hologram', brief: { intent: 'x' } });
     expect(directive.goal).toContain('Create a short-form video piece.');
+  });
+
+  it('adds the generic shot recipe and MiniMax guidance for the selected model', () => {
+    const directive = buildCommissionDirective({
+      targetAbility: 'video',
+      brief: { intent: 'a courier crosses a rainy plaza' },
+      generation: { videoModelId: 'minimax_h3_8bit' },
+    });
+    expect(directive.goal).toContain('beginning, middle, and end');
+    expect(directive.goal).toContain('master timeline plus timestamped micro-beats');
+    expect(directive.goal).toContain('7000 characters');
+  });
+
+  it('keeps model-specific guidance off the generic path while retaining the shot recipe', () => {
+    expect(isMiniMaxVideoModel('ltx-2.5')).toBe(false);
+    expect(buildVideoPromptGuidance('ltx-2.5')).toContain('production-ready prompt');
+    expect(buildVideoPromptGuidance('ltx-2.5')).not.toContain('[Tracking shot]');
+  });
+
+  it('keeps the MiniMax recipe when the brief nearly fills the directive budget', () => {
+    const directive = buildCommissionDirective({
+      targetAbility: 'video',
+      brief: { intent: 'x'.repeat(2000), styleSpec: 'y'.repeat(2000) },
+      generation: { videoModelId: 'minimax_h3_cuda' },
+    });
+    expect(directive.goal).toContain('MiniMax H3 prompt template');
   });
 });
 

--- a/server/services/creativeCommissions/abilityAdapters.test.js
+++ b/server/services/creativeCommissions/abilityAdapters.test.js
@@ -109,6 +109,15 @@ describe('buildCommissionDirective — video (unchanged brief/feedback fold)', (
     );
     expect(directive.goal).toContain('MiniMax H3 prompt template');
   });
+
+  it('does not apply local-model guidance to a Grok-pinned commission', () => {
+    const directive = buildCommissionDirective(
+      { targetAbility: 'video', brief: { intent: 'a quiet harbor' }, generation: { videoMode: 'grok' } },
+      { defaultVideoModelId: () => 'minimax_h3_8bit' },
+    );
+    expect(directive.goal).not.toContain('MiniMax H3 prompt template');
+    expect(directive.goal).toContain('production-ready prompt');
+  });
 });
 
 describe('per-ability directives steer the planner to the right tools', () => {

--- a/server/services/creativeCommissions/abilityAdapters.test.js
+++ b/server/services/creativeCommissions/abilityAdapters.test.js
@@ -118,6 +118,14 @@ describe('buildCommissionDirective — video (unchanged brief/feedback fold)', (
     expect(directive.goal).not.toContain('MiniMax H3 prompt template');
     expect(directive.goal).toContain('production-ready prompt');
   });
+
+  it('honors the resolved settings-level cloud backend for auto mode', () => {
+    const directive = buildCommissionDirective(
+      { targetAbility: 'video', brief: { intent: 'a quiet harbor' } },
+      { defaultVideoModelId: () => 'minimax_h3_8bit', effectiveVideoMode: 'grok' },
+    );
+    expect(directive.goal).not.toContain('MiniMax H3 prompt template');
+  });
 });
 
 describe('per-ability directives steer the planner to the right tools', () => {

--- a/server/services/creativeCommissions/abilityAdapters.test.js
+++ b/server/services/creativeCommissions/abilityAdapters.test.js
@@ -126,6 +126,14 @@ describe('buildCommissionDirective — video (unchanged brief/feedback fold)', (
     );
     expect(directive.goal).not.toContain('MiniMax H3 prompt template');
   });
+
+  it('uses the resolved creative-agent target model before the install default', () => {
+    const directive = buildCommissionDirective(
+      { targetAbility: 'video', brief: { intent: 'a quiet harbor' } },
+      { defaultVideoModelId: () => 'ltx-2.5', effectiveVideoModelId: 'minimax_h3_8bit' },
+    );
+    expect(directive.goal).toContain('MiniMax H3 prompt template');
+  });
 });
 
 describe('per-ability directives steer the planner to the right tools', () => {

--- a/server/services/creativeCommissions/abilityAdapters.test.js
+++ b/server/services/creativeCommissions/abilityAdapters.test.js
@@ -101,6 +101,14 @@ describe('buildCommissionDirective — video (unchanged brief/feedback fold)', (
     });
     expect(directive.goal).toContain('MiniMax H3 prompt template');
   });
+
+  it('uses the install default model when choosing model-specific guidance', () => {
+    const directive = buildCommissionDirective(
+      { targetAbility: 'video', brief: { intent: 'a quiet harbor' } },
+      { defaultVideoModelId: () => 'minimax_h3_8bit' },
+    );
+    expect(directive.goal).toContain('MiniMax H3 prompt template');
+  });
 });
 
 describe('per-ability directives steer the planner to the right tools', () => {

--- a/server/services/creativeCommissions/scheduler.js
+++ b/server/services/creativeCommissions/scheduler.js
@@ -26,6 +26,7 @@ import { schedule, cancel, isValidCron } from '../eventScheduler.js';
 import { getUserTimezone } from '../../lib/timezone.js';
 import { getSettings, settingsEvents } from '../settings.js';
 import { RENDER_TARGET } from '../../lib/renderTargets.js';
+import { renderTargetDefaults } from '../imageGen/cloudProviderConfig.js';
 import { resolveVideoMode, VIDEO_GEN_MODE } from '../videoGen/modes.js';
 import { listCommissions, getCommission, recordCommissionRun, commissionEvents } from './store.js';
 import { commissionToCron } from './directive.js';
@@ -287,10 +288,14 @@ async function fireCommission(commission, trigger) {
     const effectiveVideoMode = (commission.targetAbility === 'video' || commission.targetAbility === 'music-video')
       ? resolveVideoMode(requestedVideoMode, settings, { target: RENDER_TARGET.CREATIVE_AGENT })
       : VIDEO_GEN_MODE.LOCAL;
+    const effectiveVideoModelId = effectiveVideoMode === VIDEO_GEN_MODE.LOCAL
+      ? renderTargetDefaults(settings, RENDER_TARGET.CREATIVE_AGENT).videoModel
+      : null;
     const directive = buildCommissionDirective(commission, {
       tasteRecipe: startedTasteRecipe,
       defaultVideoModelId,
       effectiveVideoMode,
+      effectiveVideoModelId,
     });
     // Fan the commission's single LLM pin onto BOTH CD cognitive stages
     // (treatment + plan) as the project's `modelOverrides`, so the scheduled

--- a/server/services/creativeCommissions/scheduler.js
+++ b/server/services/creativeCommissions/scheduler.js
@@ -277,7 +277,10 @@ async function fireCommission(commission, trigger) {
       import('../videoGen/local.js'),
     ]);
 
-    const directive = buildCommissionDirective(commission, { tasteRecipe: startedTasteRecipe });
+    const directive = buildCommissionDirective(commission, {
+      tasteRecipe: startedTasteRecipe,
+      defaultVideoModelId,
+    });
     // Fan the commission's single LLM pin onto BOTH CD cognitive stages
     // (treatment + plan) as the project's `modelOverrides`, so the scheduled
     // fire is processed by the provider/model the user chose rather than the

--- a/server/services/creativeCommissions/scheduler.js
+++ b/server/services/creativeCommissions/scheduler.js
@@ -24,7 +24,9 @@
 
 import { schedule, cancel, isValidCron } from '../eventScheduler.js';
 import { getUserTimezone } from '../../lib/timezone.js';
-import { settingsEvents } from '../settings.js';
+import { getSettings, settingsEvents } from '../settings.js';
+import { RENDER_TARGET } from '../../lib/renderTargets.js';
+import { resolveVideoMode, VIDEO_GEN_MODE } from '../videoGen/modes.js';
 import { listCommissions, getCommission, recordCommissionRun, commissionEvents } from './store.js';
 import { commissionToCron } from './directive.js';
 import { buildCommissionDirective, getAbilityAdapter } from './abilityAdapters.js';
@@ -277,9 +279,18 @@ async function fireCommission(commission, trigger) {
       import('../videoGen/local.js'),
     ]);
 
+    const settings = (commission.targetAbility === 'video' || commission.targetAbility === 'music-video')
+      ? await getSettings().catch(() => ({}))
+      : {};
+    const requestedVideoMode = commission.generation?.videoMode === 'auto'
+      ? null : commission.generation?.videoMode;
+    const effectiveVideoMode = (commission.targetAbility === 'video' || commission.targetAbility === 'music-video')
+      ? resolveVideoMode(requestedVideoMode, settings, { target: RENDER_TARGET.CREATIVE_AGENT })
+      : VIDEO_GEN_MODE.LOCAL;
     const directive = buildCommissionDirective(commission, {
       tasteRecipe: startedTasteRecipe,
       defaultVideoModelId,
+      effectiveVideoMode,
     });
     // Fan the commission's single LLM pin onto BOTH CD cognitive stages
     // (treatment + plan) as the project's `modelOverrides`, so the scheduled

--- a/server/services/creativeCommissions/scheduler.test.js
+++ b/server/services/creativeCommissions/scheduler.test.js
@@ -13,7 +13,7 @@ vi.mock('../eventScheduler.js', () => ({
 vi.mock('../../lib/timezone.js', () => ({ getUserTimezone: async () => 'UTC' }));
 
 const settingsEvents = new EventEmitter();
-vi.mock('../settings.js', () => ({ settingsEvents }));
+vi.mock('../settings.js', () => ({ settingsEvents, getSettings: async () => ({}) }));
 
 const listCommissionsMock = vi.fn();
 const getCommissionMock = vi.fn();

--- a/server/services/creativeCommissions/videoPromptGuidance.js
+++ b/server/services/creativeCommissions/videoPromptGuidance.js
@@ -1,0 +1,50 @@
+/**
+ * Prompt-writing guidance for video commissions.
+ *
+ * This is intentionally guidance for the Creative Director, not a prompt
+ * rewriter. The director still owns the creative choices; this supplies the
+ * production details that make those choices actionable to a renderer.
+ */
+
+const MINIMAX_H3_MODEL_PATTERN = /(?:^|[_-])minimax(?:[_-])?h3(?:[_-]|$)|minimax_h3/i;
+const HAILUO_MODEL_PATTERN = /hailuo/i;
+
+export const GENERIC_VIDEO_PROMPT_GUIDANCE = [
+  'Write a production-ready prompt for one continuous shot, not a vague mood board.',
+  'Specify the subject and distinctive appearance, environment, time of day, lighting, composition, and visual style.',
+  'Describe an observable beginning, middle, and end: what moves, how it moves, and what has changed by the final moment.',
+  'Choose one primary camera behavior and state its framing and speed; keep the action physically plausible and focused.',
+  'Prefer concrete nouns and visible verbs over adjectives such as beautiful, cinematic, or dynamic by themselves.',
+  'For image-to-video or continuation renders, describe motion and scene evolution from the source frame instead of re-describing a replacement image.',
+].join(' ');
+
+export const MINIMAX_H3_VIDEO_PROMPT_GUIDANCE = [
+  'MiniMax H3 prompt template: expand the brief in this order — output goal and duration, subjects/assets and reference mapping, chronological timeline, scene/environment, camera (shot size, angle, movement, focus, cuts), look (style, color, texture, mood, pacing), sound, and continuity/artifact constraints.',
+  'For image-to-video or continuation, treat the supplied image as the opening state and describe how the subject and camera move from it; do not replace it with a new still-image description.',
+  'Use one causal action beat per shot. Give it an exact beginning, preparation, core action, settle/hold, and locked end state; keep actions physically achievable in the selected 4–15 second duration.',
+  'When there are ordered references, name them in order and use a contiguous master timeline plus timestamped micro-beats with no gaps or overlaps. The next shot must inherit the prior shot’s locked pose, gaze, prop ownership, spatial relationship, and camera side.',
+  'Use explicit natural-language camera direction with movement type, amplitude, and speed. Do not silently add brands, dialogue, text overlays, or unrelated actions.',
+  'Keep the final MiniMax H3 render prompt under 7000 characters.',
+].join(' ');
+
+export const HAILUO_VIDEO_PROMPT_GUIDANCE = [
+  'MiniMax Hailuo prompt recipe: use a concise shot description with explicit temporal progression and a single clear subject action.',
+  'For image-to-video, treat the input image as the opening frame and describe only how the scene develops from it.',
+  'Use explicit camera commands when useful: [Static shot], [Tracking shot], [Pan left], [Pan right], [Push in], [Pull out], [Tilt up], [Tilt down], [Zoom in], or [Zoom out]. Sequence distinct movements in order, and combine no more than three commands in one bracket.',
+  'Include the subject action, camera movement, timing or progression, lighting/atmosphere, and intended final beat. Keep the final render prompt under MiniMax’s 2000-character prompt limit.',
+].join(' ');
+
+export function isMiniMaxVideoModel(modelId) {
+  return typeof modelId === 'string'
+    && (MINIMAX_H3_MODEL_PATTERN.test(modelId.trim()) || HAILUO_MODEL_PATTERN.test(modelId.trim()));
+}
+
+export function buildVideoPromptGuidance(modelId) {
+  const normalized = typeof modelId === 'string' ? modelId.trim() : '';
+  const modelLine = MINIMAX_H3_MODEL_PATTERN.test(normalized)
+    ? MINIMAX_H3_VIDEO_PROMPT_GUIDANCE
+    : (HAILUO_MODEL_PATTERN.test(normalized)
+      ? HAILUO_VIDEO_PROMPT_GUIDANCE
+      : 'If the selected model has a documented prompt grammar, follow that model grammar while preserving this shot structure.');
+  return `Video prompt guidance: ${GENERIC_VIDEO_PROMPT_GUIDANCE} ${modelLine}`;
+}


### PR DESCRIPTION
## Summary
- Add a reusable video prompt guidance layer to Creative Commission directives.
- Add MiniMax H3 guidance based on the official production prompt order, timeline, continuity, and 7000-character limit.
- Add Hailuo camera-command guidance and retain a generic recipe for other models.
- Preserve guidance under the existing directive length budget.

## Test plan
- `cd server && npm test -- --run services/creativeCommissions/abilityAdapters.test.js services/creative/tools/media.test.js`
- `git diff --check`