### PR TITLE
fix: make OpenWorld playable on mobile

### DIFF
--- a/client/src/components/openworld/OpenWorldHud.jsx
+++ b/client/src/components/openworld/OpenWorldHud.jsx
@@ -14,7 +14,7 @@ import { formatClockTime } from '../../utils/formatters';
 
 // The first drop-in hint is intentionally a small invitation, not a manual. The full
 // control reference remains discoverable from the settings drawer and keyboard behavior.
-function ControlsHint({ visible }) {
+function ControlsHint({ visible, isDesktop }) {
   const [show, setShow] = useState(false);
   const hasShownRef = useRef(false);
 
@@ -28,7 +28,7 @@ function ControlsHint({ visible }) {
     if (!visible) setShow(false);
   }, [visible]);
 
-  if (!show) return null;
+  if (!show || !isDesktop) return null;
 
   return (
     <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 pointer-events-none animate-in fade-in duration-500">
@@ -276,7 +276,7 @@ export default function OpenWorldHud({ cosStatus, cosAgents, agentMap, eventLogs
       )}
 
       {explorationMode && <Crosshair />}
-      <ControlsHint visible={explorationMode} />
+      <ControlsHint visible={explorationMode} isDesktop={isDesktop} />
     </div>
   );
 }

--- a/client/src/components/openworld/OpenWorldMobileControls.jsx
+++ b/client/src/components/openworld/OpenWorldMobileControls.jsx
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowUp, Eye, Hand, LogOut, Zap } from 'lucide-react';
+
+const STICK_TRAVEL = 32;
+
+function clearMobileInput(mobileInputRef) {
+  if (!mobileInputRef.current) return;
+  mobileInputRef.current.moveX = 0;
+  mobileInputRef.current.moveY = 0;
+  mobileInputRef.current.lookDeltaX = 0;
+  mobileInputRef.current.lookDeltaY = 0;
+  mobileInputRef.current.boost = false;
+  mobileInputRef.current.jump = false;
+}
+
+function HoldButton({ label, hint, icon: Icon, onStart, onEnd, wide = false }) {
+  const finish = (event) => {
+    event.preventDefault();
+    onEnd?.();
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      className={`openworld-mobile-action ${wide ? 'openworld-mobile-action--wide' : ''}`}
+      onPointerDown={(event) => {
+        event.preventDefault();
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+        onStart?.();
+      }}
+      onPointerUp={finish}
+      onPointerCancel={finish}
+      onContextMenu={(event) => event.preventDefault()}
+    >
+      <Icon size={18} strokeWidth={1.9} aria-hidden="true" />
+      <span>{label}</span>
+      {hint && <small>{hint}</small>}
+    </button>
+  );
+}
+
+export default function OpenWorldMobileControls({
+  mobileInputRef,
+  playerActionRef,
+  onToggleCameraView,
+  onToggleExploration,
+}) {
+  const joystickRef = useRef(null);
+  const lookPointRef = useRef(null);
+  const [stick, setStick] = useState({ x: 0, y: 0 });
+
+  const writeMovement = useCallback((clientX, clientY) => {
+    const bounds = joystickRef.current?.getBoundingClientRect();
+    if (!bounds) return;
+    const centerX = bounds.left + bounds.width / 2;
+    const centerY = bounds.top + bounds.height / 2;
+    const radius = Math.max(1, Math.min(bounds.width, bounds.height) / 2 - 24);
+    const x = clientX - centerX;
+    const y = clientY - centerY;
+    const distance = Math.min(radius, Math.hypot(x, y));
+    const angle = Math.atan2(y, x);
+    const next = {
+      x: Math.cos(angle) * distance / radius,
+      y: Math.sin(angle) * distance / radius,
+    };
+    if (distance < radius * 0.12) {
+      next.x = 0;
+      next.y = 0;
+    }
+    setStick(next);
+    if (mobileInputRef.current) {
+      mobileInputRef.current.moveX = next.x;
+      mobileInputRef.current.moveY = next.y;
+    }
+  }, [mobileInputRef]);
+
+  const resetMovement = useCallback(() => {
+    setStick({ x: 0, y: 0 });
+    if (mobileInputRef.current) {
+      mobileInputRef.current.moveX = 0;
+      mobileInputRef.current.moveY = 0;
+    }
+  }, [mobileInputRef]);
+
+  const handleJoystickDown = (event) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    writeMovement(event.clientX, event.clientY);
+  };
+
+  const handleLookDown = (event) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture?.(event.pointerId);
+    lookPointRef.current = { x: event.clientX, y: event.clientY };
+  };
+
+  const handleLookMove = (event) => {
+    const previous = lookPointRef.current;
+    if (!previous || !mobileInputRef.current) return;
+    mobileInputRef.current.lookDeltaX += event.clientX - previous.x;
+    mobileInputRef.current.lookDeltaY += event.clientY - previous.y;
+    lookPointRef.current = { x: event.clientX, y: event.clientY };
+  };
+
+  const handleLookEnd = () => {
+    lookPointRef.current = null;
+  };
+
+  const setBoost = (active) => {
+    if (mobileInputRef.current) mobileInputRef.current.boost = active;
+  };
+
+  const setJump = (active) => {
+    if (mobileInputRef.current) mobileInputRef.current.jump = active;
+  };
+
+  useEffect(() => () => clearMobileInput(mobileInputRef), [mobileInputRef]);
+
+  return (
+    <div className="openworld-mobile-controls absolute inset-0 z-30 pointer-events-none" aria-label="Mobile free roam controls">
+      <div
+        className="openworld-mobile-look-zone"
+        role="group"
+        aria-label="Drag to look around"
+        onPointerDown={handleLookDown}
+        onPointerMove={handleLookMove}
+        onPointerUp={handleLookEnd}
+        onPointerCancel={handleLookEnd}
+        onContextMenu={(event) => event.preventDefault()}
+      >
+        <span className="openworld-mobile-look-hint">DRAG TO LOOK</span>
+      </div>
+
+      <div
+        ref={joystickRef}
+        className="openworld-mobile-joystick"
+        role="group"
+        aria-label="Movement joystick"
+        onPointerDown={handleJoystickDown}
+        onPointerMove={(event) => writeMovement(event.clientX, event.clientY)}
+        onPointerUp={resetMovement}
+        onPointerCancel={resetMovement}
+        onContextMenu={(event) => event.preventDefault()}
+      >
+        <span
+          className="openworld-mobile-joystick-knob"
+          style={{ transform: `translate(calc(-50% + ${stick.x * STICK_TRAVEL}px), calc(-50% + ${stick.y * STICK_TRAVEL}px))` }}
+          aria-hidden="true"
+        />
+        <span className="openworld-mobile-joystick-label" aria-hidden="true">DRIVE</span>
+      </div>
+
+      <div className="openworld-mobile-actions pointer-events-auto" role="toolbar" aria-label="Mobile game actions">
+        <HoldButton label="BOOST" hint="HOLD" icon={Zap} onStart={() => setBoost(true)} onEnd={() => setBoost(false)} />
+        <HoldButton label="JUMP" icon={ArrowUp} onStart={() => setJump(true)} onEnd={() => setJump(false)} />
+        <button
+          type="button"
+          aria-label="Interact with nearby building or warp pad"
+          className="openworld-mobile-action openworld-mobile-action--wide"
+          onClick={() => playerActionRef.current?.interact?.()}
+        >
+          <Hand size={18} strokeWidth={1.9} aria-hidden="true" />
+          <span>ACTION</span>
+        </button>
+        <button
+          type="button"
+          aria-label="Switch camera view"
+          className="openworld-mobile-action"
+          onClick={onToggleCameraView}
+        >
+          <Eye size={18} strokeWidth={1.9} aria-hidden="true" />
+          <span>VIEW</span>
+        </button>
+        <button
+          type="button"
+          aria-label="Fly out to orbital view"
+          className="openworld-mobile-action openworld-mobile-action--exit"
+          onClick={onToggleExploration}
+        >
+          <LogOut size={17} strokeWidth={1.9} aria-hidden="true" />
+          <span>EXIT</span>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/openworld/OpenWorldMobileControls.test.jsx
+++ b/client/src/components/openworld/OpenWorldMobileControls.test.jsx
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import OpenWorldMobileControls from './OpenWorldMobileControls';
+
+function createInput() {
+  return {
+    current: {
+      moveX: 0,
+      moveY: 0,
+      lookDeltaX: 0,
+      lookDeltaY: 0,
+      boost: false,
+      jump: false,
+    },
+  };
+}
+
+function renderControls(overrides = {}) {
+  const mobileInputRef = createInput();
+  const playerActionRef = { current: { interact: vi.fn() } };
+  const props = {
+    mobileInputRef,
+    playerActionRef,
+    onToggleCameraView: vi.fn(),
+    onToggleExploration: vi.fn(),
+    ...overrides,
+  };
+
+  return { ...render(<OpenWorldMobileControls {...props} />), ...props };
+}
+
+describe('OpenWorldMobileControls', () => {
+  it('exposes the complete touch action set', () => {
+    renderControls();
+
+    expect(screen.getByRole('group', { name: 'Movement joystick' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'Drag to look around' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'BOOST' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'JUMP' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Interact with nearby building or warp pad' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Switch camera view' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Fly out to orbital view' })).toBeInTheDocument();
+  });
+
+  it('maps hold actions to the game input refs and clears them on release', () => {
+    const { mobileInputRef } = renderControls();
+    const boost = screen.getByRole('button', { name: 'BOOST' });
+    const jump = screen.getByRole('button', { name: 'JUMP' });
+
+    fireEvent.pointerDown(boost, { pointerId: 1 });
+    expect(mobileInputRef.current.boost).toBe(true);
+    fireEvent.pointerUp(boost, { pointerId: 1 });
+    expect(mobileInputRef.current.boost).toBe(false);
+
+    fireEvent.pointerDown(jump, { pointerId: 2 });
+    expect(mobileInputRef.current.jump).toBe(true);
+    fireEvent.pointerUp(jump, { pointerId: 2 });
+    expect(mobileInputRef.current.jump).toBe(false);
+  });
+
+  it('maps the virtual joystick to normalized drive input', () => {
+    const { mobileInputRef } = renderControls();
+    const joystick = screen.getByRole('group', { name: 'Movement joystick' });
+    vi.spyOn(joystick, 'getBoundingClientRect').mockReturnValue({
+      left: 0,
+      top: 0,
+      width: 100,
+      height: 100,
+      right: 100,
+      bottom: 100,
+      x: 0,
+      y: 0,
+      toJSON: () => {},
+    });
+
+    fireEvent.pointerDown(joystick, { pointerId: 6, clientX: 75, clientY: 25 });
+    expect(mobileInputRef.current.moveX).toBeCloseTo(Math.SQRT1_2);
+    expect(mobileInputRef.current.moveY).toBeCloseTo(-Math.SQRT1_2);
+
+    fireEvent.pointerUp(joystick, { pointerId: 6 });
+    expect(mobileInputRef.current.moveX).toBe(0);
+    expect(mobileInputRef.current.moveY).toBe(0);
+  });
+
+  it('accumulates drag-to-look deltas for the player rig', () => {
+    const { mobileInputRef } = renderControls();
+    const lookZone = screen.getByRole('group', { name: 'Drag to look around' });
+
+    fireEvent.pointerDown(lookZone, { pointerId: 3, clientX: 100, clientY: 120 });
+    fireEvent.pointerMove(lookZone, { pointerId: 3, clientX: 128, clientY: 110 });
+    fireEvent.pointerMove(lookZone, { pointerId: 3, clientX: 120, clientY: 114 });
+    fireEvent.pointerUp(lookZone, { pointerId: 3 });
+
+    expect(mobileInputRef.current.lookDeltaX).toBe(20);
+    expect(mobileInputRef.current.lookDeltaY).toBe(-6);
+  });
+
+  it('routes action buttons to their game callbacks', () => {
+    const onToggleCameraView = vi.fn();
+    const onToggleExploration = vi.fn();
+    const { playerActionRef } = renderControls({ onToggleCameraView, onToggleExploration });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Interact with nearby building or warp pad' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Switch camera view' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Fly out to orbital view' }));
+
+    expect(playerActionRef.current.interact).toHaveBeenCalledTimes(1);
+    expect(onToggleCameraView).toHaveBeenCalledTimes(1);
+    expect(onToggleExploration).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears active touch state when the controls unmount', () => {
+    const { mobileInputRef, unmount } = renderControls();
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'BOOST' }), { pointerId: 4 });
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'JUMP' }), { pointerId: 5 });
+    mobileInputRef.current.moveX = 0.8;
+    mobileInputRef.current.lookDeltaX = 12;
+
+    unmount();
+
+    expect(mobileInputRef.current).toEqual({
+      moveX: 0,
+      moveY: 0,
+      lookDeltaX: 0,
+      lookDeltaY: 0,
+      boost: false,
+      jump: false,
+    });
+  });
+});

--- a/client/src/components/openworld/OpenWorldScene.jsx
+++ b/client/src/components/openworld/OpenWorldScene.jsx
@@ -58,7 +58,7 @@ import { useVisibilityEvent } from '../../hooks/useVisibilityEvent';
 
 const STARTUP_PARTICLE_DENSITY = 0.49;
 
-export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onToggleCameraView, cosStatus, reviewCounts, instances, backupStatus, cosTasks, healthMetrics, voiceState, aiActivity, productivityData, activityCalendar, goals, character, chronotype, memoryGraph, inboxDepth, jiraTickets, introspection, playback = false, photoMode, photoPresetId, photoDof, onPhotoCaptureReady, settings, playSfx, keysRef, dimmedAppIds, focusedAppId, focusedRegion, playerTeleport, hudSafe, background, palette, onTravelToRegion, autoQuality = false, autoStartTier = 'high', autoResetToken = 0, diagnosticsEnabled = false, onAutoTierChange, onAutoDiagnostics }) {
+export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onToggleCameraView, cosStatus, reviewCounts, instances, backupStatus, cosTasks, healthMetrics, voiceState, aiActivity, productivityData, activityCalendar, goals, character, chronotype, memoryGraph, inboxDepth, jiraTickets, introspection, playback = false, photoMode, photoPresetId, photoDof, onPhotoCaptureReady, settings, playSfx, keysRef, mobileInputRef, playerActionRef, dimmedAppIds, focusedAppId, focusedRegion, playerTeleport, hudSafe, background, palette, onTravelToRegion, autoQuality = false, autoStartTier = 'high', autoResetToken = 0, diagnosticsEnabled = false, onAutoTierChange, onAutoDiagnostics }) {
   const [positions, setPositions] = useState(null);
   const [proximityApp, setProximityApp] = useState(null);
   const [transitioning, setTransitioning] = useState(false);
@@ -353,6 +353,8 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
           teleport={playerTeleport}
           warpPads={warpRegions}
           onWarpPadInteract={onTravelToRegion}
+          mobileInputRef={mobileInputRef}
+          playerActionRef={playerActionRef}
         />
       )}
       {!explorationMode && !transitioning && !photoMode && (

--- a/client/src/components/openworld/PlayerController.jsx
+++ b/client/src/components/openworld/PlayerController.jsx
@@ -54,6 +54,8 @@ export default function PlayerController({
   teleport = null,
   warpPads = [],
   onWarpPadInteract,
+  mobileInputRef = null,
+  playerActionRef = null,
 }) {
   const { camera, gl } = useThree();
   const rigRef = useRef({
@@ -174,14 +176,21 @@ export default function PlayerController({
 
   // F interacts with the nearby building; V swaps first/third person; R returns to the
   // current drop-in point. (E is vertical-up in the free-look controls, so neither shadows movement.)
+  const interact = useCallback(() => {
+    if (!active) return;
+    if (proximityWarpPadRef.current) {
+      onWarpPadInteract?.(proximityWarpPadRef.current);
+    } else if (proximityAppRef.current) {
+      onBuildingClick?.(proximityAppRef.current);
+    }
+  }, [active, onBuildingClick, onWarpPadInteract]);
+
   useEffect(() => {
     if (!active) return;
     const handleKeyDown = (e) => {
       const key = e.key.toLowerCase();
-      if (key === 'f' && proximityWarpPadRef.current) {
-        onWarpPadInteract?.(proximityWarpPadRef.current);
-      } else if (key === 'f' && proximityAppRef.current) {
-        onBuildingClick?.(proximityAppRef.current);
+      if (key === 'f') {
+        interact();
       } else if (key === 'v') {
         onToggleCameraView?.();
       } else if (key === 'r' && lastSpawnRef.current) {
@@ -196,7 +205,15 @@ export default function PlayerController({
     };
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [active, onBuildingClick, onToggleCameraView]);
+  }, [active, interact, onToggleCameraView]);
+
+  useEffect(() => {
+    if (!playerActionRef) return undefined;
+    playerActionRef.current = { interact };
+    return () => {
+      if (playerActionRef.current?.interact === interact) playerActionRef.current = null;
+    };
+  }, [interact, playerActionRef]);
 
   // In exploration mode, Space is the jump key — capture it before it bubbles to the
   // global voice push-to-talk hotkey (VoiceWidget listens for the same key on `window`).
@@ -236,7 +253,17 @@ export default function PlayerController({
     const rig = rigRef.current;
 
     const keys = keysRef.current;
-    const isSprinting = keys.has('shift');
+    const mobileInput = mobileInputRef?.current;
+    if (mobileInput) {
+      const lookDeltaX = mobileInput.lookDeltaX || 0;
+      const lookDeltaY = mobileInput.lookDeltaY || 0;
+      mobileInput.lookDeltaX = 0;
+      mobileInput.lookDeltaY = 0;
+      rig.yaw -= lookDeltaX * MOUSE_SENSITIVITY;
+      rig.pitch = Math.max(-PITCH_LIMIT, Math.min(PITCH_LIMIT, rig.pitch - lookDeltaY * MOUSE_SENSITIVITY));
+    }
+
+    const isSprinting = keys.has('shift') || Boolean(mobileInput?.boost);
     const speed = (isSprinting ? SPRINT_SPEED : WALK_SPEED) * delta;
     const verticalSpeed = (isSprinting ? SPRINT_SPEED : VERTICAL_SPEED) * delta;
 
@@ -244,10 +271,12 @@ export default function PlayerController({
     const forward = _forward.set(-Math.sin(rig.yaw), 0, -Math.cos(rig.yaw));
     const right = _right.set(-forward.z, 0, forward.x);
 
-    const forwardInput = (keys.has('w') || keys.has('arrowup') ? 1 : 0)
+    const keyboardForward = (keys.has('w') || keys.has('arrowup') ? 1 : 0)
       - (keys.has('s') || keys.has('arrowdown') ? 1 : 0);
-    const strafeInput = (keys.has('d') || keys.has('arrowright') ? 1 : 0)
+    const keyboardStrafe = (keys.has('d') || keys.has('arrowright') ? 1 : 0)
       - (keys.has('a') || keys.has('arrowleft') ? 1 : 0);
+    const forwardInput = THREE.MathUtils.clamp(keyboardForward - (mobileInput?.moveY || 0), -1, 1);
+    const strafeInput = THREE.MathUtils.clamp(keyboardStrafe + (mobileInput?.moveX || 0), -1, 1);
     const moveDir = _moveDir.set(0, 0, 0)
       .addScaledVector(forward, forwardInput)
       .addScaledVector(right, strafeInput);
@@ -267,7 +296,7 @@ export default function PlayerController({
       rig.vy = 0;
       dy = flyDir * verticalSpeed;
     } else {
-      if (keys.has(' ') && grounded && !rig.jumping) { rig.vy = JUMP_SPEED; rig.jumping = true; } // launch
+      if ((keys.has(' ') || mobileInput?.jump) && grounded && !rig.jumping) { rig.vy = JUMP_SPEED; rig.jumping = true; } // launch
       if (rig.jumping) {
         rig.vy += GRAVITY * delta; // gravity through the arc
         dy = rig.vy * delta;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1279,6 +1279,173 @@ html[data-port-theme] .openworld-themed [class~="hover:bg-cyan-500/5"]:hover { b
   .openworld-hud-action { min-height: 2.75rem; min-width: 2.75rem; }
 }
 
+/* === OpenWorld mobile game controls ===
+   The compact HUD owns information and navigation panels. These controls own the
+   game loop, so a phone can drive, look, jump, interact, and exit without a keyboard. */
+.openworld-mobile-controls {
+  isolation: isolate;
+  user-select: none;
+}
+
+.openworld-mobile-look-zone {
+  position: absolute;
+  right: 0.4rem;
+  bottom: calc(6.3rem + env(safe-area-inset-bottom));
+  width: 48%;
+  height: 46%;
+  pointer-events: auto;
+  touch-action: none;
+}
+
+.openworld-mobile-look-hint {
+  position: absolute;
+  top: 50%;
+  right: 1.25rem;
+  color: var(--ow-muted);
+  font-family: var(--font-pixel, monospace);
+  font-size: 0.5rem;
+  letter-spacing: 0.16em;
+  opacity: 0;
+  transform: translateY(-50%);
+  transition: opacity 160ms ease;
+}
+
+.openworld-mobile-look-zone:active .openworld-mobile-look-hint,
+.openworld-mobile-look-zone:focus-visible .openworld-mobile-look-hint {
+  opacity: 0.7;
+}
+
+.openworld-mobile-joystick {
+  position: absolute;
+  left: 1rem;
+  bottom: calc(5.8rem + env(safe-area-inset-bottom));
+  width: 7rem;
+  height: 7rem;
+  border: 1px solid rgb(var(--port-accent) / 0.34);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgb(var(--port-accent) / 0.14), rgb(var(--port-bg) / 0.42));
+  box-shadow: 0 12px 30px rgb(0 0 0 / 0.2), inset 0 1px 0 rgb(255 255 255 / 0.08);
+  backdrop-filter: blur(12px) saturate(1.08);
+  pointer-events: auto;
+  touch-action: none;
+}
+
+.openworld-mobile-joystick::before,
+.openworld-mobile-joystick::after {
+  position: absolute;
+  content: '';
+  background: rgb(var(--port-accent) / 0.16);
+}
+
+.openworld-mobile-joystick::before {
+  top: 50%;
+  left: 1rem;
+  right: 1rem;
+  height: 1px;
+}
+
+.openworld-mobile-joystick::after {
+  top: 1rem;
+  bottom: 1rem;
+  left: 50%;
+  width: 1px;
+}
+
+.openworld-mobile-joystick-knob {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 3rem;
+  height: 3rem;
+  border: 1px solid rgb(var(--port-accent) / 0.6);
+  border-radius: 50%;
+  background: linear-gradient(145deg, rgb(var(--port-accent) / 0.32), rgb(var(--port-bg) / 0.62));
+  box-shadow: 0 0 18px rgb(var(--port-accent) / 0.16), inset 0 1px 0 rgb(255 255 255 / 0.12);
+  transition: transform 80ms ease-out;
+  z-index: 1;
+}
+
+.openworld-mobile-joystick-label {
+  position: absolute;
+  right: 0;
+  bottom: 0.95rem;
+  left: 0;
+  color: var(--ow-muted);
+  font-family: var(--font-pixel, monospace);
+  font-size: 0.48rem;
+  letter-spacing: 0.16em;
+  text-align: center;
+  pointer-events: none;
+}
+
+.openworld-mobile-actions {
+  position: absolute;
+  right: 0.5rem;
+  bottom: calc(5.8rem + env(safe-area-inset-bottom));
+  display: flex;
+  align-items: flex-end;
+  gap: 0.2rem;
+  max-width: calc(100vw - 8.75rem);
+  overflow: visible;
+  padding: 0.2rem;
+  scrollbar-width: none;
+}
+
+.openworld-mobile-actions::-webkit-scrollbar {
+  display: none;
+}
+
+.openworld-mobile-action {
+  display: inline-flex;
+  flex: 0 0 auto;
+  width: 2.65rem;
+  height: 3.05rem;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.15rem;
+  border: 1px solid rgb(var(--port-accent) / 0.38);
+  border-radius: 1rem;
+  background: var(--ow-panel-soft);
+  color: var(--ow-ink);
+  font-family: var(--font-pixel, monospace);
+  font-size: 0.46rem;
+  letter-spacing: 0.1em;
+  line-height: 1;
+  box-shadow: 0 12px 28px rgb(0 0 0 / 0.18), inset 0 1px 0 rgb(255 255 255 / 0.08);
+  backdrop-filter: blur(16px) saturate(1.08);
+  touch-action: none;
+}
+
+.openworld-mobile-action:active,
+.openworld-mobile-action:focus-visible {
+  border-color: rgb(var(--port-accent) / 0.78);
+  background: rgb(var(--port-accent) / 0.2);
+  color: var(--ow-accent);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.openworld-mobile-action small {
+  color: var(--ow-muted);
+  font-size: 0.4rem;
+  letter-spacing: 0.08em;
+}
+
+.openworld-mobile-action--wide {
+  width: 3.4rem;
+  border-color: rgb(var(--port-accent) / 0.54);
+  background: linear-gradient(145deg, rgb(var(--port-accent) / 0.2), var(--ow-panel-soft));
+}
+
+.openworld-mobile-action--exit {
+  color: var(--ow-muted);
+}
+
+@media (min-width: 768px) {
+  .openworld-mobile-controls { display: none; }
+}
+
 /* === Lumen Glass Day === */
 /* Same card set as the base elevation rule above — every fill opacity, not just
    `/50` — so this theme's softened border lands on all of its cards. */

--- a/client/src/pages/OpenWorld.jsx
+++ b/client/src/pages/OpenWorld.jsx
@@ -10,6 +10,7 @@ import { mergeFrameIntoOpenWorldProps } from '../lib/openWorldPlaybackFrame';
 import * as api from '../services/api';
 import OpenWorldScene from '../components/openworld/OpenWorldScene';
 import OpenWorldHud from '../components/openworld/OpenWorldHud';
+import OpenWorldMobileControls from '../components/openworld/OpenWorldMobileControls';
 import OpenWorldScanlines from '../components/openworld/OpenWorldScanlines';
 import OpenWorldPhotoOverlay from '../components/openworld/OpenWorldPhotoOverlay';
 import OpenWorldPlaybackOverlay from '../components/openworld/OpenWorldPlaybackOverlay';
@@ -175,6 +176,15 @@ function OpenWorldInner() {
   }, [updateSetting, settings?.cameraView]);
 
   const keysRef = useKeyboardControls(handleToggleExploration);
+  const mobileInputRef = useRef({
+    moveX: 0,
+    moveY: 0,
+    lookDeltaX: 0,
+    lookDeltaY: 0,
+    boost: false,
+    jump: false,
+  });
+  const playerActionRef = useRef(null);
 
   // --- World map / fast travel ----------------------------------------------
   // Warping stays under `/openworld/region/:regionId`; the route param drives the orbital
@@ -528,6 +538,8 @@ function OpenWorldInner() {
         settings={sceneSettings}
         playSfx={playSfx}
         keysRef={keysRef}
+        mobileInputRef={mobileInputRef}
+        playerActionRef={playerActionRef}
         dimmedAppIds={filterResult.dimmed}
         autoQuality={qualityMode === 'auto'}
         autoStartTier="high"
@@ -576,6 +588,14 @@ function OpenWorldInner() {
           onOpenDestination={handleTravelToRegionId}
           onAttentionItem={handleAttentionItem}
           activeRegion={focusedRegion}
+        />
+      )}
+      {!photoMode && !playback.active && !isDesktop && settings?.explorationMode && !showSettings && !fastTravelOpen && (
+        <OpenWorldMobileControls
+          mobileInputRef={mobileInputRef}
+          playerActionRef={playerActionRef}
+          onToggleCameraView={handleToggleCameraView}
+          onToggleExploration={handleToggleExploration}
         />
       )}
       <OpenWorldPhotoOverlay


### PR DESCRIPTION
## Summary
- add a mobile game-control layer with a virtual drive stick and drag-to-look input
- add boost, jump, interact, camera, and exit actions wired into the existing player rig
- hide the desktop keyboard-only launch hint on mobile and keep the compact HUD for navigation
- add focused interaction and cleanup coverage for the touch controls

## Test plan
- `npm test -- --run src/components/openworld/OpenWorldMobileControls.test.jsx src/components/openworld/OpenWorldHudCompact.test.jsx`
- `npm run lint`
- `npm run build`
- visually verified the 390px mobile viewport with all five actions visible above the dock

The mobile interaction model follows the reference game's explicit input/player loop while preserving the existing desktop controls.