### PR TITLE
harden BYOV probe logging: a normal LoRA verdict is not a failure

### DIFF
--- a/server/services/videoGen/runtimes.js
+++ b/server/services/videoGen/runtimes.js
@@ -316,32 +316,81 @@ export async function isByovRuntimeReady(runtimeId) {
   // earlier successful probe.
   if (info.expectedRevision && !await isByovRuntimeCurrent(runtimeId)) return false;
   if (readyCache.get(runtimeId) === true) return true;
-  const probeOk = await runVenvProbe(info.venvPython, info.probeArgs || ['-c', info.importProbe]);
+  const probeOk = await runVenvProbe(
+    info.venvPython, info.probeArgs || ['-c', info.importProbe], `${runtimeId} readiness`,
+  );
   if (probeOk) readyCache.set(runtimeId, true);
   return probeOk;
 }
 
+// How much probe stderr to retain. The probes emit single diagnostic lines, so
+// a few KB is generous; an unbounded buffer on a child that wedges mid-spew is
+// its own failure mode. The TAIL is what we keep — Python prints the exception
+// last, under whatever traceback preceded it.
 const VENV_PROBE_STDERR_LIMIT = 4096;
 
+// Collapse captured probe stderr to one log line. An empty capture reports
+// itself explicitly rather than shortening the message: "the probe failed and
+// said nothing" must not read like "the probe was never run".
+const summarizeProbeStderr = (stderr) => stderr.replace(/\s+/g, ' ').trim() || '(no stderr output)';
+
 // Spawn one boolean probe in a BYOV venv. Bounded (30s SIGKILL) so a wedged
-// import can't pin a request open; any spawn/exit failure is `false`.
-function runVenvProbe(venvPython, args) {
+// import can't pin a request open; any spawn/exit/timeout failure is `false`.
+//
+// stderr is piped and echoed on every negative outcome because it is the only
+// channel these probes have: they name the exact import or seam that broke.
+// The resolve contract stays a boolean — the reason goes to the log, not the
+// return value. stdout stays ignored deliberately: nothing reads it, and an
+// unread pipe can fill and block the child.
+//
+// Two negative outcomes, deliberately different icons: a non-zero exit is the
+// probe ANSWERING — for the LoRA probe, "this checkout has no applicator" is
+// the documented normal verdict (see scripts/minimax_h3_lora_probe.py), cached
+// as a legitimate `false` — while a spawn error or timeout means it never
+// answered at all. Calling the first one a failure cries wolf on every healthy
+// install that predates the applicator.
+//
+// `label` names the runtime and which probe ran, so a status request that fans
+// out over several runtimes produces attributable lines. It must never carry a
+// filesystem path — venv paths embed the OS username.
+function runVenvProbe(venvPython, args, label) {
   return new Promise((resolve) => {
     let stderr = '';
+    let settled = false;
+    let timer = null;
+    const finish = (ok, icon, outcome) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (!ok) console.error(`${icon} ${label} probe ${outcome}: ${summarizeProbeStderr(stderr)}`);
+      resolve(ok);
+    };
     const child = spawn(venvPython, args, safeChildProcessOptions({
       stdio: ['ignore', 'ignore', 'pipe'],
     }));
-    child.stderr.on('data', (chunk) => {
-      stderr = `${stderr}${chunk}`.slice(-VENV_PROBE_STDERR_LIMIT);
-    });
-    const timer = setTimeout(() => { if (!child.killed) child.kill('SIGKILL'); resolve(false); }, 30000);
-    child.on('close', (code) => {
-      clearTimeout(timer);
-      const detail = stderr.trim().replace(/\s+/g, ' ');
-      if (code !== 0 && detail) console.error(`❌ BYOV runtime probe failed: ${detail}`);
-      resolve(code === 0);
-    });
-    child.on('error', () => { clearTimeout(timer); resolve(false); });
+    // Decode as text on the stream, so a multi-byte character split across two
+    // chunks survives rather than becoming U+FFFD. Slice per chunk, not once at
+    // the end: that is what bounds the buffer.
+    child.stderr?.setEncoding?.('utf8');
+    child.stderr?.on('data', (chunk) => { stderr = `${stderr}${chunk}`.slice(-VENV_PROBE_STDERR_LIMIT); });
+    // These handlers run outside the request lifecycle, where a throw would
+    // take the process down. Nothing in them can throw today, and nothing that
+    // can may be added without its own guard.
+    //
+    // The timeout settles on the kill rather than waiting for `close`: the 30s
+    // ceiling on the caller is the whole point of the timer, and stderr is
+    // drained as it arrives, so what we hold is already everything the child
+    // flushed.
+    timer = setTimeout(() => {
+      if (!child.killed) child.kill('SIGKILL');
+      finish(false, '❌', 'timed out after 30s');
+    }, 30000);
+    child.on('close', (code, signal) => finish(
+      code === 0, '⚠️', signal ? `was killed by ${signal}` : `exited ${code}`,
+    ));
+    // Node's spawn-error message interpolates the full interpreter path, which
+    // embeds the OS username — the code alone says what went wrong.
+    child.on('error', (err) => finish(false, '❌', `could not be spawned (${err?.code || 'unknown error'})`));
   });
 }
 
@@ -369,7 +418,7 @@ export async function resolveByovRuntimeLoraCapable(runtimeId) {
   if (cached !== undefined) return cached;
   if (!existsSync(info.venvPython)) return false;
   return loraProbeFlight.run(runtimeId, async () => {
-    const capable = await runVenvProbe(info.venvPython, info.loraProbeArgs);
+    const capable = await runVenvProbe(info.venvPython, info.loraProbeArgs, `${runtimeId} LoRA-capability`);
     loraCapabilityCache.set(runtimeId, capable);
     return capable;
   });

--- a/server/services/videoGen/runtimes.test.js
+++ b/server/services/videoGen/runtimes.test.js
@@ -40,16 +40,28 @@ const statusChild = (stdout) => {
   return child;
 };
 
-// Boolean probe child (no stdout), for the LoRA capability probe.
+// Boolean venv-probe child. stdout is never piped by runVenvProbe, so this has
+// none; stderr is, because that is where the probes write their diagnostics.
 const exitChild = (code, stderr = '') => {
   const child = new EventEmitter();
-  child.stderr = new EventEmitter();
+  child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
   child.kill = vi.fn();
   queueMicrotask(() => {
-    if (stderr) child.stderr.emit('data', Buffer.from(stderr));
+    // The real stream is switched to utf8, so it hands over decoded strings.
+    if (stderr) child.stderr.emit('data', stderr);
     child.emit('close', code);
   });
   return child;
+};
+
+// Run `probe`, returning every console.error line it produced. Spying rather
+// than asserting on a mock keeps the real console quiet during the suite.
+const captureProbeLogs = async (probe) => {
+  const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const result = await probe();
+  const lines = spy.mock.calls.map(([line]) => line);
+  spy.mockRestore();
+  return { result, lines };
 };
 
 beforeEach(() => {
@@ -92,6 +104,78 @@ describe('isByovRuntimeReady', () => {
   });
 });
 
+describe('venv probe diagnostics', () => {
+  it('pipes stderr (never stdout) and logs the failing probe’s own diagnostic', async () => {
+    runtimeMocks.spawn.mockImplementationOnce(() => exitChild(
+      1, 'ModuleNotFoundError: No module named "diffusers.modular_pipelines.minimax_h3"\n',
+    ));
+
+    const { result, lines } = await captureProbeLogs(() => isByovRuntimeReady('minimax_h3_cuda'));
+
+    expect(result).toBe(false);
+    expect(runtimeMocks.spawn.mock.calls[0][2].stdio).toEqual(['ignore', 'ignore', 'pipe']);
+    // Decoding on the stream is what keeps a multi-byte character split across
+    // two chunks from arriving as U+FFFD.
+    expect(runtimeMocks.spawn.mock.results[0].value.stderr.setEncoding).toHaveBeenCalledWith('utf8');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('minimax_h3_cuda readiness');
+    expect(lines[0]).toContain('exited 1');
+    expect(lines[0]).toContain('No module named "diffusers.modular_pipelines.minimax_h3"');
+    expect(lines[0]).not.toContain('\n');
+  });
+
+  it('says so explicitly when a failing probe wrote nothing at all', async () => {
+    runtimeMocks.spawn.mockImplementationOnce(() => exitChild(1));
+
+    const { result, lines } = await captureProbeLogs(() => isByovRuntimeReady('minimax_h3_cuda'));
+
+    // "Failed and said nothing" must not go silent — that reads identically to
+    // "the probe never ran", which is the state this whole change removes.
+    expect(result).toBe(false);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('exited 1');
+    expect(lines[0]).toContain('no stderr output');
+  });
+
+  it('logs and resolves false when the venv python cannot be spawned', async () => {
+    runtimeMocks.spawn.mockImplementationOnce(() => {
+      const child = new EventEmitter();
+      child.stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+      child.kill = vi.fn();
+      // Node's real message interpolates the interpreter path, as here.
+      const err = Object.assign(new Error('spawn /home/example/.portos/x/.venv/bin/python3 ENOENT'), {
+        code: 'ENOENT',
+      });
+      queueMicrotask(() => child.emit('error', err));
+      return child;
+    });
+
+    const { result, lines } = await captureProbeLogs(() => isByovRuntimeReady('minimax_h3_cuda'));
+
+    expect(result).toBe(false);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('could not be spawned (ENOENT)');
+    // The label already says which runtime this was; the venv path would only
+    // add the OS username to the log.
+    expect(lines[0]).not.toContain('/home/example');
+  });
+
+  it('attributes the line to the LoRA probe without calling its verdict a fault', async () => {
+    runtimeMocks.spawn.mockImplementationOnce(() => exitChild(
+      1, 'ModuleNotFoundError: No module named "minimax_h3_mlx.lora"\n',
+    ));
+
+    const { result, lines } = await captureProbeLogs(() => resolveByovRuntimeLoraCapable('minimax_h3'));
+
+    // A checkout with no applicator is the documented normal answer, not a
+    // broken install — so the reason is surfaced, but not under the failure icon.
+    expect(result).toBe(false);
+    expect(lines[0]).toContain('minimax_h3 LoRA-capability');
+    expect(lines[0]).toContain('No module named "minimax_h3_mlx.lora"');
+    expect(lines[0].startsWith('❌')).toBe(false);
+  });
+});
+
 // H3's DiT is quantized, so whether a LoRA can ride along is a property of the
 // installed checkout, not the model entry — hence a probe rather than a
 // hardcoded predicate. The gate must fail CLOSED until that probe has answered.
@@ -104,7 +188,10 @@ describe('MiniMax H3 LoRA capability', () => {
 
   it('reports not capable when the pinned checkout has no LoRA applicator', async () => {
     runtimeMocks.spawn.mockImplementationOnce(() => exitChild(1));
-    await expect(resolveByovRuntimeLoraCapable('minimax_h3')).resolves.toBe(false);
+    // Captured, not asserted on: the verdict now writes a line, and letting it
+    // through would print a scary-looking probe log during an unrelated test.
+    const { result } = await captureProbeLogs(() => resolveByovRuntimeLoraCapable('minimax_h3'));
+    expect(result).toBe(false);
     expect(byovRuntimeLoraCapable('minimax_h3')).toBe(false);
   });
 
@@ -121,7 +208,8 @@ describe('MiniMax H3 LoRA capability', () => {
     expect(runtimeMocks.spawn.mock.calls[0][2].stdio).toEqual(['ignore', 'ignore', 'pipe']);
     expect(message).toContain('missing quant-aware applicator');
     expect(message).not.toContain('\n');
-    expect(message.length).toBeLessThanOrEqual(4096 + '❌ BYOV runtime probe failed: '.length);
+    // Bound the retained tail, not the label prefix, which varies per runtime.
+    expect(message.length).toBeLessThanOrEqual(4096 + 128);
   });
 
   it('caches both outcomes so the probe runs once per process', async () => {


### PR DESCRIPTION
Follow-up to #4622, which landed the core of #4618 (piping the probe's stderr). This fixes four cases its logging still gets wrong.

## What's wrong today

- **A normal verdict is reported as a failure.** `runVenvProbe` serves two callers with opposite meanings for a non-zero exit. For `isByovRuntimeReady` it's a fault; for the LoRA-capability probe it's the *documented normal answer* — `scripts/minimax_h3_lora_probe.py` says any non-zero exit means "this checkout has no applicator", and the result is cached as a legitimate `false`. Every healthy H3 install predating the applicator currently logs `❌ BYOV runtime probe failed: Traceback… ModuleNotFoundError`.
- **A failure with empty stderr logs nothing**, which reads identically to "never probed" — the exact sentinel-vs-empty case `CLAUDE.md` calls out.
- **The spawn-error and timeout paths are still silent**, so "the venv python is missing" and "the import wedged for 30s" stay as opaque as before the fix.
- **Lines are unattributable** — a status request fans out over several runtimes and every line reads the same.

## Changes

- Split the icons: `⚠️` when the probe answered, `❌` when it never did.
- Empty capture logs `(no stderr output)` rather than going quiet.
- Log on spawn error and on timeout.
- Label each line with the runtime and which probe ran. The spawn error is reduced to `err.code` — Node's message interpolates the interpreter path, which embeds the OS username.
- Decode stderr on the stream, so a multi-byte character split across chunks survives instead of becoming U+FFFD.

## Test plan

- 4 new tests in `services/videoGen/runtimes.test.js`, **each verified failing against #4622 as merged** and passing here.
- #4622's own test is kept; only its cap assertion changed, since it pinned the old fixed prefix and the line is now labelled per runtime.
- Full server suite: 31002 passed / 19 skipped. Client lint clean.

Refs #4618
