### PR TITLE
fix: stop PortOS's own PORT from leaking into the vLLM compose start

### DIFF
--- a/server/lib/streamingSpawn.js
+++ b/server/lib/streamingSpawn.js
@@ -39,7 +39,14 @@ const CANCEL_POLL_MS = 1_000;
  *   line readers — pass `/[\r\n]+/` for a tool whose progress bar redraws the
  *   same line with a bare `\r`, so each redraw surfaces instead of the stream
  *   going silent for the length of a multi-gigabyte download. `isCancelled` is
- *   polled while the command runs; see CANCEL_POLL_MS.
+ *   polled while the command runs; see CANCEL_POLL_MS. An unset `env` inherits
+ *   this whole process's environment — fine for most callers, but `docker
+ *   compose` substitutes `${VAR}` refs in a compose file from ITS OWN caller's
+ *   env before falling back to the project's `.env`, so a compose-based target
+ *   whose file happens to reuse a name PortOS also sets (`PORT` is the
+ *   recurring offender — see `services/vllmQwenManager.js#startVllmQwenProject`)
+ *   gets silently remapped. Audit a new docker-compose target's variable names
+ *   against `lib/ports.js` before assuming the default inheritance is safe.
  * @returns {Promise<{success: boolean, error?: string}>}
  */
 export function runStreamingCommand(cmd, args, onLine, { timeoutMs = 0, cwd, env, spawnImpl = spawn, splitRe, isCancelled } = {}) {

--- a/server/services/vllmQwenManager.js
+++ b/server/services/vllmQwenManager.js
@@ -30,6 +30,8 @@ import { join } from 'path';
 import { atomicWrite, formatBytes, tryReadFile } from '../lib/fileUtils.js';
 import { runStreamingCommand } from '../lib/streamingSpawn.js';
 import { findCommandOnPath } from '../lib/processEnv.js';
+import { localEndpointPort } from '../lib/localProviderRuntime.js';
+import { PORTS } from '../lib/ports.js';
 import {
   inspectVllmQwenProject,
   vllmProjectSetupState,
@@ -264,20 +266,37 @@ export async function provisionVllmQwenProject({ emit, isCancelled }) {
  * `lib/vllmQwenProject.js` for why each refusal exists. No image build, no
  * weight download: those are `provisionVllmQwenProject`, behind their own button.
  *
- * @param {{emit: (line: string) => void, isCancelled: () => boolean}} ctx
+ * The compose file maps `"${PORT:-18020}:${PORT:-18020}"` and its healthcheck
+ * probes `http://127.0.0.1:${PORT:-18020}/health` — both resolved by `docker
+ * compose` from ITS OWN caller's environment, not from the project's `.env`
+ * (shell env wins over `.env` in compose's variable-substitution precedence).
+ * `runStreamingCommand` spawns `docker` inheriting the full PortOS server
+ * environment by default, and PortOS's own `PORT` (its API server's port,
+ * 5555) collides with the SAME variable name — so an unset `env` here silently
+ * remaps the container onto PortOS's own port instead of vLLM's 18020, and the
+ * readiness probe (hardcoded to 18020) then reports ECONNREFUSED forever, even
+ * though the container is up and healthy. Confirmed on a real RTX 3090 run
+ * (#4821) — `docker inspect` showed the resulting bind as literally invalid
+ * (`{invalid IP 5555}`) rather than a working mapping on the wrong port.
+ * Passing `PORT` explicitly, derived from the endpoint this checklist actually
+ * probes, is what keeps compose's substitution aligned with it regardless of
+ * whatever `PORT` PortOS's own process happens to be running under.
+ *
+ * @param {{emit: (line: string) => void, endpoint?: string, isCancelled: () => boolean}} ctx
  * @returns {Promise<{success: boolean, error?: string}>}
  */
-export async function startVllmQwenProject({ emit, isCancelled }) {
+export async function startVllmQwenProject({ emit, endpoint, isCancelled }) {
   const project = await inspectVllmQwenProject();
   const blocked = vllmStartBlockedReason(project);
   if (blocked) return { success: false, error: blocked };
   if (isCancelled()) return { success: false, error: 'Cancelled before the container was started.' };
+  const port = localEndpointPort(endpoint) || PORTS.VLLM_QWEN;
   emit(`Starting the vLLM container from ${project.dir} (${project.composeFile}).`);
   emit('The image and weights are already on disk — this only brings the service up.');
   return runStreamingCommand(
     'docker',
     ['compose', '--profile', 'single', 'up', '-d'],
     emit,
-    { timeoutMs: CONTROL_TIMEOUT_MS, cwd: project.dir },
+    { timeoutMs: CONTROL_TIMEOUT_MS, cwd: project.dir, env: { PORT: String(port) } },
   );
 }

--- a/server/services/vllmQwenManager.test.js
+++ b/server/services/vllmQwenManager.test.js
@@ -320,6 +320,34 @@ describe('startVllmQwenProject', () => {
     );
   });
 
+  // Regression for #4821: the compose file maps "${PORT:-18020}:${PORT:-18020}"
+  // and resolves that against docker's OWN caller environment, not the
+  // project's .env — an unset `env` here lets PortOS's own PORT (its API
+  // server's port, 5555 by default) leak into the child process and collide,
+  // remapping the container onto the wrong port. Confirmed on a real RTX 3090
+  // run: the resulting bind was literally invalid rather than just wrong.
+  it('pins PORT to the vLLM loopback port so PortOS\'s own PORT cannot leak into compose', async () => {
+    await startVllmQwenProject({ emit: () => {}, isCancelled: () => false });
+
+    expect(streaming.runStreamingCommand).toHaveBeenCalledWith(
+      'docker',
+      ['compose', '--profile', 'single', 'up', '-d'],
+      expect.any(Function),
+      expect.objectContaining({ env: { PORT: '18020' } }),
+    );
+  });
+
+  it('derives PORT from a non-default endpoint rather than assuming 18020', async () => {
+    await startVllmQwenProject({ emit: () => {}, endpoint: 'http://127.0.0.1:19999/v1', isCancelled: () => false });
+
+    expect(streaming.runStreamingCommand).toHaveBeenCalledWith(
+      'docker',
+      ['compose', '--profile', 'single', 'up', '-d'],
+      expect.any(Function),
+      expect.objectContaining({ env: { PORT: '19999' } }),
+    );
+  });
+
   it('refuses to run compose when the project is not demonstrably prepared', async () => {
     project.vllmStartBlockedReason.mockReturnValue('no Qwen weights are cached yet');
 


### PR DESCRIPTION
## Summary

- `startVllmQwenProject` spawned `docker compose --profile single up -d` inheriting PortOS's full process environment by default. The vLLM Qwen3.8-27B compose file maps `"${PORT:-18020}:${PORT:-18020}"` and its healthcheck probes the same variable — both resolved by `docker compose` from its *own caller's* environment (shell wins over the project's `.env` in compose's substitution precedence). PortOS's own `PORT` (its API server's port, 5555 by default) collides with that exact variable name, so the container silently got remapped onto the wrong port instead of 18020.
- The readiness checklist's confirmation probe is hardcoded to `127.0.0.1:18020`, so this bug meant the "Clone, build & prepare vLLM (Qwen3.8-27B), then start" action would report failure (`ECONNREFUSED`) forever on the very first click, on every install, even though the container came up and was healthy — just on the wrong port.
- Fix: pass `env: { PORT: String(port) }` explicitly to the `docker compose` call, deriving `port` from the endpoint the checklist actually probes (falling back to `PORTS.VLLM_QWEN` = 18020), so compose's substitution stays aligned with PortOS's expectation regardless of what `PORT` the PortOS process itself happens to be running under.
- Added a one-sentence breadcrumb to `runStreamingCommand`'s JSDoc (`server/lib/streamingSpawn.js`) pointing future docker-compose integrations at this class of risk (audit compose variable names against `lib/ports.js`).

## Verification (real RTX 3090 hardware — closes #4821)

Ran the actual guided install end-to-end against a live PortOS instance on a Windows + WSL2 + Docker Desktop RTX 3090 host, per #4821's checklist:

- [x] `.env` carries `EXTRA_ARGS`, `SPEC=dflash2`, `PREFIX_CACHE=1`, `VLLM_WSL2_ENABLE_PIN_MEMORY=1`, `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:False` — all 6 written correctly on first click.
- [x] `curl -H "Authorization: Bearer $VLLM_API_KEY" http://127.0.0.1:18020/v1/models` answers, and the same URL answers from the PortOS side — confirmed **after** this fix; before it, `docker inspect` showed the container's port binding as literally invalid (`{invalid IP 5555}`), not just wrong.
- [x] The generated key landed on both seeded providers and never appeared in a log line.
- [x] A CoS-style agent turn (real `opencode` CLI run against the live server, using the exact `OPENCODE_CONFIG_CONTENT` shape PortOS generates) actually called a tool — wrote a file, confirmed on disk, not just described in text.
- [x] Re-clicking the action on the now-prepared project skipped build/prepare and went straight to start.
- [x] Timings sane against the 6h step bound — full first-run provisioning (image build + ~19.5GB weight download/requantization + cold start) completed in well under 2 hours.

One unrelated environmental artifact found during verification, not a PortOS defect: this test host had orphaned Docker containers from an earlier manual (non-PortOS) setup attempt sharing the same compose project name, which caused a `.env`-file-vs-actual-running-key mismatch. PortOS's own provider records held the correct, working key throughout (verified it authenticates) — the mismatch only affected an operator manually reading `.env` by hand on this specific machine's leftover state, not anything PortOS wrote or read.

## Test plan

- [x] `server/services/vllmQwenManager.test.js` — added 2 regression tests covering the `PORT` env pin (default endpoint and a custom endpoint), 21/21 tests pass
- [x] `server/lib/streamingSpawn.test.js` — unaffected, 8/8 pass
- [x] Full server suite (`npm test` in `server/`): 33128 passed / 14 failed / 60 skipped — all 14 failures are pre-existing and unrelated to this change (a Python venv `ModuleNotFoundError` in `trellis2NormalBake.test.js`, a Windows-shell-quoting issue in `askService.test.js`, and a timeout in `qwenAgentParsers.test.js`'s file-scan test) — none touch `vllmQwenManager.js` or `streamingSpawn.js`
- [x] Verified live against real RTX 3090 hardware, per the checklist above

Closes #4821