### PR TITLE
Stop telling agents `--review-with` has no effort suffix — it does

### DIFF
--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -531,12 +531,12 @@ export function normalizeReviewerEffort(raw, reviewer) {
  * same emitted `--review-with` token as `normalizeReviewerModels` (e.g.
  * `{ codex: 'high', ollama: 'low' }`).
  *
- * Unlike the model pin, this never becomes part of a slashdo token: slashdo's
- * entry grammar has no effort suffix. It reaches a reviewer through the two
- * places PortOS actually controls the invocation — the review-loop follow-up
- * prompt's CLI command line (`codex -c model_reasoning_effort=high`, `claude
- * --effort high`) and the `reasoning_effort` field of the local reviewer's
- * `/api/code-review/local` request body.
+ * Three carriers, depending on who invokes the reviewer. On a slashdo invocation
+ * it rides the emitted token as `~effort=<level>` (`markSuffixes`), which slashdo
+ * turns into the reviewer's own flag. Where PortOS drives the invocation itself it
+ * is spelled out instead: the review-loop follow-up prompt's CLI command line
+ * (`codex -c model_reasoning_effort=high`, `claude --effort high`) and the
+ * `reasoning_effort` field of the local reviewer's `/api/code-review/local` body.
  *
  * An absent key means "let that reviewer use its own default effort", which is
  * NOT the same as a blank string, so an unusable value is DROPPED rather than

--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -707,24 +707,31 @@ export function reviewerEffortArgs(reviewer, effort) {
 }
 
 /**
- * Prose instruction carrying the per-reviewer effort pins into a **slashdo**
- * invocation — `/do:pr --review-with …`, where the model pin rides the token's
- * `[<model>]` bracket but the effort has nowhere to go: slashdo's entry grammar
- * (`<agent>[<model>](~opt|~max=<n>)*`) has no effort suffix, and inventing one
- * would just be a token its parser drops.
+ * Prose instruction carrying the per-reviewer effort pins into a prompt whose
+ * agent spawns the reviewer CLI ITSELF — the claim flows (which run each
+ * configured reviewer by hand, no `--review-with` anywhere in the prompt) and a
+ * slashdo invocation that pins no reviewer list.
  *
- * So the effort is delivered the only way that actually reaches the nested CLI:
- * as an instruction to append the flag when the loop invokes it. Scoped to CLI
- * reviewers on purpose — slashdo's local-model loop calls the backend itself
- * rather than through PortOS's endpoint, so there is no flag to name for
- * `ollama`/`lmstudio` there (their effort still applies on the PortOS-driven
- * review-loop follow-up, which posts to `/api/code-review/local`).
+ * **Not for an invocation that pins `--review-with`.** slashdo's entry grammar is
+ * `<agent>[<model>](~opt|~max=<n>|~effort=<level>)*`, and `markSuffixes` emits
+ * that `~effort=` suffix, so the pin already reaches the CLI the loop spawns.
+ * Restating it as prose there is worse than silent: the agent passes the flag a
+ * second time, or hand-runs a reviewer the loop was about to run. Pass the
+ * emitted `--review-with` text as `reviewWith` and this returns '' when it sees
+ * the suffix — one check, so a caller can't decide wrong.
+ *
+ * Scoped to CLI reviewers on purpose — `ollama`/`lmstudio` have no binary to
+ * name (their effort rides the `POST /api/code-review/local` body instead).
  *
  * @param {string[]} reviewers - the reviewer slugs the invocation emits
  * @param {Object<string, string>} [reviewerEfforts] - token-keyed effort pins
- * @returns {string} a single sentence, or '' when no reviewer carries an effort
+ * @param {Object} [options]
+ * @param {string} [options.reviewWith] - the `--review-with` text this prompt
+ *   emits, if any. A `~effort=` in it means slashdo already carries the pin.
+ * @returns {string} a single sentence, or '' when nothing is left to say
  */
-export function buildReviewerEffortNote(reviewers, reviewerEfforts = {}) {
+export function buildReviewerEffortNote(reviewers, reviewerEfforts = {}, { reviewWith = '' } = {}) {
+  if (typeof reviewWith === 'string' && reviewWith.includes('~effort=')) return '';
   const efforts = normalizeReviewerEfforts(reviewerEfforts) || {};
   const entries = (Array.isArray(reviewers) ? reviewers : [])
     .map((r) => {
@@ -733,7 +740,7 @@ export function buildReviewerEffortNote(reviewers, reviewerEfforts = {}) {
     })
     .filter(Boolean);
   if (!entries.length) return '';
-  return `When the review loop invokes a reviewer CLI, add its pinned reasoning effort: ${entries.join(', ')}. \`--review-with\` has no effort suffix, so this is the only way it reaches the reviewer.`;
+  return `Invoke each reviewer CLI at its pinned reasoning effort: ${entries.join(', ')}. Pass the flag yourself when you spawn the reviewer — nothing else in this prompt applies it (a \`~effort=<level>\` suffix in a reviewer list is slashdo's own grammar, which only its \`--review-with\` parses).`;
 }
 
 /**

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -333,6 +333,10 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
     expect(noEffort).not.toContain('~effort=');
     expect(buildReviewerEffortNote(['codex'], { codex: 'high' }, { reviewWith: noEffort })).toContain('`codex -c model_reasoning_effort=high`');
     expect(buildReviewerEffortNote(['codex'], { codex: 'high' }, { reviewWith: '' })).toContain('`codex -c model_reasoning_effort=high`');
+    // And a lone copilot can't carry an effort at all (no ladder — see the DROPS
+    // test above), which is why the lone-default suppression stays correct without
+    // an effort clause of its own in applySlashdoInvocation.
+    expect(buildReviewWithArgs(['copilot'], { reviewerEfforts: { copilot: 'high' } })).toBe('');
   });
 
   it('never claims --review-with lacks an effort suffix', () => {

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -305,7 +305,7 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
     expect(reviewerEffortArgs('codex', ' HIGH ')).toEqual(['-c', 'model_reasoning_effort=high']);
   });
 
-  it('builds the slashdo-invocation note only for CLI reviewers carrying an effort', () => {
+  it('builds the hand-invocation note only for CLI reviewers carrying an effort', () => {
     const note = buildReviewerEffortNote(['codex', 'claude', 'copilot'], { codex: 'high', claude: 'low', copilot: 'high' });
     expect(note).toContain('`codex -c model_reasoning_effort=high`');
     expect(note).toContain('`claude --effort low`');
@@ -317,6 +317,31 @@ describe('per-reviewer reasoning effort (reviewerEfforts)', () => {
     // slashdo's local-model loop calls the backend itself, so there's no flag to
     // name for lmstudio/ollama in this path.
     expect(buildReviewerEffortNote(['ollama'], { ollama: 'high' })).toBe('');
+  });
+
+  it('goes SILENT once the emitted --review-with carries the effort itself', () => {
+    // slashdo has parsed `~effort=<level>` since v3.31, and markSuffixes emits it —
+    // so on a pinned invocation the loop already runs the reviewer at that effort.
+    // Repeating it as prose tells the agent to pass the flag a second time, or to
+    // hand-run a reviewer `/do:pr` was about to run.
+    const reviewWith = buildReviewWithArgs(['codex', 'claude'], { reviewerEfforts: { codex: 'high', claude: 'low' } });
+    expect(reviewWith).toContain('codex~effort=high');
+    expect(buildReviewerEffortNote(['codex', 'claude'], { codex: 'high', claude: 'low' }, { reviewWith })).toBe('');
+    // An invocation that pins reviewers but NO effort leaves the note as the only
+    // carrier, and an absent/blank pin is the unpinned case.
+    const noEffort = buildReviewWithArgs(['codex', 'claude'], {});
+    expect(noEffort).not.toContain('~effort=');
+    expect(buildReviewerEffortNote(['codex'], { codex: 'high' }, { reviewWith: noEffort })).toContain('`codex -c model_reasoning_effort=high`');
+    expect(buildReviewerEffortNote(['codex'], { codex: 'high' }, { reviewWith: '' })).toContain('`codex -c model_reasoning_effort=high`');
+  });
+
+  it('never claims --review-with lacks an effort suffix', () => {
+    // The note predates slashdo's `~effort=` support and used to justify itself
+    // with "`--review-with` has no effort suffix". It does have one — an agent
+    // reading that next to its own `codex~effort=high` token is being misled.
+    const note = buildReviewerEffortNote(['codex'], { codex: 'high' });
+    expect(note).not.toContain('has no effort suffix');
+    expect(note).toContain('Pass the flag yourself when you spawn the reviewer');
   });
 
   it('carries reviewerEfforts through the task schema and the metadata sanitizer', () => {

--- a/server/lib/slashdoInvocation.js
+++ b/server/lib/slashdoInvocation.js
@@ -419,10 +419,11 @@ export function oversizedBodyPointer(bodyPath, body) {
  * @param {string} [opts.reviewWith=''] - reviewer CSV to pin (`codex,copilot`).
  *   Required when `body` had reviewer variants pruned out of it.
  * @param {string} [opts.reviewerEffortNote=''] - the per-reviewer reasoning-effort
- *   instruction (`buildReviewerEffortNote`). Emitted independently of `reviewWith`:
- *   this workflow runs its OWN review loop, so an effort pinned on the task has no
- *   other way to reach the reviewer CLI the workflow spawns — and unlike the CSV it
- *   applies whether or not the body was pruned.
+ *   instruction (`buildReviewerEffortNote`). Non-empty only when `reviewWith` is
+ *   NOT emitted: a pinned CSV carries each effort as slashdo's `~effort=<level>`
+ *   suffix, so the prose would just have the agent pass the flag twice. Unpinned,
+ *   the workflow resolves reviewers itself and this is the pin's only route to the
+ *   CLI it spawns.
  * @returns {string} markdown section, or '' when `resolved` is null
  */
 export function buildSlashdoSection(resolved, body = null, { bodyPath = null, reviewWith = '', reviewerEffortNote = '' } = {}) {

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -653,11 +653,13 @@ async function applySlashdoInvocation(task, {
   const reviewWith = skipIncludes.length
     ? buildReviewersCsv(resolvedReviewers, resolvedUsernames, resolvedOptional, resolvedMaxRounds, resolvedModels, resolvedEfforts)
     : '';
-  // Unlike `reviewWith` this is NOT gated on pruning: the workflow drives its own
-  // review loop, so a pinned effort has no other route to the reviewer CLI it
-  // spawns — the `/do:pr` completion step further down the prompt is a different
-  // invocation entirely, and for a slashdo-backed task usually isn't reached.
-  const reviewerEffortNote = buildReviewerEffortNote(resolvedReviewers, resolvedEfforts);
+  // Gated on the PIN, not on pruning. When `reviewWith` is emitted, each token
+  // carries `~effort=<level>` and slashdo's loop applies it — the note would only
+  // have the agent pass the flag twice. When nothing is pinned, the workflow
+  // resolves reviewers itself and the note is the pin's only route to the CLI it
+  // spawns (the `/do:pr` completion step further down is a different invocation
+  // entirely, and for a slashdo-backed task usually isn't reached).
+  const reviewerEffortNote = buildReviewerEffortNote(resolvedReviewers, resolvedEfforts, { reviewWith });
   const section = buildSlashdoSection(resolved, body, { bodyPath, reviewWith, reviewerEffortNote });
   return { ...task, description: `${task.description}\n\n${section}` };
 }
@@ -2380,9 +2382,12 @@ function resolveReviewInvocation({ willOpenPR, runsReviewLoop, reviewers, userna
   const reviewArgs = willOpenPR
     ? (runsReviewLoop ? buildReviewWithArgs(reviewers, { stopMode: reviewStopMode, reviewerApplies, usernames: reviewUsernames, optionalReviewers, reviewerMaxRounds, reviewerModels, reviewerEfforts }) : '--review-with none')
     : '';
-  // Effort pins can't ride `--review-with` (no suffix for them in slashdo's
-  // grammar), so they're stated as an instruction on the invocation instead.
-  const effortNote = willOpenPR && runsReviewLoop ? buildReviewerEffortNote(reviewers, reviewerEfforts) : '';
+  // Effort pins ride the emitted `--review-with` tokens as `~effort=<level>`, so
+  // the prose note is suppressed whenever that suffix is present — it only speaks
+  // for an invocation that pins no reviewer list (see buildReviewerEffortNote).
+  const effortNote = willOpenPR && runsReviewLoop
+    ? buildReviewerEffortNote(reviewers, reviewerEfforts, { reviewWith: reviewArgs })
+    : '';
   return { reviewUsernames, reviewArgs, effortNote };
 }
 
@@ -2706,8 +2711,8 @@ function buildCliCompletionSection({ worktreeInfo, willOpenPR, prCompletion = PR
           : `and drives the review loop for ${[...reviewers, ...reviewUsernames.map(u => `@${u}`)].join(', ')} in order until clean.`)
       : 'with external review disabled.';
     lines.push(`${step++}. \`/do:pr${reviewerArg}\` — commits your changes, pushes the branch, and opens a pull request against the default branch ${completionNote}`);
-    // Effort pins have no `--review-with` suffix to ride, so they're stated as an
-    // instruction on the invocation instead (see buildReviewerEffortNote).
+    // Empty whenever the emitted `--review-with` already carries `~effort=<level>`
+    // (see buildReviewerEffortNote) — this speaks only for an unpinned invocation.
     if (effortNote) lines.push(`   ${effortNote}`);
     // Merge steps follow — review-gated with a loop, CI-gated without one — unless
     // this PR is a human's to land (JIRA-tracked; see lib/prDisposition.js).

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -618,7 +618,11 @@ async function applySlashdoInvocation(task, {
   // explicit naming: nothing defaults to either suffix, so both are deliberate
   // choices, and dropping one would silently turn a non-blocking review blocking
   // or spend an unbudgeted number of rounds. `buildReviewWithArgs` makes the same
-  // exemption for its lone-default suppression — keep the two in step.
+  // exemption for its lone-default suppression — keep the two in step. It carries a
+  // third clause for a copilot `~effort=`; there is deliberately none here, because
+  // copilot has no effort ladder at all (`REVIEWER_EFFORT_LEVELS` is keyed off
+  // `reviewerCliBinary`, and copilot names no binary), so `normalizeReviewerEfforts`
+  // drops the pin long before either function sees it.
   const taskPinnedReviewer = (Array.isArray(task.metadata?.reviewers) && task.metadata.reviewers.length > 0)
     || (typeof task.metadata?.reviewer === 'string' && !!task.metadata.reviewer);
   const optionalDefaultReviewer = resolvedOptional.some(t => t.toLowerCase() === DEFAULT_REVIEWER);

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -2534,14 +2534,33 @@ describe('buildAgentPrompt — slashdo prompt-size controls', () => {
     warn.mockRestore();
   });
 
-  // The workflow drives its OWN review loop, so an effort pinned on the task has
-  // no other route to the reviewer CLI it spawns — `--review-with` carries a
-  // `[<model>]` bracket but has no effort suffix.
-  it('states a pinned reviewer effort in the slashdo section', async () => {
+  // A pinned reviewer list carries the effort as slashdo's own `~effort=<level>`
+  // suffix, so the section states it ONCE — on the pin. The prose instruction is
+  // for the unpinned case, where the workflow resolves reviewers itself.
+  it('carries a pinned reviewer effort on the --review-with token, not as prose', async () => {
     const prompt = await buildAgentPrompt(
       slashdoTask({ reviewers: ['codex'], reviewerEfforts: { codex: 'high' } }),
       {}, '/r', null, isTruthyMeta,
       { providerType: 'cli', providerId: 'codex' });
+    expect(prompt).toContain('codex~effort=high');
+    // Restating it would have the agent pass `-c model_reasoning_effort=high` a
+    // second time, on top of the one slashdo's loop already passes.
+    expect(prompt).not.toContain('Invoke each reviewer CLI at its pinned reasoning effort');
+  });
+
+  it('states the effort in prose when the section pins no reviewer list', async () => {
+    // Reviewers spanning every loop variant prune nothing, so no `--review-with`
+    // is emitted — the pin's only route to the CLI the workflow spawns is prose.
+    const prompt = await buildAgentPrompt(
+      slashdoTask({
+        reviewers: ['copilot', 'codex', 'ollama'],
+        usernames: ['octocat'],
+        reviewerEfforts: { codex: 'high' },
+      }),
+      {}, '/r', null, isTruthyMeta,
+      { providerType: 'cli', providerId: 'codex' });
+    // (the note's own prose mentions the flag — assert on the pin line instead)
+    expect(prompt).not.toContain('Run this workflow with');
     expect(prompt).toContain('`codex -c model_reasoning_effort=high`');
   });
 
@@ -2553,7 +2572,8 @@ describe('buildAgentPrompt — slashdo prompt-size controls', () => {
       slashdoTask({ reviewers: ['codex'], reviewerEfforts: { codex: 'high', claude: 'xhigh' } }),
       {}, '/r', null, isTruthyMeta,
       { providerType: 'cli', providerId: 'codex' });
-    expect(prompt).toContain('`codex -c model_reasoning_effort=high`');
+    expect(prompt).toContain('codex~effort=high');
+    expect(prompt).not.toContain('claude~effort=xhigh');
     expect(prompt).not.toContain('--effort xhigh');
   });
 

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -486,8 +486,10 @@ export async function buildClaimWorkTask(app, {
   // Per-reviewer model pins (slashdo's `[<model>]` bracket) and reasoning efforts
   // ride the same explicit-option → task metadata → Code Review Defaults
   // precedence, and resolve together so the two describe one invocation (an agy
-  // model id can carry its effort as a suffix). The efforts carry no
-  // `--review-with` token, so they land as an appended instruction below.
+  // model id can carry its effort as a suffix). The claim prompt runs its
+  // reviewers by hand rather than through `--review-with`, so the effort also
+  // lands as an appended instruction below — the CSV's `~effort=` suffix is
+  // slashdo grammar nothing in this flow parses.
   const { reviewerModels: promptReviewerModels, reviewerEfforts: promptReviewerEfforts } = resolveReviewerPins({
     reviewerModels: reviewerModels ?? metadata.reviewerModels,
     reviewerEfforts: reviewerEfforts ?? metadata.reviewerEfforts,
@@ -535,7 +537,8 @@ export async function buildClaimWorkTask(app, {
  *
  * Returns BOTH pieces because the two travel differently: `csv` fills the
  * template's `{reviewers}` placeholder, while `effortBlock` is appended prose —
- * `--review-with` has no effort suffix to carry it.
+ * the claim agent spawns each reviewer CLI itself, so no `--review-with` parser
+ * ever reads the CSV's `~effort=` suffix.
  */
 async function resolveClaimReviewerPrompt() {
   const codeReviewDefaults = await getCodeReviewDefaults().catch(() => null);
@@ -697,8 +700,9 @@ const appendTargetWorkItemBlock = (promptTaskType, ref) => {
  * the same blank-line separator. APPENDED rather than substituted into a
  * `{...}` placeholder because a new placeholder would be silently dropped by
  * every install whose customized claim template predates it (the same reason
- * `swarmBlock` is prepended) — and because there is no `--review-with` suffix to
- * carry it, so it has to be prose. Empty when no reviewer in the list pins one.
+ * `swarmBlock` is prepended) — and prose because the claim agent invokes each
+ * reviewer CLI directly: this flow emits no `--review-with`, so the CSV's
+ * `~effort=` suffix reaches no parser. Empty when no reviewer in the list pins one.
  */
 const appendReviewerEffortBlock = (reviewers, reviewerEfforts) => {
   const note = buildReviewerEffortNote(reviewers, reviewerEfforts);

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -359,21 +359,35 @@ describe('{reviewers} interpolation honors Code Review Defaults', () => {
     expect(GEN_SRC).toContain('appendLocalReviewerInstructions(promptTaskType, promptReviewers');
   });
 
+  it('keeps the reasoning-effort PROSE on every claim path (they emit no --review-with)', () => {
+    // `buildReviewerEffortNote` goes silent when it is handed a `--review-with`
+    // string carrying `~effort=<level>` — correct for a slashdo invocation, where
+    // the suffix already reaches the reviewer CLI. A claim prompt has no such
+    // invocation: the agent spawns each reviewer itself, so the CSV's suffix
+    // reaches no parser and the sentence is the pin's only route. No claim path
+    // may start passing `reviewWith` and mute itself.
+    expect(GEN_SRC).toContain('appendReviewerEffortBlock(reviewersList, promptReviewerEfforts)');
+    expect(GEN_SRC).toContain('appendReviewerEffortBlock(list, reviewerEfforts)');
+    expect(GEN_SRC).toContain('appendReviewerEffortBlock(promptReviewers, promptReviewerEfforts)');
+    expect(GEN_SRC).not.toMatch(/buildReviewerEffortNote\([^)]*reviewWith/);
+  });
+
   it('threads per-reviewer ~max round caps into the prompt CSV on both claim paths', () => {
-    // The `{reviewers}` token IS the flag string for the claim flows, so a
-    // configured cap only reaches slashdo if the CSV carries it. Both the
-    // scheduled path and buildClaimWorkTask resolve it with task-over-default
-    // precedence (unit-tested in validation.test.js).
+    // The `{reviewers}` token is the whole reviewer contract the claim agent
+    // gets — it runs each reviewer by hand, so a configured cap only reaches the
+    // run if the CSV carries it. Both the scheduled path and buildClaimWorkTask
+    // resolve it with task-over-default precedence (unit-tested in
+    // validation.test.js).
     expect(GEN_SRC).toContain('resolveReviewerMaxRounds(metadata.reviewerMaxRounds, codeReviewDefaults?.reviewerMaxRounds)');
     expect(GEN_SRC).toContain('resolveReviewerMaxRounds(reviewerMaxRounds ?? metadata.reviewerMaxRounds, codeReviewDefaults?.reviewerMaxRounds)');
     expect(GEN_SRC).toContain('buildReviewersCsv(reviewersList, promptUsernames, promptOptionalReviewers, promptReviewerMaxRounds, promptReviewerModels, promptReviewerEfforts)');
   });
 
   it('threads per-reviewer model pins into the prompt CSV on both claim paths (#3133)', () => {
-    // Same argument as the caps above: `{reviewers}` IS the flag string for the
-    // claim flows, so a pinned model only reaches slashdo (as its `[<model>]`
-    // bracket) if the CSV carries it. Both paths resolve with task-over-default
-    // precedence off the Code Review Defaults' `<reviewer>Model` scalars.
+    // Same argument as the caps above: `{reviewers}` is the only place the claim
+    // prompt names a pinned model, so it only reaches the run if the CSV carries
+    // it. Both paths resolve with task-over-default precedence off the Code
+    // Review Defaults' `<reviewer>Model` scalars.
     //
     // All three prompt paths go through `resolveReviewerPins`, which resolves the
     // model map TOGETHER with the effort map and reconciles the two (#3728) — an


### PR DESCRIPTION
## Summary

A CoS agent's prompt carried both `--review-with claude~effort=xhigh` **and** a sentence telling it that "`--review-with` has no effort suffix, so this is the only way it reaches the reviewer." Both came from PortOS, and the second one is false: slashdo has parsed `~effort=<level>` since v3.31 (the pinned submodule is well past it), and #4399 taught `markSuffixes` to emit it. So the agent was told to pass by hand a flag slashdo's own review loop already passes, justified by a claim its own invocation contradicts.

`buildReviewerEffortNote` now takes the emitted `--review-with` text and returns `''` when it sees `~effort=`, so the pin is stated exactly once — on the token. The check lives in the builder rather than at each call site, so a caller can't decide it wrong.

The note still speaks for the two flows that emit no such pin, and its prose now says why instead of the old false claim:

- a slashdo section that pruned nothing, so no reviewer list is pinned and the workflow resolves reviewers itself;
- the **claim prompts**, which never emit `--review-with` at all — their agent spawns each reviewer CLI by hand, so the `{reviewers}` CSV's `~effort=` suffix reaches no parser.

Also corrects the comments that described that claim CSV as "the flag string for the claim flows".

Filed [#4555](https://github.com/atomantic/PortOS/issues/4555) for the adjacent gap this surfaced: `cursor` is the one model-capable CLI reviewer whose effort PortOS can't pin, because `effortLevelsForProvider` returns `null` for `cursor-agent` — while slashdo supports `cursor[<model>]~effort=<level>` by folding the level into `--model`.

## Test plan

- `NODE_ENV=test npx vitest run` in `server/` — 1468 files, 30275 tests pass.
- New in `server/lib/cosValidation.test.js`: the note goes silent once `buildReviewWithArgs` emits `~effort=`, still fires for a pinned-but-effort-less invocation and for the unpinned case, and never again claims `--review-with` lacks the suffix.
- New in `server/services/agentPromptBuilder.test.js`: a pinned reviewer list carries the effort as `codex~effort=high` with no duplicate prose; a reviewer set spanning every loop variant prunes nothing, emits no pin, and gets the prose instead.
- New in `server/services/cosTaskGenerator.test.js`: all three claim paths keep the prose (none may start passing `reviewWith` and mute itself).
- Reviewed by `codex` (`gpt-5.6-luna`, effort high): clean, no findings.