### PR TITLE
fix: redesign scheduled task card header to keep cron timers clean

### DIFF
--- a/client/src/components/cos/tabs/schedule/AppTaskCard.test.jsx
+++ b/client/src/components/cos/tabs/schedule/AppTaskCard.test.jsx
@@ -63,6 +63,14 @@ describe('AppTaskCard', () => {
     expect(screen.getByText(/^in /)).toBeTruthy();
   });
 
+  it('renders a clean Cron badge and next-run schedule description for cron tasks', () => {
+    renderCard({ type: 'cron', cronExpression: '0 6 * * 1-5' }, {}, 'layered-intelligence');
+    expect(screen.getByText('Cron')).toBeTruthy();
+    expect(screen.getAllByTitle('Weekdays at 06:00 (0 6 * * 1-5)').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/^in .* · Weekdays at 06:00/)).toBeTruthy();
+    expect(screen.getByText('layered-intelligence')).toBeTruthy();
+  });
+
   it('shows "Manual trigger only" for on-demand tasks', () => {
     renderCard({ type: 'on-demand' });
     expect(screen.getByText('Manual trigger only')).toBeTruthy();

--- a/client/src/components/cos/tabs/schedule/IntervalBadge.jsx
+++ b/client/src/components/cos/tabs/schedule/IntervalBadge.jsx
@@ -2,11 +2,17 @@ import { describeCron } from '../../../../utils/cronHelpers';
 import { badge, INTERVAL_LABELS, INTERVAL_BADGE_VARIANT } from './scheduleConstants';
 
 export default function IntervalBadge({ type, cronExpression }) {
-  const label = type === 'cron' && cronExpression
-    ? describeCron(cronExpression) || cronExpression
-    : INTERVAL_LABELS[type] || type;
+  const label = INTERVAL_LABELS[type] || type;
+  const cronDesc = type === 'cron' && cronExpression ? describeCron(cronExpression) : null;
+  const title = type === 'cron' && cronExpression
+    ? (cronDesc ? `${cronDesc} (${cronExpression})` : cronExpression)
+    : undefined;
+
   return (
-    <span className={badge(INTERVAL_BADGE_VARIANT[type] || 'success')} title={type === 'cron' && cronExpression ? cronExpression : undefined}>
+    <span
+      className={`${badge(INTERVAL_BADGE_VARIANT[type] || 'success')} whitespace-nowrap shrink-0`}
+      title={title}
+    >
       {label}
     </span>
   );

--- a/client/src/components/cos/tabs/schedule/TaskHeader.jsx
+++ b/client/src/components/cos/tabs/schedule/TaskHeader.jsx
@@ -16,24 +16,26 @@ export default function TaskHeader({ taskType, config }) {
   const branchesPerAgent = config.taskMetadata?.branchesPerAgent;
   const branchBatchOn = taskType === 'branch-reconcile' && Number.isInteger(branchesPerAgent) && branchesPerAgent > 0;
   return (
-    <div className="flex items-start gap-2">
-      <span className={`mt-1.5 w-2 h-2 rounded-full shrink-0 ${statusDot(group)}`} title={group} aria-hidden="true" />
-      <span className="font-mono text-sm text-white break-all leading-tight flex-1 min-w-0">{taskType}</span>
-      <div className="flex items-center gap-1.5 shrink-0">
+    <div className="flex items-center justify-between gap-2 min-w-0">
+      <div className="flex items-center gap-2 min-w-0 flex-1">
+        <span className={`w-2 h-2 rounded-full shrink-0 ${statusDot(group)}`} title={group} aria-hidden="true" />
+        <span className="font-mono text-sm text-white truncate leading-tight" title={taskType}>{taskType}</span>
+      </div>
+      <div className="flex items-center gap-1.5 shrink-0 flex-wrap justify-end">
         {swarmOn && (
-          <span className={badge('cyan')} title={`Swarm mode — claims & ships up to ${swarmCount} independent issues in parallel per run`}>
+          <span className={`${badge('cyan')} whitespace-nowrap`} title={`Swarm mode — claims & ships up to ${swarmCount} independent issues in parallel per run`}>
             <Users size={11} className="inline mr-0.5" />
             ×{swarmCount}
           </span>
         )}
         {branchBatchOn && (
-          <span className={badge('cyan')} title={`Branch-reconcile batch — up to ${branchesPerAgent} branch(es) per coordinator run`}>
+          <span className={`${badge('cyan')} whitespace-nowrap`} title={`Branch-reconcile batch — up to ${branchesPerAgent} branch(es) per coordinator run`}>
             <GitBranch size={11} className="inline mr-0.5" />
             ×{branchesPerAgent}
           </span>
         )}
         {stages?.length > 0 && (
-          <span className={badge('purple')} title={stages.map(s => s.name).join(' → ')}>
+          <span className={`${badge('purple')} whitespace-nowrap`} title={stages.map(s => s.name).join(' → ')}>
             <GitMerge size={11} className="inline mr-0.5" />
             {stages.length}
           </span>

--- a/client/src/components/cos/tabs/schedule/scheduleConstants.js
+++ b/client/src/components/cos/tabs/schedule/scheduleConstants.js
@@ -1,5 +1,6 @@
 // Shared constants and pure helpers for the CoS Schedule tab subcomponents.
 import { timeUntil } from '../../../../utils/formatters';
+import { describeCron } from '../../../../utils/cronHelpers';
 
 export const INTERVAL_LABELS = {
   rotation: 'Rotation',
@@ -146,9 +147,16 @@ export function describeNextRun(config) {
     return { text: 'draining — runs back-to-back until done', tone: 'text-port-success' };
   }
   const next = config.status?.nextRunAt;
+  const cronDesc = config.type === 'cron' && config.cronExpression ? describeCron(config.cronExpression) : null;
+  const cronTitle = config.type === 'cron' && config.cronExpression
+    ? (cronDesc ? `${cronDesc} (${config.cronExpression})` : config.cronExpression)
+    : undefined;
   return {
-    text: next ? timeUntil(next, 'soon') : `${INTERVAL_LABELS[config.type] || config.type} — pending`,
+    text: next
+      ? (cronDesc ? `${timeUntil(next, 'soon')} · ${cronDesc}` : timeUntil(next, 'soon'))
+      : `${cronDesc || INTERVAL_LABELS[config.type] || config.type} — pending`,
     tone: 'text-gray-300',
+    title: cronTitle,
   };
 }
 

--- a/client/src/components/cos/tabs/schedule/scheduleConstants.test.js
+++ b/client/src/components/cos/tabs/schedule/scheduleConstants.test.js
@@ -167,8 +167,15 @@ describe('describeNextRun', () => {
     expect(describeNextRun({ enabled: true, type: 'daily', status: { nextRunAt: '2999-01-01T00:00:00Z' } }).text).toMatch(/^in /);
   });
 
+  it('reports a relative countdown with cron description for a scheduled cron task with next run', () => {
+    const out = describeNextRun({ enabled: true, type: 'cron', cronExpression: '0 6 * * 1-5', status: { nextRunAt: '2999-01-01T00:00:00Z' } });
+    expect(out.text).toMatch(/^in .* · Weekdays at 06:00/);
+    expect(out.title).toBe('Weekdays at 06:00 (0 6 * * 1-5)');
+  });
+
   it('falls back to an interval-label pending string when no next run is known', () => {
     expect(describeNextRun({ enabled: true, type: 'daily' }).text).toBe('Daily — pending');
+    expect(describeNextRun({ enabled: true, type: 'cron', cronExpression: '0 6 * * 1-5' }).text).toBe('Weekdays at 06:00 — pending');
   });
 
   it('reports a draining perpetual task', () => {

--- a/client/src/utils/cronHelpers.js
+++ b/client/src/utils/cronHelpers.js
@@ -93,9 +93,10 @@ export function describeCron(expr) {
   const [min, hour, dom, mon, dow] = parts;
   const segments = [];
   if (/^\d{1,2}$/.test(min) && /^\d{1,2}$/.test(hour)) {
-    if (dow === '1-5') segments.push('Weekdays');
-    else if (dow === '0,6' || dow === '6,0') segments.push('Weekends');
-    else if (dow !== '*') segments.push(dow.split(',').map(d => DOW_MAP[d] || d).join(', '));
+    const normalizedDow = dow.split(',').sort().join(',');
+    if (dow === '1-5' || normalizedDow === '1,2,3,4,5') segments.push('Weekdays');
+    else if (dow === '0,6' || dow === '6,0' || normalizedDow === '0,6' || dow === '0,7' || dow === '7,0') segments.push('Weekends');
+    else if (dow !== '*' && normalizedDow !== '0,1,2,3,4,5,6') segments.push(dow.split(',').map(d => DOW_MAP[d] || d).join(', '));
     if (dom !== '*') segments.push(`day ${dom}`);
     if (mon !== '*') segments.push(`month ${mon}`);
     segments.push(`at ${hour.padStart(2, '0')}:${min.padStart(2, '0')}`);

--- a/client/src/utils/cronHelpers.test.js
+++ b/client/src/utils/cronHelpers.test.js
@@ -72,7 +72,9 @@ describe('describeCron weekly cases', () => {
 
   it('labels weekdays and weekends', () => {
     expect(describeCron('0 7 * * 1-5')).toBe('Weekdays at 07:00');
+    expect(describeCron('0 6 * * 1,2,3,4,5')).toBe('Weekdays at 06:00');
     expect(describeCron('0 10 * * 0,6')).toBe('Weekends at 10:00');
+    expect(describeCron('0 10 * * 6,0')).toBe('Weekends at 10:00');
   });
 });
 

--- a/server/services/updateExecutor.js
+++ b/server/services/updateExecutor.js
@@ -55,9 +55,12 @@ export async function executeUpdate(tag, emit, { forceCleanWorkspaces } = {}) {
   const cleanList = Array.isArray(forceCleanWorkspaces)
     ? forceCleanWorkspaces.filter(w => CLEANABLE_WORKSPACES.has(w))
     : [];
-  const childEnv = cleanList.length
-    ? { ...process.env, PORTOS_FORCE_CLEAN_WORKSPACES: cleanList.join(',') }
-    : process.env;
+  const childEnv = { ...process.env };
+  if (cleanList.length) {
+    childEnv.PORTOS_FORCE_CLEAN_WORKSPACES = cleanList.join(',');
+  } else {
+    delete childEnv.PORTOS_FORCE_CLEAN_WORKSPACES;
+  }
 
   // POSIX: double-fork via spawnDetached so the script reparents to init and
   // survives the pm2 TreeKill its own `pm2 delete`/`pm2 start` steps trigger.


### PR DESCRIPTION
## Summary
When tasks were configured with cron schedules, IntervalBadge rendered the full multi-day cron description (e.g. `Mon, Tue, Wed, Thu, Fri at 06:00`) inline in the header badge. Combined with `shrink-0` on badges and `break-all` on the title, this caused the task name to wrap character-by-character into a vertical column on narrow task cards.

This change redesigns the task card and header layout:
- Standardizes `IntervalBadge` on concise interval labels (e.g. `Cron`) consistent with other interval types, with full schedule tooltips on hover.
- Redesigns `TaskHeader` to use `truncate` and separate title and badge containers cleanly.
- Displays the human-readable schedule in the Next Run row below the header (e.g. `in 2d · Weekdays at 06:00`).
- Enhances `describeCron` to recognize comma-delimited weekdays (`1,2,3,4,5`) as `Weekdays`.
- Prevents ambient `PORTOS_FORCE_CLEAN_WORKSPACES` environment variable leakage in `updateExecutor`.

## Test plan
- Run `npm --prefix client test -- src/components/cos/tabs/schedule src/utils/cronHelpers.test.js`
- Run `npm --prefix server test -- services/updateExecutor.test.js`
- All tests pass.