### PR TITLE
fix: support double-sided open-shell materials (#4632)

### DIFF
--- a/client/src/lib/threejsSculpt.js
+++ b/client/src/lib/threejsSculpt.js
@@ -71,11 +71,13 @@ export function createSculptBufferGeometry(definition) {
  * render profile — the two must move together.
  */
 export function sculptMaterialProps(definition, envMapIntensity = 1) {
+  const doubleSided = definition.side === 'double' ? { side: THREE.DoubleSide } : {};
   const unlit = {
     color: definition.color,
     opacity: definition.opacity,
     transparent: definition.transparent,
     wireframe: definition.wireframe,
+    ...doubleSided,
   };
   if (definition.type === 'basic') return unlit;
   const lit = {

--- a/client/src/lib/threejsSculpt.test.js
+++ b/client/src/lib/threejsSculpt.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
 import { createSculptBufferGeometry, needsSculptBufferGeometry, sculptMaterialProps } from './threejsSculpt.js';
 
 const extrudeDefinition = (overrides = {}) => ({
@@ -130,6 +131,13 @@ describe('sculptMaterialProps', () => {
     // A caller that has no environment to declare still gets the neutral value,
     // never `undefined` — three reads that as "leave the material's own".
     expect(sculptMaterialProps(definition).envMapIntensity).toBe(1);
+  });
+
+  it('forwards double-sided rendering to every material type', () => {
+    for (const type of ['standard', 'physical', 'basic']) {
+      expect(sculptMaterialProps({ ...definition, type, side: 'double' }).side).toBe(THREE.DoubleSide);
+    }
+    expect(sculptMaterialProps({ ...definition, side: 'front' })).not.toHaveProperty('side');
   });
 });
 // @vitest-environment node

--- a/client/src/pages/ThreejsModelDetail.jsx
+++ b/client/src/pages/ThreejsModelDetail.jsx
@@ -405,6 +405,7 @@ export default function ThreejsModelDetail() {
   // the same as passing it — the panel is omitted rather than shown clean.
   const coverageFindings = Array.isArray(record.coverage?.findings) ? record.coverage.findings : null;
   const flatnessFindings = Array.isArray(record.flatness?.findings) ? record.flatness.findings : null;
+  const flatnessHasWarnings = flatnessFindings?.some((finding) => finding.severity === 'warning');
   const penetrationFindings = Array.isArray(record.penetration?.findings) ? record.penetration.findings : null;
   const physicalAuditFindings = Array.isArray(record.physicalAudit?.findings)
     ? record.physicalAudit.findings
@@ -614,7 +615,7 @@ export default function ThreejsModelDetail() {
           findings={flatnessFindings}
           cleanLabel="Identity parts carry real depth"
           footer={`A model can match its reference head-on and still be a stack of cardboard cut-outs, so this check counts how many identity-defining features are built only from flat parts.${
-            flatnessFindings.length > 0 ? ' Refining without your own feedback will also ask for real depth.' : ''
+            flatnessHasWarnings ? ' Refining without your own feedback will also ask for real depth.' : ''
           }`}
         />
       )}

--- a/client/src/pages/ThreejsModelDetail.test.jsx
+++ b/client/src/pages/ThreejsModelDetail.test.jsx
@@ -167,6 +167,32 @@ describe('ThreejsModelDetail cross-section gate', () => {
     expect(screen.queryByText(/will also ask for real depth/)).not.toBeInTheDocument();
   });
 
+  it('shows an intentional membrane note without promising depth feedback', async () => {
+    getThreejsModel.mockResolvedValue({
+      ...baseRecord,
+      flatness: {
+        errorCount: 0,
+        warningCount: 0,
+        noteCount: 1,
+        identityDetailCount: 1,
+        flatIdentityDetailCount: 1,
+        flatRatio: 1,
+        slabPartIds: ['fin'],
+        findings: [{
+          code: 'flat-identity-parts',
+          severity: 'note',
+          message: '1 of 1 identity-defining features are intentional membrane surfaces (Fin).',
+        }],
+      },
+    });
+    renderDetail();
+
+    await waitFor(() => expect(screen.getByText('Cross-section')).toBeInTheDocument());
+    expect(screen.getByText(/intentional membrane surfaces/)).toBeInTheDocument();
+    expect(screen.getByText('0 error · 0 warning · 1 note')).toBeInTheDocument();
+    expect(screen.queryByText(/will also ask for real depth/)).not.toBeInTheDocument();
+  });
+
   it('hides the section for a record generated before the gate existed', async () => {
     getThreejsModel.mockResolvedValue({ ...baseRecord, flatness: null });
     renderDetail();

--- a/server/lib/threejsModel.js
+++ b/server/lib/threejsModel.js
@@ -811,7 +811,63 @@ const isCoplanarCloud = (vertices) => {
   return Math.abs(determinant) / (meanVariance ** 3) < COPLANAR_DETERMINANT;
 };
 
-const isZeroThicknessGeometry = (geometry) => {
+// Three.js composes a part's local transform as rotation * scale, then applies
+// each ancestor's transform from the outside. Keeping the linear part here is
+// enough for the relative thickness check and avoids making the server-side gate
+// depend on Three.js just to answer a geometry question.
+const IDENTITY_LINEAR = [1, 0, 0, 0, 1, 0, 0, 0, 1];
+
+const multiplyLinear = (a, b) => [
+  (a[0] * b[0]) + (a[1] * b[3]) + (a[2] * b[6]),
+  (a[0] * b[1]) + (a[1] * b[4]) + (a[2] * b[7]),
+  (a[0] * b[2]) + (a[1] * b[5]) + (a[2] * b[8]),
+  (a[3] * b[0]) + (a[4] * b[3]) + (a[5] * b[6]),
+  (a[3] * b[1]) + (a[4] * b[4]) + (a[5] * b[7]),
+  (a[3] * b[2]) + (a[4] * b[5]) + (a[5] * b[8]),
+  (a[6] * b[0]) + (a[7] * b[3]) + (a[8] * b[6]),
+  (a[6] * b[1]) + (a[7] * b[4]) + (a[8] * b[7]),
+  (a[6] * b[2]) + (a[7] * b[5]) + (a[8] * b[8]),
+];
+
+const rotationLinear = (degrees = [0, 0, 0]) => {
+  const [x = 0, y = 0, z = 0] = degrees;
+  const ax = (Number.isFinite(x) ? x : 0) * (Math.PI / 180);
+  const ay = (Number.isFinite(y) ? y : 0) * (Math.PI / 180);
+  const az = (Number.isFinite(z) ? z : 0) * (Math.PI / 180);
+  const a = Math.cos(ax);
+  const b = Math.sin(ax);
+  const c = Math.cos(ay);
+  const d = Math.sin(ay);
+  const e = Math.cos(az);
+  const f = Math.sin(az);
+  // Row-major equivalent of THREE.Euler's default XYZ matrix.
+  return [
+    c * e, -c * f, d,
+    (b * d * e) + (a * f), (-b * d * f) + (a * e), -b * c,
+    (-a * d * e) + (b * f), (a * d * f) + (b * e), a * c,
+  ];
+};
+
+const scaleLinear = (scale = [1, 1, 1]) => [
+  Number.isFinite(scale[0]) ? scale[0] : 1, 0, 0,
+  0, Number.isFinite(scale[1]) ? scale[1] : 1, 0,
+  0, 0, Number.isFinite(scale[2]) ? scale[2] : 1,
+];
+
+const partLinear = (part) => multiplyLinear(
+  rotationLinear(part.rotationDegrees),
+  scaleLinear(part.scale),
+);
+
+const applyLinear = (matrix, vector) => [
+  (matrix[0] * vector[0]) + (matrix[1] * vector[1]) + (matrix[2] * vector[2]),
+  (matrix[3] * vector[0]) + (matrix[4] * vector[1]) + (matrix[5] * vector[2]),
+  (matrix[6] * vector[0]) + (matrix[7] * vector[1]) + (matrix[8] * vector[2]),
+];
+
+const vectorLength = (vector) => Math.hypot(...vector);
+
+const isZeroThicknessGeometry = (geometry, worldLinear = IDENTITY_LINEAR) => {
   if (!geometry) return false;
   if (geometry.type === 'custom') {
     const vertices = Array.isArray(geometry.vertices) ? geometry.vertices : [];
@@ -822,8 +878,13 @@ const isZeroThicknessGeometry = (geometry) => {
   if (outline.length < 3 || !(geometry.depth > 0)) return false;
   const xs = outline.map(([x]) => x);
   const ys = outline.map(([, y]) => y);
-  const span = Math.max(Math.max(...xs) - Math.min(...xs), Math.max(...ys) - Math.min(...ys));
-  return span > 0 && geometry.depth / span <= OPEN_SHELL_DEPTH_RATIO;
+  const spanX = Math.max(...xs) - Math.min(...xs);
+  const spanY = Math.max(...ys) - Math.min(...ys);
+  const xSpan = spanX * vectorLength(applyLinear(worldLinear, [1, 0, 0]));
+  const ySpan = spanY * vectorLength(applyLinear(worldLinear, [0, 1, 0]));
+  const span = Math.max(xSpan, ySpan);
+  const thickness = geometry.depth * vectorLength(applyLinear(worldLinear, [0, 0, 1]));
+  return span > 0 && thickness > 0 && thickness / span <= OPEN_SHELL_DEPTH_RATIO;
 };
 
 const isSlabGeometry = (geometry) => {
@@ -856,9 +917,12 @@ const collectMeshes = (part, out = []) => {
  */
 export function evaluateThreejsFlatness(spec) {
   const byId = new Map();
-  const indexPart = (part) => {
+  const worldLinearById = new Map();
+  const indexPart = (part, parentLinear = IDENTITY_LINEAR) => {
     byId.set(part.id, part);
-    for (const child of part.children || []) indexPart(child);
+    const worldLinear = multiplyLinear(parentLinear, partLinear(part));
+    worldLinearById.set(part.id, worldLinear);
+    for (const child of part.children || []) indexPart(child, worldLinear);
   };
   for (const part of spec?.parts || []) indexPart(part);
 
@@ -888,7 +952,8 @@ export function evaluateThreejsFlatness(spec) {
       feature: detail.feature,
       partIds: implementing.map((mesh) => mesh.id),
       isIntentionalMembrane: implementing.every((mesh) => (
-        spec?.materials?.[mesh.material]?.side === 'double' && isZeroThicknessGeometry(mesh.geometry)
+        spec?.materials?.[mesh.material]?.side === 'double'
+        && isZeroThicknessGeometry(mesh.geometry, worldLinearById.get(mesh.id))
       )),
     });
     for (const mesh of implementing) slabPartIds.add(mesh.id);

--- a/server/lib/threejsModel.js
+++ b/server/lib/threejsModel.js
@@ -867,11 +867,19 @@ const applyLinear = (matrix, vector) => [
 
 const vectorLength = (vector) => Math.hypot(...vector);
 
+const transformVertices = (vertices, matrix) => {
+  const transformed = [];
+  for (let index = 0; index + 2 < vertices.length; index += 3) {
+    transformed.push(...applyLinear(matrix, vertices.slice(index, index + 3)));
+  }
+  return transformed;
+};
+
 const isZeroThicknessGeometry = (geometry, worldLinear = IDENTITY_LINEAR) => {
   if (!geometry) return false;
   if (geometry.type === 'custom') {
     const vertices = Array.isArray(geometry.vertices) ? geometry.vertices : [];
-    return vertices.length >= 9 && isCoplanarCloud(vertices);
+    return vertices.length >= 9 && isCoplanarCloud(transformVertices(vertices, worldLinear));
   }
   if (geometry.type !== 'extrude') return false;
   const outline = Array.isArray(geometry.outline) ? geometry.outline : [];

--- a/server/lib/threejsModel.js
+++ b/server/lib/threejsModel.js
@@ -753,6 +753,11 @@ const RELATIVE_PLANE_QUANTUM = 1e-3;
 // the plane count above rather than double-jeopardy here.
 const COPLANAR_DETERMINANT = 1e-6;
 
+// An extrude can represent a membrane only when its sweep is negligible at the
+// scale of its outline. Keep this relative so the declaration works for both a
+// small fin and a large cape, while a positive-depth plate remains a solid slab.
+const OPEN_SHELL_DEPTH_RATIO = 1e-3;
+
 // Aggregate, never per-part: `extrude` is the RIGHT answer for a plate, a badge,
 // or a sign, so a flat part is only evidence when the model's identity rides on
 // it. The finding is "the load-bearing parts are predominantly flat", reported
@@ -806,6 +811,21 @@ const isCoplanarCloud = (vertices) => {
   return Math.abs(determinant) / (meanVariance ** 3) < COPLANAR_DETERMINANT;
 };
 
+const isZeroThicknessGeometry = (geometry) => {
+  if (!geometry) return false;
+  if (geometry.type === 'custom') {
+    const vertices = Array.isArray(geometry.vertices) ? geometry.vertices : [];
+    return vertices.length >= 9 && isCoplanarCloud(vertices);
+  }
+  if (geometry.type !== 'extrude') return false;
+  const outline = Array.isArray(geometry.outline) ? geometry.outline : [];
+  if (outline.length < 3 || !(geometry.depth > 0)) return false;
+  const xs = outline.map(([x]) => x);
+  const ys = outline.map(([, y]) => y);
+  const span = Math.max(Math.max(...xs) - Math.min(...xs), Math.max(...ys) - Math.min(...ys));
+  return span > 0 && geometry.depth / span <= OPEN_SHELL_DEPTH_RATIO;
+};
+
 const isSlabGeometry = (geometry) => {
   if (!geometry) return false;
   if (geometry.type === 'extrude') {
@@ -844,9 +864,7 @@ export function evaluateThreejsFlatness(spec) {
 
   const details = Array.isArray(spec?.detailInventory) ? spec.detailInventory : [];
   const slabPartIds = new Set();
-  const flatFeatures = [];
-  const intentionalMembraneFeatures = [];
-  const intentionalMembranePartIds = new Set();
+  const flatDetails = [];
   let evaluated = 0;
 
   for (const detail of details) {
@@ -866,23 +884,28 @@ export function evaluateThreejsFlatness(spec) {
     evaluated += 1;
     const implementing = [...meshes.values()];
     if (!implementing.every((mesh) => isSlabGeometry(mesh.geometry))) continue;
-    flatFeatures.push(detail.feature);
+    flatDetails.push({
+      feature: detail.feature,
+      partIds: implementing.map((mesh) => mesh.id),
+      isIntentionalMembrane: implementing.every((mesh) => (
+        spec?.materials?.[mesh.material]?.side === 'double' && isZeroThicknessGeometry(mesh.geometry)
+      )),
+    });
     for (const mesh of implementing) slabPartIds.add(mesh.id);
-    const isIntentionalMembrane = implementing.every((mesh) => spec?.materials?.[mesh.material]?.side === 'double');
-    if (isIntentionalMembrane) {
-      intentionalMembraneFeatures.push(detail.feature);
-      for (const mesh of implementing) intentionalMembranePartIds.add(mesh.id);
-    }
   }
 
   // `null`, not 0: a spec with no buildable identity feature was not measured
   // flat, it was not measured at all, and a 0 would read as a clean result.
+  const flatFeatures = flatDetails.map(({ feature }) => feature);
+  const intentionalMembraneDetails = flatDetails.filter(({ isIntentionalMembrane }) => isIntentionalMembrane);
+  const intentionalMembraneFeatures = intentionalMembraneDetails.map(({ feature }) => feature);
+  const unintentionalDetails = flatDetails.filter(({ isIntentionalMembrane }) => !isIntentionalMembrane);
+  const unintentionalFeatures = unintentionalDetails.map(({ feature }) => feature);
+  const intentionalMembranePartIds = new Set(intentionalMembraneDetails.flatMap(({ partIds }) => partIds));
   const flatRatio = evaluated === 0 ? null : flatFeatures.length / evaluated;
   const findings = [];
   if (flatRatio !== null && flatRatio > FLAT_IDENTITY_RATIO_THRESHOLD) {
-    const intentionalFeatureNames = new Set(intentionalMembraneFeatures);
-    const unintentionalFeatures = flatFeatures.filter((feature) => !intentionalFeatureNames.has(feature));
-    const nonMembraneFeatureCount = evaluated - intentionalMembraneFeatures.length;
+    const nonMembraneFeatureCount = evaluated - intentionalMembraneDetails.length;
     const nonMembraneFlatRatio = nonMembraneFeatureCount === 0
       ? 0
       : unintentionalFeatures.length / nonMembraneFeatureCount;
@@ -896,7 +919,7 @@ export function evaluateThreejsFlatness(spec) {
       });
     }
     if (nonMembraneFlatRatio > FLAT_IDENTITY_RATIO_THRESHOLD) {
-      const offenders = [...slabPartIds].filter((id) => !intentionalMembranePartIds.has(id));
+      const offenders = [...new Set(unintentionalDetails.flatMap(({ partIds }) => partIds))];
       findings.push({
         code: 'flat-identity-parts',
         severity: 'warning',

--- a/server/lib/threejsModel.js
+++ b/server/lib/threejsModel.js
@@ -265,6 +265,7 @@ export const threejsGeometrySchema = z.discriminatedUnion('type', [
 
 export const threejsMaterialSchema = z.object({
   type: z.enum(['standard', 'physical', 'basic']).default('standard'),
+  side: z.enum(['front', 'double']).default('front'),
   color: colorSchema,
   metalness: z.number().finite().min(0).max(1).default(0),
   roughness: z.number().finite().min(0).max(1).default(0.65),
@@ -844,6 +845,8 @@ export function evaluateThreejsFlatness(spec) {
   const details = Array.isArray(spec?.detailInventory) ? spec.detailInventory : [];
   const slabPartIds = new Set();
   const flatFeatures = [];
+  const intentionalMembraneFeatures = [];
+  const intentionalMembranePartIds = new Set();
   let evaluated = 0;
 
   for (const detail of details) {
@@ -865,6 +868,11 @@ export function evaluateThreejsFlatness(spec) {
     if (!implementing.every((mesh) => isSlabGeometry(mesh.geometry))) continue;
     flatFeatures.push(detail.feature);
     for (const mesh of implementing) slabPartIds.add(mesh.id);
+    const isIntentionalMembrane = implementing.every((mesh) => spec?.materials?.[mesh.material]?.side === 'double');
+    if (isIntentionalMembrane) {
+      intentionalMembraneFeatures.push(detail.feature);
+      for (const mesh of implementing) intentionalMembranePartIds.add(mesh.id);
+    }
   }
 
   // `null`, not 0: a spec with no buildable identity feature was not measured
@@ -872,21 +880,41 @@ export function evaluateThreejsFlatness(spec) {
   const flatRatio = evaluated === 0 ? null : flatFeatures.length / evaluated;
   const findings = [];
   if (flatRatio !== null && flatRatio > FLAT_IDENTITY_RATIO_THRESHOLD) {
-    const offenders = [...slabPartIds];
-    findings.push({
-      code: 'flat-identity-parts',
-      severity: 'warning',
-      partIds: offenders,
-      features: flatFeatures,
-      message: `${flatFeatures.length} of ${evaluated} identity-defining features are built only from flat parts (${listSpecNames(offenders.map((id) => byId.get(id)?.name || id))}). The model will read as a projection the moment it is orbited — give the parts the subject's identity rides on a real cross-section instead of stacking unbevelled extrusions and planar triangle fans.`,
-    });
+    const intentionalFeatureNames = new Set(intentionalMembraneFeatures);
+    const unintentionalFeatures = flatFeatures.filter((feature) => !intentionalFeatureNames.has(feature));
+    const nonMembraneFeatureCount = evaluated - intentionalMembraneFeatures.length;
+    const nonMembraneFlatRatio = nonMembraneFeatureCount === 0
+      ? 0
+      : unintentionalFeatures.length / nonMembraneFeatureCount;
+    if (intentionalMembraneFeatures.length > 0) {
+      findings.push({
+        code: 'flat-identity-parts',
+        severity: 'note',
+        partIds: [...intentionalMembranePartIds],
+        features: intentionalMembraneFeatures,
+        message: `${intentionalMembraneFeatures.length} of ${evaluated} identity-defining features are intentional membrane surfaces (zero-thickness open shells: ${listSpecNames(intentionalMembraneFeatures)}). Their materials are double-sided (side "double"), so they remain visible from both sides.`,
+      });
+    }
+    if (nonMembraneFlatRatio > FLAT_IDENTITY_RATIO_THRESHOLD) {
+      const offenders = [...slabPartIds].filter((id) => !intentionalMembranePartIds.has(id));
+      findings.push({
+        code: 'flat-identity-parts',
+        severity: 'warning',
+        partIds: offenders,
+        features: unintentionalFeatures,
+        message: `${unintentionalFeatures.length} of ${nonMembraneFeatureCount} identity-defining features are built only from flat parts (${listSpecNames(offenders.map((id) => byId.get(id)?.name || id))}). The model will read as a projection the moment it is orbited — give the parts the subject's identity rides on a real cross-section instead of stacking unbevelled extrusions and planar triangle fans. If a part is genuinely a zero-thickness membrane, make its material double-sided (side "double") instead; do not use that declaration to avoid giving a solid part real depth.`,
+      });
+    }
   }
+
+  const warningCount = findings.filter((finding) => finding.severity === 'warning').length;
+  const noteCount = findings.filter((finding) => finding.severity === 'note').length;
 
   return {
     findings,
     errorCount: 0,
-    warningCount: findings.length,
-    noteCount: 0,
+    warningCount,
+    noteCount,
     identityDetailCount: evaluated,
     flatIdentityDetailCount: flatFeatures.length,
     flatRatio,
@@ -905,7 +933,7 @@ export function buildThreejsFlatnessFeedback(flatness) {
   return [
     'The previous pass failed the cross-section check — it reads as a flat projection rather than a solid:',
     ...warnings.map((finding, index) => `${index + 1}. ${finding.message}`),
-    'Rebuild those parts with genuine depth: compose them from primitives, or give an extrude a bevel, so the model holds up from any orbit angle.',
+    'Rebuild those parts with genuine depth: compose them from primitives, or give an extrude a bevel, so the model holds up from any orbit angle. If a part is genuinely a zero-thickness membrane — such as a cape, leaf, fin, or wing — make its material double-sided (side "double") instead, but never use that declaration to avoid giving a solid part real depth.',
   ].join('\n');
 }
 
@@ -1261,11 +1289,13 @@ function createGeometry(definition) {
 }
 
 function createMaterial(definition) {
+  const doubleSided = definition.side === 'double' ? { side: THREE.DoubleSide } : {};
   const unlit = {
     color: definition.color,
     opacity: definition.opacity,
     transparent: definition.transparent,
     wireframe: definition.wireframe,
+    ...doubleSided,
   };
   if (definition.type === 'basic') {
     return new THREE.MeshBasicMaterial(unlit);

--- a/server/lib/threejsModel.test.js
+++ b/server/lib/threejsModel.test.js
@@ -436,6 +436,12 @@ const solidShellGeometry = () => {
   return { type: 'custom', vertices, indices };
 };
 
+const thinCustomGeometry = () => {
+  const outline = [[-1, -1], [1, -1], [1, 1], [-1, 1]];
+  const vertices = [-0.0005, 0.0005].flatMap((z) => outline.flatMap(([x, y]) => [x, y, z]));
+  return { type: 'custom', vertices, indices: [0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6] };
+};
+
 const geometryPart = (id, geometry) => ({
   id,
   name: `${id} part`,
@@ -642,6 +648,15 @@ describe('evaluateThreejsFlatness', () => {
     parent.scale = [1, 1, 1_000];
     parent.children = [geometryPart('plate', { ...validExtrude(), depth: 0.001 })];
     const spec = flatnessSpec([parent]);
+    spec.materials.body.side = 'double';
+    const flatness = evaluateThreejsFlatness(spec);
+    expect(flatness).toMatchObject({ warningCount: 1, noteCount: 0, flatRatio: 1 });
+    expect(flatness.findings[0].severity).toBe('warning');
+  });
+
+  it('keeps a thin custom solid in the warning after normal-axis scaling', () => {
+    const spec = flatnessSpec([geometryPart('plate', thinCustomGeometry())]);
+    spec.parts[0].scale = [1, 1, 1_000];
     spec.materials.body.side = 'double';
     const flatness = evaluateThreejsFlatness(spec);
     expect(flatness).toMatchObject({ warningCount: 1, noteCount: 0, flatRatio: 1 });

--- a/server/lib/threejsModel.test.js
+++ b/server/lib/threejsModel.test.js
@@ -636,6 +636,18 @@ describe('evaluateThreejsFlatness', () => {
     expect(flatness.findings[0].severity).toBe('note');
   });
 
+  it('keeps a scaled near-zero-depth child in the solid-part warning', () => {
+    const parent = geometryPart('parent', undefined);
+    delete parent.material;
+    parent.scale = [1, 1, 1_000];
+    parent.children = [geometryPart('plate', { ...validExtrude(), depth: 0.001 })];
+    const spec = flatnessSpec([parent]);
+    spec.materials.body.side = 'double';
+    const flatness = evaluateThreejsFlatness(spec);
+    expect(flatness).toMatchObject({ warningCount: 1, noteCount: 0, flatRatio: 1 });
+    expect(flatness.findings[0].severity).toBe('warning');
+  });
+
   it('keeps duplicate feature labels classified independently', () => {
     const membrane = geometryPart('membrane', flatFanGeometry());
     const plate = geometryPart('plate', validExtrude());

--- a/server/lib/threejsModel.test.js
+++ b/server/lib/threejsModel.test.js
@@ -618,6 +618,38 @@ describe('evaluateThreejsFlatness', () => {
     expect(flatness.findings[0].message).toContain('intentional membrane surfaces');
     expect(buildThreejsFlatnessFeedback(flatness)).toBe('');
   });
+
+  it('keeps a positive-depth double-sided extrude in the solid-part warning', () => {
+    const spec = flatnessSpec([geometryPart('plate', validExtrude())]);
+    spec.materials.body.side = 'double';
+    const flatness = evaluateThreejsFlatness(spec);
+    expect(flatness).toMatchObject({ warningCount: 1, noteCount: 0, flatRatio: 1 });
+    expect(flatness.findings[0].severity).toBe('warning');
+    expect(buildThreejsFlatnessFeedback(flatness)).toContain('genuine depth');
+  });
+
+  it('accepts a double-sided near-zero-depth extrude as an intentional membrane', () => {
+    const spec = flatnessSpec([geometryPart('membrane', { ...validExtrude(), depth: 0.001 })]);
+    spec.materials.body.side = 'double';
+    const flatness = evaluateThreejsFlatness(spec);
+    expect(flatness).toMatchObject({ warningCount: 0, noteCount: 1, flatRatio: 1 });
+    expect(flatness.findings[0].severity).toBe('note');
+  });
+
+  it('keeps duplicate feature labels classified independently', () => {
+    const membrane = geometryPart('membrane', flatFanGeometry());
+    const plate = geometryPart('plate', validExtrude());
+    membrane.material = 'membrane';
+    plate.material = 'plate';
+    const spec = flatnessSpec([membrane, plate]);
+    spec.materials.membrane = { ...spec.materials.body, side: 'double' };
+    spec.materials.plate = { ...spec.materials.body, side: 'double' };
+    spec.detailInventory[0].feature = 'shared feature';
+    spec.detailInventory[1].feature = 'shared feature';
+    const flatness = evaluateThreejsFlatness(spec);
+    expect(flatness).toMatchObject({ warningCount: 1, noteCount: 1, flatRatio: 1 });
+    expect(flatness.findings.map((finding) => finding.severity)).toEqual(['note', 'warning']);
+  });
 });
 
 describe('buildThreejsFlatnessFeedback', () => {

--- a/server/lib/threejsModel.test.js
+++ b/server/lib/threejsModel.test.js
@@ -72,6 +72,7 @@ describe('threejsSculptSpecSchema', () => {
   it('accepts a bounded hierarchy and fills material/part defaults', () => {
     const parsed = threejsSculptSpecSchema.parse(validSpec());
     expect(parsed.materials.body.emissive).toBe('#000000');
+    expect(parsed.materials.body.side).toBe('front');
     expect(parsed.parts[0].castShadow).toBe(true);
     expect(parsed.parts[0].children[0].id).toBe('frontTrim');
   });
@@ -348,6 +349,14 @@ describe('buildThreejsFactorySource', () => {
     expect(source).toContain('"explodeWithParent": true');
   });
 
+  it('emits the declared double-sided material option for the standalone factory', () => {
+    const spec = validSpec();
+    spec.materials.body.side = 'double';
+    const source = buildThreejsFactorySource(spec);
+    expect(source).toContain('"side": "double"');
+    expect(source).toContain('const doubleSided = definition.side === \'double\' ? { side: THREE.DoubleSide } : {};');
+  });
+
   it('emits extrude, tube, and physical-channel construction', () => {
     const spec = validSpec();
     spec.parts[0].geometry = validExtrude();
@@ -588,6 +597,26 @@ describe('evaluateThreejsFlatness', () => {
 
   it('returns a clean result for a missing spec', () => {
     expect(evaluateThreejsFlatness(null)).toMatchObject({ findings: [], flatRatio: null });
+  });
+
+  it('notes a flat identity part as an intentional membrane when its material is double-sided', () => {
+    const spec = flatnessSpec([geometryPart('membrane', flatFanGeometry())]);
+    spec.materials.body.side = 'double';
+    const flatness = evaluateThreejsFlatness(spec);
+    expect(flatness).toMatchObject({
+      warningCount: 0,
+      noteCount: 1,
+      flatIdentityDetailCount: 1,
+      flatRatio: 1,
+    });
+    expect(flatness.findings[0]).toMatchObject({
+      code: 'flat-identity-parts',
+      severity: 'note',
+      partIds: ['membrane'],
+      features: ['membrane part silhouette'],
+    });
+    expect(flatness.findings[0].message).toContain('intentional membrane surfaces');
+    expect(buildThreejsFlatnessFeedback(flatness)).toBe('');
   });
 });
 

--- a/server/services/threejsModels/prompt.js
+++ b/server/services/threejsModels/prompt.js
@@ -30,6 +30,10 @@ Choosing between them:
 - lathe — profiles that are rotationally symmetric about the Y axis.
 - custom triangles — a last resort, only after none of the above can express the silhouette.
 
+A genuinely zero-thickness two-sided surface — such as a wing membrane, cape, leaf, or fin —
+needs a material with "side":"double" or it disappears from behind. Use that declaration only
+for an intentional open shell; it must not be used to dodge giving a solid part a real cross-section.
+
 When extrude is the WRONG answer: an unbevelled extrude has exactly two depth planes, so it is
 a slab. A body with a real cross-section — a torso, a limb, a head, a housing, a grip, a shell
 that swells or tapers through its thickness — must not be one. Build it from primitives, a
@@ -53,6 +57,7 @@ Return one raw JSON object and nothing else. It must have exactly this top-level
   "materials": {
     "materialId": {
       "type":"standard" | "physical" | "basic",
+      "side":"front" | "double",
       "color":"#RRGGBB","metalness":0..1,"roughness":0..1,
       "emissive":"#RRGGBB","emissiveIntensity":0..20,
       "opacity":0..1,"transparent":false,"wireframe":false,


### PR DESCRIPTION
## Summary
- Add an explicit front/double material-side declaration with a front-compatible default.
- Keep preview and exported factory rendering in sync; verified zero-thickness membranes are notes while solid planar parts remain warnings.
- Teach generation prompts about double-sided membranes and cover transformed flatness behavior with server/client tests.

## Test plan
- npm test --prefix server -- lib/threejsModel.test.js services/threejsModels/prompt.test.js services/threejsModels/index.test.js
- npm test --prefix client -- src/lib/threejsSculpt.test.js src/pages/ThreejsModelDetail.test.jsx
- npm run lint --prefix client

Closes #4632