### PR TITLE
Fetch trellis2-apple submodules so TRELLIS.2's Metal texture baker can build

### DIFF
--- a/client/src/pages/Media3D.jsx
+++ b/client/src/pages/Media3D.jsx
@@ -500,12 +500,14 @@ export default function Media3D() {
         label={installTarget?.label}
         installUrlBase={installTarget ? `/api/image-to-3d/targets/${installTarget.id}/install` : undefined}
         // Repairing an already-installed target must re-run setup.sh rather than
-        // short-circuit on "already installed" — that re-run is what rebuilds the
-        // Metal texture-baking backends once the Metal Toolchain is present (#2952).
+        // short-circuit on "already installed" — that re-run is what rebuilds the Metal
+        // texture-baking backends once their build deps are present: the Metal Toolchain
+        // (#2952/#3041) and trellis2-apple's Eigen submodule, which upstream's setup.sh
+        // never fetches, so o_voxel could never compile without the apple-deps step.
         params={installTarget?.textureBake?.quality === 'fallback' ? { repair: '1' } : undefined}
         description={installTarget?.textureBake?.quality === 'fallback'
-          ? 'Downloading the Xcode Metal Toolchain if it\'s missing, then re-running the TRELLIS.2 setup to rebuild its Metal texture-baking backends. Your already-downloaded models are kept, and no password is required.'
-          : `Cloning the TRELLIS.2 (Apple Silicon) port and installing its Python environment (~15 GB on first run). If the Xcode Metal Toolchain is missing it is downloaded first, so textures bake at full quality.${gatedRepoCount ? ` It also pulls ${gatedRepoCount} gated Hugging Face ${gatedRepoCount === 1 ? 'model' : 'models'} on first render — accept their terms and add a Hugging Face token above (see the note on the 3D page).` : ''}`}
+          ? 'Fetching whichever build dependency is missing — the Xcode Metal Toolchain, the Eigen submodule the mesh baker compiles against, or both — then re-running the TRELLIS.2 setup to rebuild its Metal texture-baking backends. Your already-downloaded models are kept, and no password is required.'
+          : `Cloning the TRELLIS.2 (Apple Silicon) port and installing its Python environment (~15 GB on first run). Missing build dependencies (the Xcode Metal Toolchain, the mesh baker's Eigen submodule) are fetched first, so textures bake at full quality.${gatedRepoCount ? ` It also pulls ${gatedRepoCount} gated Hugging Face ${gatedRepoCount === 1 ? 'model' : 'models'} on first render — accept their terms and add a Hugging Face token above (see the note on the 3D page).` : ''}`}
         onClose={() => setInstallTarget(null)}
         onComplete={() => { setInstallTarget(null); load(); }}
       />

--- a/server/services/imageTo3d/trellis2.js
+++ b/server/services/imageTo3d/trellis2.js
@@ -284,6 +284,18 @@ export const TRELLIS2_METAL_TOOLCHAIN_STEP = Object.freeze({
  *    submodules in place. `setup.sh` re-runs the `o-voxel` install unconditionally, so
  *    the rebuild follows in the same pass.
  *
+ * **"Already cloned" needs `o-voxel/` present, not just `.git`.** A clone killed
+ * partway (SIGKILL, power loss) can leave `.git` behind with no worktree. Keying only
+ * on `.git` would then pick the update branch, whose `git submodule update` cannot
+ * restore a missing superproject worktree — it would succeed as a no-op, upstream's
+ * `! -d` guard would skip its own clone, and `pip install deps/trellis2-apple/o-voxel`
+ * would fail on a path that does not exist: silent, permanent degradation, the exact
+ * failure this step exists to remove. Requiring the directory upstream actually
+ * installs from routes that state to the clone branch instead, which fails loudly on
+ * the non-empty target and names the real problem in the log. It does not self-heal
+ * (that needs a re-clone, so it is deliberately left to the operator) but it never
+ * again reports success while leaving `o_voxel` unbuildable.
+ *
  * `optional` for the same reason the toolchain step is: a host that cannot reach
  * gitlab.com for Eigen must still be able to install and render, degraded, rather than
  * fail the whole install.
@@ -294,7 +306,10 @@ export const TRELLIS2_METAL_TOOLCHAIN_STEP = Object.freeze({
  */
 function trellis2AppleDepsStep(base, exists) {
   const dir = trellis2AppleDepDir(base);
-  const cloned = exists(join(dir, '.git'));
+  // Both halves required — see "Already cloned" above. `o-voxel` is the subdirectory
+  // upstream's `setup.sh` pip-installs, so its absence means the checkout is unusable
+  // no matter what `.git` says.
+  const cloned = exists(join(dir, '.git')) && exists(join(dir, 'o-voxel'));
   return {
     stage: 'apple-deps',
     command: 'git',

--- a/server/services/imageTo3d/trellis2.js
+++ b/server/services/imageTo3d/trellis2.js
@@ -37,9 +37,26 @@ const LABEL = 'TRELLIS.2';
 /** The Apple Silicon MPS port of Microsoft TRELLIS.2. */
 export const TRELLIS2_REPO = 'https://github.com/shivampkumar/trellis-mac';
 
+/**
+ * The one upstream dep PortOS clones itself — not because it is the only one with a
+ * submodule (`deps/mtlmesh` has two), but because it is the only one whose submodule is
+ * load-bearing on Apple Silicon: `mtlmesh`'s `cubvh`/`mtlbvh` feed only its CUDA
+ * extensions, so they stay empty here harmlessly. See `trellis2AppleDepsStep`.
+ */
+export const TRELLIS2_APPLE_REPO = 'https://github.com/pedronaugusto/trellis2-apple.git';
+
 /** Clone/install root. `base` overridable for tests. */
 export function trellis2Root(base = join(HOME, '.portos')) {
   return join(base, 'trellis2');
+}
+
+/**
+ * Where `setup.sh` expects the `trellis2-apple` dep checkout. Its `deps/` is
+ * gitignored in the port, so this is never a submodule of `TRELLIS2_REPO` — it is a
+ * plain directory that upstream clones into, and that PortOS can therefore pre-fill.
+ */
+export function trellis2AppleDepDir(base) {
+  return join(trellis2Root(base), 'deps', 'trellis2-apple');
 }
 
 /** The venv Python the `setup.sh` script builds inside the clone. */
@@ -104,7 +121,7 @@ export const TRELLIS2_BAKE_QUALITY_MODULES = ['flex_gemm'];
 export const TRELLIS2_FALLBACK_BAKE_HELP = 'TRELLIS.2 is installed, but its Metal '
   + 'texture-baking backend is missing, so renders fall back to a low-resolution '
   + 'baker that produces correct geometry with a scrambled, speckled surface. Repair '
-  + 'install downloads the Xcode Metal Toolchain and rebuilds the Metal backends — '
+  + 'install fetches the missing build dependencies and rebuilds the Metal backends — '
   + 'your downloaded models are kept.';
 
 /** The shell probe that reports which bake modules resolve inside the venv. */
@@ -243,6 +260,55 @@ export const TRELLIS2_METAL_TOOLCHAIN_STEP = Object.freeze({
 });
 
 /**
+ * Pre-fetch `deps/trellis2-apple` **with its submodules**, which upstream's `setup.sh`
+ * cannot do for itself.
+ *
+ * `o_voxel` — one of the three modules `TRELLIS2_METAL_BAKE_MODULES` gates the Metal
+ * bake on — compiles against Eigen, which `trellis2-apple` carries as a git submodule
+ * (`o-voxel/third_party/eigen`). Upstream's `clone_dep` runs a bare
+ * `git clone --depth 1` with no `--recurse-submodules`, so `third_party/eigen` lands as
+ * an EMPTY directory and the build dies on `fatal error: 'Eigen/Dense' file not found`.
+ * `setup.sh` swallows that (`|| echo`) and still exits 0 — so the install "succeeds"
+ * while permanently stuck on the confetti fallback baker of
+ * `TRELLIS2_FALLBACK_BAKE_HELP`, and installing Xcode or the Metal Toolchain (what the
+ * warning used to tell users to do) could never fix it.
+ *
+ * PortOS fixes it from outside upstream: `clone_dep`'s guard is a bare
+ * `if [ ! -d "$DEPS_DIR/$dir" ]`, so a directory we cloned ourselves makes upstream skip
+ * its own clone, and its unconditional `o-voxel` install then succeeds on the first
+ * pass — no need to duplicate upstream's uv / `--no-build-isolation` flags here.
+ *
+ * Two shapes, because a repair has to fix an install that is already on disk:
+ *  - **absent** → clone it, submodules and all.
+ *  - **already cloned** by an older `setup.sh`, so Eigen is missing → initialize the
+ *    submodules in place. `setup.sh` re-runs the `o-voxel` install unconditionally, so
+ *    the rebuild follows in the same pass.
+ *
+ * `optional` for the same reason the toolchain step is: a host that cannot reach
+ * gitlab.com for Eigen must still be able to install and render, degraded, rather than
+ * fail the whole install.
+ *
+ * @param {string|undefined} base
+ * @param {(p: string) => boolean} exists
+ * @returns {{stage: string, command: string, args: string[], cwd?: string, optional: boolean}}
+ */
+function trellis2AppleDepsStep(base, exists) {
+  const dir = trellis2AppleDepDir(base);
+  const cloned = exists(join(dir, '.git'));
+  return {
+    stage: 'apple-deps',
+    command: 'git',
+    args: cloned
+      ? ['submodule', 'update', '--init', '--recursive', '--depth', '1']
+      : ['clone', '--depth', '1', '--recurse-submodules', '--shallow-submodules',
+        TRELLIS2_APPLE_REPO, dir],
+    // Only the in-place update needs a cwd; the clone creates `dir` itself.
+    ...(cloned ? { cwd: dir } : {}),
+    optional: true,
+  };
+}
+
+/**
  * The install as an ordered list of `{stage, command, args, cwd?}` steps: shallow-
  * clone the port, then run its `setup.sh` (which builds the venv + fetches weights).
  * Keeping the plan a data structure makes it assertable without running it.
@@ -262,6 +328,12 @@ export const TRELLIS2_METAL_TOOLCHAIN_STEP = Object.freeze({
  * from `probeMetalToolchain()`; a host that already has it, can't have it (Command
  * Line Tools only), or isn't macOS gets no step.
  *
+ * **The `apple-deps` step sits between the clone and `setup.sh`.** Both sides of that
+ * are load-bearing: AFTER the root clone, for the non-empty-target reason above (this
+ * step creates `<root>/deps/…`); and BEFORE `setup.sh`, because that is what makes
+ * upstream's `clone_dep` skip its own submodule-less clone. See
+ * `trellis2AppleDepsStep`.
+ *
  * @param {string} [base]
  * @param {{exists?: (p: string) => boolean, installMetalToolchain?: boolean}} [opts]
  * @returns {Array<{stage: string, command: string, args: string[], cwd?: string, optional?: boolean}>}
@@ -277,6 +349,7 @@ export function buildInstallSteps(base, { exists = existsSync, installMetalToolc
   if (!exists(join(root, '.git'))) {
     steps.push({ stage: 'clone', command: 'git', args: ['clone', '--depth', '1', TRELLIS2_REPO, root] });
   }
+  steps.push(trellis2AppleDepsStep(base, exists));
   steps.push({ stage: 'setup', command: 'bash', args: ['setup.sh'], cwd: root });
   return steps;
 }

--- a/server/services/imageTo3d/trellis2.test.js
+++ b/server/services/imageTo3d/trellis2.test.js
@@ -3,7 +3,9 @@ import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import {
   TRELLIS2_REPO,
+  TRELLIS2_APPLE_REPO,
   trellis2Root,
+  trellis2AppleDepDir,
   trellis2VenvPython,
   trellis2GenerateScript,
   trellis2GenerateRunnerScript,
@@ -74,31 +76,35 @@ describe('isTrellis2Installed', () => {
 describe('buildInstallSteps', () => {
   it('clones the MPS port then runs its setup.sh when nothing is on disk', () => {
     const steps = buildInstallSteps(BASE, { exists: () => false });
-    expect(steps.map((s) => s.stage)).toEqual(['clone', 'setup']);
+    // apple-deps sits between the two for reasons both load-bearing: after the clone
+    // because `git clone <root>` refuses a non-empty root, before setup.sh because that
+    // is what makes upstream's `if [ ! -d deps/trellis2-apple ]` guard skip its clone.
+    expect(steps.map((s) => s.stage)).toEqual(['clone', 'apple-deps', 'setup']);
     expect(steps[0]).toMatchObject({ command: 'git' });
     expect(steps[0].args).toContain(TRELLIS2_REPO);
     expect(steps[0].args).toContain(trellis2Root(BASE));
-    expect(steps[1]).toMatchObject({ command: 'bash', args: ['setup.sh'], cwd: trellis2Root(BASE) });
+    expect(steps[2]).toMatchObject({ command: 'bash', args: ['setup.sh'], cwd: trellis2Root(BASE) });
   });
 
   // #3041: setup.sh compiles the Metal packages from .metal sources, so the
   // toolchain must land BEFORE it runs or those builds fail silently.
   it('leads with the Metal Toolchain step when the toolchain is missing but fetchable', () => {
     const steps = buildInstallSteps(BASE, { exists: () => false, installMetalToolchain: true });
-    expect(steps.map((s) => s.stage)).toEqual(['metal-toolchain', 'clone', 'setup']);
+    expect(steps.map((s) => s.stage)).toEqual(['metal-toolchain', 'clone', 'apple-deps', 'setup']);
     expect(steps[0]).toMatchObject({ command: 'xcodebuild', args: ['-downloadComponent', 'MetalToolchain'] });
   });
 
-  it('marks the toolchain step optional — a missing bake degrades output, it does not break it', () => {
-    const [toolchainStep] = buildInstallSteps(BASE, { exists: () => false, installMetalToolchain: true });
-    expect(toolchainStep.optional).toBe(true);
-    // The required steps stay required, or a real failure would be swallowed.
-    expect(buildInstallSteps(BASE, { exists: () => false }).every((s) => !s.optional)).toBe(true);
+  it('marks the bake-only steps optional — a missing bake degrades output, it does not break it', () => {
+    // Only the two bake-dependency steps degrade. The clone and setup.sh stay
+    // required, or a real failure would be swallowed.
+    const optionalStages = buildInstallSteps(BASE, { exists: () => false, installMetalToolchain: true })
+      .filter((s) => s.optional).map((s) => s.stage);
+    expect(optionalStages).toEqual(['metal-toolchain', 'apple-deps']);
   });
 
   it('omits the toolchain step by default (already present / not macOS / not fetchable)', () => {
     expect(buildInstallSteps(BASE, { exists: () => false }).map((s) => s.stage))
-      .toEqual(['clone', 'setup']);
+      .toEqual(['clone', 'apple-deps', 'setup']);
   });
 
   it('does not let a caller mutate the shared toolchain step template', () => {
@@ -114,8 +120,43 @@ describe('buildInstallSteps', () => {
     // begin at the idempotent setup.sh.
     const gitDir = join(trellis2Root(BASE), '.git');
     const steps = buildInstallSteps(BASE, { exists: (p) => p === gitDir });
-    expect(steps.map((s) => s.stage)).toEqual(['setup']);
-    expect(steps[0]).toMatchObject({ command: 'bash', args: ['setup.sh'], cwd: trellis2Root(BASE) });
+    expect(steps.map((s) => s.stage)).toEqual(['apple-deps', 'setup']);
+    expect(steps[1]).toMatchObject({ command: 'bash', args: ['setup.sh'], cwd: trellis2Root(BASE) });
+  });
+
+  // The bug behind #2952's long tail: o_voxel compiles against Eigen, which
+  // trellis2-apple carries as a submodule. Upstream's clone_dep never fetches it, the
+  // build dies on 'Eigen/Dense' not found, setup.sh swallows it, and the install lands
+  // permanently on the confetti fallback baker — unfixable by installing Xcode.
+  describe('apple-deps (the Eigen submodule upstream never fetches)', () => {
+    const appleGitDir = join(trellis2AppleDepDir(BASE), '.git');
+    const appleStep = (exists) => buildInstallSteps(BASE, { exists })
+      .find((s) => s.stage === 'apple-deps');
+
+    it('clones trellis2-apple WITH submodules when the dep is not on disk', () => {
+      const step = appleStep(() => false);
+      expect(step).toMatchObject({ command: 'git', optional: true });
+      expect(step.args).toContain('--recurse-submodules');
+      // Eigen's full history is ~117 MB against ~10 MB shallow, for zero benefit.
+      expect(step.args).toContain('--shallow-submodules');
+      expect(step.args).toContain(TRELLIS2_APPLE_REPO);
+      expect(step.args).toContain(trellis2AppleDepDir(BASE));
+      // Cloned into place, so there is nothing to cd into yet.
+      expect(step.cwd).toBeUndefined();
+    });
+
+    // Re-cloning over an existing checkout would abort the way the root clone does, so
+    // the repair path updates in place instead. `optional` matters most on THIS branch:
+    // it is the one a user reaches by clicking Repair, and Eigen is the install's only
+    // gitlab.com fetch — the likeliest to be blocked.
+    it('initializes submodules in place when an older setup.sh already cloned it', () => {
+      expect(appleStep((p) => p === appleGitDir)).toMatchObject({
+        command: 'git',
+        args: ['submodule', 'update', '--init', '--recursive', '--depth', '1'],
+        cwd: trellis2AppleDepDir(BASE),
+        optional: true,
+      });
+    });
   });
 });
 
@@ -688,7 +729,7 @@ describe('installTrellis2', () => {
   };
 
   it('runs each install step in order and emits stage + complete events', async () => {
-    const children = [makeChild(), makeChild()];
+    const children = [makeChild(), makeChild(), makeChild()];
     let i = 0;
     const spawnImpl = vi.fn(() => children[i++]);
     const events = [];
@@ -698,11 +739,16 @@ describe('installTrellis2', () => {
     expect(spawnImpl).toHaveBeenNthCalledWith(1, 'git', expect.arrayContaining(['clone']), {});
     children[0].emit('close', 0);
     await flush(); // let the await in the loop (through the retry wrapper) advance
-    expect(spawnImpl).toHaveBeenNthCalledWith(2, 'bash', ['setup.sh'], { cwd: trellis2Root(BASE) });
+    // step 2 (apple-deps) — the submodule-aware clone upstream's setup.sh cannot do.
+    expect(spawnImpl).toHaveBeenNthCalledWith(2, 'git', expect.arrayContaining(['--recurse-submodules']), {});
     children[1].emit('close', 0);
+    await flush();
+    expect(spawnImpl).toHaveBeenNthCalledWith(3, 'bash', ['setup.sh'], { cwd: trellis2Root(BASE) });
+    children[2].emit('close', 0);
     await expect(promise).resolves.toEqual({ ok: true });
 
-    expect(events.filter((e) => e.type === 'stage').map((e) => e.stage)).toEqual(['clone', 'setup']);
+    expect(events.filter((e) => e.type === 'stage').map((e) => e.stage))
+      .toEqual(['clone', 'apple-deps', 'setup']);
     expect(events.at(-1)).toMatchObject({ type: 'complete' });
   });
 
@@ -710,15 +756,17 @@ describe('installTrellis2', () => {
   // install must verify what landed and report it BEFORE the terminal `complete`
   // frame — which closes the client's EventSource (#2952).
   const runToCompletion = async (probeBake) => {
-    const children = [makeChild(), makeChild()];
+    const children = [makeChild(), makeChild(), makeChild()];
     let i = 0;
     const events = [];
     const { promise } = installTrellis2({
       base: BASE, spawnImpl: () => children[i++], onEvent: (e) => events.push(e), probeBake,
     });
-    children[0].emit('close', 0);
+    children[0].emit('close', 0); // clone
     await flush();
-    children[1].emit('close', 0);
+    children[1].emit('close', 0); // apple-deps
+    await flush();
+    children[2].emit('close', 0); // setup
     await promise;
     return events;
   };
@@ -726,7 +774,7 @@ describe('installTrellis2', () => {
   // #3041: the caller (the route) resolves the toolchain situation and passes a
   // plain boolean, so installTrellis2 keeps returning { promise, kill } synchronously.
   it('downloads the Metal Toolchain first when the caller says it is needed', async () => {
-    const children = [makeChild(), makeChild(), makeChild()];
+    const children = [makeChild(), makeChild(), makeChild(), makeChild()];
     let i = 0;
     const spawnImpl = vi.fn(() => children[i++]);
     const { promise } = installTrellis2({
@@ -741,14 +789,16 @@ describe('installTrellis2', () => {
     expect(spawnImpl).toHaveBeenNthCalledWith(2, 'git', expect.arrayContaining(['clone']), {});
     children[1].emit('close', 0);
     await flush();
-    children[2].emit('close', 0);
+    children[2].emit('close', 0); // apple-deps
+    await flush();
+    children[3].emit('close', 0); // setup
     await expect(promise).resolves.toEqual({ ok: true });
   });
 
   it('continues the install when the optional toolchain step fails, and still verifies', async () => {
     // Geometry is unaffected by a missing bake, so a host that cannot fetch the
     // toolchain must still end up with a working (if degraded) install.
-    const children = [makeChild(), makeChild(), makeChild()];
+    const children = [makeChild(), makeChild(), makeChild(), makeChild()];
     let i = 0;
     const events = [];
     const { promise } = installTrellis2({
@@ -760,9 +810,11 @@ describe('installTrellis2', () => {
     });
     children[0].emit('close', 1); // toolchain download failed
     await flush();
-    children[1].emit('close', 0);
+    children[1].emit('close', 0); // clone
     await flush();
-    children[2].emit('close', 0);
+    children[2].emit('close', 0); // apple-deps
+    await flush();
+    children[3].emit('close', 0); // setup
     await expect(promise).resolves.toEqual({ ok: true });
     expect(events.find((e) => e.stage === 'metal-toolchain' && /Optional step/.test(e.message || ''))).toBeTruthy();
     expect(events.find((e) => e.stage === 'verify')?.message).toContain('degraded');
@@ -771,7 +823,7 @@ describe('installTrellis2', () => {
   it('retries a TRANSIENT optional-step failure before giving up on it', async () => {
     // Optional-ness must not short-circuit the retry path — a dropped connection
     // during the toolchain download deserves the same retries as any other step.
-    const children = [makeChild(), makeChild(), makeChild(), makeChild()];
+    const children = [makeChild(), makeChild(), makeChild(), makeChild(), makeChild()];
     let i = 0;
     const spawnImpl = vi.fn(() => children[i++]);
     const { promise } = installTrellis2({
@@ -792,7 +844,9 @@ describe('installTrellis2', () => {
     expect(spawnImpl).toHaveBeenNthCalledWith(3, 'git', expect.arrayContaining(['clone']), {});
     children[2].emit('close', 0);
     await flush();
-    children[3].emit('close', 0);
+    children[3].emit('close', 0); // apple-deps
+    await flush();
+    children[4].emit('close', 0); // setup
     await expect(promise).resolves.toEqual({ ok: true });
   });
 
@@ -831,7 +885,7 @@ describe('installTrellis2', () => {
   });
 
   it('spawns install steps under the caller-supplied env, alongside each step cwd', async () => {
-    const children = [makeChild(), makeChild()];
+    const children = [makeChild(), makeChild(), makeChild()];
     let i = 0;
     const spawnImpl = vi.fn(() => children[i++]);
     const env = { PATH: '/usr/bin', HF_TOKEN: 'hf_test' };
@@ -841,8 +895,12 @@ describe('installTrellis2', () => {
     expect(spawnImpl).toHaveBeenNthCalledWith(1, 'git', expect.arrayContaining(['clone']), { env });
     children[0].emit('close', 0);
     await flush();
-    expect(spawnImpl).toHaveBeenNthCalledWith(2, 'bash', ['setup.sh'], { cwd: trellis2Root(BASE), env });
+    // Same for the apple-deps clone, which also runs without a cwd.
+    expect(spawnImpl).toHaveBeenNthCalledWith(2, 'git', expect.arrayContaining(['--recurse-submodules']), { env });
     children[1].emit('close', 0);
+    await flush();
+    expect(spawnImpl).toHaveBeenNthCalledWith(3, 'bash', ['setup.sh'], { cwd: trellis2Root(BASE), env });
+    children[2].emit('close', 0);
     await expect(promise).resolves.toEqual({ ok: true });
   });
 
@@ -865,22 +923,27 @@ describe('installTrellis2', () => {
 
   it('resumes at setup (no re-clone) when the repo is already on disk', async () => {
     // Re-running Install after a setup-stage failure must NOT re-clone into the
-    // existing root; it must go straight to the idempotent setup.sh.
-    const child = makeChild();
-    const spawnImpl = vi.fn(() => child);
+    // existing root; it must go straight to the apple-deps fix and the idempotent
+    // setup.sh.
+    const children = [makeChild(), makeChild()];
+    let i = 0;
+    const spawnImpl = vi.fn(() => children[i++]);
     const gitDir = join(trellis2Root(BASE), '.git');
     const { promise } = installTrellis2({
       base: BASE, spawnImpl, exists: (p) => p === gitDir, sleep: () => Promise.resolve(),
     });
-    expect(spawnImpl).toHaveBeenCalledTimes(1);
-    expect(spawnImpl).toHaveBeenNthCalledWith(1, 'bash', ['setup.sh'], { cwd: trellis2Root(BASE) });
-    child.emit('close', 0);
+    expect(spawnImpl).not.toHaveBeenCalledWith('git', expect.arrayContaining([TRELLIS2_REPO]), expect.anything());
+    expect(spawnImpl).toHaveBeenNthCalledWith(1, 'git', expect.arrayContaining(['--recurse-submodules']), {});
+    children[0].emit('close', 0);
+    await flush();
+    expect(spawnImpl).toHaveBeenNthCalledWith(2, 'bash', ['setup.sh'], { cwd: trellis2Root(BASE) });
+    children[1].emit('close', 0);
     await expect(promise).resolves.toEqual({ ok: true });
   });
 
   it('retries a transient network failure in place and succeeds on the retry', async () => {
-    // clone attempt 1 (transient fail) → clone attempt 2 (ok) → setup (ok)
-    const children = [makeChild(), makeChild(), makeChild()];
+    // clone attempt 1 (transient fail) → clone attempt 2 (ok) → apple-deps → setup
+    const children = [makeChild(), makeChild(), makeChild(), makeChild()];
     let i = 0;
     const spawnImpl = vi.fn(() => children[i++]);
     const events = [];
@@ -896,7 +959,9 @@ describe('installTrellis2', () => {
     expect(spawnImpl).toHaveBeenNthCalledWith(2, 'git', expect.arrayContaining(['clone']), {});
     children[1].emit('close', 0);
     await flush();
-    children[2].emit('close', 0); // setup
+    children[2].emit('close', 0); // apple-deps
+    await flush();
+    children[3].emit('close', 0); // setup
     await expect(promise).resolves.toEqual({ ok: true });
 
     expect(events.some((e) => e.type === 'log' && /retrying/i.test(e.message))).toBe(true);

--- a/server/services/imageTo3d/trellis2.test.js
+++ b/server/services/imageTo3d/trellis2.test.js
@@ -130,6 +130,10 @@ describe('buildInstallSteps', () => {
   // permanently on the confetti fallback baker — unfixable by installing Xcode.
   describe('apple-deps (the Eigen submodule upstream never fetches)', () => {
     const appleGitDir = join(trellis2AppleDepDir(BASE), '.git');
+    const appleOVoxelDir = join(trellis2AppleDepDir(BASE), 'o-voxel');
+    // A healthy existing checkout has both the git dir and the subdirectory upstream
+    // pip-installs from.
+    const healthyCheckout = (p) => p === appleGitDir || p === appleOVoxelDir;
     const appleStep = (exists) => buildInstallSteps(BASE, { exists })
       .find((s) => s.stage === 'apple-deps');
 
@@ -150,12 +154,25 @@ describe('buildInstallSteps', () => {
     // it is the one a user reaches by clicking Repair, and Eigen is the install's only
     // gitlab.com fetch — the likeliest to be blocked.
     it('initializes submodules in place when an older setup.sh already cloned it', () => {
-      expect(appleStep((p) => p === appleGitDir)).toMatchObject({
+      expect(appleStep(healthyCheckout)).toMatchObject({
         command: 'git',
         args: ['submodule', 'update', '--init', '--recursive', '--depth', '1'],
         cwd: trellis2AppleDepDir(BASE),
         optional: true,
       });
+    });
+
+    // A clone killed partway can leave `.git` with no worktree. `git submodule update`
+    // cannot restore a missing superproject, so treating that as "already cloned" would
+    // succeed as a no-op while leaving o_voxel unbuildable forever — upstream's `! -d`
+    // guard skips its clone, and its `pip install …/o-voxel` then targets a path that
+    // does not exist. Route it to the clone branch, which fails loudly instead.
+    it('does NOT treat a partial checkout (.git but no o-voxel/) as already cloned', () => {
+      const step = appleStep((p) => p === appleGitDir);
+      expect(step.args).toContain('clone');
+      expect(step.args).toContain('--recurse-submodules');
+      expect(step.args).not.toContain('submodule');
+      expect(step.cwd).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
## Summary

TRELLIS.2's Metal texture baker could never build on a fresh macOS install, and the warning telling users about it pointed at a remedy that could not fix it.

`o_voxel` — one of the three modules `TRELLIS2_METAL_BAKE_MODULES` gates the Metal bake on — compiles against Eigen, which the `trellis2-apple` dependency carries as a **git submodule**. Upstream's `setup.sh` clones its deps with a bare `git clone --depth 1` and no `--recurse-submodules`, so `o-voxel/third_party/eigen` lands as an **empty directory** and the build dies:

```
src/convert/flexible_dual_grid.cpp:1:10: fatal error: 'Eigen/Dense' file not found
```

`setup.sh` swallows that (`|| echo "  o_voxel (Apple fork) install failed …"`) and still exits 0. So the install reports success, `probeTrellis2TextureBake()` correctly returns `quality: 'fallback'`, and every render silently takes the confetti baker — **permanently**, because the help text sent users to install Xcode and the Metal Toolchain, neither of which can populate an empty submodule.

### The fix

A new `apple-deps` install step, ordered between the root clone and `setup.sh`:

- **Dep absent** → `git clone --depth 1 --recurse-submodules --shallow-submodules <trellis2-apple> <root>/deps/trellis2-apple`
- **Dep already cloned** (older `setup.sh`, so Eigen is missing) → `git submodule update --init --recursive --depth 1` in place

Upstream's `clone_dep` guard is a bare `if [ ! -d "$DEPS_DIR/$dir" ]`, so a directory we created makes it skip its own clone, and its unconditional `o-voxel` install then succeeds on the first pass — without PortOS duplicating upstream's `uv` / `--no-build-isolation` flags.

Both ordering constraints are load-bearing: **after** the root clone (`git clone <root>` refuses a non-empty target, and this step creates `<root>/deps/…`), **before** `setup.sh` (that is what makes the guard skip).

Marked `optional`, matching the Metal Toolchain step: Eigen is the install's only gitlab.com fetch, so a host that cannot reach it must still get a working, if degraded, install rather than a failed one.

### Also

- **Stopped blaming the Metal Toolchain for the whole problem.** `TRELLIS2_FALLBACK_BAKE_HELP` and the client's install/repair copy both said the remedy was downloading the toolchain. That is what sent users off to install Xcode for a fault it could not fix. Server and client wording now match.
- **A partial checkout no longer passes as healthy.** Keying "already cloned" on `.git` alone meant a clone killed partway (`.git`, no worktree) took the in-place update branch — a no-op that cannot restore a missing superproject, after which upstream skips its clone and `pip install …/o-voxel` fails on a nonexistent path. Now requires `o-voxel/` too, so that state routes to the clone branch and fails loudly instead. It does not self-heal (that needs a re-clone, left to the operator), but it never again reports success while `o_voxel` stays unbuildable.

## Why only this dep

`deps/mtlmesh` also has submodules (`cubvh`, `mtlbvh`) and they are also empty — but they feed only its **CUDA** extensions (`_cuda_extensions()` in its `setup.py`); the Apple path `_metal_extensions()` doesn't reference them, `cumesh` imports fine without them, and `mtlmesh` isn't in `TRELLIS2_METAL_BAKE_MODULES`. Recursing all deps would fetch CUDA-only sources for zero benefit, so the special case is deliberate.

## Test plan

**On-device, before/after.** The probe went from `{"o_voxel": false, "mtldiffrast": false, "mtlbvh": false, "flex_gemm": false}` to all four `true` once Eigen was fetched — `o_voxel` built in 19s. `GET /api/image-to-3d/targets` then reported:

```json
"textureBake": { "quality": "metal", "missing": [], "degradedQuality": [] }
```

**Verified empirically rather than assumed:**
- `git clone` creates leading directories, so the fresh-install path works even though `<root>/deps` doesn't exist yet (this matters because the step is `optional` — a failure here would degrade silently).
- `--depth 1` shallows only the superproject; `--shallow-submodules` is what avoids Eigen's full history (117 MB → ~10 MB).
- `git submodule update --init --recursive --depth 1` on an already-populated checkout is a ~120 ms no-op needing no network (confirmed with `-c protocol.https.allow=never`).

**Suites:** `server` 30,938 passed / `client` 686 files, 8,500 passed / client `biome lint` clean. Every new guard was watched fail with the fix removed, then restored.

## Follow-up

#4636 — surface `textureBake.missing` in the verify frame and target card. The data already reaches the client; nothing renders it, so a failed `apple-deps` step still leaves Repair reprinting a generic message. Deferred to keep this change to one seam.
