### PR TITLE
fix([issue-4359]): mark MiniMax Music 3's CUDA offload profile supported

### DIFF
--- a/client/src/components/music/MusicGenPanel.test.jsx
+++ b/client/src/components/music/MusicGenPanel.test.jsx
@@ -215,7 +215,7 @@ describe('MusicGenPanel', () => {
         modelReady: true,
         vramState: 'sufficient',
         executionProfile: 'cuda-bf16-auto-experimental',
-        vramProfileLabel: 'CUDA BF16 (experimental automatic placement)',
+        vramProfileLabel: 'CUDA BF16 (automatic full-residency/offload placement)',
       })],
     });
     const track = {

--- a/server/services/pipeline/musicGen.js
+++ b/server/services/pipeline/musicGen.js
@@ -137,20 +137,24 @@ export const MINIMAX_MUSIC3_MODELS = Object.freeze([
   },
 ]);
 
-// VRAM requirements belong to the execution profile, not the model name. The
-// experimental automatic profile has passed only a short smoke render; the
-// full-length benchmark and listening gate remain incomplete. Null floors keep
-// app-driven CUDA generation blocked until that evidence exists.
+// VRAM requirements belong to the execution profile, not the model name.
 export const MUSIC_VRAM_READINESS = Object.freeze({
   SUFFICIENT: 'sufficient',
   INSUFFICIENT: 'insufficient',
   UNKNOWN_SIZE: 'unknown-size',
 });
+// Measured on an RTX 3090 (24 GB): a fixed-seed, production-shaped full-length
+// render (default 60s ceiling, natural length 41s) passed the technical
+// benchmark (scripts/music_benchmark.py — clean WAV, negligible clipping, no
+// truncation) with 18.3-18.7 GB peak reserved VRAM, plus a positive full-length
+// listening review (issue #4359). `minVramGb` is set above the observed peak
+// for desktop/driver headroom; only this card class has been validated, so
+// `recommendedVramGb` matches it rather than claiming a lower comfortable tier.
 export const MINIMAX_MUSIC3_VRAM_PROFILES = Object.freeze({
   'cuda-bf16-auto-experimental': Object.freeze({
-    label: 'CUDA BF16 (experimental automatic placement)',
-    minVramGb: null,
-    recommendedVramGb: null,
+    label: 'CUDA BF16 (automatic full-residency/offload placement)',
+    minVramGb: 20,
+    recommendedVramGb: 24,
   }),
 });
 
@@ -329,7 +333,7 @@ export const ENGINES = Object.freeze({
     executionProfile: 'cuda-bf16-auto-experimental',
     vramProfiles: MINIMAX_MUSIC3_VRAM_PROFILES,
     benchmarkGuide: MUSIC_RENDERER_BENCHMARK_GUIDE,
-    requiresFullLengthListening: true,
+    requiresFullLengthListening: false,
   },
   'minimax-music3-mlx': {
     id: 'minimax-music3-mlx',

--- a/server/services/pipeline/musicGen.test.js
+++ b/server/services/pipeline/musicGen.test.js
@@ -143,16 +143,16 @@ describe('ENGINES backend registry', () => {
     const engine = ENGINES['minimax-music3'];
     expect(engine.executionProfile).toBe('cuda-bf16-auto-experimental');
     expect(engine.vramProfiles[engine.executionProfile]).toMatchObject({
-      label: 'CUDA BF16 (experimental automatic placement)',
-      minVramGb: null,
-      recommendedVramGb: null,
+      label: 'CUDA BF16 (automatic full-residency/offload placement)',
+      minVramGb: 20,
+      recommendedVramGb: 24,
     });
   });
 
-  it('keeps MiniMax profile support gated on technical checks plus full-length listening', () => {
+  it('records that MiniMax profile support has cleared technical checks plus full-length listening', () => {
     expect(ENGINES['minimax-music3']).toMatchObject({
       benchmarkGuide: MUSIC_RENDERER_BENCHMARK_GUIDE,
-      requiresFullLengthListening: true,
+      requiresFullLengthListening: false,
     });
     expect(MUSIC_RENDERER_BENCHMARK_GUIDE).toBe('docs/features/music-renderer-benchmarks.md');
   });
@@ -170,15 +170,27 @@ describe('VRAM readiness', () => {
       .toBe(MUSIC_VRAM_READINESS.UNKNOWN_SIZE);
   });
 
-  it('keeps the experimental CUDA execution profile unknown-size', () => {
+  it('reports the measured MiniMax CUDA execution profile as sufficient on a large card', () => {
     expect(resolveEngineVramReadiness('minimax-music3', {
       status: 'available', maxVramGb: 80,
     })).toMatchObject({
-      state: MUSIC_VRAM_READINESS.UNKNOWN_SIZE,
+      state: MUSIC_VRAM_READINESS.SUFFICIENT,
       executionProfile: 'cuda-bf16-auto-experimental',
-      minVramGb: null,
-      recommendedVramGb: null,
+      minVramGb: 20,
+      recommendedVramGb: 24,
       maxVramGb: 80,
+    });
+  });
+
+  it('reports the measured MiniMax CUDA execution profile as insufficient below its measured floor', () => {
+    expect(resolveEngineVramReadiness('minimax-music3', {
+      status: 'available', maxVramGb: 12,
+    })).toMatchObject({
+      state: MUSIC_VRAM_READINESS.INSUFFICIENT,
+      executionProfile: 'cuda-bf16-auto-experimental',
+      minVramGb: 20,
+      recommendedVramGb: 24,
+      maxVramGb: 12,
     });
   });
 });
@@ -527,14 +539,24 @@ describe('generateMusic backend selection', () => {
     expect(spawnCalls).toHaveLength(1);
   });
 
-  it('blocks MiniMax while its experimental CUDA profile has no measured VRAM floor', async () => {
+  it('runs MiniMax on a card meeting its measured VRAM floor', async () => {
+    await generateMusic({
+      prompt: 'warm cinematic pop',
+      lyrics: '[verse]\nExample words\n[outro]',
+      engine: 'minimax-music3',
+    });
+    expect(spawnCalls).toHaveLength(1);
+  });
+
+  it('blocks MiniMax on a card below its measured VRAM floor', async () => {
+    cuda.maxVramGb = 12;
     await expect(generateMusic({
       prompt: 'warm cinematic pop',
       lyrics: '[verse]\nExample words\n[outro]',
       engine: 'minimax-music3',
     })).rejects.toMatchObject({
       status: 503,
-      code: 'PIPELINE_MUSIC_VRAM_UNKNOWN',
+      code: 'PIPELINE_MUSIC_VRAM_INSUFFICIENT',
     });
     expect(spawnCalls).toHaveLength(0);
   });


### PR DESCRIPTION
## Summary
- Marks MiniMax Music 3's automatic CUDA full-residency/component-offload execution profile as supported: `MINIMAX_MUSIC3_VRAM_PROFILES` now carries measured `minVramGb: 20` / `recommendedVramGb: 24` (previously `null`, fail-closed) and `requiresFullLengthListening` is cleared.
- Evidence: a fixed-seed (17), production-shaped full-length render (60s ceiling, natural 41s length, same lyric-sheet builder the server uses) on an RTX 3090 passed the technical benchmark (`scripts/music_benchmark.py` — clean WAV, negligible clipping, no truncation) with 18.3-18.7GB peak reserved VRAM, plus a positive full-length human listening review — full details in the issue comment thread.
- Notably, the previously-reported 4.5-hour stall on a full-length render did not reproduce on this run; several short and two independent full-length renders all completed cleanly in minutes. No root cause identified for the earlier hang.
- Only the tested 24GB card class has been validated — `minVramGb` is set with headroom above the observed peak rather than claiming a lower comfortable tier untested.
- The rest of this issue's plumbing (route return, render persistence, UI display of `executionProfile`) was already shipped in the earlier draft PR #4523; this PR is the remaining "graduate to supported" step.

Closes #4359

## Test plan
- [x] `server/services/pipeline/musicGen.test.js` — updated/added cases for the measured VRAM floor (sufficient/insufficient), full server suite run (1508/1509 files passed; the one failure, `askService.test.js`, is a pre-existing Windows shell-quoting flake unrelated to this change and reproduces identically on `main`)
- [x] `server/routes/music.test.js` — unaffected (self-contained fixtures), passes
- [x] `client/src/components/music/MusicGenPanel.test.jsx` — updated fixture label, passes
- [x] `/simplify` review pass (reuse/simplification/efficiency/altitude, 4 parallel agents) — no findings
- [x] Manual GPU benchmark on RTX 3090: technical validator passed, human listening review positive (recorded on the issue)