### PR TITLE
make the "Measure this model" gate a routable sidebar instead of a modal

### DIFF
--- a/client/src/components/settings/LocalModelAssessments.jsx
+++ b/client/src/components/settings/LocalModelAssessments.jsx
@@ -214,7 +214,9 @@ function AssessmentDrawer({
       subtitle={target.modelId}
       size="md"
       // Closing IS stopping — the close button aborts the run in flight — so
-      // both accidental-dismissal paths are shut off while one is working.
+      // both accidental-dismissal paths are shut off while one is working, and
+      // the icon-only close button says what it will actually do.
+      closeLabel={running ? 'Stop the assessment' : 'Close'}
       closeOnEsc={!running}
       closeOnBackdrop={!running}
     >

--- a/client/src/components/settings/LocalModelAssessments.jsx
+++ b/client/src/components/settings/LocalModelAssessments.jsx
@@ -22,10 +22,11 @@
  * per-context table. PortOS never derives one unit from the other.
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Gauge, RefreshCw, Trash2, Play, AlertTriangle, History, SlidersHorizontal, ChevronDown, ChevronUp } from 'lucide-react';
+import { useSearchParams } from 'react-router';
 import socket from '../../services/socket';
-import Modal from '../ui/Modal';
+import Drawer from '../Drawer';
 import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
@@ -84,6 +85,15 @@ const compactTuning = (draft) => Object.fromEntries(
 // part of a row's identity — not decoration. Keying on model alone gave two
 // variants the same React key and made "discard" target the wrong record.
 const entryKey = (entry) => `${entry.backend}:${entry.modelId}@${entry.tuningKey || ''}`;
+
+// Which model the measure drawer has open lives in the URL, not in local state,
+// so the gate is shareable, bookmarkable and reload-safe — the same rule the
+// AI-provider editor follows at /ai/edit/:providerId. Search params rather than
+// a path segment because a model id is not one: it carries `/` and `:`
+// (`hf.co/org/repo:Q4_K_M`), and the drawer is an overlay on an already-routed
+// tab. `measureTuning` is the tuning key of the record being re-measured, so a
+// deep link reopens the configuration it describes rather than the defaults.
+const MEASURE_PARAMS = ['measureBackend', 'measureModel', 'measureTuning'];
 
 // `null` is NOT MEASURED and must render as such — never as 0, and never as a
 // dash the reader could mistake for "measured, none".
@@ -186,20 +196,49 @@ function TuningFields({ specs, draft, onChange, disabled }) {
 // Consent gate. PortOS never calls a provider the user didn't knowingly ask for,
 // so this names the exact backend, model, and generation count before the first
 // request goes out — the same contract as the POST drill cache's fill modal.
-function AssessmentConsentModal({
-  target, runtimeLabel, contextTokens, tuningSpecs, tuning, onTuningChange,
-  onCancel, onConfirm, running, progress,
+//
+// It is a routable slide-in rather than a modal: which model is open lives in
+// the URL, so the gate is shareable, bookmarkable and survives a reload — the
+// same pattern the AI-provider editor uses for /ai/edit/:providerId. The extra
+// width also lets the tuning knobs lay out as a real form instead of a cramped
+// column inside a dialog.
+function AssessmentDrawer({
+  target, reportLoaded, runtimeLabel, contextTokens, tuningSpecs, tuning, onTuningChange,
+  onClose, onConfirm, running, progress,
 }) {
   const [showTuning, setShowTuning] = useState(false);
   if (!target) return null;
   const tunedCount = Object.keys(compactTuning(tuning)).length;
+  // A link naming a model this report doesn't list — deleted since, or a
+  // hand-edited URL. The drawer still opens (the URL is what's open), it just
+  // says the row is gone rather than silently presenting a run that would fail.
+  // Held back while a run is in flight: the target legitimately moves between
+  // "not yet measured" and "ranked" the moment its first result lands.
+  const unknownTarget = reportLoaded && !target.resolved && !running;
   return (
-    <Modal open onClose={onCancel} size="sm" ariaLabel="Run local model assessment" closeOnBackdrop={!running}>
-      <div className="bg-port-card border border-port-border rounded-lg p-5 space-y-4">
+    <Drawer
+      open
+      onClose={onClose}
+      title="Measure this model"
+      subtitle={target.modelId}
+      size="md"
+      // Closing IS stopping — the close button aborts the run in flight — so
+      // both accidental-dismissal paths are shut off while one is working.
+      closeOnEsc={!running}
+      closeOnBackdrop={!running}
+    >
+      <div className="space-y-4">
         <div className="flex items-center gap-2">
           <Gauge size={18} className="text-port-accent" />
           <h3 className="text-white font-medium">Measure this model?</h3>
         </div>
+        {unknownTarget && (
+          <p className="text-xs text-port-warning flex items-start gap-1.5" role="alert">
+            <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+            This model is not in the current list — it may have been removed since the link was made.
+            Running it will still ask {runtimeLabel} for it.
+          </p>
+        )}
         <p className="text-sm text-gray-400">
           PortOS will run <span className="text-gray-200 font-mono break-all">{target.modelId}</span> on{' '}
           <span className="text-gray-200">{runtimeLabel}</span>{' '}
@@ -261,10 +300,10 @@ function AssessmentConsentModal({
         )}
         <div className="flex gap-3 pt-1">
           {/* Stays enabled while the run is in flight — it aborts the request
-              rather than merely closing the modal, so the user is never stuck
+              rather than merely closing the drawer, so the user is never stuck
               watching a multi-minute job they no longer want. */}
           <button
-            onClick={onCancel}
+            onClick={onClose}
             className="flex-1 px-4 py-2 bg-port-card border border-port-border hover:border-port-accent text-white text-sm font-medium rounded-lg transition-colors"
           >
             {running ? 'Stop' : 'Cancel'}
@@ -278,7 +317,7 @@ function AssessmentConsentModal({
           </button>
         </div>
       </div>
-    </Modal>
+    </Drawer>
   );
 }
 
@@ -500,10 +539,10 @@ export function LocalModelAssessments() {
   const [intent, setIntent] = useState('balanced');
   const [report, setReport] = useState(null);
   const [loading, setLoading] = useState(true);
-  const [pendingTarget, setPendingTarget] = useState(null);
-  // Tuning for the run being set up. Kept beside `pendingTarget` rather than
-  // inside the modal so re-measuring can pre-fill it from the existing record,
-  // and so it survives the collapse/expand of the tuning section.
+  // Tuning for the run being set up. Form state, so it stays local rather than
+  // riding in the URL — but it lives HERE rather than inside the drawer so
+  // re-measuring can pre-fill it from the record the URL names, and so it
+  // survives the collapse/expand of the tuning section.
   const [tuningDraft, setTuningDraft] = useState({});
   // Per-sample progress for the run in flight. `null` = no frame yet, which is
   // rendered as "no progress bar" rather than as 0 of N.
@@ -516,6 +555,34 @@ export function LocalModelAssessments() {
   // so there is only one place that renders it.
   const [tuningSweepRequest, setTuningSweepRequest] = useState(null);
 
+  const [searchParams, setSearchParams] = useSearchParams();
+  const measureBackend = searchParams.get('measureBackend') || '';
+  const measureModel = searchParams.get('measureModel') || '';
+  const measureTuning = searchParams.get('measureTuning') || '';
+
+  const openTarget = useCallback((entry) => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('measureBackend', entry.backend);
+      next.set('measureModel', entry.modelId);
+      // Absent, not empty: an untuned target and a target tuned to "" would
+      // otherwise resolve to the same row.
+      if (entry.tuningKey) next.set('measureTuning', entry.tuningKey);
+      else next.delete('measureTuning');
+      return next;
+    });
+  }, [setSearchParams]);
+
+  // `replace` so closing the drawer doesn't leave a Back button that reopens it
+  // on a run the user just cancelled.
+  const closeTarget = useCallback(() => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      for (const key of MEASURE_PARAMS) next.delete(key);
+      return next;
+    }, { replace: true });
+  }, [setSearchParams]);
+
   const load = useCallback(async (nextIntent) => {
     setLoading(true);
     // The panel owns its own empty/error rendering, so silence the default toast
@@ -526,6 +593,43 @@ export function LocalModelAssessments() {
   }, []);
 
   useEffect(() => { load(intent); }, [load, intent]);
+
+  // The row the URL names, once the report can say which one it is — that record
+  // is what carries the tuning a re-measure should start from. An id the report
+  // doesn't list still opens the drawer (the URL is the source of truth for
+  // what's open); it renders a "not in the current list" notice rather than
+  // bouncing, because the same id is legitimately absent for the moment between
+  // a first run landing and the refreshed report arriving.
+  const pendingTarget = useMemo(() => {
+    if (!measureBackend || !measureModel) return null;
+    const rows = [...(report?.ranked || []), ...(report?.excluded || []), ...(report?.unassessed || [])];
+    const match = rows.find((entry) => entry.backend === measureBackend
+      && entry.modelId === measureModel
+      && (entry.tuningKey || '') === measureTuning);
+    return match
+      ? { ...match, resolved: true }
+      : { backend: measureBackend, modelId: measureModel, tuningKey: measureTuning || undefined, resolved: false };
+  }, [report, measureBackend, measureModel, measureTuning]);
+
+  const pendingKey = pendingTarget ? entryKey(pendingTarget) : '';
+  // Which target the tuning form has already been seeded for. Seeding ONCE per
+  // target — not on every report refresh — is what keeps a half-typed knob from
+  // being overwritten by a background reload.
+  const seededTuningRef = useRef(null);
+  useEffect(() => {
+    if (!pendingTarget) {
+      seededTuningRef.current = null;
+      setTuningDraft({});
+      return;
+    }
+    // Re-measuring starts from the tuning that produced the existing record, so
+    // "run it again" reproduces the same configuration by default and adjusting
+    // one knob is a one-field edit. On a cold deep link that record only exists
+    // once the report lands, hence the wait.
+    if (!pendingTarget.resolved || seededTuningRef.current === pendingKey) return;
+    seededTuningRef.current = pendingKey;
+    setTuningDraft(pendingTarget.tuning && typeof pendingTarget.tuning === 'object' ? { ...pendingTarget.tuning } : {});
+  }, [pendingKey, pendingTarget]);
 
   // Which model this panel is currently measuring. A ref, not state: the socket
   // handler subscribes once and must read the CURRENT target, not the one
@@ -587,14 +691,17 @@ export function LocalModelAssessments() {
   }, { errorMessage: 'Assessment failed' });
 
   const confirmRun = async () => {
-    const target = { ...pendingTarget, tuning: compactTuning(tuningDraft) };
+    const target = {
+      backend: pendingTarget.backend,
+      modelId: pendingTarget.modelId,
+      tuning: compactTuning(tuningDraft),
+    };
     activeTargetRef.current = target;
     setProgress(null);
     const result = await runAssessment(target);
     activeTargetRef.current = null;
     setProgress(null);
-    setPendingTarget(null);
-    setTuningDraft({});
+    closeTarget();
     // An aborted run recorded nothing on either side, so there is no verdict to
     // report — marked `cancelled` by the abort catch above, or by the server
     // when it saw the signal drop mid-run.
@@ -635,20 +742,11 @@ export function LocalModelAssessments() {
 
   const cancelRun = () => {
     runControllerRef.current?.abort();
-    // Stop accepting frames for the abandoned run BEFORE the modal closes, or a
+    // Stop accepting frames for the abandoned run BEFORE the drawer closes, or a
     // late frame would repopulate a progress bar with nothing behind it.
     activeTargetRef.current = null;
     setProgress(null);
-    setPendingTarget(null);
-    setTuningDraft({});
-  };
-
-  // Re-measuring starts from the tuning that produced the existing record, so
-  // "run it again" reproduces the same configuration by default and adjusting
-  // one knob is a one-field edit rather than re-entering the whole set.
-  const openTarget = (entry) => {
-    setTuningDraft(entry?.tuning && typeof entry.tuning === 'object' ? { ...entry.tuning } : {});
-    setPendingTarget(entry);
+    closeTarget();
   };
 
   // Hands the model to the sweep panel's consent gate. The grid rides along so
@@ -834,8 +932,9 @@ export function LocalModelAssessments() {
         </>
       )}
 
-      <AssessmentConsentModal
+      <AssessmentDrawer
         target={pendingTarget}
+        reportLoaded={Boolean(report)}
         runtimeLabel={backendLabel(report, pendingTarget?.backend)}
         contextTokens={report?.defaultContextTokens || []}
         tuningSpecs={specsFor(report, pendingTarget?.backend)}
@@ -843,7 +942,7 @@ export function LocalModelAssessments() {
         onTuningChange={setTuningDraft}
         running={running}
         progress={progress}
-        onCancel={cancelRun}
+        onClose={cancelRun}
         onConfirm={confirmRun}
       />
     </div>

--- a/client/src/components/settings/LocalModelAssessments.jsx
+++ b/client/src/components/settings/LocalModelAssessments.jsx
@@ -24,13 +24,13 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Gauge, RefreshCw, Trash2, Play, AlertTriangle, History, SlidersHorizontal, ChevronDown, ChevronUp } from 'lucide-react';
-import { useSearchParams } from 'react-router';
 import socket from '../../services/socket';
 import Drawer from '../Drawer';
 import BrailleSpinner from '../BrailleSpinner';
 import toast from '../ui/Toast';
 import { useAsyncAction } from '../../hooks/useAsyncAction';
 import useMounted from '../../hooks/useMounted';
+import useUrlParams from '../../hooks/useUrlParams';
 import AssessmentSweepPanel from './AssessmentSweepPanel';
 import ModelThroughputReport from './ModelThroughputReport';
 import { formatContextTokens, formatDurationMs, throughputLabel } from '../../utils/formatters';
@@ -93,7 +93,7 @@ const entryKey = (entry) => `${entry.backend}:${entry.modelId}@${entry.tuningKey
 // (`hf.co/org/repo:Q4_K_M`), and the drawer is an overlay on an already-routed
 // tab. `measureTuning` is the tuning key of the record being re-measured, so a
 // deep link reopens the configuration it describes rather than the defaults.
-const MEASURE_PARAMS = ['measureBackend', 'measureModel', 'measureTuning'];
+const CLOSED_MEASURE_PARAMS = { measureBackend: null, measureModel: null, measureTuning: null };
 
 // `null` is NOT MEASURED and must render as such — never as 0, and never as a
 // dash the reader could mistake for "measured, none".
@@ -197,24 +197,15 @@ function TuningFields({ specs, draft, onChange, disabled }) {
 // so this names the exact backend, model, and generation count before the first
 // request goes out — the same contract as the POST drill cache's fill modal.
 //
-// It is a routable slide-in rather than a modal: which model is open lives in
-// the URL, so the gate is shareable, bookmarkable and survives a reload — the
-// same pattern the AI-provider editor uses for /ai/edit/:providerId. The extra
-// width also lets the tuning knobs lay out as a real form instead of a cramped
-// column inside a dialog.
+// Routable rather than modal — see CLOSED_MEASURE_PARAMS above for why the open
+// target lives in the URL.
 function AssessmentDrawer({
-  target, reportLoaded, runtimeLabel, contextTokens, tuningSpecs, tuning, onTuningChange,
+  target, unknownTarget, runtimeLabel, contextTokens, tuningSpecs, tuning, onTuningChange,
   onClose, onConfirm, running, progress,
 }) {
   const [showTuning, setShowTuning] = useState(false);
   if (!target) return null;
   const tunedCount = Object.keys(compactTuning(tuning)).length;
-  // A link naming a model this report doesn't list — deleted since, or a
-  // hand-edited URL. The drawer still opens (the URL is what's open), it just
-  // says the row is gone rather than silently presenting a run that would fail.
-  // Held back while a run is in flight: the target legitimately moves between
-  // "not yet measured" and "ranked" the moment its first result lands.
-  const unknownTarget = reportLoaded && !target.resolved && !running;
   return (
     <Drawer
       open
@@ -228,10 +219,6 @@ function AssessmentDrawer({
       closeOnBackdrop={!running}
     >
       <div className="space-y-4">
-        <div className="flex items-center gap-2">
-          <Gauge size={18} className="text-port-accent" />
-          <h3 className="text-white font-medium">Measure this model?</h3>
-        </div>
         {unknownTarget && (
           <p className="text-xs text-port-warning flex items-start gap-1.5" role="alert">
             <AlertTriangle size={12} className="mt-0.5 shrink-0" />
@@ -539,11 +526,13 @@ export function LocalModelAssessments() {
   const [intent, setIntent] = useState('balanced');
   const [report, setReport] = useState(null);
   const [loading, setLoading] = useState(true);
-  // Tuning for the run being set up. Form state, so it stays local rather than
-  // riding in the URL — but it lives HERE rather than inside the drawer so
-  // re-measuring can pre-fill it from the record the URL names, and so it
-  // survives the collapse/expand of the tuning section.
-  const [tuningDraft, setTuningDraft] = useState({});
+  // The knobs the user has typed, or `null` while they have typed nothing — in
+  // which case the form shows the tuning of the record the URL names, so
+  // re-measuring reproduces that configuration and adjusting one knob is a
+  // one-field edit. Deriving it (rather than seeding a state copy) is what lets
+  // a cold deep link pick the record up the moment the report lands, while a
+  // background refresh can never overwrite a half-typed value.
+  const [tuningEdits, setTuningEdits] = useState(null);
   // Per-sample progress for the run in flight. `null` = no frame yet, which is
   // rendered as "no progress bar" rather than as 0 of N.
   const [progress, setProgress] = useState(null);
@@ -555,33 +544,23 @@ export function LocalModelAssessments() {
   // so there is only one place that renders it.
   const [tuningSweepRequest, setTuningSweepRequest] = useState(null);
 
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams, updateParams] = useUrlParams();
   const measureBackend = searchParams.get('measureBackend') || '';
   const measureModel = searchParams.get('measureModel') || '';
   const measureTuning = searchParams.get('measureTuning') || '';
 
-  const openTarget = useCallback((entry) => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      next.set('measureBackend', entry.backend);
-      next.set('measureModel', entry.modelId);
-      // Absent, not empty: an untuned target and a target tuned to "" would
-      // otherwise resolve to the same row.
-      if (entry.tuningKey) next.set('measureTuning', entry.tuningKey);
-      else next.delete('measureTuning');
-      return next;
-    });
-  }, [setSearchParams]);
+  const openTarget = useCallback((entry) => updateParams({
+    measureBackend: entry.backend,
+    measureModel: entry.modelId,
+    measureTuning: entry.tuningKey || null,
+  }), [updateParams]);
 
   // `replace` so closing the drawer doesn't leave a Back button that reopens it
   // on a run the user just cancelled.
   const closeTarget = useCallback(() => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      for (const key of MEASURE_PARAMS) next.delete(key);
-      return next;
-    }, { replace: true });
-  }, [setSearchParams]);
+    updateParams(CLOSED_MEASURE_PARAMS, { replace: true });
+    setTuningEdits(null);
+  }, [updateParams]);
 
   const load = useCallback(async (nextIntent) => {
     setLoading(true);
@@ -595,41 +574,25 @@ export function LocalModelAssessments() {
   useEffect(() => { load(intent); }, [load, intent]);
 
   // The row the URL names, once the report can say which one it is — that record
-  // is what carries the tuning a re-measure should start from. An id the report
-  // doesn't list still opens the drawer (the URL is the source of truth for
-  // what's open); it renders a "not in the current list" notice rather than
-  // bouncing, because the same id is legitimately absent for the moment between
-  // a first run landing and the refreshed report arriving.
-  const pendingTarget = useMemo(() => {
+  // is what carries the tuning a re-measure starts from. Matched through
+  // `entryKey` so "the same measurement" has one definition, not two.
+  const measureMatch = useMemo(() => {
     if (!measureBackend || !measureModel) return null;
-    const rows = [...(report?.ranked || []), ...(report?.excluded || []), ...(report?.unassessed || [])];
-    const match = rows.find((entry) => entry.backend === measureBackend
-      && entry.modelId === measureModel
-      && (entry.tuningKey || '') === measureTuning);
-    return match
-      ? { ...match, resolved: true }
-      : { backend: measureBackend, modelId: measureModel, tuningKey: measureTuning || undefined, resolved: false };
+    const wanted = entryKey({ backend: measureBackend, modelId: measureModel, tuningKey: measureTuning });
+    const hit = (rows) => rows?.find((entry) => entryKey(entry) === wanted);
+    return hit(report?.ranked) || hit(report?.excluded) || hit(report?.unassessed) || null;
   }, [report, measureBackend, measureModel, measureTuning]);
 
-  const pendingKey = pendingTarget ? entryKey(pendingTarget) : '';
-  // Which target the tuning form has already been seeded for. Seeding ONCE per
-  // target — not on every report refresh — is what keeps a half-typed knob from
-  // being overwritten by a background reload.
-  const seededTuningRef = useRef(null);
-  useEffect(() => {
-    if (!pendingTarget) {
-      seededTuningRef.current = null;
-      setTuningDraft({});
-      return;
-    }
-    // Re-measuring starts from the tuning that produced the existing record, so
-    // "run it again" reproduces the same configuration by default and adjusting
-    // one knob is a one-field edit. On a cold deep link that record only exists
-    // once the report lands, hence the wait.
-    if (!pendingTarget.resolved || seededTuningRef.current === pendingKey) return;
-    seededTuningRef.current = pendingKey;
-    setTuningDraft(pendingTarget.tuning && typeof pendingTarget.tuning === 'object' ? { ...pendingTarget.tuning } : {});
-  }, [pendingKey, pendingTarget]);
+  // An id the report doesn't list still opens the drawer — the URL is the source
+  // of truth for what's open — and says so, rather than bouncing: the same id is
+  // legitimately absent for the moment between a first run landing and the
+  // refreshed report arriving, which is why the notice also stands down mid-run.
+  const pendingTarget = measureBackend && measureModel
+    ? measureMatch || { backend: measureBackend, modelId: measureModel, tuningKey: measureTuning }
+    : null;
+  const recordTuning = measureMatch?.tuning;
+  const tuningDraft = tuningEdits
+    ?? (recordTuning && typeof recordTuning === 'object' ? recordTuning : {});
 
   // Which model this panel is currently measuring. A ref, not state: the socket
   // handler subscribes once and must read the CURRENT target, not the one
@@ -934,12 +897,12 @@ export function LocalModelAssessments() {
 
       <AssessmentDrawer
         target={pendingTarget}
-        reportLoaded={Boolean(report)}
+        unknownTarget={Boolean(report) && !measureMatch && !running}
         runtimeLabel={backendLabel(report, pendingTarget?.backend)}
         contextTokens={report?.defaultContextTokens || []}
         tuningSpecs={specsFor(report, pendingTarget?.backend)}
         tuning={tuningDraft}
-        onTuningChange={setTuningDraft}
+        onTuningChange={setTuningEdits}
         running={running}
         progress={progress}
         onClose={cancelRun}

--- a/client/src/components/settings/LocalModelAssessments.test.jsx
+++ b/client/src/components/settings/LocalModelAssessments.test.jsx
@@ -269,8 +269,10 @@ describe('LocalModelAssessments', () => {
     getLocalLlmAssessments.mockResolvedValue(report({
       unassessed: [{ backend: 'ollama', modelId: 'example-model:7b', params: '7B' }],
     }));
-    // A run occupies the local provider for minutes; the modal's only exit must
-    // stay live and actually abort, not merely close over a job still running.
+    // A run occupies the local provider for minutes; every exit the drawer
+    // offers must stay live and actually abort, not merely close over a job
+    // still running — including the header's icon-only close button, which has
+    // to announce that it stops the run rather than "Close".
     let capturedSignal;
     runLocalLlmAssessment.mockImplementation((_payload, options) => {
       capturedSignal = options.signal;
@@ -282,9 +284,10 @@ describe('LocalModelAssessments', () => {
 
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(screen.getByRole('button', { name: /run assessment/i }));
-    await waitFor(() => expect(screen.getByRole('button', { name: /stop/i })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Stop' })).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Stop the assessment' })).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /stop/i }));
+    await user.click(screen.getByRole('button', { name: 'Stop' }));
     await waitFor(() => expect(capturedSignal.aborted).toBe(true));
     // The abort is what the user asked for — it must not surface as an error.
     expect(toast.error).not.toHaveBeenCalled();

--- a/client/src/components/settings/LocalModelAssessments.test.jsx
+++ b/client/src/components/settings/LocalModelAssessments.test.jsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter, useLocation } from 'react-router';
 
 vi.mock('../../services/api', () => ({
   getLocalLlmAssessments: vi.fn(),
@@ -28,6 +29,23 @@ import {
 import toast from '../ui/Toast';
 import socket from '../../services/socket';
 import LocalModelAssessments from './LocalModelAssessments.jsx';
+
+// The measure drawer's target lives in the URL, so every render needs a router.
+// `currentUrl()` reads back what the panel wrote, which is what the deep-link
+// tests assert on — the drawer being open is a property of the URL now, not of
+// component state.
+let location = null;
+function LocationProbe() {
+  location = useLocation();
+  return null;
+}
+const currentUrl = () => `${location.pathname}${location.search}`;
+const renderPanel = (initialEntry = '/models/performance') => render(
+  <MemoryRouter initialEntries={[initialEntry]}>
+    <LocalModelAssessments />
+    <LocationProbe />
+  </MemoryRouter>,
+);
 
 const report = (overrides = {}) => ({
   intent: 'balanced',
@@ -108,7 +126,7 @@ describe('LocalModelAssessments', () => {
   });
 
   it('loads persisted results on mount without triggering any model run', async () => {
-    render(<LocalModelAssessments />);
+    renderPanel();
     await waitFor(() => expect(getLocalLlmAssessments).toHaveBeenCalled());
     // The AI Provider Usage Policy boundary: mounting the panel must never
     // reach a provider.
@@ -117,7 +135,7 @@ describe('LocalModelAssessments', () => {
 
   it('renders measured numbers for a ranked model', async () => {
     getLocalLlmAssessments.mockResolvedValue(report({ ranked: [rankedEntry()] }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText('example-model:7b')).toBeInTheDocument();
     expect(screen.getByText('120 chars/s')).toBeInTheDocument();
     expect(screen.getByText('4K tokens')).toBeInTheDocument();
@@ -135,7 +153,7 @@ describe('LocalModelAssessments', () => {
         scores: { capability: 0.5, speed: null, fidelity: null, memory: null },
       })],
     }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     await screen.findByText('example-model:7b');
     expect(screen.getAllByText('not measured').length).toBeGreaterThanOrEqual(3);
     // An unmeasured axis renders as n/a, never as an empty bar that reads as 0.
@@ -148,7 +166,7 @@ describe('LocalModelAssessments', () => {
       unassessed: [{ backend: 'ollama', modelId: 'example-model:7b', params: '7B' }],
     }));
     runLocalLlmAssessment.mockResolvedValue({ verdict: 'fits' });
-    render(<LocalModelAssessments />);
+    renderPanel();
 
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     // Nothing has been sent yet — the click opens the ask, it does not run.
@@ -169,7 +187,7 @@ describe('LocalModelAssessments', () => {
     getLocalLlmAssessments.mockResolvedValue(report({
       unassessed: [{ backend: 'ollama', modelId: 'example-model:7b', params: '7B' }],
     }));
-    render(<LocalModelAssessments />);
+    renderPanel();
 
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(screen.getByRole('button', { name: /cancel/i }));
@@ -181,7 +199,7 @@ describe('LocalModelAssessments', () => {
     getLocalLlmAssessments.mockResolvedValue(report({
       unassessed: [{ backend: 'lmstudio', modelId: 'example-model:14b', params: '14B' }],
     }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText(/Not yet measured \(1\)/)).toBeInTheDocument();
     expect(screen.getByText(/not a mark against them/)).toBeInTheDocument();
   });
@@ -193,7 +211,7 @@ describe('LocalModelAssessments', () => {
       unassessed: [{ backend: 'ollama', modelId: 'example-model:7b', params: '7B' }],
     }));
     getLocalLlmAssessmentSweep.mockResolvedValue({ status: 'running', total: 4, completed: 1, current: null, results: [] });
-    render(<LocalModelAssessments />);
+    renderPanel();
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'Measure' })).toBeDisabled());
   });
@@ -202,7 +220,7 @@ describe('LocalModelAssessments', () => {
     const user = userEvent.setup();
     getLocalLlmAssessmentSweep.mockResolvedValue({ status: 'running', total: 2, completed: 1, current: null, results: [] });
     cancelLocalLlmAssessmentSweep.mockResolvedValue({ status: 'cancelled', total: 2, completed: 1, current: null, results: [] });
-    render(<LocalModelAssessments />);
+    renderPanel();
 
     await user.click(await screen.findByRole('button', { name: /stop sweep/i }));
     // Once for the mount, once because the queue's evidence just changed.
@@ -213,20 +231,20 @@ describe('LocalModelAssessments', () => {
     getLocalLlmAssessments.mockResolvedValue(report({
       ranked: [rankedEntry({ performance: { ...rankedEntry().performance, meanTokensPerSecond: 58.5, tokensEstimated: false } })],
     }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText(/58.5 tok\/s/)).toBeInTheDocument();
   });
 
   it('shows chars/s alone for a runtime that reported no token counts', async () => {
     getLocalLlmAssessments.mockResolvedValue(report({ ranked: [rankedEntry()] }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText('120 chars/s')).toBeInTheDocument();
     expect(screen.queryByText(/tok\/s/)).not.toBeInTheDocument();
   });
 
   it('refetches for the selected intent', async () => {
     const user = userEvent.setup();
-    render(<LocalModelAssessments />);
+    renderPanel();
     await waitFor(() => expect(getLocalLlmAssessments).toHaveBeenCalledWith('balanced', { silent: true }));
     await user.selectOptions(screen.getByLabelText('Rank for'), 'fastest');
     await waitFor(() => expect(getLocalLlmAssessments).toHaveBeenCalledWith('fastest', { silent: true }));
@@ -239,7 +257,7 @@ describe('LocalModelAssessments', () => {
       assessments: [{ backend: 'ollama', modelId: 'example-model:7b' }],
     }));
     deleteLocalLlmAssessment.mockResolvedValue({ success: true });
-    render(<LocalModelAssessments />);
+    renderPanel();
 
     await user.click(await screen.findByRole('button', { name: /discard the measurement/i }));
     await waitFor(() => expect(screen.getByText(/Not yet measured \(1\)/)).toBeInTheDocument());
@@ -260,7 +278,7 @@ describe('LocalModelAssessments', () => {
         options.signal.addEventListener('abort', () => reject(new Error('Server unreachable')));
       });
     });
-    render(<LocalModelAssessments />);
+    renderPanel();
 
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(screen.getByRole('button', { name: /run assessment/i }));
@@ -283,7 +301,7 @@ describe('LocalModelAssessments', () => {
       capturedSignal = options.signal;
       return new Promise(() => {});
     });
-    const { unmount } = render(<LocalModelAssessments />);
+    const { unmount } = renderPanel();
 
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(screen.getByRole('button', { name: /run assessment/i }));
@@ -297,7 +315,7 @@ describe('LocalModelAssessments', () => {
     getLocalLlmAssessments.mockResolvedValue(report({
       excluded: [{ backend: 'ollama', modelId: 'example-model:70b', verdict: 'does-not-fit', reason: 'out of memory' }],
     }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText('example-model:70b')).toBeInTheDocument();
     expect(screen.getByText('Does not fit')).toBeInTheDocument();
     expect(screen.getByText('out of memory')).toBeInTheDocument();
@@ -305,7 +323,7 @@ describe('LocalModelAssessments', () => {
 
   it('warns when a backend model list could not be read instead of implying it is empty', async () => {
     getLocalLlmAssessments.mockResolvedValue(report({ listErrors: ['lmstudio'] }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText(/Could not list installed models for LM Studio/)).toBeInTheDocument();
   });
 
@@ -321,7 +339,7 @@ describe('LocalModelAssessments', () => {
           },
         })],
       }));
-      render(<LocalModelAssessments />);
+      renderPanel();
 
       expect(await screen.findByText('stale')).toBeInTheDocument();
       expect(screen.getByText(/installed memory 32 → 64/)).toBeInTheDocument();
@@ -332,7 +350,7 @@ describe('LocalModelAssessments', () => {
       getLocalLlmAssessments.mockResolvedValue(report({
         ranked: [rankedEntry({ staleness: { comparable: true, stale: false, changes: [], description: null } })],
       }));
-      render(<LocalModelAssessments />);
+      renderPanel();
 
       await screen.findByText('example-model:7b');
       expect(screen.queryByText('stale')).not.toBeInTheDocument();
@@ -344,7 +362,7 @@ describe('LocalModelAssessments', () => {
       getLocalLlmAssessments.mockResolvedValue(report({
         ranked: [rankedEntry({ staleness: { comparable: false, stale: false, changes: [], description: null } })],
       }));
-      render(<LocalModelAssessments />);
+      renderPanel();
 
       await screen.findByText('example-model:7b');
       expect(screen.queryByText('stale')).not.toBeInTheDocument();
@@ -366,7 +384,7 @@ describe('LocalModelAssessments', () => {
       }));
       // Never resolves during the test — the run stays in flight so progress renders.
       runLocalLlmAssessment.mockImplementation(() => new Promise(() => {}));
-      render(<LocalModelAssessments />);
+      renderPanel();
       await user.click(await screen.findByRole('button', { name: 'Measure' }));
       await user.click(await screen.findByRole('button', { name: /run assessment/i }));
       return user;
@@ -400,7 +418,7 @@ describe('LocalModelAssessments', () => {
 
     it('unsubscribes on unmount so a late frame cannot update a dead panel', async () => {
       getLocalLlmAssessments.mockResolvedValue(report());
-      const { unmount } = render(<LocalModelAssessments />);
+      const { unmount } = renderPanel();
       await screen.findByText(/Nothing measured yet/);
       unmount();
       expect(socket.off).toHaveBeenCalledWith('localLlm:progress', expect.any(Function));
@@ -420,7 +438,7 @@ describe('LocalModelAssessments — runtimes', () => {
   });
 
   it('lists every assessable runtime from the report, not a hardcoded set', async () => {
-    render(<LocalModelAssessments />);
+    renderPanel();
     for (const label of ['Ollama', 'llama.cpp', 'MTPLX']) {
       expect(await screen.findByText(label)).toBeInTheDocument();
     }
@@ -429,7 +447,7 @@ describe('LocalModelAssessments — runtimes', () => {
   // A stopped daemon must not read as "0 models" — that says "nothing
   // installed" when the fix is to start it.
   it('shows an unreachable runtime as unreachable, never as zero models', async () => {
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText('unreachable')).toBeInTheDocument();
     expect(screen.getByText('1 model')).toBeInTheDocument();
     expect(screen.getByText('3 models')).toBeInTheDocument();
@@ -439,7 +457,7 @@ describe('LocalModelAssessments — runtimes', () => {
     getLocalLlmAssessments.mockResolvedValue(report({
       ranked: [rankedEntry({ backend: 'llama', modelId: 'dflash' })],
     }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText('dflash')).toBeInTheDocument();
     // Once in the roster, once on the row.
     expect(screen.getAllByText('llama.cpp').length).toBeGreaterThan(1);
@@ -458,7 +476,7 @@ describe('LocalModelAssessments — tuning', () => {
   it('sends the knobs the user set with the run', async () => {
     runLocalLlmAssessment.mockResolvedValue({ verdict: 'fits', tuningApplied: true });
     const user = userEvent.setup();
-    render(<LocalModelAssessments />);
+    renderPanel();
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(await screen.findByRole('button', { name: /Tuning/ }));
     await user.type(screen.getByLabelText('Micro-batch size'), '512');
@@ -474,7 +492,7 @@ describe('LocalModelAssessments — tuning', () => {
   it('omits an untouched knob rather than sending a zero', async () => {
     runLocalLlmAssessment.mockResolvedValue({ verdict: 'fits', tuningApplied: true });
     const user = userEvent.setup();
-    render(<LocalModelAssessments />);
+    renderPanel();
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(await screen.findByRole('button', { name: /Tuning/ }));
     await user.click(screen.getByRole('button', { name: 'Run assessment' }));
@@ -489,7 +507,7 @@ describe('LocalModelAssessments — tuning', () => {
   // sentence is derived server-side and rides on the spec.
   it('names the transport that carries each knob to the daemon', async () => {
     const user = userEvent.setup();
-    render(<LocalModelAssessments />);
+    renderPanel();
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(await screen.findByRole('button', { name: /Tuning/ }));
     expect(screen.getAllByText(/puts this on the server's launch line/).length).toBe(2);
@@ -500,7 +518,7 @@ describe('LocalModelAssessments — tuning', () => {
       unassessed: [{ backend: 'ollama', modelId: 'example-model:7b', params: null }],
     }));
     const user = userEvent.setup();
-    render(<LocalModelAssessments />);
+    renderPanel();
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(await screen.findByRole('button', { name: /Tuning/ }));
     expect(screen.getByText(/restarts the server with OLLAMA_CONTEXT_LENGTH set/)).toBeInTheDocument();
@@ -511,7 +529,7 @@ describe('LocalModelAssessments — tuning', () => {
       verdict: 'fits', tuningKey: 'ubatchSize=512', tuningApplied: false, tuningNotApplied: 'llama-server is not running',
     });
     const user = userEvent.setup();
-    render(<LocalModelAssessments />);
+    renderPanel();
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(screen.getByRole('button', { name: 'Run assessment' }));
     await waitFor(() => expect(toast.warning).toHaveBeenCalledWith(expect.stringMatching(/tuning not applied/)));
@@ -534,7 +552,7 @@ describe('LocalModelAssessments — tuning comparison', () => {
         ],
       }],
     }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText('Tuning comparison')).toBeInTheDocument();
     expect(screen.getByText('Micro-batch size 512')).toBeInTheDocument();
     expect(screen.getByText('75%')).toBeInTheDocument();
@@ -542,14 +560,14 @@ describe('LocalModelAssessments — tuning comparison', () => {
 
   it('renders nothing when no model has been measured under two tunings', async () => {
     getLocalLlmAssessments.mockResolvedValue(report());
-    render(<LocalModelAssessments />);
+    renderPanel();
     await screen.findByText('Ollama');
     expect(screen.queryByText('Tuning comparison')).toBeNull();
   });
 
   it('labels an untuned reading as backend defaults, not as a blank', async () => {
     getLocalLlmAssessments.mockResolvedValue(report({ ranked: [rankedEntry()] }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText('backend defaults')).toBeInTheDocument();
   });
 });
@@ -577,7 +595,7 @@ describe('LocalModelAssessments — one row per tuning', () => {
   });
 
   it('labels each variant by its own tuning, not all as backend defaults', async () => {
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText('Micro-batch size 512')).toBeInTheDocument();
     expect(screen.getByText('backend defaults')).toBeInTheDocument();
   });
@@ -585,7 +603,7 @@ describe('LocalModelAssessments — one row per tuning', () => {
   it('discards the tuning the row names, not the backend-defaults record', async () => {
     deleteLocalLlmAssessment.mockResolvedValue({ success: true });
     const user = userEvent.setup();
-    render(<LocalModelAssessments />);
+    renderPanel();
     const buttons = await screen.findAllByRole('button', { name: /Discard the measurement for dflash/ });
     // Ranked order puts the tuned row second (both score alike, tie broken on
     // tuning signature: '' sorts before 'ubatchSize=512').
@@ -599,7 +617,7 @@ describe('LocalModelAssessments — one row per tuning', () => {
   it('pre-fills a re-measure from the row\'s own tuning', async () => {
     runLocalLlmAssessment.mockResolvedValue({ verdict: 'fits', tuningApplied: true });
     const user = userEvent.setup();
-    render(<LocalModelAssessments />);
+    renderPanel();
     const remeasure = await screen.findAllByRole('button', { name: /Measure dflash again/ });
     await user.click(remeasure[1]);
     await user.click(await screen.findByRole('button', { name: 'Run assessment' }));
@@ -624,7 +642,7 @@ describe('LocalModelAssessments — one row per tuning', () => {
         reason: 'measured, but the requested tuning was not applied — llama-server is not running',
       }],
     }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText(/requested tuning was not applied/)).toBeInTheDocument();
   });
 
@@ -641,7 +659,7 @@ describe('LocalModelAssessments — one row per tuning', () => {
         reason: 'measured, but the daemon still carried an earlier tuning — Ollama would not stop',
       }],
     }));
-    render(<LocalModelAssessments />);
+    renderPanel();
     expect(await screen.findByText(/daemon still carried an earlier tuning/)).toBeInTheDocument();
   });
 });
@@ -658,7 +676,7 @@ describe('LocalModelAssessments — sweep tunings', () => {
   it('opens the tuning consent gate for the model whose button was pressed', async () => {
     const user = userEvent.setup();
     getLocalLlmAssessments.mockResolvedValue(report({ ranked: [llamaEntry()] }));
-    render(<LocalModelAssessments />);
+    renderPanel();
 
     await user.click(await screen.findByRole('button', { name: 'Sweep tunings for example-model.gguf' }));
 
@@ -673,7 +691,7 @@ describe('LocalModelAssessments — sweep tunings', () => {
   // page offers the action exactly where the server would accept it.
   it('offers no sweep for a runtime the server will not sweep', async () => {
     getLocalLlmAssessments.mockResolvedValue(report({ ranked: [rankedEntry()] }));
-    render(<LocalModelAssessments />);
+    renderPanel();
 
     await screen.findByText('example-model:7b');
     expect(screen.queryByRole('button', { name: /Sweep tunings for/ })).not.toBeInTheDocument();
@@ -683,7 +701,7 @@ describe('LocalModelAssessments — sweep tunings', () => {
     const user = userEvent.setup();
     getLocalLlmAssessments.mockResolvedValue(report({ ranked: [llamaEntry()] }));
     startLocalLlmAssessmentSweep.mockResolvedValue({ status: 'running', total: 3, completed: 0, results: [] });
-    render(<LocalModelAssessments />);
+    renderPanel();
 
     await user.click(await screen.findByRole('button', { name: 'Sweep tunings for example-model.gguf' }));
     await user.click(screen.getByRole('button', { name: /start sweep/i }));
@@ -700,8 +718,89 @@ describe('LocalModelAssessments — sweep tunings', () => {
     getLocalLlmAssessmentSweep.mockResolvedValue({
       status: 'running', total: 3, completed: 1, current: { backend: 'llama', modelId: 'example-model.gguf' }, results: [],
     });
-    render(<LocalModelAssessments />);
+    renderPanel();
 
     await waitFor(() => expect(screen.getByRole('button', { name: 'Sweep tunings for example-model.gguf' })).toBeDisabled());
+  });
+});
+
+// The measure gate is a routable drawer, not a modal: which model is open lives
+// in the URL, so it is shareable, bookmarkable, and survives a reload — the same
+// rule the AI-provider editor follows at /ai/edit/:providerId.
+describe('LocalModelAssessments — routable measure drawer', () => {
+  const tunedEntry = () => rankedEntry({
+    backend: 'llama',
+    modelId: 'dflash',
+    tuningKey: 'ubatchSize=512',
+    tuning: { ubatchSize: 512 },
+    tuningLabel: 'Micro-batch size 512',
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    idleSweep();
+    getLocalLlmAssessments.mockResolvedValue(report({
+      unassessed: [{ backend: 'ollama', modelId: 'example-model:7b', params: '7B' }],
+    }));
+  });
+
+  it('puts the model it opens on in the URL rather than local state', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: 'Measure' }));
+    await waitFor(() => expect(currentUrl()).toBe(
+      '/models/performance?measureBackend=ollama&measureModel=example-model%3A7b',
+    ));
+  });
+
+  it('opens straight from a deep link, with no click to get there', async () => {
+    renderPanel('/models/performance?measureBackend=ollama&measureModel=example-model%3A7b');
+
+    expect(await screen.findByRole('dialog', { name: 'Measure this model' })).toBeInTheDocument();
+    expect(screen.getByText(/512, 4K, 16K tokens of context/)).toBeInTheDocument();
+  });
+
+  // The tuning a re-measure starts from rides on the record the URL names, so a
+  // reloaded deep link has to resolve that record — not fall back to defaults.
+  it('seeds the tuning form from the record a deep link names', async () => {
+    getLocalLlmAssessments.mockResolvedValue(report({ ranked: [tunedEntry()] }));
+    runLocalLlmAssessment.mockResolvedValue({ verdict: 'fits', tuningApplied: true });
+    const user = userEvent.setup();
+    renderPanel('/models/performance?measureBackend=llama&measureModel=dflash&measureTuning=ubatchSize%3D512');
+
+    await user.click(await screen.findByRole('button', { name: 'Run assessment' }));
+    await waitFor(() => expect(runLocalLlmAssessment).toHaveBeenCalledWith(
+      expect.objectContaining({ tuning: { ubatchSize: 512 } }),
+      expect.anything(),
+    ));
+  });
+
+  // A link whose model the report no longer lists still opens — the URL is what
+  // is open — but it says the row is gone instead of presenting a run as normal.
+  it('says so when the model a link names is not in the current list', async () => {
+    renderPanel('/models/performance?measureBackend=ollama&measureModel=gone:7b');
+
+    expect(await screen.findByText(/not in the current list/)).toBeInTheDocument();
+  });
+
+  it('clears the URL when the drawer is dismissed', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: 'Measure' }));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    await waitFor(() => expect(currentUrl()).toBe('/models/performance'));
+    expect(runLocalLlmAssessment).not.toHaveBeenCalled();
+  });
+
+  it('clears the URL once a run lands', async () => {
+    runLocalLlmAssessment.mockResolvedValue({ verdict: 'fits' });
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: 'Measure' }));
+    await user.click(screen.getByRole('button', { name: 'Run assessment' }));
+    await waitFor(() => expect(currentUrl()).toBe('/models/performance'));
   });
 });

--- a/client/src/components/settings/LocalModelAssessments.test.jsx
+++ b/client/src/components/settings/LocalModelAssessments.test.jsx
@@ -171,7 +171,7 @@ describe('LocalModelAssessments', () => {
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     // Nothing has been sent yet — the click opens the ask, it does not run.
     expect(runLocalLlmAssessment).not.toHaveBeenCalled();
-    expect(screen.getByText(/Measure this model\?/)).toBeInTheDocument();
+    expect(screen.getByRole('dialog', { name: 'Measure this model' })).toBeInTheDocument();
     expect(screen.getByText(/3 times/)).toBeInTheDocument();
     expect(screen.getByText(/512, 4K, 16K tokens of context/)).toBeInTheDocument();
 
@@ -182,7 +182,7 @@ describe('LocalModelAssessments', () => {
     ));
   });
 
-  it('does not run when the consent modal is cancelled', async () => {
+  it('does not run when the consent drawer is cancelled', async () => {
     const user = userEvent.setup();
     getLocalLlmAssessments.mockResolvedValue(report({
       unassessed: [{ backend: 'ollama', modelId: 'example-model:7b', params: '7B' }],
@@ -192,7 +192,7 @@ describe('LocalModelAssessments', () => {
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(screen.getByRole('button', { name: /cancel/i }));
     expect(runLocalLlmAssessment).not.toHaveBeenCalled();
-    await waitFor(() => expect(screen.queryByText(/Measure this model\?/)).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 
   it('presents unmeasured models as an open question, not as a poor choice', async () => {


### PR DESCRIPTION
## Summary

- The **"Measure this model"** consent gate is now a routable `Drawer` instead of a `Modal`. Which model is open lives in the URL — `?measureBackend=&measureModel=&measureTuning=` on `/models/performance` — so the gate is shareable, bookmarkable and survives a reload, the same rule the AI-provider editor follows at `/ai/edit/:providerId`.
- **Search params, not a path segment**, because a model id is not one: it carries `/` and `:` (`hf.co/org/repo:Q4_K_M`), and the drawer is an overlay on an already-routed tab.
- The **consent contract is unchanged** — the gate still names the backend, model and generation count before any provider call, and closing it still aborts a run in flight.
- A deep link naming a record the report no longer lists **opens with a notice instead of bouncing** — the same id is legitimately absent for the moment between a first run landing and the refreshed report arriving.
- The tuning form is derived from the record the URL names, so a re-measure reproduces that configuration; a background report refresh can't overwrite a half-typed knob.
- The Drawer's icon-only close button now announces **"Stop the assessment"** while a run is in flight, rather than the primitive's default "Close settings".

Follow-up filed as #4803: the sibling per-model **Sweep tunings** gate is still a modal, so two consent gates on the same row now behave differently.

## Test plan

- `client` suite: `LocalModelAssessments.test.jsx` 48/48 — the 42 existing tests now render inside a `MemoryRouter`, plus 6 new ones covering the routable behavior (URL written on open, deep link opens with no click, tuning seeded from the record a link names, notice for an unlisted id, URL cleared on cancel and on a completed run).
- `client/src/components/settings/` + `Models.test.jsx` + `a11yConventions.test.js`: 311/311.
- Full client suite green; the two failures seen under parallel load (`Catalog.test.jsx`, `a11yConventions.test.js`) pass in isolation and are unrelated load flakes.
- `biome lint --error-on-warnings src`: clean.
