### PR TITLE
feat: add Cursor Agent to Code Review Defaults

### DIFF
--- a/client/src/components/cos/ReviewerPicker.jsx
+++ b/client/src/components/cos/ReviewerPicker.jsx
@@ -15,8 +15,9 @@ import {
   reviewerLabel,
   sanitizeReviewerModelInput
 } from './constants';
+import { normalizeReviewerSlug } from '../../lib/reviewerPins';
 
-const normalizeReviewerValue = (value) => value === 'gemini' ? 'antigravity' : value;
+const normalizeReviewerValue = (value) => normalizeReviewerSlug(value);
 
 /**
  * Ordered multi-reviewer picker, rendered as one row per reviewer with the five

--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -225,7 +225,7 @@ export function pinnedPrCompletion(metadata) {
 }
 
 // Reviewer choices for the Review Loop. `copilot` requests a GitHub Copilot
-// review via the native reviewer API; CLI reviewers (claude/antigravity/codex/grok)
+// review via the native reviewer API; CLI reviewers (claude/antigravity/codex/grok/cursor)
 // instruct the follow-up agent to invoke the named CLI; local-LLM reviewers
 // (lmstudio/ollama) route the diff through PortOS's `POST /api/code-review/local`
 // endpoint, which runs the model configured on the AI Providers → Code Review
@@ -237,6 +237,7 @@ export const REVIEWER_OPTIONS = [
   { value: 'antigravity', label: 'Antigravity', description: 'Antigravity CLI (agy) reviews the PR diff' },
   { value: 'codex', label: 'Codex', description: 'Codex CLI reviews the PR diff (optional model tier on AI Providers → Code Review Defaults)' },
   { value: 'grok', label: 'Grok', description: 'Grok Build CLI (grok) reviews the PR diff' },
+  { value: 'cursor', label: 'Cursor Agent', description: 'Cursor Agent CLI (cursor-agent) reviews the PR diff' },
   { value: 'lmstudio', label: 'LM Studio', description: 'Local LM Studio model reviews the diff (set model on AI Providers)' },
   { value: 'ollama', label: 'Ollama', description: 'Local Ollama model reviews the diff (set model on AI Providers)' }
 ];
@@ -378,7 +379,7 @@ export const DEFAULT_REVIEW_STOP_MODE = 'all';
 // server's normalizeReviewers): prefers `reviewers`, falls back to legacy
 // single `reviewer`, defaults to `['copilot']`.
 const REVIEWER_VALUES = REVIEWER_OPTIONS.map(o => o.value);
-const REVIEWER_ALIASES = { gemini: 'antigravity' };
+const REVIEWER_ALIASES = { gemini: 'antigravity', 'cursor-agent': 'cursor' };
 export function normalizeReviewers(meta) {
   const raw = meta && typeof meta === 'object' && !Array.isArray(meta) ? meta : {};
   const source = Array.isArray(raw.reviewers)

--- a/client/src/hooks/useReviewerModelOptions.js
+++ b/client/src/hooks/useReviewerModelOptions.js
@@ -13,7 +13,7 @@ import { reviewerEffortLevels, normalizeReviewerSlug } from '../lib/reviewerPins
  * Two sources, because the two reviewer kinds are different things:
  * - `lmstudio` / `ollama` ids come from `/api/local-llm/status`, so they reflect
  *   what's actually installed rather than a provider's stale stored `models`.
- * - `codex` / `claude` / `antigravity` / `grok` tiers come from the provider
+ * - `codex` / `claude` / `antigravity` / `grok` / `cursor` tiers come from the provider
  *   catalog (`/api/providers`) — these are CLI reviewers, not local backends, so
  *   there's nothing to probe.
  *
@@ -98,6 +98,7 @@ export default function useReviewerModelOptions() {
       // the user lists real ids on the provider. The Model cell stays useful
       // regardless because grok, like every CLI reviewer, is free-text.
       grok: providerTiers((p) => p.id === 'grok-cli', isGrokBuildCli),
+      cursor: providerTiers((p) => p.id === 'cursor-cli', (p) => p.id === 'cursor-tui'),
     };
 
     // The agy provider's RAW catalog — one id per effort tier
@@ -123,7 +124,7 @@ export default function useReviewerModelOptions() {
       modelEffortLevels,
       // A local backend's id list is authoritative (we probed it), so keep those
       // pickers a closed `<select>`. Every CLI reviewer is free-text: `claude` for
-      // the Ollama-backed / Bedrock-form cases above, `codex`/`antigravity`/`grok`
+      // the Ollama-backed / Bedrock-form cases above, `codex`/`antigravity`/`grok`/`cursor`
       // because their catalogs are stored snapshots that can lag a newly-released
       // tier — grok's shipped catalog holds no real id at all, so a typed id is the
       // ONLY way to pin one (an agy pin may also be typed effort-suffixed — the

--- a/client/src/hooks/useReviewerModelOptions.test.jsx
+++ b/client/src/hooks/useReviewerModelOptions.test.jsx
@@ -28,6 +28,7 @@ const providers = [
   // spawned non-interactively, so the CLI's catalog is the one it should offer.
   { id: 'grok-tui', type: 'tui', command: 'grok', models: ['stale-tui-id'] },
   { id: 'grok-cli', type: 'cli', command: 'grok', models: ['grok-configured-default', 'grok-code-fast-1'] },
+  { id: 'cursor-cli', type: 'cli', command: 'cursor-agent', models: ['auto', 'gpt-5'] },
 ];
 
 describe('useReviewerModelOptions', () => {
@@ -65,6 +66,13 @@ describe('useReviewerModelOptions', () => {
     // Free-text: the shipped grok catalog is sentinel-only, so a typed id is
     // often the only way to pin one.
     expect(result.current.freeText.grok).toBe(true);
+  });
+
+  it('sources Cursor Agent options from its cursor-agent provider', async () => {
+    const { result } = renderHook(() => useReviewerModelOptions());
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.optionsByReviewer.cursor).toEqual(['auto', 'gpt-5']);
+    expect(result.current.freeText.cursor).toBe(true);
   });
 
   it('falls back to a TUI-only grok install for its catalog', async () => {

--- a/client/src/lib/reviewerPins.js
+++ b/client/src/lib/reviewerPins.js
@@ -27,9 +27,10 @@ import {
 
 // CLI reviewers whose binary takes a `--model <id>` tier. Mirror of
 // MODEL_CAPABLE_CLI_REVIEWERS (`antigravity` runs `agy --model <id>`, `grok` runs
-// `grok --model <id>` — the latter takes a model but no effort, so this roster is
+// `grok --model <id>`, and Cursor runs `cursor-agent --model <id>` — the latter
+// two take a model but no separate effort flag, so this roster is
 // deliberately wider than EFFORT_SELECTABLE_REVIEWERS below).
-export const MODEL_CAPABLE_CLI_REVIEWERS = ['codex', 'claude', 'antigravity', 'grok'];
+export const MODEL_CAPABLE_CLI_REVIEWERS = ['codex', 'claude', 'antigravity', 'grok', 'cursor'];
 
 // The local-LLM backends, which take both a model and an effort.
 export const LOCAL_LLM_REVIEWERS = ['lmstudio', 'ollama'];
@@ -68,7 +69,7 @@ export const REVIEWER_EFFORT_LEVELS = Object.freeze({
 export const EFFORT_SELECTABLE_REVIEWERS = Object.freeze(Object.keys(REVIEWER_EFFORT_LEVELS));
 
 // Reviewer slug aliases. `gemini` is the historical name for the Antigravity CLI.
-const REVIEWER_ALIASES = { gemini: 'antigravity' };
+const REVIEWER_ALIASES = { gemini: 'antigravity', 'cursor-agent': 'cursor' };
 
 // The canonical slug for a reviewer token: lower-cased, trimmed, aliases resolved.
 // `''` for a non-string. `@username` tokens ride through as-is (they're no

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -21,13 +21,13 @@ import { PR_COMPLETION_VALUES } from './prDisposition.js';
 // =============================================================================
 
 // Reviewer choices for the Review Loop. `copilot` requests a native GitHub
-// Copilot review; `claude`/`antigravity`/`codex`/`grok` instruct the review-loop
+// Copilot review; `claude`/`antigravity`/`codex`/`grok`/`cursor` instruct the review-loop
 // follow-up agent to invoke the named CLI to critique the PR diff; `lmstudio`/`ollama`
 // route the diff through PortOS's local code-review endpoint
 // (`POST /api/code-review/local`) which runs the configured local LLM model.
 // Mirrored in client/src/components/cos/constants.js → REVIEWER_OPTIONS.
-export const REVIEWER_VALUES = ['copilot', 'claude', 'antigravity', 'codex', 'grok', 'lmstudio', 'ollama'];
-export const REVIEWER_ALIASES = { gemini: 'antigravity' };
+export const REVIEWER_VALUES = ['copilot', 'claude', 'antigravity', 'codex', 'grok', 'cursor', 'lmstudio', 'ollama'];
+export const REVIEWER_ALIASES = { gemini: 'antigravity', 'cursor-agent': 'cursor' };
 export const DEFAULT_REVIEWER = 'copilot';
 export const DEFAULT_REVIEWERS = ['copilot'];
 // Reviewers that resolve to a local-LLM backend (rather than a CLI or GitHub
@@ -50,7 +50,7 @@ export const LOCAL_LLM_REVIEWERS = ['lmstudio', 'ollama'];
 // get their model injected server-side by `POST /api/code-review/local`. Add a
 // reviewer here when its CLI gains model selection; the `<reviewer>Model`
 // settings scalar is generated from this roster (codeReviewSettingsSchema).
-export const MODEL_CAPABLE_CLI_REVIEWERS = ['codex', 'claude', 'antigravity', 'grok'];
+export const MODEL_CAPABLE_CLI_REVIEWERS = ['codex', 'claude', 'antigravity', 'grok', 'cursor'];
 // Every reviewer whose model the user can PICK in the UI: the model-capable CLIs
 // above (threaded into the follow-up prompt as `<reviewer> --model <id>`) plus the
 // local-LLM backends (whose id is injected server-side by
@@ -74,6 +74,7 @@ export const REVIEWER_CLI_BINARIES = {
   antigravity: ANTIGRAVITY_COMMAND,
   codex: 'codex',
   grok: 'grok',
+  cursor: 'cursor-agent',
 };
 
 /**
@@ -383,7 +384,7 @@ function normalizeReviewerModel(raw, reviewer = null) {
 }
 
 // Reviewers whose slashdo `--review-with` entry accepts a `[<model>]` bracket
-// (`lib/multi-reviewer-loop.md`: codex/claude/agy/grok/ollama). PortOS's
+// (`lib/multi-reviewer-loop.md`: codex/claude/agy/grok/cursor/ollama). PortOS's
 // `lmstudio` reviewer has NO slashdo counterpart — it's served by
 // `POST /api/code-review/local`, which takes the model in its request body — so a
 // pinned lmstudio model never becomes a bracket, and `copilot`/`@login` entries

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -166,6 +166,9 @@ describe('cosValidation reviewer CLI binaries', () => {
       expect(reviewerCliBinary(slug)).toBe(slug);
       expect(describeReviewerCli(slug)).toBe(`\`${slug}\``);
     }
+    expect(reviewerCliBinary('cursor')).toBe('cursor-agent');
+    expect(reviewerCliBinary('cursor-agent')).toBe('cursor-agent');
+    expect(describeReviewerCli('cursor')).toBe('`cursor-agent` (the `cursor` reviewer)');
   });
 
   it('returns null for reviewers that have no spawnable CLI', () => {
@@ -376,6 +379,13 @@ describe('client mirror of the reviewer effort ladders', () => {
 });
 
 describe('per-reviewer model pins', () => {
+  it('accepts Cursor Agent in the reviewer config and persists its model pin', () => {
+    const parsed = codeReviewSettingsSchema.parse({ reviewers: ['cursor-agent'], cursorModel: 'gpt-5' });
+    expect(parsed.reviewers).toEqual(['cursor']);
+    expect(parsed.cursorModel).toBe('gpt-5');
+    expect(reviewerModelsFromDefaults(parsed)).toEqual({ cursor: 'gpt-5' });
+  });
+
   it('keeps an antigravity model pin on the code-review settings slice', () => {
     // `agy --model <id>` is real (unlike the effort-only support PortOS assumed
     // before #3728), so the scalar has to survive the `.strict()` schema.

--- a/server/lib/slashdoInvocation.js
+++ b/server/lib/slashdoInvocation.js
@@ -60,7 +60,7 @@ export const SLASHDO_INLINE_BUDGET_CHARS = 24000;
  *
  * Keyed by the PortOS reviewer slug (`REVIEWER_VALUES` in `cosValidation.js`) so
  * the keep-set derives from already-resolved run settings. `copilot` and the
- * arbitrary-`@login` loop are GitHub-side; `claude`/`codex`/`antigravity`/`grok`
+ * arbitrary-`@login` loop are GitHub-side; `claude`/`codex`/`antigravity`/`grok`/`cursor`
  * all share slashdo's one local-agent loop; `ollama`/`lmstudio` are the
  * local-model loop.
  *
@@ -90,7 +90,7 @@ export const SLASHDO_REVIEWER_INCLUDE_NAMES = Object.freeze(Object.values(SLASHD
  * can pin it against `REVIEWER_CLI_BINARIES` (whose keys are the same roster);
  * a reviewer added to one and not the other is a drift the test catches.
  */
-export const LOCAL_AGENT_REVIEWERS = new Set(['claude', 'codex', 'antigravity', 'grok']);
+export const LOCAL_AGENT_REVIEWERS = new Set(['claude', 'codex', 'antigravity', 'grok', 'cursor']);
 /** Reviewer slugs that drive slashdo's local-model (Ollama-style) loop. */
 const LOCAL_MODEL_REVIEWERS = new Set(['ollama', 'lmstudio']);
 

--- a/server/lib/slashdoInvocation.test.js
+++ b/server/lib/slashdoInvocation.test.js
@@ -347,7 +347,7 @@ describe('unreachableReviewerIncludes', () => {
   });
 
   it('maps every CLI reviewer onto the one shared local-agent loop', () => {
-    for (const slug of ['claude', 'codex', 'antigravity', 'grok']) {
+    for (const slug of ['claude', 'codex', 'antigravity', 'grok', 'cursor']) {
       expect(unreachableReviewerIncludes({ reviewers: [slug] }))
         .not.toContain(SLASHDO_REVIEWER_INCLUDES.localAgent);
     }

--- a/server/services/codeReview.js
+++ b/server/services/codeReview.js
@@ -203,7 +203,7 @@ export async function resolveReviewLoopOptions(metadata, { normalize, isTruthyMe
 
 /**
  * Per-reviewer CLI-binary install probe, keyed by reviewer slug (e.g.
- * `{ claude: true, antigravity: false, codex: true, grok: false }`). Only CLI
+ * `{ claude: true, antigravity: false, codex: true, grok: false, cursor: true }`). Only CLI
  * reviewers (`isCliReviewer`) are probed — `copilot` is a GitHub API review
  * and `lmstudio`/`ollama` route through `/api/code-review/local`, neither has
  * a binary to find.

--- a/server/services/codeReview.test.js
+++ b/server/services/codeReview.test.js
@@ -166,6 +166,7 @@ describe('codeReview helpers', () => {
         claudeModel: 'qwen2.5:7b',
         antigravityModel: 'gemini-3.6-flash',
         grokModel: 'grok-code-fast-1',
+        cursorModel: null,
         ...NO_EFFORTS,
       })
     })
@@ -201,8 +202,8 @@ describe('codeReview helpers', () => {
       const probed = []
       commandExistsMock.impl = async (binary) => { probed.push(binary); return binary !== 'agy' }
       const out = await getReviewerCliInstalled()
-      expect(out).toEqual({ claude: true, antigravity: false, codex: true, grok: true })
-      expect(probed.sort()).toEqual(['agy', 'claude', 'codex', 'grok'])
+      expect(out).toEqual({ claude: true, antigravity: false, codex: true, grok: true, cursor: true })
+      expect(probed.sort()).toEqual(['agy', 'claude', 'codex', 'cursor-agent', 'grok'])
     })
 
     it('caches the result within the TTL — a second call does not re-probe', async () => {
@@ -210,7 +211,7 @@ describe('codeReview helpers', () => {
       commandExistsMock.impl = async () => { calls += 1; return true }
       await getReviewerCliInstalled()
       await getReviewerCliInstalled()
-      expect(calls).toBe(4) // one probe per CLI reviewer, only on the first call
+      expect(calls).toBe(5) // one probe per CLI reviewer, only on the first call
     })
 
     it('probes with the longer 15s timeout these heavier agentic CLIs need', async () => {


### PR DESCRIPTION
## Summary

- add Cursor Agent as a supported Code Review Defaults reviewer with cursor-agent alias normalization
- wire cursor-agent binary discovery, model pinning, slashdo invocation, and client/server config parity
- add focused coverage for validation, persistence, model options, and reviewer integration

## Test plan

- cd server && npm test -- lib/cosValidation.test.js lib/slashdoInvocation.test.js services/codeReview.test.js routes/codeReview.test.js
- cd client && npm test -- src/hooks/useReviewerModelOptions.test.jsx src/components/providers/CodeReviewDefaultsPanel.test.jsx src/components/cos/ReviewerPicker.test.jsx src/components/cos/constants.test.js
- cd client && npm run lint
- local agy review: NO FINDINGS

No PR-side reviewer was requested; this change was reviewed locally with agy.