### PR TITLE
feat: polish OpenWorld landscape presentation

### DIFF
--- a/client/src/components/openworld/CameraTransition.jsx
+++ b/client/src/components/openworld/CameraTransition.jsx
@@ -2,9 +2,27 @@ import { useRef } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { smoothstep } from '../../utils/easing';
+import { DEFAULT_SPAWN_Z, EYE_HEIGHT, THIRD_PERSON, thirdPersonCamera } from '../../utils/openWorldPlayerRig';
 
 const ORBITAL_POS = new THREE.Vector3(0, 25, 45);
 const ORBITAL_TARGET = new THREE.Vector3(0, 0, 0);
+const DEFAULT_EXPLORATION_RIG = { x: 0, y: EYE_HEIGHT, z: DEFAULT_SPAWN_Z };
+const DEFAULT_EXPLORATION_FRAME = thirdPersonCamera({
+  pos: DEFAULT_EXPLORATION_RIG,
+  yaw: THIRD_PERSON.isometricYaw,
+  pitch: 0,
+  pitchOffset: THIRD_PERSON.isometricPitch,
+});
+const DEFAULT_EXPLORATION_POS = new THREE.Vector3(
+  DEFAULT_EXPLORATION_FRAME.camera.x,
+  DEFAULT_EXPLORATION_FRAME.camera.y,
+  DEFAULT_EXPLORATION_FRAME.camera.z,
+);
+const DEFAULT_EXPLORATION_TARGET = new THREE.Vector3(
+  DEFAULT_EXPLORATION_FRAME.lookAt.x,
+  DEFAULT_EXPLORATION_FRAME.lookAt.y,
+  DEFAULT_EXPLORATION_FRAME.lookAt.z,
+);
 const DURATION = 0.8;
 
 export default function CameraTransition({ active, targetPos, targetLookAt, onTransitionComplete }) {
@@ -44,8 +62,8 @@ export default function CameraTransition({ active, targetPos, targetLookAt, onTr
     // Match the elevated diagonal exploration framing while the player rig takes over.
     // The transition target is only a short hand-off; PlayerController then tracks the
     // actual rover position and applies the same isometric offset every frame.
-    const endPos = active ? (targetPos || new THREE.Vector3(0, 10, 20)) : ORBITAL_POS;
-    const endTarget = active ? (targetLookAt || new THREE.Vector3(-2, 1.2, 8)) : ORBITAL_TARGET;
+    const endPos = active ? (targetPos || DEFAULT_EXPLORATION_POS) : ORBITAL_POS;
+    const endTarget = active ? (targetLookAt || DEFAULT_EXPLORATION_TARGET) : ORBITAL_TARGET;
 
     camera.position.lerpVectors(startPosRef.current, endPos, t);
 

--- a/client/src/components/openworld/OpenWorldLandscape.jsx
+++ b/client/src/components/openworld/OpenWorldLandscape.jsx
@@ -7,6 +7,8 @@ import { WORLD } from '../../utils/openWorldPlan';
 const TERRAIN_SIZE = 2400;
 const MOUNTAIN_INNER_RADIUS = 560;
 const MOUNTAIN_RADIUS_SPREAD = 190;
+const NEAR_HILL_INNER_RADIUS = 72;
+const NEAR_HILL_RADIUS_SPREAD = 28;
 
 const TERRAIN_VERT = `
   varying vec2 vUv;
@@ -146,6 +148,42 @@ function Mountain({ mountain, dayMix, surface }) {
   );
 }
 
+function NearHill({ hill, dayMix, surface, terrain }) {
+  const geometry = useMemo(() => {
+    const geom = new THREE.ConeGeometry(hill.radius, hill.height, hill.sides, 4);
+    const position = geom.getAttribute('position');
+    const colors = [];
+    const base = new THREE.Color(mixHex('#304b58', terrain.ridge, dayMix));
+    const lit = new THREE.Color(mixHex('#466b72', terrain.meadow, dayMix));
+    const cap = new THREE.Color(mixHex('#6b7890', '#d5c49c', dayMix));
+
+    for (let i = 0; i < position.count; i += 1) {
+      const y = (position.getY(i) + hill.height / 2) / hill.height;
+      const shoulder = smoothstepRange(0.16, 0.78, y);
+      const capMix = smoothstepRange(0.72, 1, y) * hill.cap;
+      const color = base.clone()
+        .lerp(lit, Math.min(1, hill.light + shoulder * 0.3))
+        .lerp(cap, capMix);
+      colors.push(color.r, color.g, color.b);
+    }
+
+    geom.setAttribute('color', new THREE.Float32BufferAttribute(colors, 3));
+    geom.computeVertexNormals();
+    return geom;
+  }, [dayMix, hill.cap, hill.height, hill.light, hill.radius, hill.sides, terrain]);
+
+  useEffect(() => () => geometry.dispose(), [geometry]);
+
+  return (
+    <group position={hill.position} rotation={[0, hill.rotation, 0]} scale={hill.scale}>
+      <mesh position={[0, hill.height / 2 - 0.08, 0]}>
+        <primitive attach="geometry" object={geometry} />
+        <meshStandardMaterial vertexColors roughness={0.98} metalness={0} depthWrite {...surface} />
+      </mesh>
+    </group>
+  );
+}
+
 export default function OpenWorldLandscape({ settings }) {
   const { accent, terrain, surface } = useOpenWorldPalette();
   const dayMix = openWorldDayMix(settings);
@@ -176,12 +214,71 @@ export default function OpenWorldLandscape({ settings }) {
     return result;
   }, []);
 
+  // A second, closer ring gives the playable city a landscape silhouette. The far
+  // mountain ring is intentionally distant for orbital mode, but without this nearer
+  // ring the empty/offline world reads as a flat plane until live buildings arrive.
+  const nearHills = useMemo(() => {
+    const result = [];
+    const rand = seededRand(8421);
+    const count = 14;
+
+    for (let i = 0; i < count; i++) {
+      const angle = (i / count) * Math.PI * 2 + (rand() - 0.5) * 0.22;
+      const radius = NEAR_HILL_INNER_RADIUS + rand() * NEAR_HILL_RADIUS_SPREAD;
+      const x = Math.cos(angle) * radius;
+      const z = Math.sin(angle) * radius;
+      if (z < WORLD.shorelineZ + 6) continue;
+      result.push({
+        id: `near-hill-${i}`,
+        position: [x, 0, z],
+        rotation: -angle + Math.PI / 2,
+        height: 6 + rand() * 12,
+        radius: 8 + rand() * 10,
+        sides: rand() > 0.45 ? 5 : 6,
+        light: 0.22 + rand() * 0.32,
+        cap: rand() > 0.7 ? 0.55 : 0.12,
+        scale: [1.1 + rand() * 1.4, 0.72 + rand() * 0.28, 0.7 + rand() * 0.9],
+      });
+    }
+
+    return result;
+  }, []);
+
+  const roadsideRocks = useMemo(() => {
+    const rand = seededRand(6112);
+    return Array.from({ length: 10 }, (_, i) => {
+      const side = i % 2 === 0 ? -1 : 1;
+      const row = Math.floor(i / 2);
+      return {
+        id: `roadside-rock-${i}`,
+        position: [side * (6 + rand() * 2.2), 0, 38 + row * 7 + rand() * 2.2],
+        rotation: rand() * Math.PI * 2,
+        height: 0.9 + rand() * 1.2,
+        radius: 0.8 + rand() * 0.7,
+        sides: 5,
+        light: 0.18 + rand() * 0.26,
+        cap: 0,
+        scale: [1.05 + rand() * 0.45, 0.7 + rand() * 0.2, 0.85 + rand() * 0.35],
+      };
+    });
+  }, []);
+
   return (
     <group>
       <TerrainPlane dayMix={dayMix} accent={accent} terrain={terrain} />
       <group>
         {mountains.map((mountain) => (
           <Mountain key={mountain.id} mountain={mountain} dayMix={dayMix} surface={surface} />
+        ))}
+      </group>
+      <group>
+        {nearHills.map((hill) => (
+          <NearHill key={hill.id} hill={hill} dayMix={dayMix} surface={surface} terrain={terrain} />
+        ))}
+      </group>
+      <group>
+        {roadsideRocks.map((rock) => (
+          <NearHill key={rock.id} hill={rock} dayMix={dayMix} surface={surface} terrain={terrain} />
         ))}
       </group>
     </group>

--- a/client/src/components/openworld/OpenWorldScene.jsx
+++ b/client/src/components/openworld/OpenWorldScene.jsx
@@ -301,7 +301,7 @@ export default function OpenWorldScene({ apps, agentMap, onBuildingClick, onTogg
       <OpenWorldEnergyOverlay chronotype={chronotype} settings={renderSettings} />
       {neonLayers && <OpenWorldStarfield settings={renderSettings} />}
       {neonLayers && <OpenWorldShootingStars playSfx={playSfx} settings={renderSettings} />}
-      {!explorationMode && <OpenWorldCelestial settings={renderSettings} />}
+      {!explorationMode && !palette?.lowPoly && <OpenWorldCelestial settings={renderSettings} />}
       <OpenWorldSkyline settings={renderSettings} />
       <OpenWorldFederationHorizon instances={instances} settings={renderSettings} />
       <OpenWorldBackupVault backupStatus={backupStatus} settings={renderSettings} />

--- a/client/src/components/openworld/OpenWorldSignalBeacons.jsx
+++ b/client/src/components/openworld/OpenWorldSignalBeacons.jsx
@@ -3,7 +3,7 @@ import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { computeDistrictBounds } from '../../utils/openWorldMiniMap';
 import { listRegions, regionWarpPadPosition } from '../../utils/openWorldRegions';
-import { PIXEL_FONT_URL, openWorldDayMix, openWorldShowDetail } from './openWorldConstants';
+import { PIXEL_FONT_URL, openWorldDayMix, openWorldShowDetail, mixHex } from './openWorldConstants';
 import { useOpenWorldPalette } from './OpenWorldPaletteContext';
 import OpenWorldLabel from './OpenWorldLabel';
 
@@ -86,6 +86,8 @@ function WarpPad({ region, active, detailed, dayMix, onTravel }) {
   const ringRef = useRef();
   const beamRef = useRef();
   const color = active ? '#fff4d6' : accent;
+  const padRadius = active ? 1.8 : 1.55;
+  const ringRadius = active ? 1.2 : 1.02;
   const position = regionWarpPadPosition(region);
 
   useFrame(({ clock }) => {
@@ -97,7 +99,7 @@ function WarpPad({ region, active, detailed, dayMix, onTravel }) {
       ringRef.current.rotation.z = t * 0.35;
       ringRef.current.material.opacity = 0.35 + pulse * 0.25;
     }
-    if (beamRef.current) beamRef.current.material.opacity = detailed ? 0.05 + pulse * 0.07 : 0;
+    if (beamRef.current) beamRef.current.material.opacity = detailed && active ? 0.05 + pulse * 0.07 : 0;
   });
 
   if (!position) return null;
@@ -112,16 +114,31 @@ function WarpPad({ region, active, detailed, dayMix, onTravel }) {
       }}
     >
       {/* The pad is always present, including the low tier, because it is an interaction
-          surface rather than decoration. Its hit area is intentionally larger than the disc. */}
+          surface rather than decoration. The player proximity radius remains larger than
+          the disc so it stays easy to use on foot. */}
       <mesh position={[0, 0, 0]}>
-        <cylinderGeometry args={[2.2, 2.2, 0.16, 24]} />
+        <cylinderGeometry args={[padRadius, padRadius, 0.16, 24]} />
         <meshStandardMaterial color={tintStructure('#13212a')} emissive={color} emissiveIntensity={active ? 1.1 : 0.5} roughness={0.8} metalness={0} />
       </mesh>
+      <mesh position={[0, 0.11, 0]}>
+        <cylinderGeometry args={[padRadius * 0.58, padRadius * 0.66, 0.05, 6]} />
+        <meshStandardMaterial
+          color={mixHex(color, '#183246', 0.42)}
+          emissive={color}
+          emissiveIntensity={active ? 0.75 : 0.3}
+          roughness={0.74}
+          metalness={0.08}
+        />
+      </mesh>
       <mesh ref={ringRef} position={[0, 0.1, 0]} rotation={[0, 0, Math.PI / 4]}>
-        <torusGeometry args={[1.45, 0.08, 8, 4]} />
+        <torusGeometry args={[ringRadius, 0.07, 8, 4]} />
         <meshBasicMaterial color={color} transparent opacity={0.5} blending={THREE.AdditiveBlending} depthWrite={false} />
       </mesh>
-      {detailed && (
+      <mesh position={[0, 0.17, 0]} rotation={[-Math.PI / 2, 0, 0]}>
+        <circleGeometry args={[0.18, 6]} />
+        <meshBasicMaterial color={color} transparent opacity={0.9} toneMapped={false} />
+      </mesh>
+      {detailed && active && (
         <mesh ref={beamRef} position={[0, 3.2, 0]}>
           <cylinderGeometry args={[0.08, 0.72, 6.2, 12, 1, true]} />
           <meshBasicMaterial color={color} transparent opacity={0.1} blending={THREE.AdditiveBlending} depthWrite={false} side={THREE.DoubleSide} />
@@ -138,7 +155,7 @@ function WarpPad({ region, active, detailed, dayMix, onTravel }) {
       >
         {region.label}
       </OpenWorldLabel>
-      {detailed && (
+      {detailed && active && (
         <OpenWorldLabel
           position={[0, 5.98, 0]}
           fontSize={0.16}

--- a/client/src/components/openworld/OpenWorldSkyline.jsx
+++ b/client/src/components/openworld/OpenWorldSkyline.jsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import * as THREE from 'three';
 import { openWorldDayMix, seededRand } from './openWorldConstants';
+import { useOpenWorldPalette } from './OpenWorldPaletteContext';
 import { isInWater } from '../../utils/openWorldPlan';
 
 // Distant cyberpunk skyline silhouettes with neon trim
@@ -85,6 +86,7 @@ function DistantBuilding({ position, width, height, color, accent, dayMix }) {
 }
 
 export default function OpenWorldSkyline({ settings }) {
+  const { lowPoly } = useOpenWorldPalette();
   const dayMix = openWorldDayMix(settings);
   const buildings = useMemo(() => {
     const result = [];
@@ -124,6 +126,11 @@ export default function OpenWorldSkyline({ settings }) {
 
     return result;
   }, []);
+
+  // The Vibes world uses the low-poly hill ring as its horizon. The old translucent
+  // cyber skyline reads as floating glass slabs against the clean landscape, so keep
+  // that silhouette layer exclusive to the cyber art direction.
+  if (lowPoly) return null;
 
   return (
     <group>

--- a/client/src/components/openworld/OpenWorldStreetProps.jsx
+++ b/client/src/components/openworld/OpenWorldStreetProps.jsx
@@ -60,15 +60,19 @@ export default function OpenWorldStreetProps({ settings }) {
   // Low preset: streets only, no furniture.
   if (!openWorldShowDetail(settings) || (props.lamps.length === 0 && props.trees.length === 0)) return null;
 
-  const lampGlow = mixHex(accent, '#fff7d6', 0.35);
+  const lampGlow = mixHex(accent, '#ffe2a6', 0.58);
   const headOpacity = 0.95 * (1 - dayMix) + 0.4 * dayMix; // lamps rest by day
   const poolOpacity = 0.1 * (1 - dayMix); // light pools are a night thing
+  const structureColor = lowPoly
+    ? mixHex('#3e5a5f', accent, 0.18)
+    : tintStructure('#141b2c');
+  const foliageColor = mixHex(mixHex('#6fa37f', accent, 0.22), '#d5bd83', dayMix * 0.18);
 
   return (
     <group>
       {/* Lamp poles */}
       <Instances placements={props.lamps} geometry="cylinder" geometryArgs={[0.05, 0.08, 3.4, 6]} position={POLE_POS}>
-        <meshStandardMaterial {...surface} color={tintStructure('#141b2c')} roughness={0.7} metalness={lowPoly ? 0 : 0.45} />
+        <meshStandardMaterial {...surface} color={structureColor} roughness={0.7} metalness={lowPoly ? 0 : 0.45} />
       </Instances>
       {/* Lamp heads — emissive spheres standing in for point lights */}
       <Instances placements={props.lamps} geometry="sphere" geometryArgs={[0.16, 10, 10]} position={HEAD_POS}>
@@ -88,12 +92,12 @@ export default function OpenWorldStreetProps({ settings }) {
       )}
       {/* Holo-tree trunks around the plaza */}
       <Instances placements={props.trees} geometry="cylinder" geometryArgs={[0.07, 0.1, 1.1, 5]} position={TRUNK_POS}>
-        <meshStandardMaterial {...surface} color={tintStructure('#101626')} roughness={0.8} />
+        <meshStandardMaterial {...surface} color={structureColor} roughness={0.8} />
       </Instances>
       {/* Vibes uses solid faceted foliage; cyber keeps the established wireframe holo-trees. */}
       <Instances placements={props.trees} geometry="icosahedron" geometryArgs={[0.8, 1]} position={CANOPY_POS}>
         {lowPoly ? (
-          <meshStandardMaterial {...surface} color={mixHex(accent, '#5d916e', 0.55)} roughness={0.98} transparent opacity={0.9} />
+          <meshStandardMaterial {...surface} color={foliageColor} roughness={0.98} transparent opacity={0.94} />
         ) : (
           <meshBasicMaterial
             color={mixHex(accent, '#22c55e', 0.45)}

--- a/client/src/components/openworld/OpenWorldStreets.jsx
+++ b/client/src/components/openworld/OpenWorldStreets.jsx
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 import { mergeGeometries } from 'three/addons/utils/BufferGeometryUtils.js';
 import { openWorldDayMix, mixHex, getAccentColor } from './openWorldConstants';
 import { useOpenWorldPalette } from './OpenWorldPaletteContext';
-import { computeStreets, PARCELS } from '../../utils/openWorldPlan';
+import { computeStreets, PARCELS, PLAZA } from '../../utils/openWorldPlan';
 
 // The street network from the master plan (openWorldPlan.js): an octagonal ring road around
 // downtown, spokes out to every district, the grand avenue to the harbor, a plaza
@@ -69,6 +69,31 @@ export default function OpenWorldStreets({ settings }) {
       pushColored(flatRect(c.x, c.z, c.length, c.width, c.angle, 0.028), paintColor);
     }
 
+    // Dashed center marks make the southern drop-in lane read as a drivable approach
+    // instead of a dark rectangle, especially on the first mobile frame.
+    for (const arrival of streets.segments.filter((segment) => segment.kind === 'arrival')) {
+      const dashLength = 1.5;
+      const dashGap = 3.4;
+      const count = Math.floor(arrival.length / (dashLength + dashGap));
+      const cos = Math.cos(arrival.angle);
+      const sin = Math.sin(arrival.angle);
+      for (let i = 0; i < count; i++) {
+        const along = -arrival.length / 2 + dashLength / 2 + i * (dashLength + dashGap);
+        pushColored(
+          flatRect(arrival.x + cos * along, arrival.z + sin * along, dashLength, 0.12, arrival.angle, 0.032),
+          new THREE.Color(mixHex('#f2d49c', '#ffffff', dayMix * 0.35)),
+        );
+      }
+    }
+
+    // A faceted plaza floor gives the central AI Core a readable stage even when
+    // there are no live app towers yet. The outer sidewalk ring remains separate,
+    // so the avenue and ring road still read as the town's navigation landmarks.
+    const plaza = new THREE.CircleGeometry(PLAZA.radius, 12);
+    plaza.rotateX(-Math.PI / 2);
+    plaza.translate(0, 0.022, 0);
+    pushColored(plaza, new THREE.Color(mixHex('#2e4b55', '#c7b995', dayMix)));
+
     const ring = new THREE.RingGeometry(streets.plazaRing.inner, streets.plazaRing.outer, 48);
     ring.rotateX(-Math.PI / 2);
     ring.translate(0, 0.018, 0);
@@ -92,11 +117,11 @@ export default function OpenWorldStreets({ settings }) {
     paintGeom.dispose();
   }, [asphaltGeom, stripGeom, paintGeom]);
 
-  // Night: near-black asphalt with accent-glow borders. Day: concrete gray, strips
-  // muted to painted lane edges.
-  const asphaltColor = mixHex('#0b0f18', '#566273', dayMix);
+  // Night: deep blue asphalt with accent-glow borders. Day: slate-blue roads keep
+  // their contrast against the sage ground instead of disappearing into a gray slab.
+  const asphaltColor = mixHex('#152536', '#536d7a', dayMix);
   const stripOpacity = 0.55 * (1 - dayMix) + 0.25 * dayMix;
-  const paintOpacity = 0.12 + 0.16 * dayMix;
+  const paintOpacity = 0.16 + 0.18 * dayMix;
 
   return (
     <group>
@@ -104,7 +129,7 @@ export default function OpenWorldStreets({ settings }) {
         <meshStandardMaterial color={asphaltColor} roughness={0.92} metalness={0.08} />
       </mesh>
       <mesh geometry={stripGeom}>
-        <meshBasicMaterial color={mixHex(accent, '#dde6ee', dayMix)} transparent opacity={stripOpacity} toneMapped={false} />
+        <meshBasicMaterial color={mixHex(accent, '#f1d5a5', dayMix)} transparent opacity={stripOpacity} toneMapped={false} />
       </mesh>
       <mesh geometry={paintGeom}>
         <meshBasicMaterial vertexColors transparent opacity={paintOpacity} />

--- a/client/src/components/openworld/OpenWorldTransitLoop.jsx
+++ b/client/src/components/openworld/OpenWorldTransitLoop.jsx
@@ -13,7 +13,7 @@ import { TRANSIT } from '../../utils/openWorldPlan';
 const TRAM_SIZE = [0.9, 0.5, 0.42];
 
 export default function OpenWorldTransitLoop({ settings }) {
-  const { accent, tintStructure } = useOpenWorldPalette();
+  const { accent, tintStructure, lowPoly, surface } = useOpenWorldPalette();
   const dayMix = openWorldDayMix(settings);
   const showTrams = openWorldShowDetail(settings);
 
@@ -41,8 +41,13 @@ export default function OpenWorldTransitLoop({ settings }) {
     });
   });
 
-  const trackColor = mixHex(accent, '#8b9bb0', dayMix);
-  const trackOpacity = 0.5 * (1 - dayMix) + 0.3 * dayMix;
+  const trackColor = lowPoly
+    ? mixHex('#4e7c7f', '#e1c28d', dayMix)
+    : mixHex(accent, '#8b9bb0', dayMix);
+  const trackOpacity = lowPoly
+    ? 0.46 * (1 - dayMix) + 0.62 * dayMix
+    : 0.5 * (1 - dayMix) + 0.3 * dayMix;
+  const pylonColor = lowPoly ? mixHex('#38545a', '#6d887c', dayMix) : tintStructure('#121a2c');
 
   return (
     <group>
@@ -55,7 +60,7 @@ export default function OpenWorldTransitLoop({ settings }) {
         <group key={stop.id} position={[stop.point[0], 0, stop.point[2]]}>
           <mesh position={[0, TRANSIT.y / 2, 0]}>
             <cylinderGeometry args={[0.12, 0.2, TRANSIT.y, 6]} />
-            <meshStandardMaterial color={tintStructure('#121a2c')} roughness={0.7} metalness={0.4} />
+            <meshStandardMaterial {...surface} color={pylonColor} roughness={0.7} metalness={lowPoly ? 0 : 0.4} />
           </mesh>
           <mesh position={[0, TRANSIT.y - 0.35, 0]} rotation={[Math.PI / 2, 0, 0]}>
             <torusGeometry args={[0.55, 0.05, 6, 20]} />
@@ -68,11 +73,12 @@ export default function OpenWorldTransitLoop({ settings }) {
         <mesh key={i} ref={(el) => { if (el) tramRefs.current[i] = el; }}>
           <boxGeometry args={TRAM_SIZE} />
           <meshStandardMaterial
-            color={tintStructure('#1a2440')}
+            {...surface}
+            color={lowPoly ? mixHex('#d57b67', accent, 0.2) : tintStructure('#1a2440')}
             emissive={accent}
             emissiveIntensity={0.5 * (1 - dayMix) + 0.15 * dayMix}
-            metalness={0.5}
-            roughness={0.3}
+            metalness={lowPoly ? 0.05 : 0.5}
+            roughness={lowPoly ? 0.85 : 0.3}
             toneMapped={false}
           />
         </mesh>

--- a/client/src/components/openworld/OpenWorldVoiceMarker.jsx
+++ b/client/src/components/openworld/OpenWorldVoiceMarker.jsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { PIXEL_FONT_URL, openWorldDayMix } from './openWorldConstants';
+import { PIXEL_FONT_URL, openWorldDayMix, mixHex } from './openWorldConstants';
 import { useOpenWorldPalette } from './OpenWorldPaletteContext';
 import OpenWorldLabel from './OpenWorldLabel';
 import { computeVoiceMarker } from '../../utils/openWorldVoiceMarker';
@@ -11,7 +11,7 @@ import { computeVoiceMarker } from '../../utils/openWorldVoiceMarker';
 // while listening, green while dictating, red on error, and barely-lit when voice mode is
 // off. Keeps to a small footprint so it reads as a district marker, not a landmark.
 export default function OpenWorldVoiceMarker({ voiceState, settings }) {
-  const { tintStructure } = useOpenWorldPalette();
+  const { tintStructure, lowPoly, surface } = useOpenWorldPalette();
   const marker = useMemo(() => computeVoiceMarker(voiceState), [voiceState]);
   const orbRef = useRef();
 
@@ -34,18 +34,20 @@ export default function OpenWorldVoiceMarker({ voiceState, settings }) {
   });
 
   const { position, baseRadius, poleHeight, beaconRadius, color, label } = marker;
+  const baseColor = lowPoly ? mixHex('#426267', '#d1b47f', dayMix) : tintStructure('#0c1620');
+  const poleColor = lowPoly ? mixHex('#38545a', '#718678', dayMix) : '#1a2533';
 
   return (
     <group position={position}>
       {/* Low disc base — anchors the marker to the ground */}
       <mesh position={[0, 0.1, 0]}>
         <cylinderGeometry args={[baseRadius, baseRadius * 1.15, 0.2, 24]} />
-        <meshStandardMaterial color={tintStructure('#0c1620')} emissive={color} emissiveIntensity={0.12} metalness={0.5} roughness={0.6} />
+        <meshStandardMaterial {...surface} color={baseColor} emissive={color} emissiveIntensity={0.12} metalness={lowPoly ? 0 : 0.5} roughness={0.6} />
       </mesh>
       {/* Slim antenna pole */}
       <mesh position={[0, poleHeight / 2, 0]}>
         <cylinderGeometry args={[0.14, 0.18, poleHeight, 12]} />
-        <meshStandardMaterial color="#1a2533" emissive={color} emissiveIntensity={0.15} metalness={0.7} roughness={0.4} />
+        <meshStandardMaterial {...surface} color={poleColor} emissive={color} emissiveIntensity={0.15} metalness={lowPoly ? 0 : 0.7} roughness={0.4} />
       </mesh>
       {/* Beacon orb — the live voice-state indicator */}
       <mesh ref={orbRef} position={[0, poleHeight + beaconRadius * 0.6, 0]}>

--- a/client/src/components/openworld/PlayerAvatar.jsx
+++ b/client/src/components/openworld/PlayerAvatar.jsx
@@ -24,9 +24,9 @@ export default function PlayerAvatar({ rigRef }) {
   const underglowRef = useRef();
   const wheelRefs = useRef([]);
 
-  const bodyColor = mixHex('#e7825c', accent, 0.22);
+  const bodyColor = mixHex('#ee8f68', accent, 0.16);
   const bodyShadow = mixHex('#263447', accent, 0.16);
-  const glassColor = mixHex('#15243a', accent, 0.25);
+  const glassColor = mixHex('#294765', accent, 0.22);
   const wheelColor = '#17212d';
 
   useFrame(({ clock }, delta) => {

--- a/client/src/components/openworld/PlayerController.jsx
+++ b/client/src/components/openworld/PlayerController.jsx
@@ -4,7 +4,7 @@ import * as THREE from 'three';
 import PlayerAvatar from './PlayerAvatar';
 import ErrorBoundary from '../ErrorBoundary';
 import {
-  THIRD_PERSON, EYE_HEIGHT, BUILDING_COLLISION_RADIUS,
+  THIRD_PERSON, EYE_HEIGHT, DEFAULT_SPAWN_Z, BUILDING_COLLISION_RADIUS,
   thirdPersonCamera, resolveBoom,
   dampFactor, dampAngle, moveFacing, avatarState, bankAngle,
 } from '../../utils/openWorldPlayerRig';
@@ -20,7 +20,6 @@ const PROXIMITY_DISTANCE = 6;
 const MAX_CAMERA_HEIGHT = 160;
 const BUILDING_FLYOVER_HEIGHT = 12; // above this the player clears rooftops, so skip collision
 const AIRBORNE_HEIGHT = EYE_HEIGHT + 0.6; // above this the avatar reads as flying (hover state)
-const DEFAULT_SPAWN_Z = 42; // clear the central AI Core when an install has few/no app buildings
 const MOUSE_SENSITIVITY = 0.002;
 const PITCH_LIMIT = Math.PI / 2 - 0.02;
 

--- a/client/src/components/openworld/openWorldConstants.js
+++ b/client/src/components/openworld/openWorldConstants.js
@@ -146,7 +146,7 @@ export const CITY_COLORS = {
       isMoon: false,
       daylightFactor: 1.0,
       // Meadow green rather than pavement — the ground plane is a landscape here.
-      groundColor: '#628b6d',
+      groundColor: '#86b893',
       groundRoughness: 0.95,
       hemiSkyColor: '#b9e3d8',
       hemiGroundColor: '#3f5c4a',
@@ -170,7 +170,7 @@ export const CITY_COLORS = {
       sunScale: 1.0,
       isMoon: false,
       daylightFactor: 0.9,
-      groundColor: '#57755f',
+      groundColor: '#6f9b80',
       groundRoughness: 0.95,
       hemiSkyColor: '#9fc7cd',
       hemiGroundColor: '#3a4a3c',
@@ -451,9 +451,10 @@ export const WORLD_STYLE_DEFS = {
     // Warm sand / coral / teal / sage / amber instead of the cyberpunk neon set, so the
     // bright low-poly world doesn't wear night-club colors.
     accents: ['#63f2db', '#f07f6d', '#d7b98c', '#9873b9', '#f3b562', '#57c9c0', '#8c7169', '#dde4df'],
-    // Warm stone rather than the cyber world's near-black slab.
-    buildingBody: '#a87868',
-    terrain: { inner: '#8c7169', meadow: '#628b6d', ridge: '#51666a' },
+    // A painted coastal palette: blue-green city soil, sage meadows, and cool stone
+    // ridges keep the empty world readable before any live app towers arrive.
+    buildingBody: '#7e9e90',
+    terrain: { inner: '#6d8f8f', meadow: '#91b983', ridge: '#7896a2' },
   },
   cyber: {
     id: 'cyber',

--- a/client/src/utils/openWorldAiCore.js
+++ b/client/src/utils/openWorldAiCore.js
@@ -16,8 +16,8 @@ import { PARCELS } from './openWorldPlan';
 
 export const AI_CORE = {
   position: PARCELS.aiCore.anchor, // city center — the spire rises above the building grid
-  height: 34, // tall enough to clear downtown and read as the central landmark
-  apexY: 34, // beams/glow originate from the apex
+  height: 28, // tall enough to clear downtown while leaving the plaza visible around it
+  apexY: 28, // beams/glow originate from the apex
   maxBeams: 6, // visible activity beams cap
   // How long an op with no terminal (complete/error) event lingers before being pruned,
   // so a dropped/never-finished call can't pin the core "busy" forever.

--- a/client/src/utils/openWorldPlan.js
+++ b/client/src/utils/openWorldPlan.js
@@ -178,6 +178,14 @@ export function computeStreets() {
     kind: 'avenue',
   });
 
+  // A short southern arrival lane gives the rover a deliberate place to enter the
+  // world when the install has no app data yet. It connects the downtown ring to
+  // the default drop-in area without cutting through the central plaza.
+  segments.push({
+    ...segment(0, PLAZA.sidewalkOuter + 15, 0, WORLD.landHalf + 12, AVENUE_WIDTH),
+    kind: 'arrival',
+  });
+
   return { segments, crosswalks, plazaRing: { inner: PLAZA.radius, outer: PLAZA.sidewalkOuter } };
 }
 

--- a/client/src/utils/openWorldPlan.test.js
+++ b/client/src/utils/openWorldPlan.test.js
@@ -144,6 +144,14 @@ describe('computeStreets', () => {
     expect(farEdge).toBeGreaterThanOrEqual(WORLD.shorelineZ);
   });
 
+  it('provides a southern arrival lane for the default rover drop-in', () => {
+    const arrival = streets.segments.find((s) => s.kind === 'arrival');
+    expect(arrival).toBeTruthy();
+    expect(arrival.x).toBe(0);
+    expect(arrival.z + arrival.length / 2).toBeGreaterThan(WORLD.landHalf);
+    expect(arrival.z - arrival.length / 2).toBeGreaterThan(PLAZA.sidewalkOuter);
+  });
+
   it('keeps every street on land', () => {
     for (const seg of streets.segments) {
       const cos = Math.cos(seg.angle);

--- a/client/src/utils/openWorldPlayerRig.js
+++ b/client/src/utils/openWorldPlayerRig.js
@@ -11,19 +11,20 @@
 // these (restating them at call sites is how walk collision and camera collision drift).
 export const EYE_HEIGHT = 1.6;
 export const BUILDING_COLLISION_RADIUS = 3.5;
+export const DEFAULT_SPAWN_Z = 52;
 
 export const THIRD_PERSON = {
-  boom: 13, // camera distance behind the character
-  shoulder: 0.9, // lateral over-the-shoulder offset (positive = right)
-  height: 3.2, // camera rise above the character's feet at pitch 0
+  boom: 16.5, // camera distance behind the character
+  shoulder: 0.95, // lateral over-the-shoulder offset (positive = right)
+  height: 3.6, // camera rise above the character's feet at pitch 0
   isometricYaw: Math.PI / 12, // slight diagonal framing keeps the downtown avenue in view
-  isometricPitch: 0.52, // about 30° above the landscape, keeping landmarks in the frame
-  fov: 38, // tighter perspective keeps the city readable from the elevated angle
+  isometricPitch: 0.62, // about 36° above the landscape, keeping landmarks in the frame
+  fov: 42, // broader perspective gives the rover room to move through the landscape
   minPitch: -0.45, // looking up from under the character — floor-limited
   maxPitch: 1.15, // looking down over the character
   minCamY: 0.6, // the camera never dips into the pavement
-  lookAhead: 0.8, // keep the rover on-screen while the road opens ahead
-  lookHeight: 0.8, // aim near the rover's roof so it stays clear of the mobile controls
+  lookAhead: 2.4, // compose the rover against the road and landmarks ahead
+  lookHeight: 0.85, // aim just above the rover so the landscape owns the frame
   camDampRate: 8, // camera position smoothing (lower = floatier)
   lookDampRate: 12, // aim smoothing (tighter than position so aim stays crisp)
 };


### PR DESCRIPTION
## Summary
- Give the Vibes world a readable coastal low-poly palette with near-field hills, roadside rocks, and a staged central plaza.
- Make the arrival road, lane markings, warp pads, transit, lamps, voice marker, and rover read as one cohesive game scene.
- Share the default spawn/camera rig with orbital re-entry so the isometric framing remains stable.

## Visual verification
- Checked the live OpenWorld preview at 390x844 and 1280x900.
- Verified orbital exit and isometric re-entry.

## Test plan
- `npm test -- --run src/utils/openWorldPlan.test.js src/utils/openWorldPlayerRig.test.js src/utils/openWorldAiCore.test.js src/components/openworld/openWorldTheme.test.js`
- `npm run lint`
- `npm run build`
- Full client suite: 2 unrelated timing-sensitive tests failed in the full run (`MidiGatedModal`, `PostHistory`); both pass when run in isolation.