### PR TITLE
move iMessage ingestion settings into a drawer on the iMessage manager page

### DIFF
--- a/client/src/components/messages/IMessageSettingsPanel.jsx
+++ b/client/src/components/messages/IMessageSettingsPanel.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'react-router';
-import { Save, Loader2, MessageSquare, ShieldCheck, ShieldAlert, RefreshCw, ExternalLink } from 'lucide-react';
+import { Save, Loader2, MessageSquare, ShieldCheck, ShieldAlert, RefreshCw } from 'lucide-react';
 import toast from '../ui/Toast';
 import BrailleSpinner from '../BrailleSpinner';
 import { formatDateTime } from '../../utils/formatters';
@@ -12,10 +12,15 @@ import {
   syncImessage,
 } from '../../services/api';
 
-// Settings → iMessage (#2151). Opt-in, machine-local ingestion of the macOS
-// Messages database (chat.db) into the Tribe touchpoint log + activity timeline.
-// OFF by default — reading chat.db needs macOS Full Disk Access.
-export function IMessageTab() {
+// iMessage ingestion settings (#2151). Opt-in, machine-local ingestion of the
+// macOS Messages database (chat.db) into the Tribe touchpoint log + activity
+// timeline. OFF by default — reading chat.db needs macOS Full Disk Access.
+//
+// Hosted as a right-side Drawer on Comms → Messages → iMessage rather than its
+// own Settings page, so the config sits next to the data it governs (same
+// pattern as Media Gen Settings over the Image page). `onSynced` lets the host
+// page refresh its conversation list after a sync run from in here.
+export function IMessageSettingsPanel({ onSynced }) {
   const [loading, setLoading] = useState(true);
   const [enabled, setEnabled] = useState(false);
   const [intervalMinutes, setIntervalMinutes] = useState(30);
@@ -76,6 +81,7 @@ export function IMessageTab() {
     if (result?.ok) {
       toast.success(`Synced: ${result.recorded} event(s), ${result.touchpointsCreated} touchpoint(s)${result.hasMore ? ' — more history remains, run again' : ''}`);
       setStatus((prev) => ({ ...(prev || {}), state: { ...(prev?.state || {}), cursorRowid: result.cursorRowid, lastResult: result, lastRunAt: new Date().toISOString() } }));
+      onSynced?.();
     } else {
       toast.error(result?.fullDiskAccessRequired ? 'Full Disk Access required' : (result?.error || 'Sync failed'));
       setSetup(result);
@@ -97,11 +103,8 @@ export function IMessageTab() {
           Reads your local macOS Messages database (<code className="text-gray-300">~/Library/Messages/chat.db</code>) read-only
           and feeds both Tribe touchpoints and the activity timeline. Machine-local — nothing federates to peers.
           Requires macOS <strong>Full Disk Access</strong> for the process running PortOS.
-          Browse, purge spam, and manage ingested events under{' '}
-          <Link to="/messages/imessage" className="text-port-accent hover:underline inline-flex items-center gap-1">
-            Comms → iMessage <ExternalLink size={12} />
-          </Link>
-          {' '}— deletes there remove PortOS copies only, never Apple Messages.
+          Browse, purge spam, and manage ingested events on the page behind this panel
+          — deletes there remove PortOS copies only, never Apple Messages.
           For names instead of phone numbers, sync{' '}
           <Link to="/messages/contacts" className="text-port-accent hover:underline">Comms → Contacts</Link>
           {' '}(and optionally fill Tribe phones/emails).
@@ -187,15 +190,7 @@ export function IMessageTab() {
 
       {(lastResult || status?.state?.cursorRowid > 0) && (
         <div className="bg-port-card border border-port-border rounded-lg p-4 sm:p-6">
-          <div className="flex flex-wrap items-center justify-between gap-2 mb-2">
-            <h3 className="text-sm font-semibold text-white">Last sync</h3>
-            <Link
-              to="/messages/imessage"
-              className="inline-flex items-center gap-1 text-xs text-port-accent hover:underline"
-            >
-              Open iMessage manager <ExternalLink size={12} />
-            </Link>
-          </div>
+          <h3 className="text-sm font-semibold text-white mb-2">Last sync</h3>
           <dl className="grid grid-cols-2 sm:grid-cols-3 gap-3 text-sm">
             <div><dt className="text-gray-500 text-xs uppercase">Cursor ROWID</dt><dd className="text-gray-200">{status?.state?.cursorRowid ?? 0}</dd></div>
             <div><dt className="text-gray-500 text-xs uppercase">Events recorded</dt><dd className="text-gray-200">{lastResult?.recorded ?? '—'}</dd></div>
@@ -206,12 +201,10 @@ export function IMessageTab() {
           </dl>
           {lastResult?.hasMore && (
             <p className="mt-3 text-xs text-port-warning">
-              More history remains in chat.db — run Sync now again (or open the manager) until the cursor catches up.
+              More history remains in chat.db — run Sync now again until the cursor catches up.
               First batches are often older messages; open{' '}
               <Link to="/timeline" className="text-port-accent hover:underline">Timeline</Link>
-              {' '}on those dates or use{' '}
-              <Link to="/messages/imessage" className="text-port-accent hover:underline">Comms → iMessage</Link>
-              {' '}to browse by conversation.
+              {' '}on those dates, or close this panel to browse by conversation.
             </p>
           )}
         </div>
@@ -220,4 +213,4 @@ export function IMessageTab() {
   );
 }
 
-export default IMessageTab;
+export default IMessageSettingsPanel;

--- a/client/src/components/messages/IMessageTab.jsx
+++ b/client/src/components/messages/IMessageTab.jsx
@@ -5,9 +5,12 @@ import {
   Loader2, ExternalLink, ShieldOff, Settings, CalendarClock, Users,
 } from 'lucide-react';
 import BrailleSpinner from '../BrailleSpinner';
+import Drawer from '../Drawer';
 import toast from '../ui/Toast';
 import * as api from '../../services/api';
 import { formatClockTime, timeAgo, formatDateNumeric } from '../../utils/formatters';
+import useDrawerTab from '../../hooks/useDrawerTab';
+import { IMessageSettingsPanel } from './IMessageSettingsPanel';
 
 // Comms → Messages → iMessage (#2413). Browse / manage PortOS-side activity
 // ingested from macOS chat.db. Deletes and blocklists never write Apple's Messages database.
@@ -73,7 +76,7 @@ function ConversationList({ conversations, selectedKey, onSelect, query, onQuery
           <div className="px-4 py-10 text-center text-sm text-gray-500">
             No conversations yet.
             <div className="mt-1 text-xs text-gray-600">
-              Run a sync from Settings → iMessage, then refresh.
+              Run a sync from the Settings panel above, then refresh.
             </div>
           </div>
         ) : (
@@ -452,6 +455,16 @@ export default function IMessageTab() {
   const [eventsLoading, setEventsLoading] = useState(false);
   const [syncing, setSyncing] = useState(false);
 
+  // Ingestion config lives in a right-side drawer over this page (not its own
+  // Settings page), deep-linked as ?settings=1 so ⌘K / voice can open it. The
+  // drawer has a single section, so the "tab" id list is just ['1'] — a
+  // hand-edited ?settings=xyz degrades to closed, and the hook's `replace`
+  // writes keep opening/closing it out of the browser history.
+  const [settingsParam, setSettingsParam] = useDrawerTab('settings', null, ['1']);
+  const settingsOpen = settingsParam === '1';
+  const openSettings = () => setSettingsParam('1');
+  const closeSettings = () => setSettingsParam(null);
+
   useEffect(() => {
     const t = setTimeout(() => setDebouncedQ(query.trim()), 250);
     return () => clearTimeout(t);
@@ -557,10 +570,19 @@ export default function IMessageTab() {
   const hasMore = stats?.sync?.state?.lastResult?.hasMore;
   const showDetailMobile = !!selectedKey;
 
+  // Rendered in both branches so a ?settings=1 deep link opens the drawer
+  // immediately instead of waiting on the conversation list.
+  const settingsDrawer = (
+    <Drawer open={settingsOpen} onClose={closeSettings} title="iMessage Settings" size="md">
+      <IMessageSettingsPanel onSynced={loadList} />
+    </Drawer>
+  );
+
   if (listLoading && conversations.length === 0 && !stats) {
     return (
       <div className="flex h-full items-center justify-center">
         <BrailleSpinner text="Loading iMessage" />
+        {settingsDrawer}
       </div>
     );
   }
@@ -579,13 +601,14 @@ export default function IMessageTab() {
             <Users size={12} />
             Contacts
           </Link>
-          <Link
-            to="/settings/imessage"
+          <button
+            type="button"
+            onClick={openSettings}
             className="inline-flex items-center gap-1.5 rounded border border-port-border bg-port-card px-3 py-1.5 text-xs text-gray-300 hover:border-port-accent"
           >
             <Settings size={12} />
             Settings
-          </Link>
+          </button>
           <button
             type="button"
             onClick={handleSync}
@@ -622,9 +645,9 @@ export default function IMessageTab() {
 
       {stats?.eventCount === 0 && (
         <div className="shrink-0 rounded border border-dashed border-port-border px-4 py-3 text-sm text-gray-500">
-          Nothing ingested yet. Grant Full Disk Access if needed, then use{' '}
-          <Link to="/settings/imessage" className="text-port-accent hover:underline">Settings → iMessage</Link>
-          {' '}or <strong className="text-gray-400">Sync now</strong> above. Data also appears on the{' '}
+          Nothing ingested yet. Grant Full Disk Access if needed, then open{' '}
+          <button type="button" onClick={openSettings} className="text-port-accent hover:underline">Settings</button>
+          {' '}or hit <strong className="text-gray-400">Sync now</strong> above. Data also appears on the{' '}
           <Link to="/timeline" className="text-port-accent hover:underline">Timeline</Link>
           {' '}day view (navigate to the date range of your messages).
         </div>
@@ -660,6 +683,8 @@ export default function IMessageTab() {
       {(stats?.blockedCount > 0) && (
         <BlocklistPanel onChanged={loadList} />
       )}
+
+      {settingsDrawer}
     </div>
   );
 }

--- a/client/src/components/messages/IMessageTab.test.jsx
+++ b/client/src/components/messages/IMessageTab.test.jsx
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+
+const api = vi.hoisted(() => ({
+  checkImessageSetup: vi.fn(),
+  getImessageConversationEvents: vi.fn(),
+  getImessageConversations: vi.fn(),
+  getImessageStats: vi.fn(),
+  getImessageStatus: vi.fn(),
+  getSettings: vi.fn(),
+  syncImessage: vi.fn(),
+  updateSettings: vi.fn(),
+}));
+const toast = vi.hoisted(() => Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }));
+
+vi.mock('../../services/api', () => api);
+vi.mock('../ui/Toast', () => ({ default: toast }));
+
+const IMessageTab = (await import('./IMessageTab')).default;
+
+function LocationProbe() {
+  const { search } = useLocation();
+  return <div data-testid="search">{search}</div>;
+}
+
+function renderTab(route = '/messages/imessage') {
+  return render(
+    <MemoryRouter initialEntries={[route]}>
+      <Routes>
+        <Route path="/messages/imessage" element={<><IMessageTab /><LocationProbe /></>} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getImessageStats.mockResolvedValue({ eventCount: 2, conversationCount: 1, blockedCount: 0 });
+  api.getImessageConversations.mockResolvedValue({ conversations: [] });
+  api.getImessageConversationEvents.mockResolvedValue({ events: [], identity: null });
+  api.getSettings.mockResolvedValue({ imessage: { enabled: false, intervalMinutes: 30 } });
+  api.getImessageStatus.mockResolvedValue({ state: {} });
+  api.syncImessage.mockResolvedValue({ ok: true, recorded: 1, touchpointsCreated: 0 });
+});
+
+// The ingestion config used to be its own /settings/imessage page; it is now a
+// right-side drawer over this page, deep-linked via ?settings=1 so ⌘K and voice
+// ("open iMessage settings") can still land on it.
+describe('IMessageTab — settings drawer', () => {
+  it('stays closed until the Settings button is pressed, then sets ?settings=1', async () => {
+    renderTab();
+    await screen.findByRole('button', { name: 'Settings' });
+    expect(screen.queryByText('iMessage ingestion')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Settings' }));
+
+    expect(await screen.findByText('iMessage ingestion')).toBeTruthy();
+    expect(screen.getByTestId('search').textContent).toBe('?settings=1');
+  });
+
+  it('opens straight from a ?settings=1 deep link', async () => {
+    renderTab('/messages/imessage?settings=1');
+    expect(await screen.findByText('iMessage ingestion')).toBeTruthy();
+  });
+
+  it('closing the drawer drops the param without leaving the page', async () => {
+    renderTab('/messages/imessage?settings=1');
+    await screen.findByText('iMessage ingestion');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close settings' }));
+
+    await waitFor(() => expect(screen.getByTestId('search').textContent).toBe(''));
+    expect(screen.queryByText('iMessage ingestion')).toBeNull();
+  });
+
+  it('refreshes the conversation list after a sync run inside the drawer', async () => {
+    renderTab('/messages/imessage?settings=1');
+    await screen.findByText('iMessage ingestion');
+    const listCalls = api.getImessageConversations.mock.calls.length;
+
+    const drawer = screen.getByRole('dialog', { name: 'iMessage Settings' });
+    fireEvent.click(within(drawer).getByRole('button', { name: /Sync now/ }));
+
+    await waitFor(() => {
+      expect(api.getImessageConversations.mock.calls.length).toBeGreaterThan(listCalls);
+    });
+  });
+});

--- a/client/src/components/settings/SettingsTabsHeader.jsx
+++ b/client/src/components/settings/SettingsTabsHeader.jsx
@@ -18,7 +18,6 @@ export const TABS = [
   { id: 'database', label: 'Database', to: '/settings/database' },
   { id: 'embeddings', label: 'Embeddings', to: '/settings/embeddings' },
   { id: 'general', label: 'General', to: '/settings/general' },
-  { id: 'imessage', label: 'iMessage', to: '/settings/imessage' },
   { id: 'local-llm', label: 'Local LLMs', to: '/settings/local-llm' },
   { id: 'mortalloom', label: 'MortalLoom', to: '/settings/mortalloom' },
   { id: 'openclaw', label: 'OpenClaw', to: '/openclaw' },

--- a/client/src/pages/Settings.jsx
+++ b/client/src/pages/Settings.jsx
@@ -11,7 +11,6 @@ import EmbeddingsTab from '../components/settings/EmbeddingsTab';
 import { LocalLlmTab } from '../components/settings/LocalLlmTab';
 import { TelegramTab } from '../components/settings/TelegramTab';
 import { GeneralTab } from '../components/settings/GeneralTab';
-import { IMessageTab } from '../components/settings/IMessageTab';
 import { MortalLoomTab } from '../components/settings/MortalLoomTab';
 import { SecurityTab } from '../components/settings/SecurityTab';
 import { SharingTab } from '../components/settings/SharingTab';
@@ -25,7 +24,8 @@ import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
 // it makes sense. Redirect old direct URLs to the new home so bookmarks and
 // stale palette entries keep working.
 const REDIRECTS = {
-  'image-gen': '/media/image?settings=1'
+  'image-gen': '/media/image?settings=1',
+  imessage: '/messages/imessage?settings=1'
 };
 
 export default function Settings() {
@@ -39,7 +39,6 @@ export default function Settings() {
   const renderTabContent = () => {
     switch (activeTab) {
       case 'general': return <GeneralTab />;
-      case 'imessage': return <IMessageTab />;
       case 'ai-assignments': return <AiAssignmentsTab />;
       case 'api-access': return <ApiAccessTab />;
       case 'autofixer': return <AutofixerTab />;

--- a/client/src/pages/Settings.redirects.test.jsx
+++ b/client/src/pages/Settings.redirects.test.jsx
@@ -2,7 +2,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
 
-vi.mock('../services/api', () => new Proxy({}, { get: () => vi.fn().mockResolvedValue({}) }));
+// Settings.jsx imports every tab component, and those pull in the API client.
+// Stub the whole module so no tab's import-time wiring reaches the network. The
+// Proxy answers any named import with a resolved-promise spy; `then` must stay
+// undefined or Vitest's `await` on the factory result treats the namespace as a
+// thenable and hangs waiting for a resolve that never comes.
+vi.mock('../services/api', () => new Proxy({}, {
+  get: (_target, key) => (key === 'then' || key === '__esModule' ? undefined : vi.fn().mockResolvedValue({})),
+}));
 
 const Settings = (await import('./Settings')).default;
 

--- a/client/src/pages/Settings.redirects.test.jsx
+++ b/client/src/pages/Settings.redirects.test.jsx
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router';
+
+vi.mock('../services/api', () => new Proxy({}, { get: () => vi.fn().mockResolvedValue({}) }));
+
+const Settings = (await import('./Settings')).default;
+
+function Landed() {
+  const { pathname, search } = useLocation();
+  return <div data-testid="landed">{`${pathname}${search}`}</div>;
+}
+
+// Two former Settings tabs now live as drawers over the page they configure.
+// Their old /settings/<tab> URLs stay live as redirects so bookmarks, stale ⌘K
+// history, and older docs keep working — and land with the drawer already open.
+describe('Settings — retired tabs redirect to their drawer', () => {
+  it.each([
+    ['/settings/image-gen', '/media/image?settings=1'],
+    ['/settings/imessage', '/messages/imessage?settings=1'],
+  ])('%s → %s', (from, to) => {
+    render(
+      <MemoryRouter initialEntries={[from]}>
+        <Routes>
+          <Route path="/settings/:tab" element={<Settings />} />
+          <Route path="*" element={<Landed />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId('landed').textContent).toBe(to);
+  });
+});

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -149,6 +149,9 @@ export const NAV_COMMANDS = [
   { id: 'nav.messages.drafts', path: '/messages/drafts', label: 'Drafts', section: 'Comms', aliases: ['drafts', 'comms-drafts'], keywords: ['comms'] },
   { id: 'nav.messages.imessage', path: '/messages/imessage', label: 'iMessage', section: 'Comms', aliases: ['imessage', 'i-message', 'apple-messages', 'comms-imessage'], keywords: ['comms', 'imessage', 'sms', 'text messages', 'chat.db', 'blocklist', 'spam'] },
   { id: 'nav.messages.contacts', path: '/messages/contacts', label: 'Contacts', section: 'Comms', aliases: ['contacts', 'address-book', 'comms-contacts', 'settings-contacts'], keywords: ['comms', 'contacts', 'address book', 'phone', 'email', 'tribe', 'imessage', 'names', 'resolve'] },
+  // Ingestion config is a drawer over the iMessage manager (?settings=1), not a
+  // Settings page — the settings-* aliases stay so "open iMessage settings" still lands.
+  { id: 'nav.messages.imessage-settings', path: '/messages/imessage?settings=1', label: 'iMessage Settings', section: 'Comms', aliases: ['settings-imessage', 'imessage-settings', 'imessage-sync'], keywords: ['imessage', 'sync', 'chat.db', 'sms', 'texts', 'tribe', 'timeline', 'full disk access'] },
   { id: 'nav.messages.config', path: '/messages/config', label: 'Config', section: 'Comms', aliases: ['messages-config', 'comms-config'], keywords: ['comms'] },
   { id: 'nav.messages.sync', path: '/messages/sync', label: 'Sync', section: 'Comms', aliases: ['messages-sync', 'comms-sync'], keywords: ['comms'] },
   { id: 'nav.stacker-news', path: '/stacker-news', label: 'Stacker News', section: 'Comms', aliases: ['stacker-news', 'stacker', 'sn'], keywords: ['comms', 'community', 'territory', 'moderation', 'stewardship'] },
@@ -259,9 +262,6 @@ export const NAV_COMMANDS = [
   { id: 'nav.settings.database', path: '/settings/database', label: 'Database', section: 'Settings', aliases: ['settings-database', 'database'] },
   { id: 'nav.settings.embeddings', path: '/settings/embeddings', label: 'Embeddings', section: 'Settings', aliases: ['settings-embeddings', 'embeddings', 'embedding'], keywords: ['vector', 'pgvector', 'semantic search', 'nomic', 'ollama', 'lm studio'] },
   { id: 'nav.settings.general', path: '/settings/general', label: 'General', section: 'Settings', aliases: ['settings', 'settings-general', 'general'] },
-  // Alias `imessage` lives on Comms → iMessage (the manager page, #2413); settings
-  // keeps the explicit settings-* tokens so voice "open iMessage settings" still works.
-  { id: 'nav.settings.imessage', path: '/settings/imessage', label: 'iMessage', section: 'Settings', aliases: ['settings-imessage', 'imessage-settings'], keywords: ['imessage', 'sync', 'chat.db', 'sms', 'texts', 'tribe', 'timeline', 'full disk access'] },
   { id: 'nav.settings.local-llm', path: '/settings/local-llm', label: 'Local LLMs', section: 'Settings', aliases: ['local-llm', 'local-llms', 'ollama', 'lm-studio', 'lmstudio'], keywords: ['ollama', 'lm studio', 'local model', 'local llm', 'gguf', 'pull model', 'install model', 'migrate', 'switch backend'] },
   { id: 'nav.settings.local-llm-playground', path: '/local-llm/playground', label: 'Local LLM Playground', section: 'Settings', aliases: ['llm-playground', 'playground', 'model-playground', 'compare-models'], keywords: ['ollama', 'lm studio', 'compare', 'benchmark', 'chat', 'test model', 'ttft', 'tokens per second', 'local llm'] },
   { id: 'nav.settings.mortalloom', path: '/settings/mortalloom', label: 'MortalLoom', section: 'Settings', aliases: ['settings-mortalloom', 'mortalloom'] },

--- a/server/services/bootstrap.js
+++ b/server/services/bootstrap.js
@@ -378,7 +378,8 @@ const startBackgroundServices = ({ spawnerReady }) => {
   // for the historical timeline scrubber (issue #877).
   startOpenWorldSnapshotScheduler().catch(err => console.error(`❌ OpenWorld snapshot scheduler init failed: ${err.message}`));
   // Initialize iMessage sync scheduler — OFF by default; only polls chat.db when
-  // the user opts in via Settings → iMessage (needs macOS Full Disk Access) (#2151).
+  // the user opts in from the iMessage Settings drawer on Comms → Messages → iMessage
+  // (needs macOS Full Disk Access) (#2151).
   startImessageScheduler().catch(err => console.error(`❌ iMessage sync scheduler init failed: ${err.message}`));
   // Initialize Signal sync scheduler — OFF by default; only reads the SQLCipher
   // chat DB (via the keychain-wrapped key) when the user opts in via

--- a/server/services/imessageScheduler.js
+++ b/server/services/imessageScheduler.js
@@ -5,8 +5,9 @@
  * ingestion (see imessageSync.js). Mirrors the openWorldSnapshotScheduler pattern.
  *
  * OFF by default: the scheduler is only registered when the user has opted in via
- * Settings → iMessage (`settings.imessage.enabled`). Reading chat.db needs macOS
- * Full Disk Access, so we never poll it silently. The interval value is locked in
+ * the iMessage Settings drawer on Comms → Messages → iMessage
+ * (`settings.imessage.enabled`). Reading chat.db needs macOS Full Disk Access,
+ * so we never poll it silently. The interval value is locked in
  * at registration (changing it needs a restart), but the `enabled` toggle is
  * re-read on every tick so disabling from settings stops runs without a restart.
  *

--- a/server/services/imessageSync.js
+++ b/server/services/imessageSync.js
@@ -45,8 +45,9 @@ const DEFAULT_CHAT_DB = '~/Library/Messages/chat.db';
 const STATE_FILE = 'imessage-sync-state.json';
 
 // Config defaults — surfaced via getImessageConfig(). Sync is OFF by default;
-// the user opts in from Settings → iMessage. Reading chat.db needs Full Disk
-// Access, so we never enable it silently.
+// the user opts in from the iMessage Settings drawer (Comms → Messages →
+// iMessage). Reading chat.db needs Full Disk Access, so we never enable it
+// silently.
 const DEFAULT_CONFIG = {
   enabled: false,
   intervalMinutes: 30,


### PR DESCRIPTION
## Summary

The iMessage sync config had its own page under Settings, one click away from the conversation list it governs. It now opens as a right-side slide-in `Drawer` over **Comms → Messages → iMessage**, matching how Media Gen Settings sits over the Image page.

- Renamed `components/settings/IMessageTab.jsx` → `components/messages/IMessageSettingsPanel.jsx` and dropped its self-referential links to the page it now overlays. A new `onSynced` callback refreshes the conversation list after a sync run started from inside the drawer.
- The page's **Settings** button (and the empty-state prompt) open the drawer via `useDrawerTab('settings', null, ['1'])`, so `?settings=1` is deep-linkable, a hand-edited `?settings=xyz` degrades to closed, and toggling stays out of the browser history.
- Retired the Settings tab: removed the `renderTabContent` case, the `SettingsTabsHeader` entry, and the `nav.settings.imessage` manifest command. `/settings/imessage` now redirects to `/messages/imessage?settings=1` through the same `REDIRECTS` mechanism `image-gen` already uses, and a new `nav.messages.imessage-settings` entry keeps the `settings-imessage` / `imessage-settings` aliases resolving from ⌘K and voice.
- Refreshed three server comments (`imessageScheduler.js`, `imessageSync.js`, `bootstrap.js`) that still pointed readers at the retired page.

## Test plan

- New `client/src/components/messages/IMessageTab.test.jsx` — the drawer stays closed until the Settings button is pressed (and then sets `?settings=1`), opens straight from a `?settings=1` deep link, drops the param on close without leaving the page, and refreshes the conversation list after a sync run inside the drawer.
- New `client/src/pages/Settings.redirects.test.jsx` — both retired tabs (`image-gen`, `imessage`) redirect to their drawer URL.
- Existing `server/lib/navManifest.test.js` guards cover the manifest change in both directions: nav↔tab-bar coverage and the Settings header↔switch parity check both required removing all three `imessage` Settings surfaces together.
- Full suites green: client 681 files / 8406 tests, server 1485 files / 30646 tests. `biome lint --error-on-warnings src` clean.