### PR TITLE
Shallow depth-2 CI checkouts and retire the two legacy check-name jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,17 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # Depth 2, not full history: a pull_request checkout is the merge ref,
+          # so depth 2 carries both of its parents — which is everything the
+          # planner (a three-dot diff against the base parent) and `git
+          # ls-files` need. Cloning every commit in the repo buys nothing more.
+          fetch-depth: 2
+
+      # Reads the base commit off HEAD^1 rather than the event payload, so a
+      # depth-2 clone is enough for every three-dot diff downstream. Exports
+      # CI_BASE_SHA to the rest of the job.
+      - name: Resolve the pull-request diff base
+        run: node scripts/ci-base-sha.js
 
       - name: Select affected test surfaces
         id: plan
@@ -65,8 +75,6 @@ jobs:
           # The planner turns a PR into `release` into a full plan: that PR is
           # the single gate a release ships behind, so it never runs scoped.
           CI_BASE_REF: ${{ github.base_ref }}
-          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          CI_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node scripts/ci-test-plan.js
 
       - name: Publish plan summary
@@ -97,16 +105,19 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   server:
-    # Preserve the historical required-check context while branch protection
-    # transitions to the stable aggregate "CI Gate" check.
-    name: test (24.x)
+    name: Server tests
     needs: impact
     if: needs.impact.outputs.server_mode != 'skip'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # See the impact job: depth 2 is the whole PR merge ref, which is all
+          # Vitest's `--changed <sha>` three-dot diff reads.
+          fetch-depth: 2
+
+      - name: Resolve the pull-request diff base
+        run: node scripts/ci-base-sha.js
 
       - name: Use Node.js 24.x
         uses: actions/setup-node@v7
@@ -148,7 +159,6 @@ jobs:
         env:
           CI_TEST_MODE: ${{ needs.impact.outputs.server_mode }}
           CI_TEST_FILES: ${{ needs.impact.outputs.server_files }}
-          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: node scripts/run-ci-tests.js server
 
       # Smoke-boot does not need Postgres: NODE_ENV=test selects the file
@@ -166,7 +176,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # See the impact job: depth 2 is the whole PR merge ref, which is all
+          # Vitest's `--changed <sha>` three-dot diff reads.
+          fetch-depth: 2
+
+      - name: Resolve the pull-request diff base
+        run: node scripts/ci-base-sha.js
 
       - name: Use Node.js 24.x
         uses: actions/setup-node@v7
@@ -201,7 +216,6 @@ jobs:
         env:
           CI_TEST_MODE: ${{ needs.impact.outputs.client_mode }}
           CI_TEST_FILES: ${{ needs.impact.outputs.client_files }}
-          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: node scripts/run-ci-tests.js client
 
       - name: Build client
@@ -276,29 +290,6 @@ jobs:
         env:
           PGDATABASE: portos_test
 
-  lint:
-    # Historical required-check name. Lint itself now runs inside the client
-    # job so we do not pay a second `npm ci --prefix client`. This job only
-    # mirrors that result so branch protection can keep requiring "lint".
-    name: lint
-    needs: [impact, client]
-    if: always() && needs.impact.result == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Require client-job lint when it was selected
-        if: needs.impact.outputs.lint_mode != 'skip'
-        env:
-          CLIENT_RESULT: ${{ needs.client.result }}
-        run: |
-          if [ "$CLIENT_RESULT" != "success" ]; then
-            echo "Lint ran inside the client job, which did not succeed ($CLIENT_RESULT)."
-            exit 1
-          fi
-
-      - name: Lint not selected
-        if: needs.impact.outputs.lint_mode == 'skip'
-        run: echo "Lint skipped by impact plan"
-
   windows-server:
     name: Windows server unit tests
     needs: impact
@@ -307,7 +298,12 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
-          fetch-depth: 0
+          # See the impact job: depth 2 is the whole PR merge ref, which is all
+          # Vitest's `--changed <sha>` three-dot diff reads.
+          fetch-depth: 2
+
+      - name: Resolve the pull-request diff base
+        run: node scripts/ci-base-sha.js
 
       - name: Use Node.js 24.x
         uses: actions/setup-node@v7
@@ -340,13 +336,12 @@ jobs:
         env:
           CI_TEST_MODE: ${{ needs.impact.outputs.windows_mode }}
           CI_TEST_FILES: ${{ needs.impact.outputs.windows_files }}
-          CI_BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: node scripts/run-ci-tests.js server
 
   gate:
     name: CI Gate
     if: always()
-    needs: [impact, server, client, database, lint, windows-server]
+    needs: [impact, server, client, database, windows-server]
     runs-on: ubuntu-latest
     steps:
       - name: Require every selected job to pass
@@ -355,7 +350,6 @@ jobs:
           SERVER_RESULT: ${{ needs.server.result }}
           CLIENT_RESULT: ${{ needs.client.result }}
           DATABASE_RESULT: ${{ needs.database.result }}
-          LINT_RESULT: ${{ needs.lint.result }}
           WINDOWS_SERVER_RESULT: ${{ needs.windows-server.result }}
         run: |
           node -e '
@@ -364,7 +358,6 @@ jobs:
               server: process.env.SERVER_RESULT,
               client: process.env.CLIENT_RESULT,
               database: process.env.DATABASE_RESULT,
-              lint: process.env.LINT_RESULT,
               windows_server: process.env.WINDOWS_SERVER_RESULT,
             };
             const failed = Object.entries(results)
@@ -381,8 +374,8 @@ jobs:
     # suite. release.yml keys on this name to skip re-running CI on the push to
     # `release`; the aggregate "CI Gate" above cannot serve that purpose,
     # because an impact-scoped PR run publishes a green "CI Gate" too.
-    # Mirrors the gate result the same way the "lint" job mirrors the client
-    # job, so it costs one echo rather than a second aggregation.
+    # It mirrors the aggregate gate rather than re-aggregating every job, so it
+    # costs one comparison instead of a second fan-in.
     name: Full CI Gate
     if: always() && needs.impact.outputs.full == 'true'
     needs: [impact, gate]

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -62,6 +62,33 @@ writes Vitest wall time to the job summary so later runs can be compared
 against the pre-change full-suite job wall on `main` (2026-08-16, run
 `31951919659`): server ~300s, client+build ~467s, Windows ~463s.
 
+### Shallow checkouts
+
+No job clones full history. `actions/checkout` runs at `fetch-depth: 2`,
+which on a pull request is the merge ref plus both of its parents — and the
+first parent *is* the base-branch commit the pull request is diffed against.
+`scripts/ci-base-sha.js` reads it (`HEAD^1`) and exports `CI_BASE_SHA` for the
+rest of the job, so both three-dot diffs that matter resolve without deeper
+history:
+
+- the planner's `git diff <base>...HEAD`;
+- Vitest's own `--changed <sha>`, which is also a three-dot diff internally.
+
+Reading the base off the checkout rather than `github.event.pull_request.base.sha`
+is also more correct: GitHub rebuilds the merge ref when the base branch moves,
+so the payload value can name a commit the tested tree was never merged with.
+
+Non-pull-request runs (nightly, dispatch, release fallback) force the complete
+suite, need no diff at all, and get no base.
+
+### Required checks
+
+The `main` ruleset — which also covers `release` — requires exactly one
+context: **`CI Gate`**. The workflow used to carry two extra jobs solely to
+publish historical required-check names (`lint`, which echoed the client job's
+result, and `test (24.x)` on the server job); both are retired. If a required
+check is ever added, require `CI Gate`, never a job name.
+
 The selected work is split across parallel jobs:
 
 - **Server tests** — full, related, or explicit feature test files. Smoke-boots
@@ -79,8 +106,6 @@ The selected work is split across parallel jobs:
   `bufferedSpawn`, `cos-runner`, shell/PM2, etc.). Docs-only and ordinary
   Linux-faithful PRs skip this job. `pinPlatform('win32')` tests still run on
   Linux.
-- **lint** — historical required-check name. The real lint step lives in the
-  client job; this job only mirrors that result.
 - **CI Gate** — always reports one stable required-check result and fails if any
   selected job failed or was cancelled.
 - **Full CI Gate** — published only when the plan chose the complete suite, and

--- a/scripts/ci-base-sha.js
+++ b/scripts/ci-base-sha.js
@@ -53,13 +53,24 @@ export function resolveBaseSha({ eventName, revParse = gitRevParse } = {}) {
 }
 
 function main() {
-  const baseSha = resolveBaseSha({ eventName: process.env.GITHUB_EVENT_NAME });
-  if (!baseSha) {
-    console.log('No pull-request merge base to resolve — this run tests the complete suite.');
+  const eventName = process.env.GITHUB_EVENT_NAME;
+  const baseSha = resolveBaseSha({ eventName });
+  if (baseSha) {
+    writeStepEnv('CI_BASE_SHA', baseSha);
+    console.log(`📌 Diff base for this pull request: ${baseSha}`);
     return;
   }
-  writeStepEnv('CI_BASE_SHA', baseSha);
-  console.log(`📌 Diff base for this pull request: ${baseSha}`);
+  if (eventName === 'pull_request') {
+    // Say so here rather than leaving the reader with "tests the complete
+    // suite", which describes a forced-full run and is the opposite of what
+    // happens next: a scoped pull request with no base fails loudly one step
+    // later, on the planner's throw or the runner's requiresBaseSha guard.
+    // Not fatal on its own — a pull request into the release branch forces
+    // the complete suite and legitimately needs no base.
+    console.error('❌ pull_request checkout is not a merge ref — no diff base to resolve.');
+    return;
+  }
+  console.log('No pull-request merge base to resolve — this run tests the complete suite.');
 }
 
 const isMain = process.argv[1]

--- a/scripts/ci-base-sha.js
+++ b/scripts/ci-base-sha.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+/**
+ * Resolve the commit a pull-request CI run diffs against, reading it out of the
+ * checkout instead of the event payload.
+ *
+ * ZERO external dependencies — this runs before `npm ci` in every test job.
+ *
+ * actions/checkout builds a `pull_request` run from `refs/pull/<n>/merge`, a
+ * merge commit whose FIRST parent is the base-branch commit GitHub merged the
+ * pull request into. Reading that parent beats
+ * `github.event.pull_request.base.sha` twice over:
+ *
+ *   - It needs no history. `merge-base(HEAD^1, HEAD)` is HEAD^1 by
+ *     construction, so `fetch-depth: 2` is enough for both the impact plan's
+ *     `<base>...HEAD` diff and Vitest's `--changed <sha>` (which also runs a
+ *     three-dot diff internally). Every job used to clone all ~13k commits to
+ *     get the same answer.
+ *   - It cannot drift. The payload's `base.sha` is the base tip when the event
+ *     fired, and GitHub rebuilds the merge ref when the base branch moves, so
+ *     the two can disagree — at which point a three-dot diff attributes
+ *     base-branch commits to the pull request.
+ *
+ * Non-pull_request runs force the complete suite (`CI_FORCE_FULL`), so they
+ * need no base at all and this emits nothing.
+ */
+
+import { spawnSync } from 'child_process';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+import { writeStepEnv } from './lib/githubOutput.js';
+
+/** Resolve a revision to a commit sha, or null when git cannot. */
+export function gitRevParse(rev) {
+  const result = spawnSync('git', ['rev-parse', '--verify', '--quiet', `${rev}^{commit}`], {
+    encoding: 'utf8',
+  });
+  if (result.error || result.status !== 0) return null;
+  return result.stdout.trim() || null;
+}
+
+/**
+ * The base commit for this run, or null when the run needs none.
+ *
+ * The `HEAD^2` probe is what distinguishes a merge-ref checkout from a plain
+ * head-commit one: only the former has a second parent, and only the former
+ * has a first parent that means "the base branch".
+ */
+export function resolveBaseSha({ eventName, revParse = gitRevParse } = {}) {
+  if (eventName !== 'pull_request') return null;
+  if (!revParse('HEAD^2')) return null;
+  return revParse('HEAD^1');
+}
+
+function main() {
+  const baseSha = resolveBaseSha({ eventName: process.env.GITHUB_EVENT_NAME });
+  if (!baseSha) {
+    console.log('No pull-request merge base to resolve — this run tests the complete suite.');
+    return;
+  }
+  writeStepEnv('CI_BASE_SHA', baseSha);
+  console.log(`📌 Diff base for this pull request: ${baseSha}`);
+}
+
+const isMain = process.argv[1]
+  && resolve(process.argv[1]) === resolve(fileURLToPath(import.meta.url));
+
+if (isMain) main();

--- a/scripts/ci-base-sha.test.js
+++ b/scripts/ci-base-sha.test.js
@@ -1,0 +1,108 @@
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveBaseSha } from './ci-base-sha.js';
+
+const WORKFLOW = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', '.github', 'workflows', 'ci.yml'),
+  'utf8',
+);
+
+const BASE = 'a'.repeat(40);
+const HEAD = 'b'.repeat(40);
+
+/** A merge-ref checkout: both parents resolve. */
+const mergeRefRevParse = (rev) => ({ 'HEAD^1': BASE, 'HEAD^2': HEAD }[rev] ?? null);
+
+/** Split the workflow into `jobs:` entries keyed by job id. */
+function workflowJobs(yaml) {
+  const body = yaml.slice(yaml.indexOf('\njobs:\n'));
+  const jobs = {};
+  let current = null;
+  for (const line of body.split('\n')) {
+    const header = line.match(/^ {2}([a-z][a-z0-9-]*):\s*$/);
+    if (header) {
+      current = header[1];
+      jobs[current] = [];
+      continue;
+    }
+    if (current) jobs[current].push(line);
+  }
+  return Object.fromEntries(Object.entries(jobs).map(([id, lines]) => [id, lines.join('\n')]));
+}
+
+describe('resolveBaseSha', () => {
+  it('reads the base branch off the pull-request merge ref', () => {
+    expect(resolveBaseSha({ eventName: 'pull_request', revParse: mergeRefRevParse })).toBe(BASE);
+  });
+
+  it('emits no base for a run that is not a pull request', () => {
+    // Nightly, dispatch, and the release workflow_call all force the complete
+    // suite, so there is nothing to diff against.
+    expect(resolveBaseSha({ eventName: 'schedule', revParse: mergeRefRevParse })).toBeNull();
+    expect(resolveBaseSha({ eventName: 'workflow_dispatch', revParse: mergeRefRevParse })).toBeNull();
+    expect(resolveBaseSha({ eventName: undefined, revParse: mergeRefRevParse })).toBeNull();
+  });
+
+  it('refuses to treat a plain head-commit checkout as a merge ref', () => {
+    // Without a second parent, HEAD^1 is the PR's own previous commit — using
+    // it as the diff base would scope CI to the last commit of the branch.
+    const headOnly = (rev) => (rev === 'HEAD^1' ? BASE : null);
+
+    expect(resolveBaseSha({ eventName: 'pull_request', revParse: headOnly })).toBeNull();
+  });
+
+  it('emits nothing when git cannot resolve the parent at all', () => {
+    expect(resolveBaseSha({ eventName: 'pull_request', revParse: () => null })).toBeNull();
+  });
+});
+
+describe('ci.yml checkout depth', () => {
+  const jobs = workflowJobs(WORKFLOW);
+
+  it('never asks for full history', () => {
+    // fetch-depth: 0 clones every commit in the repo on a job that only ever
+    // diffs the merge ref against its own first parent.
+    expect(WORKFLOW).not.toMatch(/fetch-depth:\s*0\b/);
+    // Negative control: the assertion above can fail.
+    expect('        with:\n          fetch-depth: 0\n').toMatch(/fetch-depth:\s*0\b/);
+  });
+
+  it('resolves the diff base in every job that consumes it', () => {
+    const consumers = Object.entries(jobs)
+      .filter(([, body]) => /run-ci-tests\.js|ci-test-plan\.js/.test(body));
+
+    expect(consumers.map(([id]) => id).sort())
+      .toEqual(['client', 'impact', 'server', 'windows-server']);
+
+    for (const [id, body] of consumers) {
+      expect(body, id).toMatch(/node scripts\/ci-base-sha\.js/);
+      // Depth 2 is the merge commit plus both parents — the minimum that keeps
+      // `<base>...HEAD` resolvable.
+      expect(body, id).toMatch(/fetch-depth:\s*2\b/);
+      // The event payload's base.sha can disagree with the merge ref's parent,
+      // and needs history the shallow clone no longer has.
+      expect(body, id).not.toMatch(/CI_BASE_SHA:\s*\$\{\{/);
+    }
+  });
+});
+
+describe('ci.yml required checks', () => {
+  const jobs = workflowJobs(WORKFLOW);
+
+  it('publishes the gate the branch ruleset actually requires', () => {
+    expect(jobs.gate).toMatch(/name: CI Gate/);
+    expect(jobs['full-gate']).toMatch(/name: Full CI Gate/);
+  });
+
+  it('no longer carries the retired legacy check-name jobs', () => {
+    // `lint` was a whole runner that echoed the client job's result, and the
+    // server job wore `test (24.x)`; the ruleset requires neither.
+    expect(jobs.lint).toBeUndefined();
+    expect(WORKFLOW).not.toMatch(/name: test \(24\.x\)/);
+    expect(jobs.gate).not.toMatch(/needs\.lint\b/);
+  });
+});

--- a/scripts/ci-test-plan.js
+++ b/scripts/ci-test-plan.js
@@ -29,7 +29,7 @@ const FULL_TRIGGER_RULES = [
   // The scripts that decide what CI runs, run it, and gate the release on it.
   // A bug in any of them can make a scoped plan silently test nothing, so they
   // prove themselves against the complete suite rather than their own scope.
-  { re: /^scripts\/(?:ci-test-plan|run-ci-(?:lint|tests)|verify-ci-status)(?:\.test)?\.js$/, reason: 'CI pipeline script changed' },
+  { re: /^scripts\/(?:lib\/githubOutput|ci-base-sha|ci-test-plan|run-ci-(?:lint|tests)|verify-ci-status)(?:\.test)?\.js$/, reason: 'CI pipeline script changed' },
 ];
 
 // Files whose Windows behavior is not faithfully exercised by pinPlatform()
@@ -462,14 +462,17 @@ function main() {
     baseRef: process.env.CI_BASE_REF,
   });
   const forceFull = Boolean(forceFullReason);
+  // scripts/ci-base-sha.js exports this from the checkout: on a pull request
+  // HEAD is the merge ref and CI_BASE_SHA is its first parent, so the
+  // three-dot diff below resolves against a commit git already has. That is
+  // what lets every job clone at depth 2 instead of full history.
   const base = process.env.CI_BASE_SHA;
-  const head = process.env.CI_HEAD_SHA || 'HEAD';
   if (!forceFull && !base) {
     throw new Error('CI_BASE_SHA is required unless the run is forced full (CI_FORCE_FULL=true or CI_BASE_REF=release).');
   }
   const changedFiles = forceFull
     ? []
-    : gitLines(['diff', '--name-only', '--diff-filter=ACMRD', `${base}...${head}`]);
+    : gitLines(['diff', '--name-only', '--diff-filter=ACMRD', `${base}...HEAD`]);
   const trackedFiles = gitLines(['ls-files']);
   emitGitHubPlan(buildCiTestPlan(changedFiles, { trackedFiles, forceFull, forceFullReason }));
 }

--- a/scripts/ci-test-plan.test.js
+++ b/scripts/ci-test-plan.test.js
@@ -296,6 +296,9 @@ describe('CI test impact planner', () => {
 
   it('routes CI pipeline scripts to the complete suite', () => {
     for (const path of [
+      'scripts/ci-base-sha.js',
+      'scripts/ci-base-sha.test.js',
+      'scripts/lib/githubOutput.js',
       'scripts/ci-test-plan.js',
       'scripts/run-ci-tests.js',
       'scripts/run-ci-lint.js',

--- a/scripts/lib/githubOutput.js
+++ b/scripts/lib/githubOutput.js
@@ -1,5 +1,5 @@
 /**
- * GitHub Actions step-output/summary append helpers for CI scripts.
+ * GitHub Actions step-output/step-env/summary append helpers for CI scripts.
  *
  * ZERO external dependencies — these run in jobs that have not installed
  * anything yet. Do NOT import from server/lib or any installed package.
@@ -8,18 +8,39 @@
 import { appendFileSync } from 'fs';
 
 /**
- * Append `name=value` to $GITHUB_OUTPUT, or do nothing outside Actions.
+ * Append a `name=value` line to one of Actions' key/value command files.
  *
  * Newlines and carriage returns are stripped: the `name=value` form has no
  * escape, so an embedded newline silently truncates the value and lets the
- * remainder forge a second output. Callers that render a value as markdown
+ * remainder forge a second entry. Callers that render a value as markdown
  * should sanitize further at their own call site.
+ */
+function appendCommandFile(envVar, name, value) {
+  const path = process.env[envVar];
+  if (!path) return;
+  appendFileSync(path, `${name}=${String(value).replace(/[\r\n]+/g, ' ')}\n`);
+}
+
+/**
+ * Append `name=value` to $GITHUB_OUTPUT, or do nothing outside Actions.
  *
  * @param {string} name - output name
  * @param {unknown} value - stringified before writing
  */
 export function writeStepOutput(name, value) {
-  const outputPath = process.env.GITHUB_OUTPUT;
-  if (!outputPath) return;
-  appendFileSync(outputPath, `${name}=${String(value).replace(/[\r\n]+/g, ' ')}\n`);
+  appendCommandFile('GITHUB_OUTPUT', name, value);
+}
+
+/**
+ * Append `name=value` to $GITHUB_ENV, or do nothing outside Actions.
+ *
+ * Unlike a step output this needs no `id`, and later steps in the same job read
+ * it as an ordinary process environment variable — which is what lets one
+ * resolver step feed several plain `node scripts/...` steps.
+ *
+ * @param {string} name - environment variable name
+ * @param {unknown} value - stringified before writing
+ */
+export function writeStepEnv(name, value) {
+  appendCommandFile('GITHUB_ENV', name, value);
 }

--- a/scripts/lib/githubOutput.test.js
+++ b/scripts/lib/githubOutput.test.js
@@ -4,7 +4,7 @@ import { join } from 'path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { writeStepOutput } from './githubOutput.js';
+import { writeStepEnv, writeStepOutput } from './githubOutput.js';
 
 describe('writeStepOutput', () => {
   let outputPath;
@@ -39,5 +39,54 @@ describe('writeStepOutput', () => {
 
     expect(() => writeStepOutput('verified', false)).not.toThrow();
     expect(readFileSync(outputPath, 'utf8')).toBe('');
+  });
+});
+
+describe('writeStepEnv', () => {
+  let envPath;
+  const previous = process.env.GITHUB_ENV;
+
+  beforeEach(() => {
+    envPath = join(mkdtempSync(join(tmpdir(), 'gh-env-')), 'env.txt');
+    writeFileSync(envPath, '');
+    process.env.GITHUB_ENV = envPath;
+  });
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.GITHUB_ENV;
+    else process.env.GITHUB_ENV = previous;
+  });
+
+  it('appends one name=value line per call', () => {
+    writeStepEnv('CI_BASE_SHA', 'abc123');
+
+    expect(readFileSync(envPath, 'utf8')).toBe('CI_BASE_SHA=abc123\n');
+  });
+
+  it('strips newlines so a value cannot forge a second variable', () => {
+    writeStepEnv('CI_BASE_SHA', 'abc123\nPATH=/evil');
+
+    expect(readFileSync(envPath, 'utf8')).toBe('CI_BASE_SHA=abc123 PATH=/evil\n');
+  });
+
+  it('writes to GITHUB_ENV, not GITHUB_OUTPUT', () => {
+    const outputPath = join(mkdtempSync(join(tmpdir(), 'gh-output-')), 'output.txt');
+    writeFileSync(outputPath, '');
+    const previousOutput = process.env.GITHUB_OUTPUT;
+    process.env.GITHUB_OUTPUT = outputPath;
+
+    writeStepEnv('CI_BASE_SHA', 'abc123');
+
+    if (previousOutput === undefined) delete process.env.GITHUB_OUTPUT;
+    else process.env.GITHUB_OUTPUT = previousOutput;
+    expect(readFileSync(outputPath, 'utf8')).toBe('');
+    expect(readFileSync(envPath, 'utf8')).toBe('CI_BASE_SHA=abc123\n');
+  });
+
+  it('does nothing outside GitHub Actions', () => {
+    delete process.env.GITHUB_ENV;
+
+    expect(() => writeStepEnv('CI_BASE_SHA', 'abc123')).not.toThrow();
+    expect(readFileSync(envPath, 'utf8')).toBe('');
   });
 });

--- a/scripts/run-ci-tests.js
+++ b/scripts/run-ci-tests.js
@@ -173,7 +173,12 @@ function main() {
     const listed = listRelatedFiles(scope, baseSha);
     if (listed) {
       relatedFiles = listed;
-    } else if (mode === 'related') {
+    } else {
+      // The list failed, so the union cannot be built. Run the import-graph
+      // half through Vitest directly and the planner's explicit half after
+      // it — two processes instead of one, but never a green run that
+      // quietly dropped every related test. This fallback covers a `files`
+      // plan as much as a `related` one: both union the same two halves.
       const relatedStatus = spawnNpm(scope, ['--changed', baseSha], 'related tests');
       if (relatedStatus !== 0) process.exit(relatedStatus);
       process.exit(selectedFiles.length ? spawnNpm(scope, selectedFiles, 'explicit structural tests') : 0);

--- a/scripts/run-ci-tests.js
+++ b/scripts/run-ci-tests.js
@@ -52,6 +52,21 @@ export function shouldSkipRelatedList(mode, repoFiles) {
     && repoFiles.every((path) => ALWAYS_RUN_TESTS.includes(path));
 }
 
+/**
+ * Does this plan need the diff base to select the right tests?
+ *
+ * Both scoped modes union the planner's explicit files with Vitest's
+ * import-graph `--changed` set, and that half needs a base commit. Without one
+ * a `files` plan used to quietly run the explicit half alone — a narrower
+ * suite that still reports green, which is exactly the failure a shallow
+ * checkout would introduce if scripts/ci-base-sha.js ever stopped exporting
+ * CI_BASE_SHA. Only an always-run-only plan genuinely needs no base.
+ */
+export function requiresBaseSha(mode, repoFiles) {
+  if (mode === 'full') return false;
+  return !shouldSkipRelatedList(mode, repoFiles);
+}
+
 export function toRunnerPath(scope, path) {
   // Prefix in-root selectors so a contributor-controlled filename beginning
   // with "-" cannot be interpreted as another Vitest CLI option.
@@ -134,8 +149,8 @@ function main() {
     process.exit(2);
   }
 
-  if (mode === 'related' && !baseSha) {
-    console.error('CI_BASE_SHA is required for related-test mode.');
+  if (!baseSha && requiresBaseSha(mode, repoFiles)) {
+    console.error(`CI_BASE_SHA is required for ${mode}-test mode.`);
     process.exit(2);
   }
 
@@ -151,8 +166,10 @@ function main() {
   // One Vitest process for the union of planner files + import-graph related
   // tests. `--changed` ANDs with path selectors, so they cannot share argv —
   // list the related set, then run the union once.
+  // Skipping the list entirely only happens on an always-run-only plan, which
+  // requiresBaseSha() already established names every file it needs.
   let relatedFiles = [];
-  if (baseSha && !shouldSkipRelatedList(mode, repoFiles)) {
+  if (!shouldSkipRelatedList(mode, repoFiles)) {
     const listed = listRelatedFiles(scope, baseSha);
     if (listed) {
       relatedFiles = listed;
@@ -161,8 +178,6 @@ function main() {
       if (relatedStatus !== 0) process.exit(relatedStatus);
       process.exit(selectedFiles.length ? spawnNpm(scope, selectedFiles, 'explicit structural tests') : 0);
     }
-  } else if (mode === 'related') {
-    process.exit(spawnNpm(scope, ['--changed', baseSha], 'related tests'));
   }
 
   const union = unionSelectors(selectedFiles, relatedFiles);

--- a/scripts/run-ci-tests.test.js
+++ b/scripts/run-ci-tests.test.js
@@ -3,10 +3,12 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { ALWAYS_RUN_TESTS } from './ci-test-plan.js';
 import {
   listRelatedCwd,
   parseVitestListOutput,
   recordVitestDuration,
+  requiresBaseSha,
   shouldSkipRelatedList,
   toRunnerPath,
   unionSelectors,
@@ -111,5 +113,22 @@ describe('recordVitestDuration', () => {
     process.env.GITHUB_STEP_SUMMARY = summaryPath;
     recordVitestDuration('server', 'full suite', Date.now() - 1500);
     expect(readFileSync(summaryPath, 'utf8')).toMatch(/^⏱ server full suite: 1\.\ds\n$/);
+  });
+});
+
+describe('requiresBaseSha', () => {
+  it('needs no base for the complete suite', () => {
+    expect(requiresBaseSha('full', [])).toBe(false);
+  });
+
+  it('needs a base for both scoped modes', () => {
+    // A 'files' plan unions the planner's list with Vitest's import graph, so
+    // running it without a base silently drops the second half.
+    expect(requiresBaseSha('files', ['server/services/shell.test.js'])).toBe(true);
+    expect(requiresBaseSha('related', [])).toBe(true);
+  });
+
+  it('needs no base for an always-run-only plan', () => {
+    expect(requiresBaseSha('files', ALWAYS_RUN_TESTS)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Two of the three independent speedups in #4734. Both are verifiable by this PR's own CI run.

- **Depth-2 checkouts everywhere** (was `fetch-depth: 0` in four jobs on a ~13k-commit repo). A `pull_request` checkout is `refs/pull/N/merge`, whose first parent *is* the base commit — so depth 2 already carries everything CI diffs. New `scripts/ci-base-sha.js` reads that parent and exports `CI_BASE_SHA`, keeping both three-dot diffs resolvable: the planner's `git diff <base>...HEAD`, and Vitest's internal `--changed <sha>`. Reading the base off the checkout also beats the event payload's `base.sha`, which names the base tip when the event fired and can disagree with the merge ref GitHub actually built.
- **Retired the two legacy check-name jobs.** `lint` was a whole runner that echoed the client job's lint result; `server` carried `name: test (24.x)`. The `main` ruleset (which also covers `release`) requires exactly one context — `CI Gate` — so neither name is load-bearing. Lint still runs inside the `client` job, whose failure fails the gate.

Rolled in, because the change is what makes it matter: `run-ci-tests.js` now **stops** when a scoped plan has no diff base, and falls back to a direct `--changed` run when the related-list command fails in `files` mode. Both previously ran only the planner's explicit files and reported green — the one way this change could regress unnoticed.

## Test plan

- `cd server && npx vitest run ../scripts` — 274 files / 2015 tests pass.
- Verified the premise against a real depth-2 shallow clone of a merge commit: `merge-base` resolves, `git diff --diff-filter=ACMRD <base>...HEAD` returns the right file set, Vitest's `--changed` diff form works, `git ls-files` unaffected. `.git` is 32M vs ~100 MiB at full depth.
- Confirmed the live ruleset requires only `CI Gate`; no script or workflow keys on `lint` or `test (24.x)` (`verify-ci-status.js` keys on `Full CI Gate`, untouched).
- New `scripts/ci-base-sha.test.js` guards the workflow shape. Bypass-probed: reverting a job to `fetch-depth: 0`, deleting a resolver step, re-adding the payload `CI_BASE_SHA`, or restoring the retired job/name each makes it fail.
- This PR touches `.github/workflows/`, so its own run is a forced full-CI run.

## Remaining

Item 2 of the issue — caching `server/node_modules` keyed on `server/package-lock.json` across the `server`, `database`, and `windows-server` jobs — is deliberately not here. The issue asks for the three to ship separately, and this one cannot be validated by its own run: the first run is always a cache miss, so the restore path only exercises on a later PR. It also carries a real poisoning hazard (`server/.npmrc` pins `ignore-scripts=true`, so the cache must be saved *after* the native rebuild). Follow-up issue to come.

Refs #4734