### PR TITLE
fix: auto-link llama.cpp keg when brew install leaves it unlinked

### DIFF
--- a/server/services/llamaServerManager.js
+++ b/server/services/llamaServerManager.js
@@ -226,6 +226,20 @@ export async function stopLlamaServer() {
 }
 
 /**
+ * Runs `brew link --overwrite llama.cpp`, resolving true/false on exit
+ * rather than rejecting — a failed link attempt should fall through to the
+ * caller's own error message, not replace it with a `brew link` failure.
+ */
+function linkLlamaCpp(env) {
+  return new Promise((resolve) => {
+    const spawnOpts = safeChildProcessOptions({ env, shell: false, stdio: 'ignore' });
+    const child = spawn('brew', ['link', '--overwrite', 'llama.cpp'], spawnOpts);
+    child.on('error', () => resolve(false));
+    child.on('exit', (code) => resolve(code === 0));
+  });
+}
+
+/**
  * Installs llama.cpp via Homebrew.
  */
 export async function installLlamaServer({ onProgress = () => {} } = {}) {
@@ -258,13 +272,29 @@ export async function installLlamaServer({ onProgress = () => {} } = {}) {
       reject(new ServerError(`Failed to run brew: ${err.message}`, { status: 500 }));
     });
     child.on('exit', async (code) => {
-      const binaryPath = await findCommandOnPath('llama-server');
-      const installed = Boolean(binaryPath) && await commandExists(binaryPath);
+      let binaryPath = await findCommandOnPath('llama-server');
+      let installed = Boolean(binaryPath) && await commandExists(binaryPath);
+
+      // `brew install` exits 0 without linking when the keg is already
+      // installed but unlinked ("Warning: llama.cpp X is already installed,
+      // it's just not linked."). Link it explicitly rather than leaving that
+      // warning as a dead end for the caller.
+      if (!installed && code === 0) {
+        onProgress({ event: 'progress', message: 'llama.cpp keg is installed but not linked — linking…' });
+        const linked = await linkLlamaCpp(env);
+        if (linked) {
+          binaryPath = await findCommandOnPath('llama-server');
+          installed = Boolean(binaryPath) && await commandExists(binaryPath);
+        }
+      }
+
       if (installed) {
         onProgress({ event: 'complete', message: 'llama.cpp installed successfully' });
         resolve({ success: true, message: 'llama.cpp installed successfully' });
       } else {
-        const msg = code === 0 ? 'brew completed but llama-server was not found on PATH' : `brew install llama.cpp failed (exit code ${code})`;
+        const msg = code === 0
+          ? 'brew completed but llama-server was not found on PATH — try running `brew link --overwrite llama.cpp` manually'
+          : `brew install llama.cpp failed (exit code ${code})`;
         reject(new ServerError(msg, { status: 500 }));
       }
     });

--- a/server/services/llamaServerManager.test.js
+++ b/server/services/llamaServerManager.test.js
@@ -11,6 +11,13 @@ import * as commandExistsModule from '../lib/commandExists.js';
 import * as childProcess from '../lib/childProcess.js';
 import { EventEmitter } from 'events';
 
+function fakeSpawnProcess() {
+  const child = new EventEmitter();
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  return child;
+}
+
 describe('llamaServerManager', () => {
   beforeEach(() => {
     _resetLlamaServerStateForTests();
@@ -136,5 +143,49 @@ describe('llamaServerManager', () => {
     vi.spyOn(commandExistsModule, 'commandExists').mockResolvedValue(false);
 
     await expect(installLlamaServer()).rejects.toThrow(/Homebrew was not found/i);
+  });
+
+  it('links an already-installed-but-unlinked keg after `brew install` exits 0', async () => {
+    // brew is present; llama-server is NOT on PATH until after the link step.
+    vi.spyOn(commandExistsModule, 'commandExists').mockImplementation(async (cmd) => cmd === 'brew');
+    const findSpy = vi.spyOn(processEnv, 'findCommandOnPath').mockResolvedValue(null);
+
+    const installChild = fakeSpawnProcess();
+    const linkChild = fakeSpawnProcess();
+    const spawnCalls = [];
+    vi.spyOn(childProcess, 'spawn').mockImplementation((cmd, args) => {
+      spawnCalls.push({ cmd, args });
+      const child = args[0] === 'install' ? installChild : linkChild;
+      setTimeout(() => child.emit('exit', 0), 10);
+      return child;
+    });
+
+    const resultPromise = installLlamaServer();
+
+    // Once `brew link` resolves, the binary shows up on PATH.
+    setTimeout(() => {
+      findSpy.mockResolvedValue('/opt/homebrew/bin/llama-server');
+      commandExistsModule.commandExists.mockImplementation(async () => true);
+    }, 15);
+
+    const result = await resultPromise;
+    expect(result.success).toBe(true);
+    expect(spawnCalls).toEqual([
+      { cmd: 'brew', args: ['install', 'llama.cpp'] },
+      { cmd: 'brew', args: ['link', '--overwrite', 'llama.cpp'] },
+    ]);
+  });
+
+  it('rejects with a `brew link` hint when linking does not resolve the binary', async () => {
+    vi.spyOn(commandExistsModule, 'commandExists').mockImplementation(async (cmd) => cmd === 'brew');
+    vi.spyOn(processEnv, 'findCommandOnPath').mockResolvedValue(null);
+
+    vi.spyOn(childProcess, 'spawn').mockImplementation(() => {
+      const child = fakeSpawnProcess();
+      setTimeout(() => child.emit('exit', 0), 10);
+      return child;
+    });
+
+    await expect(installLlamaServer()).rejects.toThrow(/brew link --overwrite llama\.cpp/i);
   });
 });


### PR DESCRIPTION
## Summary
- \`brew install llama.cpp\` exits 0 without linking the binaries when the keg is already installed but was previously unlinked (\`Warning: llama.cpp X is already installed, it's just not linked.\`), so \`llama-server\` never lands on PATH and the local-LLM "Install llama.cpp" flow stalls on that brew warning.
- \`installLlamaServer\` now detects this case (exit code 0, binary still not found) and runs \`brew link --overwrite llama.cpp\`, then re-checks PATH before giving up. On failure it now also surfaces an actionable hint (\`brew link --overwrite llama.cpp\`) instead of a dead-end message.

## Test plan
- [x] \`cd server && npx vitest run services/llamaServerManager.test.js\` — includes two new tests covering the unlinked-keg auto-link success path and the failure-hint path
- [x] Full server suite (\`npm test\` in \`server/\`) — 1486 files / 30669 tests passing