### PR TITLE
feat: allow local LLM backends to be marked disabled

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -10,7 +10,7 @@ import { useConfirmDelete } from '../../hooks/useConfirmDelete';
 import {
   getLocalLlmStatus, getLocalLlmCatalog, getLocalLlmHuggingFaceSearch, installLocalLlmModel,
   deleteLocalLlmModel, switchLocalLlmBackend, migrateLocalLlmBackend, installLocalLlmBackend, upgradeLocalLlmBackend, controlOllamaService,
-  installAudioModel
+  installAudioModel, patchSettingsSlice
 } from '../../services/api';
 import socket from '../../services/socket';
 import MemoryManagement from './MemoryManagement.jsx';
@@ -129,8 +129,8 @@ function BackendCard({ backend, status, isDefault, busy, actionInProgress, runAc
   const Icon = backend.icon;
   const other = backend.id === 'ollama' ? 'lmstudio' : 'ollama';
   const otherData = status?.[other];
-  const statusLabel = data?.available ? 'Running' : data?.installed ? 'Installed (stopped)' : 'Not installed';
-  const statusColor = data?.available ? 'bg-port-success' : data?.installed ? 'bg-port-warning' : 'bg-gray-600';
+  const statusLabel = data?.disabled ? 'Disabled' : data?.available ? 'Running' : data?.installed ? 'Installed (stopped)' : 'Not installed';
+  const statusColor = data?.disabled ? 'bg-gray-600' : data?.available ? 'bg-port-success' : data?.installed ? 'bg-port-warning' : 'bg-gray-600';
   const startupService = backend.id === 'ollama' ? data?.service : null;
   const runsAtStartup = Boolean(startupService?.runAtStartup);
   // The window resident models were ACTUALLY loaded at — Ollama picks it from
@@ -307,6 +307,23 @@ function BackendCard({ backend, status, isDefault, busy, actionInProgress, runAc
           )}
         </div>
       )}
+
+      <div className="flex items-center justify-between gap-2 pt-1 border-t border-port-border/50">
+        <span className="text-xs text-gray-500">{data?.disabled ? 'PortOS will not expect this backend to be running.' : 'Show a warning when this backend is offline.'}</span>
+        <button
+          onClick={() => runAction(
+            `toggle-disabled-${backend.id}`,
+            () => patchSettingsSlice(`localLlm.${backend.id}`, { disabled: !data?.disabled }),
+            data?.disabled ? `${backend.label} enabled` : `${backend.label} marked as disabled`
+          )}
+          disabled={busy}
+          className={`${btnClass} ${data?.disabled ? 'bg-port-border hover:bg-port-border/70 text-white' : 'bg-port-warning/20 hover:bg-port-warning/30 text-port-warning'}`}
+          title={data?.disabled ? `Re-enable ${backend.label} availability warnings` : `Mark ${backend.label} as intentionally disabled`}
+        >
+          {actionInProgress === `toggle-disabled-${backend.id}` ? <BrailleSpinner /> : data?.disabled ? <Power size={12} /> : <PowerOff size={12} />}
+          {data?.disabled ? 'Enable warnings' : 'Mark disabled'}
+        </button>
+      </div>
     </div>
   );
 }
@@ -763,7 +780,7 @@ export function LocalLlmTab() {
           </div>
         </div>
 
-        {selectedData && !selectedData.available && (
+        {selectedData && !selectedData.available && !selectedData.disabled && (
           <div className="flex items-center gap-2 flex-wrap text-xs text-port-warning">
             <span>
               {labelFor(selected)} isn't running — {selectedData.installed

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -14,6 +14,7 @@ vi.mock('../../services/api', () => ({
   upgradeLocalLlmBackend: vi.fn(),
   controlOllamaService: vi.fn(),
   installAudioModel: vi.fn(),
+  patchSettingsSlice: vi.fn(),
 }));
 vi.mock('../../services/socket', () => ({
   default: { on: vi.fn(), off: vi.fn() },
@@ -24,7 +25,7 @@ vi.mock('../ui/Toast', () => ({
   default: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() }),
 }));
 
-import { getLocalLlmStatus, getLocalLlmCatalog } from '../../services/api';
+import { getLocalLlmStatus, getLocalLlmCatalog, patchSettingsSlice } from '../../services/api';
 import { LocalLlmTab } from './LocalLlmTab';
 
 // A realistically long HF model id — the shape that got ellipsised to
@@ -61,6 +62,32 @@ beforeEach(() => {
     lmstudio: { installed: false, available: false, modelCount: 0, models: [] },
   });
   getLocalLlmCatalog.mockResolvedValue({ models: [] });
+  patchSettingsSlice.mockResolvedValue({});
+});
+
+describe('LocalLlmTab backend disable state', () => {
+  it('suppresses the offline warning and persists the intentional disabled state', async () => {
+    getLocalLlmStatus.mockResolvedValue({
+      backend: 'lmstudio',
+      ollama: { installed: true, available: true, modelCount: 0, models: [] },
+      lmstudio: { installed: true, available: false, disabled: false, modelCount: 0, models: [] },
+    });
+    getLocalLlmStatus.mockResolvedValueOnce({
+      backend: 'lmstudio',
+      ollama: { installed: true, available: true, modelCount: 0, models: [] },
+      lmstudio: { installed: true, available: false, disabled: false, modelCount: 0, models: [] },
+    }).mockResolvedValue({
+      backend: 'lmstudio',
+      ollama: { installed: true, available: true, modelCount: 0, models: [] },
+      lmstudio: { installed: true, available: false, disabled: true, modelCount: 0, models: [] },
+    });
+    await renderTab();
+    expect(screen.getByText(/LM Studio isn't running/)).toBeInTheDocument();
+    fireEvent.click(screen.getByTitle('Mark LM Studio as intentionally disabled'));
+    await waitFor(() => expect(patchSettingsSlice).toHaveBeenCalledWith('localLlm.lmstudio', { disabled: true }));
+    await waitFor(() => expect(screen.queryByText(/LM Studio isn't running/)).toBeNull());
+    expect(screen.getByText('Disabled')).toBeInTheDocument();
+  });
 });
 
 describe('LocalLlmTab installed models', () => {

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -1231,6 +1231,14 @@ export const settingsEmbeddingsSchema = z.object({
   model: z.string().trim().max(200).optional().nullable(),
 }).strict();
 
+// Local backend availability is machine-local configuration. Disabled means
+// the user intentionally does not run that backend; it does not remove any
+// installed models or prevent an explicit model-management action.
+export const localLlmSettingsSchema = z.object({
+  ollama: z.object({ disabled: z.boolean().optional() }).strict().optional(),
+  lmstudio: z.object({ disabled: z.boolean().optional() }).strict().optional(),
+}).strict();
+
 // =============================================================================
 // LM STUDIO (server/routes/lmstudio.js)
 // =============================================================================

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -12,7 +12,7 @@ import {
 import { asyncHandler } from '../lib/errorHandler.js';
 import { isPlainObject } from '../lib/objects.js';
 import { agentContextSettingsSchema } from '../lib/agentContextValidation.js';
-import { backupConfigSchema, sharingSettingsPatchSchema, featureProviderConfigSchema, autofixerSettingsSchema, codeReviewSettingsSchema, locationSettingsSchema, settingsEmbeddingsSchema, citySnapshotConfigSchema, imessageConfigSchema, signalConfigSchema, spotifyConfigSchema, youtubeConfigSchema, apiAccessSettingsSchema, loraTrainingConfigSchema, pipelineEditorialChecksSettingsSchema, creativeDirectorSettingsSchema, musicSettingsSchema, federationSettingsSchema, privacySettingsSchema, seriesAutopilotSettingsSchema, layeredIntelligenceSettingsSchema, imageGenGrokSettingsSchema, imageGenAgySettingsSchema, renderDefaultsSettingsSchema, videoGenSettingsSchema, subscriptionCostsMapSchema, validateRequest } from '../lib/validation.js';
+import { backupConfigSchema, sharingSettingsPatchSchema, featureProviderConfigSchema, autofixerSettingsSchema, codeReviewSettingsSchema, locationSettingsSchema, settingsEmbeddingsSchema, localLlmSettingsSchema, citySnapshotConfigSchema, imessageConfigSchema, signalConfigSchema, spotifyConfigSchema, youtubeConfigSchema, apiAccessSettingsSchema, loraTrainingConfigSchema, pipelineEditorialChecksSettingsSchema, creativeDirectorSettingsSchema, musicSettingsSchema, federationSettingsSchema, privacySettingsSchema, seriesAutopilotSettingsSchema, layeredIntelligenceSettingsSchema, imageGenGrokSettingsSchema, imageGenAgySettingsSchema, renderDefaultsSettingsSchema, videoGenSettingsSchema, subscriptionCostsMapSchema, validateRequest } from '../lib/validation.js';
 
 const router = Router();
 
@@ -172,6 +172,9 @@ router.put('/', asyncHandler(async (req, res) => {
   }
   if (req.body?.embeddings !== undefined) {
     validateRequest(settingsEmbeddingsSchema.partial(), req.body.embeddings);
+  }
+  if (req.body?.localLlm !== undefined) {
+    validateRequest(localLlmSettingsSchema, req.body.localLlm);
   }
   // CyberCity snapshot capture config — validate the slice when present so a
   // malformed interval/cap can't reach disk and break the scheduler.

--- a/server/services/localLlm.js
+++ b/server/services/localLlm.js
@@ -36,6 +36,7 @@ import { commandExists } from '../lib/commandExists.js'
 import * as ollamaManager from './ollamaManager.js'
 import * as lmStudioManager from './lmStudioManager.js'
 import { getProviderById, getAllProviders, updateProvider, refreshProviderModelsBatch, isOllamaBackedProvider } from './providers.js'
+import { getSettings } from './settings.js'
 
 const execFileAsync = promisify(execFile)
 const ENV_PATH = join(PATHS.root, '.env')
@@ -687,7 +688,7 @@ export async function listModels(backend, forceRefresh = false) {
  * Combined status for both backends plus the active marker.
  */
 export async function getStatus() {
-  const [ollamaStatus, ollamaCli, lmStudioStatus, lmsCli, lmStudioModels, latestOllamaVersion] = await Promise.all([
+  const [ollamaStatus, ollamaCli, lmStudioStatus, lmsCli, lmStudioModels, latestOllamaVersion, settings] = await Promise.all([
     ollamaManager.getStatus(true),
     commandExists('ollama', ['--version']),
     lmStudioManager.getStatus(),
@@ -695,7 +696,8 @@ export async function getStatus() {
     // forceRefresh: status/refresh path bypasses the list cache.
     listModels('lmstudio', true).catch(() => []),
     // Cached (6h) — never blocks the steady-state UI on a GitHub round-trip.
-    getLatestOllamaVersion().catch(() => null)
+    getLatestOllamaVersion().catch(() => null),
+    getSettings()
   ])
 
   const ollamaModels = normalizeModels('ollama', ollamaStatus.models)
@@ -710,6 +712,7 @@ export async function getStatus() {
   return {
     backend: getBackend(),
     ollama: {
+      disabled: Boolean(settings.localLlm?.ollama?.disabled),
       installed: ollamaCli || ollamaStatus.available,
       available: ollamaStatus.available,
       version: ollamaStatus.version,
@@ -728,6 +731,7 @@ export async function getStatus() {
       downloadUrl: DOWNLOAD_URL.ollama
     },
     lmstudio: {
+      disabled: Boolean(settings.localLlm?.lmstudio?.disabled),
       // macOS app bundle counts as installed even with no CLI / server stopped.
       installed: lmsCli || lmStudioStatus.available || lmStudioManager.isAppInstalled(),
       available: lmStudioStatus.available,

--- a/server/services/localLlm.test.js
+++ b/server/services/localLlm.test.js
@@ -19,6 +19,7 @@ vi.mock('../lib/fileUtils.js', async () => {
 });
 
 const mocks = vi.hoisted(() => ({
+  settings: { getSettings: vi.fn(async () => ({})) },
   ollama: {
     getInstalledModels: vi.fn(async () => []),
     getModelCapabilities: vi.fn(async () => []),
@@ -75,6 +76,7 @@ vi.mock('./providers.js', async () => {
     isOllamaBackedProvider: real.isOllamaBackedProvider
   };
 });
+vi.mock('./settings.js', () => mocks.settings);
 
 // child_process is mocked so the install/upgrade paths (spawn-based streaming +
 // execFile-based presence checks) are drivable. Defaults are benign for the rest


### PR DESCRIPTION
## Summary
- add persisted per-backend disabled state for local LLM availability
- expose the state in local LLM status and add LM Studio/Ollama controls
- suppress offline warnings when a backend is intentionally disabled

## Test plan
- cd client && npm test -- --run src/components/settings/LocalLlmTab.test.jsx
- cd server && npm test -- --run services/localLlm.test.js
