### PR TITLE
feat: add max Codex effort level

### DIFF
--- a/client/src/components/cos/EffortSelect.test.jsx
+++ b/client/src/components/cos/EffortSelect.test.jsx
@@ -23,7 +23,7 @@ describe('EffortSelect', () => {
   it('offers codex its full ladder', () => {
     render(<EffortSelect provider={CODEX} value="" onChange={() => {}} />);
     expect(screen.getAllByRole('option').map(o => o.textContent))
-      .toEqual(['Default effort', 'minimal', 'low', 'medium', 'high', 'xhigh']);
+      .toEqual(['Default effort', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
   });
 
   // The server clamps an out-of-ladder effort rather than dropping it, so the

--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -190,13 +190,12 @@ export const filterSelectableModels = (models) =>
  * Claude Code and agy take `--effort <level>`, Codex takes
  * `-c model_reasoning_effort=<level>`.
  *
- * Codex's ladder stops at `xhigh`: its config enum is
- * `none|minimal|low|medium|high|xhigh`, and `-c model_reasoning_effort=max`
- * makes codex fail while LOADING ITS CONFIG, killing the agent at startup.
- * `resolveCliEffort` clamps `max`/`ultra` down to `xhigh` for codex.
+ * Codex's config enum includes `max` alongside
+ * `none|minimal|low|medium|high|xhigh`. `ultra` is retained only as a legacy
+ * stored value and resolves to `max` when sent to codex.
  */
 export const CLAUDE_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
-export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh']);
+export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
 export const ANTIGRAVITY_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
 // OpenCode passes this through as `reasoningEffort` to its configured local
 // provider. Ollama's OpenAI-compatible API accepts this narrow ladder for

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -94,11 +94,8 @@ describe('resolveCliEffort (server mirror)', () => {
     ['codex-only ultra clamps on claude', 'ultra', CLAUDE, 'max'],
     ['codex-only minimal clamps on claude', 'minimal', CLAUDE, 'low'],
     ['codex accepts its whole ladder', 'minimal', CODEX, 'minimal'],
-    // codex's config enum stops at `xhigh`; `-c model_reasoning_effort=max`
-    // makes it fail while loading its config, so the picker must never show a
-    // level the run can't use.
-    ['max clamps to codex xhigh', 'max', CODEX, 'xhigh'],
-    ['ultra clamps to codex xhigh', 'ultra', CODEX, 'xhigh'],
+    ['codex accepts max', 'max', CODEX, 'max'],
+    ['legacy ultra resolves to codex max', 'ultra', CODEX, 'max'],
     ['unknown value yields no flag', 'bogus', AGY, null],
     ['effort-less provider yields no flag', 'high', GROK, null],
     ['unset yields no flag', '', AGY, null],

--- a/server/lib/providerModels.js
+++ b/server/lib/providerModels.js
@@ -71,25 +71,20 @@ export const resolveCliModel = (model) => isConfiguredDefaultModel(model) ? null
 // Reasoning-effort levels — Claude Code (`--effort <level>`), Antigravity
 // (`--effort <level>`) and Codex (`-c model_reasoning_effort=<level>`) all
 // accept a per-invocation override of how hard the model thinks. Value sets
-// verified against claude CLI v2.1.x (`--help`), codex-cli 0.130 (its config
-// enum, read straight off codex's own rejection message: `none`, `minimal`,
-// `low`, `medium`, `high`, `xhigh`) and agy (`--help`: "Reasoning effort for
-// the current CLI session (low|medium|high)"). Mirrored in
+// verified against claude CLI v2.1.x (`--help`), current Codex CLI config
+// values (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`) and agy
+// (`--help`: "Reasoning effort for the current CLI session (low|medium|high)"). Mirrored in
 // client/src/utils/providers.js — keep in sync.
 //
-// Codex does NOT accept `max`/`ultra`. Listing them here emitted
-// `-c model_reasoning_effort=max`, which codex rejects while LOADING ITS CONFIG
-// — before the prompt is ever read — so the agent died at startup with "unknown
-// variant `max`, expected one of …" and burned every retry. `resolveCliEffort`
-// clamps those levels to `xhigh` instead, which also degrades gracefully if a
-// future codex does add them.
+// `ultra` remains accepted as a legacy stored value and resolves to the
+// strongest supported level, `max`, when sent to Codex.
 //
 // `none` is a real codex variant but is deliberately NOT offered: it means "do
 // not reason at all", which no PortOS effort control should be able to select.
 // ---------------------------------------------------------------------------
 
 export const CLAUDE_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhigh', 'max']);
-export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh']);
+export const CODEX_EFFORT_LEVELS = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
 export const ANTIGRAVITY_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high']);
 // OpenCode forwards this narrow OpenAI-compatible ladder as `reasoningEffort`
 // to a local Ollama model. Keep it separate from vendor-CLI-only levels.
@@ -379,7 +374,7 @@ const EFFORT_RANK = Object.freeze(['minimal', 'low', 'medium', 'high', 'xhigh', 
  * accepts, or null when the flag should be omitted entirely (no override set,
  * provider has no effort control, or the value isn't a known effort at all).
  * An out-of-range value is clamped to the nearest supported level at or below
- * it (`ultra`→`max` on claude, `max`/`ultra`→`xhigh` on codex,
+ * it (`ultra`→`max` on claude/codex,
  * `xhigh`/`max`/`ultra`→`high` on agy), falling back to the provider's weakest
  * level when nothing sits below it (`minimal`→`low`) — rather than being
  * dropped.

--- a/server/lib/providerModels.test.js
+++ b/server/lib/providerModels.test.js
@@ -385,15 +385,10 @@ describe('providerModels', () => {
         .toEqual(['-c', 'model_reasoning_effort=xhigh']);
     });
 
-    // Regression: codex's config enum stops at `xhigh`, and it rejects an
-    // unknown variant while LOADING ITS CONFIG — the agent dies at startup
-    // ("unknown variant `max`, expected one of …") before the prompt is read,
-    // then burns all three retries. A dispatch label of `effort:max` must clamp,
-    // never pass through.
-    it('never emits a level codex rejects (max/ultra clamp to xhigh)', () => {
+    it('emits max for codex and resolves legacy ultra to max', () => {
       const codex = { id: 'codex', command: 'codex' };
-      expect(buildEffortArgs('max', codex)).toEqual(['-c', 'model_reasoning_effort=xhigh']);
-      expect(buildEffortArgs('ultra', codex)).toEqual(['-c', 'model_reasoning_effort=xhigh']);
+      expect(buildEffortArgs('max', codex)).toEqual(['-c', 'model_reasoning_effort=max']);
+      expect(buildEffortArgs('ultra', codex)).toEqual(['-c', 'model_reasoning_effort=max']);
     });
 
     it('returns [] when unset, unsupported, or already baked into existing args', () => {
@@ -484,6 +479,7 @@ describe('providerModels', () => {
       expect(resolveCliEffort('high', { id: 'claude-code', command: 'claude' })).toBe('high');
       expect(resolveCliEffort('minimal', { id: 'codex', command: 'codex' })).toBe('minimal');
       expect(resolveCliEffort('xhigh', { id: 'codex', command: 'codex' })).toBe('xhigh');
+      expect(resolveCliEffort('max', { id: 'codex', command: 'codex' })).toBe('max');
     });
 
     it('clamps codex-only values to the claude equivalents on a claude provider', () => {

--- a/server/services/agentCliSpawning.test.js
+++ b/server/services/agentCliSpawning.test.js
@@ -394,18 +394,12 @@ describe('buildCliSpawnConfig', () => {
       expect(config.args).toContain('model_reasoning_effort=xhigh');
     });
 
-    // Regression for the 2026-08-17 incident: codex's config enum stops at
-    // `xhigh`, so a task dispatched at `effort:max` used to spawn
-    // `codex -c model_reasoning_effort=max`, which codex rejects while LOADING
-    // its config — before the prompt is read, so every retry died identically.
-    // The TUI builder has the twin of this assertion; the CLI builder is the one
-    // that actually shipped the bad argv.
-    it('clamps max/ultra down to xhigh for codex rather than emitting a value it rejects', () => {
-      for (const effort of ['max', 'ultra']) {
-        const config = buildCliSpawnConfig({ id: 'codex', command: 'codex' }, 'gpt-5.4', {}, { effort });
-        expect(config.args).toContain('model_reasoning_effort=xhigh');
-        expect(config.args.join(' ')).not.toContain(`model_reasoning_effort=${effort}`);
-      }
+    it('passes max to codex and resolves legacy ultra to max', () => {
+      const codex = { id: 'codex', command: 'codex' };
+      const maxConfig = buildCliSpawnConfig(codex, 'gpt-5.4', {}, { effort: 'max' });
+      expect(maxConfig.args).toContain('model_reasoning_effort=max');
+      const legacyConfig = buildCliSpawnConfig(codex, 'gpt-5.4', {}, { effort: 'ultra' });
+      expect(legacyConfig.args).toContain('model_reasoning_effort=max');
     });
 
     it('adds --effort for claude', () => {

--- a/server/services/agentTuiSpawning.test.js
+++ b/server/services/agentTuiSpawning.test.js
@@ -407,11 +407,9 @@ describe('agent TUI spawning', () => {
     const codex = buildTuiSpawnConfig(
       { id: 'codex-tui', command: 'codex', type: 'tui', args: [] },
       null,
-      // codex's config enum stops at `xhigh`; `max`/`ultra` clamp down rather
-      // than reaching the CLI, where they would fail its config load outright.
       { effort: 'max' },
     );
-    expect(codex.args).toContain('model_reasoning_effort=xhigh');
+    expect(codex.args).toContain('model_reasoning_effort=max');
     expect(codex.args).not.toContain('--effort');
   });
 

--- a/server/services/imageGen/codex.js
+++ b/server/services/imageGen/codex.js
@@ -190,9 +190,9 @@ export async function generateImage({
   // effort instead of the promised cheap `low` default. Fall back to the default
   // so the low-effort guarantee holds even for garbage input.
   // `resolveCliEffort` (rather than a bare `CODEX_EFFORT_LEVELS.includes`) so a
-  // level saved when codex's ladder was wider — `max`/`ultra`, which codex
-  // rejects at config load — clamps DOWN to `xhigh` instead of collapsing to the
-  // cheap default and silently rendering at a fraction of the requested effort.
+  // legacy `ultra` value resolves to Codex's strongest supported level instead
+  // of collapsing to the cheap default and silently rendering at a fraction of
+  // the requested effort.
   const requestedEffort = (typeof effort === 'string' && effort.trim()) ? effort.trim() : CODEX_IMAGEGEN_DEFAULT_EFFORT;
   const effectiveEffort = resolveCliEffort(requestedEffort, { command: 'codex' }) || CODEX_IMAGEGEN_DEFAULT_EFFORT;
 


### PR DESCRIPTION
## Summary
- Add `max` to the mirrored Codex effort ladders used by CoS task, schedule, reviewer, provider, and image-generation selectors.
- Pass `max` through Codex CLI/TUI/image-generation argv; resolve legacy `ultra` values to `max`.
- Update parity and spawn coverage for the new supported level.

## Test plan
- `cd server && npm test -- --run lib/providerModels.test.js lib/cosValidation.test.js services/agentCliSpawning.test.js services/agentTuiSpawning.test.js`
- `cd server && npm test -- --run routes/mediaJobs.test.js routes/cosScheduleRoutes.test.js services/imageGen/codex.test.js`
- `cd client && npm test -- --run src/components/cos/EffortSelect.test.jsx src/utils/providers.test.js src/components/cos/TaskAddForm.test.jsx src/components/cos/tabs/schedule/GlobalConfigControls.test.jsx src/components/settings/ImageGenTab.test.jsx`
- `cd client && npm run lint`
- `npm run build --prefix client`