### PR TITLE
feat: add OrcaRouter provider and OpenCode wrappers (#4521)

### DIFF
--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -1149,7 +1149,7 @@ function ProviderForm({ provider, onClose, onSave, allProviders = [], runnerAllo
                 <p className="text-xs text-gray-500 mt-1">
                   This field is the only place API providers read a key from — it's stored on this
                   provider and sent as an <code>Authorization: Bearer</code> header on every request.
-                  No environment variable is involved. Hosted APIs (Cerebras, Grok, NVIDIA, …) require
+                  No environment variable is involved. Hosted APIs (Cerebras, Grok, NVIDIA, OrcaRouter, …) require
                   one; local backends (Ollama, LM Studio) don't.
                 </p>
               </FormField>

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -853,7 +853,8 @@ describe('supportsModelRefresh', () => {
       'claude-code-bedrock', 'claude-ollama', 'claude-ollama-tui', 'cursor-cli',
       'cursor-tui', 'grok', 'lmstudio', 'mtplx', 'nvidia-kimi', 'ollama',
       'opencode-mtplx', 'opencode-mtplx-tui', 'opencode-ollama',
-      'opencode-ollama-tui',
+      'opencode-ollama-tui', 'opencode-orcarouter', 'opencode-orcarouter-tui',
+      'orcarouter',
     ]);
   });
 });

--- a/data.reference/providers.json
+++ b/data.reference/providers.json
@@ -230,6 +230,59 @@
       "secretEnvVars": [],
       "tuiPromptDelayMs": 2500
     },
+    "orcarouter": {
+      "id": "orcarouter",
+      "name": "OrcaRouter",
+      "type": "api",
+      "endpoint": "https://api.orcarouter.ai/v1",
+      "apiKey": "",
+      "models": ["orcarouter/auto"],
+      "defaultModel": "orcarouter/auto",
+      "lightModel": "orcarouter/auto",
+      "mediumModel": "orcarouter/auto",
+      "heavyModel": "orcarouter/auto",
+      "timeout": 300000,
+      "enabled": false,
+      "envVars": {},
+      "secretEnvVars": []
+    },
+    "opencode-orcarouter": {
+      "id": "opencode-orcarouter",
+      "name": "OpenCode OrcaRouter",
+      "type": "cli",
+      "command": "opencode",
+      "args": ["run"],
+      "endpoint": "https://api.orcarouter.ai/v1",
+      "models": ["orcarouter/auto"],
+      "defaultModel": "orcarouter/auto",
+      "orcarouterBacked": true,
+      "timeout": 600000,
+      "enabled": false,
+      "envVars": {
+        "OPENCODE_CONFIG_CONTENT": "{\"permission\":\"allow\",\"provider\":{\"orcarouter\":{\"npm\":\"@ai-sdk/openai-compatible\",\"name\":\"OrcaRouter\",\"options\":{\"baseURL\":\"https://api.orcarouter.ai/v1\"}}}}"
+      },
+      "secretEnvVars": [],
+      "headlessArgs": []
+    },
+    "opencode-orcarouter-tui": {
+      "id": "opencode-orcarouter-tui",
+      "name": "OpenCode OrcaRouter TUI",
+      "type": "tui",
+      "command": "opencode",
+      "args": [],
+      "endpoint": "https://api.orcarouter.ai/v1",
+      "models": ["orcarouter/auto"],
+      "defaultModel": "orcarouter/auto",
+      "orcarouterBacked": true,
+      "timeout": 600000,
+      "enabled": false,
+      "envVars": {
+        "OPENCODE_CONFIG_CONTENT": "{\"permission\":\"allow\",\"provider\":{\"orcarouter\":{\"npm\":\"@ai-sdk/openai-compatible\",\"name\":\"OrcaRouter\",\"options\":{\"baseURL\":\"https://api.orcarouter.ai/v1\"}}}}"
+      },
+      "secretEnvVars": [],
+      "tuiPromptDelayMs": 2500,
+      "tuiIdleTimeoutMs": 180000
+    },
     "antigravity-tui": {
       "id": "antigravity-tui",
       "name": "Antigravity TUI",

--- a/scripts/migrations/278-orcarouter-providers.js
+++ b/scripts/migrations/278-orcarouter-providers.js
@@ -1,0 +1,73 @@
+/**
+ * Ship disabled OrcaRouter API and OpenCode presets to existing installs.
+ *
+ * OrcaRouter is an OpenAI-compatible gateway. The API provider owns the key;
+ * the OpenCode wrappers keep their static config keyless and resolve the
+ * sibling API key only when spawning or refreshing models. This migration is
+ * additive and never contacts the gateway or changes the active provider.
+ *
+ * Kept in lockstep with data.reference/providers.json and
+ * server/lib/aiToolkit/defaults/providers.sample.json. Later default changes
+ * require a new migration.
+ */
+
+import { makeProviderSeedMigration } from './_lib.js';
+
+const OPENCODE_CONFIG_CONTENT = '{"permission":"allow","provider":{"orcarouter":{"npm":"@ai-sdk/openai-compatible","name":"OrcaRouter","options":{"baseURL":"https://api.orcarouter.ai/v1"}}}}';
+
+const ORCAROUTER_API = {
+  id: 'orcarouter',
+  name: 'OrcaRouter',
+  type: 'api',
+  endpoint: 'https://api.orcarouter.ai/v1',
+  apiKey: '',
+  models: ['orcarouter/auto'],
+  defaultModel: 'orcarouter/auto',
+  lightModel: 'orcarouter/auto',
+  mediumModel: 'orcarouter/auto',
+  heavyModel: 'orcarouter/auto',
+  timeout: 300000,
+  enabled: false,
+  envVars: {},
+  secretEnvVars: [],
+};
+
+const OPENCODE_ORCAROUTER_CLI = {
+  id: 'opencode-orcarouter',
+  name: 'OpenCode OrcaRouter',
+  type: 'cli',
+  command: 'opencode',
+  args: ['run'],
+  endpoint: 'https://api.orcarouter.ai/v1',
+  models: ['orcarouter/auto'],
+  defaultModel: 'orcarouter/auto',
+  orcarouterBacked: true,
+  timeout: 600000,
+  enabled: false,
+  envVars: { OPENCODE_CONFIG_CONTENT },
+  secretEnvVars: [],
+  headlessArgs: [],
+};
+
+const OPENCODE_ORCAROUTER_TUI = {
+  id: 'opencode-orcarouter-tui',
+  name: 'OpenCode OrcaRouter TUI',
+  type: 'tui',
+  command: 'opencode',
+  args: [],
+  endpoint: 'https://api.orcarouter.ai/v1',
+  models: ['orcarouter/auto'],
+  defaultModel: 'orcarouter/auto',
+  orcarouterBacked: true,
+  timeout: 600000,
+  enabled: false,
+  envVars: { OPENCODE_CONFIG_CONTENT },
+  secretEnvVars: [],
+  tuiPromptDelayMs: 2500,
+  tuiIdleTimeoutMs: 180000,
+};
+
+export default makeProviderSeedMigration({
+  label: 'OrcaRouter',
+  defs: [ORCAROUTER_API, OPENCODE_ORCAROUTER_CLI, OPENCODE_ORCAROUTER_TUI],
+});

--- a/scripts/migrations/278-orcarouter-providers.test.js
+++ b/scripts/migrations/278-orcarouter-providers.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import migration from './278-orcarouter-providers.js';
+
+const writeJson = (path, value) => writeFileSync(path, JSON.stringify(value, null, 2) + '\n');
+const readJson = (path) => JSON.parse(readFileSync(path, 'utf-8'));
+
+describe('migration 278 — OrcaRouter providers', () => {
+  let rootDir;
+  let providersPath;
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'migration-278-'));
+    mkdirSync(join(rootDir, 'data'), { recursive: true });
+    providersPath = join(rootDir, 'data/providers.json');
+  });
+
+  afterEach(() => rmSync(rootDir, { recursive: true, force: true }));
+
+  it('adds disabled presets without changing the active provider', async () => {
+    writeJson(providersPath, {
+      activeProvider: 'claude-code',
+      providers: { 'claude-code': { id: 'claude-code', type: 'cli', command: 'claude' } },
+    });
+
+    await migration.up({ rootDir });
+    const out = readJson(providersPath);
+    const api = out.providers.orcarouter;
+    const cli = out.providers['opencode-orcarouter'];
+    const tui = out.providers['opencode-orcarouter-tui'];
+
+    expect(api).toMatchObject({
+      endpoint: 'https://api.orcarouter.ai/v1',
+      apiKey: '',
+      models: ['orcarouter/auto'],
+      enabled: false,
+    });
+    expect(cli).toMatchObject({ type: 'cli', orcarouterBacked: true, enabled: false });
+    expect(tui).toMatchObject({ type: 'tui', orcarouterBacked: true, enabled: false, tuiIdleTimeoutMs: 180000 });
+    expect(JSON.parse(cli.envVars.OPENCODE_CONFIG_CONTENT).provider.orcarouter.options.apiKey).toBeUndefined();
+    expect(JSON.parse(tui.envVars.OPENCODE_CONFIG_CONTENT).provider.orcarouter.options.apiKey).toBeUndefined();
+    expect(out.activeProvider).toBe('claude-code');
+  });
+
+  it('preserves an existing OrcaRouter API key and custom provider', async () => {
+    const existing = { id: 'orcarouter', name: 'My Orca', type: 'api', apiKey: 'sk-orca-example', enabled: true };
+    writeJson(providersPath, { providers: { orcarouter: existing } });
+
+    await migration.up({ rootDir });
+    expect(readJson(providersPath).providers.orcarouter).toEqual(existing);
+  });
+});

--- a/server/lib/aiToolkit/defaults/providers.sample.json
+++ b/server/lib/aiToolkit/defaults/providers.sample.json
@@ -150,6 +150,59 @@
       "secretEnvVars": [],
       "tuiPromptDelayMs": 2500
     },
+    "orcarouter": {
+      "id": "orcarouter",
+      "name": "OrcaRouter",
+      "type": "api",
+      "endpoint": "https://api.orcarouter.ai/v1",
+      "apiKey": "",
+      "models": ["orcarouter/auto"],
+      "defaultModel": "orcarouter/auto",
+      "lightModel": "orcarouter/auto",
+      "mediumModel": "orcarouter/auto",
+      "heavyModel": "orcarouter/auto",
+      "timeout": 300000,
+      "enabled": false,
+      "envVars": {},
+      "secretEnvVars": []
+    },
+    "opencode-orcarouter": {
+      "id": "opencode-orcarouter",
+      "name": "OpenCode OrcaRouter",
+      "type": "cli",
+      "command": "opencode",
+      "args": ["run"],
+      "endpoint": "https://api.orcarouter.ai/v1",
+      "models": ["orcarouter/auto"],
+      "defaultModel": "orcarouter/auto",
+      "orcarouterBacked": true,
+      "timeout": 600000,
+      "enabled": false,
+      "envVars": {
+        "OPENCODE_CONFIG_CONTENT": "{\"permission\":\"allow\",\"provider\":{\"orcarouter\":{\"npm\":\"@ai-sdk/openai-compatible\",\"name\":\"OrcaRouter\",\"options\":{\"baseURL\":\"https://api.orcarouter.ai/v1\"}}}}"
+      },
+      "secretEnvVars": [],
+      "headlessArgs": []
+    },
+    "opencode-orcarouter-tui": {
+      "id": "opencode-orcarouter-tui",
+      "name": "OpenCode OrcaRouter TUI",
+      "type": "tui",
+      "command": "opencode",
+      "args": [],
+      "endpoint": "https://api.orcarouter.ai/v1",
+      "models": ["orcarouter/auto"],
+      "defaultModel": "orcarouter/auto",
+      "orcarouterBacked": true,
+      "timeout": 600000,
+      "enabled": false,
+      "envVars": {
+        "OPENCODE_CONFIG_CONTENT": "{\"permission\":\"allow\",\"provider\":{\"orcarouter\":{\"npm\":\"@ai-sdk/openai-compatible\",\"name\":\"OrcaRouter\",\"options\":{\"baseURL\":\"https://api.orcarouter.ai/v1\"}}}}"
+      },
+      "secretEnvVars": [],
+      "tuiPromptDelayMs": 2500,
+      "tuiIdleTimeoutMs": 180000
+    },
     "codex": {
       "id": "codex",
       "name": "Codex CLI",

--- a/server/lib/aiToolkit/internal/endpointGuard.js
+++ b/server/lib/aiToolkit/internal/endpointGuard.js
@@ -63,6 +63,7 @@ const ALLOWED_PROVIDER_HOSTS = new Set([
   'api.cohere.com',
   'api.fireworks.ai',
   'api.cerebras.ai',
+  'api.orcarouter.ai',
   'integrate.api.nvidia.com', // NVIDIA NIM (bundled `nvidia-kimi` provider)
 ]);
 

--- a/server/lib/aiToolkit/internal/endpointGuard.test.js
+++ b/server/lib/aiToolkit/internal/endpointGuard.test.js
@@ -84,6 +84,9 @@ describe('endpointGuard — evaluateSecretEndpoint', () => {
     it('allows the bundled NVIDIA NIM host without opt-in', () => {
       expect(evaluateSecretEndpoint('https://integrate.api.nvidia.com/v1').allowed).toBe(true);
     });
+    it('allows the bundled OrcaRouter host without opt-in', () => {
+      expect(evaluateSecretEndpoint('https://api.orcarouter.ai/v1').allowed).toBe(true);
+    });
   });
 
   describe('arbitrary public hosts require explicit opt-in', () => {
@@ -124,6 +127,9 @@ describe('endpointGuard — assertSecretEndpoint', () => {
   });
   it('does not throw for the Cerebras host with a secret', () => {
     expect(() => assertSecretEndpoint('https://api.cerebras.ai/v1', { hasSecret: true })).not.toThrow();
+  });
+  it('does not throw for the OrcaRouter host with a secret', () => {
+    expect(() => assertSecretEndpoint('https://api.orcarouter.ai/v1', { hasSecret: true })).not.toThrow();
   });
   it('does not throw for loopback with a secret', () => {
     expect(() => assertSecretEndpoint('http://127.0.0.1:1234/v1', { hasSecret: true })).not.toThrow();

--- a/server/lib/aiToolkit/internal/modelFetchers.js
+++ b/server/lib/aiToolkit/internal/modelFetchers.js
@@ -71,6 +71,14 @@ export const MODEL_FETCHERS = [
     fetch: '_fetchMtplxModels',
   },
   {
+    key: 'orcarouter',
+    // OrcaRouter-backed OpenCode wrappers probe the sibling API provider's
+    // OpenAI-compatible `/models` endpoint, never `opencode models`.
+    cliMatch: (p) => p?.orcarouterBacked === true,
+    tuiMatch: (p) => p?.orcarouterBacked === true,
+    fetch: '_fetchOrcaRouterModels',
+  },
+  {
     key: 'cursor',
     // No `cliNameMatch` on purpose — see the column notes above.
     cliMatch: (p) => isCursorCommand(p?.command),

--- a/server/lib/aiToolkit/internal/modelFetchers.test.js
+++ b/server/lib/aiToolkit/internal/modelFetchers.test.js
@@ -19,6 +19,7 @@ const SHIPPED_REFRESHABLE = [
   'claude-code-bedrock', 'claude-ollama', 'claude-ollama-tui', 'cursor-cli',
   'cursor-tui', 'grok', 'lmstudio', 'mtplx', 'nvidia-kimi', 'ollama',
   'opencode-mtplx', 'opencode-mtplx-tui', 'opencode-ollama', 'opencode-ollama-tui',
+  'opencode-orcarouter', 'opencode-orcarouter-tui', 'orcarouter',
 ];
 const SHIPPED_NOT_REFRESHABLE = [
   'claude-code-tui', 'claude-code-tui-bedrock', 'codex', 'codex-tui',

--- a/server/lib/aiToolkit/providers.js
+++ b/server/lib/aiToolkit/providers.js
@@ -39,6 +39,22 @@ export { canRefreshModels };
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_SAMPLE_PATH = join(__dirname, 'defaults/providers.sample.json');
 
+// OpenCode OrcaRouter wrappers intentionally keep no key in their persisted
+// record. Attach the sibling API key only to execution-time copies, and make
+// the property non-enumerable so provider responses and provider writes cannot
+// accidentally expose or persist it.
+function withOrcaRouterApiKey(provider, providers) {
+  const siblingKey = providers?.orcarouter?.apiKey;
+  if (provider?.orcarouterBacked !== true || provider.apiKey || !siblingKey) return provider;
+  const executionProvider = { ...provider };
+  Object.defineProperty(executionProvider, 'apiKey', {
+    value: siblingKey,
+    enumerable: false,
+    configurable: true,
+  });
+  return executionProvider;
+}
+
 // Extensions Windows can launch directly, checked in cmd.exe's own resolution
 // preference. Deliberately excludes an extension-less match — npm ships a
 // POSIX shell-script stub alongside a package's `.cmd`/`.bat`/`.ps1` Windows
@@ -504,13 +520,15 @@ export function createProviderService(config = {}) {
 
     async getProviderById(id) {
       const data = await loadProviders();
-      return data.providers[id] || null;
+      const provider = data.providers[id];
+      return provider ? withOrcaRouterApiKey(provider, data.providers) : null;
     },
 
     async getActiveProvider() {
       const data = await loadProviders();
       if (!data.activeProvider) return null;
-      return data.providers[data.activeProvider] || null;
+      const provider = data.providers[data.activeProvider];
+      return provider ? withOrcaRouterApiKey(provider, data.providers) : null;
     },
 
     async setActiveProvider(id) {
@@ -560,6 +578,7 @@ export function createProviderService(config = {}) {
         // backend. Preserve this marker so OpenCode receives the `mtplx/`
         // namespace and model refresh probes its local endpoint.
         ...(providerData.mtplxBacked === true ? { mtplxBacked: true } : {}),
+        ...(providerData.orcarouterBacked === true ? { orcarouterBacked: true } : {}),
         // Explicit opt-in to send the API key to an arbitrary (non-local,
         // non-allowlisted) endpoint — see internal/endpointGuard.js. Only
         // persisted when true so existing keyless/local providers stay clean.
@@ -567,7 +586,8 @@ export function createProviderService(config = {}) {
         envVars: providerData.envVars || {},
         secretEnvVars: providerData.secretEnvVars || [],
         headlessArgs: providerData.headlessArgs || [],
-        tuiPromptDelayMs: providerData.tuiPromptDelayMs || 2500
+        tuiPromptDelayMs: providerData.tuiPromptDelayMs || 2500,
+        ...(providerData.tuiIdleTimeoutMs != null ? { tuiIdleTimeoutMs: providerData.tuiIdleTimeoutMs } : {})
       };
 
       data.providers[id] = provider;
@@ -618,7 +638,7 @@ export function createProviderService(config = {}) {
 
     async testProvider(id) {
       const data = await loadProviders();
-      const provider = data.providers[id];
+      const provider = withOrcaRouterApiKey(data.providers[id], data.providers);
 
       if (!provider) {
         return { success: false, error: 'Provider not found' };
@@ -752,7 +772,7 @@ export function createProviderService(config = {}) {
      */
     async fetchProviderModels(id) {
       const data = await loadProviders();
-      const provider = data.providers[id];
+      const provider = withOrcaRouterApiKey(data.providers[id], data.providers);
 
       if (!provider) {
         return null;
@@ -1040,6 +1060,11 @@ export function createProviderService(config = {}) {
      * @returns {Promise<string[]>}
      */
     async _fetchMtplxModels(provider) {
+      return this._refreshAPIProviderModels(provider);
+    },
+
+    /** Fetch the OrcaRouter catalog for its OpenCode CLI/TUI wrappers. */
+    async _fetchOrcaRouterModels(provider) {
       return this._refreshAPIProviderModels(provider);
     },
 

--- a/server/lib/aiToolkit/providers.test.js
+++ b/server/lib/aiToolkit/providers.test.js
@@ -1217,6 +1217,52 @@ describe('Provider Service', () => {
     });
   });
 
+  describe('OrcaRouter model refresh and sibling-key resolution', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('uses the sibling API key for OpenCode CLI/TUI model refresh without persisting it on wrappers', async () => {
+      const fetchSpy = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ id: 'orcarouter/auto' }, { id: 'anthropic/claude-sonnet-4.6' }] }),
+      });
+      vi.stubGlobal('fetch', fetchSpy);
+
+      await providerService.createProvider({
+        id: 'orcarouter',
+        name: 'OrcaRouter',
+        type: 'api',
+        endpoint: 'https://api.orcarouter.ai/v1',
+        apiKey: 'sk-orca-example',
+      });
+      const wrapper = await providerService.createProvider({
+        id: 'opencode-orcarouter',
+        name: 'OpenCode OrcaRouter',
+        type: 'cli',
+        command: 'opencode',
+        endpoint: 'https://api.orcarouter.ai/v1',
+        orcarouterBacked: true,
+        models: ['orcarouter/auto'],
+      });
+
+      const resolved = await providerService.getProviderById(wrapper.id);
+      expect(resolved.apiKey).toBe('sk-orca-example');
+      expect(Object.keys(resolved)).not.toContain('apiKey');
+
+      const updated = await providerService.refreshProviderModels(wrapper.id);
+      expect(updated.models).toEqual(['orcarouter/auto', 'anthropic/claude-sonnet-4.6']);
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'https://api.orcarouter.ai/v1/models',
+        expect.objectContaining({ headers: { Authorization: 'Bearer sk-orca-example' } }),
+      );
+
+      const stored = (await providerService.getAllProviders()).providers.find(p => p.id === wrapper.id);
+      expect(stored.apiKey).toBe('');
+      expect(stored.models).toEqual(['orcarouter/auto', 'anthropic/claude-sonnet-4.6']);
+    });
+  });
+
   describe('_refreshAPIProviderModels — network layer', () => {
     afterEach(() => {
       vi.unstubAllGlobals();

--- a/server/lib/aiToolkit/validation.js
+++ b/server/lib/aiToolkit/validation.js
@@ -104,6 +104,10 @@ export const providerSchema = z.object({
   // server. This is intentionally distinct from `ollamaBacked`: model weights
   // and runtime protocol configuration are not interchangeable.
   mtplxBacked: z.boolean().optional(),
+  // Marks an OpenCode CLI/TUI wrapper for the OrcaRouter OpenAI-compatible
+  // gateway. Its API key is read from the sibling `orcarouter` API record at
+  // spawn/refresh time and is never stored in this wrapper's config.
+  orcarouterBacked: z.boolean().optional(),
   // Explicit opt-in to attach the provider's API key to an arbitrary
   // (non-local, non-allowlisted) endpoint. Guards against SSRF / key
   // exfiltration to a hostile or mistyped host — see
@@ -112,7 +116,8 @@ export const providerSchema = z.object({
   envVars: z.record(z.string()).optional(),
   secretEnvVars: z.array(z.string()).optional(),
   headlessArgs: z.array(z.string()).optional(),
-  tuiPromptDelayMs: z.number().int().min(250).max(60000).optional()
+  tuiPromptDelayMs: z.number().int().min(250).max(60000).optional(),
+  tuiIdleTimeoutMs: z.number().int().min(1000).max(86400000).optional()
 });
 
 // PUT /api/providers/active — set the active provider by id. Constrain to the

--- a/server/lib/aiToolkit/validation.test.js
+++ b/server/lib/aiToolkit/validation.test.js
@@ -76,6 +76,11 @@ describe('providerSchema', () => {
     expect(providerSchema.safeParse({ ...minimalProvider, mtplxBacked: 'true' }).success).toBe(false);
   });
 
+  it('accepts the explicit OrcaRouter marker and rejects a non-boolean value', () => {
+    expect(providerSchema.safeParse({ ...minimalProvider, orcarouterBacked: true }).success).toBe(true);
+    expect(providerSchema.safeParse({ ...minimalProvider, orcarouterBacked: 'true' }).success).toBe(false);
+  });
+
   describe('endpoint empty-string/null → undefined coercion', () => {
     it('coerces endpoint: "" to undefined so the URL check is skipped for CLI providers', () => {
       const r = providerSchema.safeParse({ ...minimalProvider, endpoint: '' });

--- a/server/lib/cliChildEnv.js
+++ b/server/lib/cliChildEnv.js
@@ -75,7 +75,7 @@ function claudeOllamaEnvDefaults(provider) {
  * @param {object} options
  * @param {object|null} [options.before] - layered first, so `provider.envVars`
  *   overrides it (forgeTokenEnv, claudeSettingsEnv).
- * @param {{command?:string, envVars?:object, models?:string[], defaultModel?:string|null, ollamaBacked?:boolean, mtplxBacked?:boolean, thinking?:boolean}|null} [options.provider]
+ * @param {{command?:string, envVars?:object, models?:string[], defaultModel?:string|null, ollamaBacked?:boolean, mtplxBacked?:boolean, orcarouterBacked?:boolean, thinking?:boolean}|null} [options.provider]
  * @param {string|null} [options.model] - the model being run this invocation,
  *   unioned into the OpenCode declared-models map. Omit when the site has no
  *   per-call model — `provider.defaultModel` is always declared regardless.

--- a/server/lib/opencodeConfig.js
+++ b/server/lib/opencodeConfig.js
@@ -36,6 +36,11 @@ const OPENCODE_LOCAL_BASE_PROVIDERS = {
     name: 'MTPLX (local MTP)',
     options: { baseURL: 'http://127.0.0.1:8000/v1' },
   },
+  orcarouter: {
+    npm: '@ai-sdk/openai-compatible',
+    name: 'OrcaRouter',
+    options: { baseURL: 'https://api.orcarouter.ai/v1' },
+  },
 };
 
 const localProviderBase = (providerKey) => {
@@ -49,6 +54,7 @@ const localProviderBase = (providerKey) => {
 // config `models` map. Idempotent for an already-bare id. A slash-bearing model
 // id (`hf.co/user/model:tag`) retains every slash after the leading namespace.
 const stripProviderPrefix = (id, providerKey) =>
+  providerKey === 'orcarouter' ? id :
   typeof id === 'string' && id.startsWith(`${providerKey}/`)
     ? id.slice(providerKey.length + 1)
     : id;
@@ -57,7 +63,7 @@ const stripProviderPrefix = (id, providerKey) =>
  * Normalize an id or list of ids to the unique, non-empty, prefix-stripped bare
  * model ids that key the OpenCode `models` map.
  * @param {string|string[]|null|undefined} models
- * @param {'ollama'|'mtplx'} [providerKey='ollama']
+ * @param {'ollama'|'mtplx'|'orcarouter'} [providerKey='ollama']
  * @returns {string[]}
  */
 export function toBareModelIds(models, providerKey = 'ollama') {
@@ -86,7 +92,7 @@ export function toBareModelIds(models, providerKey = 'ollama') {
  *
  * @param {string|string[]|null|undefined} models
  * @param {object|null} [base] - existing config to merge into (a fresh clone is made)
- * @param {'ollama'|'mtplx'} [providerKey='ollama']
+ * @param {'ollama'|'mtplx'|'orcarouter'} [providerKey='ollama']
  * @returns {object} OpenCode config object
  */
 export function buildOpencodeConfig(models, base = null, providerKey = 'ollama', generation = null) {
@@ -151,8 +157,8 @@ export function buildOpencodeConfigContent(models, base = null, providerKey = 'o
 
 /**
  * Build dynamic env vars for an OpenCode local-provider spawn. Returns an
- * object with `OPENCODE_CONFIG_CONTENT` (models map declared) for Ollama- or
- * MTPLX-backed OpenCode providers, otherwise an empty object (caller keeps
+ * object with `OPENCODE_CONFIG_CONTENT` (models map declared) for Ollama-,
+ * MTPLX-, or OrcaRouter-backed OpenCode providers, otherwise an empty object (caller keeps
  * existing env).
  *
  * The provider's already-stored `OPENCODE_CONFIG_CONTENT` is used as the base and
@@ -162,7 +168,7 @@ export function buildOpencodeConfigContent(models, base = null, providerKey = 'o
  * model, and the model being run this invocation — so whichever namespaced
  * `--model` the spawner passes is always accepted.
  *
- * @param {{command?:string, ollamaBacked?:boolean, mtplxBacked?:boolean, models?:string[], defaultModel?:string|null, envVars?:object}} provider
+ * @param {{command?:string, ollamaBacked?:boolean, mtplxBacked?:boolean, orcarouterBacked?:boolean, models?:string[], defaultModel?:string|null, apiKey?:string, orcarouterApiKey?:string, envVars?:object}} provider
  * @param {string|null|undefined} model - the model being run (may differ from defaultModel)
  * @returns {{OPENCODE_CONFIG_CONTENT?: string}} env vars to merge
  */
@@ -188,7 +194,16 @@ export function buildOpencodeEnvVars(provider, model) {
     provider?.defaultModel,
     model,
   ];
+  const config = buildOpencodeConfig(ids, base, providerKey, provider);
+  const apiKey = providerKey === 'orcarouter' ? (provider?.apiKey || provider?.orcarouterApiKey) : null;
+  if (apiKey) {
+    config.provider.orcarouter.options = {
+      ...config.provider.orcarouter.options,
+      apiKey,
+    };
+  }
   return {
-    OPENCODE_CONFIG_CONTENT: buildOpencodeConfigContent(ids, base, providerKey, provider),
+    OPENCODE_CONFIG_CONTENT: JSON.stringify(config),
+    ...(apiKey ? { ORCAROUTER_API_KEY: apiKey } : {}),
   };
 }

--- a/server/lib/opencodeConfig.test.js
+++ b/server/lib/opencodeConfig.test.js
@@ -25,7 +25,7 @@ describe('toBareModelIds', () => {
       .toEqual(['mtplx', 'qwen/model']);
   });
 
-  it('keeps OrcaRouter vendor ids unchanged for its provider models map', () => {
+  it('keeps OrcaRouter stored ids unchanged for the models map', () => {
     expect(toBareModelIds(['orcarouter/auto', 'anthropic/claude-sonnet-4.6'], 'orcarouter'))
       .toEqual(['orcarouter/auto', 'anthropic/claude-sonnet-4.6']);
   });
@@ -61,19 +61,6 @@ describe('buildOpencodeConfig', () => {
     const cfg = buildOpencodeConfig(['ollama/qwen2.5:7b', 'llama3.1:8b']);
     expect(Object.keys(cfg.provider.ollama.models).sort()).toEqual(['llama3.1:8b', 'qwen2.5:7b']);
     expect(cfg.provider.ollama.models['qwen2.5:7b']).toEqual({ name: 'qwen2.5:7b', tool_call: true });
-  });
-
-  it('declares OrcaRouter stored ids under the orcarouter provider', () => {
-    const cfg = buildOpencodeConfig(['orcarouter/auto', 'anthropic/claude-sonnet-4.6'], null, 'orcarouter');
-    expect(cfg.provider.orcarouter).toMatchObject({
-      npm: '@ai-sdk/openai-compatible',
-      name: 'OrcaRouter',
-      options: { baseURL: 'https://api.orcarouter.ai/v1' },
-    });
-    expect(Object.keys(cfg.provider.orcarouter.models).sort()).toEqual([
-      'anthropic/claude-sonnet-4.6',
-      'orcarouter/auto',
-    ]);
   });
 
   it('preserves a slash-bearing bare model id', () => {
@@ -114,6 +101,18 @@ describe('buildOpencodeConfig', () => {
     expect(cfg.provider.mtplx.models).toEqual({
       mtplx: { name: 'mtplx', tool_call: true },
     });
+  });
+
+  it('declares OrcaRouter models under unchanged keys and its gateway endpoint', () => {
+    const cfg = buildOpencodeConfig(['orcarouter/auto', 'anthropic/claude-sonnet-4.6'], null, 'orcarouter');
+    expect(cfg.provider.orcarouter).toMatchObject({
+      npm: '@ai-sdk/openai-compatible',
+      name: 'OrcaRouter',
+      options: { baseURL: 'https://api.orcarouter.ai/v1' },
+    });
+    expect(Object.keys(cfg.provider.orcarouter.models).sort()).toEqual([
+      'anthropic/claude-sonnet-4.6', 'orcarouter/auto',
+    ]);
   });
 });
 
@@ -171,23 +170,23 @@ describe('buildOpencodeEnvVars', () => {
     expect(cfg.provider.mtplx.models.mtplx).toEqual({ name: 'mtplx', tool_call: true });
   });
 
-  it('injects the OrcaRouter sibling key only into the dynamic spawn config', () => {
+  it('injects the sibling OrcaRouter API key only into the composed spawn config', () => {
+    const storedConfig = JSON.stringify({
+      permission: 'allow',
+      provider: { orcarouter: { npm: '@ai-sdk/openai-compatible', options: { baseURL: 'https://api.orcarouter.ai/v1' } } },
+    });
     const result = buildOpencodeEnvVars({
       command: 'opencode',
       orcarouterBacked: true,
-      apiKey: 'sk-orca-example',
       models: ['orcarouter/auto'],
-      envVars: {
-        OPENCODE_CONFIG_CONTENT: JSON.stringify({
-          permission: 'allow',
-          provider: { orcarouter: { options: { baseURL: 'https://api.orcarouter.ai/v1' } } },
-        }),
-      },
+      envVars: { OPENCODE_CONFIG_CONTENT: storedConfig },
+      orcarouterApiKey: 'sk-orca-example',
     }, 'orcarouter/auto');
     const cfg = JSON.parse(result.OPENCODE_CONFIG_CONTENT);
-    expect(cfg.provider.orcarouter.models['orcarouter/auto']).toBeDefined();
+    expect(cfg.provider.orcarouter.models['orcarouter/auto']).toEqual({ name: 'orcarouter/auto', tool_call: true });
     expect(cfg.provider.orcarouter.options.apiKey).toBe('sk-orca-example');
     expect(result.ORCAROUTER_API_KEY).toBe('sk-orca-example');
+    expect(storedConfig).not.toContain('sk-orca-example');
   });
 
   it('unions the provider models, defaultModel, and the run model (deduped, bare)', () => {

--- a/server/lib/opencodeConfig.test.js
+++ b/server/lib/opencodeConfig.test.js
@@ -25,6 +25,11 @@ describe('toBareModelIds', () => {
       .toEqual(['mtplx', 'qwen/model']);
   });
 
+  it('keeps OrcaRouter vendor ids unchanged for its provider models map', () => {
+    expect(toBareModelIds(['orcarouter/auto', 'anthropic/claude-sonnet-4.6'], 'orcarouter'))
+      .toEqual(['orcarouter/auto', 'anthropic/claude-sonnet-4.6']);
+  });
+
   it('rejects an unknown local provider key instead of silently using Ollama', () => {
     expect(() => toBareModelIds('model', 'unknown')).toThrow(/unsupported opencode local provider/i);
   });
@@ -56,6 +61,19 @@ describe('buildOpencodeConfig', () => {
     const cfg = buildOpencodeConfig(['ollama/qwen2.5:7b', 'llama3.1:8b']);
     expect(Object.keys(cfg.provider.ollama.models).sort()).toEqual(['llama3.1:8b', 'qwen2.5:7b']);
     expect(cfg.provider.ollama.models['qwen2.5:7b']).toEqual({ name: 'qwen2.5:7b', tool_call: true });
+  });
+
+  it('declares OrcaRouter stored ids under the orcarouter provider', () => {
+    const cfg = buildOpencodeConfig(['orcarouter/auto', 'anthropic/claude-sonnet-4.6'], null, 'orcarouter');
+    expect(cfg.provider.orcarouter).toMatchObject({
+      npm: '@ai-sdk/openai-compatible',
+      name: 'OrcaRouter',
+      options: { baseURL: 'https://api.orcarouter.ai/v1' },
+    });
+    expect(Object.keys(cfg.provider.orcarouter.models).sort()).toEqual([
+      'anthropic/claude-sonnet-4.6',
+      'orcarouter/auto',
+    ]);
   });
 
   it('preserves a slash-bearing bare model id', () => {
@@ -151,6 +169,25 @@ describe('buildOpencodeEnvVars', () => {
     const cfg = JSON.parse(result.OPENCODE_CONFIG_CONTENT);
     expect(cfg.provider.mtplx.options.baseURL).toBe('http://127.0.0.1:8000/v1');
     expect(cfg.provider.mtplx.models.mtplx).toEqual({ name: 'mtplx', tool_call: true });
+  });
+
+  it('injects the OrcaRouter sibling key only into the dynamic spawn config', () => {
+    const result = buildOpencodeEnvVars({
+      command: 'opencode',
+      orcarouterBacked: true,
+      apiKey: 'sk-orca-example',
+      models: ['orcarouter/auto'],
+      envVars: {
+        OPENCODE_CONFIG_CONTENT: JSON.stringify({
+          permission: 'allow',
+          provider: { orcarouter: { options: { baseURL: 'https://api.orcarouter.ai/v1' } } },
+        }),
+      },
+    }, 'orcarouter/auto');
+    const cfg = JSON.parse(result.OPENCODE_CONFIG_CONTENT);
+    expect(cfg.provider.orcarouter.models['orcarouter/auto']).toBeDefined();
+    expect(cfg.provider.orcarouter.options.apiKey).toBe('sk-orca-example');
+    expect(result.ORCAROUTER_API_KEY).toBe('sk-orca-example');
   });
 
   it('unions the provider models, defaultModel, and the run model (deduped, bare)', () => {

--- a/server/lib/providerModels.js
+++ b/server/lib/providerModels.js
@@ -455,7 +455,7 @@ export function isOpencodeCommand(command) {
  * already-qualified id (`openai/gpt-4o`, `anthropic/claude-sonnet`), and blindly
  * prefixing `ollama/` would route it to the wrong backend. No-op for
  * non-local / non-OpenCode providers and empty models.
- * @param {{command?:string, ollamaBacked?:boolean, mtplxBacked?:boolean}} provider
+ * @param {{command?:string, ollamaBacked?:boolean, mtplxBacked?:boolean, orcarouterBacked?:boolean}} provider
  * @param {string|null|undefined} model
  * @returns {string|null|undefined}
  */
@@ -463,6 +463,9 @@ export function prefixOpencodeModel(provider, model) {
   const namespace = getOpencodeLocalProviderNamespace(provider);
   if (!isOpencodeCommand(provider?.command) || !namespace || !model) return model;
   const id = String(model);
+  if (namespace === 'orcarouter') {
+    return id.startsWith('orcarouter/orcarouter/') ? id : `orcarouter/${id}`;
+  }
   return id.startsWith(`${namespace}/`) ? id : `${namespace}/${id}`;
 }
 
@@ -471,12 +474,13 @@ export function prefixOpencodeModel(provider, model) {
  * opted into one. Structural markers avoid deriving a backend from an editable
  * display name or endpoint and preserve the legacy Ollama outcome if a malformed
  * record carries both markers.
- * @param {{ollamaBacked?:boolean, mtplxBacked?:boolean}|null|undefined} provider
- * @returns {'ollama'|'mtplx'|null}
+ * @param {{ollamaBacked?:boolean, mtplxBacked?:boolean, orcarouterBacked?:boolean}|null|undefined} provider
+ * @returns {'ollama'|'mtplx'|'orcarouter'|null}
  */
 export function getOpencodeLocalProviderNamespace(provider) {
   if (provider?.ollamaBacked === true) return 'ollama';
   if (provider?.mtplxBacked === true) return 'mtplx';
+  if (provider?.orcarouterBacked === true) return 'orcarouter';
   return null;
 }
 

--- a/server/lib/providerModels.test.js
+++ b/server/lib/providerModels.test.js
@@ -139,6 +139,13 @@ describe('providerModels', () => {
       expect(prefixOpencodeModel(mtplx, 'mtplx/mtplx')).toBe('mtplx/mtplx');
     });
 
+    it('keeps the OrcaRouter stored id in the models map but double-prefixes the OpenCode argv id', () => {
+      const orca = { command: 'opencode', orcarouterBacked: true };
+      expect(prefixOpencodeModel(orca, 'orcarouter/auto')).toBe('orcarouter/orcarouter/auto');
+      expect(prefixOpencodeModel(orca, 'anthropic/claude-sonnet-4.6')).toBe('orcarouter/anthropic/claude-sonnet-4.6');
+      expect(prefixOpencodeModel(orca, 'orcarouter/orcarouter/auto')).toBe('orcarouter/orcarouter/auto');
+    });
+
     it('is idempotent — an already-namespaced id is returned unchanged', () => {
       expect(prefixOpencodeModel(oc, 'ollama/qwen2.5:7b')).toBe('ollama/qwen2.5:7b');
     });
@@ -171,6 +178,7 @@ describe('providerModels', () => {
     it('uses explicit markers and keeps Ollama as the malformed dual-marker fallback', () => {
       expect(getOpencodeLocalProviderNamespace({ ollamaBacked: true })).toBe('ollama');
       expect(getOpencodeLocalProviderNamespace({ mtplxBacked: true })).toBe('mtplx');
+      expect(getOpencodeLocalProviderNamespace({ orcarouterBacked: true })).toBe('orcarouter');
       expect(getOpencodeLocalProviderNamespace({ ollamaBacked: true, mtplxBacked: true })).toBe('ollama');
       expect(getOpencodeLocalProviderNamespace({})).toBeNull();
     });

--- a/server/lib/validation.js
+++ b/server/lib/validation.js
@@ -411,13 +411,17 @@ export const providerSchema = z.object({
   // Kept in schema parity with aiToolkit's provider schema. Marks OpenCode
   // wrappers for a separately started local MTPLX native-MTP server.
   mtplxBacked: z.boolean().optional(),
+  // Marks an OpenCode CLI/TUI wrapper for the OrcaRouter OpenAI-compatible
+  // gateway; the sibling API record owns its key.
+  orcarouterBacked: z.boolean().optional(),
   // Explicit opt-in to attach the API key to an arbitrary (non-local,
   // non-allowlisted) endpoint — mirrors the aiToolkit providerSchema. Guards
   // SSRF / key exfiltration (server/lib/aiToolkit/internal/endpointGuard.js).
   allowCustomEndpoint: z.boolean().optional(),
   envVars: z.record(z.string()).optional(),
   headlessArgs: z.array(z.string()).optional(),
-  tuiPromptDelayMs: z.number().int().min(250).max(60000).optional()
+  tuiPromptDelayMs: z.number().int().min(250).max(60000).optional(),
+  tuiIdleTimeoutMs: z.number().int().min(1000).max(86400000).optional()
 });
 
 // Run command schema


### PR DESCRIPTION
## Summary

- Add disabled OrcaRouter API, OpenCode CLI, and OpenCode TUI provider presets.
- Preserve stored OrcaRouter model IDs in OpenCode config while generating the required namespaced CLI model arguments.
- Resolve the sibling API key only for execution-time config/model refresh, allowlist the gateway, and add the migration, catalog refresh, and validation coverage.

## Test plan

- `server`: focused provider, OpenCode config, endpoint guard, model fetcher, validation, and migration tests (all passing).
- `client`: provider refresh utility test (passing).
- Biome lint and `git diff --check` (passing).

Closes #4521
