### PR TITLE
Make the POST cognitive drill how-to cards reachable after the first run

### DIFF
--- a/client/src/components/meatspace/post/PostCognitiveDrillRunner.jsx
+++ b/client/src/components/meatspace/post/PostCognitiveDrillRunner.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Brain, Check, X, BookOpen, Play } from 'lucide-react';
-import { DRILL_LABELS, nBackBalancedAccuracy } from './constants';
+import { DRILL_LABELS, nBackBalancedAccuracy, effectiveCognitiveDrillConfig, cognitiveRungPending } from './constants';
 import { safeReadJsonStorage, safeWriteStorage } from '../../../lib/safeStorage.js';
 import useMounted from '../../../hooks/useMounted';
 import useKeyCapture from '../../../hooks/useKeyCapture';
@@ -127,6 +127,17 @@ export function buildNBackExample(n) {
 export function hasDrillTutorial(type) {
   return getDrillTutorial({ type }) != null;
 }
+
+/**
+ * Drill types whose how-to copy actually VARIES with the drill config — the
+ * n-back lag, the digit-span recall direction, the reaction-time mode. Only
+ * these need the effective (ladder) config resolved before the card can be
+ * shown; every other card reads the same at any difficulty, so it opens
+ * immediately. Guarded by a property test that probes `getDrillTutorial` with
+ * two configs, so a new config-dependent branch can't be added without landing
+ * on this list.
+ */
+export const CONFIG_DEPENDENT_TUTORIAL_TYPES = ['n-back', 'digit-span', 'reaction-time'];
 
 // Per-type how-to content. A pure function of the drill so config-dependent
 // copy (n-back lag, digit-span direction, reaction-time mode) reads correctly.
@@ -329,10 +340,28 @@ function CognitiveDrillTutorial({ drill, tut, header = null, onAction, actionLab
  * `drill` may be null (nothing selected) or a type with no tutorial — both
  * render nothing, so callers can pass state straight through.
  */
-export function CognitiveDrillTutorialPreview({ drill, onClose }) {
+export function CognitiveDrillTutorialPreview({ type, drillConfig, cognitiveProgress, onClose }) {
+  // Both the effective config and the "can we show it yet?" question are decided
+  // HERE, not at each call site: the two surfaces would otherwise each carry
+  // (and each get to drift on) the same three-way derivation.
+  const drill = type ? { type, config: effectiveCognitiveDrillConfig(drillConfig, cognitiveProgress?.[type]) } : null;
   const tut = drill ? getDrillTutorial(drill) : null;
   if (!tut) return null;
-  const label = DRILL_LABELS[drill.type] || drill.type;
+  const label = DRILL_LABELS[type] || type;
+  const pending = CONFIG_DEPENDENT_TUTORIAL_TYPES.includes(type)
+    && cognitiveRungPending(type, drillConfig, cognitiveProgress);
+  if (pending) {
+    // The rung that decides this drill's lag / recall direction hasn't loaded.
+    // Waiting beats rendering the stored knobs, which would state one rule and
+    // then swap it for another mid-read.
+    return (
+      <Modal open onClose={onClose} size="md" usePortal ariaLabel={`How ${label} works`}>
+        <div className="bg-port-card border border-port-border rounded-xl p-5 text-center text-sm text-gray-400" role="status">
+          Resolving your current {label} difficulty…
+        </div>
+      </Modal>
+    );
+  }
   return (
     // `usePortal` per the overlay convention in client/src/CLAUDE.md: this is
     // rendered mid-tree inside two long settings/launcher pages, and a

--- a/client/src/components/meatspace/post/PostCognitiveDrillRunner.jsx
+++ b/client/src/components/meatspace/post/PostCognitiveDrillRunner.jsx
@@ -5,6 +5,7 @@ import { safeReadJsonStorage, safeWriteStorage } from '../../../lib/safeStorage.
 import useMounted from '../../../hooks/useMounted';
 import useKeyCapture from '../../../hooks/useKeyCapture';
 import { isPressKey } from '../../../lib/a11yKeyboard.js';
+import Modal from '../../ui/Modal';
 
 /**
  * Interactive runner for deterministic cognitive drills (n-back, digit-span,
@@ -242,19 +243,25 @@ function DrillTutorialGate({ drill, isTraining, drillIndex, drillCount, children
   return (
     <CognitiveDrillTutorial
       drill={drill}
-      isTraining={isTraining}
-      drillIndex={drillIndex}
-      drillCount={drillCount}
-      onStart={() => { markDrillTutorialSeen(drill.type); setShowTutorial(false); }}
+      header={<DrillHeader type={drill.type} isTraining={isTraining} drillIndex={drillIndex} drillCount={drillCount} />}
+      onAction={() => { markDrillTutorialSeen(drill.type); setShowTutorial(false); }}
+      footNote="You’ll only see this the first time for each drill type. Reopen it any time from the launcher or Config."
     />
   );
 }
 
-function CognitiveDrillTutorial({ drill, isTraining, drillIndex, drillCount, onStart }) {
+/**
+ * The how-to card for one cognitive drill type. Everything around the card body
+ * is caller-supplied so one component serves both entry points: the first-run
+ * gate (drill header, "Start drill", the one-shot footnote) and the standalone
+ * preview below (no header, "Got it", no run behind it). Keeping the body in one
+ * place is the point — the n-back worked example must not drift between them.
+ */
+function CognitiveDrillTutorial({ drill, header = null, onAction, actionLabel = 'Start drill', ActionIcon = Play, footNote = null }) {
   const tut = getDrillTutorial(drill);
   return (
     <div className="max-w-lg mx-auto space-y-6">
-      <DrillHeader type={drill.type} isTraining={isTraining} drillIndex={drillIndex} drillCount={drillCount} />
+      {header}
 
       <div className="rounded-xl border border-rose-500/30 bg-rose-500/5 p-5 space-y-4">
         <div className="flex items-center gap-2 text-rose-300">
@@ -285,15 +292,47 @@ function CognitiveDrillTutorial({ drill, isTraining, drillIndex, drillCount, onS
 
       <button
         type="button"
-        onClick={onStart}
+        onClick={onAction}
         autoFocus
         className="w-full px-6 py-4 bg-rose-500/20 hover:bg-rose-500/30 text-rose-200 border border-rose-500/40 font-semibold rounded-lg transition-colors flex items-center justify-center gap-2"
       >
-        <Play size={18} /> Start drill
+        <ActionIcon size={18} /> {actionLabel}
       </button>
 
-      <p className="text-center text-xs text-gray-600">You&rsquo;ll only see this the first time for each drill type.</p>
+      {footNote && <p className="text-center text-xs text-gray-600">{footNote}</p>}
     </div>
+  );
+}
+
+/**
+ * Standalone how-to card for a drill type, with no runner behind it — the way
+ * back to a tutorial once its one-shot first-run gate has been spent (issue
+ * #4732). Rendered from the POST launcher and the drill config so a rule you
+ * last read weeks ago is re-readable without starting a scored run.
+ *
+ * Deliberately NOT reachable from inside a live drill: every cognitive runner
+ * stamps `startedAtRef` at mount, so re-showing the tutorial mid-run would
+ * either drop the run or bill the reading time to its `totalMs`. The preview
+ * takes a plain `{ type, config }` and mounts no runner at all.
+ *
+ * `drill` may be null (nothing selected) or a type with no tutorial — both
+ * render nothing, so callers can pass state straight through.
+ */
+export function CognitiveDrillTutorialPreview({ drill, onClose }) {
+  if (!drill || !getDrillTutorial(drill)) return null;
+  const label = DRILL_LABELS[drill.type] || drill.type;
+  return (
+    <Modal open onClose={onClose} size="lg" ariaLabel={`How ${label} works`}>
+      <div className="bg-port-card border border-port-border rounded-xl p-5 max-h-[85vh] overflow-y-auto">
+        <CognitiveDrillTutorial
+          drill={drill}
+          onAction={onClose}
+          actionLabel="Got it"
+          ActionIcon={Check}
+          footNote="Preview only — nothing is timed or scored here."
+        />
+      </div>
+    </Modal>
   );
 }
 

--- a/client/src/components/meatspace/post/PostCognitiveDrillRunner.jsx
+++ b/client/src/components/meatspace/post/PostCognitiveDrillRunner.jsx
@@ -119,6 +119,15 @@ export function buildNBackExample(n) {
   return { sequence, n: lag };
 }
 
+/**
+ * Whether a drill type has a how-to card at all. The one predicate that owns
+ * this rule: a "How it works" affordance must not render for a type
+ * `getDrillTutorial` has no case for, or it opens nothing.
+ */
+export function hasDrillTutorial(type) {
+  return getDrillTutorial({ type }) != null;
+}
+
 // Per-type how-to content. A pure function of the drill so config-dependent
 // copy (n-back lag, digit-span direction, reaction-time mode) reads correctly.
 // Returns null for types with no tutorial (which skip the gate entirely).
@@ -237,14 +246,17 @@ export function getDrillTutorial(drill) {
 // Holds the runner until the first-run tutorial (if any) is dismissed.
 function DrillTutorialGate({ drill, isTraining, drillIndex, drillCount, children }) {
   const [showTutorial, setShowTutorial] = useState(
-    () => getDrillTutorial(drill) != null && !hasSeenDrillTutorial(drill.type),
+    () => hasDrillTutorial(drill.type) && !hasSeenDrillTutorial(drill.type),
   );
   if (!showTutorial) return children;
   return (
     <CognitiveDrillTutorial
       drill={drill}
+      tut={getDrillTutorial(drill)}
       header={<DrillHeader type={drill.type} isTraining={isTraining} drillIndex={drillIndex} drillCount={drillCount} />}
       onAction={() => { markDrillTutorialSeen(drill.type); setShowTutorial(false); }}
+      actionLabel="Start drill"
+      ActionIcon={Play}
       footNote="You’ll only see this the first time for each drill type. Reopen it any time from the launcher or Config."
     />
   );
@@ -257,8 +269,7 @@ function DrillTutorialGate({ drill, isTraining, drillIndex, drillCount, children
  * preview below (no header, "Got it", no run behind it). Keeping the body in one
  * place is the point — the n-back worked example must not drift between them.
  */
-function CognitiveDrillTutorial({ drill, header = null, onAction, actionLabel = 'Start drill', ActionIcon = Play, footNote = null }) {
-  const tut = getDrillTutorial(drill);
+function CognitiveDrillTutorial({ drill, tut, header = null, onAction, actionLabel, ActionIcon, footNote = null }) {
   return (
     <div className="max-w-lg mx-auto space-y-6">
       {header}
@@ -319,13 +330,21 @@ function CognitiveDrillTutorial({ drill, header = null, onAction, actionLabel = 
  * render nothing, so callers can pass state straight through.
  */
 export function CognitiveDrillTutorialPreview({ drill, onClose }) {
-  if (!drill || !getDrillTutorial(drill)) return null;
+  const tut = drill ? getDrillTutorial(drill) : null;
+  if (!tut) return null;
   const label = DRILL_LABELS[drill.type] || drill.type;
   return (
-    <Modal open onClose={onClose} size="lg" ariaLabel={`How ${label} works`}>
+    // `usePortal` per the overlay convention in client/src/CLAUDE.md: this is
+    // rendered mid-tree inside two long settings/launcher pages, and a
+    // `backdrop-filter` ancestor (every bordered `.bg-port-card` on the glass
+    // themes) would otherwise become the fixed overlay's containing block.
+    // Sized `md` to match the card body's own `max-w-lg`, so there is no dead
+    // gutter inside the panel.
+    <Modal open onClose={onClose} size="md" usePortal ariaLabel={`How ${label} works`}>
       <div className="bg-port-card border border-port-border rounded-xl p-5 max-h-[85vh] overflow-y-auto">
         <CognitiveDrillTutorial
           drill={drill}
+          tut={tut}
           onAction={onClose}
           actionLabel="Got it"
           ActionIcon={Check}
@@ -333,6 +352,35 @@ export function CognitiveDrillTutorialPreview({ drill, onClose }) {
         />
       </div>
     </Modal>
+  );
+}
+
+/**
+ * The affordance that opens the preview. Shared by the POST launcher sidebar and
+ * the Drill Config cards so the accessible name (`How <label> works`, which both
+ * suites assert) and the mobile hit area live in ONE place rather than drifting
+ * per surface. Renders nothing for a type with no how-to card, so the button can
+ * never open an empty modal.
+ *
+ * `compact` is the launcher's dense sidebar row: icon only, with the 44px touch
+ * target collapsing to a tight icon on `sm+`.
+ */
+export function CognitiveDrillHowItWorksButton({ type, onClick, compact = false }) {
+  if (!hasDrillTutorial(type)) return null;
+  const label = DRILL_LABELS[type] || type;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={`How ${label} works`}
+      title="How it works"
+      className={compact
+        ? 'shrink-0 inline-flex items-center justify-center min-w-[44px] min-h-[44px] sm:min-w-0 sm:min-h-0 sm:p-1 -m-1 sm:m-0 rounded-lg text-gray-500 hover:text-rose-300 transition-colors focus:outline-hidden focus:ring-2 focus:ring-port-accent'
+        : 'mt-1 inline-flex items-center justify-center gap-1 min-h-[44px] sm:min-h-0 sm:py-0.5 text-xs text-gray-500 hover:text-port-accent transition-colors rounded focus:outline-hidden focus:ring-2 focus:ring-port-accent'}
+    >
+      <BookOpen size={compact ? 14 : 12} />
+      {!compact && 'How it works'}
+    </button>
   );
 }
 

--- a/client/src/components/meatspace/post/PostCognitiveDrillRunner.test.jsx
+++ b/client/src/components/meatspace/post/PostCognitiveDrillRunner.test.jsx
@@ -19,6 +19,7 @@ import PostCognitiveDrillRunner, {
   hasSeenDrillTutorial,
   markDrillTutorialSeen,
   buildNBackExample,
+  CognitiveDrillTutorialPreview,
 } from './PostCognitiveDrillRunner';
 
 // Result-assembly tests for PostCognitiveDrillRunner's `finish()` builders.
@@ -664,6 +665,59 @@ describe('first-run tutorial gate', () => {
     );
     expect(screen.queryByRole('button', { name: /start drill/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /wait for the signal/i })).toBeInTheDocument();
+  });
+});
+
+// Standalone how-to preview (issue #4732) — the way back to a tutorial card the
+// one-shot first-run gate has already been spent on. The load-bearing property
+// is that it renders the SAME body with NO runner behind it, so nothing is
+// timed or scored while the user reads.
+describe('CognitiveDrillTutorialPreview', () => {
+  beforeEach(() => window.localStorage.clear());
+  afterEach(() => window.localStorage.clear());
+
+  it('renders the how-to card, including the n-back worked example, with no runner mounted', () => {
+    render(<CognitiveDrillTutorialPreview drill={{ type: 'n-back', config: { n: 3 } }} onClose={vi.fn()} />);
+    expect(screen.getByText(/catch when one repeats from 3 steps earlier/i)).toBeInTheDocument();
+    // The worked example strip — the whole reason the card needs to stay reachable.
+    const example = screen.getByRole('list', { name: /example letter stream/i });
+    expect(within(example).getByText('Match!')).toBeInTheDocument();
+    expect(within(example).getByText('3 steps back')).toBeInTheDocument();
+    // No runner: the n-back stimulus button and the gate's Start button are both absent.
+    expect(screen.queryByRole('button', { name: /^match$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /start drill/i })).not.toBeInTheDocument();
+  });
+
+  it('does not consume the first-run gate for the type it previewed', () => {
+    render(<CognitiveDrillTutorialPreview drill={{ type: 'stroop', config: {} }} onClose={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /got it/i })).toBeInTheDocument();
+    expect(hasSeenDrillTutorial('stroop')).toBe(false);
+  });
+
+  it('closes on "Got it"', () => {
+    const onClose = vi.fn();
+    render(<CognitiveDrillTutorialPreview drill={{ type: 'flanker', config: {} }} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /got it/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders nothing for no selection or a type with no tutorial', () => {
+    const { container, rerender } = render(<CognitiveDrillTutorialPreview drill={null} onClose={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+    rerender(<CognitiveDrillTutorialPreview drill={{ type: 'not-a-drill' }} onClose={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('reflects the drill config it is handed, so a re-read matches the configured difficulty', () => {
+    const { rerender } = render(
+      <CognitiveDrillTutorialPreview drill={{ type: 'digit-span', config: { direction: 'backward' } }} onClose={vi.fn()} />,
+    );
+    expect(screen.getByText(/then type them in reverse/i)).toBeInTheDocument();
+    rerender(
+      <CognitiveDrillTutorialPreview drill={{ type: 'digit-span', config: { direction: 'forward' } }} onClose={vi.fn()} />,
+    );
+    expect(screen.queryByText(/then type them in reverse/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/then type them back in order/i)).toBeInTheDocument();
   });
 });
 

--- a/client/src/components/meatspace/post/PostCognitiveDrillRunner.test.jsx
+++ b/client/src/components/meatspace/post/PostCognitiveDrillRunner.test.jsx
@@ -20,7 +20,10 @@ import PostCognitiveDrillRunner, {
   markDrillTutorialSeen,
   buildNBackExample,
   CognitiveDrillTutorialPreview,
+  CONFIG_DEPENDENT_TUTORIAL_TYPES,
+  hasDrillTutorial,
 } from './PostCognitiveDrillRunner';
+import { COGNITIVE_DRILL_TYPES } from './constants';
 
 // Result-assembly tests for PostCognitiveDrillRunner's `finish()` builders.
 // The server rescores each drill deterministically from `drillData`/`questions`
@@ -668,6 +671,25 @@ describe('first-run tutorial gate', () => {
   });
 });
 
+// Property guard for CONFIG_DEPENDENT_TUTORIAL_TYPES (issue #4732): the preview
+// waits for the ladder rung only for the types on that list, so a new
+// config-dependent branch in `getDrillTutorial` that ISN'T listed would silently
+// go back to describing the stored knobs. Probing the real function beats
+// re-listing the types by hand — the test can't drift from the code it guards.
+describe('CONFIG_DEPENDENT_TUTORIAL_TYPES', () => {
+  // Every knob any cognitive ladder or drill config can move, at two distinct
+  // values — if the copy reads ANY of them, one of these pairs shifts it.
+  const CONFIG_A = { n: 1, direction: 'forward', mode: 'simple', startLength: 4, maxLength: 6, size: 4, incongruentPct: 10, optionCount: 3, stimulusMs: 2500, ruleCount: 2, switchRatePct: 10, noGoPct: 10, lureSimilarity: 'low', congruentPct: 10, flankerStrength: 1, count: 5 };
+  const CONFIG_B = { n: 3, direction: 'backward', mode: 'choice', startLength: 6, maxLength: 9, size: 6, incongruentPct: 90, optionCount: 4, stimulusMs: 1600, ruleCount: 3, switchRatePct: 90, noGoPct: 90, lureSimilarity: 'high', congruentPct: 90, flankerStrength: 3, count: 20 };
+
+  it('lists exactly the drill types whose how-to copy changes with config', () => {
+    const varies = COGNITIVE_DRILL_TYPES.filter(type => hasDrillTutorial(type)
+      && JSON.stringify(getDrillTutorial({ type, config: CONFIG_A }))
+        !== JSON.stringify(getDrillTutorial({ type, config: CONFIG_B })));
+    expect(varies.sort()).toEqual([...CONFIG_DEPENDENT_TUTORIAL_TYPES].sort());
+  });
+});
+
 // Standalone how-to preview (issue #4732) — the way back to a tutorial card the
 // one-shot first-run gate has already been spent on. The load-bearing property
 // is that it renders the SAME body with NO runner behind it, so nothing is
@@ -677,7 +699,7 @@ describe('CognitiveDrillTutorialPreview', () => {
   afterEach(() => window.localStorage.clear());
 
   it('renders the how-to card, including the n-back worked example, with no runner mounted', () => {
-    render(<CognitiveDrillTutorialPreview drill={{ type: 'n-back', config: { n: 3 } }} onClose={vi.fn()} />);
+    render(<CognitiveDrillTutorialPreview type="n-back" drillConfig={{ n: 3, progressive: false }} onClose={vi.fn()} />);
     expect(screen.getByText(/catch when one repeats from 3 steps earlier/i)).toBeInTheDocument();
     // The worked example strip — the whole reason the card needs to stay reachable.
     const example = screen.getByRole('list', { name: /example letter stream/i });
@@ -689,32 +711,67 @@ describe('CognitiveDrillTutorialPreview', () => {
   });
 
   it('does not consume the first-run gate for the type it previewed', () => {
-    render(<CognitiveDrillTutorialPreview drill={{ type: 'stroop', config: {} }} onClose={vi.fn()} />);
+    render(<CognitiveDrillTutorialPreview type="stroop" drillConfig={{}} onClose={vi.fn()} />);
     expect(screen.getByRole('button', { name: /got it/i })).toBeInTheDocument();
     expect(hasSeenDrillTutorial('stroop')).toBe(false);
   });
 
   it('closes on "Got it"', () => {
     const onClose = vi.fn();
-    render(<CognitiveDrillTutorialPreview drill={{ type: 'flanker', config: {} }} onClose={onClose} />);
+    render(<CognitiveDrillTutorialPreview type="flanker" drillConfig={{}} onClose={onClose} />);
     fireEvent.click(screen.getByRole('button', { name: /got it/i }));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('waits for the ladder rung rather than showing the stored knobs first', () => {
+    // Laddered + progressive (the default) + progress not loaded (`null` = not
+    // fetched). Rendering the card now would state a lag that changes under the
+    // reader a moment later.
+    render(<CognitiveDrillTutorialPreview type="n-back" drillConfig={{ n: 1 }} cognitiveProgress={null} onClose={vi.fn()} />);
+    expect(screen.getByRole('status')).toHaveTextContent(/resolving your current n-back difficulty/i);
+    expect(screen.queryByText(/repeats from 1 step earlier/i)).toBeNull();
+  });
+
+  it('shows the card immediately once the rung has resolved', () => {
+    render(<CognitiveDrillTutorialPreview
+      type="n-back"
+      drillConfig={{ n: 1 }}
+      cognitiveProgress={{ 'n-back': { config: { n: 3 } } }}
+      onClose={vi.fn()}
+    />);
+    expect(screen.getByText(/catch when one repeats from 3 steps earlier/i)).toBeInTheDocument();
+  });
+
+  it('falls back to the stored knobs when the rung fetch came back empty, rather than hanging', () => {
+    // `{}` = fetched-or-failed. The card is the best available answer; waiting
+    // forever on a rung that is never coming is not.
+    render(<CognitiveDrillTutorialPreview type="n-back" drillConfig={{ n: 1 }} cognitiveProgress={{}} onClose={vi.fn()} />);
+    expect(screen.getByText(/catch when one repeats from 1 step earlier/i)).toBeInTheDocument();
+    expect(screen.queryByText(/resolving your current/i)).toBeNull();
+  });
+
+  it('opens a config-independent card straight away, with no rung to wait for', () => {
+    // Flanker is laddered, but its copy never mentions a config value — making it
+    // wait would be a spinner for nothing.
+    render(<CognitiveDrillTutorialPreview type="flanker" drillConfig={{}} cognitiveProgress={null} onClose={vi.fn()} />);
+    expect(screen.getByText(/report the center arrow/i)).toBeInTheDocument();
+    expect(screen.queryByText(/resolving your current/i)).toBeNull();
+  });
+
   it('renders nothing for no selection or a type with no tutorial', () => {
-    const { container, rerender } = render(<CognitiveDrillTutorialPreview drill={null} onClose={vi.fn()} />);
+    const { container, rerender } = render(<CognitiveDrillTutorialPreview type={null} onClose={vi.fn()} />);
     expect(container).toBeEmptyDOMElement();
-    rerender(<CognitiveDrillTutorialPreview drill={{ type: 'not-a-drill' }} onClose={vi.fn()} />);
+    rerender(<CognitiveDrillTutorialPreview type="not-a-drill" onClose={vi.fn()} />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it('reflects the drill config it is handed, so a re-read matches the configured difficulty', () => {
     const { rerender } = render(
-      <CognitiveDrillTutorialPreview drill={{ type: 'digit-span', config: { direction: 'backward' } }} onClose={vi.fn()} />,
+      <CognitiveDrillTutorialPreview type="digit-span" drillConfig={{ direction: 'backward', progressive: false }} onClose={vi.fn()} />,
     );
     expect(screen.getByText(/then type them in reverse/i)).toBeInTheDocument();
     rerender(
-      <CognitiveDrillTutorialPreview drill={{ type: 'digit-span', config: { direction: 'forward' } }} onClose={vi.fn()} />,
+      <CognitiveDrillTutorialPreview type="digit-span" drillConfig={{ direction: 'forward', progressive: false }} onClose={vi.fn()} />,
     );
     expect(screen.queryByText(/then type them in reverse/i)).not.toBeInTheDocument();
     expect(screen.getByText(/then type them back in order/i)).toBeInTheDocument();

--- a/client/src/components/meatspace/post/PostDrillConfig.jsx
+++ b/client/src/components/meatspace/post/PostDrillConfig.jsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from 'react';
-import { ArrowLeft, Save, Brain, Bell, Target, Layers, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { ArrowLeft, Save, Brain, Bell, Target, Layers, TrendingUp, TrendingDown, Minus, BookOpen } from 'lucide-react';
 import { updatePostConfig, getProviders, getPostAdaptivePreview, getPostMultiplicationProgress, getPostPowersProgress, getPostCognitiveProgress, getMemoryItems } from '../../../services/api';
 import toast from '../../ui/Toast';
 import { FormField } from '../../ui/FormField';
 import { filterSelectableModels, enabledApiProviderFilter } from '../../../utils/providers';
 import { GOAL_DEFS, POST_TOPICS, MODULE_LABELS, DRILL_LABELS, DRILL_DESCRIPTIONS, composedSessionDrillTypes } from './constants';
+import { CognitiveDrillTutorialPreview } from './PostCognitiveDrillRunner';
 
 // Modules a Full/Quick composed session can draw from (issue #2100), DERIVED
 // from the shared topic registry so the list has one owner (issue #3252): a
@@ -463,7 +464,7 @@ function GroupBulkToggle({ groupLabel, onEnableAll, onDisableAll }) {
   );
 }
 
-function DrillCard({ type, meta, drillConfig, enabled, accent, onToggle, onUpdateField, adaptiveInfo, progressive, onToggleProgressive, progressInfo, managedFieldKeys = [], speedGated = false, managedLabel = 'Manual knobs' }) {
+function DrillCard({ type, meta, drillConfig, enabled, accent, onToggle, onUpdateField, adaptiveInfo, progressive, onToggleProgressive, progressInfo, managedFieldKeys = [], speedGated = false, managedLabel = 'Manual knobs', onPreviewHowItWorks }) {
   // Label and description both come from the shared registries in constants.js —
   // the per-module META objects carry only the knobs, so a drill rename is one edit.
   const label = DRILL_LABELS[type];
@@ -483,6 +484,18 @@ function DrillCard({ type, meta, drillConfig, enabled, accent, onToggle, onUpdat
         <div>
           <h3 className="text-white font-medium">{label}</h3>
           <p className="text-gray-500 text-xs">{DRILL_DESCRIPTIONS[type]}</p>
+          {/* Outside the `enabled &&` blocks on purpose: previewing the rules is
+              how you decide whether to switch a drill ON (issue #4732). */}
+          {onPreviewHowItWorks && (
+            <button
+              type="button"
+              onClick={onPreviewHowItWorks}
+              aria-label={`How ${label} works`}
+              className="mt-1 inline-flex items-center gap-1 text-xs text-gray-500 hover:text-port-accent transition-colors"
+            >
+              <BookOpen size={12} /> How it works
+            </button>
+          )}
         </div>
         <button
           type="button"
@@ -587,6 +600,10 @@ export default function PostDrillConfig({ config, onSaved, onBack }) {
   const [multiplicationProgress, setMultiplicationProgress] = useState(null);
   const [powersProgress, setPowersProgress] = useState(null);
   const [cognitiveProgress, setCognitiveProgress] = useState(null);
+  // Drill type whose how-to card is open in the preview modal (issue #4732), or
+  // null. Held as the type alone — the drill payload is rebuilt from the CURRENT
+  // draft config on render, so editing `n` and reopening shows the new lag.
+  const [howItWorksType, setHowItWorksType] = useState(null);
   // Opt-in daily reminder — off by default; see server/services/meatspacePostReminder.js.
   const [reminderEnabled, setReminderEnabled] = useState(
     () => config?.reminder?.enabled === true
@@ -1102,11 +1119,17 @@ export default function PostDrillConfig({ config, onSaved, onBack }) {
                 managedFieldKeys={supportsProgressive ? (meta.ladderFields || []) : []}
                 speedGated={false}
                 managedLabel="The difficulty knobs"
+                onPreviewHowItWorks={() => setHowItWorksType(type)}
               />
             );
           })}
         </div>
       )}
+
+      <CognitiveDrillTutorialPreview
+        drill={howItWorksType ? { type: howItWorksType, config: cognitiveDrillTypes[howItWorksType] || {} } : null}
+        onClose={() => setHowItWorksType(null)}
+      />
 
       {/* LLM Drills Section */}
       <div className="flex items-center justify-between pt-2">

--- a/client/src/components/meatspace/post/PostDrillConfig.jsx
+++ b/client/src/components/meatspace/post/PostDrillConfig.jsx
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
-import { ArrowLeft, Save, Brain, Bell, Target, Layers, TrendingUp, TrendingDown, Minus, BookOpen } from 'lucide-react';
+import { ArrowLeft, Save, Brain, Bell, Target, Layers, TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import { updatePostConfig, getProviders, getPostAdaptivePreview, getPostMultiplicationProgress, getPostPowersProgress, getPostCognitiveProgress, getMemoryItems } from '../../../services/api';
 import toast from '../../ui/Toast';
 import { FormField } from '../../ui/FormField';
 import { filterSelectableModels, enabledApiProviderFilter } from '../../../utils/providers';
-import { GOAL_DEFS, POST_TOPICS, MODULE_LABELS, DRILL_LABELS, DRILL_DESCRIPTIONS, composedSessionDrillTypes } from './constants';
-import { CognitiveDrillTutorialPreview } from './PostCognitiveDrillRunner';
+import { GOAL_DEFS, POST_TOPICS, MODULE_LABELS, DRILL_LABELS, DRILL_DESCRIPTIONS, composedSessionDrillTypes, effectiveCognitiveDrillConfig } from './constants';
+import { CognitiveDrillTutorialPreview, CognitiveDrillHowItWorksButton } from './PostCognitiveDrillRunner';
 
 // Modules a Full/Quick composed session can draw from (issue #2100), DERIVED
 // from the shared topic registry so the list has one owner (issue #3252): a
@@ -486,16 +486,7 @@ function DrillCard({ type, meta, drillConfig, enabled, accent, onToggle, onUpdat
           <p className="text-gray-500 text-xs">{DRILL_DESCRIPTIONS[type]}</p>
           {/* Outside the `enabled &&` blocks on purpose: previewing the rules is
               how you decide whether to switch a drill ON (issue #4732). */}
-          {onPreviewHowItWorks && (
-            <button
-              type="button"
-              onClick={onPreviewHowItWorks}
-              aria-label={`How ${label} works`}
-              className="mt-1 inline-flex items-center gap-1 text-xs text-gray-500 hover:text-port-accent transition-colors"
-            >
-              <BookOpen size={12} /> How it works
-            </button>
-          )}
+          {onPreviewHowItWorks && <CognitiveDrillHowItWorksButton type={type} onClick={onPreviewHowItWorks} />}
         </div>
         <button
           type="button"
@@ -701,7 +692,7 @@ export default function PostDrillConfig({ config, onSaved, onBack }) {
   useEffect(() => {
     if (!anyCognitiveProgressive) { setCognitiveProgress(null); return; }
     let cancelled = false;
-    getPostCognitiveProgress()
+    getPostCognitiveProgress({ silent: true })
       .then(p => { if (!cancelled) setCognitiveProgress(p); })
       .catch(err => console.warn('⚠️ Failed to load cognitive progress: ' + err.message));
     return () => { cancelled = true; };
@@ -1126,8 +1117,17 @@ export default function PostDrillConfig({ config, onSaved, onBack }) {
         </div>
       )}
 
+      {/* The card must teach the rules of the drill that will ACTUALLY run: while
+          a laddered drill is progressive (the default), the server overrides the
+          manual knobs with the rung's config, so a stored `n: 2` would otherwise
+          describe a 3-back run — and digit-span would say "in order" for a rung
+          that is backward recall. Built at render, not at click, so editing a
+          knob and reopening shows the new value. */}
       <CognitiveDrillTutorialPreview
-        drill={howItWorksType ? { type: howItWorksType, config: cognitiveDrillTypes[howItWorksType] || {} } : null}
+        drill={howItWorksType ? {
+          type: howItWorksType,
+          config: effectiveCognitiveDrillConfig(cognitiveDrillTypes[howItWorksType], cognitiveProgress?.[howItWorksType]),
+        } : null}
         onClose={() => setHowItWorksType(null)}
       />
 

--- a/client/src/components/meatspace/post/PostDrillConfig.jsx
+++ b/client/src/components/meatspace/post/PostDrillConfig.jsx
@@ -4,7 +4,7 @@ import { updatePostConfig, getProviders, getPostAdaptivePreview, getPostMultipli
 import toast from '../../ui/Toast';
 import { FormField } from '../../ui/FormField';
 import { filterSelectableModels, enabledApiProviderFilter } from '../../../utils/providers';
-import { GOAL_DEFS, POST_TOPICS, MODULE_LABELS, DRILL_LABELS, DRILL_DESCRIPTIONS, composedSessionDrillTypes, effectiveCognitiveDrillConfig } from './constants';
+import { GOAL_DEFS, POST_TOPICS, MODULE_LABELS, DRILL_LABELS, DRILL_DESCRIPTIONS, composedSessionDrillTypes } from './constants';
 import { CognitiveDrillTutorialPreview, CognitiveDrillHowItWorksButton } from './PostCognitiveDrillRunner';
 
 // Modules a Full/Quick composed session can draw from (issue #2100), DERIVED
@@ -693,8 +693,13 @@ export default function PostDrillConfig({ config, onSaved, onBack }) {
     if (!anyCognitiveProgressive) { setCognitiveProgress(null); return; }
     let cancelled = false;
     getPostCognitiveProgress({ silent: true })
-      .then(p => { if (!cancelled) setCognitiveProgress(p); })
-      .catch(err => console.warn('⚠️ Failed to load cognitive progress: ' + err.message));
+      .then(p => { if (!cancelled) setCognitiveProgress(p || {}); })
+      // `{}` on failure, not null: null means "not fetched yet", which would
+      // leave the how-to preview waiting on a rung that is never coming.
+      .catch(err => {
+        console.warn('⚠️ Failed to load cognitive progress: ' + err.message);
+        if (!cancelled) setCognitiveProgress({});
+      });
     return () => { cancelled = true; };
   }, [anyCognitiveProgressive]);
 
@@ -1124,10 +1129,9 @@ export default function PostDrillConfig({ config, onSaved, onBack }) {
           that is backward recall. Built at render, not at click, so editing a
           knob and reopening shows the new value. */}
       <CognitiveDrillTutorialPreview
-        drill={howItWorksType ? {
-          type: howItWorksType,
-          config: effectiveCognitiveDrillConfig(cognitiveDrillTypes[howItWorksType], cognitiveProgress?.[howItWorksType]),
-        } : null}
+        type={howItWorksType}
+        drillConfig={howItWorksType ? cognitiveDrillTypes[howItWorksType] : null}
+        cognitiveProgress={cognitiveProgress}
         onClose={() => setHowItWorksType(null)}
       />
 

--- a/client/src/components/meatspace/post/PostDrillConfig.test.jsx
+++ b/client/src/components/meatspace/post/PostDrillConfig.test.jsx
@@ -391,9 +391,26 @@ describe('PostDrillConfig', () => {
       }
     });
 
-    it('opens the how-to card with the drill\'s CURRENT draft config, and closes again', async () => {
+    // The DEFAULT configuration: progressive is on, so the server runs the
+    // ladder rung's config and IGNORES the stored knobs. The card has to teach
+    // the rung, or it explains a different drill than the one about to run.
+    it('teaches the progressive ladder rung, not the stored knobs', async () => {
+      getPostCognitiveProgress.mockResolvedValue({
+        'n-back': { type: 'n-back', level: 2, label: '3-back @ 2500ms', levels: [], config: { n: 3, stimulusMs: 2500 } },
+      });
+      // Stored `n` is 1; the rung says 3. The card must say 3.
+      const laggedConfig = { ...config, cognitive: { enabled: true, drillTypes: { 'n-back': { enabled: true, n: 1 } } } };
+      await renderConfig(<PostDrillConfig config={laggedConfig} onSaved={vi.fn()} onBack={vi.fn()} />);
+      await waitFor(() => expect(getPostCognitiveProgress).toHaveBeenCalled());
+
+      fireEvent.click(screen.getByRole('button', { name: 'How N-Back works' }));
+      expect(screen.getByText(/catch when one repeats from 3 steps earlier/i)).toBeTruthy();
+      expect(screen.queryByText(/repeats from 1 step earlier/i)).toBeNull();
+    });
+
+    it('opens the how-to card with the drill\'s CURRENT draft config once progressive is off, and closes again', async () => {
       await renderConfig(<PostDrillConfig config={config} onSaved={vi.fn()} onBack={vi.fn()} />);
-      // Take n-back off progressive so the manual lag knob is editable, then change it.
+      // Progressive off → the ladder no longer applies and the manual lag knob wins.
       fireEvent.click(screen.getByRole('switch', { name: 'Progressive difficulty — N-Back' }));
       fireEvent.change(screen.getByLabelText('N (steps back)'), { target: { value: '4' } });
 

--- a/client/src/components/meatspace/post/PostDrillConfig.test.jsx
+++ b/client/src/components/meatspace/post/PostDrillConfig.test.jsx
@@ -14,7 +14,7 @@ vi.mock('../../ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn() }
 
 import PostDrillConfig from './PostDrillConfig';
 import { updatePostConfig, getProviders, getPostAdaptivePreview, getPostMultiplicationProgress, getPostPowersProgress, getPostCognitiveProgress, getMemoryItems } from '../../../services/api';
-import { LLM_DRILL_TYPES, DRILL_LABELS } from './constants';
+import { LLM_DRILL_TYPES, DRILL_LABELS, COGNITIVE_DRILL_TYPES } from './constants';
 
 // The generatable LLM drill types + labels, imported from the canonical
 // client constant (mirrors server LLM_DRILL_TYPES in meatspacePostLlm.js) —
@@ -374,6 +374,37 @@ describe('PostDrillConfig', () => {
     const cognitive = updatePostConfig.mock.calls[0][0].cognitive.drillTypes;
     expect(cognitive.stroop).toMatchObject({ progressive: false, incongruentPct: 75 });
     expect(cognitive['mental-rotation']).toMatchObject({ progressive: false, rotationComplexity: 3, optionCount: 4 });
+  });
+
+  // Issue #4732 — the first-run how-to card is one-shot per drill type, so the
+  // config grid is the durable way back to it (and the only surface that offers
+  // one for a drill that is currently switched OFF).
+  describe('cognitive "How it works" preview', () => {
+    it('offers the preview for every cognitive drill type, enabled or not', async () => {
+      const noCognitive = { ...config, cognitive: { enabled: true, drillTypes: { 'n-back': { enabled: false } } } };
+      await renderConfig(<PostDrillConfig config={noCognitive} onSaved={vi.fn()} onBack={vi.fn()} />);
+      expect(screen.getByRole('switch', { name: 'N-Back' }).getAttribute('aria-checked')).toBe('false');
+      // Type list from the canonical constant, not a hardcoded copy — a new
+      // cognitive drill must not be able to ship without a way to read its rules.
+      for (const type of COGNITIVE_DRILL_TYPES) {
+        expect(screen.getByRole('button', { name: `How ${DRILL_LABELS[type]} works` })).toBeTruthy();
+      }
+    });
+
+    it('opens the how-to card with the drill\'s CURRENT draft config, and closes again', async () => {
+      await renderConfig(<PostDrillConfig config={config} onSaved={vi.fn()} onBack={vi.fn()} />);
+      // Take n-back off progressive so the manual lag knob is editable, then change it.
+      fireEvent.click(screen.getByRole('switch', { name: 'Progressive difficulty — N-Back' }));
+      fireEvent.change(screen.getByLabelText('N (steps back)'), { target: { value: '4' } });
+
+      fireEvent.click(screen.getByRole('button', { name: 'How N-Back works' }));
+      expect(screen.getByText(/catch when one repeats from 4 steps earlier/i)).toBeTruthy();
+      // Preview only: the card is open but no drill runner exists behind it.
+      expect(screen.queryByRole('button', { name: /start drill/i })).toBeNull();
+
+      fireEvent.click(screen.getByRole('button', { name: /got it/i }));
+      expect(screen.queryByText(/catch when one repeats from 4 steps earlier/i)).toBeNull();
+    });
   });
 
   it('toggling Adaptive on persists enabled=true', async () => {

--- a/client/src/components/meatspace/post/PostDrillConfig.test.jsx
+++ b/client/src/components/meatspace/post/PostDrillConfig.test.jsx
@@ -14,7 +14,7 @@ vi.mock('../../ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn() }
 
 import PostDrillConfig from './PostDrillConfig';
 import { updatePostConfig, getProviders, getPostAdaptivePreview, getPostMultiplicationProgress, getPostPowersProgress, getPostCognitiveProgress, getMemoryItems } from '../../../services/api';
-import { LLM_DRILL_TYPES, DRILL_LABELS, COGNITIVE_DRILL_TYPES } from './constants';
+import { LLM_DRILL_TYPES, DRILL_LABELS, COGNITIVE_DRILL_TYPES, COGNITIVE_LADDER_TYPES } from './constants';
 
 // The generatable LLM drill types + labels, imported from the canonical
 // client constant (mirrors server LLM_DRILL_TYPES in meatspacePostLlm.js) —
@@ -389,6 +389,26 @@ describe('PostDrillConfig', () => {
       for (const type of COGNITIVE_DRILL_TYPES) {
         expect(screen.getByRole('button', { name: `How ${DRILL_LABELS[type]} works` })).toBeTruthy();
       }
+    });
+
+    // Drift guard for the COGNITIVE_LADDER_TYPES mirror in constants.js: the
+    // launcher's fetch gate and `cognitiveRungPending` both key on it, so if it
+    // and this file's per-drill `progressive` flags ever disagree, the how-to
+    // card silently goes back to describing the stored knobs.
+    it('COGNITIVE_LADDER_TYPES matches exactly the drills that expose a Progressive toggle', async () => {
+      // Every cognitive drill switched ON — the three executive-control drills
+      // ship disabled, and the Progressive toggle only renders on an enabled card.
+      const allOn = {
+        ...config,
+        cognitive: {
+          enabled: true,
+          drillTypes: Object.fromEntries(COGNITIVE_DRILL_TYPES.map(t => [t, { enabled: true }])),
+        },
+      };
+      await renderConfig(<PostDrillConfig config={allOn} onSaved={vi.fn()} onBack={vi.fn()} />);
+      const laddered = COGNITIVE_DRILL_TYPES.filter(type =>
+        screen.queryByRole('switch', { name: `Progressive difficulty — ${DRILL_LABELS[type]}` }) != null);
+      expect(laddered.sort()).toEqual([...COGNITIVE_LADDER_TYPES].sort());
     });
 
     // The DEFAULT configuration: progressive is on, so the server runs the

--- a/client/src/components/meatspace/post/PostSessionLauncher.jsx
+++ b/client/src/components/meatspace/post/PostSessionLauncher.jsx
@@ -1,16 +1,16 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router';
-import { Zap, Play, Brain, Dumbbell, Timer, Target, TrendingUp, TrendingDown, Minus, Compass, ArrowRight, ChevronRight, Layers, BookOpen } from 'lucide-react';
-import { getPostReviewReps, getPostRecommendations, getMorseProgress, getPostProgress, getPostBenchmarkProtocol, getMemoryItems, updatePostConfig } from '../../../services/api';
+import { Zap, Play, Brain, Dumbbell, Timer, Target, TrendingUp, TrendingDown, Minus, Compass, ArrowRight, ChevronRight, Layers } from 'lucide-react';
+import { getPostReviewReps, getPostRecommendations, getMorseProgress, getPostProgress, getPostBenchmarkProtocol, getMemoryItems, updatePostConfig, getPostCognitiveProgress } from '../../../services/api';
 import { FormField } from '../../ui/FormField';
 import Pill from '../../ui/Pill';
 import { enabledApiProviderFilter } from '../../../utils/providers';
 import useProviderModels from '../../../hooks/useProviderModels.js';
-import { DOMAINS, DRILL_TO_DOMAIN, DRILL_LABELS, computeDomainAverages, computeGoalProgress, isTopicEnabled, selectMemoryItemForDrill, resolveTopicForDrillType } from './constants';
+import { DOMAINS, DRILL_TO_DOMAIN, DRILL_LABELS, effectiveCognitiveDrillConfig, computeDomainAverages, computeGoalProgress, isTopicEnabled, selectMemoryItemForDrill, resolveTopicForDrillType } from './constants';
 import { otherPostSections, TOPIC_SURFACE_SECTIONS } from './practiceCatalog';
 import { postIcon } from './postIcons';
 import BrowseCatalogLink from './BrowseCatalogLink';
-import { CognitiveDrillTutorialPreview } from './PostCognitiveDrillRunner';
+import { CognitiveDrillTutorialPreview, CognitiveDrillHowItWorksButton } from './PostCognitiveDrillRunner';
 import { streakGlyph } from '../../../lib/streakGlyph.js';
 import useUserTimezone from '../../../hooks/useUserTimezone.js';
 import { todayKeyInTimezone } from '../../../utils/timezone.js';
@@ -155,9 +155,12 @@ export default function PostSessionLauncher({
   const [quickDurationSaveState, setQuickDurationSaveState] = useState('idle');
   const [benchmarkState, setBenchmarkState] = useState('idle');
   const [benchmarkError, setBenchmarkError] = useState(null);
-  // `{ type, config }` of the cognitive drill whose how-to card is open, or null
-  // (issue #4732). Nothing mounts a runner, so no drill timer is affected.
-  const [howItWorksDrill, setHowItWorksDrill] = useState(null);
+  // Drill TYPE whose how-to card is open, or null (issue #4732) — same shape as
+  // PostDrillConfig, with the payload derived at render so the card can never
+  // show a config snapshot that has since moved. Nothing mounts a runner, so no
+  // drill timer is affected.
+  const [howItWorksType, setHowItWorksType] = useState(null);
+  const [cognitiveProgress, setCognitiveProgress] = useState(null);
 
   useEffect(() => {
     setQuickDurationMin(normalizeQuickDurationMinutes(config?.quickDurationMin));
@@ -220,6 +223,24 @@ export default function PostSessionLauncher({
       .catch(() => { if (!cancelled) setMorseWpm(null); });
     return () => { cancelled = true; };
   }, [config?.goals?.morseWpmTarget]);
+
+  // Cognitive ladder rungs. Needed only so the "How it works" card describes the
+  // drill that will ACTUALLY run: while a laddered drill is progressive (the
+  // shipped default) the server overrides the stored knobs with the rung's
+  // config, so the card would otherwise teach the wrong lag / recall direction.
+  // Conditional-fetch like the goal-scoped effects above — nothing is requested
+  // on an install with no progressive cognitive drill enabled.
+  const needsCognitiveProgress = config?.cognitive?.enabled !== false
+    && Object.values(config?.cognitive?.drillTypes || {})
+      .some(cfg => cfg?.enabled !== false && cfg?.progressive !== false);
+  useEffect(() => {
+    if (!needsCognitiveProgress) { setCognitiveProgress(null); return; }
+    let cancelled = false;
+    getPostCognitiveProgress({ silent: true })
+      .then(p => { if (!cancelled) setCognitiveProgress(p); })
+      .catch(err => console.warn('⚠️ Failed to load cognitive progress: ' + err.message));
+    return () => { cancelled = true; };
+  }, [needsCognitiveProgress]);
 
   // Today's total training minutes (incl. training-log practice) — fetched only
   // when a daily-minutes goal is set, so that goal counts Training/Morse/memory
@@ -1171,15 +1192,7 @@ export default function PostSessionLauncher({
                       {/* Re-entry to the how-to card the first-run gate showed once
                           and never again (issue #4732). Opens a preview with no
                           runner behind it, so no timer starts and nothing is scored. */}
-                      <button
-                        type="button"
-                        onClick={() => setHowItWorksDrill({ type, config: cfg })}
-                        aria-label={`How ${DRILL_LABELS[type] || type} works`}
-                        title="How it works"
-                        className="shrink-0 text-gray-600 hover:text-rose-300 transition-colors"
-                      >
-                        <BookOpen size={13} />
-                      </button>
+                      <CognitiveDrillHowItWorksButton type={type} onClick={() => setHowItWorksType(type)} compact />
                     </span>
                     <span className="text-gray-500 text-right">
                       {cognitiveSummary(type, cfg)}
@@ -1229,7 +1242,13 @@ export default function PostSessionLauncher({
         </div>
       </div>
 
-      <CognitiveDrillTutorialPreview drill={howItWorksDrill} onClose={() => setHowItWorksDrill(null)} />
+      <CognitiveDrillTutorialPreview
+        drill={howItWorksType ? {
+          type: howItWorksType,
+          config: effectiveCognitiveDrillConfig(config.cognitive?.drillTypes?.[howItWorksType], cognitiveProgress?.[howItWorksType]),
+        } : null}
+        onClose={() => setHowItWorksType(null)}
+      />
     </div>
   );
 }

--- a/client/src/components/meatspace/post/PostSessionLauncher.jsx
+++ b/client/src/components/meatspace/post/PostSessionLauncher.jsx
@@ -6,7 +6,7 @@ import { FormField } from '../../ui/FormField';
 import Pill from '../../ui/Pill';
 import { enabledApiProviderFilter } from '../../../utils/providers';
 import useProviderModels from '../../../hooks/useProviderModels.js';
-import { DOMAINS, DRILL_TO_DOMAIN, DRILL_LABELS, effectiveCognitiveDrillConfig, computeDomainAverages, computeGoalProgress, isTopicEnabled, selectMemoryItemForDrill, resolveTopicForDrillType } from './constants';
+import { DOMAINS, DRILL_TO_DOMAIN, DRILL_LABELS, COGNITIVE_LADDER_TYPES, computeDomainAverages, computeGoalProgress, isTopicEnabled, selectMemoryItemForDrill, resolveTopicForDrillType } from './constants';
 import { otherPostSections, TOPIC_SURFACE_SECTIONS } from './practiceCatalog';
 import { postIcon } from './postIcons';
 import BrowseCatalogLink from './BrowseCatalogLink';
@@ -231,14 +231,21 @@ export default function PostSessionLauncher({
   // Conditional-fetch like the goal-scoped effects above — nothing is requested
   // on an install with no progressive cognitive drill enabled.
   const needsCognitiveProgress = config?.cognitive?.enabled !== false
-    && Object.values(config?.cognitive?.drillTypes || {})
-      .some(cfg => cfg?.enabled !== false && cfg?.progressive !== false);
+    && COGNITIVE_LADDER_TYPES.some(type => {
+      const cfg = config?.cognitive?.drillTypes?.[type];
+      return cfg && cfg.enabled !== false && cfg.progressive !== false;
+    });
   useEffect(() => {
     if (!needsCognitiveProgress) { setCognitiveProgress(null); return; }
     let cancelled = false;
     getPostCognitiveProgress({ silent: true })
-      .then(p => { if (!cancelled) setCognitiveProgress(p); })
-      .catch(err => console.warn('⚠️ Failed to load cognitive progress: ' + err.message));
+      .then(p => { if (!cancelled) setCognitiveProgress(p || {}); })
+      // `{}` on failure, not null: null means "not fetched yet" and would leave
+      // the preview waiting forever on a rung that is never coming.
+      .catch(err => {
+        console.warn('⚠️ Failed to load cognitive progress: ' + err.message);
+        if (!cancelled) setCognitiveProgress({});
+      });
     return () => { cancelled = true; };
   }, [needsCognitiveProgress]);
 
@@ -1243,10 +1250,9 @@ export default function PostSessionLauncher({
       </div>
 
       <CognitiveDrillTutorialPreview
-        drill={howItWorksType ? {
-          type: howItWorksType,
-          config: effectiveCognitiveDrillConfig(config.cognitive?.drillTypes?.[howItWorksType], cognitiveProgress?.[howItWorksType]),
-        } : null}
+        type={howItWorksType}
+        drillConfig={howItWorksType ? config.cognitive?.drillTypes?.[howItWorksType] : null}
+        cognitiveProgress={cognitiveProgress}
         onClose={() => setHowItWorksType(null)}
       />
     </div>

--- a/client/src/components/meatspace/post/PostSessionLauncher.jsx
+++ b/client/src/components/meatspace/post/PostSessionLauncher.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link } from 'react-router';
-import { Zap, Play, Brain, Dumbbell, Timer, Target, TrendingUp, TrendingDown, Minus, Compass, ArrowRight, ChevronRight, Layers } from 'lucide-react';
+import { Zap, Play, Brain, Dumbbell, Timer, Target, TrendingUp, TrendingDown, Minus, Compass, ArrowRight, ChevronRight, Layers, BookOpen } from 'lucide-react';
 import { getPostReviewReps, getPostRecommendations, getMorseProgress, getPostProgress, getPostBenchmarkProtocol, getMemoryItems, updatePostConfig } from '../../../services/api';
 import { FormField } from '../../ui/FormField';
 import Pill from '../../ui/Pill';
@@ -10,6 +10,7 @@ import { DOMAINS, DRILL_TO_DOMAIN, DRILL_LABELS, computeDomainAverages, computeG
 import { otherPostSections, TOPIC_SURFACE_SECTIONS } from './practiceCatalog';
 import { postIcon } from './postIcons';
 import BrowseCatalogLink from './BrowseCatalogLink';
+import { CognitiveDrillTutorialPreview } from './PostCognitiveDrillRunner';
 import { streakGlyph } from '../../../lib/streakGlyph.js';
 import useUserTimezone from '../../../hooks/useUserTimezone.js';
 import { todayKeyInTimezone } from '../../../utils/timezone.js';
@@ -154,6 +155,9 @@ export default function PostSessionLauncher({
   const [quickDurationSaveState, setQuickDurationSaveState] = useState('idle');
   const [benchmarkState, setBenchmarkState] = useState('idle');
   const [benchmarkError, setBenchmarkError] = useState(null);
+  // `{ type, config }` of the cognitive drill whose how-to card is open, or null
+  // (issue #4732). Nothing mounts a runner, so no drill timer is affected.
+  const [howItWorksDrill, setHowItWorksDrill] = useState(null);
 
   useEffect(() => {
     setQuickDurationMin(normalizeQuickDurationMinutes(config?.quickDurationMin));
@@ -1161,9 +1165,23 @@ export default function PostSessionLauncher({
               </div>
               <div className="space-y-2">
                 {enabledCognitiveDrills.map(([type, cfg]) => (
-                  <div key={type} className="flex items-center justify-between text-sm">
-                    <span className="text-white">{DRILL_LABELS[type] || type}</span>
-                    <span className="text-gray-500">
+                  <div key={type} className="flex items-center justify-between gap-2 text-sm">
+                    <span className="flex items-center gap-1.5 min-w-0">
+                      <span className="text-white truncate">{DRILL_LABELS[type] || type}</span>
+                      {/* Re-entry to the how-to card the first-run gate showed once
+                          and never again (issue #4732). Opens a preview with no
+                          runner behind it, so no timer starts and nothing is scored. */}
+                      <button
+                        type="button"
+                        onClick={() => setHowItWorksDrill({ type, config: cfg })}
+                        aria-label={`How ${DRILL_LABELS[type] || type} works`}
+                        title="How it works"
+                        className="shrink-0 text-gray-600 hover:text-rose-300 transition-colors"
+                      >
+                        <BookOpen size={13} />
+                      </button>
+                    </span>
+                    <span className="text-gray-500 text-right">
                       {cognitiveSummary(type, cfg)}
                     </span>
                   </div>
@@ -1210,6 +1228,8 @@ export default function PostSessionLauncher({
           )}
         </div>
       </div>
+
+      <CognitiveDrillTutorialPreview drill={howItWorksDrill} onClose={() => setHowItWorksDrill(null)} />
     </div>
   );
 }

--- a/client/src/components/meatspace/post/PostSessionLauncher.test.jsx
+++ b/client/src/components/meatspace/post/PostSessionLauncher.test.jsx
@@ -20,6 +20,7 @@ vi.mock('../../../services/api', () => ({
   getMorseProgress: vi.fn().mockResolvedValue({ settings: { wpm: 18, farnsworthWpm: 12 } }),
   getPostProgress: vi.fn().mockResolvedValue({ series: { byDay: [] } }),
   getMemoryItems: vi.fn().mockResolvedValue([{ id: 'example-memory' }]),
+  getPostCognitiveProgress: vi.fn().mockResolvedValue({}),
   getPostBenchmarkProtocol: vi.fn().mockResolvedValue({
     protocolId: 'post-foundation-battery',
     protocolVersion: 1,
@@ -37,7 +38,7 @@ vi.mock('../../../services/api', () => ({
 
 import PostSessionLauncher, { buildCleanConditions, cognitiveSummary, interleaveByDomain } from './PostSessionLauncher';
 import { otherPostSections, TOPIC_SURFACE_SECTIONS } from './practiceCatalog';
-import { getPostRecommendations, getMorseProgress, getPostProgress, getPostReviewReps, getPostBenchmarkProtocol, getMemoryItems, updatePostConfig } from '../../../services/api';
+import { getPostRecommendations, getMorseProgress, getPostProgress, getPostReviewReps, getPostBenchmarkProtocol, getMemoryItems, updatePostConfig, getPostCognitiveProgress } from '../../../services/api';
 
 // Pure-function tests for PostSessionLauncher's pre-submit helpers (issue
 // #2102 gap #10; structured conditions issue #4442). Both were lifted from
@@ -172,6 +173,7 @@ describe('PostSessionLauncher render (issue #2100)', () => {
     getPostReviewReps.mockResolvedValue({ reps: [] });
     getMorseProgress.mockResolvedValue({ settings: { wpm: 18, farnsworthWpm: 12 } });
     getPostProgress.mockResolvedValue({ series: { byDay: [] } });
+    getPostCognitiveProgress.mockResolvedValue({});
     getPostBenchmarkProtocol.mockResolvedValue({
       protocolId: 'post-foundation-battery',
       protocolVersion: 1,
@@ -431,7 +433,8 @@ describe('PostSessionLauncher render (issue #2100)', () => {
       onStart,
       config: {
         ...baseConfig,
-        cognitive: { enabled: true, drillTypes: { 'n-back': { enabled: true, n: 3 } } },
+        // progressive:false → the stored knobs are what the drill runs with.
+        cognitive: { enabled: true, drillTypes: { 'n-back': { enabled: true, n: 3, progressive: false } } },
       },
     });
     await waitFor(() => expect(getPostRecommendations).toHaveBeenCalled());
@@ -442,9 +445,35 @@ describe('PostSessionLauncher render (issue #2100)', () => {
     expect(screen.getByRole('list', { name: /example letter stream/i })).toBeTruthy();
     // Reading the rules must never start (or count toward) a scored session.
     expect(onStart).not.toHaveBeenCalled();
+    // Nothing to resolve → no ladder fetch on an all-manual cognitive config.
+    expect(getPostCognitiveProgress).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('button', { name: /got it/i }));
     expect(screen.queryByText(/catch when one repeats from 3 steps earlier/i)).toBeNull();
+  });
+
+  // The DEFAULT: progressive on, so the server swaps in the ladder rung's config
+  // at generation time and the stored knobs never reach the drill. Digit-span is
+  // the sharpest case — the ladder flips recall to BACKWARD at rung 3, and a card
+  // built from the stored config would teach forward recall for a backward run.
+  it('teaches the ladder rung for a progressive drill, not the stored knobs', async () => {
+    getPostCognitiveProgress.mockResolvedValue({
+      'digit-span': {
+        type: 'digit-span', level: 3, label: 'backward 4–6', levels: [],
+        config: { direction: 'backward', startLength: 4, maxLength: 6 },
+      },
+    });
+    renderLauncher({
+      config: {
+        ...baseConfig,
+        cognitive: { enabled: true, drillTypes: { 'digit-span': { enabled: true, direction: 'forward' } } },
+      },
+    });
+    await waitFor(() => expect(getPostCognitiveProgress).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'How Digit Span works' }));
+    expect(screen.getByText(/then type them in reverse/i)).toBeTruthy();
+    expect(screen.queryByText(/then type them back in order/i)).toBeNull();
   });
 });
 
@@ -483,6 +512,7 @@ describe('PostSessionLauncher — Start card (issue #3249)', () => {
     getPostReviewReps.mockResolvedValue({ reps: [] });
     getMorseProgress.mockResolvedValue({ settings: { wpm: 18, farnsworthWpm: 12 } });
     getPostProgress.mockResolvedValue({ series: { byDay: [] } });
+    getPostCognitiveProgress.mockResolvedValue({});
   });
 
   it('puts the session starts ahead of status, goals, Up next and the analytics block', async () => {
@@ -599,6 +629,7 @@ describe('PostSessionLauncher topic gating (issue #3252)', () => {
     getPostReviewReps.mockResolvedValue({ reps: [] });
     getMorseProgress.mockResolvedValue({ settings: { wpm: 18, farnsworthWpm: 12 } });
     getPostProgress.mockResolvedValue({ series: { byDay: [] } });
+    getPostCognitiveProgress.mockResolvedValue({});
   });
 
   it('composes every llm-drills topic when no topics key is set (legacy config)', async () => {
@@ -676,6 +707,7 @@ describe('PostSessionLauncher review-rep topic gating (issue #3252)', () => {
     ] });
     getMorseProgress.mockResolvedValue({ settings: { wpm: 18, farnsworthWpm: 12 } });
     getPostProgress.mockResolvedValue({ series: { byDay: [] } });
+    getPostCognitiveProgress.mockResolvedValue({});
   });
 
   it('mixes a review rep into a Quick session while its topic is on', async () => {
@@ -710,6 +742,7 @@ describe('PostSessionLauncher honors the mentalMath module flag (issue #3252)', 
     getPostReviewReps.mockResolvedValue({ reps: [] });
     getMorseProgress.mockResolvedValue({ settings: { wpm: 18, farnsworthWpm: 12 } });
     getPostProgress.mockResolvedValue({ series: { byDay: [] } });
+    getPostCognitiveProgress.mockResolvedValue({});
   });
 
   it('composes no math drills when mentalMath.enabled is false', async () => {

--- a/client/src/components/meatspace/post/PostSessionLauncher.test.jsx
+++ b/client/src/components/meatspace/post/PostSessionLauncher.test.jsx
@@ -422,6 +422,30 @@ describe('PostSessionLauncher render (issue #2100)', () => {
     });
     expect(await screen.findByText('system default')).toBeInTheDocument();
   });
+
+  // Issue #4732 — the drill's first-run how-to card is one-shot per type, so the
+  // sidebar row is the way back to it from the screen you launch a session from.
+  it('re-opens a cognitive drill\'s how-to card from the sidebar without starting a run', async () => {
+    const onStart = vi.fn();
+    renderLauncher({
+      onStart,
+      config: {
+        ...baseConfig,
+        cognitive: { enabled: true, drillTypes: { 'n-back': { enabled: true, n: 3 } } },
+      },
+    });
+    await waitFor(() => expect(getPostRecommendations).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByRole('button', { name: 'How N-Back works' }));
+    // The card reads against the CONFIGURED lag, not a hardcoded default.
+    expect(screen.getByText(/catch when one repeats from 3 steps earlier/i)).toBeTruthy();
+    expect(screen.getByRole('list', { name: /example letter stream/i })).toBeTruthy();
+    // Reading the rules must never start (or count toward) a scored session.
+    expect(onStart).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: /got it/i }));
+    expect(screen.queryByText(/catch when one repeats from 3 steps earlier/i)).toBeNull();
+  });
 });
 
 // The launcher is the entry point to a DAILY habit, so the actions that start a

--- a/client/src/components/meatspace/post/constants.js
+++ b/client/src/components/meatspace/post/constants.js
@@ -9,6 +9,28 @@ export const MEMORY_DRILL_TYPES = ['memory-fill-blank', 'memory-sequence', 'memo
 // COGNITIVE_DRILL_TYPES in server/services/meatspacePostCognitive.js.
 export const COGNITIVE_DRILL_TYPES = ['n-back', 'digit-span', 'stroop', 'schulte-table', 'mental-rotation', 'reaction-time', 'task-switching', 'go-no-go', 'flanker'];
 
+// Cognitive drills that have a progressive difficulty ladder. Mirror of the
+// COGNITIVE_LADDERS keys in server/lib/postProgression.js — reaction-time is the
+// one cognitive drill with no ladder, so its stored config always runs as-is.
+export const COGNITIVE_LADDER_TYPES = ['n-back', 'digit-span', 'schulte-table', 'mental-rotation', 'stroop', 'task-switching', 'go-no-go', 'flanker'];
+
+/**
+ * Whether this drill's effective config is still UNKNOWN: a laddered drill left
+ * progressive (the default) whose rung has not been fetched yet. Anything that
+ * DESCRIBES the drill must wait rather than fall back to the stored knobs —
+ * rendering those first would state the wrong rule and then silently swap it
+ * out from under the reader.
+ *
+ * `cognitiveProgress` is the whole `getPostCognitiveProgress()` map, using the
+ * `null` = not fetched / `{}` = fetched-or-failed sentinel, so a failed fetch
+ * degrades to the stored knobs instead of hanging on "resolving" forever.
+ */
+export function cognitiveRungPending(type, drillConfig, cognitiveProgress) {
+  if (!COGNITIVE_LADDER_TYPES.includes(type)) return false;
+  if (drillConfig?.progressive === false) return false;
+  return cognitiveProgress == null;
+}
+
 /**
  * The config a cognitive drill will ACTUALLY run with — not necessarily the one
  * stored in POST config. Mirrors the server's override in `resolveDrillConfig`

--- a/client/src/components/meatspace/post/constants.js
+++ b/client/src/components/meatspace/post/constants.js
@@ -9,6 +9,27 @@ export const MEMORY_DRILL_TYPES = ['memory-fill-blank', 'memory-sequence', 'memo
 // COGNITIVE_DRILL_TYPES in server/services/meatspacePostCognitive.js.
 export const COGNITIVE_DRILL_TYPES = ['n-back', 'digit-span', 'stroop', 'schulte-table', 'mental-rotation', 'reaction-time', 'task-switching', 'go-no-go', 'flanker'];
 
+/**
+ * The config a cognitive drill will ACTUALLY run with — not necessarily the one
+ * stored in POST config. Mirrors the server's override in `resolveDrillConfig`
+ * (server/services/meatspacePost.js): while a laddered drill is progressive
+ * (the shipped default), the rung's config wins over the manual knobs.
+ *
+ * This matters for anything that DESCRIBES a drill to the user rather than just
+ * labelling it: a default n-back at rung 4 runs 3-back while the stored `n` is
+ * still 2, and digit-span flips to backward recall at rung 3 — so a how-to card
+ * built from the stored config would teach the wrong rule.
+ *
+ * `progressInfo` is one type's entry from `getPostCognitiveProgress()`; pass
+ * null/undefined when it hasn't loaded (or the type has no ladder) and the
+ * stored config is returned unchanged.
+ */
+export function effectiveCognitiveDrillConfig(drillConfig, progressInfo) {
+  const stored = drillConfig || {};
+  if (stored.progressive === false) return stored;
+  return progressInfo?.config ? { ...stored, ...progressInfo.config } : stored;
+}
+
 // Drill types valid elsewhere but not yet wired into the interactive POST
 // session drill picker. Multi-blank fill-in-the-blank is now wired end to end,
 // so this remains empty until a future generation-only type needs the guard.

--- a/client/src/components/meatspace/post/constants.test.js
+++ b/client/src/components/meatspace/post/constants.test.js
@@ -3,6 +3,7 @@ import {
   computeDomainAverages, domainLabel, computeGoalProgress, hasGoals,
   POST_TOPICS, DOMAINS, DRILL_TO_DOMAIN, composedSessionDrillTypes,
   isTopicEnabled, isMemoryItemEnabled, resolveTopicForDrillType, appliedNumeracyAnswerCorrect,
+  effectiveCognitiveDrillConfig,
 } from './constants';
 
 describe('domainLabel', () => {
@@ -261,4 +262,38 @@ describe('resolveTopicForDrillType client mirror', () => {
     expect(resolveTopicForDrillType('nope')).toBeNull();
   });
 });
+
+
+// Mirrors the server's progressive override in `resolveDrillConfig`
+// (server/services/meatspacePost.js). Anything that DESCRIBES a cognitive drill
+// to the user has to resolve through this, or it explains the stored knobs while
+// a different rung actually runs.
+describe('effectiveCognitiveDrillConfig', () => {
+  it('lets the ladder rung win over the stored knobs while progressive (the default)', () => {
+    expect(effectiveCognitiveDrillConfig({ n: 1, length: 20 }, { config: { n: 3, stimulusMs: 2000 } }))
+      .toEqual({ n: 3, length: 20, stimulusMs: 2000 });
+  });
+
+  it('keeps the stored knobs when progressive is explicitly off', () => {
+    expect(effectiveCognitiveDrillConfig({ n: 1, progressive: false }, { config: { n: 3 } }))
+      .toEqual({ n: 1, progressive: false });
+  });
+
+  it('flips digit-span recall direction with the rung, not the stored value', () => {
+    expect(effectiveCognitiveDrillConfig(
+      { direction: 'forward' },
+      { config: { direction: 'backward', startLength: 4, maxLength: 6 } },
+    ).direction).toBe('backward');
+  });
+
+  it('falls back to the stored config when the rung has not loaded or the type has no ladder', () => {
+    expect(effectiveCognitiveDrillConfig({ mode: 'choice' }, null)).toEqual({ mode: 'choice' });
+    expect(effectiveCognitiveDrillConfig({ mode: 'choice' }, {})).toEqual({ mode: 'choice' });
+  });
+
+  it('tolerates a missing stored config', () => {
+    expect(effectiveCognitiveDrillConfig(undefined, null)).toEqual({});
+  });
+});
+
 // @vitest-environment node

--- a/client/src/services/apiMeatspace.js
+++ b/client/src/services/apiMeatspace.js
@@ -215,7 +215,9 @@ export const getPostRecommendations = (limit, options = {}) => request(
 );
 export const getPostMultiplicationProgress = () => request('/meatspace/post/multiplication-progress');
 export const getPostPowersProgress = () => request('/meatspace/post/powers-progress');
-export const getPostCognitiveProgress = () => request('/meatspace/post/cognitive-progress');
+// `options` so a caller with its own catch can pass `{ silent: true }` and not
+// double-report — both current callers fetch this in the background.
+export const getPostCognitiveProgress = (options) => request('/meatspace/post/cognitive-progress', options);
 export const generatePostDrill = (type, config = {}, providerId, model, options = {}) => request('/meatspace/post/drill', {
   method: 'POST',
   body: JSON.stringify({ type, config, ...(providerId && { providerId }), ...(model && { model }) }),


### PR DESCRIPTION
## Summary

The first-run how-to card for a POST cognitive drill is one-shot per drill type, forever — so the n-back worked example (the strip that shows an actual letter stream with the one match called out) becomes unreachable after a single run, and there is no way to preview a drill's rules without starting a scored session.

Adds a standalone how-to preview: the same card body, with no runner behind it.

- **POST launcher sidebar** — a book icon on each enabled cognitive drill row. This is the discoverable entry point: it sits on the screen you launch a session from.
- **Drill Config cognitive cards** — a "How it works" link on every card, *including drills that are switched off*, so every cognitive type is covered (the launcher only lists enabled ones) and you can read the rules before deciding to enable one.

The timed path is deliberately untouched. Every runner stamps `startedAtRef` at mount, so re-showing the tutorial mid-run would either drop the run or bill reading time to `totalMs`; the preview mounts no runner at all, and the first-run gate still holds the runner's timers until Start.

### The card has to describe the drill that will actually run

While a laddered cognitive drill is progressive — the shipped default — the server overrides the stored knobs with the ladder rung's config (`resolveDrillConfig`, `server/services/meatspacePost.js`). A default n-back at rung 4 runs 3-back while the stored `n` is still 2, and digit-span flips to **backward** recall at rung 3. A card built from the stored config would teach the wrong rule, which is the one thing it exists to get right.

So `effectiveCognitiveDrillConfig()` mirrors that server override, and the preview waits on a short resolving state rather than rendering the stored knobs and swapping the rule out mid-read. It waits only for the types whose copy actually varies with config (n-back lag, digit-span direction, reaction-time mode) — a property test probes `getDrillTutorial` with two configs so that list can't drift from the code. A failed rung fetch degrades to the stored knobs instead of hanging.

## Test plan

- `cd client && npm test` — full suite green (712 files, 9051 tests).
- New coverage:
  - `PostCognitiveDrillRunner.test.jsx` — the preview renders the card (n-back worked example included) with no runner mounted, does not consume the first-run gate, waits for an unresolved rung, degrades on an empty rung fetch, and opens config-independent cards immediately; plus the `CONFIG_DEPENDENT_TUTORIAL_TYPES` property guard. The existing "first-run tutorial gate" block is unchanged and still passes.
  - `PostDrillConfig.test.jsx` — a preview affordance for every cognitive type incl. disabled ones; teaches the ladder rung under the default config; honors the live draft config once progressive is off; `COGNITIVE_LADDER_TYPES` drift guard against the drills that render a Progressive toggle.
  - `PostSessionLauncher.test.jsx` — opens from the sidebar without starting a run, teaches the rung for a progressive digit-span, and skips the ladder fetch entirely on an all-manual cognitive config.
  - `constants.test.js` — unit tests for `effectiveCognitiveDrillConfig`.

Closes #4732