### PR TITLE
fix: buffer a video render child's exit across the accelerator handoff so it can't strand the job (#4617)

### DIFF
--- a/server/services/videoGen/generateVideoHelpers.js
+++ b/server/services/videoGen/generateVideoHelpers.js
@@ -465,6 +465,40 @@ export function isWatchdogSuccess({ completionWatchdogFired, idleStallFired = fa
 }
 
 /**
+ * Hold a freshly spawned render child's terminal event until its real handlers
+ * are wired (#4617).
+ *
+ * `spawnDetached` defers its first emission to a `setImmediate` so a caller that
+ * subscribes synchronously misses nothing — but generateVideo must first hand
+ * the machine accelerator claim to the child's PID, and that await does real
+ * file I/O. A child that dies inside that window (a venv that imports and
+ * aborts, an OOM kill, a launcher that never produced a PID) emits with nobody
+ * listening: the 'close' is lost and the job sits `running` forever still
+ * holding the claim, while a lost 'error' is worse — an EventEmitter with no
+ * 'error' listener THROWS, which outside the request lifecycle takes the whole
+ * server down.
+ *
+ * Attach this in the SAME tick the spawn resolved. It returns a `take()` that
+ * detaches these listeners and hands back the first terminal event seen, or
+ * `null` when the child is still alive — read it immediately before the real
+ * listeners go on, with no await in between, or the gap reopens. Leaving it
+ * attached is also valid: for a child that is being abandoned rather than
+ * wired, it stays a harmless sink that keeps an 'error' from going unhandled.
+ */
+export function bufferChildExit(proc) {
+  let buffered = null;
+  const onClose = (code, signal) => { buffered = buffered || { type: 'close', code, signal }; };
+  const onError = (error) => { buffered = buffered || { type: 'error', error }; };
+  proc.on('close', onClose);
+  proc.on('error', onError);
+  return () => {
+    proc.off?.('close', onClose);
+    proc.off?.('error', onError);
+    return buffered;
+  };
+}
+
+/**
  * Success path of generateVideo's `close` handler: faststart-optimize the
  * output, generate a thumbnail, prepend the history entry, and emit the
  * `complete` SSE frame + `completed` queue event. Mutates `job.status` to

--- a/server/services/videoGen/generateVideoHelpers.test.js
+++ b/server/services/videoGen/generateVideoHelpers.test.js
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { writeFileSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { makeVideoGenLineHandler, isWatchdogSuccess, finalizeGeneratedVideo, parseByteProgress, formatBytes, formatDownloadMessage, describeSignalDeath, formatRuntimeFingerprint, describeRenderConditioning, isPromptEncodingMetalWatchdog, planPromptEncodingRetry, DEFAULT_GEMMA_MAX_LENGTH, RETRY_GEMMA_MAX_LENGTH, RENDER_INPUTS_VERSION } from './generateVideoHelpers.js';
+import { EventEmitter } from 'events';
+import { makeVideoGenLineHandler, isWatchdogSuccess, finalizeGeneratedVideo, parseByteProgress, formatBytes, formatDownloadMessage, describeSignalDeath, formatRuntimeFingerprint, describeRenderConditioning, isPromptEncodingMetalWatchdog, planPromptEncodingRetry, DEFAULT_GEMMA_MAX_LENGTH, RETRY_GEMMA_MAX_LENGTH, bufferChildExit, RENDER_INPUTS_VERSION } from './generateVideoHelpers.js';
 
 describe('parseByteProgress', () => {
   it('parses single byte value (e.g., "2.5G")', () => {
@@ -569,5 +570,52 @@ describe('planPromptEncodingRetry', () => {
   it('passes the classifier verdict straight through', () => {
     expect(planPromptEncodingRetry({ ...qualifying, promptEncodePhase: 'done' })).toBeNull();
     expect(planPromptEncodingRetry({ ...qualifying, signal: 'SIGKILL' })).toBeNull();
+  });
+});
+
+// The window between "spawn resolved" and "real listeners attached" is an await
+// on real file I/O (the accelerator claim handoff). A child that dies in it
+// emits unsubscribed — and for 'error' that is not merely lost but fatal, since
+// an EventEmitter with no 'error' listener throws.
+describe('bufferChildExit', () => {
+  it('reports nothing for a child that is still alive', () => {
+    expect(bufferChildExit(new EventEmitter())()).toBeNull();
+  });
+
+  it('holds a close emitted before the real listeners were attached', () => {
+    const proc = new EventEmitter();
+    const take = bufferChildExit(proc);
+    proc.emit('close', 3, null);
+    expect(take()).toEqual({ type: 'close', code: 3, signal: null });
+  });
+
+  it('absorbs an error that would otherwise throw out of the emitter', () => {
+    const proc = new EventEmitter();
+    const take = bufferChildExit(proc);
+    const err = new Error('detached spawn produced no PID');
+    expect(() => proc.emit('error', err)).not.toThrow();
+    expect(take()).toEqual({ type: 'error', error: err });
+  });
+
+  it('keeps the FIRST terminal event — a later one must not rewrite the verdict', () => {
+    const proc = new EventEmitter();
+    const take = bufferChildExit(proc);
+    proc.emit('error', new Error('spawn failed'));
+    proc.emit('close', 0, null);
+    expect(take().type).toBe('error');
+  });
+
+  it('detaches on take, so the real handlers own everything that follows', () => {
+    const proc = new EventEmitter();
+    const take = bufferChildExit(proc);
+    expect(take()).toBeNull();
+    expect(proc.listenerCount('close')).toBe(0);
+    expect(proc.listenerCount('error')).toBe(0);
+  });
+
+  it('stays a sink for a child that is abandoned rather than wired', () => {
+    const proc = new EventEmitter();
+    bufferChildExit(proc);
+    expect(() => proc.emit('error', new Error('abandoned'))).not.toThrow();
   });
 });

--- a/server/services/videoGen/local.js
+++ b/server/services/videoGen/local.js
@@ -40,7 +40,7 @@ import {
 import { hfChildEnv } from '../../lib/hfToken.js';
 import { inspectModelCache, findCachedRepoFile, findCachedRepoFiles } from '../../lib/hfCache.js';
 import { safeChildProcessEnv, safeChildProcessOptions } from '../../lib/processEnv.js';
-import { makeVideoGenLineHandler, finalizeGeneratedVideo, isWatchdogSuccess, describeSignalDeath, describeRenderConditioning, planPromptEncodingRetry, RENDER_INPUTS_VERSION } from './generateVideoHelpers.js';
+import { makeVideoGenLineHandler, finalizeGeneratedVideo, isWatchdogSuccess, describeSignalDeath, describeRenderConditioning, planPromptEncodingRetry, bufferChildExit, RENDER_INPUTS_VERSION } from './generateVideoHelpers.js';
 import { assertSafeLoraFilename, getLoraKeyLayout } from '../loras.js';
 import { videoLoraFamily, isLtx2FamilyRuntime } from '../../lib/runners.js';
 import {
@@ -1587,7 +1587,9 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
   // The first render child. Named apart from the `proc` each wireRenderChild()
   // call binds, so a relaunch cannot be confused with the original.
   let firstProc;
-  let claimHandedOff = false;
+  // Reads (and detaches) whatever terminal event the first child emitted before
+  // its real listeners were attached. Set the instant the spawn resolves.
+  let takeEarlyExit = null;
   // Prompt-encode relaunches already spent on this job. Exactly one is allowed:
   // a second watchdog abort at the reduced budget is a real failure the user has
   // to see, not something to keep grinding the GPU over.
@@ -1595,79 +1597,6 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
   // Hoisted out of the try so a relaunch can respawn with the SAME child env
   // plus a lowered Gemma budget, instead of rebuilding it from scratch.
   let childEnv;
-  try {
-    const memoryReport = await prepareLocalMemory();
-    if (memoryReport.unloaded.length) console.log(`🧹 Video generation [${jobId.slice(0, 8)}] freed ${memoryReport.unloaded.length} resident model(s)`);
-
-    // History-calibrated wall-clock estimate (#3801). `null` when this install
-    // has never measured a render on this model — an explicit "no estimate"
-    // sentinel the UI must render as "unknown", never as 0 or a guess. Stamped
-    // on the job so every progress frame can carry it alongside step progress.
-    const etaEstimate = estimateRenderMs({
-      history: await loadHistory(),
-      modelId,
-      width: w,
-      height: h,
-      numFrames: parsedNumFrames,
-      steps: actualSteps,
-    });
-    job.etaMs = etaEstimate ? etaEstimate.etaMs : null;
-    const etaFields = etaEstimate
-      ? { etaMs: etaEstimate.etaMs, etaBasis: etaEstimate.basis, etaSampleCount: etaEstimate.sampleCount }
-      : { etaMs: null };
-    job.renderStartedAtMs = Date.now();
-
-    console.log(`🎬 Generating video [${jobId.slice(0, 8)}]: ${modelId} ${w}x${h} frames=${parsedNumFrames} steps=${actualSteps} eta=${etaEstimate ? `${Math.round(etaEstimate.etaMs / 1000)}s (${etaEstimate.basis}, n=${etaEstimate.sampleCount})` : 'unknown'}`);
-    videoGenEvents.emit('started', { generationId: jobId, totalSteps: actualSteps, ...meta, ...etaFields });
-
-    // Clear PYTHONPATH so the child uses the venv's own site-packages instead
-    // of the parent shell's PYTHONPATH. Setting to `undefined` in a spread does
-    // NOT unset the var — Node coerces it to the literal string "undefined" —
-    // so build the env explicitly and `delete`.
-    // Build the complete HF child env so the Wan 2.2 / HunyuanVideo
-    // python helpers can authenticate snapshot_download() against gated repos
-    // (mirrors the imageGen child-spawn pattern). LTX-2 doesn't currently use
-    // a gated repo, but the merge is harmless when no token is configured.
-    childEnv = runtimeIsCacheOnly(model.runtime)
-      ? safeChildProcessEnv()
-      : await hfChildEnv();
-    delete childEnv.PYTHONPATH;
-    // Force unbuffered Python I/O so tqdm + loguru + our own STAGE: prints flush
-    // immediately. Without this, child stdio is line-buffered against a pipe and
-    // long inference loops emit nothing to handleLine() for minutes — the UI
-    // looks dead even when the model is making progress.
-    childEnv.PYTHONUNBUFFERED = '1';
-    if (runtimeIsCacheOnly(model.runtime)) {
-      // A cache-only runner never reaches the network. Do not hand it an ambient
-      // saved HF credential it neither needs nor may transmit.
-      delete childEnv.HF_TOKEN;
-      delete childEnv.HUGGING_FACE_HUB_TOKEN;
-      childEnv.HF_HUB_DISABLE_IMPLICIT_TOKEN = '1';
-      childEnv.HF_HUB_OFFLINE = '1';
-      childEnv.TRANSFORMERS_OFFLINE = '1';
-    }
-    // `spawnDetached` double-forks the render child so it reparents to init
-    // (PPID=1) and leaves pm2's process tree — without this a `pm2 restart
-    // portos-server` (e.g. on the memory ceiling) SIGINTs the in-flight render
-    // mid-inference, since pm2's TreeKill walks PPIDs. (This child previously had
-    // no detach at all, so it was fully exposed.) Output streams through on-disk
-    // log files under `data/videos/.detached/<jobId>` that the server tails; we
-    // still `proc.kill()` it directly by PID on cancel / watchdog. `cleanup: true`
-    // lets the helper drop that scratch dir on every terminal path (close/error)
-    // so it can't accumulate under data/videos.
-    firstProc = await spawnDetached(bin, args, {
-      env: childEnv,
-      controlDir: join(PATHS.videos, '.detached', jobId),
-      cleanup: true,
-      killProcessGroup: runtimeNeedsProcessGroupKill(model.runtime),
-    });
-    activeProcess = firstProc;
-    await heavyClaim.handoffTo?.(firstProc.pid);
-    claimHandedOff = true;
-  } catch (err) {
-    if (!claimHandedOff) await releaseHeavyClaim();
-    throw err;
-  }
 
   // ── one render child, fully wired ──────────────────────────────────────────
   // Everything per-CHILD lives in here — the process handle, both watchdogs, the
@@ -1779,9 +1708,19 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
     if (process.platform === 'darwin' && proc.pid) {
       spawn('caffeinate', ['-dis', '-w', String(proc.pid)], { stdio: 'ignore', detached: false }).on('error', () => {});
     }
+    // Guards the ONE terminal run of this child's teardown, across BOTH terminal
+    // paths ('error' and 'close'). The caller may have to replay a terminal
+    // event this child emitted before it was wired, and that must not
+    // double-release the accelerator claim, double-clean the temp files, or emit
+    // two terminal events if the real event lands as well.
+    let closeHandled = false;
     // Without an 'error' handler, a missing/non-executable pythonPath would
-    // crash the server with an unhandled error event.
-    proc.on('error', (err) => {
+    // crash the server with an unhandled error event. Named (rather than an
+    // inline arrow) so the caller can replay an 'error' this child emitted
+    // before it was wired.
+    const handleChildError = (err) => {
+      if (closeHandled) return;
+      closeHandled = true;
       clearCompletionWatchdog();
       clearIdleStallTimer();
       job.status = 'error';
@@ -1798,7 +1737,8 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
       // uploadedTempPaths tracking. Duplicate unlinks remain harmless.
       void cleanupTempFiles({ includeUploads: true, includeUntrackedAudio: true });
       closeJobAfterDelay(jobs, jobId);
-    });
+    };
+    proc.on('error', handleChildError);
 
     let missingPyModule = null;
     // Rolling tail of this child's stderr. The Metal abort text is the only
@@ -1867,12 +1807,6 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
       stderrReader.push(chunk);
     });
 
-    // Guards the ONE terminal run of this child's teardown. The relaunch path
-    // may have to drive handleChildClose() by hand (a replacement that died
-    // before its listener was attached), and that must not double-release the
-    // claim, double-clean the temp files, or emit two terminal events if the
-    // real event lands as well.
-    let closeHandled = false;
     const handleChildClose = async (code, signal) => {
       if (closeHandled) return;
       closeHandled = true;
@@ -1977,7 +1911,33 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
       }
     };
     proc.on('close', handleChildClose);
-    return handleChildClose;
+    return { handleChildClose, handleChildError };
+  };
+
+  // Wire a freshly spawned render child and return the replay for whatever
+  // terminal event the exit buffer caught while the claim handoff was in flight.
+  // `takeEarlyExit` is read in the SAME tick the real listeners go on — no await
+  // between — or the gap the buffer exists to close reopens.
+  //
+  // The replay is separated from the wiring so a caller can mark the child
+  // OWNED before awaiting it: the replay runs the full teardown, and a child
+  // that already owns the job must never be mistaken for an abandoned one by
+  // the failure path that would otherwise kill it.
+  const wireSpawnedChild = (proc, takeEarlyExit) => {
+    // The buffer is the primary catch. Reading the corpse's exit state is the
+    // backstop for a handle that recorded its exit without emitting anything.
+    const earlyExit = takeEarlyExit()
+      || (proc.exitCode !== null || proc.signalCode !== null
+        ? { type: 'close', code: proc.exitCode, signal: proc.signalCode }
+        : null);
+    const { handleChildClose, handleChildError } = wireRenderChild(proc);
+    const replayEarlyExit = async () => {
+      if (!earlyExit) return;
+      console.log(`⚠️ video render child exited before it was wired [${jobId.slice(0, 8)}]`);
+      if (earlyExit.type === 'error') handleChildError(earlyExit.error);
+      else await handleChildClose(earlyExit.code, earlyExit.signal);
+    };
+    return replayEarlyExit;
   };
 
   // Whether a cancel landed while the relaunch was awaiting something, and if so
@@ -1989,22 +1949,23 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
     // Fall through to the normal failure path, so the job still reports a
     // terminal event instead of quietly running to completion after a cancel.
     console.log(`🛑 canceled during the prompt-encode relaunch — stopping the replacement child [${jobId.slice(0, 8)}]`);
-    stopAbandonedRetryChild(retryProc);
+    stopAbandonedChild(retryProc);
     return true;
   };
 
-  // Stop a replacement child that was spawned but will never be wired up —
-  // canceled mid-relaunch, or abandoned because a later setup step threw. It has
-  // no close/error listeners by then, so nothing else would ever reap it.
+  // Stop a render child that was spawned but will never be wired up — the first
+  // child when its claim handoff threw, or a replacement canceled mid-relaunch /
+  // abandoned because a later setup step threw. It has no real close handler by
+  // then, so nothing else would ever reap it.
   // Tolerant of a null handle (the spawn itself threw) and of a kill that throws
   // on an already-dead PID, because this runs on the failure path of a failure
   // path and must not replace the real error with its own.
-  const stopAbandonedRetryChild = (child) => {
+  const stopAbandonedChild = (child) => {
     if (!child) return;
     try {
       child.kill('SIGTERM');
     } catch (err) {
-      console.error(`❌ abandoned prompt-encode retry child would not stop [${jobId.slice(0, 8)}]: ${err.message}`);
+      console.error(`❌ abandoned video render child would not stop [${jobId.slice(0, 8)}]: ${err.message}`);
     }
   };
 
@@ -2040,10 +2001,10 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
     // an uncaught throw here would crash the process, and a failed relaunch must
     // degrade into the normal failure report rather than strand the job.
     // Declared outside the try so the catch can stop a child that was spawned
-    // before a later step threw — an unwired child has no listeners and nothing
-    // left to reap it. `retryWired` is the cut-off: past that point the child
-    // owns the job and reports its own terminal event, so the catch must leave
-    // it alone.
+    // before a later step threw — an unwired child has only the exit buffer
+    // absorbing its events, and nothing that would ever reap it. `retryWired` is
+    // the cut-off: past that point the child owns the job and reports its own
+    // terminal event, so the catch must leave it alone.
     let retryProc = null;
     let retryWired = false;
     try {
@@ -2059,12 +2020,16 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
         cleanup: true,
         killProcessGroup: runtimeNeedsProcessGroupKill(model.runtime),
       });
+      // Catch the replacement's terminal event in the same tick the spawn
+      // resolved — the handoff below yields to the event loop, and a child that
+      // dies in that window would otherwise emit into the void.
+      const takeRetryEarlyExit = bufferChildExit(retryProc);
       if (canceledDuringRelaunch(cancelEpochAtClose, retryProc)) return false;
       // Both awaits finish BEFORE activeProcess starts pointing at the
-      // replacement, and the two statements that follow them are synchronous.
+      // replacement, and the statements that follow them are synchronous.
       // That ordering is load-bearing twice over:
-      //   - cancel() can never reach a child that has no close listener yet, so
-      //     no exit can be emitted into the void and strand the job `running`;
+      //   - cancel() can never reach a child that is not fully wired yet, so no
+      //     exit can be acted on before the job is ready for it;
       //   - the child therefore cannot run its close handler (and release the
       //     accelerator claim) while this handoff is still in flight, which would
       //     otherwise let the handoff re-write the claim file with a dead PID and
@@ -2077,25 +2042,16 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
       // render that actually produced the video would poison every later
       // estimate for this model.
       job.renderStartedAtMs = Date.now();
-      const handleRetryClose = wireRenderChild(retryProc);
+      const replayEarlyExit = wireSpawnedChild(retryProc, takeRetryEarlyExit);
       retryWired = true;
-      // The handoff above yields to the event loop, so a replacement child that
-      // died in that window emitted its 'close' with nobody listening — the job
-      // would sit `running` forever, holding the accelerator claim. Read the
-      // corpse's exit state and drive the terminal path by hand; the handler is
-      // guarded against a double run, so a real 'close' that also lands is a
-      // no-op.
-      if (retryProc.exitCode !== null || retryProc.signalCode !== null) {
-        console.log(`⚠️ prompt-encode replacement child exited before it was wired [${jobId.slice(0, 8)}]`);
-        await handleRetryClose(retryProc.exitCode, retryProc.signalCode);
-      }
+      await replayEarlyExit();
       return true;
     } catch (err) {
       console.error(`❌ prompt-encode retry failed to spawn [${jobId.slice(0, 8)}]: ${err.message}`);
       // Wired means the child owns the job and will report its own terminal
       // event, so nothing here may kill it. Unwired, it can never report at all.
       if (retryWired) return true;
-      stopAbandonedRetryChild(retryProc);
+      stopAbandonedChild(retryProc);
       // Nothing is running under this job any more; leave the invariant cancel()
       // reads (activeProcess === the live child, or null) intact.
       activeProcess = null;
@@ -2103,7 +2059,100 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
     }
   };
 
-  wireRenderChild(firstProc);
+  try {
+    const memoryReport = await prepareLocalMemory();
+    if (memoryReport.unloaded.length) console.log(`🧹 Video generation [${jobId.slice(0, 8)}] freed ${memoryReport.unloaded.length} resident model(s)`);
+
+    // History-calibrated wall-clock estimate (#3801). `null` when this install
+    // has never measured a render on this model — an explicit "no estimate"
+    // sentinel the UI must render as "unknown", never as 0 or a guess. Stamped
+    // on the job so every progress frame can carry it alongside step progress.
+    const etaEstimate = estimateRenderMs({
+      history: await loadHistory(),
+      modelId,
+      width: w,
+      height: h,
+      numFrames: parsedNumFrames,
+      steps: actualSteps,
+    });
+    job.etaMs = etaEstimate ? etaEstimate.etaMs : null;
+    const etaFields = etaEstimate
+      ? { etaMs: etaEstimate.etaMs, etaBasis: etaEstimate.basis, etaSampleCount: etaEstimate.sampleCount }
+      : { etaMs: null };
+    job.renderStartedAtMs = Date.now();
+
+    console.log(`🎬 Generating video [${jobId.slice(0, 8)}]: ${modelId} ${w}x${h} frames=${parsedNumFrames} steps=${actualSteps} eta=${etaEstimate ? `${Math.round(etaEstimate.etaMs / 1000)}s (${etaEstimate.basis}, n=${etaEstimate.sampleCount})` : 'unknown'}`);
+    videoGenEvents.emit('started', { generationId: jobId, totalSteps: actualSteps, ...meta, ...etaFields });
+
+    // Clear PYTHONPATH so the child uses the venv's own site-packages instead
+    // of the parent shell's PYTHONPATH. Setting to `undefined` in a spread does
+    // NOT unset the var — Node coerces it to the literal string "undefined" —
+    // so build the env explicitly and `delete`.
+    // Build the complete HF child env so the Wan 2.2 / HunyuanVideo
+    // python helpers can authenticate snapshot_download() against gated repos
+    // (mirrors the imageGen child-spawn pattern). LTX-2 doesn't currently use
+    // a gated repo, but the merge is harmless when no token is configured.
+    childEnv = runtimeIsCacheOnly(model.runtime)
+      ? safeChildProcessEnv()
+      : await hfChildEnv();
+    delete childEnv.PYTHONPATH;
+    // Force unbuffered Python I/O so tqdm + loguru + our own STAGE: prints flush
+    // immediately. Without this, child stdio is line-buffered against a pipe and
+    // long inference loops emit nothing to handleLine() for minutes — the UI
+    // looks dead even when the model is making progress.
+    childEnv.PYTHONUNBUFFERED = '1';
+    if (runtimeIsCacheOnly(model.runtime)) {
+      // A cache-only runner never reaches the network. Do not hand it an ambient
+      // saved HF credential it neither needs nor may transmit.
+      delete childEnv.HF_TOKEN;
+      delete childEnv.HUGGING_FACE_HUB_TOKEN;
+      childEnv.HF_HUB_DISABLE_IMPLICIT_TOKEN = '1';
+      childEnv.HF_HUB_OFFLINE = '1';
+      childEnv.TRANSFORMERS_OFFLINE = '1';
+    }
+    // `spawnDetached` double-forks the render child so it reparents to init
+    // (PPID=1) and leaves pm2's process tree — without this a `pm2 restart
+    // portos-server` (e.g. on the memory ceiling) SIGINTs the in-flight render
+    // mid-inference, since pm2's TreeKill walks PPIDs. (This child previously had
+    // no detach at all, so it was fully exposed.) Output streams through on-disk
+    // log files under `data/videos/.detached/<jobId>` that the server tails; we
+    // still `proc.kill()` it directly by PID on cancel / watchdog. `cleanup: true`
+    // lets the helper drop that scratch dir on every terminal path (close/error)
+    // so it can't accumulate under data/videos.
+    firstProc = await spawnDetached(bin, args, {
+      env: childEnv,
+      controlDir: join(PATHS.videos, '.detached', jobId),
+      cleanup: true,
+      killProcessGroup: runtimeNeedsProcessGroupKill(model.runtime),
+    });
+    // Subscribe in the SAME tick the spawn resolved, before anything below can
+    // yield. spawnDetached defers its first emission to a setImmediate so a
+    // caller that wires synchronously misses nothing — but the claim handoff
+    // below awaits real file I/O, and a child that dies inside that window (a
+    // venv that imports and aborts, an OOM kill, a launcher that never produced
+    // a PID) emits into the void: a lost 'close' strands the job `running`
+    // forever, still holding the accelerator claim, and a lost 'error' is worse
+    // — an EventEmitter with no 'error' listener THROWS and takes the server
+    // with it.
+    takeEarlyExit = bufferChildExit(firstProc);
+    activeProcess = firstProc;
+    await heavyClaim.handoffTo?.(firstProc.pid);
+  } catch (err) {
+    // Nothing is wired, so this child can never report a terminal event and
+    // nothing would reap it — and once the handoff pointed the claim at its PID,
+    // nothing would release the claim either. Stop it and release unconditionally
+    // (release() is idempotent and still ours after a handoff).
+    stopAbandonedChild(firstProc);
+    if (activeProcess === firstProc) activeProcess = null;
+    await releaseHeavyClaim();
+    throw err;
+  }
+
+  // Terminal listeners go on here, and the buffer hands over anything the child
+  // already emitted — so a child that died during the handoff still drives the
+  // job to a terminal state and gives the accelerator claim back.
+  const replayEarlyExit = wireSpawnedChild(firstProc, takeEarlyExit);
+  await replayEarlyExit();
 
   return { jobId, generationId: jobId, filename, mode: 'local', model: modelId };
 }

--- a/server/services/videoGen/local.js
+++ b/server/services/videoGen/local.js
@@ -1738,7 +1738,6 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
       void cleanupTempFiles({ includeUploads: true, includeUntrackedAudio: true });
       closeJobAfterDelay(jobs, jobId);
     };
-    proc.on('error', handleChildError);
 
     let missingPyModule = null;
     // Rolling tail of this child's stderr. The Metal abort text is the only
@@ -1910,6 +1909,12 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
         closeJobAfterDelay(jobs, jobId);
       }
     };
+    // Both real subscriptions land here, at the very end. Nothing in this
+    // function awaits, so no event can fire before them — and a throw anywhere
+    // above (a stream handle that vanished) therefore leaves the child with NO
+    // real listeners, so the caller's exit buffer stays its only sink instead of
+    // a half-wired handler reporting the job twice.
+    proc.on('error', handleChildError);
     proc.on('close', handleChildClose);
     return { handleChildClose, handleChildError };
   };
@@ -1924,13 +1929,16 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
   // that already owns the job must never be mistaken for an abandoned one by
   // the failure path that would otherwise kill it.
   const wireSpawnedChild = (proc, takeEarlyExit) => {
-    // The buffer is the primary catch. Reading the corpse's exit state is the
-    // backstop for a handle that recorded its exit without emitting anything.
+    // Wire first, then read the buffer: wireRenderChild() never awaits, so
+    // nothing can fire between the two — and if it throws, the buffer is still
+    // attached and keeps absorbing this child's events while the caller kills
+    // it. The buffer is the primary catch; reading the corpse's exit state is
+    // the backstop for a handle that recorded its exit without emitting.
+    const { handleChildClose, handleChildError } = wireRenderChild(proc);
     const earlyExit = takeEarlyExit()
       || (proc.exitCode !== null || proc.signalCode !== null
         ? { type: 'close', code: proc.exitCode, signal: proc.signalCode }
         : null);
-    const { handleChildClose, handleChildError } = wireRenderChild(proc);
     const replayEarlyExit = async () => {
       if (!earlyExit) return;
       console.log(`⚠️ video render child exited before it was wired [${jobId.slice(0, 8)}]`);
@@ -2059,6 +2067,25 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
     }
   };
 
+  // Every failure before this render child is wired converges here. Nothing
+  // is listening yet, so the child can never report its own terminal event —
+  // without this the job would sit `running` in the jobs map forever, holding
+  // the accelerator claim and its staged temp files, exactly the way #4617's
+  // lost 'close' did. Mirrors the buildArgs failure path above so every
+  // pre-wiring failure looks the same to the client and to the media queue.
+  const abandonBeforeWiring = async (err) => {
+    stopAbandonedChild(firstProc);
+    if (activeProcess === firstProc) activeProcess = null;
+    await releaseHeavyClaim();
+    job.status = 'error';
+    const reason = err.message || 'Video generation failed before the render child was wired';
+    console.log(`❌ Video generation setup error [${jobId.slice(0, 8)}]: ${reason}`);
+    broadcastSse(job, { type: 'error', error: reason });
+    videoGenEvents.emit('failed', { generationId: jobId, error: reason });
+    void cleanupTempFiles({ includeUploads: true, includeUntrackedAudio: true });
+    closeJobAfterDelay(jobs, jobId);
+  };
+
   try {
     const memoryReport = await prepareLocalMemory();
     if (memoryReport.unloaded.length) console.log(`🧹 Video generation [${jobId.slice(0, 8)}] freed ${memoryReport.unloaded.length} resident model(s)`);
@@ -2138,20 +2165,23 @@ export async function generateVideo({ pythonPath, prompt, negativePrompt = '', m
     activeProcess = firstProc;
     await heavyClaim.handoffTo?.(firstProc.pid);
   } catch (err) {
-    // Nothing is wired, so this child can never report a terminal event and
-    // nothing would reap it — and once the handoff pointed the claim at its PID,
-    // nothing would release the claim either. Stop it and release unconditionally
-    // (release() is idempotent and still ours after a handoff).
-    stopAbandonedChild(firstProc);
-    if (activeProcess === firstProc) activeProcess = null;
-    await releaseHeavyClaim();
+    await abandonBeforeWiring(err);
     throw err;
   }
 
   // Terminal listeners go on here, and the buffer hands over anything the child
   // already emitted — so a child that died during the handoff still drives the
   // job to a terminal state and gives the accelerator claim back.
-  const replayEarlyExit = wireSpawnedChild(firstProc, takeEarlyExit);
+  let replayEarlyExit;
+  try {
+    replayEarlyExit = wireSpawnedChild(firstProc, takeEarlyExit);
+  } catch (err) {
+    // Wiring itself threw (a stream handle that vanished under us), so this
+    // child has no terminal handler and never will — the same dead end the
+    // relaunch path guards with `retryWired`.
+    await abandonBeforeWiring(err);
+    throw err;
+  }
   await replayEarlyExit();
 
   return { jobId, generationId: jobId, filename, mode: 'local', model: modelId };

--- a/server/services/videoGen/local.test.js
+++ b/server/services/videoGen/local.test.js
@@ -4277,14 +4277,14 @@ describe('generateVideo — Gemma prompt-encode watchdog relaunch', () => {
 describe('generateVideo — first render child dies during the accelerator handoff', () => {
   // A child that never exits on its own, so the test decides exactly when — and
   // from where — its terminal event fires.
-  const makeSilentProc = (pid) => {
+  const makeSilentProc = (pid, { failWiring = false } = {}) => {
     const listeners = {};
     const proc = {
       pid,
       exitCode: null,
       signalCode: null,
       killed: false,
-      stdout: { on: vi.fn() },
+      stdout: { on: vi.fn(() => { if (failWiring) throw new Error('stdout stream vanished'); }) },
       stderr: { on: vi.fn() },
       on(event, fn) { listeners[event] = fn; return proc; },
       off(event, fn) { if (listeners[event] === fn) delete listeners[event]; return proc; },
@@ -4384,5 +4384,32 @@ describe('generateVideo — first render child dies during the accelerator hando
     // running, and the claim it may already have been handed has to come back.
     expect(child.proc.kill).toHaveBeenCalledWith('SIGTERM');
     expect(heavyClaimRelease).toHaveBeenCalled();
+    // …and the job converges instead of sitting `running` in the jobs map with
+    // its staged temp files, which is the same stranding #4617 is about.
+    expect(failures).toHaveLength(1);
+    expect(failures[0].error).toMatch(/claim file vanished/);
+  });
+
+  it('stops the child and fails the job when the wiring itself throws', async () => {
+    const child = makeSilentProc(204, { failWiring: true });
+    const { spawnDetached } = await import('../../lib/detachedSpawn.js');
+    vi.mocked(spawnDetached).mockClear();
+    vi.mocked(spawnDetached).mockResolvedValueOnce(child.proc);
+
+    await expect(generateVideo({
+      jobId: 'first-child-wiring-throws',
+      pythonPath: '/usr/bin/python3',
+      modelId: 'ltx2_unified',
+      prompt: 'a lighthouse in fog',
+      width: 512,
+      height: 512,
+      numFrames: 25,
+      fps: 24,
+      seed: 987654,
+    })).rejects.toThrow('stdout stream vanished');
+
+    expect(child.proc.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(heavyClaimRelease).toHaveBeenCalled();
+    expect(failures).toHaveLength(1);
   });
 });

--- a/server/services/videoGen/local.test.js
+++ b/server/services/videoGen/local.test.js
@@ -289,6 +289,7 @@ const { makeProc } = vi.hoisted(() => ({
       stdout: { on: vi.fn() },
       stderr: { on: vi.fn() },
       on(event, fn) { listeners[event] = fn; return proc; },
+      off(event, fn) { if (listeners[event] === fn) delete listeners[event]; return proc; },
       kill: vi.fn(),
     };
     // fire close(0) async so the caller's .on('close') handler can register first
@@ -653,6 +654,7 @@ describe('generateChainedVideo — continuation strategy (context window vs last
         stdout: { on: vi.fn() },
         stderr: { on: vi.fn() },
         on(event, fn) { listeners[event] = fn; return proc; },
+        off(event, fn) { if (listeners[event] === fn) delete listeners[event]; return proc; },
         kill: vi.fn(),
       };
       setImmediate(() => listeners.close?.(1, null));
@@ -1388,6 +1390,7 @@ describe('generateVideo — panel-side completion watchdog', () => {
       stdout: { on: vi.fn((event, fn) => { if (event === 'data') stdoutData = fn; }) },
       stderr: { on: vi.fn() },
       on(event, fn) { listeners[event] = fn; return proc; },
+      off(event, fn) { if (listeners[event] === fn) delete listeners[event]; return proc; },
       kill: vi.fn((signal) => { proc.killed = true; proc.signalCode = signal; }),
     };
     return {
@@ -1627,6 +1630,7 @@ describe('generateVideo — pre-output idle-stall deadline', () => {
       stdout: { on: vi.fn((event, fn) => { if (event === 'data') stdoutData = fn; }) },
       stderr: { on: vi.fn((event, fn) => { if (event === 'data') stderrData = fn; }) },
       on(event, fn) { listeners[event] = fn; return proc; },
+      off(event, fn) { if (listeners[event] === fn) delete listeners[event]; return proc; },
       kill: vi.fn((signal) => { proc.killed = true; proc.signalCode = signal; }),
     };
     return {
@@ -2128,15 +2132,13 @@ describe('generateVideo — close-handler resilience (issue #1334)', () => {
   // `running` with no terminal SSE — it has to surface as a 'failed' event.
   it('routes a finalize throw to a terminal failed event instead of an unhandled rejection', async () => {
     vi.resetModules();
-    vi.doMock('./generateVideoHelpers.js', () => ({
-      makeVideoGenLineHandler: () => () => true,
+    // Spread the real module rather than enumerating the handful of exports
+    // generateVideo happens to use today: a listed-exports-only mock breaks the
+    // whole file the moment local.js imports one more helper (it did, twice).
+    vi.doMock('./generateVideoHelpers.js', async (importOriginal) => ({
+      ...(await importOriginal()),
       isWatchdogSuccess: () => false,
       finalizeGeneratedVideo: vi.fn(async () => { throw new Error('boom finalize'); }),
-      // Durable re-render inputs (#3696) — generateVideo reads both while
-      // building `meta`, so a partial mock has to carry them or every render
-      // in this file throws on the missing export.
-      describeRenderConditioning: () => [],
-      RENDER_INPUTS_VERSION: 1,
     }));
     const { generateVideo: gv } = await import('./local.js');
     const { videoGenEvents: events } = await import('./events.js');
@@ -2752,6 +2754,7 @@ describe('generateVideo — BYOV missing-python-module failure path (#1833 regre
         stdout: { on: vi.fn() },
         stderr: { on: (event, fn) => { stderrListeners[event] = fn; } },
         on(event, fn) { listeners[event] = fn; return proc; },
+        off(event, fn) { if (listeners[event] === fn) delete listeners[event]; return proc; },
         kill: vi.fn(),
       };
       // Feed the missing-module traceback to the stderr parser, then exit non-zero.
@@ -2825,6 +2828,7 @@ describe('generateVideo — chunk-boundary marker parsing (#2463)', () => {
       stdout: { on: vi.fn((event, fn) => { if (event === 'data') stdoutData = fn; }) },
       stderr: { on: vi.fn((event, fn) => { if (event === 'data') stderrData = fn; }) },
       on(event, fn) { listeners[event] = fn; return proc; },
+      off(event, fn) { if (listeners[event] === fn) delete listeners[event]; return proc; },
       kill: vi.fn((signal) => { proc.killed = true; proc.signalCode = signal; }),
     };
     return {
@@ -2931,6 +2935,7 @@ describe('generateVideo — signal-death diagnosis (#3101)', () => {
       stdout: { on: vi.fn((event, fn) => { if (event === 'data') stdoutData = fn; }) },
       stderr: { on: vi.fn((event, fn) => { if (event === 'data') stderrData = fn; }) },
       on(event, fn) { listeners[event] = fn; return proc; },
+      off(event, fn) { if (listeners[event] === fn) delete listeners[event]; return proc; },
       kill: vi.fn((signal) => { proc.killed = true; proc.signalCode = signal; }),
     };
     return {
@@ -3885,13 +3890,16 @@ describe('generateVideo — Gemma prompt-encode watchdog relaunch', () => {
       },
       stderr: { on: vi.fn((event, fn) => { onData[`stderr:${event}`] = fn; }) },
       on(event, fn) { listeners[event] = fn; return proc; },
+      off(event, fn) { if (listeners[event] === fn) delete listeners[event]; return proc; },
       kill: vi.fn(),
     };
     return {
       proc,
-      // The listener that decides whether this child can ever report a terminal
-      // event. Its presence is the whole point of wiring before the handoff.
-      isWired: () => typeof listeners.close === 'function',
+      // Full wiring — the stdout reader goes on with the real terminal handler,
+      // and only there. The pre-handoff exit buffer subscribes to 'close'/'error'
+      // alone, so this stays false across the handoff window even though the
+      // child's exit can no longer be lost.
+      isWired: () => typeof onData['stdout:data'] === 'function',
       stderr: (text) => onData['stderr:data']?.(Buffer.from(`${text}\n`)),
       close: async (code, signal) => {
         proc.exitCode = code;
@@ -4256,5 +4264,125 @@ describe('generateVideo — Gemma prompt-encode watchdog relaunch', () => {
     await second.close(3, null);
     expect(failures).toHaveLength(1);
     expect(heavyClaimRelease).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── the first render child vs the accelerator handoff (#4617) ────────────────
+// Between `spawnDetached` resolving and the render child's real listeners going
+// on sits the machine-claim handoff — an await on real file I/O. A child that
+// dies inside that window emits with nobody subscribed: a lost 'close' leaves
+// the job `running` forever while still holding the accelerator claim (every
+// later render then 409s), and a lost 'error' is worse, since an EventEmitter
+// with no 'error' listener throws and takes the server down with it.
+describe('generateVideo — first render child dies during the accelerator handoff', () => {
+  // A child that never exits on its own, so the test decides exactly when — and
+  // from where — its terminal event fires.
+  const makeSilentProc = (pid) => {
+    const listeners = {};
+    const proc = {
+      pid,
+      exitCode: null,
+      signalCode: null,
+      killed: false,
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on(event, fn) { listeners[event] = fn; return proc; },
+      off(event, fn) { if (listeners[event] === fn) delete listeners[event]; return proc; },
+      kill: vi.fn(),
+    };
+    return {
+      proc,
+      close: (code, signal) => {
+        proc.exitCode = code;
+        proc.signalCode = signal;
+        return listeners.close?.(code, signal);
+      },
+      // A spawn-side failure (no `sh`, no PID recorded) — the handle reports it
+      // as 'error' and never populates exitCode, so nothing but a listener can
+      // observe it.
+      error: (err) => listeners.error?.(err),
+    };
+  };
+
+  let failures;
+  let onFailed;
+
+  beforeEach(() => {
+    failures = [];
+    onFailed = (payload) => failures.push(payload);
+    videoGenEvents.on('failed', onFailed);
+  });
+
+  afterEach(() => {
+    videoGenEvents.off('failed', onFailed);
+  });
+
+  const render = async (jobId, child, duringHandoff) => {
+    const { spawnDetached } = await import('../../lib/detachedSpawn.js');
+    vi.mocked(spawnDetached).mockClear();
+    vi.mocked(spawnDetached).mockResolvedValueOnce(child.proc);
+    heavyClaimHandoff.mockImplementationOnce(async () => duringHandoff());
+    return generateVideo({
+      jobId,
+      pythonPath: '/usr/bin/python3',
+      modelId: 'ltx2_unified',
+      prompt: 'a lighthouse in fog',
+      width: 512,
+      height: 512,
+      numFrames: 25,
+      fps: 24,
+      seed: 987654,
+    });
+  };
+
+  it('reports the exit and hands the accelerator claim back when the close lands unsubscribed', async () => {
+    const child = makeSilentProc(201);
+    await render('first-child-close-in-handoff', child, () => child.close(3, null));
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0].error).toMatch(/Exit code 3/);
+    expect(heavyClaimRelease).toHaveBeenCalled();
+
+    // …and the real 'close' arriving late carries the same status through a
+    // handler that already ran, so the job must not fail (or release) twice.
+    await child.close(3, null);
+    expect(failures).toHaveLength(1);
+    expect(heavyClaimRelease).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a spawn error raised in the same window, which no exit status records', async () => {
+    const child = makeSilentProc(202);
+    await render('first-child-error-in-handoff', child, () => child.error(new Error('detached spawn produced no PID')));
+
+    // exitCode/signalCode stay null on a spawn failure — only a subscriber sees it.
+    expect(child.proc.exitCode).toBeNull();
+    expect(failures).toHaveLength(1);
+    expect(failures[0].error).toMatch(/produced no PID/);
+    expect(heavyClaimRelease).toHaveBeenCalled();
+  });
+
+  it('stops the child and releases the claim when the handoff itself throws', async () => {
+    const child = makeSilentProc(203);
+    const { spawnDetached } = await import('../../lib/detachedSpawn.js');
+    vi.mocked(spawnDetached).mockClear();
+    vi.mocked(spawnDetached).mockResolvedValueOnce(child.proc);
+    heavyClaimHandoff.mockImplementationOnce(async () => { throw new Error('claim file vanished'); });
+
+    await expect(generateVideo({
+      jobId: 'first-child-handoff-throws',
+      pythonPath: '/usr/bin/python3',
+      modelId: 'ltx2_unified',
+      prompt: 'a lighthouse in fog',
+      width: 512,
+      height: 512,
+      numFrames: 25,
+      fps: 24,
+      seed: 987654,
+    })).rejects.toThrow('claim file vanished');
+
+    // Never wired, so it could never report anything — it must not be left
+    // running, and the claim it may already have been handed has to come back.
+    expect(child.proc.kill).toHaveBeenCalledWith('SIGTERM');
+    expect(heavyClaimRelease).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

`generateVideo()` spawned the first render child, then awaited the machine accelerator-claim handoff **before** attaching any `close` / `error` listener. `spawnDetached` defers its first emission to a `setImmediate` precisely so a caller that subscribes synchronously misses nothing — but that handoff does real file I/O, so a child that died inside the window (a venv that imports and aborts, an OOM kill, a launcher that never recorded a PID) emitted with nobody subscribed:

- a lost `close` left the job `running` forever while the claim stayed handed off to a dead PID, so every later local render 409'd on a busy accelerator;
- a lost `error` was worse — an `EventEmitter` with no `'error'` listener **throws**, and outside the request lifecycle that takes the server down.

Both render children now go through one path: a `bufferChildExit()` sink attached in the same tick the spawn resolves, read back in the same tick the real handlers go on, and replayed into them so the job still reaches a terminal state and gives the claim back. That subsumes the `exitCode`-only corpse check the prompt-encode relaunch used (kept as a backstop), which could not observe an `error` at all.

Local review surfaced two adjacent holes on the same window, fixed in the second commit: a handoff that itself threw released the claim but left the job `running` in the jobs map with its staged temp files and no terminal event, and left the unwired child running; and a throw out of the wiring itself was unguarded on the first child the way `retryWired` guards the relaunch. All pre-wiring failures now converge on `abandonBeforeWiring()`, mirroring the existing `buildArgs` failure path. `wireRenderChild()` also attaches both real listeners last, so a throw part-way through leaves the exit buffer as the child's only sink rather than a half-wired handler reporting the job twice.

## Test plan

- `cd server && npm test` — 1494 files, 30986 tests green.
- Four new integration tests in `local.test.js` drive the first child's terminal event from *inside* the claim handoff (unsubscribed `close`; a spawn `error` that never populates `exitCode`, so only a subscriber can see it), plus a handoff that throws and a wiring that throws. Each asserts the job reaches a terminal `failed` event and the accelerator claim is released, and the late real `close` is absorbed rather than failing the job twice.
- All four **fail on `origin/main`** (verified by restoring the baseline `local.js` under the new tests): no `failed` event, no claim release, no `SIGTERM`.
- Six unit tests for `bufferChildExit` in `generateVideoHelpers.test.js` lock the contract: first event wins, `take()` detaches, and an `error` is absorbed instead of thrown.
- Reviewed locally with `codex` (high effort, two rounds — findings applied) and `antigravity` (medium effort); both report no material findings.

Closes #4617
