### PR TITLE
surface linked FableLoom branching narratives inside series management

### DIFF
--- a/client/src/components/pipeline/SeriesLoomsPanel.jsx
+++ b/client/src/components/pipeline/SeriesLoomsPanel.jsx
@@ -1,0 +1,121 @@
+/**
+ * SeriesLoomsPanel — the "Branching narratives" card on a series detail page.
+ *
+ * FableLoom looms are their own record type (`fableloom_stories`), not a series
+ * type: a scene graph has no linear stage chain, so the pipeline's issue/stage
+ * semantics never applied to it. The integration is a soft ref (`loom.seriesId`)
+ * surfaced here — the same posture `CatalogCastPanel` takes for catalog records.
+ *
+ * The create action mints the loom pre-linked to this series (and to the
+ * series' universe, so the AI lanes inherit its canon) and lands in the editor.
+ */
+
+import { useEffect, useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { Loader2, Plus, Waypoints } from 'lucide-react';
+import Pill from '../ui/Pill';
+import { useAsyncAction } from '../../hooks/useAsyncAction';
+import { timeAgo } from '../../utils/formatters';
+import { createLoom, listLooms } from '../../services/api';
+
+// Mirrors LOOM_LIMITS.NAME_MAX (server/services/fableLoom/limits.js) — the
+// derived name is built from the series name, which has its own longer cap, so
+// it has to be clamped before the create PATCH hits the door check.
+const LOOM_NAME_MAX = 200;
+
+const NEW_LOOM_SUFFIX = ' — branching narrative';
+
+export const deriveLoomName = (seriesName) => {
+  const base = String(seriesName || '').trim() || 'Untitled series';
+  return `${base}${NEW_LOOM_SUFFIX}`.slice(0, LOOM_NAME_MAX);
+};
+
+const countLabel = (n, noun) => `${n} ${noun}${n === 1 ? '' : 's'}`;
+
+export default function SeriesLoomsPanel({ series }) {
+  const navigate = useNavigate();
+  const seriesId = series?.id;
+  const [looms, setLooms] = useState(null);
+
+  useEffect(() => {
+    if (!seriesId) return undefined;
+    let canceled = false;
+    setLooms(null);
+    listLooms({ seriesId, silent: true })
+      .then((rows) => { if (!canceled) setLooms(Array.isArray(rows) ? rows : []); })
+      .catch(() => { if (!canceled) setLooms([]); });
+    return () => { canceled = true; };
+  }, [seriesId]);
+
+  const [runCreate, creating] = useAsyncAction(async () => {
+    const loom = await createLoom({
+      name: deriveLoomName(series?.name),
+      logline: series?.logline || '',
+      universeId: series?.universeId || null,
+      seriesId,
+    }, { silent: true });
+    navigate(`/fableloom/${loom.id}`);
+  }, { errorMessage: 'Could not create the branching narrative' });
+
+  if (!seriesId) return null;
+
+  return (
+    <section className="rounded-lg border border-port-border bg-port-card/40 p-3 space-y-3">
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div>
+          <h3 className="text-xs uppercase tracking-wider text-gray-500 flex items-center gap-1.5">
+            <Waypoints size={13} className="text-port-accent" aria-hidden="true" />
+            Branching narratives
+          </h3>
+          <p className="text-[11px] text-gray-600">
+            FableLoom looms linked to this series — scene graphs readers play through, alongside the linear episodes.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={runCreate}
+          disabled={creating}
+          className="inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded text-xs bg-port-accent/15 border border-port-accent/40 text-port-accent hover:bg-port-accent/25 disabled:opacity-50"
+        >
+          {creating
+            ? <Loader2 size={12} className="animate-spin" aria-hidden="true" />
+            : <Plus size={12} aria-hidden="true" />}
+          New branching narrative
+        </button>
+      </div>
+
+      {looms === null ? (
+        <div className="flex items-center gap-2 text-xs text-gray-500">
+          <Loader2 size={12} className="animate-spin" aria-hidden="true" />
+          Loading branching narratives…
+        </div>
+      ) : looms.length === 0 ? (
+        <p className="text-xs text-gray-600">
+          None yet. A branching narrative stays its own record — it just carries this series&apos; canon and shows up here.
+        </p>
+      ) : (
+        <ul className="grid gap-2 @md:grid-cols-2">
+          {looms.map((loom) => (
+            <li key={loom.id}>
+              <Link
+                to={`/fableloom/${loom.id}`}
+                className="block rounded border border-port-border bg-port-card p-2.5 hover:border-port-accent transition-colors"
+              >
+                <div className="text-sm text-white truncate">{loom.name}</div>
+                {loom.logline ? (
+                  <div className="text-[11px] text-gray-500 mt-0.5 line-clamp-2">{loom.logline}</div>
+                ) : null}
+                <div className="flex items-center gap-1.5 mt-2 flex-wrap text-[10px] text-gray-500">
+                  <Pill size="xs">{countLabel(loom.episodeCount, 'episode')}</Pill>
+                  <Pill size="xs">{countLabel(loom.sceneCount, 'scene')}</Pill>
+                  <Pill size="xs">{countLabel(loom.endingCount, 'ending')}</Pill>
+                  <span className="ml-auto">{timeAgo(loom.updatedAt)}</span>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/client/src/components/pipeline/SeriesLoomsPanel.test.jsx
+++ b/client/src/components/pipeline/SeriesLoomsPanel.test.jsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
+
+vi.mock('../../services/api', () => ({
+  listLooms: vi.fn(),
+  createLoom: vi.fn(),
+}));
+
+const navigate = vi.fn();
+vi.mock('react-router', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, useNavigate: () => navigate };
+});
+
+import * as api from '../../services/api';
+import SeriesLoomsPanel, { deriveLoomName } from './SeriesLoomsPanel';
+
+const series = { id: 'ser-1', name: 'Example Series', universeId: 'uni-1', logline: 'A quiet town keeps a loud secret.' };
+
+const summary = {
+  id: 'loom-1',
+  name: 'Example Series — branching narrative',
+  logline: 'A quiet town keeps a loud secret.',
+  seriesId: 'ser-1',
+  updatedAt: '2026-08-20T00:00:00Z',
+  episodeCount: 1,
+  sceneCount: 4,
+  endingCount: 2,
+};
+
+const renderPanel = (props = {}) =>
+  render(<MemoryRouter><SeriesLoomsPanel series={series} {...props} /></MemoryRouter>);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.listLooms.mockResolvedValue([summary]);
+});
+
+describe('SeriesLoomsPanel', () => {
+  it('lists the series-scoped looms with their counts and a link to the editor', async () => {
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('Example Series — branching narrative')).toBeInTheDocument());
+    expect(api.listLooms).toHaveBeenCalledWith({ seriesId: 'ser-1', silent: true });
+    expect(screen.getByText('1 episode')).toBeInTheDocument();
+    expect(screen.getByText('4 scenes')).toBeInTheDocument();
+    expect(screen.getByText('2 endings')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Example Series — branching narrative/ }))
+      .toHaveAttribute('href', '/fableloom/loom-1');
+  });
+
+  it('shows an empty state when nothing links to the series', async () => {
+    api.listLooms.mockResolvedValue([]);
+    renderPanel();
+    await waitFor(() => expect(screen.getByText(/None yet/)).toBeInTheDocument());
+  });
+
+  it('degrades to the empty state when the list fetch fails', async () => {
+    api.listLooms.mockRejectedValue(new Error('offline'));
+    renderPanel();
+    await waitFor(() => expect(screen.getByText(/None yet/)).toBeInTheDocument());
+  });
+
+  it('creates a loom pre-linked to the series and its universe, then opens the editor', async () => {
+    api.createLoom.mockResolvedValue({ id: 'loom-9' });
+    const user = userEvent.setup();
+    renderPanel();
+    await waitFor(() => expect(screen.getByText('Example Series — branching narrative')).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /New branching narrative/ }));
+    await waitFor(() => expect(api.createLoom).toHaveBeenCalledWith({
+      name: 'Example Series — branching narrative',
+      logline: 'A quiet town keeps a loud secret.',
+      universeId: 'uni-1',
+      seriesId: 'ser-1',
+    }, { silent: true }));
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/fableloom/loom-9'));
+  });
+
+  it('passes null (not an empty string) for a series with no universe', async () => {
+    api.listLooms.mockResolvedValue([]);
+    api.createLoom.mockResolvedValue({ id: 'loom-9' });
+    const user = userEvent.setup();
+    renderPanel({ series: { id: 'ser-2', name: 'Bare Series' } });
+    await waitFor(() => expect(screen.getByText(/None yet/)).toBeInTheDocument());
+
+    await user.click(screen.getByRole('button', { name: /New branching narrative/ }));
+    await waitFor(() => expect(api.createLoom).toHaveBeenCalledWith(
+      expect.objectContaining({ universeId: null, seriesId: 'ser-2' }),
+      { silent: true },
+    ));
+  });
+
+  it('renders nothing without a series id', () => {
+    const { container } = render(<MemoryRouter><SeriesLoomsPanel series={null} /></MemoryRouter>);
+    expect(container).toBeEmptyDOMElement();
+    expect(api.listLooms).not.toHaveBeenCalled();
+  });
+});
+
+describe('deriveLoomName', () => {
+  it('suffixes the series name and clamps to the server name cap', () => {
+    expect(deriveLoomName('Example Series')).toBe('Example Series — branching narrative');
+    expect(deriveLoomName('  ')).toBe('Untitled series — branching narrative');
+    expect(deriveLoomName('x'.repeat(400))).toHaveLength(200);
+  });
+});

--- a/client/src/pages/FableLoomStory.jsx
+++ b/client/src/pages/FableLoomStory.jsx
@@ -9,7 +9,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import { Link, Navigate, useNavigate, useParams, useSearchParams } from 'react-router';
-import { ArrowLeft, BookOpenText, Loader2, Plus, Settings, Sparkles, Trash2, Waypoints } from 'lucide-react';
+import { ArrowLeft, BookOpenText, Loader2, Plus, Settings, Sparkles, Trash2, Waypoints, Workflow as WorkflowIcon } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import Drawer from '../components/Drawer';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
@@ -25,8 +25,8 @@ import LoomSettingsDrawer from '../components/fableloom/LoomSettingsDrawer';
 import LoomValidationPanel from '../components/fableloom/LoomValidationPanel';
 import { fieldClass, labelClass } from '../components/fableloom/fieldStyles';
 import {
-  addLoomEpisode, addLoomNode, deleteLoomEpisode, getLoom, updateLoomEpisode,
-  updateLoomNode, weaveLoomEpisode,
+  addLoomEpisode, addLoomNode, deleteLoomEpisode, getLoom, getPipelineSeries,
+  updateLoomEpisode, updateLoomNode, weaveLoomEpisode,
 } from '../services/api';
 
 export default function FableLoomStory() {
@@ -34,6 +34,10 @@ export default function FableLoomStory() {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const [loom, setLoom] = useState(null);
+  // The series this loom is soft-linked to, resolved for the header backlink.
+  // `seriesId` is a soft ref: deleting the series is allowed and leaves the id
+  // dangling, so an unresolvable id renders NO chip rather than a dead link.
+  const [linkedSeries, setLinkedSeries] = useState(null);
   const [notFound, setNotFound] = useState(false);
   const [setupOpen, setSetupOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -43,6 +47,19 @@ export default function FableLoomStory() {
     setNotFound(false);
     getLoom(loomId).then(setLoom).catch(() => setNotFound(true));
   }, [loomId]);
+
+  const linkedSeriesId = loom?.seriesId || null;
+  useEffect(() => {
+    if (!linkedSeriesId) {
+      setLinkedSeries(null);
+      return undefined;
+    }
+    let canceled = false;
+    getPipelineSeries(linkedSeriesId, { silent: true })
+      .then((series) => { if (!canceled) setLinkedSeries(series || null); })
+      .catch(() => { if (!canceled) setLinkedSeries(null); });
+    return () => { canceled = true; };
+  }, [linkedSeriesId]);
 
   const episode = loom?.episodes.find((e) => e.id === episodeId) || null;
   const node = episode?.nodes.find((n) => n.id === nodeId) || null;
@@ -145,6 +162,16 @@ export default function FableLoomStory() {
             <Waypoints size={16} className="text-port-accent shrink-0" />
             <span className="truncate">{loom.name}</span>
           </h1>
+          {linkedSeries ? (
+            <Link
+              to={`/pipeline/series/${encodeURIComponent(linkedSeries.id)}`}
+              className="flex items-center gap-1 px-2 py-1 rounded border border-port-border text-xs text-port-text-muted hover:text-port-text hover:border-port-accent min-w-0"
+              title="Open the series this branching narrative is linked to"
+            >
+              <WorkflowIcon size={12} className="shrink-0" />
+              <span className="truncate max-w-[12rem]">{linkedSeries.name || 'Untitled series'}</span>
+            </Link>
+          ) : null}
           <div className="flex items-center gap-2 ml-auto">
             <button
               type="button"

--- a/client/src/pages/FableLoomStory.test.jsx
+++ b/client/src/pages/FableLoomStory.test.jsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router';
+
+vi.mock('../services/api', () => ({
+  addLoomEpisode: vi.fn(),
+  addLoomNode: vi.fn(),
+  deleteLoomEpisode: vi.fn(),
+  getLoom: vi.fn(),
+  getPipelineSeries: vi.fn(),
+  updateLoomEpisode: vi.fn(),
+  updateLoomNode: vi.fn(),
+  weaveLoomEpisode: vi.fn(),
+}));
+
+// The graph canvas and the rails are irrelevant to the header — stub them so
+// the suite exercises the loom → series backlink and nothing else.
+vi.mock('../components/fableloom/LoomCanvas', () => ({ default: () => <div /> }));
+vi.mock('../components/fableloom/LoomNodeEditor', () => ({ default: () => <div /> }));
+vi.mock('../components/fableloom/LoomPlayPanel', () => ({ default: () => <div /> }));
+vi.mock('../components/fableloom/LoomSettingsDrawer', () => ({ default: () => <div /> }));
+vi.mock('../components/fableloom/LoomValidationPanel', () => ({ default: () => <div /> }));
+
+import * as api from '../services/api';
+import FableLoomStory from './FableLoomStory';
+
+const loom = (fields = {}) => ({
+  id: 'loom-1',
+  name: 'Example Loom',
+  format: 'prose',
+  universeId: null,
+  seriesId: null,
+  episodes: [],
+  ...fields,
+});
+
+const renderEditor = () => render(
+  <MemoryRouter initialEntries={['/fableloom/loom-1']}>
+    <Routes>
+      <Route path="/fableloom/:loomId" element={<FableLoomStory />} />
+    </Routes>
+  </MemoryRouter>,
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getLoom.mockResolvedValue(loom());
+});
+
+describe('FableLoomStory series backlink', () => {
+  it('links back to the series a loom is soft-linked to', async () => {
+    api.getLoom.mockResolvedValue(loom({ seriesId: 'ser-1' }));
+    api.getPipelineSeries.mockResolvedValue({ id: 'ser-1', name: 'Example Series' });
+    renderEditor();
+
+    const link = await screen.findByRole('link', { name: /Example Series/ });
+    expect(link).toHaveAttribute('href', '/pipeline/series/ser-1');
+    expect(api.getPipelineSeries).toHaveBeenCalledWith('ser-1', { silent: true });
+  });
+
+  it('renders no chip (not a dead link) when the linked series has been deleted', async () => {
+    api.getLoom.mockResolvedValue(loom({ seriesId: 'ser-gone' }));
+    api.getPipelineSeries.mockRejectedValue(new Error('Series not found'));
+    renderEditor();
+
+    await screen.findByText('Example Loom');
+    await waitFor(() => expect(api.getPipelineSeries).toHaveBeenCalled());
+    expect(screen.queryByRole('link', { name: /series/i })).toBeNull();
+  });
+
+  it('falls back to a placeholder for a series with no name', async () => {
+    api.getLoom.mockResolvedValue(loom({ seriesId: 'ser-1' }));
+    api.getPipelineSeries.mockResolvedValue({ id: 'ser-1', name: '' });
+    renderEditor();
+
+    expect(await screen.findByRole('link', { name: /Untitled series/ }))
+      .toHaveAttribute('href', '/pipeline/series/ser-1');
+  });
+
+  it('never asks for a series when the loom is standalone', async () => {
+    renderEditor();
+    await screen.findByText('Example Loom');
+    expect(api.getPipelineSeries).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/pages/Pipeline.jsx
+++ b/client/src/pages/Pipeline.jsx
@@ -10,7 +10,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useConfirmDelete } from '../hooks/useConfirmDelete';
 import { Link, useNavigate, useSearchParams } from 'react-router';
-import { Plus, Workflow as WorkflowIcon, Trash2, Loader2, Globe2, FileInput, Sparkles, BookOpen } from 'lucide-react';
+import { Plus, Workflow as WorkflowIcon, Trash2, Loader2, Globe2, FileInput, Sparkles, BookOpen, Waypoints } from 'lucide-react';
 import toast from '../components/ui/Toast';
 import ConfirmButtonPair from '../components/ui/ConfirmButtonPair';
 import ImageThumb from '../components/ui/ImageThumb';
@@ -20,6 +20,7 @@ import OriginBadge from '../components/sharing/OriginBadge';
 import SyncBadge from '../components/sync/SyncBadge';
 import { useSyncIntegrity, syncBadgeStatus } from '../hooks/useSyncIntegrity';
 import {
+  listLooms,
   listPipelineSeries,
   createPipelineSeries,
   deletePipelineSeries,
@@ -34,6 +35,18 @@ import { ArcShapePicker, ArcShapeSparkline, getStoryShape } from '../components/
 import AuthorPicker from '../components/pipeline/AuthorPicker';
 import MoodBoardReferenceStrip from '../components/moodBoard/MoodBoardReferenceStrip';
 import { buildImporterLink } from '../lib/importerDeepLink';
+
+// Roll the loom summaries into a per-series count for the row badge. Looms with
+// no seriesId (standalone) and looms pointing at a series that no longer exists
+// simply never match a row — the link is a soft ref in both directions.
+const countLoomsBySeries = (looms) => {
+  const counts = new Map();
+  for (const loom of Array.isArray(looms) ? looms : []) {
+    if (!loom?.seriesId) continue;
+    counts.set(loom.seriesId, (counts.get(loom.seriesId) || 0) + 1);
+  }
+  return counts;
+};
 
 const emptyForm = () => ({
   name: '',
@@ -51,6 +64,9 @@ export default function Pipeline() {
   const navigate = useNavigate();
   const [series, setSeries] = useState([]);
   const [universes, setWorlds] = useState([]);
+  // seriesId -> number of FableLoom looms soft-linked to it (#4785). A failed
+  // fetch degrades to "no badges", never to a broken series list.
+  const [loomCounts, setLoomCounts] = useState(() => new Map());
   const [loading, setLoading] = useState(true);
 
   const sync = useSyncIntegrity('series');
@@ -83,9 +99,13 @@ export default function Pipeline() {
         toast.error(err.message || 'Failed to load universes');
         return [];
       }),
-    ]).then(([s, w]) => {
+      // Loom summaries are a side quest for the row badge — a failure here must
+      // not toast over the series list or block it.
+      listLooms({ silent: true }).catch(() => []),
+    ]).then(([s, w, looms]) => {
       setSeries(Array.isArray(s) ? s : []);
       setWorlds(Array.isArray(w) ? w : []);
+      setLoomCounts(countLoomsBySeries(looms));
       setLoading(false);
     });
   }, []);
@@ -516,6 +536,7 @@ export default function Pipeline() {
         <ul className="space-y-2">
           {series.map((s) => {
             const shapeDef = s.arc?.shape ? getStoryShape(s.arc.shape) : null;
+            const loomCount = loomCounts.get(s.id) || 0;
             return (
             <li key={s.id} className="flex flex-col sm:flex-row sm:items-start gap-3 p-3 bg-port-card border border-port-border rounded-lg hover:border-port-accent/40 transition-colors">
               <Link to={`/pipeline/series/${s.id}`} className="flex-1 min-w-0 flex items-start gap-3">
@@ -524,6 +545,15 @@ export default function Pipeline() {
                   <div className="text-white font-medium flex items-center gap-2 flex-wrap">
                     <span>{s.name}</span>
                     {s.origin ? <OriginBadge origin={s.origin} compact /> : null}
+                    {loomCount ? (
+                      <span
+                        className="inline-flex items-center gap-1 text-[10px] uppercase tracking-wider px-2 py-0.5 rounded bg-port-bg border border-port-border text-gray-300"
+                        title={`${loomCount} branching narrative${loomCount === 1 ? '' : 's'} linked to this series`}
+                      >
+                        <Waypoints size={10} aria-hidden="true" />
+                        {loomCount} branching
+                      </span>
+                    ) : null}
                     {shapeDef ? (
                       <span
                         className="inline-flex items-center gap-1.5 text-[10px] uppercase tracking-wider px-2 py-0.5 rounded bg-port-bg border border-port-accent/40 text-port-accent"

--- a/client/src/pages/Pipeline.loomBadge.test.jsx
+++ b/client/src/pages/Pipeline.loomBadge.test.jsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import Pipeline from './Pipeline';
+
+const listPipelineSeries = vi.fn();
+const listUniverses = vi.fn();
+const listLooms = vi.fn();
+
+vi.mock('../services/api', () => ({
+  listPipelineSeries: (...a) => listPipelineSeries(...a),
+  createPipelineSeries: vi.fn(),
+  deletePipelineSeries: vi.fn(),
+  generateSeriesTitleLogo: vi.fn(),
+  generateSeriesConcepts: vi.fn(),
+  listUniverses: (...a) => listUniverses(...a),
+  listLooms: (...a) => listLooms(...a),
+  WORLD_LOGLINE_MAX: 400,
+  WORLD_PREMISE_MAX: 2000,
+  WORLD_STYLE_NOTES_MAX: 2000,
+}));
+
+vi.mock('../hooks/useSyncIntegrity', () => ({
+  useSyncIntegrity: () => ({ integrity: null }),
+  syncBadgeStatus: () => 'not-syncing',
+}));
+
+vi.mock('../components/sharing/ShareToButton', () => ({ default: () => <button type="button">share</button> }));
+vi.mock('../components/sharing/SyncToPeerButton', () => ({ default: () => <button type="button">sync-to-peer</button> }));
+vi.mock('../components/moodBoard/MoodBoardReferenceStrip', () => ({ default: () => <div>mood-board</div> }));
+vi.mock('../components/ui/Toast', () => ({ default: { success: vi.fn(), error: vi.fn() } }));
+
+const SERIES = [
+  { id: 'series-1', name: 'Example Series' },
+  { id: 'series-2', name: 'Second Series' },
+];
+
+const renderPage = () => render(
+  <MemoryRouter initialEntries={['/pipeline']}><Pipeline /></MemoryRouter>,
+);
+
+describe('Pipeline series list — branching-narrative badge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listPipelineSeries.mockResolvedValue(SERIES);
+    listUniverses.mockResolvedValue([]);
+    listLooms.mockResolvedValue([
+      { id: 'loom-1', seriesId: 'series-1' },
+      { id: 'loom-2', seriesId: 'series-1' },
+      { id: 'loom-3', seriesId: null },
+      { id: 'loom-4', seriesId: 'series-gone' },
+    ]);
+  });
+
+  it('counts only the looms linked to each row and leaves unlinked rows bare', async () => {
+    renderPage();
+    await screen.findByText('Example Series');
+    await waitFor(() => expect(screen.getByText('2 branching')).toBeInTheDocument());
+
+    const badged = screen.getByText('2 branching').closest('li');
+    expect(badged).toContainElement(screen.getByText('Example Series'));
+    // series-2 has no looms, and the standalone / dangling ones match nothing.
+    expect(screen.queryByText('1 branching')).toBeNull();
+  });
+
+  it('renders the list without badges when the loom fetch fails', async () => {
+    listLooms.mockRejectedValue(new Error('offline'));
+    renderPage();
+    await screen.findByText('Example Series');
+    await waitFor(() => expect(screen.getByText('Second Series')).toBeInTheDocument());
+    expect(screen.queryByText(/branching/)).toBeNull();
+  });
+});

--- a/client/src/pages/Pipeline.responsive.test.jsx
+++ b/client/src/pages/Pipeline.responsive.test.jsx
@@ -5,6 +5,7 @@ import Pipeline from './Pipeline';
 
 const listPipelineSeries = vi.fn();
 const listUniverses = vi.fn();
+const listLooms = vi.fn();
 
 vi.mock('../services/api', () => ({
   listPipelineSeries: (...a) => listPipelineSeries(...a),
@@ -13,6 +14,7 @@ vi.mock('../services/api', () => ({
   generateSeriesTitleLogo: vi.fn(),
   generateSeriesConcepts: vi.fn(),
   listUniverses: (...a) => listUniverses(...a),
+  listLooms: (...a) => listLooms(...a),
   WORLD_LOGLINE_MAX: 400,
   WORLD_PREMISE_MAX: 2000,
   WORLD_STYLE_NOTES_MAX: 2000,
@@ -50,6 +52,7 @@ describe('Pipeline series list — mobile layout', () => {
     vi.clearAllMocks();
     listPipelineSeries.mockResolvedValue([SERIES]);
     listUniverses.mockResolvedValue([]);
+    listLooms.mockResolvedValue([]);
   });
 
   it('stacks the row below sm so the logline gets the full card width', async () => {

--- a/client/src/pages/PipelineSeries.jsx
+++ b/client/src/pages/PipelineSeries.jsx
@@ -21,6 +21,7 @@ import toast from '../components/ui/Toast';
 import ArcCanvas from '../components/pipeline/ArcCanvas';
 import AutopilotPanel from '../components/pipeline/AutopilotPanel';
 import SeriesReviewPanel from '../components/pipeline/SeriesReviewPanel';
+import SeriesLoomsPanel from '../components/pipeline/SeriesLoomsPanel';
 import CatalogCastPanel from '../components/CatalogCastPanel';
 import TabPills from '../components/ui/TabPills';
 import Field from '../components/ui/FormField';
@@ -290,6 +291,8 @@ export default function PipelineSeries() {
             onSeriesUpdate={updateSeriesFromServer}
             onIssuesUpdate={handleIssuesUpdate}
           />
+
+          <SeriesLoomsPanel series={series} />
 
           <ArcCanvas
             series={series}

--- a/client/src/pages/PipelineSeries.responsive.test.jsx
+++ b/client/src/pages/PipelineSeries.responsive.test.jsx
@@ -28,6 +28,7 @@ vi.mock('../hooks/useLocalStorageBool', () => ({ useLocalStorageBool: () => [fal
 vi.mock('../components/pipeline/ArcCanvas', () => ({ default: () => <div>arc canvas</div> }));
 vi.mock('../components/pipeline/AutopilotPanel', () => ({ default: () => <div>autopilot</div> }));
 vi.mock('../components/pipeline/SeriesReviewPanel', () => ({ default: () => <div>series review</div> }));
+vi.mock('../components/pipeline/SeriesLoomsPanel', () => ({ default: () => <div>branching narratives</div> }));
 vi.mock('../components/CatalogCastPanel', () => ({ default: () => <div>cast</div> }));
 vi.mock('../components/pipeline/AuthorPicker', () => ({ default: () => <div>author</div> }));
 vi.mock('../components/VoiceExemplarEditor', () => ({ default: () => <div>voice exemplars</div>, VOICE_EXEMPLARS_MAX: 5 }));

--- a/client/src/services/apiFableLoom.js
+++ b/client/src/services/apiFableLoom.js
@@ -8,7 +8,10 @@ const nodePath = (id, episodeId, nodeId, rest = '') =>
 const transitionPath = (id, episodeId, nodeId, transitionId) =>
   nodePath(id, episodeId, nodeId, `/transitions/${encodeURIComponent(transitionId)}`);
 
-export const listLooms = (options = {}) => request('/fableloom', options);
+// `seriesId` scopes the index to one pipeline series' linked looms; every other
+// key is passed through to `request` as fetch options (e.g. `{ silent: true }`).
+export const listLooms = ({ seriesId, ...options } = {}) =>
+  request(seriesId ? `/fableloom?seriesId=${encodeURIComponent(seriesId)}` : '/fableloom', options);
 export const getLoom = (id, options = {}) => request(loomPath(id), options);
 
 export const createLoom = (body, options = {}) => request('/fableloom', {

--- a/client/src/services/apiFableLoom.test.js
+++ b/client/src/services/apiFableLoom.test.js
@@ -16,6 +16,16 @@ beforeEach(async () => {
 });
 
 describe('apiFableLoom', () => {
+  it('lists every loom when no series scope is given', async () => {
+    await api.listLooms({ silent: true });
+    expect(request).toHaveBeenCalledWith('/fableloom', { silent: true });
+  });
+
+  it('scopes the index to one series and keeps the remaining request options', async () => {
+    await api.listLooms({ seriesId: 'ser/1', silent: true });
+    expect(request).toHaveBeenCalledWith('/fableloom?seriesId=ser%2F1', { silent: true });
+  });
+
   it('encodes ids in nested node paths', async () => {
     await api.updateLoomNode('loom/1', 'ep/1', 'node/1', { prose: 'x' }, { silent: true });
     expect(request).toHaveBeenCalledWith('/fableloom/loom%2F1/episodes/ep%2F1/nodes/node%2F1', {

--- a/docs/features/fableloom.md
+++ b/docs/features/fableloom.md
@@ -31,6 +31,10 @@ answers in-world without leaving the scene when nothing matches.
   (restart is free; nothing persists server-side).
 - **Story settings drawer** — scene format (plus the rewrite pass), and the
   narrator's provider/model/effort pin.
+- **Series detail page** (`/pipeline/series/:seriesId`) — a "Branching
+  narratives" card lists the looms linked to that series (counts + a link into
+  the editor) and spawns a new one pre-linked to the series and its universe.
+  The series index badges each row with its loom count.
 
 ## Editing paths
 
@@ -117,5 +121,16 @@ weave / store / db); routes: `server/routes/fableLoom.js` (`/api/fableloom`).
 A loom can *link* to a pipeline series (`seriesId`) but is its own record
 type — branching narratives don't run the linear issue/stage pipeline
 (manuscript formats, autopilot, federation semantics don't apply to a graph).
-Deeper integration (a branching series type surfaced inside series
-management) is deliberately deferred.
+There is deliberately **no `seriesType: 'branching'` enum** on
+`pipeline_series`: a scene graph has no linear stage chain, and a type enum
+would force a special case into every pipeline surface. The integration is a
+soft ref surfaced at the presentation layer instead (#4785) — the same posture
+as Games / Creative Director:
+
+- `GET /api/fableloom?seriesId=<id>` scopes the index to one series' looms. A
+  blank value means "no filter"; a dangling id simply matches nothing.
+- The series detail page renders those looms and can spawn a new pre-linked
+  one; the series index badges each row with its count.
+- The link is soft in both directions — deleting a series is never blocked by a
+  loom pointing at it, and the loom editor's series backlink renders **no chip**
+  (rather than a dead link) once the series is gone.

--- a/server/lib/fableLoomValidation.js
+++ b/server/lib/fableLoomValidation.js
@@ -31,6 +31,14 @@ const playSettings = z.object({
   effort: effort.nullable().optional(),
 }).nullable();
 
+// Index filter. `?seriesId=` scopes the list to the looms soft-linked to one
+// pipeline series (the series detail page's "Branching narratives" card). An
+// empty value is a no-op filter, not a 400 — a UI that builds the query from a
+// possibly-unset id should not have to branch on it.
+export const loomListQuerySchema = z.object({
+  seriesId: z.string().max(LOOM_LIMITS.REF_ID_MAX).optional(),
+});
+
 export const loomCreateSchema = z.object({
   name,
   logline: logline.optional(),

--- a/server/routes/fableLoom.js
+++ b/server/routes/fableLoom.js
@@ -16,6 +16,7 @@ import {
   episodeCreateSchema,
   episodePatchSchema,
   loomCreateSchema,
+  loomListQuerySchema,
   loomPatchSchema,
   nodeCreateSchema,
   nodePatchSchema,
@@ -53,8 +54,12 @@ const router = Router();
 
 // Summaries only — a woven episode carries pages of prose per node, and the
 // index renders three counts. The full record comes from GET /:id.
+// `?seriesId=` scopes the list to one pipeline series' linked looms (the series
+// detail page's "Branching narratives" card). A blank value means "no filter",
+// so a caller can build the query from a possibly-unset id.
 router.get('/', asyncHandler(async (req, res) => {
-  res.json(await listLoomSummaries());
+  const { seriesId } = validateRequest(loomListQuerySchema, req.query);
+  res.json(await listLoomSummaries({ seriesId: seriesId?.trim() || undefined }));
 }));
 
 // Linked universe/series refs are validated by the service (createLoom /

--- a/server/routes/fableLoom.test.js
+++ b/server/routes/fableLoom.test.js
@@ -44,6 +44,24 @@ describe('FableLoom routes', () => {
     const response = await request(makeApp()).get('/api/fableloom');
     expect(response.status).toBe(200);
     expect(response.body).toEqual([{ id: 'loom-1', name: 'X', sceneCount: 3 }]);
+    expect(fableLoom.listLoomSummaries).toHaveBeenCalledWith({ seriesId: undefined });
+  });
+
+  it('GET /?seriesId= scopes the list to one series', async () => {
+    fableLoom.listLoomSummaries.mockResolvedValueOnce([{ id: 'loom-1', seriesId: 'ser-1' }]);
+    const response = await request(makeApp()).get('/api/fableloom?seriesId=ser-1');
+    expect(response.status).toBe(200);
+    expect(fableLoom.listLoomSummaries).toHaveBeenCalledWith({ seriesId: 'ser-1' });
+  });
+
+  it('GET / treats a blank seriesId as no filter and rejects an over-long one', async () => {
+    const blank = await request(makeApp()).get('/api/fableloom?seriesId=');
+    expect(blank.status).toBe(200);
+    expect(fableLoom.listLoomSummaries).toHaveBeenCalledWith({ seriesId: undefined });
+
+    const tooLong = await request(makeApp()).get(`/api/fableloom?seriesId=${'s'.repeat(65)}`);
+    expect(tooLong.status).toBe(400);
+    expect(fableLoom.listLoomSummaries).toHaveBeenCalledTimes(1);
   });
 
   it('POST / forwards the validated create payload (refs are checked in the service)', async () => {

--- a/server/services/fableLoom/records.js
+++ b/server/services/fableLoom/records.js
@@ -184,9 +184,15 @@ export async function listLooms() {
  * Index-page projection: everything the list UI shows, WITHOUT the episode
  * graphs — a woven episode carries up to 20k chars of prose per node, so the
  * full records would make the index multi-MB to render three counts.
+ *
+ * `seriesId` scopes the list to one pipeline series' linked looms. The link is
+ * a soft ref, so a series that no longer exists simply matches nothing — this
+ * never throws on a dangling id.
  */
-export async function listLoomSummaries() {
-  return (await listLooms()).map(({ id, name, logline, format, universeId, seriesId, createdAt, updatedAt, episodes }) => ({
+export async function listLoomSummaries({ seriesId: scopeSeriesId } = {}) {
+  const looms = await listLooms();
+  const scoped = scopeSeriesId ? looms.filter((loom) => loom.seriesId === scopeSeriesId) : looms;
+  return scoped.map(({ id, name, logline, format, universeId, seriesId, createdAt, updatedAt, episodes }) => ({
     id,
     name,
     logline,

--- a/server/services/fableLoom/records.test.js
+++ b/server/services/fableLoom/records.test.js
@@ -182,6 +182,21 @@ describe('listLoomSummaries', () => {
     });
     expect(summary.episodes).toBeUndefined();
   });
+
+  it('scopes the list to one series when seriesId is passed', async () => {
+    const linked = await makeLoom({ name: 'Linked', seriesId: 'ser-1' });
+    await makeLoom({ name: 'Other series', seriesId: 'ser-2' });
+    await makeLoom({ name: 'Standalone' });
+
+    const scoped = await listLoomSummaries({ seriesId: 'ser-1' });
+    expect(scoped.map((l) => l.id)).toEqual([linked.id]);
+    expect(await listLoomSummaries()).toHaveLength(3);
+  });
+
+  it('returns nothing (never throws) for a series id nothing links to', async () => {
+    await makeLoom({ name: 'Standalone' });
+    expect(await listLoomSummaries({ seriesId: 'ser-deleted' })).toEqual([]);
+  });
 });
 
 describe('episodes', () => {


### PR DESCRIPTION
## Summary

Surfaces FableLoom looms inside series management at the presentation/cross-linking layer. Per the issue's decision, a loom stays its own record — **no `seriesType: 'branching'` enum on `pipeline_series`, no `pipeline_series` schema change, no schema-version bump.**

- **`GET /api/fableloom?seriesId=`** scopes the index to one series' looms (`loomListQuerySchema` in `server/lib/fableLoomValidation.js`, filtering in `listLoomSummaries`). A blank value is a no-op filter rather than a 400, so a caller can build the query from a possibly-unset id; a dangling id matches nothing instead of throwing.
- **Series detail page** gains a "Branching narratives" card (`SeriesLoomsPanel`) listing linked looms with their episode/scene/ending counts and a link into `/fableloom/:loomId` — mirroring how `CatalogCastPanel` surfaces linked catalog records.
- **"New branching narrative"** action mints a loom pre-linked to the series and its universe, then lands in the editor.
- **Series index** badges each row with its linked-loom count. A failed loom fetch degrades to "no badges", never a broken list.
- **Loom editor header** gains a series backlink. The ref is soft in both directions: deleting a series is never blocked, and an unresolvable `seriesId` renders **no chip** rather than a dead link.

## Test plan

- `cd server && npm test` — full suite green (32,759 passed). New coverage: `listLoomSummaries` series scoping + dangling-id case (`services/fableLoom/records.test.js`), and the route's filter / blank-value / over-long-id cases (`routes/fableLoom.test.js`).
- `cd client && npm test` — full suite green apart from two known load-related flakes (`a11yConventions` timeout, `Catalog.test.jsx` act warning) that pass in isolation and are untouched by this branch. New suites: `SeriesLoomsPanel.test.jsx`, `Pipeline.loomBadge.test.jsx`, `FableLoomStory.test.jsx` (backlink present / deleted-series graceful / unnamed-series fallback / standalone), plus `apiFableLoom.test.js` query-encoding cases.
- `cd client && npm run lint` — clean.

Closes #4785
