### PR TITLE
make the per-model "Sweep tunings" consent gate a routable drawer

### DIFF
--- a/client/src/components/settings/AssessmentSweepPanel.jsx
+++ b/client/src/components/settings/AssessmentSweepPanel.jsx
@@ -22,7 +22,8 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { PlayCircle, Square, AlertTriangle, CheckCircle2, SlidersHorizontal } from 'lucide-react';
+import { PlayCircle, Square, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import Drawer from '../Drawer';
 import Modal from '../ui/Modal';
 import ProgressBar from '../ui/ProgressBar';
 import BrailleSpinner from '../BrailleSpinner';
@@ -55,44 +56,34 @@ const isRunning = (status) => status?.status === 'running';
 const measuredUnit = (status) => (status?.mode === 'tunings' ? 'tuning' : 'model');
 
 /**
- * The consent gate both sweeps share: the card, the heading, and the
- * Cancel/Start footer.
+ * The Cancel/Start footer both sweeps share.
  *
  * The AI Provider Usage Policy (root CLAUDE.md) demands the same three things of
  * either sweep — say what will run, say how many generations that is, and let
- * the user decline — so the parts that differ are only which middle the caller
- * fills in and which numbers it names. Two copies of this shell would drift, and
- * the half that drifted would be the half stating the cost.
+ * the user decline. The two gates differ in their container (the batch gate
+ * targets no record, so it stays a modal; the per-model gate is a routable
+ * drawer) and in the numbers they name, but never in the decision they offer.
+ * Two copies of these buttons would drift, and the half that drifted would be
+ * the half that decides whether hours of GPU start.
  */
-function SweepConsentShell({ icon, title, ariaLabel, children, onCancel, onConfirm, starting, confirmDisabled }) {
+function SweepConsentActions({ onCancel, onConfirm, starting, confirmDisabled }) {
   return (
-    <Modal open onClose={onCancel} size="sm" ariaLabel={ariaLabel}>
-      <div className="bg-port-card border border-port-border rounded-lg p-5 space-y-4">
-        <div className="flex items-center gap-2">
-          {icon}
-          <h3 className="text-white font-medium">{title}</h3>
-        </div>
-
-        {children}
-
-        <div className="flex gap-3 pt-1">
-          <button
-            onClick={onCancel}
-            disabled={starting}
-            className="flex-1 px-4 py-2 bg-port-card border border-port-border hover:border-port-accent text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          <button
-            onClick={onConfirm}
-            disabled={starting || confirmDisabled}
-            className="flex-1 px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-port-on-accent text-sm font-medium rounded-lg transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
-          >
-            {starting ? <><BrailleSpinner /> Starting…</> : <>Start sweep</>}
-          </button>
-        </div>
-      </div>
-    </Modal>
+    <div className="flex gap-3 pt-1">
+      <button
+        onClick={onCancel}
+        disabled={starting}
+        className="flex-1 px-4 py-2 bg-port-card border border-port-border hover:border-port-accent text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50"
+      >
+        Cancel
+      </button>
+      <button
+        onClick={onConfirm}
+        disabled={starting || confirmDisabled}
+        className="flex-1 px-4 py-2 bg-port-accent hover:bg-port-accent/80 text-port-on-accent text-sm font-medium rounded-lg transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
+      >
+        {starting ? <><BrailleSpinner /> Starting…</> : <>Start sweep</>}
+      </button>
+    </div>
   );
 }
 
@@ -101,20 +92,20 @@ function SweepConsentShell({ icon, title, ariaLabel, children, onCancel, onConfi
 // compute it the same way.
 const generationsFor = (count, contextTokens) => count * Math.max(1, contextTokens.length);
 
+// Stays a MODAL, deliberately: this gate targets no record — it is a scope
+// selector — so there is nothing to put in a URL and nothing a deep link could
+// usefully reopen.
 function SweepConsentModal({ scope, onScopeChange, counts, contextTokens, onCancel, onConfirm, starting }) {
   const count = counts?.[scope] ?? 0;
   const generations = generationsFor(count, contextTokens);
   return (
-    <SweepConsentShell
-      icon={<PlayCircle size={18} className="text-port-accent" />}
-      title="Measure every model?"
-      ariaLabel="Measure every local model"
-      starting={starting}
-      confirmDisabled={count === 0}
-      onCancel={onCancel}
-      onConfirm={onConfirm}
-    >
-      <>
+    <Modal open onClose={onCancel} size="sm" ariaLabel="Measure every local model">
+      <div className="bg-port-card border border-port-border rounded-lg p-5 space-y-4">
+        <div className="flex items-center gap-2">
+          <PlayCircle size={18} className="text-port-accent" />
+          <h3 className="text-white font-medium">Measure every model?</h3>
+        </div>
+
         <fieldset className="space-y-2">
           <legend className="text-xs text-gray-400 mb-1">What to measure</legend>
           {SCOPES.map((option) => {
@@ -153,8 +144,15 @@ function SweepConsentModal({ scope, onScopeChange, counts, contextTokens, onCanc
           this a job for overnight — expect several minutes per model. It keeps running with this tab closed,
           and you can stop it at any point; everything measured up to then is kept.
         </p>
-      </>
-    </SweepConsentShell>
+
+        <SweepConsentActions
+          starting={starting}
+          confirmDisabled={count === 0}
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+        />
+      </div>
+    </Modal>
   );
 }
 
@@ -165,24 +163,41 @@ function SweepConsentModal({ scope, onScopeChange, counts, contextTokens, onCanc
  * many variants, how many generations in total, and that the runtime is
  * restarted between each one, which is what makes a tuning sweep slower per
  * measurement than a model sweep.
+ *
+ * A routable Drawer rather than a modal: this gate targets one model, so which
+ * model it is open on belongs in the URL — shareable, bookmarkable, reload-safe,
+ * exactly like the "Measure this model" gate it sits beside. The caller owns
+ * those params; everything here is derived from the `target` it is handed.
  */
-function TuningSweepConsentModal({ target, contextTokens, onCancel, onConfirm, starting }) {
-  const variants = target.variants;
+function TuningSweepConsentDrawer({ target, contextTokens, onCancel, onConfirm, starting }) {
+  const variants = target.variants || [];
   const count = variants.length;
   const generations = generationsFor(count, contextTokens);
   return (
-    <SweepConsentShell
-      icon={<SlidersHorizontal size={18} className="text-port-accent" />}
-      title="Sweep tunings?"
-      ariaLabel={`Sweep tunings for ${target.modelId}`}
-      starting={starting}
-      // The baseline alone is one measurement with nothing to compare it to —
-      // the server refuses that, and the gate must not offer it either.
-      confirmDisabled={count < 2}
-      onCancel={onCancel}
-      onConfirm={onConfirm}
+    <Drawer
+      open
+      onClose={onCancel}
+      title="Sweep tunings"
+      subtitle={target.modelId}
+      size="sm"
+      // Dismissing mid-POST would drop the gate while the start request is still
+      // in flight, so both accidental paths are shut off for those few seconds.
+      closeOnEsc={!starting}
+      closeOnBackdrop={!starting}
+      closeLabel="Close"
     >
-      <>
+      <div className="space-y-4">
+        {/* A link whose model the report no longer lists still opens — the URL
+            is what is open — but it says the row is gone rather than presenting
+            hours of GPU as a normal next step. */}
+        {target.unknownTarget && (
+          <p className="text-xs text-port-warning flex items-start gap-1.5" role="alert">
+            <AlertTriangle size={12} className="mt-0.5 shrink-0" />
+            This model is not in the current list — it may have been removed since the link was made.
+            Sweeping it will still ask {target.runtimeLabel} for it.
+          </p>
+        )}
+
         <p className="text-sm text-gray-400">
           PortOS will measure <span className="text-gray-200 font-mono break-all">{target.modelId}</span> under{' '}
           <span className="text-gray-200">{count}</span> configuration{count === 1 ? '' : 's'} —{' '}
@@ -206,8 +221,17 @@ function TuningSweepConsentModal({ target, contextTokens, onCancel, onConfirm, s
           actually take effect — expect several minutes per configuration. It keeps running with this tab closed,
           and you can stop it at any point; everything measured up to then is kept and ranked.
         </p>
-      </>
-    </SweepConsentShell>
+
+        <SweepConsentActions
+          starting={starting}
+          // The baseline alone is one measurement with nothing to compare it to —
+          // the server refuses that, and the gate must not offer it either.
+          confirmDisabled={count < 2}
+          onCancel={onCancel}
+          onConfirm={onConfirm}
+        />
+      </div>
+    </Drawer>
   );
 }
 
@@ -254,11 +278,15 @@ function SweepResultRow({ result }) {
  * @param {(running: boolean) => void} [props.onRunningChange] lets the parent
  *   disable its own per-model Measure buttons while the queue holds the provider
  * @param {boolean} props.disabled a single-model run is already occupying the provider
- * @param {{backend:string, modelId:string, runtimeLabel:string, variants:Array<{key:string,label:string|null}>}|null} [props.tuningRequest]
+ * @param {{backend:string, modelId:string, runtimeLabel:string, variants:Array<{key:string,label:string|null}>, unknownTarget?:boolean}|null} [props.tuningRequest]
  *   a "sweep tunings" request raised elsewhere on the page — opens this panel's
- *   tuning consent gate. `null` closes it.
- * @param {() => void} [props.onTuningRequestClose] clears that request, whether
- *   it was confirmed or cancelled
+ *   routable tuning consent gate. `null` closes it. The caller derives the whole
+ *   object from the model pair it keeps in the URL plus the report, so
+ *   `unknownTarget` is how it says that pair names a model the report no longer
+ *   lists.
+ * @param {() => void} [props.onTuningRequestClose] clears that request — in
+ *   practice, drops the model pair from the URL — whether it was confirmed or
+ *   cancelled
  */
 export default function AssessmentSweepPanel({
   counts, contextTokens = [], onSweepFinished, onRunningChange, disabled, tuningRequest, onTuningRequestClose,
@@ -515,7 +543,7 @@ export default function AssessmentSweepPanel({
       )}
 
       {tuningRequest && (
-        <TuningSweepConsentModal
+        <TuningSweepConsentDrawer
           target={tuningRequest}
           contextTokens={contextTokens}
           starting={startingTuning}

--- a/client/src/components/settings/AssessmentSweepPanel.test.jsx
+++ b/client/src/components/settings/AssessmentSweepPanel.test.jsx
@@ -207,7 +207,7 @@ describe('AssessmentSweepPanel — tuning sweep', () => {
   it('names the variant count, the generation count, and every configuration', async () => {
     renderPanel({ tuningRequest });
 
-    expect(await screen.findByText(/Sweep tunings\?/)).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: 'Sweep tunings' })).toBeInTheDocument();
     expect(startLocalLlmAssessmentSweep).not.toHaveBeenCalled();
     // 3 variants × 3 context lengths = 9 generations.
     expect(screen.getByText('3')).toBeInTheDocument();
@@ -260,6 +260,21 @@ describe('AssessmentSweepPanel — tuning sweep', () => {
   it('will not start a sweep with only the baseline in the grid', async () => {
     renderPanel({ tuningRequest: { ...tuningRequest, variants: [{ key: '', label: null }] } });
     expect(await screen.findByRole('button', { name: /start sweep/i })).toBeDisabled();
+  });
+
+  // The gate is routable, so its target can outlive the row it was opened from.
+  // A deep link to a model the report no longer lists still opens — the URL is
+  // what is open — but it says the row is gone rather than presenting hours of
+  // GPU as a normal next step.
+  it('says so when the model it was pointed at is not in the current list', async () => {
+    renderPanel({ tuningRequest: { ...tuningRequest, unknownTarget: true } });
+    expect(await screen.findByText(/not in the current list/)).toBeInTheDocument();
+  });
+
+  it('says nothing of the sort for a model the report still lists', async () => {
+    renderPanel({ tuningRequest });
+    await screen.findByRole('dialog', { name: 'Sweep tunings' });
+    expect(screen.queryByText(/not in the current list/)).not.toBeInTheDocument();
   });
 
   // Every step names the same model, so counting models — or printing the model
@@ -466,6 +481,6 @@ describe('AssessmentSweepPanel — tuning sweep', () => {
   it('shows no tuning gate until one is requested', async () => {
     renderPanel();
     await screen.findByRole('button', { name: 'Measure all models' });
-    expect(screen.queryByText(/Sweep tunings\?/)).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Sweep tunings' })).not.toBeInTheDocument();
   });
 });

--- a/client/src/components/settings/LocalModelAssessments.jsx
+++ b/client/src/components/settings/LocalModelAssessments.jsx
@@ -90,7 +90,12 @@ const compactTuning = (draft) => Object.fromEntries(
 // A model can hold several measurements, one per launch tuning, so the tuning is
 // part of a row's identity — not decoration. Keying on model alone gave two
 // variants the same React key and made "discard" target the wrong record.
-const entryKey = (entry) => `${entry.backend}:${entry.modelId}@${entry.tuningKey || ''}`;
+//
+// `modelKey` is the coarser identity a TUNING SWEEP works in: a sweep is what
+// measures the tunings, so it targets the model rather than one of its recorded
+// configurations.
+const modelKey = (entry) => `${entry.backend}:${entry.modelId}`;
+const entryKey = (entry) => `${modelKey(entry)}@${entry.tuningKey || ''}`;
 
 // Which model the measure drawer has open lives in the URL, not in local state,
 // so the gate is shareable, bookmarkable and reload-safe — the same rule the
@@ -100,6 +105,13 @@ const entryKey = (entry) => `${entry.backend}:${entry.modelId}@${entry.tuningKey
 // tab. `measureTuning` is the tuning key of the record being re-measured, so a
 // deep link reopens the configuration it describes rather than the defaults.
 const CLOSED_MEASURE_PARAMS = { measureBackend: null, measureModel: null, measureTuning: null };
+
+// Its neighbour on the same row — the per-model "Sweep tunings" gate — is
+// routable for the same reasons and by the same mechanism. It names no tuning:
+// the sweep is what measures the tunings, so the model is the whole target, and
+// everything else the gate shows (the runtime label, the grid it will run) is
+// derivable from that pair plus the report.
+const CLOSED_SWEEP_PARAMS = { sweepBackend: null, sweepModel: null };
 
 // `null` is NOT MEASURED and must render as such — never as 0, and never as a
 // dash the reader could mistake for "measured, none".
@@ -615,18 +627,21 @@ export function LocalModelAssessments() {
   // Whether the server-side sweep is working. Owned here rather than in the
   // sweep panel because it gates this panel's per-model buttons too.
   const [sweepRunning, setSweepRunning] = useState(false);
-  // A "sweep tunings" request handed to the sweep panel, which owns the consent
-  // gate and the progress for BOTH sweeps — there is only one server-side queue,
-  // so there is only one place that renders it.
-  const [tuningSweepRequest, setTuningSweepRequest] = useState(null);
   const [agentBenchmarkResults, setAgentBenchmarkResults] = useState({});
 
   const [searchParams, updateParams] = useUrlParams();
   const measureBackend = searchParams.get('measureBackend') || '';
   const measureModel = searchParams.get('measureModel') || '';
   const measureTuning = searchParams.get('measureTuning') || '';
+  const sweepBackend = searchParams.get('sweepBackend') || '';
+  const sweepModel = searchParams.get('sweepModel') || '';
 
+  // The two gates are alternatives, not siblings — both hold the provider, and
+  // only one is reachable by clicking. Each open therefore drops the other's
+  // params, so the URL never carries a target for a gate that is not on screen.
+  // (What GUARANTEES one drawer is the precedence rule further down, not this.)
   const openTarget = useCallback((entry) => updateParams({
+    ...CLOSED_SWEEP_PARAMS,
     measureBackend: entry.backend,
     measureModel: entry.modelId,
     measureTuning: entry.tuningKey || null,
@@ -638,6 +653,20 @@ export function LocalModelAssessments() {
     updateParams(CLOSED_MEASURE_PARAMS, { replace: true });
     setTuningEdits(null);
   }, [updateParams]);
+
+  // Names the model for the sweep panel's consent gate — that panel owns the
+  // gate and the progress for BOTH sweeps, because there is only one
+  // server-side queue and so only one place that may render a Stop button.
+  const openSweepTarget = useCallback((entry) => updateParams({
+    ...CLOSED_MEASURE_PARAMS,
+    sweepBackend: entry.backend,
+    sweepModel: entry.modelId,
+  }), [updateParams]);
+
+  const closeSweepTarget = useCallback(
+    () => updateParams(CLOSED_SWEEP_PARAMS, { replace: true }),
+    [updateParams],
+  );
 
   const load = useCallback(async (nextIntent) => {
     setLoading(true);
@@ -664,12 +693,40 @@ export function LocalModelAssessments() {
   // of truth for what's open — and says so, rather than bouncing: the same id is
   // legitimately absent for the moment between a first run landing and the
   // refreshed report arriving, which is why the notice also stands down mid-run.
-  const pendingTarget = measureBackend && measureModel
+  const measureOpen = Boolean(measureBackend && measureModel);
+  const pendingTarget = measureOpen
     ? measureMatch || { backend: measureBackend, modelId: measureModel, tuningKey: measureTuning }
     : null;
   const recordTuning = measureMatch?.tuning;
   const tuningDraft = tuningEdits
     ?? (recordTuning && typeof recordTuning === 'object' ? recordTuning : {});
+
+  // The row the sweep URL names. Matched through `modelKey`, not `entryKey`: a
+  // sweep varies the tuning, so a model with three recorded configurations is
+  // still one sweep target, not three.
+  const sweepMatch = useMemo(() => {
+    if (!sweepBackend || !sweepModel) return null;
+    const wanted = modelKey({ backend: sweepBackend, modelId: sweepModel });
+    const hit = (rows) => rows?.find((entry) => modelKey(entry) === wanted);
+    return hit(report?.ranked) || hit(report?.excluded) || hit(report?.unassessed) || null;
+  }, [report, sweepBackend, sweepModel]);
+
+  // The whole gate payload, derived from the pair in the URL plus the report —
+  // the runtime label and the grid are the server's own, never carried in the
+  // link. An id the report no longer lists still opens the gate (the URL is the
+  // source of truth for what's open) and says so, the same as the measure
+  // drawer; with no grid behind it, Start is already off anyway.
+  //
+  // The measure drawer wins when a hand-edited link names both: a Drawer assumes
+  // it is the only one open (one scroll lock, one focus trap), and the measure
+  // gate is the one that can be mid-run.
+  const tuningSweepRequest = useMemo(() => (sweepBackend && sweepModel && !measureOpen ? {
+    backend: sweepBackend,
+    modelId: sweepModel,
+    runtimeLabel: backendLabel(report, sweepBackend),
+    variants: gridFor(report, sweepBackend),
+    unknownTarget: Boolean(report) && !sweepMatch,
+  } : null), [report, sweepBackend, sweepModel, sweepMatch, measureOpen]);
 
   // Which model this panel is currently measuring. A ref, not state: the socket
   // handler subscribes once and must read the CURRENT target, not the one
@@ -800,16 +857,6 @@ export function LocalModelAssessments() {
     closeTarget();
   };
 
-  // Hands the model to the sweep panel's consent gate. The grid rides along so
-  // the modal can list what it is about to run — it is the server's own grid,
-  // shipped on the report, not a count derived here.
-  const requestTuningSweep = (entry) => setTuningSweepRequest({
-    backend: entry.backend,
-    modelId: entry.modelId,
-    runtimeLabel: backendLabel(report, entry.backend),
-    variants: gridFor(report, entry.backend),
-  });
-
   // A sweep holds the provider for hours. A single-model run started on top of
   // it would measure the contention between the two, so every per-model action
   // goes quiet while the queue is working.
@@ -874,7 +921,7 @@ export function LocalModelAssessments() {
         onRunningChange={setSweepRunning}
         onSweepFinished={() => load(intent)}
         tuningRequest={tuningSweepRequest}
-        onTuningRequestClose={() => setTuningSweepRequest(null)}
+        onTuningRequestClose={closeSweepTarget}
       />
 
       <div className="flex items-center gap-2 flex-wrap">
@@ -920,7 +967,7 @@ export function LocalModelAssessments() {
                   sweepVariants={gridFor(report, entry.backend).length}
                   onRemeasure={openTarget}
                   onDelete={removeAssessment}
-                  onSweepTunings={requestTuningSweep}
+                  onSweepTunings={openSweepTarget}
                 />
               ))}
             </div>
@@ -969,7 +1016,7 @@ export function LocalModelAssessments() {
               </p>
               <div className="space-y-1 pt-1">
                 {report.unassessed.map((entry) => (
-                  <div key={`${entry.backend}:${entry.modelId}`} className="flex items-center justify-between gap-2 text-xs">
+                  <div key={modelKey(entry)} className="flex items-center justify-between gap-2 text-xs">
                     <span className="text-gray-300 font-mono break-all min-w-0">
                       {entry.modelId}
                       <span className="text-gray-600 ml-2">{backendLabel(report, entry.backend)}</span>

--- a/client/src/components/settings/LocalModelAssessments.jsx
+++ b/client/src/components/settings/LocalModelAssessments.jsx
@@ -113,6 +113,11 @@ const CLOSED_MEASURE_PARAMS = { measureBackend: null, measureModel: null, measur
 // derivable from that pair plus the report.
 const CLOSED_SWEEP_PARAMS = { sweepBackend: null, sweepModel: null };
 
+// Dismissing either gate clears BOTH targets. Only a hand-edited link can name
+// both at once, and having one gate close straight into the other would read as
+// the dismissal not having worked.
+const CLOSED_GATE_PARAMS = { ...CLOSED_MEASURE_PARAMS, ...CLOSED_SWEEP_PARAMS };
+
 // `null` is NOT MEASURED and must render as such — never as 0, and never as a
 // dash the reader could mistake for "measured, none".
 const Measured = ({ value, suffix = '', digits = 0 }) =>
@@ -650,7 +655,7 @@ export function LocalModelAssessments() {
   // `replace` so closing the drawer doesn't leave a Back button that reopens it
   // on a run the user just cancelled.
   const closeTarget = useCallback(() => {
-    updateParams(CLOSED_MEASURE_PARAMS, { replace: true });
+    updateParams(CLOSED_GATE_PARAMS, { replace: true });
     setTuningEdits(null);
   }, [updateParams]);
 
@@ -664,7 +669,7 @@ export function LocalModelAssessments() {
   }), [updateParams]);
 
   const closeSweepTarget = useCallback(
-    () => updateParams(CLOSED_SWEEP_PARAMS, { replace: true }),
+    () => updateParams(CLOSED_GATE_PARAMS, { replace: true }),
     [updateParams],
   );
 
@@ -701,32 +706,32 @@ export function LocalModelAssessments() {
   const tuningDraft = tuningEdits
     ?? (recordTuning && typeof recordTuning === 'object' ? recordTuning : {});
 
-  // The row the sweep URL names. Matched through `modelKey`, not `entryKey`: a
-  // sweep varies the tuning, so a model with three recorded configurations is
-  // still one sweep target, not three.
-  const sweepMatch = useMemo(() => {
-    if (!sweepBackend || !sweepModel) return null;
-    const wanted = modelKey({ backend: sweepBackend, modelId: sweepModel });
-    const hit = (rows) => rows?.find((entry) => modelKey(entry) === wanted);
-    return hit(report?.ranked) || hit(report?.excluded) || hit(report?.unassessed) || null;
-  }, [report, sweepBackend, sweepModel]);
-
-  // The whole gate payload, derived from the pair in the URL plus the report —
-  // the runtime label and the grid are the server's own, never carried in the
-  // link. An id the report no longer lists still opens the gate (the URL is the
-  // source of truth for what's open) and says so, the same as the measure
-  // drawer; with no grid behind it, Start is already off anyway.
+  // The sweep gate's whole payload, derived from the model pair in the URL plus
+  // the report — the runtime label and the grid are the server's own, never
+  // carried in the link, so a shared link describes what would run TODAY.
+  //
+  // The row is matched through `modelKey`, not `entryKey`: a sweep varies the
+  // tuning, so a model with three recorded configurations is still one sweep
+  // target, not three. A pair the report no longer lists still opens the gate —
+  // the URL is the source of truth for what's open — and says so, the same as
+  // the measure drawer; with no grid behind it, Start is already off anyway.
   //
   // The measure drawer wins when a hand-edited link names both: a Drawer assumes
   // it is the only one open (one scroll lock, one focus trap), and the measure
   // gate is the one that can be mid-run.
-  const tuningSweepRequest = useMemo(() => (sweepBackend && sweepModel && !measureOpen ? {
-    backend: sweepBackend,
-    modelId: sweepModel,
-    runtimeLabel: backendLabel(report, sweepBackend),
-    variants: gridFor(report, sweepBackend),
-    unknownTarget: Boolean(report) && !sweepMatch,
-  } : null), [report, sweepBackend, sweepModel, sweepMatch, measureOpen]);
+  const tuningSweepRequest = useMemo(() => {
+    if (!sweepBackend || !sweepModel || measureOpen) return null;
+    const wanted = modelKey({ backend: sweepBackend, modelId: sweepModel });
+    const hit = (rows) => rows?.find((entry) => modelKey(entry) === wanted);
+    const listed = Boolean(hit(report?.ranked) || hit(report?.excluded) || hit(report?.unassessed));
+    return {
+      backend: sweepBackend,
+      modelId: sweepModel,
+      runtimeLabel: backendLabel(report, sweepBackend),
+      variants: gridFor(report, sweepBackend),
+      unknownTarget: Boolean(report) && !listed,
+    };
+  }, [report, sweepBackend, sweepModel, measureOpen]);
 
   // Which model this panel is currently measuring. A ref, not state: the socket
   // handler subscribes once and must read the CURRENT target, not the one

--- a/client/src/components/settings/LocalModelAssessments.test.jsx
+++ b/client/src/components/settings/LocalModelAssessments.test.jsx
@@ -913,6 +913,23 @@ describe('LocalModelAssessments — routable tuning-sweep drawer', () => {
     expect(screen.queryByRole('dialog', { name: 'Sweep tunings' })).not.toBeInTheDocument();
   });
 
+  // ...and dismissing the one on screen closes the page, rather than closing
+  // straight into the gate the same link also named — which would read as the
+  // dismissal not having worked.
+  it('dismisses both targets, not just the one on screen', async () => {
+    const user = userEvent.setup();
+    renderPanel(
+      '/models/performance?measureBackend=llama&measureModel=example-model.gguf'
+      + '&sweepBackend=llama&sweepModel=example-model.gguf',
+    );
+
+    await screen.findByRole('dialog', { name: 'Measure this model' });
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+    await waitFor(() => expect(currentUrl()).toBe('/models/performance'));
+    expect(screen.queryByRole('dialog', { name: 'Sweep tunings' })).not.toBeInTheDocument();
+  });
+
   // Opening one clears the other's params, so the URL never accumulates a target
   // for a gate that is not on screen.
   it('drops a stale measure target from the URL when the sweep gate opens', async () => {

--- a/client/src/components/settings/LocalModelAssessments.test.jsx
+++ b/client/src/components/settings/LocalModelAssessments.test.jsx
@@ -700,7 +700,7 @@ describe('LocalModelAssessments — sweep tunings', () => {
 
     await user.click(await screen.findByRole('button', { name: 'Sweep tunings for example-model.gguf' }));
 
-    expect(await screen.findByText(/Sweep tunings\?/)).toBeInTheDocument();
+    expect(await screen.findByRole('dialog', { name: 'Sweep tunings' })).toBeInTheDocument();
     // The grid the server shipped, not a count derived here.
     expect(screen.getByText('Micro-batch size 1024')).toBeInTheDocument();
     expect(screen.getByText('Flash attention on')).toBeInTheDocument();
@@ -822,5 +822,109 @@ describe('LocalModelAssessments — routable measure drawer', () => {
     await user.click(await screen.findByRole('button', { name: 'Measure' }));
     await user.click(screen.getByRole('button', { name: 'Run assessment' }));
     await waitFor(() => expect(currentUrl()).toBe('/models/performance'));
+  });
+});
+
+// The per-model "Sweep tunings" gate is routable for the same reasons as its
+// neighbour: it targets one model, so which model it is open on lives in the URL
+// rather than evaporating on a reload. Only the model pair rides in the link —
+// the runtime label and the grid are derived from the report, so a shared link
+// always describes what the server would actually run today.
+describe('LocalModelAssessments — routable tuning-sweep drawer', () => {
+  const llamaEntry = () => rankedEntry({ backend: 'llama', modelId: 'example-model.gguf' });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    idleSweep();
+    getLocalLlmAssessments.mockResolvedValue(report({ ranked: [llamaEntry()] }));
+  });
+
+  it('puts the model it opens on in the URL rather than local state', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: 'Sweep tunings for example-model.gguf' }));
+    await waitFor(() => expect(currentUrl()).toBe(
+      '/models/performance?sweepBackend=llama&sweepModel=example-model.gguf',
+    ));
+  });
+
+  it('opens straight from a deep link, with no click to get there', async () => {
+    renderPanel('/models/performance?sweepBackend=llama&sweepModel=example-model.gguf');
+
+    expect(await screen.findByRole('dialog', { name: 'Sweep tunings' })).toBeInTheDocument();
+    // The grid the server shipped for that runtime, resolved from the report —
+    // it was never in the link.
+    expect(screen.getByText('Micro-batch size 1024')).toBeInTheDocument();
+    expect(screen.getByText(/llama\.cpp is restarted between each one/)).toBeInTheDocument();
+    expect(startLocalLlmAssessmentSweep).not.toHaveBeenCalled();
+  });
+
+  // A sweep varies the tuning, so it targets the MODEL: a model with several
+  // recorded configurations is one sweep target, not one per row.
+  it('resolves a model whose only rows carry their own tunings', async () => {
+    getLocalLlmAssessments.mockResolvedValue(report({
+      ranked: [rankedEntry({
+        backend: 'llama', modelId: 'example-model.gguf', tuningKey: 'ubatchSize=1024', tuningLabel: 'Micro-batch size 1024',
+      })],
+    }));
+    renderPanel('/models/performance?sweepBackend=llama&sweepModel=example-model.gguf');
+
+    await screen.findByRole('dialog', { name: 'Sweep tunings' });
+    expect(screen.queryByText(/not in the current list/)).not.toBeInTheDocument();
+  });
+
+  it('says so when the model a link names is not in the current list', async () => {
+    renderPanel('/models/performance?sweepBackend=llama&sweepModel=gone.gguf');
+
+    expect(await screen.findByText(/not in the current list/)).toBeInTheDocument();
+  });
+
+  it('clears the URL when the gate is dismissed', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: 'Sweep tunings for example-model.gguf' }));
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+    await waitFor(() => expect(currentUrl()).toBe('/models/performance'));
+    expect(startLocalLlmAssessmentSweep).not.toHaveBeenCalled();
+  });
+
+  it('clears the URL once the sweep is queued', async () => {
+    const user = userEvent.setup();
+    startLocalLlmAssessmentSweep.mockResolvedValue({ status: 'running', total: 3, completed: 0, results: [] });
+    renderPanel();
+
+    await user.click(await screen.findByRole('button', { name: 'Sweep tunings for example-model.gguf' }));
+    await user.click(screen.getByRole('button', { name: /start sweep/i }));
+    await waitFor(() => expect(currentUrl()).toBe('/models/performance'));
+  });
+
+  // A Drawer assumes it is the only one open — one scroll lock, one focus trap —
+  // so a hand-edited link naming both gates must resolve to exactly one panel,
+  // not stack two. The measure gate wins: it is the one that can be mid-run.
+  it('opens one drawer, not two, for a link that names both gates', async () => {
+    renderPanel(
+      '/models/performance?measureBackend=llama&measureModel=example-model.gguf'
+      + '&sweepBackend=llama&sweepModel=example-model.gguf',
+    );
+
+    expect(await screen.findByRole('dialog', { name: 'Measure this model' })).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', { name: 'Sweep tunings' })).not.toBeInTheDocument();
+  });
+
+  // Opening one clears the other's params, so the URL never accumulates a target
+  // for a gate that is not on screen.
+  it('drops a stale measure target from the URL when the sweep gate opens', async () => {
+    const user = userEvent.setup();
+    renderPanel('/models/performance?measureBackend=llama&measureModel=example-model.gguf');
+
+    await screen.findByRole('dialog', { name: 'Measure this model' });
+    await user.click(await screen.findByRole('button', { name: 'Sweep tunings for example-model.gguf' }));
+
+    await waitFor(() => expect(currentUrl()).toBe(
+      '/models/performance?sweepBackend=llama&sweepModel=example-model.gguf',
+    ));
+    expect(screen.queryByRole('dialog', { name: 'Measure this model' })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- The per-model **Sweep tunings** consent gate is now a routable `Drawer` keyed on `?sweepBackend=&sweepModel=` at `/models/performance`, matching its neighbour on the same row. Both per-model gates on a table row now behave the same way: shareable, bookmarkable, and reload-safe.
- Only the model pair rides in the link. The runtime label, the server's tuning grid, and the generation count are re-derived from the report on every render, so a shared link always describes what the server would actually run today rather than a snapshot baked into the URL.
- A link naming a model the report no longer lists still opens and says so, the same as the measure drawer — with no grid behind it, Start is already disabled.
- Sweep targets are matched by model, not by tuning record: a sweep is what *measures* the tunings, so a model with three recorded configurations is one sweep target. That coarser identity is now `modelKey`, with the existing `entryKey` built on top of it.
- Opening either gate clears the other's params, and dismissing either clears both — a hand-edited link naming both resolves to exactly one drawer (the measure gate, which is the one that can be mid-run), rather than stacking two.

The batch **Measure every model** gate stays a modal on purpose (per the issue's Out-of-scope note): it targets no record, just a scope, so there is nothing for a deep link to reopen. The consent shell the two gates shared shrinks to the Cancel/Start footer they still share.

## Test plan

- `cd client && npm test` — full jsdom suite green (731 files / 9338 tests).
- `cd client && npm run lint` — clean.
- New coverage in `LocalModelAssessments.test.jsx`: opening writes the pair to the URL; a deep link opens the gate with the server's grid and no click; a model whose only rows carry tunings still resolves; an unlisted model shows the notice; cancel and start both clear the URL; a link naming both gates opens one drawer; dismissing clears both targets.
- New coverage in `AssessmentSweepPanel.test.jsx`: the unknown-target notice appears for a stale target and stays absent for a listed one.
- Both new guards were bypass-probed — reverting the precedence check and the param clearing each turns the corresponding test red.

Closes #4803
