### PR TITLE
Report local LLM test durations

### DIFF
--- a/client/src/components/settings/ModelThroughputReport.jsx
+++ b/client/src/components/settings/ModelThroughputReport.jsx
@@ -1,5 +1,5 @@
 /**
- * Tokens-per-second report.
+ * Tokens-per-second and test-time report.
  *
  * The ranked list above it answers "which model should I use?". This answers
  * "how fast is each one, and where does it fall off?" — one row per measured
@@ -21,7 +21,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { Timer, Copy, Check } from 'lucide-react';
 import { copyToClipboard } from '../../lib/clipboard';
 import { tuningNoticeChip } from '../../lib/assessmentTuningNotice';
-import { formatContextTokens, formatDurationMs } from '../../utils/formatters';
+import { formatContextTokens, formatDurationMs, formatRuntime } from '../../utils/formatters';
 
 // One rate, as text. `null` is not measured and renders as an em dash — never a
 // zero; `estimated` marks a frame-counted figure with a `~` so it is never
@@ -36,6 +36,14 @@ const Rate = ({ value, estimated, suffix = '' }) => (
     : <span className="text-gray-600">{rateText(value, estimated)}</span>
 );
 
+// Per-context tests can be shorter than a second, so use the formatter that
+// preserves milliseconds rather than the coarse multi-second formatter used by
+// summary cards. A finite zero is still an observed duration, not an unknown.
+const elapsedText = (value) => {
+  if (!Number.isFinite(value) || value < 0) return '—';
+  return formatRuntime(value) || '0ms';
+};
+
 const timingLabel = (source) => ({
   runtime: 'runtime timing',
   'stream-window': 'observed stream window',
@@ -46,10 +54,19 @@ const timingLabel = (source) => ({
 // A row's samples keyed by context, for the per-context columns.
 const pointsByContext = (row) => new Map((row.points || []).map((p) => [p.contextTokens, p]));
 
+const contextMarkdown = (point, estimated) => {
+  if (!point) return '—';
+  if (!point.ok) {
+    const elapsed = elapsedText(point.totalMs);
+    return elapsed === '—' ? 'failed' : `failed (${elapsed})`;
+  }
+  return `${rateText(point.tokensPerSecond, estimated)} (${elapsedText(point.totalMs)})`;
+};
+
 /** The report as a markdown table — what a copy of this is actually useful as. */
 export function toMarkdown(report) {
   const contexts = report?.contexts || [];
-  const header = ['Model', 'Runtime', 'Tuning', 'Rate basis', 'tok/s', 'chars/s', 'Prefill tok/s', 'TTFT', ...contexts.map((c) => `${formatContextTokens(c)} tok/s`)];
+  const header = ['Model', 'Runtime', 'Tuning', 'Rate basis', 'tok/s', 'chars/s', 'Prefill tok/s', 'TTFT', ...contexts.map((c) => `${formatContextTokens(c)} tok/s / elapsed`)];
   const lines = [
     `| ${header.join(' | ')} |`,
     `| ${header.map(() => '---').join(' | ')} |`,
@@ -65,7 +82,7 @@ export function toMarkdown(report) {
       rateText(row.meanCharsPerSecond, false),
       rateText(row.meanPromptTokensPerSecond, row.tokensEstimated),
       Number.isFinite(row.meanTtftMs) ? formatDurationMs(row.meanTtftMs) : '—',
-      ...contexts.map((c) => rateText(byContext.get(c)?.tokensPerSecond, row.tokensEstimated)),
+      ...contexts.map((c) => contextMarkdown(byContext.get(c), row.tokensEstimated)),
     ].join(' | ')} |`);
   }
   return lines.join('\n');
@@ -99,7 +116,7 @@ export default function ModelThroughputReport({ report, runtimeLabelFor }) {
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-2 flex-wrap">
         <h3 className="text-xs font-medium text-gray-400 flex items-center gap-1.5">
-          <Timer size={12} /> Tokens per second
+          <Timer size={12} /> Tokens per second / test time
         </h3>
         <button
           onClick={copy}
@@ -113,7 +130,8 @@ export default function ModelThroughputReport({ report, runtimeLabelFor }) {
         Generation speed after the first token — exact tokens/s when the runtime reports usage, with chars/s
         beside it as the universal cross-runtime fallback. Prefill speed (how fast the prompt was read) and
         time to first token are beside them, so a model that decodes fast but chews slowly through long context
-        is visible as such.
+        is visible as such. Each context column shows its throughput on top and the total elapsed time for
+        that individual test below it.
         {report.modelsWithTokenRates < rows.length && (
           <> A <span className="text-gray-400">—</span> means the runtime reported no token counts for that
           reading; its chars/s figure is in the ranked list above.</>
@@ -137,7 +155,8 @@ export default function ModelThroughputReport({ report, runtimeLabelFor }) {
               <th scope="col" className="text-right font-medium px-2 py-1.5 whitespace-nowrap">TTFT</th>
               {contexts.map((context) => (
                 <th key={context} scope="col" className="text-right font-medium px-2 py-1.5 whitespace-nowrap">
-                  {formatContextTokens(context)}
+                  <div>{formatContextTokens(context)}</div>
+                  <div className="text-[10px] font-normal text-gray-600">rate / elapsed</div>
                 </th>
               ))}
             </tr>
@@ -178,9 +197,19 @@ export default function ModelThroughputReport({ report, runtimeLabelFor }) {
                         // never sampled — the title says which, and why.
                         title={point && !point.ok ? (point.error || 'failed') : undefined}
                       >
-                        {point && !point.ok
-                          ? <span className="text-port-warning">failed</span>
-                          : <Rate value={point?.tokensPerSecond} estimated={row.tokensEstimated} />}
+                        <div className="flex flex-col items-end gap-0.5">
+                          {point && !point.ok
+                            ? <span className="text-port-warning">failed</span>
+                            : <Rate value={point?.tokensPerSecond} estimated={row.tokensEstimated} />}
+                          {point && (
+                            <span
+                              className="text-gray-500 whitespace-nowrap"
+                              title="Total elapsed time for this context test"
+                            >
+                              {elapsedText(point.totalMs)}
+                            </span>
+                          )}
+                        </div>
                       </td>
                     );
                   })}

--- a/client/src/components/settings/ModelThroughputReport.test.jsx
+++ b/client/src/components/settings/ModelThroughputReport.test.jsx
@@ -9,7 +9,7 @@ import ModelThroughputReport, { toMarkdown } from './ModelThroughputReport.jsx';
 
 const point = (contextTokens, tokensPerSecond, extra = {}) => ({
   contextTokens, ok: true, tokensPerSecond, promptTokensPerSecond: 900, charsPerSecond: 200,
-  ttftMs: 300, completionTokens: 96, error: null, ...extra,
+  ttftMs: 300, totalMs: 800, completionTokens: 96, error: null, ...extra,
 });
 
 const row = (modelId, overrides = {}) => ({
@@ -41,10 +41,19 @@ beforeEach(() => vi.clearAllMocks());
 describe('ModelThroughputReport', () => {
   it('renders a column per sampled context and the per-context rates', () => {
     render(<ModelThroughputReport report={report([row('example-model:7b')])} />);
-    expect(screen.getByRole('columnheader', { name: '512' })).toBeInTheDocument();
-    expect(screen.getByRole('columnheader', { name: '4K' })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /512.*rate.*elapsed/i })).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', { name: /4K.*rate.*elapsed/i })).toBeInTheDocument();
     expect(screen.getByText('60.0')).toBeInTheDocument();
     expect(screen.getByText('40.0')).toBeInTheDocument();
+  });
+
+  it('shows the elapsed time for each context test beneath its rate', () => {
+    const measured = row('timed-model', {
+      points: [point(512, 60, { totalMs: 800 }), point(4096, 40, { totalMs: 2400 })],
+    });
+    render(<ModelThroughputReport report={report([measured])} />);
+    expect(screen.getByText('800ms')).toBeInTheDocument();
+    expect(screen.getByText('2.4s')).toBeInTheDocument();
   });
 
   // The sentinel contract, in the UI: a runtime that reported no token counts
@@ -119,9 +128,9 @@ describe('toMarkdown', () => {
   it('emits one row per measurement with a column per context', () => {
     const md = toMarkdown(report([row('example-model:7b')]));
     const lines = md.split('\n');
-    expect(lines[0]).toBe('| Model | Runtime | Tuning | Rate basis | tok/s | chars/s | Prefill tok/s | TTFT | 512 tok/s | 4K tok/s |');
+    expect(lines[0]).toBe('| Model | Runtime | Tuning | Rate basis | tok/s | chars/s | Prefill tok/s | TTFT | 512 tok/s / elapsed | 4K tok/s / elapsed |');
     expect(lines[2]).toContain('| example-model:7b | ollama | backend defaults | timing basis unavailable | 50.0 |');
-    expect(lines[2]).toContain('| 60.0 | 40.0 |');
+    expect(lines[2]).toContain('| 60.0 (800ms) | 40.0 (800ms) |');
   });
 
   it('writes a dash for an unmeasured cell rather than a zero', () => {

--- a/server/lib/localModelAssessment.js
+++ b/server/lib/localModelAssessment.js
@@ -186,10 +186,11 @@ export function summarizePerformance(samples) {
  * Flatten every measurement into one tokens-per-second table, fastest first.
  *
  * This is the "how fast is each model, really" view: one row per measured
- * model+tuning, carrying the per-context readings so falloff as the prompt grows
- * is visible rather than averaged away. It is a REPORT, not a ranking — no
- * scoring, no intent, no exclusions — so a model that only ran at 512 tokens
- * still appears, with one column filled and the rest honestly blank.
+ * model+tuning, carrying the per-context readings and elapsed test time so
+ * falloff as the prompt grows is visible rather than averaged away. It is a
+ * REPORT, not a ranking — no scoring, no intent, no exclusions — so a model that
+ * only ran at 512 tokens still appears, with one column filled and the rest
+ * honestly blank.
  *
  * Rows whose runtime reported no token counts are still included (with `null`
  * rates) rather than dropped: "this runtime does not report tokens" is the
@@ -222,6 +223,10 @@ export function buildThroughputReport(assessments) {
         promptTokensPerSecond: num(sample.promptTokensPerSecond),
         charsPerSecond: num(sample.charsPerSecond),
         ttftMs: num(sample.ttftMs),
+        // Keep the end-to-end duration with the context column. Unlike the
+        // aggregate mean TTFT, this answers how long THIS individual test took,
+        // including prompt processing and generation.
+        totalMs: num(sample.totalMs),
         completionTokens: num(sample.completionTokens),
         timingSource: sample.timingSource || null,
         error: sample?.error || null,

--- a/server/lib/localModelAssessment.test.js
+++ b/server/lib/localModelAssessment.test.js
@@ -606,6 +606,7 @@ describe('buildThroughputReport', () => {
     expect(report.rows.map((r) => r.modelId)).toEqual(['fast-model', 'slow-model']);
     expect(report.contexts).toEqual([512, 4096]);
     expect(report.rows[0].points.map((p) => p.tokensPerSecond)).toEqual([60, 40]);
+    expect(report.rows[0].points.map((p) => p.totalMs)).toEqual([1000, 1000]);
     expect(report.modelsWithTokenRates).toBe(2);
   });
 

--- a/server/services/localModelAssessments.test.js
+++ b/server/services/localModelAssessments.test.js
@@ -175,7 +175,7 @@ describe('buildSamplePrompt', () => {
 describe('toSample', () => {
   it('records timings from a successful run', () => {
     expect(svc.toSample(512, okRun())).toMatchObject({
-      contextTokens: 512, ok: true, charsPerSecond: 120, ttftMs: 250, error: null,
+      contextTokens: 512, ok: true, charsPerSecond: 120, ttftMs: 250, totalMs: 800, error: null,
     });
   });
 


### PR DESCRIPTION
## Summary
- Preserve each local LLM sample's total elapsed time in throughput reports.
- Show elapsed time alongside throughput in every context-size column and copied Markdown.
- Keep sub-second and failed-test durations visible.

## Test plan
- `cd server && npm test -- lib/localModelAssessment.test.js services/localModelAssessments.test.js`
- `cd client && npm test -- src/components/settings/ModelThroughputReport.test.jsx`
- `cd client && ./node_modules/.bin/biome lint --error-on-warnings src/components/settings/ModelThroughputReport.jsx src/components/settings/ModelThroughputReport.test.jsx`
- `cd client && npm run build`