### PR TITLE
fix(cos): name the health issue and make the Issues tile open Health

### DIFF
--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -213,8 +213,8 @@ export const summarizeHealthIssues = (issues) => {
 
 // StatCard tone for the Issues tile. `error`-type issues mean something is
 // broken; a warning-only check (e.g. a memory-hungry process) stays amber
-// rather than screaming red — matching how HealthTab colors the same list.
-// 'default' (not null) so a zero-issue tile keeps its explicit gray icon.
+// rather than screaming red — the same severity split HealthTab draws when it
+// renders the list. 'default' (not null) so a zero-issue tile keeps its gray icon.
 export const healthIssueTone = (issues) => {
   if (!Array.isArray(issues) || issues.length === 0) return 'default';
   return issues.some((issue) => issue?.type === 'error') ? 'critical' : 'warning';

--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -203,12 +203,31 @@ export const STATE_MESSAGES = {
 export const summarizeHealthIssues = (issues) => {
   if (!Array.isArray(issues) || issues.length === 0) return null;
   const messages = issues.map((issue) => issue?.message).filter(Boolean);
+  // Counts come from `issues`, never from `messages` — a mixed list like
+  // [{message:'A'}, {}] has two problems and one description, and counting the
+  // descriptions would under-report it as a single issue.
+  const plural = issues.length > 1 ? 's' : '';
   // A message-less issue still has to read as an issue — `null` means "nothing
   // to report", so callers that already know the list is non-empty never need a
   // fallback of their own.
-  if (messages.length === 0) return `${issues.length} health issue${issues.length > 1 ? 's' : ''} detected`;
-  if (messages.length === 1) return messages[0];
-  return `${messages.length} health issues: ${messages.join(' · ')}`;
+  if (messages.length === 0) return `${issues.length} health issue${plural} detected`;
+  if (issues.length === 1) return messages[0];
+  return `${issues.length} health issues: ${messages.join(' · ')}`;
+};
+
+// Which of two health snapshots to keep. `getCosHealth` reads the *pre-check*
+// persisted health while the same fetch batch triggers a fresh server-side check
+// whose `cos:health:check` socket event can land first — so the slow read must
+// not clobber the fresher socket result. Keep whichever check is newer by
+// `lastCheck` (Date.parse normalizes the ISO timestamps so the compare never
+// goes lexicographic), keep `prev` when the incoming read has no comparable
+// timestamp but `prev` does, and treat a failed read (null) as "keep prev".
+export const fresherHealth = (prev, next) => {
+  if (!next) return prev ?? null;
+  const prevT = Date.parse(prev?.lastCheck ?? '');
+  const nextT = Date.parse(next.lastCheck ?? '');
+  if (!Number.isNaN(prevT) && (Number.isNaN(nextT) || nextT < prevT)) return prev;
+  return next;
 };
 
 // StatCard tone for the Issues tile. `error`-type issues mean something is

--- a/client/src/components/cos/constants.js
+++ b/client/src/components/cos/constants.js
@@ -193,6 +193,33 @@ export const STATE_MESSAGES = {
   ideating: "Analyzing options...",
 };
 
+// A health issue is the ONLY thing that flips an idle-but-running CoS into
+// `investigating`, so the status bubble has to say *which* issue. Falling back
+// to the generic STATE_MESSAGES line left the avatar parked on "Investigating
+// issue..." with zero agents running and the detail reachable only by guessing
+// at the Health tab. Returns null when there is nothing to report so callers
+// can fall back to their own default. Issue shape mirrors the server's
+// `runHealthCheck` (`{ type, category, message }` — server/services/cosHealthMonitor.js).
+export const summarizeHealthIssues = (issues) => {
+  if (!Array.isArray(issues) || issues.length === 0) return null;
+  const messages = issues.map((issue) => issue?.message).filter(Boolean);
+  // A message-less issue still has to read as an issue — `null` means "nothing
+  // to report", so callers that already know the list is non-empty never need a
+  // fallback of their own.
+  if (messages.length === 0) return `${issues.length} health issue${issues.length > 1 ? 's' : ''} detected`;
+  if (messages.length === 1) return messages[0];
+  return `${messages.length} health issues: ${messages.join(' · ')}`;
+};
+
+// StatCard tone for the Issues tile. `error`-type issues mean something is
+// broken; a warning-only check (e.g. a memory-hungry process) stays amber
+// rather than screaming red — matching how HealthTab colors the same list.
+// 'default' (not null) so a zero-issue tile keeps its explicit gray icon.
+export const healthIssueTone = (issues) => {
+  if (!Array.isArray(issues) || issues.length === 0) return 'default';
+  return issues.some((issue) => issue?.type === 'error') ? 'critical' : 'warning';
+};
+
 // Agent option toggles for task metadata (useWorktree, openPR, simplify, requireApproval).
 export const AGENT_OPTIONS = [
   { field: 'requireApproval', label: 'Require approval', shortLabel: 'Apr', description: 'Queue as awaiting-approve and do not auto-run — including Run Now — until you approve. Off (default): Run Now starts immediately; scheduled runs still follow the confidence and safety gates.' },

--- a/client/src/components/cos/constants.test.js
+++ b/client/src/components/cos/constants.test.js
@@ -15,7 +15,8 @@ import {
   MODEL_CAPABLE_CLI_REVIEWERS,
   reviewerLabel,
   summarizeHealthIssues,
-  healthIssueTone
+  healthIssueTone,
+  fresherHealth
 } from './constants';
 
 // These mirror the server's domainBudgets/domainAutonomy helpers so the UI's
@@ -243,6 +244,44 @@ describe('summarizeHealthIssues', () => {
   it('still reads as an issue when the payload carries no message', () => {
     expect(summarizeHealthIssues([{ type: 'error' }])).toBe('1 health issue detected');
     expect(summarizeHealthIssues([{ type: 'error' }, {}])).toBe('2 health issues detected');
+  });
+
+  // Counting the descriptions instead of the issues under-reported a mixed
+  // list as a single issue, hiding the message-less one entirely.
+  it('counts issues, not messages, when only some carry one', () => {
+    expect(summarizeHealthIssues([{ message: 'A' }, {}])).toBe('2 health issues: A');
+    expect(summarizeHealthIssues([{ message: 'A' }, {}, { message: 'B' }])).toBe('3 health issues: A \u00b7 B');
+  });
+});
+
+// The slow `getCosHealth` read routinely resolves AFTER the socket event for the
+// check that same fetch batch triggered, so "newest wins" is what keeps the
+// Issues tile and the status bubble describing the same check.
+describe('fresherHealth', () => {
+  const older = { lastCheck: '2026-01-01T00:00:00.000Z', issues: [] };
+  const newer = { lastCheck: '2026-01-02T00:00:00.000Z', issues: [{ type: 'warning' }] };
+
+  it('takes the newer check', () => {
+    expect(fresherHealth(older, newer)).toBe(newer);
+  });
+
+  it('keeps the newer previous check against a stale read', () => {
+    expect(fresherHealth(newer, older)).toBe(newer);
+  });
+
+  it('keeps the last-good check when the read failed', () => {
+    expect(fresherHealth(newer, null)).toBe(newer);
+    expect(fresherHealth(null, null)).toBeNull();
+  });
+
+  it('keeps a timestamped previous check over an untimed read', () => {
+    expect(fresherHealth(newer, { issues: [] })).toBe(newer);
+  });
+
+  it('accepts any read when there is no comparable previous check', () => {
+    const untimed = { issues: [] };
+    expect(fresherHealth(null, untimed)).toBe(untimed);
+    expect(fresherHealth({ issues: [] }, untimed)).toBe(untimed);
   });
 });
 

--- a/client/src/components/cos/constants.test.js
+++ b/client/src/components/cos/constants.test.js
@@ -13,7 +13,9 @@ import {
   MUSE_ROOT_MOTION_CLIPS,
   resolveMuseMotion,
   MODEL_CAPABLE_CLI_REVIEWERS,
-  reviewerLabel
+  reviewerLabel,
+  summarizeHealthIssues,
+  healthIssueTone
 } from './constants';
 
 // These mirror the server's domainBudgets/domainAutonomy helpers so the UI's
@@ -217,4 +219,46 @@ describe('reviewerLabel', () => {
     expect(reviewerLabel('@octocat')).toBe('@octocat');
   });
 });
+
+// A warning-level health issue put the CoS avatar in `investigating` while the
+// status bubble showed the generic "Investigating issue..." and the Issues tile
+// was an inert number. Both helpers exist so the UI can name the issue and color
+// the tile by severity.
+describe('summarizeHealthIssues', () => {
+  it('returns null when there is nothing to report', () => {
+    expect(summarizeHealthIssues([])).toBeNull();
+    expect(summarizeHealthIssues(null)).toBeNull();
+    expect(summarizeHealthIssues(undefined)).toBeNull();
+  });
+
+  it('names the single issue verbatim', () => {
+    expect(summarizeHealthIssues([{ type: 'warning', category: 'memory', message: 'High memory usage in: example-app (900MB)' }]))
+      .toBe('High memory usage in: example-app (900MB)');
+  });
+
+  it('counts and joins multiple issues', () => {
+    expect(summarizeHealthIssues([{ message: 'a' }, { message: 'b' }])).toBe('2 health issues: a \u00b7 b');
+  });
+
+  it('still reads as an issue when the payload carries no message', () => {
+    expect(summarizeHealthIssues([{ type: 'error' }])).toBe('1 health issue detected');
+    expect(summarizeHealthIssues([{ type: 'error' }, {}])).toBe('2 health issues detected');
+  });
+});
+
+describe('healthIssueTone', () => {
+  it('stays neutral with no issues', () => {
+    expect(healthIssueTone([])).toBe('default');
+    expect(healthIssueTone(null)).toBe('default');
+  });
+
+  it('keeps warning-only checks amber rather than red', () => {
+    expect(healthIssueTone([{ type: 'warning' }, { type: 'warning' }])).toBe('warning');
+  });
+
+  it('escalates to critical when any issue is an error', () => {
+    expect(healthIssueTone([{ type: 'warning' }, { type: 'error' }])).toBe('critical');
+  });
+});
+
 // @vitest-environment node

--- a/client/src/components/cos/index.js
+++ b/client/src/components/cos/index.js
@@ -1,5 +1,5 @@
 // Constants
-export { TABS, AGENT_STATES, STATE_MESSAGES, MEMORY_TYPES, MEMORY_TYPE_COLORS, summarizeHealthIssues, healthIssueTone } from './constants';
+export { TABS, AGENT_STATES, STATE_MESSAGES, MEMORY_TYPES, MEMORY_TYPE_COLORS, summarizeHealthIssues, healthIssueTone, fresherHealth } from './constants';
 
 // Avatar/Character Components
 // The five three.js *CoSAvatar variants are intentionally NOT re-exported:

--- a/client/src/components/cos/index.js
+++ b/client/src/components/cos/index.js
@@ -1,5 +1,5 @@
 // Constants
-export { TABS, AGENT_STATES, STATE_MESSAGES, MEMORY_TYPES, MEMORY_TYPE_COLORS } from './constants';
+export { TABS, AGENT_STATES, STATE_MESSAGES, MEMORY_TYPES, MEMORY_TYPE_COLORS, summarizeHealthIssues, healthIssueTone } from './constants';
 
 // Avatar/Character Components
 // The five three.js *CoSAvatar variants are intentionally NOT re-exported:

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -16,6 +16,8 @@ import PageSkeleton from '../components/ui/PageSkeleton';
 import {
   TABS,
   STATE_MESSAGES,
+  summarizeHealthIssues,
+  healthIssueTone,
   CoSCharacter,
   StateLabel,
   TerminalCoSPanel,
@@ -198,10 +200,13 @@ export default function ChiefOfStaff() {
 
     const newState = deriveAgentState(statusData, agentsData, healthData);
     setAgentState(newState);
-    // Use default state message - real messages come from socket events
+    // Default state message — richer messages come from socket events. The one
+    // state whose default is useless is `investigating`: only a health issue
+    // gets us here, so name it rather than saying "Investigating issue..." next
+    // to an Active count of 0 with no agent to inspect.
     setStatusMessage(statusData?.paused
       ? `Paused${statusData.pauseReason ? ` — ${statusData.pauseReason}` : ''}`
-      : STATE_MESSAGES[newState]);
+      : (newState === 'investigating' && summarizeHealthIssues(healthData?.issues)) || STATE_MESSAGES[newState]);
 
     // Set active agent metadata for dynamic avatar (use first running agent)
     const runningAgent = agentsData.find(a => a.status === 'running');
@@ -362,7 +367,7 @@ export default function ChiefOfStaff() {
       // (see the note by the redirect effect). Banner refreshes on the next poll.
       if (data.issues?.length > 0) {
         setAgentState('investigating');
-        setStatusMessage(`Health check: ${data.issues.length} issue${data.issues.length > 1 ? 's' : ''} found`);
+        setStatusMessage(summarizeHealthIssues(data.issues));
         setSpeaking(true);
         setTimeout(() => setSpeaking(false), 2000);
       }
@@ -531,7 +536,7 @@ export default function ChiefOfStaff() {
       // count refreshes on the next fetchData poll instead (see the note above).
       toast.success('Health check complete');
       if (result.issues?.length > 0) {
-        setStatusMessage(`Health: ${result.issues.length} issue${result.issues.length > 1 ? 's' : ''} detected`);
+        setStatusMessage(summarizeHealthIssues(result.issues));
       } else {
         setAgentState('sleeping');
         setStatusMessage("Health check passed - all systems OK");
@@ -544,10 +549,6 @@ export default function ChiefOfStaff() {
   const activeAgentCount = useMemo(() =>
     agents.filter(a => a.status === 'running').length,
     [agents]
-  );
-  const hasIssues = useMemo(() =>
-    (health?.issues?.length || 0) > 0,
-    [health?.issues?.length]
   );
 
   // Memoize pending task count
@@ -600,6 +601,20 @@ export default function ChiefOfStaff() {
     onClick: () => navigate('/cos/learning'),
   };
 
+  // The Issues tile is the only place the UI admits CoS found something wrong,
+  // so it has to click through to the detail. Without that, a warning-level
+  // health issue parked the avatar on "Investigating" with Active 0, no agent
+  // to open, and the offending message reachable only by guessing at the Health
+  // tab. `title` surfaces the same summary on hover/touch-and-hold.
+  const healthIssues = health?.issues || [];
+  const issuesStatProps = {
+    label: 'Issues',
+    value: healthIssues.length,
+    tone: healthIssueTone(healthIssues),
+    title: summarizeHealthIssues(healthIssues) || 'No issues detected — view system health',
+    onClick: () => navigate('/cos/health'),
+  };
+
   // Compact stats card grid — rendered both inside the desktop CoS sidebar and
   // the mobile compressed header so the metrics always live "inside" CoS.
   const statsGridCards = (
@@ -624,9 +639,8 @@ export default function ChiefOfStaff() {
         compact
       />
       <StatCard
-        label="Issues"
-        value={health?.issues?.length || 0}
-        icon={<AlertCircle className={`w-4 h-4 ${hasIssues ? 'text-port-error' : 'text-gray-500'}`} />}
+        {...issuesStatProps}
+        icon={<AlertCircle className="w-4 h-4" />}
         compact
       />
       <StatCard
@@ -816,7 +830,7 @@ export default function ChiefOfStaff() {
                   <StatCard label="Active" value={activeAgentCount} icon={<Cpu className="w-4 h-4 text-port-accent" />} active={activeAgentCount > 0} compact />
                   <StatCard label="Pending" value={pendingTaskCount} icon={<Clock className="w-4 h-4 text-port-warning" />} compact />
                   <StatCard label="Done" value={status?.stats?.tasksCompleted || 0} icon={<CheckCircle className="w-4 h-4 text-port-success" />} compact />
-                  <StatCard label="Issues" value={health?.issues?.length || 0} icon={<AlertCircle className={`w-4 h-4 ${hasIssues ? 'text-port-error' : 'text-gray-500'}`} />} compact />
+                  <StatCard {...issuesStatProps} icon={<AlertCircle className="w-4 h-4" />} compact />
                 </div>
               </div>
             )}
@@ -960,9 +974,8 @@ export default function ChiefOfStaff() {
             mini
           />
           <StatCard
-            label="Issues"
-            value={health?.issues?.length || 0}
-            icon={<AlertCircle className={`w-3 h-3 sm:w-4 sm:h-4 lg:w-5 lg:h-5 ${hasIssues ? 'text-port-error' : 'text-gray-500'}`} />}
+            {...issuesStatProps}
+            icon={<AlertCircle className="w-3 h-3 sm:w-4 sm:h-4 lg:w-5 lg:h-5" />}
             mini
           />
           {/* Learning Health - clickable to go to Learning tab */}

--- a/client/src/pages/ChiefOfStaff.jsx
+++ b/client/src/pages/ChiefOfStaff.jsx
@@ -18,6 +18,7 @@ import {
   STATE_MESSAGES,
   summarizeHealthIssues,
   healthIssueTone,
+  fresherHealth,
   CoSCharacter,
   StateLabel,
   TerminalCoSPanel,
@@ -131,6 +132,22 @@ export default function ChiefOfStaff() {
     setDesktopPanelCollapsed((prev) => !prev);
   }, [setDesktopPanelCollapsed]);
 
+  // ONE writer for the health snapshot, so the Issues tile, the avatar state and
+  // the status bubble can never describe different health checks. The ref is
+  // written synchronously alongside the state, which is what lets fetchData run
+  // the freshness rule and then derive from the value it actually committed —
+  // with a functional updater the merged result was only visible inside the
+  // updater, so the derivation below fell back to the raw (possibly older, or
+  // null) read. `merge` runs the freshness rule; the socket and manual paths
+  // deliver the newest check by definition and set it outright.
+  const healthRef = useRef(null);
+  const applyHealth = useCallback((next, { merge = false } = {}) => {
+    const resolved = merge ? fresherHealth(healthRef.current, next) : next;
+    healthRef.current = resolved;
+    setHealth(resolved);
+    return resolved;
+  }, []);
+
   // Derive agent state from system status
   const deriveAgentState = useCallback((statusData, agentsData, healthData) => {
     if (!statusData?.running) return 'sleeping';
@@ -172,21 +189,11 @@ export default function ChiefOfStaff() {
     // `getCosHealth` above reads the *pre-check* persisted health, while the
     // getCosActionableInsights call in this same batch triggers a fresh server
     // health check (cos.runHealthCheck) that emits `cos:health:check` — the
-    // socket handler's setHealth can land in `prev` before this runs. Don't let
-    // this fetch's older read clobber that fresher result; keep whichever health
-    // check is newer by lastCheck (Date.parse normalizes the ISO timestamps so
-    // the compare never goes lexicographic). A failed read (null) keeps the
-    // last-good health rather than blanking a fresher socket-delivered one.
-    setHealth(prev => {
-      if (!healthData) return prev ?? null;
-      const prevT = Date.parse(prev?.lastCheck ?? '');
-      const newT = Date.parse(healthData.lastCheck ?? '');
-      // Keep prev when it is strictly newer, OR when this read has no comparable
-      // timestamp but prev does — a timestamped health check is fresher than an
-      // untimed read, so an absent/unparseable lastCheck must not clobber it.
-      if (!Number.isNaN(prevT) && (Number.isNaN(newT) || newT < prevT)) return prev;
-      return healthData;
-    });
+    // socket handler's health write can land before this runs. `fresherHealth`
+    // keeps whichever check is newer (and keeps the last-good one when this read
+    // failed); everything below derives from what it returned, never from the
+    // raw read, so the bubble can't name an older issue than the tile shows.
+    const mergedHealth = applyHealth(healthData, { merge: true });
     setProviders(providersData.providers || []);
     setActiveProviderId(providersData.activeProvider || null);
     // Filter out PortOS Autofixer (it's part of PortOS project)
@@ -198,7 +205,7 @@ export default function ChiefOfStaff() {
     if (insightsData?.insights) setInsights(insightsData.insights);
     setLoading(false);
 
-    const newState = deriveAgentState(statusData, agentsData, healthData);
+    const newState = deriveAgentState(statusData, agentsData, mergedHealth);
     setAgentState(newState);
     // Default state message — richer messages come from socket events. The one
     // state whose default is useless is `investigating`: only a health issue
@@ -206,12 +213,12 @@ export default function ChiefOfStaff() {
     // to an Active count of 0 with no agent to inspect.
     setStatusMessage(statusData?.paused
       ? `Paused${statusData.pauseReason ? ` — ${statusData.pauseReason}` : ''}`
-      : (newState === 'investigating' && summarizeHealthIssues(healthData?.issues)) || STATE_MESSAGES[newState]);
+      : (newState === 'investigating' && summarizeHealthIssues(mergedHealth?.issues)) || STATE_MESSAGES[newState]);
 
     // Set active agent metadata for dynamic avatar (use first running agent)
     const runningAgent = agentsData.find(a => a.status === 'running');
     setActiveAgentMeta(runningAgent?.metadata || null);
-  }, [deriveAgentState]);
+  }, [deriveAgentState, applyHealth]);
 
   // A cheap, read-only refresh of just the queue — the task lists plus the agent
   // list the Tasks tab reads to tell an already-spawning task from a waiting one.
@@ -361,7 +368,7 @@ export default function ChiefOfStaff() {
     socket.on('cos:agent:completed', handleAgentCompleted);
 
     const handleHealthCheck = (data) => {
-      setHealth({ lastCheck: data.metrics?.timestamp, issues: data.issues });
+      applyHealth({ lastCheck: data.metrics?.timestamp, issues: data.issues });
       // Do NOT refresh banner insights here — /cos/actionable-insights runs a
       // health check that re-emits this very socket event, which would loop
       // (see the note by the redirect effect). Banner refreshes on the next poll.
@@ -529,7 +536,7 @@ export default function ChiefOfStaff() {
     });
     setSpeaking(false);
     if (result) {
-      setHealth({ lastCheck: result.metrics?.timestamp, issues: result.issues });
+      applyHealth({ lastCheck: result.metrics?.timestamp, issues: result.issues });
       // Do NOT refresh the banner insights here — /cos/actionable-insights runs
       // a process-restarting health check, so an on-demand refresh would fire a
       // second restart ~1s after forceHealthCheck's own. The banner's health

--- a/client/src/pages/ChiefOfStaff.test.jsx
+++ b/client/src/pages/ChiefOfStaff.test.jsx
@@ -646,6 +646,28 @@ describe('ChiefOfStaff Issues card', () => {
     expect(within(panel).getByText(memoryWarning.message)).toBeInTheDocument();
   });
 
+  // The live path: a health check finishing while the page is open pushes the
+  // issue over the socket rather than through fetchData.
+  it('names the issue arriving on a live health-check socket event', async () => {
+    renderWithIssues([]);
+    // Wait for the clean first paint so the socket handler is registered.
+    for (const card of await issueCards()) expect(within(card).getByText('0')).toBeInTheDocument();
+
+    const handleHealthCheck = socketStub.on.mock.calls.find(([evt]) => evt === 'cos:health:check')?.[1];
+    expect(handleHealthCheck).toBeTypeOf('function');
+    await act(async () => {
+      handleHealthCheck({ metrics: { timestamp: '2026-01-02T00:00:00.000Z' }, issues: [memoryWarning] });
+    });
+
+    expect(await screen.findByText(memoryWarning.message)).toBeInTheDocument();
+    for (const card of await issueCards()) {
+      expect(card).toHaveAttribute('title', memoryWarning.message);
+      expect(within(card).getByText('1')).toBeInTheDocument();
+    }
+    // Drain the >0 branch's speaking timer so no state update escapes act.
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 2100)); });
+  });
+
   it('stays a click-through to Health when there are no issues at all', async () => {
     renderWithIssues([]);
 

--- a/client/src/pages/ChiefOfStaff.test.jsx
+++ b/client/src/pages/ChiefOfStaff.test.jsx
@@ -668,12 +668,71 @@ describe('ChiefOfStaff Issues card', () => {
     await act(async () => { await new Promise((resolve) => setTimeout(resolve, 2100)); });
   });
 
+  // Without these, deleting the `tone` prop would leave every tile neutral gray
+  // while the helper's own unit tests stayed green.
+  it('colors the tile amber for a warning-only check', async () => {
+    renderWithIssues([memoryWarning]);
+
+    for (const card of await issueCards()) {
+      expect(card.className).toContain('border-port-warning');
+      expect(card.className).not.toContain('border-port-error');
+    }
+  });
+
+  it('escalates the tile to red when an issue is error-level', async () => {
+    renderWithIssues([memoryWarning, { type: 'error', category: 'processes', message: 'example-app failed to auto-restart' }]);
+
+    for (const card of await issueCards()) {
+      expect(card.className).toContain('border-port-error');
+    }
+  });
+
   it('stays a click-through to Health when there are no issues at all', async () => {
     renderWithIssues([]);
 
     for (const card of await issueCards()) {
       expect(card).toHaveAttribute('title', 'No issues detected — view system health');
       expect(within(card).getByText('0')).toBeInTheDocument();
+      expect(card.className).not.toContain('border-port-warning');
+      expect(card.className).not.toContain('border-port-error');
+    }
+  });
+
+  // fetchData's health read is the SLOW one — it resolves after the socket event
+  // for the check that same batch triggered. Everything the page derives from
+  // health (tile, avatar state, status bubble) must come from the merged
+  // snapshot, or the bubble names an older issue than the tile is counting.
+  it('does not let a slow health read clobber a fresher socket-delivered check', async () => {
+    const staleWarning = { type: 'warning', category: 'memory', message: 'Stale issue from the older read' };
+    api.getCosStatus.mockResolvedValue({ running: true, config, stats: {} });
+    // The slow read carries the OLDER timestamp; the socket event below is newer.
+    api.getCosHealth.mockResolvedValue({ lastCheck: '2026-01-01T00:00:00.000Z', issues: [staleWarning] });
+    render(
+      <MemoryRouter initialEntries={['/cos/config']}>
+        <Routes>
+          <Route path="/cos/:tab" element={<ChiefOfStaff />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+    expect(await screen.findByText(staleWarning.message)).toBeInTheDocument();
+
+    const handleHealthCheck = socketStub.on.mock.calls.find(([evt]) => evt === 'cos:health:check')?.[1];
+    await act(async () => {
+      handleHealthCheck({ metrics: { timestamp: '2026-01-02T00:00:00.000Z' }, issues: [memoryWarning] });
+    });
+    await act(async () => { await new Promise((resolve) => setTimeout(resolve, 2100)); });
+
+    // Now force the slow batch to run again with its stale payload — the merge
+    // must keep the socket's newer check, for the tile AND the bubble.
+    await act(async () => {
+      socketStub.on.mock.calls.find(([evt]) => evt === 'apps:changed')?.[1]?.();
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    });
+
+    expect(screen.getByText(memoryWarning.message)).toBeInTheDocument();
+    expect(screen.queryByText(staleWarning.message)).not.toBeInTheDocument();
+    for (const card of await issueCards()) {
+      expect(card).toHaveAttribute('title', memoryWarning.message);
     }
   });
 });

--- a/client/src/pages/ChiefOfStaff.test.jsx
+++ b/client/src/pages/ChiefOfStaff.test.jsx
@@ -576,3 +576,82 @@ describe('ChiefOfStaff stale queue-read guard', () => {
     expect(screen.getByText('FRESH in-progress copy')).toBeInTheDocument();
   });
 });
+
+// A single warning-level health issue parked the avatar on "Investigating
+// issue..." with Active 0. Nothing on screen said what was being investigated,
+// and the Issues tile was an inert <div> holding the number 1, so the detail was
+// reachable only by guessing at the Health tab.
+describe('ChiefOfStaff Issues card', () => {
+  const memoryWarning = {
+    type: 'warning',
+    category: 'memory',
+    message: 'High memory usage in: example-app (900MB)',
+  };
+
+  const renderWithIssues = (issues) => {
+    api.getCosStatus.mockResolvedValue({ running: true, config, stats: {} });
+    api.getCosHealth.mockResolvedValue({ lastCheck: '2026-01-01T00:00:00.000Z', issues });
+    return render(
+      <MemoryRouter initialEntries={['/cos/config']}>
+        <Routes>
+          <Route path="/cos/:tab" element={<ChiefOfStaff />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  };
+
+  // Same "never index a match list" rule as the Learning card above: the page
+  // paints the Issues tile in up to four places (desktop sidebar, mobile grid,
+  // the compressed header, and the Tailwind-`hidden` ascii `mini` bar, all still
+  // in the jsdom tree). Hold every variant to the contract.
+  const issueCards = async () => {
+    const cards = await screen.findAllByRole('button', { name: /^Issues:/ });
+    expect(cards.length).toBeGreaterThan(0);
+    return cards;
+  };
+
+  it('names the health issue in the status bubble instead of the generic investigating line', async () => {
+    renderWithIssues([memoryWarning]);
+
+    expect(await screen.findByText(memoryWarning.message)).toBeInTheDocument();
+    expect(screen.queryByText('Investigating issue...')).not.toBeInTheDocument();
+  });
+
+  it('summarizes the count when more than one issue is open', async () => {
+    renderWithIssues([memoryWarning, { type: 'error', category: 'processes', message: 'example-app failed to auto-restart' }]);
+
+    expect(await screen.findByText(/^2 health issues: /)).toBeInTheDocument();
+  });
+
+  it('makes every Issues tile a button that carries the issue summary', async () => {
+    renderWithIssues([memoryWarning]);
+
+    for (const card of await issueCards()) {
+      expect(card).toHaveAttribute('title', memoryWarning.message);
+      expect(within(card).getByText('1')).toBeInTheDocument();
+    }
+  });
+
+  it('opens the Health tab when the tile is clicked', async () => {
+    renderWithIssues([memoryWarning]);
+    const cards = await issueCards();
+
+    // Clicking the first is enough: the assertion above pins every variant to
+    // the same props object, and the click swaps the route out from under the
+    // rest of the list.
+    fireEvent.click(cards[0]);
+
+    const panel = await screen.findByRole('tabpanel');
+    expect(panel).toHaveAttribute('id', 'tabpanel-health');
+    expect(within(panel).getByText(memoryWarning.message)).toBeInTheDocument();
+  });
+
+  it('stays a click-through to Health when there are no issues at all', async () => {
+    renderWithIssues([]);
+
+    for (const card of await issueCards()) {
+      expect(card).toHaveAttribute('title', 'No issues detected — view system health');
+      expect(within(card).getByText('0')).toBeInTheDocument();
+    }
+  });
+});

--- a/server/routes/cosInsightRoutes.js
+++ b/server/routes/cosInsightRoutes.js
@@ -189,9 +189,11 @@ router.get('/actionable-insights', asyncHandler(async (req, res) => {
     });
   }
 
-  // Sort by priority
+  // Sort by priority. `??`, not `||` — `critical` ranks 0, and `0 || 5` demoted
+  // it below every other priority, so the single most urgent insight sorted LAST
+  // and fell off the `slice(0, 5)` below once six insights were open.
   const priorityOrder = { critical: 0, high: 1, medium: 2, low: 3, info: 4 };
-  insights.sort((a, b) => (priorityOrder[a.priority] || 5) - (priorityOrder[b.priority] || 5));
+  insights.sort((a, b) => (priorityOrder[a.priority] ?? 5) - (priorityOrder[b.priority] ?? 5));
 
   res.json({
     insights: insights.slice(0, 5), // Max 5 insights

--- a/server/routes/cosInsightRoutes.js
+++ b/server/routes/cosInsightRoutes.js
@@ -100,13 +100,19 @@ router.get('/actionable-insights', asyncHandler(async (req, res) => {
   // 3. Health issues
   const healthIssues = healthCheck?.issues || [];
   if (healthIssues.length > 0) {
-    const criticalIssues = healthIssues.filter(i => i.severity === 'critical');
+    // `type`, not `severity` — runHealthCheck stamps issues `error`/`warning`
+    // and never writes a `severity` field, so the old check matched nothing and
+    // a process that failed to auto-restart banner'd at `medium` alongside a
+    // memory warning.
+    const criticalIssues = healthIssues.filter(i => i.type === 'error');
     insights.push({
       type: 'health',
       priority: criticalIssues.length > 0 ? 'critical' : 'medium',
       icon: 'AlertTriangle',
       title: `${healthIssues.length} system health issue${healthIssues.length > 1 ? 's' : ''}`,
-      description: healthIssues[0]?.message || 'System health issue detected',
+      // Lead with the error when there is one — otherwise a red `critical`
+      // banner can describe an unrelated warning that merely sorted first.
+      description: (criticalIssues[0] || healthIssues[0])?.message || 'System health issue detected',
       action: { label: 'Check Health', route: '/cos/health' },
       count: healthIssues.length
     });

--- a/server/routes/cosInsightRoutes.test.js
+++ b/server/routes/cosInsightRoutes.test.js
@@ -156,6 +156,53 @@ describe('CoS Insight Routes', () => {
       }));
     });
 
+    // The health insight filtered on a `severity` field runHealthCheck never
+    // writes, so a PM2 process that failed to auto-restart banner'd at the same
+    // muted `medium` priority as a memory warning.
+    it('raises the health insight to critical for an error-type issue', async () => {
+      cos.getAllTasks.mockResolvedValue({ user: null, cos: null });
+      taskLearning.getLearningInsights.mockResolvedValue({ skippedTypes: [] });
+      cos.getPendingAgentFeedbackCount.mockResolvedValue(0);
+      productivity.getOptimalTimeInfo.mockResolvedValue({ hasData: false });
+      cos.runHealthCheck.mockResolvedValue({
+        issues: [
+          { type: 'warning', category: 'memory', message: 'High memory usage in: example-app (900MB)' },
+          { type: 'error', category: 'processes', message: 'example-app failed to auto-restart' }
+        ]
+      });
+
+      const response = await request(app).get('/api/cos/actionable-insights');
+
+      expect(response.status).toBe(200);
+      expect(response.body.insights).toContainEqual(expect.objectContaining({
+        type: 'health',
+        priority: 'critical',
+        count: 2,
+        // …and it describes the error, not the warning that happened to sort first.
+        description: 'example-app failed to auto-restart',
+        action: { label: 'Check Health', route: '/cos/health' }
+      }));
+    });
+
+    it('keeps a warning-only health check at medium priority', async () => {
+      cos.getAllTasks.mockResolvedValue({ user: null, cos: null });
+      taskLearning.getLearningInsights.mockResolvedValue({ skippedTypes: [] });
+      cos.getPendingAgentFeedbackCount.mockResolvedValue(0);
+      productivity.getOptimalTimeInfo.mockResolvedValue({ hasData: false });
+      cos.runHealthCheck.mockResolvedValue({
+        issues: [{ type: 'warning', category: 'memory', message: 'High memory usage in: example-app (900MB)' }]
+      });
+
+      const response = await request(app).get('/api/cos/actionable-insights');
+
+      expect(response.status).toBe(200);
+      expect(response.body.insights).toContainEqual(expect.objectContaining({
+        type: 'health',
+        priority: 'medium',
+        description: 'High memory usage in: example-app (900MB)'
+      }));
+    });
+
     it('should handle errors gracefully in parallel calls', async () => {
       cos.getAllTasks.mockRejectedValue(new Error('fail'));
       taskLearning.getLearningInsights.mockRejectedValue(new Error('fail'));

--- a/server/routes/cosInsightRoutes.test.js
+++ b/server/routes/cosInsightRoutes.test.js
@@ -52,6 +52,7 @@ import * as autonomousJobs from '../services/autonomousJobs.js';
 import * as productivity from '../services/productivity.js';
 import * as goalProgress from '../services/goalProgress.js';
 import * as decisionLog from '../services/decisionLog.js';
+import * as notifications from '../services/notifications.js';
 
 describe('CoS Insight Routes', () => {
   let app;
@@ -62,6 +63,9 @@ describe('CoS Insight Routes', () => {
     app.use('/api/cos', insightRoutes);
     vi.clearAllMocks();
     cos.getPendingAgentFeedbackCount.mockResolvedValue(0);
+    // clearAllMocks keeps implementations, so a per-test override would leak
+    // into later tests — restore the default empty notification list here.
+    notifications.getNotifications.mockResolvedValue([]);
   });
 
   describe('GET /api/cos/productivity', () => {
@@ -201,6 +205,33 @@ describe('CoS Insight Routes', () => {
         priority: 'medium',
         description: 'High memory usage in: example-app (900MB)'
       }));
+    });
+
+    // The priority sort used `priorityOrder[p] || 5`, and `critical` ranks 0 —
+    // so `0 || 5` demoted the single most urgent insight below every other
+    // priority. It sorted LAST and, once six insights were open, fell off the
+    // `slice(0, 5)` entirely. Only reachable now that a health issue can
+    // actually be `critical`.
+    it('sorts a critical insight first and keeps it within the top-5 slice', async () => {
+      cos.getAllTasks.mockResolvedValue({
+        user: { grouped: { pending: [], blocked: [{ id: 'b1', description: 'Blocked task' }] } },
+        cos: { awaitingApproval: [{ id: 'a1', description: 'Approve me' }], grouped: { pending: [], blocked: [] } }
+      });
+      taskLearning.getLearningInsights.mockResolvedValue({ skippedTypes: [{ type: 'flaky' }] });
+      cos.getPendingAgentFeedbackCount.mockResolvedValue(2);
+      productivity.getOptimalTimeInfo.mockResolvedValue({ hasData: false });
+      notifications.getNotifications.mockResolvedValue([{ type: 'briefing_ready' }]);
+      cos.runHealthCheck.mockResolvedValue({
+        issues: [{ type: 'error', category: 'processes', message: 'example-app failed to auto-restart' }]
+      });
+
+      const response = await request(app).get('/api/cos/actionable-insights');
+
+      expect(response.status).toBe(200);
+      // Six insights were built, so a demoted critical would have been sliced off.
+      expect(response.body.totalCount).toBe(6);
+      expect(response.body.insights[0]).toMatchObject({ type: 'health', priority: 'critical' });
+      expect(response.body.insights.map(i => i.priority)).toEqual(['critical', 'high', 'high', 'medium', 'low']);
     });
 
     it('should handle errors gracefully in parallel calls', async () => {


### PR DESCRIPTION
## Summary

CoS parks the avatar in the **Investigating** state whenever a health check leaves any issue behind — but the status bubble showed a generic `Investigating issue...` next to an **Active** count of **0**, with no agent to open. The **Issues** tile beside it was an inert `<div>` holding a number, so the only way to find out what was actually wrong was to guess at the Health tab.

Reported symptom: *"the cos system says there is 1 issue and that it is investigating but I don't see any active agents or status and the issues card is not clickable to take me into it or tell me what the issue is."*

### What changed

- **The status bubble names the issue.** `summarizeHealthIssues` renders the health-check findings (e.g. `High memory usage in: example-app (900MB)`) on page load, on the `cos:health:check` socket event, and after a manual Run Check. One issue reads verbatim; several read as `N health issues: … · …`.
- **The Issues tile is a click-through.** It is now a `<button>` that opens `/cos/health`, carries the summary as its `title`, and takes its color from severity — amber for a warning-only check, red only when an issue is `type: 'error'`. All four render sites (desktop sidebar, mobile grid, compressed header, ascii stats bar) share one props object so they cannot drift.
- **The actionable-insights banner keyed on a field that is never written.** `cosInsightRoutes.js` filtered health issues on `severity === 'critical'`, but `cosHealthMonitor.js` stamps `type: 'error' | 'warning'` and no `severity` at all — so a process that *failed to auto-restart* banner'd at the same muted `medium` priority as a memory warning. It now keys on `type`, and leads with the error's message rather than whichever issue happened to sort first.

### Fixes from the review pass

- **The priority sort dropped critical insights.** `priorityOrder[p] || 5` — and `critical` ranks `0`, so `0 || 5` demoted the single most urgent insight *below every other priority*. It sorted last and, once six insights were open, fell off the `slice(0, 5)` entirely. Latent until now, because a health insight could never actually reach `critical`; this change is what activates it.
- **The bubble and the tile could describe different health checks.** The page derived the avatar state and status message from the raw `getCosHealth` read while `setHealth` kept whichever snapshot was fresher — so an in-flight health check could leave the tile counting the new issue while the bubble named the old one (or fell back to generic text on a failed read). The freshness rule is now the pure `fresherHealth` helper, and a single `applyHealth` writer keeps the state, the ref, and every derived value on the same snapshot.
- `summarizeHealthIssues` counted *messages* rather than *issues*, so a mixed list like `[{message:'A'}, {}]` under-reported as one issue.

## Test plan

- `client`: **688 files / 8631 tests** pass (`npx vitest run`), lint clean (`biome`).
- `server`: **1518 files / 31522 tests** pass (`npx vitest run`).
- 24 new tests across `constants.test.js`, `ChiefOfStaff.test.jsx`, and `cosInsightRoutes.test.js`. **Every one was verified to fail against the pre-fix code** — including the tile's severity coloring (so dropping the `tone` prop can't pass silently) and the socket-vs-slow-read race.
- The `fresherHealth` extraction is behavior-preserving: the three pre-existing health-freshness tests were confirmed to fail when the merge is stubbed out and pass with the helper in place.