### PR TITLE
fix: llama.cpp installs from the UI no longer report a working binary as missing

### DIFF
--- a/server/services/llamaServerManager.js
+++ b/server/services/llamaServerManager.js
@@ -264,7 +264,11 @@ function linkLlamaCpp(env) {
     child.stdout?.on('data', collect);
     child.stderr?.on('data', collect);
     child.on('error', (err) => resolve({ linked: false, output: err.message }));
-    child.on('exit', (code) => resolve({ linked: code === 0, output: output.trim() }));
+    // 'close' rather than 'exit': 'exit' fires the moment the process ends, with
+    // stdio possibly still buffered, which would hand back a truncated (often
+    // empty) `output` exactly when a failure needs explaining. `brew link` is a
+    // short, single-process command, so waiting for the pipes to close is safe.
+    child.on('close', (code) => resolve({ linked: code === 0, output: output.trim() }));
   });
 }
 
@@ -297,7 +301,15 @@ export async function installLlamaServer({ onProgress = () => {} } = {}) {
     child.stderr?.on('data', (d) => {
       onProgress({ event: 'progress', message: d.toString().trim() });
     });
+    // `error` and `exit` can both fire for one child (an `error` raised after a
+    // successful spawn is followed by the process's own exit). Without this
+    // guard the exit path would still emit a `complete` progress event to the
+    // UI after the request had already been rejected — the client would render
+    // "installed successfully" alongside a 500.
+    let settled = false;
     child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
       reject(new ServerError(`Failed to run brew: ${err.message}`, { status: 500 }));
     });
     // Async listener on a child-process event: it runs outside the Express
@@ -305,6 +317,8 @@ export async function installLlamaServer({ onProgress = () => {} } = {}) {
     // unguarded throw here would surface as an unhandled rejection while the
     // install request hung forever. Route every failure to `reject`.
     child.on('exit', async (code) => {
+      if (settled) return;
+      settled = true;
       try {
         let binaryPath = resolveLlamaServerBinary();
         let linkOutput = '';

--- a/server/services/llamaServerManager.js
+++ b/server/services/llamaServerManager.js
@@ -47,11 +47,30 @@ async function probeEndpoint(endpoint) {
 }
 
 /**
+ * Resolves the `llama-server` executable on the child-process PATH.
+ *
+ * Deliberately a filesystem probe only — `findCommandOnPath` already requires a
+ * regular file carrying the execute bit, which is all "is it installed?" means.
+ * Do NOT re-add a `commandExists`-style `llama-server --version` probe on top:
+ * llama.cpp registers its ggml backends (Metal included) at process start, so
+ * the first launch after `brew link` — a cold binary, a loaded machine — blows
+ * past `commandExists`'s 5s bound. That made the probe report "not installed"
+ * for an installed, working binary, and because the timeout killed the process
+ * before it finished warming, every retry from the UI failed the same way:
+ * "brew completed but llama-server was not found on PATH".
+ *
+ * @returns {string|null} absolute path, or null when it is not on PATH
+ */
+function resolveLlamaServerBinary() {
+  return findCommandOnPath('llama-server');
+}
+
+/**
  * Returns current status of llama-server (binary availability, running state, config, logs).
  */
 export async function getLlamaServerStatus() {
-  const binaryPath = await findCommandOnPath('llama-server');
-  const installed = Boolean(binaryPath) && await commandExists(binaryPath);
+  const binaryPath = resolveLlamaServerBinary();
+  const installed = Boolean(binaryPath);
 
   const host = currentConfig?.host || '127.0.0.1';
   const port = currentConfig?.port || 8080;
@@ -78,8 +97,8 @@ export async function getLlamaServerStatus() {
  * Starts llama-server with the specified model and options.
  */
 export async function startLlamaServer(options = {}) {
-  const binaryPath = await findCommandOnPath('llama-server');
-  if (!binaryPath || !(await commandExists(binaryPath))) {
+  const binaryPath = resolveLlamaServerBinary();
+  if (!binaryPath) {
     throw new ServerError(
       'llama-server binary was not found on PATH. Install it via Homebrew (`brew install llama.cpp`) or build from source.',
       { status: 400 }
@@ -226,16 +245,26 @@ export async function stopLlamaServer() {
 }
 
 /**
- * Runs `brew link --overwrite llama.cpp`, resolving true/false on exit
+ * Runs `brew link --overwrite llama.cpp`, resolving `{ linked, output }` on exit
  * rather than rejecting — a failed link attempt should fall through to the
- * caller's own error message, not replace it with a `brew link` failure.
+ * caller's own error message, not replace it with a `brew link` failure. The
+ * captured output is what makes a failure diagnosable ("Could not symlink…",
+ * a permissions error on the prefix); discarding it left the caller guessing.
  */
 function linkLlamaCpp(env) {
   return new Promise((resolve) => {
-    const spawnOpts = safeChildProcessOptions({ env, shell: false, stdio: 'ignore' });
+    const spawnOpts = safeChildProcessOptions({
+      env,
+      shell: false,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
     const child = spawn('brew', ['link', '--overwrite', 'llama.cpp'], spawnOpts);
-    child.on('error', () => resolve(false));
-    child.on('exit', (code) => resolve(code === 0));
+    let output = '';
+    const collect = (chunk) => { output += chunk.toString(); };
+    child.stdout?.on('data', collect);
+    child.stderr?.on('data', collect);
+    child.on('error', (err) => resolve({ linked: false, output: err.message }));
+    child.on('exit', (code) => resolve({ linked: code === 0, output: output.trim() }));
   });
 }
 
@@ -272,28 +301,31 @@ export async function installLlamaServer({ onProgress = () => {} } = {}) {
       reject(new ServerError(`Failed to run brew: ${err.message}`, { status: 500 }));
     });
     child.on('exit', async (code) => {
-      let binaryPath = await findCommandOnPath('llama-server');
-      let installed = Boolean(binaryPath) && await commandExists(binaryPath);
+      let binaryPath = resolveLlamaServerBinary();
+      let linkOutput = '';
 
       // `brew install` exits 0 without linking when the keg is already
       // installed but unlinked ("Warning: llama.cpp X is already installed,
       // it's just not linked."). Link it explicitly rather than leaving that
       // warning as a dead end for the caller.
-      if (!installed && code === 0) {
+      if (!binaryPath && code === 0) {
         onProgress({ event: 'progress', message: 'llama.cpp keg is installed but not linked — linking…' });
-        const linked = await linkLlamaCpp(env);
-        if (linked) {
-          binaryPath = await findCommandOnPath('llama-server');
-          installed = Boolean(binaryPath) && await commandExists(binaryPath);
-        }
+        const { linked, output } = await linkLlamaCpp(env);
+        linkOutput = output;
+        if (linked) binaryPath = resolveLlamaServerBinary();
       }
 
-      if (installed) {
-        onProgress({ event: 'complete', message: 'llama.cpp installed successfully' });
-        resolve({ success: true, message: 'llama.cpp installed successfully' });
+      if (binaryPath) {
+        onProgress({ event: 'complete', message: `llama.cpp installed successfully (${binaryPath})` });
+        resolve({ success: true, message: 'llama.cpp installed successfully', binaryPath });
       } else {
+        // A `brew link` conflict can list every clashing file, so cap what
+        // rides along into the error message.
+        const hint = linkOutput
+          ? `brew link said: ${linkOutput.slice(0, 500)}`
+          : 'try running `brew link --overwrite llama.cpp` manually';
         const msg = code === 0
-          ? 'brew completed but llama-server was not found on PATH — try running `brew link --overwrite llama.cpp` manually'
+          ? `brew completed but llama-server was not found on PATH — ${hint}`
           : `brew install llama.cpp failed (exit code ${code})`;
         reject(new ServerError(msg, { status: 500 }));
       }

--- a/server/services/llamaServerManager.js
+++ b/server/services/llamaServerManager.js
@@ -300,25 +300,32 @@ export async function installLlamaServer({ onProgress = () => {} } = {}) {
     child.on('error', (err) => {
       reject(new ServerError(`Failed to run brew: ${err.message}`, { status: 500 }));
     });
+    // Async listener on a child-process event: it runs outside the Express
+    // lifecycle AND outside this Promise executor's own throw path, so an
+    // unguarded throw here would surface as an unhandled rejection while the
+    // install request hung forever. Route every failure to `reject`.
     child.on('exit', async (code) => {
-      let binaryPath = resolveLlamaServerBinary();
-      let linkOutput = '';
+      try {
+        let binaryPath = resolveLlamaServerBinary();
+        let linkOutput = '';
 
-      // `brew install` exits 0 without linking when the keg is already
-      // installed but unlinked ("Warning: llama.cpp X is already installed,
-      // it's just not linked."). Link it explicitly rather than leaving that
-      // warning as a dead end for the caller.
-      if (!binaryPath && code === 0) {
-        onProgress({ event: 'progress', message: 'llama.cpp keg is installed but not linked — linking…' });
-        const { linked, output } = await linkLlamaCpp(env);
-        linkOutput = output;
-        if (linked) binaryPath = resolveLlamaServerBinary();
-      }
+        // `brew install` exits 0 without linking when the keg is already
+        // installed but unlinked ("Warning: llama.cpp X is already installed,
+        // it's just not linked."). Link it explicitly rather than leaving that
+        // warning as a dead end for the caller.
+        if (!binaryPath && code === 0) {
+          onProgress({ event: 'progress', message: 'llama.cpp keg is installed but not linked — linking…' });
+          const { linked, output } = await linkLlamaCpp(env);
+          linkOutput = output;
+          if (linked) binaryPath = resolveLlamaServerBinary();
+        }
 
-      if (binaryPath) {
-        onProgress({ event: 'complete', message: `llama.cpp installed successfully (${binaryPath})` });
-        resolve({ success: true, message: 'llama.cpp installed successfully', binaryPath });
-      } else {
+        if (binaryPath) {
+          onProgress({ event: 'complete', message: `llama.cpp installed successfully (${binaryPath})` });
+          resolve({ success: true, message: 'llama.cpp installed successfully' });
+          return;
+        }
+
         // A `brew link` conflict can list every clashing file, so cap what
         // rides along into the error message.
         const hint = linkOutput
@@ -328,6 +335,8 @@ export async function installLlamaServer({ onProgress = () => {} } = {}) {
           ? `brew completed but llama-server was not found on PATH — ${hint}`
           : `brew install llama.cpp failed (exit code ${code})`;
         reject(new ServerError(msg, { status: 500 }));
+      } catch (err) {
+        reject(new ServerError(`Failed to verify the llama.cpp install: ${err.message}`, { status: 500 }));
       }
     });
   });

--- a/server/services/llamaServerManager.test.js
+++ b/server/services/llamaServerManager.test.js
@@ -30,7 +30,7 @@ describe('llamaServerManager', () => {
   });
 
   it('reports installed: false when binary is not found on PATH', async () => {
-    vi.spyOn(processEnv, 'findCommandOnPath').mockResolvedValue(null);
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(null);
 
     const status = await getLlamaServerStatus();
     expect(status.installed).toBe(false);
@@ -39,15 +39,20 @@ describe('llamaServerManager', () => {
   });
 
   it('reports installed: true when binary is found on PATH', async () => {
-    vi.spyOn(processEnv, 'findCommandOnPath').mockResolvedValue('/opt/homebrew/bin/llama-server');
-    vi.spyOn(commandExistsModule, 'commandExists').mockResolvedValue(true);
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/opt/homebrew/bin/llama-server');
+    const execProbe = vi.spyOn(commandExistsModule, 'commandExists').mockResolvedValue(true);
 
     const status = await getLlamaServerStatus();
     expect(status.installed).toBe(true);
+    // Regression: the binary must never be executed to answer
+    // "installed?". llama.cpp initializes its ggml/Metal backends at launch, so
+    // a cold run right after `brew link` blew past commandExists' 5s bound and
+    // reported an installed, working binary as missing.
+    expect(execProbe).not.toHaveBeenCalled();
   });
 
   it('rejects start when binary is missing', async () => {
-    vi.spyOn(processEnv, 'findCommandOnPath').mockResolvedValue(null);
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(null);
 
     await expect(startLlamaServer({ model: '/path/to/model.gguf' })).rejects.toThrow(
       /llama-server binary was not found/i
@@ -55,8 +60,7 @@ describe('llamaServerManager', () => {
   });
 
   it('spawns llama-server with draftModel and specType arguments', async () => {
-    vi.spyOn(processEnv, 'findCommandOnPath').mockResolvedValue('/usr/local/bin/llama-server');
-    vi.spyOn(commandExistsModule, 'commandExists').mockResolvedValue(true);
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/usr/local/bin/llama-server');
 
     const fakeChild = new EventEmitter();
     fakeChild.pid = 12345;
@@ -101,8 +105,7 @@ describe('llamaServerManager', () => {
   });
 
   it('stops managed process cleanly', async () => {
-    vi.spyOn(processEnv, 'findCommandOnPath').mockResolvedValue('/usr/local/bin/llama-server');
-    vi.spyOn(commandExistsModule, 'commandExists').mockResolvedValue(true);
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/usr/local/bin/llama-server');
 
     const fakeChild = new EventEmitter();
     fakeChild.pid = 54321;
@@ -124,7 +127,7 @@ describe('llamaServerManager', () => {
 
   it('installs llama.cpp via Homebrew when brew is available', async () => {
     vi.spyOn(commandExistsModule, 'commandExists').mockImplementation(async (cmd) => true);
-    vi.spyOn(processEnv, 'findCommandOnPath').mockResolvedValue('/opt/homebrew/bin/llama-server');
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue('/opt/homebrew/bin/llama-server');
 
     const fakeChild = new EventEmitter();
     fakeChild.stdout = new EventEmitter();
@@ -148,7 +151,7 @@ describe('llamaServerManager', () => {
   it('links an already-installed-but-unlinked keg after `brew install` exits 0', async () => {
     // brew is present; llama-server is NOT on PATH until after the link step.
     vi.spyOn(commandExistsModule, 'commandExists').mockImplementation(async (cmd) => cmd === 'brew');
-    const findSpy = vi.spyOn(processEnv, 'findCommandOnPath').mockResolvedValue(null);
+    const findSpy = vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(null);
 
     const installChild = fakeSpawnProcess();
     const linkChild = fakeSpawnProcess();
@@ -164,8 +167,7 @@ describe('llamaServerManager', () => {
 
     // Once `brew link` resolves, the binary shows up on PATH.
     setTimeout(() => {
-      findSpy.mockResolvedValue('/opt/homebrew/bin/llama-server');
-      commandExistsModule.commandExists.mockImplementation(async () => true);
+      findSpy.mockReturnValue('/opt/homebrew/bin/llama-server');
     }, 15);
 
     const result = await resultPromise;
@@ -176,9 +178,29 @@ describe('llamaServerManager', () => {
     ]);
   });
 
+  it('surfaces brew link output when the link step fails', async () => {
+    vi.spyOn(commandExistsModule, 'commandExists').mockImplementation(async (cmd) => cmd === 'brew');
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(null);
+
+    vi.spyOn(childProcess, 'spawn').mockImplementation((cmd, args) => {
+      const child = fakeSpawnProcess();
+      setTimeout(() => {
+        if (args[0] === 'link') {
+          child.stderr.emit('data', Buffer.from('Error: Could not symlink bin/llama-server'));
+          child.emit('exit', 1);
+        } else {
+          child.emit('exit', 0);
+        }
+      }, 10);
+      return child;
+    });
+
+    await expect(installLlamaServer()).rejects.toThrow(/Could not symlink bin\/llama-server/);
+  });
+
   it('rejects with a `brew link` hint when linking does not resolve the binary', async () => {
     vi.spyOn(commandExistsModule, 'commandExists').mockImplementation(async (cmd) => cmd === 'brew');
-    vi.spyOn(processEnv, 'findCommandOnPath').mockResolvedValue(null);
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(null);
 
     vi.spyOn(childProcess, 'spawn').mockImplementation(() => {
       const child = fakeSpawnProcess();

--- a/server/services/llamaServerManager.test.js
+++ b/server/services/llamaServerManager.test.js
@@ -18,6 +18,14 @@ function fakeSpawnProcess() {
   return child;
 }
 
+// A real child emits 'exit' and then 'close' (once stdio has flushed). Mirror
+// both so the mocks stay honest for either listener: `brew install` is awaited
+// on 'exit', while the `brew link` step waits for 'close' to capture output.
+function endProcess(child, code) {
+  child.emit('exit', code);
+  child.emit('close', code);
+}
+
 describe('llamaServerManager', () => {
   beforeEach(() => {
     _resetLlamaServerStateForTests();
@@ -134,7 +142,7 @@ describe('llamaServerManager', () => {
     fakeChild.stderr = new EventEmitter();
 
     vi.spyOn(childProcess, 'spawn').mockImplementation(() => {
-      setTimeout(() => fakeChild.emit('exit', 0), 10);
+      setTimeout(() => endProcess(fakeChild, 0), 10);
       return fakeChild;
     });
 
@@ -159,7 +167,7 @@ describe('llamaServerManager', () => {
     vi.spyOn(childProcess, 'spawn').mockImplementation((cmd, args) => {
       spawnCalls.push({ cmd, args });
       const child = args[0] === 'install' ? installChild : linkChild;
-      setTimeout(() => child.emit('exit', 0), 10);
+      setTimeout(() => endProcess(child, 0), 10);
       return child;
     });
 
@@ -187,9 +195,9 @@ describe('llamaServerManager', () => {
       setTimeout(() => {
         if (args[0] === 'link') {
           child.stderr.emit('data', Buffer.from('Error: Could not symlink bin/llama-server'));
-          child.emit('exit', 1);
+          endProcess(child, 1);
         } else {
-          child.emit('exit', 0);
+          endProcess(child, 0);
         }
       }, 10);
       return child;
@@ -208,7 +216,7 @@ describe('llamaServerManager', () => {
     vi.spyOn(childProcess, 'spawn').mockImplementation((cmd, args) => {
       if (args[0] === 'link') throw new Error('spawn EACCES');
       const child = fakeSpawnProcess();
-      setTimeout(() => child.emit('exit', 0), 10);
+      setTimeout(() => endProcess(child, 0), 10);
       return child;
     });
 
@@ -221,7 +229,7 @@ describe('llamaServerManager', () => {
 
     vi.spyOn(childProcess, 'spawn').mockImplementation(() => {
       const child = fakeSpawnProcess();
-      setTimeout(() => child.emit('exit', 0), 10);
+      setTimeout(() => endProcess(child, 0), 10);
       return child;
     });
 

--- a/server/services/llamaServerManager.test.js
+++ b/server/services/llamaServerManager.test.js
@@ -198,6 +198,23 @@ describe('llamaServerManager', () => {
     await expect(installLlamaServer()).rejects.toThrow(/Could not symlink bin\/llama-server/);
   });
 
+  it('rejects instead of hanging when the link spawn throws synchronously', async () => {
+    // The exit listener is async and lives inside a Promise executor, so an
+    // unguarded throw would escape as an unhandled rejection while the install
+    // request never settled.
+    vi.spyOn(commandExistsModule, 'commandExists').mockImplementation(async (cmd) => cmd === 'brew');
+    vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(null);
+
+    vi.spyOn(childProcess, 'spawn').mockImplementation((cmd, args) => {
+      if (args[0] === 'link') throw new Error('spawn EACCES');
+      const child = fakeSpawnProcess();
+      setTimeout(() => child.emit('exit', 0), 10);
+      return child;
+    });
+
+    await expect(installLlamaServer()).rejects.toThrow(/Failed to verify the llama\.cpp install: spawn EACCES/);
+  });
+
   it('rejects with a `brew link` hint when linking does not resolve the binary', async () => {
     vi.spyOn(commandExistsModule, 'commandExists').mockImplementation(async (cmd) => cmd === 'brew');
     vi.spyOn(processEnv, 'findCommandOnPath').mockReturnValue(null);


### PR DESCRIPTION
## Summary

Clicking **Install llama.cpp** on the Local LLMs page failed every time with `brew completed but llama-server was not found on PATH`, even once Homebrew had installed and linked the keg and `llama-server --version` ran fine in a shell.

The install and status checks answered *"is it installed?"* by **executing** the binary through `commandExists()`, which bounds the child at 5 seconds. llama.cpp registers its ggml backends (Metal included) at process start, so the first launch after `brew link` — a cold binary on a loaded machine — runs past that bound. The probe timed out, the code concluded the binary was missing, and because the timeout killed the process before it finished warming, **every retry from the UI failed the same way**.

Binary availability is now a filesystem fact: `findCommandOnPath()` already requires a regular file carrying the execute bit, which is all "installed" means. The same fix applies to the status endpoint (which reported an installed server as missing) and to the start guard (which would have refused to launch it).

Also in this change:

- A failed `brew link` now surfaces brew's own output (`Error: Could not symlink…`, a permissions error on the prefix) instead of discarding it and leaving a generic "run it manually" hint. The output is captured on `'close'`, not `'exit'`, so it isn't truncated, and capped at 500 chars since a link conflict can enumerate every clashing file.
- The `'exit'` listener is async and lives inside a `Promise` executor, so a throw from the link step (a synchronous `spawn` failure such as `EACCES`) escaped as an unhandled rejection while the install request never settled. It now routes to `reject`.
- `'error'` and `'exit'` can both fire for one child; a `settled` flag keeps the settle *and* the `complete` progress event to exactly one, so the UI can no longer render "installed successfully" alongside a 500.

## Test plan

- `server/services/llamaServerManager.test.js` — 11 tests, including a regression test asserting the binary is **never executed** to answer "installed?", one for surfacing `brew link` output on failure, and one asserting a synchronously-throwing link `spawn` rejects rather than hanging.
- Full server suite: 30756 passed, 6 skipped.
- Verified end to end against a real Homebrew install: `brew unlink llama.cpp` → status reports `installed: false` → install through the real code path links the keg and reports `installed: true`, with no hang.