### PR TITLE
feat: unblock a blocked CoS task from its own card

### DIFF
--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -16,7 +16,8 @@ import {
   AlertCircle,
   TrendingUp,
   Play,
-  Scale
+  Scale,
+  Unlock
 } from 'lucide-react';
 import toast from '../../ui/Toast';
 import * as api from '../../../services/api';
@@ -160,16 +161,27 @@ export default function TaskItem({ task, isSystem, selected = false, onRefresh, 
     return null;
   }, [durations, task, task.status]);
 
-  const handleStatusChange = async (newStatus, blockedReasonText = '') => {
+  const handleStatusChange = async (newStatus, blockedReasonText = '', successMessage = `Task marked as ${newStatus}`) => {
     const updates = { status: newStatus, type: taskSource };
     if (newStatus === 'blocked' && blockedReasonText) {
       updates.blockedReason = blockedReasonText;
     }
     const result = await api.updateCosTask(task.id, updates, { silent: true }).catch(err => { toast.error(err.message); return null; });
     if (!result) return false;
-    toast.success(`Task marked as ${newStatus}`);
+    toast.success(successMessage);
     onRefresh();
     return true;
+  };
+
+  // Unblocking is the same status write the actionable-insights banner performs,
+  // offered here on the card itself so clearing a blocker doesn't require
+  // scrolling back to the banner at the top of the page. Gated while in flight so
+  // a double-click can't fire two writes.
+  const [unblocking, setUnblocking] = useState(false);
+  const handleUnblock = async () => {
+    setUnblocking(true);
+    await handleStatusChange('pending', '', 'Task unblocked and moved to pending');
+    setUnblocking(false);
   };
 
   const handleMarkBlocked = () => {
@@ -573,7 +585,7 @@ export default function TaskItem({ task, isSystem, selected = false, onRefresh, 
         {/* Action buttons. Keep the delete confirmation here, next to the trash
             icon, rather than at the bottom of the card — a task with a lot of
             context would otherwise push the confirm row far below the fold. */}
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 shrink-0">
           {!editing && (
             isConfirming(task.id) ? (
               <ConfirmButtonPair
@@ -597,6 +609,23 @@ export default function TaskItem({ task, isSystem, selected = false, onRefresh, 
                     aria-label="Process task now"
                   >
                     <Play size={14} aria-hidden="true" />
+                  </button>
+                )}
+                {/* Labeled, not icon-only: this is the primary next action for a
+                    blocked task, and the icon-only affordance (clicking the status
+                    glyph) wasn't discoverable — the user had to go find the banner
+                    at the top of the page instead. */}
+                {task.status === 'blocked' && (
+                  <button
+                    type="button"
+                    onClick={handleUnblock}
+                    disabled={unblocking}
+                    className="flex items-center gap-1 px-2 py-1 min-h-[32px] text-xs font-medium text-port-success bg-port-success/10 hover:bg-port-success/20 rounded transition-colors disabled:opacity-50"
+                    title="Unblock and move to pending"
+                    aria-label={`Unblock task ${task.id} and move it to pending`}
+                  >
+                    <Unlock size={12} aria-hidden="true" />
+                    {unblocking ? 'Unblocking…' : 'Unblock'}
                   </button>
                 )}
                 {task.status !== 'blocked' && task.status !== 'completed' && (

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -126,6 +126,52 @@ describe('TaskItem blocked reason', () => {
   });
 });
 
+describe('TaskItem unblock action', () => {
+  const blocked = {
+    id: 'sys-blocked-3',
+    description: 'Blocked task',
+    status: 'blocked',
+    metadata: { blockedReason: 'Max total spawns exceeded' },
+  };
+  const unblockButton = () =>
+    screen.getByRole('button', { name: `Unblock task ${blocked.id} and move it to pending` });
+
+  it('moves a blocked task to pending from the card itself', async () => {
+    const onRefresh = vi.fn();
+    render(<TaskItem task={blocked} isSystem onRefresh={onRefresh} providers={providers} />);
+
+    fireEvent.click(unblockButton());
+
+    await waitFor(() => expect(api.updateCosTask).toHaveBeenCalledWith(
+      'sys-blocked-3',
+      { status: 'pending', type: 'internal' },
+      { silent: true }
+    ));
+    await waitFor(() => expect(onRefresh).toHaveBeenCalled());
+    expect(toast.success).toHaveBeenCalledWith('Task unblocked and moved to pending');
+  });
+
+  it('is offered only on blocked tasks, and never alongside Mark as blocked', () => {
+    const { unmount } = render(<TaskItem task={blocked} isSystem onRefresh={vi.fn()} providers={providers} />);
+    expect(screen.queryByRole('button', { name: 'Mark task as blocked' })).not.toBeInTheDocument();
+    unmount();
+
+    render(<TaskItem task={task} isSystem onRefresh={vi.fn()} providers={providers} />);
+    expect(screen.queryByRole('button', { name: /^Unblock task/ })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Mark task as blocked' })).toBeInTheDocument();
+  });
+
+  it('re-enables the button when the update fails so the user can retry', async () => {
+    api.updateCosTask.mockRejectedValue(new Error('network down'));
+    render(<TaskItem task={blocked} isSystem onRefresh={vi.fn()} providers={providers} />);
+
+    fireEvent.click(unblockButton());
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('network down'));
+    expect(unblockButton()).not.toBeDisabled();
+  });
+});
+
 describe('TaskItem block modal state (#4038)', () => {
   const openBlockModal = () =>
     fireEvent.click(screen.getByRole('button', { name: 'Mark task as blocked' }));


### PR DESCRIPTION
## Summary

Blocked task cards in the Chief of Staff task list only offered unblocking through the small status glyph on the left of the card, which reads as decoration rather than a control. In practice the only discoverable path was scrolling up to the actionable-insights banner, expanding it, and clicking Unblock on each task there.

This adds a labeled **Unblock** button to the card's own action row whenever the task is blocked, performing the same status write the banner does (`PATCH` status → `pending`).

- Labeled rather than icon-only — it is the primary next action for a blocked task, and the icon-only affordance was exactly what wasn't being found.
- Shown only on blocked tasks; it takes the slot the "Mark as blocked" button vacates, so the action row never offers both.
- Gated while the write is in flight (`Unblocking…`, disabled) so a double-click can't fire two writes, matching the existing Approve and challenge-resolve buttons.
- `handleStatusChange` gained an optional success-message argument so the toast reads "Task unblocked and moved to pending" instead of the generic "Task marked as pending"; every existing call site keeps its previous message via the default.

The banner path is unchanged and still works.

## Test plan

- `cd client && npx vitest run src/components/cos` — 318 tests pass, including three new ones covering the button:
  - clicking it PATCHes `{ status: 'pending', type: 'internal' }`, refreshes, and toasts the unblock message
  - it renders only for blocked tasks, and never alongside "Mark as blocked"
  - it re-enables after a failed update so the user can retry
- `npx biome lint --error-on-warnings` clean on the changed files.