### PR TITLE
fix: one resolver decides the degraded TRELLIS.2 bake remedy, so the install frame stops promising an impossible Repair

### DIFF
--- a/server/services/imageTo3d/adapters.degraded.test.js
+++ b/server/services/imageTo3d/adapters.degraded.test.js
@@ -117,6 +117,12 @@ describe('trellis2 degraded-state projection', () => {
     expect(state.fields.degraded).toEqual({
       label: 'degraded textures', help: 'install Xcode', repairable: false, detail: 'Missing: o_voxel',
     });
+    // The route replays `warnings` into the SAME `verify` stage the install writes,
+    // and that hook now resolves the remedy through the same helper — so a blocker
+    // host is told to install Xcode on BOTH paths, never to run the Repair the card
+    // has already hidden (#4742). The literal is asserted verbatim in trellis2.test.js
+    // against the install's own frame.
+    expect(state.warnings).toEqual(['install Xcode Missing: o_voxel.']);
   });
 
   it('reports nothing degraded — and no detail — for a healthy Metal bake', async () => {

--- a/server/services/imageTo3d/adapters.js
+++ b/server/services/imageTo3d/adapters.js
@@ -61,6 +61,7 @@ import {
   probeMetalToolchain,
   missingBakeModulesLabel,
   appendMissingBakeModules,
+  resolveDegradedBakeRemedy,
 } from './trellis2.js';
 import {
   isTrellis2CudaInstalled,
@@ -100,14 +101,13 @@ export const TARGET_ADAPTERS = Object.freeze({
       const degradedBake = bake.quality === 'fallback';
       const missingModules = missingBakeModulesLabel(bake);
       const toolchain = degradedBake ? await probeMetalToolchain() : null;
-      // A degraded bake has two very different remedies, and the card must not
-      // offer the wrong one: when the Metal Toolchain is merely missing, Repair
-      // install fetches it and rebuilds (#3041); when only the Command Line Tools
-      // are active there is nothing PortOS can run, and the user has to install
-      // Xcode first.
-      const textureBake = toolchain?.blocker
-        ? { ...bake, repairable: false, blocker: toolchain.blocker, help: toolchain.hint }
-        : { ...bake, ...(degradedBake ? { repairable: true } : {}) };
+      // A degraded bake has two very different remedies, and the card must not offer
+      // the wrong one: when the Metal Toolchain is merely missing, Repair install
+      // fetches it and rebuilds (#3041); when only the Command Line Tools are active
+      // there is nothing PortOS can run, and the user has to install Xcode first. The
+      // install's own `verify` frame resolves it through the SAME helper, so the two
+      // lanes cannot name different fixes for one host state (#4742).
+      const textureBake = { ...bake, ...(resolveDegradedBakeRemedy(bake, toolchain) ?? {}) };
       return {
         fields: {
           textureBake,

--- a/server/services/imageTo3d/trellis2.js
+++ b/server/services/imageTo3d/trellis2.js
@@ -232,6 +232,31 @@ export function appendMissingBakeModules(help, bake) {
 }
 
 /**
+ * Which remedy a degraded texture bake actually has, given the host's toolchain state.
+ *
+ * A `quality: 'fallback'` bake has two very different fixes and only one of them applies
+ * on a given host: when the Xcode Metal Toolchain is merely missing, Repair install
+ * fetches it and rebuilds (#3041); when only the Command Line Tools are active there is
+ * nothing PortOS can run, so the remedy is to install Xcode and no Repair button is
+ * offered at all. Both server lanes that report a degraded bake resolve it HERE — the
+ * card/short-circuit projection in `adapters.js`, and the install's own `verify` frame —
+ * so the two cannot promise different fixes for the same host state (#4742). Same
+ * one-place-only reasoning as `appendMissingBakeModules` above, which fixed the
+ * module-name half of that parity.
+ *
+ * @param {{quality?: string, help?: string}} bake a result from `probeTrellis2TextureBake`
+ * @param {{blocker?: string, hint?: string}|null} [toolchain] a result from `probeMetalToolchain`
+ * @returns {{help?: string, repairable: boolean, blocker?: string}|null} `null` when the
+ *          bake is not degraded, i.e. there is no remedy to name
+ */
+export function resolveDegradedBakeRemedy(bake, toolchain) {
+  if (bake?.quality !== 'fallback') return null;
+  return toolchain?.blocker
+    ? { help: toolchain.hint, repairable: false, blocker: toolchain.blocker }
+    : { help: bake.help, repairable: true };
+}
+
+/**
  * Whether the Xcode Metal Toolchain is present — the prerequisite `setup.sh`
  * documents for building `mtldiffrast`/`mtlbvh`/`mtlgemm`. Checked BEFORE a ~15 GB
  * install so the user can fix it first, instead of discovering an hour later that
@@ -741,7 +766,8 @@ export const isTransientInstallError = textMatcher([
  *
  * @param {{base?: string, onEvent?: (ev: object) => void, spawnImpl?: Function,
  *          maxRetries?: number, sleep?: (ms: number) => Promise<void>,
- *          env?: NodeJS.ProcessEnv, probeBake?: Function, installMetalToolchain?: boolean}} [opts]
+ *          env?: NodeJS.ProcessEnv, probeBake?: Function, probeToolchain?: Function,
+ *          installMetalToolchain?: boolean}} [opts]
  * @returns {{promise: Promise<{ok: true}>, kill: () => void}}
  */
 export function installTrellis2({
@@ -753,6 +779,7 @@ export function installTrellis2({
   exists = existsSync,
   env,
   probeBake = probeTrellis2TextureBake,
+  probeToolchain = probeMetalToolchain,
   installMetalToolchain = false,
 } = {}) {
   // `exists` lets the clone step self-skip when the repo is already on disk (resume
@@ -775,6 +802,14 @@ export function installTrellis2({
     verify: async (emit) => {
       const bake = await probeBake({ base });
       if (bake.quality === 'fallback') {
+        // WHICH remedy applies depends on the host, and the card already resolves that
+        // the same way: a toolchain `blocker` host gets no Repair button, so promising
+        // "Repair install fetches the missing build dependencies" here would name a fix
+        // the UI has deliberately withheld (#4742). One shared resolver, probed only on
+        // the degraded path so a healthy install still spawns nothing extra. Probing now
+        // rather than reusing the caller's preflight result matters: the Metal Toolchain
+        // step may have installed it in between.
+        const remedy = resolveDegradedBakeRemedy(bake, await probeToolchain());
         // Name the culprits. The help text says which remedy to run, but not what is
         // actually missing — and `apple-deps` (the install's only gitlab.com fetch, and
         // an `optional` step) fails with one line that scrolls past inside a ~15 GB log.
@@ -783,7 +818,7 @@ export function installTrellis2({
         emit({
           type: 'log',
           stage: 'verify',
-          message: `⚠️ ${appendMissingBakeModules(bake.help, bake)}`,
+          message: `⚠️ ${appendMissingBakeModules(remedy.help, bake)}`,
         });
       } else if (bake.quality === 'metal') {
         emit({ type: 'log', stage: 'verify', message: '✅ Metal texture baking is available.' });

--- a/server/services/imageTo3d/trellis2.test.js
+++ b/server/services/imageTo3d/trellis2.test.js
@@ -29,6 +29,7 @@ import {
   TRELLIS2_BAKE_QUALITY_MODULES,
   TRELLIS2_FALLBACK_BAKE_HELP,
   missingBakeModulesLabel,
+  resolveDegradedBakeRemedy,
   TRELLIS2_METAL_TOOLCHAIN_HINT,
   TRELLIS2_REQUIRES_XCODE_HINT,
   TRELLIS2_DEFAULT_TEXTURE_SIZE,
@@ -393,6 +394,36 @@ describe('probeTrellis2TextureBake', () => {
     }),
   ).resolves.toMatchObject({ quality: 'metal', degradedQuality: ['flex_gemm'] }));
 
+  // #4742: one resolver decides WHICH remedy a degraded bake has, so the card and the
+  // install's verify frame cannot promise different fixes for the same host.
+  describe('resolveDegradedBakeRemedy', () => {
+    const fallbackBake = { quality: 'fallback', help: TRELLIS2_FALLBACK_BAKE_HELP, missing: ['o_voxel'] };
+
+    it('names Xcode and withholds Repair on a Command-Line-Tools-only host', () => expect(
+      resolveDegradedBakeRemedy(fallbackBake, {
+        available: false, installable: false, blocker: 'requires-xcode', hint: TRELLIS2_REQUIRES_XCODE_HINT,
+      }),
+    ).toEqual({ help: TRELLIS2_REQUIRES_XCODE_HINT, repairable: false, blocker: 'requires-xcode' }));
+
+    it('keeps the Repair remedy when the toolchain is merely missing-but-fetchable', () => expect(
+      resolveDegradedBakeRemedy(fallbackBake, { available: false, installable: true, hint: TRELLIS2_METAL_TOOLCHAIN_HINT }),
+    ).toEqual({ help: TRELLIS2_FALLBACK_BAKE_HELP, repairable: true }));
+
+    it('keeps the Repair remedy when the toolchain state is unknown or absent', () => {
+      expect(resolveDegradedBakeRemedy(fallbackBake, null))
+        .toEqual({ help: TRELLIS2_FALLBACK_BAKE_HELP, repairable: true });
+      expect(resolveDegradedBakeRemedy(fallbackBake, undefined))
+        .toEqual({ help: TRELLIS2_FALLBACK_BAKE_HELP, repairable: true });
+    });
+
+    // `null` (not an empty remedy) so callers can spread it away entirely — a healthy
+    // bake must not gain a `repairable` key it never had.
+    it('has no remedy to name for a healthy or undetermined bake', () => {
+      expect(resolveDegradedBakeRemedy({ quality: 'metal' }, { blocker: 'requires-xcode' })).toBeNull();
+      expect(resolveDegradedBakeRemedy({ quality: 'unknown' }, null)).toBeNull();
+      expect(resolveDegradedBakeRemedy(undefined, null)).toBeNull();
+    });
+  });
   // #4636: one formatter feeds both the install's verify frame and the card's
   // `degraded.detail`, so the two lanes cannot drift on the wording.
   describe('missingBakeModulesLabel', () => {
@@ -1080,12 +1111,19 @@ describe('installTrellis2', () => {
   // `setup.sh` swallows a failed Metal-backend build and still exits 0, so the
   // install must verify what landed and report it BEFORE the terminal `complete`
   // frame — which closes the client's EventSource (#2952).
-  const runToCompletion = async (probeBake) => {
+  // `probeToolchain` is injected on EVERY call: the degraded branch resolves which
+  // remedy applies from the host toolchain (#4742), and the suite must never spawn
+  // `xcrun`/`xcode-select` against the developer machine to find out.
+  const runToCompletion = async (probeBake, probeToolchain = async () => ({ available: true })) => {
     const children = CHILD_POOL();
     let i = 0;
     const events = [];
     const { promise } = installTrellis2({
-      base: BASE, spawnImpl: () => children[i++], onEvent: (e) => events.push(e), probeBake,
+      base: BASE,
+      spawnImpl: () => children[i++],
+      onEvent: (e) => events.push(e),
+      probeBake,
+      probeToolchain,
     });
     children[0].emit('close', 0); // clone
     await flush();
@@ -1136,6 +1174,7 @@ describe('installTrellis2', () => {
       onEvent: (e) => events.push(e),
       installMetalToolchain: true,
       probeBake: async () => ({ quality: 'fallback', missing: ['mtldiffrast'], help: 'degraded' }),
+      probeToolchain: async () => ({ available: true }),
     });
     children[0].emit('close', 1); // toolchain download failed
     await flush();
@@ -1164,6 +1203,7 @@ describe('installTrellis2', () => {
       maxRetries: 1,
       sleep: async () => {},
       probeBake: async () => ({ quality: 'fallback', missing: ['mtldiffrast'], help: 'degraded' }),
+      probeToolchain: async () => ({ available: true }),
     });
     children[0].stderr.emit('data', 'fatal: early EOF');
     children[0].emit('close', 128);
@@ -1230,6 +1270,40 @@ describe('installTrellis2', () => {
   });
 
 
+  // #4742: the card hides Repair on a `blocker` host, so the frame that finishes the
+  // install must not tell the user to run it. Same state, same remedy, both lanes.
+  it('names the Xcode remedy — not Repair — in the degraded frame on a blocker host', async () => {
+    const events = await runToCompletion(
+      async () => ({ quality: 'fallback', missing: ['o_voxel'], help: TRELLIS2_FALLBACK_BAKE_HELP }),
+      async () => ({ available: false, installable: false, blocker: 'requires-xcode', hint: TRELLIS2_REQUIRES_XCODE_HINT }),
+    );
+    const message = events.find((e) => e.stage === 'verify').message;
+    // Whole sentence, not a substring: the module names are the useful half on this
+    // path too (#4636), and the adapter lane asserts the same shape verbatim so the
+    // two frames cannot drift.
+    expect(message).toBe(`⚠️ ${TRELLIS2_REQUIRES_XCODE_HINT} Missing: o_voxel.`);
+    expect(message).not.toContain(TRELLIS2_FALLBACK_BAKE_HELP);
+  });
+
+  it('keeps the Repair remedy on a degraded host whose toolchain is merely fetchable', async () => {
+    const events = await runToCompletion(
+      async () => ({ quality: 'fallback', missing: ['o_voxel'], help: TRELLIS2_FALLBACK_BAKE_HELP }),
+      async () => ({ available: false, installable: true, hint: TRELLIS2_METAL_TOOLCHAIN_HINT }),
+    );
+    const message = events.find((e) => e.stage === 'verify').message;
+    expect(message).toContain(TRELLIS2_FALLBACK_BAKE_HELP);
+    expect(message).not.toContain(TRELLIS2_REQUIRES_XCODE_HINT);
+  });
+
+  // Resolving the remedy costs two subprocess spawns; a healthy or undetermined bake
+  // has no remedy to resolve, so it must not pay for one.
+  it('spawns no toolchain probe unless the bake actually came out degraded', async () => {
+    const probeToolchain = vi.fn(async () => ({ available: true }));
+    await runToCompletion(async () => ({ quality: 'metal', missing: [] }), probeToolchain);
+    expect(probeToolchain).not.toHaveBeenCalled();
+    await runToCompletion(async () => ({ quality: 'unknown', missing: [] }), probeToolchain);
+    expect(probeToolchain).not.toHaveBeenCalled();
+  });
   it('confirms a healthy Metal bake on a good install', async () => {
     const events = await runToCompletion(async () => ({ quality: 'metal', missing: [] }));
     expect(events.find((e) => e.stage === 'verify')?.message).toMatch(/Metal texture baking is available/);


### PR DESCRIPTION
## Summary

- On a Command-Line-Tools-only host the card correctly **hides** the Repair button, but the install's own `verify` frame still printed *"Repair install fetches the missing build dependencies and rebuilds the Metal backends"* — advice that host provably cannot act on.
- Both lanes now resolve **which** remedy applies through one exported helper, `resolveDegradedBakeRemedy(bake, toolchain)` in `trellis2.js`: Xcode hint + `repairable: false` on a toolchain `blocker` host, fallback help + `repairable: true` otherwise, `null` when the bake isn't degraded.
- `adapters.js` calls the same helper instead of duplicating the branch — its output is byte-identical to before on all four states.
- The `verify` hook probes the toolchain **only** on the degraded path, and probes fresh rather than reusing the caller's preflight result (the Metal Toolchain step may have installed it in between). The probe is injectable (`probeToolchain`), matching the existing `probeBake` pattern, so the suite never touches the host toolchain.
- `TRELLIS2_FALLBACK_BAKE_HELP` is byte-identical. Same shared-formatter shape as `appendMissingBakeModules`, which fixed the module-name half of this parity in #4636.

## Test plan

- `cd server && npx vitest run services/imageTo3d routes/imageTo3d.test.js` → 18 files, 498 tests pass.
- New coverage: unit tests for `resolveDegradedBakeRemedy` (blocker / fetchable / unknown toolchain / non-degraded bake); the verify frame on a blocker host asserted as the whole sentence (`⚠️ <Xcode hint> Missing: o_voxel.`); the non-blocker degraded frame asserted unchanged; and a spawn-count guard that the toolchain probe is never called for a `metal` or `unknown` bake.
- `adapters.degraded.test.js` now pins the replayed `warnings` string on the blocker path to the same sentence, so the already-installed short-circuit and the post-install frame cannot drift.

Closes #4742