### PR TITLE
fix: show subscription reset times on mobile

### DIFF
--- a/client/src/pages/UsagePage.jsx
+++ b/client/src/pages/UsagePage.jsx
@@ -63,10 +63,10 @@ function UsageMeter({ limit }) {
           style={{ width: `${Math.min(100, Math.max(0, used))}%` }}
         />
       </div>
-      <div className="flex items-center justify-between mt-0.5 sm:mt-1">
+      <div className="flex items-start justify-between gap-1 mt-0.5 sm:mt-1">
         <span className="text-[9px] sm:text-xs text-gray-500">{used}% used</span>
         {limit.resetsAt && (
-          <span className="hidden sm:flex text-xs text-gray-500 items-center gap-1 truncate">
+          <span className="flex min-w-0 text-[9px] sm:text-xs text-gray-500 items-start justify-end gap-1 text-right leading-tight">
             <Clock size={11} /> resets {formatResetsAt(limit.resetsAt)}
           </span>
         )}

--- a/client/src/pages/UsagePage.test.jsx
+++ b/client/src/pages/UsagePage.test.jsx
@@ -241,6 +241,7 @@ describe('UsagePage provider reset times', () => {
     // wording — it shows a localized instant plus "in 3h".
     const reset = await screen.findByText(/resets .*\(in 3h\)/);
     expect(reset).toBeInTheDocument();
+    expect(reset.className.split(/\s+/)).not.toContain('hidden');
     expect(reset.textContent).not.toContain(resetsAt);
   });
 });


### PR DESCRIPTION
## Summary
- Keep weekly subscription reset date/time visible on mobile usage cards.
- Allow the reset text to wrap within narrow provider cards.
- Add regression coverage for the mobile-visible reset line.

## Test plan
- npm test -- --run src/pages/UsagePage.test.jsx
- npm test