### PR TITLE
fix: give vLLM-backed OpenCode providers the generation controls they were silently dropping

### DIFF
--- a/client/src/utils/providers.js
+++ b/client/src/utils/providers.js
@@ -209,10 +209,12 @@ export const CURSOR_EFFORT_LEVELS = Object.freeze(['low', 'medium', 'high', 'xhi
 
 /**
  * True when an OpenCode process provider runs against one of the local
- * OpenAI-compatible backends (Ollama / MTPLX / llama.cpp / OrcaRouter) rather
- * than a vendor cloud model. MIRROR of `isOpencodeProvider(p) &&
+ * OpenAI-compatible backends (Ollama / MTPLX / llama.cpp / vLLM / OrcaRouter)
+ * rather than a vendor cloud model. MIRROR of `isOpencodeProvider(p) &&
  * getOpencodeLocalProviderNamespace(p)` in server/lib/providerModels.js, which
- * is exactly what gates the effort ladder there.
+ * is exactly what gates the effort ladder there — so a backend marker missing
+ * here hides the effort picker for a provider the server would happily forward
+ * `reasoningEffort` for (#4765).
  */
 export const isOpencodeLocalProvider = (provider) =>
   (['opencode', 'opencode-tui'].includes(String(provider?.id || '').toLowerCase())
@@ -220,6 +222,7 @@ export const isOpencodeLocalProvider = (provider) =>
   && (provider?.ollamaBacked === true
     || provider?.mtplxBacked === true
     || provider?.llamaBacked === true
+    || provider?.vllmBacked === true
     || provider?.orcarouterBacked === true);
 
 /**
@@ -993,11 +996,12 @@ export const isOrcaRouterBackedProvider = (provider) => provider?.orcarouterBack
  * Which default generation controls the provider editor should offer, or null
  * when the provider has none.
  *
- * Only the local OpenAI-compatible backends qualify — Ollama, llama.cpp and
- * MTPLX (reached directly as an `api` provider, or through an OpenCode CLI/TUI
- * wrapper), plus the OrcaRouter gateway. A hosted cloud provider is deliberately
- * excluded: PortOS sends it no sampling fields at all, so offering a stored
- * temperature there would be a control that silently does nothing.
+ * Only the local OpenAI-compatible backends qualify — Ollama, llama.cpp, MTPLX
+ * and vLLM (the first three reached directly as an `api` provider or through an
+ * OpenCode CLI/TUI wrapper; vLLM ships only the wrappers), plus the OrcaRouter
+ * gateway. A hosted cloud provider is deliberately excluded: PortOS sends it no
+ * sampling fields at all, so offering a stored temperature there would be a
+ * control that silently does nothing.
  *
  * Each control is reported separately because the forwarding is uneven:
  * OrcaRouter's upstream models own their own reasoning switch, so it has no
@@ -1015,7 +1019,8 @@ export const generationControlsFor = (provider) => {
   const orcarouter = isOrcaRouterBackedProvider(provider);
   const local = isOllamaBackedProvider(provider)
     || provider?.llamaBacked === true
-    || provider?.mtplxBacked === true;
+    || provider?.mtplxBacked === true
+    || provider?.vllmBacked === true;
   if (!local && !orcarouter) return null;
   if (commandBasename(provider?.command) === 'claude') {
     return { temperature: false, topP: false, thinking: true };

--- a/client/src/utils/providers.test.js
+++ b/client/src/utils/providers.test.js
@@ -128,6 +128,7 @@ describe('effortLevelsForProvider (server mirror)', () => {
     // to, so the ladder belongs to every local namespace, not just Ollama.
     ['OpenCode llama TUI', { id: 'opencode-llama-tui', command: 'opencode', llamaBacked: true }, ['low', 'medium', 'high']],
     ['OpenCode MTPLX', { id: 'opencode-mtplx', command: 'opencode', mtplxBacked: true }, ['low', 'medium', 'high']],
+    ['OpenCode vLLM TUI', { id: 'opencode-vllm-tui', command: 'opencode', vllmBacked: true }, ['low', 'medium', 'high']],
     ['OpenCode with no local backend', { id: 'opencode', command: 'opencode' }, null],
     ['grok (no effort control)', { id: 'grok-cli', command: 'grok' }, null],
     ['blank command is not claude', { id: 'ollama' }, null],
@@ -148,6 +149,11 @@ describe('generationControlsFor', () => {
   it.each([
     ['OpenCode llama TUI', { id: 'opencode-llama-tui', command: 'opencode', llamaBacked: true }, { temperature: true, topP: true, thinking: true }],
     ['OpenCode MTPLX', { id: 'opencode-mtplx', command: 'opencode', mtplxBacked: true }, { temperature: true, topP: true, thinking: true }],
+    // vLLM routes the thinking toggle through the chat template like the other
+    // two. Both sides were written before `vllmBacked` existed, so the editor
+    // hid the whole block while the server discarded every control anyway
+    // (#4765).
+    ['OpenCode vLLM TUI', { id: 'opencode-vllm-tui', command: 'opencode', vllmBacked: true }, { temperature: true, topP: true, thinking: true }],
     // A Claude harness on Ollama is forwarded only MAX_THINKING_TOKENS
     // (server/lib/cliChildEnv.js) — it owns its own sampling.
     ['Claude Ollama TUI', { id: 'claude-ollama-tui', command: 'claude', ollamaBacked: true }, { temperature: false, topP: false, thinking: true }],

--- a/docs/features/dflash2.md
+++ b/docs/features/dflash2.md
@@ -8,6 +8,8 @@ PortOS integrates both through the **OpenCode llama TUI** provider preset and th
 
 > **Which one to run:** `--spec-type draft-dspark` **merged into llama.cpp on 2026-07-28** ([#25173](https://github.com/ggml-org/llama.cpp/pull/25173)) and works on a stock `brew install llama.cpp`. DFlash 2's engine modules are **still an open PR** ([#27342](https://github.com/ggml-org/llama.cpp/pull/27342)) and need a from-source build of that branch. llama.cpp falls back **silently** on a spec-type/drafter mismatch rather than erroring, so a DFlash 2 drafter on a stock build degrades quietly. Start with DSpark unless you have built the DFlash 2 branch. Full comparison: [DSpark vs DFlash 2](../research/2026-08-19-dspark-vs-dflash2.md).
 
+> **On an NVIDIA RTX 3090?** There is a shorter path than building llama.cpp from a branch. Upstream froze a working DFlash 2 setup for that exact card — patched vLLM 0.27.1 plus a requantized Qwen3.8-27B, shipped as a Docker compose project — and PortOS fronts it with its own OpenCode presets. You get DFlash 2 drafting and prefix caching without vendoring an unmerged engine patch, at the cost of the container holding the whole 24 GB card. See [vLLM Qwen3.8-27B on an RTX 3090](./qwen38-rtx3090.md). It is CUDA-only: Apple Silicon stays on DSpark or [MTPLX](./mtplx.md).
+
 ---
 
 ## What PortOS Adds

--- a/docs/features/qwen38-rtx3090.md
+++ b/docs/features/qwen38-rtx3090.md
@@ -204,7 +204,22 @@ workload that fits.
 3. Click **Refresh Models**. The served model should appear; the seeded alias is
    `qwen3.8-27b`, so update the default model if your container publishes a
    different id.
-4. Assign the provider to a CoS agent task.
+4. Under **Generation Defaults** on the same card, set **thinking off** and
+   **temperature 0.7** (see below).
+5. Assign the provider to a CoS agent task.
+
+**Turn thinking off for agent work.** Qwen3.8's tool-call format is markedly more
+reliable with `enable_thinking: false`, and every measurement in the
+[bring-up record](../research/2026-08-21-qwen38-rtx3090-vllm.md) was taken that
+way. The provider card's **Generation Defaults** block is where you set it:
+PortOS emits the toggle as `chat_template_kwargs.enable_thinking` on the spawned
+OpenCode's `agent.build`, which is how vLLM takes it. Temperature ~0.7 is the
+matching default for coding work.
+
+Both controls ship **unset**, not pre-filled — an unset control means the
+container keeps its own chat-template default, which is not the same as being
+pinned to a value. So this is a step you take once per install, not something
+the preset does for you.
 
 The provider card's requirements checklist probes `:18020` directly. Its
 **Start** button runs `docker compose --profile single up -d` — but only when it

--- a/docs/research/2026-08-21-qwen38-rtx3090-vllm.md
+++ b/docs/research/2026-08-21-qwen38-rtx3090-vllm.md
@@ -22,6 +22,35 @@ Ubuntu on kernel 6.6.87.2, Docker Desktop 29.7.2 with the `nvidia` runtime,
 Compose v5.3.1. Image built locally (9.79 GB — there is no registry to pull
 from); weights ~19.5 GB into the project's `models/` bind mount.
 
+## The two serving profiles
+
+The stack is a frozen serving setup, not a model format, and it ships two
+compose profiles. `single-user/` is the one PortOS points at.
+
+| | `batch/` | `single-user/` (what CoS wants) |
+| --- | --- | --- |
+| For | many concurrent API requests | one or a few interactive clients |
+| Realistic chat | ~46 tok/s | MTP ~114, DFlash 2 ~122–133 |
+| Reproducing its own context (quoting / applying an edit) | ~46 tok/s | **up to 381 tok/s** (`SPEC=dflash2` + `DFLASH_TOKENS=15`) |
+| Context | 150k typical | 64k default (`CTX=fast`); 56k with `DFLASH_TOKENS=15`; 150k with `CTX=long` |
+| Trick | int8 tensor-core GEMMs + fp16 DeltaNet state | DFlash 2 block drafter + lookup-from-context + prefix cache |
+
+**The 381 tok/s headline is not ordinary chat.** It is a 25k-token document
+reproduction workload where 15 of 16 drafted tokens are accepted because the
+answer is already in the prompt. Upstream is explicit that ordinary chat is
+~133 tok/s and that the fast mode targets RAG, *coding assistants applying
+edits*, quoting/rewriting, and extraction — which is the CoS TUI shape (large
+files in context, patches written back).
+
+The context trade-off is why `DFLASH_TOKENS=15` is deliberately not a PortOS
+default: 56k across four slots is too tight for agent prompts carrying a repo's
+worth of files. Lookup drafting stays on either way.
+
+WSL2 on a 3090 is independently reproduced upstream (`docs/docker.md`):
+`single-fast` measured 114 tok/s greedy. Two WSL knobs are load-bearing there —
+`GPU_UTIL=0.93` when the free-memory gate fails, and
+`PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` on some Windows drivers.
+
 ## Measured
 
 Streaming `/v1/chat/completions`, greedy, `enable_thinking: false`, against a
@@ -97,9 +126,27 @@ only as `Killed` / exit 137. The download half is unaffected and resumes.
 `OPENCODE_CONFIG_CONTENT`, ran a three-step agent loop, and wrote a file with its
 write tool. The API key is enforced — unauthenticated `/v1/models` is 401.
 
+## Sources
+
+- [syv-ai/qwen38-27b-rtx3090](https://github.com/syv-ai/qwen38-27b-rtx3090) — the
+  frozen compose project this record brings up.
+- [upstream Docker / WSL2 notes](https://github.com/syv-ai/qwen38-27b-rtx3090/blob/main/docs/docker.md)
+  — the independent WSL2 reproduction and the `GPU_UTIL` / allocator knobs.
+- [X announcement](https://x.com/teksedge/status/2090595990114037832) and the
+  [LocalLLaMA thread](https://www.reddit.com/r/LocalLLaMA/comments/1vtup5s/) —
+  where the throughput numbers were first published and discussed.
+
 ## Related
 
 - [features/qwen38-rtx3090.md](../features/qwen38-rtx3090.md) — the setup guide.
 - [2026-08-19-dflash2-speculative-decoding.md](./2026-08-19-dflash2-speculative-decoding.md)
   — the earlier evaluation that concluded PortOS should not vendor an unmerged
-  engine patch. That still holds; this stack is upstream's frozen container.
+  engine patch. That still holds; this stack is upstream's frozen container, and
+  Ollama / LM Studio still cannot run DFlash 2 at all.
+- [2026-08-19-dspark-vs-dflash2.md](./2026-08-19-dspark-vs-dflash2.md) — why
+  Apple Silicon stays on DSpark / MTPLX rather than this path.
+- [2026-08-16-qwen38-mlx-macos.md](./2026-08-16-qwen38-mlx-macos.md) — the same
+  checkpoint on macOS via MLX.
+- [2026-08-05-torch-flux2-lora-cuda-validation.md](./2026-08-05-torch-flux2-lora-cuda-validation.md)
+  — the same class of Windows 3090 box for media generation, and why the card
+  cannot be shared with this container.

--- a/server/lib/aiToolkit/internal/generationOptions.js
+++ b/server/lib/aiToolkit/internal/generationOptions.js
@@ -23,12 +23,20 @@ const finiteNumber = (value, min, max) => {
 };
 
 /**
- * @param {{temperature?:unknown, topP?:unknown, thinking?:unknown, llamaBacked?:boolean, mtplxBacked?:boolean}|null|undefined} provider
+ * Every local backend marker belongs in the guard below. A missing one does not
+ * degrade to "no thinking toggle" — it returns `{}` and drops temperature and
+ * top_p with it, which is how the vLLM providers shipped with every generation
+ * control silently discarded on the OpenCode side (#4765).
+ *
+ * @param {{temperature?:unknown, topP?:unknown, thinking?:unknown, llamaBacked?:boolean, mtplxBacked?:boolean, vllmBacked?:boolean}|null|undefined} provider
  * @returns {{temperature?:number, top_p?:number, think?:boolean, chat_template_kwargs?:{enable_thinking:boolean}}}
  */
 export function apiGenerationOptions(provider) {
   const ollama = isOllamaBackedProvider(provider);
-  if (!ollama && provider?.llamaBacked !== true && provider?.mtplxBacked !== true) return {};
+  if (!ollama
+    && provider?.llamaBacked !== true
+    && provider?.mtplxBacked !== true
+    && provider?.vllmBacked !== true) return {};
   // Ollama API runs have defaulted to 0.6 since this control shipped; the other
   // local backends keep their own default until the user pins one.
   const temperature = finiteNumber(provider.temperature, 0, 2) ?? (ollama ? 0.6 : undefined);
@@ -36,8 +44,8 @@ export function apiGenerationOptions(provider) {
   return {
     ...(temperature === undefined ? {} : { temperature }),
     ...(topP === undefined ? {} : { top_p: topP }),
-    // Ollama takes its own native `think` boolean; llama.cpp / MTPLX route the
-    // toggle through the chat template instead.
+    // Ollama takes its own native `think` boolean; llama.cpp / MTPLX / vLLM
+    // route the toggle through the chat template instead.
     ...(typeof provider.thinking !== 'boolean'
       ? {}
       : ollama

--- a/server/lib/aiToolkit/runner.test.js
+++ b/server/lib/aiToolkit/runner.test.js
@@ -149,6 +149,29 @@ describe('AI Toolkit runner service', () => {
     expect(body.think).toBeUndefined();
   });
 
+  it('sends a vLLM endpoint its temperature/top_p and routes thinking through the chat template', async () => {
+    // No vLLM `api` preset ships (the container is reached through the OpenCode
+    // wrappers), but the guard here mirrors `generationControlsFor` on the
+    // client — which now offers the controls — so a hand-built endpoint record
+    // must not be the one place they are silently dropped again (#4765).
+    const dataDir = await mkdtemp(join(tmpdir(), 'ai-toolkit-runner-'));
+    tempDirs.push(dataDir);
+    const fetch = stubStreamingFetch();
+    const runner = createRunnerService({ dataDir, hooks: { ensureProviderReady: async () => ({ success: true }) } });
+    let done;
+    const completed = new Promise((resolve) => { done = resolve; });
+    await runner.executeApiRun({
+      runId: 'run-vllm-options',
+      provider: runReady({ id: 'vllm', endpoint: 'http://127.0.0.1:18020/v1', vllmBacked: true, temperature: 0.7, topP: 0.9, thinking: false }),
+      model: null, prompt: 'hi', workspacePath: process.cwd(), screenshots: [], onData: undefined, onComplete: () => done(),
+    });
+    await completed;
+
+    const body = JSON.parse(fetch.mock.calls[0][1].body);
+    expect(body).toMatchObject({ temperature: 0.7, top_p: 0.9, chat_template_kwargs: { enable_thinking: false } });
+    expect(body.think).toBeUndefined();
+  });
+
   it('sends a cloud provider no sampling fields at all', async () => {
     // Widening the editor must not start re-shaping hosted models' output.
     const dataDir = await mkdtemp(join(tmpdir(), 'ai-toolkit-runner-'));

--- a/server/lib/aiToolkit/validation.js
+++ b/server/lib/aiToolkit/validation.js
@@ -87,7 +87,7 @@ export const providerSchema = z.object({
   // prompts (e.g. a whole manuscript) aren't silently truncated. Null = unset.
   numCtx: z.number().int().min(512).max(1048576).nullable().optional(),
   // Default generation controls for the local OpenAI-compatible backends
-  // (Ollama, llama.cpp, MTPLX) and the OpenCode wrappers in front of them.
+  // (Ollama, llama.cpp, MTPLX, vLLM) and the OpenCode wrappers in front of them.
   // Provider-level so the same local model keeps its defaults across API, CLI,
   // and TUI launchers; a run may still override them per task.
   // All three are nullable, and null is the UI's "unset" — a backend that is

--- a/server/lib/opencodeConfig.js
+++ b/server/lib/opencodeConfig.js
@@ -115,17 +115,26 @@ export function toBareModelIds(models, providerKey = 'ollama') {
  * `temperature`, `topP` and `reasoningEffort` are portable — every daemon behind
  * these entries speaks the OpenAI chat-completions shape, so they are emitted
  * for all of them. The thinking toggle is NOT: Ollama takes its own native
- * `think` boolean, while a llama.cpp / MTPLX OpenAI endpoint routes it through
- * the chat template (`chat_template_kwargs.enable_thinking`). OrcaRouter fronts
- * cloud models that own their reasoning switch upstream, so it gets no toggle at
- * all and the editor hides the checkbox for it. MIRROR of
+ * `think` boolean, while a llama.cpp / MTPLX / vLLM OpenAI endpoint routes it
+ * through the chat template (`chat_template_kwargs.enable_thinking`). OrcaRouter
+ * fronts cloud models that own their reasoning switch upstream, so it gets no
+ * toggle at all and the editor hides the checkbox for it. MIRROR of
  * `generationControlsFor` in `client/src/utils/providers.js`; keep in lockstep.
- * @type {Record<'ollama'|'mtplx'|'llama'|'orcarouter', 'think'|'chatTemplate'|null>}
+ *
+ * A missing entry is not a missing checkbox — `buildAgentGeneration` bails on it
+ * and drops temperature / topP / reasoningEffort along with the toggle, which is
+ * how vLLM shipped with no generation controls at all (#4765). Every local
+ * runtime OpenCode can be pointed at needs a row here; `opencodeConfig.test.js`
+ * walks `LOCAL_RUNTIMES` to make a missing one fail.
+ * @type {Record<'ollama'|'mtplx'|'llama'|'vllm'|'orcarouter', 'think'|'chatTemplate'|null>}
  */
 const THINKING_STYLE = {
   ollama: 'think',
   mtplx: 'chatTemplate',
   llama: 'chatTemplate',
+  // vLLM routes it through the chat template exactly as MTPLX and llama.cpp do
+  // — see `server/services/voice/llm.js` for the same body shape on the HTTP side.
+  vllm: 'chatTemplate',
   orcarouter: null,
 };
 
@@ -153,7 +162,7 @@ const readBoolean = (value) =>
  * the provider.
  *
  * @param {{temperature?:unknown, topP?:unknown, thinking?:unknown, effort?:unknown}|null|undefined} generation
- * @param {'ollama'|'mtplx'|'llama'|'orcarouter'} providerKey
+ * @param {'ollama'|'mtplx'|'llama'|'vllm'|'orcarouter'} providerKey
  * @returns {object|null}
  */
 export function buildAgentGeneration(generation, providerKey) {

--- a/server/lib/opencodeConfig.test.js
+++ b/server/lib/opencodeConfig.test.js
@@ -1,10 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import {
+  buildAgentGeneration,
   buildOpencodeConfig,
   buildOpencodeConfigContent,
   buildOpencodeEnvVars,
+  opencodeLocalBaseUrl,
   toBareModelIds,
 } from './opencodeConfig.js';
+import { LOCAL_RUNTIMES } from './localProviderRuntime.js';
 
 describe('toBareModelIds', () => {
   it('strips the ollama/ namespace, drops empties, and dedupes', () => {
@@ -239,6 +242,31 @@ describe('buildOpencodeEnvVars', () => {
     expect(cfg.provider.vllm.models['qwen3.8-27b']).toEqual({ name: 'qwen3.8-27b', tool_call: true });
   });
 
+  it('sends vLLM its generation defaults, routing thinking through the chat template', () => {
+    // The container's own chat-template default applied instead until #4765:
+    // vLLM had no THINKING_STYLE row, so buildAgentGeneration bailed and dropped
+    // temperature and topP with it. `enable_thinking: false` + temperature 0.7
+    // is the documented posture for tool-calling agent work on this preset.
+    const result = buildOpencodeEnvVars(
+      { command: 'opencode', vllmBacked: true, models: [], temperature: 0.7, topP: 0.9, thinking: false, effort: 'high' },
+      'qwen3.8-27b',
+    );
+    const cfg = JSON.parse(result.OPENCODE_CONFIG_CONTENT);
+    expect(cfg.agent.build).toEqual({
+      temperature: 0.7,
+      topP: 0.9,
+      chat_template_kwargs: { enable_thinking: false },
+      reasoningEffort: 'high',
+    });
+  });
+
+  it('leaves a vLLM provider with no configured generation alone', () => {
+    // Only Ollama carries the historical 0.6 default; an unset control must stay
+    // unset so the container keeps its own.
+    const result = buildOpencodeEnvVars({ command: 'opencode', vllmBacked: true, models: [] }, 'qwen3.8-27b');
+    expect(JSON.parse(result.OPENCODE_CONFIG_CONTENT).agent).toBeUndefined();
+  });
+
   it("injects the vLLM container's API key into options.apiKey, and no ORCAROUTER_API_KEY", () => {
     const result = buildOpencodeEnvVars({
       command: 'opencode',
@@ -310,5 +338,27 @@ describe('buildOpencodeEnvVars', () => {
     const cfg = JSON.parse(buildOpencodeEnvVars(provider, null).OPENCODE_CONFIG_CONTENT);
     expect(cfg.provider.ollama.options.baseURL).toBe('http://localhost:11434/v1');
     expect(cfg.provider.ollama.models['qwen2.5:7b']).toBeDefined();
+  });
+});
+
+// A local runtime OpenCode can be pointed at but that has no THINKING_STYLE row
+// does not merely lose its thinking checkbox: `buildAgentGeneration` bails on
+// the missing key and returns null, taking temperature, topP and
+// reasoningEffort with it. That is how the seeded vLLM providers shipped with
+// every generation control silently discarded (#4765). Walk LOCAL_RUNTIMES so a
+// sixth runtime cannot land with the same hole.
+describe('every OpenCode-reachable local runtime forwards generation controls', () => {
+  // LM Studio is skipped deliberately — nothing spawns OpenCode against it, so
+  // it has no provider entry (and no base URL) in opencodeConfig's table.
+  const opencodeRuntimes = Object.keys(LOCAL_RUNTIMES).filter((id) => opencodeLocalBaseUrl(id));
+
+  it('actually walks the runtimes (a degenerate filter would pass vacuously)', () => {
+    expect(opencodeRuntimes).toContain('vllm');
+    expect(opencodeRuntimes.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it.each(opencodeRuntimes)('%s', (id) => {
+    expect(buildAgentGeneration({ temperature: 0.7, topP: 0.9, effort: 'high' }, id))
+      .toMatchObject({ temperature: 0.7, topP: 0.9, reasoningEffort: 'high' });
   });
 });


### PR DESCRIPTION
## Summary

The seeded OpenCode vLLM providers were the one local OpenAI-compatible runtime whose generation controls did nothing — temperature, top-p, thinking mode and reasoning effort were all silently discarded, and the editor rendered no controls to set in the first place.

- **`THINKING_STYLE` gains a `vllm: 'chatTemplate'` row.** A missing entry is not a missing checkbox: `buildAgentGeneration` bails on its `hasOwn` guard and returns `null`, so temperature, top-p and `reasoningEffort` went with the toggle. vLLM routes thinking through the chat template exactly as MTPLX and llama.cpp do.
- **The client mirrors gain the `vllmBacked` marker** — `generationControlsFor` (the Generation Defaults block) and `isOpencodeLocalProvider` (the reasoning-effort ladder). Both were written before `vllmBacked` existed; the second one was found by the new test table rather than reported.
- **`apiGenerationOptions` gains the same marker.** No vLLM `api` preset ships, but that guard mirrors the client's, so leaving one half narrower re-creates the bug the moment a record is hand-built.
- **No provider seed gains a `temperature` / `topP` / `thinking` value.** Unset stays unset — an unset control means the container keeps its own chat-template default, which is not the same as being pinned. What was missing is the capability, not a default.
- **A new guard walks `LOCAL_RUNTIMES`** and fails if a runtime OpenCode can be pointed at has no `THINKING_STYLE` entry, so a sixth one cannot land with the same hole.

Docs cleanup folded in from the same #4716 review:

- `dflash2.md` now points RTX 3090 readers at the container (it linked one way only).
- The bring-up record regains the upstream source links, the `batch/` vs `single-user/` profile comparison with its context trade-offs, and the cross-links to the sibling research notes — all lost when the doc was rewritten in place.
- The feature doc tells operators to set thinking off + temperature ~0.7 on the provider card, and why both ship unset.

## Test plan

- `cd server && npm test` — 32,746 passing. One pre-existing local failure, `routes/imageGen.multipart.test.js` (a 10s `beforeAll` hook timeout, unrelated to this diff); confirmed it fails identically with `origin/main`'s `server/` and `client/` checked out.
- `cd client && npm test` — 9,330 passing; `npm run lint` clean.
- Bypass-probed both new guards: removing the `vllm` row from `THINKING_STYLE` turns the `LOCAL_RUNTIMES` walk red, and removing `vllmBacked` from the `apiGenerationOptions` guard turns the new runner test red.

Closes #4765
