### PR TITLE
feat: allow editing media prompts

### DIFF
--- a/client/src/components/media/MediaLightbox.jsx
+++ b/client/src/components/media/MediaLightbox.jsx
@@ -106,6 +106,7 @@ export default function MediaLightbox({
   hasNext = false,
   annotation = null,
   onAnnotationChange,
+  onPromptChange,
   variantGroup = null,
   onSelectVariant,
 }) {
@@ -371,6 +372,7 @@ export default function MediaLightbox({
             onPromptFrom={() => setPromptFromOpen(true)}
             annotation={annotation}
             onAnnotationChange={onAnnotationChange}
+            onPromptChange={onPromptChange}
             variantGroup={variantGroup}
             onSelectVariant={onSelectVariant}
           />
@@ -412,7 +414,7 @@ function SettingsPane({
   item, meta, isVideo,
   onClose, onRemix, onSendToImage, onSendToVideo, onSendTo3d, onContinue, onClean, onRegenerate, onRemoveWatermark, regenAvailable, regenBounds,
   copy, onRefine, onPromptFrom,
-  annotation, onAnnotationChange,
+  annotation, onAnnotationChange, onPromptChange,
   variantGroup, onSelectVariant,
 }) {
   const asideClasses = 'md:w-80 lg:w-96 shrink-0 flex flex-col border-t md:border-t-0 md:border-l border-port-border max-h-[40vh] md:max-h-[92vh]';
@@ -465,6 +467,9 @@ function SettingsPane({
   // would otherwise restart the timer every time a media-gen event arrived.
   const [noteDraft, setNoteDraft] = useState(annotation?.note ?? '');
   const [saveStatus, setSaveStatus] = useState('idle');
+  const [promptDraft, setPromptDraft] = useState('');
+  const [promptStatus, setPromptStatus] = useState('idle');
+  const [promptSaving, setPromptSaving] = useState(false);
   const onSaveRef = useRef(onAnnotationChange);
   const pendingNoteRef = useRef(null);
   useEffect(() => { onSaveRef.current = onAnnotationChange; });
@@ -474,6 +479,20 @@ function SettingsPane({
   useEffect(() => {
     setNoteDraft(annotation?.note ?? '');
   }, [item?.key, annotation?.note]);
+  useEffect(() => {
+    setPromptDraft(item.prompt === '(no prompt)' ? '' : (item.prompt || ''));
+    setPromptStatus('idle');
+  }, [item?.key, item?.prompt]);
+  const savePrompt = async () => {
+    if (!onPromptChange || promptSaving) return;
+    setPromptSaving(true);
+    setPromptStatus('saving');
+    await onPromptChange(item, promptDraft).then(
+      () => setPromptStatus('saved'),
+      () => setPromptStatus('error'),
+    );
+    setPromptSaving(false);
+  };
   // On item swap (or full unmount): flush any pending note to the *old* item's
   // save callback before resetting local state. onSaveRef still holds the old
   // closure at cleanup time because React runs effect cleanups before the new
@@ -536,7 +555,26 @@ function SettingsPane({
       </header>
 
       <div className="flex-1 overflow-y-auto p-3 space-y-3 text-xs">
-        {item.prompt && (
+        {onPromptChange ? (
+          <div>
+            <div className="flex items-center justify-between mb-1">
+              <label htmlFor="media-prompt" className="text-gray-500 uppercase tracking-wide">Prompt</label>
+              <div className="flex items-center gap-2 text-[10px] text-gray-500">
+                {promptStatus === 'saving' && <span>Saving…</span>}
+                {promptStatus === 'saved' && <span className="text-port-success">Saved</span>}
+                {promptStatus === 'error' && <span className="text-port-error">Save failed</span>}
+                <span>{promptDraft.length}/8000</span>
+              </div>
+            </div>
+            <textarea id="media-prompt" value={promptDraft}
+              onChange={(e) => { setPromptDraft(e.target.value.slice(0, 8000)); setPromptStatus('idle'); }}
+              placeholder="Add the prompt used to create this media" rows={5} maxLength={8000}
+              className="w-full bg-port-bg border border-port-border rounded p-2 text-xs text-gray-200 placeholder:text-gray-600 focus:outline-none focus:border-port-accent resize-y" />
+            <div className="flex justify-end mt-1">
+              <button type="button" onClick={savePrompt} disabled={promptSaving || promptDraft === (item.prompt === '(no prompt)' ? '' : (item.prompt || ''))} className="px-2 py-1 rounded bg-port-accent text-white disabled:opacity-40">Save prompt</button>
+            </div>
+          </div>
+        ) : item.prompt ? (
           <div>
             <div className="flex items-center justify-between mb-1">
               <span className="text-gray-500 uppercase tracking-wide">Prompt</span>
@@ -551,7 +589,7 @@ function SettingsPane({
             </div>
             <p className="text-gray-200 whitespace-pre-wrap">{item.prompt}</p>
           </div>
-        )}
+        ) : null}
 
         {onAnnotationChange && (
           <div>

--- a/client/src/components/media/MediaPreview.jsx
+++ b/client/src/components/media/MediaPreview.jsx
@@ -2,6 +2,7 @@ import { useMemo, useCallback } from 'react';
 import MediaLightbox from './MediaLightbox';
 import { getMediaNavProps } from '../../lib/mediaNavigation';
 import { computeImageVariantGroup } from './variants';
+import { updateImagePrompt, updateVideoPrompt } from '../../services/apiImageVideo';
 
 // Thin wrapper around MediaLightbox that owns the consistent wiring every
 // page repeated by hand: open/close, prev/next nav, and the annotation
@@ -19,6 +20,7 @@ export default function MediaPreview({
   items,
   annotations,
   updateAnnotation,
+  onPromptSaved,
   ...handlers
 }) {
   const navProps = useMemo(
@@ -37,12 +39,24 @@ export default function MediaPreview({
     if (!nextItem) return;
     setPreview(nextItem);
   }, [setPreview]);
+  const savePrompt = useCallback(async (item, prompt) => {
+    const result = item.kind === 'image'
+      ? await updateImagePrompt(item.filename, prompt, { silent: true })
+      : await updateVideoPrompt(item.id, prompt, { silent: true });
+    const nextPrompt = result?.prompt || '(no prompt)';
+    setPreview((current) => current?.key === item.key
+      ? { ...current, prompt: nextPrompt, raw: { ...current.raw, prompt: result?.prompt || '' } }
+      : current);
+    onPromptSaved?.(item, nextPrompt);
+    return result;
+  }, [onPromptSaved, setPreview]);
   return (
     <MediaLightbox
       item={preview}
       onClose={() => setPreview(null)}
       annotation={annotations?.[preview?.key] ?? null}
       onAnnotationChange={preview && updateAnnotation ? (patch) => updateAnnotation(preview.key, patch) : undefined}
+      onPromptChange={savePrompt}
       variantGroup={variantGroup}
       onSelectVariant={onSelectVariant}
       {...handlers}

--- a/client/src/pages/MediaHistory.jsx
+++ b/client/src/pages/MediaHistory.jsx
@@ -146,6 +146,10 @@ export default function MediaHistory() {
     }
   };
 
+  const handlePromptSaved = (item, prompt) => {
+    setItems((all) => all.map((current) => current.key === item.key ? { ...current, prompt } : current));
+  };
+
   // Remix / SendToVideo / Continue / Clean all share a single implementation
   // with MediaCollectionDetail, ImageGen, and the Universe Builder lightbox
   // via `useMediaPreviewActions`. Only the post-clean side effect (splicing
@@ -310,6 +314,7 @@ export default function MediaHistory() {
         items={filtered}
         annotations={annotations}
         updateAnnotation={updateAnnotation}
+        onPromptSaved={handlePromptSaved}
         onRemix={handleRemix}
         onSendToImage={handleSendToImage}
         onSendToVideo={handleSendToVideo}

--- a/client/src/services/apiImageVideo.js
+++ b/client/src/services/apiImageVideo.js
@@ -40,6 +40,9 @@ export const setImageHidden = (filename, hidden, options = {}) => request(`/imag
   body: JSON.stringify({ hidden }),
   ...options,
 });
+export const updateImagePrompt = (filename, prompt, options = {}) => request(`/image-gen/${encodeURIComponent(filename)}/prompt`, {
+  method: 'PATCH', body: JSON.stringify({ prompt }), ...options,
+});
 export const cleanGalleryImage = (filename, options = {}) => request(`/image-gen/${encodeURIComponent(filename)}/clean`, {
   method: 'POST',
   body: JSON.stringify({}),
@@ -241,6 +244,9 @@ export const setVideoHidden = (id, hidden, options = {}) => request(`/video-gen/
   method: 'POST',
   body: JSON.stringify({ hidden }),
   ...options,
+});
+export const updateVideoPrompt = (id, prompt, options = {}) => request(`/video-gen/history/${encodeURIComponent(id)}/prompt`, {
+  method: 'PATCH', body: JSON.stringify({ prompt }), ...options,
 });
 export const extractLastFrame = (id, options = {}) => request(`/video-gen/last-frame/${encodeURIComponent(id)}`, { method: 'POST', ...options });
 export const upscaleVideo = (id, options = {}) => request(`/video-gen/upscale/${encodeURIComponent(id)}`, { method: 'POST', ...options });

--- a/server/routes/imageGen.js
+++ b/server/routes/imageGen.js
@@ -51,6 +51,7 @@ const MAX_PROMPT_LENGTH = 8000;
 const MAX_LORAS = 8;
 const MAX_REFERENCE_IMAGES = 4;
 const MAX_IMAGE_UPLOAD_BYTES = 20 * 1024 * 1024;
+const updatePromptSchema = z.object({ prompt: z.string().max(MAX_PROMPT_LENGTH) });
 
 router.get('/style-presets', (_req, res) => res.json(STYLE_PRESETS));
 
@@ -647,6 +648,11 @@ router.delete('/:filename', asyncHandler(async (req, res) => {
 
 router.post('/:filename/visibility', asyncHandler(async (req, res) => {
   res.json(await local.setImageHidden(req.params.filename, !!req.body?.hidden));
+}));
+
+router.patch('/:filename/prompt', asyncHandler(async (req, res) => {
+  const body = validateRequest(updatePromptSchema, req.body ?? {});
+  res.json(await local.updateImagePrompt(req.params.filename, body.prompt));
 }));
 
 router.post('/:filename/clean', asyncHandler(async (req, res) => {

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -40,6 +40,7 @@ import {
   getHistoryItem,
   deleteHistoryItem,
   setHistoryItemHidden,
+  updateHistoryItemPrompt,
   extractLastFrame,
   stitchVideos,
   upscaleHistoryItem,
@@ -1244,6 +1245,7 @@ router.get('/history', asyncHandler(async (_req, res) => {
 // value is only compared against stored ids — so a length-capped string is the
 // right bound.
 const historyLookupIdSchema = z.string().min(1).max(200);
+const updatePromptSchema = z.object({ prompt: z.string().max(8000) });
 
 router.get('/history/:id', asyncHandler(async (req, res) => {
   const parsed = historyLookupIdSchema.safeParse(req.params.id);
@@ -1279,6 +1281,14 @@ router.delete('/history/:id', asyncHandler(async (req, res) => {
 
 router.post('/history/:id/visibility', asyncHandler(async (req, res) => {
   res.json(await setHistoryItemHidden(req.params.id, !!req.body?.hidden));
+}));
+
+router.patch('/history/:id/prompt', asyncHandler(async (req, res) => {
+  const parsedId = historyLookupIdSchema.safeParse(req.params.id);
+  if (!parsedId.success) failValidation(parsedId);
+  const body = updatePromptSchema.safeParse(req.body ?? {});
+  if (!body.success) failValidation(body);
+  res.json(await updateHistoryItemPrompt(parsedId.data, body.data.prompt));
 }));
 
 // Render jobs use UUID history ids, while shared-gallery uploads use an

--- a/server/services/imageGen/local.js
+++ b/server/services/imageGen/local.js
@@ -1068,6 +1068,16 @@ export async function setImageHidden(filename, hidden) {
   return { ok: true, hidden: metadata.hidden };
 }
 
+export async function updateImagePrompt(filename, prompt) {
+  assertGalleryFilename(filename);
+  const { path: sidecarPath, metadata } = await readImageSidecar(filename);
+  const trimmedPrompt = typeof prompt === 'string' ? prompt.trim() : '';
+  if (trimmedPrompt) metadata.prompt = trimmedPrompt;
+  else delete metadata.prompt;
+  await atomicWrite(sidecarPath, metadata);
+  return { filename, prompt: trimmedPrompt };
+}
+
 // Returns just `{ filename, name }` — clients send `filename` back in the
 // generate payload's `loraFilenames` and the server resolves it against
 // PATHS.loras. Avoids leaking absolute server paths into the API surface.

--- a/server/services/videoGen/local.js
+++ b/server/services/videoGen/local.js
@@ -90,6 +90,20 @@ export * from './modeContract.js';
 export * from './eta.js';
 export { loadHistory, saveHistory, mutateVideoHistory, getHistoryItem };
 
+export async function updateHistoryItemPrompt(id, prompt) {
+  let result;
+  await mutateVideoHistory((history) => {
+    const item = history.find((h) => h.id === id);
+    if (!item) throw new ServerError('Not found', { status: 404, code: 'NOT_FOUND' });
+    const trimmedPrompt = typeof prompt === 'string' ? prompt.trim() : '';
+    if (trimmedPrompt) item.prompt = trimmedPrompt;
+    else delete item.prompt;
+    result = { id, prompt: trimmedPrompt };
+    return history;
+  });
+  return result;
+}
+
 // LoRA wrapper for the notapalindrome `mlx_video` runtime. The stock
 // `mlx_video.generate_av` CLI has no --lora flag, but the package ships an
 // LTX-aware LoRA subsystem (`mlx_video.lora`) — this helper imports generate_av,


### PR DESCRIPTION
## Summary
- add validated prompt PATCH endpoints for image sidecars and video history records
- add prompt editing to the shared media lightbox for imported, uploaded, and generated media
- keep the media history list updated after a successful save

## Test plan
- npm test -- --run routes/imageGen.test.js routes/videoGen.test.js (server)
- npm test -- --run components/media/MediaLightbox.test.jsx components/media/MediaCard.test.jsx (client)
- npm run lint (client)