### PR TITLE
feat: frame OpenWorld as an isometric rover game

### DIFF
--- a/client/src/components/openworld/CameraTransition.jsx
+++ b/client/src/components/openworld/CameraTransition.jsx
@@ -41,8 +41,11 @@ export default function CameraTransition({ active, targetPos, targetLookAt, onTr
 
     const t = smoothstep(Math.min(progressRef.current, 1));
 
-    const endPos = active ? (targetPos || new THREE.Vector3(0, 2, 15)) : ORBITAL_POS;
-    const endTarget = active ? (targetLookAt || new THREE.Vector3(0, 1.4, 10)) : ORBITAL_TARGET;
+    // Match the elevated diagonal exploration framing while the player rig takes over.
+    // The transition target is only a short hand-off; PlayerController then tracks the
+    // actual rover position and applies the same isometric offset every frame.
+    const endPos = active ? (targetPos || new THREE.Vector3(0, 10, 20)) : ORBITAL_POS;
+    const endTarget = active ? (targetLookAt || new THREE.Vector3(-2, 1.2, 8)) : ORBITAL_TARGET;
 
     camera.position.lerpVectors(startPosRef.current, endPos, t);
 

--- a/client/src/components/openworld/OpenWorldScene.jsx
+++ b/client/src/components/openworld/OpenWorldScene.jsx
@@ -51,6 +51,7 @@ import OpenWorldDepthOfField from './OpenWorldDepthOfField';
 import OpenWorldAdaptiveQuality from './OpenWorldAdaptiveQuality';
 import { openWorldDayMix, getTimeOfDayPreset } from './openWorldConstants';
 import { CITY_MAX_ORBIT_DISTANCE } from '../../utils/openWorldFocusCamera';
+import { THIRD_PERSON } from '../../utils/openWorldPlayerRig';
 import { listRegions } from '../../utils/openWorldRegions';
 import { OpenWorldPaletteProvider } from './OpenWorldPaletteContext';
 import ErrorBoundary from '../ErrorBoundary';
@@ -250,7 +251,7 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
     <div className="absolute inset-0" style={{ background: fallbackBackground }}>
       <Canvas
         key={`${photoMode ? 'photo' : 'live'}-${canvasRevision}`}
-        camera={{ position: [0, 25, 45], fov: 50 }}
+        camera={{ position: [0, 25, 45], fov: THIRD_PERSON.fov }}
         dpr={dpr}
         shadows={false}
         // Photo mode freezes the scene for a clean still (roadmap 3.6): "demand" stops the

--- a/client/src/components/openworld/PlayerController.jsx
+++ b/client/src/components/openworld/PlayerController.jsx
@@ -20,7 +20,7 @@ const PROXIMITY_DISTANCE = 6;
 const MAX_CAMERA_HEIGHT = 160;
 const BUILDING_FLYOVER_HEIGHT = 12; // above this the player clears rooftops, so skip collision
 const AIRBORNE_HEIGHT = EYE_HEIGHT + 0.6; // above this the avatar reads as flying (hover state)
-const DEFAULT_SPAWN_Z = 36; // clear the central AI Core when an install has few/no app buildings
+const DEFAULT_SPAWN_Z = 42; // clear the central AI Core when an install has few/no app buildings
 const MOUSE_SENSITIVITY = 0.002;
 const PITCH_LIMIT = Math.PI / 2 - 0.02;
 
@@ -61,9 +61,9 @@ export default function PlayerController({
   const { camera, gl } = useThree();
   const rigRef = useRef({
     position: new THREE.Vector3(0, EYE_HEIGHT, 0),
-    yaw: 0, // camera heading; forward is (-sin yaw, 0, -cos yaw)
+    yaw: THIRD_PERSON.isometricYaw, // camera heading; forward is (-sin yaw, 0, -cos yaw)
     pitch: 0,
-    facing: 0, // the character's body heading (damped toward movement direction)
+    facing: THIRD_PERSON.isometricYaw, // the character's body heading (damped toward movement direction)
     bank: 0, // lean into turns
     vy: 0, // vertical velocity for the Space jump arc (E/Q free-fly zeroes it)
     jumping: false, // an active Space jump arc — gates gravity so E/Q free-fly holds altitude
@@ -102,12 +102,12 @@ export default function PlayerController({
       });
       // With an empty or single-app install, `maxZ + 8` places the rover inside the
       // central plaza's sightline and the AI Core fills the entire mobile viewport.
-      // Keep the same north-facing drop-in, but start far enough back to reveal the
+      // Keep the same city-facing drop-in, but start far enough back to reveal the
       // playable streets and landmarks before the player drives toward downtown.
       rig.position.set(0, EYE_HEIGHT, Math.max(maxZ + 8, DEFAULT_SPAWN_Z));
-      rig.yaw = 0; // Forward = (0, 0, -1), facing toward city center
+      rig.yaw = THIRD_PERSON.isometricYaw;
       rig.pitch = 0;
-      rig.facing = 0;
+      rig.facing = THIRD_PERSON.isometricYaw;
       lastSpawnRef.current = rig.position.clone();
     }
     lookInitRef.current = false;
@@ -122,11 +122,10 @@ export default function PlayerController({
     if (!active || teleportToken === null || !teleport) return;
     const rig = rigRef.current;
     rig.position.set(teleport.x, EYE_HEIGHT, teleport.z);
-    // Face the destination: the arrival point sits on the +Z side of the district, so
-    // looking down -Z (yaw 0) puts the region in front of the player.
-    rig.yaw = 0;
+    // Face the destination from the same diagonal heading as the default isometric view.
+    rig.yaw = THIRD_PERSON.isometricYaw;
     rig.pitch = 0;
-    rig.facing = 0;
+    rig.facing = THIRD_PERSON.isometricYaw;
     rig.vy = 0;
     rig.jumping = false;
     lastSpawnRef.current = rig.position.clone();
@@ -200,9 +199,9 @@ export default function PlayerController({
         onToggleCameraView?.();
       } else if (key === 'r' && lastSpawnRef.current) {
         rigRef.current.position.copy(lastSpawnRef.current);
-        rigRef.current.yaw = 0;
+        rigRef.current.yaw = THIRD_PERSON.isometricYaw;
         rigRef.current.pitch = 0;
-        rigRef.current.facing = 0;
+        rigRef.current.facing = THIRD_PERSON.isometricYaw;
         rigRef.current.vy = 0;
         rigRef.current.jumping = false;
         lookInitRef.current = false;
@@ -435,7 +434,12 @@ export default function PlayerController({
 
     // Third person: boom behind the camera yaw, shortened when it would clip a building,
     // damped so the camera glides while the aim stays tight.
-    const desired = thirdPersonCamera({ pos: rig.position, yaw: rig.yaw, pitch: rig.pitch });
+    const desired = thirdPersonCamera({
+      pos: rig.position,
+      yaw: rig.yaw,
+      pitch: rig.pitch,
+      pitchOffset: THIRD_PERSON.isometricPitch,
+    });
     const anchor = { x: rig.position.x, y: rig.position.y + THIRD_PERSON.lookHeight, z: rig.position.z };
     const { point: resolvedCam } = resolveBoom({ anchor, camera: desired.camera, buildings: buildingList });
 

--- a/client/src/utils/openWorldPlayerRig.js
+++ b/client/src/utils/openWorldPlayerRig.js
@@ -13,14 +13,17 @@ export const EYE_HEIGHT = 1.6;
 export const BUILDING_COLLISION_RADIUS = 3.5;
 
 export const THIRD_PERSON = {
-  boom: 6.5, // camera distance behind the character
-  shoulder: 0.6, // lateral over-the-shoulder offset (positive = right)
-  height: 2.4, // camera rise above the character's feet at pitch 0
+  boom: 13, // camera distance behind the character
+  shoulder: 0.9, // lateral over-the-shoulder offset (positive = right)
+  height: 3.2, // camera rise above the character's feet at pitch 0
+  isometricYaw: Math.PI / 12, // slight diagonal framing keeps the downtown avenue in view
+  isometricPitch: 0.52, // about 30° above the landscape, keeping landmarks in the frame
+  fov: 38, // tighter perspective keeps the city readable from the elevated angle
   minPitch: -0.45, // looking up from under the character — floor-limited
   maxPitch: 1.15, // looking down over the character
   minCamY: 0.6, // the camera never dips into the pavement
-  lookAhead: 2, // lookAt leads the character so the view reads forward
-  lookHeight: 1.4, // aim at the chest, not the feet
+  lookAhead: 0.8, // keep the rover on-screen while the road opens ahead
+  lookHeight: 0.8, // aim near the rover's roof so it stays clear of the mobile controls
   camDampRate: 8, // camera position smoothing (lower = floatier)
   lookDampRate: 12, // aim smoothing (tighter than position so aim stays crisp)
 };
@@ -30,8 +33,14 @@ export const clampPitch = (pitch) =>
 
 // Desired third-person camera + aim point for a rig pose. Pure — collision is applied
 // separately via resolveBoom so callers can damp toward the resolved point.
-export function thirdPersonCamera({ pos, yaw, pitch, boom = THIRD_PERSON.boom }) {
-  const p = clampPitch(pitch);
+export function thirdPersonCamera({
+  pos,
+  yaw,
+  pitch,
+  boom = THIRD_PERSON.boom,
+  pitchOffset = 0,
+}) {
+  const p = clampPitch(pitch + pitchOffset);
   const back = boom * Math.cos(p);
   const sinYaw = Math.sin(yaw);
   const cosYaw = Math.cos(yaw);

--- a/client/src/utils/openWorldPlayerRig.test.js
+++ b/client/src/utils/openWorldPlayerRig.test.js
@@ -34,6 +34,18 @@ describe('thirdPersonCamera', () => {
     expect(clampPitch(-9)).toBe(THIRD_PERSON.minPitch);
   });
 
+  it('supports a separate isometric tilt without changing the rig pitch', () => {
+    const level = thirdPersonCamera({ pos, yaw: 0, pitch: 0 });
+    const tilted = thirdPersonCamera({
+      pos,
+      yaw: 0,
+      pitch: 0,
+      pitchOffset: THIRD_PERSON.isometricPitch,
+    });
+    expect(tilted.camera.y).toBeGreaterThan(level.camera.y);
+    expect(tilted.camera.z).toBeLessThan(level.camera.z);
+  });
+
   it('never dips the camera into the pavement', () => {
     const { camera } = thirdPersonCamera({ pos: { x: 0, y: 1.6, z: 0 }, yaw: 0, pitch: -0.45 });
     expect(camera.y).toBeGreaterThanOrEqual(THIRD_PERSON.minCamY);


### PR DESCRIPTION
## Summary
- tune the rover follow camera into a deliberate elevated, diagonal landscape view
- keep first-person pitch and mobile look controls independent while framing the rover, streets, and landmarks
- align the Canvas FOV, spawn/reset/teleport heading, and exploration transition with the new view

## Test plan
- `cd client && npm test -- --run src/utils/openWorldPlayerRig.test.js src/components/openworld/OpenWorldMobileControls.test.jsx src/components/openworld/OpenWorldHudCompact.test.jsx`
- `cd client && npm test -- --run`
- `cd client && npm run lint`
- `cd client && npm run build`
- visually verified the local OpenWorld preview at 390x844 and 1280x900, including orbital leave/re-entry