### PR TITLE
fix: Shell tabs show the folder name on Windows and follow a cd (#4624)

### DIFF
--- a/client/src/components/shell/ShellSessionTabs.jsx
+++ b/client/src/components/shell/ShellSessionTabs.jsx
@@ -4,6 +4,12 @@ import { clickableProps } from '../../lib/a11yKeyboard.js';
 
 const shortId = (id) => id?.slice(0, 6) ?? '';
 
+// Separator-agnostic basename for the tab label. A Windows cwd (`I:\code\example-app`)
+// contains no `/`, so a POSIX-only split leaves the whole path in the tab and blows
+// out its width. `filter(Boolean)` drops the empty tail a trailing separator leaves,
+// and yields undefined for a bare root so the caller falls through to the short id.
+const folderName = (cwd) => cwd?.split(/[\\/]/).filter(Boolean).pop();
+
 // Presentational session-tab strip for the Shell page. External TUI runs get a
 // distinct bot icon + accent tint + pulsing dot so they read as "live run you can
 // watch and drive"; interactive shells use the terminal icon. All session actions
@@ -23,7 +29,7 @@ export default function ShellSessionTabs({ sessions, activeSessionId, onSwitch, 
     <div className="flex items-center gap-1.5 overflow-x-auto scrollbar-hide touch-pan-x">
       {sessions.map((s) => {
         const isActive = s.sessionId === activeSessionId;
-        const label = s.label || s.cwd?.split('/').pop() || shortId(s.sessionId);
+        const label = s.label || folderName(s.cwd) || shortId(s.sessionId);
         const isRun = s.external;
         const TabIcon = isRun ? Bot : TerminalIcon;
         const age = formatDurationMs(Date.now() - s.createdAt);

--- a/client/src/components/shell/ShellSessionTabs.jsx
+++ b/client/src/components/shell/ShellSessionTabs.jsx
@@ -6,8 +6,9 @@ const shortId = (id) => id?.slice(0, 6) ?? '';
 
 // Separator-agnostic basename for the tab label. A Windows cwd (`I:\code\example-app`)
 // contains no `/`, so a POSIX-only split leaves the whole path in the tab and blows
-// out its width. `filter(Boolean)` drops the empty tail a trailing separator leaves,
-// and yields undefined for a bare root so the caller falls through to the short id.
+// out its width. `filter(Boolean)` drops the empty tail a trailing separator leaves.
+// POSIX `/` has no segment left and yields undefined, so the caller falls through to
+// the short id; a Windows drive root keeps its `C:` segment, which reads fine as a label.
 const folderName = (cwd) => cwd?.split(/[\\/]/).filter(Boolean).pop();
 
 // Presentational session-tab strip for the Shell page. External TUI runs get a

--- a/client/src/components/shell/ShellSessionTabs.test.jsx
+++ b/client/src/components/shell/ShellSessionTabs.test.jsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ShellSessionTabs from './ShellSessionTabs';
+
+const session = (overrides = {}) => ({
+  sessionId: 'abcdef123456',
+  cwd: '/home/user/example-app',
+  createdAt: Date.now(),
+  ...overrides,
+});
+
+const renderTabs = (sessions, props = {}) =>
+  render(
+    <ShellSessionTabs
+      sessions={sessions}
+      activeSessionId={sessions[0]?.sessionId}
+      onSwitch={vi.fn()}
+      onKill={vi.fn()}
+      onNew={vi.fn()}
+      {...props}
+    />
+  );
+
+describe('ShellSessionTabs labels', () => {
+  it('shows the folder name for a POSIX cwd', () => {
+    renderTabs([session()]);
+    expect(screen.getByText('example-app')).toBeTruthy();
+  });
+
+  it('shows the folder name for a Windows cwd, not the whole drive path', () => {
+    renderTabs([session({ cwd: 'I:\\code\\example-app' })]);
+    expect(screen.getByText('example-app')).toBeTruthy();
+    expect(screen.queryByText('I:\\code\\example-app')).toBeNull();
+  });
+
+  it('ignores a trailing separator on either platform', () => {
+    renderTabs([
+      session({ sessionId: 'posix1', cwd: '/home/user/example-app/' }),
+      session({ sessionId: 'win111', cwd: 'I:\\code\\other-app\\' }),
+    ]);
+    expect(screen.getByText('example-app')).toBeTruthy();
+    expect(screen.getByText('other-app')).toBeTruthy();
+  });
+
+  it('falls back to the short session id when the cwd is a bare root', () => {
+    renderTabs([session({ sessionId: 'abcdef123456', cwd: '/' })]);
+    expect(screen.getByText('abcdef')).toBeTruthy();
+  });
+
+  it('prefers an explicit label over the cwd', () => {
+    renderTabs([session({ label: 'Claude Code TUI' })]);
+    expect(screen.getByText('Claude Code TUI')).toBeTruthy();
+    expect(screen.queryByText('example-app')).toBeNull();
+  });
+
+  it('relabels when a cd moves the session cwd', () => {
+    const { rerender } = renderTabs([session()]);
+    expect(screen.getByText('example-app')).toBeTruthy();
+
+    rerender(
+      <ShellSessionTabs
+        sessions={[session({ cwd: 'I:\\code\\other-app' })]}
+        activeSessionId="abcdef123456"
+        onSwitch={vi.fn()}
+        onKill={vi.fn()}
+        onNew={vi.fn()}
+      />
+    );
+    expect(screen.getByText('other-app')).toBeTruthy();
+    expect(screen.queryByText('example-app')).toBeNull();
+  });
+
+  it('kills a session without switching to it', () => {
+    const onKill = vi.fn();
+    const onSwitch = vi.fn();
+    renderTabs([session()], { onKill, onSwitch });
+    fireEvent.click(screen.getByRole('button', { name: /kill session/i }));
+    expect(onKill).toHaveBeenCalledWith('abcdef123456');
+    expect(onSwitch).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/components/shell/ShellSessionTabs.test.jsx
+++ b/client/src/components/shell/ShellSessionTabs.test.jsx
@@ -47,6 +47,11 @@ describe('ShellSessionTabs labels', () => {
     expect(screen.getByText('abcdef')).toBeTruthy();
   });
 
+  it('keeps the drive segment for a Windows drive root', () => {
+    renderTabs([session({ cwd: 'I:\\' })]);
+    expect(screen.getByText('I:')).toBeTruthy();
+  });
+
   it('prefers an explicit label over the cwd', () => {
     renderTabs([session({ label: 'Claude Code TUI' })]);
     expect(screen.getByText('Claude Code TUI')).toBeTruthy();

--- a/server/services/shell.js
+++ b/server/services/shell.js
@@ -590,11 +590,17 @@ export function submitToSession(sessionId, line) {
  *
  * @param {string} sessionId
  * @param {string} dirPath
- * @returns {boolean} false when the session is unknown
+ * @returns {boolean} false when the session is unknown or is an external TUI run
  */
 export function changeSessionDirectory(sessionId, dirPath) {
   const session = shellSessions.get(sessionId);
   if (!session) return false;
+  // An external (TUI-run) session has no shell reading that line: the bytes land in
+  // the agent as typed text and the trailing Enter posts them as a message. Refuse
+  // rather than type into someone else's run — socket.js turns this into an error the
+  // Shell page shows. Its `cwd` also stays pinned to the repo the RUN was spawned in,
+  // which is what workspaceContext groups runs by.
+  if (session.external) return false;
   if (!submitToSession(sessionId, buildCdCommand(dirPath, session.shell))) return false;
   // Track the cd optimistically so the Shell tab label and the Workspace Contexts
   // widget follow the session instead of staying pinned to its spawn directory.
@@ -602,13 +608,8 @@ export function changeSessionDirectory(sessionId, dirPath) {
   // come from the managed-apps list, so they exist. Asking the PTY for its REAL cwd
   // would need a per-platform probe plus a round-trip, which is not worth it for a
   // label; a rejected path just leaves the label wrong until the next cd.
-  // …but only for an interactive shell. An external (TUI-run) session has no shell
-  // reading that line — the bytes land in the agent as typed text — and its `cwd` is
-  // the repo the RUN was spawned in, which is what workspaceContext groups runs by.
-  if (!session.external) {
-    session.cwd = dirPath;
-    broadcastSessionList();
-  }
+  session.cwd = dirPath;
+  broadcastSessionList();
   return true;
 }
 

--- a/server/services/shell.js
+++ b/server/services/shell.js
@@ -602,8 +602,13 @@ export function changeSessionDirectory(sessionId, dirPath) {
   // come from the managed-apps list, so they exist. Asking the PTY for its REAL cwd
   // would need a per-platform probe plus a round-trip, which is not worth it for a
   // label; a rejected path just leaves the label wrong until the next cd.
-  session.cwd = dirPath;
-  broadcastSessionList();
+  // …but only for an interactive shell. An external (TUI-run) session has no shell
+  // reading that line — the bytes land in the agent as typed text — and its `cwd` is
+  // the repo the RUN was spawned in, which is what workspaceContext groups runs by.
+  if (!session.external) {
+    session.cwd = dirPath;
+    broadcastSessionList();
+  }
   return true;
 }
 

--- a/server/services/shell.js
+++ b/server/services/shell.js
@@ -586,6 +586,8 @@ export function submitToSession(sessionId, line) {
  * because only the server knows which shell this PTY is running — and the command
  * differs per shell. See lib/shellCd.js for why.
  *
+ * Updates `session.cwd` on success — see the body for why that is optimistic.
+ *
  * @param {string} sessionId
  * @param {string} dirPath
  * @returns {boolean} false when the session is unknown
@@ -593,7 +595,16 @@ export function submitToSession(sessionId, line) {
 export function changeSessionDirectory(sessionId, dirPath) {
   const session = shellSessions.get(sessionId);
   if (!session) return false;
-  return submitToSession(sessionId, buildCdCommand(dirPath, session.shell));
+  if (!submitToSession(sessionId, buildCdCommand(dirPath, session.shell))) return false;
+  // Track the cd optimistically so the Shell tab label and the Workspace Contexts
+  // widget follow the session instead of staying pinned to its spawn directory.
+  // `cwd` is display-only after spawn — nothing functional reads it — and the paths
+  // come from the managed-apps list, so they exist. Asking the PTY for its REAL cwd
+  // would need a per-platform probe plus a round-trip, which is not worth it for a
+  // label; a rejected path just leaves the label wrong until the next cd.
+  session.cwd = dirPath;
+  broadcastSessionList();
+  return true;
 }
 
 /**

--- a/server/services/shell.test.js
+++ b/server/services/shell.test.js
@@ -390,6 +390,35 @@ describe('changeSessionDirectory', () => {
     expect(shell.changeSessionDirectory('missing', '/tmp')).toBe(false);
   });
 
+  it('moves session.cwd to the new directory so the tab label stops showing the spawn dir', () => {
+    const sock = makeSocket('sock-cd');
+    const id = shell.createShellSession(sock, { shell: '/bin/zsh', cwd: '/home/user/example' });
+    expect(shell.listAllSessions(sock).find(s => s.sessionId === id).cwd).toBe('/home/user/example');
+
+    expect(shell.changeSessionDirectory(id, '/home/user/example-app')).toBe(true);
+    expect(shell.listAllSessions(sock).find(s => s.sessionId === id).cwd).toBe('/home/user/example-app');
+  });
+
+  it('broadcasts the refreshed session list so open Shell tabs relabel without a reload', () => {
+    const observer = makeSocket('obs-cd');
+    const id = shell.createShellSession(makeSocket('owner-cd'), { shell: '/bin/zsh', cwd: '/home/user/example' });
+    shell.subscribeSessionList(observer);
+
+    shell.changeSessionDirectory(id, '/home/user/example-app');
+
+    const broadcasts = observer.emit.mock.calls.filter(c => c[0] === 'shell:sessions');
+    expect(broadcasts).toHaveLength(1);
+    expect(broadcasts[0][1].find(s => s.sessionId === id).cwd).toBe('/home/user/example-app');
+    shell.unsubscribeSessionList(observer);
+  });
+
+  it('leaves cwd untouched when the session is gone', () => {
+    const sock = makeSocket('sock-cd-gone');
+    const id = shell.createShellSession(sock, { shell: '/bin/zsh', cwd: '/home/user/example' });
+    shell.killSession(id);
+    expect(shell.changeSessionDirectory(id, '/home/user/example-app')).toBe(false);
+  });
+
   it('records the shell it spawned when the caller names none', () => {
     // The recorded shell is what picks the cd dialect, so a session started from
     // the default must remember which binary that was rather than leaving

--- a/server/services/shell.test.js
+++ b/server/services/shell.test.js
@@ -412,6 +412,17 @@ describe('changeSessionDirectory', () => {
     shell.unsubscribeSessionList(observer);
   });
 
+  it('leaves an external TUI run cwd pinned to the repo it was spawned in', () => {
+    // A cd typed at an agent TUI is text the agent reads, not a shell directory
+    // change — and workspaceContext groups runs by the repo they were spawned in.
+    const sock = makeSocket('sock-ext');
+    const pty = makeFakePty();
+    shell.registerExternalSession('run-1', pty, { cwd: '/home/user/example', label: 'Claude Code TUI' });
+
+    expect(shell.changeSessionDirectory('run-1', '/home/user/example-app')).toBe(true);
+    expect(shell.listAllSessions(sock).find(s => s.sessionId === 'run-1').cwd).toBe('/home/user/example');
+  });
+
   it('leaves cwd untouched when the session is gone', () => {
     const sock = makeSocket('sock-cd-gone');
     const id = shell.createShellSession(sock, { shell: '/bin/zsh', cwd: '/home/user/example' });

--- a/server/services/shell.test.js
+++ b/server/services/shell.test.js
@@ -412,14 +412,15 @@ describe('changeSessionDirectory', () => {
     shell.unsubscribeSessionList(observer);
   });
 
-  it('leaves an external TUI run cwd pinned to the repo it was spawned in', () => {
-    // A cd typed at an agent TUI is text the agent reads, not a shell directory
-    // change — and workspaceContext groups runs by the repo they were spawned in.
+  it('refuses an external TUI run rather than typing the cd into the agent', () => {
+    // The run's PTY has no shell reading that line — it would post as a message —
+    // and workspaceContext groups runs by the repo they were spawned in.
     const sock = makeSocket('sock-ext');
     const pty = makeFakePty();
     shell.registerExternalSession('run-1', pty, { cwd: '/home/user/example', label: 'Claude Code TUI' });
 
-    expect(shell.changeSessionDirectory('run-1', '/home/user/example-app')).toBe(true);
+    expect(shell.changeSessionDirectory('run-1', '/home/user/example-app')).toBe(false);
+    expect(pty.write).not.toHaveBeenCalled();
     expect(shell.listAllSessions(sock).find(s => s.sessionId === 'run-1').cwd).toBe('/home/user/example');
   });
 

--- a/server/services/socket.js
+++ b/server/services/socket.js
@@ -684,7 +684,13 @@ export function initSocket(io) {
       const validated = validateSocketData(shellCdSchema, rawData, socket, 'shell:cd');
       if (!validated) return;
       if (!shellService.changeSessionDirectory(validated.sessionId, validated.path)) {
-        socket.emit('shell:error', { sessionId: validated.sessionId, error: 'Session not found' });
+        // Two different refusals: the session is gone, or it is a live agent run
+        // whose PTY would read the `cd` as a typed message rather than a command.
+        const isRun = shellService.getSession(validated.sessionId)?.external;
+        socket.emit('shell:error', {
+          sessionId: validated.sessionId,
+          error: isRun ? 'This is a live agent run, not a shell — cd is unavailable here' : 'Session not found'
+        });
       }
     });
 

--- a/server/services/socket.test.js
+++ b/server/services/socket.test.js
@@ -38,6 +38,7 @@ vi.mock('./shell.js', () => ({
   listAllSessions: vi.fn(() => []),
   writeToSession: vi.fn(),
   changeSessionDirectory: vi.fn(() => true),
+  getSession: vi.fn(() => null),
   resizeSession: vi.fn(),
   killSession: vi.fn(),
   unsubscribeSessionList: vi.fn(),
@@ -397,6 +398,19 @@ describe('socket.js — initSocket', () => {
 
     const err = socket.emitted.find(([ev]) => ev === 'shell:error');
     expect(err[1].sessionId).toBe('gone');
+  });
+
+  it('shell:cd says WHY when the target is a live agent run, not a dead session', () => {
+    const socket = makeSocket('shell-cd-run');
+    io.connect(socket);
+    shellService.changeSessionDirectory.mockReturnValueOnce(false);
+    shellService.getSession.mockReturnValueOnce({ external: true });
+
+    socket.handlers['shell:cd']({ sessionId: 'run-1', path: '/home/user/example-app' });
+
+    const err = socket.emitted.find(([ev]) => ev === 'shell:error');
+    expect(err[1].sessionId).toBe('run-1');
+    expect(err[1].error).toMatch(/live agent run/i);
   });
 
   // ===========================================================================


### PR DESCRIPTION
## Summary

Two Shell-page display bugs, both visible on a Windows session.

**Tab labels were POSIX-only.** `ShellSessionTabs` derived the folder name with `split('/')`, so a cwd like `I:\code\example-app` had no separator to split on and the tab rendered the whole drive path, blowing out the tab width. The label now splits on either separator and drops the empty tail a trailing separator leaves behind. `/` falls through to the short session id as before; a Windows drive root keeps its `I:` segment, which reads fine as a label.

**`session.cwd` went stale after a `cd`.** `changeSessionDirectory()` wrote the `cd` to the PTY but left `session.cwd` at its spawn value, so the tab label and the Workspace Contexts widget kept naming the folder the session *started* in. It now moves `session.cwd` and rebroadcasts the session list, so open Shell tabs relabel without a reload. That update is optimistic by design: `cwd` is display-only after spawn, the paths come from the managed-apps list so they exist, and probing the PTY for its real cwd would need a per-platform probe plus a round-trip that a tab label does not justify.

The basename helper stays in the component rather than moving to `client/src/utils/formatters.js` — that file is for value formatting, not path parsing.

**Also, from local review:** a `cd` aimed at an external (TUI-run) session was being written into the agent's PTY, where there is no shell reading it — the bytes land as typed text and the trailing Enter posts them to the agent as a message. `changeSessionDirectory()` now refuses those, and the `shell:cd` handler says why instead of reporting a live run as `Session not found`. This was pre-existing on `main`; it surfaced because making the label follow a cd would otherwise have relabeled a run under the wrong workspace context.

## Test plan

- `cd server && npm test` — 1494 files / 30981 tests pass.
- `cd client && npm test` — 687 files / 8532 tests pass.
- `cd client && npm run lint` — clean.
- New `client/src/components/shell/ShellSessionTabs.test.jsx` covers the Windows path, trailing separators, the drive root, the POSIX-root fallback, an explicit label winning over the cwd, and relabeling on a cwd change. Three of these fail against the baseline component.
- New `server/services/shell.test.js` cases cover the post-`cd` `listAllSessions()` cwd, the `shell:sessions` rebroadcast, and the external-run refusal (asserting `pty.write` was never called). All fail against the baseline service.
- New `server/services/socket.test.js` case covers the live-agent-run error message.

Closes #4624
