### PR TITLE
pin claim-agent reviews to the reviewers PortOS configured, not the host's saved slashdo defaults

### DIFF
--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -36,6 +36,13 @@ export const DEFAULT_REVIEWERS = ['copilot'];
 // bot). Used by the code-review endpoint, settings panel, and prompt builder
 // to gate model-id resolution.
 export const LOCAL_LLM_REVIEWERS = ['lmstudio', 'ollama'];
+// Reviewers PortOS serves ITSELF, with no counterpart in slashdo's reviewer
+// vocabulary: `lmstudio` runs through `POST /api/code-review/local`, which takes
+// its model in the request body. slashdo has no such slug, so it can neither
+// carry a `[<model>]` bracket nor appear in a `--review-with` list (an unknown
+// value aborts the command). One constant so a future addition can't be fixed
+// in one of those two places and missed in the other.
+export const PORTOS_ONLY_REVIEWERS = ['lmstudio'];
 // CLI reviewers whose binary accepts a `--model <id>` tier the user can pin on
 // the Code Review Defaults panel (stored as a `<reviewer>Model` settings scalar,
 // e.g. `codexModel` / `claudeModel` / `antigravityModel`). The review-loop
@@ -389,12 +396,11 @@ function normalizeReviewerModel(raw, reviewer = null) {
 }
 
 // Reviewers whose slashdo `--review-with` entry accepts a `[<model>]` bracket
-// (`lib/multi-reviewer-loop.md`: codex/claude/agy/grok/cursor/ollama). PortOS's
-// `lmstudio` reviewer has NO slashdo counterpart — it's served by
-// `POST /api/code-review/local`, which takes the model in its request body — so a
-// pinned lmstudio model never becomes a bracket, and `copilot`/`@login` entries
-// reject one outright.
-export const BRACKET_MODEL_REVIEWERS = MODEL_SELECTABLE_REVIEWERS.filter(r => r !== 'lmstudio');
+// (`lib/multi-reviewer-loop.md`: codex/claude/agy/grok/cursor/ollama). A
+// PORTOS_ONLY_REVIEWERS entry has no slashdo counterpart at all, so a pinned
+// model for it never becomes a bracket, and `copilot`/`@login` entries reject
+// one outright.
+export const BRACKET_MODEL_REVIEWERS = MODEL_SELECTABLE_REVIEWERS.filter(r => !PORTOS_ONLY_REVIEWERS.includes(r));
 
 /**
  * Per-reviewer model pins — the model id ONE reviewer runs with, keyed by the
@@ -810,6 +816,76 @@ export function buildReviewerEffortNote(reviewers, reviewerEfforts = {}, { revie
     .filter(Boolean);
   if (!entries.length) return '';
   return `Invoke each reviewer CLI at its pinned reasoning effort: ${entries.join(', ')}. Pass the flag yourself when you spawn the reviewer — nothing else in this prompt applies it (a \`~effort=<level>\` suffix in a reviewer list is slashdo's own grammar, which only its \`--review-with\` parses).`;
+}
+
+// Examples of slashdo commands that run a review loop and therefore resolve
+// `--review-with` from a saved default when the invocation doesn't pin one.
+// EXAMPLES, deliberately — the rule is stated over "any `/do:*` that reviews"
+// because the real roster is larger and moves with the submodule (`/do:review`,
+// `/do:better`, `/do:better-swift`, `/do:depfree`, `/do:release` all read it
+// too). A hand-maintained enumeration is the part that rots, and a command
+// missing from it would read as exempt.
+const REVIEW_LOOP_SLASHDO_EXAMPLES_MD = ['/do:pr', '/do:next', '/do:review', '/do:rpr']
+  .map(command => `\`${command}\``).join(', ');
+
+/**
+ * The reviewer slug inside an emitted `--review-with` token, without its
+ * `[<model>]` / `~<suffix>` decoration — the inverse of `markSuffixes`, which is
+ * the only thing that ever builds one. Kept beside its emitter, and pinned to it
+ * by a round-trip test, so a grammar change can't silently mis-slug here.
+ */
+export const reviewerTokenSlug = (token) => String(token).split('[')[0].split('~')[0].trim().toLowerCase();
+
+/**
+ * Prose block pinning a claim prompt's reviewer list against slashdo's SAVED
+ * defaults.
+ *
+ * The claim flows hand-run their reviewers, so the prompt names the list and
+ * emits no flag. But the claim agent is usually a Claude Code session with
+ * slashdo installed, and reaching for `/do:pr` mid-flow is a short step from
+ * the phase text — at which point slashdo resolves `--review-with` from the
+ * host's saved defaults (`.slashdo.json` at the repo root, or the host CLI's
+ * `.slashdo-config.json`), i.e. some OTHER user-level reviewer set, plus
+ * whatever `merge` default rides with it. That silently replaces the reviewers
+ * PortOS resolved for this run. So state the pin once, in the prompt, with the
+ * exact token list to pass.
+ *
+ * `reviewersCsv` must be the text `buildReviewersCsv` emits — the same
+ * `<agent>[<model>]~opt~max=<n>~effort=<level>` grammar `--review-with` parses —
+ * so the agent can paste it verbatim.
+ *
+ * Unlike `buildReviewWithArgs` this does NOT suppress a lone bare `copilot`
+ * (the #2507 stall): every claim path resolves its list through
+ * `normalizeClaimReviewers`, which strips `copilot` and falls back to `codex`,
+ * so the suppressed case cannot reach here. A future caller that skips that
+ * normalizer has to add the guard rather than assume it.
+ *
+ * @param {string} reviewersCsv - the emitted reviewer token list
+ * @returns {string} a Markdown block, or '' when there is no list to pin
+ */
+export function buildReviewerPinNote(reviewersCsv) {
+  const csv = typeof reviewersCsv === 'string' ? reviewersCsv.trim() : '';
+  if (!csv) return '';
+  // A `@login` entry is always a valid slashdo reviewer; a keyed one is valid
+  // unless PortOS serves it itself. Emitting a PORTOS_ONLY_REVIEWERS slug in a
+  // `--review-with` list would abort the command outright, so it is dropped from
+  // the flag text and named separately with the procedure that DOES run it.
+  const tokens = csv.split(',').map(t => t.trim()).filter(Boolean);
+  const flagTokens = tokens.filter(t => t.startsWith('@') || !PORTOS_ONLY_REVIEWERS.includes(reviewerTokenSlug(t)));
+  // Named by bare slug: the `[<model>]`/`~<suffix>` decoration is slashdo
+  // grammar, and these reviewers never reach a slashdo parser.
+  const portosOnly = [...new Set(tokens.filter(t => !flagTokens.includes(t)).map(reviewerTokenSlug))];
+
+  return [
+    '## Reviewer pin — use the reviewers PortOS configured',
+    `PortOS resolved this run's reviewers from its own configuration: \`${csv}\`. That list is authoritative for every review in this run — it is the same list the phases above name. Never substitute a different reviewer set for it.`,
+    flagTokens.length
+      && `**A saved slashdo default must never stand in for it.** If you invoke ANY slashdo \`/do:*\` command that runs a review loop (${REVIEW_LOOP_SLASHDO_EXAMPLES_MD}, and others), pass \`--review-with ${flagTokens.join(',')}\` explicitly. A bare invocation resolves \`--review-with\` from the host's saved defaults instead — \`.slashdo.json\` at the repo root, or the host CLI's \`.slashdo-config.json\` — which name a different reviewer set and can carry an auto-merge default this run never asked for.`,
+    flagTokens.length
+      && 'Pass those tokens exactly as written: their `[<model>]`, `~opt`, `~max=<n>`, and `~effort=<level>` suffixes are slashdo grammar and already carry each reviewer\'s pinned model, optional/blocking status, round cap, and reasoning effort — so do not also apply those by hand on that path.',
+    portosOnly.length
+      && `PortOS runs \`${portosOnly.join('`, `')}\` itself — no slashdo slug, so never a \`--review-with\` value. That review happens through the Local Reviewer Procedure below, and leaving it out of a slashdo invocation is not permission to skip it.`,
+  ].filter(Boolean).join('\n\n');
 }
 
 /**

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -26,6 +26,9 @@ import {
   reviewerEffortArgs,
   reviewerModelArg,
   buildReviewerEffortNote,
+  buildReviewerPinNote,
+  buildReviewersCsv,
+  reviewerTokenSlug,
   sanitizeTaskMetadata,
   codeReviewSettingsSchema,
   taskTemplateSettingsSchema,
@@ -550,5 +553,69 @@ describe('per-reviewer model pins', () => {
     expect(pairReviewerModelsAndEfforts({ grok: 'grok-code-fast-1' }, {}))
       .toEqual({ reviewerModels: { grok: 'grok-code-fast-1' }, reviewerEfforts: {} });
     expect(reviewerEffortLevels('grok')).toBeNull();
+  });
+});
+
+describe('reviewer pin note (saved slashdo defaults must not win)', () => {
+  it('names the resolved list AND the exact --review-with text to pass', () => {
+    const note = buildReviewerPinNote('codex,claude');
+    // Both halves matter: the list the phases run by hand, and the flag text for
+    // the moment the agent reaches for a slashdo command instead.
+    expect(note).toContain('`codex,claude`');
+    expect(note).toContain('--review-with codex,claude');
+    expect(note).toContain('/do:pr');
+    // The failure mode this block exists to prevent, named so the agent can
+    // recognize it: a bare invocation silently adopting the host's saved config.
+    expect(note).toMatch(/\.slashdo-config\.json/);
+  });
+
+  it('carries the per-entry suffixes verbatim so the pinned model/effort survive the paste', () => {
+    // A reviewer pin is only honored if the agent pastes the whole token — the
+    // bracket and the ~suffixes ARE the model/optional/cap/effort pins.
+    const csv = 'antigravity[gemini-3.7-flash]~opt~max=1~effort=medium';
+    expect(buildReviewerPinNote(csv)).toContain(`--review-with ${csv}`);
+  });
+
+  it('keeps a PortOS-served reviewer OUT of the pinned flag — slashdo aborts on a slug it does not know', () => {
+    const note = buildReviewerPinNote('lmstudio~effort=high,ollama,@alice');
+    // The flag text carries only tokens slashdo can parse...
+    expect(note).toContain('--review-with ollama,@alice');
+    expect(note).not.toContain('--review-with lmstudio');
+    // ...and the dropped reviewer is named by bare slug, pointed at the
+    // procedure that actually runs it, so dropping it from a slashdo call can't
+    // read as permission to skip the review.
+    expect(note).toContain('PortOS runs `lmstudio` itself');
+    expect(note).toContain('Local Reviewer Procedure');
+  });
+
+  it('states the pin with no flag text at all when every reviewer is PortOS-only', () => {
+    const note = buildReviewerPinNote('lmstudio');
+    expect(note).toContain('authoritative');
+    // No flag to hand out — the only `--review-with` mention left is the
+    // prohibition, never an instruction to pass one.
+    expect(note).not.toMatch(/pass `--review-with/);
+  });
+
+  it('reads back every slug an emitted token can carry (inverse of markSuffixes)', () => {
+    // reviewerTokenSlug is the only place the emitted grammar is parsed rather
+    // than built. Round-trip a fully decorated token through the real emitter so
+    // a new bracket or ~suffix in markSuffixes fails HERE instead of silently
+    // mis-slugging a reviewer out of (or into) the pinned flag.
+    const csv = buildReviewersCsv(
+      ['antigravity', 'lmstudio'],
+      ['alice'],
+      ['antigravity'],
+      { antigravity: 1 },
+      { antigravity: 'gemini-3.7-flash', lmstudio: 'qwen' },
+      { antigravity: 'medium', lmstudio: 'high' }
+    );
+    expect(csv.split(',').map(reviewerTokenSlug)).toEqual(['antigravity', 'lmstudio', '@alice']);
+  });
+
+  it('emits nothing when there is no list to pin', () => {
+    expect(buildReviewerPinNote('')).toBe('');
+    expect(buildReviewerPinNote('   ')).toBe('');
+    expect(buildReviewerPinNote(null)).toBe('');
+    expect(buildReviewerPinNote(undefined)).toBe('');
   });
 });

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -22,7 +22,7 @@
 import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { sanitizeTaskMetadata, PIPELINE_BEHAVIOR_FLAGS, MAX_TOTAL_SPAWNS, normalizeReviewers, resolveReviewUsernames, resolveOptionalReviewers, resolveReviewerMaxRounds, resolveReviewerPins, buildReviewerEffortNote, buildReviewersCsv, LOCAL_LLM_REVIEWERS, SWARM_COUNT_MIN, ISSUE_AUTHOR_FILTERS, CLAIM_OVERRIDE_CONTEXT_MAX_CHARS } from '../lib/validation.js';
+import { sanitizeTaskMetadata, PIPELINE_BEHAVIOR_FLAGS, MAX_TOTAL_SPAWNS, normalizeReviewers, resolveReviewUsernames, resolveOptionalReviewers, resolveReviewerMaxRounds, resolveReviewerPins, buildReviewerEffortNote, buildReviewerPinNote, buildReviewersCsv, LOCAL_LLM_REVIEWERS, SWARM_COUNT_MIN, ISSUE_AUTHOR_FILTERS, CLAIM_OVERRIDE_CONTEXT_MAX_CHARS } from '../lib/validation.js';
 import { isPlainObject } from '../lib/objects.js';
 import { parsePlanItems, extractAllIds, findInProgressIds, pickFirstAvailable, diagnoseUnpickablePlan } from '../lib/planIds.js';
 import { loadState, saveState, withStateLock, isImprovementEnabled, isDaemonRunning } from './cosState.js';
@@ -535,6 +535,7 @@ export async function buildClaimWorkTask(app, {
     + appendTargetWorkItemBlock(promptTaskType, targetRef, issueExcludeLabelsBlock)
     + appendPrefetchedIssueContext(promptTaskType, targetRef, issueContext)
     + appendClaimOverrideContext(overrideContext)
+    + appendReviewerPinBlock(reviewersCsv)
     + appendReviewerEffortBlock(reviewersList, promptReviewerEfforts, promptReviewerModels)
     + buildLocalReviewerInstructions(reviewersList, promptReviewerModels, promptReviewerEfforts);
 
@@ -570,8 +571,10 @@ async function resolveClaimReviewerPrompt() {
   // suffix), so the bracket and the appended instruction can't describe different
   // invocations.
   const { reviewerModels, reviewerEfforts } = resolveReviewerPins(null, codeReviewDefaults);
+  const csv = buildReviewersCsv(list, codeReviewDefaults?.usernames, codeReviewDefaults?.optionalReviewers, codeReviewDefaults?.reviewerMaxRounds, reviewerModels, reviewerEfforts);
   return {
-    csv: buildReviewersCsv(list, codeReviewDefaults?.usernames, codeReviewDefaults?.optionalReviewers, codeReviewDefaults?.reviewerMaxRounds, reviewerModels, reviewerEfforts),
+    csv,
+    pinBlock: appendReviewerPinBlock(csv),
     effortBlock: appendReviewerEffortBlock(list, reviewerEfforts, reviewerModels),
     localReviewerBlock: buildLocalReviewerInstructions(list, reviewerModels, reviewerEfforts),
   };
@@ -696,11 +699,12 @@ ${body || '(empty)'}
 </portos-prefetched-issue>`;
 }
 
-/** The same block with the leading blank-line separator used by prompt appends. */
-const appendPrefetchedIssueContext = (promptTaskType, target, issueContext) => {
-  const block = buildPrefetchedIssueContextBlock(promptTaskType, target, issueContext);
-  return block ? `\n\n${block}` : '';
-};
+// Every prompt-append helper below joins its block onto the prompt with the same
+// blank-line separator, and renders nothing when the block is empty.
+const appendBlock = (block) => (block ? `\n\n${block}` : '');
+
+const appendPrefetchedIssueContext = (promptTaskType, target, issueContext) =>
+  appendBlock(buildPrefetchedIssueContextBlock(promptTaskType, target, issueContext));
 
 /**
  * Render optional guidance entered by the user on the managed-app Issues tab.
@@ -723,16 +727,10 @@ ${context}
 </portos-claim-override>`;
 }
 
-const appendClaimOverrideContext = (overrideContext) => {
-  const block = buildClaimOverrideContextBlock(overrideContext);
-  return block ? `\n\n${block}` : '';
-};
+const appendClaimOverrideContext = (overrideContext) => appendBlock(buildClaimOverrideContextBlock(overrideContext));
 
-/** The same block with the leading blank-line separator a prompt append needs. */
-const appendTargetWorkItemBlock = (promptTaskType, ref, excludeLabelsBlock = '') => {
-  const block = buildTargetWorkItemBlock(promptTaskType, ref, excludeLabelsBlock);
-  return block ? `\n\n${block}` : '';
-};
+const appendTargetWorkItemBlock = (promptTaskType, ref, excludeLabelsBlock = '') =>
+  appendBlock(buildTargetWorkItemBlock(promptTaskType, ref, excludeLabelsBlock));
 
 /**
  * The per-reviewer reasoning-effort instruction, appended to a claim prompt with
@@ -747,10 +745,21 @@ const appendTargetWorkItemBlock = (promptTaskType, ref, excludeLabelsBlock = '')
  * rather than a flag — without them a pinned `cursor[<id>]~effort=<level>` would
  * have no invocation to name here at all.
  */
-const appendReviewerEffortBlock = (reviewers, reviewerEfforts, reviewerModels) => {
-  const note = buildReviewerEffortNote(reviewers, reviewerEfforts, { reviewerModels });
-  return note ? `\n\n${note}` : '';
-};
+const appendReviewerEffortBlock = (reviewers, reviewerEfforts, reviewerModels) =>
+  appendBlock(buildReviewerEffortNote(reviewers, reviewerEfforts, { reviewerModels }));
+
+/**
+ * Append the reviewer pin: the claim agent must review with the list PortOS
+ * resolved, never with the host's saved slashdo defaults. Prose (not a
+ * `{...}` placeholder) for the same reason as the effort block — a customized
+ * legacy claim template would silently drop a new placeholder, and that is
+ * exactly the install whose agent then adopts the host's saved slashdo
+ * `--review-with` the moment it reaches for `/do:pr`.
+ *
+ * Takes the already-rendered CSV rather than the reviewer list so the block can
+ * only ever name the same tokens the prompt's `{reviewers}` does.
+ */
+const appendReviewerPinBlock = (reviewersCsv) => appendBlock(buildReviewerPinNote(reviewersCsv));
 
 /**
  * Append the invocation contract for claim reviewers that have no CLI binary.
@@ -827,7 +836,7 @@ export async function buildJiraTicketTask(app, ticketKey) {
   const key = normalizeWorkItemRef(ticketKey);
 
   // Independent reads (prompt body + Code Review Defaults) — fetch concurrently.
-  const [template, { csv: reviewersCsv, effortBlock, localReviewerBlock }] = await Promise.all([
+  const [template, { csv: reviewersCsv, pinBlock, effortBlock, localReviewerBlock }] = await Promise.all([
     getTaskPrompt('claim-issue-jira'),
     resolveClaimReviewerPrompt(),
   ]);
@@ -839,6 +848,7 @@ export async function buildJiraTicketTask(app, ticketKey) {
     // a backreference.
     .replace(/\{reviewers\}/g, () => reviewersCsv)
     + appendTargetWorkItemBlock('claim-issue-jira', key)
+    + pinBlock
     + effortBlock
     + localReviewerBlock;
 
@@ -2908,6 +2918,9 @@ async function buildImprovementTaskDescription({ promptTemplate, app, promptTask
   // sanitizeTaskMetadata, so read it from `metadata`. Empty for non-issue
   // trackers and when swarm is off.
   const swarmBlock = resolveSwarmBlock(promptTaskType, metadata.swarmCount);
+  // Does this template drive its own reviewers? Gates the three reviewer blocks
+  // appended after the substitutions below.
+  const rendersReviewers = /\{reviewers\}/.test(promptTemplate);
 
   return `${swarmBlock}${promptTemplate}`
     // {modeInstructions} before {trackerInstructions}: the file-issues mode
@@ -2938,17 +2951,17 @@ async function buildImprovementTaskDescription({ promptTemplate, app, promptTask
     .replace(/\{repoFullName\}/g, () => blocks.repoFullName)
     .replace(/\{defaultBranch\}/g, () => blocks.defaultBranch)
     .replace(/\{planConstraint\}/g, () => blocks.planConstraint)
-    // The effort note accompanies the reviewer CSV, so it's only appended when this
-    // template actually carries one. A task type whose prompt does NOT drive its own
+    // The reviewer pin, the effort note, and the local-reviewer procedure all
+    // accompany the reviewer CSV, so they are appended only when this template
+    // actually carries one. A task type whose prompt does NOT drive its own
     // reviewers gets its PR reviewed by the completion workflow instead, and
-    // `buildCliCompletionSection` already states the effort next to that `/do:pr`
-    // step — appending here too would print the same sentence twice and give one
-    // instruction two owners to drift apart.
-    + (/\{reviewers\}/.test(promptTemplate)
-        ? appendReviewerEffortBlock(promptReviewers, promptReviewerEfforts, promptReviewerModels)
-        : '')
-    + (/\{reviewers\}/.test(promptTemplate)
-        ? buildLocalReviewerInstructions(promptReviewers, promptReviewerModels, promptReviewerEfforts)
+    // `buildCliCompletionSection` already emits `--review-with` (and states the
+    // effort) next to that `/do:pr` step — appending here too would print the
+    // same instruction twice and give it two owners to drift apart.
+    + (rendersReviewers
+        ? appendReviewerPinBlock(reviewersCsv)
+          + appendReviewerEffortBlock(promptReviewers, promptReviewerEfforts, promptReviewerModels)
+          + buildLocalReviewerInstructions(promptReviewers, promptReviewerModels, promptReviewerEfforts)
         : '');
 }
 

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -27,6 +27,27 @@ vi.mock('./codeReview.js', async (importActual) => ({
   ...(await importActual()),
   getCodeReviewDefaults: vi.fn(async () => ({ reviewers: ['ollama'], usernames: ['alice'], optionalReviewers: [] })),
 }));
+// buildClaimWorkTask (the Issues-tab / `/do:next` claim button) resolves the app's
+// work tracker with a git shell-out and its claim-work metadata from the schedule
+// + per-app overrides. Mock those three leaves — spreading the actual modules so
+// every other consumer in this file keeps the real implementation.
+vi.mock('../lib/workTracker.js', async (importActual) => ({
+  ...(await importActual()),
+  resolveAppWorkTracker: vi.fn(async () => ({ resolved: 'github', source: 'test' })),
+}));
+vi.mock('./apps.js', async (importActual) => ({
+  ...(await importActual()),
+  getAppTaskTypeOverrides: vi.fn(async () => ({})),
+}));
+vi.mock('./taskSchedule.js', async (importActual) => {
+  const actual = await importActual();
+  return {
+    ...actual,
+    getTaskInterval: vi.fn(async (key) => (key === 'claim-work'
+      ? { prompt: null, taskMetadata: { reviewers: ['codex', 'claude'] } }
+      : actual.getTaskInterval(key))),
+  };
+});
 // emitOnDemandEmpty's gh-health read spawns `gh api rate_limit` for real. Stub it
 // so the transient-verdict tests assert OUR branching, not the machine's gh.
 const ghHealth = vi.fn(async () => ({ status: 'ok', ok: true, detail: null, remedy: null }));
@@ -47,6 +68,7 @@ import {
   isConfiguredApprovalRequired,
   recordPerpetualTransient,
   buildJiraTicketTask,
+  buildClaimWorkTask,
   buildImprovementDedupSets,
   normalizeWorkItemRef,
   buildTargetWorkItemBlock,
@@ -377,6 +399,15 @@ describe('{reviewers} interpolation honors Code Review Defaults', () => {
     expect(GEN_SRC).not.toMatch(/buildReviewerEffortNote\([^)]*reviewWith/);
   });
 
+  it('appends the reviewer pin on the SCHEDULED claim path too', () => {
+    // The manual/Issues-tab claim and the JIRA play button are covered
+    // behaviorally below; `buildImprovementTaskDescription` is not exported, so
+    // its site is pinned by source. A scheduled claim that renders the CSV but
+    // skips the pin leaves that agent free to fall back to the host's saved
+    // slashdo --review-with default.
+    expect(GEN_SRC).toContain('rendersReviewers\n        ? appendReviewerPinBlock(reviewersCsv)');
+  });
+
   it('threads per-reviewer ~max round caps into the prompt CSV on both claim paths', () => {
     // The `{reviewers}` token is the whole reviewer contract the claim agent
     // gets — it runs each reviewer by hand, so a configured cap only reaches the
@@ -633,6 +664,9 @@ describe('buildJiraTicketTask', () => {
     expect(prompt).not.toContain('{reviewers}');
     expect(prompt).toContain('ollama');
     expect(prompt).toContain('Local Reviewer Procedure');
+    // The pin travels with the CSV on this path too — the play button's claim
+    // agent is the same kind of slashdo-capable session as the /do:next one.
+    expect(prompt).toContain('--review-with ollama,@alice');
     expect(prompt).not.toContain('copilot');
     expect(prompt).toContain('@alice');
     // Target-ticket constraint pins the uppercased key.
@@ -1600,4 +1634,30 @@ describe('automated drain refills do not clear their own convergence brakes', ()
       expect(src()).toMatch(/\}\s*else if \(!task && userInitiated\) \{/);
     });
   }
+});
+
+// The claim button on the managed-app Issues tab, the Agent Operations `/do:next`
+// drawer, and the scheduled claim-work router all land here. The claim prompt
+// names its reviewer list as prose and emits no flag, so a claim agent that
+// reaches for `/do:pr` mid-flow would have slashdo resolve `--review-with` from
+// the HOST's saved defaults — a different reviewer set (and often an auto-merge
+// default) silently replacing the one PortOS resolved.
+describe('buildClaimWorkTask reviewer pin', () => {
+  const app = { id: 'acme', name: 'Acme App', repoPath: '/repos/acme' };
+
+  it('pins the configured reviewers against slashdo saved defaults', async () => {
+    const { prompt } = await buildClaimWorkTask(app);
+    // The configured claim-work reviewers reach the prompt body...
+    expect(prompt).toContain('Reviewers: codex,claude');
+    // ...and the appended pin names the same tokens as an explicit flag, so the
+    // agent has the exact text to pass rather than a list to re-derive.
+    expect(prompt).toContain('--review-with codex,claude');
+    expect(prompt).toContain('Reviewer pin');
+  });
+
+  it('carries an explicitly requested reviewer list into the pin, not the configured one', async () => {
+    const { prompt } = await buildClaimWorkTask(app, { reviewers: ['claude'] });
+    expect(prompt).toContain('--review-with claude');
+    expect(prompt).not.toContain('--review-with codex,claude');
+  });
 });


### PR DESCRIPTION
## Summary

Claiming an issue from the managed-app **Issues** tab queues a `/do:next` claim prompt that *names* its reviewer list as prose and emits no `--review-with` flag — the agent is expected to hand-run each reviewer. But that agent is usually a Claude Code session with slashdo installed, so reaching for `/do:pr` mid-flow is a short step from the phase text, and a bare invocation resolves `--review-with` from the **host's saved slashdo defaults** (`.slashdo.json`, or the host CLI's `.slashdo-config.json`) — silently swapping in a different reviewer set, plus whatever `merge` default rides with it.

- Every claim-prompt assembly site now appends a **Reviewer pin** block naming the resolved list *and* the exact `--review-with` text to pass: the Issues-tab / `/do:next` claim (`buildClaimWorkTask`), the JIRA play button (`buildJiraTicketTask`), and the scheduled `claim-work` router.
- Appended prose rather than a `{...}` placeholder — same reason as the effort note and the local-reviewer procedure: a customized legacy claim template silently drops a new placeholder, and that is exactly the install whose agent falls back to the host defaults.
- The rule is stated over *any* `/do:*` that reviews (with examples) rather than a hand-maintained command list, so a command missing from an enumeration can't read as exempt.
- `lmstudio` is dropped from the flag text and named separately with the Local Reviewer Procedure that does run it — slashdo aborts on a slug it doesn't know. That exclusion now derives from one shared `PORTOS_ONLY_REVIEWERS` constant instead of a bare `lmstudio` literal duplicated with `BRACKET_MODEL_REVIEWERS`.

Reviewer *resolution* is unchanged: explicit request → configured `claim-work` metadata → Code Review Defaults.

## Test plan

- `server/lib/cosValidation.test.js` — the note names the list and the exact flag text, carries `[model]`/`~opt`/`~max=`/`~effort=` suffixes verbatim, keeps a PortOS-served reviewer out of the flag, emits no flag instruction when every reviewer is PortOS-only, and round-trips `markSuffixes` output through `reviewerTokenSlug` so a grammar change fails loudly.
- `server/services/cosTaskGenerator.test.js` — behavioral: `buildClaimWorkTask` pins the configured reviewers and honors an explicitly requested list; `buildJiraTicketTask` carries the pin; source guard for the non-exported scheduled router path.
- Full server suite: 32432 passed, 1 pre-existing environment failure (`updateExecutor` inherits `PORTOS_FORCE_CLEAN_WORKSPACES` from the launcher; green in isolation).
- Pre-PR local review: `agy` (`gemini-3.7-flash`, effort medium) — NO FINDINGS.