### PR TITLE
make the AI Assignments provider counts clickable filters

### DIFF
--- a/client/src/components/settings/AiAssignmentsTab.jsx
+++ b/client/src/components/settings/AiAssignmentsTab.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router';
 import { ArrowRight, Bot, RefreshCw, Save, Search } from 'lucide-react';
 import toast from '../ui/Toast';
 import ToolUseWarning from '../ui/ToolUseWarning.jsx';
+import TabPills from '../ui/TabPills.jsx';
 import { getAiAssignments, updateAiAssignment } from '../../services/api';
 import useVisionModelIds from '../../hooks/useVisionModelIds.js';
 import useToolUseModelIds from '../../hooks/useToolUseModelIds.js';
@@ -39,6 +40,11 @@ const reconcileDrafts = (prev, assignments, savedIds) => {
 // Provider label with the settings-table's "Default" fallback for an unset id.
 const providerName = (providers, id) => providerDisplayName(providers, id, 'Default');
 
+// Chip key for rows with no provider pinned. An empty string already means
+// "no provider chip selected", so unset rows need their own sentinel to be
+// selectable rather than collapsing into "show everything".
+const UNSET_PROVIDER = '__unset__';
+
 export default function AiAssignmentsTab() {
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState({});
@@ -47,6 +53,7 @@ export default function AiAssignmentsTab() {
   const [query, setQuery] = useState('');
   const [area, setArea] = useState('all');
   const [scope, setScope] = useState('all');
+  const [providerFilter, setProviderFilter] = useState('');
   const [fromProvider, setFromProvider] = useState('');
   const [toProvider, setToProvider] = useState('');
   const [bulkSaving, setBulkSaving] = useState(false);
@@ -81,7 +88,10 @@ export default function AiAssignmentsTab() {
     [data.assignments]
   );
 
-  const filtered = useMemo(() => {
+  // Everything except the provider chips, so the chip counts describe what the
+  // OTHER filters left behind (faceted-filter behaviour) instead of a global
+  // total that stops matching the table the moment you type in the search box.
+  const preProviderFiltered = useMemo(() => {
     const q = query.trim().toLowerCase();
     return (data.assignments || []).filter((entry) => {
       if (area !== 'all' && entry.area !== area) return false;
@@ -98,15 +108,35 @@ export default function AiAssignmentsTab() {
     });
   }, [area, data.assignments, query, scope]);
 
+  const filtered = useMemo(() => {
+    if (!providerFilter) return preProviderFiltered;
+    return preProviderFiltered.filter((entry) => (
+      providerFilter === UNSET_PROVIDER ? !entry.providerId : entry.providerId === providerFilter
+    ));
+  }, [preProviderFiltered, providerFilter]);
+
   const providerCounts = useMemo(() => {
     const counts = {};
-    for (const entry of data.assignments || []) {
-      if (!entry.providerId) continue;
-      const id = entry.providerId;
+    for (const entry of preProviderFiltered) {
+      const id = entry.providerId || UNSET_PROVIDER;
       counts[id] = (counts[id] || 0) + 1;
     }
+    // Keep the active chip on screen even when the other filters zero it out —
+    // otherwise clicking Search strands the selection with no way to clear it.
+    if (providerFilter) counts[providerFilter] ??= 0;
     return counts;
-  }, [data.assignments]);
+  }, [preProviderFiltered, providerFilter]);
+
+  const providerTabs = useMemo(() => ([
+    { id: '', label: 'All', count: preProviderFiltered.length },
+    ...Object.entries(providerCounts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([id, count]) => ({
+        id,
+        label: id === UNSET_PROVIDER ? 'Default / unset' : providerName(data.providers, id),
+        count,
+      })),
+  ]), [data.providers, preProviderFiltered.length, providerCounts]);
 
   const setDraft = (id, patch) => {
     setDrafts((prev) => ({ ...prev, [id]: { ...(prev[id] || {}), ...patch } }));
@@ -178,13 +208,17 @@ export default function AiAssignmentsTab() {
             <Bot size={18} className="text-port-accent" />
             <h2 className="text-lg font-semibold">AI Assignments</h2>
           </div>
-          <div className="mt-2 flex flex-wrap gap-2 text-xs">
-            {Object.entries(providerCounts).sort((a, b) => b[1] - a[1]).map(([id, count]) => (
-              <span key={id} className="max-w-full truncate px-2 py-1 rounded bg-port-card border border-port-border text-gray-300">
-                {providerName(data.providers, id)}: {count}
-              </span>
-            ))}
-          </div>
+          <TabPills
+            tabs={providerTabs}
+            activeTab={providerFilter}
+            // Re-clicking the active chip clears the filter, so the row needs no
+            // separate "clear" affordance beyond the All chip.
+            onChange={(id) => setProviderFilter(id === providerFilter ? '' : id)}
+            variant="filter"
+            size="sm"
+            ariaLabel="Filter by provider"
+            className="mt-2 max-w-full"
+          />
         </div>
 
         <div className="w-full min-w-0 max-w-full shrink-0 bg-port-card border border-port-border rounded-lg p-3 space-y-2 xl:w-[520px]">

--- a/client/src/components/settings/AiAssignmentsTab.test.jsx
+++ b/client/src/components/settings/AiAssignmentsTab.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router';
 
 vi.mock('../../services/api', () => ({ getAiAssignments: vi.fn(), updateAiAssignment: vi.fn() }));
@@ -147,5 +148,66 @@ describe('AiAssignmentsTab tool-use warning', () => {
     });
     renderTab();
     expect(await screen.findByText(WARNING)).toBeInTheDocument();
+  });
+});
+
+describe('AiAssignmentsTab provider chips', () => {
+  // TabPills renders the count in its own span right after the label, so the
+  // accessible name of a chip is 'Ollama1' — and a zero count renders no span
+  // at all, leaving a bare 'Ollama'.
+  const chip = (label, count = '') => screen.getByRole('button', { name: `${label}${count}` });
+
+  // Rendered per test rather than in a beforeEach: the mount's async load has to
+  // settle inside the test body, or the suite's act(...) guard fails it.
+  const renderRows = () => {
+    getAiAssignments.mockResolvedValue(payload([
+      entry({ id: 'a', label: 'Alpha row', providerId: 'ollama', model: 'gemma2:9b' }),
+      entry({ id: 'b', label: 'Bravo row', providerId: 'openai', model: 'gpt-4o' }),
+      entry({ id: 'c', label: 'Charlie row', providerId: '', model: '' }),
+    ]));
+    renderTab();
+  };
+
+  it('filters the table to one provider when its chip is clicked, and clears on a second click', async () => {
+    renderRows();
+    const ollama = await screen.findByRole('button', { name: 'Ollama1' });
+
+    await userEvent.click(ollama);
+    expect(ollama).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('Alpha row')).toBeInTheDocument();
+    expect(screen.queryByText('Bravo row')).not.toBeInTheDocument();
+    expect(screen.queryByText('Charlie row')).not.toBeInTheDocument();
+
+    await userEvent.click(ollama);
+    expect(ollama).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByText('Bravo row')).toBeInTheDocument();
+  });
+
+  it('gives rows with no provider their own chip', async () => {
+    renderRows();
+    await userEvent.click(await screen.findByRole('button', { name: 'Default / unset1' }));
+    expect(screen.getByText('Charlie row')).toBeInTheDocument();
+    expect(screen.queryByText('Alpha row')).not.toBeInTheDocument();
+  });
+
+  it('clears the filter from the All chip', async () => {
+    renderRows();
+    await userEvent.click(await screen.findByRole('button', { name: 'Ollama1' }));
+    await userEvent.click(chip('All', 3));
+    expect(screen.getByText('Bravo row')).toBeInTheDocument();
+    expect(screen.getByText('Charlie row')).toBeInTheDocument();
+  });
+
+  it('recounts chips against the other filters and keeps the selected chip clickable at zero', async () => {
+    // The chip counts have to describe the rows the search left behind, or the
+    // numbers stop matching the table; and a selection the search zeroes out
+    // must stay on screen or there is no way to undo it.
+    renderRows();
+    await userEvent.click(await screen.findByRole('button', { name: 'Ollama1' }));
+    await userEvent.type(screen.getByLabelText('Search assignments'), 'Bravo');
+
+    expect(chip('OpenAI', 1)).toBeInTheDocument();
+    await userEvent.click(chip('Ollama'));
+    expect(screen.getByText('Bravo row')).toBeInTheDocument();
   });
 });

--- a/client/src/components/ui/README.md
+++ b/client/src/components/ui/README.md
@@ -35,7 +35,7 @@ accessibility). Feature-specific components live under their own feature directo
 | `ProvenanceChip` | Chip + popover showing where a generated value came from. |
 | `SideBySideDiff` | Columnar word-level diff — old left, new right. |
 | `Skeleton` | Loading-placeholder primitives (`SkeletonBlock` / `Lines` / `Card` / `Rows` / `Region`) — what `PageSkeleton` is built from, and what a sub-region loader should reserve its shape with instead of a bare spinner. |
-| `TabPills` | Shared tab nav — `underline` / `pills` families, with a mobile `<select>` fallback. |
+| `TabPills` | Shared tab nav — `underline` / `pills` / `filter` (toggle chips) families, with a mobile `<select>` fallback. |
 | `Toast` | Toast notification system (`toast()`, `.success()`, `.error()`, `.loading()`, `<Toaster />`). |
 | `ToggleChip` | Checkbox styled as a pill — the "pick some of these" affordance. |
 | `ToolUseWarning` | The "this model can't call tools" warning every agent/model picker shows. |

--- a/client/src/components/ui/TabPills.jsx
+++ b/client/src/components/ui/TabPills.jsx
@@ -1,6 +1,11 @@
-// Shared tab-nav primitive. Two visual families: `underline` (default — flat
-// bottom border with port-accent marker; used across page-level tabs) and
-// `pills` (rounded card with internal pill rows; used by UniverseBuilder).
+// Shared tab-nav primitive. Three visual families: `underline` (default — flat
+// bottom border with port-accent marker; used across page-level tabs),
+// `pills` (rounded card with internal pill rows; used by UniverseBuilder), and
+// `filter` (pills' markup, toggle-button semantics). `filter` exists because a
+// faceted count chip row (Settings > AI Assignments) narrows rows in place
+// rather than swapping panels: a tab promises a panel it never shows, so those
+// chips are a `role="group"` of `aria-pressed` buttons — the same semantics the
+// app's other toggle filters use — while sharing this component's styling.
 // Knobs cover the call-site quirks: `runningKind` swaps a per-tab icon for a
 // spinner; `stretch` makes each tab `flex-1` (StoryboardPanel); `mobileDropdown`
 // collapses to a `<select>` below `sm` (UniverseBuilder); `controlsIdPrefix`
@@ -56,7 +61,8 @@ export default function TabPills({
     </div>
   ) : null;
 
-  if (variant === 'pills') {
+  if (variant === 'pills' || variant === 'filter') {
+    const isFilter = variant === 'filter';
     return (
       <>
         {mobileSelect}
@@ -64,7 +70,7 @@ export default function TabPills({
           ref={listRef}
           onScroll={onScroll}
           className={`${mobileDropdown ? 'hidden sm:flex' : 'flex'} shrink-0 items-center gap-1 bg-port-card border border-port-border rounded p-1 overflow-x-auto scrollbar-hide touch-pan-x ${className}`}
-          role="tablist"
+          role={isFilter ? 'group' : 'tablist'}
           aria-label={ariaLabel}
         >
           {visibleTabs.map((t) => {
@@ -75,10 +81,11 @@ export default function TabPills({
               <button
                 key={t.id}
                 type="button"
-                role="tab"
-                aria-selected={active}
-                aria-controls={controlsIdPrefix ? `${controlsIdPrefix}-${t.id}` : undefined}
-                id={controlsIdPrefix ? `tab-${t.id}` : undefined}
+                role={isFilter ? undefined : 'tab'}
+                aria-selected={isFilter ? undefined : active}
+                aria-pressed={isFilter ? active : undefined}
+                aria-controls={!isFilter && controlsIdPrefix ? `${controlsIdPrefix}-${t.id}` : undefined}
+                id={!isFilter && controlsIdPrefix ? `tab-${t.id}` : undefined}
                 disabled={t.disabled}
                 onClick={() => onChange(t.id)}
                 className={`flex items-center ${sz.gap} ${sz.padding} rounded ${sz.text} transition-colors whitespace-nowrap ${

--- a/client/src/components/ui/TabPills.test.jsx
+++ b/client/src/components/ui/TabPills.test.jsx
@@ -129,3 +129,26 @@ describe('TabPills — trailing slot', () => {
     expect(within(screen.getByRole('tab', { name: /B/i })).getByTestId('dot-b')).toBeInTheDocument();
   });
 });
+
+describe('TabPills — filter variant', () => {
+  it('emits toggle-button semantics instead of tab/tablist', () => {
+    // A filter chip row narrows rows in place; it never swaps a panel, so
+    // promising `role="tab"` (and an aria-controls target that does not exist)
+    // misdescribes the control to a screen reader.
+    render(<TabPills variant="filter" tabs={sampleTabs} activeTab="cast" onChange={() => {}} ariaLabel="Filter by kind" />);
+    expect(screen.queryAllByRole('tab')).toHaveLength(0);
+    const group = screen.getByRole('group', { name: 'Filter by kind' });
+    expect(within(group).getAllByRole('button')).toHaveLength(3);
+    expect(screen.getByRole('button', { name: /Cast/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /Places/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('keeps the pills styling and count badges, and reports clicks by id', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<TabPills variant="filter" tabs={sampleTabs} activeTab="cast" onChange={onChange} />);
+    expect(screen.getByRole('button', { name: /Cast/i })).toHaveTextContent('3');
+    await user.click(screen.getByRole('button', { name: /Objects/i }));
+    expect(onChange).toHaveBeenCalledWith('objects');
+  });
+});


### PR DESCRIPTION
## Summary

- The provider chips at the top of **Settings → AI Assignments** are now filter buttons: click one to show only that provider's rows, click again (or the new **All** chip) to clear.
- Chip counts now describe what the *other* filters left behind (search / area / scope), so the numbers keep matching the table instead of staying at a global total. A selected chip stays on screen even when a search zeroes it out, so the filter is always clearable.
- Rows with no provider pinned get their own **Default / unset** chip — previously they were counted nowhere.
- Adds a `filter` variant to the shared `TabPills` primitive so a faceted chip row gets toggle semantics (`role="group"` + `aria-pressed`) instead of `role="tab"` promising a panel it never swaps. Styling and count badges are unchanged from the `pills` variant.

## Test plan

- `client`: new `AiAssignmentsTab` tests cover select → filter, re-click → clear, the All chip, the unset-provider chip, and the recount-under-search case including a selected chip at count 0.
- `client`: new `TabPills` tests pin the `filter` variant's semantics (no `tab` role, `role="group"`, `aria-pressed`) and that it keeps the pills styling, count badges, and `onChange(id)`.
- `npm run lint` and the full client suite (350 files / 3972 tests) pass locally.