### PR TITLE
fix: remove duplicate OpenWorld loading screen

### DIFF
--- a/client/src/pages/OpenWorld.fastTravel.test.jsx
+++ b/client/src/pages/OpenWorld.fastTravel.test.jsx
@@ -7,6 +7,7 @@ import { MemoryRouter, Routes, Route, useLocation } from 'react-router';
 // rendering WebGL in jsdom. The scene stub records the props it received so the assertions
 // can read them directly.
 const sceneProps = { current: null };
+const openWorldDataState = vi.hoisted(() => ({ loading: false }));
 vi.mock('../components/openworld/OpenWorldScene', () => ({
   default: (props) => {
     sceneProps.current = props;
@@ -32,7 +33,7 @@ vi.mock('../hooks/useOpenWorldData', () => ({
     apps: [], cosAgents: [], cosStatus: {}, eventLogs: [], agentMap: new Map(),
     reviewCounts: {}, instances: {}, systemHealth: null, notificationCounts: {},
     backupStatus: null, cosTasks: [], healthMetrics: null, voiceState: null,
-    character: null, aiActivity: null, loading: false, connected: true,
+    character: null, aiActivity: null, loading: openWorldDataState.loading, connected: true,
   }),
 }));
 vi.mock('../hooks/useOpenWorldPlayback', () => ({
@@ -80,7 +81,17 @@ const renderAt = (path) => render(
 describe('OpenWorld — fast travel wiring', () => {
   beforeEach(() => {
     sceneProps.current = null;
+    openWorldDataState.loading = false;
     localStorage.clear();
+  });
+
+  it('keeps the scene mounted while the initial data bundle is loading', () => {
+    openWorldDataState.loading = true;
+
+    renderAt('/openworld');
+
+    expect(screen.getByTestId('scene')).toBeInTheDocument();
+    expect(screen.queryByText('ENTERING OPENWORLD')).not.toBeInTheDocument();
   });
 
   it('hands the scene no region on the plain overview route', () => {

--- a/client/src/pages/OpenWorld.jsx
+++ b/client/src/pages/OpenWorld.jsx
@@ -432,21 +432,11 @@ function OpenWorldInner() {
 
   const v = useCallback((key, live) => (playbackProps && key in playbackProps ? playbackProps[key] : live), [playbackProps]);
 
-  if (loading) {
-    return (
-      <div className="flex flex-col items-center justify-center h-full gap-4 openworld-themed" style={{ background: openWorldPalette.background }}>
-        <div className="font-pixel text-cyan-400 text-lg tracking-widest animate-pulse" style={{ textShadow: '0 0 12px rgba(6,182,212,0.5)' }}>
-          ENTERING OPENWORLD
-        </div>
-        <div className="w-48 h-1 bg-gray-800 rounded-full overflow-hidden">
-          <div className="h-full bg-cyan-500 rounded-full animate-pulse" style={{ width: '60%', boxShadow: '0 0 8px rgba(6,182,212,0.5)' }} />
-        </div>
-        <div className="font-pixel text-[10px] text-cyan-500/40 tracking-wider">
-          LOADING WORLD...
-        </div>
-      </div>
-    );
-  }
+  // Keep the scene and app shell mounted while the initial data bundle arrives. The route's
+  // Suspense boundary already covers the lazy OpenWorld chunk; replacing the entire page here
+  // created a second full-screen loader after the first one, then remounted WebGL once the API
+  // calls settled. Empty/default props are safe for every landmark, and OpenWorldScene's own
+  // warm-up keeps the first data-driven layout cheap while the real values stream in.
 
   return (
     <OpenWorldPaletteProvider palette={openWorldPalette}>


### PR DESCRIPTION
## Summary
- Keep the OpenWorld scene and app shell mounted while the initial data requests settle.
- Remove the second full-screen `ENTERING OPENWORLD` loader that remounted WebGL after the route loader.
- Add regression coverage for rendering the scene while initial data is still loading.

## Validation
- `npm test -- --run src/pages/OpenWorld.fastTravel.test.jsx src/components/openworld/OpenWorldFastTravel.test.jsx src/utils/openWorldMiniMap.test.js src/utils/openWorldRegions.test.js` (73 tests)
- `npm run lint`
- `npm run build`

The build retains the existing large-chunk warning for the Three.js/vendor bundles.