### PR TITLE
Release v2.47.0 — fix two CI-load test races blocking the publish

### DIFF
--- a/client/src/components/music/TracksManager.test.jsx
+++ b/client/src/components/music/TracksManager.test.jsx
@@ -191,6 +191,11 @@ describe('<TracksManager> generative workflow hand-off', () => {
     renderAt('track-1');
 
     const prompt = await screen.findByLabelText(/^Prompt/);
+    // The form hydrates from the loaded track in an effect that can commit after
+    // the fields mount — `findByLabelText` resolves on the DOM node appearing,
+    // not on hydration landing. Type only once it has, or hydration overwrites
+    // the typed prompt and the save sends the original.
+    await waitFor(() => expect(screen.getByLabelText('Title').value).toBe('Example Song'));
     fireEvent.change(prompt, { target: { value: 'A patient analog pulse.' } });
     fireEvent.click(screen.getByRole('button', { name: 'Design with AI' }));
 

--- a/client/src/pages/SongBookViewer.test.jsx
+++ b/client/src/pages/SongBookViewer.test.jsx
@@ -452,8 +452,15 @@ K:  o - - - - - o -`;
       api.getSong.mockResolvedValue(drumSong());
       renderPage();
       await screen.findByLabelText('Turn the metronome off');
-      fireEvent.keyDown(window, { key: 'm' });
-      expect(await screen.findByLabelText('Turn the metronome on')).toBeTruthy();
+      // The `m` binding lives on a window listener attached in an effect, while
+      // `findByLabelText` resolves on the transport bar's DOM mutation — which
+      // can commit first. Retry the keystroke until it lands, or a loaded runner
+      // drops it into a page that has no handler yet. (The click-based tests
+      // aren't exposed to this: those are React prop handlers.)
+      await waitFor(() => {
+        fireEvent.keyDown(window, { key: 'm' });
+        expect(screen.getByLabelText('Turn the metronome on')).toBeTruthy();
+      });
       fireEvent.keyDown(window, { key: 'm' });
       expect(await screen.findByLabelText('Turn the metronome off')).toBeTruthy();
     });

--- a/server/services/llamaServerManager.test.js
+++ b/server/services/llamaServerManager.test.js
@@ -318,18 +318,16 @@ describe('llamaServerManager', () => {
     vi.spyOn(childProcess, 'spawn').mockImplementation((cmd, args) => {
       spawnCalls.push({ cmd, args });
       const child = args[0] === 'install' ? installChild : linkChild;
+      // The binary shows up on PATH because `brew link` ran — key the mock off
+      // that spawn, not a wall-clock timer. A timer races the install child's
+      // own exit handler, and on a loaded runner it can fire first, making the
+      // binary look already-linked so the link step never happens (#4642).
+      if (args[0] === 'link') findSpy.mockReturnValue('/opt/homebrew/bin/llama-server');
       setTimeout(() => endProcess(child, 0), 10);
       return child;
     });
 
-    const resultPromise = installLlamaServer();
-
-    // Once `brew link` resolves, the binary shows up on PATH.
-    setTimeout(() => {
-      findSpy.mockReturnValue('/opt/homebrew/bin/llama-server');
-    }, 15);
-
-    const result = await resultPromise;
+    const result = await installLlamaServer();
     expect(result.success).toBe(true);
     expect(spawnCalls).toEqual([
       { cmd: 'brew', args: ['install', 'llama.cpp'] },


### PR DESCRIPTION
## Summary

The v2.47.0 release PR (#4721) merged, but the Release workflow's `full-ci` went red, so the publish job skipped and no `v2.47.0` tag or GitHub Release was created. Both failures were wall-clock races in tests, not product bugs — they only surface under `full: true`, which runs the whole suite rather than the impact-scoped subset the PR checks use.

- **`llamaServerManager`** — the brew-keg-link test flipped `findCommandOnPath` on a 15 ms timer racing the install child's own 10 ms exit. On a loaded Windows runner the timer won, so the binary looked already-linked and `brew link` never ran (1 spawn call instead of 2). Now the flip is keyed off the `link` spawn, which is what actually puts the binary on PATH — deterministic, and still fails if the product stops linking.
- **`SongBookViewer`** — the `m` metronome shortcut is a window listener attached in an effect, but `findByLabelText` resolves on the DOM mutation, which can commit first. The keystroke landed on a page with no handler. Now the keystroke is retried until it lands. (The click-based metronome tests were never exposed: those are React prop handlers.)

The `lint` job failure was a pure cascade — lint itself passed ("Checked 2142 files. No fixes applied"); the job only re-reports the client job's result.

No product code changed. `package.json` is already at 2.47.0 and no `v2.47.0` tag exists, so merging this re-runs the Release workflow, which auto-tags and publishes.

## Test plan

- `server && npx vitest run services/llamaServerManager.test.js` — 18 passed
- `client && npx vitest run src/pages/SongBookViewer.test.jsx` — 64 passed, 5 consecutive runs
- Full suites green before the release commit: 32,024 server / 8,822 client / 257 DB
