### PR TITLE
fix: llama-server speculative launch used a flag llama.cpp has never had

### DIFF
--- a/docs/features/dflash2.md
+++ b/docs/features/dflash2.md
@@ -76,7 +76,7 @@ Start `llama-server` on loopback port `8080` with speculative decoding enabled
 ```bash
 llama-server \
   -m models/Qwen3.8-27B-Q4_K_M.gguf \
-  --draft-model models/Qwen3.8-27B-DSpark-BF16.gguf \
+  --model-draft models/Qwen3.8-27B-DSpark-BF16.gguf \
   --spec-type draft-dspark \
   --port 8080 \
   --host 127.0.0.1 \

--- a/server/services/llamaServerManager.js
+++ b/server/services/llamaServerManager.js
@@ -164,7 +164,14 @@ export async function startLlamaServer(options = {}) {
 
   const args = ['-m', expandHome(model.trim())];
   if (draftPath) {
-    args.push('--draft-model', expandHome(draftPath));
+    // `--model-draft` is the drafter flag llama.cpp parses. Newer builds also
+    // spell it `--spec-draft-model`, but the legacy name (alias `-md`) is the
+    // one every build accepts. `--draft-model` has never existed in any of
+    // them, and an unknown flag is fatal — llama.cpp prints
+    // `error: invalid argument: …` and exits 1 before loading a single weight,
+    // so the typo killed the launch outright rather than quietly dropping
+    // speculative decoding.
+    args.push('--model-draft', expandHome(draftPath));
     if (specType) args.push('--spec-type', specType.trim());
   }
   if (port) args.push('--port', String(port));

--- a/server/services/llamaServerManager.test.js
+++ b/server/services/llamaServerManager.test.js
@@ -116,9 +116,13 @@ describe('llamaServerManager', () => {
     expect(result.success).toBe(true);
     expect(result.pid).toBe(12345);
     expect(spawnArgs.cmd).toBe('/usr/local/bin/llama-server');
+    // The drafter flag was once spelled `--draft-model`, which llama.cpp has
+    // never accepted — it exits 1 on an unknown flag before touching the
+    // weights, so every speculative launch died on arrival. Pinning the exact
+    // argv is what keeps a plausible-looking misspelling out.
     expect(spawnArgs.args).toEqual([
       '-m', modelPath,
-      '--draft-model', draftPath,
+      '--model-draft', draftPath,
       '--spec-type', 'draft-dflash',
       '--port', '8080',
       '--host', '127.0.0.1',


### PR DESCRIPTION
## Summary

Starting `llama-server` with a drafter model died instantly:

```
error: invalid argument: --draft-model
Process exited with code 1
```

so speculative decoding (DSpark / DFlash 2) could not be launched at all from
**Settings → Local LLM**, no matter how the presets or GGUF paths were configured.

The drafter flag llama.cpp actually parses is **`--model-draft`** (alias `-md`; spelled
`--spec-draft-model` in builds carrying the speculative-params rename). `--draft-model`
has never existed in any build, and llama.cpp treats an unknown flag as fatal — it exits
before loading a single weight rather than degrading to non-speculative decoding, which
is why a perfectly-configured pair still died on arrival.

`--model-draft` is the spelling accepted by **both** the pre-rename and current builds,
so it works whether the user is on a stock `brew install llama.cpp` or a from-source
DFlash 2 branch.

## Changes

- `server/services/llamaServerManager.js` — emit `--model-draft` instead of the
  non-existent `--draft-model`, with a comment recording why the legacy spelling is the
  compatible one.
- `server/services/llamaServerManager.test.js` — the exact-argv assertion now pins the
  corrected flag (it fails if the misspelling regresses).
- `docs/features/dflash2.md` — fix the copy-pasteable launch command, which carried the
  same wrong flag.

The remaining `draft-model` hits in the repo are the Hugging Face **repo tag** of that
name (`huggingFaceCatalog.js`) and a DOM `id` — a different namespace, correctly left
alone.

## Test plan

- `cd server && npm test` — 1505 files / 31225 tests pass.
- The corrected assertion was verified to **fail** against the pre-fix code before the
  fix was applied.
- Verified end to end against llama.cpp build 10470 with a real 27B base + DSpark
  drafter pair: the draft model loads, the `draft-dspark` speculative implementation
  registers, the server reaches `listening on http://127.0.0.1:<port>`, and
  `/v1/models` + `/v1/chat/completions` both answer.