### PR TITLE
feat: filter app management issues

### DIFF
--- a/client/src/components/apps/tabs/IssuesTab.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.jsx
@@ -39,10 +39,11 @@ const claimStatusForTask = (status) => ({
 const enabledProcessProviderFilter = (p) => Boolean(p?.enabled) && isProcessProvider(p);
 
 // `in-progress` is the forge label a `/do:next` claim stamps on an issue it is
-// actively working (server/services/issueReconcile.js#IN_PROGRESS_LABEL). Those
-// rows aren't claimable, so the tab hides them until the user toggles the chip
-// back on.
-const DEFAULT_HIDDEN_LABELS = ['in-progress'];
+// actively working (server/services/issueReconcile.js#IN_PROGRESS_LABEL), and
+// `blocked` marks work that should not be picked up by default. Those rows
+// aren't useful claim candidates, so the tab hides them until the user toggles
+// the chip back on.
+const DEFAULT_HIDDEN_LABELS = ['blocked', 'in-progress'];
 
 // Why the forge returned nothing, in the user's terms. Sentinel-aware: a
 // definitive "no open issues" and a failed probe are different sentences, so an
@@ -135,6 +136,7 @@ export default function IssuesTab({ appId, appName }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [query, setQuery] = useState('');
+  const [unassignedOnly, setUnassignedOnly] = useState(false);
   // Labels whose issues are hidden. Tracking the HIDDEN set (rather than the
   // shown one) means a label that shows up in a later refresh is visible by
   // default without reconciling state against the new facet list.
@@ -180,6 +182,7 @@ export default function IssuesTab({ appId, appName }) {
     setClaims({});
     setOverrideContext('');
     setHiddenLabels(new Set(DEFAULT_HIDDEN_LABELS));
+    setUnassignedOnly(false);
   }, [appId]);
 
   useEffect(() => {
@@ -310,15 +313,16 @@ export default function IssuesTab({ appId, appName }) {
     const q = query.trim().toLowerCase();
     const rows = haystacks.filter(h =>
       (hiddenLabels.size === 0 || !h.issue.labels.some(l => hiddenLabels.has(l.name)))
+      && (!unassignedOnly || h.issue.assignees.length === 0)
       && (!q || h.hay.includes(q))
     );
     return rows.map(h => h.issue);
-  }, [haystacks, query, hiddenLabels]);
+  }, [haystacks, query, hiddenLabels, unassignedOnly]);
 
   const total = data?.issues?.length ?? 0;
   // Only labels actually on this tracker count as "filtering something" — the
-  // seeded `in-progress` default must not claim to hide anything in a repo that
-  // never uses it.
+  // seeded defaults must not claim to hide anything in a repo that never uses
+  // them.
   const hidingByLabel = labelFacets.some(f => hiddenLabels.has(f.name));
 
   const toggleLabel = (name) => setHiddenLabels(prev => {
@@ -399,6 +403,18 @@ export default function IssuesTab({ appId, appName }) {
             {issues.length === total ? `${total} open` : `${issues.length} of ${total} open`}
           </span>
         )}
+        <button
+          type="button"
+          onClick={() => setUnassignedOnly(prev => !prev)}
+          aria-pressed={unassignedOnly}
+          title={unassignedOnly ? 'Show assigned issues too' : 'Show only issues without assignees'}
+          className={`px-3 py-1.5 rounded-lg text-xs border flex items-center gap-1.5 transition-colors ${unassignedOnly
+            ? 'bg-port-accent/20 text-port-accent border-port-accent/40'
+            : 'bg-port-bg text-gray-400 border-port-border hover:text-white'
+          }`}
+        >
+          <User size={13} /> Unassigned only
+        </button>
         <div className="relative ml-auto">
           <label htmlFor={searchId} className="sr-only">Filter issues</label>
           <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-gray-500" />
@@ -516,7 +532,9 @@ export default function IssuesTab({ appId, appName }) {
         <div className="px-3 py-2 text-sm text-gray-500 bg-port-card border border-port-border rounded-lg">
           {query.trim()
             ? <>No open issues match &ldquo;{query}&rdquo;{hidingByLabel ? ' with the current label filters' : ''}.</>
-            : 'Every open issue carries a hidden label.'}
+            : unassignedOnly
+              ? <>No unassigned open issues{hidingByLabel ? ' match the current label filters' : ''}.</>
+              : 'Every open issue carries a hidden label.'}
         </div>
       )}
 

--- a/client/src/components/apps/tabs/IssuesTab.test.jsx
+++ b/client/src/components/apps/tabs/IssuesTab.test.jsx
@@ -233,6 +233,27 @@ describe('IssuesTab', () => {
     expect(screen.queryByText('Crash on save')).not.toBeInTheDocument();
   });
 
+  it('filters to unassigned issues when the toggle is enabled', async () => {
+    api.getAppIssues.mockResolvedValue(okPayload([
+      ISSUE,
+      { ...ISSUE, number: 43, title: 'Add CSV export', labels: [], assignees: [] },
+    ]));
+    await renderTab();
+
+    await screen.findByText('Crash on save');
+    const toggle = screen.getByRole('button', { name: 'Unassigned only' });
+    expect(toggle).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(toggle);
+
+    expect(await screen.findByText('Add CSV export')).toBeInTheDocument();
+    expect(screen.queryByText('Crash on save')).not.toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-pressed', 'true');
+
+    fireEvent.click(toggle);
+    expect(await screen.findByText('Crash on save')).toBeInTheDocument();
+  });
+
   it('hides in-progress issues by default and lists them once the chip is toggled on', async () => {
     api.getAppIssues.mockResolvedValue(okPayload([
       ISSUE,
@@ -260,6 +281,30 @@ describe('IssuesTab', () => {
     expect(chip).toHaveAttribute('aria-pressed', 'true');
   });
 
+  it('hides blocked issues by default and lists them once the chip is toggled on', async () => {
+    api.getAppIssues.mockResolvedValue(okPayload([
+      ISSUE,
+      {
+        ...ISSUE,
+        number: 43,
+        title: 'Waiting on a dependency',
+        labels: [{ name: 'blocked', color: '#b60205', description: '' }],
+      },
+    ]));
+    await renderTab();
+
+    await screen.findByText('Crash on save');
+    expect(screen.queryByText('Waiting on a dependency')).not.toBeInTheDocument();
+    expect(screen.getByText('1 of 2 open')).toBeInTheDocument();
+
+    const chip = screen.getByRole('button', { name: 'blocked (1)' });
+    expect(chip).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(chip);
+    expect(await screen.findByText('Waiting on a dependency')).toBeInTheDocument();
+    expect(chip).toHaveAttribute('aria-pressed', 'true');
+  });
+
   it('toggles a label chip off to hide every issue carrying that label', async () => {
     api.getAppIssues.mockResolvedValue(okPayload([
       ISSUE,
@@ -280,7 +325,7 @@ describe('IssuesTab', () => {
     expect(await screen.findByText('Crash on save')).toBeInTheDocument();
   });
 
-  it('resets label filters back to the in-progress default when the app changes', async () => {
+  it('resets label and assignee filters when the app changes', async () => {
     const inProgress = {
       ...ISSUE,
       number: 43,
@@ -292,6 +337,7 @@ describe('IssuesTab', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /in-progress/ }));
     expect(await screen.findByText('Being worked right now')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Unassigned only' }));
 
     rerender(
       <MemoryRouter>
@@ -301,6 +347,7 @@ describe('IssuesTab', () => {
     await act(async () => {});
 
     await waitFor(() => expect(screen.queryByText('Being worked right now')).not.toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Unassigned only' })).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('ignores a stale in-flight response when the app changes mid-request', async () => {


### PR DESCRIPTION
## Summary

- Add an Unassigned only toggle to the app management Git issues list.
- Hide issues carrying the blocked label by default while keeping the existing label toggle available.
- Reset the new filter when switching managed apps and cover both behaviors with regression tests.

## Test plan

- `cd client && npm test`
- `cd client && npm run lint`
- `cd client && npm run build`