### PR TITLE
move AI run history to a Chief of Staff Runs tab, off the AI Providers settings page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -16,7 +16,6 @@ const Ambient = lazyWithReload(() => import('./pages/Ambient'));
 // DevTools pages are large (~2300 lines total) so lazy load them
 const AIProviders = lazyWithReload(() => import('./pages/AIProviders'));
 const HistoryPage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.HistoryPage })));
-const RunsHistoryPage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.RunsHistoryPage })));
 const RunnerPage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.RunnerPage })));
 const UsagePage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.UsagePage })));
 const ProcessesPage = lazyWithReload(() => import('./pages/DevTools').then(m => ({ default: m.ProcessesPage })));
@@ -255,7 +254,7 @@ export default function App() {
         <Route path="/" element={<Layout />}>
           <Route index element={<Dashboard />} />
           <Route path="apps" element={<Apps />} />
-          <Route path="devtools" element={<Navigate to="/devtools/runs" replace />} />
+          <Route path="devtools" element={<Navigate to="/devtools/agents" replace />} />
           <Route path="devtools/datadog" element={<DataDog />} />
           <Route path="devtools/flows" element={<FlowsDoc />} />
           <Route path="devtools/github" element={<GitHub />} />
@@ -263,7 +262,9 @@ export default function App() {
           <Route path="devtools/image-clean" element={<ImageClean />} />
           <Route path="devtools/quota-burn" element={<QuotaBurn />} />
           <Route path="devtools/quota-burn/:familyId" element={<QuotaBurn />} />
-          <Route path="devtools/runs" element={<RunsHistoryPage />} />
+          {/* AI run history moved under the Chief of Staff (/cos/runs); keep old
+              links and bookmarks working. */}
+          <Route path="devtools/runs" element={<RedirectWithSearch to="/cos/runs" />} />
           <Route path="devtools/runner" element={<RunnerPage />} />
           {/* Submodules moved onto the managed-app detail page (one tab per repo).
               Keeps old links/bookmarks working by landing on PortOS's own tab. */}

--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -200,6 +200,7 @@ const navItems = [
       { to: '/cos/health', label: 'Health', icon: Activity },
       { to: '/cos/learning', label: 'Learning', icon: GraduationCap },
       { to: '/cos/memory', label: 'Memory', icon: Brain },
+      { to: '/cos/runs', label: 'Runs', icon: Play },
       { to: '/cos/schedule', label: 'Schedule', icon: Clock },
       { to: '/agents', label: 'Social Agents', icon: Users },
       { to: '/cos/productivity', label: 'Streaks', icon: Flame },
@@ -255,7 +256,6 @@ const navItems = [
     icon: Terminal,
     children: [
       { to: '/devtools/agents', label: 'AI Agents', icon: Cpu },
-      { to: '/devtools/runs', label: 'AI Runs', icon: Play },
       { to: '/ambient', label: 'Ambient', icon: Sparkles },
       { href: '//:5560', label: 'Autofixer', icon: Wrench, external: true, dynamicHost: true },
       { to: '/browser', label: 'Browser', icon: Globe },

--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -11,7 +11,8 @@ import {
   Bot,
   Flame,
   Newspaper,
-  ChartGantt
+  ChartGantt,
+  Play
 } from 'lucide-react';
 import { normalizeReviewerSlug } from '../../lib/reviewerPins';
 import { inPlaceClipName } from '../../utils/animationClips';
@@ -21,6 +22,7 @@ export const TABS = [
   { id: 'tasks', label: 'Tasks', icon: FileText },
   { id: 'agents', label: 'Agents', icon: Cpu },
   { id: 'jobs', label: 'System Tasks', icon: Bot },
+  { id: 'runs', label: 'Runs', icon: Play },
   { id: 'schedule', label: 'Schedule', icon: Clock },
   { id: 'workflow', label: 'Timeline', icon: ChartGantt },
   { id: 'digest', label: 'Digest', icon: Calendar },

--- a/client/src/components/cos/tabs/RunsTab.deepLink.test.jsx
+++ b/client/src/components/cos/tabs/RunsTab.deepLink.test.jsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+
+const api = vi.hoisted(() => ({
+  getRuns: vi.fn(),
+  getRunPrompt: vi.fn(),
+  getRunOutput: vi.fn(),
+  deleteRun: vi.fn(),
+  deleteFailedRuns: vi.fn(),
+  stopRun: vi.fn(),
+  getProcessLogs: vi.fn(),
+}));
+
+vi.mock('../../../services/api', () => api);
+vi.mock('../../ui/ProcessLogModal', () => ({
+  default: () => null,
+}));
+
+import RunsTab from './RunsTab';
+
+const RUNS = [
+  { id: 'run-a', prompt: 'first prompt', providerName: 'demo', success: true, startTime: '2026-01-01T00:00:00Z' },
+  { id: 'run-b', prompt: 'second prompt', providerName: 'demo', success: true, startTime: '2026-01-01T00:01:00Z' },
+];
+
+const renderTab = (path) => render(
+  <MemoryRouter initialEntries={[path]}>
+    <RunsTab />
+  </MemoryRouter>
+);
+
+describe('RunsTab ?run= deep link', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getRuns.mockResolvedValue({ runs: RUNS });
+    api.getRunPrompt.mockResolvedValue('full prompt for run-b');
+    api.getRunOutput.mockResolvedValue('full output for run-b');
+  });
+
+  it('expands the run named by ?run= once the list has loaded', async () => {
+    renderTab('/cos/runs?run=run-b');
+
+    expect(await screen.findByText('full output for run-b')).toBeInTheDocument();
+    expect(api.getRunPrompt).toHaveBeenCalledWith('run-b');
+    expect(api.getRunOutput).toHaveBeenCalledWith('run-b');
+  });
+
+  it('expands nothing when no ?run= param is present', async () => {
+    renderTab('/cos/runs');
+
+    expect(await screen.findByText('first prompt')).toBeInTheDocument();
+    expect(api.getRunPrompt).not.toHaveBeenCalled();
+  });
+
+  it('ignores a ?run= id that is not in the loaded list', async () => {
+    renderTab('/cos/runs?run=run-missing');
+
+    expect(await screen.findByText('first prompt')).toBeInTheDocument();
+    expect(api.getRunPrompt).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/cos/tabs/RunsTab.jsx
+++ b/client/src/components/cos/tabs/RunsTab.jsx
@@ -1,14 +1,13 @@
-import { useState, useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { useNavigate, useSearchParams } from 'react-router';
 import { Trash2, RotateCcw, MessageSquarePlus, ScrollText, Square } from 'lucide-react';
-import * as api from '../services/api';
-import { formatTime, formatRuntime, formatBytes, formatDateTime } from '../utils/formatters';
-import BrailleSpinner from '../components/BrailleSpinner';
-import PageSkeleton from '../components/ui/PageSkeleton';
-import Banner from '../components/ui/Banner';
-import ProcessLogModal from '../components/ui/ProcessLogModal';
-import { writeClipboardSilently } from '../lib/clipboard';
-import { clickableProps } from '../lib/a11yKeyboard.js';
+import * as api from '../../../services/api';
+import { formatTime, formatRuntime, formatBytes, formatDateTime } from '../../../utils/formatters';
+import BrailleSpinner from '../../BrailleSpinner';
+import Banner from '../../ui/Banner';
+import ProcessLogModal from '../../ui/ProcessLogModal';
+import { writeClipboardSilently } from '../../../lib/clipboard';
+import { clickableProps } from '../../../lib/a11yKeyboard.js';
 
 // Map an AI run's source to the PM2 process whose system log holds the full
 // context for that run. CoS-agent runs are driven by the `portos-cos` process;
@@ -17,8 +16,10 @@ export function runLogProcessName(source) {
   return source === 'cos-agent' ? 'portos-cos' : 'portos-server';
 }
 
-export function RunsHistoryPage() {
+export default function RunsTab() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const deepLinkRunId = searchParams.get('run');
   const [runs, setRuns] = useState([]);
   const [loading, setLoading] = useState(true);
   const [expandedId, setExpandedId] = useState(null);
@@ -84,12 +85,7 @@ export function RunsHistoryPage() {
     });
   };
 
-  const toggleExpand = async (id) => {
-    if (expandedId === id) {
-      setExpandedId(null);
-      return;
-    }
-
+  const expandRun = useCallback(async (id) => {
     setExpandedId(id);
 
     // Load full prompt and output if not already loaded
@@ -103,7 +99,26 @@ export function RunsHistoryPage() {
         [id]: { prompt, output }
       }));
     }
+  }, [expandedDetails]);
+
+  const toggleExpand = (id) => {
+    if (expandedId === id) {
+      setExpandedId(null);
+      return;
+    }
+    expandRun(id);
   };
+
+  // Open the run named by `?run=<id>` on entry — the Local LLM Playground links
+  // straight at a run it just finished. One-shot: switching CoS tabs drops the
+  // param, and the user stays free to collapse the row afterwards.
+  const deepLinkOpened = useRef(false);
+  useEffect(() => {
+    if (deepLinkOpened.current || !deepLinkRunId || loading) return;
+    if (!runs.some(run => run.id === deepLinkRunId)) return;
+    deepLinkOpened.current = true;
+    expandRun(deepLinkRunId);
+  }, [deepLinkRunId, loading, runs, expandRun]);
 
   const handleContinue = (run) => {
     const details = expandedDetails[run.id] || {};
@@ -169,7 +184,11 @@ export function RunsHistoryPage() {
   };
 
   if (loading) {
-    return <PageSkeleton label="Loading runs history" titleWidthClass="w-48" showAction={false} cards={4} sidebar={false} />;
+    return (
+      <div className="flex items-center justify-center py-12">
+        <BrailleSpinner text="Loading runs" />
+      </div>
+    );
   }
 
   const failedCount = runs.filter(r => r.success === false).length;
@@ -185,7 +204,7 @@ export function RunsHistoryPage() {
   return (
     <div className="space-y-4 lg:space-y-6">
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-        <h1 className="text-lg sm:text-2xl font-bold text-white">AI Runs History</h1>
+        <h2 className="text-lg sm:text-xl font-bold text-white">Recent Runs</h2>
         {failedCount > 0 && (
           <button
             onClick={handleClearFailed}
@@ -526,5 +545,3 @@ export function RunsHistoryPage() {
     </div>
   );
 }
-
-export default RunsHistoryPage;

--- a/client/src/components/cos/tabs/RunsTab.test.jsx
+++ b/client/src/components/cos/tabs/RunsTab.test.jsx
@@ -2,11 +2,11 @@
 
 import { describe, it, expect, vi } from 'vitest';
 
-// RunsHistoryPage pulls in the API barrel transitively; stub it so importing the
+// RunsTab pulls in the API barrel transitively; stub it so importing the
 // module for the pure-helper test doesn't drag real HTTP wrappers into scope.
-vi.mock('../services/api', () => ({}));
+vi.mock('../../../services/api', () => ({}));
 
-import { runLogProcessName } from './RunsHistoryPage';
+import { runLogProcessName } from './RunsTab';
 
 describe('runLogProcessName', () => {
   it('maps cos-agent runs to the portos-cos process', () => {

--- a/client/src/components/ui/ProcessLogModal.jsx
+++ b/client/src/components/ui/ProcessLogModal.jsx
@@ -3,7 +3,7 @@
  *
  * Built so an operator who doesn't know where the system logs live can open the
  * relevant log straight from wherever an error surfaced (e.g. a failed AI run in
- * RunsHistoryPage). Fetches a static tail via `getProcessLogs` (not the live SSE
+ * the CoS Runs tab). Fetches a static tail via `getProcessLogs` (not the live SSE
  * stream — a past failure's context is already written), with a process picker,
  * a tail-length selector, and a manual refresh.
  *

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router';
 import { AlertTriangle } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import * as api from '../services/api';
@@ -15,7 +16,6 @@ import {
   TIMEOUT_INPUT_MIN_MS,
   TIMEOUT_INPUT_MAX_MS,
   TIMEOUT_INPUT_STEP_MS,
-  formatDateTime,
 } from '../utils/formatters';
 import SettingsTabsHeader from '../components/settings/SettingsTabsHeader';
 import EffortSelect from '../components/cos/EffortSelect';
@@ -93,7 +93,6 @@ export default function AIProviders() {
   const [editingProvider, setEditingProvider] = useState(null);
   const [testResults, setTestResults] = useState({});
   const [refreshing, setRefreshing] = useState({});
-  const [runs, setRuns] = useState([]);
   const [showRunPanel, setShowRunPanel] = useState(false);
   const [runPrompt, setRunPrompt] = useState('');
   const [selectedWorkspace, setSelectedWorkspace] = useState('');
@@ -113,11 +112,6 @@ export default function AIProviders() {
     loadData();
   }, []);
 
-  const loadRuns = useCallback(async () => {
-    const runsData = await api.getRuns(20).catch(() => ({ runs: [] }));
-    setRuns(runsData.runs || []);
-  }, []);
-
   useEffect(() => {
     if (!activeRun) return;
 
@@ -127,7 +121,6 @@ export default function AIProviders() {
 
     const handleComplete = (_metadata) => {
       setActiveRun(null);
-      loadRuns();
     };
 
     socket.on(`run:${activeRun}:data`, handleData);
@@ -137,19 +130,18 @@ export default function AIProviders() {
       socket.off(`run:${activeRun}:data`, handleData);
       socket.off(`run:${activeRun}:complete`, handleComplete);
     };
-  }, [activeRun, loadRuns]);
+  }, [activeRun]);
 
   const loadData = async () => {
     setLoading(true);
     setLoadError(false);
     let providersFailed = false;
-    const [providersData, appsData, runsData, statusData, opencodeData] = await Promise.all([
+    const [providersData, appsData, statusData, opencodeData] = await Promise.all([
       api.getProviders().catch(() => {
         providersFailed = true;
         return null;
       }),
       api.getApps().catch(() => []),
-      api.getRuns(20).catch(() => ({ runs: [] })),
       api.getProviderStatuses().catch(() => ({ providers: {} })),
       api.getOpenCodeInstallStatus({ silent: true }).catch(() => null),
     ]);
@@ -168,7 +160,6 @@ export default function AIProviders() {
         : null);
     }
     setApps(appsData);
-    setRuns(runsData.runs || []);
     setStatuses(statusData.providers || {});
     setOpenCodeInstallStatus(opencodeData && typeof opencodeData.installed === 'boolean'
       ? opencodeData
@@ -854,37 +845,13 @@ export default function AIProviders() {
         )}
       </div>
 
-      {/* Recent Runs */}
-      {runs.length > 0 && (
-        <div className="mt-8">
-          <h2 className="text-xl font-bold text-white mb-4">Recent Runs</h2>
-          <div className="space-y-2">
-            {runs.map(run => (
-              <div
-                key={run.id}
-                className="bg-port-card border border-port-border rounded-lg p-3 flex flex-col sm:flex-row sm:items-center justify-between gap-2"
-              >
-                <div className="flex items-start sm:items-center gap-3 min-w-0">
-                  <span className={`w-2 h-2 rounded-full shrink-0 mt-1.5 sm:mt-0 ${
-                    run.success === true ? 'bg-port-success' :
-                    run.success === false ? 'bg-port-error' :
-                    'bg-port-warning animate-pulse'
-                  }`} />
-                  <div className="min-w-0">
-                    <p className="text-sm text-white break-words">{run.prompt}</p>
-                    <p className="text-xs text-gray-500 break-words">
-                      {run.providerName} • {run.workspaceName || 'No workspace'} • {formatDateTime(run.startTime)}
-                    </p>
-                  </div>
-                </div>
-                <div className="text-sm text-gray-400 shrink-0 pl-5 sm:pl-0">
-                  {run.duration ? `${(run.duration / 1000).toFixed(1)}s` : 'Running...'}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+      {/* Full run history lives on the Chief of Staff → Runs tab; this page
+          only configures providers. */}
+      <div className="mt-8">
+        <Link to="/cos/runs" className="text-sm text-port-accent hover:underline">
+          View AI run history →
+        </Link>
+      </div>
 
       {/* Provider Form Modal */}
       {showForm && (

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -5,7 +5,6 @@ import { MemoryRouter } from 'react-router';
 const api = vi.hoisted(() => ({
   getProviders: vi.fn(),
   getApps: vi.fn(),
-  getRuns: vi.fn(),
   getProviderStatuses: vi.fn(),
   getOpenCodeInstallStatus: vi.fn(),
   getSampleProviders: vi.fn(),
@@ -52,7 +51,6 @@ describe('AIProviders page load error handling', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.getApps.mockResolvedValue([]);
-    api.getRuns.mockResolvedValue({ runs: [] });
     api.getProviderStatuses.mockResolvedValue({ providers: {} });
     api.getOpenCodeInstallStatus.mockResolvedValue({ installed: false, npmAvailable: true });
   });
@@ -154,7 +152,6 @@ describe('handleAddSample error handling', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.getApps.mockResolvedValue([]);
-    api.getRuns.mockResolvedValue({ runs: [] });
     api.getProviderStatuses.mockResolvedValue({ providers: {} });
     api.getOpenCodeInstallStatus.mockResolvedValue({ installed: false, npmAvailable: true });
     api.getProviders.mockResolvedValue({
@@ -191,7 +188,6 @@ describe('handleAddAllSamples partial failure handling', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.getApps.mockResolvedValue([]);
-    api.getRuns.mockResolvedValue({ runs: [] });
     api.getProviderStatuses.mockResolvedValue({ providers: {} });
     api.getOpenCodeInstallStatus.mockResolvedValue({ installed: false, npmAvailable: true });
     api.getProviders.mockResolvedValue({
@@ -237,7 +233,6 @@ describe('CoS Agent Runner allowlist warning', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.getApps.mockResolvedValue([]);
-    api.getRuns.mockResolvedValue({ runs: [] });
     api.getProviderStatuses.mockResolvedValue({ providers: {} });
     api.getOpenCodeInstallStatus.mockResolvedValue({ installed: false, npmAvailable: true });
   });
@@ -337,7 +332,6 @@ describe('Local num_ctx field', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.getApps.mockResolvedValue([]);
-    api.getRuns.mockResolvedValue({ runs: [] });
     api.getProviderStatuses.mockResolvedValue({ providers: {} });
     api.getOpenCodeInstallStatus.mockResolvedValue({ installed: false, npmAvailable: true });
   });
@@ -392,7 +386,6 @@ describe('OpenCode OrcaRouter key hint', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     api.getApps.mockResolvedValue([]);
-    api.getRuns.mockResolvedValue({ runs: [] });
     api.getProviderStatuses.mockResolvedValue({ providers: {} });
     api.getOpenCodeInstallStatus.mockResolvedValue({ installed: true, npmAvailable: true });
    });

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -40,6 +40,11 @@ import {
 } from '../components/cos';
 import { resolveDynamicAvatar } from '../components/cos/constants';
 
+// The Runs tab (full AI run history + its log modal) is lazy-loaded so its weight
+// stays out of the eager CoS chunk every /cos/* visit pays for — same reason the
+// avatars below are not re-exported from the components/cos barrel.
+const RunsTab = lazy(() => import('../components/cos/tabs/RunsTab'));
+
 // Three.js-based avatars lazy-loaded so the R3F stack isn't bundled unless the
 // user's chosen avatar style actually needs it.
 const LAZY_AVATARS = {
@@ -969,6 +974,13 @@ export default function ChiefOfStaff() {
         {activeTab === 'jobs' && (
           <div role="tabpanel" id="tabpanel-jobs" aria-labelledby="tab-jobs">
             <JobsTab />
+          </div>
+        )}
+        {activeTab === 'runs' && (
+          <div role="tabpanel" id="tabpanel-runs" aria-labelledby="tab-runs">
+            <Suspense fallback={<div className="flex items-center justify-center py-12"><BrailleSpinner text="Loading runs" /></div>}>
+              <RunsTab />
+            </Suspense>
           </div>
         )}
         {activeTab === 'schedule' && (

--- a/client/src/pages/DevTools.jsx
+++ b/client/src/pages/DevTools.jsx
@@ -1,6 +1,5 @@
 // Barrel file — each page component lives in its own file
 export { HistoryPage } from './HistoryPage';
-export { RunsHistoryPage } from './RunsHistoryPage';
 export { RunnerPage } from './RunnerPage';
 export { ProcessesPage } from './ProcessesPage';
 export { UsagePage } from './UsagePage';

--- a/client/src/pages/LocalLlmPlayground.jsx
+++ b/client/src/pages/LocalLlmPlayground.jsx
@@ -163,7 +163,7 @@ function ResultPanel({ result }) {
 
       <div className="flex items-center gap-2 flex-wrap">
         {result.runId && (
-          <Link to={`/devtools/runs?run=${encodeURIComponent(result.runId)}`} className="text-xs text-port-accent hover:underline">
+          <Link to={`/cos/runs?run=${encodeURIComponent(result.runId)}`} className="text-xs text-port-accent hover:underline">
             Run {result.runId.slice(0, 8)}
           </Link>
         )}

--- a/docs/API.md
+++ b/docs/API.md
@@ -66,7 +66,7 @@ PortOS is designed for personal/developer use on trusted networks. It implements
 | POST | `/providers/:id/test` | Test provider connectivity |
 | PUT | `/providers/active` | Set active provider |
 
-### AI Runs (DevTools)
+### AI Runs
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|

--- a/docs/features/product-surfaces.md
+++ b/docs/features/product-surfaces.md
@@ -14,7 +14,7 @@ PortOS is a local-first operating system for a developer's machines, work, and p
 
 - **Chief of Staff** — Submit work, schedule automations, monitor tasks, and review operational decisions. See [Chief of Staff](./chief-of-staff.md), [Agent Runner](./cos-agent-runner.md), [Agent Skills](./agent-skills.md), and [CoS Enhancement](./cos-enhancement.md).
 - **Feature Agents, Review Hub, and workspace contexts** — Create durable agents for a feature area, collect approvals and alerts, and give agents the right repository context.
-- **Prompt Manager, AI Runner, AI Runs, and AI Agents** — Configure reusable prompts; run a provider directly; and inspect active or past model work. See [Prompt Manager](./prompt-manager.md) and [Claude on Ollama](./claude-ollama.md).
+- **Prompt Manager, AI Runner, and AI Agents** — Configure reusable prompts; run a provider directly; and inspect active model work. Past and in-flight AI runs are listed on the Chief of Staff's Runs tab (`/cos/runs`). See [Prompt Manager](./prompt-manager.md) and [Claude on Ollama](./claude-ollama.md).
 - **Autofixer** — Detect and repair managed-process failures with controlled retries. See [Autofixer](./autofixer.md).
 
 ## Create stories, media, and music

--- a/server/lib/navManifest.js
+++ b/server/lib/navManifest.js
@@ -137,6 +137,7 @@ export const NAV_COMMANDS = [
   { id: 'nav.cos.health', path: '/cos/health', label: 'Health', section: 'Chief of Staff', aliases: ['cos-health', 'health'] },
   { id: 'nav.cos.learning', path: '/cos/learning', label: 'Learning', section: 'Chief of Staff', aliases: ['cos-learning'] },
   { id: 'nav.cos.memory', path: '/cos/memory', label: 'Memory', section: 'Chief of Staff', aliases: ['cos-memory'] },
+  { id: 'nav.cos.runs', path: '/cos/runs', label: 'Runs', section: 'Chief of Staff', aliases: ['runs', 'ai-runs', 'cos-runs', 'recent-runs', 'run-history'], keywords: ['runs', 'run history', 'recent runs', 'ai runs', 'agent runs', 'failed runs'] },
   { id: 'nav.cos.schedule', path: '/cos/schedule', label: 'Schedule', section: 'Chief of Staff', aliases: ['schedule', 'cos-schedule'] },
   { id: 'nav.social-agents', path: '/agents', label: 'Social Agents', section: 'Chief of Staff', aliases: ['social-agents'] },
   // The page at /cos/workflow is now the Schedule Timeline (launch-order
@@ -159,8 +160,7 @@ export const NAV_COMMANDS = [
   { id: 'nav.timeline', path: '/timeline', label: 'Timeline', section: 'Brain', aliases: ['activity-timeline', 'activity', 'my-day', 'life-log', 'life-timeline'], keywords: ['human activity', 'life log', 'timeline', 'messages', 'calendar', 'history', 'what did i do', 'daily', 'import', 'backfill', 'whatsapp', 'spotify', 'discord', 'youtube'] },
   { id: 'nav.tribe', path: '/tribe', label: 'Tribe', section: 'Brain', aliases: ['tribe', 'relationships', 'relationship-manager', 'people'], keywords: ['dunbar', 'friends', 'family', 'network', 'social graph', 'care cadence'] },
 
-  { id: 'nav.devtools.runs', path: '/devtools/runs', label: 'AI Runs', section: 'Dev Tools', aliases: ['ai-runs', 'devtools'] },
-  { id: 'nav.devtools.agents', path: '/devtools/agents', label: 'AI Agents', section: 'Dev Tools', aliases: ['ai-agents'] },
+  { id: 'nav.devtools.agents', path: '/devtools/agents', label: 'AI Agents', section: 'Dev Tools', aliases: ['ai-agents', 'devtools'] },
   { id: 'nav.browser', path: '/browser', label: 'Browser', section: 'Dev Tools', aliases: ['browser'] },
   { id: 'nav.devtools.runner', path: '/devtools/runner', label: 'Code', section: 'Dev Tools', aliases: ['devtools-runner'] },
   { id: 'nav.devtools.datadog', path: '/devtools/datadog', label: 'DataDog', section: 'Dev Tools', aliases: ['datadog', 'devtools-datadog'] },


### PR DESCRIPTION
## Summary

Run history belongs with the agents that produce it, not with provider configuration. It was in two places, neither of them Chief of Staff: the AI Providers settings page carried an inline "Recent Runs" list, and a fuller history page lived under Dev Tools.

The history page now renders as the CoS **Runs** tab at `/cos/runs`. AI Providers drops its list — and the `getRuns` call from its mount fan-out — in favor of a link to the tab.

- `/devtools/runs` redirects via `RedirectWithSearch` so old bookmarks (and the Local LLM Playground's `?run=<id>` deep link) keep working; the bare `/devtools` landing moves to `/devtools/agents`.
- The nav manifest entry moves to the Chief of Staff section with aliases `runs` / `ai-runs` / `cos-runs` / `recent-runs` / `run-history`; the `devtools` alias re-homes to the AI Agents entry so bare "devtools" still resolves.
- The tab is **lazy-loaded** rather than re-exported from the `components/cos` barrel. A static barrel export pulls it plus `ProcessLogModal` into the eager CoS chunk that every `/cos/*` visit pays for (measured 482 → 507 kB) — the same trap the barrel already documents for the three.js avatars. With the lazy import, `ChiefOfStaff` stays at 482.89 kB and `RunsTab` is its own 25 kB on-demand chunk.

While here, `?run=<id>` now actually expands that run on entry. It never did — neither the old page nor the new tab read the param, so the Playground's "view run" link landed on an unfiltered list. `client/src/CLAUDE.md` makes this a contract: "Deep-link URL with query params is a contract: receiving page MUST consume them."

## Test plan

- New `RunsTab.deepLink.test.jsx` covers `?run=` expanding the named run, doing nothing without the param, and ignoring an id absent from the loaded list. Verified non-vacuous with a bypass probe (removing the `expandRun` call fails the first case).
- `server/lib/navManifest.test.js` — 53 pass, including the tab↔nav parity contract and the App.jsx route-coverage guard.
- Full client suite: 683 files, 8418 tests pass. Full server suite: 1488 files, 30726 tests pass.
- `biome lint --error-on-warnings src` clean; `npm run build` clean, with the chunk split confirmed above.