### PR TITLE
fix: administer llama.cpp model mismatch from the provider card

### DIFF
--- a/client/src/components/providers/ProviderCard.jsx
+++ b/client/src/components/providers/ProviderCard.jsx
@@ -90,6 +90,7 @@ export default function ProviderCard({
   onRecover,
   onInstallRuntime,
   onAutoSetupRuntime,
+  onUseServedModel,
 }) {
   const style = CARD_STATE_STYLES[cardState.state];
   return (
@@ -262,6 +263,7 @@ export default function ProviderCard({
           className="max-w-3xl"
           readiness={daemonReadiness}
           onAutoSetup={(setup) => onAutoSetupRuntime?.({ ...setup, providerId: provider.id })}
+          onUseServedModel={(modelId) => onUseServedModel?.(provider, modelId)}
         />
 
         {provider.enabled && status?.available === false && (

--- a/client/src/components/providers/ProviderReadiness.jsx
+++ b/client/src/components/providers/ProviderReadiness.jsx
@@ -10,15 +10,14 @@
  * transcript.
  *
  * `readiness` is one entry of the map from `GET /api/providers/readiness`
- * (`{ kind, label, endpoint, ready, checks, manageUrl, docsUrl, setup }`).
+ * (`{ kind, label, endpoint, ready, checks, manageUrl, setup }`).
  * Renders nothing without one, so providers with no local dependency — and
  * cards drawn before the fetch resolves — show no checklist at all.
  *
- * `setup` is the one-click fix: when PortOS can install and/or start this
- * daemon itself (`services/localRuntimeSetup.js`), the banner leads with that
- * button instead of a setup-doc link. The docs link stays as a secondary
- * affordance — it is the right answer for the checks a button cannot fix (which
- * model to download) and for a host the setup does not support.
+ * Every unmet check is fixed from this banner: a one-click daemon setup
+ * (`setup.action`), a "use the served model as default" button when the
+ * running server answers under a different id, or an in-app Local LLM
+ * settings link. Vendor setup docs are never the way forward.
  */
 
 import { Link } from 'react-router';
@@ -35,7 +34,7 @@ const ICONS = {
   null: { Icon: HelpCircle, cls: 'text-gray-500' },
 };
 
-const LINK_CLASS = 'text-port-accent hover:text-port-accent/80 underline underline-offset-2';
+const ACTION_CLASS = 'inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded bg-port-accent/20 text-port-accent hover:bg-port-accent/30 transition-colors font-medium';
 
 /**
  * Render `text` with `backtick`-quoted spans as inline code. The server writes
@@ -55,9 +54,9 @@ function CodeText({ text }) {
   );
 }
 
-export default function ProviderReadiness({ readiness, onAutoSetup, className = '' }) {
+export default function ProviderReadiness({ readiness, onAutoSetup, onUseServedModel, className = '' }) {
   if (!readiness || !Array.isArray(readiness.checks) || readiness.checks.length === 0) return null;
-  const { label, endpoint, ready, checks, manageUrl, docsUrl, setup } = readiness;
+  const { label, endpoint, ready, checks, manageUrl, setup } = readiness;
 
   if (ready) {
     return (
@@ -89,6 +88,22 @@ export default function ProviderReadiness({ readiness, onAutoSetup, className = 
                 {check.fixHint && (
                   <span className="block text-port-warning/90"><CodeText text={check.fixHint} /></span>
                 )}
+                {check.id === 'model' && check.ok === false && onUseServedModel
+                  && Array.isArray(check.servedModels) && check.servedModels.length > 0 && (
+                  <span className="flex flex-wrap gap-1.5 mt-1.5">
+                    {check.servedModels.slice(0, 3).map((id) => (
+                      <button
+                        key={id}
+                        type="button"
+                        onClick={() => onUseServedModel(id)}
+                        className={ACTION_CLASS}
+                        title={`Set this provider's default model to ${id} so it matches what ${label} is serving.`}
+                      >
+                        Use {id} as default
+                      </button>
+                    ))}
+                  </span>
+                )}
               </span>
             </li>
           );
@@ -99,7 +114,7 @@ export default function ProviderReadiness({ readiness, onAutoSetup, className = 
           <button
             type="button"
             onClick={() => onAutoSetup(setup)}
-            className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded bg-port-accent/20 text-port-accent hover:bg-port-accent/30 transition-colors font-medium"
+            className={ACTION_CLASS}
             title={`PortOS runs this on ${endpoint} for you — no terminal needed.`}
           >
             <Wand2 size={12} />
@@ -107,10 +122,7 @@ export default function ProviderReadiness({ readiness, onAutoSetup, className = 
           </button>
         )}
         {manageUrl && (
-          <Link to={manageUrl} className={LINK_CLASS}>Open Local LLM settings</Link>
-        )}
-        {docsUrl && (
-          <a href={docsUrl} target="_blank" rel="noreferrer" className={LINK_CLASS}>{label} setup docs</a>
+          <Link to={manageUrl} className={ACTION_CLASS}>Open Local LLM settings</Link>
         )}
       </div>
     </Banner>

--- a/client/src/components/providers/ProviderReadiness.test.jsx
+++ b/client/src/components/providers/ProviderReadiness.test.jsx
@@ -52,16 +52,17 @@ describe('ProviderReadiness', () => {
     expect(screen.getByText(/1 requirement unmet/)).toBeTruthy();
   });
 
-  it('links to the Local LLM tab and the vendor docs when the setup is incomplete', () => {
+  it('links to the Local LLM tab as an in-app action — never to vendor setup docs', () => {
     renderWithRouter(<ProviderReadiness readiness={readiness()} />);
     expect(screen.getByText('Open Local LLM settings').closest('a').getAttribute('href')).toBe('/settings/local-llm');
-    expect(screen.getByText('llama.cpp setup docs').closest('a').getAttribute('href')).toBe('https://example.com/llama-docs');
+    expect(screen.queryByText(/setup docs/i)).toBeNull();
+    expect(screen.queryByRole('link', { name: /llama\.cpp setup docs/i })).toBeNull();
   });
 
-  it('omits the manage link for a runtime PortOS does not install', () => {
+  it('omits the manage link for a runtime PortOS does not install, and still never points at docs', () => {
     renderWithRouter(<ProviderReadiness readiness={readiness({ label: 'MTPLX', manageUrl: null })} />);
     expect(screen.queryByText('Open Local LLM settings')).toBeNull();
-    expect(screen.getByText('MTPLX setup docs')).toBeTruthy();
+    expect(screen.queryByText(/setup docs/i)).toBeNull();
   });
 
   it('offers the one-click setup instead of leaving a docs link as the only way forward', () => {
@@ -73,8 +74,44 @@ describe('ProviderReadiness', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /Install & start MTPLX/ }));
     expect(onAutoSetup).toHaveBeenCalledWith(setup);
-    // The docs stay reachable — they answer the checks a button cannot fix.
-    expect(screen.getByText('MTPLX setup docs')).toBeTruthy();
+    expect(screen.queryByText(/setup docs/i)).toBeNull();
+  });
+
+  it('offers a one-click default-model match when the daemon is serving a different id', () => {
+    const onUseServedModel = vi.fn();
+    const mismatch = readiness({
+      checks: [
+        { id: 'runtime', label: 'llama.cpp installed', ok: true, detail: 'on PATH', fixHint: null },
+        { id: 'server', label: 'llama.cpp server responding', ok: true, detail: 'answered', fixHint: null },
+        {
+          id: 'model',
+          label: 'Model `qwen3.8-27b-dflash2` available',
+          ok: false,
+          detail: 'llama.cpp is serving `dflash`.',
+          fixHint: 'This provider will send `qwen3.8-27b-dflash2`, but the running server only accepts `dflash`.',
+          servedModels: ['dflash'],
+        },
+      ],
+    });
+    renderWithRouter(<ProviderReadiness readiness={mismatch} onUseServedModel={onUseServedModel} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Use dflash as default/ }));
+    expect(onUseServedModel).toHaveBeenCalledWith('dflash');
+    expect(screen.queryByText(/setup docs/i)).toBeNull();
+  });
+
+  it('does not invent a use-as-default button when nothing is loaded', () => {
+    renderWithRouter(
+      <ProviderReadiness
+        readiness={readiness({
+          checks: [
+            { id: 'model', label: 'Model `dflash` available', ok: false, detail: 'no model loaded', fixHint: 'Start a preset from Settings → Local LLM.', servedModels: [] },
+          ],
+        })}
+        onUseServedModel={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /as default/ })).toBeNull();
   });
 
   it('shows no setup button when the host cannot run the runtime', () => {

--- a/client/src/components/settings/LocalLlmTab.jsx
+++ b/client/src/components/settings/LocalLlmTab.jsx
@@ -1104,6 +1104,13 @@ export function LocalLlmTab() {
                 {llamaStatus.config?.draftModel && (
                   <p><span className="text-gray-500">Drafter:</span> <code className="text-port-accent">{llamaStatus.config.draftModel}</code> ({llamaStatus.config.specType || 'draft-dflash'})</p>
                 )}
+                {llamaStatus.config && (
+                  <p>
+                    <span className="text-gray-500">Model id:</span>{' '}
+                    <code className="text-port-accent">{llamaStatus.config.alias || 'dflash'}</code>
+                    {' '}— Providers must send this name. Change it under Advanced options before starting.
+                  </p>
+                )}
               </div>
               {llamaStatus.managed ? (
                 <button
@@ -1233,6 +1240,17 @@ export function LocalLlmTab() {
                     className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
                   />
                 </div>
+                <div>
+                  <label htmlFor="llama-alias" className="text-[11px] text-gray-400 block mb-1">Model id (alias)</label>
+                  <input
+                    id="llama-alias"
+                    aria-label="Model id (alias)"
+                    type="text"
+                    value={llamaForm.alias}
+                    onChange={(e) => setLlamaForm((prev) => ({ ...prev, alias: e.target.value }))}
+                    className="w-full bg-port-card border border-port-border rounded px-2 py-1 text-xs text-white"
+                  />
+                </div>
               </div>
             )}
 
@@ -1243,7 +1261,7 @@ export function LocalLlmTab() {
                 className="text-[11px] text-gray-500 hover:text-gray-300 flex items-center gap-1"
               >
                 {showLlamaAdvanced ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-                {showLlamaAdvanced ? 'Hide options' : 'Advanced options (port, ctx, GPU layers)'}
+                {showLlamaAdvanced ? 'Hide options' : 'Advanced options (port, ctx, GPU layers, model id)'}
               </button>
               <div className="flex items-center gap-2">
                 {llamaStartBlocked && (

--- a/client/src/components/settings/LocalLlmTab.test.jsx
+++ b/client/src/components/settings/LocalLlmTab.test.jsx
@@ -558,6 +558,22 @@ describe('LocalLlmTab llama-server management', () => {
     });
   });
 
+  it('lets the user set the model id llama.cpp will answer as', async () => {
+    const { getLlamaServerStatus, startLlamaServer } = await import('../../services/api');
+    getLlamaServerStatus.mockResolvedValue(llamaReady());
+    startLlamaServer.mockResolvedValueOnce({ success: true, pid: 23 });
+
+    await renderTab();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Advanced options/ }));
+    fireEvent.change(screen.getByLabelText(/Model id \(alias\)/), { target: { value: 'dspark' } });
+    fireEvent.click(screen.getByRole('button', { name: /Start Speculative Server/ }));
+
+    await waitFor(() => {
+      expect(startLlamaServer).toHaveBeenCalledWith(expect.objectContaining({ alias: 'dspark' }));
+    });
+  });
+
   it('drops the preset label to Custom once a preset-supplied path is hand-edited', async () => {
     const { getLlamaServerStatus } = await import('../../services/api');
     getLlamaServerStatus.mockResolvedValue(llamaReady());
@@ -677,13 +693,15 @@ describe('LocalLlmTab llama-server management', () => {
       presets: specPresets(),
       pid: 9999,
       endpoint: 'http://127.0.0.1:5568/v1',
-      config: { model: 'models/base.gguf', draftModel: 'models/draft.gguf', specType: 'draft-dflash' },
+      config: { model: 'models/base.gguf', draftModel: 'models/draft.gguf', specType: 'draft-dflash', alias: 'dflash' },
     });
     stopLlamaServer.mockResolvedValueOnce({ success: true });
 
     await renderTab();
 
     expect(await screen.findByText(/Running \(PID 9999\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Providers must send/)).toBeInTheDocument();
+    expect(screen.getByText('dflash')).toBeInTheDocument();
     const stopBtn = screen.getByRole('button', { name: /Stop Server/ });
     fireEvent.click(stopBtn);
 

--- a/client/src/pages/AIProviders.jsx
+++ b/client/src/pages/AIProviders.jsx
@@ -271,6 +271,25 @@ export default function AIProviders() {
     loadData();
   };
 
+  // llama.cpp (and similar local daemons) answer as a single model id — the
+  // server's `--alias`, not the preset name on this card. Matching the
+  // provider's default to what is actually served is the in-place fix for the
+  // "model X available — serving Y" checklist, so the user never has to open
+  // the editor or leave the page.
+  const handleUseServedModel = async (provider, modelId) => {
+    if (!provider?.id || typeof modelId !== 'string' || modelId.trim() === '') return;
+    const defaultModel = modelId.trim();
+    const models = Array.isArray(provider.models) ? [...provider.models] : [];
+    const updates = { defaultModel };
+    if (!models.includes(defaultModel)) updates.models = [defaultModel, ...models];
+    const updated = await api.updateProvider(provider.id, updates).catch(() => null);
+    if (!updated) return;
+    setProviders((prev) => prev.map((entry) => (
+      entry.id === provider.id ? { ...entry, ...updates } : entry
+    )));
+    toast.success(`Default model set to ${defaultModel}`);
+    loadReadiness();
+  };
 
   const handleRefreshModels = async (id) => {
     setRefreshing(prev => ({ ...prev, [id]: true }));
@@ -747,6 +766,7 @@ export default function AIProviders() {
                       onRecover={handleRecover}
                       onInstallRuntime={setInstallingRuntime}
                       onAutoSetupRuntime={setSettingUpRuntime}
+                      onUseServedModel={handleUseServedModel}
                     />
                   ))}
                 </CollapsibleSection>

--- a/client/src/pages/AIProviders.test.jsx
+++ b/client/src/pages/AIProviders.test.jsx
@@ -319,6 +319,56 @@ describe('local-daemon readiness on the provider card', () => {
 
     expect(await screen.findByText(/llama\.cpp setup incomplete/)).toBeInTheDocument();
     expect(screen.getByText(/Install llama\.cpp from Settings/)).toBeInTheDocument();
+    expect(screen.queryByText(/setup docs/i)).not.toBeInTheDocument();
+  });
+
+  it('lets the user match this provider to the model llama.cpp is actually serving', async () => {
+    api.updateProvider.mockResolvedValue({ id: 'opencode-llama-tui', defaultModel: 'dflash' });
+    api.getProviderReadiness.mockResolvedValue({
+      readiness: {
+        'opencode-llama-tui': {
+          kind: 'llama',
+          label: 'llama.cpp',
+          endpoint: 'http://127.0.0.1:5568/v1',
+          manageUrl: '/settings/local-llm',
+          ready: false,
+          checks: [
+            { id: 'runtime', label: 'llama.cpp installed', ok: true, detail: 'on PATH', fixHint: null },
+            { id: 'server', label: 'llama.cpp server responding', ok: true, detail: 'answered', fixHint: null },
+            {
+              id: 'model',
+              label: 'Model `qwen3.8-27b-dflash2` available',
+              ok: false,
+              detail: 'llama.cpp is serving `dflash`.',
+              fixHint: 'This provider will send `qwen3.8-27b-dflash2`, but the running server only accepts `dflash`.',
+              servedModels: ['dflash'],
+            },
+          ],
+        },
+      },
+    });
+    api.getProviders.mockResolvedValue({
+      providers: [{
+        id: 'opencode-llama-tui',
+        name: 'OpenCode llama TUI',
+        type: 'tui',
+        command: 'opencode',
+        args: [],
+        enabled: true,
+        endpoint: 'http://127.0.0.1:5568/v1',
+        llamaBacked: true,
+        models: ['dflash', 'qwen3.8-27b-dflash2'],
+        defaultModel: 'qwen3.8-27b-dflash2',
+      }],
+      activeProvider: null,
+    });
+
+    renderPage();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Use dflash as default/ }));
+    await waitFor(() => {
+      expect(api.updateProvider).toHaveBeenCalledWith('opencode-llama-tui', { defaultModel: 'dflash' });
+    });
   });
 
   it('renders no checklist for a provider the server reports nothing about', async () => {

--- a/server/lib/localProviderRuntime.js
+++ b/server/lib/localProviderRuntime.js
@@ -134,7 +134,7 @@ export const LOCAL_RUNTIMES = Object.freeze({
     // Named so an unmet check can say what the user still has to fetch. GGUF
     // weights are a separate download from the binary — the single most common
     // reason a freshly-installed llama.cpp still cannot serve a request.
-    modelsHint: 'llama.cpp serves GGUF weights you download yourself — a base model, plus a drafter for speculative decoding.',
+    modelsHint: 'Pick a GGUF preset on that tab — PortOS downloads the weights and starts the server there.',
   }),
   ollama: Object.freeze({
     id: 'ollama',

--- a/server/services/providerReadiness.js
+++ b/server/services/providerReadiness.js
@@ -158,7 +158,7 @@ function runtimeCheck(runtime, { onPath, appInstalled, installed, reachable, set
   const fixHint = installed ? null
     : setupHint(setup, 'install')
       || (runtime.manageUrl ? `Install ${runtime.label} from Settings → Local LLM.`
-        : `Follow the ${runtime.label} setup docs, then reload this page.`);
+        : `Use the setup button below to install ${runtime.label}.`);
   return { id: 'runtime', label: `${runtime.label} installed`, ok: installed, detail, fixHint };
 }
 
@@ -209,15 +209,22 @@ function modelCheck(runtime, wanted, served, probeError = null) {
   if (served.includes(wanted)) {
     return { id: 'model', label, ok: true, detail: `${runtime.label} is serving \`${wanted}\`.`, fixHint: null };
   }
+  const listed = served.slice(0, 3).map((id) => `\`${id}\``).join(', ');
   const detail = served.length === 0
     ? `${runtime.label} is running but has no model loaded.`
-    : `${runtime.label} is serving ${served.slice(0, 3).map((id) => `\`${id}\``).join(', ')}${served.length > 3 ? ` +${served.length - 3} more` : ''}.`;
+    : `${runtime.label} is serving ${listed}${served.length > 3 ? ` +${served.length - 3} more` : ''}.`;
+  const fixHint = served.length === 0
+    ? (runtime.manageUrl
+      ? 'No model is loaded. Start a preset from Settings → Local LLM.'
+      : 'No model is loaded. Use the setup controls on this card to load one.')
+    : `This provider will send \`${wanted}\`, but the running server only accepts ${listed}. Use the button below to match them${runtime.manageUrl ? ', or change the loaded weights in Local LLM settings' : ''}.`;
   return {
     id: 'model',
     label,
     ok: false,
     detail,
-    fixHint: `${runtime.modelsHint} Then set this provider's default model to one the server reports.`,
+    fixHint,
+    servedModels: served,
   };
 }
 
@@ -274,7 +281,6 @@ export async function getProviderReadiness(provider, deps = {}) {
     label: runtime.label,
     endpoint: runtime.endpoint,
     manageUrl: runtime.manageUrl,
-    docsUrl: runtime.docsUrl,
     // `ready` is strict: a check that could not be evaluated (`ok: null`) is not
     // a pass, so the card never claims a provider is good to go on unknowns.
     ready: checks.every((check) => check.ok === true),
@@ -282,7 +288,8 @@ export async function getProviderReadiness(provider, deps = {}) {
     // What a one-click "set this up for me" button can do about the unmet
     // checks, or `null` when nothing here is auto-fixable (see
     // `localRuntimeSetup.js`). Carried on the readiness payload so the card
-    // offers the ACTION next to the failing check instead of a setup-doc link.
+    // offers the ACTION next to the failing check instead of sending the user
+    // out of the app.
     setup,
   };
 }

--- a/server/services/providerReadiness.test.js
+++ b/server/services/providerReadiness.test.js
@@ -106,7 +106,12 @@ describe('getProviderReadiness', () => {
     const model = checkById(readiness, 'model');
     expect(model.ok).toBe(false);
     expect(model.detail).toContain('dflash');
+    expect(model.servedModels).toEqual(['dflash', 'qwen3.8-27b']);
+    expect(model.fixHint).toMatch(/Use the button below/);
+    expect(model.fixHint).not.toMatch(/download yourself/i);
+    expect(model.fixHint).not.toMatch(/setup docs/i);
     expect(readiness.ready).toBe(false);
+    expect(readiness.docsUrl).toBeUndefined();
   });
 
   it('calls out a running server with nothing loaded', async () => {
@@ -114,7 +119,11 @@ describe('getProviderReadiness', () => {
       findCommand: () => '/opt/homebrew/bin/llama-server',
       probe: reachable([]),
     });
-    expect(checkById(readiness, 'model').detail).toMatch(/no model loaded/);
+    const model = checkById(readiness, 'model');
+    expect(model.detail).toMatch(/no model loaded/);
+    expect(model.servedModels).toEqual([]);
+    expect(model.fixHint).toMatch(/Local LLM/);
+    expect(model.fixHint).not.toMatch(/button below/);
   });
 
   it('leaves the model check unknown — never failed — while the server is down', async () => {
@@ -191,14 +200,14 @@ describe('getProviderReadiness', () => {
     );
     restore();
     expect(readiness.manageUrl).toBeNull();
-    // The docs link stays as a secondary affordance for the model choice.
-    expect(readiness.docsUrl).toBeTruthy();
+    // Setup lives in the PortOS UI — the payload never points at a vendor doc.
+    expect(readiness.docsUrl).toBeUndefined();
     expect(readiness.setup).toMatchObject({ runtime: 'mtplx', action: 'install-start', blockedReason: null });
     expect(checkById(readiness, 'runtime').fixHint).toMatch(/Install & start MTPLX/);
     expect(checkById(readiness, 'server').fixHint).toMatch(/Install & start MTPLX/);
   });
 
-  it('falls back to the setup docs on a host that cannot run the runtime', async () => {
+  it('explains why the host cannot run the runtime instead of pointing at a doc', async () => {
     const restore = pinPlatform('linux');
     const readiness = await getProviderReadiness(
       { id: 'opencode-mtplx', command: 'opencode', mtplxBacked: true, defaultModel: 'mtplx' },


### PR DESCRIPTION
## Summary

The OpenCode llama TUI card showed a red “llama.cpp is serving `dflash`” note plus a **llama.cpp setup docs** link when the provider default did not match the running server’s model id. That left people reading vendor docs instead of fixing it in PortOS.

- Drop vendor setup-doc links from the local-daemon readiness banner. Setup stays in the PortOS UI (Install/Start buttons and Local LLM settings).
- When llama.cpp (or any local daemon) is serving a different model id than this provider’s default, explain the mismatch and offer **Use `<served id>` as default** on the card.
- Show the running llama.cpp model id (its `--alias`) on the Local LLM speculative-decoding card, and let that alias be set under Advanced options before start.

Assumption: matching the provider default to the currently served id is the right in-place fix, because llama.cpp answers as a single alias (default `dflash`) regardless of which GGUF preset is loaded. Changing the loaded weights remains a Local LLM action.

## Test plan

- [x] `ProviderReadiness` no longer renders a setup-docs link; a mismatch check renders **Use dflash as default**
- [x] Clicking that button `PUT`s the provider with `defaultModel: 'dflash'`
- [x] Server readiness payload includes `servedModels` and a button-oriented hint, not “download yourself”
- [x] Local LLM running panel shows “Providers must send” the alias; advanced options can set alias `dspark`
- [x] Server suite (`npm test --prefix server`) and client suite (`npm test --prefix client`) green