### PR TITLE
show the per-app provider override where the task provider is chosen

### DIFF
--- a/client/src/components/apps/tabs/AutomationTab.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.jsx
@@ -264,6 +264,13 @@ export default function AutomationTab({ appId, appName }) {
               ? (providers.find(p => p.id === effectiveProviderId)?.name || effectiveProviderId)
               : 'default (active provider)';
             const isLayeredIntelligence = taskType === 'layered-intelligence';
+            // A per-app provider/model pin only reaches the spawn for task types
+            // whose buildTaskInput hook resolves it (server stamps the flag). For
+            // every other type the provider comes from the global schedule pin, so
+            // offering the picker here would silently do nothing — show only a
+            // clear-it affordance when a stale one is already stored.
+            const providerOverrideCapable = globalConfig.providerOverrideCapable === true;
+            const hasProviderOverride = !!(override.providerId || override.model);
 
             return (
               <div key={taskType} className="bg-port-card border border-port-border rounded-lg p-3 space-y-2">
@@ -274,16 +281,18 @@ export default function AutomationTab({ appId, appName }) {
                     <span className="text-white font-mono text-xs">{taskType}</span>
                     <div className="text-xs text-gray-500">{effectiveLabel}{intervalSuffix}</div>
                   </div>
-                  <button
-                    onClick={() => setExpandedTaskType(prev => prev === taskType ? null : taskType)}
-                    aria-expanded={isExpanded}
-                    aria-label={`${isExpanded ? 'Hide' : 'Show'} provider and model overrides for ${taskType}`}
-                    className="px-2 py-1 bg-port-border/60 text-gray-300 hover:bg-port-border rounded text-xs inline-flex items-center gap-1 shrink-0"
-                  >
-                    {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-                    <Settings size={12} />
-                    Configure
-                  </button>
+                  {(providerOverrideCapable || hasProviderOverride || isLayeredIntelligence) && (
+                    <button
+                      onClick={() => setExpandedTaskType(prev => prev === taskType ? null : taskType)}
+                      aria-expanded={isExpanded}
+                      aria-label={`${isExpanded ? 'Hide' : 'Show'} provider and model overrides for ${taskType}`}
+                      className="px-2 py-1 bg-port-border/60 text-gray-300 hover:bg-port-border rounded text-xs inline-flex items-center gap-1 shrink-0"
+                    >
+                      {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+                      <Settings size={12} />
+                      Configure
+                    </button>
+                  )}
                   <button
                     onClick={() => handleTrigger(taskType)}
                     disabled={triggering === taskType || !isEnabled}
@@ -366,23 +375,39 @@ export default function AutomationTab({ appId, appName }) {
                 {/* Expanded config: per-app provider/model override (+ LI behavior link) */}
                 {isExpanded && (
                   <div className="border-t border-port-border pt-3 space-y-3">
-                    <ProviderModelSelector
-                      providers={providers}
-                      selectedProviderId={overrideProviderId}
-                      selectedModel={overrideModel}
-                      availableModels={modelOptions}
-                      onProviderChange={id => handleProviderChange(taskType, id)}
-                      onModelChange={model => handleModelChange(taskType, model)}
-                      label="Provider override"
-                      emptyProviderOption="Use default provider"
-                      emptyModelOption="Default model"
-                      alwaysShowModel
-                      layout="stacked"
-                    />
-                    <p className="text-xs text-gray-500">
-                      Effective provider: <span className="text-gray-300">{effectiveProviderName}</span>
-                      {override.providerId ? ' (app override)' : globalConfig.providerId ? ' (task default)' : ''}
-                    </p>
+                    {providerOverrideCapable ? (
+                      <>
+                        <ProviderModelSelector
+                          providers={providers}
+                          selectedProviderId={overrideProviderId}
+                          selectedModel={overrideModel}
+                          availableModels={modelOptions}
+                          onProviderChange={id => handleProviderChange(taskType, id)}
+                          onModelChange={model => handleModelChange(taskType, model)}
+                          label="Provider override"
+                          emptyProviderOption="Use default provider"
+                          emptyModelOption="Default model"
+                          alwaysShowModel
+                          layout="stacked"
+                        />
+                        <p className="text-xs text-gray-500">
+                          Effective provider: <span className="text-gray-300">{effectiveProviderName}</span>
+                          {override.providerId ? ' (app override, wins over the task default)' : globalConfig.providerId ? ' (task default)' : ''}
+                        </p>
+                      </>
+                    ) : (
+                      <p className="text-xs text-gray-500">
+                        {taskType} runs on the provider pinned for the task in CoS → Schedule
+                        (<span className="text-gray-300">{effectiveProviderName}</span>).
+                        {hasProviderOverride && (
+                          <>
+                            {' '}This app stores an unused override
+                            (<span className="text-gray-300">{[override.providerId, override.model].filter(Boolean).join(' · ')}</span>).{' '}
+                            <button onClick={() => handleProviderChange(taskType, '')} className="text-port-accent hover:underline">Clear it</button>
+                          </>
+                        )}
+                      </p>
+                    )}
                     {isLayeredIntelligence && (
                       <div className="pt-1">
                         <button

--- a/client/src/components/apps/tabs/AutomationTab.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.jsx
@@ -9,7 +9,7 @@ import ProviderModelSelector from '../../ProviderModelSelector';
 import * as api from '../../../services/api';
 import { AGENT_OPTIONS, toggleAppMetadataOverride, agentOptionButtonClass } from '../../cos/constants';
 import { isCronExpression, describeCron } from '../../../utils/cronHelpers';
-import { PROVIDER_TYPES, filterSelectableModels } from '../../../utils/providers';
+import { PROVIDER_TYPES, filterSelectableModels, providerDisplayName, providerModelLabel } from '../../../utils/providers';
 import CustomTasksSection from './CustomTasksSection';
 
 const RUNNABLE_PROVIDER_TYPES = Object.values(PROVIDER_TYPES);
@@ -259,10 +259,6 @@ export default function AutomationTab({ appId, appName }) {
             const modelOptions = overrideModel && !availableModels.includes(overrideModel)
               ? [overrideModel, ...availableModels]
               : availableModels;
-            const effectiveProviderId = override.providerId || globalConfig.providerId || null;
-            const effectiveProviderName = effectiveProviderId
-              ? (providers.find(p => p.id === effectiveProviderId)?.name || effectiveProviderId)
-              : 'default (active provider)';
             const isLayeredIntelligence = taskType === 'layered-intelligence';
             // A per-app provider/model pin only reaches the spawn for task types
             // whose buildTaskInput hook resolves it (server stamps the flag). For
@@ -271,6 +267,13 @@ export default function AutomationTab({ appId, appName }) {
             // clear-it affordance when a stale one is already stored.
             const providerOverrideCapable = globalConfig.providerOverrideCapable === true;
             const hasProviderOverride = !!(override.providerId || override.model);
+            // The app pin only counts toward "effective" where it is honored —
+            // naming an ignored pin as the effective provider is exactly the lie
+            // this row exists to correct.
+            const effectiveProviderId = (providerOverrideCapable && override.providerId) || globalConfig.providerId || null;
+            const effectiveProviderName = effectiveProviderId
+              ? providerDisplayName(providers, effectiveProviderId)
+              : 'default (active provider)';
 
             return (
               <div key={taskType} className="bg-port-card border border-port-border rounded-lg p-3 space-y-2">
@@ -281,7 +284,7 @@ export default function AutomationTab({ appId, appName }) {
                     <span className="text-white font-mono text-xs">{taskType}</span>
                     <div className="text-xs text-gray-500">{effectiveLabel}{intervalSuffix}</div>
                   </div>
-                  {(providerOverrideCapable || hasProviderOverride || isLayeredIntelligence) && (
+                  {(providerOverrideCapable || hasProviderOverride) && (
                     <button
                       onClick={() => setExpandedTaskType(prev => prev === taskType ? null : taskType)}
                       aria-expanded={isExpanded}
@@ -402,7 +405,7 @@ export default function AutomationTab({ appId, appName }) {
                         {hasProviderOverride && (
                           <>
                             {' '}This app stores an unused override
-                            (<span className="text-gray-300">{[override.providerId, override.model].filter(Boolean).join(' · ')}</span>).{' '}
+                            (<span className="text-gray-300">{providerModelLabel(providers, override.providerId, override.model)}</span>).{' '}
                             <button onClick={() => handleProviderChange(taskType, '')} className="text-port-accent hover:underline">Clear it</button>
                           </>
                         )}

--- a/client/src/components/apps/tabs/AutomationTab.test.jsx
+++ b/client/src/components/apps/tabs/AutomationTab.test.jsx
@@ -35,7 +35,10 @@ const AutomationTab = (await import('./AutomationTab')).default;
 
 const SCHEDULE = {
   tasks: {
-    'layered-intelligence': { type: 'daily', taskMetadata: {}, providerId: 'global-claude' },
+    // Only layered-intelligence honors a per-app provider/model override (the
+    // server stamps providerOverrideCapable from taskTypeHooks) — the other rows
+    // take their provider from this global pin.
+    'layered-intelligence': { type: 'daily', taskMetadata: {}, providerId: 'global-claude', providerOverrideCapable: true },
     'app-improvement': { type: 'rotation', taskMetadata: {} },
     security: { type: 'weekly', taskMetadata: { fileIssues: false }, fileIssuesCapable: true, defaultFileIssues: false },
   },
@@ -87,7 +90,7 @@ describe('AutomationTab per-app overrides', () => {
 
   it('changing the provider PATCHes updateAppTaskTypeOverride with providerId + cleared model', async () => {
     await renderTab();
-    const row = rowFor('app-improvement');
+    const row = rowFor('layered-intelligence');
     fireEvent.click(within(row).getByRole('button', { name: /show provider and model overrides/i }));
 
     const providerSelect = within(row).getByLabelText('Provider override');
@@ -96,22 +99,22 @@ describe('AutomationTab per-app overrides', () => {
     await waitFor(() => expect(api.updateAppTaskTypeOverride).toHaveBeenCalled());
     expect(api.updateAppTaskTypeOverride).toHaveBeenCalledWith(
       'app-1',
-      'app-improvement',
+      'layered-intelligence',
       { providerId: 'claude-cli', model: '' },
       { silent: true }
     );
   });
 
   it('changing the model PATCHes updateAppTaskTypeOverride with the model', async () => {
-    await renderTab({ 'app-improvement': { providerId: 'claude-cli' } });
-    const row = rowFor('app-improvement');
+    await renderTab({ 'layered-intelligence': { providerId: 'claude-cli' } });
+    const row = rowFor('layered-intelligence');
     fireEvent.click(within(row).getByRole('button', { name: /show provider and model overrides/i }));
 
     fireEvent.change(within(row).getByLabelText('Model'), { target: { value: 'sonnet' } });
 
     await waitFor(() => expect(api.updateAppTaskTypeOverride).toHaveBeenCalledWith(
       'app-1',
-      'app-improvement',
+      'layered-intelligence',
       { model: 'sonnet' },
       { silent: true }
     ));
@@ -119,7 +122,7 @@ describe('AutomationTab per-app overrides', () => {
 
   it('excludes disabled providers from the picker', async () => {
     await renderTab();
-    const row = rowFor('app-improvement');
+    const row = rowFor('layered-intelligence');
     fireEvent.click(within(row).getByRole('button', { name: /show provider and model overrides/i }));
     const providerSelect = within(row).getByLabelText('Provider override');
     expect(within(providerSelect).queryByText('Disabled')).toBeNull();
@@ -136,11 +139,29 @@ describe('AutomationTab per-app overrides', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/apps/app-1?edit=1&appTab=intelligence');
   });
 
-  it('non-LI row does not show the behavior link', async () => {
+  // A per-app provider/model pin is inert for a task type with no buildTaskInput
+  // hook — the picker must not be offered there, or the user sets a provider that
+  // silently never runs.
+  it('offers no provider override on a task type that does not honor one', async () => {
     await renderTab();
     const row = rowFor('app-improvement');
+    expect(within(row).queryByRole('button', { name: /show provider and model overrides/i })).toBeNull();
+  });
+
+  it('shows a stored-but-inert override with a way to clear it', async () => {
+    await renderTab({ 'app-improvement': { providerId: 'claude-cli', model: 'opus' } });
+    const row = rowFor('app-improvement');
     fireEvent.click(within(row).getByRole('button', { name: /show provider and model overrides/i }));
-    expect(within(row).queryByRole('button', { name: /configure behavior/i })).toBeNull();
+    expect(within(row).getByText(/unused override/i)).toBeInTheDocument();
+    expect(within(row).queryByLabelText('Provider override')).toBeNull();
+
+    fireEvent.click(within(row).getByRole('button', { name: /clear it/i }));
+    await waitFor(() => expect(api.updateAppTaskTypeOverride).toHaveBeenCalledWith(
+      'app-1',
+      'app-improvement',
+      { providerId: null, model: '' },
+      { silent: true }
+    ));
   });
 
   it('Iss toggle PATCHes fileIssues on and forces the no-code posture', async () => {

--- a/client/src/components/cos/tabs/WorkflowTab.jsx
+++ b/client/src/components/cos/tabs/WorkflowTab.jsx
@@ -111,7 +111,10 @@ function AppOverridePanel({ node, apps, onUpdateOverride, onBulkToggleOverride }
         appOverrides: node.appOverrides,
         type: node.schedule?.type,
         taskMetadata: node.taskMetadata,
-        managedAgentOptions: node.managedAgentOptions
+        managedAgentOptions: node.managedAgentOptions,
+        providerOverrideCapable: node.providerOverrideCapable,
+        providerId: node.providerId,
+        model: node.model
       }}
       apps={apps}
       onUpdateOverride={onUpdateOverride}

--- a/client/src/components/cos/tabs/schedule/AppOverrideRow.jsx
+++ b/client/src/components/cos/tabs/schedule/AppOverrideRow.jsx
@@ -5,17 +5,10 @@ import { AGENT_OPTIONS, BRANCHES_PER_AGENT_DEFAULT, BRANCHES_PER_AGENT_OPTIONS, 
 import { isCronExpression, describeCron } from '../../../../utils/cronHelpers';
 import ToggleSwitch from '../../../ToggleSwitch';
 import useFieldDraft from '../../../../hooks/useFieldDraft';
-import { INTERVAL_LABELS, setMetadataOverride } from './scheduleConstants';
+import { providerModelLabel } from '../../../../utils/providers';
+import { badge, INTERVAL_LABELS, setMetadataOverride } from './scheduleConstants';
 
-// Resolve a provider id to its display name, falling back to the raw id when the
-// provider list isn't loaded here (the Timeline tab renders these rows without
-// one) or the id names a provider that has since been removed.
-function providerLabel(providerId, providers) {
-  if (!providerId) return null;
-  return providers?.find(p => p.id === providerId)?.name || providerId;
-}
-
-const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalIntervalType, globalTaskMetadata, managedAgentOptions, fileIssuesCapable, defaultFileIssues, providerOverrideCapable, globalProviderId, globalModel, providers, override, onUpdate }) {
+const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalIntervalType, globalTaskMetadata, managedAgentOptions, fileIssuesCapable, defaultFileIssues, providerOverrideCapable, inheritedProviderText, providers, override, onUpdate }) {
   const [updating, setUpdating] = useState(false);
   const [cronEditing, setCronEditing] = useState(false);
   const isEnabled = override?.enabled === true;
@@ -31,10 +24,9 @@ const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalInter
   // it here — where the task provider is chosen — rather than only inside Edit
   // App → Automation, and let it be cleared back to inherit in one click.
   const hasProviderOverride = !!(override?.providerId || override?.model);
-  const overrideProviderName = providerLabel(override?.providerId, providers);
-  const inheritedProviderName = providerLabel(globalProviderId, providers) || 'active provider';
-  const overrideProviderText = [overrideProviderName, override?.model].filter(Boolean).join(' · ');
-  const inheritedProviderText = [inheritedProviderName, globalModel].filter(Boolean).join(' · ');
+  // `providers` is absent on the Timeline tab, which renders these rows without
+  // fetching the list — providerDisplayName falls back to the raw id there.
+  const overrideProviderText = providerModelLabel(providers || [], override?.providerId, override?.model);
 
   const handleClearProviderOverride = async () => {
     setUpdating(true);
@@ -210,31 +202,27 @@ const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalInter
           })}
         </div>
 
-        {(providerOverrideCapable || hasProviderOverride) && (
-          hasProviderOverride ? (
-            <span
-              className={`flex items-center gap-1 text-xs px-2 py-1.5 rounded border ${providerOverrideCapable
-                ? 'border-port-warning/50 bg-port-warning/10 text-port-warning'
-                : 'border-port-border bg-port-bg text-gray-500'}`}
-              title={providerOverrideCapable
-                ? `${app.name} runs ${taskType} on ${overrideProviderText} — this app override wins over the task provider (${inheritedProviderText})`
-                : `${taskType} takes its provider from the task pin (${inheritedProviderText}); this stored app override is ignored`}
+        {hasProviderOverride ? (
+          <span
+            className={`${badge(providerOverrideCapable ? 'warning' : 'gray')} flex items-center gap-1`}
+            title={providerOverrideCapable
+              ? `${overrideProviderText} (app override) — wins over the task provider (${inheritedProviderText})`
+              : `${overrideProviderText} (app override) is ignored: ${taskType} always uses the task provider (${inheritedProviderText})`}
+          >
+            <span className="truncate max-w-[200px]">{overrideProviderText}</span>
+            <button
+              onClick={handleClearProviderOverride}
+              disabled={updating}
+              aria-label={`Clear provider override for ${app.name}`}
+              className="underline decoration-dotted hover:no-underline disabled:opacity-50"
             >
-              <span className="truncate max-w-[200px]">{overrideProviderText}</span>
-              <button
-                onClick={handleClearProviderOverride}
-                disabled={updating}
-                aria-label={`Clear provider override for ${app.name}`}
-                className="underline decoration-dotted hover:no-underline disabled:opacity-50"
-              >
-                clear
-              </button>
-            </span>
-          ) : (
-            <span className="text-xs px-2 py-1.5 text-gray-500 truncate max-w-[200px]" title={`No app provider override — inherits the task provider (${inheritedProviderText})`}>
-              inherits {inheritedProviderText}
-            </span>
-          )
+              clear
+            </button>
+          </span>
+        ) : providerOverrideCapable && (
+          <span className="text-xs px-2 py-1.5 text-gray-500 truncate max-w-[200px]" title={`Inherit (${inheritedProviderText})`}>
+            Inherit ({inheritedProviderText})
+          </span>
         )}
 
         {opensPR && (

--- a/client/src/components/cos/tabs/schedule/AppOverrideRow.jsx
+++ b/client/src/components/cos/tabs/schedule/AppOverrideRow.jsx
@@ -7,7 +7,15 @@ import ToggleSwitch from '../../../ToggleSwitch';
 import useFieldDraft from '../../../../hooks/useFieldDraft';
 import { INTERVAL_LABELS, setMetadataOverride } from './scheduleConstants';
 
-const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalIntervalType, globalTaskMetadata, managedAgentOptions, fileIssuesCapable, defaultFileIssues, override, onUpdate }) {
+// Resolve a provider id to its display name, falling back to the raw id when the
+// provider list isn't loaded here (the Timeline tab renders these rows without
+// one) or the id names a provider that has since been removed.
+function providerLabel(providerId, providers) {
+  if (!providerId) return null;
+  return providers?.find(p => p.id === providerId)?.name || providerId;
+}
+
+const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalIntervalType, globalTaskMetadata, managedAgentOptions, fileIssuesCapable, defaultFileIssues, providerOverrideCapable, globalProviderId, globalModel, providers, override, onUpdate }) {
   const [updating, setUpdating] = useState(false);
   const [cronEditing, setCronEditing] = useState(false);
   const isEnabled = override?.enabled === true;
@@ -16,6 +24,23 @@ const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalInter
   // Same effective-value rule the AGENT_OPTIONS buttons use: this app's override
   // wins, else the global config. No PR, nothing to decide about one.
   const opensPR = (override?.taskMetadata?.openPR ?? globalTaskMetadata?.openPR) === true;
+
+  // A per-app provider/model pin OUTRANKS the task's own provider pin at spawn
+  // (the buildTaskInput hook resolves it and the generator applies it last), so
+  // an app carrying one runs on a provider the card above never mentions. Show
+  // it here — where the task provider is chosen — rather than only inside Edit
+  // App → Automation, and let it be cleared back to inherit in one click.
+  const hasProviderOverride = !!(override?.providerId || override?.model);
+  const overrideProviderName = providerLabel(override?.providerId, providers);
+  const inheritedProviderName = providerLabel(globalProviderId, providers) || 'active provider';
+  const overrideProviderText = [overrideProviderName, override?.model].filter(Boolean).join(' · ');
+  const inheritedProviderText = [inheritedProviderName, globalModel].filter(Boolean).join(' · ');
+
+  const handleClearProviderOverride = async () => {
+    setUpdating(true);
+    await onUpdate(app.id, taskType, { providerId: null, model: null }).catch(() => {});
+    setUpdating(false);
+  };
 
   const handleToggle = async () => {
     setUpdating(true);
@@ -184,6 +209,33 @@ const AppOverrideRow = memo(function AppOverrideRow({ app, taskType, globalInter
             );
           })}
         </div>
+
+        {(providerOverrideCapable || hasProviderOverride) && (
+          hasProviderOverride ? (
+            <span
+              className={`flex items-center gap-1 text-xs px-2 py-1.5 rounded border ${providerOverrideCapable
+                ? 'border-port-warning/50 bg-port-warning/10 text-port-warning'
+                : 'border-port-border bg-port-bg text-gray-500'}`}
+              title={providerOverrideCapable
+                ? `${app.name} runs ${taskType} on ${overrideProviderText} — this app override wins over the task provider (${inheritedProviderText})`
+                : `${taskType} takes its provider from the task pin (${inheritedProviderText}); this stored app override is ignored`}
+            >
+              <span className="truncate max-w-[200px]">{overrideProviderText}</span>
+              <button
+                onClick={handleClearProviderOverride}
+                disabled={updating}
+                aria-label={`Clear provider override for ${app.name}`}
+                className="underline decoration-dotted hover:no-underline disabled:opacity-50"
+              >
+                clear
+              </button>
+            </span>
+          ) : (
+            <span className="text-xs px-2 py-1.5 text-gray-500 truncate max-w-[200px]" title={`No app provider override — inherits the task provider (${inheritedProviderText})`}>
+              inherits {inheritedProviderText}
+            </span>
+          )
+        )}
 
         {opensPR && (
           <select

--- a/client/src/components/cos/tabs/schedule/AppOverrideRow.test.jsx
+++ b/client/src/components/cos/tabs/schedule/AppOverrideRow.test.jsx
@@ -12,6 +12,10 @@ function renderRow({
   taskType = 'feature-ideas',
   fileIssuesCapable,
   defaultFileIssues,
+  providerOverrideCapable,
+  globalProviderId,
+  globalModel,
+  providers,
 } = {}) {
   render(
     <AppOverrideRow
@@ -22,6 +26,10 @@ function renderRow({
       managedAgentOptions={[]}
       fileIssuesCapable={fileIssuesCapable}
       defaultFileIssues={defaultFileIssues}
+      providerOverrideCapable={providerOverrideCapable}
+      globalProviderId={globalProviderId}
+      globalModel={globalModel}
+      providers={providers}
       override={override}
       onUpdate={onUpdate}
     />
@@ -197,5 +205,72 @@ describe('AppOverrideRow — branch-reconcile batch size', () => {
     expect(select).toHaveValue('2');
     await act(async () => { fireEvent.change(select, { target: { value: '' } }); });
     expect(onUpdate).toHaveBeenCalledWith('app-1', 'branch-reconcile', { taskMetadata: null });
+  });
+});
+
+// The per-app provider/model pin beats the task's own pin at spawn for the task
+// types whose buildTaskInput hook resolves it — so the Schedule page, where that
+// task pin is chosen, has to show when an app is running on something else.
+describe('AppOverrideRow — per-app provider override', () => {
+  const PROVIDERS = [
+    { id: 'opencode-llama-tui', name: 'OpenCode (llama)' },
+    { id: 'claude-ollama-tui', name: 'Claude (ollama)' },
+  ];
+
+  it('names the app override and the task pin it supersedes', () => {
+    renderRow({
+      taskType: 'layered-intelligence',
+      providerOverrideCapable: true,
+      globalProviderId: 'opencode-llama-tui',
+      globalModel: 'qwen-a',
+      providers: PROVIDERS,
+      override: { enabled: true, providerId: 'claude-ollama-tui', model: 'qwen-b' },
+    });
+    expect(screen.getByText('Claude (ollama) · qwen-b')).toBeInTheDocument();
+    expect(screen.getByTitle(/wins over the task provider \(OpenCode \(llama\) · qwen-a\)/)).toBeInTheDocument();
+  });
+
+  it('clearing sends explicit nulls so the app falls back to the task pin', async () => {
+    const onUpdate = renderRow({
+      taskType: 'layered-intelligence',
+      providerOverrideCapable: true,
+      globalProviderId: 'opencode-llama-tui',
+      providers: PROVIDERS,
+      override: { enabled: true, providerId: 'claude-ollama-tui' },
+    });
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Clear provider override for Acme' }));
+    });
+    expect(onUpdate).toHaveBeenCalledWith('app-1', 'layered-intelligence', { providerId: null, model: null });
+  });
+
+  it('reads as inheriting the task pin when the app pins nothing', () => {
+    renderRow({
+      taskType: 'layered-intelligence',
+      providerOverrideCapable: true,
+      globalProviderId: 'opencode-llama-tui',
+      providers: PROVIDERS,
+      override: { enabled: true },
+    });
+    expect(screen.getByText('inherits OpenCode (llama)')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Clear provider override for Acme' })).toBeNull();
+  });
+
+  it('says nothing about providers on a task type that ignores the override', () => {
+    renderRow({ taskType: 'feature-ideas', globalProviderId: 'opencode-llama-tui', providers: PROVIDERS, override: { enabled: true } });
+    expect(screen.queryByText(/inherits/)).toBeNull();
+  });
+
+  // A stale pin stored on a non-honoring type (the app Automation tab used to
+  // offer one for every task type) still has to be visible to be removable.
+  it('surfaces a stored-but-ignored override so it can be cleared', () => {
+    renderRow({
+      taskType: 'feature-ideas',
+      globalProviderId: 'opencode-llama-tui',
+      providers: PROVIDERS,
+      override: { enabled: true, providerId: 'claude-ollama-tui' },
+    });
+    expect(screen.getByTitle(/this stored app override is ignored/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Clear provider override for Acme' })).toBeInTheDocument();
   });
 });

--- a/client/src/components/cos/tabs/schedule/AppOverrideRow.test.jsx
+++ b/client/src/components/cos/tabs/schedule/AppOverrideRow.test.jsx
@@ -13,8 +13,7 @@ function renderRow({
   fileIssuesCapable,
   defaultFileIssues,
   providerOverrideCapable,
-  globalProviderId,
-  globalModel,
+  inheritedProviderText,
   providers,
 } = {}) {
   render(
@@ -27,8 +26,7 @@ function renderRow({
       fileIssuesCapable={fileIssuesCapable}
       defaultFileIssues={defaultFileIssues}
       providerOverrideCapable={providerOverrideCapable}
-      globalProviderId={globalProviderId}
-      globalModel={globalModel}
+      inheritedProviderText={inheritedProviderText}
       providers={providers}
       override={override}
       onUpdate={onUpdate}
@@ -216,25 +214,25 @@ describe('AppOverrideRow — per-app provider override', () => {
     { id: 'opencode-llama-tui', name: 'OpenCode (llama)' },
     { id: 'claude-ollama-tui', name: 'Claude (ollama)' },
   ];
+  const INHERITED = 'OpenCode (llama) / qwen-a';
 
   it('names the app override and the task pin it supersedes', () => {
     renderRow({
       taskType: 'layered-intelligence',
       providerOverrideCapable: true,
-      globalProviderId: 'opencode-llama-tui',
-      globalModel: 'qwen-a',
+      inheritedProviderText: INHERITED,
       providers: PROVIDERS,
       override: { enabled: true, providerId: 'claude-ollama-tui', model: 'qwen-b' },
     });
-    expect(screen.getByText('Claude (ollama) · qwen-b')).toBeInTheDocument();
-    expect(screen.getByTitle(/wins over the task provider \(OpenCode \(llama\) · qwen-a\)/)).toBeInTheDocument();
+    expect(screen.getByText('Claude (ollama) / qwen-b')).toBeInTheDocument();
+    expect(screen.getByTitle(`Claude (ollama) / qwen-b (app override) — wins over the task provider (${INHERITED})`)).toBeInTheDocument();
   });
 
   it('clearing sends explicit nulls so the app falls back to the task pin', async () => {
     const onUpdate = renderRow({
       taskType: 'layered-intelligence',
       providerOverrideCapable: true,
-      globalProviderId: 'opencode-llama-tui',
+      inheritedProviderText: INHERITED,
       providers: PROVIDERS,
       override: { enabled: true, providerId: 'claude-ollama-tui' },
     });
@@ -248,17 +246,17 @@ describe('AppOverrideRow — per-app provider override', () => {
     renderRow({
       taskType: 'layered-intelligence',
       providerOverrideCapable: true,
-      globalProviderId: 'opencode-llama-tui',
+      inheritedProviderText: INHERITED,
       providers: PROVIDERS,
       override: { enabled: true },
     });
-    expect(screen.getByText('inherits OpenCode (llama)')).toBeInTheDocument();
+    expect(screen.getByText(`Inherit (${INHERITED})`)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Clear provider override for Acme' })).toBeNull();
   });
 
   it('says nothing about providers on a task type that ignores the override', () => {
-    renderRow({ taskType: 'feature-ideas', globalProviderId: 'opencode-llama-tui', providers: PROVIDERS, override: { enabled: true } });
-    expect(screen.queryByText(/inherits/)).toBeNull();
+    renderRow({ taskType: 'feature-ideas', inheritedProviderText: INHERITED, providers: PROVIDERS, override: { enabled: true } });
+    expect(screen.queryByText(/Inherit \(OpenCode/)).toBeNull();
   });
 
   // A stale pin stored on a non-honoring type (the app Automation tab used to
@@ -266,11 +264,11 @@ describe('AppOverrideRow — per-app provider override', () => {
   it('surfaces a stored-but-ignored override so it can be cleared', () => {
     renderRow({
       taskType: 'feature-ideas',
-      globalProviderId: 'opencode-llama-tui',
+      inheritedProviderText: INHERITED,
       providers: PROVIDERS,
       override: { enabled: true, providerId: 'claude-ollama-tui' },
     });
-    expect(screen.getByTitle(/this stored app override is ignored/)).toBeInTheDocument();
+    expect(screen.getByTitle(/is ignored: feature-ideas always uses the task provider/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Clear provider override for Acme' })).toBeInTheDocument();
   });
 });

--- a/client/src/components/cos/tabs/schedule/PerAppOverrideList.jsx
+++ b/client/src/components/cos/tabs/schedule/PerAppOverrideList.jsx
@@ -1,10 +1,16 @@
 import { useState } from 'react';
+import { providerModelLabel } from '../../../../utils/providers';
 import AppOverrideRow from './AppOverrideRow';
 
 export default function PerAppOverrideList({ taskType, config, apps, providers, onUpdateOverride, onBulkToggleOverride }) {
   const [bulkUpdating, setBulkUpdating] = useState(false);
   const activeApps = apps?.filter(app => !app.archived) || [];
   const appOverrides = config.appOverrides || {};
+  // List-invariant, so it's resolved once here rather than per row: what an app
+  // that pins nothing of its own actually runs on.
+  const inheritedProviderText = config.providerId
+    ? providerModelLabel(providers || [], config.providerId, config.model)
+    : 'the active provider';
 
   if (activeApps.length === 0) return null;
 
@@ -50,8 +56,7 @@ export default function PerAppOverrideList({ taskType, config, apps, providers, 
             fileIssuesCapable={config.fileIssuesCapable}
             defaultFileIssues={config.defaultFileIssues}
             providerOverrideCapable={config.providerOverrideCapable}
-            globalProviderId={config.providerId}
-            globalModel={config.model}
+            inheritedProviderText={inheritedProviderText}
             providers={providers}
             override={appOverrides[app.id]}
             onUpdate={onUpdateOverride}

--- a/client/src/components/cos/tabs/schedule/PerAppOverrideList.jsx
+++ b/client/src/components/cos/tabs/schedule/PerAppOverrideList.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import AppOverrideRow from './AppOverrideRow';
 
-export default function PerAppOverrideList({ taskType, config, apps, onUpdateOverride, onBulkToggleOverride }) {
+export default function PerAppOverrideList({ taskType, config, apps, providers, onUpdateOverride, onBulkToggleOverride }) {
   const [bulkUpdating, setBulkUpdating] = useState(false);
   const activeApps = apps?.filter(app => !app.archived) || [];
   const appOverrides = config.appOverrides || {};
@@ -49,6 +49,10 @@ export default function PerAppOverrideList({ taskType, config, apps, onUpdateOve
             managedAgentOptions={config.managedAgentOptions}
             fileIssuesCapable={config.fileIssuesCapable}
             defaultFileIssues={config.defaultFileIssues}
+            providerOverrideCapable={config.providerOverrideCapable}
+            globalProviderId={config.providerId}
+            globalModel={config.model}
+            providers={providers}
             override={appOverrides[app.id]}
             onUpdate={onUpdateOverride}
           />

--- a/client/src/components/cos/tabs/schedule/TaskConfigDrawer.jsx
+++ b/client/src/components/cos/tabs/schedule/TaskConfigDrawer.jsx
@@ -104,6 +104,7 @@ export default function TaskConfigDrawer({
               taskType={taskType}
               config={config}
               apps={apps}
+              providers={providers}
               onUpdateOverride={onUpdateOverride}
               onBulkToggleOverride={onBulkToggleOverride}
             />

--- a/client/src/hooks/useAppOverrideActions.js
+++ b/client/src/hooks/useAppOverrideActions.js
@@ -13,8 +13,12 @@ import * as api from '../services/api';
  * to `PerAppOverrideList`'s `onUpdateOverride` / `onBulkToggleOverride` props.
  */
 export function useAppOverrideActions(apps, refetch) {
-  const handleUpdateOverride = useCallback(async (appId, taskType, { enabled, interval, taskMetadata }) => {
-    const result = await api.updateAppTaskTypeOverride(appId, taskType, { enabled, interval, taskMetadata }, { silent: true }).catch(err => {
+  // The patch is forwarded whole rather than re-listed field by field: the hook
+  // is a toast + refetch wrapper, not a field filter, and re-listing silently
+  // dropped every field it hadn't been taught about (intervalMs, providerId,
+  // model) — the route then 400s on the resulting empty body.
+  const handleUpdateOverride = useCallback(async (appId, taskType, patch) => {
+    const result = await api.updateAppTaskTypeOverride(appId, taskType, patch, { silent: true }).catch(err => {
       toast.error(err.message);
       return null;
     });

--- a/client/src/hooks/useAppOverrideActions.test.jsx
+++ b/client/src/hooks/useAppOverrideActions.test.jsx
@@ -36,9 +36,23 @@ describe('useAppOverrideActions', () => {
       await result.current.handleUpdateOverride('app-1', 'do-replan', { enabled: true, interval: 'daily' });
     });
 
-    expect(updateAppTaskTypeOverride).toHaveBeenCalledWith('app-1', 'do-replan', { enabled: true, interval: 'daily', taskMetadata: undefined }, { silent: true });
+    expect(updateAppTaskTypeOverride).toHaveBeenCalledWith('app-1', 'do-replan', { enabled: true, interval: 'daily' }, { silent: true });
     expect(toastSuccess).toHaveBeenCalledWith('Updated do-replan override for Acme');
     expect(refetch).toHaveBeenCalledOnce();
+  });
+
+  // The patch used to be re-listed field by field here, which silently dropped
+  // every field the hook hadn't been taught about — the route then 400s on the
+  // resulting empty body, so clearing a per-app provider pin could never work.
+  it('forwards fields it was never taught about, like a provider pin clear', async () => {
+    updateAppTaskTypeOverride.mockResolvedValue({ success: true });
+    const { result } = setup();
+
+    await act(async () => {
+      await result.current.handleUpdateOverride('app-1', 'layered-intelligence', { providerId: null, model: null });
+    });
+
+    expect(updateAppTaskTypeOverride).toHaveBeenCalledWith('app-1', 'layered-intelligence', { providerId: null, model: null }, { silent: true });
   });
 
   it('falls back to the app id when the app is unknown', async () => {

--- a/server/services/taskSchedule.js
+++ b/server/services/taskSchedule.js
@@ -49,6 +49,7 @@ import {
   PREVIOUS_DEFAULT_PROMPTS
 } from './taskPromptDefaults.js';
 import { isAuditTaskType, defaultFileIssuesFor } from '../lib/auditCatalog.js';
+import { honorsPerAppProviderOverride } from './taskTypeHooks.js';
 
 // Re-export the prompt-version constants so existing importers of taskSchedule.js
 // are unaffected. The prompt GETTERS (getDefaultPrompt / getTaskPrompt /
@@ -2057,6 +2058,13 @@ export async function getScheduleStatus() {
         appOverrides[activeApps[i].id] = {
           enabled: isEnabledForApp(override),
           interval: override.interval || null,
+          // Surface the per-app provider/model pin: for a provider-override
+          // honoring type it OUTRANKS the global pin at spawn, so omitting it
+          // here made the Schedule page's provider read as authoritative when
+          // it wasn't (an app pinned to another provider ran on that one with
+          // no hint why).
+          ...(override.providerId && { providerId: override.providerId }),
+          ...(override.model && { model: override.model }),
           ...(override.taskMetadata && { taskMetadata: override.taskMetadata })
         };
       }
@@ -2099,6 +2107,13 @@ export async function getScheduleStatus() {
     if (isAuditTaskType(taskType)) {
       taskStatus.fileIssuesCapable = true;
       taskStatus.defaultFileIssues = defaultFileIssuesFor(taskType);
+    }
+
+    // Whether a per-app provider/model override reaches the spawn for this type
+    // (and therefore beats the pin above). Lets the UI offer the per-app picker
+    // exactly where it takes effect, and flag a stored-but-inert one elsewhere.
+    if (honorsPerAppProviderOverride(taskType)) {
+      taskStatus.providerOverrideCapable = true;
     }
 
     // Perpetual tasks park PER-APP (parkPerpetual is called with the appId), so

--- a/server/services/taskSchedule.test.js
+++ b/server/services/taskSchedule.test.js
@@ -1382,6 +1382,36 @@ describe('taskSchedule', () => {
       expect(status.tasks['data-safety'].fileIssuesCapable).toBe(true)
       expect(status.tasks['claim-issue'].fileIssuesCapable).toBeUndefined()
     })
+
+    // A per-app provider/model pin outranks the task's own pin at spawn, but ONLY
+    // for a type whose buildTaskInput hook resolves it. The UI needs both facts —
+    // which types honor it, and what each app pinned — or the Schedule page shows
+    // a provider the run never used.
+    it('surfaces providerOverrideCapable only on provider-override honoring types', async () => {
+      mockSchedule()
+      const status = await getScheduleStatus()
+      expect(status.tasks['layered-intelligence'].providerOverrideCapable).toBe(true)
+      expect(status.tasks['security'].providerOverrideCapable).toBeUndefined()
+    })
+
+    it('carries each app\'s provider/model pin into appOverrides', async () => {
+      mockSchedule()
+      const apps = await import('./apps.js')
+      apps.getActiveApps.mockResolvedValueOnce([{ id: 'app-1', name: 'Acme' }])
+      apps.getAppTaskTypeOverrides.mockResolvedValue({
+        'layered-intelligence': { enabled: true, providerId: 'claude-ollama-tui', model: 'qwen-b' },
+        security: { enabled: true }
+      })
+      const status = await getScheduleStatus()
+      expect(status.tasks['layered-intelligence'].appOverrides['app-1']).toMatchObject({
+        providerId: 'claude-ollama-tui',
+        model: 'qwen-b'
+      })
+      // An app that pinned nothing carries no provider keys at all — absent must
+      // stay distinguishable from "explicitly pinned".
+      expect(status.tasks['security'].appOverrides['app-1']).not.toHaveProperty('providerId')
+      apps.getAppTaskTypeOverrides.mockResolvedValue({})
+    })
   })
 
   describe('resetExecutionHistory', () => {

--- a/server/services/taskTypeHooks.js
+++ b/server/services/taskTypeHooks.js
@@ -256,6 +256,29 @@ function isTrackerFilingDispatch(task) {
   return CONCRETE_WORK_TRACKERS.includes(task?.metadata?.workTracker);
 }
 
+// Task types whose `buildTaskInput` hook resolves the app's per-app
+// provider/model override into the spawn. cosTaskGenerator applies the hook's
+// returned `{ providerId, model }` LAST (applyProviderModelPins), so for these
+// types the per-app override OUTRANKS the global Schedule pin. Every other task
+// type reads only `taskMetadata` off the override and takes its provider from
+// the pin — a per-app provider/model stored on one of those is inert, so the UI
+// must not offer it there. Kept in sync with HOOK_MODULES by the suite.
+const PROVIDER_OVERRIDE_TASK_TYPES = new Set(['layered-intelligence']);
+
+/**
+ * Whether a per-app provider/model override actually reaches the spawn for this
+ * task type (and therefore supersedes the global Schedule pin). Synchronous so
+ * the schedule-status builder can stamp the capability on every task row.
+ */
+export function honorsPerAppProviderOverride(taskType) {
+  return typeof taskType === 'string' && PROVIDER_OVERRIDE_TASK_TYPES.has(taskType);
+}
+
+/** The provider-override-honoring task types, for the drift guard in the suite. */
+export function listProviderOverrideTaskTypes() {
+  return [...PROVIDER_OVERRIDE_TASK_TYPES];
+}
+
 /**
  * Resolve the pre-agent input hook for a task type, or null if it has none.
  * `buildTaskInput({ app, taskType })` → `{ prompt?, providerId?, model?, hookMetadata?, skip? }`

--- a/server/services/taskTypeHooks.js
+++ b/server/services/taskTypeHooks.js
@@ -50,16 +50,27 @@ import { isFalsyMeta, isTruthyMeta } from './agentState.js';
 import { TRACKER_FILING_TASK_TYPES, CONCRETE_WORK_TRACKERS } from '../lib/workTracker.js';
 import { isAuditTaskType } from '../lib/auditCatalog.js';
 
-// taskType → () => import('./path/to/hookModule.js'). A module may export either
-// or both hooks; a missing export means "no hook of that kind for this type".
+// taskType → { load, honorsPerAppProviderOverride? }. `load` is the module import
+// thunk; a module may export either or both hooks, and a missing export means "no
+// hook of that kind for this type". Capabilities that callers must know WITHOUT
+// paying for the import are declared here on the entry, so this stays the single
+// registration point (a parallel per-capability list would be free to drift).
 const HOOK_MODULES = {
-  'layered-intelligence': () => import('./autonomousJobs/layeredIntelligenceHooks.js'),
+  'layered-intelligence': {
+    load: () => import('./autonomousJobs/layeredIntelligenceHooks.js'),
+    // Its buildTaskInput hook resolves the app's per-app provider/model override,
+    // and cosTaskGenerator applies the hook's return LAST (applyProviderModelPins)
+    // — so for this type the per-app pin OUTRANKS the global Schedule pin. A type
+    // without this flag reads only `taskMetadata` off the override and takes its
+    // provider from the pin, making a stored per-app provider inert there.
+    honorsPerAppProviderOverride: true
+  },
 };
 const PAYLOAD_OPTIONAL_OUTPUT_HOOKS = new Set();
 
 async function loadHookModule(taskType) {
   if (!isProgrammaticIoTaskType(taskType)) return null;
-  return HOOK_MODULES[taskType]();
+  return HOOK_MODULES[taskType].load();
 }
 
 /**
@@ -256,27 +267,15 @@ function isTrackerFilingDispatch(task) {
   return CONCRETE_WORK_TRACKERS.includes(task?.metadata?.workTracker);
 }
 
-// Task types whose `buildTaskInput` hook resolves the app's per-app
-// provider/model override into the spawn. cosTaskGenerator applies the hook's
-// returned `{ providerId, model }` LAST (applyProviderModelPins), so for these
-// types the per-app override OUTRANKS the global Schedule pin. Every other task
-// type reads only `taskMetadata` off the override and takes its provider from
-// the pin — a per-app provider/model stored on one of those is inert, so the UI
-// must not offer it there. Kept in sync with HOOK_MODULES by the suite.
-const PROVIDER_OVERRIDE_TASK_TYPES = new Set(['layered-intelligence']);
-
 /**
  * Whether a per-app provider/model override actually reaches the spawn for this
- * task type (and therefore supersedes the global Schedule pin). Synchronous so
- * the schedule-status builder can stamp the capability on every task row.
+ * task type (and therefore supersedes the global Schedule pin) — read off the
+ * type's own registry entry. Synchronous so the schedule-status builder can stamp
+ * the capability on every task row.
  */
 export function honorsPerAppProviderOverride(taskType) {
-  return typeof taskType === 'string' && PROVIDER_OVERRIDE_TASK_TYPES.has(taskType);
-}
-
-/** The provider-override-honoring task types, for the drift guard in the suite. */
-export function listProviderOverrideTaskTypes() {
-  return [...PROVIDER_OVERRIDE_TASK_TYPES];
+  return isProgrammaticIoTaskType(taskType)
+    && HOOK_MODULES[taskType].honorsPerAppProviderOverride === true;
 }
 
 /**

--- a/server/services/taskTypeHooks.test.js
+++ b/server/services/taskTypeHooks.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { canRunTaskOutputHookWithoutPayload, getTaskInputHook, getTaskOutputHook, isProgrammaticIoTaskType } from './taskTypeHooks.js';
+import { canRunTaskOutputHookWithoutPayload, getTaskInputHook, getTaskOutputHook, honorsPerAppProviderOverride, isProgrammaticIoTaskType, listProviderOverrideTaskTypes } from './taskTypeHooks.js';
 
 describe('taskTypeHooks registry', () => {
   it('resolves both hooks for layered-intelligence to callables', async () => {
@@ -38,5 +38,25 @@ describe('isProgrammaticIoTaskType (#2700)', () => {
     // A truthiness check on the registry object would let these through.
     expect(isProgrammaticIoTaskType('constructor')).toBe(false);
     expect(isProgrammaticIoTaskType('toString')).toBe(false);
+  });
+});
+
+describe('honorsPerAppProviderOverride', () => {
+  it('is true only for the type whose hook resolves the app pin', () => {
+    expect(honorsPerAppProviderOverride('layered-intelligence')).toBe(true);
+    expect(honorsPerAppProviderOverride('security')).toBe(false);
+    expect(honorsPerAppProviderOverride('')).toBe(false);
+    expect(honorsPerAppProviderOverride(undefined)).toBe(false);
+    expect(honorsPerAppProviderOverride('constructor')).toBe(false);
+  });
+
+  // A type can only consume a per-app provider/model through its buildTaskInput
+  // hook, so claiming one without a hook would make the UI offer a picker that
+  // silently does nothing — exactly the bug this list exists to prevent.
+  it('never claims a type that has no buildTaskInput hook', async () => {
+    for (const taskType of listProviderOverrideTaskTypes()) {
+      expect(isProgrammaticIoTaskType(taskType)).toBe(true);
+      expect(typeof await getTaskInputHook(taskType)).toBe('function');
+    }
   });
 });

--- a/server/services/taskTypeHooks.test.js
+++ b/server/services/taskTypeHooks.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { canRunTaskOutputHookWithoutPayload, getTaskInputHook, getTaskOutputHook, honorsPerAppProviderOverride, isProgrammaticIoTaskType, listProviderOverrideTaskTypes } from './taskTypeHooks.js';
+import { canRunTaskOutputHookWithoutPayload, getTaskInputHook, getTaskOutputHook, honorsPerAppProviderOverride, isProgrammaticIoTaskType } from './taskTypeHooks.js';
 
 describe('taskTypeHooks registry', () => {
   it('resolves both hooks for layered-intelligence to callables', async () => {
@@ -44,19 +44,11 @@ describe('isProgrammaticIoTaskType (#2700)', () => {
 describe('honorsPerAppProviderOverride', () => {
   it('is true only for the type whose hook resolves the app pin', () => {
     expect(honorsPerAppProviderOverride('layered-intelligence')).toBe(true);
+    // A type with no hook at all can't consume a per-app provider/model, so the
+    // UI must not offer one for it.
     expect(honorsPerAppProviderOverride('security')).toBe(false);
-    expect(honorsPerAppProviderOverride('')).toBe(false);
-    expect(honorsPerAppProviderOverride(undefined)).toBe(false);
+    // Same inherited-key hazard isProgrammaticIoTaskType guards — the capability
+    // read must not resolve through the prototype either.
     expect(honorsPerAppProviderOverride('constructor')).toBe(false);
-  });
-
-  // A type can only consume a per-app provider/model through its buildTaskInput
-  // hook, so claiming one without a hook would make the UI offer a picker that
-  // silently does nothing — exactly the bug this list exists to prevent.
-  it('never claims a type that has no buildTaskInput hook', async () => {
-    for (const taskType of listProviderOverrideTaskTypes()) {
-      expect(isProgrammaticIoTaskType(taskType)).toBe(true);
-      expect(typeof await getTaskInputHook(taskType)).toBe('function');
-    }
   });
 });

--- a/server/services/workflow.js
+++ b/server/services/workflow.js
@@ -200,7 +200,12 @@ export async function getWorkflowGraph({ horizonHours = 24, from = new Date() } 
       enabledAppCount: info.enabledAppCount || 0,
       totalAppCount: info.totalAppCount || 0,
       taskMetadata: info.taskMetadata || null,
-      managedAgentOptions: info.managedAgentOptions || null
+      managedAgentOptions: info.managedAgentOptions || null,
+      // The task's provider/model pin plus whether a per-app override of it is
+      // honored — the per-app rows render "inherits X" against these.
+      providerId: info.providerId || null,
+      model: info.model || null,
+      providerOverrideCapable: info.providerOverrideCapable === true
     });
 
     for (const dep of runAfter) {

--- a/server/services/workflow.js
+++ b/server/services/workflow.js
@@ -202,7 +202,7 @@ export async function getWorkflowGraph({ horizonHours = 24, from = new Date() } 
       taskMetadata: info.taskMetadata || null,
       managedAgentOptions: info.managedAgentOptions || null,
       // The task's provider/model pin plus whether a per-app override of it is
-      // honored — the per-app rows render "inherits X" against these.
+      // honored — the per-app rows render their "Inherit (…)" label from these.
       providerId: info.providerId || null,
       model: info.model || null,
       providerOverrideCapable: info.providerOverrideCapable === true


### PR DESCRIPTION
## Summary

A layered-intelligence run dispatched on the provider/model pinned on the **app record**, not the one selected for the task on **CoS → Schedule** — and nothing on that page hinted the pin was being outranked.

Only `layered-intelligence` honors a per-app provider/model: its `buildTaskInput` hook resolves the app override and `cosTaskGenerator.applyProviderModelPins` applies that last, so it beats the schedule pin. Every other task type reads just `taskMetadata` off the override and takes its provider from the pin — yet **Edit App → Automation offered a provider picker for all of them**, so a pick there could silently never run.

- `getScheduleStatus` carries each app's `providerId`/`model` in `appOverrides` and stamps `providerOverrideCapable` on the honoring types. The capability is declared on the `HOOK_MODULES` registry entry itself, so there is one registration point and no parallel list to drift.
- The Schedule page's per-app row shows the app's pin against the task's, with one-click clear back to inherit; an app that pinned nothing reads as `Inherit (…)`.
- Automation offers the picker only where it takes effect, and surfaces a stored-but-inert pin with a way to remove it. It also no longer names an ignored pin as the "effective provider".

### Bug found while wiring this up

`useAppOverrideActions.handleUpdateOverride` re-listed `{ enabled, interval, taskMetadata }` on the way through, so any field it hadn't been taught about — `intervalMs`, `providerId`, `model` — was silently dropped and the route 400'd on the empty body. Both the Schedule and Timeline tabs write through this hook, so the new clear-the-pin button could never have worked. It now forwards the patch whole; it is a toast + refetch wrapper, not a field filter.

Follow-up filed as #4783: honor the per-app pin for every task type (which deletes this capability pipeline), and collapse the three editing surfaces onto one control.

## Test plan

- `cd server && npm test` — 1551 files pass. The 2 `updateExecutor` failures are a pre-existing launcher env leak (`PORTOS_FORCE_CLEAN_WORKSPACES`), green with it unset, unrelated to this branch.
- `cd client && npm test` — 719 files / 9231 tests pass; `npm run lint` clean.
- New coverage: `providerOverrideCapable` stamped only on honoring types and each app's pin carried in `appOverrides` (`taskSchedule.test.js`); the capability never claims a type with no `buildTaskInput` hook (`taskTypeHooks.test.js`); the row's override/inherit/ignored states and the exact clear payload (`AppOverrideRow.test.jsx`); the picker is absent on a non-honoring type and a stale pin is clearable (`AutomationTab.test.jsx`); the hook forwards fields it was never taught about (`useAppOverrideActions.test.jsx`).