### PR TITLE
fix(ui): stop the provider card's action buttons from starving its details column

### DIFF
--- a/client/src/components/providers/ProviderCard.jsx
+++ b/client/src/components/providers/ProviderCard.jsx
@@ -3,7 +3,7 @@
  *
  * Lives here rather than inline on the page because the page also owns the
  * provider EDITOR, the sample-provider panel and the ad-hoc runner — the card
- * is ~250 lines of its own and was already three `map`s deep once the page
+ * is ~300 lines of its own and was already three `map`s deep once the page
  * started grouping cards by their card state.
  *
  * The card renders no derivation of its own: `cardState`, `runtime` and

--- a/client/src/components/providers/ProviderCard.jsx
+++ b/client/src/components/providers/ProviderCard.jsx
@@ -94,212 +94,77 @@ export default function ProviderCard({
   const style = CARD_STATE_STYLES[cardState.state];
   return (
     <div
-      className={`bg-port-card border border-l-4 rounded-xl p-4 ${style.border} ${style.dim || ''} ${
+      className={`@container bg-port-card border border-l-4 rounded-xl p-4 ${style.border} ${style.dim || ''} ${
         isDefault ? 'ring-1 ring-port-accent/60' : ''
       }`}
     >
-      <div className="flex flex-col lg:flex-row lg:items-start justify-between gap-4">
-        <div className="flex-1 min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <h3 className="text-lg font-semibold text-white">{provider.name}</h3>
-            <span className={`text-xs px-2 py-0.5 rounded ${providerTypeClass(provider.type)}`}>
-              {provider.type.toUpperCase()}
+      {/* Identity and actions share the top row; everything else sits BELOW it
+          at the card's full width. The details used to be the row's first flex
+          item, which meant the un-shrinkable seven-button action group claimed
+          its max-content width first and left the details whatever remained —
+          on a real desktop card that was a ~275px column of hard-wrapped text
+          beside an empty half-card. Breakpoints are container-relative (`@`)
+          rather than viewport-relative: the card is what has to be wide enough
+          to split, and it is narrower than the viewport by the sidebar. */}
+      <div className="flex flex-col @2xl:flex-row @2xl:items-start justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2 min-w-0">
+          <h3 className="text-lg font-semibold text-white">{provider.name}</h3>
+          <span className={`text-xs px-2 py-0.5 rounded ${providerTypeClass(provider.type)}`}>
+            {provider.type.toUpperCase()}
+          </span>
+          {isDefault && (
+            <span className="text-xs px-2 py-0.5 rounded bg-port-accent/20 text-port-accent">
+              DEFAULT
             </span>
-            {isDefault && (
-              <span className="text-xs px-2 py-0.5 rounded bg-port-accent/20 text-port-accent">
-                DEFAULT
-              </span>
-            )}
-            {provider.llamaBacked && (
-              <span className="text-xs px-2 py-0.5 rounded bg-purple-500/20 text-purple-300 border border-purple-500/30">
-                LLAMA.CPP / DFLASH
-              </span>
-            )}
-            {provider.mtplxBacked && (
-              <span className="text-xs px-2 py-0.5 rounded bg-blue-500/20 text-blue-300 border border-blue-500/30">
-                MTPLX
-              </span>
-            )}
-            {/* One badge for the card's state — the same one that
-                colors its border and decides which section it sits in.
-                BENCHED covers what used to render as UNAVAILABLE: an
-                enabled provider sidelined after a failure (usage limit,
-                model-not-found, auth) in favor of its fallback. */}
+          )}
+          {provider.llamaBacked && (
+            <span className="text-xs px-2 py-0.5 rounded bg-purple-500/20 text-purple-300 border border-purple-500/30">
+              LLAMA.CPP / DFLASH
+            </span>
+          )}
+          {provider.mtplxBacked && (
+            <span className="text-xs px-2 py-0.5 rounded bg-blue-500/20 text-blue-300 border border-blue-500/30">
+              MTPLX
+            </span>
+          )}
+          {/* One badge for the card's state — the same one that
+              colors its border and decides which section it sits in.
+              BENCHED covers what used to render as UNAVAILABLE: an
+              enabled provider sidelined after a failure (usage limit,
+              model-not-found, auth) in favor of its fallback. */}
+          <span
+            className={`text-xs px-2 py-0.5 rounded ${style.badge}`}
+            title={cardState.state === PROVIDER_CARD_STATE.BLOCKED
+              ? cardState.missing.map(m => m.label).join(' · ')
+              : (status?.message || style.hint)}
+          >
+            {style.label}
+            {cardState.state === PROVIDER_CARD_STATE.BENCHED && status?.reason
+              ? ` · ${status.reason}`
+              : ''}
+          </span>
+          {/* A blocked provider's toggle is not what's stopping it, so
+              spell out which way it sits rather than leaving the reader
+              to infer it from the Enable/Disable button. */}
+          {cardState.state === PROVIDER_CARD_STATE.BLOCKED && (
+            <span className="text-xs px-2 py-0.5 rounded bg-gray-500/20 text-gray-400">
+              {provider.enabled ? 'SWITCHED ON' : 'SWITCHED OFF'}
+            </span>
+          )}
+          {/* Off the CoS Agent Runner's exec allowlist: the provider still
+              works for direct spawn, it just can't be launched by /spawn
+              or /spawn-tui. Informational — never a save-time rejection. */}
+          {isProcessProvider(provider) && isRunnerAllowedCommand(provider.command, runnerAllowedCommands) === false && (
             <span
-              className={`text-xs px-2 py-0.5 rounded ${style.badge}`}
-              title={cardState.state === PROVIDER_CARD_STATE.BLOCKED
-                ? cardState.missing.map(m => m.label).join(' · ')
-                : (status?.message || style.hint)}
+              className="text-xs px-2 py-0.5 rounded bg-port-warning/20 text-port-warning"
+              title={RUNNER_NOT_ALLOWED_HINT}
             >
-              {style.label}
-              {cardState.state === PROVIDER_CARD_STATE.BENCHED && status?.reason
-                ? ` · ${status.reason}`
-                : ''}
+              NO AGENT RUNNER
             </span>
-            {/* A blocked provider's toggle is not what's stopping it, so
-                spell out which way it sits rather than leaving the reader
-                to infer it from the Enable/Disable button. */}
-            {cardState.state === PROVIDER_CARD_STATE.BLOCKED && (
-              <span className="text-xs px-2 py-0.5 rounded bg-gray-500/20 text-gray-400">
-                {provider.enabled ? 'SWITCHED ON' : 'SWITCHED OFF'}
-              </span>
-            )}
-            {/* Off the CoS Agent Runner's exec allowlist: the provider still
-                works for direct spawn, it just can't be launched by /spawn
-                or /spawn-tui. Informational — never a save-time rejection. */}
-            {isProcessProvider(provider) && isRunnerAllowedCommand(provider.command, runnerAllowedCommands) === false && (
-              <span
-                className="text-xs px-2 py-0.5 rounded bg-port-warning/20 text-port-warning"
-                title={RUNNER_NOT_ALLOWED_HINT}
-              >
-                NO AGENT RUNNER
-              </span>
-            )}
-          </div>
-
-          <ProviderRuntimeStatus
-            className="mt-2"
-            runtime={runtime}
-            onInstall={onInstallRuntime}
-          />
-
-          {/* The other half of "can this actually run": is the local daemon this
-              provider points at installed, up, and serving the model it names.
-              Distinct from the card STATE above — that one is about the toggle
-              and the credentials, this one probes the daemon. */}
-          <ProviderReadiness
-            className="mt-2"
-            readiness={daemonReadiness}
-            onAutoSetup={(setup) => onAutoSetupRuntime?.({ ...setup, providerId: provider.id })}
-          />
-
-          {provider.enabled && status?.available === false && (
-            <div className="mt-2 text-xs rounded border border-port-error/40 bg-port-error/10 px-3 py-2 text-port-error space-y-1">
-              <p className="break-words">
-                <span className="font-semibold">Benched ({status?.reason || 'unknown'})</span>
-                {status?.timeUntilRecovery ? ` — auto-retries in ${status.timeUntilRecovery}` : ''}
-                . Calls route to the fallback until then.
-              </p>
-              {status?.message && (
-                <p className="break-words text-port-error/80">Why: {status.message}</p>
-              )}
-              <button
-                type="button"
-                onClick={() => onRecover(provider.id)}
-                disabled={recovering}
-                className="mt-1 px-2 py-0.5 rounded bg-port-error/20 hover:bg-port-error/30 disabled:opacity-50 text-port-error"
-              >
-                {recovering ? 'Clearing…' : 'Recover now'}
-              </button>
-            </div>
-          )}
-
-          <div className="mt-2 text-sm text-gray-400 space-y-1">
-            {provider.llamaBacked && (
-              <p className="text-xs text-purple-300/90">
-                Local llama.cpp / llama-server harness (endpoint: <code className="text-purple-200">{provider.endpoint}</code>) — supports DFlash 2 speculative drafting.
-              </p>
-            )}
-            {isProcessProvider(provider) && (
-              <p className="break-words">Command: <code className="text-gray-300 break-all">{provider.command} {provider.args?.join(' ')}</code></p>
-            )}
-            {isApiProvider(provider) && (
-              <p className="break-words">Endpoint: <code className="text-gray-300 break-all">{provider.endpoint}</code></p>
-            )}
-            {/* API-type providers auth solely via the stored apiKey (sent as a
-                Bearer header) — surface its state here so "where does the key
-                go?" is answered from the card, not by spelunking the form. */}
-            {isApiProvider(provider) && (
-              provider.hasApiKey ? (
-                <p className="text-xs">API key: <span className="text-port-success">set</span></p>
-              ) : isPrivateNetworkEndpoint(provider.endpoint) ? (
-                /* Same rule as `providerCardState`'s apiKey prerequisite — a
-                   keyless call to a private OpenAI-compatible server (loopback,
-                   the LAN box, a tailnet peer) is a supported setup, so the two
-                   must not disagree: a card badged READY used to carry an
-                   orange "API key: not set" line for exactly those endpoints. */
-                <p className="text-xs">API key: <span className="text-gray-500">none (private network endpoint)</span></p>
-              ) : (
-                <p className="text-xs">API key: <span className="text-port-warning">not set — Edit this provider to paste one</span></p>
-              )
-            )}
-            {provider.models?.length > 0 && (
-              <p>Models: {provider.models.slice(0, 3).join(', ')}{provider.models.length > 3 ? ` +${provider.models.length - 3}` : ''}</p>
-            )}
-            {provider.defaultModel && (
-              <p className="break-words">Default: <code className="text-gray-300 break-all">{provider.defaultModel}</code></p>
-            )}
-            {provider.effort && (
-              <p className="break-words">Default effort: <code className="text-gray-300">{provider.effort}</code></p>
-            )}
-            {(() => {
-              const windowLabel = formatContextLength(effectiveModelContextWindow(provider, provider.defaultModel));
-              return windowLabel ? (
-                <p className="text-xs">
-                  Context: <span className="text-gray-300">{windowLabel}</span>
-                  {provider.contextWindow ? <span className="text-gray-500"> override</span> : null}
-                </p>
-              ) : null;
-            })()}
-            {(provider.lightModel || provider.mediumModel || provider.heavyModel) && (
-              <p className="text-xs">
-                Tiers:
-                {provider.lightModel && <span className="ml-1 text-port-success">{provider.lightModel}</span>}
-                {provider.mediumModel && <span className="ml-1 text-port-warning">{provider.mediumModel}</span>}
-                {provider.heavyModel && <span className="ml-1 text-port-error">{provider.heavyModel}</span>}
-              </p>
-            )}
-            {provider.headlessArgs?.length > 0 && (
-              <p className="text-xs break-words">
-                Headless: <code className="text-gray-300 break-all">{provider.headlessArgs.join(' ')}</code>
-              </p>
-            )}
-            {isTuiProvider(provider) && (
-              <p className="text-xs break-words">
-                TUI: paste delay <span className="text-gray-300">{provider.tuiPromptDelayMs || 2500}ms</span>, completion by sentinel, process exit, or explicit failure
-              </p>
-            )}
-            {provider.fallbackProvider && (
-              <p className="text-xs">
-                Fallback: <span className="text-port-accent">{providersById[provider.fallbackProvider]?.name || provider.fallbackProvider}</span>
-                {provider.fallbackModel && <span className="ml-1 text-gray-300">({provider.fallbackModel})</span>}
-              </p>
-            )}
-            {provider.envVars && Object.keys(provider.envVars).length > 0 && (
-              <div className="text-xs mt-1">
-                <span className="text-gray-400">Env:</span>
-                {Object.entries(provider.envVars).map(([k, v]) => (
-                  <div key={k}>
-                    <code className="ml-1 text-orange-400">
-                      {k}={provider.secretEnvVars?.includes(k) ? '***' : v}
-                    </code>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {isGrokBuildCli(provider) && <GrokUploadWarning className="mt-2" />}
-
-          {isOrcaRouterBackedProvider(provider) && (
-            <OrcaRouterKeyHint
-              sibling={providersById.orcarouter}
-              onEdit={onEdit}
-              className="mt-2"
-            />
-          )}
-
-          {testResult && !testResult.testing && (
-            <div className={`mt-2 text-sm ${testResult.success ? 'text-port-success' : 'text-port-error'}`}>
-              {testResult.success
-                ? `✓ Available${testResult.version ? ` (${testResult.version})` : ''}`
-                : `✗ ${testResult.error}`
-              }
-            </div>
           )}
         </div>
 
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2 @2xl:justify-end">
           {/* TUI providers are the only ones a human can drive interactively, so
               they get a one-click hand-off to the Shell page. The link carries
               only the provider ID: the server resolves both the command line
@@ -374,6 +239,150 @@ export default function ProviderCard({
             Delete
           </button>
         </div>
+      </div>
+
+      {/* Card body — full width, below the header row rather than beside the
+          action buttons. */}
+      <div className="mt-3 space-y-2">
+        <ProviderRuntimeStatus
+          runtime={runtime}
+          onInstall={onInstallRuntime}
+        />
+
+        {/* The other half of "can this actually run": is the local daemon this
+            provider points at installed, up, and serving the model it names.
+            Distinct from the card STATE above — that one is about the toggle
+            and the credentials, this one probes the daemon. */}
+        <ProviderReadiness
+          className="max-w-3xl"
+          readiness={daemonReadiness}
+          onAutoSetup={(setup) => onAutoSetupRuntime?.({ ...setup, providerId: provider.id })}
+        />
+
+        {provider.enabled && status?.available === false && (
+          <div className="max-w-3xl text-xs rounded border border-port-error/40 bg-port-error/10 px-3 py-2 text-port-error space-y-1">
+            <p className="break-words">
+              <span className="font-semibold">Benched ({status?.reason || 'unknown'})</span>
+              {status?.timeUntilRecovery ? ` — auto-retries in ${status.timeUntilRecovery}` : ''}
+              . Calls route to the fallback until then.
+            </p>
+            {status?.message && (
+              <p className="break-words text-port-error/80">Why: {status.message}</p>
+            )}
+            <button
+              type="button"
+              onClick={() => onRecover(provider.id)}
+              disabled={recovering}
+              className="mt-1 px-2 py-0.5 rounded bg-port-error/20 hover:bg-port-error/30 disabled:opacity-50 text-port-error"
+            >
+              {recovering ? 'Clearing…' : 'Recover now'}
+            </button>
+          </div>
+        )}
+
+        <div className="text-sm text-gray-400 space-y-1">
+          {provider.llamaBacked && (
+            <p className="text-xs text-purple-300/90">
+              Local llama.cpp / llama-server harness (endpoint: <code className="text-purple-200">{provider.endpoint}</code>) — supports DFlash 2 speculative drafting.
+            </p>
+          )}
+          {isProcessProvider(provider) && (
+            <p className="break-words">Command: <code className="text-gray-300 break-all">{provider.command} {provider.args?.join(' ')}</code></p>
+          )}
+          {isApiProvider(provider) && (
+            <p className="break-words">Endpoint: <code className="text-gray-300 break-all">{provider.endpoint}</code></p>
+          )}
+          {/* API-type providers auth solely via the stored apiKey (sent as a
+              Bearer header) — surface its state here so "where does the key
+              go?" is answered from the card, not by spelunking the form. */}
+          {isApiProvider(provider) && (
+            provider.hasApiKey ? (
+              <p className="text-xs">API key: <span className="text-port-success">set</span></p>
+            ) : isPrivateNetworkEndpoint(provider.endpoint) ? (
+              /* Same rule as `providerCardState`'s apiKey prerequisite — a
+                 keyless call to a private OpenAI-compatible server (loopback,
+                 the LAN box, a tailnet peer) is a supported setup, so the two
+                 must not disagree: a card badged READY used to carry an
+                 orange "API key: not set" line for exactly those endpoints. */
+              <p className="text-xs">API key: <span className="text-gray-500">none (private network endpoint)</span></p>
+            ) : (
+              <p className="text-xs">API key: <span className="text-port-warning">not set — Edit this provider to paste one</span></p>
+            )
+          )}
+          {provider.models?.length > 0 && (
+            <p>Models: {provider.models.slice(0, 3).join(', ')}{provider.models.length > 3 ? ` +${provider.models.length - 3}` : ''}</p>
+          )}
+          {provider.defaultModel && (
+            <p className="break-words">Default: <code className="text-gray-300 break-all">{provider.defaultModel}</code></p>
+          )}
+          {provider.effort && (
+            <p className="break-words">Default effort: <code className="text-gray-300">{provider.effort}</code></p>
+          )}
+          {(() => {
+            const windowLabel = formatContextLength(effectiveModelContextWindow(provider, provider.defaultModel));
+            return windowLabel ? (
+              <p className="text-xs">
+                Context: <span className="text-gray-300">{windowLabel}</span>
+                {provider.contextWindow ? <span className="text-gray-500"> override</span> : null}
+              </p>
+            ) : null;
+          })()}
+          {(provider.lightModel || provider.mediumModel || provider.heavyModel) && (
+            <p className="text-xs">
+              Tiers:
+              {provider.lightModel && <span className="ml-1 text-port-success">{provider.lightModel}</span>}
+              {provider.mediumModel && <span className="ml-1 text-port-warning">{provider.mediumModel}</span>}
+              {provider.heavyModel && <span className="ml-1 text-port-error">{provider.heavyModel}</span>}
+            </p>
+          )}
+          {provider.headlessArgs?.length > 0 && (
+            <p className="text-xs break-words">
+              Headless: <code className="text-gray-300 break-all">{provider.headlessArgs.join(' ')}</code>
+            </p>
+          )}
+          {isTuiProvider(provider) && (
+            <p className="text-xs break-words">
+              TUI: paste delay <span className="text-gray-300">{provider.tuiPromptDelayMs || 2500}ms</span>, completion by sentinel, process exit, or explicit failure
+            </p>
+          )}
+          {provider.fallbackProvider && (
+            <p className="text-xs">
+              Fallback: <span className="text-port-accent">{providersById[provider.fallbackProvider]?.name || provider.fallbackProvider}</span>
+              {provider.fallbackModel && <span className="ml-1 text-gray-300">({provider.fallbackModel})</span>}
+            </p>
+          )}
+          {provider.envVars && Object.keys(provider.envVars).length > 0 && (
+            <div className="text-xs mt-1">
+              <span className="text-gray-400">Env:</span>
+              {Object.entries(provider.envVars).map(([k, v]) => (
+                <div key={k}>
+                  <code className="ml-1 text-orange-400">
+                    {k}={provider.secretEnvVars?.includes(k) ? '***' : v}
+                  </code>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {isGrokBuildCli(provider) && <GrokUploadWarning className="max-w-3xl" />}
+
+        {isOrcaRouterBackedProvider(provider) && (
+          <OrcaRouterKeyHint
+            sibling={providersById.orcarouter}
+            onEdit={onEdit}
+            className="max-w-3xl"
+          />
+        )}
+
+        {testResult && !testResult.testing && (
+          <div className={`text-sm ${testResult.success ? 'text-port-success' : 'text-port-error'}`}>
+            {testResult.success
+              ? `✓ Available${testResult.version ? ` (${testResult.version})` : ''}`
+              : `✗ ${testResult.error}`
+            }
+          </div>
+        )}
       </div>
     </div>
   );

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -873,3 +873,44 @@ describe('Launch in Shell button on TUI provider cards', () => {
     expect(screen.queryByRole('link', { name: /Launch in Shell/ })).not.toBeInTheDocument();
   });
 });
+
+describe('provider card layout', () => {
+  // The card's details used to be the FIRST flex item of the same row that
+  // holds the action buttons. The button group never shrinks below its
+  // max-content width (seven buttons ≈ 660px), so on a real desktop card the
+  // details were squeezed into a ~275px column of hard-wrapped text beside an
+  // empty half-card. Keeping the details OUT of that row is what fixes it, so
+  // that is what this pins — a class assertion would just restate the JSX.
+  it('renders the details below the action row, not as a flex sibling of it', async () => {
+    vi.clearAllMocks();
+    api.getApps.mockResolvedValue([]);
+    api.getProviderStatuses.mockResolvedValue({ providers: {} });
+    api.getProviderRuntimes.mockResolvedValue({ runtimes: {} });
+    api.getProviderReadiness.mockResolvedValue({ readiness: {} });
+    localModels.value = { ctxById: {}, installed: { ollama: null, lmstudio: null } };
+    api.getProviders.mockResolvedValue({
+      providers: [{
+        id: 'opencode-llama',
+        name: 'OpenCode llama TUI',
+        type: 'tui',
+        command: 'opencode',
+        args: [],
+        enabled: true,
+        defaultModel: 'dflash',
+        tuiCommandLine: 'opencode',
+      }],
+      activeProvider: null,
+    });
+
+    renderPage();
+
+    const deleteButton = await screen.findByRole('button', { name: 'Delete' });
+    // The row that lays identity out against the actions — one level above the
+    // button group the Delete button sits in.
+    const headerRow = deleteButton.closest('.flex-wrap').parentElement;
+    expect(headerRow.className).toContain('flex-row');
+    expect(headerRow.textContent).toContain('OpenCode llama TUI');
+    expect(headerRow.textContent).not.toContain('Command:');
+    expect(headerRow.textContent).not.toContain('Default:');
+  });
+});


### PR DESCRIPTION
## Summary

On Settings → AI Providers, a card's details rendered as a narrow, hard-wrapped column beside an empty half-card on desktop.

**Cause:** the details were the first flex item of the same row as the action buttons. The button group never shrinks below its max-content width — seven buttons on a TUI provider is ~660px — so on a desktop card (~940px inside the sidebar) the details got whatever was left: ~275px.

**Fix:**
- Identity + actions share the top row; runtime status, readiness checklist and details sit **below** it at the card's full width.
- The row's breakpoint is container-relative (`@2xl`) rather than viewport-relative (`lg`) — the card is what has to be wide enough to split, and it is always narrower than the viewport by the sidebar.
- Wrapped action rows right-align (`@2xl:justify-end`); per-child `mt-2` collapses into one `space-y-2` on the body.
- Prose callouts (readiness checklist, benched banner, Grok/OrcaRouter notices) capped at `max-w-3xl` so they don't stretch to full width on a wide card.

## Test plan

- Reproduced and verified in a real browser at 1280px: the pre-fix layout matches the reported screenshot; post-fix the card is compact and readable.
- New regression test in `AIProviders.test.jsx` pins the structural contract (details are not a flex sibling of the action row) — confirmed to **fail** against the pre-fix layout.
- `client` suite green: 688 files / 8632 tests. Biome lint clean.