### PR TITLE
test: cover music track concept persistence

### DIFF
--- a/server/routes/tracks.test.js
+++ b/server/routes/tracks.test.js
@@ -201,6 +201,13 @@ describe('tracks routes', () => {
     expect(tracks.updateTrack).toHaveBeenCalledWith('track-1', { prompt: 'warm folk' });
   });
 
+  it('PATCH /:id accepts a saved music-designer concept', async () => {
+    tracks.getTrack.mockResolvedValue({ id: 'track-1', title: 'Intro' });
+    const r = await request(app).patch('/api/tracks/track-1').send({ concept: 'A dusk-time pulse' });
+    expect(r.status).toBe(200);
+    expect(tracks.updateTrack).toHaveBeenCalledWith('track-1', { concept: 'A dusk-time pulse' });
+  });
+
   it('DELETE /:id soft-deletes a track', async () => {
     tracks.getTrack.mockResolvedValue({ id: 'track-1', title: 'Intro' });
     const r = await request(app).delete('/api/tracks/track-1');

--- a/server/services/tracks/logic.test.js
+++ b/server/services/tracks/logic.test.js
@@ -71,6 +71,13 @@ describe('tracks logic', () => {
       expect(mergeTrackRecord(local, { ...local, title: 'New', updatedAt: '2099-01-01T00:00:00.000Z' }).remoteWins).toBe(true);
       expect(mergeTrackRecord(local, { ...local, title: 'Old', updatedAt: '2000-01-01T00:00:00.000Z' }).remoteWins).toBe(false);
     });
+
+    it('preserves a local concept when an older peer omits the additive field', () => {
+      const authored = buildTrackRecord({ title: 'Local', concept: 'A dusk-time pulse' }, { id: 'track-1', now: '2026-06-01T00:00:00.000Z' });
+      const remote = { ...authored, title: 'Remote', updatedAt: '2099-01-01T00:00:00.000Z' };
+      delete remote.concept;
+      expect(mergeTrackRecord(authored, remote).next.concept).toBe('A dusk-time pulse');
+    });
   });
 
   describe('render history', () => {


### PR DESCRIPTION
## Summary

- cover PATCH persistence for a track concept
- cover preservation of the local concept when an older peer omits the field
- prevent regressions across the API and sync merge paths

## Test plan

- npm exec -- vitest run routes/tracks.test.js services/tracks/logic.test.js (50 passed)