### PR TITLE
Cap concurrent CoS agents per local inference endpoint

### DIFF
--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -499,6 +499,13 @@ async function runAgentSpawn(task) {
       // answer that — a path-configured `claude` under a custom id is slashdo-
       // capable, and a lean `--bare` session is not.
       providerCommand: provider.command || null,
+      // The endpoint this agent's inference actually lands on, stamped for the
+      // same reason as the command above: the per-local-endpoint spawn cap
+      // (#4834) must know which GPU a RUNNING agent is occupying, and an id
+      // alone can't answer that once the provider record is edited or deleted
+      // mid-run. Pre-#4834 agent records have no value here, so the counter
+      // falls back to resolving the id against the live provider list.
+      providerEndpoint: provider.endpoint || null,
       leanMode,
       // Whether THIS run's prompt told the agent to push, open, review, and merge
       // its own PR. Persisted rather than re-derived at cleanup time: the two

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -505,7 +505,11 @@ async function runAgentSpawn(task) {
       // alone can't answer that once the provider record is edited or deleted
       // mid-run. Pre-#4834 agent records have no value here, so the counter
       // falls back to resolving the id against the live provider list.
-      providerEndpoint: provider.endpoint || null,
+      //
+      // `ANTHROPIC_BASE_URL` is the second source because an Ollama-backed CLI
+      // provider (shipped: claude-ollama, claude-ollama-tui) records its daemon
+      // there and leaves `endpoint` unset.
+      providerEndpoint: provider.endpoint || provider.envVars?.ANTHROPIC_BASE_URL || null,
       leanMode,
       // Whether THIS run's prompt told the agent to push, open, review, and merge
       // its own PR. Persisted rather than re-derived at cleanup time: the two

--- a/server/services/agentLifecycle.js
+++ b/server/services/agentLifecycle.js
@@ -75,6 +75,7 @@ import { v4 as uuidv4 } from '../lib/uuid.js';
 // Imported for use here only; the pass-through re-exports that used to sit
 // below them were retired with the `subAgentSpawner.js` barrel (#3450).
 import { resolveAgentProviderAndModel } from './agentProviderResolution.js';
+import { providerBaseUrl } from './cosLocalEndpointSlots.js';
 import { prepareAgentWorkspace } from './agentWorkspacePrep.js';
 // `releaseRetryHold` is imported STATICALLY here (the TUI/direct-CLI spawners
 // reach for it via `await import()` only because they sit BELOW this module and
@@ -506,10 +507,12 @@ async function runAgentSpawn(task) {
       // mid-run. Pre-#4834 agent records have no value here, so the counter
       // falls back to resolving the id against the live provider list.
       //
-      // `ANTHROPIC_BASE_URL` is the second source because an Ollama-backed CLI
-      // provider (shipped: claude-ollama, claude-ollama-tui) records its daemon
-      // there and leaves `endpoint` unset.
-      providerEndpoint: provider.endpoint || provider.envVars?.ANTHROPIC_BASE_URL || null,
+      // Resolved through the SAME helper the counter reads with, so writer and
+      // reader can't drift — a CLI provider records its daemon in envVars or an
+      // OpenCode config, not in `endpoint`. Stamped as the RAW url, never the
+      // slot key: a slot key is null for a cloud provider, and stamping null
+      // would re-open the mid-run-edit hole this exists to close.
+      providerEndpoint: providerBaseUrl(provider),
       leanMode,
       // Whether THIS run's prompt told the agent to push, open, review, and merge
       // its own PR. Persisted rather than re-derived at cleanup time: the two

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -596,7 +596,7 @@ export async function forceSpawnTask(taskId) {
   // "Run now" would toast "Spawning" for a task the chokepoint immediately holds
   // as pending. Checked against the RESOLVED provider (post-fallback), so it
   // never refuses a run that would have swapped to a cloud provider anyway.
-  const localCapacityError = await localEndpointCapacityError(resolution.provider, state.agents);
+  const localCapacityError = await localEndpointCapacityError(resolution.provider, state.agents, taskId);
   if (localCapacityError) {
     return { error: localCapacityError };
   }

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -147,7 +147,7 @@ import {
 // guards instead of a local replica. The async tiers stay here as
 // `spawnDequeuePriorityN(ctx)` helpers.
 import { createDequeueCapacity, countRunningAgentsByLocalEndpoint, isMissionTierEligible, isIdleTierEligible } from './cosDequeue.js';
-import { buildLocalEndpointSlotContext } from './cosLocalEndpointSlots.js';
+import { buildLocalEndpointSlotContext, localEndpointCapacityError } from './cosLocalEndpointSlots.js';
 
 /**
  * Get current CoS status
@@ -589,6 +589,16 @@ export async function forceSpawnTask(taskId) {
   const resolution = await resolveAgentProviderAndModel(task);
   if (!resolution.ok) {
     return { error: resolution.error };
+  }
+
+  // Same reason as the resolution pre-check above: the local-endpoint cap
+  // (#4834) is enforced later, inside the `task:ready` listener, so without this
+  // "Run now" would toast "Spawning" for a task the chokepoint immediately holds
+  // as pending. Checked against the RESOLVED provider (post-fallback), so it
+  // never refuses a run that would have swapped to a cloud provider anyway.
+  const localCapacityError = await localEndpointCapacityError(resolution.provider, state.agents);
+  if (localCapacityError) {
+    return { error: localCapacityError };
   }
 
   cosEvents.emit('task:ready', { ...task, taskType: task.taskType || 'internal' });

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -966,7 +966,12 @@ async function spawnDequeuePriority0OnDemand(ctx) {
     }
 
     applyOnDemandConsent(task);
-    if (task && capacity.canSpawn(task)) {
+    // `gateLocalEndpoint: false` — a denial HERE would discard the user's "Run":
+    // the request is already cleared and the app-review marker bound, and this
+    // branch is the only thing that persists the task. Let it through and let the
+    // chokepoint hold it (#4834) — that path leaves the task pending and releases
+    // both side effects.
+    if (task && capacity.canSpawn(task, undefined, { gateLocalEndpoint: false })) {
       // Mark this as a MANUAL (on-demand) run so a completed perpetual drain
       // continues in the same user-initiated lane instead of the auto-run-gated
       // queue path (see perpetualRefillPlan). Stamped before addTask so the

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -1177,10 +1177,9 @@ async function spawnDequeuePriority3Missions(ctx) {
     // Committed tier — `generateMissionTasks` has already flipped the sub-task to
     // `in_progress` and saved the mission, and mission tasks are never written to
     // COS-TASKS.md, so a denial drops the only copy of a sub-task that
-    // `generateMissionTask` will never re-pick (it selects `pending` only). See
-    // canSpawnCommitted (#4834). Note the emit does NOT recover the sub-task
-    // either — `holdTask` releases `metadata.app`/`jobId`, and a mission task
-    // carries neither — it just avoids making the loss worse here. Filed as #4858.
+    // `generateMissionTask` will never re-pick (it selects `pending` only).
+    // Emitting hands it to the chokepoint, whose `holdTask` reverts the flip
+    // (#4858) — so the sub-task really is recovered. See canSpawnCommitted (#4834).
     if (!capacity.canSpawnCommitted(cosTask, ctx.autonomousSpawnCeiling)) continue;
     cosEvents.emit('task:ready', cosTask);
     capacity.trackSpawn(cosTask);

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -146,7 +146,8 @@ import {
 // predicates are shared with the scheduler unit tests so they exercise the real
 // guards instead of a local replica. The async tiers stay here as
 // `spawnDequeuePriorityN(ctx)` helpers.
-import { createDequeueCapacity, isMissionTierEligible, isIdleTierEligible } from './cosDequeue.js';
+import { createDequeueCapacity, countRunningAgentsByLocalEndpoint, isMissionTierEligible, isIdleTierEligible } from './cosDequeue.js';
+import { buildLocalEndpointSlotContext } from './cosLocalEndpointSlots.js';
 
 /**
  * Get current CoS status
@@ -842,6 +843,20 @@ async function tryImmediateSpawn(task) {
     return;
   }
 
+  // Per-local-endpoint cap (#4834). This path bypasses the evaluation interval
+  // entirely, so without the same gate a user-submitted task would dispatch
+  // straight past the local-GPU slot limit dequeueNextTask enforces.
+  const localSlots = await buildLocalEndpointSlotContext();
+  const taskEndpoint = localSlots.resolveLocalEndpoint(task);
+  if (taskEndpoint) {
+    const endpointCounts = countRunningAgentsByLocalEndpoint(state.agents, localSlots.endpointForAgent);
+    const running = endpointCounts[taskEndpoint] || 0;
+    if (running >= localSlots.limit) {
+      emitLog('debug', `⏳ Queued task ${task.id} - local endpoint ${taskEndpoint} at capacity (${running}/${localSlots.limit})`);
+      return;
+    }
+  }
+
   emitLog('info', `⚡ Immediate spawn: ${task.id} (${task.priority || 'MEDIUM'})`, {
     taskId: task.id,
     availableSlots
@@ -1228,7 +1243,24 @@ async function dequeueNextTask({ ignoreTaskId = null } = {}) {
   const paused = await isPaused();
 
   const state = await loadState();
-  const capacity = createDequeueCapacity(state, { agentsByProject: countRunningAgentsByProject(state.agents) });
+  // Per-local-endpoint agent slots (#4834). A CoS agent runs a vendor CLI that
+  // talks to the local model server directly, so promptRunner's in-flight gate
+  // never sees it; without this, two agents can be dispatched at one GPU and
+  // take an accelerator OOM. Resolved once per cycle and threaded into the
+  // capacity tracker, which enforces it alongside the global/per-project caps.
+  const localSlots = await buildLocalEndpointSlotContext();
+  const capacity = createDequeueCapacity(state, {
+    agentsByProject: countRunningAgentsByProject(state.agents),
+    localEndpointCounts: countRunningAgentsByLocalEndpoint(state.agents, localSlots.endpointForAgent),
+    localEndpointLimit: localSlots.limit,
+    resolveLocalEndpoint: localSlots.resolveLocalEndpoint,
+    onLocalEndpointHold: (task, endpoint, running) => {
+      emitLog('debug', `⏳ Queued task ${task.id} - local endpoint ${endpoint} at capacity (${running}/${localSlots.limit})`, {
+        taskId: task.id,
+        endpoint
+      });
+    }
+  });
   const availableSlots = capacity.availableSlots;
 
   if (availableSlots <= 0) return;

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -1183,7 +1183,13 @@ async function spawnDequeuePriority3Missions(ctx) {
       taskType: 'internal',
       approvalRequired: !missionTask.autoApprove
     };
-    if (!capacity.canSpawn(cosTask, ctx.autonomousSpawnCeiling)) continue;
+    // `gateLocalEndpoint: false` — same reason as Priority 0 (#4834). Mission
+    // tasks are never written to COS-TASKS.md, and `generateMissionTasks` has
+    // ALREADY flipped the sub-task to `in_progress` and saved the mission by the
+    // time we get here. A denial would drop the only copy of a sub-task that
+    // `generateMissionTask` will never re-pick (it selects `pending` only).
+    // Emitting lets the chokepoint hold it instead.
+    if (!capacity.canSpawn(cosTask, ctx.autonomousSpawnCeiling, { gateLocalEndpoint: false })) continue;
     cosEvents.emit('task:ready', cosTask);
     capacity.trackSpawn(cosTask);
     emitLog('info', `Generated mission task: ${missionTask.id}`, {
@@ -1211,7 +1217,12 @@ async function spawnDequeuePriority4IdleReview(ctx) {
   const pendingSystemTasks = freshCosTasks.autoApproved?.length || 0;
   if (pendingSystemTasks === 0) {
     const idleTask = await generateIdleReviewTask(state, { ignoreTaskId });
-    if (idleTask && capacity.canSpawn(idleTask, ctx.autonomousSpawnCeiling)) {
+    // `gateLocalEndpoint: false` — same reason as Priority 0 (#4834).
+    // `generateIdleReviewTask` has already bound the app-review marker and
+    // advanced the 30-minute review cooldown by the time we get here, and only
+    // `holdTask` releases that marker — which requires the emit. A denial would
+    // leave the app reading "in review" indefinitely (issue #978's failure mode).
+    if (idleTask && capacity.canSpawn(idleTask, ctx.autonomousSpawnCeiling, { gateLocalEndpoint: false })) {
       cosEvents.emit('task:ready', idleTask);
       capacity.trackSpawn(idleTask);
     }

--- a/server/services/cos.js
+++ b/server/services/cos.js
@@ -853,19 +853,12 @@ async function tryImmediateSpawn(task) {
     return;
   }
 
-  // Per-local-endpoint cap (#4834). This path bypasses the evaluation interval
-  // entirely, so without the same gate a user-submitted task would dispatch
-  // straight past the local-GPU slot limit dequeueNextTask enforces.
-  const localSlots = await buildLocalEndpointSlotContext();
-  const taskEndpoint = localSlots.resolveLocalEndpoint(task);
-  if (taskEndpoint) {
-    const endpointCounts = countRunningAgentsByLocalEndpoint(state.agents, localSlots.endpointForAgent);
-    const running = endpointCounts[taskEndpoint] || 0;
-    if (running >= localSlots.limit) {
-      emitLog('debug', `⏳ Queued task ${task.id} - local endpoint ${taskEndpoint} at capacity (${running}/${localSlots.limit})`);
-      return;
-    }
-  }
+  // No local-endpoint check here (#4834). The task is already persisted by
+  // `addTask`, so emitting and letting the chokepoint hold it produces exactly
+  // the state an early return would — still `pending`, marker released, job
+  // reservation freed — and the chokepoint also counts in-flight reservations,
+  // which a snapshot here cannot. A copy would be a weaker duplicate that can
+  // pass a task the chokepoint then holds, for a fourth provider-list fetch.
 
   emitLog('info', `⚡ Immediate spawn: ${task.id} (${task.priority || 'MEDIUM'})`, {
     taskId: task.id,
@@ -966,12 +959,10 @@ async function spawnDequeuePriority0OnDemand(ctx) {
     }
 
     applyOnDemandConsent(task);
-    // `gateLocalEndpoint: false` — a denial HERE would discard the user's "Run":
-    // the request is already cleared and the app-review marker bound, and this
-    // branch is the only thing that persists the task. Let it through and let the
-    // chokepoint hold it (#4834) — that path leaves the task pending and releases
-    // both side effects.
-    if (task && capacity.canSpawn(task, undefined, { gateLocalEndpoint: false })) {
+    // Committed tier — the request is already cleared and the marker bound, and
+    // this branch is the only thing that persists the task, so a denial would
+    // discard the user's "Run". See canSpawnCommitted (#4834).
+    if (task && capacity.canSpawnCommitted(task)) {
       // Mark this as a MANUAL (on-demand) run so a completed perpetual drain
       // continues in the same user-initiated lane instead of the auto-run-gated
       // queue path (see perpetualRefillPlan). Stamped before addTask so the
@@ -1183,13 +1174,14 @@ async function spawnDequeuePriority3Missions(ctx) {
       taskType: 'internal',
       approvalRequired: !missionTask.autoApprove
     };
-    // `gateLocalEndpoint: false` — same reason as Priority 0 (#4834). Mission
-    // tasks are never written to COS-TASKS.md, and `generateMissionTasks` has
-    // ALREADY flipped the sub-task to `in_progress` and saved the mission by the
-    // time we get here. A denial would drop the only copy of a sub-task that
-    // `generateMissionTask` will never re-pick (it selects `pending` only).
-    // Emitting lets the chokepoint hold it instead.
-    if (!capacity.canSpawn(cosTask, ctx.autonomousSpawnCeiling, { gateLocalEndpoint: false })) continue;
+    // Committed tier — `generateMissionTasks` has already flipped the sub-task to
+    // `in_progress` and saved the mission, and mission tasks are never written to
+    // COS-TASKS.md, so a denial drops the only copy of a sub-task that
+    // `generateMissionTask` will never re-pick (it selects `pending` only). See
+    // canSpawnCommitted (#4834). Note the emit does NOT recover the sub-task
+    // either — `holdTask` releases `metadata.app`/`jobId`, and a mission task
+    // carries neither — it just avoids making the loss worse here. Filed as #4858.
+    if (!capacity.canSpawnCommitted(cosTask, ctx.autonomousSpawnCeiling)) continue;
     cosEvents.emit('task:ready', cosTask);
     capacity.trackSpawn(cosTask);
     emitLog('info', `Generated mission task: ${missionTask.id}`, {
@@ -1217,12 +1209,11 @@ async function spawnDequeuePriority4IdleReview(ctx) {
   const pendingSystemTasks = freshCosTasks.autoApproved?.length || 0;
   if (pendingSystemTasks === 0) {
     const idleTask = await generateIdleReviewTask(state, { ignoreTaskId });
-    // `gateLocalEndpoint: false` — same reason as Priority 0 (#4834).
-    // `generateIdleReviewTask` has already bound the app-review marker and
-    // advanced the 30-minute review cooldown by the time we get here, and only
-    // `holdTask` releases that marker — which requires the emit. A denial would
-    // leave the app reading "in review" indefinitely (issue #978's failure mode).
-    if (idleTask && capacity.canSpawn(idleTask, ctx.autonomousSpawnCeiling, { gateLocalEndpoint: false })) {
+    // Committed tier — `generateIdleReviewTask` has already bound the app-review
+    // marker and advanced the 30-minute cooldown, and only `holdTask` releases
+    // that marker, which requires the emit. A denial would leave the app reading
+    // "in review" indefinitely (#978's mode). See canSpawnCommitted (#4834).
+    if (idleTask && capacity.canSpawnCommitted(idleTask, ctx.autonomousSpawnCeiling)) {
       cosEvents.emit('task:ready', idleTask);
       capacity.trackSpawn(idleTask);
     }
@@ -1269,18 +1260,37 @@ async function dequeueNextTask({ ignoreTaskId = null } = {}) {
   const paused = await isPaused();
 
   const state = await loadState();
+
+  // Bail before the provider fetch below. This function fires from ~8 event
+  // sources plus a setImmediate on every completion, and a saturated pool — the
+  // state that makes those fire in bursts — would otherwise pay two awaits and
+  // a full agent scan per trigger for a tracker discarded immediately.
+  if (state.config.maxConcurrentAgents - Object.values(state.agents).filter(a => a.status === 'running').length <= 0) return;
+
   // Per-local-endpoint agent slots (#4834). A CoS agent runs a vendor CLI that
   // talks to the local model server directly, so promptRunner's in-flight gate
   // never sees it; without this, two agents can be dispatched at one GPU and
   // take an accelerator OOM. Resolved once per cycle and threaded into the
   // capacity tracker, which enforces it alongside the global/per-project caps.
+  //
+  // Predictive only — it just avoids emitting a task the chokepoint would hold,
+  // so unlike `acquireLocalEndpointSpawnSlot` it does NOT count in-flight
+  // reservations. Erring toward admitting is correct here: the authoritative
+  // gate still refuses, and a hold is cheap.
   const localSlots = await buildLocalEndpointSlotContext();
+  // One debug line per saturated endpoint per cycle, not one per queued task —
+  // the user/system tiers `continue` past a denial, so a 40-task queue behind
+  // one busy GPU would otherwise emit 40 identical log events, each broadcast
+  // to every CoS-subscribed socket client.
+  const loggedFullEndpoints = new Set();
   const capacity = createDequeueCapacity(state, {
     agentsByProject: countRunningAgentsByProject(state.agents),
     localEndpointCounts: countRunningAgentsByLocalEndpoint(state.agents, localSlots.endpointForAgent),
     localEndpointLimit: localSlots.limit,
     resolveLocalEndpoint: localSlots.resolveLocalEndpoint,
     onLocalEndpointHold: (task, endpoint, running) => {
+      if (loggedFullEndpoints.has(endpoint)) return;
+      loggedFullEndpoints.add(endpoint);
       emitLog('debug', `⏳ Queued task ${task.id} - local endpoint ${endpoint} at capacity (${running}/${localSlots.limit})`, {
         taskId: task.id,
         endpoint

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -40,6 +40,7 @@ import { createDequeueCapacity, countRunningAgentsByLocalEndpoint, isMissionTier
 import {
   createLocalEndpointSlotContext,
   localEndpointOfProvider,
+  providerBaseUrl,
   reserveLocalEndpointSpawn,
   pendingLocalEndpointSpawns,
   __resetLocalEndpointSpawnReservations,
@@ -1081,6 +1082,34 @@ describe('localEndpointOfProvider — Ollama-backed CLI/TUI providers (#4834)', 
       id: 'remote-claude-ollama', ollamaBacked: true,
       envVars: { ANTHROPIC_BASE_URL: 'http://192.0.2.10:11434' },
     })).toBeNull();
+  });
+});
+
+describe('providerBaseUrl — the stamp source (#4834)', () => {
+  it('returns the REMOTE base of an Ollama-backed CLI that has no endpoint', () => {
+    // `localRuntimeForProvider` answers null for it (correctly — it is not this
+    // box), and it records its daemon ONLY in envVars. Returning null here would
+    // stamp an absent endpoint, and `endpointForAgent` reads absent as
+    // "re-resolve by provider id" — so re-pointing that provider at a local URL
+    // mid-run would start counting a remote agent against the local GPU.
+    const remote = { id: 'remote-ollama-cli', ollamaBacked: true, envVars: { ANTHROPIC_BASE_URL: 'http://192.0.2.10:11434' } };
+    expect(providerBaseUrl(remote)).toBe('http://192.0.2.10:11434');
+    expect(localEndpointOfProvider(remote)).toBeNull();
+  });
+
+  it('prefers the resolved local runtime endpoint over the raw record', () => {
+    const local = { id: 'claude-ollama', ollamaBacked: true, envVars: { ANTHROPIC_BASE_URL: 'http://localhost:11434' } };
+    expect(localEndpointOfProvider(local)).toBe('localhost:11434');
+  });
+
+  it('is null only when the record names no base at all', () => {
+    expect(providerBaseUrl({ id: 'claude-cli', type: 'cli', endpoint: null })).toBeNull();
+    expect(providerBaseUrl(null)).toBeNull();
+  });
+
+  it('keeps a cloud base so its agent is never re-resolved', () => {
+    expect(providerBaseUrl(CLOUD_PROVIDER)).toBe('https://api.anthropic.com/v1');
+    expect(localEndpointOfProvider(CLOUD_PROVIDER)).toBeNull();
   });
 });
 

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -104,10 +104,12 @@ function priorityDequeue(buckets, capacity, { paused = false } = {}) {
   const ceiling = capacity.availableSlots;
 
   const drain = (bucketName) => {
-    // Priority 0 opts OUT of the local-endpoint cap, exactly as production does:
-    // a denial there discards the already-cleared on-demand request instead of
-    // deferring it, so the task is emitted and the spawner chokepoint holds it.
-    const opts = { gateLocalEndpoint: bucketName !== 'onDemand' };
+    // Priorities 0, 3 and 4 opt OUT of the local-endpoint cap, exactly as
+    // production does: a denial there DISCARDS an already-committed task (a
+    // cleared on-demand request, an `in_progress` mission sub-task, a bound
+    // app-review marker) instead of deferring it, so they emit and let the
+    // spawner chokepoint hold.
+    const opts = { gateLocalEndpoint: !['onDemand', 'mission', 'idle'].includes(bucketName) };
     for (const task of buckets[bucketName] || []) {
       if (capacity.spawned >= capacity.availableSlots) return;
       if (!capacity.canSpawn(task, undefined, opts)) continue;
@@ -568,6 +570,49 @@ describe('dequeueNextTask — per-local-endpoint agent cap (#4834)', () => {
 
     expect(spawned.map(t => t.id)).toEqual(['task-run-now']);
     expect(holds).toEqual([]);
+  });
+
+  it('does NOT suppress a mission or idle task at a saturated endpoint', () => {
+    // Both tiers commit before canSpawn and never persist: Priority 3 has
+    // already flipped the mission sub-task to `in_progress` (and only `pending`
+    // sub-tasks are ever re-picked), Priority 4 has already bound the app-review
+    // marker and advanced its 30-minute cooldown. A denial strands both; the
+    // chokepoint's hold at least releases the marker.
+    const state = makeState({
+      maxConcurrentAgents: 5,
+      runningAgents: [makeRunningAgentOnProvider('lmstudio-tui')],
+    });
+    const { capacity } = makeLocalSlotCapacity(state);
+
+    const spawned = priorityDequeue({
+      onDemand: [],
+      user: [],
+      autoSystem: [],
+      mission: [taskOnProvider('mission-task', 'lmstudio-tui')],
+      idle: [],
+    }, capacity);
+
+    expect(spawned.map(t => t.id)).toEqual(['mission-task']);
+  });
+
+  it('keeps gating the deferrable tiers (1 and 2) at the same endpoint', () => {
+    // The opt-out is scoped to the tiers whose denial is destructive. A
+    // persisted user- or system-queue task stays queued, which is a real defer.
+    const state = makeState({
+      maxConcurrentAgents: 5,
+      runningAgents: [makeRunningAgentOnProvider('lmstudio-tui')],
+    });
+    const { capacity } = makeLocalSlotCapacity(state);
+
+    const spawned = priorityDequeue({
+      onDemand: [],
+      user: [],
+      autoSystem: [taskOnProvider('system-task', 'lmstudio-tui')],
+      mission: [],
+      idle: [],
+    }, capacity);
+
+    expect(spawned).toEqual([]);
   });
 
   it('still gates the SAME task from a deferrable tier', () => {
@@ -1411,14 +1456,19 @@ describe('cos.js source — priority + capacity invariants', () => {
       .toMatch(/getFallbackProvider\(/);
   });
 
-  it('Priority 0 opts out of the local-endpoint cap so a Run is never discarded (#4834)', () => {
-    // The on-demand tier clears the request and binds the app-review marker
-    // before canSpawn, and is the only path that persists the task — a denial
-    // there is destructive, not a defer. Pin the opt-out at the call site.
-    const p0 = extractFnBody(COS_SRC, COS_SRC.indexOf('async function spawnDequeuePriority0OnDemand'));
-    expect(p0).toMatch(/canSpawn\(task,\s*undefined,\s*\{\s*gateLocalEndpoint:\s*false\s*\}\)/);
-    // Every other tier keeps the cap: none of them may pass the opt-out.
-    for (const tier of ['spawnDequeuePriority1UserTasks', 'spawnDequeuePriority2AutoApproved', 'spawnDequeuePriority3Missions', 'spawnDequeuePriority4IdleReview']) {
+  it('the DESTRUCTIVE-denial tiers opt out of the local-endpoint cap (#4834)', () => {
+    // Priorities 0, 3 and 4 each commit side effects before `canSpawn` and never
+    // persist the task, so a denial DISCARDS it rather than deferring it: the
+    // on-demand request is already cleared, the mission sub-task is already
+    // flipped to `in_progress` (and only `pending` ones are ever re-picked), the
+    // app-review marker is already bound. They emit and let the chokepoint hold.
+    // Priorities 1 and 2 read from persisted queues, so skipping there is a
+    // genuine defer — they keep the cap.
+    for (const tier of ['spawnDequeuePriority0OnDemand', 'spawnDequeuePriority3Missions', 'spawnDequeuePriority4IdleReview']) {
+      const body = extractFnBody(COS_SRC, COS_SRC.indexOf(`async function ${tier}`));
+      expect(body, `${tier} must opt out of the local-endpoint cap`).toMatch(/gateLocalEndpoint:\s*false/);
+    }
+    for (const tier of ['spawnDequeuePriority1UserTasks', 'spawnDequeuePriority2AutoApproved']) {
       const body = extractFnBody(COS_SRC, COS_SRC.indexOf(`async function ${tier}`));
       expect(body, `${tier} must not opt out of the local-endpoint cap`).not.toMatch(/gateLocalEndpoint:\s*false/);
     }

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -30,14 +30,20 @@
  * `availableSlots <= 0` short-circuit flips a clear red flag.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { firstLine, isPerpetualRefillCandidate, perpetualRefillPlan } from './cos.js';
 import { canQueueImprovementTasks } from './cosState.js';
 import { createDequeueCapacity, countRunningAgentsByLocalEndpoint, isMissionTierEligible, isIdleTierEligible } from './cosDequeue.js';
-import { createLocalEndpointSlotContext, localEndpointOfProvider } from './cosLocalEndpointSlots.js';
+import {
+  createLocalEndpointSlotContext,
+  localEndpointOfProvider,
+  reserveLocalEndpointSpawn,
+  pendingLocalEndpointSpawns,
+  __resetLocalEndpointSpawnReservations,
+} from './cosLocalEndpointSlots.js';
 import { PENDING_MERGE_SWEEP_INTERVAL_MS, MAX_PENDING_MERGE_TICKS } from './prWatcher.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -708,6 +714,77 @@ describe('localEndpointOfProvider (#4834)', () => {
 });
 
 
+describe('local-endpoint spawn reservations (#4834)', () => {
+  beforeEach(() => __resetLocalEndpointSpawnReservations());
+
+  it('counts a reserved-but-not-yet-running spawn against the endpoint', () => {
+    // The window between `task:ready` and the agent record reaching `running`
+    // is several awaits wide. Without the reservation, a second dispatch inside
+    // it reads a snapshot showing zero running agents and over-dispatches.
+    expect(pendingLocalEndpointSpawns(LOCAL_ENDPOINT)).toBe(0);
+    const release = reserveLocalEndpointSpawn(LOCAL_ENDPOINT);
+    expect(pendingLocalEndpointSpawns(LOCAL_ENDPOINT)).toBe(1);
+    release();
+    expect(pendingLocalEndpointSpawns(LOCAL_ENDPOINT)).toBe(0);
+  });
+
+  it('is idempotent — a double release cannot free a slot twice', () => {
+    // The spawner releases in a `finally`, so a throw plus the finally can call
+    // it twice. A naive decrement would go negative and hand out a phantom slot.
+    const first = reserveLocalEndpointSpawn(LOCAL_ENDPOINT);
+    const second = reserveLocalEndpointSpawn(LOCAL_ENDPOINT);
+    expect(pendingLocalEndpointSpawns(LOCAL_ENDPOINT)).toBe(2);
+    first();
+    first();
+    first();
+    expect(pendingLocalEndpointSpawns(LOCAL_ENDPOINT)).toBe(1);
+    second();
+    expect(pendingLocalEndpointSpawns(LOCAL_ENDPOINT)).toBe(0);
+  });
+
+  it('reserving a null endpoint is a no-op', () => {
+    const release = reserveLocalEndpointSpawn(null);
+    expect(pendingLocalEndpointSpawns(null)).toBe(0);
+    expect(() => release()).not.toThrow();
+  });
+
+  it('keeps reservations per endpoint', () => {
+    reserveLocalEndpointSpawn(LOCAL_ENDPOINT);
+    reserveLocalEndpointSpawn(OTHER_LOCAL_ENDPOINT);
+    expect(pendingLocalEndpointSpawns(LOCAL_ENDPOINT)).toBe(1);
+    expect(pendingLocalEndpointSpawns(OTHER_LOCAL_ENDPOINT)).toBe(1);
+  });
+});
+
+describe('endpointForAgent — stamped endpoint wins over the id lookup (#4834)', () => {
+  const slots = createLocalEndpointSlotContext({ providers: ALL_PROVIDERS, activeProvider: CLOUD_PROVIDER });
+
+  it('counts an agent whose provider record was deleted mid-run', () => {
+    // Only `providerId` was persisted pre-#4834, so a deleted provider made a
+    // still-running agent invisible to the cap — freeing a slot the GPU was
+    // still holding. The stamped endpoint survives the deletion.
+    const orphaned = { status: 'running', metadata: { providerId: 'deleted-provider', providerEndpoint: LOCAL_ENDPOINT } };
+    expect(slots.endpointForAgent(orphaned)).toBe(LOCAL_ENDPOINT);
+    expect(countRunningAgentsByLocalEndpoint({ a: orphaned }, slots.endpointForAgent)).toEqual({ [LOCAL_ENDPOINT]: 1 });
+  });
+
+  it('prefers the stamp when the provider record was re-pointed mid-run', () => {
+    // The agent is still talking to the endpoint it started on, not the one the
+    // provider now names.
+    const agent = { status: 'running', metadata: { providerId: 'ollama-local', providerEndpoint: LOCAL_ENDPOINT } };
+    expect(slots.endpointForAgent(agent)).toBe(LOCAL_ENDPOINT);
+  });
+
+  it('falls back to the id lookup for a pre-#4834 record with no stamp', () => {
+    expect(slots.endpointForAgent({ status: 'running', metadata: { providerId: 'lmstudio-tui' } })).toBe(LOCAL_ENDPOINT);
+  });
+
+  it('ignores a stamped REMOTE endpoint rather than gating on it', () => {
+    const agent = { status: 'running', metadata: { providerId: 'anthropic', providerEndpoint: 'https://api.anthropic.com/v1' } };
+    expect(slots.endpointForAgent(agent)).toBeNull();
+  });
+});
+
 // ─── Source-level regression guards ────────────────────────────────────────
 //
 // These pin two structural invariants of the production code that the
@@ -1041,6 +1118,30 @@ describe('cos.js source — priority + capacity invariants', () => {
     const immediateFn = extractFnBody(COS_SRC, COS_SRC.indexOf('async function tryImmediateSpawn'));
     expect(immediateFn).toMatch(/resolveLocalEndpoint\(task\)/);
     expect(immediateFn).toMatch(/countRunningAgentsByLocalEndpoint\(/);
+  });
+
+  it('subAgentSpawner holds at the chokepoint every task:ready emitter funnels through (#4834)', () => {
+    // dequeueNextTask is only ONE of the emitters — evaluateTasks,
+    // forceSpawnTask, the job scheduler and the Creative Director bridge all
+    // reach the spawner directly. If the gate ever moves back to the scheduler
+    // alone, those paths silently over-dispatch at the local GPU again.
+    const SPAWNER_SRC = readFileSync(join(__dirname, 'subAgentSpawner.js'), 'utf-8');
+    expect(SPAWNER_SRC, 'spawner must acquire a local-endpoint slot before spawning')
+      .toMatch(/acquireLocalEndpointSpawnSlot\(/);
+    // The reservation is only correct if it is released once the spawn settles;
+    // a missing `finally` leaks the slot and wedges the endpoint forever.
+    const listener = SPAWNER_SRC.slice(SPAWNER_SRC.indexOf("cosEvents.on('task:ready'"));
+    expect(listener, 'the acquired slot must be released in a finally')
+      .toMatch(/finally\s*\{\s*\n\s*localSlot\.release\(\);/);
+    expect(listener, 'a task at capacity must be HELD (left pending), not failed')
+      .toMatch(/holdTask\(task,\s*localSlot\.reason\)/);
+  });
+
+  it('agentLifecycle stamps the resolved endpoint onto the agent record (#4834)', () => {
+    // Counting a running agent by provider id alone breaks when the provider is
+    // edited or deleted while the agent still holds the GPU.
+    const LIFECYCLE_SRC = readFileSync(join(__dirname, 'agentLifecycle.js'), 'utf-8');
+    expect(LIFECYCLE_SRC).toMatch(/providerEndpoint:\s*provider\.endpoint\s*\|\|\s*null/);
   });
 
   it('idle generator is fenced by spawned===0 / tasksToSpawn.length===0', () => {

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -1063,6 +1063,71 @@ describe('readEndpointCapacity (#4834)', () => {
   });
 });
 
+describe('localEndpointOfProvider — Ollama-backed CLI/TUI providers (#4834)', () => {
+  // Four SHIPPED providers run against the local Ollama daemon with no
+  // `endpoint` field at all. They are the archetype of this issue — PortOS
+  // launches a vendor CLI that opens its own connection — so leaving them
+  // ungated would make the cap inconsistent across providers of the same shape.
+  it('reads the daemon from ANTHROPIC_BASE_URL when endpoint is unset', () => {
+    expect(localEndpointOfProvider({
+      id: 'claude-ollama-tui', type: 'tui', ollamaBacked: true,
+      envVars: { ANTHROPIC_BASE_URL: 'http://localhost:11434' },
+    })).toBe('localhost:11434');
+  });
+
+  it('falls back to the default daemon for a bare ollamaBacked marker', () => {
+    // opencode-ollama* keep their base inside an OPENCODE_CONFIG_CONTENT blob;
+    // the marker alone means the default daemon (what the toolkit's own
+    // ollamaBaseFromProvider does).
+    expect(localEndpointOfProvider({
+      id: 'opencode-ollama-tui', type: 'tui', ollamaBacked: true,
+      envVars: { OPENCODE_CONFIG_CONTENT: '{}' },
+    })).toBe('localhost:11434');
+  });
+
+  it('shares ONE slot with the api-type `ollama` provider on the same daemon', () => {
+    const cli = localEndpointOfProvider({ id: 'claude-ollama', ollamaBacked: true, envVars: { ANTHROPIC_BASE_URL: 'http://localhost:11434' } });
+    const api = localEndpointOfProvider({ id: 'ollama', type: 'api', endpoint: 'http://localhost:11434/v1' });
+    expect(cli).toBe(api);
+  });
+
+  it('does NOT localize a REMOTE Ollama daemon', () => {
+    // The recorded base wins over the local default — an Ollama on another host
+    // is not this machine's GPU.
+    expect(localEndpointOfProvider({ id: 'remote-ollama', type: 'api', endpoint: 'http://192.0.2.10:11434' })).toBeNull();
+    expect(localEndpointOfProvider({
+      id: 'remote-claude-ollama', ollamaBacked: true,
+      envVars: { ANTHROPIC_BASE_URL: 'http://192.0.2.10:11434' },
+    })).toBeNull();
+  });
+
+  it('leaves a non-Ollama CLI provider with no endpoint ungated', () => {
+    expect(localEndpointOfProvider({ id: 'claude-cli', type: 'cli', endpoint: null })).toBeNull();
+  });
+});
+
+describe('endpointForAgent — a present stamp is authoritative both ways (#4834)', () => {
+  const slots = createLocalEndpointSlotContext({ providers: ALL_PROVIDERS, activeProvider: CLOUD_PROVIDER });
+
+  it('does NOT re-resolve when the stamp is REMOTE', () => {
+    // The agent is talking to the cloud. If its provider record is re-pointed at
+    // a local server mid-run, falling through to the id lookup would count this
+    // cloud agent against that GPU — saturating an endpoint with zero agents on
+    // it and holding every task behind it at the default limit of 1.
+    const cloudAgent = {
+      status: 'running',
+      metadata: { providerId: 'lmstudio-tui', providerEndpoint: 'https://api.orcarouter.ai/v1' },
+    };
+    expect(slots.endpointForAgent(cloudAgent)).toBeNull();
+    expect(countRunningAgentsByLocalEndpoint({ a: cloudAgent }, slots.endpointForAgent)).toEqual({});
+  });
+
+  it('still falls back to the id lookup when the stamp is ABSENT', () => {
+    expect(slots.endpointForAgent({ status: 'running', metadata: { providerId: 'lmstudio-tui' } })).toBe(LOCAL_ENDPOINT);
+    expect(slots.endpointForAgent({ status: 'running', metadata: { providerId: 'lmstudio-tui', providerEndpoint: null } })).toBe(LOCAL_ENDPOINT);
+  });
+});
+
 // ─── Source-level regression guards ────────────────────────────────────────
 //
 // These pin two structural invariants of the production code that the
@@ -1419,7 +1484,9 @@ describe('cos.js source — priority + capacity invariants', () => {
     // Counting a running agent by provider id alone breaks when the provider is
     // edited or deleted while the agent still holds the GPU.
     const LIFECYCLE_SRC = readFileSync(join(__dirname, 'agentLifecycle.js'), 'utf-8');
-    expect(LIFECYCLE_SRC).toMatch(/providerEndpoint:\s*provider\.endpoint\s*\|\|\s*null/);
+    // Second source: an Ollama-backed CLI provider records its daemon in
+    // ANTHROPIC_BASE_URL and leaves `endpoint` unset.
+    expect(LIFECYCLE_SRC).toMatch(/providerEndpoint:\s*provider\.endpoint\s*\|\|\s*provider\.envVars\?\.ANTHROPIC_BASE_URL\s*\|\|\s*null/);
   });
 
   it('forceSpawnTask refuses synchronously when the local endpoint is full (#4834)', () => {

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -103,9 +103,13 @@ function priorityDequeue(buckets, capacity, { paused = false } = {}) {
   const ceiling = capacity.availableSlots;
 
   const drain = (bucketName) => {
+    // Priority 0 opts OUT of the local-endpoint cap, exactly as production does:
+    // a denial there discards the already-cleared on-demand request instead of
+    // deferring it, so the task is emitted and the spawner chokepoint holds it.
+    const opts = { gateLocalEndpoint: bucketName !== 'onDemand' };
     for (const task of buckets[bucketName] || []) {
       if (capacity.spawned >= capacity.availableSlots) return;
-      if (!capacity.canSpawn(task)) continue;
+      if (!capacity.canSpawn(task, undefined, opts)) continue;
       capacity.trackSpawn(task);
       admitted.push({ ...task, _bucket: bucketName });
     }
@@ -534,6 +538,42 @@ describe('dequeueNextTask — per-local-endpoint agent cap (#4834)', () => {
     expect(spawned.map(t => t.id)).toEqual(['task-local-1']);
     expect(holds).toEqual([{ taskId: 'task-local-2', endpoint: LOCAL_ENDPOINT, running: 1 }]);
     expect(capacity.spawnLocalEndpointCounts[LOCAL_ENDPOINT]).toBe(1);
+  });
+
+  it('does NOT suppress an explicit on-demand Run at a saturated endpoint', () => {
+    // Priority 0 clears the request and binds the app-review marker BEFORE
+    // canSpawn runs, and that branch is the only thing that persists the task —
+    // so a denial here destroys the user's "Run" and strands the marker rather
+    // than deferring it. The task must be admitted and held at the spawner
+    // chokepoint instead, which leaves it pending and releases both side effects.
+    const state = makeState({
+      maxConcurrentAgents: 5,
+      runningAgents: [makeRunningAgentOnProvider('lmstudio-tui')],
+    });
+    const { capacity, holds } = makeLocalSlotCapacity(state);
+
+    const spawned = priorityDequeue({
+      onDemand: [taskOnProvider('task-run-now', 'lmstudio-tui')],
+      user: [],
+      autoSystem: [],
+      mission: [],
+      idle: [],
+    }, capacity);
+
+    expect(spawned.map(t => t.id)).toEqual(['task-run-now']);
+    expect(holds).toEqual([]);
+  });
+
+  it('still gates the SAME task from a deferrable tier', () => {
+    // The opt-out is scoped to Priority 0. A user-tier task at the same endpoint
+    // stays queued, because skipping it there is a genuine defer.
+    const state = makeState({
+      maxConcurrentAgents: 5,
+      runningAgents: [makeRunningAgentOnProvider('lmstudio-tui')],
+    });
+    const { capacity } = makeLocalSlotCapacity(state);
+
+    expect(priorityDequeue(userBuckets([taskOnProvider('task-run-now', 'lmstudio-tui')]), capacity)).toEqual([]);
   });
 
   it('dispatches the held task once the endpoint frees up (next cycle)', () => {
@@ -1224,6 +1264,19 @@ describe('cos.js source — priority + capacity invariants', () => {
     expect(ctxFn).toMatch(/if \(!isAvailable\(provider\.id\)\) return null;/);
     expect(SLOTS_SRC, 'the live context must use the real provider-status predicate')
       .toMatch(/isAvailable:\s*isProviderAvailable/);
+  });
+
+  it('Priority 0 opts out of the local-endpoint cap so a Run is never discarded (#4834)', () => {
+    // The on-demand tier clears the request and binds the app-review marker
+    // before canSpawn, and is the only path that persists the task — a denial
+    // there is destructive, not a defer. Pin the opt-out at the call site.
+    const p0 = extractFnBody(COS_SRC, COS_SRC.indexOf('async function spawnDequeuePriority0OnDemand'));
+    expect(p0).toMatch(/canSpawn\(task,\s*undefined,\s*\{\s*gateLocalEndpoint:\s*false\s*\}\)/);
+    // Every other tier keeps the cap: none of them may pass the opt-out.
+    for (const tier of ['spawnDequeuePriority1UserTasks', 'spawnDequeuePriority2AutoApproved', 'spawnDequeuePriority3Missions', 'spawnDequeuePriority4IdleReview']) {
+      const body = extractFnBody(COS_SRC, COS_SRC.indexOf(`async function ${tier}`));
+      expect(body, `${tier} must not opt out of the local-endpoint cap`).not.toMatch(/gateLocalEndpoint:\s*false/);
+    }
   });
 
   it('idle generator is fenced by spawned===0 / tasksToSpawn.length===0', () => {

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -109,10 +109,10 @@ function priorityDequeue(buckets, capacity, { paused = false } = {}) {
     // cleared on-demand request, an `in_progress` mission sub-task, a bound
     // app-review marker) instead of deferring it, so they emit and let the
     // spawner chokepoint hold.
-    const opts = { gateLocalEndpoint: !['onDemand', 'mission', 'idle'].includes(bucketName) };
+    const committed = ['onDemand', 'mission', 'idle'].includes(bucketName);
     for (const task of buckets[bucketName] || []) {
       if (capacity.spawned >= capacity.availableSlots) return;
-      if (!capacity.canSpawn(task, undefined, opts)) continue;
+      if (!(committed ? capacity.canSpawnCommitted(task) : capacity.canSpawn(task))) continue;
       capacity.trackSpawn(task);
       admitted.push({ ...task, _bucket: bucketName });
     }
@@ -595,9 +595,10 @@ describe('dequeueNextTask — per-local-endpoint agent cap (#4834)', () => {
     expect(spawned.map(t => t.id)).toEqual(['mission-task']);
   });
 
-  it('keeps gating the deferrable tiers (1 and 2) at the same endpoint', () => {
-    // The opt-out is scoped to the tiers whose denial is destructive. A
-    // persisted user- or system-queue task stays queued, which is a real defer.
+  it.each(['user', 'autoSystem'])('keeps gating the deferrable %s tier at the same endpoint', (bucket) => {
+    // The opt-out is scoped to the tiers whose denial is destructive. A task
+    // from a persisted queue stays queued, which is a real defer — the next
+    // cycle re-picks it once the endpoint frees up.
     const state = makeState({
       maxConcurrentAgents: 5,
       runningAgents: [makeRunningAgentOnProvider('lmstudio-tui')],
@@ -605,39 +606,11 @@ describe('dequeueNextTask — per-local-endpoint agent cap (#4834)', () => {
     const { capacity } = makeLocalSlotCapacity(state);
 
     const spawned = priorityDequeue({
-      onDemand: [],
-      user: [],
-      autoSystem: [taskOnProvider('system-task', 'lmstudio-tui')],
-      mission: [],
-      idle: [],
+      onDemand: [], user: [], autoSystem: [], mission: [], idle: [],
+      [bucket]: [taskOnProvider('deferrable-task', 'lmstudio-tui')],
     }, capacity);
 
     expect(spawned).toEqual([]);
-  });
-
-  it('still gates the SAME task from a deferrable tier', () => {
-    // The opt-out is scoped to Priority 0. A user-tier task at the same endpoint
-    // stays queued, because skipping it there is a genuine defer.
-    const state = makeState({
-      maxConcurrentAgents: 5,
-      runningAgents: [makeRunningAgentOnProvider('lmstudio-tui')],
-    });
-    const { capacity } = makeLocalSlotCapacity(state);
-
-    expect(priorityDequeue(userBuckets([taskOnProvider('task-run-now', 'lmstudio-tui')]), capacity)).toEqual([]);
-  });
-
-  it('dispatches the held task once the endpoint frees up (next cycle)', () => {
-    // Same fixture, but the first agent has finished — nothing is running, so
-    // the previously-held task now takes the slot. This is the "dispatches when
-    // the first finishes" half of the acceptance criteria.
-    const state = makeState({ maxConcurrentAgents: 5 });
-    const { capacity, holds } = makeLocalSlotCapacity(state);
-
-    const spawned = priorityDequeue(userBuckets([taskOnProvider('task-local-2', 'lmstudio-tui')]), capacity);
-
-    expect(spawned.map(t => t.id)).toEqual(['task-local-2']);
-    expect(holds).toEqual([]);
   });
 
   it('counts an ALREADY-RUNNING agent against its local endpoint', () => {
@@ -949,11 +922,20 @@ describe('endpointForAgent — stamped endpoint wins over the id lookup (#4834)'
 
   it('falls back to the id lookup for a pre-#4834 record with no stamp', () => {
     expect(slots.endpointForAgent({ status: 'running', metadata: { providerId: 'lmstudio-tui' } })).toBe(LOCAL_ENDPOINT);
+    expect(slots.endpointForAgent({ status: 'running', metadata: { providerId: 'lmstudio-tui', providerEndpoint: null } })).toBe(LOCAL_ENDPOINT);
   });
 
-  it('ignores a stamped REMOTE endpoint rather than gating on it', () => {
-    const agent = { status: 'running', metadata: { providerId: 'anthropic', providerEndpoint: 'https://api.anthropic.com/v1' } };
-    expect(slots.endpointForAgent(agent)).toBeNull();
+  it('does NOT re-resolve when the stamp is REMOTE', () => {
+    // The agent is talking to the cloud. If its provider record is re-pointed at
+    // a local server mid-run, falling through to the id lookup would count this
+    // cloud agent against that GPU — saturating an endpoint with zero agents on
+    // it and holding every task behind it at the default limit of 1.
+    const cloudAgent = {
+      status: 'running',
+      metadata: { providerId: 'lmstudio-tui', providerEndpoint: 'https://api.anthropic.com/v1' },
+    };
+    expect(slots.endpointForAgent(cloudAgent)).toBeNull();
+    expect(countRunningAgentsByLocalEndpoint({ a: cloudAgent }, slots.endpointForAgent)).toEqual({});
   });
 });
 
@@ -1099,32 +1081,6 @@ describe('localEndpointOfProvider — Ollama-backed CLI/TUI providers (#4834)', 
       id: 'remote-claude-ollama', ollamaBacked: true,
       envVars: { ANTHROPIC_BASE_URL: 'http://192.0.2.10:11434' },
     })).toBeNull();
-  });
-
-  it('leaves a non-Ollama CLI provider with no endpoint ungated', () => {
-    expect(localEndpointOfProvider({ id: 'claude-cli', type: 'cli', endpoint: null })).toBeNull();
-  });
-});
-
-describe('endpointForAgent — a present stamp is authoritative both ways (#4834)', () => {
-  const slots = createLocalEndpointSlotContext({ providers: ALL_PROVIDERS, activeProvider: CLOUD_PROVIDER });
-
-  it('does NOT re-resolve when the stamp is REMOTE', () => {
-    // The agent is talking to the cloud. If its provider record is re-pointed at
-    // a local server mid-run, falling through to the id lookup would count this
-    // cloud agent against that GPU — saturating an endpoint with zero agents on
-    // it and holding every task behind it at the default limit of 1.
-    const cloudAgent = {
-      status: 'running',
-      metadata: { providerId: 'lmstudio-tui', providerEndpoint: 'https://api.orcarouter.ai/v1' },
-    };
-    expect(slots.endpointForAgent(cloudAgent)).toBeNull();
-    expect(countRunningAgentsByLocalEndpoint({ a: cloudAgent }, slots.endpointForAgent)).toEqual({});
-  });
-
-  it('still falls back to the id lookup when the stamp is ABSENT', () => {
-    expect(slots.endpointForAgent({ status: 'running', metadata: { providerId: 'lmstudio-tui' } })).toBe(LOCAL_ENDPOINT);
-    expect(slots.endpointForAgent({ status: 'running', metadata: { providerId: 'lmstudio-tui', providerEndpoint: null } })).toBe(LOCAL_ENDPOINT);
   });
 });
 
@@ -1455,12 +1411,15 @@ describe('cos.js source — priority + capacity invariants', () => {
     expect(dequeueFn).toMatch(/localEndpointLimit:/);
   });
 
-  it('tryImmediateSpawn enforces the same local-endpoint cap (#4834)', () => {
-    // This path bypasses the evaluation interval, so without its own check a
-    // user-submitted task would dispatch straight past the local-GPU limit.
+  it('tryImmediateSpawn does NOT re-implement the local-endpoint cap (#4834)', () => {
+    // Its task is already persisted by `addTask`, so emitting and letting the
+    // chokepoint hold produces exactly what an early return would. A local copy
+    // would be a weaker duplicate — it can only see a running-agent snapshot,
+    // not the in-flight reservations the authoritative gate also counts — so it
+    // could pass a task the chokepoint then holds, for an extra provider fetch.
     const immediateFn = extractFnBody(COS_SRC, COS_SRC.indexOf('async function tryImmediateSpawn'));
-    expect(immediateFn).toMatch(/resolveLocalEndpoint\(task\)/);
-    expect(immediateFn).toMatch(/countRunningAgentsByLocalEndpoint\(/);
+    expect(immediateFn).not.toMatch(/resolveLocalEndpoint\(/);
+    expect(immediateFn).not.toMatch(/countRunningAgentsByLocalEndpoint\(/);
   });
 
   it('subAgentSpawner holds at the chokepoint every task:ready emitter funnels through (#4834)', () => {
@@ -1484,9 +1443,9 @@ describe('cos.js source — priority + capacity invariants', () => {
     // Counting a running agent by provider id alone breaks when the provider is
     // edited or deleted while the agent still holds the GPU.
     const LIFECYCLE_SRC = readFileSync(join(__dirname, 'agentLifecycle.js'), 'utf-8');
-    // Second source: an Ollama-backed CLI provider records its daemon in
-    // ANTHROPIC_BASE_URL and leaves `endpoint` unset.
-    expect(LIFECYCLE_SRC).toMatch(/providerEndpoint:\s*provider\.endpoint\s*\|\|\s*provider\.envVars\?\.ANTHROPIC_BASE_URL\s*\|\|\s*null/);
+    // Stamped through the SAME resolver the counter reads with, so writer and
+    // reader cannot drift on where a CLI provider records its daemon.
+    expect(LIFECYCLE_SRC).toMatch(/providerEndpoint:\s*providerBaseUrl\(provider\)/);
   });
 
   it('forceSpawnTask refuses synchronously when the local endpoint is full (#4834)', () => {
@@ -1503,23 +1462,25 @@ describe('cos.js source — priority + capacity invariants', () => {
       .toBeLessThan(forceFn.indexOf("cosEvents.emit('task:ready'"));
   });
 
-  it('forceSpawnTask excludes the task\'s own zombie agent from the tally (#4834)', () => {
-    // The route deliberately supersedes a stale `running` holder — counting it
-    // would make that recovery unreachable at a limit of 1.
+  it('forceSpawnTask passes its task id so its own zombie agent is excluded (#4834)', () => {
+    // The route deliberately supersedes a stale `running` holder — counting that
+    // agent would make the recovery unreachable at a limit of 1. The exclusion
+    // itself is driven directly in the `readEndpointCapacity` block above; what
+    // that can't see is whether this caller opts into it.
     const forceFn = extractFnBody(COS_SRC, COS_SRC.indexOf('export async function forceSpawnTask'));
-    expect(forceFn).toMatch(/localEndpointCapacityError\(resolution\.provider,\s*state\.agents,\s*taskId\)/);
+    expect(forceFn).toMatch(/localEndpointCapacityError\([^)]*taskId\)/);
   });
 
-  it('the gate ignores an UNAVAILABLE provider so a held task cannot starve (#4834)', () => {
-    // A saturated local provider that is down is not where the task lands —
-    // spawn swaps it for a fallback. Holding on it would wait on a GPU the task
-    // never touches, with nothing to clear the hold.
+  it('the LIVE gate wires in the real availability + fallback resolvers (#4834)', () => {
+    // The branch logic itself is driven directly above (`resolveLocalEndpoint —
+    // follows the fallback swap`) through injected doubles. What no unit test
+    // can reach is whether the PRODUCTION context injects the real ones — if it
+    // ever passed its own approximation, the prediction would silently drift
+    // from where spawn actually sends the task.
     const SLOTS_SRC = readFileSync(join(__dirname, 'cosLocalEndpointSlots.js'), 'utf-8');
-    const ctxFn = extractFnBody(SLOTS_SRC, SLOTS_SRC.indexOf('export function createLocalEndpointSlotContext'));
-    expect(ctxFn).toMatch(/isAvailable\(primary\.id\)\s*\?\s*primary\s*:\s*resolveFallback\(/);
-    expect(SLOTS_SRC, 'the live context must use the real provider-status predicate')
+    expect(SLOTS_SRC, 'must use the real provider-status predicate')
       .toMatch(/isAvailable:\s*isProviderAvailable/);
-    expect(SLOTS_SRC, 'and the REAL fallback resolver, so the prediction cannot drift from spawn')
+    expect(SLOTS_SRC, 'and the real fallback resolver spawn uses')
       .toMatch(/getFallbackProvider\(/);
   });
 
@@ -1533,11 +1494,11 @@ describe('cos.js source — priority + capacity invariants', () => {
     // genuine defer — they keep the cap.
     for (const tier of ['spawnDequeuePriority0OnDemand', 'spawnDequeuePriority3Missions', 'spawnDequeuePriority4IdleReview']) {
       const body = extractFnBody(COS_SRC, COS_SRC.indexOf(`async function ${tier}`));
-      expect(body, `${tier} must opt out of the local-endpoint cap`).toMatch(/gateLocalEndpoint:\s*false/);
+      expect(body, `${tier} must admit via canSpawnCommitted`).toMatch(/canSpawnCommitted\(/);
     }
     for (const tier of ['spawnDequeuePriority1UserTasks', 'spawnDequeuePriority2AutoApproved']) {
       const body = extractFnBody(COS_SRC, COS_SRC.indexOf(`async function ${tier}`));
-      expect(body, `${tier} must not opt out of the local-endpoint cap`).not.toMatch(/gateLocalEndpoint:\s*false/);
+      expect(body, `${tier} defers rather than discards — it must keep the cap`).not.toMatch(/canSpawnCommitted\(/);
     }
   });
 

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -43,6 +43,7 @@ import {
   reserveLocalEndpointSpawn,
   pendingLocalEndpointSpawns,
   __resetLocalEndpointSpawnReservations,
+  readEndpointCapacity,
 } from './cosLocalEndpointSlots.js';
 import { PENDING_MERGE_SWEEP_INTERVAL_MS, MAX_PENDING_MERGE_TICKS } from './prWatcher.js';
 
@@ -477,16 +478,21 @@ describe('dequeueNextTask — capacity guards', () => {
 // tracker — the same pair `dequeueNextTask` wires together — so a regression in
 // either half fails here.
 
-const LOCAL_ENDPOINT = 'http://localhost:1234/v1';
-const OTHER_LOCAL_ENDPOINT = 'http://127.0.0.1:11434';
+// What the PROVIDER RECORD holds, vs the normalized SLOT KEY the cap is keyed
+// by. They differ on purpose: host+port identifies the model server, so
+// `localhost` and `127.0.0.1` on one port must share a single slot.
+const LOCAL_URL = 'http://localhost:1234/v1';
+const LOCAL_ENDPOINT = 'localhost:1234';
+const OTHER_LOCAL_URL = 'http://127.0.0.1:11434';
+const OTHER_LOCAL_ENDPOINT = 'localhost:11434';
 
 // A TUI provider pointed at a local server is exactly the case #4834 exists
 // for: PortOS launches the CLI, the CLI talks to the GPU directly.
-const LOCAL_TUI_PROVIDER = { id: 'lmstudio-tui', type: 'tui', endpoint: LOCAL_ENDPOINT };
-const OTHER_LOCAL_PROVIDER = { id: 'ollama-local', type: 'api', endpoint: OTHER_LOCAL_ENDPOINT };
+const LOCAL_TUI_PROVIDER = { id: 'lmstudio-tui', type: 'tui', enabled: true, endpoint: LOCAL_URL };
+const OTHER_LOCAL_PROVIDER = { id: 'ollama-local', type: 'api', enabled: true, endpoint: OTHER_LOCAL_URL };
 // No recorded endpoint — PortOS cannot know where it points, so it stays ungated.
-const BARE_CLI_PROVIDER = { id: 'claude-cli', type: 'cli', endpoint: null };
-const CLOUD_PROVIDER = { id: 'anthropic', type: 'api', endpoint: 'https://api.anthropic.com/v1' };
+const BARE_CLI_PROVIDER = { id: 'claude-cli', type: 'cli', enabled: true, endpoint: null };
+const CLOUD_PROVIDER = { id: 'anthropic', type: 'api', enabled: true, endpoint: 'https://api.anthropic.com/v1' };
 
 const ALL_PROVIDERS = [LOCAL_TUI_PROVIDER, OTHER_LOCAL_PROVIDER, BARE_CLI_PROVIDER, CLOUD_PROVIDER];
 
@@ -735,8 +741,32 @@ describe('countRunningAgentsByLocalEndpoint (#4834)', () => {
 
 describe('localEndpointOfProvider (#4834)', () => {
   it('resolves a local endpoint regardless of provider type', () => {
-    expect(localEndpointOfProvider({ type: 'tui', endpoint: 'http://localhost:1234/v1' })).toBe('http://localhost:1234/v1');
-    expect(localEndpointOfProvider({ type: 'api', endpoint: 'http://127.0.0.1:11434' })).toBe('http://127.0.0.1:11434');
+    expect(localEndpointOfProvider({ type: 'tui', endpoint: 'http://localhost:1234/v1' })).toBe('localhost:1234');
+    expect(localEndpointOfProvider({ type: 'api', endpoint: 'http://127.0.0.1:11434' })).toBe('localhost:11434');
+  });
+
+  it('collapses every spelling of ONE local server onto a single slot key', () => {
+    // Host+port identifies the model server; scheme, path and host spelling do
+    // not. The shipped catalog already mixes spellings (`lmstudio` is seeded at
+    // localhost:1234, everything else at 127.0.0.1), so keying on the raw string
+    // would give one LM Studio process two independent caps — and let two agents
+    // onto the same GPU, the exact OOM this issue exists to prevent.
+    const spellings = [
+      'http://localhost:1234/v1',
+      'http://127.0.0.1:1234/v1',
+      'http://127.0.0.1:1234',
+      'https://localhost:1234/v1',
+      'localhost:1234',
+      '  http://0.0.0.0:1234/v1  ',
+    ];
+    for (const endpoint of spellings) {
+      expect(localEndpointOfProvider({ endpoint }), endpoint).toBe('localhost:1234');
+    }
+  });
+
+  it('keeps distinct local servers on distinct keys', () => {
+    expect(localEndpointOfProvider({ endpoint: 'http://127.0.0.1:1234/v1' }))
+      .not.toBe(localEndpointOfProvider({ endpoint: 'http://127.0.0.1:11434/v1' }));
   });
 
   it('returns null for a remote endpoint, a missing endpoint, or no provider', () => {
@@ -860,7 +890,7 @@ describe('endpointForAgent — stamped endpoint wins over the id lookup (#4834)'
     // Only `providerId` was persisted pre-#4834, so a deleted provider made a
     // still-running agent invisible to the cap — freeing a slot the GPU was
     // still holding. The stamped endpoint survives the deletion.
-    const orphaned = { status: 'running', metadata: { providerId: 'deleted-provider', providerEndpoint: LOCAL_ENDPOINT } };
+    const orphaned = { status: 'running', metadata: { providerId: 'deleted-provider', providerEndpoint: LOCAL_URL } };
     expect(slots.endpointForAgent(orphaned)).toBe(LOCAL_ENDPOINT);
     expect(countRunningAgentsByLocalEndpoint({ a: orphaned }, slots.endpointForAgent)).toEqual({ [LOCAL_ENDPOINT]: 1 });
   });
@@ -868,7 +898,7 @@ describe('endpointForAgent — stamped endpoint wins over the id lookup (#4834)'
   it('prefers the stamp when the provider record was re-pointed mid-run', () => {
     // The agent is still talking to the endpoint it started on, not the one the
     // provider now names.
-    const agent = { status: 'running', metadata: { providerId: 'ollama-local', providerEndpoint: LOCAL_ENDPOINT } };
+    const agent = { status: 'running', metadata: { providerId: 'ollama-local', providerEndpoint: LOCAL_URL } };
     expect(slots.endpointForAgent(agent)).toBe(LOCAL_ENDPOINT);
   });
 
@@ -879,6 +909,112 @@ describe('endpointForAgent — stamped endpoint wins over the id lookup (#4834)'
   it('ignores a stamped REMOTE endpoint rather than gating on it', () => {
     const agent = { status: 'running', metadata: { providerId: 'anthropic', providerEndpoint: 'https://api.anthropic.com/v1' } };
     expect(slots.endpointForAgent(agent)).toBeNull();
+  });
+});
+
+describe('resolveLocalEndpoint — follows the fallback swap (#4834)', () => {
+  // An unavailable provider is not where the task lands, so the gate follows the
+  // SAME getFallbackProvider spawn uses. Both directions matter: a cloud
+  // fallback must ungate (or the task starves behind a GPU it never touches),
+  // and a fallback on the same local server must stay gated (or the cap
+  // disappears exactly when the endpoint is unhealthy — the shipped catalog has
+  // four providers on 127.0.0.1:18021).
+  const SAME_SERVER_SIBLING = { id: 'lmstudio-api', type: 'api', enabled: true, endpoint: 'http://127.0.0.1:1234' };
+
+  const withFallback = (fallbackProvider) => createLocalEndpointSlotContext({
+    providers: [...ALL_PROVIDERS, SAME_SERVER_SIBLING],
+    activeProvider: CLOUD_PROVIDER,
+    isAvailable: (id) => id !== 'lmstudio-tui',
+    resolveFallback: () => fallbackProvider,
+  });
+
+  it('stays gated when the fallback lands on the SAME local server', () => {
+    // Different provider record, different host spelling, same GPU.
+    expect(withFallback(SAME_SERVER_SIBLING).resolveLocalEndpoint(taskOnProvider('t', 'lmstudio-tui')))
+      .toBe(LOCAL_ENDPOINT);
+  });
+
+  it('ungates when the fallback is a cloud provider', () => {
+    expect(withFallback(CLOUD_PROVIDER).resolveLocalEndpoint(taskOnProvider('t', 'lmstudio-tui'))).toBeNull();
+  });
+
+  it('gates on the FALLBACK endpoint when it is a different local server', () => {
+    expect(withFallback(OTHER_LOCAL_PROVIDER).resolveLocalEndpoint(taskOnProvider('t', 'lmstudio-tui')))
+      .toBe(OTHER_LOCAL_ENDPOINT);
+  });
+
+  it('ungates when no fallback resolves at all', () => {
+    expect(withFallback(null).resolveLocalEndpoint(taskOnProvider('t', 'lmstudio-tui'))).toBeNull();
+  });
+
+  it('passes the task through so a task-level fallback pin is honored', () => {
+    // getFallbackProvider's first tier reads metadata.fallbackProvider /
+    // metadata.fallbackModel off the task; the context must hand them over.
+    const seen = [];
+    const slots = createLocalEndpointSlotContext({
+      providers: ALL_PROVIDERS,
+      activeProvider: CLOUD_PROVIDER,
+      isAvailable: () => false,
+      resolveFallback: (primaryId, providersMap, task) => { seen.push({ primaryId, task }); return null; },
+    });
+    slots.resolveLocalEndpoint({ id: 't', metadata: { provider: 'lmstudio-tui', fallbackProvider: 'ollama-local' } });
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].primaryId).toBe('lmstudio-tui');
+    expect(seen[0].task.metadata.fallbackProvider).toBe('ollama-local');
+  });
+});
+
+describe('readEndpointCapacity (#4834)', () => {
+  beforeEach(() => __resetLocalEndpointSpawnReservations());
+
+  const slots = createLocalEndpointSlotContext({ providers: ALL_PROVIDERS, activeProvider: CLOUD_PROVIDER, limit: 1 });
+  const runningOn = (providerId, taskId) => ({ status: 'running', taskId, metadata: { providerId } });
+
+  it('counts a running agent against its endpoint', () => {
+    const capacity = readEndpointCapacity(LOCAL_ENDPOINT, { a: runningOn('lmstudio-tui', 'task-a') }, slots);
+    expect(capacity).toMatchObject({ inFlight: 1, limit: 1, atCapacity: true });
+  });
+
+  it('excludes the dispatching task\'s OWN agent so Run-now can supersede a zombie', () => {
+    // forceSpawnTask deliberately supersedes a `running` holder older than the
+    // spawn grace — that is the documented recovery for an agent whose PTY died
+    // without a close handler. Counting the zombie would make the one recovery
+    // the route exists to provide unreachable at a limit of 1.
+    const agents = { a: runningOn('lmstudio-tui', 'task-stuck') };
+    expect(readEndpointCapacity(LOCAL_ENDPOINT, agents, slots, { ignoreTaskId: 'task-stuck' }).atCapacity).toBe(false);
+    expect(readEndpointCapacity(LOCAL_ENDPOINT, agents, slots, { ignoreTaskId: 'other-task' }).atCapacity).toBe(true);
+  });
+
+  it('does not double-count a reservation whose agent already registered', () => {
+    // registerAgent flips the record to `running` well before spawnAgentForTask
+    // returns, so for the whole PTY-launch window the same agent is both in the
+    // running tally and holding its reservation.
+    reserveLocalEndpointSpawn(LOCAL_ENDPOINT, 'task-a');
+    const agents = { a: runningOn('lmstudio-tui', 'task-a') };
+
+    expect(readEndpointCapacity(LOCAL_ENDPOINT, agents, slots).inFlight).toBe(1);
+  });
+
+  it('still counts a reservation that has NOT registered yet', () => {
+    reserveLocalEndpointSpawn(LOCAL_ENDPOINT, 'task-b');
+    const agents = { a: runningOn('lmstudio-tui', 'task-a') };
+
+    expect(readEndpointCapacity(LOCAL_ENDPOINT, agents, slots).inFlight).toBe(2);
+  });
+
+  it('counts an anonymous reservation (no task id) unconditionally', () => {
+    reserveLocalEndpointSpawn(LOCAL_ENDPOINT, null);
+    expect(readEndpointCapacity(LOCAL_ENDPOINT, {}, slots).inFlight).toBe(1);
+  });
+
+  it('ignores agents on other endpoints and non-running agents', () => {
+    const agents = {
+      a: runningOn('ollama-local', 'task-a'),
+      b: runningOn('anthropic', 'task-b'),
+      c: { status: 'completed', taskId: 'task-c', metadata: { providerId: 'lmstudio-tui' } },
+    };
+    expect(readEndpointCapacity(LOCAL_ENDPOINT, agents, slots).inFlight).toBe(0);
   });
 });
 
@@ -1255,15 +1391,24 @@ describe('cos.js source — priority + capacity invariants', () => {
       .toBeLessThan(forceFn.indexOf("cosEvents.emit('task:ready'"));
   });
 
+  it('forceSpawnTask excludes the task\'s own zombie agent from the tally (#4834)', () => {
+    // The route deliberately supersedes a stale `running` holder — counting it
+    // would make that recovery unreachable at a limit of 1.
+    const forceFn = extractFnBody(COS_SRC, COS_SRC.indexOf('export async function forceSpawnTask'));
+    expect(forceFn).toMatch(/localEndpointCapacityError\(resolution\.provider,\s*state\.agents,\s*taskId\)/);
+  });
+
   it('the gate ignores an UNAVAILABLE provider so a held task cannot starve (#4834)', () => {
     // A saturated local provider that is down is not where the task lands —
     // spawn swaps it for a fallback. Holding on it would wait on a GPU the task
     // never touches, with nothing to clear the hold.
     const SLOTS_SRC = readFileSync(join(__dirname, 'cosLocalEndpointSlots.js'), 'utf-8');
     const ctxFn = extractFnBody(SLOTS_SRC, SLOTS_SRC.indexOf('export function createLocalEndpointSlotContext'));
-    expect(ctxFn).toMatch(/if \(!isAvailable\(provider\.id\)\) return null;/);
+    expect(ctxFn).toMatch(/isAvailable\(primary\.id\)\s*\?\s*primary\s*:\s*resolveFallback\(/);
     expect(SLOTS_SRC, 'the live context must use the real provider-status predicate')
       .toMatch(/isAvailable:\s*isProviderAvailable/);
+    expect(SLOTS_SRC, 'and the REAL fallback resolver, so the prediction cannot drift from spawn')
+      .toMatch(/getFallbackProvider\(/);
   });
 
   it('Priority 0 opts out of the local-endpoint cap so a Run is never discarded (#4834)', () => {

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -714,6 +714,63 @@ describe('localEndpointOfProvider (#4834)', () => {
 });
 
 
+describe('resolveLocalEndpoint — unavailable providers are not gated (#4834)', () => {
+  // A saturated LOCAL provider that is currently unavailable (rate-limited,
+  // cooling down, down) is not where the task lands: resolveAgentProviderAndModel
+  // swaps it for a fallback, often a cloud one. Gating on it anyway would hold
+  // the task behind a GPU it never touches — and nothing about that busy GPU
+  // would ever clear the hold, so the task starves.
+  const withAvailability = (available) => createLocalEndpointSlotContext({
+    providers: ALL_PROVIDERS,
+    activeProvider: CLOUD_PROVIDER,
+    isAvailable: (id) => available.includes(id),
+  });
+
+  it('resolves to null when the pinned local provider is unavailable', () => {
+    const slots = withAvailability(['anthropic']);
+    expect(slots.resolveLocalEndpoint(taskOnProvider('t', 'lmstudio-tui'))).toBeNull();
+  });
+
+  it('still gates the same provider once it is available again', () => {
+    const slots = withAvailability(['lmstudio-tui', 'anthropic']);
+    expect(slots.resolveLocalEndpoint(taskOnProvider('t', 'lmstudio-tui'))).toBe(LOCAL_ENDPOINT);
+  });
+
+  it('resolves to null when the ACTIVE local provider is unavailable', () => {
+    const slots = createLocalEndpointSlotContext({
+      providers: ALL_PROVIDERS,
+      activeProvider: LOCAL_TUI_PROVIDER,
+      isAvailable: () => false,
+    });
+    expect(slots.resolveLocalEndpoint(taskOnProvider('t'))).toBeNull();
+  });
+
+  it('does not starve a queued task behind an unavailable local endpoint', () => {
+    // End-to-end through the real tracker: one agent is running on the local
+    // endpoint, but the provider has since gone unavailable, so the queued task
+    // must dispatch (onto its fallback) instead of waiting forever.
+    const state = makeState({
+      maxConcurrentAgents: 5,
+      runningAgents: [makeRunningAgentOnProvider('lmstudio-tui')],
+    });
+    const slots = withAvailability(['anthropic']);
+    const capacity = createDequeueCapacity(state, {
+      localEndpointCounts: countRunningAgentsByLocalEndpoint(state.agents, slots.endpointForAgent),
+      localEndpointLimit: slots.limit,
+      resolveLocalEndpoint: slots.resolveLocalEndpoint,
+    });
+
+    const spawned = priorityDequeue(userBuckets([taskOnProvider('task-local-1', 'lmstudio-tui')]), capacity);
+    expect(spawned.map(t => t.id)).toEqual(['task-local-1']);
+  });
+
+  it('leaves a task with no resolvable provider ungated', () => {
+    const slots = createLocalEndpointSlotContext({ providers: [], activeProvider: null });
+    expect(slots.resolveLocalEndpoint(taskOnProvider('t'))).toBeNull();
+    expect(slots.resolveLocalEndpoint(taskOnProvider('t', 'ghost'))).toBeNull();
+  });
+});
+
 describe('local-endpoint spawn reservations (#4834)', () => {
   beforeEach(() => __resetLocalEndpointSpawnReservations());
 
@@ -1142,6 +1199,31 @@ describe('cos.js source — priority + capacity invariants', () => {
     // edited or deleted while the agent still holds the GPU.
     const LIFECYCLE_SRC = readFileSync(join(__dirname, 'agentLifecycle.js'), 'utf-8');
     expect(LIFECYCLE_SRC).toMatch(/providerEndpoint:\s*provider\.endpoint\s*\|\|\s*null/);
+  });
+
+  it('forceSpawnTask refuses synchronously when the local endpoint is full (#4834)', () => {
+    // "Run now" returns before the spawn happens, so without its own check it
+    // would answer { success: true } and toast "Spawning" for a task the
+    // chokepoint immediately holds — the same lie the provider-resolution
+    // pre-check directly above it exists to prevent. It must run AFTER
+    // resolution so it reads the post-fallback provider.
+    const forceFn = extractFnBody(COS_SRC, COS_SRC.indexOf('export async function forceSpawnTask'));
+    expect(forceFn).toMatch(/localEndpointCapacityError\(resolution\.provider/);
+    expect(forceFn.indexOf('resolveAgentProviderAndModel'))
+      .toBeLessThan(forceFn.indexOf('localEndpointCapacityError'));
+    expect(forceFn.indexOf('localEndpointCapacityError'))
+      .toBeLessThan(forceFn.indexOf("cosEvents.emit('task:ready'"));
+  });
+
+  it('the gate ignores an UNAVAILABLE provider so a held task cannot starve (#4834)', () => {
+    // A saturated local provider that is down is not where the task lands —
+    // spawn swaps it for a fallback. Holding on it would wait on a GPU the task
+    // never touches, with nothing to clear the hold.
+    const SLOTS_SRC = readFileSync(join(__dirname, 'cosLocalEndpointSlots.js'), 'utf-8');
+    const ctxFn = extractFnBody(SLOTS_SRC, SLOTS_SRC.indexOf('export function createLocalEndpointSlotContext'));
+    expect(ctxFn).toMatch(/if \(!isAvailable\(provider\.id\)\) return null;/);
+    expect(SLOTS_SRC, 'the live context must use the real provider-status predicate')
+      .toMatch(/isAvailable:\s*isProviderAvailable/);
   });
 
   it('idle generator is fenced by spawned===0 / tasksToSpawn.length===0', () => {

--- a/server/services/cos.test.js
+++ b/server/services/cos.test.js
@@ -36,7 +36,8 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { firstLine, isPerpetualRefillCandidate, perpetualRefillPlan } from './cos.js';
 import { canQueueImprovementTasks } from './cosState.js';
-import { createDequeueCapacity, isMissionTierEligible, isIdleTierEligible } from './cosDequeue.js';
+import { createDequeueCapacity, countRunningAgentsByLocalEndpoint, isMissionTierEligible, isIdleTierEligible } from './cosDequeue.js';
+import { createLocalEndpointSlotContext, localEndpointOfProvider } from './cosLocalEndpointSlots.js';
 import { PENDING_MERGE_SWEEP_INTERVAL_MS, MAX_PENDING_MERGE_TICKS } from './prWatcher.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -458,6 +459,255 @@ describe('dequeueNextTask — capacity guards', () => {
   });
 });
 
+// ─── dequeueNextTask: per-local-endpoint agent cap (issue #4834) ───────────
+//
+// A CoS agent runs a vendor CLI that opens its own connection to the local
+// model server, so promptRunner's in-flight gate never sees it. These drive the
+// REAL `createLocalEndpointSlotContext` resolvers through the REAL capacity
+// tracker — the same pair `dequeueNextTask` wires together — so a regression in
+// either half fails here.
+
+const LOCAL_ENDPOINT = 'http://localhost:1234/v1';
+const OTHER_LOCAL_ENDPOINT = 'http://127.0.0.1:11434';
+
+// A TUI provider pointed at a local server is exactly the case #4834 exists
+// for: PortOS launches the CLI, the CLI talks to the GPU directly.
+const LOCAL_TUI_PROVIDER = { id: 'lmstudio-tui', type: 'tui', endpoint: LOCAL_ENDPOINT };
+const OTHER_LOCAL_PROVIDER = { id: 'ollama-local', type: 'api', endpoint: OTHER_LOCAL_ENDPOINT };
+// No recorded endpoint — PortOS cannot know where it points, so it stays ungated.
+const BARE_CLI_PROVIDER = { id: 'claude-cli', type: 'cli', endpoint: null };
+const CLOUD_PROVIDER = { id: 'anthropic', type: 'api', endpoint: 'https://api.anthropic.com/v1' };
+
+const ALL_PROVIDERS = [LOCAL_TUI_PROVIDER, OTHER_LOCAL_PROVIDER, BARE_CLI_PROVIDER, CLOUD_PROVIDER];
+
+/** A running agent stamped with the providerId agentLifecycle persists. */
+function makeRunningAgentOnProvider(providerId, app = '_self') {
+  return { status: 'running', metadata: { taskApp: app, app, providerId } };
+}
+
+/** A pending task pinned to a provider via `metadata.provider`. */
+const taskOnProvider = (id, providerId) => ({
+  id,
+  priority: 'HIGH',
+  status: 'pending',
+  metadata: providerId === undefined ? {} : { provider: providerId },
+});
+
+/**
+ * Build the capacity tracker the way `dequeueNextTask` does: real slot context
+ * over the fixture provider list, real running-agent endpoint tally, real hold
+ * callback (captured so tests can assert the queued-no-slot log fired).
+ */
+function makeLocalSlotCapacity(state, { activeProvider = CLOUD_PROVIDER, limit = 1, agentsByProject = {} } = {}) {
+  const slots = createLocalEndpointSlotContext({ providers: ALL_PROVIDERS, activeProvider, limit });
+  const holds = [];
+  const capacity = createDequeueCapacity(state, {
+    agentsByProject,
+    localEndpointCounts: countRunningAgentsByLocalEndpoint(state.agents, slots.endpointForAgent),
+    localEndpointLimit: slots.limit,
+    resolveLocalEndpoint: slots.resolveLocalEndpoint,
+    onLocalEndpointHold: (task, endpoint, running) => holds.push({ taskId: task.id, endpoint, running }),
+  });
+  return { capacity, holds, slots };
+}
+
+const userBuckets = (tasks) => ({ onDemand: [], user: tasks, autoSystem: [], mission: [], idle: [] });
+
+describe('dequeueNextTask — per-local-endpoint agent cap (#4834)', () => {
+  it('serializes two queued tasks that resolve to the SAME local endpoint', () => {
+    // Global cap 5, nothing running: both tasks clear the global and
+    // per-project guards. Only the local-endpoint slot separates them.
+    const state = makeState({ maxConcurrentAgents: 5 });
+    const { capacity, holds } = makeLocalSlotCapacity(state);
+
+    const spawned = priorityDequeue(userBuckets([
+      taskOnProvider('task-local-1', 'lmstudio-tui'),
+      taskOnProvider('task-local-2', 'lmstudio-tui'),
+    ]), capacity);
+
+    expect(spawned.map(t => t.id)).toEqual(['task-local-1']);
+    expect(holds).toEqual([{ taskId: 'task-local-2', endpoint: LOCAL_ENDPOINT, running: 1 }]);
+    expect(capacity.spawnLocalEndpointCounts[LOCAL_ENDPOINT]).toBe(1);
+  });
+
+  it('dispatches the held task once the endpoint frees up (next cycle)', () => {
+    // Same fixture, but the first agent has finished — nothing is running, so
+    // the previously-held task now takes the slot. This is the "dispatches when
+    // the first finishes" half of the acceptance criteria.
+    const state = makeState({ maxConcurrentAgents: 5 });
+    const { capacity, holds } = makeLocalSlotCapacity(state);
+
+    const spawned = priorityDequeue(userBuckets([taskOnProvider('task-local-2', 'lmstudio-tui')]), capacity);
+
+    expect(spawned.map(t => t.id)).toEqual(['task-local-2']);
+    expect(holds).toEqual([]);
+  });
+
+  it('counts an ALREADY-RUNNING agent against its local endpoint', () => {
+    // One agent is live on the local TUI provider. A queued task for the same
+    // endpoint must be held even though the global cap has room.
+    const state = makeState({
+      maxConcurrentAgents: 5,
+      runningAgents: [makeRunningAgentOnProvider('lmstudio-tui')],
+    });
+    const { capacity, holds } = makeLocalSlotCapacity(state);
+
+    const spawned = priorityDequeue(userBuckets([taskOnProvider('task-local-1', 'lmstudio-tui')]), capacity);
+
+    expect(spawned).toEqual([]);
+    expect(holds).toEqual([{ taskId: 'task-local-1', endpoint: LOCAL_ENDPOINT, running: 1 }]);
+  });
+
+  it('leaves cloud and endpoint-less providers unaffected', () => {
+    // A cloud API provider and a CLI provider with NO recorded endpoint both
+    // resolve to null. Neither is gated, so all three spawn concurrently even
+    // though a local agent is already saturating its endpoint.
+    const state = makeState({
+      maxConcurrentAgents: 5,
+      runningAgents: [makeRunningAgentOnProvider('lmstudio-tui')],
+    });
+    const { capacity, holds } = makeLocalSlotCapacity(state);
+
+    const spawned = priorityDequeue(userBuckets([
+      taskOnProvider('task-cloud', 'anthropic'),
+      taskOnProvider('task-bare-cli', 'claude-cli'),
+      taskOnProvider('task-cloud-2', 'anthropic'),
+    ]), capacity);
+
+    expect(spawned.map(t => t.id)).toEqual(['task-cloud', 'task-bare-cli', 'task-cloud-2']);
+    expect(holds).toEqual([]);
+  });
+
+  it('runs two DISTINCT local endpoints in parallel', () => {
+    // Keyed by endpoint, not by "is local" — two separate local servers each
+    // get their own slot.
+    const state = makeState({ maxConcurrentAgents: 5 });
+    const { capacity } = makeLocalSlotCapacity(state);
+
+    const spawned = priorityDequeue(userBuckets([
+      taskOnProvider('task-lmstudio', 'lmstudio-tui'),
+      taskOnProvider('task-ollama', 'ollama-local'),
+    ]), capacity);
+
+    expect(spawned.map(t => t.id)).toEqual(['task-lmstudio', 'task-ollama']);
+  });
+
+  it('honors a lifted limit (LOCAL_LLM_MAX_CONCURRENCY > 1)', () => {
+    const state = makeState({ maxConcurrentAgents: 5 });
+    const { capacity, holds } = makeLocalSlotCapacity(state, { limit: 2 });
+
+    const spawned = priorityDequeue(userBuckets([
+      taskOnProvider('task-local-1', 'lmstudio-tui'),
+      taskOnProvider('task-local-2', 'lmstudio-tui'),
+      taskOnProvider('task-local-3', 'lmstudio-tui'),
+    ]), capacity);
+
+    expect(spawned.map(t => t.id)).toEqual(['task-local-1', 'task-local-2']);
+    expect(holds.map(h => h.taskId)).toEqual(['task-local-3']);
+  });
+
+  it('gates UNPINNED tasks by the ACTIVE provider endpoint', () => {
+    // A task with no `metadata.provider` runs on the active provider — when
+    // that is local, the cap applies to it too.
+    const state = makeState({ maxConcurrentAgents: 5 });
+    const { capacity } = makeLocalSlotCapacity(state, { activeProvider: LOCAL_TUI_PROVIDER });
+
+    const spawned = priorityDequeue(userBuckets([
+      taskOnProvider('task-unpinned-1'),
+      taskOnProvider('task-unpinned-2'),
+    ]), capacity);
+
+    expect(spawned.map(t => t.id)).toEqual(['task-unpinned-1']);
+  });
+
+  it('falls back to the active provider for an UNKNOWN pinned id (mirrors spawn)', () => {
+    // resolveAgentProviderAndModel logs and uses the active provider when the
+    // pinned id is missing; the gate must predict the same landing spot.
+    const state = makeState({ maxConcurrentAgents: 5 });
+    const { capacity, holds } = makeLocalSlotCapacity(state, { activeProvider: LOCAL_TUI_PROVIDER });
+
+    const spawned = priorityDequeue(userBuckets([
+      taskOnProvider('task-local-1', 'lmstudio-tui'),
+      taskOnProvider('task-ghost', 'deleted-provider'),
+    ]), capacity);
+
+    expect(spawned.map(t => t.id)).toEqual(['task-local-1']);
+    expect(holds).toEqual([{ taskId: 'task-ghost', endpoint: LOCAL_ENDPOINT, running: 1 }]);
+  });
+
+  it('leaves the cap disabled when no limit is supplied', () => {
+    // createDequeueCapacity's defaults must not gate anything — every existing
+    // caller (and every test above this block) constructs it without the
+    // local-endpoint options.
+    const state = makeState({ maxConcurrentAgents: 5 });
+    const capacity = createDequeueCapacity(state, {});
+    expect(capacity.localEndpointLimit).toBe(Infinity);
+    expect(priorityDequeue(userBuckets([
+      taskOnProvider('task-a', 'lmstudio-tui'),
+      taskOnProvider('task-b', 'lmstudio-tui'),
+    ]), capacity)).toHaveLength(2);
+  });
+
+  it('floors a 0/NaN limit at 1 rather than wedging the queue forever', () => {
+    const state = makeState({ maxConcurrentAgents: 5 });
+    const slots = createLocalEndpointSlotContext({ providers: ALL_PROVIDERS, activeProvider: CLOUD_PROVIDER, limit: 0 });
+    const capacity = createDequeueCapacity(state, {
+      localEndpointLimit: slots.limit,
+      resolveLocalEndpoint: slots.resolveLocalEndpoint,
+    });
+    expect(capacity.localEndpointLimit).toBe(1);
+    expect(priorityDequeue(userBuckets([
+      taskOnProvider('task-a', 'lmstudio-tui'),
+      taskOnProvider('task-b', 'lmstudio-tui'),
+    ]), capacity).map(t => t.id)).toEqual(['task-a']);
+  });
+});
+
+describe('countRunningAgentsByLocalEndpoint (#4834)', () => {
+  const slots = createLocalEndpointSlotContext({ providers: ALL_PROVIDERS, activeProvider: CLOUD_PROVIDER });
+
+  it('tallies only RUNNING agents, only on local endpoints', () => {
+    const agents = {
+      a: makeRunningAgentOnProvider('lmstudio-tui'),
+      b: makeRunningAgentOnProvider('lmstudio-tui'),
+      c: makeRunningAgentOnProvider('ollama-local'),
+      d: makeRunningAgentOnProvider('anthropic'),      // cloud → not counted
+      e: makeRunningAgentOnProvider('claude-cli'),     // no endpoint → not counted
+      f: { status: 'completed', metadata: { providerId: 'lmstudio-tui' } },
+    };
+    expect(countRunningAgentsByLocalEndpoint(agents, slots.endpointForAgent)).toEqual({
+      [LOCAL_ENDPOINT]: 2,
+      [OTHER_LOCAL_ENDPOINT]: 1,
+    });
+  });
+
+  it('ignores agents with no provider stamp (pre-upgrade records)', () => {
+    const agents = { a: { status: 'running', metadata: {} }, b: { status: 'running' } };
+    expect(countRunningAgentsByLocalEndpoint(agents, slots.endpointForAgent)).toEqual({});
+  });
+});
+
+describe('localEndpointOfProvider (#4834)', () => {
+  it('resolves a local endpoint regardless of provider type', () => {
+    expect(localEndpointOfProvider({ type: 'tui', endpoint: 'http://localhost:1234/v1' })).toBe('http://localhost:1234/v1');
+    expect(localEndpointOfProvider({ type: 'api', endpoint: 'http://127.0.0.1:11434' })).toBe('http://127.0.0.1:11434');
+  });
+
+  it('returns null for a remote endpoint, a missing endpoint, or no provider', () => {
+    expect(localEndpointOfProvider({ type: 'api', endpoint: 'https://api.anthropic.com/v1' })).toBeNull();
+    expect(localEndpointOfProvider({ type: 'cli', endpoint: null })).toBeNull();
+    expect(localEndpointOfProvider({ type: 'tui' })).toBeNull();
+    expect(localEndpointOfProvider(null)).toBeNull();
+  });
+
+  it('never guesses from a model id — only the recorded endpoint counts', () => {
+    // The issue is explicit: a TUI provider whose endpoint isn't recorded stays
+    // ungated even when its model id names a local runtime.
+    expect(localEndpointOfProvider({ type: 'tui', defaultModel: 'mtplx/local-qwen-27b', endpoint: null })).toBeNull();
+  });
+});
+
+
 // ─── Source-level regression guards ────────────────────────────────────────
 //
 // These pin two structural invariants of the production code that the
@@ -771,6 +1021,26 @@ describe('cos.js source — priority + capacity invariants', () => {
     const pattern = /maxConcurrentAgentsPerProject\s*\|\|\s*state\.config\.maxConcurrentAgents/;
     expect(dequeueFn).toMatch(pattern);
     expect(evalFn).toMatch(pattern);
+  });
+
+  it('dequeueNextTask threads the local-endpoint cap into its capacity tracker (#4834)', () => {
+    // The gate only works if the scheduler actually supplies the resolver and
+    // the running-agent tally — a refactor that drops either option silently
+    // reverts to unlimited local dispatch, which is what caused the accelerator
+    // OOM in the first place. Read from the real function body so a stray
+    // reference elsewhere in cos.js can't satisfy this.
+    const dequeueFn = extractFnBody(COS_SRC, COS_SRC.indexOf('async function dequeueNextTask'));
+    expect(dequeueFn).toMatch(/countRunningAgentsByLocalEndpoint\(/);
+    expect(dequeueFn).toMatch(/resolveLocalEndpoint:/);
+    expect(dequeueFn).toMatch(/localEndpointLimit:/);
+  });
+
+  it('tryImmediateSpawn enforces the same local-endpoint cap (#4834)', () => {
+    // This path bypasses the evaluation interval, so without its own check a
+    // user-submitted task would dispatch straight past the local-GPU limit.
+    const immediateFn = extractFnBody(COS_SRC, COS_SRC.indexOf('async function tryImmediateSpawn'));
+    expect(immediateFn).toMatch(/resolveLocalEndpoint\(task\)/);
+    expect(immediateFn).toMatch(/countRunningAgentsByLocalEndpoint\(/);
   });
 
   it('idle generator is fenced by spawned===0 / tasksToSpawn.length===0', () => {

--- a/server/services/cosDequeue.js
+++ b/server/services/cosDequeue.js
@@ -34,37 +34,91 @@
  * against both the global slots and the budget. A task with no `metadata.app`
  * buckets into the `_self` project key (PortOS-on-itself work) so app-less tasks
  * can't bypass the per-project cap.
+ *
+ * The THIRD cap is per local inference endpoint (issue #4834): a single GPU
+ * can't hold N model contexts at once, so agents whose provider resolves to the
+ * same local endpoint dispatch `localEndpointLimit` at a time and the rest stay
+ * queued. Callers supply the already-resolved pieces — `localEndpointCounts`
+ * (endpoint → running agents) and `resolveLocalEndpoint(task)` (which endpoint a
+ * candidate would land on, built by cosLocalEndpointSlots.js) — so this module
+ * stays pure and dependency-free. A task resolving to `null` (cloud provider, or
+ * a TUI provider with no recorded endpoint) is ungated. `onLocalEndpointHold`
+ * fires on a denial so the scheduler can log queued-no-slot without this module
+ * importing the event bus.
  */
-export function createDequeueCapacity(state, { agentsByProject = {} } = {}) {
+export function createDequeueCapacity(state, {
+  agentsByProject = {},
+  localEndpointCounts = {},
+  localEndpointLimit = Infinity,
+  resolveLocalEndpoint = () => null,
+  onLocalEndpointHold = null,
+} = {}) {
   const runningAgents = Object.values(state.agents).filter(a => a.status === 'running').length;
   const availableSlots = state.config.maxConcurrentAgents - runningAgents;
   const perProjectLimit = state.config.maxConcurrentAgentsPerProject || state.config.maxConcurrentAgents;
+  // A caller passing 0/NaN would wedge every local-endpoint task forever; floor
+  // at 1 so the cap degrades to "serialize", never to "never dispatch".
+  const localSlotLimit = localEndpointLimit === Infinity
+    ? Infinity
+    : Math.max(1, Number(localEndpointLimit) || 1);
 
   const spawnProjectCounts = { ...agentsByProject };
+  const spawnLocalEndpointCounts = { ...localEndpointCounts };
   let spawned = 0;
 
   const canSpawn = (task, ceiling = availableSlots) => {
     if (spawned >= ceiling) return false;
     const project = task.metadata?.app || '_self';
-    return (spawnProjectCounts[project] || 0) < perProjectLimit;
+    if ((spawnProjectCounts[project] || 0) >= perProjectLimit) return false;
+    const endpoint = resolveLocalEndpoint(task);
+    if (endpoint) {
+      const running = spawnLocalEndpointCounts[endpoint] || 0;
+      if (running >= localSlotLimit) {
+        onLocalEndpointHold?.(task, endpoint, running);
+        return false;
+      }
+    }
+    return true;
   };
 
   const trackSpawn = (task) => {
     const project = task.metadata?.app || '_self';
     spawnProjectCounts[project] = (spawnProjectCounts[project] || 0) + 1;
+    const endpoint = resolveLocalEndpoint(task);
+    if (endpoint) spawnLocalEndpointCounts[endpoint] = (spawnLocalEndpointCounts[endpoint] || 0) + 1;
     spawned++;
   };
 
   return {
     availableSlots,
     perProjectLimit,
+    localEndpointLimit: localSlotLimit,
     spawnProjectCounts,
+    spawnLocalEndpointCounts,
     canSpawn,
     trackSpawn,
     // Live read of the running spawn count — a getter so callers always see the
     // current total after trackSpawn mutations rather than a stale snapshot.
     get spawned() { return spawned; },
   };
+}
+
+/**
+ * Count running agents grouped by the local inference endpoint they occupy
+ * (issue #4834). `endpointForAgent` maps a running agent to its local endpoint
+ * or null — supplied by cosLocalEndpointSlots.js so this stays pure. Agents on
+ * cloud providers (and TUI providers with no recorded endpoint) resolve to null
+ * and are not counted, mirroring the ungated path in `createDequeueCapacity`.
+ */
+export function countRunningAgentsByLocalEndpoint(agents, endpointForAgent) {
+  const counts = {};
+  for (const agent of Object.values(agents || {})) {
+    if (agent.status !== 'running') continue;
+    const endpoint = endpointForAgent(agent);
+    if (!endpoint) continue;
+    counts[endpoint] = (counts[endpoint] || 0) + 1;
+  }
+  return counts;
 }
 
 /**

--- a/server/services/cosDequeue.js
+++ b/server/services/cosDequeue.js
@@ -45,6 +45,15 @@
  * a TUI provider with no recorded endpoint) is ungated. `onLocalEndpointHold`
  * fires on a denial so the scheduler can log queued-no-slot without this module
  * importing the event bus.
+ *
+ * `gateLocalEndpoint: false` opts a tier out of that third cap. Priority 0 does,
+ * because a denial there is DESTRUCTIVE, not a defer: the on-demand request has
+ * already been cleared and the app-review marker bound by the time `canSpawn`
+ * runs, so a `false` discards the user's explicit "Run" and strands the marker.
+ * Emitting instead is strictly better — the authoritative cap at subAgentSpawner's
+ * `task:ready` chokepoint HOLDS the task (still `pending`, marker released, job
+ * reservation freed), which is exactly the outcome this tier cannot produce.
+ * The global/per-project caps carry the same hazard here; that is pre-existing.
  */
 export function createDequeueCapacity(state, {
   agentsByProject = {},
@@ -66,11 +75,11 @@ export function createDequeueCapacity(state, {
   const spawnLocalEndpointCounts = { ...localEndpointCounts };
   let spawned = 0;
 
-  const canSpawn = (task, ceiling = availableSlots) => {
+  const canSpawn = (task, ceiling = availableSlots, { gateLocalEndpoint = true } = {}) => {
     if (spawned >= ceiling) return false;
     const project = task.metadata?.app || '_self';
     if ((spawnProjectCounts[project] || 0) >= perProjectLimit) return false;
-    const endpoint = resolveLocalEndpoint(task);
+    const endpoint = gateLocalEndpoint ? resolveLocalEndpoint(task) : null;
     if (endpoint) {
       const running = spawnLocalEndpointCounts[endpoint] || 0;
       if (running >= localSlotLimit) {

--- a/server/services/cosDequeue.js
+++ b/server/services/cosDequeue.js
@@ -54,7 +54,8 @@
  *   - Priority 0 has cleared the on-demand request and bound the app-review
  *     marker — a denial silently swallows the user's explicit "Run".
  *   - Priority 3 has flipped the mission sub-task to `in_progress` and saved the
- *     mission; `generateMissionTask` only ever re-picks `pending` sub-tasks.
+ *     mission; `generateMissionTask` only ever re-picks `pending` sub-tasks, and
+ *     the emitted object is the only copy (holdTask reverts the flip — #4858).
  *   - Priority 4 has bound the app-review marker and advanced the 30-minute
  *     review cooldown (issue #978's failure mode).
  *

--- a/server/services/cosDequeue.js
+++ b/server/services/cosDequeue.js
@@ -46,7 +46,7 @@
  * fires on a denial so the scheduler can log queued-no-slot without this module
  * importing the event bus.
  *
- * `gateLocalEndpoint: false` opts a tier out of that third cap. Three tiers do,
+ * `canSpawnCommitted` opts a tier out of that third cap. Three tiers use it,
  * because a denial there is DESTRUCTIVE rather than a defer — each has already
  * committed side effects by the time `canSpawn` runs, and none of them persists
  * the task, so `false` discards the only copy:
@@ -75,15 +75,14 @@ export function createDequeueCapacity(state, {
   const perProjectLimit = state.config.maxConcurrentAgentsPerProject || state.config.maxConcurrentAgents;
   // A caller passing 0/NaN would wedge every local-endpoint task forever; floor
   // at 1 so the cap degrades to "serialize", never to "never dispatch".
-  const localSlotLimit = localEndpointLimit === Infinity
-    ? Infinity
-    : Math.max(1, Number(localEndpointLimit) || 1);
+  // `Infinity` (the no-cap default) passes through unchanged.
+  const localSlotLimit = Math.max(1, Number(localEndpointLimit) || 1);
 
   const spawnProjectCounts = { ...agentsByProject };
   const spawnLocalEndpointCounts = { ...localEndpointCounts };
   let spawned = 0;
 
-  const canSpawn = (task, ceiling = availableSlots, { gateLocalEndpoint = true } = {}) => {
+  const admit = (task, ceiling, gateLocalEndpoint) => {
     if (spawned >= ceiling) return false;
     const project = task.metadata?.app || '_self';
     if ((spawnProjectCounts[project] || 0) >= perProjectLimit) return false;
@@ -97,6 +96,12 @@ export function createDequeueCapacity(state, {
     }
     return true;
   };
+
+  const canSpawn = (task, ceiling = availableSlots) => admit(task, ceiling, true);
+  // For a COMMITTED tier — one that has already taken side effects and does not
+  // persist the task, so a denial would discard it rather than defer it. Skips
+  // only the local-endpoint cap; see the header for which tiers qualify and why.
+  const canSpawnCommitted = (task, ceiling = availableSlots) => admit(task, ceiling, false);
 
   const trackSpawn = (task) => {
     const project = task.metadata?.app || '_self';
@@ -113,6 +118,7 @@ export function createDequeueCapacity(state, {
     spawnProjectCounts,
     spawnLocalEndpointCounts,
     canSpawn,
+    canSpawnCommitted,
     trackSpawn,
     // Live read of the running spawn count — a getter so callers always see the
     // current total after trackSpawn mutations rather than a stale snapshot.

--- a/server/services/cosDequeue.js
+++ b/server/services/cosDequeue.js
@@ -46,13 +46,21 @@
  * fires on a denial so the scheduler can log queued-no-slot without this module
  * importing the event bus.
  *
- * `gateLocalEndpoint: false` opts a tier out of that third cap. Priority 0 does,
- * because a denial there is DESTRUCTIVE, not a defer: the on-demand request has
- * already been cleared and the app-review marker bound by the time `canSpawn`
- * runs, so a `false` discards the user's explicit "Run" and strands the marker.
+ * `gateLocalEndpoint: false` opts a tier out of that third cap. Three tiers do,
+ * because a denial there is DESTRUCTIVE rather than a defer — each has already
+ * committed side effects by the time `canSpawn` runs, and none of them persists
+ * the task, so `false` discards the only copy:
+ *
+ *   - Priority 0 has cleared the on-demand request and bound the app-review
+ *     marker — a denial silently swallows the user's explicit "Run".
+ *   - Priority 3 has flipped the mission sub-task to `in_progress` and saved the
+ *     mission; `generateMissionTask` only ever re-picks `pending` sub-tasks.
+ *   - Priority 4 has bound the app-review marker and advanced the 30-minute
+ *     review cooldown (issue #978's failure mode).
+ *
  * Emitting instead is strictly better — the authoritative cap at subAgentSpawner's
  * `task:ready` chokepoint HOLDS the task (still `pending`, marker released, job
- * reservation freed), which is exactly the outcome this tier cannot produce.
+ * reservation freed), which is exactly the outcome these tiers cannot produce.
  * The global/per-project caps carry the same hazard here; that is pre-existing.
  */
 export function createDequeueCapacity(state, {

--- a/server/services/cosLocalEndpointSlots.js
+++ b/server/services/cosLocalEndpointSlots.js
@@ -24,6 +24,7 @@
 
 import { isLocalEndpoint, LOCAL_LLM_MAX_CONCURRENCY } from '../lib/promptRunner.js';
 import { listProviders, getActiveProvider } from './providers.js';
+import { isProviderAvailable } from './providerStatus.js';
 import { countRunningAgentsByLocalEndpoint } from './cosDequeue.js';
 
 // One knob governs both paths — no new config key. A local box beefy enough to
@@ -55,13 +56,23 @@ export function localEndpointOfProvider(provider) {
  *  - `endpointForAgent(agent)`  — the endpoint a RUNNING agent is occupying,
  *    from the `providerId` agentLifecycle stamps onto its metadata.
  *  - `resolveLocalEndpoint(task)` — the endpoint a QUEUED task would land on.
- *    Mirrors `resolveAgentProviderAndModel`: a `metadata.provider` pin wins,
- *    and an unknown pin falls back to the active provider exactly as spawn
- *    does. A runtime fallback swap can still move a run to another provider —
- *    this is avoidance, not a guarantee, and promptRunner's gate plus the OOM
- *    nudge/fail-over remain the recovery half.
+ *    Mirrors `resolveAgentProviderAndModel`: a `metadata.provider` pin wins, an
+ *    unknown pin falls back to the active provider, and an UNAVAILABLE provider
+ *    resolves to null because spawn will swap it for a fallback (often cloud) —
+ *    gating on it would hold the task behind a GPU it is never going to touch,
+ *    with nothing to clear the hold. A runtime fallback swap after that point
+ *    can still move a run: this is avoidance, not a guarantee, and
+ *    promptRunner's gate plus the OOM nudge/fail-over remain the recovery half.
+ *
+ * `isAvailable` is injected (rather than imported) so this stays pure and a
+ * test can drive the real resolver without provider-status module state.
  */
-export function createLocalEndpointSlotContext({ providers = [], activeProvider = null, limit = LOCAL_ENDPOINT_AGENT_LIMIT } = {}) {
+export function createLocalEndpointSlotContext({
+  providers = [],
+  activeProvider = null,
+  limit = LOCAL_ENDPOINT_AGENT_LIMIT,
+  isAvailable = () => true,
+} = {}) {
   const byId = new Map();
   for (const provider of providers) {
     if (provider?.id) byId.set(provider.id, provider);
@@ -69,7 +80,14 @@ export function createLocalEndpointSlotContext({ providers = [], activeProvider 
   if (activeProvider?.id && !byId.has(activeProvider.id)) byId.set(activeProvider.id, activeProvider);
 
   const endpointById = (id) => localEndpointOfProvider(byId.get(id));
-  const activeEndpoint = localEndpointOfProvider(activeProvider);
+
+  // The provider a queued task would be resolved onto, before the availability
+  // check below. An unknown pin falls through to the active provider, exactly
+  // as `resolveAgentProviderAndModel` does.
+  const providerForTask = (task) => {
+    const pinnedId = task?.metadata?.provider;
+    return (pinnedId && byId.get(pinnedId)) || activeProvider;
+  };
 
   return {
     limit,
@@ -84,9 +102,14 @@ export function createLocalEndpointSlotContext({ providers = [], activeProvider 
       return providerId ? endpointById(providerId) : null;
     },
     resolveLocalEndpoint: (task) => {
-      const pinnedId = task?.metadata?.provider;
-      if (pinnedId) return byId.has(pinnedId) ? endpointById(pinnedId) : activeEndpoint;
-      return activeEndpoint;
+      const provider = providerForTask(task);
+      if (!provider?.id) return null;
+      // An unavailable provider is NOT where this task lands — spawn swaps it
+      // for a fallback. Holding the task at this endpoint anyway would starve
+      // it: the fallback it actually wants may be cloud, and nothing about the
+      // busy GPU would ever clear the hold.
+      if (!isAvailable(provider.id)) return null;
+      return localEndpointOfProvider(provider);
     },
   };
 }
@@ -101,7 +124,7 @@ export function createLocalEndpointSlotContext({ providers = [], activeProvider 
 export async function buildLocalEndpointSlotContext() {
   const providers = await listProviders();
   const activeProvider = await getActiveProvider().catch(() => null);
-  return createLocalEndpointSlotContext({ providers, activeProvider });
+  return createLocalEndpointSlotContext({ providers, activeProvider, isAvailable: isProviderAvailable });
 }
 
 // ── In-flight spawn reservations ───────────────────────────────────────────
@@ -170,10 +193,36 @@ export async function acquireLocalEndpointSpawnSlot(task, agents) {
   const endpoint = slots.resolveLocalEndpoint(task);
   if (!endpoint) return { ok: true, release: NOOP_RELEASE };
 
-  const running = countRunningAgentsByLocalEndpoint(agents, slots.endpointForAgent)[endpoint] || 0;
-  const inFlight = running + pendingLocalEndpointSpawns(endpoint);
-  if (inFlight >= slots.limit) {
-    return { ok: false, reason: `local endpoint ${endpoint} is at capacity (${inFlight}/${slots.limit})` };
+  const { atCapacity, inFlight, limit } = readEndpointCapacity(endpoint, agents, slots);
+  if (atCapacity) {
+    return { ok: false, reason: `local endpoint ${endpoint} is at capacity (${inFlight}/${limit})` };
   }
   return { ok: true, release: reserveLocalEndpointSpawn(endpoint) };
+}
+
+/** Running agents plus in-flight reservations on `endpoint`, against the cap. */
+function readEndpointCapacity(endpoint, agents, slots) {
+  const running = countRunningAgentsByLocalEndpoint(agents, slots.endpointForAgent)[endpoint] || 0;
+  const inFlight = running + pendingLocalEndpointSpawns(endpoint);
+  return { inFlight, limit: slots.limit, atCapacity: inFlight >= slots.limit };
+}
+
+/**
+ * Why a spawn on the ALREADY-RESOLVED `provider` must wait, or null when it may
+ * proceed.
+ *
+ * `forceSpawnTask` (the user's explicit "Run now") returns synchronously while
+ * the spawn happens later in a `task:ready` listener, so without this it would
+ * answer `{ success: true }` and toast "Spawning" for a dispatch the chokepoint
+ * immediately holds — the same lie the provider-resolution pre-check upstream of
+ * it exists to prevent. Takes the post-fallback provider, so it is strictly more
+ * accurate than the queued-task prediction in `resolveLocalEndpoint`.
+ */
+export async function localEndpointCapacityError(provider, agents) {
+  const endpoint = localEndpointOfProvider(provider);
+  if (!endpoint) return null;
+  const slots = await buildLocalEndpointSlotContext();
+  const { atCapacity, inFlight, limit } = readEndpointCapacity(endpoint, agents, slots);
+  if (!atCapacity) return null;
+  return `Local inference endpoint ${endpoint} is at capacity (${inFlight}/${limit}) — wait for a running agent to finish`;
 }

--- a/server/services/cosLocalEndpointSlots.js
+++ b/server/services/cosLocalEndpointSlots.js
@@ -1,0 +1,93 @@
+/**
+ * CoS local-inference agent slots (issue #4834)
+ *
+ * `promptRunner`'s `withLocalConcurrencyGate` caps concurrent IN-FLIGHT calls
+ * per local endpoint, but it only sees requests PortOS itself makes. A CoS TUI
+ * agent runs a vendor CLI that opens its own connection to the local model
+ * server — PortOS never observes that traffic, so `dequeueNextTask` could
+ * dispatch two or three agents at one GPU and push it into an accelerator OOM.
+ *
+ * This module supplies the *avoidance* half: the per-cycle lookups the spawn
+ * scheduler needs to count running agents per local endpoint and to predict
+ * which endpoint a queued task would land on. The gate itself is enforced by
+ * the pure capacity tracker in cosDequeue.js.
+ *
+ * Deliberately separate accounting from promptRunner's in-process gate: one
+ * throttles requests PortOS makes, the other throttles agents PortOS launches.
+ * A shared counter across process boundaries isn't worth the coupling.
+ */
+
+import { isLocalEndpoint, LOCAL_LLM_MAX_CONCURRENCY } from '../lib/promptRunner.js';
+import { listProviders, getActiveProvider } from './providers.js';
+
+// One knob governs both paths — no new config key. A local box beefy enough to
+// hold N model contexts lifts LOCAL_LLM_MAX_CONCURRENCY and gets N agent slots
+// along with N in-flight API calls.
+export const LOCAL_ENDPOINT_AGENT_LIMIT = LOCAL_LLM_MAX_CONCURRENCY;
+
+/**
+ * The local endpoint a provider runs against, or null when it has none.
+ *
+ * Reads ONLY the endpoint recorded on the provider — never a model-id prefix.
+ * A CLI/TUI provider with no recorded endpoint resolves to null and stays
+ * ungated, which is the intended behavior: PortOS cannot know where an
+ * unconfigured vendor CLI points.
+ *
+ * Not gated on `provider.type === 'api'` (unlike promptRunner's request gate):
+ * a TUI provider pointed at a local LM Studio IS the case this exists for.
+ */
+export function localEndpointOfProvider(provider) {
+  const endpoint = provider?.endpoint;
+  return isLocalEndpoint(endpoint) ? endpoint.trim() : null;
+}
+
+/**
+ * Build the per-cycle local-endpoint lookups from an ALREADY-FETCHED provider
+ * snapshot. Pure and synchronous — the capacity tracker consults it per
+ * candidate task, and tests drive it with fixtures instead of a live toolkit.
+ *
+ *  - `endpointForAgent(agent)`  — the endpoint a RUNNING agent is occupying,
+ *    from the `providerId` agentLifecycle stamps onto its metadata.
+ *  - `resolveLocalEndpoint(task)` — the endpoint a QUEUED task would land on.
+ *    Mirrors `resolveAgentProviderAndModel`: a `metadata.provider` pin wins,
+ *    and an unknown pin falls back to the active provider exactly as spawn
+ *    does. A runtime fallback swap can still move a run to another provider —
+ *    this is avoidance, not a guarantee, and promptRunner's gate plus the OOM
+ *    nudge/fail-over remain the recovery half.
+ */
+export function createLocalEndpointSlotContext({ providers = [], activeProvider = null, limit = LOCAL_ENDPOINT_AGENT_LIMIT } = {}) {
+  const byId = new Map();
+  for (const provider of providers) {
+    if (provider?.id) byId.set(provider.id, provider);
+  }
+  if (activeProvider?.id && !byId.has(activeProvider.id)) byId.set(activeProvider.id, activeProvider);
+
+  const endpointById = (id) => localEndpointOfProvider(byId.get(id));
+  const activeEndpoint = localEndpointOfProvider(activeProvider);
+
+  return {
+    limit,
+    endpointForAgent: (agent) => {
+      const providerId = agent?.metadata?.providerId || agent?.providerId;
+      return providerId ? endpointById(providerId) : null;
+    },
+    resolveLocalEndpoint: (task) => {
+      const pinnedId = task?.metadata?.provider;
+      if (pinnedId) return byId.has(pinnedId) ? endpointById(pinnedId) : activeEndpoint;
+      return activeEndpoint;
+    },
+  };
+}
+
+/**
+ * Fetch the provider snapshot and build the lookups above.
+ *
+ * Never throws: `listProviders` already swallows a failed read into `[]`, and
+ * an uninitialized toolkit yields a null active provider — which resolves every
+ * task to null (ungated) rather than stalling the queue.
+ */
+export async function buildLocalEndpointSlotContext() {
+  const providers = await listProviders();
+  const activeProvider = await getActiveProvider().catch(() => null);
+  return createLocalEndpointSlotContext({ providers, activeProvider });
+}

--- a/server/services/cosLocalEndpointSlots.js
+++ b/server/services/cosLocalEndpointSlots.js
@@ -23,7 +23,7 @@
  */
 
 import { isLocalEndpoint, LOCAL_LLM_MAX_CONCURRENCY } from '../lib/promptRunner.js';
-import { listProviders, getActiveProvider } from './providers.js';
+import { listProviders, getActiveProvider, isOllamaBackedProvider } from './providers.js';
 import { isProviderAvailable, getFallbackProvider } from './providerStatus.js';
 
 // One knob governs both paths — no new config key. A local box beefy enough to
@@ -31,13 +31,26 @@ import { isProviderAvailable, getFallbackProvider } from './providerStatus.js';
 // along with N in-flight API calls.
 export const LOCAL_ENDPOINT_AGENT_LIMIT = LOCAL_LLM_MAX_CONCURRENCY;
 
+// An Ollama-backed CLI/TUI provider carries the daemon in `envVars`, not in
+// `endpoint` — the shipped `claude-ollama` / `claude-ollama-tui` set
+// `ANTHROPIC_BASE_URL`, and `opencode-ollama` / `opencode-ollama-tui` carry only
+// the `ollamaBacked` marker (their base lives inside an OPENCODE_CONFIG_CONTENT
+// blob, which `ollamaBaseFromProvider` in the toolkit does not parse either —
+// the marker alone means the default daemon).
+const DEFAULT_OLLAMA_BASE = 'http://localhost:11434';
+
 /**
  * The local endpoint a provider runs against, or null when it has none.
  *
- * Reads ONLY the endpoint recorded on the provider — never a model-id prefix.
- * A CLI/TUI provider with no recorded endpoint resolves to null and stays
- * ungated, which is the intended behavior: PortOS cannot know where an
- * unconfigured vendor CLI points.
+ * Reads ONLY what the provider RECORD says — the endpoint, else the Ollama base
+ * its `envVars` name, else the default daemon when (and only when) the record
+ * carries an explicit `ollamaBacked` marker. Never a model-id prefix. Everything
+ * else stays ungated: PortOS cannot know where an unconfigured vendor CLI points.
+ *
+ * The Ollama arm matters because four SHIPPED CLI/TUI providers run against the
+ * local daemon with no `endpoint` at all — precisely the "the vendor CLI opens
+ * its own connection and PortOS never sees it" case #4834 exists for. Skipping
+ * them would leave the cap inconsistent across providers of the same shape.
  *
  * Not gated on `provider.type === 'api'` (unlike promptRunner's request gate):
  * a TUI provider pointed at a local LM Studio IS the case this exists for.
@@ -47,7 +60,12 @@ export const LOCAL_ENDPOINT_AGENT_LIMIT = LOCAL_LLM_MAX_CONCURRENCY;
  * queued-no-slot log line.
  */
 export function localEndpointOfProvider(provider) {
-  return localSlotKey(provider?.endpoint);
+  if (!provider) return null;
+  // A recorded base is authoritative, including when it is REMOTE: an Ollama
+  // daemon on another host must resolve to null, not to the local default.
+  const recorded = provider.endpoint || provider.envVars?.ANTHROPIC_BASE_URL;
+  if (recorded) return localSlotKey(recorded);
+  return isOllamaBackedProvider(provider) ? localSlotKey(DEFAULT_OLLAMA_BASE) : null;
 }
 
 // Host+port identifies the model server; the scheme, path (`/v1`) and host
@@ -120,12 +138,15 @@ export function createLocalEndpointSlotContext({
   return {
     limit,
     endpointForAgent: (agent) => {
-      // The endpoint stamped at spawn wins: it is what this agent's inference
-      // ACTUALLY landed on, and it survives the provider record being edited or
-      // deleted while the agent is still holding the GPU. Falling back to the id
-      // lookup keeps pre-#4834 agent records counted.
-      const stamped = localEndpointOfProvider({ endpoint: agent?.metadata?.providerEndpoint });
-      if (stamped) return stamped;
+      // A PRESENT stamp is authoritative in BOTH directions: it is what this
+      // agent's inference actually landed on, so a REMOTE stamp means "not on a
+      // local endpoint" — never "go re-resolve the provider". Falling through
+      // there would reintroduce the mid-run edit the stamp exists to prevent: a
+      // cloud agent would start counting against whatever endpoint its provider
+      // record now names, saturating a GPU that has no agents on it at all.
+      // Only an ABSENT stamp (a pre-#4834 record) falls back to the id lookup.
+      const stamped = agent?.metadata?.providerEndpoint;
+      if (stamped != null) return localSlotKey(stamped);
       const providerId = agent?.metadata?.providerId || agent?.providerId;
       return providerId ? endpointById(providerId) : null;
     },

--- a/server/services/cosLocalEndpointSlots.js
+++ b/server/services/cosLocalEndpointSlots.js
@@ -24,8 +24,7 @@
 
 import { isLocalEndpoint, LOCAL_LLM_MAX_CONCURRENCY } from '../lib/promptRunner.js';
 import { listProviders, getActiveProvider } from './providers.js';
-import { isProviderAvailable } from './providerStatus.js';
-import { countRunningAgentsByLocalEndpoint } from './cosDequeue.js';
+import { isProviderAvailable, getFallbackProvider } from './providerStatus.js';
 
 // One knob governs both paths — no new config key. A local box beefy enough to
 // hold N model contexts lifts LOCAL_LLM_MAX_CONCURRENCY and gets N agent slots
@@ -42,10 +41,30 @@ export const LOCAL_ENDPOINT_AGENT_LIMIT = LOCAL_LLM_MAX_CONCURRENCY;
  *
  * Not gated on `provider.type === 'api'` (unlike promptRunner's request gate):
  * a TUI provider pointed at a local LM Studio IS the case this exists for.
+ *
+ * The return value is a NORMALIZED SLOT KEY (`localhost:<port>`), not the raw
+ * string — see `LOCAL_SLOT_KEY_RE`. It is only ever used as a Map key and in the
+ * queued-no-slot log line.
  */
 export function localEndpointOfProvider(provider) {
-  const endpoint = provider?.endpoint;
-  return isLocalEndpoint(endpoint) ? endpoint.trim() : null;
+  return localSlotKey(provider?.endpoint);
+}
+
+// Host+port identifies the model server; the scheme, path (`/v1`) and host
+// SPELLING do not. The shipped catalog already mixes spellings — `lmstudio` is
+// seeded at `http://localhost:1234/v1` while everything else uses `127.0.0.1` —
+// so keying on the raw string would give one LM Studio process two independent
+// caps and let two agents onto the same GPU, the exact OOM #4834 prevents.
+// Every loopback host collapses onto one key; the port keeps distinct local
+// servers apart.
+const LOCAL_SLOT_KEY_RE = /^(?:https?:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?)(?::(\d+))?(?:[/?#]|$)/i;
+
+/** The slot key for `endpoint`, or null when it is remote/absent/unparseable. */
+function localSlotKey(endpoint) {
+  if (!isLocalEndpoint(endpoint)) return null;
+  const match = endpoint.trim().match(LOCAL_SLOT_KEY_RE);
+  if (!match) return null;
+  return match[1] ? `localhost:${match[1]}` : 'localhost';
 }
 
 /**
@@ -58,20 +77,26 @@ export function localEndpointOfProvider(provider) {
  *  - `resolveLocalEndpoint(task)` — the endpoint a QUEUED task would land on.
  *    Mirrors `resolveAgentProviderAndModel`: a `metadata.provider` pin wins, an
  *    unknown pin falls back to the active provider, and an UNAVAILABLE provider
- *    resolves to null because spawn will swap it for a fallback (often cloud) —
- *    gating on it would hold the task behind a GPU it is never going to touch,
- *    with nothing to clear the hold. A runtime fallback swap after that point
- *    can still move a run: this is avoidance, not a guarantee, and
- *    promptRunner's gate plus the OOM nudge/fail-over remain the recovery half.
+ *    is followed through the SAME `getFallbackProvider` spawn uses. Following
+ *    the swap matters in both directions: gating on a benched provider would
+ *    hold the task behind a GPU it never touches (nothing would clear the hold),
+ *    while ignoring the swap entirely would drop the cap exactly when the
+ *    endpoint is unhealthy — the shipped catalog has four providers sharing
+ *    `127.0.0.1:18021`, so a fallback commonly lands on the same server. A
+ *    RUNTIME fallback after this point can still move a run: this is avoidance,
+ *    not a guarantee, and promptRunner's gate plus the OOM nudge/fail-over
+ *    remain the recovery half.
  *
- * `isAvailable` is injected (rather than imported) so this stays pure and a
- * test can drive the real resolver without provider-status module state.
+ * `isAvailable` / `resolveFallback` are injected (rather than imported) so this
+ * stays pure and a test can drive the real resolver without provider-status
+ * module state.
  */
 export function createLocalEndpointSlotContext({
   providers = [],
   activeProvider = null,
   limit = LOCAL_ENDPOINT_AGENT_LIMIT,
   isAvailable = () => true,
+  resolveFallback = () => null,
 } = {}) {
   const byId = new Map();
   for (const provider of providers) {
@@ -80,6 +105,9 @@ export function createLocalEndpointSlotContext({
   if (activeProvider?.id && !byId.has(activeProvider.id)) byId.set(activeProvider.id, activeProvider);
 
   const endpointById = (id) => localEndpointOfProvider(byId.get(id));
+  // `getFallbackProvider` indexes its providers arg BY ID, so hand it a map —
+  // not the array (mirrors the same note in promptRunner.js / agentProviderResolution.js).
+  const providersMap = Object.fromEntries(byId);
 
   // The provider a queued task would be resolved onto, before the availability
   // check below. An unknown pin falls through to the active provider, exactly
@@ -102,14 +130,17 @@ export function createLocalEndpointSlotContext({
       return providerId ? endpointById(providerId) : null;
     },
     resolveLocalEndpoint: (task) => {
-      const provider = providerForTask(task);
-      if (!provider?.id) return null;
+      const primary = providerForTask(task);
+      if (!primary?.id) return null;
       // An unavailable provider is NOT where this task lands — spawn swaps it
-      // for a fallback. Holding the task at this endpoint anyway would starve
-      // it: the fallback it actually wants may be cloud, and nothing about the
-      // busy GPU would ever clear the hold.
-      if (!isAvailable(provider.id)) return null;
-      return localEndpointOfProvider(provider);
+      // for a fallback, which may be cloud (gating would starve the task behind
+      // a GPU it never touches) or may be another provider on the SAME local
+      // server (ignoring it would drop the cap when the endpoint is unhealthy).
+      // Follow the real resolver rather than guessing either way.
+      const effective = isAvailable(primary.id)
+        ? primary
+        : resolveFallback(primary.id, providersMap, task);
+      return localEndpointOfProvider(effective);
     },
   };
 }
@@ -124,11 +155,22 @@ export function createLocalEndpointSlotContext({
 export async function buildLocalEndpointSlotContext() {
   const providers = await listProviders();
   const activeProvider = await getActiveProvider().catch(() => null);
-  return createLocalEndpointSlotContext({ providers, activeProvider, isAvailable: isProviderAvailable });
+  return createLocalEndpointSlotContext({
+    providers,
+    activeProvider,
+    isAvailable: isProviderAvailable,
+    // The REAL resolver spawn uses, so the prediction can't drift from it.
+    resolveFallback: (primaryId, providersMap, task) => getFallbackProvider(
+      primaryId,
+      providersMap,
+      task?.metadata?.fallbackProvider ?? null,
+      task?.metadata?.fallbackModel ?? null
+    )?.provider ?? null,
+  });
 }
 
 // ── In-flight spawn reservations ───────────────────────────────────────────
-// A dispatched task is invisible to `countRunningAgentsByLocalEndpoint` until
+// A dispatched task is invisible to the running-agent tally until
 // its agent record reaches `running` — a window several awaits wide (provider
 // resolution, prompt build, worktree setup, PTY spawn). Two `task:ready`
 // dispatches landing inside that window would both read the same snapshot and
@@ -139,31 +181,58 @@ export async function buildLocalEndpointSlotContext() {
 // in-process re-entrancy guard over one server's own dispatch loop, not a
 // defense against competing actors (see the Security Model in CLAUDE.md).
 // Mirrors `spawningJobIds` in cosJobScheduler.js, which bridges the same gap.
-const pendingSpawnsByEndpoint = new Map();
+//
+// Each reservation carries its task id, because `registerAgent` flips the record
+// to `running` well BEFORE `spawnAgentForTask` returns: for the config + PTY
+// launch window one agent would otherwise be counted twice (running tally AND
+// reservation) and under-admit at limits above 1. Counting only reservations
+// whose task has no running agent yet removes the overlap exactly, without
+// releasing early and reopening the window the reservation exists to close.
+const pendingSpawnsByEndpoint = new Map(); // endpoint -> Map<token, taskId|null>
+let reservationSeq = 0;
 
 const NOOP_RELEASE = () => {};
 
 /**
- * Reserve an in-flight spawn slot on `endpoint`. Returns the release function,
- * which is idempotent so a double-release (a throw plus the `finally`) can't
- * drive the count negative and hand out a slot that is still occupied.
+ * Reserve an in-flight spawn slot on `endpoint` for `taskId`. Returns the
+ * release function, which is idempotent so a double-release (a throw plus the
+ * `finally`) can't free a slot that is still occupied.
  */
-export function reserveLocalEndpointSpawn(endpoint) {
+export function reserveLocalEndpointSpawn(endpoint, taskId = null) {
   if (!endpoint) return NOOP_RELEASE;
-  pendingSpawnsByEndpoint.set(endpoint, (pendingSpawnsByEndpoint.get(endpoint) || 0) + 1);
+  const token = ++reservationSeq;
+  let held = pendingSpawnsByEndpoint.get(endpoint);
+  if (!held) {
+    held = new Map();
+    pendingSpawnsByEndpoint.set(endpoint, held);
+  }
+  held.set(token, taskId);
   let released = false;
   return () => {
     if (released) return;
     released = true;
-    const remaining = (pendingSpawnsByEndpoint.get(endpoint) || 1) - 1;
-    if (remaining > 0) pendingSpawnsByEndpoint.set(endpoint, remaining);
-    else pendingSpawnsByEndpoint.delete(endpoint);
+    const current = pendingSpawnsByEndpoint.get(endpoint);
+    if (!current) return;
+    current.delete(token);
+    if (current.size === 0) pendingSpawnsByEndpoint.delete(endpoint);
   };
 }
 
-/** Spawns dispatched at `endpoint` that have not yet reached `running`. */
-export function pendingLocalEndpointSpawns(endpoint) {
-  return endpoint ? (pendingSpawnsByEndpoint.get(endpoint) || 0) : 0;
+/**
+ * Spawns dispatched at `endpoint` that have not yet reached `running`.
+ *
+ * `excludeTaskIds` drops reservations whose agent HAS already registered — the
+ * running tally counts those, and double-counting them under-admits.
+ */
+export function pendingLocalEndpointSpawns(endpoint, { excludeTaskIds = null } = {}) {
+  const held = endpoint ? pendingSpawnsByEndpoint.get(endpoint) : null;
+  if (!held) return 0;
+  if (!excludeTaskIds?.size) return held.size;
+  let count = 0;
+  for (const taskId of held.values()) {
+    if (!taskId || !excludeTaskIds.has(taskId)) count++;
+  }
+  return count;
 }
 
 /** Test hook — drop every outstanding reservation. */
@@ -193,17 +262,34 @@ export async function acquireLocalEndpointSpawnSlot(task, agents) {
   const endpoint = slots.resolveLocalEndpoint(task);
   if (!endpoint) return { ok: true, release: NOOP_RELEASE };
 
-  const { atCapacity, inFlight, limit } = readEndpointCapacity(endpoint, agents, slots);
+  const { atCapacity, inFlight, limit } = readEndpointCapacity(endpoint, agents, slots, { ignoreTaskId: task?.id });
   if (atCapacity) {
     return { ok: false, reason: `local endpoint ${endpoint} is at capacity (${inFlight}/${limit})` };
   }
-  return { ok: true, release: reserveLocalEndpointSpawn(endpoint) };
+  return { ok: true, release: reserveLocalEndpointSpawn(endpoint, task?.id ?? null) };
 }
 
-/** Running agents plus in-flight reservations on `endpoint`, against the cap. */
-function readEndpointCapacity(endpoint, agents, slots) {
-  const running = countRunningAgentsByLocalEndpoint(agents, slots.endpointForAgent)[endpoint] || 0;
-  const inFlight = running + pendingLocalEndpointSpawns(endpoint);
+/**
+ * Running agents plus in-flight reservations on `endpoint`, against the cap.
+ *
+ * `ignoreTaskId` excludes agents belonging to the task being dispatched. A task
+ * never competes with itself, and counting its own agent would break the two
+ * paths that deliberately re-dispatch one: `forceSpawnTask` supersedes a stale
+ * `running` holder (the documented "Run now" recovery for a zombie agent whose
+ * PTY died), and a retry re-runs the same task. Without this, that recovery is
+ * unreachable at a limit of 1 — the zombie it is meant to replace fills the slot.
+ */
+export function readEndpointCapacity(endpoint, agents, slots, { ignoreTaskId = null } = {}) {
+  const runningTaskIds = new Set();
+  let running = 0;
+  for (const agent of Object.values(agents || {})) {
+    if (agent.status !== 'running') continue;
+    if (ignoreTaskId && agent.taskId === ignoreTaskId) continue;
+    if (slots.endpointForAgent(agent) !== endpoint) continue;
+    running++;
+    if (agent.taskId) runningTaskIds.add(agent.taskId);
+  }
+  const inFlight = running + pendingLocalEndpointSpawns(endpoint, { excludeTaskIds: runningTaskIds });
   return { inFlight, limit: slots.limit, atCapacity: inFlight >= slots.limit };
 }
 
@@ -218,11 +304,11 @@ function readEndpointCapacity(endpoint, agents, slots) {
  * it exists to prevent. Takes the post-fallback provider, so it is strictly more
  * accurate than the queued-task prediction in `resolveLocalEndpoint`.
  */
-export async function localEndpointCapacityError(provider, agents) {
+export async function localEndpointCapacityError(provider, agents, taskId = null) {
   const endpoint = localEndpointOfProvider(provider);
   if (!endpoint) return null;
   const slots = await buildLocalEndpointSlotContext();
-  const { atCapacity, inFlight, limit } = readEndpointCapacity(endpoint, agents, slots);
+  const { atCapacity, inFlight, limit } = readEndpointCapacity(endpoint, agents, slots, { ignoreTaskId: taskId });
   if (!atCapacity) return null;
   return `Local inference endpoint ${endpoint} is at capacity (${inFlight}/${limit}) — wait for a running agent to finish`;
 }

--- a/server/services/cosLocalEndpointSlots.js
+++ b/server/services/cosLocalEndpointSlots.js
@@ -7,10 +7,15 @@
  * server — PortOS never observes that traffic, so `dequeueNextTask` could
  * dispatch two or three agents at one GPU and push it into an accelerator OOM.
  *
- * This module supplies the *avoidance* half: the per-cycle lookups the spawn
- * scheduler needs to count running agents per local endpoint and to predict
- * which endpoint a queued task would land on. The gate itself is enforced by
- * the pure capacity tracker in cosDequeue.js.
+ * This module supplies the *avoidance* half, enforced at two altitudes:
+ *
+ *   - `acquireLocalEndpointSpawnSlot` is the AUTHORITATIVE cap, called from
+ *     subAgentSpawner's `task:ready` listener — the one chokepoint every
+ *     emitter funnels through. It reserves the slot across the spawn window so
+ *     two dispatches can't both read a pre-registration snapshot and pass.
+ *   - `createLocalEndpointSlotContext` feeds the pure capacity tracker in
+ *     cosDequeue.js, so `dequeueNextTask` simply never emits a task that would
+ *     be held — cheaper, and it logs queued-no-slot against the right task.
  *
  * Deliberately separate accounting from promptRunner's in-process gate: one
  * throttles requests PortOS makes, the other throttles agents PortOS launches.
@@ -19,6 +24,7 @@
 
 import { isLocalEndpoint, LOCAL_LLM_MAX_CONCURRENCY } from '../lib/promptRunner.js';
 import { listProviders, getActiveProvider } from './providers.js';
+import { countRunningAgentsByLocalEndpoint } from './cosDequeue.js';
 
 // One knob governs both paths — no new config key. A local box beefy enough to
 // hold N model contexts lifts LOCAL_LLM_MAX_CONCURRENCY and gets N agent slots
@@ -68,6 +74,12 @@ export function createLocalEndpointSlotContext({ providers = [], activeProvider 
   return {
     limit,
     endpointForAgent: (agent) => {
+      // The endpoint stamped at spawn wins: it is what this agent's inference
+      // ACTUALLY landed on, and it survives the provider record being edited or
+      // deleted while the agent is still holding the GPU. Falling back to the id
+      // lookup keeps pre-#4834 agent records counted.
+      const stamped = localEndpointOfProvider({ endpoint: agent?.metadata?.providerEndpoint });
+      if (stamped) return stamped;
       const providerId = agent?.metadata?.providerId || agent?.providerId;
       return providerId ? endpointById(providerId) : null;
     },
@@ -90,4 +102,78 @@ export async function buildLocalEndpointSlotContext() {
   const providers = await listProviders();
   const activeProvider = await getActiveProvider().catch(() => null);
   return createLocalEndpointSlotContext({ providers, activeProvider });
+}
+
+// ── In-flight spawn reservations ───────────────────────────────────────────
+// A dispatched task is invisible to `countRunningAgentsByLocalEndpoint` until
+// its agent record reaches `running` — a window several awaits wide (provider
+// resolution, prompt build, worktree setup, PTY spawn). Two `task:ready`
+// dispatches landing inside that window would both read the same snapshot and
+// both pass the cap, which is the exact over-dispatch #4834 exists to stop.
+//
+// So the chokepoint reserves the slot up front and releases it once the spawn
+// settles — by which point the agent record carries the load. This is a simple
+// in-process re-entrancy guard over one server's own dispatch loop, not a
+// defense against competing actors (see the Security Model in CLAUDE.md).
+// Mirrors `spawningJobIds` in cosJobScheduler.js, which bridges the same gap.
+const pendingSpawnsByEndpoint = new Map();
+
+const NOOP_RELEASE = () => {};
+
+/**
+ * Reserve an in-flight spawn slot on `endpoint`. Returns the release function,
+ * which is idempotent so a double-release (a throw plus the `finally`) can't
+ * drive the count negative and hand out a slot that is still occupied.
+ */
+export function reserveLocalEndpointSpawn(endpoint) {
+  if (!endpoint) return NOOP_RELEASE;
+  pendingSpawnsByEndpoint.set(endpoint, (pendingSpawnsByEndpoint.get(endpoint) || 0) + 1);
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    const remaining = (pendingSpawnsByEndpoint.get(endpoint) || 1) - 1;
+    if (remaining > 0) pendingSpawnsByEndpoint.set(endpoint, remaining);
+    else pendingSpawnsByEndpoint.delete(endpoint);
+  };
+}
+
+/** Spawns dispatched at `endpoint` that have not yet reached `running`. */
+export function pendingLocalEndpointSpawns(endpoint) {
+  return endpoint ? (pendingSpawnsByEndpoint.get(endpoint) || 0) : 0;
+}
+
+/** Test hook — drop every outstanding reservation. */
+export function __resetLocalEndpointSpawnReservations() {
+  pendingSpawnsByEndpoint.clear();
+}
+
+/**
+ * Claim a local-endpoint spawn slot for `task`, or report why it must wait.
+ *
+ * This is the AUTHORITATIVE cap. The scheduler-side check in `dequeueNextTask`
+ * only avoids emitting a `task:ready` that would be held anyway; six other
+ * emitters (evaluateTasks, forceSpawnTask, cosJobScheduler, the Creative
+ * Director bridge, …) reach the spawner without passing through it, so the gate
+ * has to live where all of them funnel — subAgentSpawner's `task:ready`
+ * listener.
+ *
+ * `{ ok: true }` with a no-op release when the task has no local endpoint.
+ * Callers MUST invoke `release()` in a `finally` once the spawn settles.
+ *
+ * @param {object} task
+ * @param {object} agents - `state.agents`, the running-agent map
+ * @returns {Promise<{ ok: true, release: () => void } | { ok: false, reason: string }>}
+ */
+export async function acquireLocalEndpointSpawnSlot(task, agents) {
+  const slots = await buildLocalEndpointSlotContext();
+  const endpoint = slots.resolveLocalEndpoint(task);
+  if (!endpoint) return { ok: true, release: NOOP_RELEASE };
+
+  const running = countRunningAgentsByLocalEndpoint(agents, slots.endpointForAgent)[endpoint] || 0;
+  const inFlight = running + pendingLocalEndpointSpawns(endpoint);
+  if (inFlight >= slots.limit) {
+    return { ok: false, reason: `local endpoint ${endpoint} is at capacity (${inFlight}/${slots.limit})` };
+  }
+  return { ok: true, release: reserveLocalEndpointSpawn(endpoint) };
 }

--- a/server/services/cosLocalEndpointSlots.js
+++ b/server/services/cosLocalEndpointSlots.js
@@ -45,7 +45,16 @@ import { isProviderAvailable, getFallbackProvider } from './providerStatus.js';
  * `localEndpointPort` below, never by the provider's name or model id.
  */
 export function providerBaseUrl(provider) {
-  return localRuntimeForProvider(provider)?.endpoint || provider?.endpoint || null;
+  return localRuntimeForProvider(provider)?.endpoint
+    || provider?.endpoint
+    // Last resort, and REMOTE by construction — `localRuntimeForProvider` already
+    // took this value when it pointed at this box. It still has to be returned:
+    // an Ollama-backed CLI aimed at another host records its base ONLY here, and
+    // `endpointForAgent` treats an absent stamp as "re-resolve by id". Answering
+    // null would let that cloud agent start counting against a local endpoint the
+    // moment its provider record is re-pointed — the hole the stamp exists to close.
+    || provider?.envVars?.ANTHROPIC_BASE_URL
+    || null;
 }
 
 /**
@@ -164,33 +173,12 @@ export function createLocalEndpointSlotContext({
  * an uninitialized toolkit yields a null active provider — which resolves every
  * task to null (ungated) rather than stalling the queue.
  */
-// One dispatch consults this 2-3 times — the dequeue cycle, then the chokepoint
-// per emitted task (and "Run now" checks before emitting too). Each build costs
-// two provider reads plus a Map and an object over the whole catalog, so cache
-// the SNAPSHOT for a beat. Deliberately the same TTL the toolkit's own provider
-// cache uses: this adds no staleness the callers didn't already have.
-//
-// Only the provider LIST is cached. `isAvailable` and `resolveFallback` are read
-// live inside the returned closures, so a provider going unavailable still
-// changes the answer immediately — which is what the gate turns on.
-const SNAPSHOT_TTL_MS = 1000;
-let snapshot = null;
-let snapshotAt = 0;
-
-/** Test hook — drop the cached provider snapshot. */
-export function __resetLocalEndpointSlotCache() {
-  snapshot = null;
-  snapshotAt = 0;
-}
-
+// Deliberately NOT memoized. One dispatch builds this 2-3 times, but the
+// toolkit already caches the underlying provider read, so a local snapshot would
+// only save a Map and an object allocation — while adding a staleness window the
+// toolkit does not have: it invalidates on a provider edit, and nothing here can
+// observe that, so an edited endpoint would keep gating on its old value.
 export async function buildLocalEndpointSlotContext() {
-  if (snapshot && Date.now() - snapshotAt < SNAPSHOT_TTL_MS) return snapshot;
-  snapshot = await buildSlotContextUncached();
-  snapshotAt = Date.now();
-  return snapshot;
-}
-
-async function buildSlotContextUncached() {
   const providers = await listProviders();
   const activeProvider = await getActiveProvider().catch(() => null);
   return createLocalEndpointSlotContext({

--- a/server/services/cosLocalEndpointSlots.js
+++ b/server/services/cosLocalEndpointSlots.js
@@ -205,7 +205,7 @@ export async function buildLocalEndpointSlotContext() {
 // So the chokepoint reserves the slot up front and releases it once the spawn
 // settles — by which point the agent record carries the load. This is a simple
 // in-process re-entrancy guard over one server's own dispatch loop, not a
-// defense against competing actors (see the Security Model in CLAUDE.md).
+// defense against competing actors (see the Security Model in AGENTS.md).
 // Mirrors `spawningJobIds` in cosJobScheduler.js, which bridges the same gap.
 //
 // Each reservation carries its task id, because `registerAgent` flips the record

--- a/server/services/cosLocalEndpointSlots.js
+++ b/server/services/cosLocalEndpointSlots.js
@@ -22,68 +22,56 @@
  * A shared counter across process boundaries isn't worth the coupling.
  */
 
-import { isLocalEndpoint, LOCAL_LLM_MAX_CONCURRENCY } from '../lib/promptRunner.js';
-import { listProviders, getActiveProvider, isOllamaBackedProvider } from './providers.js';
+import { LOCAL_LLM_MAX_CONCURRENCY } from '../lib/promptRunner.js';
+import { localRuntimeForProvider, localEndpointPort, normalizeOpenAiBaseUrl } from '../lib/localProviderRuntime.js';
+import { listProviders, getActiveProvider } from './providers.js';
 import { isProviderAvailable, getFallbackProvider } from './providerStatus.js';
 
-// One knob governs both paths — no new config key. A local box beefy enough to
-// hold N model contexts lifts LOCAL_LLM_MAX_CONCURRENCY and gets N agent slots
-// along with N in-flight API calls.
-export const LOCAL_ENDPOINT_AGENT_LIMIT = LOCAL_LLM_MAX_CONCURRENCY;
-
-// An Ollama-backed CLI/TUI provider carries the daemon in `envVars`, not in
-// `endpoint` — the shipped `claude-ollama` / `claude-ollama-tui` set
-// `ANTHROPIC_BASE_URL`, and `opencode-ollama` / `opencode-ollama-tui` carry only
-// the `ollamaBacked` marker (their base lives inside an OPENCODE_CONFIG_CONTENT
-// blob, which `ollamaBaseFromProvider` in the toolkit does not parse either —
-// the marker alone means the default daemon).
-const DEFAULT_OLLAMA_BASE = 'http://localhost:11434';
+/**
+ * The raw base URL a provider's inference actually goes to, local or not.
+ *
+ * `localRuntimeForProvider` already owns this question — it reads the base the
+ * provider ITSELF configures (an OpenCode `baseURL`, `ANTHROPIC_BASE_URL`, or
+ * `endpoint`), then the `OLLAMA_URL`/`OLLAMA_HOST`/`LM_STUDIO_URL` overrides the
+ * backend managers read, then the runtime's canonical default. That matters
+ * here: a user who relocates their daemon with `OLLAMA_HOST` would otherwise get
+ * two independent slot keys for one daemon — the exact double-booking this cap
+ * exists to prevent.
+ *
+ * It answers `null` for a provider that maps to no KNOWN local runtime, so fall
+ * back to the recorded endpoint: an arbitrary local server (the shipped
+ * `opencode-vllm-tui` on `127.0.0.1:18020`, or a user's own TUI provider) still
+ * occupies a GPU. Whether either is on THIS box is decided by
+ * `localEndpointPort` below, never by the provider's name or model id.
+ */
+export function providerBaseUrl(provider) {
+  return localRuntimeForProvider(provider)?.endpoint || provider?.endpoint || null;
+}
 
 /**
- * The local endpoint a provider runs against, or null when it has none.
+ * The slot key a provider's inference occupies, or null when it isn't on this
+ * machine. Host+port identifies the model server; the scheme, the path (`/v1`)
+ * and the host SPELLING do not — the shipped catalog seeds `lmstudio` at
+ * `localhost:1234` and everything else at `127.0.0.1`, so keying on the raw
+ * string would give one LM Studio process two independent caps.
  *
- * Reads ONLY what the provider RECORD says — the endpoint, else the Ollama base
- * its `envVars` name, else the default daemon when (and only when) the record
- * carries an explicit `ollamaBacked` marker. Never a model-id prefix. Everything
- * else stays ungated: PortOS cannot know where an unconfigured vendor CLI points.
- *
- * The Ollama arm matters because four SHIPPED CLI/TUI providers run against the
- * local daemon with no `endpoint` at all — precisely the "the vendor CLI opens
- * its own connection and PortOS never sees it" case #4834 exists for. Skipping
- * them would leave the cap inconsistent across providers of the same shape.
- *
- * Not gated on `provider.type === 'api'` (unlike promptRunner's request gate):
- * a TUI provider pointed at a local LM Studio IS the case this exists for.
- *
- * The return value is a NORMALIZED SLOT KEY (`localhost:<port>`), not the raw
- * string — see `LOCAL_SLOT_KEY_RE`. It is only ever used as a Map key and in the
- * queued-no-slot log line.
+ * `localEndpointPort` supplies that normalization (every loopback spelling
+ * collapses, the port defaults by scheme) AND rejects a LAN/Tailscale peer that
+ * merely shares a port. Not gated on `provider.type === 'api'` (unlike
+ * promptRunner's request gate): a TUI provider pointed at a local LM Studio is
+ * the case this exists for.
  */
 export function localEndpointOfProvider(provider) {
-  if (!provider) return null;
-  // A recorded base is authoritative, including when it is REMOTE: an Ollama
-  // daemon on another host must resolve to null, not to the local default.
-  const recorded = provider.endpoint || provider.envVars?.ANTHROPIC_BASE_URL;
-  if (recorded) return localSlotKey(recorded);
-  return isOllamaBackedProvider(provider) ? localSlotKey(DEFAULT_OLLAMA_BASE) : null;
+  return localSlotKey(providerBaseUrl(provider));
 }
 
-// Host+port identifies the model server; the scheme, path (`/v1`) and host
-// SPELLING do not. The shipped catalog already mixes spellings — `lmstudio` is
-// seeded at `http://localhost:1234/v1` while everything else uses `127.0.0.1` —
-// so keying on the raw string would give one LM Studio process two independent
-// caps and let two agents onto the same GPU, the exact OOM #4834 prevents.
-// Every loopback host collapses onto one key; the port keeps distinct local
-// servers apart.
-const LOCAL_SLOT_KEY_RE = /^(?:https?:\/\/)?(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[?::1\]?)(?::(\d+))?(?:[/?#]|$)/i;
-
-/** The slot key for `endpoint`, or null when it is remote/absent/unparseable. */
-function localSlotKey(endpoint) {
-  if (!isLocalEndpoint(endpoint)) return null;
-  const match = endpoint.trim().match(LOCAL_SLOT_KEY_RE);
-  if (!match) return null;
-  return match[1] ? `localhost:${match[1]}` : 'localhost';
-}
+// Normalize first so a schemeless value still parses — `localEndpointPort` goes
+// through `new URL`, which reads `localhost:1234` as a SCHEME and yields null.
+// Providers configured through the UI can carry a bare `host:port`.
+const localSlotKey = (endpoint) => {
+  const port = localEndpointPort(normalizeOpenAiBaseUrl(endpoint));
+  return port ? `localhost:${port}` : null;
+};
 
 /**
  * Build the per-cycle local-endpoint lookups from an ALREADY-FETCHED provider
@@ -112,7 +100,10 @@ function localSlotKey(endpoint) {
 export function createLocalEndpointSlotContext({
   providers = [],
   activeProvider = null,
-  limit = LOCAL_ENDPOINT_AGENT_LIMIT,
+  // One knob governs both paths — no new config key. A box beefy enough to hold
+  // N model contexts lifts LOCAL_LLM_MAX_CONCURRENCY and gets N agent slots
+  // along with N in-flight API calls.
+  limit = LOCAL_LLM_MAX_CONCURRENCY,
   isAvailable = () => true,
   resolveFallback = () => null,
 } = {}) {
@@ -173,7 +164,33 @@ export function createLocalEndpointSlotContext({
  * an uninitialized toolkit yields a null active provider — which resolves every
  * task to null (ungated) rather than stalling the queue.
  */
+// One dispatch consults this 2-3 times — the dequeue cycle, then the chokepoint
+// per emitted task (and "Run now" checks before emitting too). Each build costs
+// two provider reads plus a Map and an object over the whole catalog, so cache
+// the SNAPSHOT for a beat. Deliberately the same TTL the toolkit's own provider
+// cache uses: this adds no staleness the callers didn't already have.
+//
+// Only the provider LIST is cached. `isAvailable` and `resolveFallback` are read
+// live inside the returned closures, so a provider going unavailable still
+// changes the answer immediately — which is what the gate turns on.
+const SNAPSHOT_TTL_MS = 1000;
+let snapshot = null;
+let snapshotAt = 0;
+
+/** Test hook — drop the cached provider snapshot. */
+export function __resetLocalEndpointSlotCache() {
+  snapshot = null;
+  snapshotAt = 0;
+}
+
 export async function buildLocalEndpointSlotContext() {
+  if (snapshot && Date.now() - snapshotAt < SNAPSHOT_TTL_MS) return snapshot;
+  snapshot = await buildSlotContextUncached();
+  snapshotAt = Date.now();
+  return snapshot;
+}
+
+async function buildSlotContextUncached() {
   const providers = await listProviders();
   const activeProvider = await getActiveProvider().catch(() => null);
   return createLocalEndpointSlotContext({
@@ -215,9 +232,9 @@ let reservationSeq = 0;
 const NOOP_RELEASE = () => {};
 
 /**
- * Reserve an in-flight spawn slot on `endpoint` for `taskId`. Returns the
- * release function, which is idempotent so a double-release (a throw plus the
- * `finally`) can't free a slot that is still occupied.
+ * Reserve an in-flight spawn slot on `endpoint` for `taskId`. Release is
+ * idempotent because the spawner calls it from a `finally` that a throw can
+ * reach twice — a second decrement would free a slot still occupied.
  */
 export function reserveLocalEndpointSpawn(endpoint, taskId = null) {
   if (!endpoint) return NOOP_RELEASE;
@@ -239,12 +256,7 @@ export function reserveLocalEndpointSpawn(endpoint, taskId = null) {
   };
 }
 
-/**
- * Spawns dispatched at `endpoint` that have not yet reached `running`.
- *
- * `excludeTaskIds` drops reservations whose agent HAS already registered — the
- * running tally counts those, and double-counting them under-admits.
- */
+/** Spawns dispatched at `endpoint` that have not yet reached `running`. */
 export function pendingLocalEndpointSpawns(endpoint, { excludeTaskIds = null } = {}) {
   const held = endpoint ? pendingSpawnsByEndpoint.get(endpoint) : null;
   if (!held) return 0;

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -266,7 +266,9 @@ describe('both on-demand engines apply consent before addTask', () => {
   it('dequeueNextTask engine consents before canSpawn / addTask', () => {
     const engine = engineBody(COS_SRC, 'async function spawnDequeuePriority0OnDemand');
     expect(engine.indexOf('applyOnDemandConsent(task)')).toBeGreaterThan(-1);
-    expect(engine.indexOf('applyOnDemandConsent(task)')).toBeLessThan(engine.indexOf('capacity.canSpawn(task)'));
+    // Prefix match, not the full call: Priority 0 passes the local-endpoint
+    // opt-out (#4834), so the arg list is no longer bare `(task)`.
+    expect(engine.indexOf('applyOnDemandConsent(task)')).toBeLessThan(engine.indexOf('capacity.canSpawn(task'));
   });
 
   it('idle-review steal path consents when it drains an on-demand request', () => {

--- a/server/services/cosTaskGenerator.test.js
+++ b/server/services/cosTaskGenerator.test.js
@@ -266,9 +266,9 @@ describe('both on-demand engines apply consent before addTask', () => {
   it('dequeueNextTask engine consents before canSpawn / addTask', () => {
     const engine = engineBody(COS_SRC, 'async function spawnDequeuePriority0OnDemand');
     expect(engine.indexOf('applyOnDemandConsent(task)')).toBeGreaterThan(-1);
-    // Prefix match, not the full call: Priority 0 passes the local-endpoint
-    // opt-out (#4834), so the arg list is no longer bare `(task)`.
-    expect(engine.indexOf('applyOnDemandConsent(task)')).toBeLessThan(engine.indexOf('capacity.canSpawn(task'));
+    // Match either admit method: Priority 0 is a COMMITTED tier, so it calls
+    // `canSpawnCommitted` rather than `canSpawn` (#4834).
+    expect(engine.indexOf('applyOnDemandConsent(task)')).toBeLessThan(engine.search(/capacity\.canSpawn(Committed)?\(task/));
   });
 
   it('idle-review steal path consents when it drains an on-demand request', () => {

--- a/server/services/subAgentSpawner.dispatchHolds.test.js
+++ b/server/services/subAgentSpawner.dispatchHolds.test.js
@@ -1,8 +1,8 @@
 /**
- * The two dispatch HOLDS at the `task:ready` chokepoint, and what releases them.
+ * The three dispatch HOLDS at the `task:ready` chokepoint, and what releases them.
  *
- * Both leave the task queued for a condition that clears on its own, rather than
- * failing it:
+ * Each leaves the task queued for a condition that clears on its own, rather
+ * than failing it:
  *
  *  - Runner down. `portos-cos` is a separate PM2 app the user can stop from the
  *    Apps page, and in runner mode it owns every agent process. Dispatching into
@@ -14,6 +14,10 @@
  *    pull / submodule update / npm install before `pm2 delete`. An agent spawned
  *    in that window is severed by the restart.
  *
+ *  - Local inference endpoint at capacity (issue #4834). A CoS agent runs a
+ *    vendor CLI that talks to the local model server directly, so promptRunner's
+ *    in-flight gate never sees it; two agents at one GPU takes an accelerator
+ *    OOM. The slot is reserved across the spawn window and released after.
  * The holds live in that listener, not inside `runAgentSpawn`, because a hold
  * below the spawn body's entry returns past `releaseAppReviewMarker` and strands
  * the synthetic "in review" marker for the whole outage (issue #989). The side
@@ -51,6 +55,14 @@ vi.mock('./agentRunTracking.js', () => ({ completeAgentRun: vi.fn() }));
 vi.mock('./appActivity.js', () => ({ releaseAppReviewMarker: vi.fn().mockResolvedValue(undefined) }));
 vi.mock('./updateChecker.js', () => ({ isUpdateInProgress: vi.fn().mockReturnValue(false) }));
 vi.mock('./missions.js', () => ({ releaseMissionSubTask: vi.fn().mockResolvedValue(null) }));
+vi.mock('./cosState.js', () => ({ loadState: vi.fn().mockResolvedValue({ agents: {} }) }));
+// The real slot module is covered end-to-end in cos.test.js (resolvers, running
+// tally, reservations). Mocked here so this suite stays about the LISTENER's
+// wiring — hold vs spawn vs release — and doesn't drag promptRunner's provider
+// graph into a file that mocks providerStatus.
+vi.mock('./cosLocalEndpointSlots.js', () => ({
+  acquireLocalEndpointSpawnSlot: vi.fn().mockResolvedValue({ ok: true, release: vi.fn() }),
+}));
 vi.mock('./agentOrchestrator.js', () => ({
   completeAgent: vi.fn(),
   spawnAgentForTask: vi.fn().mockResolvedValue('agent-1'),
@@ -68,6 +80,7 @@ import { releaseAppReviewMarker } from './appActivity.js';
 import { isUpdateInProgress } from './updateChecker.js';
 import { releaseMissionSubTask } from './missions.js';
 import { setUseRunner } from './agentState.js';
+import { acquireLocalEndpointSpawnSlot } from './cosLocalEndpointSlots.js';
 
 const dispatch = (task) => taskHandlers.get('task:ready')(task);
 
@@ -278,6 +291,81 @@ describe('subAgentSpawner — mission sub-task release (#4858)', () => {
     expect(releaseAppReviewMarker).toHaveBeenCalledWith('some-app');
     const warnings = emitLog.mock.calls.filter(([level]) => level === 'warn');
     expect(warnings.some(([, message]) => /release mission sub-task sub-3/.test(message))).toBe(true);
+  });
+});
+
+describe('subAgentSpawner — local-endpoint capacity hold (#4834)', () => {
+  // A CoS agent runs a vendor CLI that opens its own connection to the local
+  // model server, so promptRunner's in-flight gate never sees it. The hold lives
+  // at this listener rather than in `dequeueNextTask` because six other emitters
+  // (evaluateTasks, forceSpawnTask, the job scheduler, the Creative Director
+  // bridge, …) reach the spawner without passing through the scheduler at all.
+  let release;
+
+  beforeEach(async () => {
+    await initSpawner();
+    vi.clearAllMocks();
+    vi.useRealTimers();
+    setUseRunner(true);
+    isRunnerReachable.mockResolvedValue(true);
+    isUpdateInProgress.mockReturnValue(false);
+    release = vi.fn();
+    acquireLocalEndpointSpawnSlot.mockResolvedValue({ ok: true, release });
+  });
+
+  it('spawns and releases the reserved slot when one is available', async () => {
+    await dispatch({ id: 'cos-l1', metadata: {} });
+
+    expect(spawnAgentForTask).toHaveBeenCalledTimes(1);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('holds the task instead of dispatching a second agent at a saturated GPU', async () => {
+    acquireLocalEndpointSpawnSlot.mockResolvedValue({ ok: false, reason: 'local endpoint http://localhost:1234/v1 is at capacity (1/1)' });
+
+    await dispatch({ id: 'cos-l2', metadata: {} });
+
+    // Held, not failed: the task record stays `pending`, so the next dequeue
+    // tick re-picks it once the running agent frees the endpoint.
+    expect(spawnAgentForTask).not.toHaveBeenCalled();
+  });
+
+  it('releases the app-review marker and the job reservation, same as the other holds', async () => {
+    acquireLocalEndpointSpawnSlot.mockResolvedValue({ ok: false, reason: 'at capacity' });
+
+    await dispatch({ id: 'cos-l3', metadata: { app: 'some-app', jobId: 'job-11' } });
+
+    expect(releaseAppReviewMarker).toHaveBeenCalledWith('some-app');
+    expect(cosEvents.emit).toHaveBeenCalledWith('job:spawn-failed', { jobId: 'job-11' });
+  });
+
+  it('releases the slot even when the spawn throws', async () => {
+    // Without the `finally`, a failed spawn would leak the reservation and wedge
+    // the endpoint until the process restarts.
+    spawnAgentForTask.mockRejectedValueOnce(new Error('boom'));
+
+    await dispatch({ id: 'cos-l4', metadata: {} });
+
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('checks capacity AFTER the update and runner holds, which are cheaper', async () => {
+    isUpdateInProgress.mockReturnValue(true);
+
+    await dispatch({ id: 'cos-l5', metadata: {} });
+
+    expect(acquireLocalEndpointSpawnSlot).not.toHaveBeenCalled();
+  });
+
+  it('resumes spawning once the endpoint frees up — the hold is not sticky', async () => {
+    acquireLocalEndpointSpawnSlot.mockResolvedValue({ ok: false, reason: 'at capacity' });
+    await dispatch({ id: 'cos-l6', metadata: {} });
+    expect(spawnAgentForTask).not.toHaveBeenCalled();
+
+    acquireLocalEndpointSpawnSlot.mockResolvedValue({ ok: true, release });
+    await dispatch({ id: 'cos-l6', metadata: {} });
+
+    expect(spawnAgentForTask).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/server/services/subAgentSpawner.dispatchHolds.test.js
+++ b/server/services/subAgentSpawner.dispatchHolds.test.js
@@ -18,6 +18,7 @@
  *    vendor CLI that talks to the local model server directly, so promptRunner's
  *    in-flight gate never sees it; two agents at one GPU takes an accelerator
  *    OOM. The slot is reserved across the spawn window and released after.
+ *
  * The holds live in that listener, not inside `runAgentSpawn`, because a hold
  * below the spawn body's entry returns past `releaseAppReviewMarker` and strands
  * the synthetic "in review" marker for the whole outage (issue #989). The side

--- a/server/services/subAgentSpawner.js
+++ b/server/services/subAgentSpawner.js
@@ -47,6 +47,8 @@ import { runnerAgents, setUseRunner, useRunner } from './agentState.js';
 import { releaseAppReviewMarker } from './appActivity.js';
 import { isUpdateInProgress } from './updateChecker.js';
 import { releaseMissionSubTask } from './missions.js';
+import { loadState } from './cosState.js';
+import { acquireLocalEndpointSpawnSlot } from './cosLocalEndpointSlots.js';
 // This module's own event wiring drives three LIFECYCLE TRANSITIONS, so it takes
 // them from the facade rather than from the three separate leaves that happen to
 // implement them (#3450). It can: nothing the facade imports imports this module
@@ -83,8 +85,9 @@ let runnerRecovery = Promise.resolve();
  *     revert, the sub-task is stranded for good: there is no record left queued,
  *     and generation only ever re-picks `pending` sub-tasks.
  *
- * Shared by every hold condition (self-update in progress, runner down, and any
- * that follow) so a new one can't ship with only half the releases.
+ * Shared by every hold condition (self-update in progress, runner down, local
+ * inference endpoint at capacity, and any that follow) so a new one can't ship
+ * with only half the releases.
  */
 async function holdTask(task, reason) {
   emitLog('debug', `⏸️ Holding task ${task.id} — ${reason}`, { taskId: task.id });
@@ -368,6 +371,19 @@ async function runInitSpawner() {
     if (useRunner && !(await isRunnerReachable())) {
       return holdTask(task, 'CoS Runner is down');
     }
+    // 3. Local inference endpoint at capacity (issue #4834). A CoS agent runs a
+    //    vendor CLI that opens its own connection to the local model server, so
+    //    promptRunner's in-flight gate never sees it — without this, two agents
+    //    can be dispatched at one GPU and the runtime kills a turn with an
+    //    accelerator OOM. Held HERE because `dequeueNextTask` is only one of the
+    //    emitters: evaluateTasks, forceSpawnTask, the job scheduler and the
+    //    Creative Director bridge all reach this listener directly. The slot is
+    //    reserved across the spawn window and released below, since the agent
+    //    record isn't countable until it reaches `running`.
+    const localSlot = await acquireLocalEndpointSpawnSlot(task, (await loadState()).agents);
+    if (!localSlot.ok) {
+      return holdTask(task, localSlot.reason);
+    }
     try {
       await spawnAgentForTask(task);
     } catch (err) {
@@ -376,6 +392,8 @@ async function runInitSpawner() {
       if (jobId) {
         cosEvents.emit('job:spawn-failed', { jobId });
       }
+    } finally {
+      localSlot.release();
     }
   });
 


### PR DESCRIPTION
## Summary

`LOCAL_LLM_MAX_CONCURRENCY` only throttles HTTP calls **PortOS makes**. A CoS TUI agent runs a vendor CLI that opens its own connection to the local model server, so `dequeueNextTask` could dispatch two or three agents at one GPU — the runtime then kills a turn with an accelerator OOM and the session parks at its idle footer until a human types `continue`.

Adds a third cap to the spawn scheduler alongside the global and per-project ones. No new config key: `LOCAL_LLM_MAX_CONCURRENCY` governs both paths.

- **Enforced at the chokepoint.** `subAgentSpawner`'s `task:ready` listener is the one place every emitter funnels through — `dequeueNextTask` is only one of seven. It joins the existing self-update and runner-down holds, so a capped task stays `pending`, its app-review marker is released, and its job reservation is freed.
- **Reserved across the spawn window.** An agent isn't countable until its record reaches `running`, several awaits after dispatch. Reservations carry a task id so the running tally and the reservation can't double-count the same agent.
- **Predictive check in `dequeueNextTask`** so a doomed task is never emitted. Tiers whose denial would *discard* rather than defer (on-demand, mission, idle — each commits side effects before the check and none persists the task) use `canSpawnCommitted` and let the chokepoint hold instead.
- **Endpoint identity comes from `localProviderRuntime.js`**, so the four shipped Ollama-backed CLI/TUI providers that record no `endpoint` are capped, `OLLAMA_HOST` relocation doesn't split one daemon across two slots, and `localhost` vs `127.0.0.1` share a key.
- A cloud provider, a TUI provider with no recorded endpoint, and a remote daemon are all unaffected. An unavailable provider is followed through the real `getFallbackProvider`, so a task can't starve behind a GPU it will never touch.

`promptRunner`'s in-process gate is unchanged — one throttles requests PortOS makes, the other throttles agents PortOS launches.

## Test plan

- `cd server && npm test` — 33,288 passed, 19 skipped, 0 failures.
- New coverage in `server/services/cos.test.js` (alongside the existing `maxConcurrentAgents` / `maxConcurrentAgentsPerProject` capacity tests) and `server/services/subAgentSpawner.dispatchHolds.test.js`: same-endpoint serialization and release, cloud/endpoint-less providers unaffected, distinct endpoints in parallel, lifted limits, the fallback-swap arms, spelling normalization, reservation accounting, and the committed-tier split.
- Bypass-probed: removing the gate turns 6 tests red.

## Known gap

A held mission task still leaves its sub-task `in_progress` — `holdTask` releases `metadata.app`/`jobId` and a mission task carries neither. That is pre-existing across all three chokepoint holds (the two here predate this change) and is filed as #4858.

Closes #4834