### PR TITLE
feat: add OpenCode Ollama task generation controls

### DIFF
--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -7,7 +7,7 @@ import { processScreenshotUploads, processAttachmentUploads } from '../../servic
 import { ATTACHMENT_ACCEPT } from '../../utils/fileUpload';
 import FilePickerButton from '../ui/FilePickerButton';
 import { formatBytes } from '../../utils/formatters';
-import { effectiveModelFor, effortAwareModelOptions, effortSurvivingModel, isTuiProvider, isCliProvider, isProcessProvider, isCodexProvider, seedModelEffort } from '../../utils/providers';
+import { effectiveModelFor, effortAwareModelOptions, effortSurvivingModel, isTuiProvider, isCliProvider, isProcessProvider, isCodexProvider, isOpencodeOllamaProvider, seedModelEffort } from '../../utils/providers';
 import { DEFAULT_PR_COMPLETION, DEFAULT_REVIEWERS, DEFAULT_REVIEW_STOP_MODE, PR_COMPLETION_OPTIONS, prCompletionOption } from './constants';
 import { clickableProps } from '../../lib/a11yKeyboard';
 import { slashdoLabel } from '../../lib/slashdoCatalog';
@@ -17,7 +17,7 @@ import useReviewerModelOptions from '../../hooks/useReviewerModelOptions';
 import { reviewerModelsFromDefaults, reviewerEffortsFromDefaults } from '../../lib/reviewerModels';
 
 export default function TaskAddForm({ providers, apps, onTaskAdded, compact = false, defaultExpanded = false, defaultApp = '' }) {
-  const [newTask, setNewTask] = useState({ description: '', model: '', provider: '', effort: '', app: defaultApp });
+  const [newTask, setNewTask] = useState({ description: '', model: '', provider: '', effort: '', temperature: '', thinking: '', app: defaultApp });
   const [addToTop, setAddToTop] = useState(false);
   const [enhancePrompt, setEnhancePrompt] = useState(false);
   const [isEnhancing, setIsEnhancing] = useState(false);
@@ -120,7 +120,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   // "Auto" so the visible select and the submitted value can't diverge.
   useEffect(() => {
     if (newTask.provider && !enabledProviders.some(p => p.id === newTask.provider)) {
-      setNewTask(t => ({ ...t, provider: '', model: '', effort: '' }));
+      setNewTask(t => ({ ...t, provider: '', model: '', effort: '', temperature: '', thinking: '' }));
     }
   }, [enabledProviders, newTask.provider]);
 
@@ -334,6 +334,8 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       model: newTask.model || undefined,
       provider: newTask.provider || undefined,
       effort: newTask.effort || undefined,
+      temperature: newTask.temperature === '' ? undefined : Number(newTask.temperature),
+      thinking: newTask.thinking === '' ? undefined : newTask.thinking === 'true',
       app: newTask.app || undefined,
       slashdoCommand: slashdoCommand || undefined,
       createJiraTicket,
@@ -652,7 +654,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
             <select
               id="task-provider"
               value={newTask.provider}
-              onChange={e => setNewTask(t => ({ ...t, provider: e.target.value, model: '', effort: '' }))}
+              onChange={e => setNewTask(t => ({ ...t, provider: e.target.value, model: '', effort: '', temperature: '', thinking: '' }))}
               className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
             >
               <option value="">Auto (default)</option>
@@ -695,6 +697,37 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
             className="sm:w-40 w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
           />
         </div>
+        {isOpencodeOllamaProvider(selectedProvider) && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <div>
+              <label htmlFor="task-thinking" className="sr-only">Thinking</label>
+              <select
+                id="task-thinking"
+                value={newTask.thinking}
+                onChange={e => setNewTask(t => ({ ...t, thinking: e.target.value }))}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
+              >
+                <option value="">Provider thinking default</option>
+                <option value="true">Thinking on</option>
+                <option value="false">Thinking off</option>
+              </select>
+            </div>
+            <div>
+              <label htmlFor="task-temperature" className="sr-only">Temperature</label>
+              <input
+                id="task-temperature"
+                type="number"
+                min="0"
+                max="2"
+                step="0.05"
+                placeholder="Provider temperature default"
+                value={newTask.temperature}
+                onChange={e => setNewTask(t => ({ ...t, temperature: e.target.value }))}
+                className="w-full px-3 py-2 bg-port-bg border border-port-border rounded-lg text-white text-sm min-h-[44px]"
+              />
+            </div>
+          </div>
+        )}
         {apiOnlyProviders && (
           <div className="px-3 py-2 bg-port-warning/10 border border-port-warning/40 rounded-lg text-xs text-port-warning">
             Your enabled providers are HTTP API providers with no file-writing harness, so they can't run agent tasks. Enable <span className="font-semibold">Claude Ollama</span> for Ollama, or <span className="font-semibold">OpenCode MTPLX</span> for a separately running MTPLX server, on the AI Providers page to run file-writing tasks on a local model.

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -47,6 +47,27 @@ describe('TaskAddForm responsive layout', () => {
     expect(options).toHaveClass('grid-cols-1');
     expect(options).not.toHaveClass('grid-cols-2');
   });
+
+  it('sends OpenCode Ollama thinking, effort, and temperature overrides with the task', async () => {
+    const user = userEvent.setup();
+    api.addCosTask.mockResolvedValue({ success: true });
+    render(<TaskAddForm providers={[{
+      id: 'opencode-ollama', name: 'OpenCode Ollama', enabled: true, type: 'tui',
+      command: 'opencode', ollamaBacked: true, models: ['qwen3:8b'],
+    }]} apps={[]} onTaskAdded={vi.fn()} />);
+
+    await user.type(screen.getByPlaceholderText('Task description *'), 'Implement the change');
+    await user.selectOptions(screen.getByLabelText('AI provider'), 'opencode-ollama');
+    await user.selectOptions(screen.getByLabelText('Thinking effort'), 'high');
+    await user.selectOptions(screen.getByLabelText('Thinking'), 'false');
+    await user.type(screen.getByLabelText('Temperature'), '0.25');
+    await user.click(screen.getByRole('button', { name: /^Add$/ }));
+
+    await waitFor(() => expect(api.addCosTask).toHaveBeenCalled());
+    expect(api.addCosTask.mock.calls.at(-1)[0]).toMatchObject({
+      provider: 'opencode-ollama', effort: 'high', thinking: false, temperature: 0.25,
+    });
+  });
 });
 
 // A slashdo quick-template carries the run shape its workflow implies (#3089).

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -184,6 +184,16 @@ export const filterSelectableModels = (models) =>
 export const CLAUDE_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
 export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh']);
 export const ANTIGRAVITY_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
+// OpenCode passes this through as `reasoningEffort` to its configured local
+// provider. Ollama's OpenAI-compatible API accepts this narrow ladder for
+// thinking models; the broader vendor-CLI ladders are not portable here.
+export const OPENCODE_OLLAMA_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
+
+/** True when an OpenCode process provider is backed by the local Ollama daemon. */
+export const isOpencodeOllamaProvider = (provider) =>
+  (['opencode', 'opencode-tui'].includes(String(provider?.id || '').toLowerCase())
+    || commandBasename(provider?.command) === 'opencode')
+  && provider?.ollamaBacked === true;
 
 /**
  * Antigravity base-model ↔ effort-suffix split — MIRROR of
@@ -358,6 +368,7 @@ export const seedModelEffort = (provider, model, effort) => {
  */
 export const effortLevelsForProvider = (provider, model = null) => {
   if (!provider) return null;
+  if (isOpencodeOllamaProvider(provider)) return OPENCODE_OLLAMA_EFFORT_LEVELS;
   if (isCodexProvider(provider)) return CODEX_EFFORT_LEVELS;
   if (isAntigravityProvider(provider)) {
     const perModel = model ? antigravityModelEffortLevels(model, provider.models) : null;

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -117,6 +117,7 @@ describe('effortLevelsForProvider (server mirror)', () => {
     ['path-configured agy', { id: 'custom', command: '/Users/x/.local/bin/agy' }, ANTIGRAVITY_EFFORT_LEVELS],
     ['claude code', { id: 'claude-code', command: 'claude' }, CLAUDE_EFFORT_LEVELS],
     ['codex', { id: 'codex', command: 'codex' }, CODEX_EFFORT_LEVELS],
+    ['OpenCode Ollama', { id: 'opencode-ollama', command: 'opencode', ollamaBacked: true }, ['low', 'medium', 'high']],
     ['grok (no effort control)', { id: 'grok-cli', command: 'grok' }, null],
     ['blank command is not claude', { id: 'ollama' }, null],
   ];

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -967,6 +967,8 @@ const cosTaskDiagnosticsSchema = z.object({
 // permanent through the API.
 const effortInputSchema = z.preprocess(emptyToUndefined, z.enum(EFFORT_LEVELS).optional());
 const effortUpdateSchema = z.preprocess(emptyToNull, z.enum(EFFORT_LEVELS).nullable().optional());
+const taskTemperatureInputSchema = z.number().min(0).max(2).optional();
+const taskTemperatureUpdateSchema = z.number().min(0).max(2).nullable().optional();
 
 // A bare slashdo command name (`plan-task`, `pr-better`). Shared by the task
 // schema and the quick-template schemas. `isValidSlashdoCommand` is the single
@@ -1007,6 +1009,8 @@ export const createCosTaskSchema = z.object({
   model: z.string().optional(),
   provider: z.string().optional(),
   effort: effortInputSchema,
+  temperature: taskTemperatureInputSchema,
+  thinking: z.boolean().optional(),
   app: z.string().optional(),
   type: z.string().optional().default('user'),
   approvalRequired: z.boolean().optional(),
@@ -1117,6 +1121,8 @@ export const updateCosTaskSchema = z.object({
   model: z.string().optional(),
   provider: z.string().optional(),
   effort: effortUpdateSchema,
+  temperature: taskTemperatureUpdateSchema,
+  thinking: z.boolean().nullable().optional(),
   app: z.string().optional(),
   blockedReason: z.string().optional(),
   type: z.string().optional().default('user'),

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -57,6 +57,16 @@ describe('cosValidation effort field', () => {
   });
 });
 
+describe('cosValidation OpenCode Ollama generation overrides', () => {
+  it('accepts bounded temperature and explicit thinking, including false', () => {
+    expect(createCosTaskSchema.parse({ description: 'x', temperature: 0.25, thinking: false }))
+      .toMatchObject({ temperature: 0.25, thinking: false });
+    expect(createCosTaskSchema.safeParse({ description: 'x', temperature: 2.1 }).success).toBe(false);
+    expect(updateCosTaskSchema.parse({ thinking: null, temperature: null }))
+      .toMatchObject({ thinking: null, temperature: null });
+  });
+});
+
 describe('branch-reconcile batch metadata', () => {
   it('keeps integer batch sizes from 1 through 6', () => {
     expect(sanitizeTaskMetadata({ branchesPerAgent: 1 })).toEqual({ branchesPerAgent: 1 });

--- a/server/lib/opencodeConfig.js
+++ b/server/lib/opencodeConfig.js
@@ -113,12 +113,23 @@ export function buildOpencodeConfig(models, base = null, providerKey = 'ollama',
   // Ollama's native `think` flag.
   if (generation && providerKey === 'ollama') {
     const temperature = Number.isFinite(Number(generation.temperature)) ? Number(generation.temperature) : 0.6;
-    const thinking = typeof generation.thinking === 'boolean' ? generation.thinking : undefined;
+    // TASKS.md metadata is text, so a persisted task re-enters the lifecycle as
+    // `'true'`/`'false'`. Accept both wire forms without treating an absent or
+    // malformed value as an intentional override.
+    const thinking = generation.thinking === true || generation.thinking === 'true'
+      ? true
+      : generation.thinking === false || generation.thinking === 'false'
+        ? false
+        : undefined;
+    const effort = typeof generation.effort === 'string' && generation.effort.trim()
+      ? generation.effort.trim()
+      : undefined;
     config.agent = { ...(config.agent && typeof config.agent === 'object' ? config.agent : {}) };
     config.agent.build = {
       ...(config.agent.build && typeof config.agent.build === 'object' ? config.agent.build : {}),
       temperature,
       ...(thinking === undefined ? {} : { think: thinking }),
+      ...(effort === undefined ? {} : { reasoningEffort: effort }),
     };
   }
   return config;

--- a/server/lib/opencodeConfig.test.js
+++ b/server/lib/opencodeConfig.test.js
@@ -137,6 +137,15 @@ describe('buildOpencodeEnvVars', () => {
     expect(cfg.agent.build).toEqual({ temperature: 0.6, think: false });
   });
 
+  it('passes a task-level reasoning effort through to Ollama', () => {
+    const cfg = buildOpencodeConfig('qwen2.5:7b', null, 'ollama', {
+      temperature: '0.25',
+      thinking: 'true',
+      effort: 'high',
+    });
+    expect(cfg.agent.build).toEqual({ temperature: 0.25, think: true, reasoningEffort: 'high' });
+  });
+
   it('declares the run model under provider.mtplx.models for MTPLX-backed OpenCode', () => {
     const result = buildOpencodeEnvVars({ command: 'opencode', mtplxBacked: true, models: ['mtplx'] }, 'mtplx');
     const cfg = JSON.parse(result.OPENCODE_CONFIG_CONTENT);

--- a/server/lib/providerModels.js
+++ b/server/lib/providerModels.js
@@ -91,6 +91,9 @@ export const resolveCliModel = (model) => isConfiguredDefaultModel(model) ? null
 export const CLAUDE_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
 export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh']);
 export const ANTIGRAVITY_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
+// OpenCode forwards this narrow OpenAI-compatible ladder as `reasoningEffort`
+// to a local Ollama model. Keep it separate from vendor-CLI-only levels.
+export const OPENCODE_OLLAMA_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
 
 // Effort values no CLI ladder accepts any more, kept ACCEPTED as stored/API
 // input so records saved under an older ladder still validate after an install
@@ -288,6 +291,7 @@ export function isAntigravityProvider(provider) {
  */
 export function effortLevelsForProvider(provider, model = null) {
   if (!provider) return null;
+  if (isOpencodeProvider(provider) && provider.ollamaBacked === true) return OPENCODE_OLLAMA_EFFORT_LEVELS;
   if (isCodexProvider(provider)) return CODEX_EFFORT_LEVELS;
   if (isAntigravityProvider(provider)) {
     const perModel = model ? antigravityModelEffortLevels(model, provider.models) : null;

--- a/server/lib/providerModels.test.js
+++ b/server/lib/providerModels.test.js
@@ -216,8 +216,13 @@ describe('providerModels', () => {
       expect(effortLevelsForProvider({ id: 'custom', command: '/Users/x/.local/bin/agy' })).toBe(ANTIGRAVITY_EFFORT_LEVELS);
     });
 
-    it('returns null for providers without an effort control (and does NOT default blank commands to claude)', () => {
+    it('offers the OpenAI-compatible ladder only for Ollama-backed OpenCode', () => {
+      expect(effortLevelsForProvider({ id: 'opencode-ollama', command: 'opencode', ollamaBacked: true }))
+        .toEqual(['low', 'medium', 'high']);
       expect(effortLevelsForProvider({ id: 'opencode-ollama', command: 'opencode' })).toBeNull();
+    });
+
+    it('returns null for providers without an effort control (and does NOT default blank commands to claude)', () => {
       expect(effortLevelsForProvider({ id: 'grok-cli', command: 'grok' })).toBeNull();
       expect(effortLevelsForProvider({ id: 'ollama' })).toBeNull();
       expect(effortLevelsForProvider(null)).toBeNull();

--- a/server/routes/cosTaskRoutes.js
+++ b/server/routes/cosTaskRoutes.js
@@ -317,6 +317,8 @@ router.put('/tasks/:id', asyncHandler(async (req, res) => {
   if (fields.model !== undefined) updates.model = fields.model;
   if (fields.provider !== undefined) updates.provider = fields.provider;
   if (fields.effort !== undefined) updates.effort = fields.effort;
+  if (fields.temperature !== undefined) updates.temperature = fields.temperature;
+  if (fields.thinking !== undefined) updates.thinking = fields.thinking;
   if (fields.app !== undefined) updates.app = fields.app;
 
   // Set blocker metadata when marking as blocked

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -630,12 +630,25 @@ async function runAgentSpawn(task) {
     // bake a bare, Bedrock-invalid --model into the argv. Cached (5-min TTL), so
     // the spawn helper's own getClaudeSettingsEnv() call is effectively free.
     const cliSettingsEnv = isClaudeCliProvider(provider) ? await getClaudeSettingsEnv() : {};
+    // Task-level OpenCode/Ollama generation controls override provider defaults
+    // for this one run. The child-environment composer turns these into the
+    // dynamic `agent.build` config instead of mutating saved provider state.
+    const taskTemperature = task.metadata?.temperature === '' ? NaN : Number(task.metadata?.temperature);
+    const taskThinking = task.metadata?.thinking;
+    const runProvider = {
+      ...provider,
+      ...(Number.isFinite(taskTemperature) && taskTemperature >= 0 && taskTemperature <= 2
+        ? { temperature: taskTemperature }
+        : {}),
+      ...([true, false, 'true', 'false'].includes(taskThinking) ? { thinking: taskThinking } : {}),
+      ...(typeof task.metadata?.effort === 'string' ? { effort: task.metadata.effort } : {}),
+    };
     // Per-task reasoning-effort override (task form / schedule config). The
     // builders no-op it for providers without an effort control.
     const taskEffort = task.metadata?.effort || null;
     const cliConfig = isTui
-      ? buildTuiSpawnConfig(provider, selectedModel, { systemPromptFile, effort: taskEffort })
-      : buildCliSpawnConfig(provider, selectedModel, cliSettingsEnv, { systemPromptFile, effort: taskEffort });
+      ? buildTuiSpawnConfig(runProvider, selectedModel, { systemPromptFile, effort: taskEffort })
+      : buildCliSpawnConfig(runProvider, selectedModel, cliSettingsEnv, { systemPromptFile, effort: taskEffort });
 
     emitLog('success', `Spawning agent for task ${task.id}`, {
       agentId,
@@ -664,7 +677,7 @@ async function runAgentSpawn(task) {
         prompt,
         workspacePath,
         model: selectedModel,
-        provider,
+        provider: runProvider,
         runId,
         tuiConfig: cliConfig,
         agentDir,
@@ -677,7 +690,7 @@ async function runAgentSpawn(task) {
       });
     }
     if (useRunner) {
-      return await spawnViaRunner(agentId, task, { prompt, workspacePath, model: selectedModel, provider, runId, cliConfig, executionId: toolExecution.id, laneName });
+      return await spawnViaRunner(agentId, task, { prompt, workspacePath, model: selectedModel, provider: runProvider, runId, cliConfig, executionId: toolExecution.id, laneName });
     }
     // Direct spawn mode (fallback)
     return await spawnDirectly({
@@ -686,7 +699,7 @@ async function runAgentSpawn(task) {
       prompt,
       workspacePath,
       model: selectedModel,
-      provider,
+      provider: runProvider,
       runId,
       cliConfig,
       agentDir,

--- a/server/services/cosTaskStore.js
+++ b/server/services/cosTaskStore.js
@@ -68,7 +68,7 @@ const isTerminalTaskStatus = (status) => status === 'completed' || status === 'b
 // with the #4153 split so the task editor can edit the agent-facing payload the
 // same way it edits the human note — deliberately WITHOUT re-classification, so
 // a multi-line note edit can't overwrite the payload (see `splitTaskPromptFields`).
-const LEGACY_DIRECT_FIELDS = ['context', 'prompt', 'model', 'provider', 'effort', 'app'];
+const LEGACY_DIRECT_FIELDS = ['context', 'prompt', 'model', 'provider', 'effort', 'temperature', 'thinking', 'app'];
 
 // Equality for metadata values across a fresh markdown re-parse: primitives by
 // ===, arrays/objects (reviewers[], screenshots[], …) by JSON since the two
@@ -330,6 +330,8 @@ export async function addTask(taskData, taskType = 'user', { raw = false, ignore
     if (taskData.model) metadata.model = taskData.model;
     if (taskData.provider) metadata.provider = taskData.provider;
     if (taskData.effort) metadata.effort = taskData.effort;
+    if (taskData.temperature !== undefined) metadata.temperature = taskData.temperature;
+    if (taskData.thinking !== undefined) metadata.thinking = taskData.thinking;
     if (taskData.app) metadata.app = taskData.app;
     // Tags a task dispatched by the voice code-agent tool so the proactive
     // speech layer can announce its completion (see voice/proactiveTriggers.js).

--- a/server/services/cosTaskStore.test.js
+++ b/server/services/cosTaskStore.test.js
@@ -341,6 +341,15 @@ describe('cosTaskStore.addTask', () => {
       expect(created.metadata.prompt).toBeUndefined();
     });
 
+    it('round-trips OpenCode Ollama generation controls, including thinking off', async () => {
+      const created = await addTask({
+        description: 'local task', id: 'task-opencode', effort: 'high', temperature: 0.25, thinking: false,
+      }, 'user');
+      expect(created.metadata).toMatchObject({ effort: 'high', temperature: 0.25, thinking: false });
+      const reloaded = await getTaskById('task-opencode');
+      expect(reloaded.metadata).toMatchObject({ effort: 'high', temperature: '0.25', thinking: 'false' });
+    });
+
     it('accepts an explicit prompt alongside a note and never re-classifies it', async () => {
       const created = await addTask(
         { description: 'claim', id: 'task-explicit', prompt: AGENT_BODY, context: 'one-line note' },


### PR DESCRIPTION
## Summary
- Add per-task thinking, reasoning-effort, and temperature controls for OpenCode providers backed by Ollama.
- Persist and validate the overrides, then apply them only to the spawned task through OpenCode agent configuration.

## Test plan
- client/node_modules/.bin/vitest run src/components/cos/TaskAddForm.test.jsx src/utils/providers.test.js --root client --configLoader runner
- server/node_modules/.bin/vitest run server/lib/opencodeConfig.test.js server/lib/providerModels.test.js server/lib/cosValidation.test.js server/services/cosTaskStore.test.js --configLoader runner