### PR TITLE
fix: recover stale chunks in route errors (#4525)

### DIFF
--- a/client/src/components/RouteErrorFallback.jsx
+++ b/client/src/components/RouteErrorFallback.jsx
@@ -1,6 +1,8 @@
 import { AlertTriangle } from 'lucide-react';
+import { useEffect } from 'react';
 import { useNavigate, useRouteError, isRouteErrorResponse } from 'react-router';
 import Banner from './ui/Banner';
+import { isStaleChunkError, reloadOnceForStaleChunk } from '../utils/staleChunkReload';
 
 const getErrorMessage = (error) => {
   if (isRouteErrorResponse(error)) return error.statusText || `Request failed (${error.status})`;
@@ -13,6 +15,10 @@ export default function RouteErrorFallback() {
   const error = useRouteError();
   const navigate = useNavigate();
   const message = getErrorMessage(error);
+
+  useEffect(() => {
+    if (isStaleChunkError(error)) reloadOnceForStaleChunk();
+  }, [error]);
 
   return (
     <div className="min-h-dvh-cap bg-port-bg flex items-center justify-center p-4">

--- a/client/src/components/RouteErrorFallback.test.jsx
+++ b/client/src/components/RouteErrorFallback.test.jsx
@@ -1,8 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { createMemoryRouter, Outlet, RouterProvider } from 'react-router';
 import RouteErrorFallback from './RouteErrorFallback';
+import { isStaleChunkError, reloadOnceForStaleChunk } from '../utils/staleChunkReload';
+
+vi.mock('../utils/staleChunkReload', () => ({
+  isStaleChunkError: vi.fn(),
+  reloadOnceForStaleChunk: vi.fn(),
+}));
 
 const renderRouteError = async (error) => {
   const router = createMemoryRouter([
@@ -30,6 +36,22 @@ const renderRouteError = async (error) => {
 };
 
 describe('RouteErrorFallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isStaleChunkError.mockReturnValue(false);
+  });
+
+  it('triggers stale-chunk recovery for a render-phase dynamic import failure', async () => {
+    const error = new Error('Failed to fetch dynamically imported module');
+    isStaleChunkError.mockReturnValue(true);
+    reloadOnceForStaleChunk.mockReturnValue(true);
+
+    await renderRouteError(error);
+
+    expect(isStaleChunkError).toHaveBeenCalledWith(error);
+    expect(reloadOnceForStaleChunk).toHaveBeenCalledOnce();
+  });
+
   it('explains that the page failed and offers recovery actions', async () => {
     await renderRouteError(new Error('Importing a module script failed'));
 


### PR DESCRIPTION
## Summary

- Complete the route-level error fallback's stale-chunk recovery path using the existing reload primitives.
- Trigger the build-aware one-shot reload for render-phase dynamic-import failures while preserving the friendly fallback for other route errors.
- Add regression coverage for stale-chunk detection and recovery invocation.

## Test plan

- `client`: `RouteErrorFallback`, `staleChunkReload`, and `lazyWithReload` tests (29 passing).
- Biome lint and `git diff --check` (passing).

The splat route's explicit `errorElement` is already present on `main` from commit `aa31e47cb`; this PR completes its missing stale-chunk behavior.

Closes #4525
