### PR TITLE
fix: link gated local models to Hugging Face terms

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -887,6 +887,7 @@ export function LocalLlmTab() {
                 {group.models.map((m) => {
                   const isHf = m.source === 'huggingface';
                   const isAudio = m.category === 'audio';
+                  const repositoryUrl = m.repository ? `https://huggingface.co/${m.repository}` : null;
                   // Multi-quant repos let the user trade their RAM for fidelity.
                   // `chosenId` is the selected variant's install id (defaulting to
                   // the server's RAM-aware pick `m.id`); the card's size/RAM/fit
@@ -1036,16 +1037,16 @@ export function LocalLlmTab() {
                           Sharded — use LM Studio or a smaller quant
                         </span>
                       )}
-                      {isHf && m.repository && (
+                      {repositoryUrl && (
                         <a
-                          href={`https://huggingface.co/${m.repository}`}
+                          href={repositoryUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          title="Open the model page on Hugging Face"
+                          title={m.gated ? 'Open Hugging Face to accept repository terms' : 'Open the model page on Hugging Face'}
                           className="px-2.5 py-1 text-xs bg-port-border/60 hover:bg-port-border text-gray-300 rounded flex items-center gap-1"
                         >
                           <ExternalLink size={12} />
-                          Visit
+                          {m.gated ? 'Accept terms' : 'Visit'}
                         </a>
                       )}
                     </div>

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -121,6 +121,30 @@ describe('LocalLlmTab installed models', () => {
 });
 
 describe('LocalLlmTab recommendations', () => {
+  it('links a gated curated model to Hugging Face so its terms can be accepted', async () => {
+    getLocalLlmCatalog.mockResolvedValue({
+      models: [{
+        id: 'orcarouter/qwen3.8-27b-uncensored-mlx:4bit',
+        key: 'qwen3.8-27b-uncensored-mlx',
+        name: 'Qwen3.8 27B Uncensored MLX',
+        category: 'general',
+        recommendedFor: ['general'],
+        params: '27B',
+        size: '15 GB',
+        description: 'A gated local evaluation model.',
+        repository: 'orcarouter/Qwen3.8-27B-Uncensored-MLX',
+        gated: true,
+        capabilities: ['chat'],
+      }],
+    });
+
+    await renderTab();
+
+    const termsLink = await screen.findByRole('link', { name: 'Accept terms' });
+    expect(termsLink).toHaveAttribute('href', 'https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX');
+    expect(termsLink).toHaveAttribute('target', '_blank');
+  });
+
   it('highlights the flagship general model and surfaces it in its coding use-case filter', async () => {
     getLocalLlmCatalog.mockResolvedValue({
       models: [{

--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -38,7 +38,7 @@ export const LOCAL_LLM_CATEGORIES = [
 ];
 
 // Each entry: { key, name, category, recommendedFor?, featured?, params, size,
-//               family, description, note?, capabilities, context?, format?,
+//               family, description, note?, repository?, gated?, capabilities, context?, format?,
 //               appleSiliconOnly?, ollama?, lmstudio?, ollamaImport?, ollamaAliases?,
 //               lmstudioAliases? }
 //
@@ -314,6 +314,8 @@ export const LOCAL_LLM_CATALOG = [
     family: 'qwen',
     description: 'OrcaRouter’s abliterated Qwen3.8 variant for red-team and unrestricted local evaluation, with 2-, 4-, 6-, and 8-bit MLX builds plus vision, tools, reasoning, and multilingual support.',
     note: 'Gated on Hugging Face — accept the repository terms and configure a Hugging Face token in Settings. Ollama imports the 4-bit build; LM Studio can select another quantization.',
+    repository: 'orcarouter/Qwen3.8-27B-Uncensored-MLX',
+    gated: true,
     capabilities: ['chat', 'code', 'reasoning', 'tools', 'vision', 'multilingual'],
     context: 262144,
     format: 'mlx',
@@ -726,7 +728,7 @@ export function getOllamaImportSpec(modelId) {
  * @param {string} backend - 'ollama' | 'lmstudio'
  * @param {string[]} [installedIds] - ids currently installed on that backend
  * @param {{ appleSilicon?: boolean }} [options] - host capabilities used for platform-gated entries
- * @returns {Array<{ id, key, name, category, recommendedFor, featured, params, size, family, description, note, capabilities, format, contextLength, installed }>}
+ * @returns {Array<{ id, key, name, category, recommendedFor, featured, params, size, family, description, note, repository, gated, capabilities, format, contextLength, installed }>}
  */
 export function getCatalog(backend, installedIds = [], { appleSilicon } = {}) {
   if (!isBackend(backend)) return [];
@@ -749,6 +751,8 @@ export function getCatalog(backend, installedIds = [], { appleSilicon } = {}) {
         family: entry.family,
         description: entry.description,
         note: entry.note || null,
+        repository: entry.repository || null,
+        gated: entry.gated === true,
         capabilities: entry.capabilities,
         format: entry.format || null,
         // Native context window (tokens), when it's a documented spec; null otherwise.

--- a/server/lib/localLlmCatalog.test.js
+++ b/server/lib/localLlmCatalog.test.js
@@ -72,7 +72,9 @@ describe('localLlmCatalog', () => {
       expect(getCatalog('lmstudio', [], { appleSilicon: true }).find((m) => m.key === uncensoredKey)).toMatchObject({
         format: 'mlx',
         id: 'https://huggingface.co/orcarouter/Qwen3.8-27B-Uncensored-MLX',
-        note: expect.stringContaining('Gated on Hugging Face')
+        note: expect.stringContaining('Gated on Hugging Face'),
+        repository: 'orcarouter/Qwen3.8-27B-Uncensored-MLX',
+        gated: true
       });
       expect(getCatalog('lmstudio', ['orcarouter/Qwen3.8-27B-Uncensored-MLX'], { appleSilicon: true })
         .find((m) => m.key === uncensoredKey)?.installed).toBe(true);


### PR DESCRIPTION
## Summary
- add gated-repository metadata to the curated Qwen uncensored MLX entry
- show an Accept terms link to its Hugging Face page in the local model catalog

## Test plan
- server: ./node_modules/.bin/vitest run lib/localLlmCatalog.test.js
- client: ./node_modules/.bin/vitest run src/components/settings/LocalLlmTab.test.jsx --root . --configLoader runner