### PR TITLE
Draft: track music execution profiles and preserve MiniMax CUDA experiment

### DIFF
--- a/.changelog/next/changed-issue-4359.md
+++ b/.changelog/next/changed-issue-4359.md
@@ -1,0 +1,1 @@
+- record and display the effective execution profile used for Music Studio renders

--- a/client/src/components/music/MusicGenPanel.jsx
+++ b/client/src/components/music/MusicGenPanel.jsx
@@ -87,6 +87,12 @@ function supportsAutoDuration(engine) {
   return engine?.autoDuration === true;
 }
 
+function formatExecutionProfile(profile) {
+  if (profile === 'cuda-bf16-full') return 'CUDA BF16 (full GPU)';
+  if (profile === 'cuda-bf16-component-offload') return 'CUDA BF16 (component offload)';
+  return profile || '';
+}
+
 export default function MusicGenPanel({ track, title = '', artistId = '', artist = '', albumId = '', prompt, lyrics, onGenerated, remix }) {
   const [engines, setEngines] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -256,6 +262,10 @@ export default function MusicGenPanel({ track, title = '', artistId = '', artist
   const canGenerate = !!engine?.ready && selectedModelReady && !!prompt?.trim() && !isGenerating;
   const selectedModelSizeGb = engine?.modelSizeGbById?.[selectedModelId] ?? null;
   const setup = engineSetupState(engine, selectedModelReady, selectedModelSizeGb);
+  const activeRender = track?.renders?.find((render) => render.audioFilename === track.audioFilename);
+  const effectiveExecutionProfile = activeRender && activeRender.engine === engine?.id
+    ? activeRender.executionProfile
+    : null;
 
   // `target` is the engine record to install for — passed explicitly by the
   // post-runtime chain, which holds a fresher record than component state does.
@@ -437,6 +447,16 @@ export default function MusicGenPanel({ track, title = '', artistId = '', artist
           </select>
         </label>
       </div>
+
+      {effectiveExecutionProfile ? (
+        <p className="text-[11px] text-gray-400">
+          Active render profile: <span className="text-gray-300">{formatExecutionProfile(effectiveExecutionProfile)}</span>
+        </p>
+      ) : engine?.executionProfile ? (
+        <p className="text-[11px] text-gray-500">
+          Execution profile: {engine.vramProfileLabel || formatExecutionProfile(engine.executionProfile)}
+        </p>
+      ) : null}
 
       <div className={autoDurationAvailable ? 'grid grid-cols-2 gap-2' : undefined}>
         {autoDurationAvailable ? (

--- a/client/src/components/music/MusicGenPanel.test.jsx
+++ b/client/src/components/music/MusicGenPanel.test.jsx
@@ -204,6 +204,32 @@ describe('MusicGenPanel', () => {
     expect(screen.queryByRole('button', { name: /install/i })).not.toBeInTheDocument();
   });
 
+  it('shows the configured profile and the active render effective placement', async () => {
+    api.listMusicEngines.mockResolvedValue({
+      defaultEngine: 'minimax-music3',
+      engines: [minimax({
+        ready: true,
+        runtimeReady: true,
+        modelReady: true,
+        vramState: 'sufficient',
+        executionProfile: 'cuda-bf16-auto-experimental',
+        vramProfileLabel: 'CUDA BF16 (experimental automatic placement)',
+      })],
+    });
+    const track = {
+      id: 'track-1',
+      audioFilename: 'fake.wav',
+      renders: [{
+        id: 'render-1', audioFilename: 'fake.wav', engine: 'minimax-music3',
+        executionProfile: 'cuda-bf16-component-offload',
+      }],
+    };
+
+    render(<MusicGenPanel track={track} prompt="cinematic score" lyrics="Example lyrics" />);
+
+    expect(await screen.findByText(/Active render profile:/i)).toHaveTextContent('CUDA BF16 (component offload)');
+  });
+
   it('generates an unsaved standalone track without requiring a title or associations', async () => {
     api.listMusicEngines.mockResolvedValue({
       defaultEngine: 'musicgen',

--- a/scripts/_runner_common.py
+++ b/scripts/_runner_common.py
@@ -406,6 +406,53 @@ def _pipeline_weight_bytes(pipe) -> int:
     return total
 
 
+def choose_cuda_pipeline_placement(
+    pipe,
+    torch,
+    *,
+    override_env: str,
+    offload_vram_fraction=None,
+    log_label: str,
+) -> dict:
+    """Choose full CUDA residency or CPU offload from live VRAM state.
+
+    The model weights plus a fixed activation reserve must fit in *currently
+    free* VRAM. Callers may additionally provide a total-card fraction to avoid
+    Windows sysmem fallback for pipelines that leave too little proportional
+    headroom. ``override_env`` is deliberately caller-owned so one pipeline's
+    override cannot change another pipeline family.
+    """
+    override = os.environ.get(override_env, "").strip().lower()
+    if override in ("0", "false", "never"):
+        return {"use_offload": False, "reason": f"{override_env}=0"}
+    if override in ("1", "true", "force", "always"):
+        return {"use_offload": True, "reason": f"{override_env}=1"}
+
+    weight_bytes = _pipeline_weight_bytes(pipe)
+    free_bytes, total_bytes = torch.cuda.mem_get_info()
+    fits_now = (weight_bytes + _ACTIVATION_RESERVE_BYTES) <= free_bytes
+    fills_card = (
+        offload_vram_fraction is not None
+        and weight_bytes > offload_vram_fraction * total_bytes
+    )
+    use_offload = fills_card or not fits_now
+    reason = "fills card" if fills_card else ("low free VRAM" if not fits_now else "fits")
+    gb = 1024 ** 3
+    print(
+        f"🧮 {log_label} VRAM: weights ~{weight_bytes / gb:.1f}GB, "
+        f"free ~{free_bytes / gb:.1f}GB, total ~{total_bytes / gb:.1f}GB ({reason}) → "
+        f"{'CPU offload' if use_offload else 'full GPU residency'}",
+        file=sys.stderr, flush=True,
+    )
+    return {
+        "use_offload": use_offload,
+        "reason": reason,
+        "weight_bytes": weight_bytes,
+        "free_bytes": free_bytes,
+        "total_bytes": total_bytes,
+    }
+
+
 def place_pipeline(pipe, device: str) -> str:
     """Move a loaded diffusers pipeline onto the compute device, choosing
     between full-GPU residency and model CPU offload based on free VRAM.
@@ -433,26 +480,15 @@ def place_pipeline(pipe, device: str) -> str:
 
     import torch
 
-    override = os.environ.get("PORTOS_IMAGE_OFFLOAD", "").strip().lower()
     can_offload = hasattr(pipe, "enable_model_cpu_offload")
-    if override in ("0", "false", "never"):
-        force_offload = False
-    elif override in ("1", "true", "force", "always"):
-        force_offload = True
-    else:
-        weight_bytes = _pipeline_weight_bytes(pipe)
-        free_bytes, total_bytes = torch.cuda.mem_get_info()
-        fits_now = (weight_bytes + _ACTIVATION_RESERVE_BYTES) <= free_bytes
-        fills_card = weight_bytes > _OFFLOAD_VRAM_FRACTION * total_bytes
-        force_offload = fills_card or not fits_now
-        gb = 1024 ** 3
-        reason = "fills card" if fills_card else ("low free VRAM" if not fits_now else "fits")
-        print(
-            f"🧮 image-gen VRAM: weights ~{weight_bytes / gb:.1f}GB, "
-            f"free ~{free_bytes / gb:.1f}GB, total ~{total_bytes / gb:.1f}GB ({reason}) → "
-            f"{'model CPU offload' if force_offload else 'full GPU residency'}",
-            file=sys.stderr, flush=True,
-        )
+    placement = choose_cuda_pipeline_placement(
+        pipe,
+        torch,
+        override_env="PORTOS_IMAGE_OFFLOAD",
+        offload_vram_fraction=_OFFLOAD_VRAM_FRACTION,
+        log_label="image-gen",
+    )
+    force_offload = placement["use_offload"]
 
     if force_offload and can_offload:
         pipe.enable_model_cpu_offload()

--- a/scripts/_runner_common_test.py
+++ b/scripts/_runner_common_test.py
@@ -6,6 +6,7 @@ Run: ./data/python/venv/bin/python scripts/_runner_common_test.py
 Exits non-zero on first failure. Mirrors the runnable-test style of
 scripts/train_mflux_lora_test.py.
 """
+import os
 import sys
 from pathlib import Path
 
@@ -15,8 +16,10 @@ if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
+import _runner_common as runner_common  # noqa: E402
 from _runner_common import (  # noqa: E402
     apply_memory_optimizations,
+    choose_cuda_pipeline_placement,
     empty_device_cache,
     set_vae_tiling,
     _VAE_TILING_MIN_PIXELS,
@@ -156,6 +159,49 @@ check("set_vae_tiling(False) falls back to vae.disable_tiling", p.calls == ["vae
 p = _BareRecorder()
 set_vae_tiling(p, False)
 check("set_vae_tiling on bare pipe is a no-op (no crash)", p.calls == [])
+
+
+# --- shared live-VRAM placement decision ------------------------------------
+class _FakeCudaMemory:
+    def __init__(self, free_gb, total_gb):
+        self.free_gb = free_gb
+        self.total_gb = total_gb
+
+    def mem_get_info(self):
+        gb = 1024 ** 3
+        return self.free_gb * gb, self.total_gb * gb
+
+
+class _PlacementTorch:
+    def __init__(self, free_gb, total_gb):
+        self.cuda = _FakeCudaMemory(free_gb, total_gb)
+
+
+_original_weight_bytes = runner_common._pipeline_weight_bytes
+runner_common._pipeline_weight_bytes = lambda _pipe: 20 * 1024 ** 3
+try:
+    os.environ.pop("PORTOS_TEST_OFFLOAD", None)
+    _fits = choose_cuda_pipeline_placement(
+        object(), _PlacementTorch(24, 24), override_env="PORTOS_TEST_OFFLOAD",
+        offload_vram_fraction=None, log_label="test",
+    )
+    check("placement keeps full CUDA when weights plus reserve fit", not _fits["use_offload"])
+
+    _low_free = choose_cuda_pipeline_placement(
+        object(), _PlacementTorch(22, 24), override_env="PORTOS_TEST_OFFLOAD",
+        offload_vram_fraction=None, log_label="test",
+    )
+    check("placement offloads when live free VRAM lacks the reserve", _low_free["use_offload"])
+
+    os.environ["PORTOS_TEST_OFFLOAD"] = "0"
+    _forced_full = choose_cuda_pipeline_placement(
+        object(), _PlacementTorch(8, 24), override_env="PORTOS_TEST_OFFLOAD",
+        offload_vram_fraction=None, log_label="test",
+    )
+    check("pipeline-specific override can force full CUDA", not _forced_full["use_offload"])
+finally:
+    os.environ.pop("PORTOS_TEST_OFFLOAD", None)
+    runner_common._pipeline_weight_bytes = _original_weight_bytes
 
 
 # --- empty_device_cache: dispatches on the RESOLVED device, not on capability -

--- a/scripts/generate_minimax_music3.py
+++ b/scripts/generate_minimax_music3.py
@@ -5,7 +5,66 @@ import inspect
 import json
 import os
 import sys
+import time
 import wave
+
+from _runner_common import choose_cuda_pipeline_placement
+
+
+FULL_CUDA_PROFILE = 'cuda-bf16-full'
+OFFLOAD_CUDA_PROFILE = 'cuda-bf16-component-offload'
+AUTOREGRESSIVE_COMPONENTS = frozenset({'language_model', 'rvq_depth_decoder'})
+
+
+def managed_component_name(model_id):
+    """Remove ComponentsManager's runtime object-id suffix from a hook id."""
+    name, separator, suffix = model_id.rpartition('_')
+    return name if separator and suffix.isdigit() else model_id
+
+
+def minimax_offload_strategy(hooks, model_id, model, execution_device):
+    """Keep MiniMax's mandatory autoregressive pair resident together.
+
+    Diffusers invokes the language model and RVQ decoder together for every
+    generated frame. Its generic size-based strategy can evict the first while
+    loading the second. For those two incoming components, evict only unrelated
+    phases; for every other phase, evict all resident managed components.
+    """
+    del model, execution_device
+    if managed_component_name(model_id) in AUTOREGRESSIVE_COMPONENTS:
+        return [
+            hook for hook in hooks
+            if managed_component_name(hook.model_id) not in AUTOREGRESSIVE_COMPONENTS
+        ]
+    return hooks
+
+
+def place_minimax_pipeline(pipe, components_manager, torch):
+    """Apply MiniMax's experimental CUDA placement and return its effective profile."""
+    placement = choose_cuda_pipeline_placement(
+        pipe,
+        torch,
+        override_env='PORTOS_MINIMAX_MUSIC3_OFFLOAD',
+        # MiniMax keeps full CUDA residency whenever weights plus the shared
+        # activation reserve fit. Unlike image pipelines, there is no separate
+        # proportional trigger while this profile remains experimental.
+        offload_vram_fraction=None,
+        log_label='minimax-music3',
+    )
+    if placement['use_offload']:
+        enable_offload = getattr(components_manager, 'enable_auto_cpu_offload', None)
+        if not callable(enable_offload):
+            raise RuntimeError(
+                'MiniMax Music 3 selected component offload, but this Diffusers runtime '
+                'does not expose ComponentsManager.enable_auto_cpu_offload()'
+            )
+        # The ComponentsManager API documents workflow-specific strategy
+        # callables for component sets whose co-residency requirements cannot
+        # be inferred from individual weight footprints.
+        enable_offload(device='cuda', offload_strategy=minimax_offload_strategy)
+        return OFFLOAD_CUDA_PROFILE
+    pipe.to('cuda')
+    return FULL_CUDA_PROFILE
 
 
 def to_numpy(audio, np, torch):
@@ -47,6 +106,7 @@ def seeded_generation_kwargs(pipe, torch, seed):
 
 
 def main():
+    started_at = time.perf_counter()
     parser = argparse.ArgumentParser()
     parser.add_argument('--model', required=True)
     parser.add_argument('--text', required=True)
@@ -65,14 +125,17 @@ def main():
     import numpy as np
     import torch
     from diffusers import ModularPipeline
+    from diffusers.modular_pipelines import ComponentsManager
 
     if not torch.cuda.is_available():
         raise RuntimeError('MiniMax Music 3 requires CUDA')
     print('STAGE:load-model', file=sys.stderr, flush=True)
-    pipe = ModularPipeline.from_pretrained(args.model)
+    components_manager = ComponentsManager()
+    pipe = ModularPipeline.from_pretrained(args.model, components_manager=components_manager)
     pipe.load_components(dtype=torch.bfloat16)
-    pipe.to('cuda')
+    execution_profile = place_minimax_pipeline(pipe, components_manager, torch)
     print('STAGE:generate', file=sys.stderr, flush=True)
+    torch.cuda.reset_peak_memory_stats()
     generation_kwargs = seeded_generation_kwargs(pipe, torch, args.seed)
     if args.seed is not None and not generation_kwargs:
         raise RuntimeError('this Diffusers pipeline does not support deterministic --seed generation')
@@ -84,6 +147,9 @@ def main():
         **generation_kwargs,
     )[0], np, torch)
     audio = to_stereo(audio, np)
+    torch.cuda.synchronize()
+    peak_vram_allocated_gb = torch.cuda.max_memory_allocated() / (1024 ** 3)
+    peak_vram_reserved_gb = torch.cuda.max_memory_reserved() / (1024 ** 3)
     source_rate = int(pipe.sampling_rate)
     if source_rate != 32000:
         source_x = np.arange(audio.shape[1], dtype=np.float64)
@@ -96,6 +162,12 @@ def main():
         wav.setnchannels(2); wav.setsampwidth(2); wav.setframerate(32000); wav.writeframes(pcm.tobytes())
     print('RESULT:' + json.dumps({
         'durationSec': len(pcm) / 32000,
+        'executionProfile': execution_profile,
+        # Reserved is the conservative device-memory bound; allocated remains
+        # useful for distinguishing model/activation use from allocator cache.
+        'peakVramGb': round(peak_vram_reserved_gb, 3),
+        'peakVramAllocatedGb': round(peak_vram_allocated_gb, 3),
+        'totalTimeSec': round(time.perf_counter() - started_at, 3),
         **({'seed': args.seed, 'seedApplied': True} if args.seed is not None else {}),
     }), flush=True)
 

--- a/scripts/generate_minimax_music3.test.js
+++ b/scripts/generate_minimax_music3.test.js
@@ -27,6 +27,8 @@ const hasNumpy = (() => {
 
 const PRELUDE = [
   'import importlib.util, json, sys',
+  'from pathlib import Path',
+  'sys.path.insert(0, str(Path(sys.argv[1]).parent))',
   'import numpy as np',
   'spec = importlib.util.spec_from_file_location("mm3", sys.argv[1])',
   'mod = importlib.util.module_from_spec(spec)',
@@ -48,6 +50,8 @@ const runPython = (body) => execFileSync(pyBin, ['-c', `${PRELUDE}\n${body}`, sc
 }).trim();
 const runPythonWithoutNumpy = (body) => execFileSync(pyBin, ['-c', [
   'import importlib.util, json, sys',
+  'from pathlib import Path',
+  'sys.path.insert(0, str(Path(sys.argv[1]).parent))',
   'spec = importlib.util.spec_from_file_location("mm3", sys.argv[1])',
   'mod = importlib.util.module_from_spec(spec)',
   'spec.loader.exec_module(mod)',
@@ -146,5 +150,59 @@ describe.skipIf(!pyBin)('generate_minimax_music3 deterministic benchmark hook', 
       'print(json.dumps(mod.seeded_generation_kwargs(Unsupported(), object(), 17)))',
     ].join('\n'));
     expect(JSON.parse(out)).toEqual({});
+  });
+});
+
+describe.skipIf(!pyBin)('generate_minimax_music3 CUDA placement', () => {
+  it('uses the ComponentsManager auto-offload hook and reports the effective profile', () => {
+    const out = runPythonWithoutNumpy([
+      'mod.choose_cuda_pipeline_placement = lambda *args, **kwargs: {"use_offload": True}',
+      'class Pipe:',
+      '    def to(self, device): raise AssertionError("full placement must not run")',
+      'class Manager:',
+      '    def enable_auto_cpu_offload(self, **kwargs): self.kwargs = kwargs',
+      'manager = Manager()',
+      'profile = mod.place_minimax_pipeline(Pipe(), manager, object())',
+      'print(json.dumps({"profile": profile, "device": manager.kwargs["device"], "strategy": manager.kwargs["offload_strategy"].__name__}))',
+    ].join('\n'));
+    expect(JSON.parse(out)).toEqual({
+      profile: 'cuda-bf16-component-offload',
+      device: 'cuda',
+      strategy: 'minimax_offload_strategy',
+    });
+  });
+
+  it('keeps full CUDA residency when the measured reserve fits', () => {
+    const out = runPythonWithoutNumpy([
+      'mod.choose_cuda_pipeline_placement = lambda *args, **kwargs: {"use_offload": False}',
+      'class Pipe:',
+      '    def to(self, device): self.device = device',
+      'pipe = Pipe()',
+      'profile = mod.place_minimax_pipeline(pipe, object(), object())',
+      'print(json.dumps({"profile": profile, "device": pipe.device}))',
+    ].join('\n'));
+    expect(JSON.parse(out)).toEqual({ profile: 'cuda-bf16-full', device: 'cuda' });
+  });
+
+  it('fails instead of pretending to offload when the runtime hook is unavailable', () => {
+    expect(() => runPythonWithoutNumpy([
+      'mod.choose_cuda_pipeline_placement = lambda *args, **kwargs: {"use_offload": True}',
+      'mod.place_minimax_pipeline(object(), object(), object())',
+    ].join('\n'))).toThrow();
+  });
+
+  it('preserves the autoregressive pair while evicting unrelated phases', () => {
+    const out = runPythonWithoutNumpy([
+      'class Hook:',
+      '    def __init__(self, model_id): self.model_id = model_id',
+      'hooks = [Hook("condition_encoder_101"), Hook("language_model_102"), Hook("rvq_depth_decoder_103")]',
+      'pair = [h.model_id for h in mod.minimax_offload_strategy(hooks, "rvq_depth_decoder_103", None, None)]',
+      'other = [h.model_id for h in mod.minimax_offload_strategy(hooks, "transformer", None, None)]',
+      'print(json.dumps({"pair": pair, "other": other}))',
+    ].join('\n'));
+    expect(JSON.parse(out)).toEqual({
+      pair: ['condition_encoder_101'],
+      other: ['condition_encoder_101', 'language_model_102', 'rvq_depth_decoder_103'],
+    });
   });
 });

--- a/server/lib/schemaVersions.js
+++ b/server/lib/schemaVersions.js
@@ -252,7 +252,9 @@ export const PORTOS_SCHEMA_VERSIONS = Object.freeze({
   // tracks v5 = render-history entries gained `authoredPrompt` and the explicit
   // nullable `instrumentalOnly` decision. A <=v4 peer would strip both, then LWW
   // the ambiguous render back and make a later remix silently change vocal mode.
-  tracks: 5,
+  // tracks v6 = render history entries preserve the effective generation
+  // executionProfile. Older peers would strip the measured placement on sync.
+  tracks: 6,
   // v1 = creative ingredients catalog (Postgres tables: catalog_scraps,
   // catalog_ingredients, catalog_ingredient_sources, catalog_ingredient_refs).
   // v2 = `catalog_ingredients.search_tsv` expanded to also index the

--- a/server/routes/music.test.js
+++ b/server/routes/music.test.js
@@ -23,7 +23,7 @@ vi.mock('../services/pipeline/musicGen.js', () => {
     musicgen: { id: 'musicgen', name: 'MusicGen', models: [{ id: 'm', name: 'M' }], defaultModelId: 'm', minDurationSec: 1, maxDurationSec: 30, defaultDurationSec: 12, installEnv: 'INSTALL_MUSICGEN', venvDefault: '/v/mg', resolvePython: () => (gen.ready ? '/v/mg/bin/python3' : null), customModels: true },
     acestep: { id: 'acestep', name: 'ACE-Step', models: [{ id: 'a', name: 'A' }], defaultModelId: 'a', minDurationSec: 1, maxDurationSec: 240, defaultDurationSec: 60, installEnv: 'INSTALL_ACESTEP', venvDefault: '/v/ace', resolvePython: () => (gen.ready ? '/v/ace/bin/python3' : null), lyrics: true, customModels: false },
     acestep15: { id: 'acestep15', name: 'ACE-Step 1.5', models: [{ id: 'ace-step-v1.5', repo: 'ACE-Step/Ace-Step1.5', name: 'ACE-Step 1.5' }], defaultModelId: 'ace-step-v1.5', minDurationSec: 1, maxDurationSec: 240, defaultDurationSec: 60, installEnv: 'INSTALL_ACESTEP15', venvDefault: '/v/ace15', resolvePython: () => (gen.ready ? '/v/ace15/bin/python3' : null), lyrics: true, customModels: false, fixedModelInstall: true },
-    'minimax-music3': { id: 'minimax-music3', name: 'MiniMax Music 3', models: [{ id: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', name: 'MiniMax Music 3', downloadIgnore: ['qwen_7B/*', 'flowmatching_vae.pth', 'dav.pth', 'figures/*'], downloadSizeGb: 29 }], defaultModelId: 'minimax-music3', minDurationSec: 1, maxDurationSec: 300, defaultDurationSec: 60, installEnv: 'INSTALL_MINIMAX_MUSIC3', venvDefault: '/v/minimax', resolvePython: () => (gen.ready ? '/v/minimax/bin/python3' : null), lyrics: true, customModels: false, fixedModelInstall: true, cudaRequired: true, autoDuration: true, executionProfile: 'cuda-bf16-single-gpu', vramProfiles: { 'cuda-bf16-single-gpu': { label: 'CUDA BF16 (single GPU)', minVramGb: null, recommendedVramGb: null } } },
+    'minimax-music3': { id: 'minimax-music3', name: 'MiniMax Music 3', models: [{ id: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', name: 'MiniMax Music 3', downloadIgnore: ['qwen_7B/*', 'flowmatching_vae.pth', 'dav.pth', 'figures/*'], downloadSizeGb: 29 }], defaultModelId: 'minimax-music3', minDurationSec: 1, maxDurationSec: 300, defaultDurationSec: 60, installEnv: 'INSTALL_MINIMAX_MUSIC3', venvDefault: '/v/minimax', resolvePython: () => (gen.ready ? '/v/minimax/bin/python3' : null), lyrics: true, customModels: false, fixedModelInstall: true, cudaRequired: true, autoDuration: true, executionProfile: 'cuda-bf16-auto-experimental', vramProfiles: { 'cuda-bf16-auto-experimental': { label: 'CUDA BF16 (experimental automatic placement)', minVramGb: null, recommendedVramGb: null } } },
     'minimax-music3-mlx': { id: 'minimax-music3-mlx', name: 'MiniMax Music 3 (MLX)', models: [
       { id: 'minimax-music3-mlx-8bit', repo: 'mlx-community/MiniMax-Music3-8bit', revision: '10aa4ca578d04c6f5256c1bc22fc8405a09602b5', downloadSizeGb: 14, name: 'MiniMax Music 3 MLX 8-bit' },
       { id: 'minimax-music3-mlx-bf16', repo: 'mlx-community/MiniMax-Music3-bf16', revision: '83a5f2d365673689df5c8f36e21e108751fd92ea', downloadSizeGb: 29, name: 'MiniMax Music 3 MLX BF16' },
@@ -328,12 +328,12 @@ describe('music routes', () => {
     expect(r.body.engines.find((e) => e.id === 'acestep').ready).toBe(false);
   });
 
-  it('GET /engines uses the CUDA capability status to expose installable MiniMax readiness', async () => {
+  it('GET /engines keeps the experimental CUDA profile blocked pending a full measurement', async () => {
     cache.cached = false;
     const supported = await request(app).get('/api/music/engines');
     expect(supported.body.engines.find((e) => e.id === 'minimax-music3')).toMatchObject({
       cudaState: 'available', vramState: 'unknown-size', fixedModelInstall: true, modelReady: false, runtimeReady: true, ready: false,
-      executionProfile: 'cuda-bf16-single-gpu', minVramGb: null, recommendedVramGb: null, maxVramGb: 40,
+      executionProfile: 'cuda-bf16-auto-experimental', minVramGb: null, recommendedVramGb: null, maxVramGb: 40,
       // The UI puts this on the install button so the user knows the size of the
       // pull before starting it.
       modelSizeGb: 29,
@@ -346,7 +346,7 @@ describe('music routes', () => {
     });
   });
 
-  it('refuses MiniMax runtime installation when profile VRAM is unknown', async () => {
+  it('refuses MiniMax runtime installation while profile VRAM is unknown', async () => {
     const r = await request(app).get('/api/music/setup/runtime-install?runtime=minimax-music3');
     expect(r.status).toBe(200);
     expect(r.text).toContain('VRAM requirement has not been measured');

--- a/server/services/musicStudioHook.js
+++ b/server/services/musicStudioHook.js
@@ -29,6 +29,7 @@ const hook = createMediaJobImageHook({
       durationSec: Number.isFinite(job.result?.durationSec) ? Math.round(job.result.durationSec) : null,
       engine: typeof job.result?.engine === 'string' ? job.result.engine : null,
       modelId: typeof job.result?.modelId === 'string' ? job.result.modelId : null,
+      executionProfile: typeof job.result?.executionProfile === 'string' ? job.result.executionProfile : null,
       prompt: remotePrompt || job.params.prompt,
       authoredPrompt,
       lyrics: remotePrompt ? '' : job.params.lyrics,
@@ -42,7 +43,7 @@ const hook = createMediaJobImageHook({
       albumId: tag.albumId,
     };
   },
-  attach: async ({ job, trackId, filename, durationSec, engine, modelId, prompt, authoredPrompt, lyrics, authoredLyrics, lyricsEnabled, lyricsProvided, instrumentalOnly, title, artistId, artist, albumId }) => {
+  attach: async ({ job, trackId, filename, durationSec, engine, modelId, executionProfile, prompt, authoredPrompt, lyrics, authoredLyrics, lyricsEnabled, lyricsProvided, instrumentalOnly, title, artistId, artist, albumId }) => {
     const current = trackId ? await tracks.getTrack(trackId) : null;
     // A deleted target is a successful render but no longer an attach target.
     if (trackId && !current) return null;
@@ -54,6 +55,7 @@ const hook = createMediaJobImageHook({
       instrumentalOnly,
       engine,
       modelId,
+      executionProfile,
       durationSec,
     });
     const meta = {

--- a/server/services/musicStudioHook.test.js
+++ b/server/services/musicStudioHook.test.js
@@ -37,10 +37,13 @@ describe('music studio completion hook', () => {
     queue.events.emit('completed', {
       id: 'job-1', kind: 'audio', queuedAt: new Date().toISOString(),
       params: { prompt: 'fake prompt', lyrics: '[verse] fake', musicStudio: { trackId: 'track-1', lyricsEnabled: true, lyricsProvided: true } },
-      result: { filename: 'fake.wav', durationSec: 12, engine: 'acestep', modelId: 'a' },
+      result: { filename: 'fake.wav', durationSec: 12, engine: 'acestep', modelId: 'a', executionProfile: 'cuda-bf16-component-offload' },
     });
     await new Promise((resolve) => setImmediate(resolve));
     expect(trackStore.updateTrack).toHaveBeenCalledWith('track-1', expect.objectContaining({ audioFilename: 'fake.wav', lyrics: '[verse] fake' }));
+    expect(trackStore.buildRenderAppend).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      executionProfile: 'cuda-bf16-component-offload',
+    }));
     expect(queue.updateJobResult).toHaveBeenCalledWith('job-1', { trackId: 'track-1' });
   });
 

--- a/server/services/pipeline/musicGen.js
+++ b/server/services/pipeline/musicGen.js
@@ -138,18 +138,17 @@ export const MINIMAX_MUSIC3_MODELS = Object.freeze([
 ]);
 
 // VRAM requirements belong to the execution profile, not the model name. The
-// current CUDA sidecar has no reproducible PortOS memory benchmark yet, so its
-// contract deliberately carries null floors and remains unknown-size until the
-// measured profile is recorded. A missing measurement must not be interpreted
-// as zero VRAM or as permission to start a run that will fail during loading.
+// experimental automatic profile has passed only a short smoke render; the
+// full-length benchmark and listening gate remain incomplete. Null floors keep
+// app-driven CUDA generation blocked until that evidence exists.
 export const MUSIC_VRAM_READINESS = Object.freeze({
   SUFFICIENT: 'sufficient',
   INSUFFICIENT: 'insufficient',
   UNKNOWN_SIZE: 'unknown-size',
 });
 export const MINIMAX_MUSIC3_VRAM_PROFILES = Object.freeze({
-  'cuda-bf16-single-gpu': Object.freeze({
-    label: 'CUDA BF16 (single GPU)',
+  'cuda-bf16-auto-experimental': Object.freeze({
+    label: 'CUDA BF16 (experimental automatic placement)',
     minVramGb: null,
     recommendedVramGb: null,
   }),
@@ -321,7 +320,7 @@ export const ENGINES = Object.freeze({
     customModels: false,
     fixedModelInstall: true,
     cudaRequired: true,
-    executionProfile: 'cuda-bf16-single-gpu',
+    executionProfile: 'cuda-bf16-auto-experimental',
     vramProfiles: MINIMAX_MUSIC3_VRAM_PROFILES,
     benchmarkGuide: MUSIC_RENDERER_BENCHMARK_GUIDE,
     requiresFullLengthListening: true,
@@ -716,6 +715,9 @@ export async function generateMusic({ prompt, lyrics, engine: engineId = DEFAULT
   // attaches a dangling/empty track.
   const parsed = result.ok ? parseSidecarResult(result.stdout) : null;
   const wroteFile = existsSync(outputPath) && statSync(outputPath).size > 0;
+  const executionProfile = typeof parsed?.executionProfile === 'string'
+    ? parsed.executionProfile
+    : null;
   if (!result.ok || !parsed || !wroteFile) {
     await unlink(outputPath).catch(() => {});
     const reason = !result.ok ? result.reason : (!wroteFile ? 'sidecar wrote no audio' : 'sidecar returned no result');
@@ -729,6 +731,7 @@ export async function generateMusic({ prompt, lyrics, engine: engineId = DEFAULT
     modelId: model.id,
     model: model.name,
     engine: engine.id,
+    ...(executionProfile ? { executionProfile } : {}),
     ...(provenance ? { provenance } : {}),
   };
 }

--- a/server/services/pipeline/musicGen.test.js
+++ b/server/services/pipeline/musicGen.test.js
@@ -140,9 +140,9 @@ describe('ENGINES backend registry', () => {
 
   it('declares MiniMax VRAM requirements per execution profile', () => {
     const engine = ENGINES['minimax-music3'];
-    expect(engine.executionProfile).toBe('cuda-bf16-single-gpu');
+    expect(engine.executionProfile).toBe('cuda-bf16-auto-experimental');
     expect(engine.vramProfiles[engine.executionProfile]).toMatchObject({
-      label: 'CUDA BF16 (single GPU)',
+      label: 'CUDA BF16 (experimental automatic placement)',
       minVramGb: null,
       recommendedVramGb: null,
     });
@@ -169,11 +169,12 @@ describe('VRAM readiness', () => {
       .toBe(MUSIC_VRAM_READINESS.UNKNOWN_SIZE);
   });
 
-  it('keeps an unmeasured CUDA execution profile unknown-size', () => {
+  it('keeps the experimental CUDA execution profile unknown-size', () => {
     expect(resolveEngineVramReadiness('minimax-music3', {
       status: 'available', maxVramGb: 80,
     })).toMatchObject({
       state: MUSIC_VRAM_READINESS.UNKNOWN_SIZE,
+      executionProfile: 'cuda-bf16-auto-experimental',
       minVramGb: null,
       recommendedVramGb: null,
       maxVramGb: 80,
@@ -512,12 +513,18 @@ describe('generateMusic backend selection', () => {
     expect(res.filename).toMatch(/^music-gen-.*\.wav$/);
   });
 
-  it('blocks MiniMax when its CUDA profile has no measured VRAM floor', async () => {
+  it('returns an optional effective execution profile reported by a sidecar', async () => {
+    h.mockStdout = 'STAGE:done\nRESULT:{"durationSec":12.5,"executionProfile":"cuda-bf16-component-offload"}\n';
+    const result = await generateMusic({ prompt: 'warm cinematic pop' });
+    expect(result.executionProfile).toBe('cuda-bf16-component-offload');
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it('blocks MiniMax while its experimental CUDA profile has no measured VRAM floor', async () => {
     await expect(generateMusic({
       prompt: 'warm cinematic pop',
-      lyrics: `[verse]\n${'word '.repeat(150)}\n[outro]`,
+      lyrics: '[verse]\nExample words\n[outro]',
       engine: 'minimax-music3',
-      durationMode: 'auto',
     })).rejects.toMatchObject({
       status: 503,
       code: 'PIPELINE_MUSIC_VRAM_UNKNOWN',

--- a/server/services/tracks/logic.js
+++ b/server/services/tracks/logic.js
@@ -26,7 +26,7 @@
  *                     the studio can show each render as a card and re-select an
  *                     earlier one. Each entry is `{ id, audioFilename, prompt,
  *                     authoredPrompt, lyrics, instrumentalOnly, engine,
- *                     modelId, durationSec, createdAt }`. The
+ *                     modelId, executionProfile, durationSec, createdAt }`. The
  *                     top-level `audioFilename`/`engine`/`modelId`/`durationSec`
  *                     point at whichever render is currently ACTIVE (selected).
  *
@@ -52,6 +52,7 @@ export const LYRICS_MAX = 20000;
 export const PROMPT_MAX = 8000;
 export const ENGINE_MAX = 60;
 export const MODEL_ID_MAX = 120;
+export const EXECUTION_PROFILE_MAX = 80;
 export const AUDIO_FILENAME_MAX = 256;
 export const RENDER_ID_MAX = 80;
 // Cap the render history per track so a runaway generate loop can't grow the
@@ -107,6 +108,7 @@ export function sanitizeRender(raw) {
     instrumentalOnly: typeof raw.instrumentalOnly === 'boolean' ? raw.instrumentalOnly : null,
     engine: trimTo(raw.engine, ENGINE_MAX),
     modelId: trimTo(raw.modelId, MODEL_ID_MAX),
+    executionProfile: trimTo(raw.executionProfile, EXECUTION_PROFILE_MAX),
     durationSec: sanitizeDuration(raw.durationSec),
     createdAt: isStr(raw.createdAt) && raw.createdAt ? raw.createdAt : new Date().toISOString(),
   };
@@ -163,6 +165,7 @@ export function sanitizeTrack(raw) {
       instrumentalOnly: null,
       engine,
       modelId,
+      executionProfile: '',
       durationSec,
       createdAt,
     }];

--- a/server/services/tracks/logic.test.js
+++ b/server/services/tracks/logic.test.js
@@ -127,10 +127,12 @@ describe('tracks logic', () => {
     it('makeRender stamps the caller-supplied id + now', () => {
       const r = makeRender({
         audioFilename: 'a.wav', engine: 'musicgen', authoredPrompt: 'source prompt', instrumentalOnly: true,
+        executionProfile: 'cuda-bf16-component-offload',
       }, { id: 'render-7', now: '2026-03-03T00:00:00.000Z' });
       expect(r).toMatchObject({
         id: 'render-7', audioFilename: 'a.wav', engine: 'musicgen', authoredPrompt: 'source prompt',
-        instrumentalOnly: true, createdAt: '2026-03-03T00:00:00.000Z',
+        instrumentalOnly: true, executionProfile: 'cuda-bf16-component-offload',
+        createdAt: '2026-03-03T00:00:00.000Z',
       });
     });
 


### PR DESCRIPTION
## Summary

- propagate an optional effective execution profile from music sidecars through job results and Music Studio render history
- display the configured profile and the active render's effective profile in `MusicGenPanel`
- preserve the experimental MiniMax Music 3 CUDA placement logic, telemetry, and focused tests without declaring a supported VRAM floor

## Status and deployment direction

This is intentionally a draft. CUDA is deprioritized and remains experimental: the app registry keeps the profile at `unknown-size`, so app-driven CUDA generation stays blocked. A fixed-seed 5-second smoke render completed with component offload, but a 60-second render did not reach diffusion or write a WAV within the 4.5-hour practical cutoff. The full-length technical and listening gates from #4359 therefore remain unmet.

MiniMax Music 3 is now working through MLX on macOS federated instances. That is the primary deployment path; this draft preserves the reusable telemetry/UI work and the CUDA investigation for possible later follow-up.

## Validation

- standalone Python runner checks: 28 passed
- MiniMax sidecar tests: 16 passed
- focused server tests: 149 passed
- `MusicGenPanel` tests: 22 passed

Related to #4359. This draft deliberately does not close the issue.
