### PR TITLE
deflake imageGenQuota bus tests by draining the handler instead of sleeping 20ms

### DIFF
--- a/server/services/imageGenQuota.js
+++ b/server/services/imageGenQuota.js
@@ -164,6 +164,16 @@ export async function recordImageGenOutcome({ mode, ok, error = '', at = Date.no
 
 let subscribed = false;
 
+// Single tail over every outcome the bus handlers have dispatched. An emitter
+// cannot await its listeners, so the handlers below are fire-and-forget and
+// nothing else can answer "has the render just announced on the bus actually
+// been written yet?". The recorder's write is real disk I/O — and on Windows
+// `atomicWrite` additionally sleeps between rename retries when the
+// destination is momentarily locked — so its latency is unbounded and a test
+// that sleeps a fixed number of milliseconds instead is a flake by
+// construction (#4788). Tests await this tail instead.
+let dispatched = Promise.resolve();
+
 /**
  * Subscribe the quota recorder to the image-generation bus. Called once at
  * boot from `initMediaJobDependentHooks`. Idempotent.
@@ -175,8 +185,10 @@ let subscribed = false;
 export function initImageGenQuotaHook() {
   if (subscribed) return;
   const note = (ok) => (payload) => {
-    recordImageGenOutcome({ mode: payload?.mode, ok, error: payload?.error })
+    // Already caught, so the tail below can never reject or go unhandled.
+    const recorded = recordImageGenOutcome({ mode: payload?.mode, ok, error: payload?.error })
       .catch((err) => console.error(`❌ Image-gen quota hook: ${err.message}`));
+    dispatched = dispatched.then(() => recorded);
   };
   imageGenEvents.on('completed', note(true));
   imageGenEvents.on('failed', note(false));
@@ -186,6 +198,21 @@ export function initImageGenQuotaHook() {
 /** Test-only: allow a suite to re-subscribe against fresh listeners. */
 export function __resetImageGenQuotaHookForTests() {
   subscribed = false;
+  dispatched = Promise.resolve();
+}
+
+/**
+ * Test-only: settle every render outcome the bus handlers have dispatched, so
+ * a suite can assert on the ledger the instant the recorder is done rather
+ * than guessing at a sleep. Loops until quiescent, so work a settling handler
+ * chains on is drained too.
+ */
+export async function __drainImageGenQuotaHookForTests() {
+  let seen;
+  do {
+    seen = dispatched;
+    await seen;
+  } while (dispatched !== seen);
 }
 
 /**

--- a/server/services/imageGenQuota.test.js
+++ b/server/services/imageGenQuota.test.js
@@ -17,6 +17,7 @@ const {
   isQuotaTrackedImageMode,
   initImageGenQuotaHook,
   __resetImageGenQuotaHookForTests,
+  __drainImageGenQuotaHookForTests,
 } = await import('./imageGenQuota.js');
 const { imageGenEvents } = await import('./imageGenEvents.js');
 const { checkFabrication } = await import('./imageGen/fabricationGuard.js');
@@ -140,12 +141,19 @@ describe('isQuotaTrackedImageMode', () => {
 describe('initImageGenQuotaHook', () => {
   // The recorder rides the imageGenEvents bus rather than provider finalizers,
   // so a backend that emits on the bus is tracked without touching its code.
-  const flush = () => new Promise((resolve) => setTimeout(resolve, 20));
+  // An emitter cannot await its listeners, so the assertions below have to wait
+  // for the recorder's write by asking the hook when it is done. Sleeping a
+  // fixed 20ms instead is what made this suite flake on the Windows runner
+  // (#4788): the write is real disk I/O, and `atomicWrite` sleeps between
+  // rename retries there when the destination is briefly locked, so it can
+  // easily outlast any constant a test picks.
+  const flush = () => __drainImageGenQuotaHookForTests();
 
   // The bus handler stamps its own `Date.now()`, so unlike the `getImageGenQuota`
   // suite below there is no `now` to thread in — freeze the clock instead.
-  // `shouldAdvanceTime` keeps `flush()`'s real 20ms timer working under the fake
-  // clock; without it the flush promise never settles and the test times out.
+  // `shouldAdvanceTime` keeps the real timers the write path itself may use
+  // (`atomicWrite`'s Windows rename-retry sleep) advancing under the fake clock;
+  // without it such a write would never settle and the drain would hang.
   beforeEach(() => {
     vi.useFakeTimers({ shouldAdvanceTime: true });
     vi.setSystemTime(FIXTURE_NOW);


### PR DESCRIPTION
## Summary

- `imageGenQuota`'s bus handlers are fire-and-forget (an `EventEmitter` cannot await its listeners), so the suite slept a fixed 20ms before asserting the persisted ledger. The recorder's write is real disk I/O, and on Windows `atomicWrite` additionally sleeps between rename retries when the destination is briefly locked — so the write can outlast any constant a test picks. That is the flake: `subscribes only once across repeated boots` failed with `expected 'No renders · 24h' to be '1 render · 24h'` on the Windows runner and passed on a same-SHA re-run.
- The hook now keeps a single promise tail over every outcome its handlers dispatched, and exposes `__drainImageGenQuotaHookForTests()` so the suite awaits the actual write instead of guessing at a duration. The drain loops until quiescent, so work a settling handler chains on is drained too.
- **Production behaviour is unchanged**: dispatch still happens immediately and is still fire-and-forget; the tail only records what was dispatched. The handler's existing `.catch` means the tail can never reject or go unhandled.
- Scope: this fixes only the named case's timing dependency. It does not touch the unrelated Windows-CI failures that have been red on `main` for other reasons.

## Test plan

- `npx vitest run services/imageGenQuota.test.js` — 32 passed, run 10× consecutively, green every time.
- **Not vacuous — bypass probe.** Temporarily removed the `if (subscribed) return;` guard in `initImageGenQuotaHook` (breaking the "subscribe once" invariant) and confirmed the test goes red with `expected '2 renders · 24h' to be '1 render · 24h'`. Restored.
- **Reproduced the reported failure.** Injected a 200ms artificial delay into `recordImageGenOutcome`: with the new drain all 32 tests still pass; with the old 20ms sleep restored, the suite fails with exactly the CI message `expected 'No renders · 24h' to be '1 render · 24h'`. Both probes removed before committing.
- Full server suite (`cd server && npm test`) run twice: 32,714 / 32,752 passing. The only failures were `services/imageTo3d/trellis2NormalBake.test.js` and `routes/settings.secretsStrip.test.js` hitting the known 10s timeout under full-suite load — a different pair each run, and both pass in isolation. Neither imports `imageGenQuota`.

Closes #4788
