### PR TITLE
feat: surface durable CoS agent feedback

### DIFF
--- a/client/src/components/cos/tabs/LearningTab.feedback.test.jsx
+++ b/client/src/components/cos/tabs/LearningTab.feedback.test.jsx
@@ -1,0 +1,25 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { FeedbackSummary } from './LearningTab';
+
+describe('LearningTab FeedbackSummary', () => {
+  it('labels the feedback population as durable across live and archived runs', () => {
+    render(<FeedbackSummary feedback={{
+      total: 12,
+      positive: 9,
+      neutral: 1,
+      negative: 2,
+      satisfactionRate: 75
+    }} />);
+
+    expect(screen.getByText('User Feedback')).toBeInTheDocument();
+    expect(screen.getByText('Durable ratings across live and archived agent runs')).toBeInTheDocument();
+    expect(screen.getByText('75%')).toBeInTheDocument();
+    expect(screen.getByText('12 rated runs retained in the current archive window')).toBeInTheDocument();
+  });
+
+  it('stays out of the learning view until a rating exists', () => {
+    const { container } = render(<FeedbackSummary feedback={{ total: 0 }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/client/src/components/cos/tabs/LearningTab.jsx
+++ b/client/src/components/cos/tabs/LearningTab.jsx
@@ -25,6 +25,7 @@ import {
   ShieldCheck,
   ShieldAlert,
   ShieldQuestion,
+  MessageSquare,
   X,
   Undo2
 } from 'lucide-react';
@@ -42,6 +43,54 @@ export const runsLabel = (item, noun = 'runs') =>
     ? `${item.windowedCompleted} recent ${noun}`
     : `${item?.completed} ${noun}`;
 
+export function FeedbackSummary({ feedback }) {
+  if (!feedback?.total) return null;
+
+  const satisfaction = feedback.satisfactionRate ?? 0;
+  const satisfactionClass = satisfaction >= 80
+    ? 'text-port-success'
+    : satisfaction >= 60
+      ? 'text-port-warning'
+      : 'text-port-error';
+
+  return (
+    <div className="bg-port-card border border-port-border rounded-lg p-4">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div>
+          <div className="flex items-center gap-2">
+            <MessageSquare size={16} className="text-port-accent" />
+            <h4 className="text-sm font-medium text-white">User Feedback</h4>
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            Durable ratings across live and archived agent runs
+          </p>
+        </div>
+        <div className="grid grid-cols-4 gap-4 sm:gap-6 text-center">
+          <div>
+            <div className={`text-lg font-bold ${satisfactionClass}`}>{satisfaction}%</div>
+            <div className="text-[11px] text-gray-500">helpful</div>
+          </div>
+          <div>
+            <div className="text-lg font-bold text-port-success">{feedback.positive}</div>
+            <div className="text-[11px] text-gray-500">positive</div>
+          </div>
+          <div>
+            <div className="text-lg font-bold text-gray-300">{feedback.neutral}</div>
+            <div className="text-[11px] text-gray-500">neutral</div>
+          </div>
+          <div>
+            <div className="text-lg font-bold text-port-error">{feedback.negative}</div>
+            <div className="text-[11px] text-gray-500">negative</div>
+          </div>
+        </div>
+      </div>
+      <div className="text-xs text-gray-500 mt-3 pt-3 border-t border-port-border">
+        {feedback.total} rated run{feedback.total === 1 ? '' : 's'} retained in the current archive window
+      </div>
+    </div>
+  );
+}
+
 export default function LearningTab() {
   const [learning, setLearning] = useState(null);
   const [performance, setPerformance] = useState(null);
@@ -49,6 +98,7 @@ export default function LearningTab() {
   const [durations, setDurations] = useState(null);
   const [routing, setRouting] = useState(null);
   const [confidence, setConfidence] = useState(null);
+  const [feedback, setFeedback] = useState(null);
   const [dismissed, setDismissed] = useState([]);
   const [showDismissed, setShowDismissed] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -67,13 +117,14 @@ export default function LearningTab() {
 
   const loadData = useCallback(async () => {
     setLoading(true);
-    const [learningData, performanceData, skippedData, durationsData, routingData, confidenceData, dismissedData] = await Promise.all([
+    const [learningData, performanceData, skippedData, durationsData, routingData, confidenceData, feedbackData, dismissedData] = await Promise.all([
       api.getCosLearning().catch(() => null),
       api.getCosLearningPerformance().catch(() => null),
       api.getCosLearningSkipped().catch(() => null),
       api.getCosLearningDurations().catch(() => null),
       api.getCosLearningRouting().catch(() => null),
       api.getCosLearningConfidence().catch(() => null),
+      api.getCosFeedbackStats({ silent: true }).catch(() => null),
       api.getDismissedCosRecommendations().catch(() => null)
     ]);
     setLearning(learningData);
@@ -82,6 +133,7 @@ export default function LearningTab() {
     setDurations(durationsData);
     setRouting(routingData);
     setConfidence(confidenceData);
+    setFeedback(feedbackData);
     setDismissed(dismissedData?.dismissed || []);
     setLoading(false);
   }, []);
@@ -263,6 +315,8 @@ export default function LearningTab() {
               <div className="text-xs text-gray-500">due to low success</div>
             </div>
           </div>
+
+          <FeedbackSummary feedback={feedback} />
 
           {/* Recommendations */}
           {(learning.recommendations?.length > 0 || dismissed.length > 0) && (

--- a/client/src/services/apiAgents.js
+++ b/client/src/services/apiAgents.js
@@ -162,7 +162,7 @@ export const sendCosAgentBtw = (id, message, options = {}) => request(`/cos/agen
   body: JSON.stringify({ message }),
   ...options
 });
-export const getCosFeedbackStats = () => request('/cos/feedback/stats');
+export const getCosFeedbackStats = (options = {}) => request('/cos/feedback/stats', options);
 export const getCosReports = () => request('/cos/reports');
 export const getCosTodayReport = () => request('/cos/reports/today');
 export const getCosReport = (date) => request(`/cos/reports/${date}`);

--- a/docs/features/chief-of-staff.md
+++ b/docs/features/chief-of-staff.md
@@ -21,7 +21,7 @@ Autonomous agent manager that watches task files, spawns sub-agents, and maintai
 6. **Self-Improvement**: Can analyze performance and suggest prompt/config improvements
 7. **Script Generation**: Creates automation scripts for repetitive tasks
 8. **Report Generation**: Daily summaries of completed work
-9. **Durable Agent Feedback**: Completion notifications accept quick ratings, while the Agents tab keeps a filterable queue of loaded runs that still need feedback after a notification expires. Recent unrated completed runs are also surfaced as a CoS insight that links directly to the URL-backed review filter. Feedback details can be attached to helpful, unhelpful, or neutral ratings so learning has actionable context.
+9. **Durable Agent Feedback**: Completion notifications accept quick ratings, while the Agents tab keeps a filterable queue of loaded runs that still need feedback after a notification expires. Recent unrated completed runs are also surfaced as a CoS insight that links directly to the URL-backed review filter. Feedback details can be attached to helpful, unhelpful, or neutral ratings so learning has actionable context. The Learning tab aggregates ratings from both live state and date-bucketed agent archives, de-duplicating runs that are still present in both stores so historical feedback remains visible for the archive retention window.
 10. **Learning-Aligned ETAs**: Pending tasks and active agents resolve their estimates from the same metadata-first task-learning bucket that records outcomes, including archived scheduled-agent metadata, instead of inferring a potentially different category from task text.
 
 ## Task File Format
@@ -100,6 +100,7 @@ The `selectModelForTask` function routes tasks to appropriate model tiers:
 | POST /api/cos/health/check | Run health check |
 | GET /api/cos/agents | List agents |
 | POST /api/cos/agents/:id/terminate | Terminate agent |
+| GET /api/cos/feedback/stats | Aggregate live and archived agent ratings |
 | GET /api/cos/reports | List reports |
 | GET /api/cos/learning | Get learning insights |
 | GET /api/cos/digest | Get weekly digest |

--- a/server/services/cosAgentFeedback.js
+++ b/server/services/cosAgentFeedback.js
@@ -26,6 +26,39 @@ const isSystemAgent = (agent) =>
 // on top of that is redundant nagging, not a useful signal.
 const isManualUserAgent = (agent) => agent.metadata?.taskType === 'user';
 
+const FEEDBACK_RATINGS = new Set(['positive', 'negative', 'neutral']);
+const ARCHIVE_READ_BATCH_SIZE = 50;
+
+const hasValidFeedback = (agent) => FEEDBACK_RATINGS.has(agent?.feedback?.rating);
+
+// Completed agents are written to their date-bucket archive before they age out
+// of live state. Feedback statistics therefore have to read both stores and
+// de-duplicate by agent id; reading state alone makes almost all historical
+// ratings disappear from the learning view as soon as normal retention runs.
+async function loadArchivedAgentsWithFeedback() {
+  const idx = await loadAgentIndex();
+  const entries = [...idx.entries()];
+  const agents = [];
+
+  // Match the archive reader's bounded fan-out so a long-lived install does not
+  // open every metadata file at once.
+  for (let i = 0; i < entries.length; i += ARCHIVE_READ_BATCH_SIZE) {
+    const batch = entries.slice(i, i + ARCHIVE_READ_BATCH_SIZE);
+    const reads = batch.map(async ([agentId, dateBucket]) => {
+      const content = await tryReadFile(join(getAgentDir(agentId, dateBucket), 'metadata.json'));
+      if (!content) return null;
+      const raw = safeJSONParse(content, null);
+      return hasValidFeedback(raw) ? { ...raw, id: raw.id || raw.agentId || agentId } : null;
+    });
+    const settled = await Promise.allSettled(reads);
+    for (const result of settled) {
+      if (result.status === 'fulfilled' && result.value) agents.push(result.value);
+    }
+  }
+
+  return agents;
+}
+
 // Count completed user-facing agents that are still retained in live CoS state
 // and have not received a rating. Archived history is intentionally excluded:
 // actionable insights refresh every 30s, so this remains a cheap, exact count
@@ -104,9 +137,17 @@ export async function submitAgentFeedback(agentId, feedback) {
 // Get aggregated feedback statistics
 export async function getFeedbackStats() {
   const state = await loadState();
-  const agents = Object.values(state.agents);
+  const archived = await loadArchivedAgentsWithFeedback();
+  const byAgentId = new Map(archived.map(agent => [agent.id, agent]));
 
-  const withFeedback = agents.filter(a => a.feedback);
+  // Live state is freshest, but only overwrite an archived rating when the live
+  // record actually carries valid feedback. This preserves a durable rating if
+  // a prior best-effort live-state update did not make it into both stores.
+  for (const [agentId, agent] of Object.entries(state.agents)) {
+    if (hasValidFeedback(agent)) byAgentId.set(agent.id || agentId, agent);
+  }
+
+  const withFeedback = [...byAgentId.values()];
   const positive = withFeedback.filter(a => a.feedback.rating === 'positive').length;
   const negative = withFeedback.filter(a => a.feedback.rating === 'negative').length;
   const neutral = withFeedback.filter(a => a.feedback.rating === 'neutral').length;

--- a/server/services/cosAgentFeedback.test.js
+++ b/server/services/cosAgentFeedback.test.js
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { mkdir, rm, writeFile } from 'fs/promises';
+import { join } from 'path';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 
 
 const mockCosState = vi.hoisted(() => ({
@@ -8,6 +10,8 @@ const mockCosState = vi.hoisted(() => ({
   state: null
 }));
 
+const mockAgentIndex = vi.hoisted(() => ({ entries: new Map() }));
+
 vi.mock('./cosState.js', () => ({
   AGENTS_DIR: mockCosState.agentsDir,
   loadState: vi.fn(async () => mockCosState.state),
@@ -15,11 +19,21 @@ vi.mock('./cosState.js', () => ({
   withStateLock: async (fn) => fn()
 }));
 
-import { getPendingAgentFeedbackCount } from './cosAgentFeedback.js';
+vi.mock('./cosAgentIndex.js', () => ({
+  loadAgentIndex: vi.fn(async () => mockAgentIndex.entries),
+  getAgentDir: (agentId, dateBucket) => join(mockCosState.agentsDir, dateBucket || '', agentId)
+}));
+
+import { getFeedbackStats, getPendingAgentFeedbackCount } from './cosAgentFeedback.js';
 
 describe('getPendingAgentFeedbackCount', () => {
   beforeEach(() => {
     mockCosState.state = { agents: {} };
+    mockAgentIndex.entries = new Map();
+  });
+
+  afterAll(async () => {
+    await rm(mockCosState.agentsDir, { recursive: true, force: true });
   });
 
   it('counts only unrated completed non-system manually-run agents for the feedback insight', async () => {
@@ -54,5 +68,60 @@ describe('getPendingAgentFeedbackCount', () => {
 
   it('returns 0 when nothing is awaiting a rating', async () => {
     await expect(getPendingAgentFeedbackCount()).resolves.toBe(0);
+  });
+
+  it('aggregates archived feedback and de-duplicates a live copy of the same agent', async () => {
+    const dateBucket = '2026-08-01';
+    const archived = [
+      {
+        id: 'agent-archived',
+        metadata: { taskDescription: 'Fix the example bug' },
+        feedback: { rating: 'negative', comment: 'The regression remained.', submittedAt: '2026-08-01T11:00:00.000Z' }
+      },
+      {
+        id: 'agent-duplicate',
+        metadata: { taskDescription: 'Write example tests' },
+        feedback: { rating: 'positive', submittedAt: '2026-08-01T10:00:00.000Z' }
+      }
+    ];
+
+    for (const agent of archived) {
+      const dir = join(mockCosState.agentsDir, dateBucket, agent.id);
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, 'metadata.json'), JSON.stringify(agent));
+      mockAgentIndex.entries.set(agent.id, dateBucket);
+    }
+
+    mockCosState.state.agents = {
+      'agent-duplicate': {
+        ...archived[1],
+        feedback: { rating: 'positive', submittedAt: '2026-08-01T12:00:00.000Z' }
+      },
+      'agent-live': {
+        id: 'agent-live',
+        metadata: { taskDescription: 'Document the example workflow' },
+        feedback: { rating: 'neutral', submittedAt: '2026-08-01T13:00:00.000Z' }
+      }
+    };
+
+    await expect(getFeedbackStats()).resolves.toEqual({
+      total: 3,
+      positive: 1,
+      negative: 1,
+      neutral: 1,
+      satisfactionRate: 33,
+      byTaskType: {
+        'bug-fix': { positive: 0, negative: 1, neutral: 0, total: 1 },
+        testing: { positive: 1, negative: 0, neutral: 0, total: 1 },
+        documentation: { positive: 0, negative: 0, neutral: 1, total: 1 }
+      },
+      recentWithComments: [{
+        agentId: 'agent-archived',
+        taskDescription: 'Fix the example bug',
+        rating: 'negative',
+        comment: 'The regression remained.',
+        submittedAt: '2026-08-01T11:00:00.000Z'
+      }]
+    });
   });
 });


### PR DESCRIPTION
## Summary
- aggregate CoS agent ratings from date-bucketed archives as well as live state
- de-duplicate live/archive records and ignore malformed ratings
- surface durable feedback totals and satisfaction in Learning Analytics
- document the archive-aware feedback contract

## Test plan
- `cd server && npm test -- --run services/cosAgentFeedback.test.js routes/cos.test.js`
- `cd client && npm test -- --run src/components/cos/tabs/LearningTab.runsLabel.test.jsx src/components/cos/tabs/LearningTab.feedback.test.jsx`
- `cd client && npm run lint`
- `cd client && npm run build`