### PR TITLE
probe Pixal3D's CUDA extensions in its install verify hook so a half-built setup stops reporting success

### DIFF
--- a/server/services/imageTo3d/adapters.js
+++ b/server/services/imageTo3d/adapters.js
@@ -196,11 +196,12 @@ export const TARGET_ADAPTERS = Object.freeze({
     async describeInstallState() {
       const probe = await probePixal3dModules();
       // A REQUIRED module missing means the install did not COMPLETE — `setup.sh` is
-      // sourced and can exit 0 with a failed extension build, and `installPixal3dCuda`'s
-      // `verify` hook only checks the interpreter and the entrypoint, never the compiled
-      // extensions. So this is the only place that can surface it: without this, a
-      // half-built install reads plain "Ready" and the first render dies deep in the GLB
-      // exporter as an unclassified failure.
+      // sourced and can exit 0 with a failed extension build. `installPixal3dCuda`'s
+      // `verify` hook now probes the same modules and warns as the install finishes, so
+      // this is the standing report of that state rather than the only one: a user who
+      // missed the install log must still not see a half-built install read plain
+      // "Ready" and then have the first render die deep in the GLB exporter as an
+      // unclassified failure.
       const incomplete = probe.missing?.length ? probe.missing : null;
       const nafFallback = probe.naf === 'unavailable';
       // An incomplete install outranks a NAF fallback — it is the more severe problem,

--- a/server/services/imageTo3d/pixal3dCuda.js
+++ b/server/services/imageTo3d/pixal3dCuda.js
@@ -53,6 +53,7 @@ import { cpus, homedir } from 'node:os';
 import { join } from 'node:path';
 import { spawn } from '../../lib/childProcess.js';
 import { resolveCondaEnvPython } from '../../lib/condaEnv.js';
+import { appendMissingModules } from './degradedInstall.js';
 import { rewriteGlbMaterialsOpaque } from './glbMaterials.js';
 import {
   hfGatedRepoHelp,
@@ -474,10 +475,18 @@ const CUDA_OOM_HELP = 'The GPU ran out of memory during this render. Close other
  * `detectCudaComputeCapability`) rather than probed here, keeping this function's
  * inputs explicit and its steps deterministic in tests.
  *
+ * **Post-install verification.** `setup.sh` is SOURCED and exits 0 even when a CUDA
+ * extension failed to compile, so the env and the checkout can both be on disk while
+ * `o_voxel` never built. After the presence check the install therefore runs the same
+ * module probe the card uses (`probeModules`, injectable so the suite never spawns a
+ * Python against the developer machine) and reports a half-built install BEFORE the
+ * terminal `complete` frame — otherwise a user watching the install finish sees a clean
+ * success and only learns it is incomplete on a later visit to the card (#4741).
+ *
  * @param {{base?: string, onEvent?: (ev: object) => void, spawnImpl?: Function,
  *          maxRetries?: number, sleep?: (ms: number) => Promise<void>,
  *          exists?: (p: string) => boolean, env?: NodeJS.ProcessEnv,
- *          computeCap?: string|null}} [opts]
+ *          computeCap?: string|null, probeModules?: Function}} [opts]
  * @returns {{promise: Promise<{ok: true}>, kill: () => void}}
  */
 export function installPixal3dCuda({
@@ -489,6 +498,7 @@ export function installPixal3dCuda({
   exists = existsSync,
   env,
   computeCap = null,
+  probeModules = probePixal3dModules,
 } = {}) {
   return runInstallSteps({
     steps: buildPixal3dInstallSteps(base, { exists, env, computeCap }),
@@ -502,7 +512,7 @@ export function installPixal3dCuda({
     env,
     // Steps can leave a usable env behind while a build failed, so confirm what
     // actually landed rather than trusting exit 0 (#2952's lesson).
-    verify: (emit) => {
+    verify: async (emit) => {
       if (!isPixal3dCudaInstalled({ base, exists, env })) {
         const err = new Error(
           `${LABEL} setup finished but its conda environment or the Pixal3D checkout is `
@@ -512,7 +522,26 @@ export function installPixal3dCuda({
         err.stage = 'verify';
         throw err;
       }
-      emit({ type: 'log', stage: 'verify', message: '✅ Pixal3D CUDA environment is present.' });
+      // Present ≠ complete. A missing REQUIRED extension is a `⚠️`, not a throw: the
+      // install genuinely produced a usable env for everything but the mesh exporter,
+      // and the card's Repair action is the remedy — failing the whole ~40 GB run would
+      // discard work the user can keep. Same reading, and the same precedence
+      // (incomplete outranks the NAF fallback), as the card's `describeInstallState`.
+      // A probe that could not RUN (`naf: 'unknown'`, nothing missing) still reports the
+      // clean line: "failed to determine" must never render as "determined to be bad".
+      const probe = await probeModules({ exists, env });
+      if (probe.missing?.length) {
+        emit({
+          type: 'log',
+          stage: 'verify',
+          message: `⚠️ ${appendMissingModules(PIXAL3D_INCOMPLETE_INSTALL_HELP, probe.missing)}`,
+        });
+      } else if (probe.naf === 'unavailable') {
+        // Nothing to name — NATTEN is absent as a whole, not half-built.
+        emit({ type: 'log', stage: 'verify', message: `⚠️ ${PIXAL3D_NAF_FALLBACK_HELP}` });
+      } else {
+        emit({ type: 'log', stage: 'verify', message: '✅ Pixal3D CUDA environment is present.' });
+      }
     },
   });
 }

--- a/server/services/imageTo3d/pixal3dCuda.test.js
+++ b/server/services/imageTo3d/pixal3dCuda.test.js
@@ -11,6 +11,7 @@ import {
   PIXAL3D_STANDARD_MODE_MIN_VRAM_GB,
   PIXAL3D_HIGH_RES_MIN_VRAM_GB,
   PIXAL3D_NAF_FALLBACK_HELP,
+  PIXAL3D_INCOMPLETE_INSTALL_HELP,
   pixal3dRoot,
   pixal3dRepoDir,
   pixal3dTrellisDir,
@@ -19,6 +20,7 @@ import {
   isPixal3dCudaInstalled,
   nattenWorkerCount,
   buildPixal3dInstallSteps,
+  installPixal3dCuda,
   buildPixal3dGenerateArgs,
   selectPixal3dRenderBudget,
   parsePixal3dProgress,
@@ -446,5 +448,102 @@ describe('runPixal3dCudaGenerate', () => {
     await flush();
     kill();
     expect(child.kill).toHaveBeenCalled();
+  });
+});
+
+describe('installPixal3dCuda verify hook', () => {
+  // Derived rather than hard-coded: with `INSTALLED` the conda env python is already
+  // there, so `conda create` self-skips — and a step added later must not break every
+  // test in this block.
+  const STEPS = buildPixal3dInstallSteps(BASE, { exists: INSTALLED, env: CONDA_ENV });
+
+  /** Advance the install by closing each step's child 0, in order. */
+  const closeEachStep = async (children) => {
+    for (const child of children) {
+      await flush();
+      child.emit('close', 0);
+    }
+  };
+
+  // `setup.sh` is SOURCED and exits 0 with a failed extension build, so the presence
+  // of the env and the checkout is not evidence the extensions compiled (#4761).
+  // `probeModules` is injected on EVERY call so the suite never spawns a Python.
+  const runToCompletion = async (probeModules) => {
+    const children = STEPS.map(() => makeChild());
+    let i = 0;
+    const events = [];
+    const { promise } = installPixal3dCuda({
+      base: BASE,
+      exists: INSTALLED,
+      env: CONDA_ENV,
+      spawnImpl: () => children[i++],
+      onEvent: (e) => events.push(e),
+      probeModules,
+    });
+    await closeEachStep(children);
+    await expect(promise).resolves.toEqual({ ok: true });
+    return events;
+  };
+
+  const verifyMessage = (events) => events.find((e) => e.stage === 'verify')?.message;
+
+  it('warns and names the culprit when a required CUDA extension never built', async () => {
+    const events = await runToCompletion(async () => ({ naf: 'available', missing: ['o_voxel'] }));
+    const message = verifyMessage(events);
+    expect(message).toContain('⚠️');
+    expect(message).toContain(PIXAL3D_INCOMPLETE_INSTALL_HELP);
+    expect(message).toContain('Missing: o_voxel.');
+    // A half-built install is repairable, not fatal — the ~40 GB of downloaded models
+    // stay usable, so the run must still finish green rather than throw.
+    expect(events.at(-1)).toMatchObject({ type: 'complete' });
+    expect(message).not.toContain('✅');
+  });
+
+  it('reports the milder NAF fallback when only NATTEN is absent', async () => {
+    const events = await runToCompletion(async () => ({
+      naf: 'unavailable', missing: [], help: PIXAL3D_NAF_FALLBACK_HELP,
+    }));
+    const message = verifyMessage(events);
+    expect(message).toBe(`⚠️ ${PIXAL3D_NAF_FALLBACK_HELP}`);
+    // Nothing is half-built here, so there is no module list to append.
+    expect(message).not.toContain('Missing:');
+  });
+
+  it('prefers the incomplete-install warning over the NAF fallback', async () => {
+    // Same precedence the card applies: one Repair fixes both, so report the worse one.
+    const events = await runToCompletion(async () => ({
+      naf: 'unavailable', missing: ['flex_gemm'], help: PIXAL3D_NAF_FALLBACK_HELP,
+    }));
+    expect(verifyMessage(events)).toContain(PIXAL3D_INCOMPLETE_INSTALL_HELP);
+    expect(verifyMessage(events)).not.toContain(PIXAL3D_NAF_FALLBACK_HELP);
+  });
+
+  it('keeps the clean line for a complete install', async () => {
+    const events = await runToCompletion(async () => ({ naf: 'available', missing: [] }));
+    expect(verifyMessage(events)).toBe('✅ Pixal3D CUDA environment is present.');
+  });
+
+  it('keeps the clean line when the probe itself could not run', async () => {
+    // "Failed to determine" must never render as "determined to be bad".
+    const events = await runToCompletion(async () => ({ naf: 'unknown', missing: [] }));
+    expect(verifyMessage(events)).toBe('✅ Pixal3D CUDA environment is present.');
+  });
+
+  it('never probes when the env or the checkout is missing outright', async () => {
+    const children = STEPS.map(() => makeChild());
+    let i = 0;
+    const probeModules = vi.fn();
+    // Conda python present (so the steps and the spawn count match the happy path) but
+    // no `inference.py` — the install is broken, not degraded, and must throw.
+    const { promise } = installPixal3dCuda({
+      base: BASE,
+      exists: existsFor(CONDA_PY),
+      env: CONDA_ENV,
+      spawnImpl: () => children[i++],
+      probeModules,
+    });
+    await closeEachStep(children);
+    await expect(promise).rejects.toMatchObject({ code: 'PIXAL3D_CUDA_INSTALL_INCOMPLETE' });
+    expect(probeModules).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Pixal3D's CUDA install `verify` hook only checked that the conda env and the checkout existed. `setup.sh` is *sourced* and exits 0 even when a CUDA extension failed to compile, so an install where `o_voxel` never built finished on `✅ Pixal3D CUDA environment is present.` and the user only learned it was incomplete when they came back to the target card.
- `verify` is now async and runs the same module probe the card uses (`probePixal3dModules`, injectable as `probeModules`), emitting one of three frames before the terminal `complete`:
  - `⚠️` + `PIXAL3D_INCOMPLETE_INSTALL_HELP` + `Missing: <modules>.` when a required extension is absent
  - `⚠️` + `PIXAL3D_NAF_FALLBACK_HELP` when only NATTEN is absent
  - the existing `✅` line for a clean install
- It **warns rather than throws**: the install genuinely produced a usable env for everything but the mesh exporter, and the card's Repair action is the remedy — failing the whole ~40 GB run would discard work the user can keep. Same precedence as `describeInstallState` (incomplete outranks the NAF fallback), and a probe that could not *run* (`naf: 'unknown'`) still gets the clean line, so "failed to determine" never renders as "determined to be bad".
- Mirrors what the TRELLIS.2 lane's verify hook already does for its Metal bake.
- Refreshed the now-stale comment in `adapters.js` that claimed the card was the only place able to surface a half-built install.

## Test plan

- New `installPixal3dCuda verify hook` block in `server/services/imageTo3d/pixal3dCuda.test.js` (6 cases): missing required module warns and names it while still completing green; NATTEN-only reports the milder fallback with no module list; incomplete outranks the NAF fallback; a clean probe keeps the `✅` line; an unrunnable probe also keeps it; and an env/checkout missing outright still throws `PIXAL3D_CUDA_INSTALL_INCOMPLETE` without probing.
- The probe is injected on every call, so no Python is spawned and no GPU/CUDA hardware is needed.
- Verified the three behavior-change cases fail against the pre-change hook.
- `cd server && npm test` — 1563 files, 32739 tests passing. No client changes.

Closes #4761
