### PR TITLE
Name the missing module when a TRELLIS.2 texture bake is degraded

### DIFF
--- a/client/src/components/models/Image3dRuntimes.jsx
+++ b/client/src/components/models/Image3dRuntimes.jsx
@@ -110,9 +110,17 @@ function TargetCard({ target, onInstall }) {
           )}
         </div>
       </div>
-      {degraded?.help && (
+      {/* `help` names the remedy, `detail` names what is actually missing — without the
+          second, a Repair that keeps failing just reprints the same sentence with nothing
+          to act on (#4636). The panel opens for EITHER, since the adapter contract makes
+          both optional; the server omits `detail` rather than sending an empty label, so
+          a probe that could not run renders no orphan "Missing:" line. */}
+      {(degraded?.help || degraded?.detail) && (
         <p className="mt-3 rounded border border-port-warning/40 bg-port-warning/10 p-2 text-[11px] leading-relaxed text-port-warning">
           {degraded.help}
+          {degraded.detail && (
+            <span className="mt-1 block text-port-warning/70">{degraded.detail}</span>
+          )}
         </p>
       )}
     </div>
@@ -207,9 +215,21 @@ export default function Image3dRuntimes() {
         // `undefined` rather than '' when a target has nothing to say, so
         // RuntimeInstallModal's own default description applies instead of a blank panel.
         description={installTarget?.degraded
-          // The degraded help text owns the whole message (both targets' already end by
-          // saying downloaded models are kept) — appending to it would repeat that.
-          ? installTarget.degraded.help
+          // The degraded help text owns the REMEDY half of the message (both targets'
+          // already end by saying downloaded models are kept), so the generic install
+          // prose is not appended to it — that would repeat what it just said. `detail`
+          // is the one thing it does not cover: WHAT is missing. This modal is where a
+          // user who has already run Repair once lands, so without it the retry offers
+          // the identical sentence that did not work the first time (#4636).
+          //
+          // `|| undefined` has to be repeated here: `||` binds TIGHTER than `?:`, so the
+          // one on the else-branch below groups as `(… : Y || undefined)` and never
+          // covered this branch. It matters because the modal's default description is a
+          // default PARAMETER, which only fires on `undefined` — an empty join would
+          // render a blank panel instead of falling back to it. Reachable via a
+          // `degraded` carrying neither key, which the contract permits.
+          ? [installTarget.degraded.help, installTarget.degraded.detail && `${installTarget.degraded.detail}.`]
+            .filter(Boolean).join(' ') || undefined
           : [
             installTarget?.installNotes,
             gatedRepoCount

--- a/client/src/components/models/Image3dRuntimes.test.jsx
+++ b/client/src/components/models/Image3dRuntimes.test.jsx
@@ -22,7 +22,13 @@ vi.mock('../../services/api', () => ({
 // assert only that it's opened with the chosen target.
 vi.mock('../install/RuntimeInstallModal', () => ({
   default: ({ open, runtime, description }) => (open ? <div data-testid="install-modal">
-    installing {runtime}<span data-testid="install-description">{description}</span>
+    installing {runtime}
+    <span data-testid="install-description">
+      {/* The real modal defaults this via a default PARAMETER, so only `undefined`
+          reaches the fallback — rendering the raw value would make '' (a blank panel)
+          indistinguishable from "use your default". Mark the absent case explicitly. */}
+      {description === undefined ? '(default)' : description}
+    </span>
   </div> : null),
 }));
 
@@ -89,6 +95,102 @@ describe('Image3dRuntimes', () => {
     expect(await screen.findByText(/degraded textures/i)).toBeInTheDocument();
     expect(screen.getByText('Install Xcode from the App Store.')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /install/i })).toBeNull();
+  });
+
+  // #4636: the help text names the REMEDY; on its own, a Repair that keeps failing
+  // just reprints it, with no way to tell why. `detail` names what is actually broken.
+  it('names the missing modules under the degraded help text', async () => {
+    getImageTo3dTargets.mockResolvedValue({
+      targets: [target({
+        installed: true,
+        degraded: {
+          label: 'degraded textures',
+          help: 'Install the Metal Toolchain.',
+          repairable: true,
+          detail: 'Missing: o_voxel, mtlbvh',
+        },
+      })],
+    });
+    renderPanel();
+    expect(await screen.findByText('Missing: o_voxel, mtlbvh')).toBeInTheDocument();
+  });
+
+  // The server OMITS `detail` rather than sending an empty label (a probe that could
+  // not run names nothing), so the card must render no orphan "Missing:" line.
+  it('renders no missing-module line when the server named nothing', async () => {
+    getImageTo3dTargets.mockResolvedValue({
+      targets: [target({
+        installed: true,
+        degraded: { label: 'degraded textures', help: 'Install the Metal Toolchain.', repairable: true },
+      })],
+    });
+    renderPanel();
+    expect(await screen.findByText('Install the Metal Toolchain.')).toBeInTheDocument();
+    expect(screen.queryByText(/missing:/i)).toBeNull();
+  });
+
+  // The adapter contract makes BOTH `help` and `detail` optional, so the panel must
+  // not hang off `help` alone — a target that names the culprit without prose would
+  // otherwise have it swallowed silently.
+  it('renders a detail-only degraded panel when the server sent no help text', async () => {
+    getImageTo3dTargets.mockResolvedValue({
+      targets: [target({
+        installed: true,
+        degraded: { label: 'degraded textures', repairable: true, detail: 'Missing: o_voxel' },
+      })],
+    });
+    renderPanel();
+    expect(await screen.findByText('Missing: o_voxel')).toBeInTheDocument();
+  });
+
+  // A `degraded` carrying neither key must leave the modal on its OWN default copy —
+  // an empty string would render a blank description panel instead.
+  it('falls back to the modal default when a degraded target says nothing', async () => {
+    getImageTo3dTargets.mockResolvedValue({
+      targets: [target({
+        installed: true,
+        degraded: { label: 'degraded textures', repairable: true },
+      })],
+    });
+    renderPanel();
+    fireEvent.click(await screen.findByRole('button', { name: /repair install/i }));
+    expect(await screen.findByTestId('install-description')).toHaveTextContent('(default)');
+  });
+
+  // The Repair modal is where a user who already ran Repair once lands, so it must
+  // carry the culprit too — otherwise the retry offers the identical sentence that
+  // did not work the first time.
+  it('carries the missing modules into the Repair install modal', async () => {
+    getImageTo3dTargets.mockResolvedValue({
+      targets: [target({
+        installed: true,
+        degraded: {
+          label: 'degraded textures',
+          help: 'Install the Metal Toolchain.',
+          repairable: true,
+          detail: 'Missing: o_voxel',
+        },
+      })],
+    });
+    renderPanel();
+    fireEvent.click(await screen.findByRole('button', { name: /repair install/i }));
+    expect(await screen.findByTestId('install-description'))
+      .toHaveTextContent('Install the Metal Toolchain. Missing: o_voxel.');
+  });
+
+  // With nothing named, the description must stay exactly the help text — no dangling
+  // separator, no empty label.
+  it('leaves the Repair modal description untouched when nothing was named', async () => {
+    getImageTo3dTargets.mockResolvedValue({
+      targets: [target({
+        installed: true,
+        degraded: { label: 'degraded textures', help: 'Install the Metal Toolchain.', repairable: true },
+      })],
+    });
+    renderPanel();
+    fireEvent.click(await screen.findByRole('button', { name: /repair install/i }));
+    expect(await screen.findByTestId('install-description'))
+      .toHaveTextContent(/^Install the Metal Toolchain\.$/);
   });
 
   // The degraded projection is normalized server-side, so a target degraded for an

--- a/server/routes/imageTo3d.test.js
+++ b/server/routes/imageTo3d.test.js
@@ -38,7 +38,10 @@ vi.mock('../services/imageTo3d/targets.js', async (importOriginal) => ({
   IMAGE_TO_3D_TARGET_IDS: ['trellis2'],
 }));
 
-vi.mock('../services/imageTo3d/trellis2.js', () => ({
+vi.mock('../services/imageTo3d/trellis2.js', async (importOriginal) => ({
+  // Pure formatters (`missingBakeModulesLabel`) come through REAL — the adapter's
+  // `degraded.detail` is asserted below, so stubbing them would test the stub.
+  ...(await importOriginal()),
   isTrellis2Installed: vi.fn(() => false),
   trellis2Root: vi.fn(() => '/tmp/trellis2'),
   installTrellis2: vi.fn(({ onEvent }) => {
@@ -160,6 +163,8 @@ describe('image-to-3d routes', () => {
     const res = await request(makeApp()).get('/api/image-to-3d/targets');
     expect(res.body.targets[0].textureBake).toMatchObject({ quality: 'metal' });
     expect(res.body.targets[0].textureBake.repairable).toBeUndefined();
+    // A healthy bake names no modules — and reports no degradation at all.
+    expect(res.body.targets[0].degraded).toBeUndefined();
     expect(trellis2.probeMetalToolchain).not.toHaveBeenCalled();
   });
 
@@ -216,7 +221,12 @@ describe('image-to-3d routes', () => {
     });
     const res = await request(makeApp()).get('/api/image-to-3d/targets');
     expect(res.body.targets[0].degraded).toEqual({
-      label: 'degraded textures', help: 'fix it', repairable: true,
+      label: 'degraded textures',
+      help: 'fix it',
+      repairable: true,
+      // #4636: `help` names the remedy, `detail` names what is actually missing —
+      // without it a Repair that keeps failing only ever reprints the same sentence.
+      detail: 'Missing: mtldiffrast',
     });
   });
 
@@ -328,7 +338,12 @@ describe('GET /trellis2/install (SSE)', () => {
     });
     const res = await request(makeApp()).get('/api/image-to-3d/trellis2/install');
     const frames = sseFrames(res.text);
-    expect(frames.find((f) => f.stage === 'verify' && f.type === 'log')?.message).toContain('repair me');
+    const warning = frames.find((f) => f.stage === 'verify' && f.type === 'log')?.message;
+    expect(warning).toContain('repair me');
+    // #4636: this lane writes the SAME `verify` stage the install's own hook does, so it
+    // has to name the culprit too — otherwise one condition emits two different frames
+    // depending on whether the caller hit the short-circuit or ran the install.
+    expect(warning).toContain('Missing: mtldiffrast.');
     expect(frames.at(-1)).toMatchObject({ type: 'complete' });
   });
 

--- a/server/services/imageTo3d/adapters.degraded.test.js
+++ b/server/services/imageTo3d/adapters.degraded.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Only the module probe is stubbed — the projection under test is the real thing.
 vi.mock('./pixal3dCuda.js', async (importOriginal) => ({
@@ -6,8 +6,17 @@ vi.mock('./pixal3dCuda.js', async (importOriginal) => ({
   probePixal3dModules: vi.fn(),
 }));
 
+// Same treatment for the MPS lane: the probes are stubbed, the projection is real —
+// including the missing-module formatter it shares with the install's verify frame.
+vi.mock('./trellis2.js', async (importOriginal) => ({
+  ...(await importOriginal()),
+  probeTrellis2TextureBake: vi.fn(),
+  probeMetalToolchain: vi.fn(),
+}));
+
 import { TARGET_ADAPTERS } from './adapters.js';
 import { probePixal3dModules, PIXAL3D_NAF_FALLBACK_HELP } from './pixal3dCuda.js';
+import { probeTrellis2TextureBake, probeMetalToolchain } from './trellis2.js';
 
 const describeState = () => TARGET_ADAPTERS.pixal3dCuda.describeInstallState();
 
@@ -64,5 +73,80 @@ describe('pixal3dCuda degraded-state projection', () => {
     const state = await describeState();
     expect(state.fields.degraded).toBeUndefined();
     expect(state.warnings).toEqual([]);
+  });
+});
+
+// #4636: the card told the user which remedy to run but never what was missing, so a
+// Repair that kept failing reprinted one generic sentence forever. `detail` carries
+// the culprit modules through the SAME normalized `degraded` shape the client already
+// renders — no per-target UI branch, and no reader on the back-compat `textureBake`.
+describe('trellis2 degraded-state projection', () => {
+  const describeTrellis2 = () => TARGET_ADAPTERS.trellis2.describeInstallState();
+  const fallback = (missing) => ({
+    quality: 'fallback', missing, degradedQuality: [], modules: {}, help: 'fix it',
+  });
+
+  // The toolchain probe is only consulted for a DEGRADED bake, and one case asserts it
+  // was never reached — so its call log has to start empty in every test.
+  beforeEach(() => {
+    probeTrellis2TextureBake.mockClear();
+    probeMetalToolchain.mockClear();
+  });
+
+  it('names the missing bake modules in degraded.detail', async () => {
+    probeTrellis2TextureBake.mockResolvedValueOnce(fallback(['o_voxel', 'mtlbvh']));
+    probeMetalToolchain.mockResolvedValueOnce({ available: false, installable: true });
+    const state = await describeTrellis2();
+    expect(state.fields.degraded).toEqual({
+      label: 'degraded textures', help: 'fix it', repairable: true, detail: 'Missing: o_voxel, mtlbvh',
+    });
+    // Finding 1: the install route replays `warnings` into the SAME `verify` stage the
+    // install's own hook writes, so it has to name the modules too — otherwise one
+    // condition emits two different frames depending on the path taken.
+    expect(state.warnings).toEqual(['fix it Missing: o_voxel, mtlbvh.']);
+  });
+
+  // On a Command-Line-Tools-only host `help` becomes the Xcode hint, but WHICH modules
+  // failed is still the useful half of the report.
+  it('keeps the detail on the non-repairable toolchain-blocker path', async () => {
+    probeTrellis2TextureBake.mockResolvedValueOnce(fallback(['o_voxel']));
+    probeMetalToolchain.mockResolvedValueOnce({
+      available: false, installable: false, blocker: 'requires-xcode', hint: 'install Xcode',
+    });
+    const state = await describeTrellis2();
+    expect(state.fields.degraded).toEqual({
+      label: 'degraded textures', help: 'install Xcode', repairable: false, detail: 'Missing: o_voxel',
+    });
+  });
+
+  it('reports nothing degraded — and no detail — for a healthy Metal bake', async () => {
+    probeTrellis2TextureBake.mockResolvedValueOnce({
+      quality: 'metal', missing: [], degradedQuality: [], modules: {},
+    });
+    const state = await describeTrellis2();
+    expect(state.fields.degraded).toBeUndefined();
+    expect(state.warnings).toEqual([]);
+  });
+
+  // A probe that could not run must not render a module list (could-not-determine ≠
+  // determined-to-be-bad).
+  it('reports nothing when the bake probe could not run', async () => {
+    probeTrellis2TextureBake.mockResolvedValueOnce({
+      quality: 'unknown', missing: [], degradedQuality: [], modules: {},
+    });
+    const state = await describeTrellis2();
+    expect(state.fields.degraded).toBeUndefined();
+    expect(probeMetalToolchain).not.toHaveBeenCalled();
+  });
+
+  // `flex_gemm` degrades bake QUALITY without forcing the fallback baker, so it must
+  // never be listed as a cause of the scrambled surface.
+  it('does not list degradedQuality modules as missing', async () => {
+    probeTrellis2TextureBake.mockResolvedValueOnce({
+      quality: 'fallback', missing: ['o_voxel'], degradedQuality: ['flex_gemm'], modules: {}, help: 'fix it',
+    });
+    probeMetalToolchain.mockResolvedValueOnce({ available: false, installable: true });
+    const state = await describeTrellis2();
+    expect(state.fields.degraded.detail).toBe('Missing: o_voxel');
   });
 });

--- a/server/services/imageTo3d/adapters.js
+++ b/server/services/imageTo3d/adapters.js
@@ -37,10 +37,14 @@
  *    quality). Omit when a target has nothing extra to report.
  *
  *    **A degraded-but-working install reports `fields.degraded`**:
- *    `{ label, help, repairable }`. This is the ONE shape the client renders, so the
- *    badge / help panel / Repair button work for any target without a per-target
+ *    `{ label, help, repairable, detail? }`. This is the ONE shape the client renders,
+ *    so the badge / help panel / Repair button work for any target without a per-target
  *    branch. `repairable: false` means re-running install cannot fix it and no Repair
- *    button is offered.
+ *    button is offered. `detail` is an optional short line naming the *specific* thing
+ *    that is missing (`Missing: o_voxel`) — `help` says which remedy to run, `detail`
+ *    says what is actually broken, so a user whose Repair keeps failing has something
+ *    to act on instead of the same generic sentence. Omit it entirely rather than
+ *    emitting an empty label when the probe could not determine anything.
  *
  *    A target may also return its own narrow diagnostic field, but keep it small and
  *    keep the UI off it. `trellis2` still returns `textureBake` with **no in-repo
@@ -55,6 +59,8 @@ import {
   runTrellis2Generate,
   probeTrellis2TextureBake,
   probeMetalToolchain,
+  missingBakeModulesLabel,
+  appendMissingBakeModules,
 } from './trellis2.js';
 import {
   isTrellis2CudaInstalled,
@@ -92,6 +98,7 @@ export const TARGET_ADAPTERS = Object.freeze({
     async describeInstallState() {
       const bake = await probeTrellis2TextureBake();
       const degradedBake = bake.quality === 'fallback';
+      const missingModules = missingBakeModulesLabel(bake);
       const toolchain = degradedBake ? await probeMetalToolchain() : null;
       // A degraded bake has two very different remedies, and the card must not
       // offer the wrong one: when the Metal Toolchain is merely missing, Repair
@@ -112,10 +119,24 @@ export const TARGET_ADAPTERS = Object.freeze({
               label: 'degraded textures',
               help: textureBake.help,
               repairable: textureBake.repairable !== false,
+              // Which module actually failed to build. `help` names the remedy; without
+              // this the card can only repeat that remedy, so a Repair that keeps
+              // failing looks like an unbounded loop (#4636). Shares one formatter with
+              // the install's `verify` frame so the two lanes cannot drift. Kept on the
+              // toolchain-`blocker` path too, where `help` becomes the Xcode hint but
+              // WHICH modules failed is still the useful half. The emptiness guard is
+              // defensive only: a real probe reports `fallback` exactly when `missing`
+              // is non-empty, and the `quality: 'unknown'` case never reaches here — the
+              // outer `degradedBake` gate drops the whole `degraded` key first.
+              ...(missingModules ? { detail: missingModules } : {}),
             },
           } : {}),
         },
-        warnings: degradedBake ? [textureBake.help] : [],
+        // Replayed verbatim into the install route's `verify` stage on the
+        // already-installed short-circuit — the SAME stage the install's own verify
+        // hook writes. Carry the module names here too, or one condition emits two
+        // different frames depending on which path the caller took (#4636).
+        warnings: degradedBake ? [appendMissingBakeModules(textureBake.help, bake)] : [],
       };
     },
   }),

--- a/server/services/imageTo3d/trellis2.js
+++ b/server/services/imageTo3d/trellis2.js
@@ -189,6 +189,49 @@ export async function probeTrellis2TextureBake({
 }
 
 /**
+ * The culprit modules from a bake probe, as one short human-readable label
+ * (`Missing: o_voxel, mtlbvh`) — or `''` when there is nothing to name.
+ *
+ * The `degraded.detail` field is exactly this label, and the prose lanes get it through
+ * `appendMissingBakeModules` below rather than re-assembling the sentence — the label is
+ * punctuation-free because a standalone card line wants none, so the terminal period is
+ * the appending helper's job.
+ *
+ * Returning `''` rather than a bare "Missing:" is defensive depth, not the thing that
+ * silences a `quality: 'unknown'` probe — both callers gate on `'fallback'` first, and a
+ * real probe reports that exactly when `missing` is non-empty, so an empty list never
+ * arrives here. `degradedQuality` is deliberately NOT included: `flex_gemm` lowers bake
+ * quality without forcing the fallback baker, so naming it here would read as a cause of
+ * the confetti surface when it isn't.
+ *
+ * @param {{missing?: string[]}} bake a result from `probeTrellis2TextureBake`
+ * @returns {string}
+ */
+export function missingBakeModulesLabel(bake) {
+  const missing = bake?.missing;
+  return missing?.length ? `Missing: ${missing.join(', ')}` : '';
+}
+
+/**
+ * A prose help string with the culprit modules appended as a closing sentence
+ * (`… models are kept. Missing: o_voxel.`).
+ *
+ * Both server lanes that report a degraded bake in prose go through this: the install's
+ * own `verify` hook, and the adapter `warnings` the install route replays into that
+ * SAME `verify` stage on the already-installed short-circuit. Assembling the sentence
+ * at each call site instead would let one condition emit two differently-worded frames
+ * depending on which path the caller took.
+ *
+ * @param {string} help the remedy prose (already ends in its own punctuation)
+ * @param {{missing?: string[]}} bake a result from `probeTrellis2TextureBake`
+ * @returns {string}
+ */
+export function appendMissingBakeModules(help, bake) {
+  const label = missingBakeModulesLabel(bake);
+  return [help, label && `${label}.`].filter(Boolean).join(' ');
+}
+
+/**
  * Whether the Xcode Metal Toolchain is present — the prerequisite `setup.sh`
  * documents for building `mtldiffrast`/`mtlbvh`/`mtlgemm`. Checked BEFORE a ~15 GB
  * install so the user can fix it first, instead of discovering an hour later that
@@ -732,7 +775,16 @@ export function installTrellis2({
     verify: async (emit) => {
       const bake = await probeBake({ base });
       if (bake.quality === 'fallback') {
-        emit({ type: 'log', stage: 'verify', message: `⚠️ ${bake.help}` });
+        // Name the culprits. The help text says which remedy to run, but not what is
+        // actually missing — and `apple-deps` (the install's only gitlab.com fetch, and
+        // an `optional` step) fails with one line that scrolls past inside a ~15 GB log.
+        // Without the module names a user whose Repair keeps failing has nothing to go
+        // on and reruns the same generic remedy forever (#4636).
+        emit({
+          type: 'log',
+          stage: 'verify',
+          message: `⚠️ ${appendMissingBakeModules(bake.help, bake)}`,
+        });
       } else if (bake.quality === 'metal') {
         emit({ type: 'log', stage: 'verify', message: '✅ Metal texture baking is available.' });
       }

--- a/server/services/imageTo3d/trellis2.test.js
+++ b/server/services/imageTo3d/trellis2.test.js
@@ -28,6 +28,7 @@ import {
   TRELLIS2_METAL_BAKE_MODULES,
   TRELLIS2_BAKE_QUALITY_MODULES,
   TRELLIS2_FALLBACK_BAKE_HELP,
+  missingBakeModulesLabel,
   TRELLIS2_METAL_TOOLCHAIN_HINT,
   TRELLIS2_REQUIRES_XCODE_HINT,
   TRELLIS2_DEFAULT_TEXTURE_SIZE,
@@ -391,6 +392,29 @@ describe('probeTrellis2TextureBake', () => {
       base: BASE, exists: () => true, execFileImpl: fakeExec({ ...allPresent, flex_gemm: false }),
     }),
   ).resolves.toMatchObject({ quality: 'metal', degradedQuality: ['flex_gemm'] }));
+
+  // #4636: one formatter feeds both the install's verify frame and the card's
+  // `degraded.detail`, so the two lanes cannot drift on the wording.
+  describe('missingBakeModulesLabel', () => {
+    it('names every missing Metal bake module', () => expect(
+      missingBakeModulesLabel({ missing: ['o_voxel', 'mtlbvh'] }),
+    ).toBe('Missing: o_voxel, mtlbvh'));
+
+    it('is empty when nothing is missing, so no bare "Missing:" can render', () => {
+      expect(missingBakeModulesLabel({ missing: [] })).toBe('');
+      expect(missingBakeModulesLabel({})).toBe('');
+      expect(missingBakeModulesLabel(undefined)).toBe('');
+    });
+
+    // `flex_gemm` lowers bake quality without forcing the fallback baker, so naming it
+    // here would blame it for the confetti surface it does not cause.
+    it('does not conflate degradedQuality with missing', async () => {
+      const result = await probeTrellis2TextureBake({
+        base: BASE, exists: () => true, execFileImpl: fakeExec({ ...allPresent, flex_gemm: false }),
+      });
+      expect(missingBakeModulesLabel(result)).toBe('');
+    });
+  });
 
   it('reports unknown — NOT fallback — when the probe itself fails', async () => {
     // A broken probe must never render a scary "degraded" warning about an install
@@ -1181,6 +1205,30 @@ describe('installTrellis2', () => {
     expect(verifyIdx).toBeLessThan(completeIdx);
     expect(events[verifyIdx].message).toContain(TRELLIS2_FALLBACK_BAKE_HELP);
   });
+
+  // #4636: the help text says which remedy to run but not what is broken, so a Repair
+  // that keeps failing reprints the same sentence forever. The frame must name the
+  // module — and must leave the help constant itself byte-identical, since it is a
+  // shared constant other assertions key on.
+  it('names the missing bake modules in the degraded verify frame', async () => {
+    const events = await runToCompletion(async () => ({
+      quality: 'fallback', missing: ['o_voxel', 'mtlbvh'], help: TRELLIS2_FALLBACK_BAKE_HELP,
+    }));
+    const message = events.find((e) => e.stage === 'verify').message;
+    expect(message).toContain(TRELLIS2_FALLBACK_BAKE_HELP);
+    expect(message).toContain('Missing: o_voxel, mtlbvh.');
+  });
+
+  // A `fallback` verdict with an empty culprit list is not a shape the probe produces,
+  // but a defensive one: an empty label must never render as a bare "Missing:" with
+  // nothing after it.
+  it('omits the missing-module label when a degraded probe named nothing', async () => {
+    const events = await runToCompletion(async () => ({
+      quality: 'fallback', missing: [], help: TRELLIS2_FALLBACK_BAKE_HELP,
+    }));
+    expect(events.find((e) => e.stage === 'verify').message).not.toContain('Missing');
+  });
+
 
   it('confirms a healthy Metal bake on a good install', async () => {
     const events = await runToCompletion(async () => ({ quality: 'metal', missing: [] }));


### PR DESCRIPTION
## Summary

A degraded TRELLIS.2 texture bake told the user **which remedy to run** but never **what was actually missing**, so a Repair that kept failing just reprinted the same generic sentence forever. `probeTrellis2TextureBake()` already computed the culprit list — nothing rendered it.

- **Install `verify` frame** now appends `Missing: o_voxel.` after the help text. `TRELLIS2_FALLBACK_BAKE_HELP` is byte-identical, so existing assertions on it are untouched.
- **Target card** renders the culprits as a short secondary line under the help panel.
- **Repair install modal** carries them too — that's where a user who already ran Repair once lands, so without it the retry offers the identical sentence that just failed.
- **Already-installed short-circuit** (`GET /targets/trellis2/install` on an installed host) replays the adapter's `warnings` into that *same* `verify` stage, so it names them as well. All server prose goes through one `appendMissingBakeModules` helper; one condition can't emit two differently-worded frames.

### One deviation from the issue's plan

The issue proposed reading `target.textureBake.missing` directly in `Image3dRuntimes.jsx`. That field has had **no in-repo reader** since the degraded state was normalized — the adapter contract says it's kept for API back-compat only and to "keep the UI off it." So the data rides the generic `degraded` projection instead, as a new optional `detail` key. Same rendered outcome, no per-target UI branch reintroduced, and the wire change is additive (an older client ignores it). Recorded on the issue before implementing.

Sentinel discipline preserved: a `quality: 'unknown'` probe renders nothing (the outer gate drops `degraded` wholesale, and the formatter returns `''` rather than a bare "Missing:"), and `degradedQuality` (`flex_gemm`) stays out of the list — it lowers bake quality without forcing the fallback baker.

## Test plan

- `cd server && npx vitest run services/imageTo3d routes/imageTo3d.test.js` — 491 passed
- `cd client && npx vitest run src/components/models/Image3dRuntimes.test.jsx` — 17 passed
- `cd server && npm test` — green except `services/updateExecutor.test.js`, a pre-existing false failure from the launcher leaking `PORTOS_FORCE_CLEAN_WORKSPACES` into the suite (passes under `env -u`); unrelated to this diff
- `cd client && npm test` — 8962 passed; `npm run lint` clean
- Bypass-probed the two behavioral guards: removing the card's `detail` span and removing the modal's `|| undefined` each turn their test red
- Rebased onto `origin/main` after #4728 moved the 3D target card from `pages/Media3D.jsx` into `components/models/Image3dRuntimes.jsx`; the client half was re-applied there

## Follow-ups filed

- #4741 — move `pixal3dCuda`'s missing-extension list out of help prose into `degraded.detail`, so both targets render it the same way
- #4742 — a degraded install frame promises a Repair that can't work on a Command-Line-Tools-only host (pre-existing lane divergence)

Closes #4636
