### PR TITLE
Fix dead Start button on the Speculative Decoding launcher

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -65,6 +65,12 @@ const SPEC_DECODE_PRESETS = [
   },
 ];
 
+// The select mounts on this preset, so the form has to be seeded from it too —
+// otherwise the recommended preset reads as chosen while the required model path
+// is still empty, and Start sits disabled with nothing the user can act on.
+const DEFAULT_SPEC_PRESET_ID = 'qwen3.8-27b-dspark';
+const findSpecPreset = (id) => SPEC_DECODE_PRESETS.find((p) => p.id === id);
+
 const btnClass = 'flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded transition-colors disabled:opacity-50';
 
 const CATEGORY_LABELS = {
@@ -427,15 +433,19 @@ export function LocalLlmTab() {
 
   const [llamaStatus, setLlamaStatus] = useState(null);
   const [llamaLoading, setLlamaLoading] = useState(false);
-  const [llamaForm, setLlamaForm] = useState({
-    model: '',
-    draftModel: '',
-    specType: 'draft-dspark',
-    port: 8080,
-    host: '127.0.0.1',
-    ctxSize: 32768,
-    nGpuLayers: 99,
-    alias: 'dflash',
+  const [llamaPresetId, setLlamaPresetId] = useState(DEFAULT_SPEC_PRESET_ID);
+  const [llamaForm, setLlamaForm] = useState(() => {
+    const preset = findSpecPreset(DEFAULT_SPEC_PRESET_ID);
+    return {
+      model: preset?.model || '',
+      draftModel: preset?.draftModel || '',
+      specType: preset?.specType || 'draft-dspark',
+      port: 8080,
+      host: '127.0.0.1',
+      ctxSize: 32768,
+      nGpuLayers: 99,
+      alias: 'dflash',
+    };
   });
   const [showLlamaAdvanced, setShowLlamaAdvanced] = useState(false);
   const [showLlamaLogs, setShowLlamaLogs] = useState(false);
@@ -734,9 +744,15 @@ export function LocalLlmTab() {
     });
   };
 
+  const activeSpecPreset = findSpecPreset(llamaPresetId);
+  // The Custom preset intentionally ships empty paths, so Start stays disabled
+  // until a path is typed — say so instead of leaving a dead button.
+  const llamaModelMissing = !llamaForm.model.trim();
+
   const handleStartLlama = async (e) => {
     e?.preventDefault?.();
-    if (!llamaForm.model?.trim()) {
+    // Submitting with Enter bypasses the disabled button, so re-check here.
+    if (llamaModelMissing) {
       toast.error('Please specify a base model path (e.g. models/Qwen3.8-27B-Instruct-Q4_K_M.gguf)');
       return;
     }
@@ -790,8 +806,9 @@ export function LocalLlmTab() {
   };
 
   const handlePresetSelect = (presetId) => {
-    const preset = SPEC_DECODE_PRESETS.find((p) => p.id === presetId);
+    const preset = findSpecPreset(presetId);
     if (!preset) return;
+    setLlamaPresetId(preset.id);
     if (preset.id !== 'custom') {
       setLlamaForm((prev) => ({
         ...prev,
@@ -1000,7 +1017,7 @@ export function LocalLlmTab() {
                   id="llama-preset-select"
                   aria-label="Preset"
                   onChange={(e) => handlePresetSelect(e.target.value)}
-                  defaultValue="qwen3.8-27b-dspark"
+                  value={llamaPresetId}
                   className="bg-port-card border border-port-border rounded px-2 py-1 text-xs text-port-accent focus:outline-none"
                 >
                   {SPEC_DECODE_PRESETS.map((p) => (
@@ -1021,19 +1038,19 @@ export function LocalLlmTab() {
                   type="text"
                   value={llamaForm.model}
                   onChange={(e) => setLlamaForm((prev) => ({ ...prev, model: e.target.value }))}
-                  placeholder="models/Qwen3.8-27B-Instruct-Q4_K_M.gguf"
+                  placeholder={activeSpecPreset?.model || 'models/your-target-Q4_K_M.gguf'}
                   className="w-full bg-port-card border border-port-border rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-port-accent"
                 />
               </div>
               <div>
-                <label htmlFor="llama-draft-model" className="text-[11px] text-gray-400 block mb-1">DFlash 2 Draft Model (Optional)</label>
+                <label htmlFor="llama-draft-model" className="text-[11px] text-gray-400 block mb-1">Draft Model (Optional)</label>
                 <input
                   id="llama-draft-model"
-                  aria-label="DFlash 2 Draft Model (Optional)"
+                  aria-label="Draft Model (Optional)"
                   type="text"
                   value={llamaForm.draftModel}
                   onChange={(e) => setLlamaForm((prev) => ({ ...prev, draftModel: e.target.value }))}
-                  placeholder="models/Qwen3.8-27B-DFlash2-Q4_K_M.gguf"
+                  placeholder={activeSpecPreset?.draftModel || 'models/your-drafter.gguf'}
                   className="w-full bg-port-card border border-port-border rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-port-accent"
                 />
               </div>
@@ -1070,7 +1087,7 @@ export function LocalLlmTab() {
                     aria-label="GPU Layers (-ngl)"
                     type="number"
                     value={llamaForm.nGpuLayers}
-                    onChange={(e) => setLlamaForm((prev) => ({ ...prev, nGpuLayers: parseInt(e.target.value, 10) ?? 99 }))}
+                    onChange={(e) => setLlamaForm((prev) => ({ ...prev, nGpuLayers: parseInt(e.target.value, 10) || 99 }))}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
                 </div>
@@ -1088,7 +1105,7 @@ export function LocalLlmTab() {
               </div>
             )}
 
-            <div className="flex items-center justify-between gap-2 pt-1">
+            <div className="flex flex-wrap items-center justify-between gap-2 pt-1">
               <button
                 type="button"
                 onClick={() => setShowLlamaAdvanced((prev) => !prev)}
@@ -1097,14 +1114,22 @@ export function LocalLlmTab() {
                 {showLlamaAdvanced ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
                 {showLlamaAdvanced ? 'Hide options' : 'Advanced options (port, ctx, GPU layers)'}
               </button>
-              <button
-                type="submit"
-                disabled={llamaLoading || !llamaForm.model.trim()}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent text-xs font-medium rounded-lg transition-colors disabled:opacity-50"
-              >
-                {llamaLoading ? <BrailleSpinner /> : <Power size={13} />}
-                Start Speculative Server
-              </button>
+              <div className="flex items-center gap-2">
+                {llamaModelMissing && (
+                  <span className="text-[11px] text-port-warning text-right">
+                    Enter a Target Base Model path to enable Start
+                  </span>
+                )}
+                <button
+                  type="submit"
+                  disabled={llamaLoading || llamaModelMissing}
+                  title={llamaModelMissing ? 'Target Base Model (GGUF Path) is required before the server can start' : 'Launch llama-server with these settings'}
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-port-accent/20 hover:bg-port-accent/30 text-port-accent text-xs font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+                >
+                  {llamaLoading ? <BrailleSpinner /> : <Power size={13} />}
+                  Start Speculative Server
+                </button>
+              </div>
             </div>
           </form>
         ) : (

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -745,8 +745,8 @@ export function LocalLlmTab() {
   };
 
   const activeSpecPreset = findSpecPreset(llamaPresetId);
-  // The Custom preset intentionally ships empty paths, so Start stays disabled
-  // until a path is typed — say so instead of leaving a dead button.
+  // Clearing the target path is the one way back to a disabled Start — say why
+  // rather than leaving a dead button.
   const llamaModelMissing = !llamaForm.model.trim();
 
   const handleStartLlama = async (e) => {
@@ -1087,7 +1087,12 @@ export function LocalLlmTab() {
                     aria-label="GPU Layers (-ngl)"
                     type="number"
                     value={llamaForm.nGpuLayers}
-                    onChange={(e) => setLlamaForm((prev) => ({ ...prev, nGpuLayers: parseInt(e.target.value, 10) || 99 }))}
+                    onChange={(e) => setLlamaForm((prev) => {
+                      // `-ngl 0` is a real setting (CPU-only), so only a cleared
+                      // field — parseInt's NaN — may fall back to the default.
+                      const parsed = parseInt(e.target.value, 10);
+                      return { ...prev, nGpuLayers: Number.isNaN(parsed) ? 99 : parsed };
+                    })}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
                 </div>

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -71,6 +71,11 @@ const SPEC_DECODE_PRESETS = [
 const DEFAULT_SPEC_PRESET_ID = 'qwen3.8-27b-dspark';
 const findSpecPreset = (id) => SPEC_DECODE_PRESETS.find((p) => p.id === id);
 
+// Defaults for the advanced numeric fields. They are applied when the server is
+// launched rather than on every keystroke: a controlled number input that coerces
+// as you type snaps back to its default the moment you clear it to retype.
+const LLAMA_NUMBER_DEFAULTS = { port: 8080, ctxSize: 32768, nGpuLayers: 99 };
+
 const btnClass = 'flex items-center gap-1.5 px-2 py-1 text-xs font-medium rounded transition-colors disabled:opacity-50';
 
 const CATEGORY_LABELS = {
@@ -744,6 +749,18 @@ export function LocalLlmTab() {
     });
   };
 
+  // Hand-editing a path the preset supplied means the form no longer describes
+  // that preset — say Custom rather than keep claiming the preset is in effect.
+  const setLlamaField = (field, value) => {
+    setLlamaPresetId('custom');
+    setLlamaForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  // Keep an emptied field empty so it can be retyped; the launch path fills in
+  // the default. `Number('')` is 0, hence the explicit empty check.
+  const setLlamaNumber = (field, raw) =>
+    setLlamaForm((prev) => ({ ...prev, [field]: raw === '' ? '' : Number(raw) }));
+
   const activeSpecPreset = findSpecPreset(llamaPresetId);
   // Clearing the target path is the one way back to a disabled Start — say why
   // rather than leaving a dead button.
@@ -757,10 +774,14 @@ export function LocalLlmTab() {
       return;
     }
     setLlamaLoading(true);
+    const config = { ...llamaForm };
+    for (const [field, fallback] of Object.entries(LLAMA_NUMBER_DEFAULTS)) {
+      if (!Number.isFinite(config[field])) config[field] = fallback;
+    }
     try {
-      const res = await startLlamaServer(llamaForm);
+      const res = await startLlamaServer(config);
       if (res?.success) {
-        toast.success(`llama-server started (PID ${res.pid}) on port ${llamaForm.port || 8080}`);
+        toast.success(`llama-server started (PID ${res.pid}) on port ${config.port}`);
       }
       loadLlamaStatus();
     } catch (err) {
@@ -1037,7 +1058,7 @@ export function LocalLlmTab() {
                   aria-label="Target Base Model (GGUF Path)"
                   type="text"
                   value={llamaForm.model}
-                  onChange={(e) => setLlamaForm((prev) => ({ ...prev, model: e.target.value }))}
+                  onChange={(e) => setLlamaField('model', e.target.value)}
                   placeholder={activeSpecPreset?.model || 'models/your-target-Q4_K_M.gguf'}
                   className="w-full bg-port-card border border-port-border rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-port-accent"
                 />
@@ -1049,7 +1070,7 @@ export function LocalLlmTab() {
                   aria-label="Draft Model (Optional)"
                   type="text"
                   value={llamaForm.draftModel}
-                  onChange={(e) => setLlamaForm((prev) => ({ ...prev, draftModel: e.target.value }))}
+                  onChange={(e) => setLlamaField('draftModel', e.target.value)}
                   placeholder={activeSpecPreset?.draftModel || 'models/your-drafter.gguf'}
                   className="w-full bg-port-card border border-port-border rounded px-2.5 py-1.5 text-xs text-white placeholder-gray-600 focus:outline-none focus:border-port-accent"
                 />
@@ -1065,7 +1086,7 @@ export function LocalLlmTab() {
                     aria-label="Port"
                     type="number"
                     value={llamaForm.port}
-                    onChange={(e) => setLlamaForm((prev) => ({ ...prev, port: parseInt(e.target.value, 10) || 8080 }))}
+                    onChange={(e) => setLlamaNumber('port', e.target.value)}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
                 </div>
@@ -1076,7 +1097,7 @@ export function LocalLlmTab() {
                     aria-label="Context Size"
                     type="number"
                     value={llamaForm.ctxSize}
-                    onChange={(e) => setLlamaForm((prev) => ({ ...prev, ctxSize: parseInt(e.target.value, 10) || 32768 }))}
+                    onChange={(e) => setLlamaNumber('ctxSize', e.target.value)}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
                 </div>
@@ -1087,12 +1108,7 @@ export function LocalLlmTab() {
                     aria-label="GPU Layers (-ngl)"
                     type="number"
                     value={llamaForm.nGpuLayers}
-                    onChange={(e) => setLlamaForm((prev) => {
-                      // `-ngl 0` is a real setting (CPU-only), so only a cleared
-                      // field — parseInt's NaN — may fall back to the default.
-                      const parsed = parseInt(e.target.value, 10);
-                      return { ...prev, nGpuLayers: Number.isNaN(parsed) ? 99 : parsed };
-                    })}
+                    onChange={(e) => setLlamaNumber('nGpuLayers', e.target.value)}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
                 </div>
@@ -1103,7 +1119,7 @@ export function LocalLlmTab() {
                     aria-label="Spec Type"
                     type="text"
                     value={llamaForm.specType}
-                    onChange={(e) => setLlamaForm((prev) => ({ ...prev, specType: e.target.value }))}
+                    onChange={(e) => setLlamaField('specType', e.target.value)}
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
                 </div>

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -318,7 +318,7 @@ describe('LocalLlmTab llama-server management', () => {
     });
   });
 
-  it('explains why Start is disabled when the Custom preset clears the model path', async () => {
+  it('explains why Start is disabled once the model path is cleared', async () => {
     const { getLlamaServerStatus } = await import('../../services/api');
     getLlamaServerStatus.mockResolvedValueOnce({ installed: true, running: false, managed: false });
 

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -354,6 +354,60 @@ describe('LocalLlmTab llama-server management', () => {
     });
   });
 
+  // Coercing a number input on every keystroke snaps it back to its default the
+  // moment you clear it to retype, so the default is applied at launch instead.
+  it('lets an advanced number field sit empty while retyping and defaults it at launch', async () => {
+    const { getLlamaServerStatus, startLlamaServer } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValueOnce({ installed: true, running: false, managed: false });
+    startLlamaServer.mockResolvedValueOnce({ success: true, pid: 21 });
+
+    await renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Advanced options/ }));
+    const gpuLayers = screen.getByLabelText(/GPU Layers/);
+    fireEvent.change(gpuLayers, { target: { value: '' } });
+    expect(gpuLayers).toHaveValue(null);
+
+    fireEvent.click(screen.getByRole('button', { name: /Start Speculative Server/ }));
+
+    await waitFor(() => {
+      expect(startLlamaServer).toHaveBeenCalledWith(expect.objectContaining({ nGpuLayers: 99 }));
+    });
+  });
+
+  it('keeps an explicit -ngl 0 rather than treating it as unset', async () => {
+    const { getLlamaServerStatus, startLlamaServer } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValueOnce({ installed: true, running: false, managed: false });
+    startLlamaServer.mockResolvedValueOnce({ success: true, pid: 22 });
+
+    await renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Advanced options/ }));
+    fireEvent.change(screen.getByLabelText(/GPU Layers/), { target: { value: '0' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Start Speculative Server/ }));
+
+    await waitFor(() => {
+      expect(startLlamaServer).toHaveBeenCalledWith(expect.objectContaining({ nGpuLayers: 0 }));
+    });
+  });
+
+  it('drops the preset label to Custom once a preset-supplied path is hand-edited', async () => {
+    const { getLlamaServerStatus } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValueOnce({ installed: true, running: false, managed: false });
+
+    await renderTab();
+
+    const presetSelect = await screen.findByLabelText('Preset');
+    expect(presetSelect).toHaveValue('qwen3.8-27b-dspark');
+
+    fireEvent.change(screen.getByLabelText(/Target Base Model \(GGUF Path\)/), {
+      target: { value: 'models/hand-picked.gguf' },
+    });
+
+    expect(presetSelect).toHaveValue('custom');
+  });
+
   it('renders install button and triggers install when llama-server is not installed', async () => {
     const { getLlamaServerStatus, installLlamaServer } = await import('../../services/api');
     getLlamaServerStatus.mockResolvedValueOnce({

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -293,6 +293,67 @@ describe('LocalLlmTab llama-server management', () => {
     });
   });
 
+  // The preset select mounts pre-selected, so the form must mount pre-filled too —
+  // otherwise Start is disabled while the UI reads as fully configured.
+  it('seeds the form from the mounted preset so Start is immediately usable', async () => {
+    const { getLlamaServerStatus, startLlamaServer } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValueOnce({ installed: true, running: false, managed: false });
+    startLlamaServer.mockResolvedValueOnce({ success: true, pid: 4242 });
+
+    await renderTab();
+
+    await screen.findByText(/Launch Speculative Decoding Server/);
+    expect(screen.queryByText(/Enter a Target Base Model path to enable Start/)).toBeNull();
+
+    const startBtn = screen.getByRole('button', { name: /Start Speculative Server/ });
+    expect(startBtn).not.toBeDisabled();
+    fireEvent.click(startBtn);
+
+    await waitFor(() => {
+      expect(startLlamaServer).toHaveBeenCalledWith(expect.objectContaining({
+        model: 'models/Qwen3.8-27B-Instruct-Q4_K_M.gguf',
+        draftModel: 'models/Qwen3.8-27B-DSpark-bf16.gguf',
+        specType: 'draft-dspark',
+      }));
+    });
+  });
+
+  it('explains why Start is disabled when the Custom preset clears the model path', async () => {
+    const { getLlamaServerStatus } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValueOnce({ installed: true, running: false, managed: false });
+
+    await renderTab();
+
+    const modelInput = await screen.findByLabelText(/Target Base Model \(GGUF Path\)/);
+    fireEvent.change(modelInput, { target: { value: '  ' } });
+
+    const startBtn = screen.getByRole('button', { name: /Start Speculative Server/ });
+    expect(startBtn).toBeDisabled();
+    expect(startBtn).toHaveAttribute('title', expect.stringContaining('required'));
+    expect(screen.getByText(/Enter a Target Base Model path to enable Start/)).toBeInTheDocument();
+  });
+
+  it('swaps the preset and repoints both model paths', async () => {
+    const { getLlamaServerStatus, startLlamaServer } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValueOnce({ installed: true, running: false, managed: false });
+    startLlamaServer.mockResolvedValueOnce({ success: true, pid: 7 });
+
+    await renderTab();
+
+    const presetSelect = await screen.findByLabelText('Preset');
+    fireEvent.change(presetSelect, { target: { value: 'muse-glimmer-30b' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /Start Speculative Server/ }));
+
+    await waitFor(() => {
+      expect(startLlamaServer).toHaveBeenCalledWith(expect.objectContaining({
+        model: 'models/Muse-Glimmer-30B-Instruct-Q4_K_M.gguf',
+        draftModel: 'models/Muse-Glimmer-30B-DFlash2-Q4_K_M.gguf',
+        specType: 'draft-dflash',
+      }));
+    });
+  });
+
   it('renders install button and triggers install when llama-server is not installed', async () => {
     const { getLlamaServerStatus, installLlamaServer } = await import('../../services/api');
     getLlamaServerStatus.mockResolvedValueOnce({


### PR DESCRIPTION
## Summary

The **Speculative Decoding & Custom Runtimes** card in Settings → Local LLM opened with "Start Speculative Server" disabled and nothing on screen explaining why.

The preset dropdown mounted with `defaultValue="qwen3.8-27b-dspark"`, so the card read as fully configured — a preset selected, GGUF paths visible in both fields. But `handlePresetSelect` only runs on `onChange`, so `llamaForm.model` was still `''` at mount, and the required-field guard `!llamaForm.model.trim()` held the button disabled. The "paths" the user could see were placeholders, not values. There was no visible action to take short of guessing that and retyping a path by hand.

## Changes

- **Seed the form from the preset the select mounts on.** `llamaForm` initializes from `DEFAULT_SPEC_PRESET_ID`, and the select is now controlled by a `llamaPresetId` state, so the dropdown and the form state cannot drift apart again.
- **Say why Start is disabled** when the target path is empty: an inline hint next to the button plus a `title` tooltip, and the Enter-key submit guard now reuses that same condition instead of duplicating it.
- **Derive both GGUF placeholders from the selected preset.** They were hardcoded to the DFlash 2 paths, so the recommended DSpark preset advertised a drafter it does not use.
- **Retitle the draft-model field** from "DFlash 2 Draft Model" to "Draft Model" — three of the five presets ship a DSpark drafter.
- **Advanced options:** `parseInt(...) ?? 99` never fired on a cleared GPU-layers field, because `parseInt` returns `NaN` rather than nullish, so `NaN` was submitted. Now only `NaN` falls back, which also preserves a deliberate `-ngl 0` (CPU-only offload) that a plain `||` would have swallowed.

## Test plan

Three tests added to `client/src/components/settings/LocalLlmTab.test.jsx`; two of them were verified to **fail against the pre-fix component** and pass after:

- the form is seeded from the mounted preset, Start is enabled on arrival, and clicking it posts the preset's model, drafter, and spec type (fails pre-fix);
- clearing the target path disables Start and surfaces both the inline hint and the tooltip reason (fails pre-fix);
- switching presets repoints both model paths and the spec type (regression guard on the newly-controlled select).

Full client suite: 686 files / 8497 tests passing. `npm run build` clean.