### PR TITLE
persist a claim task's resolved reviewers so the reviewer pin has one owner

### DIFF
--- a/server/lib/cosValidation.js
+++ b/server/lib/cosValidation.js
@@ -593,6 +593,64 @@ export function resolveReviewerConfig(metadata, codeReviewDefaults, defaultRevie
   };
 }
 
+/** The reviewer a claim flow falls back to when its resolved list is unusable. */
+const CLAIM_REVIEWER_FALLBACK = ['codex'];
+
+/**
+ * Constrain an already-resolved reviewer list to what an UNATTENDED claim run can
+ * actually invoke: `copilot` is a forge-side PR reviewer with no CLI, so a claim
+ * agent told to "review with copilot" has nothing to run and stalls (#2507).
+ * An empty result falls back to `codex` rather than to `DEFAULT_REVIEWERS`
+ * (which is `copilot`, the very thing being removed).
+ */
+export function claimSafeReviewers(reviewers) {
+  const kept = (Array.isArray(reviewers) ? reviewers : []).filter((reviewer) => reviewer !== 'copilot');
+  return kept.length ? kept : [...CLAIM_REVIEWER_FALLBACK];
+}
+
+/**
+ * `resolveReviewerConfig` plus the claim flow's copilot guard and the emitted
+ * `--review-with` token list — the ONE resolver a claim prompt's reviewer text
+ * and a claim task's persisted `reviewers` metadata both go through, so the two
+ * cannot name different reviewers.
+ *
+ * The generators resolve their list before a task record exists (they read
+ * schedule metadata + Code Review Defaults); the prompt builder resolves it from
+ * the persisted task metadata at spawn time. Feeding both the same function is
+ * what makes `reviewerConfigMetadata`'s round-trip exact.
+ */
+export function resolveClaimReviewerConfig(metadata, codeReviewDefaults, defaultReviewers) {
+  const config = resolveReviewerConfig(metadata, codeReviewDefaults, defaultReviewers);
+  const reviewers = claimSafeReviewers(config.reviewers);
+  return {
+    ...config,
+    reviewers,
+    csv: buildReviewersCsv(reviewers, config.usernames, config.optionalReviewers, config.reviewerMaxRounds, config.reviewerModels, config.reviewerEfforts)
+  };
+}
+
+/**
+ * The reviewer fields a task must PERSIST so a later
+ * `resolveReviewerConfig(task.metadata, …)` resolves the same list its prompt
+ * names, instead of re-deriving the install-wide Code Review Defaults (#4770).
+ *
+ * All six travel together: resolving only `reviewers` still lets the usernames,
+ * `~opt` set, and the three keyed pins fall back to the defaults, which is the
+ * same disagreement one field down. Sanitized on the way out so a hand-crafted
+ * request body can't smuggle an unrecognized key onto the task record, and every
+ * value is re-validated rather than trusted.
+ */
+export function reviewerConfigMetadata(config) {
+  return sanitizeTaskMetadata({
+    reviewers: config?.reviewers,
+    usernames: config?.usernames,
+    optionalReviewers: config?.optionalReviewers,
+    reviewerMaxRounds: config?.reviewerMaxRounds,
+    reviewerModels: config?.reviewerModels,
+    reviewerEfforts: config?.reviewerEfforts
+  }) || {};
+}
+
 /**
  * Resolve the model and effort pins TOGETHER — `{ reviewerModels, reviewerEfforts }`
  * with task-over-default precedence, already reconciled into a pair the reviewer's
@@ -856,7 +914,7 @@ export const reviewerTokenSlug = (token) => String(token).split('[')[0].split('~
  *
  * Unlike `buildReviewWithArgs` this does NOT suppress a lone bare `copilot`
  * (the #2507 stall): every claim path resolves its list through
- * `normalizeClaimReviewers`, which strips `copilot` and falls back to `codex`,
+ * `claimSafeReviewers`, which strips `copilot` and falls back to `codex`,
  * so the suppressed case cannot reach here. A future caller that skips that
  * normalizer has to add the guard rather than assume it.
  *

--- a/server/lib/cosValidation.test.js
+++ b/server/lib/cosValidation.test.js
@@ -28,6 +28,10 @@ import {
   buildReviewerEffortNote,
   buildReviewerPinNote,
   buildReviewersCsv,
+  claimSafeReviewers,
+  resolveReviewerConfig,
+  resolveClaimReviewerConfig,
+  reviewerConfigMetadata,
   reviewerTokenSlug,
   sanitizeTaskMetadata,
   codeReviewSettingsSchema,
@@ -617,5 +621,108 @@ describe('reviewer pin note (saved slashdo defaults must not win)', () => {
     expect(buildReviewerPinNote('   ')).toBe('');
     expect(buildReviewerPinNote(null)).toBe('');
     expect(buildReviewerPinNote(undefined)).toBe('');
+  });
+});
+
+// The claim generators resolve reviewers BEFORE a task record exists and render
+// the CSV into `{reviewers}`; the prompt builder re-resolves them from the
+// persisted task at spawn time to emit the reviewer pin. Those two resolutions
+// have to land on the same list, or the pin names reviewers the prompt does not
+// (#4770). `reviewerConfigMetadata` is the round-trip that makes them agree.
+describe('claim reviewer round-trip (prompt CSV ↔ persisted metadata)', () => {
+  const defaults = {
+    reviewers: ['copilot'],
+    usernames: ['alice'],
+    optionalReviewers: ['ollama'],
+    reviewerMaxRounds: { codex: 2 },
+    antigravityModel: 'gemini-3.7-flash-high',
+    codexEffort: 'high'
+  };
+
+  it('claimSafeReviewers drops copilot and never falls back to it', () => {
+    expect(claimSafeReviewers(['codex', 'copilot'])).toEqual(['codex']);
+    expect(claimSafeReviewers(['copilot'])).toEqual(['codex']);
+    expect(claimSafeReviewers([])).toEqual(['codex']);
+    expect(claimSafeReviewers(undefined)).toEqual(['codex']);
+  });
+
+  it('resolves through the claim guard from every input shape a claim task can carry', () => {
+    // The install default is the fallback, the claim guard is applied after it,
+    // and legacy single-`reviewer` metadata still resolves.
+    expect(resolveClaimReviewerConfig({}, null, undefined).reviewers).toEqual(['codex']);
+    expect(resolveClaimReviewerConfig({ reviewers: ['copilot'] }, null, ['copilot']).reviewers).toEqual(['codex']);
+    expect(resolveClaimReviewerConfig({}, null, ['claude', 'copilot']).reviewers).toEqual(['claude']);
+    expect(resolveClaimReviewerConfig({ reviewer: 'grok' }, null, ['claude']).reviewers).toEqual(['grok']);
+  });
+
+  it('resolveClaimReviewerConfig emits a CSV matching its own resolved bundle', () => {
+    const config = resolveClaimReviewerConfig({ reviewers: ['codex', 'antigravity'] }, defaults, defaults.reviewers);
+    expect(config.reviewers).toEqual(['codex', 'antigravity']);
+    expect(config.csv).toBe(buildReviewersCsv(
+      config.reviewers, config.usernames, config.optionalReviewers,
+      config.reviewerMaxRounds, config.reviewerModels, config.reviewerEfforts
+    ));
+    // The agy model id's baked tier is split off exactly once — resolving the
+    // persisted config a second time must not re-split or double-apply it.
+    expect(config.reviewerModels.antigravity).toBe('gemini-3.7-flash');
+    expect(config.reviewerEfforts.antigravity).toBe('high');
+  });
+
+  it('persisting reviewerConfigMetadata makes the SECOND resolution reproduce the first CSV', () => {
+    // Round 1: the generator, with no task record yet.
+    const generated = resolveClaimReviewerConfig({ reviewers: ['codex', 'antigravity'] }, defaults, defaults.reviewers);
+    const metadata = { claimFlow: true, ...reviewerConfigMetadata(generated) };
+    // Round 2: the prompt builder, reading the task back — and deliberately
+    // WITHOUT the defaults it would otherwise fall through to, to prove the
+    // persisted values are what carry the list.
+    const rebuilt = resolveClaimReviewerConfig(metadata, null, null);
+    expect(rebuilt.csv).toBe(generated.csv);
+    expect(rebuilt).toMatchObject({
+      reviewers: generated.reviewers,
+      usernames: generated.usernames,
+      optionalReviewers: generated.optionalReviewers,
+      reviewerMaxRounds: generated.reviewerMaxRounds,
+      reviewerModels: generated.reviewerModels,
+      reviewerEfforts: generated.reviewerEfforts
+    });
+    // And the plain (non-claim) resolver the prompt builder shares with the
+    // review loop agrees too — that is the resolution #4770 was silently
+    // answering from the install-wide defaults.
+    expect(resolveReviewerConfig(metadata, null, null).reviewers).toEqual(generated.reviewers);
+  });
+
+  it('a DIFFERENT install default cannot override what the task persisted', () => {
+    const generated = resolveClaimReviewerConfig({ reviewers: ['grok'] }, defaults, defaults.reviewers);
+    const metadata = reviewerConfigMetadata(generated);
+    const otherInstall = { reviewers: ['claude'], usernames: ['bob'], optionalReviewers: ['grok'], reviewerMaxRounds: { grok: 9 } };
+    expect(resolveClaimReviewerConfig(metadata, otherInstall, otherInstall.reviewers).csv).toBe(generated.csv);
+  });
+
+  it('sanitizes rather than trusts: unknown keys and junk values never reach the task record', () => {
+    const meta = reviewerConfigMetadata({
+      reviewers: ['codex', 'bogus'],
+      usernames: ['@Alice', 'bad token'],
+      optionalReviewers: ['nope'],
+      reviewerMaxRounds: { codex: 'three' },
+      reviewerModels: {},
+      reviewerEfforts: {},
+      swarmCount: 6,
+      issueAuthorFilter: 'any'
+    });
+    expect(meta).toEqual({
+      reviewers: ['codex'],
+      usernames: ['Alice'],
+      optionalReviewers: [],
+      reviewerMaxRounds: {},
+      reviewerModels: {},
+      reviewerEfforts: {}
+    });
+  });
+
+  it('returns an empty patch rather than null when nothing survives sanitizing', () => {
+    // Callers spread this into a task's metadata, so a null would throw at the
+    // three claim generators rather than degrade.
+    expect(reviewerConfigMetadata(null)).toEqual({});
+    expect(reviewerConfigMetadata({ reviewers: ['bogus'] })).toEqual({});
   });
 });

--- a/server/routes/cos.test.js
+++ b/server/routes/cos.test.js
@@ -1106,6 +1106,50 @@ describe('CoS Routes', () => {
       expect(taskData.claimFlow).toBe(true);
     });
 
+    // The claim prompt names its reviewers as prose and emits no flag, so the
+    // ONLY way a later consumer (the prompt builder's reviewer pin) can know who
+    // the prompt named is the task record. #4770: the resolved bundle rides out
+    // of buildClaimWorkTask on taskMetadata and must reach addTask intact.
+    it('persists the reviewer bundle the claim prompt resolved onto the task', async () => {
+      getAppById.mockResolvedValue({ id: 'my-app', name: 'MyApp', repoPath: '/repo' });
+      buildClaimWorkTask.mockResolvedValue({
+        tracker: 'github',
+        source: 'config',
+        promptTaskType: 'claim-issue',
+        prompt: 'CLAIM ISSUE PROMPT',
+        taskMetadata: {
+          useWorktree: false,
+          openPR: false,
+          claimFlow: true,
+          reviewers: ['codex', 'claude'],
+          usernames: ['alice'],
+          optionalReviewers: [],
+          reviewerMaxRounds: { codex: 2 },
+          reviewerModels: {},
+          reviewerEfforts: { codex: 'high' }
+        }
+      });
+      cos.addTask.mockResolvedValue({ id: 'task-sd-next-reviewers', status: 'pending' });
+
+      const response = await request(app)
+        .post('/api/cos/tasks/slashdo')
+        .send({ command: 'next', app: 'my-app' });
+
+      expect(response.status).toBe(200);
+      const [taskData] = cos.addTask.mock.calls.at(-1);
+      expect(taskData).toMatchObject({
+        reviewers: ['codex', 'claude'],
+        usernames: ['alice'],
+        optionalReviewers: [],
+        reviewerMaxRounds: { codex: 2 },
+        reviewerModels: {},
+        reviewerEfforts: { codex: 'high' },
+        claimFlow: true
+      });
+      // `reviewLoop` stays off — the claim prompt owns its own review sequence.
+      expect(taskData.reviewLoop).toBe(false);
+    });
+
     // `next` is commit-shaped in the catalog, but the claim flow resolves the
     // app's actual work tracker — a forge tracker files its outcome outside the
     // repo, so its `worktreeChangesExpected` must override the catalog default

--- a/server/services/agentPromptBuilder.js
+++ b/server/services/agentPromptBuilder.js
@@ -17,7 +17,7 @@ import { getActiveProvider } from './providers.js';
 import { runPromptThroughProvider } from '../lib/promptRunner.js';
 import { readJSONFile, PATHS, tryReadFile, expandHome } from '../lib/fileUtils.js';
 import { loadSlashdoFile, loadSlashdoLib, writeResolvedSlashdoBody } from '../lib/slashdoLoader.js';
-import { DEFAULT_REVIEWER, DEFAULT_REVIEWERS, DEFAULT_REVIEW_STOP_MODE, LOCAL_LLM_REVIEWERS, MODEL_CAPABLE_CLI_REVIEWERS, describeReviewerCli, isCliReviewer, reviewerCliBinary, normalizeReviewUsernames, normalizeOptionalReviewers, normalizeReviewerMaxRounds, resolveReviewerConfig, reviewerEffortArgs, reviewerModelArg, buildReviewerEffortNote, resolveKeyedReviewers, buildReviewWithArgs, buildReviewersCsv } from '../lib/validation.js';
+import { DEFAULT_REVIEWER, DEFAULT_REVIEWERS, DEFAULT_REVIEW_STOP_MODE, LOCAL_LLM_REVIEWERS, MODEL_CAPABLE_CLI_REVIEWERS, describeReviewerCli, isCliReviewer, reviewerCliBinary, normalizeReviewUsernames, normalizeOptionalReviewers, normalizeReviewerMaxRounds, resolveReviewerConfig, resolveClaimReviewerConfig, buildReviewerPinNote, reviewerEffortArgs, reviewerModelArg, buildReviewerEffortNote, resolveKeyedReviewers, buildReviewWithArgs, buildReviewersCsv } from '../lib/validation.js';
 import { PROVIDER_TYPES } from '../lib/aiToolkit/constants.js';
 import { doneSentinelName, PROGRAMMATIC_OUTPUT_COMPLETION_HEADING } from '../lib/agentSentinel.js';
 import { canTypeSlashCommands, agentOwnsPrWorkflow, resolveSlashdoInvocation, buildSlashdoSection, oversizedBodyPointer, unreachableReviewerIncludes, SLASHDO_INLINE_BUDGET_CHARS } from '../lib/slashdoInvocation.js';
@@ -1493,13 +1493,39 @@ export function buildActionOutputCompletionSection({ isTui = false, sentinelPath
 }
 
 /**
+ * The `--review-with` token list a claim task's prompt names, read back off the
+ * task record. The claim generators persist the bundle they rendered into
+ * `{reviewers}` (`reviewerConfigMetadata`), so this reproduces that CSV exactly.
+ *
+ * A claim task queued before #4770 carries no reviewer metadata, so this falls
+ * through to the install's Code Review Defaults — routed through the claim
+ * resolver so an in-flight legacy task can't be pinned to a bare `copilot`,
+ * which a claim agent has no CLI to invoke (#2507).
+ */
+function claimReviewersCsv(task, codeReviewDefaults, defaultReviewers) {
+  return resolveClaimReviewerConfig(task?.metadata, codeReviewDefaults, defaultReviewers).csv;
+}
+
+/**
  * Completion handoff for claim prompts that create their own worktree and own
  * the forge lifecycle. `openPR: false` must remain the CoS provisioning posture,
  * so claimFlow is the explicit signal that keeps these prompts out of the
  * generic commit-only handoff.
+ *
+ * This is also the ONE emitter of the reviewer pin (#4770). Every claim
+ * generator persists the reviewer bundle it rendered into `{reviewers}` onto the
+ * task, so `resolveClaimReviewerConfig(task.metadata, …)` here reproduces that
+ * exact CSV — which means the pin covers all five claim task types from one call
+ * site, instead of three prose appends in `cosTaskGenerator.js` that a new claim
+ * generator could forget.
+ *
+ * @param {string} [reviewersCsv] - the emitted `--review-with` token list to pin;
+ *   empty suppresses the block (`buildReviewerPinNote` returns '').
  */
-function buildClaimFlowCompletionSection({ isTui = false, sentinelPath = null } = {}) {
+function buildClaimFlowCompletionSection({ isTui = false, sentinelPath = null, reviewersCsv = '' } = {}) {
+  const pin = buildReviewerPinNote(reviewersCsv);
   const lines = [
+    ...(pin ? [pin, ''] : []),
     '## Claim Workflow Handoff',
     'This is a self-managed claim flow. The claim prompt above owns its claim worktree, branch, PR/MR, review, merge or human-handoff, and cleanup. Follow its phase-specific exit conditions — do NOT stop after a code commit or hand the lifecycle back to PortOS.',
     '',
@@ -1794,7 +1820,7 @@ After completing your work and before committing, ${simplifyInstruction}. Fix an
     : discardWorktree
       ? buildProgrammaticOutputCompletionSection(sentinelPath)
       : claimFlow
-        ? buildClaimFlowCompletionSection({ isTui, sentinelPath })
+        ? buildClaimFlowCompletionSection({ isTui, sentinelPath, reviewersCsv: claimReviewersCsv(task, codeReviewDefaults, defaultReviewers) })
       : isTui
         ? buildTuiCompletionSection({
             willOpenPR, prCompletion, simplifyEnabled,
@@ -2254,6 +2280,7 @@ function buildLightContextSections(task, workspaceDir, worktreeInfo, isTruthyMet
     contractSections.push(buildClaimFlowCompletionSection({
       isTui,
       sentinelPath: resolveSentinelPath(worktreeInfo, workspaceDir, agentId),
+      reviewersCsv: claimReviewersCsv(task, codeReviewDefaults, defaultReviewers),
     }));
   } else if (isReadOnly) {
     contractSections.push(buildReadOnlyCompletionSection({

--- a/server/services/agentPromptBuilder.test.js
+++ b/server/services/agentPromptBuilder.test.js
@@ -294,6 +294,79 @@ describe('claim-flow completion handoff', () => {
     expect(prompt).toMatch(/## Claim Workflow Handoff/);
     expect(prompt).not.toMatch(/PortOS will merge it back after completion/);
   });
+
+  // The reviewer pin used to be appended by each of three claim-prompt
+  // generators; #4770 moved it here, off the task's persisted reviewer bundle,
+  // so it covers all five claim task types from ONE call site.
+  describe('reviewer pin', () => {
+    const claimMeta = (extra = {}) => ({ claimFlow: true, useWorktree: false, openPR: false, ...extra });
+
+    it('pins the reviewers the task persisted, exactly once', () => {
+      const prompt = buildLightContextPrompt(
+        makeTask({ metadata: claimMeta({ reviewers: ['codex', 'claude'], usernames: ['alice'] }) }),
+        '/repo', null, isTruthyMeta,
+        { isTui: true, providerId: 'codex-tui', providerCommand: 'codex' },
+      );
+
+      expect(prompt).toContain('## Reviewer pin — use the reviewers PortOS configured');
+      expect(prompt).toContain('--review-with codex,claude,@alice');
+      expect(prompt.match(/## Reviewer pin/g)).toHaveLength(1);
+      // The pin leads the handoff rather than replacing it.
+      expect(prompt.indexOf('## Reviewer pin')).toBeLessThan(prompt.indexOf('## Claim Workflow Handoff'));
+    });
+
+    it('carries the per-reviewer suffixes the task persisted into the pinned flag', () => {
+      const prompt = buildLightContextPrompt(
+        makeTask({
+          metadata: claimMeta({
+            reviewers: ['antigravity', 'ollama'],
+            usernames: [],
+            optionalReviewers: ['ollama'],
+            reviewerMaxRounds: { antigravity: 1 },
+            reviewerModels: { antigravity: 'gemini-3.7-flash' },
+            reviewerEfforts: { antigravity: 'medium' },
+          }),
+        }),
+        '/repo', null, isTruthyMeta,
+        { isTui: true, providerId: 'codex-tui', providerCommand: 'codex' },
+      );
+
+      expect(prompt).toContain('--review-with antigravity[gemini-3.7-flash]~max=1~effort=medium,ollama~opt');
+    });
+
+    it('emits the pin on the full API prompt path too', async () => {
+      const prompt = await buildAgentPrompt(
+        makeTask({ metadata: claimMeta({ reviewers: ['grok'], usernames: [] }) }),
+        {}, '/repo', null, isTruthyMeta, { providerType: 'api' },
+      );
+
+      expect(prompt).toContain('--review-with grok');
+      expect(prompt.match(/## Reviewer pin/g)).toHaveLength(1);
+    });
+
+    it('never pins a bare copilot on a claim task — the claim agent has no CLI to run it', async () => {
+      // A claim task queued before #4770 carries no reviewer metadata, so the
+      // pin falls through to the install default. Routing that through the claim
+      // resolver is what keeps an in-flight legacy task off the #2507 stall.
+      vi.mocked(getCodeReviewDefaults).mockResolvedValueOnce({ reviewers: ['copilot'] });
+      const prompt = await buildAgentPrompt(
+        makeTask({ metadata: claimMeta() }), {}, '/repo', null, isTruthyMeta, { providerType: 'api' },
+      );
+
+      expect(prompt).toContain('--review-with codex');
+      expect(prompt).not.toContain('--review-with copilot');
+    });
+
+    it('does not emit the pin for a non-claim task', () => {
+      const prompt = buildLightContextPrompt(
+        makeTask({ metadata: { openPR: false, reviewers: ['codex'] } }),
+        '/repo', null, isTruthyMeta,
+        { isTui: true, providerId: 'codex-tui', providerCommand: 'codex' },
+      );
+
+      expect(prompt).not.toContain('## Reviewer pin');
+    });
+  });
 });
 
 describe('buildLightContextPrompt', () => {

--- a/server/services/cosTaskGenerator.js
+++ b/server/services/cosTaskGenerator.js
@@ -22,7 +22,7 @@
 import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { sanitizeTaskMetadata, PIPELINE_BEHAVIOR_FLAGS, MAX_TOTAL_SPAWNS, normalizeReviewers, resolveReviewUsernames, resolveOptionalReviewers, resolveReviewerMaxRounds, resolveReviewerPins, buildReviewerEffortNote, buildReviewerPinNote, buildReviewersCsv, LOCAL_LLM_REVIEWERS, SWARM_COUNT_MIN, ISSUE_AUTHOR_FILTERS, CLAIM_OVERRIDE_CONTEXT_MAX_CHARS } from '../lib/validation.js';
+import { sanitizeTaskMetadata, PIPELINE_BEHAVIOR_FLAGS, MAX_TOTAL_SPAWNS, resolveClaimReviewerConfig, reviewerConfigMetadata, buildReviewerEffortNote, LOCAL_LLM_REVIEWERS, SWARM_COUNT_MIN, ISSUE_AUTHOR_FILTERS, CLAIM_OVERRIDE_CONTEXT_MAX_CHARS } from '../lib/validation.js';
 import { isPlainObject } from '../lib/objects.js';
 import { parsePlanItems, extractAllIds, findInProgressIds, pickFirstAvailable, diagnoseUnpickablePlan } from '../lib/planIds.js';
 import { loadState, saveState, withStateLock, isImprovementEnabled, isDaemonRunning } from './cosState.js';
@@ -485,33 +485,28 @@ export async function buildClaimWorkTask(app, {
 
   const resolvedAuthorFilter = resolveClaimAuthorFilter(issueAuthorFilter, metadata);
 
-  // Reviewers: explicit option wins; otherwise mirror the scheduler. Local-LLM
-  // reviewers stay in the operative list; an appended procedure below tells the
-  // claim agent how to invoke PortOS's review service instead of silently replacing
-  // the user's configured reviewer.
-  const reviewersList = reviewers !== undefined
-    ? normalizeClaimReviewers({ reviewers: Array.isArray(reviewers) ? reviewers : [reviewers] }, codeReviewDefaults?.reviewers)
-    : normalizeClaimReviewers(metadata, codeReviewDefaults?.reviewers);
-  // Arbitrary GitHub reviewer usernames appended as `@user` tokens so the
-  // claim prompt's `/do:next --review-with` gates the merge on them too. An
-  // explicit option wins, then a task-level list, then the Code Review Defaults.
-  const promptUsernames = resolveReviewUsernames(usernames ?? metadata.usernames, codeReviewDefaults?.usernames);
-  const promptOptionalReviewers = resolveOptionalReviewers(optionalReviewers ?? metadata.optionalReviewers, codeReviewDefaults?.optionalReviewers);
-  // Per-reviewer `~max=<n>` round caps ride the same explicit-option → task
-  // metadata → Code Review Defaults precedence.
-  const promptReviewerMaxRounds = resolveReviewerMaxRounds(reviewerMaxRounds ?? metadata.reviewerMaxRounds, codeReviewDefaults?.reviewerMaxRounds);
-  // Per-reviewer model pins (slashdo's `[<model>]` bracket) and reasoning efforts
-  // ride the same explicit-option → task metadata → Code Review Defaults
-  // precedence, and resolve together so the two describe one invocation (an agy
-  // model id can carry its effort as a suffix). The claim prompt runs its
-  // reviewers by hand rather than through `--review-with`, so the effort also
-  // lands as an appended instruction below — the CSV's `~effort=` suffix is
-  // slashdo grammar nothing in this flow parses.
-  const { reviewerModels: promptReviewerModels, reviewerEfforts: promptReviewerEfforts } = resolveReviewerPins({
+  // Reviewers: an explicit option wins per field, then the app's configured
+  // claim-work metadata, then the Code Review Defaults. One resolver for the
+  // whole bundle (list + usernames + `~opt` set + the three keyed pins), so the
+  // CSV the prompt names and the `reviewers` this task PERSISTS below cannot
+  // disagree. Local-LLM reviewers stay in the operative list; an appended
+  // procedure below tells the claim agent how to invoke PortOS's review service
+  // instead of silently replacing the user's configured reviewer.
+  const claimReviewers = resolveClaimReviewerConfig({
+    ...metadata,
+    reviewers: reviewers !== undefined ? (Array.isArray(reviewers) ? reviewers : [reviewers]) : metadata.reviewers,
+    usernames: usernames ?? metadata.usernames,
+    optionalReviewers: optionalReviewers ?? metadata.optionalReviewers,
+    reviewerMaxRounds: reviewerMaxRounds ?? metadata.reviewerMaxRounds,
     reviewerModels: reviewerModels ?? metadata.reviewerModels,
-    reviewerEfforts: reviewerEfforts ?? metadata.reviewerEfforts,
-  }, codeReviewDefaults);
-  const reviewersCsv = buildReviewersCsv(reviewersList, promptUsernames, promptOptionalReviewers, promptReviewerMaxRounds, promptReviewerModels, promptReviewerEfforts);
+    reviewerEfforts: reviewerEfforts ?? metadata.reviewerEfforts
+  }, codeReviewDefaults, codeReviewDefaults?.reviewers);
+  const {
+    reviewers: reviewersList,
+    reviewerModels: promptReviewerModels,
+    reviewerEfforts: promptReviewerEfforts,
+    csv: reviewersCsv
+  } = claimReviewers;
   const issueAuthorFilterBlock = resolveIssueAuthorFilterBlock(promptTaskType, resolvedAuthorFilter);
   const issueExcludeLabelsBlock = resolveIssueExcludeLabelsBlock(metadata.issueExcludeLabels);
   // Swarm mode (`/do:next --swarm`) is prepended (not an in-template
@@ -535,14 +530,16 @@ export async function buildClaimWorkTask(app, {
     + appendTargetWorkItemBlock(promptTaskType, targetRef, issueExcludeLabelsBlock)
     + appendPrefetchedIssueContext(promptTaskType, targetRef, issueContext)
     + appendClaimOverrideContext(overrideContext)
-    + appendReviewerPinBlock(reviewersCsv)
     + appendReviewerEffortBlock(reviewersList, promptReviewerEfforts, promptReviewerModels)
     + buildLocalReviewerInstructions(reviewersList, promptReviewerModels, promptReviewerEfforts);
 
   // Mirror the scheduler: inherit the delegated flow's isolation posture so the
   // JIRA route runs in a CoS-managed worktree rather than the live checkout.
+  // The resolved reviewer bundle rides along so the prompt builder's
+  // `resolveReviewerConfig(task.metadata, …)` reads back the list this prompt
+  // names — the reviewer pin is emitted once from there (#4770).
   const delegatedMeta = taskSchedule.DEFAULT_TASK_INTERVALS[promptTaskType]?.taskMetadata || {};
-  const taskMetadata = { claimFlow: true };
+  const taskMetadata = { ...reviewerConfigMetadata(claimReviewers), claimFlow: true };
   if ('useWorktree' in delegatedMeta) taskMetadata.useWorktree = delegatedMeta.useWorktree;
   if ('openPR' in delegatedMeta) taskMetadata.openPR = delegatedMeta.openPR;
 
@@ -555,26 +552,24 @@ export async function buildClaimWorkTask(app, {
  * scheduled claim-work resolution so the JIRA play button honors the user's
  * reviewer choice.
  *
- * Returns BOTH pieces because the two travel differently: `csv` fills the
- * template's `{reviewers}` placeholder, while `effortBlock` is appended prose —
- * the claim agent spawns each reviewer CLI itself, so no `--review-with` parser
- * ever reads the CSV's `~effort=` suffix.
+ * Returns each piece separately because they travel differently: `csv` fills the
+ * template's `{reviewers}` placeholder, `effortBlock` is appended prose (the
+ * claim agent spawns each reviewer CLI itself, so no `--review-with` parser ever
+ * reads the CSV's `~effort=` suffix), and `taskMetadata` is PERSISTED so the
+ * prompt builder resolves the same list back off the task record (#4770).
  */
 async function resolveClaimReviewerPrompt() {
   const codeReviewDefaults = await getCodeReviewDefaults().catch(() => null);
-  const list = normalizeClaimReviewers({}, codeReviewDefaults?.reviewers);
-  // Arbitrary GitHub reviewer usernames from the Code Review Defaults, appended
-  // as `@user` tokens so the play button's claim gates the merge on them too.
-  // Optional-reviewer set rides along so a `~opt` reviewer stays non-blocking,
-  // as do the per-reviewer `~max=<n>` round caps.
-  // Model + effort resolve together (an agy model id can carry its effort as a
-  // suffix), so the bracket and the appended instruction can't describe different
-  // invocations.
-  const { reviewerModels, reviewerEfforts } = resolveReviewerPins(null, codeReviewDefaults);
-  const csv = buildReviewersCsv(list, codeReviewDefaults?.usernames, codeReviewDefaults?.optionalReviewers, codeReviewDefaults?.reviewerMaxRounds, reviewerModels, reviewerEfforts);
+  // No task record exists yet for the play button, so the whole bundle resolves
+  // from the Code Review Defaults: the reviewer list, the `@user` tokens that
+  // gate the merge, the `~opt` set, the `~max=<n>` caps, and the model/effort
+  // pins (which resolve together — an agy model id can carry its effort as a
+  // suffix, so the bracket and the appended instruction can't disagree).
+  const config = resolveClaimReviewerConfig({}, codeReviewDefaults, codeReviewDefaults?.reviewers);
+  const { reviewers: list, reviewerModels, reviewerEfforts, csv } = config;
   return {
     csv,
-    pinBlock: appendReviewerPinBlock(csv),
+    taskMetadata: reviewerConfigMetadata(config),
     effortBlock: appendReviewerEffortBlock(list, reviewerEfforts, reviewerModels),
     localReviewerBlock: buildLocalReviewerInstructions(list, reviewerModels, reviewerEfforts),
   };
@@ -748,18 +743,12 @@ const appendTargetWorkItemBlock = (promptTaskType, ref, excludeLabelsBlock = '')
 const appendReviewerEffortBlock = (reviewers, reviewerEfforts, reviewerModels) =>
   appendBlock(buildReviewerEffortNote(reviewers, reviewerEfforts, { reviewerModels }));
 
-/**
- * Append the reviewer pin: the claim agent must review with the list PortOS
- * resolved, never with the host's saved slashdo defaults. Prose (not a
- * `{...}` placeholder) for the same reason as the effort block — a customized
- * legacy claim template would silently drop a new placeholder, and that is
- * exactly the install whose agent then adopts the host's saved slashdo
- * `--review-with` the moment it reaches for `/do:pr`.
- *
- * Takes the already-rendered CSV rather than the reviewer list so the block can
- * only ever name the same tokens the prompt's `{reviewers}` does.
- */
-const appendReviewerPinBlock = (reviewersCsv) => appendBlock(buildReviewerPinNote(reviewersCsv));
+// The reviewer pin (`buildReviewerPinNote`) is deliberately NOT appended here.
+// Each claim generator instead persists its resolved reviewer bundle onto the
+// task (`reviewerConfigMetadata`), and `buildClaimFlowCompletionSection` in
+// agentPromptBuilder.js emits the pin once from that record — covering all five
+// claim task types regardless of which generator built the body, instead of
+// three prose appends that must be kept in lockstep (#4770).
 
 /**
  * Append the invocation contract for claim reviewers that have no CLI binary.
@@ -826,7 +815,9 @@ export function buildLocalReviewerInstructions(reviewers, reviewerModels = {}, r
  * lifecycle ownership while `useWorktree/openPR` stay `false/false` so CoS does
  * not provision a nested worktree.
  *
- * @returns {Promise<{ ticketKey: string, prompt: string, taskMetadata: { useWorktree: boolean, openPR: boolean, claimFlow: boolean } }>}
+ * @returns {Promise<{ ticketKey: string, prompt: string, taskMetadata: { useWorktree: boolean, openPR: boolean, claimFlow: boolean } }>} —
+ *   `taskMetadata` also carries the resolved reviewer bundle so the prompt
+ *   builder's reviewer pin names this prompt's list (#4770).
  */
 export async function buildJiraTicketTask(app, ticketKey) {
   const { getTaskPrompt } = await import('./taskPromptService.js');
@@ -836,7 +827,7 @@ export async function buildJiraTicketTask(app, ticketKey) {
   const key = normalizeWorkItemRef(ticketKey);
 
   // Independent reads (prompt body + Code Review Defaults) — fetch concurrently.
-  const [template, { csv: reviewersCsv, pinBlock, effortBlock, localReviewerBlock }] = await Promise.all([
+  const [template, { csv: reviewersCsv, taskMetadata: reviewerMetadata, effortBlock, localReviewerBlock }] = await Promise.all([
     getTaskPrompt('claim-issue-jira'),
     resolveClaimReviewerPrompt(),
   ]);
@@ -848,11 +839,10 @@ export async function buildJiraTicketTask(app, ticketKey) {
     // a backreference.
     .replace(/\{reviewers\}/g, () => reviewersCsv)
     + appendTargetWorkItemBlock('claim-issue-jira', key)
-    + pinBlock
     + effortBlock
     + localReviewerBlock;
 
-  return { ticketKey: key, prompt, taskMetadata: { useWorktree: false, openPR: false, claimFlow: true } };
+  return { ticketKey: key, prompt, taskMetadata: { ...reviewerMetadata, useWorktree: false, openPR: false, claimFlow: true } };
 }
 
 /**
@@ -2878,7 +2868,9 @@ async function resolvePrWatcherBlock(app, taskType, metadata, taskSchedule) {
  * then render every token in the prompt template. `blocks` carries the
  * dynamically-assembled Markdown chunks produced by the deterministic
  * pre-steps above (reference-watch, pr-watcher, branch-/issue-reconcile,
- * PLAN gating). Pure string work — no gating, no early return.
+ * PLAN gating). String work plus ONE mutation: a template that drives its own
+ * reviewers stamps the resolved bundle back onto `metadata` (see below), the
+ * same way `applyPlanIdMetadata` writes `planId`.
  */
 async function buildImprovementTaskDescription({ promptTemplate, app, promptTaskType, metadata, blocks }) {
   // Resolve the `{reviewers}` the agent is told to run. When the task itself
@@ -2888,23 +2880,19 @@ async function buildImprovementTaskDescription({ promptTemplate, app, promptTask
   // loop directly, would always tell the agent to use Copilot regardless of the
   // user's configured reviewers. Settings I/O failures degrade to the hardcoded
   // default inside normalizeReviewers, so a read error never blocks dispatch.
+  //
+  // One resolver for the whole bundle (list + usernames + `~opt` set + the three
+  // keyed pins). Local-LLM reviewers stay in the operative list; their service
+  // invocation contract is appended after rendering so customized legacy prompts
+  // receive it without needing a new placeholder.
   const codeReviewDefaults = await getCodeReviewDefaults().catch(() => null);
-  // Keep local-LLM reviewers in the operative list. Their service invocation
-  // contract is appended after rendering so customized legacy prompts receive
-  // it without needing a new placeholder.
-  const promptReviewers = normalizeClaimReviewers(metadata, codeReviewDefaults?.reviewers);
-  // Arbitrary GitHub reviewer usernames appended as `@user` tokens so the claim
-  // prompt's `/do:next --review-with` gates the merge on them too. A task-level
-  // list overrides the Code Review Defaults; forge-agnostic, so not filtered.
-  const promptUsernames = resolveReviewUsernames(metadata.usernames, codeReviewDefaults?.usernames);
-  const promptOptionalReviewers = resolveOptionalReviewers(metadata.optionalReviewers, codeReviewDefaults?.optionalReviewers);
-  const promptReviewerMaxRounds = resolveReviewerMaxRounds(metadata.reviewerMaxRounds, codeReviewDefaults?.reviewerMaxRounds);
-  // Per-reviewer model pins ride the same precedence, emitted as slashdo's
-  // `[<model>]` bracket. Efforts resolve in the same call and are appended as an
-  // instruction after the substitutions below.
-  const { reviewerModels: promptReviewerModels, reviewerEfforts: promptReviewerEfforts } =
-    resolveReviewerPins(metadata, codeReviewDefaults);
-  const reviewersCsv = buildReviewersCsv(promptReviewers, promptUsernames, promptOptionalReviewers, promptReviewerMaxRounds, promptReviewerModels, promptReviewerEfforts);
+  const claimReviewers = resolveClaimReviewerConfig(metadata, codeReviewDefaults, codeReviewDefaults?.reviewers);
+  const {
+    reviewers: promptReviewers,
+    reviewerModels: promptReviewerModels,
+    reviewerEfforts: promptReviewerEfforts,
+    csv: reviewersCsv
+  } = claimReviewers;
   // {issueAuthorFilter} directive — the filter was already merged (global →
   // per-app override) and value-constrained by sanitizeTaskMetadata, so read it
   // from `metadata` (default 'self', the slashdo `/do:next --self` security
@@ -2918,9 +2906,14 @@ async function buildImprovementTaskDescription({ promptTemplate, app, promptTask
   // sanitizeTaskMetadata, so read it from `metadata`. Empty for non-issue
   // trackers and when swarm is off.
   const swarmBlock = resolveSwarmBlock(promptTaskType, metadata.swarmCount);
-  // Does this template drive its own reviewers? Gates the three reviewer blocks
-  // appended after the substitutions below.
+  // Does this template drive its own reviewers? Gates the two reviewer blocks
+  // appended after the substitutions below, and the persisted bundle.
   const rendersReviewers = /\{reviewers\}/.test(promptTemplate);
+  // Persist what the prompt just named, so `resolveReviewerConfig(task.metadata, …)`
+  // at spawn time reads back THIS list instead of re-deriving the install-wide
+  // Code Review Defaults — that is what lets the reviewer pin be emitted once,
+  // from the completion section, for every claim task type (#4770).
+  if (rendersReviewers) Object.assign(metadata, reviewerConfigMetadata(claimReviewers));
 
   return `${swarmBlock}${promptTemplate}`
     // {modeInstructions} before {trackerInstructions}: the file-issues mode
@@ -2951,16 +2944,15 @@ async function buildImprovementTaskDescription({ promptTemplate, app, promptTask
     .replace(/\{repoFullName\}/g, () => blocks.repoFullName)
     .replace(/\{defaultBranch\}/g, () => blocks.defaultBranch)
     .replace(/\{planConstraint\}/g, () => blocks.planConstraint)
-    // The reviewer pin, the effort note, and the local-reviewer procedure all
-    // accompany the reviewer CSV, so they are appended only when this template
-    // actually carries one. A task type whose prompt does NOT drive its own
-    // reviewers gets its PR reviewed by the completion workflow instead, and
-    // `buildCliCompletionSection` already emits `--review-with` (and states the
-    // effort) next to that `/do:pr` step — appending here too would print the
-    // same instruction twice and give it two owners to drift apart.
+    // The effort note and the local-reviewer procedure accompany the reviewer
+    // CSV, so they are appended only when this template actually carries one. A
+    // task type whose prompt does NOT drive its own reviewers gets its PR
+    // reviewed by the completion workflow instead, and `buildCliCompletionSection`
+    // already emits `--review-with` (and states the effort) next to that
+    // `/do:pr` step — appending here too would print the same instruction twice
+    // and give it two owners to drift apart.
     + (rendersReviewers
-        ? appendReviewerPinBlock(reviewersCsv)
-          + appendReviewerEffortBlock(promptReviewers, promptReviewerEfforts, promptReviewerModels)
+        ? appendReviewerEffortBlock(promptReviewers, promptReviewerEfforts, promptReviewerModels)
           + buildLocalReviewerInstructions(promptReviewers, promptReviewerModels, promptReviewerEfforts)
         : '');
 }
@@ -3198,13 +3190,7 @@ export async function generateManagedAppImprovementTaskForType(taskType, app, st
 
   return task;
 }
-const CLAIM_REVIEWER_FALLBACK = ['codex'];
-
-/** Claim workflows are unattended and must use an invokable reviewer. */
-export function normalizeClaimReviewers(metadata, configuredReviewers) {
-  const fallback = Array.isArray(configuredReviewers) && configuredReviewers.length
-    ? configuredReviewers
-    : CLAIM_REVIEWER_FALLBACK;
-  const reviewers = normalizeReviewers(metadata, fallback).filter((reviewer) => reviewer !== 'copilot');
-  return reviewers.length ? reviewers : [...CLAIM_REVIEWER_FALLBACK];
-}
+// `normalizeClaimReviewers` moved to server/lib/cosValidation.js (#4770): the
+// prompt builder needs the same copilot guard when it re-resolves reviewers off
+// a persisted claim task, and a service-level definition would have meant a
+// second copy there.

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -75,7 +75,6 @@ import {
   buildPrefetchedIssueContextBlock,
   buildClaimOverrideContextBlock,
   buildLocalReviewerInstructions,
-  normalizeClaimReviewers,
   resolveTaskInputHook,
   resolveReconcileDrainGate,
   applyPerpetualDrainCap
@@ -92,11 +91,6 @@ const task = (id, metadata = {}) => ({ id, metadata });
 const noCooldown = () => Promise.resolve(false);
 
 describe('claim reviewer resolution', () => {
-  it('uses codex instead of resurrecting Copilot when claim settings are absent or Copilot-only', () => {
-    expect(normalizeClaimReviewers({}, undefined)).toEqual(['codex']);
-    expect(normalizeClaimReviewers({ reviewers: ['copilot'] }, ['copilot'])).toEqual(['codex']);
-  });
-
   // The claim prompts run their local reviewers BEFORE the PR/MR is opened, so
   // the diff has to come from the branch. A forge command (`gh pr diff` /
   // `glab mr diff`) would resolve nothing at that point and the one review pass
@@ -371,15 +365,19 @@ describe('isCooldownExemptTask', () => {
 // not the bare `normalizeReviewers(metadata)` call. The claim-specific wrapper
 // also prevents the retired Copilot fallback from reappearing.
 describe('{reviewers} interpolation honors Code Review Defaults', () => {
-  it('resolves getCodeReviewDefaults and passes them through the claim reviewer normalizer', () => {
+  it('resolves getCodeReviewDefaults and routes every claim path through the one claim reviewer resolver', () => {
     expect(GEN_SRC).toContain("import { getCodeReviewDefaults } from './codeReview.js'");
-    expect(GEN_SRC).toContain('normalizeClaimReviewers(metadata, codeReviewDefaults?.reviewers)');
+    // One resolver per claim path: the list, the `@user` tokens, the `~opt` set
+    // and the three keyed pins come out together, so a new pin kind cannot reach
+    // one site and silently miss another. It also applies the claim copilot
+    // guard, which is what keeps the retired Copilot fallback from reappearing.
+    expect(GEN_SRC).toContain('resolveClaimReviewerConfig(metadata, codeReviewDefaults, codeReviewDefaults?.reviewers)');
+    expect(GEN_SRC).toContain('resolveClaimReviewerConfig({}, codeReviewDefaults, codeReviewDefaults?.reviewers)');
     expect(GEN_SRC).not.toMatch(/normalizeReviewers\(metadata\)(?!,)/);
   });
 
   it('keeps local-LLM reviewers and appends their fail-closed invocation procedure', () => {
     expect(GEN_SRC).not.toContain('.filter((r) => !LOCAL_LLM_REVIEWERS.includes(r))');
-    expect(GEN_SRC).toContain('buildReviewersCsv(promptReviewers, promptUsernames, promptOptionalReviewers, promptReviewerMaxRounds, promptReviewerModels, promptReviewerEfforts)');
     expect(GEN_SRC).toContain('buildLocalReviewerInstructions(promptReviewers');
   });
 
@@ -399,24 +397,27 @@ describe('{reviewers} interpolation honors Code Review Defaults', () => {
     expect(GEN_SRC).not.toMatch(/buildReviewerEffortNote\([^)]*reviewWith/);
   });
 
-  it('appends the reviewer pin on the SCHEDULED claim path too', () => {
-    // The manual/Issues-tab claim and the JIRA play button are covered
-    // behaviorally below; `buildImprovementTaskDescription` is not exported, so
-    // its site is pinned by source. A scheduled claim that renders the CSV but
-    // skips the pin leaves that agent free to fall back to the host's saved
-    // slashdo --review-with default.
-    expect(GEN_SRC).toContain('rendersReviewers\n        ? appendReviewerPinBlock(reviewersCsv)');
+  it('persists the resolved reviewer bundle on the SCHEDULED claim path instead of appending a pin (#4770)', () => {
+    // The pin now has ONE owner — buildClaimFlowCompletionSection, which reads
+    // the reviewers back off the task record — so every claim generator must
+    // stamp what its prompt named. The manual/Issues-tab claim and the JIRA play
+    // button are covered behaviorally below; `buildImprovementTaskDescription`
+    // is not exported, so its site is pinned by source.
+    expect(GEN_SRC).toContain('if (rendersReviewers) Object.assign(metadata, reviewerConfigMetadata(claimReviewers))');
+    // No generator may re-grow a per-site pin append: three prose copies drifting
+    // apart is exactly what #4770 collapsed.
+    expect(GEN_SRC).not.toContain('appendReviewerPinBlock');
   });
 
   it('threads per-reviewer ~max round caps into the prompt CSV on both claim paths', () => {
     // The `{reviewers}` token is the whole reviewer contract the claim agent
     // gets — it runs each reviewer by hand, so a configured cap only reaches the
     // run if the CSV carries it. Both the scheduled path and buildClaimWorkTask
-    // resolve it with task-over-default precedence (unit-tested in
-    // validation.test.js).
-    expect(GEN_SRC).toContain('resolveReviewerMaxRounds(metadata.reviewerMaxRounds, codeReviewDefaults?.reviewerMaxRounds)');
-    expect(GEN_SRC).toContain('resolveReviewerMaxRounds(reviewerMaxRounds ?? metadata.reviewerMaxRounds, codeReviewDefaults?.reviewerMaxRounds)');
-    expect(GEN_SRC).toContain('buildReviewersCsv(reviewersList, promptUsernames, promptOptionalReviewers, promptReviewerMaxRounds, promptReviewerModels, promptReviewerEfforts)');
+    // feed the cap into the shared claim resolver, which applies task-over-default
+    // precedence (unit-tested in cosValidation.test.js).
+    expect(GEN_SRC).toContain('reviewerMaxRounds: reviewerMaxRounds ?? metadata.reviewerMaxRounds');
+    expect(GEN_SRC).toContain('resolveClaimReviewerConfig(metadata, codeReviewDefaults, codeReviewDefaults?.reviewers)');
+    expect(GEN_SRC).not.toContain('resolveReviewerMaxRounds(');
   });
 
   it('threads per-reviewer model pins into the prompt CSV on both claim paths (#3133)', () => {
@@ -430,14 +431,15 @@ describe('{reviewers} interpolation honors Code Review Defaults', () => {
     // agy model id can carry its effort as a suffix, so a path that resolved the
     // models alone would emit `--model <suffixed> --effort <tier>`, a pair agy
     // rejects, while the other paths emitted the split form.
-    expect(GEN_SRC).toContain('resolveReviewerPins(metadata, codeReviewDefaults)');
     expect(GEN_SRC).toContain('reviewerModels: reviewerModels ?? metadata.reviewerModels');
     expect(GEN_SRC).toContain('reviewerEfforts: reviewerEfforts ?? metadata.reviewerEfforts');
     // The play-button path reads the defaults directly (no task metadata to layer).
-    expect(GEN_SRC).toContain('resolveReviewerPins(null, codeReviewDefaults)');
-    // No path may resolve one map without the other.
+    expect(GEN_SRC).toContain('resolveClaimReviewerConfig({}, codeReviewDefaults, codeReviewDefaults?.reviewers)');
+    // No path may resolve one map without the other — or reach past the shared
+    // claim resolver, which wraps `resolveReviewerPins` for all three sites.
     expect(GEN_SRC).not.toContain('resolveReviewerModels(');
     expect(GEN_SRC).not.toContain('resolveReviewerEfforts(');
+    expect(GEN_SRC).not.toContain('resolveReviewerPins(');
   });
 });
 
@@ -484,7 +486,7 @@ describe('claim-work single-source routing', () => {
     expect(GEN_SRC).toContain('taskSchedule.DEFAULT_TASK_INTERVALS[promptTaskType]?.taskMetadata');
     expect(GEN_SRC).toContain("'useWorktree' in delegatedMeta");
     expect(GEN_SRC).toContain("'openPR' in delegatedMeta");
-    expect(GEN_SRC).toContain('const taskMetadata = { claimFlow: true }');
+    expect(GEN_SRC).toContain('const taskMetadata = { ...reviewerConfigMetadata(claimReviewers), claimFlow: true }');
     expect(GEN_SRC).toContain('metadata.claimFlow = true');
   });
 
@@ -510,9 +512,11 @@ describe('claim-work single-source routing', () => {
     const fn = GEN_SRC.slice(GEN_SRC.indexOf('export async function buildClaimWorkTask('));
     expect(fn).toMatch(/resolveClaimWorkMetadata\(app\)/);
     expect(fn).toMatch(/resolveClaimAuthorFilter\(issueAuthorFilter, metadata\)/);
-    // reviewers fall back to Code Review Defaults through the claim-specific
-    // normalizer, which keeps local LLMs and excludes the retired Copilot path.
-    expect(fn).toMatch(/normalizeClaimReviewers\(metadata, codeReviewDefaults\?\.reviewers\)/);
+    // Reviewers layer an explicit per-field option over the configured claim-work
+    // metadata, then fall back to the Code Review Defaults — through the claim
+    // resolver, which keeps local LLMs and excludes the retired Copilot path.
+    expect(fn).toMatch(/resolveClaimReviewerConfig\(\{\s*\.\.\.metadata,/);
+    expect(fn).toMatch(/reviewers: reviewers !== undefined/);
     expect(fn).toMatch(/LOCAL_LLM_REVIEWERS\.includes/);
     // A direct claim-work prompt customization overrides the tracker body, same
     // as the scheduled router's promptKeyForBody selection.
@@ -664,9 +668,6 @@ describe('buildJiraTicketTask', () => {
     expect(prompt).not.toContain('{reviewers}');
     expect(prompt).toContain('ollama');
     expect(prompt).toContain('Local Reviewer Procedure');
-    // The pin travels with the CSV on this path too — the play button's claim
-    // agent is the same kind of slashdo-capable session as the /do:next one.
-    expect(prompt).toContain('--review-with ollama,@alice');
     expect(prompt).not.toContain('copilot');
     expect(prompt).toContain('@alice');
     // Target-ticket constraint pins the uppercased key.
@@ -675,8 +676,21 @@ describe('buildJiraTicketTask', () => {
     // Ticket key normalized to upper-case.
     expect(ticketKey).toBe('PROJ-1234');
     // claim-issue-jira self-manages worktree + PR; claimFlow keeps that
-    // lifecycle from falling into CoS's generic false/false handoff.
-    expect(taskMetadata).toEqual({ useWorktree: false, openPR: false, claimFlow: true });
+    // lifecycle from falling into CoS's generic false/false handoff. The
+    // resolved reviewer bundle rides along so the prompt builder's reviewer pin
+    // names the same tokens this prompt does (#4770) — the play button's claim
+    // agent is the same kind of slashdo-capable session as the /do:next one.
+    expect(taskMetadata).toEqual({
+      useWorktree: false,
+      openPR: false,
+      claimFlow: true,
+      reviewers: ['ollama'],
+      usernames: ['alice'],
+      optionalReviewers: [],
+      reviewerMaxRounds: {},
+      reviewerModels: {},
+      reviewerEfforts: {}
+    });
   });
 
   it('is exported so the /tasks/jira-ticket route reuses the shared assembly', () => {
@@ -1645,19 +1659,24 @@ describe('automated drain refills do not clear their own convergence brakes', ()
 describe('buildClaimWorkTask reviewer pin', () => {
   const app = { id: 'acme', name: 'Acme App', repoPath: '/repos/acme' };
 
-  it('pins the configured reviewers against slashdo saved defaults', async () => {
-    const { prompt } = await buildClaimWorkTask(app);
+  it('persists the reviewers its prompt names so the pin has one owner', async () => {
+    const { prompt, taskMetadata } = await buildClaimWorkTask(app);
     // The configured claim-work reviewers reach the prompt body...
-    expect(prompt).toContain('Reviewers: codex,claude');
-    // ...and the appended pin names the same tokens as an explicit flag, so the
-    // agent has the exact text to pass rather than a list to re-derive.
-    expect(prompt).toContain('--review-with codex,claude');
-    expect(prompt).toContain('Reviewer pin');
+    expect(prompt).toContain('Reviewers: codex,claude,@alice');
+    // ...and the SAME resolved list is stamped on the task, so
+    // resolveReviewerConfig(task.metadata, …) at spawn time reproduces the CSV
+    // the prompt names rather than re-deriving the install-wide defaults.
+    expect(taskMetadata.reviewers).toEqual(['codex', 'claude']);
+    expect(taskMetadata.usernames).toEqual(['alice']);
+    expect(taskMetadata.claimFlow).toBe(true);
+    // The pin itself is emitted once from buildClaimFlowCompletionSection, not
+    // appended here (#4770).
+    expect(prompt).not.toContain('Reviewer pin');
   });
 
-  it('carries an explicitly requested reviewer list into the pin, not the configured one', async () => {
-    const { prompt } = await buildClaimWorkTask(app, { reviewers: ['claude'] });
-    expect(prompt).toContain('--review-with claude');
-    expect(prompt).not.toContain('--review-with codex,claude');
+  it('carries an explicitly requested reviewer list into the persisted bundle, not the configured one', async () => {
+    const { prompt, taskMetadata } = await buildClaimWorkTask(app, { reviewers: ['claude'] });
+    expect(prompt).toContain('Reviewers: claude,@alice');
+    expect(taskMetadata.reviewers).toEqual(['claude']);
   });
 });


### PR DESCRIPTION
## Summary

- **Claim tasks now persist the reviewers their prompt names.** All three claim generators (`/do:next` button, JIRA play button, scheduled `claim-work` router) stamp the resolved bundle — list, `@user` tokens, `~opt` set, and the three keyed pins — onto `taskMetadata` via `reviewerConfigMetadata`. `resolveReviewerConfig(task.metadata, …)` then resolves the same list the prompt body rendered, instead of the install-wide Code Review Defaults.
- **The "Reviewer pin" block has one owner.** `buildClaimFlowCompletionSection` emits it once from the task record, covering all five claim task types regardless of which generator built the body. The three per-site `appendReviewerPinBlock` calls in `cosTaskGenerator.js` are gone.
- **One shared resolver.** `resolveClaimReviewerConfig` (in `server/lib/cosValidation.js`) replaces five hand-copied resolver calls at each of four sites, and returns the emitted CSV alongside the bundle so the prompt text and the persisted metadata cannot describe different reviewers.

### Backward compatibility

A claim task queued before this change carries no reviewer metadata and still falls through to the install defaults — but now routed through the claim copilot guard (`claimSafeReviewers`), so an in-flight legacy task can't be pinned to `copilot`, which a claim agent has no CLI to invoke (#2507).

## Test plan

- `cd server && npm test` — 32767 passed, 1563 files green.
- New coverage:
  - `server/lib/cosValidation.test.js` — round-trip: persisting `reviewerConfigMetadata` makes a second `resolveClaimReviewerConfig` reproduce the first CSV; a different install's defaults cannot override what the task persisted; junk keys/values are sanitized out; an empty patch (not `null`) when nothing survives.
  - `server/services/agentPromptBuilder.test.js` — the pin renders exactly once, ahead of the handoff, on both the light and full prompt paths; per-reviewer `[model]`/`~opt`/`~max`/`~effort` suffixes survive into the pinned flag; a legacy claim task never gets a bare `copilot`; a non-claim task gets no pin.
  - `server/services/cosTaskGenerator.test.js` — `buildClaimWorkTask` and `buildJiraTicketTask` persist the bundle their prompt named and no longer append the pin.
  - `server/routes/cos.test.js` — the `/tasks/slashdo` `next` branch carries the bundle through to `addTask`.

Closes #4770
