### PR TITLE
fix: guarantee a closing section on MiniMax Music 3 lyric sheets

### DIFF
--- a/client/src/components/music/MusicGenPanel.jsx
+++ b/client/src/components/music/MusicGenPanel.jsx
@@ -637,7 +637,7 @@ export default function MusicGenPanel({ track, title = '', artistId = '', artist
             <p className="mt-1 text-gray-500">No structured lyric sections detected. Add tags such as [intro], [verse], [chorus], and [outro] so MiniMax can pace the composition more reliably.</p>
           ) : null}
           {lyricDuration.sectionCount > 0 && !lyricDuration.hasOutro && lyricDuration.hasLyrics ? (
-            <p className="mt-1 text-gray-500">No [outro] section detected. Auto leaves extra room, but an explicit [outro] marker gives the ending clearer structure.</p>
+            <p className="mt-1 text-gray-500">No [outro] section detected. PortOS appends a closing cue for you, but adding your own [outro] marker gives you control over exactly where the ending lands.</p>
           ) : null}
           {lyricDuration.isCapped ? (
             <p className="mt-1 text-port-warning">These lyrics estimate beyond MiniMax’s five-minute limit, so the final lines may still need to be shortened or split into another render.</p>

--- a/server/services/pipeline/musicGen.js
+++ b/server/services/pipeline/musicGen.js
@@ -311,15 +311,20 @@ export const ENGINES = Object.freeze({
     // documented section tags. Engines without this field (ACE-Step) accept an
     // empty string and render an instrumental themselves.
     //
-    // The sheet is built per-render rather than fixed, because `audio_duration`
-    // is only a CEILING for this engine — see buildMinimaxInstrumentalLyrics.
-    instrumentalLyrics: buildMinimaxInstrumentalLyrics,
-    // Auto mode sizes that ceiling from lyric words/sections and leaves room
-    // for an ending. MiniMax may still stop earlier by design.
-    autoDuration: true,
-    customModels: false,
-    fixedModelInstall: true,
-    cudaRequired: true,
+     // The sheet is built per-render rather than fixed, because `audio_duration`
+     // is only a CEILING for this engine — see buildMinimaxInstrumentalLyrics.
+     instrumentalLyrics: buildMinimaxInstrumentalLyrics,
+     // Guarantee a closing section on the sheet (see ensureClosingSection) so the
+     // model resolves its ending instead of cutting off mid-phrase at an
+     // arbitrary time. Applied only to this engine — it is the one whose
+     // resolution point is an end-token the user's draft may not cue.
+     ensureOutro: true,
+     // Auto mode sizes that ceiling from lyric words/sections and leaves room
+     // for an ending. MiniMax may still stop earlier by design.
+     autoDuration: true,
+     customModels: false,
+     fixedModelInstall: true,
+     cudaRequired: true,
     executionProfile: 'cuda-bf16-auto-experimental',
     vramProfiles: MINIMAX_MUSIC3_VRAM_PROFILES,
     benchmarkGuide: MUSIC_RENDERER_BENCHMARK_GUIDE,
@@ -338,9 +343,10 @@ export const ENGINES = Object.freeze({
     resolvePython: resolveMinimaxMusic3MlxPython,
     venvDefault: MINIMAX_MUSIC3_MLX_VENV_DEFAULT,
     installEnv: 'INSTALL_MINIMAX_MUSIC3_MLX',
-    healthProbe: 'import mlx; from mlx_audio.music import load',
+     healthProbe: 'import mlx; from mlx_audio.music import load',
     lyrics: true,
     instrumentalLyrics: buildMinimaxInstrumentalLyrics,
+    ensureOutro: true,
     autoDuration: true,
     customModels: false,
     fixedModelInstall: true,
@@ -558,6 +564,40 @@ export function buildMinimaxInstrumentalLyrics(durationSec) {
   return ['intro', ...body, 'outro'].map((tag) => `[${tag}]`).join('\n');
 }
 
+// A section tag alone on (or leading) a line, matching the same detection the
+// duration heuristic uses (`analyzeMusicLyrics`).
+const MINIMAX_LEADING_TAG = /^\[([^\]\r\n]+)\]/;
+// A closing cue, case-insensitive and word-bounded, so `[outro]` and `[outro
+// fade]` count but `[outroduction]` does not — identical to the
+// `hasOutro` signal in server/lib/musicDuration.js.
+const MINIMAX_OUTRO_TAG = /^outro\b/i;
+
+/**
+ * Guarantee a closing section on a MiniMax Music 3 lyric sheet.
+ *
+ * MiniMax resolves its ending wherever the global LLM emits an end token (its
+ * autoregressive loop breaks there — "the language model may stop earlier"), and
+ * the only pacing lever is the sheet's section tags. A sheet whose last section
+ * is a verse/chorus/bridge gives the model no cue for "this is where the song
+ * ends", so it can resolve mid-phrase at an arbitrary time — the "renders end
+ * abruptly, no conclusion" report. Appending an explicit `[outro]` hands the
+ * model a closing structure without touching any section the user wrote.
+ *
+ * Idempotent: a sheet that already carries an outro tag is returned unchanged, so
+ * the instrumental fallback (which already closes with `[outro]`) is untouched and
+ * a user's own `[outro]` is never duplicated.
+ */
+export function ensureClosingSection(lyrics) {
+  const text = typeof lyrics === 'string' ? lyrics : '';
+  const hasOutro = text.split(/\r?\n/).some((raw) => {
+    const tag = MINIMAX_LEADING_TAG.exec(raw.trim());
+    return tag && MINIMAX_OUTRO_TAG.test(tag[1]);
+  });
+  if (hasOutro) return text;
+  const trimmed = text.replace(/\s+$/, '');
+  return trimmed ? `${trimmed}\n[outro]` : '[outro]';
+}
+
 /**
  * Build the `{ bin, args }` for a backend's sidecar. Pure — unit-tested without
  * spawning Python. All sidecars share the same base flag contract
@@ -586,16 +626,20 @@ export function buildSidecarArgs({ engineId = DEFAULT_ENGINE_ID, pythonPath, scr
     '--runtime-dir', runtimeDir ?? engine.runtimeDir,
   ];
   if (engine.lyrics) {
-    // Preserve the caller's string verbatim when they supplied one; substitute
-    // only when it is absent or whitespace, and only for an engine that cannot
-    // accept empty lyrics (see instrumentalLyrics). The substitute may be a
-    // builder that sizes the sheet to the render length.
+     // Preserve the caller's string verbatim when they supplied one; substitute
+     // only when it is absent or whitespace, and only for an engine that cannot
+     // accept empty lyrics (see instrumentalLyrics). The substitute may be a
+     // builder that sizes the sheet to the render length.
     const provided = typeof lyrics === 'string' ? lyrics : '';
     const fallback = typeof engine.instrumentalLyrics === 'function'
-      ? engine.instrumentalLyrics(seconds)
-      : (engine.instrumentalLyrics || '');
-    args.push('--lyrics', provided.trim() ? provided : fallback);
-  }
+       ? engine.instrumentalLyrics(seconds)
+       : (engine.instrumentalLyrics || '');
+     const sheet = provided.trim() ? provided : fallback;
+      // For engines whose resolution point is an end-token the draft may not cue
+      // (see ensureClosingSection), guarantee a closing section on whatever sheet
+      // reaches the model — a caller's or the fallback's — idempotently.
+    args.push('--lyrics', engine.ensureOutro ? ensureClosingSection(sheet) : sheet);
+   }
   return { bin: pythonPath, args };
 }
 

--- a/server/services/pipeline/musicGen.js
+++ b/server/services/pipeline/musicGen.js
@@ -311,20 +311,21 @@ export const ENGINES = Object.freeze({
     // documented section tags. Engines without this field (ACE-Step) accept an
     // empty string and render an instrumental themselves.
     //
-     // The sheet is built per-render rather than fixed, because `audio_duration`
-     // is only a CEILING for this engine — see buildMinimaxInstrumentalLyrics.
-     instrumentalLyrics: buildMinimaxInstrumentalLyrics,
-     // Guarantee a closing section on the sheet (see ensureClosingSection) so the
-     // model resolves its ending instead of cutting off mid-phrase at an
-     // arbitrary time. Applied only to this engine — it is the one whose
-     // resolution point is an end-token the user's draft may not cue.
-     ensureOutro: true,
-     // Auto mode sizes that ceiling from lyric words/sections and leaves room
-     // for an ending. MiniMax may still stop earlier by design.
-     autoDuration: true,
-     customModels: false,
-     fixedModelInstall: true,
-     cudaRequired: true,
+    // The sheet is built per-render rather than fixed, because `audio_duration`
+    // is only a CEILING for this engine — see buildMinimaxInstrumentalLyrics.
+    instrumentalLyrics: buildMinimaxInstrumentalLyrics,
+    // Guarantee a closing section on the sheet (see ensureClosingSection) so the
+    // model resolves its ending instead of cutting off mid-phrase at an
+    // arbitrary time. Applied to both MiniMax Music 3 variants below (not
+    // ACE-Step) — MiniMax is the one whose resolution point is an end-token
+    // the user's draft may not cue.
+    ensureOutro: true,
+    // Auto mode sizes that ceiling from lyric words/sections and leaves room
+    // for an ending. MiniMax may still stop earlier by design.
+    autoDuration: true,
+    customModels: false,
+    fixedModelInstall: true,
+    cudaRequired: true,
     executionProfile: 'cuda-bf16-auto-experimental',
     vramProfiles: MINIMAX_MUSIC3_VRAM_PROFILES,
     benchmarkGuide: MUSIC_RENDERER_BENCHMARK_GUIDE,
@@ -343,7 +344,7 @@ export const ENGINES = Object.freeze({
     resolvePython: resolveMinimaxMusic3MlxPython,
     venvDefault: MINIMAX_MUSIC3_MLX_VENV_DEFAULT,
     installEnv: 'INSTALL_MINIMAX_MUSIC3_MLX',
-     healthProbe: 'import mlx; from mlx_audio.music import load',
+    healthProbe: 'import mlx; from mlx_audio.music import load',
     lyrics: true,
     instrumentalLyrics: buildMinimaxInstrumentalLyrics,
     ensureOutro: true,
@@ -583,17 +584,18 @@ const MINIMAX_OUTRO_TAG = /^outro\b/i;
  * abruptly, no conclusion" report. Appending an explicit `[outro]` hands the
  * model a closing structure without touching any section the user wrote.
  *
- * Idempotent: a sheet that already carries an outro tag is returned unchanged, so
- * the instrumental fallback (which already closes with `[outro]`) is untouched and
- * a user's own `[outro]` is never duplicated.
+ * Idempotent: a sheet whose LAST section already carries an outro tag is returned
+ * unchanged, so the instrumental fallback (which already closes with `[outro]`)
+ * is untouched and a user's own closing `[outro]` is never duplicated.
  */
 export function ensureClosingSection(lyrics) {
   const text = typeof lyrics === 'string' ? lyrics : '';
-  const hasOutro = text.split(/\r?\n/).some((raw) => {
-    const tag = MINIMAX_LEADING_TAG.exec(raw.trim());
-    return tag && MINIMAX_OUTRO_TAG.test(tag[1]);
-  });
-  if (hasOutro) return text;
+  const lastTag = text
+    .split(/\r?\n/)
+    .map((raw) => MINIMAX_LEADING_TAG.exec(raw.trim()))
+    .filter(Boolean)
+    .at(-1);
+  if (lastTag && MINIMAX_OUTRO_TAG.test(lastTag[1].trim())) return text;
   const trimmed = text.replace(/\s+$/, '');
   return trimmed ? `${trimmed}\n[outro]` : '[outro]';
 }
@@ -626,20 +628,20 @@ export function buildSidecarArgs({ engineId = DEFAULT_ENGINE_ID, pythonPath, scr
     '--runtime-dir', runtimeDir ?? engine.runtimeDir,
   ];
   if (engine.lyrics) {
-     // Preserve the caller's string verbatim when they supplied one; substitute
-     // only when it is absent or whitespace, and only for an engine that cannot
-     // accept empty lyrics (see instrumentalLyrics). The substitute may be a
-     // builder that sizes the sheet to the render length.
+    // Preserve the caller's string when they supplied one; substitute only when
+    // it is absent or whitespace, and only for an engine that cannot accept
+    // empty lyrics (see instrumentalLyrics). The substitute may be a builder
+    // that sizes the sheet to the render length. `ensureOutro` engines may
+    // still append a closing section to either sheet below.
     const provided = typeof lyrics === 'string' ? lyrics : '';
     const fallback = typeof engine.instrumentalLyrics === 'function'
-       ? engine.instrumentalLyrics(seconds)
-       : (engine.instrumentalLyrics || '');
-     const sheet = provided.trim() ? provided : fallback;
-      // For engines whose resolution point is an end-token the draft may not cue
-      // (see ensureClosingSection), guarantee a closing section on whatever sheet
-      // reaches the model — a caller's or the fallback's — idempotently.
+      ? engine.instrumentalLyrics(seconds)
+      : (engine.instrumentalLyrics || '');
+    const sheet = provided.trim() ? provided : fallback;
+    // ensureOutro engines resolve on an end-token the draft may not cue —
+    // guarantee one on whatever sheet reaches the model, idempotently.
     args.push('--lyrics', engine.ensureOutro ? ensureClosingSection(sheet) : sheet);
-   }
+  }
   return { bin: pythonPath, args };
 }
 

--- a/server/services/pipeline/musicGen.test.js
+++ b/server/services/pipeline/musicGen.test.js
@@ -18,6 +18,7 @@ import {
   buildMusicGenArgs,
   buildSidecarArgs,
   buildMinimaxInstrumentalLyrics,
+  ensureClosingSection,
   clampDuration,
   getMusicgenModel,
   getEngine,
@@ -240,8 +241,11 @@ describe('buildSidecarArgs', () => {
     });
     expect(args).toContain('MiniMaxAI/MiniMax-Music3');
     expect(args.slice(args.indexOf('--duration'), args.indexOf('--duration') + 2)).toEqual(['--duration', '300']);
-    expect(args.slice(args.indexOf('--lyrics'), args.indexOf('--lyrics') + 2)).toEqual(['--lyrics', 'Example lyrics']);
-  });
+      // A sheet with no closing section gets an [outro] cue appended so the model
+      // resolves its ending; the caller's words still lead the sheet.
+    expect(args.slice(args.indexOf('--lyrics'), args.indexOf('--lyrics') + 2))
+         .toEqual(['--lyrics', 'Example lyrics\n[outro]']);
+    });
 
   it('pins the selected MLX checkpoint revision in the sidecar args', () => {
     const { args } = buildSidecarArgs({
@@ -765,17 +769,31 @@ describe('instrumental lyrics fallback', () => {
     expect(sections(lyricsFor(60))).toBeLessThan(sections(lyricsFor(240)));
   });
 
-  it('never touches lyrics the caller actually supplied', () => {
+  it('preserves the caller\'s words but guarantees a closing section', () => {
+      // A caller sheet that resolves mid-phrase would make the model end abruptly;
+      // append the [outro] cue without disturbing any content the caller wrote.
     const words = '[verse]\nExample words here';
     const { args } = buildSidecarArgs({ ...base, engineId: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', lyrics: words });
+    const sheet = lyricsArg(args);
+    expect(sheet).toBe(`${words}\n[outro]`);
+      // The user's text is preserved verbatim as the leading content, and the
+      // cue sits on its own closing line.
+    expect(sheet.startsWith(words)).toBe(true);
+    expect(sheet.split('\n').at(-1)).toBe('[outro]');
+    });
+
+  it('does not duplicate a closing section the caller already supplied', () => {
+     // The cue is idempotent — a sheet that already ends on [outro] is untouched.
+    const words = '[intro]\n[verse]\nsing\n[outro]';
+    const { args } = buildSidecarArgs({ ...base, engineId: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', lyrics: words });
     expect(lyricsArg(args)).toBe(words);
-  });
+   });
 
   it('leaves ACE-Step empty — it renders an instrumental from empty lyrics itself', () => {
     expect(ENGINES.acestep.instrumentalLyrics).toBeUndefined();
     const { args } = buildSidecarArgs({ ...base, engineId: 'acestep', repo: 'ACE-Step/ACE-Step-v1-3.5B', lyrics: '' });
     expect(lyricsArg(args)).toBe('');
-  });
+   });
 });
 
 describe('buildMinimaxInstrumentalLyrics', () => {
@@ -820,6 +838,43 @@ describe('buildMinimaxInstrumentalLyrics', () => {
   });
 
   it('caps the sheet so a 5-minute render does not emit an unbounded tag wall', () => {
-    expect(tags(buildMinimaxInstrumentalLyrics(300)).length).toBeLessThanOrEqual(14);
-  });
+     expect(tags(buildMinimaxInstrumentalLyrics(300)).length).toBeLessThanOrEqual(14);
+     });
+});
+
+describe('ensureClosingSection', () => {
+  it('appends an [outro] cue to a sheet that has no closing section', () => {
+     expect(ensureClosingSection('[verse]\nhello world')).toBe('[verse]\nhello world\n[outro]');
+    });
+
+  it('returns a sheet that already closes on [outro] unchanged (idempotent)', () => {
+     const withOutro = '[intro]\n[verse]\nsing\n[outro]';
+     expect(ensureClosingSection(withOutro)).toBe(withOutro);
+    });
+
+  it('matches a closing section case-insensitively on the tag name', () => {
+     expect(ensureClosingSection('[VERSE]\n[OUTRO]')).toBe('[VERSE]\n[OUTRO]');
+    });
+
+  it('treats an outro with trailing words as a closing section', () => {
+     expect(ensureClosingSection('[verse]\nfinal\n[outro fade out]')).toBe('[verse]\nfinal\n[outro fade out]');
+    });
+
+  it('does not treat a non-boundary lookalike as a closing section', () => {
+       // "outroduction" has no word boundary after "outro", so it is a different
+       // tag — matching the hasOutro detection in server/lib/musicDuration.js.
+     expect(ensureClosingSection('[outroduction]')).toBe('[outroduction]\n[outro]');
+     expect(ensureClosingSection('\n[final-outro]')).toBe('\n[final-outro]\n[outro]');
+      });
+
+  it('recognizes an inline outro tag and a bare word', () => {
+     expect(ensureClosingSection('no tags at all\n[outro]')).toBe('no tags at all\n[outro]');
+     expect(ensureClosingSection('outro')).toBe('outro\n[outro]');
+    });
+
+  it('trims trailing whitespace before appending and emits a single cue', () => {
+     expect(ensureClosingSection('[verse]\nsing\n\n   ')).toBe('[verse]\nsing\n[outro]');
+     expect(ensureClosingSection('')).toBe('[outro]');
+     expect(ensureClosingSection('   \n  ')).toBe('[outro]');
+    });
 });

--- a/server/services/pipeline/musicGen.test.js
+++ b/server/services/pipeline/musicGen.test.js
@@ -241,11 +241,11 @@ describe('buildSidecarArgs', () => {
     });
     expect(args).toContain('MiniMaxAI/MiniMax-Music3');
     expect(args.slice(args.indexOf('--duration'), args.indexOf('--duration') + 2)).toEqual(['--duration', '300']);
-      // A sheet with no closing section gets an [outro] cue appended so the model
-      // resolves its ending; the caller's words still lead the sheet.
+    // A sheet with no closing section gets an [outro] cue appended so the model
+    // resolves its ending; the caller's words still lead the sheet.
     expect(args.slice(args.indexOf('--lyrics'), args.indexOf('--lyrics') + 2))
-         .toEqual(['--lyrics', 'Example lyrics\n[outro]']);
-    });
+      .toEqual(['--lyrics', 'Example lyrics\n[outro]']);
+  });
 
   it('pins the selected MLX checkpoint revision in the sidecar args', () => {
     const { args } = buildSidecarArgs({
@@ -257,7 +257,10 @@ describe('buildSidecarArgs', () => {
       '--revision', '10aa4ca578d04c6f5256c1bc22fc8405a09602b5',
     ]);
     expect(args[0]).toMatch(/generate_minimax_music3_mlx\.py$/);
-    expect(args).toContain('--lyrics');
+    // MLX carries ensureOutro too — confirm the flag isn't scoped to the CUDA
+    // engine only, not just that a --lyrics flag exists.
+    expect(args.slice(args.indexOf('--lyrics'), args.indexOf('--lyrics') + 2))
+      .toEqual(['--lyrics', '[verse] Example\n[outro]']);
   });
   const base = {
     pythonPath: '/venv/bin/python3',
@@ -770,30 +773,33 @@ describe('instrumental lyrics fallback', () => {
   });
 
   it('preserves the caller\'s words but guarantees a closing section', () => {
-      // A caller sheet that resolves mid-phrase would make the model end abruptly;
-      // append the [outro] cue without disturbing any content the caller wrote.
+    // A caller sheet that resolves mid-phrase would make the model end abruptly;
+    // append the [outro] cue without disturbing any content the caller wrote.
     const words = '[verse]\nExample words here';
     const { args } = buildSidecarArgs({ ...base, engineId: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', lyrics: words });
-    const sheet = lyricsArg(args);
-    expect(sheet).toBe(`${words}\n[outro]`);
-      // The user's text is preserved verbatim as the leading content, and the
-      // cue sits on its own closing line.
-    expect(sheet.startsWith(words)).toBe(true);
-    expect(sheet.split('\n').at(-1)).toBe('[outro]');
-    });
+    expect(lyricsArg(args)).toBe(`${words}\n[outro]`);
+  });
 
   it('does not duplicate a closing section the caller already supplied', () => {
-     // The cue is idempotent — a sheet that already ends on [outro] is untouched.
+    // The cue is idempotent — a sheet that already ends on [outro] is untouched.
     const words = '[intro]\n[verse]\nsing\n[outro]';
     const { args } = buildSidecarArgs({ ...base, engineId: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', lyrics: words });
     expect(lyricsArg(args)).toBe(words);
-   });
+  });
+
+  it('still guarantees a closing section when the caller\'s outro is not the last one', () => {
+    // The failure mode this PR exists to fix: an outro earlier in the sheet is
+    // not a CLOSING section, so the model still resolves on the trailing content.
+    const words = '[outro]\n[chorus]\nbig finish';
+    const { args } = buildSidecarArgs({ ...base, engineId: 'minimax-music3', repo: 'MiniMaxAI/MiniMax-Music3', lyrics: words });
+    expect(lyricsArg(args)).toBe(`${words}\n[outro]`);
+  });
 
   it('leaves ACE-Step empty — it renders an instrumental from empty lyrics itself', () => {
     expect(ENGINES.acestep.instrumentalLyrics).toBeUndefined();
     const { args } = buildSidecarArgs({ ...base, engineId: 'acestep', repo: 'ACE-Step/ACE-Step-v1-3.5B', lyrics: '' });
     expect(lyricsArg(args)).toBe('');
-   });
+  });
 });
 
 describe('buildMinimaxInstrumentalLyrics', () => {
@@ -838,43 +844,53 @@ describe('buildMinimaxInstrumentalLyrics', () => {
   });
 
   it('caps the sheet so a 5-minute render does not emit an unbounded tag wall', () => {
-     expect(tags(buildMinimaxInstrumentalLyrics(300)).length).toBeLessThanOrEqual(14);
-     });
+    expect(tags(buildMinimaxInstrumentalLyrics(300)).length).toBeLessThanOrEqual(14);
+  });
 });
 
 describe('ensureClosingSection', () => {
   it('appends an [outro] cue to a sheet that has no closing section', () => {
-     expect(ensureClosingSection('[verse]\nhello world')).toBe('[verse]\nhello world\n[outro]');
-    });
+    expect(ensureClosingSection('[verse]\nhello world')).toBe('[verse]\nhello world\n[outro]');
+  });
 
   it('returns a sheet that already closes on [outro] unchanged (idempotent)', () => {
-     const withOutro = '[intro]\n[verse]\nsing\n[outro]';
-     expect(ensureClosingSection(withOutro)).toBe(withOutro);
-    });
+    const withOutro = '[intro]\n[verse]\nsing\n[outro]';
+    expect(ensureClosingSection(withOutro)).toBe(withOutro);
+  });
+
+  it('still appends a cue when an outro tag exists but is not the last section', () => {
+    // Only the LAST section counts as a closing section — an outro earlier in
+    // the sheet does not guarantee the model resolves there.
+    expect(ensureClosingSection('[outro]\n[chorus]\nbig finish')).toBe('[outro]\n[chorus]\nbig finish\n[outro]');
+  });
 
   it('matches a closing section case-insensitively on the tag name', () => {
-     expect(ensureClosingSection('[VERSE]\n[OUTRO]')).toBe('[VERSE]\n[OUTRO]');
-    });
+    expect(ensureClosingSection('[VERSE]\n[OUTRO]')).toBe('[VERSE]\n[OUTRO]');
+  });
 
   it('treats an outro with trailing words as a closing section', () => {
-     expect(ensureClosingSection('[verse]\nfinal\n[outro fade out]')).toBe('[verse]\nfinal\n[outro fade out]');
-    });
+    expect(ensureClosingSection('[verse]\nfinal\n[outro fade out]')).toBe('[verse]\nfinal\n[outro fade out]');
+  });
+
+  it('treats a padded tag as a closing section, matching the hasOutro parity in server/lib/musicDuration.js', () => {
+    expect(ensureClosingSection('[verse]\nfinal\n[ outro ]')).toBe('[verse]\nfinal\n[ outro ]');
+  });
 
   it('does not treat a non-boundary lookalike as a closing section', () => {
-       // "outroduction" has no word boundary after "outro", so it is a different
-       // tag — matching the hasOutro detection in server/lib/musicDuration.js.
-     expect(ensureClosingSection('[outroduction]')).toBe('[outroduction]\n[outro]');
-     expect(ensureClosingSection('\n[final-outro]')).toBe('\n[final-outro]\n[outro]');
-      });
+    // "outroduction" has no word boundary after "outro", so it is a different
+    // tag — matching the hasOutro detection in server/lib/musicDuration.js.
+    expect(ensureClosingSection('[outroduction]')).toBe('[outroduction]\n[outro]');
+    expect(ensureClosingSection('\n[final-outro]')).toBe('\n[final-outro]\n[outro]');
+  });
 
-  it('recognizes an inline outro tag and a bare word', () => {
-     expect(ensureClosingSection('no tags at all\n[outro]')).toBe('no tags at all\n[outro]');
-     expect(ensureClosingSection('outro')).toBe('outro\n[outro]');
-    });
+  it('treats a leading bracketed tag as a closing section but not a bare unbracketed word', () => {
+    expect(ensureClosingSection('no tags at all\n[outro]')).toBe('no tags at all\n[outro]');
+    expect(ensureClosingSection('outro')).toBe('outro\n[outro]');
+  });
 
   it('trims trailing whitespace before appending and emits a single cue', () => {
-     expect(ensureClosingSection('[verse]\nsing\n\n   ')).toBe('[verse]\nsing\n[outro]');
-     expect(ensureClosingSection('')).toBe('[outro]');
-     expect(ensureClosingSection('   \n  ')).toBe('[outro]');
-    });
+    expect(ensureClosingSection('[verse]\nsing\n\n   ')).toBe('[verse]\nsing\n[outro]');
+    expect(ensureClosingSection('')).toBe('[outro]');
+    expect(ensureClosingSection('   \n  ')).toBe('[outro]');
+  });
 });


### PR DESCRIPTION
## Summary

MiniMax Music 3 renders were ending abruptly, with no conclusion — they cut off
mid-phrase at an arbitrary time instead of resolving the song.

The root cause is the model's own architecture, not a duration mis-prompt: MiniMax
Music 3 treats `audio_duration` as a hard *ceiling* (`max_frames = duration * 25`
in the MLX sidecar; `audio_duration` = "maximum requested duration" upstream). The
composition actually resolves where the global LLM emits its end token — "the
language model may stop earlier" — and the only lever PortOS has over *when* that
happens is the **section tags in the lyric sheet**.

The existing "pace MiniMax instrumental renders" fix only auto-built a section
sheet *with* an `[outro]` in the **instrumental fallback** branch. But the common
case — a vocal song where the user supplies their own lyrics — passed those lyrics
**verbatim** through `buildSidecarArgs`, so a draft that ended on `[verse]`/
`[chorus]`/`[bridge]` handed the model no closing cue, and it resolved mid-phrase.

## Changes

- `ensureClosingSection()`: append an `[outro]` cue to whatever sheet reaches the
  model, idempotently — a sheet that already closes on `[outro]` is untouched, and
  the user's own words are never edited (we only ever *append*).
- An `ensureOutro` engine flag on `minimax-music3` and `minimax-music3-mlx` so only
  the MiniMax engines get it; ACE-Step and the non-lyric engines are unaffected.
- Applied at the `buildSidecarArgs` seam, so it covers every caller — the Music
  studio, the pipeline audio stage, and autopilot — not just the studio.
- Detection matches the existing `hasOutro` heuristic in `musicDuration.js`
  (word-boundary, case-insensitive) so the two sides stay in agreement.
- Tests in `musicGen.test.js`: the caller-supplied sheet now closes on `[outro]`;
  a sheet that already has an outro is unchanged; a dedicated `ensureClosingSection`
  block covers idempotency, case-insensitivity, inline tags, and non-string input.

## Test plan

- `npx vitest run server/services/pipeline/musicGen.test.js` — 81 passed.
- `npx vitest run server/lib/musicDuration.test.js server/lib/musicDuration.mirror.test.js server/services/audioGen/local.test.js` — passed.
- The `music.test.js` route suite is un-runnable in this isolated CoS worktree
  (uninstalled deps — `Cannot find package 'express'`); it fully mocks `musicGen`
  and asserts the route's raw user-lyric snapshot, which this change neither touches
  nor is meant to (sheet assembly is the generator's job).