### PR TITLE
Run CI once per gate: drop the main push trigger, reuse the release PR's full run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,8 @@ jobs:
   impact:
     name: Plan test impact
     runs-on: ubuntu-latest
+    # Still live despite the removed push trigger: a called workflow inherits
+    # the caller's event, and release.yml calls this one from a push.
     if: github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]')
     outputs:
       full: ${{ steps.plan.outputs.full }}
@@ -55,10 +57,10 @@ jobs:
       - name: Select affected test surfaces
         id: plan
         env:
-          # Full suite for anything that is not an ordinary PR, and for the
-          # main -> release PR: that PR is the single gate a release ships
-          # behind, so it never runs a scoped plan.
-          CI_FORCE_FULL: ${{ github.event_name != 'pull_request' || github.base_ref == 'release' || inputs.full == true }}
+          CI_FORCE_FULL: ${{ github.event_name != 'pull_request' }}
+          # The planner turns a PR into `release` into a full plan: that PR is
+          # the single gate a release ships behind, so it never runs scoped.
+          CI_BASE_REF: ${{ github.base_ref }}
           CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           CI_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/ci-test-plan.js
@@ -369,3 +371,25 @@ jobs:
             }
             console.log("CI gate passed:", results);
           '
+
+  full-gate:
+    # A second check run published ONLY when the impact plan chose the complete
+    # suite. release.yml keys on this name to skip re-running CI on the push to
+    # `release`; the aggregate "CI Gate" above cannot serve that purpose,
+    # because an impact-scoped PR run publishes a green "CI Gate" too.
+    # Mirrors the gate result the same way the "lint" job mirrors the client
+    # job, so it costs one echo rather than a second aggregation.
+    name: Full CI Gate
+    if: always() && needs.impact.outputs.full == 'true'
+    needs: [impact, gate]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the aggregate gate to have passed
+        env:
+          GATE_RESULT: ${{ needs.gate.result }}
+        run: |
+          if [ "$GATE_RESULT" != "success" ]; then
+            echo "The complete suite ran but CI Gate did not pass ($GATE_RESULT)."
+            exit 1
+          fi
+          echo "Complete suite passed — this tree does not need re-testing on release."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,13 @@
 name: CI
 
 on:
+  # No push trigger. Every change reaches `main` through a pull request whose
+  # own CI gate must be green, so re-running the suite on the merge commit only
+  # repeats work. The nightly schedule below is the main-branch health signal,
+  # and the main -> release pull request runs the complete suite before a
+  # release ships.
   pull_request:
     branches: [main, release]
-  push:
-    branches: [main]
   schedule:
     - cron: '17 9 * * *'
   workflow_dispatch:
@@ -52,7 +55,10 @@ jobs:
       - name: Select affected test surfaces
         id: plan
         env:
-          CI_FORCE_FULL: ${{ github.event_name != 'pull_request' || inputs.full }}
+          # Full suite for anything that is not an ordinary PR, and for the
+          # main -> release PR: that PR is the single gate a release ships
+          # behind, so it never runs a scoped plan.
+          CI_FORCE_FULL: ${{ github.event_name != 'pull_request' || github.base_ref == 'release' || inputs.full == true }}
           CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           CI_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/ci-test-plan.js

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,11 @@ jobs:
       - name: Select affected test surfaces
         id: plan
         env:
-          CI_FORCE_FULL: ${{ github.event_name != 'pull_request' }}
+          # `inputs.full` is only decisive for a caller that invokes this
+          # reusable workflow from a pull_request-triggered workflow — every
+          # call site in this repo comes from a push, which the first clause
+          # already covers. It stays honored so the declared input is real.
+          CI_FORCE_FULL: ${{ github.event_name != 'pull_request' || inputs.full == true }}
           # The planner turns a PR into `release` into a full plan: that PR is
           # the single gate a release ships behind, so it never runs scoped.
           CI_BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,17 +8,58 @@ permissions:
   contents: write
 
 jobs:
-  full-ci:
+  # The main -> release pull request already ran the complete suite on the very
+  # tree this push carries. Look for that green gate instead of paying for it
+  # twice; anything unverified (a direct push to release, a merge that changed
+  # the tree, an API failure) still falls through to the full run below.
+  verify-ci:
+    name: Check for an existing full CI run
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: read
+    outputs:
+      verified: ${{ steps.check.outputs.verified }}
+      sha: ${{ steps.check.outputs.sha }}
+      reason: ${{ steps.check.outputs.reason }}
+    steps:
+      # Depth 2 so both parents of the release merge commit — and their trees —
+      # are available to compare against the tree being released.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+
+      - name: Look for a passing CI Gate on this tree
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/verify-ci-status.js
+
+      - name: Publish verification summary
+        env:
+          VERIFIED: ${{ steps.check.outputs.verified }}
+          REASON: ${{ steps.check.outputs.reason }}
+        run: |
+          {
+            echo "### Release CI verification"
+            echo
+            echo "- Already verified: \`${VERIFIED}\`"
+            echo "- Reason: \`${REASON}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  full-ci:
+    needs: verify-ci
+    if: needs.verify-ci.outputs.verified != 'true'
     uses: ./.github/workflows/ci.yml
     with:
       full: true
 
   release:
-    needs: full-ci
+    needs: [verify-ci, full-ci]
     runs-on: ubuntu-latest
     # Skip version bump commits
-    if: always() && !contains(github.event.head_commit.message, '[skip ci]')
+    if: always() && !contains(github.event.head_commit.message, '[skip ci]') && needs.verify-ci.result == 'success'
 
     steps:
       - uses: actions/checkout@v7
@@ -40,8 +81,10 @@ jobs:
         id: package-version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
+      # full-ci is skipped when verify-ci already found a green gate for this
+      # tree, so only an actually-executed-and-failed run blocks the release.
       - name: Report release failure on CI failure
-        if: needs.full-ci.result != 'success'
+        if: needs.verify-ci.outputs.verified != 'true' && needs.full-ci.result != 'success'
         run: |
           VERSION="${{ steps.package-version.outputs.version }}"
           echo "::error::release v${VERSION} did NOT publish because full-ci status was '${{ needs.full-ci.result }}'"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
       checks: read
     outputs:
       verified: ${{ steps.check.outputs.verified }}
-      sha: ${{ steps.check.outputs.sha }}
       reason: ${{ steps.check.outputs.reason }}
     steps:
       # Depth 2 so both parents of the release merge commit — and their trees —
@@ -30,7 +29,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Look for a passing CI Gate on this tree
+      - name: Look for a passing Full CI Gate on this tree
         id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -58,8 +57,10 @@ jobs:
   release:
     needs: [verify-ci, full-ci]
     runs-on: ubuntu-latest
-    # Skip version bump commits
-    if: always() && !contains(github.event.head_commit.message, '[skip ci]') && needs.verify-ci.result == 'success'
+    # Skip version bump commits. Every other reason a release must not ship is
+    # reported loudly by the step below rather than silently skipping the job —
+    # a silent skip is what leaves a tag with no GitHub Release behind it.
+    if: always() && !contains(github.event.head_commit.message, '[skip ci]')
 
     steps:
       - uses: actions/checkout@v7
@@ -81,13 +82,22 @@ jobs:
         id: package-version
         run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
 
-      # full-ci is skipped when verify-ci already found a green gate for this
-      # tree, so only an actually-executed-and-failed run blocks the release.
+      # full-ci is skipped exactly when verify-ci found a green gate for this
+      # tree, so 'skipped' is a pass here and only a run that actually executed
+      # and failed blocks the release.
       - name: Report release failure on CI failure
-        if: needs.verify-ci.outputs.verified != 'true' && needs.full-ci.result != 'success'
+        if: needs.verify-ci.result != 'success' || needs.full-ci.result == 'failure' || needs.full-ci.result == 'cancelled'
+        env:
+          VERIFY_RESULT: ${{ needs.verify-ci.result }}
+          FULL_CI_RESULT: ${{ needs.full-ci.result }}
+          VERSION: ${{ steps.package-version.outputs.version }}
         run: |
-          VERSION="${{ steps.package-version.outputs.version }}"
-          echo "::error::release v${VERSION} did NOT publish because full-ci status was '${{ needs.full-ci.result }}'"
+          if [ "$VERIFY_RESULT" != "success" ]; then
+            BECAUSE="the CI verification job status was '$VERIFY_RESULT'"
+          else
+            BECAUSE="full-ci status was '$FULL_CI_RESULT'"
+          fi
+          echo "::error::release v${VERSION} did NOT publish because ${BECAUSE}"
           echo "release v${VERSION} did NOT publish"
           exit 1
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -140,11 +140,13 @@ npm run test:db
 cd server && npm run test:watch
 ```
 
-Pull requests run the tests for affected feature directories, with conservative
-fallbacks to Vitest related-test mode or the complete suite. Pushes to `main`,
-nightly CI, manual CI runs, and releases always run the complete server, client,
-DB, lint, build, and smoke checks. Release publication is blocked until that
-full CI gate succeeds.
+Pull requests into `main` run the tests for affected feature directories, with
+conservative fallbacks to Vitest related-test mode or the complete suite. The
+pull request into `release`, nightly CI, and manual CI runs always run the
+complete server, client, DB, lint, build, and smoke checks. Pushes to `main`
+run nothing — the pull request gate already covered that tree. Release
+publication is blocked until a full CI gate has succeeded on the exact tree
+being released. See [GITHUB_ACTIONS.md](./GITHUB_ACTIONS.md).
 
 ## API Documentation
 

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -1,23 +1,43 @@
 # GitHub Actions Workflows
 
 PortOS uses a test-impact-aware CI workflow plus a release workflow that cannot
-publish until the complete CI suite passes.
+publish until the complete CI suite has passed on the exact tree being released.
+
+## Where the suite actually runs
+
+Every change reaches `main` through a pull request, and `main` reaches
+`release` through a pull request, so the suite runs once per gate rather than
+once per event:
+
+| Event | What runs |
+|-------|-----------|
+| PR into `main` | Impact-scoped plan (only the surfaces the diff touches) |
+| Push/merge to `main` | **Nothing** — no push trigger; the PR gate already passed |
+| PR `main` → `release` | **Full suite**, forced regardless of the diff |
+| Push/merge to `release` | Reuses the release PR's green gate; full suite only if it cannot be verified |
+| Nightly 09:17 UTC | Full suite — the `main`-branch health signal |
+| `workflow_dispatch` | Full suite |
+
+A release therefore pays for one full run (on its PR), not three.
 
 ## Branch Strategy
 
 | Branch | Purpose |
 |--------|---------|
 | `main` | Active development |
-| `release` | Push `main` to `release` to trigger releases |
+| `release` | Merge `main` into `release` to trigger releases |
 
 ## CI Workflow (`ci.yml`)
 
-PRs to `main`/`release` use `scripts/ci-test-plan.js` to classify the changed
-files before installing dependencies. Directory-scoped features run their
-server and client feature tests; flat modules fall back to Vitest's
-import-graph-aware `--changed` mode. The planner deliberately chooses full CI
-for shared composition roots, test configuration, dependency manifests,
-workflow changes, unknown artifacts, or wide diffs.
+PRs into `main` use `scripts/ci-test-plan.js` to classify the changed files
+before installing dependencies. Directory-scoped features run their server and
+client feature tests; flat modules fall back to Vitest's import-graph-aware
+`--changed` mode. The planner deliberately chooses full CI for shared
+composition roots, test configuration, dependency manifests, workflow changes,
+unknown artifacts, or wide diffs.
+
+PRs into `release` skip the planner entirely and force the full suite: that PR
+is the single gate a release ships behind.
 
 A short always-run list (`ALWAYS_RUN_TESTS` in the planner) is added to every
 plan, so no impact scope can drop it — currently
@@ -54,7 +74,7 @@ The selected work is split across parallel jobs:
 - **DB tests** — provisions only the isolated `portos_test` database and runs
   the serial DB suite when database-sensitive files changed.
 - **Windows server tests** — the same server selection, but only on full CI
-  (push to `main`, nightly, release, workflow dispatch) or when a
+  (the `main` → `release` PR, nightly, release, workflow dispatch) or when a
   Windows-sensitive surface changed (`.ps1` / `.cmd` spawn, PowerShell BOM,
   `bufferedSpawn`, `cos-runner`, shell/PM2, etc.). Docs-only and ordinary
   Linux-faithful PRs skip this job. `pinPlatform('win32')` tests still run on
@@ -76,10 +96,15 @@ JSON argument array to `spawnSync`, never through shell interpolation.
 
 The complete server, client, DB, lint, build, and smoke suite runs:
 
-- after every push to `main`;
+- on every pull request whose base branch is `release` (the release gate);
 - nightly at 09:17 UTC;
 - from manual workflow dispatch;
-- as a reusable workflow called by every release.
+- as a reusable workflow called by a release whose tree has no verifiable gate.
+
+There is **no push trigger on `main`**. A merge commit on `main` re-tests a
+tree whose PR gate is already green, so the run was pure duplication; the
+nightly full run is what catches a semantic conflict between two independently
+green PRs, and the `main` → `release` PR catches it before a release ships.
 
 Changes to CI/test configuration also force the full suite on their own PR.
 `[skip ci]` remains honored for push events only; PR CI always runs.
@@ -103,17 +128,35 @@ Changes to CI/test configuration also force the full suite on their own PR.
 
 Triggers on push to `release` branch. Steps:
 
-1. Calls `ci.yml` with `full: true` and waits for the complete CI gate.
-2. Reads version from `package.json`.
-3. Checks if the git tag already exists (skips release creation if so).
-4. Looks for a changelog file:
+1. Runs `scripts/verify-ci-status.js` to look for a full CI run that already
+   covered this exact tree (see below).
+2. Calls `ci.yml` with `full: true` **only if** step 1 found nothing.
+3. Reads version from `package.json`.
+4. Checks if the git tag already exists (skips release creation if so).
+5. Looks for a changelog file:
    - First: `.changelog/v{version}.md` (exact match)
    - Then: `.changelog/v{major}.{minor}.x.md` (pattern match, replaces placeholders)
    - Fallback: generates changelog from commit messages
-5. Creates the GitHub release with tag `v{version}`.
-6. If a pattern changelog file (`.changelog/v{major}.{minor}.x.md`) was used,
+6. Creates the GitHub release with tag `v{version}`.
+7. If a pattern changelog file (`.changelog/v{major}.{minor}.x.md`) was used,
    archives it on `main` (renames `.x.md` to the exact version).
-7. If the archive step ran, fast-forwards `release` to match `main`.
+8. If the archive step ran, fast-forwards `release` to match `main`.
+
+### Reusing the release PR's CI run
+
+`scripts/verify-ci-status.js` decides whether the push already has a green
+gate. The rule is **content-based, not SHA-based**: a commit vouches for this
+push only when its git tree is byte-identical to the tree being released *and*
+it carries a completed, successful `CI Gate` check run. It considers the pushed
+commit itself and its direct parents.
+
+The ordinary release merge satisfies this — `release` is strictly behind
+`main`, so the merge commit's tree equals the `main` tip it merged, and that
+tip is exactly the SHA the release PR ran full CI on.
+
+Everything else fails closed and runs the complete suite again: a direct push to
+`release`, a hotfix committed on `release` that changes the merge tree, a
+missing or failed gate, or an unreachable checks API.
 
 ## Working with CI
 

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -83,6 +83,9 @@ The selected work is split across parallel jobs:
   client job; this job only mirrors that result.
 - **CI Gate** — always reports one stable required-check result and fails if any
   selected job failed or was cancelled.
+- **Full CI Gate** — published only when the plan chose the complete suite, and
+  mirrors `CI Gate`'s result. This is the check the release workflow looks for;
+  see "Reusing the release PR's CI run" below.
 
 Targeted `files` / `related` plans run **one** Vitest process for the union of
 planner-selected files and Vitest's `--changed` import graph. The two sets are
@@ -145,10 +148,16 @@ Triggers on push to `release` branch. Steps:
 ### Reusing the release PR's CI run
 
 `scripts/verify-ci-status.js` decides whether the push already has a green
-gate. The rule is **content-based, not SHA-based**: a commit vouches for this
-push only when its git tree is byte-identical to the tree being released *and*
-it carries a completed, successful `CI Gate` check run. It considers the pushed
-commit itself and its direct parents.
+gate. Two independent conditions must hold, because each alone is forgeable:
+
+1. **Content, not SHA.** A commit vouches for this push only when its git tree
+   is byte-identical to the tree being released. It considers the pushed commit
+   itself and its direct parents.
+2. **Fullness.** The gate must be `Full CI Gate`, a check run `ci.yml`
+   publishes *only* when the impact plan chose the complete suite. The
+   aggregate `CI Gate` cannot serve here — an impact-scoped PR run turns it
+   green too, so it cannot distinguish "the full suite passed on this tree"
+   from "some subset of it did".
 
 The ordinary release merge satisfies this — `release` is strictly behind
 `main`, so the merge commit's tree equals the `main` tip it merged, and that
@@ -156,7 +165,7 @@ tip is exactly the SHA the release PR ran full CI on.
 
 Everything else fails closed and runs the complete suite again: a direct push to
 `release`, a hotfix committed on `release` that changes the merge tree, a
-missing or failed gate, or an unreachable checks API.
+missing, failed, or merely impact-scoped gate, or an unreachable checks API.
 
 ## Working with CI
 

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -33,7 +33,7 @@ const FULL_TRIGGER_RULES = [
 // Files whose Windows behavior is not faithfully exercised by pinPlatform()
 // stubs on Linux: real .cmd spawn, PowerShell BOM, PTY wrap, path.basename
 // on backslashes. A PR that does not touch these still gets a full Windows
-// run on main / nightly / release.
+// run nightly, on the main -> release PR, and on release.
 const WINDOWS_RISK_RULES = [
   /\.(?:ps1|cmd|bat)$/i,
   /^scripts\/fix-windows-console(?:\.test)?\.js$/,

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -465,7 +465,7 @@ function main() {
   const base = process.env.CI_BASE_SHA;
   const head = process.env.CI_HEAD_SHA || 'HEAD';
   if (!forceFull && !base) {
-    throw new Error('CI_BASE_SHA is required unless CI_FORCE_FULL=true.');
+    throw new Error('CI_BASE_SHA is required unless the run is forced full (CI_FORCE_FULL=true or CI_BASE_REF=release).');
   }
   const changedFiles = forceFull
     ? []

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 
-import { appendFileSync } from 'fs';
 import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { resolve } from 'path';
+import { writeStepOutput } from './lib/githubOutput.js';
 
 const TEST_FILE_RE = /\.(?:test|spec)\.[cm]?[jt]sx?$/i;
 const CLIENT_LINT_RE = /^client\/src\/.*\.(?:js|jsx)$/i;
@@ -26,8 +26,10 @@ const FULL_TRIGGER_RULES = [
   { re: /^server\/index\.js$/, reason: 'server composition root changed' },
   { re: /^client\/src\/App\.jsx$/, reason: 'client composition root changed' },
   { re: /^server\/lib\/(?:schemaVersions|validation)\.js$/, reason: 'shared server contract changed' },
-  { re: /^scripts\/ci-test-plan(?:\.test)?\.js$/, reason: 'CI impact planner changed' },
-  { re: /^scripts\/run-ci-(?:lint|tests)(?:\.test)?\.js$/, reason: 'CI runner changed' },
+  // The scripts that decide what CI runs, run it, and gate the release on it.
+  // A bug in any of them can make a scoped plan silently test nothing, so they
+  // prove themselves against the complete suite rather than their own scope.
+  { re: /^scripts\/(?:ci-test-plan|run-ci-(?:lint|tests)|verify-ci-status)(?:\.test)?\.js$/, reason: 'CI pipeline script changed' },
 ];
 
 // Files whose Windows behavior is not faithfully exercised by pinPlatform()
@@ -248,14 +250,18 @@ const skippedRunner = () => ({ mode: 'skip', files: [] });
  * Flat/shared files fall back to Vitest's import-graph-aware "related" mode,
  * while composition roots and test configuration force the complete suite.
  */
-export function buildCiTestPlan(changedFiles, { trackedFiles = [], forceFull = false } = {}) {
+export function buildCiTestPlan(changedFiles, {
+  trackedFiles = [],
+  forceFull = false,
+  forceFullReason = 'full CI requested',
+} = {}) {
   const changed = uniqueSorted(changedFiles.filter(Boolean));
   const trackedSet = new Set(trackedFiles);
 
   if (forceFull) {
     return {
       full: true,
-      reason: 'full CI requested',
+      reason: forceFullReason,
       changedFiles: changed,
       server: { mode: 'full', files: [] },
       client: { mode: 'full', files: [] },
@@ -414,12 +420,6 @@ const gitLines = (args) => execFileSync('git', args, { encoding: 'utf8' })
   .map((line) => line.trim())
   .filter(Boolean);
 
-const writeOutput = (name, value) => {
-  const outputPath = process.env.GITHUB_OUTPUT;
-  if (!outputPath) return;
-  appendFileSync(outputPath, `${name}=${String(value)}\n`);
-};
-
 export function emitGitHubPlan(plan) {
   const outputs = {
     full: plan.full,
@@ -439,12 +439,29 @@ export function emitGitHubPlan(plan) {
     server_native: plan.serverNative,
   };
 
-  Object.entries(outputs).forEach(([name, value]) => writeOutput(name, value));
+  Object.entries(outputs).forEach(([name, value]) => writeStepOutput(name, value));
   console.log(JSON.stringify({ ...outputs, changed_files: plan.changedFiles }, null, 2));
 }
 
+/**
+ * Why this run cannot be scoped, or null when it can be.
+ *
+ * A pull request into `release` is the single gate a release ships behind —
+ * release.yml skips its own suite on the strength of it — so it always runs
+ * complete, whatever its diff touches.
+ */
+export function forceFullReasonFor({ forceFull, baseRef }) {
+  if (forceFull) return 'full CI requested';
+  if (baseRef === 'release') return 'release gate: pull request into release';
+  return null;
+}
+
 function main() {
-  const forceFull = process.env.CI_FORCE_FULL === 'true';
+  const forceFullReason = forceFullReasonFor({
+    forceFull: process.env.CI_FORCE_FULL === 'true',
+    baseRef: process.env.CI_BASE_REF,
+  });
+  const forceFull = Boolean(forceFullReason);
   const base = process.env.CI_BASE_SHA;
   const head = process.env.CI_HEAD_SHA || 'HEAD';
   if (!forceFull && !base) {
@@ -454,7 +471,7 @@ function main() {
     ? []
     : gitLines(['diff', '--name-only', '--diff-filter=ACMRD', `${base}...${head}`]);
   const trackedFiles = gitLines(['ls-files']);
-  emitGitHubPlan(buildCiTestPlan(changedFiles, { trackedFiles, forceFull }));
+  emitGitHubPlan(buildCiTestPlan(changedFiles, { trackedFiles, forceFull, forceFullReason }));
 }
 
 const isMain = process.argv[1]

--- a/scripts/ci-test-plan.test.js
+++ b/scripts/ci-test-plan.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildCiTestPlan, WINDOWS_CONTRACT_TESTS } from './ci-test-plan.js';
+import { buildCiTestPlan, forceFullReasonFor, WINDOWS_CONTRACT_TESTS } from './ci-test-plan.js';
 
 const TRACKED = [
   'server/lib/index.test.js',
@@ -271,6 +271,41 @@ describe('CI test impact planner', () => {
     );
     expect(wide.full).toBe(true);
     expect(wide.reason).toMatch(/wide change/);
+  });
+
+  it('forces the complete suite for a pull request into release', () => {
+    // release.yml skips its own suite on the strength of this run, so it must
+    // never be scoped — whatever the diff happens to touch.
+    expect(forceFullReasonFor({ forceFull: false, baseRef: 'release' }))
+      .toBe('release gate: pull request into release');
+
+    const plan = buildCiTestPlan([], {
+      trackedFiles: TRACKED,
+      forceFull: true,
+      forceFullReason: forceFullReasonFor({ forceFull: false, baseRef: 'release' }),
+    });
+    expect(plan).toMatchObject({ full: true, server: { mode: 'full' }, windows: true });
+    expect(plan.reason).toMatch(/release gate/);
+  });
+
+  it('lets an ordinary pull request into main stay scoped', () => {
+    expect(forceFullReasonFor({ forceFull: false, baseRef: 'main' })).toBeNull();
+    expect(forceFullReasonFor({ forceFull: false, baseRef: undefined })).toBeNull();
+    expect(forceFullReasonFor({ forceFull: true, baseRef: 'main' })).toBe('full CI requested');
+  });
+
+  it('routes CI pipeline scripts to the complete suite', () => {
+    for (const path of [
+      'scripts/ci-test-plan.js',
+      'scripts/run-ci-tests.js',
+      'scripts/run-ci-lint.js',
+      'scripts/verify-ci-status.js',
+      'scripts/verify-ci-status.test.js',
+    ]) {
+      const plan = buildCiTestPlan([path], { trackedFiles: TRACKED });
+      expect(plan.full, path).toBe(true);
+      expect(plan.reason, path).toMatch(/CI pipeline script changed/);
+    }
   });
 
   it('honors an explicit full-CI request', () => {

--- a/scripts/lib/githubOutput.js
+++ b/scripts/lib/githubOutput.js
@@ -1,0 +1,25 @@
+/**
+ * GitHub Actions step-output/summary append helpers for CI scripts.
+ *
+ * ZERO external dependencies — these run in jobs that have not installed
+ * anything yet. Do NOT import from server/lib or any installed package.
+ */
+
+import { appendFileSync } from 'fs';
+
+/**
+ * Append `name=value` to $GITHUB_OUTPUT, or do nothing outside Actions.
+ *
+ * Newlines and carriage returns are stripped: the `name=value` form has no
+ * escape, so an embedded newline silently truncates the value and lets the
+ * remainder forge a second output. Callers that render a value as markdown
+ * should sanitize further at their own call site.
+ *
+ * @param {string} name - output name
+ * @param {unknown} value - stringified before writing
+ */
+export function writeStepOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  appendFileSync(outputPath, `${name}=${String(value).replace(/[\r\n]+/g, ' ')}\n`);
+}

--- a/scripts/lib/githubOutput.test.js
+++ b/scripts/lib/githubOutput.test.js
@@ -1,0 +1,43 @@
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { writeStepOutput } from './githubOutput.js';
+
+describe('writeStepOutput', () => {
+  let outputPath;
+  const previous = process.env.GITHUB_OUTPUT;
+
+  beforeEach(() => {
+    outputPath = join(mkdtempSync(join(tmpdir(), 'gh-output-')), 'output.txt');
+    writeFileSync(outputPath, '');
+    process.env.GITHUB_OUTPUT = outputPath;
+  });
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.GITHUB_OUTPUT;
+    else process.env.GITHUB_OUTPUT = previous;
+  });
+
+  it('appends one name=value line per call', () => {
+    writeStepOutput('verified', true);
+    writeStepOutput('reason', 'identical tree');
+
+    expect(readFileSync(outputPath, 'utf8')).toBe('verified=true\nreason=identical tree\n');
+  });
+
+  it('strips newlines so a value cannot forge a second output', () => {
+    writeStepOutput('reason', 'first line\nverified=true');
+
+    expect(readFileSync(outputPath, 'utf8')).toBe('reason=first line verified=true\n');
+  });
+
+  it('does nothing outside GitHub Actions', () => {
+    delete process.env.GITHUB_OUTPUT;
+
+    expect(() => writeStepOutput('verified', false)).not.toThrow();
+    expect(readFileSync(outputPath, 'utf8')).toBe('');
+  });
+});

--- a/scripts/verify-ci-status.js
+++ b/scripts/verify-ci-status.js
@@ -4,58 +4,63 @@
 // run, so the release workflow does not repeat the ~8-minute suite the
 // main -> release pull request just finished.
 //
-// The rule is content-based, not SHA-based: a candidate commit verifies this
-// push only when its git tree is byte-identical to the tree being released AND
-// it carries a completed, successful "CI Gate" check run. A merge commit on
-// `release` has the same tree as the `main` tip it merged (release is strictly
-// behind main), and that tip is exactly the SHA the release PR ran full CI on.
+// Two independent conditions must hold, because each alone is forgeable:
+//
+//   1. CONTENT, not SHA. A candidate commit vouches for this push only when its
+//      git tree is byte-identical to the tree being released. A merge commit on
+//      `release` has the same tree as the `main` tip it merged (release is
+//      strictly behind main), and that tip is the SHA the release PR gated.
+//   2. FULLNESS. The gate must be `Full CI Gate`, which ci.yml publishes only
+//      when the impact plan chose the complete suite. The aggregate `CI Gate`
+//      check is green on impact-scoped PR runs too, so it cannot distinguish
+//      "the full suite passed on this tree" from "some subset of it did".
 //
 // Anything else — a direct push to `release`, a merge that changed the tree, a
-// missing or failed gate, an unreachable API — reports `verified=false`, and
-// the release workflow falls back to running the complete suite.
+// missing/failed/scoped gate, an unreachable checks API — reports
+// `verified=false`, and the release workflow runs the complete suite.
 
 import { spawnSync } from 'child_process';
-import { appendFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { resolve } from 'path';
+import { writeStepOutput } from './lib/githubOutput.js';
 
-export const CI_GATE_CHECK_NAME = 'CI Gate';
+// Must match the `Full CI Gate` job name in .github/workflows/ci.yml.
+// verify-ci-status.test.js asserts that, because a silent rename here would
+// make every release fall back to the full suite forever with no other symptom.
+export const FULL_CI_GATE_CHECK_NAME = 'Full CI Gate';
 
-/** Parent SHAs from a raw `git cat-file -p <commit>` payload. */
-export function parseCommitParents(commitObject) {
-  // The header ends at the first blank line. Stop there, or a commit message
-  // body line beginning with "parent " would forge a candidate.
-  const lines = String(commitObject || '').split('\n');
-  const headerEnd = lines.indexOf('');
-  return lines
-    .slice(0, headerEnd === -1 ? lines.length : headerEnd)
-    .filter((line) => line.startsWith('parent '))
-    .map((line) => line.slice('parent '.length).trim())
-    .filter(Boolean);
+/** Tree SHA and parent SHAs from `git show -s --format=%T%n%P <commit>`. */
+export function parseCommitSummary(showOutput) {
+  const [tree = '', parents = ''] = String(showOutput || '').split('\n');
+  return {
+    tree: tree.trim() || null,
+    parents: parents.trim().split(' ').filter(Boolean),
+  };
 }
 
-/** The completed, successful CI gate in a `/check-runs` payload, or null. */
-export function findPassingGate(checkRuns, gateName = CI_GATE_CHECK_NAME) {
-  const runs = Array.isArray(checkRuns) ? checkRuns : [];
-  return runs.find((run) => (
-    run?.name === gateName
+/** True when a `/check-runs` payload holds a completed, successful full gate. */
+export function hasPassingGate(checkRuns) {
+  return Array.isArray(checkRuns) && checkRuns.some((run) => (
+    run?.name === FULL_CI_GATE_CHECK_NAME
     && run?.status === 'completed'
     && run?.conclusion === 'success'
-  )) || null;
+  ));
 }
 
 /**
- * Pick the commit whose green CI gate vouches for `headTree`.
+ * SHA of the first candidate whose green full gate vouches for `headTree`.
  *
- * @param {Array<{sha: string, tree: string|null, checkRuns: Array}>} candidates
- * @param {string} headTree tree SHA of the commit being released
+ * Checks are fetched lazily so a verified first candidate costs one API call.
+ *
+ * @param {Array<{sha: string, tree: string|null}>} candidates
+ * @param {string|null} headTree tree SHA of the commit being released
+ * @param {(sha: string) => Array|null} fetchCheckRuns null = could not ask
  */
-export function selectVerifiedCommit(candidates, headTree, gateName = CI_GATE_CHECK_NAME) {
+export function findVerifiedSha(candidates, headTree, fetchCheckRuns) {
   if (!headTree) return null;
-  for (const candidate of candidates) {
-    if (!candidate?.tree || candidate.tree !== headTree) continue;
-    const gate = findPassingGate(candidate.checkRuns, gateName);
-    if (gate) return { sha: candidate.sha, gate };
+  for (const { sha, tree } of candidates) {
+    if (tree !== headTree) continue;
+    if (hasPassingGate(fetchCheckRuns(sha))) return sha;
   }
   return null;
 }
@@ -66,57 +71,53 @@ const capture = (command, args) => {
   return result.stdout.trim();
 };
 
-const gitTree = (sha) => capture('git', ['rev-parse', `${sha}^{tree}`]);
-
+// null = the checks API could not be reached, [] = it answered with no gate.
+// Both end the release at "unverified", but only the first is worth a warning.
 function fetchCheckRuns(repo, sha) {
-  const body = capture('gh', ['api', `repos/${repo}/commits/${sha}/check-runs?per_page=100`]);
-  if (!body) {
-    console.warn(`⚠️  Could not read check runs for ${sha.slice(0, 8)}.`);
-    return [];
+  const query = `check_name=${encodeURIComponent(FULL_CI_GATE_CHECK_NAME)}&filter=latest`;
+  const body = capture('gh', ['api', `repos/${repo}/commits/${sha}/check-runs?${query}`]);
+  if (body === null) {
+    console.warn(`⚠️  Checks API unreachable for ${sha.slice(0, 8)} — treating it as unverified.`);
+    return null;
   }
   return JSON.parse(body).check_runs || [];
 }
 
-const writeOutput = (name, value) => {
-  if (!process.env.GITHUB_OUTPUT) return;
-  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${String(value)}\n`);
-};
-
-function emit(verified, sha, reason) {
-  writeOutput('verified', verified);
-  writeOutput('sha', sha);
-  writeOutput('reason', reason);
+function emit(verified, reason) {
+  writeStepOutput('verified', verified);
+  writeStepOutput('reason', reason);
 }
 
 function main() {
   const repo = process.env.GITHUB_REPOSITORY;
   const head = process.env.GITHUB_SHA || capture('git', ['rev-parse', 'HEAD']);
   if (!repo || !head) {
-    console.log('❔ No repository or head SHA available — requiring a full CI run.');
-    emit(false, '', 'missing repository or head SHA');
+    console.log('❔ No repository or head SHA available — running the full suite.');
+    emit(false, 'missing repository or head SHA');
     return;
   }
 
-  const headTree = gitTree(head);
-  const commitObject = capture('git', ['cat-file', '-p', head]) || '';
+  const { tree: headTree, parents } = parseCommitSummary(
+    capture('git', ['show', '-s', '--format=%T%n%P', head]),
+  );
   // HEAD first: a workflow_dispatch or re-run may have gated this exact SHA.
-  // Parents are content-checked too, so the previous release tip cannot vouch
-  // for a merge that actually changed the tree.
-  const candidates = [head, ...parseCommitParents(commitObject)].map((sha) => {
-    const tree = gitTree(sha);
-    return { sha, tree, checkRuns: tree === headTree ? fetchCheckRuns(repo, sha) : [] };
-  });
+  // Parents are tree-checked too, so the previous release tip cannot vouch for
+  // a merge that actually changed the tree.
+  const candidates = [
+    { sha: head, tree: headTree },
+    ...parents.map((sha) => ({ sha, tree: capture('git', ['rev-parse', `${sha}^{tree}`]) })),
+  ];
 
-  const verified = selectVerifiedCommit(candidates, headTree);
+  const verified = findVerifiedSha(candidates, headTree, (sha) => fetchCheckRuns(repo, sha));
   if (verified) {
-    const short = verified.sha.slice(0, 8);
-    console.log(`✅ CI Gate already passed on ${short} with this exact tree — skipping the full suite.`);
-    emit(true, verified.sha, `CI Gate succeeded on ${short} with an identical tree`);
+    const short = verified.slice(0, 8);
+    console.log(`✅ Full CI already passed on ${short} with this exact tree — skipping the suite.`);
+    emit(true, `${FULL_CI_GATE_CHECK_NAME} succeeded on ${short} with an identical tree`);
     return;
   }
 
-  console.log('🧪 No green CI Gate found for this tree — running the full suite.');
-  emit(false, '', 'no successful CI Gate found for this tree');
+  console.log(`🧪 No green ${FULL_CI_GATE_CHECK_NAME} for this tree — running the full suite.`);
+  emit(false, `no successful ${FULL_CI_GATE_CHECK_NAME} for this tree`);
 }
 
 const isMain = process.argv[1]

--- a/scripts/verify-ci-status.js
+++ b/scripts/verify-ci-status.js
@@ -71,8 +71,13 @@ const capture = (command, args) => {
   return result.stdout.trim();
 };
 
-// null = the checks API could not be reached, [] = it answered with no gate.
-// Both end the release at "unverified", but only the first is worth a warning.
+// null = the checks API could not be answered for this sha, [] = it answered
+// with no gate. Both end the release at "unverified", but only the first warns.
+//
+// The parse is guarded because an unreadable answer must degrade to "run the
+// full suite", not throw: an uncaught throw here fails the verify job, and the
+// release then reports a hard error instead of simply re-testing the tree.
+// A 200 carrying non-JSON (proxy/captive-portal HTML) is the realistic case.
 function fetchCheckRuns(repo, sha) {
   const query = `check_name=${encodeURIComponent(FULL_CI_GATE_CHECK_NAME)}&filter=latest`;
   const body = capture('gh', ['api', `repos/${repo}/commits/${sha}/check-runs?${query}`]);
@@ -80,7 +85,19 @@ function fetchCheckRuns(repo, sha) {
     console.warn(`⚠️  Checks API unreachable for ${sha.slice(0, 8)} — treating it as unverified.`);
     return null;
   }
-  return JSON.parse(body).check_runs || [];
+  return parseCheckRuns(body, sha);
+}
+
+/** check_runs from a `/check-runs` response body, or null when unreadable. */
+export function parseCheckRuns(body, sha = '') {
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    console.warn(`⚠️  Unreadable checks response for ${String(sha).slice(0, 8)} — treating it as unverified.`);
+    return null;
+  }
+  return Array.isArray(parsed?.check_runs) ? parsed.check_runs : [];
 }
 
 function emit(verified, reason) {

--- a/scripts/verify-ci-status.js
+++ b/scripts/verify-ci-status.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+
+// Decides whether the commit being released was ALREADY validated by a full CI
+// run, so the release workflow does not repeat the ~8-minute suite the
+// main -> release pull request just finished.
+//
+// The rule is content-based, not SHA-based: a candidate commit verifies this
+// push only when its git tree is byte-identical to the tree being released AND
+// it carries a completed, successful "CI Gate" check run. A merge commit on
+// `release` has the same tree as the `main` tip it merged (release is strictly
+// behind main), and that tip is exactly the SHA the release PR ran full CI on.
+//
+// Anything else — a direct push to `release`, a merge that changed the tree, a
+// missing or failed gate, an unreachable API — reports `verified=false`, and
+// the release workflow falls back to running the complete suite.
+
+import { spawnSync } from 'child_process';
+import { appendFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { resolve } from 'path';
+
+export const CI_GATE_CHECK_NAME = 'CI Gate';
+
+/** Parent SHAs from a raw `git cat-file -p <commit>` payload. */
+export function parseCommitParents(commitObject) {
+  // The header ends at the first blank line. Stop there, or a commit message
+  // body line beginning with "parent " would forge a candidate.
+  const lines = String(commitObject || '').split('\n');
+  const headerEnd = lines.indexOf('');
+  return lines
+    .slice(0, headerEnd === -1 ? lines.length : headerEnd)
+    .filter((line) => line.startsWith('parent '))
+    .map((line) => line.slice('parent '.length).trim())
+    .filter(Boolean);
+}
+
+/** The completed, successful CI gate in a `/check-runs` payload, or null. */
+export function findPassingGate(checkRuns, gateName = CI_GATE_CHECK_NAME) {
+  const runs = Array.isArray(checkRuns) ? checkRuns : [];
+  return runs.find((run) => (
+    run?.name === gateName
+    && run?.status === 'completed'
+    && run?.conclusion === 'success'
+  )) || null;
+}
+
+/**
+ * Pick the commit whose green CI gate vouches for `headTree`.
+ *
+ * @param {Array<{sha: string, tree: string|null, checkRuns: Array}>} candidates
+ * @param {string} headTree tree SHA of the commit being released
+ */
+export function selectVerifiedCommit(candidates, headTree, gateName = CI_GATE_CHECK_NAME) {
+  if (!headTree) return null;
+  for (const candidate of candidates) {
+    if (!candidate?.tree || candidate.tree !== headTree) continue;
+    const gate = findPassingGate(candidate.checkRuns, gateName);
+    if (gate) return { sha: candidate.sha, gate };
+  }
+  return null;
+}
+
+const capture = (command, args) => {
+  const result = spawnSync(command, args, { encoding: 'utf8' });
+  if (result.error || result.status !== 0) return null;
+  return result.stdout.trim();
+};
+
+const gitTree = (sha) => capture('git', ['rev-parse', `${sha}^{tree}`]);
+
+function fetchCheckRuns(repo, sha) {
+  const body = capture('gh', ['api', `repos/${repo}/commits/${sha}/check-runs?per_page=100`]);
+  if (!body) {
+    console.warn(`⚠️  Could not read check runs for ${sha.slice(0, 8)}.`);
+    return [];
+  }
+  return JSON.parse(body).check_runs || [];
+}
+
+const writeOutput = (name, value) => {
+  if (!process.env.GITHUB_OUTPUT) return;
+  appendFileSync(process.env.GITHUB_OUTPUT, `${name}=${String(value)}\n`);
+};
+
+function emit(verified, sha, reason) {
+  writeOutput('verified', verified);
+  writeOutput('sha', sha);
+  writeOutput('reason', reason);
+}
+
+function main() {
+  const repo = process.env.GITHUB_REPOSITORY;
+  const head = process.env.GITHUB_SHA || capture('git', ['rev-parse', 'HEAD']);
+  if (!repo || !head) {
+    console.log('❔ No repository or head SHA available — requiring a full CI run.');
+    emit(false, '', 'missing repository or head SHA');
+    return;
+  }
+
+  const headTree = gitTree(head);
+  const commitObject = capture('git', ['cat-file', '-p', head]) || '';
+  // HEAD first: a workflow_dispatch or re-run may have gated this exact SHA.
+  // Parents are content-checked too, so the previous release tip cannot vouch
+  // for a merge that actually changed the tree.
+  const candidates = [head, ...parseCommitParents(commitObject)].map((sha) => {
+    const tree = gitTree(sha);
+    return { sha, tree, checkRuns: tree === headTree ? fetchCheckRuns(repo, sha) : [] };
+  });
+
+  const verified = selectVerifiedCommit(candidates, headTree);
+  if (verified) {
+    const short = verified.sha.slice(0, 8);
+    console.log(`✅ CI Gate already passed on ${short} with this exact tree — skipping the full suite.`);
+    emit(true, verified.sha, `CI Gate succeeded on ${short} with an identical tree`);
+    return;
+  }
+
+  console.log('🧪 No green CI Gate found for this tree — running the full suite.');
+  emit(false, '', 'no successful CI Gate found for this tree');
+}
+
+const isMain = process.argv[1]
+  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) main();

--- a/scripts/verify-ci-status.test.js
+++ b/scripts/verify-ci-status.test.js
@@ -8,6 +8,7 @@ import {
   FULL_CI_GATE_CHECK_NAME,
   findVerifiedSha,
   hasPassingGate,
+  parseCheckRuns,
   parseCommitSummary,
 } from './verify-ci-status.js';
 
@@ -60,6 +61,25 @@ describe('hasPassingGate', () => {
   it('treats an unreachable checks API the same as no gate', () => {
     expect(hasPassingGate(null)).toBe(false);
     expect(hasPassingGate([])).toBe(false);
+  });
+});
+
+describe('parseCheckRuns', () => {
+  it('returns the check runs from a well-formed response', () => {
+    expect(parseCheckRuns(JSON.stringify({ check_runs: [passingGate] }))).toEqual([passingGate]);
+  });
+
+  it('reads a gate-less answer as empty, not unreadable', () => {
+    expect(parseCheckRuns(JSON.stringify({ check_runs: [] }))).toEqual([]);
+    expect(parseCheckRuns(JSON.stringify({ total_count: 0 }))).toEqual([]);
+  });
+
+  it('degrades an unreadable body to null instead of throwing', () => {
+    // A 200 carrying non-JSON (proxy / captive-portal HTML) must fall back to
+    // running the full suite, not fail the verify job and block the release.
+    expect(() => parseCheckRuns('<html>nope</html>')).not.toThrow();
+    expect(parseCheckRuns('<html>nope</html>')).toBeNull();
+    expect(parseCheckRuns('null')).toEqual([]);
   });
 });
 

--- a/scripts/verify-ci-status.test.js
+++ b/scripts/verify-ci-status.test.js
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CI_GATE_CHECK_NAME,
+  findPassingGate,
+  parseCommitParents,
+  selectVerifiedCommit,
+} from './verify-ci-status.js';
+
+const passingGate = { name: CI_GATE_CHECK_NAME, status: 'completed', conclusion: 'success' };
+
+const mergeCommit = [
+  'tree 1111111111111111111111111111111111111111',
+  'parent aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  'parent bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  'author github-actions <bot@example.com> 0 +0000',
+  'committer github-actions <bot@example.com> 0 +0000',
+  '',
+  'Merge pull request #1 from example/main',
+].join('\n');
+
+describe('parseCommitParents', () => {
+  it('reads both parents of a merge commit', () => {
+    expect(parseCommitParents(mergeCommit)).toEqual([
+      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    ]);
+  });
+
+  it('stops at the header so a commit message cannot forge a parent', () => {
+    const forged = [
+      'tree 1111111111111111111111111111111111111111',
+      'parent aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '',
+      'parent cccccccccccccccccccccccccccccccccccccccc',
+    ].join('\n');
+
+    expect(parseCommitParents(forged)).toEqual(['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
+  });
+
+  it('returns nothing for a root commit or empty input', () => {
+    expect(parseCommitParents('tree 1111\nauthor a <a@example.com> 0 +0000\n\nroot')).toEqual([]);
+    expect(parseCommitParents('')).toEqual([]);
+    expect(parseCommitParents(null)).toEqual([]);
+  });
+});
+
+describe('findPassingGate', () => {
+  it('only accepts a completed successful gate under the exact name', () => {
+    expect(findPassingGate([passingGate])).toEqual(passingGate);
+    expect(findPassingGate([{ ...passingGate, conclusion: 'failure' }])).toBeNull();
+    expect(findPassingGate([{ ...passingGate, status: 'in_progress', conclusion: null }])).toBeNull();
+    expect(findPassingGate([{ ...passingGate, name: 'lint' }])).toBeNull();
+    expect(findPassingGate([])).toBeNull();
+    expect(findPassingGate(undefined)).toBeNull();
+  });
+});
+
+describe('selectVerifiedCommit', () => {
+  const headTree = 'tree-head';
+
+  it('accepts the merged branch head when its tree matches', () => {
+    const verified = selectVerifiedCommit([
+      { sha: 'merge', tree: headTree, checkRuns: [] },
+      { sha: 'prev-release', tree: 'tree-old', checkRuns: [passingGate] },
+      { sha: 'main-tip', tree: headTree, checkRuns: [passingGate] },
+    ], headTree);
+
+    expect(verified).toMatchObject({ sha: 'main-tip' });
+  });
+
+  it('refuses a green parent whose tree differs from what is being released', () => {
+    expect(selectVerifiedCommit([
+      { sha: 'merge', tree: headTree, checkRuns: [] },
+      { sha: 'prev-release', tree: 'tree-old', checkRuns: [passingGate] },
+    ], headTree)).toBeNull();
+  });
+
+  it('refuses a same-tree commit whose gate did not pass', () => {
+    expect(selectVerifiedCommit([
+      { sha: 'main-tip', tree: headTree, checkRuns: [{ ...passingGate, conclusion: 'failure' }] },
+    ], headTree)).toBeNull();
+  });
+
+  it('prefers a gate on the released commit itself', () => {
+    const verified = selectVerifiedCommit([
+      { sha: 'merge', tree: headTree, checkRuns: [passingGate] },
+      { sha: 'main-tip', tree: headTree, checkRuns: [passingGate] },
+    ], headTree);
+
+    expect(verified).toMatchObject({ sha: 'merge' });
+  });
+
+  it('fails closed when the head tree could not be resolved', () => {
+    expect(selectVerifiedCommit([
+      { sha: 'main-tip', tree: null, checkRuns: [passingGate] },
+    ], null)).toBeNull();
+  });
+});

--- a/scripts/verify-ci-status.test.js
+++ b/scripts/verify-ci-status.test.js
@@ -1,99 +1,105 @@
-import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+import { describe, expect, it, vi } from 'vitest';
 
 import {
-  CI_GATE_CHECK_NAME,
-  findPassingGate,
-  parseCommitParents,
-  selectVerifiedCommit,
+  FULL_CI_GATE_CHECK_NAME,
+  findVerifiedSha,
+  hasPassingGate,
+  parseCommitSummary,
 } from './verify-ci-status.js';
 
-const passingGate = { name: CI_GATE_CHECK_NAME, status: 'completed', conclusion: 'success' };
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const passingGate = { name: FULL_CI_GATE_CHECK_NAME, status: 'completed', conclusion: 'success' };
 
-const mergeCommit = [
-  'tree 1111111111111111111111111111111111111111',
-  'parent aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-  'parent bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-  'author github-actions <bot@example.com> 0 +0000',
-  'committer github-actions <bot@example.com> 0 +0000',
-  '',
-  'Merge pull request #1 from example/main',
-].join('\n');
-
-describe('parseCommitParents', () => {
-  it('reads both parents of a merge commit', () => {
-    expect(parseCommitParents(mergeCommit)).toEqual([
-      'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
-    ]);
+describe('the full-CI gate name', () => {
+  it('matches the job ci.yml actually publishes', () => {
+    // A rename on either side has no symptom other than every release silently
+    // paying for the full suite again, so pin the two together.
+    const ci = readFileSync(join(repoRoot, '.github/workflows/ci.yml'), 'utf8');
+    expect(ci).toContain(`name: ${FULL_CI_GATE_CHECK_NAME}`);
   });
 
-  it('stops at the header so a commit message cannot forge a parent', () => {
-    const forged = [
-      'tree 1111111111111111111111111111111111111111',
-      'parent aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
-      '',
-      'parent cccccccccccccccccccccccccccccccccccccccc',
-    ].join('\n');
-
-    expect(parseCommitParents(forged)).toEqual(['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa']);
-  });
-
-  it('returns nothing for a root commit or empty input', () => {
-    expect(parseCommitParents('tree 1111\nauthor a <a@example.com> 0 +0000\n\nroot')).toEqual([]);
-    expect(parseCommitParents('')).toEqual([]);
-    expect(parseCommitParents(null)).toEqual([]);
+  it('is not the aggregate gate, which is green on scoped runs too', () => {
+    expect(FULL_CI_GATE_CHECK_NAME).not.toBe('CI Gate');
   });
 });
 
-describe('findPassingGate', () => {
-  it('only accepts a completed successful gate under the exact name', () => {
-    expect(findPassingGate([passingGate])).toEqual(passingGate);
-    expect(findPassingGate([{ ...passingGate, conclusion: 'failure' }])).toBeNull();
-    expect(findPassingGate([{ ...passingGate, status: 'in_progress', conclusion: null }])).toBeNull();
-    expect(findPassingGate([{ ...passingGate, name: 'lint' }])).toBeNull();
-    expect(findPassingGate([])).toBeNull();
-    expect(findPassingGate(undefined)).toBeNull();
+describe('parseCommitSummary', () => {
+  it('reads the tree and both parents of a merge commit', () => {
+    expect(parseCommitSummary('tree-sha\nparent-a parent-b')).toEqual({
+      tree: 'tree-sha',
+      parents: ['parent-a', 'parent-b'],
+    });
+  });
+
+  it('reads a root commit as having no parents', () => {
+    expect(parseCommitSummary('tree-sha\n')).toEqual({ tree: 'tree-sha', parents: [] });
+  });
+
+  it('reports no tree when git could not be asked', () => {
+    expect(parseCommitSummary(null)).toEqual({ tree: null, parents: [] });
+    expect(parseCommitSummary('')).toEqual({ tree: null, parents: [] });
   });
 });
 
-describe('selectVerifiedCommit', () => {
+describe('hasPassingGate', () => {
+  it('only accepts a completed successful run under the full-gate name', () => {
+    expect(hasPassingGate([passingGate])).toBe(true);
+    expect(hasPassingGate([{ ...passingGate, conclusion: 'failure' }])).toBe(false);
+    expect(hasPassingGate([{ ...passingGate, conclusion: 'skipped' }])).toBe(false);
+    expect(hasPassingGate([{ ...passingGate, status: 'in_progress', conclusion: null }])).toBe(false);
+  });
+
+  it('rejects the aggregate gate, which a scoped PR run also turns green', () => {
+    expect(hasPassingGate([{ ...passingGate, name: 'CI Gate' }])).toBe(false);
+  });
+
+  it('treats an unreachable checks API the same as no gate', () => {
+    expect(hasPassingGate(null)).toBe(false);
+    expect(hasPassingGate([])).toBe(false);
+  });
+});
+
+describe('findVerifiedSha', () => {
   const headTree = 'tree-head';
+  const gated = (...shas) => vi.fn((sha) => (shas.includes(sha) ? [passingGate] : []));
 
   it('accepts the merged branch head when its tree matches', () => {
-    const verified = selectVerifiedCommit([
-      { sha: 'merge', tree: headTree, checkRuns: [] },
-      { sha: 'prev-release', tree: 'tree-old', checkRuns: [passingGate] },
-      { sha: 'main-tip', tree: headTree, checkRuns: [passingGate] },
-    ], headTree);
+    const candidates = [
+      { sha: 'merge', tree: headTree },
+      { sha: 'prev-release', tree: 'tree-old' },
+      { sha: 'main-tip', tree: headTree },
+    ];
 
-    expect(verified).toMatchObject({ sha: 'main-tip' });
+    expect(findVerifiedSha(candidates, headTree, gated('main-tip'))).toBe('main-tip');
   });
 
-  it('refuses a green parent whose tree differs from what is being released', () => {
-    expect(selectVerifiedCommit([
-      { sha: 'merge', tree: headTree, checkRuns: [] },
-      { sha: 'prev-release', tree: 'tree-old', checkRuns: [passingGate] },
-    ], headTree)).toBeNull();
+  it('never asks about a parent whose tree differs from what is being released', () => {
+    const fetch = gated('prev-release');
+    const candidates = [
+      { sha: 'merge', tree: headTree },
+      { sha: 'prev-release', tree: 'tree-old' },
+    ];
+
+    expect(findVerifiedSha(candidates, headTree, fetch)).toBeNull();
+    expect(fetch).not.toHaveBeenCalledWith('prev-release');
   });
 
-  it('refuses a same-tree commit whose gate did not pass', () => {
-    expect(selectVerifiedCommit([
-      { sha: 'main-tip', tree: headTree, checkRuns: [{ ...passingGate, conclusion: 'failure' }] },
-    ], headTree)).toBeNull();
-  });
+  it('stops fetching once a candidate verifies', () => {
+    const fetch = gated('merge', 'main-tip');
+    const candidates = [{ sha: 'merge', tree: headTree }, { sha: 'main-tip', tree: headTree }];
 
-  it('prefers a gate on the released commit itself', () => {
-    const verified = selectVerifiedCommit([
-      { sha: 'merge', tree: headTree, checkRuns: [passingGate] },
-      { sha: 'main-tip', tree: headTree, checkRuns: [passingGate] },
-    ], headTree);
-
-    expect(verified).toMatchObject({ sha: 'merge' });
+    expect(findVerifiedSha(candidates, headTree, fetch)).toBe('merge');
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 
   it('fails closed when the head tree could not be resolved', () => {
-    expect(selectVerifiedCommit([
-      { sha: 'main-tip', tree: null, checkRuns: [passingGate] },
-    ], null)).toBeNull();
+    const fetch = gated('main-tip');
+
+    expect(findVerifiedSha([{ sha: 'main-tip', tree: null }], null, fetch)).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

The suite was running three times for content that only needed testing once: on the PR, again on the merge commit on `main`, and again on the push to `release`. Now it runs once per gate.

| Event | Before | After |
|-------|--------|-------|
| PR into `main` | Impact-scoped plan | Impact-scoped plan (unchanged) |
| Push/merge to `main` | **Full suite** | **Nothing** — no push trigger |
| PR `main` → `release` | Impact-scoped plan | **Full suite**, forced regardless of diff |
| Push/merge to `release` | **Full suite** | Reuses that PR's green gate |
| Nightly / dispatch | Full suite | Full suite (unchanged) |

**Measured baseline (2026-08-21):** ~58 full runs/day fire on `main` pushes alone (100 runs in 41h), each ~10 min wall and ~38 billable runner-minutes with Windows at 2× — roughly **2,200 billable minutes/day**. A release drops from three full runs to one.

The `main` push trigger re-tested a tree whose PR gate was already green. The nightly full run is what catches a semantic conflict between two independently-green PRs, and the `main` → `release` PR catches it before a release ships.

### Reusing the release PR's run, safely

`scripts/verify-ci-status.js` requires **two** independent conditions, because each alone is forgeable:

1. **Content, not SHA** — a commit vouches for the push only when its git tree is byte-identical to the tree being released. The ordinary release merge satisfies this: `release` is strictly behind `main`, so the merge tree equals the `main` tip the release PR gated.
2. **Fullness** — the gate must be `Full CI Gate`, a check `ci.yml` publishes *only* when the impact plan chose the complete suite. The aggregate `CI Gate` is green on impact-scoped runs too, so it cannot tell "the full suite passed on this tree" from "some subset of it did". Without this, a rebase-merge that fast-forwards leaves `main`'s tip carrying only a feature PR's scoped gate, and a release onto it would skip the suite on that basis.

Everything else fails closed and runs the complete suite: a direct push to `release`, a hotfix that changes the merge tree, a missing/failed/scoped gate, or an unreadable checks API.

Side effect: a red `full-ci` no longer strands a release with a tag but no GitHub Release when CI was already green on the same tree.

Force-full policy moved out of an untestable YAML expression into the planner (`forceFullReasonFor`), so the release-gate rule is unit-tested and reports itself in the plan summary.

## Test plan

- `scripts/` suite: **273 files / 2000 tests green**, including new coverage for the gate-name drift guard, tree-vs-fullness selection, lazy check fetching, unreadable-response fallback, and the release-gate plan reason.
- Full `server` and `client` suites run: the only failures are pre-existing local-environment artifacts — all pass in isolation, and `updateExecutor`'s two are the launcher leaking `PORTOS_FORCE_CLEAN_WORKSPACES` into the shell (green under `env -u`).
- `verify-ci-status.js` exercised **live** against real history: on release merge `1c66413d` it correctly reports unverified (no `Full CI Gate` exists on that tree yet), and correctly ignores the previous-release parent whose tree differs. An earlier revision keyed on `CI Gate` wrongly verified that same commit — which is what motivated the fullness condition.
- Fail-closed paths confirmed live: unreachable checks API and unreadable body both report `verified=false`.
- Both workflow files parse as valid YAML; job graph verified.
- This PR touches `.github/workflows/`, so its own CI run is a full one.

Remaining per-run savings (shallow checkouts, cached server deps, retiring the legacy check-name jobs) are filed as #4734.
