### PR TITLE
Skip CLAUDE.md injection for Creative Director agent prompts

### DIFF
--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -1643,8 +1643,15 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
       : buildLightContextPrompt(task, workspaceDir, worktreeInfo, isTruthyMetaFn, lightOptions);
   }
 
-  // Full path: API providers don't read CLAUDE.md natively, so always include it.
-  const skipClaudeMd = false;
+  // Creative Director tasks (scene evaluation, treatment/plan run via API) judge
+  // generated content rather than writing PortOS code — shared below by both
+  // `skipClaudeMd` (the repo's dev-oriented CLAUDE.md files are pure noise for
+  // that prompt) and `noCodeOutput` (the deliverable is an HTTP PATCH, not a
+  // commit).
+  const isCreativeDirectorTask = !!task.metadata?.creativeDirector;
+  // Full path: API providers don't read CLAUDE.md natively, so always include it —
+  // except for Creative Director tasks, per above.
+  const skipClaudeMd = isCreativeDirectorTask;
   // Fetch independent context sections in parallel
   const [memorySection, claudeMdSection, digitalTwinSection] = await Promise.all([
     getMemorySection(task, { maxTokens: config.memory?.maxContextTokens || 2000 })
@@ -1673,7 +1680,7 @@ export async function buildAgentPrompt(task, config, workspaceDir, worktreeInfo 
   // derive from a CD task's own `creativeDirector` marker so tasks queued as
   // `pending` BEFORE this flag existed (persisted across an upgrade) are still
   // recognized without a metadata migration.
-  const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput) || !!task.metadata?.creativeDirector;
+  const noCodeOutput = isTruthyMetaFn(task.metadata?.noCodeOutput) || isCreativeDirectorTask;
   const isWorktreeOnExistingBranch = isPrBranchWorktree(task, worktreeInfo);
   const worktreeSection = worktreeInfo ? `
 ## Git Worktree Context

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -2212,6 +2212,15 @@ describe('discardWorktree (reasoning-only) completion contract', () => {
       expect(builderAuthored).toMatch(/Do NOT commit, push, or open a PR/);
     });
 
+    it('a Creative Director task on the full (api) path never splices CLAUDE.md — the fixture is reachable but irrelevant to a content-judging prompt', async () => {
+      const cdTask = makeTask({
+        metadata: { creativeDirector: { projectId: 'p', kind: 'evaluate' }, useWorktree: false, openPR: false },
+      });
+      const prompt = await buildAgentPrompt(cdTask, {}, '/r', null, isTruthyMeta, { providerType: 'api' });
+      expect(prompt).not.toMatch(/## CLAUDE\.md Instructions/);
+      expect(prompt).not.toMatch(/Example Global Instructions/);
+    });
+
     it('light TUI path suppresses the merge instruction and never splices the global CLAUDE.md at all', () => {
       // `openPR: true` on purpose: this is the shape where merge suppression has
       // to do work — the task metadata asks for a PR, and discardWorktree must


### PR DESCRIPTION
## Summary
- Creative Director agent prompts (scene evaluation, treatment/plan run via the API path) were getting the repo's dev-oriented `CLAUDE.md` files (git conventions, code style, etc.) spliced in — noise for a task that judges/generates content rather than writing PortOS code.
- Gates `skipClaudeMd` on the same `task.metadata?.creativeDirector` marker `noCodeOutput` already derives from, hoisted into a shared `isCreativeDirectorTask` local.
- Follow-up filed as #4650 for the broader gaps this doesn't cover (TUI/CLI-routed CD runs still pick up CLAUDE.md via native cwd discovery; `memorySection`/`digitalTwinSection`/`toolsSection` still unconditional).

## Test plan
- `cd server && NODE_ENV=test npx vitest run services/agentPromptBuilder.test.js` — 195 passed, including a new fixture-pinned test asserting a CD task on the API path never splices the global CLAUDE.md.