### PR TITLE
fix: return null failure sentinel for malformed peer manifests (#4560)

### DIFF
--- a/server/services/autonomousJobs/brainParitySweep.js
+++ b/server/services/autonomousJobs/brainParitySweep.js
@@ -66,7 +66,7 @@ function summarizePeer(report) {
  *
  * @param {object} [deps]
  * @param {(opts?: object) => Promise<{ reports: object[] }>} [deps.check] - sweep runner (test seam)
- * @returns {Promise<{ peersChecked: number, peersUnavailable: number, peersOutOfParity: number, outOfParityRecords: number, peers: object[] }>}
+ * @returns {Promise<{ peersChecked: number, peersUnavailable: number, peersOutOfParity: number, outOfParityRecords: number, peerRegistryUnavailable: boolean, peers: object[] }>}
  */
 export async function runBrainParitySweep({ check } = {}) {
   // Imported lazily so the scriptHandlers registry — loaded on every jobs read —
@@ -79,6 +79,10 @@ export async function runBrainParitySweep({ check } = {}) {
 
   const result = await run({})
   const reports = Array.isArray(result?.reports) ? result.reports : []
+  // A sweep that could not read the peer registry checked nothing; it did not
+  // find nothing. Kept distinct so a scheduled run can't record "all clear"
+  // for an audit that never ran.
+  const peerRegistryUnavailable = result?.peerRegistryUnavailable === true
   const peers = reports.map(summarizePeer)
 
   const peersUnavailable = peers.filter((p) => !p.available).length
@@ -94,10 +98,13 @@ export async function runBrainParitySweep({ check } = {}) {
     peersUnavailable,
     peersOutOfParity: outOfParityPeers.length,
     outOfParityRecords,
+    peerRegistryUnavailable,
     peers
   }
 
-  if (peers.length === 0) {
+  if (peerRegistryUnavailable) {
+    console.log('🧠🔍 Brain parity sweep: peer registry unreadable — no peers were checked, parity is unknown')
+  } else if (peers.length === 0) {
     console.log('🧠🔍 Brain parity sweep: no federating peers to check')
   } else if (outOfParityPeers.length === 0) {
     console.log(`🧠🔍 Brain parity sweep: ${peers.length} peer(s) checked, none out of parity (${peersUnavailable} unavailable)`)

--- a/server/services/autonomousJobs/brainParitySweep.test.js
+++ b/server/services/autonomousJobs/brainParitySweep.test.js
@@ -101,6 +101,23 @@ describe('runBrainParitySweep', () => {
     const check = vi.fn().mockResolvedValue(null)
     await expect(runBrainParitySweep({ check })).resolves.toMatchObject({ peersChecked: 0 })
   })
+
+  it('surfaces an unreadable peer registry distinctly from a peerless install', async () => {
+    // Both check nothing and report zero peers. Only one of them means the
+    // audit actually ran, so a scheduled sweep must not record "all clear"
+    // for a registry it could not read.
+    const unreadable = await runBrainParitySweep({
+      check: vi.fn().mockResolvedValue({ reports: [], peerRegistryUnavailable: true })
+    })
+    const peerless = await runBrainParitySweep({
+      check: vi.fn().mockResolvedValue({ reports: [] })
+    })
+
+    expect(unreadable.peerRegistryUnavailable).toBe(true)
+    expect(peerless.peerRegistryUnavailable).toBe(false)
+    expect(unreadable.peersChecked).toBe(0)
+    expect(peerless.peersChecked).toBe(0)
+  })
 })
 
 describe('job-brain-parity-sweep registration', () => {

--- a/server/services/brainParity.js
+++ b/server/services/brainParity.js
@@ -107,7 +107,7 @@ function normalizeRemoteManifest(body) {
     const rows = types[type];
     if (!Array.isArray(rows)) continue;
     out[type] = rows
-      .filter((r) => r && typeof r === 'object' && isNonEmptyStr(r.id))
+      .filter((r) => r && typeof r === 'object' && !Array.isArray(r) && isNonEmptyStr(r.id))
       .map((r) => ({ id: r.id, updatedAt: r.updatedAt ?? null, deleted: r.deleted === true }));
   }
   return out;
@@ -130,7 +130,7 @@ function manifestFromSnapshot(snapshot) {
     const byId = records[type];
     if (!byId || typeof byId !== 'object' || Array.isArray(byId)) continue;
     out[type] = Object.entries(byId)
-      .filter(([, rec]) => rec && typeof rec === 'object')
+      .filter(([, rec]) => rec && typeof rec === 'object' && !Array.isArray(rec))
       .map(([id, rec]) => ({ id, updatedAt: rec.updatedAt ?? null, deleted: rec._deleted === true }));
   }
   return out;

--- a/server/services/brainParity.js
+++ b/server/services/brainParity.js
@@ -99,9 +99,10 @@ export async function buildBrainManifest() {
  * store we don't have yet is not divergence, it's a version gap.
  */
 function normalizeRemoteManifest(body) {
+  if (!body || typeof body !== 'object') return null;
+  const types = body.types;
+  if (!types || typeof types !== 'object' || Array.isArray(types)) return null;
   const out = {};
-  const types = body?.types;
-  if (!types || typeof types !== 'object') return out;
   for (const type of BRAIN_ENTITY_TYPES) {
     const rows = types[type];
     if (!Array.isArray(rows)) continue;
@@ -121,12 +122,13 @@ function normalizeRemoteManifest(body) {
  * every peer that supports reconcile at all, not just upgraded ones.
  */
 function manifestFromSnapshot(snapshot) {
+  if (!snapshot || typeof snapshot !== 'object') return null;
+  const records = snapshot.records;
+  if (!records || typeof records !== 'object' || Array.isArray(records)) return null;
   const out = {};
-  const records = snapshot?.records;
-  if (!records || typeof records !== 'object') return out;
   for (const type of BRAIN_ENTITY_TYPES) {
     const byId = records[type];
-    if (!byId || typeof byId !== 'object') continue;
+    if (!byId || typeof byId !== 'object' || Array.isArray(byId)) continue;
     out[type] = Object.entries(byId)
       .filter(([, rec]) => rec && typeof rec === 'object')
       .map(([id, rec]) => ({ id, updatedAt: rec.updatedAt ?? null, deleted: rec._deleted === true }));
@@ -157,7 +159,11 @@ async function fetchPeerJson(peer, path) {
  */
 async function fetchRemoteManifest(peer) {
   const direct = await fetchPeerJson(peer, '/api/brain/reconcile/manifest');
-  if (!direct.reason) return { reason: null, byType: normalizeRemoteManifest(direct.body) };
+  if (!direct.reason) {
+    const normalized = normalizeRemoteManifest(direct.body);
+    if (!normalized) return { reason: 'fetch-failed', byType: null };
+    return { reason: null, byType: normalized };
+  }
   if (direct.reason !== 'peer-too-old') return { reason: direct.reason, byType: null };
 
   const snapshot = await fetchPeerJson(peer, '/api/brain/reconcile/snapshot');
@@ -166,7 +172,9 @@ async function fetchRemoteManifest(peer) {
     // all — still "too old", just further back.
     return { reason: snapshot.reason === 'peer-too-old' ? 'peer-too-old' : snapshot.reason, byType: null };
   }
-  return { reason: null, byType: manifestFromSnapshot(snapshot.body) };
+  const normalized = manifestFromSnapshot(snapshot.body);
+  if (!normalized) return { reason: 'fetch-failed', byType: null };
+  return { reason: null, byType: normalized };
 }
 
 const emptyCounts = () => ({

--- a/server/services/brainParity.js
+++ b/server/services/brainParity.js
@@ -315,10 +315,25 @@ export async function getBrainParityReports() {
  *
  * @param {{ peerId?: string }} [opts] - Local peer-registry id. Omitted runs
  *   every federating peer.
- * @returns {Promise<{ reports: object[] }>}
+ * @returns {Promise<{ reports: object[], peerRegistryUnavailable?: true }>}
+ *   `peerRegistryUnavailable` is set only when the peer registry could not be
+ *   read, so a caller can tell that apart from a genuinely peerless install.
  */
 export async function runBrainParityCheck({ peerId } = {}) {
-  const peers = await getPeers().catch(() => []);
+  // Sentinel, not `.catch(() => [])`: an unreadable peer registry must not look
+  // like "this install federates with nobody". Both collapse to zero reports,
+  // and the sweep job then logs a clean "no federating peers to check" run —
+  // the same absent-vs-empty conflation this module's manifest parsers guard
+  // against. A non-array return (corrupt `data.peers`) is a read failure too,
+  // and would otherwise throw on the `.filter` below.
+  const peers = await getPeers().then(
+    (list) => (Array.isArray(list) ? list : null),
+    () => null,
+  );
+  if (!peers) {
+    console.error('🧠🔍 Brain parity: peer registry unreadable — sweep skipped, parity is unknown');
+    return { reports: [], peerRegistryUnavailable: true };
+  }
   // The sweep deliberately does NOT filter on the peer's brain sync CATEGORY.
   // A peer whose brain category was turned off (or never turned on) is exactly
   // where silent divergence accumulates — filtering it out would hide the case

--- a/server/services/brainParity.test.js
+++ b/server/services/brainParity.test.js
@@ -249,6 +249,56 @@ describe('checkPeerBrainParity', () => {
     expect(await checkPeerBrainParity(PEER)).toMatchObject({ available: false, reason: 'peer-too-old' });
   });
 
+  it('treats a 200 with a malformed manifest body (missing types) as fetch-failed rather than divergence', async () => {
+    stores({ people: { p1: { id: 'p1', updatedAt: 'T1' } } });
+    peerRoutes({
+      '/api/brain/reconcile/manifest': jsonResponse({ ok: true }),
+    });
+
+    const report = await checkPeerBrainParity(PEER);
+
+    expect(report.available).toBe(false);
+    expect(report.reason).toBe('fetch-failed');
+    expect(report.summary.total).toBe(0);
+  });
+
+  it('preserves empty-but-valid manifest { types: {} } as valid parity check reporting local-only', async () => {
+    stores({ people: { p1: { id: 'p1', updatedAt: 'T1' } } });
+    peerRoutes({
+      '/api/brain/reconcile/manifest': jsonResponse({ types: {} }),
+      '/api/brain/reconcile/checksum': jsonResponse({ checksum: 'peer-checksum' }),
+    });
+
+    const report = await checkPeerBrainParity(PEER);
+
+    expect(report.available).toBe(true);
+    expect(report.summary).toMatchObject({ total: 1, 'local-only': 1 });
+  });
+
+  it('treats a 200 with an array-shaped types property as fetch-failed', async () => {
+    stores({ people: { p1: { id: 'p1', updatedAt: 'T1' } } });
+    peerRoutes({
+      '/api/brain/reconcile/manifest': jsonResponse({ types: [] }),
+    });
+
+    const report = await checkPeerBrainParity(PEER);
+
+    expect(report.available).toBe(false);
+    expect(report.reason).toBe('fetch-failed');
+  });
+
+  it('treats a malformed snapshot fallback body (missing or array records) as fetch-failed', async () => {
+    stores({ people: { p1: { id: 'p1', updatedAt: 'T1' } } });
+    peerRoutes({
+      '/api/brain/reconcile/snapshot': jsonResponse({ records: [] }),
+    });
+
+    const report = await checkPeerBrainParity(PEER);
+
+    expect(report.available).toBe(false);
+    expect(report.reason).toBe('fetch-failed');
+  });
+
   it('ignores malformed peer manifest rows instead of throwing', async () => {
     stores({ people: { p1: { id: 'p1', updatedAt: 'T1' } } });
     peerRoutes({

--- a/server/services/brainParity.test.js
+++ b/server/services/brainParity.test.js
@@ -352,6 +352,34 @@ describe('checkPeerBrainParity', () => {
 });
 
 describe('runBrainParityCheck', () => {
+  it('flags an unreadable peer registry instead of reporting a peerless sweep', async () => {
+    getPeers.mockRejectedValue(new Error('peer registry read failed'));
+
+    const result = await runBrainParityCheck();
+
+    expect(result.peerRegistryUnavailable).toBe(true);
+    expect(result.reports).toEqual([]);
+    expect(peerFetch).not.toHaveBeenCalled();
+  });
+
+  it('treats a non-array peer registry as unreadable rather than throwing on filter', async () => {
+    getPeers.mockResolvedValue(undefined);
+
+    const result = await runBrainParityCheck();
+
+    expect(result.peerRegistryUnavailable).toBe(true);
+    expect(result.reports).toEqual([]);
+  });
+
+  it('leaves peerRegistryUnavailable unset for a genuinely peerless install', async () => {
+    getPeers.mockResolvedValue([]);
+
+    const result = await runBrainParityCheck();
+
+    expect(result.peerRegistryUnavailable).toBeUndefined();
+    expect(result.reports).toEqual([]);
+  });
+
   it('returns peer-not-found for an unknown peer id without contacting anyone', async () => {
     getPeers.mockResolvedValue([PEER]);
 


### PR DESCRIPTION
## Summary

Two absent-vs-empty conflations in the brain-parity audit, both of which make a
failed check look like a completed one.

**Malformed peer manifest → whole brain reported diverged.** When a peer answers
`200 OK` with an unusable body (`{}`, `{"ok":true}`, or `types`/`records` present
but not a plain object), `normalizeRemoteManifest` and `manifestFromSnapshot`
returned `{}` — indistinguishable from a peer with a legitimately empty brain.
`diffBrainManifests` then paired every local record against an empty remote list
and classified the entire brain `local-only`. Both parsers now return an explicit
`null` sentinel, which `fetchRemoteManifest` maps to `reason: 'fetch-failed'` and
`checkPeerBrainParity` already renders as `available: false` — no new UI state.
A genuinely empty-but-well-formed manifest (`{ types: {} }`) stays on the success
path, so an install with an empty brain still gets a real comparison.

**Unreadable peer registry → sweep records a clean run.** `runBrainParityCheck`
did `getPeers().catch(() => [])`, so a registry read failure produced the same
empty result as an install that federates with nobody. Since #4557 registered the
sweep as a scheduled job, that logged "no federating peers to check" and recorded
an all-clear for an audit that never contacted anyone. It now returns
`peerRegistryUnavailable: true`, and `runBrainParitySweep` carries that into its
summary and logs it distinctly. A non-array return (corrupt `data.peers`) counts
as a read failure too — previously it escaped the `.catch` and threw on `.filter`.

Closes #4560

## Test plan

- `cd server && npm test -- --run services/brainParity.test.js services/autonomousJobs/brainParitySweep.test.js routes/brainSync.test.js` — 52 passing.
- New coverage pins the malformed-envelope cases (`{ ok: true }`, `types: []`, snapshot `records: []`) to `available: false, reason: 'fetch-failed'`, against a `{ types: {} }` case that must stay on the success path reporting real `local-only` records — so the two can't re-collapse.
- New coverage pins a rejecting and a non-array `getPeers()` to `peerRegistryUnavailable: true`, against a genuinely peerless install that must leave it unset.
- Verified the new guards fail against the unfixed source (reverted the sentinel locally: both registry tests fail, then restored).