### PR TITLE
feat: turn OpenWorld into a rover game world

### DIFF
--- a/client/src/components/openworld/AgentEntity.jsx
+++ b/client/src/components/openworld/AgentEntity.jsx
@@ -15,6 +15,7 @@ const DEFAULT_COLOR = '#06b6d4';
 
 export default function AgentEntity({ agent, position, index = 0, settings }) {
   const bodyRef = useRef();
+  const ringRef = useRef();
   const trailRef = useRef();
 
   const state = agent.state || agent.status || 'coding';
@@ -58,6 +59,7 @@ export default function AgentEntity({ agent, position, index = 0, settings }) {
       const material = bodyRef.current.children[0]?.material;
       if (material) material.emissiveIntensity = 0.5 + Math.sin(t * 3) * 0.3;
     }
+    if (ringRef.current) ringRef.current.rotation.z = -t * 0.55 - index * 0.4;
 
     if (trailRef.current && trailSamples > 0) {
       const attr = trailRef.current.geometry.getAttribute('position');
@@ -76,7 +78,7 @@ export default function AgentEntity({ agent, position, index = 0, settings }) {
           <lineBasicMaterial
             vertexColors
             transparent
-            opacity={0.7}
+            opacity={0.38}
             blending={THREE.AdditiveBlending}
             depthWrite={false}
           />
@@ -84,23 +86,32 @@ export default function AgentEntity({ agent, position, index = 0, settings }) {
       )}
       <group ref={bodyRef}>
         <mesh>
-          <octahedronGeometry args={[0.3, 0]} />
+          <icosahedronGeometry args={[0.3, 1]} />
           <meshStandardMaterial
             color={color}
             emissive={color}
             emissiveIntensity={0.5}
-            wireframe
             transparent
-            opacity={0.8}
+            opacity={0.9}
+            roughness={0.32}
+            metalness={0.18}
           />
         </mesh>
+        <mesh ref={ringRef} rotation={[Math.PI / 2, 0, 0]}>
+          <torusGeometry args={[0.46, 0.016, 6, 20]} />
+          <meshBasicMaterial color={color} transparent opacity={0.46} />
+        </mesh>
+        <mesh position={[0, 0.34, 0]}>
+          <sphereGeometry args={[0.045, 8, 6]} />
+          <meshBasicMaterial color={color} transparent opacity={0.9} />
+        </mesh>
         <Sparkles
-          count={15}
-          scale={0.8}
-          size={1}
-          speed={0.5}
+          count={8}
+          scale={0.68}
+          size={0.7}
+          speed={0.35}
           color={color}
-          opacity={0.6}
+          opacity={0.34}
         />
       </group>
     </group>

--- a/client/src/components/openworld/Borough.jsx
+++ b/client/src/components/openworld/Borough.jsx
@@ -62,7 +62,6 @@ export default function Borough({ app, position, agentMap, onBuildingClick, play
       {processPositions.map(({ x, z, rotation, seed, process: proc }) => (
         <ProcessBuilding
           key={proc.name}
-          process={proc}
           pm2Status={pm2Status[proc.name]}
           position={[position.x + x, 0, position.z + z, rotation]}
           seed={seed}

--- a/client/src/components/openworld/Building.jsx
+++ b/client/src/components/openworld/Building.jsx
@@ -394,6 +394,38 @@ function FloorLightBands({ width, depth, height, color, accentColor, seed, dimMu
   );
 }
 
+// A small, always-readable status marker replaces the old wall of floating holograms.
+// It gives each building a game-like "beacon" without turning every facade into a UI panel.
+function StatusBeacon({ height, color, accentColor, active = false, dimMul = 1 }) {
+  const ringRef = useRef();
+  const glowRef = useRef();
+
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime();
+    if (ringRef.current) ringRef.current.rotation.z = t * (active ? 0.9 : 0.35);
+    if (glowRef.current) {
+      glowRef.current.material.opacity = (active ? 0.5 + Math.sin(t * 3) * 0.15 : 0.28) * dimMul;
+    }
+  });
+
+  return (
+    <group position={[0, height + 0.08, 0]}>
+      <mesh position={[0, 0.02, 0]}>
+        <cylinderGeometry args={[0.16, 0.25, 0.06, 6]} />
+        <meshBasicMaterial color={color} transparent opacity={0.42 * dimMul} />
+      </mesh>
+      <mesh ref={ringRef} rotation={[Math.PI / 2, 0, 0]}>
+        <torusGeometry args={[0.32, 0.018, 6, 18]} />
+        <meshBasicMaterial color={accentColor} transparent opacity={(active ? 0.72 : 0.34) * dimMul} />
+      </mesh>
+      <mesh ref={glowRef} position={[0, 0.18, 0]}>
+        <octahedronGeometry args={[0.09, 0]} />
+        <meshBasicMaterial color={accentColor} transparent opacity={0.35 * dimMul} />
+      </mesh>
+    </group>
+  );
+}
+
 // The Vibes facade is a small cluster of matte, faceted masses rather than one cyber-era
 // slab. The seed comes from the app name, so the silhouette is stable across live updates
 // and playback. The main mass keeps the existing status-driven height/color semantics while
@@ -462,7 +494,7 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
 
   // `surface` carries the world style's finish (flat shading + matte under the low-poly
   // style); spread last on the facade material so it wins over the cyber defaults.
-  const { getBuildingColor, getAccentColor, tintStructure, surface, lowPoly } = useOpenWorldPalette();
+  const { getBuildingColor, getAccentColor, tintStructure, surface, lowPoly, neonLayers } = useOpenWorldPalette();
   const height = getBuildingHeight(app);
   const edgeColor = getBuildingColor(app.overallStatus, app.archived);
   const accentColor = getAccentColor(app);
@@ -481,6 +513,8 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
   // `!daytime`-gated mounts (halo/strips/glow/ground-lines) to opacity fades too so a
   // partial dayMix degrades gracefully instead of popping at 0.5.
   const daytime = dayMix > 0.5;
+  const showNightFx = neonLayers && !daytime;
+  const showBuildingSignal = !dimmed && (hovered || isProximity || focused);
   // Mid-tone facade (not near-white) so strong daylight lands around a clean gray
   // rather than clipping to white; a touch of the status color keeps variety.
   const dayFacade = mixHex('#9aa0ac', edgeColor, 0.12);
@@ -516,8 +550,8 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
   // would rasterize a full canvas per building (nested fillRect loops, ~1–2k 2D ops each)
   // at scene mount and again on every theme-accent change, and bind none of them.
   const windowTexture = useMemo(
-    () => (daytime ? null : createWindowTexture(accentColor, width, height, seed, tintStructure)),
-    [daytime, accentColor, width, height, seed, tintStructure]
+    () => (showNightFx ? createWindowTexture(accentColor, width, height, seed, tintStructure) : null),
+    [showNightFx, accentColor, width, height, seed, tintStructure]
   );
 
   // R3F does NOT dispose a CanvasTexture handed in via `map`/`emissiveMap` — it
@@ -642,7 +676,7 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
       {/* Interior-mapped window panes (InteriorMappingMaterial) — parallax fake-3D lit
           rooms on selected online towers. Night-only (by day the tower reads as a
           sunlit solid) and gated to the high quality preset by the caller. */}
-      {!daytime && interiorWindows && buildingHasInteriorWindows(app, height) && (
+      {showNightFx && interiorWindows && buildingHasInteriorWindows(app, height) && (
         <BuildingWindows
           width={width}
           depth={depth}
@@ -660,7 +694,7 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
         <lineBasicMaterial
           color={edgeLineColor}
           transparent
-          opacity={((app.archived ? 0.5 : 0.9) - dayMix * 0.55) * dimMul}
+          opacity={(neonLayers ? (app.archived ? 0.5 : 0.9) - dayMix * 0.55 : (focused || hovered ? 0.55 : 0.22)) * dimMul}
         />
       </lineSegments>
 
@@ -687,8 +721,18 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
       {/* Rooftop fixtures — deterministic per app name; off on the low preset */}
       {rooftops && <RooftopKit name={app.name || app.id} width={width} y={height} />}
 
+      {!app.archived && (
+        <StatusBeacon
+          height={height}
+          color={edgeColor}
+          accentColor={accentColor}
+          active={isProximity || focused || hovered}
+          dimMul={dimMul}
+        />
+      )}
+
       {/* Glow halo wireframe - slightly larger than building (night only) */}
-      {!app.archived && !daytime && (
+      {!app.archived && showNightFx && (
         <lineSegments ref={haloRef} position={[0, height / 2, 0]} geometry={haloEdgesGeom}>
           <lineBasicMaterial
             color={accentColor}
@@ -699,7 +743,7 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
       )}
 
       {/* Vertical neon edge strips on corners (night only) */}
-      {!app.archived && !daytime && (
+      {!app.archived && showNightFx && (
         <>
           <NeonEdgeStrip position={[width / 2, height / 2, depth / 2]} height={height} color={accentColor} delay={0} dimMul={dimMul} />
           <NeonEdgeStrip position={[-width / 2, height / 2, depth / 2]} height={height} color={accentColor} delay={1} dimMul={dimMul} />
@@ -709,7 +753,7 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
       )}
 
       {/* Lit floor bands stay on even for archived buildings so dark towers remain readable. */}
-      {!daytime && (
+      {showNightFx && (
         <FloorLightBands
           width={width}
           depth={depth}
@@ -736,38 +780,6 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
         {displayName}
       </OpenWorldLabel>
 
-      {/* Building name on back face */}
-      <OpenWorldLabel
-        position={[0, height * 0.88, -(depth / 2 + 0.02)]}
-        fontSize={0.2}
-        color={edgeColor}
-        dayMix={dayMix}
-        fillOpacity={dimMul}
-        anchorX="center"
-        anchorY="middle"
-        rotation={[0, Math.PI, 0]}
-        font={PIXEL_FONT_URL}
-        maxWidth={width * 0.9}
-      >
-        {displayName}
-      </OpenWorldLabel>
-
-      {/* Name on left side */}
-      <OpenWorldLabel
-        position={[-(width / 2 + 0.02), height * 0.88, 0]}
-        fontSize={0.18}
-        color={accentColor}
-        dayMix={dayMix}
-        fillOpacity={dimMul}
-        anchorX="center"
-        anchorY="middle"
-        rotation={[0, -Math.PI / 2, 0]}
-        font={PIXEL_FONT_URL}
-        maxWidth={depth * 0.85}
-      >
-        {displayName}
-      </OpenWorldLabel>
-
       {/* Focus selection ring (issue #2593) — a bright accent ring at the base marking the
           URL-focused borough. Rendered day AND night (unlike the neon glow) so the selected
           building is unambiguously distinguished in any lighting. */}
@@ -779,7 +791,7 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
       )}
 
       {/* Base glow circle - wider and brighter (night only) */}
-      {!daytime && (
+      {showNightFx && (
         <mesh ref={glowRef} rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.01, 0]}>
           <circleGeometry args={[1.8, 32]} />
           <meshBasicMaterial
@@ -792,7 +804,7 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
       )}
 
       {/* Neon ground line accents (night only) */}
-      {!app.archived && !daytime && (
+      {!app.archived && showNightFx && (
         <>
           <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, depth / 2 + 0.3]}>
             <planeGeometry args={[width + 0.5, 0.05]} />
@@ -817,10 +829,9 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
         />
       )}
 
-      {/* Floating hologram and label hide entirely when dimmed — they read as
-          "this app isn't your focus right now". Major sub-meshes above already
-          fade via dimMul; suppressing these keeps the dim effect unambiguous. */}
-      {!dimmed && (
+      {/* A signal appears only when the player is actually looking at a building. This
+          keeps the world legible at a distance and makes proximity feel rewarding. */}
+      {showBuildingSignal && (
         <BuildingHologram
           position={[0, height + 0.8, 0]}
           color={accentColor}
@@ -828,7 +839,7 @@ export default function Building({ app, position, agentCount, onClick, playSfx, 
         />
       )}
 
-      {!dimmed && (hovered || isOnline || app.archived || isProximity || focused) && (
+      {showBuildingSignal && (
         <HolographicPanel
           app={app}
           agentCount={agentCount}

--- a/client/src/components/openworld/OpenWorldAgentBar.jsx
+++ b/client/src/components/openworld/OpenWorldAgentBar.jsx
@@ -17,8 +17,8 @@ export default function OpenWorldAgentBar({ cosAgents, agentMap }) {
   };
 
   return (
-    <div className="absolute bottom-3 left-3 right-3 pointer-events-auto">
-      <div className="bg-black/80 backdrop-blur-sm border border-cyan-500/25 rounded-lg px-3 py-2.5">
+    <div className="absolute bottom-20 left-1/2 -translate-x-1/2 w-fit max-w-[calc(100vw-2rem)] pointer-events-auto">
+      <div className="openworld-hud-panel openworld-hud-panel--quiet px-3 py-2.5">
         <div className="flex items-center gap-3 overflow-x-auto" style={{ scrollbarWidth: 'thin', scrollbarColor: 'rgba(6,182,212,0.2) transparent' }}>
           <span className="text-cyan-400 text-[11px] font-pixel tracking-wider font-bold shrink-0">AGENTS</span>
           <div className="w-px h-4 bg-cyan-500/20 shrink-0" />

--- a/client/src/components/openworld/OpenWorldBillboards.jsx
+++ b/client/src/components/openworld/OpenWorldBillboards.jsx
@@ -217,7 +217,7 @@ function Billboard({ position, rotation, messages, color, width = 3.5, height = 
 }
 
 export default function OpenWorldBillboards({ positions, apps, cosStatus, reviewCounts, instances, productivityData }) {
-  const { neonAccents } = useOpenWorldPalette();
+  const { neonAccents, neonLayers } = useOpenWorldPalette();
   // Build billboard messages from real system data
   const billboardConfig = useMemo(() => {
     if (!positions || positions.size < 2) return [];
@@ -323,7 +323,10 @@ export default function OpenWorldBillboards({ positions, apps, cosStatus, review
     return billboards;
   }, [positions, apps, cosStatus, reviewCounts, instances, productivityData, neonAccents]);
 
-  if (billboardConfig.length === 0) return null;
+  // Floating system billboards belong to the cyber style. The default Vibes world
+  // communicates through landmarks and focused building signals instead of turning
+  // the horizon into a second dashboard.
+  if (!neonLayers || billboardConfig.length === 0) return null;
 
   return (
     <group>

--- a/client/src/components/openworld/OpenWorldFilterBar.jsx
+++ b/client/src/components/openworld/OpenWorldFilterBar.jsx
@@ -43,7 +43,7 @@ export default function OpenWorldFilterBar({ filter, onChange, matchCount, onJum
     : 'font-pixel text-[9px] tracking-wider px-2 py-1 rounded border transition-colors';
 
   return (
-    <div className="pointer-events-auto bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg px-2 py-2 flex items-center gap-2 flex-wrap">
+    <div className="openworld-hud-panel pointer-events-auto px-2 py-2 flex items-center gap-2 flex-wrap">
       <div className="flex items-center gap-1 flex-wrap">
         {STATUS_FILTERS.map(f => {
           const active = filter.status === f.id;

--- a/client/src/components/openworld/OpenWorldFocusPanel.jsx
+++ b/client/src/components/openworld/OpenWorldFocusPanel.jsx
@@ -28,7 +28,7 @@ function StatBlock({ label, value, tone = 'text-cyan-300' }) {
 export default function OpenWorldFocusPanel({ app, notFound = false, agents = [], onClose, onFocusInWorld, isDesktop = true }) {
   // Desktop: occupy the Intel-pane slot. Compact: a bottom sheet above the dock.
   const containerClass = isDesktop
-    ? 'absolute top-16 right-3 bottom-20 w-72 pointer-events-auto'
+    ? 'absolute top-20 right-4 bottom-24 w-[19rem] pointer-events-auto'
     : 'absolute inset-x-2 bottom-16 pointer-events-auto';
 
   const procSummary = useMemo(() => {
@@ -53,7 +53,7 @@ export default function OpenWorldFocusPanel({ app, notFound = false, agents = []
     return (
       <div className={containerClass}>
         <div
-          className="bg-black/85 backdrop-blur-sm border border-port-warning/40 rounded-lg overflow-hidden flex flex-col"
+          className="openworld-intel-surface overflow-hidden flex flex-col"
           role="region"
           aria-label="Building not found"
         >
@@ -82,7 +82,7 @@ export default function OpenWorldFocusPanel({ app, notFound = false, agents = []
   return (
     <div className={containerClass}>
       <div
-        className={`${isDesktop ? 'h-full' : 'max-h-[55vh]'} bg-black/85 backdrop-blur-sm border border-cyan-500/40 rounded-lg overflow-hidden flex flex-col`}
+        className={`${isDesktop ? 'h-full' : 'max-h-[55vh]'} openworld-intel-surface overflow-hidden flex flex-col`}
         role="region"
         aria-label={`Focused building: ${title}`}
       >

--- a/client/src/components/openworld/OpenWorldHud.jsx
+++ b/client/src/components/openworld/OpenWorldHud.jsx
@@ -1,19 +1,19 @@
 import { useState, useEffect, useMemo, useRef } from 'react';
 import { useNavigate, useLocation } from 'react-router';
-import { Map as MapIcon } from 'lucide-react';
+import { Camera, Compass, History, Map as MapIcon, Settings } from 'lucide-react';
 import OpenWorldIntelPane from './OpenWorldIntelPane';
 import OpenWorldFocusPanel from './OpenWorldFocusPanel';
 import OpenWorldAgentBar from './OpenWorldAgentBar';
 import OpenWorldFilterBar from './OpenWorldFilterBar';
 import OpenWorldXpBadge from './OpenWorldXpBadge';
 import OpenWorldMiniMap from './OpenWorldMiniMap';
-import OpenWorldVitalsList from './OpenWorldVitalsList';
 import OpenWorldHudCompact from './OpenWorldHudCompact';
-import { HudCorner, HealthBar, getHealthSentinel } from './openWorldHudBits';
+import { HealthBar, getHealthSentinel } from './openWorldHudBits';
 import useOpenWorldViewport from '../../hooks/useOpenWorldViewport';
 import { formatClockTime } from '../../utils/formatters';
 
-// WASD controls hint shown briefly on first exploration entry
+// The first drop-in hint is intentionally a small invitation, not a manual. The full
+// control reference remains discoverable from the settings drawer and keyboard behavior.
 function ControlsHint({ visible }) {
   const [show, setShow] = useState(false);
   const hasShownRef = useRef(false);
@@ -22,7 +22,7 @@ function ControlsHint({ visible }) {
     if (visible && !hasShownRef.current) {
       hasShownRef.current = true;
       setShow(true);
-      const timer = setTimeout(() => setShow(false), 5000);
+      const timer = setTimeout(() => setShow(false), 4500);
       return () => clearTimeout(timer);
     }
     if (!visible) setShow(false);
@@ -31,26 +31,18 @@ function ControlsHint({ visible }) {
   if (!show) return null;
 
   return (
-    <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none animate-in fade-in duration-500">
-      <div className="bg-black/85 border border-cyan-500/40 rounded-lg px-6 py-4 text-center">
-        <div className="font-pixel text-[11px] text-cyan-400 tracking-wider mb-3" style={{ textShadow: '0 0 8px rgba(6,182,212,0.5)' }}>
-          FIRST-PERSON EXPLORATION
+    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none animate-in fade-in duration-500">
+      <div className="openworld-hud-panel px-5 py-4 text-center">
+        <div className="openworld-hud-eyebrow mb-3">FREE ROAM</div>
+        <div className="mb-3 flex items-center justify-center gap-1.5">
+          {['W', 'A', 'S', 'D'].map((key) => (
+            <span key={key} className="flex h-7 w-7 items-center justify-center rounded-lg border border-[rgb(var(--port-accent)/.28)] bg-[rgb(var(--port-accent)/.08)] font-pixel text-[10px] text-[rgb(var(--port-text))]">
+              {key}
+            </span>
+          ))}
         </div>
-        <div className="grid grid-cols-3 gap-1 w-fit mx-auto mb-3">
-          <div />
-          <div className="font-pixel text-[10px] text-gray-300 bg-gray-800/60 border border-gray-600/40 rounded px-2 py-1 text-center">W</div>
-          <div />
-          <div className="font-pixel text-[10px] text-gray-300 bg-gray-800/60 border border-gray-600/40 rounded px-2 py-1 text-center">A</div>
-          <div className="font-pixel text-[10px] text-gray-300 bg-gray-800/60 border border-gray-600/40 rounded px-2 py-1 text-center">S</div>
-          <div className="font-pixel text-[10px] text-gray-300 bg-gray-800/60 border border-gray-600/40 rounded px-2 py-1 text-center">D</div>
-        </div>
-        <div className="font-pixel text-[8px] text-gray-500 tracking-wide space-y-1">
-          <div>MOUSE: LOOK AROUND (CLICK TO LOCK)</div>
-          <div>WASD: MOVE · Q/E: DOWN/UP</div>
-          <div>SHIFT: SPRINT</div>
-          <div>F: FOCUS BUILDING / WARP PAD</div>
-          <div>M: WORLD MAP</div>
-          <div>TAB: ORBITAL OVERVIEW · V: THIRD PERSON</div>
+        <div className="font-pixel text-[8px] tracking-wide text-[rgb(var(--port-text-muted))]">
+          WASD DRIVE <span className="mx-1 opacity-50">·</span> SHIFT BOOST <span className="mx-1 opacity-50">·</span> SPACE JUMP <span className="mx-1 opacity-50">·</span> M MAP
         </div>
       </div>
     </div>
@@ -59,15 +51,26 @@ function ControlsHint({ visible }) {
 
 function Crosshair() {
   return (
-    <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none">
-      <div className="relative w-6 h-6">
-        <div className="absolute top-0 left-1/2 -translate-x-1/2 w-px h-2 bg-cyan-400/60" />
-        <div className="absolute bottom-0 left-1/2 -translate-x-1/2 w-px h-2 bg-cyan-400/60" />
-        <div className="absolute left-0 top-1/2 -translate-y-1/2 w-2 h-px bg-cyan-400/60" />
-        <div className="absolute right-0 top-1/2 -translate-y-1/2 w-2 h-px bg-cyan-400/60" />
-        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-1 h-1 rounded-full bg-cyan-400/40" />
-      </div>
+    <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none">
+      <div className="openworld-hud-crosshair" />
     </div>
+  );
+}
+
+function HudAction({ icon: Icon, label, hint, active, primary = false, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      aria-pressed={active === undefined ? undefined : active}
+      className={`openworld-hud-action ${primary ? 'openworld-hud-action--primary' : ''}`}
+    >
+      <Icon size={16} strokeWidth={1.8} aria-hidden="true" />
+      <span className="openworld-hud-action-copy">{label}</span>
+      {hint && <span className="openworld-hud-action-hint">{hint}</span>}
+    </button>
   );
 }
 
@@ -78,6 +81,7 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
   const { isDesktop } = useOpenWorldViewport();
   const [time, setTime] = useState(new Date());
   const [uptimeSeconds, setUptimeSeconds] = useState(0);
+
   useEffect(() => {
     const interval = setInterval(() => {
       setTime(new Date());
@@ -115,8 +119,6 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
     a.status === 'running' || a.state === 'coding' || a.state === 'thinking' || a.state === 'investigating'
   ).length;
 
-  // The shared vitals payload — backs both the desktop cockpit's vitals panel and
-  // the compact/phone `vitals` disclosure surface (via <OpenWorldVitalsList>).
   const vitals = {
     uptimeSeconds,
     sentinel,
@@ -139,49 +141,31 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
   };
 
   return (
-    // z-20 keeps the HUD above the OpenWorldScanlines CRT overlay (z-10) so the vignette
-    // + scanline-multiply + chromatic-aberration glow stay on the 3D scene and don't
-    // haze the (now theme-colored) HUD panels.
-    <div className="absolute inset-0 pointer-events-none overflow-hidden z-20">
+    <div className="absolute inset-0 z-20 pointer-events-none openworld-hud-shell overflow-hidden">
       {isDesktop ? (
         <>
-          {/* Top-left: Clock + system status + vitals */}
-          <div className="absolute top-3 left-3 pointer-events-auto">
-            <div className="relative bg-black/85 backdrop-blur-sm border border-cyan-500/40 rounded-lg px-4 py-3 overflow-hidden">
-              <HudCorner position="tl" />
-              <HudCorner position="tr" />
-              <HudCorner position="bl" />
-              <HudCorner position="br" />
-
-              <div className="font-pixel text-cyan-400 text-xl tracking-wider" style={{ textShadow: '0 0 10px rgba(6,182,212,0.6)' }}>
-                {formatClockTime(time)}
+          <div className="absolute left-4 top-4 pointer-events-auto">
+            <div className="openworld-hud-panel w-[min(17rem,calc(100vw-2rem))] px-4 py-3.5">
+              <div className="flex items-center justify-between gap-4">
+                <span className="openworld-hud-eyebrow">OpenWorld / free roam</span>
+                <span className={`h-2.5 w-2.5 rounded-full ${sentinel.dot}`} title={sentinel.label} aria-label={`World health ${sentinel.label}`} />
               </div>
-              <div className="font-pixel text-[11px] text-cyan-500 tracking-wide mt-0.5">
-                {activeApps}/{totalApps} SYSTEMS ONLINE
+              <div className="mt-2 flex items-end justify-between gap-4">
+                <span className="font-pixel text-2xl tracking-[0.12em] text-[rgb(var(--port-text))]">{formatClockTime(time, { seconds: false })}</span>
+                <span className="font-pixel text-[9px] tracking-[0.12em] text-[rgb(var(--port-accent))]">{activeApps}/{totalApps} ACTIVE</span>
               </div>
-
-              {/* System health bar */}
               <div className="mt-2">
-                <HealthBar value={activeApps} max={totalApps} color="#06b6d4" />
+                <HealthBar value={activeApps} max={totalApps} color="rgb(var(--port-accent))" />
               </div>
-            </div>
-
-            {/* System Vitals panel */}
-            <div className="relative mt-2 bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg px-3 py-2.5 overflow-hidden">
-              <HudCorner position="tl" />
-              <HudCorner position="tr" />
-              <HudCorner position="bl" />
-              <HudCorner position="br" />
-
-              {/* Animated scan line (CSS-only, no React re-renders) */}
-              <div className="absolute left-0 right-0 h-px bg-cyan-400/15 pointer-events-none animate-scanline" />
-
-              <OpenWorldVitalsList {...vitals} />
+              <div className="mt-2 flex items-center justify-between gap-3 font-pixel text-[8px] tracking-[0.12em] text-[rgb(var(--port-text-muted))]">
+                <span className="truncate">{activeRegion?.label || 'DOWNTOWN'}</span>
+                <span className={sentinel.text}>{sentinel.label}</span>
+              </div>
             </div>
           </div>
 
           {filter && onFilterChange && (
-            <div className="absolute top-3 left-1/2 -translate-x-1/2">
+            <div className="absolute left-1/2 top-4 -translate-x-1/2">
               <OpenWorldFilterBar
                 filter={filter}
                 onChange={onFilterChange}
@@ -191,32 +175,22 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
             </div>
           )}
 
-          {/* Top-right: Connection + CoS status */}
-          <div className="absolute top-3 right-3 pointer-events-auto">
-            <div className="relative bg-black/85 backdrop-blur-sm border border-cyan-500/40 rounded-lg px-4 py-2.5 flex items-center gap-4">
-              <HudCorner position="tl" />
-              <HudCorner position="tr" />
-              <HudCorner position="bl" />
-              <HudCorner position="br" />
-
+          <div className="absolute right-4 top-4 pointer-events-auto">
+            <div className="openworld-hud-panel openworld-hud-panel--quiet flex items-center gap-3 px-3.5 py-2.5">
               <div className="flex items-center gap-2">
-                <span className={`w-2.5 h-2.5 rounded-full ${connected ? 'bg-port-success shadow-[0_0_8px_rgba(34,197,94,0.6)]' : 'bg-port-error shadow-[0_0_8px_rgba(239,68,68,0.6)] animate-pulse'}`} />
-                <span className={`font-pixel text-[11px] tracking-wide ${connected ? 'text-gray-300' : 'text-port-error'}`}>
-                  {connected ? 'LINK' : 'OFFLINE'}
+                <span className={`h-2 w-2 rounded-full ${connected ? 'bg-port-success' : 'bg-port-error animate-pulse'}`} />
+                <span className={`font-pixel text-[9px] tracking-[0.12em] ${connected ? 'text-[rgb(var(--port-text-muted))]' : 'text-port-error'}`}>
+                  {connected ? 'SYNCED' : 'OFFLINE'}
                 </span>
               </div>
-              <div className="w-px h-5 bg-cyan-500/25" />
+              <span className="h-4 w-px bg-[rgb(var(--port-accent)/.22)]" />
               <div className="flex items-center gap-2">
-                <span className={`w-2.5 h-2.5 rounded-full ${cosStatus?.running ? 'bg-cyan-400 animate-pulse shadow-[0_0_8px_rgba(6,182,212,0.6)]' : 'bg-gray-600'}`} />
-                <span className={`font-pixel text-[11px] tracking-wide ${cosStatus?.running ? 'text-cyan-400' : 'text-gray-500'}`}>
-                  CoS {cosStatus?.running ? 'RUN' : 'IDLE'}
-                </span>
+                <span className={`h-2 w-2 rounded-full ${cosStatus?.running ? 'bg-[rgb(var(--port-accent))] animate-pulse' : 'bg-[rgb(var(--port-text-muted)/.45)]'}`} />
+                <span className="font-pixel text-[9px] tracking-[0.12em] text-[rgb(var(--port-text-muted))]">CoS {cosStatus?.running ? 'RUN' : 'IDLE'}</span>
               </div>
             </div>
           </div>
 
-          {/* Right side: focus detail panel while a borough is focused (issue #2593),
-              otherwise the Intel pane. The focus panel REPLACES the intel pane — never overlaps. */}
           {isFocused ? (
             <OpenWorldFocusPanel
               app={focusedApp}
@@ -240,129 +214,29 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
             />
           )}
 
-          {/* Bottom: Agent status bar */}
           <OpenWorldAgentBar cosAgents={cosAgents} agentMap={agentMap} />
-
-          {/* Bottom-right: character level / XP HUD badge (roadmap 2.11) */}
           <OpenWorldXpBadge character={character} onOpenDestination={onOpenDestination} />
 
-          {/* Bottom-left: mini-map + Settings gear + legend + corner decoration */}
-          <div className="absolute bottom-16 left-3">
-            {/* Top-down mini-map of every building (roadmap 2.8) */}
+          <div className="absolute bottom-4 left-4 pointer-events-auto">
             <OpenWorldMiniMap apps={apps} onSelectApp={onSelectApp} selectedAppId={focusedAppId} />
-
-            {/* Status legend */}
-            <div className="pointer-events-none mb-2 bg-black/70 backdrop-blur-sm border border-cyan-500/15 rounded-lg px-2.5 py-2 space-y-1">
-              <div className="font-pixel text-[8px] text-cyan-500/50 tracking-wider mb-1">LEGEND</div>
-              <div className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-xs bg-cyan-500" />
-                <span className="font-pixel text-[8px] text-gray-400 tracking-wide">ONLINE</span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-xs bg-red-500" />
-                <span className="font-pixel text-[8px] text-gray-400 tracking-wide">STOPPED</span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-xs bg-violet-500" />
-                <span className="font-pixel text-[8px] text-gray-400 tracking-wide">NOT STARTED</span>
-              </div>
-              <div className="flex items-center gap-1.5">
-                <span className="w-2 h-2 rounded-xs bg-slate-500" />
-                <span className="font-pixel text-[8px] text-gray-400 tracking-wide">ARCHIVED</span>
-              </div>
-            </div>
-
-            {/* World map (M) — warp to any named region without leaving the game */}
-            {onOpenFastTravel && (
-              <button
-                type="button"
-                onClick={onOpenFastTravel}
-                className="pointer-events-auto mb-2 relative bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg px-3 py-2 hover:border-cyan-400/60 hover:bg-cyan-500/10 transition-all w-full"
-                title="World map — teleport to a region (M)"
-                aria-label="World map — teleport to a region"
-              >
-                <HudCorner position="tl" />
-                <HudCorner position="br" />
-                <div className="flex items-center justify-center gap-2 font-pixel text-[10px] text-cyan-400 tracking-wider truncate" style={{ textShadow: '0 0 6px rgba(6,182,212,0.4)' }}>
-                  <MapIcon size={15} aria-hidden="true" />
-                  <span>[ WORLD MAP ]</span>
-                </div>
-                <div className="font-pixel text-[7px] text-cyan-500/40 tracking-wide mt-0.5 text-center truncate">
-                  {activeRegion ? activeRegion.label.toUpperCase() : '(M)'}
-                </div>
-              </button>
-            )}
-
-            {/* Drop In / Fly Out button */}
-            <button
-              onClick={onToggleExploration}
-              className={`pointer-events-auto mb-2 relative bg-black/85 backdrop-blur-sm border rounded-lg px-3 py-2 hover:bg-cyan-500/10 transition-all group ${
-                explorationMode
-                  ? 'border-cyan-400/60 shadow-[0_0_8px_rgba(6,182,212,0.3)]'
-                  : 'border-cyan-500/30 hover:border-cyan-400/60'
-              }`}
-              title={explorationMode ? 'Return to orbital view (Tab)' : 'Enter street-level exploration (Tab)'}
-            >
-              <HudCorner position="tl" />
-              <HudCorner position="br" />
-              <div className="font-pixel text-[10px] text-cyan-400 tracking-wider" style={{ textShadow: '0 0 6px rgba(6,182,212,0.4)' }}>
-                {explorationMode ? '[ FLY OUT ]' : '[ DROP IN ]'}
-              </div>
-              <div className="font-pixel text-[7px] text-cyan-500/40 tracking-wide mt-0.5 text-center">(Tab)</div>
-            </button>
-
-            {/* Photo mode — cinematic camera + postcard capture */}
-            {onEnterPhotoMode && (
-              <button
-                onClick={onEnterPhotoMode}
-                className="pointer-events-auto mb-2 relative bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg w-10 h-10 flex items-center justify-center hover:border-cyan-400/60 hover:bg-cyan-500/10 transition-all group"
-                title="Photo mode — cinematic camera & screenshots"
-              >
-                <HudCorner position="tl" />
-                <HudCorner position="br" />
-                <svg className="w-4.5 h-4.5 text-cyan-500/70 group-hover:text-cyan-400 transition-colors" style={{ filter: 'drop-shadow(0 0 6px rgba(6,182,212,0.4))' }} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z" />
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M15 13a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-              </button>
-            )}
-
-            {/* History / playback mode — scrub recorded city-state snapshots */}
-            {onEnterPlayback && (
-              <button
-                onClick={onEnterPlayback}
-                className="pointer-events-auto mb-2 relative bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg w-10 h-10 flex items-center justify-center hover:border-cyan-400/60 hover:bg-cyan-500/10 transition-all group"
-                title="History — scrub back through past city states"
-              >
-                <HudCorner position="tl" />
-                <HudCorner position="br" />
-                <svg className="w-4.5 h-4.5 text-cyan-500/70 group-hover:text-cyan-400 transition-colors" style={{ filter: 'drop-shadow(0 0 6px rgba(6,182,212,0.4))' }} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3 3v5h5" />
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M3.05 13A9 9 0 106 5.3L3 8" />
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M12 7v5l3 2" />
-                </svg>
-              </button>
-            )}
-
-            <button
-              onClick={() => navigate(location.pathname === '/openworld/settings' ? `/openworld${location.search}` : `/openworld/settings${location.search}`)}
-              className="pointer-events-auto mb-2 relative bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg w-10 h-10 flex items-center justify-center hover:border-cyan-400/60 hover:bg-cyan-500/10 transition-all group"
-              title="Settings"
-              aria-label="OpenWorld settings"
-            >
-              <HudCorner position="tl" />
-              <HudCorner position="br" />
-              <svg className="w-4.5 h-4.5 text-cyan-500/70 group-hover:text-cyan-400 transition-colors" style={{ filter: 'drop-shadow(0 0 6px rgba(6,182,212,0.4))' }} fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
-                <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-            </button>
-            <div className="pointer-events-none">
-              <div className="font-pixel text-[8px] text-cyan-500/20 tracking-widest leading-tight">
-                {'>'} SYS.INIT<br/>
-                {'>'} NET.LINK<br/>
-                {'>'} HUD.READY
-              </div>
+            <div className="openworld-hud-action-rail">
+              {onOpenFastTravel && <HudAction icon={MapIcon} label="World map" hint="M" onClick={onOpenFastTravel} />}
+              <HudAction
+                icon={Compass}
+                label={explorationMode ? 'Fly out' : 'Drop in'}
+                hint="TAB"
+                active={explorationMode}
+                primary
+                onClick={onToggleExploration}
+              />
+              {onEnterPhotoMode && <HudAction icon={Camera} label="Photo mode" onClick={onEnterPhotoMode} />}
+              {onEnterPlayback && <HudAction icon={History} label="History" onClick={onEnterPlayback} />}
+              <HudAction
+                icon={Settings}
+                label="OpenWorld settings"
+                active={location.pathname === '/openworld/settings'}
+                onClick={() => navigate(location.pathname === '/openworld/settings' ? `/openworld${location.search}` : `/openworld/settings${location.search}`)}
+              />
             </div>
           </div>
         </>
@@ -401,10 +275,7 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
         />
       )}
 
-      {/* Center crosshair in exploration mode (shared by both layouts) */}
       {explorationMode && <Crosshair />}
-
-      {/* Controls hint overlay (shared) */}
       <ControlsHint visible={explorationMode} />
     </div>
   );

--- a/client/src/components/openworld/OpenWorldHudCompact.jsx
+++ b/client/src/components/openworld/OpenWorldHudCompact.jsx
@@ -21,11 +21,7 @@ function DockButton({ icon: Icon, label, active, badge = 0, badgeCritical = fals
       title={label}
       aria-label={label}
       aria-pressed={active === undefined ? undefined : active}
-      className={`relative shrink-0 w-11 h-11 flex items-center justify-center rounded-md border transition-colors ${
-        active
-          ? 'border-cyan-400/70 bg-cyan-500/15 text-cyan-300 shadow-[0_0_6px_rgba(6,182,212,0.3)]'
-          : 'border-cyan-500/25 text-cyan-500/70 hover:text-cyan-300 hover:border-cyan-400/50'
-      }`}
+      className="openworld-hud-action relative shrink-0 w-11 h-11"
     >
       <Icon size={18} aria-hidden="true" />
       {badge > 0 && (
@@ -157,9 +153,7 @@ export default function OpenWorldHudCompact({
           onClick={() => togglePane('vitals')}
           aria-label="Time and system vitals"
           aria-pressed={activePane === 'vitals'}
-          className={`relative bg-black/85 backdrop-blur-sm border rounded-lg px-3 min-h-[44px] flex items-center gap-2 transition-colors ${
-            activePane === 'vitals' ? 'border-cyan-400/70' : 'border-cyan-500/40'
-          }`}
+          className="openworld-hud-chip openworld-hud-action relative px-3 min-h-[44px] flex items-center gap-2"
         >
           <span className={`w-2 h-2 rounded-full ${vitals.sentinel.dot} shadow-[0_0_4px_currentColor]`} />
           <span className="font-pixel text-cyan-400 text-sm tracking-wider" style={{ textShadow: '0 0 8px rgba(6,182,212,0.5)' }}>
@@ -172,7 +166,7 @@ export default function OpenWorldHudCompact({
       {/* Top-right: connection + CoS + level */}
       <div className="absolute top-2 right-2 pointer-events-auto flex items-center gap-1.5">
         <div
-          className="bg-black/85 backdrop-blur-sm border border-cyan-500/40 rounded-lg px-2.5 min-h-[44px] flex items-center gap-2"
+          className="openworld-hud-chip px-2.5 min-h-[44px] flex items-center gap-2"
           role="status"
           aria-label={`Link ${connected ? 'online' : 'offline'}, Chief of Staff ${cosStatus?.running ? 'running' : 'idle'}`}
         >
@@ -185,7 +179,7 @@ export default function OpenWorldHudCompact({
             onClick={() => onOpenDestination?.('artifacts')}
             aria-label={`Teleport to Hall of Achievements — level ${character.level}`}
             title="Teleport to Hall of Achievements"
-            className="bg-black/85 backdrop-blur-sm border border-cyan-500/40 rounded-lg px-2.5 min-h-[44px] flex items-center font-pixel text-[11px] text-cyan-300 tracking-wider"
+            className="openworld-hud-chip openworld-hud-action px-2.5 min-h-[44px] flex items-center font-pixel text-[11px] text-cyan-300 tracking-wider"
           >
             LV {character.level}
           </button>
@@ -200,10 +194,10 @@ export default function OpenWorldHudCompact({
             title="Teleport to Goal Monuments"
             // A present-but-unusable date (invalid/future/unreadable) renders in the warning color,
             // matching the CharacterSheet "fix" prompt and the changelog's promise (#2757).
-            className={`bg-black/85 backdrop-blur-sm rounded-lg px-2.5 min-h-[44px] flex items-center font-pixel text-[11px] tracking-wider border ${
+            className={`openworld-hud-chip openworld-hud-action px-2.5 min-h-[44px] flex items-center font-pixel text-[11px] tracking-wider ${
               birthCta.kind === 'fix'
                 ? 'border-port-warning/50 text-port-warning'
-                : 'border-cyan-500/40 text-cyan-300/70'
+                : 'text-cyan-300/70'
             }`}
           >
             {birthCta.badgeLabel}
@@ -227,7 +221,7 @@ export default function OpenWorldHudCompact({
       {/* Disclosure sheet — one surface at a time, above the dock */}
       {!isFocused && activePane && (
         <div className="absolute inset-x-2 bottom-16 pointer-events-auto">
-          <div className="bg-black/90 backdrop-blur-md border border-cyan-500/35 rounded-lg flex flex-col max-h-[55vh] overflow-hidden">
+          <div className="openworld-intel-surface flex flex-col max-h-[55vh] overflow-hidden">
             <div className="flex items-center justify-between pl-3 pr-1 py-1.5 border-b border-cyan-500/20 shrink-0">
               <span className="font-pixel text-[11px] text-cyan-400 tracking-widest" style={{ textShadow: '0 0 8px rgba(6,182,212,0.4)' }}>
                 {(CITY_PANE_LABELS[activePane] || '').toUpperCase()}
@@ -252,7 +246,7 @@ export default function OpenWorldHudCompact({
       {/* Bottom dock — every HUD function within two taps */}
       <div className="absolute bottom-2 left-2 right-2 pointer-events-auto">
         <div
-          className="flex items-center gap-1.5 bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg px-1.5 py-1.5 overflow-x-auto scrollbar-hide touch-pan-x"
+          className="openworld-hud-dock overflow-x-auto scrollbar-hide touch-pan-x"
           role="toolbar"
           aria-label="OpenWorld controls"
         >

--- a/client/src/components/openworld/OpenWorldIntelPane.jsx
+++ b/client/src/components/openworld/OpenWorldIntelPane.jsx
@@ -391,8 +391,8 @@ export default function OpenWorldIntelPane({ apps, cosAgents, reviewCounts, inst
   };
 
   return (
-    <div className={`absolute top-16 right-3 ${collapsed ? '' : 'bottom-20'} w-72 pointer-events-auto`}>
-      <div className={`${collapsed ? '' : 'h-full'} bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg overflow-hidden flex flex-col`}>
+    <div className={`absolute top-20 right-4 ${collapsed ? '' : 'bottom-24'} w-[19rem] pointer-events-auto`}>
+      <div className={`${collapsed ? '' : 'h-full'} openworld-intel-surface overflow-hidden flex flex-col`}>
         <div className="flex items-stretch border-b border-cyan-500/20">
           {/* Deliberately NOT `ui/TabPills`: this bar wears the immersive OpenWorld
               HUD skin (cyan-on-black, `font-pixel` micro-caps, per-tab severity-tinted

--- a/client/src/components/openworld/OpenWorldMiniMap.jsx
+++ b/client/src/components/openworld/OpenWorldMiniMap.jsx
@@ -32,8 +32,8 @@ export default function OpenWorldMiniMap({ apps, onSelectApp, selectedAppId = nu
   if (view.empty) return null;
 
   return (
-    <div className={`${alwaysShow ? 'block' : 'hidden md:block'} mb-2 pointer-events-auto`}>
-      <div className="relative bg-black/85 backdrop-blur-sm border border-cyan-500/30 rounded-lg p-2">
+    <div className={`${alwaysShow ? 'block' : 'hidden md:block'} mb-2 w-fit pointer-events-auto`}>
+      <div className="openworld-hud-panel openworld-hud-map relative w-fit p-2">
         <div className="flex items-center justify-between mb-1.5 px-0.5">
           <span className="font-pixel text-[8px] text-cyan-500/60 tracking-wider">MAP</span>
           <span className="font-pixel text-[8px] text-cyan-400/80 tracking-wider">{view.count}</span>

--- a/client/src/components/openworld/OpenWorldScene.jsx
+++ b/client/src/components/openworld/OpenWorldScene.jsx
@@ -349,7 +349,7 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
           apps={apps}
           active={explorationMode}
           transitioning={transitioning}
-          cameraView={settings?.cameraView ?? 'first'}
+          cameraView={settings?.cameraView ?? 'third'}
           teleport={playerTeleport}
           warpPads={warpRegions}
           onWarpPadInteract={onTravelToRegion}

--- a/client/src/components/openworld/OpenWorldSettingsDrawer.jsx
+++ b/client/src/components/openworld/OpenWorldSettingsDrawer.jsx
@@ -383,7 +383,7 @@ export default function OpenWorldSettingsDrawer({ open, onClose, qualityMode = '
                 { key: 'third', label: 'ROVER' },
                 { key: 'first', label: 'FIRST PERSON' },
               ]}
-                value={settings.cameraView ?? 'third'}
+              value={settings.cameraView ?? 'third'}
               onChange={(key) => updateSetting('cameraView', key)}
               hint="CAMERA WHILE DRIVING (V SWAPS IN-WORLD)"
             />

--- a/client/src/components/openworld/OpenWorldSettingsDrawer.jsx
+++ b/client/src/components/openworld/OpenWorldSettingsDrawer.jsx
@@ -370,7 +370,7 @@ export default function OpenWorldSettingsDrawer({ open, onClose, qualityMode = '
       {activeTab === 'explore' && (
         <div className="space-y-5">
           <div>
-            <SectionHeader title="EXPLORATION" subtitle="Street-level character mode" />
+            <SectionHeader title="EXPLORATION" subtitle="Street-level rover mode" />
             <SettingToggle
               id="city-exploration-mode"
               label="DROP IN MODE"
@@ -380,12 +380,12 @@ export default function OpenWorldSettingsDrawer({ open, onClose, qualityMode = '
             />
             <SettingSegment
               options={[
-                { key: 'third', label: 'CHARACTER' },
+                { key: 'third', label: 'ROVER' },
                 { key: 'first', label: 'FIRST PERSON' },
               ]}
-              value={settings.cameraView ?? 'first'}
+                value={settings.cameraView ?? 'third'}
               onChange={(key) => updateSetting('cameraView', key)}
-              hint="CAMERA WHILE EXPLORING (V SWAPS IN-WORLD)"
+              hint="CAMERA WHILE DRIVING (V SWAPS IN-WORLD)"
             />
           </div>
           <button

--- a/client/src/components/openworld/OpenWorldTraffic.jsx
+++ b/client/src/components/openworld/OpenWorldTraffic.jsx
@@ -1,10 +1,11 @@
 import { useRef, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { computeDistrictBounds } from '../../utils/openWorldMiniMap';
+import { mixHex } from './openWorldConstants';
 import { useOpenWorldPalette } from './OpenWorldPaletteContext';
 
-// A single flying hover vehicle
-function HoverVehicle({ path, color, speed, offset, altitude }) {
+// A single ambient vehicle. Vibes keeps traffic on the road; cyber keeps the original hover lanes.
+function HoverVehicle({ path, color, speed, offset, altitude, lowPoly, surface }) {
   const groupRef = useRef();
   const lightRef = useRef();
   const bodyRef = useRef();
@@ -25,7 +26,9 @@ function HoverVehicle({ path, color, speed, offset, altitude }) {
 
     const x = ax + (bx - ax) * segT;
     const z = az + (bz - az) * segT;
-    const y = altitude + Math.sin(t * Math.PI * 2) * 0.15;
+    const y = lowPoly
+      ? 0.02 + Math.sin(t * Math.PI * 2) * 0.025
+      : altitude + Math.sin(t * Math.PI * 2) * 0.15;
 
     groupRef.current.position.set(x, y, z);
 
@@ -48,30 +51,63 @@ function HoverVehicle({ path, color, speed, offset, altitude }) {
   return (
     <group ref={groupRef}>
       <group ref={bodyRef}>
-        {/* Vehicle body - elongated box */}
-        <mesh>
-          <boxGeometry args={[0.4, 0.08, 0.15]} />
-          <meshBasicMaterial color={color} transparent opacity={0.6} />
+        {/* Vehicle body — grounded in Vibes, airborne in the cyber style. */}
+        <mesh position={lowPoly ? [0, 0.3, 0] : [0, 0, 0]}>
+          <boxGeometry args={lowPoly ? [0.72, 0.24, 0.34] : [0.4, 0.08, 0.15]} />
+          {lowPoly ? (
+            <meshStandardMaterial {...surface} color={mixHex(color, '#f2c28e', 0.28)} roughness={0.74} metalness={0.08} />
+          ) : (
+            <meshBasicMaterial color={color} transparent opacity={0.6} />
+          )}
         </mesh>
         {/* Cockpit windshield */}
-        <mesh position={[0.12, 0.05, 0]}>
-          <boxGeometry args={[0.12, 0.04, 0.12]} />
-          <meshBasicMaterial color="#ffffff" transparent opacity={0.3} />
+        <mesh position={[lowPoly ? 0.1 : 0.12, lowPoly ? 0.48 : 0.05, 0]}>
+          <boxGeometry args={lowPoly ? [0.3, 0.13, 0.25] : [0.12, 0.04, 0.12]} />
+          {lowPoly ? (
+            <meshStandardMaterial {...surface} color="#27384a" roughness={0.28} metalness={0.24} />
+          ) : (
+            <meshBasicMaterial color="#ffffff" transparent opacity={0.3} />
+          )}
         </mesh>
-        {/* Engine glow at rear */}
-        <mesh position={[-0.22, 0, 0]}>
-          <sphereGeometry args={[0.04, 6, 6]} />
-          <meshBasicMaterial color={color} transparent opacity={0.9} />
-        </mesh>
-        {/* Tail light */}
-        <pointLight ref={lightRef} position={[-0.22, 0, 0]} color={color} intensity={0.3} distance={3} decay={2} />
+        {lowPoly && (
+          <>
+            <mesh position={[-0.38, 0.34, 0]}>
+              <boxGeometry args={[0.035, 0.08, 0.22]} />
+              <meshBasicMaterial color="#ef6b61" toneMapped={false} />
+            </mesh>
+            {[-1, 1].map((side) => (
+              <mesh key={`headlight-${side}`} position={[0.38, 0.32, side * 0.1]}>
+                <boxGeometry args={[0.035, 0.07, 0.07]} />
+                <meshBasicMaterial color="#fff1c9" toneMapped={false} />
+              </mesh>
+            ))}
+            {[-1, 1].map((side) => (
+              <group key={`wheel-${side}`} position={[0, 0.15, side * 0.2]}>
+                <mesh rotation={[Math.PI / 2, 0, 0]}>
+                  <cylinderGeometry args={[0.13, 0.13, 0.08, 10]} />
+                  <meshStandardMaterial color="#1b2633" roughness={0.9} metalness={0.05} />
+                </mesh>
+              </group>
+            ))}
+          </>
+        )}
+        {/* Engine glow at rear — cyber traffic keeps its luminous signature. */}
+        {!lowPoly && (
+          <>
+            <mesh position={[-0.22, 0, 0]}>
+              <sphereGeometry args={[0.04, 6, 6]} />
+              <meshBasicMaterial color={color} transparent opacity={0.9} />
+            </mesh>
+            <pointLight ref={lightRef} position={[-0.22, 0, 0]} color={color} intensity={0.3} distance={3} decay={2} />
+          </>
+        )}
       </group>
     </group>
   );
 }
 
 export default function OpenWorldTraffic({ positions }) {
-  const { neonAccents } = useOpenWorldPalette();
+  const { neonAccents, lowPoly, surface } = useOpenWorldPalette();
   // Generate traffic lanes based on building layout
   const vehicles = useMemo(() => {
     if (!positions || positions.size < 2) return [];
@@ -150,6 +186,8 @@ export default function OpenWorldTraffic({ positions }) {
           speed={v.speed}
           offset={v.offset}
           altitude={v.altitude}
+          lowPoly={lowPoly}
+          surface={surface}
         />
       ))}
     </group>

--- a/client/src/components/openworld/OpenWorldXpBadge.jsx
+++ b/client/src/components/openworld/OpenWorldXpBadge.jsx
@@ -64,12 +64,12 @@ export default function OpenWorldXpBadge({ character, onOpenDestination }) {
   const fixState = cta?.kind === 'fix';
 
   return (
-    <div className="absolute bottom-16 right-3 pointer-events-auto">
+    <div className="absolute bottom-4 right-4 pointer-events-auto">
       <button
         type="button"
         onClick={() => onOpenDestination?.(destination)}
         title={view.hasBirthDate ? 'Teleport to Hall of Achievements' : 'Teleport to Goal Monuments'}
-        className={`relative block w-40 sm:w-48 bg-black/85 backdrop-blur-sm border rounded-lg px-3 py-2.5 overflow-hidden text-left transition-all duration-300 hover:bg-cyan-500/10 ${
+        className={`openworld-hud-panel relative block w-40 sm:w-48 px-3 py-2.5 overflow-hidden text-left transition-all duration-300 hover:bg-cyan-500/10 ${
           leveling
             ? 'border-amber-400/70 shadow-[0_0_16px_rgba(245,158,11,0.5)]'
             : fixState

--- a/client/src/components/openworld/PlayerAvatar.jsx
+++ b/client/src/components/openworld/PlayerAvatar.jsx
@@ -1,169 +1,139 @@
-import { useRef, useMemo, useEffect, useCallback } from 'react';
+import { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { useGLTF } from '@react-three/drei';
 import * as THREE from 'three';
 import { useOpenWorldPalette } from './OpenWorldPaletteContext';
 import { dampFactor, EYE_HEIGHT } from '../../utils/openWorldPlayerRig';
-import { withInPlaceClips, inPlaceClipName } from '../../utils/animationClips';
-import { fitModelToHeight } from '../../utils/modelFit';
-import useClonedGltf, { GltfPrimitive } from '../../hooks/useClonedGltf';
-// The root-motion clip set + treadmill suffix are model-level facts about the bundled
-// RobotExpressive GLB, so import the single source of truth rather than redeclaring it —
-// a divergent copy would silently break in-place routing in one avatar and not the other.
-import { MUSE_ROOT_MOTION_CLIPS as ROOT_MOTION_CLIPS, MUSE_IN_PLACE_SUFFIX as IN_PLACE_SUFFIX } from '../cos/constants';
+import { mixHex } from './openWorldConstants';
 
-// The exploration-mode player, rendered in third person with the bundled rigged GLB
-// (three.js's RobotExpressive by default — data/avatar/model.glb, the same model the CoS
-// "Cyber Muse" avatar uses). The character keeps its own textures/colors; the only city
-// tint is a themed ground-glow disc under its feet so it still reads as "our runner."
-//
-// It reads the PlayerController's mutable rig every frame (no React state on the hot path)
-// and crossfades the GLB's skeletal clips by rig.state:
-//   idle  → Idle
-//   walk  → Walking (in place)
-//   run   → Running (in place)
-//   hover → Jump (flyover: legs off the ground, body floated toward the camera anchor)
-// Walking/Running carry root translation (they'd walk the model out from under the rig,
-// which OWNS world position); we route them to the synthesized "in place" treadmill
-// variants (see withInPlaceClips) so the gait animates while the rig drives movement.
-
-const MODEL_URL = '/api/avatar/model.glb';
-const TARGET_HEIGHT = 1.7; // world units, matches the old procedural runner
-const FADE = 0.25;         // crossfade seconds between state clips
-// The bundled RobotExpressive model is authored facing +Z; the rig's forward is -Z
-// (rig.facing 0 → -z), so we add a 180° yaw so the runner faces its travel direction.
-// If a user swaps in a GLB with a different forward axis, the runner would face the wrong
-// way — this offset is the one model-orientation assumption, called out so it's greppable.
-const MODEL_FACING_OFFSET = Math.PI;
-const buildPlayerAnimations = (animations) => (
-  withInPlaceClips(animations, ROOT_MOTION_CLIPS, IN_PLACE_SUFFIX)
-);
-
-// rig.state → { desired GLB clip, playback rate }. The clip is auto-routed to its
-// in-place variant when it's a root-motion clip. Rates lean a touch fast so the gait
-// reads energetic and foot-skate against the rig's move speed stays subtle.
-const STATE_CLIP = {
-  idle:  { clip: 'Idle',    timeScale: 1.0 },
-  walk:  { clip: 'Walking', timeScale: 1.3 },
-  run:   { clip: 'Running', timeScale: 1.5 },
-  hover: { clip: 'Jump',    timeScale: 1.0 },
-};
+// A small, procedural low-poly rover keeps the third-person actor local to OpenWorld.
+// It is intentionally made from primitives instead of another downloaded GLB: the car
+// inherits the active theme, loads instantly, and stays readable while sprinting, jumping,
+// or flying above the city.
+const CAR_LENGTH = 1.85;
+const CAR_WIDTH = 1.06;
+const WHEEL_RADIUS = 0.24;
+const WHEEL_X = CAR_WIDTH * 0.57;
+const WHEEL_Z = CAR_LENGTH * 0.31;
+const _rootTarget = new THREE.Vector3();
 
 export default function PlayerAvatar({ rigRef }) {
-  const { accent } = useOpenWorldPalette();
-  // Append neutralized in-place variants of the root-motion clips so walk/run
-  // cycles the legs without translating the model off the rig-driven position.
-  const { scene, actions, names } = useClonedGltf(MODEL_URL, buildPlayerAnimations);
-  const hasClips = names.length > 0;
-
+  const { accent, surface } = useOpenWorldPalette();
   const rootRef = useRef();
-  const groundOffsetRef = useRef(-EYE_HEIGHT);
-  const activeClipRef = useRef(null);
-  const discMatRef = useRef();
+  const bodyRef = useRef();
+  const hoverRingRef = useRef();
+  const underglowRef = useRef();
+  const wheelRefs = useRef([]);
 
-  // Fit the model to TARGET_HEIGHT with feet at y=0 and centered on x/z, mutating the
-  // scene directly. This MUST run in an effect (not a render-time useMemo): the bounding
-  // box is only correct after useAnimations has set up the skeleton/mixer — measuring
-  // during render sees an unposed rig and yields a wildly wrong (≈34×) size, shrinking the
-  // model to an invisible speck. Frustum culling is off because animated poses (jump, arms
-  // out) exceed the bind-pose box; shadows off to match the CoS avatar. Runs once per
-  // loaded scene (absolute transform — re-running on state changes would pop the size).
-  useEffect(() => {
-    scene.traverse((obj) => {
-      if (!obj.isMesh) return;
-      obj.frustumCulled = false;
-      obj.castShadow = false;
-      obj.receiveShadow = false;
-    });
-    fitModelToHeight(scene, { targetHeight: TARGET_HEIGHT, feetOnGround: true });
-  }, [scene]);
-
-  // Precompute each rig.state → the concrete clip present on the loaded GLB (root-motion →
-  // in-place variant; fall back through the routed name → Idle → first clip). This only
-  // depends on the loaded clip set, so resolving it once here keeps the per-frame loop to a
-  // single object lookup instead of re-scanning `names` every frame.
-  const clipByState = useMemo(() => {
-    if (!hasClips) return null;
-    const resolve = (state) => {
-      const wanted = (STATE_CLIP[state] || STATE_CLIP.idle).clip;
-      const routed = inPlaceClipName(wanted, ROOT_MOTION_CLIPS, IN_PLACE_SUFFIX);
-      if (names.includes(routed)) return routed;
-      if (names.includes('Idle')) return 'Idle';
-      return names[0] || null;
-    };
-    return Object.fromEntries(Object.keys(STATE_CLIP).map((s) => [s, resolve(s)]));
-  }, [hasClips, names]);
-
-  // Crossfade to `clipName` at the given rate. No-op if it's already the active clip,
-  // so this is safe to call every frame.
-  const fadeTo = useCallback((clipName, timeScale) => {
-    if (!clipName || clipName === activeClipRef.current) return;
-    const next = actions[clipName];
-    if (!next) return;
-    const prev = actions[activeClipRef.current];
-    next.reset();
-    next.enabled = true;
-    next.setEffectiveTimeScale(timeScale ?? 1);
-    next.setEffectiveWeight(1);
-    next.setLoop(THREE.LoopRepeat, Infinity);
-    next.fadeIn(FADE).play();
-    if (prev && prev !== next) prev.fadeOut(FADE);
-    activeClipRef.current = clipName;
-  }, [actions]);
+  const bodyColor = mixHex('#e7825c', accent, 0.22);
+  const bodyShadow = mixHex('#263447', accent, 0.16);
+  const glassColor = mixHex('#15243a', accent, 0.25);
+  const wheelColor = '#17212d';
 
   useFrame(({ clock }, delta) => {
     const root = rootRef.current;
+    const body = bodyRef.current;
     const rig = rigRef?.current;
-    if (!root || !rig) return;
-    const f = dampFactor(8, delta);
-    const state = rig.state;
-    const hovering = state === 'hover';
+    if (!root || !body || !rig) return;
 
-    // Root follows the rig: feet on the ground normally (rig.position.y is eye height, so
-    // subtract EYE_HEIGHT to drop the feet to the plane); in hover the body floats up
-    // toward the camera anchor with a gentle bob so a flyover reads as airborne.
     const t = clock.getElapsedTime();
-    const targetOffset = hovering ? -1.05 : -EYE_HEIGHT;
-    groundOffsetRef.current += (targetOffset - groundOffsetRef.current) * f;
-    const bob = hovering ? Math.sin(t * 2.2) * 0.06 : 0;
-    root.position.set(rig.position.x, rig.position.y + groundOffsetRef.current + bob, rig.position.z);
+    const hovering = rig.state === 'hover';
+    const moving = rig.state === 'walk' || rig.state === 'run';
+    const running = rig.state === 'run';
+    const follow = dampFactor(10, delta);
+    const targetY = rig.position.y - EYE_HEIGHT + (hovering ? 0.25 : 0);
 
-    // Face the travel direction (see MODEL_FACING_OFFSET); bank leans into turns.
-    root.rotation.y = rig.facing + MODEL_FACING_OFFSET;
-    root.rotation.z = rig.bank;
+    root.position.lerp(_rootTarget.set(rig.position.x, targetY, rig.position.z), follow);
+    root.rotation.y = rig.facing;
+    root.rotation.z = rig.bank * 0.38;
 
-    // Drive the skeleton from the mutable rig state (crossfades only on change).
-    if (clipByState) {
-      const cfg = STATE_CLIP[state] || STATE_CLIP.idle;
-      fadeTo(clipByState[state] || clipByState.idle, cfg.timeScale);
+    const bob = hovering ? 0.2 + Math.sin(t * 2.4) * 0.07 : 0;
+    body.position.y += (bob - body.position.y) * follow;
+    body.rotation.x = hovering ? Math.sin(t * 2.1) * 0.045 : 0;
+    body.rotation.z = rig.bank * 0.32;
+
+    const wheelSpeed = running ? 15 : moving ? 8 : 0;
+    wheelRefs.current.forEach((wheel) => {
+      if (!wheel) return;
+      wheel.rotation.x -= wheelSpeed * delta;
+      wheel.rotation.y = hovering ? Math.sin(t * 2) * 0.08 : 0;
+    });
+
+    if (hoverRingRef.current) {
+      hoverRingRef.current.rotation.z = t * 0.75;
+      hoverRingRef.current.material.opacity = hovering ? 0.72 : 0.22;
+      hoverRingRef.current.scale.setScalar(hovering ? 1 + Math.sin(t * 3) * 0.08 : 1);
     }
-
-    // Brighten the footprint disc slightly while flying.
-    if (discMatRef.current) discMatRef.current.opacity = hovering ? 0.3 : 0.16;
+    if (underglowRef.current) {
+      underglowRef.current.material.opacity = (hovering ? 0.42 : moving ? 0.26 : 0.16) + Math.sin(t * 4) * 0.025;
+    }
   });
+
+  const setWheelRef = (index) => (node) => {
+    wheelRefs.current[index] = node;
+  };
 
   return (
     <group ref={rootRef}>
-      {/* scene carries its own fit scale/position (applied in the effect above). */}
-      <GltfPrimitive object={scene} />
-      {/* Accent-tinted ground glow — the runner's neon footprint. Declared as JSX so R3F
-          owns the geometry/material lifecycle; `color` tracks the theme reactively and the
-          per-frame opacity write goes through discMatRef. */}
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
-        <circleGeometry args={[0.45, 18]} />
-        <meshBasicMaterial
-          ref={discMatRef}
-          color={accent}
-          transparent
-          opacity={0.16}
-          blending={THREE.AdditiveBlending}
-          depthWrite={false}
-          side={THREE.DoubleSide}
-        />
+      <group ref={bodyRef}>
+        {/* Low-poly body and cabin */}
+        <mesh position={[0, 0.48, 0]}>
+          <boxGeometry args={[CAR_WIDTH, 0.42, CAR_LENGTH]} />
+          <meshStandardMaterial {...surface} color={bodyColor} roughness={0.58} metalness={0.22} />
+        </mesh>
+        <mesh position={[0, 0.74, 0.08]}>
+          <boxGeometry args={[CAR_WIDTH * 0.72, 0.26, CAR_LENGTH * 0.46]} />
+          <meshStandardMaterial {...surface} color={glassColor} roughness={0.24} metalness={0.36} transparent opacity={0.92} />
+        </mesh>
+        <mesh position={[0, 0.39, -CAR_LENGTH * 0.53]}>
+          <boxGeometry args={[CAR_WIDTH * 0.88, 0.08, 0.1]} />
+          <meshStandardMaterial color={accent} emissive={accent} emissiveIntensity={0.45} />
+        </mesh>
+        <mesh position={[0, 0.4, CAR_LENGTH * 0.53]}>
+          <boxGeometry args={[CAR_WIDTH * 0.82, 0.07, 0.08]} />
+          <meshStandardMaterial color="#ef5252" emissive="#ef5252" emissiveIntensity={0.28} />
+        </mesh>
+
+        {/* Front lamps and the small roof beacon make the vehicle readable in both views. */}
+        {[-1, 1].map((side) => (
+          <mesh key={`lamp-${side}`} position={[side * CAR_WIDTH * 0.3, 0.55, -CAR_LENGTH * 0.53]}>
+            <boxGeometry args={[0.13, 0.08, 0.035]} />
+            <meshBasicMaterial color="#fff5cf" toneMapped={false} />
+          </mesh>
+        ))}
+        <mesh position={[0, 0.96, 0.08]}>
+          <sphereGeometry args={[0.055, 8, 6]} />
+          <meshBasicMaterial color={accent} toneMapped={false} />
+        </mesh>
+
+        {/* Wheels are deliberately chunky: the actor should read as a vehicle at a glance. */}
+        {[
+          [-WHEEL_X, WHEEL_Z],
+          [WHEEL_X, WHEEL_Z],
+          [-WHEEL_X, -WHEEL_Z],
+          [WHEEL_X, -WHEEL_Z],
+        ].map(([x, z], index) => (
+          <group key={`wheel-${index}`} ref={setWheelRef(index)} position={[x, WHEEL_RADIUS, z]} rotation={[0, 0, Math.PI / 2]}>
+            <mesh>
+              <cylinderGeometry args={[WHEEL_RADIUS, WHEEL_RADIUS, 0.16, 12]} />
+              <meshStandardMaterial color={wheelColor} roughness={0.88} metalness={0.08} />
+            </mesh>
+            <mesh rotation={[0, Math.PI / 2, 0]}>
+              <cylinderGeometry args={[WHEEL_RADIUS * 0.44, WHEEL_RADIUS * 0.44, 0.17, 10]} />
+              <meshStandardMaterial color={bodyShadow} roughness={0.48} metalness={0.4} />
+            </mesh>
+          </group>
+        ))}
+      </group>
+
+      {/* Ground feedback is intentionally simpler than the old robot's large footprint. */}
+      <mesh ref={underglowRef} rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.025, 0]}>
+        <circleGeometry args={[0.9, 24]} />
+        <meshBasicMaterial color={accent} transparent opacity={0.16} blending={THREE.AdditiveBlending} depthWrite={false} side={THREE.DoubleSide} />
+      </mesh>
+      <mesh ref={hoverRingRef} rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.04, 0]}>
+        <torusGeometry args={[0.82, 0.025, 6, 24]} />
+        <meshBasicMaterial color={accent} transparent opacity={0.22} blending={THREE.AdditiveBlending} depthWrite={false} />
       </mesh>
     </group>
   );
 }
-
-// Warm the loader cache once the URL is known (matches MuseCoSAvatar).
-useGLTF.preload(MODEL_URL);

--- a/client/src/components/openworld/PlayerController.jsx
+++ b/client/src/components/openworld/PlayerController.jsx
@@ -34,9 +34,9 @@ const _lookTarget = new THREE.Vector3();
 
 // Exploration-mode player rig. One mutable rig object is the single source of truth for
 // the player's pose; both camera modes (and the third-person avatar) read from it:
-//   - 'first' (default): the classic invisible first-person camera.
-//   - 'third' (V to toggle): a damped follow camera behind a visible low-poly rover, with
+//   - 'third' (default): a damped follow camera behind a visible low-poly rover, with
 //     building-aware boom shortening (openWorldPlayerRig.js owns all the math).
+//   - 'first' (V to toggle): the classic invisible first-person camera.
 // All original behavior is preserved: WASD/arrows, shift boost, E/Q vertical, F interact,
 // R respawn, pointer-lock mouselook, per-building cylinder collision below flyover height,
 // world bounds, and spawn persistence. Ground movement can't enter the bay (the harbor piers
@@ -50,7 +50,7 @@ export default function PlayerController({
   apps,
   active,
   transitioning = false,
-  cameraView = 'first',
+  cameraView = 'third',
   teleport = null,
   warpPads = [],
   onWarpPadInteract,

--- a/client/src/components/openworld/PlayerController.jsx
+++ b/client/src/components/openworld/PlayerController.jsx
@@ -35,12 +35,12 @@ const _lookTarget = new THREE.Vector3();
 // Exploration-mode player rig. One mutable rig object is the single source of truth for
 // the player's pose; both camera modes (and the third-person avatar) read from it:
 //   - 'first' (default): the classic invisible first-person camera.
-//   - 'third' (V to toggle): a damped follow camera behind a visible cyber-runner, with
+//   - 'third' (V to toggle): a damped follow camera behind a visible low-poly rover, with
 //     building-aware boom shortening (openWorldPlayerRig.js owns all the math).
-// All original behavior is preserved: WASD/arrows, shift sprint, E/Q vertical, F interact,
-// pointer-lock mouselook, per-building cylinder collision below flyover height, world
-// bounds, spawn persistence. New: ground movement can't walk into the bay (the harbor
-// piers stay walkable — see isWalkable in openWorldPlan.js).
+// All original behavior is preserved: WASD/arrows, shift boost, E/Q vertical, F interact,
+// R respawn, pointer-lock mouselook, per-building cylinder collision below flyover height,
+// world bounds, and spawn persistence. Ground movement can't enter the bay (the harbor piers
+// stay walkable — see isWalkable in openWorldPlan.js).
 export default function PlayerController({
   keysRef,
   positions,
@@ -101,6 +101,7 @@ export default function PlayerController({
       rig.yaw = 0; // Forward = (0, 0, -1), facing toward city center
       rig.pitch = 0;
       rig.facing = 0;
+      lastSpawnRef.current = rig.position.clone();
     }
     lookInitRef.current = false;
   }, [active, positions]);
@@ -171,8 +172,8 @@ export default function PlayerController({
     };
   }, [active, gl.domElement, handleClick, handlePointerLockChange, handleMouseMove]);
 
-  // F interacts with the nearby building; V swaps first/third person. (E is vertical-up
-  // in the free-look controls, so neither shadows movement.)
+  // F interacts with the nearby building; V swaps first/third person; R returns to the
+  // current drop-in point. (E is vertical-up in the free-look controls, so neither shadows movement.)
   useEffect(() => {
     if (!active) return;
     const handleKeyDown = (e) => {
@@ -183,6 +184,14 @@ export default function PlayerController({
         onBuildingClick?.(proximityAppRef.current);
       } else if (key === 'v') {
         onToggleCameraView?.();
+      } else if (key === 'r' && lastSpawnRef.current) {
+        rigRef.current.position.copy(lastSpawnRef.current);
+        rigRef.current.yaw = 0;
+        rigRef.current.pitch = 0;
+        rigRef.current.facing = 0;
+        rigRef.current.vy = 0;
+        rigRef.current.jumping = false;
+        lookInitRef.current = false;
       }
     };
     window.addEventListener('keydown', handleKeyDown);
@@ -411,12 +420,9 @@ export default function PlayerController({
 
   if (!active) return null;
 
-  // The visible character exists only in third person — first person stays the
-  // classic invisible camera (and can't self-clip). PlayerAvatar loads a rigged GLB
-  // (useGLTF suspends), so it's wrapped: Suspense keeps the streaming model from
-  // blanking the whole city canvas, and the error boundary degrades to "no visible
-  // runner" if the GLB is missing/corrupt (e.g. a checkout without `npm run setup:data`)
-  // rather than crashing the scene.
+  // The visible vehicle exists only in third person — first person stays the classic
+  // invisible camera (and can't self-clip). The procedural actor is still wrapped by the
+  // existing boundaries so the scene keeps its defensive mount contract.
   if (cameraView !== 'third') return null;
   return (
     <ErrorBoundary fallback={null}>

--- a/client/src/components/openworld/ProcessBuilding.jsx
+++ b/client/src/components/openworld/ProcessBuilding.jsx
@@ -1,9 +1,8 @@
 import { useRef, useMemo, useEffect } from 'react';
 import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
-import { PROCESS_BUILDING_PARAMS, PIXEL_FONT_URL, mixHex } from './openWorldConstants';
+import { PROCESS_BUILDING_PARAMS, mixHex } from './openWorldConstants';
 import { useOpenWorldPalette } from './OpenWorldPaletteContext';
-import OpenWorldLabel from './OpenWorldLabel';
 
 // Process status → color, unified with the themed building map (so 'online' follows
 // the active theme accent and the semantic colors match a stopped/missing *app*):
@@ -21,14 +20,16 @@ const getProcessColor = (status, building) => {
   }
 };
 
-export default function ProcessBuilding({ process, pm2Status, position, seed, dimmed = false, dayMix = 0 }) {
+export default function ProcessBuilding({ pm2Status, position, seed, dimmed = false, dayMix = 0 }) {
   const { building, buildingBody, surface } = useOpenWorldPalette();
   const blinkRef = useRef();
   const glowRef = useRef();
+  const ringRef = useRef();
 
   const status = pm2Status?.status || 'not_found';
   const color = getProcessColor(status, building);
   const { width, depth } = PROCESS_BUILDING_PARAMS;
+  const radius = Math.max(width, depth) * 0.58;
   const dimMul = dimmed ? 0.25 : 1;
   // Match the main Building's daytime treatment — sheds neon, lightens to a lit solid.
   const bodyColor = mixHex(buildingBody, mixHex('#9aa0ac', color, 0.12), dayMix);
@@ -42,8 +43,8 @@ export default function ProcessBuilding({ process, pm2Status, position, seed, di
     return 1.5;
   }, [status, seed]);
 
-  const boxGeom = useMemo(() => new THREE.BoxGeometry(width, height, depth), [width, height, depth]);
-  const edgesGeom = useMemo(() => new THREE.EdgesGeometry(boxGeom), [boxGeom]);
+  const bodyGeom = useMemo(() => new THREE.CylinderGeometry(radius * 0.82, radius, height, 6), [radius, height]);
+  const edgesGeom = useMemo(() => new THREE.EdgesGeometry(bodyGeom), [bodyGeom]);
 
   // edgesGeom is handed to <lineSegments> via a `geometry` prop, so R3F does not
   // manage its disposal the way it would a JSX <edgesGeometry> child. `height`
@@ -52,14 +53,10 @@ export default function ProcessBuilding({ process, pm2Status, position, seed, di
   // previous geometry's GPU buffers, same leak class as Building.jsx's windowTexture.
   useEffect(() => {
     return () => {
-      boxGeom.dispose();
+      bodyGeom.dispose();
       edgesGeom.dispose();
     };
-  }, [boxGeom, edgesGeom]);
-
-  const displayName = useMemo(() => {
-    return (process.name || '').replace(/[-_.]/g, ' ').toUpperCase();
-  }, [process.name]);
+  }, [bodyGeom, edgesGeom]);
 
   // Rotation to face center (passed via position array)
   const rotation = position[3] || 0;
@@ -75,15 +72,15 @@ export default function ProcessBuilding({ process, pm2Status, position, seed, di
         : 0.08;
       glowRef.current.material.opacity = base * dimMul * neonFade;
     }
+    if (ringRef.current) ringRef.current.rotation.z = t * 0.45 + seed;
   });
 
   return (
     <group position={[position[0], 0, position[2]]} rotation={[0, rotation, 0]}>
-      {/* Building body */}
-      <mesh position={[0, height / 2, 0]}>
-        <boxGeometry args={[width, height, depth]} />
+      {/* Hexagonal process pylon: a readable status token rather than a second tiny building. */}
+      <mesh position={[0, height / 2, 0]} geometry={bodyGeom}>
         <meshStandardMaterial
-        {...surface}
+          {...surface}
           color={bodyColor}
           emissive={color}
           emissiveIntensity={(status === 'online' ? 0.2 : 0.08) * dimMul * (1 - dayMix * 0.9)}
@@ -99,25 +96,17 @@ export default function ProcessBuilding({ process, pm2Status, position, seed, di
       </lineSegments>
 
       {/* Neon top cap */}
-      <mesh position={[0, height + 0.01, 0]} rotation={[-Math.PI / 2, 0, 0]}>
-        <planeGeometry args={[width + 0.05, depth + 0.05]} />
+      <mesh position={[0, height + 0.01, 0]}>
+        <cylinderGeometry args={[radius * 0.86, radius * 0.86, 0.05, 6]} />
         <meshBasicMaterial color={color} transparent opacity={0.4 * dimMul * (1 - dayMix * 0.6)} />
       </mesh>
 
-      {/* Process name on front face (dark ink + halo by day) */}
-      <OpenWorldLabel
-        position={[0, height * 0.7, depth / 2 + 0.02]}
-        fontSize={0.1}
-        color={color}
-        dayMix={dayMix}
-        fillOpacity={dimMul}
-        anchorX="center"
-        anchorY="middle"
-        font={PIXEL_FONT_URL}
-        maxWidth={width * 0.85}
-      >
-        {displayName}
-      </OpenWorldLabel>
+      {/* A quiet rotating ring makes the pylon readable at a glance while keeping labels
+          reserved for the focused main building. */}
+      <mesh ref={ringRef} rotation={[Math.PI / 2, 0, 0]} position={[0, 0.09, 0]}>
+        <torusGeometry args={[radius * 0.78, 0.014, 6, 12]} />
+        <meshBasicMaterial color={color} transparent opacity={0.42 * dimMul * (0.35 + neonFade * 0.65)} />
+      </mesh>
 
       {/* Blinking tip light */}
       <mesh ref={blinkRef} position={[0, height + 0.12, 0]}>

--- a/client/src/components/openworld/WorldGround.jsx
+++ b/client/src/components/openworld/WorldGround.jsx
@@ -65,7 +65,7 @@ function RollingFog({ dayMix = 0 }) {
 }
 
 export default function WorldGround({ settings }) {
-  const { ground, neonAccents } = useOpenWorldPalette();
+  const { ground, neonAccents, lowPoly } = useOpenWorldPalette();
   const reflectionsEnabled = settings?.reflectionsEnabled ?? true;
   const groundMatRef = useRef();
 
@@ -82,8 +82,15 @@ export default function WorldGround({ settings }) {
   // theme). At night they read as accent neon; by day the grid mutes to faint pavement
   // lines and the glow fog fades out.
   const accent = ground;
-  const gridSectionColor = mixHex(accent, '#bcc4cc', dayMix);
-  const gridCellColor = mixHex(mixHex(accent, '#0a1420', 0.5), '#a7afb8', dayMix);
+  // The original cyber grid is useful orientation in the neon world, but a dense
+  // cyan debug grid fights the open-air Vibes landscape. Keep a sparse, low-contrast
+  // field there so the player can still read distance without feeling boxed into a UI.
+  const gridSectionColor = lowPoly
+    ? mixHex('#6d8f77', '#c5a77d', dayMix)
+    : mixHex(accent, '#bcc4cc', dayMix);
+  const gridCellColor = lowPoly
+    ? mixHex('#557866', '#9eb39a', dayMix)
+    : mixHex(mixHex(accent, '#0a1420', 0.5), '#a7afb8', dayMix);
   const groundFogOpacity = 0.045 * (1 - dayMix);
 
   useFrame((_, delta) => {
@@ -129,14 +136,14 @@ export default function WorldGround({ settings }) {
 
       <Grid
         args={[GROUND_HALF * 2, GROUND_DEPTH]}
-        cellSize={2}
-        sectionSize={6}
+        cellSize={lowPoly ? 4 : 2}
+        sectionSize={lowPoly ? 16 : 6}
         cellColor={gridCellColor}
         sectionColor={gridSectionColor}
-        cellThickness={0.6}
-        sectionThickness={1.4}
+        cellThickness={lowPoly ? 0.22 : 0.6}
+        sectionThickness={lowPoly ? 0.55 : 1.4}
         fadeDistance={80}
-        fadeStrength={0.6}
+        fadeStrength={lowPoly ? 0.8 : 0.6}
         position={[0, -0.01, GROUND_CENTER_Z]}
       />
 

--- a/client/src/hooks/useOpenWorldSettings.js
+++ b/client/src/hooks/useOpenWorldSettings.js
@@ -56,9 +56,9 @@ const DEFAULT_SETTINGS = {
   // the Visual tab switches back with no migration.
   worldStyle: 'vibes',
   // OpenWorld opens as a game, not an orbital dashboard. Users can still press Tab (or the
-  // HUD control) to pull back to the planning view, but a fresh visit starts in first person.
+  // HUD control) to pull back to the planning view, while V / settings can switch to first person.
   explorationMode: true,
-  cameraView: 'first', // exploration camera: 'first' is the default FPS view; 'third' is optional
+  cameraView: 'third', // the rover is the default actor; first person remains an explicit option
   ...QUALITY_PRESETS.high,
 };
 

--- a/client/src/hooks/useOpenWorldSettings.test.jsx
+++ b/client/src/hooks/useOpenWorldSettings.test.jsx
@@ -56,7 +56,7 @@ describe('useOpenWorldSettings localStorage resilience', () => {
     expect(settings.qualityMode).toBe('auto');
     expect(settings.qualityPreset).toBe('high');
     expect(settings.explorationMode).toBe(true);
-    expect(settings.cameraView).toBe('first');
+    expect(settings.cameraView).toBe('third');
   });
 
   it('loads an existing pre-Auto payload as Manual, keeping its preset', () => {
@@ -98,7 +98,7 @@ describe('useOpenWorldSettings localStorage resilience', () => {
     const [settings] = result.current;
     expect(settings.qualityMode).toBe('auto'); // reset restores Auto default
     expect(settings.explorationMode).toBe(true);
-    expect(settings.cameraView).toBe('first');
+    expect(settings.cameraView).toBe('third');
   });
 
   it('handles the time-of-day-auto event without throwing when writes fail', () => {

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1097,6 +1097,188 @@ html[data-port-theme] .openworld-themed [class~="hover:bg-cyan-300"]:hover { bac
 html[data-port-theme] .openworld-themed [class~="hover:bg-cyan-500/10"]:hover { background-color: rgb(var(--port-accent) / 0.12) !important; }
 html[data-port-theme] .openworld-themed [class~="hover:bg-cyan-500/5"]:hover { background-color: rgb(var(--port-accent) / 0.08) !important; }
 
+/* === OpenWorld HUD refresh ===
+   OpenWorld is a playable map, so its controls should feel like a light cockpit
+   around the world instead of a stack of debug panels. These primitives keep the
+   HUD quiet, theme-aware, and consistent across the desktop and compact layouts.
+   The older utility remap above remains for legacy scene labels and settings. */
+.openworld-themed {
+  --ow-panel: rgb(var(--port-card) / 0.92);
+  --ow-panel-soft: rgb(var(--port-card) / 0.76);
+  --ow-ink: rgb(var(--port-text));
+  --ow-muted: rgb(var(--port-text-muted));
+  --ow-accent: rgb(var(--port-accent));
+  --ow-line: rgb(var(--port-accent) / 0.28);
+  --ow-soft: rgb(var(--port-accent) / 0.1);
+}
+
+.openworld-hud-shell {
+  color: var(--ow-ink);
+  font-variant-numeric: tabular-nums;
+}
+
+.openworld-hud-panel {
+  background: linear-gradient(145deg, var(--ow-panel), rgb(var(--port-bg) / 0.88));
+  border: 1px solid var(--ow-line);
+  border-radius: 18px;
+  box-shadow: 0 16px 42px rgb(0 0 0 / 0.16), inset 0 1px 0 rgb(255 255 255 / 0.08);
+  backdrop-filter: blur(18px) saturate(1.08);
+}
+
+.openworld-hud-panel--quiet {
+  background: var(--ow-panel-soft);
+  box-shadow: 0 12px 32px rgb(0 0 0 / 0.12), inset 0 1px 0 rgb(255 255 255 / 0.06);
+}
+
+.openworld-hud-eyebrow {
+  color: var(--ow-muted);
+  font-family: var(--font-pixel, monospace);
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.openworld-hud-action-rail {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem;
+  border: 1px solid var(--ow-line);
+  border-radius: 18px;
+  background: var(--ow-panel-soft);
+  box-shadow: 0 16px 40px rgb(0 0 0 / 0.15), inset 0 1px 0 rgb(255 255 255 / 0.06);
+  backdrop-filter: blur(18px) saturate(1.08);
+}
+
+.openworld-hud-action {
+  position: relative;
+  display: inline-flex;
+  min-height: 2.65rem;
+  min-width: 2.65rem;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  border: 1px solid transparent;
+  border-radius: 13px;
+  color: var(--ow-muted);
+  font-family: var(--font-pixel, monospace);
+  font-size: 0.6rem;
+  letter-spacing: 0.08em;
+  line-height: 1.1;
+  padding: 0.42rem 0.55rem;
+  text-transform: uppercase;
+  transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.openworld-hud-action:hover,
+.openworld-hud-action:focus-visible {
+  border-color: rgb(var(--port-accent) / 0.38);
+  background: rgb(var(--port-accent) / 0.1);
+  color: var(--ow-ink);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.openworld-hud-action[aria-pressed="true"] {
+  border-color: rgb(var(--port-accent) / 0.5);
+  background: rgb(var(--port-accent) / 0.16);
+  color: var(--ow-accent);
+}
+
+.openworld-hud-action--primary {
+  border-color: rgb(var(--port-accent) / 0.36);
+  background: linear-gradient(135deg, rgb(var(--port-accent) / 0.2), rgb(var(--port-accent) / 0.06));
+  color: var(--ow-accent);
+  padding-inline: 0.75rem;
+}
+
+.openworld-hud-action-copy {
+  display: none;
+  white-space: nowrap;
+}
+
+.openworld-hud-action-hint {
+  color: var(--ow-muted);
+  font-size: 0.5rem;
+  letter-spacing: 0.12em;
+  opacity: 0.72;
+}
+
+.openworld-hud-map {
+  border-radius: 16px;
+  overflow: hidden;
+}
+
+.openworld-hud-dock {
+  display: flex;
+  align-items: center;
+  gap: 0.32rem;
+  padding: 0.32rem;
+  border: 1px solid var(--ow-line);
+  border-radius: 17px;
+  background: var(--ow-panel-soft);
+  box-shadow: 0 10px 28px rgb(0 0 0 / 0.14), inset 0 1px 0 rgb(255 255 255 / 0.06);
+  backdrop-filter: blur(18px) saturate(1.08);
+}
+
+.openworld-hud-chip {
+  border-radius: 12px;
+  background: var(--ow-panel-soft);
+  border: 1px solid var(--ow-line);
+  box-shadow: 0 10px 28px rgb(0 0 0 / 0.12), inset 0 1px 0 rgb(255 255 255 / 0.06);
+  backdrop-filter: blur(16px) saturate(1.05);
+}
+
+.openworld-hud-chip[aria-pressed="true"] {
+  border-color: rgb(var(--port-accent) / 0.5);
+  background: rgb(var(--port-accent) / 0.14);
+}
+
+.openworld-hud-crosshair {
+  position: relative;
+  width: 1.75rem;
+  height: 1.75rem;
+  opacity: 0.78;
+}
+
+.openworld-hud-crosshair::before,
+.openworld-hud-crosshair::after {
+  position: absolute;
+  content: '';
+  inset: 0.72rem 0.15rem;
+  border-top: 1px solid rgb(var(--port-accent) / 0.72);
+  border-bottom: 1px solid rgb(var(--port-accent) / 0.72);
+}
+
+.openworld-hud-crosshair::after {
+  inset: 0.15rem 0.72rem;
+  border-top: 0;
+  border-right: 1px solid rgb(var(--port-accent) / 0.72);
+  border-bottom: 0;
+  border-left: 1px solid rgb(var(--port-accent) / 0.72);
+}
+
+.openworld-intel-surface {
+  border-radius: 20px;
+  background: linear-gradient(160deg, var(--ow-panel), rgb(var(--port-bg) / 0.9));
+  border: 1px solid var(--ow-line);
+  box-shadow: 0 20px 48px rgb(0 0 0 / 0.18), inset 0 1px 0 rgb(255 255 255 / 0.07);
+  backdrop-filter: blur(20px) saturate(1.08);
+}
+
+@media (min-width: 768px) {
+  .openworld-hud-action-copy { display: inline; }
+}
+
+@media (max-width: 767px) {
+  .openworld-hud-panel { border-radius: 16px; }
+  .openworld-hud-dock { border-radius: 16px; overflow-x: auto; scrollbar-width: none; }
+  .openworld-hud-dock::-webkit-scrollbar { display: none; }
+  .openworld-hud-action { min-height: 2.75rem; min-width: 2.75rem; }
+}
+
 /* === Lumen Glass Day === */
 /* Same card set as the base elevation rule above — every fill opacity, not just
    `/50` — so this theme's softened border lands on all of its cards. */

--- a/client/src/pages/OpenWorld.jsx
+++ b/client/src/pages/OpenWorld.jsx
@@ -171,7 +171,7 @@ function OpenWorldInner() {
 
   // V (in exploration mode) swaps the follow-camera character view and first person.
   const handleToggleCameraView = useCallback(() => {
-    updateSetting('cameraView', settings?.cameraView === 'first' ? 'third' : 'first');
+    updateSetting('cameraView', (settings?.cameraView ?? 'third') === 'first' ? 'third' : 'first');
   }, [updateSetting, settings?.cameraView]);
 
   const keysRef = useKeyboardControls(handleToggleExploration);


### PR DESCRIPTION
## Summary

- Reframed OpenWorld as a game-like free-roam experience with a third-person rover as the default actor.
- Rebuilt the desktop and compact HUD into calmer cockpit surfaces with clearer hierarchy, action rails, map access, and discoverable controls.
- Reworked buildings, process pylons, agents, traffic, ground grid, billboards, and scene effects so the bright low-poly Vibes style feels coherent while Cyber City remains available.
- Preserved first-person mode, orbit mode, focus/deep-link behavior, keyboard controls, proximity actions, and settings persistence.
- Removed the runtime GLB dependency from the player actor; the procedural rover loads instantly and responds to movement, boost, jump, hover, banking, and wheel motion.

## Reference

The visual direction was informed by [Bruno Simon’s folio-2025](https://github.com/brunosimon/folio-2025): an environment that feels like a navigable experience first, with interface elements kept subordinate to the world.

## Validation

- [x] Focused OpenWorld regression suite: 8 files, 95 tests passed
- [x] `cd client && npm run lint`
- [x] `cd client && npm run build`
- [x] `git diff --check`
- [x] Browser visual QA of the desktop HUD, map sizing, agent bar, and scene shell

The full client suite remains at 3 unrelated failures outside the OpenWorld diff: `src/a11yConventions.test.js`, `src/pages/QuotaBurn.test.jsx`, and `src/components/meatspace/post/PostDrillConfig.test.jsx`. The production build retains the repository’s existing large `vendor-three` chunk warning.

## Review

- Local code review completed across all 23 changed files.
- No external reviewer was requested by the saved do-pr defaults.
- PR is intentionally left open for review; merge was not requested.