### PR TITLE
fix(tests): settle MoodBoard picker effects under CI load

### DIFF
--- a/client/src/pages/MoodBoardDetail.test.jsx
+++ b/client/src/pages/MoodBoardDetail.test.jsx
@@ -1,6 +1,6 @@
 import { StrictMode } from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
 
 // ── Mocks must be declared before any imports that use them ──────────────────
@@ -106,6 +106,9 @@ describe('MoodBoardDetail stale-response guards', () => {
       .mockReturnValueOnce(second.promise); // board 'b'
 
     const { rerender } = renderPage();
+    // GalleryImagePicker has mount work even while closed. Flush it before
+    // changing boards so its state cannot settle after this test finishes.
+    await act(async () => {});
     // The user navigates to board 'b' before board 'a' has resolved.
     currentId = 'b';
     rerender(<MemoryRouter><MoodBoardDetail /></MemoryRouter>);

--- a/client/src/pages/MoodBoardDetail.test.jsx
+++ b/client/src/pages/MoodBoardDetail.test.jsx
@@ -106,9 +106,6 @@ describe('MoodBoardDetail stale-response guards', () => {
       .mockReturnValueOnce(second.promise); // board 'b'
 
     const { rerender } = renderPage();
-    // GalleryImagePicker has mount work even while closed. Flush it before
-    // changing boards so its state cannot settle after this test finishes.
-    await act(async () => {});
     // The user navigates to board 'b' before board 'a' has resolved.
     currentId = 'b';
     rerender(<MemoryRouter><MoodBoardDetail /></MemoryRouter>);
@@ -116,6 +113,9 @@ describe('MoodBoardDetail stale-response guards', () => {
     // Newer request resolves first — its data should show.
     second.resolve({ id: 'b', name: 'Board B', items: [] });
     await waitFor(() => expect(boardNameValue()).toBe('Board B'));
+    // GalleryImagePicker mounts with the loaded board and resets its filter
+    // state in a mount effect. Settle it before the unwrapped stale response.
+    await act(async () => {});
 
     // Older (stale) request resolves last — it must NOT overwrite current state.
     first.resolve({ id: 'a', name: 'Board A', items: [] });


### PR DESCRIPTION
## Summary

- Flushes `GalleryImagePicker` mount effects after the loaded board renders in the stale-response test.
- Completes the paired TracksManager hydration race fix already on `main` (`2ed14f573`) for issue #4720.
- Test-only changes; no production code changes.

## Test plan

- `npm test -- --run src/components/music/TracksManager.test.jsx src/pages/MoodBoardDetail.test.jsx`
- Repeated the focused pair 20 times.
- `npm test` — 700 test files and 8,822 tests passed.

Closes #4720