### PR TITLE
fix: recover OpenWorld mobile startup

### DIFF
--- a/client/src/components/openworld/CameraTransition.jsx
+++ b/client/src/components/openworld/CameraTransition.jsx
@@ -12,8 +12,12 @@ export default function CameraTransition({ active, targetPos, targetLookAt, onTr
   const progressRef = useRef(0);
   const startPosRef = useRef(new THREE.Vector3());
   const startTargetRef = useRef(new THREE.Vector3());
-  const wasActiveRef = useRef(false);
-  const completedRef = useRef(false);
+  // The player controller already owns the initial exploration camera. Starting a
+  // transition from the Canvas' orbital camera makes the world visibly sweep past
+  // the player on load, and on a phone that can leave the first frame aimed at the
+  // sky. Only animate when the user actually changes modes after mount.
+  const wasActiveRef = useRef(active);
+  const completedRef = useRef(true);
 
   useFrame((_, delta) => {
     // Detect transition start

--- a/client/src/components/openworld/OpenWorldScene.jsx
+++ b/client/src/components/openworld/OpenWorldScene.jsx
@@ -63,6 +63,8 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
   const [proximityApp, setProximityApp] = useState(null);
   const [transitioning, setTransitioning] = useState(false);
   const [webglLost, setWebglLost] = useState(false);
+  const [canvasRevision, setCanvasRevision] = useState(0);
+  const [contextRecoveryMode, setContextRecoveryMode] = useState(false);
   const [startupSettled, setStartupSettled] = useState(false);
   // Visibility-aware frameloop (issue #2592): pause the live OpenWorld render loop while the
   // tab is hidden, resume (with a fresh warm-up) when it's shown again. `resumeToken`
@@ -80,11 +82,12 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
     setDocumentHidden(hidden);
     if (!hidden) setResumeToken(t => t + 1);
   }, []));
-  const prevExplorationRef = useRef(false);
+  const prevExplorationRef = useRef(null);
   const orbitRef = useRef(null);
   const contextCleanupRef = useRef(null);
   const contextLostTimerRef = useRef(null);
   const activeCanvasRef = useRef(null);
+  const contextRecoveryRef = useRef(0);
   // Shared between OpenWorldDepthOfField (which owns the EffectComposer while photo mode is on) and
   // OpenWorldPhotoCamera (whose capture path renders through that composer so the postcard matches the
   // DoF preview). Null whenever DoF isn't mounted — capture then falls back to a plain render.
@@ -113,7 +116,7 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
   }, [apps.length, photoMode, resumeToken]);
 
   const renderSettings = useMemo(() => {
-    if (photoMode || startupSettled) return settings;
+    if (!contextRecoveryMode && (photoMode || startupSettled)) return settings;
     // During the startup (and post-visibility-resume) warm-up, drop to the cheapest
     // render path. `effectiveTier: 'low'` also suppresses set dressing + the ray-marched
     // interior-window shader via openWorldShowDetail/openWorldShowInteriorWindows — previously the
@@ -122,10 +125,10 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
       ...settings,
       effectiveTier: 'low',
       reflectionsEnabled: false,
-      particleDensity: Math.min(settings?.particleDensity ?? 1, STARTUP_PARTICLE_DENSITY),
+      particleDensity: Math.min(settings?.particleDensity ?? 1, contextRecoveryMode ? 0.25 : STARTUP_PARTICLE_DENSITY),
       dpr: [1, 1],
     };
-  }, [photoMode, settings, startupSettled]);
+  }, [contextRecoveryMode, photoMode, settings, startupSettled]);
 
   const clearContextTimer = useCallback(() => {
     if (contextLostTimerRef.current) {
@@ -150,8 +153,14 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
     contextCleanupRef.current?.();
   }, [clearContextTimer]);
 
-  // Set transitioning=true when exploration mode toggles
+  // Set transitioning=true when exploration mode toggles. The initial mount is
+  // already in the requested mode; starting a transition there briefly hands the
+  // camera to the orbital framing before the player rig takes over.
   useEffect(() => {
+    if (prevExplorationRef.current === null) {
+      prevExplorationRef.current = explorationMode;
+      return;
+    }
     if (prevExplorationRef.current !== explorationMode) {
       setTransitioning(true);
       prevExplorationRef.current = explorationMode;
@@ -205,7 +214,18 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
         if (activeCanvasRef.current !== canvas || !canvas.isConnected) return;
         const context = gl.getContext?.();
         if (context?.isContextLost?.()) {
-          setWebglLost(true);
+          // A transient mobile GPU reset can recover if the renderer is recreated
+          // at the cheap tier. Give it one bounded retry instead of leaving the
+          // player with an invisible Canvas forever. If the replacement also loses
+          // its context, keep the fallback visible and stop retrying.
+          if (contextRecoveryRef.current < 1) {
+            contextRecoveryRef.current += 1;
+            setContextRecoveryMode(true);
+            setWebglLost(false);
+            setCanvasRevision(revision => revision + 1);
+          } else {
+            setWebglLost(true);
+          }
         }
       }, 750);
     };
@@ -229,7 +249,7 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
   return (
     <div className="absolute inset-0" style={{ background: fallbackBackground }}>
       <Canvas
-        key={photoMode ? 'photo' : 'live'}
+        key={`${photoMode ? 'photo' : 'live'}-${canvasRevision}`}
         camera={{ position: [0, 25, 45], fov: 50 }}
         dpr={dpr}
         shadows={false}
@@ -245,7 +265,7 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
         // preserveDrawingBuffer is only needed while taking postcards. Keeping it
         // always-on makes Chromium's WebGL context much easier to lose in the live
         // dashboard, which reads as a blank white scene.
-        gl={{ antialias: true, preserveDrawingBuffer: Boolean(photoMode), alpha: false, powerPreference: 'high-performance' }}
+        gl={{ antialias: !contextRecoveryMode, preserveDrawingBuffer: Boolean(photoMode), alpha: false, powerPreference: contextRecoveryMode ? 'default' : 'high-performance' }}
       >
       {/* Re-provide the themed palette INSIDE the Canvas — react-three-fiber runs its
           own reconciler, so the provider in OpenWorldInner doesn't reach these scene

--- a/client/src/components/openworld/PlayerController.jsx
+++ b/client/src/components/openworld/PlayerController.jsx
@@ -20,6 +20,7 @@ const PROXIMITY_DISTANCE = 6;
 const MAX_CAMERA_HEIGHT = 160;
 const BUILDING_FLYOVER_HEIGHT = 12; // above this the player clears rooftops, so skip collision
 const AIRBORNE_HEIGHT = EYE_HEIGHT + 0.6; // above this the avatar reads as flying (hover state)
+const DEFAULT_SPAWN_Z = 36; // clear the central AI Core when an install has few/no app buildings
 const MOUSE_SENSITIVITY = 0.002;
 const PITCH_LIMIT = Math.PI / 2 - 0.02;
 
@@ -99,7 +100,11 @@ export default function PlayerController({
       positions?.forEach((pos) => {
         if (pos.z > maxZ) maxZ = pos.z;
       });
-      rig.position.set(0, EYE_HEIGHT, maxZ + 8);
+      // With an empty or single-app install, `maxZ + 8` places the rover inside the
+      // central plaza's sightline and the AI Core fills the entire mobile viewport.
+      // Keep the same north-facing drop-in, but start far enough back to reveal the
+      // playable streets and landmarks before the player drives toward downtown.
+      rig.position.set(0, EYE_HEIGHT, Math.max(maxZ + 8, DEFAULT_SPAWN_Z));
       rig.yaw = 0; // Forward = (0, 0, -1), facing toward city center
       rig.pitch = 0;
       rig.facing = 0;


### PR DESCRIPTION
## Summary
- recover the OpenWorld canvas once after a persistent WebGL context loss, using a low-cost renderer configuration instead of leaving the game hidden behind the sky fallback
- skip the initial orbital camera sweep so the player rig owns the first exploration frame
- place empty and small installs farther back from the central AI Core for a readable mobile drop-in

## Test plan
- `cd client && npm test -- --run`
- `cd client && npm run lint`
- `cd client && npm run build`
- visually verified the rendered world and camera action at a 390x844 viewport
