### PR TITLE
fix release-check Run Now sitting in awaiting-approve unless Require approval is on

### DIFF
--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -189,8 +189,9 @@ export const STATE_MESSAGES = {
   ideating: "Analyzing options...",
 };
 
-// Agent option toggles for task metadata (useWorktree, openPR, simplify).
+// Agent option toggles for task metadata (useWorktree, openPR, simplify, requireApproval).
 export const AGENT_OPTIONS = [
+  { field: 'requireApproval', label: 'Require approval', shortLabel: 'Apr', description: 'Queue as awaiting-approve and do not auto-run — including Run Now — until you approve. Off (default): Run Now starts immediately; scheduled runs still follow the confidence and safety gates.' },
   { field: 'useWorktree', label: 'Worktree', shortLabel: 'WT', description: 'Work in an isolated git worktree on a feature branch. If unchecked, commits directly to the default branch.' },
   { field: 'openPR', label: 'Open PR', shortLabel: 'PR', description: 'Open a pull request to the default branch (implies worktree). Choose whether PortOS reviews and merges it, merges on green CI, or leaves it open. If unchecked with worktree enabled, auto-merges to the default branch on completion.' },
   { field: 'simplify', label: 'Run /simplify', shortLabel: '/s', description: 'Review code for reuse and quality before committing' }

--- a/client/src/components/cos/tabs/TaskItem.jsx
+++ b/client/src/components/cos/tabs/TaskItem.jsx
@@ -47,7 +47,8 @@ const statusIcons = {
 // their own entries here rather than a parallel field.
 const APPROVAL_REASON_HINTS = {
   'investigation-loop:repeat-fingerprint': 'Held for you: this same failure cause was investigated within the last 24 hours and came back.',
-  'investigation-loop:failure-storm': 'Held for you: this hour is nearly out of investigation budget — failures are cascading, not isolated.'
+  'investigation-loop:failure-storm': 'Held for you: this hour is nearly out of investigation budget — failures are cascading, not isolated.',
+  'config:requireApproval': 'Held for you: this scheduled task type has Require approval turned on.'
 };
 
 const getTaskEditData = (task) => ({

--- a/client/src/components/cos/tabs/TaskItem.test.jsx
+++ b/client/src/components/cos/tabs/TaskItem.test.jsx
@@ -567,4 +567,15 @@ describe('TaskItem investigation approval hint (#3714)', () => {
     const approve = screen.getByRole('button', { name: 'Approve task sys-approve-plain' });
     expect(approve).not.toHaveAttribute('title');
   });
+
+  it('names the schedule Require approval toggle on the APPROVE button', () => {
+    const gated = {
+      ...held,
+      id: 'sys-require-approval',
+      metadata: { requireApproval: true, approvalReason: 'config:requireApproval' },
+    };
+    render(<TaskItem task={gated} isSystem onRefresh={vi.fn()} providers={providers} />);
+    const approve = screen.getByRole('button', { name: /^Approve task sys-require-approval — / });
+    expect(approve).toHaveAttribute('title', expect.stringContaining('Require approval'));
+  });
 });

--- a/client/src/components/cos/tabs/schedule/GlobalConfigControls.test.jsx
+++ b/client/src/components/cos/tabs/schedule/GlobalConfigControls.test.jsx
@@ -149,6 +149,27 @@ describe('GlobalConfigControls — branch-reconcile batch size', () => {
   });
 });
 
+describe('GlobalConfigControls — require approval', () => {
+  it('toggles requireApproval on the task metadata', () => {
+    const onUpdate = renderControls({ taskType: 'release-check', taskMetadata: { useWorktree: false, openPR: false } });
+    fireEvent.click(screen.getByRole('button', { name: /Require approval/i }));
+    expect(onUpdate).toHaveBeenCalledWith('release-check', {
+      taskMetadata: { useWorktree: false, openPR: false, requireApproval: true },
+    });
+  });
+
+  it('turns requireApproval off when it is already on', () => {
+    const onUpdate = renderControls({
+      taskType: 'release-check',
+      taskMetadata: { requireApproval: true },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Require approval/i }));
+    expect(onUpdate).toHaveBeenCalledWith('release-check', {
+      taskMetadata: { requireApproval: false },
+    });
+  });
+});
+
 describe('GlobalConfigControls — file issues only', () => {
   it('is hidden for non-audit tasks', () => {
     renderControls();

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -1415,7 +1415,11 @@ const ALLOWED_TASK_METADATA_KEYS = [
   'worktreeChangesExpected',
   // Audit-type toggle: file tracker issues (no code) vs implement the fix.
   // Dispatch stamps `noCodeOutput` when this is true. See server/lib/auditCatalog.js.
-  'fileIssues'
+  'fileIssues',
+  // Dispatch gate: when true, the generated system task is always awaiting-
+  // approve — including an explicit Run Now. Absent/false keeps the default
+  // (Run Now consents; unattended runs follow confidence/safety-kind).
+  'requireApproval'
 ];
 
 // pr-watcher author-gate values. 'self' = PRs opened by the gh-authenticated

--- a/server/lib/validation.test.js
+++ b/server/lib/validation.test.js
@@ -846,6 +846,12 @@ describe('validation.js', () => {
       expect(sanitizeTaskMetadata({ fileIssues: 'true' })).toBeNull();
     });
 
+    it('should accept requireApproval as an allowed boolean key', () => {
+      expect(sanitizeTaskMetadata({ requireApproval: true })).toEqual({ requireApproval: true });
+      expect(sanitizeTaskMetadata({ requireApproval: false })).toEqual({ requireApproval: false });
+      expect(sanitizeTaskMetadata({ requireApproval: 'true' })).toBeNull();
+    });
+
     it('should accept only known PR completion metadata', () => {
       expect(sanitizeTaskMetadata({ prCompletion: 'review-then-merge' }))
         .toEqual({ prCompletion: 'review-then-merge' });

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -110,6 +110,7 @@ import {
   queueEligibleImprovementTasks,
   generateSelfImprovementTaskForType,
   generateManagedAppImprovementTaskForType,
+  applyOnDemandConsent,
   emitOnDemandEmpty,
   blockIfExceedsMaxSpawns,
   selectDryRunAutoApproved,
@@ -911,6 +912,7 @@ async function spawnDequeuePriority0OnDemand(ctx) {
       task = await generateSelfImprovementTaskForType(request.taskType, state);
     }
 
+    applyOnDemandConsent(task);
     if (task && capacity.canSpawn(task)) {
       // Mark this as a MANUAL (on-demand) run so a completed perpetual drain
       // continues in the same user-initiated lane instead of the auto-run-gated

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -1055,6 +1055,7 @@ async function spawnPriority0OnDemand(ctx) {
         task = await generateSelfImprovementTaskForType(request.taskType, state);
       }
 
+      applyOnDemandConsent(task);
       if (task && canSpawnTask(task)) {
         // Mark this a MANUAL (on-demand) run so its perpetual drain continues in
         // the on-demand lane (see perpetualRefillPlan in cos.js). BOTH on-demand
@@ -1822,9 +1823,26 @@ export async function queueEligibleImprovementTasks(state, cosTaskData, { ignore
  * to spread into task objects — `safetyKind` + `approvalReason` surface WHY a
  * high-confidence task still needs approval on the task record and in the UI.
  */
+export function isConfiguredApprovalRequired(metadata) {
+  return metadata?.requireApproval === true;
+}
+
 async function resolveConfidenceApproval(state, taskTypeKey, logLabel, metadata = {}) {
   const safety = classifySafetyKind({ taskTypeKey, metadata });
   const safetyConfig = state?.config?.safetyKindApproval ?? {};
+
+  // Explicit per-type/per-app toggle wins over every automatic gate. The user
+  // turned "Require approval" on for this scheduled type; do not second-guess
+  // that with confidence or a Run Now consent flip.
+  if (isConfiguredApprovalRequired(metadata)) {
+    emitLog('info', `🔒 ${logLabel} requires approval (task metadata requireApproval)`, {}, '[Approval]');
+    return {
+      autoApproved: false,
+      approvalRequired: true,
+      safetyKind: safety.kind,
+      approvalReason: 'config:requireApproval'
+    };
+  }
 
   // Safety-kind override runs BEFORE (and independent of) the confidence gate.
   if (safety.outwardFacing && requiresSafetyApproval(safety.kind, safetyConfig)) {
@@ -1852,6 +1870,27 @@ async function resolveConfidenceApproval(state, taskTypeKey, logLabel, metadata 
     safetyKind: safety.kind,
     ...(confidence.autoApprove ? {} : { approvalReason: `confidence:${confidence.tier}` })
   };
+}
+
+/**
+ * Clicking Run (or a refill of that run) is the user's consent. Safety-kind
+ * and confidence gates exist so UNATTENDED queue-path work can't ship
+ * irreversible actions on its own — they must not re-hold a task the user
+ * just asked to run, or "Run Now" lands in awaiting-approve and never
+ * auto-spawns (Priority 2 only picks AUTO tasks; force-spawn refuses
+ * APPROVAL tasks).
+ *
+ * `metadata.requireApproval` is the escape hatch: a type the user marked
+ * "always ask" (e.g. release-check when they want to review the merge)
+ * keeps the hold even on Run Now.
+ */
+export function applyOnDemandConsent(task) {
+  if (!task) return task;
+  if (isConfiguredApprovalRequired(task.metadata)) return task;
+  task.approvalRequired = false;
+  task.autoApproved = true;
+  if ('approvalReason' in task) delete task.approvalReason;
+  return task;
 }
 
 /**
@@ -2093,7 +2132,11 @@ async function generateManagedAppImprovementTask(app, state, { ignoreTaskId = nu
   // with the literal {prData}/{referenceData} markers and never poll. The
   // recordExecution + activity bump above already accounted for the idle
   // spawn; the per-type generator does not record execution itself.
-  return generateManagedAppImprovementTaskForType(nextType, app, state, { ignoreTaskId });
+  const task = await generateManagedAppImprovementTaskForType(nextType, app, state, { ignoreTaskId });
+  // Idle-review can steal a queued on-demand request for this app. That
+  // request is still a user Run — apply the same consent as Priority 0.
+  if (selectionReason === 'on-demand') applyOnDemandConsent(task);
+  return task;
 }
 
 /**

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -1890,7 +1890,15 @@ export function applyOnDemandConsent(task) {
   task.approvalRequired = false;
   task.autoApproved = true;
   if ('approvalReason' in task) delete task.approvalReason;
+  // The hint TaskItem reads lives on metadata — COS-TASKS.md only persists
+  // that bag. Clear both so a consented Run Now does not keep a stale reason.
+  if (task.metadata && 'approvalReason' in task.metadata) delete task.metadata.approvalReason;
   return task;
+}
+
+function stampApprovalReason(metadata, approval) {
+  if (approval?.approvalReason) metadata.approvalReason = approval.approvalReason;
+  else delete metadata.approvalReason;
 }
 
 /**
@@ -1936,6 +1944,7 @@ export async function generateSelfImprovementTaskForType(taskType, state) {
   }
 
   const approval = await resolveConfidenceApproval(state, `self-improve:${taskType}`, `Task self-improve:${taskType}`, metadata);
+  stampApprovalReason(metadata, approval);
 
   const task = {
     id: `self-improve-${taskType}-${Date.now().toString(36)}`,
@@ -3055,6 +3064,7 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
   applyProviderModelPins(metadata, interval, hookOverride);
 
   const approval = await resolveConfidenceApproval(state, `app-improve:${taskType}`, `Task app-improve:${taskType} for ${app.name}`, metadata);
+  stampApprovalReason(metadata, approval);
 
   // All gates passed — stamp the buildTaskInput hook's metadata bag, record the
   // rotation-pointer advance, and emit the generation log. Deferred from the top

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -42,6 +42,8 @@ import {
   resolveSwarmBlock,
   isCooldownExemptTask,
   emitOnDemandEmpty,
+  applyOnDemandConsent,
+  isConfiguredApprovalRequired,
   recordPerpetualTransient,
   buildJiraTicketTask,
   buildImprovementDedupSets,
@@ -160,6 +162,92 @@ describe('both on-demand engines stamp metadata.onDemand', () => {
   it('dequeueNextTask engine (spawnDequeuePriority0OnDemand) stamps onDemand before addTask', () => {
     const engine = onDemandStamp(COS_SRC, 'async function spawnDequeuePriority0OnDemand');
     expect(/task\.metadata = \{ \.\.\.\(task\.metadata \|\| \{\}\), onDemand: true \}/.test(engine)).toBe(true);
+  });
+});
+
+describe('applyOnDemandConsent', () => {
+  it('flips an approval-gated task to AUTO and drops the hold reason', () => {
+    const task = {
+      approvalRequired: true,
+      autoApproved: false,
+      approvalReason: 'safety-kind:publish',
+      metadata: { analysisType: 'release-check' }
+    };
+    expect(applyOnDemandConsent(task)).toBe(task);
+    expect(task).toMatchObject({ approvalRequired: false, autoApproved: true });
+    expect(task.approvalReason).toBeUndefined();
+  });
+
+  it('leaves a requireApproval task gated so the schedule toggle still holds Run Now', () => {
+    const task = {
+      approvalRequired: true,
+      autoApproved: false,
+      approvalReason: 'config:requireApproval',
+      metadata: { analysisType: 'release-check', requireApproval: true }
+    };
+    applyOnDemandConsent(task);
+    expect(task).toMatchObject({
+      approvalRequired: true,
+      autoApproved: false,
+      approvalReason: 'config:requireApproval'
+    });
+  });
+
+  it('is a no-op on a missing task so callers can apply it unconditionally', () => {
+    expect(applyOnDemandConsent(null)).toBeNull();
+    expect(applyOnDemandConsent(undefined)).toBeUndefined();
+  });
+});
+
+describe('isConfiguredApprovalRequired', () => {
+  it('is true only for an explicit requireApproval: true', () => {
+    expect(isConfiguredApprovalRequired({ requireApproval: true })).toBe(true);
+    expect(isConfiguredApprovalRequired({ requireApproval: false })).toBe(false);
+    expect(isConfiguredApprovalRequired({ analysisType: 'release-check' })).toBe(false);
+    expect(isConfiguredApprovalRequired(undefined)).toBe(false);
+  });
+
+  it('resolveConfidenceApproval consults the toggle before safety-kind and confidence', () => {
+    const start = GEN_SRC.indexOf('async function resolveConfidenceApproval');
+    expect(start).toBeGreaterThan(-1);
+    const body = GEN_SRC.slice(start, start + 1800);
+    const configIdx = body.indexOf('isConfiguredApprovalRequired(metadata)');
+    const safetyIdx = body.indexOf('safety.outwardFacing && requiresSafetyApproval');
+    expect(configIdx).toBeGreaterThan(-1);
+    expect(safetyIdx).toBeGreaterThan(configIdx);
+    expect(body).toContain("approvalReason: 'config:requireApproval'");
+  });
+});
+
+describe('both on-demand engines apply consent before addTask', () => {
+  // Run Now is the user's sign-off. Without this flip, a safety-kind or
+  // low-confidence type (release-check used to match `\brelease\b`) is
+  // persisted as APPROVAL, Priority 2 will not pick it, and force-spawn
+  // refuses it — so "Run Now" sits in awaiting-approve forever.
+  const engineBody = (src, engineFn) => {
+    const start = src.indexOf(engineFn);
+    expect(start, `${engineFn} must exist`).toBeGreaterThan(-1);
+    const next = src.indexOf('\nasync function ', start + 1);
+    return src.slice(start, next === -1 ? src.length : next);
+  };
+
+  it('evaluateTasks engine consents before canSpawn / addTask', () => {
+    const engine = engineBody(GEN_SRC, 'async function spawnPriority0OnDemand');
+    expect(engine.indexOf('applyOnDemandConsent(task)')).toBeGreaterThan(-1);
+    expect(engine.indexOf('applyOnDemandConsent(task)')).toBeLessThan(engine.indexOf('canSpawnTask(task)'));
+  });
+
+  it('dequeueNextTask engine consents before canSpawn / addTask', () => {
+    const engine = engineBody(COS_SRC, 'async function spawnDequeuePriority0OnDemand');
+    expect(engine.indexOf('applyOnDemandConsent(task)')).toBeGreaterThan(-1);
+    expect(engine.indexOf('applyOnDemandConsent(task)')).toBeLessThan(engine.indexOf('capacity.canSpawn(task)'));
+  });
+
+  it('idle-review steal path consents when it drains an on-demand request', () => {
+    const start = GEN_SRC.indexOf('async function generateManagedAppImprovementTask(app, state');
+    expect(start).toBeGreaterThan(-1);
+    const body = GEN_SRC.slice(start, start + 3500);
+    expect(body).toMatch(/selectionReason === 'on-demand'\) applyOnDemandConsent\(task\)/);
   });
 });
 

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -171,11 +171,12 @@ describe('applyOnDemandConsent', () => {
       approvalRequired: true,
       autoApproved: false,
       approvalReason: 'safety-kind:publish',
-      metadata: { analysisType: 'release-check' }
+      metadata: { analysisType: 'release-check', approvalReason: 'safety-kind:publish' }
     };
     expect(applyOnDemandConsent(task)).toBe(task);
     expect(task).toMatchObject({ approvalRequired: false, autoApproved: true });
     expect(task.approvalReason).toBeUndefined();
+    expect(task.metadata.approvalReason).toBeUndefined();
   });
 
   it('leaves a requireApproval task gated so the schedule toggle still holds Run Now', () => {
@@ -205,6 +206,13 @@ describe('isConfiguredApprovalRequired', () => {
     expect(isConfiguredApprovalRequired({ requireApproval: false })).toBe(false);
     expect(isConfiguredApprovalRequired({ analysisType: 'release-check' })).toBe(false);
     expect(isConfiguredApprovalRequired(undefined)).toBe(false);
+  });
+
+  it('both generators stamp approvalReason onto metadata so the hint survives COS-TASKS.md', () => {
+    const selfStart = GEN_SRC.indexOf('export async function generateSelfImprovementTaskForType');
+    const appStart = GEN_SRC.indexOf('export async function generateManagedAppImprovementTaskForType');
+    expect(GEN_SRC.slice(selfStart, selfStart + 2500)).toContain('stampApprovalReason(metadata, approval)');
+    expect(GEN_SRC.slice(appStart, appStart + 9000)).toContain('stampApprovalReason(metadata, approval)');
   });
 
   it('resolveConfidenceApproval consults the toggle before safety-kind and confidence', () => {

--- a/server/services/taskLearning/safetyKind.js
+++ b/server/services/taskLearning/safetyKind.js
@@ -39,11 +39,17 @@ const OUTWARD_KIND_SET = new Set(OUTWARD_SAFETY_KINDS);
  * asks the user to review a task that may not have needed it (safe direction);
  * a false negative would auto-approve genuinely outward work (the dangerous one
  * this feature exists to prevent).
+ *
+ * Bare `\brelease\b` is intentionally NOT a publish signal. It matches
+ * `release-check` (a readiness coordinator the user clicks Run on) and
+ * `pre-release` (a check, not a ship). Shipping names still match via
+ * `\bpublish\b` (`publish-release`) or the explicit `cut/create/ship/do-release`
+ * forms below.
  */
 const KIND_SIGNATURES = [
   { kind: 'federation', re: /federat|peer[-\s]?sync|sync[-\s]?peer|fan[-\s]?out[-\s]?record/ },
   { kind: 'external-pr', re: /external[-\s]?pr|upstream[-\s]?pr|fork[-\s]?pr/ },
-  { kind: 'publish', re: /\bpublish\b|\bdeploy\b|\brelease\b|go[-\s]?live|auto[-\s]?send|outbound[-\s]?message/ },
+  { kind: 'publish', re: /\bpublish\b|\bdeploy\b|\b(cut|create|ship|do)[- ]release\b|go[-\s]?live|auto[-\s]?send|outbound[-\s]?message/ },
   { kind: 'content', re: /social[-\s]?media|newsletter|\bblog\b|generate[-\s]?content/ }
 ];
 

--- a/server/services/taskLearning/safetyKind.test.js
+++ b/server/services/taskLearning/safetyKind.test.js
@@ -58,8 +58,24 @@ describe('classifySafetyKind (#2440)', () => {
     expect(classifySafetyKind({ taskTypeKey: 'app-improve:federate-records' }).kind).toBe('federation');
     expect(classifySafetyKind({ taskTypeKey: 'open-upstream-pr' }).kind).toBe('external-pr');
     expect(classifySafetyKind({ taskTypeKey: 'publish-release' }).kind).toBe('publish');
+    expect(classifySafetyKind({ taskTypeKey: 'cut-release' }).kind).toBe('publish');
     expect(classifySafetyKind({ metadata: { taskDescription: 'Deploy the site to production' } }).kind).toBe('publish');
     expect(classifySafetyKind({ metadata: { taskDescription: 'Draft a social-media post' } }).kind).toBe('content');
+  });
+
+  it('does not treat release-check (or pre-release) as a publish action', () => {
+    // `\brelease\b` used to match `release-check` and force every Run Now into
+    // awaiting-approve. The type is a readiness coordinator, not a ship.
+    for (const input of [
+      { taskTypeKey: 'app-improve:release-check' },
+      { taskTypeKey: 'self-improve:release-check' },
+      { metadata: { analysisType: 'release-check' } },
+      { taskTypeKey: 'pre-release-audit' }
+    ]) {
+      const out = classifySafetyKind(input);
+      expect(out.kind).toBe(REVERSIBLE_SAFETY_KIND);
+      expect(out.outwardFacing).toBe(false);
+    }
   });
 
   it('all outward classifications set outwardFacing true; reversible sets false', () => {
@@ -123,6 +139,7 @@ describe('safety-kind override branch (#2440) — composed decision', () => {
 
   it('leaves reversible internal tasks to the confidence gate (no override)', () => {
     expect(wouldForceApproval({ taskTypeKey: 'self-improve:code-review' }, {})).toBe(false);
+    expect(wouldForceApproval({ taskTypeKey: 'app-improve:release-check' }, {})).toBe(false);
   });
 
   it('lets the user disable the safety override entirely', () => {


### PR DESCRIPTION
## Summary

Release-check Run Now was landing in the awaiting-approve queue instead of starting an agent. The safety-kind classifier treated the word `release` in `release-check` as a publish action, and Priority 2 never auto-spawns APPROVAL tasks.

This change:

- Stops matching bare `\brelease\b` as publish (shipping names still match via `publish` / `deploy` / `cut-release` and friends)
- Treats an explicit Run Now as consent, unless the type is marked to wait
- Adds a per-task **Require approval** toggle on the schedule card (and app overrides) so a release-check can still be gated when you want to review the merge first
- Persists the hold reason on task metadata so the Approve button can explain why it is waiting

## Test plan

- [x] `server`: `vitest` for `safetyKind`, `cosTaskGenerator`, `validation` (requireApproval sanitizer)
- [x] `client`: `GlobalConfigControls`, `TaskItem`, `AppOverrideRow`, `AutomationTab`
- [ ] CoS → Jobs → release-check → Run Now starts an agent (Require approval off)
- [ ] Turn **Require approval** on, Run Now again — task stays awaiting-approve until Approve
- [ ] Approve button tooltip names the schedule toggle
- [ ] Per-app override chip on the schedule row and app Automation tab flips independently