### PR TITLE
fix: suppress memory-panel nag for disabled local LLM backends

### DIFF
--- a/client/src/components/settings/MemoryManagement.jsx
+++ b/client/src/components/settings/MemoryManagement.jsx
@@ -46,6 +46,7 @@ const EMPTY_SNAPSHOT = {
   whisperRunning: false,
   sttEngine: 'whisper',
   unavailableSources: [],
+  disabledSources: [],
 };
 
 const SOURCE_LABELS = {
@@ -80,6 +81,10 @@ export default function MemoryManagement({ onLoadedModelsChange } = {}) {
   const [loading, setLoading] = useState(true);
   const [lastFetched, setLastFetched] = useState(0);
   const [unavailableSources, setUnavailableSources] = useState([]);
+   // Backends the user marked intentionally disabled stay in unavailableSources
+   // (so "Free everything" still skips their unknown residency) but are excluded
+   // from the "Status unavailable" banner — the nag the user opted out of.
+  const [disabledSources, setDisabledSources] = useState([]);
   // Guards the polled setState calls — a late /voice/status response that
   // resolves after unmount would otherwise call setState on a dead tree.
   // useMounted resets the ref to true on every mount so React 18 StrictMode's
@@ -123,6 +128,10 @@ export default function MemoryManagement({ onLoadedModelsChange } = {}) {
     const ttsValid = typeof tts?.kokoro?.state === 'string';
     const voiceValid = voice != null && typeof voice === 'object';
     const llmSourceErrors = llmValid && Array.isArray(llm.sourceErrors) ? llm.sourceErrors : [];
+      // Distinguish "field absent" from "present-but-empty" so a later failed poll
+       // keeps the last-known disabled backends (the outage is the very scenario
+       // the banner suppression exists for) while an explicit [] clears them.
+    const llmDisabledSources = Array.isArray(llm?.disabled) ? llm.disabled : previous.disabledSources;
     const failedSources = [
       ...(!llmValid ? ['ollama', 'lmstudio'] : llmSourceErrors),
       ...(!ttsValid ? ['tts'] : []),
@@ -139,7 +148,8 @@ export default function MemoryManagement({ onLoadedModelsChange } = {}) {
       whisperRunning: voiceValid ? Boolean(voice.services?.whisper?.ok) : previous.whisperRunning,
       sttEngine: voiceValid ? (voice.sttEngine || 'whisper') : previous.sttEngine,
       unavailableSources: [...new Set(failedSources)],
-    };
+      disabledSources: [...new Set(llmDisabledSources)],
+     };
     snapshotRef.current = snapshot;
     if (priority) priorityRefreshRef.current = false;
     if (!mountedRef.current) return snapshot;
@@ -149,6 +159,7 @@ export default function MemoryManagement({ onLoadedModelsChange } = {}) {
     setWhisperRunning(snapshot.whisperRunning);
     setSttEngine(snapshot.sttEngine);
     setUnavailableSources(snapshot.unavailableSources);
+    setDisabledSources(snapshot.disabledSources);
     setLoading(false);
     setLastFetched(Date.now());
     onLoadedModelsChange?.({
@@ -233,6 +244,11 @@ export default function MemoryManagement({ onLoadedModelsChange } = {}) {
     || whisperRunning || ttsState.state !== 'lazy';
   const anyActionRunning =
     unloadingModel || unloadingLmStudio || unloadingKokoro || stoppingWhisper || startingWhisper || freeingAll;
+   // The banner is the nag the user can opt out of per backend, so it drops
+   // user-disabled backends. The free-everything guard and empty-state check
+   // below still use the full unavailableSources, so a disabled-but-running
+   // backend can't be silently freed as "nothing resident."
+  const bannerSources = unavailableSources.filter((source) => !disabledSources.includes(source));
 
   return (
       <div className="bg-port-card border border-port-border rounded mb-4">
@@ -266,15 +282,15 @@ export default function MemoryManagement({ onLoadedModelsChange } = {}) {
         </div>
       </div>
 
-      {unavailableSources.length > 0 && (
-        <div className="mx-3 mt-3 flex items-start gap-2 rounded border border-port-warning/30 bg-port-warning/10 px-3 py-2 text-xs text-port-warning">
-          <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
-          <span>
-            Status unavailable for {unavailableSources.map((source) => SOURCE_LABELS[source] || source).join(', ')}.
+         {bannerSources.length > 0 && (
+          <div className="mx-3 mt-3 flex items-start gap-2 rounded border border-port-warning/30 bg-port-warning/10 px-3 py-2 text-xs text-port-warning">
+           <AlertTriangle className="mt-0.5 h-3 w-3 shrink-0" />
+           <span>
+            Status unavailable for {bannerSources.map((source) => SOURCE_LABELS[source] || source).join(', ')}.
             Last known values remain visible; unknown resources are excluded from Free everything.
-          </span>
-        </div>
-      )}
+           </span>
+          </div>
+         )}
 
       {loadedOllama.length === 0 && loadedLmStudio.length === 0
         && !whisperRunning && ttsState.state === 'lazy' && unavailableSources.length === 0 ? (

--- a/client/src/components/settings/MemoryManagement.test.jsx
+++ b/client/src/components/settings/MemoryManagement.test.jsx
@@ -83,5 +83,57 @@ describe('MemoryManagement', () => {
     });
     expect(screen.queryByText('older-model')).not.toBeInTheDocument();
     expect(screen.getByText('newer-model')).toBeInTheDocument();
-  });
+    });
+
+  it('hides the unavailability banner for a user-disabled backend', async () => {
+       // A backend the user marked disabled opts out of the availability nag. Its
+       // failed residency still lands in unavailableSources (the "Free everything"
+       // guard), but the banner excludes it.
+    getLoadedLlmModels.mockResolvedValue({
+       ollama: [],
+       lmstudio: [],
+       sourceErrors: ['lmstudio'],
+       disabled: ['lmstudio'],
+       });
+
+    render(<MemoryManagement />);
+
+     // Wait for the first refresh to clear the loading state so the poll result
+     // is the thing under test, not the pre-poll empty render.
+    expect(await screen.findByRole('button', { name: 'Free everything' })).toBeInTheDocument();
+     // The banned nag is suppressed for the disabled backend, even though its
+     // residency is unknown.
+    expect(screen.queryByText(/Status unavailable for LM Studio/i)).not.toBeInTheDocument();
+     // The "free everything" guard and empty-state check still key off the full
+     // unavailable list, so "nothing resident" is NOT claimed while lmstudio's
+     // residency is unconfirmed.
+    expect(screen.queryByText(/full unified memory is available/i)).not.toBeInTheDocument();
+        });
+
+  it('keeps a backend disabled across a later failed poll', async () => {
+          // The banner-suppression scenario IS a transient outage, so a failed poll
+          // must not resurrect the warning for a backend a good poll already marked
+          // disabled — disabled sources are retained (present-vs-empty, not falsy).
+     getLoadedLlmModels
+           .mockResolvedValueOnce({
+             ollama: [],
+             lmstudio: [],
+             sourceErrors: ['lmstudio'],
+             disabled: ['lmstudio'],
+             })
+           .mockRejectedValueOnce(new Error('LLM status failed'));
+
+    render(<MemoryManagement />);
+       // First (good) poll: lmstudio is known-disabled, so the banner is silent even
+       // though its residency error would otherwise show.
+    expect(await screen.findByRole('button', { name: 'Free everything' })).toBeInTheDocument();
+    expect(screen.queryByText(/Status unavailable for/i)).not.toBeInTheDocument();
+       // A later FAILED poll re-adds both backends to unavailableSources, but the
+       // still-known-disabled lmstudio must stay excluded from the banner (ollama,
+       // which is enabled, shows instead).
+    fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+    await waitFor(() => expect(getLoadedLlmModels).toHaveBeenCalledTimes(2));
+    expect(screen.getByText(/Status unavailable for Ollama/i)).toBeInTheDocument();
+    expect(screen.queryByText(/LM Studio/i)).not.toBeInTheDocument();
+       });
 });

--- a/server/routes/localLlm.js
+++ b/server/routes/localLlm.js
@@ -290,28 +290,30 @@ router.post('/migrate', asyncHandler(async (req, res) => {
 // right now so the Memory Management panel can show what to unload before
 // kicking off a big diffusion render.
 //
-// A backend the user has marked intentionally disabled (localLlm.<id>.disabled —
-// "PortOS will not expect this backend to be running") is a KNOWN not-resident
-// state, not an unavailable one, so it is not probed and never surfaces as a
-// "Status unavailable for …" error for the Memory Management panel.
+// sourceErrors stays the full failure list: a backend the user marked disabled
+// (localLlm.<id>.disabled — "PortOS will not expect this backend to be running")
+// is STILL probed, and a failed probe on a disabled-but-actually-running backend
+// must keep its "unknown residency" status so "Free everything" can't claim it
+// reclaimed a model it can't even see. The `disabled` field names the backends
+// the user opted out of availability warnings for, so the panel stays quiet
+// about them WITHOUT weakening that cleanup guard.
 router.get('/loaded', asyncHandler(async (_req, res) => {
-  // A disabled backend is a known not-resident state, so skip both the probe and
-  // the residency-error check for it — an intentionally-off backend must not read
-  // as "status unavailable".
   const settings = await getSettings().catch(() => ({}))
   const ollamaDisabled = Boolean(settings.localLlm?.ollama?.disabled)
   const lmStudioDisabled = Boolean(settings.localLlm?.lmstudio?.disabled)
-  // The residency getters return [] on a failed/unreachable probe (never throw),
-  // recording the failure via their getLastLoadedModelsError().
   const [ollama, lmstudio] = await Promise.all([
-    ollamaDisabled ? Promise.resolve([]) : getLoadedOllamaModels(),
-    lmStudioDisabled ? Promise.resolve([]) : getLoadedLmStudioModels(true),
+    getLoadedOllamaModels(),
+    getLoadedLmStudioModels(true),
    ])
   const sourceErrors = [
-     ...(!ollamaDisabled && getOllamaResidencyError() ? ['ollama'] : []),
-     ...(!lmStudioDisabled && getLmStudioResidencyError() ? ['lmstudio'] : []),
+     ...(getOllamaResidencyError() ? ['ollama'] : []),
+     ...(getLmStudioResidencyError() ? ['lmstudio'] : []),
    ]
-  res.json({ ollama, lmstudio, sourceErrors })
+  const disabled = [
+     ...(ollamaDisabled ? ['ollama'] : []),
+     ...(lmStudioDisabled ? ['lmstudio'] : []),
+   ]
+  res.json({ ollama, lmstudio, sourceErrors, disabled })
 }))
 
 // POST /api/local-llm/unload — body: { backend: 'ollama', modelId }.

--- a/server/routes/localLlm.js
+++ b/server/routes/localLlm.js
@@ -31,6 +31,7 @@ import {
   getStatus, listModels, listVisionModels, listToolUseModels, installModel, deleteModel, switchBackend, migrateBackend, installBackend, upgradeBackend, controlOllamaServer,
   describeInstallProgress
 } from '../services/localLlm.js'
+import { getSettings } from '../services/settings.js'
 import { runLocalLlmTest, compareLocalLlmModels } from '../services/localLlmPlayground.js'
 import { listUserModels } from '../services/audioModels.js'
 import { ENGINES } from '../services/pipeline/musicGen.js'
@@ -288,15 +289,28 @@ router.post('/migrate', asyncHandler(async (req, res) => {
 // Distinct from /catalog (disk-installed) — only flags what's eating VRAM
 // right now so the Memory Management panel can show what to unload before
 // kicking off a big diffusion render.
+//
+// A backend the user has marked intentionally disabled (localLlm.<id>.disabled —
+// "PortOS will not expect this backend to be running") is a KNOWN not-resident
+// state, not an unavailable one, so it is not probed and never surfaces as a
+// "Status unavailable for …" error for the Memory Management panel.
 router.get('/loaded', asyncHandler(async (_req, res) => {
+  // A disabled backend is a known not-resident state, so skip both the probe and
+  // the residency-error check for it — an intentionally-off backend must not read
+  // as "status unavailable".
+  const settings = await getSettings().catch(() => ({}))
+  const ollamaDisabled = Boolean(settings.localLlm?.ollama?.disabled)
+  const lmStudioDisabled = Boolean(settings.localLlm?.lmstudio?.disabled)
+  // The residency getters return [] on a failed/unreachable probe (never throw),
+  // recording the failure via their getLastLoadedModelsError().
   const [ollama, lmstudio] = await Promise.all([
-    getLoadedOllamaModels(),
-    getLoadedLmStudioModels(true),
-  ])
+    ollamaDisabled ? Promise.resolve([]) : getLoadedOllamaModels(),
+    lmStudioDisabled ? Promise.resolve([]) : getLoadedLmStudioModels(true),
+   ])
   const sourceErrors = [
-    ...(getOllamaResidencyError() ? ['ollama'] : []),
-    ...(getLmStudioResidencyError() ? ['lmstudio'] : []),
-  ]
+     ...(!ollamaDisabled && getOllamaResidencyError() ? ['ollama'] : []),
+     ...(!lmStudioDisabled && getLmStudioResidencyError() ? ['lmstudio'] : []),
+   ]
   res.json({ ollama, lmstudio, sourceErrors })
 }))
 

--- a/server/routes/localLlm.test.js
+++ b/server/routes/localLlm.test.js
@@ -6,7 +6,8 @@ import { runLocalLlmTest, compareLocalLlmModels } from '../services/localLlmPlay
 import { listModels, listVisionModels, listToolUseModels } from '../services/localLlm.js';
 import { enrichCatalogWithVariants } from '../services/huggingFaceCatalog.js';
 import { getLoadedModels, unloadModel } from '../services/ollamaManager.js';
-import { getLoadedModels as getLoadedLmStudioModels } from '../services/lmStudioManager.js';
+import { getLoadedModels as getLoadedLmStudioModels, getLastLoadedModelsError as getLmStudioResidencyError } from '../services/lmStudioManager.js';
+import { getSettings } from '../services/settings.js';
 import { localLlmCompareSchema, localLlmTestSchema } from '../lib/validation.js';
 import { errorEvents } from '../lib/errorHandler.js';
 
@@ -52,6 +53,12 @@ vi.mock('../services/lmStudioManager.js', () => ({
 vi.mock('../services/huggingFaceCatalog.js', () => ({
   searchHuggingFaceModels: vi.fn(async () => []),
   enrichCatalogWithVariants: vi.fn(async (catalog) => catalog),
+}));
+
+// /loaded reads getSettings() to honor a user's intentionally-disabled backends,
+// so mock it (defaults to no backends disabled; the disabled-case test flips it).
+vi.mock('../services/settings.js', () => ({
+  getSettings: vi.fn(async () => ({})),
 }));
 
 function makeApp() {
@@ -245,8 +252,8 @@ describe('local LLM memory-management routes', () => {
   });
 
   it('GET /loaded reports models both local backends currently have resident', async () => {
-    // Mirror the real getLoadedModels() field set so the fixture documents the
-    // pass-through contract and would catch any future field-stripping.
+     // Mirror the real getLoadedModels() field set so the fixture documents the
+     // pass-through contract and would catch any future field-stripping.
     const resident = { id: 'llama3.2', name: 'llama3.2', size: 4096, sizeVram: 4096, expiresAt: null };
     const lmStudioResident = { id: 'example/lmstudio', state: 'loaded' };
     getLoadedModels.mockResolvedValue([resident]);
@@ -258,7 +265,41 @@ describe('local LLM memory-management routes', () => {
     expect(res.body).toEqual({ ollama: [resident], lmstudio: [lmStudioResident], sourceErrors: [] });
     expect(getLoadedModels).toHaveBeenCalledTimes(1);
     expect(getLoadedLmStudioModels).toHaveBeenCalledWith(true);
-  });
+   });
+
+  it('GET /loaded does not probe a user-disabled backend or report it unavailable', async () => {
+     // A backend the user marked intentionally disabled (localLlm.<id>.disabled) is
+     // a known not-resident state, not an unavailable one — so /loaded must skip
+     // probing it and never surface "Status unavailable for LM Studio" to the
+     // Memory Management panel. Even though the residency probe would otherwise
+     // record a "LM Studio is unavailable" error, a disabled backend must not carry it.
+    getSettings.mockResolvedValueOnce({ localLlm: { lmstudio: { disabled: true } } });
+    getLmStudioResidencyError.mockReturnValueOnce('LM Studio is unavailable');
+
+    const res = await request(makeApp()).get('/api/local-llm/loaded');
+
+    expect(res.status).toBe(200);
+    expect(res.body.sourceErrors).not.toContain('lmstudio');
+    expect(res.body.lmstudio).toEqual([]);
+     // The disabled backend is a no-residency state — never probed.
+    expect(getLoadedLmStudioModels).not.toHaveBeenCalled();
+    expect(getSettings).toHaveBeenCalled();
+   });
+
+  it('GET /loaded still reports an enabled backend whose residency probe fails', async () => {
+     // The disabled-skip must not suppress a genuine "status unavailable" — an
+     // enabled backend that fails its residency probe still surfaces as a source
+     // error so the panel keeps its "excluded from Free everything" guard.
+    getSettings.mockResolvedValueOnce({});
+    getLmStudioResidencyError.mockReturnValueOnce('LM Studio is unavailable');
+
+    const res = await request(makeApp()).get('/api/local-llm/loaded');
+
+    expect(res.status).toBe(200);
+    expect(res.body.sourceErrors).toContain('lmstudio');
+    expect(getLoadedLmStudioModels).toHaveBeenCalledWith(true);
+   });
+
 
   it('POST /unload evicts a resident model and echoes the service result', async () => {
     // Real unloadModel() success shape is { unloaded: true, model } — NOT modelId

--- a/server/routes/localLlm.test.js
+++ b/server/routes/localLlm.test.js
@@ -252,8 +252,8 @@ describe('local LLM memory-management routes', () => {
   });
 
   it('GET /loaded reports models both local backends currently have resident', async () => {
-     // Mirror the real getLoadedModels() field set so the fixture documents the
-     // pass-through contract and would catch any future field-stripping.
+      // Mirror the real getLoadedModels() field set so the fixture documents the
+      // pass-through contract and would catch any future field-stripping.
     const resident = { id: 'llama3.2', name: 'llama3.2', size: 4096, sizeVram: 4096, expiresAt: null };
     const lmStudioResident = { id: 'example/lmstudio', state: 'loaded' };
     getLoadedModels.mockResolvedValue([resident]);
@@ -262,34 +262,39 @@ describe('local LLM memory-management routes', () => {
     const res = await request(makeApp()).get('/api/local-llm/loaded');
 
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ ollama: [resident], lmstudio: [lmStudioResident], sourceErrors: [] });
+    expect(res.body).toEqual({ ollama: [resident], lmstudio: [lmStudioResident], sourceErrors: [], disabled: [] });
     expect(getLoadedModels).toHaveBeenCalledTimes(1);
     expect(getLoadedLmStudioModels).toHaveBeenCalledWith(true);
-   });
+     });
 
-  it('GET /loaded does not probe a user-disabled backend or report it unavailable', async () => {
-     // A backend the user marked intentionally disabled (localLlm.<id>.disabled) is
-     // a known not-resident state, not an unavailable one — so /loaded must skip
-     // probing it and never surface "Status unavailable for LM Studio" to the
-     // Memory Management panel. Even though the residency probe would otherwise
-     // record a "LM Studio is unavailable" error, a disabled backend must not carry it.
+  it('GET /loaded keeps a failed disabled backend in sourceErrors but names it disabled', async () => {
+      // "Mark disabled" only silences the availability NAG — it is not evidence the
+      // backend holds no memory. So /loaded must still probe a disabled backend AND
+      // still surface its failed residency in sourceErrors (the panel's
+      // "Free everything" guard keys off that), while separately naming it in
+      // `disabled` so the banner can stay quiet about it.
     getSettings.mockResolvedValueOnce({ localLlm: { lmstudio: { disabled: true } } });
     getLmStudioResidencyError.mockReturnValueOnce('LM Studio is unavailable');
+    getLoadedLmStudioModels.mockResolvedValue([{ id: 'example/lmstudio', state: 'loaded' }]);
 
     const res = await request(makeApp()).get('/api/local-llm/loaded');
 
     expect(res.status).toBe(200);
-    expect(res.body.sourceErrors).not.toContain('lmstudio');
-    expect(res.body.lmstudio).toEqual([]);
-     // The disabled backend is a no-residency state — never probed.
-    expect(getLoadedLmStudioModels).not.toHaveBeenCalled();
+       // Residency is honored — the backend is still probed…
+    expect(getLoadedLmStudioModels).toHaveBeenCalledWith(true);
+    expect(res.body.lmstudio).toEqual([{ id: 'example/lmstudio', state: 'loaded' }]);
+       // …and its failed probe keeps the "unknown residency" status sourceErrors so
+       // "Free everything" can't claim it freed a model it never saw.
+    expect(res.body.sourceErrors).toContain('lmstudio');
+       // The disabled flag is the signal the panel uses to hold the banner.
+    expect(res.body.disabled).toEqual(['lmstudio']);
     expect(getSettings).toHaveBeenCalled();
-   });
+      });
 
   it('GET /loaded still reports an enabled backend whose residency probe fails', async () => {
-     // The disabled-skip must not suppress a genuine "status unavailable" — an
-     // enabled backend that fails its residency probe still surfaces as a source
-     // error so the panel keeps its "excluded from Free everything" guard.
+      // An enabled backend that fails its residency probe surfaces in sourceErrors
+      // and is NOT in `disabled`, so the panel both shows the nag and keeps its
+      // "excluded from Free everything" guard.
     getSettings.mockResolvedValueOnce({});
     getLmStudioResidencyError.mockReturnValueOnce('LM Studio is unavailable');
 
@@ -297,9 +302,10 @@ describe('local LLM memory-management routes', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.sourceErrors).toContain('lmstudio');
+       // An enabled backend is not in the disabled list.
+    expect(res.body.disabled).not.toContain('lmstudio');
     expect(getLoadedLmStudioModels).toHaveBeenCalledWith(true);
-   });
-
+      });
 
   it('POST /unload evicts a resident model and echoes the service result', async () => {
     // Real unloadModel() success shape is { unloaded: true, model } — NOT modelId


### PR DESCRIPTION
## Summary

The Memory Management panel kept showing "Status unavailable for LM Studio. Last known values remain visible; unknown resources are excluded from Free everything." even when the user had **marked that backend intentionally disabled**.

Root cause: `GET /api/local-llm/loaded` probed every backend and reported any failed residency probe as a `sourceError`, which the panel renders as the availability banner. A backend the user disabled (the "PortOS will not expect this backend to be running" flag) is a known, opted-out state — not an outage — so it should not nag.

The fix threads a new `disabled[]` field from the server to the panel:

- `server/routes/localLlm.js` — `/loaded` still probes every backend (a disabled backend may still hold a resident model, and the "Free everything" guard must keep its unknown-residency status) but adds `disabled[]` listing the backends the user has opted out of availability warnings for.
- `client/src/components/settings/MemoryManagement.jsx` — derives the banner from `unavailableSources − disabledSources`, so the nag is held for opted-out backends while they stay in `unavailableSources` (the free-everything guard and the "nothing resident" empty-state check are untouched). Disabled sources are retained across a later failed poll via the present-vs-empty sentinel (a failed poll keeps the last-known disabled set; an explicit `[]` clears it), so the outage the suppression exists for does not resurrect the banner.

## Test plan

- `cd server && vitest run routes/localLlm.test.js` — 20 pass. New: a disabled backend keeps its `sourceErrors` entry but is named in `disabled[]`; an enabled backend with a failed probe is not in `disabled[]`.
- `cd client && vitest run src/components/settings/MemoryManagement.test.jsx` — 5 pass. New: a user-disabled backend is excluded from the banner while its residency error is present, and stays excluded across a subsequent failed poll.
- Reviewed with codex (`gpt-5.6-terra`, medium effort) to convergence: no actionable findings.
