### PR TITLE
Make a routed media job unrenderable by a build rolled back past remoteMedia

### DIFF
--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -56,9 +56,9 @@ const codexEffortOf = (raw) => (typeof raw === 'string' ? raw.trim() : '');
 // Compact "engine / model" badge so a failed row tells the user *what* failed,
 // not just that it failed. Codex jobs carry `params.model`; local image/video
 // jobs carry `params.modelId`; training jobs carry a runtime + character. A
-// federated job is badged `remote` off the server-projected `renderer` field.
+// federated job is badged `remote` off the server-projected `job.renderer`.
 // Trims long HF repo paths to the tail segment.
-function modelLabel(params) {
+function modelLabel(params, renderer) {
   if (!params) return null;
   if (params.runtime || params.runId) {
     // Training job — surface the engine + who's being trained, not a prompt.
@@ -89,9 +89,9 @@ function modelLabel(params) {
   }
   const id = (params.modelId || '').trim();
   // A federated render ran on a peer, so it must not wear the local badge. The
-  // server projects `renderer` (and rebuilds `modelId` off the wire request)
+  // server projects `job.renderer` (and rebuilds `modelId` off the wire request)
   // for exactly this — the raw job nulls both to fail closed on a downgrade.
-  const where = params.renderer === 'remote' ? 'remote' : 'local';
+  const where = renderer === 'remote' ? 'remote' : 'local';
   if (!id) return where;
   const tail = id.includes('/') ? id.slice(id.lastIndexOf('/') + 1) : id;
   return `${where} / ${tail}`;
@@ -382,7 +382,11 @@ function JobRow({ job, onCancel, onRetry, onRunNow, onDelete }) {
     : 0;
   // Inline edit form for retry-with-overrides.
   const [editing, setEditing] = useState(false);
-  const canEdit = canRetry;
+  // A federated job renders from the wire request inside its `remoteMedia`
+  // marker, so a prompt/model edit here would never reach the peer — and the
+  // server re-normalizes the retry anyway. Offer the plain Retry, not the
+  // editor, rather than showing a form whose edits are silently discarded.
+  const canEdit = canRetry && job.renderer !== 'remote';
   const { isConfirming, requestDelete, cancelDelete, confirmDelete } = useConfirmDelete();
   return (
     <div className="bg-port-bg border border-port-border rounded p-2.5">
@@ -393,9 +397,9 @@ function JobRow({ job, onCancel, onRetry, onRunNow, onDelete }) {
             <div className="text-sm font-medium truncate">
               <span className="font-mono">{job.id.slice(0, 8)}</span>
               <span className="text-port-text-muted"> · {job.kind}</span>
-              {modelLabel(job.params) && (
+              {modelLabel(job.params, job.renderer) && (
                 <span className="text-port-text-muted" title={job.params.model || job.params.modelId || ''}>
-                  {' · '}{modelLabel(job.params)}
+                  {' · '}{modelLabel(job.params, job.renderer)}
                 </span>
               )}
               {job.position && job.status === 'queued' && (

--- a/client/src/components/media/MediaJobsQueue.jsx
+++ b/client/src/components/media/MediaJobsQueue.jsx
@@ -55,7 +55,8 @@ const codexEffortOf = (raw) => (typeof raw === 'string' ? raw.trim() : '');
 
 // Compact "engine / model" badge so a failed row tells the user *what* failed,
 // not just that it failed. Codex jobs carry `params.model`; local image/video
-// jobs carry `params.modelId`; training jobs carry a runtime + character.
+// jobs carry `params.modelId`; training jobs carry a runtime + character. A
+// federated job is badged `remote` off the server-projected `renderer` field.
 // Trims long HF repo paths to the tail segment.
 function modelLabel(params) {
   if (!params) return null;
@@ -87,9 +88,13 @@ function modelLabel(params) {
       : 'agy / configured default';
   }
   const id = (params.modelId || '').trim();
-  if (!id) return 'local';
+  // A federated render ran on a peer, so it must not wear the local badge. The
+  // server projects `renderer` (and rebuilds `modelId` off the wire request)
+  // for exactly this — the raw job nulls both to fail closed on a downgrade.
+  const where = params.renderer === 'remote' ? 'remote' : 'local';
+  if (!id) return where;
   const tail = id.includes('/') ? id.slice(id.lastIndexOf('/') + 1) : id;
-  return `local / ${tail}`;
+  return `${where} / ${tail}`;
 }
 
 // Embeds the live render queue inline on the Image / Video gen pages so the

--- a/client/src/components/media/MediaJobsQueue.test.jsx
+++ b/client/src/components/media/MediaJobsQueue.test.jsx
@@ -122,7 +122,8 @@ describe('MediaJobsQueue — federated render badge', () => {
       kind: 'image',
       status: 'running',
       queuedAt: '2026-06-19T10:00:00Z',
-      params: { prompt: 'a lighthouse at dusk', modelId: 'dev', renderer: 'remote' },
+      renderer: 'remote',
+      params: { prompt: 'a lighthouse at dusk', modelId: 'dev' },
     }]);
 
     render(<MediaJobsQueue kind="image" />);
@@ -137,6 +138,20 @@ describe('MediaJobsQueue — federated render badge', () => {
     render(<MediaJobsQueue kind="image" />);
 
     expect(await screen.findByText(/local \/ z-image-turbo/)).toBeInTheDocument();
+  });
+
+  it('offers plain Retry but not the editor on a failed federated job', async () => {
+    // A prompt/model edit would never reach the peer — the remote executor
+    // renders from the wire request inside the marker — so showing the form
+    // would silently discard what the user typed.
+    const user = userEvent.setup();
+    listMediaJobs.mockResolvedValue([{ ...failedLocalJob, id: 'remotefail0000beef', renderer: 'remote' }]);
+
+    render(<MediaJobsQueue kind="image" />);
+    await expandReel(user);
+
+    expect(await screen.findByRole('button', { name: /^Retry$/ })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Edit and retry')).not.toBeInTheDocument();
   });
 });
 

--- a/client/src/components/media/MediaJobsQueue.test.jsx
+++ b/client/src/components/media/MediaJobsQueue.test.jsx
@@ -113,6 +113,33 @@ describe('MediaJobsQueue — Creative Director renders', () => {
   });
 });
 
+describe('MediaJobsQueue — federated render badge', () => {
+  it('badges a peer-rendered job remote instead of claiming a local render', async () => {
+    // The server projects `renderer` and rebuilds `modelId` off the wire
+    // request — the raw job nulls both so a rolled-back build fails closed.
+    listMediaJobs.mockResolvedValue([{
+      id: 'remotejob0000beef',
+      kind: 'image',
+      status: 'running',
+      queuedAt: '2026-06-19T10:00:00Z',
+      params: { prompt: 'a lighthouse at dusk', modelId: 'dev', renderer: 'remote' },
+    }]);
+
+    render(<MediaJobsQueue kind="image" />);
+
+    expect(await screen.findByText(/remote \/ dev/)).toBeInTheDocument();
+    expect(screen.queryByText(/local \/ dev/)).not.toBeInTheDocument();
+  });
+
+  it('keeps the local badge on a job with no renderer projection', async () => {
+    listMediaJobs.mockResolvedValue([{ ...failedLocalJob, status: 'running', error: undefined }]);
+
+    render(<MediaJobsQueue kind="image" />);
+
+    expect(await screen.findByText(/local \/ z-image-turbo/)).toBeInTheDocument();
+  });
+});
+
 describe('MediaJobsQueue — Codex reasoning-effort retry control', () => {
   it('surfaces the job effort in the row label', async () => {
     const user = userEvent.setup();

--- a/server/lib/federatedMediaWire.js
+++ b/server/lib/federatedMediaWire.js
@@ -55,6 +55,32 @@ export function renderFederatedMediaAudioPrompt(profile) {
 }
 
 /**
+ * The prompt a finished media job actually rendered from.
+ *
+ * A routed job's top-level `params.prompt` is deliberately blank — that is what
+ * makes it unrenderable by a build rolled back past `remoteMedia` (#4683) — so
+ * anything recording what was rendered (completion hooks, the public queue
+ * projection) must read the marker instead. Audio renders it from the
+ * fixed-vocabulary profile, since free-form personal text never reaches an audio
+ * provider at all; image and video carry the submitted prompt itself.
+ *
+ * Returns `null` only when there is no prompt to report, so callers can tell
+ * "nothing was recorded" apart from "rendered with an empty prompt".
+ *
+ * @param {object} job - A media job (or anything with `.params`).
+ * @returns {string|null}
+ */
+export function effectiveJobPrompt(job) {
+  const marker = job?.params?.remoteMedia;
+  if (marker) {
+    const audioPrompt = renderFederatedMediaAudioPrompt(marker.profile);
+    if (audioPrompt) return audioPrompt;
+    if (typeof marker.request?.prompt === 'string') return marker.request.prompt;
+  }
+  return typeof job?.params?.prompt === 'string' ? job.params.prompt : null;
+}
+
+/**
  * Validate that a prompt string conforms to the canonical federated audio grammar.
  * Provider-side validation receives only the rendered text (not the local profile)
  * so older wire-v1 providers can accept newer consumers. Parses the canonical grammar

--- a/server/lib/federatedMediaWire.test.js
+++ b/server/lib/federatedMediaWire.test.js
@@ -3,6 +3,7 @@ import {
   federatedMediaAudioProfileSchema,
   federatedMediaProviderStatusSchema,
   federatedMediaProviderJobSchema,
+  effectiveJobPrompt,
   isFederatedMediaAudioPrompt,
   normalizeRequestedMediaKinds,
   renderFederatedMediaAudioPrompt,
@@ -144,5 +145,46 @@ describe('federated media privacy-safe audio profiles', () => {
       subject: 'alice@example.com',
     }).success).toBe(false);
     expect(renderFederatedMediaAudioPrompt({ ...profile, mood: 'a named person' })).toBeNull();
+  });
+});
+
+describe('effectiveJobPrompt', () => {
+  it('reads a routed job through to the wire request, not the blanked params', () => {
+    // A routed job's top-level prompt is blank on purpose (#4683). Anything
+    // recording what was rendered must read the marker, or it files a finished
+    // render with no prompt at all.
+    expect(effectiveJobPrompt({
+      kind: 'image',
+      params: {
+        prompt: '',
+        remoteMedia: { wireVersion: 1, request: { kind: 'image', modelId: 'dev', prompt: 'a lighthouse at dusk' } },
+      },
+    })).toBe('a lighthouse at dusk');
+  });
+
+  it('renders an audio job from its fixed-vocabulary profile', () => {
+    expect(effectiveJobPrompt({
+      kind: 'audio',
+      params: {
+        prompt: '',
+        remoteMedia: {
+          wireVersion: 1,
+          profile: { style: 'ambient', mood: 'calm', tempo: 'slow', energy: 'low', instruments: [] },
+          request: { engine: 'remote-audio', modelId: 'example/model' },
+        },
+      },
+    })).toBe('Instrumental ambient music with a calm mood, slow tempo, low energy. No vocals or spoken words.');
+  });
+
+  it('returns a local job\'s own prompt untouched', () => {
+    expect(effectiveJobPrompt({ kind: 'image', params: { prompt: 'a fox' } })).toBe('a fox');
+  });
+
+  it('distinguishes no prompt at all from a legitimately empty one', () => {
+    expect(effectiveJobPrompt({ kind: 'image', params: {} })).toBeNull();
+    expect(effectiveJobPrompt(undefined)).toBeNull();
+    // An img2img render genuinely has no text — that is an empty string, not
+    // "nothing was recorded".
+    expect(effectiveJobPrompt({ kind: 'image', params: { prompt: '' } })).toBe('');
   });
 });

--- a/server/routes/imageGen.js
+++ b/server/routes/imageGen.js
@@ -44,7 +44,6 @@ import { buildUniverseRunTag } from '../services/universeRunTag.js';
 import { getSettings } from '../services/settings.js';
 import { federatedMediaImageJobSubmissionSchema } from '../lib/validation.js';
 import { prepareRemoteMediaJob } from '../services/federatedMedia/remoteSubmission.js';
-import { routedJobParams } from '../services/federatedMedia/routedJobParams.js';
 
 const router = Router();
 
@@ -479,14 +478,13 @@ router.post('/generate', imageGenUploads, asyncHandler(async (req, res) => {
       mediaProviderPeerId: _peerId, mediaProviderEngine: _engine,
       mode: _mode, cloudModel: _cloudModel, ...jobParams
     } = params;
-    // The conditioning prompt and the model id ride ONLY inside the versioned
-    // marker. `routedJobParams` nulls every top-level field a LOCAL dispatcher
-    // would render from, so an older build that cannot route `remoteMedia`
-    // fails closed on its own model guard rather than quietly re-rendering this
-    // job for real on local hardware. See that module for the full contract.
+    // The prompt and model ride only inside the versioned marker: enqueueJob
+    // normalizes any job carrying one into the downgrade-safe shape, so this
+    // render cannot be re-run for real by a build rolled back past
+    // `remoteMedia`. Contract: services/federatedMedia/routedJobParams.js.
     const queued = enqueueJob({
       kind: 'image',
-      params: routedJobParams({ params: jobParams, remoteMedia }),
+      params: { ...jobParams, remoteMedia },
     });
     return res.json(queuedImageResponse({
       ...queued,

--- a/server/routes/imageGen.js
+++ b/server/routes/imageGen.js
@@ -44,6 +44,7 @@ import { buildUniverseRunTag } from '../services/universeRunTag.js';
 import { getSettings } from '../services/settings.js';
 import { federatedMediaImageJobSubmissionSchema } from '../lib/validation.js';
 import { prepareRemoteMediaJob } from '../services/federatedMedia/remoteSubmission.js';
+import { routedJobParams } from '../services/federatedMedia/routedJobParams.js';
 
 const router = Router();
 
@@ -478,13 +479,14 @@ router.post('/generate', imageGenUploads, asyncHandler(async (req, res) => {
       mediaProviderPeerId: _peerId, mediaProviderEngine: _engine,
       mode: _mode, cloudModel: _cloudModel, ...jobParams
     } = params;
-    // The conditioning prompt rides ONLY inside the versioned marker. An older
-    // build that cannot route `remoteMedia` therefore falls through to a local
-    // render with no prompt and no configured backend, rather than quietly
-    // re-rendering this job for real on local hardware.
+    // The conditioning prompt and the model id ride ONLY inside the versioned
+    // marker. `routedJobParams` nulls every top-level field a LOCAL dispatcher
+    // would render from, so an older build that cannot route `remoteMedia`
+    // fails closed on its own model guard rather than quietly re-rendering this
+    // job for real on local hardware. See that module for the full contract.
     const queued = enqueueJob({
       kind: 'image',
-      params: { ...jobParams, prompt: '', remoteMedia },
+      params: routedJobParams({ params: jobParams, remoteMedia }),
     });
     return res.json(queuedImageResponse({
       ...queued,

--- a/server/routes/imageGen.test.js
+++ b/server/routes/imageGen.test.js
@@ -1465,14 +1465,10 @@ describe('Image Gen Routes', () => {
       });
 
       const [{ params }] = mediaJobQueue.enqueueJob.mock.calls[0];
-      // Blank top-level prompt, nulled model + interpreter, no routing fields:
-      // an older build that cannot read `remoteMedia` falls through to a local
-      // render it has to refuse, rather than quietly re-running this job on
-      // local hardware. The shape contract itself lives in
-      // services/federatedMedia/routedJobParams.test.js.
-      expect(params.prompt).toBe('');
-      expect(params.modelId).toBeNull();
-      expect(params.pythonPath).toBeNull();
+      // The conditioning prompt rides only inside the versioned marker, and the
+      // routing fields never reach the queue. enqueueJob owns blanking the
+      // local render fields on top of this (#4683) — its own suites cover that,
+      // and enqueueJob is mocked here.
       expect(params.remoteMedia.request.prompt).toBe('a lighthouse at dusk');
       expect(params.remoteMedia.request.modelId).toBe('dev');
       expect(params).not.toHaveProperty('mediaProviderPeerId');

--- a/server/routes/imageGen.test.js
+++ b/server/routes/imageGen.test.js
@@ -1465,11 +1465,16 @@ describe('Image Gen Routes', () => {
       });
 
       const [{ params }] = mediaJobQueue.enqueueJob.mock.calls[0];
-      // Blank top-level prompt + no routing fields: an older build that cannot
-      // read `remoteMedia` falls through to a local render with nothing to
-      // render, rather than quietly re-running this job on local hardware.
+      // Blank top-level prompt, nulled model + interpreter, no routing fields:
+      // an older build that cannot read `remoteMedia` falls through to a local
+      // render it has to refuse, rather than quietly re-running this job on
+      // local hardware. The shape contract itself lives in
+      // services/federatedMedia/routedJobParams.test.js.
       expect(params.prompt).toBe('');
+      expect(params.modelId).toBeNull();
+      expect(params.pythonPath).toBeNull();
       expect(params.remoteMedia.request.prompt).toBe('a lighthouse at dusk');
+      expect(params.remoteMedia.request.modelId).toBe('dev');
       expect(params).not.toHaveProperty('mediaProviderPeerId');
       expect(params).not.toHaveProperty('mediaProviderEngine');
     });

--- a/server/routes/mediaJobs.js
+++ b/server/routes/mediaJobs.js
@@ -15,6 +15,7 @@ import { promptFromMedia } from '../services/mediaPromptFromMedia.js';
 import { CODEX_EFFORT_LEVELS } from '../lib/providerModels.js';
 import { sanitizeJob } from '../services/mediaJobQueue/sanitizeJob.js';
 import { validateVideoRetryParams } from '../services/videoGen/prepareParams.js';
+import { routedJobParams } from '../services/federatedMedia/routedJobParams.js';
 
 const router = Router();
 
@@ -293,7 +294,15 @@ router.post('/:id/retry', asyncHandler(async (req, res) => {
   // fallback (CODEX_IMAGEGEN_DEFAULT_EFFORT) take over, which a merged sentinel
   // string could not do (it would fail the CODEX_EFFORT_LEVELS validation).
   if (clearEffort) delete params.effort;
-  const result = enqueueJob({ kind: job.kind, params, owner: job.owner });
+  // A retried federated job must keep the downgrade-safe shape (#4683). The
+  // remote executor renders from `remoteMedia.request`, so a merged `prompt` /
+  // `modelId` override never reached the peer anyway — but leaving one on
+  // top-level params would hand a rolled-back build a locally-renderable job.
+  // Re-normalize instead of trusting the merge.
+  const retryParams = params.remoteMedia !== undefined
+    ? routedJobParams({ params, remoteMedia: params.remoteMedia })
+    : params;
+  const result = enqueueJob({ kind: job.kind, params: retryParams, owner: job.owner });
   // Drop the original failed/canceled row from archive — the new job inherits
   // its work, and leaving both visible just lets users keep clicking Retry on
   // the dead row and stacking duplicate jobs. If the prune returns false the

--- a/server/routes/mediaJobs.js
+++ b/server/routes/mediaJobs.js
@@ -263,7 +263,7 @@ router.post('/:id/retry', asyncHandler(async (req, res) => {
       { status: 409, code: 'JOB_RETRY_TEMP_UPLOAD' },
     );
   }
-  const body = validateRequest(retryBodySchema, req.body ?? {}) ?? {};
+  const body = validateRequest(retryBodySchema, req.body ?? {});
   const rawOverrides = body.params ?? {};
   // A `effort: 'default'` override is a clear-to-default signal, not a value to
   // merge — handled by deleting params.effort below so the render falls back to
@@ -307,8 +307,12 @@ router.post('/:id/retry', asyncHandler(async (req, res) => {
   //     recover; it must submit rather than skip preflight.
   // Cleared here, not in routedJobParams — boot restoration re-enqueues an
   // interrupted job under its ORIGINAL id and needs `reconcile: true` kept.
+  // `?? {}` because the predicate gates on PRESENCE, not truthiness — a
+  // hand-edited or peer-merged `remoteMedia: null` passes it, and this is the
+  // one marker consumer that would hard-crash rather than fail closed in the
+  // kind's remote module the way every other one does.
   if (isRemoteMediaJob({ kind: job.kind, params })) {
-    const { cancelRequested: _canceled, reconcile: _reconcile, ...marker } = params.remoteMedia;
+    const { cancelRequested: _canceled, reconcile: _reconcile, ...marker } = params.remoteMedia ?? {};
     params.remoteMedia = { ...marker, cancelRequested: false, reconcile: false };
   }
   const result = enqueueJob({ kind: job.kind, params, owner: job.owner });

--- a/server/routes/mediaJobs.js
+++ b/server/routes/mediaJobs.js
@@ -14,6 +14,7 @@ import { refineMediaPrompt } from '../services/mediaPromptRefiner.js';
 import { promptFromMedia } from '../services/mediaPromptFromMedia.js';
 import { CODEX_EFFORT_LEVELS } from '../lib/providerModels.js';
 import { sanitizeJob } from '../services/mediaJobQueue/sanitizeJob.js';
+import { isRemoteMediaJob } from '../services/mediaJobQueue/remoteMediaJob.js';
 import { validateVideoRetryParams } from '../services/videoGen/prepareParams.js';
 
 const router = Router();
@@ -293,10 +294,23 @@ router.post('/:id/retry', asyncHandler(async (req, res) => {
   // fallback (CODEX_IMAGEGEN_DEFAULT_EFFORT) take over, which a merged sentinel
   // string could not do (it would fail the CODEX_EFFORT_LEVELS validation).
   if (clearEffort) delete params.effort;
-  // A federated retry needs no special handling here: enqueueJob re-normalizes
-  // any job carrying a `remoteMedia` marker, so a merged prompt/model override
-  // (which never reached the peer anyway — the remote executor renders from
-  // `remoteMedia.request`) cannot restore a locally-renderable shape.
+  // enqueueJob re-normalizes any job carrying a `remoteMedia` marker, so a
+  // merged prompt/model override (which never reached the peer anyway — the
+  // remote executor renders from `remoteMedia.request`) cannot restore a
+  // locally-renderable shape. What the retry DOES have to reset is the marker's
+  // transient run state, which describes the finished attempt, not this one:
+  //   - `cancelRequested` — inherited from a canceled render, it makes the
+  //     executor's preflight abort the retry immediately, and the flag rides
+  //     along again on every further retry. That render could never be re-run.
+  //   - `reconcile` — "recover the provider job for this Idempotency-Key". The
+  //     retry gets a fresh queue id, which IS the key, so there is nothing to
+  //     recover; it must submit rather than skip preflight.
+  // Cleared here, not in routedJobParams — boot restoration re-enqueues an
+  // interrupted job under its ORIGINAL id and needs `reconcile: true` kept.
+  if (isRemoteMediaJob({ kind: job.kind, params })) {
+    const { cancelRequested: _canceled, reconcile: _reconcile, ...marker } = params.remoteMedia;
+    params.remoteMedia = { ...marker, cancelRequested: false, reconcile: false };
+  }
   const result = enqueueJob({ kind: job.kind, params, owner: job.owner });
   // Drop the original failed/canceled row from archive — the new job inherits
   // its work, and leaving both visible just lets users keep clicking Retry on

--- a/server/routes/mediaJobs.js
+++ b/server/routes/mediaJobs.js
@@ -15,7 +15,6 @@ import { promptFromMedia } from '../services/mediaPromptFromMedia.js';
 import { CODEX_EFFORT_LEVELS } from '../lib/providerModels.js';
 import { sanitizeJob } from '../services/mediaJobQueue/sanitizeJob.js';
 import { validateVideoRetryParams } from '../services/videoGen/prepareParams.js';
-import { routedJobParams } from '../services/federatedMedia/routedJobParams.js';
 
 const router = Router();
 
@@ -294,15 +293,11 @@ router.post('/:id/retry', asyncHandler(async (req, res) => {
   // fallback (CODEX_IMAGEGEN_DEFAULT_EFFORT) take over, which a merged sentinel
   // string could not do (it would fail the CODEX_EFFORT_LEVELS validation).
   if (clearEffort) delete params.effort;
-  // A retried federated job must keep the downgrade-safe shape (#4683). The
-  // remote executor renders from `remoteMedia.request`, so a merged `prompt` /
-  // `modelId` override never reached the peer anyway — but leaving one on
-  // top-level params would hand a rolled-back build a locally-renderable job.
-  // Re-normalize instead of trusting the merge.
-  const retryParams = params.remoteMedia !== undefined
-    ? routedJobParams({ params, remoteMedia: params.remoteMedia })
-    : params;
-  const result = enqueueJob({ kind: job.kind, params: retryParams, owner: job.owner });
+  // A federated retry needs no special handling here: enqueueJob re-normalizes
+  // any job carrying a `remoteMedia` marker, so a merged prompt/model override
+  // (which never reached the peer anyway — the remote executor renders from
+  // `remoteMedia.request`) cannot restore a locally-renderable shape.
+  const result = enqueueJob({ kind: job.kind, params, owner: job.owner });
   // Drop the original failed/canceled row from archive — the new job inherits
   // its work, and leaving both visible just lets users keep clicking Retry on
   // the dead row and stacking duplicate jobs. If the prune returns false the

--- a/server/routes/mediaJobs.test.js
+++ b/server/routes/mediaJobs.test.js
@@ -166,11 +166,12 @@ describe('mediaJobs routes', () => {
     expect(call.params.steps).toBe(40);
   });
 
-  it('POST /:id/retry re-normalizes a federated job so an override cannot restore a locally-renderable shape', async () => {
-    // The remote executor renders from `remoteMedia.request`, so these
-    // overrides never reached the peer anyway — but leaving them on top-level
-    // params would hand a build rolled back before `remoteMedia` a job it could
-    // render locally for real (#4683).
+  it('POST /:id/retry hands a federated job back to enqueueJob with its marker intact', async () => {
+    // The retry route deliberately does NOT special-case a federated job:
+    // enqueueJob re-normalizes anything carrying a marker into the
+    // downgrade-safe shape (#4683), so the override the user typed — which
+    // never reached the peer anyway, the remote executor renders from
+    // `remoteMedia.request` — cannot restore a locally-renderable job.
     const remoteMedia = {
       wireVersion: 1,
       peerId: '00000000-0000-4000-8000-0000000004f1',
@@ -185,10 +186,6 @@ describe('mediaJobs routes', () => {
       .send({ params: { prompt: 'something else', modelId: 'sdxl-base' } });
     expect(r.status).toBe(200);
     const { params } = stubs.enqueueJob.mock.calls[0][0];
-    expect(params.prompt).toBe('');
-    expect(params.modelId).toBeNull();
-    expect(params.pythonPath).toBeNull();
-    // The marker (and the surviving job params) still ride through untouched.
     expect(params.remoteMedia).toEqual(remoteMedia);
     expect(params.width).toBe(512);
   });

--- a/server/routes/mediaJobs.test.js
+++ b/server/routes/mediaJobs.test.js
@@ -186,8 +186,52 @@ describe('mediaJobs routes', () => {
       .send({ params: { prompt: 'something else', modelId: 'sdxl-base' } });
     expect(r.status).toBe(200);
     const { params } = stubs.enqueueJob.mock.calls[0][0];
-    expect(params.remoteMedia).toEqual(remoteMedia);
+    expect(params.remoteMedia.request).toEqual(remoteMedia.request);
+    expect(params.remoteMedia.peerId).toBe(remoteMedia.peerId);
     expect(params.width).toBe(512);
+  });
+
+  it('POST /:id/retry clears the marker run state so a CANCELED federated render can actually re-run', async () => {
+    // `cancelRequested` describes the finished attempt. Inherited, it makes the
+    // remote executor's preflight abort the retry on its first line — and rides
+    // along again on every further retry, so the render could never be re-run.
+    // `reconcile` is "recover the provider job for this Idempotency-Key"; the
+    // retry gets a fresh queue id, which IS the key, so there is nothing to
+    // recover and it must submit instead of skipping preflight.
+    jobStore.set('j-canceled', {
+      id: 'j-canceled', kind: 'image', owner: null, status: 'canceled',
+      params: {
+        prompt: '', modelId: null, pythonPath: null,
+        remoteMedia: {
+          wireVersion: 1,
+          peerId: '00000000-0000-4000-8000-0000000004f1',
+          cancelRequested: true,
+          reconcile: true,
+          request: { kind: 'image', engine: 'local', modelId: 'dev', prompt: 'a lighthouse at dusk' },
+        },
+      },
+    });
+    const r = await request(makeApp()).post('/api/media-jobs/j-canceled/retry').send({});
+    expect(r.status).toBe(200);
+    const { params } = stubs.enqueueJob.mock.calls[0][0];
+    expect(params.remoteMedia.cancelRequested).toBe(false);
+    expect(params.remoteMedia.reconcile).toBe(false);
+    // Everything that identifies the render survives.
+    expect(params.remoteMedia.peerId).toBe('00000000-0000-4000-8000-0000000004f1');
+    expect(params.remoteMedia.request.prompt).toBe('a lighthouse at dusk');
+  });
+
+  it('POST /:id/retry leaves a local job\'s params alone', async () => {
+    // Bypass probe for the marker reset above: a training job carrying a stray
+    // marker has no federated contract, so it must keep the local path.
+    jobStore.set('j-training', {
+      id: 'j-training', kind: 'training', owner: null, status: 'failed',
+      params: { runId: 'run-1', runtime: 'mflux', remoteMedia: { wireVersion: 1, cancelRequested: true } },
+    });
+    const r = await request(makeApp()).post('/api/media-jobs/j-training/retry').send({});
+    expect(r.status).toBe(200);
+    const { params } = stubs.enqueueJob.mock.calls[0][0];
+    expect(params.remoteMedia.cancelRequested).toBe(true);
   });
 
   it('POST /:id/retry accepts the editable video generation controls', async () => {

--- a/server/routes/mediaJobs.test.js
+++ b/server/routes/mediaJobs.test.js
@@ -221,6 +221,21 @@ describe('mediaJobs routes', () => {
     expect(params.remoteMedia.request.prompt).toBe('a lighthouse at dusk');
   });
 
+  it('POST /:id/retry survives a corrupt null marker instead of 500ing', async () => {
+    // `isRemoteMediaJob` gates on presence, not truthiness — a hand-edited
+    // media-jobs.json (or a peer-merged record) can hold `remoteMedia: null`
+    // and still be classified as routed. The queue's remote module is where a
+    // malformed marker fails closed; the retry route must not crash first.
+    jobStore.set('j-null-marker', {
+      id: 'j-null-marker', kind: 'image', owner: null, status: 'failed',
+      params: { prompt: '', modelId: null, remoteMedia: null },
+    });
+    const r = await request(makeApp()).post('/api/media-jobs/j-null-marker/retry').send({});
+    expect(r.status).toBe(200);
+    const { params } = stubs.enqueueJob.mock.calls[0][0];
+    expect(params.remoteMedia).toEqual({ cancelRequested: false, reconcile: false });
+  });
+
   it('POST /:id/retry leaves a local job\'s params alone', async () => {
     // Bypass probe for the marker reset above: a training job carrying a stray
     // marker has no federated contract, so it must keep the local path.

--- a/server/routes/mediaJobs.test.js
+++ b/server/routes/mediaJobs.test.js
@@ -166,6 +166,33 @@ describe('mediaJobs routes', () => {
     expect(call.params.steps).toBe(40);
   });
 
+  it('POST /:id/retry re-normalizes a federated job so an override cannot restore a locally-renderable shape', async () => {
+    // The remote executor renders from `remoteMedia.request`, so these
+    // overrides never reached the peer anyway — but leaving them on top-level
+    // params would hand a build rolled back before `remoteMedia` a job it could
+    // render locally for real (#4683).
+    const remoteMedia = {
+      wireVersion: 1,
+      peerId: '00000000-0000-4000-8000-0000000004f1',
+      request: { kind: 'image', engine: 'local', modelId: 'dev', prompt: 'a lighthouse at dusk' },
+    };
+    jobStore.set('j-remote', {
+      id: 'j-remote', kind: 'image', owner: null, status: 'failed',
+      params: { prompt: '', modelId: null, pythonPath: null, width: 512, remoteMedia },
+    });
+    const r = await request(makeApp())
+      .post('/api/media-jobs/j-remote/retry')
+      .send({ params: { prompt: 'something else', modelId: 'sdxl-base' } });
+    expect(r.status).toBe(200);
+    const { params } = stubs.enqueueJob.mock.calls[0][0];
+    expect(params.prompt).toBe('');
+    expect(params.modelId).toBeNull();
+    expect(params.pythonPath).toBeNull();
+    // The marker (and the surviving job params) still ride through untouched.
+    expect(params.remoteMedia).toEqual(remoteMedia);
+    expect(params.width).toBe(512);
+  });
+
   it('POST /:id/retry accepts the editable video generation controls', async () => {
     jobStore.set('j-video-edit', {
       id: 'j-video-edit', kind: 'video', owner: null, status: 'failed',

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -69,6 +69,7 @@ import { saveUploadedGalleryVideo } from '../services/videoUpload.js';
 import { JSON_BODY_LIMIT_BYTES } from '../lib/uploadLimits.js';
 import { createInstallLogger } from '../lib/installLogger.js';
 import { prepareRemoteMediaJob } from '../services/federatedMedia/remoteSubmission.js';
+import { effectiveJobPrompt } from '../lib/federatedMediaWire.js';
 
 const router = Router();
 
@@ -1265,6 +1266,17 @@ const pickJobParams = (params) => {
     if (names.length && icLoraSpecForMode(params.mode)?.referenceKind === 'image') {
       out.icReferenceImageFiles = names;
     }
+  }
+  // A federated render's prompt and model live only inside the versioned marker
+  // — the top-level copies are blanked so a downgraded build fails closed
+  // (#4683). Read through to the wire request, as the queue's own projection
+  // does, or a page reload mid-render resumes the form with an empty prompt and
+  // the LOCAL default model instead of the peer's.
+  if (params.remoteMedia) {
+    const prompt = effectiveJobPrompt({ params });
+    if (typeof prompt === 'string') out.prompt = prompt;
+    const { modelId } = params.remoteMedia.request ?? {};
+    if (typeof modelId === 'string' && modelId) out.modelId = modelId;
   }
   return out;
 };

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -69,7 +69,6 @@ import { saveUploadedGalleryVideo } from '../services/videoUpload.js';
 import { JSON_BODY_LIMIT_BYTES } from '../lib/uploadLimits.js';
 import { createInstallLogger } from '../lib/installLogger.js';
 import { prepareRemoteMediaJob } from '../services/federatedMedia/remoteSubmission.js';
-import { routedJobParams } from '../services/federatedMedia/routedJobParams.js';
 
 const router = Router();
 
@@ -1069,14 +1068,13 @@ router.post('/', frameImageUpload, asyncHandler(async (req, res) => {
       kind: 'video',
       request,
     });
-    // Prompt, dials, and model id ride ONLY inside the versioned marker.
-    // `routedJobParams` is shared with the routed image path so the two shapes
-    // cannot drift: an older build that can't route `remoteMedia` hits
-    // generateVideo's "Prompt is required" guard, and its `Unknown video model`
-    // guard behind that, instead of re-rendering this job locally.
+    // Prompt and dials ride only inside the versioned marker: enqueueJob
+    // normalizes any job carrying one into the downgrade-safe shape, so a build
+    // rolled back past `remoteMedia` cannot re-render this locally. Contract:
+    // services/federatedMedia/routedJobParams.js.
     const { jobId, position, status } = enqueueJob({
       kind: 'video',
-      params: routedJobParams({ remoteMedia }),
+      params: { remoteMedia },
     });
     return res.json({
       jobId,

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -70,6 +70,7 @@ import { JSON_BODY_LIMIT_BYTES } from '../lib/uploadLimits.js';
 import { createInstallLogger } from '../lib/installLogger.js';
 import { prepareRemoteMediaJob } from '../services/federatedMedia/remoteSubmission.js';
 import { effectiveJobPrompt } from '../lib/federatedMediaWire.js';
+import { isRemoteMediaJob } from '../services/mediaJobQueue/remoteMediaJob.js';
 
 const router = Router();
 
@@ -1231,7 +1232,8 @@ const ACTIVE_JOB_PARAM_FIELDS = [
   // path, which the whitelist exists to keep off this surface).
   'icStrength', 'icAttentionStrength', 'icSkipStage2',
 ];
-const pickJobParams = (params) => {
+const pickJobParams = (job) => {
+  const params = job?.params;
   if (!params || typeof params !== 'object') return {};
   const out = {};
   for (const k of ACTIVE_JOB_PARAM_FIELDS) {
@@ -1272,8 +1274,8 @@ const pickJobParams = (params) => {
   // (#4683). Read through to the wire request, as the queue's own projection
   // does, or a page reload mid-render resumes the form with an empty prompt and
   // the LOCAL default model instead of the peer's.
-  if (params.remoteMedia) {
-    const prompt = effectiveJobPrompt({ params });
+  if (isRemoteMediaJob(job)) {
+    const prompt = effectiveJobPrompt(job);
     if (typeof prompt === 'string') out.prompt = prompt;
     const { modelId } = params.remoteMedia.request ?? {};
     if (typeof modelId === 'string' && modelId) out.modelId = modelId;
@@ -1293,7 +1295,7 @@ router.get('/active', (_req, res) => {
       generationId: job.id,
       status: job.status,
       position: job.position,
-      params: pickJobParams(job.params),
+      params: pickJobParams(job),
     },
   });
 });

--- a/server/routes/videoGen.js
+++ b/server/routes/videoGen.js
@@ -69,6 +69,7 @@ import { saveUploadedGalleryVideo } from '../services/videoUpload.js';
 import { JSON_BODY_LIMIT_BYTES } from '../lib/uploadLimits.js';
 import { createInstallLogger } from '../lib/installLogger.js';
 import { prepareRemoteMediaJob } from '../services/federatedMedia/remoteSubmission.js';
+import { routedJobParams } from '../services/federatedMedia/routedJobParams.js';
 
 const router = Router();
 
@@ -1068,13 +1069,14 @@ router.post('/', frameImageUpload, asyncHandler(async (req, res) => {
       kind: 'video',
       request,
     });
-    // Prompt and dials ride ONLY inside the versioned marker, and the job
-    // carries no pythonPath. An older build that can't route `remoteMedia`
-    // therefore hits generateVideo's "Prompt is required" guard and fails
-    // closed instead of re-rendering this job locally.
+    // Prompt, dials, and model id ride ONLY inside the versioned marker.
+    // `routedJobParams` is shared with the routed image path so the two shapes
+    // cannot drift: an older build that can't route `remoteMedia` hits
+    // generateVideo's "Prompt is required" guard, and its `Unknown video model`
+    // guard behind that, instead of re-rendering this job locally.
     const { jobId, position, status } = enqueueJob({
       kind: 'video',
-      params: { prompt: '', modelId: request.modelId, remoteMedia },
+      params: routedJobParams({ remoteMedia }),
     });
     return res.json({
       jobId,

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -2293,14 +2293,10 @@ describe('videoGen routes', () => {
       });
 
       const [{ params }] = mediaJobQueue.enqueueJob.mock.calls[0];
-      // Blank top-level prompt, nulled model + interpreter: an older build that
-      // cannot read `remoteMedia` hits generateVideo's "Prompt is required"
-      // guard (and its model guard behind that) instead of re-rendering this
-      // job on local hardware. Shape contract:
-      // services/federatedMedia/routedJobParams.test.js.
-      expect(params.prompt).toBe('');
-      expect(params.modelId).toBeNull();
-      expect(params.pythonPath).toBeNull();
+      // Prompt and dials ride only inside the versioned marker; no local render
+      // input is carried over at all. enqueueJob owns blanking the rest (#4683)
+      // — its own suites cover that, and enqueueJob is mocked here.
+      expect(params).toEqual({ remoteMedia: expect.objectContaining({ peerId: federatedPeerId }) });
       expect(params.remoteMedia.request.prompt).toBe('a slow pan across a harbour');
       expect(params.remoteMedia.request.modelId).toBe('ltx2');
     });

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -2293,12 +2293,16 @@ describe('videoGen routes', () => {
       });
 
       const [{ params }] = mediaJobQueue.enqueueJob.mock.calls[0];
-      // Blank top-level prompt + no pythonPath: an older build that cannot read
-      // `remoteMedia` hits generateVideo's "Prompt is required" guard and fails
-      // closed instead of re-rendering this job on local hardware.
+      // Blank top-level prompt, nulled model + interpreter: an older build that
+      // cannot read `remoteMedia` hits generateVideo's "Prompt is required"
+      // guard (and its model guard behind that) instead of re-rendering this
+      // job on local hardware. Shape contract:
+      // services/federatedMedia/routedJobParams.test.js.
       expect(params.prompt).toBe('');
-      expect(params).not.toHaveProperty('pythonPath');
+      expect(params.modelId).toBeNull();
+      expect(params.pythonPath).toBeNull();
       expect(params.remoteMedia.request.prompt).toBe('a slow pan across a harbour');
+      expect(params.remoteMedia.request.modelId).toBe('ltx2');
     });
 
     it('requires an explicit provider model instead of falling back to a local default', async () => {

--- a/server/routes/videoGen.test.js
+++ b/server/routes/videoGen.test.js
@@ -1958,6 +1958,37 @@ describe('videoGen routes', () => {
       expect(r.body.activeJob.params.prompt).toBe('P running');
     });
 
+    it('resumes a federated render from its marker, not the blanked local fields', async () => {
+      // The routed job's top-level prompt/model are blanked so a downgraded
+      // build fails closed (#4683). Without reading through to the wire
+      // request, a reload mid-render would repopulate the form with an empty
+      // prompt and the LOCAL default model instead of the peer's.
+      mediaJobQueue.listJobs.mockImplementation(listJobsByFilter([{
+        id: 'remote-running',
+        kind: 'video',
+        status: 'running',
+        position: 1,
+        params: {
+          prompt: '',
+          modelId: null,
+          pythonPath: null,
+          remoteMedia: {
+            wireVersion: 1,
+            peerId: federatedPeerId,
+            request: {
+              kind: 'video', engine: 'local', modelId: 'ltx2', prompt: 'a slow pan across a harbour',
+            },
+          },
+        },
+      }]));
+      const r = await request(app).get('/api/video-gen/active');
+      expect(r.status).toBe(200);
+      expect(r.body.activeJob.params.prompt).toBe('a slow pan across a harbour');
+      expect(r.body.activeJob.params.modelId).toBe('ltx2');
+      // The marker itself stays off this surface — it carries peer routing state.
+      expect(r.body.activeJob.params).not.toHaveProperty('remoteMedia');
+    });
+
     // Selection of the newest queued (not oldest) matches /cancel's fallback
     // selection — see the surrounding comment in routes/videoGen.js. Diverging
     // would mean Cancel from a resumed-queued page targets a different job.

--- a/server/services/federatedMedia/routedJobParams.js
+++ b/server/services/federatedMedia/routedJobParams.js
@@ -1,10 +1,13 @@
 /**
  * The persisted params shape for a media job that renders on a federated peer.
  *
- * Both routed generate paths (`routes/imageGen.js`, `routes/videoGen.js`) build
- * their queue params through this one helper so the two cannot drift: the
- * downgrade contract below only holds if every routed job carries the same
- * shape.
+ * `enqueueJob` applies this to EVERY job carrying a `remoteMedia` marker — no
+ * route calls it directly. The contract below only holds if it is unbypassable:
+ * a helper each routed enqueue site had to remember would be one forgotten call
+ * away from shipping a job a rolled-back build renders locally for real, with
+ * no guard test to catch it. It normalizes the fields every kind shares; a kind
+ * with its own conditioning input still blanks that itself (audio's `lyrics`,
+ * `routes/music.js`).
  *
  * ## Downgrade contract (#4683)
  *
@@ -40,10 +43,12 @@
  * @param {object} [args.params] - Job params that survive routing (destination
  *   tags, dimensions, seed). Local-only routing/backend selectors are stripped
  *   by the caller before they get here.
- * @param {object} args.remoteMedia - The versioned marker from prepareRemoteMediaJob.
+ * @param {object} [args.remoteMedia] - The versioned marker from
+ *   prepareRemoteMediaJob. Defaults to the one already on `params` — which is
+ *   how enqueueJob calls it, having selected the job on that same marker.
  * @returns {object} Params to persist on the queued proxy job.
  */
-export const routedJobParams = ({ params = {}, remoteMedia }) => ({
+export const routedJobParams = ({ params = {}, remoteMedia = params.remoteMedia }) => ({
   ...params,
   prompt: '',
   modelId: null,

--- a/server/services/federatedMedia/routedJobParams.js
+++ b/server/services/federatedMedia/routedJobParams.js
@@ -1,0 +1,52 @@
+/**
+ * The persisted params shape for a media job that renders on a federated peer.
+ *
+ * Both routed generate paths (`routes/imageGen.js`, `routes/videoGen.js`) build
+ * their queue params through this one helper so the two cannot drift: the
+ * downgrade contract below only holds if every routed job carries the same
+ * shape.
+ *
+ * ## Downgrade contract (#4683)
+ *
+ * PortOS is distributed software — one machine of a federated pair can be
+ * rolled back to a build that predates `remoteMedia` while the other keeps
+ * queueing routed jobs. A legacy build ignores the unknown `remoteMedia` key
+ * and dispatches the job to its LOCAL renderer, so the top-level params must be
+ * unrenderable there:
+ *
+ * - `prompt: ''` — the conditioning text rides only inside the versioned
+ *   marker. `generateVideo` refuses a blank prompt outright; `generateImage`
+ *   deliberately allows one (img2img / regen), so it needs the guard below.
+ * - `modelId: null` — NOT a deleted key. `generateImage` and `generateVideo`
+ *   both declare `modelId` as a default parameter (`= 'dev'` /
+ *   `= defaultVideoModelId()`), and a JS default fires on `undefined` only —
+ *   dropping the key would silently select the local default and render for
+ *   real wherever that model happens to be installed. An explicit `null`
+ *   suppresses the default and lands on the `Unknown or unsupported model`
+ *   guard every time, whatever is installed.
+ * - `pythonPath: null` — belt and braces for the legacy mflux/imagine_win path,
+ *   which refuses an unconfigured interpreter (`IMAGE_GEN_NOT_CONFIGURED`).
+ *
+ * A persisted `renderer: 'remote'` discriminator was considered and rejected:
+ * an older build has no such check, so it would ignore the field entirely and
+ * buy no protection. The remote/local distinction is surfaced for DISPLAY
+ * instead, off the marker, in `mediaJobQueue/sanitizeJob.js`.
+ *
+ * Nothing a current build reads is lost — the remote adapters
+ * (`imageGen/remote.js`, `videoGen/remote.js`) take the prompt and the model id
+ * from `remoteMedia.request`, which is the same body that goes over the wire.
+ *
+ * @param {object} args
+ * @param {object} [args.params] - Job params that survive routing (destination
+ *   tags, dimensions, seed). Local-only routing/backend selectors are stripped
+ *   by the caller before they get here.
+ * @param {object} args.remoteMedia - The versioned marker from prepareRemoteMediaJob.
+ * @returns {object} Params to persist on the queued proxy job.
+ */
+export const routedJobParams = ({ params = {}, remoteMedia }) => ({
+  ...params,
+  prompt: '',
+  modelId: null,
+  pythonPath: null,
+  remoteMedia,
+});

--- a/server/services/federatedMedia/routedJobParams.test.js
+++ b/server/services/federatedMedia/routedJobParams.test.js
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { routedJobParams } from './routedJobParams.js';
+
+const PEER_ID = '00000000-0000-4000-8000-0000000004f1';
+
+const remoteMedia = {
+  wireVersion: 1,
+  peerId: PEER_ID,
+  reconcile: false,
+  cancelRequested: false,
+  request: {
+    kind: 'image',
+    engine: 'local',
+    modelId: 'dev',
+    prompt: 'a lighthouse at dusk',
+    width: 512,
+    height: 512,
+  },
+};
+
+describe('routedJobParams', () => {
+  it('nulls every top-level field a local dispatcher would render from', () => {
+    const params = routedJobParams({
+      params: { prompt: 'a lighthouse at dusk', modelId: 'dev', width: 512, height: 512 },
+      remoteMedia,
+    });
+
+    expect(params.prompt).toBe('');
+    // `null`, NOT absent — generateImage/generateVideo declare `modelId` as a
+    // default parameter, which fires on `undefined` only.
+    expect(params.modelId).toBeNull();
+    expect(params).toHaveProperty('modelId');
+    expect(params.pythonPath).toBeNull();
+    expect(params).toHaveProperty('pythonPath');
+  });
+
+  it('keeps the versioned marker and the destination tags a completion hook needs', () => {
+    const params = routedJobParams({
+      params: { universeRun: 'run-1', catalogAttach: true, width: 512 },
+      remoteMedia,
+    });
+
+    expect(params.remoteMedia).toEqual(remoteMedia);
+    expect(params.universeRun).toBe('run-1');
+    expect(params.catalogAttach).toBe(true);
+    expect(params.width).toBe(512);
+  });
+
+  it('still produces the guarded shape when the caller passes no params at all', () => {
+    // The video route routes without carrying any surviving job params.
+    const params = routedJobParams({ remoteMedia });
+
+    expect(params).toEqual({ prompt: '', modelId: null, pythonPath: null, remoteMedia });
+  });
+});
+
+// The point of the shape above: a machine rolled back to a build that predates
+// `remoteMedia` ignores the marker and dispatches the job to its LOCAL renderer.
+// These feed the routed params straight to the real local entry points — the
+// surface a legacy dispatcher would land on — and assert they refuse.
+describe('downgrade to a pre-remoteMedia build', () => {
+  let tmpRegistryDir;
+  let priorRegistryEnv;
+  let generateImage;
+  let generateVideo;
+  let getImageModels;
+  let LOCAL_IMAGEGEN_DEFAULT_MODEL;
+
+  beforeAll(async () => {
+    // Same guard local.test.js uses: point the model registry at a temp file so
+    // the seed-on-read path can't write into the repo's data dir.
+    tmpRegistryDir = mkdtempSync(join(tmpdir(), 'portos-routed-params-test-'));
+    priorRegistryEnv = process.env.PORTOS_MEDIA_MODELS_FILE;
+    process.env.PORTOS_MEDIA_MODELS_FILE = join(tmpRegistryDir, 'media-models.json');
+    vi.resetModules();
+    ({ generateImage } = await import('../imageGen/local.js'));
+    ({ generateVideo } = await import('../videoGen/local.js'));
+    ({ getImageModels } = await import('../../lib/mediaModels.js'));
+    ({ LOCAL_IMAGEGEN_DEFAULT_MODEL } = await import('../imageGen/modes.js'));
+  });
+
+  afterAll(() => {
+    if (priorRegistryEnv === undefined) delete process.env.PORTOS_MEDIA_MODELS_FILE;
+    else process.env.PORTOS_MEDIA_MODELS_FILE = priorRegistryEnv;
+    rmSync(tmpRegistryDir, { recursive: true, force: true });
+  });
+
+  // Bypass probe for the two guards below — without it they could pass for the
+  // wrong reason. The shipped default model IS registered, so the "just delete
+  // the modelId key" variant of this fix would have resolved a real model and
+  // rendered for real wherever its weights are installed. That is precisely why
+  // the routed params carry an explicit `null` instead of dropping the key.
+  it('would have resolved the shipped default if modelId were merely absent', () => {
+    expect(getImageModels().map((m) => m.id)).toContain(LOCAL_IMAGEGEN_DEFAULT_MODEL);
+  });
+
+  it('refuses a routed image job — generateImage permits a blank prompt, so the model guard is the one that fires', async () => {
+    const params = routedJobParams({
+      params: { width: 512, height: 512, seed: 42 },
+      remoteMedia,
+    });
+
+    await expect(generateImage(params)).rejects.toThrow(/Unknown or unsupported model/);
+  });
+
+  it('refuses a routed video job on the prompt guard, and on the model guard behind it', async () => {
+    const params = routedJobParams({ remoteMedia });
+
+    await expect(generateVideo(params)).rejects.toThrow(/Prompt is required/);
+    // Second, independent guard: even a build whose prompt check ever loosened
+    // has nothing to render with.
+    await expect(generateVideo({ ...params, prompt: 'a lighthouse at dusk' }))
+      .rejects.toThrow(/Unknown video model/);
+  });
+});

--- a/server/services/federatedMedia/routedJobParams.test.js
+++ b/server/services/federatedMedia/routedJobParams.test.js
@@ -31,11 +31,10 @@ describe('routedJobParams', () => {
 
     expect(params.prompt).toBe('');
     // `null`, NOT absent — generateImage/generateVideo declare `modelId` as a
-    // default parameter, which fires on `undefined` only.
+    // default parameter, which fires on `undefined` only. `toBeNull` is the
+    // assertion that distinguishes the two.
     expect(params.modelId).toBeNull();
-    expect(params).toHaveProperty('modelId');
     expect(params.pythonPath).toBeNull();
-    expect(params).toHaveProperty('pythonPath');
   });
 
   it('keeps the versioned marker and the destination tags a completion hook needs', () => {
@@ -55,6 +54,14 @@ describe('routedJobParams', () => {
     const params = routedJobParams({ remoteMedia });
 
     expect(params).toEqual({ prompt: '', modelId: null, pythonPath: null, remoteMedia });
+  });
+
+  it('defaults the marker off params, which is how enqueueJob calls it', () => {
+    const params = routedJobParams({ params: { modelId: 'dev', prompt: 'edited', remoteMedia } });
+
+    expect(params.remoteMedia).toEqual(remoteMedia);
+    expect(params.prompt).toBe('');
+    expect(params.modelId).toBeNull();
   });
 });
 

--- a/server/services/mediaJobQueue/index.js
+++ b/server/services/mediaJobQueue/index.js
@@ -463,7 +463,10 @@ export async function initMediaJobQueue() {
       } else if (j.status === 'queued') {
         queue.push({ ...j, params: restoredParams(j) });
       } else {
-        archive.push(j);
+        // The archive needs it too: a rolled-back build restores these rows,
+        // shows them in the Render Queue's recent reel, and its Retry hands the
+        // stored params straight to a local render.
+        archive.push({ ...j, params: restoredParams(j) });
       }
     }
     // Re-attach jobs resume ahead of everything else (they were mid-flight), so

--- a/server/services/mediaJobQueue/index.js
+++ b/server/services/mediaJobQueue/index.js
@@ -45,6 +45,8 @@ import { trainingEvents } from '../loraTraining/events.js';
 import { audioGenEvents } from '../audioGen/events.js';
 import { getSettings } from '../settings.js';
 import { IMAGE_GEN_MODE, CLOUD_IMAGE_GEN_MODES } from '../imageGen/modes.js';
+import { REMOTE_MEDIA_MODULES, isRemoteMediaJob } from './remoteMediaJob.js';
+import { routedJobParams } from '../federatedMedia/routedJobParams.js';
 
 // Cloud-CLI jobs (Codex/Grok/Agy images, Grok videos) share one parallel lane —
 // each render
@@ -57,23 +59,11 @@ const isCloudImageJob = (j) =>
   (j.kind === 'image' && CLOUD_IMAGE_GEN_MODES.includes(j.params?.mode))
   || (j.kind === 'video' && j.params?.mode === IMAGE_GEN_MODE.GROK);
 
-// The federatable kinds and the adapter each one dispatches to, in one map so
-// the two cannot drift apart. Kinds are listed explicitly rather than inferred
-// from the marker alone: a 'training' job has no federated contract, so a marker
-// on one is corrupt state that must keep taking the local path, not a routing
-// instruction.
-const REMOTE_MEDIA_MODULES = {
-  audio: () => import('../audioGen/remote.js'),
-  image: () => import('../imageGen/remote.js'),
-  video: () => import('../videoGen/remote.js'),
-};
-
-// Presence, not truthiness of individual nested fields, selects the remote
-// adapter. Persisted queue state is user-editable; a malformed marker must fail
-// closed in the kind's remote module rather than accidentally falling through to
-// a local engine with a remote-only model id.
-export const isRemoteMediaJob = (job) =>
-  Object.hasOwn(REMOTE_MEDIA_MODULES, job?.kind ?? '') && job.params?.remoteMedia !== undefined;
+// The federated-kind map and its predicate live in ./remoteMediaJob.js so light
+// consumers (sanitizeJob, route handlers) can ask "is this routed?" without
+// pulling the queue in. Re-exported here because that is where callers have
+// always found it.
+export { isRemoteMediaJob };
 
 const jobLane = (job) => {
   if (isRemoteMediaJob(job)) return 'remote';
@@ -1062,17 +1052,24 @@ export function enqueueJob({ kind, params, owner = null }) {
     throw new Error(`enqueueJob: invalid kind '${kind}'`);
   }
   const id = randomUUID();
+  // Every routed job is normalized HERE rather than at each caller (#4683): the
+  // downgrade contract only holds if it is unbypassable, and a future enqueue
+  // site that forgets the helper would ship a job a rolled-back build renders
+  // locally for real. See services/federatedMedia/routedJobParams.js.
+  const safeParams = isRemoteMediaJob({ kind, params })
+    ? routedJobParams({ params })
+    : params;
   const job = {
     id,
     kind,
     owner,
     status: 'queued',
     queuedAt: new Date().toISOString(),
-    params,
+    params: safeParams,
     // position counts "where you sit in your lane" — a running job in the
     // same lane occupies slot 1, then same-lane queued jobs follow.
     position: (() => {
-      const candidate = { kind, params };
+      const candidate = { kind, params: safeParams };
       const lane = jobLane(candidate);
       const laneQueue = queue.filter((j) => jobLane(j) === lane);
       const liveCount = lane === 'cloud'

--- a/server/services/mediaJobQueue/index.js
+++ b/server/services/mediaJobQueue/index.js
@@ -71,6 +71,16 @@ const jobLane = (job) => {
   return 'gpu';
 };
 
+// Boot restoration is the second way a job enters the queue, so it needs the
+// same routed-job normalization enqueueJob applies (#4683). A job written by a
+// build older than that fix still carries the top-level model id a legacy
+// dispatcher would render from; re-normalizing on restore (and letting the boot
+// persist write the safe shape back) means upgrading and then rolling back
+// cannot resurrect a locally-renderable routed job.
+const restoredParams = (job) => (isRemoteMediaJob(job)
+  ? routedJobParams({ params: job.params })
+  : job.params);
+
 const JOBS_FILE = join(PATHS.data, 'media-jobs.json');
 const COMPLETED_TTL_MS = 24 * 60 * 60 * 1000;
 const MAX_PERSISTED_ARCHIVE = 500;
@@ -403,13 +413,16 @@ export async function initMediaJobQueue() {
             ...j,
             status: 'queued',
             cancelRequested: marker?.cancelRequested === true,
-            params: {
-              ...j.params,
-              remoteMedia: {
-                ...(marker && typeof marker === 'object' && !Array.isArray(marker) ? marker : {}),
-                reconcile: true,
+            params: restoredParams({
+              ...j,
+              params: {
+                ...j.params,
+                remoteMedia: {
+                  ...(marker && typeof marker === 'object' && !Array.isArray(marker) ? marker : {}),
+                  reconcile: true,
+                },
               },
-            },
+            }),
           });
           console.log(`🔁 media-job [${j.id.slice(0, 8)}] remote ${j.kind} interrupted — re-enqueued for reconciliation`);
           continue;
@@ -448,7 +461,7 @@ export async function initMediaJobQueue() {
           safeUnlinkUpload(p);
         }
       } else if (j.status === 'queued') {
-        queue.push({ ...j });
+        queue.push({ ...j, params: restoredParams(j) });
       } else {
         archive.push(j);
       }

--- a/server/services/mediaJobQueue/index.test.js
+++ b/server/services/mediaJobQueue/index.test.js
@@ -910,6 +910,50 @@ describe('Audio kind (#1928)', () => {
     expect(stubs.generateImage).not.toHaveBeenCalled();
   });
 
+  it('re-normalizes a routed job restored from a snapshot an older build wrote', async () => {
+    // Boot restoration is the second way a job enters the queue. A record
+    // persisted before #4683 still carries the top-level model id a legacy
+    // dispatcher would render from, so upgrading and then rolling back would
+    // otherwise resurrect a locally-renderable job.
+    writeFileSync(join(tempDataDir, 'media-jobs.json'), JSON.stringify({
+      jobs: [
+        {
+          id: 'aaaaaaaa-0000-4000-8000-000000000001',
+          kind: 'image',
+          status: 'queued',
+          queuedAt: '2026-08-01T00:00:00.000Z',
+          params: {
+            prompt: 'a harbour', modelId: 'dev', pythonPath: '/usr/bin/python3',
+            remoteMedia: remoteImageMediaParams(),
+          },
+        },
+        {
+          id: 'aaaaaaaa-0000-4000-8000-000000000002',
+          kind: 'image',
+          status: 'running',
+          queuedAt: '2026-08-01T00:00:00.000Z',
+          params: {
+            prompt: 'a harbour', modelId: 'dev', pythonPath: '/usr/bin/python3',
+            remoteMedia: remoteImageMediaParams(),
+          },
+        },
+      ],
+    }));
+    stubs.generateImageRemote.mockImplementation(() => new Promise(() => {}));
+    await importFresh();
+    await mediaJobQueue.initMediaJobQueue();
+
+    for (const id of ['aaaaaaaa-0000-4000-8000-000000000001', 'aaaaaaaa-0000-4000-8000-000000000002']) {
+      const { params } = mediaJobQueue.getJob(id);
+      expect(params.prompt).toBe('');
+      expect(params.modelId).toBeNull();
+      expect(params.pythonPath).toBeNull();
+      expect(params.remoteMedia.request.prompt).toBe('a harbour');
+    }
+    // The interrupted running job still gets its reconcile flag.
+    expect(mediaJobQueue.getJob('aaaaaaaa-0000-4000-8000-000000000002').params.remoteMedia.reconcile).toBe(true);
+  });
+
   it('leaves a training job carrying a stray marker on the local path', () => {
     // Bypass probe for the normalization above: `training` has no federated
     // contract, so a marker on one is corrupt state — blanking its params would

--- a/server/services/mediaJobQueue/index.test.js
+++ b/server/services/mediaJobQueue/index.test.js
@@ -880,6 +880,48 @@ describe('Audio kind (#1928)', () => {
     await waitFor(() => mediaJobQueue.getJob(remote.jobId)?.status === 'completed');
   });
 
+  // #4683 — the downgrade contract is enforced HERE, not at each routed enqueue
+  // site, so a future caller that forgets to blank the local render fields can't
+  // ship a job a build rolled back past `remoteMedia` would render for real.
+  it('normalizes any enqueued job carrying a marker into the downgrade-safe shape', async () => {
+    stubs.generateImageRemote.mockImplementation(() => new Promise(() => {}));
+    // Deliberately hostile input: a caller that passed the local render fields
+    // straight through, exactly as a forgotten normalization would.
+    const remote = mediaJobQueue.enqueueJob({
+      kind: 'image',
+      params: {
+        prompt: 'a harbour',
+        modelId: 'dev',
+        pythonPath: '/usr/bin/python3',
+        width: 512,
+        remoteMedia: remoteImageMediaParams(),
+      },
+    });
+
+    const { params } = mediaJobQueue.getJob(remote.jobId);
+    expect(params.prompt).toBe('');
+    expect(params.modelId).toBeNull();
+    expect(params.pythonPath).toBeNull();
+    // Surviving job params and the marker itself ride through untouched, and
+    // the job still routes to the remote adapter on this build.
+    expect(params.width).toBe(512);
+    expect(params.remoteMedia.request.prompt).toBe('a harbour');
+    await waitFor(() => stubs.generateImageRemote.mock.calls.length === 1);
+    expect(stubs.generateImage).not.toHaveBeenCalled();
+  });
+
+  it('leaves a training job carrying a stray marker on the local path', () => {
+    // Bypass probe for the normalization above: `training` has no federated
+    // contract, so a marker on one is corrupt state — blanking its params would
+    // destroy a real local run.
+    const job = mediaJobQueue.enqueueJob({
+      kind: 'training',
+      params: { runId: 'run-1', runtime: 'mflux', modelId: 'dev', remoteMedia: remoteImageMediaParams() },
+    });
+
+    expect(mediaJobQueue.getJob(job.jobId).params.modelId).toBe('dev');
+  });
+
   it('persists cancellation intent before signaling a running remote adapter', async () => {
     stubs.generateAudioRemote.mockImplementation(() => new Promise(() => {}));
     const remote = mediaJobQueue.enqueueJob({

--- a/server/services/mediaJobQueue/index.test.js
+++ b/server/services/mediaJobQueue/index.test.js
@@ -954,6 +954,37 @@ describe('Audio kind (#1928)', () => {
     expect(mediaJobQueue.getJob('aaaaaaaa-0000-4000-8000-000000000002').params.remoteMedia.reconcile).toBe(true);
   });
 
+  it('re-normalizes an ARCHIVED routed job too — the recent reel is a retry surface', async () => {
+    // A rolled-back build restores archived rows, shows them in the Render
+    // Queue's recent reel, and its Retry hands the stored params straight to a
+    // local render. Leaving the archive un-normalized would keep #4683 open
+    // through that path.
+    writeFileSync(join(tempDataDir, 'media-jobs.json'), JSON.stringify({
+      jobs: [{
+        id: 'bbbbbbbb-0000-4000-8000-000000000001',
+        kind: 'image',
+        status: 'failed',
+        error: 'peer unreachable',
+        queuedAt: new Date(Date.now() - 60_000).toISOString(),
+        // Inside the archive's 24h retention window, or the boot prune drops it.
+        completedAt: new Date().toISOString(),
+        params: {
+          prompt: 'a harbour', modelId: 'dev', pythonPath: '/usr/bin/python3',
+          remoteMedia: remoteImageMediaParams(),
+        },
+      }],
+    }));
+    await importFresh();
+    await mediaJobQueue.initMediaJobQueue();
+
+    const { params, status } = mediaJobQueue.getJob('bbbbbbbb-0000-4000-8000-000000000001');
+    expect(status).toBe('failed');
+    expect(params.prompt).toBe('');
+    expect(params.modelId).toBeNull();
+    expect(params.pythonPath).toBeNull();
+    expect(params.remoteMedia.request.prompt).toBe('a harbour');
+  });
+
   it('leaves a training job carrying a stray marker on the local path', () => {
     // Bypass probe for the normalization above: `training` has no federated
     // contract, so a marker on one is corrupt state — blanking its params would

--- a/server/services/mediaJobQueue/remoteMediaJob.js
+++ b/server/services/mediaJobQueue/remoteMediaJob.js
@@ -1,0 +1,28 @@
+/**
+ * The one definition of "is this queued job rendering on a federated peer?".
+ *
+ * It lives in its own module rather than in `index.js` so the light consumers —
+ * the public projection (`sanitizeJob.js`), route handlers — can ask the
+ * question without dragging the whole queue (its timers, persistence, and
+ * event emitters) into their module graph. Every caller must use this predicate
+ * instead of testing `params.remoteMedia` inline: an inline test silently drops
+ * the kind gate below.
+ */
+
+// The federatable kinds and the adapter each one dispatches to, in one map so
+// the two cannot drift apart. Kinds are listed explicitly rather than inferred
+// from the marker alone: a 'training' job has no federated contract, so a marker
+// on one is corrupt state that must keep taking the local path, not a routing
+// instruction.
+export const REMOTE_MEDIA_MODULES = {
+  audio: () => import('../audioGen/remote.js'),
+  image: () => import('../imageGen/remote.js'),
+  video: () => import('../videoGen/remote.js'),
+};
+
+// Presence, not truthiness of individual nested fields, selects the remote
+// adapter. Persisted queue state is user-editable; a malformed marker must fail
+// closed in the kind's remote module rather than accidentally falling through to
+// a local engine with a remote-only model id.
+export const isRemoteMediaJob = (job) =>
+  Object.hasOwn(REMOTE_MEDIA_MODULES, job?.kind ?? '') && job.params?.remoteMedia !== undefined;

--- a/server/services/mediaJobQueue/sanitizeJob.js
+++ b/server/services/mediaJobQueue/sanitizeJob.js
@@ -1,4 +1,5 @@
 import { renderFederatedMediaAudioPrompt } from '../../lib/federatedMediaWire.js';
+import { isRemoteMediaJob } from './remoteMediaJob.js';
 
 // Public projection of a media job. Keep worker-only paths and subprocess
 // details out of both the queue API and the processing dashboard.
@@ -38,27 +39,24 @@ export function sanitizeJob(job) {
   const remotePrompt = renderFederatedMediaAudioPrompt(job.params?.remoteMedia?.profile)
     ?? (typeof job.params?.remoteMedia?.request?.prompt === 'string'
       ? job.params.remoteMedia.request.prompt : null);
-  if (safeParams && remotePrompt) {
-    safeParams.prompt = remotePrompt;
-  }
-  // Same reasoning for the model id: it is nulled in top-level params so a
-  // downgraded build cannot render the job locally (#4683), so rebuild it from
-  // the marker here — the Render Queue card's model badge reads
+  // The model id is nulled in top-level params for the same reason (#4683), so
+  // rebuild it from the marker too — the Render Queue's model badge reads
   // `params.modelId`. Audio carries no wire model id and keeps whatever the
   // local engine recorded.
+  const routed = isRemoteMediaJob(job);
   const remoteModelId = job.params?.remoteMedia?.request?.modelId;
-  if (safeParams && typeof remoteModelId === 'string' && remoteModelId) {
-    safeParams.modelId = remoteModelId;
-  }
-  // Display-only discriminator, never persisted in job params: a routed job
-  // renders on a peer, so labelling it with the local-render badge ("local /
-  // flux") would misreport where the pixels came from.
-  if (safeParams && job.params?.remoteMedia !== undefined) {
-    safeParams.renderer = 'remote';
+  if (safeParams && routed) {
+    if (remotePrompt) safeParams.prompt = remotePrompt;
+    if (typeof remoteModelId === 'string' && remoteModelId) safeParams.modelId = remoteModelId;
   }
   return {
     id: job.id,
     kind: job.kind,
+    // Where this job renders. Job metadata, not a render input, so it rides on
+    // the envelope rather than inside `params` — the PARAM_ALLOWLIST above stays
+    // an exact description of what a projected `params` can contain. The UI
+    // needs it because a peer render must not wear the local model badge.
+    renderer: routed ? 'remote' : 'local',
     owner: job.owner,
     status: job.status,
     queuedAt: job.queuedAt,

--- a/server/services/mediaJobQueue/sanitizeJob.js
+++ b/server/services/mediaJobQueue/sanitizeJob.js
@@ -1,4 +1,4 @@
-import { renderFederatedMediaAudioPrompt } from '../../lib/federatedMediaWire.js';
+import { effectiveJobPrompt } from '../../lib/federatedMediaWire.js';
 import { isRemoteMediaJob } from './remoteMediaJob.js';
 
 // Public projection of a media job. Keep worker-only paths and subprocess
@@ -33,16 +33,13 @@ export function sanitizeJob(job) {
   // in top-level params — that is what makes an older build (which cannot route
   // the marker) fail closed instead of quietly re-rendering the job locally.
   // Rebuild the prompt for the public projection without exposing private peer
-  // routing state. Audio renders it from the fixed-vocabulary profile (free-form
-  // personal text never reaches an audio provider at all); image and video carry
-  // the submitted prompt itself.
-  const remotePrompt = renderFederatedMediaAudioPrompt(job.params?.remoteMedia?.profile)
-    ?? (typeof job.params?.remoteMedia?.request?.prompt === 'string'
-      ? job.params.remoteMedia.request.prompt : null);
+  // routing state.
+  const remotePrompt = effectiveJobPrompt(job);
   // The model id is nulled in top-level params for the same reason (#4683), so
   // rebuild it from the marker too — the Render Queue's model badge reads
-  // `params.modelId`. Audio carries no wire model id and keeps whatever the
-  // local engine recorded.
+  // `params.modelId`, and every routed kind (audio included: routes/music.js
+  // requires an explicit `modelId` for a peer render) carries it on the wire
+  // request. This branch is now the ONLY source of a routed job's model id.
   const routed = isRemoteMediaJob(job);
   const remoteModelId = job.params?.remoteMedia?.request?.modelId;
   if (safeParams && routed) {

--- a/server/services/mediaJobQueue/sanitizeJob.js
+++ b/server/services/mediaJobQueue/sanitizeJob.js
@@ -41,6 +41,21 @@ export function sanitizeJob(job) {
   if (safeParams && remotePrompt) {
     safeParams.prompt = remotePrompt;
   }
+  // Same reasoning for the model id: it is nulled in top-level params so a
+  // downgraded build cannot render the job locally (#4683), so rebuild it from
+  // the marker here — the Render Queue card's model badge reads
+  // `params.modelId`. Audio carries no wire model id and keeps whatever the
+  // local engine recorded.
+  const remoteModelId = job.params?.remoteMedia?.request?.modelId;
+  if (safeParams && typeof remoteModelId === 'string' && remoteModelId) {
+    safeParams.modelId = remoteModelId;
+  }
+  // Display-only discriminator, never persisted in job params: a routed job
+  // renders on a peer, so labelling it with the local-render badge ("local /
+  // flux") would misreport where the pixels came from.
+  if (safeParams && job.params?.remoteMedia !== undefined) {
+    safeParams.renderer = 'remote';
+  }
   return {
     id: job.id,
     kind: job.kind,

--- a/server/services/mediaJobQueue/sanitizeJob.test.js
+++ b/server/services/mediaJobQueue/sanitizeJob.test.js
@@ -78,20 +78,22 @@ describe('sanitizeJob', () => {
     expect(sanitized.params).toEqual({
       prompt: 'Instrumental orchestral music with a triumphant mood, moderate tempo, high energy, featuring brass and strings. No vocals or spoken words.',
       modelId: 'example/model',
+      renderer: 'remote',
     });
     expect(sanitized.params).not.toHaveProperty('remoteMedia');
   });
 
-  it('restores an image/video remote job prompt from its marker, not from params', () => {
+  it('restores an image/video remote job prompt and model from its marker, not from params', () => {
     const sanitized = sanitizeJob({
       id: 'job-image',
       kind: 'image',
       status: 'running',
       params: {
-        // Blank on purpose: the prompt lives only inside the versioned marker so
-        // an older build that cannot route it fails closed instead of rendering.
+        // Blank/nulled on purpose: the prompt and the model live only inside
+        // the versioned marker so an older build that cannot route it fails
+        // closed instead of rendering (#4683).
         prompt: '',
-        modelId: 'dev',
+        modelId: null,
         width: 512,
         height: 512,
         remoteMedia: {
@@ -114,7 +116,22 @@ describe('sanitizeJob', () => {
       modelId: 'dev',
       width: 512,
       height: 512,
+      // Display-only: the Render Queue badges this 'remote / dev' rather than
+      // claiming a local render produced it.
+      renderer: 'remote',
     });
     expect(sanitized.params).not.toHaveProperty('remoteMedia');
+  });
+
+  it('leaves a local job unbadged so it keeps the local render label', () => {
+    const sanitized = sanitizeJob({
+      id: 'job-local',
+      kind: 'image',
+      status: 'running',
+      params: { prompt: 'a lighthouse at dusk', modelId: 'dev' },
+    });
+
+    expect(sanitized.params).toEqual({ prompt: 'a lighthouse at dusk', modelId: 'dev' });
+    expect(sanitized.params).not.toHaveProperty('renderer');
   });
 });

--- a/server/services/mediaJobQueue/sanitizeJob.test.js
+++ b/server/services/mediaJobQueue/sanitizeJob.test.js
@@ -55,8 +55,11 @@ describe('sanitizeJob', () => {
       kind: 'audio',
       status: 'queued',
       params: {
+        // Blank/nulled by routedJobParams, exactly as the queue persists it —
+        // if the fixture carried the model id here too, the marker rebuild
+        // below could stop working and this test would still pass.
         prompt: '',
-        modelId: 'example/model',
+        modelId: null,
         remoteMedia: {
           wireVersion: 1,
           peerId: '00000000-0000-4000-8000-000000000001',

--- a/server/services/mediaJobQueue/sanitizeJob.test.js
+++ b/server/services/mediaJobQueue/sanitizeJob.test.js
@@ -78,8 +78,8 @@ describe('sanitizeJob', () => {
     expect(sanitized.params).toEqual({
       prompt: 'Instrumental orchestral music with a triumphant mood, moderate tempo, high energy, featuring brass and strings. No vocals or spoken words.',
       modelId: 'example/model',
-      renderer: 'remote',
     });
+    expect(sanitized.renderer).toBe('remote');
     expect(sanitized.params).not.toHaveProperty('remoteMedia');
   });
 
@@ -116,14 +116,15 @@ describe('sanitizeJob', () => {
       modelId: 'dev',
       width: 512,
       height: 512,
-      // Display-only: the Render Queue badges this 'remote / dev' rather than
-      // claiming a local render produced it.
-      renderer: 'remote',
     });
     expect(sanitized.params).not.toHaveProperty('remoteMedia');
+    // Job metadata, not a render input — the Render Queue badges this
+    // 'remote / dev' rather than claiming a local render produced it.
+    expect(sanitized.renderer).toBe('remote');
+    expect(sanitized.params).not.toHaveProperty('renderer');
   });
 
-  it('leaves a local job unbadged so it keeps the local render label', () => {
+  it('reports a local job as locally rendered', () => {
     const sanitized = sanitizeJob({
       id: 'job-local',
       kind: 'image',
@@ -132,6 +133,24 @@ describe('sanitizeJob', () => {
     });
 
     expect(sanitized.params).toEqual({ prompt: 'a lighthouse at dusk', modelId: 'dev' });
-    expect(sanitized.params).not.toHaveProperty('renderer');
+    expect(sanitized.renderer).toBe('local');
+  });
+
+  it('reports a training job carrying a stray marker as local — training has no federated contract', () => {
+    const sanitized = sanitizeJob({
+      id: 'job-training',
+      kind: 'training',
+      status: 'running',
+      params: {
+        runId: 'run-1',
+        runtime: 'mflux',
+        modelId: 'dev',
+        remoteMedia: { wireVersion: 1, request: { modelId: 'peer-model' } },
+      },
+    });
+
+    expect(sanitized.renderer).toBe('local');
+    // The marker must not rewrite a local training job's model either.
+    expect(sanitized.params.modelId).toBe('dev');
   });
 });

--- a/server/services/sprites/reference.js
+++ b/server/services/sprites/reference.js
@@ -58,6 +58,7 @@ import {
 import {
   analyzeForeground, paletteFromAnalysis, normalizeFromAnalysis, recompositeOnKey,
 } from './normalize.js';
+import { effectiveJobPrompt } from '../../lib/federatedMediaWire.js';
 
 // Default i2i strengths: a render that redraws a NEW figure from the frozen
 // sheet (every anchor, and the main in the turnaround-first flow) mostly
@@ -812,12 +813,19 @@ export async function attachReferenceCandidate(ctx) {
     // Prefer the completed job's live params — Render Queue's Edit & Retry
     // rewrites top-level params but carries the original tag through, so the
     // tag's model can be stale provenance.
-    model: ctx.job?.params?.model || ctx.job?.params?.modelId || ctx.model || null,
+    // A federated render nulls the top-level model and blanks the prompt to
+    // fail closed on a downgrade (#4683), so read through to the wire request
+    // before falling back — otherwise the sidecar records no provenance at all.
+    model: ctx.job?.params?.model
+      || ctx.job?.params?.modelId
+      || ctx.job?.params?.remoteMedia?.request?.modelId
+      || ctx.model
+      || null,
     // The literal prompt sent to the provider — the completed job's live params
     // are canonical (Render Queue's Edit & Retry can rewrite it). Persisting it
     // lets the preview modals show exactly what was rendered; older sidecars
     // without it fall back to a deterministic rebuild (services/sprites/assetPrompt.js).
-    prompt: ctx.job?.params?.prompt || null,
+    prompt: effectiveJobPrompt(ctx.job) || null,
     jobId: ctx.jobId || null,
     ...(ctx.designPrompt ? { designPrompt: ctx.designPrompt } : {}),
     ...(ctx.correctionPrompt ? { correctionPrompt: ctx.correctionPrompt } : {}),

--- a/server/services/sprites/reference.test.js
+++ b/server/services/sprites/reference.test.js
@@ -493,6 +493,36 @@ describe('attachReferenceCandidate', () => {
     expect(sidecar.model).toBe('retried-model');
   });
 
+  it('reads a federated render\'s provenance through to the wire request', async () => {
+    // A routed job blanks `params.prompt` and nulls `params.modelId` so a build
+    // rolled back past `remoteMedia` fails closed (#4683) — reading them
+    // directly would record a sidecar with no provenance at all.
+    const id = newId();
+    await createCharacter(id);
+    await mkdir(join(TEST_ROOT, 'images'), { recursive: true });
+    await writeCandidatePng(join(TEST_ROOT, 'images', 'render-remote.png'));
+    await attachReferenceCandidate({
+      recordId: id, target: 'main', direction: 'south', anchorId: 'walk-south',
+      chromaKey: '#FF00FF', jobId: 'j-remote', filename: 'render-remote.png',
+      job: {
+        params: {
+          prompt: '',
+          modelId: null,
+          remoteMedia: {
+            wireVersion: 1,
+            peerId: '00000000-0000-4000-8000-0000000004f1',
+            request: { kind: 'image', engine: 'local', modelId: 'dev', prompt: 'a sprite facing south' },
+          },
+        },
+      },
+    });
+    const sidecar = JSON.parse(await readFile(
+      join(TEST_ROOT, 'sprites', id, 'reference', 'candidates', 'walk-south-candidate-01.generation.json'), 'utf8',
+    ));
+    expect(sidecar.model).toBe('dev');
+    expect(sidecar.prompt).toBe('a sprite facing south');
+  });
+
   it('records an anchor correction prompt in the sidecar as provenance', async () => {
     const id = newId();
     await createCharacter(id);

--- a/server/services/writersRoomSceneImageHook.js
+++ b/server/services/writersRoomSceneImageHook.js
@@ -28,14 +28,17 @@
 import { createMediaJobImageHook } from './mediaJobImageHook.js';
 import { persistSceneImage } from './writersRoom/evaluator.js';
 import { writersRoomEvents } from './writersRoomEvents.js';
+import { effectiveJobPrompt } from '../lib/federatedMediaWire.js';
 
 // The render filename is `${jobId}.png`; prefer the job id, fall back to
 // stripping the extension so the attach records a stable jobId either way.
 const deriveJobId = (job, filename) =>
   (typeof job.id === 'string' && job.id ? job.id : filename.replace(/\.png$/, ''));
 // The gen prompt IS the scene prompt (buildScenePrompt output), so record it on
-// the attach without the tag having to carry a duplicate copy.
-const derivePrompt = (job) => (typeof job.params?.prompt === 'string' ? job.params.prompt : null);
+// the attach without the tag having to carry a duplicate copy. A federated
+// render blanks top-level `prompt` to fail closed on a downgrade (#4683), so
+// read through to the marker rather than saving the scene an empty prompt.
+const derivePrompt = (job) => effectiveJobPrompt(job);
 
 const hook = createMediaJobImageHook({
   label: 'writers-room scene-image',

--- a/server/services/writersRoomSceneImageHook.test.js
+++ b/server/services/writersRoomSceneImageHook.test.js
@@ -63,6 +63,29 @@ describe('writersRoomSceneImageHook', () => {
     });
   });
 
+  it('records the wire prompt for a federated render, whose top-level prompt is blank', async () => {
+    // A routed job blanks `params.prompt` so a build rolled back past
+    // `remoteMedia` fails closed (#4683). Reading it directly would file the
+    // scene with an empty prompt instead of the one that actually rendered.
+    mediaJobEvents.emit('completed', completedImageJob({
+      params: {
+        writersRoom: tag(),
+        prompt: '',
+        modelId: null,
+        remoteMedia: {
+          wireVersion: 1,
+          peerId: '00000000-0000-4000-8000-0000000004f1',
+          request: { kind: 'image', engine: 'local', modelId: 'dev', prompt: 'a cinematic alley' },
+        },
+      },
+      filename: 'job-remote.png', id: 'job-remote',
+    }));
+    await waitFor(() => emitted.length > 0);
+    expect(persistSceneImage).toHaveBeenCalledWith('w1', 'script', {
+      sceneId: 's1', filename: 'job-remote.png', jobId: 'job-remote', prompt: 'a cinematic alley',
+    });
+  });
+
   it('derives jobId from the filename when the job carries no id', async () => {
     mediaJobEvents.emit('completed', completedImageJob({ params: { writersRoom: tag() }, filename: 'noid.png', id: null }));
     await waitFor(() => persistSceneImage.mock.calls.length > 0);


### PR DESCRIPTION
## Summary

A queued **remote image** job did not fail closed when an install was downgraded to a build predating `remoteMedia`. The legacy queue ignores the unknown marker key and dispatches the job to local image generation — and `generateImage` deliberately permits an empty prompt (img2img/regen rely on it). With a matching local model installed, the user got a real local render of nothing in particular, filed by its completion hook as if it were the requested image.

**The load-bearing detail:** the fix nulls `modelId` rather than dropping the key. `generateImage`/`generateVideo` both declare `modelId` as a default parameter, and a JS default fires on `undefined` only — deleting the key would have selected the shipped default and rendered for real wherever those weights are installed. An explicit `null` lands on the `Unknown or unsupported model` guard every time. A persisted `renderer: 'remote'` discriminator was considered and rejected: an older build has no such check, so it would ignore the field and buy no protection.

## What shipped

- **`services/federatedMedia/routedJobParams.js`** — the downgrade-safe shape: `prompt: ''`, `modelId: null`, `pythonPath: null`.
- **Enforced at the chokepoint, not per call site.** All four queue write paths normalize any job carrying a marker: `enqueueJob`, and boot restore's queued / running-reconcile / archive branches. A helper each routed enqueue site had to remember would be one forgotten call from re-opening this, with no guard test to catch it — and it left `routes/music.js` uncovered.
- **`mediaJobQueue/remoteMediaJob.js`** — `isRemoteMediaJob` + its kind map, lifted out of the queue so light consumers can ask "is this routed?" without pulling in timers and persistence. Three inline `params.remoteMedia !== undefined` tests became one predicate; the inline form silently dropped the kind gate, so a training job with a stray marker was treated as federated.
- **`effectiveJobPrompt`** (`lib/federatedMediaWire.js`) — one resolver for "what prompt did this actually render from", since a routed job's prompt lives only in its marker. Used by the queue projection, the writers-room scene-image hook, the sprite reference sidecar, and `GET /api/video-gen/active`.
- **Retry** clears the marker's transient run state. Inheriting `cancelRequested` meant a canceled federated render could *never* be retried — the executor's preflight aborted on the flag, which then rode along to every further retry.
- **UI** badges a peer render `remote / dev` instead of claiming `local / dev`, and hides the retry *editor* on federated jobs, whose prompt/model edits never reached the peer.

## Fixed along the way

- A federated writers-room render saved its scene with an **empty prompt** (pre-existing since #4676; API-reachable only — the Writers Room UI never sends a provider peer).
- `GET /api/video-gen/active` had no marker rebuild, so a reload mid-federated-render resumed the form on the **local default model**.
- A corrupt `remoteMedia: null` 500'd the retry route instead of failing closed.

Audio was checked and is genuinely out of scope: `generateMusic` already hard-refuses a blank prompt (`PIPELINE_MUSIC_EMPTY_PROMPT`), and it now inherits the shared normalization anyway.

## Test plan

- `server`: 31,533 passed / 1,518 files. `client`: 8,635 passed / 688 files. `biome lint` clean.
- New regression coverage feeds the routed params to the **real** `generateImage`/`generateVideo` — the surface a legacy dispatcher lands on — and asserts they refuse. It carries a bypass probe proving the shipped default model IS registered, so the "just delete the key" variant would have rendered for real.
- Bypass probes at three layers assert a `training` job carrying a stray marker keeps the local path.
- Every fix was verified non-vacuous by reverting the hunk and confirming its test fails.

Closes #4683