### PR TITLE
feat: label filters on the app Issues tab, hiding in-progress work by default

### DIFF
--- a/client/src/components/apps/tabs/IssuesTab.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useId, useRef } from 'react'
 import { Link } from 'react-router';
 import {
   AlertTriangle, Bot, ChevronDown, ChevronRight, CircleDot, ExternalLink,
-  Loader2, RefreshCw, Rocket, Search, User
+  Loader2, RefreshCw, Rocket, Search, Tag, User
 } from 'lucide-react';
 import BrailleSpinner from '../../BrailleSpinner';
 import Banner from '../../ui/Banner';
@@ -38,6 +38,12 @@ const claimStatusForTask = (status) => ({
 // (CLI/TUI agents with a file-writing harness) can run a `/do:next` claim.
 const enabledProcessProviderFilter = (p) => Boolean(p?.enabled) && isProcessProvider(p);
 
+// `in-progress` is the forge label a `/do:next` claim stamps on an issue it is
+// actively working (server/services/issueReconcile.js#IN_PROGRESS_LABEL). Those
+// rows aren't claimable, so the tab hides them until the user toggles the chip
+// back on.
+const DEFAULT_HIDDEN_LABELS = ['in-progress'];
+
 // Why the forge returned nothing, in the user's terms. Sentinel-aware: a
 // definitive "no open issues" and a failed probe are different sentences, so an
 // unreachable CLI can never read as an empty tracker.
@@ -54,22 +60,62 @@ const EMPTY_REASONS = {
  * so it can't be a Tailwind class (those must be literal strings in source).
  * Render it as a tinted chip via inline style: the color for text and border,
  * a low-alpha wash of it for the background, which stays legible on the dark
- * surface for the full hue range. A label with no color falls back to `muted`.
+ * surface for the full hue range. A label with no color gets no inline style, so
+ * the chip keeps its own neutral look (the `muted` Pill tone on a row chip).
  */
+const labelChipStyle = (color) => (color ? {
+  color,
+  borderColor: `${color}66`,
+  backgroundColor: `${color}1a`
+} : undefined);
+
 function LabelChip({ label }) {
   return (
     <Pill
       size="xs"
       tone={label.color ? 'bare' : 'muted'}
       title={label.description || undefined}
-      style={label.color ? {
-        color: label.color,
-        borderColor: `${label.color}66`,
-        backgroundColor: `${label.color}1a`
-      } : undefined}
+      style={labelChipStyle(label.color)}
     >
       {label.name}
     </Pill>
+  );
+}
+
+/**
+ * One label's show/hide toggle. Pressed (default) = issues carrying the label
+ * are listed; un-pressed strikes the chip through and drops every issue that
+ * carries it — so an issue tagged `bug` + `in-progress` disappears while
+ * `in-progress` is off, which is what "hide in-progress work" has to mean.
+ *
+ * The count renders as a node adjacent to the name, so the computed accessible
+ * name would be "bug1" — `aria-label` spells it out instead.
+ *
+ * NOT the shared `ui/ToggleChip`: that one is a fixed-accent pill wrapping a
+ * real checkbox, which can't carry the forge's per-label color (the thing the
+ * user recognizes a label by) and stacks a checkbox per chip into a row that
+ * routinely runs 20+ labels wide.
+ */
+function LabelFilterChip({ facet, hidden, onToggle }) {
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(facet.name)}
+      aria-pressed={!hidden}
+      aria-label={`${facet.name} (${facet.count})`}
+      title={facet.description
+        ? `${facet.description} — click to ${hidden ? 'show' : 'hide'} these issues`
+        : `Click to ${hidden ? 'show' : 'hide'} issues labeled ${facet.name}`}
+      className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-[10px] transition-opacity ${
+        hidden
+          ? 'border-port-border bg-port-bg text-gray-500 line-through opacity-60 hover:opacity-100'
+          : 'border-port-border bg-port-bg text-gray-300 hover:opacity-80'
+      }`}
+      style={hidden ? undefined : labelChipStyle(facet.color)}
+    >
+      {facet.name}
+      <span className="font-mono opacity-70">{facet.count}</span>
+    </button>
   );
 }
 
@@ -89,6 +135,10 @@ export default function IssuesTab({ appId, appName }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [query, setQuery] = useState('');
+  // Labels whose issues are hidden. Tracking the HIDDEN set (rather than the
+  // shown one) means a label that shows up in a later refresh is visible by
+  // default without reconciling state against the new facet list.
+  const [hiddenLabels, setHiddenLabels] = useState(() => new Set(DEFAULT_HIDDEN_LABELS));
   const [expanded, setExpanded] = useState(() => new Set());
   // Per-issue claim lifecycle: 'queuing' while the POST is in flight, then the
   // task's live CoS state. Keyed by issue number so one claim can't disable
@@ -129,6 +179,7 @@ export default function IssuesTab({ appId, appName }) {
     claimsRef.current = {};
     setClaims({});
     setOverrideContext('');
+    setHiddenLabels(new Set(DEFAULT_HIDDEN_LABELS));
   }, [appId]);
 
   useEffect(() => {
@@ -241,13 +292,40 @@ export default function IssuesTab({ appId, appName }) {
     ].join('\n').toLowerCase()
   })), [data]);
 
+  // Every label present on the fetched issues, with how many issues carry it,
+  // alphabetical so the chip row doesn't reshuffle between refreshes.
+  const labelFacets = useMemo(() => {
+    const byName = new Map();
+    for (const issue of data?.issues || []) {
+      for (const label of issue.labels || []) {
+        const seen = byName.get(label.name);
+        if (seen) seen.count += 1;
+        else byName.set(label.name, { ...label, count: 1 });
+      }
+    }
+    return [...byName.values()].sort((a, b) => a.name.localeCompare(b.name));
+  }, [data]);
+
   const issues = useMemo(() => {
     const q = query.trim().toLowerCase();
-    const rows = q ? haystacks.filter(h => h.hay.includes(q)) : haystacks;
+    const rows = haystacks.filter(h =>
+      (hiddenLabels.size === 0 || !h.issue.labels.some(l => hiddenLabels.has(l.name)))
+      && (!q || h.hay.includes(q))
+    );
     return rows.map(h => h.issue);
-  }, [haystacks, query]);
+  }, [haystacks, query, hiddenLabels]);
 
   const total = data?.issues?.length ?? 0;
+  // Only labels actually on this tracker count as "filtering something" — the
+  // seeded `in-progress` default must not claim to hide anything in a repo that
+  // never uses it.
+  const hidingByLabel = labelFacets.some(f => hiddenLabels.has(f.name));
+
+  const toggleLabel = (name) => setHiddenLabels(prev => {
+    const next = new Set(prev);
+    if (next.has(name)) next.delete(name); else next.add(name);
+    return next;
+  });
 
   const toggleExpanded = (number) => setExpanded(prev => {
     const next = new Set(prev);
@@ -342,6 +420,35 @@ export default function IssuesTab({ appId, appName }) {
         </button>
       </div>
 
+      {labelFacets.length > 0 && (
+        <div
+          role="group"
+          aria-label="Label filters"
+          className="flex flex-wrap items-center gap-1.5 px-3 py-2 bg-port-card border border-port-border rounded-lg"
+        >
+          <span className="flex items-center gap-1.5 text-xs text-gray-500 uppercase tracking-wide shrink-0">
+            <Tag size={14} /> Labels
+          </span>
+          {labelFacets.map(facet => (
+            <LabelFilterChip
+              key={facet.name}
+              facet={facet}
+              hidden={hiddenLabels.has(facet.name)}
+              onToggle={toggleLabel}
+            />
+          ))}
+          {hidingByLabel && (
+            <button
+              type="button"
+              onClick={() => setHiddenLabels(new Set())}
+              className="ml-auto text-xs text-gray-500 hover:text-port-accent transition-colors"
+            >
+              Show all labels
+            </button>
+          )}
+        </div>
+      )}
+
       <div className="space-y-3 px-3 py-2 bg-port-card border border-port-border rounded-lg">
         <div className="flex flex-col sm:flex-row sm:items-center gap-2">
           <span className="flex items-center gap-1.5 text-xs text-gray-500 uppercase tracking-wide shrink-0">
@@ -407,7 +514,9 @@ export default function IssuesTab({ appId, appName }) {
           showing them alongside a "couldn't refresh" notice. */}
       {issues.length === 0 && total > 0 && (
         <div className="px-3 py-2 text-sm text-gray-500 bg-port-card border border-port-border rounded-lg">
-          No open issues match &ldquo;{query}&rdquo;.
+          {query.trim()
+            ? <>No open issues match &ldquo;{query}&rdquo;{hidingByLabel ? ' with the current label filters' : ''}.</>
+            : 'Every open issue carries a hidden label.'}
         </div>
       )}
 

--- a/client/src/components/apps/tabs/IssuesTab.test.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.test.jsx
@@ -81,7 +81,9 @@ describe('IssuesTab', () => {
     expect(await screen.findByText('Crash on save')).toBeInTheDocument();
     expect(api.getAppIssues).toHaveBeenCalledWith('app-1');
     expect(screen.getByText('#42')).toBeInTheDocument();
-    expect(screen.getByText('bug')).toBeInTheDocument();
+    // Scoped by the row chip's own title — the label also appears as a filter
+    // toggle in the header, so a bare getByText('bug') is ambiguous.
+    expect(screen.getByTitle('Something is broken')).toHaveTextContent('bug');
     expect(screen.getByText(/alice/)).toBeInTheDocument();
     expect(screen.getByText('acme/widget')).toBeInTheDocument();
   });
@@ -229,6 +231,76 @@ describe('IssuesTab', () => {
 
     expect(screen.getByText('Add CSV export')).toBeInTheDocument();
     expect(screen.queryByText('Crash on save')).not.toBeInTheDocument();
+  });
+
+  it('hides in-progress issues by default and lists them once the chip is toggled on', async () => {
+    api.getAppIssues.mockResolvedValue(okPayload([
+      ISSUE,
+      {
+        ...ISSUE,
+        number: 43,
+        title: 'Being worked right now',
+        labels: [
+          { name: 'bug', color: '#d73a4a', description: '' },
+          { name: 'in-progress', color: '#0e8a16', description: '' },
+        ],
+      },
+    ]));
+    await renderTab();
+
+    await screen.findByText('Crash on save');
+    expect(screen.queryByText('Being worked right now')).not.toBeInTheDocument();
+    expect(screen.getByText('1 of 2 open')).toBeInTheDocument();
+
+    const chip = screen.getByRole('button', { name: /in-progress/ });
+    expect(chip).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(chip);
+    expect(await screen.findByText('Being worked right now')).toBeInTheDocument();
+    expect(chip).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('toggles a label chip off to hide every issue carrying that label', async () => {
+    api.getAppIssues.mockResolvedValue(okPayload([
+      ISSUE,
+      { ...ISSUE, number: 43, title: 'Add CSV export', labels: [{ name: 'feature', color: null, description: '' }] },
+    ]));
+    await renderTab();
+
+    await screen.findByText('Crash on save');
+    // Facet counts come from the fetched issues, one chip per distinct label.
+    const bugChip = screen.getByRole('button', { name: 'bug (1)' });
+    expect(screen.getByRole('button', { name: 'feature (1)' })).toBeInTheDocument();
+
+    fireEvent.click(bugChip);
+    await waitFor(() => expect(screen.queryByText('Crash on save')).not.toBeInTheDocument());
+    expect(screen.getByText('Add CSV export')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show all labels' }));
+    expect(await screen.findByText('Crash on save')).toBeInTheDocument();
+  });
+
+  it('resets label filters back to the in-progress default when the app changes', async () => {
+    const inProgress = {
+      ...ISSUE,
+      number: 43,
+      title: 'Being worked right now',
+      labels: [{ name: 'in-progress', color: '#0e8a16', description: '' }],
+    };
+    api.getAppIssues.mockResolvedValue(okPayload([ISSUE, inProgress]));
+    const { rerender } = await renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: /in-progress/ }));
+    expect(await screen.findByText('Being worked right now')).toBeInTheDocument();
+
+    rerender(
+      <MemoryRouter>
+        <IssuesTab appId="app-2" appName="Other" />
+      </MemoryRouter>
+    );
+    await act(async () => {});
+
+    await waitFor(() => expect(screen.queryByText('Being worked right now')).not.toBeInTheDocument());
   });
 
   it('ignores a stale in-flight response when the app changes mid-request', async () => {


### PR DESCRIPTION
## Summary

The managed-app **Issues tab** now derives a filter row from the labels actually present on the fetched open issues, and opens on the issues that are actually claimable.

- **Label toggles.** Every distinct label across the fetched issues becomes a chip carrying the forge's own label color and a per-label issue count. Each chip is a show/hide toggle (`aria-pressed`), and turning one off drops **every** issue carrying that label — so an issue tagged both `bug` and `in-progress` disappears while `in-progress` is off.
- **`in-progress` starts hidden.** That's the label a `/do:next` claim stamps on an issue an agent is actively working (`IN_PROGRESS_LABEL` in `server/services/issueReconcile.js`); those rows aren't claimable, so the tab no longer leads with them. One click on the chip brings them back.
- **Show all labels** clears the filters in one click, and switching apps resets the row to the default.
- The header count already reads `N of M open`, so the hidden rows are still accounted for, and the "nothing matches" copy now distinguishes a search miss from a label-filtered-out list.

Hidden state is tracked as the *hidden* set rather than the shown one, so a label that first appears in a later refresh is visible by default without reconciling against the new facet list.

## Notes

The chips deliberately don't reuse `ui/ToggleChip`: that primitive is a fixed-accent pill wrapping a real checkbox, which can't carry the forge's per-label color (the thing a user recognizes a label by) and stacks a checkbox per chip into a row that routinely runs 20+ labels wide. The rationale is recorded in a comment at the component.

## Test plan

- `client/src/components/apps/tabs/IssuesTab.test.jsx` — three new tests, each verified failing before the change:
  - in-progress issues are hidden on load and appear once the chip is toggled on (`1 of 2 open`)
  - toggling a label chip off hides every issue carrying it; "Show all labels" restores them
  - switching apps resets the filters back to the `in-progress` default
- `cd client && npm test` — 688 files / 8583 tests pass.
- `cd client && npm run build` — clean.
- Local `agy` (Gemini 3.7 Flash, medium effort) review pass: no findings.