### PR TITLE
feat: make OpenWorld a first-person game world

### DIFF
--- a/client/src/components/openworld/OpenWorldFastTravel.jsx
+++ b/client/src/components/openworld/OpenWorldFastTravel.jsx
@@ -5,10 +5,10 @@ import { listRegions, searchRegions } from '../../utils/openWorldRegions';
 import { WORLD } from '../../utils/openWorldPlan';
 import useOpenWorldViewport from '../../hooks/useOpenWorldViewport';
 
-// OpenWorld's fast-travel panel — the thing that makes this an open world rather than one
-// city you pan around. Every named region is a warp destination: pick one and the camera
-// (or, in exploration mode, the player) travels there, and each region carries a door into
-// the 2D PortOS page it visualizes.
+// OpenWorld's world map — the thing that makes this an open world rather than one city you pan
+// around. Every named region is a warp destination: pick one and the camera (or, in exploration
+// mode, the player) travels there. The region metadata describes the PortOS area represented by
+// the district; this panel never opens that area as a separate page.
 //
 // Selection is NOT held here. Clicking a region navigates to `/openworld/region/:regionId`
 // and the route param drives the camera — the same URL-is-the-source-of-truth rule building
@@ -33,7 +33,7 @@ const MAP_BOUNDS = {
 // disagree about where the bay starts.
 const GEOGRAPHY = projectGeography(MAP_BOUNDS, MINI_MAP_PADDING);
 
-export default function OpenWorldFastTravel({ open, onClose, onTravel, activeRegionId, onOpenPage, onLeaveRegion }) {
+export default function OpenWorldFastTravel({ open, onClose, onTravel, activeRegionId, onLeaveRegion }) {
   const [query, setQuery] = useState('');
   const inputRef = useRef(null);
   const { isCondensed } = useOpenWorldViewport();
@@ -75,11 +75,11 @@ export default function OpenWorldFastTravel({ open, onClose, onTravel, activeReg
       onClose={onClose}
       size="none"
       usePortal
-      ariaLabel="Fast travel"
+      ariaLabel="World map"
       panelClassName="w-full max-w-3xl max-h-[85vh] rounded-xl border port-media-overlay flex flex-col overflow-hidden"
     >
       <div className="flex items-center gap-3 px-4 py-3 border-b border-current/10">
-        <div className="font-pixel text-[12px] tracking-widest">FAST TRAVEL</div>
+        <div className="font-pixel text-[12px] tracking-widest">WORLD MAP</div>
         <input
           ref={inputRef}
           type="text"
@@ -135,7 +135,7 @@ export default function OpenWorldFastTravel({ open, onClose, onTravel, activeReg
                 key={region.id}
                 type="button"
                 title={region.label}
-                aria-label={`Travel to ${region.label}`}
+                aria-label={`Teleport to ${region.label}`}
                 onClick={() => travel(region)}
                 className={`absolute -translate-x-1/2 -translate-y-1/2 rounded-full border transition-all flex items-center justify-center ${
                   isActive
@@ -171,16 +171,6 @@ export default function OpenWorldFastTravel({ open, onClose, onTravel, activeReg
                   <div className="font-pixel text-[11px] tracking-wide truncate">{region.label}</div>
                   <div className="text-[11px] opacity-70 truncate">{region.blurb}</div>
                 </button>
-                {region.appPath && onOpenPage && (
-                  <button
-                    type="button"
-                    onClick={() => onOpenPage(region.appPath)}
-                    title={`Open ${region.appPath}`}
-                    className="port-media-overlay-item shrink-0 font-pixel text-[9px] px-2 py-2 rounded border border-current/20 tracking-wide"
-                  >
-                    OPEN
-                  </button>
-                )}
               </div>
             </li>
           ))}

--- a/client/src/components/openworld/OpenWorldFastTravel.test.jsx
+++ b/client/src/components/openworld/OpenWorldFastTravel.test.jsx
@@ -8,7 +8,6 @@ const renderPanel = (props = {}) => render(
     open
     onClose={vi.fn()}
     onTravel={vi.fn()}
-    onOpenPage={vi.fn()}
     activeRegionId={null}
     onLeaveRegion={vi.fn()}
     {...props}
@@ -57,16 +56,11 @@ describe('OpenWorldFastTravel', () => {
     expect(screen.getByText(/NO REGION MATCHES/)).toBeInTheDocument();
   });
 
-  it('opens the PortOS page a region stands for without warping', () => {
-    const onOpenPage = vi.fn();
-    const onTravel = vi.fn();
-    renderPanel({ onOpenPage, onTravel });
+  it('does not offer a PortOS page escape hatch', () => {
+    renderPanel();
 
-    fireEvent.change(screen.getByLabelText('Search regions'), { target: { value: 'memory' } });
-    fireEvent.click(screen.getByTitle('Open /brain/inbox'));
-
-    expect(onOpenPage).toHaveBeenCalledWith('/brain/inbox');
-    expect(onTravel).not.toHaveBeenCalled();
+    expect(screen.queryByText('OPEN')).not.toBeInTheDocument();
+    expect(screen.queryByTitle(/Open\s+\//)).not.toBeInTheDocument();
   });
 
   it('omits the OPEN affordance for a region with no page behind it', () => {
@@ -89,7 +83,6 @@ describe('OpenWorldFastTravel', () => {
         open
         onClose={onClose}
         onTravel={vi.fn()}
-        onOpenPage={vi.fn()}
         onLeaveRegion={onLeaveRegion}
         activeRegionId="memory"
       />
@@ -106,7 +99,7 @@ describe('OpenWorldFastTravel', () => {
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
-    expect(dialog).toHaveAttribute('aria-label', 'Fast travel');
+    expect(dialog).toHaveAttribute('aria-label', 'World map');
 
     fireEvent.click(dialog.parentElement);
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -119,9 +112,9 @@ describe('OpenWorldFastTravel', () => {
     const onTravel = vi.fn();
     renderPanel({ onTravel });
     for (const region of OPEN_WORLD_REGIONS) {
-      expect(screen.getByLabelText(`Travel to ${region.label}`)).toBeInTheDocument();
+      expect(screen.getByLabelText(`Teleport to ${region.label}`)).toBeInTheDocument();
     }
-    fireEvent.click(screen.getByLabelText('Travel to Data Harbor'));
+    fireEvent.click(screen.getByLabelText('Teleport to Data Harbor'));
     expect(onTravel.mock.calls[0][0].id).toBe('data-harbor');
   });
 });

--- a/client/src/components/openworld/OpenWorldFocusPanel.jsx
+++ b/client/src/components/openworld/OpenWorldFocusPanel.jsx
@@ -3,8 +3,8 @@ import { useMemo } from 'react';
 // Building-detail panel shown while a borough is focused (issue #2593). It REPLACES the Intel pane
 // (desktop) / renders as a bottom sheet (compact) — never overlapping it — and surfaces the app's
 // live state from data OpenWorld already has: status, process summary + unhealthy processes, and the
-// agents assigned to the app. Two explicit actions: Open app (routes to /apps/:id) and Close
-// (returns to the /city overview). Also renders the stale/deleted-id "not found" fallback.
+// agents assigned to the app. Two explicit actions: focus the building in the world and Close
+// (returns to the OpenWorld overview). It never opens the represented PortOS page.
 
 const STATUS_STYLES = {
   online: { text: 'text-port-success', dot: 'bg-port-success', label: 'ONLINE' },
@@ -25,7 +25,7 @@ function StatBlock({ label, value, tone = 'text-cyan-300' }) {
   );
 }
 
-export default function OpenWorldFocusPanel({ app, notFound = false, agents = [], onClose, onOpenApp, isDesktop = true }) {
+export default function OpenWorldFocusPanel({ app, notFound = false, agents = [], onClose, onFocusInWorld, isDesktop = true }) {
   // Desktop: occupy the Intel-pane slot. Compact: a bottom sheet above the dock.
   const containerClass = isDesktop
     ? 'absolute top-16 right-3 bottom-20 w-72 pointer-events-auto'
@@ -158,11 +158,11 @@ export default function OpenWorldFocusPanel({ app, notFound = false, agents = []
         <div className="flex items-center gap-2 px-3 py-2 border-t border-cyan-500/20 shrink-0">
           <button
             type="button"
-            onClick={() => onOpenApp?.(app.id)}
+            onClick={() => onFocusInWorld?.(app.id)}
             className="flex-1 min-h-[44px] font-pixel text-[10px] text-cyan-400 tracking-wider border border-cyan-500/40 rounded px-2 py-2 hover:bg-cyan-500/10 transition-colors"
-            title="Open the app detail page"
+            title="Focus this building in the world"
           >
-            OPEN APP {'>'}
+            FOCUS BUILDING {'>'}
           </button>
           <button
             type="button"

--- a/client/src/components/openworld/OpenWorldFocusPanel.test.jsx
+++ b/client/src/components/openworld/OpenWorldFocusPanel.test.jsx
@@ -39,11 +39,11 @@ describe('OpenWorldFocusPanel', () => {
     expect(screen.queryByText('Old done task')).toBeNull();
   });
 
-  it('fires onOpenApp with the app id from the explicit Open app action', () => {
-    const onOpenApp = vi.fn();
-    render(<OpenWorldFocusPanel app={app} agents={[]} onOpenApp={onOpenApp} />);
-    fireEvent.click(screen.getByTitle('Open the app detail page'));
-    expect(onOpenApp).toHaveBeenCalledWith('alpha');
+  it('fires onFocusInWorld with the app id from the explicit in-world action', () => {
+    const onFocusInWorld = vi.fn();
+    render(<OpenWorldFocusPanel app={app} agents={[]} onFocusInWorld={onFocusInWorld} />);
+    fireEvent.click(screen.getByTitle('Focus this building in the world'));
+    expect(onFocusInWorld).toHaveBeenCalledWith('alpha');
   });
 
   it('fires onClose from the close and back actions', () => {

--- a/client/src/components/openworld/OpenWorldHud.jsx
+++ b/client/src/components/openworld/OpenWorldHud.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router';
+import { Map as MapIcon } from 'lucide-react';
 import OpenWorldIntelPane from './OpenWorldIntelPane';
 import OpenWorldFocusPanel from './OpenWorldFocusPanel';
 import OpenWorldAgentBar from './OpenWorldAgentBar';
@@ -33,7 +34,7 @@ function ControlsHint({ visible }) {
     <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none animate-in fade-in duration-500">
       <div className="bg-black/85 border border-cyan-500/40 rounded-lg px-6 py-4 text-center">
         <div className="font-pixel text-[11px] text-cyan-400 tracking-wider mb-3" style={{ textShadow: '0 0 8px rgba(6,182,212,0.5)' }}>
-          EXPLORATION MODE
+          FIRST-PERSON EXPLORATION
         </div>
         <div className="grid grid-cols-3 gap-1 w-fit mx-auto mb-3">
           <div />
@@ -47,9 +48,9 @@ function ControlsHint({ visible }) {
           <div>MOUSE: LOOK AROUND (CLICK TO LOCK)</div>
           <div>WASD: MOVE · Q/E: DOWN/UP</div>
           <div>SHIFT: SPRINT</div>
-          <div>F: INTERACT WITH BUILDING</div>
-          <div>M: FAST TRAVEL</div>
-          <div>TAB: FLY OUT</div>
+          <div>F: FOCUS BUILDING / WARP PAD</div>
+          <div>M: WORLD MAP</div>
+          <div>TAB: ORBITAL OVERVIEW · V: THIRD PERSON</div>
         </div>
       </div>
     </div>
@@ -70,7 +71,7 @@ function Crosshair() {
   );
 }
 
-export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs, connected, apps, reviewCounts, instances, productivityData, systemHealth, notificationCounts, character, filter, onFilterChange, onJumpToFirst, matchCount, onToggleExploration, explorationMode, onSelectApp, onEnterPhotoMode, onEnterPlayback, focusedAppId, focusedApp, focusNotFound, focusAgents, onCloseFocus, onOpenApp, onOpenFastTravel, activeRegion }) {
+export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs, connected, apps, reviewCounts, instances, productivityData, systemHealth, notificationCounts, character, filter, onFilterChange, onJumpToFirst, matchCount, onToggleExploration, explorationMode, onSelectApp, onEnterPhotoMode, onEnterPlayback, focusedAppId, focusedApp, focusNotFound, focusAgents, onCloseFocus, onFocusInWorld, onOpenFastTravel, onOpenDestination, onAttentionItem, activeRegion }) {
   const isFocused = Boolean(focusedApp || focusNotFound);
   const navigate = useNavigate();
   const location = useLocation();
@@ -134,6 +135,7 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
     productivityData,
     activeApps,
     totalApps,
+    onOpenDestination,
   };
 
   return (
@@ -221,7 +223,7 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
               notFound={focusNotFound}
               agents={focusAgents}
               onClose={onCloseFocus}
-              onOpenApp={onOpenApp}
+              onFocusInWorld={onFocusInWorld}
               isDesktop
             />
           ) : (
@@ -233,6 +235,8 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
               systemHealth={systemHealth}
               notificationCounts={notificationCounts}
               eventLogs={eventLogs}
+              onItemActivate={onAttentionItem}
+              onOpenFastTravel={onOpenFastTravel}
             />
           )}
 
@@ -240,7 +244,7 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
           <OpenWorldAgentBar cosAgents={cosAgents} agentMap={agentMap} />
 
           {/* Bottom-right: character level / XP HUD badge (roadmap 2.11) */}
-          <OpenWorldXpBadge character={character} />
+          <OpenWorldXpBadge character={character} onOpenDestination={onOpenDestination} />
 
           {/* Bottom-left: mini-map + Settings gear + legend + corner decoration */}
           <div className="absolute bottom-16 left-3">
@@ -268,17 +272,20 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
               </div>
             </div>
 
-            {/* Fast travel (M) — warp to any named region of the world */}
+            {/* World map (M) — warp to any named region without leaving the game */}
             {onOpenFastTravel && (
               <button
+                type="button"
                 onClick={onOpenFastTravel}
                 className="pointer-events-auto mb-2 relative bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg px-3 py-2 hover:border-cyan-400/60 hover:bg-cyan-500/10 transition-all w-full"
-                title="Fast travel to a region (M)"
+                title="World map — teleport to a region (M)"
+                aria-label="World map — teleport to a region"
               >
                 <HudCorner position="tl" />
                 <HudCorner position="br" />
-                <div className="font-pixel text-[10px] text-cyan-400 tracking-wider truncate" style={{ textShadow: '0 0 6px rgba(6,182,212,0.4)' }}>
-                  [ FAST TRAVEL ]
+                <div className="flex items-center justify-center gap-2 font-pixel text-[10px] text-cyan-400 tracking-wider truncate" style={{ textShadow: '0 0 6px rgba(6,182,212,0.4)' }}>
+                  <MapIcon size={15} aria-hidden="true" />
+                  <span>[ WORLD MAP ]</span>
                 </div>
                 <div className="font-pixel text-[7px] text-cyan-500/40 tracking-wide mt-0.5 text-center truncate">
                   {activeRegion ? activeRegion.label.toUpperCase() : '(M)'}
@@ -387,8 +394,10 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
           focusNotFound={focusNotFound}
           focusAgents={focusAgents}
           onCloseFocus={onCloseFocus}
-          onOpenApp={onOpenApp}
+          onFocusInWorld={onFocusInWorld}
           onOpenFastTravel={onOpenFastTravel}
+          onOpenDestination={onOpenDestination}
+          onAttentionItem={onAttentionItem}
         />
       )}
 

--- a/client/src/components/openworld/OpenWorldHudCompact.jsx
+++ b/client/src/components/openworld/OpenWorldHudCompact.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useNavigate, useLocation } from 'react-router';
-import { Gauge, Bell, Clock, Activity, Map as MapIcon, Filter, Palette, Compass, Camera, History, Settings, Navigation, X } from 'lucide-react';
+import { Gauge, Bell, Clock, Activity, Map as MapIcon, Filter, Palette, Compass, Camera, History, Settings, X } from 'lucide-react';
 import useDrawerTab from '../../hooks/useDrawerTab';
 import { buildAttentionItems, OpenWorldIntelContent } from './OpenWorldIntelPane';
 import OpenWorldVitalsList from './OpenWorldVitalsList';
@@ -85,12 +85,14 @@ export default function OpenWorldHudCompact({
   onEnterPhotoMode,
   onEnterPlayback,
   onOpenFastTravel,
+  onOpenDestination,
+  onAttentionItem,
   focusedAppId,
   focusedApp,
   focusNotFound,
   focusAgents,
   onCloseFocus,
-  onOpenApp,
+  onFocusInWorld,
 }) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -114,10 +116,10 @@ export default function OpenWorldHudCompact({
 
   const renderPaneBody = () => {
     if (CITY_INTEL_PANE_IDS.includes(activePane)) {
-      return <OpenWorldIntelContent tab={activePane} items={items} eventLogs={eventLogs} />;
+      return <OpenWorldIntelContent tab={activePane} items={items} eventLogs={eventLogs} onItemActivate={onAttentionItem} onOpenFastTravel={onOpenFastTravel} />;
     }
     if (activePane === 'vitals') {
-      return <div className="p-3"><OpenWorldVitalsList {...vitals} /></div>;
+      return <div className="p-3"><OpenWorldVitalsList {...vitals} onOpenDestination={onOpenDestination} /></div>;
     }
     if (activePane === 'map') {
       return hasApps
@@ -180,22 +182,22 @@ export default function OpenWorldHudCompact({
         {character?.level != null ? (
           <button
             type="button"
-            onClick={() => navigate('/character')}
-            aria-label={`Character sheet — level ${character.level}`}
-            title="Open character sheet"
+            onClick={() => onOpenDestination?.('artifacts')}
+            aria-label={`Teleport to Hall of Achievements — level ${character.level}`}
+            title="Teleport to Hall of Achievements"
             className="bg-black/85 backdrop-blur-sm border border-cyan-500/40 rounded-lg px-2.5 min-h-[44px] flex items-center font-pixel text-[11px] text-cyan-300 tracking-wider"
           >
             LV {character.level}
           </button>
         ) : birthCta ? (
           // Character loaded but no usable level (age-based, #2673). Prompt the user to set the
-          // birth date — or FIX it when present-but-unusable (#2757) — routing to the age editor
-          // where the field lives.
+          // birth date — or FIX it when present-but-unusable (#2757). The CTA points to a
+          // nearby in-world district so the game remains the active surface.
           <button
             type="button"
-            onClick={() => navigate(birthCta.path)}
-            aria-label={`${birthCta.title} to show your level`}
-            title={birthCta.title}
+            onClick={() => onOpenDestination?.('goals')}
+            aria-label={`${birthCta.title} — teleport to Goal Monuments`}
+            title="Teleport to Goal Monuments"
             // A present-but-unusable date (invalid/future/unreadable) renders in the warning color,
             // matching the CharacterSheet "fix" prompt and the changelog's promise (#2757).
             className={`bg-black/85 backdrop-blur-sm rounded-lg px-2.5 min-h-[44px] flex items-center font-pixel text-[11px] tracking-wider border ${
@@ -217,7 +219,7 @@ export default function OpenWorldHudCompact({
           notFound={focusNotFound}
           agents={focusAgents}
           onClose={onCloseFocus}
-          onOpenApp={onOpenApp}
+          onFocusInWorld={onFocusInWorld}
           isDesktop={false}
         />
       )}
@@ -258,7 +260,11 @@ export default function OpenWorldHudCompact({
           <DockButton icon={Bell} label="Attention" active={activePane === 'attention'} badge={items.length} badgeCritical={criticalCount > 0} onClick={() => togglePane('attention')} />
           <DockButton icon={Clock} label="Timeline" active={activePane === 'timeline'} onClick={() => togglePane('timeline')} />
           <DockButton icon={Activity} label="Activity log" active={activePane === 'activity'} onClick={() => togglePane('activity')} />
-          {hasApps && <DockButton icon={MapIcon} label="Map" active={activePane === 'map'} onClick={() => togglePane('map')} />}
+          {onOpenFastTravel ? (
+            <DockButton icon={MapIcon} label="World map — teleport to a region" onClick={onOpenFastTravel} />
+          ) : hasApps && (
+            <DockButton icon={MapIcon} label="Building map" active={activePane === 'map'} onClick={() => togglePane('map')} />
+          )}
           <DockButton icon={Filter} label="Filter apps" active={activePane === 'filter'} onClick={() => togglePane('filter')} />
           <DockButton icon={Palette} label="Legend" active={activePane === 'legend'} onClick={() => togglePane('legend')} />
 
@@ -270,7 +276,6 @@ export default function OpenWorldHudCompact({
             active={explorationMode}
             onClick={onToggleExploration}
           />
-          {onOpenFastTravel && <DockButton icon={Navigation} label="Fast travel" onClick={onOpenFastTravel} />}
           {onEnterPhotoMode && <DockButton icon={Camera} label="Photo mode" onClick={onEnterPhotoMode} />}
           {onEnterPlayback && <DockButton icon={History} label="History playback" onClick={onEnterPlayback} />}
           <DockButton icon={Settings} label="OpenWorld settings" active={onSettings} onClick={goSettings} />

--- a/client/src/components/openworld/OpenWorldHudCompact.test.jsx
+++ b/client/src/components/openworld/OpenWorldHudCompact.test.jsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter, useLocation } from 'react-router';
 import OpenWorldHudCompact from './OpenWorldHudCompact';
@@ -50,6 +50,8 @@ const baseProps = {
   onSelectApp: () => {},
   onEnterPhotoMode: () => {},
   onEnterPlayback: () => {},
+  onOpenFastTravel: () => {},
+  onOpenDestination: () => {},
 };
 
 const renderCompact = (search = '', props = {}) =>
@@ -77,6 +79,13 @@ describe('OpenWorldHudCompact', () => {
     expect(screen.getByTestId('loc').textContent).toContain('openWorldPane=attention');
     // The sheet header for the opened pane appears.
     expect(screen.getByText('ATTENTION')).toBeInTheDocument();
+  });
+
+  it('uses the map icon to open the in-world teleport map', () => {
+    const onOpenFastTravel = vi.fn();
+    renderCompact('', { onOpenFastTravel });
+    fireEvent.click(screen.getByLabelText('World map — teleport to a region'));
+    expect(onOpenFastTravel).toHaveBeenCalledTimes(1);
   });
 
   it('restores the open pane from the URL on load', () => {

--- a/client/src/components/openworld/OpenWorldIntelPane.jsx
+++ b/client/src/components/openworld/OpenWorldIntelPane.jsx
@@ -1,5 +1,4 @@
 import { useMemo, useRef, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router';
 import { formatClockTime } from '../../utils/formatters';
 import { computeActivityDensity, buildTimelineBuckets } from '../../utils/openWorldTimeline';
 import useDrawerTab from '../../hooks/useDrawerTab';
@@ -23,7 +22,7 @@ export function buildAttentionItems({ apps, cosAgents, reviewCounts, instances, 
         severity: 'critical',
         label: `${app.name || app.id}`,
         detail: 'Stopped',
-        to: `/apps/${app.id}`,
+        appId: app.id,
         category: 'app',
       });
     }
@@ -35,7 +34,7 @@ export function buildAttentionItems({ apps, cosAgents, reviewCounts, instances, 
           severity: 'critical',
           label: `${app.name || app.id} · ${procName}`,
           detail: 'Process errored',
-          to: `/apps/${app.id}`,
+          appId: app.id,
           category: 'app',
         });
       }
@@ -50,7 +49,7 @@ export function buildAttentionItems({ apps, cosAgents, reviewCounts, instances, 
         severity: sev,
         label: w.message || `System: ${w.type}`,
         detail: 'System health',
-        to: '/',
+        regionId: 'wellness',
         category: 'system',
       });
     });
@@ -62,7 +61,7 @@ export function buildAttentionItems({ apps, cosAgents, reviewCounts, instances, 
       severity: 'critical',
       label: `${reviewCounts.alert} alert${reviewCounts.alert === 1 ? '' : 's'}`,
       detail: 'Review hub',
-      to: '/review',
+      regionId: 'task-queue',
       category: 'review',
     });
   }
@@ -72,7 +71,7 @@ export function buildAttentionItems({ apps, cosAgents, reviewCounts, instances, 
       severity: 'warning',
       label: `${reviewCounts.total} pending review${reviewCounts.total === 1 ? '' : 's'}`,
       detail: 'Review hub',
-      to: '/review',
+      regionId: 'task-queue',
       category: 'review',
     });
   }
@@ -85,7 +84,7 @@ export function buildAttentionItems({ apps, cosAgents, reviewCounts, instances, 
       severity: 'warning',
       label: `${offlinePeers.length} of ${peers.length} peer${peers.length === 1 ? '' : 's'} offline`,
       detail: 'Federation',
-      to: '/instances',
+      regionId: 'data-harbor',
       category: 'federation',
     });
   }
@@ -99,7 +98,7 @@ export function buildAttentionItems({ apps, cosAgents, reviewCounts, instances, 
       severity: 'warning',
       label: agent.task || agent.taskTitle || `Agent ${agent.agentId?.slice(0, 8) || ''}`,
       detail: 'Agent failed',
-      to: '/cos',
+      regionId: 'ai-core',
       category: 'agent',
     });
   });
@@ -111,7 +110,7 @@ export function buildAttentionItems({ apps, cosAgents, reviewCounts, instances, 
       severity: 'info',
       label: `${unread} unread notification${unread === 1 ? '' : 's'}`,
       detail: 'Open dashboard alerts',
-      to: '/',
+      regionId: 'downtown',
       category: 'notifications',
     });
   }
@@ -119,9 +118,7 @@ export function buildAttentionItems({ apps, cosAgents, reviewCounts, instances, 
   return items.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]);
 }
 
-function AttentionList({ items }) {
-  const navigate = useNavigate();
-
+function AttentionList({ items, onItemActivate }) {
   if (items.length === 0) {
     return (
       <div className="flex-1 flex items-center justify-center px-3 py-6">
@@ -141,7 +138,7 @@ function AttentionList({ items }) {
           <button
             key={item.id}
             type="button"
-            onClick={() => item.to && navigate(item.to)}
+            onClick={() => onItemActivate?.(item)}
             className={`w-full text-left flex items-start gap-2 px-2 py-1.5 rounded border ${colors.border} bg-black/40 hover:bg-cyan-500/10 transition-colors`}
             title={`${item.label} — ${item.detail}`}
           >
@@ -245,8 +242,7 @@ const relativeAge = (ms) => {
 // Temporal view of the event stream: a density sparkbar (when did bursts of
 // activity happen) over relative-age buckets (what happened, newest first).
 // Reads the same `eventLogs` the ACTIVITY tab does — no new data wiring.
-function TimelineView({ logs }) {
-  const navigate = useNavigate();
+function TimelineView({ logs, onOpenFastTravel }) {
   // Tick `now` every 15s so "2m" ages forward without re-fetching anything.
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
@@ -326,10 +322,10 @@ function TimelineView({ logs }) {
 
       <button
         type="button"
-        onClick={() => navigate('/cos')}
+        onClick={onOpenFastTravel}
         className="w-full font-pixel text-[8px] text-cyan-500/40 hover:text-cyan-400 tracking-wider py-1 transition-colors"
       >
-        OPEN CHIEF OF STAFF {'>'}
+        OPEN WORLD MAP {'>'}
       </button>
     </div>
   );
@@ -347,13 +343,13 @@ export const CITY_INTEL_TABS = [
 // Renders just the body for a given intel tab — reused by the desktop cockpit pane
 // and the compact/phone disclosure sheet so both show identical content. The parent
 // must be a bounded `flex flex-col` container (the lists are `flex-1`).
-export function OpenWorldIntelContent({ tab, items, eventLogs }) {
-  if (tab === 'timeline') return <TimelineView logs={eventLogs} />;
+export function OpenWorldIntelContent({ tab, items, eventLogs, onItemActivate, onOpenFastTravel }) {
+  if (tab === 'timeline') return <TimelineView logs={eventLogs} onOpenFastTravel={onOpenFastTravel} />;
   if (tab === 'activity') return <ActivityLogList logs={eventLogs} />;
-  return <AttentionList items={items} />;
+  return <AttentionList items={items} onItemActivate={onItemActivate} />;
 }
 
-export default function OpenWorldIntelPane({ apps, cosAgents, reviewCounts, instances, systemHealth, notificationCounts, eventLogs }) {
+export default function OpenWorldIntelPane({ apps, cosAgents, reviewCounts, instances, systemHealth, notificationCounts, eventLogs, onItemActivate, onOpenFastTravel }) {
   // The active tab is URL-addressable via `openWorldPane` (shared with the compact
   // layout), so a reload / back-forward restores it and a deep link opens it.
   // `vitals`/`map`/etc. aren't intel tabs, so anything outside the intel subset
@@ -464,7 +460,7 @@ export default function OpenWorldIntelPane({ apps, cosAgents, reviewCounts, inst
             tabIndex={0}
             className="flex-1 min-h-0 flex flex-col focus:outline-none focus-visible:ring-1 focus-visible:ring-cyan-400/60"
           >
-            <OpenWorldIntelContent tab={tab} items={items} eventLogs={eventLogs} />
+            <OpenWorldIntelContent tab={tab} items={items} eventLogs={eventLogs} onItemActivate={onItemActivate} onOpenFastTravel={onOpenFastTravel} />
           </div>
         )}
       </div>

--- a/client/src/components/openworld/OpenWorldMiniMap.jsx
+++ b/client/src/components/openworld/OpenWorldMiniMap.jsx
@@ -10,8 +10,8 @@ import { computeMiniMap } from '../../utils/openWorldMiniMap';
 // matches its building's color exactly.
 //
 // Click-to-select reuses the existing building-click plumbing: `onSelectApp(app)` is the same
-// callback OpenWorldScene fires on a building click (OpenWorld navigates to /apps/:id). When no
-// callback is supplied the map is purely informational.
+// callback OpenWorldScene fires on a building click (OpenWorld focuses the building in-world).
+// When no callback is supplied the map is purely informational.
 //
 // Hidden on very small screens (per OpenWorldHud conventions — the right-side intel pane and
 // bottom agent bar already crowd a phone viewport). It's flow-positioned (no absolute) so it

--- a/client/src/components/openworld/OpenWorldScene.jsx
+++ b/client/src/components/openworld/OpenWorldScene.jsx
@@ -90,7 +90,7 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
   // DoF preview). Null whenever DoF isn't mounted — capture then falls back to a plain render.
   const photoComposerRef = useRef(null);
 
-  const explorationMode = settings?.explorationMode || false;
+  const explorationMode = settings?.explorationMode ?? true;
   // Art direction gate, read off the palette every other themed surface already consumes
   // (Building, ProcessBuilding, OpenWorldLandscape) rather than re-resolving the style from
   // settings — one bit, one channel. The neon-night layers below (galaxy spheremap,
@@ -349,7 +349,7 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
           apps={apps}
           active={explorationMode}
           transitioning={transitioning}
-          cameraView={settings?.cameraView ?? 'third'}
+          cameraView={settings?.cameraView ?? 'first'}
           teleport={playerTeleport}
           warpPads={warpRegions}
           onWarpPadInteract={onTravelToRegion}

--- a/client/src/components/openworld/OpenWorldSettingsDrawer.jsx
+++ b/client/src/components/openworld/OpenWorldSettingsDrawer.jsx
@@ -383,7 +383,7 @@ export default function OpenWorldSettingsDrawer({ open, onClose, qualityMode = '
                 { key: 'third', label: 'CHARACTER' },
                 { key: 'first', label: 'FIRST PERSON' },
               ]}
-              value={settings.cameraView ?? 'third'}
+              value={settings.cameraView ?? 'first'}
               onChange={(key) => updateSetting('cameraView', key)}
               hint="CAMERA WHILE EXPLORING (V SWAPS IN-WORLD)"
             />

--- a/client/src/components/openworld/OpenWorldVitalsList.jsx
+++ b/client/src/components/openworld/OpenWorldVitalsList.jsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router';
 import { formatDurationMs, formatMonthDay } from '../../utils/formatters';
 import { StatButton, metricColor } from './openWorldHudBits';
 
@@ -22,9 +21,8 @@ export default function OpenWorldVitalsList({
   totalNodes,
   notificationCounts,
   productivityData,
+  onOpenDestination,
 }) {
-  const navigate = useNavigate();
-
   return (
     <div className="space-y-1.5">
       <div className="font-pixel text-[10px] text-cyan-500/70 tracking-wider mb-1">
@@ -41,10 +39,10 @@ export default function OpenWorldVitalsList({
 
       <button
         type="button"
-        onClick={() => navigate('/')}
+        onClick={() => onOpenDestination?.('wellness')}
         className="w-full flex items-center justify-between gap-3 -mx-1 px-1 py-1 min-h-[44px] sm:min-h-0 rounded hover:bg-cyan-500/5 transition-colors"
-        title={warnings?.length ? warnings.map(w => w.message).join(' · ') : 'System health — click to open dashboard'}
-        aria-label="System health — open dashboard"
+        title={warnings?.length ? warnings.map(w => w.message).join(' · ') : 'Teleport to Wellness District'}
+        aria-label="System health — teleport to Wellness District"
       >
         <span className="font-pixel text-[10px] text-gray-400 tracking-wide flex items-center gap-1.5">
           <span className={`w-1.5 h-1.5 rounded-full ${sentinel.dot} shadow-[0_0_4px_currentColor]`} />
@@ -68,16 +66,16 @@ export default function OpenWorldVitalsList({
         valueClass={activeAgentCount > 0 ? 'text-emerald-400' : 'text-gray-600'}
         value={`${activeAgentCount} ACTIVE`}
         prefix={activeAgentCount > 0 ? <span className="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400 mr-1 animate-pulse" /> : null}
-        onClick={() => navigate('/cos')}
-        title="Open Chief of Staff"
+        onClick={() => onOpenDestination?.('ai-core')}
+        title="Teleport to AI Core"
       />
 
       {stoppedApps > 0 && (
-        <StatButton label="STOPPED" valueClass="text-red-400" value={stoppedApps} onClick={() => navigate('/apps')} title="View apps" />
+        <StatButton label="STOPPED" valueClass="text-red-400" value={stoppedApps} onClick={() => onOpenDestination?.('downtown')} title="Teleport to Downtown" />
       )}
 
       {archivedApps > 0 && (
-        <StatButton label="ARCHIVED" valueClass="text-gray-500" value={archivedApps} onClick={() => navigate('/apps')} title="View apps" />
+        <StatButton label="ARCHIVED" valueClass="text-gray-500" value={archivedApps} onClick={() => onOpenDestination?.('downtown')} title="Teleport to Downtown" />
       )}
 
       {(pendingReview > 0 || alertCount > 0) && (
@@ -85,8 +83,8 @@ export default function OpenWorldVitalsList({
           label="REVIEW"
           valueClass={alertCount > 0 ? 'text-orange-400' : 'text-cyan-400'}
           value={`${pendingReview} PENDING${alertCount > 0 ? ` · ${alertCount} ALERT${alertCount === 1 ? '' : 'S'}` : ''}`}
-          onClick={() => navigate('/review')}
-          title="Open Review Hub"
+          onClick={() => onOpenDestination?.('task-queue')}
+          title="Teleport to Task Queue"
         />
       )}
 
@@ -94,16 +92,16 @@ export default function OpenWorldVitalsList({
         label="NODES"
         valueClass={onlinePeers > 0 ? 'text-violet-400' : 'text-gray-500'}
         value={`${onlinePeers}/${totalNodes} LINKED`}
-        onClick={() => navigate('/instances')}
-        title="Open Federation / Instances"
+        onClick={() => onOpenDestination?.('data-harbor')}
+        title="Teleport to Data Harbor"
       />
 
       {notificationCounts?.unread > 0 && (
-        <StatButton label="NOTIFS" valueClass="text-cyan-400" value={`${notificationCounts.unread} UNREAD`} onClick={() => navigate('/')} title="Open dashboard alerts" />
+        <StatButton label="NOTIFS" valueClass="text-cyan-400" value={`${notificationCounts.unread} UNREAD`} onClick={() => onOpenDestination?.('downtown')} title="Teleport to Downtown" />
       )}
 
       {productivityData?.todaySucceeded > 0 && (
-        <StatButton label="TASKS" valueClass="text-purple-400" value={`${productivityData.todaySucceeded} TODAY`} onClick={() => navigate('/cos')} title="Open Chief of Staff" />
+        <StatButton label="TASKS" valueClass="text-purple-400" value={`${productivityData.todaySucceeded} TODAY`} onClick={() => onOpenDestination?.('productivity')} title="Teleport to Productivity" />
       )}
 
       {productivityData?.currentDailyStreak > 0 && (
@@ -111,8 +109,8 @@ export default function OpenWorldVitalsList({
           label="STREAK"
           valueClass={productivityData.currentDailyStreak >= 3 ? 'text-orange-400' : 'text-gray-400'}
           value={`${productivityData.currentDailyStreak}d`}
-          onClick={() => navigate('/cos')}
-          title="Open Chief of Staff"
+          onClick={() => onOpenDestination?.('productivity')}
+          title="Teleport to Productivity"
         />
       )}
 

--- a/client/src/components/openworld/OpenWorldXpBadge.jsx
+++ b/client/src/components/openworld/OpenWorldXpBadge.jsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { useNavigate } from 'react-router';
 import { computeAgeView, diffXp, birthDateCta } from '../../utils/characterXp';
 
 // OpenWorld character HUD badge (roadmap 2.11; reframed in #2673). A compact floating panel
@@ -11,8 +10,7 @@ import { computeAgeView, diffXp, birthDateCta } from '../../utils/characterXp';
 //
 // Animations are self-contained (transient state + inline transition) so the component
 // stays standalone and doesn't depend on global keyframes.
-export default function OpenWorldXpBadge({ character }) {
-  const navigate = useNavigate();
+export default function OpenWorldXpBadge({ character, onOpenDestination }) {
   const view = useMemo(() => computeAgeView(character), [character]);
 
   const prevCharRef = useRef(null);
@@ -50,17 +48,17 @@ export default function OpenWorldXpBadge({ character }) {
   const gaining = burst.kind !== null;
   const barColor = leveling ? '#f59e0b' : '#06b6d4';
   const pct = Math.round(view.progress * 100);
-  // No usable level → show a prompt instead of NaN and send the click to the age editor (where
-  // the birth-date field lives). The CTA distinguishes a genuinely unset date ("set") from a
-  // present-but-unusable one ("fix" — invalid/future/unreadable), so we never tell the user to
-  // set a date they already entered (#2757).
+  // No usable level → show a prompt instead of NaN and send the click to the Goal Monuments
+  // district. The CTA distinguishes a genuinely unset date ("set") from a present-but-unusable
+  // one ("fix" — invalid/future/unreadable), so we never tell the user to set a date they already
+  // entered (#2757).
   // birthDateCta returns null for 'ok' (a real level exists). It's non-null whenever hasBirthDate
   // is false under the server's status⟺level invariant, but read every cta.* through `?.`/`??`
   // anyway so a hypothetical invariant break degrades to the SET prompt instead of crashing the
   // whole HUD — the same defensive gate CharacterSheet and OpenWorldHudCompact use (#2757, claude review).
   const cta = view.hasBirthDate ? null : birthDateCta(view.birthDateStatus);
   const levelLabel = view.hasBirthDate ? `LV ${view.level}` : (cta?.badgeLabel ?? 'LV —');
-  const target = view.hasBirthDate ? '/character' : (cta?.path ?? '/meatspace/age');
+  const destination = view.hasBirthDate ? 'artifacts' : 'goals';
   // A present-but-unusable date (invalid/future/unreadable) renders in the warning color, matching
   // the CharacterSheet "fix" prompt and the changelog's promise (#2757). Never true while leveling.
   const fixState = cta?.kind === 'fix';
@@ -69,8 +67,8 @@ export default function OpenWorldXpBadge({ character }) {
     <div className="absolute bottom-16 right-3 pointer-events-auto">
       <button
         type="button"
-        onClick={() => navigate(target)}
-        title={view.hasBirthDate ? 'Open character sheet' : (cta?.title ?? 'Set your birth date')}
+        onClick={() => onOpenDestination?.(destination)}
+        title={view.hasBirthDate ? 'Teleport to Hall of Achievements' : 'Teleport to Goal Monuments'}
         className={`relative block w-40 sm:w-48 bg-black/85 backdrop-blur-sm border rounded-lg px-3 py-2.5 overflow-hidden text-left transition-all duration-300 hover:bg-cyan-500/10 ${
           leveling
             ? 'border-amber-400/70 shadow-[0_0_16px_rgba(245,158,11,0.5)]'

--- a/client/src/components/openworld/OpenWorldXpBadge.test.jsx
+++ b/client/src/components/openworld/OpenWorldXpBadge.test.jsx
@@ -22,7 +22,7 @@ describe('OpenWorldXpBadge birth-date CTA (#2757)', () => {
     renderBadge({ level: null, ageYears: null, birthDateStatus: 'unset' });
     expect(screen.getByText('LV —')).toBeInTheDocument();
     expect(screen.getByText('SET BIRTH DATE')).toBeInTheDocument();
-    expect(screen.getByTitle('Set your birth date')).toBeInTheDocument();
+    expect(screen.getByTitle('Teleport to Goal Monuments')).toBeInTheDocument();
   });
 
   it('shows the FIX prompt (LV !) in the warning style for a present-but-unusable date', () => {

--- a/client/src/components/openworld/PlayerController.jsx
+++ b/client/src/components/openworld/PlayerController.jsx
@@ -34,8 +34,8 @@ const _lookTarget = new THREE.Vector3();
 
 // Exploration-mode player rig. One mutable rig object is the single source of truth for
 // the player's pose; both camera modes (and the third-person avatar) read from it:
-//   - 'first' (V to toggle): the classic invisible first-person camera.
-//   - 'third' (default): a damped follow camera behind a visible cyber-runner, with
+//   - 'first' (default): the classic invisible first-person camera.
+//   - 'third' (V to toggle): a damped follow camera behind a visible cyber-runner, with
 //     building-aware boom shortening (openWorldPlayerRig.js owns all the math).
 // All original behavior is preserved: WASD/arrows, shift sprint, E/Q vertical, F interact,
 // pointer-lock mouselook, per-building cylinder collision below flyover height, world
@@ -50,7 +50,7 @@ export default function PlayerController({
   apps,
   active,
   transitioning = false,
-  cameraView = 'third',
+  cameraView = 'first',
   teleport = null,
   warpPads = [],
   onWarpPadInteract,

--- a/client/src/hooks/useOpenWorldSettings.js
+++ b/client/src/hooks/useOpenWorldSettings.js
@@ -55,8 +55,10 @@ const DEFAULT_SETTINGS = {
   // land on the new default — deliberate, this IS the world's new look — and the picker in
   // the Visual tab switches back with no migration.
   worldStyle: 'vibes',
-  explorationMode: false,
-  cameraView: 'third', // exploration camera: 'third' follows the cyber-runner; 'first' is classic FPS (V toggles)
+  // OpenWorld opens as a game, not an orbital dashboard. Users can still press Tab (or the
+  // HUD control) to pull back to the planning view, but a fresh visit starts in first person.
+  explorationMode: true,
+  cameraView: 'first', // exploration camera: 'first' is the default FPS view; 'third' is optional
   ...QUALITY_PRESETS.high,
 };
 

--- a/client/src/hooks/useOpenWorldSettings.test.jsx
+++ b/client/src/hooks/useOpenWorldSettings.test.jsx
@@ -55,6 +55,8 @@ describe('useOpenWorldSettings localStorage resilience', () => {
     const [settings] = result.current;
     expect(settings.qualityMode).toBe('auto');
     expect(settings.qualityPreset).toBe('high');
+    expect(settings.explorationMode).toBe(true);
+    expect(settings.cameraView).toBe('first');
   });
 
   it('loads an existing pre-Auto payload as Manual, keeping its preset', () => {
@@ -95,6 +97,8 @@ describe('useOpenWorldSettings localStorage resilience', () => {
     expect(result.current[3]).toBe(before + 1);
     const [settings] = result.current;
     expect(settings.qualityMode).toBe('auto'); // reset restores Auto default
+    expect(settings.explorationMode).toBe(true);
+    expect(settings.cameraView).toBe('first');
   });
 
   it('handles the time-of-day-auto event without throwing when writes fail', () => {

--- a/client/src/pages/OpenWorld.fastTravel.test.jsx
+++ b/client/src/pages/OpenWorld.fastTravel.test.jsx
@@ -106,6 +106,16 @@ describe('OpenWorld — fast travel wiring', () => {
     expect(sceneProps.current.focusedRegion.anchor).toBeDefined();
   });
 
+  it('arms the first-person arrival point for a direct region deep link', () => {
+    renderAt('/openworld/region/memory');
+    expect(sceneProps.current.playerTeleport).toMatchObject({
+      x: expect.any(Number),
+      z: expect.any(Number),
+      regionId: 'memory',
+      token: 1,
+    });
+  });
+
   it('hands the scene a null region for an unknown id rather than crashing', () => {
     renderAt('/openworld/region/atlantis');
     expect(sceneProps.current.focusedRegion).toBeNull();
@@ -130,7 +140,7 @@ describe('OpenWorld — fast travel wiring', () => {
     renderAt('/openworld');
     act(() => { fireEvent.keyDown(window, { key: 'm' }); });
 
-    fireEvent.click(screen.getByLabelText('Travel to Memory Quarter'));
+    fireEvent.click(screen.getByLabelText('Teleport to Memory Quarter'));
 
     expect(screen.getByTestId('path')).toHaveTextContent('/openworld/region/memory');
     expect(sceneProps.current.focusedRegion.id).toBe('memory');
@@ -139,7 +149,7 @@ describe('OpenWorld — fast travel wiring', () => {
   it('opens fast travel from the HUD button too', () => {
     renderAt('/openworld');
     fireEvent.click(screen.getByText('hud-fast-travel'));
-    expect(screen.getByLabelText('Travel to Memory Quarter')).toBeInTheDocument();
+    expect(screen.getByLabelText('Teleport to Memory Quarter')).toBeInTheDocument();
   });
 
   it('closes fast travel with Escape', () => {
@@ -162,7 +172,7 @@ describe('OpenWorld — fast travel wiring', () => {
     // land at the region rather than the old spawn.
     renderAt('/openworld');
     act(() => { fireEvent.keyDown(window, { key: 'm' }); });
-    fireEvent.click(screen.getByLabelText('Travel to Memory Quarter'));
+    fireEvent.click(screen.getByLabelText('Teleport to Memory Quarter'));
 
     const teleport = sceneProps.current.playerTeleport;
     expect(teleport).toMatchObject({ x: expect.any(Number), z: expect.any(Number) });
@@ -173,7 +183,7 @@ describe('OpenWorld — fast travel wiring', () => {
     localStorage.setItem('portos-city-settings', JSON.stringify({ explorationMode: true }));
     renderAt('/openworld');
     act(() => { fireEvent.keyDown(window, { key: 'm' }); });
-    fireEvent.click(screen.getByLabelText('Travel to Memory Quarter'));
+    fireEvent.click(screen.getByLabelText('Teleport to Memory Quarter'));
 
     const teleport = sceneProps.current.playerTeleport;
     expect(teleport).toMatchObject({ x: expect.any(Number), z: expect.any(Number) });
@@ -184,11 +194,11 @@ describe('OpenWorld — fast travel wiring', () => {
     renderAt('/openworld');
 
     act(() => { fireEvent.keyDown(window, { key: 'm' }); });
-    fireEvent.click(screen.getByLabelText('Travel to Memory Quarter'));
+    fireEvent.click(screen.getByLabelText('Teleport to Memory Quarter'));
     expect(sceneProps.current.playerTeleport.token).toBe(1);
 
     act(() => { fireEvent.keyDown(window, { key: 'm' }); });
-    fireEvent.click(screen.getByLabelText('Travel to Memory Quarter'));
+    fireEvent.click(screen.getByLabelText('Teleport to Memory Quarter'));
     // Same destination, new warp — a plain {x,z} identity check would have swallowed this.
     expect(sceneProps.current.playerTeleport.token).toBe(2);
   });
@@ -211,11 +221,11 @@ describe('OpenWorld — fast travel wiring', () => {
     expect(screen.getByTestId('hud-region')).toHaveTextContent('data-harbor');
   });
 
-  it('opens the PortOS page a region stands for', () => {
+  it('keeps map interactions inside OpenWorld', () => {
     renderAt('/openworld/region/memory');
     act(() => { fireEvent.keyDown(window, { key: 'm' }); });
-    fireEvent.click(screen.getByTitle('Open /brain/inbox'));
-    expect(screen.getByTestId('path')).toHaveTextContent('/brain/inbox');
+    expect(screen.queryByTitle(/Open\s+\//)).not.toBeInTheDocument();
+    expect(screen.getByTestId('path')).toHaveTextContent('/openworld/region/memory');
   });
 
   it('returns to the overview from the panel', () => {

--- a/client/src/pages/OpenWorld.jsx
+++ b/client/src/pages/OpenWorld.jsx
@@ -176,27 +176,54 @@ function OpenWorldInner() {
 
   const keysRef = useKeyboardControls(handleToggleExploration);
 
-  // --- Fast travel ----------------------------------------------------------
-  // Warping navigates to `/openworld/region/:regionId`; the route param then drives the
-  // camera (OpenWorldFocusCamera) and, on foot, the player rig. Only the panel's open/closed
-  // state is local — the destination itself always lives in the URL.
+  // --- World map / fast travel ----------------------------------------------
+  // Warping stays under `/openworld/region/:regionId`; the route param drives the orbital
+  // camera and, on foot, the player rig. The destination is still shareable, but it never
+  // sends the player to the 2D page represented by that district.
   const [fastTravelOpen, setFastTravelOpen] = useState(false);
   // The walking player's arrival point for the latest warp, carrying a monotonic token so
   // PlayerController can tell "warp again to the same place" from a re-render with equal
-  // coordinates — which is why it isn't derived from the region id. Set on every warp, not
-  // only while exploring: PlayerController mounts only in exploration mode and applies the
-  // current token on mount, so arming it unconditionally also means warping in the orbital
-  // overview and THEN dropping in (Tab) lands you at the region you were looking at,
+  // coordinates — which is why it isn't derived from the region id. Direct region deep links
+  // seed the first arrival synchronously; later route changes arm the same handoff in an effect.
+  // Set on every warp, not only while exploring: PlayerController mounts only in exploration mode
+  // and applies the current token on mount, so arming it unconditionally also means warping in the
+  // orbital overview and THEN dropping in (Tab) lands you at the region you were looking at,
   // instead of back at your old spawn.
-  const [playerTeleport, setPlayerTeleport] = useState(null);
+  const [playerTeleport, setPlayerTeleport] = useState(() => {
+    if (!focusedRegion) return null;
+    const arrival = regionArrivalPoint(focusedRegion);
+    return arrival ? { ...arrival, regionId: focusedRegion.id, token: 1 } : null;
+  });
+  const lastRoutedRegionIdRef = useRef(regionId);
+
+  const armPlayerTeleport = useCallback((region, force = false) => {
+    const arrival = regionArrivalPoint(region);
+    if (!arrival) return;
+    setPlayerTeleport(prev => {
+      if (!force && prev?.regionId === region.id) return prev;
+      return { ...arrival, regionId: region.id, token: (prev?.token ?? 0) + 1 };
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!focusedRegion) {
+      lastRoutedRegionIdRef.current = regionId;
+      return;
+    }
+    if (lastRoutedRegionIdRef.current === regionId) return;
+    lastRoutedRegionIdRef.current = regionId;
+    armPlayerTeleport(focusedRegion);
+  }, [armPlayerTeleport, focusedRegion, regionId]);
 
   const handleTravelToRegion = useCallback((region) => {
     if (!region?.id) return;
     navigate(regionPath(region.id));
-    const arrival = regionArrivalPoint(region);
-    if (arrival) setPlayerTeleport(prev => ({ ...arrival, token: (prev?.token ?? 0) + 1 }));
+    // A map pick is an explicit warp even when the destination matches the current route (or
+    // stale route state), so always re-arm it; browser back/forward and direct deep links are
+    // armed by the effect above.
+    armPlayerTeleport(region, true);
     playSfx?.('dataPulse');
-  }, [navigate, playSfx]);
+  }, [armPlayerTeleport, navigate, playSfx]);
 
   const openFastTravel = useCallback(() => setFastTravelOpen(true), []);
 
@@ -383,25 +410,44 @@ function OpenWorldInner() {
   );
 
   // Selecting a building focuses it in-place (issue #2593) — the URL becomes /openworld/apps/:id and the
-  // camera flies to frame the borough WITHOUT leaving OpenWorld. In street-level exploration the old
-  // behavior stands (walking up to a building and interacting opens the app page).
+  // camera/HUD stay inside OpenWorld. This is also the interaction target for the first-person player:
+  // walking up to a building and pressing F opens its live status panel, never the 2D app page.
   const handleBuildingClick = useCallback((app) => {
     if (!app?.id) return;
-    if (settings?.explorationMode) navigate(`/apps/${app.id}`);
-    else navigate(`/openworld/apps/${app.id}`);
-  }, [navigate, settings?.explorationMode]);
+    navigate(`/openworld/apps/${app.id}`);
+  }, [navigate]);
 
   const handleJumpToFirst = useCallback(() => {
     const first = filterResult.matches[0];
     if (!first?.id) return;
-    // Mirror handleBuildingClick: focus in-place from the overview, open the app page in exploration.
-    if (settings?.explorationMode) navigate(`/apps/${first.id}`);
-    else navigate(`/openworld/apps/${first.id}`);
-  }, [filterResult.matches, navigate, settings?.explorationMode]);
+    handleBuildingClick(first);
+  }, [filterResult.matches, handleBuildingClick]);
 
-  // Close focus → back to the plain overview. Open app → the existing app detail page (explicit).
+  const handleTravelToRegionId = useCallback((id) => {
+    const region = getRegion(id);
+    if (region) handleTravelToRegion(region);
+  }, [handleTravelToRegion]);
+
+  // Every HUD attention item resolves to a building/region in the world. There is no external
+  // page fallback: an item without a more specific destination opens the world map instead.
+  const handleAttentionItem = useCallback((item) => {
+    if (item?.appId) {
+      handleBuildingClick({ id: item.appId });
+      return;
+    }
+    if (item?.regionId) {
+      handleTravelToRegionId(item.regionId);
+      return;
+    }
+    openFastTravel();
+  }, [handleBuildingClick, handleTravelToRegionId, openFastTravel]);
+
+  // Close focus → back to the plain in-world overview. The panel's primary action also
+  // re-focuses the building in OpenWorld rather than opening a separate PortOS page.
   const handleCloseFocus = useCallback(() => navigate('/openworld'), [navigate]);
-  const handleOpenApp = useCallback((id) => { if (id) navigate(`/apps/${id}`); }, [navigate]);
+  const handleFocusInWorld = useCallback((id) => {
+    if (id) handleBuildingClick({ id });
+  }, [handleBuildingClick]);
 
   // Headline numbers baked onto a captured city postcard. Derived from data the page already
   // has — no extra fetch. buildPostcardStats (in the overlay) omits absent/zero fields.
@@ -525,8 +571,10 @@ function OpenWorldInner() {
           focusNotFound={focusNotFound}
           focusAgents={focusAgents}
           onCloseFocus={handleCloseFocus}
-          onOpenApp={handleOpenApp}
+          onFocusInWorld={handleFocusInWorld}
           onOpenFastTravel={openFastTravel}
+          onOpenDestination={handleTravelToRegionId}
+          onAttentionItem={handleAttentionItem}
           activeRegion={focusedRegion}
         />
       )}
@@ -556,14 +604,13 @@ function OpenWorldInner() {
         onCycleSpeed={playback.cycleSpeed}
         onExit={playback.exit}
       />
-      {/* Fast travel (M). Hidden in photo + playback mode, which own the camera and would
+      {/* World map (M). Hidden in photo + playback mode, which own the camera and would
           fight a warp. Mounted OUTSIDE the HUD's pointer-events-none shell so it can take
           clicks, and above the CRT overlay so its panel isn't scanlined. */}
       <OpenWorldFastTravel
         open={fastTravelOpen && !photoMode && !playback.active}
         onClose={() => setFastTravelOpen(false)}
         onTravel={handleTravelToRegion}
-        onOpenPage={(path) => navigate(path)}
         activeRegionId={focusedRegion?.id || null}
         onLeaveRegion={() => navigate('/openworld')}
       />

--- a/client/src/utils/openWorldRegions.js
+++ b/client/src/utils/openWorldRegions.js
@@ -17,7 +17,8 @@ import { PARCELS } from './openWorldPlan';
 
 // Ordered for the fast-travel list: the two places you look at most first, then a clockwise
 // sweep of the outer districts, then the far shore. `parcel` keys into PARCELS for geography;
-// `appPath` is the 2D PortOS page the region visualizes (null for pure set dressing).
+// `appPath` is semantic metadata for the PortOS area the region visualizes (null for pure set
+// dressing). OpenWorld uses the region id for in-world travel and never follows this path.
 //
 // `district` marks a region whose real extent is DATA-DRIVEN — the downtown and archive grids
 // grow with the install's app count, so their PARCELS footprint is only a nominal size. It


### PR DESCRIPTION
## Summary

- Make OpenWorld open directly as a first-person playable world, with third-person remaining an optional in-world setting.
- Add an in-world regional map with map/list teleport controls and first-person arrival points, including direct region deep links.
- Keep building, HUD, vitals, character, and attention interactions inside OpenWorld instead of navigating to PortOS pages.
- Refresh coverage for map controls, internal routing, defaults, and deep-link arrivals.

## Research

The regional respawn and map-marker interaction patterns were informed by Folio 2025:
- https://github.com/brunosimon/folio-2025
- https://raw.githubusercontent.com/brunosimon/folio-2025/main/sources/Game/Player.js
- https://raw.githubusercontent.com/brunosimon/folio-2025/main/sources/Game/Map.js

## Test plan

- Focused OpenWorld/settings suite: 6 files, 57 tests passed
- Full client suite with CI worker cap: 682 files, 8,417 tests passed
- npm run lint passed
- npm run build passed; only existing large-chunk warnings remain

The initial unbounded full-suite run exposed a concurrency-only Catalog test flake; the Catalog file passed all 26 tests in isolation, and the bounded full suite passed.