### PR TITLE
fail a MiniMax H3 pin bump at Install/Repair, not on a failed keyframe render

### DIFF
--- a/scripts/_minimax_h3_pin.py
+++ b/scripts/_minimax_h3_pin.py
@@ -1,0 +1,169 @@
+"""The pinned-MiniMax-H3 seams PortOS patches, stated once for both callers.
+
+`generate_minimax_h3.py` corrects four things PipeNetwork's pinned MLX port
+gets wrong on the keyframe path, and each correction wraps a specific method of
+`MiniMaxH3TextEncoder` — so each is only valid against the exact implementation
+it was written against. Which methods those are, and what "unchanged" means for
+the one whose body is copied rather than wrapped, are facts about the PIN, not
+about the runner, and two callers need them:
+
+  - the runner, which refuses to install a correction onto a hook that moved
+  - `minimax_h3_runtime_probe.py --verify-seams`, which Install / Repair runs and
+    which therefore fails at the action that moved the pin, rather than minutes
+    into the first keyframe render that happens to reach the seam
+
+`PINNED_ENCODE_DIGEST` in particular must have exactly ONE home. A second copy
+is a copy that goes stale, and a stale digest asserts a pin bump is fine when
+it is not — which is the failure this module exists to make impossible.
+
+Stdlib-only at import, like `_runner_common.py` and `_minimax_h3_common.py`:
+the pinned package and mlx-vlm are imported inside the functions that need
+them, so nothing here forces a venv to grow a dependency, and the probe can
+import this module before deciding the checkout is usable at all.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import inspect
+
+# The merge the pinned port performs instead of a scatter. Asserted before the
+# replacement is installed, so the day upstream fixes this the patch says so
+# loudly rather than shadowing a working implementation forever.
+PINNED_BROADCAST_MERGE = "mx.where(image_mask[..., None], hidden.astype(inputs_embeds.dtype)[None], inputs_embeds)"
+
+# sha256 of the whole pinned `encode`, because the replacement re-runs its body
+# with one line changed rather than wrapping it. Matching only the merge line
+# would let every OTHER edit a pin bump makes — a new `_hidden_states` argument,
+# a different dtype, an added step — pass silently into a stale copy.
+# Re-record this when bumping MINIMAX_H3_EXPECTED_REVISION, after re-reading
+# `encode` and folding whatever changed into the replacement.
+PINNED_ENCODE_DIGEST = "8047e407e797cd46cd7538024ca09d97402d369d97b1d825757a1590416bda7d"
+
+# Every method of the pinned encoder a PortOS correction wraps: what breaks when
+# the pin no longer has it, the shape the correction requires it to still be, and
+# the way out that rescues the render. A TABLE rather than arguments at the four
+# call sites, because the runner patches these and the probe asserts them —
+# stating the pair apart is exactly how the install-time check drifts from the
+# render-time one, which is the failure this module exists to prevent.
+#
+# `remedy` defaults to dropping the keyframe, which is what rescues three of
+# them. The key-prefix map is the exception: it is reached by a substituted
+# conditioner, which a keyframe has nothing to do with.
+DEFAULT_REMEDY = "Render text-only"
+PINNED_ENCODER_SEAMS = {
+    "_wanted": {
+        "consequence": "a substituted text encoder cannot be key-mapped onto it",
+        "remedy": "Render with the stock text encoder",
+    },
+    "processor": {
+        "consequence": "a keyframe cannot be encoded without PyTorch",
+        # The correction binds a property, and the pinned caller reads rather
+        # than calls it — a `processor` that is no longer one is as much a pin
+        # change as an absent one.
+        "kind": property,
+    },
+    "_load_weights": {
+        "consequence": "its vision tower cannot be laid out for MLX",
+    },
+    "encode": {
+        "consequence": "a keyframe cannot be merged into the prompt",
+    },
+}
+
+# Every mlx-vlm entry point the corrections reach for, as
+# (module, dotted attribute, what breaks without it). The two methods are named
+# rather than just their classes: a `Model` that still imports but no longer
+# carries `merge_input_ids_with_image_features` breaks the correction exactly as
+# hard as one that vanished. Kept in step with the runner's own `from mlx_vlm …
+# import` lines by a drift guard in minimax_h3_runtime_probe.test.js.
+PINNED_MLX_VLM_SYMBOLS = (
+    ("mlx_vlm.utils", "sanitize_weights",
+     "a keyframe's vision tower cannot be laid out for MLX"),
+    ("mlx_vlm.models.qwen3_vl.qwen3_vl", "Model.merge_input_ids_with_image_features",
+     "a keyframe cannot be scattered into the prompt"),
+    ("mlx_vlm.models.qwen3_vl.language", "LanguageModel.get_rope_index",
+     "a keyframe's position ids cannot be built"),
+)
+
+
+def pinned_encoder_hook(name: str):
+    """Return one seam of the pinned text encoder, or say the pin moved.
+
+    Each keyframe correction wraps a different method of
+    `MiniMaxH3TextEncoder`, and each is only correct against the implementation
+    it was written for — so every one of them checks its hook is still there and
+    still the shape it patches, and reports the same two ways out.
+    """
+    from minimax_h3_mlx.text_encoder import MiniMaxH3TextEncoder
+
+    seam = PINNED_ENCODER_SEAMS[name]
+    hook = getattr(MiniMaxH3TextEncoder, name, None)
+    kind = seam.get("kind")
+    if hook is None or (kind is not None and not isinstance(hook, kind)):
+        raise RuntimeError(
+            f"The pinned MiniMax H3 runtime no longer exposes MiniMaxH3TextEncoder.{name}, so "
+            f"{seam['consequence']}. {seam.get('remedy', DEFAULT_REMEDY)}, or update PortOS "
+            "for the new pin."
+        )
+    return MiniMaxH3TextEncoder, hook
+
+
+def verify_pinned_encode(encode) -> None:
+    """Assert the copied `encode` body is still the one PortOS copied.
+
+    Two checks, because they fail for opposite reasons and want opposite fixes:
+    the merge line going missing means upstream fixed the bug and the correction
+    must RETIRE, while the merge line surviving under a different digest means
+    something else in the body moved and the copy must be REFRESHED.
+    """
+    source = inspect.getsource(encode)
+    if PINNED_BROADCAST_MERGE not in source:
+        raise RuntimeError(
+            "The pinned MiniMax H3 runtime no longer merges keyframe embeddings the way PortOS "
+            "corrects for; re-check the pin before rendering with a keyframe."
+        )
+    if hashlib.sha256(source.encode("utf-8")).hexdigest() != PINNED_ENCODE_DIGEST:
+        raise RuntimeError(
+            "The pinned MiniMax H3 runtime changed MiniMaxH3TextEncoder.encode outside the merge "
+            "PortOS corrects; fold the change into the replacement and re-record "
+            "PINNED_ENCODE_DIGEST before rendering with a keyframe."
+        )
+
+
+def verify_mlx_vlm_symbol(module_path: str, dotted: str, consequence: str) -> None:
+    """Require one mlx-vlm attribute the corrections call, by its dotted path."""
+    full = f"{module_path}.{dotted}"
+    try:
+        target = importlib.import_module(module_path)
+    except ImportError as exc:
+        raise RuntimeError(
+            f"The MiniMax H3 runtime's mlx-vlm no longer provides {module_path}, so {consequence}. "
+            "Update PortOS for the new mlx-vlm."
+        ) from exc
+    for part in dotted.split("."):
+        target = getattr(target, part, None)
+        if target is None:
+            raise RuntimeError(
+                f"The MiniMax H3 runtime's mlx-vlm no longer exposes {full}, so {consequence}. "
+                "Update PortOS for the new mlx-vlm."
+            )
+
+
+def verify_pinned_seams() -> None:
+    """Check every seam the keyframe corrections depend on, loading no weights.
+
+    The runner guards each seam again at the moment it patches it — that stays
+    the last line for anyone who overrides the pin — but by then a cache resolve
+    and a pipeline load have already happened, and only an image-conditioned
+    render reaches three of the four. Running the same assertions from the
+    Install / Repair probe puts the failure at the action that caused it.
+
+    Requires `minimax_h3_mlx` to already be importable, which for the probe means
+    after `register_source_namespace`.
+    """
+    hooks = {name: pinned_encoder_hook(name)[1] for name in PINNED_ENCODER_SEAMS}
+    verify_pinned_encode(hooks["encode"])
+    for module_path, dotted, consequence in PINNED_MLX_VLM_SYMBOLS:
+        verify_mlx_vlm_symbol(module_path, dotted, consequence)

--- a/scripts/generate_minimax_h3.py
+++ b/scripts/generate_minimax_h3.py
@@ -14,9 +14,7 @@ Each `--image` needs its own `--anchor`, in the same order.
 from __future__ import annotations
 
 import argparse
-import hashlib
 import importlib.util
-import inspect
 import json
 import re
 import shutil
@@ -34,6 +32,7 @@ from _minimax_h3_common import (  # noqa: E402
     FPS, add_h3_common_args, emit_result, load_keyframes, resolve_cached_snapshot,
     validate_h3_output_args,
 )
+from _minimax_h3_pin import pinned_encoder_hook, verify_pinned_encode  # noqa: E402
 
 
 # The MLX port accepts H3's full documented 4-15s range. The diffusers CUDA
@@ -131,15 +130,7 @@ def install_key_prefix_map(rules: list[tuple[str, str]]) -> None:
     Deliberately NOT a source edit: the checkout is verified clean above, and it
     must stay that way.
     """
-    from minimax_h3_mlx.text_encoder import MiniMaxH3TextEncoder
-
-    original = getattr(MiniMaxH3TextEncoder, "_wanted", None)
-    if original is None:
-        raise RuntimeError(
-            "The pinned MiniMax H3 runtime no longer exposes MiniMaxH3TextEncoder._wanted, "
-            "so a substituted text encoder cannot be key-mapped onto it. Render with the "
-            "stock text encoder, or update PortOS for the new pin."
-        )
+    MiniMaxH3TextEncoder, original = pinned_encoder_hook("_wanted")
 
     def _wanted(self, key: str):
         for source, target in rules:
@@ -149,25 +140,6 @@ def install_key_prefix_map(rules: list[tuple[str, str]]) -> None:
         return original(self, key)
 
     MiniMaxH3TextEncoder._wanted = _wanted
-
-
-def pinned_encoder_hook(name: str, consequence: str, kind: type | None = None):
-    """Return one attribute of the pinned text encoder, or say the pin moved.
-
-    Each keyframe correction below wraps a different method of
-    `MiniMaxH3TextEncoder`, and each is only correct against the implementation
-    it was written for — so every one of them checks its hook is still there and
-    still the shape it patches, and reports the same two ways out.
-    """
-    from minimax_h3_mlx.text_encoder import MiniMaxH3TextEncoder
-
-    hook = getattr(MiniMaxH3TextEncoder, name, None)
-    if hook is None or (kind is not None and not isinstance(hook, kind)):
-        raise RuntimeError(
-            f"The pinned MiniMax H3 runtime no longer exposes MiniMaxH3TextEncoder.{name}, so "
-            f"{consequence}. Render text-only, or update PortOS for the new pin."
-        )
-    return MiniMaxH3TextEncoder, hook
 
 
 def torch_image_stack_available() -> bool:
@@ -226,9 +198,7 @@ def install_pil_image_processor() -> None:
     it doesn't use and — deliberately, like the key-prefix map above — leaves the
     pinned checkout untouched, because it is verified clean before this runs.
     """
-    encoder, _ = pinned_encoder_hook(
-        "processor", "a keyframe cannot be encoded without PyTorch", kind=property
-    )
+    encoder, _ = pinned_encoder_hook("processor")
 
     def processor(self):
         if self._processor is None:
@@ -259,9 +229,7 @@ def install_vision_weight_sanitizer() -> None:
     correctly-laid-out tensor as a no-op, so this stays right if a later pin (or a
     later mlx-vlm) starts handing the tower a sanitized weight.
     """
-    encoder, original = pinned_encoder_hook(
-        "_load_weights", "its vision tower cannot be laid out for MLX"
-    )
+    encoder, original = pinned_encoder_hook("_load_weights")
 
     def _load_weights(self, model_dir, dtype, verbose):
         original(self, model_dir, dtype, verbose)
@@ -288,20 +256,6 @@ def sanitize_vision_weights(vision) -> None:
     mx.eval(vision.parameters())
 
 
-# The merge the pinned port performs instead of a scatter. Asserted before the
-# replacement below is installed, so the day upstream fixes this the patch says
-# so loudly rather than shadowing a working implementation forever.
-PINNED_BROADCAST_MERGE = "mx.where(image_mask[..., None], hidden.astype(inputs_embeds.dtype)[None], inputs_embeds)"
-
-# sha256 of the whole pinned `encode`, because the replacement below re-runs its
-# body with one line changed rather than wrapping it. Matching only the merge
-# line would let every OTHER edit a pin bump makes — a new `_hidden_states`
-# argument, a different dtype, an added step — pass silently into a stale copy.
-# Re-record this when bumping MINIMAX_H3_EXPECTED_REVISION, after re-reading
-# `encode` and folding whatever changed into the replacement.
-PINNED_ENCODE_DIGEST = "8047e407e797cd46cd7538024ca09d97402d369d97b1d825757a1590416bda7d"
-
-
 def install_vision_embed_merge() -> None:
     """Scatter a keyframe's vision rows into the tokens that stand for them.
 
@@ -318,21 +272,8 @@ def install_vision_embed_merge() -> None:
     the broadcast could never check). A text-only request never reaches the merge,
     so it is handed straight back to the pinned implementation untouched.
     """
-    encoder, original = pinned_encoder_hook(
-        "encode", "a keyframe cannot be merged into the prompt"
-    )
-    source = inspect.getsource(original)
-    if PINNED_BROADCAST_MERGE not in source:
-        raise RuntimeError(
-            "The pinned MiniMax H3 runtime no longer merges keyframe embeddings the way PortOS "
-            "corrects for; re-check the pin before rendering with a keyframe."
-        )
-    if hashlib.sha256(source.encode("utf-8")).hexdigest() != PINNED_ENCODE_DIGEST:
-        raise RuntimeError(
-            "The pinned MiniMax H3 runtime changed MiniMaxH3TextEncoder.encode outside the merge "
-            "PortOS corrects; fold the change into the replacement and re-record "
-            "PINNED_ENCODE_DIGEST before rendering with a keyframe."
-        )
+    encoder, original = pinned_encoder_hook("encode")
+    verify_pinned_encode(original)
 
     def encode(self, prompt: str, images: list | None = None):
         # A text-only request never reaches the merge, so it goes back to the

--- a/scripts/generate_minimax_h3.test.js
+++ b/scripts/generate_minimax_h3.test.js
@@ -39,6 +39,10 @@ const importRunner = [
   'spec = importlib.util.spec_from_file_location("generate_minimax_h3", script)',
   'runner = importlib.util.module_from_spec(spec)',
   'spec.loader.exec_module(runner)',
+  // The pin facts live in the module BOTH the runner and the install-time probe
+  // import (_minimax_h3_pin.py), so the cases that stand in for a moved pin have
+  // to rebind them there — rebinding a name on the runner would patch nothing.
+  'pin = sys.modules["_minimax_h3_pin"]',
 ].join('\n');
 
 // validate_args reads the namespace argparse produces, so every field it touches
@@ -85,21 +89,21 @@ const stubPin = (classBody, preamble = []) => [
 // The merge correction guards itself with `inspect.getsource`, which needs a
 // real file — so that stand-in is written out and imported rather than declared
 // inline. Each `encodeBody` entry is a PYTHON expression evaluated against the
-// already-imported runner, so the line under test comes from the runner's own
+// already-imported pin module, so the line under test comes from the shipped
 // constant instead of a copy that could drift from it. The result is carried as
 // a COMMENT: the stub only has to look like the pin to `getsource`, not run.
 const filePin = (encodeBody) => [
   'import atexit, importlib.util, shutil, sys, tempfile, types',
   'temp = tempfile.mkdtemp()',
   'atexit.register(shutil.rmtree, temp, True)',
-  'pin = Path(temp) / "pinned_text_encoder.py"',
-  'pin.write_text("\\n".join([',
+  'pin_file = Path(temp) / "pinned_text_encoder.py"',
+  'pin_file.write_text("\\n".join([',
   '    "class MiniMaxH3TextEncoder:",',
   '    "    def encode(self, prompt, images=None):",',
   ...encodeBody.map((expr) => `    "        # " + ${expr},`),
   '    "        return (\'pinned\', prompt, images)",',
   ']))',
-  'spec = importlib.util.spec_from_file_location("minimax_h3_mlx.text_encoder", pin)',
+  'spec = importlib.util.spec_from_file_location("minimax_h3_mlx.text_encoder", pin_file)',
   'module = importlib.util.module_from_spec(spec)',
   'sys.modules["minimax_h3_mlx"] = types.ModuleType("minimax_h3_mlx")',
   'sys.modules["minimax_h3_mlx.text_encoder"] = module',
@@ -715,9 +719,9 @@ describe.skipIf(!pyBin)('generate_minimax_h3.py', () => {
   // the pinned body with that one line swapped, so it is guarded twice: by the
   // line it replaces, and by a digest over the whole body it copied.
   it('corrects a pin that still merges by broadcast, and hands its text-only path back', () => {
-    const output = runPython(`${importRunner}\n${filePin(["runner.PINNED_BROADCAST_MERGE"])}\n${[
+    const output = runPython(`${importRunner}\n${filePin(["pin.PINNED_BROADCAST_MERGE"])}\n${[
       'import hashlib, inspect',
-      'runner.PINNED_ENCODE_DIGEST = hashlib.sha256(',
+      'pin.PINNED_ENCODE_DIGEST = hashlib.sha256(',
       '    inspect.getsource(MiniMaxH3TextEncoder.encode).encode("utf-8")',
       ').hexdigest()',
       'runner.install_vision_embed_merge()',
@@ -730,14 +734,14 @@ describe.skipIf(!pyBin)('generate_minimax_h3.py', () => {
 
   it.each([
     // Upstream fixed the merge: the correction has to retire, not shadow it.
-    [['runner.PINNED_BROADCAST_MERGE.replace("mx.where", "masked_scatter")'], 'digest-of-this-pin', /no longer merges keyframe embeddings/],
+    [['pin.PINNED_BROADCAST_MERGE.replace("mx.where", "masked_scatter")'], 'digest-of-this-pin', /no longer merges keyframe embeddings/],
     // The merge is untouched but something else in the body moved — the copy is
     // stale in a way matching one line could never see.
-    [['runner.PINNED_BROADCAST_MERGE'], `"${'0'.repeat(64)}"`, /changed MiniMaxH3TextEncoder\.encode outside the merge/],
+    [['pin.PINNED_BROADCAST_MERGE'], `"${'0'.repeat(64)}"`, /changed MiniMaxH3TextEncoder\.encode outside the merge/],
   ])('refuses a pin the copied encode no longer matches (%j)', (body, digest, expected) => {
     const output = runPython(`${importRunner}\n${filePin(body)}\n${[
       'import hashlib, inspect',
-      `runner.PINNED_ENCODE_DIGEST = ${digest === 'digest-of-this-pin'
+      `pin.PINNED_ENCODE_DIGEST = ${digest === 'digest-of-this-pin'
         ? 'hashlib.sha256(inspect.getsource(MiniMaxH3TextEncoder.encode).encode("utf-8")).hexdigest()'
         : digest}`,
       'try:',

--- a/scripts/minimax_h3_runtime_probe.py
+++ b/scripts/minimax_h3_runtime_probe.py
@@ -1,25 +1,58 @@
 #!/usr/bin/env python3
-"""Import-probe a pinned MiniMax H3 source package without trusting its root."""
+"""Import-probe a pinned MiniMax H3 source package without trusting its root.
+
+Two callers, and they want different strictness — hence `--verify-seams`:
+
+  - `isByovRuntimeReady` (server/services/videoGen/runtimes.js) runs this bare,
+    as a readiness check. It must answer ONLY "can this runtime render at all",
+    because a false negative there sets `byovGateBlocked` in the Video Gen page
+    and disables Generate outright. Same rule minimax_h3_lora_probe.py is kept
+    separate for: a runtime that is perfectly healthy for plain renders is never
+    marked unready over a capability it doesn't need.
+
+  - `scripts/setup-image-video.sh` runs it WITH the flag at Install / Repair,
+    where the extra strictness is what the user asked for and a failure is
+    actionable at the action that caused it.
+
+The flag adds `verify_pinned_seams()`: every method of the pinned encoder that
+`generate_minimax_h3.py` patches, asserted up front. Those adapters are only
+correct against the exact implementation they were written for, and their
+render-time guards otherwise fire minutes later — after a cache resolve and a
+pipeline load, and only on the image-conditioned path three of them serve. A pin
+bump reaches Install / Repair anyway (a moved MINIMAX_H3_EXPECTED_REVISION fails
+`isByovRuntimeCurrent`, and a re-locked mlx-vlm needs a re-sync), so gating the
+strict check there costs no coverage a stock user would ever have seen.
+"""
 
 from __future__ import annotations
 
+import argparse
 import importlib
-import sys
 from pathlib import Path
 
 from _runner_common import register_source_namespace
+from _minimax_h3_pin import verify_pinned_seams
 
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        raise SystemExit("usage: minimax_h3_runtime_probe.py <runtime-dir>")
-    runtime_dir = Path(sys.argv[1]).resolve()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("runtime_dir")
+    parser.add_argument("--verify-seams", action="store_true",
+                        help="also assert the encoder seams PortOS patches (Install / Repair only)")
+    args = parser.parse_args()
+
+    runtime_dir = Path(args.runtime_dir).resolve()
     package_dir = runtime_dir / "minimax_h3_mlx"
     if not (package_dir / "pipeline.py").is_file():
         raise RuntimeError(f"MiniMax H3 runtime source is missing under {runtime_dir}.")
     register_source_namespace("minimax_h3_mlx", package_dir)
     importlib.import_module("minimax_h3_mlx.pipeline")
+    # The bare readiness path keeps this one import: the vision tower's language
+    # model is loaded by every keyframe render, so a checkout that cannot resolve
+    # it is broken for real rather than merely un-patchable.
     importlib.import_module("mlx_vlm.models.qwen3_vl.language")
+    if args.verify_seams:
+        verify_pinned_seams()
     return 0
 
 

--- a/scripts/minimax_h3_runtime_probe.test.js
+++ b/scripts/minimax_h3_runtime_probe.test.js
@@ -1,0 +1,255 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { resolveTestPython } from '../server/lib/testHelper.js';
+import { MINIMAX_H3_EXPECTED_REVISION } from '../server/services/videoGen/runtimes.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = join(here, 'minimax_h3_runtime_probe.py');
+const readScript = (name) => readFileSync(join(here, name), 'utf8');
+
+// Same interpreter probe generate_minimax_h3.test.js explains: a name-only
+// choice passes on a Windows box whose `python` is the Store alias STUB, and
+// then every case dies with an opaque "Command failed".
+const pyBin = resolveTestPython();
+const runPython = (source) => execFileSync(pyBin, ['-c', source, script], { encoding: 'utf8' });
+
+// The probe reaches `_runner_common` and `_minimax_h3_pin` by bare name, which
+// works when Python runs it as a script because the script's own directory
+// lands on sys.path. Loading it through spec_from_file_location does not do
+// that, so the harness has to.
+const importProbe = [
+  'import hashlib, importlib.util, inspect, sys',
+  'from pathlib import Path',
+  'script = Path(sys.argv[1])',
+  'sys.path.insert(0, str(script.parent))',
+  'spec = importlib.util.spec_from_file_location("minimax_h3_runtime_probe", script)',
+  'probe = importlib.util.module_from_spec(spec)',
+  'spec.loader.exec_module(probe)',
+  'pin = sys.modules["_minimax_h3_pin"]',
+  'common = sys.modules["_runner_common"]',
+].join('\n');
+
+// mlx-vlm is a Metal-only dependency that exists solely inside the H3 venv, and
+// the probe reads exactly three attributes off it — so the suite stands in
+// through sys.modules rather than skipping everywhere it isn't installed. The
+// stub SHADOWS a real install too: a stub parent carries no `__path__`, so its
+// submodules are unimportable unless this puts them in sys.modules. That is what
+// makes `drop` work for a whole module as well as for a leaf, and what makes
+// every case behave the same on a dev Mac and in CI.
+const stubMlxVlm = (drop = null) => [
+  'import sys, types',
+  'def _module(name):',
+  '    module = types.ModuleType(name)',
+  '    sys.modules[name] = module',
+  '    return module',
+  'for _name in ["mlx_vlm", "mlx_vlm.models", "mlx_vlm.models.qwen3_vl"]:',
+  '    _module(_name)',
+  '_module("mlx_vlm.utils").sanitize_weights = lambda *a, **k: None',
+  '_module("mlx_vlm.models.qwen3_vl.qwen3_vl").Model = type(',
+  '    "Model", (), {"merge_input_ids_with_image_features": staticmethod(lambda *a, **k: None)})',
+  '_module("mlx_vlm.models.qwen3_vl.language").LanguageModel = type(',
+  '    "LanguageModel", (), {"get_rope_index": staticmethod(lambda *a, **k: None)})',
+  // Built whole, then holed: a `drop` is one `del` against the finished stub
+  // rather than a conditional threaded through every line that builds it.
+  ...(drop ? [`_drop = ${JSON.stringify(drop)}`, [
+    'if _drop in sys.modules:',
+    '    del sys.modules[_drop]',
+    'else:',
+    '    _owner, _, _leaf = _drop.rpartition(".")',
+    '    _parent, _, _attr = _owner.rpartition(".")',
+    '    delattr(sys.modules.get(_owner) or getattr(sys.modules[_parent], _attr), _leaf)',
+  ].join('\n')] : []),
+].join('\n');
+
+// A stand-in for the pinned checkout, on disk: the probe registers the package
+// namespace itself and the encode seam is guarded with `inspect.getsource`, so
+// neither part survives a sys.modules-only fake. Written as ordinary Python text
+// with the merge line spliced in from the SHIPPED constant, so a re-recorded pin
+// can never leave this suite asserting the old one.
+const CHECKOUT_SEAMS = {
+  _wanted: ['    def _wanted(self, key):', '        return key'],
+  processor: ['    @property', '    def processor(self):', '        return None'],
+  _load_weights: ['    def _load_weights(self, model_dir, dtype, verbose):', '        return None'],
+  encode: ['    def encode(self, prompt, images=None):', '        # __MERGE__', '        return None'],
+};
+
+const fakeCheckout = ({ drop = null, plainProcessor = false } = {}) => {
+  const body = Object.entries(CHECKOUT_SEAMS)
+    .filter(([name]) => name !== drop)
+    .flatMap(([name, lines]) => (name === 'processor' && plainProcessor ? lines.slice(1) : lines));
+  const source = ['class MiniMaxH3TextEncoder:', ...body, ''].join('\n');
+  return [
+    'import atexit, shutil, tempfile',
+    'temp = Path(tempfile.mkdtemp())',
+    'atexit.register(shutil.rmtree, temp, True)',
+    'package = temp / "minimax_h3_mlx"',
+    'package.mkdir()',
+    '(package / "pipeline.py").write_text("MiniMaxH3Pipeline = object\\n")',
+    `(package / "text_encoder.py").write_text(${JSON.stringify(source)}.replace(`
+    + '    "__MERGE__", pin.PINNED_BROADCAST_MERGE))',
+  ].join('\n');
+};
+
+// The fake's `encode` is not the pinned one, so its digest has to be recorded
+// before the probe reads it — otherwise every case would fail on the digest and
+// prove nothing about the seam it actually removed. Registering the namespace
+// here is what `probe.main()` does anyway, and it leaves the already-imported
+// module cached for the run under test.
+const recordFakeDigest = [
+  'common.register_source_namespace("minimax_h3_mlx", package)',
+  'from minimax_h3_mlx.text_encoder import MiniMaxH3TextEncoder as Fake',
+  // The dropped-encode case has no body to hash, and does not need one: its
+  // missing-hook check fires before the digest is ever consulted.
+  'if hasattr(Fake, "encode"):',
+  '    pin.PINNED_ENCODE_DIGEST = hashlib.sha256(',
+  '        inspect.getsource(Fake.encode).encode("utf-8")',
+  '    ).hexdigest()',
+].join('\n');
+
+const runProbe = (flags = ['--verify-seams']) => [
+  `sys.argv = ["minimax_h3_runtime_probe.py", str(temp), ${flags.map((f) => JSON.stringify(f)).join(', ')}]`,
+  'try:',
+  '    print("exit", probe.main())',
+  'except RuntimeError as exc:',
+  '    print(str(exc))',
+].filter(Boolean).join('\n');
+
+const seamCase = (opts, flags) => runPython([
+  importProbe, stubMlxVlm(opts.mlxVlmDrop), fakeCheckout(opts), recordFakeDigest, runProbe(flags),
+].join('\n'));
+
+describe.skipIf(!pyBin)('minimax_h3_runtime_probe.py', () => {
+  it('passes a checkout whose every patched seam is still where PortOS left it', () => {
+    expect(seamCase({}).trim()).toBe('exit 0');
+  });
+
+  // The readiness path in server/services/videoGen/runtimes.js runs this probe
+  // BARE, and a false negative there sets byovGateBlocked and disables Generate
+  // for text-only renders too. So a moved seam — which breaks only the keyframe
+  // and substituted-conditioner paths — must not fail the flagless probe.
+  it('ignores a moved seam without --verify-seams, so readiness is unaffected', () => {
+    expect(seamCase({ drop: 'encode' }, []).trim()).toBe('exit 0');
+  });
+
+  // The whole point of the move: each of these used to surface minutes into a
+  // keyframe render (three of the four only on the image-conditioned path),
+  // where the pin bump that caused it was long out of sight.
+  it.each([
+    ['_wanted', /no longer exposes MiniMaxH3TextEncoder\._wanted/],
+    ['processor', /no longer exposes MiniMaxH3TextEncoder\.processor/],
+    ['_load_weights', /no longer exposes MiniMaxH3TextEncoder\._load_weights/],
+    ['encode', /no longer exposes MiniMaxH3TextEncoder\.encode/],
+  ])('fails Install / Repair when the pin dropped %s', (seam, expected) => {
+    expect(seamCase({ drop: seam })).toMatch(expected);
+  });
+
+  // A `processor` that is no longer a property is as much a pin change as an
+  // absent one: the pinned caller would start reading it as a plain attribute,
+  // and the correction binds a property.
+  it('fails Install / Repair when processor is no longer a property', () => {
+    expect(seamCase({ plainProcessor: true })).toMatch(/no longer exposes MiniMaxH3TextEncoder\.processor/);
+  });
+
+  // The merge correction copies the pinned `encode` body rather than wrapping
+  // it, so "the hook is present" is not enough — the body has to be the one that
+  // was copied, and the two ways it can stop being that want opposite fixes.
+  it('fails Install / Repair when the pinned encode body moved under an intact hook', () => {
+    const output = runPython([
+      importProbe, stubMlxVlm(), fakeCheckout(), runProbe(),
+    ].join('\n'));
+    expect(output).toMatch(/changed MiniMaxH3TextEncoder\.encode outside the merge/);
+  });
+
+  it('fails Install / Repair when upstream stopped merging by broadcast', () => {
+    const fixedUpstream = [
+      'source = (package / "text_encoder.py").read_text()',
+      '(package / "text_encoder.py").write_text(',
+      '    source.replace(pin.PINNED_BROADCAST_MERGE, "a real scatter"))',
+    ].join('\n');
+    const output = runPython([
+      importProbe, stubMlxVlm(), fakeCheckout(), fixedUpstream, runProbe(),
+    ].join('\n'));
+    expect(output).toMatch(/no longer merges keyframe embeddings/);
+  });
+
+  // The corrections call these three by name; the probe did not import two of
+  // them at all before, so a locked-mlx-vlm bump could take them away and only
+  // a keyframe render would notice.
+  it.each([
+    ['mlx_vlm.utils', /no longer provides mlx_vlm\.utils/],
+    ['mlx_vlm.utils.sanitize_weights', /no longer exposes mlx_vlm\.utils\.sanitize_weights/],
+    ['mlx_vlm.models.qwen3_vl.qwen3_vl', /no longer provides mlx_vlm\.models\.qwen3_vl\.qwen3_vl/],
+    [
+      'mlx_vlm.models.qwen3_vl.qwen3_vl.Model.merge_input_ids_with_image_features',
+      /no longer exposes mlx_vlm\.models\.qwen3_vl\.qwen3_vl\.Model\.merge_input_ids_with_image_features/,
+    ],
+    [
+      'mlx_vlm.models.qwen3_vl.language.LanguageModel.get_rope_index',
+      /no longer exposes mlx_vlm\.models\.qwen3_vl\.language\.LanguageModel\.get_rope_index/,
+    ],
+  ])('fails Install / Repair when mlx-vlm no longer carries %s', (dotted, expected) => {
+    expect(seamCase({ mlxVlmDrop: dotted })).toMatch(expected);
+  });
+
+  // The one mlx-vlm module the FLAGLESS probe imports as well: losing it is a
+  // broken runtime, not a moved seam, so it fails readiness too — and as an
+  // ImportError from the bare import rather than a seam RuntimeError.
+  it('fails even the flagless probe when mlx-vlm loses the language module', () => {
+    expect(() => runPython([
+      importProbe, stubMlxVlm('mlx_vlm.models.qwen3_vl.language'), fakeCheckout(), runProbe([]),
+    ].join('\n'))).toThrow(/No module named .mlx_vlm.models.qwen3_vl.language./);
+  });
+
+  it('still refuses a runtime directory with no source package at all', () => {
+    const output = runPython([
+      importProbe,
+      'import atexit, shutil, tempfile',
+      'temp = Path(tempfile.mkdtemp())',
+      'atexit.register(shutil.rmtree, temp, True)',
+      runProbe([]),
+    ].join('\n'));
+    expect(output).toMatch(/runtime source is missing/);
+  });
+});
+
+describe('MiniMax H3 pin facts', () => {
+  // The failure this whole mechanism defends against is authored HERE, on a
+  // branch: someone advances MINIMAX_H3_EXPECTED_REVISION and does not re-read
+  // `encode`. Both probe suites overwrite PINNED_ENCODE_DIGEST with a freshly
+  // computed one, so without this the shipped digest is asserted by nothing and
+  // a stale pair ships green. Update this triple in the same commit that moves
+  // the revision — after re-reading the new `encode` and folding whatever
+  // changed into install_vision_embed_merge.
+  it('keeps the recorded encode digest moving with the pinned revision', () => {
+    const pin = readScript('_minimax_h3_pin.py');
+    expect(MINIMAX_H3_EXPECTED_REVISION).toBe('fcd9e9b79a1d6018d91ac477c0968de1fa067e49');
+    expect(pin).toContain(
+      'PINNED_ENCODE_DIGEST = "8047e407e797cd46cd7538024ca09d97402d369d97b1d825757a1590416bda7d"',
+    );
+    expect(pin).toContain(
+      'PINNED_BROADCAST_MERGE = "mx.where(image_mask[..., None], '
+      + 'hidden.astype(inputs_embeds.dtype)[None], inputs_embeds)"',
+    );
+  });
+
+  // PINNED_MLX_VLM_SYMBOLS is a hand-kept mirror of what the corrections import.
+  // A correction that reaches for a fourth symbol would otherwise sail past
+  // Install / Repair and fail mid-render — the exact gap this change closes for
+  // the encoder seams.
+  it('probes every mlx-vlm symbol the corrections import', () => {
+    const covered = new Set(
+      [...readScript('_minimax_h3_pin.py').matchAll(/\("(mlx_vlm[\w.]*)",\s*"([\w.]+)"/g)]
+        .map(([, module, dotted]) => `${module}.${dotted.split('.')[0]}`),
+    );
+    const imported = [...readScript('generate_minimax_h3.py')
+      .matchAll(/^\s*from (mlx_vlm[\w.]*) import (.+)$/gm)]
+      .flatMap(([, module, names]) => names.split(',').map((name) => `${module}.${name.trim()}`));
+    // Bypass probe: an import line that stopped matching would make the
+    // assertion below vacuously true rather than failing.
+    expect(imported.length).toBeGreaterThanOrEqual(3);
+    expect(imported.filter((name) => !covered.has(name))).toEqual([]);
+  });
+});

--- a/scripts/setup-image-video.sh
+++ b/scripts/setup-image-video.sh
@@ -442,8 +442,15 @@ if [[ "$INSTALL_MINIMAX_H3" == "1" ]]; then
   fi
   echo "📦 Syncing pinned MiniMax H3 MLX packages..."
   "$MINIMAX_H3_UV" pip sync --python "$MINIMAX_H3_PY" "$MINIMAX_H3_LOCK"
-  if ! "$MINIMAX_H3_PY" "${SCRIPT_DIR}/minimax_h3_runtime_probe.py" "$MINIMAX_H3_DIR" 2>/dev/null; then
-    echo "❌ MiniMax H3 MLX synced but its pipeline import failed." >&2
+  # --verify-seams is Install/Repair-only strictness: it also asserts the encoder
+  # seams generate_minimax_h3.py patches, which the readiness probe deliberately
+  # skips (a moved seam must not mark a text-only-capable runtime unready). That
+  # message is then the one thing telling a pin bump apart from a broken sync, so
+  # capture stderr instead of discarding it and show the tail — the exception
+  # line, under whatever traceback preceded it.
+  if ! MINIMAX_H3_PROBE_OUT="$("$MINIMAX_H3_PY" "${SCRIPT_DIR}/minimax_h3_runtime_probe.py" "$MINIMAX_H3_DIR" --verify-seams 2>&1)"; then
+    echo "❌ MiniMax H3 MLX synced but its runtime probe failed." >&2
+    printf '%s\n' "$MINIMAX_H3_PROBE_OUT" | tail -n 5 | sed "s/^/   /" >&2
     echo "   Use Repair / Upgrade from the Video Gen runtime panel to retry." >&2
     exit 1
   fi

--- a/server/services/videoGen/runtimes.js
+++ b/server/services/videoGen/runtimes.js
@@ -135,6 +135,13 @@ export const BYOV_RUNTIME_INFO = Object.freeze({
     // The port is source-only rather than pip-installed. The dedicated probe
     // registers only the source package namespace; it never prepends the whole
     // checkout, where an untracked root module could shadow a locked venv dep.
+    // Deliberately WITHOUT the probe's --verify-seams flag: that flag asserts the
+    // encoder seams generate_minimax_h3.py patches, and a moved seam breaks only
+    // the keyframe / substituted-conditioner paths. Failing readiness over it
+    // would set byovGateBlocked and disable Generate for text-only renders too —
+    // the same trap minimax_h3_lora_probe.py is kept a separate probe to avoid.
+    // Install / Repair passes the flag (scripts/setup-image-video.sh), which is
+    // where a pin bump is actionable.
     probeArgs: [MINIMAX_H3_RUNTIME_PROBE_SCRIPT, MINIMAX_H3_REPO_DIR],
     // Separate, OPTIONAL capability probe: can this checkout apply LoRAs to the
     // quantized DiT at runtime? H3's shipped weights are 8-bit, so a LoRA can


### PR DESCRIPTION
## Summary

PortOS patches four adapters onto PipeNetwork's pinned MiniMax H3 MLX text encoder, and each is only correct against the exact implementation it was written for. Those seam guards only fired at **render** time — so whoever bumps `MINIMAX_H3_EXPECTED_REVISION` found out after a cache resolve and a pipeline load, and only on the image-conditioned path three of the four serve.

- The pin facts (`PINNED_BROADCAST_MERGE`, `PINNED_ENCODE_DIGEST`, the seam table, `pinned_encoder_hook`) move to one module, `scripts/_minimax_h3_pin.py`, which the runner and the install probe both import. The digest now has exactly one home — a second copy is a copy that goes stale.
- `minimax_h3_runtime_probe.py --verify-seams` asserts every seam up front: `_wanted` / `processor` (still a `property`) / `_load_weights` / `encode` (still contains the broadcast merge, still hashes to the digest), plus the three mlx-vlm attributes the corrections call — two of which the probe did not import at all before.
- `scripts/setup-image-video.sh` passes the flag and now prints the probe's message instead of discarding stderr. That message is the only thing distinguishing a moved pin from a broken package sync.
- The seam table also collapses the four call sites: each installer now says `pinned_encoder_hook("encode")` and reads its consequence/remedy/shape from the table, so the install-time check cannot drift from the render-time one.

The render-time guards stay as the last line for anyone overriding the pin.

### The flag is deliberately Install/Repair-only

The same script is the readiness probe behind `isByovRuntimeReady`. A failure there sets `byovGateBlocked` and disables Generate outright — but a moved seam breaks only the keyframe and substituted-conditioner paths, so failing readiness over it would block text-only renders that still work, and offer Repair as the remedy, which re-runs the same probe. That is precisely the trap `minimax_h3_lora_probe.py` is kept a separate probe to avoid:

> Kept separate from minimax_h3_runtime_probe.py so a runtime that is perfectly healthy for plain renders is never marked unready just because it predates the LoRA applicator.

No coverage is lost: a pin bump reaches Install/Repair anyway, because a moved revision already fails `isByovRuntimeCurrent`, and a re-locked mlx-vlm needs a re-sync.

### Two drift guards for gaps this exposed

- **The shipped digest must move with the pinned revision.** Both probe suites overwrite `PINNED_ENCODE_DIGEST` with a freshly computed one, so nothing asserted the *shipped* value — a revision bump with a stale digest would have passed every test and shipped green. Same co-movement shape as `PROMPT_VERSIONS` / `PREVIOUS_DEFAULT_PROMPTS`.
- **Every mlx-vlm symbol the corrections import must be in the probed set**, so a correction reaching for a fourth one can't sail past Install/Repair and fail mid-render.

Closes #4606. Filed #4619 for the related-but-separate sweep: 14 other install probes in `setup-image-video.sh` still discard their traceback.

## Test plan

- `scripts/minimax_h3_runtime_probe.test.js` — new, 18 cases. A checkout with every seam intact passes; each seam individually dropped (and `processor` demoted from a property) fails Install/Repair with its own message; an `encode` body that moved under an intact hook, and one where upstream stopped merging by broadcast, fail with the two opposite remedies; each mlx-vlm module/attribute dropped fails by name. One case asserts the **flagless** probe still exits 0 with a moved seam, which is the readiness-gate regression this guards.
- The fixture builds a real on-disk package (the encode seam is guarded with `inspect.getsource`, so a `sys.modules`-only fake won't do) and splices the merge line in from the shipped constant, so a re-recorded pin can't leave the suite asserting the old one.
- Guards verified non-vacuous by deliberately breaking each: neutering `verify_pinned_seams()` → 12 failures; bumping the revision without re-recording the digest → co-movement test fails; adding an unprobed `from mlx_vlm.newthing import Widget` to the runner → import-drift test fails.
- `scripts/generate_minimax_h3.test.js` (45 cases) retargeted at the constants' new home and still green.
- Full server suite: 1489 files, 30,794 tests passing. `bash -n scripts/setup-image-video.sh` clean.
