### PR TITLE
feat: redownload local LLMs and catalog Unsloth Dynamic 3.0 Qwen3.8

### DIFF
--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -24,6 +24,14 @@ const BACKENDS = [
 ];
 const labelFor = (id) => BACKENDS.find((b) => b.id === id)?.label || id;
 
+// LM Studio's installed list is folder-scoped (`publisher/repo`) plus a separate
+// `quantization` field. A force redownload has to target a tagged id so the
+// server evicts that GGUF instead of no-op'ing on a bare repo.
+const redownloadInstallId = (model, backend) => {
+  if (backend !== 'lmstudio' || !model?.quantization || /@/.test(model.id || '')) return model.id;
+  return `${model.id}@${model.quantization}`;
+};
+
 // The speculative-decoding presets come from the server
 // (`server/lib/specDecodePresets.js`, surfaced on the llama-server status
 // response) rather than a table here: each preset names a multi-gigabyte GGUF,
@@ -659,10 +667,10 @@ export function LocalLlmTab() {
   // queued, not finished — so don't claim "installed" in that case. Install is
   // silent so an OLLAMA_OUTDATED failure can take over the UI with the upgrade
   // banner instead of stacking a useless toast with the auto-upgrade flow.
-  const install = (modelId) => runAction(
+  const install = (modelId, { force = false } = {}) => runAction(
     `install-${modelId}`,
-    () => installLocalLlmModel(selected, modelId, { silent: true }),
-    (r) => r?.pending ? `${modelId} download started` : `${modelId} installed`,
+    () => installLocalLlmModel(selected, modelId, { silent: true, force }),
+    (r) => r?.pending ? `${modelId} download started` : `${modelId} ${force ? 'redownloaded' : 'installed'}`,
     {
       onError: (err) => {
         if (err?.code === 'OLLAMA_OUTDATED' && selected === 'ollama') {
@@ -1568,7 +1576,20 @@ export function LocalLlmTab() {
                         Desktop keeps them stacked at the card's right edge. */}
                     <div className="flex flex-row sm:flex-col items-center sm:items-end gap-2 sm:gap-1 shrink-0 justify-end flex-wrap">
                       {chosenInstalled ? (
-                        <span className="text-xs px-2 py-1 text-port-success">Installed</span>
+                        <>
+                          <span className="text-xs px-2 py-1 text-port-success">Installed</span>
+                          {!isAudio && (
+                            <button
+                              onClick={() => install(chosenId, { force: true })}
+                              disabled={busy}
+                              title="Pull this build again. Updated GGUF files keep the same name, so an existing install will not refresh until you redownload."
+                              className="px-2.5 py-1 text-xs bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-1"
+                            >
+                              {actionInProgress === `install-${chosenId}` ? <BrailleSpinner /> : <RefreshCw size={12} />}
+                              Redownload
+                            </button>
+                          )}
+                        </>
                       ) : m.installable === false ? (
                         // Audio models with no PortOS runtime (or a fixed-checkpoint
                         // engine like ACE-Step) are discovery-only — "Visit" below.
@@ -1679,6 +1700,16 @@ export function LocalLlmTab() {
                   <FlaskConical size={12} />
                   Chat
                 </Link>
+                <button
+                  onClick={() => install(redownloadInstallId(m, selected), { force: true })}
+                  disabled={busy}
+                  title="Pull this build again. Updated GGUF files keep the same name, so an existing install will not refresh until you redownload."
+                  className="px-2.5 py-1 text-xs bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded disabled:opacity-50 flex items-center gap-1 shrink-0"
+                  aria-label={`Redownload ${m.name || m.id}`}
+                >
+                  {actionInProgress === `install-${m.id}` ? <BrailleSpinner /> : <RefreshCw size={12} />}
+                  Redownload
+                </button>
                 {isConfirmingDelete(m.id) ? (
                   <ConfirmButtonPair
                     prompt="Delete?"

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -28,8 +28,12 @@ const labelFor = (id) => BACKENDS.find((b) => b.id === id)?.label || id;
 // `quantization` field. A force redownload has to target a tagged id so the
 // server evicts that GGUF instead of no-op'ing on a bare repo.
 const redownloadInstallId = (model, backend) => {
-  if (backend !== 'lmstudio' || !model?.quantization || /@/.test(model.id || '')) return model.id;
-  return `${model.id}@${model.quantization}`;
+  if (backend !== 'lmstudio') return model.id;
+  if (/@/.test(model.id || '')) return model.id;
+  if (model?.quantization) return `${model.id}@${model.quantization}`;
+  // /v1/models fallback has no quantization — a bare repo force-redownload
+  // would skip existing GGUFs and still toast success.
+  return null;
 };
 
 // The speculative-decoding presets come from the server
@@ -1578,7 +1582,7 @@ export function LocalLlmTab() {
                       {chosenInstalled ? (
                         <>
                           <span className="text-xs px-2 py-1 text-port-success">Installed</span>
-                          {!isAudio && (
+                          {!isAudio && (selected !== 'lmstudio' || /@/.test(chosenId || '')) && (
                             <button
                               onClick={() => install(chosenId, { force: true })}
                               disabled={busy}
@@ -1700,6 +1704,7 @@ export function LocalLlmTab() {
                   <FlaskConical size={12} />
                   Chat
                 </Link>
+                {redownloadInstallId(m, selected) && (
                 <button
                   onClick={() => install(redownloadInstallId(m, selected), { force: true })}
                   disabled={busy}
@@ -1707,9 +1712,10 @@ export function LocalLlmTab() {
                   className="px-2.5 py-1 text-xs bg-port-accent/20 hover:bg-port-accent/30 text-port-accent rounded disabled:opacity-50 flex items-center gap-1 shrink-0"
                   aria-label={`Redownload ${m.name || m.id}`}
                 >
-                  {actionInProgress === `install-${m.id}` ? <BrailleSpinner /> : <RefreshCw size={12} />}
+                  {actionInProgress === `install-${redownloadInstallId(m, selected)}` ? <BrailleSpinner /> : <RefreshCw size={12} />}
                   Redownload
                 </button>
+                )}
                 {isConfirmingDelete(m.id) ? (
                   <ConfirmButtonPair
                     prompt="Delete?"

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -167,6 +167,26 @@ describe('LocalLlmTab installed models', () => {
       expect.objectContaining({ force: true }),
     ));
   });
+
+  it('hides redownload when LM Studio did not report a quantization', async () => {
+    getLocalLlmStatus.mockResolvedValue({
+      backend: 'lmstudio',
+      ollama: { installed: false, available: false, modelCount: 0, models: [] },
+      lmstudio: {
+        installed: true,
+        available: true,
+        modelCount: 1,
+        models: [{ id: 'unsloth/Qwen3.8-27B-GGUF', name: 'Qwen3.8 27B' }],
+      },
+    });
+    render(
+      <MemoryRouter>
+        <LocalLlmTab />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText(/Installed on LM Studio/)).toBeTruthy());
+    expect(screen.queryByRole('button', { name: /Redownload/ })).toBeNull();
+  });
 });
 
 describe('LocalLlmTab recommendations', () => {

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -33,7 +33,7 @@ vi.mock('../ui/Toast', () => ({
   default: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn(), warning: vi.fn(), info: vi.fn() }),
 }));
 
-import { getLocalLlmStatus, getLocalLlmCatalog, patchSettingsSlice } from '../../services/api';
+import { getLocalLlmStatus, getLocalLlmCatalog, patchSettingsSlice, installLocalLlmModel } from '../../services/api';
 import { LocalLlmTab } from './LocalLlmTab';
 
 // A realistically long HF model id — the shape that got ellipsised to
@@ -126,6 +126,47 @@ describe('LocalLlmTab installed models', () => {
     // rides along with params/quant/family so nothing is squeezed out.
     expect(screen.getByText(/^34\.7B · Q6_K · qwen2 · [\d.]+ GB$/)).toBeTruthy();
   });
+
+  it('redownloads an installed model instead of requiring delete-then-install', async () => {
+    installLocalLlmModel.mockResolvedValue({ success: true });
+    await renderTab();
+    fireEvent.click(screen.getByRole('button', { name: `Redownload ${LONG_ID}` }));
+    await waitFor(() => expect(installLocalLlmModel).toHaveBeenCalledWith(
+      'ollama',
+      LONG_ID,
+      expect.objectContaining({ force: true, silent: true }),
+    ));
+  });
+
+  it('tags an LM Studio installed model with its quantization so redownload can evict that GGUF', async () => {
+    installLocalLlmModel.mockResolvedValue({ success: true });
+    getLocalLlmStatus.mockResolvedValue({
+      backend: 'lmstudio',
+      ollama: { installed: false, available: false, modelCount: 0, models: [] },
+      lmstudio: {
+        installed: true,
+        available: true,
+        modelCount: 1,
+        models: [{
+          id: 'unsloth/Qwen3.8-27B-GGUF',
+          name: 'Qwen3.8 27B',
+          quantization: 'UD-Q4_K_M',
+        }],
+      },
+    });
+    render(
+      <MemoryRouter>
+        <LocalLlmTab />
+      </MemoryRouter>,
+    );
+    await waitFor(() => expect(screen.getByText(/Installed on LM Studio/)).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: 'Redownload Qwen3.8 27B' }));
+    await waitFor(() => expect(installLocalLlmModel).toHaveBeenCalledWith(
+      'lmstudio',
+      'unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M',
+      expect.objectContaining({ force: true }),
+    ));
+  });
 });
 
 describe('LocalLlmTab recommendations', () => {
@@ -156,7 +197,7 @@ describe('LocalLlmTab recommendations', () => {
   it('highlights the flagship general model and surfaces it in its coding use-case filter', async () => {
     getLocalLlmCatalog.mockResolvedValue({
       models: [{
-        id: 'hf.co/unsloth/Qwen3.8-27B-GGUF:Q4_K_M',
+        id: 'hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M',
         key: 'qwen3.8-27b',
         name: 'Qwen3.8 27B',
         category: 'general',
@@ -166,8 +207,10 @@ describe('LocalLlmTab recommendations', () => {
           description: 'Flagship local pick for general work, coding and agents, reasoning, and image analysis.',
         },
         params: '27B',
-        size: '17 GB',
+        size: '16.5 GB',
         description: 'A broad local model.',
+        note: 'Dynamic 3.0 is baked into the GGUF files — re-download if you already have an older Unsloth Qwen3.8 build.',
+        repository: 'unsloth/Qwen3.8-27B-GGUF',
         capabilities: ['chat', 'code', 'reasoning', 'tools', 'vision'],
       }],
     });
@@ -179,6 +222,32 @@ describe('LocalLlmTab recommendations', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Coding & agents (1)' }));
     await waitFor(() => expect(screen.getByText('Qwen3.8 27B')).toBeTruthy());
+  });
+
+  it('offers redownload on an already-installed catalog card', async () => {
+    installLocalLlmModel.mockResolvedValue({ success: true });
+    getLocalLlmCatalog.mockResolvedValue({
+      models: [{
+        id: 'hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M',
+        key: 'qwen3.8-27b',
+        name: 'Qwen3.8 27B',
+        installed: true,
+        category: 'general',
+        recommendedFor: ['general'],
+        params: '27B',
+        size: '16.5 GB',
+        description: 'A broad local model.',
+        capabilities: ['chat'],
+      }],
+    });
+    await renderTab();
+    expect(await screen.findByText('Qwen3.8 27B')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: /^Redownload$/ }));
+    await waitFor(() => expect(installLocalLlmModel).toHaveBeenCalledWith(
+      'ollama',
+      'hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M',
+      expect.objectContaining({ force: true }),
+    ));
   });
 });
 

--- a/client/src/services/apiLocalLlm.js
+++ b/client/src/services/apiLocalLlm.js
@@ -27,8 +27,14 @@ export const getLocalLlmHuggingFaceSearch = (backend, q = '', category = 'all', 
 // `options` lets callers opt into `{ silent: true }` so structured failure codes
 // (e.g. OLLAMA_OUTDATED → offer to upgrade in place) can be handled by the UI
 // without the default error toast firing first and stacking with the prompt.
-export const installLocalLlmModel = (backend, modelId, options) =>
-  request('/local-llm/install', { method: 'POST', body: JSON.stringify({ backend, modelId }), ...options });
+export const installLocalLlmModel = (backend, modelId, options = {}) => {
+  const { force, ...rest } = options;
+  return request('/local-llm/install', {
+    method: 'POST',
+    body: JSON.stringify({ backend, modelId, ...(force ? { force: true } : {}) }),
+    ...rest,
+  });
+};
 
 export const deleteLocalLlmModel = (backend, modelId, options = {}) =>
   request('/local-llm/delete', { method: 'POST', body: JSON.stringify({ backend, modelId }), ...options });

--- a/server/lib/localLlmCatalog.js
+++ b/server/lib/localLlmCatalog.js
@@ -339,12 +339,15 @@ export const LOCAL_LLM_CATALOG = [
       description: 'Flagship local pick for general work, coding and agents, reasoning, and image analysis.'
     },
     params: '27B',
-    size: '17 GB',
+    size: '16.5 GB',
     family: 'qwen',
-    description: 'Dense current-generation Qwen with a 256K context, strong coding and agent work, vision, tools, multilingual support, and a thinking mode — the strongest all-round local model that still fits 32GB.',
+    description: 'Dense current-generation Qwen with a 256K context, strong coding and agent work, vision, tools, multilingual support, and a thinking mode — the strongest all-round local model that still fits 32GB. Unsloth Dynamic 3.0 GGUF: higher fidelity at the same size than earlier Unsloth quants.',
+    note: 'Dynamic 3.0 is baked into the GGUF files — re-download if you already have an older Unsloth Qwen3.8 build. Native MLX Dynamic 3.0 is not available yet.',
+    repository: 'unsloth/Qwen3.8-27B-GGUF',
     capabilities: ['chat', 'code', 'reasoning', 'tools', 'vision', 'multilingual'],
     context: 262144,
-    ollama: 'hf.co/unsloth/Qwen3.8-27B-GGUF:Q4_K_M',
+    ollama: 'hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M',
+    ollamaAliases: ['hf.co/unsloth/Qwen3.8-27B-GGUF:Q4_K_M'],
     lmstudio: 'unsloth/Qwen3.8-27B-GGUF'
   },
   {

--- a/server/lib/localLlmCatalog.test.js
+++ b/server/lib/localLlmCatalog.test.js
@@ -129,9 +129,20 @@ describe('localLlmCatalog', () => {
       expect(qwen).toMatchObject({
         category: 'general',
         featured: { label: 'Best overall' },
+        id: 'hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M',
+        size: '16.5 GB',
+        repository: 'unsloth/Qwen3.8-27B-GGUF',
       });
+      expect(qwen.note).toMatch(/Dynamic 3\.0/i);
       expect(qwen.recommendedFor).toEqual(expect.arrayContaining(['general', 'coding', 'reasoning', 'vision']));
       expect(qwen.capabilities).toEqual(expect.arrayContaining(['code', 'tools', 'vision']));
+    });
+
+    it('still treats an older Unsloth Q4_K_M install as the same Qwen3.8 catalog entry', () => {
+      const qwen = getCatalog('ollama', ['hf.co/unsloth/Qwen3.8-27B-GGUF:Q4_K_M'])
+        .find((m) => m.key === 'qwen3.8-27b');
+      expect(qwen.installed).toBe(true);
+      expect(qwen.id).toBe('hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M');
     });
 
     it('never lists an Ollama `:cloud` tag — those manifests carry no local weights', () => {
@@ -185,6 +196,13 @@ describe('localLlmCatalog', () => {
         .toEqual({ targetId: 'qwen3.8:27b-mlx', exact: true });
       expect(mapModelToBackend('ollama', 'qwen3.8:27b-mlx', 'lmstudio'))
         .toEqual({ targetId: 'mlx-community/Qwen3.8-27B-4bit', exact: true });
+    });
+
+    it('maps an older Unsloth Qwen3.8 Q4_K_M tag to the same LM Studio repo', () => {
+      expect(mapModelToBackend('ollama', 'hf.co/unsloth/Qwen3.8-27B-GGUF:Q4_K_M', 'lmstudio'))
+        .toEqual({ targetId: 'unsloth/Qwen3.8-27B-GGUF', exact: true });
+      expect(mapModelToBackend('ollama', 'hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M', 'lmstudio'))
+        .toEqual({ targetId: 'unsloth/Qwen3.8-27B-GGUF', exact: true });
     });
 
     it('maps the uncensored MLX build to its curated local Ollama import name', () => {

--- a/server/lib/mediaValidation.js
+++ b/server/lib/mediaValidation.js
@@ -141,6 +141,9 @@ export const localLlmModelIdSchema = z.string().min(1).max(256)
 export const localLlmInstallSchema = z.object({
   backend: localLlmBackendSchema,
   modelId: localLlmModelIdSchema,
+  // Re-pull even when the model is already on disk. Needed when a publisher
+  // replaces GGUF files in place (e.g. Unsloth Dynamic 3.0) under the same id.
+  force: z.boolean().optional(),
 });
 export const localLlmDeleteSchema = localLlmInstallSchema;
 // Memory-management unload: same `backend` + `modelId` shape as install/delete

--- a/server/routes/localLlm.js
+++ b/server/routes/localLlm.js
@@ -213,9 +213,9 @@ router.post('/ollama-service', asyncHandler(async (req, res) => {
 
 // POST /api/local-llm/install — pull/download a model (streams progress)
 router.post('/install', asyncHandler(async (req, res) => {
-  const { backend, modelId } = validateRequest(localLlmInstallSchema, req.body)
+  const { backend, modelId, force } = validateRequest(localLlmInstallSchema, req.body)
   const emit = emitter(req)
-  emit('start', `Installing ${modelId} on ${backend}…`)
+  emit('start', `${force ? 'Redownloading' : 'Installing'} ${modelId} on ${backend}…`)
   // A thrown rejection (e.g. the pull stream dropping mid-download) would 500
   // via asyncHandler but never emit a terminal progress frame, leaving the
   // client's progress banner stuck on the last 'start'. Surface it as 'error'.
@@ -225,7 +225,7 @@ router.post('/install', asyncHandler(async (req, res) => {
   const result = await installModel(backend, modelId, (p) => {
     const label = describeInstallProgress(p)
     if (label) emit('start', `${modelId}: ${label}`)
-  }).catch((err) => {
+  }, { force: !!force }).catch((err) => {
     emit('error', `Install failed: ${err.message}`)
     throw err
   })
@@ -238,7 +238,7 @@ router.post('/install', asyncHandler(async (req, res) => {
   }
   emit('complete', result.pending
     ? `${modelId} download started in LM Studio — it'll finish in the background`
-    : `${modelId} installed on ${backend}`)
+    : `${modelId} ${force ? 'redownloaded' : 'installed'} on ${backend}`)
   res.json({ success: true, ...result })
 }))
 

--- a/server/routes/localLlm.test.js
+++ b/server/routes/localLlm.test.js
@@ -3,7 +3,7 @@ import express from 'express';
 import { request } from '../lib/testHelper.js';
 import localLlmRoutes from './localLlm.js';
 import { runLocalLlmTest, compareLocalLlmModels } from '../services/localLlmPlayground.js';
-import { listModels, listVisionModels, listToolUseModels } from '../services/localLlm.js';
+import { listModels, listVisionModels, listToolUseModels, installModel } from '../services/localLlm.js';
 import { enrichCatalogWithVariants, applyMeasuredFit } from '../services/huggingFaceCatalog.js';
 import { getMeasuredFits } from '../services/localModelAssessmentStore.js';
 import { runAssessment } from '../services/localModelAssessments.js';
@@ -24,6 +24,7 @@ vi.mock('../services/localLlm.js', () => ({
   listVisionModels: vi.fn(async () => []),
   listToolUseModels: vi.fn(async () => []),
   installModel: vi.fn(),
+  describeInstallProgress: vi.fn((p) => p?.status || null),
   deleteModel: vi.fn(),
   switchBackend: vi.fn(),
   migrateBackend: vi.fn(),
@@ -126,6 +127,33 @@ describe('local LLM playground routes', () => {
     expect(Array.isArray(res.body.models)).toBe(true);
     // The playground only needs catalog metadata — it must not pay for HF probes.
     expect(enrichCatalogWithVariants).not.toHaveBeenCalled();
+  });
+
+  it('POST /install forwards force so a redownload can replace on-disk weights', async () => {
+    installModel.mockResolvedValue({ success: true, modelId: 'unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M' });
+
+    const res = await request(makeApp())
+      .post('/api/local-llm/install')
+      .send({ backend: 'lmstudio', modelId: 'unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M', force: true });
+
+    expect(res.status).toBe(200);
+    expect(installModel).toHaveBeenCalledWith(
+      'lmstudio',
+      'unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M',
+      expect.any(Function),
+      { force: true }
+    );
+  });
+
+  it('POST /install without force still pulls as a regular install', async () => {
+    installModel.mockResolvedValue({ success: true, modelId: 'llama3.2' });
+
+    const res = await request(makeApp())
+      .post('/api/local-llm/install')
+      .send({ backend: 'ollama', modelId: 'llama3.2' });
+
+    expect(res.status).toBe(200);
+    expect(installModel).toHaveBeenCalledWith('ollama', 'llama3.2', expect.any(Function), { force: false });
   });
 
   it('runs a single local model test with validated defaults', async () => {

--- a/server/services/huggingFaceCatalog.js
+++ b/server/services/huggingFaceCatalog.js
@@ -126,7 +126,9 @@ const QUANT_PRIORITY = [
   'IQ4_XS',
   'UD-IQ4_XS',
   'Q5_K_M',
+  'UD-Q6_K',
   'Q6_K',
+  'UD-Q8_K_XL',
   'Q8_0',
   'BF16',
   'F16'

--- a/server/services/lmStudioManager.js
+++ b/server/services/lmStudioManager.js
@@ -563,6 +563,85 @@ function modelIdsReferToSameRepo(left, right) {
   return Boolean(leftKey && rightKey && leftKey === rightKey)
 }
 
+// `lms get` skips files that already exist, so a publisher replacing a GGUF in
+// place (Unsloth Dynamic 3.0, etc.) never lands unless we evict first. Strip the
+// backend-specific install wrapper down to the on-disk `<publisher>/<repo>` id.
+function repoIdFromInstallId(modelId) {
+  return String(modelId || '')
+    .trim()
+    .replace(/^https?:\/\/huggingface\.co\//i, '')
+    .replace(/^hf\.co\//i, '')
+    .replace(/@[^/@]+$/, '')
+    .replace(/:([^:/]+)$/, '')
+}
+
+function quantFromInstallId(modelId) {
+  const s = String(modelId || '').trim()
+  const at = s.match(/@([^/@]+)$/)
+  if (at) return at[1]
+  const colon = s.match(/:([^:/]+)$/)
+  return colon ? colon[1] : null
+}
+
+function trailingGgufQuant(filename) {
+  const stem = String(filename || '').split('/').pop()
+    .replace(/\.gguf$/i, '')
+    .replace(/-\d{5}-of-\d{5}$/i, '')
+  // Same trailing-token rule as huggingFaceCatalog.quantFromFilename: UD-Q4_K_M
+  // and Q4_K_M are distinct, so a suffix match would evict the wrong file.
+  const match = stem.match(/(?:^|[-_.])((?:UD-)?(?:IQ\d(?:_[A-Z0-9]+)*|Q\d(?:_[A-Z0-9]+)*|BF16|F16))$/i)
+  return match?.[1] || null
+}
+
+function ggufMatchesQuant(filename, quant) {
+  const parsed = trailingGgufQuant(filename)
+  return parsed != null && parsed.toLowerCase() === String(quant).toLowerCase()
+}
+
+/**
+ * Remove on-disk LM Studio files so a subsequent `lms get` actually re-fetches
+ * them. A quant-tagged id (`repo@UD-Q4_K_M` / `hf.co/repo:UD-Q4_K_M`) evicts
+ * only matching GGUFs and leaves sibling quants alone. A bare repo id is a
+ * no-op (`missing: true`) rather than wiping every quant in the folder — pick
+ * a tagged variant to redownload a specific build. Missing files are success
+ * so a first-time install can share this path. Ambiguous ids refuse, same as
+ * deleteModel.
+ * @returns {Promise<{ success: boolean, modelId: string, missing?: boolean, error?: string }>}
+ */
+async function evictDownloadedQuant(modelId) {
+  const repoId = repoIdFromInstallId(modelId)
+  const quant = quantFromInstallId(modelId)
+  const modelsDir = await getModelsDir()
+  const matches = await findDeletableModelDirs(modelsDir, repoId)
+  if (matches === null) return { success: false, error: `Invalid model id "${modelId}".`, modelId }
+  if (matches.length === 0) return { success: true, missing: true, modelId }
+  if (matches.length > 1) {
+    return { success: false, error: `Ambiguous model id "${modelId}" matches ${matches.length} folders — redownload by exact "publisher/repo".`, modelId }
+  }
+  const dir = matches[0]
+  if (!isModelLeafDir(modelsDir, dir)) {
+    return { success: false, error: `Refusing to evict "${dir}" — not a model folder under ${modelsDir}.`, modelId }
+  }
+  if (!quant) {
+    // Bare `publisher/repo` would otherwise rm every quant in the folder. The
+    // caller still runs `lms get`; without a tag we cannot know which file to
+    // replace, so leave the disk alone rather than delete sibling builds.
+    return { success: true, missing: true, modelId }
+  }
+
+  if (await checkLMStudioAvailable()) await unloadModel(modelId).catch(() => {})
+
+  const files = await readdir(dir)
+  const targets = files.filter((name) => /\.gguf$/i.test(name) && !/mmproj/i.test(name) && ggufMatchesQuant(name, quant))
+  if (targets.length === 0) return { success: true, missing: true, modelId }
+  for (const name of targets) {
+    await rm(join(dir, name), { force: true })
+  }
+  resetCache()
+  console.log(`🗑️ LM Studio evicted ${targets.length} ${quant} file(s) for redownload: ${modelId}`)
+  return { success: true, modelId }
+}
+
 async function findModelDir(modelsDir, modelId) {
   // Reject `.`/`..` traversal segments before joining — mirrors the stricter
   // findDeletableModelDirs guard so the read path can't resolve outside the
@@ -755,5 +834,6 @@ export {
   resolveLocalModel,
   importModelFromGguf,
   deleteModel,
+  evictDownloadedQuant,
   DEFAULT_CONFIG
 }

--- a/server/services/lmStudioManager.js
+++ b/server/services/lmStudioManager.js
@@ -601,16 +601,25 @@ function ggufMatchesQuant(filename, quant) {
 /**
  * Remove on-disk LM Studio files so a subsequent `lms get` actually re-fetches
  * them. A quant-tagged id (`repo@UD-Q4_K_M` / `hf.co/repo:UD-Q4_K_M`) evicts
- * only matching GGUFs and leaves sibling quants alone. A bare repo id is a
- * no-op (`missing: true`) rather than wiping every quant in the folder — pick
- * a tagged variant to redownload a specific build. Missing files are success
- * so a first-time install can share this path. Ambiguous ids refuse, same as
- * deleteModel.
+ * only matching GGUFs and leaves sibling quants alone. A bare repo id fails —
+ * we cannot name the file to replace, and wiping the folder would drop sibling
+ * quants. Missing files are success (`missing: true`) so a first-time install
+ * can share this path. Ambiguous ids refuse, same as deleteModel.
  * @returns {Promise<{ success: boolean, modelId: string, missing?: boolean, error?: string }>}
  */
 async function evictDownloadedQuant(modelId) {
   const repoId = repoIdFromInstallId(modelId)
   const quant = quantFromInstallId(modelId)
+  // A bare `publisher/repo` cannot name the GGUF to replace. Evicting the whole
+  // folder would drop sibling quants; leaving files in place makes `lms get`
+  // skip them and report a fake success. Callers must pass `repo@QUANT`.
+  if (!quant) {
+    return {
+      success: false,
+      error: 'Redownload needs a quantization tag (e.g. repo@UD-Q4_K_M). A bare repo id would skip existing GGUFs without replacing them.',
+      modelId
+    }
+  }
   const modelsDir = await getModelsDir()
   const matches = await findDeletableModelDirs(modelsDir, repoId)
   if (matches === null) return { success: false, error: `Invalid model id "${modelId}".`, modelId }
@@ -621,12 +630,6 @@ async function evictDownloadedQuant(modelId) {
   const dir = matches[0]
   if (!isModelLeafDir(modelsDir, dir)) {
     return { success: false, error: `Refusing to evict "${dir}" — not a model folder under ${modelsDir}.`, modelId }
-  }
-  if (!quant) {
-    // Bare `publisher/repo` would otherwise rm every quant in the folder. The
-    // caller still runs `lms get`; without a tag we cannot know which file to
-    // replace, so leave the disk alone rather than delete sibling builds.
-    return { success: true, missing: true, modelId }
   }
 
   if (await checkLMStudioAvailable()) await unloadModel(modelId).catch(() => {})

--- a/server/services/lmStudioManager.test.js
+++ b/server/services/lmStudioManager.test.js
@@ -187,3 +187,59 @@ describe('lmStudioManager deleteModel', () => {
     expect(fs.existsSync(path.join(tempDir, 'lmstudio-community', 'qwen3-4b-MLX-4bit'))).toBe(true);
   });
 });
+
+describe('lmStudioManager evictDownloadedQuant', () => {
+  it('removes only the matching GGUF and leaves sibling quants', async () => {
+    const keep = writeFile('unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-UD-Q8_K_XL.gguf');
+    const drop = writeFile('unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-UD-Q4_K_M.gguf');
+    writeFile('unsloth/Qwen3.8-27B-GGUF/mmproj-Qwen3.8-27B-UD-Q4_K_M.gguf');
+    const { evictDownloadedQuant } = await import('./lmStudioManager.js');
+
+    const result = await evictDownloadedQuant('unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M');
+
+    expect(result).toMatchObject({ success: true, modelId: 'unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M' });
+    expect(fs.existsSync(drop)).toBe(false);
+    expect(fs.existsSync(keep)).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, 'unsloth', 'Qwen3.8-27B-GGUF', 'mmproj-Qwen3.8-27B-UD-Q4_K_M.gguf'))).toBe(true);
+  });
+
+  it('does not treat UD-Q4_K_M as a Q4_K_M match', async () => {
+    const ud = writeFile('unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-UD-Q4_K_M.gguf');
+    const plain = writeFile('unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-Q4_K_M.gguf');
+    const { evictDownloadedQuant } = await import('./lmStudioManager.js');
+
+    const result = await evictDownloadedQuant('hf.co/unsloth/Qwen3.8-27B-GGUF:Q4_K_M');
+
+    expect(result.success).toBe(true);
+    expect(fs.existsSync(plain)).toBe(false);
+    expect(fs.existsSync(ud)).toBe(true);
+  });
+
+  it('treats a missing quant as a successful no-op so first-time install can share the path', async () => {
+    writeFile('unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-UD-Q8_K_XL.gguf');
+    const { evictDownloadedQuant } = await import('./lmStudioManager.js');
+
+    const result = await evictDownloadedQuant('unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M');
+
+    expect(result).toMatchObject({ success: true, missing: true });
+    expect(fs.existsSync(path.join(tempDir, 'unsloth', 'Qwen3.8-27B-GGUF', 'Qwen3.8-27B-UD-Q8_K_XL.gguf'))).toBe(true);
+  });
+
+  it('does not wipe sibling quants when the id has no quant tag', async () => {
+    writeFile('unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-UD-Q4_K_M.gguf');
+    writeFile('unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-UD-Q8_K_XL.gguf');
+    const { evictDownloadedQuant } = await import('./lmStudioManager.js');
+
+    const result = await evictDownloadedQuant('unsloth/Qwen3.8-27B-GGUF');
+
+    expect(result).toMatchObject({ success: true, missing: true });
+    expect(fs.existsSync(path.join(tempDir, 'unsloth', 'Qwen3.8-27B-GGUF', 'Qwen3.8-27B-UD-Q4_K_M.gguf'))).toBe(true);
+    expect(fs.existsSync(path.join(tempDir, 'unsloth', 'Qwen3.8-27B-GGUF', 'Qwen3.8-27B-UD-Q8_K_XL.gguf'))).toBe(true);
+  });
+
+  it('returns missing:true when the repo is not on disk', async () => {
+    const { evictDownloadedQuant } = await import('./lmStudioManager.js');
+    expect(await evictDownloadedQuant('unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M'))
+      .toMatchObject({ success: true, missing: true });
+  });
+});

--- a/server/services/lmStudioManager.test.js
+++ b/server/services/lmStudioManager.test.js
@@ -225,14 +225,15 @@ describe('lmStudioManager evictDownloadedQuant', () => {
     expect(fs.existsSync(path.join(tempDir, 'unsloth', 'Qwen3.8-27B-GGUF', 'Qwen3.8-27B-UD-Q8_K_XL.gguf'))).toBe(true);
   });
 
-  it('does not wipe sibling quants when the id has no quant tag', async () => {
+  it('refuses a bare repo id so a force redownload cannot skip existing GGUFs', async () => {
     writeFile('unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-UD-Q4_K_M.gguf');
     writeFile('unsloth/Qwen3.8-27B-GGUF/Qwen3.8-27B-UD-Q8_K_XL.gguf');
     const { evictDownloadedQuant } = await import('./lmStudioManager.js');
 
     const result = await evictDownloadedQuant('unsloth/Qwen3.8-27B-GGUF');
 
-    expect(result).toMatchObject({ success: true, missing: true });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/quantization tag/i);
     expect(fs.existsSync(path.join(tempDir, 'unsloth', 'Qwen3.8-27B-GGUF', 'Qwen3.8-27B-UD-Q4_K_M.gguf'))).toBe(true);
     expect(fs.existsSync(path.join(tempDir, 'unsloth', 'Qwen3.8-27B-GGUF', 'Qwen3.8-27B-UD-Q8_K_XL.gguf'))).toBe(true);
   });

--- a/server/services/localLlm.js
+++ b/server/services/localLlm.js
@@ -872,8 +872,11 @@ export function describeInstallProgress(p) {
 /**
  * Install (pull/download) a model on a backend.
  * @param {(p) => void} [onProgress] - streaming progress (Ollama only)
+ * @param {{ force?: boolean }} [opts] - when true, evict existing LM Studio
+ *   files first so `lms get` actually re-fetches in-place GGUF replacements.
+ *   Ollama's pull already re-checks the registry digest, so force is a no-op there.
  */
-export async function installModel(backend, modelId, onProgress) {
+export async function installModel(backend, modelId, onProgress, { force = false } = {}) {
   if (!isBackend(backend)) return { success: false, error: `Unknown backend: ${backend}` }
   if (backend === 'ollama') {
     const importSpec = getOllamaImportSpec(modelId)
@@ -882,6 +885,12 @@ export async function installModel(backend, modelId, onProgress) {
       : await ollamaManager.pullModel(modelId, onProgress)
     if (result.success) refreshOllamaBackedProviders()
     return result
+  }
+  // `lms get` skips files already on disk. A force redownload has to evict the
+  // matching GGUF (or the whole repo folder) first, or the "new" weights never land.
+  if (force) {
+    const evicted = await lmStudioManager.evictDownloadedQuant(modelId)
+    if (!evicted.success) return { success: false, error: evicted.error, modelId }
   }
   // LM Studio: prefer the `lms` CLI (real, blocking download), fall back to the
   // REST hook.

--- a/server/services/localLlm.test.js
+++ b/server/services/localLlm.test.js
@@ -250,6 +250,15 @@ describe('localLlm', () => {
       expect(result).toMatchObject({ success: false, error: 'ambiguous' });
       expect(mocks.lmstudio.downloadModel).not.toHaveBeenCalled();
     });
+    it('does not download a force LM Studio redownload of a bare repo id', async () => {
+      mocks.lmstudio.evictDownloadedQuant.mockResolvedValueOnce({
+        success: false,
+        error: 'Redownload needs a quantization tag'
+      });
+      const result = await svc.installModel('lmstudio', 'unsloth/Qwen3.8-27B-GGUF', undefined, { force: true });
+      expect(result.success).toBe(false);
+      expect(mocks.lmstudio.downloadModel).not.toHaveBeenCalled();
+    });
     it('force is a no-op for Ollama beyond a regular pull', async () => {
       await svc.installModel('ollama', 'hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M', undefined, { force: true });
       expect(mocks.ollama.pullModel).toHaveBeenCalledWith('hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M', undefined);

--- a/server/services/localLlm.test.js
+++ b/server/services/localLlm.test.js
@@ -53,6 +53,7 @@ const mocks = vi.hoisted(() => ({
     modelIdsReferToSameRepo: vi.fn((left, right) => String(left).split('/').pop().replace(/-GGUF$/i, '').toLowerCase()
       === String(right).split('/').pop().replace(/-GGUF$/i, '').toLowerCase()),
     deleteModel: vi.fn(async (id) => ({ success: true, modelId: id })),
+    evictDownloadedQuant: vi.fn(async (id) => ({ success: true, modelId: id })),
     downloadModel: vi.fn(async (id) => ({ success: true, modelId: id })),
     getStatus: vi.fn(async () => ({ available: false, baseUrl: 'y', loadedModels: 0 })),
     resetCache: vi.fn(),
@@ -232,6 +233,27 @@ describe('localLlm', () => {
     it('routes Ollama install to pullModel', async () => {
       await svc.installModel('ollama', 'llama3.2');
       expect(mocks.ollama.pullModel).toHaveBeenCalledWith('llama3.2', undefined);
+    });
+    it('does not evict LM Studio files on a normal install', async () => {
+      await svc.installModel('lmstudio', 'unsloth/Qwen3.8-27B-GGUF');
+      expect(mocks.lmstudio.evictDownloadedQuant).not.toHaveBeenCalled();
+      expect(mocks.lmstudio.downloadModel).toHaveBeenCalledWith('unsloth/Qwen3.8-27B-GGUF');
+    });
+    it('evicts existing LM Studio files before a force redownload', async () => {
+      await svc.installModel('lmstudio', 'unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M', undefined, { force: true });
+      expect(mocks.lmstudio.evictDownloadedQuant).toHaveBeenCalledWith('unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M');
+      expect(mocks.lmstudio.downloadModel).toHaveBeenCalledWith('unsloth/Qwen3.8-27B-GGUF@UD-Q4_K_M');
+    });
+    it('does not download when a force LM Studio eviction fails', async () => {
+      mocks.lmstudio.evictDownloadedQuant.mockResolvedValueOnce({ success: false, error: 'ambiguous' });
+      const result = await svc.installModel('lmstudio', 'qwen3.8', undefined, { force: true });
+      expect(result).toMatchObject({ success: false, error: 'ambiguous' });
+      expect(mocks.lmstudio.downloadModel).not.toHaveBeenCalled();
+    });
+    it('force is a no-op for Ollama beyond a regular pull', async () => {
+      await svc.installModel('ollama', 'hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M', undefined, { force: true });
+      expect(mocks.ollama.pullModel).toHaveBeenCalledWith('hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M', undefined);
+      expect(mocks.lmstudio.evictDownloadedQuant).not.toHaveBeenCalled();
     });
     it('routes a curated Safetensors model through Ollama create instead of registry pull', async () => {
       const onProgress = vi.fn();


### PR DESCRIPTION
## Summary
- Catalog the Unsloth Dynamic 3.0 Qwen3.8 GGUF as the default local pick (`UD-Q4_K_M`, 16.5 GB). Older `Q4_K_M` installs still map as the same model.
- Add a **Redownload** action for already-installed local LLMs. Unsloth (and similar publishers) replace GGUF files in place; Install used to hide once a copy was on disk, so those updates never landed.
- Force-redownload on LM Studio evicts only the matching quant first so `lms get` does not skip existing files. Ollama pull already re-checks the registry digest.

## Test plan
- [ ] Settings → Local LLM: an already-installed catalog card shows **Installed** plus **Redownload**; a fresh card still shows **Install**.
- [ ] Redownload an Ollama HF tag (`hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M`) and confirm the pull progress banner runs.
- [ ] On LM Studio, redownload a specific quant and confirm sibling quants in the same repo folder stay on disk.
- [ ] Curated catalog lists Qwen3.8 27B at `hf.co/unsloth/Qwen3.8-27B-GGUF:UD-Q4_K_M` with a Dynamic 3.0 note.
- [ ] `cd server && npm test -- lib/localLlmCatalog.test.js services/lmStudioManager.test.js services/localLlm.test.js routes/localLlm.test.js`
- [ ] `cd client && npm test -- src/components/settings/LocalLlmTab.test.jsx`