### PR TITLE
fix(local-llm): point speculative-decoding presets at Hugging Face repos that exist

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -843,7 +843,7 @@ export function LocalLlmTab() {
     e?.preventDefault?.();
     // Submitting with Enter bypasses the disabled button, so re-check here.
     if (llamaModelMissing) {
-      toast.error('Please specify a base model path (e.g. models/Qwen3.8-27B-Instruct-Q4_K_M.gguf)');
+      toast.error('Please specify a base model path (e.g. models/Qwen3.8-27B-Q4_K_M.gguf)');
       return;
     }
     if (baseWeightMissing || draftWeightMissing) {

--- a/docs/features/dflash2.md
+++ b/docs/features/dflash2.md
@@ -46,8 +46,13 @@ search filters them out of the install picker.
 
 DSpark pairs (stock llama.cpp):
 
-- **Qwen 3.8 27B**: base `Qwen/Qwen3.8-27B-Instruct-GGUF` + drafter `DimInfer/Qwen3.8-27B-Dspark-v1`
-- **Qwen 3 8B**: base `Qwen/Qwen3-8B-Instruct-GGUF` + drafter converted from `deepseek-ai/dspark_qwen3_8b_block7`
+- **Qwen 3.8 27B**: base `ggml-org/Qwen3.8-27B-GGUF` + drafter `erlidev/Qwen3.8-27B-DSpark-GGUF` (a GGUF conversion of `DimInfer/Qwen3.8-27B-Dspark-v1`)
+- **Qwen 3 8B**: base `Qwen/Qwen3-8B-GGUF` + drafter converted from `deepseek-ai/dspark_qwen3_8b_block7`
+
+Qwen publishes no GGUF of the 27B itself — `ggml-org` (llama.cpp's own org) and
+`unsloth`/`bartowski` are the maintained conversions. `ggml-org` is what the
+preset points at because it is the only one publishing a plain, unsharded
+`Qwen3.8-27B-Q4_K_M.gguf`.
 
 DSpark drafters ship without tokenizers — converting one to GGUF requires passing
 `--target-model-dir` so it reuses the target's tokenizer. Keep the drafter at bf16;
@@ -56,11 +61,13 @@ the target can be any quant.
 DFlash 2 pairs (require a source build of llama.cpp [#27342](https://github.com/ggml-org/llama.cpp/pull/27342)):
 
 - **Qwen 3.8 27B Draft Pair**:
-  - Base: `Qwen/Qwen3.8-27B-Instruct-GGUF` (e.g. `Qwen3.8-27B-Instruct-Q4_K_M.gguf`)
+  - Base: `ggml-org/Qwen3.8-27B-GGUF` (e.g. `Qwen3.8-27B-Q4_K_M.gguf`)
   - Drafter: `incoai/Qwen3.8-27B-DFlash2-GGUF` (e.g. `Qwen3.8-27B-DFlash2-Q4_K_M.gguf`)
 - **Muse-Glimmer 30B Draft Pair**:
-  - Base: `meta-models/Muse-Glimmer-30B-GGUF`
-  - Drafter: `z-lab/Muse-Glimmer-30B-DFlash2-GGUF`
+  - Base: `meta-models/Muse-Glimmer-30B-GGUF` (`Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf` — this
+    repo also ships an `mmproj-…-Q4_K_M.gguf` projector and its own `dflash-…-Q4_K_M.gguf`
+    drafter, so take the target by name rather than by quant tag)
+  - Drafter: `z-lab/Muse-Glimmer-30B-DFlash2-GGUF` (e.g. `Muse-Glimmer-30B-DFlash2-Q4_K_M.gguf`)
 
 ### 2. Launch llama-server
 Start `llama-server` on loopback port `8080` with speculative decoding enabled
@@ -68,8 +75,8 @@ Start `llama-server` on loopback port `8080` with speculative decoding enabled
 
 ```bash
 llama-server \
-  -m models/Qwen3.8-27B-Instruct-Q4_K_M.gguf \
-  --draft-model models/Qwen3.8-27B-DSpark-bf16.gguf \
+  -m models/Qwen3.8-27B-Q4_K_M.gguf \
+  --draft-model models/Qwen3.8-27B-DSpark-BF16.gguf \
   --spec-type draft-dspark \
   --port 8080 \
   --host 127.0.0.1 \

--- a/server/lib/localLlmDisk.js
+++ b/server/lib/localLlmDisk.js
@@ -131,7 +131,12 @@ export function dirIsMlx(filenames = []) {
   return hasSafetensors && !hasGguf;
 }
 
-const isProjectorName = (f) => /(^|[-_./])(mmproj|projector)/i.test(f);
+/**
+ * Is this filename a multimodal projector sidecar rather than model weights?
+ * A projector is never loadable on its own, and repos publish it under the
+ * target's own quant tag, so every "pick the model file" path has to skip it.
+ */
+export const isProjectorName = (f) => /(^|[-_./])(mmproj|projector)/i.test(f);
 const isShardName = (f) => /-\d{5}-of-\d{5}\.gguf$/i.test(f);
 
 /**

--- a/server/lib/specDecodePresets.js
+++ b/server/lib/specDecodePresets.js
@@ -9,7 +9,10 @@
  *
  * `quant` is a HINT, not a filename: repos rename their builds
  * (`…-Q4_K_M.gguf`, `…-instruct-q4_k_m.gguf`, `….Q4_K_M.gguf`) and a hard-coded
- * filename rots the moment one of them re-uploads. `file`, when present, wins.
+ * filename rots the moment one of them re-uploads — so most entries carry only
+ * the hint. `file` is the exception, and it is a PIN rather than a preference:
+ * it appears only where the quant tag cannot discriminate the target, so a pin
+ * that stops resolving is an error, not a cue to fall back to the hint.
  *
  * A file with no published single-file GGUF (the DSpark 8B block ships as a
  * tokenizer-less checkpoint that has to be converted against its target) simply

--- a/server/lib/specDecodePresets.js
+++ b/server/lib/specDecodePresets.js
@@ -29,13 +29,13 @@ export const SPEC_DECODE_PRESETS = Object.freeze([
     label: 'Qwen 3.8 27B + DSpark Drafter (Recommended — stock llama.cpp)',
     specType: 'draft-dspark',
     model: {
-      path: 'models/Qwen3.8-27B-Instruct-Q4_K_M.gguf',
-      repo: 'Qwen/Qwen3.8-27B-Instruct-GGUF',
+      path: 'models/Qwen3.8-27B-Q4_K_M.gguf',
+      repo: 'ggml-org/Qwen3.8-27B-GGUF',
       quant: 'Q4_K_M',
     },
     draftModel: {
-      path: 'models/Qwen3.8-27B-DSpark-bf16.gguf',
-      repo: 'magnitudedev/Qwen3.8-27B-DSpark-GGUF',
+      path: 'models/Qwen3.8-27B-DSpark-BF16.gguf',
+      repo: 'erlidev/Qwen3.8-27B-DSpark-GGUF',
       quant: 'BF16',
     },
   },
@@ -44,8 +44,8 @@ export const SPEC_DECODE_PRESETS = Object.freeze([
     label: 'Qwen 3 8B + DSpark Drafter (small target)',
     specType: 'draft-dspark',
     model: {
-      path: 'models/Qwen3-8B-Instruct-Q4_K_M.gguf',
-      repo: 'Qwen/Qwen3-8B-Instruct-GGUF',
+      path: 'models/Qwen3-8B-Q4_K_M.gguf',
+      repo: 'Qwen/Qwen3-8B-GGUF',
       quant: 'Q4_K_M',
     },
     draftModel: {
@@ -57,8 +57,8 @@ export const SPEC_DECODE_PRESETS = Object.freeze([
     label: 'Qwen 3.8 27B + DFlash 2 Drafter (needs llama.cpp PR #27342 build)',
     specType: 'draft-dflash',
     model: {
-      path: 'models/Qwen3.8-27B-Instruct-Q4_K_M.gguf',
-      repo: 'Qwen/Qwen3.8-27B-Instruct-GGUF',
+      path: 'models/Qwen3.8-27B-Q4_K_M.gguf',
+      repo: 'ggml-org/Qwen3.8-27B-GGUF',
       quant: 'Q4_K_M',
     },
     draftModel: {
@@ -72,8 +72,12 @@ export const SPEC_DECODE_PRESETS = Object.freeze([
     label: 'Muse-Glimmer 30B + DFlash 2 Drafter (needs llama.cpp PR #27342 build)',
     specType: 'draft-dflash',
     model: {
-      path: 'models/Muse-Glimmer-30B-Instruct-Q4_K_M.gguf',
+      path: 'models/Muse-Glimmer-30B-Q4_K_M.gguf',
       repo: 'meta-models/Muse-Glimmer-30B-GGUF',
+      // Pinned: this repo publishes the target next to its own `dflash-` drafter
+      // and `mmproj-` projector, all three carrying the Q4_K_M tag, so the quant
+      // hint alone cannot pick the 17 GB target out of the 1.4 GB sidecars.
+      file: 'Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf',
       quant: 'Q4_K_M',
     },
     draftModel: {

--- a/server/services/specDecodeModels.js
+++ b/server/services/specDecodeModels.js
@@ -19,6 +19,7 @@ import { randomBytes } from 'crypto';
 import { Readable, Transform } from 'stream';
 import { pipeline } from 'stream/promises';
 import { ensureDir, expandHome } from '../lib/fileUtils.js';
+import { isProjectorName, isShardedGguf } from '../lib/localLlmDisk.js';
 import { ServerError } from '../lib/errorHandler.js';
 import { buildHfAuthHeaders, buildHfResolveUrl, fetchHuggingfaceModel, modelSiblingFilenames } from '../lib/huggingfaceLora.js';
 import { getHfToken } from '../lib/hfToken.js';
@@ -89,7 +90,6 @@ export async function getSpecDecodePresetStatus() {
 // A quant hint matches loosely: repos publish `…-Q4_K_M.gguf`, `….q4_k_m.gguf`
 // and `…-Q4_K_M-00001-of-00002.gguf` for the same build.
 const normalize = (text) => String(text).toLowerCase().replace(/[^a-z0-9]/g, '');
-const isShard = (filename) => /-\d{5}-of-\d{5}\.gguf$/i.test(filename);
 
 /**
  * Choose which `.gguf` sibling of the repo to fetch.
@@ -100,15 +100,27 @@ const isShard = (filename) => /-\d{5}-of-\d{5}\.gguf$/i.test(filename);
  * this whole module exists to remove.
  */
 export function pickGgufSibling(model, { file, quant, repo }) {
-  const ggufs = modelSiblingFilenames(model).filter((name) => /\.gguf$/i.test(name));
-  if (!ggufs.length) {
+  const all = modelSiblingFilenames(model).filter((name) => /\.gguf$/i.test(name));
+  if (!all.length) {
     throw new ServerError(`Hugging Face repo ${repo} publishes no .gguf file`, { status: 422, code: 'SPEC_NO_GGUF' });
   }
   if (file) {
-    const exact = ggufs.find((name) => name === file);
+    const exact = all.find((name) => name === file);
     if (exact) return exact;
   }
-  const whole = ggufs.filter((name) => !isShard(name));
+  // A projector ships under the target's own quant tag
+  // (`mmproj-Muse-Glimmer-30B-Q4_K_M.gguf`, 1.4 GB) right beside the 17 GB target,
+  // so shortest-name-wins below would hand one back — and it would then satisfy
+  // the launcher's existence check and fail at load. Only an explicit `file` may
+  // name one, which is why this filter sits after the exact-match branch.
+  const ggufs = all.filter((name) => !isProjectorName(name));
+  if (!ggufs.length) {
+    throw new ServerError(
+      `Hugging Face repo ${repo} publishes only projector (mmproj) sidecars, not a loadable model`,
+      { status: 422, code: 'SPEC_NO_GGUF' },
+    );
+  }
+  const whole = ggufs.filter((name) => !isShardedGguf(name));
   const wanted = quant ? normalize(quant) : null;
   const matches = wanted ? whole.filter((name) => normalize(name).includes(wanted)) : whole;
   if (matches.length) {

--- a/server/services/specDecodeModels.js
+++ b/server/services/specDecodeModels.js
@@ -107,6 +107,16 @@ export function pickGgufSibling(model, { file, quant, repo }) {
   if (file) {
     const exact = all.find((name) => name === file);
     if (exact) return exact;
+    // A pin is authoritative, never a preference: a preset carries `file` only
+    // because its repo's quant tag CANNOT discriminate the target (Muse-Glimmer
+    // tags the projector and the drafter Q4_K_M too). Falling through to the
+    // quant hint there would reinstate the very ambiguity the pin removes — and
+    // land a 1.6 GB drafter in the base model's path. Fail with something the
+    // user can act on instead.
+    throw new ServerError(
+      `Hugging Face repo ${repo} no longer publishes the pinned file ${file} — pick the replacement at https://huggingface.co/${repo} and set the path by hand.`,
+      { status: 422, code: 'SPEC_FILE_MISSING' },
+    );
   }
   // A projector ships under the target's own quant tag
   // (`mmproj-Muse-Glimmer-30B-Q4_K_M.gguf`, 1.4 GB) right beside the 17 GB target,

--- a/server/services/specDecodeModels.test.js
+++ b/server/services/specDecodeModels.test.js
@@ -47,6 +47,44 @@ describe('pickGgufSibling', () => {
   it('rejects a repo with no GGUF at all', () => {
     expect(() => pickGgufSibling(siblings('model.safetensors'), { quant: 'Q4_K_M', repo: 'o/r' })).toThrow(/no \.gguf/i);
   });
+
+  // meta-models/Muse-Glimmer-30B-GGUF ships the projector and the repo's own
+  // drafter beside the target, all three tagged Q4_K_M. Shortest-name-wins would
+  // hand back the 1.4 GB `mmproj-…`, which then satisfies the launcher's
+  // existence check and fails at load.
+  it('never auto-picks an mmproj projector that carries the wanted quant', () => {
+    const model = siblings(
+      'Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf',
+      'mmproj-Muse-Glimmer-30B-Q4_K_M.gguf',
+    );
+    expect(pickGgufSibling(model, { quant: 'Q4_K_M', repo: 'meta-models/Muse-Glimmer-30B-GGUF' }))
+      .toBe('Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf');
+  });
+
+  it('says "projectors only" rather than blaming sharding when that is all a repo has', () => {
+    expect(() => pickGgufSibling(siblings('mmproj-model-Q4_K_M.gguf'), { quant: 'Q4_K_M', repo: 'o/r' }))
+      .toThrow(/projector \(mmproj\) sidecars/i);
+  });
+
+  it('still honours an explicit projector filename', () => {
+    const model = siblings('model-Q4_K_M.gguf', 'mmproj-model-Q4_K_M.gguf');
+    expect(pickGgufSibling(model, { file: 'mmproj-model-Q4_K_M.gguf', quant: 'Q4_K_M', repo: 'o/r' }))
+      .toBe('mmproj-model-Q4_K_M.gguf');
+  });
+
+  // The preset pins `file` precisely because the quant hint is ambiguous here;
+  // this asserts the pin still resolves against the repo's real sibling list.
+  it('resolves the Muse-Glimmer preset to the 17 GB target, not its dflash sidecar', () => {
+    const entry = specDecodePresets.findSpecDecodePreset('muse-glimmer-30b').model;
+    const model = siblings(
+      'Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf',
+      'Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf',
+      'dflash-Muse-Glimmer-30B-Q4_K_M.gguf',
+      'mmproj-Muse-Glimmer-30B-Q4_K_M.gguf',
+    );
+    expect(pickGgufSibling(model, { file: entry.file, quant: entry.quant, repo: entry.repo }))
+      .toBe('Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf');
+  });
 });
 
 describe('getSpecDecodePresetStatus', () => {

--- a/server/services/specDecodeModels.test.js
+++ b/server/services/specDecodeModels.test.js
@@ -32,6 +32,21 @@ describe('pickGgufSibling', () => {
     expect(pickGgufSibling(model, { file: 'pinned.gguf', quant: 'Q4_K_M', repo: 'o/r' })).toBe('pinned.gguf');
   });
 
+  // A preset pins `file` only where the quant tag can't discriminate the target,
+  // so falling back to the hint when the pin is gone reinstates the ambiguity —
+  // here it would fetch the 1.6 GB drafter into the base model's path.
+  it('refuses to fall back to the quant hint when a pinned file is gone', () => {
+    const model = siblings(
+      'Muse-Glimmer-30B-KQuant-Dynamic-Q4_K_XL.gguf',
+      'dflash-Muse-Glimmer-30B-Q4_K_M.gguf',
+    );
+    expect(() => pickGgufSibling(model, {
+      file: 'Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf',
+      quant: 'Q4_K_M',
+      repo: 'meta-models/Muse-Glimmer-30B-GGUF',
+    })).toThrow(/no longer publishes the pinned file/i);
+  });
+
   // A lone shard on disk would satisfy the launcher's existence check and then
   // fail at load — the exact confusion this module exists to remove.
   it('refuses a sharded-only repo instead of fetching part one', () => {


### PR DESCRIPTION
## Summary

Clicking **Download** on either weight in the Speculative Decoding card
(Settings → Local LLMs) failed with `HuggingFace repo Qwen/Qwen3.8-27B-Instruct-GGUF not found`.

Qwen publishes no GGUF conversion of the 27B — and no `Qwen3-8B-Instruct-GGUF`
either — so three of the four presets named a base repo that has never existed,
and the recommended preset's drafter repo publishes only a `Q8_0` build where the
preset asked for `BF16`. Every Download button in the card was dead.

Every preset's repo, quant hint, and resulting filename is now verified against
the live Hugging Face API:

| Preset / role | Was | Now |
|---|---|---|
| Qwen 3.8 27B — base (2 presets) | `Qwen/Qwen3.8-27B-Instruct-GGUF` (404) | `ggml-org/Qwen3.8-27B-GGUF` |
| Qwen 3.8 27B — DSpark drafter | `magnitudedev/…-DSpark-GGUF` @ BF16 (only ships Q8_0) | `erlidev/Qwen3.8-27B-DSpark-GGUF` @ BF16 |
| Qwen 3 8B — base | `Qwen/Qwen3-8B-Instruct-GGUF` (404) | `Qwen/Qwen3-8B-GGUF` |
| Muse-Glimmer 30B — base | quant hint only → resolved to the projector | pinned `file:` to the 17 GB target |

`ggml-org` (llama.cpp's own org) is the pick for the 27B base because it is the
only maintained conversion publishing a plain, unsharded `Qwen3.8-27B-Q4_K_M.gguf`
— `unsloth` ships only `UD-` variants and a sharded BF16.

### The second, quieter bug

`meta-models/Muse-Glimmer-30B-GGUF` ships the 17 GB target beside a 1.4 GB
`mmproj-` projector **and** its own `dflash-` drafter, all three tagged `Q4_K_M`.
`pickGgufSibling`'s shortest-name-wins tiebreak therefore resolved to the
**projector** — which would then satisfy the launcher's file-exists check and fail
at load time, the exact confusion the whole download flow exists to remove.

Projector sidecars are now excluded from automatic selection (an explicit `file`
may still name one, so the pinned-projector case still works), and a repo holding
nothing but projectors says so instead of blaming sharding. The filter reuses
`isProjectorName` / `isShardedGguf` from `server/lib/localLlmDisk.js` — the disk
path already had both patterns — rather than re-deriving them.

A pin is also now **authoritative rather than a preference**. A preset carries
`file` only where the quant tag can't discriminate, so falling back to the hint
when the pinned name stops resolving would reinstate the same ambiguity — with the
target renamed, the hint matches `dflash-Muse-Glimmer-30B-Q4_K_M.gguf` and lands a
1.6 GB drafter in the base model's path. A missing pin is now a 422 naming the file
and linking the repo. (Surfaced by the `agy` review pass.)

Local model paths also drop the `-Instruct` that no upstream filename carries, and
`docs/features/dflash2.md` is corrected to match.

## Test plan

- `cd server && npm test` — 1496 files, 31011 passed
- `cd client && npm test` — 686 files, 8528 passed
- 5 new `pickGgufSibling` tests covering projector exclusion, the explicit-file
  override, the projectors-only error, the Muse-Glimmer pin, and the missing-pin refusal
- End-to-end resolution against the **live** Hugging Face API — every preset role
  resolves to a real file, and all four `resolve/main/…` URLs return 200:

  ```
  qwen3.8-27b-dspark/model      ggml-org/Qwen3.8-27B-GGUF            -> Qwen3.8-27B-Q4_K_M.gguf
  qwen3.8-27b-dspark/draftModel erlidev/Qwen3.8-27B-DSpark-GGUF      -> Qwen3.8-27B-DSpark-BF16.gguf
  qwen3-8b-dspark/model         Qwen/Qwen3-8B-GGUF                   -> Qwen3-8B-Q4_K_M.gguf
  qwen3.8-27b/model             ggml-org/Qwen3.8-27B-GGUF            -> Qwen3.8-27B-Q4_K_M.gguf
  qwen3.8-27b/draftModel        incoai/Qwen3.8-27B-DFlash2-GGUF      -> Qwen3.8-27B-DFlash2-Q4_K_M.gguf
  muse-glimmer-30b/model        meta-models/Muse-Glimmer-30B-GGUF    -> Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf
  muse-glimmer-30b/draftModel   z-lab/Muse-Glimmer-30B-DFlash2-GGUF  -> Muse-Glimmer-30B-DFlash2-Q4_K_M.gguf
  ```

## Note

Preset paths under `models/` changed (`Qwen3.8-27B-Instruct-Q4_K_M.gguf` →
`Qwen3.8-27B-Q4_K_M.gguf`). No migration is needed: these are download
destinations, not persisted records, and the broken download path means PortOS
never created a file at the old name. Anyone who fetched one by hand can still
type the old path into the editable base-model field.
