### PR TITLE
perf: deduplicate git fetches and tab loaders (#4563)

### DIFF
--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -145,10 +145,10 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
 
   const loadGitInfo = useCallback(() => loadGitData({ includeRemote: false }), [loadGitData]);
 
-  const loadRemoteBranches = useCallback(async () => {
+  const loadRemoteBranches = useCallback(async (opts = {}) => {
     if (!repoPath) return;
     setLoadingRemote(true);
-    const result = await api.getRemoteBranches(repoPath).catch(() => null);
+    const result = await api.getRemoteBranches(repoPath, opts).catch(() => null);
     if (result) {
       setRemoteBranches(result.branches || []);
       setDefaultBranch(result.defaultBranch || 'main');
@@ -769,7 +769,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
                   </div>
                 )}
                 <button
-                  onClick={loadRemoteBranches}
+                  onClick={() => loadRemoteBranches({ force: true })}
                   disabled={loadingRemote}
                   className={`text-xs ${touchBtnCls} text-port-accent hover:underline disabled:opacity-50`}
                 >

--- a/client/src/components/apps/tabs/GitTab.jsx
+++ b/client/src/components/apps/tabs/GitTab.jsx
@@ -108,22 +108,42 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
   const [cleaningUp, setCleaningUp] = useState(false);
   const [cleanupConfirm, setCleanupConfirm] = useState(false);
 
-  const loadGitInfo = useCallback(async () => {
+  const loadGitData = useCallback(async (opts = {}) => {
     if (!repoPath) return;
+    const { includeRemote = true } = opts;
     setLoading(true);
-    const [info, branchesResult] = await Promise.all([
+    if (includeRemote) setLoadingRemote(true);
+
+    const promises = [
       api.getGitInfo(repoPath).catch(() => null),
       api.getBranches(repoPath).catch(() => ({ branches: [] }))
-    ]);
+    ];
+    if (includeRemote) {
+      promises.push(api.getRemoteBranches(repoPath).catch(() => null));
+    }
+
+    const [info, branchesResult, remoteResult] = await Promise.all(promises);
+
     let comparison = null;
     if (info?.baseBranch && info?.devBranch) {
       comparison = await api.getBranchComparison(repoPath, info.baseBranch, info.devBranch).catch(() => null);
     }
+
     setGitInfo(info);
-    setBranches(branchesResult.branches || []);
+    setBranches(branchesResult?.branches || []);
     setBranchComparison(comparison);
     setLoading(false);
+
+    if (includeRemote) {
+      if (remoteResult) {
+        setRemoteBranches(remoteResult.branches || []);
+        setDefaultBranch(remoteResult.defaultBranch || 'main');
+      }
+      setLoadingRemote(false);
+    }
   }, [repoPath]);
+
+  const loadGitInfo = useCallback(() => loadGitData({ includeRemote: false }), [loadGitData]);
 
   const loadRemoteBranches = useCallback(async () => {
     if (!repoPath) return;
@@ -137,9 +157,8 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
   }, [repoPath]);
 
   useEffect(() => {
-    loadGitInfo();
-    loadRemoteBranches();
-  }, [loadGitInfo, loadRemoteBranches]);
+    loadGitData({ includeRemote: true });
+  }, [loadGitData]);
 
   const loadDiff = async () => {
     if (!repoPath) return;
@@ -181,7 +200,7 @@ export default function GitTab({ appId: _appId, appName, repoPath }) {
       }
       toast.success(`Branches updated — ${parts.join(', ')}`);
     }
-    await loadGitInfo();
+    await loadGitData({ includeRemote: true });
   };
 
   const handleReleasePR = async () => {

--- a/client/src/services/apiGit.js
+++ b/client/src/services/apiGit.js
@@ -61,9 +61,9 @@ export const syncBranch = (path, branch) => request('/git/sync', {
   method: 'POST',
   body: JSON.stringify({ path, branch })
 });
-export const getRemoteBranches = (path) => request('/git/remote-branches', {
+export const getRemoteBranches = (path, { force = false } = {}) => request('/git/remote-branches', {
   method: 'POST',
-  body: JSON.stringify({ path })
+  body: JSON.stringify({ path, force })
 });
 // `options` lets a caller suppress request()'s auto-toast with `{ silent: true }`
 // when it already renders its own error UI.

--- a/server/routes/git.js
+++ b/server/routes/git.js
@@ -221,9 +221,9 @@ router.post('/sync', asyncHandler(async (req, res) => {
 
 // POST /api/git/remote-branches - Get remote branches with merge status
 router.post('/remote-branches', asyncHandler(async (req, res) => {
-  const { path } = req.body;
+  const { path, force } = req.body;
   assertAllowedWorkspace(path);
-  const result = await git.getRemoteBranches(path);
+  const result = await git.getRemoteBranches(path, { force });
   res.json(result);
 }));
 

--- a/server/services/git.fetchOrigin.test.js
+++ b/server/services/git.fetchOrigin.test.js
@@ -6,12 +6,13 @@ vi.mock('../lib/execGit.js', () => ({
   execGit: execGitMock
 }));
 
-import { fetchOrigin } from './git.js';
+import { getRemoteBranches, fetchOrigin, clearFetchCache, isFetchFresh } from './git.js';
 
 describe('fetchOrigin', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     execGitMock.mockReset();
+    clearFetchCache();
   });
 
   afterEach(() => {
@@ -61,5 +62,63 @@ describe('fetchOrigin', () => {
 
     await assertion;
     expect(execGitMock).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe('getRemoteBranches fetch freshness window & deduplication', () => {
+  beforeEach(() => {
+    execGitMock.mockReset();
+    clearFetchCache();
+  });
+
+  it('skips fetch when getRemoteBranches is called again inside freshness window', async () => {
+    // Return success for fetch and standard mock outputs for git branch commands
+    execGitMock.mockResolvedValue({ stdout: 'origin/main|2026-08-19|author\n', stderr: '', exitCode: 0 });
+
+    await getRemoteBranches('/repo-fresh');
+    const callsFirst = execGitMock.mock.calls.filter(c => c[0][0] === 'fetch');
+    expect(callsFirst).toHaveLength(1);
+    expect(isFetchFresh('/repo-fresh')).toBe(true);
+
+    // Second call immediately within window
+    await getRemoteBranches('/repo-fresh');
+    const callsSecond = execGitMock.mock.calls.filter(c => c[0][0] === 'fetch');
+    expect(callsSecond).toHaveLength(1); // No new fetch calls
+  });
+
+  it('deduplicates concurrent calls to getRemoteBranches for the same repo', async () => {
+    let resolveFetch;
+    const fetchPromise = new Promise(r => { resolveFetch = r; });
+
+    execGitMock.mockImplementation((args) => {
+      if (args[0] === 'fetch') {
+        return fetchPromise.then(() => ({ stdout: '', stderr: '', exitCode: 0 }));
+      }
+      return Promise.resolve({ stdout: '', stderr: '', exitCode: 0 });
+    });
+
+    // Launch two calls concurrently
+    const p1 = getRemoteBranches('/repo-concurrent');
+    const p2 = getRemoteBranches('/repo-concurrent');
+
+    resolveFetch();
+    await Promise.all([p1, p2]);
+
+    const fetchCalls = execGitMock.mock.calls.filter(c => c[0][0] === 'fetch');
+    expect(fetchCalls).toHaveLength(1);
+  });
+
+  it('fetchOrigin runs unconditionally and updates freshness for getRemoteBranches', async () => {
+    execGitMock.mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+    await fetchOrigin('/repo-update');
+    expect(isFetchFresh('/repo-update')).toBe(true);
+
+    // Subsequent getRemoteBranches call skips fetch because fetchOrigin refreshed it
+    await getRemoteBranches('/repo-update');
+    const fetchCalls = execGitMock.mock.calls.filter(c => c[0][0] === 'fetch');
+    // 1 from fetchOrigin, 0 from getRemoteBranches
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0][0]).toEqual(['fetch', 'origin']);
   });
 });

--- a/server/services/git.fetchOrigin.test.js
+++ b/server/services/git.fetchOrigin.test.js
@@ -121,4 +121,17 @@ describe('getRemoteBranches fetch freshness window & deduplication', () => {
     expect(fetchCalls).toHaveLength(1);
     expect(fetchCalls[0][0]).toEqual(['fetch', 'origin']);
   });
+
+  it('bypasses freshness window when getRemoteBranches is called with force option', async () => {
+    execGitMock.mockResolvedValue({ stdout: 'origin/main|2026-08-19|author\n', stderr: '', exitCode: 0 });
+
+    await getRemoteBranches('/repo-forced');
+    const callsFirst = execGitMock.mock.calls.filter(c => c[0][0] === 'fetch');
+    expect(callsFirst).toHaveLength(1);
+
+    // Second call with force = true
+    await getRemoteBranches('/repo-forced', { force: true });
+    const callsSecond = execGitMock.mock.calls.filter(c => c[0][0] === 'fetch');
+    expect(callsSecond).toHaveLength(2);
+  });
 });

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -916,9 +916,9 @@ export async function ensureLatest(dir) {
  * Returns branches that exist on origin, indicating whether each has been
  * fully merged into the default branch and whether a local copy exists.
  */
-export async function getRemoteBranches(dir) {
-  // Fetch latest refs if not fresh within window
-  if (!isFetchFresh(dir)) {
+export async function getRemoteBranches(dir, { force = false } = {}) {
+  // Fetch latest refs if forced or not fresh within window
+  if (force || !isFetchFresh(dir)) {
     if (activeFetches.has(dir)) {
       await activeFetches.get(dir);
     } else {

--- a/server/services/git.js
+++ b/server/services/git.js
@@ -186,10 +186,33 @@ export async function getRemote(dir) {
  */
 const FETCH_MAX_ATTEMPTS = 4;
 const FETCH_RETRY_DELAY_MS = 250;
+const FETCH_FRESHNESS_MS = 15000;
+
+const lastFetchTimes = new Map();
+const activeFetches = new Map();
+
+export function recordFetchSuccess(dir) {
+  if (dir) lastFetchTimes.set(dir, Date.now());
+}
+
+export function isFetchFresh(dir, windowMs = FETCH_FRESHNESS_MS) {
+  if (!dir) return false;
+  const last = lastFetchTimes.get(dir);
+  if (!last) return false;
+  return (Date.now() - last) < windowMs;
+}
+
+export function clearFetchCache() {
+  lastFetchTimes.clear();
+  activeFetches.clear();
+}
 
 function fetchOriginAttempt(dir, attempt) {
   return execGit(['fetch', 'origin'], dir).then(
-    () => true,
+    () => {
+      recordFetchSuccess(dir);
+      return true;
+    },
     (err) => {
       // A concurrent fetch that already wrote the exact refs this one wanted is
       // a SUCCESS reported as a failure — git exits non-zero on the lost
@@ -197,7 +220,10 @@ function fetchOriginAttempt(dir, attempt) {
       // right commits. Retrying re-runs a whole network fetch to learn there is
       // nothing to do, and on a busy repo every attempt loses the same race, so
       // the caller surfaced a red error for work that had actually completed.
-      if (isBenignConcurrentFetchRefRace(err.message)) return true;
+      if (isBenignConcurrentFetchRefRace(err.message)) {
+        recordFetchSuccess(dir);
+        return true;
+      }
       // Another PortOS surface or agent may advance the same remote ref mid-fetch.
       if (attempt >= FETCH_MAX_ATTEMPTS || !isGitLockError(err.message)) throw err;
       return sleep(FETCH_RETRY_DELAY_MS).then(() => fetchOriginAttempt(dir, attempt + 1));
@@ -838,6 +864,7 @@ export async function ensureLatest(dir) {
   if (fetchResult.stderr?.includes('fatal')) {
     return { success: false, branch: currentBranch, conflict: false, error: `fetch failed: ${fetchResult.stderr}` };
   }
+  recordFetchSuccess(dir);
 
   // Check if remote tracking branch exists
   const remoteRef = await execGit(['rev-parse', `origin/${currentBranch}`], dir, { ignoreExitCode: true });
@@ -890,8 +917,25 @@ export async function ensureLatest(dir) {
  * fully merged into the default branch and whether a local copy exists.
  */
 export async function getRemoteBranches(dir) {
-  // Fetch latest refs
-  await execGit(['fetch', 'origin', '--prune'], dir, { ignoreExitCode: true });
+  // Fetch latest refs if not fresh within window
+  if (!isFetchFresh(dir)) {
+    if (activeFetches.has(dir)) {
+      await activeFetches.get(dir);
+    } else {
+      const fetchPromise = execGit(['fetch', 'origin', '--prune'], dir, { ignoreExitCode: true })
+        .then(res => {
+          if (res.exitCode === 0 || isBenignConcurrentFetchRefRace(res.stderr || res.stdout || '')) {
+            recordFetchSuccess(dir);
+          }
+          return res;
+        })
+        .finally(() => {
+          activeFetches.delete(dir);
+        });
+      activeFetches.set(dir, fetchPromise);
+      await fetchPromise;
+    }
+  }
 
   // Detect default branch
   const { baseBranch } = await getRepoBranches(dir);


### PR DESCRIPTION
Closes #4563

## Summary
- **Server-side fetch freshness window**: Added a 15-second per-repo freshness window (`FETCH_FRESHNESS_MS`) and active fetch promise deduplication (`activeFetches`) to `server/services/git.js`. `getRemoteBranches()` skips duplicate `git fetch origin --prune` calls within the freshness window and awaits in-flight fetch promises to prevent ref store racing. Explicit `updateBranches()` calls continue to fetch origin unconditionally.
- **Client-side GitTab unified loader**: Unified `loadGitInfo` and `loadRemoteBranches` in `client/src/components/apps/tabs/GitTab.jsx` into a single `loadGitData` call executed via `Promise.all` on mount, so one component mount issues one round of parallel requests.
- **Tests**: Added server-side unit tests in `server/services/git.fetchOrigin.test.js` verifying fetch freshness window, concurrent fetch deduplication, and unconditional update fetches.

## Test Plan
- Run `npx vitest run services/git.test.js services/git.fetchOrigin.test.js` in `server` -> All 36 tests pass.
- Run `npx vitest run src/components/apps/tabs/GitTab.test.jsx` in `client` -> All 6 tests pass.
- Run `routes/git.test.js` in `server` -> All 33 tests pass.
