### PR TITLE
Let a model sweep reset only the runtimes it actually captured

### DIFF
--- a/server/services/localModelAssessmentSweep.js
+++ b/server/services/localModelAssessmentSweep.js
@@ -139,7 +139,7 @@ function snapshot() {
     // runtime is now serving the last variant's launch line and nothing else on
     // the page would say so. Separate from `error` so neither one lies.
     restoreError: sweep.restoreError || null,
-    // `launchState` is deliberately NOT exposed: it holds on-disk model paths,
+    // `launchStates` is deliberately NOT exposed: it holds on-disk model paths,
     // and the page has no use for the configuration being put back.
   };
 }
@@ -164,8 +164,7 @@ export function getSweepStatus() {
  * on the sweep's last variant, which is the thing this exists to prevent. It
  * waits, bounded, then restores anyway and lets the reason be reported.
  */
-async function restoreUnderClaim(run, backend, launchState = run.launchState) {
-  if (!launchState) return { restored: false, reason: 'nothing to restore' };
+async function restoreUnderClaim(backend, launchState) {
   const claim = await claimHeavyLocalJob({
     kind: 'local-model assessment',
     id: `${backend} launch restore`,
@@ -181,11 +180,18 @@ async function restoreUnderClaim(run, backend, launchState = run.launchState) {
   }
 }
 
-/** Restore every backend touched by a model or tuning sweep, one at a time. */
+/**
+ * Restore every backend touched by a model or tuning sweep, one at a time.
+ *
+ * Only CAPTURED backends are in the map, so every entry is a real restore —
+ * there is no "nothing to restore" here to mistake for a failure. Each is caught
+ * on its own: one runtime that will not come back must not leave the next one
+ * serving the sweep's launch line.
+ */
 async function restoreAllUnderClaim(run) {
   const failures = [];
-  for (const [backend, launchState] of Object.entries(run.launchStates || {})) {
-    const result = await restoreUnderClaim(run, backend, launchState)
+  for (const [backend, launchState] of Object.entries(run.launchStates)) {
+    const result = await restoreUnderClaim(backend, launchState)
       .catch((err) => ({ restored: false, reason: err?.message || 'restore failed' }));
     if (result?.restored === false) {
       failures.push(`${backend}: ${result.reason || 'the launch configuration could not be put back'}`);
@@ -259,7 +265,15 @@ async function runSweepLoop(run, targets, contextTokens, emit) {
     // KV / speculative flags while its record named only B's tuning (#4774).
     // Other endpoint runtimes have no sweep-safe reset/restore path, so they
     // remain ordinary model measurements.
-    const resetTuning = run.mode === 'tunings' || isTuningSweepable(target.backend);
+    //
+    // Gated on a CAPTURED configuration rather than on `isTuningSweepable`
+    // alone: a reset renders the cleared launch line, which wipes knobs the USER
+    // may have set on the LLMs page, and only a caller holding what was running
+    // there is entitled to do that. `beginSweep` captured every sweepable
+    // backend it could, so a runtime that could not be captured — llama-server
+    // stopped, or started outside PortOS — measures under what is running
+    // instead of losing flags nothing can put back.
+    const resetTuning = Boolean(run.launchStates[target.backend]);
     const result = await runAssessment({
       backend: target.backend,
       modelId: target.modelId,
@@ -408,17 +422,33 @@ async function beginSweep({ scope, backend, modelId, tunings, contextTokens, onP
   // llama daemon is machine-wide, so the one launch state has to be restored
   // after the whole queue, not after each model. Endpoint runtimes that cannot
   // reset safely are intentionally absent from this map.
+  //
+  // A backend whose capture comes back `null` is LEFT OUT rather than stored as
+  // null: the daemon is stopped or somebody else started it, so there is nothing
+  // to put back — and the loop reads presence here as its permission to reset.
   const restoreBackends = [...new Set(targets.map((target) => target.backend).filter(isTuningSweepable))];
   const launchStates = {};
   for (const restoreBackend of restoreBackends) {
     const state = await captureLaunchState(restoreBackend);
-    if (!state) {
-      return {
-        ...snapshot(),
-        rejected: `PortOS is not running ${restoreBackend}, so it cannot vary the launch configuration safely — start it from the LLMs page first`,
-      };
-    }
-    launchStates[restoreBackend] = state;
+    if (state) launchStates[restoreBackend] = state;
+  }
+  // Nothing to capture means the daemon is stopped, or someone else started it —
+  // either way PortOS cannot put a tuning on its launch line, so every variant
+  // would record `tuningApplied: false` and the comparison would rank a set of
+  // configurations that never ran. Refusing costs a click; running costs the
+  // whole sweep.
+  //
+  // Only a TUNING sweep refuses. Varying the launch line is its entire job, so
+  // an uncapturable runtime leaves it nothing to do — but a MODEL sweep is a
+  // queue of real measurements across every runtime the scope covers, and one
+  // llama-server somebody else started must not cancel the Ollama and LM Studio
+  // models alongside it. It measures that runtime under whatever is running, as
+  // it did before the reset existed.
+  if (grid && !launchStates[named.backend]) {
+    return {
+      ...snapshot(),
+      rejected: `PortOS is not running ${named.backend}, so it cannot vary the launch configuration — start it from the LLMs page first`,
+    };
   }
 
   const run = {
@@ -440,9 +470,6 @@ async function beginSweep({ scope, backend, modelId, tunings, contextTokens, onP
     // while it is false, so a cancelled sweep cannot relaunch the daemon
     // underneath the sweep that replaced it.
     settled: false,
-    // Kept as a compatibility alias for callers/tests that only ever had one
-    // tuning backend. The restore path uses the per-backend map above.
-    launchState: named ? launchStates[named.backend] || null : null,
     launchStates,
     controller: new AbortController(),
   };

--- a/server/services/localModelAssessmentSweep.test.js
+++ b/server/services/localModelAssessmentSweep.test.js
@@ -645,3 +645,123 @@ describe('startSweep — the tuning dimension', () => {
     expect(started.scope).toBeNull();
   });
 });
+
+// A MODEL sweep may reset a runtime only where it can put the launch line back,
+// and that permission is the CAPTURE, not the runtime's `sweepable` flag alone.
+// llama-server started outside PortOS captures nothing, and a sweep that reset
+// it anyway would clear flags the user chose with no record of what they were —
+// while refusing outright would cancel every Ollama and LM Studio model queued
+// alongside it.
+describe('startSweep — a model sweep across runtimes', () => {
+  const twoLlamaModels = () => getAssessmentReport.mockResolvedValue(report({
+    assessments: [
+      {
+        backend: 'llama', modelId: 'first', tuningKey: 'batchSize=4096', tuningLabel: 'batch 4096',
+        tuning: { batchSize: 4096 }, staleness: { stale: true },
+      },
+      {
+        backend: 'llama', modelId: 'second', tuningKey: 'ubatchSize=1024', tuningLabel: 'ubatch 1024',
+        tuning: { ubatchSize: 1024 }, staleness: { stale: true },
+      },
+    ],
+  }));
+
+  // The seam this module owns. What a reset then DOES — clear every sweepable
+  // knob the new tuning does not name — is `llamaServerManager`'s contract, and
+  // its own suite asserts the second launch line carries none of the first's.
+  it('gives each model the complete tuning its record names', async () => {
+    twoLlamaModels();
+    runAssessment.mockResolvedValue(measured());
+
+    await startSweep({ scope: 'stale' });
+    await settle();
+    expect(runAssessment.mock.calls.map(([args]) => args)).toMatchObject([
+      { modelId: 'first', tuning: { batchSize: 4096 }, resetTuning: true },
+      { modelId: 'second', tuning: { ubatchSize: 1024 }, resetTuning: true },
+    ]);
+  });
+
+  it('captures a runtime once for the whole queue, however many models it holds', async () => {
+    twoLlamaModels();
+    runAssessment.mockResolvedValue(measured());
+
+    await startSweep({ scope: 'stale' });
+    expect(captureLaunchState).toHaveBeenCalledTimes(1);
+    await settle();
+    expect(restoreLaunchState).toHaveBeenCalledTimes(1);
+    expect(restoreLaunchState).toHaveBeenCalledWith('llama', { model: '/models/example.gguf' });
+  });
+
+  it('resets only the sweepable runtimes in a mixed sweep', async () => {
+    getAssessmentReport.mockResolvedValue(report({
+      unassessed: [{ backend: 'llama', modelId: 'gguf' }, { backend: 'ollama', modelId: 'pulled' }],
+    }));
+    runAssessment.mockResolvedValue(measured());
+
+    await startSweep({ scope: 'unmeasured' });
+    await settle();
+    expect(captureLaunchState).toHaveBeenCalledWith('llama');
+    expect(captureLaunchState).not.toHaveBeenCalledWith('ollama');
+    expect(runAssessment.mock.calls.map(([args]) => args)).toMatchObject([
+      { backend: 'llama', resetTuning: true },
+      { backend: 'ollama', resetTuning: false },
+    ]);
+  });
+
+  // The regression this guards: refusing the whole queue over one runtime PortOS
+  // does not own throws away every measurement it could still have taken.
+  it('measures the rest of the queue when a runtime cannot be captured', async () => {
+    getAssessmentReport.mockResolvedValue(report({
+      unassessed: [{ backend: 'llama', modelId: 'gguf' }, { backend: 'ollama', modelId: 'pulled' }],
+    }));
+    captureLaunchState.mockResolvedValue(null);
+    runAssessment.mockResolvedValue(measured());
+
+    const started = await startSweep({ scope: 'unmeasured' });
+    expect(started.rejected).toBeUndefined();
+    expect(started.total).toBe(2);
+    await settle();
+    expect(getSweepStatus().results).toHaveLength(2);
+  });
+
+  // Nothing was captured, so nothing may be cleared — the measurement falls back
+  // to the behavior it had before the reset existed rather than wiping launch
+  // flags with no record of what they were.
+  it('never resets a runtime whose launch line it could not capture', async () => {
+    twoLlamaModels();
+    captureLaunchState.mockResolvedValue(null);
+    runAssessment.mockResolvedValue(measured());
+
+    await startSweep({ scope: 'stale' });
+    await settle();
+    for (const [args] of runAssessment.mock.calls) expect(args.resetTuning).toBe(false);
+    expect(restoreLaunchState).not.toHaveBeenCalled();
+    expect(getSweepStatus().restoreError).toBeNull();
+  });
+
+  // A TUNING sweep of the same uncapturable runtime still refuses — varying the
+  // launch line is its entire job, so it is left with nothing to do. That is
+  // "refuses when there is no launch configuration to vary" above; the asymmetry
+  // between the two sweeps is deliberate.
+
+  // Two runtimes can be left wrong at once, and one that will not come back must
+  // not strand the next — so the restores are caught individually and the reason
+  // names which runtime to go fix.
+  it('restores every captured runtime even when one of them throws', async () => {
+    getAssessmentReport.mockResolvedValue(report({
+      unassessed: [{ backend: 'llama', modelId: 'gguf' }, { backend: 'mtplx', modelId: 'mlx' }],
+    }));
+    isTuningSweepable.mockImplementation((backend) => backend === 'llama' || backend === 'mtplx');
+    captureLaunchState.mockImplementation(async (backend) => ({ model: `/models/${backend}.bin` }));
+    restoreLaunchState.mockImplementation(async (backend) => {
+      if (backend === 'llama') throw new Error('llama-server would not come back');
+      return { restored: true, reason: null };
+    });
+    runAssessment.mockResolvedValue(measured());
+
+    await startSweep({ scope: 'unmeasured' });
+    await settle();
+    expect(restoreLaunchState).toHaveBeenCalledWith('mtplx', { model: '/models/mtplx.bin' });
+    expect(getSweepStatus().restoreError).toBe('llama: llama-server would not come back');
+  });
+});


### PR DESCRIPTION
## Summary

**#4796 landed the mechanism this issue asked for while this branch was in flight.** It gave the model sweep the reset and the per-backend capture/restore — but it also made the sweep **refuse outright when any sweepable runtime's launch line cannot be captured**. `captureLlamaServerConfig` returns `null` whenever llama-server is stopped or was started outside PortOS, so one externally-started daemon now cancels every Ollama and LM Studio model queued alongside it, where before the sweep simply measured them. This PR rebases onto that work and closes the gap.

- **Gate the reset on having captured that runtime's launch line**, not on `isTuningSweepable` alone. A reset renders the *cleared* launch line, which wipes knobs the user set on the LLMs page — only a caller holding what was running there may do that, and an uncapturable runtime left nothing to put back.
- **A model sweep no longer refuses.** It measures an uncapturable runtime under whatever is running, exactly as it did before the reset existed, and keeps the rest of the queue.
- **A tuning sweep still refuses.** Varying the launch line is its entire job, so an uncapturable runtime leaves it nothing to do. The asymmetry is deliberate and now stated in the code.
- Drops the dead `run.launchState` compatibility alias and the unreachable `nothing to restore` branch in `restoreUnderClaim` — only captured backends reach the restore map.

Server-side only: `server/services/localModelAssessmentSweep.js` and its suite.

## Test plan

- `cd server && npx vitest run services/localModelAssessmentSweep.test.js` — 50 pass, including six new cases for the model-sweep dimension #4774 named: two llama targets each get the complete tuning its record names; one capture per runtime covers the whole queue; a mixed llama+Ollama sweep resets only llama; an uncapturable runtime measures the rest of the queue instead of refusing; it is never reset and reports no `restoreError`; a two-runtime restore where one daemon throws still brings the other back and names the failing one.
- What a reset then *does* — clear every sweepable knob the new tuning does not name — stays asserted in `server/services/llamaServerManager.test.js` ("clears the knobs a reset tuning does not name, so variants cannot accumulate").
- `cd server && npx vitest run` — full suite green (1564 files, 32773 tests).

Closes #4774
