### PR TITLE
Default the CoS task form's Worktree and Open PR toggles to on

### DIFF
--- a/client/src/components/cos/ReviewerPicker.jsx
+++ b/client/src/components/cos/ReviewerPicker.jsx
@@ -643,6 +643,7 @@ export default function ReviewerPicker({
             type="button"
             disabled={disabled || !usernameInput.trim() || atMaxUsernames}
             onClick={addUsername}
+            aria-label="Add reviewer username"
             className="inline-flex items-center gap-1 px-1.5 py-0.5 bg-transparent border border-port-border rounded text-xs text-gray-400 hover:text-white hover:border-port-accent disabled:opacity-50"
           >
             <Plus size={11} />

--- a/client/src/components/cos/ReviewerPicker.test.jsx
+++ b/client/src/components/cos/ReviewerPicker.test.jsx
@@ -108,7 +108,7 @@ describe('ReviewerPicker', () => {
     const user = userEvent.setup();
     render(<ReviewerPicker reviewers={['copilot']} onChange={onChange} />);
     await typeSettled(user, screen.getByLabelText('Add a GitHub reviewer username'), '@CodeReviewbot');
-    await user.click(screen.getByRole('button', { name: /^Add$/ }));
+    await user.click(screen.getByRole('button', { name: 'Add reviewer username' }));
     expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ usernames: ['CodeReviewbot'] }));
   });
 

--- a/client/src/components/cos/TaskAddForm.jsx
+++ b/client/src/components/cos/TaskAddForm.jsx
@@ -23,8 +23,12 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   const [addToTop, setAddToTop] = useState(false);
   const [enhancePrompt, setEnhancePrompt] = useState(false);
   const [isEnhancing, setIsEnhancing] = useState(false);
-  const [useWorktree, setUseWorktree] = useState(false);
-  const [openPR, setOpenPR] = useState(false);
+  // Worktree + Open PR default ON: an isolated branch reviewed through a
+  // PR is the safe posture for agent work, so opting OUT is the deliberate act.
+  // An app that explicitly pins either flag false still wins — see the
+  // app-defaults effect below, which distinguishes absent from `false`.
+  const [useWorktree, setUseWorktree] = useState(true);
+  const [openPR, setOpenPR] = useState(true);
   const [simplify, setSimplify] = useState(true);
   // Hidden run-shape state, never a user-facing toggle: the slashdo catalog's
   // deliverable posture (#3636/#3651). `undefined` = the form pins no opinion,
@@ -141,7 +145,7 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
   // `apps` array reference) so periodic re-fetches in the parent don't
   // stomp manual checkbox toggles between renders.
   const appDefaultsSig = useMemo(() => selectedApp
-    ? `${selectedApp.id}|${!!selectedApp.defaultOpenPR}|${selectedApp.defaultPrCompletion || DEFAULT_PR_COMPLETION}|${!!selectedApp.defaultUseWorktree}|${!!selectedApp.jira?.enabled}`
+    ? `${selectedApp.id}|${String(selectedApp.defaultOpenPR)}|${selectedApp.defaultPrCompletion || DEFAULT_PR_COMPLETION}|${String(selectedApp.defaultUseWorktree)}|${!!selectedApp.jira?.enabled}`
     : `none:${newTask.app || ''}`,
     [selectedApp, newTask.app]
   );
@@ -155,8 +159,12 @@ export default function TaskAddForm({ providers, apps, onTaskAdded, compact = fa
       templateAppChangeRef.current = false;
       return;
     }
-    const defaultOpenPR = !!selectedApp?.defaultOpenPR;
-    const defaultUseWorktree = !!selectedApp?.defaultUseWorktree || defaultOpenPR;
+    // Absent (app never configured, or no app selected) falls back to the
+    // form's on-by-default posture; an explicit `false` on the app record is a
+    // deliberate opt-out and is honored.
+    const worktreeOptOut = selectedApp?.defaultUseWorktree === false;
+    const defaultOpenPR = selectedApp?.defaultOpenPR ?? !worktreeOptOut;
+    const defaultUseWorktree = (selectedApp?.defaultUseWorktree ?? true) || defaultOpenPR;
     setCreateJiraTicket(!!selectedApp?.jira?.enabled);
     setUseWorktree(defaultUseWorktree);
     setOpenPR(defaultOpenPR);

--- a/client/src/components/cos/TaskAddForm.test.jsx
+++ b/client/src/components/cos/TaskAddForm.test.jsx
@@ -19,6 +19,9 @@ const apiSystem = vi.hoisted(() => ({ getAssignableInstances: vi.fn() }));
 vi.mock('../../services/apiSystem', () => apiSystem);
 vi.mock('../../services/api', () => api);
 
+const worktreeToggle = () => screen.getByTitle(/isolated git worktree/i).closest('label').querySelector('input');
+const openPrToggle = () => screen.getByTitle(/Open a pull request/i).closest('label').querySelector('input');
+
 describe('TaskAddForm responsive layout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -80,7 +83,6 @@ describe('TaskAddForm responsive layout', () => {
 // means "turn it off" — collapsing the two would make a plain user template
 // silently clear toggles it never meant to touch.
 describe('TaskAddForm quick templates', () => {
-  const worktreeToggle = () => screen.getByTitle(/isolated git worktree/i).closest('label').querySelector('input');
   const openTemplates = async (user) => {
     await waitFor(() => expect(screen.getByText('Quick Templates')).toBeInTheDocument());
     await user.click(screen.getByText('Quick Templates'));
@@ -261,5 +263,63 @@ describe('TaskAddForm federated instance picker (#4520)', () => {
     await user.click(screen.getByRole('button', { name: /^Add$/ }));
     await waitFor(() => expect(api.addCosTask).toHaveBeenCalledTimes(2));
     expect(api.addCosTask.mock.calls[1][0].targetInstanceId).toBe(PEER);
+  });
+});
+
+// Worktree + Open PR ride ON by default so a queued task lands on a
+// branch behind a PR unless the user (or the app record) opts out.
+describe('TaskAddForm worktree/PR defaults', () => {
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    api.getCosPopularTemplates.mockResolvedValue({ templates: [] });
+    api.getCodeReviewDefaults.mockResolvedValue(null);
+    api.getLocalLlmStatus.mockResolvedValue({ ollama: { models: [] }, lmstudio: { models: [] } });
+    api.getProviders.mockResolvedValue({ providers: [] });
+    api.applyCosTaskTemplate.mockResolvedValue({ success: true });
+    apiSystem.getAssignableInstances.mockResolvedValue({ instances: [] });
+    api.addCosTask.mockResolvedValue({ success: true });
+  });
+
+  it('checks both toggles when no app pins a default, and submits them', async () => {
+    const user = userEvent.setup();
+    render(<TaskAddForm providers={[]} apps={[]} onTaskAdded={vi.fn()} />);
+
+    await waitFor(() => expect(worktreeToggle()).toBeChecked());
+    expect(openPrToggle()).toBeChecked();
+
+    await user.type(screen.getByPlaceholderText('Task description *'), 'Ship the change');
+    await user.click(screen.getByRole('button', { name: /^Add$/ }));
+    await waitFor(() => expect(api.addCosTask).toHaveBeenCalled());
+    expect(api.addCosTask.mock.calls[0][0]).toMatchObject({ useWorktree: true, openPR: true });
+  });
+
+  it('honors an app that explicitly opts out of both', async () => {
+    render(
+      <TaskAddForm
+        providers={[]}
+        apps={[{ id: 'example-app', name: 'Example App', repoPath: 'example.com/repo', defaultUseWorktree: false, defaultOpenPR: false }]}
+        defaultApp="example-app"
+        onTaskAdded={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(worktreeToggle()).not.toBeChecked());
+    expect(openPrToggle()).not.toBeChecked();
+  });
+
+  it('leaves the PR off for an app that pins only defaultUseWorktree:false', async () => {
+    render(
+      <TaskAddForm
+        providers={[]}
+        apps={[{ id: 'example-app', name: 'Example App', repoPath: 'example.com/repo', defaultUseWorktree: false }]}
+        defaultApp="example-app"
+        onTaskAdded={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(screen.getByPlaceholderText('Task description *')).toBeInTheDocument());
+    expect(worktreeToggle()).not.toBeChecked();
+    expect(openPrToggle()).not.toBeChecked();
   });
 });


### PR DESCRIPTION
## Summary

Queuing a task from the CoS Tasks form now defaults to **Worktree** and **Open PR** enabled, so the agent runs on an isolated branch behind a pull request unless someone deliberately opts out. Previously both toggles started off, which meant the common case committed straight to the default branch.

App-level configuration still wins. The form now distinguishes an **absent** `defaultUseWorktree` / `defaultOpenPR` on the app record (fall back to the new on-by-default posture) from an **explicit `false`** (a deliberate opt-out, honored) — the same absent-vs-empty rule the rest of the codebase uses. The app-defaults signature carries the tri-state via `String(...)` so an `undefined -> false` change still re-fires the effect instead of collapsing into the same signature.

One knock-on fix: with the reviewer section now rendering by default, the ReviewerPicker's username **Add** button collided with the form's submit button by accessible name. It gets an `aria-label="Add reviewer username"`, which both disambiguates the two and is the better a11y story for a `<Plus>`-icon button.

## Changes

- `client/src/components/cos/TaskAddForm.jsx` — initial state for `useWorktree` / `openPR` is `true`; the app-defaults effect resolves `?? true` for an absent app default and honors an explicit `false`; `appDefaultsSig` keeps the tri-state.
- `client/src/components/cos/ReviewerPicker.jsx` — `aria-label` on the add-username button.
- Tests: three new cases covering the no-app default, an app opting out of both, and an app pinning only `defaultUseWorktree: false`; the shared toggle query helpers are hoisted to module scope.

## Test plan

- `client/src/components/cos/TaskAddForm.test.jsx` — 13 passing; the new default-on case was verified to **fail** against the pre-change effect, so it actually pins the behavior.
- `client/src/components/cos/ReviewerPicker.test.jsx` — 62 passing.
- Full client suite: 725 files / 9262 tests passing.
- `biome lint --error-on-warnings` clean on the changed files; `vite build` succeeds.