### PR TITLE
feat: add versioned POST benchmark battery (#4442)

### DIFF
--- a/client/src/components/meatspace/post/PostSessionLauncher.jsx
+++ b/client/src/components/meatspace/post/PostSessionLauncher.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router';
 import { Zap, History, Settings, Play, Brain, BookOpen, Dumbbell, Timer, Radio, Target, TrendingUp, TrendingDown, Minus, Compass, ArrowRight, ChevronRight, Layers } from 'lucide-react';
-import { getPostReviewReps, getPostRecommendations, getMorseProgress, getPostProgress, getMemoryItems, updatePostConfig } from '../../../services/api';
+import { getPostReviewReps, getPostRecommendations, getMorseProgress, getPostProgress, getPostBenchmarkProtocol, getMemoryItems, updatePostConfig } from '../../../services/api';
 import { FormField } from '../../ui/FormField';
 import Pill from '../../ui/Pill';
 import { enabledApiProviderFilter } from '../../../utils/providers';
@@ -123,6 +123,8 @@ export default function PostSessionLauncher({
   const [mode, setMode] = useState('test'); // 'test' | 'train'
   const [quickDurationMin, setQuickDurationMin] = useState(() => normalizeQuickDurationMinutes(config?.quickDurationMin));
   const [quickDurationSaveState, setQuickDurationSaveState] = useState('idle');
+  const [benchmarkState, setBenchmarkState] = useState('idle');
+  const [benchmarkError, setBenchmarkError] = useState(null);
 
   useEffect(() => {
     setQuickDurationMin(normalizeQuickDurationMinutes(config?.quickDurationMin));
@@ -446,6 +448,30 @@ export default function PostSessionLauncher({
       omittedReviews: quickPlan.omittedReviews,
       selectedTypes: quickPlan.selected.map(candidate => candidate.type),
     });
+  }
+
+  function handleBenchmarkSession() {
+    setBenchmarkState('loading');
+    setBenchmarkError(null);
+    getPostBenchmarkProtocol({ silent: true })
+      .then((protocol) => {
+        const form = protocol?.forms?.find(candidate => candidate.formId === protocol.nextFormId);
+        if (!form) throw new Error('No benchmark form is available');
+        const drillConfigs = form.tasks.map(task => ({
+          type: task.type,
+          domain: task.domain,
+          config: { ...task.config },
+          timeLimitSec: task.timeLimitSec,
+        }));
+        onStart(drillConfigs, buildCleanTags(tags), false, null, {
+          protocolId: protocol.protocolId,
+          protocolVersion: protocol.protocolVersion,
+          scorerVersion: protocol.scorerVersion,
+          formId: form.formId,
+        });
+      })
+      .catch(error => setBenchmarkError(error.message || 'Benchmark could not be loaded'))
+      .finally(() => setBenchmarkState('idle'));
   }
 
   // Build a full-length (non-abbreviated) drill config for a single enabled
@@ -786,6 +812,24 @@ export default function PostSessionLauncher({
                 {mode === 'train' ? 'Full Training' : 'Full POST'}
               </button>
             </div>
+
+            {mode === 'test' && (
+              <div className="border-t border-port-border pt-3 space-y-2">
+                <button
+                  type="button"
+                  onClick={handleBenchmarkSession}
+                  disabled={benchmarkState === 'loading'}
+                  className="w-full flex items-center justify-center gap-2 px-6 py-2.5 bg-port-card border border-port-accent text-port-accent hover:bg-port-accent/10 disabled:opacity-50 disabled:cursor-not-allowed font-medium rounded-lg transition-colors"
+                >
+                  <Target size={17} />
+                  {benchmarkState === 'loading' ? 'Loading Benchmark...' : 'Fixed Benchmark POST'}
+                </button>
+                <p className="text-xs text-gray-500">
+                  Versioned two-drill battery with alternating forms for comparable progress.
+                </p>
+                {benchmarkError && <p className="text-xs text-port-error">{benchmarkError}</p>}
+              </div>
+            )}
 
             {/* Mode toggle — compact, on the same card as the starts it governs */}
             <div className="flex items-center gap-2">

--- a/client/src/components/meatspace/post/PostSessionLauncher.test.jsx
+++ b/client/src/components/meatspace/post/PostSessionLauncher.test.jsx
@@ -20,13 +20,23 @@ vi.mock('../../../services/api', () => ({
   getMorseProgress: vi.fn().mockResolvedValue({ settings: { wpm: 18, farnsworthWpm: 12 } }),
   getPostProgress: vi.fn().mockResolvedValue({ series: { byDay: [] } }),
   getMemoryItems: vi.fn().mockResolvedValue([{ id: 'example-memory' }]),
+  getPostBenchmarkProtocol: vi.fn().mockResolvedValue({
+    protocolId: 'post-foundation-battery',
+    protocolVersion: 1,
+    scorerVersion: 'post-deterministic-v1',
+    nextFormId: 'a',
+    forms: [{ formId: 'a', tasks: [
+      { type: 'doubling-chain', domain: 'mental-math', config: { startValue: 5, steps: 8 }, timeLimitSec: 60 },
+      { type: 'task-switching', domain: 'cognitive', config: { seed: 'post-foundation-a', count: 12 }, timeLimitSec: 120 },
+    ] }],
+  }),
   updatePostConfig: vi.fn().mockResolvedValue({}),
   // useUserTimezone (via the today day key) reads getSettings; pin to UTC.
   getSettings: vi.fn().mockResolvedValue({ timezone: 'UTC' }),
 }));
 
 import PostSessionLauncher, { buildCleanTags, cognitiveSummary, interleaveByDomain } from './PostSessionLauncher';
-import { getPostRecommendations, getMorseProgress, getPostProgress, getPostReviewReps, getMemoryItems, updatePostConfig } from '../../../services/api';
+import { getPostRecommendations, getMorseProgress, getPostProgress, getPostReviewReps, getPostBenchmarkProtocol, getMemoryItems, updatePostConfig } from '../../../services/api';
 
 // Pure-function tests for PostSessionLauncher's pre-submit helpers (issue
 // #2102 gap #10). Both were lifted from component-body closures to module
@@ -163,6 +173,37 @@ describe('PostSessionLauncher render (issue #2100)', () => {
     getPostReviewReps.mockResolvedValue({ reps: [] });
     getMorseProgress.mockResolvedValue({ settings: { wpm: 18, farnsworthWpm: 12 } });
     getPostProgress.mockResolvedValue({ series: { byDay: [] } });
+    getPostBenchmarkProtocol.mockResolvedValue({
+      protocolId: 'post-foundation-battery',
+      protocolVersion: 1,
+      scorerVersion: 'post-deterministic-v1',
+      nextFormId: 'a',
+      forms: [{ formId: 'a', tasks: [
+        { type: 'doubling-chain', domain: 'mental-math', config: { startValue: 5, steps: 8 }, timeLimitSec: 60 },
+        { type: 'task-switching', domain: 'cognitive', config: { seed: 'post-foundation-a', count: 12 }, timeLimitSec: 120 },
+      ] }],
+    });
+  });
+
+  it('starts the next fixed benchmark form with versioned metadata', async () => {
+    const onStart = vi.fn();
+    renderLauncher({ onStart });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Fixed Benchmark POST' }));
+
+    await waitFor(() => expect(onStart).toHaveBeenCalledTimes(1));
+    expect(getPostBenchmarkProtocol).toHaveBeenCalledWith({ silent: true });
+    expect(onStart.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ type: 'doubling-chain', config: { startValue: 5, steps: 8 } }),
+      expect.objectContaining({ type: 'task-switching', config: { seed: 'post-foundation-a', count: 12 } }),
+    ]);
+    expect(onStart.mock.calls[0][2]).toBe(false);
+    expect(onStart.mock.calls[0][4]).toEqual({
+      protocolId: 'post-foundation-battery',
+      protocolVersion: 1,
+      scorerVersion: 'post-deterministic-v1',
+      formId: 'a',
+    });
   });
 
   it('renders the "Up next" panel with working deep links', async () => {

--- a/client/src/components/meatspace/post/PostSessionResults.jsx
+++ b/client/src/components/meatspace/post/PostSessionResults.jsx
@@ -3,7 +3,7 @@ import PostSessionSummary from './PostSessionSummary';
 import PostCompletionActions from './PostCompletionActions';
 
 export default function PostSessionResults({ session, tags = {}, onSaved, onBack }) {
-  const { drillResults, sessionScore, state, saveSession, isTraining, sessionPlan, savedSession } = session;
+  const { drillResults, sessionScore, state, saveSession, isTraining, sessionPlan, benchmark, savedSession } = session;
 
   async function handleSave(continueDaily) {
     const savedSession = await saveSession(tags);
@@ -19,6 +19,12 @@ export default function PostSessionResults({ session, tags = {}, onSaved, onBack
         plan={sessionPlan}
         actualDurationMs={savedSession?.actualDurationMs}
       />
+
+      {benchmark && (
+        <p className="text-center text-xs text-gray-500">
+          Fixed benchmark · form {benchmark.formId.toUpperCase()} · protocol v{benchmark.protocolVersion}
+        </p>
+      )}
 
       {/* Every completed assessment offers the same explicit daily-routine fork. */}
       {state === 'complete' && (

--- a/client/src/components/meatspace/tabs/PostTab.jsx
+++ b/client/src/components/meatspace/tabs/PostTab.jsx
@@ -87,8 +87,8 @@ export default function PostTab({ tab = 'launcher', subtab, mode }) {
     setStatsWeek(stWeek);
   }
 
-  async function handleStart(drillConfigs, tags, training = false, sessionPlan = null) {
-    const started = await session.startSession(drillConfigs, training, tags || {}, sessionPlan);
+  async function handleStart(drillConfigs, tags, training = false, sessionPlan = null, benchmark = null) {
+    const started = await session.startSession(drillConfigs, training, tags || {}, sessionPlan, benchmark);
     if (started) navigate('/post/session/run');
   }
 

--- a/client/src/hooks/usePostSession.js
+++ b/client/src/hooks/usePostSession.js
@@ -174,6 +174,7 @@ export function usePostSession() {
   const [runId, setRunId] = useState(restored?.runId ?? null);
   const [tags, setTags] = useState(restored?.tags ?? {}); // session tags captured at launch
   const [sessionPlan, setSessionPlan] = useState(restored?.sessionPlan ?? null);
+  const [benchmark, setBenchmark] = useState(restored?.benchmark ?? null);
   const [lastAnswer, setLastAnswer] = useState(null); // { correct, expected, answered } for training feedback
   // Seed the timing refs from the restored snapshot so a mid-drill refresh keeps
   // measuring elapsed time from the ORIGINAL question/drill start — otherwise the
@@ -204,6 +205,7 @@ export function usePostSession() {
     sessionStorage.setItem(RUN_STORAGE_KEY, JSON.stringify({
       runId, state, drills, currentDrillIndex, currentDrill, currentQuestionIndex,
       answers, drillResults, sessionScore, isTraining, tags, sessionPlan,
+      benchmark,
       // Persist the timing anchors (mutated synchronously on each question/drill
       // transition, just before the state change that fires this effect) so a
       // refresh resumes the clock instead of restarting it.
@@ -212,9 +214,9 @@ export function usePostSession() {
       runStartedAt: runStartedAtRef.current,
       runCompletedAt: runCompletedAtRef.current,
     }));
-  }, [runId, state, drills, currentDrillIndex, currentDrill, currentQuestionIndex, answers, drillResults, sessionScore, isTraining, tags, sessionPlan]);
+  }, [runId, state, drills, currentDrillIndex, currentDrill, currentQuestionIndex, answers, drillResults, sessionScore, isTraining, tags, sessionPlan, benchmark]);
 
-  const startSession = useCallback(async (drillConfigs, training = false, sessionTags = {}, plan = null) => {
+  const startSession = useCallback(async (drillConfigs, training = false, sessionTags = {}, plan = null, benchmarkMetadata = null) => {
     // drillConfigs: [{ type, config, timeLimitSec }]
     if (!drillConfigs?.length) {
       toast.error('No drills configured');
@@ -223,6 +225,7 @@ export function usePostSession() {
     setState(STATES.LOADING);
     setIsTraining(training);
     setSessionPlan(plan || null);
+    setBenchmark(training ? null : benchmarkMetadata || null);
     setDrills(drillConfigs);
     setCurrentDrillIndex(0);
     setDrillResults([]);
@@ -592,6 +595,7 @@ export function usePostSession() {
       tags: finalTags,
       startedAt: new Date(runStartedAtRef.current).toISOString(),
       ...(sessionPlan ? { plan: sessionPlan } : {}),
+      ...(benchmark ? { benchmark } : {}),
     }, { silent: true }).catch(err => {
       toast.error(`Failed to save session: ${err.message}`);
       setState(STATES.COMPLETE);
@@ -610,7 +614,7 @@ export function usePostSession() {
     toast.success(`POST complete — score: ${session.score}`);
     setState(STATES.SAVED);
     return session;
-  }, [drillResults, isTraining, tags, runId, sessionPlan]);
+  }, [drillResults, isTraining, tags, runId, sessionPlan, benchmark]);
 
   const reset = useCallback(() => {
     setState(STATES.IDLE);
@@ -628,6 +632,7 @@ export function usePostSession() {
     runCompletedAtRef.current = null;
     setTags({});
     setSessionPlan(null);
+    setBenchmark(null);
     setLastAnswer(null);
     clearRunSnapshot();
   }, []);
@@ -646,6 +651,7 @@ export function usePostSession() {
     isTraining,
     runId,
     sessionPlan,
+    benchmark,
     lastAnswer,
     startSession,
     submitAnswer,

--- a/client/src/services/apiMeatspace.js
+++ b/client/src/services/apiMeatspace.js
@@ -174,6 +174,7 @@ export const removeEyeExam = (index) => request(`/meatspace/eyes/${index}`, {
 
 // MeatSpace - POST (Power On Self Test)
 export const getPostConfig = () => request('/meatspace/post/config');
+export const getPostBenchmarkProtocol = (options = {}) => request('/meatspace/post/benchmark/protocol', options);
 // `options` lets a caller that owns its own error UI pass `{ silent: true }` so
 // the failure only toasts once (see CLAUDE.md's silent-vs-toasting convention).
 export const updatePostConfig = (data, options = {}) => request('/meatspace/post/config', {

--- a/server/lib/postValidation.js
+++ b/server/lib/postValidation.js
@@ -286,6 +286,16 @@ export const postQuickSessionPlanSchema = z.object({
   selectedTypes: z.array(z.string().max(100)).max(50),
 });
 
+// A benchmark is a versioned, fixed-form assessment. It is deliberately
+// separate from the adaptive/Quick plan so benchmark history remains
+// comparable even when a user's normal POST configuration changes.
+export const postBenchmarkSchema = z.object({
+  protocolId: z.string().trim().min(1).max(100),
+  protocolVersion: z.number().int().min(1).max(100),
+  scorerVersion: z.string().trim().min(1).max(100),
+  formId: z.string().trim().min(1).max(100),
+});
+
 export const postSessionSubmitSchema = z.object({
   // Client-generated session id (uuid) — keys the idempotent upsert in
   // submitPostSession so a retry after a dropped response can't double-record.
@@ -298,6 +308,7 @@ export const postSessionSubmitSchema = z.object({
   tags: postTagsSchema.optional().default({}),
   startedAt: z.string().datetime().optional(),
   plan: postQuickSessionPlanSchema.optional(),
+  benchmark: postBenchmarkSchema.optional(),
 });
 
 // LLM drill type configuration

--- a/server/lib/postValidation.test.js
+++ b/server/lib/postValidation.test.js
@@ -14,8 +14,37 @@ import {
   POST_SUPPORTED_MEMORY_TYPES,
   POST_QUICK_DURATION_MINUTES,
   postQuickSessionPlanSchema,
+  postBenchmarkSchema,
 } from './postValidation.js';
 import { getTopic, POST_TOPICS } from './postTopics.js';
+
+describe('postBenchmarkSchema', () => {
+  it('accepts versioned benchmark metadata', () => {
+    expect(postBenchmarkSchema.parse({
+      protocolId: 'post-foundation-battery',
+      protocolVersion: 1,
+      scorerVersion: 'post-deterministic-v1',
+      formId: 'a',
+    })).toEqual({
+      protocolId: 'post-foundation-battery',
+      protocolVersion: 1,
+      scorerVersion: 'post-deterministic-v1',
+      formId: 'a',
+    });
+  });
+
+  it('keeps benchmark metadata optional for legacy sessions', () => {
+    expect(postSessionSubmitSchema.parse({
+      modules: ['mental-math'],
+      tasks: [{
+        module: 'mental-math',
+        type: 'doubling-chain',
+        questions: [{ prompt: '2 x 2', expected: 4, answered: 4, responseMs: 100 }],
+        totalMs: 100,
+      }],
+    }).benchmark).toBeUndefined();
+  });
+});
 
 describe('postConfigUpdateSchema llmDrills', () => {
   // Regression: the config UI (PostDrillConfig.jsx) exposed only 5 of the 14

--- a/server/routes/meatspacePostRoutes.js
+++ b/server/routes/meatspacePostRoutes.js
@@ -71,6 +71,15 @@ router.put('/post/config', asyncHandler(async (req, res) => {
 }));
 
 /**
+ * GET /api/meatspace/post/benchmark/protocol
+ * The next fixed-form benchmark and its versioned scoring contract.
+ */
+router.get('/post/benchmark/protocol', asyncHandler(async (req, res) => {
+  const protocol = await postService.getPostBenchmarkProtocol();
+  res.json(protocol);
+}));
+
+/**
  * GET /api/meatspace/post/sessions
  * Session history with optional date range
  */

--- a/server/services/meatspacePost.js
+++ b/server/services/meatspacePost.js
@@ -53,6 +53,7 @@ import { getMorseProgress, MAX_KOCH_LEVEL } from './meatspacePostMorse.js';
 import { computePostStreaks, computeUnifiedStreak, normalizeYmd, recordDayKey, withDerivedDayKeys, ymdToUTC, ymdShift } from '../lib/postStreak.js';
 import { getUserTimezone, todayInTimezone, userLocalToday as localToday } from '../lib/timezone.js';
 import { getStoredPostSession, listPostSessions, saveStoredPostSession } from './postRunStore.js';
+import { ServerError } from '../lib/errorHandler.js';
 
 // Re-export the shared streak helper so existing importers of
 // `computePostStreaks` from this module keep working after it moved to
@@ -80,6 +81,74 @@ const CONFIG_FILE = join(MEATSPACE_DIR, 'post-config.json');
 // or future caller gets slice-specific side effects "for free", instead of
 // each route handler having to remember to bolt one on (#2015).
 export const postConfigEvents = new EventEmitter();
+
+// The first fixed benchmark battery is intentionally small and deterministic:
+// one seeded arithmetic drill plus one seeded executive-control drill. It is a
+// protocol, not a projection of the user's adaptive configuration, so later
+// forms can be added without changing the meaning of an existing result.
+export const POST_BENCHMARK_PROTOCOL = Object.freeze({
+  protocolId: 'post-foundation-battery',
+  protocolVersion: 1,
+  scorerVersion: 'post-deterministic-v1',
+  forms: Object.freeze([
+    Object.freeze({
+      formId: 'a',
+      tasks: Object.freeze([
+        Object.freeze({ type: 'doubling-chain', domain: 'mental-math', config: Object.freeze({ startValue: 5, steps: 8 }), timeLimitSec: 60 }),
+        Object.freeze({ type: 'task-switching', domain: 'cognitive', config: Object.freeze({ seed: 'post-foundation-a', count: 12, ruleCount: 2, switchRatePct: 50, cueStimulusIntervalMs: 700, incongruentPct: 50, responseDeadlineMs: 2200 }) }),
+      ]),
+    }),
+    Object.freeze({
+      formId: 'b',
+      tasks: Object.freeze([
+        Object.freeze({ type: 'doubling-chain', domain: 'mental-math', config: Object.freeze({ startValue: 7, steps: 8 }), timeLimitSec: 60 }),
+        Object.freeze({ type: 'task-switching', domain: 'cognitive', config: Object.freeze({ seed: 'post-foundation-b', count: 12, ruleCount: 2, switchRatePct: 50, cueStimulusIntervalMs: 700, incongruentPct: 50, responseDeadlineMs: 2200 }) }),
+      ]),
+    }),
+  ]),
+});
+
+const cloneBenchmarkProtocol = (protocol) => JSON.parse(JSON.stringify(protocol));
+
+export function getPostBenchmarkForm(formId) {
+  return POST_BENCHMARK_PROTOCOL.forms.find((form) => form.formId === formId) || null;
+}
+
+export async function getPostBenchmarkProtocol() {
+  const sessions = await getPostSessions();
+  const formIds = new Set(sessions
+    .filter((session) => session?.benchmark?.protocolId === POST_BENCHMARK_PROTOCOL.protocolId)
+    .slice(-POST_BENCHMARK_PROTOCOL.forms.length)
+    .map((session) => session.benchmark.formId));
+  const nextForm = POST_BENCHMARK_PROTOCOL.forms.find((form) => !formIds.has(form.formId))
+    || POST_BENCHMARK_PROTOCOL.forms[0];
+  return { ...cloneBenchmarkProtocol(POST_BENCHMARK_PROTOCOL), nextFormId: nextForm.formId };
+}
+
+function assertBenchmarkSession(benchmark, tasks, modules) {
+  if (!benchmark) return;
+  const form = benchmark.protocolId === POST_BENCHMARK_PROTOCOL.protocolId
+    && benchmark.protocolVersion === POST_BENCHMARK_PROTOCOL.protocolVersion
+    && benchmark.scorerVersion === POST_BENCHMARK_PROTOCOL.scorerVersion
+    ? getPostBenchmarkForm(benchmark.formId)
+    : null;
+  const expectedModules = form ? [...new Set(form.tasks.map((task) => task.domain))] : [];
+  const modulesMatch = expectedModules.length === modules.length
+    && expectedModules.every((module) => modules.includes(module));
+  const tasksMatch = form
+    && tasks.length === form.tasks.length
+    && form.tasks.every((expected, index) => {
+      const actual = tasks[index];
+      return actual?.type === expected.type
+        && Object.entries(expected.config).every(([key, value]) => actual.config?.[key] === value);
+    });
+  if (!form || !modulesMatch || !tasksMatch) {
+    throw new ServerError('Benchmark session does not match its registered protocol form', {
+      status: 400,
+      code: 'INVALID_BENCHMARK',
+    });
+  }
+}
 
 const DEFAULT_CONFIG = {
   mentalMath: {
@@ -322,6 +391,7 @@ export async function submitPostSession(sessionData) {
   // metrics) can't persist stale client-sent values that stats aggregation
   // would then prefer over a questions[] derivation.
   const rawTasks = Array.isArray(sessionData.tasks) ? sessionData.tasks : [];
+  assertBenchmarkSession(sessionData.benchmark, rawTasks, sessionData.modules);
   const rescoredTasks = rawTasks.map(t => {
     const {
       score: _score, correct: _correct,
@@ -428,6 +498,7 @@ export async function submitPostSession(sessionData) {
     score: computeSessionScore(rescoredTasks, config.scoring?.weights),
     tags: sessionData.tags || {},
     ...(sessionData.plan ? { plan: sessionData.plan } : {}),
+    ...(sessionData.benchmark ? { benchmark: sessionData.benchmark } : {}),
   };
 
   const stored = await saveStoredPostSession(session);

--- a/server/services/meatspacePost.test.js
+++ b/server/services/meatspacePost.test.js
@@ -56,12 +56,51 @@ import {
   generateDrill,
   getSessionSkillContext,
   getPostReviewReps,
+  getPostBenchmarkProtocol,
 } from './meatspacePost.js';
 
 describe('Quick POST config', () => {
   it('defaults a new install to the five-minute preset', async () => {
     const config = await getPostConfig();
     expect(config.quickDurationMin).toBe(5);
+  });
+});
+
+describe('Fixed POST benchmark protocol', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readJSONFile.mockImplementation((path, defaultValue) => Promise.resolve(defaultValue));
+  });
+
+  it('returns the first form when no benchmark has been completed', async () => {
+    const protocol = await getPostBenchmarkProtocol();
+    expect(protocol).toMatchObject({
+      protocolId: 'post-foundation-battery',
+      protocolVersion: 1,
+      scorerVersion: 'post-deterministic-v1',
+      nextFormId: 'a',
+    });
+    expect(protocol.forms).toHaveLength(2);
+    expect(protocol.forms[0].tasks).toHaveLength(2);
+  });
+
+  it('rejects a benchmark submission whose task config was changed', async () => {
+    await expect(submitPostSession({
+      modules: ['mental-math'],
+      tasks: [{
+        module: 'mental-math',
+        type: 'doubling-chain',
+        config: { startValue: 999, steps: 1 },
+        questions: [{ prompt: '999 x 2', expected: 1998, answered: 1998, responseMs: 500 }],
+        totalMs: 500,
+      }],
+      benchmark: {
+        protocolId: 'post-foundation-battery',
+        protocolVersion: 1,
+        scorerVersion: 'post-deterministic-v1',
+        formId: 'a',
+      },
+    })).rejects.toMatchObject({ code: 'INVALID_BENCHMARK', status: 400 });
   });
 });
 


### PR DESCRIPTION
## Summary

- Add a versioned fixed-form POST benchmark protocol with alternating deterministic forms.
- Add a benchmark launcher action that starts the registered battery independently of adaptive user configuration.
- Persist benchmark metadata with scored sessions and reject task/configuration mutations at the server boundary.

## Test plan

- `npm test -- --run src/components/meatspace/post/PostSessionLauncher.test.jsx src/components/meatspace/post/PostSessionResults.test.jsx src/components/meatspace/tabs/PostTab.test.jsx src/components/meatspace/tabs/PostTab.continueRoutine.test.jsx`
- `npm test -- --run lib/postValidation.test.js services/meatspacePost.test.js`
- `npx biome lint --error-on-warnings` on changed client and server files

## Remaining

- Additional benchmark protocols/forms, benchmark trend reporting, broader condition metadata, and the rest of the benchmark battery requested by the parent issue remain for follow-up work.

Refs #4442
