### PR TITLE
fix: make music video controls mobile responsive

### DIFF
--- a/client/src/components/imageGen/RecordRenderPinRow.jsx
+++ b/client/src/components/imageGen/RecordRenderPinRow.jsx
@@ -33,13 +33,13 @@ export default function RecordRenderPinRow({
     onChange({ imageMode: pinnedMode || null, imageModelId: v.trim() || null });
   });
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-[auto_auto_1fr] gap-2 sm:items-center">
+    <div className="grid min-w-0 w-full grid-cols-1 gap-2 sm:w-auto sm:grid-cols-[auto_auto_1fr] sm:items-center">
       <label htmlFor={`${idPrefix}-mode`} className="text-xs font-medium text-gray-400">{label}</label>
       <select
         id={`${idPrefix}-mode`}
         value={pinnedMode}
         onChange={(e) => onChange({ imageMode: e.target.value || null, imageModelId: null })}
-        className="bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-44"
+        className="w-full max-w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-44"
       >
         {showAuto ? <option value="">{autoLabel}</option> : (!pinnedMode && <option value="" disabled>Pick a backend</option>)}
         {optionList.map((o) => <option key={o.id} value={o.id}>{o.label || o.id}</option>)}
@@ -53,7 +53,7 @@ export default function RecordRenderPinRow({
           onBlur={modelDraft.onBlur}
           placeholder="Model (optional)"
           aria-label={`${label} model`}
-          className="bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-52"
+          className="w-full max-w-full bg-port-bg border border-port-border rounded-lg px-2 py-2 text-sm text-white focus:outline-none focus:border-port-accent sm:w-52"
         />
       ) : <span className="hidden sm:block" />}
     </div>

--- a/client/src/components/musicVideo/ProjectToolbar.jsx
+++ b/client/src/components/musicVideo/ProjectToolbar.jsx
@@ -31,9 +31,9 @@ export default function ProjectToolbar({
   const noAudio = !project.trackId && !project.uploadedAudioFilename;
   const nextVersion = (project.version || 1) + 1;
   return (
-    <div className="flex items-start justify-between gap-2 flex-wrap">
-      <h2 className="text-lg font-semibold shrink-0">{project.name}</h2>
-      <div className="min-w-0 flex flex-1 flex-wrap items-center justify-end gap-2">
+    <div className="flex min-w-0 flex-wrap items-start gap-2">
+      <h2 className="w-full text-lg font-semibold sm:w-auto sm:shrink-0">{project.name}</h2>
+      <div className="flex min-w-0 w-full flex-1 flex-wrap items-center justify-start gap-2 sm:w-auto sm:justify-end">
         <button onClick={onAnalyze} disabled={busy.analyzing || noAudio}
           title={noAudio ? 'Link a track first' : 'Analyze beat grid'}
           className="flex items-center gap-1 bg-port-bg border border-port-border rounded px-2 py-1.5 text-sm min-h-[44px] sm:min-h-0 disabled:opacity-50">

--- a/client/src/components/musicVideo/VideoRenderSettings.jsx
+++ b/client/src/components/musicVideo/VideoRenderSettings.jsx
@@ -21,7 +21,7 @@ export default function VideoRenderSettings({ videoSettings, generating }) {
         onChange={(e) => change({ backend: e.target.value || null })}
         disabled={locked}
         title="Saved renderer for this project's scene videos"
-        className="bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50"
+        className="w-full max-w-full bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50 sm:w-auto"
       >
         <option value="">Install default</option>
         <option value="local">Local video</option>
@@ -49,7 +49,7 @@ export default function VideoRenderSettings({ videoSettings, generating }) {
             }}
             disabled={locked}
             title="Prompt motion uses the reference frame; audio reactive also conditions motion on this scene's song segment"
-            className="bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50"
+            className="w-full max-w-full bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50 sm:w-auto"
           >
             <option value="image">Prompt motion</option>
             <option value="audioReactive" disabled={!detectedAudioReactiveLora}>Audio reactive</option>
@@ -61,7 +61,7 @@ export default function VideoRenderSettings({ videoSettings, generating }) {
             onChange={(e) => change({ modelId: e.target.value })}
             disabled={locked || models.length === 0}
             title="Saved local image-to-video model for this project"
-            className="max-w-[240px] bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50"
+            className="w-full max-w-full bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50 sm:w-auto sm:max-w-[240px]"
           >
             <option value="">
               {defaultModel
@@ -81,7 +81,7 @@ export default function VideoRenderSettings({ videoSettings, generating }) {
                 onChange={(e) => change({ audioReactiveLora: e.target.value })}
                 disabled={locked || audioReactiveLoras.length === 0}
                 title="Saved audio-reactive LoRA version for this project"
-                className="max-w-[220px] bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50"
+                className="w-full max-w-full bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50 sm:w-auto sm:max-w-[220px]"
               >
                 {audioReactiveLoras.length === 0 && <option value="">No audio-reactive LoRA installed</option>}
                 {audioReactiveLoras.map((lora) => (
@@ -97,7 +97,7 @@ export default function VideoRenderSettings({ videoSettings, generating }) {
                 onChange={(e) => change({ audioReactiveScale: Number(e.target.value) })}
                 disabled={locked}
                 title="How strongly the song drives visible motion"
-                className="bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50"
+                className="w-full max-w-full bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50 sm:w-auto"
               >
                 <option value={1}>Reactive 1.0×</option>
                 <option value={1.2}>Reactive 1.2×</option>
@@ -128,7 +128,7 @@ export default function VideoRenderSettings({ videoSettings, generating }) {
             onChange={(e) => change({ grokDuration: Number(e.target.value) })}
             disabled={locked}
             title="Native duration for each Grok scene clip"
-            className="bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50"
+            className="w-full max-w-full bg-port-bg border border-port-border rounded px-1.5 py-1.5 text-sm disabled:opacity-50 sm:w-auto"
           >
             {GROK_VIDEO_DURATIONS.map((duration) => (
               <option key={duration} value={duration}>{duration}s clips</option>


### PR DESCRIPTION
## Summary
- Keep the music video project toolbar within the viewport on narrow screens.
- Stack long renderer and model controls on mobile while preserving compact desktop sizing.
- Allow the shared render-pin control to shrink without changing its desktop layout.

## Test plan
- Scoped MusicVideo page tests: 41 passed (validated with the repository client dependencies).
- Client production build: passed (validated with the repository client dependencies).
- : passed.